### PR TITLE
Bind credential session for ensemble/roundtable panels

### DIFF
--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -510,6 +510,18 @@ static const char *compute_request_session_id(cJSON *req)
    return NULL;
 }
 
+/* Bind this request's per-turn creds (RAM-keyring session id + Codex creds),
+ * shared by every delegate entry so single delegate and aggregate/roundtable
+ * panels resolve client-held keys identically; without it a panel runs keyless. */
+static void bind_request_session_creds(cJSON *req)
+{
+   const char *cred_sid = jo_str(req, "cred_session_id", NULL);
+   agent_set_request_session((cred_sid && cred_sid[0]) ? cred_sid
+                                                       : compute_request_session_id(req));
+   agent_set_request_codex_creds(jo_str(req, "codex_oauth_token", NULL),
+                                 jo_str(req, "codex_account_id", NULL));
+}
+
 static int delegate_dispatch(server_ctx_t *ctx, compute_ctx_t *cctx)
 {
    if (g_delegate_dispatch_override)
@@ -724,16 +736,7 @@ void delegate_worker(void *arg)
    char delegate_git_root[MAX_PATH_LEN] = "";
    char delegate_work_name[32] = "";
    cJSON *req = cctx->req;
-   /* Per-turn credential context: credential-session id (RAM keyring; a
-    * dedicated field decoupled from the chat session id) + any per-turn Codex
-    * creds (legacy direct push). Empty/absent clears them. */
-   {
-      const char *cred_sid = jo_str(req, "cred_session_id", NULL);
-      agent_set_request_session((cred_sid && cred_sid[0]) ? cred_sid
-                                                          : compute_request_session_id(req));
-   }
-   agent_set_request_codex_creds(jo_str(req, "codex_oauth_token", NULL),
-                                 jo_str(req, "codex_account_id", NULL));
+   bind_request_session_creds(req);
    cJSON *jrole = cJSON_GetObjectItemCaseSensitive(req, "role");
    cJSON *jprompt = cJSON_GetObjectItemCaseSensitive(req, "prompt");
    cJSON *jmax = cJSON_GetObjectItemCaseSensitive(req, "max_tokens");
@@ -1805,12 +1808,8 @@ int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
-/* Convene the ensemble panel from the enabled agents in the registry when no
- * explicit ensemble.reference_models is configured. The ensemble / roundtable is
- * core functionality and must work out of the box — it should not require a
- * separate, operator-only config list on top of the agents the user has already
- * set up. Caps at ENSEMBLE_MAX_REFS; defaults the aggregator to the first
- * panellist when unset. */
+/* Convene the ensemble panel from enabled registry agents when no explicit
+ * ensemble.reference_models is set. Caps at ENSEMBLE_MAX_REFS; aggregator -> 0. */
 static void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg)
 {
    if (cfg->ensemble_reference_count > 0)
@@ -1832,10 +1831,9 @@ static void ensemble_default_panel_from_agents(config_t *cfg, const agent_config
 
 /* Mixture-of-Agents ensemble aggregate. Reached over the first-class
  * POST /v1/delegate/aggregate route (method "delegate.aggregate"), dispatched
- * async via rh_dispatch_op_async — so this runs on a detached op-run worker
- * thread, never the buffered listener, and the LLM fan-out may block here. The
- * run result is finalized into /v1/runs/{id}. Before this entry point existed,
- * delegate_ensemble_run had no caller in any shipped binary. */
+ * async via rh_dispatch_op_async onto a detached op-run worker (never the
+ * buffered listener — the LLM fan-out may block here); result finalized into
+ * /v1/runs/{id}. */
 int handle_delegate_aggregate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -1860,6 +1858,7 @@ int handle_delegate_aggregate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
    if (agent_load_config(&acfg) != 0)
       return server_send_error(conn, "could not load agents.json", NULL);
    ensemble_default_panel_from_agents(&cfg, &acfg);
+   bind_request_session_creds(req);
 
    delegate_ensemble_result_t result;
    int rc = delegate_ensemble_run(&acfg, &cfg, prompt, &result);
@@ -1943,6 +1942,7 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
       return server_send_error(conn, "could not load agents.json", NULL);
    }
    ensemble_default_panel_from_agents(&cfg, &acfg);
+   bind_request_session_creds(req);
 
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, prompt, &opts, &result);


### PR DESCRIPTION
## Summary

Follow-up to #216. With #216 the roundtable convenes from configured agents, but validating it end-to-end against a live server exposed a second bug: the panel ran **keyless**.

The single-delegate handler binds the per-turn credential context at entry — `agent_set_request_session(cred_session_id)` + Codex creds — so the delegate resolves its client-held keys. The **aggregate** and **roundtable** handlers convene a *panel* that runs through the same agent runtime but never performed that binding. Result: a roundtable would convene and run its rounds, but every panellist reached no provider — the run came back `degraded`, empty `artifact`, `cost_usd: 0`.

- Add `ensemble_bind_request_session(req)` and call it in both `handle_delegate_aggregate` and `handle_delegate_roundtable`, immediately before the run. It mirrors the single-delegate binding exactly (`cred_session_id` → RAM keyring session, plus per-turn Codex creds).

A thin client pushes its keyring to the server's session cache and stamps `cred_session_id` via `cli_session_creds_prime` (already wired for roundtable in #216); the server now consumes it for the panel.

## Testing
- `make verify-local` + full `make unit-tests` green (serial; parallel-LTO flakes on this host).
- Reproduced live on `.254` (v0.2.52, post-#216): `delegate roundtable` returned `rounds_run:3` but `degraded:true, cost_usd:0` — panel keyless. A plain `delegate` on the same session returned output, isolating the gap to the panel handlers.
