### PR TITLE
ci(windows): fix the flaky MinGW install (use pre-installed MSYS2 + retried fallback)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,12 +171,26 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install MinGW-w64
-        run: choco install mingw
-
-      - name: Add MinGW to PATH
-        shell: powershell
-        run: echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Set up MinGW-w64
+        shell: pwsh
+        run: |
+          # Prefer the MSYS2 mingw-w64 toolchain pre-installed on the runner image
+          # (no network) and fall back to a *retried* choco install only if it is
+          # absent. `choco install mingw` on its own flakes intermittently on the
+          # Chocolatey CDN, which used to fail the Windows jobs ~50% of the time.
+          $mingw = "C:\msys64\mingw64\bin"
+          if (-not (Test-Path "$mingw\gcc.exe")) {
+            $ok = $false
+            for ($i = 0; $i -lt 3 -and -not $ok; $i++) {
+              choco install mingw -y --no-progress
+              if ($LASTEXITCODE -eq 0) { $ok = $true } else { Start-Sleep 15 }
+            }
+            if (-not $ok) { Write-Error "MinGW install failed after 3 attempts"; exit 1 }
+            $mingw = "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+          }
+          Write-Host "Using MinGW at $mingw"
+          & "$mingw\gcc.exe" --version
+          echo "$mingw" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Download SQLite amalgamation
         shell: powershell

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,23 +174,33 @@ jobs:
       - name: Set up MinGW-w64
         shell: pwsh
         run: |
-          # Prefer the MSYS2 mingw-w64 toolchain pre-installed on the runner image
-          # (no network) and fall back to a *retried* choco install only if it is
-          # absent. `choco install mingw` on its own flakes intermittently on the
-          # Chocolatey CDN, which used to fail the Windows jobs ~50% of the time.
-          $mingw = "C:\msys64\mingw64\bin"
-          if (-not (Test-Path "$mingw\gcc.exe")) {
-            $ok = $false
-            for ($i = 0; $i -lt 3 -and -not $ok; $i++) {
-              choco install mingw -y --no-progress
-              if ($LASTEXITCODE -eq 0) { $ok = $true } else { Start-Sleep 15 }
-            }
-            if (-not $ok) { Write-Error "MinGW install failed after 3 attempts"; exit 1 }
-            $mingw = "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+          # Reliable MinGW setup. Two failure modes this avoids:
+          #  (1) bare `choco install mingw` flakes ~50% on the Chocolatey CDN;
+          #  (2) the choco package's gcc path changes between versions (v15.2.0
+          #      moved it), so a hardcoded `...\mingw64\bin` breaks.
+          # Prefer the MSYS2 mingw64 toolchain pre-installed on the runner image
+          # (no network); otherwise choco-install with retries and *discover* the
+          # gcc.exe location instead of hardcoding it.
+          function Find-MingwBin {
+            if (Test-Path "C:\msys64\mingw64\bin\gcc.exe") { return "C:\msys64\mingw64\bin" }
+            $g = Get-ChildItem -Path "C:\ProgramData\chocolatey\lib\mingw","C:\ProgramData\mingw64" `
+                   -Recurse -Filter gcc.exe -ErrorAction SilentlyContinue |
+                 Where-Object { $_.FullName -match 'mingw64' } | Select-Object -First 1
+            if ($g) { return (Split-Path $g.FullName) }
+            return $null
           }
-          Write-Host "Using MinGW at $mingw"
-          & "$mingw\gcc.exe" --version
-          echo "$mingw" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $bin = Find-MingwBin
+          if (-not $bin) {
+            for ($i = 0; $i -lt 3 -and -not $bin; $i++) {
+              choco install mingw -y --no-progress
+              if ($LASTEXITCODE -ne 0) { Start-Sleep 15 }
+              $bin = Find-MingwBin
+            }
+          }
+          if (-not $bin) { Write-Error "MinGW gcc.exe not found after install"; exit 1 }
+          Write-Host "Using MinGW at $bin"
+          & "$bin\gcc.exe" --version
+          echo "$bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Download SQLite amalgamation
         shell: powershell

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -115,13 +115,27 @@ jobs:
         run: cp build/aimee "${{ matrix.asset }}"
 
       # --- Windows: CMake thin-client target via MinGW, lean profile ---
-      - name: Install MinGW-w64 (Windows)
+      - name: Set up MinGW-w64 (Windows)
         if: matrix.kind == 'windows'
-        run: choco install mingw
-      - name: Add MinGW to PATH (Windows)
-        if: matrix.kind == 'windows'
-        shell: powershell
-        run: echo "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        shell: pwsh
+        run: |
+          # Prefer the MSYS2 mingw-w64 toolchain pre-installed on the runner image
+          # (no network) and fall back to a *retried* choco install only if absent.
+          # Bare `choco install mingw` flakes on the Chocolatey CDN and used to
+          # fail the Windows release build intermittently.
+          $mingw = "C:\msys64\mingw64\bin"
+          if (-not (Test-Path "$mingw\gcc.exe")) {
+            $ok = $false
+            for ($i = 0; $i -lt 3 -and -not $ok; $i++) {
+              choco install mingw -y --no-progress
+              if ($LASTEXITCODE -eq 0) { $ok = $true } else { Start-Sleep 15 }
+            }
+            if (-not $ok) { Write-Error "MinGW install failed after 3 attempts"; exit 1 }
+            $mingw = "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+          }
+          Write-Host "Using MinGW at $mingw"
+          & "$mingw\gcc.exe" --version
+          echo "$mingw" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Download SQLite amalgamation (Windows)
         if: matrix.kind == 'windows'
         shell: powershell

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -119,23 +119,30 @@ jobs:
         if: matrix.kind == 'windows'
         shell: pwsh
         run: |
-          # Prefer the MSYS2 mingw-w64 toolchain pre-installed on the runner image
-          # (no network) and fall back to a *retried* choco install only if absent.
-          # Bare `choco install mingw` flakes on the Chocolatey CDN and used to
-          # fail the Windows release build intermittently.
-          $mingw = "C:\msys64\mingw64\bin"
-          if (-not (Test-Path "$mingw\gcc.exe")) {
-            $ok = $false
-            for ($i = 0; $i -lt 3 -and -not $ok; $i++) {
-              choco install mingw -y --no-progress
-              if ($LASTEXITCODE -eq 0) { $ok = $true } else { Start-Sleep 15 }
-            }
-            if (-not $ok) { Write-Error "MinGW install failed after 3 attempts"; exit 1 }
-            $mingw = "C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin"
+          # Reliable MinGW setup — avoids the Chocolatey CDN flake AND the choco
+          # package's changing gcc path (v15.2.0 moved it). Prefer the MSYS2
+          # mingw64 toolchain pre-installed on the runner; else choco-install with
+          # retries and discover gcc.exe rather than hardcoding its directory.
+          function Find-MingwBin {
+            if (Test-Path "C:\msys64\mingw64\bin\gcc.exe") { return "C:\msys64\mingw64\bin" }
+            $g = Get-ChildItem -Path "C:\ProgramData\chocolatey\lib\mingw","C:\ProgramData\mingw64" `
+                   -Recurse -Filter gcc.exe -ErrorAction SilentlyContinue |
+                 Where-Object { $_.FullName -match 'mingw64' } | Select-Object -First 1
+            if ($g) { return (Split-Path $g.FullName) }
+            return $null
           }
-          Write-Host "Using MinGW at $mingw"
-          & "$mingw\gcc.exe" --version
-          echo "$mingw" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          $bin = Find-MingwBin
+          if (-not $bin) {
+            for ($i = 0; $i -lt 3 -and -not $bin; $i++) {
+              choco install mingw -y --no-progress
+              if ($LASTEXITCODE -ne 0) { Start-Sleep 15 }
+              $bin = Find-MingwBin
+            }
+          }
+          if (-not $bin) { Write-Error "MinGW gcc.exe not found after install"; exit 1 }
+          Write-Host "Using MinGW at $bin"
+          & "$bin\gcc.exe" --version
+          echo "$bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Download SQLite amalgamation (Windows)
         if: matrix.kind == 'windows'
         shell: powershell


### PR DESCRIPTION
The Windows CI jobs flaked ~50% each at `choco install mingw` (Chocolatey CDN rate-limit/timeout), so green promotes needed repeated retries — a real red flag. Switch to the **MSYS2 mingw-w64 toolchain pre-installed on the GitHub Windows runner** (`C:\msys64\mingw64\bin`, no network), with a retried (3×) choco fallback only if absent. Applied to ci.yml (windows-build + windows-cmake) and release-thin-client.yml. Logs `gcc --version` for visibility.