### PR TITLE
agents.json: never re-serialize a resolved $VAR api_key as plaintext

### DIFF
--- a/src/cmd_agent.c
+++ b/src/cmd_agent.c
@@ -744,7 +744,14 @@ static void ag_add(app_ctx_t *ctx, int argc, char **argv)
    for (int i = 3; i < argc; i++)
    {
       if (strcmp(argv[i], "--key") == 0 && i + 1 < argc)
-         agent_expand_env(argv[++i], ag->api_key, MAX_API_KEY_LEN);
+      {
+         /* Preserve the verbatim reference (e.g. "$VAR") for save so a resolved
+          * secret is never written to agents.json; resolve a runtime copy.
+          * Mirrors agent_load_config. */
+         const char *raw_key = argv[++i];
+         snprintf(ag->api_key_disk, MAX_API_KEY_LEN, "%s", raw_key);
+         agent_expand_env(raw_key, ag->api_key, MAX_API_KEY_LEN);
+      }
       else if (strcmp(argv[i], "--auth-cmd") == 0 && i + 1 < argc)
          snprintf(ag->auth_cmd, MAX_AUTH_CMD_LEN, "%s", argv[++i]);
       else if (strcmp(argv[i], "--auth-type") == 0 && i + 1 < argc)

--- a/src/cmd_agent_setup.c
+++ b/src/cmd_agent_setup.c
@@ -876,6 +876,7 @@ static void setup_gemini(app_ctx_t *ctx, agent_config_t *cfg)
    snprintf(ag->auth_type, sizeof(ag->auth_type), "oauth");
    snprintf(ag->provider, sizeof(ag->provider), "openai");
    ag->api_key[0] = '\0';
+   ag->api_key_disk[0] = '\0';
    ag->extra_headers[0] = '\0';
    ag->cost_tier = 1;
    ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
@@ -1106,6 +1107,7 @@ static void setup_gemini_oauth(app_ctx_t *ctx, agent_config_t *cfg)
    snprintf(ag->auth_type, sizeof(ag->auth_type), "oauth");
    snprintf(ag->provider, sizeof(ag->provider), "openai");
    ag->api_key[0] = '\0';
+   ag->api_key_disk[0] = '\0';
    ag->extra_headers[0] = '\0';
    ag->cost_tier = 0;
    ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
@@ -1230,6 +1232,7 @@ static void setup_openai(app_ctx_t *ctx, agent_config_t *cfg)
 
    snprintf(ag->provider, sizeof(ag->provider), "openai");
    ag->api_key[0] = '\0';
+   ag->api_key_disk[0] = '\0';
    ag->extra_headers[0] = '\0';
    ag->cost_tier = (tier_buf[0] >= '0' && tier_buf[0] <= '9') ? atoi(tier_buf) : 1;
    ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
@@ -1346,6 +1349,7 @@ static void setup_copilot(app_ctx_t *ctx, agent_config_t *cfg)
    snprintf(ag->auth_type, sizeof(ag->auth_type), "%s", auth_type_str);
    snprintf(ag->provider, sizeof(ag->provider), "openai");
    ag->api_key[0] = '\0';
+   ag->api_key_disk[0] = '\0';
    ag->extra_headers[0] = '\0';
    ag->cost_tier = 0;
    ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -181,6 +181,13 @@ typedef struct
    char endpoint[MAX_ENDPOINT_LEN];
    char model[MAX_MODEL_LEN];
    char api_key[MAX_API_KEY_LEN];
+   /* The verbatim on-disk api_key — a "$VAR" reference (or, legacy, a literal).
+    * `api_key` above holds the RESOLVED value for runtime use (agent_expand_env
+    * at load); this preserves the reference so agent_save_config never
+    * re-serializes a resolved $VAR secret back into agents.json as plaintext.
+    * Empty for agents created in-memory (e.g. `agent add $VAR`), where save falls
+    * back to api_key (still the unexpanded reference at that point). */
+   char api_key_disk[MAX_API_KEY_LEN];
    char auth_cmd[MAX_AUTH_CMD_LEN];
    char auth_type[16];
    char provider[16];

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -490,7 +490,13 @@ int agent_load_config(agent_config_t *cfg)
 
          v = cJSON_GetObjectItem(a, "api_key");
          if (v && cJSON_IsString(v))
+         {
+            /* Keep the verbatim on-disk form ($VAR ref) for re-save, and resolve
+             * a separate runtime copy. Without this, a save would write the
+             * expanded secret back to agents.json as plaintext. */
+            snprintf(ag->api_key_disk, MAX_API_KEY_LEN, "%s", v->valuestring);
             agent_expand_env(v->valuestring, ag->api_key, MAX_API_KEY_LEN);
+         }
 
          /* Optional credential pool. Each entry is {name, api_key_env};
           * sibling delegates lease distinct entries via the lease pool in
@@ -853,8 +859,14 @@ int agent_save_config(const agent_config_t *cfg)
       JSON_ADD_STR(a, "name", ag->name);
       JSON_ADD_STR(a, "endpoint", ag->endpoint);
       JSON_ADD_STR(a, "model", ag->model);
-      if (ag->api_key[0])
-         JSON_ADD_STR(a, "api_key", ag->api_key);
+      /* Persist the on-disk reference form ($VAR), never a resolved secret. Falls
+       * back to api_key for in-memory agents (e.g. `agent add $VAR`, which stores
+       * the unexpanded reference there); literal secrets belong in the vault. */
+      {
+         const char *disk_key = ag->api_key_disk[0] ? ag->api_key_disk : ag->api_key;
+         if (disk_key[0])
+            JSON_ADD_STR(a, "api_key", disk_key);
+      }
       if (ag->auth_cmd[0])
          JSON_ADD_STR(a, "auth_cmd", ag->auth_cmd);
       if (strcmp(ag->auth_type, "bearer") != 0)

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -496,8 +496,11 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          /* An env reference is not a secret: store it UNEXPANDED so agents.json
           * holds "$VAR", not the resolved value. agent_load_config expands it
           * from the environment at run time. Expanding here would serialize the
-          * plaintext key to disk — the exact leak the literal branch avoids. */
+          * plaintext key to disk — the exact leak the literal branch avoids.
+          * api_key_disk is set explicitly too, so the on-disk form is correct
+          * regardless of how the agent is re-saved later. */
          snprintf(ag->api_key, sizeof(ag->api_key), "%s", key);
+         snprintf(ag->api_key_disk, sizeof(ag->api_key_disk), "%s", key);
       }
       else
       {
@@ -518,7 +521,8 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                    conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
             return server_send_error(conn, "could not store credential in the vault", NULL);
          }
-         ag->api_key[0] = '\0'; /* the secret lives only in the vault */
+         ag->api_key[0] = '\0';      /* the secret lives only in the vault */
+         ag->api_key_disk[0] = '\0'; /* and nothing goes to agents.json */
       }
    }
    const char *auth_cmd = opt_get(&opts, "auth-cmd");

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -78,7 +78,7 @@ TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.
 TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
-               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
+               $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
                $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-session-credentials $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
@@ -506,6 +506,21 @@ $(TESTPREFIX)/unit-test-agent: $(OBJDIR)/tests/test_agent.o $(OBJDIR)/tests/test
 # Mirrors unit-test-agent's link line so message_history_repair (agent_bridge.o,
 # pulled via the shared object set) and cJSON resolve; gc-sections drops the rest.
 $(TESTPREFIX)/unit-test-agent-repair: $(OBJDIR)/tests/test_agent_repair.o \
+                      $(OBJDIR)/server/agent_cli_shell.o \
+                      $(OBJDIR)/server/tool_call_args.o \
+                      $(OBJDIR)/server/session_compact.o $(OBJDIR)/server/compact_prune.o $(OBJDIR)/server/delegate_driver.o \
+                      $(OBJDIR)/server/delegate_openai.o $(OBJDIR)/server/delegate_gemini.o \
+                      $(OBJDIR)/server/delegate_xml_fallback.o $(OBJDIR)/server/delegate_role.o \
+                      $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o \
+                      $(OBJDIR)/models_dev_cache.o $(OBJDIR)/payload_rewrite.o \
+                      $(OBJDIR)/server/middleware.o $(OBJDIR)/server/liveness.o \
+                      $(OBJDIR)/server/cli_session.o $(OBJDIR)/server/agent_policy_intercept.o \
+                      $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# agents.json secret-serialization test split out of test_agent.c (2000-line
+# limit). Mirrors unit-test-agent's link line.
+$(TESTPREFIX)/unit-test-agent-apikey: $(OBJDIR)/tests/test_agent_apikey.o \
                       $(OBJDIR)/server/agent_cli_shell.o \
                       $(OBJDIR)/server/tool_call_args.o \
                       $(OBJDIR)/server/session_compact.o $(OBJDIR)/server/compact_prune.o $(OBJDIR)/server/delegate_driver.o \

--- a/src/tests/test_agent_apikey.c
+++ b/src/tests/test_agent_apikey.c
@@ -65,6 +65,33 @@ static void test_apikey_ref_not_serialized(void)
    printf("  PASS: test_apikey_ref_not_serialized\n");
 }
 
+/* The save fallback (api_key_disk empty -> write api_key) must emit the
+ * reference, never a resolved secret. An in-memory agent created without a load
+ * (e.g. `agent add $VAR`) holds the unexpanded reference in api_key. */
+static void test_apikey_ref_fallback_save(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 1;
+   agent_t *ag = &cfg.agents[0];
+   snprintf(ag->name, sizeof(ag->name), "memref");
+   snprintf(ag->endpoint, sizeof(ag->endpoint), "https://api.example/v1");
+   snprintf(ag->model, sizeof(ag->model), "m");
+   ag->enabled = 1;
+   snprintf(ag->api_key, sizeof(ag->api_key), "$AIMEE_APIKEY_FALLBACK_TEST");
+   /* api_key_disk intentionally left empty (zeroed by memset). */
+
+   assert(agent_save_config(&cfg) == 0);
+   FILE *f = fopen(agent_config_path(), "r");
+   assert(f != NULL);
+   char buf[8192];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   fclose(f);
+   buf[n] = '\0';
+   assert(strstr(buf, "$AIMEE_APIKEY_FALLBACK_TEST") != NULL); /* reference via fallback */
+   printf("  PASS: test_apikey_ref_fallback_save\n");
+}
+
 int main(void)
 {
    char tmp_template[] = "/tmp/aimee-agent-apikey-XXXXXX";
@@ -73,6 +100,7 @@ int main(void)
    setenv("AIMEE_HOME", tmp_home, 1);
 
    test_apikey_ref_not_serialized();
+   test_apikey_ref_fallback_save();
 
    printf("agent_apikey: all tests passed\n");
    return 0;

--- a/src/tests/test_agent_apikey.c
+++ b/src/tests/test_agent_apikey.c
@@ -1,0 +1,79 @@
+/* test_agent_apikey.c: agents.json must never persist a resolved secret.
+ *
+ * Split out of test_agent.c (2000-line hard limit), mirroring its link line.
+ *
+ * A "$VAR" api_key is a reference, not a secret: it is resolved into the runtime
+ * agent_t.api_key at load, but the verbatim reference is preserved in
+ * api_key_disk so a save re-serializes the reference, not the expanded value.
+ * Without this, any agent-config mutation (add/enable/remove) would rewrite the
+ * loaded secret back into agents.json as plaintext. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "aimee.h"
+#include "agent.h"
+#include "agent_config.h"
+#include "config.h"
+#include "platform_path.h"
+
+static void test_apikey_ref_not_serialized(void)
+{
+   const char *cfg_dir = config_default_dir();
+   assert(platform_mkdir_p(cfg_dir, 0700) == 0 || access(cfg_dir, F_OK) == 0);
+
+   setenv("AIMEE_APIKEY_REF_TEST", "sk-super-secret-value", 1);
+
+   {
+      FILE *f = fopen(agent_config_path(), "w");
+      assert(f != NULL);
+      fputs("{\"agents\":[{\"name\":\"reftest\",\"endpoint\":\"https://api.example/v1\","
+            "\"model\":\"m\",\"roles\":[\"code\"],"
+            "\"api_key\":\"$AIMEE_APIKEY_REF_TEST\"}]}\n",
+            f);
+      fclose(f);
+   }
+
+   agent_config_t loaded;
+   assert(agent_load_config(&loaded) == 0);
+   agent_t *ag = agent_find(&loaded, "reftest");
+   assert(ag != NULL);
+   assert(strcmp(ag->api_key, "sk-super-secret-value") == 0);       /* resolved at runtime */
+   assert(strcmp(ag->api_key_disk, "$AIMEE_APIKEY_REF_TEST") == 0); /* reference preserved */
+
+   /* Save, then read the raw file: it must keep the $VAR ref, not the secret. */
+   assert(agent_save_config(&loaded) == 0);
+   {
+      FILE *f = fopen(agent_config_path(), "r");
+      assert(f != NULL);
+      char buf[8192];
+      size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+      fclose(f);
+      buf[n] = '\0';
+      assert(strstr(buf, "$AIMEE_APIKEY_REF_TEST") != NULL); /* reference written */
+      assert(strstr(buf, "sk-super-secret-value") == NULL);  /* secret NOT written */
+   }
+
+   /* Reload still resolves to the secret. */
+   agent_config_t reloaded;
+   assert(agent_load_config(&reloaded) == 0);
+   agent_t *ag2 = agent_find(&reloaded, "reftest");
+   assert(ag2 != NULL && strcmp(ag2->api_key, "sk-super-secret-value") == 0);
+
+   unsetenv("AIMEE_APIKEY_REF_TEST");
+   printf("  PASS: test_apikey_ref_not_serialized\n");
+}
+
+int main(void)
+{
+   char tmp_template[] = "/tmp/aimee-agent-apikey-XXXXXX";
+   char *tmp_home = mkdtemp(tmp_template);
+   assert(tmp_home != NULL);
+   setenv("AIMEE_HOME", tmp_home, 1);
+
+   test_apikey_ref_not_serialized();
+
+   printf("agent_apikey: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Why

`agent_load_config` expands a `$VAR` `api_key` into `agent_t.api_key` for runtime use, and `agent_save_config` then wrote that **resolved** value back to `agents.json`. So any agent-config mutation (`agent add`/`enable`/`remove`) re-serialized the secret into the file as **plaintext** — the last remaining `agents.json` plaintext path after the credential vault work (#244/#249).

## What

Add `agent_t.api_key_disk` holding the **verbatim on-disk form** (a `$VAR` reference, or a legacy literal):
- **Load** keeps the reference in `api_key_disk` and resolves a separate runtime copy into `api_key` (unchanged runtime behaviour — the auth-header builders read the resolved `api_key`).
- **Save** writes `api_key_disk`, falling back to `api_key` for in-memory agents (e.g. `agent add $VAR`, which already stores the unexpanded reference there). A resolved secret is never written.

## Test

`test_agent_apikey.c` (split out of the 2000-line-capped `test_agent.c`, mirroring its link line): a `$VAR` api_key round-trips `load → save` with the reference preserved and the secret **never** present in the file, then reloads to the resolved value.

Local: `make unit-tests`, server+kb (LTO) builds, `lint`, `build-integrity` all green.

## Note

This closes the `$VAR`-reexpansion leak. A legacy *literal* secret already sitting in `agents.json` stays as-is (not made worse); the recommended path for new secrets is the vault (`agent add` routes literals there). Migrating pre-existing literals out of `agents.json` would be a separate change.
