### PR TITLE
feat(bandit): delegate_routing as a sampled decision (route A, single DB2 store)

### DIFF
--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -1009,6 +1009,32 @@ paths:
                 type: object
         "401":
           description: Unauthorized
+  /intelligence/bandit/sample:
+    post:
+      operationId: postIntelligenceBanditSample
+      summary: Sample an arm for a decision point (server-side decision points)
+      responses:
+        "200":
+          description: Selected arm + decision id (or status disabled)
+          content:
+            application/json:
+              schema:
+                type: object
+        "401":
+          description: Unauthorized
+  /intelligence/bandit/close:
+    post:
+      operationId: postIntelligenceBanditClose
+      summary: Close a sampled decision with its observed reward
+      responses:
+        "200":
+          description: Close result
+          content:
+            application/json:
+              schema:
+                type: object
+        "401":
+          description: Unauthorized
 
   /actions/{action}:
     post:

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -197,6 +197,8 @@ char *delegate_build_tier_context(const char *via_name, int tier_override, const
  * paths. Provider routing picks the cheapest enabled agent for the requested
  * provider and role, preferring the configured default agent on equal tier. */
 agent_t *delegate_route_by_provider(agent_config_t *cfg, const char *role, const char *provider);
+/* Highest cost_tier among enabled, role-capable agents (or -1 if none). */
+int delegate_max_cost_tier(agent_config_t *cfg, const char *role);
 /* Synthesize an ephemeral ACP delegate agent from an inline `--acp <command>`
  * (+ optional `--acp-args <args>`), append it to cfg, and return its generated
  * name via name_out. The agent uses the provider-cli backend with the "acp"

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -836,6 +836,15 @@ char *kb_client_bandit_export_json(void);
  * `result_json` must be a JSON object string (the replay-tool result). */
 char *kb_client_bandit_replay_record_json(const char *decision_point, const char *result_json);
 
+/* Server-side decision points reach the kb DB2 bandit through these. sample
+ * selects+logs an arm (returns 0 + fills arm_out/decision_id_out, or -1 when
+ * disabled/transport-failed); close records the reward [0,1] (best-effort). */
+int kb_client_bandit_sample(const char *decision_point, const char *const *arms, int n_arms,
+                            char *arm_out, size_t arm_out_len, char *decision_id_out,
+                            size_t decision_id_out_len);
+int kb_client_bandit_close(const char *decision_point, const char *decision_id, const char *arm_id,
+                           double reward);
+
 /* artifacts.list_proposed: list proposed artifacts by surface (NULL = all).
  * Returns heap-allocated JSON string; caller frees. */
 char *kb_client_artifacts_list_proposed_json(const char *target_surface, int limit);

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -804,6 +804,14 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return strcmp(method, "POST") == 0
                  ? kb_intel_bandit_replay_record_http(body, body_len, out_buf, out_cap)
                  : json_body_error(out_buf, out_cap, 405, "method not allowed");
+   if (strcmp(path, "/v1/intelligence/bandit/sample") == 0)
+      return strcmp(method, "POST") == 0
+                 ? kb_intel_bandit_sample_http(body, body_len, out_buf, out_cap)
+                 : json_body_error(out_buf, out_cap, 405, "method not allowed");
+   if (strcmp(path, "/v1/intelligence/bandit/close") == 0)
+      return strcmp(method, "POST") == 0
+                 ? kb_intel_bandit_close_http(body, body_len, out_buf, out_cap)
+                 : json_body_error(out_buf, out_cap, 405, "method not allowed");
    if (strncmp(path, "/v1/actions/", 12) == 0)
    {
       if (strcmp(method, "POST") != 0)

--- a/src/kb/kb_bandit_registry.c
+++ b/src/kb/kb_bandit_registry.c
@@ -26,6 +26,15 @@ static const kb_bandit_decision_point_t REGISTRY[] = {
         .reward_fn = "recall_sufficiency_v1",
         .status = "live",
     },
+    {
+        .id = "delegate_routing",
+        .description = "Delegate cost-tier preference when a sub-task is launched "
+                       "with no explicit --via/--tier/--provider override.",
+        .arms = {"cheapest", "premium"},
+        .n_arms = 2,
+        .reward_fn = "delegate_success_v1",
+        .status = "live",
+    },
 };
 
 int kb_bandit_registry_count(void)

--- a/src/kb/kb_intel_payload.c
+++ b/src/kb/kb_intel_payload.c
@@ -357,3 +357,140 @@ int kb_intel_bandit_replay_record_http(const char *body, int body_len, char *out
    free(json);
    return 200;
 }
+
+/* Serialize a response object into out_buf; returns the HTTP status. */
+static int intel_bandit_emit_http(cJSON *resp, char *out_buf, int out_cap)
+{
+   char *json = resp ? cJSON_PrintUnformatted(resp) : NULL;
+   cJSON_Delete(resp);
+   if (!json)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"status\":\"error\",\"message\":\"out of memory\"}");
+      return 500;
+   }
+   size_t n = strlen(json);
+   if (n >= (size_t)out_cap)
+   {
+      free(json);
+      snprintf(out_buf, (size_t)out_cap, "{\"status\":\"error\",\"message\":\"response too large\"}");
+      return 500;
+   }
+   memcpy(out_buf, json, n + 1);
+   free(json);
+   return 200;
+}
+
+/* bandit.sample: select an arm for a decision point (Thompson via the optimize
+ * sidecar), log the decision, and return {arm, decision_id}. Server-side
+ * decision points (e.g. delegate_routing) reach the DB2 bandit through this. */
+cJSON *kb_intel_bandit_sample_response(const char *body_json, int body_len)
+{
+   if (!body_json || body_len <= 0)
+      return intel_bandit_replay_err("missing body");
+   cJSON *body = cJSON_ParseWithLength(body_json, (size_t)body_len);
+   if (!body || !cJSON_IsObject(body))
+   {
+      cJSON_Delete(body);
+      return intel_bandit_replay_err("body must be a JSON object");
+   }
+   const char *dp = cJSON_GetStringValue(cJSON_GetObjectItem(body, "decision_point"));
+   cJSON *arms = cJSON_GetObjectItem(body, "arms");
+   if (!dp || !dp[0])
+   {
+      cJSON_Delete(body);
+      return intel_bandit_replay_err("decision_point is required");
+   }
+   if (!cJSON_IsArray(arms) || cJSON_GetArraySize(arms) < 1)
+   {
+      cJSON_Delete(body);
+      return intel_bandit_replay_err("arms (non-empty array) is required");
+   }
+   int total = cJSON_GetArraySize(arms);
+   char arm_ids[KB_BANDIT_MAX_ARMS][KB_BANDIT_MAX_ARM_ID];
+   int na = 0;
+   for (int i = 0; i < total && na < KB_BANDIT_MAX_ARMS; i++)
+   {
+      cJSON *a = cJSON_GetArrayItem(arms, i);
+      if (cJSON_IsString(a) && a->valuestring[0])
+         snprintf(arm_ids[na++], KB_BANDIT_MAX_ARM_ID, "%s", a->valuestring);
+   }
+   cJSON *ctx = cJSON_GetObjectItem(body, "context");
+   char *ctx_str = (ctx && cJSON_IsObject(ctx)) ? cJSON_PrintUnformatted(ctx) : NULL;
+
+   config_t cfg;
+   config_load(&cfg);
+   char decision_id[KB_BANDIT_MAX_DECISION] = {0};
+   int idx = (na >= 1) ? kb_bandit_sample(&cfg, dp, ctx_str, arm_ids, na, decision_id) : -1;
+   free(ctx_str);
+   cJSON_Delete(body);
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+      return NULL;
+   if (idx < 0 || idx >= na)
+   {
+      /* Sampling disabled (no optimize command) or failed — caller falls back to
+       * its default routing; no decision is logged. */
+      cJSON_AddStringToObject(resp, "status", "disabled");
+      return resp;
+   }
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "arm", arm_ids[idx]);
+   cJSON_AddStringToObject(resp, "decision_id", decision_id);
+   return resp;
+}
+
+/* bandit.close: close a logged decision with its observed reward [0,1] and update
+ * the arm posterior. */
+cJSON *kb_intel_bandit_close_response(const char *body_json, int body_len)
+{
+   if (!body_json || body_len <= 0)
+      return intel_bandit_replay_err("missing body");
+   cJSON *body = cJSON_ParseWithLength(body_json, (size_t)body_len);
+   if (!body || !cJSON_IsObject(body))
+   {
+      cJSON_Delete(body);
+      return intel_bandit_replay_err("body must be a JSON object");
+   }
+   const char *dp = cJSON_GetStringValue(cJSON_GetObjectItem(body, "decision_point"));
+   const char *did = cJSON_GetStringValue(cJSON_GetObjectItem(body, "decision_id"));
+   const char *arm = cJSON_GetStringValue(cJSON_GetObjectItem(body, "arm_id"));
+   cJSON *rj = cJSON_GetObjectItem(body, "reward");
+   if (!dp || !dp[0] || !did || !did[0] || !arm || !arm[0])
+   {
+      cJSON_Delete(body);
+      return intel_bandit_replay_err("decision_point, decision_id and arm_id are required");
+   }
+   double reward = cJSON_IsNumber(rj) ? rj->valuedouble : 0.0;
+   if (reward < 0.0)
+      reward = 0.0;
+   if (reward > 1.0)
+      reward = 1.0;
+
+   config_t cfg;
+   config_load(&cfg);
+   int rc = kb_bandit_reward(&cfg, dp, did, arm, reward);
+   cJSON_Delete(body);
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+      return NULL;
+   cJSON_AddStringToObject(resp, "status", rc == 0 ? "ok" : "error");
+   if (rc != 0)
+      cJSON_AddStringToObject(resp, "message", "failed to close decision");
+   return resp;
+}
+
+int kb_intel_bandit_sample_http(const char *body, int body_len, char *out_buf, int out_cap)
+{
+   if (!out_buf || out_cap <= 0)
+      return 500;
+   return intel_bandit_emit_http(kb_intel_bandit_sample_response(body, body_len), out_buf, out_cap);
+}
+
+int kb_intel_bandit_close_http(const char *body, int body_len, char *out_buf, int out_cap)
+{
+   if (!out_buf || out_cap <= 0)
+      return 500;
+   return intel_bandit_emit_http(kb_intel_bandit_close_response(body, body_len), out_buf, out_cap);
+}

--- a/src/kb_intel_payload.h
+++ b/src/kb_intel_payload.h
@@ -18,4 +18,12 @@ cJSON *kb_intel_bandit_replay_record_response(const char *body_json, int body_le
  * returns the HTTP status. */
 int kb_intel_bandit_replay_record_http(const char *body, int body_len, char *out_buf, int out_cap);
 
+/* bandit.sample / bandit.close: let server-side decision points reach the DB2
+ * bandit. sample selects+logs an arm ({arm, decision_id}); close records the
+ * observed reward [0,1]. Request/response objects (caller frees) + HTTP wrappers. */
+cJSON *kb_intel_bandit_sample_response(const char *body_json, int body_len);
+cJSON *kb_intel_bandit_close_response(const char *body_json, int body_len);
+int kb_intel_bandit_sample_http(const char *body, int body_len, char *out_buf, int out_cap);
+int kb_intel_bandit_close_http(const char *body, int body_len, char *out_buf, int out_cap);
+
 #endif /* DEC_KB_INTEL_PAYLOAD_H */

--- a/src/server/delegate_routing.c
+++ b/src/server/delegate_routing.c
@@ -150,6 +150,27 @@ agent_t *delegate_route_by_provider(agent_config_t *cfg, const char *role, const
    return best;
 }
 
+/* Highest cost_tier among enabled, routing-available agents that can serve the
+ * role (or -1 if none). Used by the delegate_routing bandit to translate a
+ * "premium" arm into a concrete tier_override, deployment-independently. */
+int delegate_max_cost_tier(agent_config_t *cfg, const char *role)
+{
+   int max_tier = -1;
+   if (!cfg)
+      return -1;
+   for (int i = 0; i < cfg->agent_count; i++)
+   {
+      agent_t *ag = &cfg->agents[i];
+      if (!ag->enabled || !agent_is_available_for_routing(ag))
+         continue;
+      if (role && !agent_has_role(ag, role) && !agent_is_exec_role(ag, role))
+         continue;
+      if (ag->cost_tier > max_tier)
+         max_tier = ag->cost_tier;
+   }
+   return max_tier;
+}
+
 static void route_err(char *errbuf, size_t errbuf_sz, const char *fmt, const char *a, const char *b)
 {
    if (errbuf && errbuf_sz > 0)

--- a/src/server/kb_client.c
+++ b/src/server/kb_client.c
@@ -1308,3 +1308,79 @@ char *kb_client_bandit_replay_record_json(const char *decision_point, const char
    cJSON_Delete(body);
    return resp ? resp : strdup("{\"status\":\"error\",\"message\":\"no response\"}");
 }
+
+/* Sample an arm for a server-side decision point via the kb DB2 bandit. On
+ * success (status "ok"), fills arm_out + decision_id_out and returns 0. Returns
+ * -1 when sampling is disabled (no optimize command), on transport failure, or
+ * on a malformed response — the caller falls back to its default behaviour. */
+int kb_client_bandit_sample(const char *decision_point, const char *const *arms, int n_arms,
+                            char *arm_out, size_t arm_out_len, char *decision_id_out,
+                            size_t decision_id_out_len)
+{
+   if (arm_out && arm_out_len)
+      arm_out[0] = '\0';
+   if (decision_id_out && decision_id_out_len)
+      decision_id_out[0] = '\0';
+   if (!decision_point || !decision_point[0] || !arms || n_arms < 1)
+      return -1;
+
+   cJSON *body = cJSON_CreateObject();
+   if (!body)
+      return -1;
+   cJSON_AddStringToObject(body, "decision_point", decision_point);
+   cJSON *aj = cJSON_CreateArray();
+   for (int i = 0; i < n_arms; i++)
+      if (arms[i] && arms[i][0])
+         cJSON_AddItemToArray(aj, cJSON_CreateString(arms[i]));
+   cJSON_AddItemToObject(body, "arms", aj);
+
+   int http_status = -1;
+   char *resp = kb_client_v1_post_json("/v1/intelligence/bandit/sample", body,
+                                       CLIENT_DEFAULT_TIMEOUT_MS, &http_status);
+   cJSON_Delete(body);
+   if (!resp)
+      return -1;
+   cJSON *r = cJSON_Parse(resp);
+   free(resp);
+   int rc = -1;
+   if (r)
+   {
+      const char *status = cJSON_GetStringValue(cJSON_GetObjectItem(r, "status"));
+      const char *arm = cJSON_GetStringValue(cJSON_GetObjectItem(r, "arm"));
+      const char *did = cJSON_GetStringValue(cJSON_GetObjectItem(r, "decision_id"));
+      if (status && strcmp(status, "ok") == 0 && arm && did)
+      {
+         if (arm_out && arm_out_len)
+            snprintf(arm_out, arm_out_len, "%s", arm);
+         if (decision_id_out && decision_id_out_len)
+            snprintf(decision_id_out, decision_id_out_len, "%s", did);
+         rc = 0;
+      }
+   }
+   cJSON_Delete(r);
+   return rc;
+}
+
+/* Close a sampled decision with its observed reward [0,1]. Best-effort: a failed
+ * close just means a missed learning sample, never a caller error. Returns 0. */
+int kb_client_bandit_close(const char *decision_point, const char *decision_id, const char *arm_id,
+                           double reward)
+{
+   if (!decision_point || !decision_point[0] || !decision_id || !decision_id[0] || !arm_id ||
+       !arm_id[0])
+      return -1;
+   cJSON *body = cJSON_CreateObject();
+   if (!body)
+      return -1;
+   cJSON_AddStringToObject(body, "decision_point", decision_point);
+   cJSON_AddStringToObject(body, "decision_id", decision_id);
+   cJSON_AddStringToObject(body, "arm_id", arm_id);
+   cJSON_AddNumberToObject(body, "reward", reward);
+
+   int http_status = -1;
+   char *resp = kb_client_v1_post_json("/v1/intelligence/bandit/close", body,
+                                       CLIENT_DEFAULT_TIMEOUT_MS, &http_status);
+   cJSON_Delete(body);
+   free(resp); /* best-effort */
+   return 0;
+}

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -21,6 +21,8 @@
 #include "delegate_economics.h"
 #include "delegate_run_phases.h"
 #include "db1/delegate_learning.h"
+#include "kb_client.h"
+#include "kb_bandit.h"
 #include "db1/interaction_events.h"
 #include "delegate_role.h"
 #include "guardrails.h"
@@ -734,6 +736,10 @@ void delegate_worker(void *arg)
    const char *acp_args = cJSON_IsString(jacp_args) ? jacp_args->valuestring : NULL;
    const char *provider_override = cJSON_IsString(jprovider) ? jprovider->valuestring : NULL;
    const char *model_override = cJSON_IsString(jmodel) ? jmodel->valuestring : NULL;
+   /* delegate_routing bandit: sampled at the route step below (gated, best-effort)
+    * and rewarded with the run outcome at exit. Empty unless a decision was made. */
+   char dr_decision_id[KB_BANDIT_MAX_DECISION] = {0};
+   char dr_arm_id[KB_BANDIT_MAX_ARM_ID] = {0};
    cJSON *jpersona = cJSON_GetObjectItemCaseSensitive(req, "persona");
    const char *persona_override = cJSON_IsString(jpersona) ? jpersona->valuestring : NULL;
    /* A persona is REQUIRED on every delegate request — it sets the delegate's
@@ -818,6 +824,31 @@ void delegate_worker(void *arg)
          required_caps |= inferred_caps;
          if (inferred_min_context > min_context)
             min_context = inferred_min_context;
+      }
+      /* delegate_routing bandit: when the caller gave no explicit route override,
+       * sample a cost-tier preference (cheapest vs premium) from the kb DB2 bandit
+       * and translate it into tier_override. Gated by bandit_live_decision_enabled
+       * (default off); best-effort, so a kb hiccup falls back to default routing. */
+      if (!acp_command && tier_override < 0 && !(via_name && via_name[0]) &&
+          !(provider_override && provider_override[0]) && !(model_override && model_override[0]))
+      {
+         config_t dr_cfg;
+         config_load(&dr_cfg);
+         if (dr_cfg.bandit_live_decision_enabled)
+         {
+            static const char *const dr_arms[2] = {"cheapest", "premium"};
+            if (kb_client_bandit_sample("delegate_routing", dr_arms, 2, dr_arm_id, sizeof(dr_arm_id),
+                                        dr_decision_id, sizeof(dr_decision_id)) == 0)
+            {
+               if (strcmp(dr_arm_id, "premium") == 0)
+               {
+                  int max_tier = delegate_max_cost_tier(&acfg, role);
+                  if (max_tier >= 0)
+                     tier_override = max_tier;
+               }
+               /* "cheapest" leaves tier_override = -1 (default cheapest routing). */
+            }
+         }
       }
       if (delegate_apply_route_overrides(&acfg, role, via_name, tier_override, provider_override,
                                          model_override, route_err, sizeof(route_err)) != 0 ||
@@ -1463,6 +1494,11 @@ void delegate_worker(void *arg)
 
    /* Classify and record a learning from this delegate exit. */
    delegate_record_exit_learning(sid, role, &result, rc, max_turns, &acfg, target_agent);
+
+   /* Close the delegate_routing bandit decision (if one was sampled) with the run
+    * outcome: success (rc == 0) -> 1.0, otherwise 0.0. Best-effort. */
+   if (dr_decision_id[0] && dr_arm_id[0])
+      kb_client_bandit_close("delegate_routing", dr_decision_id, dr_arm_id, rc == 0 ? 1.0 : 0.0);
 
    /* Reconcile delegate sibling-worktree edits via PR or supervisor review. */
    if (delegate_worktree_path[0] && delegate_git_root[0] && !delegate_allows_writes &&

--- a/src/tests/test_bandit.c
+++ b/src/tests/test_bandit.c
@@ -173,6 +173,13 @@ static void test_bandit_registry(void)
    assert(strcmp(fm->arms[0], "rrf") == 0);
    assert(strcmp(fm->status, "live") == 0);
 
+   /* delegate_routing (server-side decision point reached via the kb bandit). */
+   const kb_bandit_decision_point_t *dr = kb_bandit_registry_get("delegate_routing");
+   assert(dr != NULL);
+   assert(dr->n_arms == 2);
+   assert(strcmp(dr->arms[0], "cheapest") == 0);
+   assert(strcmp(dr->arms[1], "premium") == 0);
+
    /* Unknown id -> NULL; index access is bounds-checked. */
    assert(kb_bandit_registry_get("nope") == NULL);
    assert(kb_bandit_registry_get(NULL) == NULL);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -10,6 +10,7 @@
 #include "cJSON.h"
 #include "kb_http.h"
 #include "kb_service.h"
+#include "kb_bandit.h"
 #include "kb_service_backend.h"
 #include "kb_enroll.h"
 #include "kb_paths.h"
@@ -791,6 +792,31 @@ int db2_demotion_profile_read(const char *memory_class, const char *scope_kind,
    assert(strcmp(scope_kind, "global") == 0);
    assert(strcmp(scope_id, "") == 0);
    snprintf(buf, len, "{\"score_percentiles\":{\"p10\":0.5}}");
+   return 0;
+}
+
+/* kb_intel_payload's bandit.sample/close builders call these; this test does not
+ * link kb_bandit.o. Stub sample as "disabled" and reward as a no-op success. */
+int kb_bandit_sample(const config_t *cfg, const char *decision_point, const char *context_json,
+                     const char (*arm_ids)[KB_BANDIT_MAX_ARM_ID], int n_arms, char *decision_id_out)
+{
+   (void)cfg;
+   (void)decision_point;
+   (void)context_json;
+   (void)arm_ids;
+   (void)n_arms;
+   if (decision_id_out)
+      decision_id_out[0] = '\0';
+   return -1;
+}
+int kb_bandit_reward(const config_t *cfg, const char *decision_point, const char *decision_id,
+                     const char *arm_id, double reward)
+{
+   (void)cfg;
+   (void)decision_point;
+   (void)decision_id;
+   (void)arm_id;
+   (void)reward;
    return 0;
 }
 

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -387,6 +387,32 @@ const char *server_http_delegate_block(const char *session_id, const char *role,
 
 #include "test_server_compute_workspace_stubs.inc"
 
+/* delegate_routing reaches the kb DB2 bandit over kb_client, which this unit test
+ * does not link. Stub it as "sampling disabled" so delegate_worker falls back to
+ * default routing (and never closes a decision). */
+int kb_client_bandit_sample(const char *decision_point, const char *const *arms, int n_arms,
+                            char *arm_out, size_t arm_out_len, char *decision_id_out,
+                            size_t decision_id_out_len)
+{
+   (void)decision_point;
+   (void)arms;
+   (void)n_arms;
+   if (arm_out && arm_out_len)
+      arm_out[0] = '\0';
+   if (decision_id_out && decision_id_out_len)
+      decision_id_out[0] = '\0';
+   return -1;
+}
+int kb_client_bandit_close(const char *decision_point, const char *decision_id, const char *arm_id,
+                           double reward)
+{
+   (void)decision_point;
+   (void)decision_id;
+   (void)arm_id;
+   (void)reward;
+   return 0;
+}
+
 void concurrency_mgr_init(concurrency_mgr_t *mgr, int default_limit,
                           const concurrency_entry_t *per_model, int per_model_count,
                           const concurrency_entry_t *per_provider, int per_provider_count)


### PR DESCRIPTION
## Summary

**Optimization-surface P4 (the `delegate_routing` half) — route A: single DB2
store, no duplication.** The server reaches the existing kb DB2 bandit over
`kb_client` `/v1` (local Unix socket), rather than duplicating a bandit store into
DB1. Gated behind `bandit_live_decision_enabled` (**default off**); the kb calls
are **best-effort**, so a hiccup just falls back to default routing and never
stalls a delegate.

### Why route A (not a DB1 store)
Duplicating the bandit into DB1 would mean a second schema + accessor copy and a
**fractured `aimee optimize` view** (DB1 data invisible to the DB2-based export).
Route A keeps **one source of truth** — delegate_routing shows up in
`aimee optimize` like every other point — and the cross-process cost is a
sub-millisecond local-UDS round-trip against a multi-second delegate run, i.e.
negligible.

### kb side (DB2 owner)
- `kb_intel_payload.c`: `bandit.sample` (select + log an arm) and `bandit.close`
  (record reward) builders, wrapping `kb_bandit_sample` / `kb_bandit_reward`.
- `kb_http.c`: `POST /v1/intelligence/bandit/sample` + `/close`; documented in
  `openapi-v1.yaml`.
- `kb_bandit_registry.c`: register `delegate_routing` (arms `cheapest`/`premium`,
  reward `delegate_success_v1`).

### server side
- `kb_client.c`: `kb_client_bandit_sample` / `kb_client_bandit_close` wrappers.
- `delegate_routing.c`: `delegate_max_cost_tier()` translates `premium` → the
  highest available tier, deployment-independently.
- `server_compute.c` (`delegate_worker`): with no explicit `--via/--tier/--provider`,
  sample the cost-tier preference → `tier_override`; at the run's exit, close the
  decision with the outcome (`rc == 0` → 1.0 else 0.0).

## Tests / gates
- Full `cd src && make unit-tests` green; **all six** `/v1` + conformance gates
  green (the #124 surfacing gate now sees 6 intelligence routes, all surfaced).
- Registry test covers `delegate_routing`; `sample`/`close` stubbed in the two
  tests that link the callers without `kb_bandit`/`kb_client`.

Production behaviour unchanged (gated off).

This completes optimization-surface P4 (both `kb_fusion_mode` #127 and
`delegate_routing` here).
