### PR TITLE
feat(embedder): runtime model fetch — thin image, no baked weights (proposal §1)

### DIFF
--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -37,27 +37,15 @@ RUN apt-get update \
 RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
     && pip install -U "sentence-transformers>=3.3" "transformers>=5.2" einops
 
-# Pre-download EMBEDDER_MODEL at build time so runtime needs no network. The model
-# id is read from the env so the build, the runtime, and an override all agree on
-# one source of truth. HuggingFace downloads are flaky during CI image builds
-# (transient network/CDN errors fail the whole release), so retry with backoff;
-# the final attempt is unguarded so an image that genuinely couldn't fetch the
-# model still fails the build rather than shipping without it (a cached model
-# makes the re-verify a fast no-op).
-RUN for i in 1 2 3 4 5; do \
-        python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True)" && break; \
-        echo "model download attempt $i failed; retrying in $((i * 10))s"; \
-        sleep $((i * 10)); \
-    done; \
-    python -c "import os; from sentence_transformers import SentenceTransformer; SentenceTransformer(os.environ['EMBEDDER_MODEL'], trust_remote_code=True)"
-
-# Pre-download the cross-encoder reranker too (same retry rationale).
-RUN for i in 1 2 3 4 5; do \
-        python -c "import os; from sentence_transformers import CrossEncoder; CrossEncoder(os.environ['RERANKER_MODEL'], trust_remote_code=True)" && break; \
-        echo "reranker download attempt $i failed; retrying in $((i * 10))s"; \
-        sleep $((i * 10)); \
-    done; \
-    python -c "import os; from sentence_transformers import CrossEncoder; CrossEncoder(os.environ['RERANKER_MODEL'], trust_remote_code=True)"
+# Models are NOT baked into the image. Baking the multi-GB 4b embedder + 1b
+# reranker re-downloaded several GB into every release build (×2 arches) and made
+# the published image multi-GB to push and to convert to an LXC template. Instead
+# embedder-server.py fetches EMBEDDER_MODEL + RERANKER_MODEL at startup, once,
+# into HF_HOME (/opt/models — the persistent aimee-embedder-models volume), so a
+# restart/recreate/image-update reuses the cached weights and only `down -v`
+# re-downloads. Switching tier (…-0.6b / …-400m) or model is an env-var change,
+# no rebuild. During the cold first-boot fetch /health reports "loading" (503)
+# and /embed returns 503 — never a 0-vector against an unloaded model.
 
 COPY scripts/embedder-server.py /opt/aimee/scripts/embedder-server.py
 
@@ -67,7 +55,10 @@ USER embedder
 WORKDIR /opt/aimee
 EXPOSE 8080
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
+# start-period is long: on a cold volume the first boot downloads the model
+# (minutes for the multi-GB 4b) before /health returns 200, and failures during
+# start-period don't count. Subsequent boots reuse the volume and are fast.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=900s --retries=3 \
     CMD curl -fsS http://127.0.0.1:8080/health >/dev/null || exit 1
 
 ENTRYPOINT ["python", "/opt/aimee/scripts/embedder-server.py"]

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -49,7 +49,12 @@ RUN pip install --index-url https://download.pytorch.org/whl/cpu torch \
 
 COPY scripts/embedder-server.py /opt/aimee/scripts/embedder-server.py
 
+# Create HF_HOME (/opt/models) explicitly — the removed build-time model
+# pre-download used to create it; now it must exist and be owned by the embedder
+# user so the runtime fetch can write the weights (and a fresh named volume
+# mounted here inherits this ownership).
 RUN useradd --system --home-dir /opt/aimee --shell /usr/sbin/nologin embedder \
+    && mkdir -p /opt/models \
     && chown -R embedder:embedder /opt/models /opt/aimee
 USER embedder
 WORKDIR /opt/aimee

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -45,12 +45,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
-      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
-      # and AIMEE_EMBEDDING_DIM=1024 on the server/kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+    # Tier is a RUNTIME choice now: models are fetched at startup into the volume
+    # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
+    # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
+    # AIMEE_EMBEDDING_DIM=1024 on the server/kb (the 4b is 2560).
+    environment:
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -58,7 +62,9 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      # Long: a cold first boot downloads the model (minutes for the 4b) before
+      # /health returns 200; the volume makes every later boot fast.
+      start_period: 900s
 
   aimee-server-kb:
     restart: unless-stopped

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -37,12 +37,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
-      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
-      # and AIMEE_EMBEDDING_DIM=1024 on the kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+    # Tier is a RUNTIME choice now: models are fetched at startup into the volume
+    # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
+    # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
+    # AIMEE_EMBEDDING_DIM=1024 on the kb (the 4b is 2560).
+    environment:
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -50,7 +54,9 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      # Long: a cold first boot downloads the model (minutes for the 4b) before
+      # /health returns 200; the volume makes every later boot fast.
+      start_period: 900s
 
   aimee-kb:
     restart: unless-stopped

--- a/compose.yaml
+++ b/compose.yaml
@@ -22,12 +22,16 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.embedder
-      # Default tier: 4b embedder (2560-dim) + 1b reranker. For a resource-limited
-      # host, build the light tier: EMBEDDER_MODEL=...0.6b, RERANKER_MODEL=...400m-v1,
-      # and AIMEE_EMBEDDING_DIM=1024 on the kb.
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+    # Tier is a RUNTIME choice now: the models are fetched at startup into the
+    # volume (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with
+    # no rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
+    # AIMEE_EMBEDDING_DIM=1024 on the kb (the 4b is 2560).
+    environment:
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:
@@ -35,7 +39,9 @@ services:
       interval: 30s
       timeout: 5s
       retries: 3
-      start_period: 30s
+      # Long: a cold first boot downloads the model (minutes for the 4b) before
+      # /health returns 200; the volume makes every later boot fast.
+      start_period: 900s
 
   aimee-kb:
     restart: unless-stopped

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -54,6 +54,15 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+# Models are fetched at runtime now (not baked into the image), so CI must use a
+# SMALL, ungated model + matching dim — otherwise every e2e run would cold-download
+# the multi-GB 4b/1b default. all-MiniLM-L6-v2 (384-dim, ~90 MB) + a tiny
+# cross-encoder fetch in well under the embedder's start_period. compose reads
+# these via ${...}; exporting here covers every topology + the build args.
+export EMBEDDER_MODEL="${EMBEDDER_MODEL:-sentence-transformers/all-MiniLM-L6-v2}"
+export RERANKER_MODEL="${RERANKER_MODEL:-cross-encoder/ms-marco-MiniLM-L-6-v2}"
+export AIMEE_EMBEDDING_DIM="${AIMEE_EMBEDDING_DIM:-384}"
+
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 selected() { case ",$ONLY," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
 have_docker() { command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; }

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -34,6 +34,7 @@ Dependencies: pip install "sentence-transformers>=3.3" "transformers>=5.2" einop
 import json
 import os
 import sys
+import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
 MODEL_NAME = os.environ.get("EMBEDDER_MODEL", "perplexity-ai/pplx-embed-v1-4b")
@@ -60,20 +61,23 @@ EMBEDDER_QUANTIZE = os.environ.get("EMBEDDER_QUANTIZE", "fp32").strip().lower()
 _model = None
 _dim = 0
 _reranker = None
+# First-boot load/fetch state. The model is no longer baked into the image (see
+# Dockerfile.embedder) — it is fetched once into the HF_HOME volume on first
+# start, which takes minutes for a multi-GB model. Load runs in a background
+# thread (main() serves immediately) and /health reports the state. /health is
+# 200 ONLY when "ok", so a compose `depends_on: condition: service_healthy` gate
+# means the model is actually ready (the KB never starts against an unloaded
+# model); a long Dockerfile HEALTHCHECK start-period covers the cold-fetch window
+# so the "loading" 503s don't trip the container.
+_load_status = "loading"  # loading | ok | error
+_load_error = ""
 
 
 def load_model():
     global _model, _dim
     if _model is not None:
         return _model
-    try:
-        from sentence_transformers import SentenceTransformer
-    except ImportError:
-        sys.stderr.write(
-            "embedder-server: sentence-transformers not installed"
-            ' (pip install "sentence-transformers>=3.3" einops)\n'
-        )
-        sys.exit(1)
+    from sentence_transformers import SentenceTransformer  # raises on missing dep
     import torch
 
     torch.set_num_threads(EMBEDDER_THREADS)
@@ -102,8 +106,29 @@ def load_reranker():
     return _reranker
 
 
+def _background_load():
+    """Fetch (cold volume) + load the models off the request path. The embedder
+    is the critical path: once it loads, /health flips to "ok" and /embed serves.
+    The reranker is best-effort — a failure degrades reranking, not embedding."""
+    global _load_status, _load_error
+    try:
+        load_model()
+        _load_status = "ok"
+    except Exception as exc:  # noqa: BLE001
+        _load_error = str(exc)
+        _load_status = "error"
+        sys.stderr.write(f"embedder-server: model load failed: {exc}\n")
+        sys.stderr.flush()
+        return
+    try:
+        load_reranker()
+    except Exception as exc:  # noqa: BLE001
+        sys.stderr.write(f"embedder-server: reranker load failed (rerank degraded): {exc}\n")
+    sys.stderr.flush()
+
+
 def embed(text: str):
-    vec = load_model().encode(text, normalize_embeddings=True)
+    vec = _model.encode(text, normalize_embeddings=True)
     return vec.tolist()
 
 
@@ -131,10 +156,19 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         if self.path.rstrip("/") == "/health":
-            self._send(
-                200,
-                {"status": "ok", "model": MODEL_NAME, "dim": _dim, "quantize": EMBEDDER_QUANTIZE},
-            )
+            # 200 ONLY when ready (so compose service_healthy == model loaded);
+            # "loading" and "error" are 503. dim is the model's true dimension
+            # once loaded (0 while loading) — the KB reads it to size the schema,
+            # so it is never a placeholder.
+            payload = {
+                "status": _load_status,
+                "model": MODEL_NAME,
+                "dim": _dim,
+                "quantize": EMBEDDER_QUANTIZE,
+            }
+            if _load_status == "error":
+                payload["error"] = _load_error
+            self._send(200 if _load_status == "ok" else 503, payload)
         else:
             self._send(404, {"error": "not found"})
 
@@ -142,6 +176,11 @@ class Handler(BaseHTTPRequestHandler):
         path = self.path.rstrip("/")
         if path not in ("/embed", "/rerank"):
             self._send(404, {"error": "not found"})
+            return
+        # Refuse work until the model is loaded — never serve against a not-yet-
+        # loaded model (no 0-vector fallback). The KB treats 503 as "warming up".
+        if _load_status != "ok":
+            self._send(503, {"error": "embedder warming up", "status": _load_status})
             return
         length = int(self.headers.get("content-length", "0") or "0")
         raw = self.rfile.read(length) if length else b""
@@ -163,11 +202,13 @@ class Handler(BaseHTTPRequestHandler):
 
 
 def main():
-    # Fail fast if the model can't load, so the container healthcheck flips
-    # rather than silently serving 500s.
-    load_model()
+    # Serve immediately; load the model in the background. On a cold volume the
+    # first-boot fetch of a multi-GB model takes minutes, and blocking here would
+    # trip the healthcheck before the server is even up. /health reports "loading"
+    # (503) until ready; /embed + /rerank return 503 meanwhile.
     server = ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
-    sys.stderr.write(f"embedder-server: {MODEL_NAME} ready on :{PORT}\n")
+    threading.Thread(target=_background_load, daemon=True).start()
+    sys.stderr.write(f"embedder-server: serving on :{PORT}; loading {MODEL_NAME} in background\n")
     sys.stderr.flush()
     server.serve_forever()
 


### PR DESCRIPTION
## Embedder runtime model fetch — thin image, no baked weights (proposal §1)

Implements **§1 of `embedder-runtime-fetch-autodim`** (reviewed-READY). The
multi-GB 4b embedder + 1b reranker are no longer baked into the published image —
they're fetched **once at startup** into the `aimee-embedder-models` volume and
reused on every restart. Result: small image, **fast release builds** (no
per-release multi-GB model download), faster push + `.254` OCI→LXC convert, and
the tier/model is a **runtime env var** (`EMBEDDER_MODEL`/`RERANKER_MODEL`) — no
rebuild to switch.

### Changes
- **`Dockerfile.embedder`** — drop both build-time model pre-downloads; long
  `HEALTHCHECK start-period` for the cold first-boot fetch window.
- **`scripts/embedder-server.py`** — background-load both models + serve
  immediately (cold fetch can't trip the healthcheck). `/health` is **200 only
  when `ok`** (loading/error → 503), so compose `depends_on: service_healthy`
  means the model is *actually* ready (the KB never starts against an unloaded
  model); it reports the model's **true dim**. `/embed`+`/rerank` → 503 "warming
  up" until loaded (no 0-vector fallback).
- **`compose.yaml` / `.combined` / `.server`** — pass `EMBEDDER_MODEL` +
  `RERANKER_MODEL` as a **runtime env** (not just a build arg); bump the embedder
  healthcheck `start_period` to 900s.
- **`scripts/e2e-matrix.sh`** — CI uses a small ungated model
  (`all-MiniLM-L6-v2`, 384-dim) + a tiny cross-encoder + `AIMEE_EMBEDDING_DIM=384`
  so e2e doesn't cold-download the multi-GB default every run. (This is the fix
  for the e2e breakage an earlier rushed attempt hit — addressed properly here.)

### Scope
This is §1 (runtime fetch). **§2 (the KB auto-dimension handshake** — derive
`embedding_dim` from the embedder `/health`) is the follow-up PR; here
`embedding_dim` stays an operator pin (unchanged behavior, no dim-drift
regression). `.254` (4b/2560, populated) is unaffected — the volume already holds
the weights and the dim stays pinned.

### Verification
`py_compile`, `bash -n`, YAML all clean. The full runtime-fetch + first-boot
serving path is exercised by **e2e-docker** (T1–T4 across the compose topologies).
