### PR TITLE
Mark agent-directed PR review proposal done

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -281,14 +281,14 @@ Capability / coordination / research (P3):
   "participant" is the same default agent) — then generalizes it into a bounded
   multi-round roundtable: real participant routing, draft/review modes,
   deterministic convergence, keep-best, preflight cost limits. **Draft / Review / Reason. New.**
-- [Agent-Directed PR Review](proposals/pending/agent-directed-pr-review.md):
+- [Agent-Directed PR Review](proposals/done/agent-directed-pr-review.md):
   lets an agent call in the roundtable's review mode against a code change and
   direct it with a brief (focus areas, fixes made, invariants, questions), with
   an open mandate so direction reorders priority without suppressing findings.
   Adds an optional `brief` threaded through `build_round_prompt`, returns the
   structured review items (not just prose) plus answered questions, and exposes a
   `CAP_DELEGATE`-gated `ensemble_review` MCP tool. Strictly additive on the
-  roundtable. **Review / Reason. New.**
+  roundtable. **Review / Reason. Done.**
 - Composable Named Toolsets:
   one composable toolset object shared by roles, delegates, gateway
   channels, and the scripted-RPC allow-list. **Done.**

--- a/docs/proposals/done/agent-directed-pr-review.md
+++ b/docs/proposals/done/agent-directed-pr-review.md
@@ -1,6 +1,6 @@
 # Proposal: Agent-directed PR review (call in the ensemble with a brief)
 
-- **State:** draft, pending review
+- **State:** done
 - **Author:** JBailes
 - **Date:** 2026-06-09
 - **Charter roles:** Review (per-round critique and consolidation). Reason runs


### PR DESCRIPTION
## Summary
- Move the agent-directed PR review proposal from pending to done now that the implementation is present on testing
- Update docs/PROPOSALS.md to point at the completed proposal and mark it Done
- Add plugin route stubs to the server-dispatch unit-test support file so the current testing dispatch table links cleanly

## Verification
- ./src/build/obj/tests/unit-test-delegate-ensemble
- ./src/build/obj/tests/unit-test-server-http
- ./src/build/obj/tests/unit-test-server-dispatch
- ./src/build/obj/tests/unit-test-mcp-client-registry
- ./src/build/obj/tests/unit-test-cli-rpc-delegate
- make -C src proposal-links-check