### PR TITLE
docs(proposals): optimization surface + ingest-restoration/recall-contract

### DIFF
--- a/docs/proposals/pending/ingest-restoration-and-recall-contract.md
+++ b/docs/proposals/pending/ingest-restoration-and-recall-contract.md
@@ -1,10 +1,10 @@
 # Proposal: ingest restoration + bounded-hallucination recall contract
 
-- **State:** draft - pending review
+- **State:** draft — pending review
 - **Author:** JBailes
 - **Date:** 2026-06-08
 - **Charter role(s):** knowledge-base ingest + recall (kb-side intelligence
-  pass; reuses the existing curator synthesis path and artifact provenance -
+  pass; reuses the existing curator synthesis path and artifact provenance —
   no new store, no new DB tier).
 - **Scope:** `src/kb/kb_lab.c` + `src/headers/kb_lab.h` (turn the terminal
   `REJECT`/`REVIEW_NEEDED` stages into restoration candidates), corpus staging /
@@ -22,32 +22,33 @@ Two ideas, treated here as general concepts (independent of any particular
 typed-particle or "self-repairing index" framing they sometimes carry):
 
 1. **Damage-as-catalyst ingest.** aimee's ingest lab already *detects* damaged
-   documents and then **drops them**. Route them instead into a restoration
-   queue that fuses each fragment against its nearest complete neighbour to mint
-   a repaired, provenance-tracked document.
+   documents, but its verdict is advisory — nothing repairs them, so damaged
+   content is dropped or flagged. Route it instead into a restoration queue that
+   fuses each fragment against its nearest complete neighbour to mint a repaired,
+   provenance-tracked document.
 2. **Bounded-hallucination recall contract.** aimee has **no extractive
    guarantee** today. Tag each recall result as **verbatim** (stored text, zero
    synthesis) or **synthesised** (with a confidence and citations), and mark
    genuine gaps `[unknown]` rather than fabricate.
 
 ```
-  ingest --> kb_lab quality audit --> READY --------------------> index
-                     |              REVIEW_NEEDED / REJECT
-                     |                     |   (today: dropped/flagged)
-                     v                     v   (proposed: restoration job)
-            heuristic completeness  fuse fragment x nearest complete
+  ingest ──▶ kb_lab quality audit ──▶ READY ───────────────────▶ index
+                     │              REVIEW_NEEDED / REJECT
+                     │                     │   (today: dropped/flagged)
+                     ▼                     ▼   (proposed: restoration job)
+            heuristic completeness  fuse fragment × nearest complete
             signal (free, no LLM)   neighbour under restoration guardrail
-                                    -> mint repaired artifact + provenance
-                                                |
-  recall <-- verbatim | synthesised(conf) <-----'   (bounded-hallucination tag)
+                                    ──▶ mint repaired artifact + provenance
+                                                │
+  recall ◀── verbatim | synthesised(conf) ◀─────┘   (bounded-hallucination tag)
 ```
 
 ## Motivation
 
 What aimee already has (verified):
 
-- `kb_lab.c` **detects** damage - `FLAT_TEXT`, `OVERSIZED_CHUNK`,
-  `UNDERSIZED_CHUNKS`, `BINARY_NOISE`, `EMPTY_FILE`, `TABLE_SPLIT` - and sorts
+- `kb_lab.c` **detects** damage — `FLAT_TEXT`, `OVERSIZED_CHUNK`,
+  `UNDERSIZED_CHUNKS`, `BINARY_NOISE`, `EMPTY_FILE`, `TABLE_SPLIT` — and sorts
   docs into `READY` / `REVIEW_NEEDED` / `REJECT` (`kb_lab.c:246,575,658`). The
   damaged stages are a **dead end**.
 - The deep curator already does **LLM-mediated synthesis with provenance +
@@ -71,22 +72,22 @@ move the stage out of `READY`. If the MVP starts with `UNDERSIZED_CHUNKS` /
 `FLAT_TEXT`, it must explicitly change stage policy or introduce a separate
 `restoration_candidate` classification independent of stage.
 
-What is missing - and what damaged-record retrieval techniques highlight:
+What is missing — and what damaged-record retrieval techniques highlight:
 
 - The detector and the synthesiser are **joined nowhere**: a damaged doc is
   rejected rather than repaired. (Note: `memory repair` (`kb_service.c:183`) is
-  *index* repair - re-embedding failed vectors - **not** content restoration.)
-- There is **no verbatim/extractive contract** at recall time - "hallucination"
+  *index* repair — re-embedding failed vectors — **not** content restoration.)
+- There is **no verbatim/extractive contract** at recall time — "hallucination"
   appears in the codebase only as a dogfood *outcome label* (`cmd_dogfood.c`),
   never as a per-result guarantee.
 
 ## Design
 
-### Part 1 - restoration path
+### Part 1 — restoration path
 
 1. **Heuristic completeness signal, not per-chunk LLM.** Some techniques call the
    LLM to classify *every* chunk; aimee's `kb_lab` already produces completeness
-   signals **for free**. Reuse them - do not pay per-chunk LLM cost. Completeness
+   signals **for free**. Reuse them — do not pay per-chunk LLM cost. Completeness
    is an **orthogonal flag on existing artifacts**, not a new type system.
 2. **Restoration queue outside `kb_lab`.** `kb_lab` emits a report. The ingest
    pipeline persists the decision and enqueues a `corpus_processing_jobs` row
@@ -106,14 +107,14 @@ What is missing - and what damaged-record retrieval techniques highlight:
    deterministic idempotency key such as `restore:<fragment_hash>:<base_id>:<prompt_version>`
    so retries do not mint duplicate restored artifacts.
 
-### Part 2 - bounded-hallucination recall contract
+### Part 2 — bounded-hallucination recall contract
 
 1. **Per-result provenance tag.** Every recall result is tagged **verbatim**
    (returned from stored text, no synthesis) or **synthesised** (fused from
    fragments, with confidence + citations). The curator's citation infra is
    already most of the way there.
-2. **Extractive guarantee.** A high-confidence stored hit is returned verbatim -
-   no LLM rewrite - so the caller can trust it as ground truth.
+2. **Extractive guarantee.** A high-confidence stored hit is returned verbatim —
+   no LLM rewrite — so the caller can trust it as ground truth.
 3. **`[unknown]` sentinel.** Adopt it in the curator synthesis/extraction prompts
    to suppress fabrication during fusion. Treat this as a prompt/schema change,
    not just a string tweak: version the prompt, require parseable output, and
@@ -126,11 +127,11 @@ What is missing - and what damaged-record retrieval techniques highlight:
 
 ### What this deliberately does **not** adopt
 
-- Elaborate typed-particle "algebras" / physics branding - dressing. aimee's
+- Elaborate typed-particle "algebras" / physics branding — dressing. aimee's
   `entity/summary/relation/fact/claim/narrative` typing is richer; add
   completeness as a flag, not a new type system.
-- **LLM-classify-every-chunk** - `kb_lab` gives completeness heuristically.
-- Importing any prototype as a dependency - aimee already exceeds the retrieval
+- **LLM-classify-every-chunk** — `kb_lab` gives completeness heuristically.
+- Importing any prototype as a dependency — aimee already exceeds the retrieval
   sophistication (vector + graph + fusion + curator) of the demos these ideas
   come from.
 
@@ -141,13 +142,13 @@ implementations of it typically ship with **zero guardrails**. aimee has them:
 gate every restoration pass behind the benchmark suite + `baseline.json`
 regression gate once the benchmark runner supports this suite, track regressions
 via `memory_hard_negative_log`, and bound synthesis confidence with calibration
-credible intervals. aimee is therefore
-**better positioned to do this safely** than the demo-grade sources of the idea.
+credible intervals. aimee is therefore **better positioned to do this safely**
+than the demo-grade sources of the idea.
 
-The two new thresholds this introduces -
+The two new thresholds this introduces —
 
 - **repair-vs-reject** (when is a damaged doc worth restoring vs dropping?), and
-- **verbatim-vs-synthesize** (confidence cutoff for the extractive guarantee) -
+- **verbatim-vs-synthesize** (confidence cutoff for the extractive guarantee) —
 
 are exactly the kind of surface the companion proposal,
 [optimization-surface.md](optimization-surface.md), tunes. Register both as
@@ -171,21 +172,21 @@ bandit **decision points** there. The two proposals compose: this one supplies
 
 ## Phasing
 
-- **P1** - restoration candidate persistence + single-pass fusion for one
+- **P1** — restoration candidate persistence + single-pass fusion for one
   narrowly defined signal class + artifact provenance + `[unknown]` sentinel;
   default-off.
-- **P2** - recall contract: per-result verbatim/synthesised tag + extractive
+- **P2** — recall contract: per-result verbatim/synthesised tag + extractive
   guarantee for high-confidence stored hits.
-- **P3** - provenance-constrained traversal for synthesised answers.
-- **P4** - expose repair-vs-reject and verbatim-vs-synthesize thresholds as
+- **P3** — provenance-constrained traversal for synthesised answers.
+- **P4** — expose repair-vs-reject and verbatim-vs-synthesize thresholds as
   decision points in [optimization-surface.md](optimization-surface.md).
 
 ## Risks
 
-- **Fusion drift / fabrication** - bound to a single pass, `[unknown]` sentinel,
+- **Fusion drift / fabrication** — bound to a single pass, `[unknown]` sentinel,
   and the benchmark/hard-negative gate; never auto-promote a repaired doc that
   regresses recall.
-- **Cost** - restoration is LLM work; queue it, batch it, and keep it default-off
+- **Cost** — restoration is LLM work; queue it, batch it, and keep it default-off
   until the offline suite shows net recall gain.
-- **Provenance integrity** - every minted doc must carry an auditable edge back
+- **Provenance integrity** — every minted doc must carry an auditable edge back
   to its fragment + base; no orphaned synthesised nodes.

--- a/docs/proposals/pending/ingest-restoration-and-recall-contract.md
+++ b/docs/proposals/pending/ingest-restoration-and-recall-contract.md
@@ -1,18 +1,20 @@
-# Proposal: ingest restoration (damage-as-catalyst) + bounded-hallucination recall contract
+# Proposal: ingest restoration + bounded-hallucination recall contract
 
-- **State:** draft — pending review
+- **State:** draft - pending review
 - **Author:** JBailes
 - **Date:** 2026-06-08
 - **Charter role(s):** knowledge-base ingest + recall (kb-side intelligence
-  pass; reuses the existing curator synthesis path and graph provenance edges —
+  pass; reuses the existing curator synthesis path and artifact provenance -
   no new store, no new DB tier).
 - **Scope:** `src/kb/kb_lab.c` + `src/headers/kb_lab.h` (turn the terminal
-  `REJECT`/`REVIEW_NEEDED` stages into a restoration entry point), `src/kb/kb_curator_synthesize.c`
+  `REJECT`/`REVIEW_NEEDED` stages into restoration candidates), corpus staging /
+  job code around `docs` + `corpus_processing_jobs` (the queue lives there, not
+  inside the standalone lab), `src/kb/kb_curator_synthesize.c`
   (restoration-biased fusion of a fragment against its nearest complete
-  neighbour, with provenance), `src/kb/kb_service_graph.c` (provenance edges —
-  already carry `source`), `src/memory_graph_fusion.c` + `src/kb/kb.c` (recall
-  contract: tag each result verbatim vs synthesised), unit tests, docs. No new
-  long-lived service.
+  neighbour, with provenance), `artifact_citations` / `artifact_links` /
+  `audit_events` (auditable provenance), `src/memory_graph_fusion.c` +
+  `src/kb/kb.c` (recall contract: tag each result verbatim vs synthesised), unit
+  tests, docs. No new long-lived service.
 
 ## Summary
 
@@ -29,70 +31,93 @@ typed-particle or "self-repairing index" framing they sometimes carry):
    genuine gaps `[unknown]` rather than fabricate.
 
 ```
-  ingest ──▶ kb_lab quality audit ──▶ READY ───────────────────▶ index
-                     │                 REVIEW_NEEDED / REJECT
-                     │                        │   (today: dropped/flagged)
-                     ▼                        ▼   (proposed: restoration)
-            heuristic completeness    fuse fragment × nearest complete
-            signal (free, no LLM)     neighbour under restoration guardrail
-                                      → mint repaired doc + provenance edge
-                                                │
-  recall ◀── verbatim | synthesised(conf) ◀─────┘   (bounded-hallucination tag)
+  ingest --> kb_lab quality audit --> READY --------------------> index
+                     |              REVIEW_NEEDED / REJECT
+                     |                     |   (today: dropped/flagged)
+                     v                     v   (proposed: restoration job)
+            heuristic completeness  fuse fragment x nearest complete
+            signal (free, no LLM)   neighbour under restoration guardrail
+                                    -> mint repaired artifact + provenance
+                                                |
+  recall <-- verbatim | synthesised(conf) <-----'   (bounded-hallucination tag)
 ```
 
 ## Motivation
 
 What aimee already has (verified):
 
-- `kb_lab.c` **detects** damage — `FLAT_TEXT`, `OVERSIZED_CHUNK`,
-  `UNDERSIZED_CHUNKS`, `BINARY_NOISE`, `EMPTY_FILE`, `TABLE_SPLIT` — and sorts
+- `kb_lab.c` **detects** damage - `FLAT_TEXT`, `OVERSIZED_CHUNK`,
+  `UNDERSIZED_CHUNKS`, `BINARY_NOISE`, `EMPTY_FILE`, `TABLE_SPLIT` - and sorts
   docs into `READY` / `REVIEW_NEEDED` / `REJECT` (`kb_lab.c:246,575,658`). The
   damaged stages are a **dead end**.
 - The deep curator already does **LLM-mediated synthesis with provenance +
   citations** (`kb_curator_synthesize.c:198`, `kb_curator_promote.c:186`), over
   typed artifacts (`entity` / `summary` / `relation` / `fact` / `claim` /
   `narrative`).
-- Graph edges already carry `source` (`kb_service_graph.c:98`); fusion recall
-  merges lexical + vector hits (`kb.c:1348+`, `memory_graph_fusion.c`).
+- Artifact citations and links already provide better provenance primitives
+  than graph endpoint fields; fusion recall merges lexical + vector hits
+  (`kb.c:1348+`, `memory_graph_fusion.c`).
 
-What is missing — and what damaged-record retrieval techniques highlight:
+Important implementation detail: `kb_lab` is currently a **standalone read-only
+surface**. It reads a path and emits a report; it has no DB access and should
+stay that way. Restoration queueing belongs in the corpus/job layer (`docs`,
+`corpus_processing_jobs`, and `corpus_stage_events`) after a lab report has been
+attached to a staged document.
+
+Also, not every named signal is terminal today. `BINARY_NOISE` and `EMPTY_FILE`
+reject; `LONG_LINES`, `OVERSIZED_CHUNK`, `HEADING_SKIP`, and `TABLE_SPLIT` mark
+review; `FLAT_TEXT` and `UNDERSIZED_CHUNKS` are recorded but do **not** currently
+move the stage out of `READY`. If the MVP starts with `UNDERSIZED_CHUNKS` /
+`FLAT_TEXT`, it must explicitly change stage policy or introduce a separate
+`restoration_candidate` classification independent of stage.
+
+What is missing - and what damaged-record retrieval techniques highlight:
 
 - The detector and the synthesiser are **joined nowhere**: a damaged doc is
   rejected rather than repaired. (Note: `memory repair` (`kb_service.c:183`) is
-  *index* repair — re-embedding failed vectors — **not** content restoration.)
-- There is **no verbatim/extractive contract** at recall time — "hallucination"
+  *index* repair - re-embedding failed vectors - **not** content restoration.)
+- There is **no verbatim/extractive contract** at recall time - "hallucination"
   appears in the codebase only as a dogfood *outcome label* (`cmd_dogfood.c`),
   never as a per-result guarantee.
 
 ## Design
 
-### Part 1 — restoration path (turn REJECT into a repair entrance)
+### Part 1 - restoration path
 
 1. **Heuristic completeness signal, not per-chunk LLM.** Some techniques call the
    LLM to classify *every* chunk; aimee's `kb_lab` already produces completeness
-   signals **for free**. Reuse them — do not pay per-chunk LLM cost. Completeness
+   signals **for free**. Reuse them - do not pay per-chunk LLM cost. Completeness
    is an **orthogonal flag on existing artifacts**, not a new type system.
-2. **Restoration queue.** `REVIEW_NEEDED` / `REJECT` docs (and undersized/flat
-   fragments) enter a queue instead of terminating.
+2. **Restoration queue outside `kb_lab`.** `kb_lab` emits a report. The ingest
+   pipeline persists the decision and enqueues a `corpus_processing_jobs` row
+   such as `stage='restore'`, `stage_status='pending'`, with the source doc id,
+   content hash, strategy, and signal set in the job detail/event payload.
 3. **Fusion.** For each fragment, find its nearest complete neighbour by cosine
    similarity (embeddings already exist) and fuse via the curator synthesis path
    under a **restoration-biased prompt**: preserve every noun, number, and
    relationship from the source; mark genuine gaps `[unknown]`; never invent.
-   Mint a repaired document with a **provenance edge** (which fragment + which
-   base produced it) — the graph already supports `source` edges.
+   Mint a repaired artifact/document with explicit provenance:
+   `artifact_citations` for fragment/base inputs, `artifact_links` with a
+   dedicated kind such as `restores` / `restored_from`, and an `audit_events` row
+   recording source doc id, base doc id, prompt version, model version, and
+   confidence.
 4. **Bounded, gated, idempotent.** Single fusion pass by default (not multi-pass
-   re-fusion, which compounds drift and cost); re-runs must be idempotent.
+   re-fusion, which compounds drift and cost); re-runs must be idempotent. Use a
+   deterministic idempotency key such as `restore:<fragment_hash>:<base_id>:<prompt_version>`
+   so retries do not mint duplicate restored artifacts.
 
-### Part 2 — bounded-hallucination recall contract
+### Part 2 - bounded-hallucination recall contract
 
 1. **Per-result provenance tag.** Every recall result is tagged **verbatim**
    (returned from stored text, no synthesis) or **synthesised** (fused from
    fragments, with confidence + citations). The curator's citation infra is
    already most of the way there.
-2. **Extractive guarantee.** A high-confidence stored hit is returned verbatim —
-   no LLM rewrite — so the caller can trust it as ground truth.
+2. **Extractive guarantee.** A high-confidence stored hit is returned verbatim -
+   no LLM rewrite - so the caller can trust it as ground truth.
 3. **`[unknown]` sentinel.** Adopt it in the curator synthesis/extraction prompts
-   to suppress fabrication during fusion (a one-prompt change, low cost).
+   to suppress fabrication during fusion. Treat this as a prompt/schema change,
+   not just a string tweak: version the prompt, require parseable output, and
+   test that missing slots remain `[unknown]`.
 4. **Provenance-constrained traversal (refinement).** When answering from a
    synthesised node, bias graph hops along **provenance edges** (the docs that
    produced the node) rather than global k-NN over noisy rows. aimee already has
@@ -101,11 +126,11 @@ What is missing — and what damaged-record retrieval techniques highlight:
 
 ### What this deliberately does **not** adopt
 
-- Elaborate typed-particle "algebras" / physics branding — dressing. aimee's
+- Elaborate typed-particle "algebras" / physics branding - dressing. aimee's
   `entity/summary/relation/fact/claim/narrative` typing is richer; add
   completeness as a flag, not a new type system.
-- **LLM-classify-every-chunk** — `kb_lab` gives completeness heuristically.
-- Importing any prototype as a dependency — aimee already exceeds the retrieval
+- **LLM-classify-every-chunk** - `kb_lab` gives completeness heuristically.
+- Importing any prototype as a dependency - aimee already exceeds the retrieval
   sophistication (vector + graph + fusion + curator) of the demos these ideas
   come from.
 
@@ -113,15 +138,16 @@ What is missing — and what damaged-record retrieval techniques highlight:
 
 Self-repair via LLM fusion is **expensive and drift-prone**, and prototype
 implementations of it typically ship with **zero guardrails**. aimee has them:
-gate every restoration pass behind the `memory.benchmark` suite + `baseline.json`
-regression gate, track regressions via `memory_hard_negative_log`, and bound
-synthesis confidence with calibration credible intervals. aimee is therefore
+gate every restoration pass behind the benchmark suite + `baseline.json`
+regression gate once the benchmark runner supports this suite, track regressions
+via `memory_hard_negative_log`, and bound synthesis confidence with calibration
+credible intervals. aimee is therefore
 **better positioned to do this safely** than the demo-grade sources of the idea.
 
-The two new thresholds this introduces —
+The two new thresholds this introduces -
 
 - **repair-vs-reject** (when is a damaged doc worth restoring vs dropping?), and
-- **verbatim-vs-synthesize** (confidence cutoff for the extractive guarantee) —
+- **verbatim-vs-synthesize** (confidence cutoff for the extractive guarantee) -
 
 are exactly the kind of surface the companion proposal,
 [optimization-surface.md](optimization-surface.md), tunes. Register both as
@@ -130,29 +156,36 @@ bandit **decision points** there. The two proposals compose: this one supplies
 
 ## MVP
 
-1. Wire `kb_lab` `REVIEW_NEEDED` → restoration queue (start with
-   `UNDERSIZED_CHUNKS` / `FLAT_TEXT` fragments only).
-2. Single-pass curator fusion against nearest complete neighbour, with provenance
-   edge + `[unknown]` sentinel.
-3. Recall returns the verbatim/synthesised tag.
-4. Gate behind the existing benchmark + hard-negative suite; default-off flag.
+1. Persist lab reports and create a separate restoration-candidate decision in
+   the corpus/job layer; keep `kb_lab` read-only.
+2. Start with one signal family whose current stage semantics are unambiguous,
+   or explicitly update `FLAT_TEXT` / `UNDERSIZED_CHUNKS` stage policy before
+   using them as MVP inputs.
+3. Single-pass curator fusion against nearest complete neighbour, with
+   `artifact_citations`, `artifact_links`, `audit_events`, idempotency key, and
+   `[unknown]` sentinel.
+4. `kb.search` JSON returns `evidence_mode: "verbatim" | "synthesised"` per
+   result. `memory.ask` separately returns an answer-level mode, citations, and
+   confidence when answer generation has synthesis involved.
+5. Gate behind the benchmark + hard-negative suite; default-off flag.
 
 ## Phasing
 
-- **P1** — restoration queue + single-pass fusion (`UNDERSIZED`/`FLAT` only) +
-  provenance edge + `[unknown]` sentinel; default-off.
-- **P2** — recall contract: per-result verbatim/synthesised tag + extractive
+- **P1** - restoration candidate persistence + single-pass fusion for one
+  narrowly defined signal class + artifact provenance + `[unknown]` sentinel;
+  default-off.
+- **P2** - recall contract: per-result verbatim/synthesised tag + extractive
   guarantee for high-confidence stored hits.
-- **P3** — provenance-constrained traversal for synthesised answers.
-- **P4** — expose repair-vs-reject and verbatim-vs-synthesize thresholds as
+- **P3** - provenance-constrained traversal for synthesised answers.
+- **P4** - expose repair-vs-reject and verbatim-vs-synthesize thresholds as
   decision points in [optimization-surface.md](optimization-surface.md).
 
 ## Risks
 
-- **Fusion drift / fabrication** — bound to a single pass, `[unknown]` sentinel,
+- **Fusion drift / fabrication** - bound to a single pass, `[unknown]` sentinel,
   and the benchmark/hard-negative gate; never auto-promote a repaired doc that
   regresses recall.
-- **Cost** — restoration is LLM work; queue it, batch it, and keep it default-off
+- **Cost** - restoration is LLM work; queue it, batch it, and keep it default-off
   until the offline suite shows net recall gain.
-- **Provenance integrity** — every minted doc must carry an auditable edge back
+- **Provenance integrity** - every minted doc must carry an auditable edge back
   to its fragment + base; no orphaned synthesised nodes.

--- a/docs/proposals/pending/ingest-restoration-and-recall-contract.md
+++ b/docs/proposals/pending/ingest-restoration-and-recall-contract.md
@@ -1,0 +1,158 @@
+# Proposal: ingest restoration (damage-as-catalyst) + bounded-hallucination recall contract
+
+- **State:** draft — pending review
+- **Author:** JBailes
+- **Date:** 2026-06-08
+- **Charter role(s):** knowledge-base ingest + recall (kb-side intelligence
+  pass; reuses the existing curator synthesis path and graph provenance edges —
+  no new store, no new DB tier).
+- **Scope:** `src/kb/kb_lab.c` + `src/headers/kb_lab.h` (turn the terminal
+  `REJECT`/`REVIEW_NEEDED` stages into a restoration entry point), `src/kb/kb_curator_synthesize.c`
+  (restoration-biased fusion of a fragment against its nearest complete
+  neighbour, with provenance), `src/kb/kb_service_graph.c` (provenance edges —
+  already carry `source`), `src/memory_graph_fusion.c` + `src/kb/kb.c` (recall
+  contract: tag each result verbatim vs synthesised), unit tests, docs. No new
+  long-lived service.
+
+## Summary
+
+Two ideas, treated here as general concepts (independent of any particular
+typed-particle or "self-repairing index" framing they sometimes carry):
+
+1. **Damage-as-catalyst ingest.** aimee's ingest lab already *detects* damaged
+   documents and then **drops them**. Route them instead into a restoration
+   queue that fuses each fragment against its nearest complete neighbour to mint
+   a repaired, provenance-tracked document.
+2. **Bounded-hallucination recall contract.** aimee has **no extractive
+   guarantee** today. Tag each recall result as **verbatim** (stored text, zero
+   synthesis) or **synthesised** (with a confidence and citations), and mark
+   genuine gaps `[unknown]` rather than fabricate.
+
+```
+  ingest ──▶ kb_lab quality audit ──▶ READY ───────────────────▶ index
+                     │                 REVIEW_NEEDED / REJECT
+                     │                        │   (today: dropped/flagged)
+                     ▼                        ▼   (proposed: restoration)
+            heuristic completeness    fuse fragment × nearest complete
+            signal (free, no LLM)     neighbour under restoration guardrail
+                                      → mint repaired doc + provenance edge
+                                                │
+  recall ◀── verbatim | synthesised(conf) ◀─────┘   (bounded-hallucination tag)
+```
+
+## Motivation
+
+What aimee already has (verified):
+
+- `kb_lab.c` **detects** damage — `FLAT_TEXT`, `OVERSIZED_CHUNK`,
+  `UNDERSIZED_CHUNKS`, `BINARY_NOISE`, `EMPTY_FILE`, `TABLE_SPLIT` — and sorts
+  docs into `READY` / `REVIEW_NEEDED` / `REJECT` (`kb_lab.c:246,575,658`). The
+  damaged stages are a **dead end**.
+- The deep curator already does **LLM-mediated synthesis with provenance +
+  citations** (`kb_curator_synthesize.c:198`, `kb_curator_promote.c:186`), over
+  typed artifacts (`entity` / `summary` / `relation` / `fact` / `claim` /
+  `narrative`).
+- Graph edges already carry `source` (`kb_service_graph.c:98`); fusion recall
+  merges lexical + vector hits (`kb.c:1348+`, `memory_graph_fusion.c`).
+
+What is missing — and what damaged-record retrieval techniques highlight:
+
+- The detector and the synthesiser are **joined nowhere**: a damaged doc is
+  rejected rather than repaired. (Note: `memory repair` (`kb_service.c:183`) is
+  *index* repair — re-embedding failed vectors — **not** content restoration.)
+- There is **no verbatim/extractive contract** at recall time — "hallucination"
+  appears in the codebase only as a dogfood *outcome label* (`cmd_dogfood.c`),
+  never as a per-result guarantee.
+
+## Design
+
+### Part 1 — restoration path (turn REJECT into a repair entrance)
+
+1. **Heuristic completeness signal, not per-chunk LLM.** Some techniques call the
+   LLM to classify *every* chunk; aimee's `kb_lab` already produces completeness
+   signals **for free**. Reuse them — do not pay per-chunk LLM cost. Completeness
+   is an **orthogonal flag on existing artifacts**, not a new type system.
+2. **Restoration queue.** `REVIEW_NEEDED` / `REJECT` docs (and undersized/flat
+   fragments) enter a queue instead of terminating.
+3. **Fusion.** For each fragment, find its nearest complete neighbour by cosine
+   similarity (embeddings already exist) and fuse via the curator synthesis path
+   under a **restoration-biased prompt**: preserve every noun, number, and
+   relationship from the source; mark genuine gaps `[unknown]`; never invent.
+   Mint a repaired document with a **provenance edge** (which fragment + which
+   base produced it) — the graph already supports `source` edges.
+4. **Bounded, gated, idempotent.** Single fusion pass by default (not multi-pass
+   re-fusion, which compounds drift and cost); re-runs must be idempotent.
+
+### Part 2 — bounded-hallucination recall contract
+
+1. **Per-result provenance tag.** Every recall result is tagged **verbatim**
+   (returned from stored text, no synthesis) or **synthesised** (fused from
+   fragments, with confidence + citations). The curator's citation infra is
+   already most of the way there.
+2. **Extractive guarantee.** A high-confidence stored hit is returned verbatim —
+   no LLM rewrite — so the caller can trust it as ground truth.
+3. **`[unknown]` sentinel.** Adopt it in the curator synthesis/extraction prompts
+   to suppress fabrication during fusion (a one-prompt change, low cost).
+4. **Provenance-constrained traversal (refinement).** When answering from a
+   synthesised node, bias graph hops along **provenance edges** (the docs that
+   produced the node) rather than global k-NN over noisy rows. aimee already has
+   fusion recall + provenance edges, so this is a testable refinement, not a
+   rebuild.
+
+### What this deliberately does **not** adopt
+
+- Elaborate typed-particle "algebras" / physics branding — dressing. aimee's
+  `entity/summary/relation/fact/claim/narrative` typing is richer; add
+  completeness as a flag, not a new type system.
+- **LLM-classify-every-chunk** — `kb_lab` gives completeness heuristically.
+- Importing any prototype as a dependency — aimee already exceeds the retrieval
+  sophistication (vector + graph + fusion + curator) of the demos these ideas
+  come from.
+
+## Safety (and the bridge to the optimisation surface)
+
+Self-repair via LLM fusion is **expensive and drift-prone**, and prototype
+implementations of it typically ship with **zero guardrails**. aimee has them:
+gate every restoration pass behind the `memory.benchmark` suite + `baseline.json`
+regression gate, track regressions via `memory_hard_negative_log`, and bound
+synthesis confidence with calibration credible intervals. aimee is therefore
+**better positioned to do this safely** than the demo-grade sources of the idea.
+
+The two new thresholds this introduces —
+
+- **repair-vs-reject** (when is a damaged doc worth restoring vs dropping?), and
+- **verbatim-vs-synthesize** (confidence cutoff for the extractive guarantee) —
+
+are exactly the kind of surface the companion proposal,
+[optimization-surface.md](optimization-surface.md), tunes. Register both as
+bandit **decision points** there. The two proposals compose: this one supplies
+*new things to optimise*; that one supplies the *loop that tunes them safely*.
+
+## MVP
+
+1. Wire `kb_lab` `REVIEW_NEEDED` → restoration queue (start with
+   `UNDERSIZED_CHUNKS` / `FLAT_TEXT` fragments only).
+2. Single-pass curator fusion against nearest complete neighbour, with provenance
+   edge + `[unknown]` sentinel.
+3. Recall returns the verbatim/synthesised tag.
+4. Gate behind the existing benchmark + hard-negative suite; default-off flag.
+
+## Phasing
+
+- **P1** — restoration queue + single-pass fusion (`UNDERSIZED`/`FLAT` only) +
+  provenance edge + `[unknown]` sentinel; default-off.
+- **P2** — recall contract: per-result verbatim/synthesised tag + extractive
+  guarantee for high-confidence stored hits.
+- **P3** — provenance-constrained traversal for synthesised answers.
+- **P4** — expose repair-vs-reject and verbatim-vs-synthesize thresholds as
+  decision points in [optimization-surface.md](optimization-surface.md).
+
+## Risks
+
+- **Fusion drift / fabrication** — bound to a single pass, `[unknown]` sentinel,
+  and the benchmark/hard-negative gate; never auto-promote a repaired doc that
+  regresses recall.
+- **Cost** — restoration is LLM work; queue it, batch it, and keep it default-off
+  until the offline suite shows net recall gain.
+- **Provenance integrity** — every minted doc must carry an auditable edge back
+  to its fragment + base; no orphaned synthesised nodes.

--- a/docs/proposals/pending/optimization-surface.md
+++ b/docs/proposals/pending/optimization-surface.md
@@ -1,48 +1,51 @@
-# Proposal: aimee optimization surface — assemble the measure→optimize→promote loop
+# Proposal: aimee optimization surface - assemble the measure/optimize/promote loop
 
-- **State:** draft — pending review
+- **State:** draft - pending review
 - **Author:** JBailes
 - **Date:** 2026-06-08
 - **Charter role(s):** learning / self-improvement (no new store, no new DB
-  tier — reuses the existing bandit decision-log tables in DB2, the memory
+  tier - reuses the existing bandit decision-log tables in DB2, the memory
   benchmark RPC, and the learning/calibration config surface).
-- **Scope:** `src/db2/bandit.c` + `src/db2/bandit.h` (decision-log accessors —
-  extend, do not rewrite), `src/kb/kb_bandit.c` (arm selection — generalise off
+- **Scope:** `src/db2/bandit.c` + `src/db2/bandit.h` (decision-log accessors -
+  extend, do not rewrite), `src/kb/kb_bandit.c` (arm selection - generalise off
   the single `kb_fusion_mode` decision point), `src/config_learning.c` (new
   decision-point registry + reward config), `src/server/server_memory_benchmark.c`
-  (`memory.benchmark` RPC — reuse as the offline suite runner), `src/server/delegate_role.c`
-  (first new decision point: delegate routing), a new thin-client command, unit
-  tests, docs. No new long-lived service.
+  (`memory.benchmark` RPC - first generalise it beyond its current
+  `code-graph-fusion` handler), delegate selection/invocation code (first new
+  decision point: delegate routing), a new thin-client command, unit tests,
+  docs. No new long-lived service.
 
 ## Summary
 
-aimee already has every primitive for a closed-loop optimizer — a live
+aimee already has every primitive for a closed-loop optimizer - a live
 Thompson-sampling contextual bandit with propensity logging, IPW weighting, an
 exploration-budget gate, and counterfactual replay export
 (`db2_bandit_decisions_export`); a benchmark RPC with `baseline.json` regression
 gating; and self-calibrating guardrail thresholds. They are **scattered expert
-tools, not a product loop**, and the online half is wired to exactly **one**
-decision point (`kb_fusion_mode`). This proposal assembles them behind a single
-surface and generalises the bandit to multiple decision points, so a candidate
-config change can be **baselined → evaluated → promoted** with statistical gates
-instead of by hand.
+tools, not a product loop**. The DB and `kb_bandit_*` layers already key by a
+free-form `decision_point`, but the main export/introspection surface still
+hard-codes **one** decision point (`kb_fusion_mode`) and its three arms. This
+proposal assembles the pieces behind a single surface and generalises the
+caller-facing surfaces to multiple decision points, so a candidate config change
+can be baselined, evaluated, and promoted with statistical gates instead of by
+hand.
 
 ```
-  register variants (arms) ──▶ measure ──────────────▶ promote (guarded)
-   per decision point          ├─ offline: memory.benchmark suite         │
-   (delegate routing,          ├─ online:  live bandit + exploration       │
-    retrieval top-k, …)        └─ off-policy: replay logged decisions (IPW) │
-                                          │                                 │
-                                          ▼                                 │
-                               regression gate (baseline.json) +            │
-                               calibration credible interval ──────────────┘
+  register variants (arms) --> measure ------------------> promote (guarded)
+   per decision point          |- offline: benchmark suite adapter          |
+   (kb fusion mode,            |- online: live bandit + exploration         |
+    delegate routing,          `- off-policy: replay logged decisions (IPW) |
+    retrieval top-k, ...)                       |                           |
+                                               v                           |
+                               regression gate (baseline.json) +           |
+                               calibration credible interval --------------'
 ```
 
 ## Motivation
 
 The closed-loop optimizer is a well-known pattern: baseline a candidate change,
 evaluate it on a fixed suite, promote the best, repeat. Demo-grade
-implementations of it are not worth importing — their "optimizers" typically
+implementations of it are not worth importing - their "optimizers" typically
 enumerate a handful of hardcoded prompt strings scored by a brittle substring
 match over a few examples, or build variant configs that are never actually
 applied to the model. The useful import is the **product framing**, not the code:
@@ -53,30 +56,52 @@ What aimee already has (verified):
 
 | Primitive | Where | State |
 | --- | --- | --- |
-| Contextual bandit (Thompson, propensity, IPW cap, exploration-budget gate, off-policy export) | `src/db2/bandit.c`, `src/kb/kb_bandit.c` | **real, but wired to one decision point** (`kb_fusion_mode`); `bandit_live_decision_enabled` defaults **off** |
-| Offline eval + regression gate | `memory.benchmark` RPC (`server_memory_benchmark.c`), `baseline.json` gate (`cmd_memory_embed.c`), LLM-judge track (`benchmarks/judge-calibration`, `run-llm.sh`) | real |
-| Self-calibrating thresholds | `config_learning.c` (conformal ε, credible δ, prior α/β, `tau_*`) | real |
+| Contextual bandit (Thompson, propensity, IPW cap, exploration-budget gate, off-policy export) | `src/db2/bandit.c`, `src/kb/kb_bandit.c` | DB/helpers are generic by `decision_point`; current export/introspection is still `kb_fusion_mode`-specific; `bandit_live_decision_enabled` defaults **off** |
+| Offline eval + regression gate | `memory.benchmark` RPC (`server_memory_benchmark.c`), `baseline.json` gate (`cmd_memory_embed.c`), LLM-judge track (`benchmarks/judge-calibration`, `run-llm.sh`) | real, but split: CLI supports multiple benchmark modes; RPC currently accepts only `code-graph-fusion` |
+| Self-calibrating thresholds | `config_learning.c` (conformal epsilon, credible delta, prior alpha/beta, `tau_*`) | real |
 | Trajectories / hard-negatives (reward inputs) | `trajectory_export.c`, `memory_hard_negative_log` | real |
 | Typed artifact storage (variant provenance) | `db2_artifact_gen_id`, `learning_evidence.c` | real |
 
-The gap is assembly, not invention. ~70% of the loop is built; it is default-off
-and routed to a single decision.
+The gap is assembly, not invention. Much of the loop is built; it is
+default-off, partially hard-coded at the caller-facing surfaces, and missing the
+benchmark/suite adapter that would make promotion repeatable.
+
+## Current implementation constraints
+
+This proposal should not hide the work behind "already generic":
+
+- `db2_bandit_*` and `kb_bandit_*` are generic by `decision_point`; the
+  intelligence export path is not. `kb_intel_bandit_export_response()` currently
+  emits only `kb_fusion_mode` and the fixed `rrf` / `static_alpha` /
+  `dynamic_alpha` arms.
+- `memory.benchmark` is not yet a general suite runner. The server RPC rejects
+  anything except `code-graph-fusion`; the broader benchmark modes live in the
+  CLI-side `memory benchmark` code.
+- `delegate_routing` is broader than `delegate_role.c`. That file handles role
+  canonicalisation and role policy defaults; the actual decision point must sit
+  where an invocation chooses an agent/persona/cost tier.
+- Current local `feat/p4-graph-audit` work adds a graph-derived `code.audit`
+  surface. If this proposal lands after that work, treat code-audit/report
+  enrichment as another measurable evaluation surface or explicitly defer it.
 
 ## Design
 
 ### 1. Decision-point registry (generalise the bandit)
 
 `db2_bandit_*` already keys arm stats by a free-form `decision_point` string, so
-adding decisions is near-zero new infrastructure. Promote the implicit
-`kb_fusion_mode` case in `kb_bandit.c` to a small **registry** of decision points,
-each declaring: arm set, context features (for `context_hash`), and a reward
-function name. Seed decisions:
+the storage layer needs little new infrastructure. Promote the implicit
+`kb_fusion_mode` case in the caller surfaces to a small **registry** of decision
+points, each declaring: arm set, context features (for `context_hash`), reward
+function name, benchmark adapter, and promotion gate. Seed decisions:
 
-- `delegate_routing` — which delegate/persona/cost-tier handles a sub-task
-  (today **fully static** in `delegate_role.c`; highest upside).
-- `retrieval_topk` — k for fusion recall.
-- `briefing_style` — compact vs evidence-heavy session briefing.
-- `guardrail_strictness` — strict vs balanced threshold arm.
+- `kb_fusion_mode` - existing wired decision point; lowest-risk proving ground
+  for registry/export/promotion mechanics.
+- `delegate_routing` - which delegate/persona/cost-tier handles a sub-task
+  (today static policy distributed across role policy, agent config, and launch
+  paths; high upside once the loop is proven).
+- `retrieval_topk` - k for fusion recall.
+- `briefing_style` - compact vs evidence-heavy session briefing.
+- `guardrail_strictness` - strict vs balanced threshold arm.
 
 Arms and prompt/config variants are stored as **typed artifacts** (reuse
 `db2_artifact_gen_id`) with a version, not as ephemeral strings.
@@ -84,22 +109,24 @@ Arms and prompt/config variants are stored as **typed artifacts** (reuse
 ### 2. Reward signal (named per surface, not hand-waved)
 
 The hardest part, and the one most loop sketches skip. Each decision point
-declares a reward composed from already-logged signals: eval/benchmark outcome ×
-latency × cost (all present in trajectories; hard-negatives are an explicit
-penalty term). The reward closes the bandit decision via
-`db2_bandit_decision_close`.
+declares a reward composed from inspectable signals: eval/benchmark outcome,
+latency, cost when available, and explicit penalties such as hard-negatives.
+Do not assume every term is available for every surface; the registry declares
+which terms are required, optional, or unavailable. The reward closes the bandit
+decision via `db2_bandit_decision_close`.
 
 ### 3. Three measurement modes (one surface, explicit regimes)
 
 Offline batch and online learning are distinct regimes that are easily conflated;
 aimee does both and should keep them separate:
 
-- **Offline suite** — run a fixed suite via the existing `memory.benchmark` RPC;
-  rank candidates. This is the "lab run".
-- **Online** — enable live exploration behind the existing
+- **Offline suite** - run a fixed suite via a benchmark adapter. First generalise
+  the current `memory.benchmark` RPC beyond `code-graph-fusion`, or route the
+  optimizer through the existing CLI benchmark harness until the RPC catches up.
+- **Online** - enable live exploration behind the existing
   `bandit_live_decision_enabled` flag; the exploration-budget gate already caps
   exploration traffic.
-- **Off-policy replay** — score a *candidate* policy on already-logged decisions
+- **Off-policy replay** - score a *candidate* policy on already-logged decisions
   via `db2_bandit_decisions_export` + IPW, with **no live traffic and no
   re-run**. This is a strong edge most implementations lack, and should be the
   default first pass before spending live traffic.
@@ -113,15 +140,16 @@ writes rollback metadata (previous arm + decision id) as a typed artifact.
 
 ### 5. Thin-client surface (avoid the `lab` name collision)
 
-`aimee lab` / `kb_lab` **already exists** — it is the *ingest* lab (chunk-quality
+`aimee lab` / `kb_lab` **already exists** - it is the *ingest* lab (chunk-quality
 audit, `src/kb/kb_lab.c`). Do **not** reuse `lab`. Proposed verb: `aimee optimize`
 (or `aimee experiment`):
 
 ```
-aimee optimize baseline   --point delegate_routing
-aimee optimize variants   --point delegate_routing --register <artifact>
-aimee optimize replay     --point delegate_routing          # off-policy, IPW
-aimee optimize run        --point delegate_routing --suite memory   # offline
+aimee optimize points
+aimee optimize baseline   --point kb_fusion_mode
+aimee optimize variants   --point kb_fusion_mode --register <artifact>
+aimee optimize replay     --point kb_fusion_mode          # off-policy, IPW
+aimee optimize run        --point kb_fusion_mode --suite code-graph-fusion
 aimee optimize compare    --baseline <id> --candidate <id>
 aimee optimize promote    --candidate <id> --guarded               # gated
 ```
@@ -135,43 +163,50 @@ aimee optimize promote    --candidate <id> --guarded               # gated
 
 ## MVP
 
-Ship one decision point end-to-end: **`delegate_routing`** (static today → most
-upside).
+Ship one decision point end-to-end: **`kb_fusion_mode`**. It is already wired
+through retrieval and bandit logging, so it is the best proving ground for the
+registry, export, replay, benchmark, compare, and guarded-promote mechanics.
+Then add **`delegate_routing`** as the first new decision point.
 
-1. Register it in the decision-point registry with 3–5 routing arms.
-2. Reward = memory-benchmark/eval outcome × latency × cost.
-3. **Off-policy replay first** (rank arms on logged decisions, zero live cost).
-4. Then enable live exploration behind `bandit_live_decision_enabled`.
-5. Promote behind the `baseline.json` regression + credible-interval gate, with
+1. Register `kb_fusion_mode` with its existing arms.
+2. Generalise bandit export/introspection to accept `--point` and discover arms
+   from `policy_arm` artifacts or the registry.
+3. Generalise benchmark execution enough to run `code-graph-fusion` through the
+   optimizer path.
+4. **Off-policy replay first** (rank arms on logged decisions, zero live cost).
+5. Then enable live exploration behind `bandit_live_decision_enabled`.
+6. Promote behind the `baseline.json` regression + credible-interval gate, with
    rollback metadata.
 
-This is assembly of existing parts — far less new code than "build a lab".
+This is assembly of existing parts, but the assembly includes real API work at
+the export, benchmark, and promotion boundaries.
 
 ## Phasing
 
-- **P1** — decision-point registry + reward config; `delegate_routing` arms;
-  `aimee optimize baseline|replay`. (Off-policy only; no live traffic.)
-- **P2** — offline `aimee optimize run --suite` over `memory.benchmark`;
+- **P1** - decision-point registry + reward config; `kb_fusion_mode` arms;
+  `aimee optimize points|baseline|replay`. (Off-policy only; no live traffic.)
+- **P2** - offline `aimee optimize run --suite code-graph-fusion`;
   `compare`.
-- **P3** — online exploration for `delegate_routing`; `promote --guarded` with
+- **P3** - online exploration for `kb_fusion_mode`; `promote --guarded` with
   rollback metadata.
-- **P4** — fan out to `retrieval_topk`, `briefing_style`, `guardrail_strictness`
-  (the last two are the optimisation *seam* exposed by the companion proposal,
+- **P4** - add `delegate_routing`, then fan out to `retrieval_topk`,
+  `briefing_style`, `guardrail_strictness` (the last two are the optimisation
+  surface exposed by the companion proposal,
   [ingest-restoration-and-recall-contract.md](ingest-restoration-and-recall-contract.md)).
 
 ## Risks
 
-- **Reward mis-specification** dominates outcomes — keep rewards inspectable and
+- **Reward mis-specification** dominates outcomes - keep rewards inspectable and
   versioned; validate offline before any live traffic.
-- **Exploration cost** in production — already bounded by the exploration-budget
+- **Exploration cost** in production - already bounded by the exploration-budget
   gate; keep `bandit_live_decision_enabled` opt-in per decision point.
-- **Decision-point sprawl** — the registry must be a small, reviewed set, not an
+- **Decision-point sprawl** - the registry must be a small, reviewed set, not an
   open registration surface.
 
 ## Relationship to the companion proposal
 
 [ingest-restoration-and-recall-contract.md](ingest-restoration-and-recall-contract.md)
-introduces two new tunable thresholds — *repair-vs-reject* and
+introduces two new tunable thresholds - *repair-vs-reject* and
 *verbatim-vs-synthesize*. Those are registered here as decision points, so the
 two proposals compose: the restoration proposal supplies *new things to
 optimise*; this proposal supplies the *loop that tunes them safely*.

--- a/docs/proposals/pending/optimization-surface.md
+++ b/docs/proposals/pending/optimization-surface.md
@@ -106,6 +106,29 @@ subsystem is more skeletal in production than its API suggests:
   `code.audit` surface. If this proposal lands after it, treat code-audit/report
   enrichment as another measurable evaluation surface or explicitly defer it.
 
+### Standalone fix-it: the phantom bandit export
+
+The third constraint above is a real current-code wart worth fixing on its own,
+**independent of whether the larger optimization surface is built**:
+
+> `kb_intel_bandit_export_response()` (`src/kb/kb_intel_payload.c`) advertises arm
+> stats for `kb_fusion_mode` with fixed `rrf` / `static_alpha` / `dynamic_alpha`
+> arms — but `kb_fusion_mode` is never passed to `kb_bandit_sample`, so it has
+> **no live decisions**. Meanwhile the decision point that *is* sampled
+> (`kb_memory_retrieval_limit`, in `src/kb/kb_service_memory.c`) is **not**
+> exported. The introspection endpoint — and `aimee kb`'s "Bandit export" line
+> (`cmd_kb.c`) — therefore reports a decision point that does not exist at runtime
+> and hides the one that does.
+
+**Minimal fix (no new infrastructure):** make the export reflect reality — emit
+the decision point(s) actually present in the bandit decision log (the distinct
+`decision_point` values, via `db2_bandit_*`), instead of a hard-coded
+`kb_fusion_mode` literal. This is a small, self-contained correctness change that
+can ship as its own PR, and it doubles as **Step 0** for the registry work in §1:
+once the export is data-driven, adding decision points is purely additive. It
+should carry a unit test asserting the export lists only points that have logged
+decisions.
+
 ## Design
 
 ### 0. Close the reward loop (prerequisite)

--- a/docs/proposals/pending/optimization-surface.md
+++ b/docs/proposals/pending/optimization-surface.md
@@ -1,0 +1,177 @@
+# Proposal: aimee optimization surface — assemble the measure→optimize→promote loop
+
+- **State:** draft — pending review
+- **Author:** JBailes
+- **Date:** 2026-06-08
+- **Charter role(s):** learning / self-improvement (no new store, no new DB
+  tier — reuses the existing bandit decision-log tables in DB2, the memory
+  benchmark RPC, and the learning/calibration config surface).
+- **Scope:** `src/db2/bandit.c` + `src/db2/bandit.h` (decision-log accessors —
+  extend, do not rewrite), `src/kb/kb_bandit.c` (arm selection — generalise off
+  the single `kb_fusion_mode` decision point), `src/config_learning.c` (new
+  decision-point registry + reward config), `src/server/server_memory_benchmark.c`
+  (`memory.benchmark` RPC — reuse as the offline suite runner), `src/server/delegate_role.c`
+  (first new decision point: delegate routing), a new thin-client command, unit
+  tests, docs. No new long-lived service.
+
+## Summary
+
+aimee already has every primitive for a closed-loop optimizer — a live
+Thompson-sampling contextual bandit with propensity logging, IPW weighting, an
+exploration-budget gate, and counterfactual replay export
+(`db2_bandit_decisions_export`); a benchmark RPC with `baseline.json` regression
+gating; and self-calibrating guardrail thresholds. They are **scattered expert
+tools, not a product loop**, and the online half is wired to exactly **one**
+decision point (`kb_fusion_mode`). This proposal assembles them behind a single
+surface and generalises the bandit to multiple decision points, so a candidate
+config change can be **baselined → evaluated → promoted** with statistical gates
+instead of by hand.
+
+```
+  register variants (arms) ──▶ measure ──────────────▶ promote (guarded)
+   per decision point          ├─ offline: memory.benchmark suite         │
+   (delegate routing,          ├─ online:  live bandit + exploration       │
+    retrieval top-k, …)        └─ off-policy: replay logged decisions (IPW) │
+                                          │                                 │
+                                          ▼                                 │
+                               regression gate (baseline.json) +            │
+                               calibration credible interval ──────────────┘
+```
+
+## Motivation
+
+The closed-loop optimizer is a well-known pattern: baseline a candidate change,
+evaluate it on a fixed suite, promote the best, repeat. Demo-grade
+implementations of it are not worth importing — their "optimizers" typically
+enumerate a handful of hardcoded prompt strings scored by a brittle substring
+match over a few examples, or build variant configs that are never actually
+applied to the model. The useful import is the **product framing**, not the code:
+aimee already has stronger primitives, they are just scattered and mostly
+default-off.
+
+What aimee already has (verified):
+
+| Primitive | Where | State |
+| --- | --- | --- |
+| Contextual bandit (Thompson, propensity, IPW cap, exploration-budget gate, off-policy export) | `src/db2/bandit.c`, `src/kb/kb_bandit.c` | **real, but wired to one decision point** (`kb_fusion_mode`); `bandit_live_decision_enabled` defaults **off** |
+| Offline eval + regression gate | `memory.benchmark` RPC (`server_memory_benchmark.c`), `baseline.json` gate (`cmd_memory_embed.c`), LLM-judge track (`benchmarks/judge-calibration`, `run-llm.sh`) | real |
+| Self-calibrating thresholds | `config_learning.c` (conformal ε, credible δ, prior α/β, `tau_*`) | real |
+| Trajectories / hard-negatives (reward inputs) | `trajectory_export.c`, `memory_hard_negative_log` | real |
+| Typed artifact storage (variant provenance) | `db2_artifact_gen_id`, `learning_evidence.c` | real |
+
+The gap is assembly, not invention. ~70% of the loop is built; it is default-off
+and routed to a single decision.
+
+## Design
+
+### 1. Decision-point registry (generalise the bandit)
+
+`db2_bandit_*` already keys arm stats by a free-form `decision_point` string, so
+adding decisions is near-zero new infrastructure. Promote the implicit
+`kb_fusion_mode` case in `kb_bandit.c` to a small **registry** of decision points,
+each declaring: arm set, context features (for `context_hash`), and a reward
+function name. Seed decisions:
+
+- `delegate_routing` — which delegate/persona/cost-tier handles a sub-task
+  (today **fully static** in `delegate_role.c`; highest upside).
+- `retrieval_topk` — k for fusion recall.
+- `briefing_style` — compact vs evidence-heavy session briefing.
+- `guardrail_strictness` — strict vs balanced threshold arm.
+
+Arms and prompt/config variants are stored as **typed artifacts** (reuse
+`db2_artifact_gen_id`) with a version, not as ephemeral strings.
+
+### 2. Reward signal (named per surface, not hand-waved)
+
+The hardest part, and the one most loop sketches skip. Each decision point
+declares a reward composed from already-logged signals: eval/benchmark outcome ×
+latency × cost (all present in trajectories; hard-negatives are an explicit
+penalty term). The reward closes the bandit decision via
+`db2_bandit_decision_close`.
+
+### 3. Three measurement modes (one surface, explicit regimes)
+
+Offline batch and online learning are distinct regimes that are easily conflated;
+aimee does both and should keep them separate:
+
+- **Offline suite** — run a fixed suite via the existing `memory.benchmark` RPC;
+  rank candidates. This is the "lab run".
+- **Online** — enable live exploration behind the existing
+  `bandit_live_decision_enabled` flag; the exploration-budget gate already caps
+  exploration traffic.
+- **Off-policy replay** — score a *candidate* policy on already-logged decisions
+  via `db2_bandit_decisions_export` + IPW, with **no live traffic and no
+  re-run**. This is a strong edge most implementations lack, and should be the
+  default first pass before spending live traffic.
+
+### 4. Promotion gate (statistical, not argmax)
+
+"Rank and promote best" is naive. Promotion must clear the **existing**
+`baseline.json` regression gate **and** a calibration credible-interval check
+(`config_learning.c`) before a candidate becomes the default arm. Promotion
+writes rollback metadata (previous arm + decision id) as a typed artifact.
+
+### 5. Thin-client surface (avoid the `lab` name collision)
+
+`aimee lab` / `kb_lab` **already exists** — it is the *ingest* lab (chunk-quality
+audit, `src/kb/kb_lab.c`). Do **not** reuse `lab`. Proposed verb: `aimee optimize`
+(or `aimee experiment`):
+
+```
+aimee optimize baseline   --point delegate_routing
+aimee optimize variants   --point delegate_routing --register <artifact>
+aimee optimize replay     --point delegate_routing          # off-policy, IPW
+aimee optimize run        --point delegate_routing --suite memory   # offline
+aimee optimize compare    --baseline <id> --candidate <id>
+aimee optimize promote    --candidate <id> --guarded               # gated
+```
+
+### What this deliberately does **not** do
+
+- No demo-optimizer code, branding, or unsupported sample-efficiency claims.
+- No heavyweight experiment-tracking runtime dependency. aimee has
+  `trajectory_export.c`; emit a standard, **export-only** tracing format.
+- No new DB tier or long-lived service.
+
+## MVP
+
+Ship one decision point end-to-end: **`delegate_routing`** (static today → most
+upside).
+
+1. Register it in the decision-point registry with 3–5 routing arms.
+2. Reward = memory-benchmark/eval outcome × latency × cost.
+3. **Off-policy replay first** (rank arms on logged decisions, zero live cost).
+4. Then enable live exploration behind `bandit_live_decision_enabled`.
+5. Promote behind the `baseline.json` regression + credible-interval gate, with
+   rollback metadata.
+
+This is assembly of existing parts — far less new code than "build a lab".
+
+## Phasing
+
+- **P1** — decision-point registry + reward config; `delegate_routing` arms;
+  `aimee optimize baseline|replay`. (Off-policy only; no live traffic.)
+- **P2** — offline `aimee optimize run --suite` over `memory.benchmark`;
+  `compare`.
+- **P3** — online exploration for `delegate_routing`; `promote --guarded` with
+  rollback metadata.
+- **P4** — fan out to `retrieval_topk`, `briefing_style`, `guardrail_strictness`
+  (the last two are the optimisation *seam* exposed by the companion proposal,
+  [ingest-restoration-and-recall-contract.md](ingest-restoration-and-recall-contract.md)).
+
+## Risks
+
+- **Reward mis-specification** dominates outcomes — keep rewards inspectable and
+  versioned; validate offline before any live traffic.
+- **Exploration cost** in production — already bounded by the exploration-budget
+  gate; keep `bandit_live_decision_enabled` opt-in per decision point.
+- **Decision-point sprawl** — the registry must be a small, reviewed set, not an
+  open registration surface.
+
+## Relationship to the companion proposal
+
+[ingest-restoration-and-recall-contract.md](ingest-restoration-and-recall-contract.md)
+introduces two new tunable thresholds — *repair-vs-reject* and
+*verbatim-vs-synthesize*. Those are registered here as decision points, so the
+two proposals compose: the restoration proposal supplies *new things to
+optimise*; this proposal supplies the *loop that tunes them safely*.

--- a/docs/proposals/pending/optimization-surface.md
+++ b/docs/proposals/pending/optimization-surface.md
@@ -1,107 +1,142 @@
-# Proposal: aimee optimization surface - assemble the measure/optimize/promote loop
+# Proposal: aimee optimization surface — assemble the measure→optimize→promote loop
 
-- **State:** draft - pending review
+- **State:** draft — pending review
 - **Author:** JBailes
 - **Date:** 2026-06-08
 - **Charter role(s):** learning / self-improvement (no new store, no new DB
-  tier - reuses the existing bandit decision-log tables in DB2, the memory
+  tier — reuses the existing bandit decision-log tables in DB2, the memory
   benchmark RPC, and the learning/calibration config surface).
-- **Scope:** `src/db2/bandit.c` + `src/db2/bandit.h` (decision-log accessors -
-  extend, do not rewrite), `src/kb/kb_bandit.c` (arm selection - generalise off
-  the single `kb_fusion_mode` decision point), `src/config_learning.c` (new
-  decision-point registry + reward config), `src/server/server_memory_benchmark.c`
-  (`memory.benchmark` RPC - first generalise it beyond its current
-  `code-graph-fusion` handler), delegate selection/invocation code (first new
-  decision point: delegate routing), a new thin-client command, unit tests,
-  docs. No new long-lived service.
+- **Scope:** `src/db2/bandit.c` + `src/db2/bandit.h` (decision-log accessors —
+  extend, do not rewrite), `src/kb/kb_bandit.c` (arm selection + the **missing
+  reward-closure path**), `src/kb/kb_service_memory.c` (the one live sample site),
+  `src/kb/kb_intel_payload.c` (export — currently reports a decision point that is
+  never sampled), `src/config_learning.c` (new decision-point registry + reward
+  config), `src/server/server_memory_benchmark.c` (`memory.benchmark` RPC — first
+  generalise it beyond its current `code-graph-fusion` handler), delegate
+  selection/invocation code (first *new* decision point: delegate routing), a new
+  thin-client command, unit tests, docs. No new long-lived service.
 
 ## Summary
 
-aimee already has every primitive for a closed-loop optimizer - a live
+aimee already has most primitives for a closed-loop optimizer — a
 Thompson-sampling contextual bandit with propensity logging, IPW weighting, an
 exploration-budget gate, and counterfactual replay export
 (`db2_bandit_decisions_export`); a benchmark RPC with `baseline.json` regression
 gating; and self-calibrating guardrail thresholds. They are **scattered expert
-tools, not a product loop**. The DB and `kb_bandit_*` layers already key by a
-free-form `decision_point`, but the main export/introspection surface still
-hard-codes **one** decision point (`kb_fusion_mode`) and its three arms. This
-proposal assembles the pieces behind a single surface and generalises the
+tools, not a product loop** — and, critically, the loop is **not actually closed
+in production**: exactly one decision point is live-sampled, its reward is never
+observed, and the introspection surface reports a *different*, unsampled decision
+point (see *Current implementation constraints*). This proposal closes the reward
+loop, assembles the pieces behind a single surface, and generalises the
 caller-facing surfaces to multiple decision points, so a candidate config change
-can be baselined, evaluated, and promoted with statistical gates instead of by
+can be **baselined → evaluated → promoted** with statistical gates instead of by
 hand.
 
 ```
-  register variants (arms) --> measure ------------------> promote (guarded)
-   per decision point          |- offline: benchmark suite adapter          |
-   (kb fusion mode,            |- online: live bandit + exploration         |
-    delegate routing,          `- off-policy: replay logged decisions (IPW) |
-    retrieval top-k, ...)                       |                           |
-                                               v                           |
-                               regression gate (baseline.json) +           |
-                               calibration credible interval --------------'
+  register variants (arms) ──▶ measure ──────────────▶ promote (guarded)
+   per decision point          ├─ offline: benchmark suite adapter         │
+   (retrieval limit/top-k,     ├─ online:  live bandit + exploration        │
+    delegate routing,          └─ off-policy: replay logged decisions (IPW) │
+    fusion mode, …)                       │   ⚠ needs reward closure first   │
+                                          ▼                                  │
+                               regression gate (baseline.json) +            │
+                               calibration credible interval ───────────────┘
 ```
 
 ## Motivation
 
 The closed-loop optimizer is a well-known pattern: baseline a candidate change,
 evaluate it on a fixed suite, promote the best, repeat. Demo-grade
-implementations of it are not worth importing - their "optimizers" typically
+implementations of it are not worth importing — their "optimizers" typically
 enumerate a handful of hardcoded prompt strings scored by a brittle substring
 match over a few examples, or build variant configs that are never actually
 applied to the model. The useful import is the **product framing**, not the code:
-aimee already has stronger primitives, they are just scattered and mostly
-default-off.
+aimee already has stronger primitives, they are just scattered, mostly default-off,
+and not yet wired into a loop that observes its own rewards.
 
 What aimee already has (verified):
 
 | Primitive | Where | State |
 | --- | --- | --- |
-| Contextual bandit (Thompson, propensity, IPW cap, exploration-budget gate, off-policy export) | `src/db2/bandit.c`, `src/kb/kb_bandit.c` | DB/helpers are generic by `decision_point`; current export/introspection is still `kb_fusion_mode`-specific; `bandit_live_decision_enabled` defaults **off** |
+| Contextual bandit (Thompson, propensity, IPW cap, exploration-budget gate, off-policy export) | `src/db2/bandit.c`, `src/kb/kb_bandit.c` | DB/helpers are generic by `decision_point`; **one** point is live-sampled (`kb_memory_retrieval_limit`), gated by `bandit_live_decision_enabled` (default **off**); **reward closure is unwired** |
 | Offline eval + regression gate | `memory.benchmark` RPC (`server_memory_benchmark.c`), `baseline.json` gate (`cmd_memory_embed.c`), LLM-judge track (`benchmarks/judge-calibration`, `run-llm.sh`) | real, but split: CLI supports multiple benchmark modes; RPC currently accepts only `code-graph-fusion` |
-| Self-calibrating thresholds | `config_learning.c` (conformal epsilon, credible delta, prior alpha/beta, `tau_*`) | real |
+| Self-calibrating thresholds | `config_learning.c` (conformal ε, credible δ, prior α/β, `tau_*`) | real |
 | Trajectories / hard-negatives (reward inputs) | `trajectory_export.c`, `memory_hard_negative_log` | real |
 | Typed artifact storage (variant provenance) | `db2_artifact_gen_id`, `learning_evidence.c` | real |
 
-The gap is assembly, not invention. Much of the loop is built; it is
-default-off, partially hard-coded at the caller-facing surfaces, and missing the
-benchmark/suite adapter that would make promotion repeatable.
+The gap is assembly **and one missing keystone (reward attribution)**, not
+invention. Much of the loop is built; it is default-off, partially hard-coded at
+the caller-facing surfaces, missing the benchmark/suite adapter that would make
+promotion repeatable, and — most importantly — never observes the outcome of the
+decisions it logs.
 
 ## Current implementation constraints
 
-This proposal should not hide the work behind "already generic":
+This proposal should not hide the work behind "already generic". The bandit
+subsystem is more skeletal in production than its API suggests:
 
-- `db2_bandit_*` and `kb_bandit_*` are generic by `decision_point`; the
-  intelligence export path is not. `kb_intel_bandit_export_response()` currently
-  emits only `kb_fusion_mode` and the fixed `rrf` / `static_alpha` /
-  `dynamic_alpha` arms.
-- `memory.benchmark` is not yet a general suite runner. The server RPC rejects
-  anything except `code-graph-fusion`; the broader benchmark modes live in the
-  CLI-side `memory benchmark` code.
-- `delegate_routing` is broader than `delegate_role.c`. That file handles role
-  canonicalisation and role policy defaults; the actual decision point must sit
-  where an invocation chooses an agent/persona/cost tier.
-- Current local `feat/p4-graph-audit` work adds a graph-derived `code.audit`
-  surface. If this proposal lands after that work, treat code-audit/report
+- **The reward loop is open.** `kb_bandit_reward()` / `db2_bandit_decision_close()`
+  exist but are **never called in production** (only in tests). The one live
+  sampler logs a decision and never records an outcome, so posteriors never
+  update from live traffic, and `db2_bandit_decisions_export` returns rows with a
+  null/unclosed `reward`. **Off-policy replay — the proposal's "default first
+  pass" — is inert until decisions are closed.** This is P1's first deliverable,
+  not a detail.
+- **The one live decision point is `kb_memory_retrieval_limit`, not
+  `kb_fusion_mode`.** The only live `kb_bandit_sample()` call is in
+  `kb_service_memory.c` — a 2-arm `{10, 20}` retrieval-limit *shadow* bandit. This
+  is effectively the `retrieval_topk` listed below as "future work"; it already
+  exists and is the correct proving ground.
+- **`kb_fusion_mode` is a static config knob, not a bandit.** It defaults to
+  `"rrf"` (`config_learning.c`) and is read directly as the fusion mode in
+  `kb.c`. It is **never** passed to `kb_bandit_sample`. Yet
+  `kb_intel_bandit_export_response()` advertises arm stats for `kb_fusion_mode`
+  (fixed `rrf` / `static_alpha` / `dynamic_alpha` arms) — a **phantom export**:
+  it reports a decision point that has no live decisions, while the point that
+  *is* sampled (`kb_memory_retrieval_limit`) is not exported. Step 0 is to make
+  the export reflect reality (either sample `kb_fusion_mode` for real, or export
+  the live point).
+- **`memory.benchmark` is not yet a general suite runner.** The server RPC
+  rejects anything except `code-graph-fusion`; the broader benchmark modes live
+  in the CLI-side `memory benchmark` code.
+- **`delegate_routing` is broader than `delegate_role.c`.** That file handles
+  role canonicalisation and role-policy defaults; the actual decision point must
+  sit where an invocation chooses an agent/persona/cost tier.
+- **Coordinate with `feat/p4-graph-audit`.** Local work adds a graph-derived
+  `code.audit` surface. If this proposal lands after it, treat code-audit/report
   enrichment as another measurable evaluation surface or explicitly defer it.
 
 ## Design
 
+### 0. Close the reward loop (prerequisite)
+
+Before any registry or CLI work, wire outcome attribution: a sampled decision
+(`decision_id` from `kb_bandit_sample`) must be closed with an observed reward via
+`kb_bandit_reward` → `db2_bandit_decision_close`, at the point where the turn's
+outcome is known. Until this exists, every downstream mode (replay, online,
+promotion) has nothing to learn from. Start with `kb_memory_retrieval_limit`,
+whose outcome (a recall hit/miss / downstream answer quality) is already logged in
+trajectories and hard-negatives.
+
 ### 1. Decision-point registry (generalise the bandit)
 
 `db2_bandit_*` already keys arm stats by a free-form `decision_point` string, so
-the storage layer needs little new infrastructure. Promote the implicit
-`kb_fusion_mode` case in the caller surfaces to a small **registry** of decision
-points, each declaring: arm set, context features (for `context_hash`), reward
-function name, benchmark adapter, and promotion gate. Seed decisions:
+the storage layer needs little new infrastructure. Promote the hard-coded cases
+in the caller surfaces to a small **registry** of decision points, each
+declaring: arm set, context features (for `context_hash`), reward function name,
+benchmark adapter, and promotion gate. Seed decisions:
 
-- `kb_fusion_mode` - existing wired decision point; lowest-risk proving ground
-  for registry/export/promotion mechanics.
-- `delegate_routing` - which delegate/persona/cost-tier handles a sub-task
-  (today static policy distributed across role policy, agent config, and launch
-  paths; high upside once the loop is proven).
-- `retrieval_topk` - k for fusion recall.
-- `briefing_style` - compact vs evidence-heavy session briefing.
-- `guardrail_strictness` - strict vs balanced threshold arm.
+- `kb_memory_retrieval_limit` (retrieval top-k) — the **only** point already
+  live-sampled (2-arm shadow bandit); lowest-risk proving ground once reward
+  closure exists.
+- `kb_fusion_mode` — currently a static config knob with a reporting-only
+  "bandit" export; convert it to a real sampled decision (and retire the phantom
+  export) as the first conversion of a static knob into a tuned arm.
+- `delegate_routing` — which delegate/persona/cost-tier handles a sub-task (today
+  static policy distributed across role policy, agent config, and launch paths;
+  high upside once the loop is proven).
+- `briefing_style` — compact vs evidence-heavy session briefing.
+- `guardrail_strictness` — strict vs balanced threshold arm.
 
 Arms and prompt/config variants are stored as **typed artifacts** (reuse
 `db2_artifact_gen_id`) with a version, not as ephemeral strings.
@@ -110,48 +145,49 @@ Arms and prompt/config variants are stored as **typed artifacts** (reuse
 
 The hardest part, and the one most loop sketches skip. Each decision point
 declares a reward composed from inspectable signals: eval/benchmark outcome,
-latency, cost when available, and explicit penalties such as hard-negatives.
-Do not assume every term is available for every surface; the registry declares
-which terms are required, optional, or unavailable. The reward closes the bandit
-decision via `db2_bandit_decision_close`.
+latency, cost when available, and explicit penalties such as hard-negatives. Do
+not assume every term is available for every surface; the registry declares which
+terms are required, optional, or unavailable. The reward closes the bandit
+decision via `db2_bandit_decision_close` (see §0).
 
 ### 3. Three measurement modes (one surface, explicit regimes)
 
 Offline batch and online learning are distinct regimes that are easily conflated;
 aimee does both and should keep them separate:
 
-- **Offline suite** - run a fixed suite via a benchmark adapter. First generalise
+- **Offline suite** — run a fixed suite via a benchmark adapter. First generalise
   the current `memory.benchmark` RPC beyond `code-graph-fusion`, or route the
   optimizer through the existing CLI benchmark harness until the RPC catches up.
-- **Online** - enable live exploration behind the existing
+- **Online** — enable live exploration behind the existing
   `bandit_live_decision_enabled` flag; the exploration-budget gate already caps
   exploration traffic.
-- **Off-policy replay** - score a *candidate* policy on already-logged decisions
+- **Off-policy replay** — score a *candidate* policy on already-logged decisions
   via `db2_bandit_decisions_export` + IPW, with **no live traffic and no
   re-run**. This is a strong edge most implementations lack, and should be the
-  default first pass before spending live traffic.
+  default first pass before spending live traffic — but it is **only meaningful
+  once decisions carry rewards** (see §0).
 
 ### 4. Promotion gate (statistical, not argmax)
 
 "Rank and promote best" is naive. Promotion must clear the **existing**
 `baseline.json` regression gate **and** a calibration credible-interval check
-(`config_learning.c`) before a candidate becomes the default arm. Promotion
-writes rollback metadata (previous arm + decision id) as a typed artifact.
+(`config_learning.c`) before a candidate becomes the default arm. Promotion writes
+rollback metadata (previous arm + decision id) as a typed artifact.
 
 ### 5. Thin-client surface (avoid the `lab` name collision)
 
-`aimee lab` / `kb_lab` **already exists** - it is the *ingest* lab (chunk-quality
+`aimee lab` / `kb_lab` **already exists** — it is the *ingest* lab (chunk-quality
 audit, `src/kb/kb_lab.c`). Do **not** reuse `lab`. Proposed verb: `aimee optimize`
 (or `aimee experiment`):
 
 ```
 aimee optimize points
-aimee optimize baseline   --point kb_fusion_mode
-aimee optimize variants   --point kb_fusion_mode --register <artifact>
-aimee optimize replay     --point kb_fusion_mode          # off-policy, IPW
-aimee optimize run        --point kb_fusion_mode --suite code-graph-fusion
+aimee optimize baseline   --point kb_memory_retrieval_limit
+aimee optimize variants   --point kb_memory_retrieval_limit --register <artifact>
+aimee optimize replay     --point kb_memory_retrieval_limit   # off-policy, IPW
+aimee optimize run        --point kb_memory_retrieval_limit --suite code-graph-fusion
 aimee optimize compare    --baseline <id> --candidate <id>
-aimee optimize promote    --candidate <id> --guarded               # gated
+aimee optimize promote    --candidate <id> --guarded          # gated
 ```
 
 ### What this deliberately does **not** do
@@ -163,50 +199,58 @@ aimee optimize promote    --candidate <id> --guarded               # gated
 
 ## MVP
 
-Ship one decision point end-to-end: **`kb_fusion_mode`**. It is already wired
-through retrieval and bandit logging, so it is the best proving ground for the
-registry, export, replay, benchmark, compare, and guarded-promote mechanics.
-Then add **`delegate_routing`** as the first new decision point.
+Ship one decision point end-to-end: **`kb_memory_retrieval_limit`**. It is the
+only point already live-sampled, so it is the best proving ground for the reward
+loop, registry, export, replay, benchmark, compare, and guarded-promote
+mechanics. Then add **`delegate_routing`** as the first genuinely new decision
+point.
 
-1. Register `kb_fusion_mode` with its existing arms.
-2. Generalise bandit export/introspection to accept `--point` and discover arms
+1. **Close the reward loop** for `kb_memory_retrieval_limit` (§0) — attribute the
+   turn outcome back to the logged decision. Without this, steps 4–6 learn
+   nothing.
+2. Register `kb_memory_retrieval_limit` with its existing `{10, 20}` arms; fix the
+   `kb_intel` export so introspection reports the point that is actually sampled.
+3. Generalise bandit export/introspection to accept `--point` and discover arms
    from `policy_arm` artifacts or the registry.
-3. Generalise benchmark execution enough to run `code-graph-fusion` through the
+4. Generalise benchmark execution enough to run `code-graph-fusion` through the
    optimizer path.
-4. **Off-policy replay first** (rank arms on logged decisions, zero live cost).
-5. Then enable live exploration behind `bandit_live_decision_enabled`.
-6. Promote behind the `baseline.json` regression + credible-interval gate, with
-   rollback metadata.
+5. **Off-policy replay** (rank arms on now-rewarded logged decisions, zero live
+   cost).
+6. Then enable live exploration behind `bandit_live_decision_enabled`, and promote
+   behind the `baseline.json` regression + credible-interval gate, with rollback
+   metadata.
 
-This is assembly of existing parts, but the assembly includes real API work at
-the export, benchmark, and promotion boundaries.
+This is assembly of existing parts, but the assembly includes real API work at the
+**reward-closure**, export, benchmark, and promotion boundaries.
 
 ## Phasing
 
-- **P1** - decision-point registry + reward config; `kb_fusion_mode` arms;
-  `aimee optimize points|baseline|replay`. (Off-policy only; no live traffic.)
-- **P2** - offline `aimee optimize run --suite code-graph-fusion`;
-  `compare`.
-- **P3** - online exploration for `kb_fusion_mode`; `promote --guarded` with
-  rollback metadata.
-- **P4** - add `delegate_routing`, then fan out to `retrieval_topk`,
-  `briefing_style`, `guardrail_strictness` (the last two are the optimisation
-  surface exposed by the companion proposal,
+- **P1** — close the reward loop for `kb_memory_retrieval_limit`; decision-point
+  registry + reward config; fix the phantom export; `aimee optimize
+  points|baseline|replay`. (Off-policy only; no new live traffic.)
+- **P2** — offline `aimee optimize run --suite code-graph-fusion`; `compare`.
+- **P3** — online exploration for `kb_memory_retrieval_limit`; `promote --guarded`
+  with rollback metadata.
+- **P4** — convert `kb_fusion_mode` from a static knob to a sampled decision; add
+  `delegate_routing`; then fan out to `briefing_style`, `guardrail_strictness`
+  (the last two are the optimisation surface exposed by the companion proposal,
   [ingest-restoration-and-recall-contract.md](ingest-restoration-and-recall-contract.md)).
 
 ## Risks
 
-- **Reward mis-specification** dominates outcomes - keep rewards inspectable and
+- **Open reward loop is the top risk.** Until decisions are closed with observed
+  outcomes, replay/online/promotion are all inert — fix it first (§0).
+- **Reward mis-specification** dominates outcomes — keep rewards inspectable and
   versioned; validate offline before any live traffic.
-- **Exploration cost** in production - already bounded by the exploration-budget
+- **Exploration cost** in production — already bounded by the exploration-budget
   gate; keep `bandit_live_decision_enabled` opt-in per decision point.
-- **Decision-point sprawl** - the registry must be a small, reviewed set, not an
+- **Decision-point sprawl** — the registry must be a small, reviewed set, not an
   open registration surface.
 
 ## Relationship to the companion proposal
 
 [ingest-restoration-and-recall-contract.md](ingest-restoration-and-recall-contract.md)
-introduces two new tunable thresholds - *repair-vs-reject* and
-*verbatim-vs-synthesize*. Those are registered here as decision points, so the
-two proposals compose: the restoration proposal supplies *new things to
-optimise*; this proposal supplies the *loop that tunes them safely*.
+introduces two new tunable thresholds — *repair-vs-reject* and
+*verbatim-vs-synthesize*. Those are registered here as decision points, so the two
+proposals compose: the restoration proposal supplies *new things to optimise*;
+this proposal supplies the *loop that tunes them safely*.


### PR DESCRIPTION
## Summary

Two **pending design proposals** (docs-only — no code changes). Both are framed
entirely around aimee's existing primitives and describe general ideas/concepts,
not any external repo or product.

### `optimization-surface.md` — assemble the measure→optimize→promote loop
- Generalise the existing Thompson-sampling bandit (`db2/bandit.c`, `kb_bandit.c`)
  from its single `kb_fusion_mode` decision point to a small registry
  (`delegate_routing`, `retrieval_topk`, `briefing_style`, `guardrail_strictness`).
- Three explicit measurement modes: offline suite (`memory.benchmark`), online
  exploration (existing `bandit_live_decision_enabled` flag), and **off-policy
  replay** via `db2_bandit_decisions_export` + IPW (run first, zero live cost).
- Statistical promotion gate (existing `baseline.json` regression + calibration
  credible interval), not argmax.
- New `aimee optimize` thin-client verb — deliberately avoids the existing
  `kb_lab` / "lab" name collision.

### `ingest-restoration-and-recall-contract.md`
- **Damage-as-catalyst:** turn `kb_lab`'s terminal `REJECT`/`REVIEW_NEEDED`
  stages into a restoration queue that fuses damaged fragments against their
  nearest complete neighbour (curator path, provenance edges, `[unknown]`
  sentinel) instead of dropping them.
- **Bounded-hallucination recall contract:** per-result verbatim-vs-synthesised
  tag + extractive guarantee — aimee has no equivalent today.

### How they compose
The restoration proposal's *repair-vs-reject* and *verbatim-vs-synthesize*
thresholds register as decision points in the optimization surface — one supplies
new things to optimise, the other supplies the loop that tunes them safely.

## Test plan
N/A — documentation only (`docs/proposals/pending/`). No build or behaviour change.
