### PR TITLE
Make the multi-agent ensemble always available (remove ensemble.enabled gate)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -140,7 +140,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`db2`** — `vector`
 - **`dedup`** — `enabled`, `window_seconds`
 - **`dogfood`** — `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
-- **`ensemble`** — `aggregator`, `enabled`, `max_cost_usd`, `min_successful`, `reference_models`
+- **`ensemble`** — `aggregator`, `max_cost_usd`, `min_successful`, `reference_models`
 - **`guardrails`** — `semantic`
 - **`identity`** — `working_profile_injection`
 - **`ingress`** — `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`

--- a/src/cmd_agent_delegate.c
+++ b/src/cmd_agent_delegate.c
@@ -510,11 +510,6 @@ void cmd_delegate(app_ctx_t *ctx, int argc, char **argv)
       }
       config_t cfg;
       config_load(&cfg);
-      if (!cfg.ensemble_enabled)
-      {
-         fprintf(stderr, "error: ensemble is disabled. Set ensemble.enabled: true in aimee.yaml\n");
-         return;
-      }
       agent_config_t acfg;
       if (agent_load_config(&acfg) != 0)
       {

--- a/src/config.c
+++ b/src/config.c
@@ -549,7 +549,6 @@ static void config_set_defaults(config_t *cfg)
    cfg->model_meta_capability_routing = 0;
    snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "auto");
    cfg->db2_vector_corpus_diskann_threshold = 1000000;
-   cfg->ensemble_enabled = 0;
    cfg->ensemble_min_successful = 2;
    cfg->ensemble_max_cost_usd = 1.0;
    cfg->roundtable_max_rounds = 3;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -60,13 +60,12 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
    }
 
    /* ensemble.* */
-   if (cfg->ensemble_enabled || cfg->ensemble_aggregator[0] || cfg->ensemble_min_successful != 2 ||
+   if (cfg->ensemble_aggregator[0] || cfg->ensemble_min_successful != 2 ||
        cfg->ensemble_max_cost_usd != 1.0 || cfg->ensemble_reference_count > 0)
    {
       cJSON *e = cJSON_AddObjectToObject(root, "ensemble");
       if (e)
       {
-         cJSON_AddBoolToObject(e, "enabled", cfg->ensemble_enabled ? 1 : 0);
          if (cfg->ensemble_aggregator[0])
             cJSON_AddStringToObject(e, "aggregator", cfg->ensemble_aggregator);
          cJSON_AddNumberToObject(e, "min_successful", cfg->ensemble_min_successful);

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1149,9 +1149,6 @@ void config_parse_ensemble_section(config_t *cfg, cJSON *root)
    cJSON *ensemble_cfg = cJSON_GetObjectItemCaseSensitive(root, "ensemble");
    if (cJSON_IsObject(ensemble_cfg))
    {
-      item = cJSON_GetObjectItemCaseSensitive(ensemble_cfg, "enabled");
-      if (cJSON_IsBool(item))
-         cfg->ensemble_enabled = cJSON_IsTrue(item) ? 1 : 0;
       item = cJSON_GetObjectItemCaseSensitive(ensemble_cfg, "aggregator");
       if (cJSON_IsString(item) && item->valuestring)
          snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1270,12 +1270,10 @@ typedef struct config
    char db2_vector_corpus_index[16];
    int64_t db2_vector_corpus_diskann_threshold;
    /* Mixture-of-Agents ensemble (ensemble.*).
-    * ensemble_enabled: 0 = disabled (default), 1 = available for explicit invocation.
     * ensemble_reference_models: diverse model/agent names for the fan-out.
     * ensemble_aggregator: agent name for the synthesis pass.
     * ensemble_min_successful: min references that must succeed before degrading (default 2).
     * ensemble_max_cost_usd: hard per-call cost cap in USD (default 1.0). */
-   int ensemble_enabled;
    char ensemble_reference_models[8][128];
    int ensemble_reference_count;
    char ensemble_aggregator[128];
@@ -1292,14 +1290,14 @@ typedef struct config
    /* Roundtable authoring pipeline (roundtable.pipeline_*). The outer
     * REVIEW<->revise loop, done-bar, and cost/pass backstops; see
     * docs/proposals/accepted/agent-roundtable-authoring-pipeline.md section 6. */
-   char roundtable_pipeline_done_bar[40];      /* zero_blocking | zero_blocking_suggestions
-                                                * | zero_blocking_questions_answered */
-   int roundtable_pipeline_max_passes;         /* 0 = unbounded (default) */
-   int roundtable_pipeline_max_attempts_per_pass; /* infra-retry ceiling, default 2 */
-   double roundtable_pipeline_max_cost_usd;    /* per-phase cap; 0 = unbounded */
-   double roundtable_pipeline_max_total_cost_usd; /* whole-pipeline cap; 0 = unbounded */
-   int roundtable_pipeline_gate_ttl_h;         /* awaiting-human gate TTL hours; 0 = none */
-   int roundtable_pipeline_parked_releases_slot; /* bool: parked gate frees the active slot */
+   char roundtable_pipeline_done_bar[40];          /* zero_blocking | zero_blocking_suggestions
+                                                    * | zero_blocking_questions_answered */
+   int roundtable_pipeline_max_passes;             /* 0 = unbounded (default) */
+   int roundtable_pipeline_max_attempts_per_pass;  /* infra-retry ceiling, default 2 */
+   double roundtable_pipeline_max_cost_usd;        /* per-phase cap; 0 = unbounded */
+   double roundtable_pipeline_max_total_cost_usd;  /* whole-pipeline cap; 0 = unbounded */
+   int roundtable_pipeline_gate_ttl_h;             /* awaiting-human gate TTL hours; 0 = none */
+   int roundtable_pipeline_parked_releases_slot;   /* bool: parked gate frees the active slot */
    int roundtable_pipeline_unknown_context_tokens; /* conservative chunk budget fallback */
 
    /* Context engine selection (context.engine).

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1037,9 +1037,6 @@ int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char 
 
    memset(out, 0, sizeof(*out));
 
-   if (!cfg->ensemble_enabled)
-      return -1;
-
    int ref_count = cfg->ensemble_reference_count;
    if (ref_count <= 0 || ref_count > ENSEMBLE_MAX_REFS)
       return -1;
@@ -1148,8 +1145,6 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       return -1;
    memset(out, 0, sizeof(*out));
 
-   if (!cfg->ensemble_enabled)
-      return -1;
    int ref_count = cfg->ensemble_reference_count;
    if (ref_count <= 0 || ref_count > ENSEMBLE_MAX_REFS)
       return -1;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1822,10 +1822,6 @@ int handle_delegate_aggregate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
 
    config_t cfg;
    config_load(&cfg);
-   if (!cfg.ensemble_enabled)
-      return server_send_error(
-          conn, "Mixture-of-Agents ensemble disabled (set ensemble.enabled=true)", NULL);
-
    agent_config_t acfg;
    memset(&acfg, 0, sizeof(acfg));
    if (agent_load_config(&acfg) != 0)
@@ -1862,9 +1858,6 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
 
    config_t cfg;
    config_load(&cfg);
-   if (!cfg.ensemble_enabled)
-      return server_send_error(conn, "agent roundtable disabled (set ensemble.enabled=true)", NULL);
-
    roundtable_opts_t opts;
    memset(&opts, 0, sizeof(opts));
    opts.mode = ROUNDTABLE_DRAFT;

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -212,7 +212,6 @@ int main(void)
       cfg.integrity_enabled = 1;
       cfg.integrity_dry_run = 0;
       /* ensemble.* (+ reference_models array) */
-      cfg.ensemble_enabled = 1;
       snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "synthesizer");
       cfg.ensemble_min_successful = 3;
       cfg.ensemble_reference_count = 2;
@@ -378,7 +377,7 @@ int main(void)
       assert(cfg2.dogfood_enabled == 0 && cfg2.dogfood_commit_raw == 1);
       assert(strcmp(cfg2.dogfood_log_dir, "/tmp/df-rt") == 0);
       assert(cfg2.integrity_enabled == 1 && cfg2.integrity_dry_run == 0);
-      assert(cfg2.ensemble_enabled == 1 && cfg2.ensemble_min_successful == 3);
+      assert(cfg2.ensemble_min_successful == 3);
       assert(strcmp(cfg2.ensemble_aggregator, "synthesizer") == 0);
       assert(cfg2.ensemble_reference_count == 2 &&
              strcmp(cfg2.ensemble_reference_models[1], "m-b") == 0);

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -306,7 +306,6 @@ int main(void)
    assert(cfgA.aux_default_max_tokens != cfgB.aux_default_max_tokens);
    assert(cfgA.model_meta_refresh_minutes != cfgB.model_meta_refresh_minutes);
    assert(cfgA.model_meta_capability_routing == 1 && cfgB.model_meta_capability_routing == 0);
-   assert(cfgA.ensemble_enabled == 1 && cfgB.ensemble_enabled == 0);
    assert(cfgA.ensemble_min_successful != cfgB.ensemble_min_successful);
    assert(cfgA.ensemble_max_cost_usd != cfgB.ensemble_max_cost_usd);
 

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -224,7 +224,7 @@ static config_t make_cfg(int enabled, int min_ok, double max_cost)
 {
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
-   cfg.ensemble_enabled = enabled;
+   (void)enabled;
    cfg.ensemble_min_successful = min_ok;
    cfg.ensemble_max_cost_usd = max_cost;
    cfg.ensemble_reference_count = 3;
@@ -358,17 +358,6 @@ static void test_delegate_cost_estimate_uses_token_tracker(void)
    double zero = delegate_cost_estimate_usd(NULL, "zero-priced-model", 1000, 1000);
    assert(zero > 0.0);
    printf("  test_delegate_cost_estimate_uses_token_tracker: ok\n");
-}
-
-static void test_ensemble_disabled(void)
-{
-   config_t cfg = make_cfg(0, 2, 10.0); /* disabled */
-   agent_config_t acfg = make_acfg();
-   delegate_ensemble_result_t result;
-
-   int rc = delegate_ensemble_run(&acfg, &cfg, "any prompt", &result);
-   assert(rc == -1);
-   printf("  test_ensemble_disabled: ok\n");
 }
 
 static void test_ensemble_null_args(void)
@@ -838,7 +827,6 @@ static void test_roundtable_deadline_returns_best_so_far(void)
 int main(void)
 {
    printf("delegate_ensemble tests\n");
-   test_ensemble_disabled();
    test_ensemble_null_args();
    test_ensemble_basic();
    test_ensemble_cost_cap();


### PR DESCRIPTION
## Summary

The Mixture-of-Agents ensemble / roundtable is **core aimee functionality**, but it was gated behind a default-off `ensemble.enabled` flag — which wasn't even settable via `aimee config set` (load-only) — so the roundtable silently refused to run. The ensemble is now **always available**.

- Remove the `ensemble_enabled` config field (default/parse/save).
- Remove all five gates: `aimee delegate roundtable` (`cmd_agent_delegate`), the Mixture-of-Agents and roundtable handlers (`server_compute`, ×2), and the two `delegate_ensemble` entry points — no more "ensemble disabled" early-return.
- Drop the obsolete `test_ensemble_disabled` + the field's test assertions; regenerate `docs/gen/configuration.md`.

The rest of `ensemble.*` (aggregator, min_successful, max_cost_usd, reference_models) is unchanged — only the on/off gate is gone.

## Testing
- `make verify-local` + full `make unit-tests` green (serial build; parallel-LTO flakes on this host with an unrelated GCC ICE).
