### PR TITLE
fix(bandit): data-driven intelligence bandit export (proposal Step 0)

### DIFF
--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -982,33 +982,47 @@ static void kb_cmd_bandit(app_ctx_t *ctx, int argc, char **argv)
       return;
    }
 
-   cJSON *dp = cJSON_GetObjectItemCaseSensitive(resp, "decision_point");
-   cJSON *decisions = cJSON_GetObjectItemCaseSensitive(resp, "decisions");
-   cJSON *arm_stats = cJSON_GetObjectItemCaseSensitive(resp, "arm_stats");
-
-   printf("Bandit export: %s\n", cJSON_IsString(dp) ? dp->valuestring : "kb_fusion_mode");
-   printf("  decisions: %d closed\n", cJSON_IsArray(decisions) ? cJSON_GetArraySize(decisions) : 0);
-
-   if (cJSON_IsArray(arm_stats) && cJSON_GetArraySize(arm_stats) > 0)
+   cJSON *points = cJSON_GetObjectItemCaseSensitive(resp, "points");
+   if (!cJSON_IsArray(points) || cJSON_GetArraySize(points) == 0)
    {
-      printf("\n  Arm stats:\n");
-      cJSON *entry;
-      cJSON_ArrayForEach(entry, arm_stats)
+      printf("Bandit export: no decision points with logged decisions\n");
+      cJSON_Delete(resp);
+      return;
+   }
+
+   cJSON *pt;
+   cJSON_ArrayForEach(pt, points)
+   {
+      cJSON *dp = cJSON_GetObjectItemCaseSensitive(pt, "decision_point");
+      cJSON *decisions = cJSON_GetObjectItemCaseSensitive(pt, "decisions");
+      cJSON *arm_stats = cJSON_GetObjectItemCaseSensitive(pt, "arm_stats");
+
+      printf("Bandit export: %s\n", cJSON_IsString(dp) ? dp->valuestring : "?");
+      printf("  decisions: %d closed\n",
+             cJSON_IsArray(decisions) ? cJSON_GetArraySize(decisions) : 0);
+
+      if (cJSON_IsArray(arm_stats) && cJSON_GetArraySize(arm_stats) > 0)
       {
-         cJSON *arm = cJSON_GetObjectItemCaseSensitive(entry, "arm_id");
-         cJSON *nd = cJSON_GetObjectItemCaseSensitive(entry, "n_decisions");
-         cJSON *nr = cJSON_GetObjectItemCaseSensitive(entry, "n_rewards");
-         cJSON *sr = cJSON_GetObjectItemCaseSensitive(entry, "sum_reward");
-         cJSON *alpha = cJSON_GetObjectItemCaseSensitive(entry, "posterior_alpha");
-         cJSON *beta = cJSON_GetObjectItemCaseSensitive(entry, "posterior_beta");
-         printf("    %-16s decisions=%lld rewards=%lld sum=%.2f alpha=%.2f beta=%.2f\n",
-                cJSON_IsString(arm) ? arm->valuestring : "?",
-                cJSON_IsNumber(nd) ? (long long)nd->valuedouble : 0LL,
-                cJSON_IsNumber(nr) ? (long long)nr->valuedouble : 0LL,
-                cJSON_IsNumber(sr) ? sr->valuedouble : 0.0,
-                cJSON_IsNumber(alpha) ? alpha->valuedouble : 0.0,
-                cJSON_IsNumber(beta) ? beta->valuedouble : 0.0);
+         printf("  Arm stats:\n");
+         cJSON *entry;
+         cJSON_ArrayForEach(entry, arm_stats)
+         {
+            cJSON *arm = cJSON_GetObjectItemCaseSensitive(entry, "arm_id");
+            cJSON *nd = cJSON_GetObjectItemCaseSensitive(entry, "n_decisions");
+            cJSON *nr = cJSON_GetObjectItemCaseSensitive(entry, "n_rewards");
+            cJSON *sr = cJSON_GetObjectItemCaseSensitive(entry, "sum_reward");
+            cJSON *alpha = cJSON_GetObjectItemCaseSensitive(entry, "posterior_alpha");
+            cJSON *beta = cJSON_GetObjectItemCaseSensitive(entry, "posterior_beta");
+            printf("    %-24s decisions=%lld rewards=%lld sum=%.2f alpha=%.2f beta=%.2f\n",
+                   cJSON_IsString(arm) ? arm->valuestring : "?",
+                   cJSON_IsNumber(nd) ? (long long)nd->valuedouble : 0LL,
+                   cJSON_IsNumber(nr) ? (long long)nr->valuedouble : 0LL,
+                   cJSON_IsNumber(sr) ? sr->valuedouble : 0.0,
+                   cJSON_IsNumber(alpha) ? alpha->valuedouble : 0.0,
+                   cJSON_IsNumber(beta) ? beta->valuedouble : 0.0);
+         }
       }
+      printf("\n");
    }
    cJSON_Delete(resp);
 }

--- a/src/db2/bandit.c
+++ b/src/db2/bandit.c
@@ -220,6 +220,91 @@ int db2_bandit_arm_stats_update(const char *decision_point, const char *arm_id, 
    return 0;
 }
 
+/* Emit the single TEXT column of a prepared statement as a JSON array of
+ * strings.  Identifiers (decision points / arm ids) are code-controlled and
+ * contain no quotes, mirroring the no-escape convention of the export below. */
+static int bandit_emit_string_array(aimee_pg_stmt_t *st, char *buf, size_t len)
+{
+   size_t pos = 0;
+   buf[pos++] = '[';
+   char err[256] = "";
+   int first = 1;
+   while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *v = aimee_pg_column_text(st, 0);
+      if (!v || !v[0])
+         continue;
+      if (pos + strlen(v) + 4 >= len - 2)
+         break;
+      if (!first && pos < len - 2)
+         buf[pos++] = ',';
+      first = 0;
+      int written = snprintf(buf + pos, len - pos, "\"%s\"", v);
+      if (written > 0 && (size_t)written < len - pos)
+         pos += (size_t)written;
+   }
+   if (pos < len - 2)
+   {
+      buf[pos++] = ']';
+      buf[pos] = '\0';
+   }
+   return 0;
+}
+
+int db2_bandit_decision_points_list(char *buf, size_t len)
+{
+   if (!buf || len < 3)
+      return -1;
+   buf[0] = '[';
+   buf[1] = ']';
+   buf[2] = '\0';
+
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "SELECT decision_point"
+                                          "  FROM bandit_decisions"
+                                          " GROUP BY decision_point"
+                                          " ORDER BY MAX(decided_at) DESC"
+                                          " LIMIT 64",
+                                          err, sizeof(err));
+   if (!st)
+      return 0;
+   bandit_emit_string_array(st, buf, len);
+   aimee_pg_finalize(st);
+   return 0;
+}
+
+int db2_bandit_arms_list(const char *decision_point, char *buf, size_t len)
+{
+   if (!decision_point || !buf || len < 3)
+      return -1;
+   buf[0] = '[';
+   buf[1] = ']';
+   buf[2] = '\0';
+
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "SELECT DISTINCT arm_id"
+                                          "  FROM bandit_decisions"
+                                          " WHERE decision_point = ?1"
+                                          " ORDER BY arm_id",
+                                          err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_text(st, "?1", decision_point);
+   bandit_emit_string_array(st, buf, len);
+   aimee_pg_finalize(st);
+   return 0;
+}
+
 int db2_bandit_decisions_export(const char *decision_point, int limit, char *buf, size_t len)
 {
    if (!decision_point || !buf || len == 0)

--- a/src/db2/bandit.h
+++ b/src/db2/bandit.h
@@ -62,6 +62,19 @@ extern "C"
    int db2_bandit_explore_stats(const char *decision_point, int window_seconds,
                                 long long *n_explore_out, long long *n_total_out);
 
+   /* List the distinct decision points that actually have logged decisions, as a
+    * JSON array of strings ordered most-recent-first.  Writes "[]" when empty.
+    * Used by the bandit export so introspection reflects the points that are
+    * really sampled, rather than a hard-coded literal.
+    * Returns 0 on success, -1 on error. */
+   int db2_bandit_decision_points_list(char *buf, size_t len);
+
+   /* List the distinct arm ids observed for a decision point in the decision log,
+    * as a JSON array of strings ordered by arm id.  Writes "[]" when empty.
+    * Discovered from the log (not arm-stats), so arms are visible even before any
+    * reward has been observed.  Returns 0 on success, -1 on error. */
+   int db2_bandit_arms_list(const char *decision_point, char *buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/kb/kb_intel_payload.c
+++ b/src/kb/kb_intel_payload.c
@@ -144,53 +144,103 @@ cJSON *kb_intel_demote_check_response(void)
 #define KB_INTEL_BANDIT_EXPORT_LIMIT 500
 #define KB_INTEL_BANDIT_EXPORT_BUFSZ (256 * 1024)
 
+/* Build one {decision_point, decisions, arm_stats} object for a decision point
+ * that is actually present in the bandit decision log.  Arms are discovered from
+ * the log (so they appear even before any reward has been observed). */
+static cJSON *intel_bandit_point_obj(const char *decision_point)
+{
+   cJSON *pt = cJSON_CreateObject();
+   if (!pt)
+      return NULL;
+   cJSON_AddStringToObject(pt, "decision_point", decision_point);
+
+   /* Closed decisions for offline replay. */
+   char *buf = malloc(KB_INTEL_BANDIT_EXPORT_BUFSZ);
+   cJSON *decisions = NULL;
+   if (buf)
+   {
+      buf[0] = '\0';
+      db2_bandit_decisions_export(decision_point, KB_INTEL_BANDIT_EXPORT_LIMIT, buf,
+                                  KB_INTEL_BANDIT_EXPORT_BUFSZ);
+      decisions = cJSON_ParseWithLength(buf, strlen(buf));
+      free(buf);
+   }
+   cJSON_AddItemToObject(pt, "decisions", decisions ? decisions : cJSON_CreateArray());
+
+   /* Per-arm stats, over the arms observed in the log for this point. */
+   cJSON *arm_stats_arr = cJSON_CreateArray();
+   char arms_buf[8192];
+   arms_buf[0] = '\0';
+   db2_bandit_arms_list(decision_point, arms_buf, sizeof(arms_buf));
+   cJSON *arms = cJSON_ParseWithLength(arms_buf, strlen(arms_buf));
+   if (cJSON_IsArray(arms))
+   {
+      cJSON *arm;
+      cJSON_ArrayForEach(arm, arms)
+      {
+         if (!cJSON_IsString(arm) || !arm->valuestring[0])
+            continue;
+         db2_bandit_arm_stats_t stats;
+         memset(&stats, 0, sizeof(stats));
+         db2_bandit_arm_stats_read(decision_point, arm->valuestring, &stats);
+
+         cJSON *entry = cJSON_CreateObject();
+         cJSON_AddStringToObject(entry, "arm_id", arm->valuestring);
+         cJSON_AddNumberToObject(entry, "n_decisions", (double)stats.n_decisions);
+         cJSON_AddNumberToObject(entry, "n_rewards", (double)stats.n_rewards);
+         cJSON_AddNumberToObject(entry, "sum_reward", stats.sum_reward);
+         cJSON_AddNumberToObject(entry, "posterior_alpha", stats.posterior_alpha);
+         cJSON_AddNumberToObject(entry, "posterior_beta", stats.posterior_beta);
+         cJSON_AddItemToArray(arm_stats_arr, entry);
+      }
+   }
+   cJSON_Delete(arms);
+   cJSON_AddItemToObject(pt, "arm_stats", arm_stats_arr);
+   return pt;
+}
+
+/* Export bandit state for every decision point that has logged decisions.
+ *
+ * Data-driven: the set of points and their arms is read from the decision log
+ * (db2_bandit_decision_points_list / db2_bandit_arms_list), not hard-coded, so
+ * introspection reflects what is actually sampled at runtime.  The top-level
+ * `decision_point` mirrors the primary (most-recent) point for backward
+ * compatibility; `points` carries the full per-point breakdown. */
 cJSON *kb_intel_bandit_export_response(void)
 {
-   const char *decision_point = "kb_fusion_mode";
-   static const char *arms[] = {"rrf", "static_alpha", "dynamic_alpha"};
-   int n_arms = 3;
-
-   char *buf = malloc(KB_INTEL_BANDIT_EXPORT_BUFSZ);
-   if (!buf)
-      return NULL;
-
-   buf[0] = '\0';
-   db2_bandit_decisions_export(decision_point, KB_INTEL_BANDIT_EXPORT_LIMIT, buf,
-                               KB_INTEL_BANDIT_EXPORT_BUFSZ);
-
-   cJSON *decisions = cJSON_ParseWithLength(buf, strlen(buf));
-   free(buf);
-   if (!decisions)
-      decisions = cJSON_CreateArray();
-
-   cJSON *arm_stats_arr = cJSON_CreateArray();
-   for (int i = 0; i < n_arms; i++)
-   {
-      db2_bandit_arm_stats_t stats;
-      memset(&stats, 0, sizeof(stats));
-      db2_bandit_arm_stats_read(decision_point, arms[i], &stats);
-
-      cJSON *entry = cJSON_CreateObject();
-      cJSON_AddStringToObject(entry, "arm_id", arms[i]);
-      cJSON_AddNumberToObject(entry, "n_decisions", (double)stats.n_decisions);
-      cJSON_AddNumberToObject(entry, "n_rewards", (double)stats.n_rewards);
-      cJSON_AddNumberToObject(entry, "sum_reward", stats.sum_reward);
-      cJSON_AddNumberToObject(entry, "posterior_alpha", stats.posterior_alpha);
-      cJSON_AddNumberToObject(entry, "posterior_beta", stats.posterior_beta);
-      cJSON_AddItemToArray(arm_stats_arr, entry);
-   }
+   char points_buf[8192];
+   points_buf[0] = '\0';
+   db2_bandit_decision_points_list(points_buf, sizeof(points_buf));
+   cJSON *names = cJSON_ParseWithLength(points_buf, strlen(points_buf));
 
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
    {
-      cJSON_Delete(decisions);
-      cJSON_Delete(arm_stats_arr);
+      cJSON_Delete(names);
       return NULL;
    }
    cJSON_AddStringToObject(resp, "status", "ok");
-   cJSON_AddStringToObject(resp, "decision_point", decision_point);
-   cJSON_AddItemToObject(resp, "decisions", decisions);
-   cJSON_AddItemToObject(resp, "arm_stats", arm_stats_arr);
+
+   cJSON *points = cJSON_CreateArray();
+   const char *primary = "";
+   if (cJSON_IsArray(names))
+   {
+      cJSON *name;
+      cJSON_ArrayForEach(name, names)
+      {
+         if (!cJSON_IsString(name) || !name->valuestring[0])
+            continue;
+         if (!primary[0])
+            primary = name->valuestring;
+         cJSON *pt = intel_bandit_point_obj(name->valuestring);
+         if (pt)
+            cJSON_AddItemToArray(points, pt);
+      }
+   }
+   /* Back-compat: a single primary point at the top level (string is copied). */
+   cJSON_AddStringToObject(resp, "decision_point", primary);
+   cJSON_AddItemToObject(resp, "points", points);
+   cJSON_Delete(names);
    return resp;
 }
 

--- a/src/tests/test_bandit.c
+++ b/src/tests/test_bandit.c
@@ -150,6 +150,39 @@ static void test_bandit_explore_stats(void)
    printf("  bandit_explore_stats: ok\n");
 }
 
+/* ---- 7. decision_points_list / arms_list ---- */
+static void test_bandit_enumeration(void)
+{
+   open_db();
+
+   /* Two points, the first with two arms; a sibling point must not leak in. */
+   assert(db2_bandit_decision_insert("enum-a-1", "kb_memory_retrieval_limit", "10", "", 0.5, 0) == 0);
+   assert(db2_bandit_decision_insert("enum-a-2", "kb_memory_retrieval_limit", "20", "", 0.5, 0) == 0);
+   assert(db2_bandit_decision_insert("enum-a-3", "kb_memory_retrieval_limit", "10", "", 0.5, 0) == 0);
+   assert(db2_bandit_decision_insert("enum-b-1", "other_dp", "x", "", 0.5, 0) == 0);
+
+   char buf[2048];
+
+   /* Points list: both points present, none invented. */
+   assert(db2_bandit_decision_points_list(buf, sizeof(buf)) == 0);
+   assert(strstr(buf, "\"kb_memory_retrieval_limit\"") != NULL);
+   assert(strstr(buf, "\"other_dp\"") != NULL);
+   assert(strstr(buf, "kb_fusion_mode") == NULL);
+
+   /* Arms list: distinct arms for the point, scoped (no sibling-point arm). */
+   assert(db2_bandit_arms_list("kb_memory_retrieval_limit", buf, sizeof(buf)) == 0);
+   assert(strstr(buf, "\"10\"") != NULL);
+   assert(strstr(buf, "\"20\"") != NULL);
+   assert(strstr(buf, "\"x\"") == NULL);
+
+   /* Unknown point: empty array, not an error. */
+   assert(db2_bandit_arms_list("no_such_point", buf, sizeof(buf)) == 0);
+   assert(strcmp(buf, "[]") == 0);
+
+   close_db();
+   printf("  bandit_enumeration: ok\n");
+}
+
 /* ---- 6. bandit_replay_evidence ---- */
 static void test_bandit_replay_evidence(void)
 {
@@ -196,6 +229,7 @@ int main(void)
    test_bandit_reward_closed();
    test_config_bandit_defaults();
    test_bandit_explore_stats();
+   test_bandit_enumeration();
    test_bandit_replay_evidence();
 
    printf("All bandit tests passed.\n");

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -790,11 +790,26 @@ int db2_demotion_profile_read(const char *memory_class, const char *scope_kind,
    return 0;
 }
 
+int db2_bandit_decision_points_list(char *buf, size_t len)
+{
+   /* The data-driven export asks the log which points exist; return the one
+    * that is actually sampled in production (not the legacy kb_fusion_mode). */
+   snprintf(buf, len, "[\"kb_memory_retrieval_limit\"]");
+   return 0;
+}
+
+int db2_bandit_arms_list(const char *decision_point, char *buf, size_t len)
+{
+   assert(strcmp(decision_point, "kb_memory_retrieval_limit") == 0);
+   snprintf(buf, len, "[\"10\"]");
+   return 0;
+}
+
 int db2_bandit_decisions_export(const char *decision_point, int limit, char *buf, size_t len)
 {
-   assert(strcmp(decision_point, "kb_fusion_mode") == 0);
+   assert(strcmp(decision_point, "kb_memory_retrieval_limit") == 0);
    assert(limit == 500);
-   snprintf(buf, len, "[{\"id\":\"decision-1\",\"arm_id\":\"rrf\"}]");
+   snprintf(buf, len, "[{\"id\":\"decision-1\",\"arm_id\":\"10\"}]");
    return 0;
 }
 
@@ -811,10 +826,10 @@ int kb_bandit_record_replay_evidence(const char *decision_point, const char *res
 int db2_bandit_arm_stats_read(const char *decision_point, const char *arm_id,
                               db2_bandit_arm_stats_t *out)
 {
-   assert(strcmp(decision_point, "kb_fusion_mode") == 0);
+   assert(strcmp(decision_point, "kb_memory_retrieval_limit") == 0);
    assert(out != NULL);
    memset(out, 0, sizeof(*out));
-   if (strcmp(arm_id, "rrf") == 0)
+   if (strcmp(arm_id, "10") == 0)
    {
       out->n_decisions = 3;
       out->n_rewards = 2;
@@ -1125,8 +1140,12 @@ static void test_intelligence_bandit_export(void)
    int s = kb_http_route_ex("GET", "/v1/intelligence/bandit/export", NULL, NULL, NULL, NULL, 0, buf,
                             sizeof(buf));
    assert(s == 200);
-   assert(strstr(buf, "\"decision_point\":\"kb_fusion_mode\"") != NULL);
-   assert(strstr(buf, "\"arm_id\":\"rrf\"") != NULL);
+   /* Export is data-driven: it reports the point that is actually sampled, and a
+    * `points` breakdown — not the hard-coded phantom kb_fusion_mode. */
+   assert(strstr(buf, "\"points\":[") != NULL);
+   assert(strstr(buf, "\"decision_point\":\"kb_memory_retrieval_limit\"") != NULL);
+   assert(strstr(buf, "kb_fusion_mode") == NULL);
+   assert(strstr(buf, "\"arm_id\":\"10\"") != NULL);
    assert(strstr(buf, "\"n_decisions\":3") != NULL);
 }
 


### PR DESCRIPTION
## Summary

First implementation step of the **optimization-surface** proposal
(`docs/proposals/pending/optimization-surface.md`) — its self-contained
**"Standalone fix-it: the phantom bandit export"**.

`kb_intel_bandit_export_response()` hard-coded the decision point
`kb_fusion_mode` and arms `{rrf, static_alpha, dynamic_alpha}`. But
`kb_fusion_mode` is a static config knob (default `"rrf"`, read directly in
`kb.c`) that is **never** passed to `kb_bandit_sample` — so it has no live
decisions. The point that *is* sampled, `kb_memory_retrieval_limit`
(`kb_service_memory.c`), was not exported. The `/v1/intelligence/bandit/export`
route and `aimee kb bandit --export` therefore reported a decision point that
doesn't exist at runtime and hid the one that does.

## Change

Make the export **data-driven off the decision log** — no new infrastructure:

- **`src/db2/bandit.{c,h}`** — `db2_bandit_decision_points_list()` (distinct
  points with logged decisions, most-recent first) and `db2_bandit_arms_list()`
  (distinct arms per point, discovered from the log so they show up before any
  reward is observed). Shared a small JSON-array helper that mirrors the
  existing `db2_bandit_decisions_export` style.
- **`src/kb/kb_intel_payload.c`** — enumerate real points and emit a `points[]`
  breakdown (`decision_point` / `decisions` / `arm_stats` each). Keeps a
  back-compat top-level `decision_point` mirroring the primary point.
- **`src/cmd_kb.c`** — `aimee kb bandit --export` iterates `points[]` (shows
  every real decision point) instead of the single hard-coded shape.

This also makes the export **additive** for the proposal's decision-point
registry: once it's data-driven, adding points is purely additive.

## Tests
- `test_bandit.c`: new `bandit_enumeration` case (real sqlite) — point/arm
  enumeration, scoping, empty-on-unknown, and that `kb_fusion_mode` is not
  invented.
- `test_kb_http_routes.c`: data-driven stubs; asserts the export reports
  `kb_memory_retrieval_limit` + a `points[]` array and **no longer emits**
  `kb_fusion_mode`.
- Full `cd src && make unit-tests` green.
