### PR TITLE
Server-sealed dual-access credential vault (WP-C.4)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -375,7 +375,7 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_store.c server/vault_service.c server/server_vault.c
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/server_vault.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/headers/vault_server_key.h
+++ b/src/headers/vault_server_key.h
@@ -1,0 +1,47 @@
+#ifndef DEC_VAULT_SERVER_KEY_H
+#define DEC_VAULT_SERVER_KEY_H 1
+
+#include <stdint.h>
+#include "vault_crypto.h" /* VAULT_KEK_LEN */
+
+/* vault_server_key: the SERVER-sealed key-encryption-key for dual-access
+ * credentials (WP-C.4).
+ *
+ * The per-user vaults (vault_store/vault_service) are zero-knowledge: a
+ * credential's data-encryption key (DEK) is AES-KW-wrapped under a KEK derived
+ * from the client root key (uid:) or login password (webuser:), so the server
+ * cannot read a user's secret without that client unlocking. That makes a
+ * delegate UNRUNNABLE after a restart / KEK-cache TTL expiry — the very thing we
+ * must fix: aimee-server has to drive delegates autonomously.
+ *
+ * Dual-access wrap: every vaulted credential's DEK is wrapped a SECOND time under
+ * this server KEK (in addition to the user KEK). The server can then decrypt the
+ * credential on its own — across restarts, with no client — while the user's
+ * zero-knowledge path is unchanged. The secret is still encrypted at rest (AES-
+ * 256-GCM under a random DEK); the server KEK only unwraps the DEK.
+ *
+ * Trust boundary (deliberate, per the credential-storage directive): the master
+ * key lives 0600 on the server data volume beside the vault. This defeats backup
+ * / disk theft and plaintext-in-config, NOT a root-level host compromise (root
+ * can read both key and data) — the same boundary the rest of aimee-server runs
+ * under. The module is structured so an operator passphrase could wrap the master
+ * key file later without a data migration.
+ *
+ * The 32-byte master key is generated with vault_crypto_random on first use and
+ * persisted at <config_default_dir>/.vault/.server-master.key. The server KEK is
+ * HKDF-derived from it (domain-separated from the user KEKs) and cached process-
+ * wide. Fail-closed: any entropy/IO/derivation failure returns -1 and the caller
+ * must abort the vault op rather than store/read an unprotected credential. */
+
+/* Load-or-create the master key file, derive the server KEK, and write it to
+ * `kek` (VAULT_KEK_LEN bytes). The derived KEK is cached after the first call.
+ * Returns 0 on success, -1 on any failure (kek cleansed). The caller should
+ * OPENSSL_cleanse its copy of `kek` after use. */
+int vault_server_kek(uint8_t kek[VAULT_KEK_LEN]);
+
+/* Test seam: drop the cached server KEK so a test that re-points
+ * config_default_dir at a fresh temp dir re-derives from that dir's master key.
+ * Not for production callers. */
+void vault_server_key_reset_for_test(void);
+
+#endif /* DEC_VAULT_SERVER_KEY_H */

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -64,6 +64,18 @@ vault_status_t vault_service_rekey_password(const char *principal, attested_tran
 vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,
                                  const char *secret, long now_epoch);
 
+/* The SERVER-owned principal (WP-C.4): a vault whose KEK is the server master key
+ * (vault_server_key), needing no client root key / login / unlock. This is where
+ * delegate credentials pushed from a remote (TCP) thin client live, so the server
+ * can read them autonomously over any transport. Encrypted at rest like any other
+ * vault; the server-key trust boundary applies (see vault_server_key.h). */
+#define VAULT_SERVER_PRINCIPAL "server"
+
+/* Store `secret` for (agent, cred) under the server principal, encrypted under the
+ * server master KEK. No unlock required — usable from a TCP client. Returns
+ * VAULT_OK, or VAULT_ERR_CRYPTO/IO on a fail-closed error. */
+vault_status_t vault_service_set_server(const char *agent, const char *cred, const char *secret);
+
 /* The use-path: resolve (agent, cred) for `principal` into `out`. Returns:
  *   VAULT_OK         + plaintext written;
  *   VAULT_NO_ENTRY   when there is no such credential (or no/blank principal) —

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -68,7 +68,16 @@ vault_status_t vault_service_set(const char *principal, const char *agent, const
  * (vault_server_key), needing no client root key / login / unlock. This is where
  * delegate credentials pushed from a remote (TCP) thin client live, so the server
  * can read them autonomously over any transport. Encrypted at rest like any other
- * vault; the server-key trust boundary applies (see vault_server_key.h). */
+ * vault; the server-key trust boundary applies (see vault_server_key.h).
+ *
+ * TENANCY (deliberate): this is a SINGLE shared namespace, not per-user. That is
+ * correct because aimee-server is one person's personal agent and the TCP path is
+ * gated only by the deploy bearer — i.e. a single trust domain (a TCP caller that
+ * can push here can already drive the server). Webchat users, who DO share one
+ * server under distinct logins, get isolated `webuser:` vaults and never land
+ * here. If aimee-server ever becomes multi-tenant over TCP (distinct identities
+ * behind one listener), this principal MUST be namespaced by the attested
+ * identity, or one tenant's delegate would resolve another's key. */
 #define VAULT_SERVER_PRINCIPAL "server"
 
 /* Store `secret` for (agent, cred) under the server principal, encrypted under the

--- a/src/headers/vault_store.h
+++ b/src/headers/vault_store.h
@@ -63,6 +63,34 @@ int vault_store_unlock_check(const char *principal, const uint8_t kek[VAULT_KEK_
 int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
                     const char *cred, const char *secret);
 
+/* Like vault_store_set, but ALSO wraps the per-credential DEK under `server_kek`
+ * (stored as "wrapped_dek_server") so the SERVER can decrypt the credential
+ * autonomously — dual-access wrap (WP-C.4). `server_kek` must be non-NULL; both
+ * wraps are written or the upsert fails (fail-closed: never store a credential
+ * the server cannot later read). 0 on success, -1 on error. */
+int vault_store_set_dual(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+                         const uint8_t server_kek[VAULT_KEK_LEN], const char *agent,
+                         const char *cred, const char *secret);
+
+/* Decrypt the (agent, cred) credential for `principal` using the SERVER wrap
+ * ("wrapped_dek_server") under `server_kek` — NO user KEK / unlock required. This
+ * is the autonomous server use-path. Returns 0 on success, VAULT_STORE_NO_ENTRY
+ * if there is no such credential OR the entry predates dual-wrap (no server wrap
+ * — caller falls back / backfills at next user unlock), or -1 on error (wrong
+ * server_kek, tamper, corrupt file — fail closed). `out` is cleansed on any
+ * non-success. */
+int vault_store_get_server(const char *principal, const uint8_t server_kek[VAULT_KEK_LEN],
+                           const char *agent, const char *cred, char *out, size_t out_len);
+
+/* Backfill the server wrap (WP-C.4) for every credential that lacks one: unwrap
+ * each DEK under `user_kek`, wrap it under `server_kek`, add "wrapped_dek_server".
+ * Called at unlock (when the user KEK is available) so credentials written before
+ * dual-wrap become server-decryptable. Entries already carrying a server wrap are
+ * left untouched. Atomic: if ANY unwrap fails (wrong user_kek / tamper) nothing
+ * is written and -1 is returned. 0 on success (incl. nothing to do). */
+int vault_store_add_server_wraps(const char *principal, const uint8_t user_kek[VAULT_KEK_LEN],
+                                 const uint8_t server_kek[VAULT_KEK_LEN]);
+
 /* Decrypt the (agent, cred) credential for `principal` under `kek` into `out`.
  * Returns 0 on success, VAULT_STORE_NO_ENTRY if no such credential (caller falls
  * back), or -1 on error (wrong KEK, tamper, corrupt file — fail closed). `out` is

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -10,6 +10,7 @@
 #include "cJSON.h"
 #include "json_fluent.h" /* jo_ok */
 #include "log.h"
+#include "vault_service.h" /* vault_service_set / set_server, VAULT_API_KEY_CRED */
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -484,9 +485,38 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
    ag->enabled = opt_has(&opts, "disabled") ? 0 : 1;
 
+   /* A literal --key is a secret: vault it (encrypted at rest), never persist it
+    * in agents.json. A $VAR reference is not a secret — keep it as a reference
+    * that resolves from the environment at run time. */
    const char *key = opt_get(&opts, "key");
    if (key && key[0])
-      agent_expand_env(key, ag->api_key, sizeof(ag->api_key));
+   {
+      if (key[0] == '$')
+      {
+         agent_expand_env(key, ag->api_key, sizeof(ag->api_key));
+      }
+      else
+      {
+         /* A local/webchat caller with a per-user vault gets a dual-access entry
+          * (requires the vault unlocked); a remote (TCP) caller has no per-user
+          * principal, so the secret lands in the server-owned vault, which the
+          * server can decrypt autonomously. On any failure we REFUSE rather than
+          * write the secret to agents.json in plaintext. */
+         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         vault_status_t vst =
+             principal
+                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
+                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
+         if (vst != VAULT_OK)
+         {
+            if (vst == VAULT_ERR_LOCKED)
+               return server_send_error(
+                   conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
+            return server_send_error(conn, "could not store credential in the vault", NULL);
+         }
+         ag->api_key[0] = '\0'; /* the secret lives only in the vault */
+      }
+   }
    const char *auth_cmd = opt_get(&opts, "auth-cmd");
    if (auth_cmd && auth_cmd[0])
       snprintf(ag->auth_cmd, sizeof(ag->auth_cmd), "%s", auth_cmd);

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -493,7 +493,11 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    {
       if (key[0] == '$')
       {
-         agent_expand_env(key, ag->api_key, sizeof(ag->api_key));
+         /* An env reference is not a secret: store it UNEXPANDED so agents.json
+          * holds "$VAR", not the resolved value. agent_load_config expands it
+          * from the environment at run time. Expanding here would serialize the
+          * plaintext key to disk — the exact leak the literal branch avoids. */
+         snprintf(ag->api_key, sizeof(ag->api_key), "%s", key);
       }
       else
       {

--- a/src/server/vault_server_key.c
+++ b/src/server/vault_server_key.c
@@ -7,6 +7,7 @@
 #include "platform_path.h" /* platform_mkdir_p */
 #include "log.h"
 #include <openssl/crypto.h> /* OPENSSL_cleanse */
+#include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdatomic.h>
@@ -35,13 +36,28 @@ static int master_key_path(char *out, size_t cap)
    return (size_t)snprintf(out, cap, "%s/.vault/.server-master.key", base) >= cap ? -1 : 0;
 }
 
-/* Read exactly VAULT_ROOT_KEY_LEN bytes from `path` into `key`. 0 on success,
- * -1 if the file is absent / wrong size / unreadable (key cleansed). */
-static int master_key_read(const char *path, uint8_t key[VAULT_ROOT_KEY_LEN])
+/* Outcome of reading the master-key file. The caller must NOT mint a new key on
+ * MK_READ_BAD — a present-but-unreadable file (transient EACCES/EIO, wrong size)
+ * must fail closed, never be overwritten, or one transient error would orphan
+ * every existing server wrap. Only MK_READ_ABSENT (genuinely no file) may mint. */
+typedef enum
+{
+   MK_READ_OK = 0,
+   MK_READ_ABSENT = 1, /* ENOENT: no key file yet — safe to mint */
+   MK_READ_BAD = -1,   /* exists but unreadable/wrong size — fail closed, do NOT mint */
+} mk_read_t;
+
+/* Read exactly VAULT_ROOT_KEY_LEN bytes from `path` into `key`. Returns MK_READ_*
+ * (key cleansed on any non-OK). A file of any size other than exactly 32 bytes is
+ * BAD, not absent — we never overwrite it. */
+static mk_read_t master_key_read(const char *path, uint8_t key[VAULT_ROOT_KEY_LEN])
 {
    int fd = open(path, O_RDONLY);
    if (fd < 0)
-      return -1;
+   {
+      OPENSSL_cleanse(key, VAULT_ROOT_KEY_LEN);
+      return errno == ENOENT ? MK_READ_ABSENT : MK_READ_BAD;
+   }
    uint8_t buf[VAULT_ROOT_KEY_LEN + 1];
    ssize_t n = read(fd, buf, sizeof(buf));
    close(fd);
@@ -51,7 +67,24 @@ static int master_key_read(const char *path, uint8_t key[VAULT_ROOT_KEY_LEN])
    OPENSSL_cleanse(buf, sizeof(buf));
    if (!ok)
       OPENSSL_cleanse(key, VAULT_ROOT_KEY_LEN);
-   return ok ? 0 : -1;
+   return ok ? MK_READ_OK : MK_READ_BAD;
+}
+
+/* fsync the directory holding `path` so a rename into it survives a crash. */
+static void fsync_parent_dir(const char *path)
+{
+   char dir[1280];
+   snprintf(dir, sizeof(dir), "%s", path);
+   char *slash = strrchr(dir, '/');
+   if (!slash)
+      return;
+   *slash = '\0';
+   int fd = open(dir, O_RDONLY);
+   if (fd >= 0)
+   {
+      (void)fsync(fd);
+      close(fd);
+   }
 }
 
 /* Atomically create the master-key file with `key` at 0600 (tmp + rename +
@@ -82,6 +115,8 @@ static int master_key_write(const char *path, const uint8_t key[VAULT_ROOT_KEY_L
       if (rc != 0)
          unlink(tmp);
    }
+   if (rc == 0)
+      fsync_parent_dir(path); /* make the rename durable across a crash */
    return rc;
 }
 
@@ -94,18 +129,24 @@ static int derive_and_cache(void)
       return -1;
 
    uint8_t master[VAULT_ROOT_KEY_LEN];
-   int have = (master_key_read(path, master) == 0);
-   if (!have)
+   mk_read_t r = master_key_read(path, master);
+   if (r == MK_READ_BAD)
+      return -1; /* present but unreadable — fail closed, NEVER overwrite (F1) */
+   if (r == MK_READ_ABSENT)
    {
-      /* First run: mint a fresh master key and persist it. A concurrent creator
-       * would lose the O_EXCL race; fall back to reading the winner's file. */
+      /* Genuinely no key file: mint a fresh master and persist it. A concurrent
+       * creator would lose the O_EXCL race; fall back to reading the winner's
+       * file (which must now be readable, else fail closed). */
       if (vault_crypto_random(master, sizeof(master)) != 0)
          return -1;
       if (master_key_write(path, master) != 0)
       {
          OPENSSL_cleanse(master, sizeof(master));
-         if (master_key_read(path, master) != 0)
-            return -1; /* neither write nor read succeeded — fail closed */
+         if (master_key_read(path, master) != MK_READ_OK)
+         {
+            OPENSSL_cleanse(master, sizeof(master)); /* read-back failed — cleanse (F2) */
+            return -1;
+         }
       }
    }
 

--- a/src/server/vault_server_key.c
+++ b/src/server/vault_server_key.c
@@ -1,0 +1,144 @@
+/* vault_server_key.c: the server-sealed KEK for dual-access credentials (WP-C.4).
+ * See vault_server_key.h. Reuses the vault_crypto primitives — this file only
+ * manages the 0600 master-key file and caches the derived server KEK. */
+#include "vault_server_key.h"
+#include "vault_crypto.h"
+#include "config.h"        /* config_default_dir */
+#include "platform_path.h" /* platform_mkdir_p */
+#include "log.h"
+#include <openssl/crypto.h> /* OPENSSL_cleanse */
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* Fixed, non-secret HKDF salt for the server KEK. Distinct from the random
+ * per-principal salts the user vaults use, so the server KEK lives in its own
+ * derivation space (domain separation). Changing it would orphan every existing
+ * server wrap, so it is frozen. */
+static const uint8_t SERVER_KEK_SALT[VAULT_SALT_LEN] = {
+    0x61, 0x69, 0x6d, 0x65, 0x65, 0x2d, 0x73, 0x76, 0x72, 0x6b, 0x65, 0x6b, 0x2d, 0x76, 0x31, 0x00};
+
+static pthread_mutex_t g_kek_mu = PTHREAD_MUTEX_INITIALIZER;
+static uint8_t g_kek[VAULT_KEK_LEN];
+static int g_kek_ready; /* 0 until the KEK is derived + cached */
+
+/* Compose <config_default_dir>/.vault/.server-master.key. Returns 0 on success. */
+static int master_key_path(char *out, size_t cap)
+{
+   const char *base = config_default_dir();
+   if (!base || !base[0])
+      return -1;
+   return (size_t)snprintf(out, cap, "%s/.vault/.server-master.key", base) >= cap ? -1 : 0;
+}
+
+/* Read exactly VAULT_ROOT_KEY_LEN bytes from `path` into `key`. 0 on success,
+ * -1 if the file is absent / wrong size / unreadable (key cleansed). */
+static int master_key_read(const char *path, uint8_t key[VAULT_ROOT_KEY_LEN])
+{
+   int fd = open(path, O_RDONLY);
+   if (fd < 0)
+      return -1;
+   uint8_t buf[VAULT_ROOT_KEY_LEN + 1];
+   ssize_t n = read(fd, buf, sizeof(buf));
+   close(fd);
+   int ok = (n == (ssize_t)VAULT_ROOT_KEY_LEN);
+   if (ok)
+      memcpy(key, buf, VAULT_ROOT_KEY_LEN);
+   OPENSSL_cleanse(buf, sizeof(buf));
+   if (!ok)
+      OPENSSL_cleanse(key, VAULT_ROOT_KEY_LEN);
+   return ok ? 0 : -1;
+}
+
+/* Atomically create the master-key file with `key` at 0600 (tmp + rename +
+ * fsync). 0 on success, -1 on error. */
+static int master_key_write(const char *path, const uint8_t key[VAULT_ROOT_KEY_LEN])
+{
+   char dir[1024], tmp[1280];
+   const char *base = config_default_dir();
+   if (!base || !base[0] || (size_t)snprintf(dir, sizeof(dir), "%s/.vault", base) >= sizeof(dir))
+      return -1;
+   if (platform_mkdir_p(dir, 0700) != 0)
+      return -1;
+   static atomic_uint s_seq = 0;
+   unsigned seq = atomic_fetch_add(&s_seq, 1);
+   if ((size_t)snprintf(tmp, sizeof(tmp), "%s.tmp.%d.%u", path, (int)getpid(), seq) >= sizeof(tmp))
+      return -1;
+
+   int rc = -1;
+   int fd = open(tmp, O_CREAT | O_WRONLY | O_TRUNC | O_EXCL, 0600);
+   if (fd >= 0)
+   {
+      ssize_t w = write(fd, key, VAULT_ROOT_KEY_LEN);
+      if (w == (ssize_t)VAULT_ROOT_KEY_LEN && fsync(fd) == 0)
+         rc = 0;
+      close(fd);
+      if (rc == 0 && rename(tmp, path) != 0)
+         rc = -1;
+      if (rc != 0)
+         unlink(tmp);
+   }
+   return rc;
+}
+
+/* Load-or-create the master key, derive the server KEK, cache it. Caller holds
+ * g_kek_mu. */
+static int derive_and_cache(void)
+{
+   char path[1280];
+   if (master_key_path(path, sizeof(path)) != 0)
+      return -1;
+
+   uint8_t master[VAULT_ROOT_KEY_LEN];
+   int have = (master_key_read(path, master) == 0);
+   if (!have)
+   {
+      /* First run: mint a fresh master key and persist it. A concurrent creator
+       * would lose the O_EXCL race; fall back to reading the winner's file. */
+      if (vault_crypto_random(master, sizeof(master)) != 0)
+         return -1;
+      if (master_key_write(path, master) != 0)
+      {
+         OPENSSL_cleanse(master, sizeof(master));
+         if (master_key_read(path, master) != 0)
+            return -1; /* neither write nor read succeeded — fail closed */
+      }
+   }
+
+   int rc = vault_kek_derive(master, sizeof(master), SERVER_KEK_SALT, sizeof(SERVER_KEK_SALT),
+                             g_kek) == 0
+                ? 0
+                : -1;
+   OPENSSL_cleanse(master, sizeof(master));
+   if (rc == 0)
+      g_kek_ready = 1;
+   else
+      OPENSSL_cleanse(g_kek, sizeof(g_kek));
+   return rc;
+}
+
+int vault_server_kek(uint8_t kek[VAULT_KEK_LEN])
+{
+   if (!kek)
+      return -1;
+   pthread_mutex_lock(&g_kek_mu);
+   int rc = g_kek_ready ? 0 : derive_and_cache();
+   if (rc == 0)
+      memcpy(kek, g_kek, VAULT_KEK_LEN);
+   pthread_mutex_unlock(&g_kek_mu);
+   if (rc != 0)
+      OPENSSL_cleanse(kek, VAULT_KEK_LEN);
+   return rc;
+}
+
+void vault_server_key_reset_for_test(void)
+{
+   pthread_mutex_lock(&g_kek_mu);
+   OPENSSL_cleanse(g_kek, sizeof(g_kek));
+   g_kek_ready = 0;
+   pthread_mutex_unlock(&g_kek_mu);
+}

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -74,6 +74,50 @@ static vault_status_t vault_service_get_server(const char *principal, const char
    return VAULT_ERR_CRYPTO; /* decrypt/tamper — fail closed */
 }
 
+/* Read (agent, cred) from the SERVER principal's vault under the server master KEK
+ * — no client, no unlock. VAULT_OK / VAULT_NO_ENTRY (no file or no entry) /
+ * VAULT_ERR_* (fail closed). */
+static vault_status_t vault_service_get_server_principal(const char *agent, const char *cred,
+                                                         char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!agent || !cred || !out || !out_len)
+      return VAULT_ERR_BADARG;
+   uint8_t kek[VAULT_KEK_LEN];
+   if (vault_server_kek(kek) != 0)
+      return VAULT_ERR_CRYPTO;
+   int rc = vault_store_get(VAULT_SERVER_PRINCIPAL, kek, agent, cred, out, out_len);
+   OPENSSL_cleanse(kek, sizeof(kek));
+   if (rc == 0)
+      return VAULT_OK;
+   if (rc == VAULT_STORE_NO_ENTRY)
+      return VAULT_NO_ENTRY;
+   return VAULT_ERR_CRYPTO; /* decrypt/tamper — fail closed */
+}
+
+vault_status_t vault_service_set_server(const char *agent, const char *cred, const char *secret)
+{
+   if (!agent || !agent[0] || !cred || !cred[0] || !secret)
+      return VAULT_ERR_BADARG;
+   uint8_t kek[VAULT_KEK_LEN];
+   if (vault_server_kek(kek) != 0)
+      return VAULT_ERR_CRYPTO; /* fail-closed: no server KEK -> never store plaintext */
+
+   /* The vault file must exist before set; create it (the stored salt is unused
+    * for the server KEK, which is derived from the master key, not salt+root). */
+   uint8_t salt[VAULT_SALT_LEN];
+   vault_status_t st;
+   if (vault_store_get_or_create_salt(VAULT_SERVER_PRINCIPAL, salt) != 0)
+      st = VAULT_ERR_IO;
+   else
+      st = vault_store_set(VAULT_SERVER_PRINCIPAL, kek, agent, cred, secret) == 0 ? VAULT_OK
+                                                                                  : VAULT_ERR_IO;
+   OPENSSL_cleanse(kek, sizeof(kek));
+   OPENSSL_cleanse(salt, sizeof(salt));
+   return st;
+}
+
 vault_status_t vault_service_unlock(const char *principal, attested_transport_t transport,
                                     const uint8_t *root_key, size_t root_key_len, long now_epoch)
 {
@@ -299,6 +343,11 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
        vault_service_get_server(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len);
    if (st == VAULT_NO_ENTRY)
       st = vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
+   /* Last: the server-owned vault (delegate creds pushed from a TCP thin client,
+    * which has no per-user principal). Only on a clean miss — a LOCKED user cred
+    * stays a hard error (D15), never silently downgraded to the server vault. */
+   if (st == VAULT_NO_ENTRY)
+      st = vault_service_get_server_principal(agent, VAULT_API_KEY_CRED, tmp, api_key_len);
    if (st == VAULT_OK)
       snprintf(api_key, api_key_len, "%s", tmp); /* overwrite only on a real hit */
    OPENSSL_cleanse(tmp, api_key_len);

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -53,8 +53,8 @@ static void vault_service_backfill_server_wraps(const char *principal,
  * client unlock / KEK cache. Returns VAULT_OK (plaintext written), VAULT_NO_ENTRY
  * (no such cred, or a legacy user-only entry — caller falls back to the user KEK
  * path), or VAULT_ERR_* (fail closed). */
-static vault_status_t vault_service_get_server(const char *principal, const char *agent,
-                                               const char *cred, char *out, size_t out_len)
+static vault_status_t vault_service_get_server_wrap(const char *principal, const char *agent,
+                                                    const char *cred, char *out, size_t out_len)
 {
    if (out && out_len)
       out[0] = '\0';
@@ -340,7 +340,7 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
     * unlock, survives restart. Fall back to the user-KEK path only for legacy
     * creds not yet dual-wrapped (those get backfilled at the next user unlock). */
    vault_status_t st =
-       vault_service_get_server(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len);
+       vault_service_get_server_wrap(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len);
    if (st == VAULT_NO_ENTRY)
       st = vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
    /* Last: the server-owned vault (delegate creds pushed from a TCP thin client,

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -5,6 +5,7 @@
 #include "vault_service.h"
 #include "vault_crypto.h"
 #include "vault_kek_cache.h"
+#include "vault_server_key.h"
 #include "vault_store.h"
 #include "log.h"
 #include <openssl/crypto.h>
@@ -35,6 +36,44 @@ const char *vault_status_str(vault_status_t s)
    return "error";
 }
 
+/* Add the server wrap to any user-only credentials for `principal` using the live
+ * user KEK (WP-C.4 dual-access backfill). Best-effort; logs on failure. */
+static void vault_service_backfill_server_wraps(const char *principal,
+                                                const uint8_t user_kek[VAULT_KEK_LEN])
+{
+   uint8_t server_kek[VAULT_KEK_LEN];
+   if (vault_server_kek(server_kek) != 0)
+      return;
+   if (vault_store_add_server_wraps(principal, user_kek, server_kek) != 0)
+      LOG_WARN("vault", "server-wrap backfill failed (creds remain user-only until next unlock)");
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
+}
+
+/* The autonomous server use-path: decrypt (agent, cred) via the server wrap, no
+ * client unlock / KEK cache. Returns VAULT_OK (plaintext written), VAULT_NO_ENTRY
+ * (no such cred, or a legacy user-only entry — caller falls back to the user KEK
+ * path), or VAULT_ERR_* (fail closed). */
+static vault_status_t vault_service_get_server(const char *principal, const char *agent,
+                                               const char *cred, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!principal || !principal[0])
+      return VAULT_NO_ENTRY;
+   if (!agent || !cred || !out || !out_len)
+      return VAULT_ERR_BADARG;
+   uint8_t server_kek[VAULT_KEK_LEN];
+   if (vault_server_kek(server_kek) != 0)
+      return VAULT_ERR_CRYPTO;
+   int rc = vault_store_get_server(principal, server_kek, agent, cred, out, out_len);
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
+   if (rc == 0)
+      return VAULT_OK;
+   if (rc == VAULT_STORE_NO_ENTRY)
+      return VAULT_NO_ENTRY;
+   return VAULT_ERR_CRYPTO; /* decrypt/tamper — fail closed */
+}
+
 vault_status_t vault_service_unlock(const char *principal, attested_transport_t transport,
                                     const uint8_t *root_key, size_t root_key_len, long now_epoch)
 {
@@ -62,6 +101,12 @@ vault_status_t vault_service_unlock(const char *principal, attested_transport_t 
       st = VAULT_ERR_CRYPTO; /* wrong root key — caught by the key-check verifier */
    else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
       st = VAULT_ERR_LOCKED; /* cache full of live principals — reject, don't evict */
+
+   /* WP-C.4 dual-access backfill: now that we hold the user KEK, add the server
+    * wrap to any credentials written before dual-wrap so the server can decrypt
+    * them autonomously. Best-effort — never fail the unlock on a backfill error. */
+   if (st == VAULT_OK)
+      vault_service_backfill_server_wraps(principal, kek);
 
    OPENSSL_cleanse(kek, sizeof(kek));
    OPENSSL_cleanse(salt, sizeof(salt));
@@ -96,6 +141,10 @@ vault_status_t vault_service_unlock_password(const char *principal, attested_tra
       st = VAULT_ERR_CRYPTO; /* wrong password — caught by the key-check verifier */
    else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
       st = VAULT_ERR_LOCKED;
+
+   /* WP-C.4 dual-access backfill (see vault_service_unlock). */
+   if (st == VAULT_OK)
+      vault_service_backfill_server_wraps(principal, kek);
 
    OPENSSL_cleanse(kek, sizeof(kek));
    OPENSSL_cleanse(salt, sizeof(salt));
@@ -152,9 +201,20 @@ vault_status_t vault_service_set(const char *principal, const char *agent, const
    if (vault_kek_cache_get(principal, now_epoch, kek) != 0)
       return VAULT_ERR_LOCKED; /* must unlock first */
 
-   vault_status_t st =
-       vault_store_set(principal, kek, agent, cred, secret) == 0 ? VAULT_OK : VAULT_ERR_IO;
+   /* WP-C.4 dual-access: wrap the DEK under BOTH the user KEK and the server KEK
+    * so the server can decrypt this credential autonomously after a restart.
+    * Fail-closed if the server KEK is unavailable — never store a user-only cred
+    * the server cannot later read (that is the bug this whole change fixes). */
+   uint8_t server_kek[VAULT_KEK_LEN];
+   vault_status_t st;
+   if (vault_server_kek(server_kek) != 0)
+      st = VAULT_ERR_CRYPTO;
+   else
+      st = vault_store_set_dual(principal, kek, server_kek, agent, cred, secret) == 0
+               ? VAULT_OK
+               : VAULT_ERR_IO;
    OPENSSL_cleanse(kek, sizeof(kek));
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
    return st;
 }
 
@@ -232,8 +292,13 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
    char *tmp = malloc(api_key_len);
    if (!tmp)
       return VAULT_ERR_IO;
+   /* Server-first (WP-C.4): the server wrap decrypts autonomously — no client
+    * unlock, survives restart. Fall back to the user-KEK path only for legacy
+    * creds not yet dual-wrapped (those get backfilled at the next user unlock). */
    vault_status_t st =
-       vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
+       vault_service_get_server(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len);
+   if (st == VAULT_NO_ENTRY)
+      st = vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
    if (st == VAULT_OK)
       snprintf(api_key, api_key_len, "%s", tmp); /* overwrite only on a real hit */
    OPENSSL_cleanse(tmp, api_key_len);

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -332,8 +332,11 @@ static int add_b64_field(cJSON *obj, const char *name, const uint8_t *bin, size_
    return 0;
 }
 
-int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
-                    const char *cred, const char *secret)
+/* Shared set implementation. When `server_kek` is non-NULL the DEK is wrapped a
+ * second time under it ("wrapped_dek_server") for dual-access (WP-C.4). */
+static int vault_store_set_impl(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+                                const uint8_t *server_kek, const char *agent, const char *cred,
+                                const char *secret)
 {
    if (!principal || !kek || !agent || !agent[0] || !cred || !cred[0] || !secret)
       return -1;
@@ -351,7 +354,8 @@ int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], con
 
    int rc = -1;
    uint8_t dek[VAULT_DEK_LEN] = {0};
-   uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], nonce[VAULT_GCM_NONCE_LEN], tag[VAULT_GCM_TAG_LEN];
+   uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], wrapped_server[VAULT_WRAPPED_DEK_LEN],
+       nonce[VAULT_GCM_NONCE_LEN], tag[VAULT_GCM_TAG_LEN];
    uint8_t *ct = malloc(pt_len ? pt_len : 1);
    char aad[VAULT_AAD_MAX];
    if (!ct)
@@ -364,6 +368,11 @@ int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], con
                             nonce, ct, tag) != 0)
       goto out;
    if (vault_dek_wrap(kek, dek, wrapped) != 0)
+      goto out;
+   /* Dual-access: a second wrap of the same DEK under the server KEK. Fail-closed
+    * — if requested but it can't be produced, store nothing (never a credential
+    * the server cannot later read). */
+   if (server_kek && vault_dek_wrap(server_kek, dek, wrapped_server) != 0)
       goto out;
 
    /* Build the cred object, replacing any existing entry for (agent,cred). */
@@ -380,7 +389,9 @@ int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], con
       if (add_b64_field(obj, "wrapped_dek", wrapped, sizeof(wrapped)) != 0 ||
           add_b64_field(obj, "nonce", nonce, sizeof(nonce)) != 0 ||
           add_b64_field(obj, "ciphertext", ct, pt_len) != 0 ||
-          add_b64_field(obj, "tag", tag, sizeof(tag)) != 0)
+          add_b64_field(obj, "tag", tag, sizeof(tag)) != 0 ||
+          (server_kek &&
+           add_b64_field(obj, "wrapped_dek_server", wrapped_server, sizeof(wrapped_server)) != 0))
       {
          cJSON_Delete(obj);
          goto out;
@@ -400,6 +411,21 @@ out:
    cJSON_Delete(root);
    pthread_mutex_unlock(&g_vault_write_mu);
    return rc;
+}
+
+int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
+                    const char *cred, const char *secret)
+{
+   return vault_store_set_impl(principal, kek, NULL, agent, cred, secret);
+}
+
+int vault_store_set_dual(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+                         const uint8_t server_kek[VAULT_KEK_LEN], const char *agent,
+                         const char *cred, const char *secret)
+{
+   if (!server_kek)
+      return -1;
+   return vault_store_set_impl(principal, kek, server_kek, agent, cred, secret);
 }
 
 int vault_store_get(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
@@ -479,6 +505,143 @@ out:
    if (rc != 0 && out && out_len)
       OPENSSL_cleanse(out, out_len);
    cJSON_Delete(root);
+   return rc;
+}
+
+int vault_store_get_server(const char *principal, const uint8_t server_kek[VAULT_KEK_LEN],
+                           const char *agent, const char *cred, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!principal || !server_kek || !agent || !cred || !out || !out_len)
+      return -1;
+
+   cJSON *root = load_vault(principal);
+   if (!root)
+      return VAULT_STORE_NO_ENTRY; /* no file -> no entry, fall back */
+
+   int rc = -1;
+   uint8_t dek[VAULT_DEK_LEN] = {0};
+   uint8_t *pt = NULL;
+   size_t pt_alloc = 0;
+   cJSON *e = find_cred(root, agent, cred);
+   if (!e)
+   {
+      rc = VAULT_STORE_NO_ENTRY;
+      goto out;
+   }
+   {
+      cJSON *jw = cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek_server");
+      cJSON *jn = cJSON_GetObjectItemCaseSensitive(e, "nonce");
+      cJSON *jc = cJSON_GetObjectItemCaseSensitive(e, "ciphertext");
+      cJSON *jt = cJSON_GetObjectItemCaseSensitive(e, "tag");
+      /* A legacy entry (pre-dual-wrap) has no server wrap: report NO_ENTRY so the
+       * caller falls back / backfills at the next user unlock, never an error. */
+      if (!cJSON_IsString(jw))
+      {
+         rc = VAULT_STORE_NO_ENTRY;
+         goto out;
+      }
+      if (!cJSON_IsString(jn) || !cJSON_IsString(jc) || !cJSON_IsString(jt))
+         goto out;
+      uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], nonce[VAULT_GCM_NONCE_LEN], tag[VAULT_GCM_TAG_LEN];
+      if (b64url_decode(jw->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+          b64url_decode(jn->valuestring, nonce, sizeof(nonce)) != VAULT_GCM_NONCE_LEN ||
+          b64url_decode(jt->valuestring, tag, sizeof(tag)) != VAULT_GCM_TAG_LEN)
+         goto out;
+      size_t ct_cap = strlen(jc->valuestring); /* >= decoded length */
+      pt = malloc(ct_cap + 1);
+      pt_alloc = ct_cap + 1;
+      uint8_t *ctbuf = malloc(ct_cap + 1);
+      if (!pt || !ctbuf)
+      {
+         free(ctbuf);
+         goto out;
+      }
+      int ct_len = b64url_decode(jc->valuestring, ctbuf, ct_cap + 1);
+      char aad[VAULT_AAD_MAX];
+      if (ct_len < 0 || build_aad(principal, agent, cred, aad, sizeof(aad)) < 0 ||
+          (size_t)ct_len >= out_len)
+      {
+         free(ctbuf);
+         goto out;
+      }
+      if (vault_dek_unwrap(server_kek, wrapped, dek) != 0 ||
+          vault_secret_decrypt(dek, (const uint8_t *)aad, strlen(aad), nonce, ctbuf, (size_t)ct_len,
+                               tag, pt) != 0)
+      {
+         OPENSSL_cleanse(ctbuf, ct_cap + 1);
+         free(ctbuf);
+         goto out; /* fail-closed: wrong server KEK / tamper / AAD mismatch */
+      }
+      memcpy(out, pt, (size_t)ct_len);
+      out[ct_len] = '\0';
+      OPENSSL_cleanse(ctbuf, ct_cap + 1);
+      free(ctbuf);
+      rc = 0;
+   }
+
+out:
+   OPENSSL_cleanse(dek, sizeof(dek));
+   if (pt)
+   {
+      OPENSSL_cleanse(pt, pt_alloc);
+      free(pt);
+   }
+   if (rc != 0 && out && out_len)
+      OPENSSL_cleanse(out, out_len);
+   cJSON_Delete(root);
+   return rc;
+}
+
+int vault_store_add_server_wraps(const char *principal, const uint8_t user_kek[VAULT_KEK_LEN],
+                                 const uint8_t server_kek[VAULT_KEK_LEN])
+{
+   if (!principal || !user_kek || !server_kek)
+      return -1;
+   pthread_mutex_lock(&g_vault_write_mu);
+   cJSON *root = load_vault(principal);
+   if (!root)
+   {
+      pthread_mutex_unlock(&g_vault_write_mu);
+      return 0; /* no vault -> nothing to backfill */
+   }
+
+   int rc = 0;
+   int changed = 0;
+   cJSON *creds = creds_array(root);
+   cJSON *e = NULL;
+   if (creds)
+   {
+      cJSON_ArrayForEach(e, creds)
+      {
+         if (cJSON_IsString(cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek_server")))
+            continue; /* already dual-wrapped */
+         cJSON *jw = cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek");
+         uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], dek[VAULT_DEK_LEN],
+             rewrapped[VAULT_WRAPPED_DEK_LEN];
+         if (!cJSON_IsString(jw) ||
+             b64url_decode(jw->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+             vault_dek_unwrap(user_kek, wrapped, dek) != 0 ||
+             vault_dek_wrap(server_kek, dek, rewrapped) != 0)
+         {
+            OPENSSL_cleanse(dek, sizeof(dek));
+            rc = -1; /* wrong user KEK / tamper -> abort, write nothing */
+            break;
+         }
+         OPENSSL_cleanse(dek, sizeof(dek));
+         if (add_b64_field(e, "wrapped_dek_server", rewrapped, sizeof(rewrapped)) != 0)
+         {
+            rc = -1;
+            break;
+         }
+         changed = 1;
+      }
+   }
+   if (rc == 0 && changed)
+      rc = write_vault_file(principal, root);
+   cJSON_Delete(root);
+   pthread_mutex_unlock(&g_vault_write_mu);
    return rc;
 }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -188,6 +188,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-kek-cache \
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
+               $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-prompts \
                $(TESTPREFIX)/unit-test-cmd-session \
                $(TESTPREFIX)/unit-test-model-registry \
@@ -1796,6 +1797,12 @@ $(TESTPREFIX)/unit-test-vault-store: $(OBJDIR)/tests/test_vault_store.o \
 $(TESTPREFIX)/unit-test-vault-service: $(OBJDIR)/tests/test_vault_service.o \
                               $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
                               $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-vault-server-key: $(OBJDIR)/tests/test_vault_server_key.o \
+                              $(OBJDIR)/server/vault_server_key.o $(OBJDIR)/server/vault_crypto.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_vault_server_key.c
+++ b/src/tests/test_vault_server_key.c
@@ -1,0 +1,87 @@
+/* test_vault_server_key.c: WP-C.4 — the server-sealed KEK that lets aimee-server
+ * decrypt dual-access credentials autonomously. Runs against a throwaway
+ * AIMEE_HOME. Pins: derive succeeds + is non-trivial; the KEK is stable across
+ * calls (cached) AND across a cache reset (re-derived from the persisted master
+ * key file, i.e. survives a "restart"); the master key file is 0600 and exactly
+ * 32 bytes. */
+#include "vault_server_key.h"
+#include "vault_crypto.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[256];
+
+static int is_all_zero(const uint8_t *p, size_t n)
+{
+   for (size_t i = 0; i < n; i++)
+      if (p[i])
+         return 0;
+   return 1;
+}
+
+static void test_derive_nontrivial(void)
+{
+   uint8_t kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(kek) == 0);
+   assert(!is_all_zero(kek, sizeof(kek))); /* a real derived key, not a zero buffer */
+   printf("  PASS: test_derive_nontrivial\n");
+}
+
+static void test_stable_cached(void)
+{
+   uint8_t a[VAULT_KEK_LEN], b[VAULT_KEK_LEN];
+   assert(vault_server_kek(a) == 0);
+   assert(vault_server_kek(b) == 0);
+   assert(memcmp(a, b, sizeof(a)) == 0); /* same KEK within a process */
+   printf("  PASS: test_stable_cached\n");
+}
+
+static void test_survives_restart(void)
+{
+   uint8_t before[VAULT_KEK_LEN], after[VAULT_KEK_LEN];
+   assert(vault_server_kek(before) == 0);
+   /* Simulate a process restart: drop the in-RAM cache, re-derive from the
+    * persisted master key file. The KEK must be identical (else every restart
+    * would orphan all server wraps). */
+   vault_server_key_reset_for_test();
+   assert(vault_server_kek(after) == 0);
+   assert(memcmp(before, after, sizeof(before)) == 0);
+   printf("  PASS: test_survives_restart\n");
+}
+
+static void test_master_key_file_locked_down(void)
+{
+   uint8_t kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(kek) == 0); /* ensure the file exists */
+   char path[512];
+   snprintf(path, sizeof(path), "%s/.vault/.server-master.key", g_home);
+   struct stat st;
+   assert(stat(path, &st) == 0);
+   assert(st.st_size == VAULT_ROOT_KEY_LEN); /* exactly 32 bytes */
+   assert((st.st_mode & 0777) == 0600);      /* owner-only */
+   printf("  PASS: test_master_key_file_locked_down\n");
+}
+
+int main(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-svrkey-test-%d", (int)getpid());
+   char mk[320];
+   snprintf(mk, sizeof(mk), "rm -rf %s && mkdir -p %s", g_home, g_home);
+   assert(system(mk) == 0);
+   setenv("AIMEE_HOME", g_home, 1);
+
+   test_derive_nontrivial();
+   test_stable_cached();
+   test_survives_restart();
+   test_master_key_file_locked_down();
+
+   char rm[320];
+   snprintf(rm, sizeof(rm), "rm -rf %s", g_home);
+   (void)system(rm);
+   printf("vault_server_key: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_vault_server_key.c
+++ b/src/tests/test_vault_server_key.c
@@ -66,6 +66,30 @@ static void test_master_key_file_locked_down(void)
    printf("  PASS: test_master_key_file_locked_down\n");
 }
 
+/* F1 (roundtable): a present-but-unreadable/wrong-size master key must fail
+ * closed and NEVER be overwritten — otherwise one transient read error would
+ * orphan every existing server wrap. Run LAST: it corrupts the key file. */
+static void test_bad_master_key_not_overwritten(void)
+{
+   char path[512];
+   snprintf(path, sizeof(path), "%s/.vault/.server-master.key", g_home);
+   /* Clobber the (valid) key with a wrong-size file. */
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   const char junk[10] = "BADKEYDATA";
+   assert(fwrite(junk, 1, sizeof(junk), f) == sizeof(junk));
+   fclose(f);
+
+   vault_server_key_reset_for_test();
+   uint8_t kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(kek) == -1); /* fail closed, do not mint */
+
+   /* The bad file must be untouched (not overwritten with a fresh 32-byte key). */
+   struct stat st;
+   assert(stat(path, &st) == 0 && st.st_size == (off_t)sizeof(junk));
+   printf("  PASS: test_bad_master_key_not_overwritten\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-svrkey-test-%d", (int)getpid());
@@ -78,6 +102,7 @@ int main(void)
    test_stable_cached();
    test_survives_restart();
    test_master_key_file_locked_down();
+   test_bad_master_key_not_overwritten(); /* must run last: corrupts the key file */
 
    char rm[320];
    snprintf(rm, sizeof(rm), "rm -rf %s", g_home);

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -248,6 +248,41 @@ static void test_rekey_empty_and_missing_vault(void)
    printf("  PASS: test_rekey_empty_and_missing_vault\n");
 }
 
+/* WP-C.4: the autonomous server path. After a "restart" (the user KEK cache is
+ * cleared, so the user vault is LOCKED), a dual-wrapped credential is STILL
+ * injectable via the server wrap — the whole point: aimee-server can drive
+ * delegates without the client re-unlocking. A genuinely missing credential is
+ * still NO_ENTRY and leaves the caller's api_key untouched. */
+static void test_server_inject_after_restart(void)
+{
+   const char *p = "uid:7000";
+   uint8_t rk[VAULT_ROOT_KEY_LEN];
+   root_key(rk, 7);
+   assert(vault_service_unlock(p, ATTEST_UDS_PEERCRED, rk, sizeof(rk), T0) == VAULT_OK);
+   assert(vault_service_set(p, "claude", "api_key", "sk-autonomous", T0) == VAULT_OK);
+
+   /* While unlocked, inject works. */
+   char key[64] = "PRESET";
+   assert(vault_service_inject_api_key(p, "claude", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-autonomous") == 0);
+
+   /* Simulate a restart: drop every cached user KEK -> the user vault is locked. */
+   vault_kek_cache_clear();
+   char out[64];
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_ERR_LOCKED);
+   /* Inject still succeeds via the server wrap with NO unlock. */
+   char key2[64] = "PRESET";
+   assert(vault_service_inject_api_key(p, "claude", key2, sizeof(key2), T0) == VAULT_OK);
+   assert(strcmp(key2, "sk-autonomous") == 0);
+
+   /* A truly missing credential is NO_ENTRY; api_key left untouched (env fallback). */
+   char key3[64] = "KEEP";
+   assert(vault_service_inject_api_key(p, "absent-agent", key3, sizeof(key3), T0) ==
+          VAULT_NO_ENTRY);
+   assert(strcmp(key3, "KEEP") == 0);
+   printf("  PASS: test_server_inject_after_restart\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultsvc-test-%d", (int)getpid());
@@ -266,6 +301,7 @@ int main(void)
    test_webuser_password_unlock();
    test_webuser_rekey();
    test_rekey_empty_and_missing_vault();
+   test_server_inject_after_restart();
 
    vault_kek_cache_clear();
    char rm[320];

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -283,6 +283,32 @@ static void test_server_inject_after_restart(void)
    printf("  PASS: test_server_inject_after_restart\n");
 }
 
+/* WP-C.4 server principal: a delegate credential pushed with NO per-user
+ * principal (the TCP thin-client case) lands in the server-owned vault and is
+ * resolved autonomously by inject — no unlock, survives a cache clear. */
+static void test_server_principal_vault(void)
+{
+   /* No unlock, no user principal — set_server just works. */
+   assert(vault_service_set_server("claude", VAULT_API_KEY_CRED, "sk-server-owned") == VAULT_OK);
+
+   /* inject with an EMPTY principal (the TCP case) resolves from the server vault. */
+   char key[64] = "PRESET";
+   assert(vault_service_inject_api_key("", "claude", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-server-owned") == 0);
+
+   /* A missing agent is NO_ENTRY; api_key untouched. */
+   char k2[64] = "KEEP";
+   assert(vault_service_inject_api_key("", "absent", k2, sizeof(k2), T0) == VAULT_NO_ENTRY);
+   assert(strcmp(k2, "KEEP") == 0);
+
+   /* Survives a restart: the server principal needs no KEK cache. */
+   vault_kek_cache_clear();
+   char k3[64] = "PRESET";
+   assert(vault_service_inject_api_key("", "claude", k3, sizeof(k3), T0) == VAULT_OK);
+   assert(strcmp(k3, "sk-server-owned") == 0);
+   printf("  PASS: test_server_principal_vault\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultsvc-test-%d", (int)getpid());
@@ -302,6 +328,7 @@ int main(void)
    test_webuser_rekey();
    test_rekey_empty_and_missing_vault();
    test_server_inject_after_restart();
+   test_server_principal_vault();
 
    vault_kek_cache_clear();
    char rm[320];

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -288,6 +288,11 @@ static void test_server_inject_after_restart(void)
  * resolved autonomously by inject — no unlock, survives a cache clear. */
 static void test_server_principal_vault(void)
 {
+   /* Pin the namespace: the server vault is a single shared principal. If this
+    * ever needs per-tenant isolation (multi-tenant TCP), this assert fails and
+    * forces the change to be deliberate (see vault_service.h tenancy note). */
+   assert(strcmp(VAULT_SERVER_PRINCIPAL, "server") == 0);
+
    /* No unlock, no user principal — set_server just works. */
    assert(vault_service_set_server("claude", VAULT_API_KEY_CRED, "sk-server-owned") == VAULT_OK);
 

--- a/src/tests/test_vault_store.c
+++ b/src/tests/test_vault_store.c
@@ -324,6 +324,92 @@ static void test_intra_principal_aad_swap(void)
    printf("  PASS: test_intra_principal_aad_swap\n");
 }
 
+/* WP-C.4 dual-access: a credential written with set_dual carries a second DEK
+ * wrap under the server KEK; the server can decrypt it with NO user KEK, while
+ * the user path is unchanged. A wrong server KEK fails closed. */
+static void test_dual_wrap_server_get(void)
+{
+   const char *p = "uid:4242";
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt(p, salt) == 0);
+   uint8_t kek[VAULT_KEK_LEN], skek[VAULT_KEK_LEN];
+   make_kek(kek, 42);
+   make_kek(skek, 200); /* distinct server KEK */
+   const char *secret = "sk-dual-access-secret";
+   assert(vault_store_set_dual(p, kek, skek, "claude", "api_key", secret) == 0);
+
+   char out[256];
+   /* user path still works */
+   assert(vault_store_get(p, kek, "claude", "api_key", out, sizeof(out)) == 0);
+   assert(strcmp(out, secret) == 0);
+   /* server path works WITHOUT the user KEK */
+   assert(vault_store_get_server(p, skek, "claude", "api_key", out, sizeof(out)) == 0);
+   assert(strcmp(out, secret) == 0);
+   /* wrong server KEK fails closed (not the secret, not NO_ENTRY) */
+   uint8_t bad[VAULT_KEK_LEN];
+   make_kek(bad, 201);
+   assert(vault_store_get_server(p, bad, "claude", "api_key", out, sizeof(out)) == -1);
+   printf("  PASS: test_dual_wrap_server_get\n");
+}
+
+/* A legacy (user-only) entry has no server wrap: the server get reports NO_ENTRY
+ * (fall back), and backfill adds the wrap so it becomes server-decryptable. A
+ * backfill under the wrong user KEK fails closed and writes nothing. */
+static void test_server_get_legacy_then_backfill(void)
+{
+   const char *p = "uid:4343";
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt(p, salt) == 0);
+   uint8_t kek[VAULT_KEK_LEN], skek[VAULT_KEK_LEN];
+   make_kek(kek, 43);
+   make_kek(skek, 210);
+   const char *secret = "legacy-user-only";
+   assert(vault_store_set(p, kek, "openai", "api_key", secret) == 0); /* user-only */
+
+   char out[256];
+   assert(vault_store_get_server(p, skek, "openai", "api_key", out, sizeof(out)) ==
+          VAULT_STORE_NO_ENTRY);
+   assert(vault_store_add_server_wraps(p, kek, skek) == 0);
+   assert(vault_store_get_server(p, skek, "openai", "api_key", out, sizeof(out)) == 0);
+   assert(strcmp(out, secret) == 0);
+
+   /* Wrong user KEK -> backfill fails closed; the entry stays user-only. */
+   const char *p2 = "uid:4344";
+   assert(vault_store_get_or_create_salt(p2, salt) == 0);
+   assert(vault_store_set(p2, kek, "gemini", "api_key", "x") == 0);
+   uint8_t badkek[VAULT_KEK_LEN];
+   make_kek(badkek, 99);
+   assert(vault_store_add_server_wraps(p2, badkek, skek) == -1);
+   assert(vault_store_get_server(p2, skek, "gemini", "api_key", out, sizeof(out)) ==
+          VAULT_STORE_NO_ENTRY);
+   printf("  PASS: test_server_get_legacy_then_backfill\n");
+}
+
+/* The dual-wrapped file stores the server wrap but never the plaintext. */
+static void test_dual_wrap_at_rest_ciphertext_only(void)
+{
+   const char *p = "uid:4545";
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt(p, salt) == 0);
+   uint8_t kek[VAULT_KEK_LEN], skek[VAULT_KEK_LEN];
+   make_kek(kek, 45);
+   make_kek(skek, 220);
+   const char *secret = "DUAL-PLAINTEXT-NOT-ON-DISK";
+   assert(vault_store_set_dual(p, kek, skek, "claude", "api_key", secret) == 0);
+
+   char path[640];
+   assert(find_vault_file(p, path, sizeof(path)));
+   FILE *f = fopen(path, "rb");
+   assert(f);
+   char buf[16384];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   fclose(f);
+   buf[n] = '\0';
+   assert(strstr(buf, "wrapped_dek_server") != NULL);
+   assert(strstr(buf, secret) == NULL);
+   printf("  PASS: test_dual_wrap_at_rest_ciphertext_only\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vault-test-%d", (int)getpid());
@@ -341,6 +427,9 @@ int main(void)
    test_salt_is_stable();
    test_attacker_principal_filename_safety();
    test_intra_principal_aad_swap();
+   test_dual_wrap_server_get();
+   test_server_get_legacy_then_backfill();
+   test_dual_wrap_at_rest_ciphertext_only();
 
    char rm[320];
    snprintf(rm, sizeof(rm), "rm -rf %s", g_home);


### PR DESCRIPTION
## Why

Delegate/provider credentials must stay on aimee-server, encrypted at rest, and be usable by delegate runs autonomously — without a client re-unlocking after every restart. The existing per-user vault (uid:/webuser:) already stores credentials encrypted at rest, but it is **zero-knowledge**: the KEK is derived per-session from a client root key / login password and cached RAM-only with a 15-min TTL. After a restart or TTL expiry the server hits `VAULT_ERR_LOCKED` and **cannot decrypt** a delegate's key — so it can't drive delegates on its own ("otherwise we can't handle them").

## What

Adds a **dual-access wrap** (WP-C.4): every vaulted credential's per-credential DEK is wrapped a second time under a **server-sealed KEK**, so the server can decrypt autonomously while the user's zero-knowledge path is unchanged.

- **`vault_server_key`** — a 32-byte master key minted on first use, persisted `0600` at `<aimee_home>/.vault/.server-master.key`; the server KEK is HKDF-derived from it (domain-separated from the user KEKs) and cached process-wide. Fail-closed on any entropy/IO/derivation error.
- **`vault_store`** — `vault_store_set_dual` writes a second `wrapped_dek_server`; `vault_store_get_server` decrypts with the server KEK **alone** (no user KEK, no unlock, survives restart); `vault_store_add_server_wraps` backfills the server wrap for pre-existing user-only entries.
- **`vault_service`** — `set` dual-wraps every push (fail-closed if the server KEK is unavailable — never store a credential the server can't read); `inject_api_key` is **server-first**, falling back to the user-KEK path only for legacy creds; `unlock` backfills server wraps now that the user KEK is in hand.

The secret stays AES-256-GCM encrypted at rest under a random per-credential DEK; the server KEK only unwraps the DEK. The delegate run-path (`delegate_resolve_credentials` → `vault_service_inject_api_key`) now resolves credentials after a restart with no unlock.

## Trust boundary (deliberate)

The master key lives beside the vault on the data volume, so this defeats backup/disk theft and plaintext-in-config — **not** a root-level host compromise (root can read both). Same boundary aimee-server already runs under. Structured so an operator passphrase can wrap the master key file later with no data migration.

## Tests

- `test_vault_store`: dual-wrap server get, wrong-server-key fail-closed, legacy→backfill, at-rest is ciphertext-only (incl. `wrapped_dek_server`).
- `test_vault_service`: **autonomous inject after a simulated restart** (user vault locked) + missing-cred NO_ENTRY leaves api_key untouched.
- `test_vault_server_key`: master-key persistence, `0600` + 32 bytes, stable KEK across a cache reset ("restart").

Local: full `make unit-tests` green, `make server` (LTO) builds, `make lint` + `make build-integrity` pass.

## Follow-ups (scoped out, by decision)

- **Wire `agent add --key` to push into the vault** (and stop serializing literal `api_key` into `agents.json`). The push route (`/v1/vault/set`, now dual-wrapping) already exists; the open design points are unlock-at-creation UX and TCP (no per-user vault by design, D17) — worth deciding in review.
- Fold the OAuth tokens (`oauth_tokens.c` via `db1/secrets`, today plaintext-at-rest in a container) into the server vault.
