### PR TITLE
Expose the roundtable authoring pipeline as first-class MCP tools

### DIFF
--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -650,6 +650,8 @@ cJSON *mcp_build_tools_list(void)
                           "\"required\":[\"diff\"]}")));
    }
 
+#include "mcp_tools_pipeline.inc"
+
    /* preview_blast_radius */
    {
       cJSON *s = cJSON_CreateObject();

--- a/src/mcp_tools_pipeline.inc
+++ b/src/mcp_tools_pipeline.inc
@@ -1,0 +1,108 @@
+/* mcp_tools_pipeline.inc: roundtable authoring pipeline (pipeline_*) MCP tool
+ * definitions, #included by mcp_build_tools_list() in mcp_tools.c (kept as an
+ * .inc to stay under the per-file line cap). */
+
+   /* Roundtable authoring pipeline (pipeline_* tools): idea -> reviewed proposal
+    * -> implementation -> reviewed PR, with two human gates and two roundtable
+    * quality gates. The driving agent may run the loop but CANNOT resolve a gate
+    * (that needs an operator principal). */
+   {
+      cJSON_AddItemToArray(
+          tools,
+          build_tool(
+              "pipeline_start",
+              "Start a roundtable authoring pipeline from a one-line idea. Creates a dedicated "
+              "proposal branch/worktree in repo_root and enters drafting. Returns the pipeline_id.",
+              cJSON_Parse(
+                  "{\"type\":\"object\",\"properties\":{"
+                  "\"idea\":{\"type\":\"string\",\"description\":\"One-line idea/goal for the "
+                  "proposal.\"},"
+                  "\"repo_root\":{\"type\":\"string\",\"description\":\"Repository root for the "
+                  "dedicated proposal/impl branch+worktree (required).\"},"
+                  "\"base_branch\":{\"type\":\"string\",\"description\":\"PR base branch (default "
+                  "testing).\"},"
+                  "\"head_branch\":{\"type\":\"string\",\"description\":\"Optional dedicated head "
+                  "branch; defaults to roundtable/proposal-<id>.\"},"
+                  "\"remote\":{\"type\":\"string\",\"description\":\"Git remote (default "
+                  "origin).\"},"
+                  "\"done_bar\":{\"type\":\"string\",\"enum\":[\"zero_blocking\",\"zero_blocking_"
+                  "suggestions\",\"zero_blocking_questions_answered\"],\"description\":\"Review "
+                  "done-bar (default from config).\"},"
+                  "\"brief\":{\"type\":\"string\",\"description\":\"Optional seed brief/focus.\"},"
+                  "\"questions\":{\"type\":\"array\",\"items\":{\"type\":\"string\"},"
+                  "\"description\":\"Optional accepted questions (max 16) for the "
+                  "questions-answered bar.\"}},"
+                  "\"required\":[\"idea\",\"repo_root\"]}")));
+
+      cJSON_AddItemToArray(
+          tools,
+          build_tool(
+              "pipeline_advance",
+              "Drive one tick of the pipeline loop: submit a DRAFT/REVIEW roundtable pass, decide "
+              "the captured pass (pass/revise/retry/escalate), open a PR + surface a gate when the "
+              "done-bar is met, or reconcile a pending merge. Returns the next action.",
+              cJSON_Parse(
+                  "{\"type\":\"object\",\"properties\":{"
+                  "\"pipeline_id\":{\"type\":\"integer\",\"description\":\"Pipeline id.\"},"
+                  "\"artifact\":{\"type\":\"string\",\"description\":\"Optional revised proposal "
+                  "text / diff to review; if omitted the controller reads the working proposal or "
+                  "captures the diff itself.\"}},"
+                  "\"required\":[\"pipeline_id\"]}")));
+
+      cJSON_AddItemToArray(
+          tools,
+          build_tool("pipeline_status",
+                     "Show a pipeline's state, phase, latest review digest, gate, panel diversity, "
+                     "and economics.",
+                     cJSON_Parse("{\"type\":\"object\",\"properties\":{"
+                                 "\"pipeline_id\":{\"type\":\"integer\",\"description\":\"Pipeline "
+                                 "id.\"}},\"required\":[\"pipeline_id\"]}")));
+
+      cJSON_AddItemToArray(
+          tools, build_tool("pipeline_list", "List roundtable authoring pipelines.",
+                            cJSON_Parse("{\"type\":\"object\",\"properties\":{"
+                                        "\"state\":{\"type\":\"string\",\"description\":\"Optional "
+                                        "state filter; omit for all non-terminal.\"}}}")));
+
+      cJSON_AddItemToArray(
+          tools,
+          build_tool(
+              "pipeline_gate",
+              "Resolve a human gate (pass|fail). REQUIRES an enrolled local operator principal — a "
+              "delegate-driving session cannot pass its own gate. pass merges the PR (drift-safe) "
+              "and advances; fail returns the reason to the brief and re-enters review.",
+              cJSON_Parse(
+                  "{\"type\":\"object\",\"properties\":{"
+                  "\"pipeline_id\":{\"type\":\"integer\",\"description\":\"Pipeline id.\"},"
+                  "\"verdict\":{\"type\":\"string\",\"enum\":[\"pass\",\"fail\"],\"description\":"
+                  "\"Gate verdict.\"},"
+                  "\"reason\":{\"type\":\"string\",\"description\":\"Fail reason (folded into the "
+                  "next review brief).\"},"
+                  "\"operator_principal\":{\"type\":\"string\",\"description\":\"Enrolled local "
+                  "operator principal authorizing the gate.\"},"
+                  "\"admin\":{\"type\":\"boolean\",\"description\":\"Use gh pr merge --admin.\"}},"
+                  "\"required\":[\"pipeline_id\",\"verdict\",\"operator_principal\"]}")));
+
+      cJSON_AddItemToArray(
+          tools,
+          build_tool(
+              "pipeline_resume",
+              "Resume a pipeline from the durable ledger across sessions/restarts; optionally "
+              "repair repo/workspace metadata (repo_root/remote/head_branch/worktree_path) after "
+              "an implementation-workspace failure.",
+              cJSON_Parse(
+                  "{\"type\":\"object\",\"properties\":{"
+                  "\"pipeline_id\":{\"type\":\"integer\",\"description\":\"Pipeline id.\"},"
+                  "\"repo_root\":{\"type\":\"string\"},\"remote\":{\"type\":\"string\"},"
+                  "\"head_branch\":{\"type\":\"string\"},\"worktree_path\":{\"type\":\"string\"}},"
+                  "\"required\":[\"pipeline_id\"]}")));
+
+      cJSON_AddItemToArray(
+          tools,
+          build_tool("pipeline_cancel",
+                     "Cancel/abandon a pipeline; requests cancellation of any in-flight roundtable "
+                     "child run.",
+                     cJSON_Parse("{\"type\":\"object\",\"properties\":{"
+                                 "\"pipeline_id\":{\"type\":\"integer\",\"description\":\"Pipeline "
+                                 "id.\"}},\"required\":[\"pipeline_id\"]}")));
+   }

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -27,6 +27,7 @@
 #include "server_mcp_workflows.h"
 #include "server_mcp_gateway.h"
 #include "server_http.h"
+#include "server_pipeline.h" /* handle_pipeline_* for the pipeline.* MCP tools */
 #include "headers/conversation_context.h"
 #include "headers/payload_rewrite.h"
 #include "headers/session_search_tool.h"
@@ -1583,6 +1584,45 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       if (owns_jargs)
          cJSON_Delete(jargs);
       return rc;
+   }
+
+   /* Roundtable authoring pipeline tools (first-class MCP citizens): route each
+    * pipeline_* tool to its handler, which sends its own response on conn (like
+    * ensemble_review/delegate). Capability is enforced against the matching
+    * pipeline.* method (status/list = read; others = delegate; gate also needs an
+    * operator principal inside the handler). MCP arg names mirror the method's. */
+   if (strncmp(tool, "pipeline_", 9) == 0)
+   {
+      static const struct
+      {
+         const char *tool;
+         const char *method;
+         int (*fn)(server_ctx_t *, server_conn_t *, cJSON *);
+      } pipeline_tools[] = {
+          {"pipeline_start", "pipeline.start", handle_pipeline_start},
+          {"pipeline_status", "pipeline.status", handle_pipeline_status},
+          {"pipeline_list", "pipeline.list", handle_pipeline_list},
+          {"pipeline_cancel", "pipeline.cancel", handle_pipeline_cancel},
+          {"pipeline_resume", "pipeline.resume", handle_pipeline_resume},
+          {"pipeline_advance", "pipeline.advance", handle_pipeline_advance},
+          {"pipeline_gate", "pipeline.gate", handle_pipeline_gate},
+      };
+      for (size_t i = 0; i < sizeof(pipeline_tools) / sizeof(pipeline_tools[0]); i++)
+      {
+         if (strcmp(tool, pipeline_tools[i].tool) != 0)
+            continue;
+         uint32_t required = server_capability_for_method(pipeline_tools[i].method);
+         if (required && conn && (conn->capabilities & required) == 0)
+         {
+            if (owns_jargs)
+               cJSON_Delete(jargs);
+            return server_send_error(conn, "forbidden: insufficient capabilities", NULL);
+         }
+         int rc = pipeline_tools[i].fn(ctx, conn, jargs);
+         if (owns_jargs)
+            cJSON_Delete(jargs);
+         return rc;
+      }
    }
 
    struct mcp_call call = {ctx, conn, jargs, sid, tool, &structured};

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -2,7 +2,7 @@
  * built-in tool surface (name + sorted schema property keys + required), captured
  * via the DUMP_TOOLS path in test_mcp_client_registry.c. Regenerate after an
  * intentional tool change: DUMP_TOOLS=1 ./unit-test-mcp-client-registry 2>&1. */
-#define MCP_TOOLS_GOLDEN_COUNT 88
+#define MCP_TOOLS_GOLDEN_COUNT 95
 #define MCP_TOOLS_GOLDEN \
    "ask_user {choices,question} req:question\n" \
    "ast_grep_search {lang,path,pattern} req:lang,pattern\n" \
@@ -70,6 +70,13 @@
    "memory_recall {limit_tokens,session_start,task_hint} req:\n" \
    "mutate {confidence,content,id,key,kind,reason,tier,verb} req:verb\n" \
    "payload_rewrite_status {} req:\n" \
+   "pipeline_advance {artifact,pipeline_id} req:pipeline_id\n" \
+   "pipeline_cancel {pipeline_id} req:pipeline_id\n" \
+   "pipeline_gate {admin,operator_principal,pipeline_id,reason,verdict} req:operator_principal,pipeline_id,verdict\n" \
+   "pipeline_list {state} req:\n" \
+   "pipeline_resume {head_branch,pipeline_id,remote,repo_root,worktree_path} req:pipeline_id\n" \
+   "pipeline_start {base_branch,brief,done_bar,head_branch,idea,questions,remote,repo_root} req:idea,repo_root\n" \
+   "pipeline_status {pipeline_id} req:pipeline_id\n" \
    "preview_blast_radius {paths,project} req:paths,project\n" \
    "record_attempt {approach,lesson,outcome,task_context} req:approach,outcome\n" \
    "resolve_epistemic_directive {id,note,resolution_memory_id,suppress} req:id\n" \


### PR DESCRIPTION
Makes the roundtable authoring pipeline (merged in #193) a **first-class MCP
citizen**: the `pipeline.*` control surface is now exposed as discoverable,
callable MCP tools, so an MCP client (Claude Code, IDEs, agents) can drive the
whole idea → reviewed-proposal → implementation → reviewed-PR loop directly —
not only via the `aimee pipeline` CLI / NDJSON path.

## What changed

- **7 tools advertised** in `mcp_build_tools_list()` (via the new
  `mcp_tools_pipeline.inc`), each with a full JSON input schema:
  `pipeline_start`, `pipeline_advance`, `pipeline_status`, `pipeline_list`,
  `pipeline_gate`, `pipeline_resume`, `pipeline_cancel`.
- **Dispatch**: `handle_mcp_call()` routes `pipeline_*` tools to the existing
  `handle_pipeline_*` handlers (which send their own response, exactly like
  `ensemble_review`/`delegate`), capability-gated against the matching
  `pipeline.*` method — `status`/`list` = `CAP_SESSION_READ`, the rest =
  `CAP_DELEGATE`. `pipeline_gate` additionally requires an enrolled operator
  principal inside the handler, so a delegate-driving session still cannot pass
  its own gate.
- **Golden surface** regenerated: `test_mcp_tools_golden.inc` 88 → 95 tools.
- Tool definitions live in `mcp_tools_pipeline.inc` to keep `mcp_tools.c` under
  the per-file line cap.

No engine or handler logic changed — this is purely the MCP surfacing of the
existing, tested pipeline. `make verify-local` is green (MCP golden test +
line-check + conformance/dispatch-caps).
