### PR TITLE
Proposal: Agent-directed PR review (call in the ensemble with a brief)

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -281,6 +281,14 @@ Capability / coordination / research (P3):
   "participant" is the same default agent) — then generalizes it into a bounded
   multi-round roundtable: real participant routing, draft/review modes,
   deterministic convergence, keep-best, preflight cost limits. **Draft / Review / Reason. New.**
+- [Agent-Directed PR Review](proposals/pending/agent-directed-pr-review.md):
+  lets an agent call in the roundtable's review mode against a code change and
+  direct it with a brief (focus areas, fixes made, invariants, questions), with
+  an open mandate so direction reorders priority without suppressing findings.
+  Adds an optional `brief` threaded through `build_round_prompt`, returns the
+  structured review items (not just prose) plus answered questions, and exposes a
+  `CAP_DELEGATE`-gated `ensemble_review` MCP tool. Strictly additive on the
+  roundtable. **Review / Reason. New.**
 - Composable Named Toolsets:
   one composable toolset object shared by roles, delegates, gateway
   channels, and the scripted-RPC allow-list. **Done.**

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -955,3 +955,52 @@ All citations in §13/§14/§15 were re-confirmed byte-accurate against
 `openai_runs_store.c:111-120`, the three-key array fallback at
 `delegate_ensemble.c:615-620`, the repair-then-replace at `:983-984`, and the
 `free(r->artifact)`-only result free).
+
+## §17 Sixth-pass findings (event surface, artifact/item alignment, field naming)
+
+This pass re-checked the MCP dispatch table, the op-run event path, and the
+roundtable return semantics against `testing@d3eb402d`. It found three additional
+implementation details that should be pinned before P1b/P1c turns the proposal
+into code.
+
+1. **`/v1/runs/{id}/events` is authorized for op-runs, but op-runs currently
+   append no events (P1c).** §14.A.4 correctly notes that `/events` has a
+   separate capability gate (`CAP_SESSION_READ`), but the more important behavior
+   gap is that `op_run_worker` only calls `openai_runs_store_set_status` and
+   `openai_runs_store_finalize` (`server_http_routes.inc:341,377`); it never calls
+   `openai_runs_store_append_event`. `openai_runs_store_wait` returns only buffered
+   events and then `TERMINAL` when the status is terminal (`openai_runs_store.c:328-341`),
+   so an `ensemble_review` subscriber on `/v1/runs/{id}/events` will receive no
+   structured completion payload unless the bridge adds explicit queued/progress/
+   completed events or documents that op-runs are **poll-only** through
+   `GET /v1/runs/{id}`. If a dedicated `ensemble_review_status` MCP sibling is
+   chosen, it can avoid promising an inert SSE path. Add a route-level test that an
+   op-run either emits a final event carrying the same result as `GET /v1/runs/{id}`
+   or that `/events` is intentionally not part of the contract.
+
+2. **Returned items can describe a different round than the returned `artifact`
+   unless the result carries round/source metadata (P1b).** §5 says to return the
+   items from the final round that ran, but `delegate_roundtable_run` does not always
+   return the final round's consolidated text. It tracks `best_artifact` using the
+   reason scorer (`delegate_ensemble.c:1110-1117`) and finally returns
+   `best_artifact ? best_artifact : artifact` (`:1188`). On a later lower-scored
+   round, a post-fan-out cost cap, or a degraded exit, the captured "final round"
+   items may refer to a review round whose consolidated prose is **not** the
+   `artifact` the caller sees. That mismatch is manageable, but it must be explicit:
+   either capture the items from the same round that produced `best_artifact`, or
+   return `items_round`, `artifact_round`/`best_round`, and a `partial` flag so an
+   agent knows whether the findings and prose are aligned. Add a regression where
+   round 1 is best, round 2 produces different items, and the API asserts the chosen
+   alignment contract.
+
+3. **New result fields should choose a casing contract per surface.** The existing
+   V1 roundtable response is snake_case (`rounds_run`, `cost_capped`,
+   `deadline_hit`, `cost_usd`; `server_compute.c:1802-1811`), while the proposal
+   names the new arrays `answeredQuestions` and `coverageGaps`. That mixes two JSON
+   styles inside one response object and will leak into OpenAPI/SDK generation
+   (§15.2). Pick one of these explicitly: snake_case for the V1 HTTP/direct
+   handler (`answered_questions`, `coverage_gaps`) with an MCP `structuredContent`
+   translation to camelCase if desired, or camelCase everywhere with compatibility
+   aliases/tests for the existing snake_case fields. The smallest-compatible path is
+   snake_case on `/v1/delegate/roundtable` and `/v1/runs/{id}.result`, plus
+   documented MCP-specific names only if the MCP envelope deliberately differs.

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -563,6 +563,94 @@ the new agent surface. None of them touch the roundtable's core or its P0 fixes.
    the consolidator must then emit a small side JSON the engine reads without
    feeding it back into `peer_notes`.)
 
+## §13 Second-pass verification findings (implementation gaps)
+
+A second review pass re-validated every symbol and line cited above against
+`testing@d3eb402d` (all cited files are byte-identical to that commit) and
+confirmed them. It also surfaced six concrete implementation gaps the sections
+above do not yet cover. Each is small but load-bearing; fold them into the
+phase they belong to.
+
+1. **`build_round_prompt`'s malloc must grow by the brief length (P1a).** §4
+   correctly notes the prompt buffer is sized dynamically, but the size
+   expression is `needed = strlen(task) + strlen(artifact) + strlen(peer_notes)
+   + 1200` (`delegate_ensemble.c:411-412`), and that `1200` is fixed slack for
+   the *template literal + round number only*. Threading the brief as a new
+   middle `%s` without adding `strlen(brief)` to `needed` makes the final
+   `snprintf` (`:415-420`) silently truncate — and because the brief sits
+   *before* the closing `ROUND %d INSTRUCTION:\n%s` block, the part that gets
+   cut is the structured-output contract (`mode_task`), which breaks JSON
+   parsing for that reviewer and forces a `repair_review_json` call (or a
+   degrade). P1a must add the (capped) brief length into `needed`, not only
+   enforce the 4 KB cap. Add a test: a near-4 KB brief still emits a complete,
+   parseable prompt with the trailing instruction intact.
+
+2. **Registering the MCP tool breaks the tools-list golden — regenerate it
+   (P1c).** `ensemble_review` is added via `build_tool` in
+   `mcp_build_tools_list()`, which is pinned by an auto-generated surface net:
+   `src/tests/test_mcp_tools_golden.inc` (`MCP_TOOLS_GOLDEN_COUNT 86`, one
+   sorted `name {props} req:...` line per tool), asserted by
+   `test_mcp_client_registry`. P1c will fail CI on the count and the new line
+   until the golden is regenerated (`DUMP_TOOLS=1
+   ./unit-test-mcp-client-registry 2>&1`, per the file header). §10's test
+   list should name this regeneration as a required step, since it is a
+   guaranteed red build otherwise.
+
+3. **The shared async-submit helper inherits a single-writer run-id counter
+   (P1c).** `rh_dispatch_op_async` mints run ids with a non-atomic
+   `static unsigned long g_op_run_seq` (`server_http_routes.inc:400`) annotated
+   "listener thread only; single-writer." §3's extracted
+   `(op_method, request_json, caps)` helper is now reachable from a second
+   call site (the MCP dispatch path). The helper must preserve that
+   single-threaded-submit invariant, or make the counter atomic, otherwise two
+   concurrent submits can mint a colliding id (and `openai_runs_store_create`
+   would key two runs to one id). Confirm the MCP arm enqueues on the same
+   listener thread, or switch the counter to an atomic/locked allocator as part
+   of the extraction.
+
+4. **The bridge must rename the `diff` argument to `prompt` (P1c).** The tool
+   schema names the input `diff`, but the re-dispatched `delegate.roundtable`
+   handler reads `prompt` and validates *that* field for the 20-char minimum
+   (`handle_delegate_roundtable`, `server_compute.c:1745-1753`). §3/§6 say "diff
+   maps to the engine's task," but the concrete step is: the async-submit bridge
+   must copy `args.diff` into a `prompt` field on the request body it builds
+   before submitting `delegate.roundtable`. If it forwards `diff` verbatim, the
+   handler sees an empty `prompt` and rejects with "missing prompt" rather than
+   the intended short-input message. State the rename explicitly.
+
+5. **Returned-item dedup by identity key can drop distinct actionable findings
+   (P1b).** §5 dedups the returned items "by identity key across participants,"
+   reusing `normalized_identity_key` — which keys on `category` + `location`
+   only (`summary` backs the location component *only when location is empty*,
+   `delegate_ensemble.c:586-587`). That is correct for the blocking-saturation
+   set (the question there is "did a *new class* of blocking issue appear"), but
+   for the agent-facing actionable array it means two genuinely different issues
+   at the same `location` with the same `category` collapse to one returned
+   item and the other is silently dropped. The returned array should dedup on a
+   key that also includes `summary` (or carry both `severity`+`summary` so
+   distinct findings survive), kept separate from the saturation key. Add a test
+   with two same-location/same-category but different-summary items asserting
+   both survive in the returned array while the saturation set still counts one
+   key.
+
+6. **The pre-existing `delegate` MCP capability hole deserves a tracked
+   side-fix, not just avoidance.** §3 proves `handle_mcp_delegate_call` reaches
+   `handle_delegate` by a direct C call (`server_mcp_delegate.c:65`) inside the
+   `mcp.call`/`CAP_TOOL_EXECUTE` gate, so the `delegate -> CAP_DELEGATE` registry
+   entry (`server_auth.c:82`) is never consulted — a `CAP_TOOL_EXECUTE`-only
+   principal can drive a delegate today. `ensemble_review` correctly avoids
+   reproducing this by routing through the re-dispatched method gate, but the
+   existing hole stays open. Since this pass has pinpointed it exactly, fold a
+   defense-in-depth explicit `CAP_DELEGATE` check into `handle_mcp_delegate_call`
+   (with a negative test) as a small tracked side-fix, rather than leaving a
+   known privilege gap next to the new, correctly-gated sibling.
+
+   Related lifetime note for §12 Q3: if the items array / `answeredQuestions`
+   move to heap (the "raise the cap" option), `delegate_roundtable_result_free`
+   (`delegate_ensemble.h:64`) must free them too, or each run leaks. The default
+   fixed-stack bound avoids this; only the heap variant needs the free path
+   extended.
+
 ## Recommendation
 
 Ship P1a + P1b + P1c: thread an optional `brief` into review mode with an open

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -651,6 +651,137 @@ phase they belong to.
    fixed-stack bound avoids this; only the heap variant needs the free path
    extended.
 
+## §14 Third-pass and independent verification findings
+
+A further pass re-read the design against `testing@d3eb402d` and verified every
+symbol below in the tree. It splits into (A) third-pass bridge/contract gaps that
+had been raised in PR discussion but were not yet folded into this document, and
+(B) net-new findings from an independent verification that the earlier passes did
+not surface. §13 above is the *second* pass; this section is the third pass plus
+the independent check.
+
+### §14.A Bridge and contract gaps (fold into P1c unless noted)
+
+1. **The MCP bridge must force `mode: "review"`.** `handle_delegate_roundtable`
+   defaults to `ROUNDTABLE_DRAFT` (`server_compute.c:1764`) and only switches to
+   review when the submitted body carries `mode: "review"` (`:1777-1779`). The
+   `ensemble_review` schema has no `mode` argument, so the async-submit bridge must
+   **synthesize `mode: "review"`** into the re-dispatched `delegate.roundtable`
+   body. Otherwise the tool launches the *draft* loop against a diff and never
+   parses or returns review items. Keep `apply` absent/false on this path
+   (`apply_review` defaults to 0 via the handler `memset`, `:1786-1788`) unless an
+   auto-apply feature is deliberately added.
+
+2. **The queued run shape is `id`, not `run_id`.** `op_run_snapshot` emits
+   `{id, object:"op.run", method, status, created, result?}`
+   (`server_http_routes.inc:323-327`), while §3 advertises `{run_id,
+   status:"running"}`. Either the MCP arm translates `id` into a `run_id` field for
+   tool callers, or the contract adopts the existing `id` field. Pin a test that the
+   returned identifier is exactly the one accepted by `GET /v1/runs/{id}`.
+
+3. **The initial run status is `queued`, not `running`.** The snapshot is created
+   with status `queued` (`server_http_routes.inc:411`); `op_run_worker` then sets
+   the store to `in_progress` (`:341`) and finalizes as `completed|failed|cancelled`
+   (`:374-378`). The store never emits `running`. If the tool promises
+   `status:"running"`, translate it intentionally or adopt the store's
+   `queued|in_progress|completed|failed|cancelled` vocabulary so callers do not
+   special-case a value that is never produced.
+
+4. **Polling and cancellation need capabilities beyond `CAP_DELEGATE`.** The
+   follow-up lifecycle routes are gated separately: `GET /v1/runs/{id}` and
+   `/v1/runs/{id}/events` require `CAP_SESSION_READ`, and `POST /v1/runs/{id}/stop`
+   requires `CAP_CHAT` (`server_http_routes.inc:972-974`). A principal holding
+   `CAP_TOOL_EXECUTE|CAP_DELEGATE` but neither of those can *start* a review yet
+   cannot *read or stop* it. Resolve by documenting the additional required caps,
+   re-gating the op-run lifecycle routes, or adding MCP-native status/cancel
+   siblings that enforce the intended delegate capability.
+
+5. **Brief truncation needs a threaded flag, not just a reserved bit.** §4 sets
+   `roundtable_result_t.truncated` on a >4 KB brief, but if normalization/truncation
+   happens in `handle_delegate_roundtable` *before* the engine runs, the engine has
+   no way to know the brief was truncated unless that fact is threaded in
+   (`opts.brief_truncated`, a normalized-brief struct, or a post-run response
+   patch). Otherwise brief truncation is silent while `result.truncated` stays
+   reserved for the summarize-forward overflow path. Add a direct handler/HTTP test,
+   not only a prompt-builder unit test.
+
+6. **Tests should pin the synthesized delegate body, not just end behavior.**
+   Several of the above are single-field bridge mistakes (`diff`->`prompt`, add
+   `mode:"review"`, preserve `brief`, copy the caller's caps, omit `apply`). Add a
+   narrow unit seam around the MCP->`delegate.roundtable` request construction so
+   these fields are asserted *before* the async worker runs; the end-to-end async
+   test can then focus on run lifecycle and cancellation.
+
+### §14.B Net-new findings (independent verification)
+
+1. **The MCP result is unwrapped, and the async helper writes to a `resp` buffer,
+   not to `conn`.** The existing `delegate` MCP tool reaches `handle_delegate`,
+   which writes its response straight to the connection via `server_send_ok`
+   (`server_mcp_delegate.c:65`). But `rh_dispatch_op_async` writes the queued
+   snapshot into the **route-layer `resp` char buffer** — its signature is
+   `(const route_req_t *rq, char *resp, int cap)` (`server_http_routes.inc:386`),
+   with no `server_conn_t`. So the extracted helper must **return** the run id /
+   snapshot as a value, and the `server_mcp.c` arm must itself `server_send_ok`
+   that `{run_id|id, status}` onto `conn`. State explicitly that the MCP arm owns
+   the connection write; the shared helper must not assume a route-layer `resp`
+   buffer or a particular response envelope.
+
+2. **`g_rpc_conn_caps` *is* correctly populated on the synchronous `mcp.call`
+   path — frame the explicit-threading guidance as robustness, not a live bug.**
+   §3 bullet 3 says the thread-local "is not guaranteed to hold the caller's caps."
+   In fact `g_rpc_conn_caps` is set per request on the listener thread
+   (`server_http.c:1655`), and `/v1/mcp/call` dispatches **synchronously on that
+   same thread** via `rh_dispatch_op`, so by the time `handle_mcp_call` runs the
+   thread-local already equals the MCP caller's caps. Threading
+   `conn->capabilities` explicitly is still the right design — it is correct under
+   any future nested or worker-thread re-dispatch of `mcp.call`, where the
+   thread-local could diverge — but the rationale is **defense-in-depth /
+   correctness-under-nesting**, not a bug on the common path. The negative
+   `CAP_DELEGATE` test still proves the gate either way.
+
+3. **`turns: "parallel"` is inert against a sequential config default.**
+   `handle_delegate_roundtable` only forces `ROUNDTABLE_SEQUENTIAL` when the body
+   `turns == "sequential"` (`server_compute.c:1780-1782`); it never forces
+   `ROUNDTABLE_PARALLEL`. So if `roundtable_turns` config is `"sequential"`, a tool
+   caller passing `turns:"parallel"` still runs sequentially. The schema advertises
+   an enum value the handler does not honor symmetrically. Either make the handler
+   honor `"parallel"` explicitly, or document `turns` as "request *sequential*;
+   otherwise inherit the config default" so the schema does not over-promise.
+
+4. **`answeredQuestions`/`coverageGaps` need a free path independent of the
+   items-array bound decision.** §13.6's lifetime note ties extending
+   `delegate_roundtable_result_free` (`delegate_ensemble.h:64`) to the heap "raise
+   the cap" variant of the items array (§12 Q3). But `answeredQuestions`
+   (`{question, answer, evidence}`) is inherently variable-length text and cannot
+   live in a fixed `char[N]` stack the way the 64×128 identity keys do; it will be
+   heap-allocated even in the **default** P1b shape. So the result-free path must
+   free `answeredQuestions`/`coverageGaps` regardless of whether the items array
+   stays fixed-stack. Add this to P1b's free path and its leak test, not only to the
+   Q3 heap variant.
+
+5. **The enlarged result must fit `SHTTP_RESP_MAX` (256 KB) or it silently
+   degrades to an opaque string.** The async worker captures the re-dispatched
+   handler response into a `SHTTP_RESP_MAX` buffer (256 KB,
+   `server_http.c:40`) via `loopback_rpc` (`server_http_routes.inc:343,355`). If the
+   response — now carrying the consolidated artifact **plus** up to 64 items **plus**
+   `answeredQuestions` — exceeds that, the buffer truncates, `cJSON_Parse` fails in
+   `op_run_worker` (`:362`) so the `cancelled`-status check is skipped, and
+   `op_run_snapshot`'s own parse fails and stores the result as a JSON **string**
+   rather than an object (`:330-331`). A polling agent then receives `result` as
+   opaque text. In practice a consolidated review (~16 KB) plus 64 short items
+   (~20 KB) is well under 256 KB, so this is a robustness note, not a likely
+   failure: bound the serialized items/`answeredQuestions`, keep `recommendation`
+   and `evidence` strings short, and add an assertion that the serialized result
+   stays well under `SHTTP_RESP_MAX`.
+
+6. **Open question — the brief `type: ["string","object"]` union may trip strict
+   MCP clients.** Some MCP / JSON-Schema tool-call validators reject a union type on
+   a single property. Since §2 already normalizes both forms server-side, consider
+   either documenting two shapes or advertising `object` and accepting a bare string
+   at parse time (normalized to `{focus:[s]}`) without exposing a union type in the
+   schema, to maximize client compatibility. Not a blocker; folds into the §12 Q1
+   naming/shape decision.
+
 ## Recommendation
 
 Ship P1a + P1b + P1c: thread an optional `brief` into review mode with an open

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -759,20 +759,21 @@ the independent check.
    stays fixed-stack. Add this to P1b's free path and its leak test, not only to the
    Q3 heap variant.
 
-5. **The enlarged result must fit `SHTTP_RESP_MAX` (256 KB) or it silently
-   degrades to an opaque string.** The async worker captures the re-dispatched
-   handler response into a `SHTTP_RESP_MAX` buffer (256 KB,
-   `server_http.c:40`) via `loopback_rpc` (`server_http_routes.inc:343,355`). If the
-   response — now carrying the consolidated artifact **plus** up to 64 items **plus**
-   `answeredQuestions` — exceeds that, the buffer truncates, `cJSON_Parse` fails in
-   `op_run_worker` (`:362`) so the `cancelled`-status check is skipped, and
-   `op_run_snapshot`'s own parse fails and stores the result as a JSON **string**
-   rather than an object (`:330-331`). A polling agent then receives `result` as
-   opaque text. In practice a consolidated review (~16 KB) plus 64 short items
-   (~20 KB) is well under 256 KB, so this is a robustness note, not a likely
-   failure: bound the serialized items/`answeredQuestions`, keep `recommendation`
-   and `evidence` strings short, and add an assertion that the serialized result
-   stays well under `SHTTP_RESP_MAX`.
+5. **The enlarged result must fit `SHTTP_RESP_MAX` (256 KB), or the async run
+   fails with a generic bridge error.** The async worker captures the
+   re-dispatched handler response into a `SHTTP_RESP_MAX` buffer (256 KB,
+   `server_http.c:40`) via `loopback_rpc` (`server_http_routes.inc:343,355`).
+   `loopback_rpc` validates the captured body before returning; if truncation
+   makes it malformed, it overwrites the buffer with `{"error":"rpc response too
+   large or malformed"}` and returns 502 (`server_http.c:947-951`). So the current
+   failure mode is **not** an opaque string result; it is a failed run whose
+   `result` contains the bridge error object. That is better than silent
+   corruption, but still too opaque for a caller trying to act on review items.
+   In practice a consolidated review (~16 KB) plus 64 short items (~20 KB) is well
+   under 256 KB, so this is a robustness note, not a likely failure: bound the
+   serialized items/`answeredQuestions`, keep `recommendation` and `evidence`
+   strings short, and add an assertion that the serialized result stays well under
+   `SHTTP_RESP_MAX`.
 
 6. **Open question — the brief `type: ["string","object"]` union may trip strict
    MCP clients.** Some MCP / JSON-Schema tool-call validators reject a union type on
@@ -796,3 +797,70 @@ prompt-builder seam, a result array, the async submit bridge, and one tool.
 Validate it against a real change with a concrete invariant and a concrete
 hypothesis to steer at (the Wolf shutdown-race / gst-wayland-display work is a good
 first target: there is an invariant to protect and a race to ask about).
+
+## §15 Fourth-pass findings (merge-result verification)
+
+This pass reviewed the effective merge result against current `origin/testing`
+(`d3eb402d`), not only the PR head, because the PR branch is older than the target
+branch and the roundtable implementation comes from `testing`. The PR merges
+cleanly, but these additional implementation details should be folded into the
+phase plan.
+
+1. **`/v1/runs/{id}` does not expose `in_progress` for op-run jobs today.** §14.A
+   correctly says the queued snapshot starts as `status:"queued"` and the worker
+   calls `openai_runs_store_set_status(..., OPENAI_RUN_IN_PROGRESS)`
+   (`server_http_routes.inc:341`). But `openai_runs_store_set_status` updates only
+   the store's internal enum (`openai_runs_store.c:152-162`); it does **not** call
+   `openai_runs_store_update_json`, and `GET /v1/runs/{id}` returns the stored JSON
+   snapshot verbatim (`server_http.c:827`, `openai_runs_store.c:279-290`). So a
+   polling caller can see `queued` until the run finalizes, even while the internal
+   status is `OPENAI_RUN_IN_PROGRESS`. If `ensemble_review` reuses the op-run store,
+   either update the snapshot when the worker transitions to in-progress or
+   document/pin the observable vocabulary as `queued -> completed|failed|cancelled`
+   for this route. Add a route-level test that polls after `set_status` and proves
+   the JSON status the client actually sees.
+
+2. **The public V1/OpenAPI surface must be updated with the new request and result
+   fields, not only the engine and MCP tool.** P1a adds `brief` to
+   `POST /v1/delegate/roundtable`, and P1b adds structured result arrays. The
+   current OpenAPI row (`api/openapi-server-v1.yaml:1676-1690`) lists only
+   `prompt`, `mode`, `turns`, `rounds`, and `apply`, and the CLI/docs surfaces
+   (`MANUAL.md`, `docs/COMMANDS.md`, generated config/API docs) describe the old
+   result shape. P1a/P1b should explicitly include OpenAPI + generated-doc updates
+   and run the server conformance checks, otherwise remote/thin clients will not
+   learn that `brief`, `items`, `answeredQuestions`, and `coverageGaps` exist.
+
+3. **The CLI `roundtable` marshaller needs a concrete `--brief` contract if P2
+   lands.** The current marshaller accepts `--mode`, `--turns`, `--rounds`, and
+   `--apply` (`src/cli_rpc_routes.inc:1687-1705`), but there is no stdin/file
+   convention for a multi-line structured brief. If the optional CLI helper lands,
+   define the input shape up front: either `--brief <text>`, `--brief-json
+   <json>`, and/or `--brief-file <path>`, with clear precedence and the same 4 KB
+   normalization/cap as HTTP/MCP. This avoids ad hoc shell-quoting behavior for
+   the exact field agents and humans will use most.
+
+4. **Returned review items should preserve `recommendation`, not only
+   severity/category/location/summary.** §5 says the result item carries
+   `severity`, `category`, `location`, `summary`, and the engine identity key, but
+   the reviewer prompt already asks for `recommendation` and the agent-facing goal
+   is actionable feedback. Dropping `recommendation` turns a machine-readable
+   finding back into a diagnosis without the proposed fix. Include bounded
+   `recommendation` text in the returned item, dedup/merge it separately from the
+   blocking saturation key, and keep it under the response-size budget from
+   §14.B.5.
+
+5. **Deduped items should carry contributor/count metadata.** Once P1b dedups
+   participant items for the final round, the caller loses whether one reviewer or
+   the whole panel raised the issue. Add `sources` (participant names or stable
+   indexes) and/or `count` to each returned item. This is cheap to collect at the
+   parse-time capture point, helps agents prioritize fixes, and makes the
+   structured result explainable without reading the consolidated prose.
+
+6. **OpenAPI/result tests should check the actual async envelope.** The handler
+   returns a normal `jo_ok()` body, but the async run stores it under
+   `result` in an `op.run` snapshot. Tests for P1b/P1c should assert both shapes:
+   the direct handler body contains the new item/question arrays, and
+   `GET /v1/runs/{id}` returns them nested under `result` after finalization. This
+   catches accidental tests that validate only the synchronous handler path while
+   the MCP tool's poll path still drops or wraps the structured fields
+   incorrectly.

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -1252,3 +1252,47 @@ All other citations in §13–§17 were re-confirmed byte-accurate against
 `testing@d3eb402d` in this pass (including the run-store eviction at
 `openai_runs_store.c:111-120`, the snapshot `id` shape, the capability rows, the
 `set_status`-doesn't-update-JSON gap, and the `free(r->artifact)`-only result free).
+
+## §19 Eighth-pass findings (authorization timing and payload limits)
+
+This pass re-checked the MCP bridge against the actual HTTP route gate and
+`server_dispatch` payload limiter on `testing@d3eb402d`. It found two additional
+contract gaps in §3/P1c that are easy to miss because the direct V1 route already
+handles them before `rh_dispatch_op_async` runs.
+
+1. **The MCP bridge must preflight `CAP_DELEGATE` before creating the op-run, not
+   rely only on the worker's re-dispatched method gate.** §3 says the async-submit
+   design "closes the gap automatically" because `op_run_worker` re-dispatches
+   `delegate.roundtable` through `server_dispatch`, where the
+   `delegate.roundtable -> CAP_DELEGATE` method gate fires
+   (`server.c:1296`, `server_auth.c:84`). That is true for the worker, but it is
+   **later than the HTTP route gate**: a normal `POST /v1/delegate/roundtable`
+   request is denied before enqueue by `server_http_route_allowed`
+   (`server_http.c:1525-1535`), while an `ensemble_review` call inside
+   `/v1/mcp/call` has already passed only the outer `mcp.call ->
+   CAP_TOOL_EXECUTE` gate. If the extracted helper creates the run first and lets
+   the worker discover the missing `CAP_DELEGATE`, a `CAP_TOOL_EXECUTE`-only caller
+   still receives a queued run id, consumes a store slot/thread, and only sees the
+   authorization failure later by polling the failed run. That is not equivalent to
+   route-level denial and makes §10's "is denied when it calls `ensemble_review`"
+   ambiguous. P1c should add a synchronous preflight in the MCP arm/helper:
+   `server_capability_for_method("delegate.roundtable")` must be satisfied by the
+   captured caller caps before `openai_runs_store_create` or `pthread_create`.
+   Keep the worker-side gate as defense in depth, but test that the initial
+   `mcp.call` response is an authorization error and no run record is created.
+
+2. **`ensemble_review` currently inherits the 256 KB `mcp.call` payload limit,
+   not the 4 MB `delegate.*` limit the direct route gets.** Direct HTTP callers to
+   `delegate.roundtable` are checked by `server_dispatch` under the
+   `delegate` prefix, so they get `LIMIT_DELEGATE` (4 MB,
+   `server.c:1221-1242`). But the MCP tool is invoked as method `mcp.call`, and
+   `method_size_limit` has no `mcp.` override, so the outer request falls through
+   to `LIMIT_DEFAULT` (256 KB) before `handle_mcp_call` can extract `arguments.diff`
+   or repackage it as `prompt`. A realistic unified diff can easily exceed 256 KB
+   while still being well under the direct delegate limit; the proposed MCP surface
+   would reject it with `PAYLOAD_TOO_LARGE ... method 'mcp.call'` rather than the
+   roundtable handler's own validation. P1c must choose an explicit fix: raise the
+   `mcp.call` limit to at least the delegate/tool limit, add a tool-specific
+   pre-parse allowance, or lower/document the MCP diff maximum separately from the
+   V1 route. Add tests for a diff just over 256 KB and one near the accepted upper
+   bound so the MCP and V1 contracts do not drift silently.

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -1004,3 +1004,251 @@ into code.
    aliases/tests for the existing snake_case fields. The smallest-compatible path is
    snake_case on `/v1/delegate/roundtable` and `/v1/runs/{id}.result`, plus
    documented MCP-specific names only if the MCP envelope deliberately differs.
+
+## §18 Seventh-pass findings (concurrency, code-placement, retention/parse, input validation)
+
+A seventh independent pass re-verified every prior citation against
+`testing@d3eb402d` and went one level deeper into the *execution model* the async
+bridge runs in, the *placement constraints* the new code lands under, and the
+*input/parse seams* P1a/P1b must actually write. It surfaced two pre-existing live
+bugs the earlier passes hedged or missed, several hard build/placement constraints
+that make the difference between a green and a red CI, and a set of concrete
+engine/handler seams. Each is verified in the tree; line numbers are
+`testing@d3eb402d`.
+
+### §18.A Two pre-existing live bugs (not future hazards) on the path §3 reuses
+
+1. **`g_op_run_seq` is not single-writer — it is a live data race today, before any
+   second caller.** §13.3 hedges this as "preserve the single-writer invariant, or
+   confirm the MCP arm enqueues on the same listener thread." That premise is
+   **false**: there is no single listener thread for dispatch. The counter is
+   `static unsigned long g_op_run_seq = 0; /* listener thread only; single-writer */`
+   incremented non-atomically with `++g_op_run_seq` (`server_http_routes.inc:400-402`),
+   but `rh_dispatch_op_async` runs inside `handle_conn`, and **every accepted
+   connection is offloaded to its own detached worker thread** (`conn_offload` ->
+   `conn_worker` -> `handle_conn`, up to `CONN_LIVE_MAX 64` concurrent,
+   `server_http.c:1721-1766`). The architecture comment is explicit:
+   "independent /v1 requests run concurrently … per-request state is thread-local
+   (`g_rpc_conn_caps`), atomic (request-id seq), or locked" (`server_http.c:1709-1719`).
+   So two concurrent async-op submits (`POST /v1/delegate/roundtable`, `POST /v1/runs`,
+   any `rh_dispatch_op_async`) in the same wall-clock second can mint a colliding
+   `oprun_<sec>_<seq>` id; `openai_runs_store_create` returns 0 on the duplicate and
+   the second request fails with a spurious 500. **Decisive proof the comment is
+   stale:** the author's own parallel run-id counters in `openai_chat.c` are
+   `atomic_ulong` with the comment "connections run concurrently; atomic"
+   (`openai_chat.c:375,1127`). Adding the MCP submit site only widens an existing
+   hole. Reframe §13.3: the extraction must make `g_op_run_seq` a single
+   file-static **atomic** counter (matching `openai_chat.c`), not "preserve a
+   single-writer invariant" that does not exist. This also tightens §14.B.2: the
+   thread-local *does* hold the caller's caps on the synchronous `mcp.call` path, but
+   because `handle_conn` runs on the **per-connection worker thread** (`g_rpc_conn_caps`
+   is `_Thread_local`, set at `server_http.c:1700`), **not** "on the listener
+   thread" — same conclusion, corrected mechanism, and the correctness-under-nesting
+   argument for explicit cap threading stands.
+
+2. **A large run result fails as `200` + truncated/unparseable body at poll time —
+   not as the clean `502` §14.B.5 assumes.** §14.B.5 reasons only about the
+   `loopback_rpc` capture boundary and concludes an oversized result yields a tidy
+   502 bridge-error. It misses the second inflation: `op_run_worker` **wraps** the
+   already-up-to-256 KB captured body inside an `op.run` envelope via `op_run_snapshot`
+   (`server_http_routes.inc:376`, re-parsing `result` at `:328-333`), so the *stored*
+   snapshot is strictly larger than the captured body, and neither `op_run_snapshot`
+   nor `openai_runs_store_finalize` caps it. On poll, `openai_runs_store_get`
+   does `snprintf(out, 256 KB, "%s", snapshot_json)` (`openai_runs_store.c:291`),
+   which **silently truncates to malformed JSON**, and `route_runs_get` returns it as
+   **HTTP 200** with no validation (`server_http.c:827`). So the realistic failure on
+   the exact path the agent polls is "200 with a body that won't parse," which is
+   *worse* than §14.B.5's stated 502. The serialized-result bound §14.B.5 recommends
+   must account for the envelope-wrapping inflation **and** the GET-side `snprintf`
+   cap, not only the loopback capture; add a poll-path test, not only a submit-path
+   one.
+
+### §18.B Build-integrity and code-placement constraints (green-vs-red CI)
+
+3. **P1a/P1b/P1c land in two files already near the 2000-line hard fail.**
+   `test_build_integrity.sh` errors any `*.c` (incl. `tests/*.c`) over
+   `ERROR_LINES=2000` (`:511`), warns over 1500 (`:510`), exempting only
+   `memory_logic.c memory_advanced.c` (`:512`). Today **`mcp_tools.c` is 1905 lines**
+   (95 from the hard limit) and **`server_compute.c` is 1841** (159 from the limit,
+   already in the warn zone). P1c adds an `ensemble_review` registration block to
+   `mcp_tools.c`; P1a/P1b add string-or-object brief normalization, all-severity item
+   serialization, and `answered_questions`/`coverage_gaps` to `handle_delegate_roundtable`
+   in `server_compute.c`. Either file can cross 2000 and turn CI red on a check
+   §13.2 never mentions (it flags only the golden-count regen). Mitigation: land the
+   brief-normalization and result-serialization helpers in a `.inc` (the line check
+   globs `*.c` only, so `.inc` is exempt) or a new TU, and keep the new arms thin.
+
+4. **`ensemble_review` structurally cannot live in the data-driven dispatch table —
+   it must be a ladder arm in `handle_mcp_call`.** Handlers in
+   `server_mcp_call_table.inc` have signature `cJSON *(struct mcp_call *)` and return
+   a `content` cJSON that `handle_mcp_call` wraps via `send_mcp_result`
+   (`server_mcp.c:1463-1467`); they cannot write their own response, and the table's
+   own header comment says tools that send their own response (`delegate*`, workflow)
+   stay in `handle_mcp_call`. Since §14.B.1 requires `ensemble_review` to do an async
+   submit and `server_send_ok` a custom `{id|run_id, status}` envelope onto `conn`,
+   it **must** be a `strcmp` arm beside the delegate arm (`server_mcp.c:1396`) that
+   `return`s after sending — a table row would force the run-id envelope through
+   `text_content` wrapping. The proposal says "add an arm beside delegate" but never
+   states the now-canonical table path is unusable here; an implementer could
+   reasonably try it and hit the content-vs-conn contract wall.
+
+5. **The new ladder arm inherits the `owns_jargs` cleanup contract.** Every
+   early-returning arm in `handle_mcp_call` must `if (owns_jargs) cJSON_Delete(jargs);`
+   before returning (delegate `:1399-1400`, delegate_status `:1407-1408`,
+   delegate_reply `:1425-1426`), because `jargs` is synthesized as an empty object
+   when the request omits `arguments` (`:1381-1387`). An `ensemble_review` arm that
+   returns the run-id response without this leaks `jargs` on the no-arguments path.
+   Pin it in the §10 bridge unit test.
+
+### §18.C Engine retention/parse corrections (P1b)
+
+6. **There are *two* independent 64-key stacks, and the all-severity array fills far
+   faster than the blocking set — so "reuse the 64 bound" (§5/§12 Q3) makes
+   `truncated` near-permanently true.** Saturation uses two `char[64][128]` stacks
+   declared in `delegate_roundtable_run` — `prev_review_keys` (`delegate_ensemble.c:905`)
+   and `cur_review_keys` (`:961`) — passed to `parse_review_issue_keys` with the literal
+   bound `64` (`:970-971,981`). (Correction to §0/§5: the cap is *not* "at `:641`";
+   line 641 is the generic `*count < max` guard inside the parser — the 64 lives at
+   the call sites.) The saturation stack counts **blocking only** (filter at `:632`),
+   while the agent-facing array carries `blocking|suggestion|nit`. Suggestions and
+   nits vastly outnumber blocking items, so an all-severity array sharing the 64
+   bound will hit it — and set `truncated` — on routine, fully-converged reviews
+   whose blocking set is nowhere near 64. Reusing the bound makes `truncated` noise.
+   Decouple the two: size the agent-facing array independently (larger fixed bound or
+   heap per §12 Q3), and reserve `truncated` for genuine overflow.
+
+7. **A valid-JSON reviewer that emits only suggestions/nits is never re-walked, so
+   folding all-severity capture *into* `parse_review_issue_keys` cannot work as
+   written.** §16.2 correctly says to reuse the three-key fallback and read the
+   *repaired* text, but misses a control-flow constraint: `parse_review_issue_keys`
+   filters to blocking-only at `:632` (`continue`) and returns the blocking count;
+   the repair re-parse fires **only on a `-1` parse failure** (`:970-994`). A reviewer
+   whose JSON is valid but carries zero blocking items returns `0` and lands in the
+   empty `else if (cur_review_key_count == before)` branch (`~:996-1000`) — its
+   response is never re-examined. So the all-severity capture cannot be a side effect
+   of the blocking parse; it must be a **separate walk that does not short-circuit on
+   the blocking filter and runs for the zero-blocking reviewers too**, over the
+   post-repair `results[i].response`.
+
+8. **The capture has exactly one safe window: after the repair loop, before the
+   first round-exit free.** Tightening §5's "capture before the per-round free":
+   `results[i].response` is replaced mid-loop by `repair_review_json`
+   (`:983-984`) and set to `NULL` when repair fails (`~:990-991`), so a per-participant
+   inline capture sees pre-repair or freed text. The only point where all responses
+   are in final post-repair state **and** still alive is after the parse/repair loop
+   completes (~`:1001`) and before the cost estimate / cost-cap / degrade frees
+   (`:1010` onward, frees at `:1024/:1052/:1062-1063`). The retained items must be
+   deep-copied in that window, and (per finding 6) committed to the result struct
+   each round so a degrade `continue`/cost-cap `break`/saturation `break` exit still
+   carries the last good round.
+
+9. **The §12 Q5 "fold question-answering into the consolidator" leaning is
+   incompatible with the verbatim `peer_notes` reuse §5 makes load-bearing.**
+   `run_aggregator` returns one `agg_result` whose `.response` becomes **both**
+   `artifact` (`:1087`) and `peer_notes` (`:1095`) verbatim, and `peer_notes` is fed
+   straight into the next reviewer prompt (`:417`). To read a side-JSON answer block
+   out of the consolidator without polluting the next round's peer notes, the engine
+   would have to parse-and-strip `agg_result.response` before assigning it — i.e.
+   modify the prose §5 promises to reuse byte-for-byte. So the two options in §12 Q5
+   are not equivalent: "fold into the consolidator" breaks the §5 invariant; only a
+   **separate `reason`-role pass** (the non-leaning option, +1 call/round) preserves
+   it. Resolve Q5 toward the separate pass, or explicitly relax the verbatim-reuse
+   invariant.
+
+10. **§5 ("final round that ran") and §17.2 ("the round that produced
+    `best_artifact`") name different rounds, and the loser's items are unrecoverable.**
+    `cur_review_keys` is overwritten every round; the engine returns
+    `best_artifact ? best_artifact : artifact` (`:1188`), and `best_artifact` may come
+    from an earlier, higher-scored round (`:1110-1117`). To return items aligned with
+    the artifact the caller actually sees, retention must keep items for **every**
+    round until the run ends (then select the `best_round`'s items), which is a
+    strictly larger obligation than §5's "final round." Pick one contract explicitly
+    and size retention for it; do not leave §5 and §17.2 specifying different rounds.
+
+### §18.D Handler input-validation and lifetime gaps (P1a)
+
+11. **No string-or-object union helper and no string-array parser exist, and the
+    malformed-structured-brief case is unspecified.** `handle_delegate_roundtable`
+    today does only flat scalar `cJSON_GetObjectItemCaseSensitive` reads, and there is
+    no reusable `IsString||IsObject` normalizer or `json_array_to_strings` in
+    `server_compute.c` / `json_fluent.c`. §2 defines the *string-vs-object* split but
+    never says what happens when the object is present with a **wrong-typed field** —
+    `{"focus":"not-an-array"}` or `{"questions":{}}`. Without an explicit rule this
+    either mis-walks a non-array or silently drops the field. P1a must (a) write the
+    union + array-extract helpers, and (b) state the wrong-type policy (reject with a
+    clear error vs. coerce-and-ignore), with a test for each malformed shape.
+
+12. **The normalized brief buffer leaks on the two *pre-existing* handler error
+    returns.** §16.3 covers calling the result-free on *new* error paths, but the
+    brief gets its own heap buffer (normalized object string / struct) allocated
+    **before** `delegate_roundtable_run` at `:1796`, and the two existing
+    `server_send_error` returns between allocation and the result-free —
+    `agent_load_config != 0` (`:1792-1793`) and `rc != 0` (`:1797-1799`) — will leak
+    it unless freed. Add the brief-buffer free to both, plus a leak test.
+
+13. **`rounds` has no server-side upper clamp.** The handler validates only `> 0`
+    (`server_compute.c:1783-1785`) and assigns straight to `opts.max_rounds`; the §3
+    schema advertises a bare integer. An MCP/HTTP caller passing `rounds: 10000` is
+    honored, bounded only post-hoc by cost cap / deadline — a long, expensive run an
+    agent can trigger by accident. Pair the schema with a documented server-side
+    clamp (e.g. to a small max) in P1a.
+
+### §18.E Public surface, CLI, and docs (P1a/P1b/P2)
+
+14. **The thin client renders the whole response object as raw JSON, so P1b dumps an
+    unformatted item blob onto the human CLI.** The roundtable route entry has
+    `extract == NULL` (`cli_rpc_routes.inc:248`), which per `cli_client.h` means
+    "print the response object minus `status`." New structured arrays therefore reach
+    `aimee delegate roundtable --mode review` as a raw, unpretty JSON dump of up to 64
+    items. The upside (no silent drop) is real, but P1b needs a CLI renderer for the
+    new arrays that the proposal never scopes.
+
+15. **`MANUAL.md` hardcodes a *closed* enumeration of result fields, so it becomes
+    affirmatively wrong, not merely stale.** `MANUAL.md:654` states the result
+    "includes `artifact`, `rounds_run`, `converged`, `degraded`, `truncated`,
+    `cost_capped`, `deadline_hit`, `cancelled`, `best_round`, and `cost_usd`" — an
+    exhaustive list. §15.2 names the doc files generically; pin the concrete edit
+    points (`MANUAL.md:654` result list, `MANUAL.md:423` config table, and the
+    `docs/COMMANDS.md` roundtable entry) so the new `items`/`answered_questions`/
+    `coverage_gaps` (and the P2 `--brief` flag) land in the hand-maintained surfaces,
+    not only OpenAPI.
+
+16. **The CLI roundtable timeout equals the server deadline, leaving no client
+    margin.** `cli_rpc_routes.inc:248` sets the roundtable CLI timeout to exactly
+    `600000` ms — identical to the `roundtable_deadline_ms` default — whereas the
+    sibling `delegate` row deliberately uses `900000` with the comment that the CLI
+    "must outlast" the server or it reports a false "no response." A directed-review
+    loop (§5) that pushes near the deadline will trip this. Raise the roundtable CLI
+    timeout above the server deadline as part of P1a/P2.
+
+17. **§15.2's "run the server conformance checks" gives false assurance for new
+    *fields*.** `check-api-conformance-server.py` validates only that every `/v1`
+    *path* is routed and documented (path granularity, regexing `"/v1/..."` literals);
+    adding `brief` to the request or `items` to the response passes it untouched, and
+    `test_server_dispatch.c` *stubs* the roundtable handler so it does not break on
+    shape changes either. There is no field-level schema test for
+    `/v1/delegate/roundtable` today. P1a/P1b should add one (assert the request
+    accepts `brief` and the response/`run.result` carries the new arrays) rather than
+    relying on conformance. The `api-conformance-scanner-literal-trap` only bites P1c
+    if it introduces a new `/v1` literal (e.g. an `ensemble_review_status` route);
+    P1a/P1b add no path.
+
+### §18.F Minor citation corrections (symbols stable; line drift only)
+
+- The 64-item cap is a **caller-side** literal (`delegate_ensemble.c:905/961/970/981`),
+  not "at `:641`" (`:641` is the generic `*count < max` guard inside the parser). See
+  finding 6.
+- `g_rpc_conn_caps` is declared at `server_http.c:908` (§3/§14.B.2 cite 907) and set
+  in `handle_conn` at `:1700` (§14.B.2 cites 1655) — on the per-connection worker
+  thread, not the listener (finding 1).
+- The `loopback_rpc` "rpc response too large or malformed" 502 block is at
+  `server_http.c:956-958` (§14.B.5 cites 947-951).
+- In `op_run_worker` the `loopback_rpc` call is at `server_http_routes.inc:355`; line
+  343 is the `SHTTP_RESP_MAX` buffer `malloc` (§14.B.5 cites "343,355").
+- The three-key array fallback in `parse_review_issue_keys` spans
+  `delegate_ensemble.c:615-619` (§16.2 cites 615-620).
+
+All other citations in §13–§17 were re-confirmed byte-accurate against
+`testing@d3eb402d` in this pass (including the run-store eviction at
+`openai_runs_store.c:111-120`, the snapshot `id` shape, the capability rows, the
+`set_status`-doesn't-update-JSON gap, and the `free(r->artifact)`-only result free).

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -78,17 +78,24 @@ The review machinery is built and on `testing`. Confirmed in the tree
   change (§4).
 - **The structured-feedback contract.** Reviewers return JSON items; the engine
   parses them in `parse_review_issue_keys` (`delegate_ensemble.c:608`), computes a
-  model-independent identity key per item via `normalized_identity_key` (`:581`,
-  hashes `category` + `location`, falls back to `summary`), and decides saturation
-  with `review_saturated` (`:678`). **Two facts that constrain §5:** (a) the parse
+  model-independent identity key per item via `normalized_identity_key` (`:581`).
+  **It does not hash:** it builds a lowercased, colon-delimited slug from two
+  parts - `category` (empty -> `"general"`) and `location`, where `location`
+  itself falls back to `summary` only when `location` is empty. So `summary` backs
+  the *location component*, not the whole key. Saturation is decided by
+  `review_saturated` (`:678`). **Three facts that constrain §5:** (a) the parse
   keeps only the identity keys for the stop predicate and discards the items
-  themselves; (b) it counts **blocking-only** items (`:632` skips any
-  `severity != "blocking"`), and the key arrays are fixed `char[64][128]` stacks,
+  themselves; (b) it counts **blocking** items, but the filter at `:632` only skips
+  an item whose `severity` is a *present string* `!= "blocking"` - an item with a
+  missing or non-string `severity` is **not** skipped and is counted as blocking,
+  which §5 must handle consistently across the saturation set and the new
+  all-severity return array; (c) the key arrays are fixed `char[64][128]` stacks,
   so at most 64 keys, silently truncated past that (`:641`).
-- **The reviewer role.** `tasks[i].role = "review"` in review mode
-  (`delegate_ensemble.c:704` parallel, `:738` sequential); the `review` charter
-  role is defined at `src/role_templates.c:21` with severity/category/location
-  expectations.
+- **The reviewer role.** In review mode the reviewer role is `"review"`: in
+  `run_round_parallel` it is `tasks[i].role = "review"` (`delegate_ensemble.c:704`);
+  in `run_round_sequential` there is no `tasks` array - it is passed inline as the
+  role argument to `agent_run_named` (`:738`). The `review` charter role is defined
+  at `src/role_templates.c:21` with severity/category/location expectations.
 - **The V1 entry point.** `POST /v1/delegate/roundtable`
   (`server_http_routes.inc:951`, dispatch `delegate.roundtable` in
   `src/server/server.c:1140`) routes to `handle_delegate_roundtable`
@@ -103,10 +110,15 @@ The review machinery is built and on `testing`. Confirmed in the tree
 - **The MCP tool pattern.** Agent-callable tools are registered with `build_tool`
   in `src/mcp_tools.c` (`delegate:577`, `delegate_status:602`) and dispatched in
   `handle_mcp_call` (`src/server/server_mcp.c:1369`, the `delegate` arm at
-  `:1396`). `CAP_DELEGATE` is `1u << 1` (`src/headers/server.h:59`). **`/v1/mcp/call`
-  is routed via *synchronous* `rh_dispatch_op` (`server_http_routes.inc:922`), and
-  `handle_mcp_call` never sees `__run_id`** - this is the central wiring problem
-  for §3.
+  `:1396`). Note `build_tool(name, desc, schema)` only **advertises** the tool
+  (it takes no caps or handler argument, `mcp_tools.c:12`); dispatch is a separate
+  `strcmp` arm in `handle_mcp_call`. There is **no per-tool capability layer** on
+  the MCP surface - the only gate is the coarse `mcp.call -> CAP_TOOL_EXECUTE`
+  (§3), which is why `CAP_DELEGATE` enforcement for the new tool has to come from
+  the dispatch path (§3), not from registration. `CAP_DELEGATE` is `1u << 1`
+  (`src/headers/server.h:59`). **`/v1/mcp/call` is routed via *synchronous*
+  `rh_dispatch_op` (`server_http_routes.inc:922`), and `handle_mcp_call` never sees
+  `__run_id`** - this is the central wiring problem for §3.
 - **Config.** `ensemble_*` (`config.h:1202-1206`) supplies
   participants/aggregator/cost; `roundtable_*` (`config.h:1210-1213`, CLI-settable
   scalars `config_fields.c:164-169`) supplies the loop defaults. **No new config
@@ -171,7 +183,7 @@ suppressing out-of-scope findings; it only re-orders priority and seeds the
 `questions` the consolidation must answer.
 
 The brief does **not** change the convergence contract. Saturation still keys on
-the engine-computed identity hash (`normalized_identity_key:581`), on
+the engine-computed identity slug (`normalized_identity_key:581`), on
 blocking-severity items only (§7), not on whether a finding matched the brief.
 
 ## §3 Agent-callable surface: a new MCP tool over an async bridge
@@ -218,18 +230,73 @@ agent turn. Working name `ensemble_review` (final name open, §12).
   So `ensemble_review` must launch through the **same async op-run machinery the
   V1 route uses** - i.e. submit `delegate.roundtable` as an async run so a run id
   and `__run_id` are created - then **return that run id immediately** and let the
-  agent poll. This mirrors the existing async-MCP precedent exactly: the
-  `delegate` MCP tool starts a job and returns an id; `delegate_status` polls
-  (`server_mcp.c:1396-1410`). Concretely, `ensemble_review` returns
-  `{run_id, status: "running"}` and the agent polls `/v1/runs/{id}` (or a thin
-  `ensemble_review_status` sibling) for the structured result. The net new server
-  work is therefore: the async submit bridge + request parsing for `brief`, not a
-  single synchronous dispatch arm.
+  agent poll. Concretely, `ensemble_review` returns `{run_id, status: "running"}`
+  and the agent polls `/v1/runs/{id}` (or a thin `ensemble_review_status` sibling)
+  for the structured result. The UX precedent is the `delegate` MCP tool
+  (`server_mcp.c:1396-1410`): it starts a background job and returns an id;
+  `delegate_status` polls. **But mirror its *UX*, not its dispatch.** (See the next
+  bullet: the `delegate` tool reaches its worker by a direct C call that *bypasses
+  the method-cap gate*, which is precisely the capability hole `ensemble_review`
+  must avoid.)
 
-- **Gate** on the existing `CAP_DELEGATE` (`src/headers/server.h:59`). No new
-  capability: this is delegate-class, LLM-heavy, cost-bearing work, and
-  `CAP_DELEGATE` already fences exactly that. The MCP tool inherits the session's
-  caps the same way the `delegate` tool does.
+- **What the async machinery actually is, and what "extract a shared submit
+  helper" really means.** `rh_dispatch_op_async` is **`static` in
+  `server_http_routes.inc`** (`:386`) - file-local, declared in no header, so it
+  is not linkable from `server_mcp.c` as-is. Its signature is
+  `(const route_req_t *rq, char *resp, int cap)` - it does **not** take a handler
+  function pointer, a parsed request, or a caps argument (an earlier draft framed
+  it that way; that is wrong). It works by three indirections, each of which the
+  bridge must invert:
+  1. **Handler is implicit via re-dispatch.** It re-serializes `rq->body` with
+     `method` set to `rq->op` and runs it through `loopback_rpc` ->
+     `server_dispatch` on a worker thread (`op_run_worker:338`, `loopback_rpc` at
+     `server_http.c:915`). It never calls `handle_delegate_roundtable` directly.
+     So the bridge submits the *method string* `"delegate.roundtable"`, not a
+     function pointer.
+  2. **`__run_id` lives in the body.** The run id is generated, then injected into
+     the request JSON (`server_http_routes.inc:404-405`) before dispatch; that is
+     the only reason `handle_delegate_roundtable:1770` can wire cancellation. The
+     bridge must preserve this exact "`__run_id`-in-body" convention.
+  3. **Caps come from a thread-local, copied at enqueue.** The worker dispatches
+     with `j->conn_caps`, captured from the `_Thread_local g_rpc_conn_caps`
+     (`server_http.c:907`) at submit time (`:429`). That thread-local is populated
+     on the HTTP listener thread; on the MCP dispatch path it is **not** guaranteed
+     to hold the caller's caps. So the bridge must thread the caller's real caps
+     (`conn->capabilities` from the MCP call) **explicitly** into the job, not
+     rely on the thread-local.
+
+  Net: P1c must factor the body of `rh_dispatch_op_async` (run-id generation,
+  `__run_id` injection, `openai_runs_store_create`, `pthread_create(op_run_worker)`)
+  into a helper taking `(op_method, request_json, caps)` and returning the queued
+  run snapshot / run id, callable from both the route layer and `server_mcp.c`.
+  This also means **moving/exporting** `op_run_job_t`, `op_run_worker`, and
+  `op_run_snapshot`, all `static` in the `.inc` today. Note there is already a
+  *second*, parallel copy of this async-run pattern in `openai_chat.c` (its own
+  worker plus `openai_runs_store_create`/`finalize`); the right move is to extract
+  one shared helper, not add a third copy.
+
+- **Gate on `CAP_DELEGATE` - and get it for free by routing through the method
+  gate.** Capability checks are keyed on the JSON-RPC **method** string, once, in
+  `server_dispatch` (`server.c:1296`, via `server_capability_for_method`); the
+  registry maps `delegate.roundtable -> CAP_DELEGATE` (`server_auth.c:84`) and
+  `mcp.call -> CAP_TOOL_EXECUTE` (`server_auth.c:106`). Two consequences:
+  1. **The existing `delegate` MCP tool does *not* enforce `CAP_DELEGATE` today.**
+     It reaches `handle_delegate` by a direct C call (`handle_mcp_delegate_call`
+     -> `handle_delegate`), already inside the `mcp.call`/`CAP_TOOL_EXECUTE` gate,
+     so the `delegate -> CAP_DELEGATE` registry entry is never consulted. A
+     principal holding only `CAP_TOOL_EXECUTE` can drive a delegate over
+     `mcp.call`. This is a pre-existing latent privilege gap; `ensemble_review`
+     must not reproduce it.
+  2. **The async-submit design closes the gap automatically.** Because
+     `op_run_worker` re-dispatches through `loopback_rpc` -> `server_dispatch`
+     with a fake connection whose `capabilities` are `j->conn_caps`
+     (`server_http.c:931`), submitting method `"delegate.roundtable"` **re-runs the
+     per-method cap gate** against those caps. So if the bridge threads the MCP
+     caller's `conn->capabilities` into the job, `CAP_DELEGATE` fires on its own -
+     **no separate explicit check is needed on this path.** An explicit
+     `CAP_DELEGATE` check is required only as a fallback if any direct
+     (non-re-dispatched) handler path is kept. Either way, add the negative test
+     (a `CAP_TOOL_EXECUTE`-only session is denied).
 
 Because the V1 route already exists, the human-facing path (`aimee delegate
 roundtable --mode review`) and the new agent-facing MCP path converge on one
@@ -296,11 +363,24 @@ channel stays prose; the machine-readable findings come from the participant par
   existing blocking-key extraction for `review_saturated`; add a *separate*
   all-severity item buffer for the result. They share the JSON parse but not the
   filter.
-- **Which round's items.** Populate from the **final round that ran** (the
-  surviving per-participant findings of that round, deduped by identity key across
-  participants), since that is the set the panel last stood behind. Note this is
-  pre-consolidation participant output, deduped - not "the consolidated round,"
-  which is prose and has no items array.
+- **Which round's items, and capture *before* the per-round free.** Populate from
+  the **final round that ran** (the surviving per-participant findings of that
+  round, deduped by identity key across participants), since that is the set the
+  panel last stood behind. Note this is pre-consolidation participant output,
+  deduped - not "the consolidated round," which is prose and has no items array.
+  **The capture point is load-bearing:** `results[i].response` is a round-scoped
+  allocation (declared fresh each iteration, `delegate_ensemble.c:940-941`) and is
+  freed inside the loop body at multiple exits - the main synthesis path frees all
+  responses at `:1062-1063`, with other frees on the degraded branch (`:1052`),
+  the cost-cap branch (`:1024`), and repair/error paths (`:950`, `:1005`, `:1039`).
+  **No participant items survive to the end of `delegate_roundtable_run` today** -
+  only the consolidated `artifact`/`peer_notes` and the `char[128]` identity-key
+  slugs do. So the items must be deep-copied at parse time, before whichever free
+  the final round exits through. This is exactly why §5's "retain at parse time"
+  matters and ties to finding #5 below: a run that exits via cost cap after
+  fan-out, `successful < min_ok` degrade, cancellation, or deadline must still
+  populate the items it had (and set `truncated`/a partial flag), not return an
+  apparently complete-but-empty list.
 - **Bound.** The existing key path caps at **64** and truncates silently
   (`:641`). The items array reuses that bound; on overflow it sets `truncated`
   (rather than dropping silently) so the caller knows the list is partial. Raising
@@ -319,13 +399,16 @@ saturates. The caller drives that loop; this feature returns findings, it does n
 auto-apply them (the roundtable's `apply_review` remains a separate, opt-in final
 draft turn).
 
-**Convergence semantics the caller must know.** `review_saturated` returns
-"converged" as soon as a round produces **zero blocking** keys (`:678-688`,
-`cur_count <= 0`). So a directed review whose brief has steered reviewers onto
+**Convergence semantics the caller must know.** `review_saturated` (`:678-688`)
+returns "converged" under **either** of two conditions: (a) the current round
+produced **zero blocking** keys (`cur_count <= 0`, `:680`), or (b) every current
+blocking key was **already seen in the previous round** (no new blocking finding,
+`:684-687`). So a directed review whose brief has steered reviewers onto
 already-fixed code - only suggestions/nits remain - **converges in a single round**
-and reports `converged: true`, even though the returned items array is non-empty
-(those non-blocking items did not gate convergence). The agent's apply-and-re-run
-loop should treat `converged` as "no blocking issues remain," not "no items
+via (a) and reports `converged: true`, even though the returned items array is
+non-empty (those non-blocking items did not gate convergence); and a review whose
+blocking set stops growing converges via (b). The agent's apply-and-re-run loop
+should treat `converged` as "no *new* blocking issues remain," not "no items
 remain," and decide independently whether to act on the returned suggestions/nits.
 This blocking-only definition is intentional and inherited; the proposal does not
 change it.
@@ -369,10 +452,12 @@ still terminates deterministically. Three accuracy notes for implementers:
   mode is a possible optimization (it would also remove a non-determinism source
   from an otherwise deterministic review) but is out of scope.
 - **Malformed participant JSON triggers a repair call.** `repair_review_json`
-  (`:648`) re-invokes the same reference model to fix bad JSON, an extra call per
-  malformed participant per round. An agent that loops `ensemble_review` will hit
-  this more often than the human CLI; no new spend *path*, but a heavier per-call
-  spend profile worth budgeting for.
+  (`:648`) re-invokes **that participant's own reference model**
+  (`ensemble_reference_models[participant]`, role `"review"`, not a generic
+  reference model) to fix bad JSON, an extra call per malformed participant per
+  round. An agent that loops `ensemble_review` will hit this more often than the
+  human CLI; no new spend *path*, but a heavier per-call spend profile worth
+  budgeting for.
 
 ## §8 Config
 
@@ -420,15 +505,27 @@ the new agent surface. None of them touch the roundtable's core or its P0 fixes.
   `suggestion`/`nit` entries while `review_saturated` still keys only on
   `blocking` (a run with zero blocking items converges in one round yet still
   returns the non-blocking items).
+- **Missing/non-string severity:** an item whose `severity` field is absent or
+  non-string is counted as blocking by the existing filter (`:632`); a test pins
+  how it appears in the returned all-severity array (e.g. normalized to
+  `blocking`) so the saturation set and the return array stay consistent.
+- **Degraded-exit capture:** a run that exits before consolidation (cost cap
+  after fan-out, `successful < min_ok`, cancellation, deadline) still returns the
+  participant items it had and sets the partial flag, never an empty-but-complete
+  list.
 - **Structured return / identity keys:** each returned item carries
   severity/location/summary and an identity key that matches
   `normalized_identity_key` (no reliance on a model-supplied stable key); overflow
   past 64 sets `truncated`.
 - **MCP reachability + async:** an end-to-end test that `ensemble_review` reaches
   `ROUNDTABLE_REVIEW` (not the single-delegate `handle_mcp_delegate_call` path),
-  returns a run id without blocking the request, supports `/v1/runs/{id}/stop`, and
-  requires `CAP_DELEGATE`; a negative test that a session without `CAP_DELEGATE` is
-  denied.
+  returns a run id without blocking the request, and supports `/v1/runs/{id}/stop`.
+- **CAP_DELEGATE via the method gate:** a session holding `CAP_TOOL_EXECUTE` but
+  **not** `CAP_DELEGATE` is denied when it calls `ensemble_review` - proving the
+  cap is enforced by the re-dispatched `delegate.roundtable` method gate
+  (`server.c:1296`) and not merely inherited from the `mcp.call`/`CAP_TOOL_EXECUTE`
+  gate. (Contrast: the same session *can* drive the existing `delegate` MCP tool
+  today, which is the pre-existing hole this design avoids.)
 - **No second engine:** a negative check that the MCP path drives the shared
   async roundtable run and does not introduce a parallel inline engine entry.
 

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -3,22 +3,29 @@
 - **State:** draft, pending review
 - **Author:** JBailes
 - **Date:** 2026-06-09
-- **Charter roles:** Review (per-round critique and consolidation), Reason
-  (saturation/convergence judging). No new role.
+- **Charter roles:** Review (per-round critique and consolidation). Reason runs
+  the per-round quality scorer and the draft-mode convergence tiebreak; note that
+  review-mode *convergence is deterministic C* (`review_saturated`), not a Reason
+  call (§7). No new role.
+- **Base:** retargeted at `rakuen/testing` as of `d3eb402d` (the roundtable
+  landed via PR #136 and PR #142; the symbols below are live on `testing`, not on
+  an in-flight branch). All line numbers are `testing@d3eb402d`; prefer the symbol
+  names, which are stable, over the line numbers, which drift.
 - **Scope:** `src/server/delegate_ensemble.c` (thread a caller-supplied `brief`
-  into the review-mode prompt builder `build_round_prompt:304`, and return the
-  parsed structured review items, not only the consolidated prose, from
-  `delegate_roundtable_run`), `src/headers/delegate_ensemble.h` (one new
-  `const char *brief` field on `roundtable_opts_t`, and an items array on
+  into the review-mode prompt builder `build_round_prompt:393` **and the two
+  functions that call it**, `run_round_parallel:690` / `run_round_sequential:720`;
+  retain the parsed structured review items as engine state instead of discarding
+  them), `src/headers/delegate_ensemble.h` (one new `const char *brief` field on
+  `roundtable_opts_t`, plus a bounded items array and `answeredQuestions` on
   `roundtable_result_t`), `src/server/server_compute.c`
-  (`handle_delegate_roundtable:1742` reads `brief` from the request body and
-  surfaces the structured items in the run result), a new agent-callable MCP
-  tool registered in `src/mcp_tools.c` (beside `delegate:577` /
-  `delegate_status:602`) and dispatched in `src/server/server_mcp.c` (beside the
-  `strcmp(tool, "delegate"):1396` arm), gated on the existing `CAP_DELEGATE`
-  (`server.h:59`). Optional: a `--brief` flag on `aimee delegate roundtable` and
-  a thin caller-side `git diff` helper. No new engine, no new role, no new
-  capability flag, no new provider.
+  (`handle_delegate_roundtable:1742` reads `brief` and serializes the items), the
+  MCP surface in `src/mcp_tools.c` (register beside `delegate:577` /
+  `delegate_status:602`) and `src/server/server_mcp.c` (a new arm beside
+  `strcmp(tool, "delegate"):1396` in `handle_mcp_call:1369`), gated on the
+  existing `CAP_DELEGATE` (`src/headers/server.h:59`). The MCP surface needs an
+  **async bridge** (§3), not just a dispatch arm. Optional: a `--brief` flag on
+  `aimee delegate roundtable` and a thin caller-side `git diff` helper. No new
+  engine, no new role, no new capability flag, no new provider.
 
 ## Goal
 
@@ -41,67 +48,81 @@ This builds directly on
 specifically its **Mode B (review)**. That proposal generalizes the
 Mixture-of-Agents ensemble into a multi-round roundtable and defines the
 review-mode feedback contract (severity `blocking|suggestion|nit`, engine-computed
-identity keys, saturation-based convergence). That work is **in flight on the
-`feat/agent-roundtable` branch** (commit `0fae05d` plus working-tree changes to
-`delegate_ensemble.c`); the symbols this proposal cites land with it, not on
-`testing` yet. This proposal is **strictly additive** on top of a working review
-mode and adds nothing the roundtable needs to function; it can be staged or
-dropped without reopening that work. Read the two together: the roundtable is the
-engine, this is the agent-facing, directed application of it.
+identity keys, saturation-based convergence). **That work is now merged to
+`testing`** (PR #136, PR #142); the symbols this proposal cites are live, so the
+implementation guidance below depends on committed code, not an in-flight branch.
+This proposal is **strictly additive** on top of the working review mode and adds
+nothing the roundtable needs to function; it can be staged or dropped without
+reopening that work. Read the two together: the roundtable is the engine, this is
+the agent-facing, directed application of it.
 
 ## §0 What already exists (so we do not rebuild it)
 
-The review machinery is built (on the roundtable branch). Confirmed in the tree:
+The review machinery is built and on `testing`. Confirmed in the tree
+(`testing@d3eb402d`):
 
 - **The review-mode loop.** `delegate_roundtable_run`
-  (`src/headers/delegate_ensemble.h`, impl in `delegate_ensemble.c`) runs the
-  review mode end to end: per-round reviewer fan-out, each reviewer routed to a
-  distinct configured participant (`agent_run_named`), cost/min-success/degrade,
+  (`delegate_ensemble.c:868`, declared in `delegate_ensemble.h`) runs the review
+  mode end to end: per-round reviewer fan-out, each reviewer routed to a distinct
+  configured participant (`agent_run_named`), cost/min-success/degrade,
   consolidation, and saturation-based stop. `roundtable_opts_t.mode ==
   ROUNDTABLE_REVIEW` selects it.
 - **The per-round reviewer prompt builder.** `build_round_prompt`
-  (`delegate_ensemble.c:304`) already branches on mode and emits the
-  "review and critique" framing (`:308`) and the structured-output instruction
-  (`:354`). **This is the single seam the brief threads through** (§4); it takes
-  no caller context today.
+  (`delegate_ensemble.c:393`) branches on mode and emits the "review and critique"
+  framing (`role_hint`, `:396`) and the structured-output instruction
+  (`mode_task`, `:397`). **Note the shape: it is a single `snprintf` (`:415-420`),
+  not an incremental appender** (contrast `build_synthesis_prompt:327` and
+  `build_round_synthesis_prompt:425`, which *are* appenders). It takes no caller
+  context today, and there is no statement boundary "between the framing and the
+  structured instruction" to insert into; threading the brief is a format-string
+  change (§4).
 - **The structured-feedback contract.** Reviewers return JSON items; the engine
-  parses them in `parse_review_issue_keys` (`delegate_ensemble.c:524`), computes a
-  model-independent identity key per item via `normalized_identity_key`
-  (`:497`, hashes `category` + `location`, falls back to `summary`), and decides
-  saturation with `review_saturated` (`:593`). **But the parse keeps only the
-  identity keys for the stop predicate and discards the items themselves** (§5).
+  parses them in `parse_review_issue_keys` (`delegate_ensemble.c:608`), computes a
+  model-independent identity key per item via `normalized_identity_key` (`:581`,
+  hashes `category` + `location`, falls back to `summary`), and decides saturation
+  with `review_saturated` (`:678`). **Two facts that constrain §5:** (a) the parse
+  keeps only the identity keys for the stop predicate and discards the items
+  themselves; (b) it counts **blocking-only** items (`:632` skips any
+  `severity != "blocking"`), and the key arrays are fixed `char[64][128]` stacks,
+  so at most 64 keys, silently truncated past that (`:641`).
 - **The reviewer role.** `tasks[i].role = "review"` in review mode
-  (`delegate_ensemble.c:617` and the sequential path `:650`); the `review` charter
+  (`delegate_ensemble.c:704` parallel, `:738` sequential); the `review` charter
   role is defined at `src/role_templates.c:21` with severity/category/location
   expectations.
-- **The V1 entry point.** `POST /v1/delegate/roundtable` is wired
-  (`server_http_routes.inc`, dispatch method `delegate.roundtable` in
-  `src/server/server.c`) to `handle_delegate_roundtable`
-  (`src/server/server_compute.c:1742`), which loads config, builds
-  `roundtable_opts_t`, runs the engine async via `/v1/runs/{id}`, and returns
-  `artifact` plus `rounds_run` / `converged` / `degraded` / `truncated` /
-  `cost_capped` / `deadline_hit` / `best_round` / `cost_usd`. It is gated
-  `CAP_DELEGATE`.
+- **The V1 entry point.** `POST /v1/delegate/roundtable`
+  (`server_http_routes.inc:951`, dispatch `delegate.roundtable` in
+  `src/server/server.c:1140`) routes to `handle_delegate_roundtable`
+  (`server_compute.c:1742`), which loads config, builds `roundtable_opts_t`, and
+  returns `artifact` plus `rounds_run` / `converged` / `degraded` / `truncated` /
+  `cost_capped` / `deadline_hit` / `cancelled` / `best_round` / `cost_usd`. It is
+  gated `CAP_DELEGATE`. **Crucially it is exposed via `rh_dispatch_op_async`**,
+  which is what registers a run and injects `__run_id` (`server_http_routes.inc:404`)
+  so `handle_delegate_roundtable` can wire cancellation (`server_compute.c:1770`).
+  The handler body itself runs `delegate_roundtable_run` **synchronously**
+  (`:1796`); the async behavior comes entirely from the route wrapper.
 - **The MCP tool pattern.** Agent-callable tools are registered with `build_tool`
   in `src/mcp_tools.c` (`delegate:577`, `delegate_status:602`) and dispatched in
-  `src/server/server_mcp.c` (`strcmp(tool, "delegate"):1396` ->
-  `handle_mcp_delegate_call:1398`). `CAP_DELEGATE` is `1u << 1` (`server.h:59`).
-- **Config.** `ensemble_*` (`config.h:1201-1206`, parser
-  `config_sections.c:1068`) supplies participants/aggregator/cost; `roundtable_*`
-  (`config.h:1210-1213`, parser `config_sections.c:1104`, CLI-settable scalars
-  `config_fields.c:164-171`) supplies the loop defaults. **No new config keys are
-  required.**
+  `handle_mcp_call` (`src/server/server_mcp.c:1369`, the `delegate` arm at
+  `:1396`). `CAP_DELEGATE` is `1u << 1` (`src/headers/server.h:59`). **`/v1/mcp/call`
+  is routed via *synchronous* `rh_dispatch_op` (`server_http_routes.inc:922`), and
+  `handle_mcp_call` never sees `__run_id`** - this is the central wiring problem
+  for §3.
+- **Config.** `ensemble_*` (`config.h:1202-1206`) supplies
+  participants/aggregator/cost; `roundtable_*` (`config.h:1210-1213`, CLI-settable
+  scalars `config_fields.c:164-169`) supplies the loop defaults. **No new config
+  keys are required.**
 
 So the net new code is small and additive: **a brief field threaded into one
-prompt builder, the parsed review items returned instead of discarded, and an
-agent-callable MCP tool that targets review mode.**
+prompt builder (and its two callers), the parsed review items retained instead of
+discarded, and an agent-callable MCP tool that targets review mode through an
+async bridge.**
 
 ## §1 The gap: review mode is built, but it is undirected and not agent-callable
 
 Two concrete gaps stand between "review mode exists" and "an agent can call in a
 directed PR review":
 
-1. **It is undirected.** `build_round_prompt` (`:304`) composes the reviewer
+1. **It is undirected.** `build_round_prompt` (`:393`) composes the reviewer
    prompt from `task + artifact + peer_notes` only. The caller cannot say "focus
    on the shutdown race" or "I just bumped the gst pin, confirm it holds." The
    panel re-derives the author's concerns slowly and incompletely, which is
@@ -109,8 +130,8 @@ directed PR review":
 2. **It is not reachable by an in-process agent.** The only surfaces are the
    human CLI and the V1 HTTP route. There is no MCP tool an agent can call
    mid-task, and the existing `delegate` MCP tool (`mcp_tools.c:577`) runs a
-   single role-routed delegate, not the ensemble or the roundtable. The Explore
-   of the tree confirms no `ensemble`/`roundtable` MCP tool exists today.
+   single role-routed delegate, not the ensemble or the roundtable. No
+   `ensemble`/`roundtable` MCP tool exists today.
 
 There is also an **output-shape gap** (§5): even when review mode runs, the
 structured items the reviewers produced are parsed only to compute saturation keys
@@ -119,9 +140,8 @@ items (severity, location, summary) so it can act on each one and re-run.
 
 ## §2 The brief: direction without tunnel vision
 
-The brief is a short, optional, freeform-plus-light-structure block the caller
-passes in. It carries the four things an author knows that a fresh reviewer does
-not:
+The brief is a short, optional block the caller passes in. It carries the four
+things an author knows that a fresh reviewer does not:
 
 ```json
 {
@@ -132,9 +152,14 @@ not:
 }
 ```
 
-It may also be passed as a single freeform string; the tool accepts either and
-normalizes to the block above. Empty brief == today's undirected review, byte for
-byte (§4).
+Over MCP the brief is accepted as **either** a freeform string **or** this
+structured object, and normalized to the object form. `questions` in particular
+**must be carried as a structured array, not buried in freeform text**, because
+§5 promises a per-question answer back and the consolidator cannot reliably know
+which sentences were questions otherwise. The normalization is deterministic: a
+freeform string becomes `{focus: [<the string>], questions: []}` (no questions are
+invented from prose), so an unstructured brief never silently acquires answer
+obligations. Empty brief == today's undirected review, byte for byte (§4).
 
 **The brief weights attention; it never gates findings.** Every reviewer prompt
 appends, verbatim, an instruction of the form: "Prioritize the focus areas and
@@ -146,13 +171,10 @@ suppressing out-of-scope findings; it only re-orders priority and seeds the
 `questions` the consolidation must answer.
 
 The brief does **not** change the convergence contract. Saturation still keys on
-the engine-computed identity hash (`normalized_identity_key:497`), not on whether
-a finding matched the brief. A `questions` block adds one obligation: the
-consolidated review must answer each question explicitly (answered / not-answered
-+ evidence), so the caller always learns whether its hypothesis was confirmed or
-refuted.
+the engine-computed identity hash (`normalized_identity_key:581`), on
+blocking-severity items only (§7), not on whether a finding matched the brief.
 
-## §3 Agent-callable surface: a new MCP tool
+## §3 Agent-callable surface: a new MCP tool over an async bridge
 
 Add one MCP tool, the minimum that makes review mode reachable from inside an
 agent turn. Working name `ensemble_review` (final name open, §12).
@@ -164,8 +186,8 @@ agent turn. Working name `ensemble_review` (final name open, §12).
   {
     "type": "object",
     "properties": {
-      "diff":       {"type": "string", "description": "Unified diff / code under review, or a path to it"},
-      "brief":      {"type": "string", "description": "Optional: focus areas, fixes made, invariants, questions (freeform or JSON, see proposal)"},
+      "diff":       {"type": "string", "description": "Unified diff / code under review (caller-provided text, min 20 chars)"},
+      "brief":      {"type": ["string", "object"], "description": "Optional: {focus, fixes, invariants, questions} object, or freeform string (see §2)"},
       "rounds":     {"type": "integer", "description": "Max review rounds; default from roundtable.max_rounds"},
       "turns":      {"type": "string", "enum": ["parallel", "sequential"]}
     },
@@ -173,71 +195,140 @@ agent turn. Working name `ensemble_review` (final name open, §12).
   }
   ```
 
-- **Dispatch** in `src/server/server_mcp.c`, a new arm beside
-  `strcmp(tool, "delegate"):1396`. The handler builds a `roundtable_opts_t` with
-  `mode = ROUNDTABLE_REVIEW`, sets `brief` (§4), folds `rounds`/`turns` over the
-  configured defaults, and calls the **same** server-side roundtable path
-  `handle_delegate_roundtable` (`server_compute.c:1742`) uses. It must not fork a
-  second engine entry; it reuses the one async run path so cancellation
-  (`/v1/runs/{id}/stop`), cost cap, and degrade behavior are identical.
-- **Gate** on the existing `CAP_DELEGATE` (`server.h:59`). No new capability:
-  this is delegate-class, LLM-heavy, cost-bearing work, and `CAP_DELEGATE`
-  already fences exactly that. The MCP tool inherits the session's caps the same
-  way the `delegate` tool does.
+  `diff` is **caller-provided text only** - no path argument, no filesystem read,
+  no PR fetch (§6, §11). It maps to the engine's `task` argument and therefore
+  inherits the existing `handle_delegate_roundtable` validation, including the
+  **20-character minimum** (`server_compute.c:1749`); a one-line hunk below that
+  floor is rejected with "roundtable prompt too short," so the tool description
+  states the minimum.
+
+- **Dispatch and lifecycle - the load-bearing detail.** The proposal cannot just
+  call `handle_delegate_roundtable` inline from the MCP arm. `/v1/mcp/call` is
+  routed via **synchronous** `rh_dispatch_op`, and `handle_mcp_call` never
+  receives `__run_id`. Calling the handler inline would:
+  1. **Block the MCP request for up to `roundtable_deadline_ms`** (default
+     600000 ms = 10 minutes) while the full multi-round loop runs on the request
+     thread, and
+  2. **Silently lose cancellation**: with no `__run_id`, `opts.cancel_requested`
+     stays `NULL`, every cancel check in `delegate_roundtable_run` is dead, and
+     `/v1/runs/{id}/stop` has no run to stop. The cost cap and deadline still
+     apply (they read config, not the run), but "cancellation identical to the V1
+     route" is **not** achievable by inline reuse.
+
+  So `ensemble_review` must launch through the **same async op-run machinery the
+  V1 route uses** - i.e. submit `delegate.roundtable` as an async run so a run id
+  and `__run_id` are created - then **return that run id immediately** and let the
+  agent poll. This mirrors the existing async-MCP precedent exactly: the
+  `delegate` MCP tool starts a job and returns an id; `delegate_status` polls
+  (`server_mcp.c:1396-1410`). Concretely, `ensemble_review` returns
+  `{run_id, status: "running"}` and the agent polls `/v1/runs/{id}` (or a thin
+  `ensemble_review_status` sibling) for the structured result. The net new server
+  work is therefore: the async submit bridge + request parsing for `brief`, not a
+  single synchronous dispatch arm.
+
+- **Gate** on the existing `CAP_DELEGATE` (`src/headers/server.h:59`). No new
+  capability: this is delegate-class, LLM-heavy, cost-bearing work, and
+  `CAP_DELEGATE` already fences exactly that. The MCP tool inherits the session's
+  caps the same way the `delegate` tool does.
 
 Because the V1 route already exists, the human-facing path (`aimee delegate
 roundtable --mode review`) and the new agent-facing MCP path converge on one
-implementation. The only new server code is request parsing for `brief` and the
-tool dispatch arm.
+engine and one async run lifecycle.
 
 ## §4 Threading the brief through the engine
 
-One seam: `build_round_prompt` (`delegate_ensemble.c:304`).
+The seam is `build_round_prompt` (`delegate_ensemble.c:393`), but because it is a
+single `snprintf`, the change is to its **format string and signature**, not an
+appended block:
 
-1. Add `const char *brief;` to `roundtable_opts_t`
-   (`delegate_ensemble.h`). Default `NULL`.
-2. Pass it through `delegate_roundtable_run` into `build_round_prompt`
-   (both the parallel call site `:614` and the sequential `:646`).
-3. In `build_round_prompt`, when `mode == ROUNDTABLE_REVIEW` and `brief != NULL`,
-   emit the brief block plus the open-mandate instruction (§2) after the
-   "review and critique" framing (`:308`) and before the structured-output
-   instruction (`:354`). When `brief == NULL` the emitted prompt is unchanged,
-   so existing review behavior and its tests are byte-identical.
-4. The brief is included in the **per-round** prompt so that in sequential and
-   multi-round runs every reviewer (and every later round reacting to peers) keeps
-   the same direction. It is **not** included in the consolidation/aggregator
-   prompt except for the `questions`, which the consolidator must answer (§2).
+1. Add `const char *brief;` to `roundtable_opts_t` (`delegate_ensemble.h`).
+   Default `NULL`.
+2. Thread `brief` through the **two callers** the proposal must not skip -
+   `run_round_parallel` (`:690`, call site `:701`) and `run_round_sequential`
+   (`:720`, call site `:733`) - into `build_round_prompt`. Both wrapper signatures
+   gain the parameter; `delegate_roundtable_run` already holds `local.brief`.
+3. In `build_round_prompt`, when `mode == ROUNDTABLE_REVIEW`, render the brief
+   into a **middle `%s`** that is the empty string when `brief == NULL`, placed
+   after the role framing and before the `ROUND %d INSTRUCTION` block, carrying the
+   open-mandate sentence (§2). When `brief == NULL` (or in draft mode) the `%s`
+   expands to nothing and the surrounding literal is unchanged, so the emitted
+   prompt is **byte-identical** to today and existing review-mode tests stay green
+   (§10).
+4. The brief is included in the **per-round** prompt so every reviewer (and every
+   later round reacting to peers) keeps the same direction. It is **not** injected
+   into the consolidation prompt, except that `questions` are handed to the
+   structured-answer pass (§5).
 
-Budgeting: the brief counts against the same per-round byte budget the roundtable
-already enforces (`build_round_prompt` truncation / summarize-forward path). A
-brief that is itself enormous is summarized forward like any other oversized
-context, with the existing `truncated` flag set, never silently dropped.
+**Budgeting (corrected).** The roundtable does *not* bound `build_round_prompt`
+output to a fixed per-round byte budget - it allocates dynamically by input length
+(`:411-412`). The only summarize-forward path is in `delegate_roundtable_run`,
+gated on `strlen(artifact) + strlen(peer_notes) + strlen(task) > 22000`
+(`:931`), and the brief is none of those three, so **adding the brief does not
+automatically count against that check or set `truncated`.** This proposal
+therefore defines an explicit bound: the normalized brief is capped at **4 KB**;
+input beyond that is truncated at the seam and `roundtable_result_t.truncated` is
+set, so an oversized brief is never silently dropped and never silently inflates
+the prompt. (A brief is author-supplied direction, not document content;
+summarize-forward is the wrong tool for it.)
 
 ## §5 Structured, actionable output back to the caller
 
 An agent needs the items, not the essay. Today `parse_review_issue_keys`
-(`delegate_ensemble.c:524`) extracts identity keys for saturation and discards the
-rest. Extend it (or add a sibling that shares the JSON parse) to retain the full
-item: `severity`, `category`, `location`, `summary`, plus the engine-computed
-identity key.
+(`delegate_ensemble.c:608`) extracts identity keys for saturation and discards the
+rest. The fix is to **retain the full parsed items as engine state at parse
+time** - *not* to re-shape the aggregator's consolidated prose.
 
-- Add a bounded items array to `roundtable_result_t` (`delegate_ensemble.h`),
-  populated from the **final, consolidated** round (the surviving, deduplicated
-  blocking/suggestion/nit set), each item carrying its severity, location,
-  one-line summary, and identity key.
-- `handle_delegate_roundtable` (`server_compute.c:1742`) serializes that array
-  into the run result JSON alongside the existing `artifact` and flags. The MCP
-  tool returns the same shape.
-- Add `answeredQuestions: [{question, answer, evidence}]` populated by the
-  consolidation when the brief carried `questions` (§2), and `coverageGaps`
-  (e.g. "no participant addressed the teardown path") when a question went
-  unanswered.
+Why this distinction matters: the aggregator's consolidated response is reused
+**verbatim** as the next round's `artifact` and `peer_notes`
+(`delegate_ensemble.c:1087`, `:1095`), and `peer_notes` is fed straight into the
+next reviewer prompt (`:417`). If we satisfied the structured contract by forcing
+the **aggregator** to emit JSON, that JSON would become the next round's peer
+notes and change reviewer behavior and the saturation dynamics. So the consolidation
+channel stays prose; the machine-readable findings come from the participant parse.
+
+- Extend the parse (or add a sibling sharing the JSON walk) to retain each item's
+  `severity`, `category`, `location`, `summary`, plus the engine-computed identity
+  key, into a bounded array on `roundtable_result_t` (`delegate_ensemble.h`).
+- **Severity scope is split deliberately.** The returned array carries
+  `blocking | suggestion | nit` (the agent wants all of them to act on), but
+  **saturation/convergence stays blocking-only and unchanged** (`:632`, `:678`).
+  Widening the returned set must not widen the stop predicate. Concretely: keep the
+  existing blocking-key extraction for `review_saturated`; add a *separate*
+  all-severity item buffer for the result. They share the JSON parse but not the
+  filter.
+- **Which round's items.** Populate from the **final round that ran** (the
+  surviving per-participant findings of that round, deduped by identity key across
+  participants), since that is the set the panel last stood behind. Note this is
+  pre-consolidation participant output, deduped - not "the consolidated round,"
+  which is prose and has no items array.
+- **Bound.** The existing key path caps at **64** and truncates silently
+  (`:641`). The items array reuses that bound; on overflow it sets `truncated`
+  (rather than dropping silently) so the caller knows the list is partial. Raising
+  the cap is a deliberate, separate decision (§12 Q3).
+- Add `answeredQuestions: [{question, answer, evidence}]` for each `questions`
+  entry the brief carried, and `coverageGaps` when a question went unanswered.
+  Because the consolidation is prose, the per-question answers come from a small
+  **structured pass over the consolidated review** keyed on the
+  `questions` array (one extra instruction to the consolidator, or a single
+  `reason`-role JSON pass - §12 Q5), not from parsing free prose. An empty
+  `questions` array means no `answeredQuestions` obligation.
 
 This makes the result a thing an agent can loop over: apply each suggested fix,
 then re-invoke with `brief.fixes` describing what it just changed, until the panel
 saturates. The caller drives that loop; this feature returns findings, it does not
 auto-apply them (the roundtable's `apply_review` remains a separate, opt-in final
 draft turn).
+
+**Convergence semantics the caller must know.** `review_saturated` returns
+"converged" as soon as a round produces **zero blocking** keys (`:678-688`,
+`cur_count <= 0`). So a directed review whose brief has steered reviewers onto
+already-fixed code - only suggestions/nits remain - **converges in a single round**
+and reports `converged: true`, even though the returned items array is non-empty
+(those non-blocking items did not gate convergence). The agent's apply-and-re-run
+loop should treat `converged` as "no blocking issues remain," not "no items
+remain," and decide independently whether to act on the returned suggestions/nits.
+This blocking-only definition is intentional and inherited; the proposal does not
+change it.
 
 ## §6 PR / diff input
 
@@ -246,24 +337,42 @@ shells out to `git diff` in places (`src/cmd_slop.c`, `src/mcp_git_write.c`) but
 has no PR-fetch or patch-parsing layer. The `diff` argument is plain task text:
 the caller (the agent, which already has the working tree and `git`) pastes the
 unified diff in. This matches how the roundtable proposal frames its review input
-("paste the document under review").
+("paste the document under review"). The schema therefore takes **text only** - no
+path argument (an earlier draft said "or a path to it"; that is dropped, since a
+path would require filesystem reads, workspace binding, detached/remote-workspace
+checks, and payload limits that are all out of scope for v1).
 
 Optional, deferred: a thin caller-side helper that runs `git diff <range>` and
 fills `diff` so a human can say `aimee delegate roundtable --mode review --brief
 "..." --range origin/main...HEAD`. No server-side git, no GitHub API in v1.
-GitHub PR fetch and inline-comment posting are explicit non-goals for v1 (§11);
-posting anything outward is opt-in and out of scope here.
+GitHub PR fetch and inline-comment posting are explicit non-goals for v1 (§11).
 
 ## §7 Convergence, cost, and safety are inherited, not rebuilt
 
-Everything that bounds the roundtable bounds this unchanged: the running
+Everything that bounds the roundtable bounds this unchanged: the
 `ensemble_max_cost_usd` cap, `roundtable_max_rounds` (default 3),
 `roundtable_deadline_ms` (default 600000), `min_successful` degrade-to-best, the
-per-round byte budget, and `/v1/runs/{id}/stop` cancellation. The brief and the
-agent entry point add no new unbounded loop and no new spend path: the MCP tool is
-just another caller of the same async run. The saturation predicate is unchanged
-and remains model-independent (engine-computed identity keys), so a directed
-review still terminates deterministically.
+summarize-forward path, and - **once the async bridge of §3 is in place** -
+`/v1/runs/{id}/stop` cancellation. The saturation predicate is unchanged and
+remains model-independent (engine-computed identity keys), so a directed review
+still terminates deterministically. Three accuracy notes for implementers:
+
+- **The cost cap is post-round, not preflight-binding.** The per-round preflight
+  estimate only **logs a warning and continues** (`delegate_ensemble.c:922-930`);
+  the cap is enforced after a round's observed cost (`:1013`, `:1120`). An agent
+  cannot rely on preflight to prevent the first expensive round.
+- **A `reason`-role quality scorer runs every round in review mode**
+  (`run_quality_scorer:477`, called at `:1042` and `:1110`), even though review
+  convergence is decided by the deterministic `review_saturated`, not by that
+  score (the score only selects `best_artifact`). That is an extra `reason` LLM
+  call per round; surfaced here as expected cost. Skipping the scorer in review
+  mode is a possible optimization (it would also remove a non-determinism source
+  from an otherwise deterministic review) but is out of scope.
+- **Malformed participant JSON triggers a repair call.** `repair_review_json`
+  (`:648`) re-invokes the same reference model to fix bad JSON, an extra call per
+  malformed participant per round. An agent that loops `ensemble_review` will hit
+  this more often than the human CLI; no new spend *path*, but a heavier per-call
+  spend profile worth budgeting for.
 
 ## §8 Config
 
@@ -274,16 +383,20 @@ there is nothing to toggle: an empty brief is identical to plain review mode.
 
 ## §9 Phasing
 
-1. **P1a, brief plumbing.** Add `brief` to `roundtable_opts_t`, thread through
-   `build_round_prompt` (§4), parse `brief` in `handle_delegate_roundtable`. The
-   open-mandate instruction and the empty-brief == unchanged-prompt invariant
-   land here with tests.
-2. **P1b, structured return.** Retain and return the parsed review items and
-   `answeredQuestions`/`coverageGaps` (§5). This is independently useful for the
-   human CLI review mode too.
-3. **P1c, agent-callable MCP tool.** Register `ensemble_review` and its dispatch
-   arm (§3), `CAP_DELEGATE`-gated, reusing the same run path. This is what
-   delivers the headline "an agent can call in the ensemble."
+1. **P1a, brief plumbing.** Add `brief` to `roundtable_opts_t`; thread through
+   `run_round_parallel` / `run_round_sequential` into `build_round_prompt` as the
+   empty-when-NULL middle `%s` (§4); parse `brief` (string-or-object) in
+   `handle_delegate_roundtable`; enforce the 4 KB cap. The open-mandate instruction
+   and the byte-identical empty-brief invariant land here with tests.
+2. **P1b, structured return.** Retain the parsed review items as engine state
+   (all severities for the result, blocking-only for saturation) and add
+   `answeredQuestions`/`coverageGaps` (§5). Independently useful for the human CLI
+   review mode too.
+3. **P1c, agent-callable MCP tool over the async bridge.** Register
+   `ensemble_review`, add the async submit + run-id return + poll surface (§3),
+   `CAP_DELEGATE`-gated, reusing the V1 run lifecycle. This is the headline "an
+   agent can call in the ensemble." **It depends on the async bridge, not a bare
+   dispatch arm.**
 4. **P2, optional ergonomics.** `--brief` CLI flag and the `git diff` range
    helper (§6).
 
@@ -298,19 +411,26 @@ the new agent surface. None of them touch the roundtable's core or its P0 fixes.
 - **Open mandate:** a unit test asserts the brief block is followed by the
   "report blocking issues even if outside focus" instruction, so direction cannot
   be implemented as a filter.
-- **Questions answered:** a test with a `questions` brief asserts the result
-  carries an `answeredQuestions` entry per question (answered or not), so a
-  caller hypothesis is always resolved.
-- **Structured return:** a review run returns a non-empty items array with
-  severity/location/summary/identity-key for each surviving finding, and the
-  identity keys match `normalized_identity_key` (no reliance on model
-  `stable_key`).
-- **MCP reachability:** an end-to-end test that the `ensemble_review` tool call
-  reaches `ROUNDTABLE_REVIEW` (not the single-delegate `handle_mcp_delegate_call`
-  path) and requires `CAP_DELEGATE`; a negative test that a session without
-  `CAP_DELEGATE` is denied.
-- **No second engine:** a negative check that the MCP arm calls the shared
-  roundtable run path and does not introduce a parallel inline engine entry.
+- **Brief cap:** a brief over 4 KB is truncated at the seam and sets `truncated`;
+  it is never silently dropped and never pushed through summarize-forward.
+- **Questions answered:** a test with a structured `questions` brief asserts the
+  result carries an `answeredQuestions` entry per question (answered or not), and
+  a freeform-string brief acquires **no** answer obligation.
+- **Severity split:** a review run returns an items array containing
+  `suggestion`/`nit` entries while `review_saturated` still keys only on
+  `blocking` (a run with zero blocking items converges in one round yet still
+  returns the non-blocking items).
+- **Structured return / identity keys:** each returned item carries
+  severity/location/summary and an identity key that matches
+  `normalized_identity_key` (no reliance on a model-supplied stable key); overflow
+  past 64 sets `truncated`.
+- **MCP reachability + async:** an end-to-end test that `ensemble_review` reaches
+  `ROUNDTABLE_REVIEW` (not the single-delegate `handle_mcp_delegate_call` path),
+  returns a run id without blocking the request, supports `/v1/runs/{id}/stop`, and
+  requires `CAP_DELEGATE`; a negative test that a session without `CAP_DELEGATE` is
+  denied.
+- **No second engine:** a negative check that the MCP path drives the shared
+  async roundtable run and does not introduce a parallel inline engine entry.
 
 ## §11 Non-goals
 
@@ -327,29 +447,36 @@ the new agent surface. None of them touch the roundtable's core or its P0 fixes.
 1. **Tool name.** `ensemble_review` vs `pr_review` vs `review` vs
    `roundtable_review`. `delegate` is taken and means something narrower; the name
    should signal "multi-agent review," not "single delegate."
-2. **Brief shape over MCP.** Accept only a freeform string and parse it, or
-   accept the structured `{focus, fixes, invariants, questions}` object directly?
-   (Leaning: accept both; normalize to the object; questions need structure to
-   guarantee per-question answers.)
-3. **Items array bound.** What is the cap on returned items, and how do we report
-   when a verbose review overflows it (summarize-forward vs drop-with-flag, reuse
-   the existing `truncated` semantics)?
+2. **Async surface shape.** Return a bare `run_id` and let the agent poll
+   `/v1/runs/{id}` (reusing the existing run surface), or add a dedicated
+   `ensemble_review_status` tool mirroring `delegate_status`? (Leaning: reuse
+   `/v1/runs/{id}` to avoid a second polling tool; confirm the run-result JSON
+   carries the new items array.)
+3. **Items array bound.** The engine's de-facto cap today is **64** with silent
+   truncation (`:641`). Keep 64 and set `truncated` on overflow (this proposal's
+   default), or raise it deliberately for verbose reviews? Raising it means heap
+   allocation instead of the current fixed stack arrays.
 4. **Auto-brief.** When an agent does not supply a brief, should the tool
-   optionally synthesize one from the diff itself (changed files, churned hunks)
-   so even an unbriefed call is lightly directed? (Leaning: no in v1; an empty
-   brief must stay identical to plain review mode for parity.)
-5. **Aggregator and the questions.** Should answering `questions` be the
-   consolidator's job (one extra instruction) or a separate `reason`-role pass?
-   (Leaning: consolidator, to avoid an extra LLM call per run.)
+   optionally synthesize one from the diff itself (changed files, churned hunks)?
+   (Leaning: no in v1; an empty brief must stay identical to plain review mode for
+   parity.)
+5. **Answering the questions.** Should the per-question answer pass be one extra
+   instruction folded into the consolidator, or a separate `reason`-role JSON pass?
+   (Leaning: fold into the consolidator to avoid an extra LLM call, accepting that
+   the consolidator must then emit a small side JSON the engine reads without
+   feeding it back into `peer_notes`.)
 
 ## Recommendation
 
 Ship P1a + P1b + P1c: thread an optional `brief` into review mode with an open
-mandate, return the structured items plus answered questions, and expose one
-`CAP_DELEGATE`-gated MCP tool that targets review mode. It reuses the roundtable
-engine, the V1 run path, the review contract, and the existing config and
-capability model wholesale; the net new surface is a single prompt-builder seam, a
-result array, and one tool. Validate it against a real change with a concrete
-invariant and a concrete hypothesis to steer at (the Wolf shutdown-race /
-gst-wayland-display work is a good first target: there is an invariant to protect
-and a race to ask about).
+mandate (as the empty-when-NULL middle `%s`, plumbed through both round callers),
+retain the structured items as engine state (all severities returned,
+blocking-only convergence), answer structured `questions`, and expose one
+`CAP_DELEGATE`-gated MCP tool that targets review mode **through the async run
+bridge** so it does not block the MCP request or lose cancellation. It reuses the
+roundtable engine, the V1 async run lifecycle, the review contract, and the
+existing config and capability model wholesale; the net new surface is a
+prompt-builder seam, a result array, the async submit bridge, and one tool.
+Validate it against a real change with a concrete invariant and a concrete
+hypothesis to steer at (the Wolf shutdown-race / gst-wayland-display work is a good
+first target: there is an invariant to protect and a race to ask about).

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -864,3 +864,94 @@ phase plan.
    catches accidental tests that validate only the synchronous handler path while
    the MCP tool's poll path still drops or wraps the structured fields
    incorrectly.
+
+## §16 Fifth-pass findings (run lifecycle, parse-retention, free-path, parity)
+
+A further independent pass re-verified the async run store, the review parse, and
+the result free-path against `testing@d3eb402d` and surfaced five net-new gaps the
+earlier passes did not cover. They concentrate on the *lifecycle* of the run the
+agent polls and on the seams where structured retention can silently return wrong
+or leaked data.
+
+1. **The op-run store can silently evict a non-terminal or unpolled review run —
+   this is a hole in §3's polling contract (P1c).** The async run store the bridge
+   reuses is a single global fixed table: `OPENAI_RUNS_STORE_MAX 256`,
+   `static run_record_t g_entries[256]` (`openai_runs_store.c:15,32`). When the
+   table is full, `openai_runs_store_create` (`:94-135`) evicts the **oldest
+   (smallest `seq`) in-use slot unconditionally — it does not skip runs that are
+   still `queued`/`in_progress`** (`:111-120`, "Full: reuse the oldest in-use
+   slot"). That store is shared by *every* async surface — `POST /v1/runs`, every
+   `rh_dispatch_op_async` op-run, and the parallel run path in `openai_chat.c` — so
+   a review run carrying up to a 10-minute `roundtable_deadline_ms` can be evicted
+   by 256 later runs from any source before the agent polls it. After eviction the
+   failure is silent and three-fold: `GET /v1/runs/{id}` returns not-found,
+   `roundtable_run_cancel_requested -> openai_runs_store_cancel_requested`
+   (`server_compute.c:1609-1610`) returns 0 so `/v1/runs/{id}/stop` becomes a
+   no-op, and the worker's terminal `openai_runs_store_finalize` no-ops on the
+   missing id (`op_run_worker:377`) — the structured result is discarded with no
+   error surfaced to the caller. §3 must state this eviction window and pick a
+   mitigation: skip non-terminal entries when choosing an eviction victim (fall
+   back to oldest *terminal*), and/or document a "poll promptly" requirement, and/or
+   raise the bound for delegate op-runs. Add a test that fills the store past 256
+   while a non-terminal run is outstanding and asserts the contract (survives, or
+   the loss is documented and surfaced rather than silent).
+
+2. **The all-severity retention parse must reuse `parse_review_issue_keys`'s
+   array-key fallback and read the *repaired* JSON, not the raw response (P1b).**
+   Two concrete seams make a naive second parse wrong. (a) `parse_review_issue_keys`
+   resolves the items array from any of three keys in order — `issues`, then
+   `items`, then `blocking_issues` (`delegate_ensemble.c:615-620`) — so a retention
+   walk that hard-codes `"items"` returns an empty array for any reviewer that
+   emitted `issues`/`blocking_issues`, even though that reviewer's findings *did*
+   count toward saturation. (b) On malformed JSON the engine **replaces**
+   `results[i].response` with the `repair_review_json` output before the successful
+   re-parse (`:983-984`); a retention walk that captured from the original response
+   would capture malformed text for exactly the participants that needed repair.
+   The retention must therefore share the *exact* array-resolution of
+   `parse_review_issue_keys` (cleanest: capture inside it, or a sibling sharing the
+   JSON walk) and run against the post-repair text. Add a test with one reviewer
+   that uses the `issues` key and one whose first emission is malformed-then-repaired,
+   asserting both contribute returned items.
+
+3. **`delegate_roundtable_result_free` today frees only `artifact` — every heaped
+   addition is a guaranteed leak until it is added here (P1b).** The current body is
+   exactly `free(r->artifact); r->artifact = NULL;` (`delegate_ensemble.c`,
+   `delegate_ensemble.h:64`). §14.B.4 flags `answeredQuestions`/`coverageGaps`;
+   make the obligation concrete and complete: the items array (if it moves off the
+   fixed stack per §12 Q3), `answeredQuestions`, `coverageGaps`, and any heaped
+   per-item strings (`recommendation`/`location`/`summary`/`sources`) must all be
+   freed here. Note the handler calls this free only on the success path
+   (`server_compute.c:1812`); P1a/P1b must also call it on any **new** early-return
+   error path they introduce after `delegate_roundtable_run` populates `result`
+   (today every post-run path falls through to the single free, but adding
+   brief-truncation or serialization-size error returns can leak). Add a
+   leak/double-free test that runs review mode with a populated brief + questions
+   all the way through the free.
+
+4. **Empty-brief byte-parity requires the brief's *label/header* to live inside the
+   conditional `%s`, not just the brief body (P1a).** §4.3 promises a NULL brief is
+   byte-identical, but parity holds only if the *entire* brief block — any
+   `AUTHOR BRIEF:`-style header, the load-bearing open-mandate sentence (§2), and
+   the brief body — expands from one middle `%s` that is `""` when there is no
+   brief. If the format string carries a fixed header literal *around* the `%s`,
+   then a present-but-empty normalized brief (e.g. `{}` or `{focus:[],questions:[]}`
+   from an empty-object argument) emits the bare header and breaks both the golden
+   parity test (§10) and the byte-identical guarantee. State the rule explicitly:
+   normalization must collapse an empty / whitespace-only brief back to the
+   NULL/empty-`%s` path, and the golden parity test must cover `brief == NULL`,
+   `brief == "{}"`, and an empty-object argument — not only the NULL case.
+
+5. **Minor — surface the per-participant `overall` summary, not only the items.**
+   The reviewer JSON contract includes a top-level `"overall":"..."` field
+   (`build_round_prompt:402`) that the engine discards along with everything but the
+   identity keys. Like `recommendation` (§15.4), it is cheap signal an agent can act
+   on without re-reading the consolidated prose `artifact`; consider folding a
+   bounded panel/`overall` summary into the structured result. Optional; folds into
+   the §15.4/§15.5 "carry more than severity/location/summary" decision and the
+   §14.B.5 response-size budget.
+
+All citations in §13/§14/§15 were re-confirmed byte-accurate against
+`testing@d3eb402d` in this pass (including the run-store eviction at
+`openai_runs_store.c:111-120`, the three-key array fallback at
+`delegate_ensemble.c:615-620`, the repair-then-replace at `:983-984`, and the
+`free(r->artifact)`-only result free).

--- a/docs/proposals/pending/agent-directed-pr-review.md
+++ b/docs/proposals/pending/agent-directed-pr-review.md
@@ -1,0 +1,355 @@
+# Proposal: Agent-directed PR review (call in the ensemble with a brief)
+
+- **State:** draft, pending review
+- **Author:** JBailes
+- **Date:** 2026-06-09
+- **Charter roles:** Review (per-round critique and consolidation), Reason
+  (saturation/convergence judging). No new role.
+- **Scope:** `src/server/delegate_ensemble.c` (thread a caller-supplied `brief`
+  into the review-mode prompt builder `build_round_prompt:304`, and return the
+  parsed structured review items, not only the consolidated prose, from
+  `delegate_roundtable_run`), `src/headers/delegate_ensemble.h` (one new
+  `const char *brief` field on `roundtable_opts_t`, and an items array on
+  `roundtable_result_t`), `src/server/server_compute.c`
+  (`handle_delegate_roundtable:1742` reads `brief` from the request body and
+  surfaces the structured items in the run result), a new agent-callable MCP
+  tool registered in `src/mcp_tools.c` (beside `delegate:577` /
+  `delegate_status:602`) and dispatched in `src/server/server_mcp.c` (beside the
+  `strcmp(tool, "delegate"):1396` arm), gated on the existing `CAP_DELEGATE`
+  (`server.h:59`). Optional: a `--brief` flag on `aimee delegate roundtable` and
+  a thin caller-side `git diff` helper. No new engine, no new role, no new
+  capability flag, no new provider.
+
+## Goal
+
+Let an **agent**, mid-task, call in the review-mode roundtable against a code
+change and **direct it**: hand the panel a short brief saying what to look at
+(the gaps it is unsure about, the fixes it just applied, the invariants it must
+not break, the specific questions it wants answered), and get back **structured,
+actionable feedback** it can act on, not a wall of prose.
+
+The difference from the review mode that already exists is one word:
+**direction**. Today an agent that finishes a non-trivial change throws away the
+context no fresh reviewer has. A directed panel starts from the author's own risk
+map and either confirms or refutes it, while still catching what the author could
+not see.
+
+## Relationship to the roundtable proposal
+
+This builds directly on
+[`agent-roundtable-collaborative-drafting.md`](agent-roundtable-collaborative-drafting.md),
+specifically its **Mode B (review)**. That proposal generalizes the
+Mixture-of-Agents ensemble into a multi-round roundtable and defines the
+review-mode feedback contract (severity `blocking|suggestion|nit`, engine-computed
+identity keys, saturation-based convergence). That work is **in flight on the
+`feat/agent-roundtable` branch** (commit `0fae05d` plus working-tree changes to
+`delegate_ensemble.c`); the symbols this proposal cites land with it, not on
+`testing` yet. This proposal is **strictly additive** on top of a working review
+mode and adds nothing the roundtable needs to function; it can be staged or
+dropped without reopening that work. Read the two together: the roundtable is the
+engine, this is the agent-facing, directed application of it.
+
+## §0 What already exists (so we do not rebuild it)
+
+The review machinery is built (on the roundtable branch). Confirmed in the tree:
+
+- **The review-mode loop.** `delegate_roundtable_run`
+  (`src/headers/delegate_ensemble.h`, impl in `delegate_ensemble.c`) runs the
+  review mode end to end: per-round reviewer fan-out, each reviewer routed to a
+  distinct configured participant (`agent_run_named`), cost/min-success/degrade,
+  consolidation, and saturation-based stop. `roundtable_opts_t.mode ==
+  ROUNDTABLE_REVIEW` selects it.
+- **The per-round reviewer prompt builder.** `build_round_prompt`
+  (`delegate_ensemble.c:304`) already branches on mode and emits the
+  "review and critique" framing (`:308`) and the structured-output instruction
+  (`:354`). **This is the single seam the brief threads through** (§4); it takes
+  no caller context today.
+- **The structured-feedback contract.** Reviewers return JSON items; the engine
+  parses them in `parse_review_issue_keys` (`delegate_ensemble.c:524`), computes a
+  model-independent identity key per item via `normalized_identity_key`
+  (`:497`, hashes `category` + `location`, falls back to `summary`), and decides
+  saturation with `review_saturated` (`:593`). **But the parse keeps only the
+  identity keys for the stop predicate and discards the items themselves** (§5).
+- **The reviewer role.** `tasks[i].role = "review"` in review mode
+  (`delegate_ensemble.c:617` and the sequential path `:650`); the `review` charter
+  role is defined at `src/role_templates.c:21` with severity/category/location
+  expectations.
+- **The V1 entry point.** `POST /v1/delegate/roundtable` is wired
+  (`server_http_routes.inc`, dispatch method `delegate.roundtable` in
+  `src/server/server.c`) to `handle_delegate_roundtable`
+  (`src/server/server_compute.c:1742`), which loads config, builds
+  `roundtable_opts_t`, runs the engine async via `/v1/runs/{id}`, and returns
+  `artifact` plus `rounds_run` / `converged` / `degraded` / `truncated` /
+  `cost_capped` / `deadline_hit` / `best_round` / `cost_usd`. It is gated
+  `CAP_DELEGATE`.
+- **The MCP tool pattern.** Agent-callable tools are registered with `build_tool`
+  in `src/mcp_tools.c` (`delegate:577`, `delegate_status:602`) and dispatched in
+  `src/server/server_mcp.c` (`strcmp(tool, "delegate"):1396` ->
+  `handle_mcp_delegate_call:1398`). `CAP_DELEGATE` is `1u << 1` (`server.h:59`).
+- **Config.** `ensemble_*` (`config.h:1201-1206`, parser
+  `config_sections.c:1068`) supplies participants/aggregator/cost; `roundtable_*`
+  (`config.h:1210-1213`, parser `config_sections.c:1104`, CLI-settable scalars
+  `config_fields.c:164-171`) supplies the loop defaults. **No new config keys are
+  required.**
+
+So the net new code is small and additive: **a brief field threaded into one
+prompt builder, the parsed review items returned instead of discarded, and an
+agent-callable MCP tool that targets review mode.**
+
+## §1 The gap: review mode is built, but it is undirected and not agent-callable
+
+Two concrete gaps stand between "review mode exists" and "an agent can call in a
+directed PR review":
+
+1. **It is undirected.** `build_round_prompt` (`:304`) composes the reviewer
+   prompt from `task + artifact + peer_notes` only. The caller cannot say "focus
+   on the shutdown race" or "I just bumped the gst pin, confirm it holds." The
+   panel re-derives the author's concerns slowly and incompletely, which is
+   exactly the context an agent that just wrote the change already has.
+2. **It is not reachable by an in-process agent.** The only surfaces are the
+   human CLI and the V1 HTTP route. There is no MCP tool an agent can call
+   mid-task, and the existing `delegate` MCP tool (`mcp_tools.c:577`) runs a
+   single role-routed delegate, not the ensemble or the roundtable. The Explore
+   of the tree confirms no `ensemble`/`roundtable` MCP tool exists today.
+
+There is also an **output-shape gap** (§5): even when review mode runs, the
+structured items the reviewers produced are parsed only to compute saturation keys
+and then dropped; the caller gets back consolidated prose. An agent wants the
+items (severity, location, summary) so it can act on each one and re-run.
+
+## §2 The brief: direction without tunnel vision
+
+The brief is a short, optional, freeform-plus-light-structure block the caller
+passes in. It carries the four things an author knows that a fresh reviewer does
+not:
+
+```json
+{
+  "focus":      ["concurrency around session shutdown", "socket path handling"],
+  "fixes":      ["bumped gst-wayland-display pin", "added graceful stop on SIGTERM"],
+  "invariants": ["must keep the /etc/wolf/profile-data bind working"],
+  "questions":  ["does lobby teardown race session teardown?"]
+}
+```
+
+It may also be passed as a single freeform string; the tool accepts either and
+normalizes to the block above. Empty brief == today's undirected review, byte for
+byte (§4).
+
+**The brief weights attention; it never gates findings.** Every reviewer prompt
+appends, verbatim, an instruction of the form: "Prioritize the focus areas and
+answer the questions below, but report any blocking issue you find even if it is
+outside them." This is the load-bearing rule. The failure mode of a directed
+review is tunnel vision: the author points the panel at the wrong place and the
+panel misses the real bug. Keeping the mandate open prevents the brief from
+suppressing out-of-scope findings; it only re-orders priority and seeds the
+`questions` the consolidation must answer.
+
+The brief does **not** change the convergence contract. Saturation still keys on
+the engine-computed identity hash (`normalized_identity_key:497`), not on whether
+a finding matched the brief. A `questions` block adds one obligation: the
+consolidated review must answer each question explicitly (answered / not-answered
++ evidence), so the caller always learns whether its hypothesis was confirmed or
+refuted.
+
+## §3 Agent-callable surface: a new MCP tool
+
+Add one MCP tool, the minimum that makes review mode reachable from inside an
+agent turn. Working name `ensemble_review` (final name open, §12).
+
+- **Register** in `src/mcp_tools.c` with `build_tool`, immediately after
+  `delegate_status` (`:602`). Schema:
+
+  ```json
+  {
+    "type": "object",
+    "properties": {
+      "diff":       {"type": "string", "description": "Unified diff / code under review, or a path to it"},
+      "brief":      {"type": "string", "description": "Optional: focus areas, fixes made, invariants, questions (freeform or JSON, see proposal)"},
+      "rounds":     {"type": "integer", "description": "Max review rounds; default from roundtable.max_rounds"},
+      "turns":      {"type": "string", "enum": ["parallel", "sequential"]}
+    },
+    "required": ["diff"]
+  }
+  ```
+
+- **Dispatch** in `src/server/server_mcp.c`, a new arm beside
+  `strcmp(tool, "delegate"):1396`. The handler builds a `roundtable_opts_t` with
+  `mode = ROUNDTABLE_REVIEW`, sets `brief` (§4), folds `rounds`/`turns` over the
+  configured defaults, and calls the **same** server-side roundtable path
+  `handle_delegate_roundtable` (`server_compute.c:1742`) uses. It must not fork a
+  second engine entry; it reuses the one async run path so cancellation
+  (`/v1/runs/{id}/stop`), cost cap, and degrade behavior are identical.
+- **Gate** on the existing `CAP_DELEGATE` (`server.h:59`). No new capability:
+  this is delegate-class, LLM-heavy, cost-bearing work, and `CAP_DELEGATE`
+  already fences exactly that. The MCP tool inherits the session's caps the same
+  way the `delegate` tool does.
+
+Because the V1 route already exists, the human-facing path (`aimee delegate
+roundtable --mode review`) and the new agent-facing MCP path converge on one
+implementation. The only new server code is request parsing for `brief` and the
+tool dispatch arm.
+
+## §4 Threading the brief through the engine
+
+One seam: `build_round_prompt` (`delegate_ensemble.c:304`).
+
+1. Add `const char *brief;` to `roundtable_opts_t`
+   (`delegate_ensemble.h`). Default `NULL`.
+2. Pass it through `delegate_roundtable_run` into `build_round_prompt`
+   (both the parallel call site `:614` and the sequential `:646`).
+3. In `build_round_prompt`, when `mode == ROUNDTABLE_REVIEW` and `brief != NULL`,
+   emit the brief block plus the open-mandate instruction (§2) after the
+   "review and critique" framing (`:308`) and before the structured-output
+   instruction (`:354`). When `brief == NULL` the emitted prompt is unchanged,
+   so existing review behavior and its tests are byte-identical.
+4. The brief is included in the **per-round** prompt so that in sequential and
+   multi-round runs every reviewer (and every later round reacting to peers) keeps
+   the same direction. It is **not** included in the consolidation/aggregator
+   prompt except for the `questions`, which the consolidator must answer (§2).
+
+Budgeting: the brief counts against the same per-round byte budget the roundtable
+already enforces (`build_round_prompt` truncation / summarize-forward path). A
+brief that is itself enormous is summarized forward like any other oversized
+context, with the existing `truncated` flag set, never silently dropped.
+
+## §5 Structured, actionable output back to the caller
+
+An agent needs the items, not the essay. Today `parse_review_issue_keys`
+(`delegate_ensemble.c:524`) extracts identity keys for saturation and discards the
+rest. Extend it (or add a sibling that shares the JSON parse) to retain the full
+item: `severity`, `category`, `location`, `summary`, plus the engine-computed
+identity key.
+
+- Add a bounded items array to `roundtable_result_t` (`delegate_ensemble.h`),
+  populated from the **final, consolidated** round (the surviving, deduplicated
+  blocking/suggestion/nit set), each item carrying its severity, location,
+  one-line summary, and identity key.
+- `handle_delegate_roundtable` (`server_compute.c:1742`) serializes that array
+  into the run result JSON alongside the existing `artifact` and flags. The MCP
+  tool returns the same shape.
+- Add `answeredQuestions: [{question, answer, evidence}]` populated by the
+  consolidation when the brief carried `questions` (§2), and `coverageGaps`
+  (e.g. "no participant addressed the teardown path") when a question went
+  unanswered.
+
+This makes the result a thing an agent can loop over: apply each suggested fix,
+then re-invoke with `brief.fixes` describing what it just changed, until the panel
+saturates. The caller drives that loop; this feature returns findings, it does not
+auto-apply them (the roundtable's `apply_review` remains a separate, opt-in final
+draft turn).
+
+## §6 PR / diff input
+
+Aimee has **no diff-ingestion machinery** and does not need it for v1: the tree
+shells out to `git diff` in places (`src/cmd_slop.c`, `src/mcp_git_write.c`) but
+has no PR-fetch or patch-parsing layer. The `diff` argument is plain task text:
+the caller (the agent, which already has the working tree and `git`) pastes the
+unified diff in. This matches how the roundtable proposal frames its review input
+("paste the document under review").
+
+Optional, deferred: a thin caller-side helper that runs `git diff <range>` and
+fills `diff` so a human can say `aimee delegate roundtable --mode review --brief
+"..." --range origin/main...HEAD`. No server-side git, no GitHub API in v1.
+GitHub PR fetch and inline-comment posting are explicit non-goals for v1 (§11);
+posting anything outward is opt-in and out of scope here.
+
+## §7 Convergence, cost, and safety are inherited, not rebuilt
+
+Everything that bounds the roundtable bounds this unchanged: the running
+`ensemble_max_cost_usd` cap, `roundtable_max_rounds` (default 3),
+`roundtable_deadline_ms` (default 600000), `min_successful` degrade-to-best, the
+per-round byte budget, and `/v1/runs/{id}/stop` cancellation. The brief and the
+agent entry point add no new unbounded loop and no new spend path: the MCP tool is
+just another caller of the same async run. The saturation predicate is unchanged
+and remains model-independent (engine-computed identity keys), so a directed
+review still terminates deterministically.
+
+## §8 Config
+
+No new keys. The brief is per-call (request body / tool argument), not
+configuration. Participants, aggregator, cost cap come from `ensemble_*`; loop
+bounds from `roundtable_*`. If a deployment wants directed review on by default
+there is nothing to toggle: an empty brief is identical to plain review mode.
+
+## §9 Phasing
+
+1. **P1a, brief plumbing.** Add `brief` to `roundtable_opts_t`, thread through
+   `build_round_prompt` (§4), parse `brief` in `handle_delegate_roundtable`. The
+   open-mandate instruction and the empty-brief == unchanged-prompt invariant
+   land here with tests.
+2. **P1b, structured return.** Retain and return the parsed review items and
+   `answeredQuestions`/`coverageGaps` (§5). This is independently useful for the
+   human CLI review mode too.
+3. **P1c, agent-callable MCP tool.** Register `ensemble_review` and its dispatch
+   arm (§3), `CAP_DELEGATE`-gated, reusing the same run path. This is what
+   delivers the headline "an agent can call in the ensemble."
+4. **P2, optional ergonomics.** `--brief` CLI flag and the `git diff` range
+   helper (§6).
+
+P1a/P1b are mergeable without P1c (they improve the existing review mode); P1c is
+the new agent surface. None of them touch the roundtable's core or its P0 fixes.
+
+## §10 Testing
+
+- **Empty-brief parity:** `build_round_prompt` with `brief == NULL` emits a
+  byte-identical prompt to today (golden string test); existing review-mode tests
+  stay green.
+- **Open mandate:** a unit test asserts the brief block is followed by the
+  "report blocking issues even if outside focus" instruction, so direction cannot
+  be implemented as a filter.
+- **Questions answered:** a test with a `questions` brief asserts the result
+  carries an `answeredQuestions` entry per question (answered or not), so a
+  caller hypothesis is always resolved.
+- **Structured return:** a review run returns a non-empty items array with
+  severity/location/summary/identity-key for each surviving finding, and the
+  identity keys match `normalized_identity_key` (no reliance on model
+  `stable_key`).
+- **MCP reachability:** an end-to-end test that the `ensemble_review` tool call
+  reaches `ROUNDTABLE_REVIEW` (not the single-delegate `handle_mcp_delegate_call`
+  path) and requires `CAP_DELEGATE`; a negative test that a session without
+  `CAP_DELEGATE` is denied.
+- **No second engine:** a negative check that the MCP arm calls the shared
+  roundtable run path and does not introduce a parallel inline engine entry.
+
+## §11 Non-goals
+
+- No GitHub integration (PR fetch, status checks, inline comments) in v1; diff is
+  caller-provided text. Posting outward is opt-in and out of scope.
+- No new role, capability flag, provider, config key, or RPC transport.
+- No auto-apply of findings; the caller decides what to act on. (The roundtable's
+  own `apply_review` final-draft turn stays separate and opt-in.)
+- Not a replacement for the human CLI review mode; it is the agent-facing,
+  directed sibling of the same engine.
+
+## §12 Open questions
+
+1. **Tool name.** `ensemble_review` vs `pr_review` vs `review` vs
+   `roundtable_review`. `delegate` is taken and means something narrower; the name
+   should signal "multi-agent review," not "single delegate."
+2. **Brief shape over MCP.** Accept only a freeform string and parse it, or
+   accept the structured `{focus, fixes, invariants, questions}` object directly?
+   (Leaning: accept both; normalize to the object; questions need structure to
+   guarantee per-question answers.)
+3. **Items array bound.** What is the cap on returned items, and how do we report
+   when a verbose review overflows it (summarize-forward vs drop-with-flag, reuse
+   the existing `truncated` semantics)?
+4. **Auto-brief.** When an agent does not supply a brief, should the tool
+   optionally synthesize one from the diff itself (changed files, churned hunks)
+   so even an unbriefed call is lightly directed? (Leaning: no in v1; an empty
+   brief must stay identical to plain review mode for parity.)
+5. **Aggregator and the questions.** Should answering `questions` be the
+   consolidator's job (one extra instruction) or a separate `reason`-role pass?
+   (Leaning: consolidator, to avoid an extra LLM call per run.)
+
+## Recommendation
+
+Ship P1a + P1b + P1c: thread an optional `brief` into review mode with an open
+mandate, return the structured items plus answered questions, and expose one
+`CAP_DELEGATE`-gated MCP tool that targets review mode. It reuses the roundtable
+engine, the V1 run path, the review contract, and the existing config and
+capability model wholesale; the net new surface is a single prompt-builder seam, a
+result array, and one tool. Validate it against a real change with a concrete
+invariant and a concrete hypothesis to steer at (the Wolf shutdown-race /
+gst-wayland-display work is a good first target: there is an invariant to protect
+and a race to ask about).


### PR DESCRIPTION
## What

A pending design proposal: let an **agent**, mid-task, call the roundtable's review mode against a code change and **direct it** with a brief (focus areas, fixes made, invariants to protect, specific questions), then receive **structured, actionable findings** it can loop on.

Proposal file: `docs/proposals/pending/agent-directed-pr-review.md` (+ index entry in `docs/PROPOSALS.md`).

## Why

The roundtable review mode is now on `testing`, but it is still **undirected** (`build_round_prompt` only sees task/artifact/peer notes), **not agent-callable through MCP**, and its parsed review items are discarded after saturation-key extraction. An agent that just made a change has risk context that should guide the panel without narrowing the mandate.

## Shape

- **Brief:** optional string/object normalized into caller direction, threaded through `roundtable_opts_t` into `build_round_prompt` with an open mandate. Empty brief should preserve today's prompt byte-for-byte.
- **Structured return:** retain parsed review items with engine-computed identity keys, return all severities, keep saturation blocking-only, and answer structured `questions` from the brief.
- **Agent-callable MCP surface:** add a `CAP_DELEGATE`-gated review tool (working name `ensemble_review`) that launches review mode through the async op-run path used by `POST /v1/delegate/roundtable`, returning a run id rather than blocking `/v1/mcp/call`.

## Status / Dependencies

Retargeted at `rakuen/testing@d3eb402d` after the roundtable work landed via PR #136/#142. The implementation is staged as P1a (brief plumbing), P1b (structured return), P1c (MCP tool + async bridge), plus optional CLI ergonomics.

Verification: `make -C src lint` passes on this PR checkout. `git diff --check origin/testing...HEAD` is clean.

## Review Findings To Fold Into The Proposal

1. **PR body was stale relative to the proposal.** The previous body still said this built on `feat/agent-roundtable` / `0fae05d` plus working-tree changes and said `make lint` passed. The document itself now targets `testing@d3eb402d`, and the actual repo target is `make -C src lint`. This body has been updated to match.

2. **The async bridge is currently private to the HTTP route layer.** The proposal correctly says `ensemble_review` must not call `handle_delegate_roundtable` inline from `handle_mcp_call`, because `/v1/mcp/call` is synchronous and would lose `__run_id` cancellation. But the reusable pieces are `static` in `src/server/server_http_routes.inc` (`op_run_snapshot`, `op_run_worker`, `rh_dispatch_op_async`, and the `op_run_job_t` path). P1c should explicitly include extracting/exporting a small shared op-run submit helper, or another concrete bridge that preserves: captured connection caps, `__run_id` injection, `openai_runs_store_create/finalize`, cancellation via `/v1/runs/{id}/stop`, and immediate queued-run return.

3. **CAP_DELEGATE needs explicit MCP-tool enforcement.** The first-class route `delegate.roundtable` is covered by `server_auth.c`, but `/v1/mcp/call` itself is gated as `mcp.call` (`CAP_TOOL_EXECUTE`). If the new MCP arm shortcuts directly inside `handle_mcp_call`, it must not rely on the outer `mcp.call` gate. The safest design is to submit `delegate.roundtable` through the shared async dispatch helper with the caller's captured caps, so the existing `CAP_DELEGATE` method check fires. If any direct handler path remains, add an explicit CAP_DELEGATE check and a negative test.

4. **The brief/questions data model needs one more concrete seam.** `roundtable_opts_t` is proposed as a single `const char *brief`, but §5 also needs the structured `questions` array later for `answeredQuestions`. If only a rendered prompt block reaches the engine, the answer pass has to re-parse prose. P1a/P1b should specify either a small normalized brief struct (rendered block + bounded `questions[]`) or a normalized JSON string plus helper accessors, with clear ownership/lifetime and the same 4 KB cap/truncation behavior.

5. **Structured item retention must happen before participant results are freed and cover degraded exits.** Today `delegate_roundtable_run` parses participant JSON into stack key arrays, then frees `results[i].response` before/around synthesis. P1b should call out where final-round items are captured and what happens when the run exits before consolidation: cost cap after fan-out, malformed JSON repair failure, `successful < min_ok`, cancellation, or deadline. A partial/degraded result should set `truncated` or another explicit partial flag rather than returning an apparently complete items list.

6. **Branch ancestry may confuse local reviewers.** The PR diff is docs-only and mergeable, but the PR head is not rebased onto `testing`; checking out the head branch directly lacks the roundtable symbols the proposal cites. That is not a merge blocker, but rebasing onto `testing` would make local review and symbol validation less error-prone.

## Open Questions Still Worth Resolving

- Tool name: `ensemble_review`, `roundtable_review`, or another name that makes multi-agent review clear.
- Polling shape: reuse `/v1/runs/{id}` only, or add an MCP-native status sibling.
- Returned item cap: keep 64 with overflow signaling, or move to heap allocation and raise the bound.
- Question-answer pass: fold structured side-output into consolidation, or add a separate `reason` JSON pass.


## Second-pass verification (folded into §13)

A re-validation pass re-checked every cited symbol/line against `testing@d3eb402d` (all cited files are byte-identical to that commit — citations hold) and added a new **§13** with six concrete implementation gaps the sections above did not cover:

1. **`build_round_prompt` malloc (P1a).** The buffer slack `+1200` (`delegate_ensemble.c:411`) is template-only; the brief `%s` must add `strlen(brief)` to `needed` or the trailing structured-output instruction is truncated and reviewer JSON fails to parse.
2. **Tools-list golden (P1c).** Registering `ensemble_review` breaks the auto-generated `test_mcp_tools_golden.inc` (`MCP_TOOLS_GOLDEN_COUNT 86`); regenerate via `DUMP_TOOLS=1`. Named as a required test step.
3. **Run-id counter (P1c).** The extracted async-submit helper inherits `g_op_run_seq`, a non-atomic "single-writer" counter (`server_http_routes.inc:400`); preserve the invariant or make it atomic to avoid colliding run ids from concurrent submits.
4. **`diff`→`prompt` rename (P1c).** The bridge must copy `args.diff` into the `prompt` body field the `delegate.roundtable` handler validates (`server_compute.c:1745`), else it rejects with "missing prompt."
5. **Returned-item dedup (P1b).** `normalized_identity_key` keys on category+location only; reusing it for the returned array silently drops distinct findings sharing a location. Dedup the returned array on `summary` too, kept separate from the blocking-saturation key.
6. **Pre-existing CAP_DELEGATE bypass.** The verification pinpoints that the existing `delegate` MCP tool reaches `handle_delegate` without consulting its `CAP_DELEGATE` entry — track a defense-in-depth side-fix, not just avoidance. (Plus a heap-lifetime note for §12 Q3.)


## Third-pass review findings (additional gaps to fold in)

A third pass re-read the proposal against `testing@d3eb402d` and found a few more implementation details worth making explicit before this leaves design review:

1. **The MCP bridge must force review mode.** `handle_delegate_roundtable` defaults to `ROUNDTABLE_DRAFT` and only switches when the submitted body contains `mode: "review"` (`server_compute.c:1762-1783`). The `ensemble_review` schema has no `mode` argument, so the bridge must synthesize `mode: "review"` in the re-dispatched `delegate.roundtable` body. Otherwise the tool will launch the draft loop against a diff and never parse/return review items. Keep `apply` absent/false for this MCP path unless a separate auto-apply feature is deliberately added.

2. **The queued run shape is `id`, not `run_id`.** `rh_dispatch_op_async` returns `op_run_snapshot`, shaped as `{id, object:"op.run", method, status, created, result?}` (`server_http_routes.inc:320-333`), while §3 says `ensemble_review` returns `{run_id, status:"running"}`. Either the MCP arm must translate `id` to a structured `run_id` field for tool callers, or the contract should use the existing `id` field consistently. Add an assertion that the returned identifier is exactly the one accepted by `GET /v1/runs/{id}`.

3. **Polling and cancellation require capabilities beyond `CAP_DELEGATE`.** The new tool is correctly designed around `delegate.roundtable -> CAP_DELEGATE`, but the follow-up lifecycle routes are separately gated today: `GET /v1/runs/{id}` and `/events` require `CAP_SESSION_READ`, and `POST /v1/runs/{id}/stop` requires `CAP_CHAT` (`server_http_routes.inc:972-976`). A principal with `CAP_TOOL_EXECUTE|CAP_DELEGATE` but not those caps can start the review but cannot read or stop it. Resolve this by documenting the additional required caps, changing the run routes for op-runs, or adding MCP-native status/cancel siblings that enforce the intended delegate capability.

4. **Brief truncation needs a concrete result-flag path.** The proposal says a >4 KB brief is truncated and sets `roundtable_result_t.truncated`, but if normalization/truncation happens in `handle_delegate_roundtable` before calling the engine, the engine has no way to know the brief was truncated unless that fact is threaded in (`opts.brief_truncated`, a normalized-brief struct, or a post-run response patch). Without this, brief truncation can be silent while `result.truncated` remains reserved for summarize-forward overflow. Add a direct handler/HTTP test, not only a prompt-builder unit test.

5. **Keep run-store status semantics aligned with the MCP wording.** `op_run_worker` sets the store to `in_progress`, then finalizes the snapshot status as `completed|failed|cancelled` based on the re-dispatched JSON (`server_http_routes.inc:341-378`). The initial snapshot status is `queued`, not `running`. If the MCP tool promises `status:"running"`, it should either translate `queued` intentionally or promise the existing queued/in_progress/completed vocabulary so callers do not special-case a status value the store never emits.

6. **Tests should pin the synthesized delegate body, not just end behavior.** Several of the above are single-field bridge mistakes (`diff` -> `prompt`, adding `mode:"review"`, preserving `brief`, copying caller caps, omitting `apply`). Add a narrow unit seam around the MCP-to-`delegate.roundtable` request construction so these fields are asserted before the async worker runs; the end-to-end async test can then focus on run lifecycle and cancellation.



## Independent verification pass (folded into the document as §14)

The "Third-pass review findings" above were sitting in this PR description but had
not been folded into the proposal file. They are now in the document as **§14.A**,
and an independent pass that re-verified every cited symbol against
`testing@d3eb402d` added **§14.B** with six net-new findings the earlier passes
missed:

1. **The async helper writes to a route `resp` buffer, not to `conn`.**
   `rh_dispatch_op_async` is `(route_req_t*, char *resp, int cap)`
   (`server_http_routes.inc:386`) — no `server_conn_t`. Unlike the existing
   `delegate` tool, which calls `handle_delegate` and lets it `server_send_ok` onto
   the connection (`server_mcp_delegate.c:65`), the extracted helper must *return*
   the run id and the `server_mcp.c` arm must `server_send_ok` it onto `conn`
   itself. The MCP arm owns the connection write.
2. **`g_rpc_conn_caps` is actually populated on the synchronous `mcp.call` path**
   (`server_http.c:1655`), since `/v1/mcp/call` dispatches on the same listener
   thread. §3's "thread-local not guaranteed to hold the caller's caps" is over-stated:
   explicit cap-threading is correct **defense-in-depth** (and right under any
   future nested re-dispatch), not a fix for a live bug. Sharpened in §14.B.2.
3. **`turns:"parallel"` is inert against a sequential config default** — the
   handler only forces `SEQUENTIAL` on `"sequential"`, never `PARALLEL`
   (`server_compute.c:1780-1782`). The schema over-promises the enum.
4. **`answeredQuestions`/`coverageGaps` need a free path even in the default
   fixed-stack items variant** — they are variable-length text and must be heaped
   regardless of the §12 Q3 decision; `delegate_roundtable_result_free` must free
   them in P1b, not only in the heap variant.
5. **The enlarged result must fit `SHTTP_RESP_MAX` (256 KB)** or it silently
   degrades to an opaque JSON string (`op_run_worker:362` parse fail →
   `op_run_snapshot:330-331` string fallback). Artifact + 64 items +
   `answeredQuestions` is normally well under, but bound it and assert headroom.
6. **The brief `type:["string","object"]` union may trip strict MCP clients**
   (open question; folds into §12 Q1).

All §13 second-pass citations were re-confirmed byte-accurate against
`testing@d3eb402d` in this pass.



## Fifth-pass findings (folded into the document as §16)

A further independent pass re-verified the async run store, the review parse, and
the result free-path against `testing@d3eb402d` and added **§16** with five net-new
gaps the earlier passes did not cover (run *lifecycle* and the retention/free
seams, where structured data can be silently wrong or leaked):

1. **The op-run store can silently evict a non-terminal/unpolled review run.**
   `OPENAI_RUNS_STORE_MAX 256` single global table; `openai_runs_store_create`
   evicts the oldest in-use slot **unconditionally, without skipping
   non-terminal runs** (`openai_runs_store.c:111-120`). The store is shared by
   every async surface (`POST /v1/runs`, all `rh_dispatch_op_async` op-runs, the
   `openai_chat.c` run path), so a review run with a 10-minute deadline can be
   evicted by 256 later runs before the agent polls it — then `GET /v1/runs/{id}`
   404s, `/stop` becomes a no-op, and the worker's `finalize` no-ops, losing the
   result with no error. §3's polling contract must state this window and mitigate
   (skip non-terminal eviction victims / poll-promptly / raise the bound).
2. **The all-severity retention parse must reuse `parse_review_issue_keys`'s
   three-key array fallback (`issues`/`items`/`blocking_issues`, `:615-620`) and
   read the *repaired* JSON** (`results[i].response` is replaced at `:983-984`),
   else it returns empty/malformed items for reviewers that used a different key or
   needed repair.
3. **`delegate_roundtable_result_free` frees only `artifact` today** — every heaped
   addition (`items`/`answeredQuestions`/`coverageGaps`/`recommendation`/`sources`)
   leaks until added, and any new early-return error path must call the free.
4. **Empty-brief byte-parity requires the brief header + open-mandate sentence to
   live inside the conditional `%s`**, and normalization must collapse an empty /
   `{}` brief back to the NULL path; the golden parity test must cover `NULL`,
   `"{}"`, and an empty-object argument, not only `NULL`.
5. **Minor:** the per-participant `overall` field (`build_round_prompt:402`) is
   discarded with the items; surface it like `recommendation` (§15.4).

All §13/§14/§15 citations were re-confirmed byte-accurate against
`testing@d3eb402d` in this pass.


## Sixth-pass findings (folded into the document as §17)

A sixth pass re-checked the MCP dispatch table, op-run events, and roundtable result semantics against `testing@d3eb402d` and added **§17** with three net-new gaps:

1. **`/v1/runs/{id}/events` is authorized for op-runs but currently emits no op-run payloads.** `op_run_worker` only sets/finalizes status; it never appends events, so `/events` subscribers get no structured completion unless P1c adds events or documents op-runs as poll-only via `GET /v1/runs/{id}`.
2. **Returned items can describe a different round than the returned `artifact`.** The engine returns `best_artifact` when present, not always the final round artifact, so P1b should either capture items from the same round as `best_artifact` or expose `items_round`/`artifact_round`/`best_round` plus a partial/alignment flag.
3. **The new result fields need a casing contract.** Existing V1 roundtable fields are snake_case (`rounds_run`, `cost_capped`, `deadline_hit`, `cost_usd`), while the proposal names new arrays `answeredQuestions`/`coverageGaps`. Choose snake_case for V1 with optional MCP translation, or explicitly support aliases/tests.


## Eighth-pass findings (folded into the document as §19)

An eighth pass re-checked the MCP async bridge against the actual HTTP route gate and `server_dispatch` payload limiter on `testing@d3eb402d`, then folded two net-new P1c gaps into **§19**:

1. **Authorization must be preflighted before enqueue.** Relying only on the worker's re-dispatched `delegate.roundtable -> CAP_DELEGATE` gate is too late for MCP: a `CAP_TOOL_EXECUTE`-only caller would still get a queued run id and consume a run-store slot/thread before the worker fails. The MCP arm/helper should synchronously check `server_capability_for_method("delegate.roundtable")` against the captured caller caps before `openai_runs_store_create` or `pthread_create`; keep the worker gate as defense in depth. Test that the initial `mcp.call` is denied and no run record is created.
2. **MCP diff payloads inherit the 256 KB `mcp.call` limit, not the direct route's 4 MB `delegate.*` limit.** Direct `delegate.roundtable` dispatch gets `LIMIT_DELEGATE`, but `ensemble_review` arrives as method `mcp.call`, which currently falls through to `LIMIT_DEFAULT` before the bridge can move `arguments.diff` to `prompt`. Pick an explicit MCP diff limit/fix and test payloads just over 256 KB and near the accepted upper bound.