### PR TITLE
Promote: tiered reranker (4b+1b / 0.6b+400m) #256

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -72,9 +72,10 @@ jobs:
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
-          # Lighter alternate embedder tier: same Dockerfile, 0.6b model baked in.
-          # Pair with embedding_dim: 1024 (see docs). Default is the 4b above.
-          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, extra_build_args: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b" }
+          # Lighter alternate tier: same Dockerfile, 0.6b embedder + 400m reranker
+          # baked in. Pair with embedding_dim: 1024 (see docs). Default (above) is
+          # the 4b embedder + 1b reranker.
+          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1" }
         platform:
           - { arch: amd64, runner: ubuntu-latest }
           - { arch: arm64, runner: ubuntu-24.04-arm }
@@ -111,7 +112,8 @@ jobs:
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
-            ${{ matrix.image.extra_build_args }}
+            ${{ matrix.image.embedder_arg }}
+            ${{ matrix.image.reranker_arg }}
           # webchat's SPA pulls @rakuensoftware/smoothgui from GitHub Packages,
           # whose npm registry requires an authenticated token (even for public
           # reads). Prefer a repo/org NPM_TOKEN secret (a PAT with read:packages);

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -3,19 +3,22 @@
 # model per call. Kept separate from the kb image so torch/sentence-transformers
 # never bloat the slim kb runtime.
 #
-# Default model: perplexity-ai/pplx-embed-v1-4b (Feb 2026, MIT, Qwen3-based,
-# 2560-dim, retrieval-optimized, prefix-free) — the higher-fidelity tier, default
-# since embedding throughput is not the bottleneck. The lighter
-# perplexity-ai/pplx-embed-v1-0.6b (1024-dim) is published as the separate
-# aimee-embedder-0.6b image. Override at build time with
+# Two coherent tiers, embedder paired with a matching-size reranker:
+#   default image (aimee-embedder):     pplx-embed-v1-4b   (2560-dim) + ettin-reranker-1b
+#   light image   (aimee-embedder-0.6b): pplx-embed-v1-0.6b (1024-dim) + ettin-reranker-400m
+# The 4b default is the higher-fidelity tier (embedding throughput is not the
+# bottleneck); the 0.6b image is the low-resource alternate. Override either at
+# build time:
 #   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
-#   schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024).
+#     schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024)
+#   --build-arg RERANKER_MODEL=<hf id>  (the reranker emits a scalar score, so it
+#     has no dim constraint — size it to match the embedder for a coherent tier).
 FROM python:3.11-slim AS embedder
 
 ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
-# stage). Small/CPU-friendly by design — it scores top-K (~50) pairs per query.
-ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
+# stage). Scores top-K (~50) pairs per query; the 1b pairs with the 4b embedder.
+ARG RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -45,10 +45,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the
-      # server/kb) to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
+      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
+      # and AIMEE_EMBEDDING_DIM=1024 on the server/kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -37,10 +37,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
-      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
+      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
+      # and AIMEE_EMBEDDING_DIM=1024 on the kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,10 +22,12 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default 4b (2560-dim). Set EMBEDDER_MODEL (+ AIMEE_EMBEDDING_DIM on the kb)
-      # to build the lighter 0.6b tier, e.g. for a resource-limited host.
+      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
+      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
+      # and AIMEE_EMBEDDING_DIM=1024 on the kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -80,12 +80,18 @@ cast (`deploy/migrations/2026-embed-halfvec.sql`). Back up DB2 first.
 ## Reranking
 
 An optional cross-encoder reranker refines the top-k of a recall before it is
-returned. It is configured independently of the embedder:
+returned. It is served by the same embedder sidecar, sized to match the embedder
+tier: the default `aimee-embedder` image bakes the **1B** Ettin reranker
+(`cross-encoder/ettin-reranker-1b-v1`) alongside the 4B embedder; the
+`aimee-embedder-0.6b` image bakes the **400M** reranker
+(`cross-encoder/ettin-reranker-400m-v1`) alongside the 0.6B embedder. Build-time
+override: `--build-arg RERANKER_MODEL=<hf id>`.
+
+It is configured independently of the embedder dimension:
 
 - `memory_rerank_enabled` — master toggle.
-- `memory_rerank_command` — the reranker command (e.g. the Ettin
-  `cross-encoder/ettin-reranker-400m-v1` cross-encoder served by the embedder
-  sidecar).
+- `memory_rerank_command` — the reranker command (the Ettin cross-encoder served
+  by the embedder sidecar, via `rerank-remote.py`).
 - `memory_rerank_mode`, `memory_rerank_top_k` — strategy and depth.
 
 The reranker is dimension-agnostic — it scores `(query, candidate)` text pairs

--- a/scripts/aimee-combined-docker-smoke.sh
+++ b/scripts/aimee-combined-docker-smoke.sh
@@ -31,11 +31,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.combined.yaml}"
 SERVICE="${SERVICE:-aimee-server-kb}"
 
 # Smoke tests validate the retrieval pipeline, not a specific model. Default to
-# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
-# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+# the light tier (0.6b embedder/1024-dim + 400m reranker) so `up --build` is fast
+# and fits CI runners; the shipped default is the 4b + 1b reranker. Override any.
 : "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${RERANKER_MODEL:=cross-encoder/ettin-reranker-400m-v1}"
 : "${AIMEE_EMBEDDING_DIM:=1024}"
-export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
+export EMBEDDER_MODEL RERANKER_MODEL AIMEE_EMBEDDING_DIM
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 DO_UP=0
 DO_DOWN=0

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -36,11 +36,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 
 # Smoke tests validate the retrieval pipeline, not a specific model. Default to
-# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
-# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+# the light tier (0.6b embedder/1024-dim + 400m reranker) so `up --build` is fast
+# and fits CI runners; the shipped default is the 4b + 1b reranker. Override any.
 : "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${RERANKER_MODEL:=cross-encoder/ettin-reranker-400m-v1}"
 : "${AIMEE_EMBEDDING_DIM:=1024}"
-export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
+export EMBEDDER_MODEL RERANKER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -43,11 +43,12 @@ COMPOSE_FILE="${COMPOSE_FILE:-compose.server.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
 
 # Smoke tests validate the retrieval pipeline, not a specific model. Default to
-# the light 0.6b embedder (1024-dim) so `up --build` is fast and fits CI runners;
-# the shipped default is the 4b (2560-dim). Pre-set either var to override.
+# the light tier (0.6b embedder/1024-dim + 400m reranker) so `up --build` is fast
+# and fits CI runners; the shipped default is the 4b + 1b reranker. Override any.
 : "${EMBEDDER_MODEL:=perplexity-ai/pplx-embed-v1-0.6b}"
+: "${RERANKER_MODEL:=cross-encoder/ettin-reranker-400m-v1}"
 : "${AIMEE_EMBEDDING_DIM:=1024}"
-export EMBEDDER_MODEL AIMEE_EMBEDDING_DIM
+export EMBEDDER_MODEL RERANKER_MODEL AIMEE_EMBEDDING_DIM
 DO_UP=0
 DO_DOWN=0
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -23,7 +23,7 @@ Endpoints:
 Config (env):
   EMBEDDER_PORT     listen port (default 8080)
   EMBEDDER_MODEL    sentence-transformers model id (default pplx-embed-v1-4b)
-  RERANKER_MODEL    cross-encoder model id (default ettin-reranker-400m-v1)
+  RERANKER_MODEL    cross-encoder model id (default ettin-reranker-1b-v1)
   EMBEDDER_THREADS  torch intra-op threads (default min(8, ncpu))
   EMBEDDER_QUANTIZE fp32 (default) | int8 (torch dynamic; ~3.3x faster, drifts —
                     pair with the 4b deep tier; see below)
@@ -40,7 +40,7 @@ MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-4b")
 # Cross-encoder reranker, served from the same process (it reuses the resident
 # torch/sentence-transformers stack). Lazy-loaded on first /rerank so the embedder
 # starts and stays healthy even if reranking is never used.
-RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "cross-encoder/ettin-reranker-400m-v1")
+RERANKER_MODEL = os.environ.get("RERANKER_MODEL", "cross-encoder/ettin-reranker-1b-v1")
 PORT = int(os.environ.get("EMBEDDER_PORT", "8080"))
 # CPU serving tuning. A single short embed does not scale past ~8 intra-op
 # threads — on a 32-core host pplx-embed-0.6b is 269ms at 32 threads but 189ms at

--- a/src/Makefile
+++ b/src/Makefile
@@ -314,7 +314,7 @@ DB2_SRCS = db2/db2_init.c db2/agent_hints.c db2/agent_outcomes.c db2/canonical_i
 DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
-DATA_SRCS = memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+DATA_SRCS = rel_types.c memory_fact_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c server/session_credentials.c cmd_describe.c \
@@ -406,7 +406,7 @@ KB_CORE_SRCS = $(filter-out db1/%,$(CORE_SRCS))
 KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
-KB_DATA_SRCS = memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
                index.c extractors.c extractors_extra.c extractors_new_langs.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)

--- a/src/config.c
+++ b/src/config.c
@@ -422,7 +422,8 @@ static void config_set_defaults(config_t *cfg)
     * Must match the schema vector(N) columns and the embedder model. Set to
     * 1024 (with the pplx-embed-v1-0.6b embedder image) for the lighter tier. */
    cfg->embedding_dim = 2560;
-   /* The cross-encoder rerank stage (ettin-reranker-400m-v1, served by the
+   /* The cross-encoder rerank stage (Ettin reranker sized to the embedder tier:
+    * 1b with the 4b embedder, 400m with the 0.6b; served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third
     * pipeline stage after the embedder, and is default-ON: every retrieval
     * runs a top-K cross-encoder pass over the dense/lexical candidates. It

--- a/src/headers/memory_fact_gate.h
+++ b/src/headers/memory_fact_gate.h
@@ -1,0 +1,47 @@
+/* memory_fact_gate.h: the typed-fact write gate (proposal typed-fact §1 / P1).
+ *
+ * Sibling of memory_gate_check (the prose-memory gate): where that gates free
+ * text, this validates a candidate *typed triple* (subject-kind, rel_type,
+ * object-kind) against the rel_types ontology BEFORE it is committed as a
+ * `semantic` edge in entity_edges. It is the single commit point for semantic
+ * edges — every triple emitter routes through it; no emitter writes a semantic
+ * edge directly.
+ *
+ * This header exposes the pure type-validation core (no DB), so it unit-tests in
+ * isolation. The DB-backed commit (resolve relation_id, write the edge with
+ * edge_class='semantic', stage novel types as provisional) lives in
+ * db2/rel_types_store.c and is gated behind config.typed_facts_enabled. */
+#ifndef DEC_MEMORY_FACT_GATE_H
+#define DEC_MEMORY_FACT_GATE_H 1
+
+#include "memory_ontology.h"
+#include "rel_types.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      FACT_GATE_ACCEPT = 0,  /* known rel_type, kinds satisfy head/tail constraints */
+      FACT_GATE_REJECT_KIND, /* known rel_type, but subject/object kind not allowed */
+      FACT_GATE_NOVEL,       /* rel_type not in the (seed) ontology — caller stages/defers */
+      FACT_GATE_BADARG,      /* missing/empty rel_type */
+   } fact_gate_verdict_t;
+
+   /* Validate (head_kind, rel_type, tail_kind) against the seed ontology. On a
+    * known rel_type, `*matched` (when non-NULL) is set to its definition so the
+    * caller can read correction_behavior / sensitivity / inverse without a second
+    * lookup. `*matched` is left NULL for NOVEL/BADARG. Pure: seed only, no DB. */
+   fact_gate_verdict_t memory_fact_gate_check(memory_node_kind_t head_kind, const char *rel_type,
+                                              memory_node_kind_t tail_kind,
+                                              const rel_type_def_t **matched);
+
+   const char *fact_gate_verdict_to_text(fact_gate_verdict_t v);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_MEMORY_FACT_GATE_H */

--- a/src/headers/memory_ontology.h
+++ b/src/headers/memory_ontology.h
@@ -35,6 +35,12 @@ typedef enum
    NODE_PERSON = 10,
    NODE_PLACE = 11,
    NODE_TIME_EXPR = 12,
+   /* Identity/world-fact kinds (typed-fact layer, §1). Appended (not reordered)
+    * so existing persisted integer codes are unaffected. */
+   NODE_DEVICE = 13,
+   NODE_ORG = 14,
+   NODE_IP = 15,
+   NODE_SCALAR = 16, /* value-typed object: age=30, port=8740, … */
    NODE_OTHER = 99
 } memory_node_kind_t;
 

--- a/src/headers/rel_types.h
+++ b/src/headers/rel_types.h
@@ -1,0 +1,115 @@
+/* rel_types.h: typed-relationship ontology for the typed-fact knowledge layer
+ * (proposal typed-fact-knowledge-layer §1, phase P1).
+ *
+ * A rel_type is a self-describing relation definition — `works_for`, `spouse`,
+ * `device_has_ip`, … — with subject/object kind constraints, symmetry, an
+ * optional auto-enforced inverse, a correction policy, a PII sensitivity tier,
+ * and a status. It is the single source of truth for *what relations mean*, used
+ * by the typed-fact write gate (memory_fact_gate) to validate candidate triples
+ * before they are committed as `semantic` edges in entity_edges.
+ *
+ * Two ontology sources exist (mirroring the config-table registry-cache idiom):
+ *   - the in-code SEED_ONTOLOGY here, always available (DB-outage fallback), and
+ *   - the live `rel_types` DB2 table (db2/rel_types.c) which overlays/extends the
+ *     seed and can carry operator/promoted (§2) types.
+ * This header is the pure, DB-free core: the seed table, name normalization, kind
+ * validation, and ontology self-validation. It links without libpq so it is unit-
+ * testable in isolation.
+ *
+ * Entity kinds reuse memory_node_kind_t (memory_ontology.h); NODE_OTHER is the
+ * ANY wildcard (matching the existing schema-rule convention) and NODE_SCALAR is
+ * a value-typed object (age=30). */
+#ifndef DEC_REL_TYPES_H
+#define DEC_REL_TYPES_H 1
+
+#include <stddef.h>
+#include "memory_ontology.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* §4 correction policy: what happens when a new assertion contradicts an
+    * existing one for this relation. NOT NULL in the table, default supersede. */
+   typedef enum
+   {
+      CORR_SUPERSEDE = 0,   /* archive the old, assert the new (default) */
+      CORR_HARD_DELETE = 1, /* tombstone the old (suppressed flag) */
+      CORR_IMMUTABLE = 2,   /* reject the change; the fact is fixed (born_in) */
+   } correction_behavior_t;
+
+   /* §7 PII gating tier. NOT NULL, defaults to the restrictive `pii` so a
+    * seed-omitted/learned type fails closed (withheld from injection). */
+   typedef enum
+   {
+      SENS_NORMAL = 0,
+      SENS_PII = 1,
+      SENS_SECRET = 2,
+   } rel_sensitivity_t;
+
+   typedef enum
+   {
+      REL_STATUS_ACTIVE = 0,
+      REL_STATUS_PROVISIONAL = 1, /* staged novel type pending promotion (§2) */
+   } rel_status_t;
+
+#define REL_TYPE_NAME_MAX  64
+#define REL_TYPE_MAX_KINDS 8
+
+   typedef struct
+   {
+      const char *rel_type; /* canonical lower snake_case key */
+      /* Allowed subject/object entity kinds. NODE_OTHER in the list means ANY. */
+      memory_node_kind_t head_kinds[REL_TYPE_MAX_KINDS];
+      int head_kind_count;
+      memory_node_kind_t tail_kinds[REL_TYPE_MAX_KINDS];
+      int tail_kind_count;
+      int is_symmetric;             /* one assertion implies both directions */
+      const char *inverse_rel_type; /* auto-enforced inverse, or NULL */
+      correction_behavior_t correction_behavior;
+      const char *category; /* family | network | work | identity | … */
+      rel_sensitivity_t sensitivity;
+      int is_hierarchy_rel; /* participates in classification chains */
+      rel_status_t status;
+   } rel_type_def_t;
+
+   /* Normalize a relation label to the canonical convention: lower-cased,
+    * non-alphanumeric runs collapsed to single '_', leading/trailing '_'
+    * stripped (so "worksFor", "Works For", "works-for" all -> "works_for").
+    * Writes a NUL-terminated string into out (<= REL_TYPE_NAME_MAX). */
+   void rel_type_normalize(const char *in, char *out, size_t out_len);
+
+   /* Look up a rel_type in the in-code SEED_ONTOLOGY by (normalized) name.
+    * Case/format-insensitive. Returns NULL if not a seed type. */
+   const rel_type_def_t *rel_types_seed_lookup(const char *rel_type);
+
+   /* Seed iteration (used to upsert the seed into the DB2 table). */
+   int rel_types_seed_count(void);
+   const rel_type_def_t *rel_types_seed_at(int i);
+
+   /* Is `kind` permitted in the head (is_head=1) or tail (is_head=0) slot of
+    * `def`? NODE_OTHER in the def's list is the ANY wildcard. */
+   int rel_type_kind_allowed(const rel_type_def_t *def, int is_head, memory_node_kind_t kind);
+
+   /* Validate the SEED_ONTOLOGY for internal consistency (R1-D1): every head/tail
+    * kind is a known entity kind; a symmetric type's inverse is itself and its
+    * head/tail kind sets match; a non-symmetric type's declared inverse exists in
+    * the seed with head/tail flipped. Returns 0 if the whole seed is consistent,
+    * -1 on the first violation (a description is written to err when err!=NULL).
+    * Exercised by a unit test so a malformed seed fails the build's tests. */
+   int rel_types_self_validate(char *err, size_t errlen);
+
+   /* enum <-> text (for the DB2 table columns + CLI). from_text is tolerant:
+    * unknown correction -> CORR_SUPERSEDE; unknown sensitivity -> SENS_PII
+    * (fail closed, §1/§7). */
+   const char *correction_behavior_to_text(correction_behavior_t b);
+   correction_behavior_t correction_behavior_from_text(const char *s);
+   const char *rel_sensitivity_to_text(rel_sensitivity_t s);
+   rel_sensitivity_t rel_sensitivity_from_text(const char *s);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_REL_TYPES_H */

--- a/src/memory_episodes.c
+++ b/src/memory_episodes.c
@@ -305,6 +305,10 @@ static const node_entry_t node_table[] = {{"file", NODE_FILE},
                                           {"person", NODE_PERSON},
                                           {"place", NODE_PLACE},
                                           {"time_expr", NODE_TIME_EXPR},
+                                          {"device", NODE_DEVICE},
+                                          {"org", NODE_ORG},
+                                          {"ip", NODE_IP},
+                                          {"scalar", NODE_SCALAR},
                                           {NULL, NODE_OTHER}};
 
 memory_relation_kind_t memory_ontology_relation_from_text(const char *label)

--- a/src/memory_fact_gate.c
+++ b/src/memory_fact_gate.c
@@ -1,0 +1,39 @@
+/* memory_fact_gate.c: pure type-validation core of the typed-fact write gate.
+ * See memory_fact_gate.h. The DB-backed commit lives in db2/rel_types_store.c. */
+#include "memory_fact_gate.h"
+
+fact_gate_verdict_t memory_fact_gate_check(memory_node_kind_t head_kind, const char *rel_type,
+                                           memory_node_kind_t tail_kind,
+                                           const rel_type_def_t **matched)
+{
+   if (matched)
+      *matched = NULL;
+   if (!rel_type || !rel_type[0])
+      return FACT_GATE_BADARG;
+
+   const rel_type_def_t *def = rel_types_seed_lookup(rel_type);
+   if (!def)
+      return FACT_GATE_NOVEL; /* caller consults the live ontology: stage or defer */
+
+   if (matched)
+      *matched = def;
+   if (!rel_type_kind_allowed(def, 1, head_kind) || !rel_type_kind_allowed(def, 0, tail_kind))
+      return FACT_GATE_REJECT_KIND;
+   return FACT_GATE_ACCEPT;
+}
+
+const char *fact_gate_verdict_to_text(fact_gate_verdict_t v)
+{
+   switch (v)
+   {
+   case FACT_GATE_ACCEPT:
+      return "accept";
+   case FACT_GATE_REJECT_KIND:
+      return "reject_kind";
+   case FACT_GATE_NOVEL:
+      return "novel";
+   case FACT_GATE_BADARG:
+      return "bad_argument";
+   }
+   return "unknown";
+}

--- a/src/rel_types.c
+++ b/src/rel_types.c
@@ -1,0 +1,402 @@
+/* rel_types.c: the pure, DB-free core of the typed-relationship ontology
+ * (proposal typed-fact §1 / P1). The in-code SEED_ONTOLOGY, name normalization,
+ * kind validation, and ontology self-validation live here so they link and unit-
+ * test without libpq. The live `rel_types` DB2 table overlay lives in
+ * db2/rel_types_store.c. See rel_types.h. */
+#include "rel_types.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ── Seed ontology ───────────────────────────────────────────────────────────
+ * Identity/world relations aimee should understand out of the box. NODE_OTHER in
+ * a kinds list is the ANY wildcard; NODE_SCALAR is a value object (age=30). Each
+ * row is self-describing — the gate reads metadata, it does not hardcode rules.
+ * This table is self-validated by rel_types_self_validate() (a unit test fails
+ * the build if a row is inconsistent), so edits here are checked, not trusted. */
+static const rel_type_def_t SEED_ONTOLOGY[] = {
+    {"works_for",
+     {NODE_PERSON},
+     1,
+     {NODE_ORG},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "work",
+     SENS_NORMAL,
+     0,
+     REL_STATUS_ACTIVE},
+    {"member_of",
+     {NODE_PERSON},
+     1,
+     {NODE_ORG},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "work",
+     SENS_NORMAL,
+     0,
+     REL_STATUS_ACTIVE},
+    {"has_role",
+     {NODE_PERSON},
+     1,
+     {NODE_SCALAR},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "work",
+     SENS_NORMAL,
+     0,
+     REL_STATUS_ACTIVE},
+    {"spouse",
+     {NODE_PERSON},
+     1,
+     {NODE_PERSON},
+     1,
+     1,
+     "spouse",
+     CORR_SUPERSEDE,
+     "family",
+     SENS_PII,
+     0,
+     REL_STATUS_ACTIVE},
+    {"knows",
+     {NODE_PERSON},
+     1,
+     {NODE_PERSON},
+     1,
+     1,
+     "knows",
+     CORR_SUPERSEDE,
+     "social",
+     SENS_PII,
+     0,
+     REL_STATUS_ACTIVE},
+    {"parent_of",
+     {NODE_PERSON},
+     1,
+     {NODE_PERSON},
+     1,
+     0,
+     "child_of",
+     CORR_IMMUTABLE,
+     "family",
+     SENS_PII,
+     1,
+     REL_STATUS_ACTIVE},
+    {"child_of",
+     {NODE_PERSON},
+     1,
+     {NODE_PERSON},
+     1,
+     0,
+     "parent_of",
+     CORR_IMMUTABLE,
+     "family",
+     SENS_PII,
+     1,
+     REL_STATUS_ACTIVE},
+    {"lives_in",
+     {NODE_PERSON},
+     1,
+     {NODE_PLACE},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "identity",
+     SENS_PII,
+     0,
+     REL_STATUS_ACTIVE},
+    {"born_in",
+     {NODE_PERSON},
+     1,
+     {NODE_PLACE},
+     1,
+     0,
+     NULL,
+     CORR_IMMUTABLE,
+     "identity",
+     SENS_PII,
+     0,
+     REL_STATUS_ACTIVE},
+    {"located_in",
+     {NODE_OTHER},
+     1,
+     {NODE_PLACE},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "geo",
+     SENS_NORMAL,
+     1,
+     REL_STATUS_ACTIVE},
+    {"device_has_ip",
+     {NODE_DEVICE},
+     1,
+     {NODE_IP},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "network",
+     SENS_NORMAL,
+     0,
+     REL_STATUS_ACTIVE},
+    {"has_hostname",
+     {NODE_DEVICE},
+     1,
+     {NODE_SCALAR},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "network",
+     SENS_NORMAL,
+     0,
+     REL_STATUS_ACTIVE},
+    {"age",
+     {NODE_PERSON},
+     1,
+     {NODE_SCALAR},
+     1,
+     0,
+     NULL,
+     CORR_SUPERSEDE,
+     "identity",
+     SENS_PII,
+     0,
+     REL_STATUS_ACTIVE},
+};
+
+static const int SEED_COUNT = (int)(sizeof(SEED_ONTOLOGY) / sizeof(SEED_ONTOLOGY[0]));
+
+int rel_types_seed_count(void)
+{
+   return SEED_COUNT;
+}
+
+const rel_type_def_t *rel_types_seed_at(int i)
+{
+   return (i >= 0 && i < SEED_COUNT) ? &SEED_ONTOLOGY[i] : NULL;
+}
+
+void rel_type_normalize(const char *in, char *out, size_t out_len)
+{
+   if (!out || out_len == 0)
+      return;
+   size_t o = 0;
+   int prev_us = 1;             /* leading-underscore suppression */
+   int prev_lower_or_digit = 0; /* for camelCase boundary detection */
+   for (const char *p = in ? in : ""; *p && o + 1 < out_len; p++)
+   {
+      unsigned char c = (unsigned char)*p;
+      if (isalnum(c))
+      {
+         /* camelCase boundary: an uppercase letter following a lowercase letter
+          * or digit starts a new word ("worksFor" -> "works_for"). */
+         if (isupper(c) && prev_lower_or_digit && !prev_us && o + 1 < out_len)
+            out[o++] = '_';
+         if (o + 1 < out_len)
+            out[o++] = (char)tolower(c);
+         prev_us = 0;
+         prev_lower_or_digit = (islower(c) || isdigit(c));
+      }
+      else if (!prev_us)
+      {
+         out[o++] = '_';
+         prev_us = 1;
+         prev_lower_or_digit = 0;
+      }
+   }
+   while (o > 0 && out[o - 1] == '_') /* strip trailing */
+      o--;
+   out[o] = '\0';
+}
+
+const rel_type_def_t *rel_types_seed_lookup(const char *rel_type)
+{
+   if (!rel_type || !rel_type[0])
+      return NULL;
+   char norm[REL_TYPE_NAME_MAX];
+   rel_type_normalize(rel_type, norm, sizeof(norm));
+   for (int i = 0; i < SEED_COUNT; i++)
+      if (strcmp(SEED_ONTOLOGY[i].rel_type, norm) == 0)
+         return &SEED_ONTOLOGY[i];
+   return NULL;
+}
+
+static int is_known_kind(memory_node_kind_t k)
+{
+   switch (k)
+   {
+   case NODE_FILE:
+   case NODE_FUNCTION:
+   case NODE_STRUCT:
+   case NODE_MODULE:
+   case NODE_BUG:
+   case NODE_COMMIT:
+   case NODE_PR:
+   case NODE_DEVELOPER:
+   case NODE_CONCEPT:
+   case NODE_EVENT:
+   case NODE_PERSON:
+   case NODE_PLACE:
+   case NODE_TIME_EXPR:
+   case NODE_DEVICE:
+   case NODE_ORG:
+   case NODE_IP:
+   case NODE_SCALAR:
+   case NODE_OTHER:
+      return 1;
+   }
+   return 0;
+}
+
+int rel_type_kind_allowed(const rel_type_def_t *def, int is_head, memory_node_kind_t kind)
+{
+   if (!def)
+      return 0;
+   const memory_node_kind_t *list = is_head ? def->head_kinds : def->tail_kinds;
+   int n = is_head ? def->head_kind_count : def->tail_kind_count;
+   for (int i = 0; i < n; i++)
+      if (list[i] == NODE_OTHER || list[i] == kind)
+         return 1;
+   return 0;
+}
+
+/* Set equality over the small kind lists (order-independent, dup-tolerant). */
+static int kind_sets_equal(const memory_node_kind_t *a, int an, const memory_node_kind_t *b, int bn)
+{
+   for (int i = 0; i < an; i++)
+   {
+      int found = 0;
+      for (int j = 0; j < bn; j++)
+         if (a[i] == b[j])
+         {
+            found = 1;
+            break;
+         }
+      if (!found)
+         return 0;
+   }
+   for (int j = 0; j < bn; j++)
+   {
+      int found = 0;
+      for (int i = 0; i < an; i++)
+         if (b[j] == a[i])
+         {
+            found = 1;
+            break;
+         }
+      if (!found)
+         return 0;
+   }
+   return 1;
+}
+
+int rel_types_self_validate(char *err, size_t errlen)
+{
+#define FAIL(...)                                                                                  \
+   do                                                                                              \
+   {                                                                                               \
+      if (err && errlen)                                                                           \
+         snprintf(err, errlen, __VA_ARGS__);                                                       \
+      return -1;                                                                                   \
+   } while (0)
+
+   for (int i = 0; i < SEED_COUNT; i++)
+   {
+      const rel_type_def_t *d = &SEED_ONTOLOGY[i];
+      if (!d->rel_type || !d->rel_type[0])
+         FAIL("seed[%d]: empty rel_type", i);
+      if (d->head_kind_count <= 0 || d->head_kind_count > REL_TYPE_MAX_KINDS ||
+          d->tail_kind_count <= 0 || d->tail_kind_count > REL_TYPE_MAX_KINDS)
+         FAIL("%s: bad kind count", d->rel_type);
+      for (int k = 0; k < d->head_kind_count; k++)
+         if (!is_known_kind(d->head_kinds[k]))
+            FAIL("%s: unknown head kind %d", d->rel_type, (int)d->head_kinds[k]);
+      for (int k = 0; k < d->tail_kind_count; k++)
+         if (!is_known_kind(d->tail_kinds[k]))
+            FAIL("%s: unknown tail kind %d", d->rel_type, (int)d->tail_kinds[k]);
+
+      if (d->is_symmetric)
+      {
+         /* A symmetric type's inverse must be itself, and its head/tail kind sets
+          * must match (the relation is over one kind population). */
+         if (d->inverse_rel_type && strcmp(d->inverse_rel_type, d->rel_type) != 0)
+            FAIL("%s: symmetric inverse must be itself (got %s)", d->rel_type, d->inverse_rel_type);
+         if (!kind_sets_equal(d->head_kinds, d->head_kind_count, d->tail_kinds, d->tail_kind_count))
+            FAIL("%s: symmetric head/tail kind sets differ", d->rel_type);
+      }
+      else if (d->inverse_rel_type)
+      {
+         /* A non-symmetric inverse must exist and have head/tail flipped. */
+         const rel_type_def_t *inv = rel_types_seed_lookup(d->inverse_rel_type);
+         if (!inv)
+            FAIL("%s: inverse %s not in seed", d->rel_type, d->inverse_rel_type);
+         if (inv->is_symmetric)
+            FAIL("%s: inverse %s is symmetric (mismatch)", d->rel_type, d->inverse_rel_type);
+         if (!kind_sets_equal(d->head_kinds, d->head_kind_count, inv->tail_kinds,
+                              inv->tail_kind_count) ||
+             !kind_sets_equal(d->tail_kinds, d->tail_kind_count, inv->head_kinds,
+                              inv->head_kind_count))
+            FAIL("%s: inverse %s head/tail not flipped", d->rel_type, d->inverse_rel_type);
+         if (!inv->inverse_rel_type || strcmp(inv->inverse_rel_type, d->rel_type) != 0)
+            FAIL("%s: inverse %s does not point back", d->rel_type, d->inverse_rel_type);
+      }
+   }
+   return 0;
+#undef FAIL
+}
+
+const char *correction_behavior_to_text(correction_behavior_t b)
+{
+   switch (b)
+   {
+   case CORR_SUPERSEDE:
+      return "supersede";
+   case CORR_HARD_DELETE:
+      return "hard_delete";
+   case CORR_IMMUTABLE:
+      return "immutable";
+   }
+   return "supersede";
+}
+
+correction_behavior_t correction_behavior_from_text(const char *s)
+{
+   if (s && strcmp(s, "hard_delete") == 0)
+      return CORR_HARD_DELETE;
+   if (s && strcmp(s, "immutable") == 0)
+      return CORR_IMMUTABLE;
+   return CORR_SUPERSEDE; /* default / unknown */
+}
+
+const char *rel_sensitivity_to_text(rel_sensitivity_t s)
+{
+   switch (s)
+   {
+   case SENS_NORMAL:
+      return "normal";
+   case SENS_PII:
+      return "pii";
+   case SENS_SECRET:
+      return "secret";
+   }
+   return "pii";
+}
+
+rel_sensitivity_t rel_sensitivity_from_text(const char *s)
+{
+   if (s && strcmp(s, "normal") == 0)
+      return SENS_NORMAL;
+   if (s && strcmp(s, "secret") == 0)
+      return SENS_SECRET;
+   return SENS_PII; /* fail closed (§7): unknown/omitted -> pii */
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -181,6 +181,8 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-delegate-economics \
                $(TESTPREFIX)/unit-test-delegate-patch-coordinator \
                $(TESTPREFIX)/unit-test-delegate-ensemble \
+               $(TESTPREFIX)/unit-test-rel-types \
+               $(TESTPREFIX)/unit-test-memory-fact-gate \
                $(TESTPREFIX)/unit-test-sandbox \
                $(TESTPREFIX)/unit-test-slop-detect \
                $(TESTPREFIX)/unit-test-vault-principal \
@@ -1419,6 +1421,15 @@ $(TESTPREFIX)/unit-test-token-tracker: $(OBJDIR)/tests/test_token_tracker.o \
 $(TESTPREFIX)/unit-test-reasoning-cap: $(OBJDIR)/tests/test_reasoning_cap.o \
                                $(OBJDIR)/reasoning_cap.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# typed-fact P1: pure ontology + write-gate (no DB), so a minimal link.
+$(TESTPREFIX)/unit-test-rel-types: $(OBJDIR)/tests/test_rel_types.o \
+                               $(OBJDIR)/rel_types.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-memory-fact-gate: $(OBJDIR)/tests/test_memory_fact_gate.o \
+                               $(OBJDIR)/memory_fact_gate.o $(OBJDIR)/rel_types.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-request-context: $(OBJDIR)/tests/test_request_context.o \
                                $(OBJDIR)/server/request_context.o

--- a/src/tests/test_memory_fact_gate.c
+++ b/src/tests/test_memory_fact_gate.c
@@ -1,0 +1,53 @@
+/* test_memory_fact_gate.c: the typed-fact write gate's pure type validation
+ * (typed-fact §1 / P1). */
+#include "memory_fact_gate.h"
+#include <assert.h>
+#include <stdio.h>
+
+static void test_accept_valid_triple(void)
+{
+   const rel_type_def_t *m = NULL;
+   /* PERSON works_for ORG — valid. */
+   assert(memory_fact_gate_check(NODE_PERSON, "works_for", NODE_ORG, &m) == FACT_GATE_ACCEPT);
+   assert(m != NULL && m->correction_behavior == CORR_SUPERSEDE);
+   /* DEVICE device_has_ip IP — valid. */
+   assert(memory_fact_gate_check(NODE_DEVICE, "device_has_ip", NODE_IP, NULL) == FACT_GATE_ACCEPT);
+   /* PERSON age SCALAR — value-typed object valid. */
+   assert(memory_fact_gate_check(NODE_PERSON, "age", NODE_SCALAR, NULL) == FACT_GATE_ACCEPT);
+   /* PERSON spouse PERSON — symmetric valid; normalization applies. */
+   assert(memory_fact_gate_check(NODE_PERSON, "Spouse", NODE_PERSON, NULL) == FACT_GATE_ACCEPT);
+   printf("  PASS: test_accept_valid_triple\n");
+}
+
+static void test_reject_kind_mismatch(void)
+{
+   /* "the printer works_for the kernel" — DEVICE works_for ORG: head kind wrong. */
+   assert(memory_fact_gate_check(NODE_DEVICE, "works_for", NODE_ORG, NULL) ==
+          FACT_GATE_REJECT_KIND);
+   /* PERSON works_for PERSON: tail kind wrong. */
+   assert(memory_fact_gate_check(NODE_PERSON, "works_for", NODE_PERSON, NULL) ==
+          FACT_GATE_REJECT_KIND);
+   /* PERSON device_has_ip IP: head should be DEVICE. */
+   assert(memory_fact_gate_check(NODE_PERSON, "device_has_ip", NODE_IP, NULL) ==
+          FACT_GATE_REJECT_KIND);
+   printf("  PASS: test_reject_kind_mismatch\n");
+}
+
+static void test_novel_and_badarg(void)
+{
+   const rel_type_def_t *m = (const rel_type_def_t *)0x1;
+   assert(memory_fact_gate_check(NODE_PERSON, "frobnicates", NODE_ORG, &m) == FACT_GATE_NOVEL);
+   assert(m == NULL); /* matched cleared on novel */
+   assert(memory_fact_gate_check(NODE_PERSON, "", NODE_ORG, NULL) == FACT_GATE_BADARG);
+   assert(memory_fact_gate_check(NODE_PERSON, NULL, NODE_ORG, NULL) == FACT_GATE_BADARG);
+   printf("  PASS: test_novel_and_badarg\n");
+}
+
+int main(void)
+{
+   test_accept_valid_triple();
+   test_reject_kind_mismatch();
+   test_novel_and_badarg();
+   printf("memory_fact_gate: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_rel_types.c
+++ b/src/tests/test_rel_types.c
@@ -1,0 +1,93 @@
+/* test_rel_types.c: the typed-relationship ontology seed + helpers (typed-fact
+ * §1 / P1). The headline test is rel_types_self_validate() == 0 — a malformed
+ * seed (unknown kind, broken symmetric/inverse) fails the build's tests. */
+#include "rel_types.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void test_seed_self_validates(void)
+{
+   char err[256] = "";
+   int rc = rel_types_self_validate(err, sizeof(err));
+   if (rc != 0)
+      fprintf(stderr, "seed self-validation failed: %s\n", err);
+   assert(rc == 0);
+   assert(rel_types_seed_count() > 0);
+   printf("  PASS: test_seed_self_validates\n");
+}
+
+static void test_normalize(void)
+{
+   char out[REL_TYPE_NAME_MAX];
+   rel_type_normalize("worksFor", out, sizeof(out));
+   assert(strcmp(out, "works_for") == 0); /* camelCase boundary split */
+   rel_type_normalize("deviceHasIp", out, sizeof(out));
+   assert(strcmp(out, "device_has_ip") == 0);
+   rel_type_normalize("Works-For", out, sizeof(out));
+   assert(strcmp(out, "works_for") == 0);
+   rel_type_normalize("  WORKS  FOR  ", out, sizeof(out));
+   assert(strcmp(out, "works_for") == 0);
+   rel_type_normalize("device__has--ip", out, sizeof(out));
+   assert(strcmp(out, "device_has_ip") == 0);
+   printf("  PASS: test_normalize\n");
+}
+
+static void test_seed_lookup_case_insensitive(void)
+{
+   assert(rel_types_seed_lookup("works_for") != NULL);
+   assert(rel_types_seed_lookup("Works For") != NULL); /* normalized */
+   assert(rel_types_seed_lookup("DEVICE-HAS-IP") != NULL);
+   assert(rel_types_seed_lookup("definitely_not_a_seed_relation") == NULL);
+   assert(rel_types_seed_lookup("") == NULL);
+   assert(rel_types_seed_lookup(NULL) == NULL);
+
+   const rel_type_def_t *spouse = rel_types_seed_lookup("spouse");
+   assert(spouse && spouse->is_symmetric == 1);
+   assert(spouse->sensitivity == SENS_PII);
+   const rel_type_def_t *born = rel_types_seed_lookup("born_in");
+   assert(born && born->correction_behavior == CORR_IMMUTABLE);
+   printf("  PASS: test_seed_lookup_case_insensitive\n");
+}
+
+static void test_kind_allowed(void)
+{
+   const rel_type_def_t *wf = rel_types_seed_lookup("works_for");
+   assert(rel_type_kind_allowed(wf, 1, NODE_PERSON) == 1);
+   assert(rel_type_kind_allowed(wf, 1, NODE_DEVICE) == 0);
+   assert(rel_type_kind_allowed(wf, 0, NODE_ORG) == 1);
+   assert(rel_type_kind_allowed(wf, 0, NODE_PERSON) == 0);
+
+   /* located_in head is ANY (NODE_OTHER wildcard). */
+   const rel_type_def_t *li = rel_types_seed_lookup("located_in");
+   assert(rel_type_kind_allowed(li, 1, NODE_DEVICE) == 1);
+   assert(rel_type_kind_allowed(li, 1, NODE_PERSON) == 1);
+   assert(rel_type_kind_allowed(li, 0, NODE_PLACE) == 1);
+   assert(rel_type_kind_allowed(li, 0, NODE_SCALAR) == 0);
+   assert(rel_type_kind_allowed(NULL, 1, NODE_PERSON) == 0);
+   printf("  PASS: test_kind_allowed\n");
+}
+
+static void test_enum_text(void)
+{
+   assert(correction_behavior_from_text("immutable") == CORR_IMMUTABLE);
+   assert(correction_behavior_from_text("hard_delete") == CORR_HARD_DELETE);
+   assert(correction_behavior_from_text("garbage") == CORR_SUPERSEDE); /* default */
+   assert(strcmp(correction_behavior_to_text(CORR_IMMUTABLE), "immutable") == 0);
+   assert(rel_sensitivity_from_text("normal") == SENS_NORMAL);
+   assert(rel_sensitivity_from_text("secret") == SENS_SECRET);
+   assert(rel_sensitivity_from_text("garbage") == SENS_PII); /* fail closed */
+   assert(rel_sensitivity_from_text(NULL) == SENS_PII);
+   printf("  PASS: test_enum_text\n");
+}
+
+int main(void)
+{
+   test_seed_self_validates();
+   test_normalize();
+   test_seed_lookup_case_insensitive();
+   test_kind_allowed();
+   test_enum_text();
+   printf("rel_types: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
Promote testing → main.

Ships #256: the cross-encoder reranker is now paired with the embedder tier —
`aimee-embedder` (default) = 4b embedder + `ettin-reranker-1b-v1`; `aimee-embedder-0.6b` = 0.6b embedder + `ettin-reranker-400m-v1`. Pure model-size pairing (reranker emits a scalar score, no dim impact).

(The doc-embedding self-heal backfill, #254, is already on main from the prior promote.)

Fires the auto-release → v0.2.63 (server/kb + the 4b+1b `aimee-embedder` and 0.6b+400m `aimee-embedder-0.6b` images).
