### PR TITLE
Promote: aimee-server-kb tier-ready (stack + shared config + uid 1000)

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -121,7 +121,10 @@ ENV LLM_ENDPOINT=http://llm:8080/v1
 # a dedicated volume, matching Dockerfile.server.
 ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces
 
-RUN useradd --system --home-dir /var/lib/aimee --create-home --shell /usr/sbin/nologin aimee \
+# aimee runs as uid 1000 so it can own its data on storage backends that
+# present a uniform owner (e.g. SmoothNAS smoothfs tiers force uid 1000). The
+# entrypoint stays root (for webchat PAM) and drops kb/server to this user.
+RUN useradd --uid 1000 --user-group --home-dir /var/lib/aimee --create-home --shell /usr/sbin/nologin aimee \
     && mkdir -p /var/lib/aimee-workspaces /var/lib/aimee/.config/aimee \
     && chown -R aimee:aimee /var/lib/aimee-workspaces /var/lib/aimee/.config
 VOLUME /var/lib/aimee-workspaces
@@ -132,11 +135,12 @@ COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 # kb sidecar clients (LLM/embedder access code the kb invokes via popen).
 COPY scripts/embed-remote.py scripts/llm-chat.py scripts/learning-synthesize.py \
      scripts/curator-extract.py /opt/aimee/scripts/
-# Baked configs: the server config (port + bearer for the /v1 listener) and the
-# kb config (sidecar command selection). They live at distinct paths so they do
-# not collide under the shared AIMEE_HOME.
-COPY --chown=aimee:aimee deploy/container/aimee-server.yaml /var/lib/aimee/aimee.yaml
-COPY --chown=aimee:aimee deploy/container/aimee.yaml /var/lib/aimee/.config/aimee/aimee.yaml
+# Baked default config kept OUTSIDE $AIMEE_HOME so a bind-mounted (empty) volume
+# can't shadow it; the entrypoint seeds it into $AIMEE_HOME/aimee.yaml on first
+# start. server + kb share AIMEE_HOME and both read $AIMEE_HOME/aimee.yaml, so
+# this single merged file carries the server's /v1 settings AND the kb's sidecar
+# command selection (incl. embedding_command).
+COPY deploy/container/aimee-combined.yaml /opt/aimee/defaults/aimee.yaml
 # Co-located webchat browser UI: the Go service, the single-file React SPA, the
 # PAM stack for browser login, and the bootstrap/launch helpers. webchat shares
 # AIMEE_HOME so its Unix-socket transports line up with the server.
@@ -163,11 +167,12 @@ WORKDIR /var/lib/aimee
 # 8740 = server /v1; 8741 = kb /v1; 8443 = aimee-webchat browser UI (HTTPS).
 EXPOSE 8740 8741 8443
 
-# NOTE: the server's worker threads need a 64 MB stack. A Dockerfile cannot set
-# a runtime ulimit, so callers MUST raise it (the 8 MB container default
-# overflows during server startup and the process segfaults):
-#   docker run --ulimit stack=67108864 ...
-#   # or in compose:   ulimits: { stack: 67108864 }
+# NOTE: the server's/kb's worker threads need a 64 MB stack (the 8 MB container
+# default overflows during startup and the process segfaults). The entrypoint
+# raises the soft stack rlimit to 64 MB before launching them, so no runtime
+# --ulimit is required on hosts whose hard limit allows it (the usual case;
+# hard stack defaults to unlimited). A runtime ulimit still works if you'd
+# rather set it explicitly:  docker run --ulimit stack=67108864 ...
 
 # Health probe targets the SERVER /v1 listener (the container's public contract).
 # Every TCP /v1 request is authenticated, so an unauthenticated probe returns

--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -1,0 +1,36 @@
+# Default aimee-combined (server + kb) container configuration.
+#
+# In the combined image the server and the kb share AIMEE_HOME, and both read
+# their config from $AIMEE_HOME/aimee.yaml (config_default_dir() == aimee_home()
+# == $AIMEE_HOME). So a single merged file must carry BOTH the server's /v1
+# listener settings AND the kb's sidecar-command selection — otherwise whichever
+# one isn't in aimee.yaml is silently lost (the kb's embedding_command landing in
+# a never-read .config/aimee/aimee.yaml is how embeddings ended up disabled).
+#
+# Endpoints come from the environment (AIMEE_EMBEDDER_URL / LLM_ENDPOINT). The
+# entrypoint seeds this file into $AIMEE_HOME on first start, so it survives a
+# bind-mounted (empty) volume — see deploy/container/combined-entrypoint.sh.
+
+# --- server: inbound /v1 HTTP API (binds only with port + bearer set) ---
+aimee:
+  api:
+    http_port: 8740
+    bearer_token: "aimee-local-dev"
+    rate_limit_per_min: 0
+    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
+    # port a bearer is read/query/chat only. Opt into remote writes here:
+    #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
+    #   remote_writes: full   # + delegate/tool over /v1/rpc — trusted nets only
+    remote_writes: "off"
+
+# --- kb: real semantic embeddings via the persistent embedder service ---
+embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"
+
+learning:
+  synthesize:
+    enabled: false
+    command: "python3 /opt/aimee/scripts/learning-synthesize.py"
+
+kb:
+  curator:
+    extract_command: "python3 /opt/aimee/scripts/curator-extract.py"

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -16,9 +16,30 @@
 # (compose supplies AIMEE_DB2_URL / AIMEE_EMBEDDER_URL).
 set -eu
 
+AIMEE_HOME="${AIMEE_HOME:-/var/lib/aimee}"
 KB_HTTP_PORT="${AIMEE_KB_HTTP_PORT:-8741}"
 SERVER_SOCK="${AIMEE_SERVER_SOCK:-/var/lib/aimee/aimee-server.sock}"
 KB_WAIT_SECONDS="${KB_WAIT_SECONDS:-120}"
+
+# Worker threads (server + kb drain/ingest/watch/query) need a 64 MB stack; the
+# 8 MB container default overflows and SIGSEGVs on real queries. Raise the soft
+# limit here (inherited by the runuser children); hard limit is unlimited on
+# typical hosts. Best-effort — a runtime --ulimit still works if disallowed.
+ulimit -s 65536 2>/dev/null || true
+
+# Seed the baked default config into AIMEE_HOME if absent. The server and kb
+# share AIMEE_HOME and both read $AIMEE_HOME/aimee.yaml; a bind-mounted (empty)
+# volume would otherwise leave them with no config (no /v1 bearer; embeddings
+# falling back to the broken builtin). Never clobber an operator's config. Done
+# as root before dropping to "aimee", then chown so aimee can read/rewrite it.
+if [ ! -f "$AIMEE_HOME/aimee.yaml" ] && [ -f /opt/aimee/defaults/aimee.yaml ]; then
+    mkdir -p "$AIMEE_HOME"
+    cp /opt/aimee/defaults/aimee.yaml "$AIMEE_HOME/aimee.yaml"
+fi
+# Ensure aimee (uid 1000) owns its home + workspaces so it can write on an empty
+# bind mount. On smoothfs tiers ownership is forced to 1000 regardless; harmless.
+chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspaces}" 2>/dev/null || true
+[ -f "$AIMEE_HOME/aimee.yaml" ] && chown aimee:aimee "$AIMEE_HOME/aimee.yaml" 2>/dev/null || true
 
 kb_pid=""
 server_pid=""


### PR DESCRIPTION
Promote testing to main to release the combined-image tier-readiness fix (#63): raises the worker stack rlimit, seeds a merged server+kb config (restores embeddings), and runs as uid 1000 so aimee-combined works on a SmoothNAS storage tier. Auto-release rebuilds + republishes the aimee-server-kb image.