### PR TITLE
Promote testing → main (compose ghcr image fix for standard deploy)

### DIFF
--- a/README.md
+++ b/README.md
@@ -493,8 +493,15 @@ docker compose -f compose.combined.yaml restart aimee-server-kb
 docker compose -f compose.combined.yaml down         # stop + remove containers (named volumes persist)
 docker compose -f compose.combined.yaml down -v      # also drop the data volumes (DESTROYS DB2 + state)
 docker compose -f compose.combined.yaml pull && \
-  docker compose -f compose.combined.yaml up -d --build   # update: rebuild images and recreate
+  docker compose -f compose.combined.yaml up -d           # update: pull the latest published image + recreate
+docker compose -f compose.combined.yaml up -d --build     # alternative: rebuild from local source instead of pulling
 ```
+
+The compose services point at the published `ghcr.io/rakuensoftware/aimee-*`
+images (built and pushed on every merge to `main`), so `pull` fetches the latest
+release without a local build. Pin a specific version (or a fork/registry) by
+overriding `AIMEE_COMBINED_IMAGE` / `AIMEE_SERVER_IMAGE` / `AIMEE_KB_IMAGE` /
+`AIMEE_EMBEDDER_IMAGE` (e.g. `AIMEE_COMBINED_IMAGE=ghcr.io/rakuensoftware/aimee-server-kb:v0.2.41`).
 
 Each container runs as a non-root user. Durable state lives in **named volumes**,
 not the container filesystem, so `down`/recreate is safe and `down -v` is the only

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -6,6 +6,10 @@
 # the embedder remain separate services — the combined image bundles the two
 # aimee binaries, not a database.
 #
+# Deploy the published images (built + pushed to ghcr on every merge to main):
+#   docker compose -f compose.combined.yaml pull
+#   docker compose -f compose.combined.yaml up -d
+# Or build from source instead of pulling:
 #   docker compose -f compose.combined.yaml up --build
 #
 # Server /v1 on :8740 (bearer "aimee-local-dev"); the in-container kb /v1 is also
@@ -34,6 +38,10 @@ services:
 
   embedder:
     restart: unless-stopped
+    # Published image (built + pushed to ghcr on every merge to main). `docker
+    # compose pull` fetches it; `up --build` rebuilds locally and tags it the same.
+    # Override AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -57,7 +65,12 @@ services:
       #   NPM_TOKEN=<github PAT> docker compose -f compose.combined.yaml build \
       #     --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
       # (or `docker pull` the published image, which already includes webchat).
-    image: aimee-server-kb
+    # Published combined image (built + pushed to ghcr on every merge to main).
+    # `docker compose pull` fetches it so the standard deploy creates containers
+    # from the merge-built image without a local build; `up --build` still
+    # rebuilds locally and tags it the same. Override AIMEE_COMBINED_IMAGE to pin
+    # a version (e.g. ghcr.io/rakuensoftware/aimee-server-kb:v0.2.41) or a fork.
+    image: ${AIMEE_COMBINED_IMAGE:-ghcr.io/rakuensoftware/aimee-server-kb:latest}
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -5,7 +5,10 @@
 # kb-backed shared / vector operations are simply unavailable until a kb is wired
 # in (see compose.server.yaml for the full server + kb stack).
 #
-#   docker compose -f compose.server-standalone.yaml up --build
+# Deploy the published image (pushed to ghcr on every merge to main), or build:
+#   docker compose -f compose.server-standalone.yaml pull && \
+#     docker compose -f compose.server-standalone.yaml up -d
+#   docker compose -f compose.server-standalone.yaml up --build   # build from source
 #
 # The /v1 API requires a bearer token (baked default: "aimee-local-dev"):
 #   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
@@ -24,7 +27,10 @@ services:
       # Opt into the optional aimee-webchat with a GitHub Packages token:
       #   NPM_TOKEN=<github PAT> docker compose -f compose.server-standalone.yaml \
       #     build --build-arg WITH_WEBCHAT=1 --secret id=npm_token,env=NPM_TOKEN
-    image: aimee-server
+    # Published image (built + pushed to ghcr on every merge to main): `docker
+    # compose pull` fetches it; `up --build` rebuilds locally and tags it the same.
+    # Override AIMEE_SERVER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
     # The server's worker threads need a 64 MB stack (the 8 MB container default
     # overflows during startup — matches systemd's LimitSTACK=67108864).
     ulimits:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -31,6 +31,9 @@ services:
 
   embedder:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -45,6 +48,9 @@ services:
 
   aimee-kb:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_KB_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
     build:
       context: .
       dockerfile: Dockerfile
@@ -76,6 +82,9 @@ services:
 
   aimee-server:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_SERVER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
     build:
       context: .
       dockerfile: Dockerfile.server

--- a/compose.yaml
+++ b/compose.yaml
@@ -16,6 +16,9 @@ services:
 
   embedder:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
     build:
       context: .
       dockerfile: Dockerfile.embedder
@@ -30,6 +33,9 @@ services:
 
   aimee-kb:
     restart: unless-stopped
+    # Published image (pushed to ghcr on every merge to main); override
+    # AIMEE_KB_IMAGE to pin a version or use a fork/registry.
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Promote testing → main

Brings the deploy fix to `main` so the next auto-release bakes it into the published `:latest` images.

**#170 — fix(deploy): point compose services at published ghcr images.** Every compose file's aimee services used a bare/absent image name (only a `build:` section), so the documented standard deploy (`docker compose pull && up -d`) had nothing to pull — containers were only ever created from a local build, never the merge-built ghcr image. Now they reference `${AIMEE_*_IMAGE:-ghcr.io/rakuensoftware/aimee-*:latest}` (env-overridable, `build:` kept for local dev). `docker compose pull && up -d` now creates containers from the freshly merge-built image.

After this promotes, the auto-release publishes a new `:latest` containing both this fix and the flag rollout-readiness program (#168/#169), so a `docker compose -f compose.combined.yaml pull && up -d` deploys the current build.

All CI green on `testing` at the #170 merge (incl. the e2e deploy matrix, which builds + runs all four compose stacks).
