### PR TITLE
Promote: remove the 4096-file ingest cap (stream workspace pushes)

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6970,76 +6970,102 @@ static int cli_ws_ingest_batch(const char *remote, const char *bearer, const cha
    return rc;
 }
 
+/* Streaming ingest state: code_collect_files_cb hands us one file at a time and
+ * we accumulate them into byte-bounded batches, pushing (and freeing) each batch
+ * the moment it fills. This keeps memory to ~one batch regardless of tree size,
+ * so there is no file-count cap — an arbitrarily large workspace ingests fully. */
+typedef struct
+{
+   const char *remote;
+   const char *bearer;
+   const char *base;
+   const char *abs_root;
+   cJSON *batch; /* current open batch, or NULL */
+   size_t batch_bytes;
+   int pushed;
+   int failed;
+   int batches;
+   int oom; /* could not allocate a batch array */
+} ws_ingest_ctx_t;
+
+/* Push the current batch (cli_ws_ingest_batch adopts/frees it) and reset. */
+static void ws_ingest_flush(ws_ingest_ctx_t *s)
+{
+   if (!s->batch)
+      return;
+   int have = cJSON_GetArraySize(s->batch);
+   if (have == 0)
+   {
+      cJSON_Delete(s->batch);
+   }
+   else
+   {
+      if (cli_ws_ingest_batch(s->remote, s->bearer, s->base, s->abs_root, s->batch) == 0)
+         s->pushed += have;
+      else
+         s->failed += have;
+      s->batches++;
+   }
+   s->batch = NULL;
+   s->batch_bytes = 0;
+}
+
+static int ws_ingest_collect_cb(const char *rel_path, const char *content, void *ctx)
+{
+   ws_ingest_ctx_t *s = (ws_ingest_ctx_t *)ctx;
+   size_t flen = strlen(content) + strlen(rel_path) + 64;
+
+   if (s->batch && cJSON_GetArraySize(s->batch) > 0 && s->batch_bytes + flen > CLI_INGEST_BATCH_BYTES)
+      ws_ingest_flush(s);
+
+   if (!s->batch)
+   {
+      s->batch = cJSON_CreateArray();
+      if (!s->batch)
+      {
+         s->oom = 1;
+         return 1; /* stop the walk */
+      }
+   }
+
+   cJSON *entry = cJSON_CreateObject();
+   if (!entry)
+      return 0; /* skip this file, keep walking */
+   cJSON_AddStringToObject(entry, "rel_path", rel_path);
+   cJSON_AddStringToObject(entry, "content", content);
+   cJSON_AddItemToArray(s->batch, entry);
+   s->batch_bytes += flen;
+   return 0;
+}
+
 static int cli_ws_ingest_root(const char *remote, const char *bearer, const char *abs_root)
 {
    const char *base = strrchr(abs_root, '/');
    base = (base && base[1]) ? base + 1 : abs_root;
 
-   cJSON *all = cJSON_CreateArray();
-   if (!all)
-      return 1;
-   int n = code_collect_files(abs_root, all);
-   if (n == 0)
+   ws_ingest_ctx_t s = {0};
+   s.remote = remote;
+   s.bearer = bearer;
+   s.base = base;
+   s.abs_root = abs_root;
+
+   code_collect_files_cb(abs_root, ws_ingest_collect_cb, &s);
+   ws_ingest_flush(&s); /* flush the trailing partial batch */
+
+   if (s.batches == 0 && !s.oom)
    {
-      cJSON_Delete(all);
       printf("no indexable files found in %s\n", abs_root);
       return 0;
    }
 
-   /* Split into sub-cap batches: pop files off the front into a batch, flushing
-    * whenever the next file would push the batch over the byte budget. */
-   int pushed = 0, failed = 0, batches = 0;
-   cJSON *batch = cJSON_CreateArray();
-   size_t batch_bytes = 0;
-   cJSON *f = NULL;
-   while (batch && (f = cJSON_DetachItemFromArray(all, 0)) != NULL)
-   {
-      cJSON *c = cJSON_GetObjectItemCaseSensitive(f, "content");
-      cJSON *rp = cJSON_GetObjectItemCaseSensitive(f, "rel_path");
-      size_t flen = (cJSON_IsString(c) ? strlen(c->valuestring) : 0) +
-                    (cJSON_IsString(rp) ? strlen(rp->valuestring) : 0) + 64;
-      int have = cJSON_GetArraySize(batch);
-      if (have > 0 && batch_bytes + flen > CLI_INGEST_BATCH_BYTES)
-      {
-         if (cli_ws_ingest_batch(remote, bearer, base, abs_root, batch) == 0)
-            pushed += have;
-         else
-            failed += have;
-         batches++;
-         batch = cJSON_CreateArray();
-         batch_bytes = 0;
-         if (!batch)
-         {
-            cJSON_Delete(f);
-            break;
-         }
-      }
-      cJSON_AddItemToArray(batch, f); /* adopt */
-      batch_bytes += flen;
-   }
-   if (batch && cJSON_GetArraySize(batch) > 0)
-   {
-      int have = cJSON_GetArraySize(batch);
-      if (cli_ws_ingest_batch(remote, bearer, base, abs_root, batch) == 0)
-         pushed += have;
-      else
-         failed += have;
-      batches++;
-   }
-   else
-   {
-      cJSON_Delete(batch);
-   }
-   cJSON_Delete(all);
-
-   if (n >= CODE_COLLECT_MAX_FILES)
+   if (s.oom)
       fprintf(stderr,
-              "aimee: note: '%s' hit the %d-file ingest cap; the rest of the tree was "
-              "not pushed\n",
-              abs_root, CODE_COLLECT_MAX_FILES);
-   printf("ingested %d file(s) from %s (%d batch%s)%s\n", pushed, abs_root, batches,
-          batches == 1 ? "" : "es", failed ? " — some batches failed" : "");
-   return failed ? 1 : 0;
+              "aimee: warning: ran out of memory building an ingest batch; some files in "
+              "'%s' were not pushed\n",
+              abs_root);
+   printf("ingested %d file(s) from %s (%d batch%s)%s\n", s.pushed, abs_root, s.batches,
+          s.batches == 1 ? "" : "es", (s.failed || s.oom) ? " — some batches failed" : "");
+   return (s.failed || s.oom) ? 1 : 0;
 }
 
 int cli_workspace_add_remote(const char *path)

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -37,9 +37,14 @@ static int code_dir_skip(const char *name)
    return 0;
 }
 
-/* Walk root/rel recursively, appending {"rel_path","content"} entries to
- * files_arr. Stops at CODE_COLLECT_MAX_FILES. */
-static void code_collect_walk(const char *root, const char *rel, cJSON *files_arr, int *count)
+/* Walk root/rel recursively, invoking cb(rel_path, content, ctx) for each
+ * indexable file. There is deliberately no file-count cap: the tree shape is
+ * bounded by the directory skips and per-file size/extension/binary filters
+ * above, and callers that need to bound a single network request stream the
+ * files into byte-sized batches rather than relying on a fixed file count.
+ * Stops early (returning 1) if cb returns non-zero. */
+static int code_collect_walk(const char *root, const char *rel, code_collect_file_cb cb, void *ctx,
+                             int *count)
 {
    char path[4096];
    if (rel && rel[0])
@@ -49,10 +54,11 @@ static void code_collect_walk(const char *root, const char *rel, cJSON *files_ar
 
    DIR *dir = opendir(path);
    if (!dir)
-      return;
+      return 0;
 
+   int stop = 0;
    struct dirent *ent;
-   while (*count < CODE_COLLECT_MAX_FILES && (ent = readdir(dir)) != NULL)
+   while (!stop && (ent = readdir(dir)) != NULL)
    {
       if (ent->d_name[0] == '.' &&
           (ent->d_name[1] == '\0' || (ent->d_name[1] == '.' && ent->d_name[2] == '\0')))
@@ -74,7 +80,7 @@ static void code_collect_walk(const char *root, const char *rel, cJSON *files_ar
       if (S_ISDIR(st.st_mode))
       {
          if (!code_dir_skip(ent->d_name))
-            code_collect_walk(root, rel_child, files_arr, count);
+            stop = code_collect_walk(root, rel_child, cb, ctx, count);
       }
       else if (S_ISREG(st.st_mode))
       {
@@ -113,30 +119,56 @@ static void code_collect_walk(const char *root, const char *rel, cJSON *files_ar
             continue;
          }
 
-         cJSON *entry = cJSON_CreateObject();
-         if (entry)
-         {
-            cJSON_AddStringToObject(entry, "rel_path", rel_child);
-            cJSON_AddStringToObject(entry, "content", buf);
-            cJSON_AddItemToArray(files_arr, entry);
+         if (cb(rel_child, buf, ctx) != 0)
+            stop = 1;
+         else
             (*count)++;
-         }
          free(buf);
       }
    }
    closedir(dir);
+   return stop;
+}
+
+int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx)
+{
+   if (!root || !root[0] || !cb)
+      return 0;
+   int count = 0;
+   code_collect_walk(root, NULL, cb, ctx, &count);
+   return count;
+}
+
+/* Array-append callback: collect every file into a cJSON array (no cap). Used by
+ * the server-side local scan, which pushes the result in a single request. */
+static int code_collect_append_cb(const char *rel_path, const char *content, void *ctx)
+{
+   cJSON *files_arr = (cJSON *)ctx;
+   cJSON *entry = cJSON_CreateObject();
+   if (!entry)
+      return 0; /* skip this file, keep walking */
+   cJSON_AddStringToObject(entry, "rel_path", rel_path);
+   cJSON_AddStringToObject(entry, "content", content);
+   cJSON_AddItemToArray(files_arr, entry);
+   return 0;
 }
 
 int code_collect_files(const char *root, cJSON *files_arr)
 {
    if (!root || !root[0] || !files_arr)
       return 0;
-   int count = 0;
-   code_collect_walk(root, NULL, files_arr, &count);
-   return count;
+   return code_collect_files_cb(root, code_collect_append_cb, files_arr);
 }
 
 #else /* !AIMEE_POSIX */
+
+int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx)
+{
+   (void)root;
+   (void)cb;
+   (void)ctx;
+   return 0;
+}
 
 int code_collect_files(const char *root, cJSON *files_arr)
 {

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -13,14 +13,28 @@
 
 #include "cJSON.h"
 
-/* Upper bounds that keep a single push request sane. */
-#define CODE_COLLECT_MAX_FILES      4096
+/* Per-file size bound: skip anything larger so a single file can't blow up a
+ * batch. There is intentionally NO cap on the number of files collected — the
+ * tree is bounded by the directory skips and per-file filters, and callers that
+ * must keep a single network request small stream the files into byte-sized
+ * batches (code_collect_files_cb) rather than truncating at a file count. */
 #define CODE_COLLECT_MAX_FILE_BYTES (256 * 1024)
 
-/* Recursively walk `root`, appending one {"rel_path","content"} object per
- * indexable file to `files_arr`. Skips VCS/build/hidden directories and binary
- * or oversized files. Best-effort: per-file errors are silently skipped.
- * Returns the number of files appended (clamped at CODE_COLLECT_MAX_FILES). */
+/* Streaming collector: recursively walk `root` and invoke `cb` once per
+ * indexable, non-binary, non-oversized file with its project-relative path and
+ * NUL-terminated content (both owned by the walker — copy what you keep). Skips
+ * VCS/build/hidden directories. Best-effort: per-file errors are silently
+ * skipped. `cb` returns 0 to continue or non-zero to stop the walk early.
+ * Returns the number of files for which `cb` was invoked and returned 0. This
+ * is the no-limit path: it lets a caller flush batches as it walks so an
+ * arbitrarily large tree never has to sit in memory at once. */
+typedef int (*code_collect_file_cb)(const char *rel_path, const char *content, void *ctx);
+int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx);
+
+/* Convenience wrapper over code_collect_files_cb that appends one
+ * {"rel_path","content"} object per file to `files_arr`. Collects the whole
+ * tree (no file-count cap); use when the caller pushes the result in one shot
+ * and the tree is known-small. Returns the number of files appended. */
 int code_collect_files(const char *root, cJSON *files_arr);
 
 #endif /* CODE_COLLECT_H */


### PR DESCRIPTION
Promote to main: remove the 4096-file ingest cap (#199).

The thin-client workspace push now streams files into byte-bounded batches instead of collecting the whole tree into one capped array, so `aimee workspace add` / `index scan` ingest an arbitrarily large workspace in full (no file-count limit), with peak memory ~one batch. Noise excludes and per-file filters unchanged.

CI green on testing (#199): build, unit-tests, lint, build-integrity, e2e-docker, macos/windows builds, init-migrate-service-test, memory-retrieval-eval, bench-check.
