### PR TITLE
deep-tier: 4B precision guard for contradiction detection

### DIFF
--- a/src/db2/memory_vectors.c
+++ b/src/db2/memory_vectors.c
@@ -85,6 +85,11 @@ int pgvec_memory_vector_deep_search(const float *vec, int dim, int limit, int64_
    return pgvec_memory_deep_search(vec, dim, limit, ids, scores, max);
 }
 
+int pgvec_memory_vector_deep_similarity(int64_t id_a, int64_t id_b, double *out)
+{
+   return pgvec_memory_deep_similarity(id_a, id_b, out);
+}
+
 int pgvec_memory_vector_search_record_type(const char *record_type, const float *vec, int dim,
                                            int limit, int64_t *ids, double *scores, int max)
 {

--- a/src/db2/memory_vectors.h
+++ b/src/db2/memory_vectors.h
@@ -19,6 +19,7 @@ int pgvec_memory_vector_deep_update(int64_t memory_id, const float *vec, int dim
 int pgvec_memory_vector_deep_candidates(int64_t *ids, int max);
 int pgvec_memory_vector_deep_search(const float *vec, int dim, int limit, int64_t *ids,
                                     double *scores, int max);
+int pgvec_memory_vector_deep_similarity(int64_t id_a, int64_t id_b, double *out);
 int pgvec_memory_vector_search_record_type(const char *record_type, const float *vec, int dim,
                                            int limit, int64_t *ids, double *scores, int max);
 int pgvec_memory_vector_search_with_kinds(const float *vec, int dim, const char *const *kinds,

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -457,6 +457,38 @@ int pgvec_memory_deep_search(const float *vec, int dim, int limit, int64_t *ids,
    return (rc == AIMEE_PG_ERR) ? -1 : n;
 }
 
+/* Deep cosine similarity between two memories' deep embeddings. Writes the cosine
+ * to *out and returns 1 when BOTH rows have a deep embedding; returns 0 when either
+ * lacks one (caller treats it as "can't confirm" — a no-op), -1 on error. A
+ * precision guard for offline passes (e.g. contradiction pre-filtering), never a
+ * blocker — partial deep coverage simply means fewer pairs get the extra check. */
+int pgvec_memory_deep_similarity(int64_t id_a, int64_t id_b, double *out)
+{
+   if (!out)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   static const char *sql = "SELECT 1.0 - (a.embedding_deep <=> b.embedding_deep) "
+                            "FROM memory_embeddings a, memory_embeddings b "
+                            "WHERE a.point_id = :a AND b.point_id = :b "
+                            "AND a.embedding_deep IS NOT NULL AND b.embedding_deep IS NOT NULL";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return 0; /* halfvec unavailable — can't confirm */
+   aimee_pg_bind_int64(stmt, "a", id_a);
+   aimee_pg_bind_int64(stmt, "b", id_b);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      *out = aimee_pg_column_double(stmt, 0);
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   return have;
+}
+
 /* -------------------------------------------------------------------------
  * KB upsert
  * ---------------------------------------------------------------------- */

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -61,6 +61,10 @@ int pgvec_memory_deep_candidates(int64_t *ids, int max);
 int pgvec_memory_deep_search(const float *vec, int dim, int limit, int64_t *ids, double *scores,
                              int max);
 
+/* Deep tier: cosine of two memories' deep embeddings. Returns 1 (both present,
+ * *out set), 0 (either missing), -1 (error). */
+int pgvec_memory_deep_similarity(int64_t id_a, int64_t id_b, double *out);
+
 /* Upsert a single kb embedding row.  Extracts project from payload_json. */
 int pgvec_kb_upsert(int64_t point_id, const float *vec, int dim, const char *payload_json);
 

--- a/src/memory_conflict.c
+++ b/src/memory_conflict.c
@@ -6,6 +6,7 @@
 #if !defined(AIMEE_DB2_DISABLED)
 #include "db2/memory_conflicts.h"
 #include "db2/memory_query.h"
+#include "db2/memory_vectors.h"
 #endif
 #include "kb.h"
 #include "log.h"
@@ -186,6 +187,26 @@ static int retro_scan_due(void)
 }
 #endif
 
+/* Deep-tier precision guard. When the 4B deep tier is on and BOTH memories have a
+ * deep embedding, a clearly-low deep cosine means the lexical overlap that made
+ * them a candidate pair was coincidental — they aren't about the same thing, so
+ * skip the costly is_contradiction check. Conservative threshold so real
+ * contradictions (which are deep-similar) are never skipped; a no-op when deep is
+ * off or either row lacks a deep embedding (partial coverage degrades gracefully). */
+#define DEEP_CONFLICT_MIN_SIM 0.35
+
+#if !defined(AIMEE_DB2_DISABLED)
+static int deep_pair_clearly_unrelated(int deep_on, int64_t id_a, int64_t id_b)
+{
+   if (!deep_on)
+      return 0;
+   double sim = 0.0;
+   if (pgvec_memory_vector_deep_similarity(id_a, id_b, &sim) == 1 && sim < DEEP_CONFLICT_MIN_SIM)
+      return 1;
+   return 0;
+}
+#endif
+
 int memory_scan_retroactive_conflicts(void)
 {
 #if defined(AIMEE_DB2_DISABLED)
@@ -194,6 +215,11 @@ int memory_scan_retroactive_conflicts(void)
    /* Rate limit: at most once per day */
    if (!retro_scan_due())
       return 0;
+
+   /* Deep-tier precision guard on by config (stored deep embeddings only — no
+    * embedder call). Loaded once; the per-pair check is cheap when off. */
+   config_t deep_cfg;
+   int deep_on = (config_load(&deep_cfg) == 0 && deep_cfg.memory_deep_embedding_enabled);
 
    /* Skip if fewer than RETRO_CONFLICT_MIN_L2 L2 memories */
    if (db2_memory_count_l2() < RETRO_CONFLICT_MIN_L2)
@@ -209,6 +235,8 @@ int memory_scan_retroactive_conflicts(void)
       int n = db2_memory_l2_cross_key_pairs(RETRO_CONFLICT_MAX_PAIRS, pairs, pair_cap);
       for (int i = 0; i < n; i++)
       {
+         if (deep_pair_clearly_unrelated(deep_on, pairs[i].id_a, pairs[i].id_b))
+            continue;
          if (is_contradiction(pairs[i].content_a, pairs[i].content_b))
          {
             memory_record_conflict(pairs[i].id_a, pairs[i].id_b);
@@ -222,6 +250,8 @@ int memory_scan_retroactive_conflicts(void)
       int n = db2_memory_l2_fact_vs_decision_pairs(RETRO_CONFLICT_MAX_PAIRS, pairs, pair_cap);
       for (int i = 0; i < n; i++)
       {
+         if (deep_pair_clearly_unrelated(deep_on, pairs[i].id_a, pairs[i].id_b))
+            continue;
          if (is_contradiction(pairs[i].content_a, pairs[i].content_b))
          {
             memory_record_conflict(pairs[i].id_a, pairs[i].id_b);


### PR DESCRIPTION
The offline-intelligence follow-up to the 4B deep tier (#174): use the
higher-quality 4B embeddings to refine an existing offline pass.

### What actually applies
Investigating the named consumers: **dedup** is key-based (`db2_memory_dedupe_by_key`,
no embeddings), **scene clustering** is session/temporal (no embeddings), and the
**curator** uses its own `curator_*` vector tables (a separate deep-ification). The
one offline pass that consumes *memory* embeddings is **retroactive contradiction
detection** — so that's where this wires the deep space.

### Pattern: deep as a precision guard, never a blocker
Contradiction candidate pairs are lexical (overlapping terms, different keys), then
checked by `is_contradiction`. When the deep tier is on and BOTH memories have a
deep embedding, a clearly-low deep cosine (`< 0.35`) means the term overlap was
coincidental — they aren't about the same thing — so the costly check is skipped.

This sidesteps the risks that made offline-intelligence a deferred follow-up:
- **Partial coverage** degrades gracefully — no deep embedding ⇒ no-op (live behaviour).
- **Conservative threshold** ⇒ real contradictions (deep-similar) are never skipped.
- **Gated** by `memory_deep_embedding_enabled` (default off ⇒ exact prior behaviour).

Raises precision (fewer false contradictions) and saves LLM `is_contradiction` calls.

### Changes
- `pgvec_memory_deep_similarity` (cosine of two rows' `embedding_deep`) + wrapper.
- `memory_conflict.c`: gated guard on both candidate-scan loops.

Existing conflict tests pass unchanged (deep off ⇒ guard is a no-op), confirming no
regression; the deep-on path is exercised by real-pgvector e2e-docker.