### PR TITLE
promote: testing → main (credential-free Docker install #51)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -102,8 +102,12 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           platforms: linux/${{ matrix.platform.arch }}
           provenance: false
+          # Published images bundle the optional browser UI (WITH_WEBCHAT=1); the
+          # default `docker compose up --build` an end user runs leaves it off so it
+          # needs no credentials. The aimee-kb image ignores WITH_WEBCHAT.
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
+            WITH_WEBCHAT=1
           # webchat's SPA pulls @rakuensoftware/smoothgui from GitHub Packages,
           # whose npm registry requires an authenticated token (even for public
           # reads). Prefer a repo/org NPM_TOKEN secret (a PAT with read:packages);

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -9,6 +9,15 @@
 #
 #   docker compose -f compose.combined.yaml up --build
 #   # server /v1 on :8740 (bearer "aimee-local-dev"); kb internal on :8741
+#
+# WITH_WEBCHAT=1 additionally bundles the optional browser UI (aimee-webchat). It
+# is OFF by default because the React frontend pulls @rakuensoftware/smoothgui
+# from GitHub Packages, whose npm registry needs a token even for public reads —
+# so the default build needs NO credentials and ships just the server+kb
+# services. To include webchat:
+#   NPM_TOKEN=<github PAT with read:packages> docker compose \
+#     -f compose.combined.yaml build --build-arg WITH_WEBCHAT=1
+ARG WITH_WEBCHAT=0
 FROM debian:bookworm-slim AS build
 
 # Union of the aimee-server and aimee-kb build deps: server links libsqlite3
@@ -65,6 +74,17 @@ RUN go mod download
 COPY webchat/ ./
 RUN CGO_ENABLED=1 go build -o /out/aimee-webchat .
 
+# Collect webchat artifacts into a uniform /webchat layout. The "1" variant pulls
+# from the frontend + Go builds above (those stages are only in the build graph
+# when WITH_WEBCHAT=1 selects this stage, so a default build never runs npm / the
+# credentialed frontend stage). The "0" variant is empty → no webchat in the image.
+FROM debian:bookworm-slim AS webchat-stage-1
+COPY --from=webchat-build /out/aimee-webchat /webchat/aimee-webchat
+COPY --from=frontend-build /frontend/dist/index.html /webchat/index.html
+FROM debian:bookworm-slim AS webchat-stage-0
+RUN mkdir -p /webchat
+FROM webchat-stage-${WITH_WEBCHAT} AS webchat-stage
+
 FROM debian:bookworm-slim
 
 # Union of both runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
@@ -120,8 +140,17 @@ COPY --chown=aimee:aimee deploy/container/aimee.yaml /var/lib/aimee/.config/aime
 # Co-located webchat browser UI: the Go service, the single-file React SPA, the
 # PAM stack for browser login, and the bootstrap/launch helpers. webchat shares
 # AIMEE_HOME so its Unix-socket transports line up with the server.
-COPY --from=webchat-build /out/aimee-webchat /usr/local/bin/aimee-webchat
-COPY --from=frontend-build /frontend/dist/index.html /usr/local/share/aimee-webchat/index.html
+# Optional webchat: /webchat is empty unless built with WITH_WEBCHAT=1. Install
+# the binary + SPA when present; the entrypoint (webchat-lib.sh) skips the browser
+# UI when the binary is absent, so the server+kb image runs fine without it.
+COPY --from=webchat-stage /webchat/ /tmp/webchat-stage/
+RUN if [ -f /tmp/webchat-stage/aimee-webchat ]; then \
+        install -m 0755 /tmp/webchat-stage/aimee-webchat /usr/local/bin/aimee-webchat; \
+        mkdir -p /usr/local/share/aimee-webchat; \
+        cp /tmp/webchat-stage/index.html /usr/local/share/aimee-webchat/index.html; \
+        echo "aimee: webchat bundled in image"; \
+    else echo "aimee: webchat not bundled (built with WITH_WEBCHAT=0)"; fi; \
+    rm -rf /tmp/webchat-stage
 COPY deploy/container/pam-aimee-webchat /etc/pam.d/aimee-webchat
 COPY deploy/container/webchat-lib.sh /usr/local/bin/webchat-lib.sh
 # Process supervisor: starts kb, waits for kb health, starts the server + webchat.

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -3,6 +3,14 @@
 # AIMEE_KB_API_URL. Without that URL the kb-backed (shared/vector) features are
 # simply unavailable, so this image also runs standalone (DB1-backed endpoints
 # only). The legacy unix-socket kb transport + autostart were retired (#2747).
+#
+# WITH_WEBCHAT=1 bundles the optional browser UI (aimee-webchat). It is OFF by
+# default because the React frontend pulls @rakuensoftware/smoothgui from GitHub
+# Packages, whose npm registry needs a token even for public reads — so the
+# default build needs NO credentials. Enable webchat:
+#   NPM_TOKEN=<github PAT with read:packages> docker compose \
+#     -f compose.server.yaml build --build-arg WITH_WEBCHAT=1
+ARG WITH_WEBCHAT=0
 FROM debian:bookworm-slim AS build
 
 RUN apt-get update \
@@ -56,6 +64,17 @@ RUN go mod download
 COPY webchat/ ./
 RUN CGO_ENABLED=1 go build -o /out/aimee-webchat .
 
+# Collect webchat artifacts into a uniform /webchat layout. The "1" variant pulls
+# from the frontend + Go builds above (only in the build graph when
+# WITH_WEBCHAT=1 selects this stage, so a default build never runs npm / the
+# credentialed frontend stage). The "0" variant is empty → no webchat in the image.
+FROM debian:bookworm-slim AS webchat-stage-1
+COPY --from=webchat-build /out/aimee-webchat /webchat/aimee-webchat
+COPY --from=frontend-build /frontend/dist/index.html /webchat/index.html
+FROM debian:bookworm-slim AS webchat-stage-0
+RUN mkdir -p /webchat
+FROM webchat-stage-${WITH_WEBCHAT} AS webchat-stage
+
 FROM debian:bookworm-slim
 
 # Runtime shared libs the server links: libsqlite3 (DB1), libssl/libcrypto
@@ -101,8 +120,16 @@ COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 # Co-located webchat browser UI: the Go service, the single-file React SPA, the
 # PAM stack for browser login, and the bootstrap/launch helpers. webchat shares
 # AIMEE_HOME so its Unix-socket transports line up with the server.
-COPY --from=webchat-build /out/aimee-webchat /usr/local/bin/aimee-webchat
-COPY --from=frontend-build /frontend/dist/index.html /usr/local/share/aimee-webchat/index.html
+# Optional webchat: /webchat is empty unless built with WITH_WEBCHAT=1. Install
+# the binary + SPA when present; the entrypoint skips the browser UI when absent.
+COPY --from=webchat-stage /webchat/ /tmp/webchat-stage/
+RUN if [ -f /tmp/webchat-stage/aimee-webchat ]; then \
+        install -m 0755 /tmp/webchat-stage/aimee-webchat /usr/local/bin/aimee-webchat; \
+        mkdir -p /usr/local/share/aimee-webchat; \
+        cp /tmp/webchat-stage/index.html /usr/local/share/aimee-webchat/index.html; \
+        echo "aimee: webchat bundled in image"; \
+    else echo "aimee: webchat not bundled (built with WITH_WEBCHAT=0)"; fi; \
+    rm -rf /tmp/webchat-stage
 COPY deploy/container/pam-aimee-webchat /etc/pam.d/aimee-webchat
 COPY deploy/container/webchat-lib.sh /usr/local/bin/webchat-lib.sh
 COPY deploy/container/server-entrypoint.sh /usr/local/bin/aimee-server-entrypoint

--- a/README.md
+++ b/README.md
@@ -402,6 +402,13 @@ Postgres (DB2) and a CPU embedder sidecar (`all-MiniLM-L6-v2`, `Dockerfile.embed
 the kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
 boot.
 
+> **`docker compose ... up --build` needs no credentials.** The default build ships
+> the **server + kb** services only. The optional browser UI (`aimee-webchat`) pulls
+> a private-by-default npm package from GitHub Packages, so it is **off by default**;
+> the entrypoint simply skips it. To include it, either `docker pull` the published
+> image (it already bundles webchat) or build with a GitHub token:
+> `NPM_TOKEN=<PAT with read:packages> docker compose -f compose.combined.yaml build --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN`.
+
 | File | Brings up | Use when |
 |------|-----------|----------|
 | `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default**: both binaries co-located; server `/v1` on `:8740`, kb `:8741` |

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -9,9 +9,11 @@
 #   docker compose -f compose.combined.yaml up --build
 #
 # Server /v1 on :8740 (bearer "aimee-local-dev"); the in-container kb /v1 is also
-# published on :8741 for direct inspection. The aimee-webchat browser UI is on
-# https://localhost:8443 (self-signed; log in as AIMEE_WEBCHAT_USER /
-# AIMEE_WEBCHAT_PASSWORD, default aimee / aimee-local-dev).
+# published on :8741 for direct inspection. The default build needs no credentials
+# and ships server+kb only. The optional aimee-webchat browser UI (https://localhost:8443,
+# self-signed; log in as AIMEE_WEBCHAT_USER / AIMEE_WEBCHAT_PASSWORD, default
+# aimee / aimee-local-dev) is included only when built with --build-arg WITH_WEBCHAT=1
+# (needs a GitHub Packages token) or when running a published image.
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
 #   curl http://localhost:8741/v1/health?status=1
 services:
@@ -46,10 +48,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.combined
-      # webchat's SPA build needs a GitHub Packages token (see Dockerfile.combined).
-      # Sourced from the host $NPM_TOKEN; export it before `docker compose build`.
-      secrets:
-        - npm_token
+      # Default build needs NO credentials and ships the server+kb services only.
+      # The optional browser UI (aimee-webchat) pulls a GitHub Packages npm package
+      # that needs a token; opt in by building with the token + arg:
+      #   NPM_TOKEN=<github PAT> docker compose -f compose.combined.yaml build \
+      #     --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
+      # (or `docker pull` the published image, which already includes webchat).
     image: aimee-server-kb
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
@@ -113,9 +117,3 @@ volumes:
   aimee-combined-postgres:
   aimee-embedder-models:
   aimee-llm-models:
-
-# Build-time secret for the webchat SPA's GitHub Packages dependency. Empty when
-# $NPM_TOKEN is unset (fine for public packages reachable with no token).
-secrets:
-  npm_token:
-    environment: NPM_TOKEN

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -19,10 +19,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
-      # webchat's SPA build needs a GitHub Packages token (see Dockerfile.server).
-      # Sourced from the host $NPM_TOKEN; export it before `docker compose build`.
-      secrets:
-        - npm_token
+      # Default build needs NO credentials (server ships without the browser UI).
+      # Opt into the optional aimee-webchat with a GitHub Packages token:
+      #   NPM_TOKEN=<github PAT> docker compose -f compose.server-standalone.yaml \
+      #     build --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
     image: aimee-server
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
@@ -47,9 +47,3 @@ services:
 volumes:
   aimee-server-home:
   aimee-server-workspaces:
-
-# Build-time secret for the webchat SPA's GitHub Packages dependency. Empty when
-# $NPM_TOKEN is unset (fine for public packages reachable with no token).
-secrets:
-  npm_token:
-    environment: NPM_TOKEN

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -70,10 +70,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.server
-      # webchat's SPA build needs a GitHub Packages token (see Dockerfile.server).
-      # Sourced from the host $NPM_TOKEN; export it before `docker compose build`.
-      secrets:
-        - npm_token
+      # Default build needs NO credentials (server ships without the browser UI).
+      # The optional aimee-webchat pulls a GitHub Packages npm package needing a
+      # token; opt in with:
+      #   NPM_TOKEN=<github PAT> docker compose -f compose.server.yaml build \
+      #     --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
+      # (or `docker pull` the published image, which already includes webchat).
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:
@@ -137,9 +139,3 @@ volumes:
   aimee-server-postgres:
   aimee-embedder-models:
   aimee-llm-models:
-
-# Build-time secret for the webchat SPA's GitHub Packages dependency. Empty when
-# $NPM_TOKEN is unset (fine for public packages reachable with no token).
-secrets:
-  npm_token:
-    environment: NPM_TOKEN

--- a/deploy/container/webchat-lib.sh
+++ b/deploy/container/webchat-lib.sh
@@ -53,6 +53,12 @@ webchat_bootstrap_user() {
 # Launch aimee-webchat in the background (as root, for PAM). Self-signed TLS on
 # :8443 is auto-generated under AIMEE_HOME and persists on the data volume.
 webchat_start() {
+    # webchat is optional: images built with WITH_WEBCHAT=0 ship no aimee-webchat
+    # binary. Skip the browser UI rather than fail — the server is the contract.
+    if ! command -v aimee-webchat >/dev/null 2>&1; then
+        webchat_log "aimee-webchat not present (image built without WITH_WEBCHAT); skipping browser UI"
+        return 0
+    fi
     webchat_bootstrap_user
     webchat_log "starting aimee-webchat on :$WEBCHAT_PORT (https), socket=$WEBCHAT_HOME/aimee-server.sock"
     HOME=/root aimee-webchat \


### PR DESCRIPTION
Promote testing → main.

Single change since main: **#51** — makes the recommended Docker install work for any end user with no credentials.

`docker compose -f compose.combined.yaml up --build` (README's first install step) failed out of the box: the combined/server images build the webchat React frontend with `npm ci`, which 401s on the private `@rakuensoftware/smoothgui` GitHub Packages dep. Webchat is now optional in the images (`WITH_WEBCHAT=0` default): a default build ships server+kb with no credentials and skips the browser UI; published images and `--build-arg WITH_WEBCHAT=1` (with a token) still include it.

Validated on a clean Docker host: credential-free `up --build` comes up healthy (`/v1/health` ok, `/v1/kb/status` pgvector-ready, kb reachable). CI green on #51.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
