### PR TITLE
fix(mcp-serve): route each request by its own method (fixes remote tools/list)

### DIFF
--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -152,8 +152,15 @@ static cJSON *server_request(cJSON *req, int timeout_ms)
    {
       char *endpoint = cli_rpc_client_endpoint();
       char *bearer = cli_rpc_client_bearer();
+      /* Route by the request's ACTUAL method, not a hardcoded "mcp.call": e.g.
+       * mcp.tools_list -> GET /v1/mcp/tools_list, mcp.call -> POST /v1/mcp/call.
+       * Hardcoding mcp.call sent tools/list to /v1/mcp/call (which needs a `tool`
+       * arg) and failed with "Failed to list tools". */
+      cJSON *jmethod = cJSON_GetObjectItemCaseSensitive(req, "method");
+      const char *method =
+          (cJSON_IsString(jmethod) && jmethod->valuestring[0]) ? jmethod->valuestring : "mcp.call";
       const char *verb = NULL;
-      const char *path = cli_v1_route_for_method("mcp.call", &verb);
+      const char *path = cli_v1_route_for_method(method, &verb);
       cJSON *resp = NULL;
       if (endpoint && path)
       {


### PR DESCRIPTION
The aimee MCP server (`aimee mcp-serve`, used by Claude Code) failed `tools/list` against a remote aimee-server: `server_request()` hardcoded the `mcp.call` route, so `mcp.tools_list` (a GET /v1/mcp/tools_list route) was POSTed to /v1/mcp/call and errored. Route by the request's actual method instead. Verified e2e against the smoothnas plugin (tools/list=90 tools, tools/call search_memory returns kb facts).