### PR TITLE
Promote to main: broaden thin-client matrix + Windows CI smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,16 @@ jobs:
           # The new remote transport must parse on Windows (Winsock path).
           .\build\aimee.exe --server http://127.0.0.1:9 version
 
+      - name: Thin-client smoke (selfcheck, Winsock transport)
+        shell: bash
+        run: |
+          # Beyond `version`: drive a real subcommand with the HTTP transport env
+          # set, so the Windows client exercises its Winsock connect path (a
+          # connection error is the expected selfcheck outcome; a usage/parse
+          # error is not). Mirrors the macOS/Linux thin-client smoke.
+          AIMEE_BIN='./build/aimee.exe' FORCE_MODE=selfcheck \
+            bash scripts/aimee-thin-client-smoke.sh
+
   windows-build:
     runs-on: windows-latest
     steps:
@@ -234,6 +244,16 @@ jobs:
           .\build\aimee.exe version
           # The new remote transport must parse on Windows (Winsock path).
           .\build\aimee.exe --server http://127.0.0.1:9 version
+
+      - name: Thin-client smoke (selfcheck, Winsock transport)
+        shell: bash
+        run: |
+          # Beyond `version`: drive a real subcommand with the HTTP transport env
+          # set, so the Windows client exercises its Winsock connect path (a
+          # connection error is the expected selfcheck outcome; a usage/parse
+          # error is not). Mirrors the macOS/Linux thin-client smoke.
+          AIMEE_BIN='./build/aimee.exe' FORCE_MODE=selfcheck \
+            bash scripts/aimee-thin-client-smoke.sh
 
   macos-build:
     runs-on: macos-latest

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -41,11 +41,23 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Linux: authoritative make build. x86_64 + arm64 native runners.
           - os: ubuntu-latest
+            kind: linux
             asset: aimee-linux-x86_64
+          - os: ubuntu-24.04-arm
+            kind: linux
+            asset: aimee-linux-arm64
+          # macOS: CMake lean thin client. arm64 (macos-latest) + Intel (macos-13).
           - os: macos-latest
+            kind: macos
             asset: aimee-macos-arm64
+          - os: macos-13
+            kind: macos
+            asset: aimee-macos-x86_64
+          # Windows: CMake thin client via MinGW (x86_64).
           - os: windows-latest
+            kind: windows
             asset: aimee-windows-x86_64.exe
     runs-on: ${{ matrix.os }}
     steps:
@@ -71,12 +83,12 @@ jobs:
 
       # --- Linux: authoritative make build of the lean thin client ---
       - name: Linux deps
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.kind == 'linux'
         run: |
           sudo apt-get update -q
           sudo apt-get install -y -q gcc make libsqlite3-dev
       - name: Build (Linux, make)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.kind == 'linux'
         run: |
           cd src
           if [ -n "${{ steps.ver.outputs.version }}" ]; then
@@ -85,32 +97,32 @@ jobs:
             make -j"$(nproc)" ../aimee
           fi
       - name: Stage artifact (Linux)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.kind == 'linux'
         run: cp aimee "${{ matrix.asset }}"
 
       # --- macOS: CMake thin-client target, lean profile ---
       - name: macOS deps
-        if: matrix.os == 'macos-latest'
+        if: matrix.kind == 'macos'
         run: brew install sqlite3 openssl@3 || true
       - name: Build (macOS, CMake)
-        if: matrix.os == 'macos-latest'
+        if: matrix.kind == 'macos'
         run: |
           cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 3 --target aimee
       - name: Stage artifact (macOS)
-        if: matrix.os == 'macos-latest'
+        if: matrix.kind == 'macos'
         run: cp build/aimee "${{ matrix.asset }}"
 
       # --- Windows: CMake thin-client target via MinGW, lean profile ---
       - name: Install MinGW-w64 (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.kind == 'windows'
         run: choco install mingw
       - name: Add MinGW to PATH (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.kind == 'windows'
         shell: powershell
         run: echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Download SQLite amalgamation (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.kind == 'windows'
         shell: powershell
         run: |
           $url = "https://www.sqlite.org/2024/sqlite-amalgamation-3470200.zip"
@@ -120,20 +132,20 @@ jobs:
           Copy-Item sqlite-tmp\sqlite-amalgamation-3470200\sqlite3.c src\vendor\sqlite3\
           Copy-Item sqlite-tmp\sqlite-amalgamation-3470200\sqlite3.h src\vendor\sqlite3\
       - name: Build (Windows, CMake)
-        if: matrix.os == 'windows-latest'
+        if: matrix.kind == 'windows'
         run: |
           cmake -B build -G "MinGW Makefiles" -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 2 --target aimee
       - name: Stage artifact (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.kind == 'windows'
         shell: powershell
         run: Copy-Item build\aimee.exe "${{ matrix.asset }}"
 
       - name: Smoke test artifact (POSIX)
-        if: matrix.os != 'windows-latest'
+        if: matrix.kind != 'windows'
         run: ./${{ matrix.asset }} version
       - name: Smoke test artifact (Windows)
-        if: matrix.os == 'windows-latest'
+        if: matrix.kind == 'windows'
         shell: powershell
         run: .\${{ matrix.asset }} version
 


### PR DESCRIPTION
Promote `testing` to `main`.

- ci: broaden thin-client matrix (linux-arm64 + macOS Intel) + Windows selfcheck smoke (#14)

On merge, auto-release cuts v0.2.2 — the first release to build all 5 thin-client assets (adds aimee-linux-arm64 + aimee-macos-x86_64).
