### PR TITLE
Promote: Codex direct-connect Content-Length fix

### DIFF
--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1501,13 +1501,17 @@ static void handle_conn(int fd, int is_tcp)
       }
    }
 
-   /* Body via Content-Length (read remainder after the header block). */
+   /* Body via Content-Length (read remainder after the header block). Header
+    * names are case-insensitive (RFC 7230 §3.2): clients such as the Codex CLI
+    * (reqwest/hyper) send a lowercase `content-length`, so match it via the
+    * case-insensitive header lookup rather than a literal strstr — otherwise the
+    * body is never read and large POSTs misparse as empty. */
    char *body = NULL;
    int body_len = 0;
-   const char *cl = strstr(buf, "\r\nContent-Length: ");
-   if (cl)
+   char clbuf[32] = "";
+   if (http_header(buf, "Content-Length", clbuf, sizeof(clbuf)))
    {
-      body_len = atoi(cl + 18);
+      body_len = atoi(clbuf);
       if (body_len < 0)
          body_len = 0;
       if (body_len > SHTTP_MAX_BODY)


### PR DESCRIPTION
Promote the Codex direct-connect fix (#27) to main.

Reads `Content-Length` case-insensitively so the Codex CLI (reqwest sends a
lowercase `content-length`) can POST directly to aimee — without this, large
`/v1/responses` turns were read as empty and 400'd, so codex only worked through
a header-normalizing proxy. Validated on pve: real codex 0.135.0 completes the
full tool loop driven directly at aimee-server. verify-local passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
