### PR TITLE
ci: publish the aimee-embedder image

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -71,6 +71,7 @@ jobs:
           - { name: aimee-server,    dockerfile: Dockerfile.server }
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
+          - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
         platform:
           - { arch: amd64, runner: ubuntu-latest }
           - { arch: arm64, runner: ubuntu-24.04-arm }
@@ -125,7 +126,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Adds **aimee-embedder** (`Dockerfile.embedder`) to the `publish-images` build + manifest matrices, so it publishes to `ghcr.io/<owner>/aimee-embedder` (`:version` and `:latest`) on every release tag, alongside `aimee-server`, `aimee-kb`, and `aimee-server-kb`.

## Why

The self-contained aimee SmoothNAS plugins (`aimee-kb` / `aimee-combined`, see RakuenSoftware/smoothnas-plugin-aimee#2) now reference `ghcr.io/rakuensoftware/aimee-embedder:latest` as a bundled service instead of building the embedder from source in compose. That requires a published image.

## Change

Two one-line matrix additions in `.github/workflows/publish-images.yml`:
- build job: `{ name: aimee-embedder, dockerfile: Dockerfile.embedder }`
- merge job: add `aimee-embedder` to the multi-arch manifest list

Builds amd64 + arm64 on native runners and assembles the multi-arch manifest, identical to the other three images. The embedder Dockerfile already carries its own `HEALTHCHECK` on `/health`.

## Note

The unused `AIMEE_VERSION` build-arg is passed to all images (Docker ignores it for the embedder, which doesn't declare the ARG) — harmless, keeps the matrix uniform.
