### PR TITLE
Promote: roundtable convenes from configured agents (no setup)

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -1717,6 +1717,7 @@ static cJSON *marshal_delegate_roundtable(int argc, char **argv)
    rpc_opts_t opts;
    rpc_parse(argc, argv, bool_flags, &opts);
    cJSON *req = marshal_no_args("delegate.roundtable");
+   cli_session_creds_prime(req); /* client-held agent keys for the panel this turn */
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "prompt", opts.positional[0]);
    const char *mode = rpc_get(&opts, "mode");
@@ -7014,7 +7015,8 @@ static int ws_ingest_collect_cb(const char *rel_path, const char *content, void 
    ws_ingest_ctx_t *s = (ws_ingest_ctx_t *)ctx;
    size_t flen = strlen(content) + strlen(rel_path) + 64;
 
-   if (s->batch && cJSON_GetArraySize(s->batch) > 0 && s->batch_bytes + flen > CLI_INGEST_BATCH_BYTES)
+   if (s->batch && cJSON_GetArraySize(s->batch) > 0 &&
+       s->batch_bytes + flen > CLI_INGEST_BATCH_BYTES)
       ws_ingest_flush(s);
 
    if (!s->batch)

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1790,6 +1790,31 @@ int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* Convene the ensemble panel from the enabled agents in the registry when no
+ * explicit ensemble.reference_models is configured. The ensemble / roundtable is
+ * core functionality and must work out of the box — it should not require a
+ * separate, operator-only config list on top of the agents the user has already
+ * set up. Caps at ENSEMBLE_MAX_REFS; defaults the aggregator to the first
+ * panellist when unset. */
+static void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg)
+{
+   if (cfg->ensemble_reference_count > 0)
+      return;
+   int n = 0;
+   for (int i = 0; i < acfg->agent_count && n < ENSEMBLE_MAX_REFS; i++)
+   {
+      if (!acfg->agents[i].enabled || !acfg->agents[i].name[0])
+         continue;
+      snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]), "%s",
+               acfg->agents[i].name);
+      n++;
+   }
+   cfg->ensemble_reference_count = n;
+   if (!cfg->ensemble_aggregator[0] && n > 0)
+      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
+               cfg->ensemble_reference_models[0]);
+}
+
 /* Mixture-of-Agents ensemble aggregate. Reached over the first-class
  * POST /v1/delegate/aggregate route (method "delegate.aggregate"), dispatched
  * async via rh_dispatch_op_async — so this runs on a detached op-run worker
@@ -1819,12 +1844,13 @@ int handle_delegate_aggregate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
    memset(&acfg, 0, sizeof(acfg));
    if (agent_load_config(&acfg) != 0)
       return server_send_error(conn, "could not load agents.json", NULL);
+   ensemble_default_panel_from_agents(&cfg, &acfg);
 
    delegate_ensemble_result_t result;
    int rc = delegate_ensemble_run(&acfg, &cfg, prompt, &result);
    if (rc != 0)
-      return server_send_error(
-          conn, "ensemble run failed (check ensemble.enabled / ensemble.reference_models)", NULL);
+      return server_send_error(conn, "ensemble run failed (no enabled agents in agents.json?)",
+                               NULL);
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "response", result.response);
@@ -1901,14 +1927,15 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
       free(brief.rendered);
       return server_send_error(conn, "could not load agents.json", NULL);
    }
+   ensemble_default_panel_from_agents(&cfg, &acfg);
 
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, prompt, &opts, &result);
    if (rc != 0)
    {
       free(brief.rendered);
-      return server_send_error(
-          conn, "roundtable run failed (check ensemble.enabled / ensemble.reference_models)", NULL);
+      return server_send_error(conn, "roundtable run failed (no enabled agents in agents.json?)",
+                               NULL);
    }
 
    cJSON *resp = jo_ok();


### PR DESCRIPTION
Promote testing→main. Includes #216: the ensemble/roundtable convenes from enabled agents in agents.json when ensemble.reference_models is empty (zero-config), primes client-held creds, drops stale ensemble.enabled text. CI green on #216.