### PR TITLE
docs: runtime model-provisioning proposals (roundtable-reviewed)

### DIFF
--- a/docs/proposals/pending/curator-llm-backend.md
+++ b/docs/proposals/pending/curator-llm-backend.md
@@ -1,0 +1,234 @@
+# Proposal: Pluggable curator LLM backend (shared provider client + optional curator container)
+
+- **State:** reviewed — READY (roundtable 2026-06-14: security · architect · QA · contrarian; 4 rounds to convergence)
+- **Author:** JBailes
+- **Date:** 2026-06-12
+- **Base:** `origin/main` (v0.2.50). The retrieval pipeline is live and default-on:
+  indexer → 0.6B embedder → reranker (ettin-400m) → curator + KB-docs, with code/
+  memory/doc embeddings populating automatically during ingest (shipped v0.2.46–
+  v0.2.50). The deep-curator stages are default-on but **no-op without a configured
+  LLM** — this proposal supplies that LLM as a pluggable, decoupled backend.
+- **Scope:** a new shared LLM-provider client (extracted from `aimee-server`),
+  a kb-level operator-owned provider layer + stage→provider config, the curator
+  drain (`src/kb/kb_curator_drain.c`) routing stages through the shared client and
+  dropping the rate limiter, a new optional `aimee-curator` container
+  (`Dockerfile.curator` + publish-images matrix), and a curator block on the kb
+  `/v1/health` surface. Config: `kb_curator_provider` + per-stage overrides;
+  retire/repurpose the `kb_curator_*_command` sidecar hooks. No new capability flag.
+
+## Goal
+
+Make the curator LLM a **pluggable, decoupled, operator-owned backend**. An
+operator can run the curator on a **small model fetched at runtime** (the default
+is **Gemma 4 E4B**, which takes a one-time HF license acceptance + `HF_TOKEN`; an
+ungated Apache-2.0 model such as **Granite 4.1 3B** is the zero-touch
+alternative), a **large local model** (e.g. on their own GPU), or **any external
+API** — selected by config, with no coupling to the embedder and no dependence on the
+per-user `aimee-server` instances.
+
+## Background — the constraint that shapes everything
+
+The topology is **N `aimee-server` : 1 `aimee-kb`**. The kb is the *shared*
+knowledge service; the servers are per-user, and their provider credentials are
+**client-held / session-cached** (never on disk, never necessarily in the kb).
+The curator runs in the shared kb and curates the *shared* knowledge graph.
+
+Consequences:
+
+- The kb **cannot** borrow a particular user's server/model/credentials/budget to
+  curate shared knowledge — which one? whose cost? So the curator LLM is a
+  **kb-level / operator concern**, not a per-user one.
+- The curator credential is therefore a **single operator/deployment secret**
+  (same class as the DB2 password or `AIMEE_EMBEDDER_URL`), legitimately held in
+  kb config/env — a *different* class from the per-user client-held keys.
+
+## Design
+
+### 1. Shared LLM-provider client (DRY)
+
+`aimee-server` and `aimee-kb` have the identical problem: *given a provider def
+(`base_url` + `wire_api` + `model` + key) and a request (messages, optional
+JSON-schema/grammar), return a completion, handling wire-formats and retries.*
+That machinery lives in the server today. **Extract it into a shared module** both
+link:
+
+| Consumer | Provider defs from | Credential scope |
+|---|---|---|
+| `aimee-server` (per-user) | user config | client-held / session-cached |
+| `aimee-kb` (operator) | kb/operator config | operator deployment secret |
+
+Same calling code; only the source of provider defs + credentials differs. This
+is the foundation — §2/§4 are built on it.
+
+### 2. Curator stages → providers (two-tier default)
+
+The curator is a pipeline of stages with very different capability/cost profiles:
+
+- **Tier A — extract / index** (`extract_docs`, `extract_code`, `index_narrative`,
+  `index_claims`, `index_code_unit`, `link_artifacts`): read a chunk, emit
+  entities/claims/links as **grammar-constrained JSON**. High volume (one call per
+  chunk/unit), mechanical. A **small model is sufficient** — the grammar carries
+  format reliability.
+- **Tier B — reason / judge** (`judge`, `resolve_entities`,
+  `detect_contradictions`, `synthesize`, `promote_entity`): reason *over* the
+  extracted content. Low volume, but this is where a weak model **poisons the
+  graph**. Needs a **capable** model.
+
+Each stage maps to a **named provider**; the default is two-tier:
+
+- **Tier A → runtime-fetched small model** (default **Gemma 4 E4B**; default-on; see §3).
+- **Tier B → gated BYO-strong** — *no weak fallback*: the reasoning stages stay
+  idle until the operator configures a capable provider.
+
+Config: a default `kb_curator_provider` with per-stage/per-tier overrides
+(`kb_curator_extract_provider`, …). The existing per-stage hooks
+(`kb_curator_extract_command` / `judge_command` / `synthesize_command`) are
+**repurposed from sidecar scripts to provider references**.
+
+### 3. `aimee-curator` container (optional, swappable)
+
+A new **optional** container — the llama.cpp runtime plus a thin entrypoint, with
+**no model baked in**. The model is **fetched at runtime** into a persistent cache
+volume on first boot and reused thereafter, the way you'd run any llama.cpp /
+Ollama server:
+
+- **llama.cpp server** exposing an **OpenAI-compatible** `/v1/chat/completions`
+  with **JSON-schema / grammar** support (`--jinja`) — so it is *just a provider*
+  the kb points at.
+- **`CURATOR_MODEL=<hf repo / gguf>@<commit-sha>`** as an **env var** (not a build arg),
+  **pinned to a revision** by default (an upstream re-tag can't silently swap the
+  model). The entrypoint pulls it once into the **curator's own** model volume —
+  its **own** mount, *not* the embedder's `/opt/models`, so the two containers
+  never race to write the same cache on a cold start; later starts reuse it.
+  Pinning edge cases, resolved at boot so a real first boot never lands in a
+  silent "loading forever" trap: a `CURATOR_MODEL` with **no `@<sha>`** (a moving
+  tag) is **rejected at boot** with a "pin a revision" message; a revision that's
+  been deleted/GC'd on HF maps to `gated`/`not-found` distinctly from a network
+  `down`; and a **multi-part GGUF** (`*-00001-of-0000N.gguf`) is pulled via a
+  directory pointer (all parts) — the default ships a single-file model.
+- **No license-bundling gate, but a consent path.** We ship a *runtime*, not
+  weights, so the published image redistributes nothing — the operator fetches
+  the model (same posture as `ollama pull`), and any license applies to *them*.
+  **Gemma 4 E4B is the default Tier-A model.** But Gemma is **gated on
+  HuggingFace** (license acceptance + token), so a bare first boot 401/403s until
+  `HF_TOKEN` (with the license accepted) is set — the entrypoint must surface
+  that as a clear "this model is gated; set HF_TOKEN or pick an ungated model",
+  never a silent hang. For a turnkey ungated default, an Apache-2.0 model (e.g.
+  Granite 4.1 3B) is the alternative; E4B stays the recommended pick when the
+  operator has accepted its terms. `CURATOR_MODEL` runs operator-chosen weights —
+  treat it as trusted-by-the-operator (optional org/repo allowlist).
+- **Small image.** No multi-GB model layers — just the llama.cpp runtime. Weights
+  live in the cache volume, never in the published image (no slow release builds,
+  no 8 GB pulls).
+- **CPU by default; GPU-optional** build variant (ROCm/CUDA).
+
+Because the model is an env var and the service is "just a provider", **one image
+serves any tier**: a small instance (CPU) → Tier A (default Gemma 4 E4B); a large
+instance (`CURATOR_MODEL` → 27–32B, on a GPU) → Tier B; or skip it entirely and
+point Tier B at an external API. It rides **next to** the embedder, never inside it.
+
+**Same pattern as the embedder** (see `embedder-runtime-fetch-autodim`): a thin
+runtime image, model fetched **once** into a persistent cache volume, reused on
+every restart/recreate. The curator only differs in default and flexibility —
+Tier-A default (Gemma 4 E4B) on a small CPU instance, or `CURATOR_MODEL` → a
+27–32B (GPU) / external API for Tier B. The download is one-time and a
+provisioning-only network dependency; an air-gapped deploy pre-populates the
+cache volume. (Contrast the *old* embedder, which baked the model at build time
+for a no-runtime-network start; the cache-volume approach gives the same
+restart-time guarantee without the multi-GB image.)
+
+### 4. Curator health / observability
+
+Extend the kb `/v1/health` (already reports `db2_ok`/`embed_ok`/…) with a
+**curator block**, plus a `aimee kb curator status`-style readout:
+
+- **Per provider, a four-state contract** (not a boolean): `ready` (model loaded,
+  serving) · `loading` (model still downloading/loading — the curator container's
+  own `/health` returns 503 `{status:"loading"}`) · `gated` (fetch 401/403 — model
+  needs `HF_TOKEN`/license; **distinct** from down because the operator action
+  differs: accept-license vs investigate-network) · `down` (unreachable / erroring).
+  A bare "reachable?" TCP probe is not enough — a gated curator answers TCP but
+  401s every call.
+- **Pipeline progress:** queue depth (`kb_code_unit_jobs` pending/done), curator
+  vectors produced, last-curation-at, per-stage throughput, plus per-tier
+  `pending` and `dead_letter` counts (see the drain policy).
+
+This removes the **silent no-op** — including making "Tier B: no provider
+configured → reasoning stages idle" visible, which is the real harm from the
+curator being inherently operator-provisioned (we can't make it fully turnkey, but
+we can make its state legible).
+
+**Stage-unavailable drain policy (no silent poisoning, no unbounded retry).** A
+stage that errors or has no provider must **never** advance a chunk past it with
+a degraded/empty result — it parks the chunk at its last-completed stage (earlier
+output kept; the chunk stays retrievable, just less enriched) and retries with
+capped exponential backoff. This applies to **both tiers**:
+
+- **Tier B** (`judge`/`synthesize`/…): park in `pending_tier_b`; `/v1/health
+  .curator.tier_b = down` when no provider is reachable.
+- **Tier A** (`extract`/`index`/…) is upstream of every chunk, so a Tier-A outage
+  (e.g. the bundled E4B fetch failed) halts the pipeline — it gets the **same**
+  contract: `pending_tier_a`, `/v1/health.curator.tier_a` in the four-state set
+  above. Don't leave it implicit.
+- **Bounded retries + dead-letter.** Each stage has a max-attempt cap
+  (`kb_curator_tier_{a,b}_max_attempts`, default 5). On exceed, the chunk's stage
+  moves to a `kb_curator_dead_letter` table with its last error and stops
+  retrying — so a permanently-misconfigured provider (wrong model, revoked key,
+  schema always rejected) can't grow the queue without bound. Surface
+  `dead_letter_count > 0` as a **distinct** health field from `down`: "provider
+  up but consistently rejecting" is the easiest-to-miss, most-important state.
+  Dead-lettered chunks are visible + replayable via `aimee kb curator status` /
+  a requeue command.
+
+A reasoning/extraction stage that errors is a retry (then dead-letter), never a
+"good enough" promotion — the difference between "not curated yet" and "curated
+wrong".
+
+### 5. Remove the rate limiter
+
+Drop `kb_curator_max_jobs_per_hour` and the sliding-window ring buffer in the
+drain. The curator drains the backlog continuously, then idles. Natural throttle =
+backend throughput; cost control for a paid external backend lives at the
+**provider** (endpoint choice / its own limits), not an artificial jobs/hour cap.
+This also simplifies the drain loop.
+
+## Alternatives considered
+
+- **Curator → aimee-server → provider** (reuse the server's running providers):
+  rejected — N:1 means no single server to call, per-user credentials, and
+  borrowing a user's model/budget to curate *shared* knowledge is wrong.
+- **Bundle the generator in the embedder container:** rejected — different runtime
+  (llama.cpp/GGUF vs sentence-transformers), different resource profile, and the
+  embedder is required while the curator is optional.
+- **Sub-10B for the whole curator:** rejected for Tier B (weak reasoning poisons
+  the graph); kept for Tier A (mechanical + grammar-constrained, where small is
+  genuinely a value-add).
+- **Curation driven by the servers** (each server curates the shared kb with its
+  own model): rejected — coordination, per-user-model inconsistency, cost
+  attribution, and it re-introduces the per-user-credential coupling we are
+  removing.
+
+## Open questions
+
+1. **Default Tier-A model** — **Gemma 4 E4B** (~4.5B effective, 128K ctx,
+   strong grammar-constrained extraction, CPU/edge-friendly). Runtime fetch means
+   no license gate, so the choice is purely about extraction quality vs
+   throughput; alternatives to A/B against the *actual* curator schema (a one
+   env-var swap): Qwen3.5-4B/2B, IBM Granite 4.1 3B, SmolLM3-3B.
+2. **GPU build variant** (ROCm/CUDA) scope and whether it ships now or later.
+3. **Packaging:** is `aimee-curator` a **separate plugin** (maximally decoupled /
+   independently placeable) or a service in the existing combined plugin?
+4. **Config migration:** clean retirement vs alias of the `kb_curator_*_command`
+   sidecar hooks now that stages reference providers.
+
+## Risks
+
+- The shared-provider extraction (§1) is real surgery across `aimee-server`; must
+  preserve all existing wire-format/credential behavior. Mitigate with a surface
+  net before refactor.
+- Runtime model fetch adds a first-boot network dependency and download (one
+  time, then cached in the model volume). Mitigate: a persistent tier-bound cache
+  volume, a long health `startPeriod`, and pre-populating the volume for
+  air-gapped deploys. In exchange the published image stays small (runtime only).
+- A misconfigured Tier-B provider must fail **loudly** (§4), never silently emit
+  low-quality curation.

--- a/docs/proposals/pending/embedder-runtime-fetch-autodim.md
+++ b/docs/proposals/pending/embedder-runtime-fetch-autodim.md
@@ -1,0 +1,163 @@
+# Proposal: Embedder runtime model fetch + auto-dimension
+
+- **State:** reviewed — READY (roundtable 2026-06-14: security · architect · QA · contrarian; 4 rounds to convergence)
+- **Author:** JBailes
+- **Date:** 2026-06-14
+- **Base:** `origin/main` (v0.2.65). The embedder ships in two **baked** images
+  today: `aimee-embedder` (pplx-embed-v1-4b/2560 + ettin-reranker-1b) and
+  `aimee-embedder-0.6b` (pplx-embed-v1-0.6b/1024 + ettin-reranker-400m). The
+  dimension is carried separately by `embedding_dim` / `AIMEE_EMBEDDING_DIM`.
+- **Companion:** the curator container uses the same fetch-once pattern; see
+  [curator-llm-backend](curator-llm-backend.md).
+
+## Goal
+
+One small embedder image. The model (and its paired reranker) is **fetched at
+runtime, once**, into a persistent cache volume and reused on every restart. The
+KB **derives `embedding_dim` from the running embedder** instead of a hand-synced
+config value — so the model and the vector-column dimension can never drift apart.
+
+## Why
+
+Two problems with the current baked design:
+
+1. **Huge images, slow releases.** Baking the 4b + 1b weights makes the published
+   image multi-GB; every release rebuilds and re-downloads ~8 GB, and a deploy
+   pulls it. Two SKUs (4b and 0.6b) double the build/publish cost.
+2. **The dim is a footgun.** `embedding_dim` must match the embedder model by
+   hand. When they drift — e.g. switching 0.6b→4b, or a recreate that resized the
+   `halfvec` columns — the query embeds at one dimension and the corpus at
+   another, and search silently returns nothing. (This exact mismatch took the
+   .254 KB down until it was traced; see the kb-search builtin/dim fixes.)
+
+Runtime fetch fixes (1); auto-dimension fixes (2).
+
+## Design
+
+### 1. Thin image, fetch-once into a persistent volume
+
+`Dockerfile.embedder` ships only the runtime (Python + sentence-transformers /
+torch, or llama.cpp for GGUF) — **no `RUN … SentenceTransformer(MODEL)` build
+step**. The entrypoint, on start:
+
+- If the model is already in the cache volume (`HF_HOME=/opt/models`, the
+  existing `aimee-embedder-models` mount) **and intact**, load it — **no
+  download**. "Intact" = the resolved snapshot's tracked files (per
+  `huggingface_hub.snapshot_download` for the pinned revision) **all pass the
+  hub's LFS SHA verification**; the check is repo-agnostic (the same rule covers
+  `pplx-embed-v1-4b`, `pplx-embed-v1-0.6b`, and the reranker). A truncated/corrupt
+  or sha-mismatched cache (killed mid-fetch, fs damage) is **re-fetched** with a
+  clear "cache incomplete, re-downloading" log — never a cryptic load error.
+- Else fetch it once (sentence-transformers / `hf download`) into the volume,
+  then load.
+
+`/opt/models` is a **persistent volume dedicated to the embedder** (the existing
+`aimee-embedder-models` mount), so a `restart`, `recreate`, or image update
+reuses the cached weights — only `down -v` forces a re-download. It is **not
+shared with the curator**: the curator gets its own model volume, so the two
+containers never race to write the same cache on a cold start.
+
+- **Pin by default.** `EMBEDDER_MODEL` / `RERANKER_MODEL` default to a **specific
+  HF revision (commit sha)**, not a moving tag — so "is it present" is exact and
+  an upstream re-tag can't silently swap weights. A pin change is a visible,
+  logged re-download, not an accident.
+- `EMBEDDER_MODEL` (default `pplx-embed-v1-4b@<commit-sha>`) and `RERANKER_MODEL`
+  (default `ettin-reranker-1b-v1@<commit-sha>`) are **env vars**, already the build-args
+  today — now read at runtime. Switch to the light tier by setting
+  `EMBEDDER_MODEL=…-0.6b` + `RERANKER_MODEL=…-400m-v1`; no image swap, no rebuild.
+- **First-boot serving policy.** While the model downloads (minutes for the 4b),
+  the embedder `/health` is "loading" and the kb's `/v1/health` reports the
+  embed tier **degraded** (not failed); the kb **refuses vector search** (clear
+  "embedder warming up" error) rather than serve against a not-yet-loaded model —
+  no 0-vector fallback. It flips to ready once the model is loaded.
+- `HF_TOKEN` covers gated repos. Note the **default is gated**: Gemma-family and
+  some others require accepting a license on HF, so a bare first boot fails with
+  a 401/403 until `HF_TOKEN` (with the license accepted) is set — surface that as
+  a clear "model is gated; set HF_TOKEN or pick an ungated model" error, not a
+  silent hang. Air-gapped deploys pre-populate the volume.
+- **Model source is operator-trusted.** `EMBEDDER_MODEL` runs arbitrary fetched
+  weights (and `trust_remote_code` for some); treat it like any image the
+  operator chooses to run. Document it; optionally allow an org/repo allowlist.
+- **One published image.** `aimee-embedder-0.6b` is retired — the tier is an env
+  var, not a separate SKU.
+
+### 2. Auto-dimension handshake (the KB derives `embedding_dim`)
+
+The embedder `/health` returns `{"model":…, "dim":N}` — but **only after the
+model is loaded** (a hard requirement on the embedder: during load it reports
+"loading" / 503, never a placeholder dim, so the KB never sizes the schema to a
+not-yet-loaded model). The dimension has a strict **precedence**, enforced in
+code, not prose:
+
+> **operator pin (`embedding_dim` / `AIMEE_EMBEDDING_DIM`) > recorded
+> `schema_embedding_dim` > embedder `/health` probe.**
+
+- **Recorded dim is the source of truth once set, and authoritative for the
+  process lifetime.** The first schema apply writes `schema_embedding_dim` as a
+  first-class row (a `kb_meta` table) **in the same transaction** as the `halfvec`
+  DDL. Every startup reads that row first; the embedder probe is consulted **only
+  when no record exists** (fresh DB). Once recorded, a later embedder probe
+  reporting a different dim does **not** hot-re-derive or hot-fail — the recorded
+  dim stands; a real switch goes through the explicit reset path below.
+- **Fresh DB:** no recorded dim and no pin → the KB waits for the embedder healthy
+  *with a loaded model*, polls `/health` until `dim` is present and stable, then
+  — **holding a Postgres advisory lock** (`pg_try_advisory_lock(<const>)`) so two
+  racing KB starts/replicas can't both bootstrap — `db2_set_embedding_dim(dim)`,
+  creates the `halfvec` columns, and records `schema_embedding_dim`, all in one
+  txn. Non-lock-holders wait, then read the now-recorded row. A configurable wait
+  budget (default ~300s) fails fast with a clear error if the embedder never loads.
+- **Pin is the operator's backstop**, especially on a fresh DB: if set, it wins
+  over the probe and the KB **fails fast** when the embedder reports a different
+  dim (catches a misconfigured/stale embedder before it sizes the schema wrong).
+- **Populated DB, dim matches:** no-op.
+- **Populated DB, dim differs** (operator changed `EMBEDDER_MODEL`): refuse and
+  instruct by default — **never** silently serve a 2560 embedder against a 1024
+  store. **The re-embed is NOT automatic via the existing backfill:**
+  `kb_doc_embed_backfill` only embeds chunks with *no* `kb_embeddings` row — a
+  wrong-dimension vector is *present*, so the backfill skips it (this would
+  silently strand the corpus). The dim switch is therefore an explicit operation:
+  **drop** the embedding rows + their `halfvec` columns, recreate the columns at
+  the new dim + record the new `schema_embedding_dim`, restart the kb — *now* the
+  chunks have no vector, so the **indexer-side doc-embed pass (`kb_doc_embed_backfill`,
+  the kb ingest drain — not the curator)** re-embeds them at the new dim. Chunk
+  text and `file_contents` are untouched. This is exactly the sequence proven on
+  the .254 4b migration.
+
+  **It is a maintenance operation, not a hot migration, and is double-gated.**
+  `kb_reembed_on_dim_change` defaults **off (refuse-and-instruct)**; turning it on
+  is not enough — the reset also requires a fresh explicit confirmation
+  (`aimee kb reembed --confirm`, or a one-shot confirm token matching the current
+  state) so a stale `=on` in config can't silently nuke a corpus on the next
+  model change. While it runs, the kb reports `/v1/health = maintenance` (not
+  `ready`), search returns "re-embedding, retry shortly" (no partial/empty
+  results), and it records pre-drop vs post-backfill chunk counts — divergence
+  raises `degraded` rather than passing silently.
+
+## What this removes
+
+- The second embedder image (`aimee-embedder-0.6b`) and its CI matrix entry.
+- The multi-GB model layers in the published image (and the slow release builds).
+- The class of "search returns nothing because the dim and model drifted" bugs.
+- The need to keep `embedding_dim` manually in sync with `EMBEDDER_MODEL`.
+
+## Migration
+
+- Existing baked deploys keep working (the cached model loads the same way); the
+  volume just becomes the source of the weights instead of the image layer.
+- `.254` is already at 4b/2560 with a populated, consistent store — no change
+  unless the model is switched, which then takes the guided re-embed path above.
+- Keep `embedding_dim` honored as a pin for anyone who set it.
+
+## Risks / open questions
+
+- **First-boot network + download** (one-time, cached). Mitigate with a long
+  health `startPeriod`, the persistent volume, and air-gap pre-population.
+- **Startup ordering:** the KB must wait for the embedder `/health` before
+  sizing the schema on a fresh DB. The split stack already has the KB depend on
+  the embedder being healthy; formalize the dim probe there.
+- **Pinned reproducibility:** a baked image is byte-identical; a runtime fetch
+  can drift if upstream re-tags. Pin model revisions (HF commit sha) in the
+  default to keep it reproducible.
+- Should `embedding_dim` mismatch on a populated DB **auto-reset** (drop +
+  re-embed) or **refuse and instruct**? Default to refuse-and-instruct; make
+  auto-reset opt-in.

--- a/docs/proposals/pending/roundtable-panel-composition.md
+++ b/docs/proposals/pending/roundtable-panel-composition.md
@@ -1,0 +1,81 @@
+# Proposal: Roundtable panel composition — diverse personas, wide fan-out
+
+- **State:** draft, pending review
+- **Author:** JBailes
+- **Date:** 2026-06-14
+- **Motivation:** the roundtable review is the project's quality gate, but today
+  it under-uses what aimee already has (personas, multiple delegate models). Make
+  the panel genuinely multi-lens and as wide as the available models allow.
+
+## Problems with the panel today
+
+1. **Panelists get no persona.** The engine fans the reference models with
+   `agent_run_named(acfg, model, "review", NULL, prompt, …)` (delegate_ensemble.c
+   parallel + sequential paths) — the system-prompt/persona arg is `NULL`. Every
+   panelist runs the same `review` role with no persona framing and no
+   per-participant differentiation.
+2. **One lens, even when driven manually.** Running the panel by hand
+   (`aimee delegate review --persona reviewer --via <model>`) applies a real
+   persona, but the same one to every model → N models, one viewpoint.
+3. **`reviewer` is contrarian-only.** The built-in `reviewer` persona is
+   literally *"Senior contrarian code reviewer"* (persona.c). A panel of only
+   contrarians misses what a constructive/standard code review catches. There is
+   no built-in *neutral* reviewer persona (the neutral framing lives in the
+   `review` role template, not a persona).
+4. **Fixed small panel.** Effectively 3 reference models; no easy way to fan out
+   across every capable delegate.
+5. **Capability gates exclude models silently.** The `review` role requires
+   `caps=tools`; **codex** (gpt-5.5) advertises no `tools` capability, so it
+   can't join a review ("no configured model supports caps=tools"). Large review
+   prompts (~5k+ tokens) also trip a `min_context` gate on some models
+   (observed: mimo-2.5 on a 17 KB two-proposal prompt).
+
+## Design
+
+### 1. Per-participant personas (engine)
+The roundtable engine composes a **persona per panelist** (via
+`persona_compose_delegate_prompt`, as the manual delegate path already does) and
+passes it as the system prompt instead of `NULL`. Default to a **diverse spread**
+rather than N copies of one lens.
+
+### 2. A diverse default lineup
+Assign distinct lenses across the panel — e.g. **security, architect, QA,
+contrarian `reviewer`, and a *standard/neutral* reviewer**. The neutral reviewer
+needs either a new built-in persona ("constructive code reviewer") or a shipped
+custom persona — pairing it with the contrarian one is the point: one tries to
+break it, one assesses it as written.
+
+### 3. Custom personas in the panel
+Let the panel draw from **user/custom personas** (`~/.config/aimee/personas/`),
+not just built-ins — so a deployment can add domain reviewers (e.g. a "DB schema
+reviewer", a "release-safety reviewer") and have them seated automatically.
+
+### 4. Wide fan-out (N participants)
+Make the panel size configurable and let it **fan out across every enabled,
+capable delegate model** (minimax, mistral, mimo-2.5, codex, … ), not a fixed 3.
+`ensemble.reference_models` already lists them; the panel should default to "all
+capable" with a cap, and map personas across them (round-robin or pinned).
+
+### 5. Make codex (and tool-less models) usable as reviewers
+A document/proposal review needs no file tools. Either:
+- give the **review path a no-tools mode** (so a model without a `tools`
+  capability — like codex — can still review), and/or
+- mark codex tools-capable where appropriate.
+Plus raise/relax the `min_context` gate (or chunk the prompt) so large reviews
+don't silently drop capable models like mimo-2.5.
+
+## Open questions
+- Neutral-reviewer persona: new built-in vs shipped custom persona?
+- Persona→model assignment: pinned (codex→contrarian, claude→architect, …) vs
+  round-robin vs operator-configured?
+- Panel-size cap and cost: wide fan-out multiplies token spend — gate by
+  `ensemble.max_cost_usd` (now optional/uncapped by default) and surface the
+  per-panelist cost.
+- claude-via-CLI is primary-only by default (not delegate-eligible) — leave out
+  of the auto-panel unless `claude_cli_delegate_enabled`.
+
+## Notes
+This rides on the existing roundtable/ensemble engine (`delegate_ensemble.c`) and
+the persona system (`persona.c`, `persona_compose_delegate_prompt`); it's panel
+*composition*, not a new pipeline. Verify each model's `tools`/context
+capabilities at panel-build time and skip-with-a-log rather than fail silently.


### PR DESCRIPTION
Three pending design proposals, reviewed through a diverse roundtable panel (security / architect / QA / contrarian) to convergence over 4 rounds (R1 surfaced a real correctness bug; R4 all-READY):

- **`embedder-runtime-fetch-autodim.md`** — one thin embedder image (retire the `aimee-embedder-0.6b` SKU); env-picked tier fetched once into a persistent per-container volume; KB **auto-derives `embedding_dim`** from the embedder `/health` and records `schema_embedding_dim` (precedence: pin > recorded > probe) — eliminates the dim/model-drift bug class. Dim change on a populated DB = double-gated maintenance op.
- **`curator-llm-backend.md`** — shared LLM-provider client + optional `aimee-curator` container on the same runtime-fetch pattern; Gemma 4 E4B default (gated → consent path; Granite 4.1 3B ungated alternative) for Tier A, BYO-strong for Tier B; four-state provider health, bounded retries + dead-letter.
- **`roundtable-panel-composition.md`** — engine backlog: diverse per-participant personas, wide fan-out, codex-as-reviewer.

Docs only. Implementation starts next (embedder first).
