### PR TITLE
Promote: remote mcp-serve (Phase 2a+2b) + corrected thin-client proposal

### DIFF
--- a/docs/proposals/pending/self-sufficient-thin-client.md
+++ b/docs/proposals/pending/self-sufficient-thin-client.md
@@ -1,153 +1,121 @@
-# Proposal: Self-sufficient thin client — in-process execution plane + `/v1` data plane
+# Proposal: Self-sufficient thin client — one binary, strict 3-tier, server-side execution
 
-One binary an end user installs to use *any* aimee (local files or a shared
-remote), with **no separate `aimee-server` process** to run or manage.
+One `aimee` binary an end user installs to use *any* aimee. The client is a
+**pure `/v1` client to aimee-server** — it knows nothing about DB1 or DB2, runs
+no engine, and never talks to aimee-kb directly. All work happens on
+aimee-server; for operations that touch the user's local files, the client
+exposes its working tree to the server over the existing **detached workspace
+reverse-channel** — it does not absorb the engine.
 
-## Summary
+> Supersedes the earlier draft of this proposal, which argued for embedding the
+> engine *into* the client. That was the wrong direction: it would have put DB/
+> engine knowledge in the client. The architecture below is the opposite and
+> matches the intended 3-tier separation.
 
-Today the user-facing `aimee` binary is a pure client. The **data plane**
-(memory / kb / rules / index / sessions / notes) already works against any
-aimee over first-class `/v1` HTTP — proven by thin-client → remote NAS. But the
-**execution plane** (the SessionStart/pre/post hooks, `chat`, `mcp-serve`,
-`launch`, `delegate`, `agent setup`) routes through
-`cli_ensure_server_for_method()`, which only discovers a **co-located** server
-over a local socket. So a remote/thin deployment cannot run the agent at all,
-and a normal dev box needs a second component (`aimee-server`, systemd-managed)
-just to make the Claude Code integration work.
+## The invariant (3-tier)
 
-This proposal folds the execution engine into the `aimee` binary so it runs the
-agent/hooks/tools/MCP **in-process, locally**, while reaching shared memory/kb
-over `/v1` against a configurable backend (local file or remote). Result: a
-single install that is "everything an end user needs," and the execution plane
-stops being hard-bound to a co-located daemon.
+- **Thin client** — pure `/v1` HTTP to **aimee-server only**. No sqlite (DB1),
+  no libpq (DB2), no `kb_client`/`AIMEE_KB_API_URL`, no direct aimee-kb access.
+- **aimee-server** — owns **DB1** (sqlite), runs the engine (agent loop, tools,
+  hooks, MCP, delegate), and **proxies all kb/DB2 traffic to aimee-kb itself**.
+- **aimee-kb** — owns **DB2** (postgres/pgvector).
 
-Phase 0 already shipped (#69): `session-start` now serves itself over remote
-`/v1` recall when no local server is present — the first, purely-data-plane
-slice of this vision.
+The client routes everything through aimee-server; aimee-server fans out to
+aimee-kb. The client is transport + local-workspace access, nothing more.
 
-## Motivation
+## Current state (verified)
 
-- **Remote/shared deployments are first-class for the data plane but broken for
-  the agent.** After moving memory+kb to a shared host (e.g. a SmoothNAS
-  aimee-kb), the dev box's `aimee` can query everything over `/v1`, but
-  `session-start`, `chat`, and `mcp-serve` fail with "server unavailable"
-  because they want a local socket. (This is exactly the regression #69 fixed
-  for one method.)
-- **"Install one thing" is the product goal.** An end user should `install aimee`
-  and have the full surface — not "install the CLI *and* stand up/manage an
-  `aimee-server` service."
-- **The split that caused this was a lifecycle fix, not a design north star.**
-  `cli_ensure_server_for_method()` documents #1660: the CLI stopped spawning
-  servers on demand after "five iterations of orphan-listener fixes … every CLI
-  invocation was a potential server-spawner," handing lifecycle to systemd. That
-  solved orphaned **listeners** — but the answer for the execution plane is to
-  run it **in-process with no listener at all**, which sidesteps the orphan
-  problem entirely rather than requiring a managed daemon.
-
-## Background: what exists today
-
-- **Data plane (done).** `cli_rpc_lookup` + `cli_rpc_forward` resolve a method to
-  a first-class `/v1` route (`cli_v1_routes_gen.inc`) and POST it to the
-  configured endpoint — local UDS *or* remote TCP (`cli_rpc_client_endpoint`,
-  `cli_rpc_client_bearer`, `cli_rpc_has_remote_endpoint`). `kb_client_*` already
-  speaks to a remote kb. No socket-RPC bridge remains (`/v1/rpc` retired).
-- **Execution plane (local-only).** `handle_session_start`, `chat`
-  (`chat.send_stream`), `cli_mcp_serve` (`mcp.call`), `launch.run`,
-  `agent.setup`, `trigger.list` all call `cli_ensure_server_for_method()` →
-  `cli_existing_server_for_method()`, which only probes `AIMEE_SOCK` and the
-  well-known local socket. The actual work runs **server-side**, in
-  `server/*.c`: `agent_loop.c`, `agent_runtime.c`, `agent_tools.c`,
-  `delegate_backend{,_local,_ssh,_docker}.c`, `server_hooks.c`, the MCP dispatch
-  table (`server/server_mcp_call_table.inc`), plus `CORE_SRCS` (db1, config).
-- **Why it can't just point at the remote.** These operations execute tools on
-  the **local working tree** — `git pull --ff-only`, worktree isolation,
-  file/exec tools. They must run where the files are. So "route execution to the
-  NAS" is wrong; "run execution locally, fetch memory remotely" is right.
-- **Build.** `$(BINARY)` = `CLI_OBJS + CLIENT_SUPPORT_OBJS` (links `L_CLIENT`, no
-  libpq). The engine is `SERVER_OBJS` + `CORE_SRCS`. `-DAIMEE_THIN_CLIENT=ON`
-  builds the client only.
+- The thin client **already satisfies the invariant**: no sqlite/libpq refs in
+  the client TUs, `L_CLIENT = L_MINIMAL + TLS` (no DB libs), and `aimee kb …`
+  routes to method `kb.search`/`kb.status` against the configured **aimee-server**
+  endpoint (`:8740`), whose `/v1/kb/*` proxies to aimee-kb. The client never hits
+  aimee-kb (`:8741`) directly.
+- **Data plane (done):** all read/data commands work thin-client → aimee-server
+  over first-class `/v1` (Phase 1: `memory recall`, `notes`, plus the already-
+  routed `index`/`curator`/`graph`/`api`/`memory search`/`mcp audit`).
+- **Reverse-channel foundation (exists):** `aimee workspace serve` (client) polls
+  `/v1/runner/poll`, executes ops on the local tree, replies `/v1/runner/respond`
+  — remote-capable; the detached provider is already in `CLIENT_RUNNER_OBJS`.
+  Server-side, `workspace_turn_bind_active()` binds a client's detached workspace
+  to a turn and **refuses** a remote turn that acts outside one
+  (`server_compute_async.c`).
+- **The blocker:** `chat`/`launch`/`mcp` hard-refuse a remote endpoint
+  (`cli_main.c:1239,1744`, `cli_rpc_remote_endpoint_is_tcp()` → "interactive
+  needs a co-located aimee-server"). That refusal — not any missing capability —
+  is why the execution plane can't run against a remote server today.
 
 ## Design
 
-The single `aimee` binary gains an **embedded execution engine** invoked
-**in-process** (no socket, no daemon) for execution-plane commands, with the
-data plane (kb/memory and any DB2-backed reads/writes) flowing over `/v1` to a
-configurable backend via the existing client.
+Make the execution-plane commands run on a **remote** aimee-server against the
+client's **served workspace**, instead of refusing. The client orchestrates:
 
-Core seam: replace, for execution-plane commands, the
-`cli_ensure_server_for_method()` → forward-to-socket step with a dispatch that
-prefers, in order:
-1. a co-located server if one is already running (back-compat, unchanged);
-2. otherwise an **in-process engine call** (`engine_session_start()`,
-   `engine_mcp_serve()`, `engine_chat()`, `engine_delegate()`), where the engine
-   is configured with `AIMEE_KB_API_URL`/remote `/v1` for shared memory and a
-   local DB1 path for per-host session state.
+1. **Register** the client's cwd as a `detached` workspace on aimee-server
+   (`workspace add --provider detached` over `/v1`), obtaining a `workspace_id`.
+2. **Serve** it: start the `workspace serve <id>` reverse-channel loop in the
+   background (poll/respond over `/v1`), so the server can do file/exec/git on
+   the client's tree.
+3. **Run** the turn over `/v1`: `chat.send_stream` / `mcp.call` execute on the
+   server, which binds the served workspace for the turn (existing
+   `workspace_turn_bind_active`) and streams output back to the client.
+4. **Tear down** the workspace/serve loop when the command exits.
 
-DB1 (SQLite, per-host session/working state) stays local to the binary — it is
-inherently host-scoped (session_state, working memory). Durable *memory* is DB2
-(the kb) and already remote. So "one binary + a shared remote kb" loses nothing
-semantic.
+No engine and no DB ever enter the client; the server does the work and reaches
+the client's files only within the registered detached workspace (already
+enforced server-side).
 
-### Phase 0 — SessionStart over remote `/v1` recall — **shipped (#69)**
-`session-start` emits proactive recall via `POST /v1/memory/recall` when only a
-remote endpoint is configured. Pure data plane; no engine needed.
+### Phase 0 — SessionStart over remote `/v1` — shipped (#69, v0.2.27)
+`session-start` emits proactive recall via `POST /v1/memory/recall` (client →
+aimee-server → aimee-kb). Pure data plane, no co-located server.
 
-### Phase 1 — Read-only hooks + recall completeness
-Route the remaining read-only hook surfaces (pre-tool advisory reads, recall
-variants) over `/v1` the same way. No engine link yet. Low risk.
+### Phase 1 — Data-plane command coverage — shipped (#72, v0.2.28)
+`memory recall`, `notes`/`notes search` wired over `/v1`; full read surface now
+works thin-client → aimee-server.
 
-### Phase 2 — In-process `mcp-serve`
-Link the MCP dispatch (`server_mcp_call_table.inc` + the tool implementations it
-needs) into the binary and have `aimee mcp-serve` run it in-process. Pure-data
-tools call `/v1`; local-fs/exec tools run locally. This is what Claude Code's
-MCP integration actually needs and is more self-contained than `chat`.
+### Phase 2 — `mcp-serve` against a remote server + served workspace
+Replace the remote refusal in `cli_mcp_serve` with the register→serve→run→
+teardown flow above. `aimee mcp-serve` drives Claude Code's MCP against a remote
+aimee-server; tool calls that touch files run on the client via the reverse
+channel; data/kb tools run on the server (→ aimee-kb). Highest-value (Claude
+Code integration) and the smallest execution-plane command.
 
-### Phase 3 — In-process `chat` / primary agent
-Link `agent_loop.c` / `agent_runtime.c` / `agent_request_shaping.c` + provider
-calls + tool execution. `aimee chat` runs the agent loop in-process against the
-local working tree, fetching memory/kb over `/v1`. Largest phase; gated behind a
-build flag until proven.
+### Phase 3 — `chat` against a remote server + served workspace
+Same orchestration for `chat.send_stream`; lift the `cli_main.c:1239` refusal.
 
-### Phase 4 — In-process `delegate`
-Link `delegate_backend*` so `aimee delegate` runs sub-agents locally (it is
-currently "no /v1 route" — foreground delegate is socket-bound). Backends
-(local/ssh/docker) are already modular.
+### Phase 4 — `delegate` against a remote server
+`delegate` runs server-side already; expose it over `/v1` for thin clients
+(it is currently "no /v1 route") so a remote client can launch/poll delegate
+jobs that execute on the server.
 
-## Build / packaging
+## Capability / bearer note
 
-- Introduce a build profile that produces the **full single binary** (client +
-  embedded engine) as the default end-user artifact; keep
-  `-DAIMEE_THIN_CLIENT=ON` for a minimal data-only client where binary size
-  matters. Reuse `SERVER_OBJS`/`CORE_SRCS` — no logic duplication; the engine
-  becomes a library both `aimee` and `aimee-server` link.
-- `aimee-server` remains for multi-tenant/shared deployments (the NAS plugin).
+Execution-plane `/v1` routes need caps the baked dev bearer `aimee-local-dev`
+lacks over TCP (read/query/chat only). A deployment that wants remote execution
+must issue a higher-scope bearer (or set `remote_writes`) — a config concern,
+not a client change. `mcp audit`/`tools_list`/`agent`/`provider test` 403 today
+for the same reason.
 
 ## Scope / phasing
 
-Ship Phase 0 (done) → 1 → 2 first; they cover the Claude Code integration
-(hooks + MCP), which is the highest-value, lowest-risk part. Phases 3–4 (chat,
-delegate in-process) are larger and land behind a flag with their own
-validation. Each phase is independently shippable.
+Phase 2 first (MCP = the Claude Code integration), then 3 (chat), then 4
+(delegate). Each is independently shippable and reuses the workspace
+reverse-channel; no build-profile or engine-link changes — the client stays thin.
 
 ## Risks / non-goals
 
-- **Binary size / deps.** Embedding the engine pulls libpq-free engine code but
-  grows the binary; mitigate with the thin-only profile staying available.
-- **No orphan-listener regression.** In-process execution publishes **no
-  socket** and exits with the command — it does not reintroduce the #1660
-  spawner problem. A persistent local listener is explicitly a non-goal.
-- **DB1 locality.** Per-host session state stays in a local SQLite file; we do
-  not attempt to remote DB1. Durable memory is DB2/kb (already remote).
-- **Not a security boundary change.** Remote `/v1` writes remain governed by the
-  server's `remote_writes` / capability model; the in-process engine uses local
-  creds for local DB1 and the configured bearer for `/v1`.
+- **Non-goal: engine or DB in the client.** Explicitly reversed from the earlier
+  draft. The client never links sqlite/libpq and never speaks to aimee-kb.
+- **Reverse-channel latency.** Every server-side file/exec op is a `/v1` round
+  trip to the client; fine for interactive use, watch for chatty tool loops.
+- **Security.** The server may only act on the client's fs within a registered
+  detached workspace (already enforced); foreign-cwd turns are refused.
+- **Bearer scope.** Remote execution needs an appropriately-scoped bearer (see
+  above); the dev default is intentionally narrow.
 
 ## Verification
 
-- Per phase: `-Wall -Wextra -Werror` clean; unit tests; and an end-to-end check
-  with the binary pointed at a remote aimee (no local server) — e.g. Phase 2:
-  `aimee mcp-serve` answers an MCP `tools/call` with memory fetched over `/v1`;
-  Phase 3: `aimee chat` completes a turn with tools on the local tree and recall
-  from a remote kb.
-- Back-compat: with a co-located server running, every command behaves exactly
-  as today (local socket preferred).
+- Phase 2: with the client pointed at a remote aimee-server (no co-located
+  server), `aimee mcp-serve` answers an MCP `tools/call` whose file tool runs on
+  the client (via `workspace serve`) and whose memory tool resolves on the server
+  (→ aimee-kb). Phase 3: `aimee chat` completes a turn editing a local file and
+  recalling from the remote kb. Back-compat: a co-located server still uses the
+  local socket path unchanged.

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -11,6 +11,7 @@
 #include "platform_path.h"
 #include "cJSON.h"
 #include <ctype.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -141,6 +142,36 @@ static int ensure_connection(void)
 
 static cJSON *server_request(cJSON *req, int timeout_ms)
 {
+   /* Remote aimee-server: POST mcp.call to its first-class /v1 route. The local
+    * cli_v1_rpc_local path only speaks the co-located UDS, so a thin client
+    * configured with a remote endpoint must route here. Memory/kb/search tools
+    * resolve on the server (which proxies DB2 to aimee-kb). File/exec tools whose
+    * cwd is a registered detached workspace marshal back to this client over the
+    * workspace reverse-channel (Phase 2b); on a non-served cwd they fail safe
+    * server-side (the path does not exist there). */
+   if (cli_rpc_has_remote_endpoint())
+   {
+      char *endpoint = cli_rpc_client_endpoint();
+      char *bearer = cli_rpc_client_bearer();
+      const char *verb = NULL;
+      const char *path = cli_v1_route_for_method("mcp.call", &verb);
+      cJSON *resp = NULL;
+      if (endpoint && path)
+      {
+         char *body = cJSON_PrintUnformatted(req);
+         if (body)
+         {
+            int status = 0;
+            resp = cli_http_request(endpoint, verb ? verb : "POST", path, body, bearer,
+                                    timeout_ms, &status);
+            free(body);
+         }
+      }
+      free(endpoint);
+      free(bearer);
+      return resp;
+   }
+
    useconds_t delay = RECONNECT_DELAY_INIT_US;
    for (int retry = 0; retry < RECONNECT_RETRIES; retry++)
    {
@@ -935,12 +966,105 @@ static int read_mcp_message(FILE *in, char **out)
 
 /* --- Entry point --- */
 
+/* --- Phase 2b: workspace reverse-channel for a remote aimee-server ---
+ *
+ * When mcp-serve targets a remote server, register the client's cwd as a
+ * `detached` workspace and serve it on a background thread. The server binds
+ * that workspace per mcp.call (by cwd) and marshals file/exec tools back here
+ * over runner.poll/respond, so tools run on the client's tree while the agent +
+ * memory/kb stay on the server. No-op for a co-located server. */
+static volatile sig_atomic_t g_ws_serve_stop = 0;
+static pthread_t g_ws_serve_thread;
+static int g_ws_serve_active = 0;
+
+struct ws_serve_args
+{
+   char *id;
+   char *endpoint;
+   char *bearer;
+};
+
+static void *ws_serve_thread_main(void *arg)
+{
+   struct ws_serve_args *a = arg;
+   cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_ws_serve_stop);
+   free(a->id);
+   free(a->endpoint);
+   free(a->bearer);
+   free(a);
+   return NULL;
+}
+
+static void mcp_workspace_reverse_channel_start(void)
+{
+   if (!cli_rpc_has_remote_endpoint())
+      return;
+   char cwd[MAX_PATH_LEN];
+   if (!getcwd(cwd, sizeof(cwd)) || !cwd[0])
+      return;
+   char *endpoint = cli_rpc_client_endpoint();
+   if (!endpoint)
+      return;
+   char *bearer = cli_rpc_client_bearer();
+
+   /* Register the detached workspace (idempotent: re-registering the same root
+    * is harmless). Best-effort — if it fails, file tools simply won't route. */
+   cJSON *reg = cJSON_CreateObject();
+   cJSON_AddStringToObject(reg, "root", cwd);
+   cJSON_AddStringToObject(reg, "provider", "detached");
+   char *body = cJSON_PrintUnformatted(reg);
+   cJSON_Delete(reg);
+   if (body)
+   {
+      int status = 0;
+      cJSON *resp = cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000,
+                                     &status);
+      cJSON_Delete(resp);
+      free(body);
+   }
+
+   struct ws_serve_args *a = calloc(1, sizeof(*a));
+   if (!a)
+   {
+      free(endpoint);
+      free(bearer);
+      return;
+   }
+   a->id = strdup(cwd);
+   a->endpoint = endpoint; /* ownership passes to the thread */
+   a->bearer = bearer;
+   if (pthread_create(&g_ws_serve_thread, NULL, ws_serve_thread_main, a) == 0)
+      g_ws_serve_active = 1;
+   else
+   {
+      free(a->id);
+      free(a->endpoint);
+      free(a->bearer);
+      free(a);
+   }
+}
+
+static void mcp_workspace_reverse_channel_stop(void)
+{
+   if (!g_ws_serve_active)
+      return;
+   g_ws_serve_stop = 1;
+   /* The poll may be mid-flight (~30s); the process is exiting, so detach rather
+    * than block on join. */
+   pthread_detach(g_ws_serve_thread);
+   g_ws_serve_active = 0;
+}
+
 int cli_mcp_serve(void)
 {
    /* Unbuffered stdout for MCP protocol. SIGPIPE is ignored process-wide
     * by cli_main so write() to a dead server socket surfaces EPIPE rather
     * than killing the bridge. */
    setvbuf(stdout, NULL, _IONBF, 0);
+
+   /* If pointed at a remote aimee-server, serve this client's working tree to it
+    * over the reverse-channel so file/exec tools route back here (Phase 2b). */
+   mcp_workspace_reverse_channel_start();
 
    char *message = NULL;
    int rc;
@@ -963,6 +1087,7 @@ int cli_mcp_serve(void)
    free(message);
    if (rc < 0)
       mcp_error(NULL, -32700, "Parse error");
+   mcp_workspace_reverse_channel_stop();
    cli_close(&g_conn);
    return 0;
 }

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -136,6 +136,36 @@ static int serve_post(void *vctx, cJSON *response)
    return ok ? 0 : -1;
 }
 
+/* The serve loop, factored out so callers other than `aimee workspace serve`
+ * (e.g. mcp-serve's background reverse-channel thread) can drive it with their
+ * own stop flag instead of the process-wide SIGINT/SIGTERM handler. Either
+ * `sock` (local) or `endpoint` (remote) selects the transport. Returns 0 on a
+ * clean stop, 1 if it bailed after too many consecutive transport errors. */
+int cli_workspace_serve_loop(const char *workspace_id, const char *sock, const char *endpoint,
+                             const char *bearer, volatile sig_atomic_t *stop)
+{
+   serve_ctx_t ctx = {sock, workspace_id, endpoint, bearer};
+   int rc = 0;
+   int consecutive_errors = 0;
+   while (!*stop)
+   {
+      int r = ws_runner_serve_once(serve_fetch, serve_post, &ctx);
+      if (r < 0)
+      {
+         if (++consecutive_errors >= 5)
+         {
+            rc = 1;
+            break;
+         }
+      }
+      else
+      {
+         consecutive_errors = 0;
+      }
+   }
+   return rc;
+}
+
 int cmd_workspace_serve(const char *workspace_id)
 {
    if (!workspace_id || !workspace_id[0])
@@ -170,31 +200,12 @@ int cmd_workspace_serve(const char *workspace_id)
    signal(SIGINT, serve_on_signal);
    signal(SIGTERM, serve_on_signal);
 
-   serve_ctx_t ctx = {sock, workspace_id, endpoint, bearer};
    fprintf(stderr, "aimee: serving detached workspace '%s' (%s) (Ctrl-C to stop)\n", workspace_id,
            endpoint ? endpoint : "local socket");
 
-   int rc = 0;
-   int consecutive_errors = 0;
-   while (!g_serve_stop)
-   {
-      int r = ws_runner_serve_once(serve_fetch, serve_post, &ctx);
-      if (r < 0)
-      {
-         /* Transport error (server down mid-serve, etc.). Bail after a few in a
-          * row so a wedged server doesn't spin forever. */
-         if (++consecutive_errors >= 5)
-         {
-            fprintf(stderr, "aimee: too many runner errors; stopping\n");
-            rc = 1;
-            break;
-         }
-      }
-      else
-      {
-         consecutive_errors = 0;
-      }
-   }
+   int rc = cli_workspace_serve_loop(workspace_id, sock, endpoint, bearer, &g_serve_stop);
+   if (rc)
+      fprintf(stderr, "aimee: too many runner errors; stopping\n");
 
    if (!rc)
       fprintf(stderr, "\naimee: stopped serving '%s'\n", workspace_id);

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -2,6 +2,7 @@
 #define DEC_CLI_CLIENT_H 1
 
 #include <stddef.h>
+#include <signal.h>
 
 #define CLIENT_DEFAULT_TIMEOUT_MS 5000
 #define CLIENT_CONNECT_TIMEOUT_MS 1000
@@ -150,6 +151,12 @@ const char *cli_ensure_server_for_method(const char *method);
  * loop (poll -> execute locally -> respond) until interrupted. Returns 0 on a
  * clean stop, non-zero on a usage / connection error. */
 int cmd_workspace_serve(const char *workspace_id);
+
+/* The serve loop without signal handling, for callers that drive it on a
+ * background thread with their own stop flag (e.g. mcp-serve's reverse-channel).
+ * Either `sock` (local) or `endpoint`+`bearer` (remote) selects the transport. */
+int cli_workspace_serve_loop(const char *workspace_id, const char *sock, const char *endpoint,
+                             const char *bearer, volatile sig_atomic_t *stop);
 
 /* Return the path to an already-running compatible server, or NULL if none
  * is available. Unlike cli_ensure_server(), this does not auto-start. */


### PR DESCRIPTION
Promote testing -> main. #75 remote mcp-serve (mcp.call routing + workspace reverse-channel; verified e2e via git_status). #74 corrected 3-tier proposal. testing is now in sync with main (#76).