### PR TITLE
WP-C.2b: vault.rekey (webuser password change) + OpenAPI nit

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1141,9 +1141,14 @@ paths:
       responses: { "200": { description: Delegate status, content: { application/json: { schema: { type: object } } } } }
   /vault/unlock:
     post:
-      summary: Unlock the per-user credential vault with the client root key (UDS-only)
+      summary: "Unlock the credential vault (uid root key over UDS, or webuser login password under server.token)"
       requestBody: { content: { application/json: { schema: { type: object } } } }
       responses: { "200": { description: Unlocked, content: { application/json: { schema: { type: object } } } } }
+  /vault/rekey:
+    post:
+      summary: Re-key a webuser vault on a login-password change (re-wraps DEKs, no re-encryption)
+      requestBody: { content: { application/json: { schema: { type: object } } } }
+      responses: { "200": { description: Re-keyed, content: { application/json: { schema: { type: object } } } } }
   /vault/set:
     post:
       summary: Store an encrypted credential in the unlocked vault

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -163,6 +163,7 @@ static const struct
     {"vault.delete", "POST", "/v1/vault/delete"},
     {"vault.list", "POST", "/v1/vault/list"},
     {"vault.lock", "POST", "/v1/vault/lock"},
+    {"vault.rekey", "POST", "/v1/vault/rekey"},
     {"vault.set", "POST", "/v1/vault/set"},
     {"vault.unlock", "POST", "/v1/vault/unlock"},
     {"wm.context", "POST", "/v1/wm/context"},

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -367,6 +367,7 @@ int handle_delegate_launch(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_delegate_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 /* Credential vault (WP-C.1): resolve the attested principal from the conn. */
 int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_vault_rekey(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_delete(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -48,6 +48,17 @@ vault_status_t vault_service_unlock_password(const char *principal, attested_tra
                                              const uint8_t *password, size_t password_len,
                                              long now_epoch);
 
+/* Re-wrap a webuser vault on a login-password change (WP-C.2): derive the old +
+ * new KEKs (scrypt over the principal's stored salt) and re-wrap every DEK; the
+ * stored credentials are NOT re-encrypted. On success the new KEK is cached (the
+ * vault stays unlocked under the new password). Requires ATTEST_WEBCHAT_TRUSTED.
+ * Fail-closed: a wrong old password (KEK can't unwrap) leaves the vault
+ * untouched. The caller OPENSSL_cleanse's both passwords. */
+vault_status_t vault_service_rekey_password(const char *principal, attested_transport_t transport,
+                                            const uint8_t *old_password, size_t old_len,
+                                            const uint8_t *new_password, size_t new_len,
+                                            long now_epoch);
+
 /* Store `secret` for (agent, cred) under the principal's cached KEK. Requires an
  * unlocked vault (VAULT_ERR_LOCKED otherwise). */
 vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,

--- a/src/headers/vault_store.h
+++ b/src/headers/vault_store.h
@@ -41,6 +41,21 @@ typedef struct
  * created. 0 on success (salt filled), -1 on error. */
 int vault_store_get_or_create_salt(const char *principal, uint8_t salt[VAULT_SALT_LEN]);
 
+/* Read an EXISTING principal's salt without creating the vault file. Returns 0 on
+ * success, -1 if the vault does not exist or is corrupt. Used by rekey so a
+ * password change against a non-existent principal fails closed without
+ * materializing an (attacker-controlled) vault. */
+int vault_store_salt_readonly(const char *principal, uint8_t salt[VAULT_SALT_LEN]);
+
+/* Validate a derived KEK against the principal's stored key-check verifier — a
+ * fixed sentinel wrapped under the KEK — so a wrong password is caught
+ * immediately and INDEPENDENTLY of how many credentials exist (an empty vault is
+ * the normal fresh state). On the FIRST unlock (no verifier yet) the verifier is
+ * established from this KEK and 0 is returned. Thereafter: 0 if the KEK matches,
+ * -1 if it does not (wrong password/root key) or the vault is missing/corrupt.
+ * Call right after deriving the KEK at unlock, before caching it. */
+int vault_store_unlock_check(const char *principal, const uint8_t kek[VAULT_KEK_LEN]);
+
 /* Encrypt `secret` for (principal, agent, cred) under `kek` and upsert it into
  * the principal's vault file (fresh DEK + nonce each time; existing entry
  * replaced). The vault file must already exist (unlock establishes it). 0 on

--- a/src/headers/vault_store.h
+++ b/src/headers/vault_store.h
@@ -68,4 +68,12 @@ int vault_store_list(const char *principal, vault_store_entry_t *out, int max);
  * success (incl. already-absent), -1 on error. */
 int vault_store_delete(const char *principal, const char *agent, const char *cred);
 
+/* Re-wrap every credential's DEK from `old_kek` to `new_kek` (the password-change
+ * path, WP-C.2): unwrap each DEK under old_kek, re-wrap under new_kek; the DEKs,
+ * nonces, ciphertext and tags are untouched (no secret is re-encrypted). Atomic:
+ * if ANY unwrap fails (wrong old_kek / tamper) nothing is written and -1 is
+ * returned (fail-closed). 0 on success (incl. an empty vault). */
+int vault_store_rekey(const char *principal, const uint8_t old_kek[VAULT_KEK_LEN],
+                      const uint8_t new_kek[VAULT_KEK_LEN]);
+
 #endif /* DEC_VAULT_STORE_H */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1148,6 +1148,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"delegate.launch", handle_delegate_launch},
     {"delegate.status", handle_delegate_status},
     {"vault.unlock", handle_vault_unlock},
+    {"vault.rekey", handle_vault_rekey},
     {"vault.set", handle_vault_set},
     {"vault.list", handle_vault_list},
     {"vault.delete", handle_vault_delete},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -91,6 +91,7 @@ const method_policy_t method_registry[] = {
      * any non-ATTEST_UDS_PEERCRED principal — but gated here as CAP_DELEGATE so a
      * scoped/read-only TCP bearer cannot even reach the route. */
     {"vault.unlock", CAP_DELEGATE, "unlock the credential vault"},
+    {"vault.rekey", CAP_DELEGATE, "re-key the credential vault (password change)"},
     {"vault.set", CAP_DELEGATE, "store a vault credential"},
     {"vault.list", CAP_DELEGATE, "list vault credential names"},
     {"vault.delete", CAP_DELEGATE, "delete a vault credential"},

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -879,6 +879,7 @@ static const http_route_t g_v1_routes[] = {
      * so these are dispatched through the same inline bridge as the delegate
      * methods. None stream. */
     {"POST", "/v1/vault/unlock", NULL, RM_EXACT, "vault.unlock", 0, rh_dispatch_op},
+    {"POST", "/v1/vault/rekey", NULL, RM_EXACT, "vault.rekey", 0, rh_dispatch_op},
     {"POST", "/v1/vault/set", NULL, RM_EXACT, "vault.set", 0, rh_dispatch_op},
     {"POST", "/v1/vault/list", NULL, RM_EXACT, "vault.list", 0, rh_dispatch_op},
     {"POST", "/v1/vault/delete", NULL, RM_EXACT, "vault.delete", 0, rh_dispatch_op},

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -111,6 +111,32 @@ int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, resp);
 }
 
+/* POST /v1/vault/rekey — re-wrap a webuser vault on a login-password change.
+ * Takes {old_password, new_password}; webchat-trusted transport only. */
+int handle_vault_rekey(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   cJSON *jold = cJSON_GetObjectItemCaseSensitive(req, "old_password");
+   cJSON *jnew = cJSON_GetObjectItemCaseSensitive(req, "new_password");
+   if (!cJSON_IsString(jold) || !cJSON_IsString(jnew))
+      return server_send_error(conn, "vault: rekey requires old_password, new_password", NULL);
+
+   vault_status_t st = vault_service_rekey_password(
+       conn->vault_principal, conn->attested_transport, (const uint8_t *)jold->valuestring,
+       strlen(jold->valuestring), (const uint8_t *)jnew->valuestring, strlen(jnew->valuestring),
+       time(NULL));
+   OPENSSL_cleanse(jold->valuestring, strlen(jold->valuestring));
+   OPENSSL_cleanse(jnew->valuestring, strlen(jnew->valuestring));
+   if (st != VAULT_OK)
+      return vault_send_status_error(conn, st);
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+      return server_send_error(conn, "vault: out of memory", NULL);
+   cJSON_AddStringToObject(resp, "status", "ok");
+   return server_send_ok(conn, resp);
+}
+
 /* POST /v1/vault/set — store a credential under the unlocked vault. */
 int handle_vault_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -58,6 +58,8 @@ vault_status_t vault_service_unlock(const char *principal, attested_transport_t 
    vault_status_t st = VAULT_OK;
    if (vault_kek_derive(root_key, root_key_len, salt, sizeof(salt), kek) != 0)
       st = VAULT_ERR_CRYPTO;
+   else if (vault_store_unlock_check(principal, kek) != 0)
+      st = VAULT_ERR_CRYPTO; /* wrong root key — caught by the key-check verifier */
    else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
       st = VAULT_ERR_LOCKED; /* cache full of live principals — reject, don't evict */
 
@@ -90,6 +92,8 @@ vault_status_t vault_service_unlock_password(const char *principal, attested_tra
    vault_status_t st = VAULT_OK;
    if (vault_kek_derive_scrypt(password, password_len, salt, sizeof(salt), kek) != 0)
       st = VAULT_ERR_CRYPTO;
+   else if (vault_store_unlock_check(principal, kek) != 0)
+      st = VAULT_ERR_CRYPTO; /* wrong password — caught by the key-check verifier */
    else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
       st = VAULT_ERR_LOCKED;
 
@@ -112,9 +116,11 @@ vault_status_t vault_service_rekey_password(const char *principal, attested_tran
    if (!old_password || old_len == 0 || !new_password || new_len == 0)
       return VAULT_ERR_BADARG;
 
+   /* Read-only: a rekey against a non-existent principal must fail closed, never
+    * materialize a vault an attacker could then own. */
    uint8_t salt[VAULT_SALT_LEN];
-   if (vault_store_get_or_create_salt(principal, salt) != 0)
-      return VAULT_ERR_IO;
+   if (vault_store_salt_readonly(principal, salt) != 0)
+      return VAULT_ERR_CRYPTO;
 
    uint8_t old_kek[VAULT_KEK_LEN], new_kek[VAULT_KEK_LEN];
    vault_status_t st = VAULT_OK;

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -100,6 +100,40 @@ vault_status_t vault_service_unlock_password(const char *principal, attested_tra
    return st;
 }
 
+vault_status_t vault_service_rekey_password(const char *principal, attested_transport_t transport,
+                                            const uint8_t *old_password, size_t old_len,
+                                            const uint8_t *new_password, size_t new_len,
+                                            long now_epoch)
+{
+   if (!principal || !principal[0])
+      return VAULT_ERR_UNATTESTED;
+   if (transport != ATTEST_WEBCHAT_TRUSTED)
+      return VAULT_ERR_TRANSPORT;
+   if (!old_password || old_len == 0 || !new_password || new_len == 0)
+      return VAULT_ERR_BADARG;
+
+   uint8_t salt[VAULT_SALT_LEN];
+   if (vault_store_get_or_create_salt(principal, salt) != 0)
+      return VAULT_ERR_IO;
+
+   uint8_t old_kek[VAULT_KEK_LEN], new_kek[VAULT_KEK_LEN];
+   vault_status_t st = VAULT_OK;
+   if (vault_kek_derive_scrypt(old_password, old_len, salt, sizeof(salt), old_kek) != 0 ||
+       vault_kek_derive_scrypt(new_password, new_len, salt, sizeof(salt), new_kek) != 0)
+      st = VAULT_ERR_CRYPTO;
+   else if (vault_store_rekey(principal, old_kek, new_kek) != 0)
+      st = VAULT_ERR_CRYPTO; /* wrong old password / tamper -> fail closed, vault untouched */
+   else if (vault_kek_cache_put(principal, new_kek, now_epoch) != 0)
+      st = VAULT_ERR_LOCKED; /* re-wrap succeeded but cache full; caller can re-unlock */
+
+   OPENSSL_cleanse(old_kek, sizeof(old_kek));
+   OPENSSL_cleanse(new_kek, sizeof(new_kek));
+   OPENSSL_cleanse(salt, sizeof(salt));
+   if (st == VAULT_OK)
+      LOG_INFO("vault", "webuser vault re-keyed (password change)");
+   return st;
+}
+
 vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,
                                  const char *secret, long now_epoch)
 {

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -474,6 +474,56 @@ out:
    return rc;
 }
 
+int vault_store_rekey(const char *principal, const uint8_t old_kek[VAULT_KEK_LEN],
+                      const uint8_t new_kek[VAULT_KEK_LEN])
+{
+   if (!principal || !old_kek || !new_kek)
+      return -1;
+   pthread_mutex_lock(&g_vault_write_mu);
+   cJSON *root = load_vault(principal);
+   if (!root)
+   {
+      pthread_mutex_unlock(&g_vault_write_mu);
+      return -1; /* no vault to rekey */
+   }
+
+   int rc = 0;
+   cJSON *creds = creds_array(root);
+   cJSON *e = NULL;
+   if (creds)
+   {
+      cJSON_ArrayForEach(e, creds)
+      {
+         cJSON *jw = cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek");
+         uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], dek[VAULT_DEK_LEN],
+             rewrapped[VAULT_WRAPPED_DEK_LEN];
+         if (!cJSON_IsString(jw) ||
+             b64url_decode(jw->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+             vault_dek_unwrap(old_kek, wrapped, dek) != 0 ||
+             vault_dek_wrap(new_kek, dek, rewrapped) != 0)
+         {
+            OPENSSL_cleanse(dek, sizeof(dek));
+            rc = -1; /* wrong old KEK / tamper -> abort, write nothing */
+            break;
+         }
+         char *enc = b64url_encode(rewrapped, sizeof(rewrapped));
+         OPENSSL_cleanse(dek, sizeof(dek));
+         if (!enc)
+         {
+            rc = -1;
+            break;
+         }
+         cJSON_SetValuestring(jw, enc);
+         free(enc);
+      }
+   }
+   if (rc == 0)
+      rc = write_vault_file(principal, root);
+   cJSON_Delete(root);
+   pthread_mutex_unlock(&g_vault_write_mu);
+   return rc;
+}
+
 int vault_store_has_entry(const char *principal, const char *agent, const char *cred)
 {
    if (!principal || !agent || !cred)

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -28,6 +28,14 @@ static pthread_mutex_t g_vault_write_mu = PTHREAD_MUTEX_INITIALIZER;
 #define VAULT_SECRET_MAX   4096 /* max credential plaintext length */
 #define VAULT_AAD_MAX      320  /* "principal|agent|cred" (160 + 64 + 64 + seps) */
 
+/* A fixed 32-byte sentinel AES-KW-wrapped under the KEK is the vault's key-check
+ * verifier: it lets unlock + rekey prove a derived KEK is correct WITHOUT any
+ * stored credential, closing the empty-vault rekey fail-open. (Not secret — its
+ * only role is that AES-KW unwrap fails the RFC 3394 ICV under the wrong KEK.) */
+static const uint8_t VAULT_KEK_CHECK_SENTINEL[VAULT_DEK_LEN] = {
+    0x61, 0x69, 0x6d, 0x65, 0x65, 0x2d, 0x76, 0x61, 0x75, 0x6c, 0x74, 0x2d, 0x6b, 0x65, 0x6b, 0x2d,
+    0x63, 0x68, 0x65, 0x63, 0x6b, 0x2d, 0x76, 0x31, 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77};
+
 /* Detach + free the (agent,cred) entry from the creds array if present. */
 static void remove_cred(cJSON *creds, cJSON *entry)
 {
@@ -474,6 +482,81 @@ out:
    return rc;
 }
 
+int vault_store_salt_readonly(const char *principal, uint8_t salt[VAULT_SALT_LEN])
+{
+   if (!principal || !principal[0] || !salt)
+      return -1;
+   cJSON *root = load_vault(principal);
+   if (!root)
+      return -1;
+   cJSON *js = cJSON_GetObjectItemCaseSensitive(root, "salt");
+   int ok =
+       cJSON_IsString(js) && b64url_decode(js->valuestring, salt, VAULT_SALT_LEN) == VAULT_SALT_LEN;
+   cJSON_Delete(root);
+   if (!ok)
+      OPENSSL_cleanse(salt, VAULT_SALT_LEN);
+   return ok ? 0 : -1;
+}
+
+/* True if `kek` unwraps the stored kek_check verifier to the sentinel. */
+static int kek_check_matches(cJSON *root, const uint8_t kek[VAULT_KEK_LEN])
+{
+   cJSON *jc = cJSON_GetObjectItemCaseSensitive(root, "kek_check");
+   uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], out[VAULT_DEK_LEN];
+   if (!cJSON_IsString(jc) ||
+       b64url_decode(jc->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+       vault_dek_unwrap(kek, wrapped, out) != 0)
+      return 0;
+   int ok = memcmp(out, VAULT_KEK_CHECK_SENTINEL, VAULT_DEK_LEN) == 0;
+   OPENSSL_cleanse(out, sizeof(out));
+   return ok;
+}
+
+/* Wrap the sentinel under `kek` into the root's kek_check field. 0 on success. */
+static int kek_check_set(cJSON *root, const uint8_t kek[VAULT_KEK_LEN])
+{
+   uint8_t wrapped[VAULT_WRAPPED_DEK_LEN];
+   if (vault_dek_wrap(kek, VAULT_KEK_CHECK_SENTINEL, wrapped) != 0)
+      return -1;
+   char *enc = b64url_encode(wrapped, sizeof(wrapped));
+   if (!enc)
+      return -1;
+   cJSON *existing = cJSON_GetObjectItemCaseSensitive(root, "kek_check");
+   if (cJSON_IsString(existing))
+      cJSON_SetValuestring(existing, enc);
+   else
+      cJSON_AddStringToObject(root, "kek_check", enc);
+   free(enc);
+   return 0;
+}
+
+int vault_store_unlock_check(const char *principal, const uint8_t kek[VAULT_KEK_LEN])
+{
+   if (!principal || !kek)
+      return -1;
+   pthread_mutex_lock(&g_vault_write_mu);
+   cJSON *root = load_vault(principal);
+   if (!root)
+   {
+      pthread_mutex_unlock(&g_vault_write_mu);
+      return -1;
+   }
+   int rc;
+   if (cJSON_IsString(cJSON_GetObjectItemCaseSensitive(root, "kek_check")))
+   {
+      /* Established already: this KEK is valid only if it unwraps the verifier. */
+      rc = kek_check_matches(root, kek) ? 0 : -1;
+   }
+   else
+   {
+      /* First unlock: establish the verifier from this KEK (write-back). */
+      rc = (kek_check_set(root, kek) == 0 && write_vault_file(principal, root) == 0) ? 0 : -1;
+   }
+   cJSON_Delete(root);
+   pthread_mutex_unlock(&g_vault_write_mu);
+   return rc;
+}
+
 int vault_store_rekey(const char *principal, const uint8_t old_kek[VAULT_KEK_LEN],
                       const uint8_t new_kek[VAULT_KEK_LEN])
 {
@@ -487,7 +570,18 @@ int vault_store_rekey(const char *principal, const uint8_t old_kek[VAULT_KEK_LEN
       return -1; /* no vault to rekey */
    }
 
-   int rc = 0;
+   /* Validate the OLD KEK against the key-check verifier FIRST — independent of
+    * credential count, so an empty vault cannot be rekeyed with a wrong old
+    * password. A vault with no verifier was never unlocked: refuse. */
+   if (!cJSON_IsString(cJSON_GetObjectItemCaseSensitive(root, "kek_check")) ||
+       !kek_check_matches(root, old_kek))
+   {
+      cJSON_Delete(root);
+      pthread_mutex_unlock(&g_vault_write_mu);
+      return -1;
+   }
+
+   int rc = kek_check_set(root, new_kek); /* re-wrap the verifier under the new KEK */
    cJSON *creds = creds_array(root);
    cJSON *e = NULL;
    if (creds)

--- a/src/tests/support/vault_handlers_stub.c
+++ b/src/tests/support/vault_handlers_stub.c
@@ -17,6 +17,12 @@ int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)req;
    return vault_stub(conn);
 }
+int handle_vault_rekey(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+   return vault_stub(conn);
+}
 int handle_vault_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -145,14 +145,13 @@ static void test_webuser_password_unlock(void)
    assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
    assert(strcmp(out, "sk-webuser-secret") == 0);
 
-   /* A different password derives a different KEK -> the stored cred fails closed
-    * (lock first so the cache miss forces re-derivation). */
+   /* A wrong password is caught immediately by the key-check verifier (no KEK
+    * cached), so the vault stays locked. */
    assert(vault_service_lock(p) == VAULT_OK);
    const uint8_t wrong[] = "not-alices-password";
    assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, wrong, sizeof(wrong) - 1, T0) ==
-          VAULT_OK); /* unlock "succeeds" (caches a KEK) ... */
-   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) ==
-          VAULT_ERR_CRYPTO); /* ... but the wrong KEK cannot decrypt -> fail closed */
+          VAULT_ERR_CRYPTO);
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_ERR_LOCKED);
 
    /* The right password again decrypts. */
    assert(vault_service_lock(p) == VAULT_OK);
@@ -196,12 +195,10 @@ static void test_webuser_rekey(void)
    assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
    assert(strcmp(out, "bob-secret") == 0); /* same secret, now under the new KEK */
 
-   /* The OLD password no longer unwraps. */
+   /* The OLD password no longer matches the re-keyed verifier (caught at unlock). */
    assert(vault_service_lock(p) == VAULT_OK);
    assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
-                                        T0) == VAULT_OK); /* caches a KEK ... */
-   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) ==
-          VAULT_ERR_CRYPTO); /* ... that no longer decrypts */
+                                        T0) == VAULT_ERR_CRYPTO);
    /* The NEW password does. */
    assert(vault_service_lock(p) == VAULT_OK);
    assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, new_pw, sizeof(new_pw) - 1,
@@ -209,6 +206,46 @@ static void test_webuser_rekey(void)
    assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
    assert(strcmp(out, "bob-secret") == 0);
    printf("  PASS: test_webuser_rekey\n");
+}
+
+/* WP-C.2b roundtable blocker fix: rekey must validate the old password even with
+ * ZERO credentials (the normal fresh state), and must not fail-open or
+ * materialize a vault for a non-existent principal. */
+static void test_rekey_empty_and_missing_vault(void)
+{
+   const uint8_t old_pw[] = "carol-old", new_pw[] = "carol-new", wrong[] = "carol-wrong";
+
+   /* (b) rekey of a principal with NO vault at all -> fail closed, creates nothing. */
+   assert(vault_service_rekey_password("webuser:nobody", ATTEST_WEBCHAT_TRUSTED, old_pw,
+                                       sizeof(old_pw) - 1, new_pw, sizeof(new_pw) - 1,
+                                       T0) == VAULT_ERR_CRYPTO);
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_salt_readonly("webuser:nobody", salt) == -1); /* no vault materialized */
+
+   /* Provision + unlock an EMPTY vault (no credential stored). */
+   const char *p = "webuser:carol";
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                        T0) == VAULT_OK);
+
+   /* (a) rekey of the empty vault with a WRONG old password MUST fail closed —
+    * this is the fail-open the verifier closes. */
+   assert(vault_service_rekey_password(p, ATTEST_WEBCHAT_TRUSTED, wrong, sizeof(wrong) - 1, new_pw,
+                                       sizeof(new_pw) - 1, T0) == VAULT_ERR_CRYPTO);
+   /* The old password still unlocks (vault untouched by the failed rekey). */
+   assert(vault_service_lock(p) == VAULT_OK);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                        T0) == VAULT_OK);
+
+   /* (c) correct rekey on the empty vault succeeds; afterward only the new
+    * password unlocks. */
+   assert(vault_service_rekey_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                       new_pw, sizeof(new_pw) - 1, T0) == VAULT_OK);
+   assert(vault_service_lock(p) == VAULT_OK);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                        T0) == VAULT_ERR_CRYPTO);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, new_pw, sizeof(new_pw) - 1,
+                                        T0) == VAULT_OK);
+   printf("  PASS: test_rekey_empty_and_missing_vault\n");
 }
 
 int main(void)
@@ -228,6 +265,7 @@ int main(void)
    test_list_and_delete();
    test_webuser_password_unlock();
    test_webuser_rekey();
+   test_rekey_empty_and_missing_vault();
 
    vault_kek_cache_clear();
    char rm[320];

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -163,6 +163,54 @@ static void test_webuser_password_unlock(void)
    printf("  PASS: test_webuser_password_unlock\n");
 }
 
+/* WP-C.2b: password-change re-key. The stored credential survives a rekey
+ * (re-wrapped, not re-encrypted), the new password decrypts it, the old no
+ * longer does, and a wrong old password leaves the vault untouched. */
+static void test_webuser_rekey(void)
+{
+   const char *p = "webuser:bob";
+   const uint8_t old_pw[] = "bob-old-password";
+   const uint8_t new_pw[] = "bob-new-password";
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                        T0) == VAULT_OK);
+   assert(vault_service_set(p, "claude", "api_key", "bob-secret", T0) == VAULT_OK);
+
+   /* Transport gate + bad args. */
+   assert(vault_service_rekey_password(p, ATTEST_UDS_PEERCRED, old_pw, sizeof(old_pw) - 1, new_pw,
+                                       sizeof(new_pw) - 1, T0) == VAULT_ERR_TRANSPORT);
+
+   /* Wrong OLD password: rekey fails closed, vault untouched (old pw still works). */
+   const uint8_t wrong_old[] = "not-bobs-old-password";
+   assert(vault_service_rekey_password(p, ATTEST_WEBCHAT_TRUSTED, wrong_old, sizeof(wrong_old) - 1,
+                                       new_pw, sizeof(new_pw) - 1, T0) == VAULT_ERR_CRYPTO);
+   assert(vault_service_lock(p) == VAULT_OK);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                        T0) == VAULT_OK);
+   char out[64];
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
+   assert(strcmp(out, "bob-secret") == 0); /* untouched by the failed rekey */
+
+   /* Correct rekey: re-wrap under the new password; the new KEK is cached. */
+   assert(vault_service_rekey_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                       new_pw, sizeof(new_pw) - 1, T0) == VAULT_OK);
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
+   assert(strcmp(out, "bob-secret") == 0); /* same secret, now under the new KEK */
+
+   /* The OLD password no longer unwraps. */
+   assert(vault_service_lock(p) == VAULT_OK);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, old_pw, sizeof(old_pw) - 1,
+                                        T0) == VAULT_OK); /* caches a KEK ... */
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) ==
+          VAULT_ERR_CRYPTO); /* ... that no longer decrypts */
+   /* The NEW password does. */
+   assert(vault_service_lock(p) == VAULT_OK);
+   assert(vault_service_unlock_password(p, ATTEST_WEBCHAT_TRUSTED, new_pw, sizeof(new_pw) - 1,
+                                        T0) == VAULT_OK);
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_OK);
+   assert(strcmp(out, "bob-secret") == 0);
+   printf("  PASS: test_webuser_rekey\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultsvc-test-%d", (int)getpid());
@@ -179,6 +227,7 @@ int main(void)
    test_ttl_expiry_locks();
    test_list_and_delete();
    test_webuser_password_unlock();
+   test_webuser_rekey();
 
    vault_kek_cache_clear();
    char rm[320];


### PR DESCRIPTION
Server-side support for a webchat login-password change, plus the deferred C.2a documentation nit. Reuses the WP-C.1/C.2a crypto stack.

## What
- **`vault_store_rekey(old_kek, new_kek)`** — re-wrap every credential's DEK from the old KEK to the new one. DEKs, nonces, ciphertext and tags are **untouched** (no secret is re-encrypted, per D18). **Atomic + fail-closed**: if any unwrap fails (wrong old password / tamper), nothing is written.
- **`vault_service_rekey_password`** — derive old+new KEKs (scrypt over the stored salt), re-wrap, and cache the new KEK so the vault stays unlocked under the new password. `ATTEST_WEBCHAT_TRUSTED` only; both passwords cleansed.
- **`POST /v1/vault/rekey`** — handler + dispatch + `CAP_DELEGATE` policy + OpenAPI path; regenerated `cli_v1_routes_gen.inc`; dispatch-test stub.
- **Nit fix:** the stale `/v1/vault/unlock` OpenAPI summary (it now also accepts a webuser login password, not "UDS-only").

## Test
rekey re-wraps without re-encrypting (same secret under the new KEK); the old password no longer decrypts; a **wrong old password fails closed**, leaving the vault untouched; the webchat-trusted transport gate holds.

## Remaining WP-C (follow-up, coupled)
The webchat Go backend wiring (`X-Aimee-Webuser` assertion + login-time unlock/rekey calls) and the deferred streaming-path identity capture — a request that streams doesn't yet capture the principal, so a webchat user's chat-initiated delegate wouldn't reach its vault. (kdf_version read-back hardening lands there too.)

Server-side only; reviewed-before-merge per protocol.
