### PR TITLE
promote: testing → main (aimee-kb stack ulimit / Docker crash fix #55)

### DIFF
--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -45,6 +45,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    # The kb's drain/ingest/watch/query worker threads need a 64 MB stack; the
+    # 8 MB container default overflows and SIGSEGVs (exit 139) on real memory/kb
+    # queries. Matches systemd's LimitSTACK=67108864 and the cli fork-exec ulimit.
+    ulimits:
+      stack: 67108864
     environment:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    # The kb's drain/ingest/watch/query worker threads need a 64 MB stack; the
+    # 8 MB container default overflows and SIGSEGVs (exit 139) on real memory/kb
+    # queries. Matches systemd's LimitSTACK=67108864 and the cli fork-exec ulimit.
+    ulimits:
+      stack: 67108864
     environment:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -116,6 +116,15 @@ check "POST /v1/search"           '"hits"'     -X POST -H 'content-type: applica
                                                -d '{"query":"docker smoke test","max_results":3}' \
                                                "${KB_URL}/v1/search"
 
+# memory.find_facts with graph-code fusion ON is the deepest-stack worker path
+# (the server's `aimee memory search` drives it). It SIGSEGVs the kb (exit 139)
+# unless the container has a 64 MB stack ulimit — a regression the /v1/search
+# check above does NOT catch. curl -fsS fails here if the kb crashed, so this
+# guards the ulimit fix. An empty "facts" array on a fresh DB is a pass.
+check "POST memory.find_facts (fusion)" '"facts"' -X POST -H 'content-type: application/json' \
+                                               -d '{"query":"docker smoke test","limit":3,"graph_code_fusion_state":"on"}' \
+                                               "${KB_URL}/v1/actions/memory.find_facts"
+
 bold "==> Embedder round-trip (in-network, via the kb container)"
 if "${DC[@]}" ps --format '{{.Service}}' 2>/dev/null | grep -qx embedder; then
   if emb="$("${DC[@]}" exec -T aimee-kb sh -c \


### PR DESCRIPTION
Promote testing → main.

Single change since main: **#55** — fix a SIGSEGV that crashed the `aimee-kb` container on the first real memory query in the split (`compose.server.yaml`) and kb-only (`compose.yaml`) Docker stacks.

The kb's worker threads need a 64 MB stack; those `aimee-kb` services were missing `ulimits: stack`, so the kb ran with the 8 MB container default and overflowed on the `memory.find_facts` (graph-code fusion) path → exit 139. Added the ulimit (matching aimee-server / the combined image / the systemd unit) and a `memory.find_facts` check to the kb smoke (the existing `/v1/search` check didn't trigger the crash, so CI missed it).

Validated on a clean Docker host: before → kb `Exited (139)`; after → `{"facts":[],"status":"ok"}`, kb healthy. CI e2e-docker green on #55 with the new check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
