### PR TITLE
WP-C.2a: webuser scrypt KEK + password-unlock (server-side)

### DIFF
--- a/src/headers/vault_crypto.h
+++ b/src/headers/vault_crypto.h
@@ -32,10 +32,20 @@
 #define VAULT_WRAPPED_DEK_LEN 40 /* RFC 3394 wrap of a 32-byte key = 40 bytes */
 #define VAULT_SALT_LEN        16 /* per-principal HKDF salt */
 
-/* The HKDF `info` label + a recorded version tag for the vault-file header so
- * the derivation can evolve without ambiguity. */
-#define VAULT_KEK_INFO    "aimee-vault-kek-v1"
-#define VAULT_KDF_VERSION "hkdf-sha256-v1"
+/* The HKDF `info` label + recorded version tags for the vault-file header so the
+ * derivation can evolve without ambiguity. uid: principals use HKDF over a
+ * high-entropy client root key; webuser: principals (WP-C.2) use scrypt over the
+ * lower-entropy login password (memory-hard offline-attack defense). */
+#define VAULT_KEK_INFO           "aimee-vault-kek-v1"
+#define VAULT_KDF_VERSION        "hkdf-sha256-v1"
+#define VAULT_KDF_VERSION_SCRYPT "scrypt-n17-r8-p1-v1"
+
+/* scrypt parameters for the webuser password KDF (D18): N=2^17, r=8, p=1. Memory
+ * cost ≈ 128*N*r ≈ 128 MiB, so the OpenSSL maxmem guard must allow it. */
+#define VAULT_SCRYPT_N      (1u << 17)
+#define VAULT_SCRYPT_R      8u
+#define VAULT_SCRYPT_P      1u
+#define VAULT_SCRYPT_MAXMEM ((uint64_t)512 * 1024 * 1024)
 
 /* Fill out[0..n) with cryptographically-strong random bytes. 0 on success;
  * -1 (fail-closed) if the RNG is unavailable — callers must abort the vault op,
@@ -47,6 +57,12 @@ int vault_crypto_random(uint8_t *out, size_t n);
  * VAULT_ROOT_KEY_LEN. 0 on success, -1 on failure (KEK cleansed). */
 int vault_kek_derive(const uint8_t *root_key, size_t root_key_len, const uint8_t *salt,
                      size_t salt_len, uint8_t kek[VAULT_KEK_LEN]);
+
+/* Derive the 32-byte KEK from a login password + per-principal salt via scrypt
+ * (memory-hard; WP-C.2 webuser path). 0 on success, -1 on failure (KEK cleansed).
+ * The caller OPENSSL_cleanse's the password after this returns. */
+int vault_kek_derive_scrypt(const uint8_t *password, size_t password_len, const uint8_t *salt,
+                            size_t salt_len, uint8_t kek[VAULT_KEK_LEN]);
 
 /* AES-KW (RFC 3394) wrap/unwrap of a DEK under the KEK. Unwrap returns -1 if the
  * built-in integrity check fails (wrong KEK or tampered wrapped_dek) — DEK

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -39,6 +39,15 @@ const char *vault_status_str(vault_status_t s);
 vault_status_t vault_service_unlock(const char *principal, attested_transport_t transport,
                                     const uint8_t *root_key, size_t root_key_len, long now_epoch);
 
+/* Unlock the `webuser:` vault (WP-C.2): derive the KEK from the login password
+ * via scrypt and cache it. Requires an ATTEST_WEBCHAT_TRUSTED principal (the
+ * webchat backend's server.token-gated assertion) with a non-empty principal and
+ * password — refused on any other transport (VAULT_ERR_TRANSPORT). The caller
+ * must OPENSSL_cleanse `password`. */
+vault_status_t vault_service_unlock_password(const char *principal, attested_transport_t transport,
+                                             const uint8_t *password, size_t password_len,
+                                             long now_epoch);
+
 /* Store `secret` for (agent, cred) under the principal's cached KEK. Requires an
  * unlocked vault (VAULT_ERR_LOCKED otherwise). */
 vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -71,17 +71,35 @@ static int hex_decode(const char *hex, uint8_t *out, size_t n)
 int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
-   cJSON *jrk = cJSON_GetObjectItemCaseSensitive(req, "root_key_hex");
-   if (!cJSON_IsString(jrk))
-      return server_send_error(conn, "vault: missing root_key_hex", NULL);
+   vault_status_t st;
 
-   uint8_t root_key[VAULT_ROOT_KEY_LEN];
-   if (hex_decode(jrk->valuestring, root_key, sizeof(root_key)) != 0)
-      return server_send_error(conn, "vault: root_key_hex must be 64 hex chars", NULL);
-
-   vault_status_t st = vault_service_unlock(conn->vault_principal, conn->attested_transport,
-                                            root_key, sizeof(root_key), time(NULL));
-   OPENSSL_cleanse(root_key, sizeof(root_key));
+   /* A webchat-asserted webuser principal unlocks with its login password
+    * (scrypt KEK, WP-C.2); a kernel-attested uid: peer unlocks with its 32-byte
+    * client root key (hex). The transport — not the request body — selects the
+    * path, so a request can't pick the wrong (weaker) unlock for its identity. */
+   if (conn->attested_transport == ATTEST_WEBCHAT_TRUSTED)
+   {
+      cJSON *jpw = cJSON_GetObjectItemCaseSensitive(req, "password");
+      if (!cJSON_IsString(jpw))
+         return server_send_error(conn, "vault: missing password", NULL);
+      st = vault_service_unlock_password(conn->vault_principal, conn->attested_transport,
+                                         (const uint8_t *)jpw->valuestring,
+                                         strlen(jpw->valuestring), time(NULL));
+      /* Best-effort scrub of the request-body copy of the password. */
+      OPENSSL_cleanse(jpw->valuestring, strlen(jpw->valuestring));
+   }
+   else
+   {
+      cJSON *jrk = cJSON_GetObjectItemCaseSensitive(req, "root_key_hex");
+      if (!cJSON_IsString(jrk))
+         return server_send_error(conn, "vault: missing root_key_hex", NULL);
+      uint8_t root_key[VAULT_ROOT_KEY_LEN];
+      if (hex_decode(jrk->valuestring, root_key, sizeof(root_key)) != 0)
+         return server_send_error(conn, "vault: root_key_hex must be 64 hex chars", NULL);
+      st = vault_service_unlock(conn->vault_principal, conn->attested_transport, root_key,
+                                sizeof(root_key), time(NULL));
+      OPENSSL_cleanse(root_key, sizeof(root_key));
+   }
    if (st != VAULT_OK)
       return vault_send_status_error(conn, st);
 

--- a/src/server/vault_crypto.c
+++ b/src/server/vault_crypto.c
@@ -46,6 +46,28 @@ int vault_kek_derive(const uint8_t *root_key, size_t root_key_len, const uint8_t
    return rc;
 }
 
+int vault_kek_derive_scrypt(const uint8_t *password, size_t password_len, const uint8_t *salt,
+                            size_t salt_len, uint8_t kek[VAULT_KEK_LEN])
+{
+   if (!kek)
+      return -1;
+   memset(kek, 0, VAULT_KEK_LEN);
+   /* A password may be any length incl. empty-rejected by the caller; salt must
+    * be present. */
+   if (!password || (!salt && salt_len) || salt_len == 0)
+      return -1;
+
+   /* EVP_PBE_scrypt returns 1 on success; a non-1 (incl. the memory-limit guard)
+    * is fail-closed. */
+   if (EVP_PBE_scrypt((const char *)password, password_len, salt, salt_len, VAULT_SCRYPT_N,
+                      VAULT_SCRYPT_R, VAULT_SCRYPT_P, VAULT_SCRYPT_MAXMEM, kek, VAULT_KEK_LEN) != 1)
+   {
+      OPENSSL_cleanse(kek, VAULT_KEK_LEN);
+      return -1;
+   }
+   return 0;
+}
+
 int vault_dek_wrap(const uint8_t kek[VAULT_KEK_LEN], const uint8_t dek[VAULT_DEK_LEN],
                    uint8_t wrapped[VAULT_WRAPPED_DEK_LEN])
 {

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -68,6 +68,38 @@ vault_status_t vault_service_unlock(const char *principal, attested_transport_t 
    return st;
 }
 
+vault_status_t vault_service_unlock_password(const char *principal, attested_transport_t transport,
+                                             const uint8_t *password, size_t password_len,
+                                             long now_epoch)
+{
+   if (!principal || !principal[0])
+      return VAULT_ERR_UNATTESTED;
+   /* The password unlock is for the webchat-asserted webuser principal only,
+    * honored under the server.token trust boundary (ATTEST_WEBCHAT_TRUSTED). A
+    * uid:/TCP conn must use the root-key unlock instead. */
+   if (transport != ATTEST_WEBCHAT_TRUSTED)
+      return VAULT_ERR_TRANSPORT;
+   if (!password || password_len == 0)
+      return VAULT_ERR_BADARG;
+
+   uint8_t salt[VAULT_SALT_LEN];
+   if (vault_store_get_or_create_salt(principal, salt) != 0)
+      return VAULT_ERR_IO;
+
+   uint8_t kek[VAULT_KEK_LEN];
+   vault_status_t st = VAULT_OK;
+   if (vault_kek_derive_scrypt(password, password_len, salt, sizeof(salt), kek) != 0)
+      st = VAULT_ERR_CRYPTO;
+   else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
+      st = VAULT_ERR_LOCKED;
+
+   OPENSSL_cleanse(kek, sizeof(kek));
+   OPENSSL_cleanse(salt, sizeof(salt));
+   if (st == VAULT_OK)
+      LOG_INFO("vault", "webuser vault unlocked (scrypt)");
+   return st;
+}
+
 vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,
                                  const char *secret, long now_epoch)
 {

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -294,7 +294,11 @@ int vault_store_get_or_create_salt(const char *principal, uint8_t salt[VAULT_SAL
          goto done;
       cJSON_AddNumberToObject(root, "version", VAULT_FILE_VERSION);
       cJSON_AddStringToObject(root, "principal", principal);
-      cJSON_AddStringToObject(root, "kdf_version", VAULT_KDF_VERSION);
+      /* Record which KDF unlock will use: webuser: principals derive the KEK from
+       * the login password via scrypt; uid: principals use HKDF over a root key. */
+      cJSON_AddStringToObject(root, "kdf_version",
+                              strncmp(principal, "webuser:", 8) == 0 ? VAULT_KDF_VERSION_SCRYPT
+                                                                     : VAULT_KDF_VERSION);
       cJSON_AddStringToObject(root, "salt", salt_b64);
       cJSON_AddArrayToObject(root, "creds");
       free(salt_b64);

--- a/src/tests/test_vault_crypto.c
+++ b/src/tests/test_vault_crypto.c
@@ -182,10 +182,48 @@ static void test_full_envelope_roundtrip(void)
    printf("  PASS: test_full_envelope_roundtrip\n");
 }
 
+/* WP-C.2: scrypt KEK derivation for the webuser password path — deterministic,
+ * salt- and password-sensitive, and usable as a KEK in the full envelope. */
+static void test_scrypt_kek_derive(void)
+{
+   const uint8_t pw[] = "correct horse battery staple";
+   uint8_t salt1[VAULT_SALT_LEN], salt2[VAULT_SALT_LEN];
+   memset(salt1, 0x31, sizeof(salt1));
+   memset(salt2, 0x32, sizeof(salt2));
+
+   uint8_t k1[VAULT_KEK_LEN], k1b[VAULT_KEK_LEN], k2[VAULT_KEK_LEN];
+   assert(vault_kek_derive_scrypt(pw, sizeof(pw) - 1, salt1, sizeof(salt1), k1) == 0);
+   assert(vault_kek_derive_scrypt(pw, sizeof(pw) - 1, salt1, sizeof(salt1), k1b) == 0);
+   assert(memcmp(k1, k1b, VAULT_KEK_LEN) == 0); /* deterministic */
+   assert(vault_kek_derive_scrypt(pw, sizeof(pw) - 1, salt2, sizeof(salt2), k2) == 0);
+   assert(memcmp(k1, k2, VAULT_KEK_LEN) != 0); /* salt changes the KEK */
+
+   const uint8_t pw2[] = "wrong password";
+   uint8_t k3[VAULT_KEK_LEN];
+   assert(vault_kek_derive_scrypt(pw2, sizeof(pw2) - 1, salt1, sizeof(salt1), k3) == 0);
+   assert(memcmp(k1, k3, VAULT_KEK_LEN) != 0); /* password changes the KEK */
+
+   /* A scrypt-derived KEK round-trips a credential like any other KEK. */
+   uint8_t dek[VAULT_DEK_LEN], wrapped[VAULT_WRAPPED_DEK_LEN], out[VAULT_DEK_LEN];
+   assert(vault_crypto_random(dek, sizeof(dek)) == 0);
+   assert(vault_dek_wrap(k1, dek, wrapped) == 0);
+   assert(vault_dek_unwrap(k1, wrapped, out) == 0);
+   assert(memcmp(out, dek, VAULT_DEK_LEN) == 0);
+   /* The HKDF and scrypt KEKs for the same salt differ (distinct KDFs). */
+   uint8_t root[VAULT_ROOT_KEY_LEN], hk[VAULT_KEK_LEN];
+   memset(root, 0x55, sizeof(root));
+   assert(vault_kek_derive(root, sizeof(root), salt1, sizeof(salt1), hk) == 0);
+   assert(memcmp(hk, k1, VAULT_KEK_LEN) != 0);
+
+   assert(vault_kek_derive_scrypt(pw, sizeof(pw) - 1, salt1, 0, k1) == -1); /* salt required */
+   printf("  PASS: test_scrypt_kek_derive\n");
+}
+
 int main(void)
 {
    test_random_distinct_and_sized();
    test_kek_derive_deterministic_and_salted();
+   test_scrypt_kek_derive();
    test_dek_wrap_roundtrip_and_tamper();
    test_secret_gcm_roundtrip();
    test_secret_fresh_nonce_per_encrypt();

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -120,6 +120,49 @@ static void test_list_and_delete(void)
    printf("  PASS: test_list_and_delete\n");
 }
 
+/* WP-C.2: the webuser password unlock (scrypt). */
+static void test_webuser_password_unlock(void)
+{
+   const char *p = "webuser:alice";
+   const uint8_t pw[] = "alice-login-password";
+
+   /* set before unlock => locked. */
+   assert(vault_service_set(p, "claude", "api_key", "s", T0) == VAULT_ERR_LOCKED);
+
+   /* Password unlock requires the webchat-trusted transport. */
+   assert(vault_service_unlock_password(p, ATTEST_UDS_PEERCRED, pw, sizeof(pw) - 1, T0) ==
+          VAULT_ERR_TRANSPORT);
+   assert(vault_service_unlock_password(p, ATTEST_TCP_BEARER, pw, sizeof(pw) - 1, T0) ==
+          VAULT_ERR_TRANSPORT);
+   assert(vault_service_unlock_password("", ATTEST_WEBCHAT_TRUSTED, pw, sizeof(pw) - 1, T0) ==
+          VAULT_ERR_UNATTESTED);
+
+   /* Unlock + round-trip. */
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, pw, sizeof(pw) - 1, T0) ==
+          VAULT_OK);
+   assert(vault_service_set(p, "claude", "api_key", "sk-webuser-secret", T0) == VAULT_OK);
+   char out[64];
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
+   assert(strcmp(out, "sk-webuser-secret") == 0);
+
+   /* A different password derives a different KEK -> the stored cred fails closed
+    * (lock first so the cache miss forces re-derivation). */
+   assert(vault_service_lock(p) == VAULT_OK);
+   const uint8_t wrong[] = "not-alices-password";
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, wrong, sizeof(wrong) - 1, T0) ==
+          VAULT_OK); /* unlock "succeeds" (caches a KEK) ... */
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) ==
+          VAULT_ERR_CRYPTO); /* ... but the wrong KEK cannot decrypt -> fail closed */
+
+   /* The right password again decrypts. */
+   assert(vault_service_lock(p) == VAULT_OK);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, pw, sizeof(pw) - 1, T0) ==
+          VAULT_OK);
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
+   assert(strcmp(out, "sk-webuser-secret") == 0);
+   printf("  PASS: test_webuser_password_unlock\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultsvc-test-%d", (int)getpid());
@@ -135,6 +178,7 @@ int main(void)
    test_locked_vs_missing();
    test_ttl_expiry_locks();
    test_list_and_delete();
+   test_webuser_password_unlock();
 
    vault_kek_cache_clear();
    char rm[320];


### PR DESCRIPTION
The server-side foundation for the webchat (`webuser:`) credential vault — the keyless-browser path. Reuses the entire WP-C.1 crypto/store/cache/service stack; only the **identity source** (the `server.token`-gated `X-Aimee-Webuser` assertion, already classified in WP-C.0) and the **KEK source** differ.

## What
- **`vault_kek_derive_scrypt`** — scrypt (N=2¹⁷, r=8, p=1; memory-hard, ~128 MiB) over the login password + per-principal salt. scrypt not argon2id because the deploy image is OpenSSL 3.0 (D18). Fail-closed, KEK cleansed.
- **`vault_service_unlock_password`** — derive + cache the KEK from the password; requires an **`ATTEST_WEBCHAT_TRUSTED`** principal (refused on UDS/TCP, which use the root-key unlock).
- **`handle_vault_unlock` routes by the attested transport, not the body** — a webuser conn unlocks with `{password}` (scrypt), a uid: conn with `{root_key_hex}` (HKDF); a request can't pick the weaker unlock for its identity. The body password copy is cleansed after derivation.
- The vault file records the principal-appropriate `kdf_version` (scrypt for `webuser:`, hkdf for `uid:`) so it's self-describing.

## Tests
scrypt determinism + salt/password sensitivity + envelope round-trip + HKDF≠scrypt for the same salt; webuser unlock round-trip, the transport gates (UDS/TCP refused, blank principal refused), and a **wrong password failing closed** on decrypt.

## Remaining WP-C.2 (follow-up PR)
The webchat Go backend wiring (assert `X-Aimee-Webuser` + forward `server.token` on the token-bearing dispatch path; unlock at `requireAuth`) and the deferred streaming-path identity capture.

Server-side only; reviewed-before-merge per protocol.
