### PR TITLE
Mark ingest restoration proposal done

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -14,7 +14,7 @@ directory listing:
 
 - [`proposals/accepted/`](proposals/accepted/): locked but not yet
   implemented
-- [`proposals/done/`](proposals/done/): shipped (310 proposals)
+- [`proposals/done/`](proposals/done/): shipped (311 proposals)
 - [`proposals/rejected/`](proposals/rejected/): considered and
   declined
 - [`proposals/deferred/`](proposals/deferred/): parked for later
@@ -95,6 +95,10 @@ recall.
   debug surface; quality / staging recommendations for the curator's
   release gate. **Accepted. Phase 0 shipped, `aimee kb lab` command with chunk preview,
   quality signals, and stage recommendations.**
+- Ingest Restoration and Bounded-Hallucination Recall Contract:
+  restoration-candidate queueing outside `kb_lab`, single-pass
+  curator fusion with provenance and `[unknown]`, and per-result
+  verbatim vs synthesised recall evidence mode. **Done.**
 - Approximate Sketches for Ingest Pre-Filtering:
   Bloom / MinHash-LSH / Count-Min / HyperLogLog layer between
   Normalize and dense recall; cheap dedupe, near-dup clustering,

--- a/docs/proposals/done/ingest-restoration-and-recall-contract.md
+++ b/docs/proposals/done/ingest-restoration-and-recall-contract.md
@@ -1,6 +1,6 @@
 # Proposal: ingest restoration + bounded-hallucination recall contract
 
-- **State:** draft — pending review
+- **State:** done
 - **Author:** JBailes
 - **Date:** 2026-06-08
 - **Charter role(s):** knowledge-base ingest + recall (kb-side intelligence


### PR DESCRIPTION
## Summary
- move ingest restoration + bounded-hallucination recall contract proposal from pending to done
- mark the proposal state as done
- update the proposal index count and evidence-pipeline entry

## Tests
- docs-only change; verified proposal file moved locally