### PR TITLE
kb search: render the hits shape in text output (No results bug)

### DIFF
--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -5625,6 +5625,32 @@ static void pt_print_delegate_launch(const char *method, cJSON *resp)
 }
 static void pt_print_kb_search(const char *method, cJSON *resp)
 {
+   (void)method;
+   /* The kb /v1/search response (relayed by kb.search) is
+    * {"hits":[{artifact_id,score,excerpt}], ...}. Render that. (Older callers
+    * returned {"results":[{file_path,heading_path,score}]} — kept as a fallback.) */
+   cJSON *hits = cJSON_GetObjectItemCaseSensitive(resp, "hits");
+   if (cJSON_IsArray(hits))
+   {
+      if (cJSON_GetArraySize(hits) == 0)
+      {
+         printf("No results.\n");
+         return;
+      }
+      cJSON *h;
+      cJSON_ArrayForEach(h, hits)
+      {
+         cJSON *score = cJSON_GetObjectItemCaseSensitive(h, "score");
+         cJSON *id = cJSON_GetObjectItemCaseSensitive(h, "artifact_id");
+         cJSON *ex = cJSON_GetObjectItemCaseSensitive(h, "excerpt");
+         printf("  %.4f  %s\n", cJSON_IsNumber(score) ? score->valuedouble : 0.0,
+                cJSON_IsString(id) ? id->valuestring : "?");
+         if (cJSON_IsString(ex) && ex->valuestring[0])
+            printf("        %.200s\n", ex->valuestring);
+      }
+      return;
+   }
+
    cJSON *results = cJSON_GetObjectItemCaseSensitive(resp, "results");
    if (!cJSON_IsArray(results) || cJSON_GetArraySize(results) == 0)
    {


### PR DESCRIPTION
`aimee kb search` printed "No results." for every query even when the kb returned hits — but `aimee --json kb search` showed them. Root cause: `pt_print_kb_search` (the text renderer for the `kb.search` RPC response) parsed a `{"results":[{file_path,heading_path,score}]}` shape, while the relayed kb `/v1/search` response is `{"hits":[{artifact_id,score,excerpt}]}`. No `results` → "No results."

Fix: render the `hits` array (artifact id, score, excerpt); keep the `results` shape as a fallback.

**Verified live on .254** (v0.2.64 server): `aimee kb search "embedding reranker retrieval" --project aimee` now lists ranked doc chunks with scores + excerpts. `unit-tests` green.
