### PR TITLE
docs: roundtable-review fixes (sub-agent block, embedder switch, delegate quick start)

### DIFF
--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -8,10 +8,12 @@
 
 ## Quick Start
 
-Use these commands to get delegation working quickly:
+Delegation already works on a fresh install (see the note above) — `aimee
+delegate …` routes to the shipped roster. Use these commands only to **add your
+own** local provider on top of the defaults:
 
 ```bash
-# 1) Configure a local delegate provider
+# 1) Add a local delegate provider (optional — defaults already work)
 aimee agent local local http://localhost:8080 --model MODEL --slots 4 --ctx 131072
 
 # 2) Inspect the registered delegates and their routing data
@@ -20,7 +22,7 @@ aimee --json agent list
 # Optional auto-detect helper for local Ollama/llama.cpp
 ./add-local-delegate.sh
 
-# 3) Use aimee normally; the primary agent will route delegateable work automatically
+# 3) Use aimee normally; the primary agent routes delegateable work automatically.
 # See the Usage section below for realistic delegation scenarios.
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,7 +9,8 @@ For the full picture, see the [Manual](../MANUAL.md) and
 
 ## 1. Run the server
 
-One container holds both binaries. Postgres and the embedder come up alongside it.
+One container runs both binaries — the server and the knowledge base. Postgres
+and the embedder come up alongside it.
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
@@ -27,6 +28,9 @@ curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/stat
 
 Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
 convenience.
+
+The default embedder is the 4B (`pplx-embed-v1-4b`, 2560-dim). On a tight host,
+use the lighter 0.6B: `AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest AIMEE_EMBEDDING_DIM=1024 docker compose -f compose.combined.yaml up --build -d`.
 
 ## 2. Install the client
 
@@ -57,6 +61,11 @@ It registers aimee's SessionStart/PreToolUse/PostToolUse hooks and MCP server fo
 every tool it finds — Claude Code, Codex CLI, Gemini CLI, Copilot. From here,
 every session starts knowing what the last one learned, sensitive files are
 blocked before a write lands, and you can hand work to cheaper models.
+
+The host AI's own sub-agent tool (Claude's `Task`, Codex's `spawn_agent`) is
+blocked on purpose — fan work out through `aimee delegate` instead, so it stays
+in aimee's session state, cost accounting, and audit trail. See
+[Delegates](DELEGATES.md).
 
 To run your tool's front end on aimee's model instead of its built-in vendor:
 


### PR DESCRIPTION
Applies the actionable findings from running the docs through the aimee roundtable (panel: minimax, mimo-2.5, mistral).

## Changes
- **QUICKSTART**: document the always-on host-AI sub-agent block (Claude `Task`, Codex `spawn_agent`) and the `aimee delegate` path — the panel flagged this as the most surprising omission for new users. Clarify "both binaries" = server + kb. Add the lighter 0.6b embedder switch (`AIMEE_EMBEDDER_IMAGE` + `AIMEE_EMBEDDING_DIM`).
- **DELEGATES**: reword the Quick Start so it doesn't read as required setup (it contradicted the "delegates ship configured" banner) — step 1 is now explicitly for adding your *own* provider.

## Not applied (panel false positives)
- "pplx-embed-v1-4b name fabricated" and "DB1 is stale" — both are correct in source; the reviewers had no repo access.
- "Configuration Reference empty" — an artifact of the truncated review bundle, not the real doc.
- Several voice rewrites that made punchy prose more formal — kept the terser original.

The embedder-doc accuracy fixes (retrieval-stack, README, MANUAL) ride on #247.
