### PR TITLE
fix(bench): smoke judge test — stub reads prompt from stdin (--prompt-stdin)

### DIFF
--- a/benchmarks/tests/test_agent_run_delegate.py
+++ b/benchmarks/tests/test_agent_run_delegate.py
@@ -39,7 +39,10 @@ _STUB = textwrap.dedent(
         sys.stdout.write(json.dumps(obj))
 
     if "delegate" in argv and "execute" in argv:
-        prompt = argv[argv.index("execute") + 1]
+        # The harness passes the prompt over stdin with --prompt-stdin (benchmark
+        # prompts exceed the argv size limit); mirror the real client contract
+        # instead of reading the positional slot, which is now the flag itself.
+        prompt = sys.stdin.read() if "--prompt-stdin" in argv else argv[argv.index("execute") + 1]
         with open(pfile, "w") as fh:
             fh.write(prompt)
         emit({"job_id": 1, "job_status": "pending"})


### PR DESCRIPTION
## Summary

Fixes the pre-existing red **`smoke`** check on `testing`
(`test_judge_majority_correct` voting WRONG×3).

**Root cause:** `AimeeHarness._delegate_execute` queues with
`delegate execute --prompt-stdin … --background` and sends the prompt over
**stdin** (benchmark prompts exceed the argv size limit). The CI stub client
still read `argv[index("execute") + 1]` — now the literal `--prompt-stdin` flag,
not the prompt. Judge prompts never contained `Gold answer:`, so the stub
returned its canned `"four"` and every vote parsed as `WRONG`.

**Fix:** the stub now reads the prompt from stdin when `--prompt-stdin` is
present, matching the real client contract.

## Verification
- Full benchmark suite (the exact CI smoke command,
  `python3 -m unittest discover -s benchmarks/tests`): **417 tests, OK**,
  including both `judge_majority` tests.
