### PR TITLE
Default delegate tools_enabled from the backing model's capability

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -508,7 +508,30 @@ int agent_load_config(agent_config_t *cfg)
          ag->enabled = (!v || !cJSON_IsBool(v)) ? 1 : cJSON_IsTrue(v);
 
          v = cJSON_GetObjectItem(a, "tools_enabled");
-         ag->tools_enabled = (v && cJSON_IsBool(v)) ? cJSON_IsTrue(v) : 0;
+         if (v && cJSON_IsBool(v))
+         {
+            /* Explicit operator setting always wins (force on or off). */
+            ag->tools_enabled = cJSON_IsTrue(v);
+         }
+         else
+         {
+            /* Absent: derive the default from the backing model's intrinsic
+             * tool capability. `tools_enabled` is both a capability signal and
+             * an execution policy; defaulting it to a blanket 0 made every
+             * delegate that omits the key look tool-INCAPABLE to the routing
+             * filter (delegate_filter_route_capabilities), so tool-requiring
+             * roles (e.g. `review`) found zero candidates even though the
+             * underlying model (mistral / minimax / openai / anthropic / …)
+             * fully supports tool calls. Deriving from the model's real
+             * capability makes a tool-capable delegate usable for tool roles by
+             * default; a model with no known tool capability still defaults off;
+             * and an explicit "tools_enabled": false above still opts out. */
+            model_capability_t mc;
+            ag->tools_enabled =
+                (model_capability_get(ag->provider, ag->model, &mc) && (mc.flags & MODEL_CAP_TOOLS))
+                    ? 1
+                    : 0;
+         }
 
          v = cJSON_GetObjectItem(a, "recommended_sampling");
          ag->recommended_sampling = (v && cJSON_IsBool(v)) ? cJSON_IsTrue(v) : 0;

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -515,20 +515,30 @@ int agent_load_config(agent_config_t *cfg)
          }
          else
          {
-            /* Absent: derive the default from the backing model's intrinsic
-             * tool capability. `tools_enabled` is both a capability signal and
-             * an execution policy; defaulting it to a blanket 0 made every
-             * delegate that omits the key look tool-INCAPABLE to the routing
-             * filter (delegate_filter_route_capabilities), so tool-requiring
-             * roles (e.g. `review`) found zero candidates even though the
-             * underlying model (mistral / minimax / openai / anthropic / …)
-             * fully supports tool calls. Deriving from the model's real
-             * capability makes a tool-capable delegate usable for tool roles by
-             * default; a model with no known tool capability still defaults off;
-             * and an explicit "tools_enabled": false above still opts out. */
+            /* Absent key: derive the default from the backing model's intrinsic
+             * tool capability instead of a blanket 0. `tools_enabled` is both a
+             * capability signal and an execution policy; defaulting it to 0 made
+             * every delegate that omits the key look tool-INCAPABLE to the
+             * routing filter (delegate_filter_route_capabilities), so
+             * tool-requiring roles (e.g. `review`) found zero candidates even
+             * though the underlying model (mistral / minimax / openai /
+             * anthropic / …) fully supports tool calls.
+             *
+             * Invariants that bound the risk of deriving policy from capability:
+             *  - Operator intent is never overridden: an explicit
+             *    "tools_enabled": true|false is honoured verbatim (the branch
+             *    above). This only sets the value when the operator left it
+             *    UNSPECIFIED, so there is no intent to bypass.
+             *  - The lookup is total and offline: model_capability_get resolves
+             *    via on-disk overrides/caches and a pure in-code heuristic,
+             *    never the network, and returns 0 for an unknown or empty model.
+             *    It therefore cannot fail or block startup, and an unrecognised
+             *    model fails SAFE to tools-off (conservative default preserved
+             *    exactly where capability is unknown). */
             model_capability_t mc;
             ag->tools_enabled =
-                (model_capability_get(ag->provider, ag->model, &mc) && (mc.flags & MODEL_CAP_TOOLS))
+                (ag->model[0] && model_capability_get(ag->provider, ag->model, &mc) &&
+                 (mc.flags & MODEL_CAP_TOOLS))
                     ? 1
                     : 0;
          }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1121,6 +1121,7 @@ $(TESTPREFIX)/unit-test-http-retry: $(OBJDIR)/tests/test_http_retry.o $(OBJDIR)/
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/cmd_doctor.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                             $(OBJDIR)/hardware_probe.o \
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
@@ -1131,6 +1132,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                             $(OBJDIR)/cmd_onboard.o $(OBJDIR)/cmd_core.o $(OBJDIR)/cmd_init.o \
                             $(OBJDIR)/cmd_doctor.o $(OBJDIR)/hardware_probe.o $(OBJDIR)/cmd_util.o \
                             $(DB2_OBJS) \
@@ -1786,6 +1788,7 @@ $(TESTPREFIX)/unit-test-persona: $(OBJDIR)/tests/test_persona.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                            $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o $(OBJDIR)/server/presence.o \
                            $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                            $(OBJDIR)/forge_credentials.o \
@@ -1854,6 +1857,7 @@ $(TESTPREFIX)/unit-test-delegate-driver: $(OBJDIR)/tests/test_delegate_driver.o 
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-agent-http: $(OBJDIR)/tests/test_agent_http.o \
+                                 $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                 $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
                                 $(OBJDIR)/server/agent_request_shaping.o \
                                 $(OBJDIR)/server/delegate_driver.o \

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -23,6 +23,7 @@
 
 void test_agent_route_with_caps_honors_tools_enabled(void);
 void test_agent_route_with_caps_honors_context_override(void);
+void test_tools_enabled_capability_default(void);
 
 /* --- Expose tool functions for testing via redeclaration --- */
 char *tool_bash(const char *command, int timeout_ms);
@@ -566,51 +567,6 @@ static void test_agent_config_provider_cli_roundtrip(void)
    {
       unsetenv("PATH");
    }
-}
-
-/* tools_enabled defaults from the backing model's intrinsic capability when the
- * JSON key is absent, so a tool-capable delegate is usable for tool-requiring
- * roles instead of being silently filtered out by the routing capability check.
- * Explicit values still win. Regression for "no configured model supports
- * required capabilities (caps=tools)". */
-static void test_tools_enabled_capability_default(void)
-{
-   FILE *f = fopen(agent_config_path(), "w");
-   assert(f != NULL);
-   /* m_default: tool-capable model (mistral), no tools_enabled key -> derive ON.
-    * m_off:     same model, explicit "tools_enabled": false       -> stays OFF.
-    * m_on:      same model, explicit "tools_enabled": true        -> stays ON. */
-   fputs("{\"agents\":[{\"name\":\"m_default\",\"provider\":\"mistral\","
-         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
-         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\"},"
-         "{\"name\":\"m_off\",\"provider\":\"mistral\","
-         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
-         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
-         "\"tools_enabled\":false},"
-         "{\"name\":\"m_on\",\"provider\":\"mistral\","
-         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
-         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
-         "\"tools_enabled\":true}]}\n",
-         f);
-   fclose(f);
-
-   agent_config_t loaded;
-   assert(agent_load_config(&loaded) == 0);
-   assert(loaded.agent_count == 3);
-
-   const agent_t *m_default = agent_find(&loaded, "m_default");
-   const agent_t *m_off = agent_find(&loaded, "m_off");
-   const agent_t *m_on = agent_find(&loaded, "m_on");
-   assert(m_default && m_off && m_on);
-
-   /* The crux: an absent key on a tool-capable model now defaults tools ON. */
-   assert(m_default->tools_enabled == 1);
-   /* Explicit operator settings are still honoured verbatim. */
-   assert(m_off->tools_enabled == 0);
-   assert(m_on->tools_enabled == 1);
-
-   unlink(agent_config_path());
-   printf("  PASS: test_tools_enabled_capability_default\n");
 }
 
 static void test_agent_adapter_registry(void)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -568,6 +568,51 @@ static void test_agent_config_provider_cli_roundtrip(void)
    }
 }
 
+/* tools_enabled defaults from the backing model's intrinsic capability when the
+ * JSON key is absent, so a tool-capable delegate is usable for tool-requiring
+ * roles instead of being silently filtered out by the routing capability check.
+ * Explicit values still win. Regression for "no configured model supports
+ * required capabilities (caps=tools)". */
+static void test_tools_enabled_capability_default(void)
+{
+   FILE *f = fopen(agent_config_path(), "w");
+   assert(f != NULL);
+   /* m_default: tool-capable model (mistral), no tools_enabled key -> derive ON.
+    * m_off:     same model, explicit "tools_enabled": false       -> stays OFF.
+    * m_on:      same model, explicit "tools_enabled": true        -> stays ON. */
+   fputs("{\"agents\":[{\"name\":\"m_default\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\"},"
+         "{\"name\":\"m_off\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":false},"
+         "{\"name\":\"m_on\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":true}]}\n",
+         f);
+   fclose(f);
+
+   agent_config_t loaded;
+   assert(agent_load_config(&loaded) == 0);
+   assert(loaded.agent_count == 3);
+
+   const agent_t *m_default = agent_find(&loaded, "m_default");
+   const agent_t *m_off = agent_find(&loaded, "m_off");
+   const agent_t *m_on = agent_find(&loaded, "m_on");
+   assert(m_default && m_off && m_on);
+
+   /* The crux: an absent key on a tool-capable model now defaults tools ON. */
+   assert(m_default->tools_enabled == 1);
+   /* Explicit operator settings are still honoured verbatim. */
+   assert(m_off->tools_enabled == 0);
+   assert(m_on->tools_enabled == 1);
+
+   unlink(agent_config_path());
+   printf("  PASS: test_tools_enabled_capability_default\n");
+}
+
 static void test_agent_adapter_registry(void)
 {
    const agent_adapter_t *codex = agent_adapter_for_name("codex");
@@ -1914,6 +1959,7 @@ int main(void)
    test_provider_env_credentials_and_headers();
    test_codex_oauth_request_creds();
    test_agent_config_provider_cli_roundtrip();
+   test_tools_enabled_capability_default();
    test_agent_adapter_registry();
    test_provider_cli_shell_exec_uses_argv_not_shell();
    test_provider_cli_shell_timeout_covers_prompt_write();

--- a/src/tests/test_agent_caps.c
+++ b/src/tests/test_agent_caps.c
@@ -1,8 +1,11 @@
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "aimee.h"
 #include "agent.h"
+#include "agent_config.h"
 #include "model_registry.h"
 
 void test_agent_route_with_caps_honors_tools_enabled(void)
@@ -76,4 +79,49 @@ void test_agent_route_with_caps_honors_context_override(void)
    cfg.agents[0].enabled = 1;
    cfg.agents[0].middleware.context_window = 1000;
    assert(agent_route_with_caps(&cfg, "review", &sys_cfg, 0, 50000) == NULL);
+}
+
+/* tools_enabled defaults from the backing model's intrinsic capability when the
+ * JSON key is absent, so a tool-capable delegate is usable for tool-requiring
+ * roles instead of being silently filtered out by the routing capability check
+ * (delegate_filter_route_capabilities). Explicit values still win. Regression
+ * for "no configured model supports required capabilities (caps=tools)". */
+void test_tools_enabled_capability_default(void)
+{
+   FILE *f = fopen(agent_config_path(), "w");
+   assert(f != NULL);
+   /* m_default: tool-capable model (mistral), no tools_enabled key -> derive ON.
+    * m_off:     same model, explicit "tools_enabled": false       -> stays OFF.
+    * m_on:      same model, explicit "tools_enabled": true        -> stays ON. */
+   fputs("{\"agents\":[{\"name\":\"m_default\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\"},"
+         "{\"name\":\"m_off\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":false},"
+         "{\"name\":\"m_on\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":true}]}\n",
+         f);
+   fclose(f);
+
+   agent_config_t loaded;
+   assert(agent_load_config(&loaded) == 0);
+   assert(loaded.agent_count == 3);
+
+   const agent_t *m_default = agent_find(&loaded, "m_default");
+   const agent_t *m_off = agent_find(&loaded, "m_off");
+   const agent_t *m_on = agent_find(&loaded, "m_on");
+   assert(m_default && m_off && m_on);
+
+   /* The crux: an absent key on a tool-capable model now defaults tools ON. */
+   assert(m_default->tools_enabled == 1);
+   /* Explicit operator settings are still honoured verbatim. */
+   assert(m_off->tools_enabled == 0);
+   assert(m_on->tools_enabled == 1);
+
+   unlink(agent_config_path());
+   printf("  PASS: test_tools_enabled_capability_default\n");
 }


### PR DESCRIPTION
## Problem

Delegate tasks that require tool use (e.g. any `review`-role delegate) fail with:

```
no configured model supports required capabilities (caps=tools, min_context=…)
```

even though every configured delegate is backed by a tool-capable model
(mistral, minimax, openai, anthropic).

## Root cause

`tools_enabled` is **both** a capability signal and an execution policy, and the
two were conflated:

1. `agent_config.c` parsed an **absent** `tools_enabled` key as a blanket `0`.
2. The routing capability filter (`delegate_filter_route_capabilities`,
   `server/delegate_routing.c`) treats that per-agent flag as authoritative for
   the tools bit — when it is off it **clears** the model's intrinsic
   `MODEL_CAP_TOOLS` (`effective_flags &= ~MODEL_CAP_TOOLS`).

So a perfectly tool-capable model looked tool-*incapable* to the filter purely
because nobody set the opt-in flag, and tool-requiring roles found **zero**
candidates. (`min_context` in the error is the job's demand — the prompt token
count — not a model limit; the unmet capability was `tools`.)

## Fix

When the `tools_enabled` key is **absent**, derive its default from the backing
model's intrinsic tool capability (`model_capability_get`) instead of a blanket
`0`:

- tool-capable model + no key → tools **on** (routable to, and executed with,
  tools for tool roles);
- model with no known tool capability → stays **off**;
- explicit `"tools_enabled": true|false` → honoured verbatim (operator wins).

This makes capability and policy consistent in one place at config load, so both
routing **and** execution agree.

## Test-link wiring

`agent_load_config` now references `model_capability_get`, so unit-test binaries
that link the real `agent_config.o` must also link `model_registry.o` +
`models_dev.o` + `models_dev_cache.o` (previously gc-sections-dropped because the
symbol was unreachable). Added to the four affected rules: `cmd-doctor`,
`cmd-onboard`, `server-http`, `agent-http`.

## Tests

- New `test_tools_enabled_capability_default` (in `unit-test-agent`): a
  tool-capable model with no `tools_enabled` key loads `tools_enabled == 1`;
  explicit `false` stays `0`; explicit `true` stays `1`.
- Full `unit-tests` build links green tree-wide (0 undefined/multiple-definition);
  the four touched binaries build and pass; `clang-format-19` clean.
