### PR TITLE
db2: unify all embedding columns on halfvec (fp16)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,12 @@ jobs:
     # memories_code_fts trigram index (see src/schema/postgres.sql).
     services:
       postgres:
-        image: postgres:17-alpine
+        # pgvector/pgvector (debian, not alpine) so the embedding tables exercise
+        # the REAL vector path: it ships pgvector >= 0.7 (halfvec — the unified
+        # embedding column type) and the contrib modules incl. pg_trgm (the
+        # memories_code_fts trigram index). postgres:17-alpine shipped neither, so
+        # schema apply degraded; e2e-docker already runs on this image family.
+        image: pgvector/pgvector:pg18
         env:
           POSTGRES_USER: aimee
           POSTGRES_PASSWORD: aimee

--- a/deploy/migrations/2026-embed-halfvec.sql
+++ b/deploy/migrations/2026-embed-halfvec.sql
@@ -1,0 +1,78 @@
+-- 2026-embed-halfvec.sql
+--
+-- Convert every embedding column from vector (fp32) to halfvec (fp16), unifying
+-- on one vector type. halfvec halves index memory + storage and speeds up HNSW
+-- at negligible quality cost (fp16 ~= fp32 for normalized-embedding cosine
+-- recall — ~0.999 cosine, nothing like int8). pgvector added halfvec for exactly
+-- this. It also lets the live and the deep (halfvec(2560)) tiers share one type.
+--
+-- THIS IS A CAST, NOT A RE-EMBED: the dimension is unchanged (vector(1024) ->
+-- halfvec(1024)), so the stored values are preserved in place. No re-embedding,
+-- no recall downtime beyond the index rebuild. (Contrast 2026-embed-dim-1024.sql,
+-- which changes the dimension and DOES require a re-embed.)
+--
+-- REQUIRES pgvector >= 0.7.0 (halfvec type + halfvec_cosine_ops). Verify with
+--   SELECT extversion FROM pg_extension WHERE extname='vector';
+-- A fresh schema apply already creates halfvec columns; this migrates an existing
+-- vector(N) database. Back up DB2 first.
+--
+-- AFTER RUNNING: restart aimee-server/kb so schema.sql recreates the HNSW indexes
+-- with halfvec_cosine_ops (CREATE INDEX IF NOT EXISTS). Until then vector search
+-- falls back to a sequential scan (correct, just slower).
+--
+-- Idempotent: re-running is a no-op once every embedding column is already halfvec.
+
+BEGIN;
+
+-- Fail loudly if halfvec is unavailable rather than half-applying.
+DO $CHECK$
+BEGIN
+    PERFORM 'halfvec'::regtype;
+EXCEPTION WHEN undefined_object THEN
+    RAISE EXCEPTION 'halfvec unification needs pgvector >= 0.7.0 (halfvec type missing). Upgrade pgvector, then re-run.';
+END
+$CHECK$;
+
+-- Drop the pgvector indexes on the embedding columns; ALTER COLUMN TYPE cannot
+-- proceed while an index depends on the column. schema.sql recreates them with
+-- halfvec_cosine_ops on the next startup.
+DROP INDEX IF EXISTS idx_memory_embeddings_hnsw;
+DROP INDEX IF EXISTS idx_memory_embeddings_deep_hnsw;
+DROP INDEX IF EXISTS idx_kb_embeddings_hnsw;
+DROP INDEX IF EXISTS idx_code_embeddings_hnsw;
+DROP INDEX IF EXISTS idx_curator_entity_vectors_hnsw;
+DROP INDEX IF EXISTS idx_curator_narrative_vectors_hnsw;
+DROP INDEX IF EXISTS idx_curator_claim_vectors_subj_attr_hnsw;
+DROP INDEX IF EXISTS idx_curator_claim_vectors_value_hnsw;
+DROP INDEX IF EXISTS idx_curator_code_unit_vectors_intent_hnsw;
+DROP INDEX IF EXISTS idx_curator_code_unit_vectors_signature_hnsw;
+DROP INDEX IF EXISTS idx_curator_code_unit_vectors_body_hnsw;
+
+-- Cast every vector(N) column to halfvec(N) in place (fp32 -> fp16; same dim, data
+-- preserved). Dynamic so no column is missed.
+DO $MIG$
+DECLARE
+    r   RECORD;
+    dim text;
+BEGIN
+    FOR r IN
+        SELECT c.relname AS tbl, a.attname AS col,
+               format_type(a.atttypid, a.atttypmod) AS typ
+          FROM pg_attribute a
+          JOIN pg_class c     ON c.oid = a.attrelid
+          JOIN pg_namespace n ON n.oid = c.relnamespace
+         WHERE n.nspname = 'public'
+           AND c.relkind = 'r'
+           AND NOT a.attisdropped
+           AND format_type(a.atttypid, a.atttypmod) LIKE 'vector(%'
+    LOOP
+        dim := (regexp_match(r.typ, '\((\d+)\)'))[1];
+        EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE halfvec(%s) USING %I::halfvec(%s)',
+                       r.tbl, r.col, dim, r.col, dim);
+        RAISE NOTICE 'halfvec migration: %.% % -> halfvec(%) (cast, data preserved)',
+                     r.tbl, r.col, r.typ, dim;
+    END LOOP;
+END
+$MIG$;
+
+COMMIT;

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -166,7 +166,7 @@ int pgvec_ensure_index(const char *table, int dim, int recreate)
    char sql[256];
    snprintf(sql, sizeof(sql),
             "CREATE INDEX IF NOT EXISTS idx_%s_hnsw "
-            "ON %s USING hnsw (embedding vector_cosine_ops)",
+            "ON %s USING hnsw (embedding halfvec_cosine_ops)",
             table, table);
    if (aimee_pg_exec(pg, sql, errbuf, sizeof(errbuf)) != 0)
    {
@@ -237,12 +237,12 @@ int pgvec_ensure_corpus_index(const char *table, const char *index_type, int rec
    if (use_type && strcmp(use_type, "diskann") == 0)
       snprintf(sql, sizeof(sql),
                "CREATE INDEX IF NOT EXISTS idx_%s_diskann "
-               "ON %s USING diskann (embedding vector_cosine_ops)",
+               "ON %s USING diskann (embedding halfvec_cosine_ops)",
                table, table);
    else
       snprintf(sql, sizeof(sql),
                "CREATE INDEX IF NOT EXISTS idx_%s_hnsw "
-               "ON %s USING hnsw (embedding vector_cosine_ops)",
+               "ON %s USING hnsw (embedding halfvec_cosine_ops)",
                table, table);
 
    if (aimee_pg_exec(pg, sql, errbuf, sizeof(errbuf)) != 0)
@@ -298,7 +298,7 @@ int pgvec_memory_upsert(int64_t point_id, const float *vec, int dim, const char 
                             "  (point_id, embedding, record_type, primary_scope, workspace, "
                             "project, kind, payload_json) "
                             "VALUES "
-                            "  (:point_id, :embedding::vector, :record_type, :primary_scope, "
+                            "  (:point_id, :embedding::halfvec, :record_type, :primary_scope, "
                             ":workspace, :project, :kind, :payload) "
                             "ON CONFLICT (point_id) DO UPDATE SET "
                             "  embedding = EXCLUDED.embedding, "
@@ -377,7 +377,7 @@ int pgvec_kb_upsert(int64_t point_id, const float *vec, int dim, const char *pay
    static const char *sql = "INSERT INTO kb_embeddings "
                             "  (point_id, embedding, project, payload_json) "
                             "VALUES "
-                            "  (:point_id, :embedding::vector, :project, :payload) "
+                            "  (:point_id, :embedding::halfvec, :project, :payload) "
                             "ON CONFLICT (point_id) DO UPDATE SET "
                             "  embedding = EXCLUDED.embedding, "
                             "  project = EXCLUDED.project, "
@@ -559,9 +559,9 @@ int pgvec_memory_search(const float *vec, int dim, const char *record_type,
 
    char sql[2048];
    snprintf(sql, sizeof(sql),
-            "SELECT point_id, 1.0 - (embedding <=> :qvec::vector) AS score "
+            "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
             "FROM memory_embeddings %s%s "
-            "ORDER BY embedding <=> :qvec::vector "
+            "ORDER BY embedding <=> :qvec::halfvec "
             "LIMIT :lim",
             where, kinds_clause);
 
@@ -620,10 +620,10 @@ int pgvec_kb_search(const char *project, const float *vec, int dim, int limit, i
    if (!vec_text)
       return -1;
 
-   static const char *sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::vector) AS score "
+   static const char *sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
                             "FROM kb_embeddings "
                             "WHERE project = :project "
-                            "ORDER BY embedding <=> :qvec::vector "
+                            "ORDER BY embedding <=> :qvec::halfvec "
                             "LIMIT :lim";
 
    char errbuf[256];
@@ -674,7 +674,7 @@ int pgvec_curator_entity_upsert(int64_t point_id, const float *vec, int dim, con
        "INSERT INTO curator_entity_vectors "
        "  (point_id, embedding, scope_kind, scope_id, canonical_name, artifact_id, payload_json) "
        "VALUES "
-       "  (:point_id, :embedding::vector, :scope_kind, :scope_id, :canonical_name, :artifact_id, "
+       "  (:point_id, :embedding::halfvec, :scope_kind, :scope_id, :canonical_name, :artifact_id, "
        "   :payload) "
        "ON CONFLICT (point_id) DO UPDATE SET "
        "  embedding = EXCLUDED.embedding, "
@@ -800,10 +800,10 @@ int pgvec_curator_entity_search(const char *scope_kind, const char *scope_id, co
       return -1;
    }
    snprintf(sql, sql_len,
-            "SELECT point_id, 1.0 - (embedding <=> :qvec::vector) AS score "
+            "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
             "FROM curator_entity_vectors "
             "%s "
-            "ORDER BY embedding <=> :qvec::vector "
+            "ORDER BY embedding <=> :qvec::halfvec "
             "LIMIT :lim",
             where_sql);
 
@@ -860,7 +860,7 @@ int pgvec_curator_narrative_upsert(int64_t point_id, const float *vec, int dim,
        "INSERT INTO curator_narrative_vectors "
        "  (point_id, embedding, artifact_id, kind, doc_id, status, priority, payload_json) "
        "VALUES "
-       "  (:point_id, :embedding::vector, :artifact_id, :kind, :doc_id, :status, :priority, "
+       "  (:point_id, :embedding::halfvec, :artifact_id, :kind, :doc_id, :status, :priority, "
        ":payload) "
        "ON CONFLICT (point_id) DO UPDATE SET "
        "  embedding = EXCLUDED.embedding, "
@@ -961,10 +961,10 @@ int pgvec_curator_narrative_search(const char *kind, const char *status, const c
       return -1;
    }
    snprintf(sql, sql_len,
-            "SELECT point_id, 1.0 - (embedding <=> :qvec::vector) AS score "
+            "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
             "FROM curator_narrative_vectors "
             "%s "
-            "ORDER BY embedding <=> :qvec::vector "
+            "ORDER BY embedding <=> :qvec::halfvec "
             "LIMIT :lim",
             where_sql);
 
@@ -1029,7 +1029,7 @@ int pgvec_curator_claim_upsert(int64_t point_id, const float *subj_attr_vec, con
        "  (point_id, subj_attr_vec, value_vec, artifact_id, subject, attribute, value, "
        "   claim_kind, payload_json) "
        "VALUES "
-       "  (:point_id, :subj_attr::vector, :value::vector, :artifact_id, :subject, :attribute, "
+       "  (:point_id, :subj_attr::halfvec, :value::halfvec, :artifact_id, :subject, :attribute, "
        "   :value_col, :claim_kind, :payload) "
        "ON CONFLICT (point_id) DO UPDATE SET "
        "  subj_attr_vec = EXCLUDED.subj_attr_vec, "
@@ -1115,10 +1115,10 @@ int pgvec_curator_claim_search(const char *which_vec, const char *claim_kind, co
       return -1;
    }
    snprintf(sql, sql_len,
-            "SELECT point_id, 1.0 - (%s <=> :qvec::vector) AS score "
+            "SELECT point_id, 1.0 - (%s <=> :qvec::halfvec) AS score "
             "FROM curator_claim_vectors "
             "%s "
-            "ORDER BY %s <=> :qvec::vector "
+            "ORDER BY %s <=> :qvec::halfvec "
             "LIMIT :lim",
             col_name, have_kind ? "WHERE claim_kind = :claim_kind" : "", col_name);
 
@@ -1185,7 +1185,7 @@ int pgvec_curator_code_unit_upsert(int64_t point_id, const float *intent_vec,
        "  (point_id, intent_vec, signature_vec, body_vec, artifact_id, file_path, "
        "   def_kind, signature, body_hash, payload_json) "
        "VALUES "
-       "  (:point_id, :intent::vector, :signature_v::vector, :body::vector, :artifact_id, "
+       "  (:point_id, :intent::halfvec, :signature_v::halfvec, :body::halfvec, :artifact_id, "
        "   :file_path, :def_kind, :sig_col, :body_hash, :payload) "
        "ON CONFLICT (point_id) DO UPDATE SET "
        "  intent_vec    = EXCLUDED.intent_vec, "
@@ -1277,10 +1277,10 @@ int pgvec_curator_code_unit_search(const char *which_vec, const char *def_kind, 
       return -1;
    }
    snprintf(sql, sql_len,
-            "SELECT point_id, 1.0 - (%s <=> :qvec::vector) AS score "
+            "SELECT point_id, 1.0 - (%s <=> :qvec::halfvec) AS score "
             "FROM curator_code_unit_vectors "
             "%s "
-            "ORDER BY %s <=> :qvec::vector "
+            "ORDER BY %s <=> :qvec::halfvec "
             "LIMIT :lim",
             col_name, have_kind ? "WHERE def_kind = :def_kind" : "", col_name);
 
@@ -1338,7 +1338,7 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
        "   content_hash, body_hash, payload_json,"
        "   updated_at)"
        " VALUES"
-       "  (:point_id, :embedding::vector, :project, :node_key, :file_path, :symbol,"
+       "  (:point_id, :embedding::halfvec, :project, :node_key, :file_path, :symbol,"
        "   :content_hash, :body_hash, :payload,"
        "   to_char(CURRENT_TIMESTAMP,'YYYY-MM-DD HH24:MI:SS'))"
        " ON CONFLICT (point_id) DO UPDATE SET"
@@ -1425,14 +1425,14 @@ int pgvec_code_search(const char *project, const float *vec, int dim, int limit,
 
    const char *sql;
    if (project && *project)
-      sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::vector) AS score"
+      sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score"
             " FROM code_embeddings"
             " WHERE project = :project"
-            " ORDER BY embedding <=> :qvec::vector LIMIT :lim";
+            " ORDER BY embedding <=> :qvec::halfvec LIMIT :lim";
    else
-      sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::vector) AS score"
+      sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score"
             " FROM code_embeddings"
-            " ORDER BY embedding <=> :qvec::vector LIMIT :lim";
+            " ORDER BY embedding <=> :qvec::halfvec LIMIT :lim";
 
    char errbuf[256];
    aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -620,7 +620,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS memory_embeddings (
             point_id      BIGINT PRIMARY KEY,
-            embedding     vector(1024),
+            embedding     halfvec(1024),
             record_type   TEXT NOT NULL DEFAULT '',
             primary_scope TEXT NOT NULL DEFAULT '',
             workspace     TEXT NOT NULL DEFAULT '',
@@ -633,7 +633,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS kb_embeddings (
             point_id     BIGINT PRIMARY KEY,
-            embedding    vector(1024),
+            embedding    halfvec(1024),
             project      TEXT NOT NULL DEFAULT '',
             payload_json TEXT NOT NULL DEFAULT ''
         )
@@ -648,7 +648,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_entity_vectors (
             point_id       BIGINT PRIMARY KEY,
-            embedding      vector(1024),
+            embedding      halfvec(1024),
             scope_kind     TEXT NOT NULL DEFAULT '',
             scope_id       TEXT NOT NULL DEFAULT '',
             canonical_name TEXT NOT NULL DEFAULT '',
@@ -668,7 +668,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_narrative_vectors (
             point_id     BIGINT PRIMARY KEY,
-            embedding    vector(1024),
+            embedding    halfvec(1024),
             artifact_id  TEXT NOT NULL DEFAULT '',
             kind         TEXT NOT NULL DEFAULT '',
             doc_id       TEXT NOT NULL DEFAULT '',
@@ -687,8 +687,8 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_claim_vectors (
             point_id      BIGINT PRIMARY KEY,
-            subj_attr_vec vector(1024),
-            value_vec     vector(1024),
+            subj_attr_vec halfvec(1024),
+            value_vec     halfvec(1024),
             artifact_id   TEXT NOT NULL DEFAULT '',
             subject       TEXT NOT NULL DEFAULT '',
             attribute     TEXT NOT NULL DEFAULT '',
@@ -709,9 +709,9 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     EXECUTE $T$
         CREATE TABLE IF NOT EXISTS curator_code_unit_vectors (
             point_id      BIGINT PRIMARY KEY,
-            intent_vec    vector(1024),
-            signature_vec vector(1024),
-            body_vec      vector(1024),
+            intent_vec    halfvec(1024),
+            signature_vec halfvec(1024),
+            body_vec      halfvec(1024),
             artifact_id   TEXT NOT NULL DEFAULT '',
             file_path     TEXT NOT NULL DEFAULT '',
             def_kind      TEXT NOT NULL DEFAULT '',
@@ -721,16 +721,16 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         )
     $T$;
 
-    -- The embedding columns carry a fixed dimension (vector(1024)) matching the
-    -- default embedder perplexity-ai/pplx-embed-v1-0.6b; a fresh database gets
-    -- that straight from the CREATE TABLE definitions above. We deliberately do
-    -- NOT auto-alter an existing differently-dimensioned column here: a database
-    -- created with the old 384-dim embedder (all-MiniLM-L6-v2) holds vector(1024)
-    -- columns full of incompatible vectors, and silently clearing them on a
-    -- routine schema-apply would wipe the corpus. Instead we surface a clear
-    -- NOTICE; the operator runs deploy/migrations/2026-embed-dim-1024.sql (after a
-    -- backup) to drop the HNSW indexes, clear the columns to vector(1024), and
-    -- re-embed. Vector ops degrade (not crash) until then.
+    -- The embedding columns are halfvec(1024) — fp16, matching the default
+    -- embedder pplx-embed-v1-0.6b's 1024-dim output; a fresh database gets that
+    -- straight from the CREATE TABLE definitions above. We deliberately do NOT
+    -- auto-alter an existing differently-typed column here (a routine schema-apply
+    -- must never reshape the corpus); instead we surface a NOTICE:
+    --   * a column still vector(1024) (pre-halfvec) just needs an in-place cast —
+    --     run deploy/migrations/2026-embed-halfvec.sql (no re-embed);
+    --   * a column with a different DIMENSION (e.g. old vector(384) all-MiniLM)
+    --     additionally needs a re-embed — deploy/migrations/2026-embed-dim-1024.sql.
+    -- Vector ops degrade (not crash) until then.
     DECLARE
         cur_type text;
     BEGIN
@@ -738,8 +738,8 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
           FROM pg_attribute
          WHERE attrelid = 'memory_embeddings'::regclass
            AND attname = 'embedding' AND NOT attisdropped;
-        IF cur_type IS NOT NULL AND cur_type <> 'vector(1024)' THEN
-            RAISE NOTICE 'aimee: embedding columns are "%" but the embedder now produces vector(1024). Vector ops are degraded until you run deploy/migrations/2026-embed-dim-1024.sql (clears old embeddings, re-embed required) — back up DB2 first.', cur_type;
+        IF cur_type IS NOT NULL AND cur_type <> 'halfvec(1024)' THEN
+            RAISE NOTICE 'aimee: embedding columns are "%" but expected halfvec(1024). Run deploy/migrations/2026-embed-halfvec.sql to cast (no re-embed); if the dimension also differs, re-embed too. Vector ops degraded until then — back up DB2 first.', cur_type;
         END IF;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'embedding dimension check skipped (%)', SQLERRM;
@@ -777,7 +777,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_memory_embeddings_hnsw
-                ON memory_embeddings USING hnsw (embedding vector_cosine_ops)
+                ON memory_embeddings USING hnsw (embedding halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'memory_embeddings HNSW index skipped (%)', SQLERRM;
@@ -785,7 +785,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_kb_embeddings_hnsw
-                ON kb_embeddings USING hnsw (embedding vector_cosine_ops)
+                ON kb_embeddings USING hnsw (embedding halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'kb_embeddings HNSW index skipped (%)', SQLERRM;
@@ -793,7 +793,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_entity_vectors_hnsw
-                ON curator_entity_vectors USING hnsw (embedding vector_cosine_ops)
+                ON curator_entity_vectors USING hnsw (embedding halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_entity_vectors HNSW index skipped (%)', SQLERRM;
@@ -801,7 +801,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_narrative_vectors_hnsw
-                ON curator_narrative_vectors USING hnsw (embedding vector_cosine_ops)
+                ON curator_narrative_vectors USING hnsw (embedding halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_narrative_vectors HNSW index skipped (%)', SQLERRM;
@@ -809,7 +809,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_claim_vectors_subj_attr_hnsw
-                ON curator_claim_vectors USING hnsw (subj_attr_vec vector_cosine_ops)
+                ON curator_claim_vectors USING hnsw (subj_attr_vec halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_claim_vectors subj_attr HNSW index skipped (%)', SQLERRM;
@@ -817,7 +817,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_claim_vectors_value_hnsw
-                ON curator_claim_vectors USING hnsw (value_vec vector_cosine_ops)
+                ON curator_claim_vectors USING hnsw (value_vec halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_claim_vectors value HNSW index skipped (%)', SQLERRM;
@@ -825,7 +825,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_code_unit_vectors_intent_hnsw
-                ON curator_code_unit_vectors USING hnsw (intent_vec vector_cosine_ops)
+                ON curator_code_unit_vectors USING hnsw (intent_vec halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_code_unit_vectors intent HNSW index skipped (%)', SQLERRM;
@@ -833,7 +833,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_code_unit_vectors_signature_hnsw
-                ON curator_code_unit_vectors USING hnsw (signature_vec vector_cosine_ops)
+                ON curator_code_unit_vectors USING hnsw (signature_vec halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_code_unit_vectors signature HNSW index skipped (%)', SQLERRM;
@@ -841,7 +841,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_curator_code_unit_vectors_body_hnsw
-                ON curator_code_unit_vectors USING hnsw (body_vec vector_cosine_ops)
+                ON curator_code_unit_vectors USING hnsw (body_vec halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_code_unit_vectors body HNSW index skipped (%)', SQLERRM;
@@ -855,7 +855,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
                 id          BIGSERIAL PRIMARY KEY,
                 artifact_id TEXT      NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
                 collection  TEXT      NOT NULL DEFAULT 'case_exemplars',
-                embedding   vector(1024),
+                embedding   halfvec(1024),
                 created_at  TEXT      NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
             )
         $T$;
@@ -881,7 +881,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
                 id          BIGSERIAL PRIMARY KEY,
                 artifact_id TEXT      NOT NULL REFERENCES artifacts(id) ON DELETE CASCADE,
                 collection  TEXT      NOT NULL DEFAULT 'evidence',
-                embedding   vector(1024),
+                embedding   halfvec(1024),
                 created_at  TEXT      NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
             )
         $T$;
@@ -939,7 +939,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
     BEGIN
         EXECUTE $T$
             CREATE INDEX IF NOT EXISTS idx_code_embeddings_hnsw
-                ON code_embeddings USING hnsw (embedding vector_cosine_ops)
+                ON code_embeddings USING hnsw (embedding halfvec_cosine_ops)
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'code_embeddings HNSW index skipped (%)', SQLERRM;

--- a/src/tests/aimee_pg_sqlite_shim.c
+++ b/src/tests/aimee_pg_sqlite_shim.c
@@ -329,6 +329,15 @@ static char *translate_sql(const char *sql_in)
          p += 8;
          continue;
       }
+      /* ::halfvec -> drop.  Same as ::vector — the embedding columns are now
+       * halfvec (fp16), but the SQLite stub still stores embeddings as TEXT, so
+       * the bare value is compatible without a cast. Must precede no other rule
+       * (longer literal than ::vector). */
+      if (starts_with(p, "::halfvec"))
+      {
+         p += 9;
+         continue;
+      }
       /* ILIKE -> LIKE.  SQLite's LIKE is case-insensitive for ASCII by
        * default, which matches ILIKE semantics for the terms this
        * codebase searches. */


### PR DESCRIPTION
Unify every embedding column on halfvec (fp16) — one vector type across the live
and deep tiers, instead of vector for some and halfvec for others.

halfvec is fp16 vs vector's fp32: ~half the index memory + storage and faster HNSW,
at negligible quality cost for normalized-embedding cosine recall (~0.999 vs fp32 —
nothing like int8 drift). The live columns were vector(1024) only by inheritance;
the deep tier already had to be halfvec (2560 > pgvector's 2000-dim vector-index cap).

Changes:
- schema.sql: 11 vector(1024) columns -> halfvec(1024); HNSW indexes -> halfvec_cosine_ops.
- pgvec_transport.c: every ::vector cast -> ::halfvec; dynamic index ops -> halfvec_cosine_ops.
- deploy/migrations/2026-embed-halfvec.sql: idempotent cast migration (vector(N) -> halfvec(N), same dim, data preserved, no re-embed).

Requires pgvector >= 0.7.0 system-wide (verified on .254 0.8.2). An existing vector(N)
DB must run the migration BEFORE the new code (a ::halfvec upsert can't write to a
vector column). e2e-docker (fresh pgvector:pg16) is the authoritative check; CI
unit-tests run on postgres:17-alpine (no pgvector -> sync suppressed). Independent of #174.