### PR TITLE
Promote: delegates-not-agents (#239, #240) + WP-C.3 + remote_writes fix

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -109,6 +109,17 @@ ENV AIMEE_HOME=/var/lib/aimee
 # loopback HTTP via AIMEE_KB_API_URL. The entrypoint owns the kb lifecycle; the
 # server no longer autostarts a kb (that socket transport was retired, #2747).
 ENV AIMEE_SERVER_HTTP_BIND=1
+# This combined all-in-one is the trusted-network dogfood image: it binds /v1 on
+# 0.0.0.0 specifically so a thin client drives it remotely — including delegates,
+# roundtables and tools (the headline workflow). Those routes are gated behind
+# aimee.api.remote_writes=full, so set it here as deploy truth. Without it a fresh
+# (re)deploy seeds remote_writes="off" (first-start-only seed in the entrypoint)
+# and the network bearer silently loses CAP_DELEGATE — delegate/tool /v1 calls
+# 403. The env applies on EVERY start regardless of the seeded/mounted aimee.yaml
+# (config_server_api.c), so it survives the wipe-and-reinstall redeploy path.
+# Trusted networks only (this image ships a known dev bearer); override to
+# `off`/`data` (and set your own bearer + TLS) for any exposed deployment.
+ENV AIMEE_API_REMOTE_WRITES=full
 ENV AIMEE_KB_API_URL=http://127.0.0.1:8741
 ENV AIMEE_DB1_URL=sqlite:///var/lib/aimee/aimee.db
 # kb: bind its /v1 on 0.0.0.0 (so it can optionally be published for inspection)

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -99,6 +99,15 @@ ENV AIMEE_HOME=/var/lib/aimee
 # published container port reaches it. The bearer token in the baked aimee.yaml
 # is still required on every request.
 ENV AIMEE_SERVER_HTTP_BIND=1
+# Since this image binds /v1 on 0.0.0.0 for a remote thin client to drive it —
+# including delegates, roundtables and tools — permit those routes over TCP by
+# default (they are gated behind aimee.api.remote_writes=full in
+# server_http_route_allowed). Applied on EVERY start regardless of the
+# seeded/mounted aimee.yaml (config_server_api.c), so a fresh/wiped redeploy can't
+# silently reseed "off" and drop CAP_DELEGATE (delegate/tool 403). This image
+# ships a known dev bearer and is trusted-network only; override to off/data (and
+# set your own bearer + TLS) for any exposed deployment.
+ENV AIMEE_API_REMOTE_WRITES=full
 # Standalone by default: no kb configured. Point AIMEE_KB_API_URL at a running
 # aimee-kb (e.g. http://aimee-kb:8741) to enable the shared/vector features.
 # Mirror tier (workspace-resource-plane §3): the per-workspace bare mirrors +

--- a/configure-hooks.sh
+++ b/configure-hooks.sh
@@ -175,7 +175,7 @@ if [ -d "$HOME_DIR/.claude" ] || command -v claude &>/dev/null; then
     configure_json_hooks "Claude Code" \
         "$CLAUDE_SETTINGS" \
         "PreToolUse" "PostToolUse" "SessionStart" \
-        "Edit|Write|MultiEdit|Bash|Read|Glob|Grep" "Edit|Write|MultiEdit" \
+        "Edit|Write|MultiEdit|Bash|Read|Glob|Grep|Task" "Edit|Write|MultiEdit" \
         "$CLAUDE_SETTINGS" "claude"
 
     # Ensure Gemini is in the auto-allow list if permissions are already set

--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -17,11 +17,15 @@ aimee:
     http_port: 8740
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
-    # port a bearer is read/query/chat only. Opt into remote writes here:
+    # This combined all-in-one binds /v1 on 0.0.0.0 so a thin client drives it
+    # remotely, including delegates/roundtables/tools — which require
+    # remote_writes="full". The image also forces this via AIMEE_API_REMOTE_WRITES
+    # (Dockerfile.combined) so it survives a fresh redeploy that reseeds this file.
+    # Trusted networks only (this ships a known dev bearer); for any exposed
+    # deployment set your own bearer + TLS and lower this:
     #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
-    #   remote_writes: full   # + delegate/tool over /v1/rpc — trusted nets only
-    remote_writes: "off"
+    #   remote_writes: "off"  # TCP bearer is read/query/chat only
+    remote_writes: "full"
 
 # --- kb: real semantic embeddings via the persistent embedder service ---
 embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"

--- a/deploy/container/aimee-server.yaml
+++ b/deploy/container/aimee-server.yaml
@@ -15,9 +15,13 @@ aimee:
     http_port: 8740
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # Mutating /v1 routes are local-UDS-only by default; over the published TCP
-    # port a bearer is read/query/chat only. Opt into remote writes here:
+    # This image binds /v1 on 0.0.0.0 so a thin client drives it remotely,
+    # including delegates/roundtables/tools — which require remote_writes="full".
+    # The image also forces this via AIMEE_API_REMOTE_WRITES (Dockerfile.server) so
+    # it survives a fresh redeploy that reseeds this file. Trusted networks only
+    # (ships a known dev bearer); for any exposed deployment set your own bearer +
+    # TLS and lower this:
     #   remote_writes: data   # data writes (memory/work/rules/skill), cap-gated
-    #   remote_writes: full   # + delegate/tool over /v1/rpc (CAPS_ALL) — trusted nets only
-    remote_writes: "off"
+    #   remote_writes: "off"  # TCP bearer is read/query/chat only
+    remote_writes: "full"
 

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -746,9 +746,9 @@ static void emit_pretool_rewrite_unsupported_json(int rewrite_rc, const char *re
  * These must never escape the session guardrails. */
 static int client_tool_is_subagent(const char *tool_name)
 {
-   return tool_name &&
-          (strcmp(tool_name, "Agent") == 0 || strcmp(tool_name, "spawn_agent") == 0 ||
-           strcmp(tool_name, "RemoteTrigger") == 0 || strcmp(tool_name, "Subagent") == 0);
+   return tool_name && (strcmp(tool_name, "Agent") == 0 || strcmp(tool_name, "spawn_agent") == 0 ||
+                        strcmp(tool_name, "RemoteTrigger") == 0 ||
+                        strcmp(tool_name, "Subagent") == 0 || strcmp(tool_name, "Task") == 0);
 }
 
 /* Fail-closed guard for the pre-hook's fail-open paths: the server normally

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -136,7 +136,7 @@ const char *guardrails_canonical_tool_name(const char *tool_name)
    if (strcmp(tool_name, "grep") == 0 || strcmp(tool_name, "Grep") == 0)
       return "Grep";
    if (strcmp(tool_name, "Agent") == 0 || strcmp(tool_name, "spawn_agent") == 0 ||
-       strcmp(tool_name, "RemoteTrigger") == 0)
+       strcmp(tool_name, "RemoteTrigger") == 0 || strcmp(tool_name, "Task") == 0)
       return "Subagent";
 
    return tool_name;
@@ -1593,10 +1593,11 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
    if (is_subagent_tool(tool_name))
    {
       snprintf(msg_buf, msg_len,
-               "BLOCKED: provider-native sub-agent tools such as spawn_agent or Agent "
-               "are outside aimee's primary-agent guardrail model. Use the aimee "
-               "delegate MCP tool or `aimee delegate <role> \"<task>\"` so the child "
-               "inherits the current session guardrails.");
+               "BLOCKED: sub-agent tools (Task, Agent, spawn_agent, …) are outside aimee's "
+               "guardrail model. Delegate instead: `aimee delegate <role> \"<task>\" "
+               "--persona <persona>`, or `aimee delegate roundtable \"<task>\" --mode review` "
+               "for a multi-model panel. aimee delegates run on the cheapest capable model, are "
+               "cost-tracked, see the shared memory + KB, and inherit this session's guardrails.");
       audit_log("subagent_blocked",
                 "provider sub-agent tool blocked — keep delegation inside aimee");
       cJSON_Delete(root);

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -41,6 +41,10 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len);
  * NULL/empty to clear. Thread-local (each turn runs on its own worker thread). */
 void agent_set_request_codex_creds(const char *token, const char *account_id);
 
+/* 1 when a per-turn Codex OAuth token is currently bound (a fresh client push).
+ * WP-C.3: the vault-backed codex override defers to a live client push. */
+int agent_request_codex_token_present(void);
+
 /* Per-turn session id for the session-scoped credential keyring lookup (see
  * session_credentials.h). Set at the start of a chat/delegate turn from the
  * request, cleared (NULL/empty) otherwise. When set, agent_resolve_auth prefers

--- a/src/headers/delegate_credential_retry.h
+++ b/src/headers/delegate_credential_retry.h
@@ -6,6 +6,28 @@
 #include "aimee.h"
 #include "agent_types.h"
 
+/* Result of resolving a delegate's credential before the run (WP-C.1 vault-first,
+ * WP-C.3 per-principal cooldown). The caller maps a non-OK status to a delegate
+ * error; on OK it proceeds with target_agent->api_key set (vault or env hit) and
+ * the named pool row to release on exit. */
+typedef enum
+{
+   DELEGATE_CRED_RESOLVE_OK = 0,    /* proceed (api_key set, or no pool/vault) */
+   DELEGATE_CRED_RESOLVE_LOCKED,    /* vault entry exists but is locked */
+   DELEGATE_CRED_RESOLVE_COOLING,   /* vaulted cred is rate-limited (see cooldown_secs) */
+   DELEGATE_CRED_RESOLVE_POOL_EMPTY /* env pool configured but all leased/cooling */
+} delegate_cred_resolve_status_t;
+
+/* Resolve the credential for one delegate run. Restores persisted health, then:
+ * vault-FIRST for `vault_principal` (a 429-cooling vaulted cred returns COOLING),
+ * else leases from the agent's env pool. Writes target_agent->api_key on a hit,
+ * names the (principal,agent,cred) row to release in leased_principal/_cred_name,
+ * and fills credential_state_path. cooldown_secs is set for COOLING. */
+delegate_cred_resolve_status_t delegate_resolve_credentials(
+    const char *vault_principal, agent_t *target_agent, char *leased_principal,
+    size_t leased_principal_cap, char *leased_cred_name, size_t leased_cred_name_cap,
+    char *credential_state_path, size_t credential_state_path_cap, int *cooldown_secs);
+
 int delegate_run_with_credential_retry(agent_config_t *cfg, agent_t *agent, const char *role,
                                        const char *system_prompt, const char *run_prompt,
                                        int max_tokens, int force_tools, int enforce_writes,

--- a/src/headers/delegate_credentials.h
+++ b/src/headers/delegate_credentials.h
@@ -8,7 +8,14 @@
  *
  * Process-global lease state, mutex-protected. Empty agent.credentials
  * (the default) is treated as "no pool — fall through to api_key", so
- * existing single-token agents are unaffected. */
+ * existing single-token agents are unaffected.
+ *
+ * WP-C.3: every row is keyed by (principal, agent, cred). The shared
+ * agents.json env-var pool uses an EMPTY principal ("") — a 429 there is
+ * global and cools the credential for everyone, exactly as before. A
+ * per-principal VAULT credential passes its `uid:`/`webuser:` principal, so
+ * one principal's 429-cooldown and health are isolated from another's even
+ * when they vault the same agent. A NULL principal is normalised to "". */
 #ifndef DEC_DELEGATE_CREDENTIALS_H
 #define DEC_DELEGATE_CREDENTIALS_H 1
 
@@ -18,6 +25,7 @@
 #include "aimee.h" /* MAX_PATH_LEN — agent_types.h uses it without including */
 #include "agent_types.h"
 #include "failover.h"
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX — pool rows are keyed by principal */
 
 #ifdef __cplusplus
 extern "C"
@@ -34,18 +42,29 @@ extern "C"
     * returns -1 with credential_count == 0; an error return with
     * credential_count > 0 means every credential is in use or cooling
     * and the caller should retry after a backoff. */
-   int delegate_credentials_acquire(const char *agent_name, const agent_credential_t *creds,
-                                    int credential_count, char *out_name, size_t out_name_cap,
-                                    char *out_env_var, size_t out_env_var_cap);
+   int delegate_credentials_acquire(const char *principal, const char *agent_name,
+                                    const agent_credential_t *creds, int credential_count,
+                                    char *out_name, size_t out_name_cap, char *out_env_var,
+                                    size_t out_env_var_cap);
 
    /* Release a previously-acquired lease so siblings can pick it up.
-    * No-op for unknown (agent_name, cred_name) pairs. */
-   void delegate_credentials_release(const char *agent_name, const char *cred_name);
+    * No-op for unknown (principal, agent_name, cred_name) rows. */
+   void delegate_credentials_release(const char *principal, const char *agent_name,
+                                     const char *cred_name);
 
    /* Mark a credential as cooling for `seconds` seconds. Used after a 429
     * so siblings skip the entry until the cooldown elapses. The
     * credential remains leased until the caller also calls _release. */
-   void delegate_credentials_cooldown(const char *agent_name, const char *cred_name, int seconds);
+   void delegate_credentials_cooldown(const char *principal, const char *agent_name,
+                                      const char *cred_name, int seconds);
+
+   /* Read-only: seconds remaining on the (principal, agent, cred) cooldown, or 0
+    * if the credential is unknown or not cooling. The vault use-path consults
+    * this to apply per-principal 429 backpressure to a single vaulted credential
+    * without taking an exclusive lease (a user's own key may be used by their
+    * concurrent delegates). Creates no row. */
+   int delegate_credentials_cooldown_remaining(const char *principal, const char *agent_name,
+                                               const char *cred_name, time_t now_epoch);
 
    /* Default cooldown applied when a delegate run fails with a rate-
     * limit / 429 / overloaded error and a credential lease was held.
@@ -105,14 +124,15 @@ extern "C"
    /* Parse provider x-ratelimit-* response headers for the acting credential.
     * raw_headers is a CRLF/LF-separated header block. Reset values are relative
     * seconds and are stored as absolute epoch seconds using now_epoch. */
-   int delegate_credentials_capture_headers(const char *agent_name, const char *cred_name,
-                                            const char *raw_headers, time_t now_epoch);
+   int delegate_credentials_capture_headers(const char *principal, const char *agent_name,
+                                            const char *cred_name, const char *raw_headers,
+                                            time_t now_epoch);
 
    /* Mark a credential according to the failover classifier. Returns 1 when
     * the reason changed credential health, 0 for unrelated reasons. */
-   int delegate_credentials_report_failure(const char *agent_name, const char *cred_name,
-                                           failover_reason_t reason, const char *error,
-                                           time_t now_epoch);
+   int delegate_credentials_report_failure(const char *principal, const char *agent_name,
+                                           const char *cred_name, failover_reason_t reason,
+                                           const char *error, time_t now_epoch);
 
    failover_reason_t delegate_credentials_classify_failure(const char *provider, const char *error);
 
@@ -120,12 +140,19 @@ extern "C"
     * the next available member from the same pool. Returns 1 when a new
     * credential was leased, 0 when the error is not pool-rotatable or no
     * member is available, and -1 for invalid arguments. On rotatable failures
-    * the old lease is always released, even when no replacement is available. */
-   int delegate_credentials_rotate_after_failure(
-       const char *agent_name, const agent_credential_t *creds, int credential_count,
-       const char *provider, char *leased_cred_name, size_t leased_cred_name_cap, char *out_env_var,
-       size_t out_env_var_cap, const char *error, time_t now_epoch);
+    * the old lease is always released, even when no replacement is available.
+    * Env-pool rotation only — callers pass the shared "" principal. */
+   int delegate_credentials_rotate_after_failure(const char *principal, const char *agent_name,
+                                                 const agent_credential_t *creds,
+                                                 int credential_count, const char *provider,
+                                                 char *leased_cred_name,
+                                                 size_t leased_cred_name_cap, char *out_env_var,
+                                                 size_t out_env_var_cap, const char *error,
+                                                 time_t now_epoch);
 
+   /* Operator-facing health snapshot of the SHARED env pool (principal == "").
+    * Per-principal vault rows are intentionally not surfaced here (they are
+    * per-user, not operator-configured). */
    int delegate_credentials_snapshot(const char *agent_name, delegate_credential_snapshot_t *out,
                                      int max);
 

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -56,6 +56,9 @@ typedef struct
    int question_count;
    int (*cancel_requested)(void *ctx);
    void *cancel_ctx;
+   /* Originating session: panel + aggregator runs fold their cost onto it via
+    * db1_cost_fold_record, so the ensemble is accounted like a delegate. */
+   const char *parent_session_id;
 } roundtable_opts_t;
 
 typedef struct

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -86,6 +86,15 @@ vault_status_t vault_service_delete(const char *principal, const char *agent, co
 /* Lock the principal's vault: evict its cached KEK (the `vault lock` path). */
 vault_status_t vault_service_lock(const char *principal);
 
+/* The canonical credential name for an agent's primary key in the vault store
+ * and in the delegate-credential cooldown pool (WP-C.3). */
+#define VAULT_API_KEY_CRED "api_key"
+
+/* WP-C.3 codex-oauth: a principal may vault their Codex OAuth token + account id
+ * under these names; a vaulted token overrides the on-disk/session token. */
+#define VAULT_CODEX_TOKEN_CRED   "codex_oauth_token"
+#define VAULT_CODEX_ACCOUNT_CRED "codex_account_id"
+
 /* Delegate use-path helper: if `principal` has a vaulted "api_key" credential for
  * `agent`, decrypt it and overwrite `api_key` (capacity api_key_len). On any
  * non-OK status `api_key` is left UNTOUCHED (so a config/env key survives a

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -274,6 +274,11 @@ void agent_set_request_codex_creds(const char *token, const char *account_id)
       g_request_codex_account_id[0] = '\0';
 }
 
+int agent_request_codex_token_present(void)
+{
+   return g_request_codex_token[0] != '\0';
+}
+
 void agent_request_creds_snapshot(agent_request_creds_t *out)
 {
    if (!out)

--- a/src/server/delegate_credential_retry.c
+++ b/src/server/delegate_credential_retry.c
@@ -2,13 +2,107 @@
 
 #include "delegate_credential_retry.h"
 
+#include "agent_config.h" /* agent_set_request_codex_creds, *_token_present */
 #include "agent_exec.h"
+#include "config.h" /* config_output_dir */
 #include "delegate_credentials.h"
+#include "vault_service.h" /* vault_service_inject_api_key, VAULT_*_CRED */
 
+#include <openssl/crypto.h> /* OPENSSL_cleanse */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+
+/* WP-C.3 codex-oauth migration: if `principal` has a vaulted Codex OAuth token for
+ * `agent`, bind it as this turn's token so it OVERRIDES the on-disk/session token.
+ * A fresh per-turn client push still wins (we defer when one is already bound).
+ * The transient plaintext is cleansed; lifetime mirrors the existing per-turn
+ * codex token (overwritten by the next turn's bind on this worker thread). */
+static void codex_oauth_apply_vault_override(const char *principal, const agent_t *target_agent)
+{
+   if (!principal || !principal[0] || !target_agent)
+      return;
+   if (strcmp(target_agent->auth_type, "codex-oauth") != 0)
+      return;
+   if (agent_request_codex_token_present())
+      return; /* a live client push is authoritative */
+   char tok[MAX_API_KEY_LEN];
+   if (vault_service_get(principal, target_agent->name, VAULT_CODEX_TOKEN_CRED, tok, sizeof(tok),
+                         time(NULL)) != VAULT_OK)
+      return;
+   char acct[128] = "";
+   (void)vault_service_get(principal, target_agent->name, VAULT_CODEX_ACCOUNT_CRED, acct,
+                           sizeof(acct), time(NULL));
+   agent_set_request_codex_creds(tok, acct[0] ? acct : NULL);
+   OPENSSL_cleanse(tok, sizeof(tok));
+   OPENSSL_cleanse(acct, sizeof(acct));
+}
+
+delegate_cred_resolve_status_t delegate_resolve_credentials(
+    const char *vault_principal, agent_t *target_agent, char *leased_principal,
+    size_t leased_principal_cap, char *leased_cred_name, size_t leased_cred_name_cap,
+    char *credential_state_path, size_t credential_state_path_cap, int *cooldown_secs)
+{
+   if (cooldown_secs)
+      *cooldown_secs = 0;
+   if (!target_agent)
+      return DELEGATE_CRED_RESOLVE_OK;
+
+   /* Restore persisted per-credential cooldown/health (shared env pool AND
+    * per-principal vault rows) before consulting either path. */
+   const char *dir = config_output_dir();
+   snprintf(credential_state_path, credential_state_path_cap, "%s/delegate-credential-state.tsv",
+            dir ? dir : "/tmp");
+   (void)delegate_credentials_load_file(credential_state_path, time(NULL));
+
+   /* WP-C.1 vault-FIRST (D14/D15): a vaulted cred beats the env lease; LOCKED
+    * fails the run; a miss falls through to the env pool. */
+   if (vault_principal && vault_principal[0])
+   {
+      /* WP-C.3 per-principal 429 backpressure: a vaulted cred is a single key (no
+       * round-robin / exclusive lease — a user's own key may serve their
+       * concurrent delegates), but a prior 429 cools it for THIS principal only. */
+      int cooling = delegate_credentials_cooldown_remaining(vault_principal, target_agent->name,
+                                                            VAULT_API_KEY_CRED, time(NULL));
+      if (cooling > 0)
+      {
+         if (cooldown_secs)
+            *cooldown_secs = cooling;
+         return DELEGATE_CRED_RESOLVE_COOLING;
+      }
+      vault_status_t vst = vault_service_inject_api_key(
+          vault_principal, target_agent->name, target_agent->api_key, MAX_API_KEY_LEN, time(NULL));
+      if (vst == VAULT_ERR_LOCKED)
+         return DELEGATE_CRED_RESOLVE_LOCKED;
+      if (vst == VAULT_OK)
+      {
+         /* Key the failure/cooldown row by (principal, agent, "api_key"). No
+          * exclusive lease is taken, so release on exit is a harmless no-op. */
+         snprintf(leased_principal, leased_principal_cap, "%s", vault_principal);
+         snprintf(leased_cred_name, leased_cred_name_cap, "%s", VAULT_API_KEY_CRED);
+         return DELEGATE_CRED_RESOLVE_OK;
+      }
+      /* miss -> codex override / env pool below */
+   }
+
+   /* WP-C.3 codex-oauth: a vaulted token overrides the on-disk/session token. */
+   codex_oauth_apply_vault_override(vault_principal, target_agent);
+
+   /* Lease one credential from the shared env pool (principal ""), if configured. */
+   if (target_agent->credential_count > 0)
+   {
+      char leased_env[MAX_CRED_ENV_VAR_LEN] = "";
+      if (delegate_credentials_acquire("", target_agent->name, target_agent->credentials,
+                                       target_agent->credential_count, leased_cred_name,
+                                       leased_cred_name_cap, leased_env, sizeof(leased_env)) != 0)
+         return DELEGATE_CRED_RESOLVE_POOL_EMPTY;
+      const char *value = getenv(leased_env);
+      if (value && value[0])
+         snprintf(target_agent->api_key, MAX_API_KEY_LEN, "%s", value);
+   }
+   return DELEGATE_CRED_RESOLVE_OK;
+}
 
 static int run_delegate_attempt(agent_config_t *cfg, const char *role, const char *system_prompt,
                                 const char *run_prompt, int max_tokens, int force_tools,
@@ -55,8 +149,9 @@ int delegate_run_with_credential_retry(agent_config_t *cfg, agent_t *agent, cons
    {
       agent_result_t prior = *result;
       char next_env[MAX_CRED_ENV_VAR_LEN] = "";
+      /* Env-pool rotation only (credential_count > 1); the shared "" principal. */
       int rotated = delegate_credentials_rotate_after_failure(
-          agent->name, agent->credentials, agent->credential_count, agent->provider,
+          "", agent->name, agent->credentials, agent->credential_count, agent->provider,
           leased_cred_name, leased_cred_name_cap, next_env, sizeof(next_env), result->error,
           time(NULL));
       if (rotated != 1)

--- a/src/server/delegate_credentials.c
+++ b/src/server/delegate_credentials.c
@@ -14,6 +14,7 @@
 
 typedef struct
 {
+   char principal[VAULT_PRINCIPAL_MAX]; /* "" = shared env pool; uid:/webuser: = vault */
    char agent_name[MAX_AGENT_NAME];
    char cred_name[MAX_CRED_NAME_LEN];
    int leased;                  /* 1 = currently leased */
@@ -45,15 +46,22 @@ static time_t now_epoch_seconds(void)
    return now > 0 ? now : 0;
 }
 
-/* Caller holds g_mu. Locate or create the per-(agent, cred) row. */
-static cred_lease_state_t *find_or_create_locked(const char *agent_name, const char *cred_name,
-                                                 int *allocation_failed)
+/* NULL principal is normalised to the shared "" pool. */
+static const char *pr_norm(const char *principal)
 {
+   return (principal && principal[0]) ? principal : "";
+}
+
+/* Caller holds g_mu. Locate or create the per-(principal, agent, cred) row. */
+static cred_lease_state_t *find_or_create_locked(const char *principal, const char *agent_name,
+                                                 const char *cred_name, int *allocation_failed)
+{
+   const char *pr = pr_norm(principal);
    if (allocation_failed)
       *allocation_failed = 0;
    for (int i = 0; i < g_state_count; i++)
    {
-      if (strcmp(g_state[i].agent_name, agent_name) == 0 &&
+      if (strcmp(g_state[i].principal, pr) == 0 && strcmp(g_state[i].agent_name, agent_name) == 0 &&
           strcmp(g_state[i].cred_name, cred_name) == 0)
          return &g_state[i];
    }
@@ -73,6 +81,7 @@ static cred_lease_state_t *find_or_create_locked(const char *agent_name, const c
    }
    cred_lease_state_t *slot = &g_state[g_state_count++];
    memset(slot, 0, sizeof(*slot));
+   snprintf(slot->principal, sizeof(slot->principal), "%s", pr);
    snprintf(slot->agent_name, sizeof(slot->agent_name), "%s", agent_name);
    snprintf(slot->cred_name, sizeof(slot->cred_name), "%s", cred_name);
    slot->status = DELEGATE_CRED_STATUS_OK;
@@ -123,9 +132,10 @@ static long long state_headroom(const cred_lease_state_t *slot)
    return best;
 }
 
-int delegate_credentials_acquire(const char *agent_name, const agent_credential_t *creds,
-                                 int credential_count, char *out_name, size_t out_name_cap,
-                                 char *out_env_var, size_t out_env_var_cap)
+int delegate_credentials_acquire(const char *principal, const char *agent_name,
+                                 const agent_credential_t *creds, int credential_count,
+                                 char *out_name, size_t out_name_cap, char *out_env_var,
+                                 size_t out_env_var_cap)
 {
    if (!agent_name || !agent_name[0] || !creds || credential_count <= 0)
       return -1;
@@ -145,7 +155,8 @@ int delegate_credentials_acquire(const char *agent_name, const agent_credential_
       if (!cred->name[0])
          continue;
       int allocation_failed = 0;
-      cred_lease_state_t *slot = find_or_create_locked(agent_name, cred->name, &allocation_failed);
+      cred_lease_state_t *slot =
+          find_or_create_locked(principal, agent_name, cred->name, &allocation_failed);
       if (allocation_failed)
          break;
       if (!slot)
@@ -174,14 +185,16 @@ int delegate_credentials_acquire(const char *agent_name, const agent_credential_
    return -1;
 }
 
-void delegate_credentials_release(const char *agent_name, const char *cred_name)
+void delegate_credentials_release(const char *principal, const char *agent_name,
+                                  const char *cred_name)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0])
       return;
+   const char *pr = pr_norm(principal);
    pthread_mutex_lock(&g_mu);
    for (int i = 0; i < g_state_count; i++)
    {
-      if (strcmp(g_state[i].agent_name, agent_name) == 0 &&
+      if (strcmp(g_state[i].principal, pr) == 0 && strcmp(g_state[i].agent_name, agent_name) == 0 &&
           strcmp(g_state[i].cred_name, cred_name) == 0)
       {
          g_state[i].leased = 0;
@@ -191,14 +204,15 @@ void delegate_credentials_release(const char *agent_name, const char *cred_name)
    pthread_mutex_unlock(&g_mu);
 }
 
-void delegate_credentials_cooldown(const char *agent_name, const char *cred_name, int seconds)
+void delegate_credentials_cooldown(const char *principal, const char *agent_name,
+                                   const char *cred_name, int seconds)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0] || seconds <= 0)
       return;
    long long until = now_monotonic_ms() + (long long)seconds * 1000LL;
    time_t epoch_until = now_epoch_seconds() + (time_t)seconds;
    pthread_mutex_lock(&g_mu);
-   cred_lease_state_t *slot = find_or_create_locked(agent_name, cred_name, NULL);
+   cred_lease_state_t *slot = find_or_create_locked(principal, agent_name, cred_name, NULL);
    if (slot)
    {
       slot->cooldown_until_ms = until;
@@ -206,6 +220,41 @@ void delegate_credentials_cooldown(const char *agent_name, const char *cred_name
       slot->status = DELEGATE_CRED_STATUS_RATE_LIMITED;
    }
    pthread_mutex_unlock(&g_mu);
+}
+
+int delegate_credentials_cooldown_remaining(const char *principal, const char *agent_name,
+                                            const char *cred_name, time_t now_epoch)
+{
+   if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0])
+      return 0;
+   if (now_epoch <= 0)
+      now_epoch = now_epoch_seconds();
+   const char *pr = pr_norm(principal);
+   long long now_ms = now_monotonic_ms();
+   int remaining = 0;
+   pthread_mutex_lock(&g_mu);
+   for (int i = 0; i < g_state_count; i++)
+   {
+      if (strcmp(g_state[i].principal, pr) != 0 || strcmp(g_state[i].agent_name, agent_name) != 0 ||
+          strcmp(g_state[i].cred_name, cred_name) != 0)
+         continue;
+      /* Honour whichever clock still shows the credential cooling: the monotonic
+       * deadline (live process) and the wall-clock epoch (restored from disk). */
+      if (g_state[i].cooldown_until_ms > now_ms)
+      {
+         int ms = (int)(g_state[i].cooldown_until_ms - now_ms);
+         remaining = ms / 1000 + (ms % 1000 ? 1 : 0);
+      }
+      if (g_state[i].cooldown_until_epoch > now_epoch)
+      {
+         int sec = (int)(g_state[i].cooldown_until_epoch - now_epoch);
+         if (sec > remaining)
+            remaining = sec;
+      }
+      break;
+   }
+   pthread_mutex_unlock(&g_mu);
+   return remaining;
 }
 
 int delegate_credentials_is_rate_limit(const char *error)
@@ -331,8 +380,9 @@ static void capture_header(delegate_ratelimit_state_t *rl, const char *line, siz
       rl->tok_reset_1h = now_epoch + (time_t)parse_header_long(value);
 }
 
-int delegate_credentials_capture_headers(const char *agent_name, const char *cred_name,
-                                         const char *raw_headers, time_t now_epoch)
+int delegate_credentials_capture_headers(const char *principal, const char *agent_name,
+                                         const char *cred_name, const char *raw_headers,
+                                         time_t now_epoch)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0] || !raw_headers)
       return -1;
@@ -340,7 +390,7 @@ int delegate_credentials_capture_headers(const char *agent_name, const char *cre
       now_epoch = now_epoch_seconds();
 
    pthread_mutex_lock(&g_mu);
-   cred_lease_state_t *slot = find_or_create_locked(agent_name, cred_name, NULL);
+   cred_lease_state_t *slot = find_or_create_locked(principal, agent_name, cred_name, NULL);
    if (!slot)
    {
       pthread_mutex_unlock(&g_mu);
@@ -379,9 +429,9 @@ static time_t earliest_reset(const delegate_ratelimit_state_t *rl)
    return best;
 }
 
-int delegate_credentials_report_failure(const char *agent_name, const char *cred_name,
-                                        failover_reason_t reason, const char *error,
-                                        time_t now_epoch)
+int delegate_credentials_report_failure(const char *principal, const char *agent_name,
+                                        const char *cred_name, failover_reason_t reason,
+                                        const char *error, time_t now_epoch)
 {
    if (!agent_name || !agent_name[0] || !cred_name || !cred_name[0])
       return 0;
@@ -389,7 +439,7 @@ int delegate_credentials_report_failure(const char *agent_name, const char *cred
       now_epoch = now_epoch_seconds();
 
    pthread_mutex_lock(&g_mu);
-   cred_lease_state_t *slot = find_or_create_locked(agent_name, cred_name, NULL);
+   cred_lease_state_t *slot = find_or_create_locked(principal, agent_name, cred_name, NULL);
    if (!slot)
    {
       pthread_mutex_unlock(&g_mu);
@@ -427,7 +477,7 @@ int delegate_credentials_report_failure(const char *agent_name, const char *cred
    return changed;
 }
 
-int delegate_credentials_rotate_after_failure(const char *agent_name,
+int delegate_credentials_rotate_after_failure(const char *principal, const char *agent_name,
                                               const agent_credential_t *creds, int credential_count,
                                               const char *provider, char *leased_cred_name,
                                               size_t leased_cred_name_cap, char *out_env_var,
@@ -441,13 +491,14 @@ int delegate_credentials_rotate_after_failure(const char *agent_name,
    if (reason == FAILOVER_NONE)
       return 0;
 
-   (void)delegate_credentials_report_failure(agent_name, leased_cred_name, reason, error,
+   (void)delegate_credentials_report_failure(principal, agent_name, leased_cred_name, reason, error,
                                              now_epoch);
-   delegate_credentials_release(agent_name, leased_cred_name);
+   delegate_credentials_release(principal, agent_name, leased_cred_name);
    leased_cred_name[0] = '\0';
    out_env_var[0] = '\0';
-   return delegate_credentials_acquire(agent_name, creds, credential_count, leased_cred_name,
-                                       leased_cred_name_cap, out_env_var, out_env_var_cap) == 0
+   return delegate_credentials_acquire(principal, agent_name, creds, credential_count,
+                                       leased_cred_name, leased_cred_name_cap, out_env_var,
+                                       out_env_var_cap) == 0
               ? 1
               : 0;
 }
@@ -461,6 +512,10 @@ int delegate_credentials_snapshot(const char *agent_name, delegate_credential_sn
    pthread_mutex_lock(&g_mu);
    for (int i = 0; i < g_state_count && n < max; i++)
    {
+      /* Operator view = the shared env pool only; per-principal vault rows
+       * (principal != "") are a per-user concern, not surfaced here. */
+      if (g_state[i].principal[0])
+         continue;
       if (agent_name && agent_name[0] && strcmp(agent_name, g_state[i].agent_name) != 0)
          continue;
       snprintf(out[n].agent_name, sizeof(out[n].agent_name), "%s", g_state[i].agent_name);
@@ -533,26 +588,31 @@ int delegate_credentials_save_file(const char *path)
 
    pthread_mutex_lock(&g_mu);
    state_refresh_wallclock_locked(now_epoch_seconds());
-   fprintf(fp, "aimee-delegate-credential-state-v1\n");
+   /* v2 adds a leading principal column; v1 readers are gone but v1 files still
+    * load (principal defaults to the shared ""). */
+   fprintf(fp, "aimee-delegate-credential-state-v2\n");
    for (int i = 0; i < g_state_count; i++)
    {
+      char principal[VAULT_PRINCIPAL_MAX];
       char agent[MAX_AGENT_NAME];
       char cred[MAX_CRED_NAME_LEN];
       char last_error[sizeof(g_state[i].last_error)];
+      sanitize_field(principal, sizeof(principal), g_state[i].principal);
       sanitize_field(agent, sizeof(agent), g_state[i].agent_name);
       sanitize_field(cred, sizeof(cred), g_state[i].cred_name);
       sanitize_field(last_error, sizeof(last_error), g_state[i].last_error);
       fprintf(fp,
-              "%s\t%s\t%d\t%lld\t%d\t%d\t%lld\t%d\t%d\t%lld\t%ld\t%ld\t%lld\t%ld\t%ld\t%lld\t%"
+              "%s\t%s\t%s\t%d\t%lld\t%d\t%d\t%lld\t%d\t%d\t%lld\t%ld\t%ld\t%lld\t%ld\t%ld\t%lld\t%"
               "lld\t%s\n",
-              agent, cred, (int)g_state[i].status, (long long)g_state[i].cooldown_until_epoch,
-              g_state[i].rl.req_limit, g_state[i].rl.req_remaining,
-              (long long)g_state[i].rl.req_reset, g_state[i].rl.req_limit_1h,
-              g_state[i].rl.req_remaining_1h, (long long)g_state[i].rl.req_reset_1h,
-              g_state[i].rl.tok_limit, g_state[i].rl.tok_remaining,
-              (long long)g_state[i].rl.tok_reset, g_state[i].rl.tok_limit_1h,
-              g_state[i].rl.tok_remaining_1h, (long long)g_state[i].rl.tok_reset_1h,
-              (long long)g_state[i].rl.captured_at, last_error);
+              principal, agent, cred, (int)g_state[i].status,
+              (long long)g_state[i].cooldown_until_epoch, g_state[i].rl.req_limit,
+              g_state[i].rl.req_remaining, (long long)g_state[i].rl.req_reset,
+              g_state[i].rl.req_limit_1h, g_state[i].rl.req_remaining_1h,
+              (long long)g_state[i].rl.req_reset_1h, g_state[i].rl.tok_limit,
+              g_state[i].rl.tok_remaining, (long long)g_state[i].rl.tok_reset,
+              g_state[i].rl.tok_limit_1h, g_state[i].rl.tok_remaining_1h,
+              (long long)g_state[i].rl.tok_reset_1h, (long long)g_state[i].rl.captured_at,
+              last_error);
    }
    pthread_mutex_unlock(&g_mu);
 
@@ -624,7 +684,12 @@ int delegate_credentials_load_file(const char *path, time_t now_epoch)
       fclose(fp);
       return 0;
    }
-   if (strncmp(line, "aimee-delegate-credential-state-v1", 34) != 0)
+   int has_principal_col; /* v2 prepends a principal field; v1 has none */
+   if (strncmp(line, "aimee-delegate-credential-state-v2", 34) == 0)
+      has_principal_col = 1;
+   else if (strncmp(line, "aimee-delegate-credential-state-v1", 34) == 0)
+      has_principal_col = 0;
+   else
    {
       fclose(fp);
       return -1;
@@ -635,11 +700,14 @@ int delegate_credentials_load_file(const char *path, time_t now_epoch)
    {
       line[strcspn(line, "\r\n")] = '\0';
       char *cursor = line;
+      char *principal = has_principal_col ? next_field(&cursor) : "";
       char *agent = next_field(&cursor);
       char *cred = next_field(&cursor);
+      if (!principal)
+         principal = "";
       if (!agent || !agent[0] || !cred || !cred[0])
          continue;
-      cred_lease_state_t *slot = find_or_create_locked(agent, cred, NULL);
+      cred_lease_state_t *slot = find_or_create_locked(principal, agent, cred, NULL);
       if (!slot)
          continue;
       slot->leased = 0;

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -8,6 +8,10 @@
 #include "aimee.h"
 #include "delegate_ensemble.h"
 #include "agent_exec.h"
+#include "agent_config.h"
+#include "config.h"
+#include "delegate_credentials.h"
+#include "cost_fold.h"
 #include "log.h"
 #include "token_tracker.h"
 
@@ -142,6 +146,69 @@ static double estimate_cost(const agent_config_t *acfg, const agent_result_t *re
    for (int i = 0; i < count; i++)
       total += result_token_cost(acfg, &results[i], fallback_agents ? fallback_agents[i] : NULL);
    return total;
+}
+
+/* Originating session of the in-flight roundtable, set at delegate_roundtable_run
+ * entry. Read by the delegate-run core + panel cost-fold so each model call is
+ * accounted onto the caller's session like a delegate. */
+static _Thread_local const char *g_rt_parent_sid = NULL;
+
+/* Fold a completed panel/aggregator run's cost onto the originating session, the
+ * same accounting a real delegate does. No-op without a parent session or a
+ * billable result. */
+static void ensemble_fold_cost(const agent_config_t *acfg, const agent_result_t *r,
+                               const char *fallback_agent)
+{
+   if (!g_rt_parent_sid || !g_rt_parent_sid[0] || !r || !r->success)
+      return;
+   double cost = result_token_cost(acfg, r, fallback_agent);
+   if (cost > 0.0)
+      (void)db1_cost_fold_record(g_rt_parent_sid, "ensemble", cost, "ensemble");
+}
+
+/* Synchronous delegate run: the delegate economics core — a credential lease for
+ * agents with a server-side pool, plus cost-fold accounting — wrapped around a
+ * no-tools agent run. The ensemble dispatches its aggregator (and any serial
+ * participant) through this so the work runs as a delegate rather than a raw
+ * in-process agent call. delegate_worker stays the async-job path; this is its
+ * synchronous sibling. A non-empty name routes by name; NULL routes by role. */
+static int delegate_run_inline(agent_config_t *acfg, const char *agent_name, const char *role,
+                               const char *system_prompt, const char *user_prompt, int max_tokens,
+                               double temperature, agent_result_t *out)
+{
+   agent_t *ag = (agent_name && agent_name[0]) ? agent_find(acfg, agent_name) : NULL;
+   char leased_cred[MAX_CRED_NAME_LEN] = "";
+   int leased = 0;
+   /* Client-held-credential agents (the usual panel) have no pool, so this is
+    * skipped and keys resolve from the session keyring as before; a pooled agent
+    * leases one credential for the call, exactly like delegate_worker. */
+   if (ag && ag->credential_count > 0)
+   {
+      char leased_env[MAX_CRED_ENV_VAR_LEN] = "";
+      char state_path[MAX_PATH_LEN];
+      const char *dir = config_output_dir();
+      snprintf(state_path, sizeof(state_path), "%s/delegate-credential-state.tsv",
+               dir ? dir : "/tmp");
+      (void)delegate_credentials_load_file(state_path, time(NULL));
+      if (delegate_credentials_acquire(NULL, ag->name, ag->credentials, ag->credential_count,
+                                       leased_cred, sizeof(leased_cred), leased_env,
+                                       sizeof(leased_env)) == 0)
+      {
+         const char *v = getenv(leased_env);
+         if (v && v[0])
+            snprintf(ag->api_key, MAX_API_KEY_LEN, "%s", v);
+         leased = 1;
+      }
+   }
+   int rc =
+       (agent_name && agent_name[0])
+           ? agent_run_named(acfg, agent_name, role, system_prompt, user_prompt, max_tokens,
+                             temperature, out)
+           : agent_run_ex(acfg, role, system_prompt, user_prompt, max_tokens, temperature, out);
+   ensemble_fold_cost(acfg, out, agent_name);
+   if (leased && ag)
+      delegate_credentials_release(NULL, ag->name, leased_cred);
+   return rc;
 }
 
 static long monotonic_ms(void)
@@ -403,11 +470,11 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
       /* max_tokens 0 = derive from the aggregator model's own output ceiling, so
        * a reasoning aggregator isn't truncated mid-synthesis (was a hard 4096). */
       if (!at)
-         return agent_run_named(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
+         return delegate_run_inline(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
       const char *role = (at[1]) ? at + 1 : "review";
-      return agent_run_ex(&agg_cfg, role, NULL, synthesis_prompt, 0, 0.3, out);
+      return delegate_run_inline(&agg_cfg, NULL, role, NULL, synthesis_prompt, 0, 0.3, out);
    }
-   return agent_run_ex(&agg_cfg, "review", NULL, synthesis_prompt, 0, 0.3, out);
+   return delegate_run_inline(&agg_cfg, NULL, "review", NULL, synthesis_prompt, 0, 0.3, out);
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,
@@ -985,6 +1052,9 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
       tasks[i].max_tokens = 0;
    }
    agent_run_parallel(acfg, tasks, ref_count, results);
+   /* Account each participant's run onto the originating session, like a delegate. */
+   for (int i = 0; i < ref_count; i++)
+      ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
    for (int i = 0; i < ref_count; i++)
       free(prompts[i]);
    return 0;
@@ -1061,6 +1131,9 @@ int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char 
    memset(results, 0, sizeof(results));
 
    agent_run_parallel(acfg, tasks, ref_count, results);
+   /* Account each participant's run onto the originating session, like a delegate. */
+   for (int i = 0; i < ref_count; i++)
+      ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
 
    double cost = estimate_cost(acfg, results, cfg->ensemble_reference_models, ref_count);
    out->cost_usd = cost;
@@ -1169,6 +1242,12 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
       local.converge_threshold = 10;
    if (local.brief_truncated)
       out->truncated = 1;
+
+   /* Bind the originating session for this thread so panel + aggregator runs fold
+    * their cost onto it. Set unconditionally on every entry (NULL when there's no
+    * parent), so a reused worker thread can't inherit a prior turn's session; it's
+    * only read while this call runs the panel/aggregator on this same thread. */
+   g_rt_parent_sid = local.parent_session_id;
 
    long start_ms = monotonic_ms();
    char *artifact = xstrdup0("");

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1886,6 +1886,7 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    opts.max_rounds = cfg.roundtable_max_rounds > 0 ? cfg.roundtable_max_rounds : 3;
    opts.converge_threshold = cfg.roundtable_converge_threshold;
    opts.deadline_ms = cfg.roundtable_deadline_ms;
+   opts.parent_session_id = compute_request_session_id(req); /* fold panel cost onto it */
    cJSON *jrun = cJSON_GetObjectItemCaseSensitive(req, "__run_id");
    if (cJSON_IsString(jrun) && jrun->valuestring && jrun->valuestring[0])
    {
@@ -1901,7 +1902,6 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    opts.brief_truncated = brief.truncated;
    opts.questions = brief.question_ptrs;
    opts.question_count = brief.question_count;
-
    cJSON *jmode = cJSON_GetObjectItemCaseSensitive(req, "mode");
    if (cJSON_IsString(jmode) && strcmp(jmode->valuestring, "review") == 0)
       opts.mode = ROUNDTABLE_REVIEW;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -729,6 +729,9 @@ void delegate_worker(void *arg)
    char deleg_id[64] = "";
    agent_t *target_agent = NULL;
    char leased_cred_name[MAX_CRED_NAME_LEN] = "";
+   /* WP-C.3: the credential-pool row key. "" for the shared env pool; the request
+    * principal for a vaulted credential, so its 429-cooldown is per-principal. */
+   char leased_principal[VAULT_PRINCIPAL_MAX] = "";
    char credential_state_path[MAX_PATH_LEN] = "";
    char *resolved_prompt = NULL;
    char *template_sys_prompt = NULL;
@@ -996,46 +999,29 @@ void delegate_worker(void *arg)
    delegate_apply_max_turns_policy(&acfg, role, max_turns);
    if (cctx->background_job_id > 0 && target_agent)
       db1_agent_job_set_agent(cctx->background_job_id, target_agent->name);
-   /* WP-C.1 vault-FIRST (D14/D15): vaulted cred beats env lease; LOCKED fails; miss -> env. */
-   int vault_hit = 0;
-   if (target_agent && cctx->vault_principal[0])
+   /* Resolve the credential (WP-C.1 vault-FIRST + WP-C.3 per-principal cooldown):
+    * sets target_agent->api_key on a hit and names the pool row to release on
+    * exit; the worker maps a non-OK status to a delegate error. */
+   int cooldown_secs = 0;
+   delegate_cred_resolve_status_t cred_status = delegate_resolve_credentials(
+       target_agent ? cctx->vault_principal : NULL, target_agent, leased_principal,
+       sizeof(leased_principal), leased_cred_name, sizeof(leased_cred_name), credential_state_path,
+       sizeof(credential_state_path), &cooldown_secs);
+   if (cred_status != DELEGATE_CRED_RESOLVE_OK)
    {
-      vault_status_t vst =
-          vault_service_inject_api_key(cctx->vault_principal, target_agent->name,
-                                       target_agent->api_key, MAX_API_KEY_LEN, time(NULL));
-      vault_hit = (vst == VAULT_OK);
-      if (vst == VAULT_ERR_LOCKED)
-      {
-         delegation_compute_error(cctx, "vault locked: run `aimee vault unlock`");
-         compute_ctx_free(cctx);
-         return;
-      }
-   }
-   /* Lease one credential from a configured pool (skipped on a vault hit). */
-   if (!vault_hit && target_agent && target_agent->credential_count > 0)
-   {
-      char leased_env[MAX_CRED_ENV_VAR_LEN] = "";
-      const char *dir = config_output_dir();
-      snprintf(credential_state_path, sizeof(credential_state_path),
-               "%s/delegate-credential-state.tsv", dir ? dir : "/tmp");
-      (void)delegate_credentials_load_file(credential_state_path, time(NULL));
-      if (delegate_credentials_acquire(
-              target_agent->name, target_agent->credentials, target_agent->credential_count,
-              leased_cred_name, sizeof(leased_cred_name), leased_env, sizeof(leased_env)) == 0)
-      {
-         const char *value = getenv(leased_env);
-         if (value && value[0])
-            snprintf(target_agent->api_key, MAX_API_KEY_LEN, "%s", value);
-      }
+      char errmsg[200];
+      if (cred_status == DELEGATE_CRED_RESOLVE_LOCKED)
+         snprintf(errmsg, sizeof(errmsg), "vault locked: run `aimee vault unlock`");
+      else if (cred_status == DELEGATE_CRED_RESOLVE_COOLING)
+         snprintf(errmsg, sizeof(errmsg),
+                  "vault credential for agent '%s' is rate-limited; retry in %ds",
+                  target_agent->name, cooldown_secs);
       else
-      {
-         char errmsg[256];
          snprintf(errmsg, sizeof(errmsg), "no available credential in pool for agent '%s'",
                   target_agent->name);
-         delegation_compute_error(cctx, errmsg);
-         compute_ctx_free(cctx);
-         return;
-      }
+      delegation_compute_error(cctx, errmsg);
+      compute_ctx_free(cctx);
+      return;
    }
 
    /* Enforce delegation depth limit.
@@ -1621,12 +1607,13 @@ void delegate_worker(void *arg)
       if (!result.success)
          reason = delegate_credentials_classify_failure(target_agent->provider, result.error);
       if (reason != FAILOVER_NONE)
-         delegate_credentials_report_failure(target_agent->name, leased_cred_name, reason,
-                                             result.error, time(NULL));
-      delegate_credentials_release(target_agent->name, leased_cred_name);
+         delegate_credentials_report_failure(leased_principal, target_agent->name, leased_cred_name,
+                                             reason, result.error, time(NULL));
+      delegate_credentials_release(leased_principal, target_agent->name, leased_cred_name);
       if (credential_state_path[0])
          (void)delegate_credentials_save_file(credential_state_path);
       leased_cred_name[0] = '\0';
+      leased_principal[0] = '\0';
    }
 
    /* Clear thread-local CWD */
@@ -1645,7 +1632,7 @@ delegate_fail:
    free(resolved_prompt);
    free(template_sys_prompt);
    if (target_agent && leased_cred_name[0])
-      delegate_credentials_release(target_agent->name, leased_cred_name);
+      delegate_credentials_release(leased_principal, target_agent->name, leased_cred_name);
    if (delegate_worktree_path[0] && delegate_git_root[0])
       worktree_cleanup(delegate_git_root, deleg_id, delegate_work_name);
    compute_ctx_free(cctx);

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -232,7 +232,8 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
    char *tmp = malloc(api_key_len);
    if (!tmp)
       return VAULT_ERR_IO;
-   vault_status_t st = vault_service_get(principal, agent, "api_key", tmp, api_key_len, now_epoch);
+   vault_status_t st =
+       vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
    if (st == VAULT_OK)
       snprintf(api_key, api_key_len, "%s", tmp); /* overwrite only on a real hit */
    OPENSSL_cleanse(tmp, api_key_len);

--- a/src/tests/test_delegate_credentials.c
+++ b/src/tests/test_delegate_credentials.c
@@ -25,19 +25,19 @@ static void test_acquire_round_robin(void)
    creds[1] = make_cred("backup", "OPENROUTER_API_KEY_2");
 
    char a_name[32] = {0}, a_env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, a_name, sizeof(a_name), a_env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, a_name, sizeof(a_name), a_env,
                                        sizeof(a_env)) == 0);
    assert(strcmp(a_name, "main") == 0);
 
    /* Second call leases the next credential, not the same one. */
    char b_name[32] = {0}, b_env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, b_name, sizeof(b_name), b_env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, b_name, sizeof(b_name), b_env,
                                        sizeof(b_env)) == 0);
    assert(strcmp(b_name, "backup") == 0);
 
    /* Third call: pool exhausted. */
    char c_name[32] = {0}, c_env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, c_name, sizeof(c_name), c_env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, c_name, sizeof(c_name), c_env,
                                        sizeof(c_env)) == -1);
 
    printf("  PASS: test_acquire_round_robin\n");
@@ -51,17 +51,17 @@ static void test_release_makes_credential_available(void)
    creds[1] = make_cred("backup", "OPENROUTER_API_KEY_2");
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == -1);
 
-   delegate_credentials_release("openrouter", "main");
+   delegate_credentials_release("", "openrouter", "main");
 
    /* Now there is one available again. */
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "main") == 0);
    printf("  PASS: test_release_makes_credential_available\n");
@@ -75,15 +75,15 @@ static void test_cooldown_skips_credential(void)
    creds[1] = make_cred("backup", "OPENROUTER_API_KEY_2");
 
    /* Cool main; even before any acquire happens, main is unavailable. */
-   delegate_credentials_cooldown("openrouter", "main", 60);
+   delegate_credentials_cooldown("", "openrouter", "main", 60);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "backup") == 0);
 
    /* No more credentials available — main is still cooling. */
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == -1);
    printf("  PASS: test_cooldown_skips_credential\n");
 }
@@ -98,7 +98,7 @@ static void test_capture_headers_records_quota_windows(void)
                          "x-ratelimit-limit-tokens: 10000\r\n"
                          "x-ratelimit-remaining-tokens: 2500\r\n"
                          "x-ratelimit-reset-tokens: 45\r\n";
-   assert(delegate_credentials_capture_headers("openrouter", "main", headers, 1000) == 0);
+   assert(delegate_credentials_capture_headers("", "openrouter", "main", headers, 1000) == 0);
 
    delegate_credential_snapshot_t rows[4];
    int n = delegate_credentials_snapshot("openrouter", rows, 4);
@@ -121,15 +121,15 @@ static void test_acquire_prefers_freshest_quota(void)
    creds[1] = make_cred("fresh", "FRESH_KEY");
 
    assert(delegate_credentials_capture_headers(
-              "openrouter", "low",
+              "", "openrouter", "low",
               "x-ratelimit-remaining-requests: 2\nx-ratelimit-remaining-tokens: 500\n", 1000) == 0);
    assert(delegate_credentials_capture_headers(
-              "openrouter", "fresh",
+              "", "openrouter", "fresh",
               "x-ratelimit-remaining-requests: 50\nx-ratelimit-remaining-tokens: 8000\n",
               1000) == 0);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "fresh") == 0);
    assert(strcmp(env, "FRESH_KEY") == 0);
@@ -144,13 +144,13 @@ static void test_report_failure_marks_and_rotates(void)
    creds[1] = make_cred("backup", "BACKUP_KEY");
 
    assert(delegate_credentials_capture_headers(
-              "openrouter", "main",
+              "", "openrouter", "main",
               "x-ratelimit-reset-requests: 120\nx-ratelimit-remaining-requests: 0\n", 1000) == 0);
-   assert(delegate_credentials_report_failure("openrouter", "main", FAILOVER_RATE_LIMIT, "HTTP 429",
-                                              1000) == 1);
+   assert(delegate_credentials_report_failure("", "openrouter", "main", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "backup") == 0);
 
@@ -177,14 +177,14 @@ static void test_rotate_after_failure_releases_and_leases_next(void)
    creds[1] = make_cred("backup", "BACKUP_KEY");
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "main") == 0);
    assert(delegate_credentials_capture_headers(
-              "openrouter", "main",
+              "", "openrouter", "main",
               "x-ratelimit-reset-requests: 120\nx-ratelimit-remaining-requests: 0\n", 1000) == 0);
 
-   assert(delegate_credentials_rotate_after_failure("openrouter", creds, 2, "openrouter", name,
+   assert(delegate_credentials_rotate_after_failure("", "openrouter", creds, 2, "openrouter", name,
                                                     sizeof(name), env, sizeof(env), "HTTP 429",
                                                     1000) == 1);
    assert(strcmp(name, "backup") == 0);
@@ -221,13 +221,13 @@ static void test_rotate_after_non_pool_failure_keeps_lease(void)
    creds[1] = make_cred("backup", "BACKUP_KEY");
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
-   assert(delegate_credentials_rotate_after_failure("openrouter", creds, 2, "openrouter", name,
+   assert(delegate_credentials_rotate_after_failure("", "openrouter", creds, 2, "openrouter", name,
                                                     sizeof(name), env, sizeof(env),
                                                     "connection refused", 1000) == 0);
    assert(strcmp(name, "main") == 0);
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "backup") == 0);
    printf("  PASS: test_rotate_after_non_pool_failure_keeps_lease\n");
@@ -240,13 +240,13 @@ static void test_billing_and_auth_failures_are_not_reacquired(void)
    creds[0] = make_cred("billing", "BILLING_KEY");
    creds[1] = make_cred("auth", "AUTH_KEY");
 
-   assert(delegate_credentials_report_failure("openrouter", "billing", FAILOVER_BILLING,
+   assert(delegate_credentials_report_failure("", "openrouter", "billing", FAILOVER_BILLING,
                                               "payment required", 1000) == 1);
-   assert(delegate_credentials_report_failure("openrouter", "auth", FAILOVER_AUTH_PERMANENT,
+   assert(delegate_credentials_report_failure("", "openrouter", "auth", FAILOVER_AUTH_PERMANENT,
                                               "forbidden", 1000) == 1);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 2, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 2, name, sizeof(name), env,
                                        sizeof(env)) == -1);
    char quota[512];
    assert(delegate_credentials_format_quota("openrouter", quota, sizeof(quota)) == 2);
@@ -267,11 +267,11 @@ static void test_health_state_persists_across_reset(void)
    creds[2] = make_cred("fresh", "FRESH_KEY");
 
    assert(delegate_credentials_capture_headers(
-              "openrouter", "main",
+              "", "openrouter", "main",
               "x-ratelimit-reset-requests: 120\nx-ratelimit-remaining-requests: 0\n", 1000) == 0);
-   assert(delegate_credentials_report_failure("openrouter", "main", FAILOVER_RATE_LIMIT, "HTTP 429",
-                                              1000) == 1);
-   assert(delegate_credentials_report_failure("openrouter", "billing", FAILOVER_BILLING,
+   assert(delegate_credentials_report_failure("", "openrouter", "main", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
+   assert(delegate_credentials_report_failure("", "openrouter", "billing", FAILOVER_BILLING,
                                               "payment required", 1000) == 1);
    assert(delegate_credentials_save_file(path) == 0);
 
@@ -279,7 +279,7 @@ static void test_health_state_persists_across_reset(void)
    assert(delegate_credentials_load_file(path, 1000) == 2);
 
    char name[32] = {0}, env[64] = {0};
-   assert(delegate_credentials_acquire("openrouter", creds, 3, name, sizeof(name), env,
+   assert(delegate_credentials_acquire("", "openrouter", creds, 3, name, sizeof(name), env,
                                        sizeof(env)) == 0);
    assert(strcmp(name, "fresh") == 0);
 
@@ -318,12 +318,12 @@ static void test_isolation_between_agents(void)
    char name[32] = {0}, env[64] = {0};
    /* agent A leases main. agent B's "main" is a different state row,
     * so it's independent and still available. */
-   assert(delegate_credentials_acquire("agent-A", creds, 1, name, sizeof(name), env, sizeof(env)) ==
-          0);
-   assert(delegate_credentials_acquire("agent-A", creds, 1, name, sizeof(name), env, sizeof(env)) ==
-          -1);
-   assert(delegate_credentials_acquire("agent-B", creds, 1, name, sizeof(name), env, sizeof(env)) ==
-          0);
+   assert(delegate_credentials_acquire("", "agent-A", creds, 1, name, sizeof(name), env,
+                                       sizeof(env)) == 0);
+   assert(delegate_credentials_acquire("", "agent-A", creds, 1, name, sizeof(name), env,
+                                       sizeof(env)) == -1);
+   assert(delegate_credentials_acquire("", "agent-B", creds, 1, name, sizeof(name), env,
+                                       sizeof(env)) == 0);
    printf("  PASS: test_isolation_between_agents\n");
 }
 
@@ -338,8 +338,8 @@ static void test_lease_state_grows_beyond_initial_capacity(void)
       char agent[32];
       char name[32] = {0}, env[64] = {0};
       snprintf(agent, sizeof(agent), "agent-%02d", i);
-      assert(delegate_credentials_acquire(agent, creds, 1, name, sizeof(name), env, sizeof(env)) ==
-             0);
+      assert(delegate_credentials_acquire("", agent, creds, 1, name, sizeof(name), env,
+                                          sizeof(env)) == 0);
       assert(strcmp(name, "main") == 0);
    }
    printf("  PASS: test_lease_state_grows_beyond_initial_capacity\n");
@@ -350,8 +350,8 @@ static void test_empty_pool_returns_error(void)
    delegate_credentials_reset_for_test();
    char name[32] = {0}, env[64] = {0};
    /* credential_count == 0 means "no pool" — caller falls back to api_key. */
-   assert(delegate_credentials_acquire("agent-A", NULL, 0, name, sizeof(name), env, sizeof(env)) ==
-          -1);
+   assert(delegate_credentials_acquire("", "agent-A", NULL, 0, name, sizeof(name), env,
+                                       sizeof(env)) == -1);
    printf("  PASS: test_empty_pool_returns_error\n");
 }
 
@@ -393,6 +393,87 @@ static void test_failure_classifier_maps_pool_reasons(void)
    printf("  PASS: test_failure_classifier_maps_pool_reasons\n");
 }
 
+/* WP-C.3: a 429 cooling one principal's vaulted credential must not cool the
+ * same (agent, cred) for another principal, nor the shared "" env pool. */
+static void test_principal_cooldown_isolation(void)
+{
+   delegate_credentials_reset_for_test();
+   delegate_credentials_cooldown("uid:alice", "claude", "api_key", 60);
+
+   assert(delegate_credentials_cooldown_remaining("uid:alice", "claude", "api_key", 0) > 0);
+   assert(delegate_credentials_cooldown_remaining("uid:bob", "claude", "api_key", 0) == 0);
+   assert(delegate_credentials_cooldown_remaining("", "claude", "api_key", 0) == 0);
+   /* NULL principal normalises to the shared "" pool — still independent. */
+   assert(delegate_credentials_cooldown_remaining(NULL, "claude", "api_key", 0) == 0);
+   printf("  PASS: test_principal_cooldown_isolation\n");
+}
+
+/* WP-C.3: cooldown_remaining reports the live (monotonic) seconds left, returns 0
+ * for an unknown row without creating one, and 0 once a restored deadline passes. */
+static void test_cooldown_remaining_reports_seconds(void)
+{
+   delegate_credentials_reset_for_test();
+   assert(delegate_credentials_report_failure("webuser:carol", "claude", "api_key",
+                                              FAILOVER_RATE_LIMIT, "HTTP 429", 0) == 1);
+   int rem = delegate_credentials_cooldown_remaining("webuser:carol", "claude", "api_key", 0);
+   assert(rem > 0 && rem <= DELEGATE_CRED_COOLDOWN_SECONDS_DEFAULT);
+   /* Unknown row -> 0, and no row was created. */
+   assert(delegate_credentials_cooldown_remaining("uid:nobody", "claude", "api_key", 0) == 0);
+
+   /* A persisted, per-principal rate-limited row whose deadline has already passed
+    * loads as not-cooling (load re-bases the monotonic timer off the epoch). */
+   delegate_credentials_reset_for_test();
+   char p[256];
+   snprintf(p, sizeof(p), "/tmp/aimee-test-cd-%ld.tsv", (long)getpid());
+   FILE *fp = fopen(p, "w");
+   assert(fp != NULL);
+   fputs("aimee-delegate-credential-state-v2\nuid:carol\tclaude\tapi_key\t1\t1500\n", fp);
+   fclose(fp);
+   assert(delegate_credentials_load_file(p, 5000) == 1); /* now 5000 > deadline 1500 */
+   assert(delegate_credentials_cooldown_remaining("uid:carol", "claude", "api_key", 5000) == 0);
+   unlink(p);
+   printf("  PASS: test_cooldown_remaining_reports_seconds\n");
+}
+
+/* WP-C.3: the v2 state file round-trips the principal column, keeping per-principal
+ * rows distinct from the shared "" pool; legacy v1 files load with principal "". */
+static void test_save_load_v2_roundtrips_principal(void)
+{
+   delegate_credentials_reset_for_test();
+   char path[256];
+   snprintf(path, sizeof(path), "/tmp/aimee-test-cred-v2-%ld.tsv", (long)getpid());
+
+   /* A shared-pool row and a per-principal vault row, both rate-limited. */
+   assert(delegate_credentials_report_failure("", "openrouter", "main", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
+   assert(delegate_credentials_report_failure("uid:alice", "claude", "api_key", FAILOVER_RATE_LIMIT,
+                                              "HTTP 429", 1000) == 1);
+   assert(delegate_credentials_save_file(path) == 0);
+
+   delegate_credentials_reset_for_test();
+   assert(delegate_credentials_load_file(path, 1000) == 2);
+   /* The per-principal row reloaded under its own principal, isolated from "". */
+   assert(delegate_credentials_cooldown_remaining("uid:alice", "claude", "api_key", 1000) > 0);
+   assert(delegate_credentials_cooldown_remaining("", "claude", "api_key", 1000) == 0);
+   /* The shared row is visible to the operator snapshot; the vault row is not. */
+   delegate_credential_snapshot_t rows[8];
+   int n = delegate_credentials_snapshot(NULL, rows, 8);
+   assert(n == 1);
+   assert(strcmp(rows[0].agent_name, "openrouter") == 0 && strcmp(rows[0].cred_name, "main") == 0);
+   unlink(path);
+
+   /* Legacy v1 file (no principal column) loads into the shared "" pool. */
+   delegate_credentials_reset_for_test();
+   FILE *fp = fopen(path, "w");
+   assert(fp != NULL);
+   fputs("aimee-delegate-credential-state-v1\nopenrouter\tmain\t1\t1120\n", fp);
+   fclose(fp);
+   assert(delegate_credentials_load_file(path, 1000) == 1);
+   assert(delegate_credentials_cooldown_remaining("", "openrouter", "main", 1000) == 120);
+   unlink(path);
+   printf("  PASS: test_save_load_v2_roundtrips_principal\n");
+}
+
 int main(void)
 {
    printf("delegate_credentials:\n");
@@ -411,6 +492,9 @@ int main(void)
    test_empty_pool_returns_error();
    test_is_rate_limit_classifier();
    test_failure_classifier_maps_pool_reasons();
+   test_principal_cooldown_isolation();
+   test_cooldown_remaining_reports_seconds();
+   test_save_load_v2_roundtrips_principal();
    printf("ok\n");
    return 0;
 }

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -215,6 +215,58 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
    return 0;
 }
 
+/* Stubs for the delegate-run core's economics deps. agent_find returns NULL so
+ * the (server-side cred pool) lease path is skipped — the panel agents are
+ * client-held and have no pool — and the run falls through to the agent_run
+ * stubs above; cost-fold is a no-op in the test (no parent session bound). */
+agent_t *agent_find(agent_config_t *cfg, const char *name)
+{
+   (void)cfg;
+   (void)name;
+   return NULL;
+}
+static int g_cost_fold_calls = 0;
+static double g_cost_fold_total = 0.0;
+int db1_cost_fold_record(const char *parent_sid, const char *child_sid, double cost,
+                         const char *source)
+{
+   (void)child_sid;
+   (void)source;
+   if (parent_sid && parent_sid[0])
+   {
+      g_cost_fold_calls++;
+      g_cost_fold_total += cost;
+   }
+   return 0;
+}
+int delegate_credentials_load_file(const char *path, time_t now_epoch)
+{
+   (void)path;
+   (void)now_epoch;
+   return 0;
+}
+int delegate_credentials_acquire(const char *principal, const char *agent_name,
+                                 const agent_credential_t *creds, int count, char *cred_name,
+                                 size_t cred_name_sz, char *env, size_t env_sz)
+{
+   (void)principal;
+   (void)agent_name;
+   (void)creds;
+   (void)count;
+   (void)cred_name;
+   (void)cred_name_sz;
+   (void)env;
+   (void)env_sz;
+   return -1;
+}
+void delegate_credentials_release(const char *principal, const char *agent_name,
+                                  const char *cred_name)
+{
+   (void)principal;
+   (void)agent_name;
+   (void)cred_name;
+}
+
 int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
                                        const char *system_prompt, const char *user_prompt,
                                        int max_tokens, int enforce_writes, agent_result_t *out)
@@ -474,6 +526,43 @@ static void test_roundtable_parallel_basic(void)
    assert(g_parallel_calls == 2);
    delegate_roundtable_result_free(&result);
    printf("  test_roundtable_parallel_basic: ok\n");
+}
+
+/* The ensemble runs through the delegate path: each billable panel + aggregator
+ * run folds its cost onto the originating session (db1_cost_fold_record), and
+ * only when a parent session is set. */
+static void test_roundtable_folds_cost_to_parent_session(void)
+{
+   reset_modes();
+   g_cost_fold_calls = 0;
+   g_cost_fold_total = 0.0;
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   opts.parent_session_id = "parent-sess";
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "draft a short proposal", &opts, &result);
+   assert(rc == 0);
+   /* >= 2 panel participants + the aggregator all folded onto the parent. */
+   assert(g_cost_fold_calls >= 3);
+   assert(g_cost_fold_total > 0.0);
+   delegate_roundtable_result_free(&result);
+
+   /* No parent session -> no fold (the other tests run with parent unset). */
+   g_cost_fold_calls = 0;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   rc = delegate_roundtable_run(&acfg, &cfg, "draft again", &opts, &result);
+   assert(rc == 0);
+   assert(g_cost_fold_calls == 0);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_folds_cost_to_parent_session: ok\n");
 }
 
 static void test_roundtable_sequential_uses_named_agents(void)
@@ -893,6 +982,7 @@ int main(void)
    test_ensemble_min_successful_degradation();
    test_ensemble_routes_to_distinct_agents();
    test_roundtable_parallel_basic();
+   test_roundtable_folds_cost_to_parent_session();
    test_roundtable_sequential_uses_named_agents();
    test_roundtable_degrades_on_min_success();
    test_roundtable_preflight_cap_warns_observed_cap_stops();

--- a/src/tests/test_guardrails_cases_a.inc
+++ b/src/tests/test_guardrails_cases_a.inc
@@ -1076,7 +1076,17 @@ static void test_known_subagent_tools_blocked(void)
    assert(rc == 2);
    assert(strstr(msg, "BLOCKED") != NULL);
    assert(strstr(msg, "guardrails") != NULL);
-   assert(strstr(msg, "delegate MCP tool") != NULL);
+   assert(strstr(msg, "aimee delegate") != NULL);
+
+   /* Claude Code's actual sub-agent tool name (Task) should be blocked too */
+   rc = pre_tool_check("Task",
+                       "{\"subagent_type\":\"Explore\","
+                       "\"prompt\":\"Find the installer code\","
+                       "\"description\":\"Find installer\"}",
+                       &state, MODE_APPROVE, "/tmp", msg, sizeof(msg));
+   assert(rc == 2);
+   assert(strstr(msg, "BLOCKED") != NULL);
+   assert(strstr(msg, "aimee delegate") != NULL);
 
    /* Codex sub-agent tool should also be blocked */
    rc = pre_tool_check("spawn_agent",
@@ -1093,7 +1103,7 @@ static void test_known_subagent_tools_blocked(void)
                        msg, sizeof(msg));
    assert(rc == 2);
    assert(strstr(msg, "guardrails") != NULL);
-   assert(strstr(msg, "delegate MCP tool") != NULL);
+   assert(strstr(msg, "aimee delegate") != NULL);
 
    guardrails_close_test_sqlite();
 }

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -123,6 +123,10 @@ void agent_set_request_codex_creds(const char *token, const char *account_id)
    (void)token;
    (void)account_id;
 }
+int agent_request_codex_token_present(void)
+{
+   return 0;
+}
 void agent_set_request_session(const char *session_id)
 {
    (void)session_id;
@@ -192,6 +196,19 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
    (void)agent;
    (void)api_key;
    (void)api_key_len;
+   (void)now_epoch;
+   return VAULT_NO_ENTRY;
+}
+/* WP-C.3: delegate_credential_retry.o (linked here) calls vault_service_get for
+ * the codex-oauth override; these tests run keyless, so stub it to a miss. */
+vault_status_t vault_service_get(const char *principal, const char *agent, const char *cred,
+                                 char *out, size_t out_cap, long now_epoch)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)out;
+   (void)out_cap;
    (void)now_epoch;
    return VAULT_NO_ENTRY;
 }


### PR DESCRIPTION
Promote testing → main.

Headline: "use delegates, not agents" — aimee blocks the host AI's Task/subagent tool and routes that work to `aimee delegate` (#239), and the roundtable/ensemble panel + aggregator now run through a delegate core with cost-fold accounting (#240). Also folds in the WP-C.3 per-principal credential pool re-key (#235) and the combined/standalone remote_writes-on-redeploy fix (#236).

All CI green on testing.
