### PR TITLE
ci: fix multi-arch manifest merge collision + add allow-only-testing-source gate

### DIFF
--- a/.github/workflows/branch-policy.yml
+++ b/.github/workflows/branch-policy.yml
@@ -1,0 +1,32 @@
+# Branch policy gate for `main`.
+#
+# `main`'s branch protection lists `allow-only-testing-source` as a REQUIRED
+# status check, but nothing produced it — so every PR into `main` sat blocked on
+# a check that never reported. This workflow produces that check: a PR may merge
+# into `main` only when its source (head) branch is `testing`.
+#
+# The required-check context is the job's check-run name, so the job name must
+# stay EXACTLY `allow-only-testing-source` to satisfy branch protection.
+name: Branch policy
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  allow-only-testing-source:
+    name: allow-only-testing-source
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the PR source branch to be `testing`
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [ "$HEAD_REF" != "testing" ]; then
+            echo "::error::PRs into 'main' may only originate from the 'testing' branch (source was '$HEAD_REF')."
+            exit 1
+          fi
+          echo "PR source branch is 'testing' — allowed to target main."

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -98,10 +98,15 @@ jobs:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
+      # Match ONLY this image's per-arch digests. A trailing `-*` would be greedy:
+      # `digest-aimee-server-*` also matches `digest-aimee-server-kb-*` (one image
+      # name is a prefix of another), which previously pulled the combined image's
+      # digests into the aimee-server manifest and broke the push. Anchor on the
+      # exact arch suffixes instead (brace expansion, no wildcard across `-`).
       - name: Download this image's digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digest-${{ matrix.image }}-*
+          pattern: digest-${{ matrix.image }}-{amd64,arm64}
           path: /tmp/digests
           merge-multiple: true
 
@@ -129,11 +134,21 @@ jobs:
       - name: Create + push the multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          # Assemble the list of source digests for this image.
+          # Assemble the list of source digests for this image. Expect exactly the
+          # per-arch builds (amd64 + arm64); fail loudly on a mismatch rather than
+          # pushing a partial or cross-image manifest.
           srcs=""
+          count=0
           for f in *; do
+            [ -e "$f" ] || continue
             srcs="$srcs ghcr.io/${OWNER}/${{ matrix.image }}@$(cat "$f")"
+            count=$((count + 1))
           done
+          echo "Found $count digest(s) for ${{ matrix.image }}: $srcs"
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no digests matched for ${{ matrix.image }} — check the download-artifact pattern"
+            exit 1
+          fi
           # Apply every tag the metadata action produced to the merged manifest.
           tags=$(jq -r '.tags[] | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           docker buildx imagetools create $tags $srcs


### PR DESCRIPTION
Two CI fixes.

## 1. `publish-images`: multi-arch manifest merge collision (fixes the failing Publish images run)

The `merge` job downloaded per-arch digests with the greedy pattern `digest-<image>-*`. Because `aimee-server` is a prefix of `aimee-server-kb`, the `aimee-server` manifest job pulled in the **combined** image's digests (`digest-aimee-server-kb-{amd64,arm64}`) and `docker buildx imagetools create` failed pushing a manifest that referenced digests from another repo. (`aimee-kb` and `aimee-server-kb` don't collide, so only `aimee-server` failed.)

- Anchor the download pattern on exact arch suffixes: `digest-<image>-{amd64,arm64}`.
- Fail loudly in the create step if zero digests match, instead of pushing a partial/cross-image manifest.

## 2. `branch-policy`: produce the required `allow-only-testing-source` check

`main`'s branch protection requires a status check named `allow-only-testing-source`, but **no workflow produced it**, so every PR into `main` was blocked on a check that never reported. New `pull_request` (→ `main`) workflow with a job named exactly `allow-only-testing-source` that passes only when the PR's source branch is `testing`. This enforces the "only `testing` merges to `main`" policy and satisfies branch protection.

Both YAMLs validated. The branch-policy gate takes effect once it's on `testing`'s head, at which point open `testing` → `main` PRs re-trigger and the check reports.