### PR TITLE
style: fix lint — clang-format cmd_optimize.c + kb_intel_payload.c

### DIFF
--- a/src/cmd_optimize.c
+++ b/src/cmd_optimize.c
@@ -249,7 +249,9 @@ static int optimize_cmd_replay_record(int argc, char **argv, int json_output)
          file = argv[i + 1];
    if (!point || !file)
    {
-      fprintf(stderr, "usage: aimee optimize replay-record --point <decision_point> --file <result.json>\n");
+      fprintf(
+          stderr,
+          "usage: aimee optimize replay-record --point <decision_point> --file <result.json>\n");
       return 2;
    }
    char *raw = optimize_slurp(file);
@@ -677,7 +679,7 @@ static int optimize_cmd_promote(int argc, char **argv, int json_output)
       cJSON_AddStringToObject(rb, "rollback_arm", applied ? applied_rb : incumbent);
       cJSON_AddItemToObject(out, "rollback", rb);
       cJSON_AddStringToObject(out, "applied",
-                             applied ? "yes" : (blocked ? "blocked" : (apply ? "failed" : "no")));
+                              applied ? "yes" : (blocked ? "blocked" : (apply ? "failed" : "no")));
       optimize_print_json(out);
       cJSON_Delete(out);
       cJSON_Delete(resp);
@@ -706,15 +708,18 @@ static int optimize_cmd_promote(int argc, char **argv, int json_output)
 
 static void optimize_usage(void)
 {
-   fprintf(stderr,
-           "Usage: aimee optimize <subcommand> [options]\n\nSubcommands:\n"
-           "  points                              List registered decision points\n"
-           "  baseline --point <name>             Show current arm posteriors for a point\n"
-           "  replay --point <name>               Emit a point's closed-decision log for replay\n"
-           "  replay-record --point <name> --file <f>  Record a replay result (benchmark_trace)\n"
-           "  run [--suite <s>] [--arm <a>]       Run the offline benchmark suite (ranks baseline vs on)\n"
-           "  compare --baseline <a> --candidate <b> [--suite <s>]  Per-metric delta between two arms\n"
-           "  promote --point <p> --candidate <a> [--guarded] [--suite <s>] [--apply]  Gate (and optionally apply) a promotion\n");
+   fprintf(
+       stderr,
+       "Usage: aimee optimize <subcommand> [options]\n\nSubcommands:\n"
+       "  points                              List registered decision points\n"
+       "  baseline --point <name>             Show current arm posteriors for a point\n"
+       "  replay --point <name>               Emit a point's closed-decision log for replay\n"
+       "  replay-record --point <name> --file <f>  Record a replay result (benchmark_trace)\n"
+       "  run [--suite <s>] [--arm <a>]       Run the offline benchmark suite (ranks baseline vs "
+       "on)\n"
+       "  compare --baseline <a> --candidate <b> [--suite <s>]  Per-metric delta between two arms\n"
+       "  promote --point <p> --candidate <a> [--guarded] [--suite <s>] [--apply]  Gate (and "
+       "optionally apply) a promotion\n");
 }
 
 int cmd_optimize_run(int argc, char **argv, int json_output)

--- a/src/kb/kb_intel_payload.c
+++ b/src/kb/kb_intel_payload.c
@@ -372,7 +372,8 @@ static int intel_bandit_emit_http(cJSON *resp, char *out_buf, int out_cap)
    if (n >= (size_t)out_cap)
    {
       free(json);
-      snprintf(out_buf, (size_t)out_cap, "{\"status\":\"error\",\"message\":\"response too large\"}");
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"status\":\"error\",\"message\":\"response too large\"}");
       return 500;
    }
    memcpy(out_buf, json, n + 1);
@@ -536,5 +537,6 @@ int kb_intel_bandit_promote_http(const char *body, int body_len, char *out_buf, 
 {
    if (!out_buf || out_cap <= 0)
       return 500;
-   return intel_bandit_emit_http(kb_intel_bandit_promote_response(body, body_len), out_buf, out_cap);
+   return intel_bandit_emit_http(kb_intel_bandit_promote_response(body, body_len), out_buf,
+                                 out_cap);
 }


### PR DESCRIPTION
## Summary

Fixes the `make lint` / CI **lint** failure on `testing` — pre-existing
clang-format violations in `cmd_optimize.c` (14) and `kb/kb_intel_payload.c` (2),
left behind by the optimize/bandit work. Pure `clang-format-19` reformatting, no
logic change.

This restores a green lint so it can stop being bypassed.

## Verification
- `make -C src lint` → **exit 0** (format + line-check + charter-tables +
  proposal-links + schema-sync + conformance + sdk-parity + all gates).
- Both files recompile clean under `-Werror`.

Note: a broader sweep found ~40 additional format-violating files that are NOT in
`LINT_SRCS` (mostly headers), so they don't block CI; those can be a separate
cosmetic pass if desired.
