### PR TITLE
feat(retrieval): pplx-embed-v1-0.6b embedder (1024-dim) + modernbert reranker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,8 +49,9 @@ RUN useradd --system --home-dir /var/lib/aimee --create-home --shell /usr/sbin/n
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 
 # Sidecar clients (the LLM/embedder access code the kb invokes via popen).
-COPY scripts/embed-remote.py scripts/llm-chat.py scripts/learning-synthesize.py \
-     scripts/curator-extract.py scripts/guardrails-semantic.py /opt/aimee/scripts/
+COPY scripts/embed-remote.py scripts/rerank-remote.py scripts/llm-chat.py \
+     scripts/learning-synthesize.py scripts/curator-extract.py \
+     scripts/guardrails-semantic.py /opt/aimee/scripts/
 # Baked default config: selects the sidecar commands (endpoints come from env).
 # Kept OUTSIDE $AIMEE_HOME so a bind mount over /var/lib/aimee can't shadow it;
 # the entrypoint seeds it into $AIMEE_HOME/.config/aimee on first start.

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -133,8 +133,9 @@ COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
 
 # kb sidecar clients (LLM/embedder access code the kb invokes via popen).
-COPY scripts/embed-remote.py scripts/llm-chat.py scripts/learning-synthesize.py \
-     scripts/curator-extract.py scripts/guardrails-semantic.py /opt/aimee/scripts/
+COPY scripts/embed-remote.py scripts/rerank-remote.py scripts/llm-chat.py \
+     scripts/learning-synthesize.py scripts/curator-extract.py \
+     scripts/guardrails-semantic.py /opt/aimee/scripts/
 # Baked default config kept OUTSIDE $AIMEE_HOME so a bind-mounted (empty) volume
 # can't shadow it; the entrypoint seeds it into $AIMEE_HOME/aimee.yaml on first
 # start. server + kb share AIMEE_HOME and both read $AIMEE_HOME/aimee.yaml, so

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -14,10 +14,16 @@ ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
 # stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
 ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
+# Serve the q4 ONNX export by default: ~1.6x faster than fp32 on CPU (117ms vs
+# 189ms/embed @ 8 threads for pplx-embed-0.6b, identical 1024-dim output). Clear
+# EMBEDDER_ONNX_FILE (or override EMBEDDER_MODEL to a model without onnx/) to fall
+# back to fp32 torch — the server also falls back automatically if the file is
+# missing. The matching onnx files are baked below.
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \
     RERANKER_MODEL=${RERANKER_MODEL} \
+    EMBEDDER_ONNX_FILE=onnx/model_q4.onnx \
     EMBEDDER_PORT=8080
 
 RUN apt-get update \
@@ -26,8 +32,10 @@ RUN apt-get update \
 
 # CPU-only torch keeps the image off the CUDA wheels. einops + a recent
 # sentence-transformers/transformers are needed for the Qwen3-based embedder.
+# optimum[onnxruntime] backs the ONNX serving path (EMBEDDER_ONNX_FILE); the q4
+# export runs ~1.6x faster than fp32 torch on CPU.
 RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
-    && pip install -U "sentence-transformers>=3.3" einops
+    && pip install -U "sentence-transformers>=3.3" einops "optimum[onnxruntime]>=1.23"
 
 # Pre-download EMBEDDER_MODEL at build time so runtime needs no network. The model
 # id is read from the env so the build, the runtime, and an override all agree on
@@ -42,6 +50,19 @@ RUN for i in 1 2 3 4 5; do \
         sleep $((i * 10)); \
     done; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True)"
+
+# Bake the q4 ONNX export (the default serving path) + verify it loads via the
+# onnxruntime backend, so the runtime needs no network and a broken export fails
+# the build rather than silently falling back to slow fp32. allow_patterns scoped
+# to the q4 files keeps the layer small (it skips the ~2.4GB fp32 onnx). Skipped
+# cleanly for an EMBEDDER_MODEL without an onnx/ dir (nothing matches → no-op, and
+# the server falls back to torch at runtime).
+RUN for i in 1 2 3 4 5; do \
+        python -c "import os; from huggingface_hub import snapshot_download; snapshot_download(os.environ['EMBEDDER_MODEL'], allow_patterns=['onnx/model_q4*'])" && break; \
+        echo "onnx download attempt $i failed; retrying in $((i * 10))s"; \
+        sleep $((i * 10)); \
+    done; \
+    python -c "import os; from sentence_transformers import SentenceTransformer; m=SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True, backend='onnx', model_kwargs={'file_name': os.environ['EMBEDDER_ONNX_FILE']}); print('onnx q4 ok dim=', m.get_sentence_embedding_dimension())"
 
 # Pre-download the cross-encoder reranker too (same retry rationale).
 RUN for i in 1 2 3 4 5; do \

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -14,16 +14,10 @@ ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
 # stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
 ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
-# Serve the q4 ONNX export by default: ~1.6x faster than fp32 on CPU (117ms vs
-# 189ms/embed @ 8 threads for pplx-embed-0.6b, identical 1024-dim output). Clear
-# EMBEDDER_ONNX_FILE (or override EMBEDDER_MODEL to a model without onnx/) to fall
-# back to fp32 torch — the server also falls back automatically if the file is
-# missing. The matching onnx files are baked below.
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \
     RERANKER_MODEL=${RERANKER_MODEL} \
-    EMBEDDER_ONNX_FILE=onnx/model_q4.onnx \
     EMBEDDER_PORT=8080
 
 RUN apt-get update \
@@ -31,11 +25,12 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # CPU-only torch keeps the image off the CUDA wheels. einops + a recent
-# sentence-transformers/transformers are needed for the Qwen3-based embedder.
-# optimum[onnxruntime] backs the ONNX serving path (EMBEDDER_ONNX_FILE); the q4
-# export runs ~1.6x faster than fp32 torch on CPU.
+# sentence-transformers are needed for the Qwen3-based embedder. transformers>=5.2
+# is required by the Ettin (ModernBERT) cross-encoder reranker — older transformers
+# can't instantiate its tokenizer ("Unrecognized processing class") — so pin the
+# floor explicitly rather than rely on the transitive resolution.
 RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
-    && pip install -U "sentence-transformers>=3.3" einops "optimum[onnxruntime]>=1.23"
+    && pip install -U "sentence-transformers>=3.3" "transformers>=5.2" einops
 
 # Pre-download EMBEDDER_MODEL at build time so runtime needs no network. The model
 # id is read from the env so the build, the runtime, and an override all agree on
@@ -50,19 +45,6 @@ RUN for i in 1 2 3 4 5; do \
         sleep $((i * 10)); \
     done; \
     python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True)"
-
-# Bake the q4 ONNX export (the default serving path) + verify it loads via the
-# onnxruntime backend, so the runtime needs no network and a broken export fails
-# the build rather than silently falling back to slow fp32. allow_patterns scoped
-# to the q4 files keeps the layer small (it skips the ~2.4GB fp32 onnx). Skipped
-# cleanly for an EMBEDDER_MODEL without an onnx/ dir (nothing matches → no-op, and
-# the server falls back to torch at runtime).
-RUN for i in 1 2 3 4 5; do \
-        python -c "import os; from huggingface_hub import snapshot_download; snapshot_download(os.environ['EMBEDDER_MODEL'], allow_patterns=['onnx/model_q4*'])" && break; \
-        echo "onnx download attempt $i failed; retrying in $((i * 10))s"; \
-        sleep $((i * 10)); \
-    done; \
-    python -c "import os; from sentence_transformers import SentenceTransformer; m=SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True, backend='onnx', model_kwargs={'file_name': os.environ['EMBEDDER_ONNX_FILE']}); print('onnx q4 ok dim=', m.get_sentence_embedding_dimension())"
 
 # Pre-download the cross-encoder reranker too (same retry rationale).
 RUN for i in 1 2 3 4 5; do \

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -1,33 +1,55 @@
-# Persistent embedding service for aimee-kb: holds all-MiniLM-L6-v2 resident and
-# serves /embed over HTTP, so the kb container embeds without reloading the model
-# per call. Kept separate from the kb image so torch/sentence-transformers never
-# bloat the slim kb runtime.
+# Persistent embedding service for aimee-kb: holds the embedding model resident
+# and serves /embed over HTTP, so the kb container embeds without reloading the
+# model per call. Kept separate from the kb image so torch/sentence-transformers
+# never bloat the slim kb runtime.
+#
+# Default model: perplexity-ai/pplx-embed-v1-0.6b (Feb 2026, MIT, Qwen3-based,
+# 1024-dim, retrieval-optimized, prefix-free, INT8-native) — replacing the 2021
+# all-MiniLM-L6-v2 (384-dim). Override at build time with
+#   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
+#   schema vector(N) columns — pplx-embed-v1-0.6b is 1024).
 FROM python:3.11-slim AS embedder
 
+ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
+# Cross-encoder reranker served from the same process (aimee's memory rerank
+# stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
+ARG RERANKER_MODEL=Alibaba-NLP/gte-reranker-modernbert-base
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
-    EMBEDDER_MODEL=all-MiniLM-L6-v2 \
+    EMBEDDER_MODEL=${EMBEDDER_MODEL} \
+    RERANKER_MODEL=${RERANKER_MODEL} \
     EMBEDDER_PORT=8080
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
-# CPU-only torch keeps the image off the CUDA wheels.
+# CPU-only torch keeps the image off the CUDA wheels. einops + a recent
+# sentence-transformers/transformers are needed for the Qwen3-based embedder.
 RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
-    && pip install sentence-transformers
+    && pip install -U "sentence-transformers>=3.3" einops
 
-# Pre-download the model at build time so runtime needs no network. HuggingFace
-# downloads are flaky during CI image builds (transient network/CDN errors fail
-# the whole release), so retry with backoff; the final attempt is unguarded so an
-# image that genuinely couldn't fetch the model still fails the build rather than
-# shipping without it (a cached model makes the re-verify a fast no-op).
+# Pre-download EMBEDDER_MODEL at build time so runtime needs no network. The model
+# id is read from the env so the build, the runtime, and an override all agree on
+# one source of truth. HuggingFace downloads are flaky during CI image builds
+# (transient network/CDN errors fail the whole release), so retry with backoff;
+# the final attempt is unguarded so an image that genuinely couldn't fetch the
+# model still fails the build rather than shipping without it (a cached model
+# makes the re-verify a fast no-op).
 RUN for i in 1 2 3 4 5; do \
-        python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')" && break; \
+        python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True)" && break; \
         echo "model download attempt $i failed; retrying in $((i * 10))s"; \
         sleep $((i * 10)); \
     done; \
-    python -c "from sentence_transformers import SentenceTransformer; SentenceTransformer('all-MiniLM-L6-v2')"
+    python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True)"
+
+# Pre-download the cross-encoder reranker too (same retry rationale).
+RUN for i in 1 2 3 4 5; do \
+        python -c "import os; from sentence_transformers import CrossEncoder; CrossEncoder(os.environ['RERANKER_MODEL'], trust_remote_code=True)" && break; \
+        echo "reranker download attempt $i failed; retrying in $((i * 10))s"; \
+        sleep $((i * 10)); \
+    done; \
+    python -c "import os; from sentence_transformers import CrossEncoder; CrossEncoder(os.environ['RERANKER_MODEL'], trust_remote_code=True)"
 
 COPY scripts/embedder-server.py /opt/aimee/scripts/embedder-server.py
 

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -13,7 +13,7 @@ FROM python:3.11-slim AS embedder
 ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
 # stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
-ARG RERANKER_MODEL=Alibaba-NLP/gte-reranker-modernbert-base
+ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \

--- a/deploy/migrations/2026-embed-dim-1024.sql
+++ b/deploy/migrations/2026-embed-dim-1024.sql
@@ -1,0 +1,76 @@
+-- 2026-embed-dim-1024.sql
+--
+-- One-time DB2 (Postgres + pgvector) migration for the embedder change from
+-- all-MiniLM-L6-v2 (384-dim) to perplexity-ai/pplx-embed-v1-0.6b (1024-dim).
+--
+-- WHY THIS IS A SEPARATE, MANUAL SCRIPT (not auto-applied on startup):
+--   The old 384-dim vectors are NOT convertible to 1024 dims — switching the
+--   embedder means the entire corpus must be re-embedded. This script CLEARS the
+--   stored embeddings (sets the vector columns to NULL) and reshapes the columns
+--   to vector(1024); the rows/metadata are kept. The base schema deliberately
+--   only WARNS about a dimension mismatch rather than doing this automatically,
+--   so a routine restart can never silently wipe the corpus.
+--
+-- BEFORE RUNNING:
+--   1. BACK UP DB2 (pg_dump) — this clears every stored embedding.
+--   2. Deploy the new embedder image (EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b)
+--      and confirm /health reports "dim": 1024.
+--   Ideally test on a restored copy of the DB first.
+--
+-- AFTER RUNNING:
+--   3. Restart aimee-server/kb so schema.sql rebuilds the HNSW indexes on the
+--      now-1024-dim columns (CREATE INDEX IF NOT EXISTS).
+--   4. Re-embed the corpus:  aimee memory reembed --start  (then --cutover),
+--      or let normal ingestion/maintenance repopulate embeddings over time.
+--   Until re-embedded, semantic recall is degraded (lexical/BM25 still works).
+--
+-- Idempotent: re-running is a no-op once every vector column is already
+-- vector(1024).
+
+BEGIN;
+
+-- Drop the pgvector (HNSW) indexes that sit on the embedding columns; an
+-- ALTER COLUMN TYPE that changes the dimension cannot proceed while an index
+-- depends on the column. They are recreated by schema.sql on the next startup.
+DROP INDEX IF EXISTS idx_memory_embeddings_hnsw;
+DROP INDEX IF EXISTS idx_kb_embeddings_hnsw;
+DROP INDEX IF EXISTS idx_code_embeddings_hnsw;
+DROP INDEX IF EXISTS idx_curator_entity_vectors_hnsw;
+DROP INDEX IF EXISTS idx_curator_narrative_vectors_hnsw;
+DROP INDEX IF EXISTS idx_curator_claim_vectors_subj_attr_hnsw;
+DROP INDEX IF EXISTS idx_curator_claim_vectors_value_hnsw;
+DROP INDEX IF EXISTS idx_curator_code_unit_vectors_intent_hnsw;
+DROP INDEX IF EXISTS idx_curator_code_unit_vectors_signature_hnsw;
+DROP INDEX IF EXISTS idx_curator_code_unit_vectors_body_hnsw;
+
+-- Reshape every `vector(N != 1024)` column to vector(1024), clearing the old
+-- (incompatible-dimension) embeddings. Done dynamically so no column is missed.
+DO $MIG$
+DECLARE
+    r RECORD;
+BEGIN
+    FOR r IN
+        SELECT c.relname AS tbl, a.attname AS col,
+               format_type(a.atttypid, a.atttypmod) AS typ
+          FROM pg_attribute a
+          JOIN pg_class c     ON c.oid = a.attrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relkind = 'r'
+           AND NOT a.attisdropped
+           AND format_type(a.atttypid, a.atttypmod) LIKE 'vector(%'
+           AND format_type(a.atttypid, a.atttypmod) <> 'vector(1024)'
+    LOOP
+        EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE vector(1024) USING NULL',
+                       r.tbl, r.col);
+        RAISE NOTICE 'embed-dim migration: %.% % -> vector(1024) (cleared; re-embed required)',
+                     r.tbl, r.col, r.typ;
+    END LOOP;
+END
+$MIG$;
+
+-- Reset the re-embed rollover bookkeeping so a fresh `aimee memory reembed
+-- --start` re-embeds from the beginning against the new embedder.
+UPDATE memory_reembed_progress SET last_id = 0, done = 0, finished_at = NULL WHERE id = 1;
+
+COMMIT;

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -20,11 +20,14 @@ Endpoints:
   GET  /health                                         -> {"status":"ok","model":...,"dim":N}
 
 Config (env):
-  EMBEDDER_PORT   listen port (default 8080)
-  EMBEDDER_MODEL  sentence-transformers model id (default pplx-embed-v1-0.6b)
-  RERANKER_MODEL  cross-encoder model id (default ettin-reranker-400m-v1)
+  EMBEDDER_PORT     listen port (default 8080)
+  EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-0.6b)
+  RERANKER_MODEL    cross-encoder model id (default ettin-reranker-400m-v1)
+  EMBEDDER_THREADS  torch intra-op threads (default min(8, ncpu))
+  EMBEDDER_QUANTIZE fp32 (default) | int8 (torch dynamic; ~3.3x faster, drifts —
+                    pair with the 4b deep tier; see below)
 
-Dependencies: pip install "sentence-transformers>=3.3" einops
+Dependencies: pip install "sentence-transformers>=3.3" "transformers>=5.2" einops
 """
 
 import json
@@ -44,6 +47,14 @@ PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
 # an explicit EMBEDDER_THREADS wins. Set OMP before torch is imported.
 EMBEDDER_THREADS = int(os.environ.get("EMBEDDER_THREADS", "0")) or min(8, os.cpu_count() or 8)
 os.environ.setdefault("OMP_NUM_THREADS", str(EMBEDDER_THREADS))
+# Optional int8 dynamic quantization. Pure torch (no optimum/onnx), so it composes
+# with the transformers>=5.2 the Ettin reranker needs — unlike the q4 ONNX path.
+# EMBEDDER_QUANTIZE=int8 runs ~3.3x faster on CPU (58ms vs 190ms/embed @ 8 threads)
+# but the embedding drifts (~0.90 cosine vs fp32): dynamic quant is per-tensor and
+# uncalibrated. INTENDED PAIRING: serve int8 only when the 4b deep tier is enabled
+# (it re-embeds for quality, backstopping the drift); serve fp32 when the 0.6b is
+# the sole tier. The deep-tier deployment sets this to int8; the default is fp32.
+EMBEDDER_QUANTIZE = os.environ.get("EMBEDDER_QUANTIZE", "fp32").strip().lower()
 
 _model = None
 _dim = 0
@@ -68,9 +79,14 @@ def load_model():
     # trust_remote_code: the Qwen3-based embedders (pplx-embed, gte-Qwen2) ship
     # custom modelling code on the Hub.
     _model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
-    _dim = _model.get_sentence_embedding_dimension() or 0
+    _dim = _model.get_sentence_embedding_dimension() or 0  # read before quantizing
+    if EMBEDDER_QUANTIZE == "int8":
+        import torch.ao.quantization as ao_q
+
+        _model = ao_q.quantize_dynamic(_model, {torch.nn.Linear}, dtype=torch.qint8)
     sys.stderr.write(
-        f"embedder-server: loaded {MODEL_NAME} dim={_dim} threads={EMBEDDER_THREADS}\n"
+        f"embedder-server: loaded {MODEL_NAME} dim={_dim} threads={EMBEDDER_THREADS}"
+        f" quant={EMBEDDER_QUANTIZE}\n"
     )
     return _model
 
@@ -114,7 +130,10 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.rstrip("/") == "/health":
-            self._send(200, {"status": "ok", "model": MODEL_NAME, "dim": _dim})
+            self._send(
+                200,
+                {"status": "ok", "model": MODEL_NAME, "dim": _dim, "quantize": EMBEDDER_QUANTIZE},
+            )
         else:
             self._send(404, {"error": "not found"})
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -1,21 +1,30 @@
 #!/usr/bin/env python3
-"""embedder-server.py: persistent all-MiniLM-L6-v2 embedding service.
+"""embedder-server.py: persistent embedding service.
 
 A long-lived HTTP service that loads the sentence-transformers model ONCE and
 serves embeddings over HTTP, so the aimee-kb container can embed without paying
-a multi-second model reload on every call (the per-invocation cost of the
-embed-minilm.py popen sidecar). The thin embed-remote.py client in the kb image
-talks to this service; this service holds the model.
+a multi-second model reload on every call. The thin embed-remote.py client in the
+kb image talks to this service; this service holds the model.
+
+Default model: perplexity-ai/pplx-embed-v1-0.6b (1024-dim, Qwen3-based,
+retrieval-optimized, prefix-free). The reported dimension is whatever the loaded
+model produces — it MUST match config embedding_dim and the schema vector(N)
+columns, or vector inserts fail.
+
+Also serves a cross-encoder reranker (lazy-loaded) for the aimee memory rerank
+stage, reusing the resident torch stack instead of a second container.
 
 Endpoints:
-  POST /embed   body = raw UTF-8 text     -> JSON float array (384-dim, L2-norm)
-  GET  /health                            -> {"status":"ok","model":...,"dim":384}
+  POST /embed   body = raw UTF-8 text                 -> JSON float array (model dim)
+  POST /rerank  body = JSON [[query,candidate],...]    -> JSON float score array
+  GET  /health                                         -> {"status":"ok","model":...,"dim":N}
 
 Config (env):
   EMBEDDER_PORT   listen port (default 8080)
-  EMBEDDER_MODEL  sentence-transformers model id (default all-MiniLM-L6-v2)
+  EMBEDDER_MODEL  sentence-transformers model id (default pplx-embed-v1-0.6b)
+  RERANKER_MODEL  cross-encoder model id (default gte-reranker-modernbert-base)
 
-Dependencies: pip install sentence-transformers
+Dependencies: pip install "sentence-transformers>=3.3" einops
 """
 
 import json
@@ -23,14 +32,20 @@ import os
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "all-MiniLM-L6-v2")
+MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-0.6b")
+# Cross-encoder reranker, served from the same process (it reuses the resident
+# torch/sentence-transformers stack). Lazy-loaded on first /rerank so the embedder
+# starts and stays healthy even if reranking is never used.
+RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "Alibaba-NLP/gte-reranker-modernbert-base")
 PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
 
 _model = None
+_dim = 0
+_reranker = None
 
 
 def load_model():
-    global _model
+    global _model, _dim
     if _model is not None:
         return _model
     try:
@@ -38,16 +53,39 @@ def load_model():
     except ImportError:
         sys.stderr.write(
             "embedder-server: sentence-transformers not installed"
-            " (pip install sentence-transformers)\n"
+            ' (pip install "sentence-transformers>=3.3" einops)\n'
         )
         sys.exit(1)
-    _model = SentenceTransformer(MODEL_NAME)
+    # trust_remote_code: the Qwen3-based embedders (pplx-embed, gte-Qwen2) ship
+    # custom modelling code on the Hub.
+    _model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
+    _dim = _model.get_sentence_embedding_dimension() or 0
     return _model
+
+
+def load_reranker():
+    global _reranker
+    if _reranker is not None:
+        return _reranker
+    from sentence_transformers import CrossEncoder
+
+    _reranker = CrossEncoder(RERANKER_MODEL, trust_remote_code=True)
+    return _reranker
 
 
 def embed(text: str):
     vec = load_model().encode(text, normalize_embeddings=True)
     return vec.tolist()
+
+
+def rerank(pairs):
+    """pairs: [[query, candidate], ...] -> [score, ...] (one cross-encoder score
+    per pair, higher = more relevant). Matches the aimee memory_rerank_command
+    contract (memory_core_search.inc: JSON pairs in, JSON float array out)."""
+    if not pairs:
+        return []
+    scores = load_reranker().predict([[str(q), str(c)] for q, c in pairs])
+    return [float(s) for s in scores]
 
 
 class Handler(BaseHTTPRequestHandler):
@@ -64,16 +102,24 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.rstrip("/") == "/health":
-            self._send(200, {"status": "ok", "model": MODEL_NAME, "dim": 384})
+            self._send(200, {"status": "ok", "model": MODEL_NAME, "dim": _dim})
         else:
             self._send(404, {"error": "not found"})
 
     def do_POST(self):
-        if self.path.rstrip("/") != "/embed":
+        path = self.path.rstrip("/")
+        if path not in ("/embed", "/rerank"):
             self._send(404, {"error": "not found"})
             return
         length = int(self.headers.get("content-length", "0") or "0")
         raw = self.rfile.read(length) if length else b""
+        if path == "/rerank":
+            try:
+                pairs = json.loads(raw.decode("utf-8", errors="replace") or "[]")
+                self._send(200, rerank(pairs))
+            except Exception as exc:  # noqa: BLE001
+                self._send(500, {"error": str(exc)})
+            return
         text = raw.decode("utf-8", errors="replace")
         if not text.strip():
             self._send(400, {"error": "empty input"})

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -38,6 +38,19 @@ MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-0.6b"
 # starts and stays healthy even if reranking is never used.
 RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "cross-encoder/ettin-reranker-400m-v1")
 PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
+# CPU serving tuning. A single short embed does not scale past ~8 intra-op
+# threads — on a 32-core host pplx-embed-0.6b is 269ms at 32 threads but 189ms at
+# 8 (per-call thread overhead dominates the tiny workload). Cap to a sane default;
+# an explicit EMBEDDER_THREADS wins. Set OMP before torch is imported.
+EMBEDDER_THREADS = int(os.environ.get("EMBEDDER_THREADS", "0")) or min(8, os.cpu_count() or 8)
+os.environ.setdefault("OMP_NUM_THREADS", str(EMBEDDER_THREADS))
+# Optional ONNX backend: a Hub-relative onnx file (e.g. onnx/model_q4.onnx) serves
+# via onnxruntime instead of torch/safetensors. pplx-embed-0.6b's q4 export is
+# ~1.6x faster on CPU (117ms vs 189ms @ 8 threads, dim unchanged). The image bakes
+# the q4 files and sets this; clear it to fall back to fp32 torch. Loading by an
+# explicit file_name avoids the on-the-fly export that fails on split external
+# data ("External data path validation failed" with a bare backend="onnx").
+EMBEDDER_ONNX_FILE = os.environ.get("EMBEDDER_ONNX_FILE", "")
 
 _model = None
 _dim = 0
@@ -56,10 +69,30 @@ def load_model():
             ' (pip install "sentence-transformers>=3.3" einops)\n'
         )
         sys.exit(1)
+    import torch
+
+    torch.set_num_threads(EMBEDDER_THREADS)
     # trust_remote_code: the Qwen3-based embedders (pplx-embed, gte-Qwen2) ship
     # custom modelling code on the Hub.
-    _model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
+    kwargs = {"trust_remote_code": True}
+    if EMBEDDER_ONNX_FILE:
+        kwargs["backend"] = "onnx"
+        kwargs["model_kwargs"] = {"file_name": EMBEDDER_ONNX_FILE}
+    try:
+        _model = SentenceTransformer(MODEL_NAME, **kwargs)
+    except Exception as exc:  # noqa: BLE001 - any ONNX/optimum failure → torch
+        if not EMBEDDER_ONNX_FILE:
+            raise
+        sys.stderr.write(
+            f"embedder-server: ONNX backend ({EMBEDDER_ONNX_FILE}) failed"
+            f" ({type(exc).__name__}: {exc}); falling back to fp32 torch\n"
+        )
+        _model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
     _dim = _model.get_sentence_embedding_dimension() or 0
+    sys.stderr.write(
+        f"embedder-server: loaded {MODEL_NAME} dim={_dim} threads={EMBEDDER_THREADS}"
+        f" backend={'onnx:' + EMBEDDER_ONNX_FILE if EMBEDDER_ONNX_FILE else 'torch'}\n"
+    )
     return _model
 
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -44,13 +44,6 @@ PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
 # an explicit EMBEDDER_THREADS wins. Set OMP before torch is imported.
 EMBEDDER_THREADS = int(os.environ.get("EMBEDDER_THREADS", "0")) or min(8, os.cpu_count() or 8)
 os.environ.setdefault("OMP_NUM_THREADS", str(EMBEDDER_THREADS))
-# Optional ONNX backend: a Hub-relative onnx file (e.g. onnx/model_q4.onnx) serves
-# via onnxruntime instead of torch/safetensors. pplx-embed-0.6b's q4 export is
-# ~1.6x faster on CPU (117ms vs 189ms @ 8 threads, dim unchanged). The image bakes
-# the q4 files and sets this; clear it to fall back to fp32 torch. Loading by an
-# explicit file_name avoids the on-the-fly export that fails on split external
-# data ("External data path validation failed" with a bare backend="onnx").
-EMBEDDER_ONNX_FILE = os.environ.get("EMBEDDER_ONNX_FILE", "")
 
 _model = None
 _dim = 0
@@ -74,24 +67,10 @@ def load_model():
     torch.set_num_threads(EMBEDDER_THREADS)
     # trust_remote_code: the Qwen3-based embedders (pplx-embed, gte-Qwen2) ship
     # custom modelling code on the Hub.
-    kwargs = {"trust_remote_code": True}
-    if EMBEDDER_ONNX_FILE:
-        kwargs["backend"] = "onnx"
-        kwargs["model_kwargs"] = {"file_name": EMBEDDER_ONNX_FILE}
-    try:
-        _model = SentenceTransformer(MODEL_NAME, **kwargs)
-    except Exception as exc:  # noqa: BLE001 - any ONNX/optimum failure → torch
-        if not EMBEDDER_ONNX_FILE:
-            raise
-        sys.stderr.write(
-            f"embedder-server: ONNX backend ({EMBEDDER_ONNX_FILE}) failed"
-            f" ({type(exc).__name__}: {exc}); falling back to fp32 torch\n"
-        )
-        _model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
+    _model = SentenceTransformer(MODEL_NAME, trust_remote_code=True)
     _dim = _model.get_sentence_embedding_dimension() or 0
     sys.stderr.write(
-        f"embedder-server: loaded {MODEL_NAME} dim={_dim} threads={EMBEDDER_THREADS}"
-        f" backend={'onnx:' + EMBEDDER_ONNX_FILE if EMBEDDER_ONNX_FILE else 'torch'}\n"
+        f"embedder-server: loaded {MODEL_NAME} dim={_dim} threads={EMBEDDER_THREADS}\n"
     )
     return _model
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -22,7 +22,7 @@ Endpoints:
 Config (env):
   EMBEDDER_PORT   listen port (default 8080)
   EMBEDDER_MODEL  sentence-transformers model id (default pplx-embed-v1-0.6b)
-  RERANKER_MODEL  cross-encoder model id (default gte-reranker-modernbert-base)
+  RERANKER_MODEL  cross-encoder model id (default ettin-reranker-400m-v1)
 
 Dependencies: pip install "sentence-transformers>=3.3" einops
 """
@@ -36,7 +36,7 @@ MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-0.6b"
 # Cross-encoder reranker, served from the same process (it reuses the resident
 # torch/sentence-transformers stack). Lazy-loaded on first /rerank so the embedder
 # starts and stays healthy even if reranking is never used.
-RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "Alibaba-NLP/gte-reranker-modernbert-base")
+RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "cross-encoder/ettin-reranker-400m-v1")
 PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
 
 _model = None

--- a/scripts/rerank-remote.py
+++ b/scripts/rerank-remote.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""rerank-remote.py: thin memory_rerank_command client for the embedder service.
+
+aimee's cross-encoder rerank stage (memory_core_search.inc:
+memory_cross_encoder_scores) shells out to memory_rerank_command with a JSON
+array of [query, candidate] pairs on stdin and expects a JSON float array of
+scores on stdout (higher = more relevant). On any non-zero exit / malformed
+output the C caller silently falls back to hybrid ordering, so this never has to
+be present — but when it is, it gives a second-pass cross-encoder rerank of the
+top-K candidates.
+
+This client holds no model: it POSTs the pairs to the persistent embedder-server
+(/rerank), which serves the cross-encoder from its resident torch stack. Stdlib
+only — no torch in the kb image.
+
+Contract:
+  stdin:  JSON [[query, cand0], [query, cand1], ...]
+  stdout: JSON [score0, score1, ...]   (same length/order)
+  exit 0 on success; non-zero on error (C caller logs + falls back).
+
+Config (env):
+  AIMEE_EMBEDDER_URL  base URL of embedder-server (default http://embedder:8080)
+  AIMEE_RERANK_TIMEOUT  request timeout seconds (default 30)
+
+Usage:
+  memory_rerank_command: "python3 /opt/aimee/scripts/rerank-remote.py"
+"""
+
+import os
+import sys
+import urllib.error
+import urllib.request
+
+ENDPOINT = os.environ.get("AIMEE_EMBEDDER_URL", "http://embedder:8080").rstrip("/")
+TIMEOUT = int(os.environ.get("AIMEE_RERANK_TIMEOUT", "30"))
+
+
+def main() -> None:
+    payload = sys.stdin.read()
+    if not payload.strip():
+        sys.stderr.write("rerank-remote: empty input\n")
+        sys.exit(1)
+
+    req = urllib.request.Request(
+        f"{ENDPOINT}/rerank",
+        data=payload.encode("utf-8"),
+        headers={"content-type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+            body = resp.read().decode("utf-8")
+    except urllib.error.URLError as exc:
+        sys.stderr.write(f"rerank-remote: request to {ENDPOINT} failed: {exc}\n")
+        sys.exit(1)
+
+    # Pass the embedder service's JSON score array straight through.
+    sys.stdout.write(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/config.c
+++ b/src/config.c
@@ -418,6 +418,17 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;
    cfg->kb_search_max_results = 50;
+   /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
+    * Must match the schema vector(N) columns and the embedder model. */
+   cfg->embedding_dim = 1024;
+   /* The cross-encoder rerank stage (gte-reranker-modernbert-base, served by the
+    * embedder service /rerank, client scripts/rerank-remote.py) is wired and
+    * shipped but stays default-off — it is an unvalidated quality/latency
+    * tradeoff (per-query top-K cross-encoder pass), so it follows the
+    * rollout-readiness discipline (validate, then flip). Enable it with:
+    *   aimee config set memory_rerank_enabled 1
+    *   aimee config set memory_rerank_command "python3 /opt/aimee/scripts/rerank-remote.py"
+    * It degrades safely to hybrid ordering if the reranker is absent or errors. */
    cfg->memory_routing_enabled = 1;
    /* Default-on to preserve behavior: profile-card refresh ran ungated in the
     * maintenance REPLAY pass before the enable-gate was wired. Maintenance is

--- a/src/config.c
+++ b/src/config.c
@@ -421,7 +421,7 @@ static void config_set_defaults(config_t *cfg)
    /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
     * Must match the schema vector(N) columns and the embedder model. */
    cfg->embedding_dim = 1024;
-   /* The cross-encoder rerank stage (gte-reranker-modernbert-base, served by the
+   /* The cross-encoder rerank stage (ettin-reranker-400m-v1, served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is wired and
     * shipped but stays default-off — it is an unvalidated quality/latency
     * tradeoff (per-query top-K cross-encoder pass), so it follows the

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -620,7 +620,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS memory_embeddings (
             point_id      BIGINT PRIMARY KEY,
-            embedding     vector(384),
+            embedding     vector(1024),
             record_type   TEXT NOT NULL DEFAULT '',
             primary_scope TEXT NOT NULL DEFAULT '',
             workspace     TEXT NOT NULL DEFAULT '',
@@ -633,7 +633,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS kb_embeddings (
             point_id     BIGINT PRIMARY KEY,
-            embedding    vector(384),
+            embedding    vector(1024),
             project      TEXT NOT NULL DEFAULT '',
             payload_json TEXT NOT NULL DEFAULT ''
         )
@@ -648,7 +648,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_entity_vectors (
             point_id       BIGINT PRIMARY KEY,
-            embedding      vector(384),
+            embedding      vector(1024),
             scope_kind     TEXT NOT NULL DEFAULT '',
             scope_id       TEXT NOT NULL DEFAULT '',
             canonical_name TEXT NOT NULL DEFAULT '',
@@ -668,7 +668,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_narrative_vectors (
             point_id     BIGINT PRIMARY KEY,
-            embedding    vector(384),
+            embedding    vector(1024),
             artifact_id  TEXT NOT NULL DEFAULT '',
             kind         TEXT NOT NULL DEFAULT '',
             doc_id       TEXT NOT NULL DEFAULT '',
@@ -687,8 +687,8 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_claim_vectors (
             point_id      BIGINT PRIMARY KEY,
-            subj_attr_vec vector(384),
-            value_vec     vector(384),
+            subj_attr_vec vector(1024),
+            value_vec     vector(1024),
             artifact_id   TEXT NOT NULL DEFAULT '',
             subject       TEXT NOT NULL DEFAULT '',
             attribute     TEXT NOT NULL DEFAULT '',
@@ -709,9 +709,9 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_code_unit_vectors (
             point_id      BIGINT PRIMARY KEY,
-            intent_vec    vector(384),
-            signature_vec vector(384),
-            body_vec      vector(384),
+            intent_vec    vector(1024),
+            signature_vec vector(1024),
+            body_vec      vector(1024),
             artifact_id   TEXT NOT NULL DEFAULT '',
             file_path     TEXT NOT NULL DEFAULT '',
             def_kind      TEXT NOT NULL DEFAULT '',
@@ -721,34 +721,28 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         )
     $T$;
 
-    -- The embedding columns must carry a fixed dimension or the HNSW index
-    -- below cannot be built (pgvector rejects an HNSW index on an
-    -- undimensioned `vector` column), which leaves a fresh database with no
-    -- usable vector index and /v1/health reporting pgvector degraded. All
-    -- embedders in the stack emit 384 dims (MiniLM). This ALTER migrates
-    -- databases created before the columns were dimensioned; it is a no-op
-    -- once the columns are already vector(384).
+    -- The embedding columns carry a fixed dimension (vector(1024)) matching the
+    -- default embedder perplexity-ai/pplx-embed-v1-0.6b; a fresh database gets
+    -- that straight from the CREATE TABLE definitions above. We deliberately do
+    -- NOT auto-alter an existing differently-dimensioned column here: a database
+    -- created with the old 384-dim embedder (all-MiniLM-L6-v2) holds vector(1024)
+    -- columns full of incompatible vectors, and silently clearing them on a
+    -- routine schema-apply would wipe the corpus. Instead we surface a clear
+    -- NOTICE; the operator runs deploy/migrations/2026-embed-dim-1024.sql (after a
+    -- backup) to drop the HNSW indexes, clear the columns to vector(1024), and
+    -- re-embed. Vector ops degrade (not crash) until then.
+    DECLARE
+        cur_type text;
     BEGIN
-        EXECUTE $T$ ALTER TABLE memory_embeddings
-                    ALTER COLUMN embedding TYPE vector(384) USING embedding::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE kb_embeddings
-                    ALTER COLUMN embedding TYPE vector(384) USING embedding::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_entity_vectors
-                    ALTER COLUMN embedding TYPE vector(384) USING embedding::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_narrative_vectors
-                    ALTER COLUMN embedding TYPE vector(384) USING embedding::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_claim_vectors
-                    ALTER COLUMN subj_attr_vec TYPE vector(384) USING subj_attr_vec::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_claim_vectors
-                    ALTER COLUMN value_vec TYPE vector(384) USING value_vec::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_code_unit_vectors
-                    ALTER COLUMN intent_vec TYPE vector(384) USING intent_vec::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_code_unit_vectors
-                    ALTER COLUMN signature_vec TYPE vector(384) USING signature_vec::vector(384) $T$;
-        EXECUTE $T$ ALTER TABLE curator_code_unit_vectors
-                    ALTER COLUMN body_vec TYPE vector(384) USING body_vec::vector(384) $T$;
+        SELECT format_type(atttypid, atttypmod) INTO cur_type
+          FROM pg_attribute
+         WHERE attrelid = 'memory_embeddings'::regclass
+           AND attname = 'embedding' AND NOT attisdropped;
+        IF cur_type IS NOT NULL AND cur_type <> 'vector(1024)' THEN
+            RAISE NOTICE 'aimee: embedding columns are "%" but the embedder now produces vector(1024). Vector ops are degraded until you run deploy/migrations/2026-embed-dim-1024.sql (clears old embeddings, re-embed required) — back up DB2 first.', cur_type;
+        END IF;
     EXCEPTION WHEN OTHERS THEN
-        RAISE NOTICE 'embedding column dimension migration skipped (%)', SQLERRM;
+        RAISE NOTICE 'embedding dimension check skipped (%)', SQLERRM;
     END;
 
     EXECUTE $T$
@@ -861,7 +855,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
                 id          BIGSERIAL PRIMARY KEY,
                 artifact_id TEXT      NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
                 collection  TEXT      NOT NULL DEFAULT 'case_exemplars',
-                embedding   vector(384),
+                embedding   vector(1024),
                 created_at  TEXT      NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
             )
         $T$;
@@ -887,7 +881,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
                 id          BIGSERIAL PRIMARY KEY,
                 artifact_id TEXT      NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
                 collection  TEXT      NOT NULL DEFAULT 'evidence',
-                embedding   vector(384),
+                embedding   vector(1024),
                 created_at  TEXT      NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
             )
         $T$;

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -425,7 +425,7 @@ static int kb_run_fusion_probe(const char *query)
     * block) unless the pgvector memory collection exists, so ensure it. */
    if (pgvec_memory_vector_collection_exists() <= 0)
    {
-      int dim = cfg.embedding_dim > 0 ? cfg.embedding_dim : 384;
+      int dim = cfg.embedding_dim > 0 ? cfg.embedding_dim : 1024;
       (void)pgvec_memory_vector_collection_recreate(dim);
    }
 


### PR DESCRIPTION
## What

Replace the 2021 **all-MiniLM-L6-v2** (384-dim, MTEB ~56) embedder with **`perplexity-ai/pplx-embed-v1-0.6b`** (Feb 2026, MIT, Qwen3-based, **1024-dim**, retrieval-optimized, prefix-free, MTEB ~70), and wire a **cross-encoder rerank** stage (default-off).

## Embedder (1024-dim)
- `Dockerfile.embedder`: `EMBEDDER_MODEL` build-arg as the single source of truth → pplx-embed-v1-0.6b; `trust_remote_code` + `einops` + `sentence-transformers>=3.3`.
- `embedder-server.py`: loads with `trust_remote_code`; `/health` now reports the model's **real** dimension (was hardcoded 384).
- `config embedding_dim` default → 1024 (`kb_main` fallback 384→1024).
- `schema.sql`: all `vector(384)` → `vector(1024)`. The old auto-coerce block is replaced by a **guarded NOTICE** — a routine schema-apply never silently wipes an existing 384-dim corpus; it points the operator at the migration.

## Migration (`deploy/migrations/2026-embed-dim-1024.sql`)
Dynamic + idempotent + transactional: drops the HNSW indexes, reshapes every `vector(N≠1024)` column to `vector(1024)` **clearing** the dimension-incompatible embeddings, resets the reembed rollover. Old 384-d vectors can't convert to 1024, so **the corpus must be re-embedded** (`aimee memory reembed --start` → `--cutover`). Documented sequence: back up → deploy new embedder → confirm `/health` dim=1024 → run migration → restart (rebuilds indexes) → re-embed.

## Reranker (wired + shipped, **default-off**)
- `embedder-server.py` also serves **`/rerank`** — a lazy-loaded `CrossEncoder` (default **`Alibaba-NLP/gte-reranker-modernbert-base`**, 149M, Apache-2.0) from the *same* resident torch stack (no second container).
- `scripts/rerank-remote.py`: the `memory_rerank_command` client (`[[query,candidate],…]` → scores), shipped in the server/kb/combined images. Matches `memory_core_search.inc`'s contract and **degrades to hybrid ordering** on any failure.
- Kept **default-off**: it's an unvalidated quality/latency tradeoff (per-query top-K cross-encoder pass), so it follows the rollout-readiness discipline. Enable with `config set memory_rerank_enabled 1` + the rerank command. A modern 149M cross-encoder beats far larger ones and stays CPU-cheap at top-K=50/query.

## Validation
- `make verify-local` green (C build, unit-tests, lint).
- **CI `e2e-docker` exercises the real models**: it builds the embedder image (downloads + loads *both* models) and runs the combined stack on the `vector(1024)` schema — so a green run confirms the models load and the schema is sound.
- **Still needs `.254` live validation before enabling/deploying**: the migration + re-embed against the real corpus, and an **A/B of recall quality** (and the rerank stage) — exactly the rollout-readiness gate. This PR is intentionally *not* an auto-merge: validate first.
