### PR TITLE
Promote: ingest→embed→rerank/curate pipeline default-on

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -422,13 +422,14 @@ static void config_set_defaults(config_t *cfg)
     * Must match the schema vector(N) columns and the embedder model. */
    cfg->embedding_dim = 1024;
    /* The cross-encoder rerank stage (ettin-reranker-400m-v1, served by the
-    * embedder service /rerank, client scripts/rerank-remote.py) is wired and
-    * shipped but stays default-off — it is an unvalidated quality/latency
-    * tradeoff (per-query top-K cross-encoder pass), so it follows the
-    * rollout-readiness discipline (validate, then flip). Enable it with:
-    *   aimee config set memory_rerank_enabled 1
-    *   aimee config set memory_rerank_command "python3 /opt/aimee/scripts/rerank-remote.py"
-    * It degrades safely to hybrid ordering if the reranker is absent or errors. */
+    * embedder service /rerank, client scripts/rerank-remote.py) is the third
+    * pipeline stage after the 0.6B embedder, and is default-ON: every retrieval
+    * runs a top-K cross-encoder pass over the dense/lexical candidates. It
+    * degrades safely to plain hybrid ordering if the reranker service is absent
+    * or errors, so default-on is safe even without the embedder container. */
+   cfg->memory_rerank_enabled = 1;
+   snprintf(cfg->memory_rerank_command, sizeof(cfg->memory_rerank_command), "%s",
+            "python3 /opt/aimee/scripts/rerank-remote.py");
    cfg->memory_routing_enabled = 1;
    /* Default-on to preserve behavior: profile-card refresh ran ungated in the
     * maintenance REPLAY pass before the enable-gate was wired. Maintenance is

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -23,19 +23,24 @@
 
 void config_kb_curator_defaults(config_t *cfg)
 {
-   cfg->kb_curator_extract_docs_enabled = 0;
+   /* The deep-curator (larger LLM) pipeline is default-ON: it drains gradually
+    * in the background (rate-limited by kb_curator_max_jobs_per_hour) and refines
+    * what the 0.6B embedder already indexed. Every stage degrades to a no-op when
+    * its prerequisite (a configured curator/judge/synthesize command, or upstream
+    * curator rows) is absent, so default-on is safe on a bare deploy. */
+   cfg->kb_curator_extract_docs_enabled = 1;
    cfg->kb_curator_extract_prompt_version[0] = '\0';
    cfg->kb_curator_embed_model_version[0] = '\0';
    cfg->kb_curator_invalidation_notify_socket[0] = '\0';
-   cfg->kb_curator_extract_code_enabled = 0;
-   cfg->kb_curator_resolve_entities_enabled = 0;
-   cfg->kb_curator_index_narrative_enabled = 0;
-   cfg->kb_curator_index_claims_enabled = 0;
-   cfg->kb_curator_detect_contradictions_enabled = 0;
-   cfg->kb_curator_index_code_unit_enabled = 0;
-   cfg->kb_curator_link_artifacts_enabled = 0;
-   cfg->kb_curator_synthesize_enabled = 0;
-   cfg->kb_curator_promote_entity_enabled = 0;
+   cfg->kb_curator_extract_code_enabled = 1;
+   cfg->kb_curator_resolve_entities_enabled = 1;
+   cfg->kb_curator_index_narrative_enabled = 1;
+   cfg->kb_curator_index_claims_enabled = 1;
+   cfg->kb_curator_detect_contradictions_enabled = 1;
+   cfg->kb_curator_index_code_unit_enabled = 1;
+   cfg->kb_curator_link_artifacts_enabled = 1;
+   cfg->kb_curator_synthesize_enabled = 1;
+   cfg->kb_curator_promote_entity_enabled = 1;
    cfg->kb_curator_promote_min_sources = 3;
    cfg->kb_curator_extract_command[0] = '\0';
    cfg->kb_curator_judge_command[0] = '\0';

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -581,13 +581,14 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
       return 503;
    }
 
-   if (!pushed_files)
-   {
-      config_t cfg;
-      config_load(&cfg);
-      if (cfg.kb_curator_extract_code_enabled)
-         kb_curator_queue_code_units_for_project(project, root_path);
-   }
+   /* Queue code units for the deep curator on BOTH paths — a local scan and a
+    * thin-client push (which sends `files`). The queue reads code units from DB2
+    * by project name (it ignores root_path, so the server need not see the
+    * client's filesystem) and self-gates on kb_curator_extract_code_enabled.
+    * Previously this ran only for `!pushed_files`, so workspaces ingested from a
+    * thin client were never queued for curation. The 0.6B embed pass is driven
+    * separately by the curator drain. */
+   kb_curator_queue_code_units_for_project(project, root_path);
 
    snprintf(out_buf, (size_t)out_cap,
             "{\"status\":\"ok\",\"skipped\":false,\"project\":\"%s\",\"files\":%d,"

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -21,6 +21,8 @@
 #include "kb_curator_promote.h"
 #include "kb_evidence_embed.h"
 #include "kb_learning_synth.h"
+#include "kb_service_code_embed.h"
+#include "index.h"
 #include "aimee.h"
 #include "config.h"
 #include "kb_background.h"
@@ -96,6 +98,32 @@ static void *drain_thread_main(void *arg)
          int n = kb_evidence_embed_drain(cfg.kb_evidence_embed_batch, embed_cmd);
          if (n > 0)
             aimee_log(LOG_DEBUG, "kb.evidence.embed", "drained %d evidence op(s)", n);
+      }
+
+      /* Code-vector embed drain — pipeline stage 2 (the 0.6B embedder), runs
+       * every poll. Indexing (the structural scan) populates the `files` table
+       * for everything ingested — code AND docs/config; this embeds those rows
+       * into code_embeddings via the configured embedder, incrementally: the
+       * "changed_files" scope skips any file whose content_hash already matches,
+       * so a poll with nothing new is cheap, and a fresh 23k-file ingest catches
+       * up over a handful of polls (max_points caps each project per poll). It is
+       * gated only on an embedder being configured — no external LLM, no curator
+       * gate — so embeddings appear automatically right after ingest. */
+      if (cfg.embedding_command[0])
+      {
+         project_info_t projects[128];
+         int np = index_list_projects(projects, 128);
+         int total = 0;
+         for (int i = 0; i < np; i++)
+         {
+            kb_code_embed_result_t r;
+            memset(&r, 0, sizeof(r));
+            if (kb_code_embed_refresh(projects[i].name, "changed_files", NULL, 0, 0, 0, 0, &r) == 0)
+               total += (int)r.embedded;
+         }
+         if (total > 0)
+            aimee_log(LOG_DEBUG, "kb.code.embed",
+                      "embedded %d code/doc vector(s) across %d project(s)", total, np);
       }
 
       /* Candidate-generation synthesis drain — the heavy LLM pass, on the

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1339,8 +1339,10 @@ int main(void)
       memset(&cfg, 0, sizeof(cfg));
       int rc2 = config_load(&cfg);
       assert(rc2 == 0);
-      assert(cfg.memory_rerank_enabled == 0);
-      assert(cfg.memory_rerank_command[0] == '\0');
+      /* Reranking (pipeline stage 3) is default-ON with the rerank-remote.py
+       * command; it degrades to plain hybrid ordering if the service is absent. */
+      assert(cfg.memory_rerank_enabled == 1);
+      assert(strcmp(cfg.memory_rerank_command, "python3 /opt/aimee/scripts/rerank-remote.py") == 0);
       assert(cfg.memory_rerank_top_k == 0);
       assert(cfg.memory_rerank_mix == 0.0);
       assert(cfg.memory_query_expansion_mode[0] == '\0');

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -14,7 +14,29 @@
 
 #include "db2_test_shim.h"
 #include "cJSON.h"
+#include "config.h"
 #include "kb/kb_curator_grounding.h"
+
+/* The deep-curator code-extract gate is now ON by compiled default, but the
+ * gate-off tests below need it OFF. Point AIMEE_HOME at an isolated temp config
+ * with the extract gates disabled so the real config_load() the queue functions
+ * call reports the gate off deterministically (and the run never touches the
+ * developer's real ~/.config/aimee). */
+static void test_force_curator_gate_off(void)
+{
+   static char dir[] = "/tmp/aimee-curtest-XXXXXX";
+   static int done = 0;
+   if (done)
+      return;
+   done = 1;
+   if (mkdtemp(dir))
+      setenv("AIMEE_HOME", dir, 1);
+   config_t cfg;
+   config_load(&cfg);
+   cfg.kb_curator_extract_code_enabled = 0;
+   cfg.kb_curator_extract_docs_enabled = 0;
+   config_save(&cfg);
+}
 
 /* Forward declarations (headers live in src/, not src/headers/). */
 typedef struct
@@ -282,6 +304,7 @@ int main(void)
 {
    printf("curator_code_unit:\n");
 
+   test_force_curator_gate_off();
    test_queue_code_unit_gate_off();
    test_queue_code_units_for_project_gate_off();
    test_queue_null_args();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -191,7 +191,10 @@ static void test_code_scan_pushed_files_ok(void)
    assert(strcmp(g_code_scan_file_rel, "src/a.c") == 0);
    assert(strstr(g_code_scan_file_content, "pushed") != NULL);
    assert(g_code_scan_files_force == 1);
-   assert(g_curator_code_queued == 0);
+   /* The push path now queues code units for the curator just like a local scan
+    * (the queue reads from DB2 by project name and self-gates on the curator
+    * flag), so with the stubbed config_load reporting the gate on, it enqueues. */
+   assert(g_curator_code_queued == 1);
 }
 
 static void test_code_scan_pushed_files_rejects_invalid_item(void)


### PR DESCRIPTION
Promote to main: wire the ingest→embed→rerank/curate pipeline default-on (#201).

The 0.6B embedder now embeds every indexed file (code + docs/config) into code_embeddings automatically via a curator-drain step right after ingest; the cross-encoder reranker is default-on (degrades safely); the deep curator is default-on and drains gradually in the background, now enqueued on the thin-client push path too. A fresh ingest previously produced 0 vectors.

CI green on testing (#201): build, unit-tests, lint, build-integrity, e2e-docker, macos/windows builds, init-migrate-service-test, memory-retrieval-eval, bench-check.
