### PR TITLE
fix(forensics): atomic record write to fix flaky shutdown-forensics test

### DIFF
--- a/src/shutdown_forensics.c
+++ b/src/shutdown_forensics.c
@@ -246,12 +246,38 @@ int shutdown_forensics_write_record(const shutdown_ctx_t *ctx)
    if (n <= 0 || (size_t)n >= sizeof(body))
       return -1;
 
-   int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0600);
+   /* Write to a per-pid temp file then rename() over the target so the update is
+    * atomic: a concurrent reader (shutdown_forensics_list_recent) sees either the
+    * old or the new complete record, never a truncated one. This matters because
+    * the async diagnostic child rewrites the same record the parent just wrote
+    * (to add the process tree); a reader racing an O_TRUNC rewrite could
+    * otherwise observe an empty file and miss the record. */
+   char tmppath[4160];
+   int tn = snprintf(tmppath, sizeof(tmppath), "%s.tmp.%ld", path, (long)getpid());
+   if (tn <= 0 || (size_t)tn >= sizeof(tmppath))
+      return -1;
+   int fd = open(tmppath, O_CREAT | O_TRUNC | O_WRONLY | O_CLOEXEC, 0600);
    if (fd < 0)
       return -1;
    ssize_t wrote = write(fd, body, (size_t)n);
    close(fd);
-   return wrote == n ? 0 : -1;
+   if (wrote != n)
+   {
+      unlink(tmppath);
+      return -1;
+   }
+#ifdef _WIN32
+   /* Windows rename() will not replace an existing file; the atomic-replace race
+    * it guards against is POSIX-only (the async diagnostic uses /proc), so a
+    * non-atomic remove-then-rename is acceptable here. */
+   unlink(path);
+#endif
+   if (rename(tmppath, path) != 0)
+   {
+      unlink(tmppath);
+      return -1;
+   }
+   return 0;
 }
 
 #ifndef _WIN32


### PR DESCRIPTION
Fixes the intermittent `test_shutdown_forensics.c:122` `assert(count >= 1)` failure (seen flaking CI on an unrelated PR).

## Root cause (a real race, not just a test bug)
`shutdown_forensics_write_record()` opened the record file with `O_CREAT|O_TRUNC` and wrote in place. The async diagnostic child (`spawn_async_diagnostic`) rewrites the **same** record the parent just wrote, to add the process tree. A reader (`shutdown_forensics_list_recent`) racing the child's `O_TRUNC` window observes an empty/truncated file and returns 0 rows — `count == 0`, tripping the assertion under CI load. The same race can make the gateway/server forensics readers momentarily miss a record in production.

## Fix
Write to a per-pid temp file then `rename()` over the target. `rename(2)` is atomic on POSIX (same dir = same filesystem), so a reader always sees a complete record — the old one or the new one — never a truncation. Windows (where the `/proc`-based async diagnostic doesn't apply) unlinks first since its `rename()` won't replace an existing file.

## Verification
- 100 sequential + 40 concurrent runs of `unit-test-shutdown-forensics` all pass (previously flaky under load).
- `make all` (-j) + `make unit-tests` + `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
