### PR TITLE
Run the ensemble panel + aggregator through a delegate core

### DIFF
--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -56,6 +56,9 @@ typedef struct
    int question_count;
    int (*cancel_requested)(void *ctx);
    void *cancel_ctx;
+   /* Originating session: panel + aggregator runs fold their cost onto it via
+    * db1_cost_fold_record, so the ensemble is accounted like a delegate. */
+   const char *parent_session_id;
 } roundtable_opts_t;
 
 typedef struct

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -8,6 +8,10 @@
 #include "aimee.h"
 #include "delegate_ensemble.h"
 #include "agent_exec.h"
+#include "agent_config.h"
+#include "config.h"
+#include "delegate_credentials.h"
+#include "cost_fold.h"
 #include "log.h"
 #include "token_tracker.h"
 
@@ -142,6 +146,69 @@ static double estimate_cost(const agent_config_t *acfg, const agent_result_t *re
    for (int i = 0; i < count; i++)
       total += result_token_cost(acfg, &results[i], fallback_agents ? fallback_agents[i] : NULL);
    return total;
+}
+
+/* Originating session of the in-flight roundtable, set at delegate_roundtable_run
+ * entry. Read by the delegate-run core + panel cost-fold so each model call is
+ * accounted onto the caller's session like a delegate. */
+static _Thread_local const char *g_rt_parent_sid = NULL;
+
+/* Fold a completed panel/aggregator run's cost onto the originating session, the
+ * same accounting a real delegate does. No-op without a parent session or a
+ * billable result. */
+static void ensemble_fold_cost(const agent_config_t *acfg, const agent_result_t *r,
+                               const char *fallback_agent)
+{
+   if (!g_rt_parent_sid || !g_rt_parent_sid[0] || !r || !r->success)
+      return;
+   double cost = result_token_cost(acfg, r, fallback_agent);
+   if (cost > 0.0)
+      (void)db1_cost_fold_record(g_rt_parent_sid, "ensemble", cost, "ensemble");
+}
+
+/* Synchronous delegate run: the delegate economics core — a credential lease for
+ * agents with a server-side pool, plus cost-fold accounting — wrapped around a
+ * no-tools agent run. The ensemble dispatches its aggregator (and any serial
+ * participant) through this so the work runs as a delegate rather than a raw
+ * in-process agent call. delegate_worker stays the async-job path; this is its
+ * synchronous sibling. A non-empty name routes by name; NULL routes by role. */
+static int delegate_run_inline(agent_config_t *acfg, const char *agent_name, const char *role,
+                               const char *system_prompt, const char *user_prompt, int max_tokens,
+                               double temperature, agent_result_t *out)
+{
+   agent_t *ag = (agent_name && agent_name[0]) ? agent_find(acfg, agent_name) : NULL;
+   char leased_cred[MAX_CRED_NAME_LEN] = "";
+   int leased = 0;
+   /* Client-held-credential agents (the usual panel) have no pool, so this is
+    * skipped and keys resolve from the session keyring as before; a pooled agent
+    * leases one credential for the call, exactly like delegate_worker. */
+   if (ag && ag->credential_count > 0)
+   {
+      char leased_env[MAX_CRED_ENV_VAR_LEN] = "";
+      char state_path[MAX_PATH_LEN];
+      const char *dir = config_output_dir();
+      snprintf(state_path, sizeof(state_path), "%s/delegate-credential-state.tsv",
+               dir ? dir : "/tmp");
+      (void)delegate_credentials_load_file(state_path, time(NULL));
+      if (delegate_credentials_acquire(NULL, ag->name, ag->credentials, ag->credential_count,
+                                       leased_cred, sizeof(leased_cred), leased_env,
+                                       sizeof(leased_env)) == 0)
+      {
+         const char *v = getenv(leased_env);
+         if (v && v[0])
+            snprintf(ag->api_key, MAX_API_KEY_LEN, "%s", v);
+         leased = 1;
+      }
+   }
+   int rc =
+       (agent_name && agent_name[0])
+           ? agent_run_named(acfg, agent_name, role, system_prompt, user_prompt, max_tokens,
+                             temperature, out)
+           : agent_run_ex(acfg, role, system_prompt, user_prompt, max_tokens, temperature, out);
+   ensemble_fold_cost(acfg, out, agent_name);
+   if (leased && ag)
+      delegate_credentials_release(NULL, ag->name, leased_cred);
+   return rc;
 }
 
 static long monotonic_ms(void)
@@ -403,11 +470,11 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
       /* max_tokens 0 = derive from the aggregator model's own output ceiling, so
        * a reasoning aggregator isn't truncated mid-synthesis (was a hard 4096). */
       if (!at)
-         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
+         return delegate_run_inline(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
       const char *role = (at[1]) ? at + 1 : "review";
-      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 0, 0.3, out);
+      return delegate_run_inline(&agg_cfg, NULL, role, NULL, synthesis_prompt, 0, 0.3, out);
    }
-   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 0, 0.3, out);
+   return delegate_run_inline(&agg_cfg, NULL, "review", NULL, synthesis_prompt, 0, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,
@@ -985,6 +1052,9 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
       tasks[i].max_tokens = 0;
    }
    agent_run_parallel(acfg, tasks, ref_count, results);
+   /* Account each participant's run onto the originating session, like a delegate. */
+   for (int i = 0; i < ref_count; i++)
+      ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
    for (int i = 0; i < ref_count; i++)
       free(prompts[i]);
    return 0;
@@ -1061,6 +1131,9 @@ int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char 
    memset(results, 0, sizeof(results));
 
    agent_run_parallel(acfg, tasks, ref_count, results);
+   /* Account each participant's run onto the originating session, like a delegate. */
+   for (int i = 0; i < ref_count; i++)
+      ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
 
    double cost = estimate_cost(acfg, results, cfg->ensemble_reference_models, ref_count);
    out->cost_usd = cost;
@@ -1169,6 +1242,12 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       local.converge_threshold = 10;
    if (local.brief_truncated)
       out->truncated = 1;
+
+   /* Bind the originating session for this thread so panel + aggregator runs fold
+    * their cost onto it. Set unconditionally on every entry (NULL when there's no
+    * parent), so a reused worker thread can't inherit a prior turn's session; it's
+    * only read while this call runs the panel/aggregator on this same thread. */
+   g_rt_parent_sid = local.parent_session_id;
 
    long start_ms = monotonic_ms();
    char *artifact = xstrdup0("");

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1886,6 +1886,7 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    opts.max_rounds = cfg.roundtable_max_rounds > 0 ? cfg.roundtable_max_rounds : 3;
    opts.converge_threshold = cfg.roundtable_converge_threshold;
    opts.deadline_ms = cfg.roundtable_deadline_ms;
+   opts.parent_session_id = compute_request_session_id(req); /* fold panel cost onto it */
    cJSON *jrun = cJSON_GetObjectItemCaseSensitive(req, "__run_id");
    if (cJSON_IsString(jrun) && jrun->valuestring && jrun->valuestring[0])
    {
@@ -1901,7 +1902,6 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    opts.brief_truncated = brief.truncated;
    opts.questions = brief.question_ptrs;
    opts.question_count = brief.question_count;
-
    cJSON *jmode = cJSON_GetObjectItemCaseSensitive(req, "mode");
    if (cJSON_IsString(jmode) && strcmp(jmode->valuestring, "review") == 0)
       opts.mode = ROUNDTABLE_REVIEW;

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -215,6 +215,58 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
    return 0;
 }
 
+/* Stubs for the delegate-run core's economics deps. agent_find returns NULL so
+ * the (server-side cred pool) lease path is skipped — the panel agents are
+ * client-held and have no pool — and the run falls through to the agent_run
+ * stubs above; cost-fold is a no-op in the test (no parent session bound). */
+agent_t *agent_find(agent_config_t *cfg, const char *name)
+{
+   (void)cfg;
+   (void)name;
+   return NULL;
+}
+static int g_cost_fold_calls = 0;
+static double g_cost_fold_total = 0.0;
+int db1_cost_fold_record(const char *parent_sid, const char *child_sid, double cost,
+                         const char *source)
+{
+   (void)child_sid;
+   (void)source;
+   if (parent_sid && parent_sid[0])
+   {
+      g_cost_fold_calls++;
+      g_cost_fold_total += cost;
+   }
+   return 0;
+}
+int delegate_credentials_load_file(const char *path, time_t now_epoch)
+{
+   (void)path;
+   (void)now_epoch;
+   return 0;
+}
+int delegate_credentials_acquire(const char *principal, const char *agent_name,
+                                 const agent_credential_t *creds, int count, char *cred_name,
+                                 size_t cred_name_sz, char *env, size_t env_sz)
+{
+   (void)principal;
+   (void)agent_name;
+   (void)creds;
+   (void)count;
+   (void)cred_name;
+   (void)cred_name_sz;
+   (void)env;
+   (void)env_sz;
+   return -1;
+}
+void delegate_credentials_release(const char *principal, const char *agent_name,
+                                  const char *cred_name)
+{
+   (void)principal;
+   (void)agent_name;
+   (void)cred_name;
+}
+
 int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
                                        const char *system_prompt, const char *user_prompt,
                                        int max_tokens, int enforce_writes, agent_result_t *out)
@@ -474,6 +526,43 @@ static void test_roundtable_parallel_basic(void)
    assert(g_parallel_calls == 2);
    delegate_roundtable_result_free(&result);
    printf("  test_roundtable_parallel_basic: ok\n");
+}
+
+/* The ensemble runs through the delegate path: each billable panel + aggregator
+ * run folds its cost onto the originating session (db1_cost_fold_record), and
+ * only when a parent session is set. */
+static void test_roundtable_folds_cost_to_parent_session(void)
+{
+   reset_modes();
+   g_cost_fold_calls = 0;
+   g_cost_fold_total = 0.0;
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   opts.parent_session_id = "parent-sess";
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "draft a short proposal", &opts, &result);
+   assert(rc == 0);
+   /* >= 2 panel participants + the aggregator all folded onto the parent. */
+   assert(g_cost_fold_calls >= 3);
+   assert(g_cost_fold_total > 0.0);
+   delegate_roundtable_result_free(&result);
+
+   /* No parent session -> no fold (the other tests run with parent unset). */
+   g_cost_fold_calls = 0;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   rc = delegate_roundtable_run(&acfg, &cfg, "draft again", &opts, &result);
+   assert(rc == 0);
+   assert(g_cost_fold_calls == 0);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_folds_cost_to_parent_session: ok\n");
 }
 
 static void test_roundtable_sequential_uses_named_agents(void)
@@ -893,6 +982,7 @@ int main(void)
    test_ensemble_min_successful_degradation();
    test_ensemble_routes_to_distinct_agents();
    test_roundtable_parallel_basic();
+   test_roundtable_folds_cost_to_parent_session();
    test_roundtable_sequential_uses_named_agents();
    test_roundtable_degrades_on_min_success();
    test_roundtable_preflight_cap_warns_observed_cap_stops();


### PR DESCRIPTION
## Why

The roundtable/ensemble ran its panel + aggregator via raw in-process `agent_run_*` calls, bypassing the delegate machinery — so that work wasn't accounted like a delegate (no cost-fold onto the originating session), and a pooled agent wouldn't lease a credential the way `delegate_worker` does. Part two of "use delegates, not agents" (part one, #239, blocked the host AI's `Task` tool).

## What

- **`delegate_run_inline`** — the synchronous sibling of `delegate_worker`'s core: resolve the agent → lease one credential for agents with a server-side pool (a **no-op** for the client-held panel agents, whose keys resolve from the session keyring as before) → run no-tools → fold the run's cost onto the originating session (`db1_cost_fold_record`).
- The **aggregator** dispatches through it; every **panel participant** is folded the same way after the parallel fan-out (functionally identical to per-call dispatch for the client-held panel, where the lease is a no-op).
- Originating session carried on `roundtable_opts_t.parent_session_id` (set by the handler), bound to a thread-local for the run.

`delegate_worker` stays the async-job delegate path; fully unifying it onto this same core (one dispatch) is a follow-up.

## Tests

A roundtable with a parent session folds each panel participant + the aggregator onto it; none folds when no parent session is set. Server build + delegate-ensemble suite green.
