### PR TITLE
ensemble: make max_cost_usd optional, no cap by default

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -550,7 +550,7 @@ static void config_set_defaults(config_t *cfg)
    snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "auto");
    cfg->db2_vector_corpus_diskann_threshold = 1000000;
    cfg->ensemble_min_successful = 2;
-   cfg->ensemble_max_cost_usd = 1.0;
+   cfg->ensemble_max_cost_usd = 0.0; /* 0 = no cost cap (unlimited) by default */
    cfg->roundtable_max_rounds = 3;
    cfg->roundtable_converge_threshold = 10;
    cfg->roundtable_deadline_ms = 600000;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -61,7 +61,7 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
 
    /* ensemble.* */
    if (cfg->ensemble_aggregator[0] || cfg->ensemble_min_successful != 2 ||
-       cfg->ensemble_max_cost_usd != 1.0 || cfg->ensemble_reference_count > 0)
+       cfg->ensemble_max_cost_usd > 0.0 || cfg->ensemble_reference_count > 0)
    {
       cJSON *e = cJSON_AddObjectToObject(root, "ensemble");
       if (e)
@@ -69,7 +69,9 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
          if (cfg->ensemble_aggregator[0])
             cJSON_AddStringToObject(e, "aggregator", cfg->ensemble_aggregator);
          cJSON_AddNumberToObject(e, "min_successful", cfg->ensemble_min_successful);
-         cJSON_AddNumberToObject(e, "max_cost_usd", cfg->ensemble_max_cost_usd);
+         /* Only persist a cap when one is set; 0/unset = no limit (the default). */
+         if (cfg->ensemble_max_cost_usd > 0.0)
+            cJSON_AddNumberToObject(e, "max_cost_usd", cfg->ensemble_max_cost_usd);
          if (cfg->ensemble_reference_count > 0)
          {
             cJSON *refs = cJSON_AddArrayToObject(e, "reference_models");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1273,7 +1273,8 @@ typedef struct config
     * ensemble_reference_models: diverse model/agent names for the fan-out.
     * ensemble_aggregator: agent name for the synthesis pass.
     * ensemble_min_successful: min references that must succeed before degrading (default 2).
-    * ensemble_max_cost_usd: hard per-call cost cap in USD (default 1.0). */
+    * ensemble_max_cost_usd: optional per-run cost cap in USD; 0 (or unset) means
+    * no limit, which is the default. Set a positive value to cap a run. */
    char ensemble_reference_models[8][128];
    int ensemble_reference_count;
    char ensemble_aggregator[128];


### PR DESCRIPTION
## What

Default `ensemble_max_cost_usd` to `0.0` (unlimited) instead of `1.0`.

Per-run cost caps are now opt-in: leave it unset (or 0) for no limit, set a positive value to cap a run.

## Why

A roundtable run can legitimately cost more than $1; the hardcoded default silently degraded runs that blew the cap. Cost control should be a deliberate choice, not a surprise floor.

## How

- `config.c`: default `0.0` instead of `1.0`.
- `delegate_ensemble.c`: no change needed — every enforcement site already gates on `> 0.0`, so 0 = no cap.
- `config_save.c`: only persist `max_cost_usd` when a positive cap is set.
- `config_sections.c`: parse already ignores `<= 0`, so omit/0 stays unlimited.

## Test

`unit-test-config-surface` and `unit-test-delegate-ensemble` pass; server builds clean.
