### PR TITLE
typed-fact P5a: pattern-first extraction (§6) + retraction scan (§4)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -314,7 +314,7 @@ DB2_SRCS = db2/db2_init.c db2/agent_hints.c db2/agent_outcomes.c db2/canonical_i
 DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
-DATA_SRCS = rel_types.c memory_fact_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c server/session_credentials.c cmd_describe.c \
@@ -406,7 +406,7 @@ KB_CORE_SRCS = $(filter-out db1/%,$(CORE_SRCS))
 KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
-KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
                index.c extractors.c extractors_extra.c extractors_new_langs.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)

--- a/src/headers/memory_extract_patterns.h
+++ b/src/headers/memory_extract_patterns.h
@@ -1,0 +1,73 @@
+/* memory_extract_patterns.h: pattern-first fact extraction (typed-fact §6) +
+ * the cheap retraction-signal scan (§4). P5.
+ *
+ * A pure, high-precision pass that runs BEFORE the model on ingress text:
+ * structured-value classifiers (IPv4/IPv6/MAC/email/ISO-date) and a small set of
+ * unambiguous sentence templates emit candidate triples directly, so the residual
+ * text — only what the patterns don't cover — needs the (costly) model rewrite.
+ * Pattern hits are still validated by the §1 gate (db2_fact_commit); regex
+ * precision buys cost, not a bypass of validation. The same pass cheaply flags
+ * retraction cues ("forget that", "that's wrong") for the §4 correction path.
+ *
+ * No DB / config dependency — this is deterministic logic, unit-tested directly. */
+#ifndef DEC_MEMORY_EXTRACT_PATTERNS_H
+#define DEC_MEMORY_EXTRACT_PATTERNS_H 1
+
+#include <stddef.h>
+#include "memory_ontology.h" /* memory_node_kind_t */
+#include "rel_types.h"       /* REL_TYPE_NAME_MAX */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Structured value shapes the classifier recognizes (high precision). */
+   typedef enum
+   {
+      PAT_VAL_NONE = 0,
+      PAT_VAL_IPV4,
+      PAT_VAL_IPV6,
+      PAT_VAL_MAC,
+      PAT_VAL_EMAIL,
+      PAT_VAL_DATE, /* ISO 8601 calendar date YYYY-MM-DD */
+   } pattern_value_kind_t;
+
+   /* Classify a single trimmed token as a structured value, or PAT_VAL_NONE.
+    * Whole-token match only (no substring), so precision stays high. */
+   pattern_value_kind_t memory_pattern_classify_value(const char *token);
+
+   /* The entity kind a value shape implies: IPv4/IPv6 -> NODE_IP; MAC/email/date
+    * -> NODE_SCALAR; NONE -> NODE_OTHER. */
+   memory_node_kind_t memory_pattern_value_node_kind(pattern_value_kind_t k);
+
+   /* Retraction-signal scan (§4/§6): 1 if the text carries a retraction cue
+    * ("forget", "delete that", "that's wrong", "no longer", "scratch that",
+    * "ignore that"), else 0. Case-insensitive. NULL/empty -> 0. */
+   int memory_pattern_is_retraction(const char *text);
+
+   /* A candidate triple extracted before the model. rel_type is a normalized
+    * guess; the §1 gate still decides whether it is written and how. */
+   typedef struct
+   {
+      char subject[128];
+      char rel_type[REL_TYPE_NAME_MAX];
+      char object[128];
+      memory_node_kind_t subject_kind;
+      memory_node_kind_t object_kind;
+   } pattern_triple_t;
+
+   /* Extract high-precision candidate triples from `text` into `out` (up to max).
+    * Currently recognizes the canonical personal-fact template
+    *   "my <attr> is <value>"   -> (user, <attr>, <value>)
+    * with subject_kind=NODE_PERSON and object_kind inferred from the value shape.
+    * Conservative by design (precision over recall): unmatched text yields no
+    * triple and is left for the model. Returns the count written (>=0), or -1 on
+    * bad args. */
+   int memory_extract_patterns(const char *text, pattern_triple_t *out, int max);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_MEMORY_EXTRACT_PATTERNS_H */

--- a/src/memory_extract_patterns.c
+++ b/src/memory_extract_patterns.c
@@ -1,0 +1,282 @@
+/* memory_extract_patterns.c: pattern-first fact extraction (§6) + retraction
+ * scan (§4). Pure logic, no DB. See memory_extract_patterns.h. P5. */
+#include "headers/memory_extract_patterns.h"
+#include "headers/rel_types.h" /* rel_type_normalize */
+
+#include <ctype.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <string.h>
+
+static int is_hex(char c)
+{
+   return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+}
+
+static int all_digits(const char *s, int n)
+{
+   for (int i = 0; i < n; i++)
+      if (!isdigit((unsigned char)s[i]))
+         return 0;
+   return n > 0;
+}
+
+/* An IPv4 dotted-quad: four 1-3 digit octets, each 0-255. */
+static int is_ipv4(const char *t)
+{
+   int octets = 0;
+   const char *p = t;
+   while (*p)
+   {
+      int len = 0, val = 0;
+      while (isdigit((unsigned char)p[len]))
+      {
+         val = val * 10 + (p[len] - '0');
+         len++;
+         if (len > 3)
+            return 0;
+      }
+      if (len == 0 || val > 255)
+         return 0;
+      p += len;
+      octets++;
+      if (*p == '.')
+         p++;
+      else if (*p == '\0')
+         break;
+      else
+         return 0;
+   }
+   return octets == 4;
+}
+
+/* A MAC address: exactly 6 two-hex-digit groups joined by a single consistent
+ * ':' or '-' separator (aa:bb:cc:dd:ee:ff). */
+static int is_mac(const char *t)
+{
+   size_t n = strlen(t);
+   if (n != 17)
+      return 0;
+   char sep = t[2];
+   if (sep != ':' && sep != '-')
+      return 0;
+   for (int g = 0; g < 6; g++)
+   {
+      const char *grp = t + g * 3;
+      if (!is_hex(grp[0]) || !is_hex(grp[1]))
+         return 0;
+      if (g < 5 && grp[2] != sep)
+         return 0;
+   }
+   return 1;
+}
+
+/* An IPv6 address (conservative): contains a "::" run, or exactly 8 groups of
+ * 1-4 hex digits joined by ':'. Excludes the 6-group MAC shape. */
+static int is_ipv6(const char *t)
+{
+   if (!strchr(t, ':'))
+      return 0;
+   for (const char *p = t; *p; p++)
+      if (!is_hex(*p) && *p != ':')
+         return 0;
+   if (strstr(t, "::"))
+      return 1; /* compressed form */
+   /* count colon-separated groups of 1-4 hex digits */
+   int groups = 0, len = 0;
+   for (const char *p = t;; p++)
+   {
+      if (*p == ':' || *p == '\0')
+      {
+         if (len < 1 || len > 4)
+            return 0;
+         groups++;
+         len = 0;
+         if (*p == '\0')
+            break;
+      }
+      else
+      {
+         len++;
+      }
+   }
+   return groups == 8;
+}
+
+/* An email: one '@', non-empty local part, domain with an interior dot, and only
+ * conservative characters throughout. */
+static int is_email(const char *t)
+{
+   const char *at = strchr(t, '@');
+   if (!at || at == t || strchr(at + 1, '@'))
+      return 0;
+   const char *dom = at + 1;
+   const char *dot = strchr(dom, '.');
+   if (!dot || dot == dom || dot[1] == '\0')
+      return 0;
+   for (const char *p = t; *p; p++)
+   {
+      char c = *p;
+      if (c == '@' || c == '.' || c == '-' || c == '_' || c == '+' || isalnum((unsigned char)c))
+         continue;
+      return 0;
+   }
+   return 1;
+}
+
+/* An ISO calendar date YYYY-MM-DD with in-range month/day. */
+static int is_iso_date(const char *t)
+{
+   if (strlen(t) != 10 || t[4] != '-' || t[7] != '-')
+      return 0;
+   if (!all_digits(t, 4) || !all_digits(t + 5, 2) || !all_digits(t + 8, 2))
+      return 0;
+   int mo = (t[5] - '0') * 10 + (t[6] - '0');
+   int da = (t[8] - '0') * 10 + (t[9] - '0');
+   return mo >= 1 && mo <= 12 && da >= 1 && da <= 31;
+}
+
+pattern_value_kind_t memory_pattern_classify_value(const char *token)
+{
+   if (!token || !token[0])
+      return PAT_VAL_NONE;
+   if (is_ipv4(token))
+      return PAT_VAL_IPV4;
+   if (is_mac(token))
+      return PAT_VAL_MAC;
+   if (is_ipv6(token))
+      return PAT_VAL_IPV6;
+   if (is_email(token))
+      return PAT_VAL_EMAIL;
+   if (is_iso_date(token))
+      return PAT_VAL_DATE;
+   return PAT_VAL_NONE;
+}
+
+memory_node_kind_t memory_pattern_value_node_kind(pattern_value_kind_t k)
+{
+   switch (k)
+   {
+   case PAT_VAL_IPV4:
+   case PAT_VAL_IPV6:
+      return NODE_IP;
+   case PAT_VAL_MAC:
+   case PAT_VAL_EMAIL:
+   case PAT_VAL_DATE:
+      return NODE_SCALAR;
+   default:
+      return NODE_OTHER;
+   }
+}
+
+/* Case-insensitive substring search; returns index or -1. */
+static int ci_find(const char *hay, const char *needle, int from)
+{
+   int hn = (int)strlen(hay), nn = (int)strlen(needle);
+   if (nn == 0)
+      return from;
+   for (int i = from; i + nn <= hn; i++)
+   {
+      int k = 0;
+      while (k < nn && tolower((unsigned char)hay[i + k]) == tolower((unsigned char)needle[k]))
+         k++;
+      if (k == nn)
+         return i;
+   }
+   return -1;
+}
+
+int memory_pattern_is_retraction(const char *text)
+{
+   if (!text || !text[0])
+      return 0;
+   static const char *cues[] = {"forget",      "delete that", "delete the",   "that's wrong",
+                                "thats wrong", "no longer",   "scratch that", "ignore that",
+                                "never mind",  "nevermind",   "disregard",    "that is wrong"};
+   for (size_t i = 0; i < sizeof(cues) / sizeof(cues[0]); i++)
+      if (ci_find(text, cues[i], 0) >= 0)
+         return 1;
+   return 0;
+}
+
+/* Trim leading/trailing ASCII whitespace, copying at most cap-1 bytes. */
+static void copy_trimmed(char *dst, size_t cap, const char *src, int len)
+{
+   int s = 0, e = len;
+   while (s < e && isspace((unsigned char)src[s]))
+      s++;
+   while (e > s && isspace((unsigned char)src[e - 1]))
+      e--;
+   int n = e - s;
+   if (n < 0)
+      n = 0;
+   if ((size_t)n >= cap)
+      n = (int)cap - 1;
+   memcpy(dst, src + s, (size_t)n);
+   dst[n] = '\0';
+}
+
+/* True if position i in text begins a "my" word (boundary before, space after). */
+static int is_my_word(const char *text, int i)
+{
+   if (tolower((unsigned char)text[i]) != 'm' || tolower((unsigned char)text[i + 1]) != 'y')
+      return 0;
+   if (i > 0 && (isalnum((unsigned char)text[i - 1]) || text[i - 1] == '_'))
+      return 0; /* not a word start (e.g. "army") */
+   return isspace((unsigned char)text[i + 2]);
+}
+
+int memory_extract_patterns(const char *text, pattern_triple_t *out, int max)
+{
+   if (!text || !out || max <= 0)
+      return -1;
+   int n = 0, len = (int)strlen(text);
+   for (int i = 0; i < len && n < max; i++)
+   {
+      if (!is_my_word(text, i))
+         continue;
+      int attr_start = i + 2;
+      while (attr_start < len && isspace((unsigned char)text[attr_start]))
+         attr_start++;
+      /* locate the " is " separator that ends the attribute. */
+      int is_pos = ci_find(text, " is ", attr_start);
+      if (is_pos < 0)
+         continue;
+      int val_start = is_pos + 4;
+      /* value runs to a sentence terminator or end of text. A '.', '!' or '?'
+       * ends the sentence only when followed by whitespace/end — so an interior
+       * dot (e.g. "example.com" / "192.168.1.254") does not truncate the value. */
+      int val_end = val_start;
+      while (val_end < len)
+      {
+         char c = text[val_end];
+         if (c == '\n')
+            break;
+         if ((c == '.' || c == '!' || c == '?') &&
+             (text[val_end + 1] == '\0' || isspace((unsigned char)text[val_end + 1])))
+            break;
+         val_end++;
+      }
+
+      char attr[128], value[128];
+      copy_trimmed(attr, sizeof(attr), text + attr_start, is_pos - attr_start);
+      copy_trimmed(value, sizeof(value), text + val_start, val_end - val_start);
+      if (!attr[0] || !value[0])
+      {
+         i = val_end;
+         continue;
+      }
+
+      pattern_triple_t *t = &out[n];
+      memset(t, 0, sizeof(*t));
+      snprintf(t->subject, sizeof(t->subject), "user");
+      rel_type_normalize(attr, t->rel_type, sizeof(t->rel_type));
+      snprintf(t->object, sizeof(t->object), "%s", value);
+      t->subject_kind = NODE_PERSON;
+      t->object_kind = memory_pattern_value_node_kind(memory_pattern_classify_value(value));
+      if (t->rel_type[0])
+         n++;
+      i = val_end; /* continue past this match */
+   }
+   return n;
+}

--- a/src/memory_extract_patterns.c
+++ b/src/memory_extract_patterns.c
@@ -190,9 +190,15 @@ int memory_pattern_is_retraction(const char *text)
 {
    if (!text || !text[0])
       return 0;
-   static const char *cues[] = {"forget",      "delete that", "delete the",   "that's wrong",
-                                "thats wrong", "no longer",   "scratch that", "ignore that",
-                                "never mind",  "nevermind",   "disregard",    "that is wrong"};
+   /* A recall-oriented pre-filter: a positive only flags the turn for closer
+    * inspection (the actual retraction in db2_fact_retract still needs an
+    * explicit subject + relation), so it never deletes on its own. Cues are kept
+    * specific enough to avoid the obvious false positives ("don't forget to ...").
+    */
+   static const char *cues[] = {"forget that",   "forget about", "forget my",    "forget what",
+                                "delete that",   "delete the",   "that's wrong", "thats wrong",
+                                "that is wrong", "no longer",    "scratch that", "ignore that",
+                                "never mind",    "nevermind",    "disregard"};
    for (size_t i = 0; i < sizeof(cues) / sizeof(cues[0]); i++)
       if (ci_find(text, cues[i], 0) >= 0)
          return 1;
@@ -202,6 +208,8 @@ int memory_pattern_is_retraction(const char *text)
 /* Trim leading/trailing ASCII whitespace, copying at most cap-1 bytes. */
 static void copy_trimmed(char *dst, size_t cap, const char *src, int len)
 {
+   if (cap == 0)
+      return; /* defensive: no room even for the NUL */
    int s = 0, e = len;
    while (s < e && isspace((unsigned char)src[s]))
       s++;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -51,7 +51,7 @@ TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \
                        $(OBJDIR)/cJSON.o \
                        $(PLATFORM_BASIC_OBJS)
 
-TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_gate.o $(OBJDIR)/db2/rel_types_store.o $(OBJDIR)/db2/entity_registry.o $(OBJDIR)/db2/fact_lifecycle.o $(OBJDIR)/db2/ontology_evolution.o $(OBJDIR)/learning_router.o $(OBJDIR)/learning_implicit.o $(OBJDIR)/dogfood.o $(OBJDIR)/working_profile.o $(OBJDIR)/integrity_gate.o \
+TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_gate.o $(OBJDIR)/memory_extract_patterns.o $(OBJDIR)/db2/rel_types_store.o $(OBJDIR)/db2/entity_registry.o $(OBJDIR)/db2/fact_lifecycle.o $(OBJDIR)/db2/ontology_evolution.o $(OBJDIR)/learning_router.o $(OBJDIR)/learning_implicit.o $(OBJDIR)/dogfood.o $(OBJDIR)/working_profile.o $(OBJDIR)/integrity_gate.o \
                  $(OBJDIR)/memory_core.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/posix/memory.o \
                  $(OBJDIR)/memory_logic.o $(OBJDIR)/memory_effective.o $(OBJDIR)/memory_health.o $(OBJDIR)/memory_conflict.o $(OBJDIR)/memory_context.o $(OBJDIR)/memory_assemble.o $(OBJDIR)/memory_advanced.o $(OBJDIR)/memory_prospective.o $(OBJDIR)/memory_lifecycle.o $(OBJDIR)/memory_directives.o $(OBJDIR)/memory_maintenance.o $(OBJDIR)/memory_graph.o $(OBJDIR)/memory_graph_fusion.o $(OBJDIR)/memory_scan.o $(OBJDIR)/memory_improve.o $(OBJDIR)/memory_episodes.o \
                  $(OBJDIR)/workflow_learn.o \
@@ -187,6 +187,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-entity-registry \
                $(TESTPREFIX)/unit-test-fact-lifecycle \
                $(TESTPREFIX)/unit-test-ontology-evolution \
+               $(TESTPREFIX)/unit-test-extract-patterns \
                $(TESTPREFIX)/unit-test-sandbox \
                $(TESTPREFIX)/unit-test-slop-detect \
                $(TESTPREFIX)/unit-test-vault-principal \
@@ -1453,6 +1454,11 @@ $(TESTPREFIX)/unit-test-fact-lifecycle: $(OBJDIR)/tests/test_fact_lifecycle.o \
 # typed-fact P4: self-extending ontology promotion pipeline (§2), shim.
 $(TESTPREFIX)/unit-test-ontology-evolution: $(OBJDIR)/tests/test_ontology_evolution.o \
                                $(TEST_DATA_OBJS_MOCK)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# typed-fact P5: pattern-first extraction (§6) + retraction scan (§4). Pure.
+$(TESTPREFIX)/unit-test-extract-patterns: $(OBJDIR)/tests/test_extract_patterns.o \
+                               $(OBJDIR)/memory_extract_patterns.o $(OBJDIR)/rel_types.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-request-context: $(OBJDIR)/tests/test_request_context.o \

--- a/src/tests/test_extract_patterns.c
+++ b/src/tests/test_extract_patterns.c
@@ -56,6 +56,8 @@ static void test_retraction(void)
    assert(memory_pattern_is_retraction("scratch that") == 1);
    assert(memory_pattern_is_retraction("please disregard the last thing") == 1);
    assert(memory_pattern_is_retraction("my name is Theo") == 0);
+   /* tightened cues: a bare "forget" reminder is not a retraction. */
+   assert(memory_pattern_is_retraction("don't forget to call mom") == 0);
    assert(memory_pattern_is_retraction("") == 0);
    assert(memory_pattern_is_retraction(NULL) == 0);
    printf("  PASS: test_retraction\n");

--- a/src/tests/test_extract_patterns.c
+++ b/src/tests/test_extract_patterns.c
@@ -1,0 +1,116 @@
+/* test_extract_patterns.c: typed-fact §6 pattern-first extraction + §4
+ * retraction scan. Pure logic. P5. */
+#include "../headers/memory_extract_patterns.h"
+#include "../headers/memory_ontology.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void test_classify(void)
+{
+   assert(memory_pattern_classify_value("192.168.1.254") == PAT_VAL_IPV4);
+   assert(memory_pattern_classify_value("10.0.0.1") == PAT_VAL_IPV4);
+   assert(memory_pattern_classify_value("256.0.0.1") == PAT_VAL_NONE); /* octet > 255 */
+   assert(memory_pattern_classify_value("1.2.3") == PAT_VAL_NONE);     /* only 3 octets */
+   assert(memory_pattern_classify_value("1.2.3.4.5") == PAT_VAL_NONE);
+
+   assert(memory_pattern_classify_value("aa:bb:cc:dd:ee:ff") == PAT_VAL_MAC);
+   assert(memory_pattern_classify_value("AA-BB-CC-DD-EE-FF") == PAT_VAL_MAC);
+   assert(memory_pattern_classify_value("aa:bb:cc:dd:ee") == PAT_VAL_NONE); /* 5 groups */
+
+   assert(memory_pattern_classify_value("fe80::1") == PAT_VAL_IPV6);
+   assert(memory_pattern_classify_value("2001:db8:0:0:0:0:0:1") == PAT_VAL_IPV6);
+   assert(memory_pattern_classify_value("::1") == PAT_VAL_IPV6);
+   /* a 6-group colon form is a MAC, not IPv6 (MAC checked first). */
+   assert(memory_pattern_classify_value("12:34:56:78:9a:bc") == PAT_VAL_MAC);
+
+   assert(memory_pattern_classify_value("theo@example.com") == PAT_VAL_EMAIL);
+   assert(memory_pattern_classify_value("a.b+c@sub.example.co") == PAT_VAL_EMAIL);
+   assert(memory_pattern_classify_value("not-an-email") == PAT_VAL_NONE);
+   assert(memory_pattern_classify_value("a@b") == PAT_VAL_NONE); /* no domain dot */
+
+   assert(memory_pattern_classify_value("2026-06-13") == PAT_VAL_DATE);
+   assert(memory_pattern_classify_value("2026-13-01") == PAT_VAL_NONE); /* month 13 */
+   assert(memory_pattern_classify_value("2026-06-32") == PAT_VAL_NONE); /* day 32 */
+   assert(memory_pattern_classify_value("06/13/2026") == PAT_VAL_NONE);
+
+   assert(memory_pattern_classify_value("hello") == PAT_VAL_NONE);
+   assert(memory_pattern_classify_value("") == PAT_VAL_NONE);
+   assert(memory_pattern_classify_value(NULL) == PAT_VAL_NONE);
+
+   /* value -> node kind mapping. */
+   assert(memory_pattern_value_node_kind(PAT_VAL_IPV4) == NODE_IP);
+   assert(memory_pattern_value_node_kind(PAT_VAL_IPV6) == NODE_IP);
+   assert(memory_pattern_value_node_kind(PAT_VAL_MAC) == NODE_SCALAR);
+   assert(memory_pattern_value_node_kind(PAT_VAL_EMAIL) == NODE_SCALAR);
+   assert(memory_pattern_value_node_kind(PAT_VAL_DATE) == NODE_SCALAR);
+   assert(memory_pattern_value_node_kind(PAT_VAL_NONE) == NODE_OTHER);
+   printf("  PASS: test_classify\n");
+}
+
+static void test_retraction(void)
+{
+   assert(memory_pattern_is_retraction("forget that I have a dog") == 1);
+   assert(memory_pattern_is_retraction("Actually, that's wrong") == 1);
+   assert(memory_pattern_is_retraction("I NO LONGER work there") == 1);
+   assert(memory_pattern_is_retraction("scratch that") == 1);
+   assert(memory_pattern_is_retraction("please disregard the last thing") == 1);
+   assert(memory_pattern_is_retraction("my name is Theo") == 0);
+   assert(memory_pattern_is_retraction("") == 0);
+   assert(memory_pattern_is_retraction(NULL) == 0);
+   printf("  PASS: test_retraction\n");
+}
+
+static void test_extract(void)
+{
+   pattern_triple_t t[8];
+
+   /* canonical personal-fact template, value typed by its shape. */
+   int n = memory_extract_patterns("my email is theo@example.com.", t, 8);
+   assert(n == 1);
+   assert(strcmp(t[0].subject, "user") == 0 && t[0].subject_kind == NODE_PERSON);
+   assert(strcmp(t[0].rel_type, "email") == 0);
+   assert(strcmp(t[0].object, "theo@example.com") == 0);
+   assert(t[0].object_kind == NODE_SCALAR);
+
+   /* multi-word attribute -> snake_case rel_type; IPv4 object kind. */
+   n = memory_extract_patterns("My home ip is 192.168.1.254", t, 8);
+   assert(n == 1);
+   assert(strcmp(t[0].rel_type, "home_ip") == 0);
+   assert(strcmp(t[0].object, "192.168.1.254") == 0);
+   assert(t[0].object_kind == NODE_IP);
+
+   /* free-text value -> NODE_OTHER, still a triple. */
+   n = memory_extract_patterns("my name is Theo", t, 8);
+   assert(n == 1 && strcmp(t[0].rel_type, "name") == 0 && strcmp(t[0].object, "Theo") == 0 &&
+          t[0].object_kind == NODE_OTHER);
+
+   /* two facts in one input. */
+   n = memory_extract_patterns("my dog is Rex. my city is Berlin.", t, 8);
+   assert(n == 2);
+   assert(strcmp(t[0].rel_type, "dog") == 0 && strcmp(t[0].object, "Rex") == 0);
+   assert(strcmp(t[1].rel_type, "city") == 0 && strcmp(t[1].object, "Berlin") == 0);
+
+   /* "army" must not match the "my" word boundary. */
+   assert(memory_extract_patterns("the army is large", t, 8) == 0);
+   /* empty attr / empty value yield nothing. */
+   assert(memory_extract_patterns("my is here", t, 8) == 0);
+   assert(memory_extract_patterns("my car is .", t, 8) == 0);
+   /* no template -> no triple (left for the model). */
+   assert(memory_extract_patterns("the server crashed last night", t, 8) == 0);
+
+   /* bad args. */
+   assert(memory_extract_patterns(NULL, t, 8) == -1);
+   assert(memory_extract_patterns("my x is y", NULL, 8) == -1);
+   assert(memory_extract_patterns("my x is y", t, 0) == -1);
+   printf("  PASS: test_extract\n");
+}
+
+int main(void)
+{
+   test_classify();
+   test_retraction();
+   test_extract();
+   printf("extract_patterns: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## typed-fact P5a — pattern-first extraction (§6) + retraction-signal scan (§4)

First slice of the final typed-fact phase. A pure, high-precision pass that runs **before** the model on ingress text: the cost-saving front half of §6, plus the cheap retraction-signal scan that §4 (P3) deferred. No DB/config dependency — deterministic, unit-tested directly.

### New `memory_extract_patterns.{c,h}`
- `memory_pattern_classify_value` — structured-value classifiers: IPv4 (octet-ranged), MAC (6×2-hex, single consistent sep), IPv6 (`::` or 8 groups, excludes the 6-group MAC shape), email, ISO-8601 date — whole-token only for precision. Plus `memory_pattern_value_node_kind` (IPv4/6 → `NODE_IP`; MAC/email/date → `NODE_SCALAR`).
- `memory_pattern_is_retraction` — case-insensitive scan for retraction cues ("forget", "that's wrong", "no longer", "scratch that", "disregard", …). The §4 cheap scan.
- `memory_extract_patterns` — extracts the canonical personal-fact template `my <attr> is <value>` → `(user, <attr>, <value>)`, typing the object from its value shape. Conservative (precision over recall): a sentence-final `.`/`!`/`?` ends the value but an **interior** dot (`example.com`, `192.168.1.254`) does not; `army` does not match the `my` word boundary; unmatched text yields nothing and is left for the model.

Extracted triples are **candidates only** — still validated/typed by the §1 gate (`db2_fact_commit`) when a caller routes them through it; regex precision buys cost, not a bypass of validation.

### Deferred to a later P5 slice
Wiring the pass into the ingress path — to actually short-circuit model calls and feed the gate / `db2_fact_retract` handler — needs server integration and is out of scope here.

### Verification
`make lint`, `make build-integrity`, `make -j1 server` (server+kb link clean), full `make -j4 unit-tests` all green. New `test_extract_patterns.c` covers classifier boundary/range cases + MAC-vs-IPv6 precedence, retraction cues, and the template (multi-word attr → snake_case, two-facts-per-input, interior-dot values, word-boundary, empty attr/value, bad args).
