### PR TITLE
docs: complete CLI + configuration reference (generated from source)

### DIFF
--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -1,5 +1,16 @@
 # Command Reference
 
+> **Complete, always-current references** (generated from the source-of-truth
+> tables — see [`gen/cli-commands.md`](gen/cli-commands.md) and
+> [`gen/configuration.md`](gen/configuration.md)):
+> - **[Full CLI command list](gen/cli-commands.md)** — every command + subcommands,
+>   from `src/cli_help_data.h`.
+> - **[Configuration reference](gen/configuration.md)** — every config key (the
+>   `aimee config get/set` allowlist + the config-file JSON sections).
+>
+> This page is a hand-written walkthrough of the common commands; the generated
+> pages above are the authoritative, exhaustive lists.
+
 `aimee` is a thin CLI. It either handles a small local-only operation
 or forwards a typed request to `aimee-server`. Commands that are not listed
 here are not part of the client contract until they have a typed server route.

--- a/docs/gen/cli-commands.md
+++ b/docs/gen/cli-commands.md
@@ -1,0 +1,567 @@
+# CLI Command Reference
+
+> Auto-generated from `src/cli_help_data.h` by `scripts/gen-reference-docs.py`.
+> Do not edit by hand; run `make -C src docs-gen` to regenerate.
+
+`aimee` is a thin client: each command either runs a small local operation or forwards a typed request to `aimee-server`. Server-backed commands accept `--json` for machine-readable output. Run `aimee help <command>` for per-command help, or `aimee help --all` for every tier.
+
+Total commands: 50
+
+## Core commands
+
+### `aimee chat`
+
+Start the aimee primary-agent chat.
+
+Subcommands:
+
+```
+  [message...]     Send one message, or start an interactive chat with no message
+```
+
+### `aimee config`
+
+View and update configuration.
+
+Subcommands:
+
+```
+  show             Show all config values
+  get <key>        Get one config value
+  set <key> <val>  Set one config value
+```
+
+### `aimee delegate`
+
+Delegate a task to a sub-agent.
+
+Subcommands:
+
+```
+  <role> "prompt"   Run a delegate in <role>: code, review, explain,
+                   refactor, draft, execute, summarize, format, search,
+                   diagnose, validate. Aliases: implement/build -> code,
+                   test/check -> validate, inspect -> diagnose,
+                   research -> execute. REQUIRES --persona NAME (e.g.
+                   engineer, qa, security, reviewer, architect). --tools
+                   enables tool use for roles that do not enable it by
+                   default. See `aimee delegate <role> --help` for the full
+                   flag set (--persona, --context-file, --via, etc.).
+  plan             Generate read-only work packets from a proposal
+  launch <plan>    Queue a reviewed packet plan into a coord job
+  status <job_id> [job_id...]  Check background delegate status
+
+Use `aimee jobs list|status|logs|cancel` for durable background delegate jobs.
+```
+
+### `aimee help`
+
+Show help for a command.
+
+### `aimee hooks`
+
+Pre/post tool hooks.
+
+### `aimee index`
+
+Code indexing.
+
+Subcommands:
+
+```
+  find             Find a symbol or identifier
+  overview         List indexed projects
+  list             List indexed projects
+  scan             Scan workspaces and (re)build the index (--force)
+  blast-radius     Show files affected by changes to a file
+  structure        Show file structure
+  callers          Find callers of a symbol
+```
+
+### `aimee init`
+
+Run server initialization.
+
+### `aimee insights`
+
+Token usage totals over the last N days (--days N, default 30).
+
+### `aimee kb`
+
+Project knowledge base.
+
+Subcommands:
+
+```
+  search <query>   Search the knowledge base
+  build            Build the knowledge base for a project
+  update           Update the knowledge base
+  ingest           Ingest documents (status: ingest status)
+  status           Show knowledge-base status
+  docs push        Push docs into the knowledge base
+```
+
+### `aimee manuscript`
+
+Novel-mode manuscript tools.
+
+### `aimee mcp`
+
+MCP registry and OSV package gate.
+
+Subcommands:
+
+```
+  audit            List registered MCP servers and last OSV verdict
+  recheck [name]   Force a fresh OSV query for all servers or one name
+```
+
+### `aimee memory`
+
+Stored memory.
+
+Subcommands:
+
+```
+  search           Search stored memory
+  store            Store a memory
+  list             List memories
+  get              Read a memory by id
+  read             Assemble current memory context
+```
+
+### `aimee rules`
+
+Rule management (list, generate, delete).
+
+Subcommands:
+
+```
+  list             List active rules
+  generate         Generate a rules prompt
+  delete           Delete one rule
+```
+
+### `aimee session-start`
+
+SessionStart hook entry point.
+
+### `aimee skill`
+
+Project-scoped skill context injection.
+
+Subcommands:
+
+```
+  list             List available skills
+  show <name>      Print a skill body or support file
+  create           Create a project skill from a markdown file
+  patch            Patch a project skill by string replacement
+  lifecycle        Apply stale/archive lifecycle transitions
+  autostub         Propose capability skills for uncovered tools
+```
+
+### `aimee toolset`
+
+Composable named toolsets.
+
+Subcommands:
+
+```
+  list             List named toolsets
+  show <name>      Show a toolset definition
+  resolve <name>   Print the resolved tool list
+```
+
+### `aimee version`
+
+Print version.
+
+### `aimee wm`
+
+Working memory (session-scoped scratch).
+
+Subcommands:
+
+```
+  set              Store a value
+  get              Read a value
+  list             List values
+```
+
+## Advanced commands
+
+### `aimee agent`
+
+Sub-agent management.
+
+Subcommands:
+
+```
+  list             List configured delegates
+  add              Add or update a delegate provider
+  local            Register/update a local OpenAI-compatible delegate
+                   (--provider openai|llama-eval for request shaping)
+  remove           Remove a configured delegate
+  enable           Enable a configured delegate
+  disable          Disable a configured delegate
+  probe            Probe delegate endpoint, slots, and execution
+```
+
+### `aimee api`
+
+Inspect the public /v1 HTTP API (aimee.api.*).
+
+Subcommands:
+
+```
+  status           Show the loopback /v1 listener config and emit VS Code /
+                   OpenAI-compatible model-provider setup snippets
+```
+
+### `aimee claude-proxy`
+
+Route Claude Code through aimee's primary model.
+
+Subcommands:
+
+```
+  enable [url] [token]  Point Claude Code at aimee's /v1/messages ingress
+                        (url/token default to AIMEE_SERVER_URL/AIMEE_SERVER_TOKEN);
+                        reroutes ALL Claude Code sessions to your primary agent
+  disable               Restore Claude Code to its default endpoint
+```
+
+### `aimee code`
+
+Code-health audit.
+
+Subcommands:
+
+```
+  audit [dir] [--json]   File-health audit (untested files, TODO/FIXME
+                         markers, debt score) over the working tree
+  audit --graph [--project P] [--json]   Graph-derived checks via aimee-kb
+                         (dead exports, import cycles, clones)
+```
+
+### `aimee cron`
+
+Cron jobs and watchdog runs.
+
+Subcommands:
+
+```
+  list             List configured cron jobs
+  add <id>         Add or update a cron job
+  show <id>        Show one configured cron job
+  run <id>         Run one cron job now
+  history <id>     Show recent cron job runs
+  enable <id>      Enable a cron job
+  disable <id>     Disable a cron job (--all for rollback)
+  remove <id>      Remove a cron job
+```
+
+### `aimee curator`
+
+Knowledge curator queries.
+
+Subcommands:
+
+```
+  implements <topic>   What implements a topic
+  synthesize <topic>   Synthesize knowledge on a topic
+  contradictions       List contradictions
+```
+
+### `aimee delegate-backend`
+
+Inspect/drive delegate execution backends.
+
+Subcommands:
+
+```
+  list             List registered backends (local, ssh, docker, ...)
+  exec             Run a command through a backend
+                   --backend X --task-id Y [--image I] [--host H]
+                   [--no-hibernate] "<cmd>"
+```
+
+### `aimee dogfood`
+
+Qualitative memory/dogfood review reports.
+
+Subcommands:
+
+```
+  tag              Label one dogfood record
+  review           Summarize review state and close armed reminders
+  report           Build a monthly dogfood report (--month YYYY-MM, --json)
+```
+
+### `aimee episode`
+
+Delegation episodes.
+
+Subcommands:
+
+```
+  list             List recent delegation episodes
+```
+
+### `aimee graph`
+
+Code-graph projection and explain.
+
+Subcommands:
+
+```
+  sync-code        Project the code graph
+  explain          Explain a code-graph relationship
+```
+
+### `aimee hud`
+
+Real-time session status and HUD.
+
+### `aimee identity`
+
+Charter and working-profile inspection.
+
+Subcommands:
+
+```
+  show             Show charter, local operator, and working profile
+  snapshot         Write a working-profile snapshot (--out DIR)
+  diff             Compare two snapshots (--flip-threshold N)
+```
+
+### `aimee job`
+
+Coordinated parallel job management.
+
+Subcommands:
+
+```
+  start <plan_id>  Create a coordinated job from an execution plan
+  list             List recent coordinated jobs (--limit N)
+  status <job_id>  Show coordinated job progress and tasks
+  show <job_id>    Alias for status
+  cancel <job_id>  Cancel a coordinated job and pending tasks
+```
+
+### `aimee jobs`
+
+Durable delegate job inspection.
+
+Subcommands:
+
+```
+  list             List recent delegate jobs (--limit N)
+  status <job_id>  Show one delegate job, including heartbeat/tool state
+  show <job_id>    Alias for status
+  logs <job_id>    Print the recorded delegate result/log body
+  cancel <job_id>  Cooperatively cancel a queued or running delegate job
+```
+
+### `aimee model`
+
+Model capability metadata.
+
+Subcommands:
+
+```
+  list             List known models (--capability <name>, --open-weights)
+  show <model>     Show context, cost, flags, cutoff, deprecation
+  refresh          Refresh model metadata cache
+```
+
+### `aimee optimize`
+
+Bandit optimization loop.
+
+Subcommands:
+
+```
+  points                          List registered decision points
+  baseline --point <name>         Show current arm posteriors for a point
+  replay --point <name>           Emit a point's closed-decision log for replay
+  replay-record --point <n> --file <f>  Record a replay result (benchmark_trace)
+  run [--suite <s>] [--arm <a>]   Run the offline benchmark suite (ranks baseline vs on)
+  compare --baseline <a> --candidate <b>  Per-metric delta between two arms
+  promote --point <p> --candidate <a> [--guarded] [--apply]  Gate/apply a promotion (credible interval)
+```
+
+### `aimee profile`
+
+Manage aimee profiles (create/list/show/delete/current).
+
+Subcommands:
+
+```
+  create <name>    Create a profile directory
+  list             List profiles
+  show <name>      Show profile details
+  delete <name>    Delete a profile (--force for non-interactive use)
+  current          Print the active profile name
+```
+
+### `aimee provider`
+
+Model provider profiles and catalogs.
+
+Subcommands:
+
+```
+  list             List registered providers (--available, --json)
+  show <name>      Show provider profile details
+  models <name>    Fetch provider model catalog (--json)
+  test <name>      Probe provider credentials and connectivity
+  quota [name]     Show process-local credential pool quota state
+```
+
+### `aimee remote`
+
+Point the thin client at a remote aimee-server.
+
+Subcommands:
+
+```
+  set <url> [token]  Persist a remote server target
+  status             Show the resolved transport and a health probe
+  clear              Revert to the local Unix socket
+```
+
+### `aimee server`
+
+Manage the local aimee-server.
+
+Subcommands:
+
+```
+  start            Spawn aimee-server if not running
+                   (use systemctl --user start aimee-server on systemd
+                    boxes; this command is the cross-platform fallback)
+  restart          SIGTERM the running server and spawn a fresh one
+                   (run after update.sh, or when versions drift)
+```
+
+### `aimee session`
+
+Session history.
+
+Subcommands:
+
+```
+  list             List recent sessions
+  show             Show one session
+  close            Close one session
+  brief            Show a persisted session-start brief
+```
+
+### `aimee status`
+
+System health overview.
+
+### `aimee trajectory`
+
+Replayable session trajectories.
+
+Subcommands:
+
+```
+  export           Export a session trajectory
+  batch            Export trajectories in batch
+```
+
+### `aimee trigger`
+
+Event-triggered autopilot runs.
+
+Subcommands:
+
+```
+  fire             Queue a trigger run
+  list             List trigger runs
+  status           Show one trigger run
+  cancel           Cancel a queued trigger run
+```
+
+### `aimee work`
+
+Inter-session work queue.
+
+Subcommands:
+
+```
+  add              Add a work item to the queue
+  add-batch        Batch-add items (--from-proposals)
+  claim            Claim the next pending item
+  complete         Mark claimed item as done
+  fail             Mark claimed item as failed
+  list             List work items
+  cancel           Cancel a pending item
+  release          Release a claimed item back to pending
+  clear            Remove items by status
+  gc               Release stale claims
+  sync-proposals   Close items whose proposal moved out of pending/
+  stats            Show queue statistics
+```
+
+### `aimee workspace`
+
+Workspace management (add, list, remove).
+
+Subcommands:
+
+```
+  add <path>       Register a directory as a workspace and index its projects
+  list             List configured workspaces and their indexed projects
+  remove <path>    Unregister a workspace
+```
+
+### `aimee worktree`
+
+Manage session worktrees (gc abandoned ones).
+
+Subcommands:
+
+```
+  gc               Garbage-collect abandoned session worktrees
+                   (--days N, default 14; --force; --dry-run)
+```
+
+## Admin commands
+
+### `aimee acp-serve`
+
+ACP stdio server (Agent Client Protocol) for editors like Zed.
+
+### `aimee clean`
+
+Remove local aimee configuration and integrations.
+
+### `aimee eval`
+
+Eval harness.
+
+Subcommands:
+
+```
+  run <suite_dir>  Run an eval suite (--ablation <preset|all>, --runs N)
+  results [suite]  Show recent eval results
+```
+
+### `aimee git`
+
+Git helpers.
+
+Subcommands:
+
+```
+  verify           Verify the current changes before merge
+```
+
+### `aimee mcp-serve`
+
+MCP stdio bridge to aimee-server.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -1,0 +1,153 @@
+# Configuration Reference
+
+> Auto-generated from `src/config_fields.c` and the `src/config*.c` parsers by `scripts/gen-reference-docs.py`. Do not edit by hand; run `make -C src docs-gen` to regenerate.
+
+Configuration lives in the per-`AIMEE_HOME` config store. Scalar keys in the table below are settable from the CLI:
+
+```
+aimee config show                 # print the effective config
+aimee config get <key>            # read one value
+aimee config set <key> <value>    # set one value
+```
+
+Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
+
+## CLI-settable keys (87)
+
+| Key | Type |
+|-----|------|
+| `autonomous` | bool |
+| `cache_aware_rewrite_enabled` | bool |
+| `claude_model` | string |
+| `cross_verify` | bool |
+| `db2_url` | string |
+| `dogfood_autolabel_continuation` | bool |
+| `dogfood_autolabel_repair` | bool |
+| `dogfood_autolabel_repeat_question` | bool |
+| `dogfood_commit_raw` | bool |
+| `dogfood_enabled` | bool |
+| `dogfood_inline_tagging` | bool |
+| `dogfood_log_dir` | string |
+| `ecomode` | bool |
+| `embedding_command` | string |
+| `embedding_dim` | int |
+| `embedding_endpoint` | string |
+| `embedding_model` | string |
+| `guardrail_mode` | string |
+| `guardrails_semantic_allow_ml_only_block` | bool |
+| `guardrails_semantic_block_threshold` | float |
+| `guardrails_semantic_command` | string |
+| `guardrails_semantic_dry_run` | bool |
+| `guardrails_semantic_enabled` | bool |
+| `guardrails_semantic_prompt_threshold` | float |
+| `guardrails_semantic_warn_threshold` | float |
+| `identity_working_profile_injection_enabled` | bool |
+| `ingress_preinject_enabled` | bool |
+| `integrity_dry_run` | bool |
+| `integrity_enabled` | bool |
+| `kb_api_bearer_token` | string |
+| `kb_api_http_port` | int |
+| `kb_mining_enabled` | bool |
+| `kb_mining_min_poll_s` | int |
+| `kb_search_max_results` | int |
+| `learning_implicit_citation_continuation` | bool |
+| `learning_implicit_citation_repair` | bool |
+| `learning_implicit_repeat_question` | bool |
+| `learning_implicit_repeated_correction` | bool |
+| `learning_implicit_workflow_repetition` | bool |
+| `learning_max_commits_per_week` | int |
+| `learning_proposal_ttl_days` | int |
+| `learning_router_enabled` | bool |
+| `max_iterations` | int |
+| `max_iterations_delegate` | int |
+| `memory_bm25_weight` | float |
+| `memory_coref_mode` | string |
+| `memory_coref_window` | int |
+| `memory_fetch_budget_base` | int |
+| `memory_fetch_budget_enabled` | bool |
+| `memory_fetch_budget_shape_aware` | bool |
+| `memory_hard_negative_log` | string |
+| `memory_kb_neighbour_expand` | bool |
+| `memory_maintenance_trigger_inserts` | int |
+| `memory_maintenance_trigger_secs` | int |
+| `memory_negation_enabled` | bool |
+| `memory_profile_cards_enabled` | bool |
+| `memory_profile_cards_min_obs` | int |
+| `memory_profile_cards_stale_secs` | int |
+| `memory_query_expansion_k` | int |
+| `memory_query_expansion_k` | int |
+| `memory_query_expansion_mode` | string |
+| `memory_query_expansion_mode` | string |
+| `memory_rerank_command` | string |
+| `memory_rerank_command` | string |
+| `memory_rerank_enabled` | bool |
+| `memory_rerank_enabled` | bool |
+| `memory_rerank_mode` | string |
+| `memory_rerank_top_k` | int |
+| `memory_rerank_top_k` | int |
+| `memory_rewrite_command` | string |
+| `memory_rewrite_decompose` | bool |
+| `memory_rewrite_enabled` | bool |
+| `memory_rewrite_hyde` | bool |
+| `memory_rewrite_max_subqueries` | int |
+| `memory_scenes_enabled` | bool |
+| `memory_scenes_min_cluster_size` | int |
+| `memory_scenes_top_m` | int |
+| `memory_semantic_weight` | float |
+| `memory_window_radius` | int |
+| `openai_endpoint` | string |
+| `openai_key_cmd` | string |
+| `openai_model` | string |
+| `provider` | string |
+| `verify_cross_project` | bool |
+| `verify_enabled` | bool |
+| `virtual_context_assembly_budget` | int |
+| `virtual_context_enabled` | bool |
+
+## Config-file sections (37)
+
+Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`.
+
+- **`aimee`** — `api`
+- **`auxiliary`** — `default_max_tokens`, `default_model`, `default_provider`, `enabled`, `tasks`
+- **`charter`** — `hard_constraints`, `safety_axioms`, `tone_boundaries`, `values`, `working_profile_drift_limit`
+- **`compact`** — `enabled`, `head_bytes`, `per_tool`, `tail_bytes`, `threshold`
+- **`computer_use`** — `allowed_domains`, `default_navigation`, `enabled`, `redact_sensitive_screenshots`
+- **`concurrency`** — `default`, `per_model`, `per_provider`, `preempt`
+- **`context`** — `engine`
+- **`cross_verify`** — `enabled`, `prompt`, `role`, `verify_cmd`
+- **`db2`** — `vector`
+- **`dogfood`** — `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
+- **`ensemble`** — `aggregator`, `enabled`, `max_cost_usd`, `min_successful`, `reference_models`
+- **`guardrails`** — `semantic`
+- **`identity`** — `working_profile_injection`
+- **`integrity`** — `dry_run`, `enabled`
+- **`intelligence`** — `bandit`, `bandit_optimize_command`, `calibrate`, `constraint_solver_command`, `demotion`, `kb`, `planner`, `planner_search_command`, `ranker_fuse_command`, `ranking`, `reasoning`, `reasoning_datalog_command`, `synthesize`
+- **`kb`** — `api`, `background_ingest`, `connection_workers`, `curator`, `evidence`, `maintenance`, `mining`, `search_max_results`, `worker_count`
+- **`learning`** — `embed`, `router`, `synthesize`
+- **`mcp`** — `osv`
+- **`memory`** — `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_weight`
+- **`memory_maintenance`** — `enabled`, `interval_seconds`, `summarize_enabled`, `trigger_inserts`, `trigger_secs`
+- **`memory_negation`** — `enabled`
+- **`memory_query_expansion`** — `k`, `mode`
+- **`memory_recall_lanes`** — `enabled`, `fact_kinds`, `floor_fact`, `floor_summary`, `k_fact`, `k_summary`, `summary_kinds`
+- **`memory_rerank`** — `command`, `enabled`, `mix`, `top_k`
+- **`memory_rewrite`** — `command`, `decompose`, `enabled`, `hyde`, `max_subqueries`
+- **`memory_window`** — `kb_neighbour_expand`, `radius`
+- **`model_meta`** — `capability_routing`, `refresh_minutes`
+- **`otel`** — `endpoint`, `service_name`
+- **`retry`** — `base_ms`, `max_attempts`, `max_ms`
+- **`rewind`** — `auto_snapshot`
+- **`sandbox`** — `allow_paths`, `mode`, `network`
+- **`script`** — `allowed_tools`
+- **`search`** — `backend`, `max_results`, `searxng_url`, `tavily_api_key`
+- **`session`** — `max_sessions`, `max_worktrees`, `stale_threshold_secs`, `virtual_context`
+- **`skills`** — `capability`, `curator`, `dispatch`, `eval`, `manage`, `review`
+- **`transport`** — `cache_aware_rewrite`
+- **`trigger`** — `auth_token`, `max_concurrent`
+
+## Other top-level config-file keys (11)
+
+Scalar keys read directly from the config root (not via the CLI allowlist above):
+
+`cron_jobs`, `db2_pool_size`, `db2_url`, `kb_client_bearer_token`, `kb_client_url`, `lsp_servers`, `mcp_clients`, `proxy_token`, `toolsets`, `trigger_rules`, `workspaces`

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -1,0 +1,231 @@
+#!/usr/bin/env python3
+"""Generate CLI + configuration reference docs from the canonical source tables.
+
+Two committed outputs (regenerate with `make -C src docs-gen`):
+  docs/gen/cli-commands.md   — every `aimee` CLI command + subcommands, from the
+                               client help table (src/cli_help_data.h).
+  docs/gen/configuration.md  — every config key: the `aimee config get/set`
+                               scalar allowlist (src/config_fields.c) plus the
+                               config-file (JSON) sections parsed by src/config*.c.
+
+The point is completeness: these are derived from the same tables the binary
+uses, so they cannot silently drift from the implementation the way hand-written
+lists do.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+GEN = ROOT / "docs" / "gen"
+
+# ─── CLI commands (src/cli_help_data.h) ──────────────────────────────────────
+# Each entry: {"name", "description", CLIENT_TIER_X, hidden_flag, subcmd_or_NULL}
+# where subcmd is a (possibly multi-line, concatenated) C string of lines like
+#   "  sub   description\n"
+
+TIER_LABEL = {"CORE": "Core", "ADVANCED": "Advanced", "ADMIN": "Admin"}
+
+
+def _c_strings(blob):
+    """Concatenate adjacent C string literals, unescaping \\n and \\t."""
+    parts = re.findall(r'"((?:[^"\\]|\\.)*)"', blob)
+    s = "".join(parts)
+    return s.replace("\\n", "\n").replace("\\t", "\t").replace('\\"', '"')
+
+
+def parse_cli_commands():
+    text = (SRC / "cli_help_data.h").read_text(encoding="utf-8")
+    # Each entry begins with {"<name>", and ends at the matching `},` at the
+    # entry's top level. Split on the entry-start sentinel instead of brace
+    # counting (the subcmd strings contain no braces).
+    entries = []
+    # normalize: drop the file's leading comment
+    body = text[text.index('{"'):]
+    # split into entries on `},\n` boundaries that precede a new `{"`
+    raw = re.split(r'\},\s*(?=\{")', body)
+    for chunk in raw:
+        m = re.match(r'\s*\{\s*"([^"]+)"\s*,\s*"((?:[^"\\]|\\.)*)"\s*,\s*CLIENT_TIER_(\w+)\s*,\s*(\d+)\s*,\s*(.*)$',
+                     chunk, re.S)
+        if not m:
+            continue
+        name, desc, tier, hidden, rest = m.groups()
+        subs = None if rest.strip().startswith("NULL") else _c_strings(rest).strip("\n")
+        entries.append({"name": name, "desc": desc, "tier": tier,
+                        "hidden": hidden == "1", "subs": subs})
+    return entries
+
+
+def render_cli(entries):
+    out = ["# CLI Command Reference",
+           "",
+           "> Auto-generated from `src/cli_help_data.h` by `scripts/gen-reference-docs.py`.",
+           "> Do not edit by hand; run `make -C src docs-gen` to regenerate.",
+           "",
+           "`aimee` is a thin client: each command either runs a small local "
+           "operation or forwards a typed request to `aimee-server`. Server-backed "
+           "commands accept `--json` for machine-readable output. Run "
+           "`aimee help <command>` for per-command help, or `aimee help --all` for "
+           "every tier.",
+           "",
+           f"Total commands: {len(entries)}",
+           ""]
+    for tier in ("CORE", "ADVANCED", "ADMIN"):
+        group = [e for e in entries if e["tier"] == tier]
+        if not group:
+            continue
+        out.append(f"## {TIER_LABEL[tier]} commands")
+        out.append("")
+        for e in sorted(group, key=lambda e: e["name"]):
+            out.append(f"### `aimee {e['name']}`")
+            out.append("")
+            out.append(e["desc"] + ".")
+            out.append("")
+            if e["subs"]:
+                out.append("Subcommands:")
+                out.append("")
+                out.append("```")
+                out.append(e["subs"])
+                out.append("```")
+                out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+# ─── Config: CLI-settable scalars (src/config_fields.c) ───────────────────────
+
+CFG_TYPE = {"CFG_STRING": "string", "CFG_BOOL": "bool", "CFG_INT": "int", "CFG_FLOAT": "float"}
+
+
+def parse_config_fields():
+    # Each entry is `{"<key>", offsetof(...), <size>, <flag>, CFG_<TYPE>}`. The
+    # offsetof/sizeof macros embed commas, so match the key (first string before
+    # offsetof) and the type (CFG_* before the closing brace) positionally — they
+    # are 1:1 in source order.
+    text = (SRC / "config_fields.c").read_text(encoding="utf-8")
+    # Bound to the config_fields[] initializer, then parse each `{...}` entry as a
+    # unit (split on `},`) so the key and its CFG_* type are paired within one
+    # entry — robust to CFG_* uses in helper functions below the table.
+    start = text.index("config_fields[] = {")
+    text = text[start:text.index("\n};", start)]
+    fields = []
+    for chunk in text.split("},"):
+        km = re.search(r'"([a-z0-9_]+)"\s*,\s*offsetof', chunk)
+        tm = re.search(r'(CFG_\w+)', chunk)
+        if km and tm:
+            fields.append((km.group(1), CFG_TYPE.get(tm.group(1), tm.group(1))))
+    return fields
+
+
+# ─── Config: config-file (JSON) sections (src/config*.c) ──────────────────────
+# Pattern: `<var> = cJSON_GetObjectItemCaseSensitive(root, "<section>")` then
+# `cJSON_GetObjectItemCaseSensitive(<var>, "<key>")` for the section's keys.
+
+ASSIGN_RE = re.compile(
+    r'(\w+)\s*=\s*cJSON_GetObjectItemCaseSensitive\(\s*root\s*,\s*"([^"]+)"\s*\)')
+CHILD_RE = re.compile(
+    r'cJSON_GetObjectItemCaseSensitive\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)')
+
+
+def parse_config_sections():
+    sections = {}   # section name -> sorted set of keys
+    flat = set()    # top-level scalar keys read straight off root
+    for cfile in sorted(SRC.glob("config*.c")):
+        text = cfile.read_text(encoding="utf-8")
+        var_to_section = {}
+        for m in ASSIGN_RE.finditer(text):
+            var, sect = m.group(1), m.group(2)
+            if var == "root":
+                continue
+            var_to_section[var] = sect
+        # collect child keys per section-var
+        used_as_parent = set()
+        for m in CHILD_RE.finditer(text):
+            parent, key = m.group(1), m.group(2)
+            used_as_parent.add(parent)
+            if parent in var_to_section:
+                sections.setdefault(var_to_section[parent], set()).add(key)
+        # a (root,"X") whose var is never used as a parent is a flat top key
+        for var, sect in var_to_section.items():
+            if var not in used_as_parent:
+                flat.add(sect)
+    # don't double-list a name that is both a section and a stray flat read
+    flat -= set(sections)
+    return sections, flat
+
+
+def render_config(fields, sections, flat):
+    out = ["# Configuration Reference",
+           "",
+           "> Auto-generated from `src/config_fields.c` and the `src/config*.c` "
+           "parsers by `scripts/gen-reference-docs.py`. Do not edit by hand; run "
+           "`make -C src docs-gen` to regenerate.",
+           "",
+           "Configuration lives in the per-`AIMEE_HOME` config store. Scalar keys "
+           "in the table below are settable from the CLI:",
+           "",
+           "```",
+           "aimee config show                 # print the effective config",
+           "aimee config get <key>            # read one value",
+           "aimee config set <key> <value>    # set one value",
+           "```",
+           "",
+           "Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) "
+           "are not CLI-settable; they are written into the config file under the "
+           "sections listed at the end.",
+           ""]
+
+    out.append(f"## CLI-settable keys ({len(fields)})")
+    out.append("")
+    out.append("| Key | Type |")
+    out.append("|-----|------|")
+    for key, typ in sorted(fields):
+        out.append(f"| `{key}` | {typ} |")
+    out.append("")
+
+    out.append(f"## Config-file sections ({len(sections)})")
+    out.append("")
+    out.append("Set in the config JSON as `{\"<section>\": {\"<key>\": ...}}`. Keys "
+               "are derived from the section parsers in `src/config*.c`.")
+    out.append("")
+    for sect in sorted(sections):
+        keys = ", ".join(f"`{k}`" for k in sorted(sections[sect]))
+        out.append(f"- **`{sect}`** — {keys}")
+    out.append("")
+
+    if flat:
+        out.append(f"## Other top-level config-file keys ({len(flat)})")
+        out.append("")
+        out.append("Scalar keys read directly from the config root (not via the CLI "
+                   "allowlist above):")
+        out.append("")
+        out.append(", ".join(f"`{k}`" for k in sorted(flat)))
+        out.append("")
+
+    return "\n".join(out).rstrip() + "\n"
+
+
+def main():
+    check = "--check" in sys.argv
+    GEN.mkdir(parents=True, exist_ok=True)
+    cli = render_cli(parse_cli_commands())
+    cfg = render_config(parse_config_fields(), *parse_config_sections())
+    targets = {GEN / "cli-commands.md": cli, GEN / "configuration.md": cfg}
+
+    if check:
+        stale = [p.name for p, want in targets.items()
+                 if not p.exists() or p.read_text(encoding="utf-8") != want]
+        if stale:
+            print(f"gen-reference-docs: STALE — run scripts/gen-reference-docs.py: {stale}")
+            return 1
+        print("gen-reference-docs: ok (cli-commands.md, configuration.md in sync)")
+        return 0
+
+    for p, want in targets.items():
+        p.write_text(want, encoding="utf-8")
+        print(f"gen-reference-docs: wrote {p.relative_to(ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Makefile
+++ b/src/Makefile
@@ -956,6 +956,7 @@ $(OBJDIR)/server/server_http.o: server/openapi_server_data.h
 # The output is committed; regenerating on an unchanged spec is a no-op.
 docs-gen:
 	@python3 ../scripts/gen-api-docs.py
+	@python3 ../scripts/gen-reference-docs.py
 
 # CI gate: fail if docs/gen is stale relative to the committed spec.
 docs-gen-check: docs-gen


### PR DESCRIPTION
## Summary

Documents **everything configurable** and the **full set of CLI commands**, generated
from the canonical source tables so the docs can't drift from the binary.

- `scripts/gen-reference-docs.py` (wired into `make docs-gen`; `--check` mode + covered
  by `docs-gen-check`).
- **`docs/gen/cli-commands.md`** — all 50 `aimee` commands + subcommands, grouped by
  tier, from `src/cli_help_data.h`.
- **`docs/gen/configuration.md`** — the 87 `aimee config get/set` scalar keys (with
  types) from `src/config_fields.c`, plus the 37 config-file JSON sections and 11 other
  top-level keys parsed across `src/config*.c`.
- `docs/COMMANDS.md` (previously stale — missing `optimize`, `claude-proxy`, …) now links
  to the generated authoritative lists.

## Verification
- `make -C src docs-gen-check` → ok; `make -C src lint` → exit 0.
- Generator is idempotent; `--check` flags drift.

Note: `smoke` is pre-existing-red on `testing` (a benchmark `judge_majority` stub test,
unrelated to docs) — it is a non-required check.
