### PR TITLE
fix(delegate): stop starving the per-call timeout into spurious provider-unreachable

### DIFF
--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -7,18 +7,23 @@
 /* Forward declaration for cJSON (used by plan API). */
 struct cJSON;
 
-#define MAX_AGENTS                 16
-#define MAX_AGENT_ROLES            16
-#define MAX_AGENT_NAME             64
-#define MAX_ENDPOINT_LEN           512
-#define MAX_MODEL_LEN              128
-#define MAX_API_KEY_LEN            4096
-#define MAX_AUTH_CMD_LEN           512
-#define MAX_AGENT_CREDENTIALS      8
-#define MAX_CRED_NAME_LEN          32
-#define MAX_CRED_ENV_VAR_LEN       64
-#define MAX_FALLBACK               8
-#define AGENT_DEFAULT_TIMEOUT_MS   180000
+#define MAX_AGENTS               16
+#define MAX_AGENT_ROLES          16
+#define MAX_AGENT_NAME           64
+#define MAX_ENDPOINT_LEN         512
+#define MAX_MODEL_LEN            128
+#define MAX_API_KEY_LEN          4096
+#define MAX_AUTH_CMD_LEN         512
+#define MAX_AGENT_CREDENTIALS    8
+#define MAX_CRED_NAME_LEN        32
+#define MAX_CRED_ENV_VAR_LEN     64
+#define MAX_FALLBACK             8
+#define AGENT_DEFAULT_TIMEOUT_MS 180000
+/* Floor for the per-call HTTP timeout inside the multi-turn tool loop. Once the
+ * remaining loop budget drops below this, the loop stops cleanly instead of
+ * issuing a doomed short-timeout call that the provider-health tracker would
+ * misread as "provider unreachable" (see posix/agent_runtime.c). */
+#define AGENT_LOOP_MIN_CALL_MS     60000
 #define AGENT_DEFAULT_MAX_TOKENS   4096
 #define MAX_EXEC_ROLES             8
 #define MAX_EXEC_PROMPT_LEN        4096
@@ -42,6 +47,25 @@ struct cJSON;
 #define AGENT_MAX_CHECKPOINTS      32
 #define AGENT_MAX_EVAL_TASKS       64
 #define AGENT_MAX_COORD_AGENTS     4
+
+/* Per-call HTTP timeout for one turn of the multi-turn tool loop.
+ *   agent_timeout_ms  configured per-call timeout (also the per-call cap)
+ *   total_timeout_ms  whole-loop budget (typically agent_timeout_ms * N)
+ *   elapsed_ms        wall-clock already spent in the loop
+ * Returns the timeout to use, or -1 when the remaining budget is too small for a
+ * viable call (the caller should stop the loop cleanly rather than issue a
+ * doomed short-timeout call that the provider-health tracker misreads as
+ * "provider unreachable"). Pure function — unit-tested in test_agent.c. */
+static inline int agent_loop_per_call_timeout_ms(int agent_timeout_ms, int total_timeout_ms,
+                                                 int elapsed_ms)
+{
+   int remaining = total_timeout_ms - elapsed_ms;
+   int min_call =
+       agent_timeout_ms < AGENT_LOOP_MIN_CALL_MS ? agent_timeout_ms : AGENT_LOOP_MIN_CALL_MS;
+   if (remaining < min_call)
+      return -1;
+   return agent_timeout_ms < remaining ? agent_timeout_ms : remaining;
+}
 
 typedef struct
 {

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -709,10 +709,24 @@ native_provider_http:
       /* Log request trace */
       agent_trace_log(0, turn, "request", body, NULL, NULL, NULL, NULL);
 
-      /* POST with automatic retry on transient errors */
+      /* POST with automatic retry on transient errors. The per-call timeout is
+       * capped by the remaining loop budget so a single model call can't blow
+       * the total -- but once too little budget remains for a viable call,
+       * issuing one anyway just yields a short-timeout read failure (HTTP -1)
+       * that the provider-health tracker misreads as "provider unreachable" and
+       * aborts the whole delegate (the provider is fine, we starved the call).
+       * agent_loop_per_call_timeout_ms returns -1 in that case so we stop the
+       * loop cleanly with a partial result instead. */
       char *response_body = NULL;
-      int remaining = total_timeout_ms - elapsed_ms;
-      int per_call = (agent->timeout_ms < remaining) ? agent->timeout_ms : remaining;
+      int per_call =
+          agent_loop_per_call_timeout_ms(agent->timeout_ms, total_timeout_ms, elapsed_ms);
+      if (per_call < 0)
+      {
+         snprintf(out->error, sizeof(out->error), "tool loop budget exhausted (%dms of %dms used)",
+                  elapsed_ms, total_timeout_ms);
+         free(body);
+         break;
+      }
 
       config_t retry_cfg;
       config_load(&retry_cfg);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1795,6 +1795,28 @@ static void test_agent_route_health_filter(void)
    assert(agent_route(&cfg, "summarize") == &cfg.agents[0]);
 }
 
+/* Regression: the multi-turn tool loop must not issue a model call with a
+ * starved (sub-viable) timeout when its budget is nearly exhausted -- that
+ * yields an HTTP -1 read failure that gets misreported as "provider
+ * unreachable" and marks the provider degraded. agent_loop_per_call_timeout_ms
+ * returns -1 instead so the loop stops cleanly. */
+static void test_agent_loop_per_call_timeout(void)
+{
+   /* Early in the loop: full per-call timeout. */
+   assert(agent_loop_per_call_timeout_ms(180000, 720000, 0) == 180000);
+   /* Mid loop: capped to the remaining budget, still >= the viable floor. */
+   assert(agent_loop_per_call_timeout_ms(180000, 720000, 660000) == 60000);
+   /* Budget nearly gone (only 2.2s left -- the real-world failure): stop, do
+    * NOT issue a doomed 2262ms call. */
+   assert(agent_loop_per_call_timeout_ms(180000, 720000, 717738) == -1);
+   /* Exactly at the floor is still viable; one below it stops. */
+   assert(agent_loop_per_call_timeout_ms(180000, 720000, 660000) == 60000);
+   assert(agent_loop_per_call_timeout_ms(180000, 720000, 660001) == -1);
+   /* Small configured timeout: the floor never exceeds agent_timeout_ms. */
+   assert(agent_loop_per_call_timeout_ms(10000, 40000, 0) == 10000);
+   assert(agent_loop_per_call_timeout_ms(10000, 40000, 35000) == -1);
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -1809,6 +1831,7 @@ int main(void)
    test_agent_has_role();
    test_agent_find();
    test_agent_route();
+   test_agent_loop_per_call_timeout();
    test_agent_route_health_filter();
    test_agent_route_with_caps_honors_tools_enabled();
    test_current_code_only_role_tool_policy();


### PR DESCRIPTION
## Summary
Long-running delegates aborted partway with `provider 'minimax' unreachable (connection failed or local HTTP client unavailable)` and the provider got marked **degraded** — even though the provider was reachable the whole time. This was the recurring "delegate dies mid-run" problem.

## Root cause
The multi-turn tool loop in `posix/agent_runtime.c` caps each model call's HTTP timeout at the **remaining loop budget** (`total_timeout_ms - elapsed_ms`, where `total = agent->timeout_ms * 4`). As a long run nears its total budget, that remaining shrinks toward zero, so the final calls get sub-second timeouts. The model can't answer that fast → read times out → `HTTP -1` → classified `PROVIDER_ERR_NETWORK` → surfaced as "provider unreachable", and `provider_catalog` marks the agent degraded (which can poison later jobs).

Server-log smoking gun (one delegate run): the per-call `timeout` counts **down** `94816ms → 91853 → … → 6022 → 2262ms`, then three `HTTP -1` retries at `timeout=2262ms`, then `agent 'minimax' health → degraded`.

## Fix
Floor the per-call timeout. New pure helper `agent_loop_per_call_timeout_ms()` returns `-1` once the remaining budget drops below a viable-call floor (`AGENT_LOOP_MIN_CALL_MS = 60s`, never above the configured per-call timeout). The loop then stops cleanly with an honest `tool loop budget exhausted` partial **instead of issuing a doomed short-timeout call**. Because no doomed call is made, the provider is never spuriously marked degraded.

- `headers/agent_types.h` — `AGENT_LOOP_MIN_CALL_MS` + `agent_loop_per_call_timeout_ms` (pure, inline)
- `posix/agent_runtime.c` — use the helper; clean break on budget exhaustion
- `tests/test_agent.c` — unit test incl. the real-world "2262ms left" case

## Verification
- `make unit-tests`, `make lint` — green; new `test_agent_loop_per_call_timeout` passes (covers early/mid/exhausted/floor-boundary/small-config cases).
- Root-caused directly from the production `server.log`.
- Note: this does not extend the total budget (still `agent.timeout_ms * 4`); a task that genuinely needs more time now ends with an honest "budget exhausted" partial rather than a misleading "provider unreachable". Raise `timeout_ms` in `agents.json` for longer runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
