### PR TITLE
feat(ingress): P3 PreCompact re-prime hook for Claude Code

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1805,6 +1805,10 @@ int main(int argc, char **argv)
    if (strcmp(cmd, "user-prompt-submit") == 0)
       return handle_user_prompt_submit();
 
+   /* PreCompact hook (P3 re-prime; settings.json wires it as `aimee pre-compact`). */
+   if (strcmp(cmd, "pre-compact") == 0)
+      return handle_pre_compact();
+
    /* agent token: read access_token from local auth file; no server needed.
     * This command is called by agent_resolve_auth via safe_exec_capture so it
     * must exit 0 and print only the raw token on stdout. */

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -222,6 +222,73 @@ int handle_user_prompt_submit(void)
    return 0;
 }
 
+/* Thin-client PreCompact hook (P3 re-prime). Claude Code fires PreCompact just
+ * before it compacts the conversation, which drops the session-start context.
+ * Re-emit the durable recall (same broad read-only POST /v1/memory/recall as
+ * session-start) as additionalContext so the post-compaction context still
+ * carries identity/preferences/rules/active-context. Soft-fails (exit 0). */
+int handle_pre_compact(void)
+{
+   char *stdin_data = read_stdin();
+   free(stdin_data); /* PreCompact payload is informational; recall is broad. */
+
+   char *endpoint = cli_rpc_client_endpoint();
+   if (!endpoint)
+      return 0;
+   char *bearer = cli_rpc_client_bearer();
+
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "task_hint", "compaction re-prime");
+   cJSON_AddBoolToObject(body, "session_start", 1);
+   char *body_s = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+
+   int status = 0;
+   cJSON *resp =
+       cli_http_request(endpoint, "POST", "/v1/memory/recall", body_s, bearer, 30000, &status);
+   free(endpoint);
+   free(bearer);
+   free(body_s);
+   if (!resp || status != 200)
+   {
+      cJSON_Delete(resp);
+      return 0;
+   }
+
+   cJSON *recall = cJSON_GetObjectItemCaseSensitive(resp, "recall");
+   struct ss_sbuf b = {0};
+   ss_render_section(&b, "Always-On Rules", cJSON_GetObjectItem(recall, "always_on_rules"));
+   ss_render_section(&b, "Identity", cJSON_GetObjectItem(recall, "identity"));
+   ss_render_section(&b, "Preferences", cJSON_GetObjectItem(recall, "preferences"));
+   ss_render_section(&b, "Active Context", cJSON_GetObjectItem(recall, "active_context"));
+   ss_render_section(&b, "Open Commitments", cJSON_GetObjectItem(recall, "open_commitments"));
+   ss_render_section(&b, "Reminders", cJSON_GetObjectItem(recall, "reminders"));
+   ss_render_section(&b, "Directives", cJSON_GetObjectItem(recall, "directives"));
+
+   if (b.p && b.p[0])
+   {
+      cJSON *out = cJSON_CreateObject();
+      cJSON *hook_out = cJSON_AddObjectToObject(out, "hookSpecificOutput");
+      cJSON_AddStringToObject(hook_out, "hookEventName", "PreCompact");
+      struct ss_sbuf ctx = {0};
+      ss_add(&ctx, "# Proactive Recall (re-primed after compaction)\n\n");
+      ss_add(&ctx, b.p);
+      cJSON_AddStringToObject(hook_out, "additionalContext", ctx.p ? ctx.p : b.p);
+      char *s = cJSON_PrintUnformatted(out);
+      if (s)
+      {
+         fputs(s, stdout);
+         fputc('\n', stdout);
+         free(s);
+      }
+      free(ctx.p);
+      cJSON_Delete(out);
+   }
+   free(b.p);
+   cJSON_Delete(resp);
+   return 0;
+}
+
 int handle_session_start(int json_output)
 {
    char *stdin_data = read_stdin();

--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -860,6 +860,58 @@ static void ensure_claude_code_mcp(const char *settings_path)
    cJSON_Delete(root);
 }
 
+/* Ensure `hooks.<event>` contains a no-matcher entry running
+ * `AIMEE_HOOK_CLIENT=claude <aimee> <subcommand>`. Idempotent (keyed on the
+ * subcommand substring); sets *dirty when it adds the array or the entry. Used
+ * for the context-pre-injection hooks (UserPromptSubmit, PreCompact) which fire
+ * on every event and carry no matcher. */
+static void ensure_aimee_event_hook(cJSON *hooks, const char *event, const char *subcommand,
+                                    int *dirty)
+{
+   cJSON *arr = cJSON_GetObjectItemCaseSensitive(hooks, event);
+   if (!cJSON_IsArray(arr))
+   {
+      if (arr)
+         cJSON_DeleteItemFromObjectCaseSensitive(hooks, event);
+      arr = cJSON_AddArrayToObject(hooks, event);
+      *dirty = 1;
+   }
+   for (int i = 0; i < cJSON_GetArraySize(arr); i++)
+   {
+      cJSON *hook_arr = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(arr, i), "hooks");
+      if (!cJSON_IsArray(hook_arr))
+         continue;
+      for (int j = 0; j < cJSON_GetArraySize(hook_arr); j++)
+      {
+         cJSON *cmd = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(hook_arr, j), "command");
+         if (cJSON_IsString(cmd) && strstr(cmd->valuestring, subcommand))
+            return; /* already installed */
+      }
+   }
+   const char *aimee_bin = resolved_aimee_bin_path();
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "AIMEE_HOOK_CLIENT=claude %s %s", aimee_bin ? aimee_bin : "aimee",
+            subcommand);
+   cJSON *entry = cJSON_CreateObject();
+   cJSON *hook_arr = cJSON_CreateArray();
+   cJSON *hook = cJSON_CreateObject();
+   if (entry && hook_arr && hook)
+   {
+      cJSON_AddStringToObject(hook, "type", "command");
+      cJSON_AddStringToObject(hook, "command", cmd);
+      cJSON_AddItemToArray(hook_arr, hook);
+      cJSON_AddItemToObject(entry, "hooks", hook_arr);
+      cJSON_AddItemToArray(arr, entry);
+      *dirty = 1;
+   }
+   else
+   {
+      cJSON_Delete(entry);
+      cJSON_Delete(hook_arr);
+      cJSON_Delete(hook);
+   }
+}
+
 /* Ensure PostToolUse hooks include EnterWorktree|ExitWorktree so that
  * aimee's CWD tracking file gets updated when the session enters/exits
  * a worktree. Without this, MCP git tools won't follow worktree changes. */
@@ -963,57 +1015,11 @@ static void ensure_claude_code_hooks(const char *settings_path)
       }
    }
 
-   /* P1 context pre-injection: a UserPromptSubmit hook that injects a per-turn
-    * <aimee-context> envelope (recall seeded by the prompt + an explore-with
-    * pointer at aimee's tools) so Claude Code reasons over already-loaded
-    * context instead of re-exploring. The hook fires on every prompt (no
-    * matcher) and soft-fails, so it never blocks a turn. */
-   cJSON *ups = cJSON_GetObjectItemCaseSensitive(hooks, "UserPromptSubmit");
-   if (!cJSON_IsArray(ups))
-   {
-      if (ups)
-         cJSON_DeleteItemFromObjectCaseSensitive(hooks, "UserPromptSubmit");
-      ups = cJSON_AddArrayToObject(hooks, "UserPromptSubmit");
-      dirty = 1;
-   }
-   int found_ups = 0;
-   for (int i = 0; i < cJSON_GetArraySize(ups); i++)
-   {
-      cJSON *hook_arr = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(ups, i), "hooks");
-      if (!cJSON_IsArray(hook_arr))
-         continue;
-      for (int j = 0; j < cJSON_GetArraySize(hook_arr); j++)
-      {
-         cJSON *cmd = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(hook_arr, j), "command");
-         if (cJSON_IsString(cmd) && strstr(cmd->valuestring, "user-prompt-submit"))
-            found_ups = 1;
-      }
-   }
-   if (!found_ups)
-   {
-      const char *aimee_bin = resolved_aimee_bin_path();
-      char ups_cmd[512];
-      snprintf(ups_cmd, sizeof(ups_cmd), "AIMEE_HOOK_CLIENT=claude %s user-prompt-submit",
-               aimee_bin ? aimee_bin : "aimee");
-      cJSON *entry = cJSON_CreateObject();
-      cJSON *hook_arr = cJSON_CreateArray();
-      cJSON *hook = cJSON_CreateObject();
-      if (entry && hook_arr && hook)
-      {
-         cJSON_AddStringToObject(hook, "type", "command");
-         cJSON_AddStringToObject(hook, "command", ups_cmd);
-         cJSON_AddItemToArray(hook_arr, hook);
-         cJSON_AddItemToObject(entry, "hooks", hook_arr);
-         cJSON_AddItemToArray(ups, entry);
-         dirty = 1;
-      }
-      else
-      {
-         cJSON_Delete(entry);
-         cJSON_Delete(hook_arr);
-         cJSON_Delete(hook);
-      }
-   }
+   /* Context pre-injection hooks: the P1 per-turn UserPromptSubmit envelope and
+    * the P3 PreCompact re-prime. Both fire with no matcher and soft-fail, so
+    * they never block a turn. */
+   ensure_aimee_event_hook(hooks, "UserPromptSubmit", "user-prompt-submit", &dirty);
+   ensure_aimee_event_hook(hooks, "PreCompact", "pre-compact", &dirty);
 
    if (dirty)
    {

--- a/src/headers/cli_session_start.h
+++ b/src/headers/cli_session_start.h
@@ -21,4 +21,9 @@ int handle_session_start(int json_output);
  * hook's additionalContext. Always soft-fails (returns 0). */
 int handle_user_prompt_submit(void);
 
+/* `aimee pre-compact` PreCompact-hook entry (cli_session_start.c). Re-emits the
+ * durable recall as additionalContext just before Claude Code compacts, so the
+ * post-compaction context isn't lost. Always soft-fails (returns 0). */
+int handle_pre_compact(void);
+
 #endif /* DEC_CLI_SESSION_START_H */


### PR DESCRIPTION
## Summary
P3 of the context-preinjection proposal (§D PreCompact re-prime). Claude Code drops the session-start context when it compacts the conversation; this re-injects the durable recall right before that happens.

## Changes
- `handle_pre_compact()` (`cli_session_start.c`) — on the `PreCompact` event, re-fetch the broad recall (read-only `POST /v1/memory/recall`, `session_start=1`) and emit it as `additionalContext` ("# Proactive Recall (re-primed after compaction)"). Mirrors the session-start-remote path; soft-fails (exit 0).
- `aimee pre-compact` CLI dispatch.
- Refactored the per-event hook installer into `ensure_aimee_event_hook(hooks, event, subcommand, &dirty)` — used for both `UserPromptSubmit` (P1) and `PreCompact`. `claude-proxy enable` now installs both (no matcher, soft-fail).

## Tests
- `client-integrations`, `cmd-session`, `cli-mcp-serve` green; client/server build clean under `-Werror`; clang-format-19 clean.
- Functionally verified: `echo '{...}' | aimee pre-compact` soft-fails cleanly (exit 0, no output) against the live server.

## Design
Same constraint as P1: the Anthropic `/v1/messages` proxy stays a pure wire-format proxy; Claude Code gets re-priming via the hook, not the wire.
