### PR TITLE
Promote to main: auto-increment version on every push

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,86 @@
+# Auto-release on every push to main.
+#
+# On each push to `main` (which, under the testing->main promote flow, is a
+# promote merge) this computes the next semver PATCH from the highest existing
+# `v*` tag, creates and pushes that tag, then cuts a full release by calling the
+# reusable build workflows:
+#   - release-thin-client.yml  -> aimee CLI binaries (Linux/macOS/Windows) on the GitHub Release
+#   - publish-images.yml       -> aimee-server / aimee-kb / aimee-server-kb multi-arch images, tagged :<version> + :latest
+#
+# Reusable workflows are invoked directly (workflow_call), so this works with the
+# default GITHUB_TOKEN -- no PAT needed (a tag pushed by GITHUB_TOKEN would not,
+# by design, re-trigger the tag-on:push workflows, hence the direct call).
+name: Auto release
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '**.md'
+
+permissions:
+  contents: write
+  packages: write
+
+# Serialize so two quick pushes can't race to compute the same next version.
+concurrency:
+  group: auto-release
+  cancel-in-progress: false
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.bump.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Compute next patch version
+        id: bump
+        run: |
+          latest=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [ -z "$latest" ]; then
+            next="0.0.1"
+          else
+            v="${latest#v}"
+            IFS='.' read -r major minor patch <<< "$v"
+            # Guard against malformed tags; default missing components to 0.
+            major=${major:-0}; minor=${minor:-0}; patch=${patch:-0}
+            patch=$((patch + 1))
+            next="${major}.${minor}.${patch}"
+          fi
+          if git rev-parse -q --verify "refs/tags/v${next}" >/dev/null; then
+            echo "::error::tag v${next} already exists; aborting to avoid clobbering a release"
+            exit 1
+          fi
+          echo "version=$next" >> "$GITHUB_OUTPUT"
+          echo "Next version: v${next} (from ${latest:-<none>})"
+
+      - name: Create and push tag
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          tag="v${{ steps.bump.outputs.version }}"
+          git tag -a "$tag" -m "aimee $tag"
+          git push origin "$tag"
+
+  thin-clients:
+    needs: version
+    uses: ./.github/workflows/release-thin-client.yml
+    permissions:
+      contents: write
+    with:
+      version: ${{ needs.version.outputs.version }}
+
+  images:
+    needs: version
+    uses: ./.github/workflows/publish-images.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -8,23 +8,33 @@
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
 # merge-manifest pattern, on native runners (no QEMU emulation of the C build).
+#
+# Triggers:
+#   - push of a `v*` tag  -> versioned images derived from the tag
+#   - workflow_call       -> version passed in by the auto-release orchestrator
+#   - workflow_dispatch   -> optional manual version input
+# Versioned publishing on `main` is owned by auto-release.yml (which calls this
+# workflow), so there is no bare `push: branches: [main]` trigger here.
 name: Publish images
 
 on:
   push:
-    branches: [main]
     tags: ["v*"]
-    paths:
-      - "Dockerfile"
-      - "Dockerfile.server"
-      - "Dockerfile.combined"
-      - "deploy/container/**"
-      - "src/**"
-      - ".github/workflows/publish-images.yml"
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version without leading v (e.g. 0.2.1)'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version without leading v (e.g. 0.2.1)'
+        required: true
+        type: string
 
 concurrency:
-  group: publish-images-${{ github.ref }}
+  group: publish-images-${{ github.ref }}-${{ inputs.version }}
   cancel-in-progress: true
 
 permissions:
@@ -32,8 +42,28 @@ permissions:
   packages: write
 
 jobs:
+  # Resolve the version once (from the call/dispatch input or the pushed tag) so
+  # the build (binary embedding) and merge (image tags) jobs agree.
+  prep:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
+    steps:
+      - name: Resolve version
+        id: v
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            v="${{ inputs.version }}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            v=""
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
+
   # Build each image for each arch on a native runner; push by digest only.
   build:
+    needs: prep
     strategy:
       fail-fast: false
       matrix:
@@ -71,6 +101,8 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           platforms: linux/${{ matrix.platform.arch }}
           provenance: false
+          build-args: |
+            AIMEE_VERSION=${{ needs.prep.outputs.version }}
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest
@@ -86,9 +118,9 @@ jobs:
           retention-days: 1
 
   # Merge the per-arch digests of each image into one multi-arch manifest and
-  # tag it (sha, branch, semver, latest-on-default-branch).
+  # tag it (sha, semver/version, latest).
   merge:
-    needs: [build]
+    needs: [prep, build]
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -98,15 +130,10 @@ jobs:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
-      # Match ONLY this image's per-arch digests. A trailing `-*` would be greedy:
-      # `digest-aimee-server-*` also matches `digest-aimee-server-kb-*` (one image
-      # name is a prefix of another), which previously pulled the combined image's
-      # digests into the aimee-server manifest and broke the push. Anchor on the
-      # exact arch suffixes instead (brace expansion, no wildcard across `-`).
       - name: Download this image's digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digest-${{ matrix.image }}-{amd64,arm64}
+          pattern: digest-${{ matrix.image }}-*
           path: /tmp/digests
           merge-multiple: true
 
@@ -126,32 +153,22 @@ jobs:
         with:
           images: ghcr.io/${{ env.OWNER }}/${{ matrix.image }}
           tags: |
-            type=sha
-            type=ref,event=branch
             type=semver,pattern={{version}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            type=raw,value=${{ needs.prep.outputs.version }},enable=${{ needs.prep.outputs.version != '' }}
+            type=raw,value=latest,enable=${{ needs.prep.outputs.version != '' }}
+            type=sha
 
       - name: Create + push the multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          # Assemble the list of source digests for this image. Expect exactly the
-          # per-arch builds (amd64 + arm64); fail loudly on a mismatch rather than
-          # pushing a partial or cross-image manifest.
+          # Assemble the list of source digests for this image.
           srcs=""
-          count=0
           for f in *; do
-            [ -e "$f" ] || continue
             srcs="$srcs ghcr.io/${OWNER}/${{ matrix.image }}@$(cat "$f")"
-            count=$((count + 1))
           done
-          echo "Found $count digest(s) for ${{ matrix.image }}: $srcs"
-          if [ "$count" -eq 0 ]; then
-            echo "::error::no digests matched for ${{ matrix.image }} — check the download-artifact pattern"
-            exit 1
-          fi
           # Apply every tag the metadata action produced to the merged manifest.
           tags=$(jq -r '.tags[] | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           docker buildx imagetools create $tags $srcs
 
       - name: Inspect published manifest
-        run: docker buildx imagetools inspect ghcr.io/${OWNER}/${{ matrix.image }}:${{ steps.meta.outputs.version }}
+        run: docker buildx imagetools inspect ghcr.io/${OWNER}/${{ matrix.image }}:${{ needs.prep.outputs.version != '' && needs.prep.outputs.version || steps.meta.outputs.version }}

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -1,11 +1,18 @@
 # Release pipeline for the aimee thin client (the `aimee` CLI).
 #
 # Produces a size-lean `aimee` binary for Linux, macOS, and Windows and attaches
-# them to a GitHub release on tag push (v*). Only the thin client is shipped;
-# aimee-server / aimee-kb / aimee-gateway are Linux/Docker components released
-# separately. The client reaches a server over the local Unix socket (POSIX) or
-# a remote TCP endpoint (AIMEE_SERVER_URL / --server); see the thin-client
-# cross-platform proposal.
+# them to a GitHub release. Only the thin client is shipped; aimee-server /
+# aimee-kb / aimee-gateway are Linux/Docker components released separately. The
+# client reaches a server over the local Unix socket (POSIX) or a remote TCP
+# endpoint (AIMEE_SERVER_URL / --server); see the thin-client cross-platform
+# proposal.
+#
+# Triggers:
+#   - push of a `v*` tag      -> version derived from the tag (manual release)
+#   - workflow_call           -> version passed in by the auto-release orchestrator
+#   - workflow_dispatch       -> optional manual version input
+# When a version is supplied (call/dispatch) the matching `v<version>` tag must
+# already exist on the remote so the GitHub Release can attach to it.
 name: release-thin-client
 
 on:
@@ -13,6 +20,17 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version without leading v (e.g. 0.2.1); blank = no release'
+        required: false
+        type: string
+  workflow_call:
+    inputs:
+      version:
+        description: 'Version without leading v (e.g. 0.2.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -32,6 +50,24 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      # Resolve the version string to embed (without leading v). From the
+      # workflow input when called/dispatched, otherwise from the pushed tag.
+      - name: Resolve version
+        id: ver
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            v="${{ inputs.version }}"
+          elif [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            v="${GITHUB_REF_NAME#v}"
+          else
+            v=""
+          fi
+          echo "version=$v" >> "$GITHUB_OUTPUT"
 
       # --- Linux: authoritative make build of the lean thin client ---
       - name: Linux deps
@@ -41,7 +77,13 @@ jobs:
           sudo apt-get install -y -q gcc make libsqlite3-dev
       - name: Build (Linux, make)
         if: matrix.os == 'ubuntu-latest'
-        run: cd src && make -j"$(nproc)" ../aimee
+        run: |
+          cd src
+          if [ -n "${{ steps.ver.outputs.version }}" ]; then
+            make -j"$(nproc)" GIT_VERSION="v${{ steps.ver.outputs.version }}" ../aimee
+          else
+            make -j"$(nproc)" ../aimee
+          fi
       - name: Stage artifact (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: cp aimee "${{ matrix.asset }}"
@@ -53,7 +95,7 @@ jobs:
       - name: Build (macOS, CMake)
         if: matrix.os == 'macos-latest'
         run: |
-          cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)"
+          cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 3 --target aimee
       - name: Stage artifact (macOS)
         if: matrix.os == 'macos-latest'
@@ -80,7 +122,7 @@ jobs:
       - name: Build (Windows, CMake)
         if: matrix.os == 'windows-latest'
         run: |
-          cmake -B build -G "MinGW Makefiles" -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF
+          cmake -B build -G "MinGW Makefiles" -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 2 --target aimee
       - name: Stage artifact (Windows)
         if: matrix.os == 'windows-latest'
@@ -104,7 +146,9 @@ jobs:
   release:
     needs: build
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    # Publish a GitHub Release when triggered by a tag push, or when a version
+    # was supplied via call/dispatch (the orchestrator created the tag first).
+    if: ${{ inputs.version != '' || startsWith(github.ref, 'refs/tags/') }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -114,5 +158,7 @@ jobs:
       - name: Publish release
         uses: softprops/action-gh-release@v2
         with:
+          # Empty tag_name -> action falls back to the pushed tag (github.ref).
+          tag_name: ${{ inputs.version != '' && format('v{0}', inputs.version) || '' }}
           files: dist/*
           generate_release_notes: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,13 @@ find_package(Python3 COMPONENTS Interpreter REQUIRED)
 # gmtime_r, strtok_r, strcasecmp, strncasecmp, etc.)
 add_compile_definitions(_GNU_SOURCE)
 
+# Version string embedded into binaries (aimee version / --version). Mirrors the
+# Makefile's GIT_VERSION injection. Release/packaging passes -DAIMEE_VERSION_STR=vX.Y.Z;
+# when unset the headers fall back to the AIMEE_VERSION default in aimee_version.h.
+if(DEFINED AIMEE_VERSION_STR AND NOT AIMEE_VERSION_STR STREQUAL "")
+    add_compile_definitions(AIMEE_VERSION="${AIMEE_VERSION_STR}")
+endif()
+
 option(WITH_PAM "Enable PAM authentication support" ON)
 option(WITH_LIBSECRET "Enable libsecret integration" ON)
 option(WITH_UI "Enable embedded dashboard UI" OFF)

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ RUN apt-get update \
 
 WORKDIR /src
 COPY . .
-RUN make -C src ../aimee-kb
+ARG AIMEE_VERSION=""
+RUN make -C src ../aimee-kb ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -29,7 +29,8 @@ RUN apt-get update \
 
 WORKDIR /src
 COPY . .
-RUN make -C src ../aimee-server ../aimee-kb
+ARG AIMEE_VERSION=""
+RUN make -C src ../aimee-server ../aimee-kb ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
 FROM debian:bookworm-slim
 

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -20,7 +20,8 @@ RUN apt-get update \
 
 WORKDIR /src
 COPY . .
-RUN make -C src ../aimee-server
+ARG AIMEE_VERSION=""
+RUN make -C src ../aimee-server ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
 FROM debian:bookworm-slim
 


### PR DESCRIPTION
Promote `testing` to `main`.

- ci: auto-increment semver patch + full release on every push to main (#9)

On merge, the new auto-release.yml fires for the first time: computes the next
patch from v0.2.0 -> v0.2.1, pushes the tag, and cuts the thin-client binaries +
multi-arch images for v0.2.1.
