### PR TITLE
feat(ingress): x-aimee-preinject request-header override

### DIFF
--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -55,4 +55,12 @@ char *ingress_preinject_build(const char *query, int request_disabled);
  * not free its arguments. Pure. */
 char *ingress_preinject_apply(const char *instructions, const char *envelope);
 
+/* Per-request override (thread-local): the HTTP layer sets this from the
+ * `x-aimee-preinject: 0` request header before dispatching the turn, so a
+ * single request can disable pre-injection without touching the server config
+ * (used by the A/B bench). ingress_preinject_build() consults it in addition to
+ * its `request_disabled` argument and the config flag. Set per request; it does
+ * not auto-reset, so the HTTP layer sets it (to 0 or 1) on every request. */
+void ingress_preinject_set_request_disabled(int disabled);
+
 #endif /* DEC_INGRESS_PREINJECT_H */

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -16,6 +16,16 @@
 #define INGRESS_EXPLORE_WITH                                                                       \
    "find_symbol, lsp_references, ast_grep_search, search_graph, get_context_block"
 
+/* Per-request disable, set by the HTTP layer from the `x-aimee-preinject: 0`
+ * header. Thread-local: the ingress runs the turn synchronously on the request
+ * thread, so this is read by ingress_preinject_build() during the same request. */
+static __thread int g_request_disabled = 0;
+
+void ingress_preinject_set_request_disabled(int disabled)
+{
+   g_request_disabled = disabled ? 1 : 0;
+}
+
 const char *ingress_preinject_confidence(double top_score)
 {
    /* Thresholds chosen so a clear top hit is "high", a plausible-but-thin match
@@ -139,7 +149,7 @@ char *ingress_preinject_query_from_messages(const cJSON *messages)
 
 char *ingress_preinject_build(const char *query, int request_disabled)
 {
-   if (request_disabled)
+   if (request_disabled || g_request_disabled)
       return NULL;
    if (!query || !query[0])
       return NULL;

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -100,7 +100,11 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, prompt, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(prompt, 0);
+   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   free(pi_env);
    free(prompt);
 
    if (erc != 0 || !result.response)
@@ -460,7 +464,11 @@ static int responses_handler(const char *body, char *resp, int cap)
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, full, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(full, 0);
+   int erc = agent_execute(ag, pi_env, full, max_tokens, temperature, &result);
+   free(pi_env);
 
    if (erc != 0 || !result.response)
    {
@@ -563,7 +571,11 @@ static int chat_stream_handler(const char *body, server_http_sse_emit emit, void
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, prompt, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(prompt, 0);
+   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   free(pi_env);
    free(prompt);
 
    emit_chunk(emit, ctx, id, model, created, 1, NULL, 0); /* role frame */
@@ -624,7 +636,11 @@ static int completion_stream_handler(const char *body, server_http_sse_emit emit
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
-   int erc = agent_execute(ag, NULL, prompt, max_tokens, temperature, &result);
+   /* P1 pre-injection: prepend the <aimee-context> envelope as the system
+    * prompt (config ingress_preinject_enabled; no-op when off/empty). */
+   char *pi_env = ingress_preinject_build(prompt, 0);
+   int erc = agent_execute(ag, pi_env, prompt, max_tokens, temperature, &result);
+   free(pi_env);
    free(prompt);
 
    if (erc != 0 || !result.response)

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -16,6 +16,7 @@
 #include "log.h"
 #include "aimee_version.h"
 #include "openai_shape.h"
+#include "ingress_preinject.h"
 #include "openapi_server_data.h" /* AIMEE_OPENAPI_SERVER_YAML_STR (generated from api/openapi-server-v1.yaml) */
 #include "openai_runs_store.h"
 #include "presence.h"
@@ -1434,6 +1435,13 @@ static void handle_conn(int fd, int is_tcp)
       char skey[256] = "";
       int has_auth = http_header(buf, "Authorization", auth, sizeof(auth));
       int has_skey = http_header(buf, "X-Aimee-Session-Key", skey, sizeof(skey));
+      /* Per-request pre-injection override: `x-aimee-preinject: 0` disables the
+       * <aimee-context> envelope for this turn (set every request so it never
+       * leaks across requests on a reused worker thread). */
+      char preinject[16] = "";
+      ingress_preinject_set_request_disabled(
+          http_header(buf, "X-Aimee-Preinject", preinject, sizeof(preinject)) &&
+          strcmp(preinject, "0") == 0);
       int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL, has_skey);
       if (az != 0)
       {


### PR DESCRIPTION
Deferral follow-up (proposal §A): per-request `x-aimee-preinject: 0` header disables pre-injection for one turn without mutating server config (clean live A/B). The HTTP layer sets a thread-local from the header every request; `ingress_preinject_build()` consults it alongside the config flag. Stacked on #110 (OpenAI seams); narrows once that merges.