### PR TITLE
docs: remove em/en-dashes and prose double-dashes (AIisms)

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -40,9 +40,9 @@ it as a lookup reference afterward.
 26. [Server and service management](#26-server-and-service-management)
 27. [Operations and deployment](#27-operations-and-deployment)
 28. [Troubleshooting](#28-troubleshooting)
-29. [Appendix A, Environment variables](#appendix-a--environment-variables)
-30. [Appendix B, Files and paths](#appendix-b--files-and-paths)
-31. [Appendix C, Glossary](#appendix-c--glossary)
+29. [Appendix A, Environment variables](#appendix-a-environment-variables)
+30. [Appendix B, Files and paths](#appendix-b-files-and-paths)
+31. [Appendix C, Glossary](#appendix-c-glossary)
 
 ---
 
@@ -123,12 +123,12 @@ gates each tool call; PostToolUse re-indexes edited files.
 
 ## 3. Installation
 
-aimee ships four binaries — the **`aimee`** thin client, **`aimee-server`**,
+aimee ships four binaries: the **`aimee`** thin client, **`aimee-server`**,
 **`aimee-kb`**, and **`aimee-webchat`**. There are two ways to stand it up:
 
-- **Docker services + thin client (recommended, [§3.1](#31-run-the-services-in-docker-recommended)–[§3.2](#32-install-the-thin-client)).**
-  Run `aimee-server` and `aimee-kb` as containers — one combined container or two
-  split — and install only the thin `aimee` CLI on each developer machine, pointed
+- **Docker services + thin client (recommended, [§3.1](#31-run-the-services-in-docker-recommended) to [§3.2](#32-install-the-thin-client)).**
+  Run `aimee-server` and `aimee-kb` as containers (one combined container or two
+  split) and install only the thin `aimee` CLI on each developer machine, pointed
   at the server. This is the intended deployment and the path the operations
   chapter ([§27](#27-operations-and-deployment)) details.
 - **Single-box source build ([§3.3](#33-single-box-source-build)).** Build and run
@@ -165,7 +165,7 @@ Override the default `aimee-local-dev` bearer on any networked deployment.
 
 Each developer installs only the `aimee` CLI. Prebuilt thin-client binaries for
 Linux, macOS, and Windows are attached to every GitHub release; or build just the
-client from a checkout (a C compiler is the only dependency — no Go, libpq, or
+client from a checkout (a C compiler is the only dependency, no Go, libpq, or
 zstd):
 
 ```bash
@@ -175,7 +175,7 @@ cmake --build build --target aimee
 ```
 
 On macOS add `-DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)"`; on Windows (MinGW)
-add `-G "MinGW Makefiles" -DWITH_TLS=OFF` (no TLS — terminate TLS at a proxy).
+add `-G "MinGW Makefiles" -DWITH_TLS=OFF` (no TLS; terminate TLS at a proxy).
 Point the client at the server per-invocation, via the environment, or persist it:
 
 ```bash
@@ -212,7 +212,7 @@ cd aimee
 ```
 
 `install-deps.sh` installs the build/runtime packages and bootstraps the
-`aimee_shared` PostgreSQL database — the only steps that need root. (For a host
+`aimee_shared` PostgreSQL database, the only steps that need root. (For a host
 that uses a *remote* kb and needs no local database, run `AIMEE_KB_MODE=remote
 ./install-deps.sh`.) Prerequisites by platform:
 
@@ -238,18 +238,18 @@ Go 1.25+ is required only to build `aimee-webchat`. Then `install.sh`, in order:
 3. **Stop any running server/KB** gracefully to avoid "text file busy".
 4. **Install binaries** to `~/.local/bin/` and remove retired binaries.
 5. **Install bundled skills** to `~/.local/share/aimee/skills/` (idempotent).
-6. **Choose a kb mode** — local sidecar (default, backed by local Postgres) or a
+6. **Choose a kb mode**: local sidecar (default, backed by local Postgres) or a
    remote `aimee-kb` over HTTP (persists `kb_client_url`/`kb_client_bearer_token`
    to `aimee.yaml`).
-7. **Install service units** — systemd user units (Linux) or launchd plists
-   (macOS) — and enable `aimee-kb` then `aimee-server` (server only, in remote-kb
+7. **Install service units**: systemd user units (Linux) or launchd plists
+   (macOS), and enable `aimee-kb` then `aimee-server` (server only, in remote-kb
    mode).
 8. **Install `ast-grep` (`sg`)** for structural code search.
 9. **Configure your primary AI CLI** (Claude / Codex / Gemini / OpenAI-compatible),
    saved to `~/.config/aimee/aimee.yaml`.
 10. **Optionally add a local delegate** via `add-local-delegate.sh` (Ollama /
     llama.cpp).
-11. **Configure AI coding tools** via `configure-hooks.sh` — register hooks + MCP
+11. **Configure AI coding tools** via `configure-hooks.sh`: register hooks + MCP
     for Claude Code, Gemini CLI, Codex CLI, GitHub Copilot.
 
 `install-deps.sh` also bootstraps Postgres (starts the service, creates
@@ -319,7 +319,7 @@ manually) or drop the Postgres `aimee_shared` database.
 
 aimee reads three configuration files plus per-project metadata and a set of
 environment variables. All live under `~/.config/aimee/` unless `AIMEE_HOME` is
-set (see [Appendix A](#appendix-a--environment-variables)).
+set (see [Appendix A](#appendix-a-environment-variables)).
 
 ### 5.1 `aimee.yaml`, main configuration
 
@@ -790,10 +790,10 @@ scope lattice, knowledge graph, and reflection that turn stored facts into
 ### 8.1 The four tiers
 
 ```
-L0  Session       scratch / in-progress state   — lifetime: session only
-L1  Recent        decisions, context, checkpoints — lifetime: ~30 days
-L2  Long-term     stable facts, preferences, patterns — persistent
-L3  Episodic      past attempts, outcomes, failures — persistent, decays
+L0  Session       scratch / in-progress state   - lifetime: session only
+L1  Recent        decisions, context, checkpoints - lifetime: ~30 days
+L2  Long-term     stable facts, preferences, patterns - persistent
+L3  Episodic      past attempts, outcomes, failures - persistent, decays
 ```
 
 Promotion and decay are automatic: L0 folds into L1 at session end; L1 promotes
@@ -1093,12 +1093,12 @@ aimee kb docs push --scope project README.md     # stage docs for ingest
 
 Ingest runs through staged document upload → curator extraction (structured
 knowledge from prose/code/API docs) → embedding → review. `aimee-kb` serves its
-contract over an **HTTP `/v1` API on port 8741** — this is the only transport;
+contract over an **HTTP `/v1` API on port 8741**: this is the only transport;
 the legacy Unix-socket RPC was retired in #2747. The server's KB client, thin
 clients, and containerized deployments all reach it that way, via
 `AIMEE_KB_API_URL` (plus an optional bearer in `AIMEE_KB_API_BEARER_TOKEN`). The
 KB must be running (its service unit, container, or `aimee-kb --http-port=8741`)
-before the server can use kb-backed features — the server no longer autostarts it.
+before the server can use kb-backed features; the server no longer autostarts it.
 The contract is `api/openapi-v1.yaml`; the generated markdown is `docs/gen/api-v1.md`.
 
 ---
@@ -1203,7 +1203,7 @@ explicit legacy routes (e.g. `codex-cli`) still use the provider CLI.
 ## 26. Server and service management
 
 `aimee-server` runs as a long-lived service. In the recommended Docker deployment
-it is a container supervised by Docker's restart policy — manage it with `docker
+it is a container supervised by Docker's restart policy; manage it with `docker
 compose` ([§27.1](#271-containerized-deployment)). On a source install it is a
 systemd user unit, launchd agent, or Windows service wrapper installed by the
 platform scripts. Either way the thin CLI does not implicitly spawn a server for
@@ -1243,7 +1243,7 @@ limits and restart on failure. Logs go to the journal (Linux) or
 
 Running the services in containers is the recommended deployment: developers
 install only the thin client ([§3.2](#32-install-the-thin-client)) and point it at
-the server. Four compose files ship, built from three images — `aimee-server`
+the server. Four compose files ship, built from three images: `aimee-server`
 (`Dockerfile.server`), `aimee-kb` (`Dockerfile`), and the co-located
 `aimee-server+kb` (`Dockerfile.combined`). Every stack also brings up a
 `pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`all-MiniLM-L6-v2`,
@@ -1253,8 +1253,8 @@ extensions + tables) on first boot.
 | Compose file | Brings up | Use when |
 |--------------|-----------|----------|
 | `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default.** Both binaries co-located; server `/v1` on `:8740`, kb `:8741`. |
-| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack — scale/update/place server and kb independently. |
-| `compose.yaml` | `aimee-kb` + Postgres + embedder | The knowledge service alone — building block for a shared/scaled kb. |
+| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack: scale/update/place server and kb independently. |
+| `compose.yaml` | `aimee-kb` + Postgres + embedder | The knowledge service alone: building block for a shared/scaled kb. |
 | `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` with no shared knowledge. |
 
 **Bring up the recommended (combined) stack:**
@@ -1275,7 +1275,7 @@ non-root user; the kb uses Python sidecars (`scripts/embed-remote.py`,
 `llm-chat.py`, `curator-extract.py`, `learning-synthesize.py`) for embeddings,
 synthesis, and curation, with container defaults from `deploy/container/aimee.yaml`.
 
-**Container lifecycle** — the binaries run as long-lived container processes
+**Container lifecycle**: the binaries run as long-lived container processes
 (PID 1), supervised by Docker's restart policy, not systemd/launchd:
 
 ```bash
@@ -1349,14 +1349,14 @@ differently *by design*, and understanding which is which is the whole story:
 
 #### `aimee-server` is one-per-user
 
-`aimee-server` owns DB1 — local, same-user runtime state (sessions, working
-memory, conversation windows, checkpoints, jobs, secrets) — and authenticates
+`aimee-server` owns DB1, the local, same-user runtime state (sessions, working
+memory, conversation windows, checkpoints, jobs, secrets), and authenticates
 callers by `SO_PEERCRED` peer UID. Its trust model is "same Unix user = same
 principal." It is therefore **single-tenant and local by construction**: you do
 not shard it, replicate it, or place it behind a load balancer. Each developer
 (each OS login) runs exactly one `aimee-server`, normally as a systemd user unit
-or launchd agent. You scale a single user's server *vertically* — more in-flight
-delegates and parallel tool calls — with the thread-pool and concurrency knobs in
+or launchd agent. You scale a single user's server *vertically* (more in-flight
+delegates and parallel tool calls) with the thread-pool and concurrency knobs in
 [§27.4](#274-resource-tuning); that does not, and is not meant to, make it serve
 other users.
 
@@ -1371,9 +1371,9 @@ it horizontally scalable:
    over a shared database**.
 2. **It is reachable over the network.** KB serves its full `/v1` contract over
    HTTP on `:8741` (`AIMEE_KB_API_URL`, optional bearer token via
-   `AIMEE_KB_API_BEARER_TOKEN`) — the only transport since the Unix-socket RPC was
-   retired in #2747. Many `aimee-server` instances — many users, on many
-   machines — can point at one KB endpoint.
+   `AIMEE_KB_API_BEARER_TOKEN`), the only transport since the Unix-socket RPC was
+   retired in #2747. Many `aimee-server` instances (many users, on many
+   machines) can point at one KB endpoint.
 3. **Concurrent instances are safe with no external coordinator.** The background
    pipeline (ingest, curator, embedding, index-update) claims work directly off
    DB2 queues with `FOR UPDATE SKIP LOCKED`, so two workers never claim the same
@@ -1381,7 +1381,7 @@ it horizontally scalable:
 
 So the scale-out recipe is the standard stateless-web-tier one: **run several
 `aimee-kb` replicas behind a load balancer, all pointed at one Postgres.** Query
-traffic (search, recall, index reads — the hot path the servers hit) fans out
+traffic (search, recall, index reads, the hot path the servers hit) fans out
 across replicas; the workers on each replica drain the shared queues
 cooperatively. Point every server at the load-balanced KB with `AIMEE_KB_API_URL`
 (or the `kb` block in `aimee.yaml`).
@@ -1389,22 +1389,22 @@ cooperatively. Point every server at the load-balanced KB with `AIMEE_KB_API_URL
 #### The database is just standard Postgres
 
 DB2 is one ordinary Postgres database (`aimee_shared` by default) with the
-`pg_trgm` and `vector` (pgvector) extensions — there is no bespoke datastore. You
+`pg_trgm` and `vector` (pgvector) extensions; there is no bespoke datastore. You
 scale it with the normal Postgres playbook:
 
 - **Vertical sizing** of the Postgres instance (CPU/RAM/IOPS).
 - **Connection pooling** (e.g. PgBouncer) in front of Postgres; each KB instance's
-  own pool is bounded by `db2_pool_size` (1–32, default 8).
+  own pool is bounded by `db2_pool_size` (1-32, default 8).
 - **Read replicas** to fan out query load when one primary is saturated.
 
 Vector search rides inside the same Postgres and scales with it:
 
-- **pgvector HNSW is the default** — for memory vectors always, and for all
+- **pgvector HNSW is the default**: for memory vectors always, and for all
   small-to-medium corpora. Nothing extra to install; this is what a fresh
   `install.sh` gives you.
 - **pgvectorscale (StreamingDiskANN) is the opt-in scale-up** for large corpora.
   It is *additive*: built on top of pgvector, it reuses the same `vector` column
-  type and distance operators and only adds the `USING diskann` index — disk-backed
+  type and distance operators and only adds the `USING diskann` index, disk-backed
   with bounded build memory, for the large/RAM-constrained regime where HNSW's
   in-memory graph becomes the bottleneck. Select it per corpus table:
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ graph TB
 
 ### Memory that compounds, and a knowledge base that learns
 
-A 4-tier memory system tracks project context, infrastructure details, preferences, and past outcomes. Facts are deduplicated, contradictions are detected, and stale information decays automatically. Your AI starts every session already knowing what matters -- no re-discovery, no repeated questions.
+A 4-tier memory system tracks project context, infrastructure details, preferences, and past outcomes. Facts are deduplicated, contradictions are detected, and stale information decays automatically. Your AI starts every session already knowing what matters: no re-discovery, no repeated questions.
 
 That's the on-ramp. aimee doesn't just *store*, a curator pipeline **extracts, synthesizes, judges, and promotes** knowledge into a typed graph, and reflects on idle time to improve it. Point a team at a **shared `aimee-kb`** and it distills *everyone's* knowledge to *everyone*, across all domains, not just code. The longer you use it, the more it learns you. See **[How aimee learns](docs/KNOWLEDGE.md)**.
 
@@ -124,18 +124,18 @@ graph TB
 
 - **`aimee-server` is 1:1 with a user.** It owns local, same-user state (DB1 /
   SQLite) and authenticates by peer UID, so each developer runs exactly one server
-  on their own machine. It is single-tenant and local by design — you never shard
+  on their own machine. It is single-tenant and local by design; you never shard
   or replicate it.
 - **`aimee-kb` is the shared, horizontally-scalable tier.** All of its durable
   state lives in Postgres; a KB process is otherwise a stateless request server
   plus background workers. One KB deployment serves *many* `aimee-server`
-  instances — i.e. many users — and you scale it by running **multiple `aimee-kb`
+  instances (i.e. many users) and you scale it by running **multiple `aimee-kb`
   replicas behind a load balancer** on HTTP `:8741`. Even the ingest/curator
   workers coordinate purely through Postgres (`FOR UPDATE SKIP LOCKED`), so adding
   replicas needs no external coordinator.
 - **The database is just standard Postgres.** No bespoke datastore: knowledge rows
   and their vector embeddings live in one Postgres database (`aimee_shared`) with
-  the `pg_trgm` and `vector` (pgvector) extensions. Scale it like any Postgres —
+  the `pg_trgm` and `vector` (pgvector) extensions. Scale it like any Postgres:
   bigger instance, connection pooling, read replicas. For large vector corpora,
   add **`pgvectorscale`** (StreamingDiskANN): it sits on top of pgvector with
   identical data and queries, so switching is a reindex, not a migration. Small and
@@ -150,7 +150,7 @@ aimee is a few services plus a thin client. **`aimee-server`** (per-user runtime
 local DB1) and **`aimee-kb`** (the shared knowledge base, Postgres DB2 + vectors)
 are long-running services; the **`aimee` CLI is a thin client** that holds no
 database and talks to a server over `/v1`. The intended deployment is to run the
-**services in Docker** — one combined container, or two split containers — and
+**services in Docker** (one combined container, or two split containers) and
 install only the **thin client** on each developer machine, pointed at the server.
 
 > Prefer everything on one box from source (no Docker)? See
@@ -177,9 +177,9 @@ curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/stat
 ```
 
 **Combined vs. split.** The combined container (`compose.combined.yaml`) is the
-recommended default — one aimee container to run and update. Split the two
+recommended default: one aimee container to run and update. Split the two
 binaries into separate containers (`compose.server.yaml`) when you want to scale,
-update, or place `aimee-server` and `aimee-kb` independently — that matches the
+update, or place `aimee-server` and `aimee-kb` independently; that matches the
 horizontal-scaling model (many servers → one shared kb). Both publish the same
 ports and bearer. See [Run in Docker](#run-in-docker) for every topology, health
 probes, and the end-to-end smoke tests.
@@ -192,9 +192,9 @@ probes, and the end-to-end smoke tests.
 
 Each developer installs only the `aimee` CLI and points it at the server. Prebuilt
 thin-client binaries for **Linux, macOS, and Windows** are attached to every GitHub
-release — download one, put it on your `PATH`, and skip the build. To build it
+release; download one, put it on your `PATH`, and skip the build. To build it
 yourself, configure with `-DAIMEE_THIN_CLIENT=ON` (a C compiler is the only
-dependency — no Go, libpq, or zstd); see
+dependency, no Go, libpq, or zstd); see
 [Build just the thin client](#build-just-the-thin-client).
 
 Point the client at the server per-invocation, via the environment, or persist it:
@@ -217,16 +217,16 @@ aimee remote clear    # revert to a local Unix socket
 Precedence is `--server` flag > `AIMEE_SERVER_URL` env > persisted `remote.conf`.
 
 `https://` URLs are supported on Linux/macOS builds (OpenSSL), with certificate
-verification on by default — set `AIMEE_TLS_INSECURE=1` for self-signed/dev
+verification on by default; set `AIMEE_TLS_INSECURE=1` for self-signed/dev
 servers. The Windows thin client is built without TLS and refuses `https://`;
 terminate TLS at a reverse proxy and use its `http://` address there.
 
 **What a remote thin client can and can't do.** The remote transport drives the
-**data/RPC plane** — `memory`, `kb`, `rules`, `index`, `sessions`, `notes`, and
+**data/RPC plane**: `memory`, `kb`, `rules`, `index`, `sessions`, `notes`, and
 so on. Interactive **`aimee chat` / `aimee launch` need a *co-located* server**:
 they run the agent and its tools on the client host and chdir into a local
 worktree, so they refuse a remote endpoint rather than misbehave. **Writes are off
-by default over the network** (leaked-bearer protection) — a remote bearer is
+by default over the network** (leaked-bearer protection): a remote bearer is
 read/query only until the server opts in via `aimee.api.remote_writes`; see
 [Drive a remote server with the CLI](#drive-a-remote-server-with-the-cli).
 
@@ -240,8 +240,8 @@ full source install (below) does this for you as its last step.
 
 ### Single-box source install (no Docker)
 
-To build and run everything on one host without containers — the classic
-single-developer setup — install from source:
+To build and run everything on one host without containers (the classic
+single-developer setup), install from source:
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
@@ -262,7 +262,7 @@ Source-build prerequisites:
 | libcurl | `apt install libcurl4-openssl-dev` | `brew install curl` |
 | PAM (webchat) | `apt install libpam0g-dev` | built-in |
 
-**Local or remote knowledge base.** `install.sh` asks whether to run `aimee-kb` **locally** (the default — backed by the local Postgres) or point at an existing **remote** `aimee-kb` over HTTP. Choosing remote persists `kb_client_url` (and an optional bearer token) to `aimee.yaml`, skips the local sidecar and Postgres, and `aimee-server` reaches the remote kb on every launch path. For a remote-only host, also skip the database bootstrap: `AIMEE_KB_MODE=remote ./install-deps.sh`.
+**Local or remote knowledge base.** `install.sh` asks whether to run `aimee-kb` **locally** (the default, backed by the local Postgres) or point at an existing **remote** `aimee-kb` over HTTP. Choosing remote persists `kb_client_url` (and an optional bearer token) to `aimee.yaml`, skips the local sidecar and Postgres, and `aimee-server` reaches the remote kb on every launch path. For a remote-only host, also skip the database bootstrap: `AIMEE_KB_MODE=remote ./install-deps.sh`.
 
 ### Verify
 
@@ -282,7 +282,7 @@ as the cross-platform fallback.
 For packaging hosts that should ship only the `aimee` CLI (no `aimee-server`,
 `aimee-kb`, gateway, or webchat), configure with `-DAIMEE_THIN_CLIENT=ON`.
 That option restricts the build to the `aimee` target, so the box needs only
-a C compiler — no Go, libpq, or zstd. Combine with `-DAIMEE_LEAN=ON` to add
+a C compiler (no Go, libpq, or zstd). Combine with `-DAIMEE_LEAN=ON` to add
 the size-optimized strip. Add OpenSSL on Linux/macOS to keep `https://`
 support (the default for the thin client); skip it on Windows and terminate
 TLS at a reverse proxy.
@@ -295,7 +295,7 @@ cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
 cmake --build build --target aimee
 ```
 
-**macOS (Homebrew OpenSSL is keg-only — point CMake at it):**
+**macOS (Homebrew OpenSSL is keg-only; point CMake at it):**
 
 ```bash
 cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
@@ -304,7 +304,7 @@ cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
 cmake --build build --target aimee
 ```
 
-**Windows (MinGW, no TLS — use a TLS-terminating proxy for `https://`):**
+**Windows (MinGW, no TLS; use a TLS-terminating proxy for `https://`):**
 
 ```bash
 cmake -B build -G "MinGW Makefiles" \
@@ -349,9 +349,9 @@ boot.
 
 | File | Brings up | Use when |
 |------|-----------|----------|
-| `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default** — both binaries co-located; server `/v1` on `:8740`, kb `:8741` |
-| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack — scale/update/place server and kb independently; server `:8740`, kb `:8741` |
-| `compose.yaml` | `aimee-kb` + Postgres (pgvector) + embedder | The knowledge service (DB2 + vectors) on its own — building block for a shared/scaled kb |
+| `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default**: both binaries co-located; server `/v1` on `:8740`, kb `:8741` |
+| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack: scale/update/place server and kb independently; server `:8740`, kb `:8741` |
+| `compose.yaml` | `aimee-kb` + Postgres (pgvector) + embedder | The knowledge service (DB2 + vectors) on its own: building block for a shared/scaled kb |
 | `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` endpoints with no shared knowledge |
 
 ### Combined server + kb (recommended)
@@ -379,7 +379,7 @@ curl 'http://localhost:8741/v1/health?status=1'   # in-container kb: DB + pgvect
 docker compose -f compose.server.yaml up --build -d
 ```
 
-`aimee-server` and `aimee-kb` run as separate containers — the same topology as
+`aimee-server` and `aimee-kb` run as separate containers, the same topology as
 the [horizontal-scaling model](#how-aimee-scales) (many servers → one shared kb).
 The server fronts `/v1` on `:8740` (bearer `aimee-local-dev`) and reaches the kb
 over HTTP (`AIMEE_KB_API_URL=http://aimee-kb:8741`); the kb owns Postgres + the
@@ -403,7 +403,7 @@ docker compose -f compose.yaml up --build -d
 ```
 
 Brings up just `aimee-kb` + Postgres + embedder, serving the `/v1` HTTP API on
-`:8741` — the building block behind a shared or horizontally-scaled kb that many
+`:8741`: the building block behind a shared or horizontally-scaled kb that many
 servers point at:
 
 ```bash
@@ -413,13 +413,13 @@ curl http://localhost:8741/v1/capabilities
 ```
 
 The LLM-backed synthesis/curator passes are wired but disabled until you point an
-OpenAI-compatible endpoint at them — bring up a local llama.cpp server with
+OpenAI-compatible endpoint at them: bring up a local llama.cpp server with
 `docker compose -f compose.yaml --profile llm up` (the same `--profile llm` flag
 works with the combined and split stacks).
 
 ### Managing the containers
 
-The compose stacks are ordinary Docker Compose projects — the binaries run as
+The compose stacks are ordinary Docker Compose projects: the binaries run as
 **long-lived container processes** (PID 1 inside each container), supervised by
 Docker's restart policy, not by systemd/launchd. Day-to-day lifecycle:
 
@@ -440,7 +440,7 @@ thing that erases data:
 
 | Volume | Holds |
 |--------|-------|
-| `*-postgres` | DB2 (`aimee_shared`) — all shared knowledge + vectors |
+| `*-postgres` | DB2 (`aimee_shared`): all shared knowledge + vectors |
 | `*-home` (`/var/lib/aimee`) | server/kb runtime state (DB1 SQLite, config) |
 | `*-workspaces` (`/var/lib/aimee-workspaces`) | mirror-tier bare mirrors + reconstructed worktrees |
 | `*-embedder-models` / `*-llm-models` | cached model weights |
@@ -454,8 +454,8 @@ mounting your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml` (see
 ### Verify a stack end to end
 
 Each stack ships a smoke test that brings it up, waits for health, exercises the
-live surface (DB + vector readiness, search, embeddings, and — for the server
-stacks — the server→kb path), then tears down. `e2e-matrix.sh` runs several at
+live surface (DB + vector readiness, search, embeddings, and, for the server
+stacks, the server→kb path), then tears down. `e2e-matrix.sh` runs several at
 once and prints one pass/fail table (run it on a Docker host, e.g. inside CT 101):
 
 ```bash
@@ -475,7 +475,7 @@ cross-platform thin-client smoke) is documented in
 The [`--server` / `AIMEE_SERVER_URL`](#2-install-the-thin-client) path above is the
 simplest way to reach a remote server. The same connection is also expressible at
 the transport layer (the form `aimee workspace serve` and persisted `aimee.yaml`
-config use) — point it at a container's published `:8740` by selecting the HTTP
+config use): point it at a container's published `:8740` by selecting the HTTP
 transport and a remote endpoint:
 
 ```bash
@@ -493,8 +493,8 @@ variables override them. The TCP host may be a DNS name or an IPv4/IPv6 literal
 
 This drives the **data/RPC plane** (`memory`, `kb`, `rules`, `index`,
 `sessions`, `notes`, …). Interactive **`aimee chat` / `aimee launch` need a
-co-located server** — they run the agent and its tools on the client host and
-chdir into a local worktree — so they refuse a remote `tcp:` endpoint with a
+co-located server**: they run the agent and its tools on the client host and
+chdir into a local worktree, so they refuse a remote `tcp:` endpoint with a
 clear message rather than misbehaving.
 
 **Remote writes are off by default** (leaked-bearer protection): over the TCP
@@ -503,9 +503,9 @@ server opts in per `aimee.api.remote_writes`:
 
 | `aimee.api.remote_writes` | Over the TCP listener |
 |---------------------------|-----------------------|
-| `off` (default) | **reads only** — any route needing a non-read capability is local-UDS-only (the detached-workspace plane — `workspace serve`/`add`/`remove` — is the deliberate exception, still bearer-gated) |
+| `off` (default) | **reads only**: any route needing a non-read capability is local-UDS-only (the detached-workspace plane, `workspace serve`/`add`/`remove`, is the deliberate exception, still bearer-gated) |
 | `data` | + data-plane writes (`memory store`, `work …`, `rules delete`, `skill …`) |
-| `full` | + exec/control (`delegate`, `cron`, `agent`, `provider`, `api`, …) and the `/v1/rpc` delegate/tool bridge (`CAPS_ALL`). **Trusted networks only** — a leaked bearer then permits remote code execution. |
+| `full` | + exec/control (`delegate`, `cron`, `agent`, `provider`, `api`, …) and the `/v1/rpc` delegate/tool bridge (`CAPS_ALL`). **Trusted networks only**: a leaked bearer then permits remote code execution. |
 
 The capability gate is fail-closed: a route is reachable over TCP only if its
 required capability is satisfied *and* the tier permits its class. A scoped

--- a/benchmarks/PROVISIONING.md
+++ b/benchmarks/PROVISIONING.md
@@ -2,8 +2,8 @@
 
 This is the operational companion to the (implemented) unified benchmark suite.
 The harness, target adapters, pinned-judge plumbing, and per-dataset loaders all
-ship in-repo and are unit-tested. What lives **outside** the repo — the real
-datasets, the judge model, and the SWE-bench / TerminalBench sandboxes — is
+ship in-repo and are unit-tested. What lives **outside** the repo (the real
+datasets, the judge model, and the SWE-bench / TerminalBench sandboxes) is
 provisioned per host using this runbook.
 
 See the parent (implemented) proposal
@@ -67,7 +67,7 @@ any `grader = "llm"` dataset route through the configured judge:
   execute-role agent (`~/.config/aimee/agents.json`).
 - `profile = "open70b"` uses a pinned open-weights GGUF; record its digest in
   `[judge].hash`.
-- `profile = "small"` is CI-smoke only — results are **not** canonical.
+- `profile = "small"` is CI-smoke only; results are **not** canonical.
 
 `majority = 3` → three judge votes per question; `check_determinism.py` asserts
 the verdicts are stable across reruns at temperature 0.
@@ -77,22 +77,22 @@ the verdicts are stable across reruns at temperature 0.
 The `frontier` profile routes both answering and judging through
 `aimee delegate execute`, i.e. the configured execute-role **delegate**
 (MiniMax / MiMo / Mistral). No GPU or pinned local weights are required to score
-the LLM-judge track — the delegate *is* the judge. The harness queues each turn
+the LLM-judge track; the delegate *is* the judge. The harness queues each turn
 as a background delegate job and polls `jobs status` (foreground delegate is
 unsupported over the default `/v1` transport), so a running `aimee-server` with
 the execute agent configured is the only prerequisite.
 
 Knobs (all optional):
 
-- `AIMEE_BENCH_PERSONA` — delegate persona (default `engineer`; required by the server).
-- `AIMEE_BENCH_JUDGE_MAX_TOKENS` — judge token budget (default `64`). Raise to
+- `AIMEE_BENCH_PERSONA`: delegate persona (default `engineer`; required by the server).
+- `AIMEE_BENCH_JUDGE_MAX_TOKENS`: judge token budget (default `64`). Raise to
   ~2048 for *reasoning* delegates, which spend tokens on hidden reasoning before
   emitting the JSON verdict and otherwise return "no content".
-- `AIMEE_BENCH_DELEGATE_TIMEOUT` / `AIMEE_BENCH_DELEGATE_POLL` — per-job timeout
+- `AIMEE_BENCH_DELEGATE_TIMEOUT` / `AIMEE_BENCH_DELEGATE_POLL`: per-job timeout
   and poll interval (seconds).
 
 The adapter LLM targets (`model_only`, `small_agent`, `rag_chromadb`) score the
-LLM-judge track with **no** memory store/search — so no vector DB is needed:
+LLM-judge track with **no** memory store/search, so no vector DB is needed:
 
 ```bash
 benchmarks/suite/run-llm.sh --target model_only --bench longmemeval_s
@@ -137,11 +137,11 @@ with no Docker, a GPU box, or CI.
 - Memory benches skip where the dataset isn't provisioned.
 - The `aimee` target writes to a vector DB, so it is **skipped unless**
   `AIMEE_BENCH_ALLOW_AIMEE=1` (point `AIMEE_BENCH_SOURCE_HOME` at a scratch home
-  on an isolated DB first) — this keeps benchmark runs out of operational memory.
+  on an isolated DB first); this keeps benchmark runs out of operational memory.
 - Default non-aimee baseline is `bm25` (dependency-free); `rag_chromadb` needs
   the `chromadb` package.
 - `--max-samples` / `--max-questions` bound the work (LoCoMo carries ~100+
-  questions per conversation — cap them for a quick run).
+  questions per conversation, so cap them for a quick run).
 
 ## 6. Reference numbers & determinism
 
@@ -156,5 +156,5 @@ with no Docker, a GPU box, or CI.
 
 The GPU host (pve) carries the corpora and the GPU for real-model runs; the
 SWE-bench Docker harness runs on the Docker host. These are shared-infra,
-operator-driven runs — they are not executed from CI. CI runs only the
+operator-driven runs; they are not executed from CI. CI runs only the
 deterministic gates (provisioning coverage) and the fake-agent smoke slice.

--- a/benchmarks/code-vector-graph/results/README.md
+++ b/benchmarks/code-vector-graph/results/README.md
@@ -26,15 +26,15 @@ baseline p50 156.9 / p95 221.3; full_fusion p50 236.7 / p95 298.5 →
 
 ## AC status from this pass
 
-- **AC#1 (fusion-off latency baseline):** measured — see
+- **AC#1 (fusion-off latency baseline):** measured; see
   `docs/proposals/benchmarks/effectiveness-weighted-code-vector-graph-baseline.json`.
-  (`utility_score_distribution` in that file is still pending — needs a direct
+  (`utility_score_distribution` in that file is still pending; it needs a direct
   DB2 query, no RPC surface yet.)
-- **AC#4 (p95 overhead ≤ 25%):** **FAILS** — full_fusion is ~35% over baseline
+- **AC#4 (p95 overhead ≤ 25%):** **FAILS**; full_fusion is ~35% over baseline
   p95.
 - **AC#5 (per-arm matrix):** latency captured here for all 9 arms.
 
-## Caveats — do NOT read recall from these files
+## Caveats: do NOT read recall from these files
 
 - **`recall_*`, `mrr`, `ndcg_*` are 0** because the corpus is unlabelled
   (`expected_ids: []` for all 108 queries). These artifacts are **latency-only**

--- a/benchmarks/curator/OPERATIONAL_VERIFY.md
+++ b/benchmarks/curator/OPERATIONAL_VERIFY.md
@@ -10,7 +10,7 @@ The two LLM passes use the **deterministic stub sidecars** in
 Point `judge_command` / `synthesize_command` at a real model to validate
 against one instead.
 
-This is a runbook, not a CI gate — it needs a real pgvector DB2, which CI does
+This is a runbook, not a CI gate; it needs a real pgvector DB2, which CI does
 not provide. Run it on a scratch DB2 (e.g. the CT 101 scratch-Postgres recipe);
 it never touches a production aimee server.
 
@@ -22,11 +22,11 @@ it never touches a production aimee server.
 
 ## 1. Configure (`aimee.yaml`)
 
-Use **block style** — aimee's YAML parser is indentation-based and does not
+Use **block style**; aimee's YAML parser is indentation-based and does not
 parse flow maps (`{ enabled: true }`), so a flow-style gate reads as *off*:
 
 ```yaml
-embedding_command: builtin          # MiniLM builtin embedder — no GPU needed
+embedding_command: builtin          # MiniLM builtin embedder, no GPU needed
 kb:
   curator:
     resolve_entities:
@@ -61,7 +61,7 @@ VALUES ('proj-a', '/tmp/proj-a', 'ws-1', '');
 
 -- AC1: two entity mentions of the same real-world thing at different scopes.
 -- resolve_entities embeds both; the second must dedup (>=0.85 merge, or the
--- 0.70-0.85 judge band via judge_stub) onto the first — NOT a second vector.
+-- 0.70-0.85 judge band via judge_stub) onto the first, NOT a second vector.
 INSERT INTO artifacts (id, kind, state, scope_kind, scope_id, payload_json)
 VALUES
  ('ent-acme-ws',  'entity', 'proposed', 'workspace', 'ws-1',

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -81,8 +81,8 @@ graph TB
 | `aimee-gateway` | C11 | optional ambient-presence delivery (Telegram/ntfy/webhook, STT/TTS) | minimal | optional |
 
 The two **thin clients** (`aimee`, `aimee-webchat`) never touch a database.
-They reach `aimee-server` over its `/v1` HTTP surface — the local `aimee-http.sock`
-Unix socket by default, or a remote `host:port` — and forward typed requests.
+They reach `aimee-server` over its `/v1` HTTP surface (the local `aimee-http.sock`
+Unix socket by default, or a remote `host:port`) and forward typed requests.
 This is what keeps the CLI startup under 10 ms and why hook checks add ~1 ms to a
 tool call: the expensive state already lives in a warm, long-running server.
 
@@ -255,7 +255,7 @@ Key properties:
   body is a sequence of newline-delimited aimee events terminated by a final
   status object. (The legacy newline-delimited JSON-RPC socket was removed.)
 - **Authentication.** The local UDS is filesystem-permission gated and fully
-  trusted — it reaches the entire dispatch surface, with no token. The optional
+  trusted: it reaches the entire dispatch surface, with no token. The optional
   TCP listener requires a configured bearer token and is capability-scoped.
   Authorization is expressed as **16 capability flags** (chat, delegate,
   tool-execute, tool-bash, tool-write, memory-read/write, rules-read/admin,
@@ -386,7 +386,7 @@ sequenceDiagram
     participant Pool as Compute pool
     participant Prov as Provider
     PA->>SRV: delegate <role> <prompt>
-    SRV->>SRV: route — cheapest enabled agent for role
+    SRV->>SRV: route to cheapest enabled agent for role
     SRV->>Pool: enqueue (acquire compute budget)
     Pool->>Prov: HTTPS (OpenAI / ChatGPT / Anthropic format)
     Prov-->>Pool: completion (retry/fallback on failure)

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,23 +1,23 @@
 # Benchmarks
 
-## Unified suite — provisioning & rollout validation
+## Unified suite: provisioning & rollout validation
 
 The unified benchmark suite (memory / coding / reasoning) ships its harness,
 target adapters, pinned judge, and per-dataset loaders in-repo. Provisioning the
 real datasets, judge model, and sandboxes, and running each track end-to-end, is
-the **rollout-validation** half — see **[benchmarks/PROVISIONING.md](../benchmarks/PROVISIONING.md)**.
+the **rollout-validation** half; see **[benchmarks/PROVISIONING.md](../benchmarks/PROVISIONING.md)**.
 
 Key entry points:
 
-- `benchmarks/provisioning.toml` — documented, hash-pinnable provisioning path
+- `benchmarks/provisioning.toml`: documented, hash-pinnable provisioning path
   for every catalog dataset.
-- `benchmarks/check_provisioning.py` — coverage + hash-integrity gate
+- `benchmarks/check_provisioning.py`: coverage + hash-integrity gate
   (`--require-coverage`, `--verify-hashes`); wired into the `bench-smoke.yml` CI.
-- `scripts/provision-benchmarks.sh` — manifest-driven fetcher (auto-fetches what
+- `scripts/provision-benchmarks.sh`: manifest-driven fetcher (auto-fetches what
   it can, prints manual steps and the SHA-256 to pin).
-- `benchmarks/compare_targets.py` — publishes a cross-target comparison report
+- `benchmarks/compare_targets.py`: publishes a cross-target comparison report
   under `benchmarks/results/`.
-- `benchmarks/suite/run-validation.sh` — one-command operator runbook
+- `benchmarks/suite/run-validation.sh`: one-command operator runbook
   (preflight → tracks → determinism → comparison → smoke budget).
 
 ## Memory Harness v2

--- a/docs/PUBLIC_API.md
+++ b/docs/PUBLIC_API.md
@@ -1,4 +1,4 @@
-# aimee-kb Public API — Stability Contract
+# aimee-kb Public API: Stability Contract
 
 The **aimee-kb `/v1` HTTP API** is the sole, public, versioned interface to the
 aimee knowledge base. aimee-server is its primary client; third parties consume
@@ -11,7 +11,7 @@ the same endpoints with no access to aimee source.
 - **Human reference:** [`docs/gen/api-v1.md`](gen/api-v1.md), generated from the
   spec (`make docs-gen`).
 - **Client SDKs:** generated under [`api/sdks/`](../api/sdks/) for eight
-  languages — see [SDKs](#sdks).
+  languages; see [SDKs](#sdks).
 
 This document is the **stability contract**. It applies from the first tagged
 release; pre-release `/v1` may still iterate freely.
@@ -56,7 +56,7 @@ frames are unmasked text JSON.
 | Endpoint | Stream |
 |----------|--------|
 | `GET /v1/jobs/{id}/stream` | live job-status frames until the job is terminal (done/failed), then a close frame |
-| `GET /v1/events` | a `{"type":"subscribed"}` greeting, then `{"type":"invalidation","kind":...,"scope_kind":...,"scope_id":...,"ts":...}` events whenever cached retrieval state changes — a **release** is promoted/rolled back, or a **doc** is ingested |
+| `GET /v1/events` | a `{"type":"subscribed"}` greeting, then `{"type":"invalidation","kind":...,"scope_kind":...,"scope_id":...,"ts":...}` events whenever cached retrieval state changes (a **release** is promoted/rolled back, or a **doc** is ingested) |
 
 The invalidation stream lets aimee-server drop cached search/entity/index
 results on signal rather than waiting for TTL expiry (the cache itself is a
@@ -115,7 +115,7 @@ The pure decision logic lives in `src/kb/kb_scope.c` and is unit-tested in
   `{"error": "<message>"}`. The status code is the stable signal; the `message`
   text may change. The per-request correlation id is returned in the
   `X-Request-ID` response header (see below), not the body.
-- **Pagination:** opaque cursors only — responses carry `next_cursor`; pass it
+- **Pagination:** opaque cursors only; responses carry `next_cursor`, pass it
   back as `?cursor=<value>`. There are **no** numeric offsets.
 - **Observability:** every response echoes `X-Request-ID` (client-supplied or
   server-generated as `<pid>-<counter>`), and the service logs it at INFO with
@@ -157,18 +157,18 @@ spec is a **byte-for-byte no-op**, so a stale SDK is caught in review.
 
 Two gates keep SDKs honest (both wired into `make lint`):
 
-- `scripts/check-sdk-parity.py` — every `operationId` in the spec is covered by
+- `scripts/check-sdk-parity.py`: every `operationId` in the spec is covered by
   every committed SDK (`make sdk-parity-check`).
-- `scripts/check-api-conformance.py` — every spec path is routed by the
+- `scripts/check-api-conformance.py`: every spec path is routed by the
   aimee-kb server (`make api-conformance-check`).
 
 Running each SDK against a live aimee-kb is automated by `scripts/sdk-smoke.sh`
 (`make v1-sdk-smoke`): it builds a minimal consumer per language that calls the
-service through the generated client and reports PASS/SKIP/FAIL — skipping
+service through the generated client and reports PASS/SKIP/FAIL, skipping
 languages whose toolchain/deps aren't present and self-skipping when no kb is
 reachable. Run it on any host with the toolchains installed (the per-language
 list is in the script header) and point it at a deployed kb with `KB_BASE_URL` /
-`KB_BEARER_TOKEN` — no CI service required.
+`KB_BEARER_TOKEN`; no CI service required.
 
 Validated live on a Debian-12 host with all toolchains: **go, typescript,
 python, java, c, cpp, csharp PASS**; rust requires a newer cargo than Debian 12
@@ -181,8 +181,8 @@ unauthenticated kb. See also [Integration testing](#integration-testing).
 ## Integration testing
 
 A language-agnostic smoke test that uses only `curl` + `jq` exercises the
-core client journey — ingest → search → fetch artifact → subscribe to the
-invalidation/job stream — against a running service:
+core client journey (ingest → search → fetch artifact → subscribe to the
+invalidation/job stream) against a running service:
 
 ```sh
 KB_BASE_URL=http://127.0.0.1:8090/v1 \
@@ -208,7 +208,7 @@ transport differs.
 
 Switching aimee-server from local to remote kb is a **config change, not a code
 change**: set `kb_client_url` to the remote kb's `https://` **origin**
-(`scheme://host:port`, without a `/v1` suffix — the client appends the versioned
+(`scheme://host:port`, without a `/v1` suffix; the client appends the versioned
 path) and `kb_client_bearer_token` to a token the remote kb accepts.
 aimee-server exports these into
 `AIMEE_KB_API_URL` / `AIMEE_KB_API_BEARER_TOKEN`, which the kb_client transport
@@ -219,9 +219,9 @@ and [`config/aimee-kb.yaml.example`](../config/aimee-kb.yaml.example).
 
 ## References
 
-- [`api/openapi-v1.yaml`](../api/openapi-v1.yaml) — the contract.
-- [`docs/gen/api-v1.md`](gen/api-v1.md) — generated reference.
+- [`api/openapi-v1.yaml`](../api/openapi-v1.yaml): the contract.
+- [`docs/gen/api-v1.md`](gen/api-v1.md): generated reference.
 - [`docs/proposa../done/aimee-kb-service-and-public-api.md`](proposa../done/aimee-kb-service-and-public-api.md)
-  — the owning proposal.
+  is the owning proposal.
 - [`docs/proposals/done/memory-public-contract.md`](proposals/done/memory-public-contract.md)
-  — the caller-facing contract reused across CLI / MCP / `/v1`.
+  is the caller-facing contract reused across CLI / MCP / `/v1`.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -119,7 +119,7 @@ The primary attack surfaces are:
 
 7. aimee-server `/v1` HTTP listener (optional, off by default)
    - A loopback-only TCP endpoint (`http://127.0.0.1:<port>/v1`) turned on with `aimee api enable`; it exposes the OpenAI-compatible surface to local editors
-   - Bearer-authenticated, per-bearer rate-limited, and gated by token scope — a scoped token is denied with `403` when it requests an action outside its grant
+   - Bearer-authenticated, per-bearer rate-limited, and gated by token scope; a scoped token is denied with `403` when it requests an action outside its grant
    - Main concern: bearer theft by a same-host process, overbroad token scope, or exposing the port past loopback through a misconfigured proxy
 
 8. aimee-kb (DB2) transport

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -7,9 +7,9 @@ current version and prints it once after an upgrade.
 
 ## v0.2.0
 
-- **Docker-first deployment**: run `aimee-server` + `aimee-kb` as containers — one
+- **Docker-first deployment**: run `aimee-server` + `aimee-kb` as containers, either one
   combined image (`compose.combined.yaml`, recommended) or split
-  (`compose.server.yaml`) — and install only the thin client on each developer
+  (`compose.server.yaml`), and install only the thin client on each developer
   machine. See the README "Run in Docker" and Manual §27.1.
 - **Cross-platform thin client**: the `aimee` CLI now drives a remote server over
   HTTP from Linux, macOS, and Windows. Point it with `--server` /

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -47,7 +47,7 @@ The repositories to clone. Each entry needs a `url`; `path` is an optional clone
 
 ### `dependencies`
 
-Install commands, grouped by language for readability. The grouping key (`python`, `node`, `rust`, ...) is for your eyes only — aimee reads the package-manager keys underneath it and builds one command per manager:
+Install commands, grouped by language for readability. The grouping key (`python`, `node`, `rust`, ...) is for your eyes only; aimee reads the package-manager keys underneath it and builds one command per manager:
 
 | Key | Command |
 |-----|---------|
@@ -62,14 +62,14 @@ Install commands, grouped by language for readability. The grouping key (`python
 
 ### `secrets`
 
-Credentials the workspace needs but that aimee will not create for you — API tokens, deploy keys, and the like. Each entry has a `name` and an optional `description`. `aimee setup` prints them as a checklist so you know what to put in place before the build will work. It does not store or fetch them.
+Credentials the workspace needs but that aimee will not create for you: API tokens, deploy keys, and the like. Each entry has a `name` and an optional `description`. `aimee setup` prints them as a checklist so you know what to put in place before the build will work. It does not store or fetch them.
 
 ### `quickstart`
 
 Two booleans, both on by default:
 
-- `index` — index the discovered projects into the code index.
-- `generate_rules` — detect the project's stacks and write a starter `.aimee-rules`.
+- `index`: index the discovered projects into the code index.
+- `generate_rules`: detect the project's stacks and write a starter `.aimee-rules`.
 
 ## Commands
 

--- a/docs/observability/virtual-context-alerts.md
+++ b/docs/observability/virtual-context-alerts.md
@@ -21,14 +21,14 @@ per-session `event_count` / `chain_count` / `pending_events` fields.
 | `session_context_segments_total` | gauge | Tool-chains created for the session | monotonic; tracks active tool-heavy sessions |
 | `session_tool_chains_stubbed_total` | gauge | Chains collapsed into a deterministic stub | equals `segments_total` (every chain is stubbed) |
 | `session_context_bytes_saved` | gauge | `raw_bytes_total - stub_bytes_total` | > 0 and growing during long sessions |
-| `compression_ratio` | gauge | `raw_bytes_total / stub_bytes_total` | ≥ 1.7 (gate floor is 40% reduction ≈ 1.7x); typically 25–45x |
+| `compression_ratio` | gauge | `raw_bytes_total / stub_bytes_total` | ≥ 1.7 (gate floor is 40% reduction ≈ 1.7x); typically 25-45x |
 | `session_context_expand_total` | counter (labels: `result={ok,error}`) | `session_context_expand` calls recovering raw turns | error ratio < 1% over 10m |
 | `session_context_assembly_ms` | histogram | Wall time to assemble a stubbed working set | p95 < 50ms, p99 < 150ms |
 | `pending_events` | gauge | Tool events not yet flushed into a chain | drains toward 0; auto-flush at 10 |
 
 ## Alert Rules
 
-### 1. RebuildBacklog — auto-flush falling behind
+### 1. RebuildBacklog: auto-flush falling behind
 
 Fires when pending (un-stubbed) tool events accumulate faster than they are
 flushed into chains, i.e. the assembler is not keeping up with ingestion.
@@ -54,7 +54,7 @@ means the flusher is wedged or starved. 10 minutes survives a normal burst
 grows unbounded. The auto-flush threshold is 10 pending events
 (`AUTO_FLUSH_THRESHOLD`), so a steady-state queue of 200 is well above normal.
 
-### 2. ExpandFailure — raw recovery is failing
+### 2. ExpandFailure: raw recovery is failing
 
 Fires when lazy expansion of a stub back into raw turns returns `ok=false`
 at an elevated rate, meaning the recovery path itself is broken.
@@ -84,6 +84,6 @@ The feature is gated by `session.virtual_context.enabled` in the active
 `aimee.yaml` (under the aimee home dir / `AIMEE_HOME`). Set it to `false` and
 restart the server; every session reverts to raw turns on the next request.
 The flag is read at the chain/assembly boundary, so already-recorded events
-remain queryable and **raw turns stay the source of truth — no data loss**.
+remain queryable and **raw turns stay the source of truth, with no data loss**.
 The only cost is the temporary loss of token savings while a regression is
 investigated.

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -98,7 +98,7 @@ toolset); aimee delegates are the only sub-agent mechanism.
 
 ## Assigning a persona to a delegate (required)
 
-Every delegate runs **as a persona** — it is **required**, not optional. The
+Every delegate runs **as a persona**; it is **required**, not optional. The
 persona sets the delegate's identity and principles; for a non-engineer
 built-in or a custom persona, its identity prose (the "You are …" body) is
 layered onto the role template, so e.g. a `review` delegate run as `security`
@@ -114,7 +114,7 @@ engineer framing.
 The persona name resolves from the built-ins or a user-level persona file (the
 same set as the rest of the persona surface). The delegate's *role* still
 governs tool access and write capability; the *persona* governs its identity and
-principles — they compose.
+principles, and they compose.
 
 ## V1 HTTP API
 

--- a/docs/v1-op-parity-buildout.md
+++ b/docs/v1-op-parity-buildout.md
@@ -1,4 +1,4 @@
-# `/v1` op-parity buildout — route→method map and wave plan
+# `/v1` op-parity buildout: route→method map and wave plan
 
 > Working tracker for **P1 / WP1.x / WP1.fin** of the
 > [aimee `/v1` hub-migration plan](proposals/accepted/aimee-v1-hub-migration-plan.md).
@@ -7,7 +7,7 @@
 > already makes every method *reachable*; this buildout gives each one a
 > dedicated, self-documenting, OpenAPI-listed route.
 
-## Mechanism (already landed — WP0.2, #2531)
+## Mechanism (already landed: WP0.2, #2531)
 
 The `/v1` surface is a declarative table in
 `src/server/server_http_routes.inc`. Adding a first-class route is:
@@ -25,7 +25,7 @@ The `/v1` surface is a declarative table in
 ### When a row is **not** enough
 
 - **Positional `args`-array methods** (e.g. `workspace.*`) need a small bespoke
-  adapter — see `ws_dispatch_args` in the registry. Most CLI methods marshal a
+  adapter; see `ws_dispatch_args` in the registry. Most CLI methods marshal a
   JSON **object** (named fields / `marshal_no_args`), so they take the trivial
   `rh_dispatch_op` row.
 - **Streaming or foreground-blocking methods** must **not** use
@@ -41,7 +41,7 @@ The `/v1` surface is a declarative table in
   so any read that needs params is **POST** with a JSON body.
 - **POST** for all mutations and all param-bearing calls.
 - One route per RPC method. Existing dashboard read-views (`GET /v1/agents`,
-  `GET /v1/models`, `GET /v1/kb/status` — backed by `route_json_provider`) are a
+  `GET /v1/models`, `GET /v1/kb/status`, backed by `route_json_provider`) are a
   *different* curated surface and coexist with the per-method routes below.
 
 ## Deliberate exclusions (NOT given a first-class route)
@@ -58,14 +58,14 @@ The `/v1` surface is a declarative table in
 > duration. Sub-second and bounded-network methods (e.g. `agent.probe`,
 > `provider.test`) are fine. **Long-running / LLM methods** (`kb.build`,
 > `kb.ingest`, `kb.update`, `graph.sync_code`, `index.scan`, `memory.benchmark`,
-> `curator.synthesize`, `rules.generate`, `eval.run`) are *not* inline-dispatched
-> — they are routed **async** via `rh_dispatch_op_async`: the POST returns a
+> `curator.synthesize`, `rules.generate`, `eval.run`) are *not* inline-dispatched;
+> they are routed **async** via `rh_dispatch_op_async`: the POST returns a
 > queued run handle and a detached worker drives the loopback RPC to completion;
 > poll status/result at `GET /v1/runs/{id}`. So they keep the listener free
 > while still being first-class `/v1` routes.
 
 `server.health`/`server.info` and `model.list` overlap the existing
-`/v1/health`, `/v1/version`, `/v1/models` read-views — the owning wave maps them
+`/v1/health`, `/v1/version`, `/v1/models` read-views; the owning wave maps them
 to the existing route (no duplicate) and notes it.
 
 ## Family → wave map
@@ -87,12 +87,12 @@ same files collide.
 | **5** | `kb.*`, `curator.*`, `graph.*`, `memory.benchmark`, `index.scan`, `trajectory.batch` | ~12 |
 | **6** | `work.*`, `wm.*`, `skill.*`, `session.*`, `toolset.resolve`, `rules.generate`, `blast_radius.preview`, `mcp.*`, `workspace.context`, `worktree.gc`, `aux.test`, `eval.*`, `trigger.*`, `init.run`, `launch.run` | ~40 |
 
-(Method shapes — object vs positional-args vs streaming — are confirmed by the
+(Method shapes, object vs positional-args vs streaming, are confirmed by the
 owning delegate against the preloaded handler; the default is the trivial
 `rh_dispatch_op` row.)
 
-## WP1.fin — coverage gate
+## WP1.fin: coverage gate
 
 After the waves, add a conformance gate that walks `server_dispatch_table[]` and
-asserts every method has a `/v1` route **or** is on the exclusion list above —
+asserts every method has a `/v1` route **or** is on the exclusion list above,
 so parity can never silently regress. Wire into `make lint`.

--- a/docs/validation/virtual-context-rollout-validation.md
+++ b/docs/validation/virtual-context-rollout-validation.md
@@ -1,4 +1,4 @@
-# Virtual-Context Assembly — Rollout Validation Report
+# Virtual-Context Assembly: Rollout Validation Report
 
 Closes the operational acceptance criteria of
 [virtual-context-assembly-rollout-validation.md](../proposals/done/virtual-context-assembly-rollout-validation.md).
@@ -11,19 +11,19 @@ and the benchmark gate; this validates them for real and flips the default on.
 
 | Acceptance criterion | Status | Evidence |
 |---|---|---|
-| Gate passes on a real (non-synthetic) tool-heavy transcript | ✅ | §1 — `fixture_real_session.json` |
-| Manual inspection: compacted signal, not raw duplicate traffic; expand recovers raw | ✅ | §2 — `make virtual-context-inspect` |
+| Gate passes on a real (non-synthetic) tool-heavy transcript | ✅ | §1, `fixture_real_session.json` |
+| Manual inspection: compacted signal, not raw duplicate traffic; expand recovers raw | ✅ | §2, `make virtual-context-inspect` |
 | Operational metrics collected, no late-turn regression beyond 0.01 | ✅ | §1 (accuracy) + §3 (metrics surface) |
 | Default flipped to on with documented rollback | ✅ | §4 |
 | Dashboard + rebuild-backlog / expansion-failure alert thresholds | ✅ | §5 |
 
-## §1 — Real-session benchmark validation (AC#1)
+## §1: Real-session benchmark validation (AC#1)
 
 `run_eval.py` now takes a repeatable `--fixture` flag and the
 `virtual-context-eval-check` make target runs **two** fixtures: the original
 synthetic one and a new non-synthetic `fixture_real_session.json` captured from
 a real aimee coding session (each chain is a real Read/Bash/Edit chain over real
-repository files; every oracle answer is a symbol that exists in this repo —
+repository files; every oracle answer is a symbol that exists in this repo:
 `run_eval.py`, `virtual_context_enabled`, `build_stub`, `db1_conv_list_chains`).
 
 ```
@@ -53,12 +53,12 @@ budget, budget-truncated raw history drops the old long-context answers
 1.00`), with **no overall regression** (compacted ≥ baseline by +0.50, well
 inside the 0.01 tolerance). AC#3's "no regression beyond 0.01" holds.
 
-## §2 — Manual inspection (AC#2)
+## §2: Manual inspection (AC#2)
 
 `make virtual-context-inspect` builds and runs `inspect_real_session.c`, which
 drives the **real** public path with the flag on
 (`conv_ctx_record_event` → `conv_ctx_flush_pending` → `conv_ctx_assemble`, plus
-`db1_conv_search_chains` / `db1_conv_chain_events` — the same functions the
+`db1_conv_search_chains` / `db1_conv_chain_events`, the same functions the
 `session_context_search` / `_expand` / `_status` MCP tools wrap) over a
 realistic 7-event tool-heavy sequence. No LLM or network required, so it is a
 reproducible inspection artifact rather than a one-off screenshot.
@@ -93,7 +93,7 @@ This confirms the three things the parent Test Plan asked a human to check:
 3. **Expand recovers raw on demand.** `session_context_expand` (via
    `db1_conv_chain_events`) returns the raw events behind a stub.
 
-## §3 — Operational metrics (AC#3)
+## §3: Operational metrics (AC#3)
 
 `tool_session_context_status` now returns a `metrics` object derived from the
 session's chains, giving the dashboard real data:
@@ -114,11 +114,11 @@ Exposed keys: `session_context_segments_total`,
 `session_context_bytes_saved`, `compression_ratio` (plus the existing
 `event_count` / `chain_count` / `pending_events` fields).
 
-## §4 — Default flip + rollback (AC#4)
+## §4: Default flip + rollback (AC#4)
 
 `config.c` now initializes `virtual_context_enabled = 1` (was `0`); the header
 documents the new default. The full unit suite (`make unit-tests`, ~200
-binaries) passes with the flag on by default — the only test that assumed the
+binaries) passes with the flag on by default; the only test that assumed the
 compiled-off default (`test_assemble_disabled`) was updated to disable the flag
 explicitly via config.
 
@@ -127,14 +127,14 @@ explicitly via config.
 the feature reverts with no schema loss. Blast radius is prompt-assembly quality
 for long sessions; failure degrades to larger prompts, not data loss.
 
-## §5 — Dashboard + alerts (AC#5)
+## §5: Dashboard + alerts (AC#5)
 
 - [`docs/observability/virtual-context-dashboard.json`](../observability/virtual-context-dashboard.json)
-  — 7-panel Grafana dashboard over the metrics above (segments, stubbed,
+  is a 7-panel Grafana dashboard over the metrics above (segments, stubbed,
   compression ratio, pending events, bytes saved, assembly latency p50/p95, and
   stub-expansion ok/error rate).
 - [`docs/observability/virtual-context-alerts.md`](../observability/virtual-context-alerts.md)
-  — the **RebuildBacklog** alert (pending events accumulate while no segments
+  defines the **RebuildBacklog** alert (pending events accumulate while no segments
   emit → auto-flush stalled) and the **ExpandFailure** alert (>5% expand error
   rate → raw recovery broken), each with PromQL, for-duration, severity, and
   rationale, plus the rollback note.

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,8 +1,8 @@
-# aimee — VS Code extension
+# aimee: VS Code extension
 
 Chat with **aimee** inside VS Code. Prompts are routed through `aimee-server`'s
 OpenAI-compatible `/v1` API, so they go through aimee's delegate fabric with
-memory and guardrails applied — no new server protocol, just the surface that
+memory and guardrails applied, with no new server protocol, just the surface that
 already ships (see [docs/VSCODE.md](../../docs/VSCODE.md) and
 [the proposal](../../docs/proposals/pending/vscode-integration.md)).
 
@@ -39,8 +39,8 @@ already ships (see [docs/VSCODE.md](../../docs/VSCODE.md) and
    editor can read and chat but not perform admin mutations.
 
 2. In VS Code settings, set:
-   - `aimee.apiBase` — default `http://127.0.0.1:8910/v1`
-   - `aimee.bearerToken` — your `bearer_token`
+   - `aimee.apiBase`: default `http://127.0.0.1:8910/v1`
+   - `aimee.bearerToken`: your `bearer_token`
 
 3. Open **Copilot Chat** and type `@aimee <your prompt>`.
 

--- a/src/README.md
+++ b/src/README.md
@@ -1,4 +1,4 @@
-# aimee -- Technical Reference
+# aimee: Technical Reference
 
 Architecture, internals, and build instructions. For usage and getting started,
 see the [root README](../README.md) and the full [Manual](../MANUAL.md). For the
@@ -11,7 +11,7 @@ aimee's core services are written in C11 for performance and minimal footprint. 
 
 ## Architecture overview
 
-aimee supports two agent roles. The **primary agent** is the AI coding surface the user interacts with (Claude Code, Gemini CLI, direct Codex, direct Mistral, Codex CLI legacy mode, Mistral Vibe, GitHub Copilot). aimee integrates through hooks, provider-CLI adapters, or direct primary-session adapters -- intercepting tool calls, injecting memory and rules, enforcing guardrails, and managing session isolation. **Delegate agents** are sub-agents configured in `agents.json` that handle offloaded work via `aimee delegate <role> <prompt>`.
+aimee supports two agent roles. The **primary agent** is the AI coding surface the user interacts with (Claude Code, Gemini CLI, direct Codex, direct Mistral, Codex CLI legacy mode, Mistral Vibe, GitHub Copilot). aimee integrates through hooks, provider-CLI adapters, or direct primary-session adapters, intercepting tool calls, injecting memory and rules, enforcing guardrails, and managing session isolation. **Delegate agents** are sub-agents configured in `agents.json` that handle offloaded work via `aimee delegate <role> <prompt>`.
 
 ```mermaid
 graph TB
@@ -186,10 +186,10 @@ The largest source files are tracked for decomposition in waves (split the bigge
 
 ```mermaid
 graph TD
-    L0[L0 -- Session Memory<br/>Scratch, in-progress state<br/>Lifetime: session only]
-    L1[L1 -- Recent Memory<br/>Decisions, context, checkpoints<br/>Lifetime: 30 days]
-    L2[L2 -- Long-term Memory<br/>Stable facts, preferences, patterns<br/>Lifetime: persistent]
-    L3[L3 -- Episodic Memory<br/>Past attempts, outcomes, failures<br/>Lifetime: persistent with decay]
+    L0[L0: Session Memory<br/>Scratch, in-progress state<br/>Lifetime: session only]
+    L1[L1: Recent Memory<br/>Decisions, context, checkpoints<br/>Lifetime: 30 days]
+    L2[L2: Long-term Memory<br/>Stable facts, preferences, patterns<br/>Lifetime: persistent]
+    L3[L3: Episodic Memory<br/>Past attempts, outcomes, failures<br/>Lifetime: persistent with decay]
 
     L0 -->|accordion fold<br/>at session end| L1
     L1 -->|3 reuses or<br/>confidence >= 0.9| L2
@@ -709,8 +709,8 @@ worker; any handler that may block runs on the compute pool.
 - The HTTP listener (`src/server/server_http.c`) owns the accept loop over the
   `/v1` UDS (`~/.config/aimee/aimee-http.sock`) and the optional localhost TCP
   port, handing each accepted connection to its own detached worker thread.
-- `server_run()` (`src/server/server.c`) no longer runs an accept loop — the
-  legacy NDJSON RPC socket was removed — and simply parks until shutdown. The
+- `server_run()` (`src/server/server.c`) no longer runs an accept loop (the
+  legacy NDJSON RPC socket was removed) and simply parks until shutdown. The
   `server_conn_t` buffered read/write helpers (`conn_flush()` etc.) survive
   because the in-process `/v1` dispatch bridge reuses them with a stack-allocated
   connection.
@@ -814,7 +814,7 @@ reference for the separate KB API (`api/openapi-v1.yaml`). See the
 (`src/server/kb_client*.c`), typed wrappers (memory, index, docs, agent,
 dashboard, roadmap, notes, curiosity, status) that call `aimee-kb` over its
 HTTP `/v1` API (`AIMEE_KB_API_URL`, port 8741). The legacy Unix-socket transport
-was retired in #2747 — HTTP is now the only KB transport. DB1 remains local to the server;
+was retired in #2747; HTTP is now the only KB transport. DB1 remains local to the server;
 DB2 can be a local single-user KB or a shared KB, and server-side reflection or
 promotion flows send only scoped knowledge artifacts across that boundary.
 `aimee-kb` (`src/kb/`) owns the DB2 schema, the memory inference pipeline, the
@@ -833,7 +833,7 @@ knowledge service scale independently and in different ways.
 
 **`aimee-server` is 1:1 with a user.** It owns DB1 (local SQLite, same-user
 runtime state) and authenticates by `SO_PEERCRED` peer UID, so it is single-tenant
-and local by construction — one per OS login, never sharded or load-balanced. Its
+and local by construction: one per OS login, never sharded or load-balanced. Its
 only scaling axis is *vertical*: the compute pool and concurrency knobs
 (`compute_threads` / `worker_threads` / `background_threads` / `session_threads`,
 `concurrency.per_model`) raise a single user's in-flight delegate and tool-call
@@ -846,13 +846,13 @@ database. Many `aimee-server` instances (many users) reach one KB over HTTP `:87
 (`AIMEE_KB_API_URL`). Critically, the background pipeline claims work straight off
 DB2 with `FOR UPDATE SKIP LOCKED` (`db2_kb_ingest_queue_claim_next` in
 `src/kb/kb_ingest_workers.c`; the curator drain in `kb_curator_extract_code.c`), so
-concurrent KB replicas never double-claim a row — Postgres is the only
+concurrent KB replicas never double-claim a row; Postgres is the only
 coordinator. The scale-out recipe is therefore: **run N `aimee-kb` replicas behind
 a load balancer over one Postgres.**
 
 **DB2 is standard Postgres.** It is one `aimee_shared` database with `pg_trgm` +
-`vector` (pgvector) — scaled with the normal Postgres playbook (instance sizing,
-pooling, read replicas; `db2_pool_size` bounds each instance's pool, 1–32). Vector
+`vector` (pgvector), scaled with the normal Postgres playbook (instance sizing,
+pooling, read replicas; `db2_pool_size` bounds each instance's pool, 1-32). Vector
 search scales inside it: pgvector HNSW by default (and always for memory vectors),
 with **pgvectorscale (StreamingDiskANN)** as an additive, opt-in scale-up for large
 corpus tables. The index type is chosen per corpus table by

--- a/src/kb/README.md
+++ b/src/kb/README.md
@@ -1,7 +1,7 @@
 # aimee-kb
 
 This directory is the ownership boundary and implementation home for the
-`aimee-kb` service — the knowledge tier that owns **DB2** (Postgres + pgvector)
+`aimee-kb` service, the knowledge tier that owns **DB2** (Postgres + pgvector)
 and everything derived from it. For the system-level picture see
 [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md); for the code-level module map
 see the [Technical Reference](../README.md).
@@ -11,7 +11,7 @@ see the [Technical Reference](../README.md).
 `aimee-kb` is a single C11 process that owns the DB2 schema and all knowledge
 operations: the memory inference pipeline (dedup, contradiction detection,
 temporal versioning, promotion/decay), the vector collections, the code index,
-document ingest, and the curator. `aimee-server` holds **no** DB2 SQL — it reaches
+document ingest, and the curator. `aimee-server` holds **no** DB2 SQL; it reaches
 all of this through the typed KB client over a Unix socket or HTTP. KB service
 entry, dispatcher, background workers, mining, curator, ingest, and the HTTP
 surface live here (`kb_main.c`, `kb_service*.c`, `kb_ingest_workers.c`,
@@ -29,14 +29,14 @@ Where `aimee-server` is strictly 1:1 with a user, **`aimee-kb` is the shared tie
 that scales out to serve many users at once.** Three properties make this work:
 
 1. **All durable state lives in DB2 (Postgres).** A KB process keeps only
-   transient state — connection pools, in-flight request buffers, worker loops.
+   transient state: connection pools, in-flight request buffers, worker loops.
    The knowledge itself (memories, rules, code index, tasks, embeddings) is in
    Postgres. A KB instance is therefore an effectively **stateless request server
    over a shared database**.
 2. **It is reachable over the network.** Besides the local Unix socket, KB serves
    its full contract over HTTP on `:8741` (`AIMEE_KB_API_URL`, optional bearer
-   token). Many independent `aimee-server` instances — i.e. many users on many
-   machines — can point at one KB endpoint.
+   token). Many independent `aimee-server` instances (i.e. many users on many
+   machines) can point at one KB endpoint.
 3. **Concurrent instances are safe with no external coordinator.** The background
    pipeline (ingest, curator, embedding, index-update) claims work straight off
    DB2 queues using `FOR UPDATE SKIP LOCKED`
@@ -45,7 +45,7 @@ that scales out to serve many users at once.** Three properties make this work:
 
 Consequently you scale the KB the way you scale any stateless web tier: **run N
 `aimee-kb` replicas behind a load balancer**, all pointed at one Postgres. Read
-and query traffic (search, recall, index lookups — the hot path the servers hit)
+and query traffic (search, recall, index lookups, the hot path the servers hit)
 fans out across replicas freely; the background workers on each replica drain the
 shared DB2 queues cooperatively.
 
@@ -54,8 +54,8 @@ shared DB2 queues cooperatively.
 There is no bespoke datastore. DB2 is one ordinary Postgres database
 (`aimee_shared` by default) with two extensions: `pg_trgm` (lexical) and `vector`
 (pgvector, for dense embeddings). You scale it with the standard Postgres
-playbook — vertical sizing, connection pooling (e.g. PgBouncer), and read
-replicas for query fan-out — and `db2_pool_size` (1–32, default 8) bounds each KB
+playbook (vertical sizing, connection pooling such as PgBouncer, and read
+replicas for query fan-out), and `db2_pool_size` (1-32, default 8) bounds each KB
 instance's connection pool.
 
 Vector search rides inside the same Postgres, so it scales with it:
@@ -63,7 +63,7 @@ Vector search rides inside the same Postgres, so it scales with it:
 - **pgvector HNSW is the default** for memory vectors (always) and for all
   small-to-medium corpora. No extra extension required.
 - **pgvectorscale (StreamingDiskANN) is the opt-in scale-up** for large corpora.
-  It is *additive* — built on top of pgvector, same `vector` column type and same
+  It is *additive*: built on top of pgvector, same `vector` column type and same
   distance operators, adding only the `USING diskann` index access method, which
   is disk-backed with bounded build memory. Selected per corpus table by
   `db2.vector.corpus_index` (`auto` | `hnsw` | `diskann`); `auto` flips to diskann
@@ -89,7 +89,7 @@ Vector search rides inside the same Postgres, so it scales with it:
 
 ## Boundary rules
 
-Server code must not include KB internals directly — it speaks only the KB client
+Server code must not include KB internals directly; it speaks only the KB client
 contract. KB code must not link SQLite or reach DB1. The build gates
 (`make check-linking`, `make kb-target-isolation-check`,
 `make kb-container-packaging-check`, `scripts/check_tier_deps.sh`) enforce both

--- a/src/server/README.md
+++ b/src/server/README.md
@@ -1,7 +1,7 @@
 # aimee-server
 
 This directory is the ownership boundary and implementation home for
-`aimee-server` — the persistent local hub that every thin client talks to.
+`aimee-server`, the persistent local hub that every thin client talks to.
 For the system-level picture see [`docs/ARCHITECTURE.md`](../../docs/ARCHITECTURE.md);
 for the code-level module map and RPC catalog see the
 [Technical Reference](../README.md).
@@ -13,8 +13,8 @@ bounded compute pool, routes delegates, serves the lifecycle hooks, and exposes
 the public HTTP `/v1` surface (its only client transport). The thin clients
 (`aimee`, `aimee-webchat`) hold no database; they reach this process over `/v1`
 (local `aimee-http.sock` or remote TCP) and forward typed requests. The expensive
-state — open DB handles, a
-warm KB connection, the worker pool — lives here, in a warm long-running process,
+state (open DB handles, a
+warm KB connection, the worker pool) lives here, in a warm long-running process,
 which is what keeps CLI startup under 10 ms and a pre-tool hook check around 1 ms.
 
 It links `-lsqlite3` (plus `-lssl`/`-lcrypto`/`-lpam`) and is built with
@@ -28,7 +28,7 @@ knowledge operations go through the typed **KB client** (`kb_client*.c`) to
 **`aimee-server` is strictly 1:1 with a user.** This is a design invariant, not a
 deployment choice:
 
-- It owns **local, same-user runtime state** in DB1 — sessions, working memory,
+- It owns **local, same-user runtime state** in DB1: sessions, working memory,
   conversation windows, checkpoints, durable delegate jobs, secrets. That state is
   private to one OS user on one host.
 - It authenticates callers by **`SO_PEERCRED`** (the connecting process's UID).
@@ -48,7 +48,7 @@ deployment. The server is the per-user front; the KB is the many-user back. See
 
 | Concern | Where | Notes |
 |---------|-------|-------|
-| Event loop | `server.c` (`server_run`) | Single epoll thread: read, parse, dispatch — **never blocks**. Per-connection buffered I/O; `EPOLLOUT` added only while a write is pending. |
+| Event loop | `server.c` (`server_run`) | Single epoll thread: read, parse, dispatch, and **never blocks**. Per-connection buffered I/O; `EPOLLOUT` added only while a write is pending. |
 | Entry / signals | `server_main.c` | Startup handshake, SIGTERM/SIGINT graceful drain, unclean-exit forensics to DB1. |
 | Auth | `server_auth.c` | Capability lookup + a 16-bit capability mask declared per method (unknown methods default to deny). The local `/v1` UDS is filesystem-trusted (full surface); the optional TCP listener is bearer-gated (`server_http_authorize`, constant-time compare via `server_ct_equal`). |
 | Sessions | `server_session.c` | Session create/list/get/close, per-session worktrees and state. |
@@ -67,7 +67,7 @@ deployment. The server is the per-user front; the KB is the many-user back. See
   concurrent heavyweight inference so a burst of delegates cannot exhaust the host.
 
 These knobs scale a single user's server *vertically* (more in-flight delegates,
-more parallel tool calls). They do **not** make the server multi-user — that
+more parallel tool calls). They do **not** make the server multi-user; that
 remains the KB tier's job.
 
 ## Boundary rules


### PR DESCRIPTION
## What

Sweep the human-authored docs to remove AIism punctuation: em-dashes (—), en-dashes (–), and prose `--`, replacing each with plain punctuation (colon, semicolon, comma, or parentheses) chosen per context. Numeric ranges become a hyphen (`1-32`, `25-45x`).

19 files changed, balanced 185/185 (pure punctuation swaps, no content added or removed).

## Deliberately preserved

- Mermaid edge labels in `docs/SECURITY.md` (graph syntax, e.g. `C -- No -->`).
- The `git log -- <path>` shell command in `docs/PROPOSALS.md`.
- Functional arrows (→, ↔), status checkmarks (✅), and box-drawing characters.

## Also fixed

The `MANUAL.md` appendix TOC/anchor links carried a double-dash left over from former em-dash headings and no longer matched the current comma headings' single-dash GitHub anchors, so they were broken; corrected to single-dash.

## Out of scope

Auto-generated SDK docs (`api/sdks/**`) and `docs/gen/**` are untouched; they regenerate from the OpenAPI spec via `make docs-gen`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
