### PR TITLE
Implement agent-directed PR review ensemble

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -651,7 +651,7 @@ Offload work to a sub-agent (via the server compute pool).
 - `delegate plan <proposal.md> [--json] [--output PATH] [--launch] [--parallel N]`, generate work packets from a proposal.
 - `delegate launch <plan.json> [--json] [--parallel N]` (`delegate.launch`), queue reviewed packets.
 - `delegate aggregate "<task>"` (`delegate.aggregate`), run one Mixture-of-Agents fan-out and synthesis over `ensemble.reference_models`.
-- `delegate roundtable "<task>" [--mode draft|review] [--turns parallel|sequential] [--rounds N] [--apply]` (`delegate.roundtable`), run a bounded multi-round collaborative draft or review. The async run result includes `artifact`, `rounds_run`, `converged`, `degraded`, `truncated`, `cost_capped`, `deadline_hit`, `cancelled`, `best_round`, and `cost_usd`.
+- `delegate roundtable "<task>" [--mode draft|review] [--turns parallel|sequential] [--rounds N] [--brief TEXT] [--brief-json JSON] [--apply]` (`delegate.roundtable`), run a bounded multi-round collaborative draft or review. Directed review briefs may include focus/fixes/invariants/questions. The async run result includes `artifact`, `rounds_run`, `converged`, `degraded`, `truncated`, `cost_capped`, `deadline_hit`, `cancelled`, `best_round`, `items_round`, `artifact_round`, `cost_usd`, `items`, `answered_questions`, and `coverage_gaps`.
 - `delegate status <job_id> [job_id...] [--full|--result-limit N]` (`delegate.status`).
 - `delegate log` / `delegate history` (`delegate.log`) · `delegate --list-roles` (`agent.list`).
 
@@ -956,7 +956,7 @@ aimee delegate code --tools "Add tests for the auth module"
 aimee delegate summarize --files notes.md "Summarize to 5 bullets"
 aimee delegate execute --tools --background "Migrate config to YAML"
 aimee delegate roundtable "Draft a migration proposal" --rounds 3
-aimee delegate roundtable "Review this design" --mode review --turns sequential
+aimee delegate roundtable "Review this design" --mode review --turns sequential --brief "Check authorization and cancellation paths"
 ```
 
 **Roles:** `code`, `review`, `explain`, `refactor`, `draft`, `execute`,

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1689,7 +1689,21 @@ paths:
                 turns: { type: string, enum: [parallel, sequential] }
                 rounds: { type: integer }
                 apply: { type: boolean }
-      responses: { "200": { description: Queued op run, content: { application/json: { schema: { type: object } } } } }
+                brief:
+                  oneOf:
+                    - { type: string }
+                    - type: object
+                      properties:
+                        focus: { type: array, items: { type: string } }
+                        fixes: { type: array, items: { type: string } }
+                        invariants: { type: array, items: { type: string } }
+                        questions: { type: array, items: { type: string } }
+      responses:
+        "200":
+          description: Queued op run; poll GET /runs/{id}. Final result includes artifact, items, answered_questions, and coverage_gaps.
+          content:
+            application/json:
+              schema: { type: object }
   /memory/search:
     post:
       summary: Keyword-search memories

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -98,7 +98,7 @@ adapters behind provider-CLI-compatible config.
 - `aimee delegate plan <proposal.md> [--output PATH] [--launch]`: generate reviewed work packets.
 - `aimee delegate launch <plan.json> [--parallel N]`: queue a packet plan into a coordinated job.
 - `aimee delegate aggregate "<task>"`: run one Mixture-of-Agents fan-out and synthesis over `ensemble.reference_models`.
-- `aimee delegate roundtable "<task>" [--mode draft|review] [--turns parallel|sequential] [--rounds N] [--apply]`: run a bounded multi-round collaborative draft or review.
+- `aimee delegate roundtable "<task>" [--mode draft|review] [--turns parallel|sequential] [--rounds N] [--brief TEXT] [--brief-json JSON] [--apply]`: run a bounded multi-round collaborative draft or review.
 - `aimee delegate status <job_id> [job_id...]`: inspect background delegate status.
 - `aimee delegate log` / `aimee delegate history`: show delegation episodes.
 - `aimee delegate --list-roles`: list configured delegate roles.

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -1708,11 +1708,13 @@ static cJSON *marshal_delegate_roundtable(int argc, char **argv)
    if (brief_json)
    {
       cJSON *parsed = cJSON_Parse(brief_json);
-      if (parsed)
+      if (!parsed)
       {
-         cJSON_DeleteItemFromObjectCaseSensitive(req, "brief");
-         cJSON_AddItemToObject(req, "brief", parsed);
+         fprintf(stderr, "aimee: delegate roundtable: --brief-json must be valid JSON\n");
+         exit(1);
       }
+      cJSON_DeleteItemFromObjectCaseSensitive(req, "brief");
+      cJSON_AddItemToObject(req, "brief", parsed);
    }
    if (rpc_has_flag(&opts, "apply"))
       cJSON_AddBoolToObject(req, "apply", 1);

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -245,7 +245,7 @@ static const struct
      * ensemble; without it the prompt fell through to the catch-all delegate
      * route, which maps positional[0] -> role and never ran the engine. */
     {"delegate", "aggregate", "delegate.aggregate", NULL, NULL, 600000},
-    {"delegate", "roundtable", "delegate.roundtable", NULL, NULL, 600000},
+    {"delegate", "roundtable", "delegate.roundtable", NULL, NULL, 900000},
     /* Codex/openai delegate agents have agent->timeout_ms == 900000 server-side.
      * The CLI must outlast that, otherwise we report "no response" while the
      * server is still genuinely working. */
@@ -1701,6 +1701,19 @@ static cJSON *marshal_delegate_roundtable(int argc, char **argv)
    const char *rounds = rpc_get(&opts, "rounds");
    if (rounds)
       cJSON_AddNumberToObject(req, "rounds", atoi(rounds));
+   const char *brief = rpc_get(&opts, "brief");
+   if (brief)
+      cJSON_AddStringToObject(req, "brief", brief);
+   const char *brief_json = rpc_get(&opts, "brief-json");
+   if (brief_json)
+   {
+      cJSON *parsed = cJSON_Parse(brief_json);
+      if (parsed)
+      {
+         cJSON_DeleteItemFromObjectCaseSensitive(req, "brief");
+         cJSON_AddItemToObject(req, "brief", parsed);
+      }
+   }
    if (rpc_has_flag(&opts, "apply"))
       cJSON_AddBoolToObject(req, "apply", 1);
    return req;

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -5,7 +5,9 @@
 #include "agent_config.h"
 #include "config.h"
 
-#define ENSEMBLE_MAX_REFS 8
+#define ENSEMBLE_MAX_REFS           8
+#define ROUNDTABLE_MAX_REVIEW_ITEMS 128
+#define ROUNDTABLE_MAX_QUESTIONS    16
 
 typedef struct
 {
@@ -41,9 +43,33 @@ typedef struct
    int converge_threshold;
    int deadline_ms;
    int apply_review;
+   const char *brief;
+   int brief_truncated;
+   const char **questions;
+   int question_count;
    int (*cancel_requested)(void *ctx);
    void *cancel_ctx;
 } roundtable_opts_t;
+
+typedef struct
+{
+   char severity[16];
+   char category[32];
+   char location[128];
+   char summary[256];
+   char recommendation[256];
+   char identity_key[128];
+   char sources[256];
+   int count;
+} roundtable_review_item_t;
+
+typedef struct
+{
+   char question[512];
+   char answer[1024];
+   char evidence[512];
+   int answered;
+} roundtable_answered_question_t;
 
 typedef struct
 {
@@ -57,6 +83,14 @@ typedef struct
    int cancelled;
    int best_round;
    double cost_usd;
+   roundtable_review_item_t items[ROUNDTABLE_MAX_REVIEW_ITEMS];
+   int item_count;
+   int items_round;
+   int artifact_round;
+   roundtable_answered_question_t answered_questions[ROUNDTABLE_MAX_QUESTIONS];
+   int answered_question_count;
+   char coverage_gaps[ROUNDTABLE_MAX_QUESTIONS][512];
+   int coverage_gap_count;
 } roundtable_result_t;
 
 int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const char *task,

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -119,6 +119,14 @@ extern "C"
    int server_http_route(const char *method, const char *path, const char *body, int body_len,
                          char *resp, int resp_cap);
 
+   /* Submit an existing dispatch method through the HTTP async op-run machinery
+    * without going through a /v1 route. `body_json` is the method body before
+    * method/__run_id injection. `conn_caps` are the caller capabilities to use
+    * when the worker re-dispatches the method. The helper preflights the target
+    * method capability before creating a run. */
+   int server_http_submit_op_run(const char *op_method, const char *body_json, uint32_t conn_caps,
+                                 char *resp, int resp_cap);
+
    /* --- OpenAI-compatible completion seam ---
     * The /v1/chat/completions and /v1/completions routes run real inference,
     * which pulls the agent/provider dependency closure. To keep that out of

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -613,7 +613,9 @@ cJSON *mcp_build_tools_list(void)
           tools,
           build_tool("ensemble_review",
                      "Run the multi-agent roundtable in review mode against caller-provided diff "
-                     "text. Returns a queued run id; poll /v1/runs/{id}.",
+                     "text. Returns a queued run id; poll /v1/runs/{id}. The result's items "
+                     "describe items_round while artifact is artifact_round (the best round); "
+                     "compare those fields before assuming the findings match the artifact.",
                      cJSON_Parse(
                          "{\"type\":\"object\",\"properties\":{"
                          "\"diff\":{\"type\":\"string\",\"description\":\"Unified diff or code "

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -611,21 +611,28 @@ cJSON *mcp_build_tools_list(void)
    {
       cJSON_AddItemToArray(
           tools,
-          build_tool("ensemble_review",
-                     "Run the multi-agent roundtable in review mode against caller-provided diff "
-                     "text. Returns a queued run id; poll /v1/runs/{id}. The result's items "
-                     "describe items_round while artifact is artifact_round (the best round); "
-                     "compare those fields before assuming the findings match the artifact.",
-                     cJSON_Parse(
-                         "{\"type\":\"object\",\"properties\":{"
-                         "\"diff\":{\"type\":\"string\",\"description\":\"Unified diff or code "
-                         "under review, minimum 20 characters.\"},"
-                         "\"brief\":{\"type\":\"object\",\"description\":\"Optional directed "
-                         "review brief with focus/fixes/invariants/questions string arrays.\"},"
-                         "\"rounds\":{\"type\":\"integer\",\"description\":\"Max review rounds.\"},"
-                         "\"turns\":{\"type\":\"string\",\"enum\":[\"parallel\",\"sequential\"],"
-                         "\"description\":\"Round execution mode.\"}},"
-                         "\"required\":[\"diff\"]}")));
+          build_tool(
+              "ensemble_review",
+              "Run the multi-agent roundtable in review mode against caller-provided diff "
+              "text. Returns a queued run id; poll /v1/runs/{id}. The result's items "
+              "describe items_round while artifact is artifact_round (the best round); "
+              "compare those fields before assuming the findings match the artifact.",
+              cJSON_Parse("{\"type\":\"object\",\"properties\":{"
+                          "\"diff\":{\"type\":\"string\",\"description\":\"Unified diff or code "
+                          "under review.\",\"minLength\":20},"
+                          "\"brief\":{\"description\":\"Optional directed review brief as a string "
+                          "or object with focus/fixes/invariants/questions string arrays.\","
+                          "\"anyOf\":[{\"type\":\"string\"},{\"type\":\"object\","
+                          "\"properties\":{\"focus\":{\"type\":\"array\",\"items\":{\"type\":"
+                          "\"string\"}},\"fixes\":{\"type\":\"array\",\"items\":{\"type\":"
+                          "\"string\"}},\"invariants\":{\"type\":\"array\",\"items\":{\"type\":"
+                          "\"string\"}},\"questions\":{\"type\":\"array\",\"items\":{\"type\":"
+                          "\"string\"}}}}]},"
+                          "\"rounds\":{\"type\":\"integer\",\"minimum\":1,\"maximum\":16,"
+                          "\"description\":\"Max review rounds.\"},"
+                          "\"turns\":{\"type\":\"string\",\"enum\":[\"parallel\",\"sequential\"],"
+                          "\"description\":\"Round execution mode.\"}},"
+                          "\"required\":[\"diff\"]}")));
    }
 
    /* preview_blast_radius */

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -607,6 +607,25 @@ cJSON *mcp_build_tools_list(void)
                                         "background=true.\"}},\"required\":[\"job_id\"]}")));
    }
 
+   /* ensemble_review */
+   {
+      cJSON_AddItemToArray(
+          tools,
+          build_tool("ensemble_review",
+                     "Run the multi-agent roundtable in review mode against caller-provided diff "
+                     "text. Returns a queued run id; poll /v1/runs/{id}.",
+                     cJSON_Parse(
+                         "{\"type\":\"object\",\"properties\":{"
+                         "\"diff\":{\"type\":\"string\",\"description\":\"Unified diff or code "
+                         "under review, minimum 20 characters.\"},"
+                         "\"brief\":{\"type\":\"object\",\"description\":\"Optional directed "
+                         "review brief with focus/fixes/invariants/questions string arrays.\"},"
+                         "\"rounds\":{\"type\":\"integer\",\"description\":\"Max review rounds.\"},"
+                         "\"turns\":{\"type\":\"string\",\"enum\":[\"parallel\",\"sequential\"],"
+                         "\"description\":\"Round execution mode.\"}},"
+                         "\"required\":[\"diff\"]}")));
+   }
+
    /* preview_blast_radius */
    {
       cJSON *s = cJSON_CreateObject();

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -801,58 +801,52 @@ static void mark_question_gaps(const roundtable_opts_t *opts, roundtable_result_
 static void parse_question_answers(const char *text, const roundtable_opts_t *opts,
                                    roundtable_result_t *out)
 {
-   cJSON *root = cJSON_Parse(text);
+   /* Seed one entry per asked question (answered=0), then fill answers in by
+    * matching the model's entries back to the asked questions by text. This
+    * guarantees exactly one result entry per asked question regardless of how
+    * many answers the model returns or in what order, so a partial or reordered
+    * answer set never silently drops a question (§5). */
+   mark_question_gaps(opts, out);
+   int n = out->answered_question_count;
+   cJSON *root = text ? cJSON_Parse(text) : NULL;
    if (!root)
-   {
-      mark_question_gaps(opts, out);
-      return;
-   }
+      return; /* keep the gap-seeded result */
    cJSON *answers = cJSON_GetObjectItemCaseSensitive(root, "answered_questions");
    if (!cJSON_IsArray(answers))
       answers = cJSON_GetObjectItemCaseSensitive(root, "answeredQuestions");
-   int qi = 0;
    cJSON *it;
    cJSON_ArrayForEach(it, answers)
    {
-      if (qi >= ROUNDTABLE_MAX_QUESTIONS)
-         break;
       cJSON *q = cJSON_GetObjectItemCaseSensitive(it, "question");
       cJSON *a = cJSON_GetObjectItemCaseSensitive(it, "answer");
       cJSON *e = cJSON_GetObjectItemCaseSensitive(it, "evidence");
       cJSON *answered = cJSON_GetObjectItemCaseSensitive(it, "answered");
-      snprintf(out->answered_questions[qi].question, sizeof(out->answered_questions[qi].question),
-               "%s", cJSON_IsString(q) ? q->valuestring : "");
-      snprintf(out->answered_questions[qi].answer, sizeof(out->answered_questions[qi].answer), "%s",
-               cJSON_IsString(a) ? a->valuestring : "");
-      snprintf(out->answered_questions[qi].evidence, sizeof(out->answered_questions[qi].evidence),
+      const char *qtext = cJSON_IsString(q) ? q->valuestring : "";
+      int idx = -1;
+      for (int i = 0; i < n; i++)
+         if (strcmp(out->answered_questions[i].question, qtext) == 0)
+         {
+            idx = i;
+            break;
+         }
+      if (idx < 0)
+         continue; /* model answered something that was not asked; ignore it */
+      snprintf(out->answered_questions[idx].answer, sizeof(out->answered_questions[idx].answer),
+               "%s", cJSON_IsString(a) ? a->valuestring : "");
+      snprintf(out->answered_questions[idx].evidence, sizeof(out->answered_questions[idx].evidence),
                "%s", cJSON_IsString(e) ? e->valuestring : "");
-      out->answered_questions[qi].answered = cJSON_IsBool(answered)
-                                                 ? cJSON_IsTrue(answered)
-                                                 : (cJSON_IsString(a) && a->valuestring[0]);
-      qi++;
+      out->answered_questions[idx].answered = cJSON_IsBool(answered)
+                                                  ? cJSON_IsTrue(answered)
+                                                  : (cJSON_IsString(a) && a->valuestring[0]);
    }
-   out->answered_question_count = qi;
-   cJSON *gaps = cJSON_GetObjectItemCaseSensitive(root, "coverage_gaps");
-   if (!cJSON_IsArray(gaps))
-      gaps = cJSON_GetObjectItemCaseSensitive(root, "coverageGaps");
-   int gi = 0;
-   cJSON_ArrayForEach(it, gaps)
-   {
-      if (gi >= ROUNDTABLE_MAX_QUESTIONS)
-         break;
-      if (cJSON_IsString(it))
-         snprintf(out->coverage_gaps[gi++], sizeof(out->coverage_gaps[0]), "%s", it->valuestring);
-      else
-      {
-         cJSON *q = cJSON_GetObjectItemCaseSensitive(it, "question");
-         if (cJSON_IsString(q))
-            snprintf(out->coverage_gaps[gi++], sizeof(out->coverage_gaps[0]), "%s", q->valuestring);
-      }
-   }
-   out->coverage_gap_count = gi;
    cJSON_Delete(root);
-   if (out->answered_question_count == 0 && opts && opts->question_count > 0)
-      mark_question_gaps(opts, out);
+   /* Coverage gaps are exactly the asked questions still unanswered. */
+   int gi = 0;
+   for (int i = 0; i < n; i++)
+      if (!out->answered_questions[i].answered)
+         snprintf(out->coverage_gaps[gi++], sizeof(out->coverage_gaps[0]), "%s",
+                  out->answered_questions[i].question);
+   out->coverage_gap_count = gi;
 }
 
 static void answer_roundtable_questions(agent_config_t *acfg, const char *task,

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -391,7 +391,7 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,
-                                roundtable_mode_t mode, int round)
+                                roundtable_mode_t mode, int round, const char *brief)
 {
    const char *role_hint = mode == ROUNDTABLE_REVIEW ? "review and critique" : "draft and revise";
    const char *mode_task =
@@ -407,18 +407,35 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
       artifact = "";
    if (!peer_notes)
       peer_notes = "";
+   const char *brief_block = "";
+   char *owned_brief_block = NULL;
+   if (mode == ROUNDTABLE_REVIEW && brief && brief[0])
+   {
+      owned_brief_block = xasprintf3(
+          "CALLER BRIEF:\n", brief,
+          "\nPrioritize this brief and answer its questions, but report any blocking issue you "
+          "find even if it is outside the brief.\n\n");
+      if (!owned_brief_block)
+         return NULL;
+      brief_block = owned_brief_block;
+   }
 
-   size_t needed = strlen(task ? task : "") + strlen(artifact) + strlen(peer_notes) + 1200;
+   size_t needed = strlen(task ? task : "") + strlen(artifact) + strlen(peer_notes) +
+                   strlen(brief_block) + 1200;
    char *prompt = malloc(needed);
    if (!prompt)
+   {
+      free(owned_brief_block);
       return NULL;
+   }
    snprintf(prompt, needed,
             "You are one participant in an agent roundtable. Your role is to %s.\n\n"
-            "TASK:\n%s\n\nCURRENT SHARED ARTIFACT:\n%s\n\nPEER NOTES FROM PREVIOUS TURN:\n%s\n\n"
+            "TASK:\n%s\n\nCURRENT SHARED ARTIFACT:\n%s\n\nPEER NOTES FROM PREVIOUS TURN:\n%s\n\n%s"
             "ROUND %d INSTRUCTION:\n%s\n",
             role_hint, task ? task : "", artifact[0] ? artifact : "(none yet)",
-            peer_notes[0] ? peer_notes : "(none yet)", round, mode_task);
+            peer_notes[0] ? peer_notes : "(none yet)", brief_block, round, mode_task);
 
+   free(owned_brief_block);
    return prompt;
 }
 
@@ -645,6 +662,252 @@ static int parse_review_issue_keys(const char *text, char keys[][128], int *coun
    return 0;
 }
 
+static int review_items_same(const roundtable_review_item_t *a, const char *identity,
+                             const char *summary)
+{
+   return a && identity && summary && strcmp(a->identity_key, identity) == 0 &&
+          strcmp(a->summary, summary) == 0;
+}
+
+static void review_item_add_source(roundtable_review_item_t *item, const char *source)
+{
+   if (!item)
+      return;
+   item->count++;
+   if (!source || !source[0])
+      return;
+   if (strstr(item->sources, source))
+      return;
+   size_t used = strlen(item->sources);
+   if (used > 0 && used + 2 < sizeof(item->sources))
+   {
+      item->sources[used++] = ',';
+      item->sources[used++] = ' ';
+      item->sources[used] = '\0';
+   }
+   if (used + 1 < sizeof(item->sources))
+      snprintf(item->sources + used, sizeof(item->sources) - used, "%s", source);
+}
+
+static cJSON *review_items_array(cJSON *root)
+{
+   cJSON *issues = cJSON_GetObjectItemCaseSensitive(root, "issues");
+   if (!cJSON_IsArray(issues))
+      issues = cJSON_GetObjectItemCaseSensitive(root, "items");
+   if (!cJSON_IsArray(issues))
+      issues = cJSON_GetObjectItemCaseSensitive(root, "blocking_issues");
+   return cJSON_IsArray(issues) ? issues : NULL;
+}
+
+static void capture_review_items_from_text(const char *text, const char *source,
+                                           roundtable_result_t *out)
+{
+   if (!text || !out)
+      return;
+   cJSON *root = cJSON_Parse(text);
+   if (!root)
+      return;
+   cJSON *issues = review_items_array(root);
+   if (!issues)
+   {
+      cJSON_Delete(root);
+      return;
+   }
+   cJSON *it;
+   cJSON_ArrayForEach(it, issues)
+   {
+      cJSON *severity = cJSON_GetObjectItemCaseSensitive(it, "severity");
+      cJSON *category = cJSON_GetObjectItemCaseSensitive(it, "category");
+      cJSON *location = cJSON_GetObjectItemCaseSensitive(it, "location");
+      cJSON *summary = cJSON_GetObjectItemCaseSensitive(it, "summary");
+      cJSON *recommendation = cJSON_GetObjectItemCaseSensitive(it, "recommendation");
+      const char *sev =
+          cJSON_IsString(severity) && severity->valuestring[0] ? severity->valuestring : "blocking";
+      const char *cat = cJSON_IsString(category) ? category->valuestring : "";
+      const char *loc = cJSON_IsString(location) ? location->valuestring : "";
+      const char *sum = cJSON_IsString(summary) ? summary->valuestring : "";
+      const char *rec = cJSON_IsString(recommendation) ? recommendation->valuestring : "";
+      char identity[128];
+      normalized_identity_key(cat, loc, sum, identity, sizeof(identity));
+      if (!identity[0] || !sum[0])
+         continue;
+      int idx = -1;
+      for (int i = 0; i < out->item_count; i++)
+      {
+         if (review_items_same(&out->items[i], identity, sum))
+         {
+            idx = i;
+            break;
+         }
+      }
+      if (idx < 0)
+      {
+         if (out->item_count >= ROUNDTABLE_MAX_REVIEW_ITEMS)
+         {
+            out->truncated = 1;
+            continue;
+         }
+         idx = out->item_count++;
+         memset(&out->items[idx], 0, sizeof(out->items[idx]));
+         snprintf(out->items[idx].severity, sizeof(out->items[idx].severity), "%s", sev);
+         snprintf(out->items[idx].category, sizeof(out->items[idx].category), "%s", cat);
+         snprintf(out->items[idx].location, sizeof(out->items[idx].location), "%s", loc);
+         snprintf(out->items[idx].summary, sizeof(out->items[idx].summary), "%s", sum);
+         snprintf(out->items[idx].recommendation, sizeof(out->items[idx].recommendation), "%s",
+                  rec);
+         snprintf(out->items[idx].identity_key, sizeof(out->items[idx].identity_key), "%s",
+                  identity);
+      }
+      review_item_add_source(&out->items[idx], source);
+   }
+   cJSON_Delete(root);
+}
+
+static void capture_round_review_items(const agent_result_t *results, int ref_count,
+                                       roundtable_result_t *out, int round)
+{
+   if (!results || !out)
+      return;
+   out->item_count = 0;
+   out->items_round = round;
+   memset(out->items, 0, sizeof(out->items));
+   for (int i = 0; i < ref_count; i++)
+      capture_review_items_from_text(results[i].response, results[i].agent_name, out);
+}
+
+static void mark_question_gaps(const roundtable_opts_t *opts, roundtable_result_t *out)
+{
+   if (!opts || !out)
+      return;
+   int n = opts->question_count;
+   if (n > ROUNDTABLE_MAX_QUESTIONS)
+      n = ROUNDTABLE_MAX_QUESTIONS;
+   for (int i = 0; i < n; i++)
+   {
+      const char *q = opts->questions && opts->questions[i] ? opts->questions[i] : "";
+      snprintf(out->answered_questions[i].question, sizeof(out->answered_questions[i].question),
+               "%s", q);
+      snprintf(out->answered_questions[i].answer, sizeof(out->answered_questions[i].answer), "%s",
+               "");
+      snprintf(out->answered_questions[i].evidence, sizeof(out->answered_questions[i].evidence),
+               "%s", "");
+      out->answered_questions[i].answered = 0;
+      snprintf(out->coverage_gaps[i], sizeof(out->coverage_gaps[i]), "%s", q);
+   }
+   out->answered_question_count = n;
+   out->coverage_gap_count = n;
+}
+
+static void parse_question_answers(const char *text, const roundtable_opts_t *opts,
+                                   roundtable_result_t *out)
+{
+   cJSON *root = cJSON_Parse(text);
+   if (!root)
+   {
+      mark_question_gaps(opts, out);
+      return;
+   }
+   cJSON *answers = cJSON_GetObjectItemCaseSensitive(root, "answered_questions");
+   if (!cJSON_IsArray(answers))
+      answers = cJSON_GetObjectItemCaseSensitive(root, "answeredQuestions");
+   int qi = 0;
+   cJSON *it;
+   cJSON_ArrayForEach(it, answers)
+   {
+      if (qi >= ROUNDTABLE_MAX_QUESTIONS)
+         break;
+      cJSON *q = cJSON_GetObjectItemCaseSensitive(it, "question");
+      cJSON *a = cJSON_GetObjectItemCaseSensitive(it, "answer");
+      cJSON *e = cJSON_GetObjectItemCaseSensitive(it, "evidence");
+      cJSON *answered = cJSON_GetObjectItemCaseSensitive(it, "answered");
+      snprintf(out->answered_questions[qi].question, sizeof(out->answered_questions[qi].question),
+               "%s", cJSON_IsString(q) ? q->valuestring : "");
+      snprintf(out->answered_questions[qi].answer, sizeof(out->answered_questions[qi].answer), "%s",
+               cJSON_IsString(a) ? a->valuestring : "");
+      snprintf(out->answered_questions[qi].evidence, sizeof(out->answered_questions[qi].evidence),
+               "%s", cJSON_IsString(e) ? e->valuestring : "");
+      out->answered_questions[qi].answered = cJSON_IsBool(answered)
+                                                 ? cJSON_IsTrue(answered)
+                                                 : (cJSON_IsString(a) && a->valuestring[0]);
+      qi++;
+   }
+   out->answered_question_count = qi;
+   cJSON *gaps = cJSON_GetObjectItemCaseSensitive(root, "coverage_gaps");
+   if (!cJSON_IsArray(gaps))
+      gaps = cJSON_GetObjectItemCaseSensitive(root, "coverageGaps");
+   int gi = 0;
+   cJSON_ArrayForEach(it, gaps)
+   {
+      if (gi >= ROUNDTABLE_MAX_QUESTIONS)
+         break;
+      if (cJSON_IsString(it))
+         snprintf(out->coverage_gaps[gi++], sizeof(out->coverage_gaps[0]), "%s", it->valuestring);
+      else
+      {
+         cJSON *q = cJSON_GetObjectItemCaseSensitive(it, "question");
+         if (cJSON_IsString(q))
+            snprintf(out->coverage_gaps[gi++], sizeof(out->coverage_gaps[0]), "%s", q->valuestring);
+      }
+   }
+   out->coverage_gap_count = gi;
+   cJSON_Delete(root);
+   if (out->answered_question_count == 0 && opts && opts->question_count > 0)
+      mark_question_gaps(opts, out);
+}
+
+static void answer_roundtable_questions(agent_config_t *acfg, const char *task,
+                                        const roundtable_opts_t *opts, roundtable_result_t *out)
+{
+   if (!acfg || !opts || !out || !out->artifact || opts->question_count <= 0)
+      return;
+   int qn = opts->question_count;
+   if (qn > ROUNDTABLE_MAX_QUESTIONS)
+      qn = ROUNDTABLE_MAX_QUESTIONS;
+   cJSON *qs = cJSON_CreateArray();
+   if (!qs)
+   {
+      mark_question_gaps(opts, out);
+      return;
+   }
+   for (int i = 0; i < qn; i++)
+      cJSON_AddItemToArray(qs, cJSON_CreateString(opts->questions[i] ? opts->questions[i] : ""));
+   char *qjson = cJSON_PrintUnformatted(qs);
+   cJSON_Delete(qs);
+   if (!qjson)
+   {
+      mark_question_gaps(opts, out);
+      return;
+   }
+   const char *prefix =
+       "Answer the caller's roundtable review questions from the consolidated review. Return only "
+       "JSON shaped {\"answered_questions\":[{\"question\":\"...\",\"answer\":\"...\","
+       "\"evidence\":\"...\",\"answered\":true}],\"coverage_gaps\":[\"...\"]}.\n\nTASK:\n";
+   size_t n =
+       strlen(prefix) + strlen(task ? task : "") + strlen(out->artifact) + strlen(qjson) + 80;
+   char *prompt = (char *)malloc(n);
+   if (!prompt)
+   {
+      free(qjson);
+      mark_question_gaps(opts, out);
+      return;
+   }
+   snprintf(prompt, n, "%s%s\n\nQUESTIONS:\n%s\n\nCONSOLIDATED REVIEW:\n%s\n", prefix,
+            task ? task : "", qjson, out->artifact);
+   free(qjson);
+   agent_result_t res;
+   memset(&res, 0, sizeof(res));
+   if (agent_run_with_tools_write_enforce(acfg, "reason", NULL, prompt, 1024, 0, &res) == 0 &&
+       res.response && res.response[0])
+   {
+      parse_question_answers(res.response, opts, out);
+      out->cost_usd += result_token_cost(acfg, &res, "reason");
+   }
+   else
+      mark_question_gaps(opts, out);
+   free(res.response);
+   free(prompt);
+}
+
 static int repair_review_json(agent_config_t *acfg, const config_t *cfg, int participant,
                               const char *bad_text, char **fixed, double *cost_usd)
 {
@@ -689,7 +952,7 @@ static int review_saturated(char prev[][128], int prev_count, char cur[][128], i
 
 static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const char *task,
                               const char *artifact, const char *peer_notes, roundtable_mode_t mode,
-                              int round, agent_result_t *results)
+                              int round, const char *brief, agent_result_t *results)
 {
    int ref_count = cfg->ensemble_reference_count;
    agent_task_t tasks[ENSEMBLE_MAX_REFS];
@@ -698,7 +961,7 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
    memset(prompts, 0, sizeof(prompts));
    for (int i = 0; i < ref_count; i++)
    {
-      prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round);
+      prompts[i] = build_round_prompt(task, artifact, peer_notes, mode, round, brief);
       if (!prompts[i])
          goto fail;
       tasks[i].role = mode == ROUNDTABLE_REVIEW ? "review" : "draft";
@@ -719,7 +982,7 @@ fail:
 
 static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const char *task,
                                 const char *artifact, char **peer_notes, roundtable_mode_t mode,
-                                int round, agent_result_t *results)
+                                int round, const char *brief, agent_result_t *results)
 {
    int ref_count = cfg->ensemble_reference_count;
    int order[ENSEMBLE_MAX_REFS];
@@ -730,7 +993,7 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
    for (int oi = 0; oi < ref_count; oi++)
    {
       int i = order[oi];
-      char *prompt = build_round_prompt(task, artifact, *peer_notes, mode, round);
+      char *prompt = build_round_prompt(task, artifact, *peer_notes, mode, round, brief);
       if (!prompt)
          return -1;
       memset(&results[i], 0, sizeof(results[i]));
@@ -895,6 +1158,8 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       local.max_rounds = 3;
    if (local.converge_threshold < 0)
       local.converge_threshold = 10;
+   if (local.brief_truncated)
+      out->truncated = 1;
 
    long start_ms = monotonic_ms();
    char *artifact = xstrdup0("");
@@ -941,9 +1206,9 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       memset(results, 0, sizeof(results));
       int rc = local.turns == ROUNDTABLE_SEQUENTIAL
                    ? run_round_sequential(acfg, cfg, task, artifact, &peer_notes, local.mode, round,
-                                          results)
+                                          local.brief, results)
                    : run_round_parallel(acfg, cfg, task, artifact, peer_notes, local.mode, round,
-                                        results);
+                                        local.brief, results);
       if (rc != 0)
       {
          for (int i = 0; i < ref_count; i++)
@@ -1005,6 +1270,7 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
                free(results[i].response);
             break;
          }
+         capture_round_review_items(results, ref_count, out, round);
       }
 
       double round_cost = estimate_cost(acfg, results, cfg->ensemble_reference_models, ref_count);
@@ -1186,6 +1452,9 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
    }
 
    out->artifact = best_artifact ? best_artifact : xstrdup0(artifact);
+   out->artifact_round = out->best_round > 0 ? out->best_round : out->rounds_run;
+   if (out->artifact)
+      answer_roundtable_questions(acfg, task, &local, out);
    free(artifact);
    free(peer_notes);
    return out->artifact ? 0 : -1;

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1454,7 +1454,16 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
    out->artifact = best_artifact ? best_artifact : xstrdup0(artifact);
    out->artifact_round = out->best_round > 0 ? out->best_round : out->rounds_run;
    if (out->artifact)
-      answer_roundtable_questions(acfg, task, &local, out);
+   {
+      /* The question pass is an extra reason-role LLM call. Skip it when the run
+       * was cancelled (respect the stop) or already hit the cost cap (do not
+       * spend past the budget); still report the questions as gaps so the
+       * answered_questions/coverage_gaps contract stays populated. */
+      if (out->cancelled || out->cost_capped)
+         mark_question_gaps(&local, out);
+      else
+         answer_roundtable_questions(acfg, task, &local, out);
+   }
    free(artifact);
    free(peer_notes);
    return out->artifact ? 0 : -1;

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1447,11 +1447,13 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
 
    out->artifact = best_artifact ? best_artifact : xstrdup0(artifact);
    out->artifact_round = out->best_round > 0 ? out->best_round : out->rounds_run;
-   if (out->artifact)
+   if (out->artifact && local.mode == ROUNDTABLE_REVIEW)
    {
-      /* The question pass is an extra reason-role LLM call. Skip it when the run
-       * was cancelled (respect the stop) or already hit the cost cap (do not
-       * spend past the budget); still report the questions as gaps so the
+      /* Questions are a review-mode concept (directed PR review), so a draft run
+       * never triggers the pass even if a brief carried questions. The question
+       * pass is an extra reason-role LLM call: skip it when the run was cancelled
+       * (respect the stop) or already hit the cost cap (do not spend past the
+       * budget), but still report the questions as gaps so the
        * answered_questions/coverage_gaps contract stays populated. */
       if (out->cancelled || out->cost_capped)
          mark_question_gaps(&local, out);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1228,8 +1228,8 @@ static size_t method_size_limit(const char *method)
       const char *prefix;
       size_t max;
    } limits[] = {
-       {"memory.", LIMIT_MEMORY}, {"tool.", LIMIT_TOOL}, {"delegate", LIMIT_DELEGATE},
-       {"chat.", LIMIT_CHAT},     {NULL, LIMIT_DEFAULT},
+       {"memory.", LIMIT_MEMORY},    {"tool.", LIMIT_TOOL}, {"delegate", LIMIT_DELEGATE},
+       {"mcp.call", LIMIT_DELEGATE}, {"chat.", LIMIT_CHAT}, {NULL, LIMIT_DEFAULT},
    };
 
    for (int i = 0; limits[i].prefix; i++)

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -39,8 +39,10 @@
 #include "role_templates.h"
 #include "workspace.h"
 #include "cJSON.h"
+#include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
+#include <stdarg.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
@@ -1610,6 +1612,8 @@ static int roundtable_run_cancel_requested(void *ctx)
    return run_id && run_id[0] && openai_runs_store_cancel_requested(run_id);
 }
 
+#include "server_compute_roundtable.inc"
+
 int handle_tool_execute(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    compute_ctx_t *cctx = create_compute_ctx(ctx, conn, req);
@@ -1773,6 +1777,15 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
       opts.cancel_requested = roundtable_run_cancel_requested;
       opts.cancel_ctx = jrun->valuestring;
    }
+   normalized_roundtable_brief_t brief;
+   char brief_err[128];
+   brief_err[0] = '\0';
+   if (normalize_roundtable_brief(req, &brief, brief_err, sizeof(brief_err)) != 0)
+      return server_send_error(conn, brief_err[0] ? brief_err : "invalid brief", NULL);
+   opts.brief = brief.rendered;
+   opts.brief_truncated = brief.truncated;
+   opts.questions = brief.question_ptrs;
+   opts.question_count = brief.question_count;
 
    cJSON *jmode = cJSON_GetObjectItemCaseSensitive(req, "mode");
    if (cJSON_IsString(jmode) && strcmp(jmode->valuestring, "review") == 0)
@@ -1780,9 +1793,15 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    cJSON *jturns = cJSON_GetObjectItemCaseSensitive(req, "turns");
    if (cJSON_IsString(jturns) && strcmp(jturns->valuestring, "sequential") == 0)
       opts.turns = ROUNDTABLE_SEQUENTIAL;
+   else if (cJSON_IsString(jturns) && strcmp(jturns->valuestring, "parallel") == 0)
+      opts.turns = ROUNDTABLE_PARALLEL;
    cJSON *jrounds = cJSON_GetObjectItemCaseSensitive(req, "rounds");
    if (cJSON_IsNumber(jrounds) && jrounds->valuedouble > 0)
+   {
       opts.max_rounds = (int)jrounds->valuedouble;
+      if (opts.max_rounds > ROUNDTABLE_MAX_ROUNDS_REQUEST)
+         opts.max_rounds = ROUNDTABLE_MAX_ROUNDS_REQUEST;
+   }
    cJSON *japply = cJSON_GetObjectItemCaseSensitive(req, "apply");
    if (cJSON_IsBool(japply))
       opts.apply_review = cJSON_IsTrue(japply) ? 1 : 0;
@@ -1790,13 +1809,19 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    agent_config_t acfg;
    memset(&acfg, 0, sizeof(acfg));
    if (agent_load_config(&acfg) != 0)
+   {
+      free(brief.rendered);
       return server_send_error(conn, "could not load agents.json", NULL);
+   }
 
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, prompt, &opts, &result);
    if (rc != 0)
+   {
+      free(brief.rendered);
       return server_send_error(
           conn, "roundtable run failed (check ensemble.enabled / ensemble.reference_models)", NULL);
+   }
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "artifact", result.artifact ? result.artifact : "");
@@ -1808,8 +1833,12 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    cJSON_AddBoolToObject(resp, "deadline_hit", result.deadline_hit ? 1 : 0);
    cJSON_AddBoolToObject(resp, "cancelled", result.cancelled ? 1 : 0);
    cJSON_AddNumberToObject(resp, "best_round", result.best_round);
+   cJSON_AddNumberToObject(resp, "items_round", result.items_round);
+   cJSON_AddNumberToObject(resp, "artifact_round", result.artifact_round);
    cJSON_AddNumberToObject(resp, "cost_usd", result.cost_usd);
+   add_roundtable_arrays(resp, &result);
    delegate_roundtable_result_free(&result);
+   free(brief.rendered);
    return server_send_ok(conn, resp);
 }
 

--- a/src/server/server_compute_roundtable.inc
+++ b/src/server/server_compute_roundtable.inc
@@ -1,0 +1,156 @@
+#define ROUNDTABLE_BRIEF_MAX_BYTES    4096
+#define ROUNDTABLE_MAX_ROUNDS_REQUEST 16
+
+typedef struct
+{
+   char *rendered;
+   int truncated;
+   char questions[ROUNDTABLE_MAX_QUESTIONS][512];
+   const char *question_ptrs[ROUNDTABLE_MAX_QUESTIONS];
+   int question_count;
+} normalized_roundtable_brief_t;
+
+static int brief_append(char *buf, size_t cap, size_t *pos, const char *fmt, ...)
+{
+   if (!buf || !pos || *pos >= cap)
+      return -1;
+   va_list ap;
+   va_start(ap, fmt);
+   int n = vsnprintf(buf + *pos, cap - *pos, fmt, ap);
+   va_end(ap);
+   if (n < 0)
+      return -1;
+   if ((size_t)n >= cap - *pos)
+   {
+      *pos = cap - 1;
+      buf[*pos] = '\0';
+      return 1;
+   }
+   *pos += (size_t)n;
+   return 0;
+}
+
+static int brief_array_append(const char *label, cJSON *arr, char *buf, size_t cap, size_t *pos,
+                              normalized_roundtable_brief_t *out, char *err, size_t err_n)
+{
+   if (!arr)
+      return 0;
+   if (!cJSON_IsArray(arr))
+   {
+      snprintf(err, err_n, "brief.%s must be an array of strings", label);
+      return -1;
+   }
+   if (cJSON_GetArraySize(arr) <= 0)
+      return 0;
+   int rc = brief_append(buf, cap, pos, "%s:\n", label);
+   cJSON *it;
+   cJSON_ArrayForEach(it, arr)
+   {
+      if (!cJSON_IsString(it))
+      {
+         snprintf(err, err_n, "brief.%s must be an array of strings", label);
+         return -1;
+      }
+      if (strcmp(label, "questions") == 0 && out->question_count < ROUNDTABLE_MAX_QUESTIONS)
+      {
+         snprintf(out->questions[out->question_count], sizeof(out->questions[0]), "%s",
+                  it->valuestring ? it->valuestring : "");
+         out->question_ptrs[out->question_count] = out->questions[out->question_count];
+         out->question_count++;
+      }
+      if (rc == 0)
+         rc = brief_append(buf, cap, pos, "- %s\n", it->valuestring ? it->valuestring : "");
+   }
+   if (rc == 0)
+      rc = brief_append(buf, cap, pos, "\n");
+   if (rc > 0)
+      out->truncated = 1;
+   return 0;
+}
+
+static int normalize_roundtable_brief(cJSON *req, normalized_roundtable_brief_t *out, char *err,
+                                      size_t err_n)
+{
+   memset(out, 0, sizeof(*out));
+   cJSON *brief = cJSON_GetObjectItemCaseSensitive(req, "brief");
+   if (!brief)
+      return 0;
+   char tmp[ROUNDTABLE_BRIEF_MAX_BYTES + 1];
+   memset(tmp, 0, sizeof(tmp));
+   size_t pos = 0;
+   if (cJSON_IsString(brief))
+   {
+      const char *s = brief->valuestring ? brief->valuestring : "";
+      while (*s && isspace((unsigned char)*s))
+         s++;
+      if (!*s)
+         return 0;
+      int rc = brief_append(tmp, sizeof(tmp), &pos, "focus:\n- %s\n", s);
+      if (rc > 0)
+         out->truncated = 1;
+   }
+   else if (cJSON_IsObject(brief))
+   {
+      if (brief_array_append("focus", cJSON_GetObjectItemCaseSensitive(brief, "focus"), tmp,
+                             sizeof(tmp), &pos, out, err, err_n) != 0 ||
+          brief_array_append("fixes", cJSON_GetObjectItemCaseSensitive(brief, "fixes"), tmp,
+                             sizeof(tmp), &pos, out, err, err_n) != 0 ||
+          brief_array_append("invariants", cJSON_GetObjectItemCaseSensitive(brief, "invariants"),
+                             tmp, sizeof(tmp), &pos, out, err, err_n) != 0 ||
+          brief_array_append("questions", cJSON_GetObjectItemCaseSensitive(brief, "questions"), tmp,
+                             sizeof(tmp), &pos, out, err, err_n) != 0)
+         return -1;
+      if (pos == 0)
+         return 0;
+   }
+   else
+   {
+      snprintf(err, err_n, "brief must be a string or object");
+      return -1;
+   }
+   out->rendered = strdup(tmp);
+   if (!out->rendered)
+   {
+      snprintf(err, err_n, "out of memory");
+      return -1;
+   }
+   return 0;
+}
+
+static void add_roundtable_arrays(cJSON *resp, const roundtable_result_t *result)
+{
+   cJSON *items = cJSON_CreateArray();
+   for (int i = 0; i < result->item_count; i++)
+   {
+      const roundtable_review_item_t *it = &result->items[i];
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "severity", it->severity);
+      cJSON_AddStringToObject(o, "category", it->category);
+      cJSON_AddStringToObject(o, "location", it->location);
+      cJSON_AddStringToObject(o, "summary", it->summary);
+      cJSON_AddStringToObject(o, "recommendation", it->recommendation);
+      cJSON_AddStringToObject(o, "identity_key", it->identity_key);
+      cJSON_AddStringToObject(o, "sources", it->sources);
+      cJSON_AddNumberToObject(o, "count", it->count);
+      cJSON_AddItemToArray(items, o);
+   }
+   cJSON_AddItemToObject(resp, "items", items);
+
+   cJSON *answers = cJSON_CreateArray();
+   for (int i = 0; i < result->answered_question_count; i++)
+   {
+      const roundtable_answered_question_t *a = &result->answered_questions[i];
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "question", a->question);
+      cJSON_AddStringToObject(o, "answer", a->answer);
+      cJSON_AddStringToObject(o, "evidence", a->evidence);
+      cJSON_AddBoolToObject(o, "answered", a->answered ? 1 : 0);
+      cJSON_AddItemToArray(answers, o);
+   }
+   cJSON_AddItemToObject(resp, "answered_questions", answers);
+
+   cJSON *gaps = cJSON_CreateArray();
+   for (int i = 0; i < result->coverage_gap_count; i++)
+      cJSON_AddItemToArray(gaps, cJSON_CreateString(result->coverage_gaps[i]));
+   cJSON_AddItemToObject(resp, "coverage_gaps", gaps);
+}

--- a/src/server/server_compute_roundtable.inc
+++ b/src/server/server_compute_roundtable.inc
@@ -51,12 +51,17 @@ static int brief_array_append(const char *label, cJSON *arr, char *buf, size_t c
          snprintf(err, err_n, "brief.%s must be an array of strings", label);
          return -1;
       }
-      if (strcmp(label, "questions") == 0 && out->question_count < ROUNDTABLE_MAX_QUESTIONS)
+      if (strcmp(label, "questions") == 0)
       {
-         snprintf(out->questions[out->question_count], sizeof(out->questions[0]), "%s",
-                  it->valuestring ? it->valuestring : "");
-         out->question_ptrs[out->question_count] = out->questions[out->question_count];
-         out->question_count++;
+         if (out->question_count < ROUNDTABLE_MAX_QUESTIONS)
+         {
+            snprintf(out->questions[out->question_count], sizeof(out->questions[0]), "%s",
+                     it->valuestring ? it->valuestring : "");
+            out->question_ptrs[out->question_count] = out->questions[out->question_count];
+            out->question_count++;
+         }
+         else
+            out->truncated = 1; /* more questions asked than the engine can track */
       }
       if (rc == 0)
          rc = brief_append(buf, cap, pos, "- %s\n", it->valuestring ? it->valuestring : "");

--- a/src/server/server_compute_roundtable.inc
+++ b/src/server/server_compute_roundtable.inc
@@ -117,12 +117,31 @@ static int normalize_roundtable_brief(cJSON *req, normalized_roundtable_brief_t 
    return 0;
 }
 
+/* Cap the serialized items so the whole result stays under SHTTP_RESP_MAX
+ * (256 KB). The fixed item array alone can serialize to ~190 KB; left unbounded
+ * it would push a large consolidated `artifact` over the async op-run capture
+ * buffer, which loopback_rpc rejects as "response too large" (a failed run with
+ * an opaque error) instead of returning the findings. Bounding items to ~96 KB
+ * leaves ample headroom for the artifact + answered_questions. */
+#define ROUNDTABLE_ITEMS_JSON_BUDGET (96 * 1024)
+
 static void add_roundtable_arrays(cJSON *resp, const roundtable_result_t *result)
 {
    cJSON *items = cJSON_CreateArray();
+   size_t used = 0;
+   int items_truncated = 0;
    for (int i = 0; i < result->item_count; i++)
    {
       const roundtable_review_item_t *it = &result->items[i];
+      size_t est = strlen(it->severity) + strlen(it->category) + strlen(it->location) +
+                   strlen(it->summary) + strlen(it->recommendation) + strlen(it->identity_key) +
+                   strlen(it->sources) + 160; /* JSON keys, quotes, count */
+      if (i > 0 && used + est > ROUNDTABLE_ITEMS_JSON_BUDGET)
+      {
+         items_truncated = 1;
+         break;
+      }
+      used += est;
       cJSON *o = cJSON_CreateObject();
       cJSON_AddStringToObject(o, "severity", it->severity);
       cJSON_AddStringToObject(o, "category", it->category);
@@ -135,6 +154,8 @@ static void add_roundtable_arrays(cJSON *resp, const roundtable_result_t *result
       cJSON_AddItemToArray(items, o);
    }
    cJSON_AddItemToObject(resp, "items", items);
+   if (items_truncated)
+      cJSON_AddBoolToObject(resp, "items_truncated", 1);
 
    cJSON *answers = cJSON_CreateArray();
    for (int i = 0; i < result->answered_question_count; i++)

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -383,23 +383,28 @@ static void *op_run_worker(void *arg)
    return NULL;
 }
 
-static int rh_dispatch_op_async(const route_req_t *rq, char *resp, int cap)
+static int submit_op_run_internal(const char *op_method, const char *body_json, uint32_t conn_caps,
+                                  int preflight_caps, char *resp, int cap)
 {
-   if (!rq->op || !rq->op[0])
+   if (!op_method || !op_method[0])
       return err_json(resp, cap, 500, "route has no dispatch method");
-   cJSON *req = (rq->body && rq->body[0]) ? cJSON_Parse(rq->body) : cJSON_CreateObject();
+   uint32_t required = server_capability_for_method(op_method);
+   if (preflight_caps && required && (conn_caps & required) == 0)
+      return err_json(resp, cap, 403, "forbidden: insufficient capabilities");
+   cJSON *req = (body_json && body_json[0]) ? cJSON_Parse(body_json) : cJSON_CreateObject();
    if (!req || !cJSON_IsObject(req))
    {
       cJSON_Delete(req);
       return err_json(resp, cap, 400, "invalid JSON body");
    }
    cJSON_DeleteItemFromObjectCaseSensitive(req, "method");
-   cJSON_AddStringToObject(req, "method", rq->op);
+   cJSON_AddStringToObject(req, "method", op_method);
 
    long created = (long)time(NULL);
-   static unsigned long g_op_run_seq = 0; /* listener thread only; single-writer */
+   static atomic_ulong g_op_run_seq = 0;
    char id[64];
-   snprintf(id, sizeof(id), "oprun_%ld_%lu", created, ++g_op_run_seq);
+   unsigned long seq = atomic_fetch_add_explicit(&g_op_run_seq, 1, memory_order_relaxed) + 1;
+   snprintf(id, sizeof(id), "oprun_%ld_%lu", created, seq);
 
    cJSON_DeleteItemFromObjectCaseSensitive(req, "__run_id");
    cJSON_AddStringToObject(req, "__run_id", id);
@@ -408,7 +413,7 @@ static int rh_dispatch_op_async(const route_req_t *rq, char *resp, int cap)
    if (!line)
       return err_json(resp, cap, 500, "out of memory");
 
-   char *queued = op_run_snapshot(id, rq->op, "queued", created, NULL);
+   char *queued = op_run_snapshot(id, op_method, "queued", created, NULL);
    if (!queued || !openai_runs_store_create(id, queued))
    {
       free(queued);
@@ -424,9 +429,9 @@ static int rh_dispatch_op_async(const route_req_t *rq, char *resp, int cap)
       return err_json(resp, cap, 500, "out of memory");
    }
    snprintf(j->run_id, sizeof(j->run_id), "%s", id);
-   snprintf(j->op, sizeof(j->op), "%s", rq->op);
+   snprintf(j->op, sizeof(j->op), "%s", op_method);
    j->line = line; /* ownership moves to the worker */
-   j->conn_caps = g_rpc_conn_caps;
+   j->conn_caps = conn_caps;
 
    pthread_t th;
    if (pthread_create(&th, NULL, op_run_worker, j) != 0)
@@ -442,6 +447,17 @@ static int rh_dispatch_op_async(const route_req_t *rq, char *resp, int cap)
    int n = snprintf(resp, (size_t)cap, "%s", queued);
    free(queued);
    return (n > 0 && n < cap) ? 200 : 200;
+}
+
+int server_http_submit_op_run(const char *op_method, const char *body_json, uint32_t conn_caps,
+                              char *resp, int cap)
+{
+   return submit_op_run_internal(op_method, body_json, conn_caps, 1, resp, cap);
+}
+
+static int rh_dispatch_op_async(const route_req_t *rq, char *resp, int cap)
+{
+   return submit_op_run_internal(rq->op, rq->body, g_rpc_conn_caps, 0, resp, cap);
 }
 
 /* ── workspace resource plane (workspace-resource-plane §1) ───────────────────

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -109,15 +109,45 @@ static int handle_mcp_ensemble_review(server_conn_t *conn, cJSON *args)
    cJSON_AddStringToObject(body, "prompt", diff->valuestring);
    cJSON_AddStringToObject(body, "mode", "review");
    cJSON *brief = cJSON_GetObjectItemCaseSensitive(args, "brief");
-   if (brief && (cJSON_IsObject(brief) || cJSON_IsString(brief)))
-      cJSON_AddItemToObject(body, "brief", cJSON_Duplicate(brief, 1));
+   if (brief)
+   {
+      if (!cJSON_IsObject(brief) && !cJSON_IsString(brief))
+      {
+         cJSON_Delete(body);
+         return server_send_error(conn, "ensemble_review 'brief' must be a string or object", NULL);
+      }
+      cJSON *brief_copy = cJSON_Duplicate(brief, 1);
+      if (!brief_copy)
+      {
+         cJSON_Delete(body);
+         return server_send_error(conn, "out of memory", NULL);
+      }
+      cJSON_AddItemToObject(body, "brief", brief_copy);
+   }
    cJSON *rounds = cJSON_GetObjectItemCaseSensitive(args, "rounds");
-   if (cJSON_IsNumber(rounds))
+   if (rounds)
+   {
+      if (!cJSON_IsNumber(rounds) || rounds->valuedouble < 1 || rounds->valuedouble > 16 ||
+          rounds->valuedouble != (double)rounds->valueint)
+      {
+         cJSON_Delete(body);
+         return server_send_error(conn, "ensemble_review 'rounds' must be an integer from 1 to 16",
+                                  NULL);
+      }
       cJSON_AddNumberToObject(body, "rounds", rounds->valuedouble);
+   }
    cJSON *turns = cJSON_GetObjectItemCaseSensitive(args, "turns");
-   if (cJSON_IsString(turns) && (strcmp(turns->valuestring, "parallel") == 0 ||
-                                 strcmp(turns->valuestring, "sequential") == 0))
+   if (turns)
+   {
+      if (!cJSON_IsString(turns) || (strcmp(turns->valuestring, "parallel") != 0 &&
+                                     strcmp(turns->valuestring, "sequential") != 0))
+      {
+         cJSON_Delete(body);
+         return server_send_error(conn, "ensemble_review 'turns' must be parallel or sequential",
+                                  NULL);
+      }
       cJSON_AddStringToObject(body, "turns", turns->valuestring);
+   }
 
    char *line = cJSON_PrintUnformatted(body);
    cJSON_Delete(body);

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -99,6 +99,9 @@ static int handle_mcp_ensemble_review(server_conn_t *conn, cJSON *args)
    cJSON *diff = cJSON_GetObjectItemCaseSensitive(args, "diff");
    if (!cJSON_IsString(diff) || !diff->valuestring || !diff->valuestring[0])
       return server_send_error(conn, "ensemble_review requires 'diff'", NULL);
+   if (strlen(diff->valuestring) < 20)
+      return server_send_error(conn, "ensemble_review requires 'diff' of at least 20 characters",
+                               NULL);
 
    cJSON *body = cJSON_CreateObject();
    if (!body)

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -25,6 +25,7 @@
 #include "server_mcp_delegate.h"
 #include "server_mcp_workflows.h"
 #include "server_mcp_gateway.h"
+#include "server_http.h"
 #include "headers/conversation_context.h"
 #include "headers/payload_rewrite.h"
 #include "headers/session_search_tool.h"
@@ -90,6 +91,62 @@ static int send_mcp_result_structured(server_conn_t *conn, cJSON *content, cJSON
    cJSON *resp = jo_ok();
    cJSON_AddItemToObject(resp, "content", content);
    cJSON_AddItemToObject(resp, "structuredContent", structured);
+   return server_send_ok(conn, resp);
+}
+
+static int handle_mcp_ensemble_review(server_conn_t *conn, cJSON *args)
+{
+   cJSON *diff = cJSON_GetObjectItemCaseSensitive(args, "diff");
+   if (!cJSON_IsString(diff) || !diff->valuestring || !diff->valuestring[0])
+      return server_send_error(conn, "ensemble_review requires 'diff'", NULL);
+
+   cJSON *body = cJSON_CreateObject();
+   if (!body)
+      return server_send_error(conn, "out of memory", NULL);
+   cJSON_AddStringToObject(body, "prompt", diff->valuestring);
+   cJSON_AddStringToObject(body, "mode", "review");
+   cJSON *brief = cJSON_GetObjectItemCaseSensitive(args, "brief");
+   if (brief && (cJSON_IsObject(brief) || cJSON_IsString(brief)))
+      cJSON_AddItemToObject(body, "brief", cJSON_Duplicate(brief, 1));
+   cJSON *rounds = cJSON_GetObjectItemCaseSensitive(args, "rounds");
+   if (cJSON_IsNumber(rounds))
+      cJSON_AddNumberToObject(body, "rounds", rounds->valuedouble);
+   cJSON *turns = cJSON_GetObjectItemCaseSensitive(args, "turns");
+   if (cJSON_IsString(turns) && (strcmp(turns->valuestring, "parallel") == 0 ||
+                                 strcmp(turns->valuestring, "sequential") == 0))
+      cJSON_AddStringToObject(body, "turns", turns->valuestring);
+
+   char *line = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+   if (!line)
+      return server_send_error(conn, "out of memory", NULL);
+
+   char respbuf[8192];
+   int st = server_http_submit_op_run("delegate.roundtable", line, conn->capabilities, respbuf,
+                                      sizeof(respbuf));
+   free(line);
+   if (st < 200 || st >= 300)
+   {
+      cJSON *err = cJSON_Parse(respbuf);
+      cJSON *msg = err ? cJSON_GetObjectItemCaseSensitive(err, "error") : NULL;
+      const char *text = cJSON_IsString(msg) ? msg->valuestring : "could not queue ensemble_review";
+      int rc = server_send_error(conn, text, NULL);
+      cJSON_Delete(err);
+      return rc;
+   }
+
+   cJSON *snap = cJSON_Parse(respbuf);
+   if (!snap)
+      return server_send_error(conn, "could not parse queued run", NULL);
+   cJSON *id = cJSON_GetObjectItemCaseSensitive(snap, "id");
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(snap, "status");
+   cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "run_id", cJSON_IsString(id) ? id->valuestring : "");
+   cJSON_AddStringToObject(resp, "id", cJSON_IsString(id) ? id->valuestring : "");
+   cJSON_AddStringToObject(resp, "object", "op.run");
+   cJSON_AddStringToObject(resp, "method", "delegate.roundtable");
+   cJSON_AddStringToObject(resp, "status", cJSON_IsString(status) ? status->valuestring : "queued");
+   cJSON_Delete(snap);
    return server_send_ok(conn, resp);
 }
 static cJSON *tool_get_help(cJSON *args)
@@ -1404,6 +1461,14 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (strcmp(tool, "delegate_status") == 0)
    {
       int rc = handle_delegate_status(ctx, conn, jargs);
+      if (owns_jargs)
+         cJSON_Delete(jargs);
+      return rc;
+   }
+
+   if (strcmp(tool, "ensemble_review") == 0)
+   {
+      int rc = handle_mcp_ensemble_review(conn, jargs);
       if (owns_jargs)
          cJSON_Delete(jargs);
       return rc;

--- a/src/server/server_mcp_delegate.c
+++ b/src/server/server_mcp_delegate.c
@@ -29,6 +29,10 @@ static void add_resolved_delegate_cwd(cJSON *dreq, cJSON *args, const char *sid)
 
 int handle_mcp_delegate_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *args, const char *sid)
 {
+   uint32_t required = server_capability_for_method("delegate");
+   if (required && conn && (conn->capabilities & required) == 0)
+      return server_send_error(conn, "forbidden: insufficient capabilities", NULL);
+
    cJSON *dreq = cJSON_CreateObject();
    cJSON_AddStringToObject(dreq, "method", "delegate");
    cJSON *jr = cJSON_GetObjectItemCaseSensitive(args, "role");

--- a/src/tests/test_cli_rpc_delegate.c
+++ b/src/tests/test_cli_rpc_delegate.c
@@ -109,6 +109,38 @@ static void test_delegate_persona_marshaled(void)
    printf("  PASS: test_delegate_persona_marshaled\n");
 }
 
+static void test_delegate_roundtable_brief_marshaled(void)
+{
+   char *argv[] = {"review this change thoroughly",
+                   "--mode",
+                   "review",
+                   "--turns",
+                   "parallel",
+                   "--rounds",
+                   "2",
+                   "--brief",
+                   "focus on auth",
+                   "--brief-json",
+                   "{\"questions\":[\"does auth hold?\"]}",
+                   "--apply"};
+   cJSON *req = marshal_delegate_roundtable(12, argv);
+   assert(req != NULL);
+   assert(strcmp(cJSON_GetObjectItem(req, "method")->valuestring, "delegate.roundtable") == 0);
+   assert(strcmp(cJSON_GetObjectItem(req, "prompt")->valuestring,
+                 "review this change thoroughly") == 0);
+   assert(strcmp(cJSON_GetObjectItem(req, "mode")->valuestring, "review") == 0);
+   assert(strcmp(cJSON_GetObjectItem(req, "turns")->valuestring, "parallel") == 0);
+   assert(cJSON_GetObjectItem(req, "rounds")->valueint == 2);
+   assert(cJSON_IsTrue(cJSON_GetObjectItem(req, "apply")));
+   cJSON *brief = cJSON_GetObjectItem(req, "brief");
+   assert(cJSON_IsObject(brief));
+   cJSON *questions = cJSON_GetObjectItem(brief, "questions");
+   assert(cJSON_IsArray(questions));
+   assert(strcmp(cJSON_GetArrayItem(questions, 0)->valuestring, "does auth hold?") == 0);
+   cJSON_Delete(req);
+   printf("  PASS: test_delegate_roundtable_brief_marshaled\n");
+}
+
 static cJSON *marshal_delegate_with_stdin(int argc, char **argv, const char *input)
 {
    int old_stdin = dup(STDIN_FILENO);
@@ -1202,6 +1234,7 @@ int main(void)
    test_delegate_zero_max_turns_marshaled();
    test_delegate_provider_model_marshaled();
    test_delegate_persona_marshaled();
+   test_delegate_roundtable_brief_marshaled();
    test_delegate_prompt_stdin_marshaled();
    test_delegate_status_multiple_ids_marshaled();
    test_delegate_log_rejects_ignored_args();

--- a/src/tests/test_cli_rpc_delegate.c
+++ b/src/tests/test_cli_rpc_delegate.c
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #include "aimee.h"
@@ -139,6 +140,25 @@ static void test_delegate_roundtable_brief_marshaled(void)
    assert(strcmp(cJSON_GetArrayItem(questions, 0)->valuestring, "does auth hold?") == 0);
    cJSON_Delete(req);
    printf("  PASS: test_delegate_roundtable_brief_marshaled\n");
+}
+
+static void test_delegate_roundtable_invalid_brief_json_exits(void)
+{
+   pid_t pid = fork();
+   assert(pid >= 0);
+   if (pid == 0)
+   {
+      char *argv[] = {"review this change thoroughly", "--brief-json", "{\"questions\":["};
+      cJSON *req = marshal_delegate_roundtable(3, argv);
+      cJSON_Delete(req);
+      _exit(0);
+   }
+
+   int status = 0;
+   assert(waitpid(pid, &status, 0) == pid);
+   assert(WIFEXITED(status));
+   assert(WEXITSTATUS(status) == 1);
+   printf("  PASS: test_delegate_roundtable_invalid_brief_json_exits\n");
 }
 
 static cJSON *marshal_delegate_with_stdin(int argc, char **argv, const char *input)
@@ -1235,6 +1255,7 @@ int main(void)
    test_delegate_provider_model_marshaled();
    test_delegate_persona_marshaled();
    test_delegate_roundtable_brief_marshaled();
+   test_delegate_roundtable_invalid_brief_json_exits();
    test_delegate_prompt_stdin_marshaled();
    test_delegate_status_multiple_ids_marshaled();
    test_delegate_log_rejects_ignored_args();

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -571,6 +571,35 @@ static void test_roundtable_review_brief_and_items_return(void)
    printf("  test_roundtable_review_brief_and_items_return: ok\n");
 }
 
+static void test_roundtable_cost_capped_skips_question_pass(void)
+{
+   reset_modes();
+   g_parallel_mode = 7;
+   config_t cfg = make_cfg(1, 2, 0.001); /* tiny cap trips after round 1 */
+   agent_config_t acfg = make_acfg();
+   const char *questions[] = {"does auth hold?"};
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_REVIEW;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 2;
+   opts.questions = questions;
+   opts.question_count = 1;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "review with cost cap", &opts, &result);
+   assert(rc == 0);
+   assert(result.cost_capped == 1);
+   /* The reason-role question pass is skipped on a cost-capped run; the mock would
+    * have answered "does auth hold?" with answered=true, so answered==0 proves it
+    * was skipped while the question is still reported as an unanswered gap. */
+   assert(result.answered_question_count == 1);
+   assert(result.answered_questions[0].answered == 0);
+   assert(strcmp(result.answered_questions[0].question, "does auth hold?") == 0);
+   assert(result.coverage_gap_count == 1);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_cost_capped_skips_question_pass: ok\n");
+}
+
 static void test_roundtable_review_summary_fallback_key_converges(void)
 {
    reset_modes();
@@ -721,6 +750,7 @@ int main(void)
    test_roundtable_summarize_forward_sets_truncated();
    test_roundtable_review_saturation_converges();
    test_roundtable_review_brief_and_items_return();
+   test_roundtable_cost_capped_skips_question_pass();
    test_roundtable_review_summary_fallback_key_converges();
    test_roundtable_review_clean_round_converges();
    test_roundtable_malformed_review_json_counts_failed();

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -600,6 +600,37 @@ static void test_roundtable_cost_capped_skips_question_pass(void)
    printf("  test_roundtable_cost_capped_skips_question_pass: ok\n");
 }
 
+static void test_roundtable_partial_question_answers_report_gaps(void)
+{
+   reset_modes();
+   g_parallel_mode = 7;
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   /* The reason mock answers only "does auth hold?"; the second question is left
+    * unanswered. The engine must still return one entry per asked question and
+    * report the second as a coverage gap (not silently drop it). */
+   const char *questions[] = {"does auth hold?", "is the cache safe?"};
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_REVIEW;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   opts.questions = questions;
+   opts.question_count = 2;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "review two questions", &opts, &result);
+   assert(rc == 0);
+   assert(result.answered_question_count == 2);
+   assert(strcmp(result.answered_questions[0].question, "does auth hold?") == 0);
+   assert(result.answered_questions[0].answered == 1);
+   assert(strcmp(result.answered_questions[1].question, "is the cache safe?") == 0);
+   assert(result.answered_questions[1].answered == 0);
+   assert(result.coverage_gap_count == 1);
+   assert(strcmp(result.coverage_gaps[0], "is the cache safe?") == 0);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_partial_question_answers_report_gaps: ok\n");
+}
+
 static void test_roundtable_review_summary_fallback_key_converges(void)
 {
    reset_modes();
@@ -751,6 +782,7 @@ int main(void)
    test_roundtable_review_saturation_converges();
    test_roundtable_review_brief_and_items_return();
    test_roundtable_cost_capped_skips_question_pass();
+   test_roundtable_partial_question_answers_report_gaps();
    test_roundtable_review_summary_fallback_key_converges();
    test_roundtable_review_clean_round_converges();
    test_roundtable_malformed_review_json_counts_failed();

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -631,6 +631,35 @@ static void test_roundtable_partial_question_answers_report_gaps(void)
    printf("  test_roundtable_partial_question_answers_report_gaps: ok\n");
 }
 
+static void test_roundtable_draft_brief_questions_not_answered(void)
+{
+   reset_modes();
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   /* Questions are a review-mode concept. A draft run that happens to carry a
+    * brief with questions must not trigger the reason-role question pass or
+    * return answered_questions/items (it would otherwise pay for a review-only
+    * feature and emit an inconsistent draft contract). */
+   const char *questions[] = {"does auth hold?"};
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   opts.converge_threshold = 0;
+   opts.brief = "focus:\n- auth checks\n";
+   opts.questions = questions;
+   opts.question_count = 1;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "draft a short proposal", &opts, &result);
+   assert(rc == 0);
+   assert(result.answered_question_count == 0);
+   assert(result.coverage_gap_count == 0);
+   assert(result.item_count == 0);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_draft_brief_questions_not_answered: ok\n");
+}
+
 static void test_roundtable_review_summary_fallback_key_converges(void)
 {
    reset_modes();
@@ -783,6 +812,7 @@ int main(void)
    test_roundtable_review_brief_and_items_return();
    test_roundtable_cost_capped_skips_question_pass();
    test_roundtable_partial_question_answers_report_gaps();
+   test_roundtable_draft_brief_questions_not_answered();
    test_roundtable_review_summary_fallback_key_converges();
    test_roundtable_review_clean_round_converges();
    test_roundtable_malformed_review_json_counts_failed();

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -18,6 +18,7 @@ static int g_parallel_calls = 0;
 static int g_named_calls = 0;
 static int g_aggregator_calls = 0;
 static int g_cancel_after_checks = -1;
+static char g_last_parallel_prompt[8192];
 
 /* Capture the per-task participant selector the engine sets, so a test can
  * assert the §0.1 routing fix: each fan-out task must be pointed at its own
@@ -44,6 +45,8 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agen
 {
    (void)cfg;
    g_parallel_calls++;
+   snprintf(g_last_parallel_prompt, sizeof(g_last_parallel_prompt), "%s",
+            count > 0 && tasks[0].user_prompt ? tasks[0].user_prompt : "");
    g_captured_count = count < CAP_MAX ? count : CAP_MAX;
    for (int i = 0; i < g_captured_count; i++)
       snprintf(g_captured_agents[i], sizeof(g_captured_agents[i]), "%s",
@@ -79,6 +82,17 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agen
              "\"summary\":\"missing authorization check before write\"}],\"overall\":\"block\"}");
       else if (g_parallel_mode == 6 && tasks[i].role && strcmp(tasks[i].role, "review") == 0)
          out[i].response = strdup("{\"items\":[],\"overall\":\"ok\"}");
+      else if (g_parallel_mode == 7 && tasks[i].role && strcmp(tasks[i].role, "review") == 0)
+         out[i].response =
+             strdup(i == 0 ? "{\"items\":[{\"severity\":\"blocking\",\"category\":\"correctness\","
+                             "\"location\":\"src/a.c:10\",\"summary\":\"first bug\","
+                             "\"recommendation\":\"fix first\"},{\"severity\":\"suggestion\","
+                             "\"category\":\"correctness\",\"location\":\"src/a.c:10\","
+                             "\"summary\":\"second bug\",\"recommendation\":\"fix second\"}],"
+                             "\"overall\":\"mixed\"}"
+                           : "{\"items\":[{\"severity\":\"nit\",\"category\":\"style\","
+                             "\"location\":\"src/b.c:2\",\"summary\":\"rename local\","
+                             "\"recommendation\":\"use clearer name\"}],\"overall\":\"nit\"}");
       else
       {
          snprintf(buf, sizeof(buf), "mock response from %s",
@@ -141,7 +155,11 @@ int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
    memset(out, 0, sizeof(*out));
    if (role && strcmp(role, "reason") == 0)
    {
-      if (strstr(user_prompt ? user_prompt : "", "{\"completion\":N}"))
+      if (strstr(user_prompt ? user_prompt : "", "Answer the caller's roundtable review questions"))
+         out->response = strdup("{\"answered_questions\":[{\"question\":\"does auth hold?\","
+                                "\"answer\":\"yes\",\"evidence\":\"review mentions auth\","
+                                "\"answered\":true}],\"coverage_gaps\":[]}");
+      else if (strstr(user_prompt ? user_prompt : "", "{\"completion\":N}"))
          out->response = strdup("{\"completion\":95}");
       else if (g_reason_mode == 1)
          out->response =
@@ -234,6 +252,7 @@ static void reset_modes(void)
    g_named_calls = 0;
    g_aggregator_calls = 0;
    g_cancel_after_checks = -1;
+   g_last_parallel_prompt[0] = '\0';
 }
 
 /* --- tests --- */
@@ -520,6 +539,38 @@ static void test_roundtable_review_saturation_converges(void)
    printf("  test_roundtable_review_saturation_converges: ok\n");
 }
 
+static void test_roundtable_review_brief_and_items_return(void)
+{
+   reset_modes();
+   g_parallel_mode = 7;
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   const char *questions[] = {"does auth hold?"};
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_REVIEW;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   opts.brief = "focus:\n- auth checks\n";
+   opts.questions = questions;
+   opts.question_count = 1;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "review all severities", &opts, &result);
+   assert(rc == 0);
+   assert(strstr(g_last_parallel_prompt, "CALLER BRIEF:") != NULL);
+   assert(strstr(g_last_parallel_prompt, "report any blocking issue") != NULL);
+   assert(result.item_count == 3);
+   assert(strcmp(result.items[0].severity, "blocking") == 0);
+   assert(strcmp(result.items[1].severity, "suggestion") == 0);
+   assert(strcmp(result.items[2].severity, "nit") == 0);
+   assert(strcmp(result.items[0].identity_key, result.items[1].identity_key) == 0);
+   assert(strcmp(result.items[0].summary, result.items[1].summary) != 0);
+   assert(result.answered_question_count == 1);
+   assert(result.answered_questions[0].answered == 1);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_review_brief_and_items_return: ok\n");
+}
+
 static void test_roundtable_review_summary_fallback_key_converges(void)
 {
    reset_modes();
@@ -602,6 +653,8 @@ static void test_roundtable_malformed_review_json_repair_counts_successful(void)
    assert(rc == 0);
    assert(result.degraded == 0);
    assert(g_named_calls == 1);
+   assert(result.item_count == 1);
+   assert(strcmp(result.items[0].location, "src/fixed.c:9") == 0);
    delegate_roundtable_result_free(&result);
    printf("  test_roundtable_malformed_review_json_repair_counts_successful: ok\n");
 }
@@ -667,6 +720,7 @@ int main(void)
    test_roundtable_post_fanout_cap_keeps_prior_best();
    test_roundtable_summarize_forward_sets_truncated();
    test_roundtable_review_saturation_converges();
+   test_roundtable_review_brief_and_items_return();
    test_roundtable_review_summary_fallback_key_converges();
    test_roundtable_review_clean_round_converges();
    test_roundtable_malformed_review_json_counts_failed();

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -2,7 +2,7 @@
  * built-in tool surface (name + sorted schema property keys + required), captured
  * via the DUMP_TOOLS path in test_mcp_client_registry.c. Regenerate after an
  * intentional tool change: DUMP_TOOLS=1 ./unit-test-mcp-client-registry 2>&1. */
-#define MCP_TOOLS_GOLDEN_COUNT 86
+#define MCP_TOOLS_GOLDEN_COUNT 87
 #define MCP_TOOLS_GOLDEN \
    "ask_user {choices,question} req:question\n" \
    "ast_grep_search {lang,path,pattern} req:lang,pattern\n" \
@@ -21,6 +21,7 @@
    "diagnose_observe {content,diagnosis_id,source} req:content,diagnosis_id\n" \
    "diagnose_start {symptom} req:symptom\n" \
    "diagnose_status {diagnosis_id} req:diagnosis_id\n" \
+   "ensemble_review {brief,diff,rounds,turns} req:diff\n" \
    "find_symbol {identifier} req:identifier\n" \
    "get_background_output {id,tail_lines} req:id\n" \
    "get_context_block {block_type,limit,query} req:query\n" \

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1190,6 +1190,35 @@ static void test_large_delegate_payload_within_limit(void)
    free(ctx);
 }
 
+static void test_large_mcp_call_payload_within_limit(void)
+{
+   server_ctx_t *ctx = calloc(1, sizeof(*ctx));
+   server_conn_t *conn = calloc(1, sizeof(*conn));
+   assert(ctx != NULL && conn != NULL);
+   conn->peer_uid = getuid();
+   conn->capabilities = CAPS_AUTHENTICATED;
+
+   size_t size = LIMIT_DEFAULT + 64;
+   char *msg = malloc(size + 1);
+   assert(msg != NULL);
+   snprintf(msg, size + 1,
+            "{\"method\":\"mcp.call\",\"tool\":\"ensemble_review\",\"arguments\":{\"diff\":\"");
+   size_t used = strlen(msg);
+   memset(msg + used, 'a', size - used - 4);
+   msg[size - 4] = '"';
+   msg[size - 3] = '}';
+   msg[size - 2] = '}';
+   msg[size - 1] = '\0';
+
+   cJSON *json = dispatch_json(ctx, conn, msg, strlen(msg));
+   assert(strcmp(cJSON_GetObjectItem(json, "status")->valuestring, "ok") == 0);
+   assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring, "mcp.call") == 0);
+   cJSON_Delete(json);
+   free(msg);
+   free(conn);
+   free(ctx);
+}
+
 static void test_unknown_method(void)
 {
    server_ctx_t *ctx = calloc(1, sizeof(*ctx));
@@ -1557,6 +1586,7 @@ int main(void)
    test_missing_method();
    test_oversized_payload();
    test_large_delegate_payload_within_limit();
+   test_large_mcp_call_payload_within_limit();
    test_unknown_method();
    test_removed_storage_named_migration_alias();
    test_authz_denied_shape();

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -896,6 +896,14 @@ int main(void)
       assert(strstr(rb, "\"object\":\"op.run\""));
       assert(strstr(rb, "\"method\":\"delegate.roundtable\""));
       assert(strstr(rb, "\"status\":\"queued\""));
+      for (int i = 0; i < 100 && strcmp(g_disp_method, "delegate.roundtable") != 0; i++)
+         usleep(1000);
+      g_disp_method[0] = '\0';
+      g_disp_body[0] = '\0';
+      openai_runs_store_reset();
+      assert(server_http_submit_op_run("delegate.roundtable", "{\"prompt\":\"draft\"}",
+                                       CAP_TOOL_EXECUTE, rb, sizeof(rb)) == 403);
+      assert(strstr(rb, "insufficient capabilities"));
       /* The /v1/rpc bridge was retired: the path is now unrouted (404). */
       assert(server_http_route("POST", "/v1/rpc", "{}", 2, rb, sizeof(rb)) == 404);
       /* A deeper run path (two segments, no /stop|/events) does not match. */


### PR DESCRIPTION
## Summary
- add caller-provided review briefs to `delegate.roundtable`, including structured focus/fixes/invariants/questions support
- return all-severity review items, answered questions, coverage gaps, and round metadata from ensemble review runs
- add MCP `ensemble_review`, async op-run capability preflight, CLI brief flags, docs, OpenAPI, and tests

## Tests
- `git diff --check`
- `make -C src lint`
- `make -C src unit-tests -j2`
