### PR TITLE
ingress cost-accounting §2a: billable-model precedence resolver

### DIFF
--- a/src/headers/token_tracker.h
+++ b/src/headers/token_tracker.h
@@ -26,6 +26,15 @@ double token_estimate_cost(const char *model, const token_usage_t *usage);
  * model as unknown spend. *priced may be NULL. */
 double token_estimate_cost_ex(const char *model, const token_usage_t *usage, int *priced);
 
+/* Resolve the billable model for the audit/cost key by precedence (ingress
+ * cost-accounting §2a): provider-reported model (most specific, echoed in the
+ * response) > served model (what aimee actually routed to) > requested model
+ * (what the client asked for). Agent names are NEVER pricing keys. Returns one of
+ * the inputs verbatim, or "" when none is set (the by-model breakdown maps "" to
+ * "(unattributed)" rather than mis-pricing it). Inputs may be NULL. */
+const char *token_billable_model(const char *provider_model, const char *served_model,
+                                 const char *requested_model);
+
 /* Registry-price fallback hook. token_estimate_cost calls this (when installed)
  * on a static-table miss, so it covers registry-only providers (gemini, groq,
  * mistral) and models.dev / operator overrides. The hook is installed by a

--- a/src/server/agent_logging.c
+++ b/src/server/agent_logging.c
@@ -256,11 +256,12 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
        .cache_write_tokens = result->cache_write_tokens,
        .cache_read_tokens = result->cache_read_tokens,
    };
-   /* Bill against the model actually served to the provider, not the agent
-    * identity: an agent named "codex" may serve "gpt-5.4", and a turn-0 400 may
-    * have swapped in the fallback model. Fall back to the agent name only when
-    * no served model was recorded (e.g. the dedup cache-hit path). */
-   const char *bill_model = result->model[0] ? result->model : result->agent_name;
+   /* Bill against the real model by precedence (§2a), never the agent identity:
+    * provider-reported > served (what aimee routed to) > requested (what the client
+    * asked for). An agent named "codex" may serve "gpt-5.4"; agent names are not
+    * pricing keys. "" (all unset) lands in the by-model "(unattributed)" bucket. */
+   const char *bill_model =
+       token_billable_model(result->model, result->served_model, result->requested_model);
    double cost = token_estimate_cost(bill_model, &usage);
    /* Tagging the audit row with the active delegation id lets cost-fold attribute
     * a child's spend back to the parent without contaminating session_id sums. */

--- a/src/server/token_tracker.c
+++ b/src/server/token_tracker.c
@@ -184,6 +184,18 @@ double token_estimate_cost_ex(const char *model, const token_usage_t *usage, int
           (double)usage->cache_read_tokens * cr_mtok / 1e6;
 }
 
+const char *token_billable_model(const char *provider_model, const char *served_model,
+                                 const char *requested_model)
+{
+   if (provider_model && provider_model[0])
+      return provider_model;
+   if (served_model && served_model[0])
+      return served_model;
+   if (requested_model && requested_model[0])
+      return requested_model;
+   return "";
+}
+
 double cost_shaped_reward(int success, double cost_usd, int lambda_pct, int ref_usd_milli)
 {
    double base = success ? 1.0 : 0.0;

--- a/src/tests/test_token_tracker.c
+++ b/src/tests/test_token_tracker.c
@@ -210,6 +210,20 @@ static void test_cost_shaped_reward(void)
    PASS("cost: cost-shaped bandit reward");
 }
 
+static void test_billable_model(void)
+{
+   /* §2a precedence: provider-reported > served > requested. */
+   assert(strcmp(token_billable_model("gpt-5.4", "primary", "claude"), "gpt-5.4") == 0);
+   assert(strcmp(token_billable_model("", "served-x", "req-y"), "served-x") == 0);
+   assert(strcmp(token_billable_model("", "", "req-y"), "req-y") == 0);
+   /* nothing known -> "" (the by-model breakdown maps it to "(unattributed)"),
+    * never an agent name. */
+   assert(strcmp(token_billable_model("", "", ""), "") == 0);
+   assert(strcmp(token_billable_model(NULL, NULL, NULL), "") == 0);
+   assert(strcmp(token_billable_model(NULL, "served-z", NULL), "served-z") == 0);
+   PASS("cost: billable-model precedence (provider > served > requested)");
+}
+
 /* --- Main --- */
 
 int main(void)
@@ -217,6 +231,7 @@ int main(void)
    printf("token_tracker: unit tests\n");
    test_registry_overrides_base_keeps_cache();
    test_cost_shaped_reward();
+   test_billable_model();
 
    test_known_anthropic_model();
    test_cache_tokens_anthropic();


### PR DESCRIPTION
## ingress cost-accounting §2a — billable-model precedence resolver

The audit/cost key must resolve a real model by precedence, **not** the agent identity. Most of §2a was already shipped (`parsed_response_t`/`agent_result_t` carry provider-reported `model` + `stop_reason` + `requested_model`/`served_model`; the `by_model` breakdown already maps empty → `(unattributed)`). The residual gap was the resolution itself: `agent_log_call` billed `result->model[0] ? result->model : result->agent_name` — using the **agent name** as a pricing key and skipping `served`/`requested` entirely.

### Change
- New `token_billable_model(provider, served, requested)` in `token_tracker` (the shared cost authority): **provider-reported > served > requested**, returning `""` when none is set (lands in the `(unattributed)` bucket) — never an agent name.
- `agent_log_call` resolves `bill_model` through it: an agent named `codex` serving `gpt-5.4` is billed as `gpt-5.4`, and a Claude-Code turn that asked for one model but was served the configured primary attributes to the real served model with the requested model recorded separately (already a distinct `token_audit` column).

### Verification
`test_token_tracker` gains the precedence matrix (provider/served/requested fallthrough, all-empty → `""`, NULL-safe). `make lint`, `make build-integrity`, `make -j1 server` (server+kb link clean), full `make -j4 unit-tests` all green.

### Scope note
The larger §2 work (instrumenting the 6 synchronous ingress handlers to write `token_audit` rows) is live-server integration validated end-to-end on a deploy; this PR lands the shared, unit-testable resolver those writers (and the existing `agent_log_call`) depend on.
