### PR TITLE
fix(install/upgrade): unblock source install without Go; wire local kb; complete prereq docs

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -238,7 +238,9 @@ Go 1.25+ is required only to build `aimee-webchat`. Then `install.sh`, in order:
 1. **Check prerequisites** (FTS5 + the dev headers); if any are missing it stops
    and points you back at `install-deps.sh` rather than escalating privileges.
 2. **Build** (only if sources changed): `cd src && make all server`, producing
-   `aimee`, `aimee-server`, `aimee-kb`, and `aimee-webchat` at the repo root.
+   `aimee`, `aimee-server`, and `aimee-kb` at the repo root, plus `aimee-webchat`
+   when a Go toolchain is on `PATH` (otherwise `make` notes it was skipped and the
+   C services still build — webchat is optional for a source install).
 3. **Stop any running server/KB** gracefully to avoid "text file busy".
 4. **Install binaries** to `~/.local/bin/` and remove retired binaries.
 5. **Install bundled skills** to `~/.local/share/aimee/skills/` (idempotent).

--- a/README.md
+++ b/README.md
@@ -292,17 +292,30 @@ cd aimee
 ./install.sh        # build + install + configure (no sudo)
 ```
 
-`install-deps.sh` installs the system packages aimee builds against and bootstraps the `aimee_shared` PostgreSQL database, the only steps that need root. `install.sh` then builds from source, installs the four binaries to `~/.local/bin/`, installs service units where supported (systemd user units on Linux, launchd agents on macOS), enables `aimee-kb` then `aimee-server`, and configures hooks + MCP for every detected AI coding tool. If a dependency is missing, `install.sh` stops and points you back at `install-deps.sh`. Windows users run `install.ps1` (CMake build + WinSW services) and `configure-hooks.ps1`.
+`install-deps.sh` installs the system packages aimee builds against and bootstraps the `aimee_shared` PostgreSQL database, the only steps that need root. `install.sh` then builds from source, installs the binaries to `~/.local/bin/`, installs service units where supported (systemd user units on Linux, launchd agents on macOS), enables `aimee-kb` then `aimee-server`, and configures hooks + MCP for every detected AI coding tool. If a dependency is missing, `install.sh` stops and points you back at `install-deps.sh`. Windows users run `install.ps1` (CMake build + WinSW services) and `configure-hooks.ps1`.
+
+`install-deps.sh` installs the full set below; you only need this table if you are
+installing dependencies by hand. The C services (`aimee`, `aimee-server`,
+`aimee-kb`) need no Go. The browser UI (`aimee-webchat`) is the only Go artifact
+and is **optional**: `install.sh` builds it when a suitable Go toolchain is on
+`PATH` (see `webchat/go.mod` for the required version, newer than some distros
+package) and otherwise skips it with a note — install Go and re-run, or run the
+webchat from the Docker image.
 
 Source-build prerequisites:
 
 | Package | Debian/Ubuntu | macOS |
 |---------|---------------|-------|
 | C compiler | `apt install build-essential` | Xcode CLT |
+| pkg-config | `apt install pkg-config` | `brew install pkg-config` |
 | SQLite3 (FTS5) | `apt install libsqlite3-dev sqlite3` | System SQLite |
 | libpq | `apt install libpq-dev` | `brew install libpq` |
+| libzstd | `apt install libzstd-dev` | `brew install zstd` |
 | libcurl | `apt install libcurl4-openssl-dev` | `brew install curl` |
 | PAM (webchat) | `apt install libpam0g-dev` | built-in |
+| PostgreSQL + pgvector | `apt install postgresql postgresql-NN-pgvector` | `brew install postgresql pgvector` |
+| ripgrep, universal-ctags | `apt install ripgrep universal-ctags` | `brew install ripgrep universal-ctags` |
+| Go (optional, `aimee-webchat` only) | see `webchat/go.mod` | `brew install go` |
 
 **Local or remote knowledge base.** `install.sh` asks whether to run `aimee-kb` **locally** (the default, backed by the local Postgres) or point at an existing **remote** `aimee-kb` over HTTP. Choosing remote persists `kb_client_url` (and an optional bearer token) to `aimee.yaml`, skips the local sidecar and Postgres, and `aimee-server` reaches the remote kb on every launch path. For a remote-only host, also skip the database bootstrap: `AIMEE_KB_MODE=remote ./install-deps.sh`.
 

--- a/install.sh
+++ b/install.sh
@@ -121,7 +121,11 @@ fi
 # --- Build (skip if binary is newer than all source) ---
 
 needs_build() {
-    local bins=("$LOCAL_BIN" "$LOCAL_SERVER" "$LOCAL_WEBCHAT" "$LOCAL_KB")
+    # aimee-webchat (Go) is only required/buildable when a Go toolchain is
+    # present; without Go the C core still builds and installs (see make all's
+    # ALL_WEBCHAT gate), so don't let a missing webchat force a rebuild loop.
+    local bins=("$LOCAL_BIN" "$LOCAL_SERVER" "$LOCAL_KB")
+    command -v go >/dev/null 2>&1 && bins+=("$LOCAL_WEBCHAT")
     local bin
 
     for bin in "${bins[@]}"; do
@@ -186,10 +190,13 @@ rm -f "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee-server" \
       "$INSTALL_DIR/aimee-webchat" "$INSTALL_DIR/aimee-kb"
 cp "$LOCAL_BIN" "$INSTALL_DIR/aimee"
 cp "$LOCAL_SERVER" "$INSTALL_DIR/aimee-server"
-cp "$LOCAL_WEBCHAT" "$INSTALL_DIR/aimee-webchat"
 cp "$LOCAL_KB" "$INSTALL_DIR/aimee-kb"
-chmod +x "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee-server" \
-         "$INSTALL_DIR/aimee-webchat" "$INSTALL_DIR/aimee-kb"
+chmod +x "$INSTALL_DIR/aimee" "$INSTALL_DIR/aimee-server" "$INSTALL_DIR/aimee-kb"
+# webchat is optional (built only when Go is available); install it if present.
+if [ -f "$LOCAL_WEBCHAT" ]; then
+    cp "$LOCAL_WEBCHAT" "$INSTALL_DIR/aimee-webchat"
+    chmod +x "$INSTALL_DIR/aimee-webchat"
+fi
 
 # Remove retired binaries. aimee-worker was folded into aimee-server's
 # in-process compute pool; it is not a shipped artifact.
@@ -200,7 +207,11 @@ for legacy in "$INSTALL_DIR/aimee-mcp" "$INSTALL_DIR/aimem" "$INSTALL_DIR/aimee-
     fi
 done
 
-info "Installed: $INSTALL_DIR/aimee, $INSTALL_DIR/aimee-server, $INSTALL_DIR/aimee-webchat, $INSTALL_DIR/aimee-kb"
+if [ -f "$INSTALL_DIR/aimee-webchat" ]; then
+    info "Installed: $INSTALL_DIR/aimee, $INSTALL_DIR/aimee-server, $INSTALL_DIR/aimee-webchat, $INSTALL_DIR/aimee-kb"
+else
+    info "Installed: $INSTALL_DIR/aimee, $INSTALL_DIR/aimee-server, $INSTALL_DIR/aimee-kb (aimee-webchat skipped: no Go toolchain)"
+fi
 
 # --- Install bundled skills ---
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,6 +17,18 @@ WEBCHAT = ../aimee-webchat$(EXEEXT)
 GATEWAY = ../aimee-gateway$(EXEEXT)
 RETIRED_ROOT_BINARIES = ../aimee-client$(EXEEXT) ../aimee-worker$(EXEEXT)
 
+# aimee-webchat is the only Go artifact and needs the Go toolchain (go.mod pins a
+# newer Go than some distros package, e.g. Debian 13 ships 1.24). The C services
+# (aimee / aimee-server / aimee-kb) need no Go, so `make all` builds webchat only
+# when `go` is on PATH and otherwise skips it with a note — a source install on a
+# box without Go still gets a working core instead of a hard `go: not found`.
+HAVE_GO := $(shell command -v go >/dev/null 2>&1 && echo 1)
+ifeq ($(HAVE_GO),1)
+ALL_WEBCHAT = $(WEBCHAT)
+else
+ALL_WEBCHAT =
+endif
+
 define AIMEE_RUNTIME_MUTATION_GUARD
 	@if [ -n "$$AIMEE_TUI_SESSION" ]; then \
 		echo "aimee: refusing to mutate runtime target '$@' from inside the TUI" >&2; \
@@ -424,7 +436,12 @@ DEPS = $(ALL_OBJS:.o=.d)
 
 .PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
 
-all: retire-obsolete-binaries $(BINARY) $(WEBCHAT) $(SERVER) $(KB) $(GATEWAY)
+all: retire-obsolete-binaries $(BINARY) $(ALL_WEBCHAT) $(SERVER) $(KB) $(GATEWAY)
+ifneq ($(HAVE_GO),1)
+	@echo "aimee: NOTE - 'go' not found on PATH; skipped aimee-webchat (browser UI)."
+	@echo "aimee:        Install Go (>=1.25, see webchat/go.mod) and re-run to build it,"
+	@echo "aimee:        or run the browser UI from the Docker image instead."
+endif
 
 retire-obsolete-binaries:
 	$(AIMEE_RUNTIME_MUTATION_GUARD)

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -148,8 +148,24 @@ static int run_server(const char *socket_path, log_level_t log_level)
     * env-based kb_client transport (kb_client_v1_base_url / auth_header)
     * reaches the remote kb on every launch path — systemd AND the fork-and-exec
     * fallback. Pre-set env wins, so AIMEE_KB_API_URL still overrides config. */
-   if (cfg.kb_client_url[0] && !(getenv("AIMEE_KB_API_URL") && getenv("AIMEE_KB_API_URL")[0]))
-      platform_setenv("AIMEE_KB_API_URL", cfg.kb_client_url);
+   if (!(getenv("AIMEE_KB_API_URL") && getenv("AIMEE_KB_API_URL")[0]))
+   {
+      if (cfg.kb_client_url[0])
+         platform_setenv("AIMEE_KB_API_URL", cfg.kb_client_url);
+      else
+      {
+         /* Co-located default: with no remote kb_client_url and no explicit
+          * AIMEE_KB_API_URL, point at the local aimee-kb sidecar. The systemd
+          * unit, the launchd plist, and the fork-and-exec fallback all serve it
+          * on 127.0.0.1:8741 (kb_api_http_port if the operator overrode it).
+          * Without this a source install's server has no kb URL at all and every
+          * DB2-backed feature (memory/kb/rules) silently reports "unavailable". */
+         char local_kb[64];
+         int kb_port = cfg.kb_api_http_port > 0 ? cfg.kb_api_http_port : 8741;
+         snprintf(local_kb, sizeof(local_kb), "http://127.0.0.1:%d", kb_port);
+         platform_setenv("AIMEE_KB_API_URL", local_kb);
+      }
+   }
    if (cfg.kb_client_bearer_token[0] &&
        !(getenv("AIMEE_KB_API_BEARER_TOKEN") && getenv("AIMEE_KB_API_BEARER_TOKEN")[0]))
       platform_setenv("AIMEE_KB_API_BEARER_TOKEN", cfg.kb_client_bearer_token);

--- a/update.sh
+++ b/update.sh
@@ -169,7 +169,11 @@ NEW_HEAD=$(git rev-parse HEAD)
 # --- Check if rebuild is needed ---
 
 needs_build() {
-    local bins=("$LOCAL_BIN" "$LOCAL_SERVER" "$LOCAL_WEBCHAT" "$LOCAL_KB")
+    # aimee-webchat (Go) is optional: only required/buildable when a Go toolchain
+    # is present (see `make all`'s ALL_WEBCHAT gate). Without Go the C core still
+    # builds, so a missing webchat must not force a perpetual rebuild.
+    local bins=("$LOCAL_BIN" "$LOCAL_SERVER" "$LOCAL_KB")
+    command -v go >/dev/null 2>&1 && bins+=("$LOCAL_WEBCHAT")
     local bin
 
     if $FORCE; then
@@ -208,7 +212,10 @@ needs_install() {
         return 0
     fi
 
-    for bin in "$AIMEE_BIN" "$AIMEE_SERVER_BIN" "$AIMEE_WEBCHAT_BIN" "$AIMEE_KB_BIN"; do
+    local bins=("$AIMEE_BIN" "$AIMEE_SERVER_BIN" "$AIMEE_KB_BIN")
+    # webchat only counts toward "needs install" when a local build exists.
+    [ -f "$LOCAL_WEBCHAT" ] && bins+=("$AIMEE_WEBCHAT_BIN")
+    for bin in "${bins[@]}"; do
         [ -f "$bin" ] || return 0
     done
 
@@ -343,9 +350,13 @@ if $REFRESH_BINARIES; then
     rm -f "$AIMEE_BIN" "$AIMEE_SERVER_BIN" "$AIMEE_WEBCHAT_BIN" "$AIMEE_KB_BIN"
     cp "$LOCAL_BIN" "$AIMEE_BIN"
     cp "$LOCAL_SERVER" "$AIMEE_SERVER_BIN"
-    cp "$LOCAL_WEBCHAT" "$AIMEE_WEBCHAT_BIN"
     cp "$LOCAL_KB" "$AIMEE_KB_BIN"
-    chmod +x "$AIMEE_BIN" "$AIMEE_SERVER_BIN" "$AIMEE_WEBCHAT_BIN" "$AIMEE_KB_BIN"
+    chmod +x "$AIMEE_BIN" "$AIMEE_SERVER_BIN" "$AIMEE_KB_BIN"
+    # webchat is optional (built only when Go is available); install if present.
+    if [ -f "$LOCAL_WEBCHAT" ]; then
+        cp "$LOCAL_WEBCHAT" "$AIMEE_WEBCHAT_BIN"
+        chmod +x "$AIMEE_WEBCHAT_BIN"
+    fi
 fi
 
 # --- Refresh systemd user units (Linux only) ---
@@ -479,7 +490,11 @@ fi
 if ! $KB_REMOTE && ! $KB_SYSTEMD_RESTARTED && [ -x "$AIMEE_KB_BIN" ] && \
    ! pgrep -x aimee-kb >/dev/null 2>&1; then
     info "Starting aimee-kb..."
-    "$AIMEE_KB_BIN" >/dev/null 2>&1 &
+    # Match the systemd unit / launchd plist: aimee-kb serves /v1 only and EXITS
+    # without a port (kb_api_http_port defaults to 0), so pass --http-port=8741.
+    # Also give worker threads a 64 MB stack like the unit's LimitSTACK, or the
+    # drain/ingest/watch threads can overflow the default 8 MB and SIGSEGV.
+    ( ulimit -s 65536 2>/dev/null || true; exec "$AIMEE_KB_BIN" --http-port=8741 >/dev/null 2>&1 ) &
 fi
 
 bash "$SCRIPT_DIR/configure-hooks.sh"

--- a/update.sh
+++ b/update.sh
@@ -499,4 +499,8 @@ fi
 
 bash "$SCRIPT_DIR/configure-hooks.sh"
 
-info "Updated: $AIMEE_BIN, $AIMEE_SERVER_BIN, $AIMEE_WEBCHAT_BIN, $AIMEE_KB_BIN"
+if [ -f "$AIMEE_WEBCHAT_BIN" ]; then
+    info "Updated: $AIMEE_BIN, $AIMEE_SERVER_BIN, $AIMEE_WEBCHAT_BIN, $AIMEE_KB_BIN"
+else
+    info "Updated: $AIMEE_BIN, $AIMEE_SERVER_BIN, $AIMEE_KB_BIN (aimee-webchat skipped: no Go toolchain)"
+fi


### PR DESCRIPTION
Install/upgrade-story fixes, **validated end-to-end on a fresh Debian 13 LXC** running the documented `install-deps.sh` + `install.sh` flow (and `update.sh`).

## Bugs fixed
1. **Source install aborted with `go: not found`** (the documented flow was broken on any box without Go). `install.sh` runs `make all`, which builds the Go `aimee-webchat`; Go isn't a dependency, and `webchat/go.mod` pins a Go newer than distros package (Debian 13 → 1.24). The C services need no Go. `make all` now builds webchat only when `go` is on `PATH` (otherwise prints a note and builds the C core); `install.sh`/`update.sh` treat the webchat binary as optional. → clean install now completes without Go.

2. **Local install's server couldn't reach its local kb** (memory/kb/rules all dead out of the box). `install.sh` clears `kb_client_url` in local mode, the systemd server unit sets no `AIMEE_KB_API_URL`, and there was no code default (the `kb_ensure_server` fallback the unit comment cites doesn't exist) → `kb_client_v1_base_url()` was NULL → "knowledge service unavailable". `server_main.c` now defaults `AIMEE_KB_API_URL` to the co-located sidecar (`http://127.0.0.1:8741`, or `kb_api_http_port`) when no remote `kb_client_url`/env is set. Remote + Docker paths unaffected (explicit env/config win). → `memory store`/`search` round-trip after a clean install.

3. **`update.sh` kb fork-exec fallback was broken**: it ran `aimee-kb` with no `--http-port` (kb exits without one; `kb_api_http_port` defaults to 0) and without the unit's 64 MB stack. Now passes `--http-port=8741` and raises `ulimit -s`. (Confirmed bare `aimee-kb` exits 1 with "set --http-port".)

4. **Docs**: completed the README source-build prereq table (it omitted build-critical `pkg-config`/`libzstd` plus `ripgrep`/ctags/postgres) and aligned README/MANUAL with the optional-webchat/Go behavior.

## Validation (fresh CT 199, Debian 13 trixie, systemd)
- `install-deps.sh`: clean (postgres + pgvector + `aimee_shared`).
- `install.sh`: previously `go: not found` → now completes (RC 0), services `active`.
- kb: `memory store`/`search` round-trip works.
- `update.sh --force`: full rebuild (webchat skipped with note), systemd-restarts both services, kb survives the upgrade.

`make all` (-j) + `unit-tests` + `lint` green; Go-present builds still produce webchat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
