### PR TITLE
typed-fact: activate the §6 ingress ingest hook (KB-side)

### DIFF
--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -8,6 +8,8 @@
 #include "aimee.h"
 #include "memory_lint.h"
 #include "config.h"
+#include "fact_ingest.h"             /* db2_fact_ingest_text (typed-fact §6 ingress hook) */
+#include "memory_extract_patterns.h" /* memory_pattern_is_retraction */
 #include "decision_log.h"
 #include "memory.h"
 #include "memory_export.h"
@@ -1214,6 +1216,18 @@ cJSON *db2_kb_service_memory_context_block_json(const char *query, const char *b
    cJSON *resp = cJSON_CreateObject();
    if (!resp)
       return NULL;
+
+   /* typed-fact §6 ingress hook: extract high-precision facts from the turn query
+    * and route them through the typed gate, KB-side where db2 is live (the server
+    * has no DB2 connection). Default-off via typed_facts_enabled. A retraction-cue
+    * turn ("forget that ...") is a correction, not an assertion, so skip ingest. */
+   if (query && query[0])
+   {
+      config_t cfg;
+      config_load(&cfg);
+      if (cfg.typed_facts_enabled && !memory_pattern_is_retraction(query))
+         (void)db2_fact_ingest_text(query, FACT_AUTHORITY_USER, 1);
+   }
 
    char *block = memory_get_context_block(query ? query : "",
                                           (block_type && block_type[0]) ? block_type : "general",


### PR DESCRIPTION
## typed-fact: activate the §6 ingress ingest hook (KB-side)

The first **live writer** of the typed-fact layer (P1–P5e shipped the dormant machinery; this turns it on).

### Where
The KB `memory.context_block` handler (`db2_kb_service_memory_context_block_json`) runs on every ingress turn, holds the turn query, and — unlike the server process — has a live DB2 connection (the D1 constraint: `learning_evidence_*`/`db2_*` only work in-process with the KB). So the §6 "extraction in ingress before the model" point is here, not server-side.

### What
`db2_fact_ingest_text(query, FACT_AUTHORITY_USER, 1)` extracts high-precision candidate facts (§6 `memory_extract_patterns`) and routes each through the typed gate `db2_fact_commit` (§1), which writes semantic edges with §5 confidence class, §3 registry-canonical endpoints, and §2 novelty tracking. Gated default-off by `typed_facts_enabled`; a retraction-cue turn (`memory_pattern_is_retraction`) is skipped (a correction, not an assertion — the retraction path is separate).

With the flag on, a turn like "my email is x@y.com" now lands a typed fact end-to-end.

### Scope / next
Recall of typed facts into the `<aimee-context>` envelope + §7 PII gating on that surface is the next slice. This PR is just the write activation. Server-side is untouched.

### Verification
Built `aimee-server` + `aimee-kb` clean (kb links the new path); `make lint`, `make build-integrity`, full `make -j4 unit-tests` green. End-to-end behavior will be validated live on `.254` after merge+deploy.
