### PR TITLE
curator: deep-ify all four vector tables (entity/claim/narrative/code-unit)

### DIFF
--- a/deploy/migrations/2026-embed-deep-halfvec.sql
+++ b/deploy/migrations/2026-embed-deep-halfvec.sql
@@ -47,4 +47,10 @@ ALTER TABLE memory_embeddings ADD COLUMN IF NOT EXISTS embedding_deep halfvec(25
 CREATE INDEX IF NOT EXISTS idx_memory_embeddings_deep_hnsw
     ON memory_embeddings USING hnsw (embedding_deep halfvec_cosine_ops);
 
+-- Curator entity resolution shares the deep tier: the same precision column on
+-- curator_entity_vectors (written/compared by resolve_entities).
+ALTER TABLE curator_entity_vectors ADD COLUMN IF NOT EXISTS embedding_deep halfvec(2560);
+CREATE INDEX IF NOT EXISTS idx_curator_entity_vectors_deep_hnsw
+    ON curator_entity_vectors USING hnsw (embedding_deep halfvec_cosine_ops);
+
 COMMIT;

--- a/deploy/migrations/2026-embed-deep-halfvec.sql
+++ b/deploy/migrations/2026-embed-deep-halfvec.sql
@@ -59,4 +59,13 @@ ALTER TABLE curator_claim_vectors ADD COLUMN IF NOT EXISTS subj_attr_deep_vec ha
 CREATE INDEX IF NOT EXISTS idx_curator_claim_vectors_subj_attr_deep_hnsw
     ON curator_claim_vectors USING hnsw (subj_attr_deep_vec halfvec_cosine_ops);
 
+-- Near-duplicate linking: deep embeddings of the narrative text / code-unit body,
+-- used to confirm a similarity link at index time.
+ALTER TABLE curator_narrative_vectors ADD COLUMN IF NOT EXISTS embedding_deep halfvec(2560);
+CREATE INDEX IF NOT EXISTS idx_curator_narrative_vectors_deep_hnsw
+    ON curator_narrative_vectors USING hnsw (embedding_deep halfvec_cosine_ops);
+ALTER TABLE curator_code_unit_vectors ADD COLUMN IF NOT EXISTS body_deep_vec halfvec(2560);
+CREATE INDEX IF NOT EXISTS idx_curator_code_unit_vectors_body_deep_hnsw
+    ON curator_code_unit_vectors USING hnsw (body_deep_vec halfvec_cosine_ops);
+
 COMMIT;

--- a/deploy/migrations/2026-embed-deep-halfvec.sql
+++ b/deploy/migrations/2026-embed-deep-halfvec.sql
@@ -53,4 +53,10 @@ ALTER TABLE curator_entity_vectors ADD COLUMN IF NOT EXISTS embedding_deep halfv
 CREATE INDEX IF NOT EXISTS idx_curator_entity_vectors_deep_hnsw
     ON curator_entity_vectors USING hnsw (embedding_deep halfvec_cosine_ops);
 
+-- Fuzzy contradiction mining: a deep embedding of the claim's subject+attribute,
+-- used to confirm a semantic contradiction candidate before linking it.
+ALTER TABLE curator_claim_vectors ADD COLUMN IF NOT EXISTS subj_attr_deep_vec halfvec(2560);
+CREATE INDEX IF NOT EXISTS idx_curator_claim_vectors_subj_attr_deep_hnsw
+    ON curator_claim_vectors USING hnsw (subj_attr_deep_vec halfvec_cosine_ops);
+
 COMMIT;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -316,7 +316,10 @@ Responsibilities:
   and decay (the L0-L3 tier machinery).
 - **Vector operations**, pgvector collections, embeddings (built-in or via an
   external `embedding_command` sidecar), reranking, release/repair/reconcile of
-  vector state.
+  vector state. The embedder/reranker/halfvec stack is described in
+  [retrieval-stack.md](retrieval-stack.md); the optional authoritative 4B layer
+  (deep recall + precision guards across memory and the curator) in
+  [deep-embedding-tier.md](deep-embedding-tier.md).
 - **Code index**, symbol extraction across many languages, `find_symbol`,
   callers, structure, blast-radius, full-text code search.
 - **Document ingest + curator**, staged document ingest, curator extraction of

--- a/docs/deep-embedding-tier.md
+++ b/docs/deep-embedding-tier.md
@@ -1,25 +1,40 @@
 # Deep embedding tier (4B)
 
-An optional, opt-in second embedding tier: a larger model re-embeds memories in
-the background for higher-quality retrieval, backstopping the fast live tier. The
-design is "fast 0.6B initial pass + comprehensive 4B pass later."
+An optional 4B embedding tier that is **authoritative** over the live 0.6B tier.
+The 0.6B (run at reduced precision — int8 — for speed) gives the user a *fast
+initial result*; the 4B is the **higher-quality source of truth** and supersedes
+the 0.6B's view once its background pass has re-embedded the corpus. The design is
+"fast 0.6B preview now, authoritative 4B answer once complete."
 
-**Default OFF.** A lite deployment runs the live 0.6B embedder alone (~0.5 GB
-RAM). The deep tier adds a ~16 GB resident 4B model and a second vector index, so
-it is opt-in for hosts with the RAM. The deep model is lazy — never loaded until
-the tier is actually used.
+This authority shows up two ways:
+1. **Precision guards** — wherever the 0.6B makes a decision (a merge, a
+   contradiction, a duplicate), the 4B confirms or vetoes it. Where they disagree,
+   **the 4B wins.** Already live across memory and the curator (second half of
+   this page).
+2. **Deep recall** — `--deep` searches the authoritative 4B index directly. Today
+   this is opt-in because a 4B *query* embed is ~2.7 s; see
+   [Recall: making the 4B authoritative](#recall-making-the-4b-authoritative).
+
+**Default OFF** (`memory_deep_embedding_enabled`). A lite deployment runs the 0.6B
+alone (~0.5 GB RAM, served fp32 for full quality since nothing backstops it). The
+deep tier adds a ~16 GB resident 4B model + a second index, lazy-loaded, so it is
+opt-in for hosts with the RAM. For the live tier itself (0.6B model, reranker,
+int8, halfvec) see [retrieval-stack.md](retrieval-stack.md).
 
 ## How it works
 
-| Column | Dim | Model | Written by | Read by |
+| Column | Dim | Model | Written by | Authority |
 |---|---|---|---|---|
-| `embedding` | `halfvec(1024)` | 0.6B (live) | every memory write | fast per-turn recall |
-| `embedding_deep` | `halfvec(2560)` | 4B (deep) | background backfill | opt-in `--deep` recall |
+| `embedding` | `halfvec(1024)` | 0.6B (live, int8) | every memory write | fast interim — used immediately, and where the 4B hasn't filled in yet |
+| `embedding_deep` | `halfvec(2560)` | 4B (deep) | background backfill | **authoritative** — supersedes the 0.6B once populated |
 
-The two columns coexist — the 4B never replaces the 0.6B. A query embeds with one
-model and searches the matching column, so the dimensions never need to reconcile.
-Both are `halfvec` (fp16); 2560 exceeds pgvector's 2000-dim `vector`-index cap, so
-halfvec is required (it also halves index memory at negligible quality cost).
+Two columns rather than a dimension swap, because a query must embed with the same
+model as the column it searches (0.6B = 1024-dim, 4B = 2560-dim) and the 4B is
+populated lazily. The 0.6B is never *deleted* — it's the fast path while the 4B
+catches up — but once a memory has a `embedding_deep`, the 4B is the truth for it.
+Both columns are `halfvec` (fp16); 2560 exceeds pgvector's 2000-dim `vector`-index
+cap, so halfvec is required (it also halves index memory at negligible quality
+cost).
 
 - **Embedder** serves the 4B on `/embed_deep` (env `DEEP_MODEL`, default
   `perplexity-ai/pplx-embed-v1-4b`), lazy-loaded on first call.
@@ -52,10 +67,89 @@ halfvec is required (it also halves index memory at negligible quality cost).
 5. The backfill runs on the normal maintenance cycle. Until `embedding_deep` is
    populated, `--deep` recall returns empty; live recall is unaffected throughout.
 
-## Cost / when to use
+## Recall: making the 4B authoritative
 
-- A 4B query embed is ~2.7 s on CPU, so `--deep` is for occasional, quality-first
-  recall — never the default per-turn path.
+The intent is that the 4B is authoritative for recall too: the user gets a fast
+0.6B (int8) answer immediately, and the 4B result — once the corpus is backfilled
+— is the one to trust.
+
+The tension is latency: a 4B *query* embed is ~2.7 s on CPU, so it can't run
+synchronously on every turn. The shape that satisfies both is **progressive
+recall** — return the 0.6B candidates instantly, then re-resolve/re-rank against
+the authoritative 4B `embedding_deep` index and update the result. The two stored
+columns (fast 0.6B, authoritative 4B) are exactly what that needs.
+
+Today the building blocks exist but the auto-progression is not yet wired: the
+4B index is reachable via `aimee memory search --deep` (the authoritative
+answer, paid ~2.7 s up front), and the live per-turn path is the 0.6B. Wiring the
+0.6B→4B progression into the default recall is the remaining step to make recall
+fully 4B-authoritative.
+
+The **precision guards** (below) are already fully 4B-authoritative — they always
+let the 4B override the 0.6B.
+
 - The backfill is deliberately slow (throttled). It's a "take your time" pass.
-- On a lite (0.6B-only) deployment, leave it off and serve fp32 (`EMBEDDER_QUANTIZE`
-  unset) for full live-tier quality.
+- Until a memory has an `embedding_deep`, its authoritative view is still the 0.6B;
+  `--deep` recall only sees backfilled memories.
+- On a lite (0.6B-only) deployment, leave the tier off and serve fp32
+  (`EMBEDDER_QUANTIZE` unset) for full quality, since nothing backstops the 0.6B.
+
+---
+
+# The deep tier as a precision guard
+
+Beyond `--deep` recall, the 4B space is used to **confirm or veto** decisions the
+live 0.6B embedding makes. The pattern is uniform across every site:
+
+- The live embedding generates a **candidate** (a recall hit, a merge, a
+  contradiction, a duplicate).
+- When the deep tier is on **and both sides have a deep embedding**, the 4B cosine
+  must agree before the candidate is acted on.
+- The guard is **never destructive on its own**: it can only *prevent* a merge or
+  *withhold* a link — it can never collapse, drop, or invent.
+- **Partial coverage degrades gracefully**: if either side lacks a deep embedding,
+  the guard is a no-op and prior behaviour holds.
+- Everything is gated by `memory_deep_embedding_enabled` (default off ⇒ exact
+  prior behaviour) and reuses `memory_deep_embedding_command` (the 4B
+  `/embed_deep`). Thresholds are deliberately conservative — **tune them on a real
+  corpus before relying on the guards.**
+
+## Memory: contradiction pre-filter
+
+`memory_scan_retroactive_conflicts` finds candidate contradiction pairs by lexical
+term overlap, then runs an expensive `is_contradiction` check. With the deep tier
+on, a pair whose two memories are deep-embedded but clearly *unrelated* in the 4B
+space (cosine < 0.35) is skipped — the term overlap was coincidental, not a real
+contradiction. Fewer false contradictions, fewer LLM calls.
+
+## Curator deep tier
+
+The deep-curator's four vector tables each gain a deep column + a guard:
+
+| Table | Decision | Deep role | Threshold |
+|---|---|---|---|
+| `curator_entity_vectors` | `resolve_entities` merge | reject a confident live merge the 4B disagrees with — cannot collapse distinct canonical entities | live ≥ 0.85, reject if deep < 0.60 |
+| `curator_claim_vectors` | `detect_contradictions` | **fuzzy mining** (new): paraphrased contradictions (same-meaning subject+attribute, different value) the exact self-join misses, each *required* to be deep-confirmed before linking | live ≥ 0.80, link if deep ≥ 0.75 |
+| `curator_narrative_vectors` | index time | **similarity links** (new): additive `similar_to` edges between near-duplicate narratives | live ≥ 0.85, link if deep ≥ 0.85 |
+| `curator_code_unit_vectors` | index time | **clone links** (new): additive `similar_to` edges between near-duplicate code bodies | live ≥ 0.85, link if deep ≥ 0.85 |
+
+Notes:
+- **Entity** is merge-*preventing* (the only guard that changes an existing
+  decision); the others are purely *additive* (new links) or *new* detection.
+- The deep columns are stored at curate/index time when the tier is on (the
+  curator is a batch process, so the extra 4B embed is acceptable). Entities and
+  claims committed before the tier was enabled lack deep embeddings until
+  re-curated, so their guards no-op until then.
+- `curator_claim_vectors.subj_attr_deep_vec` holds the deep subject+attribute
+  embedding; `curator_code_unit_vectors.body_deep_vec` holds the deep body
+  embedding (the clone signal); narratives use `embedding_deep`.
+- All `similar_to` / `contradicts` links are written via `db2_artifact_link`,
+  which is idempotent, so re-curation is safe.
+
+## Migrations
+
+Enabling the deep tier on an existing database needs the deep columns + indexes.
+`deploy/migrations/2026-embed-deep-halfvec.sql` adds all of them (memory +
+curator) idempotently and fails loudly if pgvector lacks `halfvec`. A fresh schema
+apply already includes them (exception-guarded, so a pgvector without halfvec just
+NOTICEs and skips).

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -1,0 +1,101 @@
+# Retrieval stack (embedder, reranker, halfvec)
+
+The live retrieval foundation: the embedding model, the cross-encoder reranker,
+CPU serving, and the on-disk vector format. The optional higher-quality 4B layer
+on top is documented in [deep-embedding-tier.md](deep-embedding-tier.md).
+
+## Live embedder — pplx-embed-v1-0.6b (1024-dim)
+
+The default embedder is **`perplexity-ai/pplx-embed-v1-0.6b`** (Feb 2026, MIT,
+Qwen3-based, 1024-dim, retrieval-optimized), replacing the 2021
+`all-MiniLM-L6-v2` (384-dim). It is **prefix-free** — no query/passage role
+strings to thread through — so the integration just embeds text.
+
+- `embedding_dim = 1024` (config). The schema embedding columns are 1024-dim.
+- Served by the persistent embedder sidecar (`scripts/embedder-server.py`) over
+  HTTP `POST /embed` (raw UTF-8 text in, JSON float array out). The kb talks to it
+  via `scripts/embed-remote.py` (`embedding_command`).
+- Override the model at build/run time with `EMBEDDER_MODEL`; it must match
+  `embedding_dim` and the schema vector columns.
+
+### CPU serving and the int8 toggle
+
+Measured on a 32-core host (per embed of a short text):
+
+| Mode | ms/embed | Notes |
+|---|---|---|
+| fp32 @ 32 threads | 269 | a single short embed doesn't scale past ~8 threads |
+| fp32 @ 8 threads (default) | 190 | `EMBEDDER_THREADS` default `min(8, ncpu)` |
+| **int8 dynamic @ 8 threads** | **58** | `EMBEDDER_QUANTIZE=int8` — ~3.3x faster |
+
+`EMBEDDER_QUANTIZE=int8` uses torch dynamic quantization (pure torch — no
+`optimum`/ONNX, so it composes with the reranker's `transformers` requirement).
+int8 drifts the embedding ~0.90 cosine vs fp32, so the **policy** follows the
+tiers' roles:
+
+- **fp32** (default) when the 0.6B is the only tier — it *is* the answer, so it
+  must be full quality.
+- **int8** when the 4B deep tier is enabled — the 0.6B is then only the *fast
+  interim* (the authoritative answer comes from the 4B), so trading a little of its
+  precision for ~3.3x speed is exactly the point: get the user something fast, let
+  the authoritative 4B follow. This is the whole reason the 0.6B runs reduced-
+  precision. See [deep-embedding-tier.md](deep-embedding-tier.md).
+
+The embedder is config-decoupled, so this is realized at deploy time: the
+compose embedder service reads `EMBEDDER_QUANTIZE` from
+`${AIMEE_EMBEDDER_QUANTIZE:-fp32}`. (A q4 ONNX path was evaluated and dropped — it
+needs `optimum`, which pins `transformers` below what the reranker requires.)
+
+## Cross-encoder reranker — Ettin (default off)
+
+A second-pass reranker scores `(query, candidate)` pairs after the bi-encoder
+recall. Default model: **`cross-encoder/ettin-reranker-400m-v1`** (JHU, May 2026,
+Apache-2.0, ModernBERT). It is **lazy-loaded** in the embedder process and served
+on `POST /rerank` (JSON `[[query, cand], ...]` in, JSON scores out); the kb calls
+it via `scripts/rerank-remote.py`.
+
+- Default **off**: enable with
+  `aimee config set memory_rerank_enabled 1` +
+  `memory_rerank_command "python3 /opt/aimee/scripts/rerank-remote.py"`. On any
+  failure the C caller silently falls back to hybrid ordering.
+- Ettin needs **`transformers >= 5.2`** (older versions can't instantiate its
+  ModernBERT tokenizer); the embedder image pins it.
+
+## halfvec — all embedding columns are fp16
+
+Every embedding column is **`halfvec`** (pgvector's fp16 vector type), not
+`vector` (fp32). halfvec uses ~half the index memory and storage and speeds up
+HNSW, at negligible quality cost for normalized-embedding cosine recall (~0.999
+cosine vs fp32 — nothing like the int8 drift). It also lets the live `halfvec(1024)`
+and deep `halfvec(2560)` tiers share one type (2560 exceeds pgvector's 2000-dim
+`vector`-index cap, so the deep tier *requires* halfvec regardless).
+
+- **Requires pgvector ≥ 0.7.0** system-wide (halfvec was added there). Verified on
+  the operational DB (pgvector 0.8.x).
+- A fresh schema apply creates halfvec columns directly.
+
+## Migrations
+
+| Migration | What | Re-embed? |
+|---|---|---|
+| `deploy/migrations/2026-embed-dim-1024.sql` | MiniLM 384-dim → pplx 1024-dim (clears + reshapes the vector columns) | **Yes** — the 384-dim vectors are not convertible |
+| `deploy/migrations/2026-embed-halfvec.sql` | `vector(N)` → `halfvec(N)` (in-place cast) + rebuild HNSW | No — same dim, fp32→fp16 cast |
+| `deploy/migrations/2026-embed-deep-halfvec.sql` | add the opt-in deep columns/indexes (memory + curator) | No |
+
+**Deploy ordering for the halfvec cut:** an existing `vector(N)` database must run
+`2026-embed-halfvec.sql` *before* the new code — a `::halfvec` upsert cannot write
+to a `vector` column. Back up DB2 first. Both migrations are idempotent.
+
+## Embedder service summary
+
+`scripts/embedder-server.py` (one process, lazy models):
+
+| Route | Serves |
+|---|---|
+| `POST /embed` | live 0.6B embedding (1024-dim) |
+| `POST /embed_deep` | optional 4B deep embedding (2560-dim), lazy |
+| `POST /rerank` | optional Ettin cross-encoder scores, lazy |
+| `GET /health` | `{model, dim, quantize, deep_model, deep_dim}` |
+
+Env: `EMBEDDER_MODEL`, `DEEP_MODEL`, `RERANKER_MODEL`, `EMBEDDER_THREADS`,
+`EMBEDDER_QUANTIZE`, `EMBEDDER_PORT`.

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1290,6 +1290,101 @@ int pgvec_curator_claim_delete(int64_t point_id)
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
 }
 
+/* Deep tier (curator claims): store / compare a deep embedding of the claim's
+ * subject+attribute on subj_attr_deep_vec — the precision layer for fuzzy
+ * contradiction mining. Mirrors the entity deep update/similarity. */
+int pgvec_curator_claim_deep_update(int64_t point_id, const float *vec, int dim)
+{
+   if (!vec || dim <= 0)
+      return 0;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql =
+       "UPDATE curator_claim_vectors SET subj_attr_deep_vec = :embedding::halfvec "
+       "WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return -1;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "embedding", vec_text);
+   aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+/* Deep cosine of two claims' stored subject+attribute deep embeddings. Returns 1
+ * when BOTH have one (*out set), 0 when either lacks it (caller no-ops), -1 error. */
+int pgvec_curator_claim_deep_similarity(int64_t point_a, int64_t point_b, double *out)
+{
+   if (!out)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   static const char *sql =
+       "SELECT 1.0 - (a.subj_attr_deep_vec <=> b.subj_attr_deep_vec) "
+       "FROM curator_claim_vectors a, curator_claim_vectors b "
+       "WHERE a.point_id = :a AND b.point_id = :b "
+       "AND a.subj_attr_deep_vec IS NOT NULL AND b.subj_attr_deep_vec IS NOT NULL";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return 0;
+   aimee_pg_bind_int64(stmt, "a", point_a);
+   aimee_pg_bind_int64(stmt, "b", point_b);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      *out = aimee_pg_column_double(stmt, 0);
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   return have;
+}
+
+/* Look up a claim row's first-class fields by point_id (for fuzzy-contradiction
+ * candidate comparison). Returns 1 on a hit, 0 if absent, -1 on error. Any out
+ * buffer may be NULL to skip. */
+int pgvec_curator_claim_fields(int64_t point_id, char *artifact_out, int alen, char *subject_out,
+                               int slen, char *value_out, int vlen)
+{
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   static const char *sql = "SELECT artifact_id, subject, value FROM curator_claim_vectors "
+                            "WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return -1;
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      const char *a = aimee_pg_column_text(stmt, 0);
+      const char *s = aimee_pg_column_text(stmt, 1);
+      const char *v = aimee_pg_column_text(stmt, 2);
+      if (artifact_out && alen > 0)
+         snprintf(artifact_out, (size_t)alen, "%s", a ? a : "");
+      if (subject_out && slen > 0)
+         snprintf(subject_out, (size_t)slen, "%s", s ? s : "");
+      if (value_out && vlen > 0)
+         snprintf(value_out, (size_t)vlen, "%s", v ? v : "");
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   return have;
+}
+
 int pgvec_curator_claim_search(const char *which_vec, const char *claim_kind, const float *vec,
                                int dim, int limit, int64_t *ids, double *scores, int max)
 {

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -898,6 +898,72 @@ int pgvec_curator_entity_delete(int64_t point_id)
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
 }
 
+/* Deep tier (curator entities): store a 2560-dim deep embedding on
+ * curator_entity_vectors.embedding_deep — the precision layer for resolve_entities
+ * (the live `embedding` is untouched). Mirrors pgvec_memory_deep_update. */
+int pgvec_curator_entity_deep_update(int64_t point_id, const float *vec, int dim)
+{
+   if (!vec || dim <= 0)
+      return 0;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql =
+       "UPDATE curator_entity_vectors SET embedding_deep = :embedding::halfvec "
+       "WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return -1;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "embedding", vec_text);
+   aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+/* Cosine of a query deep vector against an entity's stored deep embedding.
+ * Returns 1 (stored deep present, *out set), 0 (none — caller no-ops), -1 (error). */
+int pgvec_curator_entity_deep_similarity(int64_t point_id, const float *vec, int dim, double *out)
+{
+   if (!vec || dim <= 0 || !out)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql = "SELECT 1.0 - (embedding_deep <=> :qvec::halfvec) "
+                            "FROM curator_entity_vectors "
+                            "WHERE point_id = :point_id AND embedding_deep IS NOT NULL";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return 0;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "qvec", vec_text);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      *out = aimee_pg_column_double(stmt, 0);
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return have;
+}
+
 int pgvec_curator_entity_search(const char *scope_kind, const char *scope_id, const float *vec,
                                 int dim, int limit, int64_t *ids, double *scores, int max)
 {

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1117,6 +1117,95 @@ int pgvec_curator_narrative_delete(int64_t point_id)
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
 }
 
+/* Deep tier (curator narratives): store/compare a deep embedding on
+ * embedding_deep + look up artifact_id by point_id, for near-duplicate linking. */
+int pgvec_curator_narrative_deep_update(int64_t point_id, const float *vec, int dim)
+{
+   if (!vec || dim <= 0)
+      return 0;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql =
+       "UPDATE curator_narrative_vectors SET embedding_deep = :embedding::halfvec "
+       "WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return -1;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "embedding", vec_text);
+   aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+int pgvec_curator_narrative_deep_similarity(int64_t point_id, const float *vec, int dim,
+                                            double *out)
+{
+   if (!vec || dim <= 0 || !out)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql = "SELECT 1.0 - (embedding_deep <=> :qvec::halfvec) "
+                            "FROM curator_narrative_vectors "
+                            "WHERE point_id = :point_id AND embedding_deep IS NOT NULL";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return 0;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "qvec", vec_text);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      *out = aimee_pg_column_double(stmt, 0);
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return have;
+}
+
+int pgvec_curator_narrative_artifact(int64_t point_id, char *artifact_out, int alen)
+{
+   if (!artifact_out || alen <= 0)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   static const char *sql =
+       "SELECT artifact_id FROM curator_narrative_vectors WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return -1;
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      const char *a = aimee_pg_column_text(stmt, 0);
+      snprintf(artifact_out, (size_t)alen, "%s", a ? a : "");
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   return have;
+}
+
 int pgvec_curator_narrative_search(const char *kind, const char *status, const char *priority,
                                    const float *vec, int dim, int limit, int64_t *ids,
                                    double *scores, int max)
@@ -1543,6 +1632,95 @@ int pgvec_curator_code_unit_delete(int64_t point_id)
    aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
    aimee_pg_finalize(stmt);
    return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+/* Deep tier (curator code units): store/compare a deep embedding of the body on
+ * body_deep_vec + look up artifact_id by point_id, for clone (near-dup) linking. */
+int pgvec_curator_code_unit_deep_update(int64_t point_id, const float *vec, int dim)
+{
+   if (!vec || dim <= 0)
+      return 0;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql =
+       "UPDATE curator_code_unit_vectors SET body_deep_vec = :embedding::halfvec "
+       "WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return -1;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "embedding", vec_text);
+   aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+int pgvec_curator_code_unit_deep_similarity(int64_t point_id, const float *vec, int dim,
+                                            double *out)
+{
+   if (!vec || dim <= 0 || !out)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+   static const char *sql = "SELECT 1.0 - (body_deep_vec <=> :qvec::halfvec) "
+                            "FROM curator_code_unit_vectors "
+                            "WHERE point_id = :point_id AND body_deep_vec IS NOT NULL";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return 0;
+   }
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   aimee_pg_bind_text(stmt, "qvec", vec_text);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      *out = aimee_pg_column_double(stmt, 0);
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   return have;
+}
+
+int pgvec_curator_code_unit_artifact(int64_t point_id, char *artifact_out, int alen)
+{
+   if (!artifact_out || alen <= 0)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+   static const char *sql =
+       "SELECT artifact_id FROM curator_code_unit_vectors WHERE point_id = :point_id";
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return -1;
+   aimee_pg_bind_int64(stmt, "point_id", point_id);
+   int have = 0;
+   if (aimee_pg_step(stmt, errbuf, sizeof(errbuf)) == AIMEE_PG_ROW)
+   {
+      const char *a = aimee_pg_column_text(stmt, 0);
+      snprintf(artifact_out, (size_t)alen, "%s", a ? a : "");
+      have = 1;
+   }
+   aimee_pg_finalize(stmt);
+   return have;
 }
 
 int pgvec_curator_code_unit_search(const char *which_vec, const char *def_kind, const float *vec,

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -142,6 +142,13 @@ int pgvec_curator_narrative_upsert(int64_t point_id, const float *vec, int dim,
 /* Delete a single curator_narrative_vectors row by point_id. */
 int pgvec_curator_narrative_delete(int64_t point_id);
 
+/* Deep tier (curator narratives): store/compare embedding_deep + look up
+ * artifact_id by point_id, for deep-confirmed near-duplicate linking. */
+int pgvec_curator_narrative_deep_update(int64_t point_id, const float *vec, int dim);
+int pgvec_curator_narrative_deep_similarity(int64_t point_id, const float *vec, int dim,
+                                            double *out);
+int pgvec_curator_narrative_artifact(int64_t point_id, char *artifact_out, int alen);
+
 /* Search curator_narrative_vectors by cosine distance.  kind/status/priority
  * are optional equality filters; pass NULL or "" to skip any.  Returns the
  * number of results written (<= max), -1 on error. */
@@ -191,6 +198,13 @@ int pgvec_curator_code_unit_upsert(int64_t point_id, const float *intent_vec,
 
 /* Delete a single curator_code_unit_vectors row by point_id. */
 int pgvec_curator_code_unit_delete(int64_t point_id);
+
+/* Deep tier (curator code units): store/compare body_deep_vec + look up
+ * artifact_id by point_id, for deep-confirmed clone (near-dup) linking. */
+int pgvec_curator_code_unit_deep_update(int64_t point_id, const float *vec, int dim);
+int pgvec_curator_code_unit_deep_similarity(int64_t point_id, const float *vec, int dim,
+                                            double *out);
+int pgvec_curator_code_unit_artifact(int64_t point_id, char *artifact_out, int alen);
 
 /* Search curator_code_unit_vectors by cosine distance.  which_vec selects the
  * named vector column to rank on: "intent", "signature" or "body" (any other

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -119,6 +119,12 @@ int pgvec_curator_entity_lookup(int64_t point_id, char *artifact_id_out, int aid
 /* Delete a single curator_entity_vectors row by point_id. */
 int pgvec_curator_entity_delete(int64_t point_id);
 
+/* Deep tier (curator entities): store / compare a deep embedding on
+ * curator_entity_vectors.embedding_deep. similarity returns 1 (present, *out set),
+ * 0 (none), -1 (error). */
+int pgvec_curator_entity_deep_update(int64_t point_id, const float *vec, int dim);
+int pgvec_curator_entity_deep_similarity(int64_t point_id, const float *vec, int dim, double *out);
+
 /* Search curator_entity_vectors by cosine distance.  scope_kind/scope_id are
  * optional equality filters; pass NULL or "" to skip either.  Returns the
  * number of results written (<= max), -1 on error. */

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -161,6 +161,15 @@ int pgvec_curator_claim_upsert(int64_t point_id, const float *subj_attr_vec, con
 /* Delete a single curator_claim_vectors row by point_id. */
 int pgvec_curator_claim_delete(int64_t point_id);
 
+/* Deep tier (curator claims): store / compare a deep embedding of subject+attribute
+ * (subj_attr_deep_vec) for fuzzy contradiction mining. similarity returns 1
+ * (present, *out set), 0 (none), -1 (error). fields looks up a claim row's
+ * artifact_id/subject/value by point_id (1 hit, 0 absent, -1 error). */
+int pgvec_curator_claim_deep_update(int64_t point_id, const float *vec, int dim);
+int pgvec_curator_claim_deep_similarity(int64_t point_a, int64_t point_b, double *out);
+int pgvec_curator_claim_fields(int64_t point_id, char *artifact_out, int alen, char *subject_out,
+                               int slen, char *value_out, int vlen);
+
 /* Search curator_claim_vectors by cosine distance.  which_vec selects the
  * named vector column to rank on: "subj_attr" or "value" (any other value is
  * rejected, returns -1).  claim_kind is an optional equality filter; pass

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -781,6 +781,23 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         RAISE NOTICE 'curator_claim_vectors.subj_attr_deep_vec column skipped (%)', SQLERRM;
     END;
 
+    -- Deep tier for near-duplicate linking: a halfvec(2560) deep embedding of the
+    -- narrative text / code-unit body, used to confirm a similarity link.
+    BEGIN
+        EXECUTE $T$
+            ALTER TABLE curator_narrative_vectors ADD COLUMN IF NOT EXISTS embedding_deep halfvec(2560)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_narrative_vectors.embedding_deep column skipped (%)', SQLERRM;
+    END;
+    BEGIN
+        EXECUTE $T$
+            ALTER TABLE curator_code_unit_vectors ADD COLUMN IF NOT EXISTS body_deep_vec halfvec(2560)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_code_unit_vectors.body_deep_vec column skipped (%)', SQLERRM;
+    END;
+
     EXECUTE $T$
         CREATE INDEX IF NOT EXISTS idx_memory_embeddings_record_type
             ON memory_embeddings (record_type)
@@ -843,6 +860,22 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_claim_vectors deep HNSW index skipped (%)', SQLERRM;
+    END;
+    BEGIN
+        EXECUTE $T$
+            CREATE INDEX IF NOT EXISTS idx_curator_narrative_vectors_deep_hnsw
+                ON curator_narrative_vectors USING hnsw (embedding_deep halfvec_cosine_ops)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_narrative_vectors deep HNSW index skipped (%)', SQLERRM;
+    END;
+    BEGIN
+        EXECUTE $T$
+            CREATE INDEX IF NOT EXISTS idx_curator_code_unit_vectors_body_deep_hnsw
+                ON curator_code_unit_vectors USING hnsw (body_deep_vec halfvec_cosine_ops)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_code_unit_vectors deep HNSW index skipped (%)', SQLERRM;
     END;
     BEGIN
         EXECUTE $T$

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -760,6 +760,16 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         RAISE NOTICE 'memory_embeddings.embedding_deep column skipped (%)', SQLERRM;
     END;
 
+    -- Deep tier for curator entity resolution: same opt-in halfvec(2560) precision
+    -- column on curator_entity_vectors, written/compared by resolve_entities.
+    BEGIN
+        EXECUTE $T$
+            ALTER TABLE curator_entity_vectors ADD COLUMN IF NOT EXISTS embedding_deep halfvec(2560)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_entity_vectors.embedding_deep column skipped (%)', SQLERRM;
+    END;
+
     EXECUTE $T$
         CREATE INDEX IF NOT EXISTS idx_memory_embeddings_record_type
             ON memory_embeddings (record_type)
@@ -806,6 +816,14 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'memory_embeddings deep HNSW index skipped (%)', SQLERRM;
+    END;
+    BEGIN
+        EXECUTE $T$
+            CREATE INDEX IF NOT EXISTS idx_curator_entity_vectors_deep_hnsw
+                ON curator_entity_vectors USING hnsw (embedding_deep halfvec_cosine_ops)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_entity_vectors deep HNSW index skipped (%)', SQLERRM;
     END;
     BEGIN
         EXECUTE $T$

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -770,6 +770,17 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         RAISE NOTICE 'curator_entity_vectors.embedding_deep column skipped (%)', SQLERRM;
     END;
 
+    -- Deep tier for fuzzy contradiction mining: a halfvec(2560) deep embedding of
+    -- the claim's subject+attribute, used to confirm a semantic contradiction
+    -- candidate before linking it.
+    BEGIN
+        EXECUTE $T$
+            ALTER TABLE curator_claim_vectors ADD COLUMN IF NOT EXISTS subj_attr_deep_vec halfvec(2560)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_claim_vectors.subj_attr_deep_vec column skipped (%)', SQLERRM;
+    END;
+
     EXECUTE $T$
         CREATE INDEX IF NOT EXISTS idx_memory_embeddings_record_type
             ON memory_embeddings (record_type)
@@ -824,6 +835,14 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         $T$;
     EXCEPTION WHEN OTHERS THEN
         RAISE NOTICE 'curator_entity_vectors deep HNSW index skipped (%)', SQLERRM;
+    END;
+    BEGIN
+        EXECUTE $T$
+            CREATE INDEX IF NOT EXISTS idx_curator_claim_vectors_subj_attr_deep_hnsw
+                ON curator_claim_vectors USING hnsw (subj_attr_deep_vec halfvec_cosine_ops)
+        $T$;
+    EXCEPTION WHEN OTHERS THEN
+        RAISE NOTICE 'curator_claim_vectors deep HNSW index skipped (%)', SQLERRM;
     END;
     BEGIN
         EXECUTE $T$

--- a/src/kb/kb_curator_contradictions.c
+++ b/src/kb/kb_curator_contradictions.c
@@ -18,11 +18,116 @@
 #include "db2/artifacts.h"
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"
+#include "db2/pgvec_transport.h"
 
 #include <string.h>
 
 /* Max claim pairs linked per drain call (bounds work per poll). */
 #define CONTRA_BATCH 32
+
+/* Fuzzy contradiction mining (opt-in via the 4B deep tier). The exact pass above
+ * only catches claims with an IDENTICAL subject+attribute text; this phase finds
+ * pairs whose subject+attribute are *semantically* the same (high live subj_attr
+ * cosine) but phrased differently, with a different value. Every fuzzy link is
+ * REQUIRED to be confirmed in the 4B deep space — it never fires on the live
+ * embedding alone — so it cannot manufacture contradictions the deep model
+ * disagrees with. All thresholds are deliberately conservative; tune on a real
+ * corpus before relying on it. Live dim matches the claim indexer's 384. */
+#define CONTRA_CLAIM_DIM      384
+#define CONTRA_FUZZY_BATCH    16   /* deep-ready claims probed per drain call */
+#define CONTRA_FUZZY_K        5    /* nearest subj_attr candidates per claim */
+#define CONTRA_FUZZY_LIVE_MIN 0.80 /* live subj_attr cosine to even consider a pair */
+#define CONTRA_FUZZY_DEEP_MIN 0.75 /* 4B-deep cosine required to link (the guard) */
+
+/* Fuzzy, deep-confirmed contradiction mining. Returns the number of new
+ * `contradicts` links written, or 0 when the deep tier is off (the guard is
+ * mandatory). Best-effort throughout: any embed/search/lookup miss just skips. */
+static int mine_fuzzy_contradictions(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) != 0 || !cfg.memory_deep_embedding_enabled ||
+       !cfg.memory_deep_embedding_command[0])
+      return 0;
+   const char *live_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+
+   struct fuzzy_claim
+   {
+      int64_t pid;
+      char artifact[64], subject[256], attribute[256], value[256];
+   } batch[CONTRA_FUZZY_BATCH];
+   int nb = 0;
+   {
+      static const char *bs =
+          "SELECT point_id, artifact_id, subject, attribute, value FROM curator_claim_vectors"
+          " WHERE subj_attr_deep_vec IS NOT NULL ORDER BY point_id DESC LIMIT 16";
+      char e[256] = "";
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, bs, e, sizeof(e));
+      if (st)
+      {
+         while (nb < CONTRA_FUZZY_BATCH && aimee_pg_step(st, e, sizeof(e)) == AIMEE_PG_ROW)
+         {
+            batch[nb].pid = aimee_pg_column_int64(st, 0);
+            const char *a = aimee_pg_column_text(st, 1);
+            const char *s = aimee_pg_column_text(st, 2);
+            const char *at = aimee_pg_column_text(st, 3);
+            const char *v = aimee_pg_column_text(st, 4);
+            snprintf(batch[nb].artifact, sizeof(batch[nb].artifact), "%s", a ? a : "");
+            snprintf(batch[nb].subject, sizeof(batch[nb].subject), "%s", s ? s : "");
+            snprintf(batch[nb].attribute, sizeof(batch[nb].attribute), "%s", at ? at : "");
+            snprintf(batch[nb].value, sizeof(batch[nb].value), "%s", v ? v : "");
+            nb++;
+         }
+         aimee_pg_finalize(st);
+      }
+   }
+
+   int written = 0;
+   for (int i = 0; i < nb; i++)
+   {
+      if (!batch[i].artifact[0])
+         continue;
+      char subj_attr[520];
+      snprintf(subj_attr, sizeof(subj_attr), "%s %s", batch[i].subject, batch[i].attribute);
+      float lvec[CONTRA_CLAIM_DIM];
+      if (memory_embed_text(subj_attr, live_cmd, lvec, CONTRA_CLAIM_DIM) != CONTRA_CLAIM_DIM)
+         continue;
+
+      int64_t cand[CONTRA_FUZZY_K];
+      double cscore[CONTRA_FUZZY_K];
+      int nc = pgvec_curator_claim_search("subj_attr", NULL, lvec, CONTRA_CLAIM_DIM, CONTRA_FUZZY_K,
+                                          cand, cscore, CONTRA_FUZZY_K);
+      for (int j = 0; j < nc; j++)
+      {
+         if (cand[j] == batch[i].pid || cscore[j] < CONTRA_FUZZY_LIVE_MIN)
+            continue;
+         char cart[64] = "", csubj[256] = "", cval[256] = "";
+         if (pgvec_curator_claim_fields(cand[j], cart, sizeof(cart), csubj, sizeof(csubj), cval,
+                                        sizeof(cval)) != 1)
+            continue;
+         /* Fuzzy case only: a DIFFERENT subject text (identical-subject pairs are
+          * the exact pass's job) asserting a DIFFERENT value. */
+         if (!cart[0] || strcmp(cart, batch[i].artifact) == 0 ||
+             strcmp(csubj, batch[i].subject) == 0 || strcmp(cval, batch[i].value) == 0)
+            continue;
+         /* Mandatory deep confirmation: both sides deep-embedded AND deep-similar. */
+         double dsim = 0.0;
+         if (pgvec_curator_claim_deep_similarity(batch[i].pid, cand[j], &dsim) != 1 ||
+             dsim < CONTRA_FUZZY_DEEP_MIN)
+            continue;
+         if (db2_artifact_link(batch[i].artifact, cart, "contradicts") == 0)
+         {
+            aimee_log(LOG_INFO, "kb.curator.contradict",
+                      "fuzzy contradiction: '%s' vs '%s' (live=%.3f deep=%.3f)", batch[i].subject,
+                      csubj, cscore[j], dsim);
+            written++;
+         }
+      }
+   }
+   return written;
+}
 
 int kb_curator_detect_contradictions_one(const kb_curator_extract_opts_t *opts)
 {
@@ -72,6 +177,11 @@ int kb_curator_detect_contradictions_one(const kb_curator_extract_opts_t *opts)
       if (db2_artifact_link(from_ids[i], to_ids[i], "contradicts") == 0)
          written++;
    }
+
+   /* Opt-in fuzzy phase: semantic subject+attribute matches the exact join misses,
+    * each mandatorily confirmed in the 4B deep space. No-op when the deep tier is off. */
+   written += mine_fuzzy_contradictions();
+
    if (written > 0)
       aimee_log(LOG_INFO, "kb.curator.contradict", "linked %d contradicting claim pair(s)",
                 written);

--- a/src/kb/kb_curator_index_claims.c
+++ b/src/kb/kb_curator_index_claims.c
@@ -115,6 +115,17 @@ int kb_curator_index_claims_one(const kb_curator_extract_opts_t *opts)
       if (pgvec_curator_claim_upsert(pid, subj_vec, val_vec, CURATOR_CLAIM_DIM, id, subject,
                                      attribute, value, claim_kind, payload ? payload : "{}") != 0)
          aimee_log(LOG_WARN, "kb.curator.claims", "claim vector upsert failed for %s", id);
+      else if (cfg.memory_deep_embedding_enabled && cfg.memory_deep_embedding_command[0])
+      {
+         /* Deep tier: store a deep embedding of subject+attribute for fuzzy
+          * contradiction mining (precision guard). Best-effort; never blocks. */
+         float subj_deep[DEEP_EMBED_MAX_DIM];
+         int dd =
+             memory_embed_text(subj_attr[0] ? subj_attr : value_text,
+                               cfg.memory_deep_embedding_command, subj_deep, DEEP_EMBED_MAX_DIM);
+         if (dd > 0)
+            pgvec_curator_claim_deep_update(pid, subj_deep, dd);
+      }
    }
    else
    {

--- a/src/kb/kb_curator_index_code_unit.c
+++ b/src/kb/kb_curator_index_code_unit.c
@@ -116,6 +116,39 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
                                          id, file_path, def_kind, signature, body_hash,
                                          payload ? payload : "{}") != 0)
          aimee_log(LOG_WARN, "kb.curator.code_unit", "code_unit vector upsert failed for %s", id);
+      else if (cfg.memory_deep_embedding_enabled && cfg.memory_deep_embedding_command[0])
+      {
+/* Deep tier: store a deep embedding of the body, then link deep-confirmed clones
+ * (near-duplicate bodies) via an additive "similar_to" edge. Conservative
+ * thresholds; gated default-off. */
+#define CURATOR_CLONE_K        5
+#define CURATOR_CLONE_LIVE_MIN 0.85
+#define CURATOR_CLONE_DEEP_MIN 0.85
+         float body_deep[DEEP_EMBED_MAX_DIM];
+         int dd = memory_embed_text(body_text, cfg.memory_deep_embedding_command, body_deep,
+                                    DEEP_EMBED_MAX_DIM);
+         if (dd > 0)
+         {
+            int64_t cand[CURATOR_CLONE_K];
+            double cscore[CURATOR_CLONE_K];
+            int nc = pgvec_curator_code_unit_search("body", NULL, body_vec, CURATOR_CODE_UNIT_DIM,
+                                                    CURATOR_CLONE_K, cand, cscore, CURATOR_CLONE_K);
+            for (int j = 0; j < nc; j++)
+            {
+               if (cand[j] == pid || cscore[j] < CURATOR_CLONE_LIVE_MIN)
+                  continue;
+               double dsim = 0.0;
+               if (pgvec_curator_code_unit_deep_similarity(cand[j], body_deep, dd, &dsim) != 1 ||
+                   dsim < CURATOR_CLONE_DEEP_MIN)
+                  continue;
+               char cart[64] = "";
+               if (pgvec_curator_code_unit_artifact(cand[j], cart, sizeof(cart)) == 1 && cart[0] &&
+                   strcmp(cart, id) != 0)
+                  db2_artifact_link(id, cart, "similar_to");
+            }
+            pgvec_curator_code_unit_deep_update(pid, body_deep, dd);
+         }
+      }
    }
    else
    {

--- a/src/kb/kb_curator_index_narrative.c
+++ b/src/kb/kb_curator_index_narrative.c
@@ -118,6 +118,39 @@ int kb_curator_index_narrative_one(const kb_curator_extract_opts_t *opts)
       if (pgvec_curator_narrative_upsert(pid, vec, dim, id, kind, doc_id, status, priority,
                                          payload ? payload : "{}") != 0)
          aimee_log(LOG_WARN, "kb.curator.narrative", "narrative vector upsert failed for %s", id);
+      else if (cfg.memory_deep_embedding_enabled && cfg.memory_deep_embedding_command[0])
+      {
+/* Deep tier: store a deep embedding, then link deep-confirmed near-duplicate
+ * narratives via an additive "similar_to" edge (never drops content). Conservative
+ * thresholds; gated default-off. */
+#define CURATOR_DEDUP_K        5
+#define CURATOR_DEDUP_LIVE_MIN 0.85
+#define CURATOR_DEDUP_DEEP_MIN 0.85
+         float deep_vec[DEEP_EMBED_MAX_DIM];
+         int dd = memory_embed_text(text, cfg.memory_deep_embedding_command, deep_vec,
+                                    DEEP_EMBED_MAX_DIM);
+         if (dd > 0)
+         {
+            int64_t cand[CURATOR_DEDUP_K];
+            double cscore[CURATOR_DEDUP_K];
+            int nc = pgvec_curator_narrative_search(NULL, NULL, NULL, vec, dim, CURATOR_DEDUP_K,
+                                                    cand, cscore, CURATOR_DEDUP_K);
+            for (int j = 0; j < nc; j++)
+            {
+               if (cand[j] == pid || cscore[j] < CURATOR_DEDUP_LIVE_MIN)
+                  continue;
+               double dsim = 0.0;
+               if (pgvec_curator_narrative_deep_similarity(cand[j], deep_vec, dd, &dsim) != 1 ||
+                   dsim < CURATOR_DEDUP_DEEP_MIN)
+                  continue;
+               char cart[64] = "";
+               if (pgvec_curator_narrative_artifact(cand[j], cart, sizeof(cart)) == 1 && cart[0] &&
+                   strcmp(cart, id) != 0)
+                  db2_artifact_link(id, cart, "similar_to");
+            }
+            pgvec_curator_narrative_deep_update(pid, deep_vec, dd);
+         }
+      }
    }
    else
    {

--- a/src/kb/kb_curator_resolve_entities.c
+++ b/src/kb/kb_curator_resolve_entities.c
@@ -44,6 +44,16 @@
  * decides. Below this, always create. */
 #define CURATOR_ENTITY_JUDGE_LOW 0.70
 
+/* Deep-tier precision guard (config memory_deep_embedding_enabled): when a confident
+ * live-embedding merge (>= MERGE_THRESHOLD) is also checkable in the 4B deep space
+ * — both the mention and the matched entity have a deep embedding — a clearly-low
+ * deep cosine means the live embedding over-estimated similarity; reject the merge
+ * and create a distinct entity instead. Conservative threshold: true matches are
+ * deep-similar (well above this), so a real merge is never blocked; a no-op when
+ * the deep tier is off or the matched entity has no deep embedding yet. Deep can
+ * only PREVENT a merge, never force one — it cannot collapse distinct entities. */
+#define CURATOR_ENTITY_DEEP_CONFIRM 0.60
+
 void kb_curator_entity_embed_text(const char *name, const char *context, char *out, size_t out_len)
 {
    if (!out || out_len == 0)
@@ -79,7 +89,8 @@ int64_t kb_curator_entity_point_id(const char *artifact_id)
  * A judge error is treated as "not the same" (create), so a flaky sidecar can
  * only over-create, never collapse distinct entities. */
 static int resolve_try_match(const char *scope_kind, const char *scope_id, const float *vec,
-                             int dim, const char *name, const char *context, const config_t *cfg)
+                             int dim, const char *name, const char *context, const config_t *cfg,
+                             const float *deep_vec, int deep_dim)
 {
    int64_t match_ids[1];
    double match_scores[1];
@@ -89,6 +100,19 @@ static int resolve_try_match(const char *scope_kind, const char *scope_id, const
       return 0;
    if (match_scores[0] >= CURATOR_ENTITY_MERGE_THRESHOLD)
    {
+      /* Deep-tier guard: reject a confident live merge only when the 4B deep space
+       * clearly disagrees (both sides deep-embedded; cosine below the floor). */
+      double dsim = 0.0;
+      if (deep_dim > 0 &&
+          pgvec_curator_entity_deep_similarity(match_ids[0], deep_vec, deep_dim, &dsim) == 1 &&
+          dsim < CURATOR_ENTITY_DEEP_CONFIRM)
+      {
+         aimee_log(LOG_INFO, "kb.curator.resolve",
+                   "entity '%s' live-matched in %s:%s (score=%.3f) but deep guard rejects "
+                   "(deep=%.3f); creating distinct entity",
+                   name, scope_kind, scope_id, match_scores[0], dsim);
+         return 0;
+      }
       aimee_log(LOG_INFO, "kb.curator.resolve",
                 "entity '%s' resolves to existing in %s:%s (score=%.3f); skipping duplicate vector",
                 name, scope_kind, scope_id, match_scores[0]);
@@ -187,6 +211,13 @@ int kb_curator_resolve_entities_one(const kb_curator_extract_opts_t *opts)
    const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
    float vec[CURATOR_ENTITY_DIM];
    int dim = memory_embed_text(embed_text, embed_cmd, vec, CURATOR_ENTITY_DIM);
+   /* Deep tier: embed the mention once with the deep model (when enabled) — reused
+    * for the merge-confirmation guard and, if it becomes a new entity, stored. */
+   float deep_vec[DEEP_EMBED_MAX_DIM];
+   int deep_dim = 0;
+   if (cfg.memory_deep_embedding_enabled && cfg.memory_deep_embedding_command[0])
+      deep_dim = memory_embed_text(embed_text, cfg.memory_deep_embedding_command, deep_vec,
+                                   DEEP_EMBED_MAX_DIM);
    if (dim == CURATOR_ENTITY_DIM)
    {
       /* Resolve to an existing canonical entity in this scope, or — per the
@@ -195,7 +226,8 @@ int kb_curator_resolve_entities_one(const kb_curator_extract_opts_t *opts)
        * workspace/global entity resolves onto it instead of creating a
        * near-duplicate. The searches run before the upsert, so they only see
        * previously-committed entities. */
-      int merged = resolve_try_match(scope_kind, scope_id, vec, dim, name, context, &cfg);
+      int merged = resolve_try_match(scope_kind, scope_id, vec, dim, name, context, &cfg, deep_vec,
+                                     deep_dim);
       if (!merged)
       {
          void *conn = db2_conn();
@@ -205,7 +237,7 @@ int kb_curator_resolve_entities_one(const kb_curator_extract_opts_t *opts)
          while (!merged && conn &&
                 kb_curator_broaden_scope(conn, ck, cid, wk, sizeof(wk), wid, sizeof(wid)))
          {
-            merged = resolve_try_match(wk, wid, vec, dim, name, context, &cfg);
+            merged = resolve_try_match(wk, wid, vec, dim, name, context, &cfg, deep_vec, deep_dim);
             snprintf(ck, sizeof(ck), "%s", wk);
             snprintf(cid, sizeof(cid), "%s", wid);
          }
@@ -216,6 +248,8 @@ int kb_curator_resolve_entities_one(const kb_curator_extract_opts_t *opts)
          if (pgvec_curator_entity_upsert(pid, vec, dim, scope_kind, scope_id, name, id,
                                          payload ? payload : "{}") != 0)
             aimee_log(LOG_WARN, "kb.curator.resolve", "entity vector upsert failed for %s", id);
+         else if (deep_dim > 0)
+            pgvec_curator_entity_deep_update(pid, deep_vec, deep_dim); /* deep precision layer */
       }
    }
    else

--- a/src/tests/test_curator_contradictions.c
+++ b/src/tests/test_curator_contradictions.c
@@ -13,6 +13,50 @@
 #include "db2_test_shim.h"
 #include "../kb/kb_curator_contradictions.h"
 
+/* Link stubs for the opt-in fuzzy phase: it is gated behind the deep tier (off in
+ * these tests), so mine_fuzzy_contradictions returns before calling any of these
+ * at runtime — they exist only to satisfy the linker. */
+int memory_embed_text(const char *text, const char *command, float *out, int max_dim)
+{
+   (void)text;
+   (void)command;
+   (void)out;
+   (void)max_dim;
+   return 0;
+}
+int pgvec_curator_claim_search(const char *which_vec, const char *claim_kind, const float *vec,
+                               int dim, int limit, int64_t *ids, double *scores, int max)
+{
+   (void)which_vec;
+   (void)claim_kind;
+   (void)vec;
+   (void)dim;
+   (void)limit;
+   (void)ids;
+   (void)scores;
+   (void)max;
+   return 0;
+}
+int pgvec_curator_claim_deep_similarity(int64_t a, int64_t b, double *out)
+{
+   (void)a;
+   (void)b;
+   (void)out;
+   return 0;
+}
+int pgvec_curator_claim_fields(int64_t point_id, char *artifact_out, int alen, char *subject_out,
+                               int slen, char *value_out, int vlen)
+{
+   (void)point_id;
+   (void)artifact_out;
+   (void)alen;
+   (void)subject_out;
+   (void)slen;
+   (void)value_out;
+   (void)vlen;
+   return 0;
+}
+
 static void seed(sqlite3 *db, const char *sql)
 {
    assert(sqlite3_exec(db, sql, NULL, NULL, NULL) == SQLITE_OK);

--- a/src/tests/test_curator_resolve_entities.c
+++ b/src/tests/test_curator_resolve_entities.c
@@ -68,6 +68,21 @@ int pgvec_curator_entity_upsert(int64_t point_id, const float *vec, int dim, con
    g_upserts++;
    return 0;
 }
+int pgvec_curator_entity_deep_update(int64_t point_id, const float *vec, int dim)
+{
+   (void)point_id;
+   (void)vec;
+   (void)dim;
+   return 0;
+}
+int pgvec_curator_entity_deep_similarity(int64_t point_id, const float *vec, int dim, double *out)
+{
+   (void)point_id;
+   (void)vec;
+   (void)dim;
+   (void)out;
+   return 0; /* no stored deep embedding in the stub => guard is a no-op */
+}
 int pgvec_curator_entity_search(const char *scope_kind, const char *scope_id, const float *vec,
                                 int dim, int limit, int64_t *ids, double *scores, int max)
 {


### PR DESCRIPTION
Extends the 4B deep tier to **all four curator vector tables**, wiring each as an
active, deep-confirmed consumer. Builds on the memory deep tier (#174) + halfvec
unification (#175). Everything is **gated by `memory_deep_embedding_enabled`
(default off)**, reuses the 4B `/embed_deep` command, and degrades gracefully on
partial coverage. Deep is always a precision guard — additive or merge-preventing,
never destructive.

### Entity resolution — merge guard
`embedding_deep` + `resolve_entities`: a confident live merge (>= 0.85) is rejected
when the 4B deep space disagrees (< 0.60), so the live embedding can't collapse
two distinct canonical entities. Deep can only prevent a merge, never force one.

### Claim contradictions — fuzzy, deep-confirmed mining (new capability)
`subj_attr_deep_vec` + a fuzzy phase in `detect_contradictions`: finds **paraphrased**
contradictions (semantically-same subject+attribute, different value) the exact
self-join misses, and **requires** a 4B-deep confirmation (>= 0.75) before linking.

### Narrative + code-unit — deep-confirmed similarity links (new capability)
`embedding_deep` / `body_deep_vec` + index-time linking: near-duplicate narratives
and code clones get an **additive `similar_to` edge** — search live (>= 0.85),
require deep confirmation (>= 0.85), never drop content.

### Safety
Deep confirmation mandatory everywhere; conservative thresholds; gated default-off;
additive/merge-preventing only (no destructive merges or drops); idempotent links;
bounded batches. The contradiction/similarity thresholds are deliberate guesses —
tune on a real corpus before enabling. All curator unit tests pass (guards no-op
with deep off); real-pgvector e2e covers the deep-on paths.