### PR TITLE
Promote: 4b default embedder, AIMEE_EMBEDDING_DIM, roundtable doc fixes

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -72,6 +72,9 @@ jobs:
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
+          # Lighter alternate embedder tier: same Dockerfile, 0.6b model baked in.
+          # Pair with embedding_dim: 1024 (see docs). Default is the 4b above.
+          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, extra_build_args: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b" }
         platform:
           - { arch: amd64, runner: ubuntu-latest }
           - { arch: arm64, runner: ubuntu-24.04-arm }
@@ -108,6 +111,7 @@ jobs:
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
+            ${{ matrix.image.extra_build_args }}
           # webchat's SPA pulls @rakuensoftware/smoothgui from GitHub Packages,
           # whose npm registry requires an authenticated token (even for public
           # reads). Prefer a repo/org NPM_TOKEN secret (a PAT with read:packages);
@@ -138,7 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-0.6b]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -3,14 +3,16 @@
 # model per call. Kept separate from the kb image so torch/sentence-transformers
 # never bloat the slim kb runtime.
 #
-# Default model: perplexity-ai/pplx-embed-v1-0.6b (Feb 2026, MIT, Qwen3-based,
-# 1024-dim, retrieval-optimized, prefix-free, INT8-native) — replacing the 2021
-# all-MiniLM-L6-v2 (384-dim). Override at build time with
+# Default model: perplexity-ai/pplx-embed-v1-4b (Feb 2026, MIT, Qwen3-based,
+# 2560-dim, retrieval-optimized, prefix-free) — the higher-fidelity tier, default
+# since embedding throughput is not the bottleneck. The lighter
+# perplexity-ai/pplx-embed-v1-0.6b (1024-dim) is published as the separate
+# aimee-embedder-0.6b image. Override at build time with
 #   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
-#   schema vector(N) columns — pplx-embed-v1-0.6b is 1024).
+#   schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024).
 FROM python:3.11-slim AS embedder
 
-ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
+ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
 # stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
 ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -384,7 +384,7 @@ corresponding `config_*.c` module.
 | `embedding_command` | string | External command that produces embeddings (sidecar). |
 | `embedding_model` | string | Embedding model name. |
 | `embedding_endpoint` | string | Embedding service URL. |
-| `embedding_dim` | int | Embedding dimensionality. |
+| `embedding_dim` | int | Embedding dimensionality; must match the embedder model. Default `2560` (pplx-embed-v1-4b); set `1024` for the pplx-embed-v1-0.6b tier. |
 
 **Memory & retrieval**
 
@@ -1375,9 +1375,11 @@ install only the thin client ([§3.2](#32-install-the-thin-client)) and point it
 the server. Four compose files ship, built from three images: `aimee-server`
 (`Dockerfile.server`), `aimee-kb` (`Dockerfile`), and the co-located
 `aimee-server+kb` (`Dockerfile.combined`). Every stack also brings up a
-`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`all-MiniLM-L6-v2`,
-`Dockerfile.embedder`); the kb auto-applies its DB2 schema (`pg_trgm`/`vector`
-extensions + tables) on first boot.
+`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`pplx-embed-v1-4b`,
+2560-dim, the default; `Dockerfile.embedder`); the kb auto-applies its DB2 schema
+(`pg_trgm`/`vector` extensions + tables) on first boot. The lighter
+`pplx-embed-v1-0.6b` tier ships as the `aimee-embedder-0.6b` image
+(`AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`).
 
 | Compose file | Brings up | Use when |
 |--------------|-----------|----------|

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1012,7 +1012,9 @@ delegate for review. Full guide: [`docs/DELEGATES.md`](docs/DELEGATES.md).
 
 **Roundtable:** `aimee delegate roundtable` reuses `ensemble.enabled`,
 `ensemble.reference_models`, `ensemble.aggregator`, `ensemble.min_successful`,
-and `ensemble.max_cost_usd`. `roundtable.max_rounds` defaults to `3`,
+and `ensemble.max_cost_usd` (optional; unset or `0` means no cost cap, the
+default — set a positive value to cap a run). The panel and aggregator ship
+configured, so the roundtable runs with no setup. `roundtable.max_rounds` defaults to `3`,
 `roundtable.converge_threshold` to `10`, `roundtable.deadline_ms` to `600000`,
 and `roundtable.turns` to `parallel`. Draft mode returns a shared artifact;
 review mode returns a consolidated review, and `--apply` asks a final draft turn

--- a/README.md
+++ b/README.md
@@ -398,9 +398,11 @@ install only the [thin client](#2-install-the-thin-client)). Four compose files
 ship; pick by topology. They build from three reusable images: **`aimee-server`**
 (`Dockerfile.server`), **`aimee-kb`** (`Dockerfile`), and **`aimee-server+kb`**
 (`Dockerfile.combined`). Every stack also brings up a `pgvector/pgvector:pg16`
-Postgres (DB2) and a CPU embedder sidecar (`all-MiniLM-L6-v2`, `Dockerfile.embedder`);
-the kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
-boot.
+Postgres (DB2) and a CPU embedder sidecar (`pplx-embed-v1-4b`, 2560-dim, the
+default; `Dockerfile.embedder`); the kb auto-applies its DB2 schema (tables +
+`pg_trgm`/`vector` extensions) on first boot. The lighter `pplx-embed-v1-0.6b`
+tier is published as the `aimee-embedder-0.6b` image — set `AIMEE_EMBEDDER_IMAGE`
+to it and `embedding_dim: 1024` to use it instead.
 
 > **`docker compose ... up --build` needs no credentials.** The default build ships
 > the **server + kb** services only. The optional browser UI (`aimee-webchat`) pulls

--- a/README.md
+++ b/README.md
@@ -589,6 +589,7 @@ Start here:
 
 | Document | Description |
 |----------|-------------|
+| **[Quickstart](docs/QUICKSTART.md)** | **Zero to working in a few minutes**: run the server, install the client, wire your tool. |
 | **[How aimee learns](docs/KNOWLEDGE.md)** | **The vision and the mechanisms**, the company-wide knowledge base, self-learning pipeline, cross-domain synthesis, and delegation economics. |
 | **[Manual](MANUAL.md)** | **The complete user reference**, installation, configuration, current command contract, and feature guides. |
 | **[Architecture](docs/ARCHITECTURE.md)** | System design, processes, storage/trust boundaries, layering, and request lifecycles. |

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -45,6 +45,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
+      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the
+      # server/kb) to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      args:
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -80,6 +84,8 @@ services:
       AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
       AIMEE_EMBEDDER_URL: http://embedder:8080
+      # Must match the embedder model's output dim (empty = config default 2560).
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       AIMEE_SERVER_HTTP_BIND: "1"
       AIMEE_KB_HTTP_BIND: "1"
       AIMEE_KB_API_URL: http://127.0.0.1:8741

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -37,6 +37,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
+      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
+      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      args:
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -63,6 +67,8 @@ services:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
       AIMEE_EMBEDDER_URL: http://embedder:8080
+      # Must match the embedder model's output dim (empty = config default 2560).
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
     # aimee-kb serves /v1 over HTTP only; the legacy --socket transport was retired (#2747).
     command: ["--http-port=8741"]
     ports:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,6 +22,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
+      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
+      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      args:
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -49,6 +53,8 @@ services:
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
       # Real semantic embeddings via the resident embedder service.
       AIMEE_EMBEDDER_URL: http://embedder:8080
+      # Must match the embedder model's output dim (empty = config default 2560).
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
       # Point at any OpenAI-compatible endpoint to enable the synthesis /
       # curator passes; the optional `llm` profile below brings up a local
       # llama.cpp server.

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -1,5 +1,11 @@
 # Delegate Agents
 
+> **Delegates ship configured.** A default roster (local + subscription-backed
+> tier-0 agents) and the roundtable panel come on out of the box, so
+> `aimee delegate …` and `aimee delegate roundtable …` work on a fresh install
+> with nothing to set up. This page is for adding your own providers, changing
+> the panel, or understanding the routing.
+
 ## Quick Start
 
 Use these commands to get delegation working quickly:
@@ -28,14 +34,16 @@ The primary agent does not need delegate configuration. It integrates with `aime
 ## Primary Agent Constraint
 
 Provider-native sub-agent tools are not Aimee delegation. Primary agents must
-not use Codex `spawn_agent`, Claude `Agent`, or similar remote-agent launchers
-for delegated or parallel work. Use the Aimee MCP `delegate` tool or
+not use Codex `spawn_agent`, Claude `Agent`/`Task`, or similar remote-agent
+launchers for delegated or parallel work. Use the Aimee MCP `delegate` tool or
 `aimee delegate <role> "<task>"` instead.
 
-Aimee guardrails block provider-native sub-agent tool calls when the client
-surfaces them through hooks. Routing through Aimee delegates keeps the work
-inside Aimee's session state, worktree isolation, depth/spawn limits, routing,
-and audit trail.
+The guard is always on: when a client surfaces a sub-agent tool through hooks
+(including Claude Code's `Task`), Aimee blocks the call and points the agent at
+`aimee delegate <role> --persona <persona>` or
+`aimee delegate roundtable "<task>" --mode review`. Routing through Aimee
+delegates keeps the work inside Aimee's session state, worktree isolation,
+depth/spawn limits, routing, and audit trail.
 
 ## How It Works
 
@@ -308,6 +316,38 @@ During a long coding session, use a `summarize` delegate to fold older context i
 - Reserve higher-tier delegates for roles such as `reason` when the task genuinely benefits from stronger reasoning.
 - Assign multiple roles to a delegate only when the model is actually suitable for those tasks.
 - Keep at least one low-cost delegate enabled to maximize the benefit of automatic routing; keep multiple tier-0 delegates enabled when you want the zero-cost layer to absorb rate limits or provider-specific failures.
+
+## Roundtable and ensemble (MoA)
+
+Two commands run a panel of models instead of one delegate and synthesize a
+single answer. Both ship configured — the panel and aggregator come on by
+default.
+
+```bash
+# Mixture-of-agents: fan out to diverse models, one aggregator synthesizes
+aimee delegate aggregate "Design a migration plan for the auth schema"
+
+# Multi-round collaborative drafting/review (review mode for a diff)
+aimee delegate roundtable "Is this migration plan sound?" --mode review
+```
+
+`aggregate` runs the reference panel in parallel and an aggregator folds their
+answers into one. `roundtable` runs multiple rounds — each round's panel sees the
+prior round — and returns the best round's artifact. Both run through the delegate
+core, so the work stays inside Aimee's session state, cost accounting, and audit
+trail (not the host AI's own sub-agent tools, which are blocked).
+
+The panel is configured under `ensemble` in `aimee.yaml`:
+
+| Field | Meaning |
+|-------|---------|
+| `reference_models` | The panel: diverse model/agent names to fan out to |
+| `aggregator` | Agent that synthesizes the panel's answers |
+| `min_successful` | Minimum panelists that must answer before degrading (default 2) |
+| `max_cost_usd` | Optional per-run cost cap in USD. **Unset/0 means no limit (the default).** Set a positive value to cap a run |
+
+Cost is folded onto the originating session, so a roundtable run shows up in the
+same cost accounting as the rest of that session's work.
 
 ## Configuration Reference
 

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -8,10 +8,12 @@
 
 ## Quick Start
 
-Use these commands to get delegation working quickly:
+Delegation already works on a fresh install (see the note above) — `aimee
+delegate …` routes to the shipped roster. Use these commands only to **add your
+own** local provider on top of the defaults:
 
 ```bash
-# 1) Configure a local delegate provider
+# 1) Add a local delegate provider (optional — defaults already work)
 aimee agent local local http://localhost:8080 --model MODEL --slots 4 --ctx 131072
 
 # 2) Inspect the registered delegates and their routing data
@@ -20,7 +22,7 @@ aimee --json agent list
 # Optional auto-detect helper for local Ollama/llama.cpp
 ./add-local-delegate.sh
 
-# 3) Use aimee normally; the primary agent will route delegateable work automatically
+# 3) Use aimee normally; the primary agent routes delegateable work automatically.
 # See the Usage section below for realistic delegation scenarios.
 ```
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,0 +1,102 @@
+# Quickstart
+
+Zero to working in a few minutes. Run the server in Docker, install the thin
+client, point your AI tool at it. Memory, guardrails, and delegation come on
+automatically.
+
+For the full picture, see the [Manual](../MANUAL.md) and
+[How aimee learns](KNOWLEDGE.md).
+
+## 1. Run the server
+
+One container holds both binaries. Postgres and the embedder come up alongside it.
+
+```bash
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+docker compose -f compose.combined.yaml up --build -d
+```
+
+The server fronts `/v1` on `:8740`; the in-container kb runs on `:8741`. Default
+bearer is `aimee-local-dev`. Confirm it's live:
+
+```bash
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+```
+
+Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
+convenience.
+
+## 2. Install the client
+
+The `aimee` CLI is a thin client. It holds no database and talks to a server
+over `/v1`. Grab a prebuilt binary from the latest
+[release](https://github.com/RakuenSoftware/aimee/releases) (Linux, macOS,
+Windows), put it on your `PATH`, done.
+
+Point it at the server:
+
+```bash
+aimee remote set http://localhost:8740 aimee-local-dev
+aimee remote status   # resolved transport + a health probe
+```
+
+Or per-invocation: `aimee --server http://host:8740 --server-token=aimee-local-dev status`.
+Or via env: `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`.
+
+## 3. Wire your AI tool
+
+From a checkout, run the hook installer on the client machine:
+
+```bash
+./configure-hooks.sh        # configure-hooks.ps1 on Windows
+```
+
+It registers aimee's SessionStart/PreToolUse/PostToolUse hooks and MCP server for
+every tool it finds — Claude Code, Codex CLI, Gemini CLI, Copilot. From here,
+every session starts knowing what the last one learned, sensitive files are
+blocked before a write lands, and you can hand work to cheaper models.
+
+To run your tool's front end on aimee's model instead of its built-in vendor:
+
+```bash
+# Claude Code on any model:
+ANTHROPIC_BASE_URL=http://localhost:8740 ANTHROPIC_AUTH_TOKEN=aimee-local-dev claude
+```
+
+Codex and any OpenAI-compatible client work the same way — see the
+[README](../README.md#use-your-front-end-on-any-model).
+
+## 4. Verify
+
+```bash
+aimee version
+aimee status   # server, DB1, and kb health
+```
+
+## 5. Use it
+
+```bash
+# Remember something across every future session
+aimee memory store db-host "PostgreSQL at 10.0.0.5:5432" --tier L2 --kind fact
+aimee memory search "database"
+
+# Hand routine work to a cheaper model
+aimee delegate review "Review this PR for security issues"
+aimee delegate code --tools "Add tests for the auth module"
+
+# Convene a panel of models and synthesize one answer
+aimee delegate roundtable --mode review "Is this migration plan sound?"
+```
+
+Delegates and the roundtable panel ship configured out of the box. You don't set
+them up. See [Setting Up Delegates](DELEGATES.md) to add your own providers or
+change the panel.
+
+## Next
+
+- [Manual](../MANUAL.md) — full command contract and configuration.
+- [How aimee learns](KNOWLEDGE.md) — the knowledge base and where this goes at team scale.
+- [Workspaces](WORKSPACES.md) — multi-repo and session isolation.
+- [Security](SECURITY.md) — trust boundaries and the capability model.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -9,7 +9,8 @@ For the full picture, see the [Manual](../MANUAL.md) and
 
 ## 1. Run the server
 
-One container holds both binaries. Postgres and the embedder come up alongside it.
+One container runs both binaries — the server and the knowledge base. Postgres
+and the embedder come up alongside it.
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
@@ -27,6 +28,9 @@ curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/stat
 
 Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
 convenience.
+
+The default embedder is the 4B (`pplx-embed-v1-4b`, 2560-dim). On a tight host,
+use the lighter 0.6B: `AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest AIMEE_EMBEDDING_DIM=1024 docker compose -f compose.combined.yaml up --build -d`.
 
 ## 2. Install the client
 
@@ -57,6 +61,11 @@ It registers aimee's SessionStart/PreToolUse/PostToolUse hooks and MCP server fo
 every tool it finds — Claude Code, Codex CLI, Gemini CLI, Copilot. From here,
 every session starts knowing what the last one learned, sensitive files are
 blocked before a write lands, and you can hand work to cheaper models.
+
+The host AI's own sub-agent tool (Claude's `Task`, Codex's `spawn_agent`) is
+blocked on purpose — fan work out through `aimee delegate` instead, so it stays
+in aimee's session state, cost accounting, and audit trail. See
+[Delegates](DELEGATES.md).
 
 To run your tool's front end on aimee's model instead of its built-in vendor:
 

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -50,6 +50,9 @@ feature-tracking reference rather than a complete roadmap.
 | Context injection (primary agent via hooks, delegate agents via agent_context) | Done | Injects execution context differently for primary and delegated agents while preserving the same working model. | agent.c, cmd_hooks.c |
 | Multi-delegate coordination (planner/critic/worker) | Done | Coordinates multiple delegate roles so planning, critique, and implementation can be split across agents. | agent_coord.c |
 | Quorum voting (across delegate agents) | Done | Compares outputs from multiple delegates and resolves decisions through quorum-based agreement. | agent_coord.c |
+| Roundtable / ensemble (MoA) | Done | `aimee delegate aggregate` fans out to a panel and an aggregator synthesizes one answer; `aimee delegate roundtable` runs multiple rounds. Runs through the delegate core; cost folds onto the originating session. Panel/aggregator ship configured. | delegate_ensemble.c |
+| Sub-agent tool block (delegates, not agents) | Done | Blocks the host AI's own sub-agent launchers (Claude `Task`, Codex `spawn_agent`) and points the agent at `aimee delegate`. Always on. | guardrails_orchestrator.c, cli_main.c |
+| Model-derived output limits | Done | Delegate/ingress output token caps come from the model registry rather than a fixed default. | model_registry.c |
 | Durable delegate jobs (create, heartbeat, resume) | Done | Persists delegate job state so work can survive interruptions and be resumed later. | agent_jobs.c |
 | Per-turn heartbeat updates (delegate agents) | Done | Emits heartbeat updates during delegate execution so long-running work remains observable. | agent.c, agent_jobs.c |
 | Project descriptions (via delegate agent) | Done | Uses a delegate agent to generate or refresh project descriptions from repository context. | cmd_describe.c, workspace.c |

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -54,6 +54,25 @@ secrets; see [THIN_CLIENT.md](THIN_CLIENT.md).
   `aimee agent add … --provider codex` is accepted as an alias for the Codex
   adapter.
 
+Delegation defaults and the roundtable — see [DELEGATES.md](DELEGATES.md).
+
+- **Delegates work out of the box**: a default agent roster, the ensemble panel,
+  and `remote_writes=full` ship seeded, so `aimee delegate …` and the roundtable
+  run on a fresh install with no setup.
+- **Roundtable runs through the delegate core**: `aimee delegate aggregate`
+  (mixture-of-agents) and `aimee delegate roundtable` fan out to a panel and an
+  aggregator synthesizes one answer; the run executes through the delegate path,
+  so it stays inside session state, cost accounting, and the audit trail. Cost is
+  folded onto the originating session.
+- **Use delegates, not agents**: the host AI's own sub-agent tool is blocked
+  (Claude Code's `Task` included), always on. The block points the agent at
+  `aimee delegate <role>` / `aimee delegate roundtable … --mode review`.
+- **Output limits come from the model**: token caps are derived from the model
+  registry instead of a hardcoded 4096, so large-context models use their real
+  ceiling.
+- **`ensemble.max_cost_usd` is optional**: a per-run cost cap is now opt-in —
+  unset (or 0) means no limit, the default. Set a positive value to cap a run.
+
 ---
 
 ## v0.2.0

--- a/docs/proposals/pending/structured-pdf-ingestion-and-evidence-layer.md
+++ b/docs/proposals/pending/structured-pdf-ingestion-and-evidence-layer.md
@@ -1,0 +1,559 @@
+# Proposal: structured PDF ingestion + coordinate-anchored evidence layer (KB)
+
+- **State:** reviewed — **roundtable sign-off (R3)**. Three review rounds
+  (R1: 10 blockers → all CLOSED in R2; R2: 2 new security blockers → both CLOSED
+  in R3). R3 verdict: reviewer / architect / data-model **Pass**, security
+  **Conditional Pass** (residual = explicitly-deferred automated PII detection, a
+  defensible v1 boundary), **no remaining blocking findings — READY FOR
+  SIGN-OFF.** Ready for implementation per the phasing below, pending human
+  sign-off. See **Review revisions (R1)** / **(R2)** / **(R3)**.
+- **Author:** JBailes
+- **Date:** 2026-06-13
+- **Charter roles:** Ingest (PDF → structured pages/blocks/lines/chunks with
+  geometry), Recall (coordinate-anchored retrieval + neighbor/page/table
+  expansion over the KB `/v1` surface), Calibrate (corpus-level answerability
+  signal returned with results), Curate (table regions promoted into the typed-
+  fact layer), Gate-Promote (default-off flag rollout per the readiness
+  program).
+- **Scope — entirely aimee-KB-side except one thin client call:**
+  a new PDF extraction front-end (`src/kb/kb_doc_pdf.{c,h}` — parse to pages /
+  blocks / lines / chunks + per-line geometry, OCR/TSR via optional local
+  sidecars, same pattern as the embedder/reranker), additive geometry on the
+  existing chunk spine (`src/db2/schema_sqlite.sql` + the Postgres equivalent:
+  `page_start` / `page_end` columns on `kb_documents`; a new fine-grained
+  `kb_doc_regions` table keyed by chunk id for per-line `page_no` + normalized
+  `bbox` + `quote`; a `kb_doc_assets` table for figure/table crops), reuse of
+  the existing heading-chunker / `prev_chunk_id`–`next_chunk_id` links / `kb_fts`
+  FTS5 / `kb_async_jobs` embedding path in `src/kb/kb_ingest_normalize.c` +
+  `src/kb/kb_service_kb.c`, a read-only document-evidence retrieval surface on
+  the KB `/v1` API (handlers in `src/kb/kb_service_kb.c` + the KB HTTP routes),
+  ingest acceptance of `application/pdf` in `src/server/kb_client_docs.c`, and a
+  **thin** consumer hook in `src/server/ingress_preinject.c` (one new
+  `kb_client_*` call returning chunks + citations; the server's existing
+  per-user confidence/steer logic is untouched). Unit + integration tests.
+  **No new datastore, no new service** (sidecars follow the existing optional-
+  model deployment pattern); the table-facts path *feeds* the existing
+  typed-fact layer rather than duplicating it.
+
+## Goal
+
+Let the **company knowledge base** ingest PDFs into the same inspectable,
+retrievable spine it already uses for code and docs — but with **page and
+bounding-box geometry retained on every chunk**, so retrieval can return
+citations that point back to the exact region of the exact page a fact came
+from. Tables become structured facts; figures/tables become retrievable crops;
+scanned PDFs are reachable via OCR.
+
+This is an **aimee-KB feature.** The KB is the shared, canonical, multi-user
+store: one PDF is ingested once for the whole company, deduped, access-
+controlled, and read by *any* person's aimee-server through `kb_client`. The
+personal agent (aimee-server) gains only a thin client call and keeps its
+existing per-user steering — it does not parse PDFs and does not hold the
+evidence model. See [[kb-vs-server-tenancy-boundary]].
+
+The design deliberately rides the spine we already have rather than standing up
+a parallel pipeline, and it closes the loop with two pending KB proposals: it
+supplies the **coordinates** that `auditable-correctness-for-the-kb` needs to
+make provenance verifiable, and it supplies a high-yield **table → typed-fact**
+source for `typed-fact-knowledge-layer`.
+
+## §0 What already exists (so we don't rebuild it)
+
+The `kb_documents` spine is already structure-aware. The PDF work *extends* it;
+it does not replace it.
+
+- **Structure-aware chunking.** `kb_documents` already carries
+  `heading_path`, `chunk_index`, `chunk_strategy` (default `'heading'`),
+  `doc_kind`, and `chunk_context`. Chunking on structural boundaries (sections /
+  headings) is the existing default, not something to invent.
+- **Neighbor links.** `prev_chunk_id` / `next_chunk_id` columns already thread
+  chunks into reading order, with `idx_kb_docs_prev` indexed. "Open the
+  neighbors of this chunk" is a column lookup we already support.
+- **Lexical search.** `kb_fts` is an FTS5 virtual table over
+  `kb_documents(content, heading_path)`. Lexical chunk search exists.
+- **Whole + chunk retention.** Per the standing "always keep origin artifact"
+  rule, the whole document is retained alongside its chunks; aggregate checks
+  retrieve rather than re-ingest. PDFs follow the same rule.
+- **Async embedding.** `kb_async_jobs` (`kind='embed_raw'`) already drains
+  chunks to the embedder. New PDF chunks enqueue the same way — embeddings are
+  one retrieval path among several, not a precondition for ingest. **Embeddings
+  stay text-only** (chunk `content`); geometry is *not* embedded and does not
+  participate in ranking — so there is no new embedding model and the "no new
+  service" claim holds. Geometry is used only for citation resolution (§2, §5).
+- **Document upload/push surface.** `src/server/kb_client_docs.c`
+  (`..._manifest_json` / `..._upload_json` / `..._push_json`) already does
+  client-push document ingest with hashing and dedup.
+- **Optional local model sidecars.** The embedder and reranker already deploy as
+  optional local models the KB calls out to. OCR and table-structure-recognition
+  models follow exactly that pattern — no new service class.
+
+**The genuine gaps for PDFs:** (1) nothing parses a PDF into text + geometry;
+(2) the chunk spine stores text-line ranges (`line_start`/`line_end`), not
+`page` + `bbox`; (3) no table-region extraction; (4) no figure/table crop
+storage; (5) no OCR fallback; (6) retrieval does not surface page/bbox/quote
+citations; (7) no read-only "open page / open neighbors / inspect structure /
+look up table" tool surface over `/v1`.
+
+## §1 PDF extraction front-end (`kb_doc_pdf`)
+
+A new KB-side module parses an uploaded PDF into the structures the spine
+expects, **plus geometry**:
+
+- **pages → blocks → lines**, each line carrying a `page_no` and a *normalized*
+  `bbox` (`[x0,y0,x1,y1]` in `[0,1]` page-relative coordinates, so they survive
+  re-rendering at any zoom).
+- a **deterministic structure tree** (heading levels → section paths) that
+  populates the existing `heading_path` / `chunk_strategy='heading'` columns.
+- **chunks** assembled on structural boundaries from the lines, threaded with
+  `prev_chunk_id` / `next_chunk_id`, exactly as the existing chunker does for
+  markdown — so semantic chunks land in `kb_documents` unchanged in shape.
+
+**Chunks may span pages (decided).** A heading at the bottom of page N whose body
+starts on page N+1 produces one chunk with `page_start=N`, `page_end=N+1`. We
+deliberately **preserve the existing heading-based chunker** rather than forcing
+a page-boundary split — chunk shape stays identical to markdown, and the
+per-line geometry in `kb_doc_regions` (§2) carries the precise page for every
+line regardless of where the chunk boundaries fall. The consequence, made
+explicit for consumers: `open_neighbors` can return content from an adjacent
+page, and a chunk's citations can carry more than one `page_no`. Citation
+precision is recovered at the *line* level, not the chunk level, so the coarser
+chunk span costs nothing for citations.
+
+**Chunk-size bound.** To keep the line-level citation join (§5) bounded, a chunk
+is capped at a maximum line count (~100); a heading section longer than the cap
+splits on paragraph (then page) boundaries while preserving its `heading_path`,
+so an outsized section never produces a single chunk whose region join dominates
+`search_chunks`.
+
+**Heading-extraction fallback.** Heading detection from PDF tags / font
+heuristics is flaky across producers. When detection is inconsistent for a
+document, extraction degrades to **page-boundary chunking** for that document
+and flags it for manual review, rather than emitting unstable heading-based
+boundaries that would scramble citations.
+
+Text extraction uses a vendored/optional PDF text+geometry library. Extraction
+is deterministic and runs entirely KB-side at ingest time; the result is the
+same `kb_documents` rows the rest of the system already understands, with the
+new geometry attached (§2). PDF-derived chunks set the existing `doc_kind`
+column to `'pdf'`.
+
+## §2 Coordinate-anchored citations
+
+A chunk spans multiple lines and can cross a page boundary, so chunk-level
+geometry is too coarse for a citation. Two additive pieces:
+
+- **`page_start` / `page_end`** columns on `kb_documents` (coarse, for "which
+  pages does this chunk touch"). These are a *cache* — the authoritative page
+  set is `MIN/MAX(page_no)` over a chunk's `kb_doc_regions` rows — populated at
+  ingest in the same transaction that writes the regions, so they cannot drift.
+- a new **`kb_doc_regions`** table, one row per extracted line:
+  `(id, chunk_id INTEGER FK→kb_documents(id) ON DELETE CASCADE, document_key
+  TEXT, page_no INTEGER, x0 REAL, y0 REAL, x1 REAL, y1 REAL, quote TEXT,
+  line_index INTEGER, content_type TEXT)`. **`bbox` is four `REAL` columns**, not
+  a `TEXT` blob, so spatial predicates (overlap/containment) need no per-row
+  parsing and an R*-tree index is available on SQLite. `document_key` is
+  carried denormalized so access-control filtering needs no join (§ Tenancy);
+  `content_type ∈ {text, table_cell, figure_caption}` lets a consumer parse
+  `quote` correctly. This is the precise evidence index.
+
+**bbox convention (fixed to avoid citation misalignment):** origin top-left,
+normalized **per page** to `[0,1]`; `(x0,y0)` is the top-left corner, `(x1,y1)`
+the bottom-right; values clamped to `[0,1]`.
+
+A **citation** is `{ document_key, page_no, bbox, quote }`, resolved at **line
+granularity**: `search_chunks` runs FTS5/embedding to get candidate chunks,
+joins to `kb_doc_regions` for *all* lines of each chunk (so the consumer has
+surrounding context, not just the matched line), and flags the line(s) whose
+`quote` overlaps the query terms as the primary highlight. A single FTS match
+spanning multiple lines yields multiple flagged line citations. This is exactly
+the artifact `auditable-correctness-for-the-kb` wants on the provenance path — a
+fact traceable to a highlightable region, not just a relevant document. The two
+proposals share this representation; this one *produces* the coordinates, that
+one *audits* against them.
+
+## §3 Tables → typed facts; figures/tables → retrievable crops
+
+- **Table Structure Recognition (TSR).** An *optional* local TSR model (ONNX-
+  class, deployed like the embedder/reranker sidecars) converts detected table
+  regions into structured cells. Cells become **searchable table facts** that
+  feed the existing typed-fact layer (`typed-fact-knowledge-layer`) rather than
+  a new fact store — tables are the highest-yield typed-fact source in real
+  documents. When the sidecar is absent, table regions degrade gracefully to
+  text chunks with geometry (still retrievable, just not cell-structured).
+- **Visual evidence.** Detected figure/table regions are rendered to crops and
+  stored in a new **`kb_doc_assets`** table
+  `(id, document_key TEXT, page_no INTEGER, x0/y0/x1/y1 REAL, kind TEXT,
+  caption TEXT, blob_ref TEXT, created_at)`. The crop is retrievable as
+  source-grounded evidence alongside the surrounding text chunk — the on-ramp to
+  multimodal KB entries.
+  - **`blob_ref` storage is a new surface, scoped explicitly to Phase 4.** Crops
+    are binary and don't belong inline in the DB. They are written to a
+    content-addressed blob store under `AIMEE_HOME` (filesystem, one file per
+    `sha256`), and `blob_ref` is that `sha256`. Content-addressing gives free
+    dedup (identical crops across re-ingests collapse). This is an honestly-new
+    storage dependency — called out here, not hidden under "no new datastore"
+    (which refers to relational stores).
+  - **Blob access is gated, never direct (R2-S1).** The `sha256` is a
+    **KB-internal** identifier — it is *never* returned to a client, and the
+    blob directory is on the KB host's private filesystem, served by **no**
+    static/file route. The sole read path is **`open_asset`**, which takes an
+    opaque `kb_doc_assets.id`, applies the same `document_key` access check as
+    every other endpoint (§5), and only then streams the bytes. A caller cannot
+    construct a path or fetch a crop by guessing/knowing a hash, so the
+    content-addressed store does not create an access-control bypass and the
+    tenancy boundary holds for binary evidence exactly as it does for text.
+  - **Keying / lifecycle.** `kb_documents` has no single "document" row (a
+    document is the set of chunk rows sharing `(project, file_path, file_hash)`),
+    so `document_key` is that logical identity, not a single-row FK.
+    `kb_doc_assets` is filtered for access control by `document_key` exactly as
+    chunks are. Orphan cleanup is **not** a relational cascade: when a document's
+    chunks are deleted/re-ingested, the same maintenance path deletes its assets
+    and dereferences their blobs. Concretely, a periodic maintenance job scans
+    `kb_doc_assets` for `blob_ref` values no row references and unlinks those
+    files; the job is covered by the integration suite. This is stated so the
+    cleanup is designed, not assumed.
+
+## §4 OCR fallback
+
+For scanned / image-only PDFs (no extractable text layer), an optional local
+OCR sidecar produces text + per-line geometry, feeding the same §1/§2 path.
+Detection is "page has no/low text layer → OCR." OCR availability is a deploy-
+time capability, not a hard dependency; without it, image-only PDFs ingest as
+asset-only documents (crops, no text chunks).
+
+## §5 Read-only document-evidence retrieval surface (KB `/v1`)
+
+A small set of **read-only** retrieval primitives on the KB `/v1` API, served by
+`src/kb/kb_service_kb.c`. These are the company-KB tools any consumer (a
+person's aimee-server, a delegate, the roundtable) can call:
+
+- **`search_chunks`** — two-stage: (1) FTS5 + text-embedding candidate retrieval
+  over chunk `content`; (2) citation resolution by joining candidates to
+  `kb_doc_regions` (§2). Returns chunks with line-level `{page_no, bbox, quote}`
+  citations. Optional `--page N` filter.
+- **`open_page`** — all regions for one page of a document, ordered by
+  `line_index`.
+- **`open_neighbors`** — by default the **linear** `prev_chunk_id`/`next_chunk_id`
+  walk; an optional `hierarchical=true` mode returns sibling chunks under the
+  same `heading_path` (more useful for context around a citation). The mode is a
+  parameter, not two endpoints.
+- **`inspect_structure`** — the heading/section tree for a document.
+- **`lookup_table`** — structured cells for a table region (when TSR ran).
+- **`open_asset`** — fetch a figure/table crop by `blob_ref`.
+
+**Access control (every endpoint).** All six endpoints apply the *same*
+document-level access check the KB already enforces on `kb_documents`, using the
+caller's auth context, and filter on the denormalized `document_key` (no join
+required). A caller that cannot read a document cannot `open_page`, enumerate
+its regions, or fetch its assets. This is enforced KB-side, not left to the
+consumer.
+
+**Answerability signal (contract, §5-A).** `search_chunks` returns a
+corpus-level answerability signal with a fixed contract so consumers can depend
+on it: a **`float score ∈ [0,1]`** plus an enum **`label ∈ {NONE, LOW, MEDIUM,
+HIGH}`** (default thresholds `<0.15`→NONE, `<0.40`→LOW, `<0.66`→MEDIUM, else
+HIGH — config-overridable per deployment; the defaults mirror the server's
+existing confidence tiers so behaviour is familiar, and the rationale is
+documented with them).
+Inputs are deterministic and KB-side: max FTS rank of the top-k hits, query-term
+coverage across matched chunks, and presence of table-facts for query entities.
+A reference test pins it (e.g. "query Q over fixture corpus C ⇒ score ≥ 0.7,
+label HIGH"). It is a *shared, document-level* judgment and stays in the KB; it
+is **not** folded into the personal server's per-user confidence tier (see
+boundary note). It may later be exposed as a standalone, cheaper
+`/v1/answerability?q=…` endpoint that runs only signal computation; that is
+additive and does not change the `search_chunks` contract.
+
+## §6 PII and sensitivity policy
+
+PDFs are the highest-risk format for PII (contracts, HR, financial, medical), and
+this is a *company-wide shared* store — so the policy is stated up front, not
+deferred. The v1 position, explicitly:
+
+- **Access control is the primary control.** A PDF is only ever as visible as the
+  `document_key`-level permissions allow (§5, Tenancy boundary). Ingesting a
+  document does not widen its audience beyond who could already read it.
+- **PII detection/redaction is out of scope for v1.** Uploaders are responsible
+  for classifying document sensitivity; this is enforced by the upload surface
+  refusing documents without a declared sensitivity class (see below), not by an
+  automated scanner. A PII-scanner integration is named as **future work**, not
+  promised in v1.
+- **Sensitivity tagging + quarantine.** The upload path requires a sensitivity
+  class on each document (`public | internal | restricted`), stored on the
+  document and propagated to its regions/assets for filtering.
+  - **Upload-time enforcement (R2-S2, Phase 1).** The `src/server/kb_client_docs.c`
+    upload handler requires a `sensitivity_class` field in the upload metadata
+    and **rejects the upload** (4xx, no rows written) if it is absent or not one
+    of the three allowed values — there is no implicit default that silently
+    under-tags a document. The validated class is persisted on the document at
+    ingest and copied to every `kb_doc_regions` / `kb_doc_assets` row so
+    retrieval filters on it without a join.
+  - **Quarantine flow.** A `restricted` document enters `pending_quarantine`,
+    which withholds it from `search_chunks` / `open_*` / ingress; an operator
+    action transitions `pending_quarantine → confirmed` (available) or
+    `→ rejected` (purged). The operator surface is a small KB `/v1` admin route;
+    the state machine exists in v1 even if the default for `public`/`internal`
+    is immediate availability.
+- **Sidecar trust perimeter.** OCR and TSR sidecars run **inside the KB's trusted
+  perimeter**, make **no external network calls**, and **retain no document
+  content** after processing (any model cache is local, access-controlled, and
+  documented). They are not a data-egress path.
+
+This section is a blocker-clearing statement of intent; the precise class enum,
+the quarantine state machine, and the upload-time enforcement land in Phase 1
+(ingest) and Phase 2 (retrieval filtering), behind the same default-off flag.
+
+## Tenancy boundary (the load-bearing scoping decision)
+
+| Concern | Lives in | Why |
+| --- | --- | --- |
+| PDF parsing, geometry, table-facts, crops, OCR | **aimee-kb** | shared canonical content; ingested once for the whole company; dedup + access control |
+| Evidence/retrieval tools (`open_page`, `search_chunks`, …) | **aimee-kb** `/v1` | read by *any* person's agent; one source of truth |
+| "Is there sufficient corpus evidence?" (answerability) | **aimee-kb** | a document/corpus-level judgment, shared |
+| Per-turn context assembly + "how hard to steer *this* user" | **aimee-server** | personal; the existing `ingress_preinject.c` confidence/steer/explore-with logic |
+
+The personal server change is intentionally minimal: `ingress_preinject.c`
+already issues `kb_client_index_code_search` and `kb_client_memory_context_block`
+and folds their results into the `<aimee-context>` envelope. We add **one** more
+of the same shape — a `kb_client` call to `search_chunks` — and `open_page`,
+`open_neighbors`, `inspect_structure`, `lookup_table` join the envelope's
+existing `explore-with:` set so a co-registered agent escalates to *multi-step*
+document retrieval through the KB exactly as it already does for code symbols
+(naming only `search_chunks` would seed the agent but starve the escalation the
+goal calls for). **No new sufficiency logic on the server.** We do *not* fold
+the KB's corpus-level answerability into the server's per-user confidence tier —
+that would drag company-KB judgment into the personal agent.
+
+## Data model summary
+
+Additive only — no new *relational* datastore, no table rebuilt. (The crop blob
+store, §3, is a deliberately-acknowledged new filesystem surface in Phase 4.)
+
+- `kb_documents`: **+ `page_start`, `page_end`** (nullable; non-PDF docs leave
+  them null; a write-time cache of `MIN/MAX(page_no)` over the chunk's regions,
+  set in the ingest transaction so it cannot drift). Everything else
+  (`heading_path`, `chunk_index`, `prev/next_chunk_id`, `chunk_strategy`,
+  `doc_kind`='pdf') is reused as-is.
+- **new `kb_doc_regions`** `(id, chunk_id INTEGER FK→kb_documents(id) ON DELETE
+  CASCADE, document_key TEXT, page_no INTEGER, x0 REAL, y0 REAL, x1 REAL,
+  y1 REAL, quote TEXT, line_index INTEGER, content_type TEXT)`.
+  Indexes: `(chunk_id, line_index)` for ordered in-chunk retrieval and the
+  search→citation join; `(document_key, page_no)` for `open_page` and
+  access-control filtering; R*-tree on `(x0,y0,x1,y1)` on SQLite for future
+  spatial predicates.
+- **new `kb_doc_assets`** `(id, document_key TEXT, page_no INTEGER, x0/y0/x1/y1
+  REAL, kind TEXT, caption TEXT, blob_ref TEXT, created_at)`, index on
+  `document_key`. Keyed by logical `document_key` (no single-row FK exists);
+  orphan + blob cleanup is a maintenance-path step, not a relational cascade
+  (§3).
+- **Volume / scale.** One region row per line: a 300-page PDF (~50 lines/page)
+  ≈ 15k rows; a 10k-PDF corpus ≈ 150M rows. The composite indexes above keep the
+  three hot queries (`open_page`, in-chunk join, table filter) index-served.
+  Row-count for the *target* corpus must be measured and a partition/archive
+  decision taken **before** default-on promotion (gating criterion, not
+  after-the-fact).
+- table cells: written through the **existing** typed-fact / entity store, not a
+  new table.
+- `kb_fts`, `kb_async_jobs`: unchanged; new chunks flow through them.
+
+## Surface
+
+- KB `/v1`: `search_chunks`, `open_page`, `open_neighbors`, `inspect_structure`,
+  `lookup_table`, `open_asset` (all read-only).
+- Ingest: `src/server/kb_client_docs.c` accepts `application/pdf` and routes to
+  the new extractor; same hash/dedup/push flow.
+- CLI: `aimee doc search [--page N]` / `aimee doc page` / `aimee doc cite` thin
+  wrappers over the `/v1` surface (read-only).
+- Server: one `kb_client` call in `ingress_preinject.c`; document tools added to
+  the envelope `explore-with:` line.
+
+## Phasing (each independently shippable, default-off)
+
+1. **Extractor + geometry.** `kb_doc_pdf` text+geometry extraction →
+   `kb_documents` + `kb_doc_regions`; PDF accepted by the upload surface with a
+   required sensitivity class (§6); chunks embed via the existing async path.
+   (Text-layer PDFs only.)
+2. **Citation retrieval + access control.** `search_chunks` / `open_page` /
+   `open_neighbors` / `inspect_structure` returning line-level
+   `{page_no, bbox, quote}` citations, each gated by the `document_key` access
+   check and sensitivity filtering (§5, §6); the thin server consumer call plus
+   the four escalation tools in the envelope `explore-with:` set. This is enough
+   for `auditable-correctness` to bind provenance to coordinates.
+3. **Tables.** TSR sidecar → table cells into the typed-fact layer +
+   `lookup_table`. Graceful text-chunk degradation when absent.
+4. **Visual + OCR.** `kb_doc_assets` crops + `open_asset`; OCR sidecar for
+   scanned PDFs.
+
+## Flags
+
+Default-off behind a KB-side `kb.pdf_ingest_enabled` (and per-sidecar capability
+gates for TSR/OCR), promoted per the flag rollout-readiness program once the
+six-criterion bar is met. The server consumer call is a no-op until the KB
+returns document evidence.
+
+## Non-goals
+
+- Layout-preserving PDF *translation*. Orthogonal to the KB's purpose.
+- A discovery/"trending papers" feed. Not a KB concern.
+- Replacing embeddings. The evidence layer is lexical+structural+geometric and
+  *complements* the existing halfvec/HNSW path; vectors remain one retrieval
+  path among several.
+- Any per-user document logic on aimee-server beyond the thin consumer call.
+
+## Risks / honest limits
+
+- **Extraction quality varies.** Multi-column, dense-math, and badly-tagged PDFs
+  produce noisy blocks/lines. Geometry is best-effort; citations point at the
+  extracted region, which may be coarser than ideal. Mitigation: retain the
+  whole origin PDF (origin-artifact rule) so re-extraction with a better parser
+  is always possible.
+- **Sidecar surface.** TSR + OCR add two optional local models to the deploy
+  matrix. Both must degrade gracefully to "text + geometry only" / "asset only"
+  when absent, and that degradation path must be tested, not assumed.
+- **Geometry storage volume.** One `kb_doc_regions` row per line is row-heavy at
+  corpus scale (~150M rows at 10k PDFs); the composite indexes keep hot queries
+  served, but the target-corpus row count must be measured and a partition/
+  archive decision taken before default-on (see Data model).
+- **PII in a shared store.** v1 relies on access control + uploader-declared
+  sensitivity, not automated detection (§6); a misclassified document is exposed
+  to whoever its declared class permits. Automated PII scanning is future work.
+- **Heading-extraction stability.** Heading detection from PDF tags / font
+  heuristics is flaky across producers (LaTeX, Word, Docs, OCR) — unstable chunk
+  boundaries degrade citations; mitigated by the producer-diversity tests below.
+- **Boundary creep.** The temptation to compute answerability once and reuse the
+  server's confidence tier is real and wrong; keep the two judgments at their
+  own layers (see boundary note).
+
+## Tests
+
+- Unit: extractor geometry normalization (bbox in `[0,1]`, top-left origin,
+  per-page), structure-tree → `heading_path`, chunk neighbor threading,
+  **line-granularity citation resolution** from `kb_doc_regions` (incl. a
+  multi-line FTS match flagging multiple lines), cross-page chunk →
+  `page_start≠page_end`, TSR-absent and OCR-absent degradation paths,
+  answerability score/label thresholds against a fixture corpus.
+- Access control: a caller without read on a document gets empty results from
+  `search_chunks`/`open_page`/`open_neighbors`/`open_asset` (no enumeration);
+  a `restricted`/quarantined document is withheld from `search_chunks`; an
+  attempt to reach a crop by its `sha256` outside `open_asset` is denied (the
+  hash is never exposed and no file route serves the blob dir); an upload
+  missing/with an invalid `sensitivity_class` is rejected with no rows written.
+- Performance: a large chunk (~500 lines) exercises the line-granularity join in
+  `search_chunks` to confirm the chunk-size bound keeps it off the hot path.
+- Producer diversity: ingest the same paper exported from ≥3 producers (LaTeX,
+  Word, Google Docs) and assert stable chunk boundaries + citations.
+- Integration: ingest a known PDF → assert chunks + regions + citations; KB
+  `/v1` round-trip with citations; table region → typed-fact write; blob-store
+  round-trip + orphan/blob cleanup on document delete; the thin server consumer
+  call folds a cited chunk into the envelope without touching per-user
+  confidence.
+- Deploy-matrix: PDF ingest with and without each sidecar.
+
+## Review revisions (R1)
+
+Folded in from a four-lens delegate roundtable (reviewer / architect /
+security-privacy / data-model). Security returned **Fail**, the other three
+**Conditional Pass**; all ten blocking findings are resolved. Each blocker and
+where it landed:
+
+- **R1-S1 — no access-control spec for new tables/endpoints** *(security)*:
+  added `document_key` (denormalized) to `kb_doc_regions`; §5 now states every
+  endpoint applies the existing `kb_documents` document-level check and filters
+  on `document_key` with no join; Tenancy table unchanged but enforcement made
+  explicit.
+- **R1-S2 — no PII / sensitivity policy** *(security)*: new **§6** — access
+  control as primary control, uploader-declared sensitivity class
+  (`public|internal|restricted`) required at upload, quarantine state, PII
+  detection explicitly out of scope for v1 (named future work). Risks now lists
+  the residual exposure.
+- **R1-R1 — embedding/geometry interaction unspecified** *(reviewer)*: §0
+  async-embedding bullet now states embeddings stay **text-only**, geometry is
+  not embedded and not ranked → no new model, "no new service" holds.
+- **R1-R2 — FTS→citation path undefined** *(reviewer)*: §2 + §5 now specify
+  **line-granularity** resolution (FTS/embedding candidate chunks → join all
+  lines → flag query-overlapping lines; multi-line matches flag multiple lines).
+- **R1-R3 — cross-page chunk policy conflicts with the chunker** *(reviewer)*:
+  §1 decides **chunks may span pages** (heading chunker preserved;
+  `page_start≠page_end` allowed; `open_neighbors` may cross pages; precision
+  recovered at the line level).
+- **R1-A1 — `blob_ref` storage unspecified** *(architect)*: §3 specifies a
+  content-addressed filesystem blob store under `AIMEE_HOME`
+  (`blob_ref`=`sha256`), called out as a **new storage surface scoped to Phase
+  4**, and the "no new datastore" claim narrowed to *relational* stores.
+- **R1-A2 — answerability signal had no contract** *(architect)*: §5-A defines
+  `score∈[0,1]` + enum `{NONE,LOW,MEDIUM,HIGH}` with thresholds, deterministic
+  inputs, and a reference test; optional standalone `/v1/answerability` noted as
+  additive.
+- **R1-D1 — `bbox` as TEXT forecloses spatial queries** *(data-model)*: changed
+  to four `REAL` columns (`x0,y0,x1,y1`) on both tables + R*-tree on SQLite;
+  normalization convention (top-left, per-page, clamped) fixed in §2.
+- **R1-D2 — per-line volume unplanned** *(data-model)*: Data model now carries
+  row estimates (~150M at 10k PDFs), the three composite indexes for the hot
+  queries, and a **measure-before-default-on** gating criterion.
+- **R1-R4 — `kb_doc_assets` keying/FK inconsistent** *(reviewer)*: keying
+  standardized on logical `document_key`; `kb_doc_regions` gets `chunk_id` FK
+  with `ON DELETE CASCADE`; assets cleanup made an explicit maintenance-path
+  step (no single-document row exists to FK against — stated honestly).
+
+**Non-blocking suggestions** — folded: producer-diversity + access-control tests
+(§Tests), `content_type` on regions (§2), `open_neighbors` hierarchical mode +
+the three escalation tools added to the server consumer (§5, Tenancy),
+`--page N` on the CLI (§Surface), `doc_kind='pdf'` reuse (§1), bbox
+normalization convention (§2), sidecar data-retention (§6). **Deferred with
+rationale:** dropping `page_start/page_end` in favour of a derived view
+(suggestion 1) — kept as a drift-proof write-time cache instead, since the join
+cost on the hot `open_page` path is the thing we're avoiding; revisit if the
+cache proves a maintenance burden.
+
+### R2 (second review round)
+
+A fresh four-lens pass over the R1 revision marked **all ten R1 findings CLOSED**
+and confirmed the tenancy boundary still holds — with one exception that became
+a new blocker (the blob store). Verdicts: reviewer / architect / data-model
+**Conditional Pass**, security **Fail** (on R2-S1). Both new blockers folded:
+
+- **R2-S1 — blob store bypasses document access control** *(security)*: a
+  content-addressed crop readable by its `sha256` would sidestep `open_asset`'s
+  check. §3 now states the `sha256` is **KB-internal, never returned to a
+  client**, the blob dir is served by **no** file route, and `open_asset` (taking
+  an opaque asset id + applying the `document_key` check) is the **sole** read
+  path — so binary evidence is gated exactly as text is. Tests assert a by-hash
+  fetch outside `open_asset` is denied.
+- **R2-S2 — upload-time sensitivity enforcement undefined** *(security)*: §6 now
+  specifies the `kb_client_docs.c` upload handler **requires** a valid
+  `sensitivity_class` and **rejects** (4xx, no rows) when it is absent/invalid —
+  no silent default — with the class persisted and propagated to regions/assets;
+  Phase 1. A test covers the rejection.
+
+**Non-blocking suggestions** — folded: chunk-size bound (~100 lines, split
+preserving `heading_path`) + the large-chunk join load test (§1, §Tests),
+heading-extraction fallback to page-boundary chunking with manual-review flag
+(§1), configurable answerability thresholds with documented defaults (§5-A),
+the explicit quarantine state machine + operator route (§6), the periodic
+orphan-blob cleanup job + its integration test (§3). **Deferred with rationale:**
+dropping the `quote` column to derive line text at query time — kept, because
+`quote` is the natural, bbox-aligned join target for a citation and re-slicing
+chunk `content` by `line_index` at query time would re-introduce the per-row work
+the four `REAL` columns were chosen to avoid; the storage cost is accepted.
+Region-level (sub-document) access control is noted as a future extensibility
+path, not v1.
+
+### R3 (third review round) — convergence
+
+A third four-lens pass confirmed both R2 security blockers **CLOSED** (the
+`sha256` never crosses the trust boundary; access rides on the opaque
+`kb_doc_assets.id` + `document_key` check — and upload enforcement is a hard 4xx
+with no silent default) and moved the lenses to **reviewer Pass / architect Pass
+/ security Conditional Pass / data-model Pass**, with **no remaining blocking
+findings** and an explicit **READY FOR SIGN-OFF**. Security's one residual — no
+automated PII detection in v1 — is the documented v1 boundary (uploader-declared
+class + access control), with scanning named as future work, judged "a
+defensible v1 position, not a blocker."
+
+The panel flagged three **execution-discipline** items for implementation (not
+proposal defects, recorded so they aren't lost): (1) `sha256` log/error-message
+hygiene so hashes don't leak into client-visible errors; (2) the eventual-
+consistency window between chunk deletion and the maintenance-path asset/blob
+cleanup (integration-tested, but operationally a brief orphan window); (3)
+keeping asset-id access checks on `document_key` regardless of id guessability.
+No further rounds are warranted — converged.

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -32,6 +32,10 @@ Keep the two in sync: `embedding_dim` must equal the dimension
 `embedding_command` actually returns, or vector inserts will be rejected by
 Postgres.
 
+`AIMEE_EMBEDDING_DIM` overrides `embedding_dim` from the environment — useful for
+a containerized deploy with no writable `aimee.yaml` (set it alongside
+`AIMEE_EMBEDDER_IMAGE` when pinning the 0.6b tier: `AIMEE_EMBEDDING_DIM=1024`).
+
 ## How the dimension flows into the schema
 
 The DB2 schema (`src/db2/schema.sql`) declares its embedding columns with a

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -60,7 +60,8 @@ out-of-range value falls back to the `2560` default (the default embedder is the
 
 `halfvec` (fp16) is used throughout: it halves index memory versus `vector`
 (fp32) at negligible recall cost, and it lifts the index dimension ceiling from
-2000 to 4000 — required for the 4B's 2560 dims.
+2000 to 4000 — required for the 4B's 2560 dims. This needs pgvector ≥ 0.7 (the
+bundled `pgvector/pgvector:pg16` image has it); older pgvector caps at 2000.
 
 The code-side embedding buffers are sized by `EMBED_MAX_DIM` (2560 in
 `src/headers/aimee.h`), large enough to hold either model's output; the embed

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -13,11 +13,12 @@ for the HuggingFace / sentence-transformers stack). Two reference models:
 
 | Model | `embedding_dim` | Notes |
 |-------|-----------------|-------|
-| `pplx-embed-v1-0.6b` (default) | `1024` | Fast; the default for most deployments. |
-| `pplx-embed-v1-4b` | `2560` | Higher quality; needs more RAM/compute. Exceeds pgvector's 2000-dim `vector` index cap, which is why all columns use `halfvec`. |
+| `pplx-embed-v1-4b` (default) | `2560` | Higher quality; the default, since embedding throughput is not the bottleneck. Needs more RAM/compute. Exceeds pgvector's 2000-dim `vector` index cap, which is why all columns use `halfvec`. |
+| `pplx-embed-v1-0.6b` | `1024` | Lighter tier — fast, low memory. Published as the `aimee-embedder-0.6b` image. |
 
-Pick one. A deployment that wants the 4B's quality runs the 4B everywhere; a
-deployment that wants speed/low memory runs the 0.6B everywhere.
+Pick one. The default `aimee-embedder` image bakes the 4B. To run the lighter
+0.6B instead, point at the `aimee-embedder-0.6b` image (`AIMEE_EMBEDDER_IMAGE`)
+and set `embedding_dim: 1024` — no rebuild needed.
 
 ## Configuration
 
@@ -50,8 +51,8 @@ schema, `db_apply_schema_postgres()` substitutes the placeholder with the
 configured dimension — the one place the schema is materialized — so every
 `halfvec` column (`memory_embeddings`, `kb_embeddings`, and the
 `curator_*_vectors` tables) is created at the right size. An unset or
-out-of-range value falls back to the `1024` default rather than emitting invalid
-DDL.
+out-of-range value falls back to the `2560` default (the default embedder is the
+4B) rather than emitting invalid DDL.
 
 `halfvec` (fp16) is used throughout: it halves index memory versus `vector`
 (fp32) at negligible recall cost, and it lifts the index dimension ceiling from

--- a/scripts/aimee-combined-docker-smoke.sh
+++ b/scripts/aimee-combined-docker-smoke.sh
@@ -29,6 +29,13 @@ KB_URL="${KB_URL:-http://localhost:8741}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.combined.yaml}"
 SERVICE="${SERVICE:-aimee-server-kb}"
+
+# Smoke tests validate the retrieval pipeline, not a specific model. Default to
+# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
+# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+: "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${AIMEE_EMBEDDING_DIM:=1024}"
+export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 DO_UP=0
 DO_DOWN=0

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -11,7 +11,7 @@
 #   3. /v1/version             — build identifies itself
 #   4. /v1/capabilities        — capability manifest serves
 #   5. POST /v1/search         — DB2-backed query path works (empty result is OK)
-#   6. embedder /embed         — real 384-dim embedding round-trip (in-network)
+#   6. embedder /embed         — real embedding round-trip (in-network)
 #
 # The embedder port is not published by compose.yaml, so its checks run inside
 # the kb container via `docker compose exec` (the kb image ships curl).
@@ -34,6 +34,13 @@ set -euo pipefail
 KB_URL="${KB_URL:-http://localhost:8741}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
+
+# Smoke tests validate the retrieval pipeline, not a specific model. Default to
+# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
+# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+: "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${AIMEE_EMBEDDING_DIM:=1024}"
+export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -41,6 +41,13 @@ KB_URL="${KB_URL:-http://localhost:8741}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.server.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
+
+# Smoke tests validate the retrieval pipeline, not a specific model. Default to
+# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
+# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+: "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${AIMEE_EMBEDDING_DIM:=1024}"
+export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -6,10 +6,11 @@ serves embeddings over HTTP, so the aimee-kb container can embed without paying
 a multi-second model reload on every call. The thin embed-remote.py client in the
 kb image talks to this service; this service holds the model.
 
-Default model: perplexity-ai/pplx-embed-v1-0.6b (1024-dim, Qwen3-based,
-retrieval-optimized, prefix-free). The reported dimension is whatever the loaded
-model produces — it MUST match config embedding_dim and the schema vector(N)
-columns, or vector inserts fail.
+Default model: perplexity-ai/pplx-embed-v1-4b (2560-dim, Qwen3-based,
+retrieval-optimized, prefix-free); the lighter pplx-embed-v1-0.6b (1024-dim) is
+the alternate tier. The reported dimension is whatever the loaded model produces
+— it MUST match config embedding_dim and the schema vector(N) columns, or vector
+inserts fail.
 
 Also serves a cross-encoder reranker (lazy-loaded) for the aimee memory rerank
 stage, reusing the resident torch stack instead of a second container.
@@ -21,7 +22,7 @@ Endpoints:
 
 Config (env):
   EMBEDDER_PORT     listen port (default 8080)
-  EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-0.6b)
+  EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-4b)
   RERANKER_MODEL    cross-encoder model id (default ettin-reranker-400m-v1)
   EMBEDDER_THREADS  torch intra-op threads (default min(8, ncpu))
   EMBEDDER_QUANTIZE fp32 (default) | int8 (torch dynamic; ~3.3x faster, drifts —
@@ -35,7 +36,7 @@ import os
 import sys
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-0.6b")
+MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-4b")
 # Cross-encoder reranker, served from the same process (it reuses the resident
 # torch/sentence-transformers stack). Lazy-loaded on first /rerank so the embedder
 # starts and stays healthy even if reranking is never used.

--- a/src/Makefile
+++ b/src/Makefile
@@ -375,7 +375,7 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_store.c server/vault_service.c server/server_vault.c
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/server_vault.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -48,8 +48,7 @@ static int bootstrap_db2(const config_t *cfg, int json_output)
       return 0;
    }
 
-   config_apply_embedding_dim_env_override(cfg);
-   db2_set_embedding_dim(cfg->embedding_dim);
+   db2_set_embedding_dim(config_resolve_embedding_dim(cfg));
    if (db2_init(cfg->db2_url) == 0)
    {
       int schema_ok = 0;

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -4,6 +4,7 @@
 #include "agent_exec.h"
 #include "agent_config.h"
 #include "config.h"
+#include "config_database.h"
 #include "db1.h"
 #include "delegate_credentials.h"
 #include "db2/lifecycle.h"
@@ -47,6 +48,7 @@ static int bootstrap_db2(const config_t *cfg, int json_output)
       return 0;
    }
 
+   config_apply_embedding_dim_env_override(cfg);
    db2_set_embedding_dim(cfg->embedding_dim);
    if (db2_init(cfg->db2_url) == 0)
    {

--- a/src/config.c
+++ b/src/config.c
@@ -418,12 +418,13 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;
    cfg->kb_search_max_results = 50;
-   /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
-    * Must match the schema vector(N) columns and the embedder model. */
-   cfg->embedding_dim = 1024;
+   /* Embedding dimension of the default embedder (pplx-embed-v1-4b = 2560).
+    * Must match the schema vector(N) columns and the embedder model. Set to
+    * 1024 (with the pplx-embed-v1-0.6b embedder image) for the lighter tier. */
+   cfg->embedding_dim = 2560;
    /* The cross-encoder rerank stage (ettin-reranker-400m-v1, served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third
-    * pipeline stage after the 0.6B embedder, and is default-ON: every retrieval
+    * pipeline stage after the embedder, and is default-ON: every retrieval
     * runs a top-K cross-encoder pass over the dense/lexical candidates. It
     * degrades safely to plain hybrid ordering if the reranker service is absent
     * or errors, so default-on is safe even without the embedder container. */

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -59,24 +59,23 @@ int config_apply_db2_url_env_override(config_t *cfg)
    return 0;
 }
 
-/* AIMEE_EMBEDDING_DIM lets a containerized deploy set the embedder dimension
- * without a writable aimee.yaml — it must match the running embedder model
- * (1024 for pplx-embed-v1-0.6b, 2560 for the default pplx-embed-v1-4b). */
-int config_apply_embedding_dim_env_override(config_t *cfg)
+/* Effective embedding dimension: the AIMEE_EMBEDDING_DIM env override when set
+ * and valid (1..EMBED_MAX_DIM), else cfg->embedding_dim. The env lets a
+ * containerized deploy set the dim without a writable aimee.yaml — it must match
+ * the running embedder model (1024 for pplx-embed-v1-0.6b, 2560 for the default
+ * pplx-embed-v1-4b). Non-mutating so const callers can use it. */
+int config_resolve_embedding_dim(const config_t *cfg)
 {
-   if (!cfg)
-      return 0;
+   int dim = cfg ? cfg->embedding_dim : 0;
    const char *env = getenv("AIMEE_EMBEDDING_DIM");
-   if (!env || !env[0])
-      return 0;
-   char *end = NULL;
-   long v = strtol(env, &end, 10);
-   if (end && *end == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+   if (env && env[0])
    {
-      cfg->embedding_dim = (int)v;
-      return 1;
+      char *end = NULL;
+      long v = strtol(env, &end, 10);
+      if (end && *end == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+         return (int)v;
+      fprintf(stderr, "aimee: config warning: AIMEE_EMBEDDING_DIM must be 1..%d, got \"%s\"\n",
+              EMBED_MAX_DIM, env);
    }
-   fprintf(stderr, "aimee: config warning: AIMEE_EMBEDDING_DIM must be 1..%d, got \"%s\"\n",
-           EMBED_MAX_DIM, env);
-   return 0;
+   return dim;
 }

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -58,3 +58,25 @@ int config_apply_db2_url_env_override(config_t *cfg)
    }
    return 0;
 }
+
+/* AIMEE_EMBEDDING_DIM lets a containerized deploy set the embedder dimension
+ * without a writable aimee.yaml — it must match the running embedder model
+ * (1024 for pplx-embed-v1-0.6b, 2560 for the default pplx-embed-v1-4b). */
+int config_apply_embedding_dim_env_override(config_t *cfg)
+{
+   if (!cfg)
+      return 0;
+   const char *env = getenv("AIMEE_EMBEDDING_DIM");
+   if (!env || !env[0])
+      return 0;
+   char *end = NULL;
+   long v = strtol(env, &end, 10);
+   if (end && *end == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+   {
+      cfg->embedding_dim = (int)v;
+      return 1;
+   }
+   fprintf(stderr, "aimee: config warning: AIMEE_EMBEDDING_DIM must be 1..%d, got \"%s\"\n",
+           EMBED_MAX_DIM, env);
+   return 0;
+}

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -48,7 +48,7 @@ static pthread_mutex_t g_init_lock = PTHREAD_MUTEX_INITIALIZER;
  * 1024 for pplx-0.6b, 2560 for pplx-4b). Set from the loaded config by the
  * server / aimee-kb startup via db2_set_embedding_dim() before db2_init(), so
  * this layer needs no config dependency. 0 = unset -> db2_embedding_dim()
- * reports the 1024 default. */
+ * reports the 2560 default (the default embedder is pplx-4b). */
 static int g_embed_dim = 0;
 
 void db2_set_embedding_dim(int dim)
@@ -58,7 +58,7 @@ void db2_set_embedding_dim(int dim)
 
 int db2_embedding_dim(void)
 {
-   return g_embed_dim > 0 ? g_embed_dim : 1024;
+   return g_embed_dim > 0 ? g_embed_dim : 2560;
 }
 static pthread_key_t g_thread_conn_key;
 static pthread_once_t g_thread_conn_key_once = PTHREAD_ONCE_INIT;
@@ -249,7 +249,7 @@ int db2_init(const char *libpq_url)
     * embedding_dim drives the dimension of the DB2 halfvec embedding columns.
     * The dimension is supplied by db2_set_embedding_dim() at startup (the server
     * and aimee-kb, which hold the loaded config) so this low-level layer stays
-    * config-free; it defaults to 1024 when unset. */
+    * config-free; it defaults to 2560 when unset. */
    if (db_apply_schema_postgres(conn, db2_embedding_dim(), errbuf, sizeof(errbuf)) != 0)
    {
       /* Surface the postgres error so callers see WHICH statement failed.

--- a/src/headers/config_database.h
+++ b/src/headers/config_database.h
@@ -21,4 +21,9 @@ void config_parse_database(config_t *cfg, cJSON *root);
  * other config consumers are unaffected. */
 int config_apply_db2_url_env_override(config_t *cfg);
 
+/* Overrides cfg->embedding_dim from AIMEE_EMBEDDING_DIM when set (1..EMBED_MAX_DIM).
+ * Apply AFTER config_load and BEFORE db2_set_embedding_dim() so the schema columns
+ * match the running embedder. Returns 1 if applied. */
+int config_apply_embedding_dim_env_override(config_t *cfg);
+
 #endif

--- a/src/headers/config_database.h
+++ b/src/headers/config_database.h
@@ -21,9 +21,9 @@ void config_parse_database(config_t *cfg, cJSON *root);
  * other config consumers are unaffected. */
 int config_apply_db2_url_env_override(config_t *cfg);
 
-/* Overrides cfg->embedding_dim from AIMEE_EMBEDDING_DIM when set (1..EMBED_MAX_DIM).
- * Apply AFTER config_load and BEFORE db2_set_embedding_dim() so the schema columns
- * match the running embedder. Returns 1 if applied. */
-int config_apply_embedding_dim_env_override(config_t *cfg);
+/* Effective embedding dim: AIMEE_EMBEDDING_DIM env override (1..EMBED_MAX_DIM)
+ * when set, else cfg->embedding_dim. Pass the result to db2_set_embedding_dim()
+ * so the schema columns match the running embedder. Non-mutating. */
+int config_resolve_embedding_dim(const config_t *cfg);
 
 #endif

--- a/src/headers/vault_server_key.h
+++ b/src/headers/vault_server_key.h
@@ -1,0 +1,47 @@
+#ifndef DEC_VAULT_SERVER_KEY_H
+#define DEC_VAULT_SERVER_KEY_H 1
+
+#include <stdint.h>
+#include "vault_crypto.h" /* VAULT_KEK_LEN */
+
+/* vault_server_key: the SERVER-sealed key-encryption-key for dual-access
+ * credentials (WP-C.4).
+ *
+ * The per-user vaults (vault_store/vault_service) are zero-knowledge: a
+ * credential's data-encryption key (DEK) is AES-KW-wrapped under a KEK derived
+ * from the client root key (uid:) or login password (webuser:), so the server
+ * cannot read a user's secret without that client unlocking. That makes a
+ * delegate UNRUNNABLE after a restart / KEK-cache TTL expiry — the very thing we
+ * must fix: aimee-server has to drive delegates autonomously.
+ *
+ * Dual-access wrap: every vaulted credential's DEK is wrapped a SECOND time under
+ * this server KEK (in addition to the user KEK). The server can then decrypt the
+ * credential on its own — across restarts, with no client — while the user's
+ * zero-knowledge path is unchanged. The secret is still encrypted at rest (AES-
+ * 256-GCM under a random DEK); the server KEK only unwraps the DEK.
+ *
+ * Trust boundary (deliberate, per the credential-storage directive): the master
+ * key lives 0600 on the server data volume beside the vault. This defeats backup
+ * / disk theft and plaintext-in-config, NOT a root-level host compromise (root
+ * can read both key and data) — the same boundary the rest of aimee-server runs
+ * under. The module is structured so an operator passphrase could wrap the master
+ * key file later without a data migration.
+ *
+ * The 32-byte master key is generated with vault_crypto_random on first use and
+ * persisted at <config_default_dir>/.vault/.server-master.key. The server KEK is
+ * HKDF-derived from it (domain-separated from the user KEKs) and cached process-
+ * wide. Fail-closed: any entropy/IO/derivation failure returns -1 and the caller
+ * must abort the vault op rather than store/read an unprotected credential. */
+
+/* Load-or-create the master key file, derive the server KEK, and write it to
+ * `kek` (VAULT_KEK_LEN bytes). The derived KEK is cached after the first call.
+ * Returns 0 on success, -1 on any failure (kek cleansed). The caller should
+ * OPENSSL_cleanse its copy of `kek` after use. */
+int vault_server_kek(uint8_t kek[VAULT_KEK_LEN]);
+
+/* Test seam: drop the cached server KEK so a test that re-points
+ * config_default_dir at a fresh temp dir re-derives from that dir's master key.
+ * Not for production callers. */
+void vault_server_key_reset_for_test(void);
+
+#endif /* DEC_VAULT_SERVER_KEY_H */

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -85,6 +85,12 @@ vault_status_t vault_service_set(const char *principal, const char *agent, const
  * VAULT_OK, or VAULT_ERR_CRYPTO/IO on a fail-closed error. */
 vault_status_t vault_service_set_server(const char *agent, const char *cred, const char *secret);
 
+/* Read (agent, cred) from the server principal's vault under the server master KEK
+ * — no client, no unlock. VAULT_OK (plaintext written), VAULT_NO_ENTRY (no file or
+ * no such entry), or VAULT_ERR_* (fail closed). `out` is cleansed on non-OK. */
+vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
+                                                  size_t out_len);
+
 /* The use-path: resolve (agent, cred) for `principal` into `out`. Returns:
  *   VAULT_OK         + plaintext written;
  *   VAULT_NO_ENTRY   when there is no such credential (or no/blank principal) —

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -64,6 +64,27 @@ vault_status_t vault_service_rekey_password(const char *principal, attested_tran
 vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,
                                  const char *secret, long now_epoch);
 
+/* The SERVER-owned principal (WP-C.4): a vault whose KEK is the server master key
+ * (vault_server_key), needing no client root key / login / unlock. This is where
+ * delegate credentials pushed from a remote (TCP) thin client live, so the server
+ * can read them autonomously over any transport. Encrypted at rest like any other
+ * vault; the server-key trust boundary applies (see vault_server_key.h).
+ *
+ * TENANCY (deliberate): this is a SINGLE shared namespace, not per-user. That is
+ * correct because aimee-server is one person's personal agent and the TCP path is
+ * gated only by the deploy bearer — i.e. a single trust domain (a TCP caller that
+ * can push here can already drive the server). Webchat users, who DO share one
+ * server under distinct logins, get isolated `webuser:` vaults and never land
+ * here. If aimee-server ever becomes multi-tenant over TCP (distinct identities
+ * behind one listener), this principal MUST be namespaced by the attested
+ * identity, or one tenant's delegate would resolve another's key. */
+#define VAULT_SERVER_PRINCIPAL "server"
+
+/* Store `secret` for (agent, cred) under the server principal, encrypted under the
+ * server master KEK. No unlock required — usable from a TCP client. Returns
+ * VAULT_OK, or VAULT_ERR_CRYPTO/IO on a fail-closed error. */
+vault_status_t vault_service_set_server(const char *agent, const char *cred, const char *secret);
+
 /* The use-path: resolve (agent, cred) for `principal` into `out`. Returns:
  *   VAULT_OK         + plaintext written;
  *   VAULT_NO_ENTRY   when there is no such credential (or no/blank principal) —

--- a/src/headers/vault_store.h
+++ b/src/headers/vault_store.h
@@ -63,6 +63,34 @@ int vault_store_unlock_check(const char *principal, const uint8_t kek[VAULT_KEK_
 int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
                     const char *cred, const char *secret);
 
+/* Like vault_store_set, but ALSO wraps the per-credential DEK under `server_kek`
+ * (stored as "wrapped_dek_server") so the SERVER can decrypt the credential
+ * autonomously — dual-access wrap (WP-C.4). `server_kek` must be non-NULL; both
+ * wraps are written or the upsert fails (fail-closed: never store a credential
+ * the server cannot later read). 0 on success, -1 on error. */
+int vault_store_set_dual(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+                         const uint8_t server_kek[VAULT_KEK_LEN], const char *agent,
+                         const char *cred, const char *secret);
+
+/* Decrypt the (agent, cred) credential for `principal` using the SERVER wrap
+ * ("wrapped_dek_server") under `server_kek` — NO user KEK / unlock required. This
+ * is the autonomous server use-path. Returns 0 on success, VAULT_STORE_NO_ENTRY
+ * if there is no such credential OR the entry predates dual-wrap (no server wrap
+ * — caller falls back / backfills at next user unlock), or -1 on error (wrong
+ * server_kek, tamper, corrupt file — fail closed). `out` is cleansed on any
+ * non-success. */
+int vault_store_get_server(const char *principal, const uint8_t server_kek[VAULT_KEK_LEN],
+                           const char *agent, const char *cred, char *out, size_t out_len);
+
+/* Backfill the server wrap (WP-C.4) for every credential that lacks one: unwrap
+ * each DEK under `user_kek`, wrap it under `server_kek`, add "wrapped_dek_server".
+ * Called at unlock (when the user KEK is available) so credentials written before
+ * dual-wrap become server-decryptable. Entries already carrying a server wrap are
+ * left untouched. Atomic: if ANY unwrap fails (wrong user_kek / tamper) nothing
+ * is written and -1 is returned. 0 on success (incl. nothing to do). */
+int vault_store_add_server_wraps(const char *principal, const uint8_t user_kek[VAULT_KEK_LEN],
+                                 const uint8_t server_kek[VAULT_KEK_LEN]);
+
 /* Decrypt the (agent, cred) credential for `principal` under `kek` into `out`.
  * Returns 0 on success, VAULT_STORE_NO_ENTRY if no such credential (caller falls
  * back), or -1 on error (wrong KEK, tamper, corrupt file — fail closed). `out` is

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -47,8 +47,9 @@
 #endif
 
 /* Fallback kb_embeddings dimension when config.embedding_dim is unset; the
- * default embedder is pplx-embed-v1-0.6b (1024-dim). */
-#define KB_DEFAULT_DIM 1024
+ * default embedder is pplx-embed-v1-4b (2560-dim). Advisory only — the real
+ * column dimension comes from the schema (see kbiw_process_job). */
+#define KB_DEFAULT_DIM 2560
 
 /* ------------------------------------------------------------------ */
 /* notify: wake parked workers (called by kb_handle_ingest on enqueue) */

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -537,7 +537,10 @@ int main(int argc, char **argv)
 
    /* aimee-kb owns DB2; tell the DB2 layer the deployment's embedding dimension
     * (one embedder: 1024 pplx-0.6b / 2560 pplx-4b) before any db2_init() so the
-    * halfvec embedding columns are created at the right size. */
+    * halfvec embedding columns are created at the right size. AIMEE_EMBEDDING_DIM
+    * overrides the configured value (containerized deploys without a writable
+    * aimee.yaml). */
+   config_apply_embedding_dim_env_override(&kb_cfg);
    db2_set_embedding_dim(kb_cfg.embedding_dim);
 
    /* AIMEE_DB2_URL, when set, is the source of truth and overrides any db2_url

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -540,8 +540,7 @@ int main(int argc, char **argv)
     * halfvec embedding columns are created at the right size. AIMEE_EMBEDDING_DIM
     * overrides the configured value (containerized deploys without a writable
     * aimee.yaml). */
-   config_apply_embedding_dim_env_override(&kb_cfg);
-   db2_set_embedding_dim(kb_cfg.embedding_dim);
+   db2_set_embedding_dim(config_resolve_embedding_dim(&kb_cfg));
 
    /* AIMEE_DB2_URL, when set, is the source of truth and overrides any db2_url
     * cached in aimee.yaml from a previous boot — applied here unconditionally,

--- a/src/server/oauth_tokens.c
+++ b/src/server/oauth_tokens.c
@@ -14,6 +14,7 @@
 #include "db1.h"
 #include "oauth_flow.h"
 #include "oauth_pkce.h"
+#include "vault_service.h" /* server-sealed vault: encrypted-at-rest token storage */
 #include "cJSON.h"
 #include "log.h"
 #include "platform_process.h"
@@ -21,6 +22,58 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+
+/* OAuth tokens are encrypted at rest in the server-owned vault (WP-C.4), keyed by
+ * (VAULT_SERVER_PRINCIPAL, client_name, cred). The server decrypts them
+ * autonomously to refresh/use them. Previously they were stored via db1/secrets,
+ * which in a container falls back to a PLAINTEXT 0600 file — the leak this closes.
+ * The legacy plaintext entries are migrated lazily on first read and scrubbed. */
+#define OAUTH_VCRED_ACCESS  "oauth_access_token"
+#define OAUTH_VCRED_REFRESH "oauth_refresh_token"
+#define OAUTH_VCRED_EXPIRES "oauth_expires_at"
+
+static int oauth_secret_store(const char *client_name, const char *vcred, const char *value)
+{
+   if (vault_service_set_server(client_name, vcred, value) == VAULT_OK)
+      return 0;
+   aimee_log(LOG_WARN, "oauth_flow", "vault store failed for %s/%s (token not persisted)",
+             client_name, vcred);
+   return -1;
+}
+
+/* Load from the vault; if absent, lazily migrate a legacy db1/secrets plaintext
+ * value (db1_fmt is the old "oauth.%s.*" key format) into the vault and scrub it.
+ * Returns 0 with `buf` filled, or -1 on a miss (buf emptied). */
+static int oauth_secret_load(const char *client_name, const char *vcred, const char *db1_fmt,
+                             char *buf, size_t len)
+{
+   if (!buf || len == 0)
+      return -1;
+   if (vault_service_get_server_principal(client_name, vcred, buf, len) == VAULT_OK && buf[0])
+      return 0;
+   char key[256];
+   snprintf(key, sizeof(key), db1_fmt, client_name);
+   if (db1_secret_load(key, buf, len) == 0 && buf[0])
+   {
+      /* Scrub the plaintext ONLY after a durable encrypted copy exists. If the
+       * vault write fails (e.g. no master key), keep the plaintext and retry the
+       * migration on the next read — never delete the only copy of the token. The
+       * value is valid either way, so we still return it to the caller. */
+      if (vault_service_set_server(client_name, vcred, buf) == VAULT_OK)
+         (void)db1_secret_remove(key);
+      return 0;
+   }
+   buf[0] = '\0';
+   return -1;
+}
+
+static void oauth_secret_remove(const char *client_name, const char *vcred, const char *db1_fmt)
+{
+   (void)vault_service_delete(VAULT_SERVER_PRINCIPAL, client_name, vcred);
+   char key[256];
+   snprintf(key, sizeof(key), db1_fmt, client_name);
+   (void)db1_secret_remove(key); /* also clear any legacy plaintext */
+}
 
 /* ---- JSON parsing ---- */
 
@@ -73,17 +126,14 @@ int oauth_token_store(const char *client_name, const oauth_token_response_t *res
    if (!client_name || !resp || !resp->access_token[0])
       return -1;
 
-   char key[256];
    int rc = 0;
 
-   snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-   if (db1_secret_store(key, resp->access_token) != 0)
+   if (oauth_secret_store(client_name, OAUTH_VCRED_ACCESS, resp->access_token) != 0)
       rc = -1;
 
    if (resp->refresh_token[0])
    {
-      snprintf(key, sizeof(key), OAUTH_KEY_REFRESH_TOKEN, client_name);
-      if (db1_secret_store(key, resp->refresh_token) != 0)
+      if (oauth_secret_store(client_name, OAUTH_VCRED_REFRESH, resp->refresh_token) != 0)
          rc = -1;
    }
 
@@ -91,8 +141,7 @@ int oauth_token_store(const char *client_name, const oauth_token_response_t *res
    {
       char ea_str[32];
       snprintf(ea_str, sizeof(ea_str), "%ld", resp->expires_at);
-      snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client_name);
-      if (db1_secret_store(key, ea_str) != 0)
+      if (oauth_secret_store(client_name, OAUTH_VCRED_EXPIRES, ea_str) != 0)
          rc = -1;
    }
 
@@ -104,17 +153,14 @@ int oauth_token_load(const char *client_name, char *buf, size_t len)
    if (!client_name || !buf || len == 0)
       return -1;
 
-   char key[256];
-   snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-
-   if (db1_secret_load(key, buf, len) != 0 || buf[0] == '\0')
+   if (oauth_secret_load(client_name, OAUTH_VCRED_ACCESS, OAUTH_KEY_ACCESS_TOKEN, buf, len) != 0)
       return -1;
 
    /* Check expiry */
-   char ea_key[256];
    char ea_str[32] = "";
-   snprintf(ea_key, sizeof(ea_key), OAUTH_KEY_EXPIRES_AT, client_name);
-   if (db1_secret_load(ea_key, ea_str, sizeof(ea_str)) == 0 && ea_str[0])
+   if (oauth_secret_load(client_name, OAUTH_VCRED_EXPIRES, OAUTH_KEY_EXPIRES_AT, ea_str,
+                         sizeof(ea_str)) == 0 &&
+       ea_str[0])
    {
       long expires_at = atol(ea_str);
       if (expires_at > 0 && time(NULL) >= expires_at)
@@ -131,13 +177,9 @@ int oauth_token_remove(const char *client_name)
 {
    if (!client_name)
       return -1;
-   char key[256];
-   snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-   db1_secret_remove(key);
-   snprintf(key, sizeof(key), OAUTH_KEY_REFRESH_TOKEN, client_name);
-   db1_secret_remove(key);
-   snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client_name);
-   db1_secret_remove(key);
+   oauth_secret_remove(client_name, OAUTH_VCRED_ACCESS, OAUTH_KEY_ACCESS_TOKEN);
+   oauth_secret_remove(client_name, OAUTH_VCRED_REFRESH, OAUTH_KEY_REFRESH_TOKEN);
+   oauth_secret_remove(client_name, OAUTH_VCRED_EXPIRES, OAUTH_KEY_EXPIRES_AT);
    return 0;
 }
 
@@ -194,9 +236,10 @@ int oauth_token_refresh(const char *client_name, const char *client_id, const ch
       return -1;
 
    /* Load the stored refresh token */
-   char rt_key[256], refresh_token[512] = "";
-   snprintf(rt_key, sizeof(rt_key), OAUTH_KEY_REFRESH_TOKEN, client_name);
-   if (db1_secret_load(rt_key, refresh_token, sizeof(refresh_token)) != 0 || !refresh_token[0])
+   char refresh_token[512] = "";
+   if (oauth_secret_load(client_name, OAUTH_VCRED_REFRESH, OAUTH_KEY_REFRESH_TOKEN, refresh_token,
+                         sizeof(refresh_token)) != 0 ||
+       !refresh_token[0])
    {
       aimee_log(LOG_WARN, "oauth_flow", "no refresh token stored for %s", client_name);
       return -1;
@@ -241,10 +284,11 @@ int oauth_token_get(const char *client_name, const char *client_id, const char *
       return -1;
 
    /* Check whether the stored token is near expiry */
-   char ea_key[256], ea_str[32] = "";
-   snprintf(ea_key, sizeof(ea_key), OAUTH_KEY_EXPIRES_AT, client_name);
+   char ea_str[32] = "";
    int need_refresh = 0;
-   if (db1_secret_load(ea_key, ea_str, sizeof(ea_str)) == 0 && ea_str[0])
+   if (oauth_secret_load(client_name, OAUTH_VCRED_EXPIRES, OAUTH_KEY_EXPIRES_AT, ea_str,
+                         sizeof(ea_str)) == 0 &&
+       ea_str[0])
    {
       long expires_at = atol(ea_str);
       if (expires_at > 0 && time(NULL) + skew_secs >= expires_at)
@@ -255,9 +299,8 @@ int oauth_token_get(const char *client_name, const char *client_id, const char *
       oauth_token_refresh(client_name, client_id, token_endpoint);
 
    /* Try to load the (possibly refreshed) access token */
-   char at_key[256];
-   snprintf(at_key, sizeof(at_key), OAUTH_KEY_ACCESS_TOKEN, client_name);
-   if (db1_secret_load(at_key, buf, len) != 0 || buf[0] == '\0')
+   if (oauth_secret_load(client_name, OAUTH_VCRED_ACCESS, OAUTH_KEY_ACCESS_TOKEN, buf, len) != 0 ||
+       buf[0] == '\0')
       return -1;
 
    return 0;

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -10,6 +10,7 @@
 #include "cJSON.h"
 #include "json_fluent.h" /* jo_ok */
 #include "log.h"
+#include "vault_service.h" /* vault_service_set / set_server, VAULT_API_KEY_CRED */
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -484,9 +485,42 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
    ag->enabled = opt_has(&opts, "disabled") ? 0 : 1;
 
+   /* A literal --key is a secret: vault it (encrypted at rest), never persist it
+    * in agents.json. A $VAR reference is not a secret — keep it as a reference
+    * that resolves from the environment at run time. */
    const char *key = opt_get(&opts, "key");
    if (key && key[0])
-      agent_expand_env(key, ag->api_key, sizeof(ag->api_key));
+   {
+      if (key[0] == '$')
+      {
+         /* An env reference is not a secret: store it UNEXPANDED so agents.json
+          * holds "$VAR", not the resolved value. agent_load_config expands it
+          * from the environment at run time. Expanding here would serialize the
+          * plaintext key to disk — the exact leak the literal branch avoids. */
+         snprintf(ag->api_key, sizeof(ag->api_key), "%s", key);
+      }
+      else
+      {
+         /* A local/webchat caller with a per-user vault gets a dual-access entry
+          * (requires the vault unlocked); a remote (TCP) caller has no per-user
+          * principal, so the secret lands in the server-owned vault, which the
+          * server can decrypt autonomously. On any failure we REFUSE rather than
+          * write the secret to agents.json in plaintext. */
+         const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
+         vault_status_t vst =
+             principal
+                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
+                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
+         if (vst != VAULT_OK)
+         {
+            if (vst == VAULT_ERR_LOCKED)
+               return server_send_error(
+                   conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
+            return server_send_error(conn, "could not store credential in the vault", NULL);
+         }
+         ag->api_key[0] = '\0'; /* the secret lives only in the vault */
+      }
+   }
    const char *auth_cmd = opt_get(&opts, "auth-cmd");
    if (auth_cmd && auth_cmd[0])
       snprintf(ag->auth_cmd, sizeof(ag->auth_cmd), "%s", auth_cmd);

--- a/src/server/vault_server_key.c
+++ b/src/server/vault_server_key.c
@@ -1,0 +1,185 @@
+/* vault_server_key.c: the server-sealed KEK for dual-access credentials (WP-C.4).
+ * See vault_server_key.h. Reuses the vault_crypto primitives — this file only
+ * manages the 0600 master-key file and caches the derived server KEK. */
+#include "vault_server_key.h"
+#include "vault_crypto.h"
+#include "config.h"        /* config_default_dir */
+#include "platform_path.h" /* platform_mkdir_p */
+#include "log.h"
+#include <openssl/crypto.h> /* OPENSSL_cleanse */
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* Fixed, non-secret HKDF salt for the server KEK. Distinct from the random
+ * per-principal salts the user vaults use, so the server KEK lives in its own
+ * derivation space (domain separation). Changing it would orphan every existing
+ * server wrap, so it is frozen. */
+static const uint8_t SERVER_KEK_SALT[VAULT_SALT_LEN] = {
+    0x61, 0x69, 0x6d, 0x65, 0x65, 0x2d, 0x73, 0x76, 0x72, 0x6b, 0x65, 0x6b, 0x2d, 0x76, 0x31, 0x00};
+
+static pthread_mutex_t g_kek_mu = PTHREAD_MUTEX_INITIALIZER;
+static uint8_t g_kek[VAULT_KEK_LEN];
+static int g_kek_ready; /* 0 until the KEK is derived + cached */
+
+/* Compose <config_default_dir>/.vault/.server-master.key. Returns 0 on success. */
+static int master_key_path(char *out, size_t cap)
+{
+   const char *base = config_default_dir();
+   if (!base || !base[0])
+      return -1;
+   return (size_t)snprintf(out, cap, "%s/.vault/.server-master.key", base) >= cap ? -1 : 0;
+}
+
+/* Outcome of reading the master-key file. The caller must NOT mint a new key on
+ * MK_READ_BAD — a present-but-unreadable file (transient EACCES/EIO, wrong size)
+ * must fail closed, never be overwritten, or one transient error would orphan
+ * every existing server wrap. Only MK_READ_ABSENT (genuinely no file) may mint. */
+typedef enum
+{
+   MK_READ_OK = 0,
+   MK_READ_ABSENT = 1, /* ENOENT: no key file yet — safe to mint */
+   MK_READ_BAD = -1,   /* exists but unreadable/wrong size — fail closed, do NOT mint */
+} mk_read_t;
+
+/* Read exactly VAULT_ROOT_KEY_LEN bytes from `path` into `key`. Returns MK_READ_*
+ * (key cleansed on any non-OK). A file of any size other than exactly 32 bytes is
+ * BAD, not absent — we never overwrite it. */
+static mk_read_t master_key_read(const char *path, uint8_t key[VAULT_ROOT_KEY_LEN])
+{
+   int fd = open(path, O_RDONLY);
+   if (fd < 0)
+   {
+      OPENSSL_cleanse(key, VAULT_ROOT_KEY_LEN);
+      return errno == ENOENT ? MK_READ_ABSENT : MK_READ_BAD;
+   }
+   uint8_t buf[VAULT_ROOT_KEY_LEN + 1];
+   ssize_t n = read(fd, buf, sizeof(buf));
+   close(fd);
+   int ok = (n == (ssize_t)VAULT_ROOT_KEY_LEN);
+   if (ok)
+      memcpy(key, buf, VAULT_ROOT_KEY_LEN);
+   OPENSSL_cleanse(buf, sizeof(buf));
+   if (!ok)
+      OPENSSL_cleanse(key, VAULT_ROOT_KEY_LEN);
+   return ok ? MK_READ_OK : MK_READ_BAD;
+}
+
+/* fsync the directory holding `path` so a rename into it survives a crash. */
+static void fsync_parent_dir(const char *path)
+{
+   char dir[1280];
+   snprintf(dir, sizeof(dir), "%s", path);
+   char *slash = strrchr(dir, '/');
+   if (!slash)
+      return;
+   *slash = '\0';
+   int fd = open(dir, O_RDONLY);
+   if (fd >= 0)
+   {
+      (void)fsync(fd);
+      close(fd);
+   }
+}
+
+/* Atomically create the master-key file with `key` at 0600 (tmp + rename +
+ * fsync). 0 on success, -1 on error. */
+static int master_key_write(const char *path, const uint8_t key[VAULT_ROOT_KEY_LEN])
+{
+   char dir[1024], tmp[1280];
+   const char *base = config_default_dir();
+   if (!base || !base[0] || (size_t)snprintf(dir, sizeof(dir), "%s/.vault", base) >= sizeof(dir))
+      return -1;
+   if (platform_mkdir_p(dir, 0700) != 0)
+      return -1;
+   static atomic_uint s_seq = 0;
+   unsigned seq = atomic_fetch_add(&s_seq, 1);
+   if ((size_t)snprintf(tmp, sizeof(tmp), "%s.tmp.%d.%u", path, (int)getpid(), seq) >= sizeof(tmp))
+      return -1;
+
+   int rc = -1;
+   int fd = open(tmp, O_CREAT | O_WRONLY | O_TRUNC | O_EXCL, 0600);
+   if (fd >= 0)
+   {
+      ssize_t w = write(fd, key, VAULT_ROOT_KEY_LEN);
+      if (w == (ssize_t)VAULT_ROOT_KEY_LEN && fsync(fd) == 0)
+         rc = 0;
+      close(fd);
+      if (rc == 0 && rename(tmp, path) != 0)
+         rc = -1;
+      if (rc != 0)
+         unlink(tmp);
+   }
+   if (rc == 0)
+      fsync_parent_dir(path); /* make the rename durable across a crash */
+   return rc;
+}
+
+/* Load-or-create the master key, derive the server KEK, cache it. Caller holds
+ * g_kek_mu. */
+static int derive_and_cache(void)
+{
+   char path[1280];
+   if (master_key_path(path, sizeof(path)) != 0)
+      return -1;
+
+   uint8_t master[VAULT_ROOT_KEY_LEN];
+   mk_read_t r = master_key_read(path, master);
+   if (r == MK_READ_BAD)
+      return -1; /* present but unreadable — fail closed, NEVER overwrite (F1) */
+   if (r == MK_READ_ABSENT)
+   {
+      /* Genuinely no key file: mint a fresh master and persist it. A concurrent
+       * creator would lose the O_EXCL race; fall back to reading the winner's
+       * file (which must now be readable, else fail closed). */
+      if (vault_crypto_random(master, sizeof(master)) != 0)
+         return -1;
+      if (master_key_write(path, master) != 0)
+      {
+         OPENSSL_cleanse(master, sizeof(master));
+         if (master_key_read(path, master) != MK_READ_OK)
+         {
+            OPENSSL_cleanse(master, sizeof(master)); /* read-back failed — cleanse (F2) */
+            return -1;
+         }
+      }
+   }
+
+   int rc = vault_kek_derive(master, sizeof(master), SERVER_KEK_SALT, sizeof(SERVER_KEK_SALT),
+                             g_kek) == 0
+                ? 0
+                : -1;
+   OPENSSL_cleanse(master, sizeof(master));
+   if (rc == 0)
+      g_kek_ready = 1;
+   else
+      OPENSSL_cleanse(g_kek, sizeof(g_kek));
+   return rc;
+}
+
+int vault_server_kek(uint8_t kek[VAULT_KEK_LEN])
+{
+   if (!kek)
+      return -1;
+   pthread_mutex_lock(&g_kek_mu);
+   int rc = g_kek_ready ? 0 : derive_and_cache();
+   if (rc == 0)
+      memcpy(kek, g_kek, VAULT_KEK_LEN);
+   pthread_mutex_unlock(&g_kek_mu);
+   if (rc != 0)
+      OPENSSL_cleanse(kek, VAULT_KEK_LEN);
+   return rc;
+}
+
+void vault_server_key_reset_for_test(void)
+{
+   pthread_mutex_lock(&g_kek_mu);
+   OPENSSL_cleanse(g_kek, sizeof(g_kek));
+   g_kek_ready = 0;
+   pthread_mutex_unlock(&g_kek_mu);
+}

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -77,8 +77,8 @@ static vault_status_t vault_service_get_server_wrap(const char *principal, const
 /* Read (agent, cred) from the SERVER principal's vault under the server master KEK
  * — no client, no unlock. VAULT_OK / VAULT_NO_ENTRY (no file or no entry) /
  * VAULT_ERR_* (fail closed). */
-static vault_status_t vault_service_get_server_principal(const char *agent, const char *cred,
-                                                         char *out, size_t out_len)
+vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
+                                                  size_t out_len)
 {
    if (out && out_len)
       out[0] = '\0';

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -5,6 +5,7 @@
 #include "vault_service.h"
 #include "vault_crypto.h"
 #include "vault_kek_cache.h"
+#include "vault_server_key.h"
 #include "vault_store.h"
 #include "log.h"
 #include <openssl/crypto.h>
@@ -35,6 +36,88 @@ const char *vault_status_str(vault_status_t s)
    return "error";
 }
 
+/* Add the server wrap to any user-only credentials for `principal` using the live
+ * user KEK (WP-C.4 dual-access backfill). Best-effort; logs on failure. */
+static void vault_service_backfill_server_wraps(const char *principal,
+                                                const uint8_t user_kek[VAULT_KEK_LEN])
+{
+   uint8_t server_kek[VAULT_KEK_LEN];
+   if (vault_server_kek(server_kek) != 0)
+      return;
+   if (vault_store_add_server_wraps(principal, user_kek, server_kek) != 0)
+      LOG_WARN("vault", "server-wrap backfill failed (creds remain user-only until next unlock)");
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
+}
+
+/* The autonomous server use-path: decrypt (agent, cred) via the server wrap, no
+ * client unlock / KEK cache. Returns VAULT_OK (plaintext written), VAULT_NO_ENTRY
+ * (no such cred, or a legacy user-only entry — caller falls back to the user KEK
+ * path), or VAULT_ERR_* (fail closed). */
+static vault_status_t vault_service_get_server_wrap(const char *principal, const char *agent,
+                                                    const char *cred, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!principal || !principal[0])
+      return VAULT_NO_ENTRY;
+   if (!agent || !cred || !out || !out_len)
+      return VAULT_ERR_BADARG;
+   uint8_t server_kek[VAULT_KEK_LEN];
+   if (vault_server_kek(server_kek) != 0)
+      return VAULT_ERR_CRYPTO;
+   int rc = vault_store_get_server(principal, server_kek, agent, cred, out, out_len);
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
+   if (rc == 0)
+      return VAULT_OK;
+   if (rc == VAULT_STORE_NO_ENTRY)
+      return VAULT_NO_ENTRY;
+   return VAULT_ERR_CRYPTO; /* decrypt/tamper — fail closed */
+}
+
+/* Read (agent, cred) from the SERVER principal's vault under the server master KEK
+ * — no client, no unlock. VAULT_OK / VAULT_NO_ENTRY (no file or no entry) /
+ * VAULT_ERR_* (fail closed). */
+static vault_status_t vault_service_get_server_principal(const char *agent, const char *cred,
+                                                         char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!agent || !cred || !out || !out_len)
+      return VAULT_ERR_BADARG;
+   uint8_t kek[VAULT_KEK_LEN];
+   if (vault_server_kek(kek) != 0)
+      return VAULT_ERR_CRYPTO;
+   int rc = vault_store_get(VAULT_SERVER_PRINCIPAL, kek, agent, cred, out, out_len);
+   OPENSSL_cleanse(kek, sizeof(kek));
+   if (rc == 0)
+      return VAULT_OK;
+   if (rc == VAULT_STORE_NO_ENTRY)
+      return VAULT_NO_ENTRY;
+   return VAULT_ERR_CRYPTO; /* decrypt/tamper — fail closed */
+}
+
+vault_status_t vault_service_set_server(const char *agent, const char *cred, const char *secret)
+{
+   if (!agent || !agent[0] || !cred || !cred[0] || !secret)
+      return VAULT_ERR_BADARG;
+   uint8_t kek[VAULT_KEK_LEN];
+   if (vault_server_kek(kek) != 0)
+      return VAULT_ERR_CRYPTO; /* fail-closed: no server KEK -> never store plaintext */
+
+   /* The vault file must exist before set; create it (the stored salt is unused
+    * for the server KEK, which is derived from the master key, not salt+root). */
+   uint8_t salt[VAULT_SALT_LEN];
+   vault_status_t st;
+   if (vault_store_get_or_create_salt(VAULT_SERVER_PRINCIPAL, salt) != 0)
+      st = VAULT_ERR_IO;
+   else
+      st = vault_store_set(VAULT_SERVER_PRINCIPAL, kek, agent, cred, secret) == 0 ? VAULT_OK
+                                                                                  : VAULT_ERR_IO;
+   OPENSSL_cleanse(kek, sizeof(kek));
+   OPENSSL_cleanse(salt, sizeof(salt));
+   return st;
+}
+
 vault_status_t vault_service_unlock(const char *principal, attested_transport_t transport,
                                     const uint8_t *root_key, size_t root_key_len, long now_epoch)
 {
@@ -62,6 +145,12 @@ vault_status_t vault_service_unlock(const char *principal, attested_transport_t 
       st = VAULT_ERR_CRYPTO; /* wrong root key — caught by the key-check verifier */
    else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
       st = VAULT_ERR_LOCKED; /* cache full of live principals — reject, don't evict */
+
+   /* WP-C.4 dual-access backfill: now that we hold the user KEK, add the server
+    * wrap to any credentials written before dual-wrap so the server can decrypt
+    * them autonomously. Best-effort — never fail the unlock on a backfill error. */
+   if (st == VAULT_OK)
+      vault_service_backfill_server_wraps(principal, kek);
 
    OPENSSL_cleanse(kek, sizeof(kek));
    OPENSSL_cleanse(salt, sizeof(salt));
@@ -96,6 +185,10 @@ vault_status_t vault_service_unlock_password(const char *principal, attested_tra
       st = VAULT_ERR_CRYPTO; /* wrong password — caught by the key-check verifier */
    else if (vault_kek_cache_put(principal, kek, now_epoch) != 0)
       st = VAULT_ERR_LOCKED;
+
+   /* WP-C.4 dual-access backfill (see vault_service_unlock). */
+   if (st == VAULT_OK)
+      vault_service_backfill_server_wraps(principal, kek);
 
    OPENSSL_cleanse(kek, sizeof(kek));
    OPENSSL_cleanse(salt, sizeof(salt));
@@ -152,9 +245,20 @@ vault_status_t vault_service_set(const char *principal, const char *agent, const
    if (vault_kek_cache_get(principal, now_epoch, kek) != 0)
       return VAULT_ERR_LOCKED; /* must unlock first */
 
-   vault_status_t st =
-       vault_store_set(principal, kek, agent, cred, secret) == 0 ? VAULT_OK : VAULT_ERR_IO;
+   /* WP-C.4 dual-access: wrap the DEK under BOTH the user KEK and the server KEK
+    * so the server can decrypt this credential autonomously after a restart.
+    * Fail-closed if the server KEK is unavailable — never store a user-only cred
+    * the server cannot later read (that is the bug this whole change fixes). */
+   uint8_t server_kek[VAULT_KEK_LEN];
+   vault_status_t st;
+   if (vault_server_kek(server_kek) != 0)
+      st = VAULT_ERR_CRYPTO;
+   else
+      st = vault_store_set_dual(principal, kek, server_kek, agent, cred, secret) == 0
+               ? VAULT_OK
+               : VAULT_ERR_IO;
    OPENSSL_cleanse(kek, sizeof(kek));
+   OPENSSL_cleanse(server_kek, sizeof(server_kek));
    return st;
 }
 
@@ -232,8 +336,18 @@ vault_status_t vault_service_inject_api_key(const char *principal, const char *a
    char *tmp = malloc(api_key_len);
    if (!tmp)
       return VAULT_ERR_IO;
+   /* Server-first (WP-C.4): the server wrap decrypts autonomously — no client
+    * unlock, survives restart. Fall back to the user-KEK path only for legacy
+    * creds not yet dual-wrapped (those get backfilled at the next user unlock). */
    vault_status_t st =
-       vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
+       vault_service_get_server_wrap(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len);
+   if (st == VAULT_NO_ENTRY)
+      st = vault_service_get(principal, agent, VAULT_API_KEY_CRED, tmp, api_key_len, now_epoch);
+   /* Last: the server-owned vault (delegate creds pushed from a TCP thin client,
+    * which has no per-user principal). Only on a clean miss — a LOCKED user cred
+    * stays a hard error (D15), never silently downgraded to the server vault. */
+   if (st == VAULT_NO_ENTRY)
+      st = vault_service_get_server_principal(agent, VAULT_API_KEY_CRED, tmp, api_key_len);
    if (st == VAULT_OK)
       snprintf(api_key, api_key_len, "%s", tmp); /* overwrite only on a real hit */
    OPENSSL_cleanse(tmp, api_key_len);

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -332,8 +332,11 @@ static int add_b64_field(cJSON *obj, const char *name, const uint8_t *bin, size_
    return 0;
 }
 
-int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
-                    const char *cred, const char *secret)
+/* Shared set implementation. When `server_kek` is non-NULL the DEK is wrapped a
+ * second time under it ("wrapped_dek_server") for dual-access (WP-C.4). */
+static int vault_store_set_impl(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+                                const uint8_t *server_kek, const char *agent, const char *cred,
+                                const char *secret)
 {
    if (!principal || !kek || !agent || !agent[0] || !cred || !cred[0] || !secret)
       return -1;
@@ -351,7 +354,8 @@ int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], con
 
    int rc = -1;
    uint8_t dek[VAULT_DEK_LEN] = {0};
-   uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], nonce[VAULT_GCM_NONCE_LEN], tag[VAULT_GCM_TAG_LEN];
+   uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], wrapped_server[VAULT_WRAPPED_DEK_LEN],
+       nonce[VAULT_GCM_NONCE_LEN], tag[VAULT_GCM_TAG_LEN];
    uint8_t *ct = malloc(pt_len ? pt_len : 1);
    char aad[VAULT_AAD_MAX];
    if (!ct)
@@ -364,6 +368,11 @@ int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], con
                             nonce, ct, tag) != 0)
       goto out;
    if (vault_dek_wrap(kek, dek, wrapped) != 0)
+      goto out;
+   /* Dual-access: a second wrap of the same DEK under the server KEK. Fail-closed
+    * — if requested but it can't be produced, store nothing (never a credential
+    * the server cannot later read). */
+   if (server_kek && vault_dek_wrap(server_kek, dek, wrapped_server) != 0)
       goto out;
 
    /* Build the cred object, replacing any existing entry for (agent,cred). */
@@ -380,7 +389,9 @@ int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], con
       if (add_b64_field(obj, "wrapped_dek", wrapped, sizeof(wrapped)) != 0 ||
           add_b64_field(obj, "nonce", nonce, sizeof(nonce)) != 0 ||
           add_b64_field(obj, "ciphertext", ct, pt_len) != 0 ||
-          add_b64_field(obj, "tag", tag, sizeof(tag)) != 0)
+          add_b64_field(obj, "tag", tag, sizeof(tag)) != 0 ||
+          (server_kek &&
+           add_b64_field(obj, "wrapped_dek_server", wrapped_server, sizeof(wrapped_server)) != 0))
       {
          cJSON_Delete(obj);
          goto out;
@@ -400,6 +411,21 @@ out:
    cJSON_Delete(root);
    pthread_mutex_unlock(&g_vault_write_mu);
    return rc;
+}
+
+int vault_store_set(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
+                    const char *cred, const char *secret)
+{
+   return vault_store_set_impl(principal, kek, NULL, agent, cred, secret);
+}
+
+int vault_store_set_dual(const char *principal, const uint8_t kek[VAULT_KEK_LEN],
+                         const uint8_t server_kek[VAULT_KEK_LEN], const char *agent,
+                         const char *cred, const char *secret)
+{
+   if (!server_kek)
+      return -1;
+   return vault_store_set_impl(principal, kek, server_kek, agent, cred, secret);
 }
 
 int vault_store_get(const char *principal, const uint8_t kek[VAULT_KEK_LEN], const char *agent,
@@ -479,6 +505,143 @@ out:
    if (rc != 0 && out && out_len)
       OPENSSL_cleanse(out, out_len);
    cJSON_Delete(root);
+   return rc;
+}
+
+int vault_store_get_server(const char *principal, const uint8_t server_kek[VAULT_KEK_LEN],
+                           const char *agent, const char *cred, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!principal || !server_kek || !agent || !cred || !out || !out_len)
+      return -1;
+
+   cJSON *root = load_vault(principal);
+   if (!root)
+      return VAULT_STORE_NO_ENTRY; /* no file -> no entry, fall back */
+
+   int rc = -1;
+   uint8_t dek[VAULT_DEK_LEN] = {0};
+   uint8_t *pt = NULL;
+   size_t pt_alloc = 0;
+   cJSON *e = find_cred(root, agent, cred);
+   if (!e)
+   {
+      rc = VAULT_STORE_NO_ENTRY;
+      goto out;
+   }
+   {
+      cJSON *jw = cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek_server");
+      cJSON *jn = cJSON_GetObjectItemCaseSensitive(e, "nonce");
+      cJSON *jc = cJSON_GetObjectItemCaseSensitive(e, "ciphertext");
+      cJSON *jt = cJSON_GetObjectItemCaseSensitive(e, "tag");
+      /* A legacy entry (pre-dual-wrap) has no server wrap: report NO_ENTRY so the
+       * caller falls back / backfills at the next user unlock, never an error. */
+      if (!cJSON_IsString(jw))
+      {
+         rc = VAULT_STORE_NO_ENTRY;
+         goto out;
+      }
+      if (!cJSON_IsString(jn) || !cJSON_IsString(jc) || !cJSON_IsString(jt))
+         goto out;
+      uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], nonce[VAULT_GCM_NONCE_LEN], tag[VAULT_GCM_TAG_LEN];
+      if (b64url_decode(jw->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+          b64url_decode(jn->valuestring, nonce, sizeof(nonce)) != VAULT_GCM_NONCE_LEN ||
+          b64url_decode(jt->valuestring, tag, sizeof(tag)) != VAULT_GCM_TAG_LEN)
+         goto out;
+      size_t ct_cap = strlen(jc->valuestring); /* >= decoded length */
+      pt = malloc(ct_cap + 1);
+      pt_alloc = ct_cap + 1;
+      uint8_t *ctbuf = malloc(ct_cap + 1);
+      if (!pt || !ctbuf)
+      {
+         free(ctbuf);
+         goto out;
+      }
+      int ct_len = b64url_decode(jc->valuestring, ctbuf, ct_cap + 1);
+      char aad[VAULT_AAD_MAX];
+      if (ct_len < 0 || build_aad(principal, agent, cred, aad, sizeof(aad)) < 0 ||
+          (size_t)ct_len >= out_len)
+      {
+         free(ctbuf);
+         goto out;
+      }
+      if (vault_dek_unwrap(server_kek, wrapped, dek) != 0 ||
+          vault_secret_decrypt(dek, (const uint8_t *)aad, strlen(aad), nonce, ctbuf, (size_t)ct_len,
+                               tag, pt) != 0)
+      {
+         OPENSSL_cleanse(ctbuf, ct_cap + 1);
+         free(ctbuf);
+         goto out; /* fail-closed: wrong server KEK / tamper / AAD mismatch */
+      }
+      memcpy(out, pt, (size_t)ct_len);
+      out[ct_len] = '\0';
+      OPENSSL_cleanse(ctbuf, ct_cap + 1);
+      free(ctbuf);
+      rc = 0;
+   }
+
+out:
+   OPENSSL_cleanse(dek, sizeof(dek));
+   if (pt)
+   {
+      OPENSSL_cleanse(pt, pt_alloc);
+      free(pt);
+   }
+   if (rc != 0 && out && out_len)
+      OPENSSL_cleanse(out, out_len);
+   cJSON_Delete(root);
+   return rc;
+}
+
+int vault_store_add_server_wraps(const char *principal, const uint8_t user_kek[VAULT_KEK_LEN],
+                                 const uint8_t server_kek[VAULT_KEK_LEN])
+{
+   if (!principal || !user_kek || !server_kek)
+      return -1;
+   pthread_mutex_lock(&g_vault_write_mu);
+   cJSON *root = load_vault(principal);
+   if (!root)
+   {
+      pthread_mutex_unlock(&g_vault_write_mu);
+      return 0; /* no vault -> nothing to backfill */
+   }
+
+   int rc = 0;
+   int changed = 0;
+   cJSON *creds = creds_array(root);
+   cJSON *e = NULL;
+   if (creds)
+   {
+      cJSON_ArrayForEach(e, creds)
+      {
+         if (cJSON_IsString(cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek_server")))
+            continue; /* already dual-wrapped */
+         cJSON *jw = cJSON_GetObjectItemCaseSensitive(e, "wrapped_dek");
+         uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], dek[VAULT_DEK_LEN],
+             rewrapped[VAULT_WRAPPED_DEK_LEN];
+         if (!cJSON_IsString(jw) ||
+             b64url_decode(jw->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+             vault_dek_unwrap(user_kek, wrapped, dek) != 0 ||
+             vault_dek_wrap(server_kek, dek, rewrapped) != 0)
+         {
+            OPENSSL_cleanse(dek, sizeof(dek));
+            rc = -1; /* wrong user KEK / tamper -> abort, write nothing */
+            break;
+         }
+         OPENSSL_cleanse(dek, sizeof(dek));
+         if (add_b64_field(e, "wrapped_dek_server", rewrapped, sizeof(rewrapped)) != 0)
+         {
+            rc = -1;
+            break;
+         }
+         changed = 1;
+      }
+   }
+   if (rc == 0 && changed)
+      rc = write_vault_file(principal, root);
+   cJSON_Delete(root);
+   pthread_mutex_unlock(&g_vault_write_mu);
    return rc;
 }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -188,6 +188,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-kek-cache \
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
+               $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-prompts \
                $(TESTPREFIX)/unit-test-cmd-session \
                $(TESTPREFIX)/unit-test-model-registry \
@@ -1796,6 +1797,12 @@ $(TESTPREFIX)/unit-test-vault-store: $(OBJDIR)/tests/test_vault_store.o \
 $(TESTPREFIX)/unit-test-vault-service: $(OBJDIR)/tests/test_vault_service.o \
                               $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
                               $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-vault-server-key: $(OBJDIR)/tests/test_vault_server_key.o \
+                              $(OBJDIR)/server/vault_server_key.o $(OBJDIR)/server/vault_crypto.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2082,6 +2082,11 @@ $(TESTPREFIX)/unit-test-oauth-pkce: $(OBJDIR)/tests/test_oauth_pkce.o \
                      $(OBJDIR)/server/oauth_pkce.o \
                      $(OBJDIR)/server/oauth_tokens.o \
                      $(OBJDIR)/db1/secrets.o \
+                     $(OBJDIR)/server/vault_service.o \
+                     $(OBJDIR)/server/vault_store.o \
+                     $(OBJDIR)/server/vault_crypto.o \
+                     $(OBJDIR)/server/vault_kek_cache.o \
+                     $(OBJDIR)/server/vault_server_key.o \
                      $(OBJDIR)/platform_random.o \
                      $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1767,7 +1767,7 @@ int main(void)
          platform_unsetenv("AIMEE_DB2_URL");
    }
 
-   /* AIMEE_EMBEDDING_DIM env override */
+   /* AIMEE_EMBEDDING_DIM env override (config_resolve_embedding_dim) */
    {
       char *saved = getenv("AIMEE_EMBEDDING_DIM");
       if (saved)
@@ -1777,31 +1777,27 @@ int main(void)
       memset(&cfg, 0, sizeof(cfg));
       cfg.embedding_dim = 2560;
 
-      /* valid env -> overrides, returns 1 */
-      platform_setenv("AIMEE_EMBEDDING_DIM", "1024");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 1);
-      assert(cfg.embedding_dim == 1024);
-
-      /* unset -> leaves value untouched, returns 0 */
+      /* unset -> returns the cfg value */
       platform_unsetenv("AIMEE_EMBEDDING_DIM");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
 
-      /* empty -> treated as unset, returns 0 */
+      /* valid env -> overrides */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "1024");
+      assert(config_resolve_embedding_dim(&cfg) == 1024);
+
+      /* empty -> treated as unset, falls back to cfg */
       platform_setenv("AIMEE_EMBEDDING_DIM", "");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
 
-      /* non-numeric / out-of-range -> rejected, value unchanged, returns 0 */
+      /* non-numeric / out-of-range -> rejected, falls back to cfg */
       platform_setenv("AIMEE_EMBEDDING_DIM", "abc");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
       platform_setenv("AIMEE_EMBEDDING_DIM", "999999");
-      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
-      assert(cfg.embedding_dim == 1024);
+      assert(config_resolve_embedding_dim(&cfg) == 2560);
 
-      /* NULL cfg -> no crash, returns 0 */
-      assert(config_apply_embedding_dim_env_override(NULL) == 0);
+      /* NULL cfg with no env -> 0 (no crash) */
+      platform_unsetenv("AIMEE_EMBEDDING_DIM");
+      assert(config_resolve_embedding_dim(NULL) == 0);
 
       if (saved)
       {

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1767,6 +1767,51 @@ int main(void)
          platform_unsetenv("AIMEE_DB2_URL");
    }
 
+   /* AIMEE_EMBEDDING_DIM env override */
+   {
+      char *saved = getenv("AIMEE_EMBEDDING_DIM");
+      if (saved)
+         saved = strdup(saved);
+
+      config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      cfg.embedding_dim = 2560;
+
+      /* valid env -> overrides, returns 1 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "1024");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 1);
+      assert(cfg.embedding_dim == 1024);
+
+      /* unset -> leaves value untouched, returns 0 */
+      platform_unsetenv("AIMEE_EMBEDDING_DIM");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+
+      /* empty -> treated as unset, returns 0 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+
+      /* non-numeric / out-of-range -> rejected, value unchanged, returns 0 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "abc");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+      platform_setenv("AIMEE_EMBEDDING_DIM", "999999");
+      assert(config_apply_embedding_dim_env_override(&cfg) == 0);
+      assert(cfg.embedding_dim == 1024);
+
+      /* NULL cfg -> no crash, returns 0 */
+      assert(config_apply_embedding_dim_env_override(NULL) == 0);
+
+      if (saved)
+      {
+         platform_setenv("AIMEE_EMBEDDING_DIM", saved);
+         free(saved);
+      }
+      else
+         platform_unsetenv("AIMEE_EMBEDDING_DIM");
+   }
+
    printf("all tests passed\n");
    return 0;
 }

--- a/src/tests/test_oauth_pkce.c
+++ b/src/tests/test_oauth_pkce.c
@@ -7,6 +7,7 @@
 
 #include "oauth_pkce.h"
 #include "oauth_flow.h"
+#include "db1.h" /* db1_secret_* — plant/verify legacy plaintext for the migration test */
 #include "aimee.h"
 #include "platform_test_util.h"
 
@@ -307,6 +308,40 @@ int main(void)
       /* After removal, load should fail */
       rc = oauth_token_load(client, loaded, sizeof(loaded));
       assert(rc != 0);
+   }
+
+   /* --- legacy plaintext (db1/secrets) is migrated into the vault on read --- */
+   {
+      const char *client = "test-oauth-migrate";
+      char key[256];
+      /* Plant a legacy plaintext access token + future expiry the old way. */
+      snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client);
+      assert(db1_secret_store(key, "legacy-access-token") == 0);
+      char ea[32];
+      snprintf(ea, sizeof(ea), "%ld", (long)time(NULL) + 7200);
+      snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client);
+      assert(db1_secret_store(key, ea) == 0);
+
+      /* Load migrates it to the encrypted vault and returns the value. */
+      char loaded[1024];
+      assert(oauth_token_load(client, loaded, sizeof(loaded)) == 0);
+      assert(strcmp(loaded, "legacy-access-token") == 0);
+
+      /* Both legacy plaintext keys that load touches (access + expires) are
+       * scrubbed once migrated. (The refresh token is only read during a network
+       * refresh, so it migrates lazily then — not on a plain load.) */
+      char chk[256];
+      snprintf(key, sizeof(key), OAUTH_KEY_ACCESS_TOKEN, client);
+      assert(db1_secret_load(key, chk, sizeof(chk)) != 0);
+      snprintf(key, sizeof(key), OAUTH_KEY_EXPIRES_AT, client);
+      assert(db1_secret_load(key, chk, sizeof(chk)) != 0);
+
+      /* ...and a subsequent load still works (now from the vault, no plaintext). */
+      assert(oauth_token_load(client, loaded, sizeof(loaded)) == 0);
+      assert(strcmp(loaded, "legacy-access-token") == 0);
+
+      oauth_token_remove(client);
+      assert(oauth_token_load(client, loaded, sizeof(loaded)) != 0);
    }
 
    /* --- oauth_token_get: returns -1 when no token stored --- */

--- a/src/tests/test_vault_server_key.c
+++ b/src/tests/test_vault_server_key.c
@@ -1,0 +1,112 @@
+/* test_vault_server_key.c: WP-C.4 — the server-sealed KEK that lets aimee-server
+ * decrypt dual-access credentials autonomously. Runs against a throwaway
+ * AIMEE_HOME. Pins: derive succeeds + is non-trivial; the KEK is stable across
+ * calls (cached) AND across a cache reset (re-derived from the persisted master
+ * key file, i.e. survives a "restart"); the master key file is 0600 and exactly
+ * 32 bytes. */
+#include "vault_server_key.h"
+#include "vault_crypto.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[256];
+
+static int is_all_zero(const uint8_t *p, size_t n)
+{
+   for (size_t i = 0; i < n; i++)
+      if (p[i])
+         return 0;
+   return 1;
+}
+
+static void test_derive_nontrivial(void)
+{
+   uint8_t kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(kek) == 0);
+   assert(!is_all_zero(kek, sizeof(kek))); /* a real derived key, not a zero buffer */
+   printf("  PASS: test_derive_nontrivial\n");
+}
+
+static void test_stable_cached(void)
+{
+   uint8_t a[VAULT_KEK_LEN], b[VAULT_KEK_LEN];
+   assert(vault_server_kek(a) == 0);
+   assert(vault_server_kek(b) == 0);
+   assert(memcmp(a, b, sizeof(a)) == 0); /* same KEK within a process */
+   printf("  PASS: test_stable_cached\n");
+}
+
+static void test_survives_restart(void)
+{
+   uint8_t before[VAULT_KEK_LEN], after[VAULT_KEK_LEN];
+   assert(vault_server_kek(before) == 0);
+   /* Simulate a process restart: drop the in-RAM cache, re-derive from the
+    * persisted master key file. The KEK must be identical (else every restart
+    * would orphan all server wraps). */
+   vault_server_key_reset_for_test();
+   assert(vault_server_kek(after) == 0);
+   assert(memcmp(before, after, sizeof(before)) == 0);
+   printf("  PASS: test_survives_restart\n");
+}
+
+static void test_master_key_file_locked_down(void)
+{
+   uint8_t kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(kek) == 0); /* ensure the file exists */
+   char path[512];
+   snprintf(path, sizeof(path), "%s/.vault/.server-master.key", g_home);
+   struct stat st;
+   assert(stat(path, &st) == 0);
+   assert(st.st_size == VAULT_ROOT_KEY_LEN); /* exactly 32 bytes */
+   assert((st.st_mode & 0777) == 0600);      /* owner-only */
+   printf("  PASS: test_master_key_file_locked_down\n");
+}
+
+/* F1 (roundtable): a present-but-unreadable/wrong-size master key must fail
+ * closed and NEVER be overwritten — otherwise one transient read error would
+ * orphan every existing server wrap. Run LAST: it corrupts the key file. */
+static void test_bad_master_key_not_overwritten(void)
+{
+   char path[512];
+   snprintf(path, sizeof(path), "%s/.vault/.server-master.key", g_home);
+   /* Clobber the (valid) key with a wrong-size file. */
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   const char junk[10] = "BADKEYDATA";
+   assert(fwrite(junk, 1, sizeof(junk), f) == sizeof(junk));
+   fclose(f);
+
+   vault_server_key_reset_for_test();
+   uint8_t kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(kek) == -1); /* fail closed, do not mint */
+
+   /* The bad file must be untouched (not overwritten with a fresh 32-byte key). */
+   struct stat st;
+   assert(stat(path, &st) == 0 && st.st_size == (off_t)sizeof(junk));
+   printf("  PASS: test_bad_master_key_not_overwritten\n");
+}
+
+int main(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-svrkey-test-%d", (int)getpid());
+   char mk[320];
+   snprintf(mk, sizeof(mk), "rm -rf %s && mkdir -p %s", g_home, g_home);
+   assert(system(mk) == 0);
+   setenv("AIMEE_HOME", g_home, 1);
+
+   test_derive_nontrivial();
+   test_stable_cached();
+   test_survives_restart();
+   test_master_key_file_locked_down();
+   test_bad_master_key_not_overwritten(); /* must run last: corrupts the key file */
+
+   char rm[320];
+   snprintf(rm, sizeof(rm), "rm -rf %s", g_home);
+   (void)system(rm);
+   printf("vault_server_key: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_vault_service.c
+++ b/src/tests/test_vault_service.c
@@ -248,6 +248,72 @@ static void test_rekey_empty_and_missing_vault(void)
    printf("  PASS: test_rekey_empty_and_missing_vault\n");
 }
 
+/* WP-C.4: the autonomous server path. After a "restart" (the user KEK cache is
+ * cleared, so the user vault is LOCKED), a dual-wrapped credential is STILL
+ * injectable via the server wrap — the whole point: aimee-server can drive
+ * delegates without the client re-unlocking. A genuinely missing credential is
+ * still NO_ENTRY and leaves the caller's api_key untouched. */
+static void test_server_inject_after_restart(void)
+{
+   const char *p = "uid:7000";
+   uint8_t rk[VAULT_ROOT_KEY_LEN];
+   root_key(rk, 7);
+   assert(vault_service_unlock(p, ATTEST_UDS_PEERCRED, rk, sizeof(rk), T0) == VAULT_OK);
+   assert(vault_service_set(p, "claude", "api_key", "sk-autonomous", T0) == VAULT_OK);
+
+   /* While unlocked, inject works. */
+   char key[64] = "PRESET";
+   assert(vault_service_inject_api_key(p, "claude", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-autonomous") == 0);
+
+   /* Simulate a restart: drop every cached user KEK -> the user vault is locked. */
+   vault_kek_cache_clear();
+   char out[64];
+   assert(vault_service_get(p, "claude", "api_key", out, sizeof(out), T0) == VAULT_ERR_LOCKED);
+   /* Inject still succeeds via the server wrap with NO unlock. */
+   char key2[64] = "PRESET";
+   assert(vault_service_inject_api_key(p, "claude", key2, sizeof(key2), T0) == VAULT_OK);
+   assert(strcmp(key2, "sk-autonomous") == 0);
+
+   /* A truly missing credential is NO_ENTRY; api_key left untouched (env fallback). */
+   char key3[64] = "KEEP";
+   assert(vault_service_inject_api_key(p, "absent-agent", key3, sizeof(key3), T0) ==
+          VAULT_NO_ENTRY);
+   assert(strcmp(key3, "KEEP") == 0);
+   printf("  PASS: test_server_inject_after_restart\n");
+}
+
+/* WP-C.4 server principal: a delegate credential pushed with NO per-user
+ * principal (the TCP thin-client case) lands in the server-owned vault and is
+ * resolved autonomously by inject — no unlock, survives a cache clear. */
+static void test_server_principal_vault(void)
+{
+   /* Pin the namespace: the server vault is a single shared principal. If this
+    * ever needs per-tenant isolation (multi-tenant TCP), this assert fails and
+    * forces the change to be deliberate (see vault_service.h tenancy note). */
+   assert(strcmp(VAULT_SERVER_PRINCIPAL, "server") == 0);
+
+   /* No unlock, no user principal — set_server just works. */
+   assert(vault_service_set_server("claude", VAULT_API_KEY_CRED, "sk-server-owned") == VAULT_OK);
+
+   /* inject with an EMPTY principal (the TCP case) resolves from the server vault. */
+   char key[64] = "PRESET";
+   assert(vault_service_inject_api_key("", "claude", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-server-owned") == 0);
+
+   /* A missing agent is NO_ENTRY; api_key untouched. */
+   char k2[64] = "KEEP";
+   assert(vault_service_inject_api_key("", "absent", k2, sizeof(k2), T0) == VAULT_NO_ENTRY);
+   assert(strcmp(k2, "KEEP") == 0);
+
+   /* Survives a restart: the server principal needs no KEK cache. */
+   vault_kek_cache_clear();
+   char k3[64] = "PRESET";
+   assert(vault_service_inject_api_key("", "claude", k3, sizeof(k3), T0) == VAULT_OK);
+   assert(strcmp(k3, "sk-server-owned") == 0);
+   printf("  PASS: test_server_principal_vault\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultsvc-test-%d", (int)getpid());
@@ -266,6 +332,8 @@ int main(void)
    test_webuser_password_unlock();
    test_webuser_rekey();
    test_rekey_empty_and_missing_vault();
+   test_server_inject_after_restart();
+   test_server_principal_vault();
 
    vault_kek_cache_clear();
    char rm[320];

--- a/src/tests/test_vault_store.c
+++ b/src/tests/test_vault_store.c
@@ -324,6 +324,92 @@ static void test_intra_principal_aad_swap(void)
    printf("  PASS: test_intra_principal_aad_swap\n");
 }
 
+/* WP-C.4 dual-access: a credential written with set_dual carries a second DEK
+ * wrap under the server KEK; the server can decrypt it with NO user KEK, while
+ * the user path is unchanged. A wrong server KEK fails closed. */
+static void test_dual_wrap_server_get(void)
+{
+   const char *p = "uid:4242";
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt(p, salt) == 0);
+   uint8_t kek[VAULT_KEK_LEN], skek[VAULT_KEK_LEN];
+   make_kek(kek, 42);
+   make_kek(skek, 200); /* distinct server KEK */
+   const char *secret = "sk-dual-access-secret";
+   assert(vault_store_set_dual(p, kek, skek, "claude", "api_key", secret) == 0);
+
+   char out[256];
+   /* user path still works */
+   assert(vault_store_get(p, kek, "claude", "api_key", out, sizeof(out)) == 0);
+   assert(strcmp(out, secret) == 0);
+   /* server path works WITHOUT the user KEK */
+   assert(vault_store_get_server(p, skek, "claude", "api_key", out, sizeof(out)) == 0);
+   assert(strcmp(out, secret) == 0);
+   /* wrong server KEK fails closed (not the secret, not NO_ENTRY) */
+   uint8_t bad[VAULT_KEK_LEN];
+   make_kek(bad, 201);
+   assert(vault_store_get_server(p, bad, "claude", "api_key", out, sizeof(out)) == -1);
+   printf("  PASS: test_dual_wrap_server_get\n");
+}
+
+/* A legacy (user-only) entry has no server wrap: the server get reports NO_ENTRY
+ * (fall back), and backfill adds the wrap so it becomes server-decryptable. A
+ * backfill under the wrong user KEK fails closed and writes nothing. */
+static void test_server_get_legacy_then_backfill(void)
+{
+   const char *p = "uid:4343";
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt(p, salt) == 0);
+   uint8_t kek[VAULT_KEK_LEN], skek[VAULT_KEK_LEN];
+   make_kek(kek, 43);
+   make_kek(skek, 210);
+   const char *secret = "legacy-user-only";
+   assert(vault_store_set(p, kek, "openai", "api_key", secret) == 0); /* user-only */
+
+   char out[256];
+   assert(vault_store_get_server(p, skek, "openai", "api_key", out, sizeof(out)) ==
+          VAULT_STORE_NO_ENTRY);
+   assert(vault_store_add_server_wraps(p, kek, skek) == 0);
+   assert(vault_store_get_server(p, skek, "openai", "api_key", out, sizeof(out)) == 0);
+   assert(strcmp(out, secret) == 0);
+
+   /* Wrong user KEK -> backfill fails closed; the entry stays user-only. */
+   const char *p2 = "uid:4344";
+   assert(vault_store_get_or_create_salt(p2, salt) == 0);
+   assert(vault_store_set(p2, kek, "gemini", "api_key", "x") == 0);
+   uint8_t badkek[VAULT_KEK_LEN];
+   make_kek(badkek, 99);
+   assert(vault_store_add_server_wraps(p2, badkek, skek) == -1);
+   assert(vault_store_get_server(p2, skek, "gemini", "api_key", out, sizeof(out)) ==
+          VAULT_STORE_NO_ENTRY);
+   printf("  PASS: test_server_get_legacy_then_backfill\n");
+}
+
+/* The dual-wrapped file stores the server wrap but never the plaintext. */
+static void test_dual_wrap_at_rest_ciphertext_only(void)
+{
+   const char *p = "uid:4545";
+   uint8_t salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt(p, salt) == 0);
+   uint8_t kek[VAULT_KEK_LEN], skek[VAULT_KEK_LEN];
+   make_kek(kek, 45);
+   make_kek(skek, 220);
+   const char *secret = "DUAL-PLAINTEXT-NOT-ON-DISK";
+   assert(vault_store_set_dual(p, kek, skek, "claude", "api_key", secret) == 0);
+
+   char path[640];
+   assert(find_vault_file(p, path, sizeof(path)));
+   FILE *f = fopen(path, "rb");
+   assert(f);
+   char buf[16384];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   fclose(f);
+   buf[n] = '\0';
+   assert(strstr(buf, "wrapped_dek_server") != NULL);
+   assert(strstr(buf, secret) == NULL);
+   printf("  PASS: test_dual_wrap_at_rest_ciphertext_only\n");
+}
+
 int main(void)
 {
    snprintf(g_home, sizeof(g_home), "/tmp/aimee-vault-test-%d", (int)getpid());
@@ -341,6 +427,9 @@ int main(void)
    test_salt_is_stable();
    test_attacker_principal_filename_safety();
    test_intra_principal_aad_swap();
+   test_dual_wrap_server_get();
+   test_server_get_legacy_then_backfill();
+   test_dual_wrap_at_rest_ciphertext_only();
 
    char rm[320];
    snprintf(rm, sizeof(rm), "rm -rf %s", g_home);


### PR DESCRIPTION
Promote testing → main.

Ships:
- **Default embedder → pplx-embed-v1-4b (2560-dim)**; `pplx-embed-v1-0.6b` (1024-dim) published as the `aimee-embedder-0.6b` image. Switch with `AIMEE_EMBEDDER_IMAGE` + `embedding_dim:1024` (or the new `AIMEE_EMBEDDING_DIM` env). (#247)
- Docker smoke tests build the 0.6b tier so CI fits runners; the shipped default is the 4b.
- Roundtable-review doc fixes: sub-agent block + embedder switch in QUICKSTART, DELEGATES quick-start reword, pgvector ≥0.7 note. (#248)

Fires the auto-release → v0.2.61 ghcr images (incl. the new 4b `aimee-embedder` and the `aimee-embedder-0.6b` variant).
