### PR TITLE
feat(optimize): aimee optimize verb over a first-class /v1 route

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1352,6 +1352,10 @@ paths:
     get:
       summary: Insights overview
       responses: { "200": { description: Insights, content: { application/json: { schema: { type: object } } } } }
+  /optimize/export:
+    get:
+      summary: Bandit optimization export (decision-point registry, arm baselines, decision log)
+      responses: { "200": { description: Optimization export, content: { application/json: { schema: { type: object } } } } }
   /identity/show:
     get:
       summary: Show current identity

--- a/src/Makefile
+++ b/src/Makefile
@@ -349,7 +349,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_main.c cli_session_start.c cli_attention_guard.c cli_code_audit.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c
+CLI_SRCS = cli_main.c cli_session_start.c cli_attention_guard.c cli_code_audit.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -200,6 +200,10 @@
     {"graph", "Code-graph projection and explain", CLIENT_TIER_ADVANCED, 0,
      "  sync-code        Project the code graph\n"
      "  explain          Explain a code-graph relationship\n"},
+    {"optimize", "Bandit optimization loop", CLIENT_TIER_ADVANCED, 0,
+     "  points                     List registered decision points\n"
+     "  baseline --point <name>    Show current arm posteriors for a point\n"
+     "  replay --point <name>      Emit a point's closed-decision log for replay\n"},
     {"code", "Code-health audit", CLIENT_TIER_ADVANCED, 0,
      "  audit [dir] [--json]   File-health audit (untested files, TODO/FIXME\n"
      "                         markers, debt score) over the working tree\n"

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1720,6 +1720,10 @@ int main(int argc, char **argv)
       return cmd_profile_run(sub_argc, sub_argv);
    if (strcmp(cmd, "claude-proxy") == 0)
       return cli_claude_proxy(sub_argc, sub_argv);
+   /* optimize: dispatches optimize.export to its first-class /v1 route, then
+    * renders points/baseline/replay client-side. */
+   if (strcmp(cmd, "optimize") == 0)
+      return cmd_optimize_run(sub_argc, sub_argv, json_output);
 #ifndef _WIN32
    /* manuscript mode talks to the server over the Unix-domain /v1 socket
     * (http_uds_client, AF_UNIX), which the Windows client does not build. */

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -112,6 +112,7 @@ static const struct
     {"model.list", "GET", "/v1/model/list"},
     {"model.refresh", "POST", "/v1/model/refresh"},
     {"model.show", "GET", "/v1/model/show"},
+    {"optimize.export", "GET", "/v1/optimize/export"},
     {"provider.get", "POST", "/v1/provider/get"},
     {"provider.list", "GET", "/v1/provider/list"},
     {"provider.models", "GET", "/v1/provider/models"},

--- a/src/cmd_optimize.c
+++ b/src/cmd_optimize.c
@@ -1,0 +1,244 @@
+/* cmd_optimize.c: `aimee optimize` — operator surface for the bandit
+ * optimization loop (decision-point registry + off-policy inspection).
+ *
+ * Thin-client command (special-cased in cli_main.c like `persona`/`manuscript`).
+ * Every subcommand dispatches the `optimize.export` method to its first-class
+ * /v1 route (GET /v1/optimize/export) via cli_v1_rpc_local; aimee-server proxies
+ * to the kb intelligence export, which carries the declared `registry`, the
+ * per-point `arm_stats` baseline, and the closed-decision log for replay.
+ * See docs/proposals/pending/optimization-surface.md (P1). */
+#include "cJSON.h"
+#include "cli_client.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Dispatch optimize.export and return the parsed response (caller frees), or
+ * NULL after printing an error. */
+static cJSON *optimize_fetch(void)
+{
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return NULL;
+   cJSON_AddStringToObject(req, "method", "optimize.export");
+   cJSON *resp = cli_v1_rpc_local(req, 30000);
+   cJSON_Delete(req);
+   if (!resp)
+   {
+      fprintf(stderr, "optimize: no response from aimee-server\n");
+      return NULL;
+   }
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   if (!cJSON_IsString(status) || strcmp(status->valuestring, "ok") != 0)
+   {
+      cJSON *msg = cJSON_GetObjectItemCaseSensitive(resp, "message");
+      fprintf(stderr, "optimize: %s\n", cJSON_IsString(msg) ? msg->valuestring : "unknown error");
+      cJSON_Delete(resp);
+      return NULL;
+   }
+   return resp;
+}
+
+static void optimize_print_json(cJSON *node)
+{
+   char *s = node ? cJSON_PrintUnformatted(node) : NULL;
+   if (s)
+   {
+      puts(s);
+      free(s);
+   }
+}
+
+static cJSON *optimize_find_point(cJSON *resp, const char *point)
+{
+   cJSON *points = cJSON_GetObjectItemCaseSensitive(resp, "points");
+   if (!cJSON_IsArray(points) || !point)
+      return NULL;
+   cJSON *pt;
+   cJSON_ArrayForEach(pt, points)
+   {
+      cJSON *dp = cJSON_GetObjectItemCaseSensitive(pt, "decision_point");
+      if (cJSON_IsString(dp) && strcmp(dp->valuestring, point) == 0)
+         return pt;
+   }
+   return NULL;
+}
+
+static int optimize_decisions_count(cJSON *resp, const char *point)
+{
+   cJSON *pt = optimize_find_point(resp, point);
+   cJSON *d = pt ? cJSON_GetObjectItemCaseSensitive(pt, "decisions") : NULL;
+   return cJSON_IsArray(d) ? cJSON_GetArraySize(d) : 0;
+}
+
+static const char *optimize_arg_point(int argc, char **argv)
+{
+   for (int i = 0; i < argc; i++)
+      if (strcmp(argv[i], "--point") == 0 && i + 1 < argc)
+         return argv[i + 1];
+   return NULL;
+}
+
+static int optimize_cmd_points(int json_output)
+{
+   cJSON *resp = optimize_fetch();
+   if (!resp)
+      return 1;
+   cJSON *registry = cJSON_GetObjectItemCaseSensitive(resp, "registry");
+
+   if (json_output)
+   {
+      optimize_print_json(registry);
+      cJSON_Delete(resp);
+      return 0;
+   }
+   if (!cJSON_IsArray(registry) || cJSON_GetArraySize(registry) == 0)
+   {
+      printf("optimize: no decision points registered\n");
+      cJSON_Delete(resp);
+      return 0;
+   }
+   printf("Decision points:\n");
+   cJSON *e;
+   cJSON_ArrayForEach(e, registry)
+   {
+      cJSON *id = cJSON_GetObjectItemCaseSensitive(e, "decision_point");
+      cJSON *status = cJSON_GetObjectItemCaseSensitive(e, "status");
+      cJSON *reward = cJSON_GetObjectItemCaseSensitive(e, "reward_fn");
+      cJSON *arms = cJSON_GetObjectItemCaseSensitive(e, "arms");
+      const char *id_s = cJSON_IsString(id) ? id->valuestring : "?";
+      printf("  %-28s [%s] reward=%s decisions=%d\n", id_s,
+             cJSON_IsString(status) ? status->valuestring : "?",
+             cJSON_IsString(reward) ? reward->valuestring : "?",
+             optimize_decisions_count(resp, id_s));
+      if (cJSON_IsArray(arms))
+      {
+         printf("      arms:");
+         cJSON *a;
+         cJSON_ArrayForEach(a, arms) printf(" %s", cJSON_IsString(a) ? a->valuestring : "?");
+         printf("\n");
+      }
+   }
+   cJSON_Delete(resp);
+   return 0;
+}
+
+static int optimize_cmd_baseline(int argc, char **argv, int json_output)
+{
+   const char *point = optimize_arg_point(argc, argv);
+   if (!point)
+   {
+      fprintf(stderr, "usage: aimee optimize baseline --point <decision_point>\n");
+      return 2;
+   }
+   cJSON *resp = optimize_fetch();
+   if (!resp)
+      return 1;
+   cJSON *pt = optimize_find_point(resp, point);
+
+   if (json_output)
+   {
+      optimize_print_json(pt ? pt : resp);
+      cJSON_Delete(resp);
+      return 0;
+   }
+   if (!pt)
+   {
+      printf("optimize: %s has no logged decisions yet (baseline empty)\n", point);
+      cJSON_Delete(resp);
+      return 0;
+   }
+   cJSON *arm_stats = cJSON_GetObjectItemCaseSensitive(pt, "arm_stats");
+   cJSON *decisions = cJSON_GetObjectItemCaseSensitive(pt, "decisions");
+   printf("Baseline for %s (%d closed decisions):\n", point,
+          cJSON_IsArray(decisions) ? cJSON_GetArraySize(decisions) : 0);
+   if (cJSON_IsArray(arm_stats) && cJSON_GetArraySize(arm_stats) > 0)
+   {
+      cJSON *entry;
+      cJSON_ArrayForEach(entry, arm_stats)
+      {
+         cJSON *arm = cJSON_GetObjectItemCaseSensitive(entry, "arm_id");
+         cJSON *nd = cJSON_GetObjectItemCaseSensitive(entry, "n_decisions");
+         cJSON *nr = cJSON_GetObjectItemCaseSensitive(entry, "n_rewards");
+         cJSON *alpha = cJSON_GetObjectItemCaseSensitive(entry, "posterior_alpha");
+         cJSON *beta = cJSON_GetObjectItemCaseSensitive(entry, "posterior_beta");
+         double a = cJSON_IsNumber(alpha) ? alpha->valuedouble : 1.0;
+         double b = cJSON_IsNumber(beta) ? beta->valuedouble : 1.0;
+         double mean = (a + b > 0.0) ? a / (a + b) : 0.0;
+         printf("  %-24s decisions=%lld rewards=%lld posterior_mean=%.3f (alpha=%.2f beta=%.2f)\n",
+                cJSON_IsString(arm) ? arm->valuestring : "?",
+                cJSON_IsNumber(nd) ? (long long)nd->valuedouble : 0LL,
+                cJSON_IsNumber(nr) ? (long long)nr->valuedouble : 0LL, mean, a, b);
+      }
+   }
+   else
+   {
+      printf("  (no arm stats)\n");
+   }
+   cJSON_Delete(resp);
+   return 0;
+}
+
+static int optimize_cmd_replay(int argc, char **argv, int json_output)
+{
+   const char *point = optimize_arg_point(argc, argv);
+   if (!point)
+   {
+      fprintf(stderr, "usage: aimee optimize replay --point <decision_point>\n");
+      return 2;
+   }
+   cJSON *resp = optimize_fetch();
+   if (!resp)
+      return 1;
+   cJSON *pt = optimize_find_point(resp, point);
+   cJSON *decisions = pt ? cJSON_GetObjectItemCaseSensitive(pt, "decisions") : NULL;
+   int n = cJSON_IsArray(decisions) ? cJSON_GetArraySize(decisions) : 0;
+
+   if (json_output)
+   {
+      optimize_print_json(cJSON_IsArray(decisions) ? decisions : resp);
+      cJSON_Delete(resp);
+      return 0;
+   }
+   printf("%s: %d closed decision(s) available for off-policy replay.\n", point, n);
+   if (n == 0)
+      printf("  (enable bandit_live_decision_enabled and accrue traffic, or check the point id)\n");
+   else
+      printf("  Pipe `aimee --json optimize replay --point %s` into tools/bandit_replay.py "
+             "for an IPW estimate.\n",
+             point);
+   cJSON_Delete(resp);
+   return 0;
+}
+
+static void optimize_usage(void)
+{
+   fprintf(stderr, "Usage: aimee optimize <subcommand> [options]\n\nSubcommands:\n"
+                   "  points                       List registered decision points\n"
+                   "  baseline --point <name>      Show current arm posteriors for a point\n"
+                   "  replay --point <name>        Emit a point's closed-decision log for replay\n");
+}
+
+int cmd_optimize_run(int argc, char **argv, int json_output)
+{
+   if (argc < 1)
+   {
+      optimize_usage();
+      return 2;
+   }
+   const char *sub = argv[0];
+   if (strcmp(sub, "points") == 0)
+      return optimize_cmd_points(json_output);
+   if (strcmp(sub, "baseline") == 0)
+      return optimize_cmd_baseline(argc - 1, argv + 1, json_output);
+   if (strcmp(sub, "replay") == 0)
+      return optimize_cmd_replay(argc - 1, argv + 1, json_output);
+   if (strcmp(sub, "--help") == 0 || strcmp(sub, "-h") == 0 || strcmp(sub, "help") == 0)
+   {
+      optimize_usage();
+      return 0;
+   }
+   fprintf(stderr, "Unknown optimize subcommand: %s\n", sub);
+   optimize_usage();
+   return 2;
+}

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -244,6 +244,9 @@ int parse_launch_meta(const char *output, launch_meta_t *meta);
  * tree). Defined in cmd_profile.c / cmd_manuscript.c. */
 int cmd_profile_run(int argc, char **argv);
 int cmd_manuscript_run(int argc, char **argv, int json_output);
+/* `aimee optimize` — bandit optimization loop (points/baseline/replay).
+ * Dispatches optimize.export to GET /v1/optimize/export. Defined in cmd_optimize.c. */
+int cmd_optimize_run(int argc, char **argv, int json_output);
 
 /* `aimee persona <list|show|edit|add|rm>` — manage personas over the server's
  * /v1 HTTP API. Defined in cli_persona.c. */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -281,6 +281,7 @@ int handle_kb_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_docs_push(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_ingest_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_optimize_export(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_workers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_rules_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_rules_generate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1048,6 +1048,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"kb.ingest", handle_kb_ingest},
     {"kb.ingest.status", handle_kb_ingest_status},
     {"kb.status", handle_kb_status},
+    {"optimize.export", handle_optimize_export},
     {"workers", handle_workers},
     /* Rules */
     {"rules.list", handle_rules_list},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -117,6 +117,7 @@ const method_policy_t method_registry[] = {
     /* Knowledge base: search/status read; build/ingest/update rebuild the store. */
     {"kb.search", CAP_INDEX_READ, "knowledge search"},
     {"kb.status", CAP_DASHBOARD_READ, "knowledge base status"},
+    {"optimize.export", CAP_DASHBOARD_READ, "bandit optimization export"},
     {"kb.build", CAP_INDEX_ADMIN, "build knowledge base"},
     {"kb.ingest", CAP_INDEX_ADMIN, "ingest corpus"},
     {"kb.update", CAP_INDEX_ADMIN, "update knowledge base"},

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -850,6 +850,7 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/dashboard/plugins", NULL, RM_EXACT, "dashboard.plugins", 0, rh_dispatch_op},
     {"GET", "/v1/dashboard/traces", NULL, RM_EXACT, "dashboard.traces", 0, rh_dispatch_op},
     {"GET", "/v1/insights/overview", NULL, RM_EXACT, "insights.overview", 0, rh_dispatch_op},
+    {"GET", "/v1/optimize/export", NULL, RM_EXACT, "optimize.export", 0, rh_dispatch_op},
     {"GET", "/v1/identity/show", NULL, RM_EXACT, "identity.show", 0, rh_dispatch_op},
     {"POST", "/v1/identity/diff", NULL, RM_EXACT, "identity.diff", 0, rh_dispatch_op},
     {"POST", "/v1/identity/snapshot", NULL, RM_EXACT, "identity.snapshot", 0, rh_dispatch_op},

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -894,6 +894,22 @@ int handle_kb_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return send_and_free(conn, resp);
 }
 
+/* optimize.export: surface the kb bandit/optimization export (decision-point
+ * registry + per-point arm baselines + closed-decision log) over a first-class
+ * /v1 route so the thin client's `aimee optimize` can reach it. */
+int handle_optimize_export(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+
+   char *json = kb_client_bandit_export_json();
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   if (!resp)
+      return server_send_error(conn, "bandit optimization export failed", NULL);
+   return send_and_free(conn, resp);
+}
+
 /* --- Rules handlers --- */
 
 int handle_rules_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -532,6 +532,10 @@ int handle_kb_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "kb.status");
 }
+int handle_optimize_export(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "optimize.export");
+}
 int handle_workers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "workers");


### PR DESCRIPTION
## Summary

Finishes the **optimization-surface** proposal's deferred `aimee optimize` CLI
verb — the proper /v1 way — and executes **P2 of the v1-dispatch-migration-finish
proposal** (route the orphaned bandit/optimization capability through the
dispatch surface). No socket RPC, no `kb_client` call from the thin client.

`aimee optimize <points|baseline|replay>` previously returned *"command has no
typed server RPC route"*. Now it dispatches `optimize.export` to a first-class
route, `GET /v1/optimize/export`.

## Server
- `handle_optimize_export` (`server_state.c`) — dispatch handler returning the kb
  bandit/optimization export (registry + arm baselines + decision log) via
  `kb_client_bandit_export_json`.
- Registered in `server_dispatch_table` (`server.c`), `method_registry` cap
  `CAP_DASHBOARD_READ` (`server_auth.c`), and a sync route in
  `server_http_routes.inc`. Regenerated `cli_v1_routes_gen.inc`; documented in
  `api/openapi-server-v1.yaml`.

## Thin client
- `cmd_optimize.c` — special-cased in `cli_main.c` (like `persona`/`manuscript`);
  `points|baseline|replay` each dispatch `optimize.export` via `cli_v1_rpc_local`
  and render client-side. Help entry in `cli_help_data.h`.

## Tests / gates
- `test_server_dispatch.c`: stub for the new handler.
- All five gates green: `check-cli-v1-routes`, `check-v1-method-coverage`
  (0 excluded), `check-kb-v1-coverage`, server + client api-conformance.
- Full `cd src && make unit-tests` green.

## Notes
The kb intelligence family's other orphans (`calibration/readiness`,
`demotion/check`, `bandit/replay-record`) remain — they're P3 of the migration
proposal. This PR routes the one needed to finish `aimee optimize`.
