### PR TITLE
docs: promote any-model / portable-memory pitch + ingress to main

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -48,9 +48,13 @@ it as a lookup reference afterward.
 
 ## 1. What aimee is
 
-aimee gives your AI coding tool a memory. It is a local-first layer that sits
-between you and tools like Claude Code, Gemini CLI, Codex CLI, Mistral Vibe, and
-GitHub Copilot, and adds three things they lack:
+aimee gives your AI coding tool a memory, and lets you run that tool on any
+model you like. It is a local-first layer that sits between you and tools like
+Claude Code, Codex, OpenCode, Gemini CLI, Mistral Vibe, and GitHub Copilot. One
+UI, any model, and a memory that travels with you between every model and
+provider, so switching never starts from zero and is never locked to a vendor
+(see [§25, Integrations](#25-integrations) for pointing a tool's front end at
+aimee). On top of that it adds three things your tools lack:
 
 - **Persistent memory** that compounds across sessions and across tools, so your
   AI starts every session already knowing your infrastructure, conventions,
@@ -1184,8 +1188,9 @@ HTTP API generated from [`api/openapi-v1.yaml`](api/openapi-v1.yaml).
 | Tool | Integration | Setup |
 |------|-------------|-------|
 | Claude Code | Hooks + MCP, or any primary model via the Anthropic ingress | `./install.sh` / `aimee claude-proxy enable` |
+| Codex CLI | Hooks + MCP + local plugin, or any primary model via the Responses ingress | `./install.sh` / `~/.codex/config.toml` |
+| OpenCode | TUI front end (`opencode attach`), any primary model via the OpenAI-compatible ingress | `./install.sh` |
 | Gemini CLI | Hooks | `./install.sh` |
-| Codex CLI | Hooks + MCP + local plugin | `./install.sh` |
 | Mistral Vibe | Provider-CLI primary + subscription-plan delegates (incl. `mistral-plan`) | `aimee agent setup mistral-plan` |
 | GitHub Copilot | MCP server | `./install.sh` |
 | VS Code | MCP tools in Copilot Chat agent mode, or aimee as an OpenAI-compatible model via the `/v1` API | [docs/VSCODE.md](docs/VSCODE.md) |
@@ -1228,6 +1233,46 @@ ANTHROPIC_BASE_URL=http://127.0.0.1:8910 ANTHROPIC_AUTH_TOKEN=<bearer> claude
 
 (The server must be reachable over HTTP — loopback TCP with a bearer, or a
 remote `AIMEE_SERVER_URL`.)
+
+### Codex on any primary model (Responses ingress)
+
+aimee-server also exposes the OpenAI Responses API at `POST /v1/responses` (with
+SSE streaming), the sibling of the Claude Code ingress above. To the open-source
+Codex CLI/TUI, aimee then behaves exactly like any other model: point Codex's
+model provider at aimee and it is indistinguishable from `gpt-5.x`. Codex drives
+its normal agent loop, aimee runs the turn on a registered primary-agent model
+selected by the request `model` field, and aimee participates in Codex's tool
+loop (it emits `function_call` items, Codex executes them in the user's
+workspace, and returns `function_call_output`). `GET /v1/models` lists the
+registered primary-agent models so Codex can list and switch models from its UI.
+
+Add a provider to `~/.codex/config.toml` and select it:
+
+```toml
+[model_providers.aimee]
+name = "aimee"
+base_url = "http://<aimee-host>:<port>/v1"
+wire_api = "responses"
+env_key = "AIMEE_API_KEY"          # aimee loopback bearer
+requires_openai_auth = false
+
+model_provider = "aimee"
+model = "aimee"                     # or any slug from GET /v1/models
+```
+
+Like the Anthropic ingress, this is a stateless wire-format proxy: Codex keeps
+owning its prompt, history, and tool execution; aimee translates the wire format
+and swaps the model. Switch models with `aimee primary <agent>`.
+
+### Any OpenAI-compatible front end (OpenCode, VS Code, custom clients)
+
+Tools that speak the OpenAI Chat Completions wire format point at
+`POST /v1/chat/completions` (SSE streaming supported) and run on aimee's primary
+agent the same way. This covers OpenCode (also launchable as a TUI through
+`opencode attach`), VS Code configured with aimee as an OpenAI-compatible model
+(see [docs/VSCODE.md](docs/VSCODE.md)), and any custom client. Whatever front end
+you choose, the memory, guardrails, and delegation are identical because they
+live in the shared server and KB, not in the tool.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # aimee
 
-**Your company's collective memory, that learns.** aimee distills what your whole organization knows, across engineering, product, sales, support, and operations, into one self-learning knowledge base, draws conclusions across every domain, and routes work to the cheapest capable model to keep costs down. Zero cloud dependencies, sub-10ms.
+**One UI. Any model. Memory that travels with you.** aimee is a single front end for every AI coding tool and model you use: drive it from Claude Code, Codex, OpenCode, or the built-in browser webchat, and run any turn on any model from any provider, Claude, GPT, Gemini, Mistral, MiniMax, or a local model. Your accumulated memory, preferences, and hard-won context move with you between every model and provider, so switching never starts from zero and is never locked to a vendor. Zero cloud dependencies, sub-10ms.
 
-It **starts as persistent memory for your AI coding tool**, one install, and every session starts knowing what the last one learned, adding memory, safety guardrails, and cost-saving delegation to Claude Code, Gemini CLI, Codex CLI, Mistral Vibe, and GitHub Copilot. The *same substrate* scales up to a company-wide knowledge base. See **[How aimee learns](docs/KNOWLEDGE.md)**.
+**It is also your company's collective memory, that learns.** aimee distills what your whole organization knows, across engineering, product, sales, support, and operations, into one self-learning knowledge base, draws conclusions across every domain, and routes work to the cheapest capable model to keep costs down.
+
+It **starts as persistent memory for your AI coding tool**, one install, and every session starts knowing what the last one learned, adding memory, safety guardrails, and cost-saving delegation to Claude Code, Gemini CLI, Codex CLI, OpenCode, Mistral Vibe, and GitHub Copilot. Point your existing tool's front end at aimee and every turn runs on whatever primary model you choose: **you can use Claude Code with any model or provider now.** The *same substrate* scales up to a company-wide knowledge base. See **[How aimee learns](docs/KNOWLEDGE.md)**.
 
 Four shipped artifacts: `aimee`, `aimee-webchat`, `aimee-server`, and `aimee-kb`. Client and webchat talk only to the local `aimee-server`; local runtime information stays in server-owned DB1, while knowledge lives behind `aimee-kb` in DB2, which can be a local or shared Postgres service. Zero cloud dependencies. The core services are C; the browser webchat is the standalone Go service in `webchat/`. Starts in under 10ms.
 
@@ -19,7 +21,7 @@ aimee sits between you and your AI tool, intercepting actions through hooks and 
 ```mermaid
 graph TB
     User["You"]
-    PA["Primary Agent<br/>Claude Code / Gemini CLI / Codex CLI / Vibe"]
+    PA["Primary Agent<br/>Claude Code / Codex / OpenCode / Gemini CLI / Vibe"]
     Hooks["aimee hooks<br/>SessionStart &bull; PreToolUse &bull; PostToolUse"]
     Memory[("Memory<br/>4-tier, scoped search")]
     Guard["Guardrails<br/>Sensitive file blocking<br/>Anti-pattern detection<br/>Planning mode"]
@@ -70,16 +72,56 @@ Each session gets its own git worktree, state file, and branch. Run two sessions
 
 ### Works with what you already use
 
-| Tool | Integration | Setup |
-|------|------------|-------|
-| Claude Code | Full hook support + MCP | `./install.sh` |
-| Gemini CLI | Full hook support | `./install.sh` |
-| Codex CLI | Full hook support + MCP + local plugin | `./install.sh` |
-| Mistral Vibe | Provider-CLI primary and subscription-plan delegates, including `mistral-plan` | `aimee agent setup mistral-plan` |
-| GitHub Copilot | MCP server | `./install.sh` |
-| VS Code | MCP tools in Copilot Chat, or aimee as an OpenAI-compatible model | [VS Code guide](docs/VSCODE.md) |
+| Tool | Integration | Run on any model | Setup |
+|------|------------|------------------|-------|
+| Claude Code | Full hook support + MCP | Yes, via the Anthropic ingress (`/v1/messages`) | `./install.sh` / `aimee claude-proxy enable` |
+| Codex CLI | Full hook support + MCP + local plugin | Yes, via the OpenAI Responses ingress (`/v1/responses`) | `./install.sh` |
+| OpenCode | TUI front end (`opencode attach`) | Yes, via the OpenAI-compatible ingress | `./install.sh` |
+| Gemini CLI | Full hook support | Provider CLI | `./install.sh` |
+| Mistral Vibe | Provider-CLI primary and subscription-plan delegates, including `mistral-plan` | Provider CLI | `aimee agent setup mistral-plan` |
+| GitHub Copilot | MCP server | Via the OpenAI-compatible model | `./install.sh` |
+| VS Code | MCP tools in Copilot Chat, or aimee as an OpenAI-compatible model | Yes, via `/v1/chat/completions` | [VS Code guide](docs/VSCODE.md) |
 
 Switch tools any time. aimee keeps all your memory and context.
+
+### Use your front end on any model
+
+aimee-server speaks the same wire formats your tools already use, so you can point
+a tool's front end at aimee and run every turn on aimee's configured **primary
+agent** (any provider's model) instead of the tool's built-in vendor. It is a
+stateless wire-format proxy: the tool keeps owning its prompt, history, and tools
+(tool execution stays client-side); aimee translates the wire format and swaps the
+model. Switch models any time with `aimee primary <agent>`, and `GET /v1/models`
+lists what is selectable.
+
+**Claude Code on any model** (Anthropic Messages ingress, `POST /v1/messages`):
+
+```bash
+aimee claude-proxy enable http://127.0.0.1:8910 <server-bearer>
+# one-off, without touching ~/.claude/settings.json:
+ANTHROPIC_BASE_URL=http://127.0.0.1:8910 ANTHROPIC_AUTH_TOKEN=<bearer> claude
+```
+
+**Codex on any model** (OpenAI Responses ingress, `POST /v1/responses`). Add a
+provider to `~/.codex/config.toml` and select it:
+
+```toml
+[model_providers.aimee]
+name = "aimee"
+base_url = "http://<aimee-host>:<port>/v1"
+wire_api = "responses"
+env_key = "AIMEE_API_KEY"          # aimee loopback bearer
+requires_openai_auth = false
+
+model_provider = "aimee"
+model = "aimee"                     # or any slug from GET /v1/models
+```
+
+**OpenCode and any OpenAI-compatible client** point at `POST /v1/chat/completions`
+(SSE streaming supported); see the [Manual](MANUAL.md#25-integrations) and
+[VS Code guide](docs/VSCODE.md) for the OpenAI-endpoint setup. Whatever front end
+you choose, the memory, guardrails, and delegation are the same, because they live
+in the shared server and KB, not in the tool.
 
 ## Performance
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -9,14 +9,15 @@ Status terms used throughout this document:
 
 ## Primary Agent Support
 
-These are the primary AI coding tools that aimee integrates with for memory injection, guardrails, and session management.
+These are the primary AI coding tools that aimee integrates with for memory injection, guardrails, and session management. Tools can also point their front end at aimee's wire-format ingress and run every turn on aimee's configured primary model (any provider), instead of the tool's built-in vendor; see [MANUAL §25](../MANUAL.md#25-integrations).
 
-| Primary agent | Integration points | Tested versions | Support level | Notes |
-|---|---|---:|---|---|
-| Claude Code | `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd` | 1.x | Full | Full hook coverage for session lifecycle and tool interception. |
-| Gemini CLI | `BeforeTool`, `AfterTool`, `SessionStart` | 2.x | Full | Uses Gemini CLI hook model rather than Claude-style hook names. |
-| Codex CLI | `PreToolUse`, `PostToolUse`, `SessionStart`, local plugin, MCP | 1.x | Full | Supports both hook-based integration and MCP-backed tooling. |
-| Mistral Vibe-compatible Mistral | native HTTP adapter using Vibe-compatible defaults | 2.9.6 source-compatible defaults | Expected | Used by Aimee's built-in primary chat and `mistral-plan` delegate route without launching `vibe`. |
+| Primary agent | Integration points | Run on any model (ingress) | Tested versions | Support level | Notes |
+|---|---|---|---:|---|---|
+| Claude Code | `SessionStart`, `PreToolUse`, `PostToolUse`, `SessionEnd` | Anthropic Messages, `POST /v1/messages` | 1.x | Full | Full hook coverage; `aimee claude-proxy enable` reroutes to any primary model. |
+| Codex CLI | `PreToolUse`, `PostToolUse`, `SessionStart`, local plugin, MCP | OpenAI Responses, `POST /v1/responses` | 1.x | Full | Hooks + MCP; `~/.codex/config.toml` model provider runs any primary model, incl. the function-call tool loop. |
+| OpenCode | TUI front end via `opencode attach` | OpenAI-compatible, `POST /v1/chat/completions` | 2.x | Full | Front end onto aimee's primary model over the OpenAI-compatible ingress. |
+| Gemini CLI | `BeforeTool`, `AfterTool`, `SessionStart` | Provider CLI | 2.x | Full | Uses Gemini CLI hook model rather than Claude-style hook names. |
+| Mistral Vibe-compatible Mistral | native HTTP adapter using Vibe-compatible defaults | Provider CLI | 2.9.6 source-compatible defaults | Expected | Used by Aimee's built-in primary chat and `mistral-plan` delegate route without launching `vibe`. |
 
 ## Platform Support
 


### PR DESCRIPTION
Promote the docs pitch + front-end ingress changes from `testing` to `main` (PR #36).

One UI, any model from any provider, and memory that travels between models and providers; plus documenting running Claude Code / Codex / OpenCode on any model via aimee's wire-format ingress.

Docs-only. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
