### PR TITLE
feat: delegate over /v1 for remote thin clients (Phase 4)

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -1729,7 +1729,10 @@ static cJSON *marshal_delegate(int argc, char **argv)
    const char *env_parent = getenv("AIMEE_PARENT_DELEGATION_ID");
    if (env_parent && env_parent[0] && (v = getenv("AIMEE_DELEGATE_DEPTH")) && v[0] && atoi(v) > 0)
       cJSON_AddNumberToObject(req, "delegation_depth", atoi(v));
-   if (rpc_get(&opts, "background"))
+   /* Foreground delegate streams over a long-lived connection and has no /v1
+    * route; against a remote aimee-server force background so the call uses the
+    * /v1/delegate/run route (returns a job_id to poll via `aimee jobs`). */
+   if (rpc_get(&opts, "background") || cli_rpc_has_remote_endpoint())
       cJSON_AddTrueToObject(req, "background");
    if (rpc_get(&opts, "tools"))
       cJSON_AddTrueToObject(req, "tools");

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -61,6 +61,7 @@ static const struct
     {"dashboard.plans", "GET", "/v1/dashboard/plans"},
     {"dashboard.plugins", "GET", "/v1/dashboard/plugins"},
     {"dashboard.traces", "GET", "/v1/dashboard/traces"},
+    {"delegate", "POST", "/v1/delegate/run"},
     {"delegate.backend_exec", "POST", "/v1/delegate/backend_exec"},
     {"delegate.backend_list", "GET", "/v1/delegate/backend_list"},
     {"delegate.launch", "POST", "/v1/delegate/launch"},

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -789,6 +789,10 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/delegate/backend_list", NULL, RM_EXACT, "delegate.backend_list", 0,
      rh_dispatch_op},
     {"POST", "/v1/delegate/status", NULL, RM_EXACT, "delegate.status", 0, rh_dispatch_op},
+    /* Background-only over /v1: the thin client forces `background` (returns a
+     * job_id to poll via the /v1/jobs routes); a foreground delegate streams and
+     * would tie up a listener thread, so remote callers use background mode. */
+    {"POST", "/v1/delegate/run", NULL, RM_EXACT, "delegate", 0, rh_dispatch_op},
     {"POST", "/v1/delegate/reply", NULL, RM_EXACT, "delegate.reply", 0, rh_dispatch_op},
     {"POST", "/v1/delegate/launch", NULL, RM_EXACT, "delegate.launch", 0, rh_dispatch_op},
     {"POST", "/v1/delegate/backend_exec", NULL, RM_EXACT, "delegate.backend_exec", 0,


### PR DESCRIPTION
`aimee delegate <role> "prompt"` mapped to the foreground `delegate` method (no `/v1` route — it streams over a long-lived connection), so a remote thin client got "no /v1 route". Expose it in **background** mode:

- **Server:** `POST /v1/delegate/run` → `delegate` (rh_dispatch_op). `handle_delegate` returns a `job_id` immediately when `background` is set (no listener-thread blocking), so it's safe over TCP.
- **Client:** `marshal_delegate` forces `background` when a remote endpoint is configured → remote `aimee delegate` queues a job to poll via `aimee jobs status`/`logs` (already routed). Co-located foreground delegate unchanged.
- Regenerated `cli_v1_routes_gen.inc`; `check-cli-v1-routes` + `check-v1-method-coverage` green; client + server build `-Werror`.

The delegate runs server-side; with a workspace reverse-channel serving (Phase 2/3), its file/exec tools route to the client (via the #79 bash-marshal fix). **Note:** a fire-and-return background delegate finishes async after the client exits; a serve-until-done remote delegate mode is a follow-up.
