### PR TITLE
promote: testing -> main (compose restart: unless-stopped #59)

### DIFF
--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -18,6 +18,7 @@
 #   curl http://localhost:8741/v1/health?status=1
 services:
   postgres:
+    restart: unless-stopped
     image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: aimee_shared
@@ -32,6 +33,7 @@ services:
       retries: 5
 
   embedder:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -45,6 +47,7 @@ services:
       start_period: 30s
 
   aimee-server-kb:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.combined
@@ -95,6 +98,7 @@ services:
   # Optional local LLM for the kb synthesis / curator passes. Enable with
   #   docker compose -f compose.combined.yaml --profile llm up
   llm:
+    restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
     profiles: ["llm"]
     environment:

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -16,6 +16,7 @@
 #     -v aimee-workspaces:/var/lib/aimee-workspaces aimee-server
 services:
   aimee-server:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.server

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -15,6 +15,7 @@
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
 services:
   postgres:
+    restart: unless-stopped
     image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: aimee_shared
@@ -29,6 +30,7 @@ services:
       retries: 5
 
   embedder:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -42,6 +44,7 @@ services:
       start_period: 30s
 
   aimee-kb:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile
@@ -72,6 +75,7 @@ services:
       - aimee-kb-home:/var/lib/aimee
 
   aimee-server:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.server
@@ -121,6 +125,7 @@ services:
   # Optional local LLM for the kb synthesis / curator passes. Enable with
   #   docker compose -f compose.server.yaml --profile llm up
   llm:
+    restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
     profiles: ["llm"]
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   postgres:
+    restart: unless-stopped
     image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: aimee_shared
@@ -14,6 +15,7 @@ services:
       retries: 5
 
   embedder:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -27,6 +29,7 @@ services:
       start_period: 30s
 
   aimee-kb:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile
@@ -68,6 +71,7 @@ services:
   # The model is fetched from HuggingFace on first start (-hf) and cached in the
   # volume; override LLAMA_ARG_HF_REPO to choose a different GGUF.
   llm:
+    restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
     profiles: ["llm"]
     environment:


### PR DESCRIPTION
Promote testing -> main: add restart: unless-stopped to all Docker compose services.

README/MANUAL say the containers are "supervised by Docker's restart policy", but no compose service set one, so a crash or host reboot left the stack down until a manual `docker compose up`. Adds `restart: unless-stopped` to postgres, embedder, aimee-kb, aimee-server, aimee-server-kb, and llm across compose.combined.yaml, compose.server.yaml, compose.yaml, and compose.server-standalone.yaml. Pairs with the pid-file restart fix already on main (#57).

Squash-merged with a clean commit message.
