### PR TITLE
fix(windows): stub reverse-channel helpers for the thin client (unblock release)

### DIFF
--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -41,6 +41,19 @@
  * output. Default is NDJSON, so spec-compliant clients work even if we have
  * to emit an error before reading anything. */
 
+#if defined(_WIN32) || defined(_WIN64)
+/* The workspace reverse-channel lives in cli_workspace_serve.c, which the Windows
+ * thin client excludes (POSIX-only: pthreads + the runner serve loop). mcp-serve
+ * and chat still reference these, so provide no-op stubs here on Windows — remote
+ * file/exec tools simply don't route back to a Windows client. POSIX builds use
+ * the real definitions in cli_workspace_serve.c (this block compiles out). */
+int cli_workspace_reverse_channel_start(void)
+{
+   return 0;
+}
+void cli_workspace_reverse_channel_stop(void) {}
+#endif
+
 static int g_output_ndjson = 1;
 
 static void mcp_send(cJSON *msg)


### PR DESCRIPTION
Phase 2b/3 (#75/#78) put the reverse-channel helpers in `cli_workspace_serve.c`, which the Windows thin client **excludes** (`CMakeLists.txt` — POSIX-only: pthreads + serve loop). But `cli_mcp_serve.c`/`cli_main.c` (Windows-compiled) now call `cli_workspace_reverse_channel_start/stop` → **undefined references** → the windows-thin-client build failed, failing the auto-release.

Adds `_WIN32`-guarded no-op stubs in `cli_mcp_serve.c` (POSIX uses the real defs). Unblocks the release; remote file/exec tools don't route to a Windows client (it can't serve a workspace anyway). POSIX build verified clean.
