### PR TITLE
fix(client): honor --server/AIMEE_SERVER_URL on POSIX + surface denied writes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -746,7 +746,13 @@ $(WEBCHAT): $(WEBCHAT_GO_SRCS)
 
 # Server (daemon). DB2-bound work routes through kb_client to aimee-kb;
 # keep this target free of DB2_OBJS and libpq.
-$(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_OBJS) $(SERVER_CMD_OBJS) $(CORE_OBJS) $(DB1_OBJS) $(PLATFORM_OBJS) $(MCP_GIT_OBJS)
+#
+# aimee_client.o resolves the dependency-free remote-target accessors
+# (aimee_client_remote_active / _token) that cli_rpc_client_endpoint now calls to
+# synthesize a tcp: endpoint from a --server / AIMEE_SERVER_URL / remote.conf
+# target. --gc-sections drops the rest of aimee_client (the actual TCP/TLS
+# transport), so no extra net/tls/uds objects are needed here.
+$(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_OBJS) $(SERVER_CMD_OBJS) $(CORE_OBJS) $(DB1_OBJS) $(PLATFORM_OBJS) $(MCP_GIT_OBJS) $(OBJDIR)/aimee_client.o
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_SERVER)
 
@@ -764,7 +770,9 @@ $(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(KB_DA
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_KB)
 
-$(GATEWAY): $(GATEWAY_OBJS)
+# aimee_client.o for the same reason as $(SERVER): cli_rpc_client_endpoint calls
+# the dependency-free remote-target accessors; --gc-sections drops the transport.
+$(GATEWAY): $(GATEWAY_OBJS) $(OBJDIR)/aimee_client.o
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_GATEWAY)
 

--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -323,6 +323,16 @@ int aimee_client_remote_active(char *desc_out, unsigned long desc_sz)
    return 1;
 }
 
+int aimee_client_remote_token(char *tok_out, unsigned long tok_sz)
+{
+   char url[512], tok[256];
+   if (!resolve_remote(url, sizeof(url), tok, sizeof(tok)))
+      return 0;
+   if (tok_out && tok_sz)
+      snprintf(tok_out, tok_sz, "%s", tok);
+   return 1;
+}
+
 char *aimee_client_request(const char *method, const char *path, const char *body, int *status_out)
 {
    if (status_out)

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -11,10 +11,39 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <direct.h>
+#define AIMEE_MKDIR(p) _mkdir(p)
+#else
+#include <sys/stat.h>
+#define AIMEE_MKDIR(p) mkdir((p), 0700)
+#endif
 
 static void remote_conf_path(char *out, size_t out_sz)
 {
    snprintf(out, out_sz, "%s/remote.conf", aimee_home());
+}
+
+/* Create |dir| and any missing parents (best effort, ignores existing/errors).
+ * A thin-client-only host (the README's recommended deployment) has nothing
+ * else that creates <aimee_home> (~/.config/aimee), so `aimee remote set` must
+ * make it before writing remote.conf or the first call fails with ENOENT. */
+static void ensure_dir_p(const char *dir)
+{
+   if (!dir || !dir[0])
+      return;
+   char tmp[512];
+   snprintf(tmp, sizeof(tmp), "%s", dir);
+   for (char *p = tmp + 1; *p; p++)
+   {
+      if (*p == '/')
+      {
+         *p = '\0';
+         AIMEE_MKDIR(tmp);
+         *p = '/';
+      }
+   }
+   AIMEE_MKDIR(tmp);
 }
 
 /* Read the persisted URL (line 1) and token (line 2, optional) into the given
@@ -57,6 +86,7 @@ static int remote_set(const char *url, const char *token, int json_output)
    }
    char path[512];
    remote_conf_path(path, sizeof(path));
+   ensure_dir_p(aimee_home());
    FILE *f = fopen(path, "w");
    if (!f)
    {

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6271,7 +6271,26 @@ char *cli_rpc_client_endpoint(void)
    const char *env = getenv("AIMEE_API_ENDPOINT");
    if (env && env[0])
       return strdup(env);
-   return cli_rpc_aimee_yaml_value("client_endpoint:");
+   char *yaml = cli_rpc_aimee_yaml_value("client_endpoint:");
+   if (yaml)
+      return yaml;
+   /* Fall back to a --server / AIMEE_SERVER_URL / remote.conf target (aimee_client)
+    * by synthesizing the "tcp:host:port" endpoint cli_http_request expects. This
+    * is what makes the README's headline remote flow drive the WHOLE data/RPC
+    * plane (status, memory, kb, …), not just the lower-level AIMEE_API_ENDPOINT
+    * form. http reaches the published container port directly; an https:// target
+    * needs a TLS-terminating proxy, the same as the AIMEE_API_ENDPOINT tcp:
+    * transport. Keeping the bridge here (vs. cli_v1_send) means the shared
+    * dispatcher references no networking symbols, so the server/gateway/tests that
+    * link it pull only the dependency-free aimee_client resolver. */
+   char hostport[300];
+   if (aimee_client_remote_active(hostport, sizeof(hostport)))
+   {
+      char ep[320];
+      snprintf(ep, sizeof(ep), "tcp:%s", hostport);
+      return strdup(ep);
+   }
+   return NULL;
 }
 
 /* cli_rpc_client_bearer: bearer token sent with the remote HTTP transport.
@@ -6283,7 +6302,15 @@ char *cli_rpc_client_bearer(void)
    const char *env = getenv("AIMEE_API_BEARER");
    if (env && env[0])
       return strdup(env);
-   return cli_rpc_aimee_yaml_value("bearer_token:");
+   char *yaml = cli_rpc_aimee_yaml_value("bearer_token:");
+   if (yaml)
+      return yaml;
+   /* Token for a synthesized aimee_client endpoint: --server-token /
+    * AIMEE_SERVER_TOKEN / remote.conf line 2. */
+   char tok[300];
+   if (aimee_client_remote_token(tok, sizeof(tok)) && tok[0])
+      return strdup(tok);
+   return NULL;
 }
 
 /* cli_rpc_has_remote_endpoint: true when the thin client is configured to reach
@@ -6295,6 +6322,9 @@ char *cli_rpc_client_bearer(void)
 int cli_rpc_has_remote_endpoint(void)
 {
 #if !defined(_WIN32) && !defined(_WIN64)
+   /* cli_rpc_client_endpoint() also synthesizes a tcp: endpoint from a --server /
+    * AIMEE_SERVER_URL / remote.conf target (aimee_client), so this transparently
+    * reports those too and the dispatcher skips the dead local-socket preflight. */
    char *ep = cli_rpc_client_endpoint();
    if (ep)
    {
@@ -6319,6 +6349,9 @@ int cli_rpc_has_remote_endpoint(void)
 int cli_rpc_remote_endpoint_is_tcp(void)
 {
 #if !defined(_WIN32) && !defined(_WIN64)
+   /* A synthesized aimee_client target (--server / AIMEE_SERVER_URL / remote.conf)
+    * is always "tcp:host:port" (a network host, never a local unix: path), so
+    * chat/launch refuse it here just like an explicit tcp: endpoint. */
    char *ep = cli_rpc_client_endpoint();
    int is_tcp = ep && strncmp(ep, "tcp:", 4) == 0;
    free(ep);
@@ -6687,6 +6720,7 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
     * always remote (resolved from --server / AIMEE_SERVER_URL inside cli_v1_send). */
    char *remote = cli_rpc_client_endpoint();
    char *bearer = remote ? cli_rpc_client_bearer() : NULL;
+   int http_status = 0; /* last HTTP status from the REST send (0 for the async path) */
 
    if (http_body && async_path)
    {
@@ -6710,7 +6744,7 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
             cJSON_Delete(resp);
             resp = NULL;
          }
-         int http_status = 0;
+         http_status = 0;
          resp = cli_v1_send(remote, bearer, rest_verb, rest_path, body, timeout, &http_status);
          if (resp)
          {
@@ -6762,6 +6796,28 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
       cJSON *msg = cJSON_GetObjectItemCaseSensitive(resp, "message");
       if (cJSON_IsString(msg) && msg->valuestring[0])
          fprintf(stderr, "aimee: %s\n", msg->valuestring);
+      cJSON_Delete(resp);
+      return 1;
+   }
+
+   /* REST error envelope: {"error":{"message":..,"type":..}}. The server emits
+    * this on any non-2xx — e.g. 403 permission_error when a write is attempted
+    * over a read-only remote listener (aimee.api.remote_writes=off). It is NOT a
+    * {"status":"error"} body, so without this the success pretty-printers below
+    * would misreport a denied write as success (e.g. print "stored memory"). */
+   if (cJSON_IsObject(err))
+   {
+      cJSON *emsg = cJSON_GetObjectItemCaseSensitive(err, "message");
+      fprintf(stderr, "aimee: %s\n",
+              (cJSON_IsString(emsg) && emsg->valuestring[0]) ? emsg->valuestring
+                                                             : "request failed");
+      cJSON_Delete(resp);
+      return 1;
+   }
+   /* Any other non-2xx with an unrecognized body: never render it as success. */
+   if (http_status >= 400)
+   {
+      fprintf(stderr, "aimee: server returned HTTP %d for '%s'\n", http_status, route->method);
       cJSON_Delete(resp);
       return 1;
    }

--- a/src/headers/aimee_client.h
+++ b/src/headers/aimee_client.h
@@ -53,6 +53,13 @@ extern "C"
     * diagnostics; desc_sz is its buffer size. */
    int aimee_client_remote_active(char *desc_out, unsigned long desc_sz);
 
+   /* Returns 1 if a remote target is in effect and copies its bearer token (the
+    * second remote.conf line / --server-token / AIMEE_SERVER_TOKEN) into *tok_out
+    * (empty string when the target has no token), else 0. Dependency-free (no
+    * networking) so callers that only need the resolved token don't pull the
+    * transport closure. tok_sz is the buffer size. */
+   int aimee_client_remote_token(char *tok_out, unsigned long tok_sz);
+
    /* Send an HTTP request to aimee-server's /v1 API over the resolved transport.
     * method: "GET"/"POST"; path: e.g. "/v1/personas"; body: JSON or NULL.
     * Returns the response body (heap; caller frees) and sets *status_out to the

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -201,7 +201,17 @@ static int bootstrap_db2_try_url(config_t *cfg, const char *url, int save_config
    {
       snprintf(cfg->db2_url, sizeof(cfg->db2_url), "%s", url);
       if (config_save(cfg) != 0)
-         return -1;
+      {
+         /* DB2 is already proven healthy (db2_init + health probe above). The
+          * config persist is only a fast-path cache for later starts — the URL
+          * is re-resolved from AIMEE_DB2_URL / db2_url every boot regardless — so
+          * a failed save (e.g. a read-only aimee.yaml, as the remote-writes
+          * compose override bind-mounts it :ro) must NOT abort an otherwise
+          * healthy kb. Record that the save was skipped and continue. */
+         fprintf(stderr, "aimee-kb: warning: could not persist db2_url to config "
+                         "(continuing; DB2 is reachable via the resolved URL)\n");
+         save_config = 0;
+      }
    }
 
    cJSON_AddStringToObject(resp, "status", "ok");

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -409,8 +409,12 @@ $(TESTPREFIX)/unit-test-context-discover: $(OBJDIR)/tests/test_context_discover.
 $(TESTPREFIX)/unit-test-cli-mcp-serve: $(OBJDIR)/tests/test_cli_mcp_serve.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
+# aimee_client.o resolves the remote-target accessors cli_rpc_client_endpoint now
+# calls (it synthesizes a tcp: endpoint from a --server/AIMEE_SERVER_URL target).
+# --gc-sections drops the rest of the transport, which this marshalling test
+# never calls.
 $(TESTPREFIX)/unit-test-cli-rpc-delegate: $(OBJDIR)/tests/test_cli_rpc_delegate.o \
-                                  $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o
+                                  $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-cli-server-compat: $(OBJDIR)/tests/test_cli_server_compat.o \

--- a/src/tests/test_cli_remote.c
+++ b/src/tests/test_cli_remote.c
@@ -57,6 +57,35 @@ static void test_clear(void)
    PASS("clear removes persisted config");
 }
 
+static void test_set_creates_missing_home(void)
+{
+   reset_state();
+   /* The README's recommended deployment installs ONLY the thin client, so
+    * nothing creates <aimee_home> (~/.config/aimee) before the user runs
+    * `aimee remote set`. Point AIMEE_HOME at a not-yet-existing nested path and
+    * confirm set creates it instead of failing with ENOENT (regression). */
+   const char *saved = getenv("AIMEE_HOME");
+   char nested[320];
+   snprintf(nested, sizeof(nested), "%s/missing/aimee_home", saved ? saved : "/tmp");
+   setenv("AIMEE_HOME", nested, 1);
+
+   char *argv[] = {(char *)"set", (char *)"http://made-host:8740", (char *)"tok"};
+   assert(cli_remote_cmd(3, argv, 1) == 0);
+   cli_remote_load_persisted();
+   char desc[128] = {0};
+   assert(aimee_client_remote_active(desc, sizeof(desc)) == 1);
+   assert(strcmp(desc, "made-host:8740") == 0);
+   PASS("remote set creates a missing aimee_home dir");
+
+   /* Best-effort cleanup + restore home for any later tests. */
+   char path[400];
+   snprintf(path, sizeof(path), "%s/remote.conf", nested);
+   unlink(path);
+   rmdir(nested);
+   if (saved)
+      setenv("AIMEE_HOME", saved, 1);
+}
+
 int main(void)
 {
    /* Isolate AIMEE_HOME so we never touch the real config. */
@@ -68,6 +97,7 @@ int main(void)
    test_set_then_load();
    test_env_wins_over_file();
    test_clear();
+   test_set_creates_missing_home();
    printf("ALL PASS\n");
 
    /* Best-effort cleanup. */


### PR DESCRIPTION
Found and fixed while doing a fresh README-driven Docker deploy of aimee.

## Bugs fixed
1. **README §2 remote flow (`--server` / `AIMEE_SERVER_URL` / `aimee remote set`) was dead on Linux/macOS.** The data/RPC dispatch only honored the `AIMEE_API_ENDPOINT` mechanism; a `--server`/env/remote.conf target fell through to the dead local-socket preflight → *"server unavailable"*. `cli_rpc_client_endpoint()`/`_bearer()` now synthesize a `tcp:host:port` endpoint + token from the aimee_client remote, reusing the already-linked `cli_http_request` (minimal blast radius — `--gc-sections` keeps the new `aimee_client.o` dep tiny on server/gateway/tests).
2. **Denied writes over the network were reported as success.** The server correctly 403s under `remote_writes=off`, but `cli_rpc_forward` ignored the `{"error":{…}}` envelope and printed *"stored memory"*. Now detects the object-`error` envelope + non-2xx → clear message, exit 1.
3. **`aimee remote set` failed on a thin-client-only host** (never created `~/.config/aimee`). Fixed + regression test.
4. **`compose.remote-writes.combined.yaml` never booted** — kb aborted because `config_save` was fatal on the `:ro`-mounted config. Made the persist best-effort (DB2 is already health-probed).

## Validation
- Fresh `compose.combined.yaml` deploy on a clean host: all README curls + all three §2 remote forms work; denied write errors cleanly (exit 1); write→read round trip works under `remote_writes=data`; remote-writes override boots healthy on a fresh volume.
- `aimee git verify` (verify-local) PASS; full `make unit-tests` green; `check-linking` / `module-boundary` / `tier-deps` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
