### PR TITLE
Promote testing → main: webchat per-user persistent chat sessions (#38, #39)

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -206,6 +206,63 @@ function saveTabs(tabs: TabData[]): void {
   try { localStorage.setItem(TABS_KEY, JSON.stringify(tabs)); } catch { /* ignore */ }
 }
 
+/* Server-side session persistence (per logged-in user). The conversation lives
+ * on aimee-server keyed by aimeeSid; webchat stores which sessions belong to the
+ * user so tabs survive a browser/laptop crash or a move to another device.
+ * localStorage remains a fast local cache (and holds per-tab message history);
+ * the server is authoritative for *which* tabs exist. */
+
+interface ServerSession {
+  id: string;
+  title?: string;
+  cwd?: string;
+  created_at?: string;
+  last_active?: string;
+}
+
+async function fetchServerSessions(): Promise<ServerSession[]> {
+  try {
+    const r = await fetch('/api/chat/sessions');
+    if (!r.ok) return [];
+    const data = await r.json();
+    return Array.isArray(data) ? (data as ServerSession[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+// mergeServerSessions restores server-persisted sessions the local cache is
+// missing (e.g. after a crash cleared localStorage, or on a fresh device),
+// appending them as message-empty tabs keyed by the stored aimeeSid. Local tabs
+// are never dropped — except a single pristine, unused default tab, which the
+// restored sessions replace so the user does not see a stray empty "Chat".
+function mergeServerSessions(local: TabData[], server: ServerSession[]): TabData[] {
+  const known = new Set(local.map(t => t.aimeeSid).filter(Boolean));
+  const restored: TabData[] = [];
+  for (const s of server) {
+    if (s.id && !known.has(s.id)) {
+      restored.push(normalizeTab({ title: s.title ?? '', messages: [], sid: '', aimeeSid: s.id }, 0));
+      known.add(s.id);
+    }
+  }
+  if (restored.length === 0) return local;
+  const pristineDefault =
+    local.length === 1 && local[0].messages.length === 0 && !local[0].sid;
+  return pristineDefault ? restored : [...local, ...restored];
+}
+
+// forgetServerSession removes a closed tab's session from the server so it does
+// not reappear on the next restore. Best-effort.
+function forgetServerSession(aimeeSid: string): void {
+  if (!aimeeSid) return;
+  try {
+    fetch(`/api/chat/session?sid=${encodeURIComponent(aimeeSid)}`, {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': window._csrf || '' },
+    }).catch(() => {});
+  } catch { /* ignore */ }
+}
+
 function rulesBannerDismissedKey(root: string): string {
   return root ? `${RULES_BANNER_DISMISSED_KEY}:${root}` : RULES_BANNER_DISMISSED_KEY;
 }
@@ -1521,6 +1578,19 @@ export default function Chat() {
     saveTabs(tabs);
   }, [tabs]);
 
+  /* Restore server-persisted sessions on load (per-user, survives a crash or a
+   * move to another device). Runs once; merges in any sessions the local cache
+   * is missing. */
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      const server = await fetchServerSessions();
+      if (cancelled || server.length === 0) return;
+      setTabs(prev => mergeServerSessions(prev, server));
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
   useEffect(() => {
     if (activeIdx >= tabs.length) {
       setActiveIdx(Math.max(0, tabs.length - 1));
@@ -1989,6 +2059,9 @@ export default function Chat() {
   function closeTab(i: number) {
     if (tabs.length <= 1) return;
     detachTabPresence(tabs[i]);
+    // Forget the server-side session so the closed tab does not reappear on the
+    // next restore (best-effort).
+    forgetServerSession(tabs[i]?.aimeeSid ?? '');
     if (i === activeIdx) abortActiveSends();
     setTabs(prev => {
       const next = [...prev];

--- a/webchat/SESSION_PERSISTENCE.md
+++ b/webchat/SESSION_PERSISTENCE.md
@@ -1,0 +1,112 @@
+# Per-user persistent chat sessions
+
+Webchat now persists, **per logged-in user**, the list of chat sessions (one per
+browser tab) so a user can reopen their browser after a crash and restore every
+tab. Conversation history itself already lives on aimee-server keyed by the
+session id; webchat stores only *ownership* and lightweight metadata (title,
+cwd, timestamps) in its SQLite DB (`webchat.db`, table `chat_sessions`).
+
+This document is the **backend contract** the frontend SPA
+(`RakuenSoftware/smoothgui`) integrates against. The Go backend is complete; the
+SPA changes described under "Frontend integration" live in that separate repo.
+
+## Identity
+
+- A **session** == one tab's conversation, identified by the aimee-server
+  conversation id — the same value the SPA already sends as `aimee_session_id`
+  on `POST /api/chat/send` and that aimee-server echoes back in the `session`
+  stream event.
+- All endpoints are gated by the existing login session cookie (`requireAuth`)
+  and scoped to the authenticated username. A user only ever sees, restores, or
+  deletes their own sessions.
+
+## Endpoints
+
+### `GET /api/chat/threads`
+
+Returns the user's sessions, most-recently-active first (bare JSON array):
+
+```json
+[
+  {
+    "id": "web-ab12cd34",
+    "title": "fix the login redirect bug",
+    "cwd": "/home/me/proj",
+    "created_at": "2026-06-04T10:00:00Z",
+    "last_active": "2026-06-04T11:30:00Z"
+  }
+]
+```
+
+Empty list is `[]`. Use this on app load to render the restorable tab list.
+
+### `GET /api/chat/session?sid=<id>`
+
+Returns one session's metadata, plus back-compat bootstrap fields the SPA
+already consumes:
+
+```json
+{
+  "session_id": "web-ab12cd34",
+  "csrf": "",
+  "prompt_tier": "standard",
+  "exists": true,
+  "title": "fix the login redirect bug",
+  "cwd": "/home/me/proj",
+  "created_at": "...",
+  "last_active": "..."
+}
+```
+
+For an unknown / not-yet-persisted `sid`, `exists` is `false` and the metadata
+fields are omitted (the other fields still return so existing bootstrap logic is
+unaffected).
+
+### `POST /api/chat/session`
+
+Create or update (rename) a session. Body:
+
+```json
+{ "id": "web-ab12cd34", "title": "optional explicit title", "cwd": "/optional" }
+```
+
+`id` may also be sent as `sid` or `aimee_session_id`. An explicitly supplied
+non-empty `title` **overwrites** the stored title (this is the rename path); an
+empty/absent title leaves any existing title untouched. Returns the stored
+record (same shape as a `threads` element). `401` if unauthenticated, `400` if
+no id.
+
+### `DELETE /api/chat/session?sid=<id>`
+
+Forget a session (close a tab). Returns `{"status":"ok","deleted":true}`.
+Scoped to the user — deleting another user's id is a no-op.
+
+## Automatic recording
+
+The SPA does **not** have to explicitly register a session for it to persist:
+`POST /api/chat/send` records the session automatically on every turn. It bumps
+`last_active`, fills `cwd` from the turn, and derives the `title` from the first
+user message (first line, truncated). The id used is the one aimee-server minted
+for a brand-new tab (delivered in the `session` stream event) when the SPA did
+not supply one. So even a tab that crashed mid-first-message is restorable.
+
+`POST /api/chat/session` is therefore only needed for **explicit** actions:
+rename, or pre-registering a tab before its first turn.
+
+## Frontend integration (smoothgui repo)
+
+1. **On app load**, call `GET /api/chat/threads`. Render each entry as a
+   restorable tab/thread in the sidebar. Clicking one re-opens that
+   conversation by reusing its `id` as the `aimee_session_id` on subsequent
+   `POST /api/chat/send` calls (aimee-server replays history for that id).
+2. **Stop relying on `localStorage`/`sessionStorage`** as the source of truth
+   for the tab list — the server is now authoritative, so the list survives a
+   device crash or a switch to another machine. (You may still cache the
+   *currently focused* session id client-side for fast reload.)
+3. **Per-tab id**: keep generating a stable per-tab id (e.g. `web-<rand>`) and
+   send it as `aimee_session_id`; it becomes the session's `id`. Each tab gets
+   its own id so each persists independently.
+4. **Rename**: `POST /api/chat/session` with `{id, title}`.
+5. **Close/forget a tab**: `DELETE /api/chat/session?sid=<id>`.
+6. The thread endpoints (`/branch`, `/switch-thread`, `/rewind`) remain stubs;
+   full thread-tree management is out of scope for per-user tab restore.

--- a/webchat/SESSION_PERSISTENCE.md
+++ b/webchat/SESSION_PERSISTENCE.md
@@ -22,9 +22,11 @@ SPA changes described under "Frontend integration" live in that separate repo.
 
 ## Endpoints
 
-### `GET /api/chat/threads`
+### `GET /api/chat/sessions`
 
-Returns the user's sessions, most-recently-active first (bare JSON array):
+Returns the user's sessions, most-recently-active first (bare JSON array).
+(Distinct from `/api/chat/threads`, which is the unrelated, not-yet-implemented
+in-tab conversation-branch surface.)
 
 ```json
 [
@@ -95,7 +97,7 @@ rename, or pre-registering a tab before its first turn.
 
 ## Frontend integration (smoothgui repo)
 
-1. **On app load**, call `GET /api/chat/threads`. Render each entry as a
+1. **On app load**, call `GET /api/chat/sessions`. Render each entry as a
    restorable tab/thread in the sidebar. Clicking one re-opens that
    conversation by reusing its `id` as the `aimee_session_id` on subsequent
    `POST /api/chat/send` calls (aimee-server replays history for that id).
@@ -108,5 +110,16 @@ rename, or pre-registering a tab before its first turn.
    its own id so each persists independently.
 4. **Rename**: `POST /api/chat/session` with `{id, title}`.
 5. **Close/forget a tab**: `DELETE /api/chat/session?sid=<id>`.
-6. The thread endpoints (`/branch`, `/switch-thread`, `/rewind`) remain stubs;
-   full thread-tree management is out of scope for per-user tab restore.
+6. The thread endpoints (`/api/chat/threads`, `/branch`, `/switch-thread`,
+   `/rewind`) remain stubs; in-tab conversation-branch management is a separate
+   feature, out of scope for per-user tab restore.
+
+## Frontend status (aimee/frontend)
+
+The aimee web SPA (`frontend/src/pages/Chat.tsx`) integrates this as of the
+session-frontend change: on mount it fetches `GET /api/chat/sessions` and merges
+any server-side sessions the local `localStorage` cache is missing (restoring
+tabs after a crash or on a fresh device), and `closeTab` issues
+`DELETE /api/chat/session?sid=` so a closed tab does not reappear. `localStorage`
+is retained as a fast local cache (it also holds per-tab message history); the
+server is authoritative for *which* tabs exist.

--- a/webchat/chat.go
+++ b/webchat/chat.go
@@ -311,6 +311,15 @@ func (s *server) handleChatClear(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"status":"ok"}`)
 }
 
+// handleChatThreads is a stub for GET /api/chat/threads (in-tab conversation
+// branching — a separate, not-yet-implemented feature). It returns the empty
+// shape the SPA's ThreadBar expects. The per-user persisted tab list lives at
+// GET /api/chat/sessions (handleChatSessionsList), not here.
+func (s *server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, `{"threads":[],"active_id":0}`)
+}
+
 // handleChatBranch is a stub for POST /api/chat/branch.
 func (s *server) handleChatBranch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")

--- a/webchat/chat.go
+++ b/webchat/chat.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -64,6 +65,11 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 
 	doneSent := false
+	// effectiveSID tracks the aimee conversation id for this turn: the one the
+	// SPA supplied, or the one aimee-server mints (delivered as a "session"
+	// event) for a brand-new tab. It is persisted against the logged-in user
+	// after the turn so the tab can be restored later.
+	effectiveSID := req.AimeeSessionID
 	// Stream the chat over aimee-server's /v1 HTTP transport (native
 	// POST /v1/chat/stream); the legacy NDJSON socket helper (chatStream)
 	// remains available as a fallback.
@@ -79,6 +85,9 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 			case "turn_end":
 				sseWrite(w, "turn_end", map[string]any{})
 			case "session":
+				if evt.ID != "" {
+					effectiveSID = evt.ID
+				}
 				sseWrite(w, "session", map[string]string{"id": evt.ID})
 			case "usage":
 				sseWrite(w, "usage", map[string]any{
@@ -103,6 +112,14 @@ func (s *server) handleChatSend(w http.ResponseWriter, r *http.Request) {
 
 	if r.Context().Err() != nil {
 		return
+	}
+	// Record this tab's session against the logged-in user so it survives a
+	// browser/laptop crash and can be restored from /api/chat/threads. The
+	// conversation itself already lives on aimee-server; this only persists the
+	// ownership + lightweight metadata. Best-effort: a failure here must not
+	// break the chat response that already streamed.
+	if uerr := s.touchChatSession(currentUser(r), effectiveSID, cwd, req.Message); uerr != nil {
+		log.Printf("aimee-webchat: persist session %q: %v", effectiveSID, uerr)
 	}
 	if err != nil {
 		sseWrite(w, "error", map[string]string{"message": err.Error()})
@@ -156,23 +173,6 @@ func (s *server) handleChatProjects(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(map[string]any{
 		"current_root": currentRoot,
 		"projects":     projects,
-	})
-}
-
-// handleChatSession returns session state for the current browser session.
-func (s *server) handleChatSession(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodGet {
-		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
-		return
-	}
-
-	sid := r.URL.Query().Get("sid")
-
-	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{
-		"session_id":  sid,
-		"csrf":        "",
-		"prompt_tier": "standard",
 	})
 }
 
@@ -311,12 +311,6 @@ func (s *server) handleChatClear(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"status":"ok"}`)
 }
 
-// handleChatThreads returns empty threads for a session.
-func (s *server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	fmt.Fprintf(w, `[]`)
-}
-
 // handleChatBranch is a stub for POST /api/chat/branch.
 func (s *server) handleChatBranch(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
@@ -339,9 +333,10 @@ func (s *server) handleChatRewind(w http.ResponseWriter, r *http.Request) {
 // for page paths it redirects to /login.
 func (s *server) requireAuth(h http.HandlerFunc) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		var username string
 		cookie, err := r.Cookie("session")
 		if err == nil {
-			_, err = s.sessions.ValidateSession(cookie.Value)
+			username, err = s.sessions.ValidateSession(cookie.Value)
 		}
 		if err != nil {
 			if isAPIPath(r.URL.Path) {
@@ -353,7 +348,9 @@ func (s *server) requireAuth(h http.HandlerFunc) http.HandlerFunc {
 			http.Redirect(w, r, "/login", http.StatusFound)
 			return
 		}
-		h(w, r)
+		// Carry the validated username so handlers can scope persistence
+		// (chat sessions) to the logged-in user.
+		h(w, withUser(r, username))
 	}
 }
 

--- a/webchat/chat_sessions.go
+++ b/webchat/chat_sessions.go
@@ -1,0 +1,281 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Per-user chat-session persistence. A "session" here is one browser tab's
+// conversation: identified by the aimee-server conversation id (the same value
+// the SPA sends as aimee_session_id and aimee-server echoes back in the
+// "session" stream event). The conversation history itself lives on
+// aimee-server; this table is webchat's durable record of WHICH sessions belong
+// to WHICH logged-in user, so a user can reopen their browser after a crash and
+// restore every tab they had open. Rows are scoped by the authenticated
+// username so users only ever see and restore their own tabs.
+
+type ctxKey string
+
+const ctxUsername ctxKey = "webchat_username"
+
+// currentUser returns the authenticated username injected by requireAuth, or ""
+// if the request was not authenticated (which the handlers treat as no session
+// ownership rather than an error).
+func currentUser(r *http.Request) string {
+	u, _ := r.Context().Value(ctxUsername).(string)
+	return u
+}
+
+// withUser returns a shallow copy of r carrying the resolved username, used by
+// requireAuth so downstream handlers can scope persistence to the user.
+func withUser(r *http.Request, username string) *http.Request {
+	return r.WithContext(context.WithValue(r.Context(), ctxUsername, username))
+}
+
+var chatSessionMigrations = []string{
+	`CREATE TABLE IF NOT EXISTS chat_sessions (
+		id          TEXT PRIMARY KEY,
+		username    TEXT NOT NULL,
+		title       TEXT NOT NULL DEFAULT '',
+		cwd         TEXT NOT NULL DEFAULT '',
+		created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now')),
+		last_active TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ','now'))
+	)`,
+	`CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(username, last_active DESC)`,
+}
+
+func applyChatSessionMigrations(db *sql.DB) error {
+	for _, m := range chatSessionMigrations {
+		if _, err := db.Exec(m); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// chatSession is the durable record of one tab's session for a user.
+type chatSession struct {
+	ID         string `json:"id"`
+	Title      string `json:"title"`
+	Cwd        string `json:"cwd,omitempty"`
+	CreatedAt  string `json:"created_at"`
+	LastActive string `json:"last_active"`
+}
+
+const sessionTitleMaxLen = 80
+
+// deriveTitle builds a short, single-line title from the first user message.
+func deriveTitle(message string) string {
+	title := strings.TrimSpace(message)
+	if i := strings.IndexAny(title, "\r\n"); i >= 0 {
+		title = strings.TrimSpace(title[:i])
+	}
+	if len(title) > sessionTitleMaxLen {
+		title = strings.TrimSpace(title[:sessionTitleMaxLen]) + "…"
+	}
+	return title
+}
+
+// touchChatSession records (or refreshes) a user's session from the chat-send
+// path. It is best-effort: a nil db, an empty user, or an empty id is a no-op,
+// and any DB error is returned for the caller to log without failing the chat.
+// The session's last_active is bumped; cwd is updated when provided; the title
+// is auto-derived from the first message only while still empty (so an explicit
+// rename via the session endpoint is never clobbered by later turns).
+func (s *server) touchChatSession(username, id, cwd, firstMessage string) error {
+	if s == nil || s.db == nil || username == "" || id == "" {
+		return nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	title := deriveTitle(firstMessage)
+	_, err := s.db.Exec(`
+		INSERT INTO chat_sessions (id, username, title, cwd, created_at, last_active)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			last_active = excluded.last_active,
+			cwd   = CASE WHEN excluded.cwd != ''        THEN excluded.cwd   ELSE chat_sessions.cwd   END,
+			title = CASE WHEN chat_sessions.title = ''  THEN excluded.title ELSE chat_sessions.title END
+		WHERE chat_sessions.username = excluded.username`,
+		id, username, title, cwd, now, now)
+	return err
+}
+
+// getChatSession loads one session owned by the user, or (nil, nil) if absent.
+func (s *server) getChatSession(username, id string) (*chatSession, error) {
+	if s == nil || s.db == nil || username == "" || id == "" {
+		return nil, nil
+	}
+	row := s.db.QueryRow(
+		`SELECT id, title, cwd, created_at, last_active
+		   FROM chat_sessions WHERE id = ? AND username = ?`, id, username)
+	var cs chatSession
+	switch err := row.Scan(&cs.ID, &cs.Title, &cs.Cwd, &cs.CreatedAt, &cs.LastActive); err {
+	case nil:
+		return &cs, nil
+	case sql.ErrNoRows:
+		return nil, nil
+	default:
+		return nil, err
+	}
+}
+
+// listChatSessions returns the user's sessions, most-recently-active first.
+func (s *server) listChatSessions(username string) ([]chatSession, error) {
+	out := []chatSession{}
+	if s == nil || s.db == nil || username == "" {
+		return out, nil
+	}
+	rows, err := s.db.Query(
+		`SELECT id, title, cwd, created_at, last_active
+		   FROM chat_sessions WHERE username = ?
+		  ORDER BY last_active DESC LIMIT 200`, username)
+	if err != nil {
+		return out, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var cs chatSession
+		if err := rows.Scan(&cs.ID, &cs.Title, &cs.Cwd, &cs.CreatedAt, &cs.LastActive); err != nil {
+			return out, err
+		}
+		out = append(out, cs)
+	}
+	return out, rows.Err()
+}
+
+// handleChatThreads (GET /api/chat/threads) returns the authenticated user's
+// persisted sessions so the SPA can restore every open tab after a reload or a
+// crash. Shape is a bare JSON array (matching the prior stub) of session
+// objects, newest activity first.
+func (s *server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	sessions, err := s.listChatSessions(currentUser(r))
+	if err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to list sessions")
+		return
+	}
+	_ = json.NewEncoder(w).Encode(sessions)
+}
+
+// handleChatSession is the per-session CRUD surface:
+//
+//	GET    /api/chat/session?sid=<id>  → read one session's metadata (back-compat
+//	                                      fields session_id/csrf/prompt_tier are
+//	                                      preserved for the existing SPA bootstrap)
+//	POST   /api/chat/session           → create/rename a session (body: {id|sid,
+//	                                      title?, cwd?}); an explicit title is
+//	                                      always applied (rename)
+//	DELETE /api/chat/session?sid=<id>  → forget a session (close a tab)
+//
+// All operations are scoped to the authenticated user.
+func (s *server) handleChatSession(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleChatSessionGet(w, r)
+	case http.MethodPost:
+		s.handleChatSessionUpsert(w, r)
+	case http.MethodDelete:
+		s.handleChatSessionDelete(w, r)
+	default:
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+	}
+}
+
+func (s *server) handleChatSessionGet(w http.ResponseWriter, r *http.Request) {
+	sid := r.URL.Query().Get("sid")
+	w.Header().Set("Content-Type", "application/json")
+
+	out := map[string]any{
+		"session_id":  sid,
+		"csrf":        "",
+		"prompt_tier": "standard",
+		"exists":      false,
+	}
+	if cs, err := s.getChatSession(currentUser(r), sid); err == nil && cs != nil {
+		out["exists"] = true
+		out["title"] = cs.Title
+		out["cwd"] = cs.Cwd
+		out["created_at"] = cs.CreatedAt
+		out["last_active"] = cs.LastActive
+	}
+	_ = json.NewEncoder(w).Encode(out)
+}
+
+func (s *server) handleChatSessionUpsert(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	var req struct {
+		ID             string `json:"id"`
+		Sid            string `json:"sid"`
+		AimeeSessionID string `json:"aimee_session_id"`
+		Title          string `json:"title"`
+		Cwd            string `json:"cwd"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad request")
+		return
+	}
+	id := firstNonEmpty(req.ID, req.Sid, req.AimeeSessionID)
+	if id == "" {
+		writeJSONError(w, http.StatusBadRequest, "session id required")
+		return
+	}
+	username := currentUser(r)
+	if username == "" {
+		writeJSONError(w, http.StatusUnauthorized, "authentication required")
+		return
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+	// Explicit upsert: unlike the send-path touch, an explicitly supplied title
+	// overwrites (this is the rename path). An empty title leaves any existing
+	// title untouched.
+	if _, err := s.db.Exec(`
+		INSERT INTO chat_sessions (id, username, title, cwd, created_at, last_active)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(id) DO UPDATE SET
+			last_active = excluded.last_active,
+			cwd   = CASE WHEN excluded.cwd   != '' THEN excluded.cwd   ELSE chat_sessions.cwd   END,
+			title = CASE WHEN excluded.title != '' THEN excluded.title ELSE chat_sessions.title END
+		WHERE chat_sessions.username = excluded.username`,
+		id, username, strings.TrimSpace(req.Title), req.Cwd, now, now); err != nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to save session")
+		return
+	}
+
+	cs, err := s.getChatSession(username, id)
+	if err != nil || cs == nil {
+		writeJSONError(w, http.StatusInternalServerError, "failed to load session")
+		return
+	}
+	_ = json.NewEncoder(w).Encode(cs)
+}
+
+func (s *server) handleChatSessionDelete(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	sid := r.URL.Query().Get("sid")
+	if sid == "" {
+		writeJSONError(w, http.StatusBadRequest, "sid required")
+		return
+	}
+	if s.db != nil {
+		if _, err := s.db.Exec(`DELETE FROM chat_sessions WHERE id = ? AND username = ?`,
+			sid, currentUser(r)); err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "failed to delete session")
+			return
+		}
+	}
+	_, _ = w.Write([]byte(`{"status":"ok","deleted":true}`))
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/webchat/chat_sessions.go
+++ b/webchat/chat_sessions.go
@@ -147,11 +147,12 @@ func (s *server) listChatSessions(username string) ([]chatSession, error) {
 	return out, rows.Err()
 }
 
-// handleChatThreads (GET /api/chat/threads) returns the authenticated user's
-// persisted sessions so the SPA can restore every open tab after a reload or a
-// crash. Shape is a bare JSON array (matching the prior stub) of session
-// objects, newest activity first.
-func (s *server) handleChatThreads(w http.ResponseWriter, r *http.Request) {
+// handleChatSessionsList (GET /api/chat/sessions) returns the authenticated
+// user's persisted sessions so the SPA can restore every open tab after a
+// reload or a crash. Shape is a bare JSON array of session objects, newest
+// activity first. (Distinct from /api/chat/threads, which is the in-tab
+// conversation-branch surface.)
+func (s *server) handleChatSessionsList(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	sessions, err := s.listChatSessions(currentUser(r))
 	if err != nil {

--- a/webchat/chat_sessions_test.go
+++ b/webchat/chat_sessions_test.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// newSessionTestServer returns a server backed by an in-memory SQLite DB with
+// the chat-session schema applied.
+func newSessionTestServer(t *testing.T) *server {
+	t.Helper()
+	db, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	if err := applyChatSessionMigrations(db); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return &server{db: db}
+}
+
+// asUser wraps a request with an authenticated username, the way requireAuth
+// would after validating the session cookie.
+func asUser(r *http.Request, username string) *http.Request {
+	return withUser(r, username)
+}
+
+func TestTouchAndListChatSessions(t *testing.T) {
+	s := newSessionTestServer(t)
+
+	if err := s.touchChatSession("alice", "sess-1", "/proj/a", "first message line\nsecond"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	if err := s.touchChatSession("alice", "sess-2", "/proj/b", "another conversation"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	// Bob's session must not appear in Alice's list.
+	if err := s.touchChatSession("bob", "sess-3", "/proj/c", "bob's chat"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+
+	got, err := s.listChatSessions("alice")
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 sessions for alice, got %d: %+v", len(got), got)
+	}
+	// Title derived from first line of the first message only.
+	var s1 *chatSession
+	for i := range got {
+		if got[i].ID == "sess-1" {
+			s1 = &got[i]
+		}
+	}
+	if s1 == nil {
+		t.Fatal("sess-1 missing from alice's list")
+	}
+	if s1.Title != "first message line" {
+		t.Fatalf("title = %q, want %q", s1.Title, "first message line")
+	}
+	if s1.Cwd != "/proj/a" {
+		t.Fatalf("cwd = %q", s1.Cwd)
+	}
+}
+
+func TestTouchChatSessionPreservesTitleAcrossTurns(t *testing.T) {
+	s := newSessionTestServer(t)
+	if err := s.touchChatSession("alice", "sess-1", "/proj/a", "original title"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	// A later turn must not overwrite the established title.
+	if err := s.touchChatSession("alice", "sess-1", "/proj/a", "a much later message"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	cs, err := s.getChatSession("alice", "sess-1")
+	if err != nil || cs == nil {
+		t.Fatalf("get: %v %+v", err, cs)
+	}
+	if cs.Title != "original title" {
+		t.Fatalf("title changed across turns: %q", cs.Title)
+	}
+}
+
+func TestTouchChatSessionScopedByUser(t *testing.T) {
+	s := newSessionTestServer(t)
+	if err := s.touchChatSession("alice", "shared-id", "/a", "alice msg"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	// A second user touching the same id must not hijack or mutate alice's row.
+	if err := s.touchChatSession("bob", "shared-id", "/b", "bob msg"); err != nil {
+		t.Fatalf("touch: %v", err)
+	}
+	cs, err := s.getChatSession("alice", "shared-id")
+	if err != nil || cs == nil {
+		t.Fatalf("alice get: %v %+v", err, cs)
+	}
+	if cs.Cwd != "/a" {
+		t.Fatalf("alice row mutated by bob: cwd=%q", cs.Cwd)
+	}
+	// Bob owns nothing under that id.
+	if bobCS, _ := s.getChatSession("bob", "shared-id"); bobCS != nil {
+		t.Fatalf("bob unexpectedly owns shared-id: %+v", bobCS)
+	}
+}
+
+func TestHandleChatThreadsReturnsUserSessions(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "sess-1", "/a", "hello there")
+	_ = s.touchChatSession("bob", "sess-2", "/b", "bob only")
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/threads", nil), "alice")
+	s.handleChatThreads(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var sessions []chatSession
+	if err := json.Unmarshal(rr.Body.Bytes(), &sessions); err != nil {
+		t.Fatalf("decode: %v (%s)", err, rr.Body.String())
+	}
+	if len(sessions) != 1 || sessions[0].ID != "sess-1" {
+		t.Fatalf("expected only alice's sess-1, got %+v", sessions)
+	}
+}
+
+func TestHandleChatThreadsEmptyIsArray(t *testing.T) {
+	s := newSessionTestServer(t)
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/threads", nil), "nobody")
+	s.handleChatThreads(rr, req)
+	if got := strings.TrimSpace(rr.Body.String()); got != "[]" {
+		t.Fatalf("empty threads = %q, want []", got)
+	}
+}
+
+func TestHandleChatSessionUpsertAndGet(t *testing.T) {
+	s := newSessionTestServer(t)
+
+	// Create via POST.
+	rr := httptest.NewRecorder()
+	body := `{"id":"sess-1","cwd":"/proj","title":"My Tab"}`
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session", strings.NewReader(body)), "alice")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("upsert status = %d (%s)", rr.Code, rr.Body.String())
+	}
+	var cs chatSession
+	if err := json.Unmarshal(rr.Body.Bytes(), &cs); err != nil {
+		t.Fatalf("decode upsert: %v", err)
+	}
+	if cs.ID != "sess-1" || cs.Title != "My Tab" || cs.Cwd != "/proj" {
+		t.Fatalf("unexpected upsert result: %+v", cs)
+	}
+
+	// Read via GET — carries back-compat fields + exists=true.
+	rr = httptest.NewRecorder()
+	req = asUser(httptest.NewRequest(http.MethodGet, "/api/chat/session?sid=sess-1", nil), "alice")
+	s.handleChatSession(rr, req)
+	var out map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &out); err != nil {
+		t.Fatalf("decode get: %v", err)
+	}
+	if out["exists"] != true || out["title"] != "My Tab" || out["prompt_tier"] != "standard" {
+		t.Fatalf("unexpected get result: %+v", out)
+	}
+}
+
+func TestHandleChatSessionRenameOverwritesTitle(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "sess-1", "/a", "auto derived title")
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodPost, "/api/chat/session",
+		strings.NewReader(`{"id":"sess-1","title":"Renamed"}`)), "alice")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	cs, _ := s.getChatSession("alice", "sess-1")
+	if cs == nil || cs.Title != "Renamed" {
+		t.Fatalf("rename failed: %+v", cs)
+	}
+}
+
+func TestHandleChatSessionDelete(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "sess-1", "/a", "to be deleted")
+
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodDelete, "/api/chat/session?sid=sess-1", nil), "alice")
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("delete status = %d", rr.Code)
+	}
+	if cs, _ := s.getChatSession("alice", "sess-1"); cs != nil {
+		t.Fatalf("session not deleted: %+v", cs)
+	}
+}
+
+func TestHandleChatSessionDeleteScopedByUser(t *testing.T) {
+	s := newSessionTestServer(t)
+	_ = s.touchChatSession("alice", "sess-1", "/a", "alice's")
+
+	// Bob attempts to delete Alice's session — must not succeed.
+	rr := httptest.NewRecorder()
+	req := asUser(httptest.NewRequest(http.MethodDelete, "/api/chat/session?sid=sess-1", nil), "bob")
+	s.handleChatSession(rr, req)
+	if cs, _ := s.getChatSession("alice", "sess-1"); cs == nil {
+		t.Fatal("bob deleted alice's session")
+	}
+}
+
+func TestHandleChatSessionUpsertRequiresAuth(t *testing.T) {
+	s := newSessionTestServer(t)
+	rr := httptest.NewRecorder()
+	// No user in context (unauthenticated).
+	req := httptest.NewRequest(http.MethodPost, "/api/chat/session", strings.NewReader(`{"id":"x"}`))
+	s.handleChatSession(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestCurrentUserDefaultsEmpty(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	if u := currentUser(req); u != "" {
+		t.Fatalf("currentUser = %q, want empty", u)
+	}
+	req = req.WithContext(context.WithValue(req.Context(), ctxUsername, "zoe"))
+	if u := currentUser(req); u != "zoe" {
+		t.Fatalf("currentUser = %q, want zoe", u)
+	}
+}

--- a/webchat/chat_sessions_test.go
+++ b/webchat/chat_sessions_test.go
@@ -112,14 +112,14 @@ func TestTouchChatSessionScopedByUser(t *testing.T) {
 	}
 }
 
-func TestHandleChatThreadsReturnsUserSessions(t *testing.T) {
+func TestHandleChatSessionsListReturnsUserSessions(t *testing.T) {
 	s := newSessionTestServer(t)
 	_ = s.touchChatSession("alice", "sess-1", "/a", "hello there")
 	_ = s.touchChatSession("bob", "sess-2", "/b", "bob only")
 
 	rr := httptest.NewRecorder()
-	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/threads", nil), "alice")
-	s.handleChatThreads(rr, req)
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/sessions", nil), "alice")
+	s.handleChatSessionsList(rr, req)
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status = %d", rr.Code)
@@ -133,13 +133,13 @@ func TestHandleChatThreadsReturnsUserSessions(t *testing.T) {
 	}
 }
 
-func TestHandleChatThreadsEmptyIsArray(t *testing.T) {
+func TestHandleChatSessionsListEmptyIsArray(t *testing.T) {
 	s := newSessionTestServer(t)
 	rr := httptest.NewRecorder()
-	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/threads", nil), "nobody")
-	s.handleChatThreads(rr, req)
+	req := asUser(httptest.NewRequest(http.MethodGet, "/api/chat/sessions", nil), "nobody")
+	s.handleChatSessionsList(rr, req)
 	if got := strings.TrimSpace(rr.Body.String()); got != "[]" {
-		t.Fatalf("empty threads = %q, want []", got)
+		t.Fatalf("empty sessions = %q, want []", got)
 	}
 }
 

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -47,6 +47,10 @@ func run(cfg *config) error {
 		return fmt.Errorf("channel migrations: %w", err)
 	}
 
+	if err := applyChatSessionMigrations(db); err != nil {
+		return fmt.Errorf("chat session migrations: %w", err)
+	}
+
 	sessions := auth.NewSessionStore(db, 24*time.Hour)
 	rl := auth.NewRateLimiter(db, 10, 15*time.Minute)
 	users := auth.NewUserManager("aimee")

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -136,6 +136,9 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/chat/prompt-tier", s.requireAuth(s.handleChatPromptTier))
 	mux.HandleFunc("/api/chat/clear", s.requireAuth(s.handleChatClear))
 	mux.HandleFunc("/api/chat/threads", s.requireAuth(s.handleChatThreads))
+	// Per-user persisted session/tab list (restore after a crash). Distinct from
+	// /api/chat/threads (in-tab branches).
+	mux.HandleFunc("/api/chat/sessions", s.requireAuth(s.handleChatSessionsList))
 	mux.HandleFunc("/api/chat/branch", s.requireAuth(s.handleChatBranch))
 	mux.HandleFunc("/api/chat/switch-thread", s.requireAuth(s.handleChatSwitchThread))
 	mux.HandleFunc("/api/chat/rewind", s.requireAuth(s.handleChatRewind))


### PR DESCRIPTION
## Promote testing → main

Webchat per-user persistent chat sessions (tab restore).

- **#38** — backend: `chat_sessions` table in `webchat.db` scoped by the
  authenticated user; `requireAuth` injects the username; `handleChatSend`
  records each tab's session; real user-scoped endpoints (`GET /api/chat/sessions`,
  `GET/POST/DELETE /api/chat/session`) replace the prior stubs. + tests.
- **#39** — frontend (`frontend/src/pages/Chat.tsx`): restore tabs from the
  server on load, forget on close; `localStorage` becomes a cache. Backend
  endpoint disambiguation (`/api/chat/sessions` vs the dormant `/api/chat/threads`).

Login was already enforced; this adds server-side per-user session ownership so
tabs survive a browser/laptop crash or a move to another device.

Verified on testing: Go build/vet/test, frontend tsc + vite build, verify-local,
and CI core checks (lint/build/build-integrity/unit-tests) green.
