### PR TITLE
feat(bandit): close the reward loop for retrieval-limit (proposal §0)

### DIFF
--- a/src/kb/kb_bandit.c
+++ b/src/kb/kb_bandit.c
@@ -276,6 +276,15 @@ int kb_bandit_reward(const config_t *cfg, const char *decision_point, const char
    return db2_bandit_arm_stats_update(decision_point, arm_id, reward, new_alpha, new_beta);
 }
 
+double kb_bandit_recall_sufficiency_reward(int n_results, int limit)
+{
+   if (n_results <= 0)
+      return 0.0;
+   if (limit > 0 && n_results >= limit)
+      return 0.5; /* truncated at the cap: a larger limit might have helped */
+   return 1.0;    /* sufficient recall without truncation */
+}
+
 /* ---- replay evidence ---- */
 
 int kb_bandit_record_replay_evidence(const char *decision_point, const char *result_json,

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -29,7 +29,12 @@ int kb_handle_memory_find_facts(int fd, cJSON *req)
       return kb_send_error(fd, "memory.find_facts requires query");
    int limit = cJSON_IsNumber(limit_j) ? (int)limit_j->valuedouble : 20;
 
-   /* Shadow bandit for memory retrieval limit (no explicit limit from caller). */
+   /* Shadow bandit for memory retrieval limit (no explicit limit from caller).
+    * Sample an arm now; carry the decision id + chosen arm so the reward can be
+    * attributed from the recall result below — otherwise the loop never closes
+    * and the arm posteriors never learn from live traffic. */
+   char ml_decision_id[KB_BANDIT_MAX_DECISION] = {0};
+   char ml_arm_id[KB_BANDIT_MAX_ARM_ID] = {0};
    if (!cJSON_IsNumber(limit_j))
    {
       config_t cfg;
@@ -37,13 +42,13 @@ int kb_handle_memory_find_facts(int fd, cJSON *req)
       if (cfg.bandit_live_decision_enabled)
       {
          static const char ml_arms[2][KB_BANDIT_MAX_ARM_ID] = {"10", "20"};
-         char ml_decision_id[KB_BANDIT_MAX_DECISION] = {0};
          int ml_arm =
              kb_bandit_sample(&cfg, "kb_memory_retrieval_limit", NULL, ml_arms, 2, ml_decision_id);
          if (ml_arm >= 0 && ml_arm < 2)
          {
             aimee_log(LOG_DEBUG, "kb.bandit", "kb_memory_retrieval_limit arm=%s", ml_arms[ml_arm]);
             limit = (ml_arm == 0) ? 10 : 20;
+            snprintf(ml_arm_id, sizeof(ml_arm_id), "%s", ml_arms[ml_arm]);
          }
       }
    }
@@ -56,6 +61,16 @@ int kb_handle_memory_find_facts(int fd, cJSON *req)
    memory_fusion_state_set(cJSON_IsString(fusion_j) ? fusion_j->valuestring : NULL);
    cJSON *resp = db2_kb_service_memory_find_facts_json(query_j->valuestring, limit);
    memory_fusion_state_clear();
+
+   /* Close the bandit loop: attribute an immediate recall-sufficiency reward to
+    * the sampled decision so the arm posteriors update from live traffic. */
+   if (ml_decision_id[0] && ml_arm_id[0])
+   {
+      cJSON *facts = resp ? cJSON_GetObjectItemCaseSensitive(resp, "facts") : NULL;
+      int n_results = cJSON_IsArray(facts) ? cJSON_GetArraySize(facts) : 0;
+      double reward = kb_bandit_recall_sufficiency_reward(n_results, limit);
+      kb_bandit_reward(NULL, "kb_memory_retrieval_limit", ml_decision_id, ml_arm_id, reward);
+   }
    return kb_reply_or_error(fd, resp, "failed to search memory facts");
 }
 

--- a/src/kb_bandit.h
+++ b/src/kb_bandit.h
@@ -43,6 +43,16 @@ extern "C"
    int kb_bandit_reward(const config_t *cfg, const char *decision_point, const char *decision_id,
                         const char *arm_id, double reward);
 
+   /* Reward (v1) for the kb_memory_retrieval_limit decision: did the chosen
+    * limit return a sufficient, non-truncated recall set?
+    *   n_results == 0           -> 0.0  (empty recall is bad at any limit)
+    *   n_results >= limit       -> 0.5  (hit the cap; a larger limit might help)
+    *   0 < n_results < limit    -> 1.0  (limit was sufficient, no truncation)
+    * Inspectable proxy; not trivially biased toward the larger arm (an arm that
+    * returns everything relevant without truncation scores 1.0 regardless of
+    * limit).  Pure function so it can be unit-tested in isolation. */
+   double kb_bandit_recall_sufficiency_reward(int n_results, int limit);
+
    /* Record offline-replay attribution as a benchmark_trace artifact.
     *
     * Used by `aimee kb bandit-replay`: the Python replay tool emits a JSON

--- a/src/tests/test_bandit.c
+++ b/src/tests/test_bandit.c
@@ -150,6 +150,28 @@ static void test_bandit_explore_stats(void)
    printf("  bandit_explore_stats: ok\n");
 }
 
+/* ---- recall-sufficiency reward (pure) ---- */
+static void test_bandit_recall_reward(void)
+{
+   /* Empty recall is bad at any limit. */
+   assert(kb_bandit_recall_sufficiency_reward(0, 10) == 0.0);
+   assert(kb_bandit_recall_sufficiency_reward(0, 20) == 0.0);
+
+   /* Sufficient, non-truncated recall scores 1.0 — and is not biased toward the
+    * larger arm: 8 results satisfy both the 10 and 20 arms. */
+   assert(kb_bandit_recall_sufficiency_reward(8, 10) == 1.0);
+   assert(kb_bandit_recall_sufficiency_reward(8, 20) == 1.0);
+
+   /* Hitting the cap is a truncation signal (a larger limit might help). */
+   assert(kb_bandit_recall_sufficiency_reward(10, 10) == 0.5);
+   assert(kb_bandit_recall_sufficiency_reward(20, 20) == 0.5);
+
+   /* 10 results: truncated for the 10-arm, sufficient for the 20-arm. */
+   assert(kb_bandit_recall_sufficiency_reward(10, 20) == 1.0);
+
+   printf("  bandit_recall_reward: ok\n");
+}
+
 /* ---- 7. decision_points_list / arms_list ---- */
 static void test_bandit_enumeration(void)
 {
@@ -229,6 +251,7 @@ int main(void)
    test_bandit_reward_closed();
    test_config_bandit_defaults();
    test_bandit_explore_stats();
+   test_bandit_recall_reward();
    test_bandit_enumeration();
    test_bandit_replay_evidence();
 


### PR DESCRIPTION
## Summary

Second implementation step of the **optimization-surface** proposal — its
**§0 "Close the reward loop"**, the keystone everything else depends on.

The `kb_memory_retrieval_limit` shadow bandit (`kb_service_memory.c`) sampled an
arm and logged a decision, but **never closed it with an observed reward**:
`kb_bandit_reward` / `db2_bandit_decision_close` existed but were never called in
production. So arm posteriors never updated from live traffic, and the decision
log carried null rewards — leaving off-policy replay (the proposal's "default
first pass") inert.

## Change

- **`src/kb_bandit.{c,h}`** — `kb_bandit_recall_sufficiency_reward(n_results, limit)`:
  a pure, inspectable v1 reward.
  - `0.0` on empty recall (bad at any limit)
  - `0.5` when the result set hit the cap (truncation — a larger limit might help)
  - `1.0` when the limit was sufficient without truncation

  Deliberately **not** biased toward the larger arm: an arm returning everything
  relevant without truncation scores `1.0` regardless of limit.
- **`src/kb/kb_service_memory.c`** — carry the sampled decision id + arm across
  the recall, then attribute the reward via `kb_bandit_reward`, closing the loop
  within the same request (immediate-reward contextual bandit).

## Tests
- `test_bandit.c`: `bandit_recall_reward` covers all three reward branches and
  the no-larger-arm-bias property. (Closure + Beta posterior update is already
  covered by the existing `bandit_reward_closed`.)
- Full `cd src && make unit-tests` green.

## Safety
Gated by the existing `bandit_live_decision_enabled` flag (default **off**) —
behaviour is unchanged unless live bandit decisions are enabled. The reward is a
documented v1 proxy; the registry/reward-schema work in later proposal phases can
swap in a trajectory/hard-negative-derived reward without touching this wiring.
