### PR TITLE
Proposal: ingress cost accounting + request-level optimizations

### DIFF
--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -1,0 +1,217 @@
+# Proposal: ingress cost accounting + request-level cost optimizations
+
+- **State:** draft - pending review
+- **Author:** JBailes
+- **Date:** 2026-06-11
+- **Charter roles:** Evaluate-Optimize (monetary reward signal feeding the
+  existing bandit surface), Calibrate (cache/thinking thresholds), Recall
+  (envelope cache-marking on the answer path), Gate-Promote (default-off flag
+  rollout per the readiness program).
+- **Scope:** `src/server/anthropic_http.c` (usage capture at the buffered +
+  streaming ingress and `count_tokens`), `src/server/anthropic_stream*.c`
+  (surface the provider's final `usage` block from `message_delta`),
+  `src/server/ingress_preinject.c` (`ingress_preinject_format_envelope` /
+  `ingress_preinject_apply` cache-marking), `src/server/delegate_economics.c`
+  (promote the qualitative cost model to a monetary one), a new
+  `src/server/cost_pricing.{c,h}` (pricing table + `cost_calc`), a new db2 ledger
+  (`src/db2/usage_ledger.c` + header) reusing the `agent_outcomes` / `bandit`
+  table idiom, a typed `/v1/usage/*` surface (`server_http_routes.inc` +
+  handler), `aimee usage` CLI, the bandit reward loop in
+  `src/server/server_compute.c` (attach a $ reward to the existing
+  `delegate_routing` decision point), and config plumbing
+  (`src/headers/config.h`, `src/config_fields.c`, `src/config_sections.c`,
+  `src/config_save.c`). Unit + integration tests. No new service, no new model.
+
+## Goal
+
+Give aimee **native USD cost accounting** for every request that crosses its
+ingress, and a small set of **request-level cost optimizations** that feed the
+optimization surface aimee already has. aimee sits directly in the request path —
+the Anthropic ingress (`POST /v1/messages`), the Codex/Responses `/v1` ingress,
+and the delegate fan-out all flow through aimee-server — so it owns the exact
+interception point that an external proxy (e.g. the `tokencost` project this is
+modelled on) has to bolt on. Today aimee tracks token *counts* and a
+*qualitative* cost tier; it does not know what a turn costs in dollars, cannot
+attribute spend by source, and applies none of the cheap request-shaping wins
+(prompt-cache marking of the stable context envelope, dedup, thinking-budget
+caps).
+
+This is deliberately **not** a new optimizer. aimee already has a learning
+optimization surface — `delegate_routing` is a registered bandit decision point
+with a closed reward loop (`docs/proposals/done/optimization-surface.md`). The
+missing piece is a **monetary reward signal** and the **observability** to
+compute it. This proposal supplies the dollars; the existing bandit consumes
+them.
+
+## §0 What already exists (so we don't rebuild it)
+
+- **Token counts are already captured at the ingress.** `anthropic_http.c`
+  proxies the raw provider call buffered (`messages`) and streaming
+  (`messages_stream`), and exposes `count_tokens`. The streaming path runs an
+  `anthropic_stream_xlate_t` translator that already parses provider SSE
+  (`message_start` / `message_delta`) — the provider's authoritative `usage`
+  (input/output/cache tokens) passes through it. We surface it rather than
+  re-count.
+- **Cache-token fields already flow through delegate economics.**
+  `delegate_economics.c` already emits `delegate_cache_read_tokens` /
+  `delegate_cache_write_tokens` and an `agent_cost_tier`, with a *qualitative*
+  `delegate_cost_model` ("free" vs "tiered"). We promote this to dollars; we do
+  not invent the token plumbing.
+- **The optimization/routing surface is built and closed-loop.**
+  `delegate_routing` is a sampled bandit decision point with a reward loop
+  reaching `db2_bandit_decision_close()`, and `aimee optimize
+  points|baseline|replay|run|compare|promote` exists. We attach a reward, not a
+  framework.
+- **The context envelope is a single, stable, cache-shaped block.**
+  `ingress_preinject_format_envelope` builds `<aimee-context confidence=…>…`
+  and `ingress_preinject_apply` injects it ahead of the instructions. It is large
+  and constant across a session — the ideal prompt-cache anchor.
+- **Persistence is Postgres (db2), not SQLite.** The ledger follows the
+  `agent_outcomes` / `bandit` table idiom in `src/db2/`, not tokencost's
+  `tracker.db`.
+
+## §1 Pricing table + `cost_calc` (item 1)
+
+New `src/server/cost_pricing.{c,h}`: a static, data-driven price map keyed by
+model id, plus a single cache-aware cost function. Mirrors the economics the
+provider actually bills:
+
+```
+cost = ( input_tok       * p.input
+       + output_tok      * p.output
+       + cache_read_tok   * p.input * 0.10     /* cached reads ~10% of input */
+       + cache_write_tok  * p.input * 1.25 )   /* cache creation ~125% input */
+     / 1e6;               /* prices are per-million tokens */
+```
+
+- Each entry: `{ input, output }` per-million USD. Claude (Opus/Sonnet/Haiku +
+  the `[1m]` long-context tiers), the three delegates (minimax, mimo-2.5,
+  mistral) whose limits aimee already records, plus the OpenAI-compatible
+  providers aimee can target. A `"default"` fallback so an unknown model degrades
+  to an estimate, never a crash.
+- **Maintenance is the real cost here.** Prices drift, so the table ships as
+  *data* with a dated `pricing_refreshed` marker and a single edit point; no
+  prices baked into call sites. `tokencost` is MIT, so its ~218-model map can
+  seed ours **with attribution** — but we only carry models aimee can actually
+  reach.
+- `cost_pricing_lookup(model)` and `cost_calc(model, in, out, cr, cw)` are pure
+  and unit-testable with no I/O.
+
+## §2 Request cost-tracking ledger (item 2)
+
+A db2 ledger that records one row per ingress turn, written from the points that
+already see the usage.
+
+- **Schema** (`src/db2/usage_ledger.c`), columns chosen from what the ingress
+  already has: `ts, source, model, input_tokens, output_tokens,
+  cache_read_tokens, cache_creation_tokens, cost_usd, duration_ms, stop_reason,
+  tool_call_count, optimizations_json, optimizer_savings_usd`. `source` is the
+  key field — it separates Claude Code vs Codex vs webchat vs a named delegate,
+  derived from the ingress entrypoint (not User-Agent sniffing; aimee knows its
+  own caller).
+- **Write points:** the buffered `messages` return and the `messages_stream`
+  finish in `anthropic_http.c` (after `anthropic_stream_finish`, where the
+  translator's final `usage` is known), and the delegate-result path that already
+  populates `delegate_cache_*` fields. Estimated counts
+  (`session_compact_estimate_tokens`) are only a fallback when the provider
+  omitted `usage`; the row records which it was.
+- **Read surface:** typed `/v1/usage/summary?period=…` and `/v1/usage/raw?limit=…`
+  routes (registered in `server_http_routes.inc`, conformance-scanner clean — no
+  stray `/v1` string literals per the scanner trap), plus `aimee usage
+  summary|raw` over the thin client. This is the "what did this cost, by source
+  and model" surface aimee lacks.
+
+## §3 Auto prompt-cache marking of the context envelope (item 3) — highest leverage
+
+The single best optimization for aimee specifically. The pre-injection envelope
+is large and stable within a session; marking it cacheable cuts its repeat-read
+cost ~90% (the `cache_read = 0.10 × input` line in §1).
+
+- In `ingress_preinject_apply` (or at the point the envelope is attached to the
+  outbound provider request in `anthropic_http.c`), add Anthropic
+  `cache_control: {type: "ephemeral"}` to the envelope/system block when it
+  exceeds a configurable size floor (default ~1k chars, matching the tokencost
+  heuristic).
+- For OpenAI-compatible providers without explicit cache controls, this is a
+  no-op — the block is simply sent normally.
+- Savings are computed from the realized `cache_read_tokens` in §2 and recorded
+  in `optimizer_savings_usd`, so the win is *measured*, not asserted.
+
+## §4 Short-window request dedup (item 4)
+
+Cheap guard against duplicate identical turns (double-submits, client retries).
+
+- A bounded in-memory map of `SHA256(canonical request body) → (response,
+  ts)` at the ingress, TTL ~5s. On hit within the window, return the cached
+  response and record a `dedup` optimization row with the full turn cost as
+  saved.
+- Strictly opt-in and conservative: streaming responses and any request carrying
+  tool-result state bypass dedup (replaying a tool turn must not be elided).
+
+## §5 Complexity score → thinking-budget cap (item 5)
+
+A deterministic 0–10 complexity score (message count, total content length, tool
+presence — the tokencost heuristic) used to **cap** extended-thinking budget, not
+to change routing (routing already belongs to the bandit, §6).
+
+- Low (<4) → small thinking budget; medium (4–7) → moderate; high → uncapped.
+  Auto-raise the cap when the turn shows tool-error signals.
+- Lives next to the attention-guard/request-shaping path
+  (`agent_request_shaping.c`). Default-off; when off, provider/user-supplied
+  thinking settings pass through untouched.
+
+## §6 Close the loop: monetary reward into the existing bandit (the point)
+
+Rather than a parallel "smart router," feed the dollars from §1–§2 back into the
+`delegate_routing` decision point that already exists. After a turn closes,
+`server_compute.c` attaches `cost_usd` (and quality outcome) as the reward when
+calling `db2_bandit_decision_close()`. The bandit then learns cheap-vs-capable
+routing from real spend, and `aimee optimize compare` can report $ deltas. This
+is what turns aimee's interception position into a *self-tuning* cost surface
+instead of a static dashboard — the differentiator over an external proxy.
+
+## Config (all default-off, flag-rollout-readiness program)
+
+New bool/int fields plumbed through `config.h` / `config_fields.c` /
+`config_sections.c` / `config_save.c`, each defaulting to inert so this lands
+dark and graduates per the 6-criterion readiness bar:
+
+- `usage_accounting_enabled` (master gate for §1–§2 recording)
+- `ingress_cache_marking_enabled` + `ingress_cache_min_chars` (§3)
+- `ingress_dedup_enabled` + `ingress_dedup_window_ms` (§4)
+- `thinking_budget_cap_enabled` (§5)
+- `cost_reward_enabled` (§6 — attach $ reward to the bandit)
+
+Accounting (§1–§2) is pure observation and is the natural first flag to flip;
+the request-mutating optimizations (§3–§5) stay off until each clears the bar
+with a benchmark showing no quality regression.
+
+## Testing
+
+- **Unit:** `cost_calc` against known provider invoices (incl. cache-read/write
+  multipliers and the `default` fallback); complexity scoring fixtures; dedup
+  hash/TTL boundaries; envelope cache-mark gating on the size floor.
+- **Integration:** drive the Anthropic ingress (buffered + streaming) against a
+  stub provider returning a known `usage` block; assert one ledger row with the
+  right `source`, tokens, and `cost_usd`, and that streaming reads `usage` from
+  the translator finish, not the estimate. Assert §3 marks the envelope only
+  above the floor and that `optimizer_savings_usd` reflects realized
+  `cache_read_tokens`.
+- **Conformance:** `/v1/usage/*` routes pass the api-conformance scanner (build
+  URLs from the documented prefix; no stray `/v1` literals).
+- **Bench:** an A/B on the bench corpus with §6 on vs off, reporting $ /
+  correct-answer, gated as a user-run job (no autonomous prod deploy).
+
+## Non-goals / what we are *not* taking from tokencost
+
+- No external proxy, no menubar app, no `dashboard.html`, no `onbording.sh`,
+  no log-scraping of other tools' files — aimee already owns the request path.
+- No silent message-trimming or model-substitution behind the user's back;
+  routing decisions stay in the bandit where they are learned and auditable.
+- No SQLite `tracker.db`; persistence is db2.
+
+## Attribution
+
+Modelled on the MIT-licensed `tokencost` project (pricing-table shape, cache
+multipliers, complexity heuristic, dedup idea). Any pricing data seeded from it
+carries attribution.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -1,7 +1,7 @@
 # Proposal: ingress cost-accounting coverage + request-level cost optimizations
 
-- **State:** draft - pending review (revised after PR #180 review + a file-by-file
-  codebase audit)
+- **State:** draft - pending review (revised after PR #180 review + repeated
+  file-by-file codebase audits)
 - **Author:** JBailes
 - **Date:** 2026-06-11
 - **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing
@@ -12,7 +12,9 @@
   Anthropic relay path + buffered path; resolve the billable model),
   `src/server/anthropic_ingress.c` (`anthropic_stream_feed_openai` - capture full
   normalized OpenAI-stream usage, not just `completion_tokens`),
-  `src/server/openai_chat.c` (the live OpenAI/Codex pre-injection seam),
+  `src/server/openai_chat.c` (the live OpenAI/Codex inference and pre-injection
+  seam; direct ingress audit rows for chat/completions, completions, responses,
+  streaming responses, and runs),
   `src/server/agent_runtime.c` (`agent_log_call` - fix model attribution so rows
   resolve a real billable model), `src/server/token_tracker.c` +
   `src/headers/token_tracker.h` (single pricing source of truth, reconciled with
@@ -23,10 +25,13 @@
   metadata/splitting only if needed by the OpenAI/Codex seam),
   `src/server_insights.inc` (the `insights.overview` implementation),
   `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c` (cost-shaped
-  reward on the existing `delegate_routing` bandit close), config plumbing
-  (`src/headers/config.h`, `src/config_fields.c`, `src/config_sections.c`,
-  `src/config_save.c`), route and auth registration only if a new API method is
-  still justified. DB2 only if a shared/multi-machine analytics need is
+  reward on the existing `delegate_routing` bandit close), `src/server/server_http.c`
+  + `src/headers/server_http.h` (request-context propagation for source,
+  idempotency, principal, and request-id metadata), dashboard/HUD/frontend
+  readers that consume token-audit totals, config plumbing (`src/headers/config.h`,
+  `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), route and
+  auth registration only if a new API method is still justified. DB2 only if a
+  shared/multi-machine analytics need is
   established (§2). Unit + integration tests. No new service, no new model.
 
 ## Revision note
@@ -63,6 +68,17 @@ land together or history shows a false zero (§0/§2); (3) the aimee-owned outbo
 Anthropic `system` is a **flat string**, so the cache carve-out's real work is a
 string→content-block conversion, not a flag (§3); (4) `stream_options.include_usage`
 is set nowhere and aborted streams drop usage (§2).
+
+This pass adds three remaining blockers: (5) OpenAI/Codex ingress does **not**
+go through `agent_log_call` either — `openai_chat.c` calls `agent_execute()` and
+`agent_execute_messages()` directly, and `agent_execute()` explicitly leaves
+logging to its callers — so those handlers need first-class audit writes, not
+only attribution fixes; (6) the registered HTTP handler signatures only receive
+`body`/`resp`/`cap`, so source/principal/idempotency/request-id metadata is
+unavailable unless `server_http.c` exposes a request context; (7) HUD, dashboard,
+frontend, and webchat consumers currently sum `estimated_cost_usd` as a scalar,
+so new `estimated` / `avoided` / `partial` rows will inflate spend unless every
+reader is updated with the same semantics.
 
 ## Goal
 
@@ -145,6 +161,32 @@ optimization surface aimee already has, not a new one.
   real models while legacy rows stay empty, the by-model surface shows a
   **false-zero history** — recent ingress spend appears while all prior spend
   vanishes. The model write-fix and the filter/backfill must land together (§2).
+- **OpenAI/Codex ingress currently bypasses `agent_log_call` entirely.**
+  `agent_execute()` intentionally does **not** log (`agent_runtime.c:1093-1095`),
+  and `openai_chat.c` calls it directly for `/v1/chat/completions`,
+  `/v1/completions`, `/v1/responses`, and `/v1/runs` (`run_completion`,
+  `responses_handler`, `run_worker`). Streaming `/v1/responses` uses
+  `agent_execute_messages()`, a local one-step provider helper that also has no
+  token-audit write. So the OpenAI-compatible ingress is not merely missing
+  source attribution; most of it writes **no** `token_audit` row at all today.
+  The implementation must add exactly-one-row audit writes at these ingress
+  completion points, while preserving `agent_execute()`'s no-log contract to
+  avoid double logging in normal agent/delegate paths.
+- **The HTTP ingress handlers cannot currently see the metadata this proposal
+  needs.** `server_http_completion_fn` and stream handler typedefs receive only
+  `(body, resp, cap)` or `(body, emit, ctx)`; `Authorization`, `x-api-key`,
+  `X-Aimee-Session-Key`, idempotency headers, request id, route path, TCP-vs-UDS,
+  and derived bearer capabilities are consumed in `server_http.c` and then
+  discarded. Source attribution, account isolation, idempotent dedup, and audit
+  row identity therefore require either a small thread-local request context
+  (matching the existing `ingress_preinject_set_request_disabled()` pattern) or
+  widening the registered handler signatures before any ingress writer lands.
+- **Existing usage readers assume every row is spend.** `hud.c`,
+  `dashboard.c` / `server/dashboard_server.c`, `frontend/src/pages/Chat.tsx`, and
+  webchat's usage event shape all sum `estimated_cost_usd` directly. Once
+  `usage_kind=estimated|avoided|partial` exists, these readers must filter or
+  split realized spend from advisory/avoided values, otherwise the UI will show
+  avoided cost as money spent.
 
 ## §1 One pricing source of truth (extend, don't add)
 
@@ -186,14 +228,27 @@ provider usage, distinguishing **billable realized usage** from **local
 estimates** and **avoided estimated cost**.
 
 - **Minimum schema migration:** add fields (or a tightly-linked extension table)
-  for `source`, `usage_kind`, `requested_model`, `served_model` or
-  `billable_model`, `duration_ms`, `stop_reason`, and `optimizations_json` /
-  `avoided_cost_usd` if dedup/cache savings are reported. If the decision is to
-  avoid migration, state exactly how each field is represented and which reports
-  lose fidelity. The migration is additive-only — `db1_reconcile_columns`
+  for `source`, `usage_kind`, `request_id` or `turn_id`, `requested_model`,
+  `served_model` or `billable_model`, `provider_model`, `duration_ms`,
+  `stop_reason`, and `optimizations_json` / `avoided_cost_usd` if dedup/cache
+  savings are reported. If the decision is to avoid migration, state exactly how
+  each field is represented and which reports lose fidelity. The migration is
+  additive-only — `db1_reconcile_columns`
   (`db_schema.c:78`) adds missing columns but creates no indexes and runs no
   data migration, so column adds are safe but the empty-model backfill below is a
   separate step.
+- **Row identity / idempotency:** give each attempted provider call a stable
+  request/turn id, and make successful audit insertion idempotent on that id (or
+  on `(source, request_id, attempt)`). This is required for retries, background
+  `/v1/runs`, and stream-abort cleanup paths; otherwise a retry or late finalizer
+  can double-count spend.
+- **Request context prerequisite:** before adding source-aware audit rows or
+  dedup, expose a per-request context from `server_http.c` to registered handlers:
+  method/path, generated `X-Request-ID`, inbound idempotency key, session key,
+  remote/local transport, bearer scope/principal (or local UID), and selected
+  route capability. The existing thread-local preinject override is a precedent,
+  but this context must be reset for every request and safe for offloaded stream
+  or `/v1/runs` worker threads.
 - **Fix `by_model` alongside the model write (prerequisite, not optional).**
   Populating `served_model` is pointless while `db1_token_audit_by_model` filters
   empty models out: either backfill legacy rows' model from their `tool_name`
@@ -212,6 +267,12 @@ estimates** and **avoided estimated cost**.
   normalized `token_usage_t` (input + cache + output), not just
   `completion_tokens`. The provider request builder has to insert the option, not
   only the parser.
+- **OpenAI/Codex direct ingress paths:** add one audit write for each successful
+  provider call in `openai_chat.c`: buffered `/v1/chat/completions`,
+  `/v1/completions`, buffered `/v1/responses`, streaming `/v1/responses`
+  (`agent_execute_messages()` result), and `/v1/runs` worker completion. Do not
+  add logging inside `agent_execute()` itself; normal `agent_run*` paths already
+  call `agent_log_call()`.
 - **Buffered path:** parse the provider JSON `usage` block after a 200 response
   and before translating it back to the client. The Anthropic parser already
   extracts cache tokens (`agent_bridge.c:791-796`), but the **OpenAI buffered
@@ -247,6 +308,11 @@ the existing `agent_log_call` empty-model weakness: **provider-reported model
 requested model**. Record the requested model separately when it differs (Claude
 Code asks for one model; aimee serves the configured primary), so attribution is
 auditable rather than silently wrong. Agent names are not pricing keys.
+
+This also requires extending response/result shapes: `parsed_response_t` and
+`agent_result_t` currently carry token counts but no provider-reported model and
+no stop reason, so parsers must extract those fields before the ledger writer can
+honor the precedence rule.
 
 ## §3 Cache-aware request shaping, scoped to real ingress ownership
 
@@ -297,6 +363,10 @@ narrow.
   resolved model, endpoint/provider, behavior-relevant config flags, the
   exact preinject/context identity, behavior-affecting request headers, auth
   principal or tenant boundary, and stream/non-stream mode.
+- **Request-context dependency:** the idempotency key and account/source boundary
+  are not available to `openai_chat.c` / `anthropic_http.c` today because handler
+  signatures receive only the body. §2's request context must land before dedup,
+  or dedup can only key on unsafe body-derived data.
 - **v1 eligibility:** buffered only, no tools / no server-side tools, non-stream,
   successful `200` only, explicit idempotency key, and no request surface that can
   consume changing memory/context unless that context hash is in the key. Anything
@@ -359,6 +429,13 @@ Any new route requires:
 - `server_auth.c` capability policy, not just route registration; and
 - tests for auth denial as well as route/spec parity.
 
+Regardless of whether a new route is added, every existing consumer of
+`token_audit` must learn the same semantics: `cmd_usage`, `insights.overview`,
+HUD, dashboard JSON, the React context panel, and webchat usage events must report
+realized spend separately from estimated, avoided, and partial rows. A single SQL
+helper for spend totals is preferable to copy-pasting `WHERE usage_kind =
+'realized'` across consumers.
+
 ## Config (all default-off, flag-rollout-readiness program)
 
 - `ingress_usage_accounting_enabled` (§2 — observe + audit ingress turns)
@@ -391,8 +468,17 @@ with a benchmark showing no quality regression.
 - **Schema/reporting:** additive migration preserves existing `token_audit` rows;
   **by-model no longer hides legacy empty-model rows** (false-zero migration
   test); spend totals exclude `estimated`, `avoided`, and `partial` rows by
-  default; source/model breakdowns are stable in `cmd_usage` and
-  `insights.overview`.
+  default; source/model breakdowns are stable in `cmd_usage`,
+  `insights.overview`, HUD, dashboard JSON, React context panel, and webchat
+  usage events.
+- **OpenAI/Codex ingress audit:** buffered chat/completions, completions,
+  responses, streaming responses, and `/v1/runs` each write exactly one realized
+  row on successful provider completion; `agent_execute()` remains no-log; normal
+  `agent_run*` paths still write exactly one row through `agent_log_call()`.
+- **Request context:** registered handlers see request id, idempotency key,
+  source/principal/session metadata, and route identity; context resets per
+  request and survives offloaded stream/run workers without leaking to the next
+  request.
 - **Aborted stream:** a stream cut before `finish` writes a `partial` row (or
   none), never a silently dropped turn.
 - **Buffered ingress:** provider usage writes **exactly one** audit row with
@@ -413,7 +499,8 @@ with a benchmark showing no quality regression.
   string.
 - **Dedup:** TTL; per-source/account/agent/model/endpoint/flags/context/stream
   key separation; no-tools/no-stream/200-only/idempotency-key eligibility;
-  error-response bypass; avoided cost does not inflate spend totals.
+  error-response bypass; no dedup when request context is unavailable; avoided
+  cost does not inflate spend totals.
 - **Bandit reward:** reward stays in `[0,1]`; cost affects arm selection only
   through normalized shaping, never raw dollars; side-metadata mode leaves arm
   selection unchanged; missing realized cost falls back safely.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -100,8 +100,8 @@ one.
   one lookup, no third table.
 - `token_estimate_cost()` keeps its current signature and the "0.0 on unknown
   model" contract; add a unit-tested registry fallback path.
-- If the MIT-licensed `tokencost` data seeds any prices, pin attribution + a
-  dated `pricing_refreshed` marker in whichever file becomes authoritative.
+- Pin a dated `pricing_refreshed` marker in whichever file becomes authoritative
+  so price drift is auditable.
 
 ## §2 Cover ingress turns in the existing audit (token_audit), not a new ledger
 
@@ -262,4 +262,5 @@ each clears the readiness bar with a benchmark showing no quality regression.
 - No SQLite `tracker.db`; per-row ledger stays in DB1, DB2 only if shared
   analytics is justified (§2).
 - No silent message-trimming or model substitution; routing stays in the bandit.
-- No external proxy / menubar / dashboard.html / log-scraping from `tokencost`.
+- No external proxy, menu-bar widget, standalone dashboard, or log-scraping of
+  other tools' files — aimee owns the request path.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -30,8 +30,9 @@
   reward on the existing `delegate_routing` bandit close), `src/server/server_http.c`
   + `src/headers/server_http.h` + `src/server/server_auth.c` (request-context
   propagation + UDS peer-UID capture for source, idempotency, principal, and
-  request-id metadata), `webchat/openai.go` and `webchat/socket.go` (webchat
-  proxy/session source attribution),
+  request-id metadata), `api/openapi-server-v1.yaml`,
+  `src/server/openapi_server_data.h`, `src/cli_rpc_routes.inc`,
+  `webchat/openai.go` and `webchat/socket.go` (webchat proxy/session source attribution),
   `src/cmd_agent.c`, dashboard/HUD/frontend readers that consume token-audit totals, config
   plumbing (`src/headers/config.h`,
   `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), route and
@@ -159,6 +160,25 @@ allowlist are **net-new code** (the legacy NDJSON socket already derives
 HTTP path), and that mechanism is a prerequisite before any forwarded source/
 principal can be trusted.
 
+A tenth pass found two contract/security gaps in the ninth-pass fix. (19)
+**A UID allowlist is not enough to trust forwarded identity.** In the expected
+local deployment, webchat, the thin CLI, MCP, and ad-hoc local tools often run as
+the same Unix user, so `trusted_uds_peer_uids=[1000]` would trust **every**
+same-user UDS client to set `X-Aimee-Source` / principal headers. Peer UID is a
+baseline principal, not a proxy-authentication mechanism. Forwarded identity
+needs a second proof such as a server-minted internal proxy token/HMAC, a
+dedicated proxy-only socket, or another capability that arbitrary same-user
+clients cannot guess; inbound forwarding headers from all other clients must be
+stripped before request context is built. (20) **Extending `insights.overview`
+is still an API contract change.** The current OpenAPI entry is just
+`type: object`, `/v1/openapi.yaml` serves the generated
+`src/server/openapi_server_data.h`, and the thin client has a custom
+`print_insights_overview` in `src/cli_rpc_routes.inc` that prints only
+`estimated_cost_usd`. Source/usage-kind realized-vs-estimated semantics must be
+added to the server OpenAPI schema, regenerated into the embedded data header,
+and taught to the thin-client printer; otherwise the new fields are present in
+JSON but invisible or undocumented to clients.
+
 ## Goal
 
 Ingress requests are a cost blind spot. Normal agent and delegate calls are
@@ -285,7 +305,9 @@ optimization surface aimee already has, not a new one.
   allowlist — so distinguishing a trusted proxy (webchat) from an arbitrary UDS
   peer, and gating forwarded-header acceptance on it, must be built before any
   forwarded source/principal is trusted (it is a security prerequisite, not a
-  config knob).
+  config knob). A UID allowlist by itself is insufficient when the proxy and
+  arbitrary local clients run as the same user; forwarded headers need a
+  proxy-only credential or equivalent second factor.
 - **DB1 is a single shared SQLite handle, and audit writes are best-effort.** DB1
   is one process-wide `sqlite3*` (`db1_init.c:19`) opened `SQLITE_OPEN_FULLMUTEX`
   with `journal_mode=WAL` and a busy handler that retries 15× (20–150 ms) then
@@ -414,9 +436,10 @@ estimates** and **avoided estimated cost**.
   pthread (and SSE may offload), the context for those paths must be **captured
   into the job/work struct at enqueue**, and the thread-local must be reset per
   request so it never leaks across reused worker threads. Forwarded identity
-  headers must be accepted only from trusted internal proxies/peer UIDs and
-  ignored or stripped on TCP and untrusted UDS requests, so external callers
-  cannot spoof source or principal.
+  headers must be accepted only from authenticated internal proxies and ignored
+  or stripped on TCP and untrusted UDS requests, so external callers cannot spoof
+  source or principal. Captured peer UID is the fallback principal; it is not
+  enough to authenticate a proxy's forwarded user/session identity.
 - **Fix `by_model` alongside the model write (prerequisite, not optional).**
   Populating `served_model` is pointless while `db1_token_audit_by_model` filters
   empty models out: either backfill legacy rows' model from their `tool_name`
@@ -625,6 +648,15 @@ Any new route requires:
 - `server_auth.c` capability policy, not just route registration; and
 - tests for auth denial as well as route/spec parity.
 
+Extending an existing route still has contract work. If `insights.overview` is
+the usage surface, `api/openapi-server-v1.yaml` must stop describing it as an
+opaque `type: object` and document the realized/estimated/avoided/partial
+breakdown, source/model arrays, and backwards-compatible legacy fields. After
+that, regenerate `src/server/openapi_server_data.h` (`src/gen_openapi_server.py`)
+so `/v1/openapi.yaml` serves the updated contract, and update
+`src/cli_rpc_routes.inc::print_insights_overview` so the thin client displays the
+new spend semantics instead of only the legacy `estimated_cost_usd` scalar.
+
 Regardless of whether a new route is added, every existing consumer of
 `token_audit` must learn the same semantics: `cmd_usage`, `insights.overview`,
 HUD, dashboard JSON, `cmd_agent` / agent stats, the React context panel, and
@@ -644,12 +676,15 @@ metrics must use the new call key instead of the current agent-name join.
 - `cost_reward_lambda` + `cost_reward_enabled` (§6; 0 / off ⇒ pure side-metadata)
 - `ingress_audit_async` (§0/§2; write audit rows via an off-thread queue rather
   than synchronously in the streaming hot path)
-- `trusted_uds_peer_uids` (§0 finding 18; allowlist of UDS peer UIDs whose
-  forwarded source/principal headers are honored — empty ⇒ trust nothing)
+- `trusted_ingress_proxy_token` or equivalent proxy credential (§0 findings
+  18–19; required before forwarded source/principal headers are honored)
 
 Most are scalar bool/int flags needing only a `config.h` struct field + a
-`config_fields.c` row (+ a `test_config.c` round-trip); `trusted_uds_peer_uids` is
-a list, so it (and only it) also touches `config_sections.c` / `config_save.c`.
+`config_fields.c` row (+ a `test_config.c` round-trip). If the trusted-proxy
+mechanism is a list or structured policy rather than one token, it also touches
+`config_sections.c` / `config_save.c`. Do not rely on a bare UID list for
+forwarded identity; peer UID is only the fallback principal when no proxy
+credential is present.
 The §1 pricing unification and the §2 model-write / `by_model` fixes are **not**
 flagged — they are correctness fixes that land on by default.
 
@@ -690,8 +725,10 @@ with a benchmark showing no quality regression.
   next request on a reused worker thread. Webchat OpenAI proxy requests arrive at
   aimee-server with trusted source/session/principal metadata after
   `Authorization` is stripped. TCP clients and untrusted UDS peers cannot spoof
-  forwarded source/principal headers, and caller-supplied `X-Request-ID` is
-  preserved only as correlation metadata, not as the sole idempotency key.
+  forwarded source/principal headers, same-UID non-proxy UDS clients are not
+  trusted merely because their UID matches webchat, and caller-supplied
+  `X-Request-ID` is preserved only as correlation metadata, not as the sole
+  idempotency key.
 - **Source attribution:** ingress rows carry a per-client source derived from the
   request context (session key/principal/UDS peer UID), **not** the PPID-shared
   `session_id()`; two distinct clients do not collapse into one `top_sessions`
@@ -737,11 +774,16 @@ with a benchmark showing no quality regression.
   multiple request threads + the `/v1/runs` worker measures `token_audit` drop
   rate (busy-handler exhaustion) and tail latency; async mode keeps both within
   budget and the request thread is not blocked on the insert.
-- **UDS trust boundary:** an untrusted UDS peer (UID not in `trusted_uds_peer_uids`)
-  cannot set source/principal via forwarded headers — they are ignored; a TCP
-  client's `X-Forwarded-*`/principal headers are always ignored; only an
-  allowlisted peer's forwarding is honored; a UDS request with no forwarding still
-  attributes to its captured peer UID.
+- **UDS/proxy trust boundary:** an untrusted UDS peer cannot set source/principal
+  via forwarded headers — they are ignored; a same-UID but non-proxy UDS peer also
+  cannot set them; a TCP client's `X-Forwarded-*`/principal headers are always
+  ignored; only a peer with the proxy credential can forward identity; a UDS
+  request with no forwarding still attributes to its captured peer UID.
+- **OpenAPI/thin-client contract:** extending `insights.overview` updates
+  `api/openapi-server-v1.yaml` with a concrete response schema, regenerates
+  `src/server/openapi_server_data.h`, and updates `src/cli_rpc_routes.inc` so
+  remote `aimee insights` displays realized spend separately from estimated,
+  avoided, and partial rows.
 - **API/auth:** any new usage route has route/spec parity, CLI RPC coverage where
   exposed, and `server_auth.c` capability tests. If only `insights.overview` is
   extended, test the existing route and capability.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -4,25 +4,28 @@
 - **Author:** JBailes
 - **Date:** 2026-06-11
 - **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing
-  bandit), Calibrate (cache/thinking thresholds), Recall (envelope cache-marking
-  on the answer path), Gate-Promote (default-off flag rollout per the readiness
-  program).
+  bandit), Calibrate (cache/thinking thresholds), Recall (cache-aware ingress
+  shaping only where the ingress already owns the prompt), Gate-Promote
+  (default-off flag rollout per the readiness program).
 - **Scope:** `src/server/anthropic_http.c` (observe provider usage in the native
   Anthropic relay path + buffered path; resolve the billable model),
-  `src/server/anthropic_ingress.c` (`anthropic_stream_feed_openai` — capture full
-  normalized usage, not just `completion_tokens`; native SSE `message_delta.usage`
-  observation), `src/server/agent_runtime.c` (`agent_log_call` — fix model
-  attribution so ingress rows resolve a real billable model), `src/server/token_tracker.c`
-  + `src/headers/token_tracker.h` (single pricing source of truth, reconciled with
+  `src/server/anthropic_ingress.c` (`anthropic_stream_feed_openai` - capture full
+  normalized OpenAI-stream usage, not just `completion_tokens`),
+  `src/server/openai_chat.c` (the live OpenAI/Codex pre-injection seam),
+  `src/server/agent_runtime.c` (`agent_log_call` - fix model attribution so rows
+  resolve a real billable model), `src/server/token_tracker.c` +
+  `src/headers/token_tracker.h` (single pricing source of truth, reconciled with
   the model registry), `src/headers/model_registry.h` (`cost_in_per_mtok` /
-  `cost_out_per_mtok` — the authoritative price fields), `src/db1/token_audit.c`
-  (the existing audit ledger ingress rows feed), `src/server/ingress_preinject.c`
-  (`ingress_preinject_build` / `ingress_preinject_format_envelope` — structured
-  `cache_control` insertion), the `insights.overview` op behind
-  `/v1/insights/overview`, `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c`
-  (cost-shaped reward on the existing `delegate_routing` bandit close), config
-  plumbing (`src/headers/config.h`, `src/config_fields.c`, `src/config_sections.c`,
-  `src/config_save.c`). DB2 only if a shared/multi-machine analytics need is
+  `cost_out_per_mtok` - the authoritative base-price fields),
+  `src/db1/token_audit.c` + `src/db1/schema.sql` (the existing audit ledger plus
+  any required migration fields), `src/server/ingress_preinject.c` (envelope
+  metadata/splitting only if needed by the OpenAI/Codex seam),
+  `src/server_insights.inc` (the `insights.overview` implementation),
+  `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c` (cost-shaped
+  reward on the existing `delegate_routing` bandit close), config plumbing
+  (`src/headers/config.h`, `src/config_fields.c`, `src/config_sections.c`,
+  `src/config_save.c`), route and auth registration only if a new API method is
+  still justified. DB2 only if a shared/multi-machine analytics need is
   established (§2). Unit + integration tests. No new service, no new model.
 
 ## Revision note
@@ -30,14 +33,23 @@
 This supersedes the first draft, which proposed new `cost_pricing.{c,h}`, a new
 db2 usage ledger, a new `aimee usage` CLI, and raw-dollar bandit rewards. The PR
 #180 review correctly showed that aimee **already ships** cache-aware pricing
-(`token_tracker.c`, `token_estimate_cost`), an audit ledger with the exact schema
-I proposed (`db1/token_audit.c`: `session_id, delegation_id, model,
+(`token_tracker.c`, `token_estimate_cost`), an audit ledger with much of the
+needed schema (`db1/token_audit.c`: `session_id, delegation_id, model,
 prompt/completion/cache tokens, estimated_cost_usd`), a reader (`cmd_usage`
 → `db1_token_audit_*`), a usage/cost summary route (`/v1/insights/overview`), and
 model-registry price fields (`cost_in_per_mtok` / `cost_out_per_mtok`). All
 verified in-tree. The objective is therefore **coverage and correctness of the
 existing machinery for ingress requests**, not new accounting. Every §1–§6 below
 is rewritten accordingly.
+
+This revision also folds in second-pass review findings: Anthropic
+`/v1/messages` is intentionally a stateless proxy and is **not** a current
+pre-injection surface; the shipped pre-injection seam is in `openai_chat.c`; the
+`<aimee-context>` envelope is per-turn query-derived and therefore not
+inherently a stable cache prefix; and the current `token_audit` schema lacks
+several fields this proposal needs (`source`, `usage_kind`, requested-vs-served
+model, duration/stop metadata, optimization metadata). Those are explicit work
+items below rather than assumptions.
 
 ## Goal
 
@@ -46,25 +58,29 @@ audited (`agent_log_call` → `token_audit`), but requests arriving on aimee's
 **Anthropic ingress** (`POST /v1/messages`) and **OpenAI-compatible ingress** are
 not consistently folded in. This proposal (a) extends the existing audit to cover
 ingress turns with a correct billable model and source, and (b) adds a small set
-of request-level optimizations — prompt-cache marking of the stable injected
-envelope first — wired into the optimization surface aimee already has, not a new
-one.
+of request-level optimizations — cache-aware shaping first — wired into the
+optimization surface aimee already has, not a new one.
 
 ## §0 What already exists, corrected
 
 - **Pricing is already cache-aware and shared.** `token_usage_t`
   (`token_tracker.h`) carries `input/output/cache_write/cache_read`;
   `token_estimate_cost()` (`token_tracker.c`) applies per-MTok input/output +
-  cache-read/write multipliers via an internal table. The **model registry**
+  cache-read/write multipliers via an internal substring table. The **model registry**
   (`model_registry.h`) separately carries `cost_in_per_mtok` /
   `cost_out_per_mtok`. Two price sources already exist — §1 reconciles them rather
   than adding a third.
-- **The audit ledger already has the proposed schema.** `db1/token_audit.c`
+- **The audit ledger already covers the basic counters.** `db1/token_audit.c`
   inserts `(session_id, delegation_id, project_name, tool_name, role, model,
   prompt_tokens, completion_tokens, cache_write_tokens, cache_read_tokens,
-  estimated_cost_usd)` and exposes totals / by-role / by-tool / by-delegation
-  aggregations. `cmd_usage` (`cmd_core.c`) already reads them. This is DB1
-  (SQLite), local.
+  estimated_cost_usd)` and exposes totals / by-role / by-tool / by-model /
+  by-delegation aggregations. `cmd_usage` (`cmd_core.c`) and `insights.overview`
+  (`src/server_insights.inc`) already read it. This is DB1 (SQLite), local.
+- **The audit ledger does not yet encode all semantics this proposal needs.** It
+  has no explicit source/client, no usage-kind (`realized`, `estimated`,
+  `avoided`), no requested-vs-served model, no duration/stop reason, and no
+  optimization metadata. Do not smuggle all of that through `role`/`tool_name` if
+  downstream dashboards need to distinguish it. §2 defines the minimum migration.
 - **The streaming translator does NOT see full Anthropic usage** (this was the
   draft's biggest error). `anthropic_http.c::messages_stream` has **two** paths:
   native Anthropic providers are relayed byte-for-byte through
@@ -77,9 +93,19 @@ one.
 - **`count_tokens` is an estimate, not spend.** It uses
   `session_compact_estimate_tokens()` locally and never calls a provider. It must
   not write a spend row.
-- **`ingress_preinject_apply` is not the live surface.** The implementation is
-  `ingress_preinject_build()` + `ingress_preinject_format_envelope()`; `apply`
-  exists only in the header/tests. §3 targets the real path.
+- **The live pre-injection surface is not Anthropic Messages ingress.**
+  `docs/proposals/done/context-preinjection-ingress.md` states this explicitly:
+  the Codex/OpenAI handlers inject the envelope, while Anthropic `/v1/messages`
+  stays a pure stateless proxy by design. The live call sites are in
+  `src/server/openai_chat.c`, with `ingress_preinject_build()` and sometimes
+  `ingress_preinject_apply()`. Anthropic support would be a separate opt-in
+  mutation phase, not a free cache-marking change in `anthropic_http.c`.
+- **The `<aimee-context>` envelope is not inherently stable.**
+  `ingress_preinject_build(query, ...)` rebuilds from the turn query, code
+  search, memory context, and fresh audit context. Cache marking must separate
+  stable prefix material from volatile per-turn retrieval material or prove
+  stability by realized cache-read measurements. Do not mark the whole envelope
+  as a stable cache anchor by assertion.
 - **The bandit reward is a scalar in [0,1].** `server_compute.c` closes
   `delegate_routing` with `rc == 0 ? 1.0 : 0.0`, and `kb_client_bandit_close`
   documents reward as `[0,1]` over beta-style posteriors. Raw dollars cannot be
@@ -99,37 +125,59 @@ one.
   `token_tracker` owns cache multipliers and the `token_usage_t` normalization** —
   one lookup, no third table.
 - `token_estimate_cost()` keeps its current signature and the "0.0 on unknown
-  model" contract; add a unit-tested registry fallback path.
+  model" contract; add a unit-tested registry fallback path. If substring
+  matching remains as a fallback, test ambiguous names explicitly (`gpt-4o-mini`
+  before `gpt-4o`, `o3-mini` before `o3`, etc.).
 - Pin a dated `pricing_refreshed` marker in whichever file becomes authoritative
   so price drift is auditable.
+- Treat provider-reported model aliases as normalization inputs. Cost lookup
+  should use the billable provider model after alias resolution, not an agent
+  nickname or a user-requested model string.
 
 ## §2 Cover ingress turns in the existing audit (token_audit), not a new ledger
 
 Write ingress turns into `token_audit` from the points that can observe real
-provider usage, distinguishing **billable** requests from **local estimates**.
+provider usage, distinguishing **billable realized usage** from **local
+estimates** and **avoided estimated cost**.
 
+- **Minimum schema migration:** add fields (or a tightly-linked extension table)
+  for `source`, `usage_kind`, `requested_model`, `served_model` or
+  `billable_model`, `duration_ms`, `stop_reason`, and `optimizations_json` /
+  `avoided_cost_usd` if dedup/cache savings are reported. If the decision is to
+  avoid migration, state exactly how each field is represented and which reports
+  lose fidelity.
 - **Native Anthropic relay path:** add a usage-observing tap to
   `anthropic_relay_chunk_cb` (or route native streams through a thin
   usage-observing relay) that parses `message_start` / `message_delta.usage`
   (input, output, `cache_read_input_tokens`, `cache_creation_input_tokens`) while
-  still relaying the original bytes unchanged. Write one `token_audit` row at
-  stream finish.
-- **OpenAI-style path:** request `include_usage`/`stream_options` where the
-  provider supports it; extend `anthropic_stream_feed_openai` state to hold full
-  normalized `token_usage_t` (input + cache, not just `completion_tokens`).
-- **Buffered path:** parse the JSON `usage` block on the `messages` return.
-- **`count_tokens`:** never writes a spend row — it is local estimation. Mark
-  estimated-vs-realized so summaries never present pseudo-cost as spend.
-- **Failure:** no row on provider error (no phantom spend).
-- **Source + model:** set `role`/`tool_name` to carry the ingress source (Claude
-  Code vs Codex vs webchat vs OpenAI-ingress) using fields the schema already has,
-  and resolve a real billable `model` (see §2a) instead of the empty string
-  `agent_log_call` writes today.
+  still relaying the original bytes unchanged. Write one realized `token_audit`
+  row at stream finish.
+- **OpenAI-style streaming path:** request `stream_options: {include_usage:true}`
+  only for providers known to support it; unsupported OpenAI-compatible providers
+  must continue to work. Extend `anthropic_stream_feed_openai` state to hold full
+  normalized `token_usage_t` (input + cache + output), not just
+  `completion_tokens`. The provider request builder has to insert the option, not
+  only the parser.
+- **Buffered path:** parse the provider JSON `usage` block after a 200 response
+  and before translating it back to the client. Use provider parser fields where
+  already available, but verify cache tokens survive parser normalization.
+- **`count_tokens`:** never writes a realized spend row. If exposed in usage
+  summaries, it must be `usage_kind=estimated` and excluded from spend totals by
+  default.
+- **Failure:** no realized-spend row on provider error. If failed calls are
+  reported at all, they are operational telemetry, not cost rows.
+- **Source + model:** record source/client explicitly (Claude Code, Codex,
+  webchat, OpenAI-compatible ingress, delegate) and resolve a real billable
+  `model` (see §2a) instead of the empty string `agent_log_call` writes today.
 - **DB1 vs DB2:** keep the per-row ledger in DB1 (local, where `cmd_usage` and
   `insights.overview` already read). Add a DB2 mirror/aggregate **only** if a
   specific shared/multi-machine optimization-analytics need is established; if so,
   the proposal must state the DB1→DB2 relationship explicitly so operators never
   face two competing cost ledgers. Default: DB1 only.
+- **Double-counting guard:** delegate child spend is already folded back to the
+  parent via `db1_token_audit_cost_for_delegation()` and `db1_cost_fold_record()`.
+  Ingress accounting must state whether parent summaries include child spend,
+  exclude it, or show both with de-duplication.
 
 ### §2a Billable-model resolution (shared fix)
 
@@ -138,26 +186,37 @@ the existing `agent_log_call` empty-model weakness: **provider-reported model
 (response) > resolved/served model (the primary agent aimee actually routed to) >
 requested model**. Record the requested model separately when it differs (Claude
 Code asks for one model; aimee serves the configured primary), so attribution is
-auditable rather than silently wrong.
+auditable rather than silently wrong. Agent names are not pricing keys.
 
-## §3 Structured prompt-cache marking of the injected envelope (highest leverage)
+## §3 Cache-aware request shaping, scoped to real ingress ownership
 
-The pre-injection envelope is large and stable within a session; marking it
-cacheable cuts its repeat-read cost (`cache_read ≈ 0.10 × input`). But Anthropic
-caching is **not** a text transform — `cache_control` must land on the correct
-**structured** system/content block in outbound provider JSON.
+Cache marking is valuable, but it must match the ingress and provider shape.
+Anthropic caching is not a text transform — `cache_control` must land on the
+correct structured system/content block in outbound provider JSON. OpenAI-style
+prompt caching is automatic/provider-specific and usually has no portable
+request metadata.
 
-- Target the real surface: where `ingress_preinject_build` /
-  `ingress_preinject_format_envelope` output is attached to the outbound provider
-  request body in `anthropic_http.c`.
-- **Per provider shape:** Anthropic native `/v1/messages` — set
-  `cache_control: {type:"ephemeral"}` on the envelope's structured system/content
-  block when it exceeds a configurable char floor. OpenAI-compatible — no-op (or
-  provider-specific automatic caching) and **never** emit Anthropic cache
-  metadata. Translated OpenAI-via-Anthropic vs non-Anthropic driver paths must be
-  handled explicitly.
-- **Negative test required:** prove cache metadata is never leaked to an
-  unsupported provider's request body.
+- **OpenAI/Codex ingress first:** target the live pre-injection seam in
+  `src/server/openai_chat.c`. Because the current `<aimee-context>` is per-turn
+  query-derived, do not assume the whole envelope is cacheable. Either split the
+  pre-injection output into stable and volatile parts, or place cache boundaries
+  on stable system/persona/history prefixes and leave volatile retrieval after
+  the boundary.
+- **Anthropic `/v1/messages` carve-out:** `anthropic_http.c` is explicitly a
+  stateless proxy. Default behavior is to preserve client-supplied structured
+  system blocks and any existing `cache_control` metadata. Adding Aimee-generated
+  cache controls or context to this path requires a separate opt-in flag and
+  tests proving it does not corrupt Claude Code-owned tools, messages, or system
+  arrays.
+- **Per provider shape:** Anthropic native `/v1/messages` — only emit
+  `cache_control: {type:"ephemeral"}` on an owned structured block and only when
+  the provider is Anthropic. OpenAI-compatible — no-op or provider-specific
+  automatic caching; never emit Anthropic cache metadata. Translated
+  OpenAI-via-Anthropic vs non-Anthropic driver paths must be handled explicitly.
+- **Negative tests required:** prove cache metadata is never leaked to an
+  unsupported provider's request body; prove existing client-supplied
+  `cache_control` blocks are preserved; prove Anthropic system arrays are not
+  flattened when a structured mutation is needed.
 - Savings are computed from realized `cache_read_tokens` (§2), not asserted.
 
 ## §4 Short-window dedup, narrowly scoped for v1
@@ -167,15 +226,18 @@ narrow.
 
 - **Key includes every behavior-affecting input:** provider/agent identity,
   resolved model, endpoint/provider, behavior-relevant config flags, the
-  preinject envelope identity, behavior-affecting request headers, and
-  stream/non-stream mode.
+  exact preinject/context identity, behavior-affecting request headers, auth
+  principal or tenant boundary, and stream/non-stream mode.
 - **v1 eligibility:** buffered only, no tools / no server-side tools, non-stream,
-  successful `200` only, and an **explicit idempotency key** on the request.
-  Anything that can emit tool calls, consume changing memory/context, or depend on
+  successful `200` only, explicit idempotency key, and no request surface that can
+  consume changing memory/context unless that context hash is in the key. Anything
+  that can emit tool calls, consume changing memory/context, or depend on
   time/session state is excluded unless replay semantics are proven.
-- **Window:** small TTL (~5s), bounded map.
-- **Savings:** record *avoided estimated cost*, not "full turn cost saved,"
-  unless the skipped provider call's price is deterministically known.
+- **Window:** small TTL (~5s), bounded map, with per-source/account isolation.
+- **Savings:** record `usage_kind=avoided` with *avoided estimated cost*, not
+  "full turn cost saved," unless the skipped provider call's price is
+  deterministically known from a prior realized row. Avoided cost must not be
+  added to spend totals.
 
 ## §5 Complexity score → reasoning-effort cap, mapped to real provider surfaces
 
@@ -190,6 +252,8 @@ presence) **caps** reasoning effort — it does not route (routing is the bandit
 - **Precedence:** an explicit user/provider setting is never overwritten by the
   cap unless a config flag opts into that. The cap only *lowers* effort on
   low-complexity turns (and may raise on tool-error signals).
+- **Provider support:** request mutation must be driver/capability-aware. Do not
+  send unknown reasoning fields to OpenAI-compatible providers that reject them.
 - Lives in the request-shaping path; default-off.
 
 ## §6 Cost-shaped reward into the existing bandit (not raw dollars)
@@ -206,61 +270,85 @@ beta-style posteriors. Feeding `cost_usd` directly would invert the semantics.
   dollars as side metadata on the decision, consumed by `aimee optimize compare`
   for $-delta reporting without touching arm selection. Default to side-metadata
   first (lower risk), graduate to shaped reward behind a flag.
+- **Accounting dependency:** shaped rewards must use realized child/delegate cost
+  after cost-fold reconciliation, not an estimate based on agent name. If no
+  realized cost exists, fall back to unchanged success reward and record why.
 
 ## §7 API surface: extend insights.overview before adding /v1/usage/*
 
-`/v1/insights/overview` (`insights.overview`) already reports usage/cost
-summaries. Default to **extending it** with ingress/source breakdowns rather than
-adding `/v1/usage/*`. If a separate route is still justified, the proposal must
-say why it does not overlap `insights.overview` and keep the two non-overlapping.
-Any new route requires **OpenAPI generator/source updates** (the conformance
-check verifies route/spec parity, not response-field completeness), plus
-`server_http_routes.inc` registration that stays scanner-clean (no stray `/v1`
-string literals).
+`/v1/insights/overview` (`insights.overview`, implemented in
+`src/server_insights.inc`) already reports usage/cost summaries. Default to
+**extending it** with ingress/source breakdowns rather than adding `/v1/usage/*`.
+If a separate route is still justified, the proposal must say why it does not
+overlap `insights.overview` and keep the two non-overlapping.
+
+Any new route requires:
+
+- OpenAPI generator/source updates and regenerated route metadata;
+- `server_http_routes.inc` registration that stays scanner-clean;
+- CLI RPC route/client updates if the thin client exposes it;
+- `server_auth.c` capability policy, not just route registration; and
+- tests for auth denial as well as route/spec parity.
 
 ## Config (all default-off, flag-rollout-readiness program)
 
 - `ingress_usage_accounting_enabled` (§2 — observe + audit ingress turns)
 - `ingress_cache_marking_enabled` + `ingress_cache_min_chars` (§3)
+- `anthropic_ingress_cache_mutation_enabled` (§3 carve-out; default off, likely
+  later phase)
 - `ingress_dedup_enabled` + `ingress_dedup_window_ms` (§4)
 - `reasoning_effort_cap_enabled` (§5)
 - `cost_reward_lambda` + `cost_reward_enabled` (§6; 0 / off ⇒ pure side-metadata)
 
-Accounting (§2) is pure observation and is the first flag to flip; the
-request-mutating optimizations (§3–§5) and the shaped reward (§6) stay off until
-each clears the readiness bar with a benchmark showing no quality regression.
+Accounting (§2) is pure observation and is the first flag to flip; schema/report
+changes should land before request mutation. The request-mutating optimizations
+(§3–§5) and the shaped reward (§6) stay off until each clears the readiness bar
+with a benchmark showing no quality regression.
 
 ## Testing
 
 - **Pricing:** unknown-model → 0.0; cache-read/write fields applied; registry
-  fallback if the registry becomes authoritative.
+  lookup/fallback; ambiguous substring ordering; provider alias normalization.
+- **Schema/reporting:** migration preserves existing `token_audit` rows; spend
+  totals exclude `estimated` and `avoided` rows by default; source/model
+  breakdowns are stable in `cmd_usage` and `insights.overview`.
 - **Buffered ingress:** provider usage writes **exactly one** audit row with
   resolved source + billable model; **no row** on provider failure.
 - **Native Anthropic streaming:** final `message_delta.usage` is observed while
   the original stream is relayed byte-for-byte unchanged.
-- **OpenAI-style streaming:** with the usage chunk enabled, full normalized usage
-  (input + cache + output) is captured, not just `completion_tokens`.
+- **OpenAI-style streaming:** with `stream_options.include_usage` enabled only for
+  supporting providers, full normalized usage (input + cache + output) is
+  captured, not just `completion_tokens`; unsupported providers do not receive
+  the option.
 - **count_tokens:** asserts **no** spend ledger row.
-- **Prompt-cache marking:** Anthropic structured-JSON insertion on the right
-  block; below-floor no-op; unsupported-provider no-op; **no cache-metadata
-  leakage** to unsupported providers.
-- **Dedup:** TTL; per-agent/model/endpoint/flags/envelope/stream key separation;
-  no-tools/no-stream/200-only/idempotency-key eligibility; error-response bypass.
+- **Prompt-cache/request shaping:** OpenAI/Codex seam handles stable-vs-volatile
+  preinject placement; Anthropic structured-JSON insertion only under the
+  explicit opt-in carve-out; below-floor no-op; unsupported-provider no-op; no
+  cache-metadata leakage; existing client cache controls preserved.
+- **Dedup:** TTL; per-source/account/agent/model/endpoint/flags/context/stream
+  key separation; no-tools/no-stream/200-only/idempotency-key eligibility;
+  error-response bypass; avoided cost does not inflate spend totals.
 - **Bandit reward:** reward stays in `[0,1]`; cost affects arm selection only
   through normalized shaping, never raw dollars; side-metadata mode leaves arm
-  selection unchanged.
+  selection unchanged; missing realized cost falls back safely.
 - **Model attribution:** ingress and `agent_log_call` rows resolve a non-empty
   billable model per §2a precedence; requested-vs-served divergence recorded.
+- **API/auth:** any new usage route has route/spec parity, CLI RPC coverage where
+  exposed, and `server_auth.c` capability tests. If only `insights.overview` is
+  extended, test the existing route and capability.
 - **Bench:** A/B on the bench corpus, §6 on vs off, reporting $/correct-answer;
   user-run job (no autonomous prod deploy).
 
 ## Non-goals
 
 - No new pricing module, no new usage ledger, no new `aimee usage` command —
-  extend `token_tracker` / model registry / `token_audit` / `insights.overview` /
-  `cmd_usage`.
+  unless `cmd_usage` and `insights.overview` are proven insufficient; extend
+  `token_tracker` / model registry / `token_audit` / `insights.overview` /
+  `cmd_usage` first.
 - No SQLite `tracker.db`; per-row ledger stays in DB1, DB2 only if shared
   analytics is justified (§2).
 - No silent message-trimming or model substitution; routing stays in the bandit.
+- No mutation of Anthropic Messages ingress by default; it remains a stateless
+  proxy unless a separate opt-in phase changes that contract.
 - No external proxy, menu-bar widget, standalone dashboard, or log-scraping of
   other tools' files — aimee owns the request path.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -139,6 +139,26 @@ UDS peers must not be able to spoof `X-Aimee-Source` / principal forwarding
 headers, and `X-Request-ID` alone must not become an idempotency key because it
 is caller-controlled.
 
+A ninth pass verified 15–16 and found two more, in different layers. (17) **DB1
+write concurrency / best-effort drops.** DB1 is one shared `sqlite3*`
+(`db1_init.c:19`, `SQLITE_OPEN_FULLMUTEX` + `journal_mode=WAL` + a busy handler
+that gives up after 15 retries, `:22-68`); every HTTP connection already runs on
+a detached worker thread (`server_http.c` `conn_worker`) and `/v1/runs` on its own
+detached pthread, so concurrent `token_audit` writes happen today. The existing
+insert is `(void)`-ignored best-effort, so under the added per-turn write volume
+in the streaming hot path the busy handler can exhaust and **silently drop** a row
+(undercount), and the synchronous insert adds tail latency. The proposal must
+state explicit best-effort semantics, consider moving audit writes off the request
+thread (async/batched queue), and load-test tail latency + drop rate. (18) **No
+trusted-UDS-peer mechanism exists** — findings 7/13/16 all assume a peer UID, but
+the HTTP-over-UDS path never extracts `SO_PEERCRED` (`peer_uid` is set only in
+tests), grants `CAPS_ALL` to every UDS peer uniformly (`server_http.c:312-325`),
+and validates no forwarding header. So peer-UID capture and a trusted-peer
+allowlist are **net-new code** (the legacy NDJSON socket already derives
+`uid:<peer_uid>`, and `platform_ipc_peer_cred()` exists but is uncalled on the
+HTTP path), and that mechanism is a prerequisite before any forwarded source/
+principal can be trusted.
+
 ## Goal
 
 Ingress requests are a cost blind spot. Normal agent and delegate calls are
@@ -259,7 +279,25 @@ optimization surface aimee already has, not a new one.
   (a) capture the UDS peer UID on accept as a baseline principal (parity with
   NDJSON), and (b) require forwarding proxies — webchat first — to stamp trusted
   internal headers for source, principal/session, original request id, and
-  idempotency. Attribution cannot rely on the forwarded HTTP request alone.
+  idempotency. Attribution cannot rely on the forwarded HTTP request alone. **Both
+  are net-new code:** `handle_conn` never calls `platform_ipc_peer_cred()` today
+  (it exists but is uncalled on the HTTP path), and there is no trusted-peer
+  allowlist — so distinguishing a trusted proxy (webchat) from an arbitrary UDS
+  peer, and gating forwarded-header acceptance on it, must be built before any
+  forwarded source/principal is trusted (it is a security prerequisite, not a
+  config knob).
+- **DB1 is a single shared SQLite handle, and audit writes are best-effort.** DB1
+  is one process-wide `sqlite3*` (`db1_init.c:19`) opened `SQLITE_OPEN_FULLMUTEX`
+  with `journal_mode=WAL` and a busy handler that retries 15× (20–150 ms) then
+  **gives up** (`:22-68`). Every HTTP connection already runs on a detached worker
+  thread and `/v1/runs` on its own pthread, so concurrent `token_audit` writes
+  happen today; the insert is `(void)`-ignored, so a busy-handler exhaustion
+  **silently drops** the row. Adding a synchronous per-turn insert to the six
+  streaming/buffered hot paths raises both contention (→ dropped rows = undercount)
+  and tail latency. The accounting design must (i) state best-effort semantics
+  explicitly, (ii) prefer an **async/batched** audit-write queue off the request
+  thread, and (iii) load-test drop rate + tail latency before flipping the
+  accounting flag on.
 - **A thread-local context is NOT sufficient — it breaks for `/v1/runs`.** The
   cited precedent `ingress_preinject_set_request_disabled()` is `static __thread`
   (`ingress_preinject.c:28`) and works **only because the turn runs synchronously
@@ -604,10 +642,14 @@ metrics must use the new call key instead of the current agent-name join.
 - `ingress_dedup_enabled` + `ingress_dedup_window_ms` (§4)
 - `reasoning_effort_cap_enabled` (§5)
 - `cost_reward_lambda` + `cost_reward_enabled` (§6; 0 / off ⇒ pure side-metadata)
+- `ingress_audit_async` (§0/§2; write audit rows via an off-thread queue rather
+  than synchronously in the streaming hot path)
+- `trusted_uds_peer_uids` (§0 finding 18; allowlist of UDS peer UIDs whose
+  forwarded source/principal headers are honored — empty ⇒ trust nothing)
 
-These are all scalar bool/int flags, so each needs only a `config.h` struct field
-+ a `config_fields.c` row (+ a `test_config.c` round-trip); `config_sections.c` /
-`config_save.c` are touched only if a flag is nested under a new compound object.
+Most are scalar bool/int flags needing only a `config.h` struct field + a
+`config_fields.c` row (+ a `test_config.c` round-trip); `trusted_uds_peer_uids` is
+a list, so it (and only it) also touches `config_sections.c` / `config_save.c`.
 The §1 pricing unification and the §2 model-write / `by_model` fixes are **not**
 flagged — they are correctness fixes that land on by default.
 
@@ -691,6 +733,15 @@ with a benchmark showing no quality regression.
   row stay visible in source-aware usage summaries but do not contaminate
   `cmd_agent` agent stats. A fixture with two `agent_log` rows and two matching
   `token_audit` rows proves cost is not multiplied four ways.
+- **DB1 write concurrency:** a load test with the new write sites firing from
+  multiple request threads + the `/v1/runs` worker measures `token_audit` drop
+  rate (busy-handler exhaustion) and tail latency; async mode keeps both within
+  budget and the request thread is not blocked on the insert.
+- **UDS trust boundary:** an untrusted UDS peer (UID not in `trusted_uds_peer_uids`)
+  cannot set source/principal via forwarded headers — they are ignored; a TCP
+  client's `X-Forwarded-*`/principal headers are always ignored; only an
+  allowlisted peer's forwarding is honored; a UDS request with no forwarding still
+  attributes to its captured peer UID.
 - **API/auth:** any new usage route has route/spec parity, CLI RPC coverage where
   exposed, and `server_auth.c` capability tests. If only `insights.overview` is
   extended, test the existing route and capability.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -26,9 +26,10 @@
   `src/server_insights.inc` (the `insights.overview` implementation),
   `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c` (cost-shaped
   reward on the existing `delegate_routing` bandit close), `src/server/server_http.c`
-  + `src/headers/server_http.h` (request-context propagation for source,
-  idempotency, principal, and request-id metadata), `webchat/openai.go` and
-  `webchat/socket.go` (webchat proxy/session source attribution),
+  + `src/headers/server_http.h` + `src/server/server_auth.c` (request-context
+  propagation + UDS peer-UID capture for source, idempotency, principal, and
+  request-id metadata), `webchat/openai.go` and `webchat/socket.go` (webchat
+  proxy/session source attribution),
   dashboard/HUD/frontend readers that consume token-audit totals, config
   plumbing (`src/headers/config.h`,
   `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), route and
@@ -109,6 +110,19 @@ trusted local traffic unless the proxy stamps explicit forwarding metadata; (14)
 `usage.prompt_tokens` without using the LLM audit path, so embeddings need an
 explicit non-LLM / estimate-only / separate embedding-spend classification rather
 than being folded into chat/completion cost.
+
+A seventh pass verified 13–14 and refined both. (13) **The UDS source-erasure is
+systemic, not webchat-specific**: `server_http_authorize` trusts any `!is_tcp`
+connection and grants `CAPS_ALL`, so the thin CLI, MCP, and webchat all arrive as
+anonymous trusted-local — yet the HTTP-over-UDS path captures no peer identity
+while the legacy NDJSON socket already derives `uid:<peer_uid>`. The fix is both
+capturing the UDS peer UID as a baseline principal and requiring proxies to stamp
+forwarding metadata. (14) **Embeddings cost $0 today**: the embedder is local
+(builtin hash or a local command), the model is in no price table, and
+`usage.prompt_tokens` is a `chars/4` estimate — so the default is to **exclude**
+embeddings from spend, with a remote-embedder pricing hook as future-only work;
+the non-LLM ingress surface is bounded to `/v1/embeddings` (+ usage-less
+`/v1/models`).
 
 ## Goal
 
@@ -215,15 +229,22 @@ optimization surface aimee already has, not a new one.
   logged, never passed to handlers. Source attribution, account isolation,
   idempotent dedup, and audit row identity therefore require widening the handler
   signatures (or a request context) before any ingress writer lands.
-- **Webchat's OpenAI proxy erases source/principal context unless it stamps
-  replacement metadata.** `webchat/openai.go` validates the caller's webchat
-  OpenAI bearer token, then `proxyV1` removes `Authorization` before forwarding
-  `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, and
-  `/v1/embeddings` over the UDS. If the server context layer only inspects the
-  forwarded HTTP request, these calls look like anonymous local traffic instead
-  of webchat traffic tied to a session/user. The proxy must add trusted internal
-  forwarding headers or an equivalent side channel for source, principal/session,
-  original request id, and idempotency.
+- **Source/principal erasure over UDS is systemic, not webchat-specific.** The
+  audit confirmed `webchat/openai.go::proxyV1` validates the webchat bearer, then
+  `req.Header.Del("Authorization")` (`:84`) and forwards `/v1/chat/completions`,
+  `/v1/completions`, `/v1/responses`, `/v1/embeddings` over the UDS with **no**
+  replacement headers — webchat HAS identity it could stamp (PAM username,
+  `aimee_session_id`, `attach_id`) but forwards none. But the deeper fact is that
+  **every** UDS HTTP client is indistinguishable: `server_http_authorize` returns
+  0 for `!is_tcp` ("UDS: filesystem-permission auth, no token") and
+  `server_http_conn_caps` grants `CAPS_ALL`, so the thin CLI, MCP, and webchat all
+  arrive as anonymous trusted-local with no caller identity. Notably the **HTTP-
+  over-UDS path captures no peer identity, whereas the legacy NDJSON socket already
+  derives `uid:<peer_uid>`** (`server_auth.c:263-265`). Two complementary fixes:
+  (a) capture the UDS peer UID on accept as a baseline principal (parity with
+  NDJSON), and (b) require forwarding proxies — webchat first — to stamp trusted
+  internal headers for source, principal/session, original request id, and
+  idempotency. Attribution cannot rely on the forwarded HTTP request alone.
 - **A thread-local context is NOT sufficient — it breaks for `/v1/runs`.** The
   cited precedent `ingress_preinject_set_request_disabled()` is `static __thread`
   (`ingress_preinject.c:28`) and works **only because the turn runs synchronously
@@ -353,12 +374,19 @@ estimates** and **avoided estimated cost**.
   call `agent_log_call()`. Net: new writes only where no row exists today. Keep
   `/v1/embeddings` out of this LLM list unless embedding provider spend is
   intentionally added as a separate usage kind.
-- **Embeddings ingress is not chat/completion spend.** `/v1/embeddings` returns
-  OpenAI-style usage, but the implementation is embedder-backed rather than a
-  chat/completion provider turn. Either exclude it from spend dashboards, record
-  it as estimate-only local usage, or add an explicit embedding usage kind and
-  embedder pricing source if external embedding billing is possible. Do not let
-  embedding prompt tokens inflate LLM model cost.
+- **Embeddings ingress costs $0 today — default to excluding it.**
+  `embeddings_handler` (`openai_chat.c`) calls `memory_embed_text`, which is
+  **local**: the builtin hash embedder (`memory_embed_text_builtin`) or a local
+  `embedding_command` via `platform_exec_pipe` — no paid API, and the embedder
+  model id is absent from every price table (so `token_estimate_cost` → 0.0
+  regardless). Its `usage.prompt_tokens` is itself a `chars/4` **estimate**, not
+  provider-reported. So the correct default is **exclude embeddings from spend**,
+  not "record as estimate-only." A remote-embedder cost hook is future-only — the
+  `embedding_endpoint` / `embedding_model` config fields exist but are **unused**
+  by `memory_embed_text` today; only if a remote embedder is wired does an
+  explicit embedding usage-kind + embedder pricing source become real. The non-LLM
+  ingress surface is **bounded**: the only other non-chat route is `/v1/models`
+  (no usage). Never let embedding tokens inflate LLM by-model cost.
 - **Buffered path:** parse the provider JSON `usage` block after a 200 response
   and before translating it back to the client. The Anthropic parser already
   extracts cache tokens (`agent_bridge.c:791-796`), but the **OpenAI buffered
@@ -568,9 +596,10 @@ with a benchmark showing no quality regression.
   one** realized row; **`/v1/runs` still writes exactly one** row (via its
   existing `agent_log_call`) and gains source attribution **without** a second
   write; `agent_execute()` remains no-log; normal `agent_run*` paths are
-  unchanged. `/v1/embeddings` is either excluded from LLM spend or recorded under
-  an explicit embedding usage kind, and never appears as chat/completion model
-  spend. Explicit assertion: no turn produces two rows.
+  unchanged. `/v1/embeddings` is **excluded from spend by default** (local $0
+  embedder) and never appears as chat/completion model spend; if a remote embedder
+  is wired it records under a distinct embedding usage-kind. Explicit assertion: no
+  turn produces two rows.
 - **Request context / threading:** registered handlers see request id, idempotency
   key, source/principal/session metadata, and route identity; the `/v1/runs`
   detached worker sees the **same** context via capture-at-enqueue (not a
@@ -579,8 +608,10 @@ with a benchmark showing no quality regression.
   aimee-server with trusted source/session/principal metadata after
   `Authorization` is stripped.
 - **Source attribution:** ingress rows carry a per-client source derived from the
-  request context (session key/principal), **not** the PPID-shared `session_id()`;
-  two distinct clients do not collapse into one `top_sessions` row.
+  request context (session key/principal/UDS peer UID), **not** the PPID-shared
+  `session_id()`; two distinct clients do not collapse into one `top_sessions`
+  row; a UDS request with no forwarding metadata still attributes to its peer UID
+  rather than an anonymous blank source.
 - **Idempotency:** a retried or late-finalized call with the same
   `(source, request_id, attempt)` produces exactly one row (index or in-process
   guard), and the migration that creates the uniqueness constraint is exercised.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -1,6 +1,7 @@
 # Proposal: ingress cost-accounting coverage + request-level cost optimizations
 
-- **State:** draft - pending review (revised after PR #180 review)
+- **State:** draft - pending review (revised after PR #180 review + a file-by-file
+  codebase audit)
 - **Author:** JBailes
 - **Date:** 2026-06-11
 - **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing
@@ -51,6 +52,18 @@ several fields this proposal needs (`source`, `usage_kind`, requested-vs-served
 model, duration/stop metadata, optimization metadata). Those are explicit work
 items below rather than assumptions.
 
+A third pass added a **file-by-file codebase audit** that confirmed the above and
+surfaced four issues no review named, now folded in with file:line evidence:
+(1) pricing lives in **four** divergent sources — token_tracker (substring +
+cache), the model registry (exact, no cache), `delegate_ensemble.c` (a third
+flat-rate calculator), and `models_dev_snapshot.json` — so the same model id can
+be priced differently by different paths (§0/§1); (2) `db1_token_audit_by_model`
+filters out every empty-model row, so the model-write fix and the filter fix must
+land together or history shows a false zero (§0/§2); (3) the aimee-owned outbound
+Anthropic `system` is a **flat string**, so the cache carve-out's real work is a
+string→content-block conversion, not a flag (§3); (4) `stream_options.include_usage`
+is set nowhere and aborted streams drop usage (§2).
+
 ## Goal
 
 Ingress requests are a cost blind spot. Normal agent and delegate calls are
@@ -63,13 +76,25 @@ optimization surface aimee already has, not a new one.
 
 ## §0 What already exists, corrected
 
-- **Pricing is already cache-aware and shared.** `token_usage_t`
-  (`token_tracker.h`) carries `input/output/cache_write/cache_read`;
-  `token_estimate_cost()` (`token_tracker.c`) applies per-MTok input/output +
-  cache-read/write multipliers via an internal substring table. The **model registry**
-  (`model_registry.h`) separately carries `cost_in_per_mtok` /
-  `cost_out_per_mtok`. Two price sources already exist — §1 reconciles them rather
-  than adding a third.
+- **Pricing is split across four sources, and they disagree.** A full audit
+  found more divergence than "two sources":
+  1. `token_tracker.c:17-47` — a 17-row table with the **only** cache-price
+     fields, matched by case-insensitive **substring**, first-match-wins
+     (`find_price` / `token_strcasestr_local`, `:56-85`).
+  2. `model_registry` — `cost_in_per_mtok` / `cost_out_per_mtok`
+     (`model_registry.h:39-40`), a 9-row static table (`model_registry.c:439-469`)
+     plus a dynamic models.dev cache and an override JSON, matched by **exact**
+     provider-qualified `strcasecmp`, with **no cache-price fields**.
+  3. `delegate_ensemble.c:88-99` (`model_token_cost`) — uses the registry and
+     falls back to a flat `0.000015`/token (`:21`), **bypassing token_tracker**,
+     so ensemble cost silently loses Anthropic cache pricing.
+  4. `data/models_dev_snapshot.json` (10 models, `inputCost`/`outputCost`, no
+     cache) loaded into the registry via `models_dev_cache.c`.
+  Because token_tracker is substring and the registry is exact, the **same model
+  id can be priced differently by different code paths**, and their coverage
+  differs (17 vs 9 models). The substring matcher is also a mispricing vector
+  (table-order dependence; an adversarial/compound id can match an Anthropic
+  price). §1 collapses these to one authority and adds a drift test.
 - **The audit ledger already covers the basic counters.** `db1/token_audit.c`
   inserts `(session_id, delegation_id, project_name, tool_name, role, model,
   prompt_tokens, completion_tokens, cache_write_tokens, cache_read_tokens,
@@ -110,10 +135,16 @@ optimization surface aimee already has, not a new one.
   `delegate_routing` with `rc == 0 ? 1.0 : 0.0`, and `kb_client_bandit_close`
   documents reward as `[0,1]` over beta-style posteriors. Raw dollars cannot be
   the reward (§6).
-- **`agent_log_call` mis-attributes the model.** It estimates cost from
-  `result->agent_name` and writes an empty `model` for those rows; and
-  `anthropic_http.c` ignores Claude Code's *requested* model and routes to the
-  configured primary agent. Billable-model resolution is its own work item.
+- **`agent_log_call` mis-attributes the model, and `by_model` hides the
+  fallout.** It estimates cost from `result->agent_name` (`agent_runtime.c:1912`)
+  and writes an **empty** `model` (`:1926`); and `anthropic_http.c:163-165` reads
+  the client's *requested* model but routes to the configured primary
+  (`resolve_primary`). Crucially, `db1_token_audit_by_model`
+  (`token_audit.c:243,253`) filters `WHERE COALESCE(model,'') != ''`, so **every
+  existing row is already excluded** from by-model. If ingress rows start writing
+  real models while legacy rows stay empty, the by-model surface shows a
+  **false-zero history** — recent ingress spend appears while all prior spend
+  vanishes. The model write-fix and the filter/backfill must land together (§2).
 
 ## §1 One pricing source of truth (extend, don't add)
 
@@ -133,6 +164,20 @@ optimization surface aimee already has, not a new one.
 - Treat provider-reported model aliases as normalization inputs. Cost lookup
   should use the billable provider model after alias resolution, not an agent
   nickname or a user-requested model string.
+- **Route `delegate_ensemble.c` through the same lookup.** Its `model_token_cost`
+  is a third calculator that bypasses token_tracker and flat-rates unknowns at
+  `0.000015`/token; once one authority exists, ensemble cost must use it so it
+  picks up cache pricing and so §6's "realized delegate cost" is consistent.
+- **Add a drift test, not just ambiguity tests.** Beyond ordering cases
+  (`gpt-4o-mini` before `gpt-4o`), assert token_tracker and the registry agree on
+  price for every model both know — substring-vs-exact divergence is the actual
+  bug, and a compound/adversarial id must not match an Anthropic price.
+- **Disambiguate zero-price from free.** The registry lists `minimax` at
+  `0.0/0.0`, which the ensemble path treats as "unknown" and silently flat-rates.
+  Use an explicit `is_priced` signal (or sentinel) so a real zero never falls
+  through, and close the coverage gap for the delegates aimee actually runs
+  (minimax / mimo-2.5 / mistral) plus the o-series / gemini rows the registry and
+  snapshot omit today.
 
 ## §2 Cover ingress turns in the existing audit (token_audit), not a new ledger
 
@@ -145,7 +190,16 @@ estimates** and **avoided estimated cost**.
   `billable_model`, `duration_ms`, `stop_reason`, and `optimizations_json` /
   `avoided_cost_usd` if dedup/cache savings are reported. If the decision is to
   avoid migration, state exactly how each field is represented and which reports
-  lose fidelity.
+  lose fidelity. The migration is additive-only — `db1_reconcile_columns`
+  (`db_schema.c:78`) adds missing columns but creates no indexes and runs no
+  data migration, so column adds are safe but the empty-model backfill below is a
+  separate step.
+- **Fix `by_model` alongside the model write (prerequisite, not optional).**
+  Populating `served_model` is pointless while `db1_token_audit_by_model` filters
+  empty models out: either backfill legacy rows' model from their `tool_name`
+  (the agent name, which is the model alias today) or relabel empty-model rows as
+  `"(unattributed)"` instead of dropping them, so enabling ingress accounting
+  does not make historical spend appear to vanish.
 - **Native Anthropic relay path:** add a usage-observing tap to
   `anthropic_relay_chunk_cb` (or route native streams through a thin
   usage-observing relay) that parses `message_start` / `message_delta.usage`
@@ -159,13 +213,19 @@ estimates** and **avoided estimated cost**.
   `completion_tokens`. The provider request builder has to insert the option, not
   only the parser.
 - **Buffered path:** parse the provider JSON `usage` block after a 200 response
-  and before translating it back to the client. Use provider parser fields where
-  already available, but verify cache tokens survive parser normalization.
+  and before translating it back to the client. The Anthropic parser already
+  extracts cache tokens (`agent_bridge.c:791-796`), but the **OpenAI buffered
+  parser drops them** — this is an *add extraction* task, not just "verify they
+  survive normalization."
 - **`count_tokens`:** never writes a realized spend row. If exposed in usage
   summaries, it must be `usage_kind=estimated` and excluded from spend totals by
   default.
-- **Failure:** no realized-spend row on provider error. If failed calls are
-  reported at all, they are operational telemetry, not cost rows.
+- **Failure / aborted streams:** no realized-spend row on provider error. A
+  stream cut before `finish` (client cancel, network drop) never reaches the
+  finish-time write, so usage is lost unless the tap accumulates incrementally;
+  emit a `usage_kind=partial` row with whatever was observed (or none) rather
+  than silently dropping the turn. Failed calls, if reported, are operational
+  telemetry, not cost rows.
 - **Source + model:** record source/client explicitly (Claude Code, Codex,
   webchat, OpenAI-compatible ingress, delegate) and resolve a real billable
   `model` (see §2a) instead of the empty string `agent_log_call` writes today.
@@ -213,6 +273,15 @@ request metadata.
   the provider is Anthropic. OpenAI-compatible — no-op or provider-specific
   automatic caching; never emit Anthropic cache metadata. Translated
   OpenAI-via-Anthropic vs non-Anthropic driver paths must be handled explicitly.
+- **The owned outbound `system` is a flat string today.** For the aimee-built
+  path, `agent_build_request_anthropic` emits `cJSON_AddStringToObject(req,
+  "system", system_prompt)` (`agent_bridge.c:197`) — a string, not a content-block
+  array. So even on an aimee-owned request, placing `cache_control` on a stable
+  block first requires restructuring `system` into a `[{type:"text", ...,
+  cache_control:{...}}, ...]` array (Anthropic only), keeping the string form for
+  every other provider. That conversion — not the flag — is the bulk of §3's
+  Anthropic work, and it is why the OpenAI/Codex seam (no portable cache metadata,
+  just prefix ordering) is the cheaper first target.
 - **Negative tests required:** prove cache metadata is never leaked to an
   unsupported provider's request body; prove existing client-supplied
   `cache_control` blocks are preserved; prove Anthropic system arrays are not
@@ -300,6 +369,12 @@ Any new route requires:
 - `reasoning_effort_cap_enabled` (§5)
 - `cost_reward_lambda` + `cost_reward_enabled` (§6; 0 / off ⇒ pure side-metadata)
 
+These are all scalar bool/int flags, so each needs only a `config.h` struct field
++ a `config_fields.c` row (+ a `test_config.c` round-trip); `config_sections.c` /
+`config_save.c` are touched only if a flag is nested under a new compound object.
+The §1 pricing unification and the §2 model-write / `by_model` fixes are **not**
+flagged — they are correctness fixes that land on by default.
+
 Accounting (§2) is pure observation and is the first flag to flip; schema/report
 changes should land before request mutation. The request-mutating optimizations
 (§3–§5) and the shaped reward (§6) stay off until each clears the readiness bar
@@ -308,10 +383,18 @@ with a benchmark showing no quality regression.
 ## Testing
 
 - **Pricing:** unknown-model → 0.0; cache-read/write fields applied; registry
-  lookup/fallback; ambiguous substring ordering; provider alias normalization.
-- **Schema/reporting:** migration preserves existing `token_audit` rows; spend
-  totals exclude `estimated` and `avoided` rows by default; source/model
-  breakdowns are stable in `cmd_usage` and `insights.overview`.
+  lookup/fallback; ambiguous substring ordering; provider alias normalization;
+  **drift test** (token_tracker ≡ registry for every shared model);
+  compound/adversarial id must not match an Anthropic price; zero-price (`minimax
+  0.0/0.0`) is not silently flat-rated; `delegate_ensemble` cost uses the unified
+  lookup.
+- **Schema/reporting:** additive migration preserves existing `token_audit` rows;
+  **by-model no longer hides legacy empty-model rows** (false-zero migration
+  test); spend totals exclude `estimated`, `avoided`, and `partial` rows by
+  default; source/model breakdowns are stable in `cmd_usage` and
+  `insights.overview`.
+- **Aborted stream:** a stream cut before `finish` writes a `partial` row (or
+  none), never a silently dropped turn.
 - **Buffered ingress:** provider usage writes **exactly one** audit row with
   resolved source + billable model; **no row** on provider failure.
 - **Native Anthropic streaming:** final `message_delta.usage` is observed while
@@ -322,9 +405,12 @@ with a benchmark showing no quality regression.
   the option.
 - **count_tokens:** asserts **no** spend ledger row.
 - **Prompt-cache/request shaping:** OpenAI/Codex seam handles stable-vs-volatile
-  preinject placement; Anthropic structured-JSON insertion only under the
-  explicit opt-in carve-out; below-floor no-op; unsupported-provider no-op; no
-  cache-metadata leakage; existing client cache controls preserved.
+  preinject placement; the aimee-owned Anthropic `system` is emitted as a
+  content-block array (not a flat string) with `cache_control` on the stable block
+  only under the explicit opt-in carve-out; below-floor no-op;
+  unsupported-provider no-op; no cache-metadata leakage; existing client cache
+  controls preserved; non-Anthropic providers still receive a plain `system`
+  string.
 - **Dedup:** TTL; per-source/account/agent/model/endpoint/flags/context/stream
   key separation; no-tools/no-stream/200-only/idempotency-key eligibility;
   error-response bypass; avoided cost does not inflate spend totals.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -27,8 +27,10 @@
   `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c` (cost-shaped
   reward on the existing `delegate_routing` bandit close), `src/server/server_http.c`
   + `src/headers/server_http.h` (request-context propagation for source,
-  idempotency, principal, and request-id metadata), dashboard/HUD/frontend
-  readers that consume token-audit totals, config plumbing (`src/headers/config.h`,
+  idempotency, principal, and request-id metadata), `webchat/openai.go` and
+  `webchat/socket.go` (webchat proxy/session source attribution),
+  dashboard/HUD/frontend readers that consume token-audit totals, config
+  plumbing (`src/headers/config.h`,
   `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), route and
   auth registration only if a new API method is still justified. DB2 only if a
   shared/multi-machine analytics need is
@@ -95,6 +97,18 @@ need defaults), so an explicit migration or in-process idempotency is needed; (1
 the scalar-spend reader set is **eight** files incl. `server_compute.c:1469`
 cost-fold and `webchat/socket.go`, but `Chat.tsx` does not price client-side so
 §1 propagates to the UI for free.
+
+A sixth pass checked the webchat OpenAI proxy and embedding ingress: (13)
+`webchat/openai.go` authenticates OpenAI-compatible clients at the webchat edge,
+then `proxyV1` strips `Authorization` and forwards over the aimee-server UDS
+without adding replacement source/session/principal context, so server-side
+request-context accounting will see webchat-originated OpenAI traffic as generic
+trusted local traffic unless the proxy stamps explicit forwarding metadata; (14)
+`/v1/embeddings` is an OpenAI-compatible ingress route proxied by webchat, but
+`embeddings_handler` calls `memory_embed_text` and returns OpenAI-style
+`usage.prompt_tokens` without using the LLM audit path, so embeddings need an
+explicit non-LLM / estimate-only / separate embedding-spend classification rather
+than being folded into chat/completion cost.
 
 ## Goal
 
@@ -201,6 +215,15 @@ optimization surface aimee already has, not a new one.
   logged, never passed to handlers. Source attribution, account isolation,
   idempotent dedup, and audit row identity therefore require widening the handler
   signatures (or a request context) before any ingress writer lands.
+- **Webchat's OpenAI proxy erases source/principal context unless it stamps
+  replacement metadata.** `webchat/openai.go` validates the caller's webchat
+  OpenAI bearer token, then `proxyV1` removes `Authorization` before forwarding
+  `/v1/chat/completions`, `/v1/completions`, `/v1/responses`, and
+  `/v1/embeddings` over the UDS. If the server context layer only inspects the
+  forwarded HTTP request, these calls look like anonymous local traffic instead
+  of webchat traffic tied to a session/user. The proxy must add trusted internal
+  forwarding headers or an equivalent side channel for source, principal/session,
+  original request id, and idempotency.
 - **A thread-local context is NOT sufficient — it breaks for `/v1/runs`.** The
   cited precedent `ingress_preinject_set_request_disabled()` is `static __thread`
   (`ingress_preinject.c:28`) and works **only because the turn runs synchronously
@@ -327,7 +350,15 @@ estimates** and **avoided estimated cost**.
   logs through `agent_run_with_tools()` → `agent_log_call()`; it needs the
   source/attribution fix only, fed by the context captured at enqueue. And do not
   add logging inside `agent_execute()` itself; normal `agent_run*` paths already
-  call `agent_log_call()`. Net: new writes only where no row exists today.
+  call `agent_log_call()`. Net: new writes only where no row exists today. Keep
+  `/v1/embeddings` out of this LLM list unless embedding provider spend is
+  intentionally added as a separate usage kind.
+- **Embeddings ingress is not chat/completion spend.** `/v1/embeddings` returns
+  OpenAI-style usage, but the implementation is embedder-backed rather than a
+  chat/completion provider turn. Either exclude it from spend dashboards, record
+  it as estimate-only local usage, or add an explicit embedding usage kind and
+  embedder pricing source if external embedding billing is possible. Do not let
+  embedding prompt tokens inflate LLM model cost.
 - **Buffered path:** parse the provider JSON `usage` block after a 200 response
   and before translating it back to the client. The Anthropic parser already
   extracts cache tokens (`agent_bridge.c:791-796`), but the **OpenAI buffered
@@ -345,6 +376,9 @@ estimates** and **avoided estimated cost**.
 - **Source + model:** record source/client explicitly (Claude Code, Codex,
   webchat, OpenAI-compatible ingress, delegate) and resolve a real billable
   `model` (see §2a) instead of the empty string `agent_log_call` writes today.
+  Webchat-proxied OpenAI-compatible requests need explicit forwarding metadata
+  because the proxy intentionally removes the client `Authorization` header
+  before the request reaches aimee-server.
 - **DB1 vs DB2:** keep the per-row ledger in DB1 (local, where `cmd_usage` and
   `insights.overview` already read). Add a DB2 mirror/aggregate **only** if a
   specific shared/multi-machine optimization-analytics need is established; if so,
@@ -421,7 +455,9 @@ narrow.
 - **Request-context dependency:** the idempotency key and account/source boundary
   are not available to `openai_chat.c` / `anthropic_http.c` today because handler
   signatures receive only the body. §2's request context must land before dedup,
-  or dedup can only key on unsafe body-derived data.
+  or dedup can only key on unsafe body-derived data. Webchat's OpenAI proxy must
+  also preserve or restamp the idempotency key and source/account boundary when
+  forwarding to aimee-server.
 - **v1 eligibility:** buffered only, no tools / no server-side tools, non-stream,
   successful `200` only, explicit idempotency key, and no request surface that can
   consume changing memory/context unless that context hash is in the key. Anything
@@ -532,12 +568,16 @@ with a benchmark showing no quality regression.
   one** realized row; **`/v1/runs` still writes exactly one** row (via its
   existing `agent_log_call`) and gains source attribution **without** a second
   write; `agent_execute()` remains no-log; normal `agent_run*` paths are
-  unchanged. Explicit assertion: no turn produces two rows.
+  unchanged. `/v1/embeddings` is either excluded from LLM spend or recorded under
+  an explicit embedding usage kind, and never appears as chat/completion model
+  spend. Explicit assertion: no turn produces two rows.
 - **Request context / threading:** registered handlers see request id, idempotency
   key, source/principal/session metadata, and route identity; the `/v1/runs`
   detached worker sees the **same** context via capture-at-enqueue (not a
   thread-local), and the thread-local resets per request so it never leaks to the
-  next request on a reused worker thread.
+  next request on a reused worker thread. Webchat OpenAI proxy requests arrive at
+  aimee-server with trusted source/session/principal metadata after
+  `Authorization` is stripped.
 - **Source attribution:** ingress rows carry a per-client source derived from the
   request context (session key/principal), **not** the PPID-shared `session_id()`;
   two distinct clients do not collapse into one `top_sessions` row.
@@ -564,8 +604,9 @@ with a benchmark showing no quality regression.
   string.
 - **Dedup:** TTL; per-source/account/agent/model/endpoint/flags/context/stream
   key separation; no-tools/no-stream/200-only/idempotency-key eligibility;
-  error-response bypass; no dedup when request context is unavailable; avoided
-  cost does not inflate spend totals.
+  error-response bypass; no dedup when request context is unavailable; webchat
+  proxy preserves or restamps idempotency/source metadata; avoided cost does not
+  inflate spend totals.
 - **Bandit reward:** reward stays in `[0,1]`; cost affects arm selection only
   through normalized shaping, never raw dollars; side-metadata mode leaves arm
   selection unchanged; missing realized cost falls back safely.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -21,7 +21,9 @@
   the model registry), `src/headers/model_registry.h` (`cost_in_per_mtok` /
   `cost_out_per_mtok` - the authoritative base-price fields),
   `src/db1/token_audit.c` + `src/db1/schema.sql` (the existing audit ledger plus
-  any required migration fields), `src/server/ingress_preinject.c` (envelope
+  any required migration fields), `src/db1/agent_log.c` + `src/db1/agent_log.h`
+  (agent metrics currently join token_audit by lossy agent/role keys),
+  `src/server/ingress_preinject.c` (envelope
   metadata/splitting only if needed by the OpenAI/Codex seam),
   `src/server_insights.inc` (the `insights.overview` implementation),
   `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c` (cost-shaped
@@ -30,7 +32,7 @@
   propagation + UDS peer-UID capture for source, idempotency, principal, and
   request-id metadata), `webchat/openai.go` and `webchat/socket.go` (webchat
   proxy/session source attribution),
-  dashboard/HUD/frontend readers that consume token-audit totals, config
+  `src/cmd_agent.c`, dashboard/HUD/frontend readers that consume token-audit totals, config
   plumbing (`src/headers/config.h`,
   `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), route and
   auth registration only if a new API method is still justified. DB2 only if a
@@ -123,6 +125,19 @@ forwarding metadata. (14) **Embeddings cost $0 today**: the embedder is local
 embeddings from spend, with a remote-embedder pricing hook as future-only work;
 the non-LLM ingress surface is bounded to `/v1/embeddings` (+ usage-less
 `/v1/models`).
+
+An eighth pass found two implementation hazards that would make a correct ledger
+still report wrong numbers. (15) `src/db1/agent_log.c` has separate agent metrics
+that join `agent_log` to `token_audit` by `(agent_name, role)` or agent name
+alone, not by a call id; that is a many-to-many join that can multiply cost by
+the number of matching log rows and cannot represent ingress token rows that have
+no `agent_log` row. The proposal must add a stable `call_id` / `agent_log_id`
+link (or stop joining these tables for cost) and include `cmd_agent` / agent
+stats in the reader migration. (16) Proxy-stamped source/principal headers are
+only safe if the server establishes a trust boundary: TCP clients and untrusted
+UDS peers must not be able to spoof `X-Aimee-Source` / principal forwarding
+headers, and `X-Request-ID` alone must not become an idempotency key because it
+is caller-controlled.
 
 ## Goal
 
@@ -264,14 +279,26 @@ optimization surface aimee already has, not a new one.
   from the **request context** (`X-Aimee-Session-Key` / principal), not from
   `session_id()`; otherwise top-sessions and per-source spend are meaningless for
   ingress.
-- **Existing usage readers assume every row is spend — full list.** The audit
-  found **eight** consumers that sum `estimated_cost_usd` (or token-audit totals)
+- **Existing usage readers assume every row is spend.** The audit
+  originally found eight consumers that sum `estimated_cost_usd` (or token-audit totals)
   with no `usage_kind` filter: `src/hud.c`, `src/cmd_core.c` (`cmd_usage`),
   `src/dashboard.c`, `src/server/dashboard_server.c`, `src/server_insights.inc`,
   `src/server/server_compute.c:1469` (the cost-fold query),
   `webchat/socket.go` (`streamEvent.Cost`), and `frontend/src/pages/Chat.tsx`.
-  Once `usage_kind=estimated|avoided|partial` exists, all of them (plus the eight
-  SQL aggregations in `token_audit.c`) must split realized spend from
+- **Agent stats are a separate cost-reporting path, and the join is already
+  lossy.** `db1_agent_log_metrics_by_role` and `db1_agent_log_agent_stats`
+  (`src/db1/agent_log.c`) join `agent_log` to `token_audit` on `tool_name =
+  agent_name` plus role, or on agent name alone. That is not a one-row-per-call
+  relationship: multiple agent_log rows join every matching token_audit row, so
+  cost/cache totals can be multiplied, and future ingress rows with no
+  corresponding `agent_log` row either disappear from agent stats or contaminate
+  an agent bucket by name. This reaches `cmd_agent` through `agent_get_stats`.
+  The accounting migration must add a stable call key (`agent_log_id` or
+  `call_id`) shared by both tables, or remove cost aggregation from agent_log
+  joins and read spend only from token_audit's source-aware summaries.
+- Once `usage_kind=estimated|avoided|partial` exists, all direct readers (plus
+  the eight SQL aggregations in `token_audit.c`, the agent_log joins above, and
+  CLI/frontend surfaces that display them) must split realized spend from
   advisory/avoided values, or the UI shows avoided cost as money spent. One
   upside: `Chat.tsx` only *displays* a server-sent `cost` (it does **not** compute
   price client-side), so unifying pricing server-side (§1) propagates to the UI
@@ -319,9 +346,10 @@ estimates** and **avoided estimated cost**.
 - **Minimum schema migration:** add fields (or a tightly-linked extension table)
   for `source`, `usage_kind`, `request_id` or `turn_id`, `requested_model`,
   `served_model` or `billable_model`, `provider_model`, `duration_ms`,
-  `stop_reason`, and `optimizations_json` / `avoided_cost_usd` if dedup/cache
-  savings are reported. If the decision is to avoid migration, state exactly how
-  each field is represented and which reports lose fidelity. Two migration
+  `stop_reason`, a stable `call_id` / `agent_log_id` for rows that correspond to
+  an `agent_log` call, and `optimizations_json` / `avoided_cost_usd` if
+  dedup/cache savings are reported. If the decision is to avoid migration, state
+  exactly how each field is represented and which reports lose fidelity. Two migration
   constraints the audit surfaced: `db1_reconcile_columns` (`db_schema.c:78`)
   **only adds columns** (no index, no data migration), and SQLite cannot
   `ALTER TABLE ADD COLUMN` a `NOT NULL` column without a default — so every new
@@ -336,6 +364,9 @@ estimates** and **avoided estimated cost**.
   contradiction explicitly: either add a one-off index-creation migration step, or
   enforce idempotency in-process (a seen-set keyed by request id) and accept that
   a crash between provider-return and insert can drop — not duplicate — a row.
+  Do not use caller-controlled `X-Request-ID` alone as this key; keep it as
+  external correlation metadata and derive audit idempotency from an explicit
+  idempotency key, a server-generated attempt id, and the source/account boundary.
 - **Request context prerequisite:** before adding source-aware audit rows or
   dedup, expose a per-request context from `server_http.c` to registered handlers:
   method/path, generated `X-Request-ID`, inbound idempotency key, session key,
@@ -344,7 +375,10 @@ estimates** and **avoided estimated cost**.
   **synchronous** handlers only; because the `/v1/runs` worker is a detached
   pthread (and SSE may offload), the context for those paths must be **captured
   into the job/work struct at enqueue**, and the thread-local must be reset per
-  request so it never leaks across reused worker threads.
+  request so it never leaks across reused worker threads. Forwarded identity
+  headers must be accepted only from trusted internal proxies/peer UIDs and
+  ignored or stripped on TCP and untrusted UDS requests, so external callers
+  cannot spoof source or principal.
 - **Fix `by_model` alongside the model write (prerequisite, not optional).**
   Populating `served_model` is pointless while `db1_token_audit_by_model` filters
   empty models out: either backfill legacy rows' model from their `tool_name`
@@ -407,6 +441,11 @@ estimates** and **avoided estimated cost**.
   Webchat-proxied OpenAI-compatible requests need explicit forwarding metadata
   because the proxy intentionally removes the client `Authorization` header
   before the request reaches aimee-server.
+- **Agent-log relationship:** for normal `agent_log_call` rows, write a shared
+  call id into both `agent_log` and `token_audit` (or insert `agent_log` first and
+  store its row id in `token_audit`). For direct ingress rows that intentionally
+  have no `agent_log` row, leave that link empty and keep them out of agent-log
+  aggregates. Never join the two tables by agent name/role for cost.
 - **DB1 vs DB2:** keep the per-row ledger in DB1 (local, where `cmd_usage` and
   `insights.overview` already read). Add a DB2 mirror/aggregate **only** if a
   specific shared/multi-machine optimization-analytics need is established; if so,
@@ -550,10 +589,11 @@ Any new route requires:
 
 Regardless of whether a new route is added, every existing consumer of
 `token_audit` must learn the same semantics: `cmd_usage`, `insights.overview`,
-HUD, dashboard JSON, the React context panel, and webchat usage events must report
-realized spend separately from estimated, avoided, and partial rows. A single SQL
-helper for spend totals is preferable to copy-pasting `WHERE usage_kind =
-'realized'` across consumers.
+HUD, dashboard JSON, `cmd_agent` / agent stats, the React context panel, and
+webchat usage events must report realized spend separately from estimated,
+avoided, and partial rows. A single SQL helper for spend totals is preferable to
+copy-pasting `WHERE usage_kind = 'realized'` across consumers, and agent-log
+metrics must use the new call key instead of the current agent-name join.
 
 ## Config (all default-off, flag-rollout-readiness program)
 
@@ -588,8 +628,9 @@ with a benchmark showing no quality regression.
   **by-model no longer hides legacy empty-model rows** (false-zero migration
   test); spend totals exclude `estimated`, `avoided`, and `partial` rows by
   default; source/model breakdowns are stable in `cmd_usage`,
-  `insights.overview`, HUD, dashboard JSON, React context panel, and webchat
-  usage events.
+  `insights.overview`, HUD, dashboard JSON, `cmd_agent` / agent stats, React
+  context panel, and webchat usage events. Agent-log metrics do not multiply
+  token_audit rows when multiple calls share the same agent/role.
 - **OpenAI/Codex ingress audit (double-count guard):** each of the six
   synchronous no-log handlers (buffered+streaming chat/completions,
   buffered+streaming completions, buffered+streaming responses) writes **exactly
@@ -606,7 +647,9 @@ with a benchmark showing no quality regression.
   thread-local), and the thread-local resets per request so it never leaks to the
   next request on a reused worker thread. Webchat OpenAI proxy requests arrive at
   aimee-server with trusted source/session/principal metadata after
-  `Authorization` is stripped.
+  `Authorization` is stripped. TCP clients and untrusted UDS peers cannot spoof
+  forwarded source/principal headers, and caller-supplied `X-Request-ID` is
+  preserved only as correlation metadata, not as the sole idempotency key.
 - **Source attribution:** ingress rows carry a per-client source derived from the
   request context (session key/principal/UDS peer UID), **not** the PPID-shared
   `session_id()`; two distinct clients do not collapse into one `top_sessions`
@@ -643,6 +686,11 @@ with a benchmark showing no quality regression.
   selection unchanged; missing realized cost falls back safely.
 - **Model attribution:** ingress and `agent_log_call` rows resolve a non-empty
   billable model per §2a precedence; requested-vs-served divergence recorded.
+- **Agent-log join:** normal agent calls write a shared `call_id` / `agent_log_id`
+  into `agent_log` and `token_audit`; direct ingress rows without an `agent_log`
+  row stay visible in source-aware usage summaries but do not contaminate
+  `cmd_agent` agent stats. A fixture with two `agent_log` rows and two matching
+  `token_audit` rows proves cost is not multiplied four ways.
 - **API/auth:** any new usage route has route/spec parity, CLI RPC coverage where
   exposed, and `server_auth.c` capability tests. If only `insights.overview` is
   extended, test the existing route and capability.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -1,217 +1,271 @@
-# Proposal: ingress cost accounting + request-level cost optimizations
+# Proposal: ingress cost-accounting coverage + request-level cost optimizations
 
-- **State:** draft - pending review
+- **State:** draft - pending review (revised after PR #180 review)
 - **Author:** JBailes
 - **Date:** 2026-06-11
-- **Charter roles:** Evaluate-Optimize (monetary reward signal feeding the
-  existing bandit surface), Calibrate (cache/thinking thresholds), Recall
-  (envelope cache-marking on the answer path), Gate-Promote (default-off flag
-  rollout per the readiness program).
-- **Scope:** `src/server/anthropic_http.c` (usage capture at the buffered +
-  streaming ingress and `count_tokens`), `src/server/anthropic_stream*.c`
-  (surface the provider's final `usage` block from `message_delta`),
-  `src/server/ingress_preinject.c` (`ingress_preinject_format_envelope` /
-  `ingress_preinject_apply` cache-marking), `src/server/delegate_economics.c`
-  (promote the qualitative cost model to a monetary one), a new
-  `src/server/cost_pricing.{c,h}` (pricing table + `cost_calc`), a new db2 ledger
-  (`src/db2/usage_ledger.c` + header) reusing the `agent_outcomes` / `bandit`
-  table idiom, a typed `/v1/usage/*` surface (`server_http_routes.inc` +
-  handler), `aimee usage` CLI, the bandit reward loop in
-  `src/server/server_compute.c` (attach a $ reward to the existing
-  `delegate_routing` decision point), and config plumbing
-  (`src/headers/config.h`, `src/config_fields.c`, `src/config_sections.c`,
-  `src/config_save.c`). Unit + integration tests. No new service, no new model.
+- **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing
+  bandit), Calibrate (cache/thinking thresholds), Recall (envelope cache-marking
+  on the answer path), Gate-Promote (default-off flag rollout per the readiness
+  program).
+- **Scope:** `src/server/anthropic_http.c` (observe provider usage in the native
+  Anthropic relay path + buffered path; resolve the billable model),
+  `src/server/anthropic_ingress.c` (`anthropic_stream_feed_openai` — capture full
+  normalized usage, not just `completion_tokens`; native SSE `message_delta.usage`
+  observation), `src/server/agent_runtime.c` (`agent_log_call` — fix model
+  attribution so ingress rows resolve a real billable model), `src/server/token_tracker.c`
+  + `src/headers/token_tracker.h` (single pricing source of truth, reconciled with
+  the model registry), `src/headers/model_registry.h` (`cost_in_per_mtok` /
+  `cost_out_per_mtok` — the authoritative price fields), `src/db1/token_audit.c`
+  (the existing audit ledger ingress rows feed), `src/server/ingress_preinject.c`
+  (`ingress_preinject_build` / `ingress_preinject_format_envelope` — structured
+  `cache_control` insertion), the `insights.overview` op behind
+  `/v1/insights/overview`, `src/cmd_core.c` (`cmd_usage`), `src/server/server_compute.c`
+  (cost-shaped reward on the existing `delegate_routing` bandit close), config
+  plumbing (`src/headers/config.h`, `src/config_fields.c`, `src/config_sections.c`,
+  `src/config_save.c`). DB2 only if a shared/multi-machine analytics need is
+  established (§2). Unit + integration tests. No new service, no new model.
+
+## Revision note
+
+This supersedes the first draft, which proposed new `cost_pricing.{c,h}`, a new
+db2 usage ledger, a new `aimee usage` CLI, and raw-dollar bandit rewards. The PR
+#180 review correctly showed that aimee **already ships** cache-aware pricing
+(`token_tracker.c`, `token_estimate_cost`), an audit ledger with the exact schema
+I proposed (`db1/token_audit.c`: `session_id, delegation_id, model,
+prompt/completion/cache tokens, estimated_cost_usd`), a reader (`cmd_usage`
+→ `db1_token_audit_*`), a usage/cost summary route (`/v1/insights/overview`), and
+model-registry price fields (`cost_in_per_mtok` / `cost_out_per_mtok`). All
+verified in-tree. The objective is therefore **coverage and correctness of the
+existing machinery for ingress requests**, not new accounting. Every §1–§6 below
+is rewritten accordingly.
 
 ## Goal
 
-Give aimee **native USD cost accounting** for every request that crosses its
-ingress, and a small set of **request-level cost optimizations** that feed the
-optimization surface aimee already has. aimee sits directly in the request path —
-the Anthropic ingress (`POST /v1/messages`), the Codex/Responses `/v1` ingress,
-and the delegate fan-out all flow through aimee-server — so it owns the exact
-interception point that an external proxy (e.g. the `tokencost` project this is
-modelled on) has to bolt on. Today aimee tracks token *counts* and a
-*qualitative* cost tier; it does not know what a turn costs in dollars, cannot
-attribute spend by source, and applies none of the cheap request-shaping wins
-(prompt-cache marking of the stable context envelope, dedup, thinking-budget
-caps).
+Ingress requests are a cost blind spot. Normal agent and delegate calls are
+audited (`agent_log_call` → `token_audit`), but requests arriving on aimee's
+**Anthropic ingress** (`POST /v1/messages`) and **OpenAI-compatible ingress** are
+not consistently folded in. This proposal (a) extends the existing audit to cover
+ingress turns with a correct billable model and source, and (b) adds a small set
+of request-level optimizations — prompt-cache marking of the stable injected
+envelope first — wired into the optimization surface aimee already has, not a new
+one.
 
-This is deliberately **not** a new optimizer. aimee already has a learning
-optimization surface — `delegate_routing` is a registered bandit decision point
-with a closed reward loop (`docs/proposals/done/optimization-surface.md`). The
-missing piece is a **monetary reward signal** and the **observability** to
-compute it. This proposal supplies the dollars; the existing bandit consumes
-them.
+## §0 What already exists, corrected
 
-## §0 What already exists (so we don't rebuild it)
+- **Pricing is already cache-aware and shared.** `token_usage_t`
+  (`token_tracker.h`) carries `input/output/cache_write/cache_read`;
+  `token_estimate_cost()` (`token_tracker.c`) applies per-MTok input/output +
+  cache-read/write multipliers via an internal table. The **model registry**
+  (`model_registry.h`) separately carries `cost_in_per_mtok` /
+  `cost_out_per_mtok`. Two price sources already exist — §1 reconciles them rather
+  than adding a third.
+- **The audit ledger already has the proposed schema.** `db1/token_audit.c`
+  inserts `(session_id, delegation_id, project_name, tool_name, role, model,
+  prompt_tokens, completion_tokens, cache_write_tokens, cache_read_tokens,
+  estimated_cost_usd)` and exposes totals / by-role / by-tool / by-delegation
+  aggregations. `cmd_usage` (`cmd_core.c`) already reads them. This is DB1
+  (SQLite), local.
+- **The streaming translator does NOT see full Anthropic usage** (this was the
+  draft's biggest error). `anthropic_http.c::messages_stream` has **two** paths:
+  native Anthropic providers are relayed byte-for-byte through
+  `anthropic_relay_chunk_cb` and **never** touch `anthropic_stream_xlate_t`; the
+  translator is the OpenAI-style path only. And
+  `anthropic_ingress.c::anthropic_stream_feed_openai` reads **only**
+  `usage.completion_tokens` — no input, no cache tokens, no Anthropic
+  `message_delta.usage`. So "the provider's authoritative usage already passes
+  through the translator" was false. §2 must add the observation.
+- **`count_tokens` is an estimate, not spend.** It uses
+  `session_compact_estimate_tokens()` locally and never calls a provider. It must
+  not write a spend row.
+- **`ingress_preinject_apply` is not the live surface.** The implementation is
+  `ingress_preinject_build()` + `ingress_preinject_format_envelope()`; `apply`
+  exists only in the header/tests. §3 targets the real path.
+- **The bandit reward is a scalar in [0,1].** `server_compute.c` closes
+  `delegate_routing` with `rc == 0 ? 1.0 : 0.0`, and `kb_client_bandit_close`
+  documents reward as `[0,1]` over beta-style posteriors. Raw dollars cannot be
+  the reward (§6).
+- **`agent_log_call` mis-attributes the model.** It estimates cost from
+  `result->agent_name` and writes an empty `model` for those rows; and
+  `anthropic_http.c` ignores Claude Code's *requested* model and routes to the
+  configured primary agent. Billable-model resolution is its own work item.
 
-- **Token counts are already captured at the ingress.** `anthropic_http.c`
-  proxies the raw provider call buffered (`messages`) and streaming
-  (`messages_stream`), and exposes `count_tokens`. The streaming path runs an
-  `anthropic_stream_xlate_t` translator that already parses provider SSE
-  (`message_start` / `message_delta`) — the provider's authoritative `usage`
-  (input/output/cache tokens) passes through it. We surface it rather than
-  re-count.
-- **Cache-token fields already flow through delegate economics.**
-  `delegate_economics.c` already emits `delegate_cache_read_tokens` /
-  `delegate_cache_write_tokens` and an `agent_cost_tier`, with a *qualitative*
-  `delegate_cost_model` ("free" vs "tiered"). We promote this to dollars; we do
-  not invent the token plumbing.
-- **The optimization/routing surface is built and closed-loop.**
-  `delegate_routing` is a sampled bandit decision point with a reward loop
-  reaching `db2_bandit_decision_close()`, and `aimee optimize
-  points|baseline|replay|run|compare|promote` exists. We attach a reward, not a
-  framework.
-- **The context envelope is a single, stable, cache-shaped block.**
-  `ingress_preinject_format_envelope` builds `<aimee-context confidence=…>…`
-  and `ingress_preinject_apply` injects it ahead of the instructions. It is large
-  and constant across a session — the ideal prompt-cache anchor.
-- **Persistence is Postgres (db2), not SQLite.** The ledger follows the
-  `agent_outcomes` / `bandit` table idiom in `src/db2/`, not tokencost's
-  `tracker.db`.
+## §1 One pricing source of truth (extend, don't add)
 
-## §1 Pricing table + `cost_calc` (item 1)
+- **Pick one authority.** Either move the cache-aware multipliers into the model
+  registry (add `cache_read_per_mtok` / `cache_write_per_mtok` beside
+  `cost_in_per_mtok` / `cost_out_per_mtok`), or make `token_estimate_cost()`
+  consume registry base prices and keep only the cache multipliers in
+  `token_tracker`. Recommended: **registry is authoritative for base prices,
+  `token_tracker` owns cache multipliers and the `token_usage_t` normalization** —
+  one lookup, no third table.
+- `token_estimate_cost()` keeps its current signature and the "0.0 on unknown
+  model" contract; add a unit-tested registry fallback path.
+- If the MIT-licensed `tokencost` data seeds any prices, pin attribution + a
+  dated `pricing_refreshed` marker in whichever file becomes authoritative.
 
-New `src/server/cost_pricing.{c,h}`: a static, data-driven price map keyed by
-model id, plus a single cache-aware cost function. Mirrors the economics the
-provider actually bills:
+## §2 Cover ingress turns in the existing audit (token_audit), not a new ledger
 
-```
-cost = ( input_tok       * p.input
-       + output_tok      * p.output
-       + cache_read_tok   * p.input * 0.10     /* cached reads ~10% of input */
-       + cache_write_tok  * p.input * 1.25 )   /* cache creation ~125% input */
-     / 1e6;               /* prices are per-million tokens */
-```
+Write ingress turns into `token_audit` from the points that can observe real
+provider usage, distinguishing **billable** requests from **local estimates**.
 
-- Each entry: `{ input, output }` per-million USD. Claude (Opus/Sonnet/Haiku +
-  the `[1m]` long-context tiers), the three delegates (minimax, mimo-2.5,
-  mistral) whose limits aimee already records, plus the OpenAI-compatible
-  providers aimee can target. A `"default"` fallback so an unknown model degrades
-  to an estimate, never a crash.
-- **Maintenance is the real cost here.** Prices drift, so the table ships as
-  *data* with a dated `pricing_refreshed` marker and a single edit point; no
-  prices baked into call sites. `tokencost` is MIT, so its ~218-model map can
-  seed ours **with attribution** — but we only carry models aimee can actually
-  reach.
-- `cost_pricing_lookup(model)` and `cost_calc(model, in, out, cr, cw)` are pure
-  and unit-testable with no I/O.
+- **Native Anthropic relay path:** add a usage-observing tap to
+  `anthropic_relay_chunk_cb` (or route native streams through a thin
+  usage-observing relay) that parses `message_start` / `message_delta.usage`
+  (input, output, `cache_read_input_tokens`, `cache_creation_input_tokens`) while
+  still relaying the original bytes unchanged. Write one `token_audit` row at
+  stream finish.
+- **OpenAI-style path:** request `include_usage`/`stream_options` where the
+  provider supports it; extend `anthropic_stream_feed_openai` state to hold full
+  normalized `token_usage_t` (input + cache, not just `completion_tokens`).
+- **Buffered path:** parse the JSON `usage` block on the `messages` return.
+- **`count_tokens`:** never writes a spend row — it is local estimation. Mark
+  estimated-vs-realized so summaries never present pseudo-cost as spend.
+- **Failure:** no row on provider error (no phantom spend).
+- **Source + model:** set `role`/`tool_name` to carry the ingress source (Claude
+  Code vs Codex vs webchat vs OpenAI-ingress) using fields the schema already has,
+  and resolve a real billable `model` (see §2a) instead of the empty string
+  `agent_log_call` writes today.
+- **DB1 vs DB2:** keep the per-row ledger in DB1 (local, where `cmd_usage` and
+  `insights.overview` already read). Add a DB2 mirror/aggregate **only** if a
+  specific shared/multi-machine optimization-analytics need is established; if so,
+  the proposal must state the DB1→DB2 relationship explicitly so operators never
+  face two competing cost ledgers. Default: DB1 only.
 
-## §2 Request cost-tracking ledger (item 2)
+### §2a Billable-model resolution (shared fix)
 
-A db2 ledger that records one row per ingress turn, written from the points that
-already see the usage.
+Define the precedence for the audited model and apply it to both ingress rows and
+the existing `agent_log_call` empty-model weakness: **provider-reported model
+(response) > resolved/served model (the primary agent aimee actually routed to) >
+requested model**. Record the requested model separately when it differs (Claude
+Code asks for one model; aimee serves the configured primary), so attribution is
+auditable rather than silently wrong.
 
-- **Schema** (`src/db2/usage_ledger.c`), columns chosen from what the ingress
-  already has: `ts, source, model, input_tokens, output_tokens,
-  cache_read_tokens, cache_creation_tokens, cost_usd, duration_ms, stop_reason,
-  tool_call_count, optimizations_json, optimizer_savings_usd`. `source` is the
-  key field — it separates Claude Code vs Codex vs webchat vs a named delegate,
-  derived from the ingress entrypoint (not User-Agent sniffing; aimee knows its
-  own caller).
-- **Write points:** the buffered `messages` return and the `messages_stream`
-  finish in `anthropic_http.c` (after `anthropic_stream_finish`, where the
-  translator's final `usage` is known), and the delegate-result path that already
-  populates `delegate_cache_*` fields. Estimated counts
-  (`session_compact_estimate_tokens`) are only a fallback when the provider
-  omitted `usage`; the row records which it was.
-- **Read surface:** typed `/v1/usage/summary?period=…` and `/v1/usage/raw?limit=…`
-  routes (registered in `server_http_routes.inc`, conformance-scanner clean — no
-  stray `/v1` string literals per the scanner trap), plus `aimee usage
-  summary|raw` over the thin client. This is the "what did this cost, by source
-  and model" surface aimee lacks.
+## §3 Structured prompt-cache marking of the injected envelope (highest leverage)
 
-## §3 Auto prompt-cache marking of the context envelope (item 3) — highest leverage
+The pre-injection envelope is large and stable within a session; marking it
+cacheable cuts its repeat-read cost (`cache_read ≈ 0.10 × input`). But Anthropic
+caching is **not** a text transform — `cache_control` must land on the correct
+**structured** system/content block in outbound provider JSON.
 
-The single best optimization for aimee specifically. The pre-injection envelope
-is large and stable within a session; marking it cacheable cuts its repeat-read
-cost ~90% (the `cache_read = 0.10 × input` line in §1).
+- Target the real surface: where `ingress_preinject_build` /
+  `ingress_preinject_format_envelope` output is attached to the outbound provider
+  request body in `anthropic_http.c`.
+- **Per provider shape:** Anthropic native `/v1/messages` — set
+  `cache_control: {type:"ephemeral"}` on the envelope's structured system/content
+  block when it exceeds a configurable char floor. OpenAI-compatible — no-op (or
+  provider-specific automatic caching) and **never** emit Anthropic cache
+  metadata. Translated OpenAI-via-Anthropic vs non-Anthropic driver paths must be
+  handled explicitly.
+- **Negative test required:** prove cache metadata is never leaked to an
+  unsupported provider's request body.
+- Savings are computed from realized `cache_read_tokens` (§2), not asserted.
 
-- In `ingress_preinject_apply` (or at the point the envelope is attached to the
-  outbound provider request in `anthropic_http.c`), add Anthropic
-  `cache_control: {type: "ephemeral"}` to the envelope/system block when it
-  exceeds a configurable size floor (default ~1k chars, matching the tokencost
-  heuristic).
-- For OpenAI-compatible providers without explicit cache controls, this is a
-  no-op — the block is simply sent normally.
-- Savings are computed from the realized `cache_read_tokens` in §2 and recorded
-  in `optimizer_savings_usd`, so the win is *measured*, not asserted.
+## §4 Short-window dedup, narrowly scoped for v1
 
-## §4 Short-window request dedup (item 4)
+A response cache keyed only on `SHA256(body)` is unsafe. v1 is deliberately
+narrow.
 
-Cheap guard against duplicate identical turns (double-submits, client retries).
+- **Key includes every behavior-affecting input:** provider/agent identity,
+  resolved model, endpoint/provider, behavior-relevant config flags, the
+  preinject envelope identity, behavior-affecting request headers, and
+  stream/non-stream mode.
+- **v1 eligibility:** buffered only, no tools / no server-side tools, non-stream,
+  successful `200` only, and an **explicit idempotency key** on the request.
+  Anything that can emit tool calls, consume changing memory/context, or depend on
+  time/session state is excluded unless replay semantics are proven.
+- **Window:** small TTL (~5s), bounded map.
+- **Savings:** record *avoided estimated cost*, not "full turn cost saved,"
+  unless the skipped provider call's price is deterministically known.
 
-- A bounded in-memory map of `SHA256(canonical request body) → (response,
-  ts)` at the ingress, TTL ~5s. On hit within the window, return the cached
-  response and record a `dedup` optimization row with the full turn cost as
-  saved.
-- Strictly opt-in and conservative: streaming responses and any request carrying
-  tool-result state bypass dedup (replaying a tool turn must not be elided).
+## §5 Complexity score → reasoning-effort cap, mapped to real provider surfaces
 
-## §5 Complexity score → thinking-budget cap (item 5)
+A deterministic 0–10 complexity score (message count, content length, tool
+presence) **caps** reasoning effort — it does not route (routing is the bandit,
+§6).
 
-A deterministic 0–10 complexity score (message count, total content length, tool
-presence — the tokencost heuristic) used to **cap** extended-thinking budget, not
-to change routing (routing already belongs to the bandit, §6).
+- **Map to what exists:** aimee config exposes `model_reasoning_effort`, not a
+  generalized numeric thinking budget. Anthropic native may use an
+  extended-thinking budget object; OpenAI/Codex-compatible surfaces use a
+  reasoning-effort enum; unsupported providers no-op.
+- **Precedence:** an explicit user/provider setting is never overwritten by the
+  cap unless a config flag opts into that. The cap only *lowers* effort on
+  low-complexity turns (and may raise on tool-error signals).
+- Lives in the request-shaping path; default-off.
 
-- Low (<4) → small thinking budget; medium (4–7) → moderate; high → uncapped.
-  Auto-raise the cap when the turn shows tool-error signals.
-- Lives next to the attention-guard/request-shaping path
-  (`agent_request_shaping.c`). Default-off; when off, provider/user-supplied
-  thinking settings pass through untouched.
+## §6 Cost-shaped reward into the existing bandit (not raw dollars)
 
-## §6 Close the loop: monetary reward into the existing bandit (the point)
+The `delegate_routing` close path takes a scalar reward in `[0,1]` over
+beta-style posteriors. Feeding `cost_usd` directly would invert the semantics.
 
-Rather than a parallel "smart router," feed the dollars from §1–§2 back into the
-`delegate_routing` decision point that already exists. After a turn closes,
-`server_compute.c` attaches `cost_usd` (and quality outcome) as the reward when
-calling `db2_bandit_decision_close()`. The bandit then learns cheap-vs-capable
-routing from real spend, and `aimee optimize compare` can report $ deltas. This
-is what turns aimee's interception position into a *self-tuning* cost surface
-instead of a static dashboard — the differentiator over an external proxy.
+- **Reward shaping:** `reward = clamp01(quality_score − λ · normalized_cost)`,
+  where `quality_score` is the existing success outcome (or a richer quality
+  signal if available), `normalized_cost` is `cost_usd` normalized over a stated
+  rolling window, and `λ` is a config weight. State the normalization window and
+  the quality source explicitly.
+- **Alternative (default first):** keep the reward scalar unchanged and store
+  dollars as side metadata on the decision, consumed by `aimee optimize compare`
+  for $-delta reporting without touching arm selection. Default to side-metadata
+  first (lower risk), graduate to shaped reward behind a flag.
+
+## §7 API surface: extend insights.overview before adding /v1/usage/*
+
+`/v1/insights/overview` (`insights.overview`) already reports usage/cost
+summaries. Default to **extending it** with ingress/source breakdowns rather than
+adding `/v1/usage/*`. If a separate route is still justified, the proposal must
+say why it does not overlap `insights.overview` and keep the two non-overlapping.
+Any new route requires **OpenAPI generator/source updates** (the conformance
+check verifies route/spec parity, not response-field completeness), plus
+`server_http_routes.inc` registration that stays scanner-clean (no stray `/v1`
+string literals).
 
 ## Config (all default-off, flag-rollout-readiness program)
 
-New bool/int fields plumbed through `config.h` / `config_fields.c` /
-`config_sections.c` / `config_save.c`, each defaulting to inert so this lands
-dark and graduates per the 6-criterion readiness bar:
-
-- `usage_accounting_enabled` (master gate for §1–§2 recording)
+- `ingress_usage_accounting_enabled` (§2 — observe + audit ingress turns)
 - `ingress_cache_marking_enabled` + `ingress_cache_min_chars` (§3)
 - `ingress_dedup_enabled` + `ingress_dedup_window_ms` (§4)
-- `thinking_budget_cap_enabled` (§5)
-- `cost_reward_enabled` (§6 — attach $ reward to the bandit)
+- `reasoning_effort_cap_enabled` (§5)
+- `cost_reward_lambda` + `cost_reward_enabled` (§6; 0 / off ⇒ pure side-metadata)
 
-Accounting (§1–§2) is pure observation and is the natural first flag to flip;
-the request-mutating optimizations (§3–§5) stay off until each clears the bar
-with a benchmark showing no quality regression.
+Accounting (§2) is pure observation and is the first flag to flip; the
+request-mutating optimizations (§3–§5) and the shaped reward (§6) stay off until
+each clears the readiness bar with a benchmark showing no quality regression.
 
 ## Testing
 
-- **Unit:** `cost_calc` against known provider invoices (incl. cache-read/write
-  multipliers and the `default` fallback); complexity scoring fixtures; dedup
-  hash/TTL boundaries; envelope cache-mark gating on the size floor.
-- **Integration:** drive the Anthropic ingress (buffered + streaming) against a
-  stub provider returning a known `usage` block; assert one ledger row with the
-  right `source`, tokens, and `cost_usd`, and that streaming reads `usage` from
-  the translator finish, not the estimate. Assert §3 marks the envelope only
-  above the floor and that `optimizer_savings_usd` reflects realized
-  `cache_read_tokens`.
-- **Conformance:** `/v1/usage/*` routes pass the api-conformance scanner (build
-  URLs from the documented prefix; no stray `/v1` literals).
-- **Bench:** an A/B on the bench corpus with §6 on vs off, reporting $ /
-  correct-answer, gated as a user-run job (no autonomous prod deploy).
+- **Pricing:** unknown-model → 0.0; cache-read/write fields applied; registry
+  fallback if the registry becomes authoritative.
+- **Buffered ingress:** provider usage writes **exactly one** audit row with
+  resolved source + billable model; **no row** on provider failure.
+- **Native Anthropic streaming:** final `message_delta.usage` is observed while
+  the original stream is relayed byte-for-byte unchanged.
+- **OpenAI-style streaming:** with the usage chunk enabled, full normalized usage
+  (input + cache + output) is captured, not just `completion_tokens`.
+- **count_tokens:** asserts **no** spend ledger row.
+- **Prompt-cache marking:** Anthropic structured-JSON insertion on the right
+  block; below-floor no-op; unsupported-provider no-op; **no cache-metadata
+  leakage** to unsupported providers.
+- **Dedup:** TTL; per-agent/model/endpoint/flags/envelope/stream key separation;
+  no-tools/no-stream/200-only/idempotency-key eligibility; error-response bypass.
+- **Bandit reward:** reward stays in `[0,1]`; cost affects arm selection only
+  through normalized shaping, never raw dollars; side-metadata mode leaves arm
+  selection unchanged.
+- **Model attribution:** ingress and `agent_log_call` rows resolve a non-empty
+  billable model per §2a precedence; requested-vs-served divergence recorded.
+- **Bench:** A/B on the bench corpus, §6 on vs off, reporting $/correct-answer;
+  user-run job (no autonomous prod deploy).
 
-## Non-goals / what we are *not* taking from tokencost
+## Non-goals
 
-- No external proxy, no menubar app, no `dashboard.html`, no `onbording.sh`,
-  no log-scraping of other tools' files — aimee already owns the request path.
-- No silent message-trimming or model-substitution behind the user's back;
-  routing decisions stay in the bandit where they are learned and auditable.
-- No SQLite `tracker.db`; persistence is db2.
+- No new pricing module, no new usage ledger, no new `aimee usage` command —
+  extend `token_tracker` / model registry / `token_audit` / `insights.overview` /
+  `cmd_usage`.
+- No SQLite `tracker.db`; per-row ledger stays in DB1, DB2 only if shared
+  analytics is justified (§2).
+- No silent message-trimming or model substitution; routing stays in the bandit.
+- No external proxy / menubar / dashboard.html / log-scraping from `tokencost`.
 
 ## Attribution
 
-Modelled on the MIT-licensed `tokencost` project (pricing-table shape, cache
-multipliers, complexity heuristic, dedup idea). Any pricing data seeded from it
-carries attribution.
+Modelled on the MIT-licensed `tokencost` project (cache-multiplier economics,
+complexity heuristic, dedup idea). Any seeded pricing data carries attribution +
+a dated refresh marker in the single source-of-truth file.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -179,6 +179,29 @@ added to the server OpenAPI schema, regenerated into the embedded data header,
 and taught to the thin-client printer; otherwise the new fields are present in
 JSON but invisible or undocumented to clients.
 
+An eleventh pass verified 19–20 (correcting one premise) and enumerated the full
+ingress surface. (19, corrected) In the **primary container deploy**, webchat runs
+as **root (uid 0)** while aimee-server runs as **uid 1000** (`Dockerfile.server`,
+`deploy/container/webchat-lib.sh`: "webchat must run as root … drops aimee-server/
+kb to the unprivileged aimee user"), so a peer-UID check **can** distinguish the
+webchat proxy there — the same-user collision is specific to local/source deploys.
+The robust cross-deploy mechanism is still a proxy credential, and aimee **already
+has the pattern**: `$AIMEE_HOME/server.token` is a shared secret webchat already
+reads for the OpenAI-proxy bearer, so the trusted-forwarding credential should
+reuse that established file/HMAC pattern rather than invent one. (21) **Webchat
+has a second, undocumented usage contract.** Browser clients get usage as an SSE
+event with only `{in, out, cost}` (`webchat/socket.go`, `chat.go`) — not in
+OpenAPI — so surfacing realized-vs-estimated to the browser needs a `usage_kind`
+field added to that SSE shape too, in addition to `insights.overview`. (22)
+**aimee-kb-side LLM spend is entirely outside `token_audit`.** The enumeration
+confirmed the aimee-server HTTP ingress surface is fully bounded (MCP is internal-
+only and logged via the agent loop), but `/v1/rules/generate`, curator/deep-
+extraction, and similar paths make **paid provider calls inside the separate
+aimee-kb process**, which has no access to aimee-server's DB1 `token_audit`. The
+proposal must name this boundary explicitly: kb-side generation cost is **out of
+scope** for this server-local ledger (or needs its own kb-side audit hook + a
+cross-process report), so it is never falsely assumed covered.
+
 ## Goal
 
 Ingress requests are a cost blind spot. Normal agent and delegate calls are
@@ -305,9 +328,12 @@ optimization surface aimee already has, not a new one.
   allowlist — so distinguishing a trusted proxy (webchat) from an arbitrary UDS
   peer, and gating forwarded-header acceptance on it, must be built before any
   forwarded source/principal is trusted (it is a security prerequisite, not a
-  config knob). A UID allowlist by itself is insufficient when the proxy and
-  arbitrary local clients run as the same user; forwarded headers need a
-  proxy-only credential or equivalent second factor.
+  config knob). A UID allowlist by itself is insufficient in a same-user local
+  deploy (proxy and arbitrary clients share a UID) — though in the container
+  deploy webchat is root and the server is uid 1000, so UID *can* separate them
+  there. The robust cross-deploy answer is a proxy credential, and aimee already
+  ships the pattern: webchat reads `$AIMEE_HOME/server.token`, so reuse that
+  shared-secret/HMAC rather than invent a new factor.
 - **DB1 is a single shared SQLite handle, and audit writes are best-effort.** DB1
   is one process-wide `sqlite3*` (`db1_init.c:19`) opened `SQLITE_OPEN_FULLMUTEX`
   with `journal_mode=WAL` and a busy handler that retries 15× (20–150 ms) then
@@ -656,6 +682,11 @@ that, regenerate `src/server/openapi_server_data.h` (`src/gen_openapi_server.py`
 so `/v1/openapi.yaml` serves the updated contract, and update
 `src/cli_rpc_routes.inc::print_insights_overview` so the thin client displays the
 new spend semantics instead of only the legacy `estimated_cost_usd` scalar.
+Webchat is a **separate, undocumented** wire contract: the browser receives usage
+as an SSE event carrying only `{in, out, cost}` (`webchat/socket.go`,
+`webchat/chat.go`), so surfacing realized-vs-estimated to the browser means adding
+a `usage_kind` (or a realized-cost field) to that SSE shape too — it is not
+covered by the OpenAPI change.
 
 Regardless of whether a new route is added, every existing consumer of
 `token_audit` must learn the same semantics: `cmd_usage`, `insights.overview`,
@@ -801,5 +832,10 @@ with a benchmark showing no quality regression.
 - No silent message-trimming or model substitution; routing stays in the bandit.
 - No mutation of Anthropic Messages ingress by default; it remains a stateless
   proxy unless a separate opt-in phase changes that contract.
+- **aimee-kb-side LLM spend is out of scope.** Provider calls made inside the
+  separate aimee-kb process (`/v1/rules/generate`, curator/deep-extraction) do not
+  reach aimee-server's DB1 `token_audit`; this ledger is server-local. Folding kb
+  cost in is a separate effort (a kb-side audit hook + cross-process report), and
+  this proposal must not be read as covering it.
 - No external proxy, menu-bar widget, standalone dashboard, or log-scraping of
   other tools' files — aimee owns the request path.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -1,7 +1,7 @@
 # Proposal: ingress cost-accounting coverage + request-level cost optimizations
 
-- **State:** draft - pending review (revised after PR #180 review + repeated
-  file-by-file codebase audits)
+- **State:** draft - pending review (consolidated after PR #180 review + twelve
+  file-by-file codebase audits; findings integrated below)
 - **Author:** JBailes
 - **Date:** 2026-06-11
 - **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing
@@ -42,180 +42,76 @@
 
 ## Revision note
 
-This supersedes the first draft, which proposed new `cost_pricing.{c,h}`, a new
-db2 usage ledger, a new `aimee usage` CLI, and raw-dollar bandit rewards. The PR
-#180 review correctly showed that aimee **already ships** cache-aware pricing
-(`token_tracker.c`, `token_estimate_cost`), an audit ledger with much of the
-needed schema (`db1/token_audit.c`: `session_id, delegation_id, model,
-prompt/completion/cache tokens, estimated_cost_usd`), a reader (`cmd_usage`
-→ `db1_token_audit_*`), a usage/cost summary route (`/v1/insights/overview`), and
-model-registry price fields (`cost_in_per_mtok` / `cost_out_per_mtok`). All
-verified in-tree. The objective is therefore **coverage and correctness of the
-existing machinery for ingress requests**, not new accounting. Every §1–§6 below
-is rewritten accordingly.
+This is a heavily revised draft. v1 proposed new machinery — a `cost_pricing.{c,h}`
+module, a DB2 usage ledger, an `aimee usage` CLI, and raw-dollar bandit rewards.
+The PR #180 review and a series of file-by-file codebase audits showed aimee
+**already ships** the core machinery: cache-aware pricing (`token_tracker.c`,
+`token_estimate_cost`), an audit ledger with most of the needed schema
+(`db1/token_audit.c`), a reader (`cmd_usage` → `db1_token_audit_*`), a usage/cost
+summary route (`insights.overview`), and registry price fields
+(`model_registry.h`). The objective is therefore **coverage and correctness of the
+existing machinery for ingress requests**, not new accounting.
 
-This revision also folds in second-pass review findings: Anthropic
-`/v1/messages` is intentionally a stateless proxy and is **not** a current
-pre-injection surface; the shipped pre-injection seam is in `openai_chat.c`; the
-`<aimee-context>` envelope is per-turn query-derived and therefore not
-inherently a stable cache prefix; and the current `token_audit` schema lacks
-several fields this proposal needs (`source`, `usage_kind`, requested-vs-served
-model, duration/stop metadata, optimization metadata). Those are explicit work
-items below rather than assumptions.
+Two framing corrections from the audits underpin everything below: Anthropic
+`/v1/messages` is intentionally a stateless proxy and is **not** a pre-injection
+surface (the shipped seam is `openai_chat.c`), and the `<aimee-context>` envelope
+is per-turn query-derived, so it is **not** an inherently stable cache prefix.
 
-A third pass added a **file-by-file codebase audit** that confirmed the above and
-surfaced four issues no review named, now folded in with file:line evidence:
-(1) pricing lives in **four** divergent sources — token_tracker (substring +
-cache), the model registry (exact, no cache), `delegate_ensemble.c` (a third
-flat-rate calculator), and `models_dev_snapshot.json` — so the same model id can
-be priced differently by different paths (§0/§1); (2) `db1_token_audit_by_model`
-filters out every empty-model row, so the model-write fix and the filter fix must
-land together or history shows a false zero (§0/§2); (3) the aimee-owned outbound
-Anthropic `system` is a **flat string**, so the cache carve-out's real work is a
-string→content-block conversion, not a flag (§3); (4) `stream_options.include_usage`
-is set nowhere and aborted streams drop usage (§2).
+### Findings map
 
-This pass adds three remaining blockers: (5) OpenAI/Codex ingress does **not**
-go through `agent_log_call` either — `openai_chat.c` calls `agent_execute()` and
-`agent_execute_messages()` directly, and `agent_execute()` explicitly leaves
-logging to its callers — so those handlers need first-class audit writes, not
-only attribution fixes; (6) the registered HTTP handler signatures only receive
-`body`/`resp`/`cap`, so source/principal/idempotency/request-id metadata is
-unavailable unless `server_http.c` exposes a request context; (7) HUD, dashboard,
-frontend, and webchat consumers currently sum `estimated_cost_usd` as a scalar,
-so new `estimated` / `avoided` / `partial` rows will inflate spend unless every
-reader is updated with the same semantics.
+The audits produced 23 verified, in-tree findings; they are grouped by theme here
+and carried with file:line evidence in §0. The `(N)` numbers are stable
+references used elsewhere in this doc.
 
-A fifth pass (four more parallel audits) verified 5–7 and corrected/added five
-points: (8) **`/v1/runs` already writes a row** (detached worker →
-`agent_run_with_tools` → `agent_log_call`), so it must get attribution **only**,
-not a new write — adding one double-counts; the new writes belong only to the six
-synchronous no-log handlers; (9) a **thread-local context is insufficient** —
-the `/v1/runs` worker is a detached pthread that does not inherit request-thread
-TLS, so its context must be captured into the job struct at enqueue; (10)
-**`session_id()` is PPID-process-wide**, so all ingress rows collapse into one
-session and per-source attribution must come from the request context, not
-`session_id()`; (11) **idempotency contradicts the additive reconcile** — a
-UNIQUE index is required and the reconcile creates none (and `NOT NULL` columns
-need defaults), so an explicit migration or in-process idempotency is needed; (12)
-the scalar-spend reader set is **eight** files incl. `server_compute.c:1469`
-cost-fold and `webchat/socket.go`, but `Chat.tsx` does not price client-side so
-§1 propagates to the UI for free.
-
-A sixth pass checked the webchat OpenAI proxy and embedding ingress: (13)
-`webchat/openai.go` authenticates OpenAI-compatible clients at the webchat edge,
-then `proxyV1` strips `Authorization` and forwards over the aimee-server UDS
-without adding replacement source/session/principal context, so server-side
-request-context accounting will see webchat-originated OpenAI traffic as generic
-trusted local traffic unless the proxy stamps explicit forwarding metadata; (14)
-`/v1/embeddings` is an OpenAI-compatible ingress route proxied by webchat, but
-`embeddings_handler` calls `memory_embed_text` and returns OpenAI-style
-`usage.prompt_tokens` without using the LLM audit path, so embeddings need an
-explicit non-LLM / estimate-only / separate embedding-spend classification rather
-than being folded into chat/completion cost.
-
-A seventh pass verified 13–14 and refined both. (13) **The UDS source-erasure is
-systemic, not webchat-specific**: `server_http_authorize` trusts any `!is_tcp`
-connection and grants `CAPS_ALL`, so the thin CLI, MCP, and webchat all arrive as
-anonymous trusted-local — yet the HTTP-over-UDS path captures no peer identity
-while the legacy NDJSON socket already derives `uid:<peer_uid>`. The fix is both
-capturing the UDS peer UID as a baseline principal and requiring proxies to stamp
-forwarding metadata. (14) **Embeddings cost $0 today**: the embedder is local
-(builtin hash or a local command), the model is in no price table, and
-`usage.prompt_tokens` is a `chars/4` estimate — so the default is to **exclude**
-embeddings from spend, with a remote-embedder pricing hook as future-only work;
-the non-LLM ingress surface is bounded to `/v1/embeddings` (+ usage-less
-`/v1/models`).
-
-An eighth pass found two implementation hazards that would make a correct ledger
-still report wrong numbers. (15) `src/db1/agent_log.c` has separate agent metrics
-that join `agent_log` to `token_audit` by `(agent_name, role)` or agent name
-alone, not by a call id; that is a many-to-many join that can multiply cost by
-the number of matching log rows and cannot represent ingress token rows that have
-no `agent_log` row. The proposal must add a stable `call_id` / `agent_log_id`
-link (or stop joining these tables for cost) and include `cmd_agent` / agent
-stats in the reader migration. (16) Proxy-stamped source/principal headers are
-only safe if the server establishes a trust boundary: TCP clients and untrusted
-UDS peers must not be able to spoof `X-Aimee-Source` / principal forwarding
-headers, and `X-Request-ID` alone must not become an idempotency key because it
-is caller-controlled.
-
-A ninth pass verified 15–16 and found two more, in different layers. (17) **DB1
-write concurrency / best-effort drops.** DB1 is one shared `sqlite3*`
-(`db1_init.c:19`, `SQLITE_OPEN_FULLMUTEX` + `journal_mode=WAL` + a busy handler
-that gives up after 15 retries, `:22-68`); every HTTP connection already runs on
-a detached worker thread (`server_http.c` `conn_worker`) and `/v1/runs` on its own
-detached pthread, so concurrent `token_audit` writes happen today. The existing
-insert is `(void)`-ignored best-effort, so under the added per-turn write volume
-in the streaming hot path the busy handler can exhaust and **silently drop** a row
-(undercount), and the synchronous insert adds tail latency. The proposal must
-state explicit best-effort semantics, consider moving audit writes off the request
-thread (async/batched queue), and load-test tail latency + drop rate. (18) **No
-trusted-UDS-peer mechanism exists** — findings 7/13/16 all assume a peer UID, but
-the HTTP-over-UDS path never extracts `SO_PEERCRED` (`peer_uid` is set only in
-tests), grants `CAPS_ALL` to every UDS peer uniformly (`server_http.c:312-325`),
-and validates no forwarding header. So peer-UID capture and a trusted-peer
-allowlist are **net-new code** (the legacy NDJSON socket already derives
-`uid:<peer_uid>`, and `platform_ipc_peer_cred()` exists but is uncalled on the
-HTTP path), and that mechanism is a prerequisite before any forwarded source/
-principal can be trusted.
-
-A tenth pass found two contract/security gaps in the ninth-pass fix. (19)
-**A UID allowlist is not enough to trust forwarded identity.** In the expected
-local deployment, webchat, the thin CLI, MCP, and ad-hoc local tools often run as
-the same Unix user, so `trusted_uds_peer_uids=[1000]` would trust **every**
-same-user UDS client to set `X-Aimee-Source` / principal headers. Peer UID is a
-baseline principal, not a proxy-authentication mechanism. Forwarded identity
-needs a second proof such as a server-minted internal proxy token/HMAC, a
-dedicated proxy-only socket, or another capability that arbitrary same-user
-clients cannot guess; inbound forwarding headers from all other clients must be
-stripped before request context is built. (20) **Extending `insights.overview`
-is still an API contract change.** The current OpenAPI entry is just
-`type: object`, `/v1/openapi.yaml` serves the generated
-`src/server/openapi_server_data.h`, and the thin client has a custom
-`print_insights_overview` in `src/cli_rpc_routes.inc` that prints only
-`estimated_cost_usd`. Source/usage-kind realized-vs-estimated semantics must be
-added to the server OpenAPI schema, regenerated into the embedded data header,
-and taught to the thin-client printer; otherwise the new fields are present in
-JSON but invisible or undocumented to clients.
-
-An eleventh pass verified 19–20 (correcting one premise) and enumerated the full
-ingress surface. (19, corrected) In the **primary container deploy**, webchat runs
-as **root (uid 0)** while aimee-server runs as **uid 1000** (`Dockerfile.server`,
-`deploy/container/webchat-lib.sh`: "webchat must run as root … drops aimee-server/
-kb to the unprivileged aimee user"), so a peer-UID check **can** distinguish the
-webchat proxy there — the same-user collision is specific to local/source deploys.
-The robust cross-deploy mechanism is still a proxy credential, and aimee **already
-has the pattern**: `$AIMEE_HOME/server.token` is a shared secret webchat already
-reads for the OpenAI-proxy bearer, so the trusted-forwarding credential should
-reuse that established file/HMAC pattern rather than invent one. (21) **Webchat
-has a second, undocumented usage contract.** Browser clients get usage as an SSE
-event with only `{in, out, cost}` (`webchat/socket.go`, `chat.go`) — not in
-OpenAPI — so surfacing realized-vs-estimated to the browser needs a `usage_kind`
-field added to that SSE shape too, in addition to `insights.overview`. (22)
-**aimee-kb-side LLM spend is entirely outside `token_audit`.** The enumeration
-confirmed the aimee-server HTTP ingress surface is fully bounded (MCP is internal-
-only and logged via the agent loop), but `/v1/rules/generate`, curator/deep-
-extraction, and similar paths make **paid provider calls inside the separate
-aimee-kb process**, which has no access to aimee-server's DB1 `token_audit`. The
-proposal must name this boundary explicitly: kb-side generation cost is **out of
-scope** for this server-local ledger (or needs its own kb-side audit hook + a
-cross-process report), so it is never falsely assumed covered.
-
-A twelfth pass found one more streaming-accounting mismatch. (23) **Not all
-`stream:true` paths are provider-incremental streams.** The OpenAI/Codex
-compatibility stream handlers in `openai_chat.c` are explicitly
-**compute-then-chunk**: they call `agent_execute()` / `agent_execute_messages()`
-to completion, then emit synthetic SSE chunks (`chat_stream_handler`,
-`completion_stream_handler`, `responses_stream_handler`). `server_http.c`
-`sse_emit` / `sse_event_emit` also ignore write failures, so these handlers
-cannot reliably tell whether the client disconnected during emission. Therefore
-the proposal's aborted-stream rule must be split: provider-incremental streams
-(native Anthropic relay / true provider SSE) can produce `partial` usage, while
-compute-then-chunk OpenAI/Codex streams should write realized spend once the
-provider call returns successfully, even if the client disconnects before all
-synthetic chunks are delivered. Treating those as partial or no-row would
-undercount real spend.
+- **Pricing (§1).** (1) Pricing lives in **four** divergent sources —
+  `token_tracker.c` (substring match, the only one with cache prices), the model
+  registry (exact match, no cache prices), `delegate_ensemble.c` (a third
+  flat-rate calculator), and `models_dev_snapshot.json` — so the same model id can
+  be priced differently by different paths.
+- **Audit schema & migration (§2).** (2) `by_model` filters out every empty-model
+  row, so the model-write fix and the filter/backfill must land together or
+  history shows a false zero. (11) Idempotency needs a UNIQUE index the additive
+  reconcile will not create, and SQLite cannot add a `NOT NULL` column without a
+  default. (15) `agent_log`↔`token_audit` is joined by agent-name/role — an N×M
+  join that multiplies cost/cache sums — so a shared `call_id` is required.
+- **Ingress write coverage (§2).** (5) The six synchronous OpenAI/Codex handlers
+  go through `agent_execute()` and write **no** audit row today; (8) but `/v1/runs`
+  already logs (detached worker → `agent_log_call`), so it needs attribution
+  **only**, never a second write (double-count guard). (4)
+  `stream_options.include_usage` is set nowhere and the OpenAI buffered parser
+  drops cache tokens. (14) `/v1/embeddings` is a local $0 embedder → exclude from
+  spend by default. (22) aimee-kb-side LLM spend (`/v1/rules/generate`, curator
+  extraction) runs in a **separate process** outside this ledger → out of scope.
+  (23) OpenAI/Codex streaming is **compute-then-chunk**, so it writes realized
+  spend on provider return; only provider-incremental streams (native Anthropic
+  relay) can be `partial`.
+- **Request context & threading (§0/§2).** (6) HTTP handlers receive only
+  `(body, resp, cap)` — no source/principal/idempotency/request-id. (9) A
+  thread-local context breaks for the detached `/v1/runs` pthread → capture into
+  the job struct at enqueue. (10) `session_id()` is PPID-process-wide, so ingress
+  source must come from the request context, not `session_id()`.
+- **Identity & trust (§0).** (13) `webchat/openai.go::proxyV1` strips
+  `Authorization` over the UDS and stamps no replacement identity. (16/18) The
+  HTTP-over-UDS path never captures `SO_PEERCRED` and grants `CAPS_ALL` to every
+  UDS peer, so peer-UID capture and a trusted-peer mechanism are **net-new** code.
+  (19) A UID allowlist is insufficient in a same-user local deploy (though the
+  container deploy runs webchat as root vs the server as uid 1000); the robust
+  answer is a proxy credential, reusing the existing `$AIMEE_HOME/server.token`
+  pattern.
+- **Cache shaping (§3).** (3) The aimee-owned outbound Anthropic `system` is a
+  **flat string**, so placing `cache_control` on a stable block requires
+  converting it to a content-block array — the real work, not a flag.
+- **Storage / concurrency (§0).** (17) DB1 is a single shared SQLite handle and the
+  audit insert is `(void)` best-effort, so under the added per-turn write volume a
+  WAL busy-handler exhaustion can **silently drop** a row (undercount) → prefer an
+  async/batched off-thread write and load-test drop rate + tail latency.
+- **Readers & API contract (§7).** (7/12) Eight consumers sum `estimated_cost_usd`
+  as scalar spend (incl. `server_compute.c` cost-fold and the agent-log join) and
+  must learn `usage_kind` semantics; `Chat.tsx` does not price client-side, so §1
+  propagates to it for free. (20) `insights.overview` is OpenAPI `type: object`,
+  served from a generated header, with a thin-client printer that shows only
+  `estimated_cost_usd` — all three must learn the new fields. (21) Webchat's
+  browser usage SSE `{in, out, cost}` is a separate, undocumented contract.
 
 ## Goal
 
@@ -540,8 +436,13 @@ estimates** and **avoided estimated cost**.
   compute-then-chunk, so the provider call and usage are complete before SSE
   emission. For those paths, write realized spend after a successful provider
   return and before/during synthetic chunk emission; client disconnect during
-  chunk delivery is delivery telemetry, not partial provider spend. Failed calls,
-  if reported, are operational telemetry, not cost rows.
+  chunk delivery is delivery telemetry, not partial provider spend. The split is
+  by **handler, not by the word "OpenAI"**: the compatibility handlers in
+  `openai_chat.c` (`chat_stream_handler` / `completion_stream_handler` /
+  `responses_stream_handler`) are compute-then-chunk, whereas the OpenAI-*upstream*
+  sub-path of `anthropic_http.c::messages_stream` feeds real provider SSE through
+  the translator and **is** provider-incremental — so the partial rule applies
+  there. Failed calls, if reported, are operational telemetry, not cost rows.
 - **Source + model:** record source/client explicitly (Claude Code, Codex,
   webchat, OpenAI-compatible ingress, delegate) and resolve a real billable
   `model` (see §2a) instead of the empty string `agent_log_call` writes today.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -202,6 +202,21 @@ proposal must name this boundary explicitly: kb-side generation cost is **out of
 scope** for this server-local ledger (or needs its own kb-side audit hook + a
 cross-process report), so it is never falsely assumed covered.
 
+A twelfth pass found one more streaming-accounting mismatch. (23) **Not all
+`stream:true` paths are provider-incremental streams.** The OpenAI/Codex
+compatibility stream handlers in `openai_chat.c` are explicitly
+**compute-then-chunk**: they call `agent_execute()` / `agent_execute_messages()`
+to completion, then emit synthetic SSE chunks (`chat_stream_handler`,
+`completion_stream_handler`, `responses_stream_handler`). `server_http.c`
+`sse_emit` / `sse_event_emit` also ignore write failures, so these handlers
+cannot reliably tell whether the client disconnected during emission. Therefore
+the proposal's aborted-stream rule must be split: provider-incremental streams
+(native Anthropic relay / true provider SSE) can produce `partial` usage, while
+compute-then-chunk OpenAI/Codex streams should write realized spend once the
+provider call returns successfully, even if the client disconnects before all
+synthetic chunks are delivered. Treating those as partial or no-row would
+undercount real spend.
+
 ## Goal
 
 Ingress requests are a cost blind spot. Normal agent and delegate calls are
@@ -517,11 +532,16 @@ estimates** and **avoided estimated cost**.
   summaries, it must be `usage_kind=estimated` and excluded from spend totals by
   default.
 - **Failure / aborted streams:** no realized-spend row on provider error. A
-  stream cut before `finish` (client cancel, network drop) never reaches the
-  finish-time write, so usage is lost unless the tap accumulates incrementally;
-  emit a `usage_kind=partial` row with whatever was observed (or none) rather
-  than silently dropping the turn. Failed calls, if reported, are operational
-  telemetry, not cost rows.
+  provider-incremental stream cut before `finish` (client cancel, network drop)
+  may never reach the finish-time write, so usage is lost unless the tap
+  accumulates incrementally; emit a `usage_kind=partial` row with whatever was
+  observed (or none) rather than silently dropping the turn. **Do not apply that
+  rule blindly to OpenAI/Codex compatibility streaming**: those handlers are
+  compute-then-chunk, so the provider call and usage are complete before SSE
+  emission. For those paths, write realized spend after a successful provider
+  return and before/during synthetic chunk emission; client disconnect during
+  chunk delivery is delivery telemetry, not partial provider spend. Failed calls,
+  if reported, are operational telemetry, not cost rows.
 - **Source + model:** record source/client explicitly (Claude Code, Codex,
   webchat, OpenAI-compatible ingress, delegate) and resolve a real billable
   `model` (see §2a) instead of the empty string `agent_log_call` writes today.
@@ -769,7 +789,9 @@ with a benchmark showing no quality regression.
   `(source, request_id, attempt)` produces exactly one row (index or in-process
   guard), and the migration that creates the uniqueness constraint is exercised.
 - **Aborted stream:** a stream cut before `finish` writes a `partial` row (or
-  none), never a silently dropped turn.
+  none) for provider-incremental streams, never a silently dropped turn. A
+  compute-then-chunk OpenAI/Codex stream that completes the provider call writes a
+  realized row even if the client disconnects during synthetic SSE delivery.
 - **Buffered ingress:** provider usage writes **exactly one** audit row with
   resolved source + billable model; **no row** on provider failure.
 - **Native Anthropic streaming:** final `message_delta.usage` is observed while

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -263,9 +263,3 @@ each clears the readiness bar with a benchmark showing no quality regression.
   analytics is justified (§2).
 - No silent message-trimming or model substitution; routing stays in the bandit.
 - No external proxy / menubar / dashboard.html / log-scraping from `tokencost`.
-
-## Attribution
-
-Modelled on the MIT-licensed `tokencost` project (cache-multiplier economics,
-complexity heuristic, dedup idea). Any seeded pricing data carries attribution +
-a dated refresh marker in the single source-of-truth file.

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -80,6 +80,22 @@ frontend, and webchat consumers currently sum `estimated_cost_usd` as a scalar,
 so new `estimated` / `avoided` / `partial` rows will inflate spend unless every
 reader is updated with the same semantics.
 
+A fifth pass (four more parallel audits) verified 5–7 and corrected/added five
+points: (8) **`/v1/runs` already writes a row** (detached worker →
+`agent_run_with_tools` → `agent_log_call`), so it must get attribution **only**,
+not a new write — adding one double-counts; the new writes belong only to the six
+synchronous no-log handlers; (9) a **thread-local context is insufficient** —
+the `/v1/runs` worker is a detached pthread that does not inherit request-thread
+TLS, so its context must be captured into the job struct at enqueue; (10)
+**`session_id()` is PPID-process-wide**, so all ingress rows collapse into one
+session and per-source attribution must come from the request context, not
+`session_id()`; (11) **idempotency contradicts the additive reconcile** — a
+UNIQUE index is required and the reconcile creates none (and `NOT NULL` columns
+need defaults), so an explicit migration or in-process idempotency is needed; (12)
+the scalar-spend reader set is **eight** files incl. `server_compute.c:1469`
+cost-fold and `webchat/socket.go`, but `Chat.tsx` does not price client-side so
+§1 propagates to the UI for free.
+
 ## Goal
 
 Ingress requests are a cost blind spot. Normal agent and delegate calls are
@@ -161,32 +177,61 @@ optimization surface aimee already has, not a new one.
   real models while legacy rows stay empty, the by-model surface shows a
   **false-zero history** — recent ingress spend appears while all prior spend
   vanishes. The model write-fix and the filter/backfill must land together (§2).
-- **OpenAI/Codex ingress currently bypasses `agent_log_call` entirely.**
-  `agent_execute()` intentionally does **not** log (`agent_runtime.c:1093-1095`),
-  and `openai_chat.c` calls it directly for `/v1/chat/completions`,
-  `/v1/completions`, `/v1/responses`, and `/v1/runs` (`run_completion`,
-  `responses_handler`, `run_worker`). Streaming `/v1/responses` uses
-  `agent_execute_messages()`, a local one-step provider helper that also has no
-  token-audit write. So the OpenAI-compatible ingress is not merely missing
-  source attribution; most of it writes **no** `token_audit` row at all today.
-  The implementation must add exactly-one-row audit writes at these ingress
-  completion points, while preserving `agent_execute()`'s no-log contract to
-  avoid double logging in normal agent/delegate paths.
+- **Most OpenAI/Codex ingress bypasses `agent_log_call` — but `/v1/runs` does
+  NOT, and that asymmetry is a double-count trap.** `agent_execute()`
+  intentionally does **not** log (`agent_runtime.c:1092-1095`: "callers … handle
+  logging … Do not log here to avoid double-logging"), and `openai_chat.c` calls
+  it (or `agent_execute_messages()`, a one-step helper that also never logs)
+  directly for the **six** synchronous handlers: buffered + streaming
+  `/v1/chat/completions`, buffered + streaming `/v1/completions`, buffered
+  `/v1/responses`, and streaming `/v1/responses`. Those write **no** `token_audit`
+  row today. **`/v1/runs` is different**: `runs_handler` spawns a detached worker
+  (`pthread_create` + `pthread_detach`, `openai_chat.c:1156-1164`) that calls
+  `agent_run_with_tools()` → `agent_log_call()` (`agent_runtime.c:406`), so it
+  **already writes a row**. Therefore the implementation must add new writes only
+  to the six no-log handlers; for `/v1/runs` it must add **attribution only**, not
+  a second write, or it double-counts. The general rule: never add an ingress
+  write to any path that already flows through `agent_run*` / `agent_log_call`.
 - **The HTTP ingress handlers cannot currently see the metadata this proposal
   needs.** `server_http_completion_fn` and stream handler typedefs receive only
   `(body, resp, cap)` or `(body, emit, ctx)`; `Authorization`, `x-api-key`,
   `X-Aimee-Session-Key`, idempotency headers, request id, route path, TCP-vs-UDS,
-  and derived bearer capabilities are consumed in `server_http.c` and then
-  discarded. Source attribution, account isolation, idempotent dedup, and audit
-  row identity therefore require either a small thread-local request context
-  (matching the existing `ingress_preinject_set_request_disabled()` pattern) or
-  widening the registered handler signatures before any ingress writer lands.
-- **Existing usage readers assume every row is spend.** `hud.c`,
-  `dashboard.c` / `server/dashboard_server.c`, `frontend/src/pages/Chat.tsx`, and
-  webchat's usage event shape all sum `estimated_cost_usd` directly. Once
-  `usage_kind=estimated|avoided|partial` exists, these readers must filter or
-  split realized spend from advisory/avoided values, otherwise the UI will show
-  avoided cost as money spent.
+  and derived bearer capabilities are consumed in `server_http.c:1422-1451`
+  (a `request_id` is even generated, `:1424-1430`) and then discarded — only
+  logged, never passed to handlers. Source attribution, account isolation,
+  idempotent dedup, and audit row identity therefore require widening the handler
+  signatures (or a request context) before any ingress writer lands.
+- **A thread-local context is NOT sufficient — it breaks for `/v1/runs`.** The
+  cited precedent `ingress_preinject_set_request_disabled()` is `static __thread`
+  (`ingress_preinject.c:28`) and works **only because the turn runs synchronously
+  on the request thread**. The six synchronous handlers above keep that property,
+  so a thread-local context would reach them. But the `/v1/runs` worker runs on a
+  **detached pthread** that does not inherit the request thread's TLS, and SSE
+  paths may offload via `sse_offload` — so any offloaded path must have its
+  context **captured into the job/work struct at enqueue**, not read from a
+  thread-local. The proposal's "survive offloaded workers" requirement is only met
+  by capture-at-enqueue.
+- **`session_id()` is process-wide for ingress, so per-source attribution cannot
+  use it.** `session_id()` keys off the server's PPID (`config.c`), so **every**
+  HTTP ingress request resolves to the **same** shared id. Consequences: ingress
+  rows all collapse into one row in `db1_insights_top_sessions` (which JOINs
+  `token_audit.session_id`), and `cost_for_delegation` only separates by
+  `delegation_id`. The new `source` (and any per-client attribution) must derive
+  from the **request context** (`X-Aimee-Session-Key` / principal), not from
+  `session_id()`; otherwise top-sessions and per-source spend are meaningless for
+  ingress.
+- **Existing usage readers assume every row is spend — full list.** The audit
+  found **eight** consumers that sum `estimated_cost_usd` (or token-audit totals)
+  with no `usage_kind` filter: `src/hud.c`, `src/cmd_core.c` (`cmd_usage`),
+  `src/dashboard.c`, `src/server/dashboard_server.c`, `src/server_insights.inc`,
+  `src/server/server_compute.c:1469` (the cost-fold query),
+  `webchat/socket.go` (`streamEvent.Cost`), and `frontend/src/pages/Chat.tsx`.
+  Once `usage_kind=estimated|avoided|partial` exists, all of them (plus the eight
+  SQL aggregations in `token_audit.c`) must split realized spend from
+  advisory/avoided values, or the UI shows avoided cost as money spent. One
+  upside: `Chat.tsx` only *displays* a server-sent `cost` (it does **not** compute
+  price client-side), so unifying pricing server-side (§1) propagates to the UI
+  with no frontend change.
 
 ## §1 One pricing source of truth (extend, don't add)
 
@@ -232,23 +277,30 @@ estimates** and **avoided estimated cost**.
   `served_model` or `billable_model`, `provider_model`, `duration_ms`,
   `stop_reason`, and `optimizations_json` / `avoided_cost_usd` if dedup/cache
   savings are reported. If the decision is to avoid migration, state exactly how
-  each field is represented and which reports lose fidelity. The migration is
-  additive-only — `db1_reconcile_columns`
-  (`db_schema.c:78`) adds missing columns but creates no indexes and runs no
-  data migration, so column adds are safe but the empty-model backfill below is a
-  separate step.
-- **Row identity / idempotency:** give each attempted provider call a stable
-  request/turn id, and make successful audit insertion idempotent on that id (or
-  on `(source, request_id, attempt)`). This is required for retries, background
-  `/v1/runs`, and stream-abort cleanup paths; otherwise a retry or late finalizer
-  can double-count spend.
+  each field is represented and which reports lose fidelity. Two migration
+  constraints the audit surfaced: `db1_reconcile_columns` (`db_schema.c:78`)
+  **only adds columns** (no index, no data migration), and SQLite cannot
+  `ALTER TABLE ADD COLUMN` a `NOT NULL` column without a default — so every new
+  column must ship with a default, and the empty-model backfill and any index are
+  **separate explicit steps**, not part of the additive reconcile.
+- **Row identity / idempotency (and its migration cost).** Give each attempted
+  provider call a stable request/turn id and make successful insertion idempotent
+  on `(source, request_id, attempt)` — required for retries, background `/v1/runs`,
+  and stream-abort cleanup. **But idempotency needs a UNIQUE index, which the
+  additive reconcile does not create** (there is none on `token_audit` today, and
+  db1's indexes are only created at table-creation in `schema.sql`). Resolve the
+  contradiction explicitly: either add a one-off index-creation migration step, or
+  enforce idempotency in-process (a seen-set keyed by request id) and accept that
+  a crash between provider-return and insert can drop — not duplicate — a row.
 - **Request context prerequisite:** before adding source-aware audit rows or
   dedup, expose a per-request context from `server_http.c` to registered handlers:
   method/path, generated `X-Request-ID`, inbound idempotency key, session key,
   remote/local transport, bearer scope/principal (or local UID), and selected
-  route capability. The existing thread-local preinject override is a precedent,
-  but this context must be reset for every request and safe for offloaded stream
-  or `/v1/runs` worker threads.
+  route capability. The thread-local preinject override is a precedent for the
+  **synchronous** handlers only; because the `/v1/runs` worker is a detached
+  pthread (and SSE may offload), the context for those paths must be **captured
+  into the job/work struct at enqueue**, and the thread-local must be reset per
+  request so it never leaks across reused worker threads.
 - **Fix `by_model` alongside the model write (prerequisite, not optional).**
   Populating `served_model` is pointless while `db1_token_audit_by_model` filters
   empty models out: either backfill legacy rows' model from their `tool_name`
@@ -268,11 +320,14 @@ estimates** and **avoided estimated cost**.
   `completion_tokens`. The provider request builder has to insert the option, not
   only the parser.
 - **OpenAI/Codex direct ingress paths:** add one audit write for each successful
-  provider call in `openai_chat.c`: buffered `/v1/chat/completions`,
-  `/v1/completions`, buffered `/v1/responses`, streaming `/v1/responses`
-  (`agent_execute_messages()` result), and `/v1/runs` worker completion. Do not
+  provider call in the **six no-log handlers**: buffered + streaming
+  `/v1/chat/completions`, buffered + streaming `/v1/completions`, buffered
+  `/v1/responses`, and streaming `/v1/responses` (`agent_execute_messages()`
+  result). **Do NOT add a write to `/v1/runs`** — its detached worker already
+  logs through `agent_run_with_tools()` → `agent_log_call()`; it needs the
+  source/attribution fix only, fed by the context captured at enqueue. And do not
   add logging inside `agent_execute()` itself; normal `agent_run*` paths already
-  call `agent_log_call()`.
+  call `agent_log_call()`. Net: new writes only where no row exists today.
 - **Buffered path:** parse the provider JSON `usage` block after a 200 response
   and before translating it back to the client. The Anthropic parser already
   extracts cache tokens (`agent_bridge.c:791-796`), but the **OpenAI buffered
@@ -471,14 +526,24 @@ with a benchmark showing no quality regression.
   default; source/model breakdowns are stable in `cmd_usage`,
   `insights.overview`, HUD, dashboard JSON, React context panel, and webchat
   usage events.
-- **OpenAI/Codex ingress audit:** buffered chat/completions, completions,
-  responses, streaming responses, and `/v1/runs` each write exactly one realized
-  row on successful provider completion; `agent_execute()` remains no-log; normal
-  `agent_run*` paths still write exactly one row through `agent_log_call()`.
-- **Request context:** registered handlers see request id, idempotency key,
-  source/principal/session metadata, and route identity; context resets per
-  request and survives offloaded stream/run workers without leaking to the next
-  request.
+- **OpenAI/Codex ingress audit (double-count guard):** each of the six
+  synchronous no-log handlers (buffered+streaming chat/completions,
+  buffered+streaming completions, buffered+streaming responses) writes **exactly
+  one** realized row; **`/v1/runs` still writes exactly one** row (via its
+  existing `agent_log_call`) and gains source attribution **without** a second
+  write; `agent_execute()` remains no-log; normal `agent_run*` paths are
+  unchanged. Explicit assertion: no turn produces two rows.
+- **Request context / threading:** registered handlers see request id, idempotency
+  key, source/principal/session metadata, and route identity; the `/v1/runs`
+  detached worker sees the **same** context via capture-at-enqueue (not a
+  thread-local), and the thread-local resets per request so it never leaks to the
+  next request on a reused worker thread.
+- **Source attribution:** ingress rows carry a per-client source derived from the
+  request context (session key/principal), **not** the PPID-shared `session_id()`;
+  two distinct clients do not collapse into one `top_sessions` row.
+- **Idempotency:** a retried or late-finalized call with the same
+  `(source, request_id, attempt)` produces exactly one row (index or in-process
+  guard), and the migration that creates the uniqueness constraint is exercised.
 - **Aborted stream:** a stream cut before `finish` writes a `partial` row (or
   none), never a silently dropped turn.
 - **Buffered ingress:** provider usage writes **exactly one** audit row with


### PR DESCRIPTION
## Summary

Proposal update after repeated codebase review: this is framed as **coverage and correctness for existing accounting**, not a parallel cost system. aimee already has cache-aware `token_tracker`, DB1 `token_audit`, `cmd_usage`, `insights.overview`, agent-log metrics, and model-registry price fields; the proposal now focuses on ingress coverage, attribution, schema gaps, request context, UDS/webchat proxy attribution, embedding classification, safe agent-log joins, DB1 write semantics, OpenAPI/thin-client contract updates, streaming-accounting boundaries, and narrowly scoped request-shaping.

## Revised scope

- **§1** Reconcile all pricing sources (`token_tracker`, model registry, `delegate_ensemble`, models.dev snapshot); no new `cost_pricing.{c,h}` by default.
- **§2** Write ingress turns into existing DB1 `token_audit`, including direct OpenAI/Codex handlers that currently bypass `agent_log_call`.
- **§2** Add explicit source/usage-kind/request-id/model-attribution fields, plus idempotent row identity, by-model backfill/filter fixes, and a stable `call_id` / `agent_log_id` for rows tied to `agent_log`.
- **§2** Split streaming accounting by implementation: native/provider-incremental streams can produce `partial` usage on cutoff, while OpenAI/Codex compatibility streams are compute-then-chunk and should record realized spend after a successful provider return even if the client disconnects during synthetic SSE delivery.
- **§2** Fix agent metrics: `src/db1/agent_log.c` currently joins `agent_log` to `token_audit` by agent/role, which can multiply costs and cannot represent direct ingress rows cleanly.
- **§2** Account for DB1 write contention: current token-audit inserts are best-effort and ignored on failure, so the proposal now calls for explicit best-effort semantics, async/batched writes, and load tests for drop rate and tail latency.
- **§2/§4** Add request-context propagation from `server_http.c` so handlers can see request id, idempotency key, source/principal/session metadata, route identity, and account boundary.
- **§2/§4** Preserve/stamp trusted metadata through UDS/internal proxies; `webchat/openai.go` strips `Authorization` before forwarding, and forwarded source/principal headers require a proxy credential or equivalent second factor. A UID allowlist alone is insufficient because same-user UDS clients can spoof forwarded headers.
- **§2** Exclude `/v1/embeddings` from spend by default: it is local `$0` today, with remote-embedder accounting only if that path is implemented later.
- **§3** Scope cache-aware shaping to real ingress ownership: OpenAI/Codex seam first; Anthropic `/v1/messages` remains stateless unless separately opted in.
- **§4** Dedup only for narrow idempotent buffered requests, with source/account/context-safe keys and avoided-cost semantics; caller-controlled `X-Request-ID` is correlation metadata, not the sole idempotency key.
- **§5** Reasoning-effort cap mapped to provider-supported fields only.
- **§6** Cost as side metadata first, shaped reward only normalized into `[0,1]` behind a flag.
- **§7** Extend `insights.overview` before adding `/v1/usage/*`; existing HUD/dashboard/frontend/webchat/`cmd_agent` consumers must distinguish realized spend from estimated/avoided/partial rows, and the existing route still needs a concrete OpenAPI schema, regenerated `openapi_server_data.h`, and thin-client printer updates.

## Notes

- Docs-only; no code changes.
- Latest proposal commit: `7733727`.