### PR TITLE
docs: quickstart, roundtable/ensemble, delegate defaults, optional cost cap

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1012,7 +1012,9 @@ delegate for review. Full guide: [`docs/DELEGATES.md`](docs/DELEGATES.md).
 
 **Roundtable:** `aimee delegate roundtable` reuses `ensemble.enabled`,
 `ensemble.reference_models`, `ensemble.aggregator`, `ensemble.min_successful`,
-and `ensemble.max_cost_usd`. `roundtable.max_rounds` defaults to `3`,
+and `ensemble.max_cost_usd` (optional; unset or `0` means no cost cap, the
+default — set a positive value to cap a run). The panel and aggregator ship
+configured, so the roundtable runs with no setup. `roundtable.max_rounds` defaults to `3`,
 `roundtable.converge_threshold` to `10`, `roundtable.deadline_ms` to `600000`,
 and `roundtable.turns` to `parallel`. Draft mode returns a shared artifact;
 review mode returns a consolidated review, and `--apply` asks a final draft turn

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Start here:
 
 | Document | Description |
 |----------|-------------|
+| **[Quickstart](docs/QUICKSTART.md)** | **Zero to working in a few minutes**: run the server, install the client, wire your tool. |
 | **[How aimee learns](docs/KNOWLEDGE.md)** | **The vision and the mechanisms**, the company-wide knowledge base, self-learning pipeline, cross-domain synthesis, and delegation economics. |
 | **[Manual](MANUAL.md)** | **The complete user reference**, installation, configuration, current command contract, and feature guides. |
 | **[Architecture](docs/ARCHITECTURE.md)** | System design, processes, storage/trust boundaries, layering, and request lifecycles. |

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -1,5 +1,11 @@
 # Delegate Agents
 
+> **Delegates ship configured.** A default roster (local + subscription-backed
+> tier-0 agents) and the roundtable panel come on out of the box, so
+> `aimee delegate …` and `aimee delegate roundtable …` work on a fresh install
+> with nothing to set up. This page is for adding your own providers, changing
+> the panel, or understanding the routing.
+
 ## Quick Start
 
 Use these commands to get delegation working quickly:
@@ -28,14 +34,16 @@ The primary agent does not need delegate configuration. It integrates with `aime
 ## Primary Agent Constraint
 
 Provider-native sub-agent tools are not Aimee delegation. Primary agents must
-not use Codex `spawn_agent`, Claude `Agent`, or similar remote-agent launchers
-for delegated or parallel work. Use the Aimee MCP `delegate` tool or
+not use Codex `spawn_agent`, Claude `Agent`/`Task`, or similar remote-agent
+launchers for delegated or parallel work. Use the Aimee MCP `delegate` tool or
 `aimee delegate <role> "<task>"` instead.
 
-Aimee guardrails block provider-native sub-agent tool calls when the client
-surfaces them through hooks. Routing through Aimee delegates keeps the work
-inside Aimee's session state, worktree isolation, depth/spawn limits, routing,
-and audit trail.
+The guard is always on: when a client surfaces a sub-agent tool through hooks
+(including Claude Code's `Task`), Aimee blocks the call and points the agent at
+`aimee delegate <role> --persona <persona>` or
+`aimee delegate roundtable "<task>" --mode review`. Routing through Aimee
+delegates keeps the work inside Aimee's session state, worktree isolation,
+depth/spawn limits, routing, and audit trail.
 
 ## How It Works
 
@@ -308,6 +316,38 @@ During a long coding session, use a `summarize` delegate to fold older context i
 - Reserve higher-tier delegates for roles such as `reason` when the task genuinely benefits from stronger reasoning.
 - Assign multiple roles to a delegate only when the model is actually suitable for those tasks.
 - Keep at least one low-cost delegate enabled to maximize the benefit of automatic routing; keep multiple tier-0 delegates enabled when you want the zero-cost layer to absorb rate limits or provider-specific failures.
+
+## Roundtable and ensemble (MoA)
+
+Two commands run a panel of models instead of one delegate and synthesize a
+single answer. Both ship configured — the panel and aggregator come on by
+default.
+
+```bash
+# Mixture-of-agents: fan out to diverse models, one aggregator synthesizes
+aimee delegate aggregate "Design a migration plan for the auth schema"
+
+# Multi-round collaborative drafting/review (review mode for a diff)
+aimee delegate roundtable "Is this migration plan sound?" --mode review
+```
+
+`aggregate` runs the reference panel in parallel and an aggregator folds their
+answers into one. `roundtable` runs multiple rounds — each round's panel sees the
+prior round — and returns the best round's artifact. Both run through the delegate
+core, so the work stays inside Aimee's session state, cost accounting, and audit
+trail (not the host AI's own sub-agent tools, which are blocked).
+
+The panel is configured under `ensemble` in `aimee.yaml`:
+
+| Field | Meaning |
+|-------|---------|
+| `reference_models` | The panel: diverse model/agent names to fan out to |
+| `aggregator` | Agent that synthesizes the panel's answers |
+| `min_successful` | Minimum panelists that must answer before degrading (default 2) |
+| `max_cost_usd` | Optional per-run cost cap in USD. **Unset/0 means no limit (the default).** Set a positive value to cap a run |
+
+Cost is folded onto the originating session, so a roundtable run shows up in the
+same cost accounting as the rest of that session's work.
 
 ## Configuration Reference
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,102 @@
+# Quickstart
+
+Zero to working in a few minutes. Run the server in Docker, install the thin
+client, point your AI tool at it. Memory, guardrails, and delegation come on
+automatically.
+
+For the full picture, see the [Manual](../MANUAL.md) and
+[How aimee learns](KNOWLEDGE.md).
+
+## 1. Run the server
+
+One container holds both binaries. Postgres and the embedder come up alongside it.
+
+```bash
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+docker compose -f compose.combined.yaml up --build -d
+```
+
+The server fronts `/v1` on `:8740`; the in-container kb runs on `:8741`. Default
+bearer is `aimee-local-dev`. Confirm it's live:
+
+```bash
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+```
+
+Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
+convenience.
+
+## 2. Install the client
+
+The `aimee` CLI is a thin client. It holds no database and talks to a server
+over `/v1`. Grab a prebuilt binary from the latest
+[release](https://github.com/RakuenSoftware/aimee/releases) (Linux, macOS,
+Windows), put it on your `PATH`, done.
+
+Point it at the server:
+
+```bash
+aimee remote set http://localhost:8740 aimee-local-dev
+aimee remote status   # resolved transport + a health probe
+```
+
+Or per-invocation: `aimee --server http://host:8740 --server-token=aimee-local-dev status`.
+Or via env: `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`.
+
+## 3. Wire your AI tool
+
+From a checkout, run the hook installer on the client machine:
+
+```bash
+./configure-hooks.sh        # configure-hooks.ps1 on Windows
+```
+
+It registers aimee's SessionStart/PreToolUse/PostToolUse hooks and MCP server for
+every tool it finds — Claude Code, Codex CLI, Gemini CLI, Copilot. From here,
+every session starts knowing what the last one learned, sensitive files are
+blocked before a write lands, and you can hand work to cheaper models.
+
+To run your tool's front end on aimee's model instead of its built-in vendor:
+
+```bash
+# Claude Code on any model:
+ANTHROPIC_BASE_URL=http://localhost:8740 ANTHROPIC_AUTH_TOKEN=aimee-local-dev claude
+```
+
+Codex and any OpenAI-compatible client work the same way — see the
+[README](../README.md#use-your-front-end-on-any-model).
+
+## 4. Verify
+
+```bash
+aimee version
+aimee status   # server, DB1, and kb health
+```
+
+## 5. Use it
+
+```bash
+# Remember something across every future session
+aimee memory store db-host "PostgreSQL at 10.0.0.5:5432" --tier L2 --kind fact
+aimee memory search "database"
+
+# Hand routine work to a cheaper model
+aimee delegate review "Review this PR for security issues"
+aimee delegate code --tools "Add tests for the auth module"
+
+# Convene a panel of models and synthesize one answer
+aimee delegate roundtable --mode review "Is this migration plan sound?"
+```
+
+Delegates and the roundtable panel ship configured out of the box. You don't set
+them up. See [Setting Up Delegates](DELEGATES.md) to add your own providers or
+change the panel.
+
+## Next
+
+- [Manual](../MANUAL.md) — full command contract and configuration.
+- [How aimee learns](KNOWLEDGE.md) — the knowledge base and where this goes at team scale.
+- [Workspaces](WORKSPACES.md) — multi-repo and session isolation.
+- [Security](SECURITY.md) — trust boundaries and the capability model.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -50,6 +50,9 @@ feature-tracking reference rather than a complete roadmap.
 | Context injection (primary agent via hooks, delegate agents via agent_context) | Done | Injects execution context differently for primary and delegated agents while preserving the same working model. | agent.c, cmd_hooks.c |
 | Multi-delegate coordination (planner/critic/worker) | Done | Coordinates multiple delegate roles so planning, critique, and implementation can be split across agents. | agent_coord.c |
 | Quorum voting (across delegate agents) | Done | Compares outputs from multiple delegates and resolves decisions through quorum-based agreement. | agent_coord.c |
+| Roundtable / ensemble (MoA) | Done | `aimee delegate aggregate` fans out to a panel and an aggregator synthesizes one answer; `aimee delegate roundtable` runs multiple rounds. Runs through the delegate core; cost folds onto the originating session. Panel/aggregator ship configured. | delegate_ensemble.c |
+| Sub-agent tool block (delegates, not agents) | Done | Blocks the host AI's own sub-agent launchers (Claude `Task`, Codex `spawn_agent`) and points the agent at `aimee delegate`. Always on. | guardrails_orchestrator.c, cli_main.c |
+| Model-derived output limits | Done | Delegate/ingress output token caps come from the model registry rather than a fixed default. | model_registry.c |
 | Durable delegate jobs (create, heartbeat, resume) | Done | Persists delegate job state so work can survive interruptions and be resumed later. | agent_jobs.c |
 | Per-turn heartbeat updates (delegate agents) | Done | Emits heartbeat updates during delegate execution so long-running work remains observable. | agent.c, agent_jobs.c |
 | Project descriptions (via delegate agent) | Done | Uses a delegate agent to generate or refresh project descriptions from repository context. | cmd_describe.c, workspace.c |

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -54,6 +54,25 @@ secrets; see [THIN_CLIENT.md](THIN_CLIENT.md).
   `aimee agent add … --provider codex` is accepted as an alias for the Codex
   adapter.
 
+Delegation defaults and the roundtable — see [DELEGATES.md](DELEGATES.md).
+
+- **Delegates work out of the box**: a default agent roster, the ensemble panel,
+  and `remote_writes=full` ship seeded, so `aimee delegate …` and the roundtable
+  run on a fresh install with no setup.
+- **Roundtable runs through the delegate core**: `aimee delegate aggregate`
+  (mixture-of-agents) and `aimee delegate roundtable` fan out to a panel and an
+  aggregator synthesizes one answer; the run executes through the delegate path,
+  so it stays inside session state, cost accounting, and the audit trail. Cost is
+  folded onto the originating session.
+- **Use delegates, not agents**: the host AI's own sub-agent tool is blocked
+  (Claude Code's `Task` included), always on. The block points the agent at
+  `aimee delegate <role>` / `aimee delegate roundtable … --mode review`.
+- **Output limits come from the model**: token caps are derived from the model
+  registry instead of a hardcoded 4096, so large-context models use their real
+  ceiling.
+- **`ensemble.max_cost_usd` is optional**: a per-run cost cap is now opt-in —
+  unset (or 0) means no limit, the default. Set a positive value to cap a run.
+
 ---
 
 ## v0.2.0


### PR DESCRIPTION
## What

- New **Quickstart** guide (`docs/QUICKSTART.md`), linked from the README docs table.
- Document the **roundtable / ensemble (MoA)** commands (`aimee delegate aggregate`, `aimee delegate roundtable`) and the `ensemble.*` config in DELEGATES.md, STATUS.md, MANUAL.md, WHATS_NEW.md.
- Note that **delegates and the roundtable ship configured** — no setup on a fresh install.
- Document the always-on **sub-agent tool block** ("delegates, not agents", incl. Claude `Task`).
- Note **model-derived output limits** (no fixed 4096).
- Reflect the now-**optional `ensemble.max_cost_usd`** (unset/0 = no cap, the default).

## Why

Closes the gap between the docs and recent shipped work; gives new users a single short on-ramp.

Voice: terse, no AI-isms.
