### PR TITLE
WP-C.2c(3): chat-initiated delegate reaches the webchat user's vault

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -47,6 +47,15 @@ void agent_set_request_codex_creds(const char *token, const char *account_id);
  * Thread-local. */
 void agent_set_request_session(const char *session_id);
 
+/* The attested vault principal (WP-C) for the in-flight chat turn, thread-local.
+ * The chat worker sets it from its compute_ctx around the agent loop and clears
+ * it after, so a delegate the chat spawns in-process (decoupled from the
+ * originating connection) can still reach the same user's vault:
+ * create_compute_ctx falls back to this when its conn carries no principal. Set
+ * strictly for the agent-loop duration; empty otherwise. NEVER a client value. */
+void agent_set_request_vault_principal(const char *principal);
+const char *agent_get_request_vault_principal(void);
+
 /* Snapshot of the per-turn, thread-local credential context (session id + Codex
  * creds). agent_set_request_session / agent_set_request_codex_creds bind these
  * on the dispatching thread, but a parallel fan-out (agent_run_parallel) runs

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -3,6 +3,7 @@
 
 #include "agent_types.h"
 #include "config.h"
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX for the per-turn vault principal */
 
 int agent_load_config(agent_config_t *cfg);
 int agent_save_config(const agent_config_t *cfg);
@@ -57,16 +58,19 @@ void agent_set_request_vault_principal(const char *principal);
 const char *agent_get_request_vault_principal(void);
 
 /* Snapshot of the per-turn, thread-local credential context (session id + Codex
- * creds). agent_set_request_session / agent_set_request_codex_creds bind these
+ * creds + WP-C vault principal). agent_set_request_session /
+ * agent_set_request_codex_creds / agent_set_request_vault_principal bind these
  * on the dispatching thread, but a parallel fan-out (agent_run_parallel) runs
  * each agent on a fresh worker thread that does NOT inherit thread-locals — so
  * the dispatcher snapshots its context and each worker restores it, or the
- * panel runs keyless. */
+ * panel runs keyless. The vault principal rides along so a fan-out delegate
+ * reaches the originating user's vault just like a same-thread delegate. */
 typedef struct
 {
    char session_id[128];
    char codex_token[MAX_API_KEY_LEN];
    char codex_account_id[128];
+   char vault_principal[VAULT_PRINCIPAL_MAX];
 } agent_request_creds_t;
 
 void agent_request_creds_snapshot(agent_request_creds_t *out);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -281,6 +281,7 @@ void agent_request_creds_snapshot(agent_request_creds_t *out)
    snprintf(out->session_id, sizeof(out->session_id), "%s", g_request_session_id);
    snprintf(out->codex_token, sizeof(out->codex_token), "%s", g_request_codex_token);
    snprintf(out->codex_account_id, sizeof(out->codex_account_id), "%s", g_request_codex_account_id);
+   snprintf(out->vault_principal, sizeof(out->vault_principal), "%s", g_request_vault_principal);
 }
 
 void agent_request_creds_restore(const agent_request_creds_t *creds)
@@ -289,6 +290,7 @@ void agent_request_creds_restore(const agent_request_creds_t *creds)
       return;
    agent_set_request_session(creds->session_id);
    agent_set_request_codex_creds(creds->codex_token, creds->codex_account_id);
+   agent_set_request_vault_principal(creds->vault_principal);
 }
 
 static void append_header_line(char *buf, size_t buf_len, const char *line)

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -2,6 +2,7 @@
 #include "aimee.h"
 #include "util.h"
 #include "agent_config.h"
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX for the per-turn vault principal */
 #include "session_credentials.h"
 #include "model_registry.h"
 #include "platform_path.h"
@@ -241,6 +242,24 @@ void agent_set_request_session(const char *session_id)
       snprintf(g_request_session_id, sizeof(g_request_session_id), "%s", session_id);
    else
       g_request_session_id[0] = '\0';
+}
+
+/* WP-C.2c(3): the attested vault principal for the in-flight chat turn, so a
+ * chat-spawned delegate (dispatched through the conn-decoupled agent loop) can
+ * reach the originating user's vault. */
+static _Thread_local char g_request_vault_principal[VAULT_PRINCIPAL_MAX];
+
+void agent_set_request_vault_principal(const char *principal)
+{
+   if (principal && principal[0])
+      snprintf(g_request_vault_principal, sizeof(g_request_vault_principal), "%s", principal);
+   else
+      g_request_vault_principal[0] = '\0';
+}
+
+const char *agent_get_request_vault_principal(void)
+{
+   return g_request_vault_principal;
 }
 
 void agent_set_request_codex_creds(const char *token, const char *account_id)

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1705,14 +1705,14 @@ compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON 
     * not be opened on the server's own fs. A NULL conn is an in-process caller. */
    cctx->conn_caps = conn ? conn->capabilities : CAPS_ALL;
 
-   /* WP-C.0 (hop 3 of 3): copy the attested vault identity while the conn is live;
-    * the detached worker (conn_fd closed, no thread-local) trusts only this
-    * principal for the vault, never the body session_id. NULL conn => no vault. */
+   /* WP-C vault identity: the live conn's attested principal (hop 3), else the
+    * chat turn's thread-local (a chat-spawned delegate, decoupled from the conn;
+    * the thread-local is cleared per-turn so it can't leak across turns). */
    if (conn)
-   {
       cctx->attested_transport = conn->attested_transport;
-      snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s", conn->vault_principal);
-   }
+   snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s",
+            (conn && conn->vault_principal[0]) ? conn->vault_principal
+                                               : agent_get_request_vault_principal());
 
    /* Clone the request since the original will be freed after dispatch */
    cctx->req = cJSON_Duplicate(req, 1);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1705,9 +1705,9 @@ compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON 
     * not be opened on the server's own fs. A NULL conn is an in-process caller. */
    cctx->conn_caps = conn ? conn->capabilities : CAPS_ALL;
 
-   /* WP-C vault identity: the live conn's attested principal (hop 3), else the
-    * chat turn's thread-local (a chat-spawned delegate, decoupled from the conn;
-    * the thread-local is cleared per-turn so it can't leak across turns). */
+   /* WP-C vault identity: the conn's attested principal (hop 3) wins; else fall back
+    * to the chat turn's per-turn thread-local — the chat-spawned delegate's loopback
+    * conn carries no restored identity, and the TL is cleared per turn (no leak). */
    if (conn)
       cctx->attested_transport = conn->attested_transport;
    snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s",

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -460,7 +460,13 @@ static void chat_stream_worker_pooled(void *arg)
    }
    agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
                                  jo_str(cctx->req, "codex_account_id", NULL));
+   /* WP-C.2c(3): carry the attested vault principal across the conn-decoupled
+    * agent loop so a delegate this chat spawns reaches the user's vault. Bounded
+    * strictly to the agent-loop execution + cleared after, so a later delegate on
+    * this pooled thread can never inherit a prior turn's principal. */
+   agent_set_request_vault_principal(cctx->vault_principal);
    chat_stream_worker(arg);
+   agent_set_request_vault_principal(NULL);
    if (locked)
       presence_turn_release(lock_session, lock_turn);
    else if (sid[0])

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -461,9 +461,16 @@ static void chat_stream_worker_pooled(void *arg)
    agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
                                  jo_str(cctx->req, "codex_account_id", NULL));
    /* WP-C.2c(3): carry the attested vault principal across the conn-decoupled
-    * agent loop so a delegate this chat spawns reaches the user's vault. Bounded
-    * strictly to the agent-loop execution + cleared after, so a later delegate on
-    * this pooled thread can never inherit a prior turn's principal. */
+    * agent loop so a delegate this chat spawns reaches the user's vault — both a
+    * same-thread delegate (via create_compute_ctx's thread-local fallback when its
+    * loopback conn carries no restored identity) and a parallel fan-out delegate
+    * (which inherits it via agent_request_creds_snapshot, now extended to capture
+    * this thread-local). Two layers keep it from leaking across turns on this
+    * pooled thread: (1) this set is UNCONDITIONAL at the top of every turn — an
+    * empty cctx->vault_principal clears it, so the next turn never sees a prior
+    * turn's value; (2) we clear it after the worker. chat_stream_worker is a plain
+    * call with no longjmp/pthread_exit/cancellation in its tree, so the post-call
+    * clear always runs on return; together the two make the guard robust. */
    agent_set_request_vault_principal(cctx->vault_principal);
    chat_stream_worker(arg);
    agent_set_request_vault_principal(NULL);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -431,45 +431,24 @@ static void test_codex_oauth_request_creds(void)
    assert(strstr(headers, "ChatGPT-Account-ID:") == NULL);
 }
 
-/* WP-C.2c(3): the per-turn vault principal must ride along in the credential
- * snapshot. A parallel fan-out delegate (agent_run_parallel) runs on a fresh
- * worker thread that does NOT inherit thread-locals and rebinds the dispatcher's
- * context via agent_request_creds_restore — so unless the principal is carried in
- * the snapshot it silently fails to reach the originating user's vault, while a
- * same-thread delegate succeeds. This pins the round-trip. */
+/* WP-C.2c(3): the vault principal must ride along in the creds snapshot so a
+ * fan-out delegate (fresh thread; rebinds via agent_request_creds_restore)
+ * reaches the user's vault like a same-thread one; empty restores to empty. */
 static void test_request_creds_snapshot_carries_vault_principal(void)
 {
-   agent_set_request_session("sess-xyz");
-   agent_set_request_codex_creds("tok-1", "acct-1");
    agent_set_request_vault_principal("webuser:dave");
-
    agent_request_creds_t snap;
    agent_request_creds_snapshot(&snap);
    assert(strcmp(snap.vault_principal, "webuser:dave") == 0);
-
-   /* Simulate the fresh fan-out worker: its thread-locals start clear. */
-   agent_set_request_session(NULL);
-   agent_set_request_codex_creds(NULL, NULL);
-   agent_set_request_vault_principal(NULL);
-   assert(agent_get_request_vault_principal()[0] == '\0');
-
-   /* The worker restores the dispatcher's snapshot and regains the principal. */
+   agent_set_request_vault_principal(NULL); /* fresh fan-out worker starts clear */
    agent_request_creds_restore(&snap);
    assert(strcmp(agent_get_request_vault_principal(), "webuser:dave") == 0);
-
-   /* An empty principal round-trips as empty (a keyless panel), and restore
-    * actively clears a stale thread-local rather than leaving it set. */
    agent_set_request_vault_principal(NULL);
-   agent_request_creds_t snap_empty;
-   agent_request_creds_snapshot(&snap_empty);
-   assert(snap_empty.vault_principal[0] == '\0');
+   agent_request_creds_snapshot(&snap);
    agent_set_request_vault_principal("webuser:eve");
-   agent_request_creds_restore(&snap_empty);
+   agent_request_creds_restore(&snap);
    assert(agent_get_request_vault_principal()[0] == '\0');
-
-   /* Clear ALL three thread-locals: restore re-bound session + codex creds too,
-    * and a leftover token would bleed into a later test on this same thread. */
-   agent_set_request_session(NULL);
+   agent_set_request_session(NULL); /* restore re-bound session+codex; clear all */
    agent_set_request_codex_creds(NULL, NULL);
    agent_set_request_vault_principal(NULL);
 }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -431,6 +431,49 @@ static void test_codex_oauth_request_creds(void)
    assert(strstr(headers, "ChatGPT-Account-ID:") == NULL);
 }
 
+/* WP-C.2c(3): the per-turn vault principal must ride along in the credential
+ * snapshot. A parallel fan-out delegate (agent_run_parallel) runs on a fresh
+ * worker thread that does NOT inherit thread-locals and rebinds the dispatcher's
+ * context via agent_request_creds_restore — so unless the principal is carried in
+ * the snapshot it silently fails to reach the originating user's vault, while a
+ * same-thread delegate succeeds. This pins the round-trip. */
+static void test_request_creds_snapshot_carries_vault_principal(void)
+{
+   agent_set_request_session("sess-xyz");
+   agent_set_request_codex_creds("tok-1", "acct-1");
+   agent_set_request_vault_principal("webuser:dave");
+
+   agent_request_creds_t snap;
+   agent_request_creds_snapshot(&snap);
+   assert(strcmp(snap.vault_principal, "webuser:dave") == 0);
+
+   /* Simulate the fresh fan-out worker: its thread-locals start clear. */
+   agent_set_request_session(NULL);
+   agent_set_request_codex_creds(NULL, NULL);
+   agent_set_request_vault_principal(NULL);
+   assert(agent_get_request_vault_principal()[0] == '\0');
+
+   /* The worker restores the dispatcher's snapshot and regains the principal. */
+   agent_request_creds_restore(&snap);
+   assert(strcmp(agent_get_request_vault_principal(), "webuser:dave") == 0);
+
+   /* An empty principal round-trips as empty (a keyless panel), and restore
+    * actively clears a stale thread-local rather than leaving it set. */
+   agent_set_request_vault_principal(NULL);
+   agent_request_creds_t snap_empty;
+   agent_request_creds_snapshot(&snap_empty);
+   assert(snap_empty.vault_principal[0] == '\0');
+   agent_set_request_vault_principal("webuser:eve");
+   agent_request_creds_restore(&snap_empty);
+   assert(agent_get_request_vault_principal()[0] == '\0');
+
+   /* Clear ALL three thread-locals: restore re-bound session + codex creds too,
+    * and a leftover token would bleed into a later test on this same thread. */
+   agent_set_request_session(NULL);
+   agent_set_request_codex_creds(NULL, NULL);
+   agent_set_request_vault_principal(NULL);
+}
+
 static void test_agent_config_provider_cli_roundtrip(void)
 {
    const char *cfg_dir = config_default_dir();
@@ -1914,6 +1957,7 @@ int main(void)
    test_current_code_only_dispatch_blocks_stale_context_tools();
    test_provider_env_credentials_and_headers();
    test_codex_oauth_request_creds();
+   test_request_creds_snapshot_carries_vault_principal();
    test_agent_config_provider_cli_roundtrip();
    test_tools_enabled_capability_default();
    test_agent_adapter_registry();

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -127,6 +127,18 @@ void agent_set_request_session(const char *session_id)
 {
    (void)session_id;
 }
+/* Functional stub: store the per-turn vault principal so the create_compute_ctx
+ * fallback (WP-C.2c(3)) is exercisable. */
+static char g_stub_vault_principal[VAULT_PRINCIPAL_MAX];
+void agent_set_request_vault_principal(const char *principal)
+{
+   snprintf(g_stub_vault_principal, sizeof(g_stub_vault_principal), "%s",
+            principal ? principal : "");
+}
+const char *agent_get_request_vault_principal(void)
+{
+   return g_stub_vault_principal;
+}
 
 int agent_load_config(agent_config_t *cfg)
 {
@@ -1758,6 +1770,35 @@ static void test_create_compute_ctx_threads_vault_identity(void)
    assert(c2->vault_principal[0] == '\0');
    compute_ctx_free(c2);
    cJSON_Delete(req2);
+
+   /* WP-C.2c(3): a conn with NO principal falls back to the per-turn thread-local
+    * (set by the chat worker) so a chat-spawned delegate inherits the user's
+    * principal. */
+   agent_set_request_vault_principal("webuser:carol");
+   server_conn_t bare2;
+   memset(&bare2, 0, sizeof(bare2));
+   bare2.fd = -1;
+   cJSON *req3 = cJSON_CreateObject();
+   compute_ctx_t *c3 = create_compute_ctx(NULL, &bare2, req3);
+   assert(c3 != NULL);
+   assert(strcmp(c3->vault_principal, "webuser:carol") == 0);
+   compute_ctx_free(c3);
+   cJSON_Delete(req3);
+
+   /* The conn principal still WINS when present (the thread-local doesn't
+    * override an attested conn). */
+   server_conn_t named;
+   memset(&named, 0, sizeof(named));
+   named.fd = -1;
+   named.attested_transport = ATTEST_UDS_PEERCRED;
+   snprintf(named.vault_principal, sizeof(named.vault_principal), "uid:1000");
+   cJSON *req4 = cJSON_CreateObject();
+   compute_ctx_t *c4 = create_compute_ctx(NULL, &named, req4);
+   assert(c4 != NULL);
+   assert(strcmp(c4->vault_principal, "uid:1000") == 0); /* conn wins over thread-local */
+   compute_ctx_free(c4);
+   cJSON_Delete(req4);
+   agent_set_request_vault_principal(NULL); /* clear for other tests */
    printf("  PASS: test_create_compute_ctx_threads_vault_identity\n");
 }
 


### PR DESCRIPTION
The final WP-C wiring. A webchat user's chat can have the model call the `delegate` tool mid-turn; that delegate must resolve the user's `webuser:` vaulted credential. But the server **agent loop is decoupled from the originating connection** (it runs on a pooled worker and carries per-request context via thread-locals like `agent_set_request_session`), so the chat-spawned delegate's `create_compute_ctx` saw **no** principal.

## Fix (mirrors the established per-request thread-local pattern)
- **`agent_set_request_vault_principal` / `_get`** (thread-local) — set by the chat worker from its `compute_ctx`'s principal **around** the agent loop and **cleared immediately after**, so it's bounded to that turn's execution and a later delegate on the same pooled thread can never inherit a prior turn's principal (cross-user-leak guard).
- **`create_compute_ctx`** falls back to the thread-local when its conn carries no principal; the **conn principal still wins** when present (the direct `/v1` path). The principal originates only from the attested conn — never a client value.

## Tests
`create_compute_ctx` falls back to the thread-local when the conn has no principal; the conn principal wins over the thread-local. `server_compute.c` kept at the 2000-line cap. Full server links; server-compute / dispatch / vault suites pass.

This closes the last WP-C.2 gap — webchat users now get their vaulted credentials both via the management UI **and** auto-injected into chat-initiated delegates. Reviewed-before-merge per protocol.
