### PR TITLE
fix(audit): forward /v1/audit/trace to aimee-kb (server dispatch handler)

### DIFF
--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -781,6 +781,11 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
                                             const char *query_fingerprint, const int64_t *ids,
                                             int n_ids);
 
+/* Auditable-correctness P1: the /v1/audit/trace read — forward to the KB
+ * evidence.trace_retrieval_event action and return its JSON response verbatim
+ * (malloc'd, caller frees; NULL on bad arg or kb error). */
+char *kb_client_evidence_trace_retrieval_event(const char *turn_id);
+
 /* Fetch the entity profile card via aimee-kb.  Returns 0 on success
  * (|out| filled) or -1 if kb is unreachable or the entity is missing.
  * Mirrors memory_get_entity_profile(). */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -283,6 +283,7 @@ int handle_blast_radius_preview(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
 int handle_graph_sync_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_graph_explain(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_synthesize(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_contradictions(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1630,6 +1630,17 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
    return ok ? 0 : -1;
 }
 
+char *kb_client_evidence_trace_retrieval_event(const char *turn_id)
+{
+   if (!turn_id || !turn_id[0])
+      return NULL;
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "turn_id", turn_id);
+   /* Pass the KB action's response through verbatim (status + four-state
+    * trace_status + retrieval_event_id + event). kb_v1_action_request owns req. */
+   return kb_v1_action_request("evidence.trace_retrieval_event", req);
+}
+
 char *kb_client_memory_lint_json(void)
 {
    cJSON *req = cJSON_CreateObject();

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1042,6 +1042,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"blast_radius.preview", handle_blast_radius_preview},
     /* KB */
     {"kb.search", handle_kb_search},
+    {"evidence.trace_retrieval_event", handle_evidence_trace},
     {"curator.implements", handle_curator_implements},
     {"curator.synthesize", handle_curator_synthesize},
     {"curator.contradictions", handle_curator_contradictions},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -134,6 +134,7 @@ const method_policy_t method_registry[] = {
      * CAPS_AUTHENTICATED — i.e. UDS / local-trust only. */
     /* Knowledge base: search/status read; build/ingest/update rebuild the store. */
     {"kb.search", CAP_INDEX_READ, "knowledge search"},
+    {"evidence.trace_retrieval_event", CAP_INDEX_READ, "audit retrieval-evidence trace"},
     {"kb.status", CAP_DASHBOARD_READ, "knowledge base status"},
     {"optimize.export", CAP_DASHBOARD_READ, "bandit optimization export"},
     {"optimize.promote", CAP_INDEX_ADMIN, "promote a bandit arm to default"},

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -541,6 +541,10 @@ int handle_blast_radius_preview(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
 
 /* --- KB handlers --- */
 
+/* Auditable-correctness /v1/audit/trace handler (kept in a textual include to
+ * stay under the per-file line cap). */
+#include "server_state_audit.inc"
+
 int handle_kb_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;

--- a/src/server/server_state_audit.inc
+++ b/src/server/server_state_audit.inc
@@ -1,0 +1,23 @@
+/* server_state_audit.inc — auditable-correctness dispatch handlers for
+ * server_state.c. Textually included (shares its file-static helpers like
+ * send_and_free); split out only to keep server_state.c under the line cap. */
+
+/* /v1/audit/trace handler. Its op (evidence.trace_retrieval_event) is a KB-only
+ * action, so — like handle_kb_search and the curator handlers — the server
+ * forwards it to aimee-kb via kb_client and passes the JSON response through.
+ * rh_dispatch_op alone cannot reach a KB-only method (server_dispatch resolves
+ * only server-side methods), which is why the cloned /v1/code/audit route never
+ * reached the KB. */
+int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *turn_id = jo_str(req, "turn_id", "");
+   if (!turn_id[0])
+      return server_send_error(conn, "audit trace requires turn_id", NULL);
+   char *json = kb_client_evidence_trace_retrieval_event(turn_id);
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   if (!resp)
+      return server_send_error(conn, "knowledge service audit trace failed", NULL);
+   return send_and_free(conn, resp);
+}

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -531,6 +531,10 @@ int handle_kb_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "kb.search");
 }
+int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "evidence.trace_retrieval_event");
+}
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "curator.implements");
@@ -1415,6 +1419,17 @@ static void test_routing(void)
                         strlen("{\"method\":\"trajectory.batch\",\"tasks_path\":\"tasks\"}"));
    assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring, "trajectory.batch") == 0);
    assert(strcmp(g_last_handler, "trajectory.batch") == 0);
+   cJSON_Delete(json);
+
+   /* Auditable-correctness P1: /v1/audit/trace's op must resolve to the
+    * server-side KB-forward handler (regression guard for the bug where the
+    * cloned KB-proxy route never reached the KB). */
+   json = dispatch_json(
+       ctx, conn, "{\"method\":\"evidence.trace_retrieval_event\",\"turn_id\":\"t1\"}",
+       strlen("{\"method\":\"evidence.trace_retrieval_event\",\"turn_id\":\"t1\"}"));
+   assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
+                 "evidence.trace_retrieval_event") == 0);
+   assert(strcmp(g_last_handler, "evidence.trace_retrieval_event") == 0);
    cJSON_Delete(json);
 
    json = dispatch_json(ctx, conn, "{\"method\":\"rules.delete\",\"id\":1}",


### PR DESCRIPTION
## Fix: `/v1/audit/trace` returned UNKNOWN_METHOD (server→KB forwarding)

**Found by live validation on .254.** After deploying v0.2.69 and validating the
`X-Aimee-Retrieval-Event` header + the KB-level emit→trace round-trip (both
pass), `/v1/audit/trace` via aimee-server returned
`UNKNOWN_METHOD: evidence.trace_retrieval_event`.

**Root cause (pre-existing, inherited by slice 3):** the slice-3 route was cloned
from `/v1/code/audit`, which is *itself broken the same way*. `rh_dispatch_op`
runs the route's op through `server_dispatch`, but `server_dispatch` only
resolves **server-side** methods. A KB-only op (`evidence.trace_retrieval_event`,
exactly like `code.audit`) is never forwarded to aimee-kb → `UNKNOWN_METHOD`.
Working KB-backed `/v1` methods (`kb.search`, `curator.*`) use an explicit
`server_dispatch_table` handler that forwards via `kb_client`.

## Fix
- `kb_client_evidence_trace_retrieval_event(turn_id)` — forward to the KB action,
  return its JSON (the four-state trace bundle) verbatim.
- `handle_evidence_trace` — server dispatch handler, in `server_state_audit.inc`
  (a textual include so `server_state.c` stays under the 2000-line cap; it shares
  `send_and_free` and compiles into `server_state.o`, which the dispatch test
  stubs — avoiding a multiple-definition with the test's stub).
- Registered in `server_dispatch_table` + a `CAP_INDEX_READ` capability entry
  (`dispatch-caps-check` requires one).
- `test_server_dispatch`: stub + a routing assertion that
  `evidence.trace_retrieval_event` resolves to the handler (regression guard).

## Already validated live (v0.2.69 on .254)
- `X-Aimee-Retrieval-Event` header on `/v1/chat/completions` ✓
- KB-level round-trip: `evidence.emit_retrieval_event` writes, then
  `evidence.trace_retrieval_event` returns `trace_status: ok` with the surfaced
  ids ✓

This restores the server-facing read path. (`/v1/code/audit` has the identical
latent gap — flagged for a separate fix.)

## Verification
`make -j1 server`, `build-integrity`, `make -j4 unit-tests`, `make lint`
(incl. `dispatch-caps-check` + the 4 `/v1` coverage gates) all green.
