### PR TITLE
kb: self-heal doc embeddings (backfill chunks missing kb_embeddings)

### DIFF
--- a/src/headers/kb.h
+++ b/src/headers/kb.h
@@ -93,6 +93,10 @@ int kb_ingest_doc_content(const char *project, const char *source_path, const ch
  * Bounded by `max_docs`. Returns chunks embedded. Replaces the old `kb build`
  * command — doc ingestion now happens automatically during workspace ingest. */
 int kb_doc_refresh(const char *project, const char *embedding_cmd, int max_docs);
+/* Embed kb_documents chunks that have no kb_embeddings row yet (self-healing
+ * backfill for partial ingests, late-configured embedders, or a vector-store
+ * reset that preserved chunk text). Returns chunks embedded, -1 on error. */
+int kb_doc_embed_backfill(const char *project, const char *embedding_cmd, int max_chunks);
 
 /* Search the knowledge base.
  *

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -142,6 +142,11 @@ static void *drain_thread_main(void *arg)
             int e = kb_doc_refresh(projects[i].name, cfg.embedding_command, 200);
             if (e > 0)
                total += e;
+            /* Self-heal chunks that exist but lost their embedding (partial
+             * ingest, late embedder, or a vector-store dim reset). */
+            int b = kb_doc_embed_backfill(projects[i].name, cfg.embedding_command, 200);
+            if (b > 0)
+               total += b;
          }
          if (total > 0)
             aimee_log(LOG_DEBUG, "kb.docs.ingest", "ingested %d doc chunk(s) across %d project(s)",

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -594,3 +594,79 @@ int kb_doc_refresh(const char *project, const char *embedding_cmd, int max_docs)
    free(rows);
    return embedded;
 }
+
+/* Self-healing embedding backfill: embed kb_documents chunks that exist but have
+ * NO kb_embeddings row. kb_doc_refresh's gate is "file has no chunks yet", so a
+ * chunk left unembedded never gets a second chance — this covers the cases that
+ * leaves behind: a partial ingest, an embedder that was unavailable at ingest
+ * time (embedding_command added later), or a vector-store reset that drops the
+ * halfvec columns while the chunk text survives (e.g. an embedding-dim change).
+ * Re-embeds in place (no re-chunk), bounded per call. Returns chunks embedded. */
+int kb_doc_embed_backfill(const char *project, const char *embedding_cmd, int max_chunks)
+{
+   if (!project || !project[0] || !db2_is_initialized())
+      return -1;
+   const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
+   if (!effective_cmd[0])
+      return 0; /* no embedder configured — nothing to do */
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   if (max_chunks <= 0)
+      max_chunks = 200;
+
+   static const char *sql =
+       "SELECT kd.id, kd.heading_path, kd.content FROM kb_documents kd"
+       " WHERE kd.project = ?1"
+       "   AND NOT EXISTS (SELECT 1 FROM kb_embeddings ke WHERE ke.point_id = kd.id)"
+       " LIMIT ?2";
+
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_int(st, "?2", max_chunks);
+
+   /* Collect rows first: sync_vector_embedding issues its own statements and the
+    * pg layer allows only one active statement per connection. */
+   typedef struct
+   {
+      int64_t id;
+      char heading[512];
+      char *content;
+   } chunk_row_t;
+   chunk_row_t *rows = calloc((size_t)max_chunks, sizeof(chunk_row_t));
+   int n = 0;
+   if (rows)
+   {
+      while (n < max_chunks && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         int64_t id = aimee_pg_column_int64(st, 0);
+         const char *heading = aimee_pg_column_text(st, 1);
+         const char *body = aimee_pg_column_text(st, 2);
+         if (id <= 0 || !body)
+            continue;
+         rows[n].id = id;
+         snprintf(rows[n].heading, sizeof(rows[n].heading), "%s", heading ? heading : "");
+         rows[n].content = strdup(body);
+         if (rows[n].content)
+            n++;
+      }
+   }
+   aimee_pg_finalize(st);
+
+   int embedded = 0;
+   for (int i = 0; i < n; i++)
+   {
+      char embed_text[4096];
+      kb_async_make_embed_text(rows[i].heading, rows[i].content, embed_text, sizeof(embed_text));
+      float vec[EMBED_MAX_DIM];
+      int dim = memory_embed_text(embed_text, effective_cmd, vec, EMBED_MAX_DIM);
+      if (dim > 0 && sync_vector_embedding(rows[i].id, vec, dim) == 0)
+         embedded++;
+      free(rows[i].content);
+   }
+   free(rows);
+   return embedded;
+}


### PR DESCRIPTION
## The bug

`kb_doc_refresh` (the curator-drain pass that embeds doc files) gates on `NOT EXISTS (SELECT 1 FROM kb_documents …)` — it only embeds files that have **no chunks yet**. So a chunk that exists but has **no `kb_embeddings` row** is never re-embedded. The KB vector layer is then permanently empty even though the corpus shows as "ingested" (`kb_documents` populated, `kb_embeddings` = 0), and `kb/search` returns 0 hits.

This strands the KB whenever:
- an ingest partially failed,
- the embedder was unavailable at ingest time (`embedding_command` configured later), or
- the `halfvec` columns were dropped + recreated at a new dimension while chunk text survived — i.e. **an embedding-dim change (0.6b→4b)**.

This is exactly the state .254 landed in after the 4b migration: `file_contents=3252`, `kb_documents=5784`, `kb_embeddings=0`, and no CLI/ingest path repopulates it.

## The fix

`kb_doc_embed_backfill(project, embedding_cmd, max)` — selects `kb_documents` chunks with no matching `kb_embeddings.point_id` and embeds them **in place** (no re-chunk), reusing the same `memory_embed_text` + `sync_vector_embedding` path as ingest. The curator drain calls it per project after `kb_doc_refresh`, bounded at 200/poll. Once every chunk is embedded, the `NOT EXISTS` query returns nothing and it idles cheaply.

**Non-destructive** — never touches chunk text or `file_contents` (respects the keep-the-origin-artifact rule). Self-heals existing deployments on the next drain poll.

## Test

Full `unit-tests` build + run green; kb builds clean. `kb_doc_refresh` is DB2-gated (no unit harness), so the backfill is verified the same way — via the live drain + e2e smoke. Will validate on .254 post-deploy (the drain should repopulate `kb_embeddings` at 2560, then `kb/search` returns hits).
