### PR TITLE
Add Codex OAuth delegate support

### DIFF
--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -372,6 +372,18 @@ binary on `PATH`.
       }
     },
     {
+      "name": "codex",
+      "provider": "chatgpt",
+      "endpoint": "https://chatgpt.com/backend-api/codex",
+      "model": "gpt-5.4",
+      "roles": ["code", "review", "explain", "refactor", "draft", "execute", "summarize", "format", "diagnose", "validate"],
+      "tier": 0,
+      "enabled": true,
+      "auth": {
+        "type": "codex-oauth"
+      }
+    },
+    {
       "name": "claude",
       "provider": "claude",
       "backend": "tmux-cli",

--- a/src/cmd_agent_setup.c
+++ b/src/cmd_agent_setup.c
@@ -107,6 +107,9 @@ static void setup_ensure_fallback(agent_config_t *cfg, const char *name)
 
 static const char *default_provider_cli_roles[] = {"code",     "review", "explain",
                                                    "refactor", "draft",  "execute"};
+static const char *codex_oauth_roles[] = {"code",     "review",  "explain",   "refactor",
+                                          "draft",    "execute", "summarize", "format",
+                                          "diagnose", "validate"};
 static const char *mistral_plan_roles[] = {"code",     "review",  "explain",   "refactor",
                                            "draft",    "execute", "summarize", "format",
                                            "diagnose", "validate"};
@@ -171,8 +174,10 @@ static void configure_tmux_cli_agent(agent_t *ag, const char *name, const char *
       snprintf(ag->roles[ag->role_count++], 32, "%s", default_provider_cli_roles[i]);
 }
 
-static void configure_direct_adapter_agent(agent_t *ag, const agent_adapter_t *adapter,
-                                           const char *name, int cost_tier, int timeout_ms)
+static void configure_direct_adapter_agent_with_roles(agent_t *ag, const agent_adapter_t *adapter,
+                                                      const char *name, int cost_tier,
+                                                      int timeout_ms, const char *const *roles,
+                                                      int role_count)
 {
    memset(ag, 0, sizeof(*ag));
    snprintf(ag->name, MAX_AGENT_NAME, "%s", name);
@@ -189,11 +194,16 @@ static void configure_direct_adapter_agent(agent_t *ag, const agent_adapter_t *a
    ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
 
    ag->role_count = 0;
-   for (int i = 0;
-        i < (int)(sizeof(default_provider_cli_roles) / sizeof(default_provider_cli_roles[0])) &&
-        ag->role_count < MAX_AGENT_ROLES;
-        i++)
-      snprintf(ag->roles[ag->role_count++], 32, "%s", default_provider_cli_roles[i]);
+   for (int i = 0; i < role_count && ag->role_count < MAX_AGENT_ROLES; i++)
+      snprintf(ag->roles[ag->role_count++], 32, "%s", roles[i]);
+}
+
+static void configure_direct_adapter_agent(agent_t *ag, const agent_adapter_t *adapter,
+                                           const char *name, int cost_tier, int timeout_ms)
+{
+   configure_direct_adapter_agent_with_roles(
+       ag, adapter, name, cost_tier, timeout_ms, default_provider_cli_roles,
+       (int)(sizeof(default_provider_cli_roles) / sizeof(default_provider_cli_roles[0])));
 }
 
 /* --- agent setup: codex-cli (legacy provider CLI) --- */
@@ -584,7 +594,9 @@ static void setup_codex_oauth(app_ctx_t *ctx, agent_config_t *cfg)
    const agent_adapter_t *adapter = agent_adapter_for_name("codex");
    if (!adapter)
       fatal("codex adapter is not registered");
-   configure_direct_adapter_agent(ag, adapter, "codex", 0, 600000);
+   configure_direct_adapter_agent_with_roles(
+       ag, adapter, "codex", 0, 600000, codex_oauth_roles,
+       (int)(sizeof(codex_oauth_roles) / sizeof(codex_oauth_roles[0])));
    if (chatgpt_account_id[0])
       snprintf(ag->extra_headers, sizeof(ag->extra_headers),
                "originator: codex_cli_rs\nChatGPT-Account-ID: %s", chatgpt_account_id);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1234,14 +1234,11 @@ int agent_is_exec_role(const agent_t *agent, const char *role)
 
 /* --- Auth resolution --- */
 
-static int agent_read_codex_oauth_token(char *token, size_t token_len)
+static int agent_read_codex_oauth_token_from_path(const char *path, char *token, size_t token_len)
 {
-   if (!token || token_len == 0)
+   if (!path || !path[0] || !token || token_len == 0)
       return -1;
    token[0] = '\0';
-
-   char path[MAX_PATH_LEN];
-   snprintf(path, sizeof(path), "%s/codex-auth.json", config_default_dir());
 
    FILE *f = fopen(path, "rb");
    if (!f)
@@ -1275,11 +1272,39 @@ static int agent_read_codex_oauth_token(char *token, size_t token_len)
       return -1;
 
    cJSON *access = cJSON_GetObjectItem(root, "access_token");
+   if (!access)
+   {
+      cJSON *tokens = cJSON_GetObjectItem(root, "tokens");
+      if (tokens && cJSON_IsObject(tokens))
+         access = cJSON_GetObjectItem(tokens, "access_token");
+   }
    if (access && cJSON_IsString(access) && access->valuestring[0])
       snprintf(token, token_len, "%s", access->valuestring);
    cJSON_Delete(root);
 
    return token[0] ? 0 : -1;
+}
+
+static int agent_read_codex_oauth_token(char *token, size_t token_len)
+{
+   if (!token || token_len == 0)
+      return -1;
+   token[0] = '\0';
+
+   char path[MAX_PATH_LEN];
+   snprintf(path, sizeof(path), "%s/codex-auth.json", config_default_dir());
+   if (agent_read_codex_oauth_token_from_path(path, token, token_len) == 0)
+      return 0;
+
+   const char *home = getenv("HOME");
+   if (home && home[0])
+   {
+      snprintf(path, sizeof(path), "%s/.codex/auth.json", home);
+      if (agent_read_codex_oauth_token_from_path(path, token, token_len) == 0)
+         return 0;
+   }
+
+   return -1;
 }
 
 int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -898,6 +898,9 @@ static void sagent_jwt_account_id(const char *jwt, char *buf, size_t buf_len)
 
 static const char *sagent_provider_cli_roles[] = {"code",     "review", "explain",
                                                   "refactor", "draft",  "execute"};
+static const char *sagent_codex_oauth_roles[] = {"code",     "review",  "explain",   "refactor",
+                                                 "draft",    "execute", "summarize", "format",
+                                                 "diagnose", "validate"};
 static const char *sagent_mistral_plan_roles[] = {"code",     "review",  "explain",   "refactor",
                                                   "draft",    "execute", "summarize", "format",
                                                   "diagnose", "validate"};
@@ -965,8 +968,10 @@ static void sagent_configure_tmux_cli_agent(agent_t *ag, const char *name, const
       snprintf(ag->roles[ag->role_count++], 32, "%s", sagent_provider_cli_roles[i]);
 }
 
-static void sagent_configure_direct_adapter_agent(agent_t *ag, const agent_adapter_t *adapter,
-                                                  const char *name, int cost_tier, int timeout_ms)
+static void
+sagent_configure_direct_adapter_agent_with_roles(agent_t *ag, const agent_adapter_t *adapter,
+                                                 const char *name, int cost_tier, int timeout_ms,
+                                                 const char *const *roles, int role_count)
 {
    memset(ag, 0, sizeof(*ag));
    snprintf(ag->name, MAX_AGENT_NAME, "%s", name);
@@ -983,11 +988,8 @@ static void sagent_configure_direct_adapter_agent(agent_t *ag, const agent_adapt
    ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
 
    ag->role_count = 0;
-   for (int i = 0;
-        i < (int)(sizeof(sagent_provider_cli_roles) / sizeof(sagent_provider_cli_roles[0])) &&
-        ag->role_count < MAX_AGENT_ROLES;
-        i++)
-      snprintf(ag->roles[ag->role_count++], 32, "%s", sagent_provider_cli_roles[i]);
+   for (int i = 0; i < role_count && ag->role_count < MAX_AGENT_ROLES; i++)
+      snprintf(ag->roles[ag->role_count++], 32, "%s", roles[i]);
 }
 
 static int sagent_setup_provider_cli(server_conn_t *conn, const char *provider)
@@ -1400,7 +1402,9 @@ int handle_agent_setup_poll(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const agent_adapter_t *adapter = agent_adapter_for_name("codex");
    if (!adapter)
       return server_send_error(conn, "codex adapter is not registered", NULL);
-   sagent_configure_direct_adapter_agent(ag, adapter, "codex", 0, 600000);
+   sagent_configure_direct_adapter_agent_with_roles(
+       ag, adapter, "codex", 0, 600000, sagent_codex_oauth_roles,
+       (int)(sizeof(sagent_codex_oauth_roles) / sizeof(sagent_codex_oauth_roles[0])));
    if (chatgpt_account_id[0])
       snprintf(ag->extra_headers, sizeof(ag->extra_headers),
                "originator: codex_cli_rs\nChatGPT-Account-ID: %s", chatgpt_account_id);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -632,6 +632,24 @@ static void test_codex_oauth_auth_resolution(void)
    char auth[MAX_API_KEY_LEN + 32];
    assert(agent_resolve_auth(&ag, auth, sizeof(auth)) == 0);
    assert(strcmp(auth, "Authorization: Bearer codex-test-token") == 0);
+
+   assert(unlink(path) == 0);
+   const char *home = getenv("HOME");
+   assert(home != NULL && home[0]);
+
+   char codex_dir[MAX_PATH_LEN];
+   snprintf(codex_dir, sizeof(codex_dir), "%s/.codex", home);
+   assert(platform_mkdir_p(codex_dir, 0700) == 0 || access(codex_dir, F_OK) == 0);
+
+   char codex_path[MAX_PATH_LEN];
+   snprintf(codex_path, sizeof(codex_path), "%s/auth.json", codex_dir);
+   f = fopen(codex_path, "w");
+   assert(f != NULL);
+   fputs("{\"tokens\":{\"access_token\":\"codex-cli-token\"}}\n", f);
+   fclose(f);
+
+   assert(agent_resolve_auth(&ag, auth, sizeof(auth)) == 0);
+   assert(strcmp(auth, "Authorization: Bearer codex-cli-token") == 0);
 }
 
 static void test_responses_parser_keeps_all_output_text_parts(void)


### PR DESCRIPTION
## Summary
- add Codex OAuth direct delegate setup with the standard code/review/summarize/diagnose/validate role set
- let Codex OAuth auth resolution read both Aimee's codex-auth.json and native Codex CLI ~/.codex/auth.json token shape
- document the representative Codex OAuth delegate config

## Validation
- make -C src ../aimee ../aimee-server build/obj/tests/unit-test-agent
- src/build/obj/tests/unit-test-agent
- installed rebuilt local thin client/server binaries for local validation
- direct Codex OAuth backend request using local Codex credentials returned 200 with expected response
- live connected delegate probes on configured remote: mistral and mimo2.5 passed execution; minimax3 reached models/slots but returned intermittent empty content on one run; codex on the remote still fails auth resolution because the CLI is routed to remote 192.168.1.254:8740, which does not have this patch deployed yet