### PR TITLE
feat: complete Anthropic Messages ingress

### DIFF
--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -34,6 +34,7 @@ extern "C"
     *   bearer_cfg      : the configured bearer token, or NULL/"" if none.
     *   auth_header     : the Authorization header value (e.g. "Bearer xyz"), or
     *                     NULL if absent.
+    *   api_key_header  : the x-api-key header value, or NULL if absent.
     *   has_session_key : an X-Aimee-Session-Key header was present.
     * Returns 0 if authorized, else the HTTP status to reject with: 503 when a
     * session key is presented without a bearer configured, or when TCP is
@@ -41,7 +42,7 @@ extern "C"
     * TCP. UDS requests are always authorized (subject to the session-key rule).
     * The compare is constant-time. */
    int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_header,
-                             int has_session_key);
+                             const char *api_key_header, int has_session_key);
 
    /* Fixed-window per-bearer rate limiter (pure — unit-testable). State is a
     * single 60s window the caller owns. limit_per_min <= 0 disables limiting
@@ -157,6 +158,7 @@ extern "C"
    typedef int (*server_http_responses_stream_fn)(const char *body, server_http_sse_event_emit emit,
                                                   void *ctx);
    void server_http_set_responses_stream_handler(server_http_responses_stream_fn fn);
+   int server_http_sse_event_format(const char *event, const char *data_json, char *buf, size_t n);
    void server_http_set_completion_handler(server_http_completion_fn fn);
    void server_http_set_embeddings_handler(server_http_completion_fn fn);
    void server_http_set_responses_handler(server_http_completion_fn fn);

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -91,26 +91,80 @@ static int write_error(char *resp, int cap, int status, const char *type, const 
    return status;
 }
 
-/* Translate an Anthropic request into the provider's OpenAI-shaped messages +
- * tools. *out_system is a malloc'd flattened system prompt (caller frees). */
-static void translate_request(const cJSON *req, cJSON **out_messages, cJSON **out_tools,
-                              char **out_system)
+static int driver_is_anthropic(const delegate_driver_t *driver)
+{
+   return driver && driver->name && strcmp(driver->name, "anthropic") == 0;
+}
+
+static int driver_consumes_system_prompt(const delegate_driver_t *driver)
+{
+   return driver && driver->name &&
+          (strcmp(driver->name, "chatgpt") == 0 || strcmp(driver->name, "gemini") == 0);
+}
+
+/* Translate an Anthropic request into the selected provider's message/tool
+ * shape. Anthropic itself receives the original Messages wire shape; the
+ * OpenAI-family providers receive the inverse delegate-driver conversion.
+ * *out_system is a malloc'd flattened system prompt (caller frees). */
+static void translate_request(const cJSON *req, const delegate_driver_t *driver,
+                              cJSON **out_messages, cJSON **out_tools, char **out_system)
 {
    *out_system = anthropic_system_to_text(req);
+   if (driver_is_anthropic(driver))
+   {
+      const cJSON *messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
+      const cJSON *tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+      *out_messages = cJSON_IsArray(messages) ? cJSON_Duplicate(messages, 1) : NULL;
+      *out_tools = cJSON_IsArray(tools) ? cJSON_Duplicate(tools, 1) : NULL;
+      return;
+   }
    *out_messages =
-       anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"), *out_system);
+       anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"),
+                                    driver_consumes_system_prompt(driver) ? NULL : *out_system);
    *out_tools = anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 
-/* Build the provider request body (OpenAI chat shape). `stream` toggles the
- * streaming flag. Returns a malloc'd JSON string (caller frees), or NULL. */
-static char *build_provider_body(const agent_t *ag, cJSON *messages, cJSON *tools, int max_tokens,
-                                 double temperature, int stream)
+/* Build the provider request body via the selected delegate driver. `stream`
+ * toggles the provider stream flag. Returns a malloc'd JSON string (caller
+ * frees), or NULL. */
+static char *build_provider_body(const delegate_driver_t *driver, const agent_t *ag,
+                                 cJSON *messages, cJSON *tools, const char *system_text,
+                                 int max_tokens, double temperature, int stream)
 {
-   cJSON *req = agent_build_request_openai((agent_t *)ag, messages, tools, max_tokens, temperature);
+   cJSON *req = NULL;
    char *body;
+
+   if (driver && driver->build_request)
+      req = driver->build_request(ag, messages, tools, system_text, max_tokens, temperature);
+   else
+      req = agent_build_request_openai((agent_t *)ag, messages, tools, max_tokens, temperature);
    if (!req)
       return NULL;
+   if (stream)
+      cJSON_AddBoolToObject(req, "stream", 1);
+   body = cJSON_PrintUnformatted(req);
+   cJSON_Delete(req);
+   return body;
+}
+
+/* Anthropic-native ingress is a near-passthrough: Claude Code already speaks
+ * Anthropic Messages, so preserve request fields such as system cache_control,
+ * tool_choice, thinking, stop_sequences, top_p, and top_k. The configured
+ * primary model still wins over the inbound model name. */
+static char *build_anthropic_provider_body(const cJSON *in, const agent_t *ag, int stream)
+{
+   cJSON *req;
+   cJSON *model;
+   char *body;
+
+   req = cJSON_Duplicate((cJSON *)in, 1);
+   if (!req)
+      return NULL;
+   cJSON_DeleteItemFromObjectCaseSensitive(req, "model");
+   model = cJSON_CreateString(ag && ag->model[0] ? ag->model : "claude");
+   if (model)
+      cJSON_AddItemToObject(req, "model", model);
+   cJSON_DeleteItemFromObjectCaseSensitive(req, "stream");
    if (stream)
       cJSON_AddBoolToObject(req, "stream", 1);
    body = cJSON_PrintUnformatted(req);
@@ -147,10 +201,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
       return write_error(resp, cap, 503, "api_error", "no primary agent configured");
    }
 
-   translate_request(req, &messages, &tools, &system_text);
-
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
+   translate_request(req, driver, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
    {
@@ -159,8 +212,12 @@ static int messages_buffered(const char *body, char *resp, int cap)
    }
    agent_build_extra_headers(ag, extra, sizeof(extra));
 
-   prov_body = build_provider_body(ag, messages, tools, jo_int(req, "max_tokens", 4096),
-                                   jo_num(req, "temperature", 1.0), 0);
+   if (driver_is_anthropic(driver))
+      prov_body = build_anthropic_provider_body(req, ag, 0);
+   else
+      prov_body =
+          build_provider_body(driver, ag, messages, tools, system_text,
+                              jo_int(req, "max_tokens", 4096), jo_num(req, "temperature", 1.0), 0);
    http_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &response, ag->timeout_ms,
                                  extra[0] ? extra : NULL);
    if (http_status != 200 || !response)
@@ -173,7 +230,12 @@ static int messages_buffered(const char *body, char *resp, int cap)
    provider_resp = cJSON_Parse(response);
    memset(&parsed, 0, sizeof(parsed));
    if (provider_resp)
-      agent_parse_response_openai(provider_resp, &parsed);
+   {
+      if (driver && driver->parse_response)
+         driver->parse_response(provider_resp, response, &parsed);
+      else
+         agent_parse_response_openai(provider_resp, &parsed);
+   }
 
    mint_msg_id(msg_id, sizeof(msg_id));
    out = anthropic_response_from_parsed(msg_id, model, &parsed);
@@ -204,6 +266,18 @@ typedef struct
    anthropic_stream_xlate_t *xl;
 } prov_stream_ctx_t;
 
+typedef struct
+{
+   sse_parser_t parser;
+   server_http_sse_event_emit emit;
+   void *emit_ctx;
+   char event[64];
+   char *data;
+   size_t data_len;
+   size_t data_cap;
+   int emitted;
+} anthropic_relay_ctx_t;
+
 static int prov_line_cb(const char *line, size_t len, void *ud)
 {
    prov_stream_ctx_t *c = (prov_stream_ctx_t *)ud;
@@ -221,6 +295,94 @@ static int prov_chunk_cb(const char *data, size_t len, void *ud)
 {
    prov_stream_ctx_t *c = (prov_stream_ctx_t *)ud;
    return sse_parser_feed(&c->parser, data, len, prov_line_cb, c);
+}
+
+static int relay_append_data(anthropic_relay_ctx_t *c, const char *data)
+{
+   size_t add = data ? strlen(data) : 0;
+   size_t sep = c->data_len ? 1 : 0;
+   size_t need = c->data_len + sep + add + 1;
+   char *tmp;
+
+   if (need > c->data_cap)
+   {
+      size_t cap = c->data_cap ? c->data_cap : 4096;
+      while (cap < need)
+         cap *= 2;
+      tmp = realloc(c->data, cap);
+      if (!tmp)
+         return -1;
+      c->data = tmp;
+      c->data_cap = cap;
+   }
+   if (sep)
+      c->data[c->data_len++] = '\n';
+   if (add)
+   {
+      memcpy(c->data + c->data_len, data, add);
+      c->data_len += add;
+   }
+   c->data[c->data_len] = '\0';
+   return 0;
+}
+
+static void relay_flush(anthropic_relay_ctx_t *c)
+{
+   const char *event = c->event[0] ? c->event : "message";
+
+   if (c->data_len > 0 && strcmp(c->data, "[DONE]") != 0)
+   {
+      c->emit(c->emit_ctx, event, c->data);
+      c->emitted++;
+   }
+   c->event[0] = '\0';
+   c->data_len = 0;
+   if (c->data)
+      c->data[0] = '\0';
+}
+
+static void relay_emit_transport_error(anthropic_relay_ctx_t *c, int status)
+{
+   char data[192];
+
+   snprintf(data, sizeof(data),
+            "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+            "\"message\":\"primary provider stream failed with status %d\"}}",
+            status);
+   c->emit(c->emit_ctx, "error", data);
+   c->emitted++;
+}
+
+static int anthropic_relay_line_cb(const char *line, size_t len, void *ud)
+{
+   anthropic_relay_ctx_t *c = (anthropic_relay_ctx_t *)ud;
+   if (len == 0)
+   {
+      relay_flush(c);
+      return 0;
+   }
+   if (strncmp(line, "event:", 6) == 0)
+   {
+      const char *p = line + 6;
+      while (*p == ' ')
+         p++;
+      snprintf(c->event, sizeof(c->event), "%s", p);
+      return 0;
+   }
+   if (strncmp(line, "data:", 5) == 0)
+   {
+      const char *p = line + 5;
+      while (*p == ' ')
+         p++;
+      return relay_append_data(c, p);
+   }
+   return 0;
+}
+
+static int anthropic_relay_chunk_cb(const char *data, size_t len, void *ud)
+{
+   anthropic_relay_ctx_t *c = (anthropic_relay_ctx_t *)ud;
+   return sse_parser_feed(&c->parser, data, len, anthropic_relay_line_cb, c);
 }
 
 static int messages_stream(const char *body, server_http_sse_event_emit emit, void *ctx)
@@ -256,26 +418,44 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
       return 0;
    }
 
-   translate_request(req, &messages, &tools, &system_text);
-   input_est = messages ? session_compact_estimate_tokens(messages) : 0;
-   xl = anthropic_stream_begin(msg_id, model, input_est, emit, ctx);
-
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
-   if (!xl || delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
+   translate_request(req, driver, &messages, &tools, &system_text);
+   if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
-   {
-      if (xl)
-      {
-         anthropic_stream_finish(xl);
-         anthropic_stream_free(xl);
-      }
       goto cleanup;
-   }
    agent_build_extra_headers(ag, extra, sizeof(extra));
 
-   prov_body = build_provider_body(ag, messages, tools, jo_int(req, "max_tokens", 4096),
-                                   jo_num(req, "temperature", 1.0), 1);
+   if (driver_is_anthropic(driver))
+      prov_body = build_anthropic_provider_body(req, ag, 1);
+   else
+      prov_body =
+          build_provider_body(driver, ag, messages, tools, system_text,
+                              jo_int(req, "max_tokens", 4096), jo_num(req, "temperature", 1.0), 1);
+
+   if (driver_is_anthropic(driver))
+   {
+      anthropic_relay_ctx_t relay;
+      int stream_status;
+      memset(&relay, 0, sizeof(relay));
+      sse_parser_init(&relay.parser);
+      relay.emit = emit;
+      relay.emit_ctx = ctx;
+      stream_status =
+          agent_http_post_stream(url, auth, prov_body ? prov_body : "{}", anthropic_relay_chunk_cb,
+                                 &relay, ag->timeout_ms, extra[0] ? extra : NULL);
+      relay_flush(&relay);
+      if (stream_status != 200)
+         relay_emit_transport_error(&relay, stream_status);
+      sse_parser_free(&relay.parser);
+      free(relay.data);
+      goto cleanup;
+   }
+
+   input_est = messages ? session_compact_estimate_tokens(messages) : 0;
+   xl = anthropic_stream_begin(msg_id, model, input_est, emit, ctx);
+   if (!xl)
+      goto cleanup;
 
    sse_parser_init(&pc.parser);
    pc.xl = xl;

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -227,9 +227,10 @@ static int err_json(char *resp, int cap, int status, const char *msg)
 /* ── auth ───────────────────────────────────────────────────────────────── */
 
 int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_header,
-                          int has_session_key)
+                          const char *api_key_header, int has_session_key)
 {
    int have_bearer = bearer_cfg && bearer_cfg[0];
+   int authorized = 0;
 
    /* Session-scoping is refused unless a bearer is configured — prevents an
     * unauthenticated session-scoping pivot, on any transport. */
@@ -242,9 +243,11 @@ int server_http_authorize(int is_tcp, const char *bearer_cfg, const char *auth_h
    /* TCP requires a configured bearer and a matching Authorization header. */
    if (!have_bearer)
       return 503;
-   const char *presented =
-       (auth_header && strncmp(auth_header, "Bearer ", 7) == 0) ? auth_header + 7 : "";
-   if (!presented[0] || !server_ct_equal(presented, bearer_cfg))
+   if (auth_header && strncmp(auth_header, "Bearer ", 7) == 0 && auth_header[7])
+      authorized = server_ct_equal(auth_header + 7, bearer_cfg);
+   if (api_key_header && api_key_header[0])
+      authorized |= server_ct_equal(api_key_header, bearer_cfg);
+   if (!authorized)
       return 401;
    return 0;
 }
@@ -1135,21 +1138,66 @@ static void handle_native_chat_stream(int fd, const char *body, uint32_t conn_ca
    cJSON_Delete(req);
 }
 
+static int append_sse_text(char *buf, size_t n, size_t *pos, const char *s, size_t len)
+{
+   if (buf && *pos < n)
+   {
+      size_t avail = n - *pos;
+      size_t copy = len < avail ? len : avail - 1;
+      if (copy)
+         memcpy(buf + *pos, s, copy);
+      buf[*pos + copy] = '\0';
+   }
+   *pos += len;
+   return (int)*pos;
+}
+
+int server_http_sse_event_format(const char *event, const char *data_json, char *buf, size_t n)
+{
+   size_t pos = 0;
+   const char *p;
+
+   if (buf && n)
+      buf[0] = '\0';
+   if (!data_json)
+      return 0;
+   if (event && event[0])
+   {
+      append_sse_text(buf, n, &pos, "event: ", 7);
+      append_sse_text(buf, n, &pos, event, strlen(event));
+      append_sse_text(buf, n, &pos, "\n", 1);
+   }
+   p = data_json;
+   for (;;)
+   {
+      const char *nl = strchr(p, '\n');
+      append_sse_text(buf, n, &pos, "data: ", 6);
+      append_sse_text(buf, n, &pos, p, nl ? (size_t)(nl - p) : strlen(p));
+      append_sse_text(buf, n, &pos, "\n", 1);
+      if (!nl)
+         break;
+      p = nl + 1;
+   }
+   append_sse_text(buf, n, &pos, "\n", 1);
+   return (int)pos;
+}
+
 /* Typed-event emit for the Responses API: `event: <name>\ndata: <json>\n\n`. */
 static void sse_event_emit(void *ctx, const char *event, const char *data_json)
 {
    int fd = *(int *)ctx;
+   int need;
+   char *frame;
+
    if (!data_json)
       return;
-   if (event && event[0])
-   {
-      write_all_fd(fd, "event: ", 7);
-      write_all_fd(fd, event, (int)strlen(event));
-      write_all_fd(fd, "\n", 1);
-   }
-   write_all_fd(fd, "data: ", 6);
-   write_all_fd(fd, data_json, (int)strlen(data_json));
-   write_all_fd(fd, "\n\n", 2);
+   need = server_http_sse_event_format(event, data_json, NULL, 0);
+   frame = malloc((size_t)need + 1);
+   if (!frame)
+      return;
+   server_http_sse_event_format(event, data_json, frame, (size_t)need + 1);
+   write_all_fd(fd, frame, need);
+   free(frame);
 }
 
 /* Run a streaming /v1/responses request: write event-stream headers, let the
@@ -1432,8 +1480,10 @@ static void handle_conn(int fd, int is_tcp)
     * configured bearer is refused on any transport. */
    {
       char auth[512] = "";
+      char api_key[512] = "";
       char skey[256] = "";
       int has_auth = http_header(buf, "Authorization", auth, sizeof(auth));
+      int has_api_key = http_header(buf, "x-api-key", api_key, sizeof(api_key));
       int has_skey = http_header(buf, "X-Aimee-Session-Key", skey, sizeof(skey));
       /* Per-request pre-injection override: `x-aimee-preinject: 0` disables the
        * <aimee-context> envelope for this turn (set every request so it never
@@ -1442,7 +1492,8 @@ static void handle_conn(int fd, int is_tcp)
       ingress_preinject_set_request_disabled(
           http_header(buf, "X-Aimee-Preinject", preinject, sizeof(preinject)) &&
           strcmp(preinject, "0") == 0);
-      int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL, has_skey);
+      int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL,
+                                     has_api_key ? api_key : NULL, has_skey);
       if (az != 0)
       {
          const char *msg = az == 401 ? "{\"error\":{\"message\":\"missing or invalid bearer "

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -152,6 +152,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-delegate-role \
                $(TESTPREFIX)/unit-test-sse-parser \
                $(TESTPREFIX)/unit-test-anthropic-ingress \
+               $(TESTPREFIX)/unit-test-anthropic-http \
                $(TESTPREFIX)/unit-test-hud \
                $(TESTPREFIX)/unit-test-coord-jobs \
                $(TESTPREFIX)/unit-test-plan-waves \
@@ -1207,6 +1208,9 @@ $(TESTPREFIX)/unit-test-sse-parser: $(OBJDIR)/tests/test_sse_parser.o $(OBJDIR)/
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-anthropic-ingress: $(OBJDIR)/tests/test_anthropic_ingress.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(OBJDIR)/tests/%.o: tests/%.c

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -1,0 +1,538 @@
+/* test_anthropic_http.c: pure tests for file-local Anthropic HTTP ingress
+ * helpers. This intentionally includes anthropic_http.c so production helpers
+ * can remain private while buffer/parsing behavior stays unit-tested. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../headers/aimee.h"
+#include "../headers/agent_config.h"
+#include "../headers/agent_exec.h"
+#include "../headers/agent_protocol.h"
+#include "../headers/delegate_driver.h"
+#include "../headers/server_http.h"
+#include "../vendor/headers/cJSON.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+static const delegate_driver_t *g_driver;
+static char *g_last_body;
+static int g_stream_status = 200;
+static const char *g_stream_payload;
+
+static void reset_capture(void)
+{
+   free(g_last_body);
+   g_last_body = NULL;
+   g_stream_status = 200;
+   g_stream_payload = NULL;
+}
+
+int agent_load_config(agent_config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   cfg->agent_count = 1;
+   snprintf(cfg->agents[0].name, sizeof(cfg->agents[0].name), "primary");
+   snprintf(cfg->agents[0].provider, sizeof(cfg->agents[0].provider), "%s",
+            g_driver && g_driver->name ? g_driver->name : "anthropic");
+   snprintf(cfg->agents[0].model, sizeof(cfg->agents[0].model), "configured-claude");
+   cfg->agents[0].timeout_ms = 1;
+   return 0;
+}
+
+agent_t *agent_find(agent_config_t *cfg, const char *name)
+{
+   (void)name;
+   return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
+}
+
+void delegate_drivers_init(void)
+{
+}
+
+const delegate_driver_t *delegate_driver_get(const char *provider)
+{
+   (void)provider;
+   return g_driver;
+}
+
+int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, char *url,
+                       size_t url_len)
+{
+   (void)driver;
+   (void)agent;
+   snprintf(url, url_len, "https://example.invalid/v1/messages");
+   return 0;
+}
+
+int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
+{
+   (void)agent;
+   snprintf(buf, buf_len, "Bearer test");
+   return 0;
+}
+
+void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
+{
+   (void)agent;
+   if (buf_len)
+      buf[0] = '\0';
+}
+
+cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *tools,
+                                  int max_tokens, double temperature)
+{
+   cJSON *out = cJSON_CreateObject();
+   (void)agent;
+   (void)messages;
+   (void)tools;
+   (void)max_tokens;
+   (void)temperature;
+   cJSON_AddStringToObject(out, "model", "openai-test");
+   return out;
+}
+
+int agent_http_post(const char *url, const char *auth_header, const char *body, char **response_buf,
+                    int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   free(g_last_body);
+   g_last_body = strdup(body ? body : "");
+   assert(g_last_body != NULL);
+   *response_buf = strdup("{}");
+   return 200;
+}
+
+int agent_http_post_stream(const char *url, const char *auth_header, const char *body,
+                           agent_http_stream_cb callback, void *userdata, int timeout_ms,
+                           const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   free(g_last_body);
+   g_last_body = strdup(body ? body : "");
+   assert(g_last_body != NULL);
+   if (g_stream_payload && callback)
+      assert(callback(g_stream_payload, strlen(g_stream_payload), userdata) == 0);
+   return g_stream_status;
+}
+
+void agent_parse_response_openai(cJSON *root, parsed_response_t *out)
+{
+   (void)root;
+   memset(out, 0, sizeof(*out));
+}
+
+void agent_free_parsed_response(parsed_response_t *p)
+{
+   if (!p)
+      return;
+   free(p->content);
+   for (int i = 0; i < p->call_count; i++)
+      free(p->calls[i].arguments);
+   cJSON_Delete(p->assistant_message);
+}
+
+int session_compact_estimate_tokens(cJSON *messages)
+{
+   return messages ? cJSON_GetArraySize(messages) : 0;
+}
+
+void server_http_set_messages_handler(server_http_completion_fn fn)
+{
+   (void)fn;
+}
+void server_http_set_messages_stream_handler(server_http_responses_stream_fn fn)
+{
+   (void)fn;
+}
+void server_http_set_count_tokens_handler(server_http_completion_fn fn)
+{
+   (void)fn;
+}
+
+#include "../server/anthropic_http.c"
+
+typedef struct
+{
+   char events[8][64];
+   char data[8][8192];
+   int count;
+} emit_capture_t;
+
+static cJSON *parse(const char *json)
+{
+   cJSON *j = cJSON_Parse(json);
+   assert(j != NULL);
+   return j;
+}
+
+static char *json_of(const cJSON *j)
+{
+   char *s = cJSON_PrintUnformatted((cJSON *)j);
+   assert(s != NULL);
+   return s;
+}
+
+static const cJSON *obj(const cJSON *parent, const char *key)
+{
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive((cJSON *)parent, key);
+   assert(v != NULL);
+   return v;
+}
+
+static cJSON *openai_driver_build(const agent_t *agent, cJSON *messages, cJSON *tools,
+                                  const char *system_prompt, int max_tokens, double temperature)
+{
+   cJSON *out = cJSON_CreateObject();
+   cJSON_AddStringToObject(out, "driver", "openai");
+   cJSON_AddStringToObject(out, "model", agent->model);
+   cJSON_AddItemToObject(out, "messages", cJSON_Duplicate(messages, 1));
+   if (tools)
+      cJSON_AddItemToObject(out, "tools", cJSON_Duplicate(tools, 1));
+   cJSON_AddNumberToObject(out, "max_tokens", max_tokens);
+   cJSON_AddNumberToObject(out, "temperature", temperature);
+   cJSON_AddStringToObject(out, "system_prompt", system_prompt ? system_prompt : "");
+   return out;
+}
+
+static cJSON *system_prompt_driver_build(const agent_t *agent, cJSON *messages, cJSON *tools,
+                                         const char *system_prompt, int max_tokens,
+                                         double temperature)
+{
+   cJSON *out = cJSON_CreateObject();
+   (void)tools;
+   (void)max_tokens;
+   (void)temperature;
+   cJSON_AddStringToObject(out, "driver", "chatgpt");
+   cJSON_AddStringToObject(out, "model", agent->model);
+   cJSON_AddStringToObject(out, "instructions", system_prompt ? system_prompt : "");
+   cJSON_AddItemToObject(out, "input", cJSON_Duplicate(messages, 1));
+   return out;
+}
+
+static void parsed_text(cJSON *root, const char *body, parsed_response_t *out)
+{
+   (void)root;
+   (void)body;
+   memset(out, 0, sizeof(*out));
+   out->content = strdup("ok");
+   assert(out->content != NULL);
+}
+
+static void cap_emit(void *ctx, const char *event, const char *data_json)
+{
+   emit_capture_t *cap = (emit_capture_t *)ctx;
+   assert(cap->count < 8);
+   snprintf(cap->events[cap->count], sizeof(cap->events[cap->count]), "%s", event);
+   snprintf(cap->data[cap->count], sizeof(cap->data[cap->count]), "%s", data_json);
+   cap->count++;
+}
+
+static void test_translate_request_anthropic_passthrough(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic"};
+   cJSON *req = parse("{\"system\":\"SYS\",\"messages\":[{\"role\":\"user\",\"content\":["
+                      "{\"type\":\"tool_result\",\"tool_use_id\":\"toolu_1\","
+                      "\"content\":\"exact\"}]}],\"tools\":[{\"name\":\"Read\","
+                      "\"input_schema\":{\"type\":\"object\"}}]}");
+   cJSON *orig_messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   cJSON *orig_tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+   cJSON *messages = NULL;
+   cJSON *tools = NULL;
+   char *system_text = NULL;
+   char *orig_messages_s;
+   char *out_messages_s;
+   char *orig_tools_s;
+   char *out_tools_s;
+
+   translate_request(req, &anthropic, &messages, &tools, &system_text);
+
+   assert(system_text && strcmp(system_text, "SYS") == 0);
+   assert(messages && messages != orig_messages);
+   assert(tools && tools != orig_tools);
+   orig_messages_s = json_of(orig_messages);
+   out_messages_s = json_of(messages);
+   orig_tools_s = json_of(orig_tools);
+   out_tools_s = json_of(tools);
+   assert(strcmp(orig_messages_s, out_messages_s) == 0);
+   assert(strcmp(orig_tools_s, out_tools_s) == 0);
+
+   free(orig_messages_s);
+   free(out_messages_s);
+   free(orig_tools_s);
+   free(out_tools_s);
+   free(system_text);
+   cJSON_Delete(messages);
+   cJSON_Delete(tools);
+   cJSON_Delete(req);
+   PASS("translate_request_anthropic_passthrough");
+}
+
+static void test_anthropic_relay_round_trip(void)
+{
+   anthropic_relay_ctx_t relay;
+   emit_capture_t cap;
+   const char *chunk1 = "event: content_block_delta\n"
+                        "data: {\"type\":\"content_block_delta\"";
+   const char *chunk2 = "}\n"
+                        "data: {\"delta\":{\"text\":\"x\"}}\n\n"
+                        "data: {\"type\":\"message_delta\"}\n\n"
+                        "event: ping\n"
+                        "data: [DONE]\n\n";
+
+   memset(&relay, 0, sizeof(relay));
+   memset(&cap, 0, sizeof(cap));
+   sse_parser_init(&relay.parser);
+   relay.emit = cap_emit;
+   relay.emit_ctx = &cap;
+
+   assert(anthropic_relay_chunk_cb(chunk1, strlen(chunk1), &relay) == 0);
+   assert(anthropic_relay_chunk_cb(chunk2, strlen(chunk2), &relay) == 0);
+   relay_flush(&relay);
+
+   assert(cap.count == 2);
+   assert(strcmp(cap.events[0], "content_block_delta") == 0);
+   assert(strcmp(cap.data[0], "{\"type\":\"content_block_delta\"}\n{\"delta\":{\"text\":\"x\"}}") ==
+          0);
+   assert(strcmp(cap.events[1], "message") == 0);
+   assert(strcmp(cap.data[1], "{\"type\":\"message_delta\"}") == 0);
+   assert(relay.emitted == 2);
+
+   sse_parser_free(&relay.parser);
+   free(relay.data);
+   PASS("anthropic_relay_round_trip");
+}
+
+static void test_relay_append_data_growth(void)
+{
+   anthropic_relay_ctx_t relay;
+   char big[7000];
+
+   memset(&relay, 0, sizeof(relay));
+   memset(big, 'a', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+
+   assert(relay_append_data(&relay, big) == 0);
+   assert(relay.data_cap >= sizeof(big));
+   assert(relay.data_len == strlen(big));
+   assert(strcmp(relay.data, big) == 0);
+
+   free(relay.data);
+   PASS("relay_append_data_growth");
+}
+
+static void test_relay_transport_error(void)
+{
+   anthropic_relay_ctx_t relay;
+   emit_capture_t cap;
+
+   memset(&relay, 0, sizeof(relay));
+   memset(&cap, 0, sizeof(cap));
+   relay.emit = cap_emit;
+   relay.emit_ctx = &cap;
+
+   relay_emit_transport_error(&relay, 599);
+   assert(cap.count == 1);
+   assert(strcmp(cap.events[0], "error") == 0);
+   assert(strstr(cap.data[0], "\"type\":\"error\"") != NULL);
+   assert(strstr(cap.data[0], "status 599") != NULL);
+   assert(relay.emitted == 1);
+   PASS("relay_transport_error");
+}
+
+static void test_messages_buffered_anthropic_preserves_request_shape(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *sent;
+   const cJSON *system;
+   const cJSON *cc;
+
+   reset_capture();
+   g_driver = &anthropic;
+   assert(
+       messages_buffered("{\"model\":\"ignored\",\"max_tokens\":64,"
+                         "\"system\":[{\"type\":\"text\",\"text\":\"SYS\","
+                         "\"cache_control\":{\"type\":\"ephemeral\"}}],"
+                         "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],"
+                         "\"tools\":[{\"name\":\"Read\",\"input_schema\":{\"type\":\"object\"}}],"
+                         "\"tool_choice\":{\"type\":\"tool\",\"name\":\"Read\"},"
+                         "\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024},"
+                         "\"stop_sequences\":[\"STOP\"],\"top_k\":7}",
+                         resp, sizeof(resp)) == 200);
+   assert(g_last_body != NULL);
+   sent = parse(g_last_body);
+   assert(strcmp(obj(sent, "model")->valuestring, "configured-claude") == 0);
+   system = obj(sent, "system");
+   assert(cJSON_IsArray(system));
+   cc = obj(cJSON_GetArrayItem((cJSON *)system, 0), "cache_control");
+   assert(strcmp(obj(cc, "type")->valuestring, "ephemeral") == 0);
+   assert(cJSON_IsObject(obj(sent, "tool_choice")));
+   assert(cJSON_IsObject(obj(sent, "thinking")));
+   assert(cJSON_IsArray(obj(sent, "stop_sequences")));
+   assert(obj(sent, "top_k")->valueint == 7);
+   assert(cJSON_GetObjectItemCaseSensitive(sent, "stream") == NULL);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_anthropic_preserves_request_shape");
+}
+
+static void test_messages_buffered_anthropic_strips_stream_false_path(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *sent;
+
+   reset_capture();
+   g_driver = &anthropic;
+   assert(messages_buffered("{\"model\":\"ignored\",\"stream\":true,"
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+   sent = parse(g_last_body);
+   assert(cJSON_GetObjectItemCaseSensitive(sent, "stream") == NULL);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_anthropic_strips_stream_false_path");
+}
+
+static void test_messages_stream_anthropic_preserves_request_shape(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   emit_capture_t cap;
+   cJSON *sent;
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &anthropic;
+   g_stream_payload = "event: message_stop\n"
+                      "data: {\"type\":\"message_stop\"}\n\n";
+   assert(messages_stream("{\"model\":\"ignored\",\"max_tokens\":64,"
+                          "\"system\":[{\"type\":\"text\",\"text\":\"SYS\","
+                          "\"cache_control\":{\"type\":\"ephemeral\"}}],"
+                          "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],"
+                          "\"tool_choice\":{\"type\":\"auto\"},"
+                          "\"thinking\":{\"type\":\"enabled\",\"budget_tokens\":1024}}",
+                          cap_emit, &cap) == 0);
+   assert(g_last_body != NULL);
+   sent = parse(g_last_body);
+   assert(strcmp(obj(sent, "model")->valuestring, "configured-claude") == 0);
+   assert(cJSON_IsArray(obj(sent, "system")));
+   assert(cJSON_IsObject(obj(sent, "tool_choice")));
+   assert(cJSON_IsObject(obj(sent, "thinking")));
+   assert(cJSON_IsTrue(obj(sent, "stream")));
+   assert(cap.count == 1);
+   assert(strcmp(cap.events[0], "message_stop") == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_stream_anthropic_preserves_request_shape");
+}
+
+static void test_messages_buffered_openai_family_translates(void)
+{
+   const delegate_driver_t openai = {.name = "openai", .build_request = openai_driver_build};
+   cJSON *sent;
+   const cJSON *messages;
+   const cJSON *tools;
+   char resp[4096];
+
+   reset_capture();
+   g_driver = &openai;
+   assert(
+       messages_buffered("{\"model\":\"ignored\",\"system\":\"SYS\","
+                         "\"messages\":[{\"role\":\"assistant\",\"content\":["
+                         "{\"type\":\"tool_use\",\"id\":\"toolu_1\",\"name\":\"Read\","
+                         "\"input\":{\"path\":\"a.c\"}}]}],"
+                         "\"tools\":[{\"name\":\"Read\",\"input_schema\":{\"type\":\"object\"}}]}",
+                         resp, sizeof(resp)) == 200);
+   sent = parse(g_last_body);
+   assert(strcmp(obj(sent, "driver")->valuestring, "openai") == 0);
+   messages = obj(sent, "messages");
+   assert(cJSON_IsArray(messages));
+   assert(strcmp(obj(cJSON_GetArrayItem((cJSON *)messages, 0), "role")->valuestring, "system") ==
+          0);
+   assert(strcmp(obj(cJSON_GetArrayItem((cJSON *)messages, 1), "role")->valuestring, "assistant") ==
+          0);
+   tools = obj(sent, "tools");
+   assert(cJSON_IsArray(tools));
+   assert(strcmp(obj(cJSON_GetArrayItem((cJSON *)tools, 0), "type")->valuestring, "function") == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_openai_family_translates");
+}
+
+static void test_messages_buffered_system_prompt_driver_no_duplicate_system(void)
+{
+   const delegate_driver_t chatgpt = {.name = "chatgpt",
+                                      .build_request = system_prompt_driver_build,
+                                      .parse_response = parsed_text};
+   cJSON *sent;
+   const cJSON *input;
+   char resp[4096];
+
+   reset_capture();
+   g_driver = &chatgpt;
+   assert(messages_buffered("{\"model\":\"ignored\",\"system\":\"SYS\","
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+   sent = parse(g_last_body);
+   assert(strcmp(obj(sent, "instructions")->valuestring, "SYS") == 0);
+   input = obj(sent, "input");
+   assert(cJSON_IsArray(input));
+   assert(cJSON_GetArraySize((cJSON *)input) == 1);
+   assert(strcmp(obj(cJSON_GetArrayItem((cJSON *)input, 0), "role")->valuestring, "user") == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_system_prompt_driver_no_duplicate_system");
+}
+
+static void test_messages_stream_openai_family_translates(void)
+{
+   const delegate_driver_t openai = {.name = "openai", .build_request = openai_driver_build};
+   emit_capture_t cap;
+   cJSON *sent;
+   const cJSON *messages;
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &openai;
+   g_stream_payload = "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"
+                      "data: [DONE]\n\n";
+   assert(messages_stream("{\"model\":\"ignored\",\"system\":\"SYS\","
+                          "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}],"
+                          "\"stream\":true}",
+                          cap_emit, &cap) == 0);
+   sent = parse(g_last_body);
+   messages = obj(sent, "messages");
+   assert(cJSON_IsArray(messages));
+   assert(strcmp(obj(cJSON_GetArrayItem((cJSON *)messages, 0), "role")->valuestring, "system") ==
+          0);
+   assert(cJSON_IsTrue(obj(sent, "stream")));
+   assert(cap.count >= 2);
+   assert(strcmp(cap.events[0], "message_start") == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_stream_openai_family_translates");
+}
+
+int main(void)
+{
+   test_translate_request_anthropic_passthrough();
+   test_anthropic_relay_round_trip();
+   test_relay_append_data_growth();
+   test_relay_transport_error();
+   test_messages_buffered_anthropic_preserves_request_shape();
+   test_messages_buffered_anthropic_strips_stream_false_path();
+   test_messages_stream_anthropic_preserves_request_shape();
+   test_messages_buffered_openai_family_translates();
+   test_messages_buffered_system_prompt_driver_no_duplicate_system();
+   test_messages_stream_openai_family_translates();
+   printf("anthropic_http: OK\n");
+   return 0;
+}

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -515,27 +515,37 @@ int main(void)
    /* --- server_http_authorize: UDS vs TCP + bearer + session-key rule --- */
    {
       /* UDS is always authorized regardless of token, when no session key. */
-      assert(server_http_authorize(0, "", NULL, 0) == 0);
-      assert(server_http_authorize(0, "secret", NULL, 0) == 0);
-      assert(server_http_authorize(0, "secret", "Bearer wrong", 0) == 0);
+      assert(server_http_authorize(0, "", NULL, NULL, 0) == 0);
+      assert(server_http_authorize(0, "secret", NULL, NULL, 0) == 0);
+      assert(server_http_authorize(0, "secret", "Bearer wrong", NULL, 0) == 0);
 
       /* TCP with no bearer configured => 503 (TCP shouldn't be serving). */
-      assert(server_http_authorize(1, "", "Bearer x", 0) == 503);
-      assert(server_http_authorize(1, NULL, NULL, 0) == 503);
+      assert(server_http_authorize(1, "", "Bearer x", NULL, 0) == 503);
+      assert(server_http_authorize(1, NULL, NULL, NULL, 0) == 503);
 
-      /* TCP with a bearer configured: exact match passes, else 401. */
-      assert(server_http_authorize(1, "secret", "Bearer secret", 0) == 0);
-      assert(server_http_authorize(1, "secret", "Bearer nope", 0) == 401);
-      assert(server_http_authorize(1, "secret", NULL, 0) == 401);
-      assert(server_http_authorize(1, "secret", "secret", 0) == 401);  /* missing "Bearer " */
-      assert(server_http_authorize(1, "secret", "Bearer ", 0) == 401); /* empty token */
+      /* TCP with a bearer configured: Authorization or x-api-key exact match passes. */
+      assert(server_http_authorize(1, "secret", "Bearer secret", NULL, 0) == 0);
+      assert(server_http_authorize(1, "secret", NULL, "secret", 0) == 0);
+      assert(server_http_authorize(1, "secret", "Bearer nope", "secret", 0) == 0);
+      assert(server_http_authorize(1, "secret", NULL, "nope", 0) == 401);
+      assert(server_http_authorize(1, "secret", NULL, NULL, 0) == 401);
+      assert(server_http_authorize(1, "secret", "secret", NULL, 0) == 401);
+      assert(server_http_authorize(1, "secret", "Bearer ", NULL, 0) == 401);
 
       /* Session-scoping key without a bearer configured => 503 on any transport. */
-      assert(server_http_authorize(0, "", NULL, 1) == 503);
-      assert(server_http_authorize(0, NULL, NULL, 1) == 503);
-      assert(server_http_authorize(1, "", NULL, 1) == 503);
+      assert(server_http_authorize(0, "", NULL, NULL, 1) == 503);
+      assert(server_http_authorize(0, NULL, NULL, NULL, 1) == 503);
+      assert(server_http_authorize(1, "", NULL, NULL, 1) == 503);
       /* With a bearer configured, the session key alone doesn't block UDS. */
-      assert(server_http_authorize(0, "secret", NULL, 1) == 0);
+      assert(server_http_authorize(0, "secret", NULL, NULL, 1) == 0);
+   }
+
+   /* --- typed SSE framing: embedded newlines become repeated data: lines --- */
+   {
+      char frame[256];
+      int n = server_http_sse_event_format("delta", "{\"a\":1}\n{\"b\":2}", frame, sizeof(frame));
+      assert(n == (int)strlen("event: delta\ndata: {\"a\":1}\ndata: {\"b\":2}\n\n"));
+      assert(strcmp(frame, "event: delta\ndata: {\"a\":1}\ndata: {\"b\":2}\n\n") == 0);
    }
 
    /* --- per-route capability matrix (pure helpers) --- */


### PR DESCRIPTION
## Summary
- Adds Anthropic Messages ingress coverage for Claude Code-compatible `/v1/messages` requests, including `x-api-key` auth compatibility for the loopback HTTP API. `x-api-key` is accepted as an alternate header for the same configured TCP bearer on all TCP routes.
- Routes OpenAI-family providers through Anthropic-to-OpenAI request translation and OpenAI-to-Anthropic response/stream translation.
- Avoids duplicate system delivery for providers that consume `system_prompt` separately, including chatgpt/Responses and Gemini.
- Routes native Anthropic providers through near-passthrough request forwarding: the configured primary model still wins, while `system` arrays/cache_control, `messages`, `tools`, `tool_choice`, `thinking`, `stop_sequences`, `top_p`, `top_k`, and other inbound Anthropic request fields are preserved. Buffered native requests defensively strip any inbound `stream` field.
- Relays native Anthropic SSE frames directly, with unit coverage for `event:`/`data:` parsing, default event names, `[DONE]` filtering, multi-line `data:` handling, buffer growth, wire framing, and transport-failure error frames.

## Scope Notes
- Removed the unrelated `body_hash`/code embedding optimization from this PR. The diff now only covers Anthropic ingress, HTTP auth, and tests, avoiding overlap with #137.
- The proposal's live Claude Code smoke needs real provider credentials that were not available in this environment. Tracked as #140; this remains the gate before calling the feature fully complete in production terms.
- Buffered response parsing now uses a driver's custom parser when one exists. For OpenAI-family/Minimax this is equivalent to the previous parser because those drivers point at `agent_parse_response_openai`; chatgpt/Responses and Gemini get their format-specific parser.
- The current system-prompt handling uses a local driver-name allowlist for drivers that consume `system_prompt` separately. That should become an explicit `delegate_driver_t` capability so the truth lives with each driver; tracked as #141.

## Verification
- `cd src && make build/obj/tests/unit-test-anthropic-http build/obj/tests/unit-test-server-http && build/obj/tests/unit-test-anthropic-http && build/obj/tests/unit-test-server-http`
- `cd src && make verify-local`

Live smoke not run here: no `ANTHROPIC_API_KEY` / `MINIMAX_API_KEY` available in the implementation environment.