### PR TITLE
embedder: default to pplx-embed-v1-4b (2560-dim), 0.6b as alternate image

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -72,6 +72,9 @@ jobs:
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
+          # Lighter alternate embedder tier: same Dockerfile, 0.6b model baked in.
+          # Pair with embedding_dim: 1024 (see docs). Default is the 4b above.
+          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, extra_build_args: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b" }
         platform:
           - { arch: amd64, runner: ubuntu-latest }
           - { arch: arm64, runner: ubuntu-24.04-arm }
@@ -108,6 +111,7 @@ jobs:
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
+            ${{ matrix.image.extra_build_args }}
           # webchat's SPA pulls @rakuensoftware/smoothgui from GitHub Packages,
           # whose npm registry requires an authenticated token (even for public
           # reads). Prefer a repo/org NPM_TOKEN secret (a PAT with read:packages);
@@ -138,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-0.6b]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -3,14 +3,16 @@
 # model per call. Kept separate from the kb image so torch/sentence-transformers
 # never bloat the slim kb runtime.
 #
-# Default model: perplexity-ai/pplx-embed-v1-0.6b (Feb 2026, MIT, Qwen3-based,
-# 1024-dim, retrieval-optimized, prefix-free, INT8-native) — replacing the 2021
-# all-MiniLM-L6-v2 (384-dim). Override at build time with
+# Default model: perplexity-ai/pplx-embed-v1-4b (Feb 2026, MIT, Qwen3-based,
+# 2560-dim, retrieval-optimized, prefix-free) — the higher-fidelity tier, default
+# since embedding throughput is not the bottleneck. The lighter
+# perplexity-ai/pplx-embed-v1-0.6b (1024-dim) is published as the separate
+# aimee-embedder-0.6b image. Override at build time with
 #   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
-#   schema vector(N) columns — pplx-embed-v1-0.6b is 1024).
+#   schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024).
 FROM python:3.11-slim AS embedder
 
-ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
+ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
 # stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
 ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -384,7 +384,7 @@ corresponding `config_*.c` module.
 | `embedding_command` | string | External command that produces embeddings (sidecar). |
 | `embedding_model` | string | Embedding model name. |
 | `embedding_endpoint` | string | Embedding service URL. |
-| `embedding_dim` | int | Embedding dimensionality. |
+| `embedding_dim` | int | Embedding dimensionality; must match the embedder model. Default `2560` (pplx-embed-v1-4b); set `1024` for the pplx-embed-v1-0.6b tier. |
 
 **Memory & retrieval**
 
@@ -1375,9 +1375,11 @@ install only the thin client ([§3.2](#32-install-the-thin-client)) and point it
 the server. Four compose files ship, built from three images: `aimee-server`
 (`Dockerfile.server`), `aimee-kb` (`Dockerfile`), and the co-located
 `aimee-server+kb` (`Dockerfile.combined`). Every stack also brings up a
-`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`all-MiniLM-L6-v2`,
-`Dockerfile.embedder`); the kb auto-applies its DB2 schema (`pg_trgm`/`vector`
-extensions + tables) on first boot.
+`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`pplx-embed-v1-4b`,
+2560-dim, the default; `Dockerfile.embedder`); the kb auto-applies its DB2 schema
+(`pg_trgm`/`vector` extensions + tables) on first boot. The lighter
+`pplx-embed-v1-0.6b` tier ships as the `aimee-embedder-0.6b` image
+(`AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`).
 
 | Compose file | Brings up | Use when |
 |--------------|-----------|----------|

--- a/README.md
+++ b/README.md
@@ -398,9 +398,11 @@ install only the [thin client](#2-install-the-thin-client)). Four compose files
 ship; pick by topology. They build from three reusable images: **`aimee-server`**
 (`Dockerfile.server`), **`aimee-kb`** (`Dockerfile`), and **`aimee-server+kb`**
 (`Dockerfile.combined`). Every stack also brings up a `pgvector/pgvector:pg16`
-Postgres (DB2) and a CPU embedder sidecar (`all-MiniLM-L6-v2`, `Dockerfile.embedder`);
-the kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
-boot.
+Postgres (DB2) and a CPU embedder sidecar (`pplx-embed-v1-4b`, 2560-dim, the
+default; `Dockerfile.embedder`); the kb auto-applies its DB2 schema (tables +
+`pg_trgm`/`vector` extensions) on first boot. The lighter `pplx-embed-v1-0.6b`
+tier is published as the `aimee-embedder-0.6b` image — set `AIMEE_EMBEDDER_IMAGE`
+to it and `embedding_dim: 1024` to use it instead.
 
 > **`docker compose ... up --build` needs no credentials.** The default build ships
 > the **server + kb** services only. The optional browser UI (`aimee-webchat`) pulls

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -45,6 +45,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
+      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the
+      # server/kb) to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      args:
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -80,6 +84,8 @@ services:
       AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
       AIMEE_EMBEDDER_URL: http://embedder:8080
+      # Must match the embedder model's output dim (empty = config default 2560).
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       AIMEE_SERVER_HTTP_BIND: "1"
       AIMEE_KB_HTTP_BIND: "1"
       AIMEE_KB_API_URL: http://127.0.0.1:8741

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -37,6 +37,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
+      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
+      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      args:
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -63,6 +67,8 @@ services:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
       AIMEE_EMBEDDER_URL: http://embedder:8080
+      # Must match the embedder model's output dim (empty = config default 2560).
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
     # aimee-kb serves /v1 over HTTP only; the legacy --socket transport was retired (#2747).
     command: ["--http-port=8741"]
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
+      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
+      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      args:
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -49,6 +53,8 @@ services:
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
       # Real semantic embeddings via the resident embedder service.
       AIMEE_EMBEDDER_URL: http://embedder:8080
+      # Must match the embedder model's output dim (empty = config default 2560).
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       # Point at any OpenAI-compatible endpoint to enable the synthesis /
       # curator passes; the optional `llm` profile below brings up a local
       # llama.cpp server.

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -32,6 +32,10 @@ Keep the two in sync: `embedding_dim` must equal the dimension
 `embedding_command` actually returns, or vector inserts will be rejected by
 Postgres.
 
+`AIMEE_EMBEDDING_DIM` overrides `embedding_dim` from the environment — useful for
+a containerized deploy with no writable `aimee.yaml` (set it alongside
+`AIMEE_EMBEDDER_IMAGE` when pinning the 0.6b tier: `AIMEE_EMBEDDING_DIM=1024`).
+
 ## How the dimension flows into the schema
 
 The DB2 schema (`src/db2/schema.sql`) declares its embedding columns with a

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -60,7 +60,8 @@ out-of-range value falls back to the `2560` default (the default embedder is the
 
 `halfvec` (fp16) is used throughout: it halves index memory versus `vector`
 (fp32) at negligible recall cost, and it lifts the index dimension ceiling from
-2000 to 4000 — required for the 4B's 2560 dims.
+2000 to 4000 — required for the 4B's 2560 dims. This needs pgvector ≥ 0.7 (the
+bundled `pgvector/pgvector:pg16` image has it); older pgvector caps at 2000.
 
 The code-side embedding buffers are sized by `EMBED_MAX_DIM` (2560 in
 `src/headers/aimee.h`), large enough to hold either model's output; the embed

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -13,11 +13,12 @@ for the HuggingFace / sentence-transformers stack). Two reference models:
 
 | Model | `embedding_dim` | Notes |
 |-------|-----------------|-------|
-| `pplx-embed-v1-0.6b` (default) | `1024` | Fast; the default for most deployments. |
-| `pplx-embed-v1-4b` | `2560` | Higher quality; needs more RAM/compute. Exceeds pgvector's 2000-dim `vector` index cap, which is why all columns use `halfvec`. |
+| `pplx-embed-v1-4b` (default) | `2560` | Higher quality; the default, since embedding throughput is not the bottleneck. Needs more RAM/compute. Exceeds pgvector's 2000-dim `vector` index cap, which is why all columns use `halfvec`. |
+| `pplx-embed-v1-0.6b` | `1024` | Lighter tier — fast, low memory. Published as the `aimee-embedder-0.6b` image. |
 
-Pick one. A deployment that wants the 4B's quality runs the 4B everywhere; a
-deployment that wants speed/low memory runs the 0.6B everywhere.
+Pick one. The default `aimee-embedder` image bakes the 4B. To run the lighter
+0.6B instead, point at the `aimee-embedder-0.6b` image (`AIMEE_EMBEDDER_IMAGE`)
+and set `embedding_dim: 1024` — no rebuild needed.
 
 ## Configuration
 
@@ -50,8 +51,8 @@ schema, `db_apply_schema_postgres()` substitutes the placeholder with the
 configured dimension — the one place the schema is materialized — so every
 `halfvec` column (`memory_embeddings`, `kb_embeddings`, and the
 `curator_*_vectors` tables) is created at the right size. An unset or
-out-of-range value falls back to the `1024` default rather than emitting invalid
-DDL.
+out-of-range value falls back to the `2560` default (the default embedder is the
+4B) rather than emitting invalid DDL.
 
 `halfvec` (fp16) is used throughout: it halves index memory versus `vector`
 (fp32) at negligible recall cost, and it lifts the index dimension ceiling from

--- a/scripts/aimee-combined-docker-smoke.sh
+++ b/scripts/aimee-combined-docker-smoke.sh
@@ -29,6 +29,13 @@ KB_URL="${KB_URL:-http://localhost:8741}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.combined.yaml}"
 SERVICE="${SERVICE:-aimee-server-kb}"
+
+# Smoke tests validate the retrieval pipeline, not a specific model. Default to
+# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
+# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+: "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${AIMEE_EMBEDDING_DIM:=1024}"
+export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 DO_UP=0
 DO_DOWN=0

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -11,7 +11,7 @@
 #   3. /v1/version             — build identifies itself
 #   4. /v1/capabilities        — capability manifest serves
 #   5. POST /v1/search         — DB2-backed query path works (empty result is OK)
-#   6. embedder /embed         — real 384-dim embedding round-trip (in-network)
+#   6. embedder /embed         — real embedding round-trip (in-network)
 #
 # The embedder port is not published by compose.yaml, so its checks run inside
 # the kb container via `docker compose exec` (the kb image ships curl).
@@ -34,6 +34,13 @@ set -euo pipefail
 KB_URL="${KB_URL:-http://localhost:8741}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
+
+# Smoke tests validate the retrieval pipeline, not a specific model. Default to
+# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
+# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+: "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${AIMEE_EMBEDDING_DIM:=1024}"
+export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -41,6 +41,13 @@ KB_URL="${KB_URL:-http://localhost:8741}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.server.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
+
+# Smoke tests validate the retrieval pipeline, not a specific model. Default to
+# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
+# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+: "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${AIMEE_EMBEDDING_DIM:=1024}"
+export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -6,10 +6,11 @@ serves embeddings over HTTP, so the aimee-kb container can embed without paying
 a multi-second model reload on every call. The thin embed-remote.py client in the
 kb image talks to this service; this service holds the model.
 
-Default model: perplexity-ai/pplx-embed-v1-0.6b (1024-dim, Qwen3-based,
-retrieval-optimized, prefix-free). The reported dimension is whatever the loaded
-model produces — it MUST match config embedding_dim and the schema vector(N)
-columns, or vector inserts fail.
+Default model: perplexity-ai/pplx-embed-v1-4b (2560-dim, Qwen3-based,
+retrieval-optimized, prefix-free); the lighter pplx-embed-v1-0.6b (1024-dim) is
+the alternate tier. The reported dimension is whatever the loaded model produces
+— it MUST match config embedding_dim and the schema vector(N) columns, or vector
+inserts fail.
 
 Also serves a cross-encoder reranker (lazy-loaded) for the aimee memory rerank
 stage, reusing the resident torch stack instead of a second container.
@@ -21,7 +22,7 @@ Endpoints:
 
 Config (env):
   EMBEDDER_PORT     listen port (default 8080)
-  EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-0.6b)
+  EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-4b)
   RERANKER_MODEL    cross-encoder model id (default ettin-reranker-400m-v1)
   EMBEDDER_THREADS  torch intra-op threads (default min(8, ncpu))
   EMBEDDER_QUANTIZE fp32 (default) | int8 (torch dynamic; ~3.3x faster, drifts —
@@ -35,7 +36,7 @@ import os
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-0.6b")
+MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-4b")
 # Cross-encoder reranker, served from the same process (it reuses the resident
 # torch/sentence-transformers stack). Lazy-loaded on first /rerank so the embedder
 # starts and stays healthy even if reranking is never used.

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -48,8 +48,7 @@ static int bootstrap_db2(const config_t *cfg, int json_output)
       return 0;
    }
 
-   config_apply_embedding_dim_env_override(cfg);
-   db2_set_embedding_dim(cfg->embedding_dim);
+   db2_set_embedding_dim(config_resolve_embedding_dim(cfg));
    if (db2_init(cfg->db2_url) == 0)
    {
       int schema_ok = 0;

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -4,6 +4,7 @@
 #include "agent_exec.h"
 #include "agent_config.h"
 #include "config.h"
+#include "config_database.h"
 #include "db1.h"
 #include "delegate_credentials.h"
 #include "db2/lifecycle.h"
@@ -47,6 +48,7 @@ static int bootstrap_db2(const config_t *cfg, int json_output)
       return 0;
    }
 
+   config_apply_embedding_dim_env_override(cfg);
    db2_set_embedding_dim(cfg->embedding_dim);
    if (db2_init(cfg->db2_url) == 0)
    {

--- a/src/config.c
+++ b/src/config.c
@@ -418,12 +418,13 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;
    cfg->kb_search_max_results = 50;
-   /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
-    * Must match the schema vector(N) columns and the embedder model. */
-   cfg->embedding_dim = 1024;
+   /* Embedding dimension of the default embedder (pplx-embed-v1-4b = 2560).
+    * Must match the schema vector(N) columns and the embedder model. Set to
+    * 1024 (with the pplx-embed-v1-0.6b embedder image) for the lighter tier. */
+   cfg->embedding_dim = 2560;
    /* The cross-encoder rerank stage (ettin-reranker-400m-v1, served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third
-    * pipeline stage after the 0.6B embedder, and is default-ON: every retrieval
+    * pipeline stage after the embedder, and is default-ON: every retrieval
     * runs a top-K cross-encoder pass over the dense/lexical candidates. It
     * degrades safely to plain hybrid ordering if the reranker service is absent
     * or errors, so default-on is safe even without the embedder container. */

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -59,24 +59,23 @@ int config_apply_db2_url_env_override(config_t *cfg)
    return 0;
 }
 
-/* AIMEE_EMBEDDING_DIM lets a containerized deploy set the embedder dimension
- * without a writable aimee.yaml — it must match the running embedder model
- * (1024 for pplx-embed-v1-0.6b, 2560 for the default pplx-embed-v1-4b). */
-int config_apply_embedding_dim_env_override(config_t *cfg)
+/* Effective embedding dimension: the AIMEE_EMBEDDING_DIM env override when set
+ * and valid (1..EMBED_MAX_DIM), else cfg->embedding_dim. The env lets a
+ * containerized deploy set the dim without a writable aimee.yaml — it must match
+ * the running embedder model (1024 for pplx-embed-v1-0.6b, 2560 for the default
+ * pplx-embed-v1-4b). Non-mutating so const callers can use it. */
+int config_resolve_embedding_dim(const config_t *cfg)
 {
-   if (!cfg)
-      return 0;
+   int dim = cfg ? cfg->embedding_dim : 0;
    const char *env = getenv("AIMEE_EMBEDDING_DIM");
-   if (!env || !env[0])
-      return 0;
-   char *end = NULL;
-   long v = strtol(env, &end, 10);
-   if (end && *end == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+   if (env && env[0])
    {
-      cfg->embedding_dim = (int)v;
-      return 1;
+      char *end = NULL;
+      long v = strtol(env, &end, 10);
+      if (end && *end == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+         return (int)v;
+      fprintf(stderr, "aimee: config warning: AIMEE_EMBEDDING_DIM must be 1..%d, got \"%s\"\n",
+              EMBED_MAX_DIM, env);
    }
-   fprintf(stderr, "aimee: config warning: AIMEE_EMBEDDING_DIM must be 1..%d, got \"%s\"\n",
-           EMBED_MAX_DIM, env);
-   return 0;
+   return dim;
 }

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -58,3 +58,25 @@ int config_apply_db2_url_env_override(config_t *cfg)
    }
    return 0;
 }
+
+/* AIMEE_EMBEDDING_DIM lets a containerized deploy set the embedder dimension
+ * without a writable aimee.yaml — it must match the running embedder model
+ * (1024 for pplx-embed-v1-0.6b, 2560 for the default pplx-embed-v1-4b). */
+int config_apply_embedding_dim_env_override(config_t *cfg)
+{
+   if (!cfg)
+      return 0;
+   const char *env = getenv("AIMEE_EMBEDDING_DIM");
+   if (!env || !env[0])
+      return 0;
+   char *end = NULL;
+   long v = strtol(env, &end, 10);
+   if (end && *end == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+   {
+      cfg->embedding_dim = (int)v;
+      return 1;
+   }
+   fprintf(stderr, "aimee: config warning: AIMEE_EMBEDDING_DIM must be 1..%d, got \"%s\"\n",
+           EMBED_MAX_DIM, env);
+   return 0;
+}

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -48,7 +48,7 @@ static pthread_mutex_t g_init_lock = PTHREAD_MUTEX_INITIALIZER;
  * 1024 for pplx-0.6b, 2560 for pplx-4b). Set from the loaded config by the
  * server / aimee-kb startup via db2_set_embedding_dim() before db2_init(), so
  * this layer needs no config dependency. 0 = unset -> db2_embedding_dim()
- * reports the 1024 default. */
+ * reports the 2560 default (the default embedder is pplx-4b). */
 static int g_embed_dim = 0;
 
 void db2_set_embedding_dim(int dim)
@@ -58,7 +58,7 @@ void db2_set_embedding_dim(int dim)
 
 int db2_embedding_dim(void)
 {
-   return g_embed_dim > 0 ? g_embed_dim : 1024;
+   return g_embed_dim > 0 ? g_embed_dim : 2560;
 }
 static pthread_key_t g_thread_conn_key;
 static pthread_once_t g_thread_conn_key_once = PTHREAD_ONCE_INIT;
@@ -249,7 +249,7 @@ int db2_init(const char *libpq_url)
     * embedding_dim drives the dimension of the DB2 halfvec embedding columns.
     * The dimension is supplied by db2_set_embedding_dim() at startup (the server
     * and aimee-kb, which hold the loaded config) so this low-level layer stays
-    * config-free; it defaults to 1024 when unset. */
+    * config-free; it defaults to 2560 when unset. */
    if (db_apply_schema_postgres(conn, db2_embedding_dim(), errbuf, sizeof(errbuf)) != 0)
    {
       /* Surface the postgres error so callers see WHICH statement failed.

--- a/src/headers/config_database.h
+++ b/src/headers/config_database.h
@@ -21,4 +21,9 @@ void config_parse_database(config_t *cfg, cJSON *root);
  * other config consumers are unaffected. */
 int config_apply_db2_url_env_override(config_t *cfg);
 
+/* Overrides cfg->embedding_dim from AIMEE_EMBEDDING_DIM when set (1..EMBED_MAX_DIM).
+ * Apply AFTER config_load and BEFORE db2_set_embedding_dim() so the schema columns
+ * match the running embedder. Returns 1 if applied. */
+int config_apply_embedding_dim_env_override(config_t *cfg);
+
 #endif

--- a/src/headers/config_database.h
+++ b/src/headers/config_database.h
@@ -21,9 +21,9 @@ void config_parse_database(config_t *cfg, cJSON *root);
  * other config consumers are unaffected. */
 int config_apply_db2_url_env_override(config_t *cfg);
 
-/* Overrides cfg->embedding_dim from AIMEE_EMBEDDING_DIM when set (1..EMBED_MAX_DIM).
- * Apply AFTER config_load and BEFORE db2_set_embedding_dim() so the schema columns
- * match the running embedder. Returns 1 if applied. */
-int config_apply_embedding_dim_env_override(config_t *cfg);
+/* Effective embedding dim: AIMEE_EMBEDDING_DIM env override (1..EMBED_MAX_DIM)
+ * when set, else cfg->embedding_dim. Pass the result to db2_set_embedding_dim()
+ * so the schema columns match the running embedder. Non-mutating. */
+int config_resolve_embedding_dim(const config_t *cfg);
 
 #endif

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -47,8 +47,9 @@
 #endif
 
 /* Fallback kb_embeddings dimension when config.embedding_dim is unset; the
- * default embedder is pplx-embed-v1-0.6b (1024-dim). */
-#define KB_DEFAULT_DIM 1024
+ * default embedder is pplx-embed-v1-4b (2560-dim). Advisory only — the real
+ * column dimension comes from the schema (see kbiw_process_job). */
+#define KB_DEFAULT_DIM 2560
 
 /* ------------------------------------------------------------------ */
 /* notify: wake parked workers (called by kb_handle_ingest on enqueue) */

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -537,7 +537,10 @@ int main(int argc, char **argv)
 
    /* aimee-kb owns DB2; tell the DB2 layer the deployment's embedding dimension
     * (one embedder: 1024 pplx-0.6b / 2560 pplx-4b) before any db2_init() so the
-    * halfvec embedding columns are created at the right size. */
+    * halfvec embedding columns are created at the right size. AIMEE_EMBEDDING_DIM
+    * overrides the configured value (containerized deploys without a writable
+    * aimee.yaml). */
+   config_apply_embedding_dim_env_override(&kb_cfg);
    db2_set_embedding_dim(kb_cfg.embedding_dim);
 
    /* AIMEE_DB2_URL, when set, is the source of truth and overrides any db2_url

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -540,8 +540,7 @@ int main(int argc, char **argv)
     * halfvec embedding columns are created at the right size. AIMEE_EMBEDDING_DIM
     * overrides the configured value (containerized deploys without a writable
     * aimee.yaml). */
-   config_apply_embedding_dim_env_override(&kb_cfg);
-   db2_set_embedding_dim(kb_cfg.embedding_dim);
+   db2_set_embedding_dim(config_resolve_embedding_dim(&kb_cfg));
 
    /* AIMEE_DB2_URL, when set, is the source of truth and overrides any db2_url
     * cached in aimee.yaml from a previous boot — applied here unconditionally,

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1767,7 +1767,7 @@ int main(void)
          platform_unsetenv("AIMEE_DB2_URL");
    }
 
-   /* AIMEE_EMBEDDING_DIM env override */
+   /* AIMEE_EMBEDDING_DIM env override (config_resolve_embedding_dim) */
    {
       char *saved = getenv("AIMEE_EMBEDDING_DIM");
       if (saved)
@@ -1777,31 +1777,27 @@ int main(void)
       memset(&cfg, 0, sizeof(cfg));
       cfg.embedding_dim = 2560;
 
-      /* valid env -> overrides, returns 1 */
-      platform_setenv("AIMEE_EMBEDDING_DIM", "1024");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 1);
-      assert(cfg.embedding_dim == 1024);
-
-      /* unset -> leaves value untouched, returns 0 */
+      /* unset -> returns the cfg value */
       platform_unsetenv("AIMEE_EMBEDDING_DIM");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
 
-      /* empty -> treated as unset, returns 0 */
+      /* valid env -> overrides */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "1024");
+      assert(config_resolve_embedding_dim(&cfg) == 1024);
+
+      /* empty -> treated as unset, falls back to cfg */
       platform_setenv("AIMEE_EMBEDDING_DIM", "");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
 
-      /* non-numeric / out-of-range -> rejected, value unchanged, returns 0 */
+      /* non-numeric / out-of-range -> rejected, falls back to cfg */
       platform_setenv("AIMEE_EMBEDDING_DIM", "abc");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
       platform_setenv("AIMEE_EMBEDDING_DIM", "999999");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
 
-      /* NULL cfg -> no crash, returns 0 */
-      assert(config_apply_embedding_dim_env_override(NULL) == 0);
+      /* NULL cfg with no env -> 0 (no crash) */
+      platform_unsetenv("AIMEE_EMBEDDING_DIM");
+      assert(config_resolve_embedding_dim(NULL) == 0);
 
       if (saved)
       {

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1767,6 +1767,51 @@ int main(void)
          platform_unsetenv("AIMEE_DB2_URL");
    }
 
+   /* AIMEE_EMBEDDING_DIM env override */
+   {
+      char *saved = getenv("AIMEE_EMBEDDING_DIM");
+      if (saved)
+         saved = strdup(saved);
+
+      config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      cfg.embedding_dim = 2560;
+
+      /* valid env -> overrides, returns 1 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "1024");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 1);
+      assert(cfg.embedding_dim == 1024);
+
+      /* unset -> leaves value untouched, returns 0 */
+      platform_unsetenv("AIMEE_EMBEDDING_DIM");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+
+      /* empty -> treated as unset, returns 0 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+
+      /* non-numeric / out-of-range -> rejected, value unchanged, returns 0 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "abc");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+      platform_setenv("AIMEE_EMBEDDING_DIM", "999999");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+
+      /* NULL cfg -> no crash, returns 0 */
+      assert(config_apply_embedding_dim_env_override(NULL) == 0);
+
+      if (saved)
+      {
+         platform_setenv("AIMEE_EMBEDDING_DIM", saved);
+         free(saved);
+      }
+      else
+         platform_unsetenv("AIMEE_EMBEDDING_DIM");
+   }
+
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Make the **4b embedder the default**; keep the 0.6b as a configurable alternate.

- `config.c`: `embedding_dim` default `1024` → `2560`.
- `Dockerfile.embedder`: default `EMBEDDER_MODEL` → `perplexity-ai/pplx-embed-v1-4b`.
- `scripts/embedder-server.py`: default model → 4b (+ docstring).
- `db2_init.c` / `kb_ingest_workers.c`: unset-fallback dim `1024` → `2560` so a config-free path can't create a 1024 column under a 2560 embedder.
- `publish-images.yml`: also build/publish **`aimee-embedder-0.6b`** so users can switch to the lighter tier with `AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024` — no local rebuild.

## Why

Embedding throughput isn't the bottleneck, so trade it for the 4b's better retrieval quality. fp32 kept (max fidelity).

## Compatibility

Existing deployments that persist `embedding_dim` are unaffected (the fallback only applies when unset). Only **fresh installs** pick up 2560. Switching an existing install between tiers is a re-embed (dim change → new halfvec columns), as before.

## Ops note

The 4b image is large (~8GB weights) and fp32-resident needs substantially more RAM than the 0.6b. The 4b CI build downloads the weights at build time (retry logic already present). Reviewers: confirm the NAS host has the RAM headroom, or pin `embedding_dim: 1024` + the 0.6b image there.

## Test

`unit-test-config-surface` and `unit-test-schema-subst` pass; server builds clean; `publish-images.yml` validates.
