### PR TITLE
Promote: aimee-kb embedder-config + stack-rlimit fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,11 @@ COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 COPY scripts/embed-remote.py scripts/llm-chat.py scripts/learning-synthesize.py \
      scripts/curator-extract.py /opt/aimee/scripts/
 # Baked default config: selects the sidecar commands (endpoints come from env).
-COPY --chown=aimee:aimee deploy/container/aimee.yaml /var/lib/aimee/.config/aimee/aimee.yaml
+# Kept OUTSIDE $AIMEE_HOME so a bind mount over /var/lib/aimee can't shadow it;
+# the entrypoint seeds it into $AIMEE_HOME/.config/aimee on first start.
+COPY deploy/container/aimee.yaml /opt/aimee/defaults/aimee.yaml
+COPY deploy/container/aimee-kb-entrypoint.sh /usr/local/bin/aimee-kb-entrypoint.sh
+RUN chmod +x /usr/local/bin/aimee-kb-entrypoint.sh
 
 USER aimee
 WORKDIR /var/lib/aimee
@@ -61,7 +65,10 @@ EXPOSE 8741
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8741/v1/health >/dev/null || exit 1
 
-ENTRYPOINT ["aimee-kb"]
+# The entrypoint raises the worker-thread stack rlimit and seeds the baked
+# config into $AIMEE_HOME when a bind mount has shadowed the image copy, then
+# execs aimee-kb. See deploy/container/aimee-kb-entrypoint.sh.
+ENTRYPOINT ["/usr/local/bin/aimee-kb-entrypoint.sh"]
 # aimee-kb serves the /v1 HTTP API only; --http-port is required (it exits without
 # one). The legacy --socket transport was retired (#2747).
 CMD ["--http-port=8741"]

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -18,6 +18,7 @@
 #   curl http://localhost:8741/v1/health?status=1
 services:
   postgres:
+    restart: unless-stopped
     image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: aimee_shared
@@ -32,6 +33,7 @@ services:
       retries: 5
 
   embedder:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -45,6 +47,7 @@ services:
       start_period: 30s
 
   aimee-server-kb:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.combined
@@ -95,6 +98,7 @@ services:
   # Optional local LLM for the kb synthesis / curator passes. Enable with
   #   docker compose -f compose.combined.yaml --profile llm up
   llm:
+    restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
     profiles: ["llm"]
     environment:

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -16,6 +16,7 @@
 #     -v aimee-workspaces:/var/lib/aimee-workspaces aimee-server
 services:
   aimee-server:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.server

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -15,6 +15,7 @@
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
 services:
   postgres:
+    restart: unless-stopped
     image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: aimee_shared
@@ -29,6 +30,7 @@ services:
       retries: 5
 
   embedder:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -42,6 +44,7 @@ services:
       start_period: 30s
 
   aimee-kb:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile
@@ -72,6 +75,7 @@ services:
       - aimee-kb-home:/var/lib/aimee
 
   aimee-server:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.server
@@ -121,6 +125,7 @@ services:
   # Optional local LLM for the kb synthesis / curator passes. Enable with
   #   docker compose -f compose.server.yaml --profile llm up
   llm:
+    restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
     profiles: ["llm"]
     environment:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,6 @@
 services:
   postgres:
+    restart: unless-stopped
     image: pgvector/pgvector:pg16
     environment:
       POSTGRES_DB: aimee_shared
@@ -14,6 +15,7 @@ services:
       retries: 5
 
   embedder:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -27,6 +29,7 @@ services:
       start_period: 30s
 
   aimee-kb:
+    restart: unless-stopped
     build:
       context: .
       dockerfile: Dockerfile
@@ -68,6 +71,7 @@ services:
   # The model is fetched from HuggingFace on first start (-hf) and cached in the
   # volume; override LLAMA_ARG_HF_REPO to choose a different GGUF.
   llm:
+    restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
     profiles: ["llm"]
     environment:

--- a/deploy/container/aimee-kb-entrypoint.sh
+++ b/deploy/container/aimee-kb-entrypoint.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# aimee-kb container entrypoint.
+#
+# Wraps the aimee-kb binary to make the image robust to deployment
+# environments whose volume semantics differ from Docker named volumes.
+#
+# 1. Stack rlimit. The kb's drain/ingest/watch/query worker threads need a
+#    64 MB stack; the 8 MB container default overflows and SIGSEGVs (exit 139)
+#    on real memory/kb queries. Compose sets `ulimits: stack: 67108864`, but
+#    runtimes that don't (e.g. SmoothNAS plugins, plain `docker run`) inherit
+#    the small default. The container's hard limit is unlimited, so raise the
+#    soft limit here before exec.
+#
+# 2. Baked config seeding. The default config that selects the embedder/LLM
+#    sidecar commands is baked at $AIMEE_HOME/.config/aimee/aimee.yaml. Docker
+#    *named* volumes copy image content into a fresh volume, so the baked file
+#    survives; *bind* mounts (including SmoothNAS "flat" plugin volumes) shadow
+#    the directory with an empty host dir, dropping the config — the kb then
+#    falls back to a non-functional builtin embedder (embed_ok=false). Keep the
+#    canonical default outside $AIMEE_HOME (at /opt/aimee/defaults) and seed it
+#    in if the config is missing, so embeddings work under any volume type.
+#
+#    The config path is aimee_home()/aimee.yaml; with AIMEE_HOME set,
+#    aimee_home() == $AIMEE_HOME verbatim (see src/aimee_home.c), so the file
+#    the kb reads is $AIMEE_HOME/aimee.yaml -- NOT $AIMEE_HOME/.config/aimee/
+#    (that path only applies when AIMEE_HOME is unset and $HOME/.config is used).
+set -e
+
+# 1. Stack rlimit (64 MB == 65536 KiB == 67108864 bytes). Best-effort: some
+#    runtimes forbid raising it, in which case the compose ulimit / a host
+#    profile is still required.
+ulimit -s 65536 2>/dev/null || true
+
+# 2. Seed the baked default config if it is missing (fresh / bind-mounted
+#    volume). Never clobber an operator-provided config.
+: "${AIMEE_HOME:=/var/lib/aimee}"
+cfg="$AIMEE_HOME/aimee.yaml"
+default="/opt/aimee/defaults/aimee.yaml"
+if [ ! -f "$cfg" ] && [ -f "$default" ]; then
+    mkdir -p "$AIMEE_HOME"
+    cp "$default" "$cfg"
+fi
+
+exec aimee-kb "$@"


### PR DESCRIPTION
Promote testing to main to release the aimee-kb deploy fix (#61) and the docker restart-policy fix (#59). Auto-release cuts the next patch (v0.2.22) and republishes aimee-kb:latest with the entrypoint that seeds the embedder config at the path the kb reads and raises the worker-thread stack rlimit.