### PR TITLE
feat(ingress): P2 code-context envelope (lead with code search)

### DIFF
--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -19,10 +19,18 @@
 #define DEC_INGRESS_PREINJECT_H 1
 
 #include "cJSON.h"
+#include "index.h" /* code_search_hit_t */
 
 /* Map a recall relevance score in [0,1] to a confidence tier string
  * ("high" | "medium" | "low"). Pure; thresholds documented in the .c. */
 const char *ingress_preinject_confidence(double top_score);
+
+/* Format code-search hits into a `recommended (code):` block — one
+ * `  - <file>` line per hit, each followed by a trimmed single-line snippet.
+ * This is the primary pre-injection signal: the agent sees which files matter
+ * for the turn before it explores. Returns a malloc'd string the caller frees,
+ * or NULL when there are no hits. Pure (no kb). */
+char *ingress_preinject_format_code_block(const code_search_hit_t *hits, int n);
 
 /* Format the <aimee-context …> envelope from an already-packed context block
  * and a confidence tier. Returns a malloc'd string the caller frees, or NULL

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -53,6 +53,40 @@ char *ingress_preinject_format_envelope(const char *context_block, const char *c
    return out;
 }
 
+char *ingress_preinject_format_code_block(const code_search_hit_t *hits, int n)
+{
+   if (!hits || n <= 0)
+      return NULL;
+   dstr_t d;
+   dstr_init(&d);
+   dstr_append_str(&d, "recommended (code):\n");
+   for (int i = 0; i < n; i++)
+   {
+      dstr_appendf(&d, "  - %s\n", hits[i].file_path);
+      /* One trimmed, single-line snippet so the agent sees why the file matched
+       * without paying for the whole match. Collapse whitespace runs. */
+      const char *s = hits[i].snippet;
+      if (s && s[0])
+      {
+         char line[160];
+         int j = 0;
+         for (const char *p = s; *p && j < (int)sizeof(line) - 1; p++)
+         {
+            char c = (*p == '\n' || *p == '\r' || *p == '\t') ? ' ' : *p;
+            if (c == ' ' && (j == 0 || line[j - 1] == ' '))
+               continue; /* skip leading / collapsed spaces */
+            line[j++] = c;
+         }
+         while (j > 0 && line[j - 1] == ' ')
+            j--;
+         line[j] = '\0';
+         if (line[0])
+            dstr_appendf(&d, "    > %s\n", line);
+      }
+   }
+   return dstr_steal(&d);
+}
+
 /* Pull the text out of a message `content` that is either a JSON string or an
  * array of {type, text} parts (the Responses content shape). Appends into d. */
 static void append_content_text(dstr_t *d, const cJSON *content)
@@ -115,23 +149,56 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    if (!cfg.ingress_preinject_enabled)
       return NULL;
 
-   char *block = kb_client_memory_context_block(query, "general", 5);
-   if (!block)
+   dstr_t block;
+   dstr_init(&block);
+   double score = 0.0;
+
+   /* Primary signal: code search over the turn query. The code index is the
+    * richest source, so recommended code files lead the envelope; the agent
+    * sees which files matter before it explores. Confidence scales with how
+    * many relevant files came back (no [0,1] rank is exposed by the search
+    * path, so map the hit count into the tiering primitive). */
+   code_search_hit_t hits[6];
+   int n = kb_client_index_code_search(query, NULL, hits, (int)(sizeof(hits) / sizeof(hits[0])));
+   if (n > 0)
+   {
+      char *code = ingress_preinject_format_code_block(hits, n);
+      if (code)
+      {
+         dstr_append_str(&block, code);
+         free(code);
+      }
+      double cs = (double)n / 6.0;
+      if (cs > score)
+         score = cs;
+   }
+
+   /* Secondary signal: durable memory context (the how/why), when present.
+    * Empty in deployments with no charter, so guarded. */
+   char *mem = kb_client_memory_context_block(query, "general", 5);
+   if (mem && mem[0])
+   {
+      int lines = 0;
+      for (const char *p = mem; *p; p++)
+         if (*p == '\n')
+            lines++;
+      if (block.len)
+         dstr_append_str(&block, "\n");
+      dstr_append_str(&block, mem);
+      double ms = lines >= 6 ? 0.7 : (lines >= 2 ? 0.4 : 0.1);
+      if (ms > score)
+         score = ms;
+   }
+   free(mem);
+
+   char *blk = dstr_steal(&block);
+   if (!blk || !blk[0])
+   {
+      free(blk);
       return NULL;
-
-   /* No score is exposed by the context-block path yet, so derive a coarse
-    * confidence from how much context came back: a multi-entry block is a
-    * stronger signal than a sparse one. This is the provisional source for the
-    * (unit-tested) ingress_preinject_confidence() tiering until the recall path
-    * surfaces graph_score. */
-   int lines = 0;
-   for (const char *p = block; *p; p++)
-      if (*p == '\n')
-         lines++;
-   double score = lines >= 6 ? 0.7 : (lines >= 2 ? 0.4 : 0.1);
-
-   char *env = ingress_preinject_format_envelope(block, ingress_preinject_confidence(score));
-   free(block);
+   }
+   char *env = ingress_preinject_format_envelope(blk, ingress_preinject_confidence(score));
+   free(blk);
    return env;
 }
 

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -19,6 +19,15 @@ char *kb_client_memory_context_block(const char *query, const char *block_type, 
    (void)limit;
    return NULL;
 }
+int kb_client_index_code_search(const char *query, const char *project, code_search_hit_t *out,
+                                int max)
+{
+   (void)query;
+   (void)project;
+   (void)out;
+   (void)max;
+   return 0;
+}
 int config_load(config_t *cfg)
 {
    if (cfg)
@@ -113,11 +122,36 @@ static void test_apply(void)
    printf("apply OK\n");
 }
 
+static void test_format_code_block(void)
+{
+   assert(ingress_preinject_format_code_block(NULL, 3) == NULL);
+   code_search_hit_t hits[2];
+   memset(hits, 0, sizeof(hits));
+   assert(ingress_preinject_format_code_block(hits, 0) == NULL);
+
+   snprintf(hits[0].file_path, sizeof(hits[0].file_path), "src/server/openai_chat.c");
+   snprintf(hits[0].snippet, sizeof(hits[0].snippet), "  static int   responses_stream_handler(\n\tconst char *body)");
+   snprintf(hits[1].file_path, sizeof(hits[1].file_path), "src/server/ingress_preinject.c");
+   hits[1].snippet[0] = '\0'; /* no snippet -> just the file line */
+
+   char *b = ingress_preinject_format_code_block(hits, 2);
+   assert(b != NULL);
+   assert(strstr(b, "recommended (code):") == b);
+   assert(strstr(b, "  - src/server/openai_chat.c") != NULL);
+   assert(strstr(b, "  - src/server/ingress_preinject.c") != NULL);
+   /* snippet whitespace collapsed to a single line, no tabs/newlines */
+   assert(strstr(b, "> static int responses_stream_handler( const char *body)") != NULL);
+   assert(strchr(b, '\t') == NULL);
+   free(b);
+   printf("format_code_block OK\n");
+}
+
 int main(void)
 {
    printf("ingress_preinject: ");
    test_confidence_tiers();
    test_format_envelope();
+   test_format_code_block();
    test_query_from_messages();
    test_apply();
    printf("all tests passed\n");

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -130,7 +130,8 @@ static void test_format_code_block(void)
    assert(ingress_preinject_format_code_block(hits, 0) == NULL);
 
    snprintf(hits[0].file_path, sizeof(hits[0].file_path), "src/server/openai_chat.c");
-   snprintf(hits[0].snippet, sizeof(hits[0].snippet), "  static int   responses_stream_handler(\n\tconst char *body)");
+   snprintf(hits[0].snippet, sizeof(hits[0].snippet),
+            "  static int   responses_stream_handler(\n\tconst char *body)");
    snprintf(hits[1].file_path, sizeof(hits[1].file_path), "src/server/ingress_preinject.c");
    hits[1].snippet[0] = '\0'; /* no snippet -> just the file line */
 


### PR DESCRIPTION
## Summary
P2 of the context-preinjection proposal: make the `<aimee-context>` envelope carry **code context** — the richest signal in a typical deployment (the code index has thousands of indexed files even when the structured memory recall bundle is empty).

The pre-injection builder now runs `index_code_search` over the turn query and packs the top file hits (with trimmed single-line snippets) into the envelope as a `recommended (code):` block, ahead of the durable memory context. The agent sees which files matter for the turn before it explores. Confidence scales with the number of relevant files.

## Changes
- `ingress_preinject_format_code_block()` — pure helper formatting `code_search_hit_t[]` into the `recommended (code):` block (file line + collapsed single-line snippet). Unit-tested.
- `ingress_preinject_build()` — leads with `kb_client_index_code_search` (primary signal), then folds in the memory context block (secondary); confidence from the stronger signal.

## Tests
- `test_ingress_preinject`: `format_code_block` (NULL/empty, file lines, whitespace-collapsed snippet, no tabs/newlines) + existing pure-helper coverage.
- Server builds clean under `-Werror`; clang-format-19 clean.

## Safety
Still gated by `ingress_preinject_enabled` (default off).
