### PR TITLE
fix(docker): aimee-kb needs a 64MB stack ulimit (SIGSEGV on first memory query)

### DIFF
--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -45,6 +45,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    # The kb's drain/ingest/watch/query worker threads need a 64 MB stack; the
+    # 8 MB container default overflows and SIGSEGVs (exit 139) on real memory/kb
+    # queries. Matches systemd's LimitSTACK=67108864 and the cli fork-exec ulimit.
+    ulimits:
+      stack: 67108864
     environment:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    # The kb's drain/ingest/watch/query worker threads need a 64 MB stack; the
+    # 8 MB container default overflows and SIGSEGVs (exit 139) on real memory/kb
+    # queries. Matches systemd's LimitSTACK=67108864 and the cli fork-exec ulimit.
+    ulimits:
+      stack: 67108864
     environment:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -116,6 +116,15 @@ check "POST /v1/search"           '"hits"'     -X POST -H 'content-type: applica
                                                -d '{"query":"docker smoke test","max_results":3}' \
                                                "${KB_URL}/v1/search"
 
+# memory.find_facts with graph-code fusion ON is the deepest-stack worker path
+# (the server's `aimee memory search` drives it). It SIGSEGVs the kb (exit 139)
+# unless the container has a 64 MB stack ulimit — a regression the /v1/search
+# check above does NOT catch. curl -fsS fails here if the kb crashed, so this
+# guards the ulimit fix. An empty "facts" array on a fresh DB is a pass.
+check "POST memory.find_facts (fusion)" '"facts"' -X POST -H 'content-type: application/json' \
+                                               -d '{"query":"docker smoke test","limit":3,"graph_code_fusion_state":"on"}' \
+                                               "${KB_URL}/v1/actions/memory.find_facts"
+
 bold "==> Embedder round-trip (in-network, via the kb container)"
 if "${DC[@]}" ps --format '{{.Service}}' 2>/dev/null | grep -qx embedder; then
   if emb="$("${DC[@]}" exec -T aimee-kb sh -c \


### PR DESCRIPTION
Deeper install-story dig: the split and kb-only **Docker stacks crash the kb on the first real memory query**.

## The bug (SIGSEGV, exit 139)
On a clean Docker host, `docker compose -f compose.server.yaml up --build` comes up healthy, but the first `aimee memory search` returns *"knowledge service search index unavailable"* and the **`aimee-kb` container is `Exited (139)`** (SIGSEGV, not OOM). Root cause: the kb's drain/ingest/watch/query worker threads need a **64 MB stack**, but the `aimee-kb` service in `compose.server.yaml` and `compose.yaml` was **missing `ulimits: stack`**, so the kb ran with the 8 MB container default and overflowed on the deep-stack `memory.find_facts` (graph-code fusion) path. `aimee-server` and the combined image already set it; the systemd unit sets `LimitSTACK=67108864`; the Dockerfile says callers MUST raise it.

## Fix
- `compose.server.yaml`, `compose.yaml`: add `ulimits: { stack: 67108864 }` to the `aimee-kb` service.
- `aimee-kb-docker-smoke.sh`: add a `POST /v1/actions/memory.find_facts` (fusion on) check — the deepest-stack path that actually triggers the crash. The existing `/v1/search` check did **not** trigger it (which is why CI missed it); the new check fails (`curl -fsS`) if the kb SIGSEGVs.

## Validated on a clean Docker host (CT 101)
Before: split stack → `memory search` → kb `Exited (139)`. After (with the ulimit): same query returns `{"facts":[],"status":"ok"}`, kb stays `Up (healthy)`. `make lint` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
