### PR TITLE
Fix async op run status snapshots

### DIFF
--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -991,6 +991,7 @@ static void *run_job_worker(void *arg)
    }
 
    openai_runs_store_set_status(j->run_id, OPENAI_RUN_IN_PROGRESS);
+   openai_runs_store_update_json(j->run_id, run_status_json(j, "in_progress", buf, RUN_JSON_CAP));
    openai_runs_store_append_event(j->run_id, "response.in_progress",
                                   run_status_json(j, "in_progress", buf, RUN_JSON_CAP));
 

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -310,6 +310,7 @@ typedef struct
    char op[64];
    char *line;         /* dispatch body with method injected; owned by worker */
    uint32_t conn_caps; /* caps captured at enqueue time */
+   long created;
 } op_run_job_t;
 
 /* Build the run snapshot object stored for GET /v1/runs/{id}. `result` is an
@@ -335,21 +336,29 @@ static char *op_run_snapshot(const char *run_id, const char *op, const char *sta
    return s;
 }
 
-static void *op_run_worker(void *arg)
+static void op_run_worker_run(void *arg)
 {
    op_run_job_t *j = (op_run_job_t *)arg;
+   compute_pool_set_job(POOL_JOB_DELEGATE, "op=%s run=%s", j->op, j->run_id);
    openai_runs_store_set_status(j->run_id, OPENAI_RUN_IN_PROGRESS);
+   char *started = op_run_snapshot(j->run_id, j->op, "in_progress", j->created, NULL);
+   if (started)
+   {
+      openai_runs_store_update_json(j->run_id, started);
+      free(started);
+   }
 
    char *buf = (char *)malloc(SHTTP_RESP_MAX);
    if (!buf)
    {
-      char *snap = op_run_snapshot(j->run_id, j->op, "failed", (long)time(NULL),
+      char *snap = op_run_snapshot(j->run_id, j->op, "failed", j->created,
                                    "{\"error\":\"out of memory\"}");
       openai_runs_store_finalize(j->run_id, OPENAI_RUN_FAILED, snap ? snap : "{}");
       free(snap);
       free(j->line);
       free(j);
-      return NULL;
+      compute_pool_clear_job();
+      return;
    }
 
    int rc = loopback_rpc(j->line, (int)strlen(j->line), buf, SHTTP_RESP_MAX, j->conn_caps);
@@ -370,16 +379,21 @@ static void *op_run_worker(void *arg)
          cJSON_Delete(parsed);
       }
    }
-   long now = (long)time(NULL);
    const char *status_str =
        terminal_status == OPENAI_RUN_CANCELLED ? "cancelled" : (ok ? "completed" : "failed");
-   char *snap = op_run_snapshot(j->run_id, j->op, status_str, now, buf);
+   char *snap = op_run_snapshot(j->run_id, j->op, status_str, j->created, buf);
    openai_runs_store_finalize(j->run_id, ok ? terminal_status : OPENAI_RUN_FAILED,
                               snap ? snap : buf);
    free(snap);
    free(buf);
    free(j->line);
    free(j);
+   compute_pool_clear_job();
+}
+
+static void *op_run_worker_thread(void *arg)
+{
+   op_run_worker_run(arg);
    return NULL;
 }
 
@@ -432,17 +446,39 @@ static int submit_op_run_internal(const char *op_method, const char *body_json, 
    snprintf(j->op, sizeof(j->op), "%s", op_method);
    j->line = line; /* ownership moves to the worker */
    j->conn_caps = conn_caps;
+   j->created = created;
 
-   pthread_t th;
-   if (pthread_create(&th, NULL, op_run_worker, j) != 0)
+   server_ctx_t *ctx = server_active_ctx();
+   if (ctx)
    {
-      openai_runs_store_finalize(id, OPENAI_RUN_FAILED, queued);
-      free(j->line);
-      free(j);
-      free(queued);
-      return err_json(resp, cap, 500, "could not start run");
+      if (compute_pool_submit(&ctx->pool, op_run_worker_run, j) != 0)
+      {
+         char *failed =
+             op_run_snapshot(id, op_method, "failed", created, "{\"error\":\"compute queue full\"}");
+         openai_runs_store_finalize(id, OPENAI_RUN_FAILED, failed ? failed : queued);
+         free(failed);
+         free(j->line);
+         free(j);
+         free(queued);
+         return err_json(resp, cap, 503, "compute queue full");
+      }
    }
-   pthread_detach(th);
+   else
+   {
+      pthread_t th;
+      if (pthread_create(&th, NULL, op_run_worker_thread, j) != 0)
+      {
+         char *failed =
+             op_run_snapshot(id, op_method, "failed", created, "{\"error\":\"could not start run\"}");
+         openai_runs_store_finalize(id, OPENAI_RUN_FAILED, failed ? failed : queued);
+         free(failed);
+         free(j->line);
+         free(j);
+         free(queued);
+         return err_json(resp, cap, 500, "could not start run");
+      }
+      pthread_detach(th);
+   }
 
    int n = snprintf(resp, (size_t)cap, "%s", queued);
    free(queued);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1680,6 +1680,7 @@ $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
                            $(OBJDIR)/delivery_target.o \
                            $(OBJDIR)/server/openai_shape.o \
                            $(OBJDIR)/server/openai_runs_store.o $(OBJDIR)/server/server_auth.o \
+                           $(OBJDIR)/server/compute_pool.o \
                            $(OBJDIR)/server/agent_config.o \
                            $(OBJDIR)/persona.o $(OBJDIR)/prompts.o \
                            $(OBJDIR)/role_templates.o \

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -45,7 +45,8 @@ static int stub_models_provider(char ids[][SERVER_HTTP_MODEL_ID_MAX], int max)
  * NDJSON method a first-class /v1 route actually dispatched, and that the body
  * survived the bridge. */
 static _Thread_local char g_disp_method[96];
-static _Thread_local char g_disp_body[512];
+static _Thread_local char g_disp_body[24576];
+static char g_agg_body[24576];
 
 int server_dispatch(server_ctx_t *ctx, server_conn_t *conn, const char *msg, size_t msg_len)
 {
@@ -53,6 +54,8 @@ int server_dispatch(server_ctx_t *ctx, server_conn_t *conn, const char *msg, siz
    /* Capture the dispatched method + body (msg is the NUL-terminated line the
     * loopback bridge built). */
    snprintf(g_disp_body, sizeof(g_disp_body), "%.*s", (int)msg_len, msg ? msg : "");
+   if (strstr(g_disp_body, "\"method\":\"delegate.aggregate\""))
+      snprintf(g_agg_body, sizeof(g_agg_body), "%s", g_disp_body);
    g_disp_method[0] = '\0';
    const char *p = strstr(g_disp_body, "\"method\":\"");
    if (p)
@@ -898,6 +901,37 @@ int main(void)
       assert(strstr(rb, "\"status\":\"queued\""));
       for (int i = 0; i < 100 && strcmp(g_disp_method, "delegate.roundtable") != 0; i++)
          usleep(1000);
+      char *large_body = malloc(9200);
+      assert(large_body);
+      strcpy(large_body, "{\"prompt\":\"");
+      size_t prefix_len = strlen(large_body);
+      memset(large_body + prefix_len, 'x', 9000);
+      strcpy(large_body + prefix_len + 9000, "\"}");
+      assert(server_http_route("POST", "/v1/delegate/aggregate", large_body,
+                               (int)strlen(large_body), rb, sizeof(rb)) == 200);
+      assert(strstr(rb, "\"object\":\"op.run\""));
+      assert(strstr(rb, "\"method\":\"delegate.aggregate\""));
+      char run_id[96] = "";
+      char *idp = strstr(rb, "\"id\":\"");
+      assert(idp);
+      idp += strlen("\"id\":\"");
+      char *ide = strchr(idp, '"');
+      assert(ide && (size_t)(ide - idp) < sizeof(run_id));
+      snprintf(run_id, sizeof(run_id), "%.*s", (int)(ide - idp), idp);
+      openai_run_status_t st = OPENAI_RUN_QUEUED;
+      for (int i = 0; i < 100; i++)
+      {
+         assert(openai_runs_store_status(run_id, &st));
+         if (openai_run_status_terminal(st))
+            break;
+         usleep(10000);
+      }
+      assert(st == OPENAI_RUN_COMPLETED);
+      assert(openai_runs_store_get(run_id, rb, sizeof(rb)));
+      assert(strstr(rb, "\"status\":\"completed\""));
+      assert(strstr(g_agg_body, "\"method\":\"delegate.aggregate\""));
+      assert(strstr(g_agg_body, "\"prompt\":\"xxx"));
+      free(large_body);
       g_disp_method[0] = '\0';
       g_disp_body[0] = '\0';
       openai_runs_store_reset();


### PR DESCRIPTION
## Summary
- run async op dispatches on the server compute pool when a server context is active, with bounded queue-full handling
- update /v1/runs snapshots to in_progress when async op and OpenAI-style runs start, so polling does not appear stuck at queued
- preserve op run created timestamps across queued/in_progress/terminal snapshots
- add a large-body /v1/delegate/aggregate regression test and link compute_pool into the HTTP unit test

## Validation
- make -C src build/obj/tests/unit-test-server-http -j"$(nproc)" && src/build/obj/tests/unit-test-server-http
- make -C src ../aimee-server -j"$(nproc)"