### PR TITLE
docs: lead install/deploy with Docker services + thin client

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -123,7 +123,98 @@ gates each tool call; PostToolUse re-indexes edited files.
 
 ## 3. Installation
 
-### 3.1 Prerequisites
+aimee ships four binaries — the **`aimee`** thin client, **`aimee-server`**,
+**`aimee-kb`**, and **`aimee-webchat`**. There are two ways to stand it up:
+
+- **Docker services + thin client (recommended, [§3.1](#31-run-the-services-in-docker-recommended)–[§3.2](#32-install-the-thin-client)).**
+  Run `aimee-server` and `aimee-kb` as containers — one combined container or two
+  split — and install only the thin `aimee` CLI on each developer machine, pointed
+  at the server. This is the intended deployment and the path the operations
+  chapter ([§27](#27-operations-and-deployment)) details.
+- **Single-box source build ([§3.3](#33-single-box-source-build)).** Build and run
+  everything on one host with `install.sh`, no Docker. The classic
+  single-developer setup.
+
+### 3.1 Run the services in Docker (recommended)
+
+The combined image co-locates both binaries in one container; Postgres (pgvector)
+and a CPU embedder come up alongside it:
+
+```bash
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+docker compose -f compose.combined.yaml up --build -d
+```
+
+The server fronts the `/v1` API on `:8740` (default bearer `aimee-local-dev`) and
+reaches the in-container kb on `:8741`:
+
+```bash
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+```
+
+Split the two binaries into separate containers with `compose.server.yaml` when
+you want to scale, update, or place them independently (the horizontal-scaling
+model in [§27.5](#275-scaling-and-multi-user-deployment)). See
+[§27.1](#271-containerized-deployment) for every compose file, the container
+lifecycle (start/logs/stop/update), volumes, and the end-to-end smoke tests.
+Override the default `aimee-local-dev` bearer on any networked deployment.
+
+### 3.2 Install the thin client
+
+Each developer installs only the `aimee` CLI. Prebuilt thin-client binaries for
+Linux, macOS, and Windows are attached to every GitHub release; or build just the
+client from a checkout (a C compiler is the only dependency — no Go, libpq, or
+zstd):
+
+```bash
+cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
+      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF
+cmake --build build --target aimee
+```
+
+On macOS add `-DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)"`; on Windows (MinGW)
+add `-G "MinGW Makefiles" -DWITH_TLS=OFF` (no TLS — terminate TLS at a proxy).
+Point the client at the server per-invocation, via the environment, or persist it:
+
+```bash
+aimee --server http://my-host:8740 --server-token=aimee-local-dev status
+
+export AIMEE_SERVER_URL=http://my-host:8740
+export AIMEE_SERVER_TOKEN=aimee-local-dev
+aimee status
+
+aimee remote set http://my-host:8740 aimee-local-dev   # persists to <aimee_home>/remote.conf
+aimee remote status                                    # resolved transport + /v1/health probe
+aimee remote clear                                     # revert to a local Unix socket
+```
+
+Precedence is `--server` > `AIMEE_SERVER_URL` > `remote.conf`. `https://` works on
+Linux/macOS builds (set `AIMEE_TLS_INSECURE=1` for self-signed certs); the Windows
+client refuses `https://`. A remote thin client drives the data/RPC plane
+(`memory`, `kb`, `rules`, `index`, `sessions`, `notes`, …); interactive `aimee
+chat`/`aimee launch` need a co-located server, and **writes are off by default over
+the network** until the server sets `aimee.api.remote_writes` (see
+[§24](#24-the-http-v1-api)). Finally, register the hooks on each machine with
+`./configure-hooks.sh` (or `configure-hooks.ps1`) so your AI coding tool calls
+aimee.
+
+### 3.3 Single-box source build
+
+To build and run everything on one host without Docker:
+
+```bash
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+./install-deps.sh   # system packages + PostgreSQL bootstrap (uses sudo)
+./install.sh        # build + install + configure (no sudo)
+```
+
+`install-deps.sh` installs the build/runtime packages and bootstraps the
+`aimee_shared` PostgreSQL database — the only steps that need root. (For a host
+that uses a *remote* kb and needs no local database, run `AIMEE_KB_MODE=remote
+./install-deps.sh`.) Prerequisites by platform:
 
 | Need | Debian/Ubuntu | Fedora/RHEL | Arch | macOS |
 |------|---------------|-------------|------|-------|
@@ -132,46 +223,41 @@ gates each tool call; PostToolUse re-indexes edited files.
 | SQLite3 (DB1) | `libsqlite3-dev sqlite3` | `sqlite-devel sqlite` | `sqlite` | system SQLite |
 | libpq (DB2) | `libpq-dev` | `libpq-devel` | `postgresql-libs` | `brew install libpq` |
 | libcurl | `libcurl4-openssl-dev` | `libcurl-devel` | `curl` | system curl |
+| libzstd | `libzstd-dev` | `libzstd-devel` | `zstd` | `brew install zstd` |
 | PAM (webchat) | `libpam0g-dev` | `pam-devel` | `pam` | built-in |
 | Postgres + pgvector | `postgresql postgresql-contrib` + pgvector | `postgresql-server` + `pgvector_NN` | `postgresql pgvector` | `brew install postgresql pgvector` |
 | ctags (indexing) | `universal-ctags` | `ctags` | `ctags` | `brew install universal-ctags` |
 | ripgrep (search) | `ripgrep` | `ripgrep` | `ripgrep` | `brew install ripgrep` |
 
-Go 1.25+ is required only to build `aimee-webchat`. `install.sh` detects your
-package manager (via `distro-detect.sh`) and installs what it can.
+Go 1.25+ is required only to build `aimee-webchat`. Then `install.sh`, in order:
 
-### 3.2 One-line install
-
-```bash
-git clone https://github.com/RakuenSoftware/aimee.git
-cd aimee
-./install.sh
-```
-
-What `install.sh` does, in order:
-
-1. **Detect platform and install prerequisites** for your package manager
-   (`apt`/`dnf`/`yum`/`pacman`/`brew`), verifying FTS5 and PAM headers afterward.
+1. **Check prerequisites** (FTS5 + the dev headers); if any are missing it stops
+   and points you back at `install-deps.sh` rather than escalating privileges.
 2. **Build** (only if sources changed): `cd src && make all server`, producing
    `aimee`, `aimee-server`, `aimee-kb`, and `aimee-webchat` at the repo root.
 3. **Stop any running server/KB** gracefully to avoid "text file busy".
 4. **Install binaries** to `~/.local/bin/` and remove retired binaries.
 5. **Install bundled skills** to `~/.local/share/aimee/skills/` (idempotent).
-6. **Install service units**, systemd user units (Linux) or launchd plists
-   (macOS), and enable `aimee-kb` then `aimee-server`.
-7. **Install `ast-grep` (`sg`)** for structural code search.
-8. **Bootstrap PostgreSQL**, start it, create the `aimee_shared` database,
-   enable the `pg_trgm` and `vector` extensions.
-9. **Configure your primary AI CLI**, prompt for provider (Claude / Codex /
-   Gemini / OpenAI-compatible) and save to `~/.config/aimee/aimee.yaml`.
+6. **Choose a kb mode** — local sidecar (default, backed by local Postgres) or a
+   remote `aimee-kb` over HTTP (persists `kb_client_url`/`kb_client_bearer_token`
+   to `aimee.yaml`).
+7. **Install service units** — systemd user units (Linux) or launchd plists
+   (macOS) — and enable `aimee-kb` then `aimee-server` (server only, in remote-kb
+   mode).
+8. **Install `ast-grep` (`sg`)** for structural code search.
+9. **Configure your primary AI CLI** (Claude / Codex / Gemini / OpenAI-compatible),
+   saved to `~/.config/aimee/aimee.yaml`.
 10. **Optionally add a local delegate** via `add-local-delegate.sh` (Ollama /
     llama.cpp).
-11. **Configure AI coding tools** via `configure-hooks.sh`, detect and register
-    hooks + MCP for Claude Code, Gemini CLI, Codex CLI, GitHub Copilot.
+11. **Configure AI coding tools** via `configure-hooks.sh` — register hooks + MCP
+    for Claude Code, Gemini CLI, Codex CLI, GitHub Copilot.
 
-Windows users run `install.ps1` (and `configure-hooks.ps1`).
+`install-deps.sh` also bootstraps Postgres (starts the service, creates
+`aimee_shared`, enables `pg_trgm` + `vector`); `aimee-kb`'s startup auto-bootstrap
+retries the same steps on first launch. Windows users run `install.ps1` (CMake +
+WinSW services) and `configure-hooks.ps1`. Update with `./update.sh` (§4).
 
-### 3.3 Manual build
+**Manual build targets:**
 
 ```bash
 cd src
@@ -194,13 +280,13 @@ full target list and the layering rules.
 
 ```bash
 aimee version
-aimee status        # aimee-server health; requires a running server
+aimee status        # server, DB1, and kb health
 ```
 
-`aimee status` confirms that the socket, DB1, and KB connection are healthy. The
-thin CLI no longer starts the server implicitly; if no service is running, use
-`systemctl --user start aimee-server` on systemd systems or `aimee server start`
-as the cross-platform fallback.
+Against a Docker server, set `AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN` (or `aimee
+remote set`) first. On a source install, the thin CLI no longer starts the server
+implicitly; if no service is running, use `systemctl --user start aimee-server` on
+systemd systems or `aimee server start` as the cross-platform fallback.
 
 ---
 
@@ -1006,10 +1092,14 @@ aimee kb docs push --scope project README.md     # stage docs for ingest
 ```
 
 Ingest runs through staged document upload → curator extraction (structured
-knowledge from prose/code/API docs) → embedding → review. The KB also serves its
-own HTTP /v1 surface on port 8741 used by the server's KB client and by
-containerized deployments. Its contract is `api/openapi-v1.yaml`; the generated
-markdown is `docs/gen/api-v1.md`.
+knowledge from prose/code/API docs) → embedding → review. `aimee-kb` serves its
+contract over an **HTTP `/v1` API on port 8741** — this is the only transport;
+the legacy Unix-socket RPC was retired in #2747. The server's KB client, thin
+clients, and containerized deployments all reach it that way, via
+`AIMEE_KB_API_URL` (plus an optional bearer in `AIMEE_KB_API_BEARER_TOKEN`). The
+KB must be running (its service unit, container, or `aimee-kb --http-port=8741`)
+before the server can use kb-backed features — the server no longer autostarts it.
+The contract is `api/openapi-v1.yaml`; the generated markdown is `docs/gen/api-v1.md`.
 
 ---
 
@@ -1112,9 +1202,12 @@ explicit legacy routes (e.g. `codex-cli`) still use the provider CLI.
 
 ## 26. Server and service management
 
-`aimee-server` is normally managed by systemd user units, launchd agents, or the
-Windows service wrapper installed by the platform scripts. The thin CLI does not
-implicitly spawn a server for ordinary RPC commands. To manage it explicitly:
+`aimee-server` runs as a long-lived service. In the recommended Docker deployment
+it is a container supervised by Docker's restart policy — manage it with `docker
+compose` ([§27.1](#271-containerized-deployment)). On a source install it is a
+systemd user unit, launchd agent, or Windows service wrapper installed by the
+platform scripts. Either way the thin CLI does not implicitly spawn a server for
+ordinary RPC commands. To manage a source-installed server explicitly:
 
 ```bash
 aimee server status      # health
@@ -1146,22 +1239,79 @@ limits and restart on failure. Logs go to the journal (Linux) or
 
 ## 27. Operations and deployment
 
-### 27.1 Containerized KB
+### 27.1 Containerized deployment
 
-`compose.yaml` brings up Postgres (pgvector), an embedder sidecar, `aimee-kb`,
-and (optionally) a local LLM:
+Running the services in containers is the recommended deployment: developers
+install only the thin client ([§3.2](#32-install-the-thin-client)) and point it at
+the server. Four compose files ship, built from three images — `aimee-server`
+(`Dockerfile.server`), `aimee-kb` (`Dockerfile`), and the co-located
+`aimee-server+kb` (`Dockerfile.combined`). Every stack also brings up a
+`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`all-MiniLM-L6-v2`,
+`Dockerfile.embedder`); the kb auto-applies its DB2 schema (`pg_trgm`/`vector`
+extensions + tables) on first boot.
+
+| Compose file | Brings up | Use when |
+|--------------|-----------|----------|
+| `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default.** Both binaries co-located; server `/v1` on `:8740`, kb `:8741`. |
+| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack — scale/update/place server and kb independently. |
+| `compose.yaml` | `aimee-kb` + Postgres + embedder | The knowledge service alone — building block for a shared/scaled kb. |
+| `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` with no shared knowledge. |
+
+**Bring up the recommended (combined) stack:**
 
 ```bash
-docker compose up                  # postgres + embedder + aimee-kb
-docker compose --profile llm up    # also start a local llama.cpp LLM
+docker compose -f compose.combined.yaml up --build -d
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
 ```
 
-The KB container (`Dockerfile`) runs as a non-root user, binds `0.0.0.0:8741`,
-and uses Python sidecars (`scripts/embed-remote.py`, `llm-chat.py`,
-`curator-extract.py`, `learning-synthesize.py`) for embeddings, synthesis, and
-curation. Container defaults come from `deploy/container/aimee.yaml`. The
-embedder image (`Dockerfile.embedder`) ships `all-MiniLM-L6-v2` on CPU. A proxy
-front-end is available via `Dockerfile.proxy` + `docker-compose.proxy.yml`.
+The combined container runs **both** aimee binaries: the kb on loopback `:8741`
+inside the container, the server fronting `:8740` with
+`AIMEE_KB_API_URL=http://127.0.0.1:8741`. The split stack
+(`compose.server.yaml`) instead runs `aimee-kb` as its own container the server
+reaches at `http://aimee-kb:8741`. Add `--profile llm` to any stack to bring up a
+local llama.cpp server for the synthesis/curator passes. Each container runs as a
+non-root user; the kb uses Python sidecars (`scripts/embed-remote.py`,
+`llm-chat.py`, `curator-extract.py`, `learning-synthesize.py`) for embeddings,
+synthesis, and curation, with container defaults from `deploy/container/aimee.yaml`.
+
+**Container lifecycle** — the binaries run as long-lived container processes
+(PID 1), supervised by Docker's restart policy, not systemd/launchd:
+
+```bash
+docker compose -f compose.combined.yaml ps           # container + health status
+docker compose -f compose.combined.yaml logs -f      # follow logs (add a service to scope)
+docker compose -f compose.combined.yaml restart aimee-server-kb
+docker compose -f compose.combined.yaml down         # stop + remove containers (volumes persist)
+docker compose -f compose.combined.yaml down -v      # also DROP data volumes (destroys DB2 + state)
+docker compose -f compose.combined.yaml up -d --build # update: rebuild images, recreate containers
+```
+
+**State and volumes.** Durable data lives in named volumes, not the container
+filesystem, so recreate is safe and only `down -v` erases it: `*-postgres` holds
+DB2 (`aimee_shared`); `*-home` (`/var/lib/aimee`) holds server/kb runtime state
+(DB1 SQLite + config); `*-workspaces` (`/var/lib/aimee-workspaces`,
+`AIMEE_WORKSPACES_DIR`) holds the mirror-tier bare mirrors + reconstructed
+worktrees; `*-models` volumes cache embedder/LLM weights. The server's worker
+threads need a 64 MB stack, so every server container sets `ulimits.stack:
+67108864` (a plain `docker run` must pass `--ulimit stack=67108864`). Override the
+baked `aimee-local-dev` bearer and other config by mounting your own `aimee.yaml`
+at `/var/lib/aimee/aimee.yaml` (see `compose.remote-writes.combined.yaml`).
+
+**Verify a stack end to end.** Each topology ships a smoke test that brings it up,
+waits for health, exercises the live surface (DB + vector readiness, search,
+embeddings, and the server→kb path), then tears down; `e2e-matrix.sh` runs several
+and prints one pass/fail table:
+
+```bash
+scripts/aimee-combined-docker-smoke.sh --up --down            # combined server+kb
+scripts/aimee-server-docker-smoke.sh --up --down              # split server + kb
+scripts/aimee-kb-docker-smoke.sh --up --down                  # kb-only
+scripts/aimee-server-standalone-docker-smoke.sh --up --down   # server standalone
+scripts/e2e-matrix.sh --only T1,T2,T3,T4                      # all Docker topologies
+```
+
+A proxy front-end is available via `Dockerfile.proxy` + `docker-compose.proxy.yml`.
 
 ### 27.2 Health and observability
 
@@ -1219,10 +1369,11 @@ it horizontally scalable:
    transient state (connection pools, request buffers, worker loops); all durable
    knowledge is in DB2. Each instance is effectively a **stateless request server
    over a shared database**.
-2. **It is reachable over the network.** Beyond the local Unix socket, KB serves
-   its full `/v1` contract over HTTP on `:8741` (`AIMEE_KB_API_URL`, optional
-   bearer token via `AIMEE_KB_API_BEARER_TOKEN`). Many `aimee-server` instances —
-   many users, on many machines — can point at one KB endpoint.
+2. **It is reachable over the network.** KB serves its full `/v1` contract over
+   HTTP on `:8741` (`AIMEE_KB_API_URL`, optional bearer token via
+   `AIMEE_KB_API_BEARER_TOKEN`) — the only transport since the Unix-socket RPC was
+   retired in #2747. Many `aimee-server` instances — many users, on many
+   machines — can point at one KB endpoint.
 3. **Concurrent instances are safe with no external coordinator.** The background
    pipeline (ingest, curator, embedding, index-update) claims work directly off
    DB2 queues with `FOR UPDATE SKIP LOCKED`, so two workers never claim the same
@@ -1278,15 +1429,15 @@ Vector search rides inside the same Postgres and scales with it:
 
 | Topology | Shape | When |
 |----------|-------|------|
-| **Single developer (default)** | One `aimee-server` + one local `aimee-kb` + local Postgres, all on one host via service units. | The out-of-the-box `install.sh` setup. |
-| **Shared KB** | Many users' `aimee-server` instances point at one `aimee-kb`/Postgres. DB1 stays per-user/per-machine; only KB-scoped knowledge crosses the boundary. | A team or a single user across several machines wanting shared knowledge. |
+| **Containerized server + KB (default)** | `aimee-server` + `aimee-kb` as containers (combined or split) + Postgres + embedder ([§27.1](#271-containerized-deployment)); developers run only the thin client. | The recommended deployment for one user or a team. |
+| **Single developer, source build** | One `aimee-server` + one local `aimee-kb` + local Postgres, all on one host via service units. | The `install.sh` no-Docker setup. |
+| **Shared KB** | Many users' `aimee-server` instances point at one `aimee-kb`/Postgres over HTTP. DB1 stays per-user/per-machine; only KB-scoped knowledge crosses the boundary. | A team or a single user across several machines wanting shared knowledge. |
 | **Scaled KB** | Several `aimee-kb` replicas behind a load balancer (`:8741`) over one Postgres (with pooling and, if needed, read replicas + pgvectorscale). | Many users and/or a large corpus where one KB instance or plain HNSW is the bottleneck. |
-| **Containerized KB** | `aimee-kb` + Postgres/pgvector + embedder sidecar via `compose.yaml`; KB binds `0.0.0.0:8741`. | Container/orchestrated deployments; the building block for the scaled topology above. |
 
-In every topology the contracts are identical: thin clients speak the socket
-protocol to their per-user server; servers speak the typed KB API to `aimee-kb`;
-the storage boundary holds. See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §11
-for the architectural view.
+In every topology the contracts are identical: thin clients speak `/v1` to their
+per-user server (local `aimee-http.sock` or a remote `host:port`); servers speak
+the typed KB `/v1` HTTP API to `aimee-kb`; the storage boundary holds. See
+[`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) §11 for the architectural view.
 
 ---
 
@@ -1316,6 +1467,9 @@ platform support in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
 | Variable | Effect |
 |----------|--------|
 | `AIMEE_HOME` | Override the config/state root (default `~/.config/aimee`). |
+| `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` | Thin-client target: remote `aimee-server` URL (`http[s]://host:port`) + bearer. Overridden by `--server`/`--server-token`; persisted form is `<aimee_home>/remote.conf`. |
+| `AIMEE_TLS_INSECURE` | Skip TLS certificate verification for the thin client's `https://` connections (self-signed/dev only). |
+| `AIMEE_API_ENDPOINT` / `AIMEE_API_BEARER` / `AIMEE_API_CLIENT_TRANSPORT` | Lower-level CLI transport: endpoint (`tcp:host:port` or `unix:/path`), bearer, and `http`/`socket` selector. Mirrors `aimee.api.client_endpoint` / `bearer_token` / `client_transport` in `aimee.yaml`. |
 | `AIMEE_PROFILE` | Select a configuration profile. |
 | `AIMEE_MODE` | Operating mode (e.g. planning vs implement). |
 | `AIMEE_MODEL` / `AIMEE_EFFORT` | Override model / reasoning effort for a run. |
@@ -1337,6 +1491,11 @@ platform support in [`docs/COMPATIBILITY.md`](docs/COMPATIBILITY.md).
 | `AIMEE_MEMORY_WEIGHT_PROFILE` | Retrieval-weight profile override. |
 | `AIMEE_KB_API_URL` / `AIMEE_KB_API_BEARER_TOKEN` | KB `/v1` HTTP endpoint and bearer token. Required for kb-backed (shared/vector) features; the server no longer autostarts `aimee-kb`. |
 | `AIMEE_KB_NO_AUTOSTART` | Deprecated no-op (the kb socket autostart was retired in #2747; the server only reaches kb via `AIMEE_KB_API_URL`). |
+| `AIMEE_DB1_URL` / `AIMEE_DB2_URL` | Storage URLs used by containerized/explicit deploys: DB1 `sqlite:///…` (server) and DB2 `postgresql://…/aimee_shared` (kb). |
+| `AIMEE_EMBEDDER_URL` | Embedding service endpoint for the kb (e.g. the embedder sidecar `http://embedder:8080`). |
+| `AIMEE_SERVER_HTTP_BIND` / `AIMEE_KB_HTTP_BIND` | Bind the server/kb `/v1` listener on `0.0.0.0` (set `1` in containers so the published port is reachable). |
+| `AIMEE_WORKSPACES_DIR` | Mirror-tier workspace root (bare mirrors + reconstructed worktrees); containers mount a volume here (`/var/lib/aimee-workspaces`). |
+| `AIMEE_KB_MODE` | Install-time selector (`local`/`remote`) consumed by `install-deps.sh`/`install.sh`. |
 | `AIMEE_SERVER_STARTUP_FD` | Internal: server startup handshake fd. |
 | `AIMEE_DOCKER_BIN` / `AIMEE_DOCKER_WORKDIR` | Docker backend for delegate execution. |
 | `AIMEE_SSH_BIN` | SSH binary for remote delegate/host access. |
@@ -1361,7 +1520,7 @@ from `~/.vibe/.env` for Mistral routes.
   agents.json                 # delegate agents + network inventory
   aimee.db (+ -wal, -shm)     # DB1 local state (SQLite)
   aimee-http.sock             # aimee-server /v1 HTTP Unix socket (loopback)
-  aimee-kb.sock               # KB service socket
+  remote.conf                 # persisted thin-client remote target (aimee remote set)
   server.token                # (legacy; unused since the NDJSON RPC socket was removed)
   server.log / audit.log      # server + audit logs
   aimee.pid / *.lock          # process/lifecycle files

--- a/README.md
+++ b/README.md
@@ -146,16 +146,102 @@ See the [Manual](MANUAL.md#275-scaling-and-multi-user-deployment) and
 
 ## Install
 
-### Prerequisites
+aimee is a few services plus a thin client. **`aimee-server`** (per-user runtime,
+local DB1) and **`aimee-kb`** (the shared knowledge base, Postgres DB2 + vectors)
+are long-running services; the **`aimee` CLI is a thin client** that holds no
+database and talks to a server over `/v1`. The intended deployment is to run the
+**services in Docker** — one combined container, or two split containers — and
+install only the **thin client** on each developer machine, pointed at the server.
 
-| Package | Debian/Ubuntu | macOS |
-|---------|---------------|-------|
-| C compiler | `apt install build-essential` | Xcode CLT |
-| SQLite3 | `apt install libsqlite3-dev` | System SQLite |
-| libpq | `apt install libpq-dev` | `brew install libpq` |
-| libcurl | `apt install libcurl4-openssl-dev` | `brew install curl` |
+> Prefer everything on one box from source (no Docker)? See
+> [Single-box source install](#single-box-source-install-no-docker) below.
 
-### Install
+### 1. Run the server (Docker)
+
+The combined image co-locates both binaries in one container and is the simplest
+way to stand up a full stack. Postgres (pgvector) and the embedder come up
+alongside it:
+
+```bash
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+docker compose -f compose.combined.yaml up --build -d
+```
+
+The server fronts the `/v1` API on `:8740` (default bearer `aimee-local-dev`) and
+reaches the in-container kb on `:8741`. Confirm it's live:
+
+```bash
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+```
+
+**Combined vs. split.** The combined container (`compose.combined.yaml`) is the
+recommended default — one aimee container to run and update. Split the two
+binaries into separate containers (`compose.server.yaml`) when you want to scale,
+update, or place `aimee-server` and `aimee-kb` independently — that matches the
+horizontal-scaling model (many servers → one shared kb). Both publish the same
+ports and bearer. See [Run in Docker](#run-in-docker) for every topology, health
+probes, and the end-to-end smoke tests.
+
+> Set a real bearer for anything but local dev. The default `aimee-local-dev` is
+> a convenience for loopback only; override it (and consider TLS termination) on
+> any networked deployment.
+
+### 2. Install the thin client
+
+Each developer installs only the `aimee` CLI and points it at the server. Prebuilt
+thin-client binaries for **Linux, macOS, and Windows** are attached to every GitHub
+release — download one, put it on your `PATH`, and skip the build. To build it
+yourself, configure with `-DAIMEE_THIN_CLIENT=ON` (a C compiler is the only
+dependency — no Go, libpq, or zstd); see
+[Build just the thin client](#build-just-the-thin-client).
+
+Point the client at the server per-invocation, via the environment, or persist it:
+
+```bash
+# Per-invocation:
+aimee --server http://my-host:8740 --server-token=aimee-local-dev status
+
+# Or via environment (applies to every command):
+export AIMEE_SERVER_URL=http://my-host:8740
+export AIMEE_SERVER_TOKEN=aimee-local-dev
+aimee status
+
+# Or persist it (stored in <aimee_home>/remote.conf):
+aimee remote set http://my-host:8740 aimee-local-dev
+aimee remote status   # shows the resolved transport + a /v1/health probe
+aimee remote clear    # revert to a local Unix socket
+```
+
+Precedence is `--server` flag > `AIMEE_SERVER_URL` env > persisted `remote.conf`.
+
+`https://` URLs are supported on Linux/macOS builds (OpenSSL), with certificate
+verification on by default — set `AIMEE_TLS_INSECURE=1` for self-signed/dev
+servers. The Windows thin client is built without TLS and refuses `https://`;
+terminate TLS at a reverse proxy and use its `http://` address there.
+
+**What a remote thin client can and can't do.** The remote transport drives the
+**data/RPC plane** — `memory`, `kb`, `rules`, `index`, `sessions`, `notes`, and
+so on. Interactive **`aimee chat` / `aimee launch` need a *co-located* server**:
+they run the agent and its tools on the client host and chdir into a local
+worktree, so they refuse a remote endpoint rather than misbehave. **Writes are off
+by default over the network** (leaked-bearer protection) — a remote bearer is
+read/query only until the server opts in via `aimee.api.remote_writes`; see
+[Drive a remote server with the CLI](#drive-a-remote-server-with-the-cli).
+
+### 3. Configure your AI coding tool
+
+On each developer machine, run `./configure-hooks.sh` (or `configure-hooks.ps1` on
+Windows) from a checkout to register aimee's SessionStart/PreToolUse/PostToolUse
+hooks and MCP server for every detected tool (Claude Code, Gemini CLI, Codex CLI,
+GitHub Copilot). The hooks call the thin client, which reaches your server. The
+full source install (below) does this for you as its last step.
+
+### Single-box source install (no Docker)
+
+To build and run everything on one host without containers — the classic
+single-developer setup — install from source:
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
@@ -164,7 +250,17 @@ cd aimee
 ./install.sh        # build + install + configure (no sudo)
 ```
 
-`install-deps.sh` installs the system packages aimee builds against and bootstraps the `aimee_shared` PostgreSQL database, the only steps that need root. `install.sh` then builds from source, installs to `~/.local/bin/`, installs service units where supported, and configures hooks for every detected AI coding tool (it also registers the MCP server for tools that support it). If a dependency is missing, `install.sh` stops and points you back at `install-deps.sh`.
+`install-deps.sh` installs the system packages aimee builds against and bootstraps the `aimee_shared` PostgreSQL database, the only steps that need root. `install.sh` then builds from source, installs the four binaries to `~/.local/bin/`, installs service units where supported (systemd user units on Linux, launchd agents on macOS), enables `aimee-kb` then `aimee-server`, and configures hooks + MCP for every detected AI coding tool. If a dependency is missing, `install.sh` stops and points you back at `install-deps.sh`. Windows users run `install.ps1` (CMake build + WinSW services) and `configure-hooks.ps1`.
+
+Source-build prerequisites:
+
+| Package | Debian/Ubuntu | macOS |
+|---------|---------------|-------|
+| C compiler | `apt install build-essential` | Xcode CLT |
+| SQLite3 (FTS5) | `apt install libsqlite3-dev sqlite3` | System SQLite |
+| libpq | `apt install libpq-dev` | `brew install libpq` |
+| libcurl | `apt install libcurl4-openssl-dev` | `brew install curl` |
+| PAM (webchat) | `apt install libpam0g-dev` | built-in |
 
 **Local or remote knowledge base.** `install.sh` asks whether to run `aimee-kb` **locally** (the default — backed by the local Postgres) or point at an existing **remote** `aimee-kb` over HTTP. Choosing remote persists `kb_client_url` (and an optional bearer token) to `aimee.yaml`, skips the local sidecar and Postgres, and `aimee-server` reaches the remote kb on every launch path. For a remote-only host, also skip the database bootstrap: `AIMEE_KB_MODE=remote ./install-deps.sh`.
 
@@ -175,40 +271,13 @@ aimee version
 aimee status
 ```
 
-If `aimee status` cannot reach the socket, start the service with `systemctl --user start aimee-server` on systemd systems, or use `aimee server start` as the cross-platform fallback.
+`aimee status` reports server, DB1, and kb health. Against a Docker server, set
+`AIMEE_SERVER_URL`/`AIMEE_SERVER_TOKEN` (or `aimee remote set`) first. On a
+source install, if `aimee status` cannot reach the socket, start the service with
+`systemctl --user start aimee-server` on systemd systems, or `aimee server start`
+as the cross-platform fallback.
 
-### Thin client against a remote server
-
-The `aimee` CLI is a thin client: by default it talks to a local `aimee-server`
-over a Unix-domain socket. To drive a **remote** `aimee-server` from macOS,
-Linux, or Windows, point the client at the server's TCP listener
-(`server_api_http_port` + `server_api_bearer_token` on the server):
-
-```bash
-# Per-invocation:
-aimee --server http://my-host:8390 --server-token=SECRET status
-
-# Or via environment (applies to every command):
-export AIMEE_SERVER_URL=http://my-host:8390
-export AIMEE_SERVER_TOKEN=SECRET
-aimee status
-
-# Or persist it (stored in <aimee_home>/remote.conf):
-aimee remote set http://my-host:8390 SECRET
-aimee remote status   # shows the resolved transport + a /v1/health probe
-aimee remote clear    # revert to the local Unix socket
-```
-
-Precedence is `--server` flag > `AIMEE_SERVER_URL` env > persisted `remote.conf`.
-
-`https://` URLs are supported on Linux/macOS builds (OpenSSL), with certificate
-verification on by default — set `AIMEE_TLS_INSECURE=1` for self-signed/dev
-servers. The Windows thin client is built without TLS and refuses `https://`;
-terminate TLS at a reverse proxy and use its `http://` address there. Prebuilt
-thin-client binaries for Linux, macOS, and Windows are attached to each GitHub
-release.
-
-#### Build just the thin client
+### Build just the thin client
 
 For packaging hosts that should ship only the `aimee` CLI (no `aimee-server`,
 `aimee-kb`, gateway, or webchat), configure with `-DAIMEE_THIN_CLIENT=ON`.
@@ -269,47 +338,52 @@ aimee status
 
 ## Run in Docker
 
-Four compose files ship for container deploys; pick by topology. They build
-from three reusable images: **`aimee-server`** (`Dockerfile.server`),
-**`aimee-kb`** (`Dockerfile`), and **`aimee-server+kb`** (`Dockerfile.combined`).
+Running the services in containers is the recommended deployment (developers then
+install only the [thin client](#2-install-the-thin-client)). Four compose files
+ship; pick by topology. They build from three reusable images: **`aimee-server`**
+(`Dockerfile.server`), **`aimee-kb`** (`Dockerfile`), and **`aimee-server+kb`**
+(`Dockerfile.combined`). Every stack also brings up a `pgvector/pgvector:pg16`
+Postgres (DB2) and a CPU embedder sidecar (`all-MiniLM-L6-v2`, `Dockerfile.embedder`);
+the kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
+boot.
 
 | File | Brings up | Use when |
 |------|-----------|----------|
-| `compose.yaml` | `aimee-kb` + Postgres (pgvector) + embedder | You want the knowledge service (DB2 + vectors) on its own |
-| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Full split stack: server `/v1` on `:8740`, kb `/v1` on `:8741` |
-| `compose.combined.yaml` | `aimee-server+kb` (one container) + Postgres + embedder | Both binaries co-located in one image; server `/v1` on `:8740` |
+| `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default** — both binaries co-located; server `/v1` on `:8740`, kb `:8741` |
+| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack — scale/update/place server and kb independently; server `:8740`, kb `:8741` |
+| `compose.yaml` | `aimee-kb` + Postgres (pgvector) + embedder | The knowledge service (DB2 + vectors) on its own — building block for a shared/scaled kb |
 | `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` endpoints with no shared knowledge |
 
-### aimee-kb
+### Combined server + kb (recommended)
 
 ```bash
-docker compose -f compose.yaml up --build
+docker compose -f compose.combined.yaml up --build -d
 ```
 
-This builds the slim kb image, starts a `pgvector/pgvector:pg16` Postgres, and
-brings up the resident embedder (`all-MiniLM-L6-v2`). The kb auto-applies its
-DB2 schema (tables + `pg_trgm`/`vector` extensions) on first boot and serves the
-`/v1` HTTP API on `:8741`:
+One `aimee-server+kb` container runs **both** binaries co-located: the kb on
+loopback `:8741` inside the container and the server fronting `:8740` with
+`AIMEE_KB_API_URL=http://127.0.0.1:8741`. Postgres + the embedder stay external
+(the image bundles the two aimee binaries, not a database). The server-routed
+knowledge endpoints prove the wiring end to end (both ports are also published
+for direct inspection):
 
 ```bash
-curl http://localhost:8741/v1/health
-curl 'http://localhost:8741/v1/health?status=1'   # DB + pgvector store status
-curl http://localhost:8741/v1/capabilities
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+curl 'http://localhost:8741/v1/health?status=1'   # in-container kb: DB + pgvector status
 ```
 
-The LLM-backed synthesis/curator passes are wired but disabled until you point
-an OpenAI-compatible endpoint at them — bring up a local llama.cpp server with
-`docker compose -f compose.yaml --profile llm up`.
-
-### Full server + kb stack
+### Split server + kb stack
 
 ```bash
-docker compose -f compose.server.yaml up --build
+docker compose -f compose.server.yaml up --build -d
 ```
 
-The server fronts the `/v1` API on `:8740` (bearer `aimee-local-dev`) and reaches
-the kb over HTTP (`AIMEE_KB_API_URL`); the kb owns Postgres + the embedder. The
-server-routed knowledge endpoints prove the wiring:
+`aimee-server` and `aimee-kb` run as separate containers — the same topology as
+the [horizontal-scaling model](#how-aimee-scales) (many servers → one shared kb).
+The server fronts `/v1` on `:8740` (bearer `aimee-local-dev`) and reaches the kb
+over HTTP (`AIMEE_KB_API_URL=http://aimee-kb:8741`); the kb owns Postgres + the
+embedder:
 
 ```bash
 curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
@@ -322,21 +396,60 @@ workspace keeps its server-side bare mirror and reconstructed worktree there, so
 the checkouts survive container recreation; the image also declares it a `VOLUME`,
 so even a plain `docker run` persists them in an anonymous volume.
 
-### Combined server+kb image
+### Knowledge base only
 
 ```bash
-docker compose -f compose.combined.yaml up --build
+docker compose -f compose.yaml up --build -d
 ```
 
-One `aimee-server+kb` container runs **both** binaries co-located: the kb on
-loopback `:8741` inside the container and the server fronting `:8740` with
-`AIMEE_KB_API_URL=http://127.0.0.1:8741`. Postgres + the embedder stay external
-(the image bundles the two aimee binaries, not a database). Same server-routed
-proof as the split stack:
+Brings up just `aimee-kb` + Postgres + embedder, serving the `/v1` HTTP API on
+`:8741` — the building block behind a shared or horizontally-scaled kb that many
+servers point at:
 
 ```bash
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+curl http://localhost:8741/v1/health
+curl 'http://localhost:8741/v1/health?status=1'   # DB + pgvector store status
+curl http://localhost:8741/v1/capabilities
 ```
+
+The LLM-backed synthesis/curator passes are wired but disabled until you point an
+OpenAI-compatible endpoint at them — bring up a local llama.cpp server with
+`docker compose -f compose.yaml --profile llm up` (the same `--profile llm` flag
+works with the combined and split stacks).
+
+### Managing the containers
+
+The compose stacks are ordinary Docker Compose projects — the binaries run as
+**long-lived container processes** (PID 1 inside each container), supervised by
+Docker's restart policy, not by systemd/launchd. Day-to-day lifecycle:
+
+```bash
+docker compose -f compose.combined.yaml up -d        # start (detached); add --build after a code change
+docker compose -f compose.combined.yaml ps           # container + health status
+docker compose -f compose.combined.yaml logs -f      # follow logs (add a service name to scope)
+docker compose -f compose.combined.yaml restart aimee-server-kb
+docker compose -f compose.combined.yaml down         # stop + remove containers (named volumes persist)
+docker compose -f compose.combined.yaml down -v      # also drop the data volumes (DESTROYS DB2 + state)
+docker compose -f compose.combined.yaml pull && \
+  docker compose -f compose.combined.yaml up -d --build   # update: rebuild images and recreate
+```
+
+Each container runs as a non-root user. Durable state lives in **named volumes**,
+not the container filesystem, so `down`/recreate is safe and `down -v` is the only
+thing that erases data:
+
+| Volume | Holds |
+|--------|-------|
+| `*-postgres` | DB2 (`aimee_shared`) — all shared knowledge + vectors |
+| `*-home` (`/var/lib/aimee`) | server/kb runtime state (DB1 SQLite, config) |
+| `*-workspaces` (`/var/lib/aimee-workspaces`) | mirror-tier bare mirrors + reconstructed worktrees |
+| `*-embedder-models` / `*-llm-models` | cached model weights |
+
+The server's worker threads need a 64 MB stack, so every server container sets
+`ulimits.stack: 67108864` (a plain `docker run` must pass `--ulimit
+stack=67108864`). Override the baked `aimee-local-dev` bearer and any config by
+mounting your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml` (see
+`compose.remote-writes.combined.yaml` for the pattern).
 
 ### Verify a stack end to end
 
@@ -359,9 +472,11 @@ cross-platform thin-client smoke) is documented in
 
 ### Drive a remote server with the CLI
 
-The `aimee` CLI normally talks to a co-located server over a Unix socket. To
-point it at a server reachable only over the network — e.g. a container's
-published `:8740` — select the HTTP transport and a remote endpoint:
+The [`--server` / `AIMEE_SERVER_URL`](#2-install-the-thin-client) path above is the
+simplest way to reach a remote server. The same connection is also expressible at
+the transport layer (the form `aimee workspace serve` and persisted `aimee.yaml`
+config use) — point it at a container's published `:8740` by selecting the HTTP
+transport and a remote endpoint:
 
 ```bash
 export AIMEE_API_CLIENT_TRANSPORT=http

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -65,7 +65,7 @@ graph TB
     CLI -->|/v1 HTTP<br/>UDS or TCP| SRV
     WC -->|/v1 HTTP<br/>UDS or TCP| SRV
     GW -.->|/v1 HTTP| SRV
-    SRV -->|typed KB RPC<br/>socket / HTTP :8741| KB
+    SRV -->|typed KB /v1<br/>HTTP :8741| KB
     SRV --> DB1
     KB --> DB2
     SRV -->|delegate HTTPS| Providers
@@ -416,15 +416,16 @@ redirected to the worktree path. Abandoned worktrees are garbage-collected by
 
 | Topology | Shape | Notes |
 |----------|-------|-------|
-| **Single developer (default)** | All processes on one host; service units keep server/KB running; DB1 in `~/.config/aimee`, DB2 in local Postgres. | Zero config beyond `install.sh` on supported service managers. |
-| **Managed services** | `aimee-kb` + local `aimee-server` as systemd user units (Linux) or launchd agents (macOS), with memory/task limits. KB starts first; server depends on it. | `systemd/user/*.service`, `service/com.aimee.*.plist`. |
-| **Shared KB** | Multiple local `aimee-server` instances point at one `aimee-kb`/Postgres deployment. DB1 remains per-user/per-machine; DB2 carries only project, workspace, global, or otherwise shareable knowledge for that KB. | Use KB URL/token config and scope promotion rules deliberately. |
-| **Containerized KB** | `aimee-kb` in a container with Postgres/pgvector, an embedder sidecar, and an optional local LLM, wired by `compose.yaml`. KB binds `0.0.0.0:8741` and uses Python sidecars for embeddings/synthesis/curation. | `Dockerfile`, `Dockerfile.embedder`, `deploy/container/aimee.yaml`. |
-| **Proxy / multi-host** | `Dockerfile.proxy` + `docker-compose.proxy.yml` for fronting a local or shared KB service. | See [`MANUAL.md`](../MANUAL.md) operations chapter. |
+| **Containerized server + KB (recommended)** | `aimee-server` + `aimee-kb` run as containers (combined in one image, or split into two) with Postgres/pgvector and an embedder sidecar; the server fronts `/v1` on `:8740` and reaches the kb over HTTP on `:8741`. Developers install only the cross-platform thin client and point it at the server. | `compose.combined.yaml` (one container) / `compose.server.yaml` (split); `Dockerfile.combined`, `Dockerfile.server`, `Dockerfile`, `Dockerfile.embedder`. |
+| **Single developer, source build** | All processes on one host from `install.sh`; service units keep server/KB running; DB1 in `~/.config/aimee`, DB2 in local Postgres. | Service-managed via `systemd/user/*.service` (Linux) or `service/com.aimee.*.plist` (macOS). KB starts first; server depends on it. |
+| **Shared KB** | Multiple `aimee-server` instances (containerized or local) point at one `aimee-kb`/Postgres deployment over HTTP. DB1 remains per-user/per-machine; DB2 carries only project, workspace, global, or otherwise shareable knowledge. | Set `AIMEE_KB_API_URL` (+ optional bearer); promote scopes deliberately. |
+| **KB-only container** | `aimee-kb` + Postgres/pgvector + embedder (+ optional local LLM) via `compose.yaml`; KB binds `0.0.0.0:8741` and uses Python sidecars for embeddings/synthesis/curation. | The building block behind a shared/scaled KB; `Dockerfile`, `Dockerfile.embedder`, `deploy/container/aimee.yaml`. |
+| **Standalone server** | `aimee-server` only (SQLite DB1, no kb), via `compose.server-standalone.yaml`. | DB1-backed `/v1` endpoints with no shared knowledge until a kb is wired in. |
 
-In every topology the contracts are identical: thin clients speak the socket
-protocol to the server; the server speaks typed KB RPC to `aimee-kb`; the
-storage boundary holds.
+In every topology the contracts are identical: thin clients speak the `/v1`
+protocol to the server (local `aimee-http.sock` or a remote `host:port`); the
+server speaks the typed KB `/v1` HTTP API to `aimee-kb` (`AIMEE_KB_API_URL`; the
+legacy Unix-socket KB transport was retired in #2747); the storage boundary holds.
 
 ---
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -102,6 +102,9 @@ This section covers how the aimee MCP server is registered with supported client
 `install.sh` and `configure-hooks.sh` automatically detect installed clients and register
 `aimee mcp-serve` for each one found. Running the installer is idempotent: if a client is
 already configured, the registration is refreshed and reported as such rather than duplicated.
+In the recommended Docker deployment (services in containers, thin client per machine),
+each developer runs `configure-hooks.sh` directly to register hooks + MCP locally; the
+hooks call the thin client, which reaches the configured `aimee-server`.
 
 | Client | Detection method | Hook config path | MCP config path | Registration status |
 |---|---|---|---|---|

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -108,7 +108,7 @@ The shipped artifacts are four binaries: `aimee`, `aimee-webchat`, `aimee-server
 flowchart TD
     CLI[aimee\nCLI + MCP stdio] -->|JSON RPC| SRV[aimee-server\nDB1 + compute pool]
     WEB[aimee-webchat\nbrowser-facing client] -->|JSON RPC| SRV
-    SRV -->|typed KB RPC| KB[aimee-kb\nDB2 + pgvector]
+    SRV -->|typed KB /v1 HTTP| KB[aimee-kb\nDB2 + pgvector]
     SRV --> DB1[src/db1/*]
     KB --> DB2[src/db2/*]
 ```

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -7,6 +7,19 @@ current version and prints it once after an upgrade.
 
 ## v0.2.0
 
+- **Docker-first deployment**: run `aimee-server` + `aimee-kb` as containers — one
+  combined image (`compose.combined.yaml`, recommended) or split
+  (`compose.server.yaml`) — and install only the thin client on each developer
+  machine. See the README "Run in Docker" and Manual §27.1.
+- **Cross-platform thin client**: the `aimee` CLI now drives a remote server over
+  HTTP from Linux, macOS, and Windows. Point it with `--server` /
+  `AIMEE_SERVER_URL` (+ `--server-token` / `AIMEE_SERVER_TOKEN`), or persist it
+  with `aimee remote set`. Prebuilt thin-client binaries ship with each release;
+  build just the client with `-DAIMEE_THIN_CLIENT=ON`.
+- **KB is HTTP-only**: `aimee-server` reaches `aimee-kb` exclusively over its `/v1`
+  HTTP API (`AIMEE_KB_API_URL`); the legacy Unix-socket KB transport and on-demand
+  autostart were retired. Deploys must run `aimee-kb --http-port=8741` (or its
+  service unit / container).
 - **Self-update notifier**: aimee now tells you what changed after each upgrade
   and warns when the binary is older than the source tree.
 - **Stale binary detection**: a one-line warning appears when the binary predates

--- a/src/README.md
+++ b/src/README.md
@@ -492,7 +492,7 @@ graph TD
     Server --> Data
     Server --> Agent
     Server --> Cmd
-    Server -.->|typed KB RPC| KB
+    Server -.->|typed KB /v1 HTTP| KB
     Core --> Data
     Data --> Agent
     Agent --> Cmd
@@ -811,9 +811,10 @@ reference for the separate KB API (`api/openapi-v1.yaml`). See the
 ## The KB split
 
 `aimee-server` owns no DB2 SQL. It reaches DB2 through the **KB client**
-(`src/server/kb_client*.c`), typed RPC wrappers (memory, index, docs, agent,
-dashboard, roadmap, notes, curiosity, status) that talk to `aimee-kb` over a Unix
-socket or HTTP (`AIMEE_KB_API_URL`, port 8741). DB1 remains local to the server;
+(`src/server/kb_client*.c`), typed wrappers (memory, index, docs, agent,
+dashboard, roadmap, notes, curiosity, status) that call `aimee-kb` over its
+HTTP `/v1` API (`AIMEE_KB_API_URL`, port 8741). The legacy Unix-socket transport
+was retired in #2747 — HTTP is now the only KB transport. DB1 remains local to the server;
 DB2 can be a local single-user KB or a shared KB, and server-side reflection or
 promotion flows send only scoped knowledge artifacts across that boundary.
 `aimee-kb` (`src/kb/`) owns the DB2 schema, the memory inference pipeline, the
@@ -821,8 +822,9 @@ vector collections, the code index, document ingest, and the curator. It exposes
 43 HTTP /v1 endpoints
 (`/v1/code/*`, `/v1/docs/*`, `/v1/search`, `/v1/ingest/*`, `/v1/entities/*`,
 `/v1/reflections/*`, `/v1/maintenance/*`, `/v1/releases/*`), see
-`api/openapi-v1.yaml`. The server auto-starts the KB on demand unless
-`AIMEE_KB_NO_AUTOSTART` is set.
+`api/openapi-v1.yaml`. The server no longer auto-starts the KB: `AIMEE_KB_API_URL`
+must point at an already-running `aimee-kb` (started by its service unit, container,
+or `aimee-kb --http-port`). `AIMEE_KB_NO_AUTOSTART` is now a deprecated no-op.
 
 ## Scaling model
 


### PR DESCRIPTION
Reframe the documentation around the intended deployment model: run `aimee-server` + `aimee-kb` as Docker container(s) (combined recommended, split documented) and install only the cross-platform thin client on each developer machine, pointed at the server. The build-from-source `install.sh` flow is demoted to a "single-box source install (no Docker)" section.

## Changes (docs-only)

- **README** — restructured `## Install` (run server in Docker → install thin client → configure tool → source-install alternative → verify); reordered `## Run in Docker` to lead with the combined stack and added a full container lifecycle + volumes/state section.
- **MANUAL** — rebuilt §3 to the same shape; expanded §27.1 into a complete "Containerized deployment" section (compose matrix, lifecycle, volumes, smoke tests); updated the deployment-topology tables.
- **KB HTTP-only (#2747)** — documented that the server reaches `aimee-kb` only via `AIMEE_KB_API_URL` over `/v1` HTTP `:8741` and no longer autostarts it; fixed stale Unix-socket / typed-KB-RPC / autostart claims and the `aimee-kb.sock` entry across MANUAL, ARCHITECTURE, STATUS, and src/README.
- **Env vars / WHATS_NEW** — added thin-client + container env vars to MANUAL Appendix A and a WHATS_NEW entry.

All documented commands were verified against the compose files, smoke scripts, and CLI/KB code. No code changes.