### PR TITLE
Promote: DB2 deploy-robustness (code_embeddings halfvec + kb startup retry)

### DIFF
--- a/deploy/migrations/2026-embed-halfvec.sql
+++ b/deploy/migrations/2026-embed-halfvec.sql
@@ -75,4 +75,47 @@ BEGIN
 END
 $MIG$;
 
+-- Also catch UNDIMENSIONED `vector` columns. A pre-fix schema.sql created
+-- code_embeddings.embedding as bare `vector` (no dimension) instead of
+-- halfvec(__EMBED_DIM__) like every other embedding column. format_type reports
+-- those as plain `vector`, so the `vector(%` loop above skips them, and the HNSW
+-- index (halfvec_cosine_ops) can never build on them. The bare column carries no
+-- dimension of its own, so we cast it at the dimension the rest of the corpus
+-- already uses — read from any sibling halfvec column converted above — keeping
+-- this script config-free. (If no halfvec column exists yet, there is no
+-- reference dimension and we leave the column for a fresh schema apply.)
+DO $BARE$
+DECLARE
+    r          RECORD;
+    target_dim text;
+BEGIN
+    SELECT (regexp_match(format_type(a.atttypid, a.atttypmod), '\((\d+)\)'))[1]
+      INTO target_dim
+      FROM pg_attribute a
+      JOIN pg_class c     ON c.oid = a.attrelid
+      JOIN pg_namespace n ON n.oid = c.relnamespace
+     WHERE n.nspname = 'public' AND c.relkind = 'r' AND NOT a.attisdropped
+       AND format_type(a.atttypid, a.atttypmod) LIKE 'halfvec(%'
+     LIMIT 1;
+
+    IF target_dim IS NULL THEN
+        RAISE NOTICE 'halfvec migration: undimensioned vector column(s) present but no sibling halfvec column to read a dimension from; leaving for a fresh schema apply';
+    ELSE
+        FOR r IN
+            SELECT c.relname AS tbl, a.attname AS col
+              FROM pg_attribute a
+              JOIN pg_class c     ON c.oid = a.attrelid
+              JOIN pg_namespace n ON n.oid = c.relnamespace
+             WHERE n.nspname = 'public' AND c.relkind = 'r' AND NOT a.attisdropped
+               AND format_type(a.atttypid, a.atttypmod) = 'vector'
+        LOOP
+            EXECUTE format('ALTER TABLE %I ALTER COLUMN %I TYPE halfvec(%s) USING %I::halfvec(%s)',
+                           r.tbl, r.col, target_dim, r.col, target_dim);
+            RAISE NOTICE 'halfvec migration: %.% vector -> halfvec(%) (undimensioned; dim from sibling halfvec column)',
+                         r.tbl, r.col, target_dim;
+        END LOOP;
+    END IF;
+END
+$BARE$;
+
 COMMIT;

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -904,7 +904,7 @@ DO $pgvec_setup$ DECLARE v_ok BOOLEAN := FALSE; BEGIN
         EXECUTE $T$
             CREATE TABLE IF NOT EXISTS code_embeddings (
                 point_id     BIGINT PRIMARY KEY,
-                embedding    vector,
+                embedding    halfvec(__EMBED_DIM__),
                 project      TEXT NOT NULL DEFAULT '',
                 node_key     TEXT NOT NULL DEFAULT '',
                 file_path    TEXT NOT NULL DEFAULT '',

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -570,12 +570,35 @@ int main(int argc, char **argv)
       }
    }
 
-   /* DB2 owns project, workspace, and global knowledge for aimee-kb. */
-   if (db2_init(kb_cfg.db2_url) != 0)
+   /* DB2 owns project, workspace, and global knowledge for aimee-kb.
+    *
+    * Wait out a not-yet-ready Postgres on a bounded backoff instead of exiting
+    * on the first failure. In a container/plugin deploy aimee-kb and its Postgres
+    * come up as sibling services; Postgres is routinely still starting (or, as
+    * seen on the smoothnas plugin runtime, started slightly later) when kb boots.
+    * A hard exit here turns that ordinary startup race into a hard outage: the
+    * process dies with DB2 reported "unavailable" and, absent an external
+    * supervisor that restarts it, the kb stays down until a manual restart. The
+    * retry is bounded, so a genuinely misconfigured/missing DB2 still surfaces as
+    * a startup failure — just after giving a slow Postgres time to arrive. */
    {
-      fprintf(stderr, "aimee-kb: DB2 init failed for %s\n", kb_cfg.db2_url);
-      agent_http_cleanup();
-      return 1;
+      const int db2_max_attempts = 24; /* ~2 min at 5s spacing */
+      const int db2_retry_secs = 5;
+      int attempt = 1;
+      while (db2_init(kb_cfg.db2_url) != 0)
+      {
+         if (attempt >= db2_max_attempts)
+         {
+            fprintf(stderr, "aimee-kb: DB2 init failed for %s after %d attempts (%ds)\n",
+                    kb_cfg.db2_url, attempt, attempt * db2_retry_secs);
+            agent_http_cleanup();
+            return 1;
+         }
+         fprintf(stderr, "aimee-kb: DB2 not ready (%s); retry %d/%d in %ds\n", kb_cfg.db2_url,
+                 attempt, db2_max_attempts, db2_retry_secs);
+         sleep(db2_retry_secs);
+         attempt++;
+      }
    }
 
    /* Diagnostic mode: run the fusion off-vs-on recall probe and exit without


### PR DESCRIPTION
Promote to main: DB2 deployment-robustness fixes (#197).

- `code_embeddings.embedding` declared `halfvec(__EMBED_DIM__)` (was bare `vector`, so its HNSW index was silently skipped on every deploy); halfvec migration extended to cast undimensioned `vector` columns so existing deploys self-heal.
- aimee-kb startup waits out a not-yet-ready Postgres on a bounded backoff instead of hard-exiting, so container/plugin deploys self-heal across the kb/Postgres startup race.

CI green on testing (#197): build, unit-tests, lint, build-integrity, e2e-docker, macos/windows builds, init-migrate-service-test, memory-retrieval-eval, bench-check all pass. Migration validated idempotent against a live DB2.
