### PR TITLE
Add agent roundtable authoring pipeline proposal

### DIFF
--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 tenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 eleventh review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -427,6 +427,39 @@ how review participants actually run shows that mis-locates the work.
     capability. Review correctness then never depends on whether a given model can
     retrieve or read files. **Resolved in §2, §3, and §10.**
 
+## PR #183 eleventh review — serialization and assembly provenance
+
+The tenth review moved retrieval to the right actor (the orchestrator), but the
+proposal still leaves three build-time correctness gaps at the response/ledger
+boundary.
+
+38. **`items_truncated` is a separate terminal-invalid flag, not covered by
+    `truncated`.** The engine sets `result.truncated` for brief/question/context
+    truncation and item-count overflow, but `add_roundtable_arrays` can still clip
+    serialized `items[]` at `ROUNDTABLE_ITEMS_JSON_BUDGET` and emit
+    `items_truncated: true` without changing `result.truncated`. A done-bar or gate
+    digest that reads only `truncated == false` can pass with missing findings.
+    The capture hook must persist `items_truncated`, and every done-bar must treat
+    it as invalid terminal evidence. **Resolved in §3, §4, and §10.**
+39. **Orchestrator-assembled inline review needs a budgeted assembly manifest.**
+    #37 says the orchestrator retrieves cross-chunk spans and hands reviewers a
+    self-contained inline unit, but it does not bound or explain that assembled
+    prompt. The current HTTP body ceiling is large, while reviewer context and
+    output fields are much smaller; over-assembling can silently omit the exact
+    span needed for correctness. Each review unit and aggregate call needs a
+    recorded assembly manifest: origin/chunk refs, selected span ids/ranges/hashes,
+    token/byte estimate against the resolved minimum participant budget, and any
+    omitted candidate spans. Required omissions keep the aggregate blocked and
+    surface as coverage gaps. **Resolved in §2, §3, §4, and §10.**
+40. **Item display fields are too small to be the only source provenance.**
+    `roundtable_review_item_t.location[128]`, `summary[256]`,
+    `recommendation[256]`, and `sources[256]` are display-sized fields. They
+    cannot safely carry long cross-chunk evidence chains, many participant
+    sources, or gate-audit provenance. The ledger must store a sidecar mapping
+    from item identity/result hash to the assembly spans and source refs that
+    produced it; `item.sources` remains a display hint, not the durable evidence
+    model. **Resolved in §4, §5, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -524,6 +557,9 @@ Both phases use the **same** engine; they differ only in input and brief.
   from chunk rows (#34), and the **orchestrator** retrieves needed spans from the
   origin plus review-scoped chunks and hands each review call a self-contained
   inline unit — panelists are not assumed to retrieve or read files (#32/#35/#37).
+  Each assembled unit records an assembly manifest with selected span refs/ranges/
+  hashes, token/byte budget, and omitted candidates; required omissions block the
+  aggregate instead of being hidden (#39).
   Pipeline-owned PR reviews use the async op-run path with validated pass
   metadata, not a direct synchronous roundtable dispatch. The brief carries the
   *fixes just applied*, the *invariants* the change must not break, and the
@@ -548,10 +584,11 @@ read from real engine fields (`roundtable_result_t`):
 
 Every bar first requires a valid completed result: `truncated == false`,
 `degraded == false`, `cost_capped == false`, `deadline_hit == false`,
-`cancelled == false`, and result provenance that the gate digest can explain. For
-review-mode done-bars, `items_round` must be the round being evaluated; if the
-surfaced artifact comes from a different `artifact_round`/`best_round`, the digest
-must say so and the phase cannot silently pass on mismatched evidence.
+`cancelled == false`, `items_truncated != true`, and result provenance that the
+gate digest can explain. For review-mode done-bars, `items_round` must be the
+round being evaluated; if the surfaced artifact comes from a different
+`artifact_round`/`best_round`, the digest must say so and the phase cannot
+silently pass on mismatched evidence.
 
 - `zero_blocking` *(default)* — `converged == true` and no `items[]` of
   `severity == "blocking"`. Suggestions/nits are surfaced in the gate digest but
@@ -581,7 +618,10 @@ missing section, a renamed reference) via vector/FTS + the `prev_chunk_id`/
 aggregate review call. A heterogeneous, possibly-remote panelist is never assumed
 to retrieve or read files; it reviews the inline digest. The full text is never
 needed in one context window, and the origin is always retained, never replaced by
-its chunks.
+its chunks. The aggregate also validates each assembled inline unit's budget and
+manifest (#39): selected spans must hash back to the retained origin/chunks, any
+omitted required span is a coverage gap, and no unit may pass if the manifest says
+the resolved minimum participant context budget was exceeded.
 
 **Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
 bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
@@ -631,12 +671,18 @@ Either way, the durable record holds:
   explicit artifact payload), review-chunk index refs (`kb_documents` rows if that
   backend is used), and content hashes — not unbounded inline text as the primary
   representation;
+- assembly manifests for orchestrator-built review units and aggregate checks:
+  selected origin/chunk span refs, ranges, hashes, input budget estimates, and
+  omitted candidate spans (#39);
 - the current brief plus compact gate digest;
 - per-pass history: each outer pass's status, aggregate child `run_id` if
   single-call, `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`,
   `best_round`, result hash, and any payload/chunk refs; for chunked passes, a
   manifest plus aggregate row that records per-chunk results and the
   whole-artifact synthesis/check (#28);
+- per-item provenance sidecars keyed by item identity/result hash, mapping
+  findings back to assembly spans, source refs, and participant sources; compact
+  `item.sources` strings are display hints only (#40);
 - per-attempt history under each pass: `attempt_no`, child `run_id`, submitted and
   terminal timestamps, captured/lost status, terminal flags, result hash, and cost
   if the result was available;
@@ -666,12 +712,13 @@ before the run record can be evicted. The hook **no-ops when `__pipeline_pass_id
 is absent**, so ordinary `ensemble_review`/roundtable calls are untouched. What it
 persists is **mode-appropriate** (#27): for a REVIEW pass, the items + severities
 + `count`, `converged`, validity flags, `items_round`, `artifact_round`, counts,
-`cost_usd`, `rounds_run`; for a DRAFT pass, the artifact **ref + content hash** +
-`best_round`/`artifact_round` + validity flags (the skeleton text itself lands in
-the working file, not as a ledger blob, per #9). Failed, cancelled, malformed, and
-capture-failed terminal states are recorded too. The `/v1/runs` id is retained
-only as a historical pointer; the ledger row is the source of truth for the
-done-bar and the gate digest.
+`cost_usd`, `rounds_run`, and `items_truncated` when the HTTP response serialized
+only a prefix of the item list (#38); for a DRAFT pass, the artifact **ref +
+content hash** + `best_round`/`artifact_round` + validity flags (the skeleton text
+itself lands in the working file, not as a ledger blob, per #9). Failed,
+cancelled, malformed, and capture-failed terminal states are recorded too. The
+`/v1/runs` id is retained only as a historical pointer; the ledger row is the
+source of truth for the done-bar and the gate digest.
 
 **The agent reads terminal from the ledger, not `/v1/runs` (#26).** Because the
 worker writes the result to DB1 at terminal, the driving agent learns a pass
@@ -940,6 +987,15 @@ ledger) before the full idea→merge pipeline of P2/P3.
   because the orchestrator pre-retrieved the needed spans and passed a
   self-contained inline unit; the panel's tool access is never load-bearing for
   review correctness.
+- **Assembled input budget/provenance (#39)** — build an aggregate review unit
+  where retrieved candidate spans exceed the smallest participant budget; the
+  assembly manifest records selected/omitted spans and hashes, omitted required
+  spans block the aggregate with a coverage gap, and no over-budget inline unit is
+  submitted as valid evidence.
+- **Item source provenance sidecar (#40)** — generate a finding whose evidence
+  spans many chunks/participants so `item.sources` would be clipped; the gate
+  digest still links the item identity/result hash to the durable sidecar spans
+  and source refs, not just the display string.
 - **Chunk threshold from min panel context (#33)** — a heterogeneous panel sizes
   chunks to the smallest participant context budget (resolved per run, reserving
   brief/role/peer-note headroom); a chunk that would overflow the smallest model is
@@ -961,9 +1017,10 @@ ledger) before the full idea→merge pipeline of P2/P3.
   capped artifact.
 - **Done-bar config** — each of the three bars stops the loop at the right point
   (suggestions block under bar 2; questions must be answered under bar 3).
-- **Done-bar validity flags** — `truncated`, `degraded`, `cost_capped`,
-  `deadline_hit`, `cancelled`, lost result, or ambiguous `items_round` /
-  `artifact_round` provenance prevents a done-bar pass and escalates.
+- **Done-bar validity flags (#38)** — `truncated`, `items_truncated`, `degraded`,
+  `cost_capped`, `deadline_hit`, `cancelled`, lost result, or ambiguous
+  `items_round` / `artifact_round` provenance prevents a done-bar pass and
+  escalates.
 - **Question cap** — a brief with >16 questions is rejected or split before using
   `zero_blocking_questions_answered`; overflow cannot be silently treated as
   answered.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 thirteenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 fourteenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -508,6 +508,32 @@ No new feedback prompted this pass; a fresh read of the loop's *outer* mechanics
     duplicate is a hard error, not a silent second PR. **Resolved in §1, §5, and
     §10.**
 
+## PR #183 fourteenth review — validity envelope and HTTP namespace
+
+The thirteenth review closed more loop mechanics, but a fresh pass over the
+server routing and run-capture code found two more buildability gaps.
+
+44. **The validity predicate cannot be a raw `roundtable_result_t` helper, and it
+    must not gate capture.** #41 names `roundtable_result_valid_terminal(result)`,
+    but some invalidity inputs are outside `roundtable_result_t`: `items_truncated`
+    is added by HTTP serialization, `lost_result` is a ledger/attempt state, and
+    capture-failed/malformed terminal attempts may not have a parsed engine result
+    at all. The worker must first persist the terminal **capture envelope** (run
+    id, attempt status, raw/sanitized result snapshot hash, parse status, HTTP
+    serialization flags, and engine flags when present). The canonical predicate
+    then evaluates that envelope for done-bar eligibility. It must never decide
+    whether the terminal attempt is recorded; invalid terminal evidence is exactly
+    what the ledger needs for retries and audits. **Resolved in §3, §4, and §10.**
+45. **`/v1/pipeline/status` is already the KB/corpus pipeline status route.** The
+    proposal says the implementation may add `aimee pipeline status|gate` as a
+    CLI/MCP/HTTP surface, but Aimee's KB sidecar already exposes
+    `GET /v1/pipeline/status` for asynchronous knowledge ingest status (with
+    `/v1/corpus/pipeline/status` as the newer corpus-specific spelling). A new
+    roundtable-authoring HTTP API must not reuse or overload that path. If an HTTP
+    surface is added, it needs an unambiguous namespace such as
+    `/v1/roundtable/pipelines/...` or `/v1/authoring/pipelines/...`; otherwise v1
+    can remain CLI/MCP-only. **Resolved in §5, §8, §10, and §12.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -635,15 +661,19 @@ Two distinct loop levels — keep them un-confused:
 its review loop only when the latest REVIEW result satisfies the configured bar,
 read from real engine fields (`roundtable_result_t`):
 
-Every bar first requires `roundtable_result_valid_terminal(result) == true` — the
-**single canonical validity predicate** (#41), false on any of `truncated`,
-`items_truncated`, `degraded`, `cost_capped`, `deadline_hit`, `cancelled`,
-`lost_result`, or an `items_round`/`artifact_round` provenance mismatch. The
-done-bar, the chunk-aggregate, the capture hook, and the gate digest all consult
-this one predicate rather than re-listing flags inline, so no consumer can pass on
-a subset. For review-mode done-bars the surfaced `artifact_round`/`best_round`
-provenance must match the evaluated `items_round`, and the gate digest explains any
-mismatch rather than silently passing.
+Every bar first requires `roundtable_terminal_envelope_valid(envelope) == true` —
+the **single canonical validity predicate** (#41/#44), evaluated over the captured
+terminal envelope rather than only raw `roundtable_result_t`. It is false on any
+of `truncated`, `items_truncated`, `degraded`, `cost_capped`, `deadline_hit`,
+`cancelled`, `lost_result`, capture/parse failure, or an
+`items_round`/`artifact_round` provenance mismatch. The done-bar, the
+chunk-aggregate, and the gate digest all consult this one predicate rather than
+re-listing flags inline, so no consumer can pass on a subset. The worker capture
+hook records every terminal envelope first and only then marks whether that
+envelope is valid for done-bar use; invalid evidence is still durable. For
+review-mode done-bars the surfaced `artifact_round`/`best_round` provenance must
+match the evaluated `items_round`, and the gate digest explains any mismatch
+rather than silently passing.
 
 - `zero_blocking` *(default)* — `converged == true` and no `items[]` of
   `severity == "blocking"`. Suggestions/nits are surfaced in the gate digest but
@@ -739,8 +769,9 @@ Either way, the durable record holds:
   findings back to assembly spans, source refs, and participant sources; compact
   `item.sources` strings are display hints only (#40);
 - per-attempt history under each pass: `attempt_no`, child `run_id`, submitted and
-  terminal timestamps, captured/lost status, terminal flags, result hash, and cost
-  if the result was available;
+  terminal timestamps, captured/lost status, terminal envelope parse status,
+  HTTP serialization flags (`items_truncated`), engine terminal flags, result
+  snapshot/hash, and cost if the result was available (#44);
 - repository/worktree state: repo root, remote, base branch, head branch,
   workspace id/provider (`shared`, `detached`, or `mirror`), dedicated worktree
   path if any, head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs,
@@ -765,15 +796,20 @@ narrow op-run-finalize hook rather than hard-coding roundtable ledger writes int
 generic HTTP routing, to **also persist the pass result** into the DB1 ledger row
 before the run record can be evicted. The hook **no-ops when `__pipeline_pass_id`
 is absent**, so ordinary `ensemble_review`/roundtable calls are untouched. What it
-persists is **mode-appropriate** (#27): for a REVIEW pass, the items + severities
-+ `count`, `converged`, validity flags, `items_round`, `artifact_round`, counts,
-`cost_usd`, `rounds_run`, and `items_truncated` when the HTTP response serialized
-only a prefix of the item list (#38); for a DRAFT pass, the artifact **ref +
-content hash** + `best_round`/`artifact_round` + validity flags (the skeleton text
-itself lands in the working file, not as a ledger blob, per #9). Failed,
-cancelled, malformed, and capture-failed terminal states are recorded too. The
-`/v1/runs` id is retained only as a historical pointer; the ledger row is the
-source of truth for the done-bar and the gate digest.
+persists is the terminal **capture envelope** first (#44): run id, attempt status,
+raw/sanitized result snapshot hash, parse status, HTTP serialization flags, and
+engine flags when available. The mode-specific parsed fields then hang off that
+envelope (#27): for a REVIEW pass, the items + severities + `count`, `converged`,
+validity flags, `items_round`, `artifact_round`, counts, `cost_usd`, `rounds_run`,
+and `items_truncated` when the HTTP response serialized only a prefix of the item
+list (#38); for a DRAFT pass, the artifact **ref + content hash** +
+`best_round`/`artifact_round` + validity flags (the skeleton text itself lands in
+the working file, not as a ledger blob, per #9). Failed, cancelled, malformed, and
+capture-failed terminal states are recorded too. The canonical validity predicate
+is evaluated **after** this record is durable; it controls done-bar eligibility,
+not whether the attempt is captured. The `/v1/runs` id is retained only as a
+historical pointer; the ledger row is the source of truth for the done-bar and the
+gate digest.
 
 **The agent reads terminal from the ledger, not `/v1/runs` (#26).** Because the
 worker writes the result to DB1 at terminal, the driving agent learns a pass
@@ -822,11 +858,13 @@ returns to the prior review phase. The fail reason is durable in the ledger so t
 re-review is genuinely directed by it.
 
 The command/API surface must be explicit in implementation. The proposal may add
-`aimee pipeline status|gate` as a new first-class CLI/MCP/HTTP surface, or extend
-the existing `autopilot` pipeline handler, but it must not leave two unrelated
-"pipeline" namespaces with different IDs. The gate action is net-new; today's
-autopilot actions cover `start`, `advance`, `status`, `list`, `cancel`, `resume`,
-`link-plan`, and `link-job`, not pass/fail gates.
+`aimee pipeline status|gate` as a new first-class CLI/MCP surface, or extend the
+existing `autopilot` pipeline handler, but it must not leave two unrelated
+"pipeline" namespaces with different IDs. If an HTTP API is added, it must avoid
+the existing KB/corpus route `GET /v1/pipeline/status`; use a namespaced path such
+as `/v1/roundtable/pipelines/...` or `/v1/authoring/pipelines/...` (#45). The gate
+action is net-new; today's autopilot actions cover `start`, `advance`, `status`,
+`list`, `cancel`, `resume`, `link-plan`, and `link-job`, not pass/fail gates.
 
 Pipeline `cancel`/`abandon` cannot be ledger-only. If a child roundtable op-run is
 active, the action must request cancellation through the child `run_id`
@@ -941,6 +979,9 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **Hard:** workspace-aware git/forge authority for PR create/merge and diff
   capture. Pipeline git/gh operations must route through Aimee's git tools or
   workspace provider so shared, detached, and mirror workspaces behave consistently.
+- **Hard if exposing HTTP:** route namespace selection. `GET /v1/pipeline/status`
+  already belongs to the KB/corpus ingest pipeline, so roundtable-authoring routes
+  must use a distinct namespace or remain CLI/MCP-only in v1 (#45).
 - **Soft:** the `git diff` range helper (agent-directed-pr-review P2) for the PR
   phase input; otherwise the pipeline captures the diff through the
   workspace-aware git surface.
@@ -1085,10 +1126,15 @@ ledger) before the full idea→merge pipeline of P2/P3.
   `items_round` / `artifact_round` provenance prevents a done-bar pass and
   escalates.
 - **Single validity predicate (#41)** — a table-driven test trips each invalidity
-  flag in turn and asserts that **every** consumer (done-bar, chunk-aggregate,
-  capture hook, gate digest) rejects it via `roundtable_result_valid_terminal`; no
-  consumer re-implements the check, so a newly added flag cannot be honored by some
-  sites and ignored by others.
+  flag in turn and asserts that **every** eligibility consumer (done-bar,
+  chunk-aggregate, gate digest) rejects it via
+  `roundtable_terminal_envelope_valid`; no consumer re-implements the check, so a
+  newly added flag cannot be honored by some sites and ignored by others.
+- **Capture-before-validity (#44)** — feed successful, failed, cancelled,
+  malformed, oversized, and `items_truncated` terminal snapshots through the worker
+  hook; every attempt gets a durable envelope row before validity is evaluated, and
+  invalid envelopes are retained for retry/audit while blocked from satisfying the
+  done-bar.
 - **Question cap** — a brief with >16 questions is rejected or split before using
   `zero_blocking_questions_answered`; overflow cannot be silently treated as
   answered.
@@ -1102,6 +1148,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Workspace authority** — run proposal/implementation PR operations in shared
   and detached workspaces; git/gh calls route through `mcp_git_run`/`git_pr` and
   forge-token state is surfaced when required.
+- **HTTP namespace collision (#45)** — assert that any authoring-pipeline HTTP
+  route does not occupy `GET /v1/pipeline/status`, and that the existing KB/corpus
+  pipeline status endpoint and generated docs/tests continue to pass unchanged.
 - **Branch/worktree isolation** — dirty user checkout blocks the pipeline unless
   the run has a dedicated branch/worktree or an explicit operator override.
 - **Large payload handling** — a diff/proposal larger than a single MCP/op-run
@@ -1140,7 +1189,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
   bounded live store and is not durable across restarts.
 - **CLI/API namespace:** add `aimee pipeline ...` as a new surface, or extend the
   existing `autopilot` pipeline actions with gate/status operations? The answer
-  must keep IDs and help text unambiguous.
+  must keep IDs and help text unambiguous. If HTTP is exposed, it must not collide
+  with the existing KB/corpus `GET /v1/pipeline/status` route; choose a distinct
+  roundtable/authoring namespace or defer HTTP.
 - **Who is the driving agent at the gate?** When paused at a human gate across
   sessions, does a fresh agent resume from the ledger automatically, or does the
   human re-invoke `aimee pipeline resume <id>`?

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 twenty-second review)
+- **Date:** 2026-06-11 (revised post-PR-#183 twenty-third review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -726,6 +726,24 @@ effect.
     surface the blocked merge reason without losing the verdict. **Resolved in §1,
     §4, §5, §9, and §10.**
 
+## PR #183 twenty-third review — the gate TTL must not abandon a human's approval
+
+#56 adds `*_merge_pending`, but the gate TTL (#47) was written for the
+*awaiting-human* gate states and does not yet say it stops there.
+
+57. **The unanswered-gate TTL must not apply to `*_merge_pending` — a pass verdict
+    cannot be auto-abandoned because infra is slow.** `roundtable_pipeline_gate_ttl_h`
+    (#47) moves an **unanswered** gate to `abandoned`, which is right while the
+    pipeline waits on a *human*. But `*_merge_pending` is post-pass: the human
+    already approved, and the wait is on the *merge* (hung CI, branch protection,
+    transient `gh` failure). Abandoning that state would silently discard a human's
+    approval and force a full re-review. So the TTL applies **only** to
+    awaiting-human `*_pending` states. A blocked `*_merge_pending` retries with
+    backoff and surfaces the merge blocker, preserving the verdict; it leaves the
+    state only by a successful merge, an explicit operator `cancel`/`abandon` (#31),
+    or — if wanted — a *separate, clearly-named* merge-block escalation timer that
+    **escalates to a human, never auto-abandons**. **Resolved in §4, §5, §6, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -1119,6 +1137,13 @@ merge SHA and advances; still unmerged retries or parks with the latest merge
 blocker; merged at a different head marks the gate evidence stale and stops for
 operator review.
 
+**The unanswered-gate TTL does not apply here (#57).** `roundtable_pipeline_gate_ttl_h`
+abandons an *awaiting-human* `*_pending` gate; `*_merge_pending` is post-pass —
+the human already approved — so it is **never** auto-abandoned for slowness. A
+blocked merge retries with backoff and surfaces the blocker, leaving the state only
+by a successful merge, an explicit operator `cancel`/`abandon`, or a separate
+merge-block escalation that pings a human rather than discarding the verdict.
+
 If the implementation chooses the distinct-capability path, it must first make the
 capability model able to represent that authority (#54). The current mask has no
 spare low bit (`CAPS_ALL` is `0xFFFFu`), so gate resolution is not just another
@@ -1199,8 +1224,10 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
   requires a fresh reconciliation and stale gate digest rather than silently
   combining DB1 token-audit totals, child-run estimates, and db2 usage rows (#52).
 - `roundtable_pipeline_gate_ttl_h` — int hours, **default 0 (no expiry)**; >0 moves
-  a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
-  cleanup (#31), never an auto-pass (#47).
+  an **awaiting-human** `*_pending` gate left unanswered past the TTL to `abandoned`
+  with full child-run-stop + cleanup (#31), never an auto-pass (#47). It does **not**
+  apply to `*_merge_pending` — a post-pass merge is never auto-abandoned for
+  slowness (#57).
 - `roundtable_pipeline_parked_releases_slot` — bool, default chosen by
   implementation policy; if true, a parked human gate releases the single active
   pipeline admission slot while retaining branch/PR ownership guards (#48).
@@ -1517,6 +1544,10 @@ ledger) before the full idea→merge pipeline of P2/P3.
   is dropped and correctly re-ingested from the origin on resume (same content
   hash, retrieval still works); with a TTL set, an unanswered gate moves to
   `abandoned` with child-run-stop + cleanup, never an auto-pass.
+- **Merge-pending survives the TTL (#57)** — with a gate TTL set, a pipeline in
+  `*_merge_pending` whose merge is blocked past the TTL is **not** abandoned: the
+  verdict is preserved, the merge retries/surfaces the blocker, and only a
+  successful merge or explicit operator abandon leaves the state.
 - **Parked-gate admission (#48)** — with one pipeline parked at a gate, start a
   second pipeline only if the selected policy releases the active slot; either way,
   branch/PR ownership prevents two active/restarted runs from mutating the same

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 nineteenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 twentieth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -16,8 +16,9 @@
   `testing`) and the in-tree `ensemble_review` review surface, with the remaining
   review contract narrowed to stable terminal result shape/payload semantics. It
   routes PR/merge/diff work through Aimee's workspace-aware git/PR tools rather
-  than assuming a raw local `gh`/`git` shell. No changes to the roundtable engine
-  itself.
+  than assuming a raw local `gh`/`git` shell, and it may need a narrowly-scoped
+  auth/capability-policy change for human gate resolution. No changes to the
+  roundtable engine itself.
 
 ## Design at a glance
 
@@ -664,6 +665,26 @@ it. That is the integrity of the whole design.
     negative test asserts a session holding only the agent's caps is **denied**
     `gate pass`. **Resolved in §5, §8, §10, and §11.**
 
+## PR #183 twentieth review — gate authority cannot assume a spare capability bit
+
+The nineteenth review fixed the security model conceptually, but one implementation
+path it names is not drop-in for the current server.
+
+54. **A new `CAP_PIPELINE_GATE` requires a capability-mask migration, not just a
+    constant.** `src/headers/server.h` already consumes bits 0-15
+    (`CAP_DASHBOARD_READ` is `1u << 15`) and defines `CAPS_ALL` as `0xFFFFu`.
+    The `/v1` transport derives TCP/UDS caps from that mask, and the route registry
+    reuses the same `uint32_t` values while still treating `CAPS_ALL` as the full
+    trusted set. Adding `CAP_PIPELINE_GATE = 1u << 16` without updating `CAPS_ALL`,
+    scoped/unscoped bearer behavior, route-cap tests, and capability advertising
+    would make the gate unreachable or inconsistently authorized. The proposal must
+    choose one of two buildable designs: (a) widen/redefine the capability model
+    and update `CAPS_ALL`, `CAPS_AUTHENTICATED`, `server_http_conn_caps`,
+    `server_http_route_allowed`, OpenAPI/capability docs, and auth tests; or (b)
+    avoid a new cap bit and implement gate resolution through an operator principal
+    / local-UDS-only out-of-band confirmation whose denial semantics are tested
+    separately. **Resolved in §5, §8, §9, §10, and §12.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -1035,6 +1056,13 @@ present in a delegate-driving session: a distinct capability (e.g.
 Without that separation the two human gates are decorative — the agent could pass
 its own.
 
+If the implementation chooses the distinct-capability path, it must first make the
+capability model able to represent that authority (#54). The current mask has no
+spare low bit (`CAPS_ALL` is `0xFFFFu`), so gate resolution is not just another
+method-registry row. A v1 implementation may instead make `gate pass|fail`
+operator-principal or local-UDS-only/out-of-band while keeping the driving agent's
+surface limited to gate creation, status, digest refresh, cancel, and resume.
+
 The command/API surface must be explicit in implementation. The proposal may add
 `aimee pipeline status|gate` as a new first-class CLI/MCP surface, or extend the
 existing `autopilot` pipeline handler, but it must not leave two unrelated
@@ -1190,6 +1218,12 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   pipeline/delegate method today maps to `CAP_DELEGATE`, which the driving agent
   holds; `gate pass|fail` must require a capability/principal that a delegate-driving
   session does not have, or the agent can self-approve its own merge.
+- **Hard if using a new capability bit:** capability-mask migration (#54). The
+  current 16-bit `CAPS_ALL` / low-bit capability set is full; adding
+  `CAP_PIPELINE_GATE` requires updating the cap constants/composites, TCP bearer
+  scope derivation, route authorization, capability/OpenAPI docs, and tests. If
+  that migration is deferred, gate resolution must use an operator-principal or
+  local/out-of-band authority instead of a new cap bit.
 - **Soft:** the cost-accounting proposal's `usage_ledger` / `/v1/usage/*` for
   whole-pipeline cost that includes implementation-phase spend (#51). Absent it,
   the total cap is roundtable-child-run-cost only and says so (#49). Any
@@ -1215,7 +1249,11 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   every terminal attempt to the ledger (#18/#20-#25). The finalize hook must be
   current-attempt guarded so late workers cannot advance stale state (#30), and
   pipeline cancel/abandon must request child-run stop when one is active (#31).
-  No loop yet; states/gates settable manually. Mergeable alone, with restart tests.
+  Choose the gate-resolution authority shape in this phase too: either migrate the
+  capability mask for a real gate cap, or make gate resolution
+  operator-principal/local-out-of-band and prove delegate-driving sessions cannot
+  call it (#53/#54). No loop yet; states/gates settable manually. Mergeable alone,
+  with restart tests.
 - **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
   `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
   escalation, the attempt retry ceiling, the echo guard. Drives the PR phase first
@@ -1395,6 +1433,12 @@ ledger) before the full idea→merge pipeline of P2/P3.
   caps (`CAP_DELEGATE`) can surface a gate but is **denied** `gate pass|fail`; only
   the separate gate authority (capability/operator principal/out-of-band) can
   resolve it. The negative test proves an agent cannot self-approve and merge.
+- **Gate capability representation (#54)** — if a distinct gate capability is
+  added, assert `CAPS_ALL`, `CAPS_AUTHENTICATED`, scoped/unscoped TCP bearer
+  behavior, `server_http_route_caps`, capability advertising/OpenAPI docs, and
+  route-allowed tests all agree on whether the gate route is reachable. If no new
+  bit is added, assert the operator/local confirmation path denies delegate-only
+  sessions and still lets an authorized human resolve the gate.
 - **Parked-gate resource release + TTL (#47)** — at a gate, the review-scoped index
   is dropped and correctly re-ingested from the origin on resume (same content
   hash, retrieval still works); with a TTL set, an unanswered gate moves to
@@ -1445,6 +1489,10 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Who is the driving agent at the gate?** When paused at a human gate across
   sessions, does a fresh agent resume from the ledger automatically, or does the
   human re-invoke `aimee pipeline resume <id>`?
+- **Gate authority shape:** should gate resolution widen/rework the capability
+  mask to add a real gate capability, or should it be operator-principal /
+  local-out-of-band only for v1? The current `CAPS_ALL == 0xFFFFu` mask leaves no
+  spare low bit for a simple `CAP_PIPELINE_GATE` constant.
 - **Parked-gate admission:** does a human gate release the single active pipeline
   slot (`roundtable_pipeline_parked_releases_slot=true`) or block new authoring
   runs until answered/abandoned?

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 twentieth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 twenty-first review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -685,6 +685,25 @@ path it names is not drop-in for the current server.
     / local-UDS-only out-of-band confirmation whose denial semantics are tested
     separately. **Resolved in §5, §8, §9, §10, and §12.**
 
+## PR #183 twenty-first review — gate resolution must be exactly-once
+
+#53/#54 settled *who* may resolve a gate; neither settled *whether resolution is
+once-only*. `gate pass` is a side-effecting transition (it merges and advances),
+so at-least-once delivery is a real hazard.
+
+55. **A double `gate pass` must not double-merge or double-advance.** A second
+    invocation — network retry, double submission, two authorized operators, or a
+    resume racing another resume — must be a no-op or a clear "already resolved"
+    error, never a second merge. Gate resolution must: (a) act **only** when the
+    pipeline is in the matching `*_pending` state and **atomically** transition out
+    of it, so a concurrent or repeat call observes a non-pending state and stops;
+    (b) make the merge **idempotent** — keyed by the recorded PR + expected head SHA
+    (the §5 drift check, #43), so retrying a merge of an already-merged PR is a
+    no-op, not a duplicate or a hard error; (c) record the verdict once with
+    actor/timestamp. Without this guard the merge side effect is exposed to
+    at-least-once delivery, and a flaky client could merge twice or skip a phase.
+    **Resolved in §4, §5, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -1055,6 +1074,15 @@ present in a delegate-driving session: a distinct capability (e.g.
 `CAP_PIPELINE_GATE`), an operator/human principal, or an out-of-band confirmation.
 Without that separation the two human gates are decorative — the agent could pass
 its own.
+
+**Gate resolution is exactly-once (#55).** `gate pass|fail` both records a verdict
+and (on pass) merges + advances, so it must be a guarded, idempotent transition,
+not a fire-and-forget command. It acts only when the pipeline is in the matching
+`*_pending` state and atomically leaves that state, so a repeat or concurrent call
+sees a non-pending state and returns "already resolved" rather than merging again;
+the merge itself is keyed by the recorded PR + expected head SHA (the drift check
+above), so a retried merge of an already-merged PR is a no-op. A flaky client must
+not be able to merge twice or skip a phase.
 
 If the implementation chooses the distinct-capability path, it must first make the
 capability model able to represent that authority (#54). The current mask has no
@@ -1433,6 +1461,10 @@ ledger) before the full idea→merge pipeline of P2/P3.
   caps (`CAP_DELEGATE`) can surface a gate but is **denied** `gate pass|fail`; only
   the separate gate authority (capability/operator principal/out-of-band) can
   resolve it. The negative test proves an agent cannot self-approve and merge.
+- **Exactly-once gate resolution (#55)** — call `gate pass` twice (and concurrently)
+  on a `*_pending` pipeline; exactly one merge + advance occurs, the second call
+  returns "already resolved," and a retried merge of an already-merged PR is a
+  no-op — never a double-merge or a skipped phase.
 - **Gate capability representation (#54)** — if a distinct gate capability is
   added, assert `CAPS_ALL`, `CAPS_AUTHENTICATED`, scoped/unscoped TCP bearer
   behavior, `server_http_route_caps`, capability advertising/OpenAPI docs, and

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 fifteenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 sixteenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -566,6 +566,44 @@ A fresh pass over the *cost* and *resource-lifecycle* of the long-lived states
     **never** an auto-pass. A parked pipeline must not pin a growing index. **Resolved
     in §4, §5, §6, and §10.**
 
+## PR #183 sixteenth review — admission, merge execution, and cost scope
+
+The fifteenth review added parked-gate cleanup and a total cap, but those changes
+expose three places where the proposal still overstates or contradicts the current
+codebase.
+
+48. **"One pipeline at a time" conflicts with parked gates unless admission is
+    explicit.** §11 says v1 has one pipeline run at a time, while #47 talks about
+    many parked pipelines and released resources. Implementation must choose the
+    admission rule: either a parked gate continues to occupy the single authoring
+    slot (simple, but one forgotten gate blocks all future runs), or entering a
+    gate transitions the run to a `parked`/`waiting_human` class that releases the
+    active slot while retaining ledger ownership and preventing two active
+    reviewers from mutating the same branch/PR. Without that distinction, the gate
+    lifecycle is ambiguous and resource cleanup can accidentally introduce
+    unscheduled parallel pipelines. **Resolved in §1, §4, §5, §10, §11, and §12.**
+49. **The whole-pipeline cost cap must define whether implementation-agent spend
+    is in scope.** #46 says the total cap spans proposal + implementation + PR
+    phases, but the ledger costs described so far are roundtable pass costs. The
+    implementation phase is "normal coding," not a roundtable call, and may not
+    expose comparable `cost_usd` without using Aimee's token-audit / agent-cost
+    surfaces. Choose one contract: either the cap is explicitly
+    `roundtable_pipeline_max_roundtable_cost_usd` (roundtable child runs only), or
+    the ledger must ingest non-roundtable implementation-agent spend from the
+    existing token/cost accounting and mark unknown implementation cost as
+    incomplete evidence. A cap that claims to include implementation but only sums
+    review passes is misleading. **Resolved in §3, §4, §6, and §10.**
+50. **`git_pr` does not merge today; pass→merge needs a real executor contract.**
+    The proposal's table says PR open/merge/diff capture exists via
+    `git_pr`/`mcp_git_run`, but the current `git_pr` tool supports
+    create/view/list/edit/checks/watch/merge_status/wait — not merge. A gate pass
+    must either add a first-class workspace-aware `git_pr action=merge` (with
+    admin/squash/rebase options, expected head SHA, and captured merge SHA) or
+    explicitly use `mcp_git_run`/`gh pr merge` through the workspace/forge-token
+    authority and persist the command, output, exit code, and merge SHA. Treating
+    merge as already covered hides a build gap at the most important state
+    transition. **Resolved in §5, §8, §9, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -634,7 +672,11 @@ Transitions:
    which pushes the fix to the **same recorded implementation branch/PR** (#43).
 
 Every state is durable (§4) so a human gate can be answered hours or days later,
-across a server restart or a new agent session.
+across a server restart or a new agent session. For v1 admission control, only
+one pipeline may be **active** in drafting/review/implementing at a time; an
+unanswered gate may either keep that active slot or enter an explicit
+`parked`/`waiting_human` class that releases it (#48). The implementation must
+choose one rule and record it in the ledger before allowing another run to start.
 
 ## §2 The two roundtable applications
 
@@ -691,7 +733,8 @@ Two distinct loop levels — keep them un-confused:
 
 **Done-bar (configurable; correctness condition, not a budget).** A phase leaves
 its review loop only when the latest REVIEW result satisfies the configured bar,
-read from real engine fields (`roundtable_result_t`):
+read from the captured terminal envelope built from real engine fields plus
+serialization/attempt state:
 
 Every bar first requires `roundtable_terminal_envelope_valid(envelope) == true` —
 the **single canonical validity predicate** (#41/#44), evaluated over the captured
@@ -755,13 +798,15 @@ prevents cross-pass echo.)
 
 **Non-termination backstop.** Besides the optional pass ceiling, the inherited
 `ensemble_max_cost_usd` (per call), a cumulative `roundtable_pipeline_max_cost_usd`
-(per phase), and a cumulative `roundtable_pipeline_max_total_cost_usd` (whole
-pipeline, §6) bound spend; any tripping escalates to the human rather than silently
-passing. **The per-phase cap accumulates across fail-return re-entries of that
-phase — a fail-return never resets it** (#46) — and the whole-pipeline cap spans
-proposal + implementation + PR phases together. Infrastructure retries under one
-pass id are separately bounded by `roundtable_pipeline_max_attempts_per_pass` (#29)
-so capture failures do not consume correctness passes but also cannot spin forever.
+(per phase), and a cumulative total cap (§6) bound spend; any tripping escalates
+to the human rather than silently passing. **The per-phase cap accumulates across
+fail-return re-entries of that phase — a fail-return never resets it** (#46). The
+total cap's accounting scope must be explicit (#49): either it covers roundtable
+child-run costs only, or it also includes normal implementation-agent spend from
+the existing token/cost accounting and treats unknown implementation cost as
+incomplete evidence. Infrastructure retries under one pass id are separately
+bounded by `roundtable_pipeline_max_attempts_per_pass` (#29) so capture failures
+do not consume correctness passes but also cannot spin forever.
 
 ## §4 Hybrid state — the resumable pipeline ledger
 
@@ -784,7 +829,9 @@ must choose one explicit path:
 
 Either way, the durable record holds:
 
-- pipeline id, state (§1), phase, created/updated timestamps, and schema version;
+- pipeline id, state (§1), phase, admission class (`active` vs `parked` /
+  `waiting_human` if parked gates release the single active slot), created/updated
+  timestamps, and schema version (#48);
 - artifact refs: proposal path/blob/ref, implementation branch, diff ref or
   chunk manifest, whole-origin ref/hash (working blob/path, db2 `docs` row, or
   explicit artifact payload), review-chunk index refs (`kb_documents` rows if that
@@ -810,7 +857,9 @@ Either way, the durable record holds:
   workspace id/provider (`shared`, `detached`, or `mirror`), dedicated worktree
   path if any, head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs,
   merge SHAs, forge-token/`gh` authority status, and last checked mergeability;
-- the human-gate verdicts, fail reasons, actor/timestamp, and resume action taken.
+- the human-gate verdicts, fail reasons, actor/timestamp, resume action taken,
+  and cost-scope evidence for total-cap accounting, including whether
+  implementation-agent spend is included, unknown, or out of scope (#49).
 
 **Result capture is server-worker-owned, not agent-poll (#10/#12/#18).** The
 done-bar is read from the roundtable run's structured result, but that lives in
@@ -884,6 +933,11 @@ worktree per open pipeline. An optional `roundtable_pipeline_gate_ttl_h` (§6) m
 a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
 cleanup (#31) — never an auto-pass.
 
+If v1 keeps the "one active pipeline" limit, this parked state must also say
+whether the gate still occupies that slot or has released it; releasing the slot
+requires branch/PR-level ownership checks so a second active pipeline cannot
+mutate the same recorded branch or PR (#48).
+
 ## §5 The two human gates
 
 At `gate1_pending` / `gate2_pending` the agent **pauses** and surfaces a compact
@@ -935,6 +989,12 @@ cannot complete under policy (auth, protected branch, hung checks), the pipeline
 parks at the gate with the reason surfaced — it never reports a phase advanced
 when the merge did not land.
 
+Because `git_pr` does not currently merge (#50), implementation must either add a
+workspace-aware `git_pr action=merge` or explicitly route the merge through
+`mcp_git_run`/`gh pr merge` with the workspace/forge-token authority. The ledger
+records the executor, command/options, expected head SHA, output, exit code, and
+merge SHA.
+
 ## §6 Config
 
 New keys (full plumbing: `config.h` field, `config_fields.c`,
@@ -956,12 +1016,17 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
 - `roundtable_pipeline_max_cost_usd` — double, cumulative per-phase spend cap;
   0 = unbounded; tripping escalates. **Accumulates across fail-return re-entries of
   the phase; a fail-return never resets it** (#46).
-- `roundtable_pipeline_max_total_cost_usd` — double, cumulative whole-pipeline
-  spend cap across proposal + implementation + PR phases; 0 = unbounded; tripping
-  escalates (#46).
+- `roundtable_pipeline_max_total_cost_usd` — double, cumulative pipeline spend
+  cap; 0 = unbounded; tripping escalates (#46). The implementation must define
+  whether this is roundtable-child-run cost only or includes normal implementation
+  agent spend via token/cost accounting (#49); unknown in-scope implementation
+  cost blocks claiming the cap is satisfied.
 - `roundtable_pipeline_gate_ttl_h` — int hours, **default 0 (no expiry)**; >0 moves
   a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
   cleanup (#31), never an auto-pass (#47).
+- `roundtable_pipeline_parked_releases_slot` — bool, default chosen by
+  implementation policy; if true, a parked human gate releases the single active
+  pipeline admission slot while retaining branch/PR ownership guards (#48).
 - `roundtable_pipeline_unknown_context_tokens` — int, conservative fallback chunk
   input budget used only when a panel participant's context window cannot be
   resolved; alternatively the implementation may make unknown context a hard
@@ -1029,6 +1094,9 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **Hard:** workspace-aware git/forge authority for PR create/merge and diff
   capture. Pipeline git/gh operations must route through Aimee's git tools or
   workspace provider so shared, detached, and mirror workspaces behave consistently.
+- **Hard for merge:** a pass→merge executor. `git_pr` can create/view/edit/check
+  PRs and report merge status, but it does not merge today; add `git_pr merge` or
+  route `gh pr merge` through `mcp_git_run` with captured evidence (#50).
 - **Hard if exposing HTTP:** route namespace selection. `GET /v1/pipeline/status`
   already belongs to the KB/corpus ingest pipeline, so roundtable-authoring routes
   must use a distinct namespace or remain CLI/MCP-only in v1 (#45).
@@ -1061,8 +1129,8 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   git/PR surface.
 - **P3 — Human gates + fail-return edges** end to end, with the durable digest,
   PR/worktree drift validation through the workspace-aware git surface,
-  mergeability/auth checks, and reason-to-brief feedback. This closes the full
-  loop.
+  mergeability/auth checks, an explicit merge executor (#50), parked-gate admission
+  policy (#48), and reason-to-brief feedback. This closes the full loop.
 - **P4 — Config surface** for all keys + generated docs + tests (lands with the
   phase that first reads each key, not deferred).
 
@@ -1217,10 +1285,22 @@ ledger) before the full idea→merge pipeline of P2/P3.
   the phase; the per-phase cap continues from its prior total (does not reset), and
   a whole-pipeline cap trips across proposal + implementation + PR phases, each
   escalating rather than auto-passing.
+- **Total cost accounting scope (#49)** — run a pipeline with implementation-agent
+  work between review phases; assert the total cap either explicitly excludes that
+  spend (roundtable-only naming/contract) or includes it from token/cost accounting,
+  and unknown in-scope implementation cost prevents claiming the cap is satisfied.
 - **Parked-gate resource release + TTL (#47)** — at a gate, the review-scoped index
   is dropped and correctly re-ingested from the origin on resume (same content
   hash, retrieval still works); with a TTL set, an unanswered gate moves to
   `abandoned` with child-run-stop + cleanup, never an auto-pass.
+- **Parked-gate admission (#48)** — with one pipeline parked at a gate, start a
+  second pipeline only if the selected policy releases the active slot; either way,
+  branch/PR ownership prevents two active/restarted runs from mutating the same
+  recorded branch or PR.
+- **Merge executor contract (#50)** — pass a gate with a mergeable PR and assert
+  the pipeline uses either `git_pr action=merge` or an explicitly authorized
+  `mcp_git_run`/`gh pr merge`, records expected head SHA/output/exit code/merge
+  SHA, and does not advance when the command fails or merges a different head.
 
 ## §11 Non-goals (v1)
 
@@ -1237,7 +1317,11 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - A fully autonomous, gate-less pipeline — the two human gates are mandatory by
   design; "configurable max passes" bounds cost, it does not remove the human.
 - Engine changes to the roundtable. The pipeline is strictly on top.
-- Multi-proposal/parallel-pipeline scheduling (one pipeline run at a time in v1).
+- Multi-proposal/parallel-pipeline scheduling beyond the explicit parked-gate
+  admission rule (#48). v1 may allow many parked/waiting-human rows only if they
+  do not count as active and branch/PR ownership prevents mutation overlap; it
+  still permits at most one active drafting/review/implementing runner unless a
+  later proposal adds scheduling.
 
 ## §12 Open questions
 
@@ -1253,6 +1337,11 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Who is the driving agent at the gate?** When paused at a human gate across
   sessions, does a fresh agent resume from the ledger automatically, or does the
   human re-invoke `aimee pipeline resume <id>`?
+- **Parked-gate admission:** does a human gate release the single active pipeline
+  slot (`roundtable_pipeline_parked_releases_slot=true`) or block new authoring
+  runs until answered/abandoned?
+- **Cost scope:** is `roundtable_pipeline_max_total_cost_usd` roundtable-only, or
+  does it include normal implementation-agent spend via token/cost accounting?
 - **Per-phase config:** do the proposal and PR phases want independent done-bars /
   ceilings by default, or one shared set with optional overrides?
 - **DRAFT seeding:** does the `drafting` step take only the idea, or also a

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 sixteenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 seventeenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -604,6 +604,25 @@ codebase.
     merge as already covered hides a build gap at the most important state
     transition. **Resolved in §5, §8, §9, and §10.**
 
+## PR #183 seventeenth review — reuse the cost-accounting ledger; correct the merge claim
+
+Two follow-ons from the sixteenth review's own resolutions.
+
+51. **Implementation-agent spend (#49) should consume the cost-accounting
+    proposal's ledger, not invent parallel accounting.** `ingress-cost-accounting-and-optimizations.md`
+    (the in-flight #180/#185 work) builds a db2 `usage_ledger` (`src/db2/usage_ledger.c`)
+    + a typed `/v1/usage/*` surface that already records per-turn agent cost. The
+    whole-pipeline cost cap's *implementation* component must read from that ledger
+    (the same pattern the ingress-compression proposal uses to cede cache work to
+    the cost proposal), marking implementation cost **incomplete evidence** when the
+    ledger has no row yet — never a second cost-accounting path. If that ledger has
+    not landed, the cap is scoped to roundtable child-run cost only
+    (`…_max_roundtable_cost_usd`) and says so, rather than silently summing a subset.
+    **Resolved in §3, §6, and §8.**
+
+(The What-exists table is also corrected here: PR **merge** is *not* a `git_pr`
+action today — #50 — so it is listed as a gap, not as existing.)
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -631,7 +650,8 @@ codebase.
 | Multi-round panel, DRAFT + REVIEW modes, deterministic convergence, dedup, severity, cost/deadline bounds | **exists** (engine, `testing`) |
 | Directed review (brief), structured items returned, `ensemble_review` MCP tool (review mode) | **in tree on `testing`** (`mcp_tools.c:610`, `handle_mcp_ensemble_review`); verify result contract (§8) |
 | A **draft**-capable callable path | **gap** — `ensemble_review` forces review mode; DRAFT needs `/v1/delegate/roundtable --mode draft` or a draft MCP sibling (§8) |
-| PR open / merge, diff capture | **exists via workspace-aware git/PR tools** (`git_pr`, `mcp_git_run`, `gh`/`git` underneath) |
+| PR **open** / diff capture | **exists** (`git_pr` create/view/edit, `mcp_git_run`) |
+| PR **merge** | **gap — `git_pr` has no merge action** (only `merge_status`); needs a merge executor (#50, §5) |
 | Outer REVIEW⇄revise loop, done-bar evaluation, pass ceiling + escalation | **net-new** (§3) |
 | The two human gates + the two fail-return edges | **net-new** (§5) |
 | Persisted, resumable roundtable pipeline ledger (hybrid state) | **net-new or explicit DB1 pipeline extension** (§4) |
@@ -1017,10 +1037,12 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
   0 = unbounded; tripping escalates. **Accumulates across fail-return re-entries of
   the phase; a fail-return never resets it** (#46).
 - `roundtable_pipeline_max_total_cost_usd` — double, cumulative pipeline spend
-  cap; 0 = unbounded; tripping escalates (#46). The implementation must define
-  whether this is roundtable-child-run cost only or includes normal implementation
-  agent spend via token/cost accounting (#49); unknown in-scope implementation
-  cost blocks claiming the cap is satisfied.
+  cap; 0 = unbounded; tripping escalates (#46). Implementation-phase spend is read
+  from the **cost-accounting proposal's `usage_ledger` / `/v1/usage/*`** (#51), not
+  a second accounting path; where that ledger has no row yet, implementation cost is
+  marked **incomplete evidence** and the cap cannot be claimed satisfied. If that
+  ledger has not landed, the cap is scoped to roundtable child-run cost only
+  (a `…_max_roundtable_cost_usd` spelling) and says so (#49).
 - `roundtable_pipeline_gate_ttl_h` — int hours, **default 0 (no expiry)**; >0 moves
   a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
   cleanup (#31), never an auto-pass (#47).
@@ -1100,6 +1122,9 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **Hard if exposing HTTP:** route namespace selection. `GET /v1/pipeline/status`
   already belongs to the KB/corpus ingest pipeline, so roundtable-authoring routes
   must use a distinct namespace or remain CLI/MCP-only in v1 (#45).
+- **Soft:** the cost-accounting proposal's `usage_ledger` / `/v1/usage/*` for
+  whole-pipeline cost that includes implementation-phase spend (#51). Absent it,
+  the total cap is roundtable-child-run-cost only and says so (#49).
 - **Soft:** the `git diff` range helper (agent-directed-pr-review P2) for the PR
   phase input; otherwise the pipeline captures the diff through the
   workspace-aware git surface.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 fourth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 fifth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -222,6 +222,51 @@ to make it concrete.
     if capture keeps failing across re-runs (a real fault), never on the first
     miss. **Resolved in §3 and §4.**
 
+## PR #183 fifth review — pass identity, worker capture, and replay safety
+
+The fourth review picked the right Hybrid seam (`op_run_worker_run`), but the
+proposal still needs to define how pipeline pass identity reaches that seam
+safely and how retry accounting stays correct.
+
+20. **`__pipeline_pass_id` is not forwarded by today's `ensemble_review` tool.**
+    `handle_mcp_ensemble_review` currently constructs a fresh body containing only
+    `prompt`, `mode:"review"`, `brief`, `rounds`, and `turns` before calling
+    `server_http_submit_op_run`; unknown caller args are not copied. So the text's
+    "thread `__pipeline_pass_id` into the request body" cannot be implemented
+    from the pipeline unless the callable surface grows a pipeline-owned
+    `pipeline_pass_id` parameter (or `server_http_submit_op_run` gains metadata
+    parameters) and forwards it deliberately. **Resolved in §4, §8, and §10.**
+21. **Pass IDs must be server-owned and state-validated.** A user-facing MCP arg
+    named `__pipeline_pass_id` would let any caller with `CAP_DELEGATE` try to
+    write arbitrary pass rows. The pipeline surface should accept a normal
+    `pipeline_pass_id` only from the pipeline orchestrator/gate command, validate
+    that the pass belongs to an active roundtable pipeline in the expected state,
+    and then inject the private `__pipeline_pass_id` internally. Raw
+    double-underscore fields remain server-private. **Resolved in §4, §8, and
+    §10.**
+22. **Capture only works on the async op-run path.** The worker capture seam is
+    present for `/v1/delegate/roundtable` and `server_http_submit_op_run`, but a
+    direct synchronous `server_dispatch("delegate.roundtable")` call bypasses
+    `op_run_worker_run`. The pipeline must require async op-run submission for
+    both DRAFT and REVIEW passes, or add an equivalent capture hook to any direct
+    path it uses. **Resolved in §2, §4, §8, and §10.**
+23. **A stable pass id still needs per-attempt rows.** Re-running a lost pass under
+    the same `pipeline_pass_id` is correct for loop accounting, but the ledger must
+    preserve each attempt (`attempt_no`, `run_id`, status, terminal flags, result
+    hash, captured/lost marker, cost if known). Otherwise a retry overwrites the
+    evidence needed to explain overhead and repeated capture failures. **Resolved
+    in §4 and §10.**
+24. **Replay is idempotent only if the artifact input is hash-pinned.** A lost
+    result should be re-run over the *same* proposal/diff. Before retrying, the
+    pipeline must compare the current artifact/diff hash to the pass input hash;
+    if it changed, the old pass is stale and a new pass id is required. **Resolved
+    in §4 and §10.**
+25. **The worker must persist failed/cancelled terminal states too.** Done-bar
+    evaluation needs completed results, but durable diagnostics need failed,
+    cancelled, malformed, and capture-failed attempts as well. The capture hook
+    must write terminal status for every op-run outcome, not just successful
+    roundtable JSON. **Resolved in §4 and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -300,15 +345,19 @@ Both phases use the **same** engine; they differ only in input and brief.
   skeleton into the full proposal across the author-revise passes. The full
   proposal lives in the working file/PR, not in the DRAFT artifact; REVIEW reviews
   the file (or chunked sections for large proposals, like the diff path below),
-  not the truncated artifact. The brief carries the proposal's *goal*, the
-  *invariants* it must satisfy, and the human's seed *questions*.
+  not the truncated artifact. Pipeline-owned DRAFT and REVIEW calls must use the
+  async op-run path so server-worker result capture runs. The brief carries the
+  proposal's *goal*, the *invariants* it must satisfy, and the human's seed
+  *questions*.
 - **PR phase (A).** Input = unified diff (normally `git diff <base>...HEAD`;
   aimee has no PR-fetch and needs none — `agent-directed-pr-review` §6). REVIEW
   mode only; the agent applies fixes between passes. For large diffs, the driving
   agent must pass an artifact file/path or chunked diff slices rather than an
   unbounded inline string, and the ledger stores the diff ref plus content hash.
-  The brief carries the *fixes just applied*, the *invariants* the change must
-  not break, and the *questions* the author is unsure about.
+  Pipeline-owned PR reviews use the async op-run path with validated pass
+  metadata, not a direct synchronous roundtable dispatch. The brief carries the
+  *fixes just applied*, the *invariants* the change must not break, and the
+  *questions* the author is unsure about.
 
 The brief is **open-mandate** (agent-directed-pr-review §2): it weights attention
 and seeds the questions, but every reviewer is still told to report any blocking
@@ -395,6 +444,9 @@ Either way, the durable record holds:
 - per-pass history: each outer pass's child roundtable `run_id`, status,
   `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`, `best_round`,
   result hash, and any payload/chunk refs;
+- per-attempt history under each pass: `attempt_no`, child `run_id`, submitted and
+  terminal timestamps, captured/lost status, terminal flags, result hash, and cost
+  if the result was available;
 - repository/worktree state: repo root, remote, base branch, head branch,
   workspace id/provider (`shared`, `detached`, or `mirror`), dedicated worktree
   path if any, head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs,
@@ -408,20 +460,30 @@ oldest-reused) and non-durable. Capture must not depend on the *driving agent*
 being awake to poll — under Hybrid the agent owns the loop, not the child-run
 completion path. Instead, the worker that **already runs the roundtable** owns
 capture: `op_run_worker_run` (`server_http_routes.inc:339`) executes the async
-`delegate.roundtable` and calls `openai_runs_store_finalize` at terminal. Thread a
-`__pipeline_pass_id` into the request body the same way `__run_id` is injected
-today (`:419`) and extend that finalize path to **also persist the structured pass
-result** (items + severities + `count`, `converged`, validity flags,
-`items_round`, `artifact_round`, counts, `cost_usd`, `rounds_run`) into the DB1
-ledger row before the run record can be evicted. The `/v1/runs` id is retained
-only as a historical pointer; the ledger row is the source of truth for the
-done-bar and the gate digest.
+`delegate.roundtable` and calls `openai_runs_store_finalize` at terminal. The
+pipeline creates a DB1 pass row first, then the pipeline-owned callable surface
+forwards a normal `pipeline_pass_id` that is validated against the active
+pipeline/pass state and injected internally as private `__pipeline_pass_id` (raw
+double-underscore fields are not user API). `server_http_submit_op_run` /
+`rh_dispatch_op_async` must preserve that private metadata alongside the existing
+`__run_id` injection (`:419`). Extend the finalize path, preferably through a
+narrow op-run-finalize hook rather than hard-coding roundtable ledger writes into
+generic HTTP routing, to **also persist the structured pass result** (items +
+severities + `count`, `converged`, validity flags, `items_round`,
+`artifact_round`, counts, `cost_usd`, `rounds_run`) into the DB1 ledger row before
+the run record can be evicted. Failed, cancelled, malformed, and capture-failed
+terminal states are recorded too. The `/v1/runs` id is retained only as a
+historical pointer; the ledger row is the source of truth for the done-bar and the
+gate digest.
 
-If a result is still not captured (a genuine fault), the pass is marked
-`lost_result` and the pipeline **auto re-runs the review pass** under a stable
-`pipeline_pass_id` (idempotent over the same artifact; bounded by the pass ceiling
-and cost cap, the lost attempt booked as overhead). A human is involved only if
-capture keeps failing across re-runs (#19) — never on a single transient miss.
+If a result is still not captured (a genuine fault), the attempt is marked
+`lost_result` and the pipeline **auto re-runs the review pass** under the same
+stable `pipeline_pass_id` but a new `attempt_no`/`run_id`. That retry is idempotent
+only if the stored artifact/diff hash still matches; if the input changed, the old
+pass is stale and the pipeline starts a new pass instead. Retries are bounded by
+the pass ceiling and cost cap, with lost attempts booked as overhead when cost is
+known. A human is involved only if capture keeps failing across re-runs (#19) —
+never on a single transient miss.
 
 This makes the human gate a durable checkpoint: `status` shows where it is and
 the evidence; `gate pass|fail --reason "…"` records the verdict and resumes the
@@ -532,6 +594,11 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **Hard:** durable DB1 checkpointing for the roundtable pipeline. `/v1/runs`
   remains a child-run polling surface only because its store is bounded and
   non-durable.
+- **Hard:** a pipeline-owned async submission contract. The existing
+  `ensemble_review` MCP surface does not forward arbitrary metadata, so the
+  pipeline needs an explicit `pipeline_pass_id`/attempt submission path that
+  validates state and injects private `__pipeline_pass_id` before
+  `op_run_worker_run` finalizes the child run.
 - **Hard:** workspace-aware git/forge authority for PR create/merge and diff
   capture. Pipeline git/gh operations must route through Aimee's git tools or
   workspace provider so shared, detached, and mirror workspaces behave consistently.
@@ -544,12 +611,13 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 
 - **P0 — Ledger + states + namespace decision.** Choose the DB shape
   (`roundtable_pipeline_runs` tables vs explicit migration of DB1 `pipelines`),
-  add the state enum/transitions, artifact refs/hashes, child run references, and
-  the CLI/MCP/HTTP namespace decision (`pipeline` vs `autopilot` extension). Wire
-  the server-worker capture seam: thread `__pipeline_pass_id` and extend
-  `op_run_worker_run`'s finalize path to persist the terminal structured result to
-  the ledger (#18). No loop yet; states/gates settable manually. Mergeable alone,
-  with restart tests.
+  add the state enum/transitions, artifact refs/hashes, pass/attempt rows, child
+  run references, and the CLI/MCP/HTTP namespace decision (`pipeline` vs
+  `autopilot` extension). Wire the server-worker capture seam: validate
+  `pipeline_pass_id`, inject private `__pipeline_pass_id`, preserve it through
+  async enqueue, and extend `op_run_worker_run`'s finalize path or hook to persist
+  every terminal attempt to the ledger (#18/#20-#25). No loop yet; states/gates
+  settable manually. Mergeable alone, with restart tests.
 - **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
   `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
   escalation, the echo guard. Drives the PR phase first (single mode, simplest).
@@ -585,10 +653,24 @@ ledger) before the full idea→merge pipeline of P2/P3.
   result is already in DB1 because `op_run_worker_run`'s finalize path wrote it
   (keyed by `__pipeline_pass_id`), **with the driving agent killed** for the
   window. The done-bar/digest are unaffected by the evicted `/v1/runs` record.
+- **Pass-id forwarding (#20/#21)** — submit a pipeline-owned `ensemble_review` /
+  draft roundtable pass and assert the private `__pipeline_pass_id` reaches
+  `op_run_worker_run`; an arbitrary user-supplied double-underscore id is rejected
+  or ignored, and a stale/non-owned pass id cannot mutate the ledger.
+- **Async-only capture (#22)** — prove pipeline-owned DRAFT and REVIEW calls go
+  through async op-run capture; any direct synchronous roundtable dispatch is
+  either forbidden for pipeline passes or has an equivalent capture hook.
 - **Lost-result re-run (#19)** — simulate a genuine capture fault: the pass is
   marked `lost_result` and auto re-runs under the **same `pipeline_pass_id`** (no
   double-counted pass; lost attempt booked as overhead), escalating to the human
   only after repeated capture failures, never on the first miss.
+- **Attempt accounting (#23/#25)** — successful, failed, cancelled, malformed,
+  capture-failed, and lost attempts all get attempt rows and preserve run IDs,
+  terminal status, flags, result hashes, and known cost without overwriting prior
+  attempts.
+- **Replay hash pinning (#24)** — mutate the proposal/diff between a lost attempt
+  and retry; the pipeline refuses to reuse the old pass id and starts a new pass
+  because the artifact hash changed.
 - **DRAFT skeleton + expansion (#9)** — a DRAFT call returns a skeleton within the
   8 KB cap without truncating mid-structure; the author-revise loop grows it to a
   full proposal in the working file, and REVIEW reviews the file/chunks, not the

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 twelfth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 thirteenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -480,6 +480,34 @@ will check a stale subset — exactly how #38 happened in the first place.
     trips each individual flag, so a newly added flag can never be honored by some
     sites and silently ignored by others. **Resolved in §3, §4, and §10.**
 
+## PR #183 thirteenth review — per-pass version freshness and fail-return PR identity
+
+No new feedback prompted this pass; a fresh read of the loop's *outer* mechanics
+(the part the inner-engine reviews never reached) found two real holes.
+
+42. **Each revise pass re-ingests; the review-scoped index must supersede the
+    prior version, or retrieval serves stale spans.** Every author-revise / agent-fix
+    pass produces a *new* artifact version. The orchestrator-assembled retrieval
+    (#37) pulls cross-chunk spans from the review-scoped db2 index, so that index
+    must be re-ingested per pass **and the prior version's chunks superseded** before
+    the new pass retrieves — otherwise #37 serves spans from an earlier revision: a
+    fixed bug reappears, a deleted section is still "found," a renamed symbol
+    resolves to its old name. Each pass pins retrieval to its own artifact content
+    hash; the assembly manifest (#39) records that version; chunks from superseded
+    versions are never retrieval-eligible for the current pass. Review-scoped cleanup
+    (#35) therefore runs **per version**, not only at pipeline end. **Resolved in §2,
+    §3, §4, and §10.**
+43. **Fail-return must update the existing PR, not open a duplicate.** The fail
+    edges (gate1 → `proposal_review`, gate2 → `implementing`) revise an artifact
+    whose PR is already open and recorded in the ledger. The revise loop must push
+    to the **same recorded branch/PR**, updating it in place — never open a second
+    PR for the same pipeline phase. On re-entry the orchestrator validates the
+    recorded branch/PR still exists and targets `testing` (the §5 drift check),
+    pushes the revision, and the human gate re-evaluates the **updated** PR with a
+    fresh review digest. A fail-return that orphaned the prior PR or opened a
+    duplicate is a hard error, not a silent second PR. **Resolved in §1, §5, and
+    §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -536,14 +564,16 @@ Transitions:
    moves to `gate1_pending`.
 3. **gate1_pending** — human gate 1 (§5). **pass** → merge proposal PR, move to
    `implementing`. **fail** → the human's reason is appended to the brief and the
-   state returns to `proposal_review`.
+   state returns to `proposal_review`, which re-revises and **pushes to the same
+   recorded proposal branch/PR** (never a duplicate, #43).
 4. **implementing** — the agent implements the merged proposal on a dedicated
    implementation branch/worktree (normal coding; not a roundtable activity),
    opens the implementation PR, captures the diff.
 5. **pr_review** — the §3 outer loop in REVIEW mode over the diff: REVIEW,
    agent-fix, re-REVIEW, until the done-bar.
 6. **gate2_pending** — human gate 2 (§5). **pass** → merge the implementation PR,
-   move to `done`. **fail** → reason → brief, state returns to `implementing`.
+   move to `done`. **fail** → reason → brief, state returns to `implementing`,
+   which pushes the fix to the **same recorded implementation branch/PR** (#43).
 
 Every state is durable (§4) so a human gate can be answered hours or days later,
 across a server restart or a new agent session.
@@ -579,7 +609,10 @@ Both phases use the **same** engine; they differ only in input and brief.
   inline unit — panelists are not assumed to retrieve or read files (#32/#35/#37).
   Each assembled unit records an assembly manifest with selected span refs/ranges/
   hashes, token/byte budget, and omitted candidates; required omissions block the
-  aggregate instead of being hidden (#39).
+  aggregate instead of being hidden (#39). **Every revise pass re-ingests the new
+  artifact version and supersedes the prior version's review-scoped chunks** (#42),
+  so retrieval is always pinned to the current pass's content hash and never serves
+  a span from an earlier revision.
   Pipeline-owned PR reviews use the async op-run path with validated pass
   metadata, not a direct synchronous roundtable dispatch. The brief carries the
   *fixes just applied*, the *invariants* the change must not break, and the
@@ -950,6 +983,14 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Loop correctness** — a fixture proposal/diff with N seeded blocking issues:
   the loop reaches the done-bar only after all N are resolved; the digest counts
   match the engine items; the ledger records each pass's `run_id`/cost.
+- **Per-pass version freshness (#42)** — revise an artifact so a span that existed
+  in pass *k* is deleted/renamed in pass *k+1*; the pass *k+1* aggregate retrieval
+  returns only the new version's spans (pinned to its content hash), never the
+  superseded chunk, and superseded review-scoped chunks are cleaned up.
+- **Fail-return updates the same PR (#43)** — fail a gate, re-revise, and assert
+  the revision is pushed to the **recorded** branch/PR (head SHA advances, PR
+  number unchanged); no second PR is opened, and an orphaned/duplicate PR is a hard
+  error.
 - **DRAFT/REVIEW callable split** — the proposal phase invokes a draft-capable
   roundtable path that returns an `artifact`; the review phases invoke the
   review-capable path that returns structured items for the done-bar.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 third review)
+- **Date:** 2026-06-11 (revised post-PR-#183 fourth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -188,6 +188,40 @@ current live-tool/workspace surfaces:
     terminal result capture, and pipeline orchestration. **Resolved in the
     relationship table and §8.**
 
+## PR #183 fourth review — reconciling capture ownership with the Hybrid decision
+
+The third review correctly demanded orchestrator-owned result capture (#12), but
+its wording ("in the same completion path") implies a *server-side* orchestrator,
+which collides with the chosen **Hybrid** architecture (the external agent drives
+the loop; only state is persisted). Two items resolve that, and a real seam exists
+to make it concrete.
+
+18. **"Orchestrator-owned capture" is unresolved against Hybrid — name the seam.**
+    Under Hybrid the driving agent owns the *loop*, but it cannot be "in the same
+    completion path" as a child run; if capture depends on the agent polling, #10's
+    eviction race is still live whenever the agent is asleep or at a gate. The
+    resolution is **not** to promote the agent to a server-side orchestrator (that
+    is the architecture the user did *not* pick). It is to use the worker that
+    *already runs the roundtable*: `op_run_worker_run`
+    (`server_http_routes.inc:339`) executes the async `delegate.roundtable` and
+    calls `openai_runs_store_finalize` at terminal. Thread a `__pipeline_pass_id`
+    into the request body exactly as `__run_id` is injected today (`:419`), and
+    extend that finalize path to **also write the structured terminal result into
+    the DB1 pipeline-ledger row**. The agent stays the loop/gate orchestrator; the
+    server worker — which already runs and finalizes the run — closes the capture
+    race durably. This is the genuine Hybrid: agent owns the loop, server owns
+    durable capture of each child run it already executes. **Resolved in §4 and §9.**
+
+19. **`lost_result` should re-run the pass, not escalate to a human.** A capture
+    miss (eviction, restart mid-pass) is an infrastructure hiccup, not a
+    correctness decision that needs a human. The pipeline should **auto re-run the
+    review pass** — it is idempotent over the same artifact; a re-run produces a
+    fresh, valid result reviewing the same input — bounded by the pass ceiling and
+    cost cap, under a **stable `pipeline_pass_id`** so the lost attempt's cost is
+    booked as overhead without double-counting the pass. Escalate to the human only
+    if capture keeps failing across re-runs (a real fault), never on the first
+    miss. **Resolved in §3 and §4.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -367,18 +401,27 @@ Either way, the durable record holds:
   merge SHAs, forge-token/`gh` authority status, and last checked mergeability;
 - the human-gate verdicts, fail reasons, actor/timestamp, and resume action taken.
 
-**Result capture is orchestrator-owned, not lazy (#10/#12).** The done-bar is read from the
-roundtable run's structured result, but that lives in `/v1/runs` /
-`openai_runs_store`, which is bounded (`OPENAI_RUNS_STORE_MAX 256`, oldest-reused)
-and non-durable. The pipeline orchestrator therefore owns result capture: it
-submits the child run, observes terminal completion, and writes the structured
-pass result (items + severities + `count`, `converged`, validity flags,
-`items_round`, `artifact_round`, counts, `cost_usd`, `rounds_run`) into DB1 in the
-same completion path before any next state transition. If the terminal result
-cannot be captured, the pass is recorded as `lost_result` and the pipeline
-escalates; it never evaluates the done-bar from a missing or later-evicted
-`/v1/runs` record. The `/v1/runs` id is retained only as a historical pointer; the
-ledger row is the source of truth for the done-bar and the gate digest.
+**Result capture is server-worker-owned, not agent-poll (#10/#12/#18).** The
+done-bar is read from the roundtable run's structured result, but that lives in
+`/v1/runs` / `openai_runs_store`, which is bounded (`OPENAI_RUNS_STORE_MAX 256`,
+oldest-reused) and non-durable. Capture must not depend on the *driving agent*
+being awake to poll — under Hybrid the agent owns the loop, not the child-run
+completion path. Instead, the worker that **already runs the roundtable** owns
+capture: `op_run_worker_run` (`server_http_routes.inc:339`) executes the async
+`delegate.roundtable` and calls `openai_runs_store_finalize` at terminal. Thread a
+`__pipeline_pass_id` into the request body the same way `__run_id` is injected
+today (`:419`) and extend that finalize path to **also persist the structured pass
+result** (items + severities + `count`, `converged`, validity flags,
+`items_round`, `artifact_round`, counts, `cost_usd`, `rounds_run`) into the DB1
+ledger row before the run record can be evicted. The `/v1/runs` id is retained
+only as a historical pointer; the ledger row is the source of truth for the
+done-bar and the gate digest.
+
+If a result is still not captured (a genuine fault), the pass is marked
+`lost_result` and the pipeline **auto re-runs the review pass** under a stable
+`pipeline_pass_id` (idempotent over the same artifact; bounded by the pass ceiling
+and cost cap, the lost attempt booked as overhead). A human is involved only if
+capture keeps failing across re-runs (#19) — never on a single transient miss.
 
 This makes the human gate a durable checkpoint: `status` shows where it is and
 the evidence; `gate pass|fail --reason "…"` records the verdict and resumes the
@@ -502,9 +545,11 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **P0 — Ledger + states + namespace decision.** Choose the DB shape
   (`roundtable_pipeline_runs` tables vs explicit migration of DB1 `pipelines`),
   add the state enum/transitions, artifact refs/hashes, child run references, and
-  the CLI/MCP/HTTP namespace decision (`pipeline` vs `autopilot` extension). Also
-  choose the orchestrator-owned terminal result capture path. No loop yet;
-  states/gates settable manually. Mergeable alone, with restart tests.
+  the CLI/MCP/HTTP namespace decision (`pipeline` vs `autopilot` extension). Wire
+  the server-worker capture seam: thread `__pipeline_pass_id` and extend
+  `op_run_worker_run`'s finalize path to persist the terminal structured result to
+  the ledger (#18). No loop yet; states/gates settable manually. Mergeable alone,
+  with restart tests.
 - **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
   `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
   escalation, the echo guard. Drives the PR phase first (single mode, simplest).
@@ -535,11 +580,15 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Run-store separation** — kill/restart after child `/v1/runs` records are gone;
   the pipeline still resumes from DB1 and marks missing child run details as
   historical evidence, not lost state.
-- **Orchestrator-owned result capture (#10/#12)** — drive ≥256 sibling runs (or
-  force eviction) between a child run completing and an agent polling it; the pass
-  result is already in DB1 because capture happened in the orchestrator's terminal
-  completion path. Simulate a missed terminal result and assert the pass becomes
-  `lost_result`, not done.
+- **Server-worker result capture (#10/#12/#18)** — drive ≥256 sibling runs (or
+  force eviction) between a child run completing and any agent poll; the pass
+  result is already in DB1 because `op_run_worker_run`'s finalize path wrote it
+  (keyed by `__pipeline_pass_id`), **with the driving agent killed** for the
+  window. The done-bar/digest are unaffected by the evicted `/v1/runs` record.
+- **Lost-result re-run (#19)** — simulate a genuine capture fault: the pass is
+  marked `lost_result` and auto re-runs under the **same `pipeline_pass_id`** (no
+  double-counted pass; lost attempt booked as overhead), escalating to the human
+  only after repeated capture failures, never on the first miss.
 - **DRAFT skeleton + expansion (#9)** — a DRAFT call returns a skeleton within the
   8 KB cap without truncating mid-structure; the author-revise loop grows it to a
   full proposal in the working file, and REVIEW reviews the file/chunks, not the

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,14 +2,16 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11
+- **Date:** 2026-06-11 (revised post-PR-#183 review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
-- **Scope:** a driving-agent orchestration spec + a thin persisted pipeline
-  ledger. Net-new code is small: a `pipeline_run` ledger (DB1 or a `/v1/runs`
-  sibling), config keys (`src/headers/config.h`, `src/config.c`,
-  `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), and the
+- **Scope:** a driving-agent orchestration spec + a durable persisted pipeline
+  ledger. Net-new code is small: a namespaced `roundtable_pipeline_runs` ledger
+  or an explicit migration/extension of the existing DB1 `pipelines` schema
+  (not the transient `/v1/runs` live store), config keys
+  (`src/headers/config.h`, `src/config.c`, `src/config_fields.c`,
+  `src/config_sections.c`, `src/config_save.c`), and the
   driving-agent runbook/skill. It **depends on** the roundtable engine (already on
   `testing`) and on `agent-directed-pr-review` P1a–c (the brief + structured items
   + the `ensemble_review` MCP tool). It reuses `gh`/`git` for PR/merge. No changes
@@ -40,6 +42,50 @@ The done-bar is a *correctness* condition, not a pass budget; the configurable
 pass ceiling is only an operator cost-backstop that **escalates to the human**
 when hit without reaching the done-bar (it never auto-passes a not-done artifact).
 
+## PR #183 review — gaps and how they are resolved
+
+The initial proposal is directionally aligned with the roundtable work, but a
+review against the current tree found several implementation gaps that need to be
+part of the proposal rather than left to interpretation:
+
+1. **`pipeline_run` cannot be a blank-slate name.** Aimee already has a durable
+   DB1 `pipelines` table and `autopilot` pipeline handler
+   (`db1_pipeline_t`, `handle_autopilot`) with `start/status/list/cancel/resume`
+   style actions. It tracks a narrow plan/job pipeline, not proposal artifacts,
+   PR refs, pass history, gate verdicts, or GitHub state. The proposal must either
+   extend that schema deliberately or create a namespaced
+   `roundtable_pipeline_runs` table; it must not introduce an ambiguous second
+   "pipeline" surface. **Resolved in §4, §5, §9, §10, and §12.**
+2. **`/v1/runs` is not a durable checkpoint store.** `openai_runs_store` is an
+   in-process live store, bounded to 256 records, oldest-reused, and not durable
+   across restarts. It is suitable for child roundtable/op-run IDs, not for a
+   human gate that can sit for hours or days. **Resolved in §4, §8, §9, and §12.**
+3. **The CLI/API surface is underspecified.** The text proposes
+   `aimee pipeline status|gate`, but the existing callable pipeline surface is
+   the `autopilot` MCP handler and does not have a gate action. The proposal must
+   define whether this is a new first-class CLI/MCP/HTTP route or an extension of
+   `autopilot`, with route tests and no name collision. **Resolved in §5, §9,
+   and §10.**
+4. **GitHub/worktree state must be resumable too.** Reusing `gh`/`git` is fine,
+   but the ledger needs enough branch, commit, remote, PR, mergeability, and auth
+   assumptions to detect drift when a gate resumes in a later session. **Resolved
+   in §4, §5, and §10.**
+5. **Large artifacts cannot be blindly inlined.** Proposal markdown and PR diffs
+   can exceed MCP/op-run payload and snapshot limits. The ledger should store
+   artifact refs plus content hashes and pass diffs/proposals by path, blob, or
+   chunked capture where needed, not unbounded text blobs. **Resolved in §2, §4,
+   §10, and §11.**
+6. **Panel diversity validation must resolve agent configs.** The configured
+   `ensemble.reference_models` are agent/model names; provider diversity is not
+   the same as string uniqueness. The validator must resolve each participant's
+   provider/model at runtime before warning or passing. **Resolved in §7 and
+   §10.**
+7. **DRAFT and REVIEW do not use the same callable tool today.** The current
+   `ensemble_review` MCP bridge forces review mode; the DRAFT phase should call
+   the existing roundtable route/CLI with `mode=draft` (or add an explicit
+   draft-capable MCP surface), while REVIEW loops use `ensemble_review`.
+   **Resolved in §1, §2, and §8.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -49,12 +95,14 @@ when hit without reaching the done-bar (it never auto-passes a not-done artifact
   `items[]` with a corroboration `count`, plus `answered_questions[]` and
   `coverage_gaps[]`), a deterministic `converged` predicate, `best_round`, and
   inherited cost/deadline bounds. **This proposal adds no engine code.**
-- **`agent-directed-pr-review.md` (pending) is the callable surface and a hard
-  dependency.** Its P1a (the **brief**: focus/fixes/invariants/questions, open
-  mandate), P1b (return the structured items to the caller), and P1c (the
-  `ensemble_review` MCP tool over the async run bridge, `CAP_DELEGATE`-gated) are
-  what let the driving agent invoke directed review mid-task and read back
-  actionable items. This pipeline is the *orchestration on top* of that surface.
+- **`agent-directed-pr-review.md` (pending) is the callable surface and remains a
+  hard dependency for the final contract.** The current tree already exposes an
+  `ensemble_review` MCP entry that queues `delegate.roundtable`, but this
+  pipeline still depends on that proposal's P1 contract being complete: P1a (the
+  **brief**: focus/fixes/invariants/questions, open mandate), P1b (return the
+  structured items to the caller in a stable shape), and P1c (the MCP/async run
+  bridge, `CAP_DELEGATE`-gated). This pipeline is the *orchestration on top* of
+  that surface.
 - **`agent-roundtable-collaborative-drafting.md` (pending residual)** lists
   deeper convergence/economics tests; this proposal's validation (§10) exercises
   exactly those at pipeline scale.
@@ -64,11 +112,11 @@ when hit without reaching the done-bar (it never auto-passes a not-done artifact
 | Capability | Status |
 |---|---|
 | Multi-round panel, DRAFT + REVIEW modes, deterministic convergence, dedup, severity, cost/deadline bounds | **exists** (engine, `testing`) |
-| Directed review (brief), structured items returned, `ensemble_review` MCP tool | **dependency** (agent-directed-pr-review P1a–c) |
+| Directed review (brief), structured items returned, `ensemble_review` MCP tool | **partial in tree; dependency on final agent-directed-pr-review P1a–c contract** |
 | PR open / merge, diff capture (`git diff`) | **exists** (`gh`, `git`) |
 | Outer REVIEW⇄revise loop, done-bar evaluation, pass ceiling + escalation | **net-new** (§3) |
 | The two human gates + the two fail-return edges | **net-new** (§5) |
-| Persisted, resumable pipeline ledger (hybrid state) | **net-new** (§4) |
+| Persisted, resumable roundtable pipeline ledger (hybrid state) | **net-new or explicit DB1 pipeline extension** (§4) |
 | Config: done-bar, pass ceiling, outer cost cap | **net-new** (§6) |
 
 ## §1 The pipeline state machine
@@ -80,8 +128,9 @@ States (persisted in the §4 ledger):
 Transitions:
 
 1. **drafting** — DRAFT roundtable turns the human idea (+ any seed brief) into a
-   first proposal artifact. One `ensemble_review`/roundtable call in
-   `ROUNDTABLE_DRAFT` mode; the converged `artifact` becomes the working draft.
+   first proposal artifact. One roundtable call in `ROUNDTABLE_DRAFT` mode
+   (through `/v1/delegate/roundtable` / `aimee delegate roundtable --mode draft`,
+   or an explicit draft-capable MCP surface) produces the working `artifact`.
 2. **proposal_review** — the §3 outer loop: REVIEW the draft, author-revise from
    the items, re-REVIEW, until the done-bar (§3). Then the agent opens the proposal
    PR (`gh pr create`, base `testing`, per repo flow) and moves to `gate1_pending`.
@@ -107,11 +156,13 @@ Both phases use the **same** engine; they differ only in input and brief.
   `proposal_review`. The brief carries the proposal's *goal*, the *invariants* it
   must satisfy, and the human's seed *questions*. Author-revise between REVIEW
   passes is done by the driving agent (it is the proposal's author).
-- **PR phase (A).** Input = unified diff (the agent pastes `git diff
-  <base>...HEAD`; aimee has no PR-fetch and needs none — `agent-directed-pr-review`
-  §6). REVIEW mode only; the agent applies fixes between passes. The brief carries
-  the *fixes just applied*, the *invariants* the change must not break, and the
-  *questions* the author is unsure about.
+- **PR phase (A).** Input = unified diff (normally `git diff <base>...HEAD`;
+  aimee has no PR-fetch and needs none — `agent-directed-pr-review` §6). REVIEW
+  mode only; the agent applies fixes between passes. For large diffs, the driving
+  agent must pass an artifact file/path or chunked diff slices rather than an
+  unbounded inline string, and the ledger stores the diff ref plus content hash.
+  The brief carries the *fixes just applied*, the *invariants* the change must
+  not break, and the *questions* the author is unsure about.
 
 The brief is **open-mandate** (agent-directed-pr-review §2): it weights attention
 and seeds the questions, but every reviewer is still told to report any blocking
@@ -140,7 +191,7 @@ read from real engine fields (`roundtable_result_t`):
 
 The driving agent computes the bar from the structured items
 (agent-directed-pr-review P1b); it never re-judges convergence itself — it trusts
-the engine's deterministic `converged`/`review_saturated`.
+the engine's deterministic saturation logic as exposed through `converged`.
 
 **Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
 bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
@@ -163,20 +214,41 @@ escalates to the human rather than silently passing.
 ## §4 Hybrid state — the resumable pipeline ledger
 
 The agent drives the loop, but pipeline state is **persisted** so it survives a
-restart and a human gate can be answered later (the decision). A `pipeline_run`
-record (DB1 table or a `/v1/runs` sibling — §12) holds:
+restart and a human gate can be answered later (the decision). This must be a DB1
+checkpoint surface, not `/v1/runs`: the current `openai_runs_store` is a bounded,
+in-process live store and is not durable across restart. `/v1/runs` IDs are child
+execution handles that may be stored in pass history, never the source of truth
+for the pipeline.
 
-- pipeline id, state (§1), phase, created/updated timestamps;
-- the working artifact (proposal text or PR ref) and the current brief;
-- per-pass history: each outer pass's roundtable `run_id`, `converged`,
-  blocking/suggestion counts, `cost_usd`, `rounds_run`, `best_round`;
-- the PR number(s) and merge SHAs;
-- the human-gate verdicts and fail reasons.
+Aimee already has a durable DB1 `pipelines` table for autopilot-style plan/job
+state (`task`, `status`, `current_phase`, `plan_id`, `job_id`, attempts, and
+classification). That schema is too narrow for this workflow, so implementation
+must choose one explicit path:
 
-This makes the human gate a durable checkpoint: `aimee pipeline status <id>` shows
-where it is and the evidence; `aimee pipeline gate <id> pass|fail --reason "…"`
-records the verdict and resumes the loop. The driving agent reconstructs its
-position from the ledger on any new session.
+- create a namespaced `roundtable_pipeline_runs` table plus child
+  `roundtable_pipeline_passes` / `roundtable_pipeline_gates` tables; or
+- migrate/extend the existing `pipelines` table in a backwards-compatible way,
+  with the old autopilot actions continuing to work.
+
+Either way, the durable record holds:
+
+- pipeline id, state (§1), phase, created/updated timestamps, and schema version;
+- artifact refs: proposal path/blob/ref, implementation branch, diff ref or
+  chunk manifest, and content hashes, not unbounded inline text as the primary
+  representation;
+- the current brief plus compact gate digest;
+- per-pass history: each outer pass's child roundtable `run_id`, status,
+  `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`, `best_round`,
+  result hash, and any payload/chunk refs;
+- repository/worktree state: repo root, remote, base branch, head branch,
+  head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs, merge SHAs,
+  and last checked mergeability;
+- the human-gate verdicts, fail reasons, actor/timestamp, and resume action taken.
+
+This makes the human gate a durable checkpoint: `status` shows where it is and
+the evidence; `gate pass|fail --reason "…"` records the verdict and resumes the
+loop. The driving agent reconstructs its position from the ledger on any new
+session and validates branch/PR drift before continuing.
 
 ## §5 The two human gates
 
@@ -194,12 +266,30 @@ reason becomes a brief `focus`/`questions` entry for the next loop, and the stat
 returns to the prior review phase. The fail reason is durable in the ledger so the
 re-review is genuinely directed by it.
 
+The command/API surface must be explicit in implementation. The proposal may add
+`aimee pipeline status|gate` as a new first-class CLI/MCP/HTTP surface, or extend
+the existing `autopilot` pipeline handler, but it must not leave two unrelated
+"pipeline" namespaces with different IDs. The gate action is net-new; today's
+autopilot actions cover `start`, `advance`, `status`, `list`, `cancel`, `resume`,
+`link-plan`, and `link-job`, not pass/fail gates.
+
+Before a **pass** can merge or advance, the resumed agent revalidates the stored
+worktree/PR state: the PR still exists, its head SHA matches the ledger or the
+digest is marked stale, the base branch is still the intended target (`testing`),
+the worktree is clean enough for the operation, `gh`/GitHub auth is available,
+and mergeability has not changed underneath the gate. A failed validation returns
+to the relevant review phase or asks the human for a fresh verdict with the stale
+evidence called out.
+
 ## §6 Config
 
 New keys (full plumbing: `config.h` field, `config_fields.c`,
 `config_sections.c`, `config_save.c`, `aimee config get/set/list`, generated docs,
 `test_config`/`test_config_surface`/`test_cmd_config`). Decide nesting
-(`roundtable.pipeline.*` section vs top-level) at implementation:
+(`roundtable.pipeline.*` section vs top-level) at implementation. If nested under
+`roundtable`, the parser/saver must explicitly add nested-object support; today's
+roundtable config surface is scalar keys like `roundtable.max_rounds`,
+`roundtable.converge_threshold`, `roundtable.deadline_ms`, and `roundtable.turns`.
 
 - `roundtable_pipeline_done_bar` — enum `zero_blocking` (default) |
   `zero_blocking_suggestions` | `zero_blocking_questions_answered`.
@@ -218,10 +308,12 @@ from `ensemble_*` / `roundtable_*`; no duplication.
 Convergence is only as meaningful as the panel. To keep the quality gate honest
 (not "agreeable panelists agreed"):
 
-- **Participant diversity** — the panel reuses `ensemble_*` participants, which
-  should be distinct models/providers; a single-model panel converges on its own
-  blind spots. Validation (§10) asserts ≥2 distinct providers for a pipeline run
-  or warns.
+- **Participant diversity** — the panel reuses `ensemble_*` participants. The
+  configured `ensemble.reference_models` values are agent/model names, so the
+  validator must resolve each participant through the agent config and compare
+  provider/model identity, not just string uniqueness. A single-provider panel can
+  converge on its own blind spots. Validation (§10) asserts ≥2 distinct providers
+  for a pipeline run or warns.
 - **Open mandate** (§2) so direction never suppresses out-of-scope findings.
 - **Corroboration surfacing** — the gate digest shows `item.count` so the human
   sees whether a finding was one panelist or all of them.
@@ -233,25 +325,37 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 ## §8 Dependencies
 
 - **Hard:** `agent-directed-pr-review` P1a (brief) + P1b (structured items
-  returned) + P1c (`ensemble_review` MCP tool over the async bridge). Without P1c
-  the agent cannot invoke directed review mid-loop; without P1b it cannot evaluate
-  the done-bar.
+  returned) + P1c (`ensemble_review` MCP tool over the async bridge) as a stable
+  callable contract. The current tree has an `ensemble_review` MCP route that
+  queues `delegate.roundtable`, but the pipeline still needs the final structured
+  result shape, status/polling contract, cancellation behavior, and payload
+  limits from that proposal. Without P1b it cannot evaluate the done-bar.
+- **Hard for proposal drafting:** a callable `ROUNDTABLE_DRAFT` path. The existing
+  `/v1/delegate/roundtable` / `aimee delegate roundtable --mode draft` surface is
+  enough if the driving agent can call it; otherwise add a narrow draft MCP
+  sibling rather than overloading the review-only `ensemble_review` tool.
+- **Hard:** durable DB1 checkpointing for the roundtable pipeline. `/v1/runs`
+  remains a child-run polling surface only because its store is bounded and
+  non-durable.
 - **Soft:** the `git diff` range helper (agent-directed-pr-review P2) for the PR
   phase input; otherwise the agent runs `git diff` itself.
 - **Repo flow:** PRs base `testing`; main promotion is separate and out of scope.
 
 ## §9 Phasing
 
-- **P0 — Ledger + states.** The `pipeline_run` record, the state enum/transitions,
-  and `aimee pipeline status|gate` CLI. No loop yet; states settable manually.
-  Mergeable alone.
+- **P0 — Ledger + states + namespace decision.** Choose the DB shape
+  (`roundtable_pipeline_runs` tables vs explicit migration of DB1 `pipelines`),
+  add the state enum/transitions, artifact refs/hashes, child run references, and
+  the CLI/MCP/HTTP namespace decision (`pipeline` vs `autopilot` extension). No
+  loop yet; states/gates settable manually. Mergeable alone, with restart tests.
 - **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
   `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
   escalation, the echo guard. Drives the PR phase first (single mode, simplest).
 - **P2 — Proposal phase (DRAFT + REVIEW).** Add the `drafting` DRAFT step and the
   proposal-review loop; wire `gh pr create`/merge for the proposal PR.
-- **P3 — Human gates + fail-return edges** end to end, with the durable digest and
-  reason-to-brief feedback. This closes the full loop.
+- **P3 — Human gates + fail-return edges** end to end, with the durable digest,
+  PR/worktree drift validation, mergeability/auth checks, and reason-to-brief
+  feedback. This closes the full loop.
 - **P4 — Config surface** for all keys + generated docs + tests (lands with the
   phase that first reads each key, not deferred).
 
@@ -263,16 +367,31 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Loop correctness** — a fixture proposal/diff with N seeded blocking issues:
   the loop reaches the done-bar only after all N are resolved; the digest counts
   match the engine items; the ledger records each pass's `run_id`/cost.
+- **DRAFT/REVIEW callable split** — the proposal phase invokes a draft-capable
+  roundtable path that returns an `artifact`; the review phases invoke the
+  review-capable path that returns structured items for the done-bar.
+- **Ledger compatibility** — if reusing DB1 `pipelines`, old autopilot
+  `start/status/list/cancel/resume/link-*` behavior remains intact; if using a new
+  table, pipeline IDs and command names are unambiguous.
+- **Run-store separation** — kill/restart after child `/v1/runs` records are gone;
+  the pipeline still resumes from DB1 and marks missing child run details as
+  historical evidence, not lost state.
 - **Done-bar config** — each of the three bars stops the loop at the right point
   (suggestions block under bar 2; questions must be answered under bar 3).
 - **Pass-ceiling escalation** — with a low cap and an unresolvable seeded issue,
   the loop escalates to the human at the cap and never auto-passes.
 - **Resumability** — kill and restart between a review pass and a gate; the ledger
   restores state and the gate is answerable post-restart.
+- **Git/PR drift** — mutate the PR head SHA, target branch, or mergeability while
+  paused at a gate; the pass action refuses stale evidence and requires a fresh
+  review or human confirmation.
+- **Large payload handling** — a diff/proposal larger than a single MCP/op-run
+  payload is reviewed through artifact refs or chunks, and the ledger stores
+  hashes so stale chunks are detected.
 - **Fail-return** — a `fail --reason` re-enters the review loop with the reason
   present in the next brief (asserted in the reviewer prompt).
-- **Panel diversity** — a single-provider panel warns; a ≥2-provider panel does
-  not.
+- **Panel diversity** — resolve `ensemble.reference_models` through agent config;
+  a single resolved provider warns; a ≥2-provider panel does not.
 - **Cost accounting** — cumulative per-phase cost matches the sum of per-pass
   `cost_usd`; the per-phase cap trips correctly.
 
@@ -280,6 +399,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
 
 - Server-side git or GitHub API (no PR fetch, no inline-comment posting); the
   agent uses `gh`/`git` (agent-directed-pr-review §11).
+- Storing whole proposals or large diffs as unbounded DB blobs. DB1 stores refs,
+  manifests, hashes, and compact digests; working files/blobs carry the large
+  content.
 - A fully autonomous, gate-less pipeline — the two human gates are mandatory by
   design; "configurable max passes" bounds cost, it does not remove the human.
 - Engine changes to the roundtable. The pipeline is strictly on top.
@@ -287,9 +409,13 @@ ledger) before the full idea→merge pipeline of P2/P3.
 
 ## §12 Open questions
 
-- **Ledger home:** a DB1 `pipeline_run` table vs a `/v1/runs` sibling vs reusing
-  the existing op-run store with a new kind. The op-run store already persists run
-  state for the async bridge; extending it may be lighter than a new table.
+- **Ledger home:** a namespaced DB1 `roundtable_pipeline_runs` schema vs an
+  explicit backwards-compatible extension of the existing DB1 `pipelines` table.
+  `/v1/runs` / `openai_runs_store` is ruled out for checkpoints because it is a
+  bounded live store and is not durable across restarts.
+- **CLI/API namespace:** add `aimee pipeline ...` as a new surface, or extend the
+  existing `autopilot` pipeline actions with gate/status operations? The answer
+  must keep IDs and help text unambiguous.
 - **Who is the driving agent at the gate?** When paused at a human gate across
   sessions, does a fresh agent resume from the ledger automatically, or does the
   human re-invoke `aimee pipeline resume <id>`?

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 sixth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 seventh review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -293,6 +293,41 @@ actually captures.
     Otherwise draft passes drop their result or are mis-shaped into review fields.
     **Resolved in §2, §4, and §10.**
 
+## PR #183 seventh review — chunk aggregation, retries, and stale async work
+
+The current shape now closes the `/v1/runs` eviction race, but four implementation
+edges still need to be explicit before this can be built without hidden correctness
+holes.
+
+28. **Chunked review needs an artifact-level aggregate, not independent green
+    slices.** §2 allows large proposals/diffs to be reviewed as chunks, but §3's
+    done-bar currently reads like it evaluates "the latest REVIEW result" as if
+    there is always one result for the whole artifact. If each chunk can pass
+    independently, cross-chunk invariants, renamed symbols, duplicated logic, and
+    missing sections can still be wrong. A chunked pass needs a manifest, per-chunk
+    child results, a deterministic aggregate row, and a final whole-artifact
+    synthesis/check before the phase can pass. **Resolved in §2, §3, §4, and §10.**
+29. **Attempt retries need their own ceiling.** `roundtable_pipeline_max_passes`
+    correctly bounds correctness passes, but capture faults and cancelled/failed
+    attempts are infrastructure retries under the same pass id. Counting those as
+    outer passes makes one transient capture failure consume a correctness pass;
+    not counting them without a separate bound can loop forever. Add an attempt
+    retry cap per pass, with costs still charged to the phase. **Resolved in §3,
+    §4, §6, and §10.**
+30. **Late worker finalization must not advance stale state.** Async op-runs can
+    outlive a pipeline cancel, abandon, fail-return, or retry. A late result from
+    an older `attempt_no`/`run_id` must be recorded as terminal history, but it
+    cannot update the current pass aggregate, satisfy the done-bar, or resume a
+    gate after the pass was superseded. **Resolved in §4, §5, and §10.**
+31. **Pipeline cancellation must bridge to child op-run cancellation.** The repo
+    already has `/v1/runs/{id}/stop` and `handle_delegate_roundtable` polls
+    `__run_id` through `openai_runs_store_cancel_requested`. A new pipeline
+    `cancel`/`abandon` action that only flips the ledger row leaves the roundtable
+    worker running and later finalizing stale work (#30). The action must request
+    stop on the active child `run_id`, mark the attempt cancelled/abandoned in the
+    ledger, and tolerate the worker's eventual terminal write. **Resolved in §4,
+    §5, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -382,6 +417,10 @@ Both phases use the **same** engine; they differ only in input and brief.
   mode only; the agent applies fixes between passes. For large diffs, the driving
   agent must pass an artifact file/path or chunked diff slices rather than an
   unbounded inline string, and the ledger stores the diff ref plus content hash.
+  Chunking is a pass-level manifest, not a set of unrelated mini-reviews: every
+  chunk stores an input hash and result, the pass stores the aggregate, and the
+  done-bar can pass only after all chunks are covered plus a whole-artifact
+  synthesis/check has considered cross-chunk invariants (#28).
   Pipeline-owned PR reviews use the async op-run path with validated pass
   metadata, not a direct synchronous roundtable dispatch. The brief carries the
   *fixes just applied*, the *invariants* the change must not break, and the
@@ -425,6 +464,13 @@ The driving agent computes the bar from the structured items
 (agent-directed-pr-review P1b); it never re-judges convergence itself — it trusts
 the engine's deterministic saturation logic as exposed through `converged`.
 
+For chunked reviews (#28), the done-bar is evaluated on the **aggregate pass
+result**, not on any one child chunk. Every manifest entry must have a completed,
+valid REVIEW result over the expected chunk hash, and the aggregate must include a
+whole-artifact synthesis/check for cross-chunk findings before the phase can pass.
+Any missing, stale, truncated, degraded, or failed chunk keeps the aggregate
+blocked.
+
 **Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
 bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
 honoring correctness-over-pass-count. When an operator sets a positive cap and the
@@ -441,7 +487,10 @@ prevents cross-pass echo.)
 **Non-termination backstop.** Besides the optional pass ceiling, the inherited
 `ensemble_max_cost_usd` (per call) and a new cumulative
 `roundtable_pipeline_max_cost_usd` (per phase, §6) bound spend; either tripping
-escalates to the human rather than silently passing.
+escalates to the human rather than silently passing. Infrastructure retries under
+one pass id are separately bounded by `roundtable_pipeline_max_attempts_per_pass`
+(#29) so capture failures do not consume correctness passes but also cannot spin
+forever.
 
 ## §4 Hybrid state — the resumable pipeline ledger
 
@@ -469,9 +518,11 @@ Either way, the durable record holds:
   chunk manifest, and content hashes, not unbounded inline text as the primary
   representation;
 - the current brief plus compact gate digest;
-- per-pass history: each outer pass's child roundtable `run_id`, status,
-  `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`, `best_round`,
-  result hash, and any payload/chunk refs;
+- per-pass history: each outer pass's status, aggregate child `run_id` if
+  single-call, `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`,
+  `best_round`, result hash, and any payload/chunk refs; for chunked passes, a
+  manifest plus aggregate row that records per-chunk results and the
+  whole-artifact synthesis/check (#28);
 - per-attempt history under each pass: `attempt_no`, child `run_id`, submitted and
   terminal timestamps, captured/lost status, terminal flags, result hash, and cost
   if the result was available;
@@ -520,9 +571,18 @@ If a result is still not captured (a genuine fault), the attempt is marked
 stable `pipeline_pass_id` but a new `attempt_no`/`run_id`. That retry is idempotent
 only if the stored artifact/diff hash still matches; if the input changed, the old
 pass is stale and the pipeline starts a new pass instead. Retries are bounded by
-the pass ceiling and cost cap, with lost attempts booked as overhead when cost is
-known. A human is involved only if capture keeps failing across re-runs (#19) —
-never on a single transient miss.
+`roundtable_pipeline_max_attempts_per_pass` plus the phase cost cap (#29), with
+lost attempts booked as overhead when cost is known. A human is involved only if
+capture keeps failing across bounded re-runs (#19) — never on a single transient
+miss.
+
+Async workers are allowed to finish after the pipeline state changes, so ledger
+writes must be conditional. The finalize hook records every terminal
+`run_id`/`attempt_no`, but only the **current active attempt** for a non-cancelled,
+non-abandoned pass may update the pass aggregate, satisfy the done-bar, or advance
+the state machine. A late terminal result from a cancelled, abandoned, failed-back,
+or superseded attempt remains audit history and cannot resurrect stale state
+(#30).
 
 This makes the human gate a durable checkpoint: `status` shows where it is and
 the evidence; `gate pass|fail --reason "…"` records the verdict and resumes the
@@ -551,6 +611,12 @@ the existing `autopilot` pipeline handler, but it must not leave two unrelated
 "pipeline" namespaces with different IDs. The gate action is net-new; today's
 autopilot actions cover `start`, `advance`, `status`, `list`, `cancel`, `resume`,
 `link-plan`, and `link-job`, not pass/fail gates.
+
+Pipeline `cancel`/`abandon` cannot be ledger-only. If a child roundtable op-run is
+active, the action must request cancellation through the child `run_id`
+(`/v1/runs/{id}/stop` / `openai_runs_store_request_cancel` semantics), mark the
+active attempt cancelled or abandoned, and leave the finalize hook free to record
+the eventual terminal state without advancing stale state (#30/#31).
 
 Before a **pass** can merge or advance, the resumed agent revalidates the stored
 worktree/PR state through Aimee's workspace-aware git surface (`git_pr` /
@@ -586,6 +652,10 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
   `zero_blocking_suggestions` | `zero_blocking_questions_answered`.
 - `roundtable_pipeline_max_passes` — int, **default 0 (unbounded)**; >0 = outer
   pass ceiling that escalates (never auto-passes) on hit.
+- `roundtable_pipeline_max_attempts_per_pass` — int, default 2; bounds
+  infrastructure retries (`lost_result`, capture failure, queue/worker failure,
+  cancellation retry) under the same stable pass id without consuming outer
+  correctness passes.
 - `roundtable_pipeline_max_cost_usd` — double, cumulative per-phase spend cap;
   0 = unbounded; tripping escalates.
 - *(optional, deferred)* per-phase overrides (`…_proposal` / `…_pr` suffixes) if
@@ -655,11 +725,14 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   `autopilot` extension). Wire the server-worker capture seam: validate
   `pipeline_pass_id`, inject private `__pipeline_pass_id`, preserve it through
   async enqueue, and extend `op_run_worker_run`'s finalize path or hook to persist
-  every terminal attempt to the ledger (#18/#20-#25). No loop yet; states/gates
-  settable manually. Mergeable alone, with restart tests.
+  every terminal attempt to the ledger (#18/#20-#25). The finalize hook must be
+  current-attempt guarded so late workers cannot advance stale state (#30), and
+  pipeline cancel/abandon must request child-run stop when one is active (#31).
+  No loop yet; states/gates settable manually. Mergeable alone, with restart tests.
 - **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
   `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
-  escalation, the echo guard. Drives the PR phase first (single mode, simplest).
+  escalation, the attempt retry ceiling, the echo guard. Drives the PR phase first
+  (single mode, simplest).
 - **P2 — Proposal phase (DRAFT + REVIEW).** Add the `drafting` DRAFT step and the
   proposal-review loop; wire proposal PR create/merge through the workspace-aware
   git/PR surface.
@@ -710,7 +783,8 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Lost-result re-run (#19)** — simulate a genuine capture fault: the pass is
   marked `lost_result` and auto re-runs under the **same `pipeline_pass_id`** (no
   double-counted pass; lost attempt booked as overhead), escalating to the human
-  only after repeated capture failures, never on the first miss.
+  only after `roundtable_pipeline_max_attempts_per_pass` is exhausted or the phase
+  cost cap trips, never on the first miss.
 - **Attempt accounting (#23/#25)** — successful, failed, cancelled, malformed,
   capture-failed, and lost attempts all get attempt rows and preserve run IDs,
   terminal status, flags, result hashes, and known cost without overwriting prior
@@ -718,6 +792,17 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Replay hash pinning (#24)** — mutate the proposal/diff between a lost attempt
   and retry; the pipeline refuses to reuse the old pass id and starts a new pass
   because the artifact hash changed.
+- **Chunk aggregate done-bar (#28)** — split a diff/proposal into multiple chunks
+  with a cross-chunk invariant violation; individual chunks can complete, but the
+  phase cannot pass until the aggregate whole-artifact synthesis/check records the
+  violation resolved. Missing or stale chunk hashes keep the aggregate blocked.
+- **Late finalization guard (#30)** — start an attempt, supersede/cancel/abandon
+  it, then let the old worker finish; the terminal attempt row is recorded, but it
+  does not update the current aggregate, pass the done-bar, open a gate, or resume
+  the pipeline.
+- **Pipeline child cancellation (#31)** — cancelling/abandoning a pipeline with an
+  active roundtable run requests child op-run cancellation, persists the cancelled
+  attempt, and tolerates the worker's later terminal write.
 - **DRAFT skeleton + expansion (#9)** — a DRAFT call returns a skeleton within the
   8 KB cap without truncating mid-structure; the author-revise loop grows it to a
   full proposal in the working file, and REVIEW reviews the file/chunks, not the
@@ -744,7 +829,8 @@ ledger) before the full idea→merge pipeline of P2/P3.
   the run has a dedicated branch/worktree or an explicit operator override.
 - **Large payload handling** — a diff/proposal larger than a single MCP/op-run
   payload is reviewed through artifact refs or chunks, and the ledger stores
-  hashes so stale chunks are detected.
+  hashes so stale chunks are detected; chunked results are aggregated before the
+  done-bar is evaluated.
 - **Fail-return** — a `fail --reason` re-enters the review loop with the reason
   present in the next brief (asserted in the reviewer prompt).
 - **Panel diversity** — resolve `ensemble.reference_models` through agent config;

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 ninth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 tenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -403,6 +403,30 @@ it overstates what the current KB tables and APIs provide.
     or fail configuration validation with a clear remediation. **Resolved in §2,
     §6, §7, and §10.**
 
+## PR #183 tenth review — who retrieves: orchestrator assembles, participants review inline
+
+Gap #32 said the whole-artifact check is "a reviewer given db2 retrieval." Reading
+how review participants actually run shows that mis-locates the work.
+
+37. **Review participants review the *inline task text*; they cannot be assumed to
+    retrieve from db2 or read the working tree.** `ensemble_review` /
+    `handle_delegate_roundtable` passes the artifact as inline `task` text, and each
+    participant runs via `agent_run_named(…, ensemble_reference_models[i],
+    "review", …)` — a **heterogeneous, often remote** model whose tool access
+    (file-read, KB-search) is per-agent and not guaranteed. The `review` charter
+    role's "inspect repository files" is best-effort: it works only where that
+    participant has file tools + workspace binding, it is not db2 retrieval, and a
+    remote delegate panelist may have neither. So #32's "reviewer given db2
+    retrieval over the artifact's chunks" is the wrong seam. The correct one: the
+    **orchestrator** (which holds the origin ref and db2) pre-assembles each review
+    unit and passes it **inline** — for a chunk, the chunk text + brief +
+    orchestrator-retrieved cross-chunk spans (the other definition of a symbol, the
+    referenced section); for the whole-artifact aggregate, a self-contained digest
+    of per-chunk findings + the cross-cutting spans the invariants need. db2/origin
+    storage (#32/#34) is what the *orchestrator* retrieves from, never a per-panelist
+    capability. Review correctness then never depends on whether a given model can
+    retrieve or read files. **Resolved in §2, §3, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -497,8 +521,9 @@ Both phases use the **same** engine; they differ only in input and brief.
   done-bar can pass only after all chunks are covered plus a whole-artifact
   synthesis/check has considered cross-chunk invariants (#28). **Chunking never
   discards the origin:** the pipeline records a whole-origin ref/hash separately
-  from chunk rows (#34), and the cross-chunk check retrieves needed spans from
-  the origin plus review-scoped chunks on demand (#32/#35).
+  from chunk rows (#34), and the **orchestrator** retrieves needed spans from the
+  origin plus review-scoped chunks and hands each review call a self-contained
+  inline unit — panelists are not assumed to retrieve or read files (#32/#35/#37).
   Pipeline-owned PR reviews use the async op-run path with validated pass
   metadata, not a direct synchronous roundtable dispatch. The brief carries the
   *fixes just applied*, the *invariants* the change must not break, and the
@@ -547,12 +572,16 @@ result**, not on any one child chunk. Every manifest entry must have a completed
 valid REVIEW result over the expected chunk hash, and the aggregate must include a
 whole-artifact synthesis/check for cross-chunk findings before the phase can pass.
 Any missing, stale, truncated, degraded, or failed chunk keeps the aggregate
-blocked. The whole-artifact check is **retrieval-backed, not a re-ingest** (#32):
-the pipeline stores the origin separately (#34) and indexes review-scoped chunks,
-so the cross-chunk reviewer pulls the other definition of a symbol, a missing
-section, or a renamed reference via vector/FTS + the `prev_chunk_id`/
-`next_chunk_id` chain on demand — it never needs the full text in one context
-window, and the origin artifact is always retained, never replaced by its chunks.
+blocked. The whole-artifact check is **retrieval-backed, but the orchestrator
+retrieves — not the panelists** (#32/#37): the pipeline stores the origin
+separately (#34) and indexes review-scoped chunks, and the **orchestrator** pulls
+the cross-chunk spans the invariants need (the other definition of a symbol, a
+missing section, a renamed reference) via vector/FTS + the `prev_chunk_id`/
+`next_chunk_id` chain, then passes a **self-contained inline unit** to the
+aggregate review call. A heterogeneous, possibly-remote panelist is never assumed
+to retrieve or read files; it reviews the inline digest. The full text is never
+needed in one context window, and the origin is always retained, never replaced by
+its chunks.
 
 **Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
 bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
@@ -906,6 +935,11 @@ ledger) before the full idea→merge pipeline of P2/P3.
   the real project KB; cleanup deletes only that pipeline's review chunks/docs.
   A test must prove `/v1/maintenance/clear` or any chosen cleanup path cannot wipe
   unrelated project data.
+- **Orchestrator-assembled inline review (#37)** — a participant configured with
+  **no file or KB-search tools** still produces a correct cross-chunk finding,
+  because the orchestrator pre-retrieved the needed spans and passed a
+  self-contained inline unit; the panel's tool access is never load-bearing for
+  review correctness.
 - **Chunk threshold from min panel context (#33)** — a heterogeneous panel sizes
   chunks to the smallest participant context budget (resolved per run, reserving
   brief/role/peer-note headroom); a chunk that would overflow the smallest model is

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 eighth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 ninth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -46,9 +46,11 @@ when hit without reaching the done-bar (it never auto-passes a not-done artifact
 
 **Design invariant — always keep the origin artifact.** Chunking is allowed
 anywhere in the pipeline, but it is never a substitute for the whole: every
-artifact (proposal, diff) is stored *whole* in db2 alongside its chunks, so the
-full origin is always retrievable and no step ever has to reconstruct it from
-slices. Chunk to fit a call; retrieve the origin when correctness needs it.
+artifact (proposal, diff) has a durable whole-origin ref/hash in the pipeline
+ledger (working blob/path, db2 `docs.normalized_text`, or an explicit artifact
+payload), and chunk rows point back to that origin. `kb_documents` is a chunk
+index, not the whole-origin store. Chunk to fit a call; retrieve the origin when
+correctness needs it.
 
 ## PR #183 review — gaps and how they are resolved
 
@@ -340,12 +342,13 @@ Gap #28 correctly demands a whole-artifact aggregate over chunks, but its own
 resolution has two holes: the aggregate can't re-read what didn't fit, and nothing
 says how big a chunk is.
 
-32. **Store the artifact in db2 as whole text + chunks and *retrieve* — don't
+32. **Store the artifact origin plus db2 chunks and *retrieve* — don't
     agonize over "fit it in one call vs. summarize it."** §3 requires a
     whole-artifact synthesis/check, and an artifact large enough to be chunked
     won't fit one review call. The resolution is Aimee's core competency, not a
-    bespoke manifest: ingest the artifact-under-review into db2's existing
-    `kb_documents` chunk store, which already gives everything the aggregate needs —
+    bespoke manifest: retain the artifact origin separately and ingest
+    review-scoped chunks into db2's existing `kb_documents` chunk store, which
+    gives the aggregate most of what it needs —
     `chunk_index` + `prev_chunk_id`/`next_chunk_id` make the whole text
     reconstructable by walking the chain, `heading_path` is a section manifest for
     free, `file_hash` tracks staleness, and vector + FTS retrieval are built in.
@@ -353,11 +356,11 @@ says how big a chunk is.
     check is a reviewer given **db2 retrieval over the artifact's own chunks**, so
     it pulls cross-chunk context (the other definition of a symbol, a missing
     section, a renamed reference) on demand instead of needing the full text inline.
-    Because both the whole and the chunks are stored, the "fit it in one call vs.
-    summarize" decision never has to be made. The artifact lives in a
-    **review-scoped/ephemeral project namespace**, cleaned up on pipeline
-    completion, so it never pollutes durable memory. **Resolved in §2, §3, §4, and
-    §10.**
+    Because both the origin and the chunks are retained, the "fit it in one call
+    vs. summarize" decision never has to be made. The chunk index lives in a
+    review-scoped namespace/contract, cleaned up on pipeline completion, so it
+    never pollutes durable memory. **Resolved in §2, §3, §4, and §10; corrected by
+    #34/#35 for the exact origin store and cleanup primitive.**
 33. **The chunk threshold must derive from the panel's *minimum* participant
     context budget, not a fixed size.** The panel is heterogeneous
     (`ensemble_reference_models` resolve to different models with different context
@@ -368,6 +371,37 @@ says how big a chunk is.
     panel** (resolved per run), reserving headroom for the brief, role framing, and
     peer notes, with the resolved budget and threshold recorded in the chunk
     manifest. **Resolved in §2 and §10.**
+
+## PR #183 ninth review — correcting the db2 origin and context-budget contracts
+
+The eighth review made the right move by grounding chunk aggregation in db2, but
+it overstates what the current KB tables and APIs provide.
+
+34. **`kb_documents` stores chunks, not the whole artifact.** The schema has
+    `kb_documents.content` per chunk plus `prev_chunk_id`/`next_chunk_id`; the
+    normal project build path calls `db2_kb_file_index_upsert(..., NULL)`, so
+    `kb_file_index.content` is not a reliable whole-text copy either. If the
+    pipeline needs the origin text, it must store a separate origin ref/blob:
+    working file/blob + hash in DB1, a db2 `docs.normalized_text` row via
+    `kb.docs.push`, or an explicit DB2 artifact payload. The chunk manifest then
+    references both the origin ref and the `kb_documents` rows. **Resolved in §2,
+    §3, §4, §10, and §11.**
+35. **Review-scoped KB indexing is not a current public primitive.** The available
+    KB surfaces are project-oriented (`kb.build`/`kb.update` over a path+project,
+    `/v1/maintenance/clear` for an entire project) plus corpus staging
+    (`kb.docs.push` into `docs`). A pipeline-specific ephemeral namespace cannot
+    be assumed unless the implementation either creates a synthetic review project
+    with safe cleanup, adds a per-file/per-scope cleanup API, or adds direct
+    pipeline artifact indexing. Otherwise cleanup can delete unrelated project KB
+    data or leave review chunks behind. **Resolved in §2, §4, §8, §9, and §10.**
+36. **Minimum panel context budget can be unknown.** The code can hold
+    `agent.middleware.context_window`, and some runtime paths use
+    `model_context_window(model)`, but configured agents and discovered
+    `model_catalog` rows can still have `context_window == 0`. The pipeline cannot
+    size chunks from "minimum participant context" unless every panelist resolves
+    a positive budget; otherwise it must use a conservative default, probe first,
+    or fail configuration validation with a clear remediation. **Resolved in §2,
+    §6, §7, and §10.**
 
 ## Relationship to existing proposals
 
@@ -462,9 +496,9 @@ Both phases use the **same** engine; they differ only in input and brief.
   chunk stores an input hash and result, the pass stores the aggregate, and the
   done-bar can pass only after all chunks are covered plus a whole-artifact
   synthesis/check has considered cross-chunk invariants (#28). **Chunking never
-  discards the origin: the artifact-under-review is ingested whole into db2
-  (`kb_documents`) alongside its chunks, so the full text is always retained and
-  the cross-chunk check retrieves any span on demand (#32).**
+  discards the origin:** the pipeline records a whole-origin ref/hash separately
+  from chunk rows (#34), and the cross-chunk check retrieves needed spans from
+  the origin plus review-scoped chunks on demand (#32/#35).
   Pipeline-owned PR reviews use the async op-run path with validated pass
   metadata, not a direct synchronous roundtable dispatch. The brief carries the
   *fixes just applied*, the *invariants* the change must not break, and the
@@ -514,11 +548,11 @@ valid REVIEW result over the expected chunk hash, and the aggregate must include
 whole-artifact synthesis/check for cross-chunk findings before the phase can pass.
 Any missing, stale, truncated, degraded, or failed chunk keeps the aggregate
 blocked. The whole-artifact check is **retrieval-backed, not a re-ingest** (#32):
-the artifact is stored whole + chunked in db2 (`kb_documents`), so the
-cross-chunk reviewer pulls the other definition of a symbol, a missing section, or
-a renamed reference via vector/FTS + the `prev_chunk_id`/`next_chunk_id` chain on
-demand — it never needs the full text in one context window, and the origin
-artifact is always retained, never replaced by its chunks.
+the pipeline stores the origin separately (#34) and indexes review-scoped chunks,
+so the cross-chunk reviewer pulls the other definition of a symbol, a missing
+section, or a renamed reference via vector/FTS + the `prev_chunk_id`/
+`next_chunk_id` chain on demand — it never needs the full text in one context
+window, and the origin artifact is always retained, never replaced by its chunks.
 
 **Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
 bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
@@ -564,9 +598,10 @@ Either way, the durable record holds:
 
 - pipeline id, state (§1), phase, created/updated timestamps, and schema version;
 - artifact refs: proposal path/blob/ref, implementation branch, diff ref or
-  chunk manifest, the db2 `kb_documents` ingest ref (the **whole** artifact +
-  chunks, per the origin-retention invariant), and content hashes — not unbounded
-  inline text as the primary representation;
+  chunk manifest, whole-origin ref/hash (working blob/path, db2 `docs` row, or
+  explicit artifact payload), review-chunk index refs (`kb_documents` rows if that
+  backend is used), and content hashes — not unbounded inline text as the primary
+  representation;
 - the current brief plus compact gate digest;
 - per-pass history: each outer pass's status, aggregate child `run_id` if
   single-call, `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`,
@@ -708,6 +743,10 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
   correctness passes.
 - `roundtable_pipeline_max_cost_usd` — double, cumulative per-phase spend cap;
   0 = unbounded; tripping escalates.
+- `roundtable_pipeline_unknown_context_tokens` — int, conservative fallback chunk
+  input budget used only when a panel participant's context window cannot be
+  resolved; alternatively the implementation may make unknown context a hard
+  validation error instead of accepting this key (#36).
 - *(optional, deferred)* per-phase overrides (`…_proposal` / `…_pr` suffixes) if
   the proposal and PR phases want different bars.
 
@@ -725,6 +764,11 @@ Convergence is only as meaningful as the panel. To keep the quality gate honest
   provider/model identity, not just string uniqueness. A single-provider panel can
   converge on its own blind spots. Validation (§10) asserts ≥2 distinct providers
   for a pipeline run or warns.
+- **Context-budget resolution** — the same participant-resolution pass must also
+  resolve a positive context budget for every panelist, using
+  `agent.middleware.context_window`, model defaults, or a configured conservative
+  fallback. Unknown budgets are surfaced before chunking (#36), not discovered by
+  truncating a reviewer mid-pass.
 - **Open mandate** (§2) so direction never suppresses out-of-scope findings.
 - **Corroboration surfacing** — the gate digest shows `item.count` so the human
   sees whether a finding was one panelist or all of them.
@@ -758,6 +802,11 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   pipeline needs an explicit `pipeline_pass_id`/attempt submission path that
   validates state and injects private `__pipeline_pass_id` before
   `op_run_worker_run` finalizes the child run.
+- **Hard for chunked review:** a pipeline-owned review-artifact indexing contract.
+  Existing KB build/update is project/path oriented and `kb.docs.push` stores whole
+  staged docs, but neither is automatically a review-scoped, cleanup-safe chunk
+  index. The implementation must choose synthetic review projects, per-file/scope
+  cleanup, or a direct artifact-index API (#35).
 - **Hard:** workspace-aware git/forge authority for PR create/merge and diff
   capture. Pipeline git/gh operations must route through Aimee's git tools or
   workspace provider so shared, detached, and mirror workspaces behave consistently.
@@ -770,9 +819,11 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 
 - **P0 — Ledger + states + namespace decision.** Choose the DB shape
   (`roundtable_pipeline_runs` tables vs explicit migration of DB1 `pipelines`),
-  add the state enum/transitions, artifact refs/hashes, pass/attempt rows, child
-  run references, and the CLI/MCP/HTTP namespace decision (`pipeline` vs
-  `autopilot` extension). Wire the server-worker capture seam: validate
+  add the state enum/transitions, artifact origin refs/hashes, chunk-index refs,
+  pass/attempt rows, child run references, and the CLI/MCP/HTTP namespace decision
+  (`pipeline` vs `autopilot` extension). Choose the review-artifact indexing and
+  cleanup contract (#35) before depending on chunked done-bars. Wire the
+  server-worker capture seam: validate
   `pipeline_pass_id`, inject private `__pipeline_pass_id`, preserve it through
   async enqueue, and extend `op_run_worker_run`'s finalize path or hook to persist
   every terminal attempt to the ledger (#18/#20-#25). The finalize hook must be
@@ -846,16 +897,23 @@ ledger) before the full idea→merge pipeline of P2/P3.
   with a cross-chunk invariant violation; individual chunks can complete, but the
   phase cannot pass until the aggregate whole-artifact synthesis/check records the
   violation resolved. Missing or stale chunk hashes keep the aggregate blocked.
-- **Origin retention + retrieval-backed aggregate (#32, origin invariant)** — the
-  artifact is ingested whole + chunked into db2 (`kb_documents`); the whole text is
-  recoverable via the `prev/next` chain and `chunk_index`, the cross-chunk check
-  resolves a planted cross-chunk reference by **retrieval** (no full re-ingest),
-  and the review-scoped namespace is cleaned up on pipeline completion without
-  touching durable memory.
+- **Origin retention + retrieval-backed aggregate (#32/#34, origin invariant)** —
+  the artifact has a durable whole-origin ref/hash separate from chunk rows; chunk
+  rows can be walked by `prev/next` and `chunk_index`, but the full text is
+  recovered from the origin ref (`docs.normalized_text`, working blob/path, or
+  artifact payload), not assumed to live in `kb_documents`.
+- **Review-scoped index cleanup (#35)** — index a review artifact without touching
+  the real project KB; cleanup deletes only that pipeline's review chunks/docs.
+  A test must prove `/v1/maintenance/clear` or any chosen cleanup path cannot wipe
+  unrelated project data.
 - **Chunk threshold from min panel context (#33)** — a heterogeneous panel sizes
   chunks to the smallest participant context budget (resolved per run, reserving
   brief/role/peer-note headroom); a chunk that would overflow the smallest model is
   never submitted to it.
+- **Unknown context fallback (#36)** — configure one participant with no
+  `context_window` and no model default; the pipeline either rejects the run with a
+  clear validation error or uses the configured conservative fallback and records
+  that fallback in the chunk manifest.
 - **Late finalization guard (#30)** — start an attempt, supersede/cancel/abandon
   it, then let the old worker finish; the terminal attempt row is recorded, but it
   does not update the current aggregate, pass the done-bar, open a gate, or resume
@@ -904,8 +962,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
   posting). The pipeline uses Aimee's existing workspace-aware git/PR tool surface,
   which may call `gh`/`git` underneath with the right workspace/forge authority.
 - Storing whole proposals or large diffs as unbounded DB blobs. DB1 stores refs,
-  manifests, hashes, and compact digests; working files/blobs carry the large
-  content.
+  manifests, hashes, and compact digests; working files/blobs, db2 `docs`, or an
+  explicit artifact payload carry the large origin content. `kb_documents` remains
+  a chunk index, not the canonical whole-origin store.
 - Expecting DRAFT mode to emit a complete proposal (#9). The 8 KB artifact cap
   means DRAFT produces a skeleton; the author-revise loop expands it in the working
   file. Generating long-form text inside the roundtable artifact is out of scope.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 seventeenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 eighteenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -623,6 +623,26 @@ Two follow-ons from the sixteenth review's own resolutions.
 (The What-exists table is also corrected here: PR **merge** is *not* a `git_pr`
 action today — #50 — so it is listed as a gap, not as existing.)
 
+## PR #183 eighteenth review — pin cost sources and validate the ledger dependency
+
+The seventeenth revision correctly avoids inventing a parallel implementation-cost
+ledger, but the codebase currently has DB1 `token_audit` / `cost_fold_log` while
+the proposed db2 `usage_ledger` is still pending. That leaves one more boundary to
+make explicit.
+
+52. **Pipeline cost evidence must pin its accounting source and scope.** A pipeline
+    may start before the cost-accounting proposal lands, resume after it lands, or
+    carry both roundtable child-run `cost_usd` and implementation-agent cost rows.
+    The durable ledger therefore needs a per-pipeline/per-phase `cost_scope` and
+    `cost_source` snapshot (for example `roundtable_result_cost`,
+    `db1_token_audit_cost_fold`, or `db2_usage_ledger`), plus a pricing/schema
+    version or reconciliation timestamp. It must not silently mix DB1 audit sums,
+    roundtable result estimates, and future db2 usage rows across retries or
+    resume. If the configured source changes, the pipeline marks cost evidence
+    stale/incomplete, recomputes from a single authoritative source where possible,
+    and re-surfaces the gate digest before claiming a cap is satisfied. **Resolved
+    in §4, §5, §6, §8, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -914,6 +934,14 @@ not whether the attempt is captured. The `/v1/runs` id is retained only as a
 historical pointer; the ledger row is the source of truth for the done-bar and the
 gate digest.
 
+Cost evidence in that ledger is not just a number. Each pipeline and phase records
+the accounting scope/source/version used to compute it (#52): roundtable-result
+child-run cost, DB1 `token_audit` / `cost_fold_log`, or the cost-accounting
+proposal's db2 `usage_ledger`. A resumed pipeline may continue with the pinned
+source, or explicitly reconcile to a newer authoritative source and mark prior
+gate evidence stale until the digest is regenerated; it cannot mix sources inside
+one cap decision.
+
 **The agent reads terminal from the ledger, not `/v1/runs` (#26).** Because the
 worker writes the result to DB1 at terminal, the driving agent learns a pass
 completed by polling the **durable ledger pass row** (`aimee pipeline status` / the
@@ -967,7 +995,8 @@ digest, then waits for the verdict:
 - the converged-review **digest**: blocking/suggestion/nit counts, the
   highest-corroboration items (`item.count`), answered questions, and any
   `coverage_gaps`;
-- pipeline economics: total outer passes, cumulative `cost_usd`, rounds.
+- pipeline economics: total outer passes, cumulative `cost_usd`, rounds, and the
+  pinned cost scope/source/version behind that number (#52).
 
 **pass** advances (merge → next phase). **fail** captures the human's reason; the
 reason becomes a brief `focus`/`questions` entry for the next loop, and the state
@@ -1042,7 +1071,10 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
   a second accounting path; where that ledger has no row yet, implementation cost is
   marked **incomplete evidence** and the cap cannot be claimed satisfied. If that
   ledger has not landed, the cap is scoped to roundtable child-run cost only
-  (a `…_max_roundtable_cost_usd` spelling) and says so (#49).
+  (a `…_max_roundtable_cost_usd` spelling) and says so (#49). The selected
+  accounting scope/source/version is pinned in the pipeline ledger; changing it
+  requires a fresh reconciliation and stale gate digest rather than silently
+  combining DB1 token-audit totals, child-run estimates, and db2 usage rows (#52).
 - `roundtable_pipeline_gate_ttl_h` — int hours, **default 0 (no expiry)**; >0 moves
   a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
   cleanup (#31), never an auto-pass (#47).
@@ -1124,7 +1156,10 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   must use a distinct namespace or remain CLI/MCP-only in v1 (#45).
 - **Soft:** the cost-accounting proposal's `usage_ledger` / `/v1/usage/*` for
   whole-pipeline cost that includes implementation-phase spend (#51). Absent it,
-  the total cap is roundtable-child-run-cost only and says so (#49).
+  the total cap is roundtable-child-run-cost only and says so (#49). Any
+  implementation that bridges from current DB1 `token_audit` / `cost_fold_log` to
+  future db2 `usage_ledger` must version and pin the accounting source per
+  pipeline, not mix both in one cap decision (#52).
 - **Soft:** the `git diff` range helper (agent-directed-pr-review P2) for the PR
   phase input; otherwise the pipeline captures the diff through the
   workspace-aware git surface.
@@ -1314,6 +1349,12 @@ ledger) before the full idea→merge pipeline of P2/P3.
   work between review phases; assert the total cap either explicitly excludes that
   spend (roundtable-only naming/contract) or includes it from token/cost accounting,
   and unknown in-scope implementation cost prevents claiming the cap is satisfied.
+- **Cost-source pinning + usage-ledger fallback (#51/#52)** — start a pipeline while
+  only DB1 `token_audit` / `cost_fold_log` and roundtable `cost_usd` are available,
+  then resume after a db2 `usage_ledger` implementation is present; assert the
+  ledger keeps the original source pinned or explicitly reconciles and marks the
+  gate digest stale. Missing in-scope usage rows block "cap satisfied"; a
+  roundtable-only configuration uses the explicit roundtable-only key/contract.
 - **Parked-gate resource release + TTL (#47)** — at a gate, the review-scoped index
   is dropped and correctly re-ingested from the origin on resume (same content
   hash, retrieval still works); with a TTL set, an unanswered gate moves to

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 eleventh review)
+- **Date:** 2026-06-11 (revised post-PR-#183 twelfth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -460,6 +460,26 @@ boundary.
     produced it; `item.sources` remains a display hint, not the durable evidence
     model. **Resolved in §4, §5, and §10.**
 
+## PR #183 twelfth review — one validity predicate, not a scattered conjunction
+
+Gap #38 is a symptom of a pattern. Validity flags have accreted across reviews
+(#13 added `truncated`/`degraded`/`cost_capped`/`deadline_hit`/`cancelled`; #38
+adds `items_truncated`), and the done-bar, the chunk-aggregate, the capture hook,
+and the gate digest each re-list the conjunction inline. The next consumer written
+will check a stale subset — exactly how #38 happened in the first place.
+
+41. **Define one canonical "valid terminal result" predicate; no call site may
+    check a subset.** Centralize validity as a single contract —
+    `roundtable_result_valid_terminal(result)` returning false on any of
+    `truncated`, `items_truncated` (#38), `degraded`, `cost_capped`,
+    `deadline_hit`, `cancelled`, `lost_result` (#19), or an
+    `items_round`/`artifact_round` provenance mismatch (#13) — and have the done-bar
+    (#3), the chunk-aggregate (#28), the worker capture hook (#18), and the gate
+    digest all consult **that one predicate**. A future invalidity flag updates the
+    predicate in one place. A test asserts every consumer rejects a result that
+    trips each individual flag, so a newly added flag can never be honored by some
+    sites and silently ignored by others. **Resolved in §3, §4, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -582,13 +602,15 @@ Two distinct loop levels — keep them un-confused:
 its review loop only when the latest REVIEW result satisfies the configured bar,
 read from real engine fields (`roundtable_result_t`):
 
-Every bar first requires a valid completed result: `truncated == false`,
-`degraded == false`, `cost_capped == false`, `deadline_hit == false`,
-`cancelled == false`, `items_truncated != true`, and result provenance that the
-gate digest can explain. For review-mode done-bars, `items_round` must be the
-round being evaluated; if the surfaced artifact comes from a different
-`artifact_round`/`best_round`, the digest must say so and the phase cannot
-silently pass on mismatched evidence.
+Every bar first requires `roundtable_result_valid_terminal(result) == true` — the
+**single canonical validity predicate** (#41), false on any of `truncated`,
+`items_truncated`, `degraded`, `cost_capped`, `deadline_hit`, `cancelled`,
+`lost_result`, or an `items_round`/`artifact_round` provenance mismatch. The
+done-bar, the chunk-aggregate, the capture hook, and the gate digest all consult
+this one predicate rather than re-listing flags inline, so no consumer can pass on
+a subset. For review-mode done-bars the surfaced `artifact_round`/`best_round`
+provenance must match the evaluated `items_round`, and the gate digest explains any
+mismatch rather than silently passing.
 
 - `zero_blocking` *(default)* — `converged == true` and no `items[]` of
   `severity == "blocking"`. Suggestions/nits are surfaced in the gate digest but
@@ -1021,6 +1043,11 @@ ledger) before the full idea→merge pipeline of P2/P3.
   `cost_capped`, `deadline_hit`, `cancelled`, lost result, or ambiguous
   `items_round` / `artifact_round` provenance prevents a done-bar pass and
   escalates.
+- **Single validity predicate (#41)** — a table-driven test trips each invalidity
+  flag in turn and asserts that **every** consumer (done-bar, chunk-aggregate,
+  capture hook, gate digest) rejects it via `roundtable_result_valid_terminal`; no
+  consumer re-implements the check, so a newly added flag cannot be honored by some
+  sites and ignored by others.
 - **Question cap** — a brief with >16 questions is rejected or split before using
   `zero_blocking_questions_answered`; overflow cannot be silently treated as
   answered.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 eighteenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 nineteenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -643,6 +643,27 @@ make explicit.
     and re-surfaces the gate digest before claiming a cap is satisfied. **Resolved
     in §4, §5, §6, §8, and §10.**
 
+## PR #183 nineteenth review — the gate's own authorization
+
+Eighteen rounds hardened what the gate *evaluates*; none specified who may *resolve*
+it. That is the integrity of the whole design.
+
+53. **The gate verdict must be human/operator-authorized, distinct from the
+    driving agent's `CAP_DELEGATE` — or the agent can self-approve its own merge.**
+    The two human gates are the load-bearing control (§11: they "do not remove the
+    human"). But every pipeline/delegate action in the tree is gated by
+    `CAP_DELEGATE` (`server_auth.c`: `delegate.roundtable`, `delegate.*`, `jobs.*`),
+    which the driving agent **already holds** to run the roundtable. If
+    `pipeline gate <id> pass|fail` is gated the same way, the driving agent can
+    `pass` its own gate and trigger the merge — defeating the gate entirely and
+    turning the pipeline into the gate-less autonomous machine §11 forbids. The gate
+    *resolution* needs a **separate authority not granted to a delegate-driving
+    session**: a distinct capability (e.g. `CAP_PIPELINE_GATE`), an operator/human
+    principal, or an out-of-band confirmation. The agent may *surface* a gate (move
+    to `*_pending`, build the digest) but must never be able to *resolve* it. A
+    negative test asserts a session holding only the agent's caps is **denied**
+    `gate pass`. **Resolved in §5, §8, §10, and §11.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -1003,6 +1024,17 @@ reason becomes a brief `focus`/`questions` entry for the next loop, and the stat
 returns to the prior review phase. The fail reason is durable in the ledger so the
 re-review is genuinely directed by it.
 
+**Resolving a gate requires authority the driving agent does not have (#53).** The
+agent may *surface* a gate — move the pipeline to `*_pending`, build the digest —
+but `gate pass|fail` is the one action it must not be able to call on itself,
+because passing triggers the merge. Since the driving agent holds `CAP_DELEGATE`
+(to run the roundtable) and every existing pipeline/delegate method is
+`CAP_DELEGATE`-gated, the gate resolution must require a **separate** authority not
+present in a delegate-driving session: a distinct capability (e.g.
+`CAP_PIPELINE_GATE`), an operator/human principal, or an out-of-band confirmation.
+Without that separation the two human gates are decorative — the agent could pass
+its own.
+
 The command/API surface must be explicit in implementation. The proposal may add
 `aimee pipeline status|gate` as a new first-class CLI/MCP surface, or extend the
 existing `autopilot` pipeline handler, but it must not leave two unrelated
@@ -1154,6 +1186,10 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **Hard if exposing HTTP:** route namespace selection. `GET /v1/pipeline/status`
   already belongs to the KB/corpus ingest pipeline, so roundtable-authoring routes
   must use a distinct namespace or remain CLI/MCP-only in v1 (#45).
+- **Hard:** a gate-resolution authority distinct from `CAP_DELEGATE` (#53). Every
+  pipeline/delegate method today maps to `CAP_DELEGATE`, which the driving agent
+  holds; `gate pass|fail` must require a capability/principal that a delegate-driving
+  session does not have, or the agent can self-approve its own merge.
 - **Soft:** the cost-accounting proposal's `usage_ledger` / `/v1/usage/*` for
   whole-pipeline cost that includes implementation-phase spend (#51). Absent it,
   the total cap is roundtable-child-run-cost only and says so (#49). Any
@@ -1355,6 +1391,10 @@ ledger) before the full idea→merge pipeline of P2/P3.
   ledger keeps the original source pinned or explicitly reconciles and marks the
   gate digest stale. Missing in-scope usage rows block "cap satisfied"; a
   roundtable-only configuration uses the explicit roundtable-only key/contract.
+- **Gate authority separation (#53)** — a session holding only the driving agent's
+  caps (`CAP_DELEGATE`) can surface a gate but is **denied** `gate pass|fail`; only
+  the separate gate authority (capability/operator principal/out-of-band) can
+  resolve it. The negative test proves an agent cannot self-approve and merge.
 - **Parked-gate resource release + TTL (#47)** — at a gate, the review-scoped index
   is dropped and correctly re-ingested from the origin on resume (same content
   hash, retrieval still works); with a TTL set, an unanswered gate moves to
@@ -1381,7 +1421,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
   means DRAFT produces a skeleton; the author-revise loop expands it in the working
   file. Generating long-form text inside the roundtable artifact is out of scope.
 - A fully autonomous, gate-less pipeline — the two human gates are mandatory by
-  design; "configurable max passes" bounds cost, it does not remove the human.
+  design; "configurable max passes" bounds cost, it does not remove the human. This
+  is **enforced by authority separation (#53)**, not convention: the driving agent
+  cannot resolve a gate, so the pipeline cannot self-approve its way to a merge.
 - Engine changes to the roundtable. The pipeline is strictly on top.
 - Multi-proposal/parallel-pipeline scheduling beyond the explicit parked-gate
   admission rule (#48). v1 may allow many parked/waiting-human rows only if they

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -25,7 +25,7 @@ quality gates**:
 
 ```
 [Human] idea
-  → DRAFT roundtable generates a first proposal
+  → DRAFT roundtable generates a first proposal skeleton (8KB-capped; expanded in review)
   → REVIEW roundtable ⇄ author-revise  (until done-bar)        ← proposal quality gate
   → open proposal PR
   → [Human gate 1] pass / fail
@@ -86,6 +86,59 @@ part of the proposal rather than left to interpretation:
    draft-capable MCP surface), while REVIEW loops use `ensemble_review`.
    **Resolved in §1, §2, and §8.**
 
+## PR #183 second review — feasibility and accuracy against the engine
+
+A second pass that read the engine buffers and the in-tree MCP surface (not just
+the proposal headers) found four more items — one of which contradicts a core
+premise.
+
+8. **The `agent-directed-pr-review` dependency is overstated; the review surface
+   is already on `testing`.** `ensemble_review` is fully registered
+   (`src/mcp_tools.c:610`) and dispatched (`handle_mcp_ensemble_review`,
+   `server_mcp.c:1502`): its schema already accepts a `diff` (minLength 20) **and**
+   a `brief` (string or `{focus,fixes,invariants,questions}`), queues
+   `delegate.roundtable`, returns a run id, and its result already exposes the
+   structured `items`/`items_round` vs `artifact_round` distinction. So P1a (brief)
+   + P1b (items) + P1c (tool) are effectively landed for **review** mode. The real
+   remaining dependency is narrow: confirm the `/v1/runs` result contract is stable
+   enough to evaluate the done-bar, and add a **draft**-capable callable path
+   (#9/§8). **Resolved in §8 and the What-exists table** (downgraded from "hard
+   dependency on an unmerged proposal" to "review surface in tree; verify result
+   contract").
+
+9. **DRAFT mode cannot generate a full-length proposal.** The roundtable
+   `artifact` is `xstrdup0(res.response)` (`delegate_ensemble.c:592`), and every
+   participant/aggregator `response` is a fixed `char[8192]`
+   (`delegate_ensemble.h:14`) produced under a ~4096-token aggregator cap
+   (`:390`). 8 KB is ~150–250 lines of markdown; real proposals in this tree run
+   300–1400 lines. So "DRAFT generates a first proposal" is **not feasible as one
+   call** — the artifact truncates. This is distinct from gap #5 (storage): #5 is
+   "don't inline large artifacts into the ledger," this is "the engine cannot
+   *emit* one." **Resolved in §1, §2, and §11** by having DRAFT produce a
+   **skeleton/outline** that the author-revise loop expands section by section,
+   never expecting a complete proposal from a single DRAFT artifact.
+
+10. **The done-bar result must be captured to DB1 at pass completion — the
+    `/v1/runs` record is eviction-prone.** The done-bar is read by polling
+    `/v1/runs/{id}`, backed by the same `openai_runs_store`
+    (`OPENAI_RUNS_STORE_MAX 256`, oldest-reused, in-process, non-durable —
+    `openai_runs_store.c:15`). A long pass (up to `roundtable_deadline_ms`, default
+    10 min), 256 sibling runs, or a restart can evict the record **before** the
+    agent reads it. Gap #2 moved the *ledger* to DB1 but left the *result-capture
+    race* open. **Resolved in §4** by requiring the structured pass result (items,
+    counts, `converged`, cost) to be persisted into the DB1 ledger the moment the
+    run reaches a terminal state — the `/v1/runs` record is a transient read, never
+    the retained result.
+
+11. **The "pass → merge" edges need explicit merge authority and CI assumptions.**
+    Both gates end in the agent merging a PR to `testing`, but this repo's flow
+    bases PRs on `testing`, may require `gh pr merge --admin` (CI has been
+    billing-suspended, so checks can hang), and enforces branch policy. The pass
+    edge cannot assume an unattended `gh pr merge` succeeds. **Resolved in §5 and
+    §8** by stating the merge is an explicit, possibly admin-gated step the agent
+    performs only after the human pass, with CI-state and branch-policy
+    preconditions surfaced rather than assumed.
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -112,7 +165,8 @@ part of the proposal rather than left to interpretation:
 | Capability | Status |
 |---|---|
 | Multi-round panel, DRAFT + REVIEW modes, deterministic convergence, dedup, severity, cost/deadline bounds | **exists** (engine, `testing`) |
-| Directed review (brief), structured items returned, `ensemble_review` MCP tool | **partial in tree; dependency on final agent-directed-pr-review P1a–c contract** |
+| Directed review (brief), structured items returned, `ensemble_review` MCP tool (review mode) | **in tree on `testing`** (`mcp_tools.c:610`, `handle_mcp_ensemble_review`); verify result contract (§8) |
+| A **draft**-capable callable path | **gap** — `ensemble_review` forces review mode; DRAFT needs `/v1/delegate/roundtable --mode draft` or a draft MCP sibling (§8) |
 | PR open / merge, diff capture (`git diff`) | **exists** (`gh`, `git`) |
 | Outer REVIEW⇄revise loop, done-bar evaluation, pass ceiling + escalation | **net-new** (§3) |
 | The two human gates + the two fail-return edges | **net-new** (§5) |
@@ -128,9 +182,13 @@ States (persisted in the §4 ledger):
 Transitions:
 
 1. **drafting** — DRAFT roundtable turns the human idea (+ any seed brief) into a
-   first proposal artifact. One roundtable call in `ROUNDTABLE_DRAFT` mode
-   (through `/v1/delegate/roundtable` / `aimee delegate roundtable --mode draft`,
-   or an explicit draft-capable MCP surface) produces the working `artifact`.
+   first proposal **skeleton**, not a finished proposal. One roundtable call in
+   `ROUNDTABLE_DRAFT` mode (through `/v1/delegate/roundtable` / `aimee delegate
+   roundtable --mode draft`, or an explicit draft-capable MCP surface) produces the
+   working `artifact` — but that artifact is `char[8192]`-capped (#9), so DRAFT
+   yields a section outline + goal/scope, which the `proposal_review` author-revise
+   loop expands section by section. A full proposal is never expected from one
+   DRAFT call.
 2. **proposal_review** — the §3 outer loop: REVIEW the draft, author-revise from
    the items, re-REVIEW, until the done-bar (§3). Then the agent opens the proposal
    PR (`gh pr create`, base `testing`, per repo flow) and moves to `gate1_pending`.
@@ -152,10 +210,13 @@ across a server restart or a new agent session.
 Both phases use the **same** engine; they differ only in input and brief.
 
 - **Proposal phase (B).** Input = proposal markdown. **Both** modes (per decision):
-  DRAFT to generate the first artifact in `drafting`, then REVIEW to gate it in
-  `proposal_review`. The brief carries the proposal's *goal*, the *invariants* it
-  must satisfy, and the human's seed *questions*. Author-revise between REVIEW
-  passes is done by the driving agent (it is the proposal's author).
+  DRAFT to generate the first **skeleton** in `drafting` (8 KB-capped, #9), then
+  REVIEW to gate it in `proposal_review`, with the driving agent expanding the
+  skeleton into the full proposal across the author-revise passes. The full
+  proposal lives in the working file/PR, not in the DRAFT artifact; REVIEW reviews
+  the file (or chunked sections for large proposals, like the diff path below),
+  not the truncated artifact. The brief carries the proposal's *goal*, the
+  *invariants* it must satisfy, and the human's seed *questions*.
 - **PR phase (A).** Input = unified diff (normally `git diff <base>...HEAD`;
   aimee has no PR-fetch and needs none — `agent-directed-pr-review` §6). REVIEW
   mode only; the agent applies fixes between passes. For large diffs, the driving
@@ -245,6 +306,16 @@ Either way, the durable record holds:
   and last checked mergeability;
 - the human-gate verdicts, fail reasons, actor/timestamp, and resume action taken.
 
+**Result capture is eager, not lazy (#10).** The done-bar is read from the
+roundtable run's structured result, but that lives in `/v1/runs` /
+`openai_runs_store`, which is bounded (`OPENAI_RUNS_STORE_MAX 256`, oldest-reused)
+and non-durable. The driving agent therefore copies the structured pass result
+(items + severities + `count`, `converged`, counts, `cost_usd`, `rounds_run`)
+into the DB1 ledger the **moment the run reaches a terminal state** — before any
+further pass, gate, or restart can evict the `/v1/runs` record. The `/v1/runs` id
+is retained only as a historical pointer; the ledger row is the source of truth
+for the done-bar and the gate digest.
+
 This makes the human gate a durable checkpoint: `status` shows where it is and
 the evidence; `gate pass|fail --reason "…"` records the verdict and resumes the
 loop. The driving agent reconstructs its position from the ledger on any new
@@ -280,6 +351,16 @@ the worktree is clean enough for the operation, `gh`/GitHub auth is available,
 and mergeability has not changed underneath the gate. A failed validation returns
 to the relevant review phase or asks the human for a fresh verdict with the stale
 evidence called out.
+
+**Merge is an explicit, policy-aware step, not an assumed `gh pr merge` (#11).**
+This repo bases PRs on `testing`, enforces branch policy, and has run with CI
+billing suspended (so required checks can hang or fail fast). The pass→merge edge
+therefore: (a) runs only after the human pass; (b) surfaces CI/mergeability state
+in the gate digest rather than assuming green; (c) may require `gh pr merge
+--admin` and states so; and (d) records the merge SHA in the ledger. If the merge
+cannot complete under policy (auth, protected branch, hung checks), the pipeline
+parks at the gate with the reason surfaced — it never reports a phase advanced
+when the merge did not land.
 
 ## §6 Config
 
@@ -324,12 +405,21 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 
 ## §8 Dependencies
 
-- **Hard:** `agent-directed-pr-review` P1a (brief) + P1b (structured items
-  returned) + P1c (`ensemble_review` MCP tool over the async bridge) as a stable
-  callable contract. The current tree has an `ensemble_review` MCP route that
-  queues `delegate.roundtable`, but the pipeline still needs the final structured
-  result shape, status/polling contract, cancellation behavior, and payload
-  limits from that proposal. Without P1b it cannot evaluate the done-bar.
+- **Mostly satisfied (review mode):** `ensemble_review` is already on `testing`
+  with the brief (string or `{focus,fixes,invariants,questions}`), the structured
+  `items`/`items_round`/`artifact_round` result, and the run-id/poll lifecycle
+  (`mcp_tools.c:610`, `handle_mcp_ensemble_review`). The remaining dependency on
+  `agent-directed-pr-review` is **narrow**: confirm the `/v1/runs` result shape is
+  stable and complete enough to evaluate the done-bar (the items array with
+  severities and `count`), and treat any tightening of that contract as a shared
+  interface, not a blocker. The pipeline is *not* gated on that proposal merging
+  wholesale.
+- **Hard for proposal drafting (open gap):** a callable `ROUNDTABLE_DRAFT` path.
+  `ensemble_review` forces review mode, so DRAFT must go through
+  `/v1/delegate/roundtable` / `aimee delegate roundtable --mode draft`, or a narrow
+  draft MCP sibling — never by overloading the review-only tool. And per #9 the
+  DRAFT artifact is ~8 KB-capped, so this path yields a skeleton, not a full
+  proposal.
 - **Hard for proposal drafting:** a callable `ROUNDTABLE_DRAFT` path. The existing
   `/v1/delegate/roundtable` / `aimee delegate roundtable --mode draft` surface is
   enough if the driving agent can call it; otherwise add a narrow draft MCP
@@ -376,6 +466,14 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Run-store separation** — kill/restart after child `/v1/runs` records are gone;
   the pipeline still resumes from DB1 and marks missing child run details as
   historical evidence, not lost state.
+- **Eager result capture (#10)** — drive ≥256 sibling runs (or force eviction)
+  between a pass completing and the done-bar being read; the pass result is already
+  in DB1, so the done-bar and digest are unaffected by the evicted `/v1/runs`
+  record.
+- **DRAFT skeleton + expansion (#9)** — a DRAFT call returns a skeleton within the
+  8 KB cap without truncating mid-structure; the author-revise loop grows it to a
+  full proposal in the working file, and REVIEW reviews the file/chunks, not the
+  capped artifact.
 - **Done-bar config** — each of the three bars stops the loop at the right point
   (suggestions block under bar 2; questions must be answered under bar 3).
 - **Pass-ceiling escalation** — with a low cap and an unresolvable seeded issue,
@@ -402,6 +500,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - Storing whole proposals or large diffs as unbounded DB blobs. DB1 stores refs,
   manifests, hashes, and compact digests; working files/blobs carry the large
   content.
+- Expecting DRAFT mode to emit a complete proposal (#9). The 8 KB artifact cap
+  means DRAFT produces a skeleton; the author-revise loop expands it in the working
+  file. Generating long-form text inside the roundtable artifact is out of scope.
 - A fully autonomous, gate-less pipeline — the two human gates are mandatory by
   design; "configurable max passes" bounds cost, it does not remove the human.
 - Engine changes to the roundtable. The pipeline is strictly on top.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 seventh review)
+- **Date:** 2026-06-11 (revised post-PR-#183 eighth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -43,6 +43,12 @@ The roundtable runs **as many passes as correctness takes** — depth is the poi
 The done-bar is a *correctness* condition, not a pass budget; the configurable
 pass ceiling is only an operator cost-backstop that **escalates to the human**
 when hit without reaching the done-bar (it never auto-passes a not-done artifact).
+
+**Design invariant — always keep the origin artifact.** Chunking is allowed
+anywhere in the pipeline, but it is never a substitute for the whole: every
+artifact (proposal, diff) is stored *whole* in db2 alongside its chunks, so the
+full origin is always retrievable and no step ever has to reconstruct it from
+slices. Chunk to fit a call; retrieve the origin when correctness needs it.
 
 ## PR #183 review — gaps and how they are resolved
 
@@ -328,6 +334,41 @@ holes.
     ledger, and tolerate the worker's eventual terminal write. **Resolved in §4,
     §5, and §10.**
 
+## PR #183 eighth review — making chunked review actually buildable
+
+Gap #28 correctly demands a whole-artifact aggregate over chunks, but its own
+resolution has two holes: the aggregate can't re-read what didn't fit, and nothing
+says how big a chunk is.
+
+32. **Store the artifact in db2 as whole text + chunks and *retrieve* — don't
+    agonize over "fit it in one call vs. summarize it."** §3 requires a
+    whole-artifact synthesis/check, and an artifact large enough to be chunked
+    won't fit one review call. The resolution is Aimee's core competency, not a
+    bespoke manifest: ingest the artifact-under-review into db2's existing
+    `kb_documents` chunk store, which already gives everything the aggregate needs —
+    `chunk_index` + `prev_chunk_id`/`next_chunk_id` make the whole text
+    reconstructable by walking the chain, `heading_path` is a section manifest for
+    free, `file_hash` tracks staleness, and vector + FTS retrieval are built in.
+    Per-chunk review passes review each chunk; the whole-artifact aggregate/seams
+    check is a reviewer given **db2 retrieval over the artifact's own chunks**, so
+    it pulls cross-chunk context (the other definition of a symbol, a missing
+    section, a renamed reference) on demand instead of needing the full text inline.
+    Because both the whole and the chunks are stored, the "fit it in one call vs.
+    summarize" decision never has to be made. The artifact lives in a
+    **review-scoped/ephemeral project namespace**, cleaned up on pipeline
+    completion, so it never pollutes durable memory. **Resolved in §2, §3, §4, and
+    §10.**
+33. **The chunk threshold must derive from the panel's *minimum* participant
+    context budget, not a fixed size.** The panel is heterogeneous
+    (`ensemble_reference_models` resolve to different models with different context
+    windows — the same resolution §7 already does for diversity). A chunk sized for
+    the largest-context participant overflows the smallest and silently truncates
+    its review; sized for the smallest, it wastes the largest and inflates pass
+    count and cost. Chunking is sized to the **min context budget across the active
+    panel** (resolved per run), reserving headroom for the brief, role framing, and
+    peer notes, with the resolved budget and threshold recorded in the chunk
+    manifest. **Resolved in §2 and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -420,7 +461,10 @@ Both phases use the **same** engine; they differ only in input and brief.
   Chunking is a pass-level manifest, not a set of unrelated mini-reviews: every
   chunk stores an input hash and result, the pass stores the aggregate, and the
   done-bar can pass only after all chunks are covered plus a whole-artifact
-  synthesis/check has considered cross-chunk invariants (#28).
+  synthesis/check has considered cross-chunk invariants (#28). **Chunking never
+  discards the origin: the artifact-under-review is ingested whole into db2
+  (`kb_documents`) alongside its chunks, so the full text is always retained and
+  the cross-chunk check retrieves any span on demand (#32).**
   Pipeline-owned PR reviews use the async op-run path with validated pass
   metadata, not a direct synchronous roundtable dispatch. The brief carries the
   *fixes just applied*, the *invariants* the change must not break, and the
@@ -469,7 +513,12 @@ result**, not on any one child chunk. Every manifest entry must have a completed
 valid REVIEW result over the expected chunk hash, and the aggregate must include a
 whole-artifact synthesis/check for cross-chunk findings before the phase can pass.
 Any missing, stale, truncated, degraded, or failed chunk keeps the aggregate
-blocked.
+blocked. The whole-artifact check is **retrieval-backed, not a re-ingest** (#32):
+the artifact is stored whole + chunked in db2 (`kb_documents`), so the
+cross-chunk reviewer pulls the other definition of a symbol, a missing section, or
+a renamed reference via vector/FTS + the `prev_chunk_id`/`next_chunk_id` chain on
+demand — it never needs the full text in one context window, and the origin
+artifact is always retained, never replaced by its chunks.
 
 **Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
 bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
@@ -515,8 +564,9 @@ Either way, the durable record holds:
 
 - pipeline id, state (§1), phase, created/updated timestamps, and schema version;
 - artifact refs: proposal path/blob/ref, implementation branch, diff ref or
-  chunk manifest, and content hashes, not unbounded inline text as the primary
-  representation;
+  chunk manifest, the db2 `kb_documents` ingest ref (the **whole** artifact +
+  chunks, per the origin-retention invariant), and content hashes — not unbounded
+  inline text as the primary representation;
 - the current brief plus compact gate digest;
 - per-pass history: each outer pass's status, aggregate child `run_id` if
   single-call, `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`,
@@ -796,6 +846,16 @@ ledger) before the full idea→merge pipeline of P2/P3.
   with a cross-chunk invariant violation; individual chunks can complete, but the
   phase cannot pass until the aggregate whole-artifact synthesis/check records the
   violation resolved. Missing or stale chunk hashes keep the aggregate blocked.
+- **Origin retention + retrieval-backed aggregate (#32, origin invariant)** — the
+  artifact is ingested whole + chunked into db2 (`kb_documents`); the whole text is
+  recoverable via the `prev/next` chain and `chunk_index`, the cross-chunk check
+  resolves a planted cross-chunk reference by **retrieval** (no full re-ingest),
+  and the review-scoped namespace is cleaned up on pipeline completion without
+  touching durable memory.
+- **Chunk threshold from min panel context (#33)** — a heterogeneous panel sizes
+  chunks to the smallest participant context budget (resolved per run, reserving
+  brief/role/peer-note headroom); a chunk that would overflow the smallest model is
+  never submitted to it.
 - **Late finalization guard (#30)** — start an attempt, supersede/cancel/abandon
   it, then let the old worker finish; the terminal attempt row is recorded, but it
   does not update the current aggregate, pass the done-bar, open a gate, or resume

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 fourteenth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 fifteenth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -534,6 +534,38 @@ server routing and run-capture code found two more buildability gaps.
     `/v1/roundtable/pipelines/...` or `/v1/authoring/pipelines/...`; otherwise v1
     can remain CLI/MCP-only. **Resolved in §5, §8, §10, and §12.**
 
+## PR #183 fifteenth review — spend bound across fail-return, and the parked-gate lifecycle
+
+A fresh pass over the *cost* and *resource-lifecycle* of the long-lived states
+(not the engine) found two more holes the prior rounds left open.
+
+46. **The per-phase cost cap's behavior across fail-return is unspecified, and
+    there is no whole-pipeline ceiling.** `roundtable_pipeline_max_cost_usd` is
+    per-phase, but a gate **fail** returns to the same review phase and runs more
+    passes. The proposal never says whether the cap **resets, continues, or
+    accumulates** across fail-return re-entries — so a repeatedly-failed gate could
+    have no real spend bound (if it resets) or surprise the operator (if it
+    accumulates). Specify: the per-phase cap **accumulates across all re-entries of
+    that phase** (a fail-return never resets it), and add a **whole-pipeline**
+    cumulative ceiling (`roundtable_pipeline_max_total_cost_usd`, default 0 =
+    unbounded) bounding proposal + implementation + PR phases together. Tripping
+    either escalates to the human, never auto-passes. The ledger already records
+    per-pass cost, so this is a sum, not new accounting. **Resolved in §3, §4, §6,
+    and §10.**
+47. **A never-answered gate holds resources indefinitely; define the park
+    lifecycle.** Gates are designed to "sit for hours or days," and explicit
+    `cancel`/`abandon` (#31) covers *intentional* teardown — but nothing covers a
+    gate simply left unanswered. While parked, the pipeline pins the review-scoped
+    db2 index, the worktree, and the branch; across many open pipelines that index
+    grows unbounded. Specify: (a) on entering a `*_pending` gate the pipeline
+    **releases re-creatable resources** — the review-scoped db2 index is dropped and
+    re-ingested from the retained origin (#42) on resume, and the worktree may be
+    released — keeping only the durable ledger + origin ref; (b) an optional gate
+    TTL (`roundtable_pipeline_gate_ttl_h`, default 0 = no expiry) that on expiry
+    moves the pipeline to `abandoned` with full child-run-stop + cleanup (#31),
+    **never** an auto-pass. A parked pipeline must not pin a growing index. **Resolved
+    in §4, §5, §6, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -722,12 +754,14 @@ anchors on its own prior output. (The engine already dedupes within a call; this
 prevents cross-pass echo.)
 
 **Non-termination backstop.** Besides the optional pass ceiling, the inherited
-`ensemble_max_cost_usd` (per call) and a new cumulative
-`roundtable_pipeline_max_cost_usd` (per phase, §6) bound spend; either tripping
-escalates to the human rather than silently passing. Infrastructure retries under
-one pass id are separately bounded by `roundtable_pipeline_max_attempts_per_pass`
-(#29) so capture failures do not consume correctness passes but also cannot spin
-forever.
+`ensemble_max_cost_usd` (per call), a cumulative `roundtable_pipeline_max_cost_usd`
+(per phase), and a cumulative `roundtable_pipeline_max_total_cost_usd` (whole
+pipeline, §6) bound spend; any tripping escalates to the human rather than silently
+passing. **The per-phase cap accumulates across fail-return re-entries of that
+phase — a fail-return never resets it** (#46) — and the whole-pipeline cap spans
+proposal + implementation + PR phases together. Infrastructure retries under one
+pass id are separately bounded by `roundtable_pipeline_max_attempts_per_pass` (#29)
+so capture failures do not consume correctness passes but also cannot spin forever.
 
 ## §4 Hybrid state — the resumable pipeline ledger
 
@@ -841,6 +875,15 @@ the evidence; `gate pass|fail --reason "…"` records the verdict and resumes th
 loop. The driving agent reconstructs its position from the ledger on any new
 session and validates branch/PR drift before continuing.
 
+**Parked gates release re-creatable resources (#47).** On entering a `*_pending`
+gate the pipeline keeps only the durable ledger + whole-origin ref and **releases
+what it can rebuild**: the review-scoped db2 index is dropped (and re-ingested from
+the retained origin, #42, when the loop resumes), and the worktree may be released.
+A pipeline parked for days therefore does not pin a growing review index or a
+worktree per open pipeline. An optional `roundtable_pipeline_gate_ttl_h` (§6) moves
+a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
+cleanup (#31) — never an auto-pass.
+
 ## §5 The two human gates
 
 At `gate1_pending` / `gate2_pending` the agent **pauses** and surfaces a compact
@@ -911,7 +954,14 @@ roundtable config surface is scalar keys like `roundtable.max_rounds`,
   cancellation retry) under the same stable pass id without consuming outer
   correctness passes.
 - `roundtable_pipeline_max_cost_usd` — double, cumulative per-phase spend cap;
-  0 = unbounded; tripping escalates.
+  0 = unbounded; tripping escalates. **Accumulates across fail-return re-entries of
+  the phase; a fail-return never resets it** (#46).
+- `roundtable_pipeline_max_total_cost_usd` — double, cumulative whole-pipeline
+  spend cap across proposal + implementation + PR phases; 0 = unbounded; tripping
+  escalates (#46).
+- `roundtable_pipeline_gate_ttl_h` — int hours, **default 0 (no expiry)**; >0 moves
+  a gate left unanswered past the TTL to `abandoned` with full child-run-stop +
+  cleanup (#31), never an auto-pass (#47).
 - `roundtable_pipeline_unknown_context_tokens` — int, conservative fallback chunk
   input budget used only when a panel participant's context window cannot be
   resolved; alternatively the implementation may make unknown context a hard
@@ -1163,6 +1213,14 @@ ledger) before the full idea→merge pipeline of P2/P3.
   a single resolved provider warns; a ≥2-provider panel does not.
 - **Cost accounting** — cumulative per-phase cost matches the sum of per-pass
   `cost_usd`; the per-phase cap trips correctly.
+- **Cost across fail-return + whole-pipeline cap (#46)** — fail a gate and re-enter
+  the phase; the per-phase cap continues from its prior total (does not reset), and
+  a whole-pipeline cap trips across proposal + implementation + PR phases, each
+  escalating rather than auto-passing.
+- **Parked-gate resource release + TTL (#47)** — at a gate, the review-scoped index
+  is dropped and correctly re-ingested from the origin on resume (same content
+  hash, retrieval still works); with a TTL set, an unanswered gate moves to
+  `abandoned` with child-run-stop + cleanup, never an auto-pass.
 
 ## §11 Non-goals (v1)
 

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 review)
+- **Date:** 2026-06-11 (revised post-PR-#183 third review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -13,9 +13,11 @@
   (`src/headers/config.h`, `src/config.c`, `src/config_fields.c`,
   `src/config_sections.c`, `src/config_save.c`), and the
   driving-agent runbook/skill. It **depends on** the roundtable engine (already on
-  `testing`) and on `agent-directed-pr-review` P1a–c (the brief + structured items
-  + the `ensemble_review` MCP tool). It reuses `gh`/`git` for PR/merge. No changes
-  to the roundtable engine itself.
+  `testing`) and the in-tree `ensemble_review` review surface, with the remaining
+  review contract narrowed to stable terminal result shape/payload semantics. It
+  routes PR/merge/diff work through Aimee's workspace-aware git/PR tools rather
+  than assuming a raw local `gh`/`git` shell. No changes to the roundtable engine
+  itself.
 
 ## Design at a glance
 
@@ -139,6 +141,53 @@ premise.
     performs only after the human pass, with CI-state and branch-policy
     preconditions surfaced rather than assumed.
 
+## PR #183 third review — orchestration ownership and gate correctness
+
+The updated proposal is much closer to the implementation, but a third pass found
+several remaining gaps at the boundary between a durable pipeline and Aimee's
+current live-tool/workspace surfaces:
+
+12. **Eager result capture cannot be a best-effort driving-agent poll.** §4 says
+    the driving agent copies `/v1/runs` results into DB1 "the moment" the child run
+    reaches terminal. If the agent is asleep, disconnected, waiting at a gate, or
+    delayed behind other work, the same eviction/restart race from #10 remains.
+    The capture must be owned by the pipeline orchestrator itself: either a
+    server-side pipeline worker submits the child run and writes the terminal
+    result to DB1 in the same completion path, or the pipeline does not advance
+    and explicitly marks the pass `lost_result`. **Resolved in §4 and §9.**
+13. **The done-bar must treat degraded or incomplete runs as not done.** The
+    current bars check `converged` and item severities, but the real result also
+    carries `truncated`, `degraded`, `cost_capped`, `deadline_hit`, `cancelled`,
+    `items_round`, and `artifact_round`. A pass with truncated items, a degraded
+    best-effort result, a cost/deadline stop, cancellation, or ambiguous
+    items/artifact provenance cannot satisfy a correctness gate. **Resolved in §3
+    and §10.**
+14. **The questions-done bar needs a cap policy.** `roundtable_result_t` can track
+    only `ROUNDTABLE_MAX_QUESTIONS` (16) answered questions / coverage gaps, and
+    long briefs are 4 KB-normalized. `zero_blocking_questions_answered` must reject
+    or split briefs with >16 questions; otherwise "every brief question answered"
+    silently means "every retained question." **Resolved in §3 and §10.**
+15. **GitHub operations must use Aimee's workspace authority, not raw local shell
+    assumptions.** Aimee has a shared/detached/mirror workspace resource plane,
+    `mcp_git_run`, `git_pr`, and a per-workspace forge-token broker. A pipeline
+    resumed from another surface may not have the same local cwd or `gh` auth as
+    the original session. All git/gh operations need to route through the existing
+    workspace provider/git tools and record the workspace id/provider plus forge
+    token availability. **Resolved in §4, §5, §8, and §10.**
+16. **The pipeline needs branch/worktree isolation rules.** "One pipeline at a
+    time" does not protect the user's current checkout. The proposal must require
+    a dedicated proposal branch and implementation branch, and either a dedicated
+    worktree or an explicit clean-worktree preflight before any write. Dirty
+    user changes are a hard stop unless the user explicitly opts into using that
+    checkout. **Resolved in §1, §4, §5, and §10.**
+17. **The dependency section regressed into duplicate/stale wording.** §8 repeats
+    the DRAFT dependency and the relationship section still describes
+    `agent-directed-pr-review` as a pending hard dependency even after #8 says
+    review mode is in tree. The proposal should make the contract precise:
+    review-mode surface exists; remaining gaps are draft-callability, stable
+    terminal result capture, and pipeline orchestration. **Resolved in the
+    relationship table and §8.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -148,14 +197,13 @@ premise.
   `items[]` with a corroboration `count`, plus `answered_questions[]` and
   `coverage_gaps[]`), a deterministic `converged` predicate, `best_round`, and
   inherited cost/deadline bounds. **This proposal adds no engine code.**
-- **`agent-directed-pr-review.md` (pending) is the callable surface and remains a
-  hard dependency for the final contract.** The current tree already exposes an
-  `ensemble_review` MCP entry that queues `delegate.roundtable`, but this
-  pipeline still depends on that proposal's P1 contract being complete: P1a (the
-  **brief**: focus/fixes/invariants/questions, open mandate), P1b (return the
-  structured items to the caller in a stable shape), and P1c (the MCP/async run
-  bridge, `CAP_DELEGATE`-gated). This pipeline is the *orchestration on top* of
-  that surface.
+- **`agent-directed-pr-review.md` (pending) is no longer a broad hard dependency
+  for review mode.** The current tree already exposes `ensemble_review` with a
+  directed brief and structured roundtable result over the async bridge. This
+  pipeline depends only on the stable interface contract that proposal documents:
+  terminal result shape, polling/cancellation semantics, payload bounds, and the
+  item/artifact provenance fields. Draft callability and durable pipeline
+  orchestration remain this proposal's responsibility.
 - **`agent-roundtable-collaborative-drafting.md` (pending residual)** lists
   deeper convergence/economics tests; this proposal's validation (§10) exercises
   exactly those at pipeline scale.
@@ -167,7 +215,7 @@ premise.
 | Multi-round panel, DRAFT + REVIEW modes, deterministic convergence, dedup, severity, cost/deadline bounds | **exists** (engine, `testing`) |
 | Directed review (brief), structured items returned, `ensemble_review` MCP tool (review mode) | **in tree on `testing`** (`mcp_tools.c:610`, `handle_mcp_ensemble_review`); verify result contract (§8) |
 | A **draft**-capable callable path | **gap** — `ensemble_review` forces review mode; DRAFT needs `/v1/delegate/roundtable --mode draft` or a draft MCP sibling (§8) |
-| PR open / merge, diff capture (`git diff`) | **exists** (`gh`, `git`) |
+| PR open / merge, diff capture | **exists via workspace-aware git/PR tools** (`git_pr`, `mcp_git_run`, `gh`/`git` underneath) |
 | Outer REVIEW⇄revise loop, done-bar evaluation, pass ceiling + escalation | **net-new** (§3) |
 | The two human gates + the two fail-return edges | **net-new** (§5) |
 | Persisted, resumable roundtable pipeline ledger (hybrid state) | **net-new or explicit DB1 pipeline extension** (§4) |
@@ -188,15 +236,18 @@ Transitions:
    working `artifact` — but that artifact is `char[8192]`-capped (#9), so DRAFT
    yields a section outline + goal/scope, which the `proposal_review` author-revise
    loop expands section by section. A full proposal is never expected from one
-   DRAFT call.
+   DRAFT call. The pipeline creates or selects a dedicated proposal branch/worktree
+   before writing the proposal file.
 2. **proposal_review** — the §3 outer loop: REVIEW the draft, author-revise from
    the items, re-REVIEW, until the done-bar (§3). Then the agent opens the proposal
-   PR (`gh pr create`, base `testing`, per repo flow) and moves to `gate1_pending`.
+   PR through the workspace-aware PR surface (base `testing`, per repo flow) and
+   moves to `gate1_pending`.
 3. **gate1_pending** — human gate 1 (§5). **pass** → merge proposal PR, move to
    `implementing`. **fail** → the human's reason is appended to the brief and the
    state returns to `proposal_review`.
-4. **implementing** — the agent implements the merged proposal (normal coding;
-   not a roundtable activity), opens the implementation PR, captures the diff.
+4. **implementing** — the agent implements the merged proposal on a dedicated
+   implementation branch/worktree (normal coding; not a roundtable activity),
+   opens the implementation PR, captures the diff.
 5. **pr_review** — the §3 outer loop in REVIEW mode over the diff: REVIEW,
    agent-fix, re-REVIEW, until the done-bar.
 6. **gate2_pending** — human gate 2 (§5). **pass** → merge the implementation PR,
@@ -242,13 +293,22 @@ Two distinct loop levels — keep them un-confused:
 its review loop only when the latest REVIEW result satisfies the configured bar,
 read from real engine fields (`roundtable_result_t`):
 
+Every bar first requires a valid completed result: `truncated == false`,
+`degraded == false`, `cost_capped == false`, `deadline_hit == false`,
+`cancelled == false`, and result provenance that the gate digest can explain. For
+review-mode done-bars, `items_round` must be the round being evaluated; if the
+surfaced artifact comes from a different `artifact_round`/`best_round`, the digest
+must say so and the phase cannot silently pass on mismatched evidence.
+
 - `zero_blocking` *(default)* — `converged == true` and no `items[]` of
   `severity == "blocking"`. Suggestions/nits are surfaced in the gate digest but
   don't block.
 - `zero_blocking_suggestions` — also requires no `suggestion`-severity items
   (nits allowed). Stricter, more passes.
-- `zero_blocking_questions_answered` — `zero_blocking` plus every brief question
-  present in `answered_questions[]` and `coverage_gaps[]` empty.
+- `zero_blocking_questions_answered` — `zero_blocking` plus every accepted brief
+  question present in `answered_questions[]` and `coverage_gaps[]` empty. The
+  brief must contain at most `ROUNDTABLE_MAX_QUESTIONS` (16) questions or be split
+  into multiple review passes; overflow is not treated as answered.
 
 The driving agent computes the bar from the structured items
 (agent-directed-pr-review P1b); it never re-judges convergence itself — it trusts
@@ -302,19 +362,23 @@ Either way, the durable record holds:
   `converged`, blocking/suggestion counts, `cost_usd`, `rounds_run`, `best_round`,
   result hash, and any payload/chunk refs;
 - repository/worktree state: repo root, remote, base branch, head branch,
-  head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs, merge SHAs,
-  and last checked mergeability;
+  workspace id/provider (`shared`, `detached`, or `mirror`), dedicated worktree
+  path if any, head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs,
+  merge SHAs, forge-token/`gh` authority status, and last checked mergeability;
 - the human-gate verdicts, fail reasons, actor/timestamp, and resume action taken.
 
-**Result capture is eager, not lazy (#10).** The done-bar is read from the
+**Result capture is orchestrator-owned, not lazy (#10/#12).** The done-bar is read from the
 roundtable run's structured result, but that lives in `/v1/runs` /
 `openai_runs_store`, which is bounded (`OPENAI_RUNS_STORE_MAX 256`, oldest-reused)
-and non-durable. The driving agent therefore copies the structured pass result
-(items + severities + `count`, `converged`, counts, `cost_usd`, `rounds_run`)
-into the DB1 ledger the **moment the run reaches a terminal state** — before any
-further pass, gate, or restart can evict the `/v1/runs` record. The `/v1/runs` id
-is retained only as a historical pointer; the ledger row is the source of truth
-for the done-bar and the gate digest.
+and non-durable. The pipeline orchestrator therefore owns result capture: it
+submits the child run, observes terminal completion, and writes the structured
+pass result (items + severities + `count`, `converged`, validity flags,
+`items_round`, `artifact_round`, counts, `cost_usd`, `rounds_run`) into DB1 in the
+same completion path before any next state transition. If the terminal result
+cannot be captured, the pass is recorded as `lost_result` and the pipeline
+escalates; it never evaluates the done-bar from a missing or later-evicted
+`/v1/runs` record. The `/v1/runs` id is retained only as a historical pointer; the
+ledger row is the source of truth for the done-bar and the gate digest.
 
 This makes the human gate a durable checkpoint: `status` shows where it is and
 the evidence; `gate pass|fail --reason "…"` records the verdict and resumes the
@@ -345,12 +409,14 @@ autopilot actions cover `start`, `advance`, `status`, `list`, `cancel`, `resume`
 `link-plan`, and `link-job`, not pass/fail gates.
 
 Before a **pass** can merge or advance, the resumed agent revalidates the stored
-worktree/PR state: the PR still exists, its head SHA matches the ledger or the
-digest is marked stale, the base branch is still the intended target (`testing`),
-the worktree is clean enough for the operation, `gh`/GitHub auth is available,
-and mergeability has not changed underneath the gate. A failed validation returns
-to the relevant review phase or asks the human for a fresh verdict with the stale
-evidence called out.
+worktree/PR state through Aimee's workspace-aware git surface (`git_pr` /
+`mcp_git_run`, not an unqualified local shell): the PR still exists, its head SHA
+matches the ledger or the digest is marked stale, the base branch is still the
+intended target (`testing`), the dedicated worktree is clean enough for the
+operation, `gh`/GitHub authority is available through local auth or the
+per-workspace forge-token broker, and mergeability has not changed underneath the
+gate. A failed validation returns to the relevant review phase or asks the human
+for a fresh verdict with the stale evidence called out.
 
 **Merge is an explicit, policy-aware step, not an assumed `gh pr merge` (#11).**
 This repo bases PRs on `testing`, enforces branch policy, and has run with CI
@@ -420,15 +486,15 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
   draft MCP sibling — never by overloading the review-only tool. And per #9 the
   DRAFT artifact is ~8 KB-capped, so this path yields a skeleton, not a full
   proposal.
-- **Hard for proposal drafting:** a callable `ROUNDTABLE_DRAFT` path. The existing
-  `/v1/delegate/roundtable` / `aimee delegate roundtable --mode draft` surface is
-  enough if the driving agent can call it; otherwise add a narrow draft MCP
-  sibling rather than overloading the review-only `ensemble_review` tool.
 - **Hard:** durable DB1 checkpointing for the roundtable pipeline. `/v1/runs`
   remains a child-run polling surface only because its store is bounded and
   non-durable.
+- **Hard:** workspace-aware git/forge authority for PR create/merge and diff
+  capture. Pipeline git/gh operations must route through Aimee's git tools or
+  workspace provider so shared, detached, and mirror workspaces behave consistently.
 - **Soft:** the `git diff` range helper (agent-directed-pr-review P2) for the PR
-  phase input; otherwise the agent runs `git diff` itself.
+  phase input; otherwise the pipeline captures the diff through the
+  workspace-aware git surface.
 - **Repo flow:** PRs base `testing`; main promotion is separate and out of scope.
 
 ## §9 Phasing
@@ -436,16 +502,19 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **P0 — Ledger + states + namespace decision.** Choose the DB shape
   (`roundtable_pipeline_runs` tables vs explicit migration of DB1 `pipelines`),
   add the state enum/transitions, artifact refs/hashes, child run references, and
-  the CLI/MCP/HTTP namespace decision (`pipeline` vs `autopilot` extension). No
-  loop yet; states/gates settable manually. Mergeable alone, with restart tests.
+  the CLI/MCP/HTTP namespace decision (`pipeline` vs `autopilot` extension). Also
+  choose the orchestrator-owned terminal result capture path. No loop yet;
+  states/gates settable manually. Mergeable alone, with restart tests.
 - **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
   `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
   escalation, the echo guard. Drives the PR phase first (single mode, simplest).
 - **P2 — Proposal phase (DRAFT + REVIEW).** Add the `drafting` DRAFT step and the
-  proposal-review loop; wire `gh pr create`/merge for the proposal PR.
+  proposal-review loop; wire proposal PR create/merge through the workspace-aware
+  git/PR surface.
 - **P3 — Human gates + fail-return edges** end to end, with the durable digest,
-  PR/worktree drift validation, mergeability/auth checks, and reason-to-brief
-  feedback. This closes the full loop.
+  PR/worktree drift validation through the workspace-aware git surface,
+  mergeability/auth checks, and reason-to-brief feedback. This closes the full
+  loop.
 - **P4 — Config surface** for all keys + generated docs + tests (lands with the
   phase that first reads each key, not deferred).
 
@@ -466,16 +535,23 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Run-store separation** — kill/restart after child `/v1/runs` records are gone;
   the pipeline still resumes from DB1 and marks missing child run details as
   historical evidence, not lost state.
-- **Eager result capture (#10)** — drive ≥256 sibling runs (or force eviction)
-  between a pass completing and the done-bar being read; the pass result is already
-  in DB1, so the done-bar and digest are unaffected by the evicted `/v1/runs`
-  record.
+- **Orchestrator-owned result capture (#10/#12)** — drive ≥256 sibling runs (or
+  force eviction) between a child run completing and an agent polling it; the pass
+  result is already in DB1 because capture happened in the orchestrator's terminal
+  completion path. Simulate a missed terminal result and assert the pass becomes
+  `lost_result`, not done.
 - **DRAFT skeleton + expansion (#9)** — a DRAFT call returns a skeleton within the
   8 KB cap without truncating mid-structure; the author-revise loop grows it to a
   full proposal in the working file, and REVIEW reviews the file/chunks, not the
   capped artifact.
 - **Done-bar config** — each of the three bars stops the loop at the right point
   (suggestions block under bar 2; questions must be answered under bar 3).
+- **Done-bar validity flags** — `truncated`, `degraded`, `cost_capped`,
+  `deadline_hit`, `cancelled`, lost result, or ambiguous `items_round` /
+  `artifact_round` provenance prevents a done-bar pass and escalates.
+- **Question cap** — a brief with >16 questions is rejected or split before using
+  `zero_blocking_questions_answered`; overflow cannot be silently treated as
+  answered.
 - **Pass-ceiling escalation** — with a low cap and an unresolvable seeded issue,
   the loop escalates to the human at the cap and never auto-passes.
 - **Resumability** — kill and restart between a review pass and a gate; the ledger
@@ -483,6 +559,11 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **Git/PR drift** — mutate the PR head SHA, target branch, or mergeability while
   paused at a gate; the pass action refuses stale evidence and requires a fresh
   review or human confirmation.
+- **Workspace authority** — run proposal/implementation PR operations in shared
+  and detached workspaces; git/gh calls route through `mcp_git_run`/`git_pr` and
+  forge-token state is surfaced when required.
+- **Branch/worktree isolation** — dirty user checkout blocks the pipeline unless
+  the run has a dedicated branch/worktree or an explicit operator override.
 - **Large payload handling** — a diff/proposal larger than a single MCP/op-run
   payload is reviewed through artifact refs or chunks, and the ledger stores
   hashes so stale chunks are detected.
@@ -495,8 +576,9 @@ ledger) before the full idea→merge pipeline of P2/P3.
 
 ## §11 Non-goals (v1)
 
-- Server-side git or GitHub API (no PR fetch, no inline-comment posting); the
-  agent uses `gh`/`git` (agent-directed-pr-review §11).
+- New server-side GitHub review/comment APIs (no PR fetch, no inline-comment
+  posting). The pipeline uses Aimee's existing workspace-aware git/PR tool surface,
+  which may call `gh`/`git` underneath with the right workspace/forge authority.
 - Storing whole proposals or large diffs as unbounded DB blobs. DB1 stores refs,
   manifests, hashes, and compact digests; working files/blobs carry the large
   content.

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 twenty-first review)
+- **Date:** 2026-06-11 (revised post-PR-#183 twenty-second review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -704,6 +704,28 @@ so at-least-once delivery is a real hazard.
     at-least-once delivery, and a flaky client could merge twice or skip a phase.
     **Resolved in §4, §5, and §10.**
 
+## PR #183 twenty-second review — exactly-once needs crash recovery, not just concurrency guards
+
+#55 makes repeated gate calls idempotent, but the external merge is outside the
+DB transaction. Aimee has DB1 transaction patterns (`BEGIN IMMEDIATE`), but GitHub
+merge execution happens through `git_pr`/`mcp_git_run`/`gh` after the ledger write,
+so a crash can still land between the local state transition and the remote side
+effect.
+
+56. **`gate pass` needs a durable merge-intent / recovery state before the external
+    merge.** If the implementation atomically leaves `gate*_pending` and then
+    crashes before recording `merge_sha`, restart sees a non-pending pipeline that
+    is neither merged nor reviewable. Conversely, if it merges first and crashes
+    before advancing, restart may try to merge again without knowing the first
+    merge succeeded. The ledger needs an explicit, resumable side-effect protocol:
+    record a gate verdict plus `merge_intent` / `merge_pending` row keyed by PR
+    number + expected head SHA under a DB transaction; execute the merge; then
+    reconcile by reading PR/merge status and record `merge_sha` before advancing to
+    `implementing`/`done`. On resume, `merge_pending` is a first-class state: if the
+    PR is already merged at the expected head, finish the advance; if not, retry or
+    surface the blocked merge reason without losing the verdict. **Resolved in §1,
+    §4, §5, §9, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -742,7 +764,7 @@ so at-least-once delivery is a real hazard.
 
 States (persisted in the §4 ledger):
 
-`drafting → proposal_review → gate1_pending → implementing → pr_review → gate2_pending → done` (plus `failed`/`abandoned`).
+`drafting → proposal_review → gate1_pending → gate1_merge_pending → implementing → pr_review → gate2_pending → gate2_merge_pending → done` (plus `failed`/`abandoned`).
 
 Transitions:
 
@@ -759,18 +781,22 @@ Transitions:
    the items, re-REVIEW, until the done-bar (§3). Then the agent opens the proposal
    PR through the workspace-aware PR surface (base `testing`, per repo flow) and
    moves to `gate1_pending`.
-3. **gate1_pending** — human gate 1 (§5). **pass** → merge proposal PR, move to
-   `implementing`. **fail** → the human's reason is appended to the brief and the
-   state returns to `proposal_review`, which re-revises and **pushes to the same
-   recorded proposal branch/PR** (never a duplicate, #43).
+3. **gate1_pending** — human gate 1 (§5). **pass** records the verdict and a
+   durable merge intent, then moves to `gate1_merge_pending`; successful merge
+   reconciliation moves to `implementing`. **fail** → the human's reason is
+   appended to the brief and the state returns to `proposal_review`, which
+   re-revises and **pushes to the same recorded proposal branch/PR** (never a
+   duplicate, #43).
 4. **implementing** — the agent implements the merged proposal on a dedicated
    implementation branch/worktree (normal coding; not a roundtable activity),
    opens the implementation PR, captures the diff.
 5. **pr_review** — the §3 outer loop in REVIEW mode over the diff: REVIEW,
    agent-fix, re-REVIEW, until the done-bar.
-6. **gate2_pending** — human gate 2 (§5). **pass** → merge the implementation PR,
-   move to `done`. **fail** → reason → brief, state returns to `implementing`,
-   which pushes the fix to the **same recorded implementation branch/PR** (#43).
+6. **gate2_pending** — human gate 2 (§5). **pass** records the verdict and a
+   durable merge intent, then moves to `gate2_merge_pending`; successful merge
+   reconciliation moves to `done`. **fail** → reason → brief, state returns to
+   `implementing`, which pushes the fix to the **same recorded implementation
+   branch/PR** (#43).
 
 Every state is durable (§4) so a human gate can be answered hours or days later,
 across a server restart or a new agent session. For v1 admission control, only
@@ -959,7 +985,8 @@ Either way, the durable record holds:
   path if any, head/base commit SHAs, dirty-state snapshot, PR number(s), PR URLs,
   merge SHAs, forge-token/`gh` authority status, and last checked mergeability;
 - the human-gate verdicts, fail reasons, actor/timestamp, resume action taken,
-  and cost-scope evidence for total-cap accounting, including whether
+  merge-intent / merge-pending records keyed by PR number + expected head SHA
+  (#56), and cost-scope evidence for total-cap accounting, including whether
   implementation-agent spend is included, unknown, or out of scope (#49).
 
 **Result capture is server-worker-owned, not agent-poll (#10/#12/#18).** The
@@ -1078,11 +1105,19 @@ its own.
 **Gate resolution is exactly-once (#55).** `gate pass|fail` both records a verdict
 and (on pass) merges + advances, so it must be a guarded, idempotent transition,
 not a fire-and-forget command. It acts only when the pipeline is in the matching
-`*_pending` state and atomically leaves that state, so a repeat or concurrent call
-sees a non-pending state and returns "already resolved" rather than merging again;
-the merge itself is keyed by the recorded PR + expected head SHA (the drift check
-above), so a retried merge of an already-merged PR is a no-op. A flaky client must
-not be able to merge twice or skip a phase.
+`*_pending` state and atomically leaves that state by writing a durable
+`gate*_merge_pending` intent (#56), so a repeat or concurrent call sees a
+non-pending state and returns "already resolving/resolved" rather than merging
+again; the merge itself is keyed by the recorded PR + expected head SHA (the drift
+check above), so a retried merge of an already-merged PR is a no-op. A flaky client
+must not be able to merge twice or skip a phase.
+
+Because the merge is an external side effect, `gate*_merge_pending` is a recovery
+state, not just an implementation detail (#56). On restart/resume, the pipeline
+reconciles the recorded PR + expected head: already merged at that head records the
+merge SHA and advances; still unmerged retries or parks with the latest merge
+blocker; merged at a different head marks the gate evidence stale and stops for
+operator review.
 
 If the implementation chooses the distinct-capability path, it must first make the
 capability model able to represent that authority (#54). The current mask has no
@@ -1123,8 +1158,8 @@ therefore: (a) runs only after the human pass; (b) surfaces CI/mergeability stat
 in the gate digest rather than assuming green; (c) may require `gh pr merge
 --admin` and states so; and (d) records the merge SHA in the ledger. If the merge
 cannot complete under policy (auth, protected branch, hung checks), the pipeline
-parks at the gate with the reason surfaced — it never reports a phase advanced
-when the merge did not land.
+parks in the merge-pending recovery state with the reason surfaced — it never
+reports a phase advanced when the merge did not land.
 
 Because `git_pr` does not currently merge (#50), implementation must either add a
 workspace-aware `git_pr action=merge` or explicitly route the merge through
@@ -1292,7 +1327,8 @@ These make a clean done-bar correspond to *correctness*, which is the real targe
 - **P3 — Human gates + fail-return edges** end to end, with the durable digest,
   PR/worktree drift validation through the workspace-aware git surface,
   mergeability/auth checks, an explicit merge executor (#50), parked-gate admission
-  policy (#48), and reason-to-brief feedback. This closes the full loop.
+  policy (#48), durable merge-intent / merge-pending recovery (#56), and
+  reason-to-brief feedback. This closes the full loop.
 - **P4 — Config surface** for all keys + generated docs + tests (lands with the
   phase that first reads each key, not deferred).
 
@@ -1465,6 +1501,12 @@ ledger) before the full idea→merge pipeline of P2/P3.
   on a `*_pending` pipeline; exactly one merge + advance occurs, the second call
   returns "already resolved," and a retried merge of an already-merged PR is a
   no-op — never a double-merge or a skipped phase.
+- **Merge-pending crash recovery (#56)** — crash after the authorized gate verdict
+  is persisted but before merge, and again after the remote merge succeeds but
+  before `merge_sha`/advance is recorded. On restart, the pipeline resumes from
+  `gate*_merge_pending`, reconciles PR number + expected head SHA, either retries
+  or records the already-landed merge SHA, and advances exactly once. A PR merged
+  at a different head stops as stale evidence.
 - **Gate capability representation (#54)** — if a distinct gate capability is
   added, assert `CAPS_ALL`, `CAPS_AUTHENTICATED`, scoped/unscoped TCP bearer
   behavior, `server_http_route_caps`, capability advertising/OpenAPI docs, and

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 twenty-third review)
+- **Date:** 2026-06-11 (consolidated — 23 PR-#183 review rounds / 57 findings folded into the design sections and indexed in Appendix A)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -53,696 +53,9 @@ payload), and chunk rows point back to that origin. `kb_documents` is a chunk
 index, not the whole-origin store. Chunk to fit a call; retrieve the origin when
 correctness needs it.
 
-## PR #183 review — gaps and how they are resolved
-
-The initial proposal is directionally aligned with the roundtable work, but a
-review against the current tree found several implementation gaps that need to be
-part of the proposal rather than left to interpretation:
-
-1. **`pipeline_run` cannot be a blank-slate name.** Aimee already has a durable
-   DB1 `pipelines` table and `autopilot` pipeline handler
-   (`db1_pipeline_t`, `handle_autopilot`) with `start/status/list/cancel/resume`
-   style actions. It tracks a narrow plan/job pipeline, not proposal artifacts,
-   PR refs, pass history, gate verdicts, or GitHub state. The proposal must either
-   extend that schema deliberately or create a namespaced
-   `roundtable_pipeline_runs` table; it must not introduce an ambiguous second
-   "pipeline" surface. **Resolved in §4, §5, §9, §10, and §12.**
-2. **`/v1/runs` is not a durable checkpoint store.** `openai_runs_store` is an
-   in-process live store, bounded to 256 records, oldest-reused, and not durable
-   across restarts. It is suitable for child roundtable/op-run IDs, not for a
-   human gate that can sit for hours or days. **Resolved in §4, §8, §9, and §12.**
-3. **The CLI/API surface is underspecified.** The text proposes
-   `aimee pipeline status|gate`, but the existing callable pipeline surface is
-   the `autopilot` MCP handler and does not have a gate action. The proposal must
-   define whether this is a new first-class CLI/MCP/HTTP route or an extension of
-   `autopilot`, with route tests and no name collision. **Resolved in §5, §9,
-   and §10.**
-4. **GitHub/worktree state must be resumable too.** Reusing `gh`/`git` is fine,
-   but the ledger needs enough branch, commit, remote, PR, mergeability, and auth
-   assumptions to detect drift when a gate resumes in a later session. **Resolved
-   in §4, §5, and §10.**
-5. **Large artifacts cannot be blindly inlined.** Proposal markdown and PR diffs
-   can exceed MCP/op-run payload and snapshot limits. The ledger should store
-   artifact refs plus content hashes and pass diffs/proposals by path, blob, or
-   chunked capture where needed, not unbounded text blobs. **Resolved in §2, §4,
-   §10, and §11.**
-6. **Panel diversity validation must resolve agent configs.** The configured
-   `ensemble.reference_models` are agent/model names; provider diversity is not
-   the same as string uniqueness. The validator must resolve each participant's
-   provider/model at runtime before warning or passing. **Resolved in §7 and
-   §10.**
-7. **DRAFT and REVIEW do not use the same callable tool today.** The current
-   `ensemble_review` MCP bridge forces review mode; the DRAFT phase should call
-   the existing roundtable route/CLI with `mode=draft` (or add an explicit
-   draft-capable MCP surface), while REVIEW loops use `ensemble_review`.
-   **Resolved in §1, §2, and §8.**
-
-## PR #183 second review — feasibility and accuracy against the engine
-
-A second pass that read the engine buffers and the in-tree MCP surface (not just
-the proposal headers) found four more items — one of which contradicts a core
-premise.
-
-8. **The `agent-directed-pr-review` dependency is overstated; the review surface
-   is already on `testing`.** `ensemble_review` is fully registered
-   (`src/mcp_tools.c:610`) and dispatched (`handle_mcp_ensemble_review`,
-   `server_mcp.c:1502`): its schema already accepts a `diff` (minLength 20) **and**
-   a `brief` (string or `{focus,fixes,invariants,questions}`), queues
-   `delegate.roundtable`, returns a run id, and its result already exposes the
-   structured `items`/`items_round` vs `artifact_round` distinction. So P1a (brief)
-   + P1b (items) + P1c (tool) are effectively landed for **review** mode. The real
-   remaining dependency is narrow: confirm the `/v1/runs` result contract is stable
-   enough to evaluate the done-bar, and add a **draft**-capable callable path
-   (#9/§8). **Resolved in §8 and the What-exists table** (downgraded from "hard
-   dependency on an unmerged proposal" to "review surface in tree; verify result
-   contract").
-
-9. **DRAFT mode cannot generate a full-length proposal.** The roundtable
-   `artifact` is `xstrdup0(res.response)` (`delegate_ensemble.c:592`), and every
-   participant/aggregator `response` is a fixed `char[8192]`
-   (`delegate_ensemble.h:14`) produced under a ~4096-token aggregator cap
-   (`:390`). 8 KB is ~150–250 lines of markdown; real proposals in this tree run
-   300–1400 lines. So "DRAFT generates a first proposal" is **not feasible as one
-   call** — the artifact truncates. This is distinct from gap #5 (storage): #5 is
-   "don't inline large artifacts into the ledger," this is "the engine cannot
-   *emit* one." **Resolved in §1, §2, and §11** by having DRAFT produce a
-   **skeleton/outline** that the author-revise loop expands section by section,
-   never expecting a complete proposal from a single DRAFT artifact.
-
-10. **The done-bar result must be captured to DB1 at pass completion — the
-    `/v1/runs` record is eviction-prone.** The done-bar is read by polling
-    `/v1/runs/{id}`, backed by the same `openai_runs_store`
-    (`OPENAI_RUNS_STORE_MAX 256`, oldest-reused, in-process, non-durable —
-    `openai_runs_store.c:15`). A long pass (up to `roundtable_deadline_ms`, default
-    10 min), 256 sibling runs, or a restart can evict the record **before** the
-    agent reads it. Gap #2 moved the *ledger* to DB1 but left the *result-capture
-    race* open. **Resolved in §4** by requiring the structured pass result (items,
-    counts, `converged`, cost) to be persisted into the DB1 ledger the moment the
-    run reaches a terminal state — the `/v1/runs` record is a transient read, never
-    the retained result.
-
-11. **The "pass → merge" edges need explicit merge authority and CI assumptions.**
-    Both gates end in the agent merging a PR to `testing`, but this repo's flow
-    bases PRs on `testing`, may require `gh pr merge --admin` (CI has been
-    billing-suspended, so checks can hang), and enforces branch policy. The pass
-    edge cannot assume an unattended `gh pr merge` succeeds. **Resolved in §5 and
-    §8** by stating the merge is an explicit, possibly admin-gated step the agent
-    performs only after the human pass, with CI-state and branch-policy
-    preconditions surfaced rather than assumed.
-
-## PR #183 third review — orchestration ownership and gate correctness
-
-The updated proposal is much closer to the implementation, but a third pass found
-several remaining gaps at the boundary between a durable pipeline and Aimee's
-current live-tool/workspace surfaces:
-
-12. **Eager result capture cannot be a best-effort driving-agent poll.** §4 says
-    the driving agent copies `/v1/runs` results into DB1 "the moment" the child run
-    reaches terminal. If the agent is asleep, disconnected, waiting at a gate, or
-    delayed behind other work, the same eviction/restart race from #10 remains.
-    The capture must be owned by the pipeline orchestrator itself: either a
-    server-side pipeline worker submits the child run and writes the terminal
-    result to DB1 in the same completion path, or the pipeline does not advance
-    and explicitly marks the pass `lost_result`. **Resolved in §4 and §9.**
-13. **The done-bar must treat degraded or incomplete runs as not done.** The
-    current bars check `converged` and item severities, but the real result also
-    carries `truncated`, `degraded`, `cost_capped`, `deadline_hit`, `cancelled`,
-    `items_round`, and `artifact_round`. A pass with truncated items, a degraded
-    best-effort result, a cost/deadline stop, cancellation, or ambiguous
-    items/artifact provenance cannot satisfy a correctness gate. **Resolved in §3
-    and §10.**
-14. **The questions-done bar needs a cap policy.** `roundtable_result_t` can track
-    only `ROUNDTABLE_MAX_QUESTIONS` (16) answered questions / coverage gaps, and
-    long briefs are 4 KB-normalized. `zero_blocking_questions_answered` must reject
-    or split briefs with >16 questions; otherwise "every brief question answered"
-    silently means "every retained question." **Resolved in §3 and §10.**
-15. **GitHub operations must use Aimee's workspace authority, not raw local shell
-    assumptions.** Aimee has a shared/detached/mirror workspace resource plane,
-    `mcp_git_run`, `git_pr`, and a per-workspace forge-token broker. A pipeline
-    resumed from another surface may not have the same local cwd or `gh` auth as
-    the original session. All git/gh operations need to route through the existing
-    workspace provider/git tools and record the workspace id/provider plus forge
-    token availability. **Resolved in §4, §5, §8, and §10.**
-16. **The pipeline needs branch/worktree isolation rules.** "One pipeline at a
-    time" does not protect the user's current checkout. The proposal must require
-    a dedicated proposal branch and implementation branch, and either a dedicated
-    worktree or an explicit clean-worktree preflight before any write. Dirty
-    user changes are a hard stop unless the user explicitly opts into using that
-    checkout. **Resolved in §1, §4, §5, and §10.**
-17. **The dependency section regressed into duplicate/stale wording.** §8 repeats
-    the DRAFT dependency and the relationship section still describes
-    `agent-directed-pr-review` as a pending hard dependency even after #8 says
-    review mode is in tree. The proposal should make the contract precise:
-    review-mode surface exists; remaining gaps are draft-callability, stable
-    terminal result capture, and pipeline orchestration. **Resolved in the
-    relationship table and §8.**
-
-## PR #183 fourth review — reconciling capture ownership with the Hybrid decision
-
-The third review correctly demanded orchestrator-owned result capture (#12), but
-its wording ("in the same completion path") implies a *server-side* orchestrator,
-which collides with the chosen **Hybrid** architecture (the external agent drives
-the loop; only state is persisted). Two items resolve that, and a real seam exists
-to make it concrete.
-
-18. **"Orchestrator-owned capture" is unresolved against Hybrid — name the seam.**
-    Under Hybrid the driving agent owns the *loop*, but it cannot be "in the same
-    completion path" as a child run; if capture depends on the agent polling, #10's
-    eviction race is still live whenever the agent is asleep or at a gate. The
-    resolution is **not** to promote the agent to a server-side orchestrator (that
-    is the architecture the user did *not* pick). It is to use the worker that
-    *already runs the roundtable*: `op_run_worker_run`
-    (`server_http_routes.inc:339`) executes the async `delegate.roundtable` and
-    calls `openai_runs_store_finalize` at terminal. Thread a `__pipeline_pass_id`
-    into the request body exactly as `__run_id` is injected today (`:419`), and
-    extend that finalize path to **also write the structured terminal result into
-    the DB1 pipeline-ledger row**. The agent stays the loop/gate orchestrator; the
-    server worker — which already runs and finalizes the run — closes the capture
-    race durably. This is the genuine Hybrid: agent owns the loop, server owns
-    durable capture of each child run it already executes. **Resolved in §4 and §9.**
-
-19. **`lost_result` should re-run the pass, not escalate to a human.** A capture
-    miss (eviction, restart mid-pass) is an infrastructure hiccup, not a
-    correctness decision that needs a human. The pipeline should **auto re-run the
-    review pass** — it is idempotent over the same artifact; a re-run produces a
-    fresh, valid result reviewing the same input — bounded by the pass ceiling and
-    cost cap, under a **stable `pipeline_pass_id`** so the lost attempt's cost is
-    booked as overhead without double-counting the pass. Escalate to the human only
-    if capture keeps failing across re-runs (a real fault), never on the first
-    miss. **Resolved in §3 and §4.**
-
-## PR #183 fifth review — pass identity, worker capture, and replay safety
-
-The fourth review picked the right Hybrid seam (`op_run_worker_run`), but the
-proposal still needs to define how pipeline pass identity reaches that seam
-safely and how retry accounting stays correct.
-
-20. **`__pipeline_pass_id` is not forwarded by today's `ensemble_review` tool.**
-    `handle_mcp_ensemble_review` currently constructs a fresh body containing only
-    `prompt`, `mode:"review"`, `brief`, `rounds`, and `turns` before calling
-    `server_http_submit_op_run`; unknown caller args are not copied. So the text's
-    "thread `__pipeline_pass_id` into the request body" cannot be implemented
-    from the pipeline unless the callable surface grows a pipeline-owned
-    `pipeline_pass_id` parameter (or `server_http_submit_op_run` gains metadata
-    parameters) and forwards it deliberately. **Resolved in §4, §8, and §10.**
-21. **Pass IDs must be server-owned and state-validated.** A user-facing MCP arg
-    named `__pipeline_pass_id` would let any caller with `CAP_DELEGATE` try to
-    write arbitrary pass rows. The pipeline surface should accept a normal
-    `pipeline_pass_id` only from the pipeline orchestrator/gate command, validate
-    that the pass belongs to an active roundtable pipeline in the expected state,
-    and then inject the private `__pipeline_pass_id` internally. Raw
-    double-underscore fields remain server-private. **Resolved in §4, §8, and
-    §10.**
-22. **Capture only works on the async op-run path.** The worker capture seam is
-    present for `/v1/delegate/roundtable` and `server_http_submit_op_run`, but a
-    direct synchronous `server_dispatch("delegate.roundtable")` call bypasses
-    `op_run_worker_run`. The pipeline must require async op-run submission for
-    both DRAFT and REVIEW passes, or add an equivalent capture hook to any direct
-    path it uses. **Resolved in §2, §4, §8, and §10.**
-23. **A stable pass id still needs per-attempt rows.** Re-running a lost pass under
-    the same `pipeline_pass_id` is correct for loop accounting, but the ledger must
-    preserve each attempt (`attempt_no`, `run_id`, status, terminal flags, result
-    hash, captured/lost marker, cost if known). Otherwise a retry overwrites the
-    evidence needed to explain overhead and repeated capture failures. **Resolved
-    in §4 and §10.**
-24. **Replay is idempotent only if the artifact input is hash-pinned.** A lost
-    result should be re-run over the *same* proposal/diff. Before retrying, the
-    pipeline must compare the current artifact/diff hash to the pass input hash;
-    if it changed, the old pass is stale and a new pass id is required. **Resolved
-    in §4 and §10.**
-25. **The worker must persist failed/cancelled terminal states too.** Done-bar
-    evaluation needs completed results, but durable diagnostics need failed,
-    cancelled, malformed, and capture-failed attempts as well. The capture hook
-    must write terminal status for every op-run outcome, not just successful
-    roundtable JSON. **Resolved in §4 and §10.**
-
-## PR #183 sixth review — closing the read side and the DRAFT path
-
-Moving the *write* to the worker (gaps #18/#20–25) was right, but two ends of that
-design are still open: how the agent *reads* terminal, and what a DRAFT pass
-actually captures.
-
-26. **The agent's terminal-detection poll target must be the durable ledger row,
-    not `/v1/runs`.** The worker now writes the result to DB1, but the proposal
-    never says how the *driving agent* learns a pass reached terminal. If it polls
-    `/v1/runs/{id}`, the **read** side still races eviction (a long pass + ≥256
-    sibling runs + a sleeping agent) — the exact race the worker-capture removed,
-    just moved downstream. The agent must poll the **durable ledger pass row**
-    (`aimee pipeline status` / the DB1 row's `captured`/terminal marker), treating
-    `/v1/runs` as a best-effort live view only. Only then is the race closed on
-    both ends. **Resolved in §4 and §10.**
-27. **The capture contract is review-shaped; a DRAFT pass has no defined durable
-    result.** Gap #22 routes *both* DRAFT and REVIEW through the async op-run
-    worker, but §4's capture lists only review fields (`items`/severities/`count`/
-    `items_round`/`artifact_round`). A DRAFT pass produces an **artifact** (the
-    skeleton), not items, and per #9 that artifact is 8 KB-capped. Capture must
-    persist the **mode-appropriate** payload: for DRAFT, the artifact ref + content
-    hash + `best_round`/`artifact_round` + validity flags (with the skeleton text
-    landing in the working file, not as a ledger blob); for REVIEW, the items.
-    Otherwise draft passes drop their result or are mis-shaped into review fields.
-    **Resolved in §2, §4, and §10.**
-
-## PR #183 seventh review — chunk aggregation, retries, and stale async work
-
-The current shape now closes the `/v1/runs` eviction race, but four implementation
-edges still need to be explicit before this can be built without hidden correctness
-holes.
-
-28. **Chunked review needs an artifact-level aggregate, not independent green
-    slices.** §2 allows large proposals/diffs to be reviewed as chunks, but §3's
-    done-bar currently reads like it evaluates "the latest REVIEW result" as if
-    there is always one result for the whole artifact. If each chunk can pass
-    independently, cross-chunk invariants, renamed symbols, duplicated logic, and
-    missing sections can still be wrong. A chunked pass needs a manifest, per-chunk
-    child results, a deterministic aggregate row, and a final whole-artifact
-    synthesis/check before the phase can pass. **Resolved in §2, §3, §4, and §10.**
-29. **Attempt retries need their own ceiling.** `roundtable_pipeline_max_passes`
-    correctly bounds correctness passes, but capture faults and cancelled/failed
-    attempts are infrastructure retries under the same pass id. Counting those as
-    outer passes makes one transient capture failure consume a correctness pass;
-    not counting them without a separate bound can loop forever. Add an attempt
-    retry cap per pass, with costs still charged to the phase. **Resolved in §3,
-    §4, §6, and §10.**
-30. **Late worker finalization must not advance stale state.** Async op-runs can
-    outlive a pipeline cancel, abandon, fail-return, or retry. A late result from
-    an older `attempt_no`/`run_id` must be recorded as terminal history, but it
-    cannot update the current pass aggregate, satisfy the done-bar, or resume a
-    gate after the pass was superseded. **Resolved in §4, §5, and §10.**
-31. **Pipeline cancellation must bridge to child op-run cancellation.** The repo
-    already has `/v1/runs/{id}/stop` and `handle_delegate_roundtable` polls
-    `__run_id` through `openai_runs_store_cancel_requested`. A new pipeline
-    `cancel`/`abandon` action that only flips the ledger row leaves the roundtable
-    worker running and later finalizing stale work (#30). The action must request
-    stop on the active child `run_id`, mark the attempt cancelled/abandoned in the
-    ledger, and tolerate the worker's eventual terminal write. **Resolved in §4,
-    §5, and §10.**
-
-## PR #183 eighth review — making chunked review actually buildable
-
-Gap #28 correctly demands a whole-artifact aggregate over chunks, but its own
-resolution has two holes: the aggregate can't re-read what didn't fit, and nothing
-says how big a chunk is.
-
-32. **Store the artifact origin plus db2 chunks and *retrieve* — don't
-    agonize over "fit it in one call vs. summarize it."** §3 requires a
-    whole-artifact synthesis/check, and an artifact large enough to be chunked
-    won't fit one review call. The resolution is Aimee's core competency, not a
-    bespoke manifest: retain the artifact origin separately and ingest
-    review-scoped chunks into db2's existing `kb_documents` chunk store, which
-    gives the aggregate most of what it needs —
-    `chunk_index` + `prev_chunk_id`/`next_chunk_id` make the whole text
-    reconstructable by walking the chain, `heading_path` is a section manifest for
-    free, `file_hash` tracks staleness, and vector + FTS retrieval are built in.
-    Per-chunk review passes review each chunk; the whole-artifact aggregate/seams
-    check is a reviewer given **db2 retrieval over the artifact's own chunks**, so
-    it pulls cross-chunk context (the other definition of a symbol, a missing
-    section, a renamed reference) on demand instead of needing the full text inline.
-    Because both the origin and the chunks are retained, the "fit it in one call
-    vs. summarize" decision never has to be made. The chunk index lives in a
-    review-scoped namespace/contract, cleaned up on pipeline completion, so it
-    never pollutes durable memory. **Resolved in §2, §3, §4, and §10; corrected by
-    #34/#35 for the exact origin store and cleanup primitive.**
-33. **The chunk threshold must derive from the panel's *minimum* participant
-    context budget, not a fixed size.** The panel is heterogeneous
-    (`ensemble_reference_models` resolve to different models with different context
-    windows — the same resolution §7 already does for diversity). A chunk sized for
-    the largest-context participant overflows the smallest and silently truncates
-    its review; sized for the smallest, it wastes the largest and inflates pass
-    count and cost. Chunking is sized to the **min context budget across the active
-    panel** (resolved per run), reserving headroom for the brief, role framing, and
-    peer notes, with the resolved budget and threshold recorded in the chunk
-    manifest. **Resolved in §2 and §10.**
-
-## PR #183 ninth review — correcting the db2 origin and context-budget contracts
-
-The eighth review made the right move by grounding chunk aggregation in db2, but
-it overstates what the current KB tables and APIs provide.
-
-34. **`kb_documents` stores chunks, not the whole artifact.** The schema has
-    `kb_documents.content` per chunk plus `prev_chunk_id`/`next_chunk_id`; the
-    normal project build path calls `db2_kb_file_index_upsert(..., NULL)`, so
-    `kb_file_index.content` is not a reliable whole-text copy either. If the
-    pipeline needs the origin text, it must store a separate origin ref/blob:
-    working file/blob + hash in DB1, a db2 `docs.normalized_text` row via
-    `kb.docs.push`, or an explicit DB2 artifact payload. The chunk manifest then
-    references both the origin ref and the `kb_documents` rows. **Resolved in §2,
-    §3, §4, §10, and §11.**
-35. **Review-scoped KB indexing is not a current public primitive.** The available
-    KB surfaces are project-oriented (`kb.build`/`kb.update` over a path+project,
-    `/v1/maintenance/clear` for an entire project) plus corpus staging
-    (`kb.docs.push` into `docs`). A pipeline-specific ephemeral namespace cannot
-    be assumed unless the implementation either creates a synthetic review project
-    with safe cleanup, adds a per-file/per-scope cleanup API, or adds direct
-    pipeline artifact indexing. Otherwise cleanup can delete unrelated project KB
-    data or leave review chunks behind. **Resolved in §2, §4, §8, §9, and §10.**
-36. **Minimum panel context budget can be unknown.** The code can hold
-    `agent.middleware.context_window`, and some runtime paths use
-    `model_context_window(model)`, but configured agents and discovered
-    `model_catalog` rows can still have `context_window == 0`. The pipeline cannot
-    size chunks from "minimum participant context" unless every panelist resolves
-    a positive budget; otherwise it must use a conservative default, probe first,
-    or fail configuration validation with a clear remediation. **Resolved in §2,
-    §6, §7, and §10.**
-
-## PR #183 tenth review — who retrieves: orchestrator assembles, participants review inline
-
-Gap #32 said the whole-artifact check is "a reviewer given db2 retrieval." Reading
-how review participants actually run shows that mis-locates the work.
-
-37. **Review participants review the *inline task text*; they cannot be assumed to
-    retrieve from db2 or read the working tree.** `ensemble_review` /
-    `handle_delegate_roundtable` passes the artifact as inline `task` text, and each
-    participant runs via `agent_run_named(…, ensemble_reference_models[i],
-    "review", …)` — a **heterogeneous, often remote** model whose tool access
-    (file-read, KB-search) is per-agent and not guaranteed. The `review` charter
-    role's "inspect repository files" is best-effort: it works only where that
-    participant has file tools + workspace binding, it is not db2 retrieval, and a
-    remote delegate panelist may have neither. So #32's "reviewer given db2
-    retrieval over the artifact's chunks" is the wrong seam. The correct one: the
-    **orchestrator** (which holds the origin ref and db2) pre-assembles each review
-    unit and passes it **inline** — for a chunk, the chunk text + brief +
-    orchestrator-retrieved cross-chunk spans (the other definition of a symbol, the
-    referenced section); for the whole-artifact aggregate, a self-contained digest
-    of per-chunk findings + the cross-cutting spans the invariants need. db2/origin
-    storage (#32/#34) is what the *orchestrator* retrieves from, never a per-panelist
-    capability. Review correctness then never depends on whether a given model can
-    retrieve or read files. **Resolved in §2, §3, and §10.**
-
-## PR #183 eleventh review — serialization and assembly provenance
-
-The tenth review moved retrieval to the right actor (the orchestrator), but the
-proposal still leaves three build-time correctness gaps at the response/ledger
-boundary.
-
-38. **`items_truncated` is a separate terminal-invalid flag, not covered by
-    `truncated`.** The engine sets `result.truncated` for brief/question/context
-    truncation and item-count overflow, but `add_roundtable_arrays` can still clip
-    serialized `items[]` at `ROUNDTABLE_ITEMS_JSON_BUDGET` and emit
-    `items_truncated: true` without changing `result.truncated`. A done-bar or gate
-    digest that reads only `truncated == false` can pass with missing findings.
-    The capture hook must persist `items_truncated`, and every done-bar must treat
-    it as invalid terminal evidence. **Resolved in §3, §4, and §10.**
-39. **Orchestrator-assembled inline review needs a budgeted assembly manifest.**
-    #37 says the orchestrator retrieves cross-chunk spans and hands reviewers a
-    self-contained inline unit, but it does not bound or explain that assembled
-    prompt. The current HTTP body ceiling is large, while reviewer context and
-    output fields are much smaller; over-assembling can silently omit the exact
-    span needed for correctness. Each review unit and aggregate call needs a
-    recorded assembly manifest: origin/chunk refs, selected span ids/ranges/hashes,
-    token/byte estimate against the resolved minimum participant budget, and any
-    omitted candidate spans. Required omissions keep the aggregate blocked and
-    surface as coverage gaps. **Resolved in §2, §3, §4, and §10.**
-40. **Item display fields are too small to be the only source provenance.**
-    `roundtable_review_item_t.location[128]`, `summary[256]`,
-    `recommendation[256]`, and `sources[256]` are display-sized fields. They
-    cannot safely carry long cross-chunk evidence chains, many participant
-    sources, or gate-audit provenance. The ledger must store a sidecar mapping
-    from item identity/result hash to the assembly spans and source refs that
-    produced it; `item.sources` remains a display hint, not the durable evidence
-    model. **Resolved in §4, §5, and §10.**
-
-## PR #183 twelfth review — one validity predicate, not a scattered conjunction
-
-Gap #38 is a symptom of a pattern. Validity flags have accreted across reviews
-(#13 added `truncated`/`degraded`/`cost_capped`/`deadline_hit`/`cancelled`; #38
-adds `items_truncated`), and the done-bar, the chunk-aggregate, the capture hook,
-and the gate digest each re-list the conjunction inline. The next consumer written
-will check a stale subset — exactly how #38 happened in the first place.
-
-41. **Define one canonical "valid terminal result" predicate; no call site may
-    check a subset.** Centralize validity as a single contract —
-    `roundtable_result_valid_terminal(result)` returning false on any of
-    `truncated`, `items_truncated` (#38), `degraded`, `cost_capped`,
-    `deadline_hit`, `cancelled`, `lost_result` (#19), or an
-    `items_round`/`artifact_round` provenance mismatch (#13) — and have the done-bar
-    (#3), the chunk-aggregate (#28), the worker capture hook (#18), and the gate
-    digest all consult **that one predicate**. A future invalidity flag updates the
-    predicate in one place. A test asserts every consumer rejects a result that
-    trips each individual flag, so a newly added flag can never be honored by some
-    sites and silently ignored by others. **Resolved in §3, §4, and §10.**
-
-## PR #183 thirteenth review — per-pass version freshness and fail-return PR identity
-
-No new feedback prompted this pass; a fresh read of the loop's *outer* mechanics
-(the part the inner-engine reviews never reached) found two real holes.
-
-42. **Each revise pass re-ingests; the review-scoped index must supersede the
-    prior version, or retrieval serves stale spans.** Every author-revise / agent-fix
-    pass produces a *new* artifact version. The orchestrator-assembled retrieval
-    (#37) pulls cross-chunk spans from the review-scoped db2 index, so that index
-    must be re-ingested per pass **and the prior version's chunks superseded** before
-    the new pass retrieves — otherwise #37 serves spans from an earlier revision: a
-    fixed bug reappears, a deleted section is still "found," a renamed symbol
-    resolves to its old name. Each pass pins retrieval to its own artifact content
-    hash; the assembly manifest (#39) records that version; chunks from superseded
-    versions are never retrieval-eligible for the current pass. Review-scoped cleanup
-    (#35) therefore runs **per version**, not only at pipeline end. **Resolved in §2,
-    §3, §4, and §10.**
-43. **Fail-return must update the existing PR, not open a duplicate.** The fail
-    edges (gate1 → `proposal_review`, gate2 → `implementing`) revise an artifact
-    whose PR is already open and recorded in the ledger. The revise loop must push
-    to the **same recorded branch/PR**, updating it in place — never open a second
-    PR for the same pipeline phase. On re-entry the orchestrator validates the
-    recorded branch/PR still exists and targets `testing` (the §5 drift check),
-    pushes the revision, and the human gate re-evaluates the **updated** PR with a
-    fresh review digest. A fail-return that orphaned the prior PR or opened a
-    duplicate is a hard error, not a silent second PR. **Resolved in §1, §5, and
-    §10.**
-
-## PR #183 fourteenth review — validity envelope and HTTP namespace
-
-The thirteenth review closed more loop mechanics, but a fresh pass over the
-server routing and run-capture code found two more buildability gaps.
-
-44. **The validity predicate cannot be a raw `roundtable_result_t` helper, and it
-    must not gate capture.** #41 names `roundtable_result_valid_terminal(result)`,
-    but some invalidity inputs are outside `roundtable_result_t`: `items_truncated`
-    is added by HTTP serialization, `lost_result` is a ledger/attempt state, and
-    capture-failed/malformed terminal attempts may not have a parsed engine result
-    at all. The worker must first persist the terminal **capture envelope** (run
-    id, attempt status, raw/sanitized result snapshot hash, parse status, HTTP
-    serialization flags, and engine flags when present). The canonical predicate
-    then evaluates that envelope for done-bar eligibility. It must never decide
-    whether the terminal attempt is recorded; invalid terminal evidence is exactly
-    what the ledger needs for retries and audits. **Resolved in §3, §4, and §10.**
-45. **`/v1/pipeline/status` is already the KB/corpus pipeline status route.** The
-    proposal says the implementation may add `aimee pipeline status|gate` as a
-    CLI/MCP/HTTP surface, but Aimee's KB sidecar already exposes
-    `GET /v1/pipeline/status` for asynchronous knowledge ingest status (with
-    `/v1/corpus/pipeline/status` as the newer corpus-specific spelling). A new
-    roundtable-authoring HTTP API must not reuse or overload that path. If an HTTP
-    surface is added, it needs an unambiguous namespace such as
-    `/v1/roundtable/pipelines/...` or `/v1/authoring/pipelines/...`; otherwise v1
-    can remain CLI/MCP-only. **Resolved in §5, §8, §10, and §12.**
-
-## PR #183 fifteenth review — spend bound across fail-return, and the parked-gate lifecycle
-
-A fresh pass over the *cost* and *resource-lifecycle* of the long-lived states
-(not the engine) found two more holes the prior rounds left open.
-
-46. **The per-phase cost cap's behavior across fail-return is unspecified, and
-    there is no whole-pipeline ceiling.** `roundtable_pipeline_max_cost_usd` is
-    per-phase, but a gate **fail** returns to the same review phase and runs more
-    passes. The proposal never says whether the cap **resets, continues, or
-    accumulates** across fail-return re-entries — so a repeatedly-failed gate could
-    have no real spend bound (if it resets) or surprise the operator (if it
-    accumulates). Specify: the per-phase cap **accumulates across all re-entries of
-    that phase** (a fail-return never resets it), and add a **whole-pipeline**
-    cumulative ceiling (`roundtable_pipeline_max_total_cost_usd`, default 0 =
-    unbounded) bounding proposal + implementation + PR phases together. Tripping
-    either escalates to the human, never auto-passes. The ledger already records
-    per-pass cost, so this is a sum, not new accounting. **Resolved in §3, §4, §6,
-    and §10.**
-47. **A never-answered gate holds resources indefinitely; define the park
-    lifecycle.** Gates are designed to "sit for hours or days," and explicit
-    `cancel`/`abandon` (#31) covers *intentional* teardown — but nothing covers a
-    gate simply left unanswered. While parked, the pipeline pins the review-scoped
-    db2 index, the worktree, and the branch; across many open pipelines that index
-    grows unbounded. Specify: (a) on entering a `*_pending` gate the pipeline
-    **releases re-creatable resources** — the review-scoped db2 index is dropped and
-    re-ingested from the retained origin (#42) on resume, and the worktree may be
-    released — keeping only the durable ledger + origin ref; (b) an optional gate
-    TTL (`roundtable_pipeline_gate_ttl_h`, default 0 = no expiry) that on expiry
-    moves the pipeline to `abandoned` with full child-run-stop + cleanup (#31),
-    **never** an auto-pass. A parked pipeline must not pin a growing index. **Resolved
-    in §4, §5, §6, and §10.**
-
-## PR #183 sixteenth review — admission, merge execution, and cost scope
-
-The fifteenth review added parked-gate cleanup and a total cap, but those changes
-expose three places where the proposal still overstates or contradicts the current
-codebase.
-
-48. **"One pipeline at a time" conflicts with parked gates unless admission is
-    explicit.** §11 says v1 has one pipeline run at a time, while #47 talks about
-    many parked pipelines and released resources. Implementation must choose the
-    admission rule: either a parked gate continues to occupy the single authoring
-    slot (simple, but one forgotten gate blocks all future runs), or entering a
-    gate transitions the run to a `parked`/`waiting_human` class that releases the
-    active slot while retaining ledger ownership and preventing two active
-    reviewers from mutating the same branch/PR. Without that distinction, the gate
-    lifecycle is ambiguous and resource cleanup can accidentally introduce
-    unscheduled parallel pipelines. **Resolved in §1, §4, §5, §10, §11, and §12.**
-49. **The whole-pipeline cost cap must define whether implementation-agent spend
-    is in scope.** #46 says the total cap spans proposal + implementation + PR
-    phases, but the ledger costs described so far are roundtable pass costs. The
-    implementation phase is "normal coding," not a roundtable call, and may not
-    expose comparable `cost_usd` without using Aimee's token-audit / agent-cost
-    surfaces. Choose one contract: either the cap is explicitly
-    `roundtable_pipeline_max_roundtable_cost_usd` (roundtable child runs only), or
-    the ledger must ingest non-roundtable implementation-agent spend from the
-    existing token/cost accounting and mark unknown implementation cost as
-    incomplete evidence. A cap that claims to include implementation but only sums
-    review passes is misleading. **Resolved in §3, §4, §6, and §10.**
-50. **`git_pr` does not merge today; pass→merge needs a real executor contract.**
-    The proposal's table says PR open/merge/diff capture exists via
-    `git_pr`/`mcp_git_run`, but the current `git_pr` tool supports
-    create/view/list/edit/checks/watch/merge_status/wait — not merge. A gate pass
-    must either add a first-class workspace-aware `git_pr action=merge` (with
-    admin/squash/rebase options, expected head SHA, and captured merge SHA) or
-    explicitly use `mcp_git_run`/`gh pr merge` through the workspace/forge-token
-    authority and persist the command, output, exit code, and merge SHA. Treating
-    merge as already covered hides a build gap at the most important state
-    transition. **Resolved in §5, §8, §9, and §10.**
-
-## PR #183 seventeenth review — reuse the cost-accounting ledger; correct the merge claim
-
-Two follow-ons from the sixteenth review's own resolutions.
-
-51. **Implementation-agent spend (#49) should consume the cost-accounting
-    proposal's ledger, not invent parallel accounting.** `ingress-cost-accounting-and-optimizations.md`
-    (the in-flight #180/#185 work) builds a db2 `usage_ledger` (`src/db2/usage_ledger.c`)
-    + a typed `/v1/usage/*` surface that already records per-turn agent cost. The
-    whole-pipeline cost cap's *implementation* component must read from that ledger
-    (the same pattern the ingress-compression proposal uses to cede cache work to
-    the cost proposal), marking implementation cost **incomplete evidence** when the
-    ledger has no row yet — never a second cost-accounting path. If that ledger has
-    not landed, the cap is scoped to roundtable child-run cost only
-    (`…_max_roundtable_cost_usd`) and says so, rather than silently summing a subset.
-    **Resolved in §3, §6, and §8.**
-
-(The What-exists table is also corrected here: PR **merge** is *not* a `git_pr`
-action today — #50 — so it is listed as a gap, not as existing.)
-
-## PR #183 eighteenth review — pin cost sources and validate the ledger dependency
-
-The seventeenth revision correctly avoids inventing a parallel implementation-cost
-ledger, but the codebase currently has DB1 `token_audit` / `cost_fold_log` while
-the proposed db2 `usage_ledger` is still pending. That leaves one more boundary to
-make explicit.
-
-52. **Pipeline cost evidence must pin its accounting source and scope.** A pipeline
-    may start before the cost-accounting proposal lands, resume after it lands, or
-    carry both roundtable child-run `cost_usd` and implementation-agent cost rows.
-    The durable ledger therefore needs a per-pipeline/per-phase `cost_scope` and
-    `cost_source` snapshot (for example `roundtable_result_cost`,
-    `db1_token_audit_cost_fold`, or `db2_usage_ledger`), plus a pricing/schema
-    version or reconciliation timestamp. It must not silently mix DB1 audit sums,
-    roundtable result estimates, and future db2 usage rows across retries or
-    resume. If the configured source changes, the pipeline marks cost evidence
-    stale/incomplete, recomputes from a single authoritative source where possible,
-    and re-surfaces the gate digest before claiming a cap is satisfied. **Resolved
-    in §4, §5, §6, §8, and §10.**
-
-## PR #183 nineteenth review — the gate's own authorization
-
-Eighteen rounds hardened what the gate *evaluates*; none specified who may *resolve*
-it. That is the integrity of the whole design.
-
-53. **The gate verdict must be human/operator-authorized, distinct from the
-    driving agent's `CAP_DELEGATE` — or the agent can self-approve its own merge.**
-    The two human gates are the load-bearing control (§11: they "do not remove the
-    human"). But every pipeline/delegate action in the tree is gated by
-    `CAP_DELEGATE` (`server_auth.c`: `delegate.roundtable`, `delegate.*`, `jobs.*`),
-    which the driving agent **already holds** to run the roundtable. If
-    `pipeline gate <id> pass|fail` is gated the same way, the driving agent can
-    `pass` its own gate and trigger the merge — defeating the gate entirely and
-    turning the pipeline into the gate-less autonomous machine §11 forbids. The gate
-    *resolution* needs a **separate authority not granted to a delegate-driving
-    session**: a distinct capability (e.g. `CAP_PIPELINE_GATE`), an operator/human
-    principal, or an out-of-band confirmation. The agent may *surface* a gate (move
-    to `*_pending`, build the digest) but must never be able to *resolve* it. A
-    negative test asserts a session holding only the agent's caps is **denied**
-    `gate pass`. **Resolved in §5, §8, §10, and §11.**
-
-## PR #183 twentieth review — gate authority cannot assume a spare capability bit
-
-The nineteenth review fixed the security model conceptually, but one implementation
-path it names is not drop-in for the current server.
-
-54. **A new `CAP_PIPELINE_GATE` requires a capability-mask migration, not just a
-    constant.** `src/headers/server.h` already consumes bits 0-15
-    (`CAP_DASHBOARD_READ` is `1u << 15`) and defines `CAPS_ALL` as `0xFFFFu`.
-    The `/v1` transport derives TCP/UDS caps from that mask, and the route registry
-    reuses the same `uint32_t` values while still treating `CAPS_ALL` as the full
-    trusted set. Adding `CAP_PIPELINE_GATE = 1u << 16` without updating `CAPS_ALL`,
-    scoped/unscoped bearer behavior, route-cap tests, and capability advertising
-    would make the gate unreachable or inconsistently authorized. The proposal must
-    choose one of two buildable designs: (a) widen/redefine the capability model
-    and update `CAPS_ALL`, `CAPS_AUTHENTICATED`, `server_http_conn_caps`,
-    `server_http_route_allowed`, OpenAPI/capability docs, and auth tests; or (b)
-    avoid a new cap bit and implement gate resolution through an operator principal
-    / local-UDS-only out-of-band confirmation whose denial semantics are tested
-    separately. **Resolved in §5, §8, §9, §10, and §12.**
-
-## PR #183 twenty-first review — gate resolution must be exactly-once
-
-#53/#54 settled *who* may resolve a gate; neither settled *whether resolution is
-once-only*. `gate pass` is a side-effecting transition (it merges and advances),
-so at-least-once delivery is a real hazard.
-
-55. **A double `gate pass` must not double-merge or double-advance.** A second
-    invocation — network retry, double submission, two authorized operators, or a
-    resume racing another resume — must be a no-op or a clear "already resolved"
-    error, never a second merge. Gate resolution must: (a) act **only** when the
-    pipeline is in the matching `*_pending` state and **atomically** transition out
-    of it, so a concurrent or repeat call observes a non-pending state and stops;
-    (b) make the merge **idempotent** — keyed by the recorded PR + expected head SHA
-    (the §5 drift check, #43), so retrying a merge of an already-merged PR is a
-    no-op, not a duplicate or a hard error; (c) record the verdict once with
-    actor/timestamp. Without this guard the merge side effect is exposed to
-    at-least-once delivery, and a flaky client could merge twice or skip a phase.
-    **Resolved in §4, §5, and §10.**
-
-## PR #183 twenty-second review — exactly-once needs crash recovery, not just concurrency guards
-
-#55 makes repeated gate calls idempotent, but the external merge is outside the
-DB transaction. Aimee has DB1 transaction patterns (`BEGIN IMMEDIATE`), but GitHub
-merge execution happens through `git_pr`/`mcp_git_run`/`gh` after the ledger write,
-so a crash can still land between the local state transition and the remote side
-effect.
-
-56. **`gate pass` needs a durable merge-intent / recovery state before the external
-    merge.** If the implementation atomically leaves `gate*_pending` and then
-    crashes before recording `merge_sha`, restart sees a non-pending pipeline that
-    is neither merged nor reviewable. Conversely, if it merges first and crashes
-    before advancing, restart may try to merge again without knowing the first
-    merge succeeded. The ledger needs an explicit, resumable side-effect protocol:
-    record a gate verdict plus `merge_intent` / `merge_pending` row keyed by PR
-    number + expected head SHA under a DB transaction; execute the merge; then
-    reconcile by reading PR/merge status and record `merge_sha` before advancing to
-    `implementing`/`done`. On resume, `merge_pending` is a first-class state: if the
-    PR is already merged at the expected head, finish the advance; if not, retry or
-    surface the blocked merge reason without losing the verdict. **Resolved in §1,
-    §4, §5, §9, and §10.**
-
-## PR #183 twenty-third review — the gate TTL must not abandon a human's approval
-
-#56 adds `*_merge_pending`, but the gate TTL (#47) was written for the
-*awaiting-human* gate states and does not yet say it stops there.
-
-57. **The unanswered-gate TTL must not apply to `*_merge_pending` — a pass verdict
-    cannot be auto-abandoned because infra is slow.** `roundtable_pipeline_gate_ttl_h`
-    (#47) moves an **unanswered** gate to `abandoned`, which is right while the
-    pipeline waits on a *human*. But `*_merge_pending` is post-pass: the human
-    already approved, and the wait is on the *merge* (hung CI, branch protection,
-    transient `gh` failure). Abandoning that state would silently discard a human's
-    approval and force a full re-review. So the TTL applies **only** to
-    awaiting-human `*_pending` states. A blocked `*_merge_pending` retries with
-    backoff and surfaces the merge blocker, preserving the verdict; it leaves the
-    state only by a successful merge, an explicit operator `cancel`/`abandon` (#31),
-    or — if wanted — a *separate, clearly-named* merge-block escalation timer that
-    **escalates to a human, never auto-abandons**. **Resolved in §4, §5, §6, and §10.**
+> The design below is authoritative and self-contained. It was hardened over 23
+> review rounds; every `(#NN)` reference resolves to **Appendix A — Decision log**
+> at the end, which indexes all 57 findings and their in-tree grounding.
 
 ## Relationship to existing proposals
 
@@ -1607,3 +920,78 @@ ledger) before the full idea→merge pipeline of P2/P3.
   ceilings by default, or one shared set with optional overrides?
 - **DRAFT seeding:** does the `drafting` step take only the idea, or also a
   pointer to sibling/related proposals so the first draft starts grounded?
+
+---
+
+## Appendix A — Decision log (PR #183 review, 57 findings)
+
+This proposal was hardened over 23 review passes against the live tree. Each
+decision below is **already implemented in the design sections above**; this log
+is the compact traceability index for the `(#NN)` references and records the
+key in-tree grounding. Grouped by review round to show how the contract evolved.
+
+**Round 1 — ledger, surfaces, and callable shape (§1, §2, §4, §5, §7–§10).**
+1. No blank-slate `pipeline_run` name — a DB1 `pipelines`/`autopilot` table already exists; namespace or migrate deliberately (§4, §12).
+2. `/v1/runs` (`openai_runs_store`, 256-bounded, non-durable) is not a checkpoint store; the ledger is DB1 (§4).
+3. CLI/API surface explicit — new `pipeline` namespace or `autopilot` extension, no collision (§5, §9).
+4. GitHub/worktree state must be resumable (branch/PR/SHA/mergeability/auth in the ledger) (§4, §5).
+5. No unbounded inline artifacts — store refs + hashes (§2, §4, §11).
+6. Panel-diversity check resolves agent→provider identity, not string uniqueness (§7).
+7. DRAFT and REVIEW use different callable paths (review-only `ensemble_review`) (§1, §2, §8).
+
+**Round 2 — engine feasibility (§1–§4, §8, §11).**
+8. The `ensemble_review` review surface is already on `testing`; dependency is narrow (§8).
+9. DRAFT can't emit a full proposal — artifact is `char[8192]`-capped; it yields a skeleton (§1, §2, §11).
+10–12. Result capture must be durable and **server-worker-owned**, not an agent poll, because `/v1/runs` evicts (§4).
+13. Done-bar rejects `degraded`/`truncated`/`cost_capped`/`deadline_hit`/`cancelled` (§3).
+14. Questions-done bar caps at `ROUNDTABLE_MAX_QUESTIONS` (16) (§3).
+15. Git ops route through Aimee's workspace authority, not raw shell (§4, §5).
+16. Dedicated proposal/impl branches + clean-worktree preflight (§1, §4, §5).
+17. Dependency wording de-duplicated (§8).
+
+**Round 3–5 — capture seam, pass identity, retrieval owner (§2–§4, §8).**
+18. Capture rides the existing `op_run_worker_run` finalize hook (the Hybrid seam) (§4).
+19. `lost_result` auto re-runs the pass (stable `pipeline_pass_id`), not human-escalate (§4).
+20–25. Pipeline-owned async submission: validated `pipeline_pass_id` → private `__pipeline_pass_id`; async-only path; per-attempt rows; hash-pinned replay; persist failed/cancelled terminals (§2, §4, §8).
+26. Agent reads terminal from the **durable ledger row**, not `/v1/runs` (§4).
+27. Capture is mode-appropriate — DRAFT persists artifact ref+hash, REVIEW persists items (§2, §4).
+
+**Round 6–9 — chunked review and origin (§2, §3, §6, §7).**
+28. Chunked review needs an artifact-level aggregate, not independent green slices (§2, §3).
+29. Infra retries get their own ceiling (`…_max_attempts_per_pass`) (§3, §6).
+30. Late finalization can't advance superseded state (current-attempt guard) (§4).
+31. Pipeline cancel/abandon bridges to child `/v1/runs/{id}/stop` (§4, §5).
+32. Store the **whole origin** + db2 chunks; the aggregate **retrieves** (no re-ingest) (§2, §3).
+33. Chunk threshold = the panel's **minimum** participant context budget (§2).
+34. `kb_documents` is a chunk index, not the whole-origin store — keep a separate origin ref (`docs.normalized_text`/blob) (§2, §4).
+35. Review-scoped indexing needs a real cleanup-safe primitive (synthetic project / scoped cleanup) (§2, §8).
+36. Unknown panel context → conservative fallback or hard validation error (§6, §7).
+
+**Round 10–12 — who retrieves, serialization, validity (§1–§4, §6).**
+37. The **orchestrator** retrieves and hands each panelist a self-contained inline unit; panelists aren't assumed to retrieve/read files (§2, §3).
+38. `items_truncated` (HTTP-serializer flag, not a struct field) is terminal-invalid evidence (§3, §4).
+39. Inline review units carry a budgeted assembly manifest (spans, budget, omissions) (§2, §3, §4).
+40. Display-sized item fields aren't durable provenance — keep an identity→spans sidecar (§4).
+41. One canonical `roundtable_result_valid_terminal()` predicate; no consumer checks a subset (§3, §4).
+42. Each revise pass re-ingests and **supersedes** the prior version's chunks (no stale spans) (§2, §3).
+43. Fail-return updates the **same** recorded PR, never a duplicate (§1, §5).
+
+**Round 13–15 — cost scope and parked-gate lifecycle (§3–§6).**
+44. The validity predicate runs on a captured **envelope** (incl. serialization/ledger flags), and never gates capture (§3, §4).
+45. `/v1/pipeline/status` is the KB/corpus route — authoring needs a distinct namespace (§5, §8, §12).
+46. Per-phase cost cap **accumulates across fail-returns**; add a whole-pipeline `…_max_total_cost_usd` (§3, §6).
+47. Parked gates release re-creatable resources (drop+re-ingest index from origin); optional `…_gate_ttl_h` → `abandoned`, never auto-pass (§4, §5, §6).
+48. Admission: a parked gate either holds or releases the single v1 slot (`…_parked_releases_slot`), with branch/PR mutual exclusion (§1, §4, §5, §11, §12).
+49. Whole-pipeline cap must define implementation-spend scope; unknown impl cost = incomplete evidence (§3, §4, §6).
+50. `git_pr` has **no merge action** (only `merge_status`) — pass→merge needs a real executor (§5, §8, §9).
+
+**Round 16–19 — cost provenance and gate authority (§3–§6, §8, §10, §11).**
+51. Implementation spend reads the cost-accounting proposal's db2 `usage_ledger`/`/v1/usage/*`, not a parallel path (§3, §6, §8).
+52. Cost evidence pins `cost_scope`/`cost_source`/version (DB1 `token_audit`/`cost_fold_log` today vs future db2 `usage_ledger`); never mixes sources in one cap decision (§4, §5, §6, §8).
+53. The gate verdict needs authority the driving agent lacks — `CAP_DELEGATE` ≠ gate authority, or the agent self-approves its own merge (§5, §8, §11).
+54. A new `CAP_PIPELINE_GATE` needs a cap-mask migration (`CAPS_ALL` is `0xFFFFu`, bits 0–15 full); else use an operator-principal/UDS-only path (§5, §8, §9, §12).
+
+**Round 20–23 — exactly-once, crash recovery, and approval safety (§1, §4, §5, §6).**
+55. Gate resolution is exactly-once — guarded `*_pending` transition + idempotent merge (PR+head SHA); a double `pass` can't double-merge (§5).
+56. The external merge needs a durable `*_merge_pending` saga state: intent → merge → reconcile→`merge_sha` before advancing; recover on restart (§1, §4, §5).
+57. The unanswered-gate TTL applies **only** to awaiting-human `*_pending`, never `*_merge_pending` — a slow merge can't auto-abandon a human's approval (§4, §5, §6).

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -1,0 +1,299 @@
+# Proposal: Agent roundtable authoring pipeline (idea → reviewed proposal → implementation → reviewed PR)
+
+- **State:** draft — pending review
+- **Author:** JBailes
+- **Date:** 2026-06-11
+- **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
+  (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
+  (done-bar + pass ceiling config), Persist (resumable ledger).
+- **Scope:** a driving-agent orchestration spec + a thin persisted pipeline
+  ledger. Net-new code is small: a `pipeline_run` ledger (DB1 or a `/v1/runs`
+  sibling), config keys (`src/headers/config.h`, `src/config.c`,
+  `src/config_fields.c`, `src/config_sections.c`, `src/config_save.c`), and the
+  driving-agent runbook/skill. It **depends on** the roundtable engine (already on
+  `testing`) and on `agent-directed-pr-review` P1a–c (the brief + structured items
+  + the `ensemble_review` MCP tool). It reuses `gh`/`git` for PR/merge. No changes
+  to the roundtable engine itself.
+
+## Design at a glance
+
+A closed-loop authoring pipeline that turns a one-line idea into a merged,
+panel-reviewed implementation, with **two human gates** and **two roundtable
+quality gates**:
+
+```
+[Human] idea
+  → DRAFT roundtable generates a first proposal
+  → REVIEW roundtable ⇄ author-revise  (until done-bar)        ← proposal quality gate
+  → open proposal PR
+  → [Human gate 1] pass / fail
+        fail → back to proposal REVIEW loop (fail reason → brief)
+        pass → merge proposal PR → implement
+  → REVIEW roundtable ⇄ agent-fix  (until done-bar)            ← PR quality gate
+  → [Human gate 2] pass / fail
+        fail → back to implement + PR REVIEW loop (fail reason → brief)
+        pass → merge implementation PR → done
+```
+
+The roundtable runs **as many passes as correctness takes** — depth is the point.
+The done-bar is a *correctness* condition, not a pass budget; the configurable
+pass ceiling is only an operator cost-backstop that **escalates to the human**
+when hit without reaching the done-bar (it never auto-passes a not-done artifact).
+
+## Relationship to existing proposals
+
+- **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
+  PRs #136/#142, on `testing`). `delegate_roundtable_run`
+  (`src/headers/delegate_ensemble.h`) provides both `ROUNDTABLE_DRAFT` (produces an
+  improved `artifact`) and `ROUNDTABLE_REVIEW` (produces deduped, severity-tagged
+  `items[]` with a corroboration `count`, plus `answered_questions[]` and
+  `coverage_gaps[]`), a deterministic `converged` predicate, `best_round`, and
+  inherited cost/deadline bounds. **This proposal adds no engine code.**
+- **`agent-directed-pr-review.md` (pending) is the callable surface and a hard
+  dependency.** Its P1a (the **brief**: focus/fixes/invariants/questions, open
+  mandate), P1b (return the structured items to the caller), and P1c (the
+  `ensemble_review` MCP tool over the async run bridge, `CAP_DELEGATE`-gated) are
+  what let the driving agent invoke directed review mid-task and read back
+  actionable items. This pipeline is the *orchestration on top* of that surface.
+- **`agent-roundtable-collaborative-drafting.md` (pending residual)** lists
+  deeper convergence/economics tests; this proposal's validation (§10) exercises
+  exactly those at pipeline scale.
+
+## What exists vs. what is net-new
+
+| Capability | Status |
+|---|---|
+| Multi-round panel, DRAFT + REVIEW modes, deterministic convergence, dedup, severity, cost/deadline bounds | **exists** (engine, `testing`) |
+| Directed review (brief), structured items returned, `ensemble_review` MCP tool | **dependency** (agent-directed-pr-review P1a–c) |
+| PR open / merge, diff capture (`git diff`) | **exists** (`gh`, `git`) |
+| Outer REVIEW⇄revise loop, done-bar evaluation, pass ceiling + escalation | **net-new** (§3) |
+| The two human gates + the two fail-return edges | **net-new** (§5) |
+| Persisted, resumable pipeline ledger (hybrid state) | **net-new** (§4) |
+| Config: done-bar, pass ceiling, outer cost cap | **net-new** (§6) |
+
+## §1 The pipeline state machine
+
+States (persisted in the §4 ledger):
+
+`drafting → proposal_review → gate1_pending → implementing → pr_review → gate2_pending → done` (plus `failed`/`abandoned`).
+
+Transitions:
+
+1. **drafting** — DRAFT roundtable turns the human idea (+ any seed brief) into a
+   first proposal artifact. One `ensemble_review`/roundtable call in
+   `ROUNDTABLE_DRAFT` mode; the converged `artifact` becomes the working draft.
+2. **proposal_review** — the §3 outer loop: REVIEW the draft, author-revise from
+   the items, re-REVIEW, until the done-bar (§3). Then the agent opens the proposal
+   PR (`gh pr create`, base `testing`, per repo flow) and moves to `gate1_pending`.
+3. **gate1_pending** — human gate 1 (§5). **pass** → merge proposal PR, move to
+   `implementing`. **fail** → the human's reason is appended to the brief and the
+   state returns to `proposal_review`.
+4. **implementing** — the agent implements the merged proposal (normal coding;
+   not a roundtable activity), opens the implementation PR, captures the diff.
+5. **pr_review** — the §3 outer loop in REVIEW mode over the diff: REVIEW,
+   agent-fix, re-REVIEW, until the done-bar.
+6. **gate2_pending** — human gate 2 (§5). **pass** → merge the implementation PR,
+   move to `done`. **fail** → reason → brief, state returns to `implementing`.
+
+Every state is durable (§4) so a human gate can be answered hours or days later,
+across a server restart or a new agent session.
+
+## §2 The two roundtable applications
+
+Both phases use the **same** engine; they differ only in input and brief.
+
+- **Proposal phase (B).** Input = proposal markdown. **Both** modes (per decision):
+  DRAFT to generate the first artifact in `drafting`, then REVIEW to gate it in
+  `proposal_review`. The brief carries the proposal's *goal*, the *invariants* it
+  must satisfy, and the human's seed *questions*. Author-revise between REVIEW
+  passes is done by the driving agent (it is the proposal's author).
+- **PR phase (A).** Input = unified diff (the agent pastes `git diff
+  <base>...HEAD`; aimee has no PR-fetch and needs none — `agent-directed-pr-review`
+  §6). REVIEW mode only; the agent applies fixes between passes. The brief carries
+  the *fixes just applied*, the *invariants* the change must not break, and the
+  *questions* the author is unsure about.
+
+The brief is **open-mandate** (agent-directed-pr-review §2): it weights attention
+and seeds the questions, but every reviewer is still told to report any blocking
+issue even outside the focus. Direction must never become a filter.
+
+## §3 The outer loop, the done-bar, and the pass ceiling
+
+Two distinct loop levels — keep them un-confused:
+
+- **Inner rounds:** rounds *within one* `delegate_roundtable_run` call
+  (`roundtable_max_rounds`, default 3). Engine-owned, unchanged.
+- **Outer passes:** REVIEW → revise → re-REVIEW cycles the *pipeline* drives. This
+  is what the human means by "passes" and what §6's ceiling bounds.
+
+**Done-bar (configurable; correctness condition, not a budget).** A phase leaves
+its review loop only when the latest REVIEW result satisfies the configured bar,
+read from real engine fields (`roundtable_result_t`):
+
+- `zero_blocking` *(default)* — `converged == true` and no `items[]` of
+  `severity == "blocking"`. Suggestions/nits are surfaced in the gate digest but
+  don't block.
+- `zero_blocking_suggestions` — also requires no `suggestion`-severity items
+  (nits allowed). Stricter, more passes.
+- `zero_blocking_questions_answered` — `zero_blocking` plus every brief question
+  present in `answered_questions[]` and `coverage_gaps[]` empty.
+
+The driving agent computes the bar from the structured items
+(agent-directed-pr-review P1b); it never re-judges convergence itself — it trusts
+the engine's deterministic `converged`/`review_saturated`.
+
+**Pass ceiling (configurable; cost backstop, not an early-exit).** `roundtable_pipeline_max_passes`
+bounds outer passes. **Default 0 = unbounded** — review runs until the done-bar,
+honoring correctness-over-pass-count. When an operator sets a positive cap and the
+loop reaches it *without* meeting the done-bar, the agent **escalates to the
+human** (surfaces the current artifact + the remaining blocking items + cost) and
+**does not auto-pass**. A cap is a budget guard, never a way to ship a not-correct
+artifact.
+
+**Echo guard.** Between passes the brief carries the *author's fixes/changes*, not
+the panel's verbatim prior findings, so a fresh panel re-derives rather than
+anchors on its own prior output. (The engine already dedupes within a call; this
+prevents cross-pass echo.)
+
+**Non-termination backstop.** Besides the optional pass ceiling, the inherited
+`ensemble_max_cost_usd` (per call) and a new cumulative
+`roundtable_pipeline_max_cost_usd` (per phase, §6) bound spend; either tripping
+escalates to the human rather than silently passing.
+
+## §4 Hybrid state — the resumable pipeline ledger
+
+The agent drives the loop, but pipeline state is **persisted** so it survives a
+restart and a human gate can be answered later (the decision). A `pipeline_run`
+record (DB1 table or a `/v1/runs` sibling — §12) holds:
+
+- pipeline id, state (§1), phase, created/updated timestamps;
+- the working artifact (proposal text or PR ref) and the current brief;
+- per-pass history: each outer pass's roundtable `run_id`, `converged`,
+  blocking/suggestion counts, `cost_usd`, `rounds_run`, `best_round`;
+- the PR number(s) and merge SHAs;
+- the human-gate verdicts and fail reasons.
+
+This makes the human gate a durable checkpoint: `aimee pipeline status <id>` shows
+where it is and the evidence; `aimee pipeline gate <id> pass|fail --reason "…"`
+records the verdict and resumes the loop. The driving agent reconstructs its
+position from the ledger on any new session.
+
+## §5 The two human gates
+
+At `gate1_pending` / `gate2_pending` the agent **pauses** and surfaces a compact
+digest, then waits for the verdict:
+
+- the PR link;
+- the converged-review **digest**: blocking/suggestion/nit counts, the
+  highest-corroboration items (`item.count`), answered questions, and any
+  `coverage_gaps`;
+- pipeline economics: total outer passes, cumulative `cost_usd`, rounds.
+
+**pass** advances (merge → next phase). **fail** captures the human's reason; the
+reason becomes a brief `focus`/`questions` entry for the next loop, and the state
+returns to the prior review phase. The fail reason is durable in the ledger so the
+re-review is genuinely directed by it.
+
+## §6 Config
+
+New keys (full plumbing: `config.h` field, `config_fields.c`,
+`config_sections.c`, `config_save.c`, `aimee config get/set/list`, generated docs,
+`test_config`/`test_config_surface`/`test_cmd_config`). Decide nesting
+(`roundtable.pipeline.*` section vs top-level) at implementation:
+
+- `roundtable_pipeline_done_bar` — enum `zero_blocking` (default) |
+  `zero_blocking_suggestions` | `zero_blocking_questions_answered`.
+- `roundtable_pipeline_max_passes` — int, **default 0 (unbounded)**; >0 = outer
+  pass ceiling that escalates (never auto-passes) on hit.
+- `roundtable_pipeline_max_cost_usd` — double, cumulative per-phase spend cap;
+  0 = unbounded; tripping escalates.
+- *(optional, deferred)* per-phase overrides (`…_proposal` / `…_pr` suffixes) if
+  the proposal and PR phases want different bars.
+
+Participants, aggregator, per-call cost, and inner-round bounds are **inherited**
+from `ensemble_*` / `roundtable_*`; no duplication.
+
+## §7 Making "converged" mean "correct"
+
+Convergence is only as meaningful as the panel. To keep the quality gate honest
+(not "agreeable panelists agreed"):
+
+- **Participant diversity** — the panel reuses `ensemble_*` participants, which
+  should be distinct models/providers; a single-model panel converges on its own
+  blind spots. Validation (§10) asserts ≥2 distinct providers for a pipeline run
+  or warns.
+- **Open mandate** (§2) so direction never suppresses out-of-scope findings.
+- **Corroboration surfacing** — the gate digest shows `item.count` so the human
+  sees whether a finding was one panelist or all of them.
+- **Adversarial framing** inherited from review mode's `review` charter role.
+
+These make a clean done-bar correspond to *correctness*, which is the real target
+— the pipeline never trades correctness for fewer passes.
+
+## §8 Dependencies
+
+- **Hard:** `agent-directed-pr-review` P1a (brief) + P1b (structured items
+  returned) + P1c (`ensemble_review` MCP tool over the async bridge). Without P1c
+  the agent cannot invoke directed review mid-loop; without P1b it cannot evaluate
+  the done-bar.
+- **Soft:** the `git diff` range helper (agent-directed-pr-review P2) for the PR
+  phase input; otherwise the agent runs `git diff` itself.
+- **Repo flow:** PRs base `testing`; main promotion is separate and out of scope.
+
+## §9 Phasing
+
+- **P0 — Ledger + states.** The `pipeline_run` record, the state enum/transitions,
+  and `aimee pipeline status|gate` CLI. No loop yet; states settable manually.
+  Mergeable alone.
+- **P1 — Outer review loop + done-bar.** The REVIEW⇄revise loop over
+  `ensemble_review`, the configurable done-bar evaluator, the pass ceiling +
+  escalation, the echo guard. Drives the PR phase first (single mode, simplest).
+- **P2 — Proposal phase (DRAFT + REVIEW).** Add the `drafting` DRAFT step and the
+  proposal-review loop; wire `gh pr create`/merge for the proposal PR.
+- **P3 — Human gates + fail-return edges** end to end, with the durable digest and
+  reason-to-brief feedback. This closes the full loop.
+- **P4 — Config surface** for all keys + generated docs + tests (lands with the
+  phase that first reads each key, not deferred).
+
+P0/P1 are useful standalone (a directed, looped PR reviewer with a durable
+ledger) before the full idea→merge pipeline of P2/P3.
+
+## §10 Validation
+
+- **Loop correctness** — a fixture proposal/diff with N seeded blocking issues:
+  the loop reaches the done-bar only after all N are resolved; the digest counts
+  match the engine items; the ledger records each pass's `run_id`/cost.
+- **Done-bar config** — each of the three bars stops the loop at the right point
+  (suggestions block under bar 2; questions must be answered under bar 3).
+- **Pass-ceiling escalation** — with a low cap and an unresolvable seeded issue,
+  the loop escalates to the human at the cap and never auto-passes.
+- **Resumability** — kill and restart between a review pass and a gate; the ledger
+  restores state and the gate is answerable post-restart.
+- **Fail-return** — a `fail --reason` re-enters the review loop with the reason
+  present in the next brief (asserted in the reviewer prompt).
+- **Panel diversity** — a single-provider panel warns; a ≥2-provider panel does
+  not.
+- **Cost accounting** — cumulative per-phase cost matches the sum of per-pass
+  `cost_usd`; the per-phase cap trips correctly.
+
+## §11 Non-goals (v1)
+
+- Server-side git or GitHub API (no PR fetch, no inline-comment posting); the
+  agent uses `gh`/`git` (agent-directed-pr-review §11).
+- A fully autonomous, gate-less pipeline — the two human gates are mandatory by
+  design; "configurable max passes" bounds cost, it does not remove the human.
+- Engine changes to the roundtable. The pipeline is strictly on top.
+- Multi-proposal/parallel-pipeline scheduling (one pipeline run at a time in v1).
+
+## §12 Open questions
+
+- **Ledger home:** a DB1 `pipeline_run` table vs a `/v1/runs` sibling vs reusing
+  the existing op-run store with a new kind. The op-run store already persists run
+  state for the async bridge; extending it may be lighter than a new table.
+- **Who is the driving agent at the gate?** When paused at a human gate across
+  sessions, does a fresh agent resume from the ledger automatically, or does the
+  human re-invoke `aimee pipeline resume <id>`?
+- **Per-phase config:** do the proposal and PR phases want independent done-bars /
+  ceilings by default, or one shared set with optional overrides?
+- **DRAFT seeding:** does the `drafting` step take only the idea, or also a
+  pointer to sibling/related proposals so the first draft starts grounded?

--- a/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/pending/agent-roundtable-authoring-pipeline.md
@@ -2,7 +2,7 @@
 
 - **State:** draft — pending review
 - **Author:** JBailes
-- **Date:** 2026-06-11 (revised post-PR-#183 fifth review)
+- **Date:** 2026-06-11 (revised post-PR-#183 sixth review)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review
   (roundtable application), Gate-Promote (human pass/fail gates), Calibrate
   (done-bar + pass ceiling config), Persist (resumable ledger).
@@ -267,6 +267,32 @@ safely and how retry accounting stays correct.
     must write terminal status for every op-run outcome, not just successful
     roundtable JSON. **Resolved in §4 and §10.**
 
+## PR #183 sixth review — closing the read side and the DRAFT path
+
+Moving the *write* to the worker (gaps #18/#20–25) was right, but two ends of that
+design are still open: how the agent *reads* terminal, and what a DRAFT pass
+actually captures.
+
+26. **The agent's terminal-detection poll target must be the durable ledger row,
+    not `/v1/runs`.** The worker now writes the result to DB1, but the proposal
+    never says how the *driving agent* learns a pass reached terminal. If it polls
+    `/v1/runs/{id}`, the **read** side still races eviction (a long pass + ≥256
+    sibling runs + a sleeping agent) — the exact race the worker-capture removed,
+    just moved downstream. The agent must poll the **durable ledger pass row**
+    (`aimee pipeline status` / the DB1 row's `captured`/terminal marker), treating
+    `/v1/runs` as a best-effort live view only. Only then is the race closed on
+    both ends. **Resolved in §4 and §10.**
+27. **The capture contract is review-shaped; a DRAFT pass has no defined durable
+    result.** Gap #22 routes *both* DRAFT and REVIEW through the async op-run
+    worker, but §4's capture lists only review fields (`items`/severities/`count`/
+    `items_round`/`artifact_round`). A DRAFT pass produces an **artifact** (the
+    skeleton), not items, and per #9 that artifact is 8 KB-capped. Capture must
+    persist the **mode-appropriate** payload: for DRAFT, the artifact ref + content
+    hash + `best_round`/`artifact_round` + validity flags (with the skeleton text
+    landing in the working file, not as a ledger blob); for REVIEW, the items.
+    Otherwise draft passes drop their result or are mis-shaped into review fields.
+    **Resolved in §2, §4, and §10.**
+
 ## Relationship to existing proposals
 
 - **The roundtable engine is done** (`docs/proposals/done/agent-roundtable-collaborative-drafting.md`,
@@ -346,8 +372,10 @@ Both phases use the **same** engine; they differ only in input and brief.
   proposal lives in the working file/PR, not in the DRAFT artifact; REVIEW reviews
   the file (or chunked sections for large proposals, like the diff path below),
   not the truncated artifact. Pipeline-owned DRAFT and REVIEW calls must use the
-  async op-run path so server-worker result capture runs. The brief carries the
-  proposal's *goal*, the *invariants* it must satisfy, and the human's seed
+  async op-run path so server-worker result capture runs; the DRAFT pass is
+  captured as an artifact **ref + hash** (mode-appropriate, #27), with the skeleton
+  text written to the working file, not stored as a ledger blob. The brief carries
+  the proposal's *goal*, the *invariants* it must satisfy, and the human's seed
   *questions*.
 - **PR phase (A).** Input = unified diff (normally `git diff <base>...HEAD`;
   aimee has no PR-fetch and needs none — `agent-directed-pr-review` §6). REVIEW
@@ -468,13 +496,24 @@ double-underscore fields are not user API). `server_http_submit_op_run` /
 `rh_dispatch_op_async` must preserve that private metadata alongside the existing
 `__run_id` injection (`:419`). Extend the finalize path, preferably through a
 narrow op-run-finalize hook rather than hard-coding roundtable ledger writes into
-generic HTTP routing, to **also persist the structured pass result** (items +
-severities + `count`, `converged`, validity flags, `items_round`,
-`artifact_round`, counts, `cost_usd`, `rounds_run`) into the DB1 ledger row before
-the run record can be evicted. Failed, cancelled, malformed, and capture-failed
-terminal states are recorded too. The `/v1/runs` id is retained only as a
-historical pointer; the ledger row is the source of truth for the done-bar and the
-gate digest.
+generic HTTP routing, to **also persist the pass result** into the DB1 ledger row
+before the run record can be evicted. The hook **no-ops when `__pipeline_pass_id`
+is absent**, so ordinary `ensemble_review`/roundtable calls are untouched. What it
+persists is **mode-appropriate** (#27): for a REVIEW pass, the items + severities
++ `count`, `converged`, validity flags, `items_round`, `artifact_round`, counts,
+`cost_usd`, `rounds_run`; for a DRAFT pass, the artifact **ref + content hash** +
+`best_round`/`artifact_round` + validity flags (the skeleton text itself lands in
+the working file, not as a ledger blob, per #9). Failed, cancelled, malformed, and
+capture-failed terminal states are recorded too. The `/v1/runs` id is retained
+only as a historical pointer; the ledger row is the source of truth for the
+done-bar and the gate digest.
+
+**The agent reads terminal from the ledger, not `/v1/runs` (#26).** Because the
+worker writes the result to DB1 at terminal, the driving agent learns a pass
+completed by polling the **durable ledger pass row** (`aimee pipeline status` / the
+row's `captured`/terminal marker), never by polling `/v1/runs/{id}`. `/v1/runs`
+remains a best-effort live view; the ledger row is what the agent waits on, so the
+eviction race is closed on the read side as well as the write side.
 
 If a result is still not captured (a genuine fault), the attempt is marked
 `lost_result` and the pipeline **auto re-runs the review pass** under the same
@@ -642,6 +681,14 @@ ledger) before the full idea→merge pipeline of P2/P3.
 - **DRAFT/REVIEW callable split** — the proposal phase invokes a draft-capable
   roundtable path that returns an `artifact`; the review phases invoke the
   review-capable path that returns structured items for the done-bar.
+- **Mode-appropriate capture (#27)** — a DRAFT pass persists an artifact ref +
+  hash + `best_round`/flags (skeleton text in the working file, not the ledger);
+  a REVIEW pass persists items/severities/`count`; neither is mis-shaped into the
+  other, and the finalize hook no-ops for a non-pipeline `ensemble_review` call.
+- **Agent reads terminal from the ledger (#26)** — with `/v1/runs` forced to evict
+  the run and the agent asleep through terminal, the agent still detects completion
+  by polling the durable ledger pass row; it never depends on `/v1/runs` being
+  present to learn a pass finished.
 - **Ledger compatibility** — if reusing DB1 `pipelines`, old autopilot
   `start/status/list/cancel/resume/link-*` behavior remains intact; if using a new
   table, pipeline IDs and command names are unambiguous.


### PR DESCRIPTION
## Summary

Proposes an **agent-driven authoring pipeline** that orchestrates the existing roundtable engine (DRAFT + REVIEW, on `testing`) into a closed loop: a one-line idea → a panel-reviewed proposal → a merged, panel-reviewed implementation, with **two human pass/fail gates** and **two roundtable quality gates**.

```
idea → DRAFT skeleton → REVIEW⇄revise (done-bar) → proposal PR → [human gate 1]
     → merge+implement → REVIEW⇄fix (done-bar) → [human gate 2] → merge
```

The roundtable runs **as many passes as correctness takes**; the done-bar is a correctness condition, and the configurable pass/cost ceilings only ever **escalate to the human** — they never auto-pass a not-done artifact.

## Status: consolidated

This proposal was hardened over **23 review rounds / 57 findings** against the live tree. As of `8fc51ae` it is **consolidated**: every finding is folded into the design sections (§1–§12), and the review archaeology is compressed into **Appendix A — Decision log** (the index for the `(#NN)` references and their in-tree grounding). The document went 1609 → ~997 lines and now reads design-first.

## Key decisions baked in
- **Hybrid** orchestration: agent drives the loop; a durable DB1 pipeline ledger makes state resumable. Result capture is **server-worker-owned** via the existing `op_run_worker_run` finalize seam (closes the `/v1/runs` 256-eviction race); the agent reads terminal from the ledger.
- **DRAFT yields a skeleton** (8 KB artifact cap), expanded in review. Large artifacts are stored **whole + chunked in db2** (origin always retained); the orchestrator retrieves cross-chunk context and hands panelists self-contained inline units.
- **One canonical validity predicate** for done-bar eligibility (operates on a capture envelope; never gates capture).
- **Configurable** done-bar, pass ceiling, per-phase + whole-pipeline cost caps (implementation spend read from the cost-accounting proposal's `usage_ledger`, source/scope pinned).
- **Gate integrity:** the gate verdict requires authority the driving agent lacks (not `CAP_DELEGATE`) so it can't self-approve; resolution is **exactly-once + crash-recoverable** (`*_merge_pending` saga); a slow merge can't auto-abandon a human's approval.

## What's net-new vs reused
- **Reused:** the roundtable engine, the in-tree `ensemble_review` review surface, `git_pr`/`mcp_git_run`, the `op_run_worker` async path.
- **Net-new:** the outer REVIEW⇄revise loop + done-bar, the two human gates + fail-return edges, the resumable ledger, config keys, and a gate-resolution authority + merge executor.

Docs-only (one file under `docs/proposals/pending/`); base `testing`; default-off throughout.

