### PR TITLE
feat(audit): P1 wire slice 3 — /v1/audit/trace + aimee audit trace

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -617,6 +617,36 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /audit/trace:
+    post:
+      summary: Per-turn retrieval-evidence trace (proxied to aimee-kb)
+      description: >-
+        Reconstruct what a turn retrieved: given the caller-visible turn_id (the
+        X-Aimee-Retrieval-Event response-header value), return the per-turn
+        retrieval_event and its surfaced ids. trace_status is one of the
+        exhaustive states ok / not_instrumented / not_evaluated /
+        evidence_unavailable (P1 produces ok and evidence_unavailable). Requires
+        aimee-kb. Gated by kb_evidence_emit_enabled at emit time.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [turn_id]
+              properties:
+                turn_id: { type: string }
+      responses:
+        "200":
+          description: Trace bundle ({status, trace_status, turn_id, retrieval_event_id?, event?})
+          content:
+            application/json:
+              schema: { type: object }
+        "502":
+          description: Knowledge service (aimee-kb) unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /notes:
     get:
       summary: List notes (proxied to aimee-kb)

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -324,6 +324,7 @@ static const struct
     {"agent", "probe", "agent.probe", NULL, NULL, 300000},
     {"mcp", "audit", "mcp.audit", NULL, "items", 0},
     {"mcp", "recheck", "mcp.recheck", NULL, "items", 300000},
+    {"audit", "trace", "evidence.trace_retrieval_event", NULL, NULL, 0},
     {"get_help", NULL, "get_help", "mcp.call", NULL, 0},
     {"get-help", NULL, "get_help", "mcp.call", NULL, 0},
     {"verify", NULL, "git.verify", "mcp.call", NULL, 900000},
@@ -986,6 +987,18 @@ static cJSON *marshal_config_get(int argc, char **argv)
    cJSON *req = marshal_no_args("config.get");
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "key", opts.positional[0]);
+   return req;
+}
+
+/* Auditable-correctness P1: `aimee audit trace <turn_id>` → the turn_id param. */
+static cJSON *marshal_audit_trace(int argc, char **argv)
+{
+   rpc_opts_t opts;
+   rpc_parse(argc, argv, NULL, &opts);
+
+   cJSON *req = marshal_no_args("evidence.trace_retrieval_event");
+   if (opts.pos_count > 0)
+      cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
    return req;
 }
 
@@ -3260,6 +3273,8 @@ static cJSON *marshal_request(const char *method, int argc, char **argv)
       return marshal_no_args(method);
    if (strcmp(method, "config.get") == 0)
       return marshal_config_get(argc, argv);
+   if (strcmp(method, "evidence.trace_retrieval_event") == 0)
+      return marshal_audit_trace(argc, argv);
    if (strcmp(method, "config.set") == 0)
       return marshal_config_set(argc, argv);
    if (strcmp(method, "aux.test") == 0)

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -76,6 +76,7 @@ static const struct
     {"dogfood.tag", "POST", "/v1/dogfood/tag"},
     {"episode.list", "GET", "/v1/episode/list"},
     {"eval.results", "GET", "/v1/eval/results"},
+    {"evidence.trace_retrieval_event", "POST", "/v1/audit/trace"},
     {"graph.explain", "POST", "/v1/graph/explain"},
     {"hooks.post", "POST", "/v1/hooks/post"},
     {"hooks.pre", "POST", "/v1/hooks/pre"},

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1053,6 +1053,7 @@ static const struct
     {"memory.briefing", kb_handle_memory_briefing},
     {"memory.context_block", kb_handle_memory_context_block},
     {"evidence.emit_retrieval_event", kb_handle_evidence_emit_retrieval_event},
+    {"evidence.trace_retrieval_event", kb_handle_evidence_trace_retrieval_event},
     {"memory.entity_profile", kb_handle_memory_entity_profile},
     {"memory.entity_edges", kb_handle_memory_entity_edges},
     {"memory.search_graph", kb_handle_memory_search_graph},

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -789,6 +789,54 @@ int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req)
    return kb_reply_or_error(fd, resp, "failed to write retrieval_event");
 }
 
+/* Auditable-correctness P1: the /v1/audit/trace read. Look up the per-turn
+ * retrieval_event by its caller-visible turn_id and return a four-state status.
+ * Only two states are reachable in P1's single-writer foundation:
+ *   - "ok"                   : a retrieval_event durably exists for the turn.
+ *   - "evidence_unavailable" : the turn id resolves to no durable event (never
+ *                              landed — e.g. DB2 was down at emit) or the read
+ *                              itself errored.
+ * The other two states are defined but produced by later phases:
+ *   - "not_instrumented"     : a path that emits no evidence (e.g. the Anthropic
+ *                              relay) — needs the per-path awareness of P1b.
+ *   - "not_evaluated"        : fidelity skipped on a tool-loop turn — P3.
+ * Never a falsely-empty success: a missing event is an explicit status, and the
+ * action always returns status:ok (the lookup ran) with trace_status set. */
+int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req)
+{
+   cJSON *turn_j = cJSON_GetObjectItemCaseSensitive(req, "turn_id");
+   if (!cJSON_IsString(turn_j) || !turn_j->valuestring[0])
+      return kb_send_error(fd, "audit.trace requires turn_id");
+
+   char ev_id[64] = "";
+   char payload[8192] = "";
+   int rc = db2_demotion_retrieval_event_by_turn(turn_j->valuestring, ev_id, sizeof(ev_id), payload,
+                                                 sizeof(payload));
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "turn_id", turn_j->valuestring);
+   if (rc == 1)
+   {
+      cJSON_AddStringToObject(resp, "trace_status", "ok");
+      cJSON_AddStringToObject(resp, "retrieval_event_id", ev_id);
+      /* Embed the event payload (surfaced ids etc.) as a structured object when
+       * it parses, else as the raw string — never silently dropped. */
+      cJSON *ev = payload[0] ? cJSON_Parse(payload) : NULL;
+      if (ev)
+         cJSON_AddItemToObject(resp, "event", ev);
+      else if (payload[0])
+         cJSON_AddStringToObject(resp, "event_raw", payload);
+   }
+   else
+   {
+      cJSON_AddStringToObject(resp, "trace_status", "evidence_unavailable");
+      cJSON_AddStringToObject(resp, "detail",
+                              rc < 0 ? "lookup error" : "no durable retrieval_event for this turn");
+   }
+   return kb_reply_or_error(fd, resp, "failed to trace retrieval_event");
+}
+
 int kb_handle_memory_entity_profile(int fd, cJSON *req)
 {
    cJSON *entity_j = cJSON_GetObjectItemCaseSensitive(req, "entity");

--- a/src/kb_service_memory.h
+++ b/src/kb_service_memory.h
@@ -59,6 +59,8 @@ int kb_handle_memory_briefing(int fd, cJSON *req);
 int kb_handle_memory_context_block(int fd, cJSON *req);
 /* Auditable-correctness P1: record a per-turn retrieval_event keyed by turn_id. */
 int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req);
+/* Auditable-correctness P1: the /v1/audit/trace read (four-state status). */
+int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req);
 int kb_handle_memory_entity_profile(int fd, cJSON *req);
 int kb_handle_memory_entity_edges(int fd, cJSON *req);
 int kb_handle_memory_search_graph(int fd, cJSON *req);

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -351,8 +351,8 @@ static void op_run_worker_run(void *arg)
    char *buf = (char *)malloc(SHTTP_RESP_MAX);
    if (!buf)
    {
-      char *snap = op_run_snapshot(j->run_id, j->op, "failed", j->created,
-                                   "{\"error\":\"out of memory\"}");
+      char *snap =
+          op_run_snapshot(j->run_id, j->op, "failed", j->created, "{\"error\":\"out of memory\"}");
       openai_runs_store_finalize(j->run_id, OPENAI_RUN_FAILED, snap ? snap : "{}");
       free(snap);
       free(j->line);
@@ -476,8 +476,8 @@ static int submit_op_run_internal(const char *op_method, const char *body_json, 
    {
       if (compute_pool_submit(&ctx->pool, op_run_worker_run, j) != 0)
       {
-         char *failed =
-             op_run_snapshot(id, op_method, "failed", created, "{\"error\":\"compute queue full\"}");
+         char *failed = op_run_snapshot(id, op_method, "failed", created,
+                                        "{\"error\":\"compute queue full\"}");
          openai_runs_store_finalize(id, OPENAI_RUN_FAILED, failed ? failed : queued);
          free(failed);
          free(j->line);
@@ -491,8 +491,8 @@ static int submit_op_run_internal(const char *op_method, const char *body_json, 
       pthread_t th;
       if (pthread_create(&th, NULL, op_run_worker_thread, j) != 0)
       {
-         char *failed =
-             op_run_snapshot(id, op_method, "failed", created, "{\"error\":\"could not start run\"}");
+         char *failed = op_run_snapshot(id, op_method, "failed", created,
+                                        "{\"error\":\"could not start run\"}");
          openai_runs_store_finalize(id, OPENAI_RUN_FAILED, failed ? failed : queued);
          free(failed);
          free(j->line);
@@ -975,6 +975,8 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/curator/invalidated", NULL, RM_EXACT, "curator.invalidated", 0, rh_dispatch_op},
     {"POST", "/v1/graph/explain", NULL, RM_EXACT, "graph.explain", 0, rh_dispatch_op},
     {"POST", "/v1/code/audit", NULL, RM_EXACT, "code.audit", 0, rh_dispatch_op},
+    {"POST", "/v1/audit/trace", NULL, RM_EXACT, "evidence.trace_retrieval_event", 0,
+     rh_dispatch_op},
     {"POST", "/v1/trajectory/batch", NULL, RM_EXACT, "trajectory.batch", 0, rh_dispatch_op},
 
     /* work.* / wm.* / skill.* / session.* / toolset.* / mcp.* / trigger.* and


### PR DESCRIPTION
## Auditable-correctness P1 — wire slice 3: `/v1/audit/trace` (the read surface)

Completes P1: the read that consumes the evidence slices 1 (#286) and 2 (#287)
produce. Given a `turn_id` (the `X-Aimee-Retrieval-Event` response-header
value), reconstruct what the turn retrieved.

### What this does
- **KB action `evidence.trace_retrieval_event`** + handler reading the
  already-merged `db2_demotion_retrieval_event_by_turn`, returning a
  **four-state `trace_status`**. Two are reachable in P1's single-writer
  foundation:
  - `ok` — durable event found (with `retrieval_event_id` + embedded `event`)
  - `evidence_unavailable` — no durable event for the turn, or a lookup error

  `not_instrumented` (paths that emit no evidence, e.g. the Anthropic relay —
  needs P1b path-awareness) and `not_evaluated` (fidelity skipped on a tool-loop
  turn — P3) are defined but produced by later phases. **Never a falsely-empty
  success**: a missing event is an explicit status.
- **`/v1/audit/trace`** route — `rh_dispatch_op` proxy to the KB op, mirroring
  `/v1/code/audit`; openapi entry + regenerated `cli_v1_routes_gen.inc`.
- **`aimee audit trace <turn_id>`** thin-client route + marshaler (positional →
  `turn_id`).

### Gates
All four coverage gates green: `cli-v1-routes-check`, `v1-method-coverage-check`,
`api-conformance-check`, `kb-v1-coverage-check` — these validate the
route↔method↔CLI↔openapi consistency. `by_turn` (the read primitive) is covered
in `test_demotion` (slice 1); the handler is thin glue mapping its 1/0/-1 return
to the 4-state. `openapi_server_data.h` is a gitignored build artifact
(regenerated from the yaml on build).

### Verification
`make -j1 server`, `build-integrity`, `make -j4 unit-tests`, `make lint` all
green. End-to-end (`aimee audit trace` → `ok`/`evidence_unavailable`) validated
live on .254 after merge.

After this, P1 (reconstructibility foundation) is complete end-to-end; next is
**P1.5** (typed refs + the two-writer idempotent upsert — folds the dedicated
emit into the retrieval handlers).
