### PR TITLE
embedder: pair reranker with embedder tier (4b+1b / 0.6b+400m)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -72,9 +72,10 @@ jobs:
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
-          # Lighter alternate embedder tier: same Dockerfile, 0.6b model baked in.
-          # Pair with embedding_dim: 1024 (see docs). Default is the 4b above.
-          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, extra_build_args: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b" }
+          # Lighter alternate tier: same Dockerfile, 0.6b embedder + 400m reranker
+          # baked in. Pair with embedding_dim: 1024 (see docs). Default (above) is
+          # the 4b embedder + 1b reranker.
+          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1" }
         platform:
           - { arch: amd64, runner: ubuntu-latest }
           - { arch: arm64, runner: ubuntu-24.04-arm }
@@ -111,7 +112,8 @@ jobs:
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
-            ${{ matrix.image.extra_build_args }}
+            ${{ matrix.image.embedder_arg }}
+            ${{ matrix.image.reranker_arg }}
           # webchat's SPA pulls @rakuensoftware/smoothgui from GitHub Packages,
           # whose npm registry requires an authenticated token (even for public
           # reads). Prefer a repo/org NPM_TOKEN secret (a PAT with read:packages);

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -3,19 +3,22 @@
 # model per call. Kept separate from the kb image so torch/sentence-transformers
 # never bloat the slim kb runtime.
 #
-# Default model: perplexity-ai/pplx-embed-v1-4b (Feb 2026, MIT, Qwen3-based,
-# 2560-dim, retrieval-optimized, prefix-free) — the higher-fidelity tier, default
-# since embedding throughput is not the bottleneck. The lighter
-# perplexity-ai/pplx-embed-v1-0.6b (1024-dim) is published as the separate
-# aimee-embedder-0.6b image. Override at build time with
+# Two coherent tiers, embedder paired with a matching-size reranker:
+#   default image (aimee-embedder):     pplx-embed-v1-4b   (2560-dim) + ettin-reranker-1b
+#   light image   (aimee-embedder-0.6b): pplx-embed-v1-0.6b (1024-dim) + ettin-reranker-400m
+# The 4b default is the higher-fidelity tier (embedding throughput is not the
+# bottleneck); the 0.6b image is the low-resource alternate. Override either at
+# build time:
 #   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
-#   schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024).
+#     schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024)
+#   --build-arg RERANKER_MODEL=<hf id>  (the reranker emits a scalar score, so it
+#     has no dim constraint — size it to match the embedder for a coherent tier).
 FROM python:3.11-slim AS embedder
 
 ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
-# stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
-ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
+# stage). Scores top-K (~50) pairs per query; the 1b pairs with the 4b embedder.
+ARG RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -45,10 +45,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the
-      # server/kb) to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
+      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
+      # and AIMEE_EMBEDDING_DIM=1024 on the server/kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -37,10 +37,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
-      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
+      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
+      # and AIMEE_EMBEDDING_DIM=1024 on the kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,10 +22,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
-      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
+      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
+      # and AIMEE_EMBEDDING_DIM=1024 on the kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -80,12 +80,18 @@ cast (`deploy/migrations/2026-embed-halfvec.sql`). Back up DB2 first.
 ## Reranking
 
 An optional cross-encoder reranker refines the top-k of a recall before it is
-returned. It is configured independently of the embedder:
+returned. It is served by the same embedder sidecar, sized to match the embedder
+tier: the default `aimee-embedder` image bakes the **1B** Ettin reranker
+(`cross-encoder/ettin-reranker-1b-v1`) alongside the 4B embedder; the
+`aimee-embedder-0.6b` image bakes the **400M** reranker
+(`cross-encoder/ettin-reranker-400m-v1`) alongside the 0.6B embedder. Build-time
+override: `--build-arg RERANKER_MODEL=<hf id>`.
+
+It is configured independently of the embedder dimension:
 
 - `memory_rerank_enabled` — master toggle.
-- `memory_rerank_command` — the reranker command (e.g. the Ettin
-  `cross-encoder/ettin-reranker-400m-v1` cross-encoder served by the embedder
-  sidecar).
+- `memory_rerank_command` — the reranker command (the Ettin cross-encoder served
+  by the embedder sidecar, via `rerank-remote.py`).
 - `memory_rerank_mode`, `memory_rerank_top_k` — strategy and depth.
 
 The reranker is dimension-agnostic — it scores `(query, candidate)` text pairs

--- a/scripts/aimee-combined-docker-smoke.sh
+++ b/scripts/aimee-combined-docker-smoke.sh
@@ -31,11 +31,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.combined.yaml}"
 SERVICE="${SERVICE:-aimee-server-kb}"
 
 # Smoke tests validate the retrieval pipeline, not a specific model. Default to
-# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
-# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+# the light tier (0.6b embedder/1024-dim + 400m reranker) so `up --build` is fast
+# and fits CI runners; the shipped default is the 4b + 1b reranker. Override any.
 : "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${RERANKER_MODEL:=cross-encoder/ettin-reranker-400m-v1}"
 : "${AIMEE_EMBEDDING_DIM:=1024}"
-export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
+export EMBEDDER_MODEL RERANKER_MODEL AIMEE_EMBEDDING_DIM
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 DO_UP=0
 DO_DOWN=0

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -36,11 +36,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 
 # Smoke tests validate the retrieval pipeline, not a specific model. Default to
-# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
-# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+# the light tier (0.6b embedder/1024-dim + 400m reranker) so `up --build` is fast
+# and fits CI runners; the shipped default is the 4b + 1b reranker. Override any.
 : "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${RERANKER_MODEL:=cross-encoder/ettin-reranker-400m-v1}"
 : "${AIMEE_EMBEDDING_DIM:=1024}"
-export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
+export EMBEDDER_MODEL RERANKER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -43,11 +43,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.server.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 
 # Smoke tests validate the retrieval pipeline, not a specific model. Default to
-# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
-# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+# the light tier (0.6b embedder/1024-dim + 400m reranker) so `up --build` is fast
+# and fits CI runners; the shipped default is the 4b + 1b reranker. Override any.
 : "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${RERANKER_MODEL:=cross-encoder/ettin-reranker-400m-v1}"
 : "${AIMEE_EMBEDDING_DIM:=1024}"
-export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
+export EMBEDDER_MODEL RERANKER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -23,7 +23,7 @@ Endpoints:
 Config (env):
   EMBEDDER_PORT     listen port (default 8080)
   EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-4b)
-  RERANKER_MODEL    cross-encoder model id (default ettin-reranker-400m-v1)
+  RERANKER_MODEL    cross-encoder model id (default ettin-reranker-1b-v1)
   EMBEDDER_THREADS  torch intra-op threads (default min(8, ncpu))
   EMBEDDER_QUANTIZE fp32 (default) | int8 (torch dynamic; ~3.3x faster, drifts —
                     pair with the 4b deep tier; see below)
@@ -40,7 +40,7 @@ MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-4b")
 # Cross-encoder reranker, served from the same process (it reuses the resident
 # torch/sentence-transformers stack). Lazy-loaded on first /rerank so the embedder
 # starts and stays healthy even if reranking is never used.
-RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "cross-encoder/ettin-reranker-400m-v1")
+RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "cross-encoder/ettin-reranker-1b-v1")
 PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
 # CPU serving tuning. A single short embed does not scale past ~8 intra-op
 # threads — on a 32-core host pplx-embed-0.6b is 269ms at 32 threads but 189ms at

--- a/src/config.c
+++ b/src/config.c
@@ -422,7 +422,8 @@ static void config_set_defaults(config_t *cfg)
     * Must match the schema vector(N) columns and the embedder model. Set to
     * 1024 (with the pplx-embed-v1-0.6b embedder image) for the lighter tier. */
    cfg->embedding_dim = 2560;
-   /* The cross-encoder rerank stage (ettin-reranker-400m-v1, served by the
+   /* The cross-encoder rerank stage (Ettin reranker sized to the embedder tier:
+    * 1b with the 4b embedder, 400m with the 0.6b; served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third
     * pipeline stage after the embedder, and is default-ON: every retrieval
     * runs a top-K cross-encoder pass over the dense/lexical candidates. It


### PR DESCRIPTION
## What

The reranker was hardcoded to `ettin-reranker-400m` regardless of embedder. Pair it with the embedder so each published image is a coherent tier:

| Image | Embedder | Reranker |
|-------|----------|----------|
| `aimee-embedder` (default) | `pplx-embed-v1-4b` (2560-dim) | `ettin-reranker-1b-v1` |
| `aimee-embedder-0.6b` (light) | `pplx-embed-v1-0.6b` (1024-dim) | `ettin-reranker-400m-v1` |

- `Dockerfile.embedder`: default `RERANKER_MODEL` → `cross-encoder/ettin-reranker-1b-v1`; both models build-arg overridable.
- `publish-images.yml`: the `aimee-embedder-0.6b` matrix entry bakes the 400m reranker (split into `embedder_arg` + `reranker_arg`).
- `compose.{combined,server,yaml}`: `RERANKER_MODEL` build-arg passthrough (default 1b).
- Docker smoke scripts: default to the 400m reranker so CI `up --build` stays light.
- `embedder-server.py` / `retrieval-stack.md` / `config.c`: defaults + docs.

## Notes

The reranker emits a scalar score — **no dim constraint**, so this is purely a model-size pairing (no schema/config-dim impact). CI's image build pre-downloads `RERANKER_MODEL`, so it validates the `ettin-reranker-1b-v1` id; if HF names it differently the build fails loudly (easy follow-up tweak).
