### PR TITLE
Move OAuth token storage into the server-sealed vault (WP-C.4)

### DIFF
--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -85,6 +85,12 @@ vault_status_t vault_service_set(const char *principal, const char *agent, const
  * VAULT_OK, or VAULT_ERR_CRYPTO/IO on a fail-closed error. */
 vault_status_t vault_service_set_server(const char *agent, const char *cred, const char *secret);
 
+/* Read (agent, cred) from the server principal's vault under the server master KEK
+ * — no client, no unlock. VAULT_OK (plaintext written), VAULT_NO_ENTRY (no file or
+ * no such entry), or VAULT_ERR_* (fail closed). `out` is cleansed on non-OK. */
+vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
+                                                  size_t out_len);
+
 /* The use-path: resolve (agent, cred) for `principal` into `out`. Returns:
  *   VAULT_OK         + plaintext written;
  *   VAULT_NO_ENTRY   when there is no such credential (or no/blank principal) —

--- a/src/server/oauth_tokens.c
+++ b/src/server/oauth_tokens.c
@@ -14,6 +14,7 @@
 #include "db1.h"
 #include "oauth_flow.h"
 #include "oauth_pkce.h"
+#include "vault_service.h" /* server-sealed vault: encrypted-at-rest token storage */
 #include "cJSON.h"
 #include "log.h"
 #include "platform_process.h"
@@ -21,6 +22,50 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+/* OAuth tokens are encrypted at rest in the server-owned vault (WP-C.4), keyed by
+ * (VAULT_SERVER_PRINCIPAL, client_name, cred). The server decrypts them
+ * autonomously to refresh/use them. Previously they were stored via db1/secrets,
+ * which in a container falls back to a PLAINTEXT 0600 file — the leak this closes.
+ * The legacy plaintext entries are migrated lazily on first read and scrubbed. */
+#define OAUTH_VCRED_ACCESS  "oauth_access_token"
+#define OAUTH_VCRED_REFRESH "oauth_refresh_token"
+#define OAUTH_VCRED_EXPIRES "oauth_expires_at"
+
+static int oauth_secret_store(const char *client_name, const char *vcred, const char *value)
+{
+   return vault_service_set_server(client_name, vcred, value) == VAULT_OK ? 0 : -1;
+}
+
+/* Load from the vault; if absent, lazily migrate a legacy db1/secrets plaintext
+ * value (db1_fmt is the old "oauth.%s.*" key format) into the vault and scrub it.
+ * Returns 0 with `buf` filled, or -1 on a miss (buf emptied). */
+static int oauth_secret_load(const char *client_name, const char *vcred, const char *db1_fmt,
+                             char *buf, size_t len)
+{
+   if (!buf || len == 0)
+      return -1;
+   if (vault_service_get_server_principal(client_name, vcred, buf, len) == VAULT_OK && buf[0])
+      return 0;
+   char key[256];
+   snprintf(key, sizeof(key), db1_fmt, client_name);
+   if (db1_secret_load(key, buf, len) == 0 && buf[0])
+   {
+      (void)vault_service_set_server(client_name, vcred, buf); /* migrate -> encrypted */
+      (void)db1_secret_remove(key);                            /* scrub the plaintext */
+      return 0;
+   }
+   buf[0] = '\0';
+   return -1;
+}
+
+static void oauth_secret_remove(const char *client_name, const char *vcred, const char *db1_fmt)
+{
+   (void)vault_service_delete(VAULT_SERVER_PRINCIPAL, client_name, vcred);
+   char key[256];
+   snprintf(key, sizeof(key), db1_fmt, client_name);
+   (void)db1_secret_remove(key); /* also clear any legacy plaintext */
+}
 
 /* ---- JSON parsing ---- */
 
@@ -73,17 +118,14 @@ int oauth_token_store(const char *client_name, const oauth_token_response_t *res
    if (!client_name || !resp || !resp->access_token[0])
       return -1;
 
-   char key[256];
    int rc = 0;
 
-   snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-   if (db1_secret_store(key, resp->access_token) != 0)
+   if (oauth_secret_store(client_name, OAUTH_VCRED_ACCESS, resp->access_token) != 0)
       rc = -1;
 
    if (resp->refresh_token[0])
    {
-      snprintf(key, sizeof(key), OAUTH_KEY_REFRESH_TOKEN, client_name);
-      if (db1_secret_store(key, resp->refresh_token) != 0)
+      if (oauth_secret_store(client_name, OAUTH_VCRED_REFRESH, resp->refresh_token) != 0)
          rc = -1;
    }
 
@@ -91,8 +133,7 @@ int oauth_token_store(const char *client_name, const oauth_token_response_t *res
    {
       char ea_str[32];
       snprintf(ea_str, sizeof(ea_str), "%ld", resp->expires_at);
-      snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client_name);
-      if (db1_secret_store(key, ea_str) != 0)
+      if (oauth_secret_store(client_name, OAUTH_VCRED_EXPIRES, ea_str) != 0)
          rc = -1;
    }
 
@@ -104,17 +145,14 @@ int oauth_token_load(const char *client_name, char *buf, size_t len)
    if (!client_name || !buf || len == 0)
       return -1;
 
-   char key[256];
-   snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-
-   if (db1_secret_load(key, buf, len) != 0 || buf[0] == '\0')
+   if (oauth_secret_load(client_name, OAUTH_VCRED_ACCESS, OAUTH_KEY_ACCESS_TOKEN, buf, len) != 0)
       return -1;
 
    /* Check expiry */
-   char ea_key[256];
    char ea_str[32] = "";
-   snprintf(ea_key, sizeof(ea_key), OAUTH_KEY_EXPIRES_AT, client_name);
-   if (db1_secret_load(ea_key, ea_str, sizeof(ea_str)) == 0 && ea_str[0])
+   if (oauth_secret_load(client_name, OAUTH_VCRED_EXPIRES, OAUTH_KEY_EXPIRES_AT, ea_str,
+                         sizeof(ea_str)) == 0 &&
+       ea_str[0])
    {
       long expires_at = atol(ea_str);
       if (expires_at > 0 && time(NULL) >= expires_at)
@@ -131,13 +169,9 @@ int oauth_token_remove(const char *client_name)
 {
    if (!client_name)
       return -1;
-   char key[256];
-   snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-   db1_secret_remove(key);
-   snprintf(key, sizeof(key), OAUTH_KEY_REFRESH_TOKEN, client_name);
-   db1_secret_remove(key);
-   snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client_name);
-   db1_secret_remove(key);
+   oauth_secret_remove(client_name, OAUTH_VCRED_ACCESS, OAUTH_KEY_ACCESS_TOKEN);
+   oauth_secret_remove(client_name, OAUTH_VCRED_REFRESH, OAUTH_KEY_REFRESH_TOKEN);
+   oauth_secret_remove(client_name, OAUTH_VCRED_EXPIRES, OAUTH_KEY_EXPIRES_AT);
    return 0;
 }
 
@@ -194,9 +228,10 @@ int oauth_token_refresh(const char *client_name, const char *client_id, const ch
       return -1;
 
    /* Load the stored refresh token */
-   char rt_key[256], refresh_token[512] = "";
-   snprintf(rt_key, sizeof(rt_key), OAUTH_KEY_REFRESH_TOKEN, client_name);
-   if (db1_secret_load(rt_key, refresh_token, sizeof(refresh_token)) != 0 || !refresh_token[0])
+   char refresh_token[512] = "";
+   if (oauth_secret_load(client_name, OAUTH_VCRED_REFRESH, OAUTH_KEY_REFRESH_TOKEN, refresh_token,
+                         sizeof(refresh_token)) != 0 ||
+       !refresh_token[0])
    {
       aimee_log(LOG_WARN, "oauth_flow", "no refresh token stored for %s", client_name);
       return -1;
@@ -241,10 +276,11 @@ int oauth_token_get(const char *client_name, const char *client_id, const char *
       return -1;
 
    /* Check whether the stored token is near expiry */
-   char ea_key[256], ea_str[32] = "";
-   snprintf(ea_key, sizeof(ea_key), OAUTH_KEY_EXPIRES_AT, client_name);
+   char ea_str[32] = "";
    int need_refresh = 0;
-   if (db1_secret_load(ea_key, ea_str, sizeof(ea_str)) == 0 && ea_str[0])
+   if (oauth_secret_load(client_name, OAUTH_VCRED_EXPIRES, OAUTH_KEY_EXPIRES_AT, ea_str,
+                         sizeof(ea_str)) == 0 &&
+       ea_str[0])
    {
       long expires_at = atol(ea_str);
       if (expires_at > 0 && time(NULL) + skew_secs >= expires_at)
@@ -255,9 +291,8 @@ int oauth_token_get(const char *client_name, const char *client_id, const char *
       oauth_token_refresh(client_name, client_id, token_endpoint);
 
    /* Try to load the (possibly refreshed) access token */
-   char at_key[256];
-   snprintf(at_key, sizeof(at_key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-   if (db1_secret_load(at_key, buf, len) != 0 || buf[0] == '\0')
+   if (oauth_secret_load(client_name, OAUTH_VCRED_ACCESS, OAUTH_KEY_ACCESS_TOKEN, buf, len) != 0 ||
+       buf[0] == '\0')
       return -1;
 
    return 0;

--- a/src/server/oauth_tokens.c
+++ b/src/server/oauth_tokens.c
@@ -34,7 +34,11 @@
 
 static int oauth_secret_store(const char *client_name, const char *vcred, const char *value)
 {
-   return vault_service_set_server(client_name, vcred, value) == VAULT_OK ? 0 : -1;
+   if (vault_service_set_server(client_name, vcred, value) == VAULT_OK)
+      return 0;
+   aimee_log(LOG_WARN, "oauth_flow", "vault store failed for %s/%s (token not persisted)",
+             client_name, vcred);
+   return -1;
 }
 
 /* Load from the vault; if absent, lazily migrate a legacy db1/secrets plaintext
@@ -51,8 +55,12 @@ static int oauth_secret_load(const char *client_name, const char *vcred, const c
    snprintf(key, sizeof(key), db1_fmt, client_name);
    if (db1_secret_load(key, buf, len) == 0 && buf[0])
    {
-      (void)vault_service_set_server(client_name, vcred, buf); /* migrate -> encrypted */
-      (void)db1_secret_remove(key);                            /* scrub the plaintext */
+      /* Scrub the plaintext ONLY after a durable encrypted copy exists. If the
+       * vault write fails (e.g. no master key), keep the plaintext and retry the
+       * migration on the next read — never delete the only copy of the token. The
+       * value is valid either way, so we still return it to the caller. */
+      if (vault_service_set_server(client_name, vcred, buf) == VAULT_OK)
+         (void)db1_secret_remove(key);
       return 0;
    }
    buf[0] = '\0';

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -77,8 +77,8 @@ static vault_status_t vault_service_get_server_wrap(const char *principal, const
 /* Read (agent, cred) from the SERVER principal's vault under the server master KEK
  * — no client, no unlock. VAULT_OK / VAULT_NO_ENTRY (no file or no entry) /
  * VAULT_ERR_* (fail closed). */
-static vault_status_t vault_service_get_server_principal(const char *agent, const char *cred,
-                                                         char *out, size_t out_len)
+vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
+                                                  size_t out_len)
 {
    if (out && out_len)
       out[0] = '\0';

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2082,6 +2082,11 @@ $(TESTPREFIX)/unit-test-oauth-pkce: $(OBJDIR)/tests/test_oauth_pkce.o \
                      $(OBJDIR)/server/oauth_pkce.o \
                      $(OBJDIR)/server/oauth_tokens.o \
                      $(OBJDIR)/db1/secrets.o \
+                     $(OBJDIR)/server/vault_service.o \
+                     $(OBJDIR)/server/vault_store.o \
+                     $(OBJDIR)/server/vault_crypto.o \
+                     $(OBJDIR)/server/vault_kek_cache.o \
+                     $(OBJDIR)/server/vault_server_key.o \
                      $(OBJDIR)/platform_random.o \
                      $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_oauth_pkce.c
+++ b/src/tests/test_oauth_pkce.c
@@ -7,6 +7,7 @@
 
 #include "oauth_pkce.h"
 #include "oauth_flow.h"
+#include "db1.h" /* db1_secret_* — plant/verify legacy plaintext for the migration test */
 #include "aimee.h"
 #include "platform_test_util.h"
 
@@ -307,6 +308,36 @@ int main(void)
       /* After removal, load should fail */
       rc = oauth_token_load(client, loaded, sizeof(loaded));
       assert(rc != 0);
+   }
+
+   /* --- legacy plaintext (db1/secrets) is migrated into the vault on read --- */
+   {
+      const char *client = "test-oauth-migrate";
+      char key[256];
+      /* Plant a legacy plaintext access token + future expiry the old way. */
+      snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client);
+      assert(db1_secret_store(key, "legacy-access-token") == 0);
+      char ea[32];
+      snprintf(ea, sizeof(ea), "%ld", (long)time(NULL) + 7200);
+      snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client);
+      assert(db1_secret_store(key, ea) == 0);
+
+      /* Load migrates it to the encrypted vault and returns the value. */
+      char loaded[1024];
+      assert(oauth_token_load(client, loaded, sizeof(loaded)) == 0);
+      assert(strcmp(loaded, "legacy-access-token") == 0);
+
+      /* The legacy plaintext entry is scrubbed... */
+      char chk[256];
+      snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client);
+      assert(db1_secret_load(key, chk, sizeof(chk)) != 0);
+
+      /* ...and a subsequent load still works (now from the vault). */
+      assert(oauth_token_load(client, loaded, sizeof(loaded)) == 0);
+      assert(strcmp(loaded, "legacy-access-token") == 0);
+
+      oauth_token_remove(client);
+      assert(oauth_token_load(client, loaded, sizeof(loaded)) != 0);
    }
 
    /* --- oauth_token_get: returns -1 when no token stored --- */

--- a/src/tests/test_oauth_pkce.c
+++ b/src/tests/test_oauth_pkce.c
@@ -327,12 +327,16 @@ int main(void)
       assert(oauth_token_load(client, loaded, sizeof(loaded)) == 0);
       assert(strcmp(loaded, "legacy-access-token") == 0);
 
-      /* The legacy plaintext entry is scrubbed... */
+      /* Both legacy plaintext keys that load touches (access + expires) are
+       * scrubbed once migrated. (The refresh token is only read during a network
+       * refresh, so it migrates lazily then — not on a plain load.) */
       char chk[256];
       snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client);
       assert(db1_secret_load(key, chk, sizeof(chk)) != 0);
+      snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client);
+      assert(db1_secret_load(key, chk, sizeof(chk)) != 0);
 
-      /* ...and a subsequent load still works (now from the vault). */
+      /* ...and a subsequent load still works (now from the vault, no plaintext). */
       assert(oauth_token_load(client, loaded, sizeof(loaded)) == 0);
       assert(strcmp(loaded, "legacy-access-token") == 0);
 


### PR DESCRIPTION
## Why

OAuth access/refresh/expiry tokens (codex/gemini) were persisted via `db1/secrets`, whose only container-viable backend is a **plaintext 0600 file** (libsecret has no Secret Service daemon in a container). So provider OAuth tokens sat **unencrypted at rest** — the last plaintext credential path after the vault landed (#244).

## What

Route `oauth_tokens.{store,load,remove,refresh,get}` through the **server-owned vault** (`VAULT_SERVER_PRINCIPAL`, AES-256-GCM at rest). The server still reads/refreshes tokens autonomously (the server KEK needs no unlock), but they're now encrypted.

- New static helpers `oauth_secret_{store,load,remove}` wrap `vault_service_set_server` / `vault_service_get_server_principal` / `vault_service_delete`, keyed by `(server, client_name, oauth_*_cred)`.
- **Lazy migration:** on first read, a legacy `db1/secrets` plaintext value is moved into the vault and the plaintext is scrubbed.
- Exposed `vault_service_get_server_principal` in the header (was static).
- **KB unaffected:** `oauth_tokens.o` is in `AGENT_SRCS` (server/full binaries only, which already link the vault), not the kb binary. Added the vault objects to the `test_oauth_pkce` link.

## Tests

`test_oauth_pkce`: existing store/load/remove round-trip now runs through the vault; new case plants a legacy plaintext token, confirms `oauth_token_load` migrates it, scrubs the old key, and serves from the vault thereafter.

Local: full `make unit-tests`, server + kb (LTO) builds, `make lint`, `make build-integrity` all green.

## Note

Server-vault trust boundary applies (master key beside data; see `vault_server_key.h`). The Codex CLI's own `~/.codex/auth.json` is a separate file owned by the Codex subprocess and is out of scope here.
