### PR TITLE
Run CI for docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main, testing]
-    paths-ignore:
-      - 'docs/**'
-      - '**.md'
-      - 'aimee.workspace.yaml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary
- remove CI pull_request path ignores so required checks run for docs-only PRs
- prevents docs-only promotion PRs from being blocked by expected but skipped required checks

## Tests
- workflow-only change