### PR TITLE
Finish recall economy proposal

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -14,7 +14,7 @@ directory listing:
 
 - [`proposals/accepted/`](proposals/accepted/): locked but not yet
   implemented
-- [`proposals/done/`](proposals/done/): shipped (311 proposals)
+- [`proposals/done/`](proposals/done/): shipped (312 proposals)
 - [`proposals/rejected/`](proposals/rejected/): considered and
   declined
 - [`proposals/deferred/`](proposals/deferred/): parked for later
@@ -125,6 +125,10 @@ recall.
 
 ### Retrieval (Recall / Rerank / Rank-Fuse)
 
+- Recall Economy: Progressive Disclosure, Bounded Envelopes, and Learned Retrieval Shortcuts:
+  bounded ingress envelope assembly, memory previews with openable
+  pull-handles, retrieval shortcuts, intent annotation, and per-layer
+  transparency for token/quality attribution. **Done.**
 - Dynamic Alpha Fusion for KB Hybrid Retrieval:
   score-aware lexical / dense blending shipped as an opt-in fusion mode on
   `POST /v1/search`; benchmark gate did not justify a default flip, so `rrf`

--- a/docs/proposals/done/recall-economy-progressive-disclosure.md
+++ b/docs/proposals/done/recall-economy-progressive-disclosure.md
@@ -1,6 +1,6 @@
 # Proposal: Recall economy — progressive disclosure, bounded envelopes, and learned retrieval shortcuts
 
-- **State:** draft — pending review
+- **State:** done
 - **Author:** JBailes
 - **Date:** 2026-06-08
 - **Charter roles:** Recall, Rewrite (envelope assembly / compression),


### PR DESCRIPTION
## Summary
- move recall economy progressive disclosure proposal from pending to done
- mark the proposal state as done
- update the proposal index count and retrieval entry

## Tests
- docs-only change; verified proposal file moved locally