### PR TITLE
Wire claude-over-tmux delegate on a thin client (detached workspace)

### DIFF
--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -38,7 +38,16 @@
 #include "provider_catalog.h"
 #include "role_templates.h"
 #include "workspace.h"
+#include "workspace_provider.h"
+#include "workspace_turn.h"
 #include "cJSON.h"
+
+/* Defined in agent_runtime_tmux.c (no shared header). Drives the standard CLI
+ * agent over a tmux session, which runs on the client over the reverse channel
+ * when the active workspace is detached. */
+int agent_execute_cli_session(const agent_t *agent, const agent_network_t *network,
+                              const char *system_prompt, const char *user_prompt, int max_tokens,
+                              double temperature, agent_result_t *out);
 #include <ctype.h>
 #include <errno.h>
 #include <pthread.h>
@@ -814,6 +823,59 @@ void delegate_worker(void *arg)
          return;
       }
       via_name = inline_acp_name;
+   }
+
+   /* Claude over the standard `claude` CLI/tmux on a DETACHED (thin-client)
+    * workspace: claude runs its own interactive session on the CLIENT (the tmux
+    * driver marshals its commands over the reverse channel) against the client's
+    * tree, doing its own edits — so it bypasses the server-side worktree
+    * isolation / write-guard machinery below (which assumes a local fs), exactly
+    * as the primary chat path does. Gated by claude_cli_delegate_enabled. */
+   if (via_name && via_name[0])
+   {
+      agent_t *cag = agent_find(&acfg, via_name);
+      if (cag && agent_is_claude_cli(cag))
+      {
+         int detached_bound = workspace_turn_bind_active(cwd);
+         const workspace_provider_t *wsp = workspace_provider_active();
+         if (detached_bound && wsp && wsp->kind == WS_PROVIDER_DETACHED && wsp->exec_shell)
+         {
+            config_t gate_cfg;
+            config_load(&gate_cfg);
+            if (!gate_cfg.claude_cli_delegate_enabled)
+            {
+               workspace_turn_unbind_active();
+               char m[320];
+               snprintf(m, sizeof(m),
+                        "agent '%s' is Claude via the `claude` CLI and is primary-only by default; "
+                        "set claude_cli_delegate_enabled=true to allow it as a delegate "
+                        "(see DELEGATES.md for the Anthropic account-risk warning)",
+                        cag->name);
+               delegation_compute_error(cctx, m);
+               compute_ctx_free(cctx);
+               return;
+            }
+            if (cwd[0] == '/' && !strstr(cwd, "/.."))
+               run_cmd_set_cwd(cwd);
+            char *tmpl = NULL;
+            const char *sysp = delegate_assemble_system_prompt(system_prompt, role, prompt, cwd,
+                                                               persona_override, cwd, &tmpl);
+            agent_result_t result;
+            memset(&result, 0, sizeof(result));
+            int rc = agent_execute_cli_session(cag, NULL, sysp ? sysp : "", prompt,
+                                               AGENT_DEFAULT_MAX_TOKENS, 0.3, &result);
+            run_cmd_set_cwd(NULL);
+            workspace_turn_unbind_active();
+            free(tmpl);
+            cJSON *resp = delegate_build_result_response(deleg_id, rc, &result, &acfg, role, cag,
+                                                         -1, 0, NULL, NULL);
+            free(result.response);
+            compute_respond(cctx, resp);
+            compute_ctx_free(cctx);
+            return;
+         }
+         workspace_turn_unbind_active();
+      }
    }
    unsigned required_caps = cJSON_IsNumber(jreq_caps) ? (unsigned)jreq_caps->valuedouble : 0;
    int min_context = cJSON_IsNumber(jmin_ctx) ? (int)jmin_ctx->valuedouble : 0;


### PR DESCRIPTION
Completes the opt-in claude-as-delegate path on a thin client. The delegate worker now short-circuits a `--via claude` (Claude CLI) delegate on a **detached** workspace: binds the workspace, enforces the `claude_cli_delegate_enabled` primary-only gate, and runs the standard `claude` CLI over tmux **on the client** (reverse channel) via `agent_execute_cli_session` — bypassing the server-side worktree/availability machinery that assumes a local fs (claude does its own edits in the client's real tree, like the primary path). Flag off → concise primary-only rejection. Auto-routing still won't select a claude CLI agent server-side (no binary there); claude-as-delegate is an explicit `--via` opt-in, matching primary-only-by-default. make unit-tests + lint green.