### PR TITLE
Promote: model-derived output caps (#233) + chat-delegate vault (#232)

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -47,6 +47,15 @@ void agent_set_request_codex_creds(const char *token, const char *account_id);
  * Thread-local. */
 void agent_set_request_session(const char *session_id);
 
+/* The attested vault principal (WP-C) for the in-flight chat turn, thread-local.
+ * The chat worker sets it from its compute_ctx around the agent loop and clears
+ * it after, so a delegate the chat spawns in-process (decoupled from the
+ * originating connection) can still reach the same user's vault:
+ * create_compute_ctx falls back to this when its conn carries no principal. Set
+ * strictly for the agent-loop duration; empty otherwise. NEVER a client value. */
+void agent_set_request_vault_principal(const char *principal);
+const char *agent_get_request_vault_principal(void);
+
 /* Snapshot of the per-turn, thread-local credential context (session id + Codex
  * creds). agent_set_request_session / agent_set_request_codex_creds bind these
  * on the dispatching thread, but a parallel fan-out (agent_run_parallel) runs

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -3,6 +3,7 @@
 
 #include "agent_types.h"
 #include "config.h"
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX for the per-turn vault principal */
 
 int agent_load_config(agent_config_t *cfg);
 int agent_save_config(const agent_config_t *cfg);
@@ -57,16 +58,19 @@ void agent_set_request_vault_principal(const char *principal);
 const char *agent_get_request_vault_principal(void);
 
 /* Snapshot of the per-turn, thread-local credential context (session id + Codex
- * creds). agent_set_request_session / agent_set_request_codex_creds bind these
+ * creds + WP-C vault principal). agent_set_request_session /
+ * agent_set_request_codex_creds / agent_set_request_vault_principal bind these
  * on the dispatching thread, but a parallel fan-out (agent_run_parallel) runs
  * each agent on a fresh worker thread that does NOT inherit thread-locals — so
  * the dispatcher snapshots its context and each worker restores it, or the
- * panel runs keyless. */
+ * panel runs keyless. The vault principal rides along so a fan-out delegate
+ * reaches the originating user's vault just like a same-thread delegate. */
 typedef struct
 {
    char session_id[128];
    char codex_token[MAX_API_KEY_LEN];
    char codex_account_id[128];
+   char vault_principal[VAULT_PRINCIPAL_MAX];
 } agent_request_creds_t;
 
 void agent_request_creds_snapshot(agent_request_creds_t *out);

--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -65,6 +65,12 @@ struct cJSON *agent_build_request_gemini(const agent_t *agent, struct cJSON *mes
                                          int max_tokens, double temperature,
                                          const char *cache_name);
 
+/* Resolve the output-token cap for an outbound request: an explicit caller
+ * `requested` (>0) wins, else the agent's pinned max_tokens (>0), else the
+ * model's registry ceiling (model_max_output). Never returns 0 — request
+ * builders emit a concrete, model-appropriate cap rather than a hardcoded one. */
+int agent_request_max_tokens(const agent_t *agent, int requested);
+
 /* --- Response parsers --- */
 
 void agent_parse_response_openai(struct cJSON *root, parsed_response_t *out);

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -23,8 +23,12 @@ struct cJSON;
  * remaining loop budget drops below this, the loop stops cleanly instead of
  * issuing a doomed short-timeout call that the provider-health tracker would
  * misread as "provider unreachable" (see posix/agent_runtime.c). */
-#define AGENT_LOOP_MIN_CALL_MS     60000
-#define AGENT_DEFAULT_MAX_TOKENS   4096
+#define AGENT_LOOP_MIN_CALL_MS 60000
+/* 0 = "no explicit cap configured" — the request layer then derives the output
+ * ceiling from the model registry (model_max_output) rather than a hardcoded
+ * default, so every model gets its own full output budget. An agent may still
+ * pin a smaller cap explicitly in agents.json / --max-tokens. */
+#define AGENT_DEFAULT_MAX_TOKENS   0
 #define MAX_EXEC_ROLES             8
 #define MAX_EXEC_PROMPT_LEN        4096
 #define AGENT_DEFAULT_MAX_TURNS    20

--- a/src/headers/model_registry.h
+++ b/src/headers/model_registry.h
@@ -91,6 +91,15 @@ int model_alias_list(model_info_t *out, int max);
 int model_context_window(const char *model_id);
 
 /*
+ * The model's output-token ceiling (max_output), used as a request's max_tokens
+ * when no explicit cap was pinned by the caller or agent config. Resolves the
+ * registry's per-model max_output (static table or inferred from family +
+ * context window); returns a conservative fallback for an unknown model, never
+ * 0. provider may be NULL/empty (inferred from the model id).
+ */
+int model_max_output(const char *provider, const char *model_id);
+
+/*
  * Heuristic offline capability lookup. This is intentionally local and
  * conservative: operator/model.dev overrides can replace these values later.
  * Provider may be NULL or empty, in which case it is inferred from the model

--- a/src/model_registry.c
+++ b/src/model_registry.c
@@ -306,9 +306,33 @@ static int model_capability_get_heuristic(const char *provider, const char *mode
       out->flags = MODEL_CAP_REASONING | MODEL_CAP_TOOLS | MODEL_CAP_STREAMING;
    }
 
+   /* Output-token ceiling inferred when the model isn't in the static table.
+    * Reasoning models must budget for a (sometimes large) hidden reasoning trace
+    * plus the visible answer, so they get a higher ceiling than plain chat
+    * models; both are clamped to the context window. This is the model-specified
+    * cap the request builders use instead of any hardcoded default. */
+   if (out->max_output <= 0)
+      out->max_output = (out->flags & MODEL_CAP_REASONING) ? 32768 : 8192;
+   if (out->context_window > 0 && out->max_output > out->context_window)
+      out->max_output = out->context_window;
+
    out->deprecated = model_contains_ci(model_id, "deprecated") ? 1 : 0;
    capability_set_modalities(out);
    return 1;
+}
+
+/* The model's output-token ceiling, the single source of truth for a request's
+ * max_tokens when the caller/agent didn't pin one explicitly. Resolves the
+ * registry's per-model max_output (static table or inferred); falls back to a
+ * conservative ceiling only for a genuinely unknown model. Never returns 0, so
+ * callers can always emit a concrete, model-appropriate cap. */
+int model_max_output(const char *provider, const char *model_id)
+{
+   model_capability_t cap;
+   if (model_id && model_id[0] && model_capability_get(provider, model_id, &cap) &&
+       cap.max_output > 0)
+      return cap.max_output;
+   return 8192;
 }
 
 unsigned model_capability_flag_from_name(const char *name)

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -537,7 +537,7 @@ native_provider_http:
    int final_instruction_added = 0;
    int final_tool_retry_count = 0;
    int degenerate_retry_count = 0;
-   int tok = (max_tokens > 0) ? max_tokens : agent->max_tokens;
+   int tok = agent_request_max_tokens(agent, max_tokens);
    int max_t = agent_resolve_max_turns(agent, role);
    int initial_max_t = max_t;
    int final_after_turns = delegate_final_after_turns_for_role(role);

--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -9,6 +9,7 @@
 #include "config.h"
 #include "log.h"
 #include "model_sampling.h"
+#include "model_registry.h"
 #include "tool_call_args.h"
 #include "cJSON.h"
 #include <string.h>
@@ -115,6 +116,16 @@ static void openrouter_add_routing_hint(const agent_t *agent, cJSON *req)
    }
    cJSON_AddItemToObject(req, "models", models);
 }
+int agent_request_max_tokens(const agent_t *agent, int requested)
+{
+   if (requested > 0)
+      return requested; /* caller pinned an explicit budget (e.g. a short ping) */
+   if (agent && agent->max_tokens > 0)
+      return agent->max_tokens; /* agents.json / --max-tokens pinned a cap */
+   /* No explicit cap: use the model's own output ceiling, never a hardcoded one. */
+   return model_max_output(agent ? agent->provider : NULL, agent ? agent->model : NULL);
+}
+
 cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *tools,
                                   int max_tokens, double temperature)
 {
@@ -140,8 +151,7 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
          cJSON_AddStringToObject(req, "tool_choice", "auto");
    }
 
-   if (max_tokens > 0)
-      cJSON_AddNumberToObject(req, "max_tokens", max_tokens);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
    if (agent_is_mistral_vibe_model(agent))
    {
       cJSON_AddStringToObject(req, "reasoning_effort", "high");
@@ -191,8 +201,7 @@ cJSON *agent_build_request_anthropic(const agent_t *agent, cJSON *messages, cJSO
    cJSON *safe_messages = provider_payload_without_private_fields(messages);
    cJSON_AddStringToObject(req, "model", agent->model);
 
-   int tok = (max_tokens > 0) ? max_tokens : 4096;
-   cJSON_AddNumberToObject(req, "max_tokens", tok);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
 
    /* §3 cache-aware shaping: when enabled, mark the aimee-owned STABLE system
     * prefix cacheable on this (tool-bearing) Anthropic request, matching the
@@ -1632,8 +1641,7 @@ cJSON *agent_build_request_gemini(const agent_t *agent, cJSON *messages, cJSON *
 
    /* Generation config */
    cJSON *gen_cfg = cJSON_CreateObject();
-   if (max_tokens > 0)
-      cJSON_AddNumberToObject(gen_cfg, "maxOutputTokens", max_tokens);
+   cJSON_AddNumberToObject(gen_cfg, "maxOutputTokens", agent_request_max_tokens(agent, max_tokens));
    if (temperature >= 0)
       cJSON_AddNumberToObject(gen_cfg, "temperature", temperature);
    cJSON_AddItemToObject(req, "generationConfig", gen_cfg);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -281,6 +281,7 @@ void agent_request_creds_snapshot(agent_request_creds_t *out)
    snprintf(out->session_id, sizeof(out->session_id), "%s", g_request_session_id);
    snprintf(out->codex_token, sizeof(out->codex_token), "%s", g_request_codex_token);
    snprintf(out->codex_account_id, sizeof(out->codex_account_id), "%s", g_request_codex_account_id);
+   snprintf(out->vault_principal, sizeof(out->vault_principal), "%s", g_request_vault_principal);
 }
 
 void agent_request_creds_restore(const agent_request_creds_t *creds)
@@ -289,6 +290,7 @@ void agent_request_creds_restore(const agent_request_creds_t *creds)
       return;
    agent_set_request_session(creds->session_id);
    agent_set_request_codex_creds(creds->codex_token, creds->codex_account_id);
+   agent_set_request_vault_principal(creds->vault_principal);
 }
 
 static void append_header_line(char *buf, size_t buf_len, const char *line)

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -2,6 +2,7 @@
 #include "aimee.h"
 #include "util.h"
 #include "agent_config.h"
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX for the per-turn vault principal */
 #include "session_credentials.h"
 #include "model_registry.h"
 #include "platform_path.h"
@@ -241,6 +242,24 @@ void agent_set_request_session(const char *session_id)
       snprintf(g_request_session_id, sizeof(g_request_session_id), "%s", session_id);
    else
       g_request_session_id[0] = '\0';
+}
+
+/* WP-C.2c(3): the attested vault principal for the in-flight chat turn, so a
+ * chat-spawned delegate (dispatched through the conn-decoupled agent loop) can
+ * reach the originating user's vault. */
+static _Thread_local char g_request_vault_principal[VAULT_PRINCIPAL_MAX];
+
+void agent_set_request_vault_principal(const char *principal)
+{
+   if (principal && principal[0])
+      snprintf(g_request_vault_principal, sizeof(g_request_vault_principal), "%s", principal);
+   else
+      g_request_vault_principal[0] = '\0';
+}
+
+const char *agent_get_request_vault_principal(void)
+{
+   return g_request_vault_principal;
 }
 
 void agent_set_request_codex_creds(const char *token, const char *account_id)

--- a/src/server/agent_context_budget.c
+++ b/src/server/agent_context_budget.c
@@ -1,12 +1,17 @@
 #include "aimee.h"
 #include "agent.h"
+#include "model_registry.h"
 
 size_t agent_exec_context_budget_chars(const agent_t *agent)
 {
    if (!agent || agent->middleware.context_window <= 0)
       return AGENT_CONTEXT_BUDGET;
 
-   int output_tokens = agent->max_tokens > 0 ? agent->max_tokens : AGENT_DEFAULT_MAX_TOKENS;
+   /* Reserve the model's output ceiling from the window for prompt budgeting;
+    * with no explicit agent cap, fall back to the model registry rather than a
+    * hardcoded default (which is now 0 = "unset"). */
+   int output_tokens =
+       agent->max_tokens > 0 ? agent->max_tokens : model_max_output(agent->provider, agent->model);
    int prompt_tokens = agent->middleware.context_window - output_tokens;
    if (prompt_tokens <= 0)
       prompt_tokens = agent->middleware.context_window / 2;

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -545,8 +545,7 @@ static cJSON *build_request_openai(const agent_t *agent, const char *system_prom
 
    cJSON_AddItemToObject(req, "messages", messages);
 
-   if (max_tokens > 0)
-      cJSON_AddNumberToObject(req, "max_tokens", max_tokens);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
    model_sampling_apply_openai(agent, req, temperature);
 
    return req;
@@ -588,8 +587,7 @@ static cJSON *build_request_anthropic(const agent_t *agent, const char *system_p
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "model", agent->model);
 
-   int tok = (max_tokens > 0) ? max_tokens : 4096;
-   cJSON_AddNumberToObject(req, "max_tokens", tok);
+   cJSON_AddNumberToObject(req, "max_tokens", agent_request_max_tokens(agent, max_tokens));
 
    /* §3 cache-aware shaping: mark the stable system prefix cacheable (cache_control)
     * only when the flag is on, matching the tool-bearing builder. Default-off so
@@ -994,8 +992,8 @@ int agent_execute(const agent_t *agent, const char *system_prompt, const char *u
    /* Run PRE_LLM_CALL hooks — appends ephemeral context to user msg, never system_prompt. */
    char *augmented_prompt = plugin_chook_apply_pre_llm(user_prompt);
    const char *effective_user = augmented_prompt ? augmented_prompt : user_prompt;
-   /* Build request body */
-   int tok = (max_tokens > 0) ? max_tokens : agent->max_tokens;
+   /* Build request body — derive the output cap from the model when unpinned. */
+   int tok = agent_request_max_tokens(agent, max_tokens);
    if (is_anthropic_provider(agent))
       track_simple_anthropic_payload_rewrite(driver, agent, system_prompt, effective_user);
    cJSON *req = build_request(agent, system_prompt, effective_user, tok, temperature);

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -230,9 +230,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
    if (driver_is_anthropic(driver))
       prov_body = build_anthropic_provider_body(req, ag, 0);
    else
-      prov_body =
-          build_provider_body(driver, ag, messages, tools, system_text,
-                              jo_int(req, "max_tokens", 4096), jo_num(req, "temperature", 1.0), 0);
+      prov_body = build_provider_body(driver, ag, messages, tools, system_text,
+                                      agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
+                                      jo_num(req, "temperature", 1.0), 0);
    http_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &response, ag->timeout_ms,
                                  extra[0] ? extra : NULL);
    if (http_status != 200 || !response)
@@ -499,9 +499,9 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    if (driver_is_anthropic(driver))
       prov_body = build_anthropic_provider_body(req, ag, 1);
    else
-      prov_body =
-          build_provider_body(driver, ag, messages, tools, system_text,
-                              jo_int(req, "max_tokens", 4096), jo_num(req, "temperature", 1.0), 1);
+      prov_body = build_provider_body(driver, ag, messages, tools, system_text,
+                                      agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
+                                      jo_num(req, "temperature", 1.0), 1);
 
    if (driver_is_anthropic(driver))
    {

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -400,12 +400,14 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
    {
       const char *agg = cfg->ensemble_aggregator;
       const char *at = strchr(agg, '@');
+      /* max_tokens 0 = derive from the aggregator model's own output ceiling, so
+       * a reasoning aggregator isn't truncated mid-synthesis (was a hard 4096). */
       if (!at)
-         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
+         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
       const char *role = (at[1]) ? at + 1 : "review";
-      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 4096, 0.3, out);
+      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 0, 0.3, out);
    }
-   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 4096, 0.3, out);
+   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 0, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -848,7 +848,7 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    char extra_headers[512];
    agent_build_extra_headers(agent, extra_headers, sizeof(extra_headers));
 
-   int tok = (max_tokens > 0) ? max_tokens : agent->max_tokens;
+   int tok = agent_request_max_tokens(agent, max_tokens);
    cJSON *req = driver->build_request(agent, messages, tools, system_prompt, tok, temperature);
    if (!req)
       return -1;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -760,7 +760,7 @@ void delegate_worker(void *arg)
    const char *role =
        delegate_role_canonicalize(cJSON_IsString(jrole) ? jrole->valuestring : "execute");
    const char *prompt = cJSON_IsString(jprompt) ? jprompt->valuestring : "";
-   int max_tokens = cJSON_IsNumber(jmax) ? (int)jmax->valuedouble : 4096;
+   int max_tokens = cJSON_IsNumber(jmax) ? (int)jmax->valuedouble : 0; /* 0 => model-derived */
    const char *system_prompt = cJSON_IsString(jsystem) ? jsystem->valuestring : NULL;
    const char *sid = cJSON_IsString(jsid) ? jsid->valuestring : NULL;
    const char *cwd = cJSON_IsString(jcwd) ? jcwd->valuestring : "";

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1705,14 +1705,14 @@ compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON 
     * not be opened on the server's own fs. A NULL conn is an in-process caller. */
    cctx->conn_caps = conn ? conn->capabilities : CAPS_ALL;
 
-   /* WP-C.0 (hop 3 of 3): copy the attested vault identity while the conn is live;
-    * the detached worker (conn_fd closed, no thread-local) trusts only this
-    * principal for the vault, never the body session_id. NULL conn => no vault. */
+   /* WP-C vault identity: the live conn's attested principal (hop 3), else the
+    * chat turn's thread-local (a chat-spawned delegate, decoupled from the conn;
+    * the thread-local is cleared per-turn so it can't leak across turns). */
    if (conn)
-   {
       cctx->attested_transport = conn->attested_transport;
-      snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s", conn->vault_principal);
-   }
+   snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s",
+            (conn && conn->vault_principal[0]) ? conn->vault_principal
+                                               : agent_get_request_vault_principal());
 
    /* Clone the request since the original will be freed after dispatch */
    cctx->req = cJSON_Duplicate(req, 1);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1705,9 +1705,9 @@ compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON 
     * not be opened on the server's own fs. A NULL conn is an in-process caller. */
    cctx->conn_caps = conn ? conn->capabilities : CAPS_ALL;
 
-   /* WP-C vault identity: the live conn's attested principal (hop 3), else the
-    * chat turn's thread-local (a chat-spawned delegate, decoupled from the conn;
-    * the thread-local is cleared per-turn so it can't leak across turns). */
+   /* WP-C vault identity: the conn's attested principal (hop 3) wins; else fall back
+    * to the chat turn's per-turn thread-local — the chat-spawned delegate's loopback
+    * conn carries no restored identity, and the TL is cleared per turn (no leak). */
    if (conn)
       cctx->attested_transport = conn->attested_transport;
    snprintf(cctx->vault_principal, sizeof(cctx->vault_principal), "%s",

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -460,7 +460,13 @@ static void chat_stream_worker_pooled(void *arg)
    }
    agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
                                  jo_str(cctx->req, "codex_account_id", NULL));
+   /* WP-C.2c(3): carry the attested vault principal across the conn-decoupled
+    * agent loop so a delegate this chat spawns reaches the user's vault. Bounded
+    * strictly to the agent-loop execution + cleared after, so a later delegate on
+    * this pooled thread can never inherit a prior turn's principal. */
+   agent_set_request_vault_principal(cctx->vault_principal);
    chat_stream_worker(arg);
+   agent_set_request_vault_principal(NULL);
    if (locked)
       presence_turn_release(lock_session, lock_turn);
    else if (sid[0])

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -461,9 +461,16 @@ static void chat_stream_worker_pooled(void *arg)
    agent_set_request_codex_creds(jo_str(cctx->req, "codex_oauth_token", NULL),
                                  jo_str(cctx->req, "codex_account_id", NULL));
    /* WP-C.2c(3): carry the attested vault principal across the conn-decoupled
-    * agent loop so a delegate this chat spawns reaches the user's vault. Bounded
-    * strictly to the agent-loop execution + cleared after, so a later delegate on
-    * this pooled thread can never inherit a prior turn's principal. */
+    * agent loop so a delegate this chat spawns reaches the user's vault — both a
+    * same-thread delegate (via create_compute_ctx's thread-local fallback when its
+    * loopback conn carries no restored identity) and a parallel fan-out delegate
+    * (which inherits it via agent_request_creds_snapshot, now extended to capture
+    * this thread-local). Two layers keep it from leaking across turns on this
+    * pooled thread: (1) this set is UNCONDITIONAL at the top of every turn — an
+    * empty cctx->vault_principal clears it, so the next turn never sees a prior
+    * turn's value; (2) we clear it after the worker. chat_stream_worker is a plain
+    * call with no longjmp/pthread_exit/cancellation in its tree, so the post-call
+    * clear always runs on return; together the two make the guard robust. */
    agent_set_request_vault_principal(cctx->vault_principal);
    chat_stream_worker(arg);
    agent_set_request_vault_principal(NULL);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -42,6 +42,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/openrouter_profile.o $(OBJDIR)/server/ollama_profile.o \
                              $(OBJDIR)/server/llama_native_profile.o $(OBJDIR)/server/mistral_profile.o \
                              $(OBJDIR)/server/minimax_profile.o \
+                             $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                              $(PLATFORM_AGENT_OBJS)
 
 TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -431,45 +431,24 @@ static void test_codex_oauth_request_creds(void)
    assert(strstr(headers, "ChatGPT-Account-ID:") == NULL);
 }
 
-/* WP-C.2c(3): the per-turn vault principal must ride along in the credential
- * snapshot. A parallel fan-out delegate (agent_run_parallel) runs on a fresh
- * worker thread that does NOT inherit thread-locals and rebinds the dispatcher's
- * context via agent_request_creds_restore — so unless the principal is carried in
- * the snapshot it silently fails to reach the originating user's vault, while a
- * same-thread delegate succeeds. This pins the round-trip. */
+/* WP-C.2c(3): the vault principal must ride along in the creds snapshot so a
+ * fan-out delegate (fresh thread; rebinds via agent_request_creds_restore)
+ * reaches the user's vault like a same-thread one; empty restores to empty. */
 static void test_request_creds_snapshot_carries_vault_principal(void)
 {
-   agent_set_request_session("sess-xyz");
-   agent_set_request_codex_creds("tok-1", "acct-1");
    agent_set_request_vault_principal("webuser:dave");
-
    agent_request_creds_t snap;
    agent_request_creds_snapshot(&snap);
    assert(strcmp(snap.vault_principal, "webuser:dave") == 0);
-
-   /* Simulate the fresh fan-out worker: its thread-locals start clear. */
-   agent_set_request_session(NULL);
-   agent_set_request_codex_creds(NULL, NULL);
-   agent_set_request_vault_principal(NULL);
-   assert(agent_get_request_vault_principal()[0] == '\0');
-
-   /* The worker restores the dispatcher's snapshot and regains the principal. */
+   agent_set_request_vault_principal(NULL); /* fresh fan-out worker starts clear */
    agent_request_creds_restore(&snap);
    assert(strcmp(agent_get_request_vault_principal(), "webuser:dave") == 0);
-
-   /* An empty principal round-trips as empty (a keyless panel), and restore
-    * actively clears a stale thread-local rather than leaving it set. */
    agent_set_request_vault_principal(NULL);
-   agent_request_creds_t snap_empty;
-   agent_request_creds_snapshot(&snap_empty);
-   assert(snap_empty.vault_principal[0] == '\0');
+   agent_request_creds_snapshot(&snap);
    agent_set_request_vault_principal("webuser:eve");
-   agent_request_creds_restore(&snap_empty);
+   agent_request_creds_restore(&snap);
    assert(agent_get_request_vault_principal()[0] == '\0');
-
-   /* Clear ALL three thread-locals: restore re-bound session + codex creds too,
-    * and a leftover token would bleed into a later test on this same thread. */
-   agent_set_request_session(NULL);
+   agent_set_request_session(NULL); /* restore re-bound session+codex; clear all */
    agent_set_request_codex_creds(NULL, NULL);
    agent_set_request_vault_principal(NULL);
 }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -431,6 +431,49 @@ static void test_codex_oauth_request_creds(void)
    assert(strstr(headers, "ChatGPT-Account-ID:") == NULL);
 }
 
+/* WP-C.2c(3): the per-turn vault principal must ride along in the credential
+ * snapshot. A parallel fan-out delegate (agent_run_parallel) runs on a fresh
+ * worker thread that does NOT inherit thread-locals and rebinds the dispatcher's
+ * context via agent_request_creds_restore — so unless the principal is carried in
+ * the snapshot it silently fails to reach the originating user's vault, while a
+ * same-thread delegate succeeds. This pins the round-trip. */
+static void test_request_creds_snapshot_carries_vault_principal(void)
+{
+   agent_set_request_session("sess-xyz");
+   agent_set_request_codex_creds("tok-1", "acct-1");
+   agent_set_request_vault_principal("webuser:dave");
+
+   agent_request_creds_t snap;
+   agent_request_creds_snapshot(&snap);
+   assert(strcmp(snap.vault_principal, "webuser:dave") == 0);
+
+   /* Simulate the fresh fan-out worker: its thread-locals start clear. */
+   agent_set_request_session(NULL);
+   agent_set_request_codex_creds(NULL, NULL);
+   agent_set_request_vault_principal(NULL);
+   assert(agent_get_request_vault_principal()[0] == '\0');
+
+   /* The worker restores the dispatcher's snapshot and regains the principal. */
+   agent_request_creds_restore(&snap);
+   assert(strcmp(agent_get_request_vault_principal(), "webuser:dave") == 0);
+
+   /* An empty principal round-trips as empty (a keyless panel), and restore
+    * actively clears a stale thread-local rather than leaving it set. */
+   agent_set_request_vault_principal(NULL);
+   agent_request_creds_t snap_empty;
+   agent_request_creds_snapshot(&snap_empty);
+   assert(snap_empty.vault_principal[0] == '\0');
+   agent_set_request_vault_principal("webuser:eve");
+   agent_request_creds_restore(&snap_empty);
+   assert(agent_get_request_vault_principal()[0] == '\0');
+
+   /* Clear ALL three thread-locals: restore re-bound session + codex creds too,
+    * and a leftover token would bleed into a later test on this same thread. */
+   agent_set_request_session(NULL);
+   agent_set_request_codex_creds(NULL, NULL);
+   agent_set_request_vault_principal(NULL);
+}
+
 static void test_agent_config_provider_cli_roundtrip(void)
 {
    const char *cfg_dir = config_default_dir();
@@ -1914,6 +1957,7 @@ int main(void)
    test_current_code_only_dispatch_blocks_stale_context_tools();
    test_provider_env_credentials_and_headers();
    test_codex_oauth_request_creds();
+   test_request_creds_snapshot_carries_vault_principal();
    test_agent_config_provider_cli_roundtrip();
    test_tools_enabled_capability_default();
    test_agent_adapter_registry();

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -105,6 +105,14 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
    return out;
 }
 
+/* Stub: the ingress passes the incoming request's max_tokens through this
+ * resolver; an explicit value wins, otherwise a model-derived ceiling applies. */
+int agent_request_max_tokens(const agent_t *agent, int requested)
+{
+   (void)agent;
+   return requested > 0 ? requested : 8192;
+}
+
 int agent_http_post(const char *url, const char *auth_header, const char *body, char **response_buf,
                     int timeout_ms, const char *extra_headers)
 {

--- a/src/tests/test_model_registry.c
+++ b/src/tests/test_model_registry.c
@@ -136,6 +136,29 @@ static void test_context_window(void)
    assert(model_context_window("GPT-4o") == 128000);
 }
 
+static void test_max_output(void)
+{
+   /* Static-table models return their pinned output ceiling. */
+   assert(model_max_output("openai", "gpt-4o") == 16384);
+   assert(model_max_output("anthropic", "claude-sonnet-4-6") == 8192);
+
+   /* Inferred (heuristic) models: reasoning families get a higher ceiling than
+    * plain chat, both well above the old hardcoded 4096 default. */
+   assert(model_max_output("minimax", "MiniMax-M3") == 32768);      /* reasoning */
+   assert(model_max_output(NULL, "mistral-medium-latest") == 8192); /* non-reasoning */
+
+   /* Never starves a reasoning model at 4096 (the bug this replaced). */
+   assert(model_max_output("minimax", "MiniMax-M3") > 4096);
+
+   /* Inferred ceiling is clamped to the model's context window. */
+   assert(model_max_output("openai", "gpt-3.5-turbo") <= model_context_window("gpt-3.5-turbo"));
+
+   /* Unknown model still yields a usable, non-zero cap (never 0). */
+   assert(model_max_output(NULL, "some-unknown-model") == 8192);
+   assert(model_max_output(NULL, "") == 8192);
+   assert(model_max_output(NULL, NULL) == 8192);
+}
+
 static void test_alias_list(void)
 {
    int total = model_alias_list(NULL, 0);
@@ -380,6 +403,8 @@ int main(void)
    printf("provider_detect OK, ");
    test_context_window();
    printf("context_window OK, ");
+   test_max_output();
+   printf("max_output OK, ");
    test_alias_list();
    printf("alias_list OK, ");
    test_model_capability_get();

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -127,6 +127,18 @@ void agent_set_request_session(const char *session_id)
 {
    (void)session_id;
 }
+/* Functional stub: store the per-turn vault principal so the create_compute_ctx
+ * fallback (WP-C.2c(3)) is exercisable. */
+static char g_stub_vault_principal[VAULT_PRINCIPAL_MAX];
+void agent_set_request_vault_principal(const char *principal)
+{
+   snprintf(g_stub_vault_principal, sizeof(g_stub_vault_principal), "%s",
+            principal ? principal : "");
+}
+const char *agent_get_request_vault_principal(void)
+{
+   return g_stub_vault_principal;
+}
 
 int agent_load_config(agent_config_t *cfg)
 {
@@ -1758,6 +1770,35 @@ static void test_create_compute_ctx_threads_vault_identity(void)
    assert(c2->vault_principal[0] == '\0');
    compute_ctx_free(c2);
    cJSON_Delete(req2);
+
+   /* WP-C.2c(3): a conn with NO principal falls back to the per-turn thread-local
+    * (set by the chat worker) so a chat-spawned delegate inherits the user's
+    * principal. */
+   agent_set_request_vault_principal("webuser:carol");
+   server_conn_t bare2;
+   memset(&bare2, 0, sizeof(bare2));
+   bare2.fd = -1;
+   cJSON *req3 = cJSON_CreateObject();
+   compute_ctx_t *c3 = create_compute_ctx(NULL, &bare2, req3);
+   assert(c3 != NULL);
+   assert(strcmp(c3->vault_principal, "webuser:carol") == 0);
+   compute_ctx_free(c3);
+   cJSON_Delete(req3);
+
+   /* The conn principal still WINS when present (the thread-local doesn't
+    * override an attested conn). */
+   server_conn_t named;
+   memset(&named, 0, sizeof(named));
+   named.fd = -1;
+   named.attested_transport = ATTEST_UDS_PEERCRED;
+   snprintf(named.vault_principal, sizeof(named.vault_principal), "uid:1000");
+   cJSON *req4 = cJSON_CreateObject();
+   compute_ctx_t *c4 = create_compute_ctx(NULL, &named, req4);
+   assert(c4 != NULL);
+   assert(strcmp(c4->vault_principal, "uid:1000") == 0); /* conn wins over thread-local */
+   compute_ctx_free(c4);
+   cJSON_Delete(req4);
+   agent_set_request_vault_principal(NULL); /* clear for other tests */
    printf("  PASS: test_create_compute_ctx_threads_vault_identity\n");
 }
 


### PR DESCRIPTION
Promote testing → main.

Includes:
- #233 Derive request output cap from the model, not a hardcoded 4096 — reasoning models (MiniMax-M3, mimo) were starved by the 4096 output cap and emitted no content, collapsing delegate roundtables to an empty artifact. Output cap now resolves from the model registry (model_max_output) via a central agent_request_max_tokens resolver wired through every request builder + cap site.
- #232 WP-C.2c(3): a chat-initiated delegate reaches the webchat user's vault (per-turn vault-principal thread-local threaded through the conn-decoupled agent loop).

All CI green on testing.
