### PR TITLE
docs: embedder tiers — 4b/1b vs 0.6b/400m, differences + pros/cons

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1375,11 +1375,13 @@ install only the thin client ([§3.2](#32-install-the-thin-client)) and point it
 the server. Four compose files ship, built from three images: `aimee-server`
 (`Dockerfile.server`), `aimee-kb` (`Dockerfile`), and the co-located
 `aimee-server+kb` (`Dockerfile.combined`). Every stack also brings up a
-`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar (`pplx-embed-v1-4b`,
-2560-dim, the default; `Dockerfile.embedder`); the kb auto-applies its DB2 schema
-(`pg_trgm`/`vector` extensions + tables) on first boot. The lighter
-`pplx-embed-v1-0.6b` tier ships as the `aimee-embedder-0.6b` image
-(`AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`).
+`pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar
+(`Dockerfile.embedder`); the kb auto-applies its DB2 schema (`pg_trgm`/`vector`
+extensions + tables) on first boot. The sidecar ships in two tiers (embedder +
+matching reranker in one image): the default `aimee-embedder` (4b/2560 + 1b
+reranker) and the lighter `aimee-embedder-0.6b` (0.6b/1024 + 400m reranker) via
+`AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`. Trade-offs:
+[retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
 
 | Compose file | Brings up | Use when |
 |--------------|-----------|----------|

--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1378,9 +1378,10 @@ the server. Four compose files ship, built from three images: `aimee-server`
 `pgvector/pgvector:pg16` Postgres and a CPU embedder sidecar
 (`Dockerfile.embedder`); the kb auto-applies its DB2 schema (`pg_trgm`/`vector`
 extensions + tables) on first boot. The sidecar ships in two tiers (embedder +
-matching reranker in one image): the default `aimee-embedder` (4b/2560 + 1b
-reranker) and the lighter `aimee-embedder-0.6b` (0.6b/1024 + 400m reranker) via
-`AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`. Trade-offs:
+reranker in one image): the default `aimee-embedder` (`pplx-embed-v1-4b`/2560 +
+`ettin-reranker-1b`) and the lighter `aimee-embedder-0.6b` (`pplx-embed-v1-0.6b`/
+1024 + `ettin-reranker-400m`) via `AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`
+(or `AIMEE_EMBEDDING_DIM=1024`). Trade-offs:
 [retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
 
 | Compose file | Brings up | Use when |

--- a/README.md
+++ b/README.md
@@ -398,11 +398,13 @@ install only the [thin client](#2-install-the-thin-client)). Four compose files
 ship; pick by topology. They build from three reusable images: **`aimee-server`**
 (`Dockerfile.server`), **`aimee-kb`** (`Dockerfile`), and **`aimee-server+kb`**
 (`Dockerfile.combined`). Every stack also brings up a `pgvector/pgvector:pg16`
-Postgres (DB2) and a CPU embedder sidecar (`pplx-embed-v1-4b`, 2560-dim, the
-default; `Dockerfile.embedder`); the kb auto-applies its DB2 schema (tables +
-`pg_trgm`/`vector` extensions) on first boot. The lighter `pplx-embed-v1-0.6b`
-tier is published as the `aimee-embedder-0.6b` image — set `AIMEE_EMBEDDER_IMAGE`
-to it and `embedding_dim: 1024` to use it instead.
+Postgres (DB2) and a CPU embedder sidecar (`Dockerfile.embedder`); the kb
+auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
+boot. The sidecar ships in two tiers — embedder + matching reranker baked into
+one image: the default `aimee-embedder` (4b embedder, 2560-dim, + 1b reranker)
+and the lighter `aimee-embedder-0.6b` (0.6b embedder, 1024-dim, + 400m reranker)
+for low-memory hosts. Switch with `AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`;
+trade-offs in [retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
 
 > **`docker compose ... up --build` needs no credentials.** The default build ships
 > the **server + kb** services only. The optional browser UI (`aimee-webchat`) pulls

--- a/README.md
+++ b/README.md
@@ -400,11 +400,12 @@ ship; pick by topology. They build from three reusable images: **`aimee-server`*
 (`Dockerfile.combined`). Every stack also brings up a `pgvector/pgvector:pg16`
 Postgres (DB2) and a CPU embedder sidecar (`Dockerfile.embedder`); the kb
 auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
-boot. The sidecar ships in two tiers — embedder + matching reranker baked into
-one image: the default `aimee-embedder` (4b embedder, 2560-dim, + 1b reranker)
-and the lighter `aimee-embedder-0.6b` (0.6b embedder, 1024-dim, + 400m reranker)
-for low-memory hosts. Switch with `AIMEE_EMBEDDER_IMAGE` + `embedding_dim: 1024`;
-trade-offs in [retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
+boot. The sidecar ships in two tiers — embedder + reranker baked into one image:
+the default `aimee-embedder` (`pplx-embed-v1-4b`, 2560-dim, + `ettin-reranker-1b`)
+and the lighter `aimee-embedder-0.6b` (`pplx-embed-v1-0.6b`, 1024-dim, +
+`ettin-reranker-400m`) for low-memory hosts. Switch with `AIMEE_EMBEDDER_IMAGE`
+plus `embedding_dim: 1024` (or `AIMEE_EMBEDDING_DIM=1024`). Trade-offs:
+[retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
 
 > **`docker compose ... up --build` needs no credentials.** The default build ships
 > the **server + kb** services only. The optional browser UI (`aimee-webchat`) pulls

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -10,8 +10,9 @@ sized to that model's output dimension.
 The embedder is any command that reads text on stdin and writes a JSON float
 array on stdout (`scripts/embedder-server.py` provides an HTTP sidecar wrapper
 for the HuggingFace / sentence-transformers stack). It ships in two tiers — one
-embedder paired with a matching-size cross-encoder reranker, baked into one
-image:
+embedder and a cross-encoder reranker sized to the same tier, baked into one
+image. (The reranker emits a scalar score, so its size is a quality choice, not
+a dimension constraint.)
 
 | Image | Embedder (`embedding_dim`) | Reranker |
 |-------|----------------------------|----------|
@@ -29,15 +30,15 @@ deployments.
 - Recall and ranking are noticeably better, especially on large or noisy
   corpora and on queries that lean on meaning over keywords.
 - Costs: the model weights are several GB (slower image pull and first build),
-  the 4b holds ~16 GB resident in fp32, and a CPU embed runs ~1–2 s versus the
-  0.6b's ~0.2 s. None of that is in the request hot path — embedding happens at
-  ingest and on the query, not per token — but it sets a RAM floor and slows a
-  cold re-embed of a large corpus.
+  the default image holds ~20 GB resident in fp32 (~16 GB embedder + ~4 GB
+  reranker), and a CPU embed runs ~1–2 s versus the 0.6b's ~0.2 s. None of that
+  is in the request hot path — embedding happens at ingest and on the query, not
+  per token — but it sets a RAM floor and slows a cold re-embed of a large corpus.
 
 **0.6b + 400m (light).** Pick it for laptops, small VMs, CI, or any host short
 on memory.
-- ~1 GB of weights, a couple of GB resident, embeds in ~0.2 s. Fast to pull,
-  fast to re-embed, runs anywhere.
+- ~2 GB of weights (embedder + reranker), a couple of GB resident, embeds in
+  ~0.2 s. Fits a small host; fast to pull, fast to re-embed.
 - Lower recall and weaker reranking than the 4b/1b — fine for smaller corpora
   and keyword-ish queries, weaker on large-corpus semantic search.
 
@@ -67,7 +68,8 @@ pairing with `--build-arg EMBEDDER_MODEL=… --build-arg RERANKER_MODEL=…`.
 Two config keys define the embedder:
 
 - `embedding_command` — the command that produces embeddings.
-- `embedding_dim` — the dimension that command emits (1024 or 2560). This is the
+- `embedding_dim` — the dimension that command emits (1024 for the light image,
+  2560 for the default; any value for a custom-built image). This is the
   single source of truth for vector-column dimensions.
 
 Keep the two in sync: `embedding_dim` must equal the dimension

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -9,16 +9,58 @@ sized to that model's output dimension.
 
 The embedder is any command that reads text on stdin and writes a JSON float
 array on stdout (`scripts/embedder-server.py` provides an HTTP sidecar wrapper
-for the HuggingFace / sentence-transformers stack). Two reference models:
+for the HuggingFace / sentence-transformers stack). It ships in two tiers — one
+embedder paired with a matching-size cross-encoder reranker, baked into one
+image:
 
-| Model | `embedding_dim` | Notes |
-|-------|-----------------|-------|
-| `pplx-embed-v1-4b` (default) | `2560` | Higher quality; the default, since embedding throughput is not the bottleneck. Needs more RAM/compute. Exceeds pgvector's 2000-dim `vector` index cap, which is why all columns use `halfvec`. |
-| `pplx-embed-v1-0.6b` | `1024` | Lighter tier — fast, low memory. Published as the `aimee-embedder-0.6b` image. |
+| Image | Embedder (`embedding_dim`) | Reranker |
+|-------|----------------------------|----------|
+| `aimee-embedder` (default) | `pplx-embed-v1-4b` (`2560`) | `ettin-reranker-1b` |
+| `aimee-embedder-0.6b` | `pplx-embed-v1-0.6b` (`1024`) | `ettin-reranker-400m` |
 
-Pick one. The default `aimee-embedder` image bakes the 4B. To run the lighter
-0.6B instead, point at the `aimee-embedder-0.6b` image (`AIMEE_EMBEDDER_IMAGE`)
-and set `embedding_dim: 1024` — no rebuild needed.
+### Choosing a tier
+
+Run one tier per deployment. The 4b/1b image is the default; the 0.6b/400m
+image is for hosts that can't spare the memory.
+
+**4b + 1b (default).** Best retrieval quality and reranking. Pick it when the
+host has the RAM and embedding throughput isn't your bottleneck — most server
+deployments.
+- Recall and ranking are noticeably better, especially on large or noisy
+  corpora and on queries that lean on meaning over keywords.
+- Costs: the model weights are several GB (slower image pull and first build),
+  the 4b holds ~16 GB resident in fp32, and a CPU embed runs ~1–2 s versus the
+  0.6b's ~0.2 s. None of that is in the request hot path — embedding happens at
+  ingest and on the query, not per token — but it sets a RAM floor and slows a
+  cold re-embed of a large corpus.
+
+**0.6b + 400m (light).** Pick it for laptops, small VMs, CI, or any host short
+on memory.
+- ~1 GB of weights, a couple of GB resident, embeds in ~0.2 s. Fast to pull,
+  fast to re-embed, runs anywhere.
+- Lower recall and weaker reranking than the 4b/1b — fine for smaller corpora
+  and keyword-ish queries, weaker on large-corpus semantic search.
+
+Rule of thumb: default to 4b/1b; drop to 0.6b/400m only when RAM or pull size
+forces it. The retrieval pipeline (hybrid search, reranking, fusion) is
+identical either way — only the model sizes differ.
+
+### Switching tiers
+
+The default `aimee-embedder` image bakes the 4b + 1b. To run the light tier,
+point at the `aimee-embedder-0.6b` image and set the dimension to match:
+
+```bash
+AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest
+AIMEE_EMBEDDING_DIM=1024   # or embedding_dim: 1024 in aimee.yaml
+```
+
+No rebuild needed — both images are published. On an **empty** database that's
+all it takes. On a **populated** one the dimension change needs a re-embed (the
+`halfvec` columns are sized to `embedding_dim`, so 1024 and 2560 vectors can't
+share a column) — see [Switching embedders on an existing
+database](#switching-embedders-on-an-existing-database) below. Build a custom
+pairing with `--build-arg EMBEDDER_MODEL=… --build-arg RERANKER_MODEL=…`.
 
 ## Configuration
 
@@ -72,10 +114,14 @@ helpers store whatever dimension the embedder actually returns.
 `db2_init()` never reshapes an existing column (a routine schema-apply must not
 touch the corpus). If you change `embedding_dim` against a populated database,
 the schema-apply emits a `NOTICE`: the columns are still the old type/dimension
-and vector ops degrade until you migrate. Switching dimension (e.g. 0.6B ⇆ 4B,
-or off legacy 384-dim all-MiniLM) requires **re-embedding** the corpus at the
-new dimension; a same-dimension `vector → halfvec` change only needs an in-place
-cast (`deploy/migrations/2026-embed-halfvec.sql`). Back up DB2 first.
+and vector ops degrade until you migrate. Switching dimension (0.6b 1024 ⇆ 4b
+2560) requires **re-embedding** the corpus at the new dimension. Drop the
+embedding rows (`kb_embeddings`, `memory_embeddings`, the `curator_*_vectors`),
+restart the kb so it recreates the columns at the new `embedding_dim`, then let
+the curator drain re-embed — it backfills any `kb_documents` chunk missing a
+vector. Chunk text and `file_contents` are untouched. A same-dimension
+`vector → halfvec` change only needs an in-place cast
+(`deploy/migrations/2026-embed-halfvec.sql`). Back up DB2 first.
 
 ## Reranking
 


### PR DESCRIPTION
Documents the two embedder images and when to pick each — requested after the 4b/1b deploy.

- **retrieval-stack.md**: tier table (`aimee-embedder` = 4b/2560 + 1b reranker; `aimee-embedder-0.6b` = 0.6b/1024 + 400m reranker), a **Choosing a tier** section with concrete pros/cons (recall/ranking quality vs RAM ~16GB/~2GB, embed latency ~1–2s/~0.2s, image pull size), a **Switching tiers** how-to (`AIMEE_EMBEDDER_IMAGE` + `embedding_dim`), and refreshed re-embed guidance (drop embedding rows → restart → the curator drain backfills; dropped the stale all-MiniLM mention).
- **README / MANUAL**: note both tiers + the reranker pairing, link to *Choosing a tier*.

Voice: terse, concrete, no AI-isms.
