### PR TITLE
kb cli: don't force builtin query embedding (aimee kb search 0-hits)

### DIFF
--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -103,7 +103,11 @@ static void kb_cmd_update(app_ctx_t *ctx, int argc, char **argv)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   /* Pass NULL when no local embedder is configured (the thin client has none)
+    * so the kb embeds with its OWN embedder; defaulting to "builtin" (384-dim
+    * hash) would mismatch a real-embedder corpus (1024/2560-dim) and return
+    * nothing. */
+   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : NULL;
 
    char proj[256];
    kb_resolve_project(project, root, proj, sizeof(proj));
@@ -175,7 +179,11 @@ static void kb_cmd_search(app_ctx_t *ctx, int argc, char **argv)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   /* Pass NULL when no local embedder is configured (the thin client has none)
+    * so the kb embeds with its OWN embedder; defaulting to "builtin" (384-dim
+    * hash) would mismatch a real-embedder corpus (1024/2560-dim) and return
+    * nothing. */
+   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : NULL;
 
    char proj[256];
    kb_resolve_project(project, NULL, proj, sizeof(proj));
@@ -453,7 +461,11 @@ static void kb_cmd_repair(app_ctx_t *ctx, int argc, char **argv)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   /* Pass NULL when no local embedder is configured (the thin client has none)
+    * so the kb embeds with its OWN embedder; defaulting to "builtin" (384-dim
+    * hash) would mismatch a real-embedder corpus (1024/2560-dim) and return
+    * nothing. */
+   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : NULL;
 
    char proj[256];
    kb_resolve_project(project, root, proj, sizeof(proj));


### PR DESCRIPTION
Follow-up to #262 (server `/v1/kb/search`): the same `"builtin"` anti-pattern is in the thin-client `cmd_kb.c` — `aimee kb search` / `aimee kb update` default `embedding_command` to `"builtin"` when the local config has none. The thin client has no embedder, so it sent `embedding_command:"builtin"` to the kb → 384-dim builtin query vector → mismatch with the real-embedder corpus → zero hits.

Fix: pass `NULL` when no local embedder is configured, so the kb embeds the query with its own. Co-located installs (with `embedding_command` set) still forward it.

`aimee` client + `unit-tests` build green. Completes the `aimee kb search` user-facing path (server side proven returning hits on v0.2.64).
