### PR TITLE
Promote: ensemble max_cost_usd optional (no cap by default)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -550,7 +550,7 @@ static void config_set_defaults(config_t *cfg)
    snprintf(cfg->db2_vector_corpus_index, sizeof(cfg->db2_vector_corpus_index), "auto");
    cfg->db2_vector_corpus_diskann_threshold = 1000000;
    cfg->ensemble_min_successful = 2;
-   cfg->ensemble_max_cost_usd = 1.0;
+   cfg->ensemble_max_cost_usd = 0.0; /* 0 = no cost cap (unlimited) by default */
    cfg->roundtable_max_rounds = 3;
    cfg->roundtable_converge_threshold = 10;
    cfg->roundtable_deadline_ms = 600000;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -61,7 +61,7 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
 
    /* ensemble.* */
    if (cfg->ensemble_aggregator[0] || cfg->ensemble_min_successful != 2 ||
-       cfg->ensemble_max_cost_usd != 1.0 || cfg->ensemble_reference_count > 0)
+       cfg->ensemble_max_cost_usd > 0.0 || cfg->ensemble_reference_count > 0)
    {
       cJSON *e = cJSON_AddObjectToObject(root, "ensemble");
       if (e)
@@ -69,7 +69,9 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
          if (cfg->ensemble_aggregator[0])
             cJSON_AddStringToObject(e, "aggregator", cfg->ensemble_aggregator);
          cJSON_AddNumberToObject(e, "min_successful", cfg->ensemble_min_successful);
-         cJSON_AddNumberToObject(e, "max_cost_usd", cfg->ensemble_max_cost_usd);
+         /* Only persist a cap when one is set; 0/unset = no limit (the default). */
+         if (cfg->ensemble_max_cost_usd > 0.0)
+            cJSON_AddNumberToObject(e, "max_cost_usd", cfg->ensemble_max_cost_usd);
          if (cfg->ensemble_reference_count > 0)
          {
             cJSON *refs = cJSON_AddArrayToObject(e, "reference_models");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1273,7 +1273,8 @@ typedef struct config
     * ensemble_reference_models: diverse model/agent names for the fan-out.
     * ensemble_aggregator: agent name for the synthesis pass.
     * ensemble_min_successful: min references that must succeed before degrading (default 2).
-    * ensemble_max_cost_usd: hard per-call cost cap in USD (default 1.0). */
+    * ensemble_max_cost_usd: optional per-run cost cap in USD; 0 (or unset) means
+    * no limit, which is the default. Set a positive value to cap a run. */
    char ensemble_reference_models[8][128];
    int ensemble_reference_count;
    char ensemble_aggregator[128];


### PR DESCRIPTION
Promote testing → main.

Ships #242: `ensemble_max_cost_usd` defaults to `0.0` (unlimited). Per-run cost caps are now opt-in — set a positive value to cap a run; leave unset for no limit. Enforcement already gated on `> 0.0`, so 0/unset = no cap.

Fires the auto-release so the new default reaches deployed servers (which carry no persisted ensemble block and thus pick up the compiled default).
