### PR TITLE
fix(verify-gate): verify committed head, not working tree, for PR creation

### DIFF
--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -702,6 +702,59 @@ static int bash_git_push_target_dir(const char *cmd, const char *fallback_cwd, c
    return rc == 0;
 }
 
+/* Resolve the commit a push / PR-create verify gate should check: the *committed*
+ * tip of the ref being pushed or proposed — NOT the live working tree. A PR ships
+ * the branch as it exists on the remote (so prefer origin/<head>); a push ships
+ * the local ref. Passing this commit to verify_check makes the gate verify the
+ * tree that will actually leave the machine, which is correct even when the head
+ * branch is checked out in a *different* (stale or foreign) worktree. Returns 1
+ * and fills out with a commit SHA, or 0 when no ref resolves — the caller then
+ * falls back to the working-tree hash (prior behavior). */
+static int bash_gate_expected_commit(const char *cmd, const char *pdir, int is_pr_create, char *out,
+                                     size_t out_len)
+{
+   char ref[256];
+   const char *candidates[2];
+   int ncand = 0;
+   char origin_ref[300];
+
+   if (is_pr_create)
+   {
+      if (!bash_gh_pr_create_head_ref(cmd, ref, sizeof(ref)))
+         return 0;
+      snprintf(origin_ref, sizeof(origin_ref), "origin/%s", ref);
+      candidates[ncand++] = origin_ref; /* what gh actually proposes */
+      candidates[ncand++] = ref;        /* fallback: local branch tip */
+   }
+   else
+   {
+      if (!bash_git_push_local_ref(cmd, ref, sizeof(ref)))
+         return 0;
+      candidates[ncand++] = ref;
+   }
+
+   for (int i = 0; i < ncand; i++)
+   {
+      char rc_cmd[MAX_PATH_LEN + 384];
+      snprintf(rc_cmd, sizeof(rc_cmd),
+               "git -C '%s' rev-parse --verify --quiet '%s^{commit}' 2>/dev/null", pdir,
+               candidates[i]);
+      int rc;
+      char *res = run_cmd(rc_cmd, &rc);
+      if (rc == 0 && res && res[0])
+      {
+         char *nl = strchr(res, '\n');
+         if (nl)
+            *nl = '\0';
+         snprintf(out, out_len, "%s", res);
+         free(res);
+         return 1;
+      }
+      free(res);
+   }
+   return 0;
+}
+
 /* Return 1 when dir is inside a git worktree checkout (not the primary repo
  * checkout). We compare --git-dir to --git-common-dir: they differ in a
  * linked worktree and match in the main checkout. */
@@ -1256,8 +1309,17 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
       const char *vr = (wrc == 0 && wt && wt[0]) ? wt : NULL;
       verify_config_t vcfg;
       char vm[256];
+      /* Verify the committed tip being pushed/proposed, not the working tree of
+       * whatever checkout happens to hold the head branch (which may be a stale
+       * or foreign worktree). Falls back to NULL (working-tree hash) if no ref
+       * resolves. */
+      char expected[64];
+      const char *exp = bash_gate_expected_commit(cmd->valuestring, pdir, is_pr_create, expected,
+                                                  sizeof(expected))
+                            ? expected
+                            : NULL;
       if (verify_load_config(vr, &vcfg) == 0 && vcfg.enforce &&
-          !verify_check(vr, NULL, vm, sizeof(vm)))
+          !verify_check(vr, exp, vm, sizeof(vm)))
       {
          snprintf(msg_buf, msg_len, "BLOCKED: %s blocked — %s. Run 'aimee git verify' first.",
                   is_push ? "push" : "pr create", vm);

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -180,6 +180,7 @@ int main(void)
    test_read_tracking_state_roundtrip();
    test_verify_gate_blocks_bash_git_push();
    test_verify_gate_blocks_bash_gh_pr_create();
+   test_verify_gate_pr_create_uses_head_commit_not_worktree();
    test_verify_gate_not_enforced_without_enforce_flag();
    test_verify_gate_worktree_uses_own_last_verify();
    test_verify_gate_uses_tool_workdir();

--- a/src/tests/test_guardrails_cases_b.inc
+++ b/src/tests/test_guardrails_cases_b.inc
@@ -1267,6 +1267,76 @@ static void test_verify_gate_blocks_bash_gh_pr_create(void)
    vy_clear_home();
 }
 
+static void test_verify_gate_pr_create_uses_head_commit_not_worktree(void)
+{
+   /* Regression (#gh-pr-create verify gate): `gh pr create --head <branch>` must
+    * verify the COMMITTED tip of the head branch, not the live working tree of
+    * the checkout that holds it. A PR ships the committed branch, so a verified
+    * head commit must pass the gate even when the working tree is dirty (or, in
+    * the real failure, belongs to a stale/foreign worktree). Prior to the fix the
+    * gate hashed the working tree and blocked. */
+   char tmpdir[256];
+   snprintf(tmpdir, sizeof(tmpdir), "/tmp/aimee-test-vg-prhead-XXXXXX");
+   assert(mkdtemp(tmpdir) != NULL);
+
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd),
+            "cd '%s' && git init -q && git config user.email t@t && "
+            "git config user.name t && echo x > f && git add f && "
+            "git commit -q -m init && git checkout -q -b testing",
+            tmpdir);
+   assert(system(cmd) == 0);
+
+   vy_set_global_yaml(
+       tmpdir, "verify:\n  enforce: true\n  steps:\n    - name: build\n      run: echo ok\n");
+
+   /* Record the COMMITTED head tree as verified (clean tree == HEAD tree). */
+   char *head_tree = verify_compute_file_hash(tmpdir);
+   assert(head_tree != NULL);
+   char lv[512];
+   snprintf(lv, sizeof(lv), "%s/.aimee/.last-verify", tmpdir);
+   {
+      char mk[600];
+      snprintf(mk, sizeof(mk), "mkdir -p '%s/.aimee'", tmpdir);
+      assert(system(mk) == 0);
+   }
+   FILE *f = fopen(lv, "w");
+   assert(f != NULL);
+   fprintf(f, "%ld\n%s\nfailed=0/total=1\n", (long)time(NULL), head_tree);
+   fclose(f);
+   free(head_tree);
+
+   /* Dirty the working tree so its hash no longer matches the verified commit. */
+   snprintf(cmd, sizeof(cmd), "cd '%s' && echo dirty >> f", tmpdir);
+   assert(system(cmd) == 0);
+
+   char saved_cwd[4096];
+   assert(getcwd(saved_cwd, sizeof(saved_cwd)) != NULL);
+   assert(chdir(tmpdir) == 0);
+
+   guardrails_open_test_sqlite();
+   session_state_t state;
+   memset(&state, 0, sizeof(state));
+   strcpy(state.session_mode, MODE_IMPLEMENT);
+   strcpy(state.guardrail_mode, MODE_APPROVE);
+
+   char msg[512] = {0};
+   int rc = pre_tool_check(
+       "Bash", "{\"command\":\"gh pr create --title 'test' --body '' --base main --head testing\"}",
+       &state, MODE_APPROVE, tmpdir, msg, sizeof(msg));
+   /* The committed head (branch `testing`) is verified, so the verify gate must
+    * NOT block even though the working tree is dirty. */
+   assert(strstr(msg, "pr create blocked") == NULL);
+   (void)rc;
+
+   guardrails_close_test_sqlite();
+
+   assert(chdir(saved_cwd) == 0);
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   system(cmd);
+   vy_clear_home();
+}
+
 static void test_verify_gate_not_enforced_without_enforce_flag(void)
 {
    /* With enforce: false, git push must NOT be blocked by the verify gate. */


### PR DESCRIPTION
## Problem

The pre-flight verify gate for `git push` / PR creation resolved the local checkout that holds the head branch, then called `verify_check()` with a NULL commit — which falls back to hashing that checkout's **live working tree**. For a PR created with `--head <branch>`, that's the wrong thing to verify: a PR ships the **committed** branch (the remote tip), not a working tree.

When the head branch is checked out in a **different worktree** (stale, or owned by another session), the gate hashed an unrelated tree and blocked a push/PR whose committed content was already verified — with no way to clear it from the current session.

## Fix

`src/guardrails_orchestrator.c`: resolve the committed tip of the ref being pushed/proposed (`origin/<head>` then local `<head>` for PR creation; the local ref for push) and pass it to `verify_check()` as `expected_commit`, so the gate verifies the tree that will actually leave the machine. Falls back to the previous working-tree hash when no ref resolves (no behavior change there).

This matches the documented intent of `verify_check`'s `expected_commit` parameter (the SHA of the ref being pushed), already used by the pre-push hook path.

## Test

Adds `test_verify_gate_pr_create_uses_head_commit_not_worktree`: records a verified head commit, dirties the working tree, and asserts the gate does **not** block the PR-create. `make lint` + `unit-test-guardrails` pass.