### PR TITLE
feat(bandit): convert kb_fusion_mode to a sampled decision (P4)

### DIFF
--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -13,6 +13,8 @@
 #include "kb_features.h"
 #include "kb_ranker.h"
 #include "kb_detect.h"
+#include "kb_bandit.h"
+#include "kb_bandit_registry.h"
 #endif
 #include "headers/sketch.h"
 #include "kb.h"
@@ -1540,16 +1542,43 @@ static char *kb_search_gather(const char *project, const char *query, const char
    char proj[256];
    kb_resolve_project(project, NULL, proj, sizeof(proj));
 
-   /* Determine fusion mode: explicit override > config > default. */
+   /* Determine fusion mode: explicit override > bandit sample > config > default.
+    * When no override is given and live bandit decisions are enabled, sample the
+    * fusion strategy from the kb_fusion_mode decision point; the choice is
+    * rewarded from this search's recall sufficiency at the success exit below. */
    config_t fusion_cfg;
    int fusion_cfg_ok = (config_load(&fusion_cfg) == 0);
    const char *fusion_mode;
+   char fm_decision_id[KB_BANDIT_MAX_DECISION] = {0};
+   char fm_arm_id[KB_BANDIT_MAX_ARM_ID] = {0};
+   const kb_bandit_decision_point_t *fm_dp = NULL;
    if (fusion_mode_override && fusion_mode_override[0])
       fusion_mode = fusion_mode_override;
-   else if (fusion_cfg_ok && fusion_cfg.kb_fusion_mode[0])
-      fusion_mode = fusion_cfg.kb_fusion_mode;
    else
-      fusion_mode = "rrf";
+   {
+      if (fusion_cfg_ok && fusion_cfg.bandit_live_decision_enabled)
+      {
+         fm_dp = kb_bandit_registry_get("kb_fusion_mode");
+         if (fm_dp && fm_dp->n_arms > 0)
+         {
+            char fm_arms[KB_BANDIT_MAX_ARMS][KB_BANDIT_MAX_ARM_ID];
+            for (int i = 0; i < fm_dp->n_arms; i++)
+               snprintf(fm_arms[i], KB_BANDIT_MAX_ARM_ID, "%s", fm_dp->arms[i]);
+            int a = kb_bandit_sample(&fusion_cfg, fm_dp->id, NULL, fm_arms, fm_dp->n_arms,
+                                     fm_decision_id);
+            if (a >= 0 && a < fm_dp->n_arms)
+               snprintf(fm_arm_id, sizeof(fm_arm_id), "%s", fm_arms[a]);
+            else
+               fm_dp = NULL; /* sample disabled/failed: fall back, no reward */
+         }
+      }
+      if (fm_arm_id[0])
+         fusion_mode = fm_arm_id; /* function-scope buffer; valid throughout */
+      else if (fusion_cfg_ok && fusion_cfg.kb_fusion_mode[0])
+         fusion_mode = fusion_cfg.kb_fusion_mode;
+      else
+         fusion_mode = "rrf";
+   }
 
    kb_result_t *lex_res = malloc(MAX_LEXICAL_RESULTS * sizeof(kb_result_t));
    kb_result_t *vec_res = malloc(MAX_VEC_RESULTS * sizeof(kb_result_t));
@@ -1716,6 +1745,15 @@ static char *kb_search_gather(const char *project, const char *query, const char
 #endif
 
    *n_out = n_results;
+
+   /* Close the kb_fusion_mode bandit loop with this search's recall sufficiency
+    * (same proxy as kb_memory_retrieval_limit), so the arm posteriors learn from
+    * live traffic. Only runs when an arm was sampled above. */
+   if (fm_dp && fm_decision_id[0] && fm_arm_id[0])
+   {
+      double reward = kb_bandit_recall_sufficiency_reward(n_results, max_results);
+      kb_bandit_reward(NULL, fm_dp->id, fm_decision_id, fm_arm_id, reward);
+   }
    return NULL;
 }
 

--- a/src/kb/kb_bandit_registry.c
+++ b/src/kb/kb_bandit_registry.c
@@ -17,6 +17,15 @@ static const kb_bandit_decision_point_t REGISTRY[] = {
         .reward_fn = "recall_sufficiency_v1",
         .status = "live",
     },
+    {
+        .id = "kb_fusion_mode",
+        .description = "KB-search hybrid fusion strategy: how lexical and dense "
+                       "results are combined when no explicit mode is requested.",
+        .arms = {"rrf", "static_alpha", "dynamic_alpha"},
+        .n_arms = 3,
+        .reward_fn = "recall_sufficiency_v1",
+        .status = "live",
+    },
 };
 
 int kb_bandit_registry_count(void)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -62,7 +62,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/learning_router.o $(OBJDIR)/learnin
                  $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/demotion.o $(OBJDIR)/db2/calibration.o \
                  $(OBJDIR)/db2/feature_rows.o $(OBJDIR)/kb/kb_features.o $(OBJDIR)/kb/kb_ranker.o $(OBJDIR)/kb/kb_detect.o \
                  $(OBJDIR)/kb/kb_reasoning.o \
-                 $(OBJDIR)/db2/bandit.o $(OBJDIR)/kb/kb_bandit.o \
+                 $(OBJDIR)/db2/bandit.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o \
                  $(OBJDIR)/kb/kb_mdl.o \
                  $(OBJDIR)/server/computer_use.o
 
@@ -430,7 +430,7 @@ $(TESTPREFIX)/unit-test-cmd-hooks-scope: $(OBJDIR)/tests/test_cmd_hooks_scope.o 
                              $(OBJDIR)/cmd_hooks_scope.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-memory: $(OBJDIR)/tests/test_memory.o $(OBJDIR)/memory_core.o \
+$(TESTPREFIX)/unit-test-memory: $(OBJDIR)/tests/test_memory.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o $(OBJDIR)/memory_core.o \
                         $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/kb_service_backend.o $(OBJDIR)/db2/kb_service_backend_ingest.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db2/feedback.o $(OBJDIR)/db2/notes.o $(OBJDIR)/db2/anti_patterns.o $(OBJDIR)/db2/curiosity.o $(OBJDIR)/db2/entity_edges.o $(OBJDIR)/db2/entity_profiles.o $(OBJDIR)/db2/epistemic_directives.o $(OBJDIR)/db2/failed_queries.o $(OBJDIR)/db2/kind_lifecycle.o $(OBJDIR)/db2/calibration.o $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o \
                         $(OBJDIR)/tests/support/mock_agent_http.o \
                         $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o \
@@ -1829,7 +1829,7 @@ $(TESTPREFIX)/unit-test-turn-narration: $(OBJDIR)/tests/test_turn_narration.o \
                                          $(OBJDIR)/turn_narration.o $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
-$(TESTPREFIX)/unit-test-kb: $(OBJDIR)/tests/test_kb.o $(OBJDIR)/kb/kb.o $(OBJDIR)/kb/kb_curator_notify.o $(OBJDIR)/kb/kb_fusion.o $(OBJDIR)/kb/kb_neardup.o $(OBJDIR)/kb/kb_conventions.o \
+$(TESTPREFIX)/unit-test-kb: $(OBJDIR)/tests/test_kb.o $(OBJDIR)/kb/kb.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o $(OBJDIR)/kb/kb_curator_notify.o $(OBJDIR)/kb/kb_fusion.o $(OBJDIR)/kb/kb_neardup.o $(OBJDIR)/kb/kb_conventions.o \
                              $(OBJDIR)/sketch.o $(OBJDIR)/db2/sketch.o \
                              $(OBJDIR)/memory_core.o $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/kb_service_backend.o $(OBJDIR)/db2/kb_service_backend_ingest.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db2/feedback.o $(OBJDIR)/db2/notes.o $(OBJDIR)/db2/anti_patterns.o $(OBJDIR)/db2/curiosity.o $(OBJDIR)/db2/entity_edges.o $(OBJDIR)/db2/entity_profiles.o $(OBJDIR)/db2/epistemic_directives.o $(OBJDIR)/db2/failed_queries.o $(OBJDIR)/db2/kind_lifecycle.o $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o $(OBJDIR)/tests/support/mock_agent_http.o $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o $(OBJDIR)/tests/support/kb_ws_stub.o $(OBJDIR)/posix/memory.o \
                              $(OBJDIR)/memory_logic.o $(OBJDIR)/memory_health.o $(OBJDIR)/memory_conflict.o $(OBJDIR)/memory_context.o $(OBJDIR)/memory_assemble.o \
@@ -1841,7 +1841,7 @@ $(TESTPREFIX)/unit-test-kb: $(OBJDIR)/tests/test_kb.o $(OBJDIR)/kb/kb.o $(OBJDIR
                              $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm -lzstd
 
-$(TESTPREFIX)/unit-test-memory-retrieval-eval: \
+$(TESTPREFIX)/unit-test-memory-retrieval-eval: $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o \
                              $(OBJDIR)/tests/test_memory_retrieval_eval.o \
                              $(OBJDIR)/server/agent_eval.o $(OBJDIR)/server/agent_eval_memory_support.o $(OBJDIR)/server/agent_eval_baseline.o \
                              $(OBJDIR)/memory_core.o $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/kb_service_backend.o $(OBJDIR)/db2/kb_service_backend_ingest.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db2/feedback.o $(OBJDIR)/db2/notes.o $(OBJDIR)/db2/anti_patterns.o $(OBJDIR)/db2/curiosity.o $(OBJDIR)/db2/entity_edges.o $(OBJDIR)/db2/entity_profiles.o $(OBJDIR)/db2/epistemic_directives.o $(OBJDIR)/db2/failed_queries.o $(OBJDIR)/db2/kind_lifecycle.o $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o $(OBJDIR)/tests/support/mock_agent_http.o $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o $(OBJDIR)/posix/memory.o \

--- a/src/tests/test_bandit.c
+++ b/src/tests/test_bandit.c
@@ -166,6 +166,13 @@ static void test_bandit_registry(void)
    assert(strcmp(dp->arms[0], "10") == 0);
    assert(strcmp(dp->arms[1], "20") == 0);
 
+   /* kb_fusion_mode is also registered (KB-search fusion strategy). */
+   const kb_bandit_decision_point_t *fm = kb_bandit_registry_get("kb_fusion_mode");
+   assert(fm != NULL);
+   assert(fm->n_arms == 3);
+   assert(strcmp(fm->arms[0], "rrf") == 0);
+   assert(strcmp(fm->status, "live") == 0);
+
    /* Unknown id -> NULL; index access is bounds-checked. */
    assert(kb_bandit_registry_get("nope") == NULL);
    assert(kb_bandit_registry_get(NULL) == NULL);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1144,17 +1144,20 @@ static void test_intelligence_bandit_export(void)
    int s = kb_http_route_ex("GET", "/v1/intelligence/bandit/export", NULL, NULL, NULL, NULL, 0, buf,
                             sizeof(buf));
    assert(s == 200);
-   /* Export is data-driven: it reports the point that is actually sampled, and a
-    * `points` breakdown — not the hard-coded phantom kb_fusion_mode. */
+   /* Export is data-driven: the `points` breakdown reports only the point that is
+    * actually sampled (no fabricated phantom — the arm_stats mock aborts on any
+    * other decision point). */
    assert(strstr(buf, "\"points\":[") != NULL);
    assert(strstr(buf, "\"decision_point\":\"kb_memory_retrieval_limit\"") != NULL);
-   assert(strstr(buf, "kb_fusion_mode") == NULL);
    assert(strstr(buf, "\"arm_id\":\"10\"") != NULL);
    assert(strstr(buf, "\"n_decisions\":3") != NULL);
    /* The registry section lists declared decision points (source of truth),
-    * including arms and the reward function — present even with no decisions. */
+    * including arms and the reward function — present even with no decisions.
+    * kb_fusion_mode is now a registered point, so it appears here (not as a
+    * phantom with fabricated arm stats). */
    assert(strstr(buf, "\"registry\":[") != NULL);
    assert(strstr(buf, "\"reward_fn\":\"recall_sufficiency_v1\"") != NULL);
+   assert(strstr(buf, "\"decision_point\":\"kb_fusion_mode\"") != NULL);
 }
 
 static void test_not_found(void)


### PR DESCRIPTION
## Summary

**Optimization-surface P4 (the `kb_fusion_mode` half).** `kb_fusion_mode` was a
static config knob whose "bandit" was only a reporting fiction (the original
phantom-export issue). This makes it a **real sampled decision**, gated behind
`bandit_live_decision_enabled` (**default off**) — the same pattern as
`kb_memory_retrieval_limit`, with a clean **single-site sample + reward**.

- **`kb_bandit_registry.c`** — register `kb_fusion_mode` (arms
  `rrf`/`static_alpha`/`dynamic_alpha`, reward `recall_sufficiency_v1`, live).
- **`kb.c` (`kb_search_gather`)** — when there's no explicit override and live
  decisions are enabled, sample the fusion strategy from the bandit and use it as
  the fusion mode; close the loop at the **single success exit** with this
  search's recall sufficiency. `kb_search_gather` both selects the mode *and*
  produces the result count, so sample and reward are co-located — no async
  threading (this is why it's clean where `delegate_routing` is not; see below).
- **tests** — registry test covers `kb_fusion_mode`; the export test now asserts
  it as a registered point (it legitimately appears in `registry`; the old
  phantom-absent assertion is replaced). `Rules.mk`: bandit objects added to the
  test targets that link `kb/kb.o`.

Full `make unit-tests` + all gates green. **Production behaviour unchanged** (gated off).

## What is NOT in this PR — `delegate_routing` (#3) and why

I am deliberately **not** shipping `delegate_routing` as a sampled decision. Its
reward (delegate success/no-op) is observed **asynchronously at job completion**,
far from the routing choice (selection in `delegate_routing.c` / launch-time vs.
outcome in `delegate_run_phases.c` / the job queue, partly for background jobs).
A correct version needs a `decision_id` **threaded through the delegate job
lifecycle** (a schema/lifecycle change). Shipping sample-without-reward would
reintroduce exactly the open-loop bug §0 fixed. That belongs in a focused,
reviewed PR — not an autonomous batch into the production delegate path.
