### PR TITLE
WP-A: remove the 4096-char delegate result/prompt cap

### DIFF
--- a/src/cmd_agent_trace.c
+++ b/src/cmd_agent_trace.c
@@ -275,7 +275,7 @@ void cmd_jobs(app_ctx_t *ctx, int argc, char **argv)
       if (db1_init(db1_cfg.db1_path) != 0)
          fatal("jobs list: could not initialize DB1");
       db1_agent_job_t jobs[20];
-      int n = db1_agent_job_list_recent(jobs, 20);
+      int n = db1_agent_job_list_recent(jobs, 20, 0); /* list view omits prompt/result */
       printf("%-6s %-12s %-10s %-6s %-12s %s\n", "ID", "Role", "Status", "Turn", "Agent",
              "Created");
       for (int i = 0; i < n; i++)
@@ -287,6 +287,7 @@ void cmd_jobs(app_ctx_t *ctx, int argc, char **argv)
             snprintf(turn, sizeof(turn), "--");
          printf("%-6d %-12s %-10s %-6s %-12s %s\n", jobs[i].id, jobs[i].role, jobs[i].status, turn,
                 jobs[i].agent_name, jobs[i].created_at);
+         db1_agent_job_free(&jobs[i]);
       }
    }
    else if ((strcmp(argv[0], "status") == 0 || strcmp(argv[0], "show") == 0) && argc >= 2)
@@ -312,6 +313,7 @@ void cmd_jobs(app_ctx_t *ctx, int argc, char **argv)
             printf("Heartbeat: %s\n", job.heartbeat_at);
          printf("Created:   %s\n", job.created_at);
          printf("Updated:   %s\n", job.updated_at);
+         db1_agent_job_free(&job);
       }
       else
       {

--- a/src/db1/agent_jobs.c
+++ b/src/db1/agent_jobs.c
@@ -130,13 +130,36 @@ void db1_agent_job_update(int job_id, const char *status, int cursor_turn, const
 
    char cursor[32];
    snprintf(cursor, sizeof(cursor), "%d", cursor_turn);
+
+   /* Stored-result ceiling: prompt/result are now unbounded heap, so bound the
+    * stored result to keep a single runaway delegate from persisting an
+    * arbitrarily large blob (a poll/list memory-pressure surface). Over the
+    * ceiling we store a truncated copy with an explicit marker rather than
+    * silently dropping the tail. */
+   const char *result_text = result ? result : "";
+   char *capped = NULL;
+   size_t rlen = strlen(result_text);
+   if (rlen > DB1_AJ_RESULT_STORE_MAX)
+   {
+      static const char marker[] = "\n\n[truncated: result exceeded storage ceiling]";
+      size_t keep = DB1_AJ_RESULT_STORE_MAX - (sizeof(marker) - 1);
+      capped = malloc(keep + sizeof(marker));
+      if (capped)
+      {
+         memcpy(capped, result_text, keep);
+         memcpy(capped + keep, marker, sizeof(marker)); /* includes NUL */
+         result_text = capped;
+      }
+   }
+
    sqlite3_bind_text(stmt, 1, status, -1, SQLITE_TRANSIENT);
    sqlite3_bind_text(stmt, 2, cursor, -1, SQLITE_TRANSIENT);
-   sqlite3_bind_text(stmt, 3, result ? result : "", -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(stmt, 3, result_text, -1, SQLITE_TRANSIENT);
    sqlite3_bind_int(stmt, 4, job_id);
    sqlite3_bind_text(stmt, 5, status, -1, SQLITE_TRANSIENT);
    (void)sqlite3_step(stmt);
    sqlite3_finalize(stmt);
+   free(capped);
 }
 
 void db1_agent_job_set_agent(int job_id, const char *agent_name)
@@ -296,10 +319,10 @@ int db1_agent_job_get(int job_id, db1_agent_job_t *out)
    {
       out->id = sqlite3_column_int(stmt, 0);
       db1_copy_col_text(out->role, sizeof(out->role), stmt, 1);
-      db1_copy_col_text(out->prompt, sizeof(out->prompt), stmt, 2);
+      out->prompt = db1_dup_col_text(stmt, 2);
       db1_copy_col_text(out->agent_name, sizeof(out->agent_name), stmt, 3);
       db1_copy_col_text(out->status, sizeof(out->status), stmt, 4);
-      db1_copy_col_text(out->result, sizeof(out->result), stmt, 5);
+      out->result = db1_dup_col_text(stmt, 5);
       const unsigned char *cursor_txt = sqlite3_column_text(stmt, 6);
       out->cursor_turn = cursor_txt ? atoi((const char *)cursor_txt) : 0;
       db1_copy_col_text(out->lease_owner, sizeof(out->lease_owner), stmt, 7);
@@ -358,7 +381,17 @@ int db1_agent_job_take_lease(int job_id, const char *owner)
    return (rc == SQLITE_DONE && sqlite3_changes(db) > 0) ? 0 : -1;
 }
 
-int db1_agent_job_list_recent(db1_agent_job_t *out, int max)
+void db1_agent_job_free(db1_agent_job_t *job)
+{
+   if (!job)
+      return;
+   free(job->prompt);
+   free(job->result);
+   job->prompt = NULL;
+   job->result = NULL;
+}
+
+int db1_agent_job_list_recent(db1_agent_job_t *out, int max, int include_heavy)
 {
    if (!out || max <= 0)
       return 0;
@@ -384,10 +417,10 @@ int db1_agent_job_list_recent(db1_agent_job_t *out, int max)
       memset(o, 0, sizeof(*o));
       o->id = sqlite3_column_int(stmt, 0);
       db1_copy_col_text(o->role, sizeof(o->role), stmt, 1);
-      db1_copy_col_text(o->prompt, sizeof(o->prompt), stmt, 2);
+      o->prompt = include_heavy ? db1_dup_col_text(stmt, 2) : strdup("");
       db1_copy_col_text(o->agent_name, sizeof(o->agent_name), stmt, 3);
       db1_copy_col_text(o->status, sizeof(o->status), stmt, 4);
-      db1_copy_col_text(o->result, sizeof(o->result), stmt, 5);
+      o->result = include_heavy ? db1_dup_col_text(stmt, 5) : strdup("");
       const unsigned char *cursor_txt = sqlite3_column_text(stmt, 6);
       o->cursor_turn = cursor_txt ? atoi((const char *)cursor_txt) : 0;
       db1_copy_col_text(o->lease_owner, sizeof(o->lease_owner), stmt, 7);

--- a/src/db1/agent_jobs.h
+++ b/src/db1/agent_jobs.h
@@ -19,20 +19,27 @@ extern "C"
 #define DB1_AJ_ROLE_LEN   32
 #define DB1_AJ_AGENT_LEN  64
 #define DB1_AJ_STATUS_LEN 32
-#define DB1_AJ_PROMPT_LEN 4096
-#define DB1_AJ_RESULT_LEN 4096
 #define DB1_AJ_TS_LEN     32
 
 #define DB1_AJ_TOOL_LEN 64
+
+   /* Ceiling on a stored result, enforced at the write chokepoint
+    * (db1_agent_job_update). prompt/result are otherwise unbounded heap; this
+    * truncates-with-marker so a single runaway delegate cannot store an
+    * arbitrarily large blob. Inbound prompt size is bounded separately by the
+    * request-body cap. */
+#define DB1_AJ_RESULT_STORE_MAX (1u << 20) /* 1 MiB */
 
    typedef struct
    {
       int id;
       char role[DB1_AJ_ROLE_LEN];
-      char prompt[DB1_AJ_PROMPT_LEN];
+      /* prompt/result are heap-owned, never NULL after a successful
+       * db1_agent_job_get/list_recent; free with db1_agent_job_free. */
+      char *prompt;
       char agent_name[DB1_AJ_AGENT_LEN];
       char status[DB1_AJ_STATUS_LEN];
-      char result[DB1_AJ_RESULT_LEN];
+      char *result;
       int cursor_turn;
       char lease_owner[32];
       char heartbeat_at[DB1_AJ_TS_LEN];
@@ -100,8 +107,15 @@ extern "C"
    int db1_agent_job_classify_stale(int job_id, int idle_threshold_secs, int in_tool_threshold_secs,
                                     char *out_state, size_t out_state_cap);
 
-   /* Load by id. Returns 0 on hit, -1 on miss. */
+   /* Load by id. Returns 0 on hit, -1 on miss. On hit, out->prompt and
+    * out->result are heap-allocated (never NULL) and must be released with
+    * db1_agent_job_free. On miss, out is zero-initialized (free is still safe). */
    int db1_agent_job_get(int job_id, db1_agent_job_t *out);
+
+   /* Release the heap-owned fields (prompt/result) of a job loaded by
+    * db1_agent_job_get / db1_agent_job_list_recent. Idempotent and NULL-safe:
+    * tolerates a zero-initialized struct (a failed get) and double calls. */
+   void db1_agent_job_free(db1_agent_job_t *job);
 
    /* Repair finished job rows created before routed agent metadata was
     * persisted. Matches blank agent_name rows to nearby agent_log rows with
@@ -116,8 +130,13 @@ extern "C"
     * Returns 0 on success, -1 on error. */
    int db1_agent_job_take_lease(int job_id, const char *owner);
 
-   /* List most recent `max` jobs (ORDER BY id DESC). Returns count. */
-   int db1_agent_job_list_recent(db1_agent_job_t *out, int max);
+   /* List most recent `max` jobs (ORDER BY id DESC). Returns count. Each
+    * returned row owns heap prompt/result; free every returned row with
+    * db1_agent_job_free. When include_heavy == 0, the (potentially large)
+    * prompt/result are returned as empty strings (not loaded) so list callers
+    * that do not serialize them avoid up to max × the result ceiling of
+    * allocation; pass 1 only when the bodies are actually needed. */
+   int db1_agent_job_list_recent(db1_agent_job_t *out, int max, int include_heavy);
 
    /* Ids of jobs currently in status='running', up to `max`. */
    int db1_agent_job_list_running_ids(int *out_ids, int max);

--- a/src/db1/db1_internal.h
+++ b/src/db1/db1_internal.h
@@ -10,6 +10,8 @@
 #include <sqlite3.h>
 #include <stddef.h>
 #include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
 #ifdef __cplusplus
 extern "C"
@@ -28,6 +30,17 @@ extern "C"
    {
       const unsigned char *v = sqlite3_column_text(stmt, col);
       snprintf(dst, cap, "%s", v ? (const char *)v : "");
+   }
+
+   /* Heap-allocating sibling of db1_copy_col_text for unbounded TEXT columns
+    * (e.g. agent_jobs.prompt/result). Returns a malloc'd copy of the column,
+    * or strdup("") for a NULL column — NEVER NULL on success, so `field[0]`
+    * guards on the result stay valid. Returns NULL only on allocation failure.
+    * Caller owns the returned pointer. */
+   static inline char *db1_dup_col_text(sqlite3_stmt *stmt, int col)
+   {
+      const unsigned char *v = sqlite3_column_text(stmt, col);
+      return strdup(v ? (const char *)v : "");
    }
 
 #ifdef __cplusplus

--- a/src/server/agent_tasks.c
+++ b/src/server/agent_tasks.c
@@ -402,29 +402,33 @@ int agent_job_resume(agent_config_t *cfg, int job_id, agent_result_t *out)
 
    memset(out, 0, sizeof(*out));
 
+   /* job.prompt/result are heap-owned after a successful get; every exit below
+    * goes through `out:` so they are freed exactly once. On a miss the get
+    * zero-inits the struct, so the free is still safe. */
    db1_agent_job_t job;
+   int rc = -1;
    if (db1_agent_job_get(job_id, &job) != 0)
    {
       snprintf(out->error, sizeof(out->error), "job %d not found", job_id);
-      return -1;
+      goto out;
    }
 
    if (strcmp(job.status, "done") == 0)
    {
       snprintf(out->error, sizeof(out->error), "job %d already completed", job_id);
-      return -1;
+      goto out;
    }
    if (strcmp(job.status, "cancelled") == 0)
    {
       snprintf(out->error, sizeof(out->error), "job %d is cancelled", job_id);
-      return -1;
+      goto out;
    }
    if (strcmp(job.status, "running") == 0 && job.heartbeat_at[0])
    {
       if (!db1_agent_job_heartbeat_is_stale(job.heartbeat_at, 10))
       {
          snprintf(out->error, sizeof(out->error), "job %d is still active", job_id);
-         return -1;
+         goto out;
       }
    }
 
@@ -435,11 +439,11 @@ int agent_job_resume(agent_config_t *cfg, int job_id, agent_result_t *out)
    if (db1_agent_job_take_lease(job_id, pid) != 0)
    {
       snprintf(out->error, sizeof(out->error), "failed to take lease for job %d", job_id);
-      return -1;
+      goto out;
    }
    agent_set_durable_job(job_id);
 
-   int rc = agent_run(cfg, job.role, NULL, job.prompt, AGENT_DEFAULT_MAX_TOKENS, out);
+   rc = agent_run(cfg, job.role, NULL, job.prompt, AGENT_DEFAULT_MAX_TOKENS, out);
    agent_set_durable_job(0);
    int cursor_turn = out->turns > job.cursor_turn ? out->turns : job.cursor_turn;
    if (rc == 0 && liveness_reject_degenerate_response(
@@ -453,6 +457,8 @@ int agent_job_resume(agent_config_t *cfg, int job_id, agent_result_t *out)
    db1_agent_job_update(job_id, (rc == 0) ? "done" : "failed", cursor_turn,
                         out->response ? out->response : out->error);
 
+out:
+   db1_agent_job_free(&job);
    return rc;
 }
 

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -337,6 +337,7 @@ static void compute_update_background_job(compute_ctx_t *cctx, cJSON *resp)
       db1_agent_job_t job;
       if (db1_agent_job_get(cctx->background_job_id, &job) == 0)
          cursor_turn = job.cursor_turn;
+      db1_agent_job_free(&job); /* zero-init by get on miss; safe either way */
    }
 
    db1_agent_job_update(cctx->background_job_id, job_status, cursor_turn, result);

--- a/src/server/server_delegate_status.c
+++ b/src/server/server_delegate_status.c
@@ -17,12 +17,20 @@ static void delegate_status_quarantine_degenerate_done(int job_id, db1_agent_job
    const char *message = "delegate returned raw tool-call markup or another degenerate response";
    db1_agent_job_update(job_id, "failed", job->cursor_turn, message);
    snprintf(job->status, sizeof(job->status), "%s", "failed");
-   snprintf(job->result, sizeof(job->result), "%s", message);
+   /* result is now heap-owned: replace it (free old, strdup new) — NOT
+    * snprintf into a char* (whose sizeof is 8). */
+   char *dup = strdup(message);
+   if (dup)
+   {
+      free(job->result);
+      job->result = dup;
+   }
 }
 
 static void delegate_status_populate_job(cJSON *resp, int job_id)
 {
    db1_agent_job_t job;
+   memset(&job, 0, sizeof(job)); /* so the single-exit free is safe on every branch */
    cJSON_AddNumberToObject(resp, "job_id", job_id);
 
    if (job_id <= 0)
@@ -58,6 +66,7 @@ static void delegate_status_populate_job(cJSON *resp, int job_id)
       if (job.updated_at[0])
          cJSON_AddStringToObject(resp, "updated_at", job.updated_at);
    }
+   db1_agent_job_free(&job);
 }
 
 int handle_delegate_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)

--- a/src/server/server_jobs_aux.c
+++ b/src/server/server_jobs_aux.c
@@ -105,15 +105,22 @@ int handle_jobs_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       limit = 100;
 
    db1_agent_job_t jobs[100];
-   int n = db1_agent_job_list_recent(jobs, limit);
+   /* include_heavy=0: the list serializes with agent_job_to_json(...,0,0) and
+    * never emits prompt/result, so do not load (and then free) up to 100 ×
+    * the result ceiling of bodies. */
+   int n = db1_agent_job_list_recent(jobs, limit, 0);
    if (n < 0)
       return server_send_error(conn, "jobs list: could not read agent jobs", NULL);
 
    cJSON *resp = jo_ok();
    cJSON_AddNumberToObject(resp, "job_count", n);
    cJSON *arr = cJSON_AddArrayToObject(resp, "jobs");
-   for (int i = 0; arr && i < n; i++)
-      cJSON_AddItemToArray(arr, agent_job_to_json(&jobs[i], 0, 0));
+   for (int i = 0; i < n; i++)
+   {
+      if (arr)
+         cJSON_AddItemToArray(arr, agent_job_to_json(&jobs[i], 0, 0));
+      db1_agent_job_free(&jobs[i]);
+   }
 
    return server_send_ok(conn, resp);
 }
@@ -138,6 +145,7 @@ int handle_jobs_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    {
       cJSON_AddStringToObject(resp, "job_status", job.status);
       cJSON_AddItemToObject(resp, "job", agent_job_to_json(&job, 1, 1));
+      db1_agent_job_free(&job);
    }
 
    return server_send_ok(conn, resp);
@@ -164,6 +172,7 @@ int handle_jobs_logs(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       cJSON_AddStringToObject(resp, "job_status", job.status);
       cJSON_AddItemToObject(resp, "job", agent_job_to_json(&job, 1, 1));
       cJSON_AddStringToObject(resp, "log", job.result);
+      db1_agent_job_free(&job);
    }
 
    return server_send_ok(conn, resp);

--- a/src/tests/test_db1_agent_job_heartbeat.c
+++ b/src/tests/test_db1_agent_job_heartbeat.c
@@ -15,6 +15,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -103,8 +104,60 @@ static void test_heartbeat_ext_writes_fields(void)
    assert(row.current_tool[0] == '\0');
    assert(row.api_call_count == 9);
 
+   db1_agent_job_free(&row);
    teardown_db();
    printf("  PASS: test_heartbeat_ext_writes_fields\n");
+}
+
+/* WP-A: prompt/result are heap-backed (was a fixed char[4096]); a prompt or
+ * result larger than the old 4096 cap must round-trip intact, and a result
+ * over the storage ceiling must be truncated-with-marker, not the full blob. */
+static void test_uncapped_prompt_result_round_trip(void)
+{
+   setup_db();
+
+   const size_t big = 50000; /* >> the old 4096 cap */
+   char *big_prompt = malloc(big + 1);
+   assert(big_prompt);
+   memset(big_prompt, 'P', big);
+   big_prompt[big] = '\0';
+
+   int job = db1_agent_job_create("code", big_prompt, "agent", "owner");
+   assert(job > 0);
+
+   db1_agent_job_t row;
+   assert(db1_agent_job_get(job, &row) == 0);
+   assert(strlen(row.prompt) == big); /* not clipped at 4096 */
+   assert(row.prompt[big - 1] == 'P');
+   db1_agent_job_free(&row);
+
+   const size_t big_res = 60000; /* > old cap, < storage ceiling */
+   char *big_result = malloc(big_res + 1);
+   assert(big_result);
+   memset(big_result, 'R', big_res);
+   big_result[big_res] = '\0';
+   db1_agent_job_update(job, "done", 1, big_result);
+   assert(db1_agent_job_get(job, &row) == 0);
+   assert(strlen(row.result) == big_res);
+   db1_agent_job_free(&row);
+
+   /* Over the storage ceiling -> truncated with marker, never the full blob. */
+   const size_t over = (size_t)DB1_AJ_RESULT_STORE_MAX + 100000;
+   char *huge = malloc(over + 1);
+   assert(huge);
+   memset(huge, 'H', over);
+   huge[over] = '\0';
+   db1_agent_job_update(job, "done", 1, huge);
+   assert(db1_agent_job_get(job, &row) == 0);
+   assert(strlen(row.result) <= DB1_AJ_RESULT_STORE_MAX);
+   assert(strstr(row.result, "[truncated") != NULL);
+   db1_agent_job_free(&row);
+
+   free(big_prompt);
+   free(big_result);
+   free(huge);
+   teardown_db();
+   printf("  PASS: test_uncapped_prompt_result_round_trip\n");
 }
 
 static void test_classify_stale_fresh(void)
@@ -393,6 +446,7 @@ int main(void)
 {
    printf("db1_agent_job_heartbeat:\n");
    test_heartbeat_ext_writes_fields();
+   test_uncapped_prompt_result_round_trip();
    test_classify_stale_fresh();
    test_classify_stale_in_tool();
    test_classify_stale_idle();


### PR DESCRIPTION
## Summary

**WP-A of the delegate refactor** (`docs/proposals/pending/delegate-refactor-async-and-credential-vault.md`): remove the 4096-char cap on a delegate's stored prompt/result. It was a fixed `char[4096]` in `db1_agent_job_t`, not a policy — and the upcoming async-only delegate model (WP-B) makes *every* delegate persist through the job row, so the cap would silently truncate every answer. **No DB migration**: SQLite `agent_jobs.prompt/result` are already `TEXT`; the cap was purely the in-memory struct + the read-path `snprintf`.

## Changes

- `db1_agent_job_t.prompt/result`: `char[4096]` → heap `char *`.
- **`db1_dup_col_text`** — allocating, **never-NULL** sibling of `db1_copy_col_text`, so `field[0]` guards stay valid.
- **`db1_agent_job_free`** — NULL-safe, idempotent, tolerates a zero-init struct.
- **`db1_agent_job_list_recent` gains `include_heavy`** — the jobs-list path (never serializes bodies) skips loading them, avoiding up-to-`max`×-ceiling allocation.
- **Stored-result ceiling (1 MiB)** at the write chokepoint (`db1_agent_job_update`), truncate-with-marker — no unbounded blob.
- Fixed the `sizeof(char*)` bug in the degenerate-response quarantine (`server_delegate_status.c`) → free+strdup.
- Freed every `get`/`list_recent` caller (`server_jobs_aux`, `server_delegate_status`, `server_compute`, `cmd_agent_trace`); converted the resume path (`agent_tasks.c`) to a single-exit `goto` so its post-get early returns no longer leak.
- Scoped strictly to `db1_agent_job_t` — the coord (`db1_coord_task_t`), cron, and roadmap structs that also have `.result[0]`/`sizeof` patterns are untouched (their `DB1_COORD_RESULT_LEN` cap is out of WP-A scope).

## Test

Adds `test_uncapped_prompt_result_round_trip`: a 50k-char prompt and 60k-char result round-trip intact; an over-ceiling result is truncated-with-marker. **Built + ran locally — all agent-jobs tests pass** with the heap struct.
