### PR TITLE
fix(server): route the bash tool through the detached workspace provider

### DIFF
--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -319,14 +319,32 @@ char *tool_edit_file(const char *path, const char *old_string, const char *new_s
 static char *td_bash(cJSON *args, const char *name, const char *dispatch_cwd,
                      const char *dispatch_sid, int timeout_ms)
 {
-   char *result = NULL;
    cJSON *cmd = cJSON_GetObjectItem(args, "command");
-   if (cmd && cJSON_IsString(cmd))
-      result = tool_bash(cmd->valuestring, timeout_ms);
-   else
-      result = safe_strdup("error: missing 'command' parameter");
+   if (!cmd || !cJSON_IsString(cmd))
+      return safe_strdup("error: missing 'command' parameter");
 
-   return result;
+   /* Detached workspace (turn bound to a serving client): marshal the shell
+    * command — with the thread-local cwd — over the reverse-channel so it runs
+    * on the CLIENT's working tree, not the server's filesystem. tool_bash's
+    * local fork/exec + read-only fast-paths only apply co-located, and would
+    * otherwise fail (the client's cwd does not exist on the server). The shared
+    * provider keeps using tool_bash below. */
+   const workspace_provider_t *ws = workspace_provider_active();
+   if (ws && ws->kind == WS_PROVIDER_DETACHED && ws->exec_shell)
+   {
+      int exit_code = -1;
+      char *out = ws->exec_shell(ws, cmd->valuestring, &exit_code);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "stdout", out ? out : "");
+      cJSON_AddStringToObject(r, "stderr", "");
+      cJSON_AddNumberToObject(r, "exit_code", exit_code);
+      free(out);
+      char *result = cJSON_PrintUnformatted(r);
+      cJSON_Delete(r);
+      return result ? result : safe_strdup("{}");
+   }
+
+   return tool_bash(cmd->valuestring, timeout_ms);
 }
 
 static char *td_execute_script(cJSON *args, const char *name, const char *dispatch_cwd,


### PR DESCRIPTION
The server-side half of remote chat tool-routing (gap noted in #78).

When a turn binds a `detached` workspace (remote thin client serving its tree over the reverse-channel), file tools (`read_file`/`write_file`/`list`/`git_*`) already marshal to the client via `workspace_provider_active()`, but **`bash` ran `tool_bash()` unconditionally** — executing on the *server's* filesystem with the client's cwd, which doesn't exist there. So a remote `aimee chat` agent's shell tools failed ("path not accessible") even though mcp-serve's git tools worked.

Fix: `td_bash` routes through `workspace_provider_active()->exec_shell` when the active provider is detached (marshals the command + thread-local cwd to the serving client — same path the git tools use). The shared/co-located provider is unchanged.

Build-verified (`aimee-server`, `-Werror`). **E2e verification needs the new server image deployed** (rebuild + reinstall the NAS plugin); once deployed, a remote `aimee chat` agent's `bash`/`ls` runs on the client's tree.
