### PR TITLE
Promote: ensemble aggregator runs without tools

### DIFF
--- a/src/headers/server_http_identity.h
+++ b/src/headers/server_http_identity.h
@@ -35,9 +35,10 @@
  *   fd      - the connection socket (SO_PEERCRED source for UDS).
  *   is_tcp  - 1 for the network listener, 0 for the local UDS socket.
  *   buf     - the raw HTTP request (read for the X-Aimee-Webuser / Authorization headers).
- *   bearer  - the configured server.token bearer (empty when none), required to
- *             honor a webuser assertion. */
-void server_http_identity_capture(int fd, int is_tcp, const char *buf, const char *bearer);
+ * A webuser assertion is honored only when the request's Bearer matches the
+ * server.token file (the secret the webchat backend holds), read from AIMEE_HOME
+ * — NOT the configured TCP /v1 bearer, which is an independent secret. */
+void server_http_identity_capture(int fd, int is_tcp, const char *buf);
 
 /* Copy the captured identity onto a (synthesized) connection — loopback_rpc's
  * hop 2. Safe to call with no prior capture: writes the un-attested defaults. */

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -508,7 +508,30 @@ int agent_load_config(agent_config_t *cfg)
          ag->enabled = (!v || !cJSON_IsBool(v)) ? 1 : cJSON_IsTrue(v);
 
          v = cJSON_GetObjectItem(a, "tools_enabled");
-         ag->tools_enabled = (v && cJSON_IsBool(v)) ? cJSON_IsTrue(v) : 0;
+         if (v && cJSON_IsBool(v))
+         {
+            /* Explicit operator setting always wins (force on or off). */
+            ag->tools_enabled = cJSON_IsTrue(v);
+         }
+         else
+         {
+            /* Absent: derive the default from the backing model's intrinsic
+             * tool capability. `tools_enabled` is both a capability signal and
+             * an execution policy; defaulting it to a blanket 0 made every
+             * delegate that omits the key look tool-INCAPABLE to the routing
+             * filter (delegate_filter_route_capabilities), so tool-requiring
+             * roles (e.g. `review`) found zero candidates even though the
+             * underlying model (mistral / minimax / openai / anthropic / …)
+             * fully supports tool calls. Deriving from the model's real
+             * capability makes a tool-capable delegate usable for tool roles by
+             * default; a model with no known tool capability still defaults off;
+             * and an explicit "tools_enabled": false above still opts out. */
+            model_capability_t mc;
+            ag->tools_enabled =
+                (model_capability_get(ag->provider, ag->model, &mc) && (mc.flags & MODEL_CAP_TOOLS))
+                    ? 1
+                    : 0;
+         }
 
          v = cJSON_GetObjectItem(a, "recommended_sampling");
          ag->recommended_sampling = (v && cJSON_IsBool(v)) ? cJSON_IsTrue(v) : 0;

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -515,20 +515,30 @@ int agent_load_config(agent_config_t *cfg)
          }
          else
          {
-            /* Absent: derive the default from the backing model's intrinsic
-             * tool capability. `tools_enabled` is both a capability signal and
-             * an execution policy; defaulting it to a blanket 0 made every
-             * delegate that omits the key look tool-INCAPABLE to the routing
-             * filter (delegate_filter_route_capabilities), so tool-requiring
-             * roles (e.g. `review`) found zero candidates even though the
-             * underlying model (mistral / minimax / openai / anthropic / …)
-             * fully supports tool calls. Deriving from the model's real
-             * capability makes a tool-capable delegate usable for tool roles by
-             * default; a model with no known tool capability still defaults off;
-             * and an explicit "tools_enabled": false above still opts out. */
+            /* Absent key: derive the default from the backing model's intrinsic
+             * tool capability instead of a blanket 0. `tools_enabled` is both a
+             * capability signal and an execution policy; defaulting it to 0 made
+             * every delegate that omits the key look tool-INCAPABLE to the
+             * routing filter (delegate_filter_route_capabilities), so
+             * tool-requiring roles (e.g. `review`) found zero candidates even
+             * though the underlying model (mistral / minimax / openai /
+             * anthropic / …) fully supports tool calls.
+             *
+             * Invariants that bound the risk of deriving policy from capability:
+             *  - Operator intent is never overridden: an explicit
+             *    "tools_enabled": true|false is honoured verbatim (the branch
+             *    above). This only sets the value when the operator left it
+             *    UNSPECIFIED, so there is no intent to bypass.
+             *  - The lookup is total and offline: model_capability_get resolves
+             *    via on-disk overrides/caches and a pure in-code heuristic,
+             *    never the network, and returns 0 for an unknown or empty model.
+             *    It therefore cannot fail or block startup, and an unrecognised
+             *    model fails SAFE to tools-off (conservative default preserved
+             *    exactly where capability is unknown). */
             model_capability_t mc;
             ag->tools_enabled =
-                (model_capability_get(ag->provider, ag->model, &mc) && (mc.flags & MODEL_CAP_TOOLS))
+                (ag->model[0] && model_capability_get(ag->provider, ag->model, &mc) &&
+                 (mc.flags & MODEL_CAP_TOOLS))
                     ? 1
                     : 0;
          }

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -406,7 +406,13 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
       }
    }
 
-   return agent_run_with_tools_write_enforce(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0, out);
+   /* Synthesis is pure text/JSON merging of the panel's responses — it needs no
+    * tools. Running it through the tool-use loop breaks aggregators whose model
+    * has no tool-calling support (e.g. MiniMax), which then return empty and
+    * collapse the whole round to a degraded, artifact-less result. Use the
+    * plain (no-tools) role-routed path; default_agent still selects the
+    * configured aggregator. */
+   return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1722,7 +1722,7 @@ static void handle_conn(int fd, int is_tcp)
     * or a server.token-gated webuser assertion) into thread-locals, live until
     * loopback_rpc copies it into the synthesized conn. Cleared after the route so
     * a reused worker thread cannot leak it into the next request. */
-   server_http_identity_capture(fd, is_tcp, buf, g_bearer);
+   server_http_identity_capture(fd, is_tcp, buf);
    int status = server_http_route(method, path, body, body_len, resp, SHTTP_RESP_MAX);
    g_rpc_conn_caps = CAPS_READ_ONLY;
    server_http_identity_clear();

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -8,9 +8,11 @@
 #endif
 #include "server_http_identity.h"
 #include "server_http.h" /* http_header */
-#include "server.h"      /* server_ct_equal */
+#include "server.h"      /* server_ct_equal, SERVER_TOKEN_FILE */
+#include "aimee_home.h"  /* aimee_home */
 #include "platform_ipc.h"
 #include "vault_principal.h"
+#include <pthread.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -23,7 +25,46 @@ static _Thread_local long tl_peer_uid = -1;
 static _Thread_local attested_transport_t tl_transport = ATTEST_NONE;
 static _Thread_local char tl_principal[VAULT_PRINCIPAL_MAX] = "";
 
-void server_http_identity_capture(int fd, int is_tcp, const char *buf, const char *bearer)
+/* The shared secret that authenticates a webchat `webuser:` assertion is the
+ * server.token file (0600, in AIMEE_HOME — the secret only the webchat backend
+ * holds), NOT the configured TCP /v1 bearer (g_bearer): those are independent
+ * secrets, and g_bearer is empty on a UDS-only server. Loaded once and cached
+ * (token rotation needs a restart, as with g_bearer). Returns NULL if absent. */
+static const char *server_token_secret(void)
+{
+   static char tok[256];
+   static int loaded = 0;
+   static pthread_mutex_t mu = PTHREAD_MUTEX_INITIALIZER;
+   pthread_mutex_lock(&mu);
+   if (!loaded)
+   {
+      const char *home = aimee_home();
+      char path[1024];
+      if (home && home[0] &&
+          (size_t)snprintf(path, sizeof(path), "%s/%s", home, SERVER_TOKEN_FILE) < sizeof(path))
+      {
+         FILE *f = fopen(path, "rb");
+         if (f)
+         {
+            if (fgets(tok, sizeof(tok), f))
+            {
+               size_t n = strlen(tok);
+               while (n && (tok[n - 1] == '\n' || tok[n - 1] == '\r' || tok[n - 1] == ' ' ||
+                            tok[n - 1] == '\t'))
+                  tok[--n] = '\0';
+               if (tok[0])
+                  loaded = 1; /* cache only a non-empty token; else retry next call */
+            }
+            fclose(f);
+         }
+      }
+   }
+   const char *out = loaded ? tok : NULL;
+   pthread_mutex_unlock(&mu);
+   return out;
+}
+
+void server_http_identity_capture(int fd, int is_tcp, const char *buf)
 {
    long peer_uid = -1;
    if (!is_tcp)
@@ -40,9 +81,10 @@ void server_http_identity_capture(int fd, int is_tcp, const char *buf, const cha
       /* A webuser assertion is honored only with the valid server.token bearer
        * (the secret only the webchat backend holds). A spoofed header without it
        * is refused by vault_principal_resolve (empty principal). */
+      const char *tok = server_token_secret();
       char wauth[512] = "";
-      if (bearer && bearer[0] && http_header(buf, "Authorization", wauth, sizeof(wauth)) &&
-          strncmp(wauth, "Bearer ", 7) == 0 && server_ct_equal(wauth + 7, bearer))
+      if (tok && http_header(buf, "Authorization", wauth, sizeof(wauth)) &&
+          strncmp(wauth, "Bearer ", 7) == 0 && server_ct_equal(wauth + 7, tok))
          webuser_token_ok = 1;
    }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1121,6 +1121,7 @@ $(TESTPREFIX)/unit-test-http-retry: $(OBJDIR)/tests/test_http_retry.o $(OBJDIR)/
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/cmd_doctor.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                             $(OBJDIR)/hardware_probe.o \
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
@@ -1131,6 +1132,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                             $(OBJDIR)/cmd_onboard.o $(OBJDIR)/cmd_core.o $(OBJDIR)/cmd_init.o \
                             $(OBJDIR)/cmd_doctor.o $(OBJDIR)/hardware_probe.o $(OBJDIR)/cmd_util.o \
                             $(DB2_OBJS) \
@@ -1786,6 +1788,7 @@ $(TESTPREFIX)/unit-test-persona: $(OBJDIR)/tests/test_persona.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                            $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o $(OBJDIR)/server/presence.o \
                            $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                            $(OBJDIR)/forge_credentials.o \
@@ -1854,6 +1857,7 @@ $(TESTPREFIX)/unit-test-delegate-driver: $(OBJDIR)/tests/test_delegate_driver.o 
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-agent-http: $(OBJDIR)/tests/test_agent_http.o \
+                                 $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                 $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
                                 $(OBJDIR)/server/agent_request_shaping.o \
                                 $(OBJDIR)/server/delegate_driver.o \

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -23,6 +23,7 @@
 
 void test_agent_route_with_caps_honors_tools_enabled(void);
 void test_agent_route_with_caps_honors_context_override(void);
+void test_tools_enabled_capability_default(void);
 
 /* --- Expose tool functions for testing via redeclaration --- */
 char *tool_bash(const char *command, int timeout_ms);
@@ -566,51 +567,6 @@ static void test_agent_config_provider_cli_roundtrip(void)
    {
       unsetenv("PATH");
    }
-}
-
-/* tools_enabled defaults from the backing model's intrinsic capability when the
- * JSON key is absent, so a tool-capable delegate is usable for tool-requiring
- * roles instead of being silently filtered out by the routing capability check.
- * Explicit values still win. Regression for "no configured model supports
- * required capabilities (caps=tools)". */
-static void test_tools_enabled_capability_default(void)
-{
-   FILE *f = fopen(agent_config_path(), "w");
-   assert(f != NULL);
-   /* m_default: tool-capable model (mistral), no tools_enabled key -> derive ON.
-    * m_off:     same model, explicit "tools_enabled": false       -> stays OFF.
-    * m_on:      same model, explicit "tools_enabled": true        -> stays ON. */
-   fputs("{\"agents\":[{\"name\":\"m_default\",\"provider\":\"mistral\","
-         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
-         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\"},"
-         "{\"name\":\"m_off\",\"provider\":\"mistral\","
-         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
-         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
-         "\"tools_enabled\":false},"
-         "{\"name\":\"m_on\",\"provider\":\"mistral\","
-         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
-         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
-         "\"tools_enabled\":true}]}\n",
-         f);
-   fclose(f);
-
-   agent_config_t loaded;
-   assert(agent_load_config(&loaded) == 0);
-   assert(loaded.agent_count == 3);
-
-   const agent_t *m_default = agent_find(&loaded, "m_default");
-   const agent_t *m_off = agent_find(&loaded, "m_off");
-   const agent_t *m_on = agent_find(&loaded, "m_on");
-   assert(m_default && m_off && m_on);
-
-   /* The crux: an absent key on a tool-capable model now defaults tools ON. */
-   assert(m_default->tools_enabled == 1);
-   /* Explicit operator settings are still honoured verbatim. */
-   assert(m_off->tools_enabled == 0);
-   assert(m_on->tools_enabled == 1);
-
-   unlink(agent_config_path());
-   printf("  PASS: test_tools_enabled_capability_default\n");
 }
 
 static void test_agent_adapter_registry(void)

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -568,6 +568,51 @@ static void test_agent_config_provider_cli_roundtrip(void)
    }
 }
 
+/* tools_enabled defaults from the backing model's intrinsic capability when the
+ * JSON key is absent, so a tool-capable delegate is usable for tool-requiring
+ * roles instead of being silently filtered out by the routing capability check.
+ * Explicit values still win. Regression for "no configured model supports
+ * required capabilities (caps=tools)". */
+static void test_tools_enabled_capability_default(void)
+{
+   FILE *f = fopen(agent_config_path(), "w");
+   assert(f != NULL);
+   /* m_default: tool-capable model (mistral), no tools_enabled key -> derive ON.
+    * m_off:     same model, explicit "tools_enabled": false       -> stays OFF.
+    * m_on:      same model, explicit "tools_enabled": true        -> stays ON. */
+   fputs("{\"agents\":[{\"name\":\"m_default\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\"},"
+         "{\"name\":\"m_off\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":false},"
+         "{\"name\":\"m_on\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":true}]}\n",
+         f);
+   fclose(f);
+
+   agent_config_t loaded;
+   assert(agent_load_config(&loaded) == 0);
+   assert(loaded.agent_count == 3);
+
+   const agent_t *m_default = agent_find(&loaded, "m_default");
+   const agent_t *m_off = agent_find(&loaded, "m_off");
+   const agent_t *m_on = agent_find(&loaded, "m_on");
+   assert(m_default && m_off && m_on);
+
+   /* The crux: an absent key on a tool-capable model now defaults tools ON. */
+   assert(m_default->tools_enabled == 1);
+   /* Explicit operator settings are still honoured verbatim. */
+   assert(m_off->tools_enabled == 0);
+   assert(m_on->tools_enabled == 1);
+
+   unlink(agent_config_path());
+   printf("  PASS: test_tools_enabled_capability_default\n");
+}
+
 static void test_agent_adapter_registry(void)
 {
    const agent_adapter_t *codex = agent_adapter_for_name("codex");
@@ -1914,6 +1959,7 @@ int main(void)
    test_provider_env_credentials_and_headers();
    test_codex_oauth_request_creds();
    test_agent_config_provider_cli_roundtrip();
+   test_tools_enabled_capability_default();
    test_agent_adapter_registry();
    test_provider_cli_shell_exec_uses_argv_not_shell();
    test_provider_cli_shell_timeout_covers_prompt_write();

--- a/src/tests/test_agent_caps.c
+++ b/src/tests/test_agent_caps.c
@@ -1,8 +1,11 @@
 #include <assert.h>
+#include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "aimee.h"
 #include "agent.h"
+#include "agent_config.h"
 #include "model_registry.h"
 
 void test_agent_route_with_caps_honors_tools_enabled(void)
@@ -76,4 +79,49 @@ void test_agent_route_with_caps_honors_context_override(void)
    cfg.agents[0].enabled = 1;
    cfg.agents[0].middleware.context_window = 1000;
    assert(agent_route_with_caps(&cfg, "review", &sys_cfg, 0, 50000) == NULL);
+}
+
+/* tools_enabled defaults from the backing model's intrinsic capability when the
+ * JSON key is absent, so a tool-capable delegate is usable for tool-requiring
+ * roles instead of being silently filtered out by the routing capability check
+ * (delegate_filter_route_capabilities). Explicit values still win. Regression
+ * for "no configured model supports required capabilities (caps=tools)". */
+void test_tools_enabled_capability_default(void)
+{
+   FILE *f = fopen(agent_config_path(), "w");
+   assert(f != NULL);
+   /* m_default: tool-capable model (mistral), no tools_enabled key -> derive ON.
+    * m_off:     same model, explicit "tools_enabled": false       -> stays OFF.
+    * m_on:      same model, explicit "tools_enabled": true        -> stays ON. */
+   fputs("{\"agents\":[{\"name\":\"m_default\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\"},"
+         "{\"name\":\"m_off\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":false},"
+         "{\"name\":\"m_on\",\"provider\":\"mistral\","
+         "\"model\":\"mistral-medium-latest\",\"roles\":[\"review\"],"
+         "\"backend\":\"provider-cli\",\"cli_kind\":\"mistral\",\"cli_cmd\":\"vibe\","
+         "\"tools_enabled\":true}]}\n",
+         f);
+   fclose(f);
+
+   agent_config_t loaded;
+   assert(agent_load_config(&loaded) == 0);
+   assert(loaded.agent_count == 3);
+
+   const agent_t *m_default = agent_find(&loaded, "m_default");
+   const agent_t *m_off = agent_find(&loaded, "m_off");
+   const agent_t *m_on = agent_find(&loaded, "m_on");
+   assert(m_default && m_off && m_on);
+
+   /* The crux: an absent key on a tool-capable model now defaults tools ON. */
+   assert(m_default->tools_enabled == 1);
+   /* Explicit operator settings are still honoured verbatim. */
+   assert(m_off->tools_enabled == 0);
+   assert(m_on->tools_enabled == 1);
+
+   unlink(agent_config_path());
+   printf("  PASS: test_tools_enabled_capability_default\n");
 }

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -157,6 +157,43 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    return 0;
 }
 
+/* The aggregator/synthesis step runs through the no-tools role-routed path
+ * (agent_run_ex) so non-tool models can synthesize. Mirror the aggregator
+ * branch of the tool-enabled stub below. */
+int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
+                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   char buf[128];
+   g_aggregator_calls++;
+   if (g_aggregator_mode == 1)
+      out->response =
+          strdup(g_aggregator_calls == 1 ? "synthesized answer 1" : "inferior final artifact");
+   else if (g_aggregator_mode == 2)
+   {
+      size_t n = 26000;
+      out->response = malloc(n);
+      memset(out->response, 'a', n - 2);
+      out->response[n - 2] = '\n';
+      out->response[n - 1] = '\0';
+   }
+   else
+   {
+      snprintf(buf, sizeof(buf), "synthesized answer %d", g_aggregator_calls);
+      out->response = strdup(buf);
+   }
+   out->prompt_tokens = 200;
+   out->completion_tokens = 100;
+   snprintf(out->agent_name, sizeof(out->agent_name), "%s", role ? role : "");
+   out->success = 1;
+   return 0;
+}
+
 int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
                                        const char *system_prompt, const char *user_prompt,
                                        int max_tokens, int enforce_writes, agent_result_t *out)


### PR DESCRIPTION
Promote testing→main. Includes #228: the roundtable/MoA aggregator now synthesizes via the no-tools role-routed path, so non-tool models (MiniMax) no longer fail the tool loop and return empty — the roundtable produces a real artifact. Completes the roundtable-out-of-the-box chain (#216, #220, #223, #228). CI green on #228.