### PR TITLE
WP-C.2c(1): anchor webuser trust on the server.token file (not g_bearer)

### DIFF
--- a/src/headers/server_http_identity.h
+++ b/src/headers/server_http_identity.h
@@ -35,9 +35,10 @@
  *   fd      - the connection socket (SO_PEERCRED source for UDS).
  *   is_tcp  - 1 for the network listener, 0 for the local UDS socket.
  *   buf     - the raw HTTP request (read for the X-Aimee-Webuser / Authorization headers).
- *   bearer  - the configured server.token bearer (empty when none), required to
- *             honor a webuser assertion. */
-void server_http_identity_capture(int fd, int is_tcp, const char *buf, const char *bearer);
+ * A webuser assertion is honored only when the request's Bearer matches the
+ * server.token file (the secret the webchat backend holds), read from AIMEE_HOME
+ * — NOT the configured TCP /v1 bearer, which is an independent secret. */
+void server_http_identity_capture(int fd, int is_tcp, const char *buf);
 
 /* Copy the captured identity onto a (synthesized) connection — loopback_rpc's
  * hop 2. Safe to call with no prior capture: writes the un-attested defaults. */

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1722,7 +1722,7 @@ static void handle_conn(int fd, int is_tcp)
     * or a server.token-gated webuser assertion) into thread-locals, live until
     * loopback_rpc copies it into the synthesized conn. Cleared after the route so
     * a reused worker thread cannot leak it into the next request. */
-   server_http_identity_capture(fd, is_tcp, buf, g_bearer);
+   server_http_identity_capture(fd, is_tcp, buf);
    int status = server_http_route(method, path, body, body_len, resp, SHTTP_RESP_MAX);
    g_rpc_conn_caps = CAPS_READ_ONLY;
    server_http_identity_clear();

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -8,9 +8,11 @@
 #endif
 #include "server_http_identity.h"
 #include "server_http.h" /* http_header */
-#include "server.h"      /* server_ct_equal */
+#include "server.h"      /* server_ct_equal, SERVER_TOKEN_FILE */
+#include "aimee_home.h"  /* aimee_home */
 #include "platform_ipc.h"
 #include "vault_principal.h"
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -23,7 +25,46 @@ static _Thread_local long tl_peer_uid = -1;
 static _Thread_local attested_transport_t tl_transport = ATTEST_NONE;
 static _Thread_local char tl_principal[VAULT_PRINCIPAL_MAX] = "";
 
-void server_http_identity_capture(int fd, int is_tcp, const char *buf, const char *bearer)
+/* The shared secret that authenticates a webchat `webuser:` assertion is the
+ * server.token file (0600, in AIMEE_HOME — the secret only the webchat backend
+ * holds), NOT the configured TCP /v1 bearer (g_bearer): those are independent
+ * secrets, and g_bearer is empty on a UDS-only server. Loaded once and cached
+ * (token rotation needs a restart, as with g_bearer). Returns NULL if absent. */
+static const char *server_token_secret(void)
+{
+   static char tok[256];
+   static int loaded = 0;
+   static pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
+   pthread_mutex_lock(&mu);
+   if (!loaded)
+   {
+      const char *home = aimee_home();
+      char path[1024];
+      if (home && home[0] &&
+          (size_t)snprintf(path, sizeof(path), "%s/%s", home, SERVER_TOKEN_FILE) < sizeof(path))
+      {
+         FILE *f = fopen(path, "rb");
+         if (f)
+         {
+            if (fgets(tok, sizeof(tok), f))
+            {
+               size_t n = strlen(tok);
+               while (n && (tok[n - 1] == '\n' || tok[n - 1] == '\r' || tok[n - 1] == ' ' ||
+                            tok[n - 1] == '\t'))
+                  tok[--n] = '\0';
+               if (tok[0])
+                  loaded = 1; /* cache only a non-empty token; else retry next call */
+            }
+            fclose(f);
+         }
+      }
+   }
+   const char *out = loaded ? tok : NULL;
+   pthread_mutex_unlock(&mu);
+   return out;
+}
+
+void server_http_identity_capture(int fd, int is_tcp, const char *buf)
 {
    long peer_uid = -1;
    if (!is_tcp)
@@ -40,9 +81,10 @@ void server_http_identity_capture(int fd, int is_tcp, const char *buf, const cha
       /* A webuser assertion is honored only with the valid server.token bearer
        * (the secret only the webchat backend holds). A spoofed header without it
        * is refused by vault_principal_resolve (empty principal). */
+      const char *tok = server_token_secret();
       char wauth[512] = "";
-      if (bearer && bearer[0] && http_header(buf, "Authorization", wauth, sizeof(wauth)) &&
-          strncmp(wauth, "Bearer ", 7) == 0 && server_ct_equal(wauth + 7, bearer))
+      if (tok && http_header(buf, "Authorization", wauth, sizeof(wauth)) &&
+          strncmp(wauth, "Bearer ", 7) == 0 && server_ct_equal(wauth + 7, tok))
          webuser_token_ok = 1;
    }
 


### PR DESCRIPTION
Prerequisite fix before the webchat (`webuser:`) vault wiring.

## The bug
WP-C.0 honored an `X-Aimee-Webuser` assertion when the request's `Bearer` matched **`g_bearer`** (the configured TCP `/v1` bearer). But that's the wrong trust anchor:
- The secret the webchat backend actually holds is the **`server.token` file** (the same secret that gates browser→webchat in `openAIBearerOK`).
- `server.token` and the `/v1` bearer are **independent** secrets, and `g_bearer` is **empty on a UDS-only server** — so the webuser vault path could never activate (or only by coincidentally-equal secrets).

## Fix
`server_http_identity_capture` now validates the webuser `Bearer` against the **`server.token` file** (0600, in the shared `AIMEE_HOME` — the secret the webchat backend holds), exactly as the WP-C design specifies. Read once + cached, constant-time compare. Dropped the now-unused `bearer` param.

Fail-closed: no/empty `server.token` ⇒ the webuser assertion is refused (empty principal, no vault).

This unblocks the Go-backend wiring (it will send its `server.token` as the Bearer, now trusted correctly regardless of TCP-bearer config). Server links; `server-http` + `server-dispatch` tests pass; `line-check` ok.

Server-side only; reviewed-before-merge per protocol.
