### PR TITLE
Remove kb build; ingest KB docs automatically during workspace ingest

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -231,7 +231,6 @@ static const struct
     {"wm", "list", "wm.list", NULL, "entries", 0},
     {"primary", NULL, "primary.set", NULL, NULL, 0},
     {"kb", "search", "kb.search", NULL, NULL, 60000},
-    {"kb", "build", "kb.build", NULL, NULL, 900000},
     {"kb", "update", "kb.update", NULL, NULL, 900000},
     {"kb", "docs push", "kb.docs.push", NULL, NULL, 900000},
     {"kb", "ingest", "kb.ingest", NULL, NULL, 30000},

--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -76,83 +76,11 @@ static int kb_async_pending_from_resp(cJSON *resp)
    return (int)pending->valuedouble;
 }
 
-static void kb_cmd_build(app_ctx_t *ctx, int argc, char **argv)
-{
-   static const char *bool_flags[] = {"force", NULL};
-   opt_parsed_t opts;
-   opt_parse(argc, argv, bool_flags, &opts);
-
-   const char *path = opt_get(&opts, "path");
-   const char *project = opt_get(&opts, "project");
-   int force = opt_get_flag(&opts, "force");
-
-   /* Resolve path */
-   char root[MAX_PATH_LEN];
-   if (path && path[0])
-      snprintf(root, sizeof(root), "%s", path);
-   else if (!getcwd(root, sizeof(root)))
-      root[0] = '\0';
-
-   /* Load config for embedding command */
-   config_t cfg;
-   config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
-
-   char proj[256];
-   kb_resolve_project(project, root, proj, sizeof(proj));
-
-   if (ctx->json_output)
-   {
-      /* JSON mode: suppress status messages */
-   }
-   else
-   {
-      printf("Building KB for project '%s' from %s...\n", proj, root);
-      printf("  embedding: %s\n", embed_cmd);
-   }
-
-   char *resp_json = kb_client_build_json(root, proj, embed_cmd, force);
-   cJSON *resp = resp_json ? cJSON_Parse(resp_json) : NULL;
-   free(resp_json);
-
-   cJSON *status = resp ? cJSON_GetObjectItemCaseSensitive(resp, "status") : NULL;
-   int ok = cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0;
-   if (!ok)
-   {
-      const char *msg = "kb build failed";
-      if (resp)
-      {
-         cJSON *m = cJSON_GetObjectItemCaseSensitive(resp, "message");
-         if (cJSON_IsString(m) && m->valuestring[0])
-            msg = m->valuestring;
-      }
-      if (!ctx->json_output)
-         fprintf(stderr, "KB build failed: %s\n", msg);
-      else
-         printf("{\"status\":\"error\",\"message\":\"%s\"}\n", msg);
-      cJSON_Delete(resp);
-      return;
-   }
-
-   kb_stats_t stats;
-   kb_extract_stats(resp, &stats);
-
-   if (ctx->json_output)
-   {
-      printf("{\"status\":\"ok\",\"project\":\"%s\","
-             "\"files_indexed\":%d,\"chunks_added\":%d,\"embeddings\":%d}\n",
-             proj, stats.files_indexed, stats.chunks_added, stats.embeddings_added);
-   }
-   else
-   {
-      printf("Done.\n");
-      print_stats(&stats);
-      int pending = kb_async_pending_from_resp(resp);
-      if (pending > 0)
-         printf("  async queue: %d pending job(s)\n", pending);
-   }
-   cJSON_Delete(resp);
-}
+/* `kb build` was removed: knowledge-base document ingestion is no longer a
+ * separate command. Prose/doc files are now chunked + embedded into the KB-docs
+ * layer automatically during workspace ingestion (the curator drain's
+ * kb_doc_refresh pass, reading content from DB2), which also works on the thin-
+ * client/remote deploy where the server cannot read the project from disk. */
 
 /* ------------------------------------------------------------------ */
 /* kb update                                                            */
@@ -984,7 +912,6 @@ static void kb_cmd_curator_profile(app_ctx_t *ctx, int argc, char **argv)
 }
 
 static const subcmd_t kb_subcmds[] = {
-    {"build", "Build KB from project docs (--path DIR, --project NAME, --force)", kb_cmd_build},
     {"repair", "Rebuild KB vector state from project docs (--path DIR, --project NAME)",
      kb_cmd_repair},
     {"update", "Incrementally update KB (only re-indexes changed files)", kb_cmd_update},

--- a/src/headers/kb.h
+++ b/src/headers/kb.h
@@ -16,7 +16,32 @@
 /* Chunking defaults */
 #define KB_DEFAULT_CHUNK_SIZE    512 /* approximate tokens per chunk */
 #define KB_DEFAULT_CHUNK_OVERLAP 64  /* token overlap between adjacent chunks */
-#define KB_DEFAULT_MAX_RESULTS   3
+
+/* Internal: text chunking + KB doc-ingest helpers, shared between kb.c and
+ * kb_ingest_workers.c (where the document-ingest entry points live). Not part of
+ * the stable KB API. */
+#include <stdio.h>
+#define MAX_CHUNKS_PER_FILE 256
+#define MAX_HEADING_LEN     256
+#define CHUNK_BUF_SIZE      (KB_DEFAULT_CHUNK_SIZE * 8)
+
+typedef struct
+{
+   char heading_path[MAX_HEADING_LEN]; /* e.g. "## Section > ### Subsection" */
+   char content[CHUNK_BUF_SIZE];
+   int line_start;
+   int line_end;
+   int token_count;
+} text_chunk_t;
+
+int chunk_stream(FILE *f, text_chunk_t *chunks, int max_chunks);
+const char *kb_effective_embedding_cmd(const char *embedding_cmd);
+int accept_generated_embedding(int64_t doc_id, const float *vec, int dim);
+int sync_vector_embedding(int64_t doc_id, const float *vec, int dim);
+void delete_file_chunks(const char *project, const char *file_path);
+void kb_async_make_embed_text(const char *heading_path, const char *content, char *out,
+                              size_t out_len);
+#define KB_DEFAULT_MAX_RESULTS 3
 
 /* kb_stats_t: summary returned by build/update operations */
 typedef struct
@@ -55,6 +80,19 @@ int kb_build(const char *root_path, const char *project, const char *embedding_c
 /* Incrementally update the knowledge base: re-index changed files, remove deleted ones. */
 int kb_update(const char *root_path, const char *project, const char *embedding_cmd,
               kb_stats_t *stats_out);
+
+/* General document-ingest entry point: chunk one document's text into kb_documents
+ * and embed each chunk under `project`, keyed by `source_path`. Source-agnostic
+ * (workspace files via DB2 file_contents today; PDFs-as-text etc. in future).
+ * Skips unchanged content. Returns chunks embedded, or -1 on error. */
+int kb_ingest_doc_content(const char *project, const char *source_path, const char *content,
+                          size_t len, const char *embedding_cmd);
+
+/* Background driver: ingest indexed prose/doc files for `project` that aren't in
+ * the KB-docs layer yet, sourcing content from DB2 file_contents (no disk).
+ * Bounded by `max_docs`. Returns chunks embedded. Replaces the old `kb build`
+ * command — doc ingestion now happens automatically during workspace ingest. */
+int kb_doc_refresh(const char *project, const char *embedding_cmd, int max_docs);
 
 /* Search the knowledge base.
  *

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -4,6 +4,7 @@
 #include "aimee.h"
 #if !defined(AIMEE_DB2_DISABLED)
 #include "db2/kb_payload.h"
+#include "db2/db_postgres.h"
 #include "db2/kb_service_backend.h"
 #include "db2/memory_query.h"
 #include "db2/vector_index_ops.h"
@@ -22,6 +23,7 @@
 #include "kb_fusion.h"
 #include "kb_neardup.h"
 #include "memory.h"
+#include "kb_doc_hash.h"
 #include "log.h"
 #include "dstr.h"
 #include "lifecycle.h"
@@ -282,7 +284,7 @@ static int should_index_file(const char *rel_path, char includes[][KB_GLOB_MAX],
 /* File walking                                                         */
 /* ------------------------------------------------------------------ */
 
-#define MAX_FILES 4096
+#define MAX_FILES        4096
 
 typedef struct
 {
@@ -361,19 +363,9 @@ static int collect_files(const char *root, const char *rel, char includes[][KB_G
 /* Markdown chunking                                                    */
 /* ------------------------------------------------------------------ */
 
-#define MAX_CHUNKS_PER_FILE 256
-#define MAX_HEADING_LEN     256
-#define CHUNK_BUF_SIZE      (KB_DEFAULT_CHUNK_SIZE * 8) /* ~4KB */
-#define KB_MINHASH_LIMIT    64
-
-typedef struct
-{
-   char heading_path[MAX_HEADING_LEN]; /* e.g. "## Section > ### Subsection" */
-   char content[CHUNK_BUF_SIZE];
-   int line_start;
-   int line_end;
-   int token_count;
-} text_chunk_t;
+/* MAX_CHUNKS_PER_FILE / MAX_HEADING_LEN / CHUNK_BUF_SIZE and text_chunk_t now
+ * live in kb.h (shared with kb_ingest_workers.c's document-ingest entry points). */
+#define KB_MINHASH_LIMIT 64
 
 /* Detect markdown heading level: returns 1-6 or 0 if not a heading. */
 static int heading_level(const char *line)
@@ -461,12 +453,11 @@ static int flush_chunk(text_chunk_t *chunks, int n_chunks, int max_chunks, const
 }
 
 /* Read a file and split it into chunks. Returns number of chunks produced. */
-static int chunk_file(const char *path, text_chunk_t *chunks, int max_chunks)
+/* Chunk a heading-structured text stream (markdown/prose) into `chunks`. The
+ * caller owns `f` (so the same logic serves both a file on disk and an
+ * in-memory document). */
+int chunk_stream(FILE *f, text_chunk_t *chunks, int max_chunks)
 {
-   FILE *f = fopen(path, "r");
-   if (!f)
-      return 0;
-
    char heading_stack[3][MAX_HEADING_LEN];
    memset(heading_stack, 0, sizeof(heading_stack));
    char heading_path[MAX_HEADING_LEN] = "";
@@ -545,7 +536,6 @@ static int chunk_file(const char *path, text_chunk_t *chunks, int max_chunks)
          }
       }
    }
-   fclose(f);
 
    /* Flush remaining buffer */
    if (buf_tokens > 0)
@@ -553,6 +543,16 @@ static int chunk_file(const char *path, text_chunk_t *chunks, int max_chunks)
                              chunk_line_start, line_num);
 
    return n_chunks < max_chunks ? n_chunks : max_chunks;
+}
+
+static int chunk_file(const char *path, text_chunk_t *chunks, int max_chunks)
+{
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return 0;
+   int n = chunk_stream(f, chunks, max_chunks);
+   fclose(f);
+   return n;
 }
 
 /* ------------------------------------------------------------------ */
@@ -569,7 +569,7 @@ static int chunk_file(const char *path, text_chunk_t *chunks, int max_chunks)
 /* Forward an embedding to pgvector for runtime dense search. The
  * conn parameter is unused — kept gone from the signature to mirror the
  * kb_service_backend equivalent. */
-static int sync_vector_embedding(int64_t doc_id, const float *vec, int dim)
+int sync_vector_embedding(int64_t doc_id, const float *vec, int dim)
 {
    if (!vec || dim <= 0)
       return 0;
@@ -587,14 +587,14 @@ static int sync_vector_embedding(int64_t doc_id, const float *vec, int dim)
    return rc;
 }
 
-static const char *kb_effective_embedding_cmd(const char *embedding_cmd)
+const char *kb_effective_embedding_cmd(const char *embedding_cmd)
 {
    return (embedding_cmd && embedding_cmd[0]) ? embedding_cmd : "builtin";
 }
 
 /* pgvector owns vector bytes. This hook exists to keep the sync/async call
  * shape explicit while the actual pgvector upsert is batched below. */
-static int accept_generated_embedding(int64_t doc_id, const float *vec, int dim)
+int accept_generated_embedding(int64_t doc_id, const float *vec, int dim)
 {
    (void)doc_id;
    (void)vec;
@@ -607,7 +607,7 @@ static int accept_generated_embedding(int64_t doc_id, const float *vec, int dim)
  * Caps at 1024 ids per call; a single source file producing >1024
  * chunks is far past the chunker's MAX_CHUNKS_PER_FILE (256), so the
  * cap is comfortably above any realistic value. */
-static void delete_file_chunks(const char *project, const char *file_path)
+void delete_file_chunks(const char *project, const char *file_path)
 {
    /* Invalidate curator artifacts derived from this file before its chunks go
     * away; the post-ingest queue then re-extracts the (changed) source, and a
@@ -630,8 +630,8 @@ static void delete_file_chunks(const char *project, const char *file_path)
 /* Async embedding queue                                                */
 /* ------------------------------------------------------------------ */
 
-static void kb_async_make_embed_text(const char *heading_path, const char *content, char *out,
-                                     size_t out_len)
+void kb_async_make_embed_text(const char *heading_path, const char *content, char *out,
+                              size_t out_len)
 {
    if (heading_path && heading_path[0])
       snprintf(out, out_len, "%s\n%s", heading_path, content ? content : "");

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -22,6 +22,7 @@
 #include "kb_evidence_embed.h"
 #include "kb_learning_synth.h"
 #include "kb_service_code_embed.h"
+#include "kb.h"
 #include "index.h"
 #include "aimee.h"
 #include "config.h"
@@ -124,6 +125,27 @@ static void *drain_thread_main(void *arg)
          if (total > 0)
             aimee_log(LOG_DEBUG, "kb.code.embed",
                       "embedded %d code/doc vector(s) across %d project(s)", total, np);
+      }
+
+      /* KB-docs ingest drain — the in-ingest replacement for `kb build`. For
+       * each indexed project, chunk + embed prose/doc files (markdown, rst, txt,
+       * …) into the curated kb_documents layer, reading content from DB2
+       * file_contents (no disk). Bounded per poll; backfills then idles cheaply.
+       * Same embedder gate as the code drain. */
+      if (cfg.embedding_command[0])
+      {
+         project_info_t projects[128];
+         int np = index_list_projects(projects, 128);
+         int total = 0;
+         for (int i = 0; i < np; i++)
+         {
+            int e = kb_doc_refresh(projects[i].name, cfg.embedding_command, 200);
+            if (e > 0)
+               total += e;
+         }
+         if (total > 0)
+            aimee_log(LOG_DEBUG, "kb.docs.ingest", "ingested %d doc chunk(s) across %d project(s)",
+                      total, np);
       }
 
       /* Candidate-generation synthesis drain — the heavy LLM pass, on the

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -27,8 +27,12 @@
 #include "db2/canonical_index.h"
 #include "db2/kb_runtime_state.h"
 #include "db2/kb_service_backend.h"
+#include "db2/kb_payload.h"
+#include "db2/db_postgres.h"
 #include "db2/lifecycle.h"
 #include "db2/pgvec_kb_service.h"
+#include "kb_doc_hash.h"
+#include "memory.h"
 
 #include <pthread.h>
 #include <stdint.h>
@@ -438,4 +442,154 @@ void kb_ingest_workers_stop(kb_service_ctx_t *ctx)
       pthread_join(ctx->bg_watch_thread, NULL);
       ctx->bg_watch_active = 0;
    }
+}
+
+/* ---- KB document ingestion (the in-ingest replacement for `kb build`) ---- */
+
+/* Chunk an in-memory document — used when the content lives in DB2 (pushed by a
+ * thin client) or comes from a non-file source (e.g. a PDF converted to text),
+ * rather than being read from local disk. Reuses kb.c's heading-aware chunker. */
+static int chunk_content(const char *content, size_t len, text_chunk_t *chunks, int max_chunks)
+{
+   if (!content)
+      return 0;
+   FILE *f = fmemopen((void *)content, len, "r");
+   if (!f)
+      return 0;
+   int n = chunk_stream(f, chunks, max_chunks);
+   fclose(f);
+   return n;
+}
+
+/* General document-ingest entry point. Chunk one document's text `content` into
+ * kb_documents and embed each chunk into the KB vector store under `project`,
+ * keyed by `source_path`. Source-agnostic by design: the workspace doc-refresh
+ * below feeds it from DB2 file_contents today, and future sources (e.g. a PDF
+ * converted to text) call this same function. Skips work when the content hash
+ * is unchanged. Returns chunks embedded, or -1 on error. */
+int kb_ingest_doc_content(const char *project, const char *source_path, const char *content,
+                          size_t len, const char *embedding_cmd)
+{
+   if (!project || !project[0] || !source_path || !source_path[0] || !content ||
+       !db2_is_initialized())
+      return -1;
+   const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
+
+   char hash[KB_DOC_HASH_HEX_LEN + 1];
+   kb_doc_content_hash(content, (int)len, hash);
+
+   char stored[KB_DOC_HASH_HEX_LEN + 1] = "";
+   if (db2_kb_documents_get_stored_hash(project, source_path, stored, sizeof(stored)) == 1 &&
+       strcmp(stored, hash) == 0)
+      return 0; /* unchanged — already ingested */
+
+   delete_file_chunks(project, source_path);
+
+   text_chunk_t *chunks = malloc(MAX_CHUNKS_PER_FILE * sizeof(text_chunk_t));
+   if (!chunks)
+      return -1;
+   int n_chunks = chunk_content(content, len, chunks, MAX_CHUNKS_PER_FILE);
+
+   int embedded = 0;
+   int64_t prev_doc_id = 0;
+   for (int ci = 0; ci < n_chunks; ci++)
+   {
+      int64_t doc_id = db2_kb_documents_insert_chunk(
+          project, source_path, hash, ci, chunks[ci].heading_path, chunks[ci].line_start,
+          chunks[ci].line_end, chunks[ci].content, chunks[ci].token_count);
+      if (doc_id < 0)
+         continue;
+      db2_kb_documents_link_neighbours(doc_id, prev_doc_id);
+      prev_doc_id = doc_id;
+      if (!effective_cmd[0])
+         continue;
+
+      char embed_text[4096];
+      kb_async_make_embed_text(chunks[ci].heading_path, chunks[ci].content, embed_text,
+                               sizeof(embed_text));
+      float vec[EMBED_MAX_DIM];
+      int dim = memory_embed_text(embed_text, effective_cmd, vec, EMBED_MAX_DIM);
+      if (dim > 0)
+      {
+         accept_generated_embedding(doc_id, vec, dim);
+         sync_vector_embedding(doc_id, vec, dim);
+         embedded++;
+      }
+   }
+   free(chunks);
+   db2_kb_file_index_upsert(project, source_path, hash, NULL);
+   return embedded;
+}
+
+/* Background driver (the in-ingest replacement for the old `kb build` command):
+ * ingest indexed prose/doc files for `project` that aren't in the KB-docs layer
+ * yet, reading content straight from DB2 file_contents (no disk — works for the
+ * thin-client push deploy). Bounded by `max_docs` per call so the curator drain
+ * makes steady progress without monopolising. Returns chunks embedded. */
+int kb_doc_refresh(const char *project, const char *embedding_cmd, int max_docs)
+{
+   if (!project || !project[0] || !db2_is_initialized())
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   if (max_docs <= 0)
+      max_docs = 200;
+
+   /* Prose/doc files only (code is served by the code-embedding layer). Pull
+    * only files with no chunks in kb_documents yet, bounded. */
+   static const char *sql =
+       "SELECT f.path, fc.content FROM files f"
+       " JOIN file_contents fc ON fc.file_id = f.id"
+       " JOIN projects p ON f.project_id = p.id"
+       " WHERE p.name = ?1"
+       "   AND (f.path LIKE '%.md' OR f.path LIKE '%.markdown' OR f.path LIKE '%.rst'"
+       "        OR f.path LIKE '%.txt' OR f.path LIKE '%.adoc' OR f.path LIKE '%.org')"
+       "   AND NOT EXISTS (SELECT 1 FROM kb_documents kd"
+       "                   WHERE kd.project = p.name AND kd.file_path = f.path)"
+       " LIMIT ?2";
+
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_int(st, "?2", max_docs);
+
+   /* Collect rows first: kb_ingest_doc_content issues its own statements, and
+    * the pg layer allows only one active statement on a connection. */
+   typedef struct
+   {
+      char path[1024];
+      char *content;
+   } doc_row_t;
+   doc_row_t *rows = calloc((size_t)max_docs, sizeof(doc_row_t));
+   int n = 0;
+   if (rows)
+   {
+      while (n < max_docs && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         const char *path = aimee_pg_column_text(st, 0);
+         const char *body = aimee_pg_column_text(st, 1);
+         if (!path || !body)
+            continue;
+         snprintf(rows[n].path, sizeof(rows[n].path), "%s", path);
+         rows[n].content = strdup(body);
+         if (rows[n].content)
+            n++;
+      }
+   }
+   aimee_pg_finalize(st);
+
+   int embedded = 0;
+   for (int i = 0; i < n; i++)
+   {
+      int e = kb_ingest_doc_content(project, rows[i].path, rows[i].content, strlen(rows[i].content),
+                                    embedding_cmd);
+      if (e > 0)
+         embedded += e;
+      free(rows[i].content);
+   }
+   free(rows);
+   return embedded;
 }


### PR DESCRIPTION
## Summary

`kb build` was a separate, disk-reading command — it couldn't work on the thin-client/remote deploy (the server can't see the client's files), and per the request it shouldn't be a separate step at all. This folds its **unique value** — chunked, content-based document passages (`kb_documents`/`kb_embeddings`), which the code-embedding layer does *not* provide — into the normal workspace ingest, and removes the command.

- **`kb_ingest_doc_content()`** — a **source-agnostic** document-ingest entry point: chunk one document's text, embed each chunk with the configured **0.6B** embedder, upsert `kb_documents`/`kb_embeddings`, skip-unchanged by content hash. The workspace doc-refresh feeds it from DB2 `file_contents` today; **future sources (e.g. PDFs converted to text) call the same function.**
- **`chunk_content()`** — content-based chunker via `fmemopen`, reusing the exact heading-aware chunker (extracted as `chunk_stream`), so chunking works on pushed/in-memory content.
- **`kb_doc_refresh()`** — background driver on the curator drain (symmetric with the code-embed drain): ingests indexed prose/doc files not yet in the KB-docs layer, sourcing content from DB2 `file_contents` (no disk). Default-on, bounded per poll. `kb_documents`/`kb_embeddings` now fill **automatically** as workspaces are ingested, including on the remote deploy.
- **Removed `kb build`** — its `kb.build` RPC route + the dead `cmd_kb.c` handler.

The doc-ingest entry points live in `kb_ingest_workers.c`; shared chunk types + a few `kb.c` helpers are exposed via `kb.h` (keeps `kb.c` under the line limit).

## Testing
- `make verify-local` + full `make unit-tests` green (serial build — parallel LTO links flake with an unrelated GCC ICE on this host; affected tests build + pass with `-j1`)
