### PR TITLE
typed-fact P5d: per-attribute PII recall-gating core (§7)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -314,7 +314,7 @@ DB2_SRCS = db2/db2_init.c db2/agent_hints.c db2/agent_outcomes.c db2/canonical_i
 DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
-DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c server/session_credentials.c cmd_describe.c \
@@ -406,7 +406,7 @@ KB_CORE_SRCS = $(filter-out db1/%,$(CORE_SRCS))
 KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
-KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
                index.c extractors.c extractors_extra.c extractors_new_langs.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)

--- a/src/headers/memory_pii_gate.h
+++ b/src/headers/memory_pii_gate.h
@@ -1,0 +1,48 @@
+/* memory_pii_gate.h: per-attribute PII sensitivity gating for recall (typed-fact
+ * §7). P5. Pure decision logic — no DB/config dependency, unit-tested directly.
+ *
+ * On the pre-injection recall path, sensitive facts are withheld from the
+ * <aimee-context> envelope unless the current turn explicitly asks for them,
+ * while identity facts needed for normal operation (preferred name, role) always
+ * pass at a low confidence floor. Sensitivity is keyed off the rel_type's
+ * `sensitivity` tier (§1), which is NOT NULL and defaults to `pii`, so a learned
+ * or seed-omitted attribute fails CLOSED (withheld) rather than leaking.
+ *
+ * This is the decision core; wiring it into ingress_preinject_* (reading each
+ * recalled fact's rel_type sensitivity + the turn text) is layered on top. */
+#ifndef DEC_MEMORY_PII_GATE_H
+#define DEC_MEMORY_PII_GATE_H 1
+
+#include "rel_types.h" /* rel_sensitivity_t */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* The minimum confidence an identity/normal fact needs to be injected (§7). */
+#define PII_GATE_CONFIDENCE_FLOOR 0.4
+
+   /* Does the turn explicitly request sensitive/PII information? Case-insensitive
+    * scan for cues ("address", "phone number", "email", "birthday", "password",
+    * "credential", "where do i live", ...). NULL/empty -> 0. */
+   int memory_pii_turn_requests_sensitive(const char *turn_text);
+
+   /* The sensitivity tier governing a rel_type: from the seed ontology, or
+    * SENS_PII (fail closed) for an unknown / unclassified type. */
+   rel_sensitivity_t memory_pii_rel_sensitivity(const char *rel_type);
+
+   /* Recall-path decision: should a fact of `sens` and `confidence` be injected
+    * into the pre-injection envelope, given whether the turn requests sensitive
+    * info? SENS_NORMAL injects at confidence >= floor; SENS_PII injects only when
+    * the turn requests it (and >= floor); SENS_SECRET never injects (credentials
+    * are served through the vault, never the pre-injection context). Returns 1 to
+    * inject, 0 to withhold. */
+   int memory_pii_should_inject(rel_sensitivity_t sens, double confidence,
+                                int turn_requests_sensitive);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_MEMORY_PII_GATE_H */

--- a/src/memory_pii_gate.c
+++ b/src/memory_pii_gate.c
@@ -54,7 +54,9 @@ rel_sensitivity_t memory_pii_rel_sensitivity(const char *rel_type)
 
 int memory_pii_should_inject(rel_sensitivity_t sens, double confidence, int turn_requests_sensitive)
 {
-   if (confidence < PII_GATE_CONFIDENCE_FLOOR)
+   /* Fail closed on a below-floor OR non-finite confidence: `confidence != confidence`
+    * is true only for NaN, which would otherwise slip past the `<` comparison. */
+   if (!(confidence >= PII_GATE_CONFIDENCE_FLOOR))
       return 0;
    switch (sens)
    {

--- a/src/memory_pii_gate.c
+++ b/src/memory_pii_gate.c
@@ -1,0 +1,69 @@
+/* memory_pii_gate.c: per-attribute PII recall gating (§7). Pure. P5.
+ * See memory_pii_gate.h. */
+#include "headers/memory_pii_gate.h"
+#include "headers/rel_types.h" /* rel_types_seed_lookup, rel_type_normalize */
+
+#include <ctype.h>
+#include <string.h>
+
+/* Case-insensitive substring search. */
+static int ci_contains(const char *hay, const char *needle)
+{
+   size_t hn = strlen(hay), nn = strlen(needle);
+   if (nn == 0)
+      return 1;
+   if (nn > hn)
+      return 0;
+   for (size_t i = 0; i + nn <= hn; i++)
+   {
+      size_t k = 0;
+      while (k < nn && tolower((unsigned char)hay[i + k]) == tolower((unsigned char)needle[k]))
+         k++;
+      if (k == nn)
+         return 1;
+   }
+   return 0;
+}
+
+int memory_pii_turn_requests_sensitive(const char *turn_text)
+{
+   if (!turn_text || !turn_text[0])
+      return 0;
+   /* Cues that the user is explicitly asking for a sensitive attribute. Kept
+    * specific enough to avoid incidental matches. */
+   static const char *cues[] = {"address",    "phone",           "email",           "birthday",
+                                "birth date", "date of birth",   "born on",         "password",
+                                "passphrase", "credential",      "secret",          "api key",
+                                "ssn",        "social security", "where do i live", "where i live",
+                                "my number",  "home ip",         "ip address"};
+   for (size_t i = 0; i < sizeof(cues) / sizeof(cues[0]); i++)
+      if (ci_contains(turn_text, cues[i]))
+         return 1;
+   return 0;
+}
+
+rel_sensitivity_t memory_pii_rel_sensitivity(const char *rel_type)
+{
+   if (!rel_type || !rel_type[0])
+      return SENS_PII; /* fail closed */
+   char norm[REL_TYPE_NAME_MAX];
+   rel_type_normalize(rel_type, norm, sizeof(norm));
+   const rel_type_def_t *def = norm[0] ? rel_types_seed_lookup(norm) : NULL;
+   return def ? def->sensitivity : SENS_PII; /* unknown -> fail closed */
+}
+
+int memory_pii_should_inject(rel_sensitivity_t sens, double confidence, int turn_requests_sensitive)
+{
+   if (confidence < PII_GATE_CONFIDENCE_FLOOR)
+      return 0;
+   switch (sens)
+   {
+   case SENS_NORMAL:
+      return 1; /* identity/operational facts always pass above the floor */
+   case SENS_PII:
+      return turn_requests_sensitive ? 1 : 0; /* withheld unless explicitly asked */
+   case SENS_SECRET:
+   default:
+      return 0; /* credentials never go through pre-injection */
+   }
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -189,6 +189,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-ontology-evolution \
                $(TESTPREFIX)/unit-test-extract-patterns \
                $(TESTPREFIX)/unit-test-fact-ingest \
+               $(TESTPREFIX)/unit-test-pii-gate \
                $(TESTPREFIX)/unit-test-sandbox \
                $(TESTPREFIX)/unit-test-slop-detect \
                $(TESTPREFIX)/unit-test-vault-principal \
@@ -1465,6 +1466,11 @@ $(TESTPREFIX)/unit-test-extract-patterns: $(OBJDIR)/tests/test_extract_patterns.
 # typed-fact P5: pattern-first ingest pipeline (§6 -> §1), shim.
 $(TESTPREFIX)/unit-test-fact-ingest: $(OBJDIR)/tests/test_fact_ingest.o \
                                $(TEST_DATA_OBJS_MOCK)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# typed-fact P5: per-attribute PII recall gating (§7). Pure.
+$(TESTPREFIX)/unit-test-pii-gate: $(OBJDIR)/tests/test_pii_gate.o \
+                               $(OBJDIR)/memory_pii_gate.o $(OBJDIR)/rel_types.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-request-context: $(OBJDIR)/tests/test_request_context.o \

--- a/src/tests/test_pii_gate.c
+++ b/src/tests/test_pii_gate.c
@@ -1,0 +1,41 @@
+/* test_pii_gate.c: typed-fact §7 per-attribute PII recall gating. Pure. P5. */
+#include "../headers/memory_pii_gate.h"
+#include "../headers/rel_types.h"
+#include <assert.h>
+#include <stdio.h>
+
+int main(void)
+{
+   /* turn-requests-sensitive detection. */
+   assert(memory_pii_turn_requests_sensitive("what is my address again?") == 1);
+   assert(memory_pii_turn_requests_sensitive("remind me of my password") == 1);
+   assert(memory_pii_turn_requests_sensitive("what's my email?") == 1);
+   assert(memory_pii_turn_requests_sensitive("when is my birthday") == 1);
+   assert(memory_pii_turn_requests_sensitive("how are you today?") == 0);
+   assert(memory_pii_turn_requests_sensitive("what do i do for work") == 0);
+   assert(memory_pii_turn_requests_sensitive("") == 0);
+   assert(memory_pii_turn_requests_sensitive(NULL) == 0);
+
+   /* rel_type -> sensitivity (seed lookup; unknown fails closed to PII). */
+   assert(memory_pii_rel_sensitivity("works_for") == SENS_NORMAL);
+   assert(memory_pii_rel_sensitivity("also_known_as") == SENS_NORMAL);
+   assert(memory_pii_rel_sensitivity("age") == SENS_PII);
+   assert(memory_pii_rel_sensitivity("totally_unknown_rel") == SENS_PII); /* fail closed */
+   assert(memory_pii_rel_sensitivity("") == SENS_PII);
+   assert(memory_pii_rel_sensitivity(NULL) == SENS_PII);
+
+   /* injection decision. */
+   /* NORMAL: passes above the floor regardless of request; withheld below it. */
+   assert(memory_pii_should_inject(SENS_NORMAL, 0.5, 0) == 1);
+   assert(memory_pii_should_inject(SENS_NORMAL, 0.4, 0) == 1); /* at the floor */
+   assert(memory_pii_should_inject(SENS_NORMAL, 0.3, 1) == 0); /* below floor, even if asked */
+   /* PII: only when the turn explicitly asks (and above the floor). */
+   assert(memory_pii_should_inject(SENS_PII, 0.9, 0) == 0);
+   assert(memory_pii_should_inject(SENS_PII, 0.9, 1) == 1);
+   assert(memory_pii_should_inject(SENS_PII, 0.3, 1) == 0); /* below floor */
+   /* SECRET: never injected, even when asked at full confidence. */
+   assert(memory_pii_should_inject(SENS_SECRET, 1.0, 1) == 0);
+
+   printf("pii_gate: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_pii_gate.c
+++ b/src/tests/test_pii_gate.c
@@ -2,6 +2,7 @@
 #include "../headers/memory_pii_gate.h"
 #include "../headers/rel_types.h"
 #include <assert.h>
+#include <math.h>
 #include <stdio.h>
 
 int main(void)
@@ -35,6 +36,8 @@ int main(void)
    assert(memory_pii_should_inject(SENS_PII, 0.3, 1) == 0); /* below floor */
    /* SECRET: never injected, even when asked at full confidence. */
    assert(memory_pii_should_inject(SENS_SECRET, 1.0, 1) == 0);
+   /* non-finite confidence fails closed (must not slip past the floor check). */
+   assert(memory_pii_should_inject(SENS_NORMAL, NAN, 1) == 0);
 
    printf("pii_gate: all tests passed\n");
    return 0;


### PR DESCRIPTION
## typed-fact P5d — per-attribute PII recall-gating core (§7)

The pure decision core for §7's privacy gating: sensitive facts are withheld from the pre-injection `<aimee-context>` envelope unless the turn explicitly asks for them, while identity/operational facts pass at a low confidence floor. Mirrors the P5a pattern (pure module, hookup deferred).

### New `memory_pii_gate.{c,h}` (no DB/config dependency)
- `memory_pii_turn_requests_sensitive` — case-insensitive scan for explicit PII requests ("address", "password", "email", "birthday", "ip address", …).
- `memory_pii_rel_sensitivity` — the rel_type's sensitivity tier from the seed ontology, or `SENS_PII` for an unknown/unclassified type — **fails closed** so a learned/seed-omitted attribute is never injected by default.
- `memory_pii_should_inject` — `NORMAL` passes above the 0.4 floor; `PII` passes only when the turn requests it (and above the floor); `SECRET` never injects (credentials are served via the vault, never the pre-injection context).

### Deferred (live wiring)
Hooking this into `ingress_preinject_*` to filter each recalled fact by its rel_type sensitivity against the turn text.

### Verification
New `test_pii_gate.c` covers request detection (incl. false-negatives), seed sensitivity + fail-closed unknown, and the full inject/withhold matrix across NORMAL/PII/SECRET × confidence × requested. `make lint`, `make build-integrity`, `make -j1 server` (server+kb link clean), full `make -j4 unit-tests` all green.
