### PR TITLE
Propagate per-turn credentials into parallel agent workers

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -47,6 +47,22 @@ void agent_set_request_codex_creds(const char *token, const char *account_id);
  * Thread-local. */
 void agent_set_request_session(const char *session_id);
 
+/* Snapshot of the per-turn, thread-local credential context (session id + Codex
+ * creds). agent_set_request_session / agent_set_request_codex_creds bind these
+ * on the dispatching thread, but a parallel fan-out (agent_run_parallel) runs
+ * each agent on a fresh worker thread that does NOT inherit thread-locals — so
+ * the dispatcher snapshots its context and each worker restores it, or the
+ * panel runs keyless. */
+typedef struct
+{
+   char session_id[128];
+   char codex_token[MAX_API_KEY_LEN];
+   char codex_account_id[128];
+} agent_request_creds_t;
+
+void agent_request_creds_snapshot(agent_request_creds_t *out);
+void agent_request_creds_restore(const agent_request_creds_t *creds);
+
 /* True if `agent` is the Claude CLI (`claude` / `claude-code`) run via tmux or
  * the provider-CLI binary — authenticated by the interactive `claude` login, not
  * an API key. Used to keep Claude-via-CLI primary-only by default (gated as a

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -255,6 +255,23 @@ void agent_set_request_codex_creds(const char *token, const char *account_id)
       g_request_codex_account_id[0] = '\0';
 }
 
+void agent_request_creds_snapshot(agent_request_creds_t *out)
+{
+   if (!out)
+      return;
+   snprintf(out->session_id, sizeof(out->session_id), "%s", g_request_session_id);
+   snprintf(out->codex_token, sizeof(out->codex_token), "%s", g_request_codex_token);
+   snprintf(out->codex_account_id, sizeof(out->codex_account_id), "%s", g_request_codex_account_id);
+}
+
+void agent_request_creds_restore(const agent_request_creds_t *creds)
+{
+   if (!creds)
+      return;
+   agent_set_request_session(creds->session_id);
+   agent_set_request_codex_creds(creds->codex_token, creds->codex_account_id);
+}
+
 static void append_header_line(char *buf, size_t buf_len, const char *line)
 {
    if (!buf || buf_len == 0 || !line || !line[0])

--- a/src/server/agent_parallel.c
+++ b/src/server/agent_parallel.c
@@ -7,6 +7,7 @@
  * (delegate_ensemble.c) and the sibling vote (agent_coord.c).
  */
 #include "aimee.h"
+#include "agent_config.h" /* agent_request_creds_t: inherit per-turn creds */
 #include "agent_exec.h"
 #include "config.h" /* aimee_resolve_compute_threads */
 
@@ -19,11 +20,16 @@ typedef struct
    agent_config_t *cfg;
    agent_task_t *task;
    agent_result_t *result;
+   const agent_request_creds_t *creds;
 } parallel_ctx_t;
 
 static void *parallel_worker(void *arg)
 {
    parallel_ctx_t *ctx = (parallel_ctx_t *)arg;
+   /* This worker is a fresh thread: re-bind the dispatcher's per-turn credential
+    * context (thread-locals are not inherited) so the agent resolves its
+    * client-held session key instead of running keyless. */
+   agent_request_creds_restore(ctx->creds);
    /* Per-task temperature, defaulting to the historical 0.3 when unset (0). */
    double temp = ctx->task->temperature > 0.0 ? ctx->task->temperature : 0.3;
    if (ctx->task->agent && ctx->task->agent[0])
@@ -85,12 +91,18 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count,
       return 0;
    }
 
+   /* Snapshot the dispatcher's per-turn credential context once; each worker
+    * thread restores it (thread-locals don't cross pthread_create). */
+   agent_request_creds_t creds;
+   agent_request_creds_snapshot(&creds);
+
    for (int i = 0; i < task_count; i++)
    {
       memset(&out[i], 0, sizeof(out[i]));
       ctxs[i].cfg = cfg;
       ctxs[i].task = &tasks[i];
       ctxs[i].result = &out[i];
+      ctxs[i].creds = &creds;
    }
 
    int ceiling = parallel_worker_ceiling();


### PR DESCRIPTION
## Summary

Third and final fix in the roundtable-works-out-of-the-box chain (after #216 convene-from-agents and #220 panel session binding). Validating #220 live on `.254` showed the roundtable *still* came back `degraded, cost_usd:0` — the panel was reaching no provider.

Root cause: the per-turn credential context (RAM-keyring session id + Codex creds) lives in **thread-local** storage (`agent_config.c`: `g_request_session_id` / `g_request_codex_*`). #220 binds it on the dispatching thread, but `agent_run_parallel` fans each panellist out to a **fresh pthread** (`parallel_worker`), and thread-locals do not cross `pthread_create`. So every agent in a parallel roundtable/MoA fan-out ran with an empty session id and resolved no client-held key — while a plain single-thread delegate on the same session worked.

- Add `agent_request_creds_snapshot()` / `agent_request_creds_restore()` to capture and re-apply the three thread-local credential values as a unit.
- `agent_run_parallel` snapshots the dispatcher's context once; `parallel_worker` restores it at the top of each worker thread before running the agent.

Also fixes the sibling-vote fan-out (`agent_coord.c`) and any other `agent_run_parallel` caller. The single-task fast path is unchanged (runs on the calling thread, which already holds the context).

## Testing
- `make verify-local` + full `make unit-tests` green (serial; parallel-LTO flakes on this host — one test binary needed a rebuild for a transient ordering flake, then passed).
- Will validate end-to-end on `.254` post-release: a thin-client roundtable should return real `cost_usd > 0` and a non-empty artifact instead of `degraded`.
