### PR TITLE
ci: fix auto-release regressions (digest collision + artifact scope)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -130,10 +130,15 @@ jobs:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
 
+      # Match ONLY this image's per-arch digests. A trailing `-*` would be greedy:
+      # `digest-aimee-server-*` also matches `digest-aimee-server-kb-*` (one image
+      # name is a prefix of another), which previously pulled the combined image's
+      # digests into the aimee-server manifest and broke the push. Anchor on the
+      # exact arch suffixes instead (brace expansion, no wildcard across `-`).
       - name: Download this image's digests
         uses: actions/download-artifact@v4
         with:
-          pattern: digest-${{ matrix.image }}-*
+          pattern: digest-${{ matrix.image }}-{amd64,arm64}
           path: /tmp/digests
           merge-multiple: true
 
@@ -161,11 +166,21 @@ jobs:
       - name: Create + push the multi-arch manifest
         working-directory: /tmp/digests
         run: |
-          # Assemble the list of source digests for this image.
+          # Assemble the list of source digests for this image. Expect exactly the
+          # per-arch builds (amd64 + arm64); fail loudly on a mismatch rather than
+          # pushing a partial or cross-image manifest.
           srcs=""
+          count=0
           for f in *; do
+            [ -e "$f" ] || continue
             srcs="$srcs ghcr.io/${OWNER}/${{ matrix.image }}@$(cat "$f")"
+            count=$((count + 1))
           done
+          echo "Found $count digest(s) for ${{ matrix.image }}: $srcs"
+          if [ "$count" -eq 0 ]; then
+            echo "::error::no digests matched for ${{ matrix.image }} — check the download-artifact pattern"
+            exit 1
+          fi
           # Apply every tag the metadata action produced to the merged manifest.
           tags=$(jq -r '.tags[] | "-t " + .' <<< "$DOCKER_METADATA_OUTPUT_JSON")
           docker buildx imagetools create $tags $srcs

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -150,9 +150,14 @@ jobs:
     # was supplied via call/dispatch (the orchestrator created the tag first).
     if: ${{ inputs.version != '' || startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - name: Download all artifacts
+      # Scope to the thin-client binaries only. When invoked via auto-release
+      # (workflow_call), the publish-images workflow shares this run and uploads
+      # digest-* artifacts too; an unscoped download would pull those into dist/
+      # (and onto the Release) and widen the flaky-download surface.
+      - name: Download thin-client artifacts
         uses: actions/download-artifact@v4
         with:
+          pattern: aimee-*
           path: dist
           merge-multiple: true
       - name: Publish release


### PR DESCRIPTION
Fixes two regressions in the auto-release path, both surfaced by the first `v0.2.1` run (#10 promote):

1. **`publish-images` merge — digest collision.** My `workflow_call` rewrite reverted the #4 fix back to a greedy `pattern: digest-<image>-*`, which also matches `digest-aimee-server-kb-*`, so the `aimee-server` manifest tried to reference a `server-kb` digest → `not found`. Restored `-{amd64,arm64}` brace expansion + the per-image digest-count guard.
2. **`release-thin-client` release — artifact scope.** Invoked via auto-release (`workflow_call`), the run also holds `publish-images` `digest-*` artifacts; the unscoped `download-artifact` pulled them into `dist/` (would land on the Release) and widened the flaky-download surface that failed the release job. Scoped to `pattern: aimee-*`.

After merge + promote, auto-release re-cuts a clean **v0.2.1** (the partial tag from the failed run is deleted first so the version number isn't skipped).
