### PR TITLE
fix(cli): surface server err_json messages; stop misleading no-route hint

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6773,8 +6773,14 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
    else if (http_body)
    {
       /* No first-class route — unreachable given the coverage gates; surface it
-       * rather than silently dropping the command. */
+       * rather than silently dropping the command. This is a routing gap, not an
+       * unreachable server, so return early instead of falling through to the
+       * misleading "is the server running?" hint below. */
       fprintf(stderr, "aimee: '%s' has no /v1 route\n", route->method);
+      free(http_body);
+      free(bearer);
+      free(remote);
+      return -1;
    }
 
    free(http_body);
@@ -6824,10 +6830,19 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
       cJSON_Delete(resp);
       return 1;
    }
-   /* Any other non-2xx with an unrecognized body: never render it as success. */
+   /* Any other non-2xx: never render it as success. Prefer a string error
+    * envelope {"error":"<msg>"} — the shape server_http.c's err_json() emits
+    * (28+ routes: 502/503 backend-unavailable, "no such persona/agent", "attach
+    * refused", ...) — over the generic HTTP line, which drops the real reason.
+    * Gated on http_status so a 2xx success that legitimately carries a top-level
+    * "error" string (e.g. cron.run returns {status:ok,...,error:"<job stderr>"})
+    * is NOT misreported as a failure. */
    if (http_status >= 400)
    {
-      fprintf(stderr, "aimee: server returned HTTP %d for '%s'\n", http_status, route->method);
+      if (cJSON_IsString(err) && err->valuestring[0])
+         fprintf(stderr, "aimee: %s\n", err->valuestring);
+      else
+         fprintf(stderr, "aimee: server returned HTTP %d for '%s'\n", http_status, route->method);
       cJSON_Delete(resp);
       return 1;
    }


### PR DESCRIPTION
Two CLI/server diagnostics fixes found while bug-hunting the error paths.

## 1. Server `err_json` messages were silently dropped at the client (28+ routes)
`server_http.c`'s `err_json()` emits errors as `{"error":"<msg>"}` — `error` as a **string** — for failures like 502/503 backend-unavailable, "no such persona", "no such agent", "attach refused", "missing surface", etc. The client's error extractor only handled `error` as an **object** (`{"error":{"message":..}}`) and `{"status":"error"}`, so every `err_json` failure dropped its message and showed the unhelpful generic `aimee: server returned HTTP <code> for '<method>'`.

The `HTTP>=400` branch now prefers the string `error` message when present. **Gated on `http_status >= 400`** so a 2xx success that legitimately carries a top-level `error` string (e.g. `cron.run` returns `{status:ok,...,error:"<job stderr>"}`) is **not** misreported as a failure.

Verified live: `aimee rules list` against a KB-less server now prints `aimee: rules backend unavailable` instead of `aimee: server returned HTTP 502 for 'rules.list'`.

## 2. Misleading "is the server running?" hint for no-route commands
Commands with no first-class `/v1` route (e.g. foreground `delegate`) printed both `'X' has no /v1 route` **and** `could not reach the aimee-server /v1 endpoint (is the server running?)` even when the server was up and reachable. The no-route branch now returns early.

## Verification
`make all` (-j) + `make unit-tests` + `make lint` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
