### PR TITLE
Release: auto-deploy webchat in aimee-server + aimee-combined images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,6 +378,11 @@ jobs:
   # ship Docker + compose, so no port offset is needed (8740/8741 are free).
   e2e-docker:
     runs-on: ubuntu-latest
+    # packages: read lets the built-in GITHUB_TOKEN pull @rakuensoftware/smoothgui
+    # (this repo's own org) from GitHub Packages when building the webchat SPA.
+    permissions:
+      contents: read
+      packages: read
     steps:
       - uses: actions/checkout@v4
       - name: Runner diagnostics
@@ -386,6 +391,12 @@ jobs:
           docker compose version
           df -h / | tail -1
       - name: Run Docker deploy matrix (T1-T4)
+        # The server/combined images build webchat's SPA, whose @rakuensoftware
+        # dependency needs a GitHub Packages token. compose reads it from
+        # $NPM_TOKEN (build.secrets); prefer a repo NPM_TOKEN secret, else the
+        # built-in GITHUB_TOKEN (sufficient for same-org packages).
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
         run: scripts/e2e-matrix.sh --only T1,T2,T3,T4
       - name: Stack logs on failure
         if: failure()

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -103,6 +103,14 @@ jobs:
           provenance: false
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
+          # webchat's SPA pulls @rakuensoftware/smoothgui from GitHub Packages,
+          # whose npm registry requires an authenticated token (even for public
+          # reads). Prefer a repo/org NPM_TOKEN secret (a PAT with read:packages);
+          # fall back to the built-in GITHUB_TOKEN, which suffices for public
+          # packages. The aimee-kb image ignores it. Passed via BuildKit so the
+          # token never lands in an image layer.
+          secrets: |
+            npm_token=${{ secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -32,6 +32,39 @@ COPY . .
 ARG AIMEE_VERSION=""
 RUN make -C src ../aimee-server ../aimee-kb ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
+# --- webchat frontend: build the React SPA into a single index.html ---
+# vite-plugin-singlefile inlines all JS/CSS, so the runtime image ships one file.
+FROM node:20-bookworm AS frontend-build
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+# @rakuensoftware/smoothgui is hosted on GitHub Packages, whose npm registry
+# requires an authenticated token even for public reads. The token arrives as a
+# BuildKit secret and is written to a throwaway .npmrc that lives only for this
+# RUN, so it never lands in an image layer:
+#   docker build --secret id=npm_token,env=NPM_TOKEN ...
+#   compose: build.secrets;  CI: npm_token=${{ secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+RUN --mount=type=secret,id=npm_token \
+    { echo '@rakuensoftware:registry=https://npm.pkg.github.com'; \
+      echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/npm_token)"; } > .npmrc \
+    && npm ci \
+    && rm -f .npmrc
+COPY frontend/ ./
+RUN npm run build
+
+# --- webchat service: the standalone Go browser server (cgo: PAM + sqlite) ---
+FROM golang:1.25-bookworm AS webchat-build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpam0g-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src/webchat
+COPY webchat/go.mod webchat/go.sum ./
+RUN go mod download
+COPY webchat/ ./
+RUN CGO_ENABLED=1 go build -o /out/aimee-webchat .
+
 FROM debian:bookworm-slim
 
 # Union of both runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
@@ -41,6 +74,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        libpam-modules \
+        libpam0g \
         libpq5 \
         libsqlite3-0 \
         libssl3 \
@@ -82,13 +117,22 @@ COPY scripts/embed-remote.py scripts/llm-chat.py scripts/learning-synthesize.py 
 # not collide under the shared AIMEE_HOME.
 COPY --chown=aimee:aimee deploy/container/aimee-server.yaml /var/lib/aimee/aimee.yaml
 COPY --chown=aimee:aimee deploy/container/aimee.yaml /var/lib/aimee/.config/aimee/aimee.yaml
-# Process supervisor: starts kb, waits for kb health, then execs the server.
-COPY --chown=aimee:aimee deploy/container/combined-entrypoint.sh /usr/local/bin/aimee-combined-entrypoint
+# Co-located webchat browser UI: the Go service, the single-file React SPA, the
+# PAM stack for browser login, and the bootstrap/launch helpers. webchat shares
+# AIMEE_HOME so its Unix-socket transports line up with the server.
+COPY --from=webchat-build /out/aimee-webchat /usr/local/bin/aimee-webchat
+COPY --from=frontend-build /frontend/dist/index.html /usr/local/share/aimee-webchat/index.html
+COPY deploy/container/pam-aimee-webchat /etc/pam.d/aimee-webchat
+COPY deploy/container/webchat-lib.sh /usr/local/bin/webchat-lib.sh
+# Process supervisor: starts kb, waits for kb health, starts the server + webchat.
+COPY deploy/container/combined-entrypoint.sh /usr/local/bin/aimee-combined-entrypoint
 RUN chmod +x /usr/local/bin/aimee-combined-entrypoint
 
-USER aimee
+# Runs as root: the entrypoint bootstraps the webchat PAM user and runs webchat
+# (pam_unix needs /etc/shadow), then drops aimee-kb + aimee-server to "aimee".
 WORKDIR /var/lib/aimee
-EXPOSE 8740 8741
+# 8740 = server /v1; 8741 = kb /v1; 8443 = aimee-webchat browser UI (HTTPS).
+EXPOSE 8740 8741 8443
 
 # NOTE: the server's worker threads need a 64 MB stack. A Dockerfile cannot set
 # a runtime ulimit, so callers MUST raise it (the 8 MB container default

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -23,16 +23,52 @@ COPY . .
 ARG AIMEE_VERSION=""
 RUN make -C src ../aimee-server ${AIMEE_VERSION:+GIT_VERSION=v$AIMEE_VERSION}
 
+# --- webchat frontend: build the React SPA into a single index.html ---
+# vite-plugin-singlefile inlines all JS/CSS, so the runtime image ships one file.
+FROM node:20-bookworm AS frontend-build
+WORKDIR /frontend
+COPY frontend/package.json frontend/package-lock.json ./
+# @rakuensoftware/smoothgui is hosted on GitHub Packages, whose npm registry
+# requires an authenticated token even for public reads. The token arrives as a
+# BuildKit secret and is written to a throwaway .npmrc that lives only for this
+# RUN, so it never lands in an image layer:
+#   docker build --secret id=npm_token,env=NPM_TOKEN ...
+#   compose: build.secrets;  CI: npm_token=${{ secrets.NPM_TOKEN || secrets.GITHUB_TOKEN }}
+RUN --mount=type=secret,id=npm_token \
+    { echo '@rakuensoftware:registry=https://npm.pkg.github.com'; \
+      echo "//npm.pkg.github.com/:_authToken=$(cat /run/secrets/npm_token)"; } > .npmrc \
+    && npm ci \
+    && rm -f .npmrc
+COPY frontend/ ./
+RUN npm run build
+
+# --- webchat service: the standalone Go browser server (cgo: PAM + sqlite) ---
+FROM golang:1.25-bookworm AS webchat-build
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        libpam0g-dev \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+WORKDIR /src/webchat
+COPY webchat/go.mod webchat/go.sum ./
+RUN go mod download
+COPY webchat/ ./
+RUN CGO_ENABLED=1 go build -o /out/aimee-webchat .
+
 FROM debian:bookworm-slim
 
 # Runtime shared libs the server links: libsqlite3 (DB1), libssl/libcrypto
 # (crypto), libzstd + zlib (compression). The server reaches Postgres-backed DB2
 # only through aimee-kb, so it does not link libpq itself. curl is for the
-# container HEALTHCHECK.
+# container HEALTHCHECK. libpam0g + libpam-modules (pam_unix.so) back the
+# co-located aimee-webchat browser login.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        libpam-modules \
+        libpam0g \
         libsqlite3-0 \
         libssl3 \
         libzstd1 \
@@ -62,12 +98,24 @@ RUN useradd --system --home-dir /var/lib/aimee --create-home --shell /usr/sbin/n
 VOLUME /var/lib/aimee-workspaces
 COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 
+# Co-located webchat browser UI: the Go service, the single-file React SPA, the
+# PAM stack for browser login, and the bootstrap/launch helpers. webchat shares
+# AIMEE_HOME so its Unix-socket transports line up with the server.
+COPY --from=webchat-build /out/aimee-webchat /usr/local/bin/aimee-webchat
+COPY --from=frontend-build /frontend/dist/index.html /usr/local/share/aimee-webchat/index.html
+COPY deploy/container/pam-aimee-webchat /etc/pam.d/aimee-webchat
+COPY deploy/container/webchat-lib.sh /usr/local/bin/webchat-lib.sh
+COPY deploy/container/server-entrypoint.sh /usr/local/bin/aimee-server-entrypoint
+RUN chmod +x /usr/local/bin/aimee-server-entrypoint
+
 # Baked default config: enables the inbound /v1 HTTP listener (port + bearer).
 COPY --chown=aimee:aimee deploy/container/aimee-server.yaml /var/lib/aimee/aimee.yaml
 
-USER aimee
+# Runs as root: the entrypoint bootstraps the webchat PAM user and runs webchat
+# (pam_unix needs /etc/shadow), then drops aimee-server to the "aimee" user.
 WORKDIR /var/lib/aimee
-EXPOSE 8740
+# 8740 = server /v1 HTTP API; 8443 = aimee-webchat browser UI (HTTPS).
+EXPOSE 8740 8443
 
 # NOTE: the server's worker threads need a 64 MB stack. A Dockerfile cannot set
 # a runtime ulimit, so callers MUST raise it (the 8 MB container default
@@ -87,5 +135,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -s -o /dev/null -w '%{http_code}' \
         http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$'
 
-ENTRYPOINT ["aimee-server"]
-CMD ["--socket=/var/lib/aimee/aimee-server.sock"]
+ENTRYPOINT ["aimee-server-entrypoint"]

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -9,7 +9,9 @@
 #   docker compose -f compose.combined.yaml up --build
 #
 # Server /v1 on :8740 (bearer "aimee-local-dev"); the in-container kb /v1 is also
-# published on :8741 for direct inspection.
+# published on :8741 for direct inspection. The aimee-webchat browser UI is on
+# https://localhost:8443 (self-signed; log in as AIMEE_WEBCHAT_USER /
+# AIMEE_WEBCHAT_PASSWORD, default aimee / aimee-local-dev).
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
 #   curl http://localhost:8741/v1/health?status=1
 services:
@@ -44,6 +46,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.combined
+      # webchat's SPA build needs a GitHub Packages token (see Dockerfile.combined).
+      # Sourced from the host $NPM_TOKEN; export it before `docker compose build`.
+      secrets:
+        - npm_token
     image: aimee-server-kb
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
@@ -57,9 +63,15 @@ services:
       AIMEE_SERVER_HTTP_BIND: "1"
       AIMEE_KB_HTTP_BIND: "1"
       AIMEE_KB_API_URL: http://127.0.0.1:8741
+      # Browser webchat (HTTPS on :8443). The entrypoint provisions this single
+      # login account via PAM; change it (and use a real password) for anything
+      # beyond local dev. Leave both unset to serve webchat with no account.
+      AIMEE_WEBCHAT_USER: aimee
+      AIMEE_WEBCHAT_PASSWORD: aimee-local-dev
     ports:
       - "8740:8740"
       - "8741:8741"
+      - "8443:8443"
     depends_on:
       postgres:
         condition: service_healthy
@@ -101,3 +113,9 @@ volumes:
   aimee-combined-postgres:
   aimee-embedder-models:
   aimee-llm-models:
+
+# Build-time secret for the webchat SPA's GitHub Packages dependency. Empty when
+# $NPM_TOKEN is unset (fine for public packages reachable with no token).
+secrets:
+  npm_token:
+    environment: NPM_TOKEN

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -19,6 +19,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
+      # webchat's SPA build needs a GitHub Packages token (see Dockerfile.server).
+      # Sourced from the host $NPM_TOKEN; export it before `docker compose build`.
+      secrets:
+        - npm_token
     image: aimee-server
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
@@ -43,3 +47,9 @@ services:
 volumes:
   aimee-server-home:
   aimee-server-workspaces:
+
+# Build-time secret for the webchat SPA's GitHub Packages dependency. Empty when
+# $NPM_TOKEN is unset (fine for public packages reachable with no token).
+secrets:
+  npm_token:
+    environment: NPM_TOKEN

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -9,7 +9,9 @@
 #
 #   docker compose -f compose.server.yaml up --build
 #
-# Server /v1 on :8740 (bearer "aimee-local-dev"); kb /v1 on :8741.
+# Server /v1 on :8740 (bearer "aimee-local-dev"); kb /v1 on :8741. The
+# aimee-webchat browser UI is on https://localhost:8443 (self-signed; log in as
+# AIMEE_WEBCHAT_USER / AIMEE_WEBCHAT_PASSWORD, default aimee / aimee-local-dev).
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
 services:
   postgres:
@@ -68,6 +70,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
+      # webchat's SPA build needs a GitHub Packages token (see Dockerfile.server).
+      # Sourced from the host $NPM_TOKEN; export it before `docker compose build`.
+      secrets:
+        - npm_token
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:
@@ -80,8 +86,14 @@ services:
       # kb_client paths already carry the /v1 prefix (kb_client_v1_url).
       AIMEE_KB_API_URL: http://aimee-kb:8741
       AIMEE_SERVER_HTTP_BIND: "1"
+      # Browser webchat (HTTPS on :8443). The entrypoint provisions this single
+      # login account via PAM; change it (and use a real password) for anything
+      # beyond local dev. Leave both unset to serve webchat with no account.
+      AIMEE_WEBCHAT_USER: aimee
+      AIMEE_WEBCHAT_PASSWORD: aimee-local-dev
     ports:
       - "8740:8740"
+      - "8443:8443"
     depends_on:
       aimee-kb:
         condition: service_healthy
@@ -125,3 +137,9 @@ volumes:
   aimee-server-postgres:
   aimee-embedder-models:
   aimee-llm-models:
+
+# Build-time secret for the webchat SPA's GitHub Packages dependency. Empty when
+# $NPM_TOKEN is unset (fine for public packages reachable with no token).
+secrets:
+  npm_token:
+    environment: NPM_TOKEN

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -3,9 +3,14 @@
 #
 # Starts aimee-kb (DB2 + pgvector + embedder over /v1 on loopback :8741), waits
 # for it to report healthy, then starts aimee-server pointed at it via
-# AIMEE_KB_API_URL=http://127.0.0.1:8741. The container's lifecycle follows the
-# SERVER: if the server exits, we tear down the kb and exit with the server's
-# code; SIGTERM/SIGINT are forwarded to both so `docker stop` is clean.
+# AIMEE_KB_API_URL=http://127.0.0.1:8741, plus the co-located aimee-webchat
+# browser UI on :8443. The container's lifecycle follows the SERVER: if the
+# server exits, we tear down the kb + webchat and exit with the server's code;
+# SIGTERM/SIGINT are forwarded to all so `docker stop` is clean.
+#
+# Runs as root so it can bootstrap the webchat PAM login user and run webchat
+# (which needs /etc/shadow access for pam_unix); aimee-kb and aimee-server are
+# dropped to the unprivileged "aimee" user via runuser.
 #
 # POSIX sh (the image has no bash). Endpoints/DB come from the environment
 # (compose supplies AIMEE_DB2_URL / AIMEE_EMBEDDER_URL).
@@ -18,17 +23,20 @@ KB_WAIT_SECONDS="${KB_WAIT_SECONDS:-120}"
 kb_pid=""
 server_pid=""
 
+. /usr/local/bin/webchat-lib.sh
+
 log() { printf '[combined-entrypoint] %s\n' "$*"; }
 
 shutdown() {
-    # Best-effort teardown of both children; ignore errors during shutdown.
+    # Best-effort teardown of all children; ignore errors during shutdown.
     [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
     [ -n "$kb_pid" ] && kill "$kb_pid" 2>/dev/null || true
+    webchat_stop
 }
 trap 'shutdown' TERM INT
 
-log "starting aimee-kb (http-port=$KB_HTTP_PORT)"
-aimee-kb --http-port="$KB_HTTP_PORT" &
+log "starting aimee-kb (http-port=$KB_HTTP_PORT) as user aimee"
+runuser -u aimee -- aimee-kb --http-port="$KB_HTTP_PORT" &
 kb_pid=$!
 
 log "waiting up to ${KB_WAIT_SECONDS}s for aimee-kb /v1/health on :$KB_HTTP_PORT"
@@ -53,14 +61,18 @@ while :; do
     sleep 1
 done
 
-log "starting aimee-server (socket=$SERVER_SOCK kb=$AIMEE_KB_API_URL)"
-aimee-server --socket="$SERVER_SOCK" &
+log "starting aimee-server (socket=$SERVER_SOCK kb=$AIMEE_KB_API_URL) as user aimee"
+runuser -u aimee -- aimee-server --socket="$SERVER_SOCK" &
 server_pid=$!
+
+# Browser UI (root, PAM). Supplementary — a webchat crash must not take the
+# container down; the server is the contract.
+webchat_start
 
 # Wait for whichever child exits first; the server is the container's contract,
 # so its exit (or a forwarded signal) tears the container down.
 wait "$server_pid"
 status=$?
-log "aimee-server exited (status $status); shutting down aimee-kb"
+log "aimee-server exited (status $status); shutting down aimee-kb + webchat"
 shutdown
 exit "$status"

--- a/deploy/container/pam-aimee-webchat
+++ b/deploy/container/pam-aimee-webchat
@@ -1,0 +1,8 @@
+# PAM stack for the aimee-webchat browser login (service name "aimee-webchat").
+#
+# Self-contained (does not @include common-*) so it works on a minimal image
+# with only libpam-modules installed. pam_unix checks /etc/shadow, which is why
+# aimee-webchat runs as root inside the container; the login user is created from
+# AIMEE_WEBCHAT_USER / AIMEE_WEBCHAT_PASSWORD by the entrypoint.
+auth     required pam_unix.so
+account  required pam_unix.so

--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Entrypoint for the aimee-server image with the co-located webchat browser UI.
+#
+# Runs as root so it can bootstrap the PAM login user and run aimee-webchat
+# (which needs /etc/shadow access for pam_unix). aimee-server itself is dropped
+# to the unprivileged "aimee" user. Lifecycle follows the SERVER: when it exits,
+# webchat is torn down and the container exits with the server's status;
+# SIGTERM/SIGINT are forwarded to both so `docker stop` is clean.
+#
+# POSIX sh (the image has no bash). Endpoints/DB come from the environment.
+set -eu
+
+SERVER_SOCK="${AIMEE_SERVER_SOCK:-/var/lib/aimee/aimee-server.sock}"
+server_pid=""
+
+. /usr/local/bin/webchat-lib.sh
+
+log() { printf '[server-entrypoint] %s\n' "$*"; }
+
+shutdown() {
+    [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
+    webchat_stop
+}
+trap 'shutdown' TERM INT
+
+# Browser UI (root, PAM). Supplementary — a webchat crash must not take the
+# container down; the server is the contract.
+webchat_start
+
+log "starting aimee-server (socket=$SERVER_SOCK) as user aimee"
+runuser -u aimee -- aimee-server --socket="$SERVER_SOCK" &
+server_pid=$!
+
+wait "$server_pid"
+status=$?
+log "aimee-server exited (status $status); shutting down webchat"
+shutdown
+exit "$status"

--- a/deploy/container/webchat-lib.sh
+++ b/deploy/container/webchat-lib.sh
@@ -1,0 +1,69 @@
+# webchat-lib.sh — POSIX sh helpers to bootstrap + launch aimee-webchat inside a
+# container. Sourced (not executed) by the image entrypoints, which run as root.
+#
+# aimee-webchat is the Go browser service. It is co-located with aimee-server in
+# the same image and shares AIMEE_HOME, so its Unix-socket transports line up
+# automatically:
+#   - chat stream + dashboard RPC  -> $AIMEE_HOME/aimee-http.sock  (server /v1 UDS)
+#   - legacy NDJSON fallback        -> $AIMEE_HOME/aimee-server.sock
+#   - OpenAI-proxy bearer            -> $AIMEE_HOME/server.token
+# Passing --socket "$AIMEE_HOME/aimee-server.sock" makes webchat derive all three
+# from that directory.
+#
+# PAM (pam_unix) reads /etc/shadow, so webchat must run as root; the entrypoint
+# therefore starts as root, runs webchat here, and drops aimee-server/kb to the
+# unprivileged "aimee" user separately.
+
+WEBCHAT_PORT="${AIMEE_WEBCHAT_PORT:-8443}"
+WEBCHAT_HOME="${AIMEE_HOME:-/var/lib/aimee}"
+WEBCHAT_SPA="${AIMEE_WEBCHAT_SPA:-/usr/local/share/aimee-webchat/index.html}"
+webchat_pid=""
+
+webchat_log() { printf '[webchat] %s\n' "$*"; }
+
+# webchat scopes its user-management surface to a named OS group (it constructs
+# auth.NewUserManager("aimee")). Adding the bootstrap account to that group makes
+# it visible/manageable in the dashboard; login itself is PAM-only and does not
+# require the group.
+WEBCHAT_GROUP="${AIMEE_WEBCHAT_GROUP:-aimee}"
+
+# Create (or update) the bootstrap login user from env. PAM authenticates browser
+# logins against a real OS user, so without this no one can sign in. Unset
+# credentials are tolerated: webchat still serves (login page up), it just has no
+# account until an operator provisions one.
+webchat_bootstrap_user() {
+    _wc_user="${AIMEE_WEBCHAT_USER:-}"
+    _wc_pass="${AIMEE_WEBCHAT_PASSWORD:-}"
+    if [ -z "$_wc_user" ] || [ -z "$_wc_pass" ]; then
+        webchat_log "AIMEE_WEBCHAT_USER/AIMEE_WEBCHAT_PASSWORD unset; skipping login bootstrap (no account can sign in until one is provisioned)"
+        return 0
+    fi
+    getent group "$WEBCHAT_GROUP" >/dev/null 2>&1 || groupadd --system "$WEBCHAT_GROUP"
+    if id "$_wc_user" >/dev/null 2>&1; then
+        # Existing user (e.g. the service account): just ensure group membership.
+        usermod --append --groups "$WEBCHAT_GROUP" "$_wc_user" 2>/dev/null || true
+    else
+        webchat_log "creating login user '$_wc_user'"
+        useradd --create-home --shell /usr/sbin/nologin --groups "$WEBCHAT_GROUP" "$_wc_user"
+    fi
+    printf '%s:%s\n' "$_wc_user" "$_wc_pass" | chpasswd
+    webchat_log "login user '$_wc_user' ready (group $WEBCHAT_GROUP)"
+}
+
+# Launch aimee-webchat in the background (as root, for PAM). Self-signed TLS on
+# :8443 is auto-generated under AIMEE_HOME and persists on the data volume.
+webchat_start() {
+    webchat_bootstrap_user
+    webchat_log "starting aimee-webchat on :$WEBCHAT_PORT (https), socket=$WEBCHAT_HOME/aimee-server.sock"
+    HOME=/root aimee-webchat \
+        --port "$WEBCHAT_PORT" \
+        --socket "$WEBCHAT_HOME/aimee-server.sock" \
+        --db "$WEBCHAT_HOME/webchat.db" \
+        --spa "$WEBCHAT_SPA" &
+    webchat_pid=$!
+}
+
+# Best-effort teardown, called from the entrypoint's shutdown trap.
+webchat_stop() {
+    [ -n "$webchat_pid" ] && kill "$webchat_pid" 2>/dev/null || true
+}

--- a/webchat/api.go
+++ b/webchat/api.go
@@ -58,34 +58,79 @@ func (s *server) socketCallForRequest(r *http.Request, req map[string]any) (map[
 	return s.rpcV1Call(ctx, req)
 }
 
-// rpcV1Call dispatches a unary RPC over aimee-server's /v1 HTTP transport
-// (POST /v1/rpc over the UDS), the cutover from the legacy NDJSON socket. The
-// bridge echoes the dispatch response byte-for-byte (the server's NDJSON↔/v1
-// parity gate proves this), so the decoded result is identical to the old
-// socket path; the UDS is filesystem-trusted, so no bearer is needed. If the
-// /v1 HTTP listener is unreachable (transport error), it falls back to the
-// NDJSON socket so webchat keeps working on socket-only servers — WP3.4 drops
-// the fallback once /v1 is always-on.
+// methodRoute is the first-class /v1 route backing a dispatch method.
+type methodRoute struct {
+	verb string
+	path string
+}
+
+// methodRoutes maps each dispatch method webchat calls to its first-class /v1
+// route. The server retired the generic POST /v1/rpc bridge once every method
+// gained a real route (src/server/server_http_routes.inc); these mirror that
+// table. GET routes take no body; POST routes carry their args in the body. The
+// server's rh_dispatch_op returns the dispatch envelope ({status,data,...})
+// byte-for-byte, so every caller's response parsing is unchanged.
+var methodRoutes = map[string]methodRoute{
+	// Dashboard read views (GET, no args).
+	"dashboard.all":            {http.MethodGet, "/v1/dashboard/all"},
+	"dashboard.delegations":    {http.MethodGet, "/v1/dashboard/delegations"},
+	"dashboard.metrics":        {http.MethodGet, "/v1/dashboard/metrics"},
+	"dashboard.logs":           {http.MethodGet, "/v1/dashboard/logs"},
+	"dashboard.plans":          {http.MethodGet, "/v1/dashboard/plans"},
+	"dashboard.traces":         {http.MethodGet, "/v1/dashboard/traces"},
+	"dashboard.plugins":        {http.MethodGet, "/v1/dashboard/plugins"},
+	"dashboard.memory_stats":   {http.MethodGet, "/v1/dashboard/memory_stats"},
+	"dashboard.onboard":        {http.MethodGet, "/v1/dashboard/onboard"},
+	"agent.list":               {http.MethodGet, "/v1/agent/list"},
+	"collab_rules.list":        {http.MethodGet, "/v1/collab_rules"},
+	"collab_rules.list_active": {http.MethodGet, "/v1/collab_rules/active"},
+	// Mutations + arg-bearing calls (POST, body carries the args; the server
+	// overrides the body's method from the matched route).
+	"collab_rules.approve":    {http.MethodPost, "/v1/collab_rules/approve"},
+	"collab_rules.reject":     {http.MethodPost, "/v1/collab_rules/reject"},
+	"collab_rules.retire":     {http.MethodPost, "/v1/collab_rules/retire"},
+	"lsp.diagnostics_summary": {http.MethodPost, "/v1/lsp/diagnostics_summary"},
+	"index.list":              {http.MethodPost, "/v1/index/list"},
+	"mcp.call":                {http.MethodPost, "/v1/mcp/call"},
+}
+
+// rpcV1Call dispatches a unary RPC over aimee-server's first-class /v1 HTTP
+// routes (resolved from the request's method via methodRoutes) over the UDS.
+// rh_dispatch_op returns the dispatch envelope byte-for-byte, so the decoded
+// result is identical to the legacy NDJSON socket; the UDS is filesystem-trusted,
+// so no bearer is needed. An unmapped method or a genuine transport error falls
+// back to the NDJSON socket, so webchat still works against an older socket-only
+// server.
 func (s *server) rpcV1Call(ctx context.Context, req map[string]any) (map[string]json.RawMessage, error) {
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, err
+	method, _ := req["method"].(string)
+	route, ok := methodRoutes[method]
+	if !ok {
+		return socketCallContext(ctx, s.cfg.socketPath, req)
 	}
-	st, data, err := s.v1Request(ctx, http.MethodPost, "/v1/rpc", body)
+
+	var body []byte
+	if route.verb != http.MethodGet {
+		var err error
+		if body, err = json.Marshal(req); err != nil {
+			return nil, err
+		}
+	}
+
+	st, data, err := s.v1Request(ctx, route.verb, route.path, body)
 	if err != nil {
 		return socketCallContext(ctx, s.cfg.socketPath, req)
 	}
 	var msg map[string]json.RawMessage
 	if len(data) > 0 {
 		if uerr := json.Unmarshal(data, &msg); uerr != nil {
-			return nil, fmt.Errorf("decode /v1/rpc response: %w", uerr)
+			return nil, fmt.Errorf("decode %s response: %w", route.path, uerr)
 		}
 	}
 	if st != http.StatusOK {
 		if rerr := rpcError(msg); rerr != nil {
 			return nil, rerr
 		}
-		return nil, fmt.Errorf("/v1/rpc status %d", st)
+		return nil, fmt.Errorf("%s status %d", route.path, st)
 	}
 	if rerr := rpcError(msg); rerr != nil {
 		return nil, rerr

--- a/webchat/chat_test.go
+++ b/webchat/chat_test.go
@@ -153,14 +153,14 @@ func TestHandleOpenAIModelsReturnsOpenAICompatibleList(t *testing.T) {
 }
 
 // TestRPCV1CallDispatchesOverV1 proves the unary RPC path (socketCallForRequest
-// → rpcV1Call) now goes over POST /v1/rpc, injecting the method into the body
-// and decoding the bridge's byte-identical dispatch response.
+// → rpcV1Call) resolves a GET-backed method to its first-class /v1 route (no
+// body) and decodes the dispatch envelope returned byte-for-byte by the server's
+// rh_dispatch_op.
 func TestRPCV1CallDispatchesOverV1(t *testing.T) {
-	var gotMethod, gotPath, gotBody string
+	var gotMethod, gotPath string
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/rpc", func(w http.ResponseWriter, r *http.Request) {
-		b, _ := io.ReadAll(r.Body)
-		gotMethod, gotPath, gotBody = r.Method, r.URL.Path, string(b)
+	mux.HandleFunc("/v1/agent/list", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod, gotPath = r.Method, r.URL.Path
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"status":"ok","agents":[{"name":"aimee"}]}`)
 	})
@@ -171,14 +171,44 @@ func TestRPCV1CallDispatchesOverV1(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rpcV1Call: %v", err)
 	}
-	if gotMethod != http.MethodPost || gotPath != "/v1/rpc" {
-		t.Fatalf("dispatched %s %s, want POST /v1/rpc", gotMethod, gotPath)
-	}
-	if !strings.Contains(gotBody, `"agent.list"`) {
-		t.Fatalf("request body missing method: %q", gotBody)
+	if gotMethod != http.MethodGet || gotPath != "/v1/agent/list" {
+		t.Fatalf("dispatched %s %s, want GET /v1/agent/list", gotMethod, gotPath)
 	}
 	if _, ok := resp["agents"]; !ok {
 		t.Fatalf("decoded response missing agents: %v", resp)
+	}
+}
+
+// TestRPCV1CallForwardsBodyForPOSTRoute proves a POST-backed method reaches its
+// first-class route and forwards the request body (args) — e.g. mcp.call carries
+// its tool/arguments.
+func TestRPCV1CallForwardsBodyForPOSTRoute(t *testing.T) {
+	var gotMethod, gotPath, gotBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/mcp/call", func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		gotMethod, gotPath, gotBody = r.Method, r.URL.Path, string(b)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"status":"ok","structuredContent":{"sessions":[]}}`)
+	})
+	cfg := startFakeV1(t, mux)
+	s := &server{cfg: cfg}
+
+	resp, err := s.rpcV1Call(context.Background(), map[string]any{
+		"method": "mcp.call", "tool": "session_list",
+		"arguments": map[string]any{"limit": 100},
+	})
+	if err != nil {
+		t.Fatalf("rpcV1Call: %v", err)
+	}
+	if gotMethod != http.MethodPost || gotPath != "/v1/mcp/call" {
+		t.Fatalf("dispatched %s %s, want POST /v1/mcp/call", gotMethod, gotPath)
+	}
+	if !strings.Contains(gotBody, `"session_list"`) {
+		t.Fatalf("request body missing tool args: %q", gotBody)
+	}
+	if _, ok := resp["structuredContent"]; !ok {
+		t.Fatalf("decoded response missing structuredContent: %v", resp)
 	}
 }
 
@@ -186,7 +216,7 @@ func TestRPCV1CallDispatchesOverV1(t *testing.T) {
 // into an error (matching the legacy socket path's rpcError behaviour).
 func TestRPCV1CallSurfacesServerError(t *testing.T) {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/rpc", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/v1/agent/list", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		fmt.Fprint(w, `{"status":"error","message":"nope"}`)
 	})


### PR DESCRIPTION
Promote the webchat Docker auto-deploy + dashboard `/v1` migration from `testing` to `main`.

Squashed as #20 on testing (`75153be`). All CI green, including `e2e-docker` (builds + boots the server/combined/standalone images with webchat across T1–T4). Triggers the auto-version + image release on merge.
