### PR TITLE
WP-C.3: per-principal credential pool re-key + vault-cred cooldown

### DIFF
--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -41,6 +41,10 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len);
  * NULL/empty to clear. Thread-local (each turn runs on its own worker thread). */
 void agent_set_request_codex_creds(const char *token, const char *account_id);
 
+/* 1 when a per-turn Codex OAuth token is currently bound (a fresh client push).
+ * WP-C.3: the vault-backed codex override defers to a live client push. */
+int agent_request_codex_token_present(void);
+
 /* Per-turn session id for the session-scoped credential keyring lookup (see
  * session_credentials.h). Set at the start of a chat/delegate turn from the
  * request, cleared (NULL/empty) otherwise. When set, agent_resolve_auth prefers

--- a/src/headers/delegate_credential_retry.h
+++ b/src/headers/delegate_credential_retry.h
@@ -6,6 +6,28 @@
 #include "aimee.h"
 #include "agent_types.h"
 
+/* Result of resolving a delegate's credential before the run (WP-C.1 vault-first,
+ * WP-C.3 per-principal cooldown). The caller maps a non-OK status to a delegate
+ * error; on OK it proceeds with target_agent->api_key set (vault or env hit) and
+ * the named pool row to release on exit. */
+typedef enum
+{
+   DELEGATE_CRED_RESOLVE_OK = 0,    /* proceed (api_key set, or no pool/vault) */
+   DELEGATE_CRED_RESOLVE_LOCKED,    /* vault entry exists but is locked */
+   DELEGATE_CRED_RESOLVE_COOLING,   /* vaulted cred is rate-limited (see cooldown_secs) */
+   DELEGATE_CRED_RESOLVE_POOL_EMPTY /* env pool configured but all leased/cooling */
+} delegate_cred_resolve_status_t;
+
+/* Resolve the credential for one delegate run. Restores persisted health, then:
+ * vault-FIRST for `vault_principal` (a 429-cooling vaulted cred returns COOLING),
+ * else leases from the agent's env pool. Writes target_agent->api_key on a hit,
+ * names the (principal,agent,cred) row to release in leased_principal/_cred_name,
+ * and fills credential_state_path. cooldown_secs is set for COOLING. */
+delegate_cred_resolve_status_t delegate_resolve_credentials(
+    const char *vault_principal, agent_t *target_agent, char *leased_principal,
+    size_t leased_principal_cap, char *leased_cred_name, size_t leased_cred_name_cap,
+    char *credential_state_path, size_t credential_state_path_cap, int *cooldown_secs);
+
 int delegate_run_with_credential_retry(agent_config_t *cfg, agent_t *agent, const char *role,
                                        const char *system_prompt, const char *run_prompt,
                                        int max_tokens, int force_tools, int enforce_writes,

--- a/src/headers/delegate_credentials.h
+++ b/src/headers/delegate_credentials.h
@@ -8,7 +8,14 @@
  *
  * Process-global lease state, mutex-protected. Empty agent.credentials
  * (the default) is treated as "no pool — fall through to api_key", so
- * existing single-token agents are unaffected. */
+ * existing single-token agents are unaffected.
+ *
+ * WP-C.3: every row is keyed by (principal, agent, cred). The shared
+ * agents.json env-var pool uses an EMPTY principal ("") — a 429 there is
+ * global and cools the credential for everyone, exactly as before. A
+ * per-principal VAULT credential passes its `uid:`/`webuser:` principal, so
+ * one principal's 429-cooldown and health are isolated from another's even
+ * when they vault the same agent. A NULL principal is normalised to "". */
 #ifndef DEC_DELEGATE_CREDENTIALS_H
 #define DEC_DELEGATE_CREDENTIALS_H 1
 
@@ -18,6 +25,7 @@
 #include "aimee.h" /* MAX_PATH_LEN — agent_types.h uses it without including */
 #include "agent_types.h"
 #include "failover.h"
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX — pool rows are keyed by principal */
 
 #ifdef __cplusplus
 extern "C"
@@ -34,18 +42,29 @@ extern "C"
     * returns -1 with credential_count == 0; an error return with
     * credential_count > 0 means every credential is in use or cooling
     * and the caller should retry after a backoff. */
-   int delegate_credentials_acquire(const char *agent_name, const agent_credential_t *creds,
-                                    int credential_count, char *out_name, size_t out_name_cap,
-                                    char *out_env_var, size_t out_env_var_cap);
+   int delegate_credentials_acquire(const char *principal, const char *agent_name,
+                                    const agent_credential_t *creds, int credential_count,
+                                    char *out_name, size_t out_name_cap, char *out_env_var,
+                                    size_t out_env_var_cap);
 
    /* Release a previously-acquired lease so siblings can pick it up.
-    * No-op for unknown (agent_name, cred_name) pairs. */
-   void delegate_credentials_release(const char *agent_name, const char *cred_name);
+    * No-op for unknown (principal, agent_name, cred_name) rows. */
+   void delegate_credentials_release(const char *principal, const char *agent_name,
+                                     const char *cred_name);
 
    /* Mark a credential as cooling for `seconds` seconds. Used after a 429
     * so siblings skip the entry until the cooldown elapses. The
     * credential remains leased until the caller also calls _release. */
-   void delegate_credentials_cooldown(const char *agent_name, const char *cred_name, int seconds);
+   void delegate_credentials_cooldown(const char *principal, const char *agent_name,
+                                      const char *cred_name, int seconds);
+
+   /* Read-only: seconds remaining on the (principal, agent, cred) cooldown, or 0
+    * if the credential is unknown or not cooling. The vault use-path consults
+    * this to apply per-principal 429 backpressure to a single vaulted credential
+    * without taking an exclusive lease (a user's own key may be used by their
+    * concurrent delegates). Creates no row. */
+   int delegate_credentials_cooldown_remaining(const char *principal, const char *agent_name,
+                                               const char *cred_name, time_t now_epoch);
 
    /* Default cooldown applied when a delegate run fails with a rate-
     * limit / 429 / overloaded error and a credential lease was held.
@@ -105,14 +124,15 @@ extern "C"
    /* Parse provider x-ratelimit-* response headers for the acting credential.
     * raw_headers is a CRLF/LF-separated header block. Reset values are relative
     * seconds and are stored as absolute epoch seconds using now_epoch. */
-   int delegate_credentials_capture_headers(const char *agent_name, const char *cred_name,
-                                            const char *raw_headers, time_t now_epoch);
+   int delegate_credentials_capture_headers(const char *principal, const char *agent_name,
+                                            const char *cred_name, const char *raw_headers,
+                                            time_t now_epoch);
 
    /* Mark a credential according to the failover classifier. Returns 1 when
     * the reason changed credential health, 0 for unrelated reasons. */
-   int delegate_credentials_report_failure(const char *agent_name, const char *cred_name,
-                                           failover_reason_t reason, const char *error,
-                                           time_t now_epoch);
+   int delegate_credentials_report_failure(const char *principal, const char *agent_name,
+                                           const char *cred_name, failover_reason_t reason,
+                                           const char *error, time_t now_epoch);
 
    failover_reason_t delegate_credentials_classify_failure(const char *provider, const char *error);
 
@@ -120,12 +140,19 @@ extern "C"
     * the next available member from the same pool. Returns 1 when a new
     * credential was leased, 0 when the error is not pool-rotatable or no
     * member is available, and -1 for invalid arguments. On rotatable failures
-    * the old lease is always released, even when no replacement is available. */
-   int delegate_credentials_rotate_after_failure(
-       const char *agent_name, const agent_credential_t *creds, int credential_count,
-       const char *provider, char *leased_cred_name, size_t leased_cred_name_cap, char *out_env_var,
-       size_t out_env_var_cap, const char *error, time_t now_epoch);
+    * the old lease is always released, even when no replacement is available.
+    * Env-pool rotation only — callers pass the shared "" principal. */
+   int delegate_credentials_rotate_after_failure(const char *principal, const char *agent_name,
+                                                 const agent_credential_t *creds,
+                                                 int credential_count, const char *provider,
+                                                 char *leased_cred_name,
+                                                 size_t leased_cred_name_cap, char *out_env_var,
+                                                 size_t out_env_var_cap, const char *error,
+                                                 time_t now_epoch);
 
+   /* Operator-facing health snapshot of the SHARED env pool (principal == "").
+    * Per-principal vault rows are intentionally not surfaced here (they are
+    * per-user, not operator-configured). */
    int delegate_credentials_snapshot(const char *agent_name, delegate_credential_snapshot_t *out,
                                      int max);
 

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -86,6 +86,15 @@ vault_status_t vault_service_delete(const char *principal, const char *agent, co
 /* Lock the principal's vault: evict its cached KEK (the `vault lock` path). */
 vault_status_t vault_service_lock(const char *principal);
 
+/* The canonical credential name for an agent's primary key in the vault store
+ * and in the delegate-credential cooldown pool (WP-C.3). */
+#define VAULT_API_KEY_CRED "api_key"
+
+/* WP-C.3 codex-oauth: a principal may vault their Codex OAuth token + account id
+ * under these names; a vaulted token overrides the on-disk/session token. */
+#define VAULT_CODEX_TOKEN_CRED   "codex_oauth_token"
+#define VAULT_CODEX_ACCOUNT_CRED "codex_account_id"
+
 /* Delegate use-path helper: if `principal` has a vaulted "api_key" credential for
  * `agent`, decrypt it and overwrite `api_key` (capacity api_key_len). On any
  * non-OK status `api_key` is left UNTOUCHED (so a config/env key survives a

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -274,6 +274,11 @@ void agent_set_request_codex_creds(const char *token, const char *account_id)
       g_request_codex_account_id[0] = '\0';
 }
 
+int agent_request_codex_token_present(void)
+{
+   return g_request_codex_token[0] != '\0';
+}
+
 void agent_request_creds_snapshot(agent_request_creds_t *out)
 {
    if (!out)

--- a/src/server/delegate_credential_retry.c
+++ b/src/server/delegate_credential_retry.c
@@ -2,13 +2,107 @@
 
 #include "delegate_credential_retry.h"
 
+#include "agent_config.h" /* agent_set_request_codex_creds, *_token_present */
 #include "agent_exec.h"
+#include "config.h" /* config_output_dir */
 #include "delegate_credentials.h"
+#include "vault_service.h" /* vault_service_inject_api_key, VAULT_*_CRED */
 
+#include <openssl/crypto.h> /* OPENSSL_cleanse */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+/* WP-C.3 codex-oauth migration: if `principal` has a vaulted Codex OAuth token for
+ * `agent`, bind it as this turn's token so it OVERRIDES the on-disk/session token.
+ * A fresh per-turn client push still wins (we defer when one is already bound).
+ * The transient plaintext is cleansed; lifetime mirrors the existing per-turn
+ * codex token (overwritten by the next turn's bind on this worker thread). */
+static void codex_oauth_apply_vault_override(const char *principal, const agent_t *target_agent)
+{
+   if (!principal || !principal[0] || !target_agent)
+      return;
+   if (strcmp(target_agent->auth_type, "codex-oauth") != 0)
+      return;
+   if (agent_request_codex_token_present())
+      return; /* a live client push is authoritative */
+   char tok[MAX_API_KEY_LEN];
+   if (vault_service_get(principal, target_agent->name, VAULT_CODEX_TOKEN_CRED, tok, sizeof(tok),
+                         time(NULL)) != VAULT_OK)
+      return;
+   char acct[128] = "";
+   (void)vault_service_get(principal, target_agent->name, VAULT_CODEX_ACCOUNT_CRED, acct,
+                           sizeof(acct), time(NULL));
+   agent_set_request_codex_creds(tok, acct[0] ? acct : NULL);
+   OPENSSL_cleanse(tok, sizeof(tok));
+   OPENSSL_cleanse(acct, sizeof(acct));
+}
+
+delegate_cred_resolve_status_t delegate_resolve_credentials(
+    const char *vault_principal, agent_t *target_agent, char *leased_principal,
+    size_t leased_principal_cap, char *leased_cred_name, size_t leased_cred_name_cap,
+    char *credential_state_path, size_t credential_state_path_cap, int *cooldown_secs)
+{
+   if (cooldown_secs)
+      *cooldown_secs = 0;
+   if (!target_agent)
+      return DELEGATE_CRED_RESOLVE_OK;
+
+   /* Restore persisted per-credential cooldown/health (shared env pool AND
+    * per-principal vault rows) before consulting either path. */
+   const char *dir = config_output_dir();
+   snprintf(credential_state_path, credential_state_path_cap, "%s/delegate-credential-state.tsv",
+            dir ? dir : "/tmp");
+   (void)delegate_credentials_load_file(credential_state_path, time(NULL));
+
+   /* WP-C.1 vault-FIRST (D14/D15): a vaulted cred beats the env lease; LOCKED
+    * fails the run; a miss falls through to the env pool. */
+   if (vault_principal && vault_principal[0])
+   {
+      /* WP-C.3 per-principal 429 backpressure: a vaulted cred is a single key (no
+       * round-robin / exclusive lease — a user's own key may serve their
+       * concurrent delegates), but a prior 429 cools it for THIS principal only. */
+      int cooling = delegate_credentials_cooldown_remaining(vault_principal, target_agent->name,
+                                                            VAULT_API_KEY_CRED, time(NULL));
+      if (cooling > 0)
+      {
+         if (cooldown_secs)
+            *cooldown_secs = cooling;
+         return DELEGATE_CRED_RESOLVE_COOLING;
+      }
+      vault_status_t vst = vault_service_inject_api_key(
+          vault_principal, target_agent->name, target_agent->api_key, MAX_API_KEY_LEN, time(NULL));
+      if (vst == VAULT_ERR_LOCKED)
+         return DELEGATE_CRED_RESOLVE_LOCKED;
+      if (vst == VAULT_OK)
+      {
+         /* Key the failure/cooldown row by (principal, agent, "api_key"). No
+          * exclusive lease is taken, so release on exit is a harmless no-op. */
+         snprintf(leased_principal, leased_principal_cap, "%s", vault_principal);
+         snprintf(leased_cred_name, leased_cred_name_cap, "%s", VAULT_API_KEY_CRED);
+         return DELEGATE_CRED_RESOLVE_OK;
+      }
+      /* miss -> codex override / env pool below */
+   }
+
+   /* WP-C.3 codex-oauth: a vaulted token overrides the on-disk/session token. */
+   codex_oauth_apply_vault_override(vault_principal, target_agent);
+
+   /* Lease one credential from the shared env pool (principal ""), if configured. */
+   if (target_agent->credential_count > 0)
+   {
+      char leased_env[MAX_CRED_ENV_VAR_LEN] = "";
+      if (delegate_credentials_acquire("", target_agent->name, target_agent->credentials,
+                                       target_agent->credential_count, leased_cred_name,
+                                       leased_cred_name_cap, leased_env, sizeof(leased_env)) != 0)
+         return DELEGATE_CRED_RESOLVE_POOL_EMPTY;
+      const char *value = getenv(leased_env);
+      if (value && value[0])
+         snprintf(target_agent->api_key, MAX_API_KEY_LEN, "%s", value);
+   }
+   return DELEGATE_CRED_RESOLVE_OK;
+}
 
 static int run_delegate_attempt(agent_config_t *cfg, const char *role, const char *system_prompt,
                                 const char *run_prompt, int max_tokens, int force_tools,
@@ -55,8 +149,9 @@ int delegate_run_with_credential_retry(agent_config_t *cfg, agent_t *agent, cons
    {
       agent_result_t prior = *result;
       char next_env[MAX_CRED_ENV_VAR_LEN] = "";
+      /* Env-pool rotation only (credential_count > 1); the shared "" principal. */
       int rotated = delegate_credentials_rotate_after_failure(
-          agent->name, agent->credentials, agent->credential_count, agent->provider,
+          "", agent->name, agent->credentials, agent->credential_count, agent->provider,
           leased_cred_name, leased_cred_name_cap, next_env, sizeof(next_env), result->error,
           time(NULL));
       if (rotated != 1)

--- a/src/server/delegate_credentials.c
+++ b/src/server/delegate_credentials.c
@@ -14,6 +14,7 @@
 
 typedef struct
 {
+   char principal[VAULT_PRINCIPAL_MAX]; /* "" = shared env pool; uid:/webuser: = vault */
    char agent_name[MAX_AGENT_NAME];
    char cred_name[MAX_CRED_NAME_LEN];
    int leased;                  /* 1 = currently leased */
@@ -45,15 +46,22 @@ static time_t now_epoch_seconds(void)
    return now > 0 ? now : 0;
 }
 
-/* Caller holds g_mu. Locate or create the per-(agent, cred) row. */
-static cred_lease_state_t *find_or_create_locked(const char *agent_name, const char *cred_name,
-                                                 int *allocation_failed)
+/* NULL principal is normalised to the shared "" pool. */
+static const char *pr_norm(const char *principal)
 {
+   return (principal && principal[0]) ? principal : "";
+}
+
+/* Caller holds g_mu. Locate or create the per-(principal, agent, cred) row. */
+static cred_lease_state_t *find_or_create_locked(const char *principal, const char *agent_name,
+                                                 const char *cred_name, int *allocation_failed)
+{
+   const char *pr = pr_norm(principal);
    if (allocation_failed)
       *allocation_failed = 0;
    for (int i = 0; i < g_state_count; i++)
    {
-      if (strcmp(g_state[i].agent_name, agent_name) == 0 &&
+      if (strcmp(g_state[i].principal, pr) == 0 && strcmp(g_state[i].agent_name, agent_name) == 0 &&
           strcmp(g_state[i].cred_name, cred_name) == 0)
          return &g_state[i];
    }
@@ -73,6 +81,7 @@ static cred_lease_state_t *find_or_create_locked(const char *agent_name, const c
    }
    cred_lease_state_t *slot = &g_state[g_state_count++];
    memset(slot, 0, sizeof(*slot));
+   snprintf(slot->principal, sizeof(slot->principal), "%s", pr);
    snprintf(slot->agent_name, sizeof(slot->agent_name), "%s", agent_name);
    snprintf(slot->cred_name, sizeof(slot->cred_name), "%s", cred_name);
    slot->status = DELEGATE_CRED_STATUS_OK;
@@ -123,9 +132,10 @@ static long long state_headroom(const cred_lease_state_t *slot)
    return best;
 }
 
-int delegate_credentials_acquire(const char *agent_name, const agent_credential_t *creds,
-                                 int credential_count, char *out_name, size_t out_name_cap,
-                                 char *out_env_var, size_t out_env_var_cap)
+int delegate_credentials_acquire(const char *principal, const char *agent_name,
+                                 const agent_credential_t *creds, int credential_count,
+                                 char *out_name, size_t out_name_cap, char *out_env_var,
+                                 size_t out_env_var_cap)
 {
    if (!agent_name || !agent_name[0] || !creds || credential_count <= 0)
       return -1;
@@ -145,7 +155,8 @@ int delegate_credentials_acquire(const char *agent_name, const agent_credential_
       if (!cred->name[0])
          continue;
       int allocation_failed = 0;
-      cred_lease_state_t *slot = find_or_create_locked(agent_name, cred->name, &allocation_failed);
+      cred_lease_state_t *slot =
+          find_or_create_locked(principal, agent_name, cred->name, &allocation_failed);
       if (allocation_failed)
          break;
       if (!slot)
@@ -174,14 +185,16 @@ int delegate_credentials_acquire(const char *agent_name, const agent_credential_
    return -1;
 }
 
-void delegate_credentials_release(const char *agent_name, const char *cred_name)
+void delegate_credentials_release(const char *principal, const char *agent_name,
+                                  const char *cred_name)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0])
       return;
+   const char *pr = pr_norm(principal);
    pthread_mutex_lock(&g_mu);
    for (int i = 0; i < g_state_count; i++)
    {
-      if (strcmp(g_state[i].agent_name, agent_name) == 0 &&
+      if (strcmp(g_state[i].principal, pr) == 0 && strcmp(g_state[i].agent_name, agent_name) == 0 &&
           strcmp(g_state[i].cred_name, cred_name) == 0)
       {
          g_state[i].leased = 0;
@@ -191,14 +204,15 @@ void delegate_credentials_release(const char *agent_name, const char *cred_name)
    pthread_mutex_unlock(&g_mu);
 }
 
-void delegate_credentials_cooldown(const char *agent_name, const char *cred_name, int seconds)
+void delegate_credentials_cooldown(const char *principal, const char *agent_name,
+                                   const char *cred_name, int seconds)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0] || seconds <= 0)
       return;
    long long until = now_monotonic_ms() + (long long)seconds * 1000LL;
    time_t epoch_until = now_epoch_seconds() + (time_t)seconds;
    pthread_mutex_lock(&g_mu);
-   cred_lease_state_t *slot = find_or_create_locked(agent_name, cred_name, NULL);
+   cred_lease_state_t *slot = find_or_create_locked(principal, agent_name, cred_name, NULL);
    if (slot)
    {
       slot->cooldown_until_ms = until;
@@ -206,6 +220,41 @@ void delegate_credentials_cooldown(const char *agent_name, const char *cred_name
       slot->status = DELEGATE_CRED_STATUS_RATE_LIMITED;
    }
    pthread_mutex_unlock(&g_mu);
+}
+
+int delegate_credentials_cooldown_remaining(const char *principal, const char *agent_name,
+                                            const char *cred_name, time_t now_epoch)
+{
+   if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0])
+      return 0;
+   if (now_epoch <= 0)
+      now_epoch = now_epoch_seconds();
+   const char *pr = pr_norm(principal);
+   long long now_ms = now_monotonic_ms();
+   int remaining = 0;
+   pthread_mutex_lock(&g_mu);
+   for (int i = 0; i < g_state_count; i++)
+   {
+      if (strcmp(g_state[i].principal, pr) != 0 || strcmp(g_state[i].agent_name, agent_name) != 0 ||
+          strcmp(g_state[i].cred_name, cred_name) != 0)
+         continue;
+      /* Honour whichever clock still shows the credential cooling: the monotonic
+       * deadline (live process) and the wall-clock epoch (restored from disk). */
+      if (g_state[i].cooldown_until_ms > now_ms)
+      {
+         int ms = (int)(g_state[i].cooldown_until_ms - now_ms);
+         remaining = ms / 1000 + (ms % 1000 ? 1 : 0);
+      }
+      if (g_state[i].cooldown_until_epoch > now_epoch)
+      {
+         int sec = (int)(g_state[i].cooldown_until_epoch - now_epoch);
+         if (sec > remaining)
+            remaining = sec;
+      }
+      break;
+   }
+   pthread_mutex_unlock(&g_mu);
+   return remaining;
 }
 
 int delegate_credentials_is_rate_limit(const char *error)
@@ -331,8 +380,9 @@ static void capture_header(delegate_ratelimit_state_t *rl, const char *line, siz
       rl->tok_reset_1h = now_epoch + (time_t)parse_header_long(value);
 }
 
-int delegate_credentials_capture_headers(const char *agent_name, const char *cred_name,
-                                         const char *raw_headers, time_t now_epoch)
+int delegate_credentials_capture_headers(const char *principal, const char *agent_name,
+                                         const char *cred_name, const char *raw_headers,
+                                         time_t now_epoch)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0] || !raw_headers)
       return -1;
@@ -340,7 +390,7 @@ int delegate_credentials_capture_headers(const char *agent_name, const char *cre
       now_epoch = now_epoch_seconds();
 
    pthread_mutex_lock(&g_mu);
-   cred_lease_state_t *slot = find_or_create_locked(agent_name, cred_name, NULL);
+   cred_lease_state_t *slot = find_or_create_locked(principal, agent_name, cred_name, NULL);
    if (!slot)
    {
       pthread_mutex_unlock(&g_mu);
@@ -379,9 +429,9 @@ static time_t earliest_reset(const delegate_ratelimit_state_t *rl)
    return best;
 }
 
-int delegate_credentials_report_failure(const char *agent_name, const char *cred_name,
-                                        failover_reason_t reason, const char *error,
-                                        time_t now_epoch)
+int delegate_credentials_report_failure(const char *principal, const char *agent_name,
+                                        const char *cred_name, failover_reason_t reason,
+                                        const char *error, time_t now_epoch)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0])
       return 0;
@@ -389,7 +439,7 @@ int delegate_credentials_report_failure(const char *agent_name, const char *cred
       now_epoch = now_epoch_seconds();
 
    pthread_mutex_lock(&g_mu);
-   cred_lease_state_t *slot = find_or_create_locked(agent_name, cred_name, NULL);
+   cred_lease_state_t *slot = find_or_create_locked(principal, agent_name, cred_name, NULL);
    if (!slot)
    {
       pthread_mutex_unlock(&g_mu);
@@ -427,7 +477,7 @@ int delegate_credentials_report_failure(const char *agent_name, const char *cred
    return changed;
 }
 
-int delegate_credentials_rotate_after_failure(const char *agent_name,
+int delegate_credentials_rotate_after_failure(const char *principal, const char *agent_name,
                                               const agent_credential_t *creds, int credential_count,
                                               const char *provider, char *leased_cred_name,
                                               size_t leased_cred_name_cap, char *out_env_var,
@@ -441,13 +491,14 @@ int delegate_credentials_rotate_after_failure(const char *agent_name,
    if (reason == FAILOVER_NONE)
       return 0;
 
-   (void)delegate_credentials_report_failure(agent_name, leased_cred_name, reason, error,
+   (void)delegate_credentials_report_failure(principal, agent_name, leased_cred_name, reason, error,
                                              now_epoch);
-   delegate_credentials_release(agent_name, leased_cred_name);
+   delegate_credentials_release(principal, agent_name, leased_cred_name);
    leased_cred_name[0] = '\0';
    out_env_var[0] = '\0';
-   return delegate_credentials_acquire(agent_name, creds, credential_count, leased_cred_name,
-                                       leased_cred_name_cap, out_env_var, out_env_var_cap) == 0
+   return delegate_credentials_acquire(principal, agent_name, creds, credential_count,
+                                       leased_cred_name, leased_cred_name_cap, out_env_var,
+                                       out_env_var_cap) == 0
               ? 1
               : 0;
 }
@@ -461,6 +512,10 @@ int delegate_credentials_snapshot(const char *agent_name, delegate_credential_sn
    pthread_mutex_lock(&g_mu);
    for (int i = 0; i < g_state_count && n < max; i++)
    {
+      /* Operator view = the shared env pool only; per-principal vault rows
+       * (principal != "") are a per-user concern, not surfaced here. */
+      if (g_state[i].principal[0])
+         continue;
       if (agent_name && agent_name[0] && strcmp(agent_name, g_state[i].agent_name) != 0)
          continue;
       snprintf(out[n].agent_name, sizeof(out[n].agent_name), "%s", g_state[i].agent_name);
@@ -533,26 +588,31 @@ int delegate_credentials_save_file(const char *path)
 
    pthread_mutex_lock(&g_mu);
    state_refresh_wallclock_locked(now_epoch_seconds());
-   fprintf(fp, "aimee-delegate-credential-state-v1\n");
+   /* v2 adds a leading principal column; v1 readers are gone but v1 files still
+    * load (principal defaults to the shared ""). */
+   fprintf(fp, "aimee-delegate-credential-state-v2\n");
    for (int i = 0; i < g_state_count; i++)
    {
+      char principal[VAULT_PRINCIPAL_MAX];
       char agent[MAX_AGENT_NAME];
       char cred[MAX_CRED_NAME_LEN];
       char last_error[sizeof(g_state[i].last_error)];
+      sanitize_field(principal, sizeof(principal), g_state[i].principal);
       sanitize_field(agent, sizeof(agent), g_state[i].agent_name);
       sanitize_field(cred, sizeof(cred), g_state[i].cred_name);
       sanitize_field(last_error, sizeof(last_error), g_state[i].last_error);
       fprintf(fp,
-              "%s\t%s\t%d\t%lld\t%d\t%d\t%lld\t%d\t%d\t%lld\t%ld\t%ld\t%lld\t%ld\t%ld\t%lld\t%"
+              "%s\t%s\t%s\t%d\t%lld\t%d\t%d\t%lld\t%d\t%d\t%lld\t%ld\t%ld\t%lld\t%ld\t%ld\t%lld\t%"
               "lld\t%s\n",
-              agent, cred, (int)g_state[i].status, (long long)g_state[i].cooldown_until_epoch,
-              g_state[i].rl.req_limit, g_state[i].rl.req_remaining,
-              (long long)g_state[i].rl.req_reset, g_state[i].rl.req_limit_1h,
-              g_state[i].rl.req_remaining_1h, (long long)g_state[i].rl.req_reset_1h,
-              g_state[i].rl.tok_limit, g_state[i].rl.tok_remaining,
-              (long long)g_state[i].rl.tok_reset, g_state[i].rl.tok_limit_1h,
-              g_state[i].rl.tok_remaining_1h, (long long)g_state[i].rl.tok_reset_1h,
-              (long long)g_state[i].rl.captured_at, last_error);
+              principal, agent, cred, (int)g_state[i].status,
+              (long long)g_state[i].cooldown_until_epoch, g_state[i].rl.req_limit,
+              g_state[i].rl.req_remaining, (long long)g_state[i].rl.req_reset,
+              g_state[i].rl.req_limit_1h, g_state[i].rl.req_remaining_1h,
+              (long long)g_state[i].rl.req_reset_1h, g_state[i].rl.tok_limit,
+              g_state[i].rl.tok_remaining, (long long)g_state[i].rl.tok_reset,
+              g_state[i].rl.tok_limit_1h, g_state[i].rl.tok_remaining_1h,
+              (long long)g_state[i].rl.tok_reset_1h, (long long)g_state[i].rl.captured_at,
+              last_error);
    }
    pthread_mutex_unlock(&g_mu);
 
@@ -624,7 +684,12 @@ int delegate_credentials_load_file(const char *path, time_t now_epoch)
       fclose(fp);
       return 0;
    }
-   if (strncmp(line, "aimee-delegate-credential-state-v1", 34) != 0)
+   int has_principal_col; /* v2 prepends a principal field; v1 has none */
+   if (strncmp(line, "aimee-delegate-credential-state-v2", 34) == 0)
+      has_principal_col = 1;
+   else if (strncmp(line, "aimee-delegate-credential-state-v1", 34) == 0)
+      has_principal_col = 0;
+   else
    {
       fclose(fp);
       return -1;
@@ -635,11 +700,14 @@ int delegate_credentials_load_file(const char *path, time_t now_epoch)
    {
       line[strcspn(line, "\r\n")] = '\0';
       char *cursor = line;
+      char *principal = has_principal_col ? next_field(&cursor) : "";
       char *agent = next_field(&cursor);
       char *cred = next_field(&cursor);
+      if (!principal)
+         principal = "";
       if (!agent || !agent[0] || !cred || !cred[0])
          continue;
-      cred_lease_state_t *slot = find_or_create_locked(agent, cred, NULL);
+      cred_lease_state_t *slot = find_or_create_locked(principal, agent, cred, NULL);
       if (!slot)
          continue;
       slot->leased = 0;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -729,6 +729,9 @@ void delegate_worker(void *arg)
    char deleg_id[64] = "";
    agent_t *target_agent = NULL;
    char leased_cred_name[MAX_CRED_NAME_LEN] = "";
+   /* WP-C.3: the credential-pool row key. "" for the shared env pool; the request
+    * principal for a vaulted credential, so its 429-cooldown is per-principal. */
+   char leased_principal[VAULT_PRINCIPAL_MAX] = "";
    char credential_state_path[MAX_PATH_LEN] = "";
    char *resolved_prompt = NULL;
    char *template_sys_prompt = NULL;
@@ -996,46 +999,29 @@ void delegate_worker(void *arg)
    delegate_apply_max_turns_policy(&acfg, role, max_turns);
    if (cctx->background_job_id > 0 && target_agent)
       db1_agent_job_set_agent(cctx->background_job_id, target_agent->name);
-   /* WP-C.1 vault-FIRST (D14/D15): vaulted cred beats env lease; LOCKED fails; miss -> env. */
-   int vault_hit = 0;
-   if (target_agent && cctx->vault_principal[0])
+   /* Resolve the credential (WP-C.1 vault-FIRST + WP-C.3 per-principal cooldown):
+    * sets target_agent->api_key on a hit and names the pool row to release on
+    * exit; the worker maps a non-OK status to a delegate error. */
+   int cooldown_secs = 0;
+   delegate_cred_resolve_status_t cred_status = delegate_resolve_credentials(
+       target_agent ? cctx->vault_principal : NULL, target_agent, leased_principal,
+       sizeof(leased_principal), leased_cred_name, sizeof(leased_cred_name), credential_state_path,
+       sizeof(credential_state_path), &cooldown_secs);
+   if (cred_status != DELEGATE_CRED_RESOLVE_OK)
    {
-      vault_status_t vst =
-          vault_service_inject_api_key(cctx->vault_principal, target_agent->name,
-                                       target_agent->api_key, MAX_API_KEY_LEN, time(NULL));
-      vault_hit = (vst == VAULT_OK);
-      if (vst == VAULT_ERR_LOCKED)
-      {
-         delegation_compute_error(cctx, "vault locked: run `aimee vault unlock`");
-         compute_ctx_free(cctx);
-         return;
-      }
-   }
-   /* Lease one credential from a configured pool (skipped on a vault hit). */
-   if (!vault_hit && target_agent && target_agent->credential_count > 0)
-   {
-      char leased_env[MAX_CRED_ENV_VAR_LEN] = "";
-      const char *dir = config_output_dir();
-      snprintf(credential_state_path, sizeof(credential_state_path),
-               "%s/delegate-credential-state.tsv", dir ? dir : "/tmp");
-      (void)delegate_credentials_load_file(credential_state_path, time(NULL));
-      if (delegate_credentials_acquire(
-              target_agent->name, target_agent->credentials, target_agent->credential_count,
-              leased_cred_name, sizeof(leased_cred_name), leased_env, sizeof(leased_env)) == 0)
-      {
-         const char *value = getenv(leased_env);
-         if (value && value[0])
-            snprintf(target_agent->api_key, MAX_API_KEY_LEN, "%s", value);
-      }
+      char errmsg[200];
+      if (cred_status == DELEGATE_CRED_RESOLVE_LOCKED)
+         snprintf(errmsg, sizeof(errmsg), "vault locked: run `aimee vault unlock`");
+      else if (cred_status == DELEGATE_CRED_RESOLVE_COOLING)
+         snprintf(errmsg, sizeof(errmsg),
+                  "vault credential for agent '%s' is rate-limited; retry in %ds",
+                  target_agent->name, cooldown_secs);
       else
-      {
-         char errmsg[256];
          snprintf(errmsg, sizeof(errmsg), "no available credential in pool for agent '%s'",
                   target_agent->name);
-         delegation_compute_error(cctx, errmsg);
-         compute_ctx_free(cctx);
-         return;
-      }
+      delegation_compute_error(cctx, errmsg);
+      compute_ctx_free(cctx);
+      return;
    }
 
    /* Enforce delegation depth limit.
@@ -1621,12 +1607,13 @@ void delegate_worker(void *arg)
       if (!result.success)
          reason = delegate_credentials_classify_failure(target_agent->provider, result.error);
       if (reason != FAILOVER_NONE)
-         delegate_credentials_report_failure(target_agent->name, leased_cred_name, reason,
-                                             result.error, time(NULL));
-      delegate_credentials_release(target_agent->name, leased_cred_name);
+         delegate_credentials_report_failure(leased_principal, target_agent->name, leased_cred_name,
+                                             reason, result.error, time(NULL));
+      delegate_credentials_release(leased_principal, target_agent->name, leased_cred_name);
       if (credential_state_path[0])
          (void)delegate_credentials_save_file(credential_state_path);
       leased_cred_name[0] = '\0';
+      leased_principal[0] = '\0';
    }
 
    /* Clear thread-local CWD */
@@ -1645,7 +1632,7 @@ delegate_fail:
    free(resolved_prompt);
    free(template_sys_prompt);
    if (target_agent && leased_cred_name[0])
-      delegate_credentials_release(target_agent->name, leased_cred_name);
+      delegate_credentials_release(leased_principal, target_agent->name, leased_cred_name);
    if (delegate_worktree_path[0] && delegate_git_root[0])
       worktree_cleanup(delegate_git_root, deleg_id, delegate_work_name);
    compute_ctx_free(cctx);

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -232,7 +232,8 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
    char *tmp = malloc(api_key_len);
    if (!tmp)
       return VAULT_ERR_IO;
-   vault_status_t st = vault_service_get(principal, agent, "api_key", tmp, api_key_len, now_epoch);
+   vault_status_t st =
+       vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
    if (st == VAULT_OK)
       snprintf(api_key, api_key_len, "%s", tmp); /* overwrite only on a real hit */
    OPENSSL_cleanse(tmp, api_key_len);

--- a/src/tests/test_delegate_credentials.c
+++ b/src/tests/test_delegate_credentials.c
@@ -25,19 +25,19 @@ static void test_acquire_round_robin(void)
    creds[1] = make_cred("backup", "OPENROUTER_API_KEY_2");
 
    char a_name[32] = {0}, a_env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, a_name, sizeof(a_name), a_env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, a_name, sizeof(a_name), a_env,
                                        sizeof(a_env)) == 0);
    assert(strcmp(a_name, "main") == 0);
 
    /* Second call leases the next credential, not the same one. */
    char b_name[32] = {0}, b_env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, b_name, sizeof(b_name), b_env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, b_name, sizeof(b_name), b_env,
                                        sizeof(b_env)) == 0);
    assert(strcmp(b_name, "backup") == 0);
 
    /* Third call: pool exhausted. */
    char c_name[32] = {0}, c_env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, c_name, sizeof(c_name), c_env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, c_name, sizeof(c_name), c_env,
                                        sizeof(c_env)) == -1);
 
    printf("  PASS: test_acquire_round_robin\n");
@@ -51,17 +51,17 @@ static void test_release_makes_credential_available(void)
    creds[1] = make_cred("backup", "OPENROUTER_API_KEY_2");
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == -1);
 
-   delegate_credentials_release("openrouter", "main");
+   delegate_credentials_release("", "openrouter", "main");
 
    /* Now there is one available again. */
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "main") == 0);
    printf("  PASS: test_release_makes_credential_available\n");
@@ -75,15 +75,15 @@ static void test_cooldown_skips_credential(void)
    creds[1] = make_cred("backup", "OPENROUTER_API_KEY_2");
 
    /* Cool main; even before any acquire happens, main is unavailable. */
-   delegate_credentials_cooldown("openrouter", "main", 60);
+   delegate_credentials_cooldown("", "openrouter", "main", 60);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "backup") == 0);
 
    /* No more credentials available — main is still cooling. */
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == -1);
    printf("  PASS: test_cooldown_skips_credential\n");
 }
@@ -98,7 +98,7 @@ static void test_capture_headers_records_quota_windows(void)
                          "x-ratelimit-limit-tokens: 10000\r\n"
                          "x-ratelimit-remaining-tokens: 2500\r\n"
                          "x-ratelimit-reset-tokens: 45\r\n";
-   assert(delegate_credentials_capture_headers("openrouter", "main", headers, 1000) == 0);
+   assert(delegate_credentials_capture_headers("", "openrouter", "main", headers, 1000) == 0);
 
    delegate_credential_snapshot_t rows[4];
    int n = delegate_credentials_snapshot("openrouter", rows, 4);
@@ -121,15 +121,15 @@ static void test_acquire_prefers_freshest_quota(void)
    creds[1] = make_cred("fresh", "FRESH_KEY");
 
    assert(delegate_credentials_capture_headers(
-              "openrouter", "low",
+              "", "openrouter", "low",
               "x-ratelimit-remaining-requests: 2\nx-ratelimit-remaining-tokens: 500\n", 1000) == 0);
    assert(delegate_credentials_capture_headers(
-              "openrouter", "fresh",
+              "", "openrouter", "fresh",
               "x-ratelimit-remaining-requests: 50\nx-ratelimit-remaining-tokens: 8000\n",
               1000) == 0);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "fresh") == 0);
    assert(strcmp(env, "FRESH_KEY") == 0);
@@ -144,13 +144,13 @@ static void test_report_failure_marks_and_rotates(void)
    creds[1] = make_cred("backup", "BACKUP_KEY");
 
    assert(delegate_credentials_capture_headers(
-              "openrouter", "main",
+              "", "openrouter", "main",
               "x-ratelimit-reset-requests: 120\nx-ratelimit-remaining-requests: 0\n", 1000) == 0);
-   assert(delegate_credentials_report_failure("openrouter", "main", FAILOVER_RATE_LIMIT, "HTTP 429",
-                                              1000) == 1);
+   assert(delegate_credentials_report_failure("", "openrouter", "main", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "backup") == 0);
 
@@ -177,14 +177,14 @@ static void test_rotate_after_failure_releases_and_leases_next(void)
    creds[1] = make_cred("backup", "BACKUP_KEY");
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "main") == 0);
    assert(delegate_credentials_capture_headers(
-              "openrouter", "main",
+              "", "openrouter", "main",
               "x-ratelimit-reset-requests: 120\nx-ratelimit-remaining-requests: 0\n", 1000) == 0);
 
-   assert(delegate_credentials_rotate_after_failure("openrouter", creds, 2, "openrouter", name,
+   assert(delegate_credentials_rotate_after_failure("", "openrouter", creds, 2, "openrouter", name,
                                                     sizeof(name), env, sizeof(env), "HTTP 429",
                                                     1000) == 1);
    assert(strcmp(name, "backup") == 0);
@@ -221,13 +221,13 @@ static void test_rotate_after_non_pool_failure_keeps_lease(void)
    creds[1] = make_cred("backup", "BACKUP_KEY");
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
-   assert(delegate_credentials_rotate_after_failure("openrouter", creds, 2, "openrouter", name,
+   assert(delegate_credentials_rotate_after_failure("", "openrouter", creds, 2, "openrouter", name,
                                                     sizeof(name), env, sizeof(env),
                                                     "connection refused", 1000) == 0);
    assert(strcmp(name, "main") == 0);
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "backup") == 0);
    printf("  PASS: test_rotate_after_non_pool_failure_keeps_lease\n");
@@ -240,13 +240,13 @@ static void test_billing_and_auth_failures_are_not_reacquired(void)
    creds[0] = make_cred("billing", "BILLING_KEY");
    creds[1] = make_cred("auth", "AUTH_KEY");
 
-   assert(delegate_credentials_report_failure("openrouter", "billing", FAILOVER_BILLING,
+   assert(delegate_credentials_report_failure("", "openrouter", "billing", FAILOVER_BILLING,
                                               "payment required", 1000) == 1);
-   assert(delegate_credentials_report_failure("openrouter", "auth", FAILOVER_AUTH_PERMANENT,
+   assert(delegate_credentials_report_failure("", "openrouter", "auth", FAILOVER_AUTH_PERMANENT,
                                               "forbidden", 1000) == 1);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == -1);
    char quota[512];
    assert(delegate_credentials_format_quota("openrouter", quota, sizeof(quota)) == 2);
@@ -267,11 +267,11 @@ static void test_health_state_persists_across_reset(void)
    creds[2] = make_cred("fresh", "FRESH_KEY");
 
    assert(delegate_credentials_capture_headers(
-              "openrouter", "main",
+              "", "openrouter", "main",
               "x-ratelimit-reset-requests: 120\nx-ratelimit-remaining-requests: 0\n", 1000) == 0);
-   assert(delegate_credentials_report_failure("openrouter", "main", FAILOVER_RATE_LIMIT, "HTTP 429",
-                                              1000) == 1);
-   assert(delegate_credentials_report_failure("openrouter", "billing", FAILOVER_BILLING,
+   assert(delegate_credentials_report_failure("", "openrouter", "main", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
+   assert(delegate_credentials_report_failure("", "openrouter", "billing", FAILOVER_BILLING,
                                               "payment required", 1000) == 1);
    assert(delegate_credentials_save_file(path) == 0);
 
@@ -279,7 +279,7 @@ static void test_health_state_persists_across_reset(void)
    assert(delegate_credentials_load_file(path, 1000) == 2);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 3, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 3, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "fresh") == 0);
 
@@ -318,12 +318,12 @@ static void test_isolation_between_agents(void)
    char name[32] = {0}, env[64] = {0};
    /* agent A leases main. agent B's "main" is a different state row,
     * so it's independent and still available. */
-   assert(delegate_credentials_acquire("agent-A", creds, 1, name, sizeof(name), env, sizeof(env)) ==
-          0);
-   assert(delegate_credentials_acquire("agent-A", creds, 1, name, sizeof(name), env, sizeof(env)) ==
-          -1);
-   assert(delegate_credentials_acquire("agent-B", creds, 1, name, sizeof(name), env, sizeof(env)) ==
-          0);
+   assert(delegate_credentials_acquire("", "agent-A", creds, 1, name, sizeof(name), env,
+                                       sizeof(env)) == 0);
+   assert(delegate_credentials_acquire("", "agent-A", creds, 1, name, sizeof(name), env,
+                                       sizeof(env)) == -1);
+   assert(delegate_credentials_acquire("", "agent-B", creds, 1, name, sizeof(name), env,
+                                       sizeof(env)) == 0);
    printf("  PASS: test_isolation_between_agents\n");
 }
 
@@ -338,8 +338,8 @@ static void test_lease_state_grows_beyond_initial_capacity(void)
       char agent[32];
       char name[32] = {0}, env[64] = {0};
       snprintf(agent, sizeof(agent), "agent-%02d", i);
-      assert(delegate_credentials_acquire(agent, creds, 1, name, sizeof(name), env, sizeof(env)) ==
-             0);
+      assert(delegate_credentials_acquire("", agent, creds, 1, name, sizeof(name), env,
+                                          sizeof(env)) == 0);
       assert(strcmp(name, "main") == 0);
    }
    printf("  PASS: test_lease_state_grows_beyond_initial_capacity\n");
@@ -350,8 +350,8 @@ static void test_empty_pool_returns_error(void)
    delegate_credentials_reset_for_test();
    char name[32] = {0}, env[64] = {0};
    /* credential_count == 0 means "no pool" — caller falls back to api_key. */
-   assert(delegate_credentials_acquire("agent-A", NULL, 0, name, sizeof(name), env, sizeof(env)) ==
-          -1);
+   assert(delegate_credentials_acquire("", "agent-A", NULL, 0, name, sizeof(name), env,
+                                       sizeof(env)) == -1);
    printf("  PASS: test_empty_pool_returns_error\n");
 }
 
@@ -393,6 +393,87 @@ static void test_failure_classifier_maps_pool_reasons(void)
    printf("  PASS: test_failure_classifier_maps_pool_reasons\n");
 }
 
+/* WP-C.3: a 429 cooling one principal's vaulted credential must not cool the
+ * same (agent, cred) for another principal, nor the shared "" env pool. */
+static void test_principal_cooldown_isolation(void)
+{
+   delegate_credentials_reset_for_test();
+   delegate_credentials_cooldown("uid:alice", "claude", "api_key", 60);
+
+   assert(delegate_credentials_cooldown_remaining("uid:alice", "claude", "api_key", 0) > 0);
+   assert(delegate_credentials_cooldown_remaining("uid:bob", "claude", "api_key", 0) == 0);
+   assert(delegate_credentials_cooldown_remaining("", "claude", "api_key", 0) == 0);
+   /* NULL principal normalises to the shared "" pool — still independent. */
+   assert(delegate_credentials_cooldown_remaining(NULL, "claude", "api_key", 0) == 0);
+   printf("  PASS: test_principal_cooldown_isolation\n");
+}
+
+/* WP-C.3: cooldown_remaining reports the live (monotonic) seconds left, returns 0
+ * for an unknown row without creating one, and 0 once a restored deadline passes. */
+static void test_cooldown_remaining_reports_seconds(void)
+{
+   delegate_credentials_reset_for_test();
+   assert(delegate_credentials_report_failure("webuser:carol", "claude", "api_key",
+                                              FAILOVER_RATE_LIMIT, "HTTP 429", 0) == 1);
+   int rem = delegate_credentials_cooldown_remaining("webuser:carol", "claude", "api_key", 0);
+   assert(rem > 0 && rem <= DELEGATE_CRED_COOLDOWN_SECONDS_DEFAULT);
+   /* Unknown row -> 0, and no row was created. */
+   assert(delegate_credentials_cooldown_remaining("uid:nobody", "claude", "api_key", 0) == 0);
+
+   /* A persisted, per-principal rate-limited row whose deadline has already passed
+    * loads as not-cooling (load re-bases the monotonic timer off the epoch). */
+   delegate_credentials_reset_for_test();
+   char p[256];
+   snprintf(p, sizeof(p), "/tmp/aimee-test-cd-%ld.tsv", (long)getpid());
+   FILE *fp = fopen(p, "w");
+   assert(fp != NULL);
+   fputs("aimee-delegate-credential-state-v2\nuid:carol\tclaude\tapi_key\t1\t1500\n", fp);
+   fclose(fp);
+   assert(delegate_credentials_load_file(p, 5000) == 1); /* now 5000 > deadline 1500 */
+   assert(delegate_credentials_cooldown_remaining("uid:carol", "claude", "api_key", 5000) == 0);
+   unlink(p);
+   printf("  PASS: test_cooldown_remaining_reports_seconds\n");
+}
+
+/* WP-C.3: the v2 state file round-trips the principal column, keeping per-principal
+ * rows distinct from the shared "" pool; legacy v1 files load with principal "". */
+static void test_save_load_v2_roundtrips_principal(void)
+{
+   delegate_credentials_reset_for_test();
+   char path[256];
+   snprintf(path, sizeof(path), "/tmp/aimee-test-cred-v2-%ld.tsv", (long)getpid());
+
+   /* A shared-pool row and a per-principal vault row, both rate-limited. */
+   assert(delegate_credentials_report_failure("", "openrouter", "main", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
+   assert(delegate_credentials_report_failure("uid:alice", "claude", "api_key", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
+   assert(delegate_credentials_save_file(path) == 0);
+
+   delegate_credentials_reset_for_test();
+   assert(delegate_credentials_load_file(path, 1000) == 2);
+   /* The per-principal row reloaded under its own principal, isolated from "". */
+   assert(delegate_credentials_cooldown_remaining("uid:alice", "claude", "api_key", 1000) > 0);
+   assert(delegate_credentials_cooldown_remaining("", "claude", "api_key", 1000) == 0);
+   /* The shared row is visible to the operator snapshot; the vault row is not. */
+   delegate_credential_snapshot_t rows[8];
+   int n = delegate_credentials_snapshot(NULL, rows, 8);
+   assert(n == 1);
+   assert(strcmp(rows[0].agent_name, "openrouter") == 0 && strcmp(rows[0].cred_name, "main") == 0);
+   unlink(path);
+
+   /* Legacy v1 file (no principal column) loads into the shared "" pool. */
+   delegate_credentials_reset_for_test();
+   FILE *fp = fopen(path, "w");
+   assert(fp != NULL);
+   fputs("aimee-delegate-credential-state-v1\nopenrouter\tmain\t1\t1120\n", fp);
+   fclose(fp);
+   assert(delegate_credentials_load_file(path, 1000) == 1);
+   assert(delegate_credentials_cooldown_remaining("", "openrouter", "main", 1000) == 120);
+   unlink(path);
+   printf("  PASS: test_save_load_v2_roundtrips_principal\n");
+}
+
 int main(void)
 {
    printf("delegate_credentials:\n");
@@ -411,6 +492,9 @@ int main(void)
    test_empty_pool_returns_error();
    test_is_rate_limit_classifier();
    test_failure_classifier_maps_pool_reasons();
+   test_principal_cooldown_isolation();
+   test_cooldown_remaining_reports_seconds();
+   test_save_load_v2_roundtrips_principal();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -123,6 +123,10 @@ void agent_set_request_codex_creds(const char *token, const char *account_id)
    (void)token;
    (void)account_id;
 }
+int agent_request_codex_token_present(void)
+{
+   return 0;
+}
 void agent_set_request_session(const char *session_id)
 {
    (void)session_id;
@@ -192,6 +196,19 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
    (void)agent;
    (void)api_key;
    (void)api_key_len;
+   (void)now_epoch;
+   return VAULT_NO_ENTRY;
+}
+/* WP-C.3: delegate_credential_retry.o (linked here) calls vault_service_get for
+ * the codex-oauth override; these tests run keyless, so stub it to a miss. */
+vault_status_t vault_service_get(const char *principal, const char *agent, const char *cred,
+                                 char *out, size_t out_cap, long now_epoch)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)out;
+   (void)out_cap;
    (void)now_epoch;
    return VAULT_NO_ENTRY;
 }


### PR DESCRIPTION
WP-C.3: per-principal credential pool re-key + vault-cred cooldown

Final phase of the credential-vault proposal. Three parts:

1. Re-key delegate_credentials.c from (agent,cred) to (principal,agent,cred).
   The shared agents.json env pool keeps principal "" (a provider 429 there is
   global, unchanged); a per-principal vaulted credential passes its uid:/webuser:
   principal so its 429-cooldown and health are isolated from other principals.
   acquire/release/cooldown/capture_headers/report_failure/rotate_after_failure
   gain a leading principal; new read-only cooldown_remaining; the state file is
   bumped to v2 with a leading principal column and still loads v1 (principal "").
   snapshot/format_quota stay the operator view of the shared "" pool.

2. Per-principal vault-cred cooldown in the delegate worker. The vault-FIRST
   use-path + env-pool lease was extracted from server_compute.c into
   delegate_resolve_credentials() (delegate_credential_retry.c), keeping
   server_compute.c under the 2000-line cap. A vaulted credential takes no
   exclusive lease (a user's own key may serve their concurrent delegates) but a
   prior 429 cools it for that principal only, and a cooling vault cred fails the
   run fast with a retry hint.

3. codex-oauth vault override: a vaulted codex_oauth_token overrides the
   on-disk/session token, deferring to a live per-turn client push; the transient
   plaintext is cleansed.

Tests: principal-cooldown isolation, cooldown_remaining, save/load v2 + v1
back-compat; existing pool tests updated for the new key. verify-local: ok.
