### PR TITLE
Fix: server images lose delegate-over-TCP on redeploy (remote_writes reset to off)

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -109,6 +109,17 @@ ENV AIMEE_HOME=/var/lib/aimee
 # loopback HTTP via AIMEE_KB_API_URL. The entrypoint owns the kb lifecycle; the
 # server no longer autostarts a kb (that socket transport was retired, #2747).
 ENV AIMEE_SERVER_HTTP_BIND=1
+# This combined all-in-one is the trusted-network dogfood image: it binds /v1 on
+# 0.0.0.0 specifically so a thin client drives it remotely — including delegates,
+# roundtables and tools (the headline workflow). Those routes are gated behind
+# aimee.api.remote_writes=full, so set it here as deploy truth. Without it a fresh
+# (re)deploy seeds remote_writes="off" (first-start-only seed in the entrypoint)
+# and the network bearer silently loses CAP_DELEGATE — delegate/tool /v1 calls
+# 403. The env applies on EVERY start regardless of the seeded/mounted aimee.yaml
+# (config_server_api.c), so it survives the wipe-and-reinstall redeploy path.
+# Trusted networks only (this image ships a known dev bearer); override to
+# `off`/`data` (and set your own bearer + TLS) for any exposed deployment.
+ENV AIMEE_API_REMOTE_WRITES=full
 ENV AIMEE_KB_API_URL=http://127.0.0.1:8741
 ENV AIMEE_DB1_URL=sqlite:///var/lib/aimee/aimee.db
 # kb: bind its /v1 on 0.0.0.0 (so it can optionally be published for inspection)

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -99,6 +99,15 @@ ENV AIMEE_HOME=/var/lib/aimee
 # published container port reaches it. The bearer token in the baked aimee.yaml
 # is still required on every request.
 ENV AIMEE_SERVER_HTTP_BIND=1
+# Since this image binds /v1 on 0.0.0.0 for a remote thin client to drive it —
+# including delegates, roundtables and tools — permit those routes over TCP by
+# default (they are gated behind aimee.api.remote_writes=full in
+# server_http_route_allowed). Applied on EVERY start regardless of the
+# seeded/mounted aimee.yaml (config_server_api.c), so a fresh/wiped redeploy can't
+# silently reseed "off" and drop CAP_DELEGATE (delegate/tool 403). This image
+# ships a known dev bearer and is trusted-network only; override to off/data (and
+# set your own bearer + TLS) for any exposed deployment.
+ENV AIMEE_API_REMOTE_WRITES=full
 # Standalone by default: no kb configured. Point AIMEE_KB_API_URL at a running
 # aimee-kb (e.g. http://aimee-kb:8741) to enable the shared/vector features.
 # Mirror tier (workspace-resource-plane §3): the per-workspace bare mirrors +

--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -17,11 +17,15 @@ aimee:
     http_port: 8740
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
-    # port a bearer is read/query/chat only. Opt into remote writes here:
+    # This combined all-in-one binds /v1 on 0.0.0.0 so a thin client drives it
+    # remotely, including delegates/roundtables/tools — which require
+    # remote_writes="full". The image also forces this via AIMEE_API_REMOTE_WRITES
+    # (Dockerfile.combined) so it survives a fresh redeploy that reseeds this file.
+    # Trusted networks only (this ships a known dev bearer); for any exposed
+    # deployment set your own bearer + TLS and lower this:
     #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
-    #   remote_writes: full   # + delegate/tool over /v1/rpc — trusted nets only
-    remote_writes: "off"
+    #   remote_writes: "off"  # TCP bearer is read/query/chat only
+    remote_writes: "full"
 
 # --- kb: real semantic embeddings via the persistent embedder service ---
 embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"

--- a/deploy/container/aimee-server.yaml
+++ b/deploy/container/aimee-server.yaml
@@ -15,9 +15,13 @@ aimee:
     http_port: 8740
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
-    # port a bearer is read/query/chat only. Opt into remote writes here:
+    # This image binds /v1 on 0.0.0.0 so a thin client drives it remotely,
+    # including delegates/roundtables/tools — which require remote_writes="full".
+    # The image also forces this via AIMEE_API_REMOTE_WRITES (Dockerfile.server) so
+    # it survives a fresh redeploy that reseeds this file. Trusted networks only
+    # (ships a known dev bearer); for any exposed deployment set your own bearer +
+    # TLS and lower this:
     #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
-    #   remote_writes: full   # + delegate/tool over /v1/rpc (CAPS_ALL) — trusted nets only
-    remote_writes: "off"
+    #   remote_writes: "off"  # TCP bearer is read/query/chat only
+    remote_writes: "full"
 


### PR DESCRIPTION
Root-caused from a live .254 redeploy: the combined all-in-one binds /v1 on 0.0.0.0 for remote thin-client use, but baked `remote_writes: "off"` + first-start-only seed meant a fresh redeploy reseeded `off`, so the network bearer lost `CAP_DELEGATE` and delegate/tool /v1 calls 403'd ("capabilities beyond the presented token's scope") — breaking the thin-client roundtable even with the server up.

Fix: set `AIMEE_API_REMOTE_WRITES=full` in Dockerfile.combined (applied every start regardless of the seeded/mounted aimee.yaml, so it survives wipe-and-reinstall) + align the baked yaml default & comments. Trusted-network dogfood image only (ships a dev bearer); override to off/data + own bearer + TLS for exposed deployments. Standalone aimee-server image unchanged.

Container-packaging + sidecar checks pass locally; e2e-docker builds the image.