### PR TITLE
Derive request output cap from the model, not a hardcoded 4096

### DIFF
--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -65,6 +65,12 @@ struct cJSON *agent_build_request_gemini(const agent_t *agent, struct cJSON *mes
                                          int max_tokens, double temperature,
                                          const char *cache_name);
 
+/* Resolve the output-token cap for an outbound request: an explicit caller
+ * `requested` (>0) wins, else the agent's pinned max_tokens (>0), else the
+ * model's registry ceiling (model_max_output). Never returns 0 — request
+ * builders emit a concrete, model-appropriate cap rather than a hardcoded one. */
+int agent_request_max_tokens(const agent_t *agent, int requested);
+
 /* --- Response parsers --- */
 
 void agent_parse_response_openai(struct cJSON *root, parsed_response_t *out);

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -23,8 +23,12 @@ struct cJSON;
  * remaining loop budget drops below this, the loop stops cleanly instead of
  * issuing a doomed short-timeout call that the provider-health tracker would
  * misread as "provider unreachable" (see posix/agent_runtime.c). */
-#define AGENT_LOOP_MIN_CALL_MS     60000
-#define AGENT_DEFAULT_MAX_TOKENS   4096
+#define AGENT_LOOP_MIN_CALL_MS 60000
+/* 0 = "no explicit cap configured" — the request layer then derives the output
+ * ceiling from the model registry (model_max_output) rather than a hardcoded
+ * default, so every model gets its own full output budget. An agent may still
+ * pin a smaller cap explicitly in agents.json / --max-tokens. */
+#define AGENT_DEFAULT_MAX_TOKENS   0
 #define MAX_EXEC_ROLES             8
 #define MAX_EXEC_PROMPT_LEN        4096
 #define AGENT_DEFAULT_MAX_TURNS    20

--- a/src/headers/model_registry.h
+++ b/src/headers/model_registry.h
@@ -91,6 +91,15 @@ int model_alias_list(model_info_t *out, int max);
 int model_context_window(const char *model_id);
 
 /*
+ * The model's output-token ceiling (max_output), used as a request's max_tokens
+ * when no explicit cap was pinned by the caller or agent config. Resolves the
+ * registry's per-model max_output (static table or inferred from family +
+ * context window); returns a conservative fallback for an unknown model, never
+ * 0. provider may be NULL/empty (inferred from the model id).
+ */
+int model_max_output(const char *provider, const char *model_id);
+
+/*
  * Heuristic offline capability lookup. This is intentionally local and
  * conservative: operator/model.dev overrides can replace these values later.
  * Provider may be NULL or empty, in which case it is inferred from the model

--- a/src/model_registry.c
+++ b/src/model_registry.c
@@ -306,9 +306,33 @@ static int model_capability_get_heuristic(const char *provider, const char *mode
       out->flags = MODEL_CAP_REASONING | MODEL_CAP_TOOLS | MODEL_CAP_STREAMING;
    }
 
+   /* Output-token ceiling inferred when the model isn't in the static table.
+    * Reasoning models must budget for a (sometimes large) hidden reasoning trace
+    * plus the visible answer, so they get a higher ceiling than plain chat
+    * models; both are clamped to the context window. This is the model-specified
+    * cap the request builders use instead of any hardcoded default. */
+   if (out->max_output <= 0)
+      out->max_output = (out->flags & MODEL_CAP_REASONING) ? 32768 : 8192;
+   if (out->context_window > 0 && out->max_output > out->context_window)
+      out->max_output = out->context_window;
+
    out->deprecated = model_contains_ci(model_id, "deprecated") ? 1 : 0;
    capability_set_modalities(out);
    return 1;
+}
+
+/* The model's output-token ceiling, the single source of truth for a request's
+ * max_tokens when the caller/agent didn't pin one explicitly. Resolves the
+ * registry's per-model max_output (static table or inferred); falls back to a
+ * conservative ceiling only for a genuinely unknown model. Never returns 0, so
+ * callers can always emit a concrete, model-appropriate cap. */
+int model_max_output(const char *provider, const char *model_id)
+{
+   model_capability_t cap;
+   if (model_id && model_id[0] && model_capability_get(provider, model_id, &cap) &&
+       cap.max_output > 0)
+      return cap.max_output;
+   return 8192;
 }
 
 unsigned model_capability_flag_from_name(const char *name)

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -537,7 +537,7 @@ native_provider_http:
    int final_instruction_added = 0;
    int final_tool_retry_count = 0;
    int degenerate_retry_count = 0;
-   int tok = (max_tokens > 0) ? max_tokens : agent->max_tokens;
+   int tok = agent_request_max_tokens(agent, max_tokens);
    int max_t = agent_resolve_max_turns(agent, role);
    int initial_max_t = max_t;
    int final_after_turns = delegate_final_after_turns_for_role(role);

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "log.h"
 #include "model_sampling.h"
+#include "model_registry.h"
 #include "tool_call_args.h"
 #include "cJSON.h"
 #include <string.h>
@@ -115,6 +116,16 @@ static void openrouter_add_routing_hint(const agent_t *agent, cJSON *req)
    }
    cJSON_AddItemToObject(req, "models", models);
 }
+int agent_request_max_tokens(const agent_t *agent, int requested)
+{
+   if (requested > 0)
+      return requested; /* caller pinned an explicit budget (e.g. a short ping) */
+   if (agent && agent->max_tokens > 0)
+      return agent->max_tokens; /* agents.json / --max-tokens pinned a cap */
+   /* No explicit cap: use the model's own output ceiling, never a hardcoded one. */
+   return model_max_output(agent ? agent->provider : NULL, agent ? agent->model : NULL);
+}
+
 cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *tools,
                                   int max_tokens, double temperature)
 {
@@ -140,8 +151,7 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
          cJSON_AddStringToObject(req, "tool_choice", "auto");
    }
 
-   if (max_tokens > 0)
-      cJSON_AddNumberToObject(req, "max_tokens", max_tokens);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
    if (agent_is_mistral_vibe_model(agent))
    {
       cJSON_AddStringToObject(req, "reasoning_effort", "high");
@@ -191,8 +201,7 @@ cJSON *agent_build_request_anthropic(const agent_t *agent, cJSON *messages, cJSO
    cJSON *safe_messages = provider_payload_without_private_fields(messages);
    cJSON_AddStringToObject(req, "model", agent->model);
 
-   int tok = (max_tokens > 0) ? max_tokens : 4096;
-   cJSON_AddNumberToObject(req, "max_tokens", tok);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
 
    /* §3 cache-aware shaping: when enabled, mark the aimee-owned STABLE system
     * prefix cacheable on this (tool-bearing) Anthropic request, matching the
@@ -1632,8 +1641,7 @@ cJSON *agent_build_request_gemini(const agent_t *agent, cJSON *messages, cJSON *
 
    /* Generation config */
    cJSON *gen_cfg = cJSON_CreateObject();
-   if (max_tokens > 0)
-      cJSON_AddNumberToObject(gen_cfg, "maxOutputTokens", max_tokens);
+   cJSON_AddNumberToObject(gen_cfg, "maxOutputTokens", agent_request_max_tokens(agent, max_tokens));
    if (temperature >= 0)
       cJSON_AddNumberToObject(gen_cfg, "temperature", temperature);
    cJSON_AddItemToObject(req, "generationConfig", gen_cfg);

--- a/src/server/agent_context_budget.c
+++ b/src/server/agent_context_budget.c
@@ -1,12 +1,17 @@
 #include "aimee.h"
 #include "agent.h"
+#include "model_registry.h"
 
 size_t agent_exec_context_budget_chars(const agent_t *agent)
 {
    if (!agent || agent->middleware.context_window <= 0)
       return AGENT_CONTEXT_BUDGET;
 
-   int output_tokens = agent->max_tokens > 0 ? agent->max_tokens : AGENT_DEFAULT_MAX_TOKENS;
+   /* Reserve the model's output ceiling from the window for prompt budgeting;
+    * with no explicit agent cap, fall back to the model registry rather than a
+    * hardcoded default (which is now 0 = "unset"). */
+   int output_tokens =
+       agent->max_tokens > 0 ? agent->max_tokens : model_max_output(agent->provider, agent->model);
    int prompt_tokens = agent->middleware.context_window - output_tokens;
    if (prompt_tokens <= 0)
       prompt_tokens = agent->middleware.context_window / 2;

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -545,8 +545,7 @@ static cJSON *build_request_openai(const agent_t *agent, const char *system_prom
 
    cJSON_AddItemToObject(req, "messages", messages);
 
-   if (max_tokens > 0)
-      cJSON_AddNumberToObject(req, "max_tokens", max_tokens);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
    model_sampling_apply_openai(agent, req, temperature);
 
    return req;
@@ -588,8 +587,7 @@ static cJSON *build_request_anthropic(const agent_t *agent, const char *system_p
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "model", agent->model);
 
-   int tok = (max_tokens > 0) ? max_tokens : 4096;
-   cJSON_AddNumberToObject(req, "max_tokens", tok);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
 
    /* §3 cache-aware shaping: mark the stable system prefix cacheable (cache_control)
     * only when the flag is on, matching the tool-bearing builder. Default-off so
@@ -994,8 +992,8 @@ int agent_execute(const agent_t *agent, const char *system_prompt, const char *u
    /* Run PRE_LLM_CALL hooks — appends ephemeral context to user msg, never system_prompt. */
    char *augmented_prompt = plugin_chook_apply_pre_llm(user_prompt);
    const char *effective_user = augmented_prompt ? augmented_prompt : user_prompt;
-   /* Build request body */
-   int tok = (max_tokens > 0) ? max_tokens : agent->max_tokens;
+   /* Build request body — derive the output cap from the model when unpinned. */
+   int tok = agent_request_max_tokens(agent, max_tokens);
    if (is_anthropic_provider(agent))
       track_simple_anthropic_payload_rewrite(driver, agent, system_prompt, effective_user);
    cJSON *req = build_request(agent, system_prompt, effective_user, tok, temperature);

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -230,9 +230,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
    if (driver_is_anthropic(driver))
       prov_body = build_anthropic_provider_body(req, ag, 0);
    else
-      prov_body =
-          build_provider_body(driver, ag, messages, tools, system_text,
-                              jo_int(req, "max_tokens", 4096), jo_num(req, "temperature", 1.0), 0);
+      prov_body = build_provider_body(driver, ag, messages, tools, system_text,
+                                      agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
+                                      jo_num(req, "temperature", 1.0), 0);
    http_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &response, ag->timeout_ms,
                                  extra[0] ? extra : NULL);
    if (http_status != 200 || !response)
@@ -499,9 +499,9 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    if (driver_is_anthropic(driver))
       prov_body = build_anthropic_provider_body(req, ag, 1);
    else
-      prov_body =
-          build_provider_body(driver, ag, messages, tools, system_text,
-                              jo_int(req, "max_tokens", 4096), jo_num(req, "temperature", 1.0), 1);
+      prov_body = build_provider_body(driver, ag, messages, tools, system_text,
+                                      agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
+                                      jo_num(req, "temperature", 1.0), 1);
 
    if (driver_is_anthropic(driver))
    {

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -400,12 +400,14 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
    {
       const char *agg = cfg->ensemble_aggregator;
       const char *at = strchr(agg, '@');
+      /* max_tokens 0 = derive from the aggregator model's own output ceiling, so
+       * a reasoning aggregator isn't truncated mid-synthesis (was a hard 4096). */
       if (!at)
-         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
+         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
       const char *role = (at[1]) ? at + 1 : "review";
-      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
+      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 0, 0.3, out);
    }
-   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
+   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 0, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -848,7 +848,7 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    char extra_headers[512];
    agent_build_extra_headers(agent, extra_headers, sizeof(extra_headers));
 
-   int tok = (max_tokens > 0) ? max_tokens : agent->max_tokens;
+   int tok = agent_request_max_tokens(agent, max_tokens);
    cJSON *req = driver->build_request(agent, messages, tools, system_prompt, tok, temperature);
    if (!req)
       return -1;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -760,7 +760,7 @@ void delegate_worker(void *arg)
    const char *role =
        delegate_role_canonicalize(cJSON_IsString(jrole) ? jrole->valuestring : "execute");
    const char *prompt = cJSON_IsString(jprompt) ? jprompt->valuestring : "";
-   int max_tokens = cJSON_IsNumber(jmax) ? (int)jmax->valuedouble : 4096;
+   int max_tokens = cJSON_IsNumber(jmax) ? (int)jmax->valuedouble : 0; /* 0 => model-derived */
    const char *system_prompt = cJSON_IsString(jsystem) ? jsystem->valuestring : NULL;
    const char *sid = cJSON_IsString(jsid) ? jsid->valuestring : NULL;
    const char *cwd = cJSON_IsString(jcwd) ? jcwd->valuestring : "";

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -42,6 +42,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/openrouter_profile.o $(OBJDIR)/server/ollama_profile.o \
                              $(OBJDIR)/server/llama_native_profile.o $(OBJDIR)/server/mistral_profile.o \
                              $(OBJDIR)/server/minimax_profile.o \
+                             $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                              $(PLATFORM_AGENT_OBJS)
 
 TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -105,6 +105,14 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
    return out;
 }
 
+/* Stub: the ingress passes the incoming request's max_tokens through this
+ * resolver; an explicit value wins, otherwise a model-derived ceiling applies. */
+int agent_request_max_tokens(const agent_t *agent, int requested)
+{
+   (void)agent;
+   return requested > 0 ? requested : 8192;
+}
+
 int agent_http_post(const char *url, const char *auth_header, const char *body, char **response_buf,
                     int timeout_ms, const char *extra_headers)
 {

--- a/src/tests/test_model_registry.c
+++ b/src/tests/test_model_registry.c
@@ -136,6 +136,29 @@ static void test_context_window(void)
    assert(model_context_window("GPT-4o") == 128000);
 }
 
+static void test_max_output(void)
+{
+   /* Static-table models return their pinned output ceiling. */
+   assert(model_max_output("openai", "gpt-4o") == 16384);
+   assert(model_max_output("anthropic", "claude-sonnet-4-6") == 8192);
+
+   /* Inferred (heuristic) models: reasoning families get a higher ceiling than
+    * plain chat, both well above the old hardcoded 4096 default. */
+   assert(model_max_output("minimax", "MiniMax-M3") == 32768);      /* reasoning */
+   assert(model_max_output(NULL, "mistral-medium-latest") == 8192); /* non-reasoning */
+
+   /* Never starves a reasoning model at 4096 (the bug this replaced). */
+   assert(model_max_output("minimax", "MiniMax-M3") > 4096);
+
+   /* Inferred ceiling is clamped to the model's context window. */
+   assert(model_max_output("openai", "gpt-3.5-turbo") <= model_context_window("gpt-3.5-turbo"));
+
+   /* Unknown model still yields a usable, non-zero cap (never 0). */
+   assert(model_max_output(NULL, "some-unknown-model") == 8192);
+   assert(model_max_output(NULL, "") == 8192);
+   assert(model_max_output(NULL, NULL) == 8192);
+}
+
 static void test_alias_list(void)
 {
    int total = model_alias_list(NULL, 0);
@@ -380,6 +403,8 @@ int main(void)
    printf("provider_detect OK, ");
    test_context_window();
    printf("context_window OK, ");
+   test_max_output();
+   printf("max_output OK, ");
    test_alias_list();
    printf("alias_list OK, ");
    test_model_capability_get();


### PR DESCRIPTION
## Problem

Every outbound LLM request capped output at `AGENT_DEFAULT_MAX_TOKENS` (4096): agents default their `max_tokens` to it, and `agent_execute` substitutes it whenever a caller passes 0. For reasoning models (MiniMax-M3, mimo) that 4096 budget is consumed by the hidden reasoning trace, leaving an empty visible answer — which the runtime classifies as "no content in response" and degrades.

Concretely this made a delegate **roundtable** whose panel is reasoning models return an empty, post-hoc-`$0` artifact even with the credential plumbing working (participants got HTTP 200, billed, but emitted no content).

## Fix — derive the output cap from the model, never a hardcoded number

- **`model_max_output(provider, model_id)`** — resolves the registry's per-model `max_output` (static table, else inferred: reasoning families get a higher ceiling than plain chat, both clamped to the context window). Never returns 0.
- **`AGENT_DEFAULT_MAX_TOKENS` → 0** ("unset"). An agent may still pin a smaller cap in `agents.json` / `--max-tokens`.
- **`agent_request_max_tokens(agent, requested)`** — explicit caller value wins → agent-pinned cap → model ceiling. Every request builder (openai/anthropic/gemini in `agent_bridge.c` and `agent_runtime.c`), `agent_execute`, `openai_chat`, the posix runtime, the Anthropic ingress, the primary-chat default and the context-budget math route through it.
- The roundtable **aggregator** synthesis was a hard 4096 too → now passes 0 so it uses the aggregator model's ceiling and isn't truncated mid-synthesis.

Explicit small functional caps (sanity pings, score/converge judges) are unchanged — they pass a positive value, which still wins.

## Tests

- New `model_max_output` coverage in `test_model_registry` (static, inferred reasoning vs chat, context clamp, unknown-model fallback, and never `< 4096` for reasoning).
- Wired `model_registry` into the agent test bundle (`agent_bridge`/`agent_context_budget` now reference it; `$^` dedups the targets that also list it) and stubbed `agent_request_max_tokens` in the anthropic-http test.
- Full `aimee-server` build + complete unit suite green locally.
