### PR TITLE
Promote: remote chat (Phase 3) + bash-marshal fix + delegate over /v1 (Phase 4)

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1236,22 +1236,24 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
     * chdirs into a server-resolved worktree on the local filesystem, so it needs
     * a co-located aimee-server over the local socket. A remote /v1 endpoint
     * serves only the data/RPC plane (memory, kb, rules, index, sessions, …). */
-   if (cli_rpc_remote_endpoint_is_tcp())
+   /* A remote aimee-server runs the agent + tools on the server; serve THIS
+    * client's working tree over the reverse-channel so those tools act here (the
+    * client never absorbs the engine or a DB). A co-located server uses the local
+    * socket as before. */
+   int remote = cli_rpc_remote_endpoint_is_tcp();
+   const char *sock = NULL;
+   if (remote)
    {
-      fprintf(stderr,
-              "aimee: interactive chat/launch needs a co-located aimee-server (the agent and its "
-              "tools run on this host) and cannot use the remote /v1 endpoint set in "
-              "AIMEE_API_ENDPOINT / aimee.api.client_endpoint. That endpoint serves the data/RPC "
-              "commands (memory, kb, rules, index, sessions, notes, ...). Unset it, or set "
-              "aimee.api.client_transport=socket, to use the local server.\n");
-      return 1;
+      cli_workspace_reverse_channel_start();
    }
-
-   const char *sock = cli_ensure_server_for_method("launch.run");
-   if (!sock)
+   else
    {
-      fprintf(stderr, "aimee: cannot launch session; server unavailable\n");
-      return 1;
+      sock = cli_ensure_server_for_method("launch.run");
+      if (!sock)
+      {
+         fprintf(stderr, "aimee: cannot launch session; server unavailable\n");
+         return 1;
+      }
    }
 
    cJSON *req = cJSON_CreateObject();
@@ -1261,7 +1263,24 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
    if (getcwd(cwd, sizeof(cwd)))
       cJSON_AddStringToObject(req, "cwd", cwd);
 
-   cJSON *resp = cli_v1_rpc_local(req, 30000);
+   cJSON *resp;
+   if (remote)
+   {
+      char *endpoint = cli_rpc_client_endpoint();
+      char *bearer = cli_rpc_client_bearer();
+      char *body = cJSON_PrintUnformatted(req);
+      int status = 0;
+      resp = (endpoint && body)
+                 ? cli_http_request(endpoint, "POST", "/v1/launch/run", body, bearer, 30000, &status)
+                 : NULL;
+      free(endpoint);
+      free(bearer);
+      free(body);
+   }
+   else
+   {
+      resp = cli_v1_rpc_local(req, 30000);
+   }
    cJSON_Delete(req);
 
    if (!resp)
@@ -1331,7 +1350,10 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
       }
    }
 
-   if (worktree_cwd && worktree_cwd[0])
+   /* Co-located only: chdir into the server-resolved worktree (it lives on this
+    * host). For a remote server the worktree is the client's own cwd (a detached
+    * workspace served over the reverse-channel), so there is nothing to chdir. */
+   if (!remote && worktree_cwd && worktree_cwd[0])
    {
       if (chdir(worktree_cwd) != 0)
          fprintf(stderr, "aimee: warning: could not chdir to worktree: %s\n", worktree_cwd);
@@ -1339,11 +1361,15 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
          fprintf(stderr, "aimee: session cwd: %s\n", worktree_cwd);
    }
 
-   /* Make sure hooks/MCP children inherit the active socket. */
-   platform_setenv("AIMEE_SOCK", sock);
+   /* Make sure hooks/MCP children inherit the active socket (co-located only;
+    * a remote session reaches the server over the configured /v1 endpoint). */
+   if (!remote && sock)
+      platform_setenv("AIMEE_SOCK", sock);
 
    int rc = builtin_chat_loop(sock, provider, model, sid, autonomous, debug, default_launch,
                               chat_argc, chat_argv);
+   if (remote)
+      cli_workspace_reverse_channel_stop();
    cJSON_Delete(resp);
    return rc;
 }

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -11,7 +11,6 @@
 #include "platform_path.h"
 #include "cJSON.h"
 #include <ctype.h>
-#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -966,95 +965,6 @@ static int read_mcp_message(FILE *in, char **out)
 
 /* --- Entry point --- */
 
-/* --- Phase 2b: workspace reverse-channel for a remote aimee-server ---
- *
- * When mcp-serve targets a remote server, register the client's cwd as a
- * `detached` workspace and serve it on a background thread. The server binds
- * that workspace per mcp.call (by cwd) and marshals file/exec tools back here
- * over runner.poll/respond, so tools run on the client's tree while the agent +
- * memory/kb stay on the server. No-op for a co-located server. */
-static volatile sig_atomic_t g_ws_serve_stop = 0;
-static pthread_t g_ws_serve_thread;
-static int g_ws_serve_active = 0;
-
-struct ws_serve_args
-{
-   char *id;
-   char *endpoint;
-   char *bearer;
-};
-
-static void *ws_serve_thread_main(void *arg)
-{
-   struct ws_serve_args *a = arg;
-   cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_ws_serve_stop);
-   free(a->id);
-   free(a->endpoint);
-   free(a->bearer);
-   free(a);
-   return NULL;
-}
-
-static void mcp_workspace_reverse_channel_start(void)
-{
-   if (!cli_rpc_has_remote_endpoint())
-      return;
-   char cwd[MAX_PATH_LEN];
-   if (!getcwd(cwd, sizeof(cwd)) || !cwd[0])
-      return;
-   char *endpoint = cli_rpc_client_endpoint();
-   if (!endpoint)
-      return;
-   char *bearer = cli_rpc_client_bearer();
-
-   /* Register the detached workspace (idempotent: re-registering the same root
-    * is harmless). Best-effort — if it fails, file tools simply won't route. */
-   cJSON *reg = cJSON_CreateObject();
-   cJSON_AddStringToObject(reg, "root", cwd);
-   cJSON_AddStringToObject(reg, "provider", "detached");
-   char *body = cJSON_PrintUnformatted(reg);
-   cJSON_Delete(reg);
-   if (body)
-   {
-      int status = 0;
-      cJSON *resp = cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000,
-                                     &status);
-      cJSON_Delete(resp);
-      free(body);
-   }
-
-   struct ws_serve_args *a = calloc(1, sizeof(*a));
-   if (!a)
-   {
-      free(endpoint);
-      free(bearer);
-      return;
-   }
-   a->id = strdup(cwd);
-   a->endpoint = endpoint; /* ownership passes to the thread */
-   a->bearer = bearer;
-   if (pthread_create(&g_ws_serve_thread, NULL, ws_serve_thread_main, a) == 0)
-      g_ws_serve_active = 1;
-   else
-   {
-      free(a->id);
-      free(a->endpoint);
-      free(a->bearer);
-      free(a);
-   }
-}
-
-static void mcp_workspace_reverse_channel_stop(void)
-{
-   if (!g_ws_serve_active)
-      return;
-   g_ws_serve_stop = 1;
-   /* The poll may be mid-flight (~30s); the process is exiting, so detach rather
-    * than block on join. */
-   pthread_detach(g_ws_serve_thread);
-   g_ws_serve_active = 0;
-}
-
 int cli_mcp_serve(void)
 {
    /* Unbuffered stdout for MCP protocol. SIGPIPE is ignored process-wide
@@ -1064,7 +974,7 @@ int cli_mcp_serve(void)
 
    /* If pointed at a remote aimee-server, serve this client's working tree to it
     * over the reverse-channel so file/exec tools route back here (Phase 2b). */
-   mcp_workspace_reverse_channel_start();
+   cli_workspace_reverse_channel_start();
 
    char *message = NULL;
    int rc;
@@ -1087,7 +997,7 @@ int cli_mcp_serve(void)
    free(message);
    if (rc < 0)
       mcp_error(NULL, -32700, "Parse error");
-   mcp_workspace_reverse_channel_stop();
+   cli_workspace_reverse_channel_stop();
    cli_close(&g_conn);
    return 0;
 }

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -1729,7 +1729,10 @@ static cJSON *marshal_delegate(int argc, char **argv)
    const char *env_parent = getenv("AIMEE_PARENT_DELEGATION_ID");
    if (env_parent && env_parent[0] && (v = getenv("AIMEE_DELEGATE_DEPTH")) && v[0] && atoi(v) > 0)
       cJSON_AddNumberToObject(req, "delegation_depth", atoi(v));
-   if (rpc_get(&opts, "background"))
+   /* Foreground delegate streams over a long-lived connection and has no /v1
+    * route; against a remote aimee-server force background so the call uses the
+    * /v1/delegate/run route (returns a job_id to poll via `aimee jobs`). */
+   if (rpc_get(&opts, "background") || cli_rpc_has_remote_endpoint())
       cJSON_AddTrueToObject(req, "background");
    if (rpc_get(&opts, "tools"))
       cJSON_AddTrueToObject(req, "tools");

--- a/src/cli_tui.c
+++ b/src/cli_tui.c
@@ -119,18 +119,37 @@ static void chat_stream_on_open(int fd, void *ud)
       control->set_stream_fd(fd, control->userdata);
 }
 
-/* Resolve the co-located /v1 HTTP endpoint for chat ("unix:<home>/aimee-http.sock").
- * Interactive chat runs the agent + tools on this host, so it always targets the
- * local server's HTTP UDS (a remote TCP endpoint is refused upstream in
- * cli_main). Returns 0 on success. */
+/* Resolve the /v1 HTTP endpoint for chat. A configured remote aimee-server is
+ * used when set (the agent runs there; this client serves its working tree over
+ * the reverse-channel set up by cli_main); otherwise the co-located server's
+ * HTTP UDS ("unix:<home>/aimee-http.sock"). Returns 0 on success. */
 static int chat_v1_endpoint(char *out, size_t out_len)
 {
+   if (!out || out_len == 0)
+      return -1;
+   if (cli_rpc_has_remote_endpoint())
+   {
+      char *ep = cli_rpc_client_endpoint();
+      if (ep)
+      {
+         int n = snprintf(out, out_len, "%s", ep);
+         free(ep);
+         return (n > 0 && (size_t)n < out_len) ? 0 : -1;
+      }
+   }
    const char *home = aimee_home();
-   if (!home || !home[0] || !out || out_len == 0)
+   if (!home || !home[0])
       return -1;
    if (snprintf(out, out_len, "unix:%s/aimee-http.sock", home) >= (int)out_len)
       return -1;
    return 0;
+}
+
+/* Bearer for the chat /v1 endpoint: the configured token for a remote endpoint,
+ * NULL for the local UDS (no auth needed). Caller frees. */
+static char *chat_v1_bearer(void)
+{
+   return cli_rpc_has_remote_endpoint() ? cli_rpc_client_bearer() : NULL;
 }
 
 /* Build "/v1/sessions/<pct-encoded session_id><suffix>" into out. Returns 0 on
@@ -154,9 +173,11 @@ static cJSON *chat_v1_post(const char *path, cJSON *body_obj)
    if (chat_v1_endpoint(endpoint, sizeof(endpoint)) != 0)
       return NULL;
    char *body = body_obj ? cJSON_PrintUnformatted(body_obj) : NULL;
+   char *bearer = chat_v1_bearer();
    int status = 0;
    cJSON *resp =
-       cli_http_request(endpoint, "POST", path, body, NULL, CLIENT_DEFAULT_TIMEOUT_MS, &status);
+       cli_http_request(endpoint, "POST", path, body, bearer, CLIENT_DEFAULT_TIMEOUT_MS, &status);
+   free(bearer);
    free(body);
    if (resp && !(status >= 200 && status < 300))
    {
@@ -324,7 +345,7 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
    if (control)
       control->aborted = 0;
 
-   (void)sock; /* chat always targets the co-located /v1 HTTP endpoint */
+   (void)sock; /* chat targets the /v1 HTTP endpoint (local UDS or remote) */
    if (control && control->should_abort && control->should_abort(control->userdata))
    {
       control->aborted = 1;
@@ -384,11 +405,13 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
    int http_status = 0;
    /* on_open surfaces the live stream fd to control->set_stream_fd (and -1 on
     * close) so the TUI's abort path can interrupt the turn exactly as before. */
+   char *bearer = chat_v1_bearer();
    cJSON *resp = body ? cli_http_request_stream_ndjson(endpoint, "POST", "/v1/chat/stream", body,
-                                                       NULL, BUILTIN_CHAT_STREAM_IDLE_TIMEOUT_MS,
+                                                       bearer, BUILTIN_CHAT_STREAM_IDLE_TIMEOUT_MS,
                                                        &http_status, chat_stream_event_cb, &st,
                                                        chat_stream_on_open, control)
                       : NULL;
+   free(bearer);
    free(body);
    chat_stream_finish(&st);
    md_stream_free(st.md);

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -61,6 +61,7 @@ static const struct
     {"dashboard.plans", "GET", "/v1/dashboard/plans"},
     {"dashboard.plugins", "GET", "/v1/dashboard/plugins"},
     {"dashboard.traces", "GET", "/v1/dashboard/traces"},
+    {"delegate", "POST", "/v1/delegate/run"},
     {"delegate.backend_exec", "POST", "/v1/delegate/backend_exec"},
     {"delegate.backend_list", "GET", "/v1/delegate/backend_list"},
     {"delegate.launch", "POST", "/v1/delegate/launch"},

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -17,9 +17,16 @@
 #include "workspace_provider_detached.h"
 #include "cJSON.h"
 
+#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef CLI_TUI_PATH_MAX
+#define CLI_TUI_PATH_MAX 4096
+#endif
 
 typedef struct
 {
@@ -212,4 +219,93 @@ int cmd_workspace_serve(const char *workspace_id)
    free(endpoint);
    free(bearer);
    return rc;
+}
+
+/* --- Reverse-channel helper for interactive/bridge commands ---
+ *
+ * When mcp-serve / chat target a remote aimee-server, the agent runs on the
+ * server but its file/exec tools must act on THIS client's tree. These helpers
+ * register the client's cwd as a `detached` workspace and serve it on a
+ * background thread, so the server (which binds that workspace per turn by cwd)
+ * marshals tool ops back here over runner.poll/respond. No-op for a co-located
+ * server. One channel per process. */
+static volatile sig_atomic_t g_rc_stop = 0;
+static pthread_t g_rc_thread;
+static int g_rc_active = 0;
+struct rc_args
+{
+   char *id;
+   char *endpoint;
+   char *bearer;
+};
+static void *rc_thread_main(void *arg)
+{
+   struct rc_args *a = arg;
+   cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_rc_stop);
+   free(a->id);
+   free(a->endpoint);
+   free(a->bearer);
+   free(a);
+   return NULL;
+}
+
+int cli_workspace_reverse_channel_start(void)
+{
+   if (g_rc_active || !cli_rpc_has_remote_endpoint())
+      return 0;
+   char cwd[CLI_TUI_PATH_MAX];
+   if (!getcwd(cwd, sizeof(cwd)) || !cwd[0])
+      return 0;
+   char *endpoint = cli_rpc_client_endpoint();
+   if (!endpoint)
+      return 0;
+   char *bearer = cli_rpc_client_bearer();
+
+   /* Register the detached workspace (idempotent). Best-effort. */
+   cJSON *reg = cJSON_CreateObject();
+   cJSON_AddStringToObject(reg, "root", cwd);
+   cJSON_AddStringToObject(reg, "provider", "detached");
+   char *body = cJSON_PrintUnformatted(reg);
+   cJSON_Delete(reg);
+   if (body)
+   {
+      int status = 0;
+      cJSON *resp = cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000,
+                                     &status);
+      cJSON_Delete(resp);
+      free(body);
+   }
+
+   struct rc_args *a = calloc(1, sizeof(*a));
+   if (!a)
+   {
+      free(endpoint);
+      free(bearer);
+      return 0;
+   }
+   a->id = strdup(cwd);
+   a->endpoint = endpoint; /* ownership passes to the thread */
+   a->bearer = bearer;
+   g_rc_stop = 0;
+   if (pthread_create(&g_rc_thread, NULL, rc_thread_main, a) == 0)
+   {
+      g_rc_active = 1;
+      return 1;
+   }
+   free(a->id);
+   free(a->endpoint);
+   free(a->bearer);
+   free(a);
+   return 0;
+}
+
+void cli_workspace_reverse_channel_stop(void)
+{
+   if (!g_rc_active)
+      return;
+   g_rc_stop = 1;
+   /* The poll may be mid-flight (~30s); the process is exiting, so detach
+    * rather than block on join. */
+   pthread_detach(g_rc_thread);
+   g_rc_active = 0;
 }

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -158,6 +158,14 @@ int cmd_workspace_serve(const char *workspace_id);
 int cli_workspace_serve_loop(const char *workspace_id, const char *sock, const char *endpoint,
                              const char *bearer, volatile sig_atomic_t *stop);
 
+/* Reverse-channel for interactive/bridge commands (mcp-serve, chat) against a
+ * remote aimee-server: register the client's cwd as a `detached` workspace and
+ * serve it on a background thread so the server's file/exec tools route back to
+ * this client. start() returns 1 if a channel was started (remote configured),
+ * 0 otherwise (incl. co-located). stop() tears it down. One channel per process. */
+int cli_workspace_reverse_channel_start(void);
+void cli_workspace_reverse_channel_stop(void);
+
 /* Return the path to an already-running compatible server, or NULL if none
  * is available. Unlike cli_ensure_server(), this does not auto-start. */
 const char *cli_existing_server(void);

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -319,14 +319,32 @@ char *tool_edit_file(const char *path, const char *old_string, const char *new_s
 static char *td_bash(cJSON *args, const char *name, const char *dispatch_cwd,
                      const char *dispatch_sid, int timeout_ms)
 {
-   char *result = NULL;
    cJSON *cmd = cJSON_GetObjectItem(args, "command");
-   if (cmd && cJSON_IsString(cmd))
-      result = tool_bash(cmd->valuestring, timeout_ms);
-   else
-      result = safe_strdup("error: missing 'command' parameter");
+   if (!cmd || !cJSON_IsString(cmd))
+      return safe_strdup("error: missing 'command' parameter");
 
-   return result;
+   /* Detached workspace (turn bound to a serving client): marshal the shell
+    * command — with the thread-local cwd — over the reverse-channel so it runs
+    * on the CLIENT's working tree, not the server's filesystem. tool_bash's
+    * local fork/exec + read-only fast-paths only apply co-located, and would
+    * otherwise fail (the client's cwd does not exist on the server). The shared
+    * provider keeps using tool_bash below. */
+   const workspace_provider_t *ws = workspace_provider_active();
+   if (ws && ws->kind == WS_PROVIDER_DETACHED && ws->exec_shell)
+   {
+      int exit_code = -1;
+      char *out = ws->exec_shell(ws, cmd->valuestring, &exit_code);
+      cJSON *r = cJSON_CreateObject();
+      cJSON_AddStringToObject(r, "stdout", out ? out : "");
+      cJSON_AddStringToObject(r, "stderr", "");
+      cJSON_AddNumberToObject(r, "exit_code", exit_code);
+      free(out);
+      char *result = cJSON_PrintUnformatted(r);
+      cJSON_Delete(r);
+      return result ? result : safe_strdup("{}");
+   }
+
+   return tool_bash(cmd->valuestring, timeout_ms);
 }
 
 static char *td_execute_script(cJSON *args, const char *name, const char *dispatch_cwd,

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -789,6 +789,10 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/delegate/backend_list", NULL, RM_EXACT, "delegate.backend_list", 0,
      rh_dispatch_op},
     {"POST", "/v1/delegate/status", NULL, RM_EXACT, "delegate.status", 0, rh_dispatch_op},
+    /* Background-only over /v1: the thin client forces `background` (returns a
+     * job_id to poll via the /v1/jobs routes); a foreground delegate streams and
+     * would tie up a listener thread, so remote callers use background mode. */
+    {"POST", "/v1/delegate/run", NULL, RM_EXACT, "delegate", 0, rh_dispatch_op},
     {"POST", "/v1/delegate/reply", NULL, RM_EXACT, "delegate.reply", 0, rh_dispatch_op},
     {"POST", "/v1/delegate/launch", NULL, RM_EXACT, "delegate.launch", 0, rh_dispatch_op},
     {"POST", "/v1/delegate/backend_exec", NULL, RM_EXACT, "delegate.backend_exec", 0,


### PR DESCRIPTION
Promote testing -> main. #78 remote chat, #79 detached bash-marshal (chat-agent tools route to client), #80 delegate over /v1 (Phase 4). Releases a new aimee-server image for the NAS redeploy + e2e verification.