### PR TITLE
WP-C.0: capture + thread the attested vault principal (SO_PEERCRED)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -771,6 +771,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_session.c
     ${AIMEE_SRC_DIR}/server/server_session_pools.c
     ${AIMEE_SRC_DIR}/server/presence.c
+    ${AIMEE_SRC_DIR}/server/vault_principal.c
     ${AIMEE_SRC_DIR}/server/server_state.c
     ${AIMEE_SRC_DIR}/server/server_plugin.c
     ${AIMEE_SRC_DIR}/server/server_work.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -368,14 +368,14 @@ CLIENT_COMPILE_OBJS = $(CLI_OBJS) $(CLIENT_PLATFORM_OBJS) $(OBJDIR)/dstr.o $(OBJ
 $(CLIENT_COMPILE_OBJS): C_FLAGS := $(CLIENT_C_FLAGS)
 
 # --- Server ---
-SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/server_http_reqctx.c server/request_context.c server/response_dedup.c server/anthropic_shape.c server/anthropic_ingress.c server/anthropic_http.c server/openai_shape.c server/openai_chat.c server/ingress_preinject.c server/openai_responses_store.c server/openai_runs_store.c server/server_api.c server/server_auth.c server/server_session.c server/server_hooks.c server/server_state.c server/server_plugin.c server/server_memory_benchmark.c server/server_work.c server/workspace_provider_detached.c server/workspace_runner_queue.c server/workspace_runner_registry.c server/workspace_turn.c \
+SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/server_http_reqctx.c server/server_http_identity.c server/request_context.c server/response_dedup.c server/anthropic_shape.c server/anthropic_ingress.c server/anthropic_http.c server/openai_shape.c server/openai_chat.c server/ingress_preinject.c server/openai_responses_store.c server/openai_runs_store.c server/server_api.c server/server_auth.c server/server_session.c server/server_hooks.c server/server_state.c server/server_plugin.c server/server_memory_benchmark.c server/server_work.c server/workspace_provider_detached.c server/workspace_runner_queue.c server/workspace_runner_registry.c server/workspace_turn.c \
               server/server_delegate_monitor.c server/server_coord_dispatcher.c server/server_session_pools.c server/presence.c \
               server/server_agent.c server/server_compute.c server/server_skill_jobs.c server/server_delegate_status.c server/server_compute_async.c server/server_jobs_aux.c server/server_skill.c server/server_mcp.c server/server_mcp_tools.c server/server_mcp_delegate.c server/server_mcp_process.c server/server_mcp_skill.c server/server_mcp_learning.c server/server_mcp_workflows.c server/server_mcp_gateway.c server/session_search_tool.c server/compute_pool.c cli_client.c \
               server/roundtable_pipeline_eval.c server/roundtable_pipeline_capture.c server/roundtable_pipeline_chunk.c server/server_pipeline.c \
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -7,6 +7,7 @@
 #include "compute_pool.h"
 #include "platform_event.h"
 #include "provider_catalog.h"
+#include "vault_principal.h"
 
 /* Forward declaration */
 typedef struct cJSON cJSON;
@@ -147,6 +148,14 @@ typedef struct
    int refcount;              /* in-flight ephemeral jobs holding this conn */
    int closing;               /* set by conn_close once teardown is committed */
    char active_verify_session[SERVER_SESSION_ID_MAX]; /* sync git.verify cancellation key */
+   /* WP-C.0: attested identity for the credential vault, captured while the conn
+    * is live and propagated across the loopback_rpc fake-conn boundary. The
+    * vault principal ("uid:<n>" / "webuser:<name>" / "" when un-attested) is the
+    * single security key for the vault file + KEK cache — derived from the
+    * kernel-attested peer_uid or the server.token-gated webuser assertion, NEVER
+    * a client-supplied session_id. Empty principal => no vault (fail-closed). */
+   attested_transport_t attested_transport;
+   char vault_principal[VAULT_PRINCIPAL_MAX];
 } server_conn_t;
 
 typedef struct

--- a/src/headers/server_compute_impl.h
+++ b/src/headers/server_compute_impl.h
@@ -29,6 +29,13 @@ typedef struct
     * path the server must not open on its own filesystem (workspace-resource-
     * plane AC #6 — the worktree_cwd-trust hole). */
    uint32_t conn_caps;
+   /* WP-C.0: the attested vault principal + transport, copied from the conn
+    * while it is live (create_compute_ctx) so the detached worker — which runs
+    * after conn_fd is closed and no thread-local survives — can resolve the
+    * right per-user vault. Empty principal => un-attested => no vault. This is
+    * the ONLY identity key the worker trusts (never the body session_id). */
+   attested_transport_t attested_transport;
+   char vault_principal[VAULT_PRINCIPAL_MAX];
    cJSON *req; /* owned by this context */
    /* Unified-presence turn arbitration. When a chat request carries an
     * attach_id and a presence exists for the session, handle_chat_send_stream

--- a/src/headers/server_http_identity.h
+++ b/src/headers/server_http_identity.h
@@ -1,0 +1,38 @@
+#ifndef DEC_SERVER_HTTP_IDENTITY_H
+#define DEC_SERVER_HTTP_IDENTITY_H 1
+
+#include "server.h" /* server_conn_t, attested_transport_t */
+
+/* server_http_identity: WP-C.0 attested-identity threading for the /v1 front-end.
+ *
+ * Every /v1 request reaches server_dispatch through loopback_rpc's synthesized
+ * (memset-zeroed) server_conn_t, so the caller's kernel-attested identity would
+ * otherwise be lost before the delegate worker resolves credentials. These three
+ * functions carry it across that boundary, all on the one worker thread that
+ * handles the connection synchronously up to compute_ctx creation:
+ *   1. capture  — handle_conn records the attested transport + vault principal
+ *      (SO_PEERCRED peer uid, or a server.token-gated `webuser:` assertion) into
+ *      thread-locals;
+ *   2. apply    — loopback_rpc copies them onto the synthesized conn;
+ *   3. clear    — handle_conn wipes them after the route so a reused worker
+ *      thread cannot leak one request's identity into the next.
+ * create_compute_ctx then copies the conn's identity into compute_ctx_t for the
+ * detached worker. The principal is the ONLY identity key the vault trusts —
+ * never a client-supplied session_id. */
+
+/* Capture this request's attested identity into the per-thread state.
+ *   fd      - the connection socket (SO_PEERCRED source for UDS).
+ *   is_tcp  - 1 for the network listener, 0 for the local UDS socket.
+ *   buf     - the raw HTTP request (read for the X-Aimee-Webuser / Authorization headers).
+ *   bearer  - the configured server.token bearer (empty when none), required to
+ *             honor a webuser assertion. */
+void server_http_identity_capture(int fd, int is_tcp, const char *buf, const char *bearer);
+
+/* Copy the captured identity onto a (synthesized) connection — loopback_rpc's
+ * hop 2. Safe to call with no prior capture: writes the un-attested defaults. */
+void server_http_identity_apply(server_conn_t *conn);
+
+/* Reset the per-thread captured identity to the un-attested, no-vault defaults. */
+void server_http_identity_clear(void);
+
+#endif /* DEC_SERVER_HTTP_IDENTITY_H */

--- a/src/headers/vault_principal.h
+++ b/src/headers/vault_principal.h
@@ -1,0 +1,59 @@
+#ifndef DEC_VAULT_PRINCIPAL_H
+#define DEC_VAULT_PRINCIPAL_H 1
+
+#include <stddef.h>
+
+/* vault_principal: the attested identity that keys the per-user credential vault
+ * (WP-C). The *vault principal* — "uid:<peer_uid>" for a kernel-attested local
+ * UDS peer, or "webuser:<username>" for a webchat user asserted under the
+ * server.token trust boundary — is the SINGLE security key for both the vault
+ * file (ownership) and the KEK cache. It is NEVER derived from a client-supplied
+ * session_id or the proxy-overridable audit principal.
+ *
+ * WP-C.0 captures the attested transport + resolves this principal while the
+ * connection is live (SO_PEERCRED + the server.token-gated X-Aimee-Webuser
+ * header), then threads it across the closed-connection boundary
+ * (handle_conn thread-locals -> loopback_rpc fake conn -> compute_ctx_t) so the
+ * detached delegate worker can reach the right vault. The crypto core that
+ * consumes it lands in WP-C.1/C.2. */
+
+/* The kind of attestation behind a connection's identity. Ordered so that
+ * ATTEST_NONE (the zero value) is the un-attested default a missed hop or a
+ * memset() collapses to — every vault path is fail-closed against it. */
+typedef enum
+{
+   ATTEST_NONE = 0,        /* un-attested: no vault (a missed hop must not become uid:0) */
+   ATTEST_TCP_BEARER,      /* network conn authorized by bearer; no OS-user attestation -> no vault (D17) */
+   ATTEST_UDS_PEERCRED,    /* local UDS conn, kernel-attested peer uid -> uid:<n> principal */
+   ATTEST_WEBCHAT_TRUSTED, /* webchat backend asserting webuser:<name> under server.token (WP-C.2) */
+} attested_transport_t;
+
+/* Max length of a vault principal string ("webuser:" + a 128-byte username, or
+ * "uid:" + digits) including the NUL. */
+#define VAULT_PRINCIPAL_MAX 160
+
+/* Resolve a connection's attested transport + vault principal, fail-closed.
+ *
+ * Inputs (all captured while the conn is live):
+ *   is_tcp           - 1 for the network listener, 0 for the local UDS socket.
+ *   peer_uid         - SO_PEERCRED uid for a UDS peer, or -1 when unavailable/TCP.
+ *   webuser          - the X-Aimee-Webuser header value, or NULL/"" if absent.
+ *   webuser_token_ok - 1 iff the request also presented the valid server.token
+ *                      bearer (the secret only the webchat backend holds).
+ *
+ * Writes the principal string into out (out[0]=='\0' when there is NO vault
+ * identity) and returns the attested transport classification:
+ *   - webuser asserted WITH a valid token  -> ATTEST_WEBCHAT_TRUSTED, "webuser:<name>"
+ *   - webuser asserted WITHOUT a valid token (spoof) -> classification per the
+ *     underlying transport, principal EMPTY (the assertion is refused, not honored)
+ *   - plain UDS peer with uid > 0           -> ATTEST_UDS_PEERCRED,    "uid:<n>"
+ *   - UDS peer with uid 0 or unknown        -> ATTEST_UDS_PEERCRED,    "" (no uid:0)
+ *   - plain TCP                             -> ATTEST_TCP_BEARER,      ""
+ *
+ * uid 0 is deliberately given NO principal: a zeroed/uninitialised conn (a missed
+ * threading hop, or loopback's memset) reads as uid 0, so treating it as a real
+ * principal would collapse to acting as root. out must be >= VAULT_PRINCIPAL_MAX. */
+attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const char *webuser,
+                                             int webuser_token_ok, char *out, size_t out_len);
+
+#endif /* DEC_VAULT_PRINCIPAL_H */

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1685,6 +1685,17 @@ compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON 
     * not be opened on the server's own fs. A NULL conn is an in-process caller. */
    cctx->conn_caps = conn ? conn->capabilities : CAPS_ALL;
 
+   /* WP-C.0: capture the attested vault identity while the conn is live (hop 3 of
+    * 3). The detached worker resolves credentials after conn_fd is closed and no
+    * thread-local survives, so the principal must be copied here — it is the only
+    * identity key the worker trusts for the vault (never the body session_id). A
+    * NULL conn (in-process caller) is un-attested => no vault. */
+   if (conn)
+   {
+      cctx->attested_transport = conn->attested_transport;
+      snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s", conn->vault_principal);
+   }
+
    /* Clone the request since the original will be freed after dispatch */
    cctx->req = cJSON_Duplicate(req, 1);
 

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -27,6 +27,7 @@
 #include "roundtable_pipeline_capture.h" /* pipeline op-run capture seam (#18/#20) */
 #include "presence.h"
 #include "request_context.h"
+#include "server_http_identity.h" /* WP-C.0 attested-identity capture/threading */
 #include "cJSON.h"
 #include <arpa/inet.h>
 #include <errno.h>
@@ -934,6 +935,11 @@ static int loopback_rpc(const char *body, int body_len, char *resp, int resp_cap
    memset(&fake, 0, sizeof(fake));
    fake.fd = sp[1];
    fake.capabilities = conn_caps;
+   /* WP-C.0 hop 2 of 3: the memset above zeroes the attested identity; restore
+    * the real one captured by handle_conn so every /v1 request — which only ever
+    * reaches server_dispatch through this synthesized conn — carries the caller's
+    * vault principal through to create_compute_ctx (same thread, identity live). */
+   server_http_identity_apply(&fake);
    pthread_mutex_init(&fake.mutex, NULL);
    pthread_cond_init(&fake.can_close, NULL);
 
@@ -1712,8 +1718,14 @@ static void handle_conn(int fd, int is_tcp)
     * CAPS_ALL, TCP => bearer-scoped) so loopback_rpc / server_dispatch re-check
     * per-method capability. Reset to the read-only default afterward. */
    g_rpc_conn_caps = server_http_conn_caps(is_tcp, g_bearer, g_remote_writes);
+   /* WP-C.0 hop 1 of 3: capture the attested vault identity (kernel UDS peer uid,
+    * or a server.token-gated webuser assertion) into thread-locals, live until
+    * loopback_rpc copies it into the synthesized conn. Cleared after the route so
+    * a reused worker thread cannot leak it into the next request. */
+   server_http_identity_capture(fd, is_tcp, buf, g_bearer);
    int status = server_http_route(method, path, body, body_len, resp, SHTTP_RESP_MAX);
    g_rpc_conn_caps = CAPS_READ_ONLY;
+   server_http_identity_clear();
    send_response(fd, status, resp, request_id);
    LOG_INFO("server.http", "%s %s -> %d req_id=%s", method, path, status, request_id);
    free(resp);

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -1,0 +1,68 @@
+/* server_http_identity.c: WP-C.0 attested-identity capture + threading for the
+ * /v1 front-end. Isolated from server_http.c (at the line-count limit) so the
+ * SO_PEERCRED capture, the server.token-gated webuser assertion, and the
+ * synthesized-conn propagation live in one small, independently-testable unit.
+ * See server_http_identity.h for the three-hop model. */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE /* struct ucred / SO_PEERCRED via platform_ipc */
+#endif
+#include "server_http_identity.h"
+#include "server_http.h" /* http_header */
+#include "server.h"      /* server_ct_equal */
+#include "platform_ipc.h"
+#include "vault_principal.h"
+#include <stdio.h>
+#include <string.h>
+
+/* Per-thread captured identity for the request currently being routed. Thread-
+ * local for the same reason as the front-end's g_rpc_conn_caps: each connection
+ * is handled on its own worker thread and these are read synchronously on that
+ * thread (handle_conn -> loopback_rpc) before the compute worker detaches.
+ * Defaults are the un-attested, no-vault state. */
+static _Thread_local long tl_peer_uid = -1;
+static _Thread_local attested_transport_t tl_transport = ATTEST_NONE;
+static _Thread_local char tl_principal[VAULT_PRINCIPAL_MAX] = "";
+
+void server_http_identity_capture(int fd, int is_tcp, const char *buf, const char *bearer)
+{
+   long peer_uid = -1;
+   if (!is_tcp)
+   {
+      platform_peer_cred_t pc;
+      if (platform_ipc_peer_cred(fd, &pc) == 0)
+         peer_uid = (long)pc.uid;
+   }
+
+   char webuser[128] = "";
+   int webuser_token_ok = 0;
+   if (buf && http_header(buf, "X-Aimee-Webuser", webuser, sizeof(webuser)) && webuser[0])
+   {
+      /* A webuser assertion is honored only with the valid server.token bearer
+       * (the secret only the webchat backend holds). A spoofed header without it
+       * is refused by vault_principal_resolve (empty principal). */
+      char wauth[512] = "";
+      if (bearer && bearer[0] && http_header(buf, "Authorization", wauth, sizeof(wauth)) &&
+          strncmp(wauth, "Bearer ", 7) == 0 && server_ct_equal(wauth + 7, bearer))
+         webuser_token_ok = 1;
+   }
+
+   tl_peer_uid = peer_uid;
+   tl_transport = vault_principal_resolve(is_tcp, peer_uid, webuser, webuser_token_ok, tl_principal,
+                                          sizeof(tl_principal));
+}
+
+void server_http_identity_apply(server_conn_t *conn)
+{
+   if (!conn)
+      return;
+   conn->peer_uid = (tl_peer_uid > 0) ? (uid_t)tl_peer_uid : 0;
+   conn->attested_transport = tl_transport;
+   snprintf(conn->vault_principal, sizeof(conn->vault_principal), "%s", tl_principal);
+}
+
+void server_http_identity_clear(void)
+{
+   tl_peer_uid = -1;
+   tl_transport = ATTEST_NONE;
+   tl_principal[0] = '\0';
+}

--- a/src/server/vault_principal.c
+++ b/src/server/vault_principal.c
@@ -1,0 +1,52 @@
+/* vault_principal.c: resolve a connection's attested vault principal (WP-C.0).
+ * Pure, side-effect-free classification — the single place the "who owns this
+ * vault" decision is made, so it can be unit-tested exhaustively in isolation
+ * before any crypto (WP-C.1) consumes it. See vault_principal.h for the policy. */
+#include "vault_principal.h"
+#include <stdio.h>
+#include <string.h>
+
+attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const char *webuser,
+                                             int webuser_token_ok, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!out || out_len < VAULT_PRINCIPAL_MAX)
+      return ATTEST_NONE;
+
+   int webuser_asserted = webuser && webuser[0];
+
+   /* A webuser assertion is honored ONLY under the server.token trust boundary
+    * (the secret only the webchat backend holds). Asserted WITHOUT a valid token
+    * it is a spoof: the principal is refused (empty), and the connection is
+    * classified by its underlying transport — never granted a vault identity. */
+   if (webuser_asserted && webuser_token_ok)
+   {
+      snprintf(out, out_len, "webuser:%s", webuser);
+      return ATTEST_WEBCHAT_TRUSTED;
+   }
+
+   /* A webuser asserted WITHOUT the valid token is a spoof. It is refused a
+    * principal entirely — it must NOT fall through to the uid: path, or a
+    * request from the shared webchat service account would silently receive that
+    * account's uid: vault, leaking credentials across webchat users (the whole
+    * reason the webuser: principal exists). Classify by transport, no vault. */
+   if (webuser_asserted)
+      return is_tcp ? ATTEST_TCP_BEARER : ATTEST_UDS_PEERCRED;
+
+   if (!is_tcp)
+   {
+      /* Local UDS peer. A kernel-attested uid > 0 owns a uid: vault. uid 0
+       * (root) and an unknown uid (-1) get NO principal: an un-attested or
+       * zeroed conn reads as uid 0, so granting it would collapse to acting as
+       * root on a missed hop. Fail-closed -> empty principal, vault refuses. */
+      if (peer_uid > 0)
+         snprintf(out, out_len, "uid:%ld", peer_uid);
+      return ATTEST_UDS_PEERCRED;
+   }
+
+   /* Plain TCP: bearer-authorized at the network edge but with no OS-user
+    * attestation. Direct-TCP multi-user vault is out of scope (D17) -> no
+    * principal. */
+   return ATTEST_TCP_BEARER;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -182,6 +182,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-delegate-ensemble \
                $(TESTPREFIX)/unit-test-sandbox \
                $(TESTPREFIX)/unit-test-slop-detect \
+               $(TESTPREFIX)/unit-test-vault-principal \
                $(TESTPREFIX)/unit-test-prompts \
                $(TESTPREFIX)/unit-test-cmd-session \
                $(TESTPREFIX)/unit-test-model-registry \
@@ -767,7 +768,7 @@ $(TESTPREFIX)/unit-test-acp-server: $(OBJDIR)/tests/test_acp_server.o \
 $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o $(OBJDIR)/server/server.o \
 	                                $(OBJDIR)/server/server_config.o $(OBJDIR)/config_fields.o \
 	                                $(OBJDIR)/server/skill_review.o $(OBJDIR)/tests/support/skill_jobs_stub.o \
-	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o \
+	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o \
 	                                $(OBJDIR)/tests/support/toolset_stub.o \
 	                                $(OBJDIR)/cJSON.o $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
 	                                $(OBJDIR)/db1/model_catalog.o \
@@ -1767,6 +1768,10 @@ $(TESTPREFIX)/unit-test-slop-detect: $(OBJDIR)/tests/test_slop_detect.o \
                               $(OBJDIR)/slop_detect.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
+$(TESTPREFIX)/unit-test-vault-principal: $(OBJDIR)/tests/test_vault_principal.o \
+                              $(OBJDIR)/server/vault_principal.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
+
 $(TESTPREFIX)/unit-test-prompts: $(OBJDIR)/tests/test_prompts.o \
                            $(OBJDIR)/prompts.o $(OBJDIR)/dstr.o $(OBJDIR)/working_profile.o \
                            $(DB1_OBJS) \
@@ -1781,7 +1786,7 @@ $(TESTPREFIX)/unit-test-persona: $(OBJDIR)/tests/test_persona.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
-                           $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/presence.o \
+                           $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o $(OBJDIR)/server/presence.o \
                            $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                            $(OBJDIR)/forge_credentials.o \
                            $(OBJDIR)/delivery_target.o \

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -1710,6 +1710,41 @@ static void test_delegate_prompt_append_block(void)
    printf("  PASS: test_delegate_prompt_append_block\n");
 }
 
+/* WP-C.0 hop 3 of 3: create_compute_ctx must copy the attested vault identity
+ * from the (still-live) conn into the compute_ctx, so the detached worker — which
+ * runs after conn_fd is closed and no thread-local survives — can resolve the
+ * right per-user vault from the only identity key it is allowed to trust. */
+static void test_create_compute_ctx_threads_vault_identity(void)
+{
+   server_conn_t conn;
+   memset(&conn, 0, sizeof(conn));
+   conn.fd = -1; /* dup(-1) -> -1, fine for this no-I/O construction test */
+   conn.attested_transport = ATTEST_UDS_PEERCRED;
+   snprintf(conn.vault_principal, sizeof(conn.vault_principal), "uid:1234");
+
+   cJSON *req = cJSON_CreateObject();
+   compute_ctx_t *cctx = create_compute_ctx(NULL, &conn, req);
+   assert(cctx != NULL);
+   assert(cctx->attested_transport == ATTEST_UDS_PEERCRED);
+   assert(strcmp(cctx->vault_principal, "uid:1234") == 0);
+   compute_ctx_free(cctx);
+   cJSON_Delete(req);
+
+   /* A conn with no attested identity (the un-attested default) yields an empty
+    * principal => no vault (fail-closed). */
+   server_conn_t bare;
+   memset(&bare, 0, sizeof(bare));
+   bare.fd = -1;
+   cJSON *req2 = cJSON_CreateObject();
+   compute_ctx_t *c2 = create_compute_ctx(NULL, &bare, req2);
+   assert(c2 != NULL);
+   assert(c2->attested_transport == ATTEST_NONE);
+   assert(c2->vault_principal[0] == '\0');
+   compute_ctx_free(c2);
+   cJSON_Delete(req2);
+   printf("  PASS: test_create_compute_ctx_threads_vault_identity\n");
+}
+
 int main(void)
 {
    /* DB1 owns delegation_spawns + delegation_messages. */
@@ -1770,6 +1805,7 @@ int main(void)
    test_delegate_worker_sets_session_override_during_run();
    test_delegate_worker_concurrency_cancelled_restores();
    test_delegate_worker_concurrency_queue_full_errors();
+   test_create_compute_ctx_threads_vault_identity();
    db1_shutdown();
    reset_last_response();
    printf("server_compute: all tests passed\n");

--- a/src/tests/test_vault_principal.c
+++ b/src/tests/test_vault_principal.c
@@ -1,0 +1,118 @@
+/* test_vault_principal.c: WP-C.0 — exhaustive characterization of the attested
+ * vault-principal resolver. This is the single place "who owns this vault" is
+ * decided, and the entire credential vault (WP-C.1/C.2) keys on it, so every
+ * branch — including the fail-closed ones (uid 0, un-attested, spoofed webuser)
+ * — is pinned here before any crypto consumes the principal. */
+#include "vault_principal.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static attested_transport_t resolve(int is_tcp, long uid, const char *webuser, int token_ok,
+                                    char *out)
+{
+   out[0] = '\xff'; /* poison: prove the resolver writes/clears it */
+   return vault_principal_resolve(is_tcp, uid, webuser, token_ok, out, VAULT_PRINCIPAL_MAX);
+}
+
+/* A kernel-attested UDS peer with uid > 0 owns a uid: vault. */
+static void test_uds_peer_uid_gets_principal(void)
+{
+   char p[VAULT_PRINCIPAL_MAX];
+   assert(resolve(0, 1000, NULL, 0, p) == ATTEST_UDS_PEERCRED);
+   assert(strcmp(p, "uid:1000") == 0);
+
+   assert(resolve(0, 4242, "", 0, p) == ATTEST_UDS_PEERCRED);
+   assert(strcmp(p, "uid:4242") == 0);
+   printf("  PASS: test_uds_peer_uid_gets_principal\n");
+}
+
+/* Two distinct uids resolve to two distinct principals (isolation foundation). */
+static void test_distinct_uids_distinct_principals(void)
+{
+   char a[VAULT_PRINCIPAL_MAX], b[VAULT_PRINCIPAL_MAX];
+   assert(resolve(0, 1000, NULL, 0, a) == ATTEST_UDS_PEERCRED);
+   assert(resolve(0, 1001, NULL, 0, b) == ATTEST_UDS_PEERCRED);
+   assert(strcmp(a, b) != 0);
+   assert(strcmp(a, "uid:1000") == 0 && strcmp(b, "uid:1001") == 0);
+   printf("  PASS: test_distinct_uids_distinct_principals\n");
+}
+
+/* uid 0 (root) and unknown uid (-1) get NO principal: a zeroed/un-attested conn
+ * reads as uid 0, so it must never collapse to acting as root. Fail-closed. */
+static void test_uid_zero_and_unknown_refused(void)
+{
+   char p[VAULT_PRINCIPAL_MAX];
+   assert(resolve(0, 0, NULL, 0, p) == ATTEST_UDS_PEERCRED);
+   assert(p[0] == '\0'); /* no "uid:0" */
+
+   assert(resolve(0, -1, NULL, 0, p) == ATTEST_UDS_PEERCRED);
+   assert(p[0] == '\0');
+   printf("  PASS: test_uid_zero_and_unknown_refused\n");
+}
+
+/* Plain TCP is bearer-authorized but has no OS-user attestation -> no vault. */
+static void test_tcp_gets_no_principal(void)
+{
+   char p[VAULT_PRINCIPAL_MAX];
+   assert(resolve(1, -1, NULL, 0, p) == ATTEST_TCP_BEARER);
+   assert(p[0] == '\0');
+   /* Even a (nonsensical) peer_uid on TCP yields no principal. */
+   assert(resolve(1, 1000, NULL, 0, p) == ATTEST_TCP_BEARER);
+   assert(p[0] == '\0');
+   printf("  PASS: test_tcp_gets_no_principal\n");
+}
+
+/* A webuser asserted WITH a valid server.token is honored as webuser:<name>,
+ * regardless of the underlying transport (the webchat backend rides UDS). */
+static void test_webuser_with_token_honored(void)
+{
+   char p[VAULT_PRINCIPAL_MAX];
+   assert(resolve(0, 33, "alice", 1, p) == ATTEST_WEBCHAT_TRUSTED);
+   assert(strcmp(p, "webuser:alice") == 0);
+   /* Over TCP too (the dispatch path carries the bearer). */
+   assert(resolve(1, -1, "bob", 1, p) == ATTEST_WEBCHAT_TRUSTED);
+   assert(strcmp(p, "webuser:bob") == 0);
+   printf("  PASS: test_webuser_with_token_honored\n");
+}
+
+/* A webuser asserted WITHOUT the valid token is a spoof: the assertion is
+ * refused (empty principal) and the conn falls back to its transport class. */
+static void test_webuser_without_token_refused(void)
+{
+   char p[VAULT_PRINCIPAL_MAX];
+   /* Spoof over UDS: no webuser principal; transport stays UDS, but a uid:N is
+    * also NOT granted (the webuser assertion suppresses the uid path). */
+   assert(resolve(0, 1000, "mallory", 0, p) == ATTEST_UDS_PEERCRED);
+   assert(p[0] == '\0');
+   /* Spoof over TCP: refused, plain bearer transport. */
+   assert(resolve(1, -1, "mallory", 0, p) == ATTEST_TCP_BEARER);
+   assert(p[0] == '\0');
+   printf("  PASS: test_webuser_without_token_refused\n");
+}
+
+/* A short output buffer is a hard, fail-closed error (never a truncated
+ * principal that could alias another user). */
+static void test_short_buffer_fails_closed(void)
+{
+   char small[8];
+   small[0] = '\xff';
+   assert(vault_principal_resolve(0, 1000, NULL, 0, small, sizeof(small)) == ATTEST_NONE);
+   assert(small[0] == '\0');
+   /* NULL out is also safe. */
+   assert(vault_principal_resolve(0, 1000, NULL, 0, NULL, 0) == ATTEST_NONE);
+   printf("  PASS: test_short_buffer_fails_closed\n");
+}
+
+int main(void)
+{
+   test_uds_peer_uid_gets_principal();
+   test_distinct_uids_distinct_principals();
+   test_uid_zero_and_unknown_refused();
+   test_tcp_gets_no_principal();
+   test_webuser_with_token_honored();
+   test_webuser_without_token_refused();
+   test_short_buffer_fails_closed();
+   printf("vault_principal: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
First slice of the per-user credential vault (WP-C): capture each connection's attested identity and thread it to the delegate worker, **fail-closed**. No crypto yet — this is the foundation every vault path (WP-C.1/C.2) keys on.

## What

The *vault principal* — `uid:<peer_uid>` for a kernel-attested local UDS peer, or `webuser:<name>` for a webchat user asserted under the `server.token` boundary — is the **single** security key for the vault file + KEK cache, **never** a client-supplied `session_id`. Every `/v1` request reaches `server_dispatch` through `loopback_rpc`'s `memset`-zeroed fake conn, so the identity is carried across that boundary explicitly via three named, separately-tested hops.

- **`vault_principal.c`** — the pure resolver that decides "who owns this vault". Fail-closed: uid 0 / unknown uid / un-attested conn get **no** principal (a zeroed conn reads as uid 0, so it must never act as root); a `webuser` asserted **without** the valid `server.token` is refused a principal entirely (no fall-through to the shared service-account `uid:` vault); direct TCP gets no vault (D17).
- **`server_http_identity.c`** — the three-hop threading, isolated from `server_http.c` (at the line-count cap): **capture** (`handle_conn`, SO_PEERCRED + the token-gated `X-Aimee-Webuser` header) → **apply** (`loopback_rpc` copies onto the synthesized conn) → **clear** (after the route, so a reused worker thread cannot leak it).
- **`server_conn_t` + `compute_ctx_t`** gain `attested_transport` + `vault_principal`; `create_compute_ctx` copies them from the live conn so the detached worker — which runs after `conn_fd` is closed and no thread-local survives — resolves the right vault.

## Tests

- `unit-test-vault-principal`: every branch incl. the fail-closed ones (uid 0, unknown, TCP, webuser±token spoof, short buffer).
- `create_compute_ctx` hop-3 threading assertion in `unit-test-server-compute`.
- `unit-test-server-http` / `-dispatch` updated to link the new objects.

Full `aimee-server` links; `server_http.c` back under the 2000-line cap. Part of the delegate-refactor (WP-A/WP-B merged; D4 deferred).
