### PR TITLE
feat(ingress): pre-inject on OpenAI chat/completions + non-stream responses seams

### DIFF
--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -100,7 +100,11 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, prompt, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(prompt, 0);
+   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   free(pi_env);
    free(prompt);
 
    if (erc != 0 || !result.response)
@@ -460,7 +464,11 @@ static int responses_handler(const char *body, char *resp, int cap)
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, full, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(full, 0);
+   int erc = agent_execute(ag, pi_env, full, max_tokens, temperature, &result);
+   free(pi_env);
 
    if (erc != 0 || !result.response)
    {
@@ -563,7 +571,11 @@ static int chat_stream_handler(const char *body, server_http_sse_emit emit, void
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, prompt, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(prompt, 0);
+   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   free(pi_env);
    free(prompt);
 
    emit_chunk(emit, ctx, id, model, created, 1, NULL, 0); /* role frame */
@@ -624,7 +636,11 @@ static int completion_stream_handler(const char *body, server_http_sse_emit emit
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, prompt, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(prompt, 0);
+   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   free(pi_env);
    free(prompt);
 
    if (erc != 0 || !result.response)


### PR DESCRIPTION
Deferral follow-up: P1 only wired the Codex streaming `/v1/responses` handler. This extends the same `<aimee-context>` envelope injection to the remaining OpenAI ingress paths — `run_completion` (/v1/chat/completions, /v1/completions), `responses_handler` (non-stream /v1/responses), `chat_stream_handler`, `completion_stream_handler` — passing the envelope as the `agent_execute` system prompt (was NULL). Config-gated (`ingress_preinject_enabled`); no-op when off/empty. Server builds clean; ingress unit test green.