### PR TITLE
Fix unit-test-server-dispatch link under CI LTO (red since #193)

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -774,10 +774,6 @@ $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o 
 	                                $(OBJDIR)/cmd_init.o \
 	                                $(OBJDIR)/server/server_trigger.o $(OBJDIR)/db1/db1_trigger.o \
 	                                $(OBJDIR)/db1/pipelines.o $(OBJDIR)/db1/token_audit.o \
-	                                $(OBJDIR)/db1/roundtable_pipeline.o $(OBJDIR)/db1/local_operator.o \
-	                                $(OBJDIR)/server/server_pipeline.o \
-	                                $(OBJDIR)/server/roundtable_pipeline_capture.o \
-	                                $(OBJDIR)/server/roundtable_pipeline_eval.o \
 	                                $(OBJDIR)/server/delegate_backend.o $(OBJDIR)/server/delegate_backend_local.o \
 	                                $(OBJDIR)/server/delegate_backend_ssh.o $(OBJDIR)/server/delegate_backend_docker.o \
 	                                $(OBJDIR)/server/model_provider.o $(OBJDIR)/server/openai_profile.o \

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -416,6 +416,37 @@ int handle_session_presence(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "session.presence");
 }
+/* The roundtable pipeline handlers are STUBBED here (this test only exercises
+ * dispatch-table routing) so the real server_pipeline.o — which drags in the
+ * op-run/git/agent-config/chunk graph — is not linked into the dispatch test. */
+int handle_pipeline_start(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.start");
+}
+int handle_pipeline_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.status");
+}
+int handle_pipeline_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.list");
+}
+int handle_pipeline_cancel(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.cancel");
+}
+int handle_pipeline_resume(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.resume");
+}
+int handle_pipeline_advance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.advance");
+}
+int handle_pipeline_gate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "pipeline.gate");
+}
 int handle_trajectory_export(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "trajectory.export");


### PR DESCRIPTION
Restores a green unit-tests job on testing. See commit message for the root cause (server_pipeline.o dragged the op-run/git/chunk/agent graph into the dispatch test; LTO retains it in CI). Stubs the pipeline handlers like the test's other ~40 handlers and drops the real object from the link. **Watching CI before merge — no admin-merge-through-red.**