### PR TITLE
Dispatch a bare-name ensemble aggregator by name, not by role

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -384,35 +384,28 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
    memset(out, 0, sizeof(*out));
 
    agent_config_t agg_cfg = *acfg;
-   const char *role = "review"; /* default aggregator role */
-
-   if (cfg->ensemble_aggregator[0])
-   {
-      const char *agg = cfg->ensemble_aggregator;
-      const char *at = strchr(agg, '@');
-      if (at)
-      {
-         size_t role_len = (size_t)(at - agg);
-         if (role_len >= sizeof(agg_cfg.default_agent))
-            role_len = sizeof(agg_cfg.default_agent) - 1;
-         memcpy(agg_cfg.default_agent, agg, role_len);
-         agg_cfg.default_agent[role_len] = '\0';
-         role = agg_cfg.default_agent;
-      }
-      else
-      {
-         snprintf(agg_cfg.default_agent, sizeof(agg_cfg.default_agent), "%s", agg);
-         role = agg_cfg.default_agent;
-      }
-   }
 
    /* Synthesis is pure text/JSON merging of the panel's responses — it needs no
     * tools. Running it through the tool-use loop breaks aggregators whose model
     * has no tool-calling support (e.g. MiniMax), which then return empty and
-    * collapse the whole round to a degraded, artifact-less result. Use the
-    * plain (no-tools) role-routed path; default_agent still selects the
-    * configured aggregator. */
-   return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
+    * collapse the whole round to a degraded, artifact-less result. So all paths
+    * below use a no-tools run.
+    *
+    * The aggregator may be configured as a bare agent NAME (what the default
+    * panel picks — its first panellist) or as "<...>@<role>". A bare name must
+    * be dispatched by NAME (agent_run_named): agent_run_ex selects by role and
+    * an agent's name is not one of its roles, so a name routed as a role finds
+    * nothing and returns empty. A role form (or no aggregator) routes by role. */
+   if (cfg->ensemble_aggregator[0])
+   {
+      const char *agg = cfg->ensemble_aggregator;
+      const char *at = strchr(agg, '@');
+      if (!at)
+         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
+      const char *role = (at[1]) ? at + 1 : "review";
+      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
+   }
+   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -121,6 +121,9 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agen
    return count;
 }
 
+static void fill_aggregator_response(agent_result_t *out, const char *who);
+static int is_synthesis_prompt(const char *p);
+
 int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
                     const char *system_prompt, const char *user_prompt, int max_tokens,
                     double temperature, agent_result_t *out)
@@ -131,8 +134,15 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    (void)user_prompt;
    (void)max_tokens;
    (void)temperature;
-   g_named_calls++;
    memset(out, 0, sizeof(*out));
+   /* A bare-name aggregator is dispatched here with the synthesis prompt; it is
+    * the aggregator, not a panel participant, so it is not a "named" call. */
+   if (is_synthesis_prompt(user_prompt))
+   {
+      fill_aggregator_response(out, name);
+      return 0;
+   }
+   g_named_calls++;
    if (role && strcmp(role, "review") == 0 &&
        strstr(user_prompt ? user_prompt : "", "Repair this malformed roundtable review"))
    {
@@ -157,18 +167,11 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    return 0;
 }
 
-/* The aggregator/synthesis step runs through the no-tools role-routed path
- * (agent_run_ex) so non-tool models can synthesize. Mirror the aggregator
- * branch of the tool-enabled stub below. */
-int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
-                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+/* The aggregator/synthesis step runs without tools: by NAME (agent_run_named)
+ * when the aggregator is a bare agent name (a name is not a role, so role-
+ * routing can't reach it), else by role (agent_run_ex). Both land here. */
+static void fill_aggregator_response(agent_result_t *out, const char *who)
 {
-   (void)cfg;
-   (void)system_prompt;
-   (void)user_prompt;
-   (void)max_tokens;
-   (void)temperature;
-   memset(out, 0, sizeof(*out));
    char buf[128];
    g_aggregator_calls++;
    if (g_aggregator_mode == 1)
@@ -189,8 +192,26 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
    }
    out->prompt_tokens = 200;
    out->completion_tokens = 100;
-   snprintf(out->agent_name, sizeof(out->agent_name), "%s", role ? role : "");
+   snprintf(out->agent_name, sizeof(out->agent_name), "%s", who ? who : "");
    out->success = 1;
+}
+
+/* True for the aggregator/synthesis prompt (vs a panel round or a repair). */
+static int is_synthesis_prompt(const char *p)
+{
+   return p && (strstr(p, "synthesis aggregator") || strstr(p, "consolidating"));
+}
+
+int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
+                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   fill_aggregator_response(out, role);
    return 0;
 }
 


### PR DESCRIPTION
## Summary

Follow-up correcting **#228**. That change routed the aggregator through the no-tools path `agent_run_ex`, but `agent_run_ex` selects **by role** — it only considers agents whose `roles[]` contains the role string. The default panel sets the aggregator to its first panellist's **name** (e.g. `minimax`), and an agent's name is not one of its roles, so `agent_run_ex` (and the original `agent_route` the tool path used) resolve **nothing** and the aggregator returns empty — collapsing every round to a `degraded`, artifact-less result.

Confirmed live on `.254`: the panel runs (`cost_usd > 0`) but the artifact is empty, `best_round:0`. Reading `agent_route` shows `agent_route(cfg, "minimax")` returns NULL because `agent_supports_role` requires the role to be in `roles[]` or be an exec role. **The earlier "non-tool models can't synthesize" diagnosis (#228) was wrong** — the aggregator was never reaching an agent at all.

`run_aggregator` now:
- **bare agent name** → `agent_run_named` (resolve by name, no tools)
- `<name>@<role>` → `agent_run_ex` on `<role>` (no tools)
- unset → `agent_run_ex` on `"review"` (no tools)

`agent_run_named` finds the agent directly (`agent_find`) and executes without tools — the same path the panel participants and a plain delegate already use successfully.

## Testing
- The aggregator is now dispatched via `agent_run_named` for a bare name; the test stub recognizes the synthesis prompt and reproduces the aggregator response (content + token accounting), so existing cost/convergence assertions hold.
- `make verify-local` + full `make unit-tests` green (15 binaries).
- Will validate live on `.254`: roundtable should return a non-empty artifact with `degraded:false`.
