### PR TITLE
Run ensemble aggregator without tools so non-tool models can synthesize

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -406,7 +406,13 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
       }
    }
 
-   return agent_run_with_tools_write_enforce(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0, out);
+   /* Synthesis is pure text/JSON merging of the panel's responses — it needs no
+    * tools. Running it through the tool-use loop breaks aggregators whose model
+    * has no tool-calling support (e.g. MiniMax), which then return empty and
+    * collapse the whole round to a degraded, artifact-less result. Use the
+    * plain (no-tools) role-routed path; default_agent still selects the
+    * configured aggregator. */
+   return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -157,6 +157,43 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    return 0;
 }
 
+/* The aggregator/synthesis step runs through the no-tools role-routed path
+ * (agent_run_ex) so non-tool models can synthesize. Mirror the aggregator
+ * branch of the tool-enabled stub below. */
+int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
+                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   char buf[128];
+   g_aggregator_calls++;
+   if (g_aggregator_mode == 1)
+      out->response =
+          strdup(g_aggregator_calls == 1 ? "synthesized answer 1" : "inferior final artifact");
+   else if (g_aggregator_mode == 2)
+   {
+      size_t n = 26000;
+      out->response = malloc(n);
+      memset(out->response, 'a', n - 2);
+      out->response[n - 2] = '\n';
+      out->response[n - 1] = '\0';
+   }
+   else
+   {
+      snprintf(buf, sizeof(buf), "synthesized answer %d", g_aggregator_calls);
+      out->response = strdup(buf);
+   }
+   out->prompt_tokens = 200;
+   out->completion_tokens = 100;
+   snprintf(out->agent_name, sizeof(out->agent_name), "%s", role ? role : "");
+   out->success = 1;
+   return 0;
+}
+
 int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
                                        const char *system_prompt, const char *user_prompt,
                                        int max_tokens, int enforce_writes, agent_result_t *out)


### PR DESCRIPTION
## Summary

Fourth fix in the roundtable-works-out-of-the-box chain (after #216 convene-from-agents, #220 panel session binding, #223 parallel-worker creds). With those, the roundtable convened and the panel ran (cost_usd > 0), but the run still came back `degraded` with an **empty artifact**.

Root cause: the aggregator synthesizes the final artifact by merging the panel's responses — a pure text/JSON task — but `run_aggregator` ran it through `agent_run_with_tools_write_enforce`, i.e. the **tool-use loop**. An aggregator whose model has no tool-calling support (e.g. **MiniMax**, which the default panel picks as aggregator) fails that loop and returns empty, collapsing every round to a degraded, artifact-less result.

Confirmed live: a plain delegate to `minimax` succeeds, but the same agent with `--tools` fails — the aggregator enabling tools is exactly what emptied the artifact.

- Switch `run_aggregator` to the **no-tools, role-routed** path (`agent_run_ex`); `default_agent` still selects the configured aggregator. Synthesis needs no tools, so this is strictly more compatible and unchanged for tool-capable aggregators.

## Testing
- Add an `agent_run_ex` stub to `test_delegate_ensemble` mirroring the aggregator branch.
- `make verify-local` + full `make unit-tests` green (15 binaries).
- Will validate live on `.254` post-release: the roundtable should return a non-empty synthesized artifact with `degraded:false`.
