### PR TITLE
feat(windows): implement the local-fs workspace provider on the thin client

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6419,7 +6419,11 @@ int cli_rpc_remote_endpoint_is_tcp(void)
    free(ep);
    return is_tcp;
 #else
-   return 0;
+   /* The Windows thin client's only remote target comes from aimee_client
+    * (AIMEE_SERVER_URL / --server), which is always a tcp:host:port network
+    * endpoint — never a local unix: socket. Report it so chat/launch start the
+    * reverse-channel and route the turn over /v1 (matching has_remote_endpoint). */
+   return aimee_client_has_remote();
 #endif
 }
 

--- a/src/config.c
+++ b/src/config.c
@@ -784,8 +784,14 @@ int config_load(config_t *cfg)
          }
          if (path_str && path_str[0])
          {
+            /* A Windows-absolute path (C:\... / C:/...) is already rooted — a
+             * detached workspace registered by a Windows thin client — so store
+             * it verbatim rather than resolving it against the server's CWD. */
+            int win_abs = (((path_str[0] >= 'A' && path_str[0] <= 'Z') ||
+                            (path_str[0] >= 'a' && path_str[0] <= 'z')) &&
+                           path_str[1] == ':' && (path_str[2] == '\\' || path_str[2] == '/'));
             /* Resolve relative workspace paths against CWD. */
-            if (path_str[0] != '/')
+            if (path_str[0] != '/' && !win_abs)
             {
                const char *base = NULL;
                char cwd_buf[MAX_PATH_LEN];

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -886,7 +886,15 @@ static int session_cwd_is_worktree(const char *cwd)
  * client's (it serves its own tree). */
 static int cwd_is_detached_workspace(const char *cwd)
 {
-   if (!cwd || cwd[0] != '/')
+   if (!cwd || !cwd[0])
+      return 0;
+   /* The cwd of a detached turn is the CLIENT's path — POSIX (/...) or Windows
+    * (C:\... / C:/...). A Windows thin client serving its tree has a drive-letter
+    * cwd, so accept that form too (the exemption is what lets its remote agent
+    * write to the served working tree). */
+   int win_abs = (((cwd[0] >= 'A' && cwd[0] <= 'Z') || (cwd[0] >= 'a' && cwd[0] <= 'z')) &&
+                  cwd[1] == ':' && (cwd[2] == '\\' || cwd[2] == '/'));
+   if (cwd[0] != '/' && !win_abs)
       return 0;
    config_t cfg;
    config_load(&cfg);
@@ -896,7 +904,8 @@ static int cwd_is_detached_workspace(const char *cwd)
       size_t len = ws ? strlen(ws) : 0;
       if (len == 0 || cfg.workspace_providers[i][0] == '\0')
          continue;
-      int inside = strncmp(cwd, ws, len) == 0 && (cwd[len] == '/' || cwd[len] == '\0');
+      int inside =
+          strncmp(cwd, ws, len) == 0 && (cwd[len] == '/' || cwd[len] == '\\' || cwd[len] == '\0');
       if (inside && strcmp(cfg.workspace_providers[i], "detached") == 0)
          return 1;
    }

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -15,6 +15,20 @@ static inline void util_free_tokens(char **tokens, int count)
       free(tokens[i]);
 }
 
+/* True when `p` is an absolute path in either POSIX (/...) or Windows
+ * (C:\... / C:/...) form. The detached reverse-channel carries the CLIENT's cwd,
+ * which may be a Windows drive-letter path even though the server is POSIX, so
+ * cwd-binding/guard checks that must accept it use this rather than `p[0]=='/'`. */
+static inline int aimee_path_is_absolute(const char *p)
+{
+   if (!p || !p[0])
+      return 0;
+   if (p[0] == '/')
+      return 1;
+   return (((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) && p[1] == ':' &&
+           (p[2] == '\\' || p[2] == '/'));
+}
+
 /* 1 if `token` is a shell control/redirection operator (| || & && ; > >> < 2> 2>> >&). */
 static inline int util_token_is_shell_operator(const char *token)
 {

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -1009,6 +1009,11 @@ const char *path_in_thread_cwd(const char *path, char *buf, size_t buf_len)
 {
    if (!path || !path[0] || path[0] == '/')
       return path;
+   /* A Windows-absolute client path (C:\... or C:/...) is already rooted — don't
+    * prefix the detached turn's cwd onto it. */
+   if (((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
+       path[1] == ':' && (path[2] == '\\' || path[2] == '/'))
+      return path;
    const char *cwd = run_cmd_get_cwd();
    if (!cwd || !cwd[0] || !buf || buf_len == 0)
       return path;

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -577,7 +577,7 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
     * client-supplied cwd. Otherwise run in the (validated) client cwd. */
    const char *eff_cwd = workspace_turn_active_cwd();
    const char *use_cwd = eff_cwd ? eff_cwd : cwd;
-   if (use_cwd && use_cwd[0] == '/' && !strstr(use_cwd, "/.."))
+   if (aimee_path_is_absolute(use_cwd) && !strstr(use_cwd, "/.."))
       run_cmd_set_cwd(use_cwd);
    if (aimee_sid && aimee_sid[0])
       session_id_set_override(aimee_sid);

--- a/src/server/primary_session_adapter.c
+++ b/src/server/primary_session_adapter.c
@@ -252,8 +252,7 @@ int primary_session_adapter_turn(const primary_session_request_t *req, agent_res
       }
    }
 
-   if (req->cwd && req->cwd[0] && req->cwd[0] == '/' && !strstr(req->cwd, "/../") &&
-       !strstr(req->cwd, "/.."))
+   if (aimee_path_is_absolute(req->cwd) && !strstr(req->cwd, "/../") && !strstr(req->cwd, "/.."))
       run_cmd_set_cwd(req->cwd);
    if (effective_aimee_session_id[0])
       session_id_set_override(effective_aimee_session_id);

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -189,7 +189,7 @@ static void tool_execute_worker(void *arg)
     * A `mirror` workspace remaps into the server-side reconstructed worktree. */
    const char *eff_cwd = workspace_turn_active_cwd();
    const char *use_cwd = eff_cwd ? eff_cwd : cwd;
-   if (use_cwd[0] && use_cwd[0] == '/' && !strstr(use_cwd, "/../") && !strstr(use_cwd, "/.."))
+   if (aimee_path_is_absolute(use_cwd) && !strstr(use_cwd, "/../") && !strstr(use_cwd, "/.."))
       run_cmd_set_cwd(use_cwd);
 
    /* Guardrail pre-check */

--- a/src/server/server_runner_endpoints.inc
+++ b/src/server/server_runner_endpoints.inc
@@ -109,7 +109,14 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    char abs[MAX_PATH_LEN];
    if (is_detached || is_mirror)
    {
-      if (argv[0][0] != '/')
+      /* The root is the CLIENT's absolute path, never resolved on this server, so
+       * accept either POSIX (/...) or Windows (C:\... / C:/...) form — a Windows
+       * thin client serving its working tree registers a drive-letter path. */
+      const char *r = argv[0];
+      int posix_abs = (r[0] == '/');
+      int win_abs = (((r[0] >= 'A' && r[0] <= 'Z') || (r[0] >= 'a' && r[0] <= 'z')) &&
+                     r[1] == ':' && (r[2] == '\\' || r[2] == '/'));
+      if (!posix_abs && !win_abs)
          return server_send_error(conn, "workspace: detached/mirror root must be an absolute path",
                                   NULL);
       snprintf(abs, sizeof(abs), "%s", argv[0]);

--- a/src/server/workspace_turn.c
+++ b/src/server/workspace_turn.c
@@ -37,7 +37,9 @@ static int cwd_in_workspace(const char *cwd, const char *ws)
    size_t len = strlen(ws);
    if (len == 0)
       return 0;
-   return strncmp(cwd, ws, len) == 0 && (cwd[len] == '/' || cwd[len] == '\0');
+   /* '\\' is also a boundary so a Windows client's subdir (C:\ws\sub) matches its
+    * registered root (C:\ws); the exact-match case (cwd[len]=='\0') covers both. */
+   return strncmp(cwd, ws, len) == 0 && (cwd[len] == '/' || cwd[len] == '\\' || cwd[len] == '\0');
 }
 
 /* Production git runner for the mirror lifecycle: prepend "git" and fork/exec

--- a/src/windows/cli_client.c
+++ b/src/windows/cli_client.c
@@ -729,6 +729,13 @@ cJSON *cli_http_request_stream_ndjson(const char *endpoint, const char *method, 
       *http_status = 0;
    if (!endpoint || !method || !path)
       return NULL;
+   /* The caller passes the chat idle-timeout sentinel (-1 = "block until the
+    * server streams / closes"). cli_win_http_connect maps any non-positive value
+    * to the tiny 5s default SO_RCVTIMEO, which truncates a chat turn the moment
+    * the provider takes >5s to respond — the stream is read in one synchronous
+    * pass, so a long recv window is required. Use a generous bound instead. */
+   if (timeout_ms <= 0)
+      timeout_ms = 600000; /* 10 min — covers provider latency + tool round-trips */
    size_t len = 0;
    char *resp = cli_win_http_exec(endpoint, method, path, body_json, bearer, timeout_ms, &len);
    if (!resp)

--- a/src/windows/workspace_provider.c
+++ b/src/windows/workspace_provider.c
@@ -1,22 +1,294 @@
-/* windows/workspace_provider.c: Windows stub for the workspace provider.
+/* windows/workspace_provider.c: the `shared` (local-fs) resource provider for
+ * the Windows thin client.
  *
- * `aimee workspace serve` (hosting a local workspace for a remote server's
- * detached provider) is a POSIX-only capability — the full provider lives in
- * posix/workspace_provider.c and depends on POSIX fs/exec primitives. The
- * Windows thin client is a *client* of a remote aimee-server (it connects out;
- * it does not host a workspace), so it needs these two symbols only to link
- * cli_workspace_serve.c / workspace_provider_detached.c. `workspace serve` on
- * Windows is therefore unsupported and reports no provider rather than serving.
- */
+ * When the client serves a `detached` workspace to a remote aimee-server (via
+ * `aimee workspace serve` or the auto-started reverse-channel), the server
+ * marshals each file/exec op back here; ws_detached_runner_handle executes it
+ * through workspace_provider_shared(). This is the Windows implementation of
+ * that provider — the Win32/CRT counterpart of posix/workspace_provider.c, so a
+ * Windows client serves its working tree exactly like a POSIX one.
+ *
+ * read_all/write_all are plain stdio; stat/list/exec use the Win32 CRT
+ * (_stat, _findfirst, _popen). exec_shell runs the command through the native
+ * shell (cmd.exe via _popen), honouring the runner's thread-local cwd. */
 #include "workspace_provider.h"
 
+#include <direct.h>
+#include <io.h>
+#include <stdint.h>
+#include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
 
-/* No local provider on Windows: workspace serving is POSIX-only. Callers on the
- * serve path must treat NULL as "unsupported on this platform". */
+/* Thread-local cwd the runner sets (run_cmd_set_cwd) before an exec op, shared
+ * with util.c. NULL when unset. */
+extern const char *run_cmd_get_cwd(void);
+
+static int shared_read_all(const workspace_provider_t *p, const char *path, char **out, size_t *len)
+{
+   (void)p;
+   if (out)
+      *out = NULL;
+   if (len)
+      *len = 0;
+   if (!path || !out)
+      return -1;
+
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return -1;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return -1;
+   }
+   long sz = ftell(f);
+   if (sz < 0 || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return -1;
+   }
+   char *buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return -1;
+   }
+   size_t rd = fread(buf, 1, (size_t)sz, f);
+   if (ferror(f))
+   {
+      free(buf);
+      fclose(f);
+      return -1;
+   }
+   fclose(f);
+   buf[rd] = '\0';
+   *out = buf;
+   if (len)
+      *len = rd;
+   return 0;
+}
+
+static int shared_write_all(const workspace_provider_t *p, const char *path, const char *data,
+                            size_t len)
+{
+   (void)p;
+   if (!path)
+      return -1;
+
+   FILE *f = fopen(path, "wb");
+   if (!f)
+      return -1;
+   if (len > 0 && data && fwrite(data, 1, len, f) != len)
+   {
+      fclose(f);
+      return -1;
+   }
+   if (fclose(f) != 0)
+      return -1;
+   return 0;
+}
+
+static int shared_stat(const workspace_provider_t *p, const char *path, ws_stat_t *st)
+{
+   (void)p;
+   if (!st)
+      return -1;
+   st->exists = 0;
+   st->is_dir = 0;
+   st->size = 0;
+
+   struct _stat sb;
+   if (path && _stat(path, &sb) == 0)
+   {
+      st->exists = 1;
+      st->is_dir = (sb.st_mode & _S_IFDIR) ? 1 : 0;
+      st->size = (sb.st_mode & _S_IFDIR) ? 0 : (long)sb.st_size;
+   }
+   return 0;
+}
+
+/* List dir entries matching pattern (default *), returning full "dir/name"
+ * paths to mirror the POSIX glob provider. Uses the Win32 CRT _findfirst API. */
+static int shared_list(const workspace_provider_t *p, const char *dir, const char *pattern,
+                       char ***out, int *count)
+{
+   (void)p;
+   if (out)
+      *out = NULL;
+   if (count)
+      *count = 0;
+   if (!dir || !out || !count)
+      return -1;
+
+   char find_pat[4096];
+   snprintf(find_pat, sizeof(find_pat), "%s/%s", dir, (pattern && pattern[0]) ? pattern : "*");
+
+   struct _finddata_t fd;
+   intptr_t h = _findfirst(find_pat, &fd);
+   if (h == -1)
+   {
+      /* No match (or unreadable dir) is an empty list, like GLOB_NOMATCH. */
+      *out = NULL;
+      *count = 0;
+      return 0;
+   }
+
+   char **arr = NULL;
+   int n = 0, cap = 0;
+   do
+   {
+      if (strcmp(fd.name, ".") == 0 || strcmp(fd.name, "..") == 0)
+         continue;
+      if (n == cap)
+      {
+         int ncap = cap ? cap * 2 : 16;
+         char **na = realloc(arr, (size_t)ncap * sizeof(char *));
+         if (!na)
+         {
+            ws_provider_free_list(arr, n);
+            _findclose(h);
+            return -1;
+         }
+         arr = na;
+         cap = ncap;
+      }
+      char full[4096];
+      snprintf(full, sizeof(full), "%s/%s", dir, fd.name);
+      arr[n] = _strdup(full);
+      if (!arr[n])
+      {
+         ws_provider_free_list(arr, n);
+         _findclose(h);
+         return -1;
+      }
+      n++;
+   } while (_findnext(h, &fd) == 0);
+   _findclose(h);
+
+   *out = arr;
+   *count = n;
+   return 0;
+}
+
+/* Append a quoted argv token to a command-line buffer (CRT quoting is enough
+ * for the cmd.exe pipeline we spawn). Returns bytes written, 0 on overflow. */
+static size_t append_quoted(char *buf, size_t cap, size_t off, const char *tok)
+{
+   int w = snprintf(buf + off, cap - off, "%s\"%s\"", off ? " " : "", tok ? tok : "");
+   if (w < 0 || (size_t)w >= cap - off)
+      return 0;
+   return (size_t)w;
+}
+
+/* Run `cmdline` through cmd.exe, capturing combined output, honouring the
+ * runner's thread-local cwd by prefixing `cd /d "<cwd>" &&`. Caller frees. */
+static char *win_capture(const char *cmdline, int *exit_code)
+{
+   if (exit_code)
+      *exit_code = -1;
+   if (!cmdline)
+      return NULL;
+
+   /* Combine stderr into stdout (the provider contract) and honour the runner's
+    * thread-local cwd by prefixing a cmd.exe `cd /d`. */
+   const char *cwd = run_cmd_get_cwd();
+   size_t need = strlen(cmdline) + (cwd ? strlen(cwd) : 0) + 48;
+   char *full = malloc(need);
+   if (!full)
+      return NULL;
+   if (cwd && cwd[0])
+      snprintf(full, need, "cd /d \"%s\" && %s 2>&1", cwd, cmdline);
+   else
+      snprintf(full, need, "%s 2>&1", cmdline);
+
+   FILE *f = _popen(full, "r");
+   free(full);
+   if (!f)
+      return NULL;
+
+   size_t cap = 65536, len = 0;
+   char *buf = malloc(cap);
+   if (!buf)
+   {
+      _pclose(f);
+      return NULL;
+   }
+   size_t r;
+   while ((r = fread(buf + len, 1, cap - len - 1, f)) > 0)
+   {
+      len += r;
+      if (len + 1 >= cap)
+      {
+         size_t ncap = cap * 2;
+         char *nb = realloc(buf, ncap);
+         if (!nb)
+            break;
+         buf = nb;
+         cap = ncap;
+      }
+   }
+   buf[len] = '\0';
+   int rc = _pclose(f);
+   if (exit_code)
+      *exit_code = rc;
+   return buf;
+}
+
+static int shared_exec(const workspace_provider_t *p, const char *const argv[], char **out,
+                       size_t max_out)
+{
+   (void)p;
+   if (out)
+      *out = NULL;
+   if (!argv || !argv[0])
+      return -1;
+
+   char cmdline[8192];
+   size_t off = 0;
+   for (int i = 0; argv[i]; i++)
+   {
+      size_t w = append_quoted(cmdline, sizeof(cmdline), off, argv[i]);
+      if (!w)
+         return -1;
+      off += w;
+   }
+
+   int rc = -1;
+   char *captured = win_capture(cmdline, &rc);
+   if (out && captured)
+   {
+      if (max_out && strlen(captured) >= max_out)
+         captured[max_out - 1] = '\0';
+      *out = captured;
+   }
+   else
+   {
+      free(captured);
+   }
+   return rc;
+}
+
+static char *shared_exec_shell(const workspace_provider_t *p, const char *cmd, int *exit_code)
+{
+   (void)p;
+   return win_capture(cmd, exit_code);
+}
+
+static const workspace_provider_t g_shared_provider = {
+    .kind = WS_PROVIDER_SHARED,
+    .read_all = shared_read_all,
+    .write_all = shared_write_all,
+    .stat = shared_stat,
+    .list = shared_list,
+    .exec = shared_exec,
+    .exec_shell = shared_exec_shell,
+};
+
 const workspace_provider_t *workspace_provider_shared(void)
 {
-   return NULL;
+   return &g_shared_provider;
 }
 
 /* Mirrors posix/workspace_provider.c: free each entry, then the array. NULL-safe. */


### PR DESCRIPTION
Completes the Windows reverse-channel (follows #92). The serve loop built, but `windows/workspace_provider.c` was a stub returning NULL, so the client had no provider to execute the server's marshalled file/exec ops. This implements the real `shared` provider on Windows (Win32/CRT counterpart of `posix/workspace_provider.c`): read/write (stdio), stat (`_stat`), list (`_findfirst`), exec (argv→cmdline), exec_shell (cmd.exe via `_popen`, honouring the runner cwd + `2>&1`). Verified by windows-build/windows-cmake; runtime e2e on a Server 2019 VM in progress.