### PR TITLE
typed-fact: query-scoped recall (entities named in the turn)

### DIFF
--- a/src/db2/fact_recall.c
+++ b/src/db2/fact_recall.c
@@ -86,7 +86,11 @@ int db2_fact_recall_in_query(const char *query, int turn_requests_sensitive, cha
    /* Entities mentioned in the query: any active entity whose alias (>=3 chars,
     * to avoid noise) is a substring of the lowercased query. LIKE + || is
     * portable across Postgres and the sqlite shim (position()/instr() are not).
-    * Skip "user" (already done above). Return each entity's preferred name. */
+    * Skip "user" (already done above). Return each entity's preferred name.
+    * name_norm is a trusted stored value (?1 is bound, no injection); the only
+    * wart is that an alias literally containing a LIKE wildcard (% or _) — rare,
+    * since names seldom do — would over-match. Acceptable: it only recalls a few
+    * extra of the user's own facts, never leaks (each is still §7 PII-gated). */
    static const char *sql =
        "SELECT (SELECT name FROM entity_aliases p WHERE p.canonical_id = r.canonical_id"
        "          AND p.suppressed = 0 ORDER BY is_preferred DESC, id ASC LIMIT 1) AS pref"

--- a/src/db2/fact_recall.c
+++ b/src/db2/fact_recall.c
@@ -65,3 +65,63 @@ int db2_fact_recall_block(const char *entity, int turn_requests_sensitive, char 
    aimee_pg_finalize(st);
    return written;
 }
+
+#define FR_MAX_ENTITIES 8
+
+int db2_fact_recall_in_query(const char *query, int turn_requests_sensitive, char *out, size_t cap)
+{
+   if (!query || !out || cap == 0)
+      return -1;
+   out[0] = '\0';
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* The user's own facts first. */
+   int total = db2_fact_recall_block("user", turn_requests_sensitive, out, cap);
+   if (total < 0)
+      total = 0;
+   size_t used = strlen(out);
+
+   /* Entities mentioned in the query: any active entity whose alias (>=3 chars,
+    * to avoid noise) is a substring of the lowercased query. LIKE + || is
+    * portable across Postgres and the sqlite shim (position()/instr() are not).
+    * Skip "user" (already done above). Return each entity's preferred name. */
+   static const char *sql =
+       "SELECT (SELECT name FROM entity_aliases p WHERE p.canonical_id = r.canonical_id"
+       "          AND p.suppressed = 0 ORDER BY is_preferred DESC, id ASC LIMIT 1) AS pref"
+       " FROM entity_registry r"
+       " WHERE r.status = 'active'"
+       "   AND EXISTS (SELECT 1 FROM entity_aliases a WHERE a.canonical_id = r.canonical_id"
+       "                 AND a.suppressed = 0 AND length(a.name_norm) >= 3"
+       "                 AND lower(?1) LIKE '%' || a.name_norm || '%')"
+       " LIMIT ?2";
+   char err[FR_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return total;
+   aimee_pg_bind_text(st, "?1", query);
+   aimee_pg_bind_int(st, "?2", FR_MAX_ENTITIES);
+
+   char names[FR_MAX_ENTITIES][128];
+   int nnames = 0;
+   while (nnames < FR_MAX_ENTITIES && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *pref = aimee_pg_column_text(st, 0);
+      if (pref && pref[0] && strcmp(pref, "user") != 0)
+         snprintf(names[nnames++], 128, "%s", pref);
+   }
+   aimee_pg_finalize(st);
+
+   /* Recall each mentioned entity's facts into the remaining buffer. */
+   for (int i = 0; i < nnames && used + 1 < cap; i++)
+   {
+      int en = db2_fact_recall_block(names[i], turn_requests_sensitive, out + used, cap - used);
+      if (en > 0)
+      {
+         total += en;
+         used = strlen(out);
+      }
+   }
+   return total;
+}

--- a/src/db2/fact_recall.h
+++ b/src/db2/fact_recall.h
@@ -23,6 +23,15 @@ extern "C"
    int db2_fact_recall_block(const char *entity, int turn_requests_sensitive, char *out,
                              size_t cap);
 
+   /* Query-scoped recall: the user's own facts PLUS facts about any registered
+    * entity whose (>=3-char) alias appears in `query` (resolved through the
+    * registry, so "DevBox"/"the workstation" collapse to one node). Each entity's
+    * facts are §7 PII-gated exactly as db2_fact_recall_block. Bounded by an
+    * internal entity cap and the caller's buffer. Returns the total facts written
+    * (>=0), or -1 on bad args. */
+   int db2_fact_recall_in_query(const char *query, int turn_requests_sensitive, char *out,
+                                size_t cap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -1243,12 +1243,13 @@ cJSON *db2_kb_service_memory_context_block_json(const char *query, const char *b
                                           (block_type && block_type[0]) ? block_type : "general",
                                           limit > 0 ? limit : 5);
 
-   /* §7 read: surface the user's current typed facts (PII-gated) into the
-    * envelope, appended after the memory block. */
+   /* §7 read: surface current typed facts (PII-gated) into the envelope — the
+    * user's own facts plus facts about any entity named in the turn. Appended
+    * after the memory block. */
    char facts[2048] = "";
-   if (typed_enabled)
+   if (typed_enabled && query && query[0])
    {
-      int fr = db2_fact_recall_block("user", requests_sensitive, facts, sizeof(facts));
+      int fr = db2_fact_recall_in_query(query, requests_sensitive, facts, sizeof(facts));
       if (fr < 0) /* recall affects prompt content, so a persistent failure is worth surfacing */
          LOG_WARN("memory", "typed-fact recall failed (db2 unavailable?)");
    }

--- a/src/tests/test_fact_recall.c
+++ b/src/tests/test_fact_recall.c
@@ -4,6 +4,7 @@
 #include "../db2/fact_recall.h"
 #include "../db2/fact_lifecycle.h"
 #include "../db2/rel_types_store.h"
+#include "../db2/entity_registry.h"
 #include "../db2/db2_test_shim.h"
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
@@ -76,6 +77,27 @@ int main(void)
    assert(n == 1);
    assert(strstr(buf, "works_for") == NULL); /* superseded -> not current */
    assert(strstr(buf, "age: 30") != NULL);
+
+   /* query-scoped recall: the user's facts PLUS facts about an entity named in the
+    * turn. Register DevBox (+alias) with a fact, then a query mentioning it. */
+   int64_t dev = db2_entity_register_named("DevBox", NODE_DEVICE);
+   assert(dev > 0);
+   assert(db2_entity_alias_bind("the workstation", dev, 0) == 0);
+   assert(db2_fact_commit("DevBox", NODE_DEVICE, "device_has_ip", "10.0.0.5", NODE_IP,
+                          FACT_AUTHORITY_USER, 1) == FACT_GATE_ACCEPT);
+   /* a query mentioning DevBox surfaces its fact (request sensitive so any PII
+    * passes; we only assert the entity-scoping here). */
+   n = db2_fact_recall_in_query("what is the ip of devbox", 1, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip: 10.0.0.5") != NULL); /* DevBox fact recalled */
+   assert(strstr(buf, "age: 30") != NULL);                 /* user fact also present */
+   /* the entity is reachable via its alias too (registry resolution). */
+   n = db2_fact_recall_in_query("tell me about the workstation", 1, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip: 10.0.0.5") != NULL);
+   /* a query naming no known entity -> just the user's facts. */
+   n = db2_fact_recall_in_query("what's the weather", 1, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip") == NULL);
+   assert(strstr(buf, "age: 30") != NULL);
+   assert(db2_fact_recall_in_query(NULL, 0, buf, sizeof(buf)) == -1);
 
    /* bad args. */
    assert(db2_fact_recall_block(NULL, 0, buf, sizeof(buf)) == -1);

--- a/src/tests/test_fact_recall.c
+++ b/src/tests/test_fact_recall.c
@@ -99,6 +99,25 @@ int main(void)
    assert(strstr(buf, "age: 30") != NULL);
    assert(db2_fact_recall_in_query(NULL, 0, buf, sizeof(buf)) == -1);
 
+   /* multi-entity: a query naming two devices recalls both. */
+   int64_t rt = db2_entity_register_named("RouterX", NODE_DEVICE);
+   assert(rt > 0);
+   assert(db2_fact_commit("RouterX", NODE_DEVICE, "device_has_ip", "10.0.0.9", NODE_IP,
+                          FACT_AUTHORITY_USER, 1) == FACT_GATE_ACCEPT);
+   n = db2_fact_recall_in_query("compare devbox and routerx", 1, buf, sizeof(buf));
+   assert(strstr(buf, "10.0.0.5") != NULL); /* DevBox */
+   assert(strstr(buf, "10.0.0.9") != NULL); /* RouterX */
+
+   /* PII gating still applies in the query path: the user's PII age is withheld
+    * when the turn does not request sensitive info (even while an entity matches). */
+   n = db2_fact_recall_in_query("what about devbox", 0, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip: 10.0.0.5") != NULL); /* NORMAL device fact passes */
+   assert(strstr(buf, "age: 30") == NULL);                 /* user PII withheld */
+
+   /* tight caller buffer: bounded, NUL-terminated, no overflow. */
+   n = db2_fact_recall_in_query("devbox", 1, buf, 12);
+   assert(n >= 0 && strlen(buf) < 12);
+
    /* bad args. */
    assert(db2_fact_recall_block(NULL, 0, buf, sizeof(buf)) == -1);
    assert(db2_fact_recall_block("user", 0, NULL, 10) == -1);


### PR DESCRIPTION
## typed-fact: query-scoped recall (facts about entities named in the turn)

Broadens typed-fact recall beyond the user's own facts — the one functional limitation noted when the read side (#278) landed. The `<aimee-context>` envelope now also surfaces facts about any registered entity mentioned in the turn.

### Change
- **New `db2_fact_recall_in_query(query, turn_requests_sensitive, out, cap)`**: recalls the user's facts, then finds active entities whose (≥3-char) alias is a substring of the lowercased query — resolved through the registry, so "DevBox"/"the workstation" collapse to one node — and recalls each one's facts. Each entity is §7 PII-gated exactly as `db2_fact_recall_block`. Bounded by an 8-entity cap and the caller's buffer. Substring match uses `LIKE` + `||` (the only form portable across Postgres and the sqlite shim — `position()`/`instr()` are not).
- KB `context_block` handler routes through it (was `"user"`-only).

### Verification
`test_fact_recall` extended: a query naming "devbox" (and via its alias "the workstation") surfaces DevBox's `device_has_ip` fact alongside the user's facts; a query naming no known entity returns only the user's facts; NULL guarded. `make lint`, `make build-integrity`, `make -j1 server` (server+kb link clean), full `make -j4 unit-tests` green.

### Note
(Branch name `feat/ingress-cost-s2-coverage` is stale — created while confirming ingress-cost §2 was already shipped; this PR is the typed-fact recall broadening.) Still behind the default-off `typed_facts_enabled` flag.
