### PR TITLE
fix(deploy): point compose services at published ghcr images (so merge→pull→deploy works)

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,8 +493,15 @@ docker compose -f compose.combined.yaml restart aimee-server-kb
 docker compose -f compose.combined.yaml down         # stop + remove containers (named volumes persist)
 docker compose -f compose.combined.yaml down -v      # also drop the data volumes (DESTROYS DB2 + state)
 docker compose -f compose.combined.yaml pull && \
-  docker compose -f compose.combined.yaml up -d --build   # update: rebuild images and recreate
+  docker compose -f compose.combined.yaml up -d           # update: pull the latest published image + recreate
+docker compose -f compose.combined.yaml up -d --build     # alternative: rebuild from local source instead of pulling
 ```
+
+The compose services point at the published `ghcr.io/rakuensoftware/aimee-*`
+images (built and pushed on every merge to `main`), so `pull` fetches the latest
+release without a local build. Pin a specific version (or a fork/registry) by
+overriding `AIMEE_COMBINED_IMAGE` / `AIMEE_SERVER_IMAGE` / `AIMEE_KB_IMAGE` /
+`AIMEE_EMBEDDER_IMAGE` (e.g. `AIMEE_COMBINED_IMAGE=ghcr.io/rakuensoftware/aimee-server-kb:v0.2.41`).
 
 Each container runs as a non-root user. Durable state lives in **named volumes**,
 not the container filesystem, so `down`/recreate is safe and `down -v` is the only

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -6,6 +6,10 @@
 # the embedder remain separate services — the combined image bundles the two
 # aimee binaries, not a database.
 #
+# Deploy the published images (built + pushed to ghcr on every merge to main):
+#   docker compose -f compose.combined.yaml pull
+#   docker compose -f compose.combined.yaml up -d
+# Or build from source instead of pulling:
 #   docker compose -f compose.combined.yaml up --build
 #
 # Server /v1 on :8740 (bearer "aimee-local-dev"); the in-container kb /v1 is also
@@ -34,6 +38,10 @@ services:
 
   embedder:
     restart: unless-stopped
+    # Published image (built + pushed to ghcr on every merge to main). `docker
+    # compose pull` fetches it; `up --build` rebuilds locally and tags it the same.
+    # Override AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -57,7 +65,12 @@ services:
       #   NPM_TOKEN=<github PAT> docker compose -f compose.combined.yaml build \
       #     --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
       # (or `docker pull` the published image, which already includes webchat).
-    image: aimee-server-kb
+    # Published combined image (built + pushed to ghcr on every merge to main).
+    # `docker compose pull` fetches it so the standard deploy creates containers
+    # from the merge-built image without a local build; `up --build` still
+    # rebuilds locally and tags it the same. Override AIMEE_COMBINED_IMAGE to pin
+    # a version (e.g. ghcr.io/rakuensoftware/aimee-server-kb:v0.2.41) or a fork.
+    image: ${AIMEE_COMBINED_IMAGE:-ghcr.io/rakuensoftware/aimee-server-kb:latest}
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -5,7 +5,10 @@
 # kb-backed shared / vector operations are simply unavailable until a kb is wired
 # in (see compose.server.yaml for the full server + kb stack).
 #
-#   docker compose -f compose.server-standalone.yaml up --build
+# Deploy the published image (pushed to ghcr on every merge to main), or build:
+#   docker compose -f compose.server-standalone.yaml pull && \
+#     docker compose -f compose.server-standalone.yaml up -d
+#   docker compose -f compose.server-standalone.yaml up --build   # build from source
 #
 # The /v1 API requires a bearer token (baked default: "aimee-local-dev"):
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
@@ -24,7 +27,10 @@ services:
       # Opt into the optional aimee-webchat with a GitHub Packages token:
       #   NPM_TOKEN=<github PAT> docker compose -f compose.server-standalone.yaml \
       #     build --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
-    image: aimee-server
+    # Published image (built + pushed to ghcr on every merge to main): `docker
+    # compose pull` fetches it; `up --build` rebuilds locally and tags it the same.
+    # Override AIMEE_SERVER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -31,6 +31,9 @@ services:
 
   embedder:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -45,6 +48,9 @@ services:
 
   aimee-kb:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_KB_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
     build:
       context: .
       dockerfile: Dockerfile
@@ -76,6 +82,9 @@ services:
 
   aimee-server:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_SERVER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
     build:
       context: .
       dockerfile: Dockerfile.server

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,9 @@ services:
 
   embedder:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -30,6 +33,9 @@ services:
 
   aimee-kb:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_KB_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## What

Fix the "standard" Docker deploy so merging to `main` actually produces deployable containers.

## The bug

Merging to `main` builds + pushes multi-arch images to `ghcr.io/rakuensoftware/aimee-*` (`:latest` + `:<version>`) — that part works. But **none of the compose files referenced those published images**: the aimee services used a bare local name (`image: aimee-server-kb`, `image: aimee-server`) or had no `image:` at all (`embedder`, `aimee-kb`) — only a `build:` section.

So the documented standard deploy —
```
docker compose -f compose.combined.yaml pull && docker compose -f compose.combined.yaml up -d
```
— had nothing to pull: `pull` can't fetch a bare/absent image, so containers were only ever (re)created from a **local build**, never from the merge-built ghcr image. That's why the box stayed on an old version after a merge even though the new image was published.

## The fix

Point each aimee/embedder service at its published ghcr image via an env-overridable default, keeping `build:` so local-dev `up --build` still works (it builds and tags the result as the same ref):

| Service | Image |
|---|---|
| `embedder` | `${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}` |
| `aimee-kb` | `${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}` |
| `aimee-server` | `${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}` |
| `aimee-server-kb` | `${AIMEE_COMBINED_IMAGE:-ghcr.io/rakuensoftware/aimee-server-kb:latest}` |

across `compose.yaml`, `compose.combined.yaml`, `compose.server.yaml`, `compose.server-standalone.yaml`. Now `docker compose pull && up -d` creates containers from the freshly merge-built image with no local build. Pin a version or a fork/registry via the env vars (e.g. `AIMEE_COMBINED_IMAGE=ghcr.io/rakuensoftware/aimee-server-kb:v0.2.41`).

README + compose headers updated to the pull-based deploy.

## Safety

- All four compose files validated as YAML; no bare aimee image names remain.
- **CI unaffected**: the e2e deploy matrix uses `docker compose up -d --build`, which builds each aimee service locally and tags it as the ghcr ref — it never pulls the real ghcr image, so it still tests the commit's own build.
- Local dev unchanged: `up --build` still builds from source.
