### PR TITLE
feat(audit): P1 wire — kb_evidence_emit flag + single-writer retrieval_event emit

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -12,7 +12,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (107)
+## CLI-settable keys (108)
 
 | Key | Type |
 |-----|------|
@@ -60,6 +60,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `integrity_enabled` | bool |
 | `kb_api_bearer_token` | string |
 | `kb_api_http_port` | int |
+| `kb_evidence_emit_enabled` | bool |
 | `kb_mining_enabled` | bool |
 | `kb_mining_min_poll_s` | int |
 | `kb_search_max_results` | int |

--- a/src/config.c
+++ b/src/config.c
@@ -778,6 +778,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->typed_facts_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "kb_evidence_emit_enabled");
+   if (cJSON_IsBool(item))
+      cfg->kb_evidence_emit_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "embedding_command");
    if (cJSON_IsString(item) && item->valuestring[0])
       snprintf(cfg->embedding_command, sizeof(cfg->embedding_command), "%s", item->valuestring);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -45,6 +45,8 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
+    {"kb_evidence_emit_enabled", offsetof(config_t, kb_evidence_emit_enabled), sizeof(int), 0,
+     CFG_BOOL},
     {"memory_rerank_command", offsetof(config_t, memory_rerank_command),
      sizeof(((config_t *)0)->memory_rerank_command), 0, CFG_STRING},
     {"memory_rerank_top_k", offsetof(config_t, memory_rerank_top_k), sizeof(int), 0, CFG_INT},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -764,6 +764,8 @@ int config_save(const config_t *cfg)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
    if (cfg->typed_facts_enabled)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
+   if (cfg->kb_evidence_emit_enabled)
+      cJSON_AddBoolToObject(root, "kb_evidence_emit_enabled", 1);
 
    /* Cross-verification */
    if (cfg->cross_verify || cfg->verify_cmd[0] || cfg->verify_role[0])

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -281,7 +281,9 @@ typedef struct config
    int ingress_preinject_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
-   int typed_facts_enabled; /* typed-fact knowledge layer master gate (default off) */
+   int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
+   int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
+                                    off) */
    int memory_pagerank_enabled;
    int memory_pagerank_iterations;
    double memory_pagerank_weight;

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -63,4 +63,19 @@ char *ingress_preinject_apply(const char *instructions, const char *envelope);
  * not auto-reset, so the HTTP layer sets it (to 0 or 1) on every request. */
 void ingress_preinject_set_request_disabled(int disabled);
 
+/* Auditable-correctness P1: the per-turn retrieval-event id (a UUID).
+ *
+ * mint generates a fresh UUID into `buf` (>=37 bytes). set/turn_id are a
+ * thread-local seam, mirroring the request-disabled override: the HTTP layer
+ * mints a turn_id and calls set() before dispatching, so the same id can be
+ * surfaced to the client (the `X-Aimee-Retrieval-Event` response header) AND
+ * keyed onto the retrieval_event emitted during context assembly. When the HTTP
+ * layer has not set one (e.g. a direct ingress_preinject_build call),
+ * ingress_preinject_build mints its own. Set per request; like the disable
+ * override it does not auto-reset — the HTTP layer sets it (or "" to clear) on
+ * every request. */
+void ingress_preinject_mint_turn_id(char *buf, size_t len);
+void ingress_preinject_set_turn_id(const char *turn_id);
+const char *ingress_preinject_turn_id(void);
+
 #endif /* DEC_INGRESS_PREINJECT_H */

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -771,6 +771,16 @@ struct cJSON *kb_client_memory_briefing(int limit_tokens);
  * memory_get_context_block(). */
 char *kb_client_memory_context_block(const char *query, const char *block_type, int limit);
 
+/* Auditable-correctness P1: ask the KB to record a single per-turn
+ * retrieval_event keyed by `turn_id` (a UUID), listing the int64 memory row ids
+ * surfaced into the turn. `role` is the recall op (e.g. "Recall"),
+ * `query_fingerprint` identifies the turn query. Returns 0 on success (event
+ * written), -1 on bad args or kb error. The KB write uses the already-merged
+ * db2_demotion_retrieval_event_write_turn (first-wins on duplicate turn_id). */
+int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *role,
+                                            const char *query_fingerprint, const int64_t *ids,
+                                            int n_ids);
+
 /* Fetch the entity profile card via aimee-kb.  Returns 0 on success
  * (|out| filled) or -1 if kb is unreachable or the entity is missing.
  * Mirrors memory_get_entity_profile(). */

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1052,6 +1052,7 @@ static const struct
     {"task.get_edges", kb_handle_task_get_edges},
     {"memory.briefing", kb_handle_memory_briefing},
     {"memory.context_block", kb_handle_memory_context_block},
+    {"evidence.emit_retrieval_event", kb_handle_evidence_emit_retrieval_event},
     {"memory.entity_profile", kb_handle_memory_entity_profile},
     {"memory.entity_edges", kb_handle_memory_entity_edges},
     {"memory.search_graph", kb_handle_memory_search_graph},

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -10,6 +10,7 @@
 #include "config.h"
 #include "db2/kb_service_backend.h"
 #include "db2/bandit.h"
+#include "db2/demotion.h" /* db2_demotion_retrieval_event_write_turn (auditable-correctness P1) */
 #include "kb_bandit.h"
 #include "kb_bandit_registry.h"
 #include "kb_service_memory.h"
@@ -739,6 +740,53 @@ int kb_handle_memory_context_block(int fd, cJSON *req)
 
    cJSON *resp = db2_kb_service_memory_context_block_json(query_j->valuestring, block_type, limit);
    return kb_reply_or_error(fd, resp, "failed to build context block");
+}
+
+/* Auditable-correctness P1: record one per-turn retrieval_event keyed by the
+ * caller-visible turn_id, listing the int64 memory rows surfaced into the turn.
+ * The emission decision (the kb_evidence_emit_enabled flag) is made server-side
+ * by the ingress before this action is called; this handler is the dumb writer.
+ * Uses the already-merged turn-keyed writer (first-wins on a duplicate turn_id).
+ * Returns {status:ok, retrieval_event_id} on success. */
+int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req)
+{
+   cJSON *turn_j = cJSON_GetObjectItemCaseSensitive(req, "turn_id");
+   cJSON *role_j = cJSON_GetObjectItemCaseSensitive(req, "role");
+   cJSON *fp_j = cJSON_GetObjectItemCaseSensitive(req, "query_fingerprint");
+   cJSON *ids_j = cJSON_GetObjectItemCaseSensitive(req, "surfaced_ids");
+   if (!cJSON_IsString(turn_j) || !turn_j->valuestring[0])
+      return kb_send_error(fd, "evidence.emit_retrieval_event requires turn_id");
+   const char *role =
+       cJSON_IsString(role_j) && role_j->valuestring[0] ? role_j->valuestring : "Recall";
+   const char *fp = cJSON_IsString(fp_j) ? fp_j->valuestring : "";
+
+   int n = cJSON_IsArray(ids_j) ? cJSON_GetArraySize(ids_j) : 0;
+   int64_t *ids = NULL;
+   int n_ids = 0;
+   if (n > 0)
+   {
+      ids = (int64_t *)calloc((size_t)n, sizeof(int64_t));
+      if (!ids)
+         return kb_send_error(fd, "out of memory");
+      for (int i = 0; i < n; i++)
+      {
+         cJSON *e = cJSON_GetArrayItem(ids_j, i);
+         if (cJSON_IsNumber(e) && e->valuedouble > 0)
+            ids[n_ids++] = (int64_t)e->valuedouble;
+      }
+   }
+
+   char ev_id[64] = "";
+   int rc = db2_demotion_retrieval_event_write_turn(turn_j->valuestring, fp, role, ids, n_ids,
+                                                    ev_id, sizeof(ev_id));
+   free(ids);
+   if (rc != 0)
+      return kb_send_error(fd, "failed to write retrieval_event");
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "retrieval_event_id", ev_id);
+   return kb_reply_or_error(fd, resp, "failed to write retrieval_event");
 }
 
 int kb_handle_memory_entity_profile(int fd, cJSON *req)

--- a/src/kb_service_memory.h
+++ b/src/kb_service_memory.h
@@ -57,6 +57,8 @@ int kb_handle_memory_link_query(int fd, cJSON *req);
 int kb_handle_memory_link_delete(int fd, cJSON *req);
 int kb_handle_memory_briefing(int fd, cJSON *req);
 int kb_handle_memory_context_block(int fd, cJSON *req);
+/* Auditable-correctness P1: record a per-turn retrieval_event keyed by turn_id. */
+int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req);
 int kb_handle_memory_entity_profile(int fd, cJSON *req);
 int kb_handle_memory_entity_edges(int fd, cJSON *req);
 int kb_handle_memory_search_graph(int fd, cJSON *req);

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -66,6 +66,22 @@ const char *ingress_preinject_turn_id(void)
    return g_turn_id;
 }
 
+/* A stable, non-reversible fingerprint of the turn query (FNV-1a 64-bit, hex).
+ * Recorded on the retrieval_event instead of the raw prompt so the audit row
+ * correlates turns (same query → same fingerprint) without persisting user
+ * prompt text. The /v1/audit/trace read never surfaces the query, so a hash
+ * loses nothing for reconstructibility. */
+static void ingress_query_fingerprint(const char *q, char *out, size_t len)
+{
+   uint64_t h = 1469598103934665603ULL; /* FNV-1a offset basis */
+   for (const unsigned char *p = (const unsigned char *)(q ? q : ""); *p; p++)
+   {
+      h ^= (uint64_t)*p;
+      h *= 1099511628211ULL; /* FNV-1a prime */
+   }
+   snprintf(out, len, "q:%016llx", (unsigned long long)h);
+}
+
 const char *ingress_preinject_confidence(double top_score)
 {
    /* Thresholds chosen so a clear top hit is "high", a plausible-but-thin match
@@ -418,13 +434,20 @@ char *ingress_preinject_build(const char *query, int request_disabled)
          ingress_preinject_mint_turn_id(minted, sizeof(minted));
          tid = minted;
       }
+      /* mems[] holds the full set of memory previews surfaced into this turn
+       * (mem_n <= the diagnose cap of 5), so recording all of them is the
+       * complete memory evidence for the turn, not a truncation. */
       int64_t ids[5];
       int n_ids = 0;
       for (int i = 0; i < mem_n && n_ids < (int)(sizeof(ids) / sizeof(ids[0])); i++)
          if (mems[i].memory.id > 0)
             ids[n_ids++] = mems[i].memory.id;
       if (n_ids > 0)
-         (void)kb_client_evidence_emit_retrieval_event(tid, "Recall", query, ids, n_ids);
+      {
+         char fp[32];
+         ingress_query_fingerprint(query, fp, sizeof(fp));
+         (void)kb_client_evidence_emit_retrieval_event(tid, "Recall", fp, ids, n_ids);
+      }
    }
 
    char *audit = ingress_preinject_read_audit_context();

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -8,6 +8,8 @@
 #include "config.h"
 #include "kb_client.h"
 #include "dstr.h"
+#include "platform_random.h"
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -32,6 +34,36 @@ static __thread int g_request_disabled = 0;
 void ingress_preinject_set_request_disabled(int disabled)
 {
    g_request_disabled = disabled ? 1 : 0;
+}
+
+/* Per-turn retrieval-event id (auditable-correctness P1). Thread-local for the
+ * same reason as the disable override: the ingress runs synchronously on the
+ * request thread. A UUID is 36 chars; 40 leaves room for the NUL. */
+static __thread char g_turn_id[40] = "";
+
+void ingress_preinject_mint_turn_id(char *buf, size_t len)
+{
+   if (!buf || len == 0)
+      return;
+   unsigned char raw[16];
+   if (platform_random_bytes(raw, sizeof(raw)) != 0)
+      memset(raw, 0, sizeof(raw));
+   snprintf(buf, len, "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+            raw[0], raw[1], raw[2], raw[3], raw[4], raw[5], raw[6], raw[7], raw[8], raw[9], raw[10],
+            raw[11], raw[12], raw[13], raw[14], raw[15]);
+}
+
+void ingress_preinject_set_turn_id(const char *turn_id)
+{
+   if (turn_id && turn_id[0])
+      snprintf(g_turn_id, sizeof(g_turn_id), "%s", turn_id);
+   else
+      g_turn_id[0] = '\0';
+}
+
+const char *ingress_preinject_turn_id(void)
+{
+   return g_turn_id;
 }
 
 const char *ingress_preinject_confidence(double top_score)
@@ -366,6 +398,33 @@ char *ingress_preinject_build(const char *query, int request_disabled)
       double ms = mem_n >= 4 ? 0.7 : (mem_n >= 2 ? 0.4 : 0.1);
       if (ms > score)
          score = ms;
+   }
+
+   /* Auditable-correctness P1: emit a single-writer, turn-keyed retrieval_event
+    * recording the memory rows surfaced into this turn's context. Default-off
+    * (kb_evidence_emit_enabled). Observation-only — the envelope and the answer
+    * are byte-identical whether or not this fires; the only added work is one
+    * synchronous KB write. The id is the one the HTTP layer minted (and surfaced
+    * to the client as X-Aimee-Retrieval-Event); if none was set (e.g. a direct
+    * build call) we mint one here so the event is still reconstructible. This is
+    * the dedicated single-writer foundation; P1.5 folds the emit into the
+    * retrieval handlers with the idempotent two-writer upsert. */
+   if (cfg.kb_evidence_emit_enabled && mem_n > 0)
+   {
+      const char *tid = ingress_preinject_turn_id();
+      char minted[40];
+      if (!tid || !tid[0])
+      {
+         ingress_preinject_mint_turn_id(minted, sizeof(minted));
+         tid = minted;
+      }
+      int64_t ids[5];
+      int n_ids = 0;
+      for (int i = 0; i < mem_n && n_ids < (int)(sizeof(ids) / sizeof(ids[0])); i++)
+         if (mems[i].memory.id > 0)
+            ids[n_ids++] = mems[i].memory.id;
+      if (n_ids > 0)
+         (void)kb_client_evidence_emit_retrieval_event(tid, "Recall", query, ids, n_ids);
    }
 
    char *audit = ingress_preinject_read_audit_context();

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1599,6 +1599,37 @@ char *kb_client_memory_context_block(const char *query, const char *block_type, 
    return out;
 }
 
+int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *role,
+                                            const char *query_fingerprint, const int64_t *ids,
+                                            int n_ids)
+{
+   if (!turn_id || !turn_id[0])
+      return -1;
+
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "turn_id", turn_id);
+   if (role && role[0])
+      cJSON_AddStringToObject(req, "role", role);
+   if (query_fingerprint && query_fingerprint[0])
+      cJSON_AddStringToObject(req, "query_fingerprint", query_fingerprint);
+   cJSON *arr = cJSON_AddArrayToObject(req, "surfaced_ids");
+   for (int i = 0; arr && ids && i < n_ids; i++)
+      cJSON_AddItemToArray(arr, cJSON_CreateNumber((double)ids[i]));
+
+   char *json = kb_v1_action_request("evidence.emit_retrieval_event", req);
+   if (!json)
+      return -1;
+
+   cJSON *resp = cJSON_Parse(json);
+   free(json);
+   if (!resp)
+      return -1;
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   int ok = cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0;
+   cJSON_Delete(resp);
+   return ok ? 0 : -1;
+}
+
 char *kb_client_memory_lint_json(void)
 {
    cJSON *req = cJSON_CreateObject();

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -69,6 +69,28 @@ const char *config_default_dir(void)
 {
    return "/tmp/aimee-test";
 }
+int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *role,
+                                            const char *query_fingerprint, const int64_t *ids,
+                                            int n_ids)
+{
+   (void)turn_id;
+   (void)role;
+   (void)query_fingerprint;
+   (void)ids;
+   (void)n_ids;
+   return 0;
+}
+/* Stub: deterministic but varying-per-call, so the mint-uniqueness assertion
+ * holds without linking the platform layer into this pure unit test. */
+int platform_random_bytes(void *buf, size_t len)
+{
+   static unsigned char ctr = 0;
+   unsigned char *p = (unsigned char *)buf;
+   for (size_t i = 0; i < len; i++)
+      p[i] = (unsigned char)(ctr + i);
+   ctr++;
+   return 0;
+}
 
 static void test_confidence_tiers(void)
 {
@@ -197,6 +219,34 @@ static void test_budgeted_build_uses_memory_previews(void)
    printf("budgeted_build_uses_memory_previews OK\n");
 }
 
+/* Auditable-correctness P1: the per-turn retrieval-event id seam. */
+static void test_turn_id_mint_and_thread_local(void)
+{
+   /* mint produces a canonical 8-4-4-4-12 UUID. */
+   char a[40], b[40];
+   ingress_preinject_mint_turn_id(a, sizeof(a));
+   ingress_preinject_mint_turn_id(b, sizeof(b));
+   assert(strlen(a) == 36);
+   assert(a[8] == '-' && a[13] == '-' && a[18] == '-' && a[23] == '-');
+   for (int i = 0; a[i]; i++)
+   {
+      char c = a[i];
+      assert(c == '-' || (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'));
+   }
+   assert(strcmp(a, b) != 0); /* random — two mints differ */
+
+   /* the thread-local set/get round-trips and clears on NULL/"" */
+   assert(ingress_preinject_turn_id()[0] == '\0'); /* unset by default */
+   ingress_preinject_set_turn_id("turn-xyz");
+   assert(strcmp(ingress_preinject_turn_id(), "turn-xyz") == 0);
+   ingress_preinject_set_turn_id(NULL);
+   assert(ingress_preinject_turn_id()[0] == '\0');
+   ingress_preinject_set_turn_id("turn-2");
+   ingress_preinject_set_turn_id("");
+   assert(ingress_preinject_turn_id()[0] == '\0');
+   printf("turn_id_mint_and_thread_local OK\n");
+}
+
 int main(void)
 {
    printf("ingress_preinject: ");
@@ -206,6 +256,7 @@ int main(void)
    test_query_from_messages();
    test_apply();
    test_budgeted_build_uses_memory_previews();
+   test_turn_id_mint_and_thread_local();
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Auditable-correctness P1 — wire slice 1: evidence emit

P1's DB foundation (turn-keyed `retrieval_event` store + lookup) merged in #284.
This is the first emitter — the single-writer foundation per the proposal's
Phasing → **P1**. The two-writer upsert, typed doc/code refs, and the
`X-Aimee-Retrieval-Event` HTTP header are deliberately the *next* slices
(P1.5 / wire slice 2).

### What this does
- **`kb_evidence_emit_enabled`** config flag (default off). Observation-only:
  with it on or off the injected envelope and the answer are byte-identical;
  the only added work is one synchronous KB write per ingress turn.
- **Turn-id seam** in `ingress_preinject`: `ingress_preinject_mint_turn_id`
  (UUID via `platform_random_bytes`) + a thread-local `set/turn_id`, mirroring
  the existing `request_disabled` override. The HTTP layer will mint + set the
  id and emit the response header in the next slice; until then
  `ingress_preinject_build` mints its own id when none is set.
- **Single-writer emit**: when the flag is on, `ingress_preinject_build`
  records the int64 memory rows it surfaced into the turn via a new KB action
  `evidence.emit_retrieval_event`
  (`kb_client_evidence_emit_retrieval_event` → `kb_handle_evidence_emit_retrieval_event`
  → the already-merged `db2_demotion_retrieval_event_write_turn`, first-wins on
  a duplicate `turn_id`).

### Deliberate deviations from the proposal text (flagged for review)
1. **Emit site = the memory *diagnose* surface, via a dedicated action — not
   `memory.context_block`.** The proposal names `kb_client_memory_context_block`,
   but the live `ingress_preinject_build` surfaces memory through
   `kb_client_memory_diagnose`; `context_block` does not run on the pre-inject
   path. A dedicated `evidence.emit_retrieval_event` action keeps P1 isolated
   (no signature churn across `diagnose`'s many callers/tests) and trivially
   testable. The cost is one extra KB round-trip; **P1.5 folds the emit into the
   retrieval handlers with the idempotent two-writer upsert**, removing it — as
   the proposal intends.
2. **Flag gated server-side** (the ingress decides whether to call); the KB
   handler is a dumb writer.

### Tests
- `test_ingress_preinject`: turn-id mint (UUID 8-4-4-4-12 shape, hex, unique
  across calls) + thread-local set/get/clear.
- `write_turn`/`by_turn` round-trip already covered in `test_demotion` (#284).

### Verification
`make -j1 server`, `make build-integrity`, `make -j4 unit-tests`, `make lint`
(incl. docs-gen-check after `make docs-gen`) all green. Default-off flag — no
behavior change until enabled.
