### PR TITLE
agent add --provider claude: configure the tmux-cli claude agent (thin-client)

### DIFF
--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -364,12 +364,20 @@ or stored on the server. Co-located deployments are unchanged (the tmux session
 runs locally). (`claude -p` print mode is **not** used.)
 
 Practical notes:
-- Configure the agent as usual (`aimee agent add claude … --provider claude`,
-  or `aimee config set provider claude` to make it the primary); the thin-client
-  routing is automatic when the workspace is `detached`.
+- Configure it with `--provider claude` (which sets the tmux-cli backend — the
+  endpoint argument is a placeholder and the model becomes `claude --model <m>`):
+
+  ```bash
+  aimee agent add claude claude sonnet --provider claude   # tmux-cli claude agent
+  aimee config set provider claude                          # use it as the primary
+  ```
+
+  (`aimee agent setup claude` does the same but only against a co-located server;
+  on a thin client use `agent add --provider claude`.) The thin-client routing is
+  automatic when the workspace is `detached`.
 - If no client is currently serving the workspace, the CLI agent cannot run
-  (there is nowhere with the binary) — start the client / `aimee workspace serve`
-  for that root, or use an HTTP provider.
+  (there is nowhere with the binary) — start the client / open `aimee chat` for
+  that root, or use an HTTP provider.
 
 #### Claude via the CLI is primary-only by default
 

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -508,6 +508,26 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          snprintf(ag->auth_type, sizeof(ag->auth_type), "codex-oauth");
    }
 
+   /* `--provider claude`/`claude-code` configures the standard `claude` CLI run
+    * over tmux (login-based, not an API key) — the same tmux-cli backend
+    * `agent setup claude` produces, but reachable from a thin client (where
+    * `agent setup` has no local server). Without this it would be stored as a
+    * generic HTTP agent pointing at a bogus endpoint. The tmux session runs on
+    * the client over the reverse channel for a detached workspace; the `model`
+    * arg becomes `claude --model <model>`. */
+   if (strcmp(ag->provider, "claude") == 0 || strcmp(ag->provider, "claude-code") == 0)
+   {
+      int is_code = strcmp(ag->provider, "claude-code") == 0;
+      snprintf(ag->backend, sizeof(ag->backend), "%s", AGENT_BACKEND_TMUX_CLI);
+      snprintf(ag->cli_kind, sizeof(ag->cli_kind), "%s", is_code ? "claude-code" : "claude");
+      if (ag->model[0])
+         snprintf(ag->cli_cmd, sizeof(ag->cli_cmd), "claude --model %s", ag->model);
+      else
+         snprintf(ag->cli_cmd, sizeof(ag->cli_cmd), "claude");
+      ag->session_reuse = 1;
+      ag->endpoint[0] = '\0'; /* tmux CLI has no HTTP endpoint */
+   }
+
    const char *roles = opt_get(&opts, "roles");
    if (roles && roles[0])
       server_agent_set_roles_csv(ag, roles);


### PR DESCRIPTION
`handle_agent_add` had a `--provider codex` alias but none for `claude`, so `aimee agent add … --provider claude` stored a generic HTTP agent (bogus endpoint) — claude-as-delegate failed with an HTTP error and the primary-only gate never matched it. The tmux-cli mapping only lived in `agent setup`, which needs a co-located server (unavailable from a thin client).

Adds the claude/claude-code alias to `handle_agent_add`: backend=tmux-cli, cli_kind=claude(-code), cli_cmd=`claude --model <model>`, session_reuse, placeholder endpoint dropped. A thin client can now configure a real standard-`claude`-over-tmux agent that runs on the client (reverse channel), works as a delegate when `claude_cli_delegate_enabled` is set, and is recognized by the primary-only gate. Docs updated.

make unit-tests + lint green.