### PR TITLE
style: clang-format thin-client phase 2-4 changes

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1051,8 +1051,8 @@ static int handle_session_start_remote(void)
    cJSON_Delete(body);
 
    int status = 0;
-   cJSON *resp = cli_http_request(endpoint, "POST", "/v1/memory/recall", body_s, bearer, 30000,
-                                  &status);
+   cJSON *resp =
+       cli_http_request(endpoint, "POST", "/v1/memory/recall", body_s, bearer, 30000, &status);
    free(endpoint);
    free(bearer);
    free(body_s);
@@ -1270,9 +1270,9 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
       char *bearer = cli_rpc_client_bearer();
       char *body = cJSON_PrintUnformatted(req);
       int status = 0;
-      resp = (endpoint && body)
-                 ? cli_http_request(endpoint, "POST", "/v1/launch/run", body, bearer, 30000, &status)
-                 : NULL;
+      resp = (endpoint && body) ? cli_http_request(endpoint, "POST", "/v1/launch/run", body, bearer,
+                                                   30000, &status)
+                                : NULL;
       free(endpoint);
       free(bearer);
       free(body);

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -51,7 +51,9 @@ int cli_workspace_reverse_channel_start(void)
 {
    return 0;
 }
-void cli_workspace_reverse_channel_stop(void) {}
+void cli_workspace_reverse_channel_stop(void)
+{
+}
 #endif
 
 static int g_output_ndjson = 1;
@@ -174,8 +176,8 @@ static cJSON *server_request(cJSON *req, int timeout_ms)
          if (body)
          {
             int status = 0;
-            resp = cli_http_request(endpoint, verb ? verb : "POST", path, body, bearer,
-                                    timeout_ms, &status);
+            resp = cli_http_request(endpoint, verb ? verb : "POST", path, body, bearer, timeout_ms,
+                                    &status);
             free(body);
          }
       }

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -3,8 +3,8 @@
  * Unported commands fail in cli_main before reaching the server.
  * =================================================================== */
 
-#include "util.h"          /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
-#include "aimee_client.h"  /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
+#include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
+#include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
@@ -6763,9 +6763,9 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
     * field, which marshalling may set to a server_method twin (e.g. `git verify`
     * dispatches as mcp.call) — not the CLI route name. */
    cJSON *bm = cJSON_GetObjectItemCaseSensitive(req, "method");
-   const char *disp_method =
-       (cJSON_IsString(bm) && bm->valuestring && bm->valuestring[0]) ? bm->valuestring
-                                                                     : route->method;
+   const char *disp_method = (cJSON_IsString(bm) && bm->valuestring && bm->valuestring[0])
+                                 ? bm->valuestring
+                                 : route->method;
    const char *rest_verb = NULL;
    const char *rest_path = NULL;
    const char *async_verb = NULL;

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -270,8 +270,8 @@ int cli_workspace_reverse_channel_start(void)
    if (body)
    {
       int status = 0;
-      cJSON *resp = cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000,
-                                     &status);
+      cJSON *resp =
+          cli_http_request(endpoint, "POST", "/v1/workspaces", body, bearer, 15000, &status);
       cJSON_Delete(resp);
       free(body);
    }


### PR DESCRIPTION
Satisfies the lint gate (clang-format-19) for the Phase 2-4 reverse-channel + remote-routing edits.