### PR TITLE
kb search: don't force builtin query embedding (split-deploy 0-hits)

### DIFF
--- a/src/server/server_api.c
+++ b/src/server/server_api.c
@@ -126,10 +126,17 @@ static int kb_search_handler(const char *body, char *resp, int cap)
    const char *format =
        (cJSON_IsString(jf) && strcmp(jf->valuestring, "text") == 0) ? "text" : "json";
 
+   /* Let the kb embed the query with ITS OWN configured embedder — the kb owns
+    * the corpus and its embedder. Forward the server's embedding_command only
+    * when one is explicitly set (co-located deploy, shared config); pass NULL
+    * otherwise. NEVER default to "builtin": in a split deploy the server has no
+    * embedder, and a 384-dim builtin query vector cannot match a real-embedder
+    * corpus (1024/2560-dim) — the dim mismatch yields zero hits even though the
+    * corpus is fully embedded. */
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    config_load(&cfg);
-   const char *emb = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *emb = cfg.embedding_command[0] ? cfg.embedding_command : NULL;
 
    char *j = kb_client_search_json(project, jq->valuestring, emb, max_results, format);
    cJSON_Delete(req);


### PR DESCRIPTION
## The bug

The HTTP `/v1/kb/search` handler (`server_api.c`) passed `embedding_command` defaulting to **`"builtin"`** when the server's config had none. In a split deploy the server has no embedder (the kb owns it), so this forced every search query to be embedded with the **384-dim builtin hash** — which can't match a corpus embedded by the real embedder (1024-dim 0.6b / 2560-dim 4b). `kb/search` returned **0 hits** (`fusion_mode_used:""`) even with a fully-embedded corpus.

This is the long-standing "search returns nothing" symptom — independent of the embedding dimension; the server always forced builtin.

## Proof (live split deploy)

Same query, same kb, same instant:
- `POST /v1/search {…, "embedding_command":"builtin"}` → **0 hits**
- `POST /v1/search {…}` (no embedding_command) → **3 hits, rrf**

The NDJSON socket handler (`handle_kb_search`) never had this bug — it forwards the request's `embedding_command` (NULL when absent).

## Fix

Pass the server's `embedding_command` only when explicitly set (co-located deploy, shared config); otherwise `NULL`, so the kb embeds the query with its own configured embedder. Never default to `"builtin"`.

`unit-tests` build+run green. Will validate end-to-end on .254 after deploy (`aimee kb search` returns hits).
