### PR TITLE
ci(embedder): fetch models at runtime + cache image layers (fast, thin builds)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -106,6 +106,16 @@ jobs:
           file: ${{ matrix.image.dockerfile }}
           platforms: linux/${{ matrix.platform.arch }}
           provenance: false
+          # Reuse layers across releases. Without this every release rebuilt all
+          # images on both arches from scratch — re-running the full LTO C build
+          # each time. Scoped per image+arch so the matrix legs never clobber each
+          # other. EXCLUDES aimee-embedder: its torch + baked multi-GB model layers
+          # would blow the 10 GB GHA cache budget and evict the (small, high-reuse)
+          # C-image caches, defeating the purpose. The embedder's real win is the
+          # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
+          # layer cache.
+          cache-from: ${{ matrix.image.name != 'aimee-embedder' && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ matrix.image.name != 'aimee-embedder' && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Published images bundle the optional browser UI (WITH_WEBCHAT=1); the
           # default `docker compose up --build` an end user runs leaves it off so it
           # needs no credentials. The aimee-kb image ignores WITH_WEBCHAT.


### PR DESCRIPTION
## Fast, thin embedder image builds — runtime model fetch + layer cache

**Why builds were slow** (the actual diagnosis): `publish-images.yml` had **no
layer cache** — every release rebuilt all 4 images on both arches from scratch —
*and* `Dockerfile.embedder` baked the multi-GB **4b embedder + 1b reranker**
weights in, re-downloading several GB into every build (×2 arches). So each
release re-ran `pip install torch` + multi-GB model downloads with nothing reused.

## Changes
- **`publish-images.yml`** — add GHA layer cache (`cache-from/to type=gha`,
  scoped per image+arch). Unchanged Dockerfiles become near-instant cache hits;
  the heavy `pip install torch` and LTO C-build layers are reused across releases.
- **`Dockerfile.embedder`** — drop both build-time model pre-downloads. Weights
  are fetched **once at runtime** into `HF_HOME` (`/opt/models`, the persistent
  `aimee-embedder-models` volume); restart/recreate/image-update reuses the
  cache, only `down -v` re-downloads. Tier swap (`…-0.6b`/`…-400m`) is an env var.
  This is the runtime-fetch half of the `embedder-runtime-fetch-autodim` proposal
  (the KB auto-dimension handshake §2 is a separate follow-up).
- **`embedder-server.py`** — load the embedder (and reranker, best-effort) in a
  **background thread** and serve immediately, so the cold first-boot fetch
  (minutes for the 4b) doesn't trip the healthcheck. `/health` reports `loading`
  (HTTP 200) until ready → `ok` with the model's true dim; `error` → 503.
  `/embed` + `/rerank` return 503 "warming up" until loaded — never a 0-vector
  against an unloaded model.

## Effect
Published embedder image is small (no baked weights); release builds stop
re-downloading models and reuse cached layers. First boot on a fresh volume
downloads once (server stays healthy via the loading state); every later boot
reuses the cached weights.

## Verification
`python3 -m py_compile scripts/embedder-server.py` ✓, YAML valid ✓. Build-config
change — fully exercised on the next release build + a `.254` deploy (the
digest-aware runtime + the small image also speed the OCI→LXC conversion).
