### PR TITLE
Block the host AI's Task subagent tool; route to aimee delegates

### DIFF
--- a/configure-hooks.sh
+++ b/configure-hooks.sh
@@ -175,7 +175,7 @@ if [ -d "$HOME_DIR/.claude" ] || command -v claude &>/dev/null; then
     configure_json_hooks "Claude Code" \
         "$CLAUDE_SETTINGS" \
         "PreToolUse" "PostToolUse" "SessionStart" \
-        "Edit|Write|MultiEdit|Bash|Read|Glob|Grep" "Edit|Write|MultiEdit" \
+        "Edit|Write|MultiEdit|Bash|Read|Glob|Grep|Task" "Edit|Write|MultiEdit" \
         "$CLAUDE_SETTINGS" "claude"
 
     # Ensure Gemini is in the auto-allow list if permissions are already set

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -746,9 +746,9 @@ static void emit_pretool_rewrite_unsupported_json(int rewrite_rc, const char *re
  * These must never escape the session guardrails. */
 static int client_tool_is_subagent(const char *tool_name)
 {
-   return tool_name &&
-          (strcmp(tool_name, "Agent") == 0 || strcmp(tool_name, "spawn_agent") == 0 ||
-           strcmp(tool_name, "RemoteTrigger") == 0 || strcmp(tool_name, "Subagent") == 0);
+   return tool_name && (strcmp(tool_name, "Agent") == 0 || strcmp(tool_name, "spawn_agent") == 0 ||
+                        strcmp(tool_name, "RemoteTrigger") == 0 ||
+                        strcmp(tool_name, "Subagent") == 0 || strcmp(tool_name, "Task") == 0);
 }
 
 /* Fail-closed guard for the pre-hook's fail-open paths: the server normally

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -136,7 +136,7 @@ const char *guardrails_canonical_tool_name(const char *tool_name)
    if (strcmp(tool_name, "grep") == 0 || strcmp(tool_name, "Grep") == 0)
       return "Grep";
    if (strcmp(tool_name, "Agent") == 0 || strcmp(tool_name, "spawn_agent") == 0 ||
-       strcmp(tool_name, "RemoteTrigger") == 0)
+       strcmp(tool_name, "RemoteTrigger") == 0 || strcmp(tool_name, "Task") == 0)
       return "Subagent";
 
    return tool_name;
@@ -1593,10 +1593,11 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
    if (is_subagent_tool(tool_name))
    {
       snprintf(msg_buf, msg_len,
-               "BLOCKED: provider-native sub-agent tools such as spawn_agent or Agent "
-               "are outside aimee's primary-agent guardrail model. Use the aimee "
-               "delegate MCP tool or `aimee delegate <role> \"<task>\"` so the child "
-               "inherits the current session guardrails.");
+               "BLOCKED: sub-agent tools (Task, Agent, spawn_agent, …) are outside aimee's "
+               "guardrail model. Delegate instead: `aimee delegate <role> \"<task>\" "
+               "--persona <persona>`, or `aimee delegate roundtable \"<task>\" --mode review` "
+               "for a multi-model panel. aimee delegates run on the cheapest capable model, are "
+               "cost-tracked, see the shared memory + KB, and inherit this session's guardrails.");
       audit_log("subagent_blocked",
                 "provider sub-agent tool blocked — keep delegation inside aimee");
       cJSON_Delete(root);

--- a/src/tests/test_guardrails_cases_a.inc
+++ b/src/tests/test_guardrails_cases_a.inc
@@ -1076,7 +1076,17 @@ static void test_known_subagent_tools_blocked(void)
    assert(rc == 2);
    assert(strstr(msg, "BLOCKED") != NULL);
    assert(strstr(msg, "guardrails") != NULL);
-   assert(strstr(msg, "delegate MCP tool") != NULL);
+   assert(strstr(msg, "aimee delegate") != NULL);
+
+   /* Claude Code's actual sub-agent tool name (Task) should be blocked too */
+   rc = pre_tool_check("Task",
+                       "{\"subagent_type\":\"Explore\","
+                       "\"prompt\":\"Find the installer code\","
+                       "\"description\":\"Find installer\"}",
+                       &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+   assert(rc == 2);
+   assert(strstr(msg, "BLOCKED") != NULL);
+   assert(strstr(msg, "aimee delegate") != NULL);
 
    /* Codex sub-agent tool should also be blocked */
    rc = pre_tool_check("spawn_agent",
@@ -1093,7 +1103,7 @@ static void test_known_subagent_tools_blocked(void)
                        msg, sizeof(msg));
    assert(rc == 2);
    assert(strstr(msg, "guardrails") != NULL);
-   assert(strstr(msg, "delegate MCP tool") != NULL);
+   assert(strstr(msg, "aimee delegate") != NULL);
 
    guardrails_close_test_sqlite();
 }


### PR DESCRIPTION
## Why

aimee already blocks provider-native sub-agent tools (`Agent`, `spawn_agent`, `RemoteTrigger`, `Subagent`) in `pre_tool_check` and the thin-client fail-open path, redirecting that work to aimee delegates — cheapest capable model, cost-tracked, memory/KB-aware, and bound by the session's guardrails. But it didn't recognize Claude Code's actual sub-agent tool name, `Task`, and the PreToolUse hook matcher didn't fire on it — so `Task` spawns slipped straight through.

## What

- **`guardrails_orchestrator.c`**: canonicalize `Task` → `Subagent` so `pre_tool_check` blocks it. Block message now names `Task` and points at both `aimee delegate <role>` and `aimee delegate roundtable --mode review`.
- **`cli_main.c`**: add `Task` to the thin client's fail-open sub-agent list (no spawn slips through while aimee-server is unreachable).
- **`configure-hooks.sh`**: add `Task` to Claude Code's PreToolUse matcher so the hook actually sees the call (Gemini/Codex/Copilot have no `Task` tool).
- **test**: block `Task` alongside `Agent`; assertions updated to the new wording.

Note: this is the first of two parts of "use delegates, not agents". The second (the roundtable/ensemble panel running through the async delegate system instead of in-process `agent_run_*`) is a separate, larger change.
