### PR TITLE
feat(windows): build the workspace reverse-channel on the Windows thin client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,13 +750,10 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/server/delegate_plan.c
     ${AIMEE_SRC_DIR}/acp_server.c
 )
-# `workspace serve` hosts the detached-workspace runner — a co-located POSIX
-# feature. On Windows the thin client is a remote /v1 consumer that does not host
-# it, and windows/cli_client.c already provides a cmd_workspace_serve stub; drop
-# the POSIX implementation here so the two do not collide at link time.
-if(WIN32)
-    list(REMOVE_ITEM CLI_SRCS ${AIMEE_SRC_DIR}/cli_workspace_serve.c)
-endif()
+# `workspace serve` + the reverse-channel host the detached-workspace runner so
+# the client serves its working tree to a remote aimee-server. It now builds on
+# Windows too (cli_workspace_serve.c is native-threaded via _beginthreadex), so
+# it is compiled on every platform — no per-OS exclusion.
 
 set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_main.c

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -41,21 +41,6 @@
  * output. Default is NDJSON, so spec-compliant clients work even if we have
  * to emit an error before reading anything. */
 
-#if defined(_WIN32) || defined(_WIN64)
-/* The workspace reverse-channel lives in cli_workspace_serve.c, which the Windows
- * thin client excludes (POSIX-only: pthreads + the runner serve loop). mcp-serve
- * and chat still reference these, so provide no-op stubs here on Windows — remote
- * file/exec tools simply don't route back to a Windows client. POSIX builds use
- * the real definitions in cli_workspace_serve.c (this block compiles out). */
-int cli_workspace_reverse_channel_start(void)
-{
-   return 0;
-}
-void cli_workspace_reverse_channel_stop(void)
-{
-}
-#endif
-
 static int g_output_ndjson = 1;
 
 static void mcp_send(cJSON *msg)

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -14,15 +14,24 @@
  * (workspace-resource-plane §3), so a client can serve its working tree to a
  * server on another host (e.g. a container). */
 #include "cli_client.h"
+#include "platform_process.h"
 #include "workspace_provider_detached.h"
 #include "cJSON.h"
 
-#include <pthread.h>
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+/* Threading for the background reverse-channel: pthreads co-located, the CRT's
+ * _beginthreadex on Windows (always present in MinGW, no winpthreads needed). */
+#ifdef _WIN32
+#include <process.h>
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
 
 #ifndef CLI_TUI_PATH_MAX
 #define CLI_TUI_PATH_MAX 4096
@@ -204,8 +213,8 @@ int cmd_workspace_serve(const char *workspace_id)
       }
    }
 
-   signal(SIGINT, serve_on_signal);
-   signal(SIGTERM, serve_on_signal);
+   platform_signal_int(serve_on_signal);
+   platform_signal_term(serve_on_signal);
 
    fprintf(stderr, "aimee: serving detached workspace '%s' (%s) (Ctrl-C to stop)\n", workspace_id,
            endpoint ? endpoint : "local socket");
@@ -230,7 +239,11 @@ int cmd_workspace_serve(const char *workspace_id)
  * marshals tool ops back here over runner.poll/respond. No-op for a co-located
  * server. One channel per process. */
 static volatile sig_atomic_t g_rc_stop = 0;
+#ifdef _WIN32
+static HANDLE g_rc_thread = NULL;
+#else
 static pthread_t g_rc_thread;
+#endif
 static int g_rc_active = 0;
 struct rc_args
 {
@@ -238,16 +251,28 @@ struct rc_args
    char *endpoint;
    char *bearer;
 };
-static void *rc_thread_main(void *arg)
+/* Shared body for both thread ABIs: drive the serve loop, then free the args. */
+static void rc_serve_run(struct rc_args *a)
 {
-   struct rc_args *a = arg;
    cli_workspace_serve_loop(a->id, NULL, a->endpoint, a->bearer, &g_rc_stop);
    free(a->id);
    free(a->endpoint);
    free(a->bearer);
    free(a);
+}
+#ifdef _WIN32
+static unsigned __stdcall rc_thread_main(void *arg)
+{
+   rc_serve_run((struct rc_args *)arg);
+   return 0;
+}
+#else
+static void *rc_thread_main(void *arg)
+{
+   rc_serve_run((struct rc_args *)arg);
    return NULL;
 }
+#endif
 
 int cli_workspace_reverse_channel_start(void)
 {
@@ -287,11 +312,20 @@ int cli_workspace_reverse_channel_start(void)
    a->endpoint = endpoint; /* ownership passes to the thread */
    a->bearer = bearer;
    g_rc_stop = 0;
+#ifdef _WIN32
+   g_rc_thread = (HANDLE)_beginthreadex(NULL, 0, rc_thread_main, a, 0, NULL);
+   if (g_rc_thread)
+   {
+      g_rc_active = 1;
+      return 1;
+   }
+#else
    if (pthread_create(&g_rc_thread, NULL, rc_thread_main, a) == 0)
    {
       g_rc_active = 1;
       return 1;
    }
+#endif
    free(a->id);
    free(a->endpoint);
    free(a->bearer);
@@ -306,6 +340,14 @@ void cli_workspace_reverse_channel_stop(void)
    g_rc_stop = 1;
    /* The poll may be mid-flight (~30s); the process is exiting, so detach
     * rather than block on join. */
+#ifdef _WIN32
+   if (g_rc_thread)
+   {
+      CloseHandle(g_rc_thread);
+      g_rc_thread = NULL;
+   }
+#else
    pthread_detach(g_rc_thread);
+#endif
    g_rc_active = 0;
 }

--- a/src/windows/cli_client.c
+++ b/src/windows/cli_client.c
@@ -780,15 +780,10 @@ cJSON *cli_http_request_stream_ndjson(const char *endpoint, const char *method, 
 
 /* cli_v1_rpc_local now lives in the shared cli_rpc_routes.inc — it resolves the
  * method's first-class /v1 route (no more POST /v1/rpc bridge). On Windows
- * cli_v1_send routes it through aimee_client_request to the configured remote. */
-
-int cmd_workspace_serve(const char *workspace_id)
-{
-   /* The detached-workspace runner serve loop is a co-located (POSIX) feature;
-    * the Windows thin client is a remote /v1 consumer and does not host it. */
-   (void)workspace_id;
-   fprintf(stderr, "aimee: 'workspace serve' is not supported on the Windows client\n");
-   return 1;
-}
+ * cli_v1_send routes it through aimee_client_request to the configured remote.
+ *
+ * cmd_workspace_serve + the reverse-channel helpers now build on Windows too
+ * (cli_workspace_serve.c, native-threaded via _beginthreadex), so the Windows
+ * thin client serves its working tree to a remote aimee-server just like POSIX. */
 
 #include "../cli_rpc_routes.inc"


### PR DESCRIPTION
## What
Makes the Windows thin client able to **serve its working tree to a remote aimee-server** — `aimee workspace serve` and the auto-started reverse-channel for remote chat / mcp-serve. Previously POSIX-only: `cli_workspace_serve.c` was excluded from the Windows build, `cmd_workspace_serve` hard-errored, and `cli_workspace_reverse_channel_start/stop` were no-ops, so a Windows client's remote agent tools never routed back to it.

## How
The HTTP transport and the poll→run→respond loop were already portable; only threading + signals were POSIX-bound:
- **thread**: `pthread_create/detach` → `_beginthreadex`/`CloseHandle` on Windows (always present in MinGW's CRT — no winpthreads dependency)
- **signals**: `signal(SIGINT/SIGTERM)` → the existing portable `platform_signal_int/term` (SetConsoleCtrlHandler on Windows)
- **includes**: `<pthread.h>` → `<process.h>`/`<windows.h>` under `_WIN32`

Removed the redundant Windows shims (no-op reverse-channel stubs in `cli_mcp_serve.c`, the `cmd_workspace_serve` error stub in `windows/cli_client.c`, the `WIN32` CMake exclusion). All symbols the loop needs already resolve in the Windows build.

## Verification
- POSIX build + unit-tests + build-integrity + full `make lint` green locally.
- The **windows-build** and **windows-cmake** CI jobs compile/link this with real MinGW-w64 — authoritative for the Windows toolchain.
- Runtime e2e on a Windows host still pending (no Windows machine in this environment) — the POSIX side of the identical code path is verified e2e against the NAS (chat agent bash + file write route to the client's tree).