### PR TITLE
Promote: dispatch bare-name ensemble aggregator by name

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -384,35 +384,28 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
    memset(out, 0, sizeof(*out));
 
    agent_config_t agg_cfg = *acfg;
-   const char *role = "review"; /* default aggregator role */
-
-   if (cfg->ensemble_aggregator[0])
-   {
-      const char *agg = cfg->ensemble_aggregator;
-      const char *at = strchr(agg, '@');
-      if (at)
-      {
-         size_t role_len = (size_t)(at - agg);
-         if (role_len >= sizeof(agg_cfg.default_agent))
-            role_len = sizeof(agg_cfg.default_agent) - 1;
-         memcpy(agg_cfg.default_agent, agg, role_len);
-         agg_cfg.default_agent[role_len] = '\0';
-         role = agg_cfg.default_agent;
-      }
-      else
-      {
-         snprintf(agg_cfg.default_agent, sizeof(agg_cfg.default_agent), "%s", agg);
-         role = agg_cfg.default_agent;
-      }
-   }
 
    /* Synthesis is pure text/JSON merging of the panel's responses — it needs no
     * tools. Running it through the tool-use loop breaks aggregators whose model
     * has no tool-calling support (e.g. MiniMax), which then return empty and
-    * collapse the whole round to a degraded, artifact-less result. Use the
-    * plain (no-tools) role-routed path; default_agent still selects the
-    * configured aggregator. */
-   return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
+    * collapse the whole round to a degraded, artifact-less result. So all paths
+    * below use a no-tools run.
+    *
+    * The aggregator may be configured as a bare agent NAME (what the default
+    * panel picks — its first panellist) or as "<...>@<role>". A bare name must
+    * be dispatched by NAME (agent_run_named): agent_run_ex selects by role and
+    * an agent's name is not one of its roles, so a name routed as a role finds
+    * nothing and returns empty. A role form (or no aggregator) routes by role. */
+   if (cfg->ensemble_aggregator[0])
+   {
+      const char *agg = cfg->ensemble_aggregator;
+      const char *at = strchr(agg, '@');
+      if (!at)
+         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
+      const char *role = (at[1]) ? at + 1 : "review";
+      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
+   }
+   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -121,6 +121,9 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agen
    return count;
 }
 
+static void fill_aggregator_response(agent_result_t *out, const char *who);
+static int is_synthesis_prompt(const char *p);
+
 int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
                     const char *system_prompt, const char *user_prompt, int max_tokens,
                     double temperature, agent_result_t *out)
@@ -131,8 +134,15 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    (void)user_prompt;
    (void)max_tokens;
    (void)temperature;
-   g_named_calls++;
    memset(out, 0, sizeof(*out));
+   /* A bare-name aggregator is dispatched here with the synthesis prompt; it is
+    * the aggregator, not a panel participant, so it is not a "named" call. */
+   if (is_synthesis_prompt(user_prompt))
+   {
+      fill_aggregator_response(out, name);
+      return 0;
+   }
+   g_named_calls++;
    if (role && strcmp(role, "review") == 0 &&
        strstr(user_prompt ? user_prompt : "", "Repair this malformed roundtable review"))
    {
@@ -157,18 +167,11 @@ int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
    return 0;
 }
 
-/* The aggregator/synthesis step runs through the no-tools role-routed path
- * (agent_run_ex) so non-tool models can synthesize. Mirror the aggregator
- * branch of the tool-enabled stub below. */
-int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
-                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+/* The aggregator/synthesis step runs without tools: by NAME (agent_run_named)
+ * when the aggregator is a bare agent name (a name is not a role, so role-
+ * routing can't reach it), else by role (agent_run_ex). Both land here. */
+static void fill_aggregator_response(agent_result_t *out, const char *who)
 {
-   (void)cfg;
-   (void)system_prompt;
-   (void)user_prompt;
-   (void)max_tokens;
-   (void)temperature;
-   memset(out, 0, sizeof(*out));
    char buf[128];
    g_aggregator_calls++;
    if (g_aggregator_mode == 1)
@@ -189,8 +192,26 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
    }
    out->prompt_tokens = 200;
    out->completion_tokens = 100;
-   snprintf(out->agent_name, sizeof(out->agent_name), "%s", role ? role : "");
+   snprintf(out->agent_name, sizeof(out->agent_name), "%s", who ? who : "");
    out->success = 1;
+}
+
+/* True for the aggregator/synthesis prompt (vs a panel round or a repair). */
+static int is_synthesis_prompt(const char *p)
+{
+   return p && (strstr(p, "synthesis aggregator") || strstr(p, "consolidating"));
+}
+
+int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
+                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   fill_aggregator_response(out, role);
    return 0;
 }
 

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -151,6 +151,13 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	// Aggregate dashboard endpoint — all panels in one server round-trip
 	mux.HandleFunc("/api/dashboard", s.requireAuth(s.handleDashboardAll))
 
+	// Credential vault (WP-C.2c): the user re-presents their login password to
+	// unlock; calls carry the server.token bearer + X-Aimee-Webuser so
+	// aimee-server resolves this user's webuser: vault.
+	mux.HandleFunc("/api/vault/unlock", s.requireAuth(s.handleVaultUnlock))
+	mux.HandleFunc("/api/vault/password", s.requireAuth(s.handleVaultPassword))
+	mux.HandleFunc("/api/vault/credentials", s.requireAuth(s.handleVaultCredentials))
+
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))
 	mux.HandleFunc("/api/rules", s.requireAuth(s.handleCollabRulesList))

--- a/webchat/vault.go
+++ b/webchat/vault.go
@@ -1,0 +1,184 @@
+package main
+
+// vault.go: WP-C.2c — webchat wiring for the per-user (`webuser:`) credential
+// vault. The browser holds nothing: the user re-presents their login password to
+// /api/vault/unlock, which the backend forwards to aimee-server with the
+// server.token bearer + an X-Aimee-Webuser assertion. aimee-server derives the
+// vault KEK (scrypt) and caches it per webuser. All vault calls go over the
+// token-bearing /v1 path (v1RequestWebuser) — NEVER the OpenAI proxy (proxyV1),
+// which strips Authorization.
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// serverToken reads the shared server.token secret (0600, in the aimee config
+// dir) — the bearer aimee-server trusts for X-Aimee-Webuser assertions. Empty if
+// absent.
+func (s *server) serverToken() string {
+	raw, err := os.ReadFile(filepath.Join(filepath.Dir(s.cfg.socketPath), "server.token"))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(raw))
+}
+
+// v1RequestWebuser is v1Request plus the webchat trust headers: the server.token
+// bearer and X-Aimee-Webuser, so aimee-server resolves the caller's webuser:
+// vault. Returns an error if the server.token or username is missing (fail-
+// closed: no assertion is sent without the trust secret).
+func (s *server) v1RequestWebuser(ctx context.Context, username, method, path string, body []byte) (int, []byte, error) {
+	token := s.serverToken()
+	if token == "" || username == "" {
+		return http.StatusUnauthorized, nil, errNoVaultTrust
+	}
+	sock := s.aimeeHTTPSockPath()
+	client := &http.Client{
+		Timeout: socketCallTimeout,
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+				return (&net.Dialer{}).DialContext(ctx, "unix", sock)
+			},
+		},
+	}
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, "http://aimee"+path, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("X-Aimee-Webuser", username)
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	data, err := io.ReadAll(resp.Body)
+	return resp.StatusCode, data, err
+}
+
+var errNoVaultTrust = &vaultErr{"vault trust unavailable (server.token or session missing)"}
+
+type vaultErr struct{ msg string }
+
+func (e *vaultErr) Error() string { return e.msg }
+
+// pass an aimee-server /v1 response through to the browser, mapping transport
+// failures to a stable JSON error.
+func (s *server) vaultRelay(w http.ResponseWriter, st int, data []byte, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "vault: aimee-server unavailable")
+		return
+	}
+	if st != http.StatusOK {
+		// Forward aimee-server's own error envelope (locked / unattested / etc.).
+		if len(data) > 0 {
+			w.WriteHeader(st)
+			w.Write(data)
+			return
+		}
+		writeJSONError(w, st, "vault: request failed")
+		return
+	}
+	if len(data) > 0 {
+		w.Write(data)
+		return
+	}
+	w.Write([]byte(`{"status":"ok"}`))
+}
+
+// POST /api/vault/unlock {password} — derive + cache the user's vault KEK.
+func (s *server) handleVaultUnlock(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req struct {
+		Password string `json:"password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Password == "" {
+		writeJSONError(w, http.StatusBadRequest, "password required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]string{"password": req.Password})
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/vault/unlock", body)
+	s.vaultRelay(w, st, data, err)
+}
+
+// POST /api/vault/password {old_password,new_password} — re-key on password change.
+func (s *server) handleVaultPassword(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req struct {
+		OldPassword string `json:"old_password"`
+		NewPassword string `json:"new_password"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.OldPassword == "" || req.NewPassword == "" {
+		writeJSONError(w, http.StatusBadRequest, "old_password and new_password required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]string{"old_password": req.OldPassword, "new_password": req.NewPassword})
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/vault/rekey", body)
+	s.vaultRelay(w, st, data, err)
+}
+
+// /api/vault/credentials — GET list (names only), POST set {agent,cred,secret},
+// DELETE remove {agent,cred}.
+func (s *server) handleVaultCredentials(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	user := currentUser(r)
+	switch r.Method {
+	case http.MethodGet:
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/vault/list", []byte(`{}`))
+		s.vaultRelay(w, st, data, err)
+	case http.MethodPost:
+		var req struct {
+			Agent  string `json:"agent"`
+			Cred   string `json:"cred"`
+			Secret string `json:"secret"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Agent == "" || req.Cred == "" || req.Secret == "" {
+			writeJSONError(w, http.StatusBadRequest, "agent, cred, secret required")
+			return
+		}
+		body, _ := json.Marshal(map[string]string{"agent": req.Agent, "cred": req.Cred, "secret": req.Secret})
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/vault/set", body)
+		s.vaultRelay(w, st, data, err)
+	case http.MethodDelete:
+		var req struct {
+			Agent string `json:"agent"`
+			Cred  string `json:"cred"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Agent == "" || req.Cred == "" {
+			writeJSONError(w, http.StatusBadRequest, "agent and cred required")
+			return
+		}
+		body, _ := json.Marshal(map[string]string{"agent": req.Agent, "cred": req.Cred})
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/vault/delete", body)
+		s.vaultRelay(w, st, data, err)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}

--- a/webchat/vault.go
+++ b/webchat/vault.go
@@ -77,29 +77,72 @@ type vaultErr struct{ msg string }
 
 func (e *vaultErr) Error() string { return e.msg }
 
-// pass an aimee-server /v1 response through to the browser, mapping transport
-// failures to a stable JSON error.
-func (s *server) vaultRelay(w http.ResponseWriter, st int, data []byte, err error) {
+// vaultSafeErrorMessage extracts ONLY a short server-generated error string from
+// an aimee-server error envelope (e.g. "vault locked"), never the raw body —
+// defense in depth so nothing unexpected reaches the browser.
+func vaultSafeErrorMessage(data []byte) string {
+	var e struct {
+		Error   any    `json:"error"`
+		Message string `json:"message"`
+	}
+	_ = json.Unmarshal(data, &e)
+	if s, ok := e.Error.(string); ok && s != "" {
+		return s
+	}
+	if m, ok := e.Error.(map[string]any); ok {
+		if ms, ok := m["message"].(string); ok && ms != "" {
+			return ms
+		}
+	}
+	if e.Message != "" {
+		return e.Message
+	}
+	return "vault: request failed"
+}
+
+// vaultRelayStatus is the browser response for a MUTATION (unlock/set/delete/
+// rekey): a fixed {"status":"ok"} on success, a sanitized error otherwise. It
+// NEVER echoes the upstream body — webchat is the user-facing trust boundary, so
+// no aimee-server bytes are passed through verbatim.
+func (s *server) vaultRelayStatus(w http.ResponseWriter, st int, data []byte, err error) {
 	w.Header().Set("Content-Type", "application/json")
 	if err != nil {
 		writeJSONError(w, http.StatusServiceUnavailable, "vault: aimee-server unavailable")
 		return
 	}
 	if st != http.StatusOK {
-		// Forward aimee-server's own error envelope (locked / unattested / etc.).
-		if len(data) > 0 {
-			w.WriteHeader(st)
-			w.Write(data)
-			return
-		}
-		writeJSONError(w, st, "vault: request failed")
-		return
-	}
-	if len(data) > 0 {
-		w.Write(data)
+		writeJSONError(w, st, vaultSafeErrorMessage(data))
 		return
 	}
 	w.Write([]byte(`{"status":"ok"}`))
+}
+
+// vaultRelayList is the browser response for GET (names only). It decodes the
+// upstream response and re-marshals a strict {agent,cred} allowlist, so a
+// secret/value/KEK field can NEVER reach the browser even if upstream regresses.
+func (s *server) vaultRelayList(w http.ResponseWriter, st int, data []byte, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "vault: aimee-server unavailable")
+		return
+	}
+	if st != http.StatusOK {
+		writeJSONError(w, st, vaultSafeErrorMessage(data))
+		return
+	}
+	var up struct {
+		Credentials []struct {
+			Agent string `json:"agent"`
+			Cred  string `json:"cred"`
+		} `json:"credentials"`
+	}
+	_ = json.Unmarshal(data, &up)
+	creds := make([]map[string]string, 0, len(up.Credentials))
+	for _, c := range up.Credentials {
+		creds = append(creds, map[string]string{"agent": c.Agent, "cred": c.Cred})
+	}
+	out, _ := json.Marshal(map[string]any{"status": "ok", "credentials": creds})
+	w.Write(out)
 }
 
 // POST /api/vault/unlock {password} — derive + cache the user's vault KEK.
@@ -119,7 +162,7 @@ func (s *server) handleVaultUnlock(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	body, _ := json.Marshal(map[string]string{"password": req.Password})
 	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/vault/unlock", body)
-	s.vaultRelay(w, st, data, err)
+	s.vaultRelayStatus(w, st, data, err)
 }
 
 // POST /api/vault/password {old_password,new_password} — re-key on password change.
@@ -140,7 +183,7 @@ func (s *server) handleVaultPassword(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	body, _ := json.Marshal(map[string]string{"old_password": req.OldPassword, "new_password": req.NewPassword})
 	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/vault/rekey", body)
-	s.vaultRelay(w, st, data, err)
+	s.vaultRelayStatus(w, st, data, err)
 }
 
 // /api/vault/credentials — GET list (names only), POST set {agent,cred,secret},
@@ -152,7 +195,7 @@ func (s *server) handleVaultCredentials(w http.ResponseWriter, r *http.Request) 
 	switch r.Method {
 	case http.MethodGet:
 		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/vault/list", []byte(`{}`))
-		s.vaultRelay(w, st, data, err)
+		s.vaultRelayList(w, st, data, err)
 	case http.MethodPost:
 		var req struct {
 			Agent  string `json:"agent"`
@@ -165,7 +208,7 @@ func (s *server) handleVaultCredentials(w http.ResponseWriter, r *http.Request) 
 		}
 		body, _ := json.Marshal(map[string]string{"agent": req.Agent, "cred": req.Cred, "secret": req.Secret})
 		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/vault/set", body)
-		s.vaultRelay(w, st, data, err)
+		s.vaultRelayStatus(w, st, data, err)
 	case http.MethodDelete:
 		var req struct {
 			Agent string `json:"agent"`
@@ -177,7 +220,7 @@ func (s *server) handleVaultCredentials(w http.ResponseWriter, r *http.Request) 
 		}
 		body, _ := json.Marshal(map[string]string{"agent": req.Agent, "cred": req.Cred})
 		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/vault/delete", body)
-		s.vaultRelay(w, st, data, err)
+		s.vaultRelayStatus(w, st, data, err)
 	default:
 		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}

--- a/webchat/vault_test.go
+++ b/webchat/vault_test.go
@@ -36,7 +36,7 @@ func TestVaultUnlockSendsWebuserAndBearer(t *testing.T) {
 	rr := httptest.NewRecorder()
 	s.handleVaultUnlock(rr, req)
 
-	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), "webuser:alice") {
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), `"status":"ok"`) {
 		t.Fatalf("unlock: code=%d body=%q", rr.Code, rr.Body.String())
 	}
 	if gotAuth != "Bearer sekret-token" {
@@ -72,6 +72,48 @@ func TestVaultUnlockFailsClosedWithoutServerToken(t *testing.T) {
 	}
 	if rr.Code == http.StatusOK {
 		t.Fatalf("expected a non-200 fail-closed status, got 200: %q", rr.Body.String())
+	}
+}
+
+// Defense in depth: even if aimee-server (wrongly) echoes a secret/value/KEK in
+// a vault response, the webchat boundary must NOT relay it to the browser.
+func TestVaultResponsesNeverLeakSecrets(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/vault/list", func(w http.ResponseWriter, r *http.Request) {
+		// A deliberately-leaky upstream: a secret/value/wrapped_dek alongside names.
+		w.Write([]byte(`{"status":"ok","credentials":[{"agent":"claude","cred":"api_key","secret":"sk-LEAKED","value":"sk-LEAKED2","wrapped_dek":"WRAPKEYLEAK"}]}`))
+	})
+	mux.HandleFunc("/v1/vault/unlock", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"status":"ok","kek":"RAWKEKLEAK","root_key":"sk-LEAKED3"}`))
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+		[]byte("tok\n"), 0600); err != nil {
+		t.Fatalf("write server.token: %v", err)
+	}
+	s := &server{cfg: cfg}
+
+	// list must surface only names.
+	rr := httptest.NewRecorder()
+	s.handleVaultCredentials(rr, withUser(httptest.NewRequest(http.MethodGet, "/api/vault/credentials", nil), "eve"))
+	body := rr.Body.String()
+	for _, leak := range []string{"sk-LEAKED", "sk-LEAKED2", "WRAPKEYLEAK"} {
+		if strings.Contains(body, leak) {
+			t.Fatalf("list leaked %q to the browser: %s", leak, body)
+		}
+	}
+	if !strings.Contains(body, `"agent":"claude"`) || !strings.Contains(body, `"cred":"api_key"`) {
+		t.Fatalf("list dropped the names: %s", body)
+	}
+
+	// unlock must surface only {status:ok}, never the upstream key fields.
+	rr2 := httptest.NewRecorder()
+	s.handleVaultUnlock(rr2, withUser(httptest.NewRequest(http.MethodPost, "/api/vault/unlock", strings.NewReader(`{"password":"p"}`)), "eve"))
+	b2 := rr2.Body.String()
+	for _, leak := range []string{"RAWKEKLEAK", "sk-LEAKED3"} {
+		if strings.Contains(b2, leak) {
+			t.Fatalf("unlock leaked %q to the browser: %s", leak, b2)
+		}
 	}
 }
 

--- a/webchat/vault_test.go
+++ b/webchat/vault_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The unlock handler must reach aimee-server's /v1/vault/unlock carrying BOTH
+// the server.token bearer AND X-Aimee-Webuser (the trust headers aimee-server
+// requires to resolve the webuser: vault), plus the password body.
+func TestVaultUnlockSendsWebuserAndBearer(t *testing.T) {
+	var gotAuth, gotWebuser, gotBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/vault/unlock", func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotWebuser = r.Header.Get("X-Aimee-Webuser")
+		b := make([]byte, r.ContentLength)
+		r.Body.Read(b)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"status":"ok","principal":"webuser:alice"}`))
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+		[]byte("sekret-token\n"), 0600); err != nil {
+		t.Fatalf("write server.token: %v", err)
+	}
+	s := &server{cfg: cfg}
+
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/vault/unlock",
+		strings.NewReader(`{"password":"hunter2"}`)), "alice")
+	rr := httptest.NewRecorder()
+	s.handleVaultUnlock(rr, req)
+
+	if rr.Code != http.StatusOK || !strings.Contains(rr.Body.String(), "webuser:alice") {
+		t.Fatalf("unlock: code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotAuth != "Bearer sekret-token" {
+		t.Fatalf("Authorization = %q, want Bearer sekret-token", gotAuth)
+	}
+	if gotWebuser != "alice" {
+		t.Fatalf("X-Aimee-Webuser = %q, want alice", gotWebuser)
+	}
+	if !strings.Contains(gotBody, "hunter2") {
+		t.Fatalf("body missing password: %q", gotBody)
+	}
+}
+
+// Fail-closed: with no server.token the backend must NOT call aimee-server and
+// must return an auth error (no webuser assertion is sent without the secret).
+func TestVaultUnlockFailsClosedWithoutServerToken(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/vault/unlock", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+	cfg := startFakeV1(t, mux) // note: no server.token written
+	s := &server{cfg: cfg}
+
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/vault/unlock",
+		strings.NewReader(`{"password":"hunter2"}`)), "alice")
+	rr := httptest.NewRecorder()
+	s.handleVaultUnlock(rr, req)
+
+	if called {
+		t.Fatalf("aimee-server was called without a server.token (should fail closed)")
+	}
+	if rr.Code == http.StatusOK {
+		t.Fatalf("expected a non-200 fail-closed status, got 200: %q", rr.Body.String())
+	}
+}
+
+// The credentials endpoint maps GET->vault.list, POST->vault.set, DELETE->vault.delete.
+func TestVaultCredentialsRoutesByMethod(t *testing.T) {
+	var listed, set, deleted bool
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/vault/list", func(w http.ResponseWriter, r *http.Request) {
+		listed = true
+		w.Write([]byte(`{"status":"ok","credentials":[]}`))
+	})
+	mux.HandleFunc("/v1/vault/set", func(w http.ResponseWriter, r *http.Request) {
+		set = true
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+	mux.HandleFunc("/v1/vault/delete", func(w http.ResponseWriter, r *http.Request) {
+		deleted = true
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+		[]byte("tok\n"), 0600); err != nil {
+		t.Fatalf("write server.token: %v", err)
+	}
+	s := &server{cfg: cfg}
+
+	do := func(method, body string) int {
+		req := withUser(httptest.NewRequest(method, "/api/vault/credentials", strings.NewReader(body)), "bob")
+		rr := httptest.NewRecorder()
+		s.handleVaultCredentials(rr, req)
+		return rr.Code
+	}
+	do(http.MethodGet, "")
+	do(http.MethodPost, `{"agent":"claude","cred":"api_key","secret":"sk-x"}`)
+	do(http.MethodDelete, `{"agent":"claude","cred":"api_key"}`)
+	if !listed || !set || !deleted {
+		t.Fatalf("routing: list=%v set=%v delete=%v", listed, set, deleted)
+	}
+}


### PR DESCRIPTION
Promote testing→main. Includes #230: the aggregator is dispatched by NAME (agent_run_named) for a bare-name aggregator, fixing the empty-artifact roundtable — agent_run_ex/agent_route can't resolve an agent name as a role. Corrects #228. CI green on #230.