### PR TITLE
Finish roundtable authoring pipeline: close review findings + mark proposal done

### DIFF
--- a/docs/proposals/done/agent-roundtable-authoring-pipeline.md
+++ b/docs/proposals/done/agent-roundtable-authoring-pipeline.md
@@ -1,6 +1,12 @@
 # Proposal: Agent roundtable authoring pipeline (idea → reviewed proposal → implementation → reviewed PR)
 
-- **State:** accepted — implementing (branch `feat/roundtable-authoring-pipeline`)
+- **State:** done — implemented and merged to `testing` across 17 commits
+  (P0–P4 + 11 implementation-review rounds + chunked-review + first-class MCP;
+  PR #193). Full unit suite green (`-Werror`, build-integrity clean); 6 pipeline
+  test files / 37 test fns cover the §10 matrix. A post-merge completeness
+  roundtable then closed four findings (§55 gate exactly-once CAS,
+  mergeable=UNKNOWN merge policy, fail-reason brief fidelity, per-phase cost
+  whitelist). Original branch `feat/roundtable-authoring-pipeline`.
 - **Author:** JBailes
 - **Date:** 2026-06-11 (consolidated — 23 PR-#183 review rounds / 57 findings folded into the design sections and indexed in Appendix A)
 - **Charter roles:** Orchestrate (pipeline state machine), Draft/Review

--- a/scripts/check-v1-method-coverage.py
+++ b/scripts/check-v1-method-coverage.py
@@ -54,7 +54,7 @@ DEDICATED = {
 # (tool.execute) became first-class routes (POST /v1/hooks/*, /v1/tools/execute)
 # so /v1/rpc could be retired; CAP_TOOL_EXECUTE keeps them local/full-tier only.
 # pipeline.* — the roundtable authoring pipeline control surface is CLI/MCP-only
-# in v1 (docs/proposals/accepted/agent-roundtable-authoring-pipeline.md §5/§12,
+# in v1 (docs/proposals/done/agent-roundtable-authoring-pipeline.md §5/§12,
 # decision #45). HTTP is deliberately deferred: it must NOT collide with the
 # existing KB/corpus `GET /v1/pipeline/status`, so if exposed later it uses a
 # distinct `/v1/roundtable/pipelines/...` namespace. Gate resolution is also

--- a/src/db1/roundtable_pipeline.c
+++ b/src/db1/roundtable_pipeline.c
@@ -199,6 +199,30 @@ int rtp_run_set_state(int id, const char *state, const char *phase)
    return changed > 0 ? 0 : -1;
 }
 
+int rtp_run_cas_state(int id, const char *expected, const char *next)
+{
+   if (id <= 0 || !expected || !next)
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return -1;
+   sqlite3_stmt *stmt = NULL;
+   /* The WHERE ... AND state=? makes the transition atomic: SQLite serializes the
+    * UPDATE, so of two concurrent callers exactly one matches `expected` and
+    * changes a row; the loser changes zero rows and gets -1. */
+   static const char *sql = "UPDATE roundtable_pipeline_runs SET state=?,"
+                            " updated_at=datetime('now') WHERE id=? AND state=?";
+   if (sqlite3_prepare_v2(db, sql, -1, &stmt, NULL) != SQLITE_OK)
+      return -1;
+   sqlite3_bind_text(stmt, 1, next, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_int(stmt, 2, id);
+   sqlite3_bind_text(stmt, 3, expected, -1, SQLITE_TRANSIENT);
+   int rc = sqlite3_step(stmt);
+   int changed = (rc == SQLITE_DONE) ? sqlite3_changes(db) : 0;
+   sqlite3_finalize(stmt);
+   return changed > 0 ? 0 : -1;
+}
+
 int rtp_run_list(const char *state_filter, rtp_run_t *out, int max)
 {
    if (!out || max <= 0)

--- a/src/db1/roundtable_pipeline.h
+++ b/src/db1/roundtable_pipeline.h
@@ -217,7 +217,9 @@ extern "C"
     * only if the row's current state still equals `expected`. Returns 0 when
     * exactly one row changed (the caller won the transition), -1 otherwise (no
     * match — already resolved/resolving). Makes gate resolution exactly-once
-    * (#55) so two concurrent `gate pass` calls cannot both merge. */
+    * (#55) so two concurrent `gate pass` calls cannot both merge. `expected` and
+    * `next` must differ: a no-op SET changes zero rows and would report a false
+    * "already resolved" (-1). */
    int rtp_run_cas_state(int id, const char *expected, const char *next);
    /* List by state filter (NULL = all non-terminal). Returns count or -1. */
    int rtp_run_list(const char *state_filter, rtp_run_t *out, int max);

--- a/src/db1/roundtable_pipeline.h
+++ b/src/db1/roundtable_pipeline.h
@@ -213,6 +213,12 @@ extern "C"
    /* Full update of all mutable columns from the struct, keyed by out->id. */
    int rtp_run_update(const rtp_run_t *run);
    int rtp_run_set_state(int id, const char *state, const char *phase);
+   /* Atomic compare-and-swap of the run state: move id from `expected` to `next`
+    * only if the row's current state still equals `expected`. Returns 0 when
+    * exactly one row changed (the caller won the transition), -1 otherwise (no
+    * match — already resolved/resolving). Makes gate resolution exactly-once
+    * (#55) so two concurrent `gate pass` calls cannot both merge. */
+   int rtp_run_cas_state(int id, const char *expected, const char *next);
    /* List by state filter (NULL = all non-terminal). Returns count or -1. */
    int rtp_run_list(const char *state_filter, rtp_run_t *out, int max);
    /* Count runs whose admission_class == 'active' (section 1 admission control). */

--- a/src/server/roundtable_pipeline_capture.c
+++ b/src/server/roundtable_pipeline_capture.c
@@ -214,9 +214,13 @@ int rtp_seam_finalize(const char *run_id, int http_ok, int cancelled, const char
       rtp_run_t run2;
       if (rtp_run_get(pass.pipeline_id, &run2) == 0)
       {
+         /* Attribute to a phase by an explicit whitelist, not a catch-all else,
+          * so a future phase cannot silently misbill to the proposal bucket
+          * (#7). v1 has exactly two phases; an unknown phase still counts toward
+          * the whole-pipeline total but is not misattributed to a per-phase cap. */
          if (strcmp(pass.phase, RTP_PHASE_IMPL) == 0)
             run2.impl_phase_cost_usd += env.cost_usd;
-         else
+         else if (strcmp(pass.phase, RTP_PHASE_PROPOSAL) == 0)
             run2.proposal_phase_cost_usd += env.cost_usd;
          run2.total_cost_usd += env.cost_usd;
          rtp_run_update(&run2);

--- a/src/server/server_pipeline.c
+++ b/src/server/server_pipeline.c
@@ -1824,16 +1824,28 @@ int handle_pipeline_gate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    if (strcmp(verdict, "fail") == 0)
    {
+      /* Exactly-once (#55): atomically claim the transition out of the matching
+       * *_pending state. A concurrent/duplicate `gate` that already moved the
+       * run loses the CAS and is told so rather than re-resolving. */
+      if (rtp_run_cas_state(id, run.state, review_back) != 0)
+         return server_send_error(conn, "pipeline: gate already resolved or resolving", NULL);
+      snprintf(run.state, sizeof(run.state), "%s", review_back); /* keep struct consistent */
       rtp_gate_update(&gate);
-      /* fail reason -> brief, return to the review phase (#43 same PR). */
+      /* fail reason -> brief, return to the review phase (#43 same PR). Reserve the
+       * buffer tail so a near-full brief never silently truncates the human's
+       * reason — the fail-return contract requires the reason reach the panel. */
       if (reason && reason[0])
       {
+         char suffix[RTP_BRIEF_LEN];
+         int sn = snprintf(suffix, sizeof(suffix), "\nhuman-gate-%d fail: %s", gate_no, reason);
+         int room = (int)sizeof(run.brief) - (sn < 0 ? 0 : sn) - 1;
+         if (room < 0)
+            room = 0;
          char nb[RTP_BRIEF_LEN];
-         snprintf(nb, sizeof(nb), "%s\nhuman-gate-%d fail: %s", run.brief, gate_no, reason);
+         snprintf(nb, sizeof(nb), "%.*s%s", room, run.brief, suffix);
          snprintf(run.brief, sizeof(run.brief), "%s", nb);
       }
-      rtp_run_update(&run);
-      rtp_run_set_state(id, review_back, NULL);
+      rtp_run_update(&run); /* persists brief + the CAS'd state */
       cJSON *resp = jo_ok();
       cJSON_AddStringToObject(resp, "verdict", "fail");
       cJSON_AddStringToObject(resp, "state", review_back);
@@ -1843,11 +1855,15 @@ int handle_pipeline_gate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    }
 
    /* pass: atomically write the merge intent + move to *_merge_pending (#56),
-    * then run the policy-aware merge and advance on success. */
+    * then run the policy-aware merge and advance on success. The CAS is the
+    * exactly-once guard (#55): only the caller that moves the run out of
+    * *_pending runs the merge; a racing duplicate gets "already resolving". */
    const char *merge_state =
        gate_no == 2 ? RTP_STATE_GATE2_MERGE_PENDING : RTP_STATE_GATE1_MERGE_PENDING;
+   if (rtp_run_cas_state(id, run.state, merge_state) != 0)
+      return server_send_error(conn, "pipeline: gate already resolved or resolving", NULL);
+   snprintf(run.state, sizeof(run.state), "%s", merge_state); /* keep struct consistent */
    rtp_gate_update(&gate);
-   rtp_run_set_state(id, merge_state, NULL);
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "verdict", "pass");

--- a/src/server/server_pipeline_merge.inc
+++ b/src/server/server_pipeline_merge.inc
@@ -46,6 +46,12 @@ static int validate_pr_for_merge(rtp_run_t *run, rtp_gate_t *gate, int gate_no, 
    }
    else if (mergeable[0] && strcmp(mergeable, "CONFLICTING") == 0)
       why = "PR is not mergeable (conflicting)";
+   else if (mergeable[0] && strcmp(mergeable, "MERGEABLE") != 0)
+      /* Anything that is neither MERGEABLE nor CONFLICTING (notably UNKNOWN,
+       * which GitHub returns while it is still computing mergeability) is not
+       * "assume green" (§5): park in *_merge_pending and re-check, rather than
+       * attempting a merge against an unknown state. */
+      why = "PR mergeability not yet known (UNKNOWN); verdict preserved, re-check shortly";
    cJSON_Delete(j);
    if (why)
    {

--- a/src/tests/test_db1_roundtable_pipeline.c
+++ b/src/tests/test_db1_roundtable_pipeline.c
@@ -347,6 +347,19 @@ static void test_cas_exactly_once(void)
 
    /* CAS against a non-existent id also fails cleanly. */
    assert(rtp_run_cas_state(999999, RTP_STATE_GATE1_PENDING, RTP_STATE_DONE) == -1);
+
+   /* Fail-path transition (gate -> review_back) is the same primitive: from a
+    * fresh gate-pending run, the first claim to proposal_review wins and a stale
+    * duplicate loses, so a duplicate `gate fail` cannot re-enter the review loop
+    * twice either. */
+   int id2 = 0;
+   assert(rtp_run_create("cas fail path", RTP_DONEBAR_ZERO_BLOCKING, "/repo", "testing", &id2) ==
+          0);
+   assert(rtp_run_set_state(id2, RTP_STATE_GATE1_PENDING, NULL) == 0);
+   assert(rtp_run_cas_state(id2, RTP_STATE_GATE1_PENDING, RTP_STATE_PROPOSAL_REVIEW) == 0);
+   assert(rtp_run_cas_state(id2, RTP_STATE_GATE1_PENDING, RTP_STATE_PROPOSAL_REVIEW) == -1);
+   assert(rtp_run_get(id2, &r) == 0);
+   assert(strcmp(r.state, RTP_STATE_PROPOSAL_REVIEW) == 0);
    printf("  cas exactly-once: ok\n");
 }
 

--- a/src/tests/test_db1_roundtable_pipeline.c
+++ b/src/tests/test_db1_roundtable_pipeline.c
@@ -323,10 +323,38 @@ static void test_chunk_group(void)
    printf("  chunk group aggregate: ok\n");
 }
 
+/* #55 exactly-once: rtp_run_cas_state moves the run only when the current state
+ * still matches `expected`; a second/stale attempt from the same `expected`
+ * loses. This is the primitive that makes a duplicate `gate pass` unable to
+ * merge twice. */
+static void test_cas_exactly_once(void)
+{
+   int id = 0;
+   assert(rtp_run_create("cas test", RTP_DONEBAR_ZERO_BLOCKING, "/repo", "testing", &id) == 0);
+   assert(rtp_run_set_state(id, RTP_STATE_GATE1_PENDING, NULL) == 0);
+
+   /* First claim from GATE1_PENDING -> GATE1_MERGE_PENDING wins. */
+   assert(rtp_run_cas_state(id, RTP_STATE_GATE1_PENDING, RTP_STATE_GATE1_MERGE_PENDING) == 0);
+   rtp_run_t r;
+   assert(rtp_run_get(id, &r) == 0);
+   assert(strcmp(r.state, RTP_STATE_GATE1_MERGE_PENDING) == 0);
+
+   /* A concurrent/duplicate caller still expecting GATE1_PENDING loses (no row
+    * changed) and must NOT re-trigger the merge. */
+   assert(rtp_run_cas_state(id, RTP_STATE_GATE1_PENDING, RTP_STATE_GATE1_MERGE_PENDING) == -1);
+   assert(rtp_run_get(id, &r) == 0);
+   assert(strcmp(r.state, RTP_STATE_GATE1_MERGE_PENDING) == 0); /* unchanged */
+
+   /* CAS against a non-existent id also fails cleanly. */
+   assert(rtp_run_cas_state(999999, RTP_STATE_GATE1_PENDING, RTP_STATE_DONE) == -1);
+   printf("  cas exactly-once: ok\n");
+}
+
 int main(void)
 {
    setup_db();
    test_run_lifecycle();
+   test_cas_exactly_once();
    test_admission();
    test_pass_and_attempts();
    test_gates();


### PR DESCRIPTION
## Summary

Completes and finalizes the **Agent roundtable authoring pipeline** proposal. The implementation already landed on `testing` (PR #193, 17 commits: P0–P4 + 11 review rounds + chunked-review + first-class MCP); this PR closes the remaining gaps a post-merge completeness review surfaced and moves the proposal `accepted/ → done/`.

## What this PR does

**Closes review findings (code):**
- **§55 gate exactly-once** — the `*_pending → *_merge_pending` transition read/checked/wrote state without atomicity, so two concurrent `gate pass` calls could both reach the merge executor (the second `gh pr merge` is blocked by `--match-head-commit`, but the app ran the path twice). Adds `rtp_run_cas_state` (atomic `UPDATE … WHERE id=? AND state=?`) and gates **both** the pass and fail transitions on it; a racing/duplicate caller now gets "already resolving" and never re-merges.
- **§5 merge policy** — `validate_pr_for_merge` treated `mergeable=UNKNOWN` (GitHub still computing) as mergeable; now any non-`MERGEABLE`/non-`CONFLICTING` state parks in `*_merge_pending` with a re-check note instead of assuming green.
- **fail-return fidelity** — the gate fail-reason append could silently truncate a near-full brief; the buffer tail is reserved so the human's reason always reaches the re-review panel.
- **cost attribution** — per-phase cost is attributed by an explicit `IMPL`/`PROPOSAL` whitelist instead of a catch-all `else`.

**Tests:** new `test_cas_exactly_once` covers the pass- and fail-path CAS (win-once / lose-stale / lose-missing).

**Docs:** proposal moved to `done/` with a State summary; one stale `accepted/` path reference fixed.

## Verification

Full unit suite green (`-Werror`), `build-integrity` clean, `clang-format-19` clean, `check-proposal-links` ok. The completion was itself roundtable-reviewed: the initial review returned INCOMPLETE (findings above); a confirmation round marked both real findings **CLOSED**, the dismissed findings **soundly triaged**, and no new blocking issues. Rebased onto current `testing`.
