### PR TITLE
feat(webchat): restore per-user chat tabs from the server (frontend)

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -206,6 +206,63 @@ function saveTabs(tabs: TabData[]): void {
   try { localStorage.setItem(TABS_KEY, JSON.stringify(tabs)); } catch { /* ignore */ }
 }
 
+/* Server-side session persistence (per logged-in user). The conversation lives
+ * on aimee-server keyed by aimeeSid; webchat stores which sessions belong to the
+ * user so tabs survive a browser/laptop crash or a move to another device.
+ * localStorage remains a fast local cache (and holds per-tab message history);
+ * the server is authoritative for *which* tabs exist. */
+
+interface ServerSession {
+  id: string;
+  title?: string;
+  cwd?: string;
+  created_at?: string;
+  last_active?: string;
+}
+
+async function fetchServerSessions(): Promise<ServerSession[]> {
+  try {
+    const r = await fetch('/api/chat/sessions');
+    if (!r.ok) return [];
+    const data = await r.json();
+    return Array.isArray(data) ? (data as ServerSession[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+// mergeServerSessions restores server-persisted sessions the local cache is
+// missing (e.g. after a crash cleared localStorage, or on a fresh device),
+// appending them as message-empty tabs keyed by the stored aimeeSid. Local tabs
+// are never dropped — except a single pristine, unused default tab, which the
+// restored sessions replace so the user does not see a stray empty "Chat".
+function mergeServerSessions(local: TabData[], server: ServerSession[]): TabData[] {
+  const known = new Set(local.map(t => t.aimeeSid).filter(Boolean));
+  const restored: TabData[] = [];
+  for (const s of server) {
+    if (s.id && !known.has(s.id)) {
+      restored.push(normalizeTab({ title: s.title ?? '', messages: [], sid: '', aimeeSid: s.id }, 0));
+      known.add(s.id);
+    }
+  }
+  if (restored.length === 0) return local;
+  const pristineDefault =
+    local.length === 1 && local[0].messages.length === 0 && !local[0].sid;
+  return pristineDefault ? restored : [...local, ...restored];
+}
+
+// forgetServerSession removes a closed tab's session from the server so it does
+// not reappear on the next restore. Best-effort.
+function forgetServerSession(aimeeSid: string): void {
+  if (!aimeeSid) return;
+  try {
+    fetch(`/api/chat/session?sid=${encodeURIComponent(aimeeSid)}`, {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': window._csrf || '' },
+    }).catch(() => {});
+  } catch { /* ignore */ }
+}
+
 function rulesBannerDismissedKey(root: string): string {
   return root ? `${RULES_BANNER_DISMISSED_KEY}:${root}` : RULES_BANNER_DISMISSED_KEY;
 }
@@ -1521,6 +1578,19 @@ export default function Chat() {
     saveTabs(tabs);
   }, [tabs]);
 
+  /* Restore server-persisted sessions on load (per-user, survives a crash or a
+   * move to another device). Runs once; merges in any sessions the local cache
+   * is missing. */
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const server = await fetchServerSessions();
+      if (cancelled || server.length === 0) return;
+      setTabs(prev => mergeServerSessions(prev, server));
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     if (activeIdx >= tabs.length) {
       setActiveIdx(Math.max(0, tabs.length - 1));
@@ -1989,6 +2059,9 @@ export default function Chat() {
   function closeTab(i: number) {
     if (tabs.length <= 1) return;
     detachTabPresence(tabs[i]);
+    // Forget the server-side session so the closed tab does not reappear on the
+    // next restore (best-effort).
+    forgetServerSession(tabs[i]?.aimeeSid ?? '');
     if (i === activeIdx) abortActiveSends();
     setTabs(prev => {
       const next = [...prev];

--- a/webchat/SESSION_PERSISTENCE.md
+++ b/webchat/SESSION_PERSISTENCE.md
@@ -22,9 +22,11 @@ SPA changes described under "Frontend integration" live in that separate repo.
 
 ## Endpoints
 
-### `GET /api/chat/threads`
+### `GET /api/chat/sessions`
 
-Returns the user's sessions, most-recently-active first (bare JSON array):
+Returns the user's sessions, most-recently-active first (bare JSON array).
+(Distinct from `/api/chat/threads`, which is the unrelated, not-yet-implemented
+in-tab conversation-branch surface.)
 
 ```json
 [
@@ -95,7 +97,7 @@ rename, or pre-registering a tab before its first turn.
 
 ## Frontend integration (smoothgui repo)
 
-1. **On app load**, call `GET /api/chat/threads`. Render each entry as a
+1. **On app load**, call `GET /api/chat/sessions`. Render each entry as a
    restorable tab/thread in the sidebar. Clicking one re-opens that
    conversation by reusing its `id` as the `aimee_session_id` on subsequent
    `POST /api/chat/send` calls (aimee-server replays history for that id).
@@ -108,5 +110,16 @@ rename, or pre-registering a tab before its first turn.
    its own id so each persists independently.
 4. **Rename**: `POST /api/chat/session` with `{id, title}`.
 5. **Close/forget a tab**: `DELETE /api/chat/session?sid=<id>`.
-6. The thread endpoints (`/branch`, `/switch-thread`, `/rewind`) remain stubs;
-   full thread-tree management is out of scope for per-user tab restore.
+6. The thread endpoints (`/api/chat/threads`, `/branch`, `/switch-thread`,
+   `/rewind`) remain stubs; in-tab conversation-branch management is a separate
+   feature, out of scope for per-user tab restore.
+
+## Frontend status (aimee/frontend)
+
+The aimee web SPA (`frontend/src/pages/Chat.tsx`) integrates this as of the
+session-frontend change: on mount it fetches `GET /api/chat/sessions` and merges
+any server-side sessions the local `localStorage` cache is missing (restoring
+tabs after a crash or on a fresh device), and `closeTab` issues
+`DELETE /api/chat/session?sid=` so a closed tab does not reappear. `localStorage`
+is retained as a fast local cache (it also holds per-tab message history); the
+server is authoritative for *which* tabs exist.

--- a/webchat/chat.go
+++ b/webchat/chat.go
@@ -311,6 +311,15 @@ func (s *server) handleChatClear(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"status":"ok"}`)
 }
 
+// handleChatThreads is a stub for GET /api/chat/threads (in-tab conversation
+// branching — a separate, not-yet-implemented feature). It returns the empty
+// shape the SPA's ThreadBar expects. The per-user persisted tab list lives at
+// GET /api/chat/sessions (handleChatSessionsList), not here.
+func (s *server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"threads":[],"active_id":0}`)
+}
+
 // handleChatBranch is a stub for POST /api/chat/branch.
 func (s *server) handleChatBranch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")

--- a/webchat/chat_sessions.go
+++ b/webchat/chat_sessions.go
@@ -147,11 +147,12 @@ func (s *server) listChatSessions(username string) ([]chatSession, error) {
 	return out, rows.Err()
 }
 
-// handleChatThreads (GET /api/chat/threads) returns the authenticated user's
-// persisted sessions so the SPA can restore every open tab after a reload or a
-// crash. Shape is a bare JSON array (matching the prior stub) of session
-// objects, newest activity first.
-func (s *server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
+// handleChatSessionsList (GET /api/chat/sessions) returns the authenticated
+// user's persisted sessions so the SPA can restore every open tab after a
+// reload or a crash. Shape is a bare JSON array of session objects, newest
+// activity first. (Distinct from /api/chat/threads, which is the in-tab
+// conversation-branch surface.)
+func (s *server) handleChatSessionsList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	sessions, err := s.listChatSessions(currentUser(r))
 	if err != nil {

--- a/webchat/chat_sessions_test.go
+++ b/webchat/chat_sessions_test.go
@@ -112,14 +112,14 @@ func TestTouchChatSessionScopedByUser(t *testing.T) {
 	}
 }
 
-func TestHandleChatThreadsReturnsUserSessions(t *testing.T) {
+func TestHandleChatSessionsListReturnsUserSessions(t *testing.T) {
 	s := newSessionTestServer(t)
 	_ = s.touchChatSession("alice", "sess-1", "/a", "hello there")
 	_ = s.touchChatSession("bob", "sess-2", "/b", "bob only")
 
 	rr := httptest.NewRecorder()
-	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/threads", nil), "alice")
-	s.handleChatThreads(rr, req)
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/sessions", nil), "alice")
+	s.handleChatSessionsList(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d", rr.Code)
@@ -133,13 +133,13 @@ func TestHandleChatThreadsReturnsUserSessions(t *testing.T) {
 	}
 }
 
-func TestHandleChatThreadsEmptyIsArray(t *testing.T) {
+func TestHandleChatSessionsListEmptyIsArray(t *testing.T) {
 	s := newSessionTestServer(t)
 	rr := httptest.NewRecorder()
-	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/threads", nil), "nobody")
-	s.handleChatThreads(rr, req)
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/sessions", nil), "nobody")
+	s.handleChatSessionsList(rr, req)
 	if got := strings.TrimSpace(rr.Body.String()); got != "[]" {
-		t.Fatalf("empty threads = %q, want []", got)
+		t.Fatalf("empty sessions = %q, want []", got)
 	}
 }
 

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -136,6 +136,9 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/chat/prompt-tier", s.requireAuth(s.handleChatPromptTier))
 	mux.HandleFunc("/api/chat/clear", s.requireAuth(s.handleChatClear))
 	mux.HandleFunc("/api/chat/threads", s.requireAuth(s.handleChatThreads))
+	// Per-user persisted session/tab list (restore after a crash). Distinct from
+	// /api/chat/threads (in-tab branches).
+	mux.HandleFunc("/api/chat/sessions", s.requireAuth(s.handleChatSessionsList))
 	mux.HandleFunc("/api/chat/branch", s.requireAuth(s.handleChatBranch))
 	mux.HandleFunc("/api/chat/switch-thread", s.requireAuth(s.handleChatSwitchThread))
 	mux.HandleFunc("/api/chat/rewind", s.requireAuth(s.handleChatRewind))


### PR DESCRIPTION
## What

Frontend half of per-user persistent chat sessions (backend was #38). The aimee
web SPA now restores open tabs from the server, so they survive a browser/laptop
crash or a move to another device — not just a same-browser reload.

## Changes

**Frontend — `frontend/src/pages/Chat.tsx`**
- On mount, `GET /api/chat/sessions` and merge any server-persisted sessions the
  local cache is missing into the tab list. A single pristine/unused default tab
  is replaced by the restored sessions (no stray empty "Chat"); existing local
  tabs are never dropped.
- `closeTab` issues `DELETE /api/chat/session?sid=` so a closed tab does not
  reappear on the next restore.
- `localStorage` is kept as a fast local cache (and still holds per-tab message
  history); the server is now authoritative for *which* tabs exist.

**Backend — endpoint disambiguation**
- The per-user tab list moves to **`GET /api/chat/sessions`**. In #38 it was
  `GET /api/chat/threads`, which collides with the SPA's separate, dormant
  in-tab conversation-"branch" surface (`{threads, active_id}`). `/api/chat/threads`
  is restored as a stub returning that empty shape, so `ThreadBar` behaves.
- Tests + `SESSION_PERSISTENCE.md` updated; frontend integration documented.

## Why a tab persists

No explicit register call is needed: `POST /api/chat/send` already records the
session server-side (id, auto-derived title, cwd, last_active) on every turn. So
any tab with at least one message is restorable; closing a tab forgets it.

## Verification

- Go: `go build` / `go vet` / `go test ./...` green.
- Frontend: `tsc -b` + `vite build` green (single-file `dist/index.html`).
- `aimee git verify` (verify-local) PASS.

Companion to #38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
