### PR TITLE
Complete done proposal audit follow-ups

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -279,12 +279,13 @@ Capability / coordination / research (P3):
   `POST /v1/delegate/aggregate` entry point and per-task agent routing (plus the
   temperature/`srand`/clone fixes). The original done-proposal file is absent from
   this tree; the analysis lives in the Agent Roundtable proposal below._
-- [Agent Roundtable — Round-Robin Collaborative Drafting and Review](proposals/pending/agent-roundtable-collaborative-drafting.md):
+- [Agent Roundtable — Round-Robin Collaborative Drafting and Review](proposals/done/agent-roundtable-collaborative-drafting.md):
   first makes the shipped-but-dead ensemble actually work — wires an entry point
   (no shipped binary calls it today) and fixes the unrouted-references bug (every
   "participant" is the same default agent) — then generalizes it into a bounded
   multi-round roundtable: real participant routing, draft/review modes,
-  deterministic convergence, keep-best, preflight cost limits. **Draft / Review / Reason. New.**
+  deterministic convergence, keep-best, preflight cost limits.
+  **Draft / Review / Reason. Done.**
 - [Agent-Directed PR Review](proposals/done/agent-directed-pr-review.md):
   lets an agent call in the roundtable's review mode against a code change and
   direct it with a brief (focus areas, fixes made, invariants, questions), with

--- a/docs/proposals/done/ingest-restoration-and-recall-contract.md
+++ b/docs/proposals/done/ingest-restoration-and-recall-contract.md
@@ -1,192 +1,50 @@
-# Proposal: ingest restoration + bounded-hallucination recall contract
+# Proposal: ingest restoration and recall contract
 
 - **State:** done
+- **Completed:** 2026-06-09
 - **Author:** JBailes
 - **Date:** 2026-06-08
-- **Charter role(s):** knowledge-base ingest + recall (kb-side intelligence
-  pass; reuses the existing curator synthesis path and artifact provenance —
-  no new store, no new DB tier).
-- **Scope:** `src/kb/kb_lab.c` + `src/headers/kb_lab.h` (turn the terminal
-  `REJECT`/`REVIEW_NEEDED` stages into restoration candidates), corpus staging /
-  job code around `docs` + `corpus_processing_jobs` (the queue lives there, not
-  inside the standalone lab), `src/kb/kb_curator_synthesize.c`
-  (restoration-biased fusion of a fragment against its nearest complete
-  neighbour, with provenance), `artifact_citations` / `artifact_links` /
-  `audit_events` (auditable provenance), `src/memory_graph_fusion.c` +
-  `src/kb/kb.c` (recall contract: tag each result verbatim vs synthesised), unit
-  tests, docs. No new long-lived service.
+- **Charter role(s):** knowledge-base ingest, Synthesize, Recall
 
-## Summary
+## Shipped work
 
-Two ideas, treated here as general concepts (independent of any particular
-typed-particle or "self-repairing index" framing they sometimes carry):
+This proposal is complete. Damaged-ingest restoration now has a concrete
+default-off queue and provenance contract, and recall answers expose whether
+their evidence is stored verbatim or synthesised.
 
-1. **Damage-as-catalyst ingest.** aimee's ingest lab already *detects* damaged
-   documents, but its verdict is advisory — nothing repairs them, so damaged
-   content is dropped or flagged. Route it instead into a restoration queue that
-   fuses each fragment against its nearest complete neighbour to mint a repaired,
-   provenance-tracked document.
-2. **Bounded-hallucination recall contract.** aimee has **no extractive
-   guarantee** today. Tag each recall result as **verbatim** (stored text, zero
-   synthesis) or **synthesised** (with a confidence and citations), and mark
-   genuine gaps `[unknown]` rather than fabricate.
+Implemented behavior:
 
-```
-  ingest ──▶ kb_lab quality audit ──▶ READY ───────────────────▶ index
-                     │              REVIEW_NEEDED / REJECT
-                     │                     │   (today: dropped/flagged)
-                     ▼                     ▼   (proposed: restoration job)
-            heuristic completeness  fuse fragment × nearest complete
-            signal (free, no LLM)   neighbour under restoration guardrail
-                                    ──▶ mint repaired artifact + provenance
-                                                │
-  recall ◀── verbatim | synthesised(conf) ◀─────┘   (bounded-hallucination tag)
-```
+- `kb_lab` remains a standalone read-only detector; restoration queueing lives in
+  the corpus/job layer.
+- `db2_corpus_job_mark_restoration_candidate` records a
+  `restoration_candidate` stage event and moves the document to
+  `stage='restore'`, `stage_status='pending'`.
+- The corpus stage runner treats `restore` as a queued/external stage rather
+  than trying to repair content inside `kb_lab`.
+- `kb_curator_restore_fragment_record` persists a single-pass `restoration`
+  artifact with `evidence_mode: "synthesised"`.
+- Restored artifacts cite the source document and optional base artifact, link
+  `restored_from` / `restores`, and write an `audit_events` row for
+  `corpus.restore`.
+- The restoration payload records the prompt version, fragment id, confidence,
+  and `[unknown]` sentinel status so gaps are explicit instead of fabricated.
+- `memory.ask` results now include `evidence_mode`, defaulting normal stored hits
+  to `verbatim` and marking L5/synthesis/restoration provenance as
+  `synthesised`.
+- The KB RPC, server client parser, and MCP structured `memory_ask` response
+  carry the evidence mode.
 
-## Motivation
+## Verification evidence
 
-What aimee already has (verified):
-
-- `kb_lab.c` **detects** damage — `FLAT_TEXT`, `OVERSIZED_CHUNK`,
-  `UNDERSIZED_CHUNKS`, `BINARY_NOISE`, `EMPTY_FILE`, `TABLE_SPLIT` — and sorts
-  docs into `READY` / `REVIEW_NEEDED` / `REJECT` (`kb_lab.c:246,575,658`). The
-  damaged stages are a **dead end**.
-- The deep curator already does **LLM-mediated synthesis with provenance +
-  citations** (`kb_curator_synthesize.c:198`, `kb_curator_promote.c:186`), over
-  typed artifacts (`entity` / `summary` / `relation` / `fact` / `claim` /
-  `narrative`).
-- Artifact citations and links already provide better provenance primitives
-  than graph endpoint fields; fusion recall merges lexical + vector hits
-  (`kb.c:1348+`, `memory_graph_fusion.c`).
-
-Important implementation detail: `kb_lab` is currently a **standalone read-only
-surface**. It reads a path and emits a report; it has no DB access and should
-stay that way. Restoration queueing belongs in the corpus/job layer (`docs`,
-`corpus_processing_jobs`, and `corpus_stage_events`) after a lab report has been
-attached to a staged document.
-
-Also, not every named signal is terminal today. `BINARY_NOISE` and `EMPTY_FILE`
-reject; `LONG_LINES`, `OVERSIZED_CHUNK`, `HEADING_SKIP`, and `TABLE_SPLIT` mark
-review; `FLAT_TEXT` and `UNDERSIZED_CHUNKS` are recorded but do **not** currently
-move the stage out of `READY`. If the MVP starts with `UNDERSIZED_CHUNKS` /
-`FLAT_TEXT`, it must explicitly change stage policy or introduce a separate
-`restoration_candidate` classification independent of stage.
-
-What is missing — and what damaged-record retrieval techniques highlight:
-
-- The detector and the synthesiser are **joined nowhere**: a damaged doc is
-  rejected rather than repaired. (Note: `memory repair` (`kb_service.c:183`) is
-  *index* repair — re-embedding failed vectors — **not** content restoration.)
-- There is **no verbatim/extractive contract** at recall time — "hallucination"
-  appears in the codebase only as a dogfood *outcome label* (`cmd_dogfood.c`),
-  never as a per-result guarantee.
-
-## Design
-
-### Part 1 — restoration path
-
-1. **Heuristic completeness signal, not per-chunk LLM.** Some techniques call the
-   LLM to classify *every* chunk; aimee's `kb_lab` already produces completeness
-   signals **for free**. Reuse them — do not pay per-chunk LLM cost. Completeness
-   is an **orthogonal flag on existing artifacts**, not a new type system.
-2. **Restoration queue outside `kb_lab`.** `kb_lab` emits a report. The ingest
-   pipeline persists the decision and enqueues a `corpus_processing_jobs` row
-   such as `stage='restore'`, `stage_status='pending'`, with the source doc id,
-   content hash, strategy, and signal set in the job detail/event payload.
-3. **Fusion.** For each fragment, find its nearest complete neighbour by cosine
-   similarity (embeddings already exist) and fuse via the curator synthesis path
-   under a **restoration-biased prompt**: preserve every noun, number, and
-   relationship from the source; mark genuine gaps `[unknown]`; never invent.
-   Mint a repaired artifact/document with explicit provenance:
-   `artifact_citations` for fragment/base inputs, `artifact_links` with a
-   dedicated kind such as `restores` / `restored_from`, and an `audit_events` row
-   recording source doc id, base doc id, prompt version, model version, and
-   confidence.
-4. **Bounded, gated, idempotent.** Single fusion pass by default (not multi-pass
-   re-fusion, which compounds drift and cost); re-runs must be idempotent. Use a
-   deterministic idempotency key such as `restore:<fragment_hash>:<base_id>:<prompt_version>`
-   so retries do not mint duplicate restored artifacts.
-
-### Part 2 — bounded-hallucination recall contract
-
-1. **Per-result provenance tag.** Every recall result is tagged **verbatim**
-   (returned from stored text, no synthesis) or **synthesised** (fused from
-   fragments, with confidence + citations). The curator's citation infra is
-   already most of the way there.
-2. **Extractive guarantee.** A high-confidence stored hit is returned verbatim —
-   no LLM rewrite — so the caller can trust it as ground truth.
-3. **`[unknown]` sentinel.** Adopt it in the curator synthesis/extraction prompts
-   to suppress fabrication during fusion. Treat this as a prompt/schema change,
-   not just a string tweak: version the prompt, require parseable output, and
-   test that missing slots remain `[unknown]`.
-4. **Provenance-constrained traversal (refinement).** When answering from a
-   synthesised node, bias graph hops along **provenance edges** (the docs that
-   produced the node) rather than global k-NN over noisy rows. aimee already has
-   fusion recall + provenance edges, so this is a testable refinement, not a
-   rebuild.
-
-### What this deliberately does **not** adopt
-
-- Elaborate typed-particle "algebras" / physics branding — dressing. aimee's
-  `entity/summary/relation/fact/claim/narrative` typing is richer; add
-  completeness as a flag, not a new type system.
-- **LLM-classify-every-chunk** — `kb_lab` gives completeness heuristically.
-- Importing any prototype as a dependency — aimee already exceeds the retrieval
-  sophistication (vector + graph + fusion + curator) of the demos these ideas
-  come from.
-
-## Safety (and the bridge to the optimisation surface)
-
-Self-repair via LLM fusion is **expensive and drift-prone**, and prototype
-implementations of it typically ship with **zero guardrails**. aimee has them:
-gate every restoration pass behind the benchmark suite + `baseline.json`
-regression gate once the benchmark runner supports this suite, track regressions
-via `memory_hard_negative_log`, and bound synthesis confidence with calibration
-credible intervals. aimee is therefore **better positioned to do this safely**
-than the demo-grade sources of the idea.
-
-The two new thresholds this introduces —
-
-- **repair-vs-reject** (when is a damaged doc worth restoring vs dropping?), and
-- **verbatim-vs-synthesize** (confidence cutoff for the extractive guarantee) —
-
-are exactly the kind of surface the companion proposal,
-[optimization-surface.md](optimization-surface.md), tunes. Register both as
-bandit **decision points** there. The two proposals compose: this one supplies
-*new things to optimise*; that one supplies the *loop that tunes them safely*.
-
-## MVP
-
-1. Persist lab reports and create a separate restoration-candidate decision in
-   the corpus/job layer; keep `kb_lab` read-only.
-2. Start with one signal family whose current stage semantics are unambiguous,
-   or explicitly update `FLAT_TEXT` / `UNDERSIZED_CHUNKS` stage policy before
-   using them as MVP inputs.
-3. Single-pass curator fusion against nearest complete neighbour, with
-   `artifact_citations`, `artifact_links`, `audit_events`, idempotency key, and
-   `[unknown]` sentinel.
-4. `kb.search` JSON returns `evidence_mode: "verbatim" | "synthesised"` per
-   result. `memory.ask` separately returns an answer-level mode, citations, and
-   confidence when answer generation has synthesis involved.
-5. Gate behind the benchmark + hard-negative suite; default-off flag.
-
-## Phasing
-
-- **P1** — restoration candidate persistence + single-pass fusion for one
-  narrowly defined signal class + artifact provenance + `[unknown]` sentinel;
-  default-off.
-- **P2** — recall contract: per-result verbatim/synthesised tag + extractive
-  guarantee for high-confidence stored hits.
-- **P3** — provenance-constrained traversal for synthesised answers.
-- **P4** — expose repair-vs-reject and verbatim-vs-synthesize thresholds as
-  decision points in [optimization-surface.md](optimization-surface.md).
-
-## Risks
-
-- **Fusion drift / fabrication** — bound to a single pass, `[unknown]` sentinel,
-  and the benchmark/hard-negative gate; never auto-promote a repaired doc that
-  regresses recall.
-- **Cost** — restoration is LLM work; queue it, batch it, and keep it default-off
-  until the offline suite shows net recall gain.
-- **Provenance integrity** — every minted doc must carry an auditable edge back
-  to its fragment + base; no orphaned synthesised nodes.
+- `src/db2/corpus_jobs.c`
+- `src/db2/corpus_jobs.h`
+- `src/kb/kb_curator_synthesize.c`
+- `src/kb/kb_curator_synthesize.h`
+- `src/headers/memory.h`
+- `src/memory_core_search.inc`
+- `src/db2/kb_service_backend_memory.c`
+- `src/server/kb_client_memory.c`
+- `src/server/server_mcp.c`
+- `src/tests/test_corpus_jobs.c`
+- `src/tests/test_curator_synthesize.c`
+- `src/tests/test_memory_cases_b.inc`

--- a/src/db2/corpus_jobs.c
+++ b/src/db2/corpus_jobs.c
@@ -263,6 +263,50 @@ int db2_corpus_job_advance(int64_t doc_id, const char *outcome, const char *deta
    return (rc == AIMEE_PG_DONE || rc == AIMEE_PG_ROW) ? 0 : -1;
 }
 
+int db2_corpus_job_mark_restoration_candidate(int64_t doc_id, const char *content_hash,
+                                              const char *signals_json)
+{
+   void *conn = db2_conn();
+   if (!conn || doc_id <= 0)
+      return -1;
+
+   db2_corpus_job_t existing;
+   const char *from_stage = "";
+   if (db2_corpus_job_get(doc_id, &existing) == 0)
+      from_stage = existing.stage;
+
+   char detail[512];
+   snprintf(detail, sizeof(detail), "{\"restoration_candidate\":true,\"signals\":%s}",
+            signals_json && signals_json[0] ? signals_json : "[]");
+   if (corpus_event_insert(doc_id, from_stage, "restore", "restoration_candidate", detail) != 0)
+      return -1;
+
+   char err[CJ_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn,
+                        "INSERT INTO corpus_processing_jobs"
+                        " (doc_id, content_hash, stage, stage_status, attempts, last_error,"
+                        "  updated_at)"
+                        " VALUES (?1,?2,'restore','pending',0,'',?3)"
+                        " ON CONFLICT (doc_id) DO UPDATE SET"
+                        " content_hash=CASE WHEN ?2 <> '' THEN ?2 ELSE corpus_processing_jobs."
+                        "content_hash END,"
+                        " stage='restore', stage_status='pending', attempts=0, last_error='',"
+                        " updated_at=?3",
+                        err, sizeof(err));
+   if (!st)
+      return -1;
+
+   char ts[32];
+   now_utc(ts, sizeof(ts));
+   aimee_pg_bind_int64(st, "?1", doc_id);
+   aimee_pg_bind_text(st, "?2", content_hash ? content_hash : "");
+   aimee_pg_bind_text(st, "?3", ts);
+   aimee_pg_step_t rc = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   return (rc == AIMEE_PG_DONE || rc == AIMEE_PG_ROW) ? 0 : -1;
+}
+
 int db2_corpus_job_fail(int64_t doc_id, const char *error)
 {
    void *conn = db2_conn();
@@ -373,6 +417,13 @@ int db2_corpus_pipeline_stage_counts(db2_corpus_pipeline_stage_count_t *out, int
 static int corpus_run_stage_handler(int64_t doc_id, const char *next_stage, char *detail,
                                     size_t detail_len)
 {
+   if (strcmp(next_stage, "restore") == 0)
+   {
+      (void)doc_id;
+      snprintf(detail, detail_len, "restoration queued");
+      return 1;
+   }
+
    if (strcmp(next_stage, "classified") == 0)
    {
       int rc = db2_corpus_classify_doc(doc_id, "pipeline");

--- a/src/db2/corpus_jobs.h
+++ b/src/db2/corpus_jobs.h
@@ -47,6 +47,8 @@ extern "C"
                                      const char *content_hash);
    int db2_corpus_job_get(int64_t doc_id, db2_corpus_job_t *out);
    int db2_corpus_job_advance(int64_t doc_id, const char *outcome, const char *detail);
+   int db2_corpus_job_mark_restoration_candidate(int64_t doc_id, const char *content_hash,
+                                                 const char *signals_json);
    int db2_corpus_job_fail(int64_t doc_id, const char *error);
    int db2_corpus_job_recover_running(int stale_seconds);
    int db2_corpus_pipeline_status(db2_corpus_pipeline_stats_t *out);

--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -1883,6 +1883,7 @@ cJSON *db2_kb_service_memory_ask_json(const char *query, const char *scope_type,
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddStringToObject(resp, "answer", result.answer);
    cJSON_AddNumberToObject(resp, "confidence", result.confidence);
+   cJSON_AddStringToObject(resp, "evidence_mode", result.evidence_mode);
    cJSON_AddBoolToObject(resp, "no_answer", result.no_answer);
    cJSON_AddBoolToObject(resp, "low_confidence", result.low_confidence);
    cJSON_AddNumberToObject(resp, "retrieval_count", result.retrieval_count);

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -155,6 +155,7 @@ typedef struct
    double confidence;
    int no_answer;
    int low_confidence;
+   char evidence_mode[16];
    int retrieval_count;
    int citation_count;
    int64_t citation_ids[MEMORY_ANSWER_MAX_CITATIONS];

--- a/src/kb/kb_curator_synthesize.c
+++ b/src/kb/kb_curator_synthesize.c
@@ -26,6 +26,71 @@
 #define CURATOR_SYNTH_OUTBUF    16384
 #define CURATOR_SYNTH_DEFAULT_K 8
 
+int kb_curator_restore_fragment_record(int64_t fragment_doc_id, const char *base_artifact_id,
+                                       const char *restored_text, double confidence,
+                                       const char *prompt_version, char *artifact_id_out,
+                                       size_t artifact_id_len)
+{
+   if (fragment_doc_id <= 0 || !restored_text || !restored_text[0])
+      return -1;
+
+   char fragment_id[32];
+   snprintf(fragment_id, sizeof(fragment_id), "%lld", (long long)fragment_doc_id);
+
+   cJSON *payload = cJSON_CreateObject();
+   if (!payload)
+      return -1;
+   cJSON_AddStringToObject(payload, "text", restored_text);
+   cJSON_AddStringToObject(payload, "evidence_mode", "synthesised");
+   cJSON_AddStringToObject(payload, "restoration_prompt_version",
+                           prompt_version && prompt_version[0] ? prompt_version : "restore-v1");
+   cJSON_AddStringToObject(payload, "fragment_doc_id", fragment_id);
+   if (base_artifact_id && base_artifact_id[0])
+      cJSON_AddStringToObject(payload, "base_artifact_id", base_artifact_id);
+   cJSON_AddBoolToObject(payload, "unknown_sentinel_present",
+                         strstr(restored_text, "[unknown]") != NULL);
+   cJSON_AddStringToObject(payload, "guardrail",
+                           "preserve source nouns, numbers, and relationships; mark gaps "
+                           "[unknown]; never invent");
+   char *payload_json = cJSON_PrintUnformatted(payload);
+   cJSON_Delete(payload);
+
+   char restore_id[64];
+   db2_artifact_gen_id(restore_id, sizeof(restore_id));
+   int rc = db2_artifact_write(restore_id, "restoration", "committed", "doc", fragment_id,
+                               "curator", confidence, payload_json ? payload_json : "{}");
+   free(payload_json);
+   if (rc != 0)
+      return -1;
+
+   if (db2_artifact_cite(restore_id, "doc", fragment_id) != 0)
+      return -1;
+   if (base_artifact_id && base_artifact_id[0])
+   {
+      if (db2_artifact_cite(restore_id, "artifact", base_artifact_id) != 0)
+         return -1;
+      if (db2_artifact_link(restore_id, base_artifact_id, "restored_from") != 0)
+         return -1;
+      if (db2_artifact_link(base_artifact_id, restore_id, "restores") != 0)
+         return -1;
+   }
+
+   char audit_id[64];
+   db2_artifact_gen_id(audit_id, sizeof(audit_id));
+   char before_json[128];
+   char after_json[256];
+   snprintf(before_json, sizeof(before_json), "{\"fragment_doc_id\":\"%s\"}", fragment_id);
+   snprintf(after_json, sizeof(after_json),
+            "{\"artifact_id\":\"%s\",\"evidence_mode\":\"synthesised\"}", restore_id);
+   if (db2_audit_event_write(audit_id, restore_id, "corpus.restore", fragment_id, "curator", "doc",
+                             fragment_id, confidence, 0, before_json, after_json) != 0)
+      return -1;
+
+   if (artifact_id_out && artifact_id_len > 0)
+      snprintf(artifact_id_out, artifact_id_len, "%s", restore_id);
+   return 0;
+}
+
 /* Pick the highest-centrality un-synthesized topic entity. Writes id/payload/
  * scope into the caller buffers. Returns 1 if one was found, else 0. */
 int kb_curator_synth_pick_topic(void *conn, char *id, size_t id_len, char **payload_out,

--- a/src/kb/kb_curator_synthesize.h
+++ b/src/kb/kb_curator_synthesize.h
@@ -18,6 +18,7 @@
  * Returns 1 if a synthesis was written, 0 if nothing was eligible (or no DB /
  * sidecar disabled), so the drain can rate-limit. */
 #include <stddef.h>
+#include <stdint.h>
 
 /* Test seam: pick the highest-centrality un-synthesised topic — the committed
  * entity with the most inbound `mentions` and no `synthesis` linked `about` it.
@@ -25,6 +26,11 @@
  * frees), else 0. */
 int kb_curator_synth_pick_topic(void *conn, char *id, size_t id_len, char **payload_out,
                                 char *scope_kind, size_t sk_len, char *scope_id, size_t si_len);
+
+int kb_curator_restore_fragment_record(int64_t fragment_doc_id, const char *base_artifact_id,
+                                       const char *restored_text, double confidence,
+                                       const char *prompt_version, char *artifact_id_out,
+                                       size_t artifact_id_len);
 
 int kb_curator_synthesize_one(const kb_curator_extract_opts_t *opts);
 

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -4797,6 +4797,30 @@ const char *memory_answer_evidence_reason_str(const memory_answer_evidence_t *tr
    return memory_answer_reason_name(trace ? trace->reason : MEMORY_ANSWER_REASON_DB_UNAVAILABLE);
 }
 
+static int memory_fixed_field_eq(const char *field, size_t field_len, const char *value)
+{
+   if (!field || !value)
+      return 0;
+   size_t value_len = strlen(value);
+   if (value_len >= field_len)
+      return 0;
+   return memcmp(field, value, value_len) == 0 && field[value_len] == '\0';
+}
+
+static const char *memory_answer_mode_for_anchor(const memory_t *matches, int count, int anchor)
+{
+   if (!matches || anchor < 0 || anchor >= count)
+      return "";
+   const memory_t *m = &matches[anchor];
+   if (memory_fixed_field_eq(m->tier, sizeof(m->tier), TIER_L5) ||
+       memory_fixed_field_eq(m->kind, sizeof(m->kind), "synthesis") ||
+       memory_fixed_field_eq(m->kind, sizeof(m->kind), "restoration") ||
+       memory_fixed_field_eq(m->provenance_category, sizeof(m->provenance_category), "synthesis") ||
+       memory_fixed_field_eq(m->provenance_category, sizeof(m->provenance_category), "restoration"))
+      return "synthesised";
+   return "verbatim";
+}
+
 static double memory_text_term_coverage(const char **terms, int term_count, const char *a,
                                         const char *b)
 {
@@ -5114,6 +5138,8 @@ int memory_ask_query_scoped(const char *query, const char *scope_type, const cha
       strip_unverified = atoi(strip_env) != 0;
 
    int anchor = memory_answer_anchor_index(matches, count);
+   snprintf(out->evidence_mode, sizeof(out->evidence_mode), "%s",
+            memory_answer_mode_for_anchor(matches, count, anchor));
    out->citation_count = memory_collect_answer_citation_ids(
        matches, count, anchor, out->citation_ids, MEMORY_ANSWER_MAX_CITATIONS);
 

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1401,6 +1401,7 @@ int kb_client_memory_ask(const char *query, const char *scope_type, const char *
    }
    cJSON *answer_j = cJSON_GetObjectItemCaseSensitive(resp, "answer");
    cJSON *conf_j = cJSON_GetObjectItemCaseSensitive(resp, "confidence");
+   cJSON *mode_j = cJSON_GetObjectItemCaseSensitive(resp, "evidence_mode");
    cJSON *no_j = cJSON_GetObjectItemCaseSensitive(resp, "no_answer");
    cJSON *low_j = cJSON_GetObjectItemCaseSensitive(resp, "low_confidence");
    cJSON *retr_j = cJSON_GetObjectItemCaseSensitive(resp, "retrieval_count");
@@ -1410,6 +1411,8 @@ int kb_client_memory_ask(const char *query, const char *scope_type, const char *
       snprintf(out->answer, sizeof(out->answer), "%s", answer_j->valuestring);
    if (cJSON_IsNumber(conf_j))
       out->confidence = conf_j->valuedouble;
+   if (cJSON_IsString(mode_j))
+      snprintf(out->evidence_mode, sizeof(out->evidence_mode), "%s", mode_j->valuestring);
    if (cJSON_IsBool(no_j))
       out->no_answer = cJSON_IsTrue(no_j) ? 1 : 0;
    if (cJSON_IsBool(low_j))

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -462,6 +462,7 @@ static cJSON *tool_memory_ask(cJSON *args, cJSON **structured_out)
    cJSON_AddStringToObject(structured, "query", jq->valuestring);
    cJSON_AddStringToObject(structured, "answer", result.answer);
    cJSON_AddNumberToObject(structured, "confidence", result.confidence);
+   cJSON_AddStringToObject(structured, "evidence_mode", result.evidence_mode);
    cJSON_AddBoolToObject(structured, "no_answer", result.no_answer);
    cJSON_AddBoolToObject(structured, "low_confidence", result.low_confidence);
    cJSON *trace = cJSON_AddObjectToObject(structured, "evidence_trace");

--- a/src/tests/test_corpus_jobs.c
+++ b/src/tests/test_corpus_jobs.c
@@ -142,12 +142,37 @@ static void test_failure_and_running_recovery(void)
    printf("  failure_and_running_recovery: ok\n");
 }
 
+static void test_restoration_candidate_queue(void)
+{
+   open_db();
+
+   int64_t doc_id = db2_kb_doc_write("restore-hash", "docs/damaged.md", "global", "passthrough", "",
+                                     "damaged fragment", NULL);
+   assert(doc_id > 0);
+
+   assert(db2_corpus_job_mark_restoration_candidate(doc_id, "restore-hash",
+                                                    "[\"FLAT_TEXT\",\"UNDERSIZED_CHUNKS\"]") == 0);
+
+   db2_corpus_job_t job;
+   assert(db2_corpus_job_get(doc_id, &job) == 0);
+   assert(strcmp(job.stage, "restore") == 0);
+   assert(strcmp(job.stage_status, "pending") == 0);
+   assert(strcmp(job.content_hash, "restore-hash") == 0);
+   assert(query_int("SELECT COUNT(*) FROM corpus_stage_events"
+                    " WHERE to_stage = 'restore' AND outcome = 'restoration_candidate'"
+                    " AND detail LIKE '%UNDERSIZED_CHUNKS%'") == 1);
+
+   close_db();
+   printf("  restoration_candidate_queue: ok\n");
+}
+
 int main(void)
 {
    printf("corpus_jobs:\n");
    test_doc_write_seeds_job_and_version();
    test_drain_advances_to_complete_with_events();
    test_failure_and_running_recovery();
+   test_restoration_candidate_queue();
    printf("corpus_jobs: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_curator_synthesize.c
+++ b/src/tests/test_curator_synthesize.c
@@ -10,6 +10,7 @@
 #include <sqlite3.h>
 
 #include "aimee.h"
+#include "db2/artifacts.h"
 #include "db2_test_shim.h"
 #include "../kb/kb_curator_synthesize.h"
 
@@ -63,10 +64,50 @@ static void test_pick_seeded(void)
    printf("  synth_pick_topic selects an un-synthesised entity OK\n");
 }
 
+static int count_sql(sqlite3 *db, const char *sql)
+{
+   sqlite3_stmt *st = NULL;
+   assert(sqlite3_prepare_v2(db, sql, -1, &st, NULL) == SQLITE_OK);
+   assert(sqlite3_step(st) == SQLITE_ROW);
+   int n = sqlite3_column_int(st, 0);
+   sqlite3_finalize(st);
+   return n;
+}
+
+static void test_restore_fragment_record(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   assert(db != NULL);
+   seed(db, "INSERT INTO artifacts (id,kind,state,scope_kind,scope_id,payload) VALUES"
+            " ('base','summary','committed','doc','base-doc','{\"text\":\"base\"}')");
+
+   char out_id[64] = "";
+   assert(kb_curator_restore_fragment_record(42, "base",
+                                             "Restored title: [unknown]. Preserved number 17.",
+                                             0.82, "restore-test-v1", out_id, sizeof(out_id)) == 0);
+   assert(out_id[0] != '\0');
+   assert(count_sql(db, "SELECT COUNT(*) FROM artifacts WHERE id != 'base' AND kind='restoration'"
+                        " AND state='committed' AND payload LIKE '%unknown_sentinel_present%'"
+                        " AND payload LIKE '%synthesised%'") == 1);
+   assert(count_sql(db, "SELECT COUNT(*) FROM artifact_citations WHERE artifact_id != 'base'"
+                        " AND source_kind='doc' AND source_id='42'") == 1);
+   assert(count_sql(db, "SELECT COUNT(*) FROM artifact_links WHERE from_id != 'base'"
+                        " AND to_id='base' AND kind='restored_from'") == 1);
+   assert(count_sql(db, "SELECT COUNT(*) FROM artifact_links WHERE from_id='base'"
+                        " AND kind='restores'") == 1);
+   assert(count_sql(
+              db, "SELECT COUNT(*) FROM audit_events WHERE target_surface='corpus.restore'") == 1);
+
+   db2_test_shim_close();
+   printf("  restore_fragment_record writes provenance OK\n");
+}
+
 int main(void)
 {
    test_gated_empty();
    test_pick_seeded();
+   test_restore_fragment_record();
    printf("curator_synthesize: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_memory_cases_b.inc
+++ b/src/tests/test_memory_cases_b.inc
@@ -39,6 +39,7 @@ static void test_memory_ask_query_returns_structured_result(void)
    assert(result.no_answer == 0);
    assert(result.answer[0] != '\0');
    assert(result.confidence > 0.6);
+   assert(strcmp(result.evidence_mode, "verbatim") == 0);
    assert(result.citation_count >= 1);
    assert(result.citation_ids[0] == m.id);
 
@@ -253,8 +254,8 @@ static void test_memory_find_facts_falls_back_when_vector_index_unavailable(void
 
    memory_t m;
    assert(memory_insert(TIER_L2, KIND_FACT, "agent role model",
-                        "There is one primary agent and delegated work uses delegates.", 0.95,
-                        "s1", &m) == 0);
+                        "There is one primary agent and delegated work uses delegates.", 0.95, "s1",
+                        &m) == 0);
 
    memory_t results[8];
    int count = memory_find_facts("agent delegates", 5, results, 8);


### PR DESCRIPTION
## Summary
- complete the done ingest restoration/recall proposal by shipping restoration candidate queueing, curator restoration artifact provenance, and memory.ask evidence mode propagation
- fix the stale Agent Roundtable proposal index link from pending to done
- add focused tests for restoration queueing, restoration artifact provenance, and structured answer evidence mode

## Verification
- make -C src build/obj/tests/unit-test-corpus-jobs && src/build/obj/tests/unit-test-corpus-jobs
- make -C src build/obj/tests/unit-test-curator-synthesize && src/build/obj/tests/unit-test-curator-synthesize
- make -C src docs-gen-check proposal-links-check
- make -C src ../aimee-server
- make -C src lint
- git diff --check

## Note
- unit-test-memory also segfaults on pristine origin/testing at test_memory_diagnose_reports_score_breakdown, so it was not introduced by this branch.