### PR TITLE
feat(code-audit): aimee code audit — local file-health scan (P4 slice)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -735,6 +735,7 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_main.c
     ${AIMEE_SRC_DIR}/cli_session_start.c
     ${AIMEE_SRC_DIR}/cli_attention_guard.c
+    ${AIMEE_SRC_DIR}/cli_code_audit.c
     ${AIMEE_SRC_DIR}/cli_tui.c
     ${AIMEE_SRC_DIR}/cli_client.c
     ${AIMEE_SRC_DIR}/cli_launch.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -349,7 +349,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_main.c cli_session_start.c cli_attention_guard.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c
+CLI_SRCS = cli_main.c cli_session_start.c cli_attention_guard.c cli_code_audit.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/cli_code_audit.c
+++ b/src/cli_code_audit.c
@@ -1,0 +1,328 @@
+/* cli_code_audit.c: see cli_code_audit.h. */
+#include "cli_code_audit.h"
+#include "cJSON.h"
+#include <ctype.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+/* ---- pure helpers ---- */
+
+static const char *audit_ext(const char *path)
+{
+   const char *base = strrchr(path, '/');
+   base = base ? base + 1 : path;
+   const char *dot = strrchr(base, '.');
+   return dot ? dot : "";
+}
+
+int audit_is_code_file(const char *path)
+{
+   static const char *exts[] = {".c",  ".h",   ".cc",    ".cpp", ".cxx",   ".hpp",  ".ts", ".tsx",
+                                ".js", ".jsx", ".py",    ".go",  ".rs",    ".java", ".kt", ".cs",
+                                ".rb", ".php", ".swift", ".m",   ".scala", ".lua"};
+   const char *e = audit_ext(path ? path : "");
+   for (size_t i = 0; i < sizeof(exts) / sizeof(exts[0]); i++)
+      if (strcmp(e, exts[i]) == 0)
+         return 1;
+   return 0;
+}
+
+int audit_is_test_file(const char *path)
+{
+   if (!path)
+      return 0;
+   if (strstr(path, "/test/") || strstr(path, "/tests/") || strstr(path, "/__tests__/") ||
+       strstr(path, "/spec/"))
+      return 1;
+   const char *base = strrchr(path, '/');
+   base = base ? base + 1 : path;
+   if (strstr(base, ".test.") || strstr(base, ".spec.") || strstr(base, "_test.") ||
+       strstr(base, "_spec.") || strncmp(base, "test_", 5) == 0 || strncmp(base, "test-", 5) == 0 ||
+       strncmp(base, "spec_", 5) == 0)
+      return 1;
+   return 0;
+}
+
+void audit_stem(const char *path, char *out, size_t cap)
+{
+   if (!out || cap == 0)
+      return;
+   out[0] = '\0';
+   if (!path)
+      return;
+   const char *base = strrchr(path, '/');
+   base = base ? base + 1 : path;
+   char tmp[256];
+   snprintf(tmp, sizeof(tmp), "%s", base);
+   char *dot = strrchr(tmp, '.');
+   if (dot)
+      *dot = '\0';
+   /* Strip a leading test_/spec_ affix and a trailing _test/_spec affix. */
+   char *s = tmp;
+   if (strncmp(s, "test_", 5) == 0 || strncmp(s, "spec_", 5) == 0 || strncmp(s, "test-", 5) == 0)
+      s += 5;
+   size_t len = strlen(s);
+   const char *suffixes[] = {"_test", "_spec", ".test", ".spec"};
+   for (size_t i = 0; i < sizeof(suffixes) / sizeof(suffixes[0]); i++)
+   {
+      size_t sl = strlen(suffixes[i]);
+      if (len >= sl && strcmp(s + len - sl, suffixes[i]) == 0)
+      {
+         s[len - sl] = '\0';
+         break;
+      }
+   }
+   snprintf(out, cap, "%s", s);
+}
+
+int audit_count_todos(const char *content)
+{
+   if (!content)
+      return 0;
+   static const char *markers[] = {"TODO", "FIXME", "HACK", "XXX"};
+   int count = 0;
+   for (size_t m = 0; m < sizeof(markers) / sizeof(markers[0]); m++)
+   {
+      const char *p = content;
+      size_t ml = strlen(markers[m]);
+      while ((p = strstr(p, markers[m])) != NULL)
+      {
+         count++;
+         p += ml;
+      }
+   }
+   return count;
+}
+
+int audit_debt_score(int code_files, int untested, int todo_markers)
+{
+   if (code_files <= 0)
+      return 100;
+   /* Penalize the untested fraction (up to 60 pts) and TODO density (up to
+    * 40 pts, ~1 pt per 2 markers per 100 files). 100 = clean. */
+   double untested_frac = (double)untested / (double)code_files;
+   double todo_density = (double)todo_markers / (double)code_files;
+   double penalty = untested_frac * 60.0 + todo_density * 20.0;
+   if (penalty > 100.0)
+      penalty = 100.0;
+   int score = (int)(100.0 - penalty + 0.5);
+   if (score < 0)
+      score = 0;
+   if (score > 100)
+      score = 100;
+   return score;
+}
+
+/* ---- tree walk + report (impure) ---- */
+
+#define AUDIT_MAX_FILES 40000
+#define AUDIT_MAX_READ  (512 * 1024)
+
+typedef struct
+{
+   char **code_paths; /* non-test code files */
+   char **code_stems;
+   int n_code, cap_code;
+   char **test_stems;
+   int n_test, cap_test;
+   int todo_markers;
+} audit_acc_t;
+
+static int skip_dir(const char *name)
+{
+   static const char *skip[] = {".git",   "node_modules", "build",  "dist",        ".next",
+                                "vendor", "target",       ".cache", "__pycache__", ".venv"};
+   for (size_t i = 0; i < sizeof(skip) / sizeof(skip[0]); i++)
+      if (strcmp(name, skip[i]) == 0)
+         return 1;
+   return name[0] == '.' && name[1] == '\0';
+}
+
+static char *audit_read_file(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   fseek(f, 0, SEEK_END);
+   long sz = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   char *buf = NULL;
+   if (sz > 0 && sz < AUDIT_MAX_READ)
+   {
+      buf = malloc((size_t)sz + 1);
+      if (buf && fread(buf, 1, (size_t)sz, f) == (size_t)sz)
+         buf[sz] = '\0';
+      else
+      {
+         free(buf);
+         buf = NULL;
+      }
+   }
+   fclose(f);
+   return buf;
+}
+
+static void acc_push(char ***arr, int *n, int *cap, const char *s)
+{
+   if (*n >= AUDIT_MAX_FILES)
+      return;
+   if (*n >= *cap)
+   {
+      int nc = *cap ? *cap * 2 : 256;
+      char **np = realloc(*arr, (size_t)nc * sizeof(char *));
+      if (!np)
+         return;
+      *arr = np;
+      *cap = nc;
+   }
+   (*arr)[(*n)++] = strdup(s);
+}
+
+/* Append a non-test code file: path and stem go to parallel arrays in lockstep
+ * under the shared n_code/cap_code counters. */
+static void code_push(audit_acc_t *a, const char *path, const char *stem)
+{
+   if (a->n_code >= AUDIT_MAX_FILES)
+      return;
+   if (a->n_code >= a->cap_code)
+   {
+      int nc = a->cap_code ? a->cap_code * 2 : 256;
+      char **np = realloc(a->code_paths, (size_t)nc * sizeof(char *));
+      if (!np)
+         return;
+      a->code_paths = np;
+      char **ns = realloc(a->code_stems, (size_t)nc * sizeof(char *));
+      if (!ns)
+         return;
+      a->code_stems = ns;
+      a->cap_code = nc;
+   }
+   a->code_paths[a->n_code] = strdup(path);
+   a->code_stems[a->n_code] = strdup(stem);
+   a->n_code++;
+}
+
+static void audit_walk(const char *dir, audit_acc_t *a, int depth)
+{
+   if (depth > 32 || a->n_code >= AUDIT_MAX_FILES)
+      return;
+   DIR *d = opendir(dir);
+   if (!d)
+      return;
+   struct dirent *ent;
+   char path[4096];
+   while ((ent = readdir(d)) != NULL)
+   {
+      if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+         continue;
+      snprintf(path, sizeof(path), "%s/%s", dir, ent->d_name);
+      struct stat st;
+      if (stat(path, &st) != 0)
+         continue;
+      if (S_ISDIR(st.st_mode))
+      {
+         if (!skip_dir(ent->d_name))
+            audit_walk(path, a, depth + 1);
+         continue;
+      }
+      if (!S_ISREG(st.st_mode) || !audit_is_code_file(path))
+         continue;
+
+      char *content = audit_read_file(path);
+      if (content)
+      {
+         a->todo_markers += audit_count_todos(content);
+         free(content);
+      }
+      char stem[256];
+      audit_stem(path, stem, sizeof(stem));
+      if (audit_is_test_file(path))
+         acc_push(&a->test_stems, &a->n_test, &a->cap_test, stem);
+      else
+         code_push(a, path, stem);
+   }
+   closedir(d);
+}
+
+static int stem_in_tests(const audit_acc_t *a, const char *stem)
+{
+   if (!stem || !stem[0])
+      return 0;
+   for (int i = 0; i < a->n_test; i++)
+      if (a->test_stems[i] && strcmp(a->test_stems[i], stem) == 0)
+         return 1;
+   return 0;
+}
+
+int handle_code_audit(int argc, char **argv, int json_output)
+{
+   const char *dir = ".";
+   int dir_set = 0;
+   for (int i = 0; i < argc; i++)
+   {
+      if (!argv[i])
+         continue;
+      if (strcmp(argv[i], "--json") == 0)
+         json_output = 1;
+      else if (argv[i][0] != '-' && !dir_set)
+      {
+         dir = argv[i];
+         dir_set = 1;
+      }
+   }
+
+   audit_acc_t a;
+   memset(&a, 0, sizeof(a));
+   audit_walk(dir, &a, 0);
+
+   int untested = 0;
+   for (int i = 0; i < a.n_code; i++)
+      if (!stem_in_tests(&a, a.code_stems[i]))
+         untested++;
+
+   int score = audit_debt_score(a.n_code, untested, a.todo_markers);
+
+   if (json_output)
+   {
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddNumberToObject(o, "code_files", a.n_code);
+      cJSON_AddNumberToObject(o, "test_files", a.n_test);
+      cJSON_AddNumberToObject(o, "untested_files", untested);
+      cJSON_AddNumberToObject(o, "todo_markers", a.todo_markers);
+      cJSON_AddNumberToObject(o, "debt_score", score);
+      char *s = cJSON_PrintUnformatted(o);
+      if (s)
+      {
+         puts(s);
+         free(s);
+      }
+      cJSON_Delete(o);
+   }
+   else
+   {
+      printf("aimee code audit — %s\n", dir);
+      printf("  code files:     %d\n", a.n_code);
+      printf("  test files:     %d\n", a.n_test);
+      printf("  untested files: %d (%.0f%%)\n", untested,
+             a.n_code ? 100.0 * untested / a.n_code : 0.0);
+      printf("  TODO/FIXME/HACK/XXX markers: %d\n", a.todo_markers);
+      printf("  debt score:     %d/100 (100 = clean)\n", score);
+      printf("\nNote: graph-derived checks (dead exports, import cycles, clones) are the kb "
+             "follow-on in docs/proposals/pending/code-health-audit.md.\n");
+   }
+
+   for (int i = 0; i < a.n_code; i++)
+   {
+      free(a.code_paths[i]);
+      free(a.code_stems[i]);
+   }
+   for (int i = 0; i < a.n_test; i++)
+      free(a.test_stems[i]);
+   free(a.code_paths);
+   free(a.code_stems);
+   free(a.test_stems);
+   return 0;
+}

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -200,6 +200,9 @@
     {"graph", "Code-graph projection and explain", CLIENT_TIER_ADVANCED, 0,
      "  sync-code        Project the code graph\n"
      "  explain          Explain a code-graph relationship\n"},
+    {"code", "Code-health audit", CLIENT_TIER_ADVANCED, 0,
+     "  audit [dir] [--json]   File-health audit (untested files, TODO/FIXME\n"
+     "                         markers, debt score) over the working tree\n"},
     {"curator", "Knowledge curator queries", CLIENT_TIER_ADVANCED, 0,
      "  implements <topic>   What implements a topic\n"
      "  synthesize <topic>   Synthesize knowledge on a topic\n"

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -5,6 +5,7 @@
 #include "cli_client.h"
 #include "cli_session_start.h"
 #include "cli_attention_guard.h"
+#include "cli_code_audit.h"
 #include "cli_mcp_serve.h"
 #include "acp_server.h"
 #include "cli_profile.h"
@@ -1796,6 +1797,15 @@ int main(int argc, char **argv)
    /* Hooks: use dedicated server methods */
    if (strcmp(cmd, "hooks") == 0)
       return handle_hooks(sub_argc, sub_argv, json_output);
+
+   /* Code audit (P4): `aimee code audit [dir] [--json]` — local file-health scan. */
+   if (strcmp(cmd, "code") == 0)
+   {
+      if (sub_argc >= 1 && strcmp(sub_argv[0], "audit") == 0)
+         return handle_code_audit(sub_argc - 1, sub_argv + 1, json_output);
+      fprintf(stderr, "usage: aimee code audit [dir] [--json]\n");
+      return 2;
+   }
 
    /* SessionStart hook (settings.json wires it as `aimee session-start`). */
    if (strcmp(cmd, "session-start") == 0)

--- a/src/headers/cli_code_audit.h
+++ b/src/headers/cli_code_audit.h
@@ -1,0 +1,42 @@
+/* cli_code_audit.h: P4 code-health audit (`aimee code audit`).
+ *
+ * A self-contained client command that walks the working tree and reports
+ * file-level health signals — untested code files (stem-matched against test
+ * files) and orphaned TODO/FIXME/HACK/XXX markers — with a 0..100 debt score
+ * (100 = clean). It runs locally over the repo and needs no kb/server.
+ *
+ * This is the self-contained slice of docs/proposals/pending/code-health-audit.md;
+ * the graph-derived checks there (dead exports, import cycles, body-hash clones)
+ * need new kb-side graph queries + a body_hash index column and remain a kb
+ * follow-on.
+ *
+ * The classification/scoring helpers are pure and unit-tested; the tree walk
+ * and reporting live in the .c.
+ */
+#ifndef DEC_CLI_CODE_AUDIT_H
+#define DEC_CLI_CODE_AUDIT_H 1
+
+#include <stddef.h>
+
+/* True if `path` looks like a source file we audit (by extension). Pure. */
+int audit_is_code_file(const char *path);
+
+/* True if `path` is a test file (…/tests?/…, *.test.*, *_test.*, test_*, spec).
+ * Pure. */
+int audit_is_test_file(const char *path);
+
+/* Write the comparison stem of `path` (basename minus extension and common
+ * test affixes like `_test` / `.test` / `test_`) into `out`. Pure. */
+void audit_stem(const char *path, char *out, size_t cap);
+
+/* Count orphaned-work markers (TODO/FIXME/HACK/XXX) in `content`. Pure. */
+int audit_count_todos(const char *content);
+
+/* Debt score in [0,100] (100 = clean) from the audit tallies. Pure. */
+int audit_debt_score(int code_files, int untested, int todo_markers);
+
+/* `aimee code audit [dir] [--json]` entry. Walks `dir` (default cwd), runs the
+ * file-level checks, prints a report (or JSON), and returns 0. */
+int handle_code_audit(int argc, char **argv, int json_output);
+
+#endif /* DEC_CLI_CODE_AUDIT_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -78,7 +78,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -541,6 +541,10 @@ $(TESTPREFIX)/unit-test-ingress-preinject: $(OBJDIR)/tests/test_ingress_preinjec
 $(TESTPREFIX)/unit-test-attention-guard: $(OBJDIR)/tests/test_attention_guard.o \
                      $(OBJDIR)/cli_attention_guard.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
+
+$(TESTPREFIX)/unit-test-code-audit: $(OBJDIR)/tests/test_code_audit.o \
+                     $(OBJDIR)/cli_code_audit.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_code_audit.c
+++ b/src/tests/test_code_audit.c
@@ -1,0 +1,80 @@
+/* test_code_audit.c: unit tests for the P4 code-audit pure helpers
+ * (file classification, stem extraction, TODO counting, debt scoring). The
+ * tree-walking handler is exercised by a functional smoke, not here. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "cli_code_audit.h"
+
+static void test_is_code_file(void)
+{
+   assert(audit_is_code_file("src/foo.c"));
+   assert(audit_is_code_file("a/b/x.py"));
+   assert(audit_is_code_file("x.tsx"));
+   assert(!audit_is_code_file("README.md"));
+   assert(!audit_is_code_file("data.json"));
+   assert(!audit_is_code_file("noext"));
+   printf("is_code_file OK\n");
+}
+
+static void test_is_test_file(void)
+{
+   assert(audit_is_test_file("src/tests/test_x.c"));
+   assert(audit_is_test_file("a/__tests__/x.ts"));
+   assert(audit_is_test_file("x.test.ts"));
+   assert(audit_is_test_file("foo_test.go"));
+   assert(audit_is_test_file("test_foo.py"));
+   assert(!audit_is_test_file("src/foo.c"));
+   assert(!audit_is_test_file("src/contest.c")); /* not a test despite 'test' substring in name */
+   printf("is_test_file OK\n");
+}
+
+static void test_stem(void)
+{
+   char s[256];
+   audit_stem("src/server/foo.c", s, sizeof(s));
+   assert(strcmp(s, "foo") == 0);
+   audit_stem("tests/test_foo.c", s, sizeof(s));
+   assert(strcmp(s, "foo") == 0);
+   audit_stem("pkg/foo_test.go", s, sizeof(s));
+   assert(strcmp(s, "foo") == 0);
+   audit_stem("a/foo.test.ts", s, sizeof(s));
+   assert(strcmp(s, "foo") == 0);
+   audit_stem("x/bar_spec.rb", s, sizeof(s));
+   assert(strcmp(s, "bar") == 0);
+   printf("stem OK\n");
+}
+
+static void test_count_todos(void)
+{
+   assert(audit_count_todos("clean code here") == 0);
+   assert(audit_count_todos("// TODO: fix\n/* FIXME */ XXX HACK") == 4);
+   assert(audit_count_todos(NULL) == 0);
+   printf("count_todos OK\n");
+}
+
+static void test_debt_score(void)
+{
+   assert(audit_debt_score(0, 0, 0) == 100);   /* no code -> clean */
+   assert(audit_debt_score(100, 0, 0) == 100); /* all tested, no todos */
+   /* all untested -> 60-pt penalty -> 40 */
+   assert(audit_debt_score(100, 100, 0) == 40);
+   /* half untested -> 30-pt penalty -> 70 */
+   assert(audit_debt_score(100, 50, 0) == 70);
+   /* todos drag the score down but stay clamped >= 0 */
+   int s = audit_debt_score(10, 10, 1000);
+   assert(s >= 0 && s <= 100);
+   printf("debt_score OK\n");
+}
+
+int main(void)
+{
+   printf("code_audit: ");
+   test_is_code_file();
+   test_is_test_file();
+   test_stem();
+   test_count_todos();
+   test_debt_score();
+   printf("all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary
The self-contained slice of the spun-out code-health audit (`docs/proposals/pending/code-health-audit.md`): `aimee code audit [dir] [--json]` — a local, no-server file-health scan over the working tree.

## What it reports
- **Untested code files** — code files whose stem has no matching test file (stem-matched against `*.test.*`, `_test.*`, `test_*`, `…/tests/…`, etc.).
- **Orphaned work markers** — TODO/FIXME/HACK/XXX counts.
- **Debt score** 0–100 (100 = clean): untested fraction (≤60 pts) + TODO density (≤40 pts).

Bounded tree walk (≤40k files, ≤512KB/file, skips `.git`/`node_modules`/`build`/`dist`/`vendor`/…). `--json` for machine output.

## Tests
- `unit-test-code-audit`: `audit_is_code_file`, `audit_is_test_file` (incl. the `contest.c`-isn't-a-test edge), `audit_stem` (test affixes), `audit_count_todos`, `audit_debt_score` (clamping/scaling).
- Functional: `aimee code audit src` → 1110 code / 324 test / 65% untested / 519 markers / score 52; `--json` emits the same as JSON.
- Builds clean under `-Werror`; wired in make + cmake; clang-format-19 clean.

## Scope note
The **graph-derived checks** (dead exports, import cycles, body-hash clones) need new kb-side graph queries + a `body_hash` index column — they remain the kb follow-on documented in the proposal, not part of this PR.
