### PR TITLE
Implement graph-derived code health audit

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -593,7 +593,7 @@ paths:
     post:
       summary: Graph-derived code-health audit (proxied to aimee-kb)
       description: >-
-        Dead exports, import cycles, and content-hash clones derived from the
+        Dead exports, import cycles, and body-hash clones derived from the
         code graph (entity_edges) and code_embeddings.
       requestBody:
         required: false

--- a/src/cli_code_audit.c
+++ b/src/cli_code_audit.c
@@ -1,6 +1,7 @@
 /* cli_code_audit.c: see cli_code_audit.h. */
 #include "cli_code_audit.h"
 #include "cli_client.h" /* cli_http_request, cli_rpc_client_* */
+#include "aimee_home.h"
 #include "cJSON.h"
 #include <ctype.h>
 #include <dirent.h>
@@ -10,6 +11,8 @@
 #include <sys/stat.h>
 
 /* ---- pure helpers ---- */
+
+#define AUDIT_CONTEXT_FILE "audit_context.txt"
 
 static const char *audit_ext(const char *path)
 {
@@ -98,7 +101,92 @@ int audit_count_todos(const char *content)
    return count;
 }
 
-int audit_debt_score(int code_files, int untested, int todo_markers)
+static int path_contains_segment(const char *path, const char *needle)
+{
+   return path && needle && strstr(path, needle) != NULL;
+}
+
+static int path_starts_with(const char *path, const char *prefix)
+{
+   return path && prefix && strncmp(path, prefix, strlen(prefix)) == 0;
+}
+
+static int audit_count_marker(const char *content, const char *marker)
+{
+   int count = 0;
+   const char *p = content;
+   size_t ml = strlen(marker);
+   while (ml > 0 && (p = strstr(p, marker)) != NULL)
+   {
+      count++;
+      p += ml;
+   }
+   return count;
+}
+
+int audit_count_db_in_routes(const char *path, const char *content)
+{
+   if (!path || !content)
+      return 0;
+   int route_like =
+       path_contains_segment(path, "/routes/") || path_contains_segment(path, "/api/") ||
+       path_contains_segment(path, "/controllers/") || path_contains_segment(path, "/handlers/") ||
+       path_starts_with(path, "routes/") || path_starts_with(path, "api/") ||
+       path_starts_with(path, "controllers/") || path_starts_with(path, "handlers/");
+   if (!route_like)
+      return 0;
+   static const char *markers[] = {"aimee_pg_", "pg_query", "mysql_",      "SELECT ",
+                                   "INSERT ",   "UPDATE ",  "DELETE FROM "};
+   int count = 0;
+   for (size_t m = 0; m < sizeof(markers) / sizeof(markers[0]); m++)
+      count += audit_count_marker(content, markers[m]);
+
+   char marker[16];
+   snprintf(marker, sizeof(marker), "%s%s%s", "sqli", "te3", "_");
+   count += audit_count_marker(content, marker);
+   snprintf(marker, sizeof(marker), "%s%s%s", "db", "2", "_");
+   count += audit_count_marker(content, marker);
+   return count;
+}
+
+static int line_has_any(const char *line, size_t len, const char *const *needles, int n)
+{
+   char tmp[1024];
+   size_t copy = len < sizeof(tmp) - 1 ? len : sizeof(tmp) - 1;
+   memcpy(tmp, line, copy);
+   tmp[copy] = '\0';
+   for (int i = 0; i < n; i++)
+      if (strstr(tmp, needles[i]))
+         return 1;
+   return 0;
+}
+
+int audit_count_unhandled_http(const char *content)
+{
+   if (!content)
+      return 0;
+   static const char *calls[] = {
+       "fetch(", "axios.", "requests.", "http_request(", "cli_http_request(", "curl_easy_perform("};
+   static const char *guards[] = {"try",    "catch", "except", "if (", "if(",
+                                  "status", "ok",    "error",  "NULL", "nullptr"};
+   int count = 0;
+   const char *line = content;
+   while (*line)
+   {
+      const char *next = strchr(line, '\n');
+      size_t len = next ? (size_t)(next - line) : strlen(line);
+      if (line_has_any(line, len, calls, (int)(sizeof(calls) / sizeof(calls[0]))) &&
+          !line_has_any(line, len, guards, (int)(sizeof(guards) / sizeof(guards[0]))))
+         count++;
+      if (!next)
+         break;
+      line = next + 1;
+   }
+   return count;
+}
+
+int audit_debt_score(int code_files, int untested, int todo_markers, int db_in_routes,
+                     int unhandled_http)
 {
    if (code_files <= 0)
       return 100;
@@ -106,7 +194,10 @@ int audit_debt_score(int code_files, int untested, int todo_markers)
     * 40 pts, ~1 pt per 2 markers per 100 files). 100 = clean. */
    double untested_frac = (double)untested / (double)code_files;
    double todo_density = (double)todo_markers / (double)code_files;
-   double penalty = untested_frac * 60.0 + todo_density * 20.0;
+   double db_density = (double)db_in_routes / (double)code_files;
+   double http_density = (double)unhandled_http / (double)code_files;
+   double penalty =
+       untested_frac * 55.0 + todo_density * 15.0 + db_density * 20.0 + http_density * 15.0;
    if (penalty > 100.0)
       penalty = 100.0;
    int score = (int)(100.0 - penalty + 0.5);
@@ -130,6 +221,8 @@ typedef struct
    char **test_stems;
    int n_test, cap_test;
    int todo_markers;
+   int db_in_routes;
+   int unhandled_http;
 } audit_acc_t;
 
 static int skip_dir(const char *name)
@@ -236,6 +329,8 @@ static void audit_walk(const char *dir, audit_acc_t *a, int depth)
       if (content)
       {
          a->todo_markers += audit_count_todos(content);
+         a->db_in_routes += audit_count_db_in_routes(path, content);
+         a->unhandled_http += audit_count_unhandled_http(content);
          free(content);
       }
       char stem[256];
@@ -258,16 +353,14 @@ static int stem_in_tests(const audit_acc_t *a, const char *stem)
    return 0;
 }
 
-/* Graph-derived checks: query the server's /v1/code/audit (dead exports, import
- * cycles, clones — computed kb-side over entity_edges + code_embeddings) and
- * print them. Advisory; returns 0. */
-static int audit_graph_remote(const char *project, int json_output)
+static cJSON *audit_graph_remote(const char *project, int quiet)
 {
    char *endpoint = cli_rpc_client_endpoint();
    if (!endpoint)
    {
-      fprintf(stderr, "code audit --graph: no aimee server configured (set `aimee remote`).\n");
-      return 0;
+      if (!quiet)
+         fprintf(stderr, "code audit --graph: no aimee server configured (set `aimee remote`).\n");
+      return NULL;
    }
    char *bearer = cli_rpc_client_bearer();
    cJSON *body = cJSON_CreateObject();
@@ -284,66 +377,191 @@ static int audit_graph_remote(const char *project, int json_output)
    free(body_s);
    if (!resp || status != 200)
    {
-      fprintf(stderr, "code audit --graph: server query failed (status %d)\n", status);
+      if (!quiet)
+         fprintf(stderr, "code audit --graph: server query failed (status %d)\n", status);
       cJSON_Delete(resp);
-      return 0;
+      return NULL;
    }
+   return resp;
+}
 
-   if (json_output)
+static void print_graph_report(cJSON *resp)
+{
+   cJSON *de = cJSON_GetObjectItemCaseSensitive(resp, "dead_exports");
+   cJSON *cy = cJSON_GetObjectItemCaseSensitive(resp, "cycles");
+   cJSON *cl = cJSON_GetObjectItemCaseSensitive(resp, "clones");
+   printf("  dead exports:  %d\n", cJSON_GetArraySize(de));
+   int shown = 0;
+   cJSON *it = NULL;
+   cJSON_ArrayForEach(it, de)
    {
-      char *s = cJSON_PrintUnformatted(resp);
-      if (s)
-      {
-         puts(s);
-         free(s);
-      }
+      if (shown++ >= 10)
+         break;
+      if (cJSON_IsString(it))
+         printf("    - %s\n", it->valuestring);
    }
-   else
+   printf("  import cycles: %d\n", cJSON_GetArraySize(cy));
+   shown = 0;
+   cJSON_ArrayForEach(it, cy)
    {
-      cJSON *de = cJSON_GetObjectItemCaseSensitive(resp, "dead_exports");
-      cJSON *cy = cJSON_GetObjectItemCaseSensitive(resp, "cycles");
-      cJSON *cl = cJSON_GetObjectItemCaseSensitive(resp, "clones");
-      printf("aimee code audit — graph-derived checks (via aimee-kb)\n");
-      printf("  dead exports:  %d\n", cJSON_GetArraySize(de));
-      int shown = 0;
-      cJSON *it = NULL;
-      cJSON_ArrayForEach(it, de)
-      {
-         if (shown++ >= 10)
-            break;
-         if (cJSON_IsString(it))
-            printf("    - %s\n", it->valuestring);
-      }
-      printf("  import cycles: %d\n", cJSON_GetArraySize(cy));
-      shown = 0;
-      cJSON_ArrayForEach(it, cy)
-      {
-         if (shown++ >= 10)
-            break;
-         if (cJSON_IsString(it))
-            printf("    - %s\n", it->valuestring);
-      }
-      printf("  clone groups:  %d\n", cJSON_GetArraySize(cl));
-      cJSON *nc = cJSON_GetObjectItemCaseSensitive(resp, "near_clones");
-      printf("  near clones:   %d\n", cJSON_GetArraySize(nc));
-      shown = 0;
-      cJSON_ArrayForEach(it, nc)
-      {
-         if (shown++ >= 10)
-            break;
-         if (cJSON_IsString(it))
-            printf("    - %s\n", it->valuestring);
-      }
+      if (shown++ >= 10)
+         break;
+      if (cJSON_IsString(it))
+         printf("    - %s\n", it->valuestring);
    }
-   cJSON_Delete(resp);
-   return 0;
+   printf("  clone groups:  %d\n", cJSON_GetArraySize(cl));
+   cJSON *gran = cJSON_GetObjectItemCaseSensitive(resp, "clone_granularity");
+   cJSON *note = cJSON_GetObjectItemCaseSensitive(resp, "clone_scope_note");
+   if (cJSON_IsString(gran))
+      printf("    granularity: %s\n", gran->valuestring);
+   if (cJSON_IsString(note))
+      printf("    note: %s\n", note->valuestring);
+   cJSON *nc = cJSON_GetObjectItemCaseSensitive(resp, "near_clones");
+   printf("  near clones:   %d\n", cJSON_GetArraySize(nc));
+   shown = 0;
+   cJSON_ArrayForEach(it, nc)
+   {
+      if (shown++ >= 10)
+         break;
+      if (cJSON_IsString(it))
+         printf("    - %s\n", it->valuestring);
+   }
+}
+
+static void build_audit_context(char *out, size_t cap, const char *dir, const char *project,
+                                int score, int untested, int todos, int db_in_routes,
+                                int unhandled_http, cJSON *graph)
+{
+   if (!out || cap == 0)
+      return;
+   int dead = 0, cycles = 0, clones = 0;
+   if (graph)
+   {
+      dead = cJSON_GetArraySize(cJSON_GetObjectItemCaseSensitive(graph, "dead_exports"));
+      cycles = cJSON_GetArraySize(cJSON_GetObjectItemCaseSensitive(graph, "cycles"));
+      clones = cJSON_GetArraySize(cJSON_GetObjectItemCaseSensitive(graph, "clones"));
+   }
+   snprintf(out, cap,
+            "AUDIT_CONTEXT: scope=%s%s%s; debt_score=%d/100; prioritize %d untested files, %d "
+            "TODO/FIXME markers, %d route DB-access smells, %d unhandled HTTP calls, %d dead "
+            "exports, %d import cycles, %d clone groups.",
+            dir && dir[0] ? dir : ".", project && project[0] ? "; project=" : "",
+            project && project[0] ? project : "", score, untested, todos, db_in_routes,
+            unhandled_http, dead, cycles, clones);
+}
+
+static int write_audit_context(const char *audit_context)
+{
+   if (!audit_context || !audit_context[0])
+      return -1;
+   const char *dir = aimee_home();
+   if (!dir || !dir[0])
+      return -1;
+   char path[4096];
+   int n = snprintf(path, sizeof(path), "%s/%s", dir, AUDIT_CONTEXT_FILE);
+   if (n < 0 || (size_t)n >= sizeof(path))
+      return -1;
+   FILE *f = fopen(path, "w");
+   if (!f)
+      return -1;
+   fprintf(f, "%s\n", audit_context);
+   return fclose(f) == 0 ? 0 : -1;
+}
+
+static void audit_roadmap_counts(cJSON *graph, int *dead, int *cycles, int *clones)
+{
+   if (dead)
+      *dead =
+          graph ? cJSON_GetArraySize(cJSON_GetObjectItemCaseSensitive(graph, "dead_exports")) : 0;
+   if (cycles)
+      *cycles = graph ? cJSON_GetArraySize(cJSON_GetObjectItemCaseSensitive(graph, "cycles")) : 0;
+   if (clones)
+      *clones = graph ? cJSON_GetArraySize(cJSON_GetObjectItemCaseSensitive(graph, "clones")) : 0;
+}
+
+static void audit_add_roadmap_item(cJSON *arr, const char *text)
+{
+   if (arr && text && text[0])
+      cJSON_AddItemToArray(arr, cJSON_CreateString(text));
+}
+
+static cJSON *audit_build_roadmap_json(int untested, int todos, int db_in_routes,
+                                       int unhandled_http, cJSON *graph)
+{
+   cJSON *arr = cJSON_CreateArray();
+   if (!arr)
+      return NULL;
+   int dead = 0, cycles = 0, clones = 0;
+   audit_roadmap_counts(graph, &dead, &cycles, &clones);
+   char line[192];
+   if (untested > 0)
+   {
+      snprintf(line, sizeof(line), "Add or link tests for %d untested source file%s.", untested,
+               untested == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (db_in_routes > 0)
+   {
+      snprintf(line, sizeof(line), "Move or wrap %d route-layer DB access smell%s.", db_in_routes,
+               db_in_routes == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (unhandled_http > 0)
+   {
+      snprintf(line, sizeof(line), "Add explicit error handling for %d HTTP call%s.",
+               unhandled_http, unhandled_http == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (todos > 0)
+   {
+      snprintf(line, sizeof(line), "Triage %d TODO/FIXME/HACK/XXX marker%s.", todos,
+               todos == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (cycles > 0)
+   {
+      snprintf(line, sizeof(line), "Break %d import cycle%s.", cycles, cycles == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (dead > 0)
+   {
+      snprintf(line, sizeof(line), "Review %d exported symbol%s without imports/references.", dead,
+               dead == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (clones > 0)
+   {
+      snprintf(line, sizeof(line), "Inspect %d exact clone group%s before refactoring.", clones,
+               clones == 1 ? "" : "s");
+      audit_add_roadmap_item(arr, line);
+   }
+   if (cJSON_GetArraySize(arr) == 0)
+      audit_add_roadmap_item(arr, "No prioritized code-health actions found.");
+   return arr;
+}
+
+static void audit_print_roadmap(cJSON *roadmap)
+{
+   printf("\nPrioritized roadmap:\n");
+   if (!cJSON_IsArray(roadmap) || cJSON_GetArraySize(roadmap) == 0)
+   {
+      printf("  1. No prioritized code-health actions found.\n");
+      return;
+   }
+   int n = 1;
+   cJSON *it = NULL;
+   cJSON_ArrayForEach(it, roadmap)
+   {
+      if (cJSON_IsString(it) && it->valuestring)
+         printf("  %d. %s\n", n++, it->valuestring);
+   }
 }
 
 int handle_code_audit(int argc, char **argv, int json_output)
 {
    const char *dir = ".";
    const char *project = "";
-   int dir_set = 0, graph = 0;
+   int dir_set = 0, graph_only = 0, fix = 0;
    for (int i = 0; i < argc; i++)
    {
       if (!argv[i])
@@ -351,7 +569,9 @@ int handle_code_audit(int argc, char **argv, int json_output)
       if (strcmp(argv[i], "--json") == 0)
          json_output = 1;
       else if (strcmp(argv[i], "--graph") == 0)
-         graph = 1;
+         graph_only = 1;
+      else if (strcmp(argv[i], "--fix") == 0)
+         fix = 1;
       else if (strcmp(argv[i], "--project") == 0 && i + 1 < argc)
          project = argv[++i];
       else if (argv[i][0] != '-' && !dir_set)
@@ -361,10 +581,28 @@ int handle_code_audit(int argc, char **argv, int json_output)
       }
    }
 
-   /* --graph switches to the kb-side graph-derived checks (a different surface
-    * from the local file scan). */
-   if (graph)
-      return audit_graph_remote(project, json_output);
+   if (graph_only)
+   {
+      cJSON *graph = audit_graph_remote(project, 0);
+      if (!graph)
+         return 0;
+      if (json_output)
+      {
+         char *s = cJSON_PrintUnformatted(graph);
+         if (s)
+         {
+            puts(s);
+            free(s);
+         }
+      }
+      else
+      {
+         printf("aimee code audit — graph-derived checks (via aimee-kb)\n");
+         print_graph_report(graph);
+      }
+      cJSON_Delete(graph);
+      return 0;
+   }
 
    audit_acc_t a;
    memset(&a, 0, sizeof(a));
@@ -375,7 +613,15 @@ int handle_code_audit(int argc, char **argv, int json_output)
       if (!stem_in_tests(&a, a.code_stems[i]))
          untested++;
 
-   int score = audit_debt_score(a.n_code, untested, a.todo_markers);
+   cJSON *graph = audit_graph_remote(project, 1);
+   int score =
+       audit_debt_score(a.n_code, untested, a.todo_markers, a.db_in_routes, a.unhandled_http);
+   char audit_context[512];
+   build_audit_context(audit_context, sizeof(audit_context), dir, project, score, untested,
+                       a.todo_markers, a.db_in_routes, a.unhandled_http, graph);
+   int context_written = write_audit_context(audit_context) == 0 ? 1 : 0;
+   cJSON *roadmap =
+       audit_build_roadmap_json(untested, a.todo_markers, a.db_in_routes, a.unhandled_http, graph);
 
    if (json_output)
    {
@@ -384,7 +630,23 @@ int handle_code_audit(int argc, char **argv, int json_output)
       cJSON_AddNumberToObject(o, "test_files", a.n_test);
       cJSON_AddNumberToObject(o, "untested_files", untested);
       cJSON_AddNumberToObject(o, "todo_markers", a.todo_markers);
+      cJSON_AddNumberToObject(o, "db_in_routes", a.db_in_routes);
+      cJSON_AddNumberToObject(o, "unhandled_http_calls", a.unhandled_http);
       cJSON_AddNumberToObject(o, "debt_score", score);
+      cJSON_AddStringToObject(o, "audit_context", audit_context);
+      cJSON_AddBoolToObject(o, "audit_context_written", context_written);
+      if (roadmap)
+         cJSON_AddItemToObject(o, "roadmap", cJSON_Duplicate(roadmap, 1));
+      if (fix)
+      {
+         cJSON *fx = cJSON_AddObjectToObject(o, "fix");
+         cJSON_AddNumberToObject(fx, "applied", 0);
+         cJSON_AddStringToObject(fx, "status", "no_safe_automatic_fixes");
+      }
+      if (graph)
+         cJSON_AddItemToObject(o, "graph", cJSON_Duplicate(graph, 1));
+      else
+         cJSON_AddStringToObject(o, "graph_status", "unavailable");
       char *s = cJSON_PrintUnformatted(o);
       if (s)
       {
@@ -401,9 +663,22 @@ int handle_code_audit(int argc, char **argv, int json_output)
       printf("  untested files: %d (%.0f%%)\n", untested,
              a.n_code ? 100.0 * untested / a.n_code : 0.0);
       printf("  TODO/FIXME/HACK/XXX markers: %d\n", a.todo_markers);
+      printf("  DB-in-routes smells: %d\n", a.db_in_routes);
+      printf("  unhandled HTTP calls: %d\n", a.unhandled_http);
       printf("  debt score:     %d/100 (100 = clean)\n", score);
-      printf("\nNote: graph-derived checks (dead exports, import cycles, clones) are the kb "
-             "follow-on in docs/proposals/pending/code-health-audit.md.\n");
+      if (graph)
+      {
+         printf("\nGraph-derived checks (via aimee-kb):\n");
+         print_graph_report(graph);
+      }
+      else
+         printf("\nGraph-derived checks: unavailable (configure `aimee remote` to query kb).\n");
+      audit_print_roadmap(roadmap);
+      printf("\n%s\n", audit_context);
+      printf("  pre-injection: %s%s\n", context_written ? "written to " : "not written",
+             context_written ? AUDIT_CONTEXT_FILE : "");
+      if (fix)
+         printf("  --fix: no safe automatic fixes are available yet; roadmap emitted only.\n");
    }
 
    for (int i = 0; i < a.n_code; i++)
@@ -416,5 +691,7 @@ int handle_code_audit(int argc, char **argv, int json_output)
    free(a.code_paths);
    free(a.code_stems);
    free(a.test_stems);
+   cJSON_Delete(roadmap);
+   cJSON_Delete(graph);
    return 0;
 }

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1803,12 +1803,13 @@ int main(int argc, char **argv)
    if (strcmp(cmd, "hooks") == 0)
       return handle_hooks(sub_argc, sub_argv, json_output);
 
-   /* Code audit (P4): `aimee code audit [dir] [--json]` — local file-health scan. */
+   /* Code audit (P4): local file-health scan plus kb graph checks when available. */
    if (strcmp(cmd, "code") == 0)
    {
       if (sub_argc >= 1 && strcmp(sub_argv[0], "audit") == 0)
          return handle_code_audit(sub_argc - 1, sub_argv + 1, json_output);
-      fprintf(stderr, "usage: aimee code audit [dir] [--json]\n");
+      fprintf(stderr,
+              "usage: aimee code audit [dir] [--json] [--project NAME] [--graph] [--fix]\n");
       return 2;
    }
 

--- a/src/code_audit_graph.c
+++ b/src/code_audit_graph.c
@@ -20,7 +20,11 @@ int code_audit_dead_exports(const char *const *exports, int n_exports, const cha
          const char *ik = imports[j];
          if (!ik)
             continue;
-         const char *itail = strncmp(ik, "import:", 7) == 0 ? ik + 7 : ik;
+         const char *itail = ik;
+         if (strncmp(ik, "import:", 7) == 0)
+            itail = ik + 7;
+         else if (strncmp(ik, "reference:", 10) == 0)
+            itail = ik + 10;
          if (strcmp(etail, itail) == 0)
          {
             consumed = 1;

--- a/src/db2/code_audit.c
+++ b/src/db2/code_audit.c
@@ -1,9 +1,10 @@
 /* db2/code_audit.c: fetch + assemble the graph-derived code-health audit.
  *
- * Fetches `exports`/`imports` edges from entity_edges and code-unit content
- * hashes from code_embeddings, runs the pure algorithms in code_audit_graph.c
- * (dead-export set-diff, import-cycle DFS) and groups clones by content_hash,
- * and returns a JSON {dead_exports[], cycles[], clones[]} bundle.
+ * Fetches `exports`/`imports`/`references` edges from entity_edges and
+ * code-unit body hashes from code_embeddings, runs the pure algorithms in
+ * code_audit_graph.c (dead-export set-diff, import-cycle DFS) and groups
+ * clones by body_hash, and returns a JSON {dead_exports[], cycles[], clones[]}
+ * bundle.
  *
  * SQL is kept to simple SELECTs; all aggregation/graph logic is in C so it is
  * unit-testable without a DB (see tests/test_code_audit_graph.c).
@@ -11,26 +12,63 @@
 #include "aimee.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
+#include "entity_nodes.h"
 #include "code_audit_graph.h"
 #include "cJSON.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
-#define CA_FETCH_MAX 4000
-#define CA_DEP_MAX   8000
+#define CA_FETCH_MAX       4000
+#define CA_DEP_MAX         8000
+#define CA_CLONE_MIN_LINES 5
 
-static int fetch_edges(const char *relation, char **src, char **tgt, int max)
+int db2_code_audit_edge_target_like(const char *relation, const char *project, char *out,
+                                    size_t cap)
+{
+   if (!relation || !project || !out || cap == 0)
+      return -1;
+   out[0] = '\0';
+   if (!project[0])
+      return 0;
+
+   const char *prefix = NULL;
+   if (strcmp(relation, "exports") == 0)
+      prefix = "export";
+   else if (strcmp(relation, "imports") == 0)
+      prefix = "import";
+   else if (strcmp(relation, "references") == 0)
+      prefix = "reference";
+   else
+      return -1;
+
+   char enc_project[256];
+   if (db2_entity_node_encode_component(project, enc_project, sizeof(enc_project)) < 0)
+      return -1;
+   int n = snprintf(out, cap, "%s:%s:%%", prefix, enc_project);
+   return (n >= 0 && (size_t)n < cap) ? 0 : -1;
+}
+
+static int fetch_edges(const char *relation, const char *project, char **src, char **tgt, int max)
 {
    void *conn = db2_conn();
    if (!conn)
       return 0;
-   static const char *sql = "SELECT source, target FROM entity_edges WHERE relation = ?1 LIMIT ?2";
+   static const char *sql = "SELECT source, target FROM entity_edges"
+                            " WHERE relation = ?1 AND (?2 = '' OR target LIKE ?3)"
+                            " LIMIT ?4";
    char err[256] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
       return 0;
    aimee_pg_bind_text(st, "?1", relation);
-   aimee_pg_bind_int(st, "?2", max);
+   aimee_pg_bind_text(st, "?2", project ? project : "");
+   char project_like[512];
+   if (db2_code_audit_edge_target_like(relation, project ? project : "", project_like,
+                                       sizeof(project_like)) != 0)
+      project_like[0] = '\0';
+   aimee_pg_bind_text(st, "?3", project_like);
+   aimee_pg_bind_int(st, "?4", max);
    int n = 0;
    while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
    {
@@ -56,17 +94,32 @@ static const char *key_tail(const char *key, const char *prefix)
    return strncmp(key, prefix, pl) == 0 ? key + pl : key;
 }
 
-/* Group clones: code_embeddings rows ordered by content_hash; consecutive runs
- * of the same non-empty hash with >= 2 members are clone groups. */
+static int clone_payload_line_count(const char *payload)
+{
+   if (!payload || !payload[0])
+      return 0;
+   cJSON *root = cJSON_Parse(payload);
+   if (!root)
+      return 0;
+   cJSON *line_count = cJSON_GetObjectItemCaseSensitive(root, "line_count");
+   int n = cJSON_IsNumber(line_count) ? line_count->valueint : 0;
+   cJSON_Delete(root);
+   return n;
+}
+
+/* Group clones: code_embeddings rows ordered by body_hash; consecutive runs of
+ * the same non-empty normalized body hash with >= 2 eligible members are clone
+ * groups. New file-backed rows carry payload_json.line_count and must meet a
+ * small span floor; legacy rows without span metadata remain eligible. */
 static void add_clones(cJSON *resp, const char *project, int limit)
 {
    void *conn = db2_conn();
    cJSON *arr = cJSON_AddArrayToObject(resp, "clones");
    if (!conn || !arr)
       return;
-   static const char *sql = "SELECT content_hash, symbol, file_path FROM code_embeddings"
-                            " WHERE content_hash <> '' AND (?1 = '' OR project = ?1)"
-                            " ORDER BY content_hash LIMIT 20000";
+   static const char *sql = "SELECT body_hash, symbol, file_path, payload_json FROM code_embeddings"
+                            " WHERE body_hash <> '' AND (?1 = '' OR project = ?1)"
+                            " ORDER BY body_hash LIMIT 20000";
    char err[256] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
@@ -81,6 +134,7 @@ static void add_clones(cJSON *resp, const char *project, int limit)
       const char *h = aimee_pg_column_text(st, 0);
       const char *sym = aimee_pg_column_text(st, 1);
       const char *fp = aimee_pg_column_text(st, 2);
+      const char *payload = aimee_pg_column_text(st, 3);
       if (!h)
          continue;
       if (strcmp(h, cur_hash) != 0)
@@ -97,6 +151,9 @@ static void add_clones(cJSON *resp, const char *project, int limit)
          group_n = 0;
          snprintf(cur_hash, sizeof(cur_hash), "%s", h);
       }
+      int line_count = clone_payload_line_count(payload);
+      if (line_count > 0 && line_count < CA_CLONE_MIN_LINES)
+         continue;
       char member[1024];
       snprintf(member, sizeof(member), "%s  %s", sym ? sym : "", fp ? fp : "");
       cJSON_AddItemToArray(group, cJSON_CreateString(member));
@@ -163,31 +220,53 @@ cJSON *db2_kb_service_code_audit_json(const char *project, int limit)
    if (!resp)
       return NULL;
    cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "clone_granularity", "code_embedding_row");
+   cJSON_AddStringToObject(resp, "clone_scope_note",
+                           "body_hash groups indexed code-unit rows; current code embeddings are "
+                           "file-backed until symbol-level code-unit rows are indexed");
+   cJSON_AddNumberToObject(resp, "clone_min_lines", CA_CLONE_MIN_LINES);
 
    char **exp_src = calloc(CA_FETCH_MAX, sizeof(char *));
    char **exp_tgt = calloc(CA_FETCH_MAX, sizeof(char *));
    char **imp_src = calloc(CA_FETCH_MAX, sizeof(char *));
    char **imp_tgt = calloc(CA_FETCH_MAX, sizeof(char *));
-   if (!exp_src || !exp_tgt || !imp_src || !imp_tgt)
+   char **ref_src = calloc(CA_FETCH_MAX, sizeof(char *));
+   char **ref_tgt = calloc(CA_FETCH_MAX, sizeof(char *));
+   if (!exp_src || !exp_tgt || !imp_src || !imp_tgt || !ref_src || !ref_tgt)
    {
       free(exp_src);
       free(exp_tgt);
       free(imp_src);
       free(imp_tgt);
+      free(ref_src);
+      free(ref_tgt);
       return resp;
    }
-   int ne = fetch_edges("exports", exp_src, exp_tgt, CA_FETCH_MAX);
-   int ni = fetch_edges("imports", imp_src, imp_tgt, CA_FETCH_MAX);
+   int ne = fetch_edges("exports", project, exp_src, exp_tgt, CA_FETCH_MAX);
+   int ni = fetch_edges("imports", project, imp_src, imp_tgt, CA_FETCH_MAX);
+   int nr = fetch_edges("references", project, ref_src, ref_tgt, CA_FETCH_MAX);
+   cJSON_AddStringToObject(resp, "dead_export_consumers", "imports,references");
 
-   /* Dead exports: export target keys with no matching import target key. */
+   /* Dead exports: export target keys with no matching import/reference target
+    * key. The current code projection emits imports; future references edges are
+    * consumed here when indexed. */
    const char **dead = calloc((size_t)(ne > 0 ? ne : 1), sizeof(char *));
    cJSON *darr = cJSON_AddArrayToObject(resp, "dead_exports");
    if (dead && darr)
    {
-      int nd = code_audit_dead_exports((const char *const *)exp_tgt, ne,
-                                       (const char *const *)imp_tgt, ni, dead, limit);
+      const char **consumed = calloc((size_t)(ni + nr > 0 ? ni + nr : 1), sizeof(char *));
+      if (consumed)
+      {
+         for (int i = 0; i < ni; i++)
+            consumed[i] = imp_tgt[i];
+         for (int i = 0; i < nr; i++)
+            consumed[ni + i] = ref_tgt[i];
+      }
+      int nd =
+          code_audit_dead_exports((const char *const *)exp_tgt, ne, consumed, ni + nr, dead, limit);
       for (int i = 0; i < nd; i++)
          cJSON_AddItemToArray(darr, cJSON_CreateString(dead[i]));
+      free(consumed);
    }
    free(dead);
 
@@ -239,9 +318,16 @@ cJSON *db2_kb_service_code_audit_json(const char *project, int limit)
       free(imp_src[i]);
       free(imp_tgt[i]);
    }
+   for (int i = 0; i < nr; i++)
+   {
+      free(ref_src[i]);
+      free(ref_tgt[i]);
+   }
    free(exp_src);
    free(exp_tgt);
    free(imp_src);
    free(imp_tgt);
+   free(ref_src);
+   free(ref_tgt);
    return resp;
 }

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -29,6 +29,20 @@ static void copy_sqlite_err(char *errbuf, size_t errlen, const char *src)
  * domain APIs. The SQLite-flavoured DB2 schema lives in
  * src/db2/schema_sqlite.sql and is embedded as AIMEE_DB2_SCHEMA_SQLITE_SQL. */
 
+#ifndef AIMEE_DISABLE_DB2_SQLITE_SHIM
+static void db2_run_sqlite_migrations(sqlite3 *db)
+{
+   /* Each statement is independent; duplicate-column / missing-table errors are
+    * ignored so legacy and fresh DBs both continue to the canonical schema. */
+   static const char *migrations[] = {
+       "ALTER TABLE code_embeddings ADD COLUMN body_hash TEXT NOT NULL DEFAULT ''",
+       NULL,
+   };
+   for (int i = 0; migrations[i]; i++)
+      sqlite3_exec(db, migrations[i], NULL, NULL, NULL);
+}
+#endif
+
 int db_apply_schema_postgres(void *pg_conn, char *errbuf, size_t errlen)
 {
    if (!pg_conn)
@@ -50,6 +64,7 @@ int db2_apply_schema_sqlite_shim(sqlite3 *db, char *errbuf, size_t errlen)
       copy_sqlite_err(errbuf, errlen, "sqlite shim unavailable");
       return -1;
    }
+   db2_run_sqlite_migrations(db);
    char *err = NULL;
    int rc = sqlite3_exec(db, AIMEE_DB2_SCHEMA_SQLITE_SQL, NULL, NULL, &err);
    if (rc != SQLITE_OK)

--- a/src/db2/kb_service_backend.h
+++ b/src/db2/kb_service_backend.h
@@ -111,6 +111,8 @@ extern "C"
    int db2_kb_service_directive_sweep_expired(void);
    cJSON *db2_kb_service_directive_list_json(const char *state, const char *cause, int max_rows);
    /* Graph-derived code-health audit: dead exports, import cycles, clones. */
+   int db2_code_audit_edge_target_like(const char *relation, const char *project, char *out,
+                                       size_t cap);
    cJSON *db2_kb_service_code_audit_json(const char *project, int limit);
    cJSON *db2_kb_service_curiosity_list_json(const char *state, int max_rows);
    cJSON *db2_kb_service_curiosity_create_json(const char *gap_type, const char *target_entity,

--- a/src/db2/pgvec_kb_service.c
+++ b/src/db2/pgvec_kb_service.c
@@ -116,14 +116,15 @@ int pgvec_kb_service_ensure_code_collection(int dim)
 
 int pgvec_kb_service_code_upsert(int64_t point_id, const float *vec, int dim, const char *project,
                                  const char *node_key, const char *file_path, const char *symbol,
-                                 const char *content_hash, const char *payload_json)
+                                 const char *content_hash, const char *body_hash,
+                                 const char *payload_json)
 {
    return pgvec_code_upsert(point_id, vec, dim, project, node_key, file_path, symbol, content_hash,
-                            payload_json);
+                            body_hash, payload_json);
 }
 
 int pgvec_kb_service_code_exists_by_hash(const char *project, const char *node_key,
-                                         const char *content_hash)
+                                         const char *content_hash, const char *body_hash)
 {
-   return pgvec_code_exists_by_hash(project, node_key, content_hash);
+   return pgvec_code_exists_by_hash(project, node_key, content_hash, body_hash);
 }

--- a/src/db2/pgvec_kb_service.h
+++ b/src/db2/pgvec_kb_service.h
@@ -36,9 +36,10 @@ extern "C"
    int pgvec_kb_service_code_upsert(int64_t point_id, const float *vec, int dim,
                                     const char *project, const char *node_key,
                                     const char *file_path, const char *symbol,
-                                    const char *content_hash, const char *payload_json);
+                                    const char *content_hash, const char *body_hash,
+                                    const char *payload_json);
    int pgvec_kb_service_code_exists_by_hash(const char *project, const char *node_key,
-                                            const char *content_hash);
+                                            const char *content_hash, const char *body_hash);
 
 #ifdef __cplusplus
 }

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1320,7 +1320,7 @@ int pgvec_curator_code_unit_search(const char *which_vec, const char *def_kind, 
 
 int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *project,
                       const char *node_key, const char *file_path, const char *symbol,
-                      const char *content_hash, const char *payload_json)
+                      const char *content_hash, const char *body_hash, const char *payload_json)
 {
    if (!vec || dim <= 0)
       return 0;
@@ -1335,11 +1335,11 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
    static const char *sql =
        "INSERT INTO code_embeddings"
        "  (point_id, embedding, project, node_key, file_path, symbol,"
-       "   content_hash, payload_json,"
+       "   content_hash, body_hash, payload_json,"
        "   updated_at)"
        " VALUES"
        "  (:point_id, :embedding::vector, :project, :node_key, :file_path, :symbol,"
-       "   :content_hash, :payload,"
+       "   :content_hash, :body_hash, :payload,"
        "   to_char(CURRENT_TIMESTAMP,'YYYY-MM-DD HH24:MI:SS'))"
        " ON CONFLICT (point_id) DO UPDATE SET"
        "  embedding = EXCLUDED.embedding,"
@@ -1348,6 +1348,7 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
        "  file_path = EXCLUDED.file_path,"
        "  symbol = EXCLUDED.symbol,"
        "  content_hash = EXCLUDED.content_hash,"
+       "  body_hash = EXCLUDED.body_hash,"
        "  payload_json = EXCLUDED.payload_json,"
        "  updated_at = EXCLUDED.updated_at";
 
@@ -1365,6 +1366,7 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
    aimee_pg_bind_text(stmt, "file_path", file_path ? file_path : "");
    aimee_pg_bind_text(stmt, "symbol", symbol ? symbol : "");
    aimee_pg_bind_text(stmt, "content_hash", content_hash ? content_hash : "");
+   aimee_pg_bind_text(stmt, "body_hash", body_hash ? body_hash : "");
    aimee_pg_bind_text(stmt, "payload", payload_json ? payload_json : "");
 
    aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
@@ -1462,16 +1464,17 @@ int pgvec_code_search(const char *project, const float *vec, int dim, int limit,
    return (rc == AIMEE_PG_ERR) ? -1 : n;
 }
 
-int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash)
+int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash,
+                              const char *body_hash)
 {
    if (!project || !node_key || !content_hash || !*content_hash)
       return 0;
    void *pg = db2_conn();
    if (!pg)
       return 0;
-   static const char *sql =
-       "SELECT 1 FROM code_embeddings"
-       " WHERE project = :proj AND node_key = :nk AND content_hash = :ch LIMIT 1";
+   static const char *sql = "SELECT 1 FROM code_embeddings"
+                            " WHERE project = :proj AND node_key = :nk AND content_hash = :ch"
+                            "   AND (:bh = '' OR body_hash = :bh) LIMIT 1";
    char errbuf[256];
    aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
    if (!stmt)
@@ -1479,6 +1482,7 @@ int pgvec_code_exists_by_hash(const char *project, const char *node_key, const c
    aimee_pg_bind_text(stmt, "proj", project);
    aimee_pg_bind_text(stmt, "nk", node_key);
    aimee_pg_bind_text(stmt, "ch", content_hash);
+   aimee_pg_bind_text(stmt, "bh", body_hash ? body_hash : "");
    int found = (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW) ? 1 : 0;
    aimee_pg_finalize(stmt);
    return found;

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -176,12 +176,14 @@ void pgvec_search_latency_snapshot(int64_t *total_us, int64_t *count, int64_t *m
 /* Code vector operations (Phase 5). */
 int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *project,
                       const char *node_key, const char *file_path, const char *symbol,
-                      const char *content_hash, const char *payload_json);
+                      const char *content_hash, const char *body_hash, const char *payload_json);
 int pgvec_code_delete(int64_t point_id);
 int pgvec_code_delete_project(const char *project);
 int pgvec_code_search(const char *project, const float *vec, int dim, int limit, int64_t *ids,
                       double *scores, int max);
-/* Returns 1 if a code_embeddings row with (project, node_key, content_hash) exists. */
-int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash);
+/* Returns 1 if a code_embeddings row with (project, node_key, content_hash,
+ * body_hash) exists. body_hash may be blank for legacy callers. */
+int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash,
+                              const char *body_hash);
 
 #endif /* DEC_DB2_PGVEC_TRANSPORT_H */

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -909,10 +909,14 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
                 symbol       TEXT NOT NULL DEFAULT '',
                 record_type  TEXT NOT NULL DEFAULT 'code_unit',
                 content_hash TEXT NOT NULL DEFAULT '',
+                body_hash    TEXT NOT NULL DEFAULT '',
                 source_hash  TEXT NOT NULL DEFAULT '',
                 payload_json TEXT NOT NULL DEFAULT '',
                 updated_at   TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
             )
+        $T$;
+        EXECUTE $T$
+            ALTER TABLE code_embeddings ADD COLUMN IF NOT EXISTS body_hash TEXT NOT NULL DEFAULT ''
         $T$;
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_code_embeddings_project
@@ -925,6 +929,10 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         EXECUTE $T$
             CREATE UNIQUE INDEX IF NOT EXISTS idx_code_embeddings_hash
                 ON code_embeddings(project, node_key, content_hash)
+        $T$;
+        EXECUTE $T$
+            CREATE INDEX IF NOT EXISTS idx_code_embeddings_body_hash
+                ON code_embeddings(project, body_hash)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'code_embeddings table skipped (%)', SQLERRM;

--- a/src/db2/schema_sqlite.sql
+++ b/src/db2/schema_sqlite.sql
@@ -296,7 +296,8 @@ CREATE INDEX IF NOT EXISTS idx_ee_source_relation ON entity_edges(source, relati
 CREATE INDEX IF NOT EXISTS idx_ee_target_relation ON entity_edges(target, relation);
 CREATE INDEX IF NOT EXISTS idx_ee_origin_source ON entity_edges(edge_origin, source);
 CREATE INDEX IF NOT EXISTS idx_ee_projection_generation ON entity_edges(projection_generation_id, source, relation);
-CREATE TABLE IF NOT EXISTS code_embeddings (  point_id INTEGER PRIMARY KEY,  embedding TEXT NOT NULL DEFAULT '[]',  project TEXT NOT NULL DEFAULT '',  node_key TEXT NOT NULL DEFAULT '',  file_path TEXT NOT NULL DEFAULT '',  symbol TEXT NOT NULL DEFAULT '',  record_type TEXT NOT NULL DEFAULT 'code_unit',  content_hash TEXT NOT NULL DEFAULT '',  source_hash TEXT NOT NULL DEFAULT '',  payload_json TEXT NOT NULL DEFAULT '',  updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+CREATE TABLE IF NOT EXISTS code_embeddings (  point_id INTEGER PRIMARY KEY,  embedding TEXT NOT NULL DEFAULT '[]',  project TEXT NOT NULL DEFAULT '',  node_key TEXT NOT NULL DEFAULT '',  file_path TEXT NOT NULL DEFAULT '',  symbol TEXT NOT NULL DEFAULT '',  record_type TEXT NOT NULL DEFAULT 'code_unit',  content_hash TEXT NOT NULL DEFAULT '',  body_hash TEXT NOT NULL DEFAULT '',  source_hash TEXT NOT NULL DEFAULT '',  payload_json TEXT NOT NULL DEFAULT '',  updated_at TEXT NOT NULL DEFAULT (datetime('now')));
 CREATE INDEX IF NOT EXISTS idx_code_embeddings_project ON code_embeddings(project);
 CREATE INDEX IF NOT EXISTS idx_code_embeddings_node ON code_embeddings(project, node_key);
 CREATE UNIQUE INDEX IF NOT EXISTS idx_code_embeddings_hash ON code_embeddings(project, node_key, content_hash);
+CREATE INDEX IF NOT EXISTS idx_code_embeddings_body_hash ON code_embeddings(project, body_hash);

--- a/src/headers/cli_code_audit.h
+++ b/src/headers/cli_code_audit.h
@@ -1,14 +1,11 @@
 /* cli_code_audit.h: P4 code-health audit (`aimee code audit`).
  *
- * A self-contained client command that walks the working tree and reports
- * file-level health signals — untested code files (stem-matched against test
- * files) and orphaned TODO/FIXME/HACK/XXX markers — with a 0..100 debt score
- * (100 = clean). It runs locally over the repo and needs no kb/server.
- *
- * This is the self-contained slice of docs/proposals/pending/code-health-audit.md;
- * the graph-derived checks there (dead exports, import cycles, body-hash clones)
- * need new kb-side graph queries + a body_hash index column and remain a kb
- * follow-on.
+ * Walks the working tree and reports file-level health signals (untested files,
+ * TODO/FIXME/HACK/XXX markers, DB-in-routes, missing HTTP error handling) with a
+ * 0..100 debt score (100 = clean). Normal audits attempt one kb-side graph
+ * request to /v1/code/audit (dead exports, import cycles, body-hash clones) and
+ * quietly degrade when the server is unavailable. They also write a short,
+ * scope-labelled AUDIT_CONTEXT block for ingress pre-injection.
  *
  * The classification/scoring helpers are pure and unit-tested; the tree walk
  * and reporting live in the .c.
@@ -32,11 +29,19 @@ void audit_stem(const char *path, char *out, size_t cap);
 /* Count orphaned-work markers (TODO/FIXME/HACK/XXX) in `content`. Pure. */
 int audit_count_todos(const char *content);
 
-/* Debt score in [0,100] (100 = clean) from the audit tallies. Pure. */
-int audit_debt_score(int code_files, int untested, int todo_markers);
+/* Count route-layer DB access smells in `content` for paths that look like
+ * routes/controllers/API handlers. Pure. */
+int audit_count_db_in_routes(const char *path, const char *content);
 
-/* `aimee code audit [dir] [--json]` entry. Walks `dir` (default cwd), runs the
- * file-level checks, prints a report (or JSON), and returns 0. */
+/* Count likely HTTP/fetch calls without obvious nearby error handling. Pure,
+ * heuristic, and intentionally conservative. */
+int audit_count_unhandled_http(const char *content);
+
+/* Debt score in [0,100] (100 = clean) from the audit tallies. Pure. */
+int audit_debt_score(int code_files, int untested, int todo_markers, int db_in_routes,
+                     int unhandled_http);
+
+/* `aimee code audit [dir] [--json] [--project NAME] [--graph] [--fix]` entry. */
 int handle_code_audit(int argc, char **argv, int json_output);
 
 #endif /* DEC_CLI_CODE_AUDIT_H */

--- a/src/headers/code_audit_graph.h
+++ b/src/headers/code_audit_graph.h
@@ -9,7 +9,9 @@
  * Edge-key formats (from db2/code_projection.c):
  *   exports edge target: "export:<proj>:<name>"
  *   imports edge target: "import:<proj>:<name>"
- * An export is consumed iff some import shares the same "<proj>:<name>" tail.
+ *   references edge target: "reference:<proj>:<name>"
+ * An export is consumed iff some import/reference shares the same
+ * "<proj>:<name>" tail.
  */
 #ifndef DEC_CODE_AUDIT_GRAPH_H
 #define DEC_CODE_AUDIT_GRAPH_H 1
@@ -21,9 +23,9 @@ typedef struct
    const char *to;   /* exporting file key */
 } audit_edge_t;
 
-/* Select dead exports: export keys ("export:<X>") with no matching import key
- * ("import:<X>"). Writes borrowed pointers from `exports` into `out`. Returns
- * the count written (<= max). Pure. */
+/* Select dead exports: export keys ("export:<X>") with no matching import or
+ * reference key ("import:<X>" / "reference:<X>"). Writes borrowed pointers from
+ * `exports` into `out`. Returns the count written (<= max). Pure. */
 int code_audit_dead_exports(const char *const *exports, int n_exports, const char *const *imports,
                             int n_imports, const char **out, int max);
 

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -14,11 +14,154 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 
 #define CE_ERRBUF               256
 #define CE_TEXT_CAP             4096
 #define CE_FALLBACK_MAX_CALLS   5
 #define CE_FALLBACK_MAX_IMPORTS 5
+
+static unsigned long long ce_fnv1a_update(unsigned long long h, unsigned char c)
+{
+   h ^= (unsigned long long)c;
+   h *= 1099511628211ULL;
+   return h;
+}
+
+static int ce_path_uses_hash_comments(const char *rel_path)
+{
+   const char *dot = rel_path ? strrchr(rel_path, '.') : NULL;
+   if (!dot)
+      return 0;
+   return strcmp(dot, ".py") == 0 || strcmp(dot, ".rb") == 0 || strcmp(dot, ".sh") == 0 ||
+          strcmp(dot, ".bash") == 0 || strcmp(dot, ".zsh") == 0 || strcmp(dot, ".yaml") == 0 ||
+          strcmp(dot, ".yml") == 0 || strcmp(dot, ".toml") == 0;
+}
+
+static int ce_path_uses_slash_comments(const char *rel_path)
+{
+   const char *dot = rel_path ? strrchr(rel_path, '.') : NULL;
+   if (!dot)
+      return 0;
+   return strcmp(dot, ".c") == 0 || strcmp(dot, ".h") == 0 || strcmp(dot, ".cc") == 0 ||
+          strcmp(dot, ".cpp") == 0 || strcmp(dot, ".cxx") == 0 || strcmp(dot, ".hpp") == 0 ||
+          strcmp(dot, ".hh") == 0 || strcmp(dot, ".java") == 0 || strcmp(dot, ".js") == 0 ||
+          strcmp(dot, ".jsx") == 0 || strcmp(dot, ".ts") == 0 || strcmp(dot, ".tsx") == 0 ||
+          strcmp(dot, ".go") == 0 || strcmp(dot, ".rs") == 0 || strcmp(dot, ".cs") == 0 ||
+          strcmp(dot, ".kt") == 0 || strcmp(dot, ".swift") == 0;
+}
+
+void kb_code_embed_normalized_file_body_hash(const char *root, const char *rel_path, char out[32])
+{
+   if (!out)
+      return;
+   out[0] = '\0';
+   if (!root || !rel_path)
+      return;
+
+   char path[1024];
+   int n = snprintf(path, sizeof(path), "%s/%s", root, rel_path);
+   if (n < 0 || (size_t)n >= sizeof(path))
+      return;
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return;
+
+   /* Lightweight heuristic normalization, not a language parser: strips common
+    * comments and collapses whitespace, but does not understand string/char
+    * literals. Good enough for advisory clone grouping; symbol-level parsers can
+    * replace it when code-unit rows become parser-backed. */
+   unsigned long long h = 1469598103934665603ULL;
+   int c;
+   int in_ws = 0;
+   int line_prefix_ws = 1;
+   int hash_comments = ce_path_uses_hash_comments(rel_path);
+   int slash_comments = ce_path_uses_slash_comments(rel_path);
+   int emitted = 0;
+   while ((c = fgetc(f)) != EOF)
+   {
+      if (slash_comments && c == '/')
+      {
+         int next = fgetc(f);
+         if (next == '/')
+         {
+            while ((c = fgetc(f)) != EOF && c != '\n')
+               ;
+            in_ws = 1;
+            line_prefix_ws = 1;
+            continue;
+         }
+         if (next == '*')
+         {
+            int prev = 0;
+            while ((c = fgetc(f)) != EOF)
+            {
+               if (prev == '*' && c == '/')
+                  break;
+               prev = c;
+            }
+            in_ws = 1;
+            continue;
+         }
+         if (next != EOF)
+            ungetc(next, f);
+      }
+      if (hash_comments && c == '#' && line_prefix_ws)
+      {
+         while ((c = fgetc(f)) != EOF && c != '\n')
+            ;
+         in_ws = 1;
+         line_prefix_ws = 1;
+         continue;
+      }
+      if (isspace((unsigned char)c))
+      {
+         in_ws = 1;
+         if (c == '\n' || c == '\r')
+            line_prefix_ws = 1;
+         continue;
+      }
+      if (in_ws)
+      {
+         h = ce_fnv1a_update(h, ' ');
+         in_ws = 0;
+      }
+      h = ce_fnv1a_update(h, (unsigned char)c);
+      emitted = 1;
+      line_prefix_ws = 0;
+   }
+   fclose(f);
+   if (emitted)
+      snprintf(out, 32, "%016llx", h);
+}
+
+static int ce_file_line_count(const char *root, const char *rel_path)
+{
+   if (!root || !rel_path)
+      return 0;
+   char path[1024];
+   int n = snprintf(path, sizeof(path), "%s/%s", root, rel_path);
+   if (n < 0 || (size_t)n >= sizeof(path))
+      return 0;
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return 0;
+   int lines = 0;
+   int saw_any = 0;
+   int last = '\n';
+   int c;
+   while ((c = fgetc(f)) != EOF)
+   {
+      saw_any = 1;
+      if (c == '\n')
+         lines++;
+      last = c;
+   }
+   fclose(f);
+   if (saw_any && last != '\n')
+      lines++;
+   return lines;
+}
 
 int kb_code_embed_build_fallback_text(const char *project, const char *file_path, int64_t file_id,
                                       char *out, size_t cap)
@@ -141,14 +284,19 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
    char err[CE_ERRBUF] = "";
 
    /* Get project id. */
-   static const char *proj_sql = "SELECT id FROM projects WHERE name = ?1 LIMIT 1";
+   static const char *proj_sql = "SELECT id, root FROM projects WHERE name = ?1 LIMIT 1";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, proj_sql, err, sizeof(err));
    if (!st)
       return -1;
    aimee_pg_bind_text(st, "?1", project);
    int64_t proj_id = -1;
+   char project_root[512] = "";
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
       proj_id = aimee_pg_column_int64(st, 0);
+      const char *root = aimee_pg_column_text(st, 1);
+      snprintf(project_root, sizeof(project_root), "%s", root ? root : "");
+   }
    aimee_pg_finalize(st);
    if (proj_id < 0)
    {
@@ -238,8 +386,17 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
       if (db2_entity_node_key_file(project, rows[i].path, node_key, sizeof(node_key)) != 0)
          continue;
 
-      /* Skip unchanged: check content_hash. */
-      if (rows[i].hash[0] && pgvec_kb_service_code_exists_by_hash(project, node_key, rows[i].hash))
+      char body_hash[32];
+      kb_code_embed_normalized_file_body_hash(project_root, rows[i].path, body_hash);
+      int line_count = ce_file_line_count(project_root, rows[i].path);
+      if (!body_hash[0] && line_count > 0)
+         snprintf(body_hash, sizeof(body_hash), "%s", rows[i].hash);
+
+      /* Skip unchanged only when both file content and normalized body hash are
+       * current. Upgraded stores with blank legacy body_hash intentionally
+       * re-embed once so clone grouping is backfilled. */
+      if (rows[i].hash[0] &&
+          pgvec_kb_service_code_exists_by_hash(project, node_key, rows[i].hash, body_hash))
       {
          skipped++;
          continue;
@@ -264,8 +421,8 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
       char payload[2048];
       int plen = snprintf(payload, sizeof(payload),
                           "{\"project\":\"%s\",\"node_key\":\"%s\",\"file_path\":\"%s\","
-                          "\"content_hash\":\"%s\"}",
-                          project, node_key, rows[i].path, rows[i].hash);
+                          "\"content_hash\":\"%s\",\"body_hash\":\"%s\",\"line_count\":%d}",
+                          project, node_key, rows[i].path, rows[i].hash, body_hash, line_count);
       if (plen < 0 || (size_t)plen >= sizeof(payload))
       {
          db2_code_index_op_record(point_id, project, node_key, rows[i].path, 0,
@@ -296,7 +453,7 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
       }
 
       int up = pgvec_kb_service_code_upsert(point_id, vec, 384, project, node_key, rows[i].path, "",
-                                            rows[i].hash, payload);
+                                            rows[i].hash, body_hash, payload);
       /* Per-chunk replay bookkeeping so a failed embed is retried by
        * `memory repair --reset-stuck`, not orphaned. */
       db2_code_index_op_record(point_id, project, node_key, rows[i].path, up == 0,

--- a/src/kb/kb_service_code_embed.h
+++ b/src/kb/kb_service_code_embed.h
@@ -25,6 +25,10 @@ typedef struct
 int kb_code_embed_build_fallback_text(const char *project, const char *file_path, int64_t file_id,
                                       char *out, size_t cap);
 
+/* Compute the normalized file body hash used for advisory clone grouping.
+ * Empty/whitespace-only normalized bodies leave out empty. */
+void kb_code_embed_normalized_file_body_hash(const char *root, const char *rel_path, char out[32]);
+
 /* Run code embedding refresh for a project.
  * scope: "changed_files" | "full_project"
  * paths: optional array of specific file paths (NULL = all in scope)

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -8,13 +8,19 @@
 #include "config.h"
 #include "kb_client.h"
 #include "dstr.h"
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <time.h>
 
 /* The standing exploration policy carried in every envelope. Kept short — it is
  * advice the model weighs, not a contract we can enforce over the wire. */
 #define INGRESS_EXPLORE_WITH                                                                       \
    "find_symbol, lsp_references, ast_grep_search, search_graph, get_context_block"
+
+#define INGRESS_AUDIT_CONTEXT_FILE            "audit_context.txt"
+#define INGRESS_AUDIT_CONTEXT_MAX_AGE_SECONDS (6 * 60 * 60)
 
 /* Per-request disable, set by the HTTP layer from the `x-aimee-preinject: 0`
  * header. Thread-local: the ingress runs the turn synchronously on the request
@@ -95,6 +101,43 @@ char *ingress_preinject_format_code_block(const code_search_hit_t *hits, int n)
       }
    }
    return dstr_steal(&d);
+}
+
+static char *ingress_preinject_read_audit_context(void)
+{
+   const char *dir = config_default_dir();
+   if (!dir || !dir[0])
+      return NULL;
+   char path[4096];
+   int n = snprintf(path, sizeof(path), "%s/%s", dir, INGRESS_AUDIT_CONTEXT_FILE);
+   if (n < 0 || (size_t)n >= sizeof(path))
+      return NULL;
+   struct stat st;
+   if (stat(path, &st) != 0 || !S_ISREG(st.st_mode))
+      return NULL;
+   time_t now = time(NULL);
+   if (now == (time_t)-1 || st.st_mtime > now ||
+       now - st.st_mtime > INGRESS_AUDIT_CONTEXT_MAX_AGE_SECONDS)
+      return NULL;
+
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   char *buf = malloc(2048);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t got = fread(buf, 1, 2047, f);
+   fclose(f);
+   buf[got] = '\0';
+   if (got == 0)
+   {
+      free(buf);
+      return NULL;
+   }
+   return buf;
 }
 
 /* Pull the text out of a message `content` that is either a JSON string or an
@@ -200,6 +243,17 @@ char *ingress_preinject_build(const char *query, int request_disabled)
          score = ms;
    }
    free(mem);
+
+   char *audit = ingress_preinject_read_audit_context();
+   if (audit && audit[0])
+   {
+      if (block.len)
+         dstr_append_str(&block, "\n");
+      dstr_append_str(&block, audit);
+      if (score < 0.4)
+         score = 0.4;
+   }
+   free(audit);
 
    char *blk = dstr_steal(&block);
    if (!blk || !blk[0])

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -78,7 +78,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -548,6 +548,11 @@ $(TESTPREFIX)/unit-test-code-audit: $(OBJDIR)/tests/test_code_audit.o \
 
 $(TESTPREFIX)/unit-test-code-audit-graph: $(OBJDIR)/tests/test_code_audit_graph.o \
                      $(OBJDIR)/code_audit_graph.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-db2-code-audit: $(OBJDIR)/tests/test_db2_code_audit.o \
+                     $(OBJDIR)/db2/code_audit.o $(OBJDIR)/db2/entity_nodes.o \
+                     $(OBJDIR)/code_audit_graph.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)

--- a/src/tests/test_code_audit.c
+++ b/src/tests/test_code_audit.c
@@ -6,6 +6,11 @@
 #include <string.h>
 #include "cli_code_audit.h"
 
+const char *aimee_home(void)
+{
+   return "/tmp/aimee-test";
+}
+
 static void test_is_code_file(void)
 {
    assert(audit_is_code_file("src/foo.c"));
@@ -53,16 +58,35 @@ static void test_count_todos(void)
    printf("count_todos OK\n");
 }
 
+static void test_db_in_routes(void)
+{
+   assert(audit_count_db_in_routes("src/routes/user.c", "SELECT * FROM users") == 1);
+   assert(audit_count_db_in_routes("src/api/user.py", "db2_code_index_project_count()") == 1);
+   assert(audit_count_db_in_routes("api/user.py", "aimee_pg_prepare(conn, sql, err, n)") == 1);
+   assert(audit_count_db_in_routes("src/lib/user.c", "SELECT * FROM users") == 0);
+   assert(audit_count_db_in_routes("src/routes/user.c", NULL) == 0);
+   printf("db_in_routes OK\n");
+}
+
+static void test_unhandled_http(void)
+{
+   assert(audit_count_unhandled_http("const r = fetch('/x');\n") == 1);
+   assert(audit_count_unhandled_http("try { await fetch('/x'); } catch (e) {}\n") == 0);
+   assert(audit_count_unhandled_http("if (cli_http_request(...)) return -1;\n") == 0);
+   assert(audit_count_unhandled_http(NULL) == 0);
+   printf("unhandled_http OK\n");
+}
+
 static void test_debt_score(void)
 {
-   assert(audit_debt_score(0, 0, 0) == 100);   /* no code -> clean */
-   assert(audit_debt_score(100, 0, 0) == 100); /* all tested, no todos */
-   /* all untested -> 60-pt penalty -> 40 */
-   assert(audit_debt_score(100, 100, 0) == 40);
-   /* half untested -> 30-pt penalty -> 70 */
-   assert(audit_debt_score(100, 50, 0) == 70);
+   assert(audit_debt_score(0, 0, 0, 0, 0) == 100);   /* no code -> clean */
+   assert(audit_debt_score(100, 0, 0, 0, 0) == 100); /* all tested, no todos */
+   /* all untested -> 55-pt penalty -> 45 */
+   assert(audit_debt_score(100, 100, 0, 0, 0) == 45);
+   /* half untested -> 28-pt rounded penalty -> 73 */
+   assert(audit_debt_score(100, 50, 0, 0, 0) == 73);
    /* todos drag the score down but stay clamped >= 0 */
-   int s = audit_debt_score(10, 10, 1000);
+   int s = audit_debt_score(10, 10, 1000, 20, 20);
    assert(s >= 0 && s <= 100);
    printf("debt_score OK\n");
 }
@@ -74,6 +98,8 @@ int main(void)
    test_is_test_file();
    test_stem();
    test_count_todos();
+   test_db_in_routes();
+   test_unhandled_http();
    test_debt_score();
    printf("all tests passed\n");
    return 0;

--- a/src/tests/test_code_audit_graph.c
+++ b/src/tests/test_code_audit_graph.c
@@ -21,6 +21,8 @@ static void test_dead_exports(void)
    const char *e2[] = {"export:p:A"};
    const char *i2[] = {"import:p:A"};
    assert(code_audit_dead_exports(e2, 1, i2, 1, out, 8) == 0);
+   const char *r2[] = {"reference:p:A"};
+   assert(code_audit_dead_exports(e2, 1, r2, 1, out, 8) == 0);
 
    /* no imports at all -> all dead, capped at max */
    assert(code_audit_dead_exports(exports, 3, NULL, 0, out, 1) == 1);

--- a/src/tests/test_code_vectors.c
+++ b/src/tests/test_code_vectors.c
@@ -1,8 +1,11 @@
 /* test_code_vectors.c: unit tests for Phase 5 code vector recall. */
 
 #include <assert.h>
+#include <errno.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "aimee.h"
 #include "db.h"
@@ -15,6 +18,21 @@
 #include "../db2/entity_nodes.h"
 
 static char g_db_path[512];
+
+static void write_text_file(const char *path, const char *text)
+{
+   FILE *f = fopen(path, "wb");
+   assert(f != NULL);
+   assert(fputs(text, f) >= 0);
+   assert(fclose(f) == 0);
+}
+
+static void make_tmp_dir(char *path, size_t cap, const char *suffix)
+{
+   snprintf(path, cap, "%s/aimee-code-vectors-%ld-%s", platform_tmpdir(), (long)getpid(), suffix);
+   if (mkdir(path, 0700) != 0 && errno != EEXIST)
+      assert(0);
+}
 
 static void setup(void)
 {
@@ -111,7 +129,7 @@ static void test_fallback_text_null(void)
 /* Test: pgvec_code_exists_by_hash graceful with no DB. */
 static void test_code_exists_no_db(void)
 {
-   int r = pgvec_kb_service_code_exists_by_hash("proj", "file:proj:foo.c", "abc123");
+   int r = pgvec_kb_service_code_exists_by_hash("proj", "file:proj:foo.c", "abc123", "body123");
    assert(r == 0 || r == 1);
 }
 
@@ -157,6 +175,41 @@ static void test_ensure_code_collection(void)
    teardown();
 }
 
+static void test_normalized_body_hash_comments(void)
+{
+   char dir[512];
+   make_tmp_dir(dir, sizeof(dir), "hash");
+
+   char p1[1024], p2[1024], p3[1024], p4[1024], p5[1024];
+   snprintf(p1, sizeof(p1), "%s/a.yaml", dir);
+   snprintf(p2, sizeof(p2), "%s/b.yaml", dir);
+   snprintf(p3, sizeof(p3), "%s/a.c", dir);
+   snprintf(p4, sizeof(p4), "%s/b.c", dir);
+   snprintf(p5, sizeof(p5), "%s/empty.c", dir);
+   write_text_file(p1, "url: https://example.com/a\n");
+   write_text_file(p2, "url: https://example.com/b\n");
+   write_text_file(p3, "int x = 1; // comment one\n");
+   write_text_file(p4, "int x = 1; /* comment two */\n");
+   write_text_file(p5, "   \n\t\n");
+
+   char h1[32], h2[32], h3[32], h4[32], h5[32];
+   kb_code_embed_normalized_file_body_hash(dir, "a.yaml", h1);
+   kb_code_embed_normalized_file_body_hash(dir, "b.yaml", h2);
+   kb_code_embed_normalized_file_body_hash(dir, "a.c", h3);
+   kb_code_embed_normalized_file_body_hash(dir, "b.c", h4);
+   kb_code_embed_normalized_file_body_hash(dir, "empty.c", h5);
+   assert(h1[0] && h2[0] && strcmp(h1, h2) != 0);
+   assert(h3[0] && h4[0] && strcmp(h3, h4) == 0);
+   assert(h5[0] == '\0');
+
+   unlink(p1);
+   unlink(p2);
+   unlink(p3);
+   unlink(p4);
+   unlink(p5);
+   rmdir(dir);
+}
+
 int main(void)
 {
    printf("test_refresh_no_db... ");
@@ -194,6 +247,9 @@ int main(void)
    printf("ok\n");
    printf("test_ensure_code_collection... ");
    test_ensure_code_collection();
+   printf("ok\n");
+   printf("test_normalized_body_hash_comments... ");
+   test_normalized_body_hash_comments();
    printf("ok\n");
    printf("code_vectors: all tests passed\n");
    return 0;

--- a/src/tests/test_db.c
+++ b/src/tests/test_db.c
@@ -148,6 +148,59 @@ static void test_key_tables_exist(void)
    sqlite3_close(db);
 }
 
+static int sqlite_column_exists(sqlite3 *db, const char *table, const char *column)
+{
+   char sql[256];
+   snprintf(sql, sizeof(sql), "PRAGMA table_info(%s)", table);
+   sqlite3_stmt *stmt = NULL;
+   assert(sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) == SQLITE_OK);
+   int found = 0;
+   while (sqlite3_step(stmt) == SQLITE_ROW)
+   {
+      const unsigned char *name = sqlite3_column_text(stmt, 1);
+      if (name && strcmp((const char *)name, column) == 0)
+      {
+         found = 1;
+         break;
+      }
+   }
+   sqlite3_finalize(stmt);
+   return found;
+}
+
+static void test_db2_sqlite_code_embeddings_body_hash_migration(void)
+{
+   sqlite3 *db = NULL;
+   assert(sqlite3_open(":memory:", &db) == SQLITE_OK);
+   db1_apply_pragmas(db, DB_MODE_CLI);
+   assert(sqlite3_exec(db,
+                       "CREATE TABLE code_embeddings ("
+                       " point_id INTEGER PRIMARY KEY,"
+                       " embedding TEXT NOT NULL DEFAULT '[]',"
+                       " project TEXT NOT NULL DEFAULT '',"
+                       " node_key TEXT NOT NULL DEFAULT '',"
+                       " file_path TEXT NOT NULL DEFAULT '',"
+                       " symbol TEXT NOT NULL DEFAULT '',"
+                       " record_type TEXT NOT NULL DEFAULT 'code_unit',"
+                       " content_hash TEXT NOT NULL DEFAULT '',"
+                       " source_hash TEXT NOT NULL DEFAULT '',"
+                       " payload_json TEXT NOT NULL DEFAULT '',"
+                       " updated_at TEXT NOT NULL DEFAULT (datetime('now')))",
+                       NULL, NULL, NULL) == SQLITE_OK);
+   assert(!sqlite_column_exists(db, "code_embeddings", "body_hash"));
+
+   char err[512] = {0};
+   assert(db2_apply_schema_sqlite_shim(db, err, sizeof(err)) == 0);
+   assert(sqlite_column_exists(db, "code_embeddings", "body_hash"));
+   assert(sqlite3_exec(db,
+                       "INSERT INTO code_embeddings"
+                       " (point_id, project, node_key, content_hash, body_hash)"
+                       " VALUES (1, 'p', 'file:p:a.c', 'content', 'body')",
+                       NULL, NULL, NULL) == SQLITE_OK);
+
+   sqlite3_close(db);
+}
+
 static void test_trigger_run_change_counts(void)
 {
    char path[PATH_MAX];
@@ -751,6 +804,7 @@ int main(void)
    test_prepare_cache_different_queries();
    test_migrations_idempotent();
    test_key_tables_exist();
+   test_db2_sqlite_code_embeddings_body_hash_migration();
    test_trigger_run_change_counts();
    test_cron_job_history_round_trip();
    test_model_catalog_cache();

--- a/src/tests/test_db2_code_audit.c
+++ b/src/tests/test_db2_code_audit.c
@@ -1,0 +1,91 @@
+/* test_db2_code_audit.c: DB2 code-audit assembly helper regressions. */
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "db2/kb_service_backend.h"
+#include "db2/db_postgres.h"
+
+void *db2_conn(void)
+{
+   return NULL;
+}
+
+aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
+{
+   (void)pg_conn;
+   (void)sql;
+   (void)errbuf;
+   (void)errlen;
+   return NULL;
+}
+
+void aimee_pg_finalize(aimee_pg_stmt_t *stmt)
+{
+   (void)stmt;
+}
+
+aimee_pg_step_t aimee_pg_step(aimee_pg_stmt_t *stmt, char *errbuf, size_t errlen)
+{
+   (void)stmt;
+   (void)errbuf;
+   (void)errlen;
+   return AIMEE_PG_DONE;
+}
+
+int aimee_pg_bind_int(aimee_pg_stmt_t *stmt, const char *name, int value)
+{
+   (void)stmt;
+   (void)name;
+   (void)value;
+   return 0;
+}
+
+int aimee_pg_bind_text(aimee_pg_stmt_t *stmt, const char *name, const char *value)
+{
+   (void)stmt;
+   (void)name;
+   (void)value;
+   return 0;
+}
+
+const char *aimee_pg_column_text(aimee_pg_stmt_t *stmt, int col)
+{
+   (void)stmt;
+   (void)col;
+   return "";
+}
+
+double aimee_pg_column_double(aimee_pg_stmt_t *stmt, int col)
+{
+   (void)stmt;
+   (void)col;
+   return 0.0;
+}
+
+static void test_edge_target_like(void)
+{
+   char like[256];
+   assert(db2_code_audit_edge_target_like("exports", "proj", like, sizeof(like)) == 0);
+   assert(strcmp(like, "export:proj:%") == 0);
+
+   assert(db2_code_audit_edge_target_like("imports", "my project", like, sizeof(like)) == 0);
+   assert(strcmp(like, "import:my%20project:%") == 0);
+
+   assert(db2_code_audit_edge_target_like("references", "my project", like, sizeof(like)) == 0);
+   assert(strcmp(like, "reference:my%20project:%") == 0);
+
+   assert(db2_code_audit_edge_target_like("exports", "", like, sizeof(like)) == 0);
+   assert(strcmp(like, "") == 0);
+   assert(db2_code_audit_edge_target_like("defines", "proj", like, sizeof(like)) != 0);
+}
+
+int main(void)
+{
+   printf("db2_code_audit: ");
+   test_edge_target_like();
+   printf("edge_target_like OK\n");
+   printf("all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -34,6 +34,10 @@ int config_load(config_t *cfg)
       memset(cfg, 0, sizeof(*cfg));
    return 0;
 }
+const char *config_default_dir(void)
+{
+   return "/tmp/aimee-test";
+}
 
 static void test_confidence_tiers(void)
 {

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -44,8 +44,8 @@ static int stub_models_provider(char ids[][SERVER_HTTP_MODEL_ID_MAX], int max)
 /* Last dispatch captured by the stub, so route→method tests can assert which
  * NDJSON method a first-class /v1 route actually dispatched, and that the body
  * survived the bridge. */
-static char g_disp_method[96];
-static char g_disp_body[512];
+static _Thread_local char g_disp_method[96];
+static _Thread_local char g_disp_body[512];
 
 int server_dispatch(server_ctx_t *ctx, server_conn_t *conn, const char *msg, size_t msg_len)
 {


### PR DESCRIPTION
## Summary
- complete `aimee code audit` by combining local heuristics with kb graph audit results when available
- fix project-scoped graph audits by matching singular, canonically encoded edge target keys (`export:<project>:%` / `import:<project>:%` / `reference:<project>:%`)
- count imports and indexed references as dead-export consumers, with regression coverage for `reference:<project>:%` keys
- persist normalized `body_hash` for code embedding rows, now whitespace/comment-normalized, and expose clone grouping from kb audit responses
- gate `//` and `/* */` stripping to C-family paths, while hash-comment languages keep URLs/floor-division-like content intact
- leave empty/whitespace-only normalized files with blank `body_hash`, excluding them from exact clone grouping
- add a file-backed clone span floor via payload `line_count` (`clone_min_lines: 5`) while keeping legacy rows without span metadata eligible
- emit a prioritized `roadmap` array/text section instead of only a flat count summary
- write scope-labelled `AUDIT_CONTEXT` to the profile-aware `audit_context.txt` and have ingress pre-injection append recent audit context automatically
- accept `--fix` and return an explicit no-op status until there are safe automatic fixes to apply
- add SQLite shim migration coverage for legacy `code_embeddings` tables missing `body_hash`
- fix a `testing` merge-race in `unit-test-server-http` by making the dispatch-capture buffers thread-local, so async route tests cannot overwrite sync parity assertions

## Scope notes
- `--fix` is intentionally a no-op placeholder: it parses, reports `no_safe_automatic_fixes`, and emits the roadmap without editing files.
- Clone grouping is reported as `code_embedding_row` granularity. Current code embeddings are file-backed, so this detects duplicate indexed code-unit rows rather than true per-symbol bodies until symbol-level rows are indexed.
- Comment stripping in `body_hash` normalization is heuristic and not string-literal aware; it is sufficient for advisory clone grouping, not semantic equivalence.
- Normal audits attempt one kb graph request and degrade to `graph_status: unavailable` when no server is configured.
- Legacy indexed files with blank `body_hash` will re-embed once after upgrade so the hash and `line_count` payload can be backfilled; subsequent refreshes skip normally when both content and body hashes match.
- The local heuristics remain advisory and conservative; comments or broad substring matches may produce false positives by design.

## Verification
- `make -C src build/obj/tests/unit-test-db2-code-audit build/obj/tests/unit-test-code-vectors build/obj/tests/unit-test-server-http && src/build/obj/tests/unit-test-db2-code-audit && src/build/obj/tests/unit-test-code-vectors && src/build/obj/tests/unit-test-server-http`
- clean synthetic merge reproduction of `unit-test-server-http` against current `testing`
- `make -C src lint build-integrity`
- `make -C src ../aimee ../aimee-kb`
- `AIMEE_HOME="$tmp" ./aimee code audit src/tests --json --fix | head -c 2200 && test -s "$tmp/audit_context.txt"`