### PR TITLE
fix(docker): seed kb config past bind-mount shadow + raise stack rlimit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,11 @@ COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 COPY scripts/embed-remote.py scripts/llm-chat.py scripts/learning-synthesize.py \
      scripts/curator-extract.py /opt/aimee/scripts/
 # Baked default config: selects the sidecar commands (endpoints come from env).
-COPY --chown=aimee:aimee deploy/container/aimee.yaml /var/lib/aimee/.config/aimee/aimee.yaml
+# Kept OUTSIDE $AIMEE_HOME so a bind mount over /var/lib/aimee can't shadow it;
+# the entrypoint seeds it into $AIMEE_HOME/.config/aimee on first start.
+COPY deploy/container/aimee.yaml /opt/aimee/defaults/aimee.yaml
+COPY deploy/container/aimee-kb-entrypoint.sh /usr/local/bin/aimee-kb-entrypoint.sh
+RUN chmod +x /usr/local/bin/aimee-kb-entrypoint.sh
 
 USER aimee
 WORKDIR /var/lib/aimee
@@ -61,7 +65,10 @@ EXPOSE 8741
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8741/v1/health >/dev/null || exit 1
 
-ENTRYPOINT ["aimee-kb"]
+# The entrypoint raises the worker-thread stack rlimit and seeds the baked
+# config into $AIMEE_HOME when a bind mount has shadowed the image copy, then
+# execs aimee-kb. See deploy/container/aimee-kb-entrypoint.sh.
+ENTRYPOINT ["/usr/local/bin/aimee-kb-entrypoint.sh"]
 # aimee-kb serves the /v1 HTTP API only; --http-port is required (it exits without
 # one). The legacy --socket transport was retired (#2747).
 CMD ["--http-port=8741"]

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# aimee-kb container entrypoint.
+#
+# Wraps the aimee-kb binary to make the image robust to deployment
+# environments whose volume semantics differ from Docker named volumes.
+#
+# 1. Stack rlimit. The kb's drain/ingest/watch/query worker threads need a
+#    64 MB stack; the 8 MB container default overflows and SIGSEGVs (exit 139)
+#    on real memory/kb queries. Compose sets `ulimits: stack: 67108864`, but
+#    runtimes that don't (e.g. SmoothNAS plugins, plain `docker run`) inherit
+#    the small default. The container's hard limit is unlimited, so raise the
+#    soft limit here before exec.
+#
+# 2. Baked config seeding. The default config that selects the embedder/LLM
+#    sidecar commands is baked at $AIMEE_HOME/.config/aimee/aimee.yaml. Docker
+#    *named* volumes copy image content into a fresh volume, so the baked file
+#    survives; *bind* mounts (including SmoothNAS "flat" plugin volumes) shadow
+#    the directory with an empty host dir, dropping the config — the kb then
+#    falls back to a non-functional builtin embedder (embed_ok=false). Keep the
+#    canonical default outside $AIMEE_HOME (at /opt/aimee/defaults) and seed it
+#    in if the config is missing, so embeddings work under any volume type.
+set -e
+
+# 1. Stack rlimit (64 MB == 65536 KiB == 67108864 bytes). Best-effort: some
+#    runtimes forbid raising it, in which case the compose ulimit / a host
+#    profile is still required.
+ulimit -s 65536 2>/dev/null || true
+
+# 2. Seed the baked default config if the (possibly bind-mounted) config dir
+#    lacks it. Never clobber an operator-provided config.
+: "${AIMEE_HOME:=/var/lib/aimee}"
+cfg="$AIMEE_HOME/.config/aimee/aimee.yaml"
+default="/opt/aimee/defaults/aimee.yaml"
+if [ ! -f "$cfg" ] && [ -f "$default" ]; then
+    mkdir -p "$AIMEE_HOME/.config/aimee"
+    cp "$default" "$cfg"
+fi
+
+exec aimee-kb "$@"

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -19,6 +19,11 @@
 #    falls back to a non-functional builtin embedder (embed_ok=false). Keep the
 #    canonical default outside $AIMEE_HOME (at /opt/aimee/defaults) and seed it
 #    in if the config is missing, so embeddings work under any volume type.
+#
+#    The config path is aimee_home()/aimee.yaml; with AIMEE_HOME set,
+#    aimee_home() == $AIMEE_HOME verbatim (see src/aimee_home.c), so the file
+#    the kb reads is $AIMEE_HOME/aimee.yaml -- NOT $AIMEE_HOME/.config/aimee/
+#    (that path only applies when AIMEE_HOME is unset and $HOME/.config is used).
 set -e
 
 # 1. Stack rlimit (64 MB == 65536 KiB == 67108864 bytes). Best-effort: some
@@ -26,13 +31,13 @@ set -e
 #    profile is still required.
 ulimit -s 65536 2>/dev/null || true
 
-# 2. Seed the baked default config if the (possibly bind-mounted) config dir
-#    lacks it. Never clobber an operator-provided config.
+# 2. Seed the baked default config if it is missing (fresh / bind-mounted
+#    volume). Never clobber an operator-provided config.
 : "${AIMEE_HOME:=/var/lib/aimee}"
-cfg="$AIMEE_HOME/.config/aimee/aimee.yaml"
+cfg="$AIMEE_HOME/aimee.yaml"
 default="/opt/aimee/defaults/aimee.yaml"
 if [ ! -f "$cfg" ] && [ -f "$default" ]; then
-    mkdir -p "$AIMEE_HOME/.config/aimee"
+    mkdir -p "$AIMEE_HOME"
     cp "$default" "$cfg"
 fi
 


### PR DESCRIPTION
## Problem

Deploying `aimee-kb` as a SmoothNAS plugin (bind-mounted `flat` volumes), the kb comes up but `/v1/health` reports `embed_ok: false`, `embed_command: builtin` — semantic memory/search is dead even though the bundled embedder service is healthy and returns valid vectors.

Root cause: the image bakes the config that selects the embedder/LLM sidecar commands at `$AIMEE_HOME/.config/aimee/aimee.yaml`. Docker **named** volumes copy image content into a fresh volume (so compose works), but **bind** mounts (SmoothNAS flat volumes, plain `docker run -v`) shadow the dir with an empty host dir → no `embedding_command` → silent fallback to a non-functional builtin embedder.

Separately, the kb worker threads need a 64 MB stack; runtimes that don't set `ulimits: stack` (compose does; SmoothNAS plugins / bare `docker run` don't) inherit the 8 MB default and SIGSEGV (exit 139) on real memory/kb queries.

## Fix

Add an entrypoint wrapper (`deploy/container/aimee-kb-entrypoint.sh`) that:
- keeps the canonical default config outside `$AIMEE_HOME` (`/opt/aimee/defaults/aimee.yaml`) and seeds it into `$AIMEE_HOME/.config/aimee` on first start if absent (never clobbering an operator config);
- raises the soft stack rlimit to 64 MB (hard limit is unlimited) before `exec aimee-kb`.

Embeddings now work out of the box under any volume type, with no plugin profile required.

## Test
- Standalone entrypoint test: empty home → config seeded with `embedding_command`; pre-existing config → preserved; stack soft limit → 65536.
- Validated against the live SmoothNAS box (.254): confirmed the bind-mount shadow drops the baked config and the kb falls back to builtin; this restores it.