### PR TITLE
fix(ci): retry flaky embedder model download in release builds

### DIFF
--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -17,8 +17,17 @@ RUN apt-get update \
 RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
     && pip install sentence-transformers
 
-# Pre-download the model at build time so runtime needs no network.
-RUN python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+# Pre-download the model at build time so runtime needs no network. HuggingFace
+# downloads are flaky during CI image builds (transient network/CDN errors fail
+# the whole release), so retry with backoff; the final attempt is unguarded so an
+# image that genuinely couldn't fetch the model still fails the build rather than
+# shipping without it (a cached model makes the re-verify a fast no-op).
+RUN for i in 1 2 3 4 5; do \
+        python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')" && break; \
+        echo "model download attempt $i failed; retrying in $((i * 10))s"; \
+        sleep $((i * 10)); \
+    done; \
+    python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
 
 COPY scripts/embedder-server.py /opt/aimee/scripts/embedder-server.py
 


### PR DESCRIPTION
## What

Stop flaky HuggingFace downloads from failing release image builds.

## Why

`Dockerfile.embedder` pre-downloads `all-MiniLM-L6-v2` from HuggingFace at build time (so the runtime needs no network). That download is **flaky in CI** — a transient HF network/CDN error fails the `aimee-embedder` build, and because the per-arch builds feed a manifest-merge job, one arch failing **skips the merge → no new `:latest` is published**. This just bit the v0.2.42 release (amd64 embedder build failed on the HF download; merge skipped). It's the same flake class as the recurring e2e-docker HuggingFace failures.

## Fix

Wrap the model download in a 5-attempt backoff retry. The final attempt is unguarded, so an image that genuinely can't fetch the model still fails the build rather than shipping without it (a cached model makes the re-verify a fast no-op).

```dockerfile
RUN for i in 1 2 3 4 5; do \
        python -c "...SentenceTransformer('all-MiniLM-L6-v2')" && break; \
        echo "model download attempt $i failed; retrying in $((i * 10))s"; sleep $((i * 10)); \
    done; \
    python -c "...SentenceTransformer('all-MiniLM-L6-v2')"
```

Same image contents, just resilient to transient download errors. (The other v0.2.42 failure — `registry-1.docker.io: context deadline exceeded` during Buildx setup — is a Docker Hub infra timeout handled by re-running; not addressed here.)
