### PR TITLE
Honor per-agent context_window override in capability routing

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1119,9 +1119,21 @@ static int agent_satisfies_required_caps(const agent_t *ag, unsigned required_ca
    if (required_caps == 0 && min_context <= 0)
       return 1;
 
+   /* An explicit per-agent context_window override (agents.json
+    * `middleware.context_window`, set via `aimee agent --ctx` or auto-detected
+    * by `ag_probe_slots`) is authoritative for the min_context gate, so a model
+    * the capability catalog doesn't know about is a config change rather than a
+    * code change to the registry table. */
+   int override_ctx = ag->middleware.context_window;
+
    model_capability_t caps;
    if (model_capability_get(ag->provider, ag->model, &caps) == 0)
-      return missing_caps == 0 && min_context <= 0;
+   {
+      if (missing_caps != 0)
+         return 0;
+      /* No catalog entry: the override is the only context signal we have. */
+      return min_context <= 0 || (override_ctx > 0 && override_ctx >= min_context);
+   }
 
    if (ag->tools_enabled)
       caps.flags |= MODEL_CAP_TOOLS;
@@ -1129,7 +1141,8 @@ static int agent_satisfies_required_caps(const agent_t *ag, unsigned required_ca
       caps.flags &= ~MODEL_CAP_TOOLS;
    if (required_caps && (caps.flags & required_caps) != required_caps)
       return 0;
-   if (min_context > 0 && caps.context_window > 0 && caps.context_window < min_context)
+   int effective_ctx = override_ctx > 0 ? override_ctx : caps.context_window;
+   if (min_context > 0 && effective_ctx > 0 && effective_ctx < min_context)
       return 0;
    if (caps.deprecated)
       return 0;

--- a/src/server/delegate_routing.c
+++ b/src/server/delegate_routing.c
@@ -98,7 +98,16 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
       }
       if (min_context > 0)
       {
-         if (!have_cap || cap.context_window <= 0 || cap.context_window < min_context)
+         /* Effective context window: prefer the agent's explicit override
+          * (agents.json `middleware.context_window`, set via `aimee agent
+          * --ctx` or auto-detected by `ag_probe_slots`); fall back to the
+          * model capability catalog (models.dev override/cache, then the
+          * built-in heuristic). This keeps onboarding a new model a config or
+          * catalog change rather than a code edit to the registry table. */
+         int effective_ctx = ag->middleware.context_window > 0
+                                 ? ag->middleware.context_window
+                                 : (have_cap ? cap.context_window : 0);
+         if (effective_ctx <= 0 || effective_ctx < min_context)
          {
             ag->enabled = 0;
             continue;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -20,6 +20,7 @@
 #include "platform_test_util.h"
 
 void test_agent_route_with_caps_honors_tools_enabled(void);
+void test_agent_route_with_caps_honors_context_override(void);
 
 /* --- Expose tool functions for testing via redeclaration --- */
 char *tool_bash(const char *command, int timeout_ms);
@@ -1852,6 +1853,7 @@ int main(void)
    test_agent_loop_per_call_timeout();
    test_agent_route_health_filter();
    test_agent_route_with_caps_honors_tools_enabled();
+   test_agent_route_with_caps_honors_context_override();
    test_current_code_only_role_tool_policy();
    test_current_code_only_dispatch_blocks_stale_context_tools();
    test_provider_env_credentials_and_headers();

--- a/src/tests/test_agent_caps.c
+++ b/src/tests/test_agent_caps.c
@@ -39,3 +39,41 @@ void test_agent_route_with_caps_honors_tools_enabled(void)
    cfg.agents[0].tools_enabled = 0;
    assert(agent_route_with_caps(&cfg, "review", &sys_cfg, MODEL_CAP_TOOLS, 0) == NULL);
 }
+
+/* Routing must honor the per-agent context_window override so onboarding a
+ * model the capability catalog doesn't know about is a config change, not a
+ * code change to the registry table. */
+void test_agent_route_with_caps_honors_context_override(void)
+{
+   agent_config_t cfg;
+   config_t sys_cfg;
+
+   memset(&cfg, 0, sizeof(cfg));
+   memset(&sys_cfg, 0, sizeof(sys_cfg));
+   sys_cfg.model_meta_capability_routing = 1;
+
+   cfg.agent_count = 1;
+   strcpy(cfg.default_agent, "small-ctx");
+   strcpy(cfg.agents[0].name, "small-ctx");
+   strcpy(cfg.agents[0].provider, "openai");
+   /* gpt-4's catalog context window is 8192 — below the 50000 requirement. */
+   strcpy(cfg.agents[0].model, "gpt-4");
+   strcpy(cfg.agents[0].roles[0], "review");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].enabled = 1;
+   strcpy(cfg.agents[0].api_key, "test-key");
+
+   /* Catalog says 8192 < 50000 and no override -> dropped by the gate. */
+   assert(agent_route_with_caps(&cfg, "review", &sys_cfg, 0, 50000) == NULL);
+
+   /* An explicit per-agent override supersedes the catalog value and routes,
+    * with no change to the model registry table. */
+   cfg.agents[0].enabled = 1;
+   cfg.agents[0].middleware.context_window = 1000000;
+   assert(agent_route_with_caps(&cfg, "review", &sys_cfg, 0, 50000) == &cfg.agents[0]);
+
+   /* An override below the requirement is still rejected. */
+   cfg.agents[0].enabled = 1;
+   cfg.agents[0].middleware.context_window = 1000;
+   assert(agent_route_with_caps(&cfg, "review", &sys_cfg, 0, 50000) == NULL);
+}


### PR DESCRIPTION
## Problem

Capability routing disqualified an agent whenever the model's context window — derived from the model-capability catalog, ultimately the hardcoded `g_ctx_windows` table — was unknown or below the requested `min_context`, surfacing as:

```
no configured model supports required capabilities (caps=-, min_context=N)
```

This forced a code edit to the registry table to onboard any model the catalog didn't already know (e.g. `mimo-v2.5-pro`), even though the agent already carries an explicit `middleware.context_window` override field (set via `aimee agent --ctx`, in `agents.json`, or auto-detected by `ag_probe_slots`) that routing simply ignored.

## Fix

Both routing paths now compute an **effective** context window that prefers the agent's explicit override and falls back to the capability catalog (models.dev override → cache → builtin heuristic):

- `agent_satisfies_required_caps()` (server/agent_config.c) — used by `agent_route_with_caps`
- `delegate_filter_route_capabilities()` (server/delegate_routing.c)

Onboarding a new model is now a config/catalog change, not a code change to the registry table.

## Test

Adds `test_agent_route_with_caps_honors_context_override` (test_agent_caps.c), covering: a catalog value below the requirement is dropped; an explicit override supersedes it and routes; an override below the requirement is still rejected. `unit-test-agent` suite passes; `-Werror` clean.
