### PR TITLE
Finish recall economy shortcuts and intent paths

### DIFF
--- a/src/db2/kb_service_backend.h
+++ b/src/db2/kb_service_backend.h
@@ -278,6 +278,9 @@ extern "C"
    cJSON *db2_kb_service_memory_insert_json(const char *tier, const char *kind, const char *key,
                                             const char *content, double confidence,
                                             const char *session_id);
+   cJSON *db2_kb_service_memory_insert_ex_json(const char *tier, const char *kind, const char *key,
+                                               const char *content, const char *use_cases,
+                                               double confidence, const char *session_id);
    cJSON *db2_kb_service_memory_briefing_json(int limit_tokens);
    cJSON *db2_kb_service_memory_context_block_json(const char *query, const char *block_type,
                                                    int limit);

--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -41,6 +41,7 @@ static cJSON *kbs_memory_row_to_json(const memory_t *m)
       headline = summaries[0].summary;
    cJSON_AddStringToObject(obj, "headline", headline);
    cJSON_AddStringToObject(obj, "content", m->content);
+   cJSON_AddStringToObject(obj, "use_cases", m->use_cases);
    cJSON_AddNumberToObject(obj, "confidence", m->confidence);
    cJSON_AddNumberToObject(obj, "use_count", m->use_count);
    cJSON_AddStringToObject(obj, "last_used_at", m->last_used_at);
@@ -1159,13 +1160,22 @@ cJSON *db2_kb_service_memory_insert_json(const char *tier, const char *kind, con
                                          const char *content, double confidence,
                                          const char *session_id)
 {
+   return db2_kb_service_memory_insert_ex_json(tier, kind, key, content, "", confidence,
+                                               session_id);
+}
+
+cJSON *db2_kb_service_memory_insert_ex_json(const char *tier, const char *kind, const char *key,
+                                            const char *content, const char *use_cases,
+                                            double confidence, const char *session_id)
+{
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
       return NULL;
 
    memory_t out;
-   int rc = memory_insert(tier ? tier : "", kind ? kind : "", key ? key : "",
-                          content ? content : "", confidence, session_id ? session_id : "", &out);
+   int rc =
+       memory_insert_ex(tier ? tier : "", kind ? kind : "", key ? key : "", content ? content : "",
+                        use_cases ? use_cases : "", confidence, session_id ? session_id : "", &out);
    if (rc != 0)
    {
       cJSON_AddStringToObject(resp, "status", "error");

--- a/src/db2/memory_query.c
+++ b/src/db2/memory_query.c
@@ -1487,10 +1487,10 @@ int db2_memory_get(int64_t memory_id, memory_t *out)
    if (!conn)
       return -1;
 
-   static const char *sql =
-       "SELECT id, tier, kind, key, content, confidence, use_count,"
-       "       last_used_at, created_at, updated_at, source_session, salience, provenance_category"
-       "  FROM memories WHERE id = ?1";
+   static const char *sql = "SELECT id, tier, kind, key, content, confidence, use_count,"
+                            "       last_used_at, created_at, updated_at, source_session, salience,"
+                            "       provenance_category, use_cases"
+                            "  FROM memories WHERE id = ?1";
    char err[MQ_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)

--- a/src/db2/memory_query.h
+++ b/src/db2/memory_query.h
@@ -236,6 +236,10 @@ extern "C"
     * observation_count, evidence_strength, salience, surprise,
     * last_used_at, updated_at WHERE id = ?. Best-effort. Returns 0 on
     * success, -1 on SQL error. */
+   int db2_memory_merge_update_ex(int64_t memory_id, const char *content, const char *use_cases,
+                                  double confidence, int use_count, int observation_count,
+                                  double evidence_strength, double salience, double surprise,
+                                  const char *ts);
    int db2_memory_merge_update(int64_t memory_id, const char *content, double confidence,
                                int use_count, int observation_count, double evidence_strength,
                                double salience, double surprise, const char *ts);
@@ -245,6 +249,10 @@ extern "C"
     * confidence/sensitivity/evidence/salience/surprise. `ts` is used for
     * last_used_at, created_at, updated_at. Returns the new rowid on
     * success, -1 on SQL error. */
+   int64_t db2_memory_row_insert_ex(const char *tier, const char *kind, const char *key,
+                                    const char *content, const char *use_cases, double confidence,
+                                    const char *session_id, const char *ts, const char *sensitivity,
+                                    double evidence_strength, double salience, double surprise);
    int64_t db2_memory_row_insert(const char *tier, const char *kind, const char *key,
                                  const char *content, double confidence, const char *session_id,
                                  const char *ts, const char *sensitivity, double evidence_strength,
@@ -678,6 +686,10 @@ extern "C"
    /* Single-row SELECT into memory_t. Returns 0 on hit, -1 on miss. */
    int db2_memory_get(int64_t memory_id, memory_t *out);
 
+   int db2_retrieval_shortcut_lookup(const char *normalized_query, int64_t *ids, int max,
+                                     int *promoted_out, int64_t *hit_count_out);
+   int db2_retrieval_shortcut_observe(const char *normalized_query, const int64_t *ids, int count);
+
    /* DELETE FROM memory_provenance WHERE memory_id = ?. Best-effort. */
    void db2_memory_provenance_delete(int64_t memory_id);
 
@@ -896,12 +908,6 @@ extern "C"
     * limit <= 0 means unlimited (still capped by `max`). */
    int db2_memory_summaries_list(int64_t memory_id, int limit, db2_memory_summary_row_t *out,
                                  int max);
-
-   /* Shadow-mode learned retrieval shortcut observation. Records a normalized
-    * query and the ordered top memory ids produced by the normal blend. Stable
-    * repeated mappings are promoted in-store, but callers still run normal
-    * recall; consumers can use the table later to safely short-circuit. */
-   int db2_retrieval_shortcut_observe(const char *normalized_query, const int64_t *ids, int count);
 
    /* INSERT OR UPDATE memory_summaries(memory_id, scope, summary).
     * Empty `scope` defaults to "headline". Best-effort; no return. */

--- a/src/db2/memory_query_bookkeeping.c
+++ b/src/db2/memory_query_bookkeeping.c
@@ -274,6 +274,50 @@ int db2_retrieval_shortcut_observe(const char *normalized_query, const int64_t *
    return rc == AIMEE_PG_DONE ? 0 : -1;
 }
 
+int db2_retrieval_shortcut_lookup(const char *normalized_query, int64_t *ids, int max,
+                                  int *promoted_out, int64_t *hit_count_out)
+{
+   if (promoted_out)
+      *promoted_out = 0;
+   if (hit_count_out)
+      *hit_count_out = 0;
+   if (!normalized_query || !normalized_query[0] || !ids || max <= 0)
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+
+   static const char *sql = "SELECT target_ids, promoted, hit_count FROM retrieval_shortcuts WHERE "
+                            "normalized_query = ?1";
+   char err[MQB_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_text(st, "?1", normalized_query);
+   int n = 0;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *targets = aimee_pg_column_text(st, 0);
+      if (promoted_out)
+         *promoted_out = aimee_pg_column_int(st, 1);
+      if (hit_count_out)
+         *hit_count_out = aimee_pg_column_int64(st, 2);
+      const char *p = targets ? targets : "";
+      while (*p && n < max)
+      {
+         char *end = NULL;
+         long long id = strtoll(p, &end, 10);
+         if (end == p)
+            break;
+         if (id > 0)
+            ids[n++] = (int64_t)id;
+         p = (*end == ',') ? end + 1 : end;
+      }
+   }
+   aimee_pg_finalize(st);
+   return n;
+}
+
 int db2_memory_event_frames_list(int64_t memory_id, db2_memory_event_frame_row_t *out, int max)
 {
    if (memory_id <= 0 || !out || max <= 0)

--- a/src/db2/memory_row_mapper_pg.c
+++ b/src/db2/memory_row_mapper_pg.c
@@ -39,4 +39,9 @@ void db2_fill_memory_12col_pg(aimee_pg_stmt_t *stmt, memory_t *m)
    const char *pcat = aimee_pg_column_text(stmt, 12);
    snprintf(m->provenance_category, sizeof(m->provenance_category), "%s",
             pcat ? pcat : "user_stated");
+   if (aimee_pg_column_count(stmt) > 13)
+   {
+      const char *use_cases = aimee_pg_column_text(stmt, 13);
+      snprintf(m->use_cases, sizeof(m->use_cases), "%s", use_cases ? use_cases : "");
+   }
 }

--- a/src/db2/memory_score_fields.c
+++ b/src/db2/memory_score_fields.c
@@ -474,36 +474,46 @@ int db2_memory_lookup_merge_fields(const char *key, int64_t *id_out, char *conte
    return hit;
 }
 
-int db2_memory_merge_update(int64_t memory_id, const char *content, double confidence,
-                            int use_count, int observation_count, double evidence_strength,
-                            double salience, double surprise, const char *ts)
+int db2_memory_merge_update_ex(int64_t memory_id, const char *content, const char *use_cases,
+                               double confidence, int use_count, int observation_count,
+                               double evidence_strength, double salience, double surprise,
+                               const char *ts)
 {
    if (memory_id <= 0 || !content || !ts)
       return -1;
    void *conn = db2_conn();
    if (!conn)
       return -1;
-   static const char *sql = "UPDATE memories SET content = ?1, confidence = ?2,"
-                            " use_count = ?3, observation_count = ?4, evidence_strength = ?5,"
-                            " salience = ?6, surprise = ?7, last_used_at = ?8, updated_at = ?9"
-                            " WHERE id = ?10";
+   static const char *sql = "UPDATE memories SET content = ?1, use_cases = ?2, confidence = ?3,"
+                            " use_count = ?4, observation_count = ?5, evidence_strength = ?6,"
+                            " salience = ?7, surprise = ?8, last_used_at = ?9, updated_at = ?10"
+                            " WHERE id = ?11";
    char err[MSF_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
       return -1;
    aimee_pg_bind_text(st, "?1", content);
-   aimee_pg_bind_double(st, "?2", confidence);
-   aimee_pg_bind_int(st, "?3", use_count);
-   aimee_pg_bind_int(st, "?4", observation_count);
-   aimee_pg_bind_double(st, "?5", evidence_strength);
-   aimee_pg_bind_double(st, "?6", salience);
-   aimee_pg_bind_double(st, "?7", surprise);
-   aimee_pg_bind_text(st, "?8", ts);
+   aimee_pg_bind_text(st, "?2", use_cases ? use_cases : "");
+   aimee_pg_bind_double(st, "?3", confidence);
+   aimee_pg_bind_int(st, "?4", use_count);
+   aimee_pg_bind_int(st, "?5", observation_count);
+   aimee_pg_bind_double(st, "?6", evidence_strength);
+   aimee_pg_bind_double(st, "?7", salience);
+   aimee_pg_bind_double(st, "?8", surprise);
    aimee_pg_bind_text(st, "?9", ts);
-   aimee_pg_bind_int64(st, "?10", memory_id);
+   aimee_pg_bind_text(st, "?10", ts);
+   aimee_pg_bind_int64(st, "?11", memory_id);
    int rc = aimee_pg_step(st, err, sizeof(err));
    aimee_pg_finalize(st);
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+int db2_memory_merge_update(int64_t memory_id, const char *content, double confidence,
+                            int use_count, int observation_count, double evidence_strength,
+                            double salience, double surprise, const char *ts)
+{
+   return db2_memory_merge_update_ex(memory_id, content, "", confidence, use_count,
+                                     observation_count, evidence_strength, salience, surprise, ts);
 }
 
 int db2_memory_active_kind_dedupe_candidates(const char *kind, db2_memory_dedupe_candidate_t *out,
@@ -542,10 +552,10 @@ int db2_memory_active_kind_dedupe_candidates(const char *kind, db2_memory_dedupe
    return n;
 }
 
-int64_t db2_memory_row_insert(const char *tier, const char *kind, const char *key,
-                              const char *content, double confidence, const char *session_id,
-                              const char *ts, const char *sensitivity, double evidence_strength,
-                              double salience, double surprise)
+int64_t db2_memory_row_insert_ex(const char *tier, const char *kind, const char *key,
+                                 const char *content, const char *use_cases, double confidence,
+                                 const char *session_id, const char *ts, const char *sensitivity,
+                                 double evidence_strength, double salience, double surprise)
 {
    if (!tier || !kind || !key || !ts)
       return -1;
@@ -554,10 +564,10 @@ int64_t db2_memory_row_insert(const char *tier, const char *kind, const char *ke
       return -1;
    /* Postgres replaces sqlite's last_insert_rowid() with INSERT ... RETURNING id. */
    static const char *sql =
-       "INSERT INTO memories (tier, kind, key, content, confidence,"
+       "INSERT INTO memories (tier, kind, key, content, use_cases, confidence,"
        " use_count, last_used_at, source_session, created_at,"
        " updated_at, sensitivity, evidence_strength, salience, surprise, observation_count)"
-       " VALUES (?1, ?2, ?3, ?4, ?5, 1, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 1)"
+       " VALUES (?1, ?2, ?3, ?4, ?5, ?6, 1, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, 1)"
        " RETURNING id";
    char err[MSF_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
@@ -567,20 +577,30 @@ int64_t db2_memory_row_insert(const char *tier, const char *kind, const char *ke
    aimee_pg_bind_text(st, "?2", kind);
    aimee_pg_bind_text(st, "?3", key);
    aimee_pg_bind_text(st, "?4", content ? content : "");
-   aimee_pg_bind_double(st, "?5", confidence);
-   aimee_pg_bind_text(st, "?6", ts);
-   aimee_pg_bind_text(st, "?7", session_id ? session_id : "");
-   aimee_pg_bind_text(st, "?8", ts);
+   aimee_pg_bind_text(st, "?5", use_cases ? use_cases : "");
+   aimee_pg_bind_double(st, "?6", confidence);
+   aimee_pg_bind_text(st, "?7", ts);
+   aimee_pg_bind_text(st, "?8", session_id ? session_id : "");
    aimee_pg_bind_text(st, "?9", ts);
-   aimee_pg_bind_text(st, "?10", sensitivity ? sensitivity : "");
-   aimee_pg_bind_double(st, "?11", evidence_strength);
-   aimee_pg_bind_double(st, "?12", salience);
-   aimee_pg_bind_double(st, "?13", surprise);
+   aimee_pg_bind_text(st, "?10", ts);
+   aimee_pg_bind_text(st, "?11", sensitivity ? sensitivity : "");
+   aimee_pg_bind_double(st, "?12", evidence_strength);
+   aimee_pg_bind_double(st, "?13", salience);
+   aimee_pg_bind_double(st, "?14", surprise);
    int64_t new_id = -1;
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
       new_id = aimee_pg_column_int64(st, 0);
    aimee_pg_finalize(st);
    return new_id;
+}
+
+int64_t db2_memory_row_insert(const char *tier, const char *kind, const char *key,
+                              const char *content, double confidence, const char *session_id,
+                              const char *ts, const char *sensitivity, double evidence_strength,
+                              double salience, double surprise)
+{
+   return db2_memory_row_insert_ex(tier, kind, key, content, "", confidence, session_id, ts,
+                                   sensitivity, evidence_strength, salience, surprise);
 }
 
 int db2_memory_count_versions(const char *key_prefix)

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -692,6 +692,9 @@ int kb_client_memory_get(int64_t id, memory_t *out);
 int kb_client_memory_insert(const char *tier, const char *kind, const char *key,
                             const char *content, double confidence, const char *session_id,
                             memory_t *out);
+int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *key,
+                               const char *content, const char *use_cases, double confidence,
+                               const char *session_id, memory_t *out);
 
 /* Look up a memory id by (key, kind) via aimee-kb.  Returns 0 if no
  * row matches or kb is unreachable; the row id otherwise.  Mirrors

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -9,6 +9,7 @@ typedef struct
    char key[512];
    char headline[512];
    char content[2048];
+   char use_cases[1024];
    double confidence;
    int use_count;
    char last_used_at[32];
@@ -29,6 +30,7 @@ typedef struct
    char kind[16];
    char key[512];
    char content[2048];
+   char use_cases[1024];
 } memory_ranker_input_t;
 
 typedef struct
@@ -302,6 +304,9 @@ int memory_approve_l4_promotion(int64_t memory_id, const char *approver, const c
 /* --- Tiered Memory --- */
 int memory_insert(const char *tier, const char *kind, const char *key, const char *content,
                   double confidence, const char *session_id, memory_t *out);
+int memory_insert_ex(const char *tier, const char *kind, const char *key, const char *content,
+                     const char *use_cases, double confidence, const char *session_id,
+                     memory_t *out);
 int memory_get(int64_t id, memory_t *out);
 int memory_touch(int64_t id);
 int memory_update_content(int64_t id, const char *content);

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -1042,12 +1042,14 @@ int kb_handle_memory_store(int fd, cJSON *req)
    cJSON *kind_j = cJSON_GetObjectItemCaseSensitive(req, "kind");
    cJSON *conf_j = cJSON_GetObjectItemCaseSensitive(req, "confidence");
    cJSON *sid_j = cJSON_GetObjectItemCaseSensitive(req, "session_id");
+   cJSON *use_cases_j = cJSON_GetObjectItemCaseSensitive(req, "use_cases");
    const char *tier = cJSON_IsString(tier_j) ? tier_j->valuestring : TIER_L0;
    const char *kind = cJSON_IsString(kind_j) ? kind_j->valuestring : KIND_FACT;
    double confidence = cJSON_IsNumber(conf_j) ? conf_j->valuedouble : 1.0;
    const char *session_id = cJSON_IsString(sid_j) ? sid_j->valuestring : "";
+   const char *use_cases = cJSON_IsString(use_cases_j) ? use_cases_j->valuestring : "";
 
-   cJSON *resp = db2_kb_service_memory_insert_json(tier, kind, key_j->valuestring,
-                                                   content_j->valuestring, confidence, session_id);
+   cJSON *resp = db2_kb_service_memory_insert_ex_json(
+       tier, kind, key_j->valuestring, content_j->valuestring, use_cases, confidence, session_id);
    return kb_reply_or_error(fd, resp, "failed to store memory");
 }

--- a/src/memory_core.c
+++ b/src/memory_core.c
@@ -189,10 +189,18 @@ void memory_query_rewrite(const char *query, const config_t *cfg, memory_query_r
 int memory_insert(const char *tier, const char *kind, const char *key, const char *content,
                   double confidence, const char *session_id, memory_t *out)
 {
+   return memory_insert_ex(tier, kind, key, content, "", confidence, session_id, out);
+}
+
+int memory_insert_ex(const char *tier, const char *kind, const char *key, const char *content,
+                     const char *use_cases, double confidence, const char *session_id,
+                     memory_t *out)
+{
    (void)tier;
    (void)kind;
    (void)key;
    (void)content;
+   (void)use_cases;
    (void)confidence;
    (void)session_id;
    if (out)

--- a/src/memory_core_crud.inc
+++ b/src/memory_core_crud.inc
@@ -129,8 +129,9 @@ static int memory_semantic_value_equivalent(const char *a, const char *b)
    return trigram_similarity(norm_a, norm_b) >= 0.92;
 }
 
-int memory_insert(const char *tier, const char *kind, const char *key, const char *content,
-                  double confidence, const char *session_id, memory_t *out)
+int memory_insert_ex(const char *tier, const char *kind, const char *key, const char *content,
+                     const char *use_cases, double confidence, const char *session_id,
+                     memory_t *out)
 {
    if (!tier || !kind || !key)
       return -1;
@@ -266,9 +267,9 @@ int memory_insert(const char *tier, const char *kind, const char *key, const cha
          if (old_surprise > new_surprise)
             new_surprise = old_surprise;
 
-         if (db2_memory_merge_update(existing_id, merged_content ? merged_content : content,
-                                     new_conf, new_use, new_obs, new_evidence,
-                                     memory_content_salience(content), new_surprise, ts) != 0)
+         if (db2_memory_merge_update_ex(existing_id, merged_content ? merged_content : content,
+                                        use_cases, new_conf, new_use, new_obs, new_evidence,
+                                        memory_content_salience(content), new_surprise, ts) != 0)
             return -1;
 
          memory_refresh_derived_metadata(
@@ -341,8 +342,9 @@ int memory_insert(const char *tier, const char *kind, const char *key, const cha
          if (dup_surprise > new_surprise)
             new_surprise = dup_surprise;
 
-         if (db2_memory_merge_update(dup_id, content, new_conf, new_use, new_obs, new_evidence,
-                                     memory_content_salience(content), new_surprise, ts) != 0)
+         if (db2_memory_merge_update_ex(dup_id, content, use_cases, new_conf, new_use, new_obs,
+                                        new_evidence, memory_content_salience(content),
+                                        new_surprise, ts) != 0)
             return -1;
 
          memory_refresh_derived_metadata(dup_id, norm_key, content ? content : "");
@@ -366,8 +368,8 @@ int memory_insert(const char *tier, const char *kind, const char *key, const cha
 
    /* Truly new: INSERT */
    {
-      int64_t new_id = db2_memory_row_insert(
-          tier, kind, norm_key, content, confidence, session_id, ts, sensitivity,
+      int64_t new_id = db2_memory_row_insert_ex(
+          tier, kind, norm_key, content, use_cases, confidence, session_id, ts, sensitivity,
           memory_base_evidence_strength(norm_key, content, confidence),
           memory_content_salience(content), memory_content_surprise(session_id, content));
       if (new_id < 0)
@@ -397,6 +399,12 @@ int memory_insert(const char *tier, const char *kind, const char *key, const cha
          memory_maybe_run_maintenance();
       return 0;
    }
+}
+
+int memory_insert(const char *tier, const char *kind, const char *key, const char *content,
+                  double confidence, const char *session_id, memory_t *out)
+{
+   return memory_insert_ex(tier, kind, key, content, "", confidence, session_id, out);
 }
 
 int memory_get(int64_t id, memory_t *out)

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -1935,6 +1935,7 @@ static memory_ranker_input_t memory_ranker_input_from(const memory_t *m)
    snprintf(r.kind, sizeof(r.kind), "%s", m->kind);
    snprintf(r.key, sizeof(r.key), "%s", m->key);
    snprintf(r.content, sizeof(r.content), "%s", m->content);
+   snprintf(r.use_cases, sizeof(r.use_cases), "%s", m->use_cases);
    return r;
 }
 
@@ -1951,6 +1952,7 @@ static void memory_compute_score_parts(const char *raw_query, const char *norm_q
    char qtokens[32][64];
    char norm_key[sizeof(m->key)];
    char norm_content[sizeof(m->content)];
+   char norm_use_cases[sizeof(m->use_cases)];
    int nq = memory_split_tokens(norm_query, qtokens, 32);
    if (nq <= 0)
       return;
@@ -1959,13 +1961,15 @@ static void memory_compute_score_parts(const char *raw_query, const char *norm_q
    memory_query_intent_t intent = memory_query_intent(raw_query, norm_query);
    normalize_key(m->key, norm_key, sizeof(norm_key));
    normalize_key(m->content, norm_content, sizeof(norm_content));
+   normalize_key(m->use_cases, norm_use_cases, sizeof(norm_use_cases));
 
    int matched = 0;
    for (int i = 0; i < nq; i++)
    {
       int in_key = memory_token_in_norm(norm_key, qtokens[i]);
       int in_content = memory_token_in_norm(norm_content, qtokens[i]);
-      if (in_key || in_content)
+      int in_use_cases = memory_token_in_norm(norm_use_cases, qtokens[i]);
+      if (in_key || in_content || in_use_cases)
       {
          double v = in_key ? w.lexical_key : w.lexical_content;
          size_t len = strlen(qtokens[i]);
@@ -4441,6 +4445,22 @@ int memory_diagnose_scoped(const char *query, const char *scope_type, const char
    if (!query || !query[0] || !out || max <= 0)
       return 0;
 
+   char norm_query[512];
+   normalize_key(query, norm_query, sizeof(norm_query));
+   if (!norm_query[0])
+      snprintf(norm_query, sizeof(norm_query), "%s", query);
+
+   int64_t shortcut_ids[8];
+   int shortcut_promoted = 0;
+   int shortcut_n =
+       db2_retrieval_shortcut_lookup(norm_query, shortcut_ids, 8, &shortcut_promoted, NULL);
+   memory_t shortcut_matches[8];
+   int shortcut_match_n = 0;
+   if (shortcut_n > 0)
+      for (int i = 0; i < shortcut_n && shortcut_match_n < 8; i++)
+         if (db2_memory_get(shortcut_ids[i], &shortcut_matches[shortcut_match_n]) == 0)
+            shortcut_match_n++;
+
    memory_t matches[64];
    int count = memory_find_facts_scoped(query, scope_type, scope_value, limit > 0 ? limit : 10,
                                         matches, 64);
@@ -4458,11 +4478,6 @@ int memory_diagnose_scoped(const char *query, const char *scope_type, const char
    if (memory_collect_semantic_matches(query, embed_cmd, 32, matches, count, 64, semantic_ids,
                                        semantic_scores, &semantic_hit_count, 128) < 0)
       return -1;
-
-   char norm_query[512];
-   normalize_key(query, norm_query, sizeof(norm_query));
-   if (!norm_query[0])
-      snprintf(norm_query, sizeof(norm_query), "%s", query);
 
    memory_pagerank_config_t pagerank_cfg;
    memory_pagerank_score_t pagerank_scores[64];
@@ -4485,6 +4500,20 @@ int memory_diagnose_scoped(const char *query, const char *scope_type, const char
       for (int i = 0; i < shortcut_n; i++)
          shortcut_ids[i] = out[i].memory.id;
       (void)db2_retrieval_shortcut_observe(norm_query, shortcut_ids, shortcut_n);
+   }
+   if (shortcut_promoted && shortcut_match_n > 0)
+   {
+      int promoted_count = shortcut_match_n < max ? shortcut_match_n : max;
+      for (int i = 0; i < promoted_count; i++)
+      {
+         out[i].memory = shortcut_matches[i];
+         memory_ranker_input_t ri = memory_ranker_input_from(&shortcut_matches[i]);
+         memory_compute_score_parts(query, norm_query, &ri, semantic_ids, semantic_scores,
+                                    semantic_hit_count, pagerank_scores, pagerank_count,
+                                    &out[i].parts);
+         out[i].parts.confidence = shortcut_matches[i].confidence;
+      }
+      return promoted_count;
    }
    return count;
 }

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -33,6 +33,7 @@ void kbc_memory_row_from_json(cJSON *f, memory_t *m)
    cJSON *key_j = cJSON_GetObjectItemCaseSensitive(f, "key");
    cJSON *headline_j = cJSON_GetObjectItemCaseSensitive(f, "headline");
    cJSON *content_j = cJSON_GetObjectItemCaseSensitive(f, "content");
+   cJSON *use_cases_j = cJSON_GetObjectItemCaseSensitive(f, "use_cases");
    cJSON *conf_j = cJSON_GetObjectItemCaseSensitive(f, "confidence");
    cJSON *uses_j = cJSON_GetObjectItemCaseSensitive(f, "use_count");
    cJSON *last_j = cJSON_GetObjectItemCaseSensitive(f, "last_used_at");
@@ -51,6 +52,8 @@ void kbc_memory_row_from_json(cJSON *f, memory_t *m)
       snprintf(m->headline, sizeof(m->headline), "%s", headline_j->valuestring);
    if (cJSON_IsString(content_j))
       snprintf(m->content, sizeof(m->content), "%s", content_j->valuestring);
+   if (cJSON_IsString(use_cases_j))
+      snprintf(m->use_cases, sizeof(m->use_cases), "%s", use_cases_j->valuestring);
    if (cJSON_IsNumber(conf_j))
       m->confidence = conf_j->valuedouble;
    if (cJSON_IsNumber(uses_j))

--- a/src/server/kb_client_memory_mutations.c
+++ b/src/server/kb_client_memory_mutations.c
@@ -275,6 +275,13 @@ int kb_client_memory_insert(const char *tier, const char *kind, const char *key,
                             const char *content, double confidence, const char *session_id,
                             memory_t *out)
 {
+   return kb_client_memory_insert_ex(tier, kind, key, content, "", confidence, session_id, out);
+}
+
+int kb_client_memory_insert_ex(const char *tier, const char *kind, const char *key,
+                               const char *content, const char *use_cases, double confidence,
+                               const char *session_id, memory_t *out)
+{
    if (!key || !content)
       return -1;
 
@@ -285,6 +292,8 @@ int kb_client_memory_insert(const char *tier, const char *kind, const char *key,
       cJSON_AddStringToObject(req, "kind", kind);
    cJSON_AddStringToObject(req, "key", key);
    cJSON_AddStringToObject(req, "content", content);
+   if (use_cases && use_cases[0])
+      cJSON_AddStringToObject(req, "use_cases", use_cases);
    cJSON_AddNumberToObject(req, "confidence", confidence);
    if (session_id && session_id[0])
       cJSON_AddStringToObject(req, "session_id", session_id);


### PR DESCRIPTION
## Summary
- consult promoted recall shortcuts before returning diagnostics while still running the normal blend path for shadow validation
- hydrate shortcut targets into previews and score promoted shortcut results before returning them
- persist and transport memory use_cases through DB rows, KB JSON, client/store APIs, and additive recall scoring

## Tests
- make -C src build/obj/tests/unit-test-ingress-preinject && src/build/obj/tests/unit-test-ingress-preinject
- make -C src build/obj/tests/unit-test-mcp-client-registry && src/build/obj/tests/unit-test-mcp-client-registry
- make -C src build/obj/tests/unit-test-server-dispatch && src/build/obj/tests/unit-test-server-dispatch
- make -C src server
- make -C src lint