### PR TITLE
Client-held agent credentials: RAM-only session keyring, no keys stored on the server

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,6 +546,7 @@ set(DATA_SRCS
     ${AIMEE_SRC_DIR}/worktree_gc.c
     ${AIMEE_SRC_DIR}/workspace_manifest.c
     ${AIMEE_SRC_DIR}/server/agent_config.c
+    ${AIMEE_SRC_DIR}/server/session_credentials.c
     ${AIMEE_SRC_DIR}/cmd_describe.c
     ${AIMEE_SRC_DIR}/history.c
     ${AIMEE_SRC_DIR}/role_templates.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -753,6 +753,7 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_persona.c
     ${AIMEE_SRC_DIR}/cli_roles.c
     ${AIMEE_SRC_DIR}/cli_workspace_serve.c
+    ${AIMEE_SRC_DIR}/cli_agent_keys.c
     ${AIMEE_SRC_DIR}/cli_remote.c
     ${AIMEE_SRC_DIR}/server/delegate_plan.c
     ${AIMEE_SRC_DIR}/acp_server.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -490,6 +490,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/memory_provider.c
     ${AIMEE_SRC_DIR}/plugin_c_hook.c
     ${AIMEE_SRC_DIR}/config_plugin.c
+    ${AIMEE_SRC_DIR}/code_collect.c
     ${AIMEE_SRC_DIR}/events.c
     ${AIMEE_SRC_DIR}/model_registry.c
     ${AIMEE_SRC_DIR}/models_dev.c
@@ -1122,6 +1123,7 @@ add_executable(aimee
     ${CLI_SRCS}
     ${CLIENT_SUPPORT_SRCS}
     ${AIMEE_SRC_DIR}/aimee_home.c
+    ${AIMEE_SRC_DIR}/code_collect.c
     ${AIMEE_SRC_DIR}/dstr.c
     ${AIMEE_SRC_DIR}/history.c
     ${AIMEE_SRC_DIR}/markdown.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,6 +491,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/plugin_c_hook.c
     ${AIMEE_SRC_DIR}/config_plugin.c
     ${AIMEE_SRC_DIR}/code_collect.c
+    ${AIMEE_SRC_DIR}/codex_auth.c
     ${AIMEE_SRC_DIR}/events.c
     ${AIMEE_SRC_DIR}/model_registry.c
     ${AIMEE_SRC_DIR}/models_dev.c
@@ -1124,6 +1125,7 @@ add_executable(aimee
     ${CLIENT_SUPPORT_SRCS}
     ${AIMEE_SRC_DIR}/aimee_home.c
     ${AIMEE_SRC_DIR}/code_collect.c
+    ${AIMEE_SRC_DIR}/codex_auth.c
     ${AIMEE_SRC_DIR}/dstr.c
     ${AIMEE_SRC_DIR}/history.c
     ${AIMEE_SRC_DIR}/markdown.c

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1657,6 +1657,29 @@ paths:
       summary: Scan/re-index the codebase (async; poll GET /runs/{id})
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Queued op run, content: { application/json: { schema: { type: object } } } } }
+  /session/credentials:
+    post:
+      summary: Push client-held agent credentials into the session's RAM keyring
+      description: >-
+        The thin client pushes its agent API keys (and Codex OAuth creds) once
+        per session. The server caches them in memory keyed by session id and
+        NEVER persists them; agent auth resolution prefers these over any
+        server-stored key, so credentials need not live on the server.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [session_id]
+              properties:
+                session_id: { type: string }
+                agents:
+                  type: object
+                  additionalProperties: { type: string }
+                codex_oauth_token: { type: string }
+                codex_account_id: { type: string }
+      responses: { "200": { description: Stored count, content: { application/json: { schema: { type: object } } } } }
   /index/ingest:
     post:
       summary: Index client-pushed workspace files (async; poll GET /runs/{id})

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1657,6 +1657,35 @@ paths:
       summary: Scan/re-index the codebase (async; poll GET /runs/{id})
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Queued op run, content: { application/json: { schema: { type: object } } } } }
+  /index/ingest:
+    post:
+      summary: Index client-pushed workspace files (async; poll GET /runs/{id})
+      description: >-
+        Index a project from file contents supplied by the caller, used by the
+        thin client to ingest a workspace whose root lives on the client and is
+        not visible to the server (a `detached` workspace). The server relays the
+        supplied {rel_path, content} entries to aimee-kb without reading any
+        local filesystem.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, root, files]
+              properties:
+                name: { type: string }
+                root: { type: string }
+                force: { type: boolean }
+                files:
+                  type: array
+                  items:
+                    type: object
+                    required: [rel_path, content]
+                    properties:
+                      rel_path: { type: string }
+                      content: { type: string }
+      responses: { "200": { description: Queued op run, content: { application/json: { schema: { type: object } } } } }
   /memory/benchmark:
     post:
       summary: Run a memory retrieval benchmark

--- a/src/Makefile
+++ b/src/Makefile
@@ -317,7 +317,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 DATA_SRCS = memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
-            workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
+            workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c server/session_credentials.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
             trajectory_export.c trajectory_batch.c \
             memory_profile_pack.c wiki_render.c \

--- a/src/Makefile
+++ b/src/Makefile
@@ -349,7 +349,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_main.c cli_session_start.c cli_attention_guard.c cli_code_audit.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c
+CLI_SRCS = cli_main.c cli_session_start.c cli_attention_guard.c cli_code_audit.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/Makefile
+++ b/src/Makefile
@@ -293,7 +293,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c \
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
-            plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c
+            plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
@@ -363,7 +363,7 @@ CLIENT_PLATFORM_OBJS = $(filter %/platform_ipc.o %/platform_net.o %/platform_pat
 # with full flags; --gc-sections trims the unused remainder). util.o supplies
 # run_cmd/run_cmd_set_cwd for the provider exec_shell op the runner now serves.
 CLIENT_RUNNER_OBJS = $(OBJDIR)/server/workspace_provider_detached.o $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/posix/util.o $(OBJDIR)/util.o
-CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
+CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
 CLIENT_COMPILE_OBJS = $(CLI_OBJS) $(CLIENT_PLATFORM_OBJS) $(OBJDIR)/dstr.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o
 $(CLIENT_COMPILE_OBJS): C_FLAGS := $(CLIENT_C_FLAGS)
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -293,7 +293,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c \
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
-            plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c
+            plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
@@ -363,7 +363,7 @@ CLIENT_PLATFORM_OBJS = $(filter %/platform_ipc.o %/platform_net.o %/platform_pat
 # with full flags; --gc-sections trims the unused remainder). util.o supplies
 # run_cmd/run_cmd_set_cwd for the provider exec_shell op the runner now serves.
 CLIENT_RUNNER_OBJS = $(OBJDIR)/server/workspace_provider_detached.o $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/posix/util.o $(OBJDIR)/util.o
-CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
+CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(OBJDIR)/codex_auth.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
 CLIENT_COMPILE_OBJS = $(CLI_OBJS) $(CLIENT_PLATFORM_OBJS) $(OBJDIR)/dstr.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o
 $(CLIENT_COMPILE_OBJS): C_FLAGS := $(CLIENT_C_FLAGS)
 

--- a/src/cli_agent_keys.c
+++ b/src/cli_agent_keys.c
@@ -1,0 +1,244 @@
+/* cli_agent_keys.c: see cli_agent_keys.h. */
+#include "cli_agent_keys.h"
+#include "cli_client.h" /* cli_http_request, cli_rpc_* */
+#include "codex_auth.h" /* codex_local_auth */
+#include "aimee_home.h" /* aimee_home */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#define AGENT_KEYS_FILE   "agent-keys.json"
+#define CRED_SESSION_FILE "cred-session.id"
+#define CRED_PUSH_MARKER  ".creds-pushed"
+/* Don't re-push within this window (one-shot CLI invocations share the keyring
+ * via the marker file; a server restart re-syncs after at most this long). */
+#define CRED_PUSH_MIN_INTERVAL_SECS 120
+
+static int aimee_file_path(const char *name, char *out, size_t out_len)
+{
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return -1;
+   snprintf(out, out_len, "%s/%s", home, name);
+   return 0;
+}
+
+static char *read_text(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   fseek(f, 0, SEEK_END);
+   long sz = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   if (sz <= 0 || sz > (1 << 20))
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t got = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   buf[got] = '\0';
+   return buf;
+}
+
+/* Load the local keyring object {name:key}; always returns an object. */
+static cJSON *load_keys(void)
+{
+   char path[1024];
+   if (aimee_file_path(AGENT_KEYS_FILE, path, sizeof(path)) != 0)
+      return cJSON_CreateObject();
+   char *buf = read_text(path);
+   cJSON *root = buf ? cJSON_Parse(buf) : NULL;
+   free(buf);
+   if (!cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      root = cJSON_CreateObject();
+   }
+   return root;
+}
+
+int cli_agent_key_set(const char *agent_name, const char *api_key)
+{
+   if (!agent_name || !agent_name[0])
+      return -1;
+   char path[1024];
+   if (aimee_file_path(AGENT_KEYS_FILE, path, sizeof(path)) != 0)
+      return -1;
+
+   cJSON *root = load_keys();
+   cJSON_DeleteItemFromObjectCaseSensitive(root, agent_name);
+   if (api_key && api_key[0])
+      cJSON_AddStringToObject(root, agent_name, api_key);
+
+   char *json = cJSON_Print(root);
+   cJSON_Delete(root);
+   if (!json)
+      return -1;
+   FILE *f = fopen(path, "wb");
+   if (!f)
+   {
+      free(json);
+      return -1;
+   }
+   fputs(json, f);
+   fclose(f);
+   chmod(path, 0600);
+   free(json);
+   return 0;
+}
+
+int cli_agent_add_localize_key(int *argc, char **argv)
+{
+   if (!argc || !argv || *argc < 2)
+      return 0;
+   const char *name = argv[1]; /* argv[0] == "add" */
+   if (!name || !name[0])
+      return 0;
+   int ki = -1;
+   for (int i = 2; i + 1 < *argc; i++)
+      if (strcmp(argv[i], "--key") == 0)
+      {
+         ki = i;
+         break;
+      }
+   if (ki < 0)
+      return 0;
+   if (cli_agent_key_set(name, argv[ki + 1]) != 0)
+      return 0;
+   /* Drop argv[ki] and argv[ki+1] by shifting the tail left. */
+   for (int j = ki; j + 2 < *argc; j++)
+      argv[j] = argv[j + 2];
+   *argc -= 2;
+   return 1;
+}
+
+int cli_cred_session_id(char *out, size_t out_len)
+{
+   if (!out || out_len == 0)
+      return -1;
+   out[0] = '\0';
+   char path[1024];
+   if (aimee_file_path(CRED_SESSION_FILE, path, sizeof(path)) != 0)
+      return -1;
+
+   char *existing = read_text(path);
+   if (existing)
+   {
+      size_t n = strcspn(existing, "\r\n");
+      if (n > 0 && n < out_len)
+      {
+         memcpy(out, existing, n);
+         out[n] = '\0';
+      }
+      free(existing);
+      if (out[0])
+         return 0;
+   }
+
+   /* Generate a random id from /dev/urandom (hex). */
+   unsigned char rnd[16] = {0};
+   FILE *ur = fopen("/dev/urandom", "rb");
+   if (ur)
+   {
+      if (fread(rnd, 1, sizeof(rnd), ur) != sizeof(rnd))
+         rnd[0] |= 1;
+      fclose(ur);
+   }
+   char id[64];
+   int p = snprintf(id, sizeof(id), "cs-");
+   for (size_t i = 0; i < sizeof(rnd) && p < (int)sizeof(id) - 2; i++)
+      p += snprintf(id + p, sizeof(id) - (size_t)p, "%02x", rnd[i]);
+   FILE *f = fopen(path, "wb");
+   if (f)
+   {
+      fputs(id, f);
+      fclose(f);
+      chmod(path, 0600);
+   }
+   snprintf(out, out_len, "%s", id);
+   return 0;
+}
+
+/* True if we pushed within CRED_PUSH_MIN_INTERVAL_SECS (marker mtime). */
+static int recently_pushed(void)
+{
+   char path[1024];
+   if (aimee_file_path(CRED_PUSH_MARKER, path, sizeof(path)) != 0)
+      return 0;
+   struct stat st;
+   if (stat(path, &st) != 0)
+      return 0;
+   return (time(NULL) - st.st_mtime) < CRED_PUSH_MIN_INTERVAL_SECS;
+}
+
+static void touch_push_marker(void)
+{
+   char path[1024];
+   if (aimee_file_path(CRED_PUSH_MARKER, path, sizeof(path)) != 0)
+      return;
+   FILE *f = fopen(path, "wb");
+   if (f)
+      fclose(f);
+}
+
+void cli_session_creds_prime(cJSON *req)
+{
+   if (!req || !cli_rpc_remote_endpoint_is_tcp())
+      return;
+   char sid[128];
+   if (cli_cred_session_id(sid, sizeof(sid)) != 0 || !sid[0])
+      return;
+   cJSON_AddStringToObject(req, "cred_session_id", sid);
+
+   if (recently_pushed())
+      return; /* server already has this session's keyring (deduped) */
+
+   /* Build the push body from the local keyring + Codex creds. */
+   cJSON *agents = load_keys();
+   char token[8192];
+   char account[256];
+   int have_codex = (codex_local_auth(token, sizeof(token), account, sizeof(account)) == 0);
+   if (cJSON_GetArraySize(agents) == 0 && !have_codex)
+   {
+      cJSON_Delete(agents);
+      return; /* nothing to push */
+   }
+
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "session_id", sid);
+   cJSON_AddItemToObject(body, "agents", agents); /* adopt */
+   if (have_codex)
+   {
+      cJSON_AddStringToObject(body, "codex_oauth_token", token);
+      if (account[0])
+         cJSON_AddStringToObject(body, "codex_account_id", account);
+   }
+   char *body_json = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+   if (!body_json)
+      return;
+
+   char *endpoint = cli_rpc_client_endpoint();
+   char *bearer = cli_rpc_client_bearer();
+   int status = 0;
+   cJSON *resp = cli_http_request(endpoint, "POST", "/v1/session/credentials", body_json, bearer,
+                                  30000, &status);
+   free(body_json);
+   free(endpoint);
+   free(bearer);
+   if (resp && status >= 200 && status < 300)
+      touch_push_marker();
+   if (resp)
+      cJSON_Delete(resp);
+}

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -6,9 +6,12 @@
  * Bash command, blocks (exit 2) when the command text mentions a path the log
  * scores at/above the high-attention threshold. Substring-matching known
  * high-attention paths against the command avoids fragile shell parsing.
- * Recursive raw scans are blocked by default and redirected toward Aimee's
- * indexed exploration tools; ingress_max_raw_scans allows a capped number per
- * session.
+ * The raw-scan redirect is OPT-IN: it is inert unless ingress_max_raw_scans is
+ * set to a positive cap, in which case a session may run that many recursive
+ * raw scans before further ones are redirected toward Aimee's indexed
+ * exploration tools. With no cap configured (the default, and what a thin-client
+ * host with no aimee.yaml sees) raw scans are never blocked. AIMEE_GUARD=0
+ * disables the guard entirely.
  */
 #include "cli_attention_guard.h"
 #include "cli_session_start.h" /* read_stdin */
@@ -433,21 +436,28 @@ int handle_attention_guard(void)
 
    if (op == ATTN_OP_RAW_SCAN)
    {
+      /* The raw-scan cap is OPT-IN: ingress_max_raw_scans <= 0 (the default,
+       * and what a thin-client host with no aimee.yaml sees) means the guard is
+       * disabled, so raw scans flow freely. Only a positive cap is enforced —
+       * after that many scans this session, redirect to the indexed tools. */
       int ingress_max_raw_scans = attn_config_ingress_max_raw_scans();
-      int used = attn_raw_scan_count(arr, now_ts);
-      if (ingress_max_raw_scans <= 0 || used >= ingress_max_raw_scans)
+      if (ingress_max_raw_scans > 0)
       {
-         fprintf(stderr,
-                 "aimee attention-guard: recursive raw scans are disabled or exhausted for this "
-                 "context. "
-                 "Use Aimee's indexed tools instead: find_symbol, ast_grep_search, "
-                 "search_graph, or get_context_block. Set ingress_max_raw_scans above 0 "
-                 "only when raw scanning is intentional.\n");
-         exit_code = 2;
-      }
-      else
-      {
-         attn_record(arr, ATTN_RAW_SCAN_PATH, 1, now_ts);
+         int used = attn_raw_scan_count(arr, now_ts);
+         if (used >= ingress_max_raw_scans)
+         {
+            fprintf(stderr,
+                    "aimee attention-guard: this session has hit its raw-scan cap (%d). Aimee "
+                    "indexes this repo — explore through it instead: find_symbol, "
+                    "ast_grep_search, search_graph, or get_context_block. Raise "
+                    "ingress_max_raw_scans (or set AIMEE_GUARD=0) to bypass.\n",
+                    ingress_max_raw_scans);
+            exit_code = 2;
+         }
+         else
+         {
+            attn_record(arr, ATTN_RAW_SCAN_PATH, 1, now_ts);
+         }
       }
    }
    else if (op == ATTN_OP_HARD && bash_cmd && bash_cmd[0])

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1910,6 +1910,18 @@ int main(int argc, char **argv)
    if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "serve") == 0)
       return cmd_workspace_serve(sub_argc >= 2 ? sub_argv[1] : NULL);
 
+   /* Thin-client workspace push: against a remote (tcp) server the workspace
+    * root lives on THIS host, which the server cannot read. Resolve + register +
+    * ingest from the client rather than forwarding the raw path (which the
+    * server would try to realpath against its own filesystem and reject). */
+   if (cli_rpc_remote_endpoint_is_tcp())
+   {
+      if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "add") == 0)
+         return cli_workspace_add_remote(sub_argc >= 2 ? sub_argv[1] : NULL);
+      if (strcmp(cmd, "index") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "scan") == 0)
+         return cli_index_scan_remote(sub_argc - 1, sub_argv + 1);
+   }
+
    /* Route through native server RPCs when possible. */
    {
       cli_rpc_route_t route;

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -3,6 +3,7 @@
 #include "aimee_client.h"
 #include "cli_remote.h"
 #include "cli_client.h"
+#include "cli_agent_keys.h"
 #include "cli_session_start.h"
 #include "cli_attention_guard.h"
 #include "cli_code_audit.h"
@@ -1920,6 +1921,12 @@ int main(int argc, char **argv)
          return cli_workspace_add_remote(sub_argc >= 2 ? sub_argv[1] : NULL);
       if (strcmp(cmd, "index") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "scan") == 0)
          return cli_index_scan_remote(sub_argc - 1, sub_argv + 1);
+      /* `agent add ... --key K` against a remote server: keep K on THIS host
+       * (local keyring) and strip it before forwarding the agent definition, so
+       * the server never stores the credential. Falls through to forward the
+       * (key-stripped) agent.add. */
+      if (strcmp(cmd, "agent") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "add") == 0)
+         cli_agent_add_localize_key(&sub_argc, sub_argv);
    }
 
    /* Route through native server RPCs when possible. */

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -3,10 +3,11 @@
  * Unported commands fail in cli_main before reaching the server.
  * =================================================================== */
 
-#include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
-#include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
-#include "code_collect.h" /* code_collect_files: thin-client workspace push */
-#include "codex_auth.h"   /* codex_local_auth: thin-client codex OAuth creds */
+#include "util.h"           /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
+#include "aimee_client.h"   /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
+#include "code_collect.h"   /* code_collect_files: thin-client workspace push */
+#include "codex_auth.h"     /* codex_local_auth: thin-client codex OAuth creds */
+#include "cli_agent_keys.h" /* cli_session_creds_prime: client-held agent keys */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
@@ -1750,7 +1751,7 @@ static cJSON *marshal_delegate(int argc, char **argv)
    rpc_parse(argc, argv, bool_flags, &opts);
 
    cJSON *req = marshal_no_args("delegate");
-   cli_attach_codex_creds(req); /* so a codex-oauth delegate auths from this host */
+   cli_session_creds_prime(req); /* client-held agent keys for this delegate turn */
 
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "role", opts.positional[0]);

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6761,7 +6761,9 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
  * string form); returns NULL when there is no error. */
 static const char *cli_ws_err_message(cJSON *resp)
 {
-   cJSON *err = resp ? cJSON_GetObjectItemCaseSensitive(resp, "error") : NULL;
+   if (!resp)
+      return NULL;
+   cJSON *err = cJSON_GetObjectItemCaseSensitive(resp, "error");
    if (cJSON_IsString(err))
       return err->valuestring;
    if (cJSON_IsObject(err))
@@ -6771,6 +6773,15 @@ static const char *cli_ws_err_message(cJSON *resp)
          return m->valuestring;
       return "error";
    }
+   /* Dispatch-error envelope: {"status":"error","message":"..."} (e.g. an op-run
+    * that failed with PAYLOAD_TOO_LARGE). Without this the failure has no "error"
+    * key and would be silently counted as success. */
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   if (cJSON_IsString(status) && strcmp(status->valuestring, "error") == 0)
+   {
+      cJSON *m = cJSON_GetObjectItemCaseSensitive(resp, "message");
+      return (cJSON_IsString(m) && m->valuestring) ? m->valuestring : "error";
+   }
    return NULL;
 }
 
@@ -6779,9 +6790,10 @@ static const char *cli_ws_err_message(cJSON *resp)
  * code-scan upserts per project+path, so batches accumulate. Returns 0 on
  * success, nonzero if any batch failed. */
 
-/* Keep each ingest POST comfortably under the server's 4 MB request-body cap
- * (SHTTP_MAX_BODY); a single file is capped well below this by code_collect. */
-#define CLI_INGEST_BATCH_BYTES (3 * 1024 * 1024)
+/* Per-batch content budget. The binding limit is aimee-kb's 1 MB request-body
+ * cap (the server relays each batch on to kb); JSON escaping inflates the wire
+ * body above the raw content total, so budget well under 1 MB. */
+#define CLI_INGEST_BATCH_BYTES (600 * 1024)
 
 /* POST one batch of files (adopted/freed) as project `name`/`root`, polling the
  * async op-run to completion. Returns 0 on success. */

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6,6 +6,7 @@
 #include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
 #include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
 #include "code_collect.h" /* code_collect_files: thin-client workspace push */
+#include "codex_auth.h"   /* codex_local_auth: thin-client codex OAuth creds */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
@@ -24,6 +25,24 @@ static void __attribute__((unused)) cli_rpc_sleep_ms(int ms)
 #else
    usleep((useconds_t)ms * 1000);
 #endif
+}
+
+/* Attach this machine's Codex OAuth creds to an outbound request so a remote
+ * server can authenticate a codex-oauth agent WITHOUT the server storing any
+ * codex credential. No-op unless the endpoint is remote-tcp and ~/.codex/auth.json
+ * is readable; the creds are consumed server-side only when a codex agent runs.
+ * Declared in cli_client.h so cli_tui.c (chat) can call it too. */
+void cli_attach_codex_creds(cJSON *req)
+{
+   if (!req || !cli_rpc_remote_endpoint_is_tcp())
+      return;
+   char token[8192];
+   char account[256];
+   if (codex_local_auth(token, sizeof(token), account, sizeof(account)) != 0)
+      return;
+   cJSON_AddStringToObject(req, "codex_oauth_token", token);
+   if (account[0])
+      cJSON_AddStringToObject(req, "codex_account_id", account);
 }
 
 /* --- Minimal arg parser (no util.h dependency) --- */
@@ -1731,6 +1750,7 @@ static cJSON *marshal_delegate(int argc, char **argv)
    rpc_parse(argc, argv, bool_flags, &opts);
 
    cJSON *req = marshal_no_args("delegate");
+   cli_attach_codex_creds(req); /* so a codex-oauth delegate auths from this host */
 
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "role", opts.positional[0]);

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -5,6 +5,7 @@
 
 #include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
 #include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
+#include "code_collect.h" /* code_collect_files: thin-client workspace push */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
@@ -6744,6 +6745,222 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
       waited += step_ms;
    }
 }
+
+/* --- Thin-client workspace push (detached-workspace ingestion) ---------------
+ *
+ * When a thin client talks to a remote aimee-server over TCP, the server cannot
+ * see this host's filesystem. So `aimee workspace add <path>` resolves the path
+ * locally, registers it as a `detached` workspace (server stores it verbatim and
+ * skips its own scan), then pushes the file contents itself to
+ * POST /v1/index/ingest. `aimee index scan` re-pushes. The collector is POSIX
+ * only, so these helpers are no-ops on Windows (the reverse-channel serve path
+ * still works there; client-push indexing does not). */
+#if defined(AIMEE_POSIX)
+
+/* Pull the human-readable message out of an {"error":...} envelope (object or
+ * string form); returns NULL when there is no error. */
+static const char *cli_ws_err_message(cJSON *resp)
+{
+   cJSON *err = resp ? cJSON_GetObjectItemCaseSensitive(resp, "error") : NULL;
+   if (cJSON_IsString(err))
+      return err->valuestring;
+   if (cJSON_IsObject(err))
+   {
+      cJSON *m = cJSON_GetObjectItemCaseSensitive(err, "message");
+      if (cJSON_IsString(m))
+         return m->valuestring;
+      return "error";
+   }
+   return NULL;
+}
+
+/* Collect <abs_root>'s source files locally and push them to the server's
+ * /v1/index/ingest, blocking until the indexing op-run completes. Returns 0 on
+ * success, nonzero on error. */
+static int cli_ws_ingest_root(const char *remote, const char *bearer, const char *abs_root)
+{
+   const char *base = strrchr(abs_root, '/');
+   base = (base && base[1]) ? base + 1 : abs_root;
+
+   cJSON *body = cJSON_CreateObject();
+   if (!body)
+      return 1;
+   cJSON_AddStringToObject(body, "name", base);
+   cJSON_AddStringToObject(body, "root", abs_root);
+   cJSON *files = cJSON_AddArrayToObject(body, "files");
+   int n = files ? code_collect_files(abs_root, files) : 0;
+
+   char *body_json = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+   if (!body_json)
+      return 1;
+
+   /* /v1/index/ingest is async (rh_dispatch_op_async): POST + poll the run. */
+   cJSON *resp = cli_v1_run_and_poll(remote, bearer, "POST", "/v1/index/ingest", body_json, 600000);
+   free(body_json);
+   if (!resp)
+   {
+      fprintf(stderr, "aimee: index ingest failed for %s (transport error)\n", abs_root);
+      return 1;
+   }
+   const char *err = cli_ws_err_message(resp);
+   if (err)
+   {
+      fprintf(stderr, "aimee: index ingest failed for %s: %s\n", abs_root, err);
+      cJSON_Delete(resp);
+      return 1;
+   }
+   cJSON_Delete(resp);
+
+   if (n >= CODE_COLLECT_MAX_FILES)
+      fprintf(stderr, "aimee: note: '%s' hit the %d-file ingest cap; the rest of the tree was "
+                      "not pushed\n",
+              abs_root, CODE_COLLECT_MAX_FILES);
+   printf("ingested %d file(s) from %s\n", n, abs_root);
+   return 0;
+}
+
+int cli_workspace_add_remote(const char *path)
+{
+   if (!path || !path[0])
+   {
+      fprintf(stderr, "usage: aimee workspace add <path>\n");
+      return 1;
+   }
+   char *abs = realpath(path, NULL);
+   if (!abs)
+   {
+      fprintf(stderr, "aimee: workspace: cannot resolve path '%s' on this host\n", path);
+      return 1;
+   }
+
+   char *remote = cli_rpc_client_endpoint();
+   char *bearer = cli_rpc_client_bearer();
+
+   /* Register as detached so the server keeps the client path verbatim (no
+    * server-side realpath) and skips its own filesystem scan. */
+   cJSON *reg = cJSON_CreateObject();
+   cJSON_AddStringToObject(reg, "root", abs);
+   cJSON_AddStringToObject(reg, "provider", "detached");
+   char *reg_json = cJSON_PrintUnformatted(reg);
+   cJSON_Delete(reg);
+
+   int status = 0;
+   cJSON *rresp = cli_v1_send(remote, bearer, "POST", "/v1/workspaces", reg_json, 60000, &status);
+   free(reg_json);
+
+   const char *err = cli_ws_err_message(rresp);
+   int already = (err && strstr(err, "already registered"));
+   if ((!rresp || status < 200 || status >= 300) && !already)
+   {
+      fprintf(stderr, "aimee: workspace add failed (HTTP %d)%s%s\n", status, err ? ": " : "",
+              err ? err : "");
+      if (rresp)
+         cJSON_Delete(rresp);
+      free(abs);
+      free(remote);
+      free(bearer);
+      return 1;
+   }
+   if (rresp)
+      cJSON_Delete(rresp);
+   printf("workspace registered: %s (detached)\n", abs);
+
+   int rc = cli_ws_ingest_root(remote, bearer, abs);
+   free(abs);
+   free(remote);
+   free(bearer);
+   return rc;
+}
+
+int cli_index_scan_remote(int argc, char **argv)
+{
+   /* Positional args mirror `index scan [name] [root]`; flags (e.g. --force) are
+    * ignored for the push path (a push is always a full re-collect). */
+   const char *pos[2] = {NULL, NULL};
+   int npos = 0;
+   for (int i = 0; i < argc; i++)
+   {
+      if (argv[i] && argv[i][0] == '-')
+         continue;
+      if (npos < 2)
+         pos[npos] = argv[i];
+      npos++;
+   }
+   const char *root_arg = (npos >= 2) ? pos[1] : (npos == 1 ? pos[0] : NULL);
+
+   char *remote = cli_rpc_client_endpoint();
+   char *bearer = cli_rpc_client_bearer();
+   int rc = 0;
+
+   if (root_arg)
+   {
+      char *abs = realpath(root_arg, NULL);
+      if (!abs)
+      {
+         fprintf(stderr, "aimee: index scan: cannot resolve path '%s' on this host\n", root_arg);
+         free(remote);
+         free(bearer);
+         return 1;
+      }
+      rc = cli_ws_ingest_root(remote, bearer, abs);
+      free(abs);
+      free(remote);
+      free(bearer);
+      return rc;
+   }
+
+   /* No path: re-ingest every detached workspace the server knows about. */
+   int status = 0;
+   cJSON *list = cli_v1_send(remote, bearer, "GET", "/v1/workspaces", NULL, 60000, &status);
+   if (!list)
+   {
+      fprintf(stderr, "aimee: index scan: could not list workspaces (HTTP %d)\n", status);
+      free(remote);
+      free(bearer);
+      return 1;
+   }
+   cJSON *arr = cJSON_GetObjectItemCaseSensitive(list, "workspaces");
+   int any = 0;
+   cJSON *w = NULL;
+   cJSON_ArrayForEach(w, arr)
+   {
+      cJSON *prov = cJSON_GetObjectItemCaseSensitive(w, "provider");
+      cJSON *p = cJSON_GetObjectItemCaseSensitive(w, "path");
+      if (cJSON_IsString(prov) && strcmp(prov->valuestring, "detached") == 0 && cJSON_IsString(p) &&
+          p->valuestring && p->valuestring[0])
+      {
+         any = 1;
+         if (cli_ws_ingest_root(remote, bearer, p->valuestring) != 0)
+            rc = 1;
+      }
+   }
+   cJSON_Delete(list);
+   if (!any)
+      printf("no detached workspaces to scan; add one with 'aimee workspace add <path>'\n");
+   free(remote);
+   free(bearer);
+   return rc;
+}
+
+#else /* !AIMEE_POSIX */
+
+int cli_workspace_add_remote(const char *path)
+{
+   (void)path;
+   fprintf(stderr, "aimee: remote workspace add is not supported on this platform\n");
+   return 1;
+}
+
+int cli_index_scan_remote(int argc, char **argv)
+{
+   (void)argc;
+   (void)argv;
+   fprintf(stderr, "aimee: remote index scan is not supported on this platform\n");
+   return 1;
+}
+
+#endif /* AIMEE_POSIX */
 
 /* cli_v1_dispatch_local: dispatch a pre-marshalled {method, ...params} request to its
  * first-class /v1 route over the co-located transport — the local aimee-http.sock

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6775,49 +6775,115 @@ static const char *cli_ws_err_message(cJSON *resp)
 }
 
 /* Collect <abs_root>'s source files locally and push them to the server's
- * /v1/index/ingest, blocking until the indexing op-run completes. Returns 0 on
- * success, nonzero on error. */
-static int cli_ws_ingest_root(const char *remote, const char *bearer, const char *abs_root)
-{
-   const char *base = strrchr(abs_root, '/');
-   base = (base && base[1]) ? base + 1 : abs_root;
+ * /v1/index/ingest in size-bounded batches, blocking on each op-run. The kb
+ * code-scan upserts per project+path, so batches accumulate. Returns 0 on
+ * success, nonzero if any batch failed. */
 
+/* Keep each ingest POST comfortably under the server's 4 MB request-body cap
+ * (SHTTP_MAX_BODY); a single file is capped well below this by code_collect. */
+#define CLI_INGEST_BATCH_BYTES (3 * 1024 * 1024)
+
+/* POST one batch of files (adopted/freed) as project `name`/`root`, polling the
+ * async op-run to completion. Returns 0 on success. */
+static int cli_ws_ingest_batch(const char *remote, const char *bearer, const char *name,
+                               const char *root, cJSON *batch)
+{
    cJSON *body = cJSON_CreateObject();
    if (!body)
+   {
+      cJSON_Delete(batch);
       return 1;
-   cJSON_AddStringToObject(body, "name", base);
-   cJSON_AddStringToObject(body, "root", abs_root);
-   cJSON *files = cJSON_AddArrayToObject(body, "files");
-   int n = files ? code_collect_files(abs_root, files) : 0;
-
+   }
+   cJSON_AddStringToObject(body, "name", name);
+   cJSON_AddStringToObject(body, "root", root);
+   cJSON_AddItemToObject(body, "files", batch); /* adopt */
    char *body_json = cJSON_PrintUnformatted(body);
    cJSON_Delete(body);
    if (!body_json)
       return 1;
 
-   /* /v1/index/ingest is async (rh_dispatch_op_async): POST + poll the run. */
    cJSON *resp = cli_v1_run_and_poll(remote, bearer, "POST", "/v1/index/ingest", body_json, 600000);
    free(body_json);
    if (!resp)
-   {
-      fprintf(stderr, "aimee: index ingest failed for %s (transport error)\n", abs_root);
       return 1;
-   }
    const char *err = cli_ws_err_message(resp);
+   int rc = err ? 1 : 0;
    if (err)
-   {
-      fprintf(stderr, "aimee: index ingest failed for %s: %s\n", abs_root, err);
-      cJSON_Delete(resp);
-      return 1;
-   }
+      fprintf(stderr, "aimee: index ingest batch failed: %s\n", err);
    cJSON_Delete(resp);
+   return rc;
+}
+
+static int cli_ws_ingest_root(const char *remote, const char *bearer, const char *abs_root)
+{
+   const char *base = strrchr(abs_root, '/');
+   base = (base && base[1]) ? base + 1 : abs_root;
+
+   cJSON *all = cJSON_CreateArray();
+   if (!all)
+      return 1;
+   int n = code_collect_files(abs_root, all);
+   if (n == 0)
+   {
+      cJSON_Delete(all);
+      printf("no indexable files found in %s\n", abs_root);
+      return 0;
+   }
+
+   /* Split into sub-cap batches: pop files off the front into a batch, flushing
+    * whenever the next file would push the batch over the byte budget. */
+   int pushed = 0, failed = 0, batches = 0;
+   cJSON *batch = cJSON_CreateArray();
+   size_t batch_bytes = 0;
+   cJSON *f = NULL;
+   while (batch && (f = cJSON_DetachItemFromArray(all, 0)) != NULL)
+   {
+      cJSON *c = cJSON_GetObjectItemCaseSensitive(f, "content");
+      cJSON *rp = cJSON_GetObjectItemCaseSensitive(f, "rel_path");
+      size_t flen = (cJSON_IsString(c) ? strlen(c->valuestring) : 0) +
+                    (cJSON_IsString(rp) ? strlen(rp->valuestring) : 0) + 64;
+      int have = cJSON_GetArraySize(batch);
+      if (have > 0 && batch_bytes + flen > CLI_INGEST_BATCH_BYTES)
+      {
+         if (cli_ws_ingest_batch(remote, bearer, base, abs_root, batch) == 0)
+            pushed += have;
+         else
+            failed += have;
+         batches++;
+         batch = cJSON_CreateArray();
+         batch_bytes = 0;
+         if (!batch)
+         {
+            cJSON_Delete(f);
+            break;
+         }
+      }
+      cJSON_AddItemToArray(batch, f); /* adopt */
+      batch_bytes += flen;
+   }
+   if (batch && cJSON_GetArraySize(batch) > 0)
+   {
+      int have = cJSON_GetArraySize(batch);
+      if (cli_ws_ingest_batch(remote, bearer, base, abs_root, batch) == 0)
+         pushed += have;
+      else
+         failed += have;
+      batches++;
+   }
+   else
+   {
+      cJSON_Delete(batch);
+   }
+   cJSON_Delete(all);
 
    if (n >= CODE_COLLECT_MAX_FILES)
-      fprintf(stderr, "aimee: note: '%s' hit the %d-file ingest cap; the rest of the tree was "
-                      "not pushed\n",
+      fprintf(stderr,
+              "aimee: note: '%s' hit the %d-file ingest cap; the rest of the tree was "
+              "not pushed\n",
               abs_root, CODE_COLLECT_MAX_FILES);
-   printf("ingested %d file(s) from %s\n", n, abs_root);
-   return 0;
+   printf("ingested %d file(s) from %s (%d batch%s)%s\n", pushed, abs_root, batches,
+          batches == 1 ? "" : "es", failed ? " — some batches failed" : "");
+   return failed ? 1 : 0;
 }
 
 int cli_workspace_add_remote(const char *path)

--- a/src/cli_tui.c
+++ b/src/cli_tui.c
@@ -1,6 +1,7 @@
 /* cli_tui.c: built-in terminal UI for aimee's default chat command */
 #include "aimee_home.h"
 #include "cli_client.h"
+#include "cli_agent_keys.h"
 #include "cli_tui.h"
 #include "aimee_client.h"
 #include "history.h"
@@ -361,7 +362,7 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "message", message);
-   cli_attach_codex_creds(req); /* codex-oauth primary auths from this host */
+   cli_session_creds_prime(req); /* client-held agent keys for this turn */
    char cwd[CLI_TUI_PATH_MAX];
    if (getcwd(cwd, sizeof(cwd)))
       cJSON_AddStringToObject(req, "cwd", cwd);

--- a/src/cli_tui.c
+++ b/src/cli_tui.c
@@ -361,6 +361,7 @@ builtin_chat_send_ex(const char *sock, const char *provider_session_id,
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "message", message);
+   cli_attach_codex_creds(req); /* codex-oauth primary auths from this host */
    char cwd[CLI_TUI_PATH_MAX];
    if (getcwd(cwd, sizeof(cwd)))
       cJSON_AddStringToObject(req, "cwd", cwd);

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -192,6 +192,7 @@ static const struct
     {"delegate.roundtable", "POST", "/v1/delegate/roundtable"},
     {"eval.run", "POST", "/v1/eval/run"},
     {"graph.sync_code", "POST", "/v1/graph/sync_code"},
+    {"index.ingest", "POST", "/v1/index/ingest"},
     {"index.scan", "POST", "/v1/index/scan"},
     {"kb.build", "POST", "/v1/kb/build"},
     {"kb.ingest", "POST", "/v1/kb/ingest"},

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -135,6 +135,7 @@ static const struct
     {"session.brief", "POST", "/v1/sessions/brief"},
     {"session.close", "POST", "/v1/sessions/close"},
     {"session.create", "POST", "/v1/sessions/create"},
+    {"session.credentials", "POST", "/v1/session/credentials"},
     {"session.get", "POST", "/v1/sessions/get"},
     {"session.presence", "GET", "/v1/sessions/presence"},
     {"skill.archive", "POST", "/v1/skills/archive"},

--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -869,6 +869,11 @@ static void ensure_claude_code_mcp(const char *settings_path)
 static void ensure_aimee_event_hook(cJSON *hooks, const char *event, const char *subcommand,
                                     const char *matcher, int *dirty)
 {
+   const char *aimee_bin = resolved_aimee_bin_path();
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "AIMEE_HOOK_CLIENT=claude %s %s", aimee_bin ? aimee_bin : "aimee",
+            subcommand);
+
    cJSON *arr = cJSON_GetObjectItemCaseSensitive(hooks, event);
    if (!cJSON_IsArray(arr))
    {
@@ -884,15 +889,21 @@ static void ensure_aimee_event_hook(cJSON *hooks, const char *event, const char 
          continue;
       for (int j = 0; j < cJSON_GetArraySize(hook_arr); j++)
       {
-         cJSON *cmd = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(hook_arr, j), "command");
-         if (cJSON_IsString(cmd) && strstr(cmd->valuestring, subcommand))
-            return; /* already installed */
+         cJSON *cmdj = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(hook_arr, j), "command");
+         if (cJSON_IsString(cmdj) && strstr(cmdj->valuestring, subcommand))
+         {
+            /* Found this aimee hook. Re-point it if its command references a
+             * different (e.g. stale or transient) binary path, so a reinstall
+             * to a new location heals the hook instead of leaving it dangling. */
+            if (strcmp(cmdj->valuestring, cmd) != 0)
+            {
+               cJSON_SetValuestring(cmdj, cmd);
+               *dirty = 1;
+            }
+            return;
+         }
       }
    }
-   const char *aimee_bin = resolved_aimee_bin_path();
-   char cmd[512];
-   snprintf(cmd, sizeof(cmd), "AIMEE_HOOK_CLIENT=claude %s %s", aimee_bin ? aimee_bin : "aimee",
-            subcommand);
    cJSON *entry = cJSON_CreateObject();
    cJSON *hook_arr = cJSON_CreateArray();
    cJSON *hook = cJSON_CreateObject();
@@ -970,7 +981,20 @@ static void ensure_claude_code_hooks(const char *settings_path)
          cJSON *cmd = cJSON_GetObjectItemCaseSensitive(h, "command");
          if (cJSON_IsString(cmd) && (strstr(cmd->valuestring, "aimee hooks post") ||
                                      strstr(cmd->valuestring, "aimee-client hooks post")))
+         {
             found_aimee = 1;
+            /* Re-point a stale/transient binary path to the resolved one, so a
+             * reinstall heals this hook (mirrors ensure_aimee_event_hook). */
+            const char *bin = resolved_aimee_bin_path();
+            char want[512];
+            snprintf(want, sizeof(want), "AIMEE_HOOK_CLIENT=claude %s hooks post",
+                     bin ? bin : "aimee");
+            if (strcmp(cmd->valuestring, want) != 0)
+            {
+               cJSON_SetValuestring(cmd, want);
+               dirty = 1;
+            }
+         }
       }
       if (!found_aimee)
          continue;

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -1,0 +1,148 @@
+/* code_collect.c: see code_collect.h. */
+#include "platform.h" /* AIMEE_POSIX */
+#include "code_collect.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef AIMEE_POSIX
+#include <dirent.h>
+#include <sys/stat.h>
+
+static int code_ext_ok(const char *name)
+{
+   static const char *const exts[] = {".c",    ".h",   ".cc",    ".cpp",  ".cxx", ".m",    ".py",
+                                      ".go",   ".rs",  ".ts",    ".tsx",  ".js",  ".jsx",  ".md",
+                                      ".yaml", ".yml", ".toml",  ".json", ".sh",  ".bash", ".rb",
+                                      ".java", ".kt",  ".swift", NULL};
+   const char *dot = strrchr(name, '.');
+   if (!dot || dot == name)
+      return 0;
+   for (int i = 0; exts[i]; i++)
+      if (strcmp(dot, exts[i]) == 0)
+         return 1;
+   return 0;
+}
+
+static int code_dir_skip(const char *name)
+{
+   static const char *const skip[] = {"node_modules", "__pycache__", "vendor", "target",
+                                      "build",        "dist",        "out",    NULL};
+   if (name[0] == '.') /* .git, .aimee, .cache, .svn, hidden dirs */
+      return 1;
+   for (int i = 0; skip[i]; i++)
+      if (strcmp(name, skip[i]) == 0)
+         return 1;
+   return 0;
+}
+
+/* Walk root/rel recursively, appending {"rel_path","content"} entries to
+ * files_arr. Stops at CODE_COLLECT_MAX_FILES. */
+static void code_collect_walk(const char *root, const char *rel, cJSON *files_arr, int *count)
+{
+   char path[4096];
+   if (rel && rel[0])
+      snprintf(path, sizeof(path), "%s/%s", root, rel);
+   else
+      snprintf(path, sizeof(path), "%s", root);
+
+   DIR *dir = opendir(path);
+   if (!dir)
+      return;
+
+   struct dirent *ent;
+   while (*count < CODE_COLLECT_MAX_FILES && (ent = readdir(dir)) != NULL)
+   {
+      if (ent->d_name[0] == '.' &&
+          (ent->d_name[1] == '\0' || (ent->d_name[1] == '.' && ent->d_name[2] == '\0')))
+         continue; /* skip . and .. */
+
+      char full[4096];
+      snprintf(full, sizeof(full), "%s/%s", path, ent->d_name);
+
+      struct stat st;
+      if (stat(full, &st) != 0)
+         continue;
+
+      char rel_child[4096];
+      if (rel && rel[0])
+         snprintf(rel_child, sizeof(rel_child), "%s/%s", rel, ent->d_name);
+      else
+         snprintf(rel_child, sizeof(rel_child), "%s", ent->d_name);
+
+      if (S_ISDIR(st.st_mode))
+      {
+         if (!code_dir_skip(ent->d_name))
+            code_collect_walk(root, rel_child, files_arr, count);
+      }
+      else if (S_ISREG(st.st_mode))
+      {
+         if (!code_ext_ok(ent->d_name))
+            continue;
+         if (st.st_size <= 0 || st.st_size > CODE_COLLECT_MAX_FILE_BYTES)
+            continue;
+
+         FILE *fp = fopen(full, "rb");
+         if (!fp)
+            continue;
+         size_t sz = (size_t)st.st_size;
+         char *buf = malloc(sz + 1);
+         if (!buf)
+         {
+            fclose(fp);
+            continue;
+         }
+         size_t got = fread(buf, 1, sz, fp);
+         fclose(fp);
+         if (got != sz)
+         {
+            free(buf);
+            continue;
+         }
+         buf[sz] = '\0';
+
+         /* Skip binary files by scanning for null bytes. */
+         int binary = 0;
+         for (size_t i = 0; i < sz && !binary; i++)
+            if ((unsigned char)buf[i] == '\0')
+               binary = 1;
+         if (binary)
+         {
+            free(buf);
+            continue;
+         }
+
+         cJSON *entry = cJSON_CreateObject();
+         if (entry)
+         {
+            cJSON_AddStringToObject(entry, "rel_path", rel_child);
+            cJSON_AddStringToObject(entry, "content", buf);
+            cJSON_AddItemToArray(files_arr, entry);
+            (*count)++;
+         }
+         free(buf);
+      }
+   }
+   closedir(dir);
+}
+
+int code_collect_files(const char *root, cJSON *files_arr)
+{
+   if (!root || !root[0] || !files_arr)
+      return 0;
+   int count = 0;
+   code_collect_walk(root, NULL, files_arr, &count);
+   return count;
+}
+
+#else /* !AIMEE_POSIX */
+
+int code_collect_files(const char *root, cJSON *files_arr)
+{
+   (void)root;
+   (void)files_arr;
+   return 0;
+}
+
+#endif /* AIMEE_POSIX */

--- a/src/codex_auth.c
+++ b/src/codex_auth.c
@@ -1,0 +1,86 @@
+/* codex_auth.c: see codex_auth.h. */
+#include "codex_auth.h"
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Read a small JSON file into a heap buffer (caller frees). NULL on error or if
+ * larger than 1 MB (auth.json is a few KB). */
+static char *codex_read_file(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long sz = ftell(f);
+   if (fseek(f, 0, SEEK_SET) != 0 || sz <= 0 || sz > (1 << 20))
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = (char *)malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t got = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   buf[got] = '\0';
+   return buf;
+}
+
+int codex_local_auth(char *token, size_t token_len, char *account_id, size_t account_id_len)
+{
+   if (token && token_len)
+      token[0] = '\0';
+   if (account_id && account_id_len)
+      account_id[0] = '\0';
+
+   const char *home = getenv("HOME");
+   if (!home || !home[0])
+      return -1;
+
+   char path[1024];
+   snprintf(path, sizeof(path), "%s/.codex/auth.json", home);
+   char *buf = codex_read_file(path);
+   if (!buf)
+      return -1;
+
+   cJSON *root = cJSON_Parse(buf);
+   free(buf);
+   if (!root)
+      return -1;
+
+   /* tokens.{access_token,account_id} is the OAuth (chatgpt) shape; the
+    * top-level keys are the fallback (matches agent_read_codex_oauth_token). */
+   cJSON *access = cJSON_GetObjectItemCaseSensitive(root, "access_token");
+   cJSON *acct = cJSON_GetObjectItemCaseSensitive(root, "account_id");
+   cJSON *tokens = cJSON_GetObjectItemCaseSensitive(root, "tokens");
+   if (cJSON_IsObject(tokens))
+   {
+      if (!cJSON_IsString(access))
+         access = cJSON_GetObjectItemCaseSensitive(tokens, "access_token");
+      if (!cJSON_IsString(acct))
+         acct = cJSON_GetObjectItemCaseSensitive(tokens, "account_id");
+   }
+
+   int ok = 0;
+   if (cJSON_IsString(access) && access->valuestring[0])
+   {
+      if (token && token_len)
+         snprintf(token, token_len, "%s", access->valuestring);
+      ok = 1;
+   }
+   if (cJSON_IsString(acct) && acct->valuestring[0] && account_id && account_id_len)
+      snprintf(account_id, account_id_len, "%s", acct->valuestring);
+
+   cJSON_Delete(root);
+   return ok ? 0 : -1;
+}

--- a/src/config_server_api.c
+++ b/src/config_server_api.c
@@ -7,49 +7,68 @@
 #include "config.h"
 #include "server.h" /* SERVER_REMOTE_WRITES_* */
 #include "cJSON.h"
+#include <stdlib.h>
 #include <string.h>
 
 void config_parse_server_api(config_t *cfg, const cJSON *root)
 {
-   if (!cfg || !root)
-      return;
-   const cJSON *aimee = cJSON_GetObjectItemCaseSensitive(root, "aimee");
-   if (!cJSON_IsObject(aimee))
-      return;
-   const cJSON *api = cJSON_GetObjectItemCaseSensitive(aimee, "api");
-   if (!cJSON_IsObject(api))
+   if (!cfg)
       return;
 
-   const cJSON *item = cJSON_GetObjectItemCaseSensitive(api, "http_port");
-   if (cJSON_IsNumber(item))
-      cfg->server_api_http_port = (int)item->valuedouble;
-
-   item = cJSON_GetObjectItemCaseSensitive(api, "bearer_token");
-   if (cJSON_IsString(item) && item->valuestring)
-      strncpy(cfg->server_api_bearer_token, item->valuestring,
-              sizeof(cfg->server_api_bearer_token) - 1);
-
-   item = cJSON_GetObjectItemCaseSensitive(api, "rate_limit_per_min");
-   if (cJSON_IsNumber(item))
-      cfg->server_api_rate_limit_per_min = (int)item->valuedouble;
-
-   item = cJSON_GetObjectItemCaseSensitive(api, "max_event_streams");
-   if (cJSON_IsNumber(item) && item->valuedouble > 0)
-      cfg->server_api_max_event_streams = (int)item->valuedouble;
-
-   item = cJSON_GetObjectItemCaseSensitive(api, "remote_writes");
-   if (cJSON_IsString(item) && item->valuestring)
+   if (root)
    {
-      if (strcmp(item->valuestring, "full") == 0)
-         cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_FULL;
-      else if (strcmp(item->valuestring, "data") == 0)
-         cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_DATA;
-      else
-         cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_OFF;
+      const cJSON *aimee = cJSON_GetObjectItemCaseSensitive(root, "aimee");
+      const cJSON *api =
+          cJSON_IsObject(aimee) ? cJSON_GetObjectItemCaseSensitive(aimee, "api") : NULL;
+      if (cJSON_IsObject(api))
+      {
+         const cJSON *item = cJSON_GetObjectItemCaseSensitive(api, "http_port");
+         if (cJSON_IsNumber(item))
+            cfg->server_api_http_port = (int)item->valuedouble;
+
+         item = cJSON_GetObjectItemCaseSensitive(api, "bearer_token");
+         if (cJSON_IsString(item) && item->valuestring)
+            strncpy(cfg->server_api_bearer_token, item->valuestring,
+                    sizeof(cfg->server_api_bearer_token) - 1);
+
+         item = cJSON_GetObjectItemCaseSensitive(api, "rate_limit_per_min");
+         if (cJSON_IsNumber(item))
+            cfg->server_api_rate_limit_per_min = (int)item->valuedouble;
+
+         item = cJSON_GetObjectItemCaseSensitive(api, "max_event_streams");
+         if (cJSON_IsNumber(item) && item->valuedouble > 0)
+            cfg->server_api_max_event_streams = (int)item->valuedouble;
+
+         item = cJSON_GetObjectItemCaseSensitive(api, "remote_writes");
+         if (cJSON_IsString(item) && item->valuestring)
+         {
+            if (strcmp(item->valuestring, "full") == 0)
+               cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_FULL;
+            else if (strcmp(item->valuestring, "data") == 0)
+               cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_DATA;
+            else
+               cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_OFF;
+         }
+
+         item = cJSON_GetObjectItemCaseSensitive(api, "client_transport");
+         if (cJSON_IsString(item) && item->valuestring)
+            strncpy(cfg->server_api_client_transport, item->valuestring,
+                    sizeof(cfg->server_api_client_transport) - 1);
+      }
    }
 
-   item = cJSON_GetObjectItemCaseSensitive(api, "client_transport");
-   if (cJSON_IsString(item) && item->valuestring)
-      strncpy(cfg->server_api_client_transport, item->valuestring,
-              sizeof(cfg->server_api_client_transport) - 1);
+   /* Env override (deploy truth, applied even when aimee.api is absent or the
+    * config file is read-only / canonical-rewritten — e.g. a containerized
+    * server). AIMEE_API_REMOTE_WRITES = off|data|full lets a deploy set the TCP
+    * write posture without a writable aimee.yaml. */
+   const char *rw_env = getenv("AIMEE_API_REMOTE_WRITES");
+   if (rw_env && rw_env[0])
+   {
+      if (strcmp(rw_env, "full") == 0)
+         cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_FULL;
+      else if (strcmp(rw_env, "data") == 0)
+         cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_DATA;
+      else if (strcmp(rw_env, "off") == 0)
+         cfg->server_api_remote_writes = SERVER_REMOTE_WRITES_OFF;
+   }
 }

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -32,4 +32,12 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len);
 int agent_has_resolvable_credentials(const agent_t *agent);
 void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len);
 
+/* Per-turn Codex OAuth creds supplied by the thin client (its ~/.codex/auth.json
+ * is the live, refreshed source; the server has no such file). Set at the start
+ * of a chat/delegate turn and cleared at the end. When set, agent_resolve_auth
+ * uses `token` for a codex-oauth agent in preference to the server's file, and
+ * agent_build_extra_headers injects ChatGPT-Account-ID from `account_id`. Pass
+ * NULL/empty to clear. Thread-local (each turn runs on its own worker thread). */
+void agent_set_request_codex_creds(const char *token, const char *account_id);
+
 #endif /* DEC_AGENT_CONFIG_H */

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -40,4 +40,11 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len);
  * NULL/empty to clear. Thread-local (each turn runs on its own worker thread). */
 void agent_set_request_codex_creds(const char *token, const char *account_id);
 
+/* Per-turn session id for the session-scoped credential keyring lookup (see
+ * session_credentials.h). Set at the start of a chat/delegate turn from the
+ * request, cleared (NULL/empty) otherwise. When set, agent_resolve_auth prefers
+ * a client-pushed session key for the agent over the server-stored api_key/env.
+ * Thread-local. */
+void agent_set_request_session(const char *session_id);
+
 #endif /* DEC_AGENT_CONFIG_H */

--- a/src/headers/cli_agent_keys.h
+++ b/src/headers/cli_agent_keys.h
@@ -1,0 +1,37 @@
+/* cli_agent_keys.h: thin-client local agent credential store + session push.
+ *
+ * Agent API keys live HERE, on the client machine (~/.config/aimee/
+ * agent-keys.json), not on aimee-server. The client pushes them once per
+ * "credential session" to the server's RAM-only keyring (POST
+ * /v1/session/credentials); the server never persists them. Each chat/delegate
+ * request carries a `cred_session_id` so the server resolves the right keyring
+ * entry, decoupled from the functional chat session id.
+ */
+#ifndef CLI_AGENT_KEYS_H
+#define CLI_AGENT_KEYS_H
+
+#include "cJSON.h"
+#include <stddef.h>
+
+/* Store/replace (NULL/empty removes) an agent's API key in the local keyring
+ * (~/.config/aimee/agent-keys.json, mode 0600). Returns 0 on success. */
+int cli_agent_key_set(const char *agent_name, const char *api_key);
+
+/* For `aimee agent add <name> ... --key <K>` against a remote server: store K in
+ * the LOCAL keyring (keyed by <name> = argv[1]) and strip `--key <K>` from argv
+ * in place (decrementing *argc) so the key is never forwarded to / stored on the
+ * server. argv[0] is "add". Returns 1 if a key was localized, 0 otherwise. */
+int cli_agent_add_localize_key(int *argc, char **argv);
+
+/* Stable per-client credential-session id (generated once into
+ * ~/.config/aimee/cred-session.id, then reused). Fills `out`; returns 0. */
+int cli_cred_session_id(char *out, size_t out_len);
+
+/* Prime a chat/delegate request for client-held credentials when talking to a
+ * remote tcp server: stamp `cred_session_id` on `req`, and (deduped, ~once per
+ * session) push the local keyring + Codex creds to /v1/session/credentials so
+ * the server can authenticate the agents without storing any key. No-op for a
+ * co-located/unset endpoint. */
+void cli_session_creds_prime(cJSON *req);
+
+#endif /* CLI_AGENT_KEYS_H */

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -58,9 +58,11 @@ int attn_weight_for(attn_op_t op);
 
 /* `aimee attention-guard` PreToolUse-hook entry. Reads the host hook JSON from
  * stdin, updates the per-session attention log, and returns the hook exit code
- * (2 = block a hard-destructive op on a high-attention file, or block a raw
- * recursive scan when ingress_max_raw_scans is exhausted; 0 = allow). Never
- * blocks on read/soft ops. Set AIMEE_GUARD=0 to bypass. */
+ * (2 = block a hard-destructive op on a high-attention file, or — only when a
+ * positive ingress_max_raw_scans cap is configured — block a raw recursive scan
+ * once that per-session cap is exhausted; 0 = allow). With no cap configured
+ * (the default) raw scans are never blocked. Never blocks on read/soft ops. Set
+ * AIMEE_GUARD=0 to bypass. */
 int handle_attention_guard(void);
 
 #endif /* DEC_CLI_ATTENTION_GUARD_H */

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -234,6 +234,11 @@ char *cli_rpc_client_bearer(void);
 int cli_workspace_add_remote(const char *path);
 int cli_index_scan_remote(int argc, char **argv);
 
+/* Attach this machine's Codex OAuth creds (~/.codex/auth.json) to an outbound
+ * request body when talking to a remote tcp server, so the server can auth a
+ * codex-oauth agent without holding any codex credential. No-op otherwise. */
+void cli_attach_codex_creds(cJSON *req);
+
 /* Launch metadata parsed from server output */
 typedef struct
 {

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -225,6 +225,15 @@ int cli_rpc_remote_endpoint_is_tcp(void);
 char *cli_rpc_client_endpoint(void);
 char *cli_rpc_client_bearer(void);
 
+/* Thin-client workspace push: when the configured endpoint is a remote
+ * "tcp:host:port" the server cannot see this host's filesystem, so
+ * `aimee workspace add <path>` resolves the path locally, registers it as a
+ * `detached` workspace, and pushes the file contents to POST /v1/index/ingest;
+ * `aimee index scan [path]` re-pushes (all detached workspaces when no path).
+ * Return 0 on success. POSIX only (no-op error on Windows). */
+int cli_workspace_add_remote(const char *path);
+int cli_index_scan_remote(int argc, char **argv);
+
 /* Launch metadata parsed from server output */
 typedef struct
 {

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -1,0 +1,26 @@
+/* code_collect.h: shared, DB-free source-file collector.
+ *
+ * Walks a directory tree and gathers indexable, non-binary source files as
+ * {"rel_path","content"} cJSON objects — the wire shape the aimee-kb
+ * /v1/code/scan handler accepts for push-based indexing. Pure filesystem +
+ * cJSON, with no kb_client / DB dependency, so it links into BOTH the engine
+ * (server-side local scans) and the thin client (which pushes its own tree to
+ * a remote server that cannot see the client filesystem). POSIX only; a no-op
+ * returning 0 elsewhere.
+ */
+#ifndef CODE_COLLECT_H
+#define CODE_COLLECT_H
+
+#include "cJSON.h"
+
+/* Upper bounds that keep a single push request sane. */
+#define CODE_COLLECT_MAX_FILES      4096
+#define CODE_COLLECT_MAX_FILE_BYTES (256 * 1024)
+
+/* Recursively walk `root`, appending one {"rel_path","content"} object per
+ * indexable file to `files_arr`. Skips VCS/build/hidden directories and binary
+ * or oversized files. Best-effort: per-file errors are silently skipped.
+ * Returns the number of files appended (clamped at CODE_COLLECT_MAX_FILES). */
+int code_collect_files(const char *root, cJSON *files_arr);
+
+#endif /* CODE_COLLECT_H */

--- a/src/headers/codex_auth.h
+++ b/src/headers/codex_auth.h
@@ -1,0 +1,21 @@
+/* codex_auth.h: read the local Codex CLI OAuth credentials.
+ *
+ * The Codex CLI stores its ChatGPT-OAuth tokens in ~/.codex/auth.json (and
+ * refreshes them in place). For the thin-client model the engine runs on a
+ * remote server that has no such file, so the client reads the live token here
+ * and supplies it per request. Pure (file + cJSON), no DB/agent dependency, so
+ * it links into both the thin client and the server.
+ */
+#ifndef CODEX_AUTH_H
+#define CODEX_AUTH_H
+
+#include <stddef.h>
+
+/* Read this machine's Codex OAuth creds from ~/.codex/auth.json: `token` <-
+ * tokens.access_token (top-level access_token fallback), `account_id` <-
+ * tokens.account_id (top-level fallback). Either out pointer may be NULL.
+ * Returns 0 when an access token was found (account_id may be empty), -1
+ * otherwise. */
+int codex_local_auth(char *token, size_t token_len, char *account_id, size_t account_id_len);
+
+#endif /* CODEX_AUTH_H */

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -949,6 +949,16 @@ typedef struct
 int kb_client_index_scan(const char *name, const char *root, int force,
                          kb_client_index_scan_result_t *out);
 
+/* Push a set of caller-supplied source files to aimee-kb for indexing,
+ * bypassing server-side filesystem enumeration. `files_arr_v` is a cJSON array
+ * of {"rel_path","content"} objects (typed void * to keep this header
+ * cJSON-free); it is ADOPTED (freed by this call) and may be NULL to let the kb
+ * scan its own filesystem. Used by the thin-client workspace push path, where
+ * the server cannot see the client's tree. Same return contract as
+ * kb_client_index_scan. */
+int kb_client_code_scan_push(const char *name, const char *root, int force, void *files_arr_v,
+                             kb_client_index_scan_result_t *out);
+
 /* Internal: map a parsed aimee-kb response into the result struct.
  * Exposed so unit tests can pin the wire contract directly without
  * spinning up a fake socket. `resp` is a const cJSON * (typed as void *

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -46,6 +46,7 @@ typedef struct cJSON cJSON;
 #define LIMIT_TOOL     (4 * 1024 * 1024) /* 4MB for tool I/O */
 #define LIMIT_DELEGATE (4 * 1024 * 1024) /* 4MB: supports 2MB prompt-file + JSON overhead */
 #define LIMIT_CHAT     (512 * 1024)      /* 512KB for chat messages */
+#define LIMIT_INGEST   (1024 * 1024)     /* 1MB: client-pushed code files (kb req cap) */
 #define LIMIT_DEFAULT  (256 * 1024)      /* 256KB default */
 
 /* JSON framing limits */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -262,6 +262,7 @@ int handle_memory_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_memory_read(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_memory_benchmark(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_scan(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_blast_radius(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -264,6 +264,7 @@ int handle_memory_read(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_memory_benchmark(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_scan(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_session_credentials(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_blast_radius(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/headers/session_credentials.h
+++ b/src/headers/session_credentials.h
@@ -1,0 +1,42 @@
+/* session_credentials.h: in-memory, session-scoped agent credential keyring.
+ *
+ * Security posture (see the client-held-credentials design): agent/delegate API
+ * keys must NOT live long-term on aimee-server. The thin client pushes its keys
+ * once per session; the server caches them HERE — in RAM only, keyed by session
+ * id — and NEVER writes them to disk. Entries are evicted on session close or
+ * after an idle TTL, so a compromised server holds no durable secret store.
+ *
+ * All functions are thread-safe.
+ */
+#ifndef SESSION_CREDENTIALS_H
+#define SESSION_CREDENTIALS_H
+
+#include <stddef.h>
+
+/* Store/replace one agent's API key for a session. A NULL/empty key removes it.
+ * No-op if session_id or agent_name is empty. */
+void session_creds_set(const char *session_id, const char *agent_name, const char *api_key);
+
+/* Store/replace the Codex OAuth creds (access token + ChatGPT account id) for a
+ * session. NULL/empty token clears them. */
+void session_creds_set_codex(const char *session_id, const char *token, const char *account_id);
+
+/* Ingest a client-pushed JSON blob for a session:
+ *   {"agents": {"<name>": "<key>", ...},
+ *    "codex_oauth_token": "...", "codex_account_id": "..."}
+ * Returns the number of credentials stored (>=0), or -1 on a parse error. */
+int session_creds_ingest_json(const char *session_id, const char *json);
+
+/* Look up an agent's key for a session. Returns 1 and fills `out` when found,
+ * 0 otherwise. */
+int session_creds_get(const char *session_id, const char *agent_name, char *out, size_t out_len);
+
+/* Look up the session's Codex creds. Either out pointer may be NULL. Returns 1
+ * when a token was found. */
+int session_creds_get_codex(const char *session_id, char *token, size_t token_len, char *account_id,
+                            size_t account_id_len);
+
+/* Drop and zero all creds for a session (call on session close). */
+void session_creds_clear(const char *session_id);
+
+#endif /* SESSION_CREDENTIALS_H */

--- a/src/server/agent_adapter.c
+++ b/src/server/agent_adapter.c
@@ -14,7 +14,7 @@ static const agent_adapter_t g_adapters[] = {
         .provider = "chatgpt",
         .display_name = "Codex",
         .default_endpoint = "https://chatgpt.com/backend-api/codex",
-        .default_model = "gpt-5.4",
+        .default_model = "gpt-5.5",
         .auth_type = "codex-oauth",
         .capabilities = AGENT_ADAPTER_CAP_DELEGATE_TURN | AGENT_ADAPTER_CAP_PRIMARY_CONVERSATION |
                         AGENT_ADAPTER_CAP_DIRECT_HTTP | AGENT_ADAPTER_CAP_PRIMARY_SESSION,

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -2,6 +2,7 @@
 #include "aimee.h"
 #include "util.h"
 #include "agent_config.h"
+#include "session_credentials.h"
 #include "model_registry.h"
 #include "platform_path.h"
 #include "provider_cli_adapter.h"
@@ -10,6 +11,12 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+
+/* Per-turn session id, set from the request in the chat/delegate workers (setter
+ * below). Lets auth resolution + routing-availability consult the session-scoped
+ * RAM-only credential keyring the thin client pushed once per session
+ * (session_credentials.h) — so agent keys need not be stored on the server. */
+static _Thread_local char g_request_session_id[128];
 
 /* --- Config path --- */
 
@@ -203,6 +210,17 @@ int agent_has_resolvable_credentials(const agent_t *agent)
       return 1;
    if (agent->auth_cmd[0] || agent_api_key_literal(agent->api_key))
       return 1;
+   /* A client-pushed session key (or codex-oauth creds) for this turn makes the
+    * agent usable even with no server-stored key. */
+   if (g_request_session_id[0])
+   {
+      char k[MAX_API_KEY_LEN];
+      if (session_creds_get(g_request_session_id, agent->name, k, sizeof(k)))
+         return 1;
+      if (strcmp(agent->auth_type, "codex-oauth") == 0 &&
+          session_creds_get_codex(g_request_session_id, k, sizeof(k), NULL, 0))
+         return 1;
+   }
    for (int i = 0; i < agent->credential_count; i++)
    {
       const char *value = getenv(agent->credentials[i].api_key_env);
@@ -216,6 +234,14 @@ int agent_has_resolvable_credentials(const agent_t *agent)
  * Thread-local: each chat/delegate turn runs on its own worker thread. */
 static _Thread_local char g_request_codex_token[MAX_API_KEY_LEN];
 static _Thread_local char g_request_codex_account_id[128];
+
+void agent_set_request_session(const char *session_id)
+{
+   if (session_id && session_id[0])
+      snprintf(g_request_session_id, sizeof(g_request_session_id), "%s", session_id);
+   else
+      g_request_session_id[0] = '\0';
+}
 
 void agent_set_request_codex_creds(const char *token, const char *account_id)
 {
@@ -266,19 +292,28 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
          append_header_line(buf, buf_len, "X-Title: aimee");
    }
 
-   /* Codex (ChatGPT OAuth): when the thin client supplied an account id this
-    * turn and the agent's stored headers don't already carry it, inject the
-    * headers the codex backend requires. Keyed on the codex-oauth auth type so
-    * it fires regardless of the provider label (the codex adapter's provider is
-    * "chatgpt"). Lets a codex agent be configured without server-held creds. */
-   if (strcmp(agent->auth_type, "codex-oauth") == 0 && g_request_codex_account_id[0] &&
-       !strstr(buf, "ChatGPT-Account-ID:"))
+   /* Codex (ChatGPT OAuth): inject the headers the codex backend requires from
+    * the client-supplied account id (per-turn push, else the session keyring),
+    * unless the agent's stored headers already carry it. Keyed on the
+    * codex-oauth auth type so it fires regardless of the provider label (the
+    * codex adapter's provider is "chatgpt"). Lets a codex agent be configured
+    * without server-held creds. */
+   if (strcmp(agent->auth_type, "codex-oauth") == 0 && !strstr(buf, "ChatGPT-Account-ID:"))
    {
-      if (!strstr(buf, "originator:"))
-         append_header_line(buf, buf_len, "originator: codex_cli_rs");
-      char line[160];
-      snprintf(line, sizeof(line), "ChatGPT-Account-ID: %s", g_request_codex_account_id);
-      append_header_line(buf, buf_len, line);
+      char acct[128];
+      acct[0] = '\0';
+      if (g_request_codex_account_id[0])
+         snprintf(acct, sizeof(acct), "%s", g_request_codex_account_id);
+      else if (g_request_session_id[0])
+         session_creds_get_codex(g_request_session_id, NULL, 0, acct, sizeof(acct));
+      if (acct[0])
+      {
+         if (!strstr(buf, "originator:"))
+            append_header_line(buf, buf_len, "originator: codex_cli_rs");
+         char line[160];
+         snprintf(line, sizeof(line), "ChatGPT-Account-ID: %s", acct);
+         append_header_line(buf, buf_len, line);
+      }
    }
 }
 
@@ -1350,16 +1385,30 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    if (strcmp(auth_type, "none") == 0)
       return 0;
 
+   /* A client-pushed, session-scoped key for THIS agent (RAM-only keyring,
+    * session_credentials.h) takes precedence over any server-stored api_key — so
+    * agent keys need not live on the server. */
+   char session_key[MAX_API_KEY_LEN];
+   int have_session_key =
+       (g_request_session_id[0] &&
+        session_creds_get(g_request_session_id, agent->name, session_key, sizeof(session_key)));
+
    if (strcmp(auth_type, "codex-oauth") == 0)
    {
-      /* Prefer the token the thin client supplied this turn (its live,
-       * CLI-refreshed ~/.codex/auth.json); fall back to a server-side file. */
+      /* Codex OAuth token, in precedence: per-turn token (legacy direct push) >
+       * session keyring (pushed once/session) > server-side file. */
       if (g_request_codex_token[0])
       {
          snprintf(buf, buf_len, "Authorization: Bearer %s", g_request_codex_token);
          return 0;
       }
       char token[MAX_API_KEY_LEN];
+      if (g_request_session_id[0] &&
+          session_creds_get_codex(g_request_session_id, token, sizeof(token), NULL, 0))
+      {
+         snprintf(buf, buf_len, "Authorization: Bearer %s", token);
+         return 0;
+      }
       if (agent_read_codex_oauth_token(token, sizeof(token)) != 0)
          return -1;
       snprintf(buf, buf_len, "Authorization: Bearer %s", token);
@@ -1400,9 +1449,14 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
       return 0;
    }
 
-   /* x-api-key auth (Anthropic): resolve via auth_cmd or api_key */
+   /* x-api-key auth (Anthropic): resolve via session keyring, auth_cmd or api_key */
    if (strcmp(auth_type, "x-api-key") == 0)
    {
+      if (have_session_key)
+      {
+         snprintf(buf, buf_len, "x-api-key: %s", session_key);
+         return 0;
+      }
       if (agent->auth_cmd[0])
       {
          char *auth_tokens[32];
@@ -1449,6 +1503,11 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    if (strcmp(agent->provider, "gemini") == 0 &&
        (!auth_type[0] || strcmp(auth_type, "api_key") == 0))
    {
+      if (have_session_key)
+      {
+         snprintf(buf, buf_len, "x-goog-api-key: %s", session_key);
+         return 0;
+      }
       if (agent_api_key_literal(agent->api_key))
       {
          snprintf(buf, buf_len, "x-goog-api-key: %s", agent->api_key);
@@ -1462,7 +1521,12 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
       }
    }
 
-   /* Default: bearer token from api_key */
+   /* Default: bearer token — session keyring first, then stored api_key. */
+   if (have_session_key)
+   {
+      snprintf(buf, buf_len, "Authorization: Bearer %s", session_key);
+      return 0;
+   }
    if (agent_api_key_literal(agent->api_key))
    {
       snprintf(buf, buf_len, "Authorization: Bearer %s", agent->api_key);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -212,6 +212,23 @@ int agent_has_resolvable_credentials(const agent_t *agent)
    return agent_provider_env_value(agent->provider, NULL, 0);
 }
 
+/* Per-turn Codex OAuth creds supplied by the thin client (see agent_config.h).
+ * Thread-local: each chat/delegate turn runs on its own worker thread. */
+static _Thread_local char g_request_codex_token[MAX_API_KEY_LEN];
+static _Thread_local char g_request_codex_account_id[128];
+
+void agent_set_request_codex_creds(const char *token, const char *account_id)
+{
+   if (token && token[0])
+      snprintf(g_request_codex_token, sizeof(g_request_codex_token), "%s", token);
+   else
+      g_request_codex_token[0] = '\0';
+   if (account_id && account_id[0])
+      snprintf(g_request_codex_account_id, sizeof(g_request_codex_account_id), "%s", account_id);
+   else
+      g_request_codex_account_id[0] = '\0';
+}
+
 static void append_header_line(char *buf, size_t buf_len, const char *line)
 {
    if (!buf || buf_len == 0 || !line || !line[0])
@@ -247,6 +264,20 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
          append_header_line(buf, buf_len, "HTTP-Referer: https://github.com/JBailes/aimee");
       if (!strstr(buf, "X-Title:"))
          append_header_line(buf, buf_len, "X-Title: aimee");
+   }
+
+   /* Codex (ChatGPT OAuth): when the thin client supplied an account id this
+    * turn and the agent's stored headers don't already carry it, inject the
+    * headers the codex backend requires. Lets a codex agent be configured
+    * without the server holding any codex creds. */
+   if (strcmp(agent->provider, "codex") == 0 && g_request_codex_account_id[0] &&
+       !strstr(buf, "ChatGPT-Account-ID:"))
+   {
+      if (!strstr(buf, "originator:"))
+         append_header_line(buf, buf_len, "originator: codex_cli_rs");
+      char line[160];
+      snprintf(line, sizeof(line), "ChatGPT-Account-ID: %s", g_request_codex_account_id);
+      append_header_line(buf, buf_len, line);
    }
 }
 
@@ -1320,6 +1351,13 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
 
    if (strcmp(auth_type, "codex-oauth") == 0)
    {
+      /* Prefer the token the thin client supplied this turn (its live,
+       * CLI-refreshed ~/.codex/auth.json); fall back to a server-side file. */
+      if (g_request_codex_token[0])
+      {
+         snprintf(buf, buf_len, "Authorization: Bearer %s", g_request_codex_token);
+         return 0;
+      }
       char token[MAX_API_KEY_LEN];
       if (agent_read_codex_oauth_token(token, sizeof(token)) != 0)
          return -1;

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -268,9 +268,10 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
 
    /* Codex (ChatGPT OAuth): when the thin client supplied an account id this
     * turn and the agent's stored headers don't already carry it, inject the
-    * headers the codex backend requires. Lets a codex agent be configured
-    * without the server holding any codex creds. */
-   if (strcmp(agent->provider, "codex") == 0 && g_request_codex_account_id[0] &&
+    * headers the codex backend requires. Keyed on the codex-oauth auth type so
+    * it fires regardless of the provider label (the codex adapter's provider is
+    * "chatgpt"). Lets a codex agent be configured without server-held creds. */
+   if (strcmp(agent->auth_type, "codex-oauth") == 0 && g_request_codex_account_id[0] &&
        !strstr(buf, "ChatGPT-Account-ID:"))
    {
       if (!strstr(buf, "originator:"))

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -1,145 +1,18 @@
 /* kb_client_index.c: thin client wrappers for the aimee-kb /v1 code-index API */
 #include "kb_client.h"
 #include "kb_client_internal.h"
+#include "code_collect.h"
 #include "cJSON.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#ifdef AIMEE_POSIX
-#include <dirent.h>
-#include <sys/stat.h>
-#endif
 
 /* Scan timeout is generous because canonical scans of large monorepos can take
  * tens of seconds. The shared v1 helpers choose remote HTTP when configured and
  * otherwise tunnel the same /v1 route over the local UDS transport. */
 #define KB_CLIENT_INDEX_SCAN_TIMEOUT_MS (5 * 60 * 1000)
 #define KB_CLIENT_INDEX_READ_TIMEOUT_MS (5 * 1000)
-
-#ifdef AIMEE_POSIX
-/* Limits for remote push-based scan: keep request sizes sane. */
-#define KB_INDEX_PUSH_MAX_FILES      4096
-#define KB_INDEX_PUSH_MAX_FILE_BYTES (256 * 1024)
-
-static int kb_index_ext_ok(const char *name)
-{
-   static const char *const exts[] = {".c",    ".h",   ".cc",    ".cpp",  ".cxx", ".m",    ".py",
-                                      ".go",   ".rs",  ".ts",    ".tsx",  ".js",  ".jsx",  ".md",
-                                      ".yaml", ".yml", ".toml",  ".json", ".sh",  ".bash", ".rb",
-                                      ".java", ".kt",  ".swift", NULL};
-   const char *dot = strrchr(name, '.');
-   if (!dot || dot == name)
-      return 0;
-   for (int i = 0; exts[i]; i++)
-      if (strcmp(dot, exts[i]) == 0)
-         return 1;
-   return 0;
-}
-
-static int kb_index_dir_skip(const char *name)
-{
-   static const char *const skip[] = {"node_modules", "__pycache__", "vendor", "target",
-                                      "build",        "dist",        "out",    NULL};
-   if (name[0] == '.') /* .git, .aimee, .cache, .svn, hidden dirs */
-      return 1;
-   for (int i = 0; skip[i]; i++)
-      if (strcmp(name, skip[i]) == 0)
-         return 1;
-   return 0;
-}
-
-/* Walk root/rel recursively, appending {"rel_path","content"} entries to
- * files_arr.  Stops at KB_INDEX_PUSH_MAX_FILES.  Returns 0 always; errors on
- * individual files are silently skipped (best-effort collection). */
-static void kb_index_collect_files(const char *root, const char *rel, cJSON *files_arr, int *count)
-{
-   char path[4096];
-   if (rel && rel[0])
-      snprintf(path, sizeof(path), "%s/%s", root, rel);
-   else
-      snprintf(path, sizeof(path), "%s", root);
-
-   DIR *dir = opendir(path);
-   if (!dir)
-      return;
-
-   struct dirent *ent;
-   while (*count < KB_INDEX_PUSH_MAX_FILES && (ent = readdir(dir)) != NULL)
-   {
-      if (ent->d_name[0] == '.' &&
-          (ent->d_name[1] == '\0' || (ent->d_name[1] == '.' && ent->d_name[2] == '\0')))
-         continue; /* skip . and .. */
-
-      char full[4096];
-      snprintf(full, sizeof(full), "%s/%s", path, ent->d_name);
-
-      struct stat st;
-      if (stat(full, &st) != 0)
-         continue;
-
-      char rel_child[4096];
-      if (rel && rel[0])
-         snprintf(rel_child, sizeof(rel_child), "%s/%s", rel, ent->d_name);
-      else
-         snprintf(rel_child, sizeof(rel_child), "%s", ent->d_name);
-
-      if (S_ISDIR(st.st_mode))
-      {
-         if (!kb_index_dir_skip(ent->d_name))
-            kb_index_collect_files(root, rel_child, files_arr, count);
-      }
-      else if (S_ISREG(st.st_mode))
-      {
-         if (!kb_index_ext_ok(ent->d_name))
-            continue;
-         if (st.st_size <= 0 || st.st_size > KB_INDEX_PUSH_MAX_FILE_BYTES)
-            continue;
-
-         FILE *fp = fopen(full, "rb");
-         if (!fp)
-            continue;
-         size_t sz = (size_t)st.st_size;
-         char *buf = malloc(sz + 1);
-         if (!buf)
-         {
-            fclose(fp);
-            continue;
-         }
-         size_t got = fread(buf, 1, sz, fp);
-         fclose(fp);
-         if (got != sz)
-         {
-            free(buf);
-            continue;
-         }
-         buf[sz] = '\0';
-
-         /* Skip binary files by scanning for null bytes. */
-         int binary = 0;
-         for (size_t i = 0; i < sz && !binary; i++)
-            if ((unsigned char)buf[i] == '\0')
-               binary = 1;
-         if (binary)
-         {
-            free(buf);
-            continue;
-         }
-
-         cJSON *entry = cJSON_CreateObject();
-         if (entry)
-         {
-            cJSON_AddStringToObject(entry, "rel_path", rel_child);
-            cJSON_AddStringToObject(entry, "content", buf);
-            cJSON_AddItemToArray(files_arr, entry);
-            (*count)++;
-         }
-         free(buf);
-      }
-   }
-   closedir(dir);
-}
-#endif /* AIMEE_POSIX */
 
 static int kb_index_find_parse(cJSON *resp, term_hit_t *out, int max)
 {
@@ -261,11 +134,15 @@ static int kb_index_find_callers_parse(cJSON *resp, caller_hit_t *out, int max)
    return count;
 }
 
-static int kb_client_index_scan_v1(const char *name, const char *root, int force,
-                                   kb_client_index_scan_result_t *out)
+int kb_client_code_scan_push(const char *name, const char *root, int force, void *files_arr_v,
+                             kb_client_index_scan_result_t *out)
 {
+   cJSON *files_arr = (cJSON *)files_arr_v;
+
    if (!name || !name[0] || !root || !root[0])
    {
+      if (files_arr)
+         cJSON_Delete(files_arr);
       if (out)
       {
          out->skipped = 1;
@@ -278,27 +155,20 @@ static int kb_client_index_scan_v1(const char *name, const char *root, int force
 
    cJSON *req = cJSON_CreateObject();
    if (!req)
+   {
+      if (files_arr)
+         cJSON_Delete(files_arr);
       return kb_client_index_scan_apply_response(NULL, out);
+   }
    cJSON_AddStringToObject(req, "project", name);
    cJSON_AddStringToObject(req, "root_path", root);
    if (force)
       cJSON_AddBoolToObject(req, "force", 1);
-
-#ifdef AIMEE_POSIX
-   /* When aimee-kb is remote (AIMEE_KB_API_URL set), the container cannot
-    * reach the host filesystem via root_path.  Enumerate and push file
-    * contents so the handler can index without filesystem access, using the
-    * {"rel_path","content"} format the /v1/code/scan handler accepts. */
-   if (kb_client_v1_base_url())
-   {
-      cJSON *files_arr = cJSON_AddArrayToObject(req, "files");
-      if (files_arr)
-      {
-         int pushed = 0;
-         kb_index_collect_files(root, NULL, files_arr, &pushed);
-      }
-   }
-#endif
+   /* Caller-supplied {"rel_path","content"} entries (adopted) let the kb index
+    * without filesystem access — used both for a remote kb and for files the
+    * thin client pushes for a workspace the server cannot see. */
+   if (files_arr)
+      cJSON_AddItemToObject(req, "files", files_arr);
 
    char *json = kb_client_v1_post_json("/v1/code/scan", req, KB_CLIENT_INDEX_SCAN_TIMEOUT_MS, NULL);
    cJSON_Delete(req);
@@ -313,6 +183,24 @@ static int kb_client_index_scan_v1(const char *name, const char *root, int force
    if (resp)
       cJSON_Delete(resp);
    return rc;
+}
+
+static int kb_client_index_scan_v1(const char *name, const char *root, int force,
+                                   kb_client_index_scan_result_t *out)
+{
+   cJSON *files_arr = NULL;
+#ifdef AIMEE_POSIX
+   /* When aimee-kb is remote (AIMEE_KB_API_URL set), the container cannot reach
+    * the host filesystem via root_path.  Enumerate and push file contents so
+    * the handler can index without filesystem access. */
+   if (name && name[0] && root && root[0] && kb_client_v1_base_url())
+   {
+      files_arr = cJSON_CreateArray();
+      if (files_arr)
+         code_collect_files(root, files_arr);
+   }
+#endif
+   return kb_client_code_scan_push(name, root, force, files_arr, out);
 }
 
 int kb_client_index_scan(const char *name, const char *root, int force,

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1028,6 +1028,9 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"memory.read", handle_memory_read},
     {"memory.benchmark", handle_memory_benchmark},
     {"index.scan", handle_index_scan},
+    /* index.ingest reuses the scan handler: the request carries client-pushed
+     * files, which index_scan_thread relays to kb instead of scanning. */
+    {"index.ingest", handle_index_scan},
     {"index.find", handle_index_find},
     {"index.list", handle_index_list},
     {"index.blast_radius", handle_index_blast_radius},

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1028,9 +1028,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"memory.read", handle_memory_read},
     {"memory.benchmark", handle_memory_benchmark},
     {"index.scan", handle_index_scan},
-    /* index.ingest reuses the scan handler: the request carries client-pushed
-     * files, which index_scan_thread relays to kb instead of scanning. */
-    {"index.ingest", handle_index_scan},
+    {"index.ingest", handle_index_ingest},
     {"index.find", handle_index_find},
     {"index.list", handle_index_list},
     {"index.blast_radius", handle_index_blast_radius},

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1011,6 +1011,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"hooks.session_start", handle_hooks_session_start},
     {"session.create", handle_session_create},
     {"session.list", handle_session_list},
+    {"session.credentials", handle_session_credentials},
     {"session.get", handle_session_get},
     {"session.close", handle_session_close},
     {"session.brief", handle_session_brief},

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1233,7 +1233,8 @@ static size_t method_size_limit(const char *method)
       size_t max;
    } limits[] = {
        {"memory.", LIMIT_MEMORY},    {"tool.", LIMIT_TOOL}, {"delegate", LIMIT_DELEGATE},
-       {"mcp.call", LIMIT_DELEGATE}, {"chat.", LIMIT_CHAT}, {NULL, LIMIT_DEFAULT},
+       {"mcp.call", LIMIT_DELEGATE}, {"chat.", LIMIT_CHAT}, {"index.ingest", LIMIT_INGEST},
+       {NULL, LIMIT_DEFAULT},
    };
 
    for (int i = 0; limits[i].prefix; i++)

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -33,6 +33,7 @@ const method_policy_t method_registry[] = {
     {"hooks.post", CAP_TOOL_EXECUTE, "post-tool hook"},
     {"hooks.session_start", CAP_TOOL_EXECUTE, "session-start hook"},
     /* Sessions (prefix) */
+    {"session.credentials", CAP_CHAT, "push session agent credentials"},
     {"session.*", CAP_SESSION_READ, "session operation"},
     {"trajectory.export", CAP_SESSION_READ, "trajectory export"},
     {"trajectory.batch", CAP_DELEGATE, "trajectory batch generation"},

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -697,6 +697,11 @@ void delegate_worker(void *arg)
       agent_set_durable_job(cctx->background_job_id);
    }
    cJSON *req = cctx->req;
+   /* Thin-client-supplied Codex OAuth creds for this delegate turn (empty/absent
+    * clears the thread-local). Used by agent_resolve_auth/headers for a
+    * codex-oauth delegate. */
+   agent_set_request_codex_creds(jo_str(req, "codex_oauth_token", NULL),
+                                 jo_str(req, "codex_account_id", NULL));
    cJSON *jrole = cJSON_GetObjectItemCaseSensitive(req, "role");
    cJSON *jprompt = cJSON_GetObjectItemCaseSensitive(req, "prompt");
    cJSON *jmax = cJSON_GetObjectItemCaseSensitive(req, "max_tokens");

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -697,9 +697,14 @@ void delegate_worker(void *arg)
       agent_set_durable_job(cctx->background_job_id);
    }
    cJSON *req = cctx->req;
-   /* Per-turn credential context: session id (RAM session keyring) + any
-    * per-turn Codex creds (legacy direct push). Empty/absent clears them. */
-   agent_set_request_session(compute_request_session_id(req));
+   /* Per-turn credential context: credential-session id (RAM keyring; a
+    * dedicated field decoupled from the chat session id) + any per-turn Codex
+    * creds (legacy direct push). Empty/absent clears them. */
+   {
+      const char *cred_sid = jo_str(req, "cred_session_id", NULL);
+      agent_set_request_session((cred_sid && cred_sid[0]) ? cred_sid
+                                                          : compute_request_session_id(req));
+   }
    agent_set_request_codex_creds(jo_str(req, "codex_oauth_token", NULL),
                                  jo_str(req, "codex_account_id", NULL));
    cJSON *jrole = cJSON_GetObjectItemCaseSensitive(req, "role");

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -697,9 +697,9 @@ void delegate_worker(void *arg)
       agent_set_durable_job(cctx->background_job_id);
    }
    cJSON *req = cctx->req;
-   /* Thin-client-supplied Codex OAuth creds for this delegate turn (empty/absent
-    * clears the thread-local). Used by agent_resolve_auth/headers for a
-    * codex-oauth delegate. */
+   /* Per-turn credential context: session id (RAM session keyring) + any
+    * per-turn Codex creds (legacy direct push). Empty/absent clears them. */
+   agent_set_request_session(compute_request_session_id(req));
    agent_set_request_codex_creds(jo_str(req, "codex_oauth_token", NULL),
                                  jo_str(req, "codex_account_id", NULL));
    cJSON *jrole = cJSON_GetObjectItemCaseSensitive(req, "role");

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -1,7 +1,8 @@
 /* server_compute_async.c: dedicated async lanes for tool.execute and chat.send_stream */
 #include "server_compute_impl.h"
 #include "aimee.h"
-#include "json_fluent.h" /* jo_ok */
+#include "agent_config.h" /* agent_set_request_codex_creds */
+#include "json_fluent.h"  /* jo_ok, jo_str */
 #include "agent_tools.h"
 #include "compute_pool.h"
 #include "guardrails.h"
@@ -448,6 +449,11 @@ static void chat_stream_worker_pooled(void *arg)
 
    if (!locked && sid[0])
       presence_emit_turn_started(sid, turn_id);
+   /* Thin-client-supplied Codex OAuth creds for this turn (empty/absent clears
+    * the thread-local, so a non-codex turn on this pooled thread can't reuse a
+    * prior turn's token). agent_resolve_auth/headers pick them up. */
+   agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
+                                 jo_str(cctx->req, "codex_account_id", NULL));
    chat_stream_worker(arg);
    if (locked)
       presence_turn_release(lock_session, lock_turn);

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -449,11 +449,15 @@ static void chat_stream_worker_pooled(void *arg)
 
    if (!locked && sid[0])
       presence_emit_turn_started(sid, turn_id);
-   /* Per-turn credential context: the session id (for the RAM session keyring
-    * the client pushed once per session) + any per-turn Codex creds (legacy
-    * direct push). Empty/absent clears the thread-locals so a turn on this
-    * pooled thread can't reuse a prior turn's creds. */
-   agent_set_request_session(sid);
+   /* Per-turn credential context: the credential-session id (for the RAM
+    * keyring the client pushed once per session — a dedicated field decoupled
+    * from the chat session id) + any per-turn Codex creds (legacy direct push).
+    * Empty/absent clears the thread-locals so a turn on this pooled thread can't
+    * reuse a prior turn's creds. */
+   {
+      const char *cred_sid = jo_str(cctx->req, "cred_session_id", NULL);
+      agent_set_request_session((cred_sid && cred_sid[0]) ? cred_sid : sid);
+   }
    agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
                                  jo_str(cctx->req, "codex_account_id", NULL));
    chat_stream_worker(arg);

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -449,9 +449,11 @@ static void chat_stream_worker_pooled(void *arg)
 
    if (!locked && sid[0])
       presence_emit_turn_started(sid, turn_id);
-   /* Thin-client-supplied Codex OAuth creds for this turn (empty/absent clears
-    * the thread-local, so a non-codex turn on this pooled thread can't reuse a
-    * prior turn's token). agent_resolve_auth/headers pick them up. */
+   /* Per-turn credential context: the session id (for the RAM session keyring
+    * the client pushed once per session) + any per-turn Codex creds (legacy
+    * direct push). Empty/absent clears the thread-locals so a turn on this
+    * pooled thread can't reuse a prior turn's creds. */
+   agent_set_request_session(sid);
    agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
                                  jo_str(cctx->req, "codex_account_id", NULL));
    chat_stream_worker(arg);

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -969,6 +969,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/sessions/close", NULL, RM_EXACT, "session.close", 0, rh_dispatch_op},
     {"POST", "/v1/sessions/get", NULL, RM_EXACT, "session.get", 0, rh_dispatch_op},
     {"POST", "/v1/sessions/brief", NULL, RM_EXACT, "session.brief", 0, rh_dispatch_op},
+    {"POST", "/v1/session/credentials", NULL, RM_EXACT, "session.credentials", 0, rh_dispatch_op},
     {"GET", "/v1/sessions/presence", NULL, RM_EXACT, "session.presence", 0, rh_dispatch_op},
     {"POST", "/v1/toolsets/resolve", NULL, RM_EXACT, "toolset.resolve", 0, rh_dispatch_op},
     {"POST", "/v1/blast_radius/preview", NULL, RM_EXACT, "blast_radius.preview", 0, rh_dispatch_op},

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -997,6 +997,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/kb/update", NULL, RM_EXACT, "kb.update", 0, rh_dispatch_op_async},
     {"POST", "/v1/graph/sync_code", NULL, RM_EXACT, "graph.sync_code", 0, rh_dispatch_op_async},
     {"POST", "/v1/index/scan", NULL, RM_EXACT, "index.scan", 0, rh_dispatch_op_async},
+    {"POST", "/v1/index/ingest", NULL, RM_EXACT, "index.ingest", 0, rh_dispatch_op_async},
     {"POST", "/v1/memory/benchmark", NULL, RM_EXACT, "memory.benchmark", 0, rh_dispatch_op_async},
     {"POST", "/v1/curator/synthesize", NULL, RM_EXACT, "curator.synthesize", 0,
      rh_dispatch_op_async},

--- a/src/server/server_runner_endpoints.inc
+++ b/src/server/server_runner_endpoints.inc
@@ -335,3 +335,25 @@ int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON *resp = (cJSON *)kb_client_index_scan_format_response(kb_rc, &res);
    return send_and_free(conn, resp);
 }
+
+/* session.credentials: the thin client pushes its agent API keys (+ Codex OAuth
+ * creds) once per session; we cache them in the RAM-only, session-scoped keyring
+ * (session_credentials.h) and NEVER persist them. agent_resolve_auth then
+ * prefers these over any server-stored key, so agent keys need not live on the
+ * server. Body: {session_id, agents:{name:key,...}, codex_oauth_token,
+ * codex_account_id}. */
+int handle_session_credentials(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *sid = jo_str(req, "session_id", NULL);
+   if (!sid || !sid[0])
+      return server_send_error(conn, "session.credentials requires session_id", NULL);
+   char *body = cJSON_PrintUnformatted(req);
+   int n = body ? session_creds_ingest_json(sid, body) : -1;
+   free(body);
+   if (n < 0)
+      return server_send_error(conn, "session.credentials: invalid body", NULL);
+   cJSON *resp = jo_ok();
+   cJSON_AddNumberToObject(resp, "stored", n);
+   return send_and_free(conn, resp);
+}

--- a/src/server/server_runner_endpoints.inc
+++ b/src/server/server_runner_endpoints.inc
@@ -150,6 +150,20 @@ int handle_workspace_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (config_save(&cfg) != 0)
       return server_send_error(conn, "workspace: failed to save config", NULL);
 
+   /* A `detached` workspace's root lives on the client; this server cannot
+    * enumerate or read it, so we don't discover projects or kick a server-side
+    * scan (which would read this host's filesystem). Ingestion is client-driven:
+    * the thin client pushes file contents via POST /v1/index/ingest. */
+   if (is_detached)
+   {
+      cJSON *resp = jo_ok();
+      jo_add_str(resp, "path", abs);
+      jo_add_str(resp, "provider", "detached");
+      cJSON_AddArrayToObject(resp, "projects");
+      cJSON_AddNumberToObject(resp, "project_count", 0);
+      return send_and_free(conn, resp);
+   }
+
    char projects[MAX_DISCOVERED_PROJECTS][MAX_PATH_LEN];
    int count =
        workspace_discover_projects(abs, MAX_WORKSPACE_DEPTH, projects, MAX_DISCOVERED_PROJECTS);

--- a/src/server/server_runner_endpoints.inc
+++ b/src/server/server_runner_endpoints.inc
@@ -305,3 +305,33 @@ int handle_runner_respond(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return server_send_error(conn, "runner.respond: no runner registered for workspace", NULL);
    return send_and_free(conn, jo_ok());
 }
+
+/* index.ingest: a thin client pushes the {"rel_path","content"} contents of a
+ * `detached` workspace this server cannot see; relay them to aimee-kb's code
+ * scan. SYNCHRONOUS (inline kb push + send_and_free) — unlike index.scan it must
+ * not use the kb_proxy_spawn detached-thread path, because /v1/index/ingest is
+ * served by the async op-run worker via loopback_rpc (server_http.c), which runs
+ * server_dispatch on a socketpair and reads the response synchronously: a reply
+ * written later on a detached thread is lost ("rpc produced no response"). The
+ * op-run worker runs off the listener thread, so blocking here is fine. */
+int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *name = jo_str(req, "name", NULL);
+   const char *root = jo_str(req, "root", NULL);
+   if (!name || !name[0] || !root || !root[0])
+      return server_send_error(conn, "index.ingest requires both name and root", NULL);
+   if (!cJSON_IsArray(cJSON_GetObjectItemCaseSensitive(req, "files")))
+      return server_send_error(conn, "index.ingest requires a files array", NULL);
+
+   int force = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "force")) ? 1 : 0;
+   /* Detach the client-pushed array so kb_client_code_scan_push adopts (frees)
+    * it without a double-free when req is released. */
+   cJSON *files = cJSON_DetachItemFromObjectCaseSensitive(req, "files");
+
+   kb_client_index_scan_result_t res;
+   memset(&res, 0, sizeof(res));
+   int kb_rc = kb_client_code_scan_push(name, root, force, files, &res);
+   cJSON *resp = (cJSON *)kb_client_index_scan_format_response(kb_rc, &res);
+   return send_and_free(conn, resp);
+}

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -304,11 +304,7 @@ static void *index_scan_thread(void *arg)
 
    kb_client_index_scan_result_t res;
    memset(&res, 0, sizeof(res));
-   /* index.ingest carries client-pushed {"rel_path","content"} files (a detached
-    * workspace this server cannot see); relay to kb. Detached so the push frees it. */
-   cJSON *files = cJSON_DetachItemFromObjectCaseSensitive(c->req, "files");
-   int kb_rc = files ? kb_client_code_scan_push(name, root, force, files, &res)
-                     : kb_client_index_scan(name, root, force, &res);
+   int kb_rc = kb_client_index_scan(name, root, force, &res);
    cJSON *resp = (cJSON *)kb_client_index_scan_format_response(kb_rc, &res);
    if (resp)
    {

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -304,7 +304,11 @@ static void *index_scan_thread(void *arg)
 
    kb_client_index_scan_result_t res;
    memset(&res, 0, sizeof(res));
-   int kb_rc = kb_client_index_scan(name, root, force, &res);
+   /* index.ingest carries client-pushed {"rel_path","content"} files (a detached
+    * workspace this server cannot see); relay to kb. Detached so the push frees it. */
+   cJSON *files = cJSON_DetachItemFromObjectCaseSensitive(c->req, "files");
+   int kb_rc = files ? kb_client_code_scan_push(name, root, force, files, &res)
+                     : kb_client_index_scan(name, root, force, &res);
    cJSON *resp = (cJSON *)kb_client_index_scan_format_response(kb_rc, &res);
    if (resp)
    {

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -15,6 +15,7 @@
 #include "compute_pool.h"
 #include "cJSON.h"
 #include "json_fluent.h"
+#include "session_credentials.h"
 #include "dogfood.h"
 #include "commands.h"
 #include "platform_path.h"

--- a/src/server/session_credentials.c
+++ b/src/server/session_credentials.c
@@ -1,0 +1,258 @@
+/* session_credentials.c: see session_credentials.h.
+ *
+ * Fixed-size in-RAM table of sessions, each holding a small set of
+ * {agent_name -> api_key} plus optional Codex OAuth creds. Mutex-guarded.
+ * Secrets are zeroed on removal/eviction. Idle sessions past SESS_CRED_TTL_SECS
+ * are reaped lazily on access, and a full table evicts the least-recently-used
+ * session. Nothing here is ever written to disk.
+ */
+#include "session_credentials.h"
+#include "cJSON.h"
+
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#define SESS_CRED_MAX_SESSIONS 256
+#define SESS_CRED_MAX_KEYS     16
+#define SESS_CRED_NAME_LEN     64
+#define SESS_CRED_KEY_LEN      8192 /* OAuth JWTs run ~1-2 KB */
+#define SESS_CRED_ACCT_LEN     128
+#define SESS_CRED_SID_LEN      128
+#define SESS_CRED_TTL_SECS     (12 * 3600)
+
+typedef struct
+{
+   char name[SESS_CRED_NAME_LEN];
+   char key[SESS_CRED_KEY_LEN];
+} cred_entry_t;
+
+typedef struct
+{
+   char session_id[SESS_CRED_SID_LEN];
+   cred_entry_t keys[SESS_CRED_MAX_KEYS];
+   int key_count;
+   char codex_token[SESS_CRED_KEY_LEN];
+   char codex_account[SESS_CRED_ACCT_LEN];
+   long last_ts;
+   int in_use;
+} sess_creds_t;
+
+static sess_creds_t g_sessions[SESS_CRED_MAX_SESSIONS];
+static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
+
+static long sess_now(void)
+{
+   return (long)time(NULL);
+}
+
+static void sess_zero(sess_creds_t *s)
+{
+   /* Zero secrets explicitly before reuse/free. */
+   memset(s, 0, sizeof(*s));
+}
+
+/* Caller holds g_lock. Find an in-use, non-expired session by id. */
+static sess_creds_t *sess_find(const char *session_id, long now)
+{
+   for (int i = 0; i < SESS_CRED_MAX_SESSIONS; i++)
+   {
+      if (!g_sessions[i].in_use)
+         continue;
+      if (now - g_sessions[i].last_ts > SESS_CRED_TTL_SECS)
+      {
+         sess_zero(&g_sessions[i]); /* reap expired */
+         continue;
+      }
+      if (strcmp(g_sessions[i].session_id, session_id) == 0)
+         return &g_sessions[i];
+   }
+   return NULL;
+}
+
+/* Caller holds g_lock. Find-or-create a session slot (evicts LRU when full). */
+static sess_creds_t *sess_get_or_create(const char *session_id, long now)
+{
+   sess_creds_t *s = sess_find(session_id, now);
+   if (s)
+      return s;
+   sess_creds_t *lru = NULL;
+   for (int i = 0; i < SESS_CRED_MAX_SESSIONS; i++)
+   {
+      if (!g_sessions[i].in_use)
+      {
+         s = &g_sessions[i];
+         break;
+      }
+      if (!lru || g_sessions[i].last_ts < lru->last_ts)
+         lru = &g_sessions[i];
+   }
+   if (!s)
+   {
+      s = lru;
+      sess_zero(s); /* evict LRU (zeroes its secrets) */
+   }
+   snprintf(s->session_id, sizeof(s->session_id), "%s", session_id);
+   s->in_use = 1;
+   s->key_count = 0;
+   return s;
+}
+
+void session_creds_set(const char *session_id, const char *agent_name, const char *api_key)
+{
+   if (!session_id || !session_id[0] || !agent_name || !agent_name[0])
+      return;
+   pthread_mutex_lock(&g_lock);
+   long now = sess_now();
+   sess_creds_t *s = sess_get_or_create(session_id, now);
+   s->last_ts = now;
+   /* Find existing entry for this agent. */
+   cred_entry_t *e = NULL;
+   for (int i = 0; i < s->key_count; i++)
+      if (strcmp(s->keys[i].name, agent_name) == 0)
+      {
+         e = &s->keys[i];
+         break;
+      }
+   if (!api_key || !api_key[0])
+   {
+      /* Remove: zero the slot and compact. */
+      if (e)
+      {
+         int idx = (int)(e - s->keys);
+         memset(e, 0, sizeof(*e));
+         for (int j = idx; j < s->key_count - 1; j++)
+            s->keys[j] = s->keys[j + 1];
+         memset(&s->keys[s->key_count - 1], 0, sizeof(s->keys[0]));
+         s->key_count--;
+      }
+      pthread_mutex_unlock(&g_lock);
+      return;
+   }
+   if (!e)
+   {
+      if (s->key_count >= SESS_CRED_MAX_KEYS)
+      {
+         pthread_mutex_unlock(&g_lock);
+         return; /* per-session key cap reached */
+      }
+      e = &s->keys[s->key_count++];
+      snprintf(e->name, sizeof(e->name), "%s", agent_name);
+   }
+   snprintf(e->key, sizeof(e->key), "%s", api_key);
+   pthread_mutex_unlock(&g_lock);
+}
+
+void session_creds_set_codex(const char *session_id, const char *token, const char *account_id)
+{
+   if (!session_id || !session_id[0])
+      return;
+   pthread_mutex_lock(&g_lock);
+   long now = sess_now();
+   sess_creds_t *s = sess_get_or_create(session_id, now);
+   s->last_ts = now;
+   if (token && token[0])
+      snprintf(s->codex_token, sizeof(s->codex_token), "%s", token);
+   else
+      memset(s->codex_token, 0, sizeof(s->codex_token));
+   if (account_id && account_id[0])
+      snprintf(s->codex_account, sizeof(s->codex_account), "%s", account_id);
+   else
+      memset(s->codex_account, 0, sizeof(s->codex_account));
+   pthread_mutex_unlock(&g_lock);
+}
+
+int session_creds_ingest_json(const char *session_id, const char *json)
+{
+   if (!session_id || !session_id[0] || !json || !json[0])
+      return -1;
+   cJSON *root = cJSON_Parse(json);
+   if (!cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   int n = 0;
+   cJSON *agents = cJSON_GetObjectItemCaseSensitive(root, "agents");
+   if (cJSON_IsObject(agents))
+   {
+      cJSON *kv = NULL;
+      cJSON_ArrayForEach(kv, agents)
+      {
+         if (cJSON_IsString(kv) && kv->string && kv->valuestring[0])
+         {
+            session_creds_set(session_id, kv->string, kv->valuestring);
+            n++;
+         }
+      }
+   }
+   cJSON *ct = cJSON_GetObjectItemCaseSensitive(root, "codex_oauth_token");
+   cJSON *ca = cJSON_GetObjectItemCaseSensitive(root, "codex_account_id");
+   if (cJSON_IsString(ct) && ct->valuestring[0])
+   {
+      session_creds_set_codex(session_id, ct->valuestring,
+                              cJSON_IsString(ca) ? ca->valuestring : NULL);
+      n++;
+   }
+   cJSON_Delete(root);
+   return n;
+}
+
+int session_creds_get(const char *session_id, const char *agent_name, char *out, size_t out_len)
+{
+   if (!session_id || !session_id[0] || !agent_name || !agent_name[0] || !out || out_len == 0)
+      return 0;
+   int found = 0;
+   pthread_mutex_lock(&g_lock);
+   sess_creds_t *s = sess_find(session_id, sess_now());
+   if (s)
+   {
+      s->last_ts = sess_now();
+      for (int i = 0; i < s->key_count; i++)
+         if (strcmp(s->keys[i].name, agent_name) == 0 && s->keys[i].key[0])
+         {
+            snprintf(out, out_len, "%s", s->keys[i].key);
+            found = 1;
+            break;
+         }
+   }
+   pthread_mutex_unlock(&g_lock);
+   return found;
+}
+
+int session_creds_get_codex(const char *session_id, char *token, size_t token_len, char *account_id,
+                            size_t account_id_len)
+{
+   if (token && token_len)
+      token[0] = '\0';
+   if (account_id && account_id_len)
+      account_id[0] = '\0';
+   if (!session_id || !session_id[0])
+      return 0;
+   int found = 0;
+   pthread_mutex_lock(&g_lock);
+   sess_creds_t *s = sess_find(session_id, sess_now());
+   if (s && s->codex_token[0])
+   {
+      s->last_ts = sess_now();
+      if (token && token_len)
+         snprintf(token, token_len, "%s", s->codex_token);
+      if (account_id && account_id_len)
+         snprintf(account_id, account_id_len, "%s", s->codex_account);
+      found = 1;
+   }
+   pthread_mutex_unlock(&g_lock);
+   return found;
+}
+
+void session_creds_clear(const char *session_id)
+{
+   if (!session_id || !session_id[0])
+      return;
+   pthread_mutex_lock(&g_lock);
+   sess_creds_t *s = sess_find(session_id, sess_now());
+   if (s)
+      sess_zero(s);
+   pthread_mutex_unlock(&g_lock);
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -21,7 +21,7 @@ TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/main
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
-                             $(OBJDIR)/server/agent_config.o $(OBJDIR)/server/agent_adapter.o $(OBJDIR)/cmd_describe.o \
+                             $(OBJDIR)/server/agent_config.o $(OBJDIR)/server/session_credentials.o $(OBJDIR)/server/agent_adapter.o $(OBJDIR)/cmd_describe.o \
                              $(OBJDIR)/posix/cmd_describe.o \
                              $(OBJDIR)/server/agent_runtime.o $(OBJDIR)/server/skill_review.o $(OBJDIR)/server/skill_curator.o $(OBJDIR)/server/agent_context_budget.o $(OBJDIR)/prompts.o $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o $(OBJDIR)/server/cli_acp.o $(OBJDIR)/conversation_context.o $(OBJDIR)/server/provider_catalog.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/agent_request_shaping.o $(OBJDIR)/server/agent_policy.o $(OBJDIR)/server/model_sampling.o \
                              $(OBJDIR)/server/agent_tasks.o $(OBJDIR)/server/agent_eval.o $(OBJDIR)/server/agent_eval_memory_support.o $(OBJDIR)/server/agent_eval_baseline.o \
@@ -78,7 +78,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-session-credentials $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -547,6 +547,10 @@ $(TESTPREFIX)/unit-test-ingress-preinject: $(OBJDIR)/tests/test_ingress_preinjec
 
 $(TESTPREFIX)/unit-test-codex-auth: $(OBJDIR)/tests/test_codex_auth.o \
                      $(OBJDIR)/codex_auth.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-session-credentials: $(OBJDIR)/tests/test_session_credentials.o \
+                     $(OBJDIR)/server/session_credentials.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-attention-guard: $(OBJDIR)/tests/test_attention_guard.o \
@@ -1715,7 +1719,7 @@ $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
                            $(OBJDIR)/server/openai_shape.o \
                            $(OBJDIR)/server/openai_runs_store.o $(OBJDIR)/server/server_auth.o \
                            $(OBJDIR)/server/compute_pool.o \
-                           $(OBJDIR)/server/agent_config.o \
+                           $(OBJDIR)/server/agent_config.o $(OBJDIR)/server/session_credentials.o \
                            $(OBJDIR)/persona.o $(OBJDIR)/prompts.o \
                            $(OBJDIR)/role_templates.o \
                            $(OBJDIR)/dstr.o $(OBJDIR)/working_profile.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -26,7 +26,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/agent_runtime.o $(OBJDIR)/server/skill_review.o $(OBJDIR)/server/skill_curator.o $(OBJDIR)/server/agent_context_budget.o $(OBJDIR)/prompts.o $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o $(OBJDIR)/server/cli_acp.o $(OBJDIR)/conversation_context.o $(OBJDIR)/server/provider_catalog.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/agent_request_shaping.o $(OBJDIR)/server/agent_policy.o $(OBJDIR)/server/model_sampling.o \
                              $(OBJDIR)/server/agent_tasks.o $(OBJDIR)/server/agent_eval.o $(OBJDIR)/server/agent_eval_memory_support.o $(OBJDIR)/server/agent_eval_baseline.o \
                              $(OBJDIR)/server/agent_coord.o $(OBJDIR)/server/agent_tools.o $(OBJDIR)/server/script_runner.o $(OBJDIR)/server/script_rpc.o $(OBJDIR)/toolset.o $(OBJDIR)/server/tool_args_coerce.o $(OBJDIR)/server/tool_schema_sanitizer.o \
-                             $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/tests/server/kb_client_tool_registry.o $(OBJDIR)/server/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o \
+                             $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/tests/server/kb_client_tool_registry.o $(OBJDIR)/server/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/posix/cli_main.o \
@@ -715,7 +715,7 @@ $(TESTPREFIX)/unit-test-workspace-memory: $(OBJDIR)/tests/test_workspace_memory.
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-dashboard: $(OBJDIR)/tests/test_dashboard.o \
-                          $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/plugin.o $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o \
+                          $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/plugin.o $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o \
                           $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(DB1_OBJS) \
                           $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/decision_log.o \
                           $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \
@@ -778,7 +778,7 @@ $(TESTPREFIX)/unit-test-kb-client-index: $(OBJDIR)/tests/test_kb_client_index.o 
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-kb-client-index-remote: $(OBJDIR)/tests/test_kb_client_index_remote.o \
-	                                 $(OBJDIR)/server/kb_client_index.o \
+	                                 $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                 $(OBJDIR)/server/kb_client_index_parse.o \
 	                                 $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -792,7 +792,7 @@ $(TESTPREFIX)/unit-test-kb-client-docs: $(OBJDIR)/tests/test_kb_client_docs.o \
 $(TESTPREFIX)/unit-test-kb-client-search: $(OBJDIR)/tests/test_kb_client_search.o \
 	                                  $(OBJDIR)/server/kb_client.o \
 	                                  $(OBJDIR)/server/kb_client_cache.o \
-	                                  $(OBJDIR)/server/kb_client_index.o \
+	                                  $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/server/kb_client_index_parse.o \
 	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
@@ -804,7 +804,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(OBJDIR)/server/kb_client.o \
 	                                  $(OBJDIR)/server/kb_client_cache.o \
 	                                  $(OBJDIR)/server/kb_client_memory.o \
-	                                  $(OBJDIR)/server/kb_client_index.o \
+	                                  $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/server/kb_client_index_parse.o \
 	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
@@ -1105,7 +1105,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
-                            $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+                            $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
                             $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/mcp_git_write.o \
                             $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -29,7 +29,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/tests/server/kb_client_tool_registry.o $(OBJDIR)/server/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
-                             $(OBJDIR)/posix/cli_client.o $(OBJDIR)/posix/cli_main.o \
+                             $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
 	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
@@ -78,7 +78,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -420,7 +420,8 @@ $(TESTPREFIX)/unit-test-cli-mcp-serve: $(OBJDIR)/tests/test_cli_mcp_serve.o $(OB
 # --gc-sections drops the rest of the transport, which this marshalling test
 # never calls.
 $(TESTPREFIX)/unit-test-cli-rpc-delegate: $(OBJDIR)/tests/test_cli_rpc_delegate.o \
-                                  $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o
+                                  $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o \
+                                  $(OBJDIR)/codex_auth.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-cli-server-compat: $(OBJDIR)/tests/test_cli_server_compat.o \
@@ -542,6 +543,10 @@ $(TESTPREFIX)/unit-test-text: $(OBJDIR)/tests/test_text.o $(OBJDIR)/util.o $(OBJ
 
 $(TESTPREFIX)/unit-test-ingress-preinject: $(OBJDIR)/tests/test_ingress_preinject.o \
                      $(OBJDIR)/server/ingress_preinject.o $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-codex-auth: $(OBJDIR)/tests/test_codex_auth.o \
+                     $(OBJDIR)/codex_auth.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-attention-guard: $(OBJDIR)/tests/test_attention_guard.o \
@@ -716,7 +721,7 @@ $(TESTPREFIX)/unit-test-workspace-memory: $(OBJDIR)/tests/test_workspace_memory.
 
 $(TESTPREFIX)/unit-test-dashboard: $(OBJDIR)/tests/test_dashboard.o \
                           $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/plugin.o $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o \
-                          $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(DB1_OBJS) \
+                          $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o $(DB1_OBJS) \
                           $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/decision_log.o \
                           $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \
                           $(OBJDIR)/yaml.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
@@ -794,7 +799,7 @@ $(TESTPREFIX)/unit-test-kb-client-search: $(OBJDIR)/tests/test_kb_client_search.
 	                                  $(OBJDIR)/server/kb_client_cache.o \
 	                                  $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/server/kb_client_index_parse.o \
-	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS)
@@ -806,7 +811,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(OBJDIR)/server/kb_client_memory.o \
 	                                  $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/server/kb_client_index_parse.o \
-	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS)
@@ -985,7 +990,7 @@ $(TESTPREFIX)/unit-test-gateway-telegram: $(OBJDIR)/tests/test_gateway_telegram.
                                           $(OBJDIR)/gateway/tts.o \
                                           $(OBJDIR)/delivery_target.o \
                                           $(OBJDIR)/posix/agent_bridge.o \
-                                          $(OBJDIR)/posix/cli_client.o \
+                                          $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
                                           $(OBJDIR)/proxy_bootstrap.o \
                                           $(OBJDIR)/cJSON.o \
                                           $(OBJDIR)/log.o \
@@ -1009,7 +1014,7 @@ $(TESTPREFIX)/unit-test-gateway-ntfy-webhook: $(OBJDIR)/tests/test_gateway_ntfy_
                                               $(OBJDIR)/gateway/tts.o \
                                               $(OBJDIR)/delivery_target.o \
                                               $(OBJDIR)/posix/agent_bridge.o \
-                                              $(OBJDIR)/posix/cli_client.o \
+                                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
                                               $(OBJDIR)/proxy_bootstrap.o \
                                               $(OBJDIR)/cJSON.o \
                                               $(OBJDIR)/log.o \
@@ -1076,7 +1081,7 @@ $(TESTPREFIX)/unit-test-openai-runs-store: $(OBJDIR)/tests/test_openai_runs_stor
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-http-transport: $(OBJDIR)/tests/test_cli_http_transport.o \
-                                            $(OBJDIR)/posix/cli_client.o \
+                                            $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
                                             $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1105,7 +1110,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
-                            $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o \
+                            $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
                             $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/mcp_git_write.o \
                             $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -402,6 +402,31 @@ static void test_provider_env_credentials_and_headers(void)
                old_gemini_mechanism[0] ? old_gemini_mechanism : NULL);
 }
 
+/* A thin-client-supplied per-turn Codex OAuth token takes precedence over any
+ * server-side file, and the account id is injected as the ChatGPT-Account-ID
+ * header; clearing removes both. */
+static void test_codex_oauth_request_creds(void)
+{
+   agent_t ag;
+   char auth[512];
+   char headers[512];
+   memset(&ag, 0, sizeof(ag));
+   snprintf(ag.provider, sizeof(ag.provider), "%s", "codex");
+   snprintf(ag.auth_type, sizeof(ag.auth_type), "%s", "codex-oauth");
+
+   agent_set_request_codex_creds("REQ-TOKEN", "acct-1");
+   assert(agent_resolve_auth(&ag, auth, sizeof(auth)) == 0);
+   assert(strcmp(auth, "Authorization: Bearer REQ-TOKEN") == 0);
+   agent_build_extra_headers(&ag, headers, sizeof(headers));
+   assert(strstr(headers, "ChatGPT-Account-ID: acct-1") != NULL);
+   assert(strstr(headers, "originator: codex_cli_rs") != NULL);
+
+   /* Clearing the per-turn creds removes the token path + header injection. */
+   agent_set_request_codex_creds(NULL, NULL);
+   agent_build_extra_headers(&ag, headers, sizeof(headers));
+   assert(strstr(headers, "ChatGPT-Account-ID:") == NULL);
+}
+
 static void test_agent_config_provider_cli_roundtrip(void)
 {
    const char *cfg_dir = config_default_dir();
@@ -1855,6 +1880,7 @@ int main(void)
    test_current_code_only_role_tool_policy();
    test_current_code_only_dispatch_blocks_stale_context_tools();
    test_provider_env_credentials_and_headers();
+   test_codex_oauth_request_creds();
    test_agent_config_provider_cli_roundtrip();
    test_agent_adapter_registry();
    test_provider_cli_shell_exec_uses_argv_not_shell();

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -1,27 +1,46 @@
 /* test_attention_guard.c: unit tests for the P3 attention-guard pure helpers
- * (scoring with recency decay, op classification, kind weights). The stateful
- * hook handler (handle_attention_guard) is exercised by a scripted functional
- * smoke, not here; stubs satisfy the linker for its unused dependencies. */
+ * (scoring with recency decay, op classification, kind weights) plus a
+ * functional test of the hook handler's raw-scan enforcement (inert by default,
+ * blocking only at a positive ingress_max_raw_scans cap). */
 #include <assert.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #include "cli_attention_guard.h"
 
-/* Stubs for handle_attention_guard's deps (it is not called here). */
+/* Stubs/fakes for handle_attention_guard's deps. read_stdin + aimee_home are
+ * driven by the functional test below via these globals. */
+static const char *g_stdin_json = NULL;
+static char g_home[256] = "/tmp";
+
 char *read_stdin(void)
 {
-   return NULL;
+   return g_stdin_json ? strdup(g_stdin_json) : NULL;
 }
 const char *aimee_home(void)
 {
-   return "/tmp";
+   return g_home;
 }
 int platform_mkdir_p(const char *path, int mode)
 {
-   (void)path;
-   (void)mode;
+   /* Real recursive mkdir so the handler can persist its per-session raw-scan
+    * log (the cap test depends on that count surviving across invocations). */
+   char buf[512];
+   snprintf(buf, sizeof(buf), "%s", path);
+   for (char *p = buf + 1; *p; p++)
+   {
+      if (*p == '/')
+      {
+         *p = '\0';
+         mkdir(buf, (mode_t)mode);
+         *p = '/';
+      }
+   }
+   mkdir(buf, (mode_t)mode);
    return 0;
 }
 
@@ -85,12 +104,75 @@ static void test_score(void)
    printf("score OK\n");
 }
 
+/* Hook input for a recursive raw scan (the Bash `grep -r` form). */
+#define RAW_SCAN_HOOK                                                                              \
+   "{\"session_id\":\"agtest\",\"tool_name\":\"Bash\","                                            \
+   "\"tool_input\":{\"command\":\"grep -r TODO src\"}}"
+
+static void write_config(const char *body)
+{
+   char path[320];
+   snprintf(path, sizeof(path), "%s/aimee.yaml", g_home);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   if (body)
+      fputs(body, f);
+   fclose(f);
+}
+
+static void rm_path(const char *p)
+{
+   remove(p);
+}
+
+/* Functional test of the raw-scan enforcement: inert unless a positive
+ * ingress_max_raw_scans cap is configured. */
+static void test_guard_enforcement(void)
+{
+   /* Isolated, real temp home so config + the session log persist. */
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee_ag_test_%d", (int)getpid());
+   mkdir(g_home, 0700);
+   char logpath[400], cfgpath[400];
+   snprintf(logpath, sizeof(logpath), "%s/.cache/attention/agtest.json", g_home);
+   snprintf(cfgpath, sizeof(cfgpath), "%s/aimee.yaml", g_home);
+   g_stdin_json = RAW_SCAN_HOOK;
+
+   /* (1) Inert default: no aimee.yaml at all -> raw scans allowed (exit 0). */
+   rm_path(cfgpath);
+   rm_path(logpath);
+   assert(handle_attention_guard() == 0);
+   assert(handle_attention_guard() == 0); /* still allowed, repeatedly */
+
+   /* (2) Explicit 0 is also disabled. */
+   write_config("ingress_max_raw_scans: 0\n");
+   rm_path(logpath);
+   assert(handle_attention_guard() == 0);
+
+   /* (3) Positive cap of 2: first two scans allowed, the third is blocked. */
+   write_config("ingress_max_raw_scans: 2\n");
+   rm_path(logpath);
+   assert(handle_attention_guard() == 0); /* used 0 -> allow, count 1 */
+   assert(handle_attention_guard() == 0); /* used 1 -> allow, count 2 */
+   assert(handle_attention_guard() == 2); /* used 2 >= cap -> block */
+
+   /* (4) AIMEE_GUARD=0 bypasses even with a cap hit. */
+   setenv("AIMEE_GUARD", "0", 1);
+   assert(handle_attention_guard() == 0);
+   unsetenv("AIMEE_GUARD");
+
+   rm_path(logpath);
+   rm_path(cfgpath);
+   g_stdin_json = NULL;
+   printf("enforcement OK\n");
+}
+
 int main(void)
 {
    printf("attention_guard: ");
    test_classify();
    test_weight();
    test_score();
+   test_guard_enforcement();
    printf("all tests passed\n");
    return 0;
 }

--- a/src/tests/test_cli_rpc_delegate.c
+++ b/src/tests/test_cli_rpc_delegate.c
@@ -17,6 +17,13 @@
 /* Include the route implementation directly so static marshal helpers are testable. */
 #include "../cli_rpc_routes.inc"
 
+/* marshal_delegate now primes client-held creds; stub it for this pure
+ * marshalling test (cli_agent_keys.o + its HTTP deps aren't linked here). */
+void cli_session_creds_prime(cJSON *req)
+{
+   (void)req;
+}
+
 static void test_delegate_max_turns_marshaled(void)
 {
    char *argv[] = {"review",

--- a/src/tests/test_client_integrations.c
+++ b/src/tests/test_client_integrations.c
@@ -355,6 +355,69 @@ static void test_claude_hooks_patch_existing_matcher(void)
    system(cmd);
 }
 
+/* A stale aimee hook command (e.g. an old/transient binary path) is re-pointed
+ * to the resolved binary, so a reinstall heals the hook rather than leaving it
+ * dangling at a path that no longer exists. */
+static void test_claude_hooks_repoint_stale_command(void)
+{
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-test-claude-hooks3-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+
+   char settings_path[512];
+   snprintf(settings_path, sizeof(settings_path), "%s/settings.json", tmpdir);
+   FILE *fp = fopen(settings_path, "w");
+   assert(fp != NULL);
+   /* A stale PreToolUse attention-guard AND a stale PostToolUse hooks-post entry,
+    * both referencing a transient /tmp build path. */
+   fputs("{\"hooks\":{"
+         "\"PreToolUse\":[{\"matcher\":\"Bash\",\"hooks\":[{\"type\":\"command\","
+         "\"command\":\"AIMEE_HOOK_CLIENT=claude /tmp/old-build/aimee attention-guard\"}]}],"
+         "\"PostToolUse\":[{\"matcher\":\"Edit|EnterWorktree|ExitWorktree\","
+         "\"hooks\":[{\"type\":\"command\","
+         "\"command\":\"AIMEE_HOOK_CLIENT=claude /tmp/old-build/aimee hooks post\"}]}]"
+         "}}",
+         fp);
+   fclose(fp);
+
+   ensure_claude_code_hooks(settings_path);
+
+   cJSON *root = read_json_file(settings_path);
+   assert(cJSON_IsObject(root));
+   cJSON *hooks = cJSON_GetObjectItemCaseSensitive(root, "hooks");
+
+   /* Both the PreToolUse attention-guard and the PostToolUse hooks-post commands
+    * are re-pointed off the stale /tmp path to the resolved binary. */
+   const char *events[] = {"PreToolUse", "PostToolUse"};
+   const char *needles[] = {"attention-guard", "hooks post"};
+   for (int e = 0; e < 2; e++)
+   {
+      cJSON *arr = cJSON_GetObjectItemCaseSensitive(hooks, events[e]);
+      assert(cJSON_IsArray(arr));
+      const char *found = NULL;
+      for (int i = 0; i < cJSON_GetArraySize(arr); i++)
+      {
+         cJSON *hook_arr = cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(arr, i), "hooks");
+         for (int j = 0; cJSON_IsArray(hook_arr) && j < cJSON_GetArraySize(hook_arr); j++)
+         {
+            cJSON *cmd =
+                cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(hook_arr, j), "command");
+            if (cJSON_IsString(cmd) && strstr(cmd->valuestring, needles[e]))
+               found = cmd->valuestring;
+         }
+      }
+      assert(found != NULL);
+      assert(strstr(found, "/tmp/old-build/aimee") == NULL);
+      assert(strstr(found, "AIMEE_HOOK_CLIENT=claude ") == found);
+      assert(strstr(found, needles[e]) != NULL);
+   }
+   cJSON_Delete(root);
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   system(cmd);
+}
+
 /* --- Test Codex plugin config (TOML-like) non-destructive update --- */
 
 static void test_codex_plugin_enabled_fresh(void)
@@ -916,6 +979,7 @@ int main(void)
    test_claude_mcp_creates_fresh_settings();
    test_claude_hooks_create_post_hook_on_fresh_settings();
    test_claude_hooks_patch_existing_matcher();
+   test_claude_hooks_repoint_stale_command();
    test_codex_plugin_enabled_fresh();
    test_codex_plugin_enabled_preserves_existing();
    test_codex_plugin_enabled_idempotent();

--- a/src/tests/test_codex_auth.c
+++ b/src/tests/test_codex_auth.c
@@ -1,0 +1,74 @@
+/* test_codex_auth.c: codex_local_auth parses ~/.codex/auth.json (OAuth tokens.*
+ * shape + top-level fallback) from the HOME-rooted path. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include "codex_auth.h"
+
+static char g_home[256];
+
+static void set_home_with_auth(const char *json)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee_codex_test_%d", (int)getpid());
+   char dir[320];
+   snprintf(dir, sizeof(dir), "%s/.codex", g_home);
+   mkdir(g_home, 0700);
+   mkdir(dir, 0700);
+   char path[400];
+   snprintf(path, sizeof(path), "%s/auth.json", dir);
+   if (json)
+   {
+      FILE *f = fopen(path, "wb");
+      assert(f);
+      fputs(json, f);
+      fclose(f);
+   }
+   else
+   {
+      remove(path);
+   }
+   setenv("HOME", g_home, 1);
+}
+
+int main(void)
+{
+   char token[4096], account[256];
+
+   /* OAuth shape: tokens.{access_token,account_id}. */
+   set_home_with_auth("{\"auth_mode\":\"chatgpt\",\"tokens\":{\"access_token\":\"AT-123\","
+                      "\"account_id\":\"acct-xyz\",\"refresh_token\":\"r\"}}");
+   assert(codex_local_auth(token, sizeof(token), account, sizeof(account)) == 0);
+   assert(strcmp(token, "AT-123") == 0);
+   assert(strcmp(account, "acct-xyz") == 0);
+
+   /* Top-level access_token fallback; account optional. */
+   set_home_with_auth("{\"access_token\":\"TOP-456\"}");
+   assert(codex_local_auth(token, sizeof(token), account, sizeof(account)) == 0);
+   assert(strcmp(token, "TOP-456") == 0);
+   assert(account[0] == '\0');
+
+   /* Missing token -> failure, outputs cleared. */
+   set_home_with_auth("{\"tokens\":{\"account_id\":\"acct-only\"}}");
+   assert(codex_local_auth(token, sizeof(token), account, sizeof(account)) == -1);
+   assert(token[0] == '\0');
+
+   /* No file -> failure. */
+   set_home_with_auth(NULL);
+   assert(codex_local_auth(token, sizeof(token), account, sizeof(account)) == -1);
+
+   /* NULL out-pointers tolerated. */
+   set_home_with_auth("{\"tokens\":{\"access_token\":\"AT\"}}");
+   assert(codex_local_auth(NULL, 0, NULL, 0) == 0);
+
+   char cmd[400];
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", g_home);
+   if (system(cmd) != 0)
+      fprintf(stderr, "cleanup warn\n");
+
+   printf("codex_auth: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -122,6 +122,10 @@ void agent_set_request_codex_creds(const char *token, const char *account_id)
    (void)token;
    (void)account_id;
 }
+void agent_set_request_session(const char *session_id)
+{
+   (void)session_id;
+}
 
 int agent_load_config(agent_config_t *cfg)
 {

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -117,6 +117,12 @@ static void *drain_pipe_thread(void *arg)
    return NULL;
 }
 
+void agent_set_request_codex_creds(const char *token, const char *account_id)
+{
+   (void)token;
+   (void)account_id;
+}
+
 int agent_load_config(agent_config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -456,6 +456,10 @@ int handle_index_scan(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "index.scan");
 }
+int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "index.ingest");
+}
 int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "index.find");

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -460,6 +460,10 @@ int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "index.ingest");
 }
+int handle_session_credentials(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "session.credentials");
+}
 int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "index.find");

--- a/src/tests/test_session_credentials.c
+++ b/src/tests/test_session_credentials.c
@@ -1,0 +1,59 @@
+/* test_session_credentials.c: the in-RAM, session-scoped credential keyring. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "session_credentials.h"
+
+int main(void)
+{
+   char out[8192];
+   char acct[128];
+
+   /* set / get, scoped by session. */
+   session_creds_set("sess-A", "minimax", "key-aaa");
+   session_creds_set("sess-A", "mistral", "key-bbb");
+   session_creds_set("sess-B", "minimax", "key-ccc");
+   assert(session_creds_get("sess-A", "minimax", out, sizeof(out)) && strcmp(out, "key-aaa") == 0);
+   assert(session_creds_get("sess-A", "mistral", out, sizeof(out)) && strcmp(out, "key-bbb") == 0);
+   assert(session_creds_get("sess-B", "minimax", out, sizeof(out)) && strcmp(out, "key-ccc") == 0);
+   /* Cross-session / unknown agent miss. */
+   assert(session_creds_get("sess-A", "mimo", out, sizeof(out)) == 0);
+   assert(session_creds_get("sess-Z", "minimax", out, sizeof(out)) == 0);
+
+   /* Overwrite. */
+   session_creds_set("sess-A", "minimax", "key-new");
+   assert(session_creds_get("sess-A", "minimax", out, sizeof(out)) && strcmp(out, "key-new") == 0);
+
+   /* Empty/NULL key removes. */
+   session_creds_set("sess-A", "mistral", "");
+   assert(session_creds_get("sess-A", "mistral", out, sizeof(out)) == 0);
+   /* minimax still present after removing mistral. */
+   assert(session_creds_get("sess-A", "minimax", out, sizeof(out)) && strcmp(out, "key-new") == 0);
+
+   /* Codex creds. */
+   session_creds_set_codex("sess-A", "tok-123", "acct-9");
+   assert(session_creds_get_codex("sess-A", out, sizeof(out), acct, sizeof(acct)));
+   assert(strcmp(out, "tok-123") == 0 && strcmp(acct, "acct-9") == 0);
+   assert(session_creds_get_codex("sess-Z", out, sizeof(out), acct, sizeof(acct)) == 0);
+
+   /* ingest_json. */
+   int n = session_creds_ingest_json(
+       "sess-C", "{\"agents\":{\"gemini\":\"gk\",\"openai\":\"ok\"},\"codex_oauth_token\":\"ct\","
+                 "\"codex_account_id\":\"ca\"}");
+   assert(n == 3);
+   assert(session_creds_get("sess-C", "gemini", out, sizeof(out)) && strcmp(out, "gk") == 0);
+   assert(session_creds_get("sess-C", "openai", out, sizeof(out)) && strcmp(out, "ok") == 0);
+   assert(session_creds_get_codex("sess-C", out, sizeof(out), acct, sizeof(acct)) &&
+          strcmp(out, "ct") == 0 && strcmp(acct, "ca") == 0);
+   assert(session_creds_ingest_json("sess-C", "not json") == -1);
+
+   /* clear drops everything for the session. */
+   session_creds_clear("sess-A");
+   assert(session_creds_get("sess-A", "minimax", out, sizeof(out)) == 0);
+   assert(session_creds_get_codex("sess-A", out, sizeof(out), acct, sizeof(acct)) == 0);
+   /* Other sessions unaffected. */
+   assert(session_creds_get("sess-B", "minimax", out, sizeof(out)) && strcmp(out, "key-ccc") == 0);
+
+   printf("session_credentials: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

Move agent/delegate API credentials **off the server**. A central key store on aimee-server is too valuable an attack target; instead keys live on the thin-client machine and are pushed once per session into a **RAM-only**, session-scoped keyring that is **never persisted to disk**.

### Server
- `session_credentials.{c,h}` — thread-safe in-RAM keyring (`session_id -> {agent: key}` + Codex creds), LRU + idle-TTL eviction, secrets zeroed on removal, **never written to disk**.
- `POST /v1/session/credentials` (`handle_session_credentials`, CAP_CHAT) ingests a pushed `{session_id, agents{}, codex_*}` blob.
- A per-turn `cred_session_id` thread-local (set in the chat + delegate workers, decoupled from the chat session id) drives auth: `agent_resolve_auth` + `agent_has_resolvable_credentials` prefer a client-pushed session key (and Codex creds) over any server-stored `api_key`/env; `agent_build_extra_headers` sources `ChatGPT-Account-ID` from it.

### Client
- `cli_agent_keys.{c,h}` — local keyring (`~/.config/aimee/agent-keys.json`, 0600) + a stable `cred-session.id`; `cli_session_creds_prime(req)` stamps `cred_session_id` and (deduped ~once/session) POSTs the keyring + Codex creds.
- chat + delegate call it instead of attaching a per-request token.
- `aimee agent add <name> … --key K` (remote) stores K **locally** and strips `--key` before forwarding the definition — the key never reaches the server.

## Validation (live, NAS v0.0.4-wsguard)
Migrated `minimax`/`mistral`/`mimo-2.5` keys to the client keyring (re-added via the new client; codex already keyless). Then:
- Delegates `--via minimax|mistral|mimo-2.5` → **4 / Madrid / Fe**.
- Primary chat (provider minimax) with the pushed `cred_session_id` → **Berlin**.
- **Negative:** same chat with a bogus `cred_session_id` (nothing pushed) → **HTTP 401** — proving the server holds **no** key and auth works *only* via the client-pushed RAM keyring.

`make unit-tests` (incl. new `unit-test-session-credentials`) + `make lint` green.

## Notes
- Stacked on #182 and #184; rebase onto `testing` as those merge.
- Codex is migrated onto the same keyring (its per-turn token path remains as a fallback).
- Server-side keyring is RAM-only with a 12h idle TTL; a server restart drops it and the client re-pushes within ~2min (marker window).
