### PR TITLE
Seed delegate defaults (roster + ensemble + remote_writes) into the images

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -142,6 +142,9 @@ COPY scripts/embed-remote.py scripts/rerank-remote.py scripts/llm-chat.py \
 # this single merged file carries the server's /v1 settings AND the kb's sidecar
 # command selection (incl. embedding_command).
 COPY deploy/container/aimee-combined.yaml /opt/aimee/defaults/aimee.yaml
+# Default delegate roster (definitions only; keys are client-held). The
+# entrypoint seeds it into $AIMEE_HOME/agents.json on first start.
+COPY deploy/container/agents.json /opt/aimee/defaults/agents.json
 # Co-located webchat browser UI: the Go service, the single-file React SPA, the
 # PAM stack for browser login, and the bootstrap/launch helpers. webchat shares
 # AIMEE_HOME so its Unix-socket transports line up with the server.

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -142,6 +142,9 @@ RUN chmod +x /usr/local/bin/aimee-server-entrypoint
 # Kept OUTSIDE $AIMEE_HOME so a bind-mounted (empty) volume can't shadow it; the
 # entrypoint seeds it into $AIMEE_HOME/aimee.yaml on first start.
 COPY deploy/container/aimee-server.yaml /opt/aimee/defaults/aimee.yaml
+# Default delegate roster (definitions only; keys are client-held). The
+# entrypoint seeds it into $AIMEE_HOME/agents.json on first start.
+COPY deploy/container/agents.json /opt/aimee/defaults/agents.json
 
 # Runs as root: the entrypoint bootstraps the webchat PAM user and runs webchat
 # (pam_unix needs /etc/shadow), then drops aimee-server to the "aimee" user.

--- a/deploy/container/agents.json
+++ b/deploy/container/agents.json
@@ -1,0 +1,61 @@
+{
+  "_comment": "Default delegate roster baked into the aimee-server / aimee-combined image and seeded into $AIMEE_HOME/agents.json on first start (only if absent). DEFINITIONS ONLY — no API keys live here. A thin client pushes its client-held keys per session (POST /v1/session/credentials), which the server caches in RAM keyed by agent name; codex uses client-sourced OAuth. Override by mounting your own agents.json over $AIMEE_HOME/agents.json.",
+  "agents": [
+    {
+      "name": "minimax",
+      "provider": "minimax",
+      "model": "MiniMax-M3",
+      "endpoint": "https://api.minimax.io/v1/chat/completions",
+      "auth_type": "bearer",
+      "enabled": 1,
+      "tools_enabled": 1,
+      "cost_tier": 0,
+      "max_parallel": 3,
+      "roles": ["code", "review", "explain", "refactor", "draft", "execute", "summarize", "format", "diagnose", "validate"]
+    },
+    {
+      "name": "mistral",
+      "model": "mistral-medium-latest",
+      "endpoint": "https://api.mistral.ai/v1/chat/completions",
+      "auth_type": "bearer",
+      "enabled": 1,
+      "tools_enabled": 1,
+      "cost_tier": 0,
+      "max_parallel": 3,
+      "roles": ["code", "review", "explain", "refactor", "draft", "execute", "summarize", "format", "diagnose", "validate"]
+    },
+    {
+      "name": "mimo-2.5",
+      "model": "mimo-v2.5-pro",
+      "endpoint": "https://token-plan-ams.xiaomimimo.com/v1/chat/completions",
+      "auth_type": "bearer",
+      "enabled": 1,
+      "tools_enabled": 1,
+      "cost_tier": 0,
+      "max_parallel": 3,
+      "roles": ["code", "review", "explain", "refactor", "draft", "execute", "summarize", "format", "diagnose", "validate"]
+    },
+    {
+      "name": "codex",
+      "provider": "chatgpt",
+      "model": "gpt-5.5",
+      "endpoint": "https://chatgpt.com/backend-api/codex",
+      "enabled": 1,
+      "tools_enabled": 0,
+      "cost_tier": 0,
+      "max_parallel": 3,
+      "roles": ["code", "review", "explain", "refactor", "draft", "execute", "summarize", "format", "diagnose", "validate"]
+    },
+    {
+      "name": "claude",
+      "provider": "claude",
+      "model": "sonnet",
+      "endpoint": "",
+      "enabled": 1,
+      "tools_enabled": 0,
+      "cost_tier": 0,
+      "max_parallel": 3,
+      "roles": ["summarize", "format", "draft", "explain"]
+    }
+  ]
+}

--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -17,11 +17,20 @@ aimee:
     http_port: 8740
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
-    # port a bearer is read/query/chat only. Opt into remote writes here:
-    #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
-    #   remote_writes: full   # + delegate/tool over /v1/rpc — trusted nets only
-    remote_writes: "off"
+    # remote_writes: off | data | full. Default `full` so a remote thin-client
+    # can run delegates / roundtable / tools out of the box (CAPS_ALL). The
+    # bearer token is the trust boundary — OVERRIDE IT (and front with TLS) for
+    # any deployment exposed beyond a trusted network.
+    remote_writes: "full"
+
+# Delegate roundtable / MoA ensemble, on by default with the seeded agents.json
+# roster as the panel; a thin client pushes the per-agent keys per session.
+ensemble:
+  enabled: true
+  reference_models:
+    - minimax
+    - mistral
+    - mimo-2.5
 
 # --- kb: real semantic embeddings via the persistent embedder service ---
 embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"

--- a/deploy/container/aimee-server.yaml
+++ b/deploy/container/aimee-server.yaml
@@ -15,9 +15,24 @@ aimee:
     http_port: 8740
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
-    # port a bearer is read/query/chat only. Opt into remote writes here:
-    #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
-    #   remote_writes: full   # + delegate/tool over /v1/rpc (CAPS_ALL) — trusted nets only
-    remote_writes: "off"
+    # remote_writes controls what a TCP bearer may do over the published port:
+    #   off    read/query/chat only (mutations are local-UDS-only)
+    #   data   + data writes (memory/work/rules/skill), capability-gated
+    #   full   + delegate/tool/roundtable (CAPS_ALL)
+    # Default `full` so the thin-client model works out of the box: a remote
+    # `aimee` client driving this server can run delegates and the roundtable
+    # without extra setup. The bearer token above is the trust boundary, so
+    # OVERRIDE IT (and front with TLS) for any deployment exposed beyond a
+    # trusted network.
+    remote_writes: "full"
+
+# Delegate roundtable / MoA ensemble, on by default. The panel is the seeded
+# agents.json roster; a thin client pushes the per-agent API keys per session
+# (no keys are baked in), so the roundtable works once a client has connected.
+ensemble:
+  enabled: true
+  reference_models:
+    - minimax
+    - mistral
+    - mimo-2.5
 

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -36,10 +36,17 @@ if [ ! -f "$AIMEE_HOME/aimee.yaml" ] && [ -f /opt/aimee/defaults/aimee.yaml ]; t
     mkdir -p "$AIMEE_HOME"
     cp /opt/aimee/defaults/aimee.yaml "$AIMEE_HOME/aimee.yaml"
 fi
+# Seed the default delegate roster (definitions only; keys are client-held) so
+# delegates / the roundtable work out of the box. Never clobber an operator's.
+if [ ! -f "$AIMEE_HOME/agents.json" ] && [ -f /opt/aimee/defaults/agents.json ]; then
+    mkdir -p "$AIMEE_HOME"
+    cp /opt/aimee/defaults/agents.json "$AIMEE_HOME/agents.json"
+fi
 # Ensure aimee (uid 1000) owns its home + workspaces so it can write on an empty
 # bind mount. On smoothfs tiers ownership is forced to 1000 regardless; harmless.
 chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspaces}" 2>/dev/null || true
 [ -f "$AIMEE_HOME/aimee.yaml" ] && chown aimee:aimee "$AIMEE_HOME/aimee.yaml" 2>/dev/null || true
+[ -f "$AIMEE_HOME/agents.json" ] && chown aimee:aimee "$AIMEE_HOME/agents.json" 2>/dev/null || true
 
 kb_pid=""
 server_pid=""

--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -28,8 +28,16 @@ if [ ! -f "$AIMEE_HOME/aimee.yaml" ] && [ -f /opt/aimee/defaults/aimee.yaml ]; t
     mkdir -p "$AIMEE_HOME"
     cp /opt/aimee/defaults/aimee.yaml "$AIMEE_HOME/aimee.yaml"
 fi
+# Seed the default delegate roster (definitions only; keys are client-held and
+# pushed per session) so delegates / the roundtable work out of the box. Never
+# clobber an operator's agents.json.
+if [ ! -f "$AIMEE_HOME/agents.json" ] && [ -f /opt/aimee/defaults/agents.json ]; then
+    mkdir -p "$AIMEE_HOME"
+    cp /opt/aimee/defaults/agents.json "$AIMEE_HOME/agents.json"
+fi
 chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspaces}" 2>/dev/null || true
 [ -f "$AIMEE_HOME/aimee.yaml" ] && chown aimee:aimee "$AIMEE_HOME/aimee.yaml" 2>/dev/null || true
+[ -f "$AIMEE_HOME/agents.json" ] && chown aimee:aimee "$AIMEE_HOME/agents.json" 2>/dev/null || true
 
 . /usr/local/bin/webchat-lib.sh
 


### PR DESCRIPTION
## Why

A clean `aimee-server` / `aimee-combined` install shipped with **no delegate roster, ensemble off, and `remote_writes=off`** — so delegates and the roundtable didn't work until the server was hand-configured. These should be deployment defaults, not per-install setup.

## What

- **`deploy/container/agents.json` (new):** the standard 5-agent roster (`minimax`, `mistral`, `mimo-2.5`, `codex`, `claude`) as **definitions only — no API keys**. A thin client still pushes its client-held keys per session; nothing secret is baked in. Seeded into `$AIMEE_HOME/agents.json` on first start by both entrypoints (never clobbers an operator's file) + `COPY`'d into `Dockerfile.server` / `Dockerfile.combined`.
- **`aimee-server.yaml` / `aimee-combined.yaml` defaults:** `ensemble.enabled=true` with the roster as the `reference_models` panel (roundtable convenes by default), and `remote_writes: off → full` so a remote `aimee` client over the published port gets `CAPS_ALL` and can run delegates/roundtable/tools.

## Security note

The dev bearer (`aimee-local-dev`) is the trust boundary and keeps its "override for any real/exposed deployment" warning. `remote_writes=full` assumes a trusted network — which is the thin-client deployment model this targets.
