### PR TITLE
fix(server): Codex direct-connect — case-insensitive Content-Length

### DIFF
--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1501,13 +1501,17 @@ static void handle_conn(int fd, int is_tcp)
       }
    }
 
-   /* Body via Content-Length (read remainder after the header block). */
+   /* Body via Content-Length (read remainder after the header block). Header
+    * names are case-insensitive (RFC 7230 §3.2): clients such as the Codex CLI
+    * (reqwest/hyper) send a lowercase `content-length`, so match it via the
+    * case-insensitive header lookup rather than a literal strstr — otherwise the
+    * body is never read and large POSTs misparse as empty. */
    char *body = NULL;
    int body_len = 0;
-   const char *cl = strstr(buf, "\r\nContent-Length: ");
-   if (cl)
+   char clbuf[32] = "";
+   if (http_header(buf, "Content-Length", clbuf, sizeof(clbuf)))
    {
-      body_len = atoi(cl + 18);
+      body_len = atoi(clbuf);
       if (body_len < 0)
          body_len = 0;
       if (body_len > SHTTP_MAX_BODY)


### PR DESCRIPTION
## Fix: Codex direct-connect (case-insensitive Content-Length)

HTTP header names are case-insensitive (RFC 7230 §3.2). aimee's request-body
reader matched `\r\nContent-Length: ` with a **case-sensitive** `strstr`, so
clients sending a lowercase header name — notably the **Codex CLI**
(reqwest/hyper sends `content-length`) — were read as having **no body**. Large
POSTs (e.g. `/v1/responses` turns) then misparsed as empty input and 400'd, so
pointing Codex *directly* at aimee failed (it only worked through a
header-normalizing proxy).

Fix: use the existing case-insensitive `http_header()` lookup (already used for
`Authorization`) to read `Content-Length`.

### Validation (on pve)
Real `codex` 0.135.0 driven **directly** at aimee-server now completes the full
two-turn tool loop: `GET /v1/models -> 200` + two `POST /v1/responses -> 200
(stream)` → Codex executes the relayed tool call and renders the final answer.
`aimee git verify` (verify-local) passes; full unit suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
