### PR TITLE
style: clang-format the remaining tree (headers + windows sources)

### DIFF
--- a/src/cli_help_data.h
+++ b/src/cli_help_data.h
@@ -207,7 +207,8 @@
      "  replay-record --point <n> --file <f>  Record a replay result (benchmark_trace)\n"
      "  run [--suite <s>] [--arm <a>]   Run the offline benchmark suite (ranks baseline vs on)\n"
      "  compare --baseline <a> --candidate <b>  Per-metric delta between two arms\n"
-     "  promote --point <p> --candidate <a> [--guarded] [--apply]  Gate/apply a promotion (credible interval)\n"},
+     "  promote --point <p> --candidate <a> [--guarded] [--apply]  Gate/apply a promotion "
+     "(credible interval)\n"},
     {"code", "Code-health audit", CLIENT_TIER_ADVANCED, 0,
      "  audit [dir] [--json]   File-health audit (untested files, TODO/FIXME\n"
      "                         markers, debt score) over the working tree\n"

--- a/src/db1/conv_context.h
+++ b/src/db1/conv_context.h
@@ -31,16 +31,15 @@ typedef struct
 } conv_tool_chain_t;
 
 /* Record a tool call event. Returns the new event id (>0) or -1 on error. */
-int64_t db1_conv_record_event(const char *session_id, const char *tool_name,
-                              const char *tool_input, const char *tool_result, int result_bytes);
+int64_t db1_conv_record_event(const char *session_id, const char *tool_name, const char *tool_input,
+                              const char *tool_result, int result_bytes);
 
 /* Assign chain_id to a range of events. Returns 0 on success. */
 int db1_conv_set_chain_id(int64_t event_id_first, int64_t event_id_last, int64_t chain_id);
 
 /* Insert a new chain. Returns the new chain id (>0) or -1 on error. */
-int64_t db1_conv_insert_chain(const char *session_id, int64_t event_id_first,
-                              int64_t event_id_last, const char *tools, const char *stub,
-                              int raw_bytes, int stub_bytes);
+int64_t db1_conv_insert_chain(const char *session_id, int64_t event_id_first, int64_t event_id_last,
+                              const char *tools, const char *stub, int raw_bytes, int stub_bytes);
 
 /* Load events not yet assigned to a chain for a session.
  * Returns count; populates out[] up to max entries. */

--- a/src/db1/coord_jobs.h
+++ b/src/db1/coord_jobs.h
@@ -55,8 +55,8 @@ extern "C"
    } db1_coord_job_t;
 
    int db1_coord_job_create(int plan_id, int max_concurrent);
-   int db1_coord_job_add_task(int job_id, int step_id, const char *files_json,
-                              const char *role, const char *prompt, const char *cwd);
+   int db1_coord_job_add_task(int job_id, int step_id, const char *files_json, const char *role,
+                              const char *prompt, const char *cwd);
    int db1_coord_job_claim_next(int job_id, const char *delegate_name, db1_coord_task_t *out);
    int db1_coord_job_complete_task(int task_id, const char *result);
    int db1_coord_job_fail_task(int task_id, const char *error);
@@ -70,11 +70,10 @@ extern "C"
    int db1_coord_job_list_recent(db1_coord_job_t *out, int max);
    /* List IDs of coord jobs with pending or running tasks (needs dispatch work). */
    int db1_coord_job_list_active_ids(int *out_ids, int max);
-   /* Read the dispatch fields (role, prompt, files, cwd) for a single task. Returns 0 on success. */
-   int db1_coord_task_get_dispatch(int task_id,
-                                   char *role_out, size_t role_cap,
-                                   char *prompt_out, size_t prompt_cap,
-                                   char *files_out, size_t files_cap,
+   /* Read the dispatch fields (role, prompt, files, cwd) for a single task. Returns 0 on success.
+    */
+   int db1_coord_task_get_dispatch(int task_id, char *role_out, size_t role_cap, char *prompt_out,
+                                   size_t prompt_cap, char *files_out, size_t files_cap,
                                    char *cwd_out, size_t cwd_cap);
 
 #ifdef __cplusplus

--- a/src/db1/cron_jobs.h
+++ b/src/db1/cron_jobs.h
@@ -93,7 +93,7 @@ extern "C"
 
    /* Update a run row on completion. */
    int db1_cron_job_run_complete(int64_t run_id, int64_t completed_at, const char *status,
-                                  int silent, const char *output, const char *error);
+                                 int silent, const char *output, const char *error);
 
    /* Mark a run as delivered. */
    int db1_cron_job_run_mark_delivered(int64_t run_id);
@@ -103,8 +103,8 @@ extern "C"
 
    /* List recent runs for a job (most recent first). Pass 0 for limit to get
     * all. Returns 0 on success, -1 on error. */
-   int db1_cron_job_run_history(const char *job_id, int limit, db1_cron_job_run_t *out,
-                                 int max_out, int *out_count);
+   int db1_cron_job_run_history(const char *job_id, int limit, db1_cron_job_run_t *out, int max_out,
+                                int *out_count);
 
 #ifdef __cplusplus
 }

--- a/src/db1/delegate_learning.h
+++ b/src/db1/delegate_learning.h
@@ -5,7 +5,8 @@
 #include <stdint.h>
 
 /* Failure modes a delegate can exit with */
-typedef enum {
+typedef enum
+{
    DL_MODE_SUCCESS,           /* delegate completed successfully */
    DL_MODE_STALL_NO_WRITES,   /* write_enforce fired, 0 writes */
    DL_MODE_STALL_SLOW_WRITES, /* write_enforce fired but eventually wrote */
@@ -16,20 +17,22 @@ typedef enum {
 } dl_failure_mode_t;
 
 /* Metrics captured at delegate exit for classification */
-typedef struct {
+typedef struct
+{
    const char *session_id;
    const char *role;
    int turns;
    int tool_calls;
-   int success;         /* 1 if rc==0, 0 otherwise */
-   int had_writes;      /* 1 if any files were written */
+   int success;             /* 1 if rc==0, 0 otherwise */
+   int had_writes;          /* 1 if any files were written */
    int write_enforce_fired; /* 1 if write_enforce triggered */
-   int max_turns_limit; /* the max_turns cap that was set */
-   const char *error;   /* error string if failure */
+   int max_turns_limit;     /* the max_turns cap that was set */
+   const char *error;       /* error string if failure */
 } dl_exit_metrics_t;
 
 /* Classified result from classify_delegate_exit */
-typedef struct {
+typedef struct
+{
    dl_failure_mode_t failure_mode;
    double confidence;
    char lesson[512];    /* human-readable lesson */

--- a/src/db1/mcp_osv_cache.h
+++ b/src/db1/mcp_osv_cache.h
@@ -9,10 +9,10 @@ extern "C"
 {
 #endif
 
-#define DB1_MCP_OSV_TEXT_LEN     256
-#define DB1_MCP_OSV_VERDICT_LEN  16
-#define DB1_MCP_OSV_ACTION_LEN   32
-#define DB1_MCP_OSV_CHECKED_LEN  32
+#define DB1_MCP_OSV_TEXT_LEN    256
+#define DB1_MCP_OSV_VERDICT_LEN 16
+#define DB1_MCP_OSV_ACTION_LEN  32
+#define DB1_MCP_OSV_CHECKED_LEN 32
 
    typedef struct
    {

--- a/src/db1/session_state.h
+++ b/src/db1/session_state.h
@@ -31,8 +31,8 @@ extern "C"
    /* Returns 1 if a session_state row exists for sid, 0 otherwise. */
    int db1_session_state_exists(const char *sid);
 
-#define DB1_SS_SID_LEN       64
-#define DB1_SS_STATE_TS_LEN  32
+#define DB1_SS_SID_LEN      64
+#define DB1_SS_STATE_TS_LEN 32
 
    typedef struct
    {
@@ -48,8 +48,8 @@ extern "C"
    int db1_session_state_get_summary(const char *sid, db1_session_state_summary_t *out);
 
    /* List session ids older than threshold_seconds. Returns ids written. */
-   int db1_session_state_list_expired(int threshold_seconds,
-                                      char (*out_ids)[DB1_SS_SID_LEN], int max);
+   int db1_session_state_list_expired(int threshold_seconds, char (*out_ids)[DB1_SS_SID_LEN],
+                                      int max);
 
 #ifdef __cplusplus
 }

--- a/src/db1/workflow_session.h
+++ b/src/db1/workflow_session.h
@@ -46,14 +46,14 @@ extern "C"
    int db1_workflow_role_needs_dissent(const char *role);
 
    int db1_workflow_session_create(const char *project_root, const char *template_name,
-                                   const char *channel, cJSON *assignments, int *out_id,
-                                   char *err, size_t errlen);
+                                   const char *channel, cJSON *assignments, int *out_id, char *err,
+                                   size_t errlen);
    int db1_workflow_session_get(int id, workflow_session_info_t *out, char **prompt_out,
                                 char **context_out, char *err, size_t errlen);
    int db1_workflow_session_pause(int id, const char *reason, char *err, size_t errlen);
    int db1_workflow_session_advance(int id, const char *sender, const char *text,
-                                    workflow_session_info_t *out, char **prompt_out,
-                                    char *err, size_t errlen);
+                                    workflow_session_info_t *out, char **prompt_out, char *err,
+                                    size_t errlen);
    int db1_workflow_session_list(workflow_session_info_t **out, int *out_count, char *err,
                                  size_t errlen);
    int db1_workflow_session_find_current_by_channel(const char *channel, int *out_id, char *err,

--- a/src/db2/curator_gaps.h
+++ b/src/db2/curator_gaps.h
@@ -13,7 +13,7 @@ extern "C"
 {
 #endif
 
-int db2_corpus_detect_gaps(int64_t doc_id);
+   int db2_corpus_detect_gaps(int64_t doc_id);
 
 #ifdef __cplusplus
 }

--- a/src/db2/curator_terms.h
+++ b/src/db2/curator_terms.h
@@ -12,7 +12,7 @@ extern "C"
 {
 #endif
 
-int db2_corpus_normalize_terms(int64_t doc_id);
+   int db2_corpus_normalize_terms(int64_t doc_id);
 
 #ifdef __cplusplus
 }

--- a/src/db2/kb_vectors.h
+++ b/src/db2/kb_vectors.h
@@ -5,12 +5,12 @@
 
 const char *pgvec_kb_vector_collection_name(void);
 int pgvec_kb_vector_upsert_document(int64_t doc_id, const float *vec, int dim,
-                                  const char *payload_json);
+                                    const char *payload_json);
 int pgvec_kb_vector_upsert_document_batch(const int64_t *doc_ids, const float *vecs, int dim,
-                                        const char *const *payloads, int count);
+                                          const char *const *payloads, int count);
 int pgvec_kb_vector_delete_point(int64_t point_id);
 int pgvec_kb_vector_delete_project(const char *project);
 int pgvec_kb_vector_search_project(const char *project, const float *vec, int dim, int limit,
-                                 int64_t *ids, double *scores, int max);
+                                   int64_t *ids, double *scores, int max);
 
 #endif /* DEC_DB2_KB_VECTORS_H */

--- a/src/db2/memory_promotion.h
+++ b/src/db2/memory_promotion.h
@@ -32,9 +32,8 @@ extern "C"
     * otherwise only rows outside that slot are eligible. Falls back to the
     * regular kind promotion when slot_modulo <= 0. */
    int db2_memory_promotion_promote_kind_slot(const char *ts, const char *kind,
-                                              int promote_use_count,
-                                              double promote_confidence, int slot_modulo,
-                                              int slot_remainder, int slot_match);
+                                              int promote_use_count, double promote_confidence,
+                                              int slot_modulo, int slot_remainder, int slot_match);
 
    /* L2 -> L1 demotion for a single kind, gated by confidence and idle days
     * (`days_neg_str` is "-N", embedded into `datetime('now', ?||' days')`).

--- a/src/db2/memory_vectors.h
+++ b/src/db2/memory_vectors.h
@@ -10,15 +10,15 @@ int pgvec_memory_vector_collection_recreate(int dim);
 int pgvec_memory_vector_ensure_payload_indexes(void);
 const char *pgvec_memory_vector_collection_name(void);
 int pgvec_memory_vector_upsert_memory(int64_t memory_id, const float *vec, int dim,
-                                    const char *payload_json);
+                                      const char *payload_json);
 int pgvec_memory_vector_upsert_unit(int64_t unit_id, const float *vec, int dim,
-                                  const char *payload_json);
+                                    const char *payload_json);
 int pgvec_memory_vector_delete_point(int64_t point_id);
 int pgvec_memory_vector_search_record_type(const char *record_type, const float *vec, int dim,
-                                         int limit, int64_t *ids, double *scores, int max);
+                                           int limit, int64_t *ids, double *scores, int max);
 int pgvec_memory_vector_search_with_kinds(const float *vec, int dim, const char *const *kinds,
-                                        int n_kinds, int limit, int64_t *ids, double *scores,
-                                        int max);
+                                          int n_kinds, int limit, int64_t *ids, double *scores,
+                                          int max);
 void pgvec_memory_vector_scope_hint_set(const char *workspace, const char *project);
 void pgvec_memory_vector_scope_hint_clear(void);
 

--- a/src/db2/notes.h
+++ b/src/db2/notes.h
@@ -37,8 +37,8 @@ extern "C"
 
    /* Create or append to a note. If a note with the same slug exists, appends
     * content to it. Returns 0 on success, -1 on error. */
-   int db2_note_create(const char *title, const char *content, const char *tags,
-                       const char *author, note_t *out);
+   int db2_note_create(const char *title, const char *content, const char *tags, const char *author,
+                       note_t *out);
 
    /* List notes, optionally filtered by tag. Returns count written to out. */
    int db2_note_list(const char *tag, int limit, note_t *out, int max);

--- a/src/headers/agent_coord.h
+++ b/src/headers/agent_coord.h
@@ -1,7 +1,6 @@
 #ifndef DEC_AGENT_COORD_H
 #define DEC_AGENT_COORD_H 1
 
-
 #include "agent_types.h"
 #include "agent_tasks.h"
 #include "db1.h"

--- a/src/headers/agent_tasks.h
+++ b/src/headers/agent_tasks.h
@@ -1,7 +1,6 @@
 #ifndef DEC_AGENT_TASKS_H
 #define DEC_AGENT_TASKS_H 1
 
-
 #include "agent_types.h"
 
 typedef struct

--- a/src/headers/cli_codex.h
+++ b/src/headers/cli_codex.h
@@ -39,10 +39,10 @@ extern "C"
       const char *cwd;           /* optional: child process working directory */
       const char *system_prompt; /* optional: developerInstructions on new threads */
       const char *user_prompt;
-      const char *model; /* optional: turn-level model override */
+      const char *model;            /* optional: turn-level model override */
       const char *reasoning_effort; /* optional: low/medium/high/xhigh */
-      int timeout_ms; /* idle timeout; <0 disables while caller stays attached */
-      int autonomous; /* auto-approve Codex client approval requests */
+      int timeout_ms;               /* idle timeout; <0 disables while caller stays attached */
+      int autonomous;               /* auto-approve Codex client approval requests */
    } cli_codex_chat_request_t;
 
    typedef struct
@@ -59,7 +59,7 @@ extern "C"
    {
       const char *thread_id; /* required: Codex thread to compact */
       const char *cwd;       /* optional: child process working directory */
-      int timeout_ms; /* idle timeout; <0 disables while caller stays attached */
+      int timeout_ms;        /* idle timeout; <0 disables while caller stays attached */
       int autonomous;
    } cli_codex_compact_request_t;
 

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -4,47 +4,48 @@
 #include <time.h>
 #include <stddef.h>
 
-#define CLI_SESSION_NAME_MAX   128
-#define CLI_SESSION_CMD_MAX    256
-#define CLI_SESSION_BUF_MAX    (256 * 1024)
-#define CLI_SESSION_POLL_MS    500      /* poll interval for completion detection */
-#define CLI_SESSION_STABLE_N   3        /* consecutive stable polls to declare done */
+#define CLI_SESSION_NAME_MAX 128
+#define CLI_SESSION_CMD_MAX  256
+#define CLI_SESSION_BUF_MAX  (256 * 1024)
+#define CLI_SESSION_POLL_MS  500 /* poll interval for completion detection */
+#define CLI_SESSION_STABLE_N 3   /* consecutive stable polls to declare done */
 
-typedef struct {
-    char session_name[CLI_SESSION_NAME_MAX];  /* tmux session name */
-    char cli_cmd[CLI_SESSION_CMD_MAX];        /* CLI command that was started */
-    int reuse;                                /* 1 = reuse across tasks */
-    time_t last_activity;
-    int active;                               /* 1 = session exists */
+typedef struct
+{
+   char session_name[CLI_SESSION_NAME_MAX]; /* tmux session name */
+   char cli_cmd[CLI_SESSION_CMD_MAX];       /* CLI command that was started */
+   int reuse;                               /* 1 = reuse across tasks */
+   time_t last_activity;
+   int active; /* 1 = session exists */
 } cli_session_t;
 
 /* --- Lifecycle --- */
 /* Creates (or attaches to existing) tmux session, starts CLI.
  * session_name must be unique (e.g. "aimee-<agent>-<taskid>").
  * Returns 0 on success, -1 on failure. */
-int  cli_session_create(cli_session_t *s, const char *session_name,
-                        const char *cli_cmd, const char *work_dir, int reuse);
+int cli_session_create(cli_session_t *s, const char *session_name, const char *cli_cmd,
+                       const char *work_dir, int reuse);
 
 /* Kills the tmux session. No-op if already dead. */
 void cli_session_destroy(cli_session_t *s);
 
 /* Returns 1 if the tmux session still exists, 0 otherwise. */
-int  cli_session_is_alive(const cli_session_t *s);
+int cli_session_is_alive(const cli_session_t *s);
 
 /* --- Send/Receive --- */
 /* Sends message to the CLI via tmux paste-buffer + Enter.
  * Returns 0 on success. */
-int  cli_session_send(cli_session_t *s, const char *message);
+int cli_session_send(cli_session_t *s, const char *message);
 
 /* Captures the current tmux pane contents immediately.
  * Writes captured text to out (NUL-terminated). Returns 0 on success,
  * -1 on error. */
-int  cli_session_capture(cli_session_t *s, char *out, size_t out_max);
+int cli_session_capture(cli_session_t *s, char *out, size_t out_max);
 
 /* Polls capture-pane until output stabilises (hash-based) or session dies.
  * Writes captured text to out (NUL-terminated). Returns 0 on success,
  * -1 if the session exits before output stabilises. */
-int  cli_session_recv(cli_session_t *s, char *out, size_t out_max);
+int cli_session_recv(cli_session_t *s, char *out, size_t out_max);
 
 /* --- Session name helpers --- */
 /* Build a deterministic session name: "aimee-<agent>-<hash(role)>".

--- a/src/headers/compute_pool.h
+++ b/src/headers/compute_pool.h
@@ -4,10 +4,10 @@
 #include <pthread.h>
 #include <stdint.h>
 
-#define COMPUTE_QUEUE_SIZE         128
-#define COMPUTE_QUEUE_HIGH_PCT     80
-#define COMPUTE_QUEUE_LOW_PCT      50
-#define POOL_SLOT_DESCRIPTOR_MAX   128
+#define COMPUTE_QUEUE_SIZE       128
+#define COMPUTE_QUEUE_HIGH_PCT   80
+#define COMPUTE_QUEUE_LOW_PCT    50
+#define POOL_SLOT_DESCRIPTOR_MAX 128
 
 typedef struct
 {
@@ -102,8 +102,8 @@ const char *pool_job_kind_name(pool_job_kind_t kind);
  * pool is reported. Concurrent registrations of the same `pool` overwrite
  * the previous entry in place.
  */
-#define COMPUTE_POOL_REGISTRY_MAX  8
-#define COMPUTE_POOL_NAME_MAX      32
+#define COMPUTE_POOL_REGISTRY_MAX 8
+#define COMPUTE_POOL_NAME_MAX     32
 
 void compute_pool_register_secondary(compute_pool_t *pool, const char *name);
 void compute_pool_unregister_secondary(compute_pool_t *pool);

--- a/src/headers/delegate_driver.h
+++ b/src/headers/delegate_driver.h
@@ -11,11 +11,12 @@ struct cJSON;
 #define DRIVER_URL_MAX 1024
 
 /* Capability flags */
-#define DRIVER_CAP_TOOL_CALLS   (1 << 0) /* native JSON tool calling */
-#define DRIVER_CAP_STREAMING    (1 << 1) /* streaming responses */
-#define DRIVER_CAP_VISION       (1 << 2) /* image inputs */
-#define DRIVER_CAP_SYSTEM_MSG   (1 << 3) /* system message in request body (vs. messages array) */
-#define DRIVER_CAP_PROMPT_CACHE (1 << 4) /* provider-side prompt caching (e.g. Gemini cachedContent) */
+#define DRIVER_CAP_TOOL_CALLS (1 << 0) /* native JSON tool calling */
+#define DRIVER_CAP_STREAMING  (1 << 1) /* streaming responses */
+#define DRIVER_CAP_VISION     (1 << 2) /* image inputs */
+#define DRIVER_CAP_SYSTEM_MSG (1 << 3) /* system message in request body (vs. messages array) */
+#define DRIVER_CAP_PROMPT_CACHE                                                                    \
+   (1 << 4) /* provider-side prompt caching (e.g. Gemini cachedContent) */
 
 /* Context window sizes (in tokens) for capability metadata */
 #define DRIVER_CTX_SMALL  4096

--- a/src/headers/delegate_launch.h
+++ b/src/headers/delegate_launch.h
@@ -13,7 +13,6 @@ typedef struct
 } delegate_launch_result_t;
 
 int delegate_launch_coord_job(cJSON *plan, int max_concurrent, const char *cwd,
-                              delegate_launch_result_t *out,
-                              char *errbuf, size_t errbuf_len);
+                              delegate_launch_result_t *out, char *errbuf, size_t errbuf_len);
 
 #endif /* DEC_DELEGATE_LAUNCH_H */

--- a/src/headers/kb.h
+++ b/src/headers/kb.h
@@ -8,7 +8,9 @@
 #define KB_GLOB_MAX 512
 
 /* Default include/exclude patterns */
-#define KB_DEFAULT_INCLUDE "**/*.md,**/*.txt,**/*.rst,**/*.c,**/*.h,**/*.cpp,**/*.hpp,**/*.py,**/*.go,**/*.rs,**/*.js,**/*.ts,**/*.tsx,**/*.jsx,**/*.sh,**/*.yaml,**/*.yml,**/*.toml"
+#define KB_DEFAULT_INCLUDE                                                                         \
+   "**/*.md,**/*.txt,**/*.rst,**/*.c,**/*.h,**/*.cpp,**/*.hpp,**/*.py,**/*.go,**/*.rs,**/*.js,**/" \
+   "*.ts,**/*.tsx,**/*.jsx,**/*.sh,**/*.yaml,**/*.yml,**/*.toml"
 #define KB_DEFAULT_EXCLUDE "node_modules/**,vendor/**,.git/**,build/**,dist/**"
 
 /* Chunking defaults */

--- a/src/headers/kb_doc_hash.h
+++ b/src/headers/kb_doc_hash.h
@@ -3,5 +3,4 @@
 
 #define KB_DOC_HASH_HEX_LEN 64
 
-void kb_doc_content_hash(const char *bytes, int nbytes,
-                         char out[KB_DOC_HASH_HEX_LEN + 1]);
+void kb_doc_content_hash(const char *bytes, int nbytes, char out[KB_DOC_HASH_HEX_LEN + 1]);

--- a/src/headers/kb_http.h
+++ b/src/headers/kb_http.h
@@ -28,5 +28,5 @@ int kb_http_route(const char *method, const char *path, const char *auth_header,
  * POST endpoints and path-parameter routes.
  * query_string and body may be NULL. out_buf must be at least out_cap bytes. */
 int kb_http_route_ex(const char *method, const char *path, const char *query_string,
-                     const char *auth_header, const char *bearer_token,
-                     const char *body, int body_len, char *out_buf, int out_cap);
+                     const char *auth_header, const char *bearer_token, const char *body,
+                     int body_len, char *out_buf, int out_cap);

--- a/src/headers/lsp.h
+++ b/src/headers/lsp.h
@@ -104,8 +104,8 @@ int lsp_manager_references(const char *workspace, const char *file, int line, in
  * Returns the number of files modified, or -1 on error (check errbuf).
  */
 int lsp_manager_rename(const char *workspace, const char *file, int line, int col,
-                       const char *new_name, char *out, size_t out_size,
-                       char *errbuf, size_t errbuf_size);
+                       const char *new_name, char *out, size_t out_size, char *errbuf,
+                       size_t errbuf_size);
 
 /*
  * lsp_manager_diag_summary() — aggregate diagnostic counts and active server

--- a/src/headers/mcp_client_registry.h
+++ b/src/headers/mcp_client_registry.h
@@ -35,8 +35,8 @@ cJSON *mcp_client_registry_build_namespaced_tools(int timeout_ms);
 
 /* Lookup a single namespaced remote tool schema. On success, |*out_tool|
  * receives a duplicated MCP-style tool object with a namespaced "name". */
-int mcp_client_registry_get_tool_schema(const char *qualified_name, int timeout_ms, cJSON **out_tool,
-                                        char *err_buf, size_t err_buf_len);
+int mcp_client_registry_get_tool_schema(const char *qualified_name, int timeout_ms,
+                                        cJSON **out_tool, char *err_buf, size_t err_buf_len);
 
 /* Dispatch a namespaced remote tool call to the matching live MCP client. */
 int mcp_client_registry_call_tool(const char *qualified_name, const cJSON *args, int timeout_ms,

--- a/src/headers/memory_ontology.h
+++ b/src/headers/memory_ontology.h
@@ -22,46 +22,46 @@
 
 typedef enum
 {
-   NODE_FILE          = 0,
-   NODE_FUNCTION      = 1,
-   NODE_STRUCT        = 2,
-   NODE_MODULE        = 3,
-   NODE_BUG           = 4,
-   NODE_COMMIT        = 5,
-   NODE_PR            = 6,
-   NODE_DEVELOPER     = 7,
-   NODE_CONCEPT       = 8,
-   NODE_EVENT         = 9,
-   NODE_PERSON        = 10,
-   NODE_PLACE         = 11,
-   NODE_TIME_EXPR     = 12,
-   NODE_OTHER         = 99
+   NODE_FILE = 0,
+   NODE_FUNCTION = 1,
+   NODE_STRUCT = 2,
+   NODE_MODULE = 3,
+   NODE_BUG = 4,
+   NODE_COMMIT = 5,
+   NODE_PR = 6,
+   NODE_DEVELOPER = 7,
+   NODE_CONCEPT = 8,
+   NODE_EVENT = 9,
+   NODE_PERSON = 10,
+   NODE_PLACE = 11,
+   NODE_TIME_EXPR = 12,
+   NODE_OTHER = 99
 } memory_node_kind_t;
 
 /* ---- Relation kinds ----------------------------------------------------- */
 
 typedef enum
 {
-   REL_DEPENDS_ON      = 0,
-   REL_IMPLEMENTS      = 1,
-   REL_FIXES           = 2,
-   REL_INTRODUCED_BY   = 3,
-   REL_TESTS           = 4,
-   REL_CALLS           = 5,
-   REL_MUTATES         = 6,
+   REL_DEPENDS_ON = 0,
+   REL_IMPLEMENTS = 1,
+   REL_FIXES = 2,
+   REL_INTRODUCED_BY = 3,
+   REL_TESTS = 4,
+   REL_CALLS = 5,
+   REL_MUTATES = 6,
    REL_PARTICIPATED_IN = 7,
-   REL_OCCURRED_AT     = 8,
-   REL_AUTHORED_BY     = 9,
-   REL_SUPERSEDES      = 10,
-   REL_CO_EDITED       = 11,  /* collaborative edit relation */
-   REL_CO_DISCUSSED    = 12,  /* collaborative discussion relation */
-   REL_SUMMARISES      = 13,
-   REL_OTHER           = 99
+   REL_OCCURRED_AT = 8,
+   REL_AUTHORED_BY = 9,
+   REL_SUPERSEDES = 10,
+   REL_CO_EDITED = 11,    /* collaborative edit relation */
+   REL_CO_DISCUSSED = 12, /* collaborative discussion relation */
+   REL_SUMMARISES = 13,
+   REL_OTHER = 99
 } memory_relation_kind_t;
 
 /* Bitmask helpers for memory_graph_walk relation filtering.
  * Use RELATION_MASK(x) to build a mask, then pass to memory_graph_walk(). */
-#define RELATION_MASK(r) (1u << (unsigned)(r))
+#define RELATION_MASK(r)  (1u << (unsigned)(r))
 #define RELATION_MASK_ALL (~0u)
 
 /* ---- Ontology helpers --------------------------------------------------- */
@@ -85,8 +85,7 @@ const char *memory_ontology_node_kind_to_text(memory_node_kind_t kind);
 /* Validate a (subject_kind, relation_id, object_kind) triple against the
  * static schema.  Returns 1 if valid (or if the schema table is empty /
  * relation is REL_OTHER), 0 if invalid. */
-int memory_ontology_validate(memory_node_kind_t subject_kind,
-                              memory_relation_kind_t relation,
-                              memory_node_kind_t object_kind);
+int memory_ontology_validate(memory_node_kind_t subject_kind, memory_relation_kind_t relation,
+                             memory_node_kind_t object_kind);
 
 #endif /* DEC_MEMORY_ONTOLOGY_H */

--- a/src/headers/memory_profile_pack.h
+++ b/src/headers/memory_profile_pack.h
@@ -23,9 +23,9 @@ extern "C"
       char description[MEMORY_PROFILE_PACK_DESC_LEN];
       /* Optional narrowing — empty means "all allowed". */
       char allowed_tiers[MEMORY_PROFILE_PACK_MAX_TIERS][4];
-      int  allowed_tier_count;
+      int allowed_tier_count;
       char allowed_kinds[MEMORY_PROFILE_PACK_MAX_KINDS][16];
-      int  allowed_kind_count;
+      int allowed_kind_count;
       /* Optional defaults */
       char default_tier[4];
       char default_visibility[16]; /* "default" | "strict" | "expanded" */
@@ -41,8 +41,8 @@ extern "C"
 
    /* Load a named pack from the pack directory into |out|.
     * Returns 0 on success, -1 if not found or invalid. */
-   int memory_profile_pack_load(const char *name, memory_profile_pack_t *out,
-                                char *errbuf, size_t errlen);
+   int memory_profile_pack_load(const char *name, memory_profile_pack_t *out, char *errbuf,
+                                size_t errlen);
 
    /* List available pack names into |names|.  Each slot is a NUL-terminated
     * string up to MEMORY_PROFILE_PACK_NAME_LEN.

--- a/src/headers/oauth_pkce.h
+++ b/src/headers/oauth_pkce.h
@@ -29,8 +29,7 @@
 /* Base64url-encode (RFC 4648 §5) |inlen| bytes from |in| into |out|.
  * No padding is emitted. |outlen| must be at least 4*ceil(inlen/3) - pad + 1.
  * Returns 0 on success, -1 if |out| is too small or args are invalid. */
-int oauth_pkce_base64url_encode(const unsigned char *in, size_t inlen,
-                                char *out, size_t outlen);
+int oauth_pkce_base64url_encode(const unsigned char *in, size_t inlen, char *out, size_t outlen);
 
 /* Fill |out| with a PKCE code_verifier of exactly |len| characters
  * (43..128). |out| must have room for |len| + 1 bytes (NUL terminator).
@@ -63,7 +62,6 @@ typedef struct
  *
  * Returns the number of bytes written (excluding NUL) on success,
  * or -1 if |out| is too small or required fields are missing. */
-int oauth_pkce_build_auth_url(const oauth_pkce_auth_request_t *req,
-                              char *out, size_t outlen);
+int oauth_pkce_build_auth_url(const oauth_pkce_auth_request_t *req, char *out, size_t outlen);
 
 #endif /* DEC_OAUTH_PKCE_H */

--- a/src/headers/otel.h
+++ b/src/headers/otel.h
@@ -75,8 +75,8 @@ void otel_flush(void);
  *   direction  "response"  → end the current turn span and flush
  *   direction  "tool_call" → emit a child span for a single tool execution
  * tool_name / tool_args / tool_result are used for tool_call spans only. */
-void otel_on_trace(const char *direction, const char *tool_name,
-                   const char *tool_args, const char *tool_result, int turn);
+void otel_on_trace(const char *direction, const char *tool_name, const char *tool_args,
+                   const char *tool_result, int turn);
 
 /* Convenience wrappers for delegation spans.
  * Call otel_delegation_start() before running the delegate; capture the

--- a/src/headers/proxy_bootstrap.h
+++ b/src/headers/proxy_bootstrap.h
@@ -6,8 +6,8 @@
 #ifndef DEC_PROXY_BOOTSTRAP_H
 #define DEC_PROXY_BOOTSTRAP_H 1
 
-#define PROXY_HOST_LEN       256
-#define PROXY_AUTH_LEN       256
+#define PROXY_HOST_LEN      256
+#define PROXY_AUTH_LEN      256
 #define PROXY_NO_PROXY_LEN  4096
 #define PROXY_CA_BUNDLE_LEN 1024
 
@@ -22,10 +22,10 @@ typedef struct
 /* Full proxy context derived from the environment */
 typedef struct
 {
-   proxy_config_t https_proxy;             /* resolved HTTPS proxy */
-   int has_proxy;                          /* 1 if a proxy was found */
-   char no_proxy[PROXY_NO_PROXY_LEN];      /* merged NO_PROXY list */
-   char ca_bundle[PROXY_CA_BUNDLE_LEN];    /* CA bundle path, or empty */
+   proxy_config_t https_proxy;          /* resolved HTTPS proxy */
+   int has_proxy;                       /* 1 if a proxy was found */
+   char no_proxy[PROXY_NO_PROXY_LEN];   /* merged NO_PROXY list */
+   char ca_bundle[PROXY_CA_BUNDLE_LEN]; /* CA bundle path, or empty */
 } proxy_bootstrap_t;
 
 /* Parse a proxy URL string into a proxy_config_t.

--- a/src/headers/report_enrichment.h
+++ b/src/headers/report_enrichment.h
@@ -5,8 +5,8 @@
 
 struct cJSON;
 
-#define REPORT_SUBJECT_TYPE_GIT_REPO "git_repo"
-#define REPORT_SUBJECT_TYPE_GIT_ORG "git_org"
+#define REPORT_SUBJECT_TYPE_GIT_REPO  "git_repo"
+#define REPORT_SUBJECT_TYPE_GIT_ORG   "git_org"
 #define REPORT_SUBJECT_TYPE_AGGREGATE "aggregate"
 
 typedef struct report_subject

--- a/src/headers/workspace_manifest.h
+++ b/src/headers/workspace_manifest.h
@@ -12,9 +12,9 @@
 
 #define WORKSPACE_MANIFEST_FILENAME "aimee.workspace.yaml"
 
-#define MANIFEST_MAX_REPOS     32
-#define MANIFEST_MAX_DEP_CMDS  16
-#define MANIFEST_MAX_SECRETS   16
+#define MANIFEST_MAX_REPOS    32
+#define MANIFEST_MAX_DEP_CMDS 16
+#define MANIFEST_MAX_SECRETS  16
 
 /* A single repository entry declared in the manifest. */
 typedef struct
@@ -38,14 +38,14 @@ typedef struct
 
 typedef struct
 {
-   manifest_repo_t    repos[MANIFEST_MAX_REPOS];
-   int                repo_count;
+   manifest_repo_t repos[MANIFEST_MAX_REPOS];
+   int repo_count;
 
    manifest_dep_cmd_t dep_cmds[MANIFEST_MAX_DEP_CMDS];
-   int                dep_cmd_count;
+   int dep_cmd_count;
 
-   manifest_secret_t  secrets[MANIFEST_MAX_SECRETS];
-   int                secret_count;
+   manifest_secret_t secrets[MANIFEST_MAX_SECRETS];
+   int secret_count;
 
    /* quickstart knobs (both default to 1 when absent) */
    int index;          /* 1 = index discovered projects */

--- a/src/headers/workspace_runner_registry.h
+++ b/src/headers/workspace_runner_registry.h
@@ -13,7 +13,7 @@
  * the registry is the rendezvous between "the server wants a file op done" and
  * "the client is here to do it". Bounded (64 live detached workspaces). */
 
-#define WS_RUNNER_REGISTRY_MAX  64
+#define WS_RUNNER_REGISTRY_MAX   64
 #define WS_RUNNER_REGISTRY_IDLEN 128
 
 /* Return the queue for `id`, creating (and initializing) it on first use.

--- a/src/kb/kb_service_code_embed.h
+++ b/src/kb/kb_service_code_embed.h
@@ -8,22 +8,22 @@
 /* Result returned by code embedding refresh operations. */
 typedef struct
 {
-   int      accepted;        /* 1 if job accepted (may be async) */
-   char     job_id[128];     /* job identifier (empty for sync) */
-   char     project[256];    /* project name */
-   char     scope[64];       /* "changed_files" | "full_project" | "paths" */
-   int64_t  estimated_points; /* estimated new/changed embeddings */
-   int64_t  skipped_unchanged; /* rows skipped due to matching content_hash */
-   int64_t  embedded;        /* rows actually embedded */
-   int      dry_run;         /* 1 if dry_run requested */
-   char     writer[64];      /* "kb_service" */
+   int accepted;              /* 1 if job accepted (may be async) */
+   char job_id[128];          /* job identifier (empty for sync) */
+   char project[256];         /* project name */
+   char scope[64];            /* "changed_files" | "full_project" | "paths" */
+   int64_t estimated_points;  /* estimated new/changed embeddings */
+   int64_t skipped_unchanged; /* rows skipped due to matching content_hash */
+   int64_t embedded;          /* rows actually embedded */
+   int dry_run;               /* 1 if dry_run requested */
+   char writer[64];           /* "kb_service" */
 } kb_code_embed_result_t;
 
 /* Build deterministic fallback text for a file from code-index facts.
  * Includes path, definitions, and bounded (≤5) calls + imports.
  * out must hold at least cap bytes.  Returns bytes written. */
-int kb_code_embed_build_fallback_text(const char *project, const char *file_path,
-                                      int64_t file_id, char *out, size_t cap);
+int kb_code_embed_build_fallback_text(const char *project, const char *file_path, int64_t file_id,
+                                      char *out, size_t cap);
 
 /* Run code embedding refresh for a project.
  * scope: "changed_files" | "full_project"

--- a/src/kb_curator_extract.h
+++ b/src/kb_curator_extract.h
@@ -4,8 +4,8 @@
 typedef struct
 {
    char extract_command[512];
-   int  max_tokens;
-   int  max_attempts;
+   int max_tokens;
+   int max_attempts;
 } kb_curator_extract_opts_t;
 
 /* Claim and process one pending extract_doc job.

--- a/src/kb_curator_queue.h
+++ b/src/kb_curator_queue.h
@@ -9,11 +9,10 @@
 int kb_curator_queue_docs_for_project(const char *project);
 
 /* Queue one extract_code_unit job when the curator code gate is enabled. */
-int kb_curator_queue_code_unit(const char *project, const char *file_path,
-                               const char *symbol, int line);
+int kb_curator_queue_code_unit(const char *project, const char *file_path, const char *symbol,
+                               int line);
 
 /* Bulk-enqueue extract_code_unit jobs for indexed terms in a project. */
-int kb_curator_queue_code_units_for_project(const char *project,
-                                            const char *root_path);
+int kb_curator_queue_code_units_for_project(const char *project, const char *root_path);
 
 #endif /* DEC_KB_CURATOR_QUEUE_H */

--- a/src/posix/agent_tools_internal.h
+++ b/src/posix/agent_tools_internal.h
@@ -19,17 +19,15 @@ static inline int agent_tools_cmd_refers_to_readonly_root(const char *cmd, const
    size_t rw_len = rw ? strlen(rw) : 0;
    for (const char *p = cmd; (p = strstr(p, ro)); p++)
    {
-      int before_ok = (p == cmd) || p[-1] == '\'' || p[-1] == '"' || p[-1] == '=' ||
-                      p[-1] == ':' || p[-1] == ',' || p[-1] == '(' || p[-1] == '[' ||
-                      p[-1] == '{' || p[-1] == '<' || p[-1] == ' ' || p[-1] == '\t' ||
-                      p[-1] == '\n';
+      int before_ok = (p == cmd) || p[-1] == '\'' || p[-1] == '"' || p[-1] == '=' || p[-1] == ':' ||
+                      p[-1] == ',' || p[-1] == '(' || p[-1] == '[' || p[-1] == '{' ||
+                      p[-1] == '<' || p[-1] == ' ' || p[-1] == '\t' || p[-1] == '\n';
       int after_ok = p[ro_len] == '/' || p[ro_len] == '\'' || p[ro_len] == '"' ||
-                     p[ro_len] == ':' || p[ro_len] == ',' || p[ro_len] == ')' ||
-                     p[ro_len] == ']' || p[ro_len] == '}' || p[ro_len] == '>' ||
-                     p[ro_len] == ' ' || p[ro_len] == '\t' || p[ro_len] == '\n' ||
-                     p[ro_len] == '\0';
-      int under_rw = rw_len && strncmp(p, rw, rw_len) == 0 &&
-                     (p[rw_len] == '/' || p[rw_len] == '\0');
+                     p[ro_len] == ':' || p[ro_len] == ',' || p[ro_len] == ')' || p[ro_len] == ']' ||
+                     p[ro_len] == '}' || p[ro_len] == '>' || p[ro_len] == ' ' ||
+                     p[ro_len] == '\t' || p[ro_len] == '\n' || p[ro_len] == '\0';
+      int under_rw =
+          rw_len && strncmp(p, rw, rw_len) == 0 && (p[rw_len] == '/' || p[rw_len] == '\0');
       if (before_ok && after_ok && !under_rw)
          return 1;
    }

--- a/src/windows/agent_bridge.c
+++ b/src/windows/agent_bridge.c
@@ -26,9 +26,8 @@ int agent_http_post(const char *url, const char *auth_header, const char *body, 
                                        response_buf, timeout_ms, extra_headers);
 }
 
-int agent_http_post_content_type(const char *url, const char *auth_header,
-                                 const char *content_type, const char *body,
-                                 char **response_buf, int timeout_ms,
+int agent_http_post_content_type(const char *url, const char *auth_header, const char *content_type,
+                                 const char *body, char **response_buf, int timeout_ms,
                                  const char *extra_headers)
 {
    (void)extra_headers; /* Phase 2: add WinHTTP extra headers support */
@@ -77,7 +76,8 @@ int agent_http_post_content_type(const char *url, const char *auth_header,
    }
 
    /* Add headers */
-   const char *ct = content_type && content_type[0] ? content_type : "Content-Type: application/json";
+   const char *ct =
+       content_type && content_type[0] ? content_type : "Content-Type: application/json";
    wchar_t wct[512];
    MultiByteToWideChar(CP_UTF8, 0, ct, -1, wct, 512);
    WinHttpAddRequestHeaders(req, wct, -1, WINHTTP_ADDREQ_FLAG_ADD);

--- a/src/windows/cmd_agent_delegate.c
+++ b/src/windows/cmd_agent_delegate.c
@@ -31,8 +31,7 @@ void platform_delegate_run_background(
       if (parent_worktree_head && parent_worktree_head[0])
          cJSON_AddStringToObject(obj, "parent_worktree_head", parent_worktree_head);
       if (parent_worktree_fingerprint && parent_worktree_fingerprint[0])
-         cJSON_AddStringToObject(obj, "parent_worktree_fingerprint",
-                                 parent_worktree_fingerprint);
+         cJSON_AddStringToObject(obj, "parent_worktree_fingerprint", parent_worktree_fingerprint);
       char *json = cJSON_Print(obj);
       if (json)
       {

--- a/src/windows/platform_net.c
+++ b/src/windows/platform_net.c
@@ -8,7 +8,12 @@
 #include <winsock2.h>
 #include <ws2tcpip.h>
 
-#define NETDBG(...) do { if (getenv("AIMEE_NET_DEBUG")) fprintf(stderr, "[net] " __VA_ARGS__); } while (0)
+#define NETDBG(...)                                                                                \
+   do                                                                                              \
+   {                                                                                               \
+      if (getenv("AIMEE_NET_DEBUG"))                                                               \
+         fprintf(stderr, "[net] " __VA_ARGS__);                                                    \
+   } while (0)
 
 /* Winsock requires one-time initialization before any socket call. Bring it up
  * lazily on first connect; the single startup is intentionally never paired


### PR DESCRIPTION
## Summary

Final clang-format cleanup so the whole `src` tree is clang-format-19 clean. 41
files (38 hand-written headers + 3 `windows/*.c`) that were **not** in `LINT_SRCS`
(so they never gated CI) but were the last violators. Pure reformatting, no logic
change.

## Verification
- `clang-format-19 --dry-run -Werror` clean on all 41.
- server + kb + thin client build clean under `-Werror`; `make -C src lint` → exit 0.
- Windows sources verified by the windows CI jobs.
