### PR TITLE
Use driver capabilities for Anthropic system prompt routing

### DIFF
--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -96,17 +96,19 @@ static int driver_is_anthropic(const delegate_driver_t *driver)
    return driver && driver->name && strcmp(driver->name, "anthropic") == 0;
 }
 
-static int driver_consumes_system_prompt(const delegate_driver_t *driver)
+static int driver_consumes_system_prompt(const delegate_driver_t *driver, const agent_t *ag)
 {
-   return driver && driver->name &&
-          (strcmp(driver->name, "chatgpt") == 0 || strcmp(driver->name, "gemini") == 0);
+   driver_caps_t caps;
+
+   delegate_get_caps(driver, ag, &caps);
+   return (caps.capability_flags & DRIVER_CAP_SYSTEM_MSG) != 0;
 }
 
 /* Translate an Anthropic request into the selected provider's message/tool
  * shape. Anthropic itself receives the original Messages wire shape; the
  * OpenAI-family providers receive the inverse delegate-driver conversion.
  * *out_system is a malloc'd flattened system prompt (caller frees). */
-static void translate_request(const cJSON *req, const delegate_driver_t *driver,
+static void translate_request(const cJSON *req, const delegate_driver_t *driver, const agent_t *ag,
                               cJSON **out_messages, cJSON **out_tools, char **out_system)
 {
    *out_system = anthropic_system_to_text(req);
@@ -120,7 +122,7 @@ static void translate_request(const cJSON *req, const delegate_driver_t *driver,
    }
    *out_messages =
        anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"),
-                                    driver_consumes_system_prompt(driver) ? NULL : *out_system);
+                                    driver_consumes_system_prompt(driver, ag) ? NULL : *out_system);
    *out_tools = anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 
@@ -203,7 +205,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
 
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
-   translate_request(req, driver, &messages, &tools, &system_text);
+   translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
    {
@@ -420,7 +422,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
 
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
-   translate_request(req, driver, &messages, &tools, &system_text);
+   translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
       goto cleanup;

--- a/src/server/delegate_openai.c
+++ b/src/server/delegate_openai.c
@@ -157,7 +157,8 @@ static cJSON *chatgpt_build_tools(void)
 static void chatgpt_get_caps(const agent_t *agent, driver_caps_t *caps)
 {
    (void)agent;
-   caps->capability_flags = DRIVER_CAP_TOOL_CALLS | DRIVER_CAP_STREAMING | DRIVER_CAP_VISION;
+   caps->capability_flags =
+       DRIVER_CAP_TOOL_CALLS | DRIVER_CAP_STREAMING | DRIVER_CAP_VISION | DRIVER_CAP_SYSTEM_MSG;
    caps->context_limit = DRIVER_CTX_HUGE;
    caps->max_output_tokens = 0;
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -57,6 +57,18 @@ const delegate_driver_t *delegate_driver_get(const char *provider)
    return g_driver;
 }
 
+void delegate_get_caps(const delegate_driver_t *driver, const agent_t *agent, driver_caps_t *caps)
+{
+   memset(caps, 0, sizeof(*caps));
+   if (driver && driver->get_caps)
+   {
+      driver->get_caps(agent, caps);
+      return;
+   }
+   caps->capability_flags = DRIVER_CAP_TOOL_CALLS | DRIVER_CAP_STREAMING;
+   caps->context_limit = DRIVER_CTX_LARGE;
+}
+
 int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, char *url,
                        size_t url_len)
 {
@@ -217,6 +229,13 @@ static cJSON *system_prompt_driver_build(const agent_t *agent, cJSON *messages, 
    return out;
 }
 
+static void system_prompt_driver_caps(const agent_t *agent, driver_caps_t *caps)
+{
+   (void)agent;
+   caps->capability_flags = DRIVER_CAP_STREAMING | DRIVER_CAP_SYSTEM_MSG;
+   caps->context_limit = DRIVER_CTX_HUGE;
+}
+
 static void parsed_text(cJSON *root, const char *body, parsed_response_t *out)
 {
    (void)root;
@@ -252,7 +271,7 @@ static void test_translate_request_anthropic_passthrough(void)
    char *orig_tools_s;
    char *out_tools_s;
 
-   translate_request(req, &anthropic, &messages, &tools, &system_text);
+   translate_request(req, &anthropic, NULL, &messages, &tools, &system_text);
 
    assert(system_text && strcmp(system_text, "SYS") == 0);
    assert(messages && messages != orig_messages);
@@ -471,7 +490,8 @@ static void test_messages_buffered_system_prompt_driver_no_duplicate_system(void
 {
    const delegate_driver_t chatgpt = {.name = "chatgpt",
                                       .build_request = system_prompt_driver_build,
-                                      .parse_response = parsed_text};
+                                      .parse_response = parsed_text,
+                                      .get_caps = system_prompt_driver_caps};
    cJSON *sent;
    const cJSON *input;
    char resp[4096];
@@ -490,6 +510,32 @@ static void test_messages_buffered_system_prompt_driver_no_duplicate_system(void
    cJSON_Delete(sent);
    reset_capture();
    PASS("messages_buffered_system_prompt_driver_no_duplicate_system");
+}
+
+static void test_messages_buffered_system_prompt_capability_no_duplicate_system(void)
+{
+   const delegate_driver_t capable = {.name = "future-responses",
+                                      .build_request = system_prompt_driver_build,
+                                      .parse_response = parsed_text,
+                                      .get_caps = system_prompt_driver_caps};
+   cJSON *sent;
+   const cJSON *input;
+   char resp[4096];
+
+   reset_capture();
+   g_driver = &capable;
+   assert(messages_buffered("{\"model\":\"ignored\",\"system\":\"SYS\","
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+   sent = parse(g_last_body);
+   assert(strcmp(obj(sent, "instructions")->valuestring, "SYS") == 0);
+   input = obj(sent, "input");
+   assert(cJSON_IsArray(input));
+   assert(cJSON_GetArraySize((cJSON *)input) == 1);
+   assert(strcmp(obj(cJSON_GetArrayItem((cJSON *)input, 0), "role")->valuestring, "user") == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_system_prompt_capability_no_duplicate_system");
 }
 
 static void test_messages_stream_openai_family_translates(void)
@@ -532,6 +578,7 @@ int main(void)
    test_messages_stream_anthropic_preserves_request_shape();
    test_messages_buffered_openai_family_translates();
    test_messages_buffered_system_prompt_driver_no_duplicate_system();
+   test_messages_buffered_system_prompt_capability_no_duplicate_system();
    test_messages_stream_openai_family_translates();
    printf("anthropic_http: OK\n");
    return 0;


### PR DESCRIPTION
## Summary
- replace Anthropic ingress system-prompt name allowlist with `DRIVER_CAP_SYSTEM_MSG` capability checks
- mark the chatgpt/Responses driver as consuming the separate system prompt parameter
- add Anthropic ingress tests for a non-chatgpt capable driver to prevent name-coupled regressions

## Verification
- `make -C src build/obj/tests/unit-test-anthropic-http build/obj/tests/unit-test-server-http && src/build/obj/tests/unit-test-anthropic-http && src/build/obj/tests/unit-test-server-http`
- `make -C src verify-local`

Closes #141