### PR TITLE
promote: testing → main (build/install/usage-path bug fixes #43)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -182,7 +182,7 @@ fi
 # --- Install binaries ---
 
 mkdir -p "$INSTALL_DIR"
-rm -f "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee-server" \
+rm -f "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee-server" \
       "$INSTALL_DIR/aimee-webchat" "$INSTALL_DIR/aimee-kb"
 cp "$LOCAL_BIN" "$INSTALL_DIR/aimee"
 cp "$LOCAL_SERVER" "$INSTALL_DIR/aimee-server"
@@ -190,8 +190,6 @@ cp "$LOCAL_WEBCHAT" "$INSTALL_DIR/aimee-webchat"
 cp "$LOCAL_KB" "$INSTALL_DIR/aimee-kb"
 chmod +x "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee-server" \
          "$INSTALL_DIR/aimee-webchat" "$INSTALL_DIR/aimee-kb"
-cp "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee"
-chmod +x "$INSTALL_DIR/aimee"
 
 # Remove retired binaries. aimee-worker was folded into aimee-server's
 # in-process compute pool; it is not a shipped artifact.
@@ -202,7 +200,7 @@ for legacy in "$INSTALL_DIR/aimee-mcp" "$INSTALL_DIR/aimem" "$INSTALL_DIR/aimee-
     fi
 done
 
-info "Installed: $INSTALL_DIR/aimee, $INSTALL_DIR/aimee-server, $INSTALL_DIR/aimee-webchat, $INSTALL_DIR/aimee-kb (with $INSTALL_DIR/aimee -> aimee)"
+info "Installed: $INSTALL_DIR/aimee, $INSTALL_DIR/aimee-server, $INSTALL_DIR/aimee-webchat, $INSTALL_DIR/aimee-kb"
 
 # --- Install bundled skills ---
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -928,7 +928,7 @@ schema_data.h: $(SCHEMA_FILES) gen_schema.py
 kb/http/openapi_data.h: ../api/openapi-v1.yaml gen_openapi.py
 	python3 gen_openapi.py $@
 
-$(OBJDIR)/kb/kb_http.o $(OBJDIR)/kb/http/kb_http.o: kb/http/openapi_data.h
+$(OBJDIR)/kb/kb_http.o $(OBJDIR)/kb/http/kb_http.o $(OBJDIR)/kb/http/kb_http_conn.o: kb/http/openapi_data.h
 
 server/openapi_server_data.h: ../api/openapi-server-v1.yaml gen_openapi_server.py
 	python3 gen_openapi_server.py $@

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -142,19 +142,10 @@
      "  models <name>    Fetch provider model catalog (--json)\n"
      "  test <name>      Probe provider credentials and connectivity\n"
      "  quota [name]     Show process-local credential pool quota state\n"},
-    {"model", "Model capability metadata", CLIENT_TIER_ADVANCED, 0,
-     "  show <provider:model>      Show context, cost, and capability flags\n"
-     "  list [--capability NAME]   List configured models matching a capability\n"},
     {"version", "Print version", CLIENT_TIER_CORE, 0, NULL},
     {"help", "Show help for a command", CLIENT_TIER_CORE, 1, NULL},
 
     {"status", "System health overview", CLIENT_TIER_ADVANCED, 0, NULL},
-    {"jobs", "Agent job management", CLIENT_TIER_ADVANCED, 0,
-     "  list             List recent background delegate jobs\n"
-     "  status <job_id>  Show one background delegate job\n"
-     "  show <job_id>    Alias for status\n"
-     "  logs <job_id>    Print the recorded delegate result/log body\n"
-     "  cancel <job_id>  Cancel one background delegate job\n"},
     {"hud", "Real-time session status and HUD", CLIENT_TIER_ADVANCED, 0, NULL},
     {"identity", "Charter and working-profile inspection", CLIENT_TIER_ADVANCED, 0,
      "  show             Show charter, local operator, and working profile\n"

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -4240,6 +4240,16 @@ static void print_memory_stats(cJSON *resp)
 
 static void print_index_scan(cJSON *resp)
 {
+   /* An error response (e.g. KB unavailable) carries no projects/files counts;
+    * surface the message instead of formatting absent numbers, which would
+    * otherwise print INT_MIN via (int)cJSON_GetNumberValue(NULL) == (int)NaN. */
+   if (strcmp(json_str(resp, "status"), "error") == 0)
+   {
+      const char *msg = json_str(resp, "message");
+      printf("==> Scan failed: %s\n", msg[0] ? msg : "knowledge service unavailable");
+      return;
+   }
+
    cJSON *skipped = cJSON_GetObjectItemCaseSensitive(resp, "skipped");
    if (cJSON_IsTrue(skipped))
    {
@@ -4254,9 +4264,9 @@ static void print_index_scan(cJSON *resp)
       return;
    }
 
-   int projects = (int)cJSON_GetNumberValue(cJSON_GetObjectItemCaseSensitive(resp, "projects"));
-   int files = (int)cJSON_GetNumberValue(cJSON_GetObjectItemCaseSensitive(resp, "files"));
-   int inspected = (int)cJSON_GetNumberValue(cJSON_GetObjectItemCaseSensitive(resp, "inspected"));
+   int projects = json_int(resp, "projects", 0);
+   int files = json_int(resp, "files", 0);
+   int inspected = json_int(resp, "inspected", 0);
    int unchanged = inspected - files;
    if (inspected > 0 && unchanged > 0)
       printf("==> Scan complete: %d project(s), %d file(s) re-indexed (%d unchanged)\n", projects,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -33,6 +33,7 @@
 #include "hud.h"
 #include "platform_event.h"
 #include "platform_ipc.h"
+#include "platform_path.h"
 #include "platform_process.h"
 #include "util.h"
 #include "workspace.h"
@@ -1441,6 +1442,22 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
       perror("aimee-server: evloop create");
       errno = saved_errno;
       return -1;
+   }
+   /* Ensure the config dir (parent of the socket, pid file, and DB1 file)
+    * exists before we write the pid file or open DB1. On a fresh AIMEE_HOME
+    * (e.g. a deploy not seeded by install.sh) nothing else has created it yet,
+    * so without this both server_pid_write and db1_init silently fail and DB1
+    * stays unavailable for the whole process lifetime. */
+   {
+      char cfg_dir[sizeof(ctx->socket_path)];
+      snprintf(cfg_dir, sizeof(cfg_dir), "%s", socket_path);
+      char *slash = strrchr(cfg_dir, '/');
+      if (slash)
+      {
+         *slash = '\0';
+         if (cfg_dir[0])
+            platform_mkdir_p(cfg_dir, 0700);
+      }
    }
    /* Record our pid so future server_init calls can detect us deterministically
     * (and `aimee server start/restart` can probe liveness). */


### PR DESCRIPTION
Promote testing → main.

Single change since main: **#43** — five verified bug fixes from an install/build/usage-path testing sweep:

1. `src/Makefile` — parallel-build race: declare `kb/http/kb_http_conn.o` dependent on the generated `kb/http/openapi_data.h` (fixed `make -j` `fatal error: openapi_data.h: No such file`).
2. `install.sh` — removed a self-copy (`cp X X` → exit 1) that aborted a fresh install under `set -euo pipefail` before hook/skill/service setup.
3. `src/cli_help_data.h` — removed duplicate `model` / `jobs` help entries (`help --all` listed them twice).
4. `src/server/server.c` — create the config dir before `db1_init` so a fresh `AIMEE_HOME` doesn't leave DB1 (working memory, sessions) dead for the whole process.
5. `src/cli_rpc_routes.inc` — `aimee index scan` no longer prints `-2147483648` (INT_MIN from `(int)NaN`) on a KB-error response; handles the error and uses the safe `json_int()` reader.

CI green on #43 (lint, build, unit-tests, build-integrity, windows/macos builds, e2e-docker, init-migrate-service-test, memory-retrieval-eval, bench-check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
