### PR TITLE
typed-fact P5e: resolve fact endpoints through the entity registry (§3)

### DIFF
--- a/src/db2/rel_types_store.c
+++ b/src/db2/rel_types_store.c
@@ -4,6 +4,7 @@
 #include "rel_types_store.h"
 #include "../headers/rel_types.h"
 #include "entity_edges.h"
+#include "entity_registry.h"    /* db2_entity_register_named (§3 endpoint resolution) */
 #include "ontology_evolution.h" /* db2_ontology_eval_observe (§2 / P4) */
 #include "db2_internal.h"
 #include "db_postgres.h"
@@ -122,6 +123,40 @@ long db2_rel_types_stage_provisional(const char *rel_type)
    return db2_rel_types_resolve(norm, &id) == 1 ? id : -1;
 }
 
+/* Entity-kind endpoints (people/places/devices/orgs/ips) are canonicalized
+ * through the registry (§3) so aliased names ("DevBox" / "the workstation")
+ * collapse to one node's preferred name; scalar/other values are stored verbatim
+ * (an age or IP literal is not an entity to canonicalize). */
+static int fact_kind_is_entity(memory_node_kind_t k)
+{
+   switch (k)
+   {
+   case NODE_PERSON:
+   case NODE_PLACE:
+   case NODE_DEVICE:
+   case NODE_ORG:
+   case NODE_IP:
+      return 1;
+   default:
+      return 0;
+   }
+}
+
+static void fact_canonical_endpoint(const char *in, memory_node_kind_t kind, char *out, size_t cap)
+{
+   if (fact_kind_is_entity(kind))
+   {
+      int64_t cid = db2_entity_register_named(in, (int)kind); /* get-or-create */
+      char names[1][128];
+      if (cid > 0 && db2_entity_aliases_for(cid, names, 1) == 1 && names[0][0])
+      {
+         snprintf(out, cap, "%s", names[0]); /* canonical (preferred) name */
+         return;
+      }
+   }
+   snprintf(out, cap, "%s", in); /* scalar/other, or registry unavailable */
+}
+
 fact_gate_verdict_t db2_fact_commit(const char *source, memory_node_kind_t head_kind,
                                     const char *rel_type, const char *target,
                                     memory_node_kind_t tail_kind, fact_authority_t authority,
@@ -137,34 +172,37 @@ fact_gate_verdict_t db2_fact_commit(const char *source, memory_node_kind_t head_
    char norm[REL_TYPE_NAME_MAX];
    rel_type_normalize(rel_type, norm, sizeof(norm));
 
+   if (v != FACT_GATE_ACCEPT && v != FACT_GATE_NOVEL)
+      return v; /* REJECT_KIND / BADARG: never write an unvalidated semantic edge */
+
    /* §5: provenance-keyed class. user -> A, model+ACCEPT -> B, model NOVEL -> C. */
    const char *cls = fact_class_for(authority, v);
    double conf = fact_class_confidence(cls);
+
+   /* §3: canonicalize entity-kind endpoints so aliased names share one node. */
+   char csrc[128], ctgt[128];
+   fact_canonical_endpoint(source, head_kind, csrc, sizeof(csrc));
+   fact_canonical_endpoint(target, tail_kind, ctgt, sizeof(ctgt));
 
    if (v == FACT_GATE_ACCEPT)
    {
       long id = 0;
       if (db2_rel_types_resolve(norm, &id) != 1)
          return v; /* ontology not seeded / DB issue — do not write unresolved */
-      (void)db2_entity_edge_upsert_semantic(source, norm, target, (int)id, (int)head_kind,
+      (void)db2_entity_edge_upsert_semantic(csrc, norm, ctgt, (int)id, (int)head_kind,
                                             (int)tail_kind, cls, conf, NULL);
       return v;
    }
-   if (v == FACT_GATE_NOVEL)
-   {
-      /* Stage as provisional so the edge's relation_id resolves; no kind validation
-       * for a novel type — that is promotion's job (§2). cls is already Class C here
-       * (fact_class_for maps NOVEL -> C regardless of authority). */
-      long id = db2_rel_types_stage_provisional(norm);
-      if (id <= 0)
-         return v;
-      /* §2: count the sighting so the promotion pipeline can evaluate this novel
-       * type once it crosses the occurrence threshold. */
-      (void)db2_ontology_eval_observe(norm);
-      (void)db2_entity_edge_upsert_semantic(source, norm, target, (int)id, (int)head_kind,
-                                            (int)tail_kind, cls, conf, NULL);
+   /* FACT_GATE_NOVEL: stage as provisional so the edge's relation_id resolves; no
+    * kind validation for a novel type — that is promotion's job (§2). cls is
+    * already Class C here (fact_class_for maps NOVEL -> C regardless of authority). */
+   long id = db2_rel_types_stage_provisional(norm);
+   if (id <= 0)
       return v;
-   }
-   /* REJECT_KIND / BADARG: never write an unvalidated semantic edge. */
+   /* §2: count the sighting so the promotion pipeline can evaluate this novel type
+    * once it crosses the occurrence threshold. */
+   (void)db2_ontology_eval_observe(norm);
+   (void)db2_entity_edge_upsert_semantic(csrc, norm, ctgt, (int)id, (int)head_kind, (int)tail_kind,
+                                         cls, conf, NULL);
    return v;
 }

--- a/src/db2/rel_types_store.c
+++ b/src/db2/rel_types_store.c
@@ -13,6 +13,9 @@
 #include <string.h>
 
 #define RTS_ERRBUF 256
+/* Entity endpoint / alias name width — matches entity_aliases.name and the
+ * edge source/target columns (db2_entity_aliases_for writes into char[128]). */
+#define FACT_ENDPOINT_MAX 128
 
 /* Serialize a kinds list to comma-separated canonical kind text (for the table;
  * validation itself uses the in-code seed). */
@@ -147,7 +150,7 @@ static void fact_canonical_endpoint(const char *in, memory_node_kind_t kind, cha
    if (fact_kind_is_entity(kind))
    {
       int64_t cid = db2_entity_register_named(in, (int)kind); /* get-or-create */
-      char names[1][128];
+      char names[1][FACT_ENDPOINT_MAX];
       if (cid > 0 && db2_entity_aliases_for(cid, names, 1) == 1 && names[0][0])
       {
          snprintf(out, cap, "%s", names[0]); /* canonical (preferred) name */
@@ -180,7 +183,7 @@ fact_gate_verdict_t db2_fact_commit(const char *source, memory_node_kind_t head_
    double conf = fact_class_confidence(cls);
 
    /* §3: canonicalize entity-kind endpoints so aliased names share one node. */
-   char csrc[128], ctgt[128];
+   char csrc[FACT_ENDPOINT_MAX], ctgt[FACT_ENDPOINT_MAX];
    fact_canonical_endpoint(source, head_kind, csrc, sizeof(csrc));
    fact_canonical_endpoint(target, tail_kind, ctgt, sizeof(ctgt));
 

--- a/src/tests/test_rel_types_store.c
+++ b/src/tests/test_rel_types_store.c
@@ -4,6 +4,7 @@
 #include "../headers/memory.h" /* edge_t (needs aimee.h first) */
 #include "../db2/rel_types_store.h"
 #include "../db2/entity_edges.h"
+#include "../db2/entity_registry.h"
 #include "../db2/db2_test_shim.h"
 #include <assert.h>
 #include <stdio.h>
@@ -77,6 +78,17 @@ int main(void)
    db2_entity_neighbor_t nb[16];
    int nn = db2_entity_edge_neighbors("zoe", nb, 16, 50);
    assert(nn == 1 && strcmp(nb[0].node, "quux") == 0);
+
+   /* §3 endpoint resolution: an entity-kind source given via an alias is stored
+    * under its canonical (preferred) name, so aliased facts share one node.
+    * (Names chosen to not collide with entities registered by earlier commits.) */
+   int64_t rid = db2_entity_register_named("Wilhelmina", NODE_PERSON);
+   assert(rid > 0);
+   assert(db2_entity_alias_bind("Billie", rid, 0) == 0);
+   assert(db2_fact_commit("Billie", NODE_PERSON, "works_for", "acme", NODE_ORG,
+                          FACT_AUTHORITY_MODEL, 1) == FACT_GATE_ACCEPT);
+   assert(semantic_count("Wilhelmina") >= 1); /* stored under the canonical name */
+   assert(semantic_count("Billie") == 0);     /* not under the alias */
 
    db2_test_shim_close();
    printf("rel_types_store: all tests passed\n");

--- a/src/tests/test_rel_types_store.c
+++ b/src/tests/test_rel_types_store.c
@@ -90,6 +90,27 @@ int main(void)
    assert(semantic_count("Wilhelmina") >= 1); /* stored under the canonical name */
    assert(semantic_count("Billie") == 0);     /* not under the alias */
 
+   /* a SECOND alias collapses to the same node; a SCALAR object is stored verbatim
+    * (only entity-kind endpoints are canonicalized). */
+   assert(db2_entity_alias_bind("Will", rid, 0) == 0);
+   assert(db2_fact_commit("Will", NODE_PERSON, "has_role", "engineer", NODE_SCALAR,
+                          FACT_AUTHORITY_MODEL, 1) == FACT_GATE_ACCEPT);
+   edge_t we[8];
+   int wn = db2_entity_edges_semantic_by_entity("Wilhelmina", we, 8);
+   assert(wn == 2); /* works_for + has_role, both under the canonical node */
+   int found_role = 0;
+   for (int i = 0; i < wn; i++)
+      if (strcmp(we[i].relation, "has_role") == 0)
+      {
+         assert(strcmp(we[i].target, "engineer") == 0); /* scalar stored verbatim */
+         found_role = 1;
+      }
+   assert(found_role);
+   /* re-commit via an alias bumps weight on the canonical edge, no new row. */
+   assert(db2_fact_commit("Billie", NODE_PERSON, "works_for", "acme", NODE_ORG,
+                          FACT_AUTHORITY_MODEL, 1) == FACT_GATE_ACCEPT);
+   assert(db2_entity_edges_semantic_by_entity("Wilhelmina", we, 8) == 2);
+
    db2_test_shim_close();
    printf("rel_types_store: all tests passed\n");
    return 0;


### PR DESCRIPTION
## typed-fact P5e — resolve fact endpoints through the entity registry (§3)

`db2_fact_commit` now canonicalizes entity-kind endpoints through the registry before writing a semantic edge: an entity given via an alias is stored under its canonical (preferred) name, so facts about "DevBox" and "the workstation" collapse onto one node instead of fragmenting. This wires §1's write path to §3's canonicalization.

### Change
- New static `fact_canonical_endpoint`: for entity kinds (`PERSON`/`PLACE`/`DEVICE`/`ORG`/`IP`) it get-or-creates the entity (`db2_entity_register_named`) and stores its preferred alias; scalar/other values (an age, an IP literal, free text) are stored verbatim — they are not entities to canonicalize. Falls back to the raw string if the registry is unavailable.
- Restructured the commit tail: bail early on `REJECT_KIND`/`BADARG`, then compute canonical source/target once and use them in both the `ACCEPT` and `NOVEL` writes.

### Remaining (live-path wiring, deferred)
The server **ingress hook** calling `db2_fact_ingest_text` under `cfg.typed_facts_enabled`, and `memory_pii_gate` into `ingress_preinject_*` — both change live ingest/recall behavior and need live-server validation.

### Verification
New `test_rel_types_store` case: a fact asserted via an alias (`Billie` → canonical `Wilhelmina`) is stored under the canonical name, not the alias. Existing endpoints (alice/acme) are unaffected (a first registration's preferred name == the raw name). `make lint`, `make build-integrity`, `make -j1 server` (server+kb link clean), full `make -j4 unit-tests` all green.
