### PR TITLE
Promote testing→main: typed-fact query recall + §4 retraction

### DIFF
--- a/src/db2/fact_ingest.c
+++ b/src/db2/fact_ingest.c
@@ -1,8 +1,14 @@
-/* fact_ingest.c: pattern-first typed-fact ingest pipeline (§6 -> §1). P5.
- * See fact_ingest.h. */
+/* fact_ingest.c: pattern-first typed-fact ingest pipeline (§6 -> §1) + the
+ * per-turn ingress orchestration (§4/§6/§7). P5. See fact_ingest.h. */
 #include "fact_ingest.h"
+#include "fact_lifecycle.h"                     /* db2_fact_retract */
+#include "fact_recall.h"                        /* db2_fact_recall_in_query */
 #include "rel_types_store.h"                    /* db2_fact_commit */
-#include "../headers/memory_extract_patterns.h" /* memory_extract_patterns */
+#include "../headers/aimee.h"                   /* config_t */
+#include "../headers/config.h"                  /* config_load */
+#include "../headers/memory_extract_patterns.h" /* memory_extract_patterns, retraction */
+#include "../headers/memory_pii_gate.h"         /* memory_pii_turn_requests_sensitive */
+#include "../headers/log.h"                     /* LOG_WARN */
 
 #define FI_MAX_TRIPLES 16
 
@@ -30,4 +36,43 @@ int db2_fact_ingest_text(const char *text, fact_authority_t authority, int enabl
          written++;
    }
    return written;
+}
+
+int db2_typed_fact_ingress(const char *query, char *facts_out, size_t facts_cap)
+{
+   if (facts_out && facts_cap)
+      facts_out[0] = '\0';
+   if (!query || !query[0])
+      return 0;
+
+   config_t cfg;
+   config_load(&cfg);
+   if (!cfg.typed_facts_enabled)
+      return 0;
+
+   int requests_sensitive = memory_pii_turn_requests_sensitive(query);
+
+   if (memory_pattern_is_retraction(query))
+   {
+      /* §4: a retraction turn corrects rather than asserts. Retract the named
+       * attribute about the user; a user retraction always wins. An imprecise attr
+       * safely no-ops (retract only affects facts that exist). */
+      char attr[128];
+      if (memory_pattern_possessive_attr(query, attr, sizeof(attr)))
+         (void)db2_fact_retract("user", attr, FACT_AUTHORITY_USER);
+   }
+   else
+   {
+      /* §6 write: extract facts from the turn and route them through the gate. */
+      (void)db2_fact_ingest_text(query, FACT_AUTHORITY_USER, 1);
+   }
+
+   /* §7 read: the user's facts + facts about any entity named in the turn,
+    * PII-gated, into the envelope. */
+   if (!facts_out || !facts_cap)
+      return 0;
+   int fr = db2_fact_recall_in_query(query, requests_sensitive, facts_out, facts_cap);
+   if (fr < 0) /* recall affects prompt content, so a persistent failure is worth surfacing */
+      LOG_WARN("memory", "typed-fact recall failed (db2 unavailable?)");
+   return fr < 0 ? 0 : fr;
 }

--- a/src/db2/fact_ingest.h
+++ b/src/db2/fact_ingest.h
@@ -30,6 +30,14 @@ extern "C"
     * db2_fact_retract() instead of ingesting the turn as new assertions. */
    int db2_fact_ingest_text(const char *text, fact_authority_t authority, int enabled);
 
+   /* The full per-turn typed-fact ingress orchestration (the KB context_block
+    * seam): when config.typed_facts_enabled, run §6 ingest — or §4 retraction on a
+    * retraction-cue turn — then write the §7-PII-gated recall block (the user's
+    * facts + facts about entities named in the turn) into facts_out. No-op with
+    * facts_out="" when the flag is off or the query is empty. Returns the number
+    * of recalled facts (>=0). */
+   int db2_typed_fact_ingress(const char *query, char *facts_out, size_t facts_cap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db2/fact_recall.c
+++ b/src/db2/fact_recall.c
@@ -65,3 +65,67 @@ int db2_fact_recall_block(const char *entity, int turn_requests_sensitive, char 
    aimee_pg_finalize(st);
    return written;
 }
+
+#define FR_MAX_ENTITIES 8
+
+int db2_fact_recall_in_query(const char *query, int turn_requests_sensitive, char *out, size_t cap)
+{
+   if (!query || !out || cap == 0)
+      return -1;
+   out[0] = '\0';
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* The user's own facts first. */
+   int total = db2_fact_recall_block("user", turn_requests_sensitive, out, cap);
+   if (total < 0)
+      total = 0;
+   size_t used = strlen(out);
+
+   /* Entities mentioned in the query: any active entity whose alias (>=3 chars,
+    * to avoid noise) is a substring of the lowercased query. LIKE + || is
+    * portable across Postgres and the sqlite shim (position()/instr() are not).
+    * Skip "user" (already done above). Return each entity's preferred name.
+    * name_norm is a trusted stored value (?1 is bound, no injection); the only
+    * wart is that an alias literally containing a LIKE wildcard (% or _) — rare,
+    * since names seldom do — would over-match. Acceptable: it only recalls a few
+    * extra of the user's own facts, never leaks (each is still §7 PII-gated). */
+   static const char *sql =
+       "SELECT (SELECT name FROM entity_aliases p WHERE p.canonical_id = r.canonical_id"
+       "          AND p.suppressed = 0 ORDER BY is_preferred DESC, id ASC LIMIT 1) AS pref"
+       " FROM entity_registry r"
+       " WHERE r.status = 'active'"
+       "   AND EXISTS (SELECT 1 FROM entity_aliases a WHERE a.canonical_id = r.canonical_id"
+       "                 AND a.suppressed = 0 AND length(a.name_norm) >= 3"
+       "                 AND lower(?1) LIKE '%' || a.name_norm || '%')"
+       " LIMIT ?2";
+   char err[FR_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return total;
+   aimee_pg_bind_text(st, "?1", query);
+   aimee_pg_bind_int(st, "?2", FR_MAX_ENTITIES);
+
+   char names[FR_MAX_ENTITIES][128];
+   int nnames = 0;
+   while (nnames < FR_MAX_ENTITIES && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *pref = aimee_pg_column_text(st, 0);
+      if (pref && pref[0] && strcmp(pref, "user") != 0)
+         snprintf(names[nnames++], 128, "%s", pref);
+   }
+   aimee_pg_finalize(st);
+
+   /* Recall each mentioned entity's facts into the remaining buffer. */
+   for (int i = 0; i < nnames && used + 1 < cap; i++)
+   {
+      int en = db2_fact_recall_block(names[i], turn_requests_sensitive, out + used, cap - used);
+      if (en > 0)
+      {
+         total += en;
+         used = strlen(out);
+      }
+   }
+   return total;
+}

--- a/src/db2/fact_recall.h
+++ b/src/db2/fact_recall.h
@@ -23,6 +23,15 @@ extern "C"
    int db2_fact_recall_block(const char *entity, int turn_requests_sensitive, char *out,
                              size_t cap);
 
+   /* Query-scoped recall: the user's own facts PLUS facts about any registered
+    * entity whose (>=3-char) alias appears in `query` (resolved through the
+    * registry, so "DevBox"/"the workstation" collapse to one node). Each entity's
+    * facts are §7 PII-gated exactly as db2_fact_recall_block. Bounded by an
+    * internal entity cap and the caller's buffer. Returns the total facts written
+    * (>=0), or -1 on bad args. */
+   int db2_fact_recall_in_query(const char *query, int turn_requests_sensitive, char *out,
+                                size_t cap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -1243,12 +1243,13 @@ cJSON *db2_kb_service_memory_context_block_json(const char *query, const char *b
                                           (block_type && block_type[0]) ? block_type : "general",
                                           limit > 0 ? limit : 5);
 
-   /* §7 read: surface the user's current typed facts (PII-gated) into the
-    * envelope, appended after the memory block. */
+   /* §7 read: surface current typed facts (PII-gated) into the envelope — the
+    * user's own facts plus facts about any entity named in the turn. Appended
+    * after the memory block. */
    char facts[2048] = "";
-   if (typed_enabled)
+   if (typed_enabled && query && query[0])
    {
-      int fr = db2_fact_recall_block("user", requests_sensitive, facts, sizeof(facts));
+      int fr = db2_fact_recall_in_query(query, requests_sensitive, facts, sizeof(facts));
       if (fr < 0) /* recall affects prompt content, so a persistent failure is worth surfacing */
          LOG_WARN("memory", "typed-fact recall failed (db2 unavailable?)");
    }

--- a/src/db2/kb_service_backend_memory.c
+++ b/src/db2/kb_service_backend_memory.c
@@ -8,11 +8,7 @@
 #include "aimee.h"
 #include "memory_lint.h"
 #include "config.h"
-#include "fact_ingest.h"             /* db2_fact_ingest_text (typed-fact §6 ingress hook) */
-#include "fact_recall.h"             /* db2_fact_recall_block (typed-fact §7 recall) */
-#include "memory_extract_patterns.h" /* memory_pattern_is_retraction */
-#include "memory_pii_gate.h"         /* memory_pii_turn_requests_sensitive */
-#include "log.h"                     /* LOG_WARN */
+#include "fact_ingest.h" /* db2_typed_fact_ingress (typed-fact §4/§6/§7 ingress) */
 #include "decision_log.h"
 #include "memory.h"
 #include "memory_export.h"
@@ -1220,39 +1216,15 @@ cJSON *db2_kb_service_memory_context_block_json(const char *query, const char *b
    if (!resp)
       return NULL;
 
-   /* typed-fact ingress, KB-side where db2 is live (the server has no DB2
-    * connection). Default-off via typed_facts_enabled. */
-   int typed_enabled = 0, requests_sensitive = 0;
-   if (query && query[0])
-   {
-      config_t cfg;
-      config_load(&cfg);
-      typed_enabled = cfg.typed_facts_enabled;
-      if (typed_enabled)
-      {
-         requests_sensitive = memory_pii_turn_requests_sensitive(query);
-         /* §6 write: extract facts from the turn and route them through the typed
-          * gate — unless the turn is a retraction cue (a correction, not an
-          * assertion). */
-         if (!memory_pattern_is_retraction(query))
-            (void)db2_fact_ingest_text(query, FACT_AUTHORITY_USER, 1);
-      }
-   }
+   /* typed-fact ingress (§4/§6/§7), KB-side where db2 is live — the server has no
+    * DB2 connection. Default-off via typed_facts_enabled; writes facts="" when off.
+    * Orchestration lives in fact_ingest so this handler stays focused + small. */
+   char facts[2048] = "";
+   (void)db2_typed_fact_ingress(query, facts, sizeof(facts));
 
    char *block = memory_get_context_block(query ? query : "",
                                           (block_type && block_type[0]) ? block_type : "general",
                                           limit > 0 ? limit : 5);
-
-   /* §7 read: surface current typed facts (PII-gated) into the envelope — the
-    * user's own facts plus facts about any entity named in the turn. Appended
-    * after the memory block. */
-   char facts[2048] = "";
-   if (typed_enabled && query && query[0])
-   {
-      int fr = db2_fact_recall_in_query(query, requests_sensitive, facts, sizeof(facts));
-      if (fr < 0) /* recall affects prompt content, so a persistent failure is worth surfacing */
-         LOG_WARN("memory", "typed-fact recall failed (db2 unavailable?)");
-   }
 
    cJSON_AddStringToObject(resp, "status", "ok");
    if (facts[0])

--- a/src/headers/memory_extract_patterns.h
+++ b/src/headers/memory_extract_patterns.h
@@ -46,6 +46,15 @@ extern "C"
     * "ignore that"), else 0. Case-insensitive. NULL/empty -> 0. */
    int memory_pattern_is_retraction(const char *text);
 
+   /* The attribute a retraction turn refers to: the word(s) after "my " up to a
+    * sentence terminator, " is "/" was ", or ~3 words. E.g. "forget my email" ->
+    * "email", "forget my favorite color please" -> "favorite color". Writes the
+    * raw attribute into out (the caller normalizes it via the rel_type path).
+    * Returns 1 when a "my <attr>" possessive is present, else 0. Pairs with
+    * memory_pattern_is_retraction to drive db2_fact_retract; because retraction
+    * only affects facts that actually exist, an imprecise attr safely no-ops. */
+   int memory_pattern_possessive_attr(const char *text, char *out, size_t out_len);
+
    /* A candidate triple extracted before the model. rel_type is a normalized
     * guess; the §1 gate still decides whether it is written and how. */
    typedef struct

--- a/src/memory_extract_patterns.c
+++ b/src/memory_extract_patterns.c
@@ -234,6 +234,61 @@ static int is_my_word(const char *text, int i)
    return isspace((unsigned char)text[i + 2]);
 }
 
+/* Case-insensitive: does `needle` start at hay[pos]? NUL-safe (a short hay stops
+ * the compare on its terminator). */
+static int ci_starts_at(const char *hay, int pos, const char *needle)
+{
+   for (int k = 0; needle[k]; k++)
+      if (tolower((unsigned char)hay[pos + k]) != tolower((unsigned char)needle[k]))
+         return 0;
+   return 1;
+}
+
+int memory_pattern_possessive_attr(const char *text, char *out, size_t out_len)
+{
+   if (!text || !out || out_len == 0)
+      return 0;
+   out[0] = '\0';
+   int len = (int)strlen(text);
+   for (int i = 0; i < len; i++)
+   {
+      if (!is_my_word(text, i))
+         continue;
+      int s = i + 2;
+      while (s < len && isspace((unsigned char)text[s]))
+         s++;
+      /* Read the attribute up to a sentence terminator, a " is "/" was " (the
+       * value clause we don't want), or after ~3 words (avoid grabbing a whole
+       * sentence like "forget my email and the rest"). */
+      int e = s, words = 0, in_word = 0;
+      while (e < len)
+      {
+         char c = text[e];
+         if (c == '.' || c == '!' || c == '?' || c == '\n')
+            break;
+         if (c == ' ')
+         {
+            if (ci_starts_at(text, e, " is ") || ci_starts_at(text, e, " was "))
+               break;
+            if (in_word)
+            {
+               if (++words >= 3)
+                  break;
+               in_word = 0;
+            }
+         }
+         else
+         {
+            in_word = 1;
+         }
+         e++;
+      }
+      copy_trimmed(out, out_len, text + s, e - s);
+      return out[0] ? 1 : 0;
+   }
+   return 0;
+}
+
 int memory_extract_patterns(const char *text, pattern_triple_t *out, int max)
 {
    if (!text || !out || max <= 0)

--- a/src/tests/test_extract_patterns.c
+++ b/src/tests/test_extract_patterns.c
@@ -108,11 +108,34 @@ static void test_extract(void)
    printf("  PASS: test_extract\n");
 }
 
+static void test_possessive_attr(void)
+{
+   char a[64];
+   assert(memory_pattern_possessive_attr("forget my email", a, sizeof(a)) == 1);
+   assert(strcmp(a, "email") == 0);
+   assert(memory_pattern_possessive_attr("please forget my favorite color", a, sizeof(a)) == 1);
+   assert(strcmp(a, "favorite color") == 0);
+   /* the value clause after "is" is not part of the attribute. */
+   assert(memory_pattern_possessive_attr("my email is wrong", a, sizeof(a)) == 1);
+   assert(strcmp(a, "email") == 0);
+   /* trailing punctuation / words capped. */
+   assert(memory_pattern_possessive_attr("forget my city.", a, sizeof(a)) == 1);
+   assert(strcmp(a, "city") == 0);
+   /* no "my <attr>" possessive -> 0. */
+   assert(memory_pattern_possessive_attr("that's wrong", a, sizeof(a)) == 0);
+   assert(memory_pattern_possessive_attr("the army is here", a, sizeof(a)) ==
+          0); /* word boundary */
+   assert(memory_pattern_possessive_attr("", a, sizeof(a)) == 0);
+   assert(memory_pattern_possessive_attr(NULL, a, sizeof(a)) == 0);
+   printf("  PASS: test_possessive_attr\n");
+}
+
 int main(void)
 {
    test_classify();
    test_retraction();
    test_extract();
+   test_possessive_attr();
    printf("extract_patterns: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_fact_ingest.c
+++ b/src/tests/test_fact_ingest.c
@@ -3,10 +3,12 @@
 #include "../headers/aimee.h"
 #include "../headers/memory.h" /* edge_t */
 #include "../db2/fact_ingest.h"
+#include "../db2/fact_lifecycle.h"
 #include "../db2/rel_types_store.h"
 #include "../db2/entity_edges.h"
 #include "../db2/ontology_evolution.h"
 #include "../db2/db2_test_shim.h"
+#include "../headers/memory_extract_patterns.h"
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -44,6 +46,16 @@ int main(void)
 
    /* No template in the text -> nothing committed. */
    assert(db2_fact_ingest_text("the server crashed last night", FACT_AUTHORITY_USER, 1) == 0);
+
+   /* §4 retraction flow (the handler's glue): a retraction turn extracts the named
+    * attribute and retracts it. After ingesting email+city, "forget my email"
+    * supersedes only the email fact. */
+   assert(db2_fact_current_count("user") == 2); /* email + city currently believed */
+   char attr[128];
+   assert(memory_pattern_is_retraction("please forget my email"));
+   assert(memory_pattern_possessive_attr("please forget my email", attr, sizeof(attr)) == 1);
+   assert(db2_fact_retract("user", attr, FACT_AUTHORITY_USER) == 1);
+   assert(db2_fact_current_count("user") == 1); /* only city remains current */
 
    /* Bad args. */
    assert(db2_fact_ingest_text(NULL, FACT_AUTHORITY_USER, 1) == -1);

--- a/src/tests/test_fact_recall.c
+++ b/src/tests/test_fact_recall.c
@@ -4,6 +4,7 @@
 #include "../db2/fact_recall.h"
 #include "../db2/fact_lifecycle.h"
 #include "../db2/rel_types_store.h"
+#include "../db2/entity_registry.h"
 #include "../db2/db2_test_shim.h"
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
@@ -76,6 +77,46 @@ int main(void)
    assert(n == 1);
    assert(strstr(buf, "works_for") == NULL); /* superseded -> not current */
    assert(strstr(buf, "age: 30") != NULL);
+
+   /* query-scoped recall: the user's facts PLUS facts about an entity named in the
+    * turn. Register DevBox (+alias) with a fact, then a query mentioning it. */
+   int64_t dev = db2_entity_register_named("DevBox", NODE_DEVICE);
+   assert(dev > 0);
+   assert(db2_entity_alias_bind("the workstation", dev, 0) == 0);
+   assert(db2_fact_commit("DevBox", NODE_DEVICE, "device_has_ip", "10.0.0.5", NODE_IP,
+                          FACT_AUTHORITY_USER, 1) == FACT_GATE_ACCEPT);
+   /* a query mentioning DevBox surfaces its fact (request sensitive so any PII
+    * passes; we only assert the entity-scoping here). */
+   n = db2_fact_recall_in_query("what is the ip of devbox", 1, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip: 10.0.0.5") != NULL); /* DevBox fact recalled */
+   assert(strstr(buf, "age: 30") != NULL);                 /* user fact also present */
+   /* the entity is reachable via its alias too (registry resolution). */
+   n = db2_fact_recall_in_query("tell me about the workstation", 1, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip: 10.0.0.5") != NULL);
+   /* a query naming no known entity -> just the user's facts. */
+   n = db2_fact_recall_in_query("what's the weather", 1, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip") == NULL);
+   assert(strstr(buf, "age: 30") != NULL);
+   assert(db2_fact_recall_in_query(NULL, 0, buf, sizeof(buf)) == -1);
+
+   /* multi-entity: a query naming two devices recalls both. */
+   int64_t rt = db2_entity_register_named("RouterX", NODE_DEVICE);
+   assert(rt > 0);
+   assert(db2_fact_commit("RouterX", NODE_DEVICE, "device_has_ip", "10.0.0.9", NODE_IP,
+                          FACT_AUTHORITY_USER, 1) == FACT_GATE_ACCEPT);
+   n = db2_fact_recall_in_query("compare devbox and routerx", 1, buf, sizeof(buf));
+   assert(strstr(buf, "10.0.0.5") != NULL); /* DevBox */
+   assert(strstr(buf, "10.0.0.9") != NULL); /* RouterX */
+
+   /* PII gating still applies in the query path: the user's PII age is withheld
+    * when the turn does not request sensitive info (even while an entity matches). */
+   n = db2_fact_recall_in_query("what about devbox", 0, buf, sizeof(buf));
+   assert(strstr(buf, "device_has_ip: 10.0.0.5") != NULL); /* NORMAL device fact passes */
+   assert(strstr(buf, "age: 30") == NULL);                 /* user PII withheld */
+
+   /* tight caller buffer: bounded, NUL-terminated, no overflow. */
+   n = db2_fact_recall_in_query("devbox", 1, buf, 12);
+   assert(n >= 0 && strlen(buf) < 12);
 
    /* bad args. */
    assert(db2_fact_recall_block(NULL, 0, buf, sizeof(buf)) == -1);


### PR DESCRIPTION
Promote testing → main: typed-fact query-scoped recall + §4 retraction wiring.

Two reviewed (roundtable APPROVE) + CI-green increments on the live-validated typed-fact layer:
- query-scoped recall (#280): recall facts about entities named in the turn, not just the user.
- §4 retraction end-to-end (#281): "forget my X" now actually retracts the named fact.

Still behind the default-off typed_facts_enabled flag. Cutting this release to deploy + live-validate the full write→recall→retract loop on .254.
