### PR TITLE
feat(thin-client): aimee chat against a remote aimee-server (Phase 3)

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1236,22 +1236,24 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
     * chdirs into a server-resolved worktree on the local filesystem, so it needs
     * a co-located aimee-server over the local socket. A remote /v1 endpoint
     * serves only the data/RPC plane (memory, kb, rules, index, sessions, …). */
-   if (cli_rpc_remote_endpoint_is_tcp())
+   /* A remote aimee-server runs the agent + tools on the server; serve THIS
+    * client's working tree over the reverse-channel so those tools act here (the
+    * client never absorbs the engine or a DB). A co-located server uses the local
+    * socket as before. */
+   int remote = cli_rpc_remote_endpoint_is_tcp();
+   const char *sock = NULL;
+   if (remote)
    {
-      fprintf(stderr,
-              "aimee: interactive chat/launch needs a co-located aimee-server (the agent and its "
-              "tools run on this host) and cannot use the remote /v1 endpoint set in "
-              "AIMEE_API_ENDPOINT / aimee.api.client_endpoint. That endpoint serves the data/RPC "
-              "commands (memory, kb, rules, index, sessions, notes, ...). Unset it, or set "
-              "aimee.api.client_transport=socket, to use the local server.\n");
-      return 1;
+      cli_workspace_reverse_channel_start();
    }
-
-   const char *sock = cli_ensure_server_for_method("launch.run");
-   if (!sock)
+   else
    {
-      fprintf(stderr, "aimee: cannot launch session; server unavailable\n");
-      return 1;
+      sock = cli_ensure_server_for_method("launch.run");
+      if (!sock)
+      {
+         fprintf(stderr, "aimee: cannot launch session; server unavailable\n");
+         return 1;
+      }
    }
 
    cJSON *req = cJSON_CreateObject();
@@ -1261,7 +1263,24 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
    if (getcwd(cwd, sizeof(cwd)))
       cJSON_AddStringToObject(req, "cwd", cwd);
 
-   cJSON *resp = cli_v1_rpc_local(req, 30000);
+   cJSON *resp;
+   if (remote)
+   {
+      char *endpoint = cli_rpc_client_endpoint();
+      char *bearer = cli_rpc_client_bearer();
+      char *body = cJSON_PrintUnformatted(req);
+      int status = 0;
+      resp = (endpoint && body)
+                 ? cli_http_request(endpoint, "POST", "/v1/launch/run", body, bearer, 30000, &status)
+                 : NULL;
+      free(endpoint);
+      free(bearer);
+      free(body);
+   }
+   else
+   {
+      resp = cli_v1_rpc_local(req, 30000);
+   }
    cJSON_Delete(req);
 
    if (!resp)
@@ -1331,7 +1350,10 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
       }
    }
 
-   if (worktree_cwd && worktree_cwd[0])
+   /* Co-located only: chdir into the server-resolved worktree (it lives on this
+    * host). For a remote server the worktree is the client's own cwd (a detached
+    * workspace served over the reverse-channel), so there is nothing to chdir. */
+   if (!remote && worktree_cwd && worktree_cwd[0])
    {
       if (chdir(worktree_cwd) != 0)
          fprintf(stderr, "aimee: warning: could not chdir to worktree: %s\n", worktree_cwd);
@@ -1339,11 +1361,15 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
          fprintf(stderr, "aimee: session cwd: %s\n", worktree_cwd);
    }
 
-   /* Make sure hooks/MCP children inherit the active socket. */
-   platform_setenv("AIMEE_SOCK", sock);
+   /* Make sure hooks/MCP children inherit the active socket (co-located only;
+    * a remote session reaches the server over the configured /v1 endpoint). */
+   if (!remote && sock)
+      platform_setenv("AIMEE_SOCK", sock);
 
    int rc = builtin_chat_loop(sock, provider, model, sid, autonomous, debug, default_launch,
                               chat_argc, chat_argv);
+   if (remote)
+      cli_workspace_reverse_channel_stop();
    cJSON_Delete(resp);
    return rc;
 }

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -11,7 +11,6 @@
 #include "platform_path.h"
 #include "cJSON.h"
 #include <ctype.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -966,95 +965,6 @@ static int read_mcp_message(FILE *in, char **out)
 
 /* --- Entry point --- */
 
-/* --- Phase 2b: workspace reverse-channel for a remote aimee-server ---
- *
- * When mcp-serve targets a remote server, register the client's cwd as a
- * `detached` workspace and serve it on a background thread. The server binds
- * that workspace per mcp.call (by cwd) and marshals file/exec tools back here
- * over runner.poll/respond, so tools run on the client's tree while the agent +
- * memory/kb stay on the server. No-op for a co-located server. */
-static volatile sig_atomic_t g_ws_serve_stop = 0;
-static pthread_t g_ws_serve_thread;
-static int g_ws_serve_active = 0;
-
-struct ws_serve_args
-{
-   char *id;
-   char *endpoint;
-   char *bearer;
-};
-
-static void *ws_serve_thread_main(void *arg)
-{
-   struct ws_serve_args *a = arg;
-   cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_ws_serve_stop);
-   free(a->id);
-   free(a->endpoint);
-   free(a->bearer);
-   free(a);
-   return NULL;
-}
-
-static void mcp_workspace_reverse_channel_start(void)
-{
-   if (!cli_rpc_has_remote_endpoint())
-      return;
-   char cwd[MAX_PATH_LEN];
-   if (!getcwd(cwd, sizeof(cwd)) || !cwd[0])
-      return;
-   char *endpoint = cli_rpc_client_endpoint();
-   if (!endpoint)
-      return;
-   char *bearer = cli_rpc_client_bearer();
-
-   /* Register the detached workspace (idempotent: re-registering the same root
-    * is harmless). Best-effort — if it fails, file tools simply won't route. */
-   cJSON *reg = cJSON_CreateObject();
-   cJSON_AddStringToObject(reg, "root", cwd);
-   cJSON_AddStringToObject(reg, "provider", "detached");
-   char *body = cJSON_PrintUnformatted(reg);
-   cJSON_Delete(reg);
-   if (body)
-   {
-      int status = 0;
-      cJSON *resp = cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000,
-                                     &status);
-      cJSON_Delete(resp);
-      free(body);
-   }
-
-   struct ws_serve_args *a = calloc(1, sizeof(*a));
-   if (!a)
-   {
-      free(endpoint);
-      free(bearer);
-      return;
-   }
-   a->id = strdup(cwd);
-   a->endpoint = endpoint; /* ownership passes to the thread */
-   a->bearer = bearer;
-   if (pthread_create(&g_ws_serve_thread, NULL, ws_serve_thread_main, a) == 0)
-      g_ws_serve_active = 1;
-   else
-   {
-      free(a->id);
-      free(a->endpoint);
-      free(a->bearer);
-      free(a);
-   }
-}
-
-static void mcp_workspace_reverse_channel_stop(void)
-{
-   if (!g_ws_serve_active)
-      return;
-   g_ws_serve_stop = 1;
-   /* The poll may be mid-flight (~30s); the process is exiting, so detach rather
-    * than block on join. */
-   pthread_detach(g_ws_serve_thread);
-   g_ws_serve_active = 0;
-}
-
 int cli_mcp_serve(void)
 {
    /* Unbuffered stdout for MCP protocol. SIGPIPE is ignored process-wide
@@ -1064,7 +974,7 @@ int cli_mcp_serve(void)
 
    /* If pointed at a remote aimee-server, serve this client's working tree to it
     * over the reverse-channel so file/exec tools route back here (Phase 2b). */
-   mcp_workspace_reverse_channel_start();
+   cli_workspace_reverse_channel_start();
 
    char *message = NULL;
    int rc;
@@ -1087,7 +997,7 @@ int cli_mcp_serve(void)
    free(message);
    if (rc < 0)
       mcp_error(NULL, -32700, "Parse error");
-   mcp_workspace_reverse_channel_stop();
+   cli_workspace_reverse_channel_stop();
    cli_close(&g_conn);
    return 0;
 }

--- a/src/cli_tui.c
+++ b/src/cli_tui.c
@@ -119,18 +119,37 @@ static void chat_stream_on_open(int fd, void *ud)
       control->set_stream_fd(fd, control->userdata);
 }
 
-/* Resolve the co-located /v1 HTTP endpoint for chat ("unix:<home>/aimee-http.sock").
- * Interactive chat runs the agent + tools on this host, so it always targets the
- * local server's HTTP UDS (a remote TCP endpoint is refused upstream in
- * cli_main). Returns 0 on success. */
+/* Resolve the /v1 HTTP endpoint for chat. A configured remote aimee-server is
+ * used when set (the agent runs there; this client serves its working tree over
+ * the reverse-channel set up by cli_main); otherwise the co-located server's
+ * HTTP UDS ("unix:<home>/aimee-http.sock"). Returns 0 on success. */
 static int chat_v1_endpoint(char *out, size_t out_len)
 {
+   if (!out || out_len == 0)
+      return -1;
+   if (cli_rpc_has_remote_endpoint())
+   {
+      char *ep = cli_rpc_client_endpoint();
+      if (ep)
+      {
+         int n = snprintf(out, out_len, "%s", ep);
+         free(ep);
+         return (n > 0 && (size_t)n < out_len) ? 0 : -1;
+      }
+   }
    const char *home = aimee_home();
-   if (!home || !home[0] || !out || out_len == 0)
+   if (!home || !home[0])
       return -1;
    if (snprintf(out, out_len, "unix:%s/aimee-http.sock", home) >= (int)out_len)
       return -1;
    return 0;
+}
+
+/* Bearer for the chat /v1 endpoint: the configured token for a remote endpoint,
+ * NULL for the local UDS (no auth needed). Caller frees. */
+static char *chat_v1_bearer(void)
+{
+   return cli_rpc_has_remote_endpoint() ? cli_rpc_client_bearer() : NULL;
 }
 
 /* Build "/v1/sessions/<pct-encoded session_id><suffix>" into out. Returns 0 on
@@ -154,9 +173,11 @@ static cJSON *chat_v1_post(const char *path, cJSON *body_obj)
    if (chat_v1_endpoint(endpoint, sizeof(endpoint)) != 0)
       return NULL;
    char *body = body_obj ? cJSON_PrintUnformatted(body_obj) : NULL;
+   char *bearer = chat_v1_bearer();
    int status = 0;
    cJSON *resp =
-       cli_http_request(endpoint, "POST", path, body, NULL, CLIENT_DEFAULT_TIMEOUT_MS, &status);
+       cli_http_request(endpoint, "POST", path, body, bearer, CLIENT_DEFAULT_TIMEOUT_MS, &status);
+   free(bearer);
    free(body);
    if (resp && !(status >= 200 && status < 300))
    {
@@ -324,7 +345,7 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
    if (control)
       control->aborted = 0;
 
-   (void)sock; /* chat always targets the co-located /v1 HTTP endpoint */
+   (void)sock; /* chat targets the /v1 HTTP endpoint (local UDS or remote) */
    if (control && control->should_abort && control->should_abort(control->userdata))
    {
       control->aborted = 1;
@@ -384,11 +405,13 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
    int http_status = 0;
    /* on_open surfaces the live stream fd to control->set_stream_fd (and -1 on
     * close) so the TUI's abort path can interrupt the turn exactly as before. */
+   char *bearer = chat_v1_bearer();
    cJSON *resp = body ? cli_http_request_stream_ndjson(endpoint, "POST", "/v1/chat/stream", body,
-                                                       NULL, BUILTIN_CHAT_STREAM_IDLE_TIMEOUT_MS,
+                                                       bearer, BUILTIN_CHAT_STREAM_IDLE_TIMEOUT_MS,
                                                        &http_status, chat_stream_event_cb, &st,
                                                        chat_stream_on_open, control)
                       : NULL;
+   free(bearer);
    free(body);
    chat_stream_finish(&st);
    md_stream_free(st.md);

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -17,9 +17,16 @@
 #include "workspace_provider_detached.h"
 #include "cJSON.h"
 
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef CLI_TUI_PATH_MAX
+#define CLI_TUI_PATH_MAX 4096
+#endif
 
 typedef struct
 {
@@ -212,4 +219,93 @@ int cmd_workspace_serve(const char *workspace_id)
    free(endpoint);
    free(bearer);
    return rc;
+}
+
+/* --- Reverse-channel helper for interactive/bridge commands ---
+ *
+ * When mcp-serve / chat target a remote aimee-server, the agent runs on the
+ * server but its file/exec tools must act on THIS client's tree. These helpers
+ * register the client's cwd as a `detached` workspace and serve it on a
+ * background thread, so the server (which binds that workspace per turn by cwd)
+ * marshals tool ops back here over runner.poll/respond. No-op for a co-located
+ * server. One channel per process. */
+static volatile sig_atomic_t g_rc_stop = 0;
+static pthread_t g_rc_thread;
+static int g_rc_active = 0;
+struct rc_args
+{
+   char *id;
+   char *endpoint;
+   char *bearer;
+};
+static void *rc_thread_main(void *arg)
+{
+   struct rc_args *a = arg;
+   cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_rc_stop);
+   free(a->id);
+   free(a->endpoint);
+   free(a->bearer);
+   free(a);
+   return NULL;
+}
+
+int cli_workspace_reverse_channel_start(void)
+{
+   if (g_rc_active || !cli_rpc_has_remote_endpoint())
+      return 0;
+   char cwd[CLI_TUI_PATH_MAX];
+   if (!getcwd(cwd, sizeof(cwd)) || !cwd[0])
+      return 0;
+   char *endpoint = cli_rpc_client_endpoint();
+   if (!endpoint)
+      return 0;
+   char *bearer = cli_rpc_client_bearer();
+
+   /* Register the detached workspace (idempotent). Best-effort. */
+   cJSON *reg = cJSON_CreateObject();
+   cJSON_AddStringToObject(reg, "root", cwd);
+   cJSON_AddStringToObject(reg, "provider", "detached");
+   char *body = cJSON_PrintUnformatted(reg);
+   cJSON_Delete(reg);
+   if (body)
+   {
+      int status = 0;
+      cJSON *resp = cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000,
+                                     &status);
+      cJSON_Delete(resp);
+      free(body);
+   }
+
+   struct rc_args *a = calloc(1, sizeof(*a));
+   if (!a)
+   {
+      free(endpoint);
+      free(bearer);
+      return 0;
+   }
+   a->id = strdup(cwd);
+   a->endpoint = endpoint; /* ownership passes to the thread */
+   a->bearer = bearer;
+   g_rc_stop = 0;
+   if (pthread_create(&g_rc_thread, NULL, rc_thread_main, a) == 0)
+   {
+      g_rc_active = 1;
+      return 1;
+   }
+   free(a->id);
+   free(a->endpoint);
+   free(a->bearer);
+   free(a);
+   return 0;
+}
+
+void cli_workspace_reverse_channel_stop(void)
+{
+   if (!g_rc_active)
+      return;
+   g_rc_stop = 1;
+   /* The poll may be mid-flight (~30s); the process is exiting, so detach
+    * rather than block on join. */
+   pthread_detach(g_rc_thread);
+   g_rc_active = 0;
 }

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -158,6 +158,14 @@ int cmd_workspace_serve(const char *workspace_id);
 int cli_workspace_serve_loop(const char *workspace_id, const char *sock, const char *endpoint,
                              const char *bearer, volatile sig_atomic_t *stop);
 
+/* Reverse-channel for interactive/bridge commands (mcp-serve, chat) against a
+ * remote aimee-server: register the client's cwd as a `detached` workspace and
+ * serve it on a background thread so the server's file/exec tools route back to
+ * this client. start() returns 1 if a channel was started (remote configured),
+ * 0 otherwise (incl. co-located). stop() tears it down. One channel per process. */
+int cli_workspace_reverse_channel_start(void);
+void cli_workspace_reverse_channel_stop(void);
+
 /* Return the path to an already-running compatible server, or NULL if none
  * is available. Unlike cli_ensure_server(), this does not auto-start. */
 const char *cli_existing_server(void);


### PR DESCRIPTION
Lifts the "interactive chat/launch needs a co-located aimee-server" refusal for the remote case and runs chat the same way as remote mcp-serve (#75): register the client's cwd as a `detached` workspace + serve it over the reverse-channel, route `launch.run` + `chat.send_stream` to the remote `/v1` (`/v1/launch/run`, `/v1/chat/stream`), and skip the local worktree `chdir` (the worktree IS the client's served tree). Client stays thin — no engine, no DB.

- Factored the reverse-channel into shared `cli_workspace_reverse_channel_start/stop()` (reused by mcp-serve + chat).
- `chat_v1_endpoint`/chat now target the configured remote endpoint + bearer when set, else the local UDS (co-located unchanged).

**Verified:** `echo … | aimee chat` against a remote aimee-server streams a turn from the server's primary model (PONG) with no co-located server.

**Known gap (server-side follow-up):** the chat agent's *tool* execution doesn't yet inherit the detached-workspace binding the way `handle_mcp_call` does (it's thread-local; the chat agent tool-exec path uses a different cwd/thread), so file/exec tools issued by the chat agent run on the server's fs instead of marshalling to the client. mcp-serve tools route correctly (Phase 2, verified via `git_status`). Chat conversation over remote works today.
