### PR TITLE
refactor(v1): retire the /v1/rpc bridge vestiges (migration P1)

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -542,7 +542,7 @@ static int handle_agent_setup_cmd(int argc, char **argv, int json_output)
    cJSON *req1 = cJSON_CreateObject();
    cJSON_AddStringToObject(req1, "method", "agent.setup");
    cJSON_AddStringToObject(req1, "provider", provider);
-   cJSON *resp1 = cli_v1_rpc_local(req1, 15000);
+   cJSON *resp1 = cli_v1_dispatch_local(req1, 15000);
    cJSON_Delete(req1);
 
    if (!resp1)
@@ -629,7 +629,7 @@ static int handle_agent_setup_cmd(int argc, char **argv, int json_output)
    cJSON_AddNumberToObject(req2, "expires_in", expires_s);
 
    int poll_timeout_ms = (expires_s + 60) * 1000;
-   cJSON *resp2 = cli_v1_rpc_local(req2, poll_timeout_ms);
+   cJSON *resp2 = cli_v1_dispatch_local(req2, poll_timeout_ms);
    cJSON_Delete(req2);
 
    if (!resp2)
@@ -848,7 +848,7 @@ static int handle_hooks(int argc, char **argv, int json_output)
    if (sid && sid[0])
       cJSON_AddStringToObject(req, "session_id", sid);
 
-   cJSON *resp = cli_v1_rpc_local(req, 5000);
+   cJSON *resp = cli_v1_dispatch_local(req, 5000);
    cJSON_Delete(req);
    free(stdin_data);
 
@@ -1036,7 +1036,7 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
    }
    else
    {
-      resp = cli_v1_rpc_local(req, 30000);
+      resp = cli_v1_dispatch_local(req, 30000);
    }
    cJSON_Delete(req);
 

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -130,8 +130,8 @@ static const char *client_session_id(void)
 }
 
 /* Ensure a co-located aimee-server is reachable over the /v1 HTTP UDS. The thin
- * client is connectionless per call now (each server_request is a one-shot POST
- * /v1/rpc), so this is a pure availability probe — no persistent socket. */
+ * client is connectionless per call now (each server_request is a one-shot /v1
+ * dispatch), so this is a pure availability probe — no persistent socket. */
 static int ensure_connection(void)
 {
    if (!g_sock_path)
@@ -142,7 +142,7 @@ static int ensure_connection(void)
 static cJSON *server_request(cJSON *req, int timeout_ms)
 {
    /* Remote aimee-server: POST mcp.call to its first-class /v1 route. The local
-    * cli_v1_rpc_local path only speaks the co-located UDS, so a thin client
+    * cli_v1_dispatch_local path only speaks the co-located UDS, so a thin client
     * configured with a remote endpoint must route here. Memory/kb/search tools
     * resolve on the server (which proxies DB2 to aimee-kb). File/exec tools whose
     * cwd is a registered detached workspace marshal back to this client over the
@@ -191,9 +191,9 @@ static cJSON *server_request(cJSON *req, int timeout_ms)
          continue;
       }
 
-      /* Each call is a one-shot POST /v1/rpc to the co-located server (mcp.call
+      /* Each call is a one-shot /v1 dispatch to the co-located server (mcp.call
        * is reached over the local UDS, which permits the full dispatch surface). */
-      cJSON *resp = cli_v1_rpc_local(req, timeout_ms);
+      cJSON *resp = cli_v1_dispatch_local(req, timeout_ms);
       if (resp)
          return resp;
 

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6678,14 +6678,14 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
    }
 }
 
-/* cli_v1_rpc_local: dispatch a pre-marshalled {method, ...params} request to its
+/* cli_v1_dispatch_local: dispatch a pre-marshalled {method, ...params} request to its
  * first-class /v1 route over the co-located transport — the local aimee-http.sock
  * on POSIX, or the configured remote on Windows (no UDS). Replaces the old POST
  * /v1/rpc bridge: the interactive co-located callers (chat, launch, mcp serve,
  * hooks, triggers, gateway, workspace serve) now reach the same dispatch surface
  * via dedicated routes (async methods are polled to completion). Returns the
  * parsed response (caller frees) or NULL. */
-cJSON *cli_v1_rpc_local(cJSON *req, int timeout_ms)
+cJSON *cli_v1_dispatch_local(cJSON *req, int timeout_ms)
 {
    if (!req)
       return NULL;

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -352,7 +352,7 @@ int handle_session_start(int json_output)
     * immediately once the background thread is launched (typically <50 ms).
     * If it doesn't, soft-fail after 10 s rather than blocking claude for 60 s. */
    int timeout_ms = nonblocking ? 10000 : 60000;
-   cJSON *resp = cli_v1_rpc_local(req, timeout_ms);
+   cJSON *resp = cli_v1_dispatch_local(req, timeout_ms);
    cJSON_Delete(req);
    cJSON_Delete(hook_json);
    free(augmented_hook);

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -52,12 +52,12 @@ static void serve_on_signal(int sig)
    g_serve_stop = 1;
 }
 
-/* One short-lived RPC call to the co-located server over POST /v1/rpc (local
- * aimee-http.sock). Returns the response (caller frees) or NULL. */
+/* One short-lived dispatch to the co-located server over its first-class /v1
+ * route (local aimee-http.sock). Returns the response (caller frees) or NULL. */
 static cJSON *serve_rpc(const char *sock, cJSON *req, int timeout_ms)
 {
    (void)sock; /* co-located runner reaches the server over the /v1 HTTP UDS */
-   return cli_v1_rpc_local(req, timeout_ms);
+   return cli_v1_dispatch_local(req, timeout_ms);
 }
 
 /* fetch: get the next op to execute (caller frees) or NULL when none is pending

--- a/src/cmd_optimize.c
+++ b/src/cmd_optimize.c
@@ -3,7 +3,7 @@
  *
  * Thin-client command (special-cased in cli_main.c like `persona`/`manuscript`).
  * Every subcommand dispatches the `optimize.export` method to its first-class
- * /v1 route (GET /v1/optimize/export) via cli_v1_rpc_local; aimee-server proxies
+ * /v1 route (GET /v1/optimize/export) via cli_v1_dispatch_local; aimee-server proxies
  * to the kb intelligence export, which carries the declared `registry`, the
  * per-point `arm_stats` baseline, and the closed-decision log for replay.
  * See docs/proposals/pending/optimization-surface.md (P1). */
@@ -21,7 +21,7 @@ static cJSON *optimize_fetch(void)
    if (!req)
       return NULL;
    cJSON_AddStringToObject(req, "method", "optimize.export");
-   cJSON *resp = cli_v1_rpc_local(req, 30000);
+   cJSON *resp = cli_v1_dispatch_local(req, 30000);
    cJSON_Delete(req);
    if (!resp)
    {

--- a/src/cmd_trigger.c
+++ b/src/cmd_trigger.c
@@ -56,7 +56,7 @@ static const char *trigger_socket(void)
 }
 
 /* No-op kept for call-site symmetry: the thin client is connectionless per call
- * now (each trigger_rpc is a one-shot POST /v1/rpc). Server availability is
+ * now (each trigger_rpc is a one-shot /v1 dispatch). Server availability is
  * already ensured by trigger_socket() → cli_ensure_server_for_method. */
 static int trigger_connect(cli_conn_t *conn, const char *sock)
 {
@@ -65,12 +65,12 @@ static int trigger_connect(cli_conn_t *conn, const char *sock)
    return 0;
 }
 
-/* Send *req over POST /v1/rpc (local aimee-http.sock), delete req.  Returns NULL
+/* Send *req over the first-class /v1 dispatch (local aimee-http.sock), delete req.  Returns NULL
  * on transport error (error already printed). */
 static cJSON *trigger_rpc(cli_conn_t *conn, cJSON *req)
 {
    (void)conn;
-   cJSON *resp = cli_v1_rpc_local(req, CLIENT_DEFAULT_TIMEOUT_MS);
+   cJSON *resp = cli_v1_dispatch_local(req, CLIENT_DEFAULT_TIMEOUT_MS);
    cJSON_Delete(req);
    if (!resp)
       fprintf(stderr, "aimee: no response from server\n");

--- a/src/gateway/gateway_ctx.c
+++ b/src/gateway/gateway_ctx.c
@@ -1,7 +1,7 @@
 /* gateway_ctx.c: gateway runtime context and message handling.
  *
  * Connects inbound platform messages to the co-located aimee-server over its
- * /v1 HTTP surface (POST /v1/chat/stream for turns, POST /v1/rpc for launch.run
+ * /v1 HTTP surface (POST /v1/chat/stream for turns, first-class /v1 routes for launch.run
  * and other unary methods), then delivers streamed responses back through the
  * platform delivery router.
  */
@@ -154,7 +154,7 @@ static int rpc_launch_run(char *sid_out, size_t sid_cap)
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "launch.run");
    cJSON_AddStringToObject(req, "cwd", "/");
-   cJSON *resp = cli_v1_rpc_local(req, 15000);
+   cJSON *resp = cli_v1_dispatch_local(req, 15000);
    cJSON_Delete(req);
    if (!resp)
    {
@@ -295,7 +295,7 @@ static int gw_resolve_workspace(const char *name, char *out, size_t out_cap)
 {
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "workspace.list");
-   cJSON *resp = cli_v1_rpc_local(req, 10000);
+   cJSON *resp = cli_v1_dispatch_local(req, 10000);
    cJSON_Delete(req);
 
    int found = -1;
@@ -361,7 +361,7 @@ static void handle_pr_command(gateway_ctx_t *ctx, const session_source_t *src, c
    cJSON *a = cJSON_AddObjectToObject(req, "arguments");
    cJSON_AddStringToObject(a, "action", "create");
    cJSON_AddStringToObject(a, "title", title);
-   cJSON *resp = cli_v1_rpc_local(req, 300000); /* gh pr create + verify gate */
+   cJSON *resp = cli_v1_dispatch_local(req, 300000); /* gh pr create + verify gate */
    cJSON_Delete(req);
 
    const char *reply = "PR command sent (no response from server).";
@@ -478,7 +478,7 @@ static int handle_slash_command(gateway_ctx_t *ctx, const session_source_t *src,
          cJSON *req = cJSON_CreateObject();
          cJSON_AddStringToObject(req, "method", "chat.graceful_cancel");
          cJSON_AddStringToObject(req, "aimee_session_id", sid_copy);
-         cJSON_Delete(cli_v1_rpc_local(req, 5000));
+         cJSON_Delete(cli_v1_dispatch_local(req, 5000));
          cJSON_Delete(req);
       }
       reply_origin(ctx, src, "Cancelled.");

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -38,14 +38,15 @@ typedef int (*cli_stream_cb)(cJSON *event, void *userdata);
  * co-located server is reached over aimee-http.sock). */
 int cli_server_available(const char *socket_path);
 
-/* Run a unary {method,...} dispatch over the co-located server's POST /v1/rpc
- * bridge (local aimee-http.sock) and return the parsed dispatch response (caller
- * cJSON_Delete()s it), or NULL on transport failure. The local UDS is
- * filesystem-trusted, so /v1/rpc permits any method (server_dispatch still
+/* Run a unary {method,...} dispatch by resolving the method to its first-class
+ * /v1 route and sending it to the co-located server (local aimee-http.sock on
+ * POSIX; the configured remote on Windows). Returns the parsed dispatch response
+ * (caller cJSON_Delete()s it), or NULL on transport failure or when the method
+ * has no /v1 route. The local UDS is filesystem-trusted (server_dispatch still
  * enforces per-method caps); dispatch-level errors come back as a
- * {status:"error",...} body. Replaces the legacy NDJSON connect/authenticate/
- * request sequence for one-shot client commands. POSIX only. */
-cJSON *cli_v1_rpc_local(cJSON *req, int timeout_ms);
+ * {status:"error",...} body. Replaces both the legacy NDJSON
+ * connect/authenticate/request sequence and the retired POST /v1/rpc bridge. */
+cJSON *cli_v1_dispatch_local(cJSON *req, int timeout_ms);
 
 /* ── /v1 HTTP transport (aimee.api.client_transport) ───────────────────────
  * First-party clients can reach aimee-server over its /v1 HTTP surface
@@ -67,8 +68,8 @@ cli_transport_t cli_transport_parse(const char *s);
  * dispatch-backed (rh_dispatch_op), so an HTTP call returns byte-identical
  * results to the NDJSON socket. Returns the request path and sets *verb_out
  * ("GET"/"POST"); returns NULL (with *verb_out defaulted to "POST") when the
- * method has no parity-safe REST route, so the caller falls back to /v1/rpc or
- * the socket. Only POST routes and no-argument GET reads are mapped. */
+ * method has no parity-safe REST route. Only POST routes and no-argument GET
+ * reads are mapped. */
 const char *cli_v1_route_for_method(const char *method, const char **verb_out);
 
 /* {id}-bearing /v1 routes (PREFIX{id}SUFFIX, e.g. /v1/workspaces/{path},

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -891,7 +891,7 @@ typedef struct config
    /* server_api_remote_writes: how far a TCP bearer may mutate (the UDS path is
     * always full). 0 = off (default; mutating routes local-UDS-only), 1 = data
     * (data-mutating /v1 routes allowed over TCP, capability-gated), 2 = full
-    * (CAPS_ALL: data writes + delegate/tool over /v1/rpc). Parsed from
+    * (CAPS_ALL: data writes + delegate/tool over /v1). Parsed from
     * aimee.api.remote_writes ("off"|"data"|"full"); see SERVER_REMOTE_WRITES_*. */
    int server_api_remote_writes;
 

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -86,8 +86,8 @@ typedef struct cJSON cJSON;
  *   OFF  — mutating /v1 routes are local-UDS-only (default; leaked-bearer safe).
  *   DATA — data-mutating routes (memory.store, work.*, rules.delete, skill.*, …)
  *          allowed over TCP, gated by the per-route capability matrix.
- *   FULL — TCP bearer is fully trusted (CAPS_ALL): data writes AND the /v1/rpc
- *          delegate/tool/bash bridge. Trusted networks only. */
+ *   FULL — TCP bearer is fully trusted (CAPS_ALL): data writes AND the
+ *          delegate/tool/bash methods over /v1. Trusted networks only. */
 #define SERVER_REMOTE_WRITES_OFF  0
 #define SERVER_REMOTE_WRITES_DATA 1
 #define SERVER_REMOTE_WRITES_FULL 2

--- a/src/posix/cli_client.c
+++ b/src/posix/cli_client.c
@@ -1,5 +1,5 @@
 /* cli_client.c: shared client library. aimee-server is reached over its /v1 HTTP
- * surface (cli_http_request / cli_v1_rpc_local); the cli_connect/cli_request
+ * surface (cli_http_request / cli_v1_dispatch_local); the cli_connect/cli_request
  * NDJSON primitives remain only for the aimee-kb sidecar socket. */
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -95,7 +95,7 @@ static const char *cli_http_sock_path(void)
  * UDS within timeout_ms. The local UDS is filesystem-trusted (no token); a 2xx
  * response means the server is up and serving /v1. This is the liveness probe
  * that replaced the NDJSON `server.info` handshake — health-only by design (the
- * /v1 surface + /v1/rpc bridge make per-method/version gating unnecessary, and
+ * first-class /v1 surface makes per-method/version gating unnecessary, and
  * strict version matching historically caused dev-vs-installed restart loops). */
 static int cli_http_health_ok(int timeout_ms)
 {
@@ -1013,7 +1013,7 @@ int cli_server_available(const char *socket_path)
    return cli_http_health_ok(CLIENT_CONNECT_TIMEOUT_MS);
 }
 
-/* cli_v1_rpc_local now lives in the shared cli_rpc_routes.inc — it resolves the
+/* cli_v1_dispatch_local now lives in the shared cli_rpc_routes.inc — it resolves the
  * method's first-class /v1 route (no more POST /v1/rpc bridge). */
 
 void cli_close(cli_conn_t *conn)

--- a/src/server/provider_catalog.c
+++ b/src/server/provider_catalog.c
@@ -339,7 +339,7 @@ static int server_slot_acquire(const char *agent_name, int max_parallel)
    cJSON_AddStringToObject(req, "method", "provider.slot_acquire");
    cJSON_AddStringToObject(req, "agent_name", agent_name);
    cJSON_AddNumberToObject(req, "max_parallel", max_parallel);
-   cJSON *resp = cli_v1_rpc_local(req, 2000); /* co-located /v1/rpc bridge */
+   cJSON *resp = cli_v1_dispatch_local(req, 2000); /* co-located /v1 dispatch */
    cJSON_Delete(req);
    if (!resp)
       return -1;
@@ -355,7 +355,7 @@ static int server_slot_release_try(const char *agent_name)
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "provider.slot_release");
    cJSON_AddStringToObject(req, "agent_name", agent_name);
-   cJSON *resp = cli_v1_rpc_local(req, 2000); /* co-located /v1/rpc bridge */
+   cJSON *resp = cli_v1_dispatch_local(req, 2000); /* co-located /v1 dispatch */
    cJSON_Delete(req);
    cJSON_Delete(resp);
    return 0;

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -313,7 +313,7 @@ uint32_t server_http_conn_caps(int is_tcp, const char *bearer, int remote_writes
    if (bearer && strncmp(bearer, "scope:", 6) == 0)
       return CAPS_READ_ONLY & ~(uint32_t)CAP_CHAT; /* scoped: query-only, no compute */
    /* Unscoped TCP bearer. "full" makes it fully trusted (CAPS_ALL), which also
-    * opens the /v1/rpc delegate/tool bridge (gated on == CAPS_ALL); "off"/"data"
+    * permits the delegate/tool methods over /v1 (gated on == CAPS_ALL); "off"/"data"
     * keep CAPS_AUTHENTICATED (write caps present, but mutating routes are gated
     * separately in server_http_route_allowed). */
    if (remote_writes >= SERVER_REMOTE_WRITES_FULL)

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -208,10 +208,10 @@ cJSON *handle_git_issue(cJSON *args)
    return stub_git_content("git_issue");
 }
 
-/* cli_mcp_serve now forwards over the co-located /v1/rpc bridge instead of the
- * legacy NDJSON socket, so the mock backend is cli_v1_rpc_local (same
+/* cli_mcp_serve now forwards over the co-located /v1 dispatch instead of the
+ * legacy NDJSON socket, so the mock backend is cli_v1_dispatch_local (same
  * {method,...} request → canned dispatch response). */
-cJSON *cli_v1_rpc_local(cJSON *request, int timeout_ms)
+cJSON *cli_v1_dispatch_local(cJSON *request, int timeout_ms)
 {
    (void)timeout_ms;
 

--- a/src/windows/cli_client.c
+++ b/src/windows/cli_client.c
@@ -785,7 +785,7 @@ cJSON *cli_http_request_stream_ndjson(const char *endpoint, const char *method, 
    return final;
 }
 
-/* cli_v1_rpc_local now lives in the shared cli_rpc_routes.inc — it resolves the
+/* cli_v1_dispatch_local now lives in the shared cli_rpc_routes.inc — it resolves the
  * method's first-class /v1 route (no more POST /v1/rpc bridge). On Windows
  * cli_v1_send routes it through aimee_client_request to the configured remote.
  *


### PR DESCRIPTION
## Summary

**P1 of the v1-dispatch-migration-finish proposal** — retire the `/v1/rpc` bridge
vestiges. The bridge is functionally retired (`cli_rpc_forward` is strict-/v1,
coverage-gated), but its **name and comments lingered and actively misled** —
this is the exact debt that made a new command look like it needed "an RPC route".

Pure cleanup, **no behaviour change**:

- **Rename** `cli_v1_rpc_local` → `cli_v1_dispatch_local` — it resolves a method
  to its first-class /v1 route; "rpc" was the dead bridge name. 25 occurrences
  across 13 files (incl. the `test_cli_mcp_serve` shim).
- **Fix the misleading comments** that still described POST /v1/rpc as the live
  path: the `cli_client.h` function doc, the call-site comments in
  `cli_workspace_serve` / `cmd_trigger` / `cli_mcp_serve` / `gateway_ctx`, and the
  `provider_catalog` inline notes.
- **Reconcile the CAPS_ALL trust-model wording** (`server_http.c`, `server.h`,
  `config.h`): "full" permits the delegate/tool/bash methods **over /v1**, not via
  a "/v1/rpc bridge".

Kept the *accurate* retirement notes ("the bridge was retired", "no more /v1/rpc").

## Tests / gates
- Thin client + server build clean.
- `check-cli-v1-routes` + `check-v1-method-coverage` green (rename doesn't touch routes).
- Full `cd src && make unit-tests` green.

## Remaining (migration P3)
Route the other orphaned kb intelligence endpoints (`calibration/readiness`,
`demotion/check`, `bandit/replay-record`) and retire their dead `cmd_kb` handlers.
