### PR TITLE
Fix remote /v1 index.scan + accept --provider codex alias

### DIFF
--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -81,6 +81,15 @@ flowchart TD
 
 ### Configuration
 
+> **Thin client (remote server):** API keys are held on the client, not the
+> server. `aimee agent add <name> <endpoint> <model> --key K` against a remote
+> `aimee-server` stores `K` locally (`~/.config/aimee/agent-keys.json`) and
+> strips it before forwarding the definition; the key is pushed once per session
+> to a RAM-only keyring on the server and never persisted. Codex agents take no
+> key (`--provider codex` sources the OAuth token from `~/.codex/auth.json`). You
+> configure agents per machine. See [THIN_CLIENT.md](THIN_CLIENT.md) and
+> [SECURITY.md](SECURITY.md#agent-credential-custody-thin-client).
+
 Use `aimee agent local` for local or LAN OpenAI-compatible runtimes such as
 `llama-server` and Ollama. The command is idempotent: re-running it updates the
 same delegate, probes `/v1/models`, probes llama.cpp `/slots` when available,

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -221,6 +221,34 @@ Security implications:
 - Token scope matters because overbroad tokens enlarge the blast radius of theft or misuse.
 - Server-side validation matters because local identity alone is insufficient for broader operations.
 
+## Agent Credential Custody (thin client)
+
+Third-party agent/delegate API keys (and Codex OAuth tokens) are **held on the
+client machine, not on the server**, to avoid making `aimee-server` a central
+secret store worth attacking.
+
+- **Storage of record is the client.** Keys live in the user's
+  `~/.config/aimee/agent-keys.json` (mode 0600); Codex OAuth lives in the Codex
+  CLI's `~/.codex/auth.json`. `aimee agent add … --key K` against a remote server
+  writes `K` locally and strips it before forwarding the agent definition, so the
+  key is never transmitted to or persisted by the server. The server's
+  `agents.json` holds definitions (endpoint, model, roles) only.
+- **Server caching is RAM-only and session-scoped.** The client pushes its keys
+  once per session to an in-memory keyring (`POST /v1/session/credentials`),
+  keyed by a `cred_session_id`. The keyring is never written to disk, is evicted
+  on an idle TTL / capacity (LRU), and secrets are zeroed on removal — so a
+  server restart or compromise yields no durable key store. Auth resolution
+  prefers the client-pushed session key over any legacy server-stored key/env.
+- **Trade-off.** A user configures their agents/keys on each machine they use.
+  This is intentional: it keeps the blast radius of a server compromise to
+  whatever sessions are live in RAM at that moment, not the full set of keys.
+- **Transport.** The push travels over the same authenticated `/v1` channel as
+  other requests; on a plaintext-HTTP LAN deployment it is only as confidential
+  as that network (consistent with the `remote_writes: full` trusted-network
+  posture). Use TLS / a trusted network for the server endpoint.
+
+See [THIN_CLIENT.md](THIN_CLIENT.md) for operational details.
+
 ## Explicit Non-Goals
 
 This security model does not aim to provide:

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -1,0 +1,160 @@
+# Thin Client: Workspaces, Agents & Client-Held Credentials
+
+This document describes how the `aimee` thin client works against a **remote**
+`aimee-server` (e.g. a shared server reached over `tcp:`), covering three things
+that are deliberately designed so the *client machine* — not the server — holds
+the working tree and the secrets:
+
+1. **Workspaces** are ingested *from the client* (the server never reads the
+   client's filesystem).
+2. **Agent/delegate API keys live on the client** and are pushed to a
+   **RAM-only, per-session** keyring on the server that is **never persisted to
+   disk**.
+3. The **attention guard** is inert by default.
+
+It complements [WORKSPACES.md](WORKSPACES.md), [DELEGATES.md](DELEGATES.md), and
+[SECURITY.md](SECURITY.md).
+
+## What runs where
+
+| Concern | Thin client (your machine) | aimee-server (remote) |
+| --- | --- | --- |
+| Your working tree / files | yes | no (never reads client fs) |
+| Agent API keys / Codex OAuth | stored here | cached in RAM per session, never on disk |
+| Engine, agent loop, DB1/DB2, KB | — | yes |
+| Code index, memory, chat/delegate execution | — | yes |
+
+Point the client at the server once:
+
+```sh
+aimee remote set http://SERVER:8740 <bearer-token>
+# or per-invocation: --server / AIMEE_SERVER_URL (+ --server-token / AIMEE_SERVER_TOKEN)
+```
+
+A remote endpoint is "tcp" (`http(s)://host:port`) vs. a co-located unix socket.
+The behaviors below activate only for a **remote tcp** endpoint; co-located use
+is unchanged.
+
+### Server write posture
+
+Mutating `/v1` calls require the server to allow remote writes. Set it in the
+server's `aimee.yaml` (`aimee.api.remote_writes: off|data|full`) **or** via the
+`AIMEE_API_REMOTE_WRITES` environment variable (deploy truth — applied even when
+the config file is read-only or absent, e.g. a containerized server). `full`
+grants the LAN bearer the capabilities needed for workspace add, ingest, and
+session-credential push; use it only on trusted networks.
+
+## Workspaces (client-push ingest)
+
+On a thin client the workspace root lives on *your* machine, which the server
+cannot read. `aimee workspace add <path>` therefore:
+
+1. resolves `<path>` locally,
+2. registers it on the server as a **`detached`** workspace (the server stores
+   the path verbatim and does not try to scan its own filesystem),
+3. collects the source files locally and pushes them to `POST /v1/index/ingest`,
+   which relays them to aimee-kb's code index.
+
+```sh
+aimee workspace add ~/dev          # register + ingest from this machine
+aimee workspace list               # shows dev as [detached] + indexed projects
+aimee index scan [path]            # re-push one path, or every detached workspace
+aimee index find <symbol>          # query the code index
+```
+
+Notes:
+- The push is **chunked** to stay under aimee-kb's 1 MB request-body cap; large
+  trees are split across several batches.
+- A single `workspace add` collects up to `CODE_COLLECT_MAX_FILES` (4096) files
+  and logs when a tree is truncated; re-run `index scan` from the client to
+  re-push after changes.
+- VCS/build/hidden directories (`.git`, `node_modules`, `target`, `dist`, …) and
+  binary/oversized files are skipped.
+
+## Agents & client-held credentials
+
+API keys for delegates and the primary provider are **held on the client**, not
+stored on the server. The model:
+
+- `agent add` stores the **definition** (name, endpoint, model, roles, provider)
+  on the server; the **key** stays local.
+- Once per session the client pushes its keys to the server's in-memory keyring;
+  the server uses them for that session's turns and **never writes them to
+  disk** (they evaporate on session end / restart). See [SECURITY.md](SECURITY.md).
+
+### Adding an agent
+
+```sh
+aimee agent add minimax https://api.minimax.io/v1/chat/completions MiniMax-M3 \
+      --key "$MINIMAX_KEY" --provider openai --default \
+      --roles "code,review,explain,refactor,draft,execute,summarize,format,diagnose,validate"
+```
+
+Against a **remote tcp** server, `--key K`:
+- is written to the local keyring `~/.config/aimee/agent-keys.json` (mode 0600),
+  keyed by the agent name, and
+- is **stripped** from the request before the definition is forwarded — the key
+  never reaches the server.
+
+Set the primary chat provider to any configured agent:
+
+```sh
+aimee config set provider minimax
+```
+
+### How keys reach the server (per session)
+
+- A stable per-client **credential-session id** is generated once into
+  `~/.config/aimee/cred-session.id`.
+- The first chat/delegate turn of a session pushes the local keyring (and Codex
+  creds, below) to `POST /v1/session/credentials`, deduplicated (re-pushes at
+  most every ~2 minutes, which also re-syncs after a server restart). Each turn
+  carries a `cred_session_id` so the server resolves the right keyring entry,
+  decoupled from the functional chat session id.
+- Server auth resolution prefers a client-pushed session key (by session + agent
+  name) over any server-stored `api_key` / provider env var.
+
+You set up agents **per machine** you use — that is the intended trade-off for
+not centralizing keys on the server.
+
+### Codex (ChatGPT OAuth)
+
+The Codex CLI keeps a refreshed OAuth token in `~/.codex/auth.json` on your
+machine. Add a Codex agent with no key — the client reads that file and pushes
+the token (and ChatGPT account id) with the session credentials:
+
+```sh
+aimee agent add codex https://chatgpt.com/backend-api/codex gpt-5.5 \
+      --provider codex --roles "code,review,explain,refactor,draft,execute,summarize,format,diagnose,validate"
+aimee config set provider codex     # optional: use Codex as the primary
+```
+
+`--provider codex` is a convenience alias for the Codex adapter (provider
+`chatgpt`, `auth_type` `codex-oauth`, the responses-wire delegate driver). The
+token is sourced live per session, so it stays fresh as the Codex CLI refreshes
+it; it is never stored on the server.
+
+## Attention guard
+
+The PreToolUse attention guard (`aimee attention-guard`, used by the Claude Code
+integration) is **inert by default**: recursive raw scans (`grep -r`, `Grep`,
+`Glob`, …) are allowed unless you set a positive `ingress_max_raw_scans` cap in
+`aimee.yaml`, after which a session may run that many raw scans before further
+ones are redirected toward the indexed tools. The destructive-file guard (it
+blocks a hard-destructive command on a file the session has actively edited) is
+always on. `AIMEE_GUARD=0` disables the guard entirely.
+
+The client's Claude Code integration (MCP server + hooks) is registered at the
+**installed** binary path and self-heals: running the installed client rewrites
+any stale hook/MCP command (e.g. one left pointing at an old build directory) to
+the resolved binary.
+
+## New `/v1` endpoints
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| POST | `/v1/index/ingest` | Index client-pushed `{rel_path, content}` files for a workspace the server cannot see (relays to aimee-kb). |
+| POST | `/v1/session/credentials` | Receive the once-per-session push of `{session_id, agents{}, codex_oauth_token, codex_account_id}` into the RAM-only keyring. |
+
+Both `/v1/index/scan` and `/v1/index/ingest` run as synchronous handlers under
+the async op-run worker (poll `GET /v1/runs/{id}`).

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -5,6 +5,39 @@ current version and prints it once after an upgrade.
 
 ---
 
+## Unreleased (testing)
+
+Thin-client hardening — the client machine owns the working tree and the
+secrets; see [THIN_CLIENT.md](THIN_CLIENT.md).
+
+- **Client-held agent credentials**: agent/delegate API keys now live on the
+  client (`~/.config/aimee/agent-keys.json`), not on the server. `aimee agent
+  add … --key K` against a remote server keeps `K` local and strips it before
+  forwarding the definition. Keys are pushed once per session to a **RAM-only**
+  keyring on the server (`POST /v1/session/credentials`) and are **never written
+  to disk** — so a compromised server holds no durable secret store. Auth
+  resolution prefers the client-pushed session key over any server-stored key.
+- **Codex OAuth from the thin client**: add a Codex agent with no key
+  (`aimee agent add codex https://chatgpt.com/backend-api/codex gpt-5.5
+  --provider codex`); the client supplies the OAuth token from this machine's
+  `~/.codex/auth.json` per session. Works as a primary provider and a delegate.
+- **Workspaces ingested from the client**: `aimee workspace add <path>` resolves
+  the path locally, registers it as `detached`, and pushes the files to the
+  server (`POST /v1/index/ingest`, chunked under aimee-kb's body cap) — the
+  server never reads the client filesystem. `aimee index scan [path]` re-pushes.
+- **Attention guard inert by default**: recursive raw scans flow freely unless a
+  positive `ingress_max_raw_scans` cap is configured; the destructive-file guard
+  is unchanged. The Claude Code integration also re-points stale hook/MCP command
+  paths to the installed binary on reinstall.
+- **`AIMEE_API_REMOTE_WRITES` env** lets a containerized server set its TCP write
+  posture (`off|data|full`) without a writable `aimee.yaml`.
+- **Fixes**: remote `/v1/index/scan` (and `/v1/index/ingest`) no longer fail with
+  "rpc produced no response" (synchronous handlers under the op-run worker);
+  `aimee agent add … --provider codex` is accepted as an alias for the Codex
+  adapter.
+
+---
+
 ## v0.2.0
 
 - **Docker-first deployment**: run `aimee-server` + `aimee-kb` as containers, either one

--- a/docs/WORKSPACES.md
+++ b/docs/WORKSPACES.md
@@ -102,6 +102,15 @@ aimee workspace remove <path>                      # unregister a root (the chec
 
 Registered roots live in `aimee.yaml` under `workspaces:`. Removing one only drops it from that list; it never deletes your checkout.
 
+#### Thin client (remote server)
+
+When the `aimee` CLI targets a **remote** `aimee-server`, the workspace root is on
+*your* machine, which the server cannot read. `aimee workspace add <path>` then
+resolves the path locally, registers it as a `detached` workspace, and **pushes
+the source files to the server** (`POST /v1/index/ingest`, chunked) to populate
+the code index; `aimee index scan [path]` re-pushes. The server never reads the
+client filesystem. See [THIN_CLIENT.md](THIN_CLIENT.md).
+
 ## Session Isolation
 
 Each session gets its own git worktree for every project in the workspace, its own state file, and its own branch. Two concurrent sessions do not clobber each other.

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -497,6 +497,17 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (provider && provider[0])
       snprintf(ag->provider, sizeof(ag->provider), "%s", provider);
 
+   /* `--provider codex` is a convenience alias for the Codex (ChatGPT OAuth)
+    * adapter, whose provider is "chatgpt" (the responses-wire delegate driver)
+    * and whose auth is codex-oauth. Without this, a literal provider "codex"
+    * routes to a chat-completions path the codex backend rejects. */
+   if (strcmp(ag->provider, "codex") == 0)
+   {
+      snprintf(ag->provider, sizeof(ag->provider), "chatgpt");
+      if (!auth_type || !auth_type[0])
+         snprintf(ag->auth_type, sizeof(ag->auth_type), "codex-oauth");
+   }
+
    const char *roles = opt_get(&opts, "roles");
    if (roles && roles[0])
       server_agent_set_roles_csv(ag, roles);

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -296,26 +296,6 @@ int handle_memory_read(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 /* --- Index handlers --- */
 
-static void *index_scan_thread(void *arg)
-{
-   kb_proxy_ctx_t *c = arg;
-   const char *name = jo_str(c->req, "name", NULL);
-   const char *root = jo_str(c->req, "root", NULL);
-   int force = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(c->req, "force")) ? 1 : 0;
-
-   kb_client_index_scan_result_t res;
-   memset(&res, 0, sizeof(res));
-   int kb_rc = kb_client_index_scan(name, root, force, &res);
-   cJSON *resp = (cJSON *)kb_client_index_scan_format_response(kb_rc, &res);
-   if (resp)
-   {
-      kb_proxy_write_response(c->conn_fd, resp);
-      cJSON_Delete(resp);
-   }
-   kb_proxy_ctx_free(c);
-   return NULL;
-}
-
 int handle_index_scan(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -325,8 +305,18 @@ int handle_index_scan(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if ((name && name[0] && (!root || !root[0])) || (root && root[0] && (!name || !name[0])))
       return server_send_error(conn, "index.scan requires both name and root, or neither", NULL);
 
-   kb_proxy_spawn(conn, req, index_scan_thread);
-   return 0;
+   /* Synchronous (inline kb scan + send_and_free), like handle_index_ingest:
+    * over /v1 this runs in the async op-run worker (HTTP already returned the
+    * run handle) and over NDJSON in the per-connection worker, so blocking here
+    * is fine. A kb_proxy_spawn detached-thread reply is NOT captured by the
+    * op-run's loopback_rpc (it reads the socketpair synchronously), which is why
+    * a remote /v1 index.scan previously failed with "rpc produced no response". */
+   int force = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(req, "force")) ? 1 : 0;
+   kb_client_index_scan_result_t res;
+   memset(&res, 0, sizeof(res));
+   int kb_rc = kb_client_index_scan(name, root, force, &res);
+   cJSON *resp = (cJSON *)kb_client_index_scan_format_response(kb_rc, &res);
+   return send_and_free(conn, resp);
 }
 
 int handle_index_find(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)


### PR DESCRIPTION
## Summary
Two follow-ups flagged during the thin-client work.

### 1. `index.scan` failed over a remote `/v1` call
`handle_index_scan` replied on a detached thread (`kb_proxy_spawn`), but over `/v1` it runs in the async op-run worker via `loopback_rpc`, which reads the response socketpair synchronously — the deferred write was lost, so `POST /v1/index/scan` (and a remote `aimee index scan`) failed with `"rpc produced no response"` (same class as the earlier `index.ingest` bug). Now `handle_index_scan` is **synchronous** (inline `kb_client_index_scan` + `send_and_free`), matching `handle_index_ingest`. Safe on both transports — `/v1` already returned the run handle before the worker runs, and NDJSON dispatch uses a per-connection ephemeral worker.

### 2. `--provider codex` didn't work
The Codex adapter's provider is `chatgpt` (the responses-wire delegate driver the backend requires). A literal `--provider codex` routed to a chat-completions path the backend rejects (`"Instructions are required"`), forcing the non-obvious `--provider chatgpt`. `handle_agent_add` now maps `--provider codex` → `chatgpt` and defaults `auth_type` to `codex-oauth`.

## Validation (live, NAS v0.0.5-wsguard)
- `POST /v1/index/scan` → op-run **completed** (`status: ok`), no "rpc produced no response".
- `aimee agent add codex … --provider codex` → delegate `--via codex` → **Athens**.

`make unit-tests` + `make lint` green. Branches off `testing` (after #182/#184/#186 merged).
