### PR TITLE
workflow engine: config-extensible blocks + CI/merge safety blocks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -503,6 +503,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/workflow/wfe_def.c
     ${AIMEE_SRC_DIR}/workflow/wfe_validate.c
     ${AIMEE_SRC_DIR}/workflow/wfe_canonical.c
+    ${AIMEE_SRC_DIR}/workflow/wfe_custom.c
     ${AIMEE_SRC_DIR}/vendor/cJSON.c
     ${PLATFORM_CORE_SRCS}
 )
@@ -1156,6 +1157,7 @@ add_executable(aimee
     ${AIMEE_SRC_DIR}/workflow/wfe_def.c
     ${AIMEE_SRC_DIR}/workflow/wfe_validate.c
     ${AIMEE_SRC_DIR}/workflow/wfe_canonical.c
+    ${AIMEE_SRC_DIR}/workflow/wfe_custom.c
 )
 target_include_directories(aimee PRIVATE ${AIMEE_SRC_DIR} ${AIMEE_SRC_DIR}/headers ${AIMEE_SRC_DIR}/vendor/headers ${AIMEE_SRC_DIR}/db1 ${AIMEE_SRC_DIR}/db2 ${AIMEE_SRC_DIR}/workflow)
 target_compile_options(aimee PRIVATE ${AIMEE_COMMON_WARNINGS})

--- a/config/workflows/build.yaml
+++ b/config/workflows/build.yaml
@@ -103,6 +103,18 @@ nodes:
       pr: code_pr.out
     params:
       policy: pr_review
+    on_pass: check_mergeable
+    on_fail: impl
+  - id: check_mergeable
+    block: check.mergeable
+    in:
+      pr: code_pr.out
+    on_pass: gate_ci
+    on_fail: impl
+  - id: gate_ci
+    block: gate.ci
+    in:
+      pr: code_pr.out
     on_pass: merge
     on_fail: impl
   - id: merge

--- a/docs/proposals/pending/workflow-config-blocks.md
+++ b/docs/proposals/pending/workflow-config-blocks.md
@@ -1,0 +1,147 @@
+# Design: config-extensible workflow blocks (+ CI/merge safety blocks)
+
+- **State:** design converged (2 rounds; reviewer READY, architect design-convincing — code-verification items deferred to the implementation roundtable)
+- **Builds on:** the merged workflow engine (`aimee-dev-lifecycle-workflow.md`, PR #288).
+- **Goal:** let users **define their own composable blocks via config** (no recompile),
+  type-checked by the same validator and run by a generic executor; and add three
+  built-in **safety blocks** (`gate.ci`, `check.mergeable`, an idempotent `merge`)
+  so a workflow can't merge red, conflicted, or already-merged work.
+
+## Motivation
+
+Today the block catalog is hard-coded (C `CATALOG[]` + the `WFE_BLK_*` enum +
+C-registered executors). Users can compose *workflows* from the built-in blocks
+but cannot add a new *block* (e.g. "run my linter", "post to Slack", "deploy")
+without editing the engine. And the engine has no built-in guard against the
+exact failure that just bit us — trying to merge a PR whose CI is red.
+
+## Part A — config-extensible blocks
+
+### Block registry (built-ins + config, merged at load)
+The catalog becomes a **runtime registry** = the static built-ins **plus** custom
+blocks loaded from `$AIMEE_HOME/workflows/blocks.yaml`:
+
+```yaml
+blocks:
+  - name: lint                 # unique; must not shadow a built-in
+    consumes: branch           # one of the closed artifact types (or "none")
+    produces: branch
+    executor: command          # command | delegate
+    command: ["make", "lint"]  # command executor: argv run in the work-item repo
+  - name: security-scan
+    consumes: branch
+    produces: branch           # scan-and-autofix transform; the GATE verdict comes
+    executor: delegate         # from gate.roundtable, NOT this block
+    persona: security
+    prompt: "Scan the branch diff for vulnerabilities and push fixes onto the branch."
+```
+
+Rules (validated at load; load fails closed on any violation):
+- `name` unique + not a built-in (shadowing a built-in is rejected).
+- `consumes` ∈ the closed artifact enum **or `none`**; `produces` ∈ **`branch` or
+  `none` only**. Custom blocks **cannot mint `verdict`, `approval`, or `pr`** —
+  those are *trust-bearing* artifacts produced only by the built-in gates
+  (the panel-scored verdict), `gate.human` (a signed approval), and `pr.open`.
+  A custom block transforms the branch (`branch→branch`, e.g. lint/format/deploy)
+  or is a side-effecting sink (`…→none`, e.g. notify). `consumes:none` (a source)
+  and `produces:none` (a sink) are both allowed and symmetric.
+- `executor ∈ {command, delegate}`; command blocks need `command` (argv), delegate
+  blocks need `persona` + `prompt`.
+The graph validator's **algorithm is unchanged**; it now resolves block types
+against the **runtime registry** (built-ins ∪ custom) instead of the static array,
+so a workflow using a custom block is type-checked exactly like one using built-ins
+(unbound/typed-mismatch still rejected).
+
+### One generic executor, keyed by `executor`
+The frozen `wfe_iface.h` seam is untouched: a custom block is a single block type
+`WFE_BLK_CUSTOM` whose node carries the resolved spec. A generic
+`exec_custom(ctx, node)`:
+- **command** — **opt-in only**: refused unless `lifecycle.allow_command_blocks:
+  true` in config (default false), because it runs operator-authored argv. Runs
+  the `command` **argv directly (never via a shell — no string interpolation)**
+  through `safe_exec_capture`, with the working directory pinned to the resolved
+  work-item repo. Non-zero exit → `WFE_STEP_FAILED`; success → the declared
+  artifact (`branch` → the branch head SHA; `none` → a sink, no artifact). Trust:
+  a `command` block is exactly as privileged as the operator's own shell; the
+  block registry is **operator-owned config** (same trust tier as `aimee.yaml`),
+  hence the explicit opt-in.
+  - **Operational contract** (a `command` block can't hang or flood the engine):
+    minimal/clean environment (PATH + a few safe vars, never the approval key or
+    other secrets), a wall-clock timeout (`lifecycle.command_timeout_ms`, default
+    ~120s → timeout ⇒ `WFE_STEP_FAILED`), and a captured-output cap (the existing
+    `safe_exec_capture` max-bytes bound).
+  - **Threat model:** the concern is not the operator (who can run anything) but a
+    malicious workflow author or a tampered `blocks.yaml`. The registry is loaded
+    only if it is operator-owned and not world/group-writable (the approval-key
+    perm check: refuse if `mode & 0022`), so a workflow author cannot introduce a
+    `command` block without write access to operator config AND the global opt-in.
+- **delegate** — dispatch the configured persona/prompt against the branch
+  (integration-gated like the other delegate-driven blocks); the produced artifact
+  is the (mutated) `branch` head, or `none`. A delegate custom block does **not**
+  produce a `verdict` — gating is the job of `gate.roundtable` with its verdict
+  contract.
+
+No new entry in the frozen seam; the executor vtable gains exactly one slot
+(`WFE_BLK_CUSTOM`); per-custom behavior is data, not code.
+
+### CLI + web
+`aimee workflow blocks` lists built-ins **and** custom blocks (marked `custom`);
+the W7 web composer renders both in the palette automatically.
+
+## Part B — three built-in safety blocks (need real forge/CI calls)
+
+These can't be pure config (they call the forge), so they ship as built-ins.
+
+**`gate.ci`** (consumes `pr` → `verdict`): polls the PR's combined CI status,
+mapping **every** state fail-closed (nothing but an explicit all-green advances):
+| forge CI state | gate result |
+| --- | --- |
+| all checks success | ADVANCE (APPROVE) |
+| any failure / error / cancelled / timed_out | LOOP (REQUEST_CHANGES) |
+| pending / queued / in_progress | PARK (re-poll later) |
+| no checks / unknown / forge unreachable | PARK (never advance) |
+Polling is **bounded**: the gate parks (it does not busy-loop); each re-poll is a
+fresh advance, and the engine's per-stage `max_attempts` + a `gate.ci.poll_timeout`
+cap the wait, then park `pending_human` so a human decides — never an indefinite
+spin.
+
+**`check.mergeable`** (consumes `pr` → `verdict`): no merge conflict against base →
+ADVANCE; conflict → LOOP (back to implement); `UNKNOWN` mergeability (forge still
+computing) → PARK + re-check.
+
+**`merge` hardened (idempotent + race-safe)**: the merge act is the single source
+of truth. It (1) reads the PR state; if **already `MERGED`** → no-op success
+(never re-push/re-merge); (2) else issues the forge merge, and treats the forge's
+own *"already merged"/"not mergeable"* responses as authoritative — an
+already-merged race resolves to success, a not-mergeable/lost-race resolves to
+LOOP, never a forced or duplicate merge. Detection is not a separate
+check-then-act window: the merge command itself is the atomic decision.
+
+The default `build.yaml` gains `check.mergeable` then `gate.ci` between the code
+PR's human pass and `merge`, so the base workflow cannot merge conflicted, red, or
+already-merged work.
+
+## Validation / tests
+- Registry loader: reject duplicate/shadowing names, unknown artifact types, bad
+  executor kinds, missing command/persona; a valid custom block round-trips.
+- A workflow composed with a custom block type-checks (and a type-mismatched one
+  is rejected) by the unchanged validator.
+- `exec_custom`: command non-zero → FAILED; command success → declared artifact.
+- `gate.ci` / `check.mergeable` decision mapping (mock forge): pass→advance,
+  fail→loop, pending→park, unknown→park; `merge` on an already-merged PR → no-op.
+
+## Out of scope
+- Custom **artifact types** (the artifact enum stays closed; custom blocks reuse
+  it). - Custom blocks that need new C capabilities beyond command/delegate.
+- The live `gate.ci`/forge calls are integration-gated (mock-tested here), like
+  the existing delegate/forge executors.
+
+## Risks
+- A `command` executor runs operator-authored argv (no shell, argv-only) — same
+  trust as the operator's shell; gated behind `lifecycle.allow_command_blocks`
+  (default false) and run only in the work-item repo. The block registry is
+  operator-owned config (same trust as `aimee.yaml`).
+- Custom blocks cannot mint trust-bearing artifacts (`verdict`/`approval`/`pr`) —
+  enforced at registry load, so a custom block can never impersonate a gate.
+- Config drift vs built-ins: a custom block shadowing a built-in name is rejected
+  at load (fail closed).

--- a/src/Makefile
+++ b/src/Makefile
@@ -294,7 +294,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
-            workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c
+            workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
@@ -364,7 +364,7 @@ CLIENT_PLATFORM_OBJS = $(filter %/platform_ipc.o %/platform_net.o %/platform_pat
 # with full flags; --gc-sections trims the unused remainder). util.o supplies
 # run_cmd/run_cmd_set_cwd for the provider exec_shell op the runner now serves.
 CLIENT_RUNNER_OBJS = $(OBJDIR)/server/workspace_provider_detached.o $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/posix/util.o $(OBJDIR)/util.o
-CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(OBJDIR)/codex_auth.o $(OBJDIR)/yaml.o $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
+CLIENT_SUPPORT_OBJS = $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o $(OBJDIR)/aimee_home.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o $(OBJDIR)/code_collect.o $(OBJDIR)/codex_auth.o $(OBJDIR)/yaml.o $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(CLIENT_PLATFORM_OBJS) $(CLIENT_RUNNER_OBJS)
 CLIENT_COMPILE_OBJS = $(CLI_OBJS) $(CLIENT_PLATFORM_OBJS) $(OBJDIR)/dstr.o $(OBJDIR)/history.o $(OBJDIR)/markdown.o
 $(CLIENT_COMPILE_OBJS): C_FLAGS := $(CLIENT_C_FLAGS)
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -102,6 +102,8 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-approval \
                $(TESTPREFIX)/unit-test-wfe-roundtable \
                $(TESTPREFIX)/unit-test-wfe-autonomy \
+               $(TESTPREFIX)/unit-test-wfe-custom \
+               $(TESTPREFIX)/unit-test-wfe-safety \
                $(TESTPREFIX)/unit-test-cli-profile \
                $(TESTPREFIX)/unit-test-cmd-profile \
                $(TESTPREFIX)/unit-test-kb-client-index \
@@ -905,7 +907,8 @@ $(TESTPREFIX)/unit-test-compute-concurrency: $(OBJDIR)/tests/test_compute_concur
 # Workflow engine W1: pure (yaml/cJSON/dstr only), no DB/config needed.
 $(TESTPREFIX)/unit-test-workflow: $(OBJDIR)/tests/test_workflow.o \
                                   $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_iface.o \
-                                  $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o \
+                                  $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                  $(OBJDIR)/aimee_home.o \
                                   $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -914,7 +917,7 @@ $(TESTPREFIX)/unit-test-wfe-engine: $(OBJDIR)/tests/test_wfe_engine.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_engine.o \
                                     $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_iface.o \
-                                    $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o \
+                                    $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
                                     $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                                     $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
@@ -925,9 +928,30 @@ $(TESTPREFIX)/unit-test-wfe-blocks: $(OBJDIR)/tests/test_wfe_blocks.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                     $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
-                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/aimee_home.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(OBJDIR)/aimee_home.o \
                                     $(OBJDIR)/util.o $(OBJDIR)/posix/util.o $(OBJDIR)/yaml.o \
                                     $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Config-extensible blocks + safety blocks share the blocks/engine/registry deps.
+$(TESTPREFIX)/unit-test-wfe-custom: $(OBJDIR)/tests/test_wfe_custom.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-wfe-safety: $(OBJDIR)/tests/test_wfe_safety.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Workflow engine W4: HMAC approval signer + gate.human.
@@ -936,7 +960,7 @@ $(TESTPREFIX)/unit-test-wfe-approval: $(OBJDIR)/tests/test_wfe_approval.o \
                                       $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                       $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                       $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
-                                      $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/aimee_home.o \
+                                      $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(OBJDIR)/aimee_home.o \
                                       $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -947,7 +971,7 @@ $(TESTPREFIX)/unit-test-wfe-roundtable: $(OBJDIR)/tests/test_wfe_roundtable.o \
                                         $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                         $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
                                         $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
-                                        $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/aimee_home.o \
+                                        $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o $(OBJDIR)/aimee_home.o \
                                         $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -958,7 +982,7 @@ $(TESTPREFIX)/unit-test-wfe-autonomy: $(OBJDIR)/tests/test_wfe_autonomy.o \
                                       $(OBJDIR)/workflow/wfe_engine.o $(OBJDIR)/db1/db1_init.o \
                                       $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/wfe_store.o \
                                       $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_iface.o \
-                                      $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o \
+                                      $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
                                       $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                                       $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_wfe_custom.c
+++ b/src/tests/test_wfe_custom.c
@@ -1,0 +1,191 @@
+/* test_wfe_custom.c -- config-extensible blocks: registry load/validate, custom
+ * block type-checking, and exec_custom (command opt-in) through the engine. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "db1.h"
+#include "wfe_store.h"
+#include "wfe_blocks.h"
+#include "wfe_def.h"
+#include "wfe_engine.h"
+#include "wfe_iface.h"
+
+static char g_home[64];
+
+static void write_file(const char *path, const char *body, mode_t mode)
+{
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(body, f);
+   fclose(f);
+   chmod(path, mode);
+}
+
+/* block-style YAML (aimee's yaml.c does not support flow [] sequences). */
+static const char *GOOD_BLOCKS = "allow_command: true\n"
+                                 "blocks:\n"
+                                 "  - name: lint\n"
+                                 "    consumes: branch\n"
+                                 "    produces: branch\n"
+                                 "    executor: command\n"
+                                 "    command:\n"
+                                 "      - /bin/true\n"
+                                 "  - name: notify\n"
+                                 "    consumes: none\n"
+                                 "    produces: none\n"
+                                 "    executor: command\n"
+                                 "    command:\n"
+                                 "      - /bin/true\n";
+
+static const char *blocks_path(void)
+{
+   static char p[256];
+   snprintf(p, sizeof p, "%s/workflows/blocks.yaml", g_home);
+   return p;
+}
+
+int main(void)
+{
+   printf("wfe-custom: ");
+   strcpy(g_home, "/tmp/wfe_cust_XXXXXX");
+   assert(mkdtemp(g_home));
+   char wf[128];
+   snprintf(wf, sizeof wf, "%s/workflows", g_home);
+   mkdir(wf, 0755);
+   setenv("AIMEE_HOME", g_home, 1);
+
+   char err[256];
+
+   /* --- valid registry loads; lookup + node-aware typing --- */
+   write_file(blocks_path(), GOOD_BLOCKS, 0600);
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) == 0);
+   assert(wfe_custom_count() == 2);
+   assert(wfe_custom_commands_allowed() == 1);
+   const wfe_custom_block_t *lint = wfe_custom_lookup("lint");
+   assert(lint && lint->consumes == WFE_ART_BRANCH && lint->produces == WFE_ART_BRANCH);
+   assert(wfe_block_from_name("lint") == WFE_BLK_CUSTOM);
+   assert(wfe_block_from_name("notify") == WFE_BLK_CUSTOM);
+
+   /* --- reject paths (each fails the load) --- */
+   wfe_custom_registry_reset();
+   write_file(blocks_path(),
+              "blocks:\n  - name: merge\n    consumes: pr\n    produces: none\n"
+              "    executor: command\n    command:\n      - /bin/true\n",
+              0600); /* shadows built-in */
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) != 0);
+
+   write_file(blocks_path(),
+              "blocks:\n  - name: x\n    consumes: branch\n    produces: verdict\n"
+              "    executor: delegate\n    persona: security\n    prompt: hi\n",
+              0600); /* trust-bearing produces forbidden */
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) != 0);
+
+   write_file(blocks_path(),
+              "blocks:\n  - name: x\n    consumes: branch\n    produces: branch\n"
+              "    executor: nonsense\n",
+              0600); /* bad executor */
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) != 0);
+
+   /* world/group-writable registry is refused */
+   write_file(blocks_path(), GOOD_BLOCKS, 0666);
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) != 0);
+
+   /* duplicate custom block name is rejected */
+   write_file(blocks_path(),
+              "blocks:\n  - name: dup\n    consumes: none\n    produces: none\n"
+              "    executor: command\n    command:\n      - /bin/true\n"
+              "  - name: dup\n    consumes: none\n    produces: none\n"
+              "    executor: command\n    command:\n      - /bin/true\n",
+              0600);
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) != 0);
+
+   /* an over-long argv element is rejected (no silent truncation) */
+   {
+      char big[1200];
+      memset(big, 'a', sizeof big - 1);
+      big[sizeof big - 1] = '\0';
+      char body[1600];
+      snprintf(body, sizeof body,
+               "allow_command: true\nblocks:\n  - name: x\n    consumes: none\n"
+               "    produces: none\n    executor: command\n    command:\n      - %s\n",
+               big);
+      write_file(blocks_path(), body, 0600);
+      assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) != 0);
+   }
+
+   /* a symlinked registry is refused, not silently treated as "no registry" */
+   {
+      char target[256], link[256];
+      snprintf(target, sizeof target, "%s/workflows/real_blocks.yaml", g_home);
+      snprintf(link, sizeof link, "%s/workflows/link_blocks.yaml", g_home);
+      write_file(target, GOOD_BLOCKS, 0600);
+      assert(symlink(target, link) == 0);
+      assert(wfe_custom_registry_load(link, err, sizeof err) != 0);
+   }
+
+   /* --- a workflow using a custom block type-checks; a mismatch is rejected --- */
+   write_file(blocks_path(), GOOD_BLOCKS, 0600);
+   assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) == 0);
+   {
+      /* impl(branch) -> lint(branch->branch) -> done(merge needs pr) : the lint
+       * input must be a branch; feed it a branch and it validates. */
+      static const char *WF = "name: cw\nstart: a\nnodes:\n"
+                              "  - id: a\n    block: implement\n    in:\n      plan: p.out\n"
+                              "    next: lint\n"
+                              "  - id: p\n    block: author.plan\n    in:\n      pr: pp.out\n"
+                              "  - id: pp\n    block: author.proposal\n    next: a\n"
+                              "  - id: lint\n    block: lint\n    in:\n      src: a.out\n";
+      /* (graph is illustrative; we only assert the custom node's typing resolves) */
+      wfe_def_t *d = wfe_def_parse(WF, err, sizeof err);
+      assert(d);
+      const wfe_node_t *ln = wfe_def_node(d, "lint");
+      assert(ln && ln->block == WFE_BLK_CUSTOM && strcmp(ln->custom_name, "lint") == 0);
+      assert(wfe_node_output(ln) == WFE_ART_BRANCH);
+      assert(wfe_node_accepts_input(ln, WFE_ART_BRANCH) == 1);
+      assert(wfe_node_accepts_input(ln, WFE_ART_PROPOSAL) == 0);
+      wfe_def_free(d);
+   }
+
+   /* --- exec_custom through the engine: a single `notify` command block
+    *     (consumes/produces none, runs `true`) advances to accepted; with
+    *     allow_command off the command block fails closed. --- */
+   {
+      assert(db1_init(":memory:") == 0);
+      /* single-node workflow: notify is start + terminal (no edges). */
+      static const char *WF = "name: cwf\nstart: n\nnodes:\n"
+                              "  - id: n\n    block: notify\n";
+      char path[256];
+      snprintf(path, sizeof path, "%s/workflows/cwf.yaml", g_home);
+      write_file(path, WF, 0644);
+      wfe_reset_block_executors();
+      wfe_register_default_executors(); /* real exec_custom */
+
+      char id[80] = "";
+      assert(wfe_work_item_create("cwf", "r", "pn", "interactive", id, err, sizeof err) == 0);
+      assert(wfe_engine_run(id, err, sizeof err) == 0);
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "accepted") == 0); /* command ran -> none -> terminal */
+
+      /* allow_command OFF -> the command block fails closed (work item not accepted) */
+      write_file(blocks_path(),
+                 "blocks:\n  - name: notify\n    consumes: none\n"
+                 "    produces: none\n    executor: command\n    command:\n"
+                 "      - /bin/true\n",
+                 0600);
+      assert(wfe_custom_registry_load(blocks_path(), err, sizeof err) == 0);
+      assert(wfe_custom_commands_allowed() == 0);
+      char id2[80] = "";
+      assert(wfe_work_item_create("cwf", "r", "pn2", "interactive", id2, err, sizeof err) == 0);
+      assert(wfe_engine_run(id2, err, sizeof err) == 0);
+      assert(db1_work_item_get(id2, &wi) == 1);
+      assert(strcmp(wi.state, "accepted") != 0); /* failed/parked, not accepted */
+   }
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_wfe_safety.c
+++ b/src/tests/test_wfe_safety.c
@@ -1,0 +1,148 @@
+/* test_wfe_safety.c -- gate.ci / check.mergeable / idempotent merge via a mock
+ * forge provider, exercised through the engine. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "db1.h"
+#include "wfe_store.h"
+#include "wfe_blocks.h"
+#include "wfe_def.h"
+#include "wfe_engine.h"
+#include "wfe_iface.h"
+
+/* configurable mock forge */
+static wfe_ci_status_t g_ci;
+static int g_mergeable, g_is_merged;
+static wfe_merge_result_t g_merge;
+static wfe_ci_status_t m_ci(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return g_ci;
+}
+static int m_mergeable(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return g_mergeable;
+}
+static int m_is_merged(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return g_is_merged;
+}
+static wfe_merge_result_t m_merge(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return g_merge;
+}
+static const wfe_forge_t MOCK = {m_ci, m_mergeable, m_is_merged, m_merge};
+
+/* pp -> pr -> check.mergeable -> gate.ci -> merge; gates loop back to pp. */
+static const char *WF = "name: sf\nstart: pp\nnodes:\n"
+                        "  - id: pp\n    block: author.proposal\n    next: pr\n"
+                        "  - id: pr\n    block: pr.open\n    in:\n      src: pp.out\n"
+                        "    next: cm\n"
+                        "  - id: cm\n    block: check.mergeable\n    in:\n      pr: pr.out\n"
+                        "    on_pass: ci\n    on_fail: pp\n"
+                        "  - id: ci\n    block: gate.ci\n    in:\n      pr: pr.out\n"
+                        "    on_pass: m\n    on_fail: pp\n"
+                        "  - id: m\n    block: merge\n    in:\n      pr: pr.out\n";
+
+static int run_fresh(const char *path_suffix)
+{
+   char id[80] = "", err[256] = "";
+   if (wfe_work_item_create("sf", "r", path_suffix, "interactive", id, err, sizeof err) != 0)
+   {
+      return -99;
+   }
+   if (wfe_engine_run(id, err, sizeof err) != 0)
+   {
+      return -98;
+   }
+   db1_work_item_t wi;
+   if (db1_work_item_get(id, &wi) != 1)
+      return -97;
+   if (strcmp(wi.state, "accepted") == 0)
+      return 1; /* merged */
+   if (strcmp(wi.pause_reason, "ci_pending") == 0)
+      return 2; /* parked on CI */
+   if (strcmp(wi.pause_reason, "pending_human") == 0)
+      return 3; /* looped out */
+   if (strcmp(wi.pause_reason, "merge_pending") == 0)
+      return 4; /* merge state undeterminable -> parked */
+   return 0;
+}
+
+int main(void)
+{
+   printf("wfe-safety: ");
+   char home[] = "/tmp/wfe_sft_XXXXXX";
+   assert(mkdtemp(home));
+   char wf[128];
+   snprintf(wf, sizeof wf, "%s/workflows", home);
+   mkdir(wf, 0755);
+   char p[256];
+   snprintf(p, sizeof p, "%s/workflows/sf.yaml", home);
+   FILE *f = fopen(p, "wb");
+   assert(f);
+   fputs(WF, f);
+   fclose(f);
+   setenv("AIMEE_HOME", home, 1);
+   assert(db1_init(":memory:") == 0);
+
+   wfe_reset_block_executors();
+   wfe_register_default_executors();
+   wfe_set_forge_provider(&MOCK);
+
+   /* A: all green + not-yet-merged -> merge OK -> accepted */
+   g_mergeable = 1;
+   g_ci = WFE_CI_SUCCESS;
+   g_is_merged = 0;
+   g_merge = WFE_MERGE_OK;
+   assert(run_fresh("a") == 1);
+
+   /* B: CI failing -> gate.ci loops -> max_attempts -> pending_human (not merged) */
+   g_ci = WFE_CI_FAILURE;
+   assert(run_fresh("b") == 3);
+
+   /* C: CI still running -> park ci_pending (never advances/merges) */
+   g_ci = WFE_CI_PENDING;
+   assert(run_fresh("c") == 2);
+
+   /* D: merge conflict -> check.mergeable loops -> pending_human */
+   g_ci = WFE_CI_SUCCESS;
+   g_mergeable = 0;
+   assert(run_fresh("d") == 3);
+
+   /* E: already merged -> idempotent no-op success (merge fn never reached) */
+   g_mergeable = 1;
+   g_ci = WFE_CI_SUCCESS;
+   g_is_merged = 1;
+   g_merge = WFE_MERGE_ERROR; /* would fail if called; is_merged short-circuits */
+   assert(run_fresh("e") == 1);
+
+   /* F: mergeability undeterminable (forge error) -> check.mergeable parks
+    *    (merge_pending), never advances on an unknown state. */
+   g_mergeable = -1;
+   g_ci = WFE_CI_SUCCESS;
+   g_is_merged = 0;
+   g_merge = WFE_MERGE_OK;
+   assert(run_fresh("f") == 4);
+
+   /* G: merge-state undeterminable at the merge step -> park (merge_pending);
+    *    merge() is never called, so a transient error cannot double-merge. */
+   g_mergeable = 1;
+   g_ci = WFE_CI_SUCCESS;
+   g_is_merged = -1;       /* cannot confirm not-already-merged */
+   g_merge = WFE_MERGE_OK; /* would merge if (wrongly) called */
+   assert(run_fresh("g") == 4);
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -93,6 +93,43 @@ int wfe_git_freeze(const char *repo_dir_in, const char *base_branch, char out_ba
    return 0;
 }
 
+/* ---- forge seam (gate.ci / check.mergeable / merge) ---- */
+
+/* Default live provider would call `gh`, but PR-identity threading is
+ * integration-gated, so until that lands it fails closed (unknown -> park,
+ * merge unavailable). Tests inject a mock to exercise the state mapping. */
+static wfe_ci_status_t live_ci_status(const char *repo, const char *pr)
+{
+   (void)repo;
+   (void)pr;
+   return WFE_CI_NONE;
+}
+static int live_mergeable(const char *repo, const char *pr)
+{
+   (void)repo;
+   (void)pr;
+   return -1;
+}
+static int live_is_merged(const char *repo, const char *pr)
+{
+   (void)repo;
+   (void)pr;
+   return -1;
+}
+static wfe_merge_result_t live_merge(const char *repo, const char *pr)
+{
+   (void)repo;
+   (void)pr;
+   return WFE_MERGE_ERROR;
+}
+static const wfe_forge_t LIVE_FORGE = {live_ci_status, live_mergeable, live_is_merged, live_merge};
+static const wfe_forge_t *g_forge = &LIVE_FORGE;
+
+void wfe_set_forge_provider(const wfe_forge_t *p)
+{
+   g_forge = p ? p : &LIVE_FORGE;
+}
+
 /* ---- executors ---- */
 
 /* author.proposal / author.plan: drive a delegate to produce/edit the artifact,
@@ -187,13 +224,117 @@ static wfe_step_result_t exec_pr_open(wfe_ctx *ctx, const wfe_node_t *node)
    return wfe_step_advanced(handle, "", 0.0);
 }
 
-/* merge: merge the approved PR. */
+/* the PR ref the forge ops act on. Live wiring would resolve a real PR number
+ * stored when pr.open ran; for now we pass the work-item id (the mock ignores
+ * it; the live provider is gated). */
+static const char *pr_ref(wfe_ctx *ctx)
+{
+   const char *wi = wfe_ctx_work_item(ctx);
+   return wi ? wi : "";
+}
+
+/* merge: idempotent + race-safe. The never-re-merge invariant is enforced by
+ * requiring a CONFIRMED not-merged state before we ever call merge():
+ *   is_merged == 1  -> idempotent no-op success (already merged)
+ *   is_merged <  0  -> state could not be determined (transient forge error) ->
+ *                      park; we never call merge() when we can't confirm the PR
+ *                      is unmerged, so a transient error can never double-merge.
+ *   is_merged == 0  -> confirmed unmerged: the forge merge act is the single
+ *                      decision (already-race -> success, not-mergeable -> loop,
+ *                      transient error -> park for a human re-drive). */
 static wfe_step_result_t exec_merge(wfe_ctx *ctx, const wfe_node_t *node)
 {
-   (void)ctx;
-   (void)node;
-   /* Production: `gh pr merge --squash`. Terminal on success. */
-   return wfe_step_advanced("merged", "", 0.0);
+   const char *repo = wfe_ctx_repo(ctx), *pr = pr_ref(ctx);
+   int im = g_forge->is_merged(repo, pr);
+   if (im == 1)
+      return wfe_step_advanced("merged", "", 0.0); /* idempotent no-op */
+   if (im < 0)
+      return wfe_step_pending(WFE_PAUSE_MERGE_PENDING); /* unconfirmed -> never merge */
+   switch (g_forge->merge(repo, pr))
+   {
+   case WFE_MERGE_OK:
+   case WFE_MERGE_ALREADY:
+      return wfe_step_advanced("merged", "", 0.0);
+   case WFE_MERGE_NOT_MERGEABLE:
+      return wfe_step_looped();
+   default:
+      /* transient/unknown forge error on the merge act itself: park for a human
+       * re-drive rather than hard-failing the run. We only reach here with a
+       * confirmed-unmerged PR, so this can never double-merge. */
+      (void)node;
+      return wfe_step_pending(WFE_PAUSE_MERGE_PENDING);
+   }
+}
+
+/* gate.ci: only an explicit all-green advances; everything else fails closed. */
+static wfe_step_result_t exec_gate_ci(wfe_ctx *ctx, const wfe_node_t *node)
+{
+   switch (g_forge->ci_status(wfe_ctx_repo(ctx), pr_ref(ctx)))
+   {
+   case WFE_CI_SUCCESS:
+   {
+      char h[80];
+      snprintf(h, sizeof h, "%s.out", node->id);
+      return wfe_step_advanced(h, "", 0.0);
+   }
+   case WFE_CI_FAILURE:
+      return wfe_step_looped();
+   default: /* PENDING or NONE/unknown -> park, never advance */
+      return wfe_step_pending(WFE_PAUSE_CI_PENDING);
+   }
+}
+
+/* check.mergeable: mergeable (1) advances; conflict (0) loops back to fix it;
+ * unknown (-1, transient forge error) parks -- it never advances on an
+ * undetermined state (fail closed), and uses the merge-state pause reason rather
+ * than the CI one so the park is labelled correctly. */
+static wfe_step_result_t exec_check_mergeable(wfe_ctx *ctx, const wfe_node_t *node)
+{
+   int m = g_forge->mergeable(wfe_ctx_repo(ctx), pr_ref(ctx));
+   if (m == 1)
+   {
+      char h[80];
+      snprintf(h, sizeof h, "%s.out", node->id);
+      return wfe_step_advanced(h, "", 0.0);
+   }
+   if (m == 0)
+      return wfe_step_looped();
+   return wfe_step_pending(WFE_PAUSE_MERGE_PENDING); /* unknown -> park, never advance */
+}
+
+/* custom: the one generic executor for config-defined blocks. */
+static wfe_step_result_t exec_custom(wfe_ctx *ctx, const wfe_node_t *node)
+{
+   const wfe_custom_block_t *c = wfe_custom_lookup(node->custom_name);
+   if (!c)
+      return wfe_step_failed();
+   char head[64] = "", base[64] = "", dhash[65] = "", err[128] = "";
+   char handle[80];
+   snprintf(handle, sizeof handle, "%s.out", node->id);
+
+   if (c->executor == WFE_EXEC_COMMAND)
+   {
+      if (!wfe_custom_commands_allowed())
+         return wfe_step_failed(); /* opt-in: lifecycle allow_command not set */
+      if (c->argc == 0)
+         return wfe_step_failed();
+      /* argv is the registry's OWNED, length-bounded, all-string, NULL-terminated
+       * array (validated at load); run it directly (no shell) in the repo. */
+      char *out = NULL;
+      int rc = safe_exec_capture((const char *const *)c->argv, &out, 1 << 20);
+      free(out);
+      if (rc != 0)
+         return wfe_step_failed();
+   }
+   /* delegate executor is integration-gated (like implement/document). */
+
+   if (c->produces == WFE_ART_BRANCH)
+   {
+      if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
+         return wfe_step_failed();
+      return wfe_step_advanced(handle, head, 0.0);
+   }
+   return wfe_step_advanced(handle, "", 0.0); /* produces: none (sink) */
 }
 
 void wfe_register_default_executors(void)
@@ -205,4 +346,7 @@ void wfe_register_default_executors(void)
    wfe_register_block_executor(WFE_BLK_FREEZE, exec_freeze);
    wfe_register_block_executor(WFE_BLK_PR_OPEN, exec_pr_open);
    wfe_register_block_executor(WFE_BLK_MERGE, exec_merge);
+   wfe_register_block_executor(WFE_BLK_GATE_CI, exec_gate_ci);
+   wfe_register_block_executor(WFE_BLK_CHECK_MERGEABLE, exec_check_mergeable);
+   wfe_register_block_executor(WFE_BLK_CUSTOM, exec_custom);
 }

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -17,4 +17,34 @@ void wfe_register_default_executors(void);
 int wfe_git_freeze(const char *repo_dir, const char *base_branch, char out_base_sha[64],
                    char out_head_sha[64], char out_diff_hash[65], char *err, size_t errlen);
 
+/* ---- Forge seam for the safety blocks (gate.ci / check.mergeable / merge).
+ * The default provider calls `gh` and is integration-gated; tests inject a mock
+ * so the state-mapping + idempotent-merge logic is unit-testable. ---- */
+typedef enum
+{
+   WFE_CI_SUCCESS = 0, /* all checks green */
+   WFE_CI_FAILURE,     /* any failed/error/cancelled/timed_out */
+   WFE_CI_PENDING,     /* still running */
+   WFE_CI_NONE         /* no checks / unknown / unreachable -> fail closed */
+} wfe_ci_status_t;
+
+typedef enum
+{
+   WFE_MERGE_OK = 0,        /* merged now */
+   WFE_MERGE_ALREADY,       /* already merged -> idempotent no-op success */
+   WFE_MERGE_NOT_MERGEABLE, /* conflict / lost race -> loop */
+   WFE_MERGE_ERROR          /* forge error -> fail closed */
+} wfe_merge_result_t;
+
+typedef struct
+{
+   wfe_ci_status_t (*ci_status)(const char *repo, const char *pr_ref);
+   int (*mergeable)(const char *repo, const char *pr_ref); /* 1 yes, 0 conflict, -1 unknown */
+   int (*is_merged)(const char *repo, const char *pr_ref); /* 1 merged, 0 open, -1 unknown */
+   wfe_merge_result_t (*merge)(const char *repo, const char *pr_ref);
+} wfe_forge_t;
+
+/* Install a forge provider (NULL restores the default live/gh provider). */
+void wfe_set_forge_provider(const wfe_forge_t *p);
+
 #endif /* DEC_WFE_BLOCKS_H */

--- a/src/workflow/wfe_canonical.c
+++ b/src/workflow/wfe_canonical.c
@@ -193,7 +193,8 @@ static cJSON *normalize(const wfe_def_t *def)
       const wfe_node_t *nd = &def->nodes[idx[i]];
       cJSON *jn = cJSON_CreateObject();
       cJSON_AddStringToObject(jn, "id", nd->id);
-      cJSON_AddStringToObject(jn, "block", wfe_block_name(nd->block));
+      cJSON_AddStringToObject(
+          jn, "block", nd->block == WFE_BLK_CUSTOM ? nd->custom_name : wfe_block_name(nd->block));
       if (nd->n_ins > 0)
       {
          cJSON *jin = cJSON_CreateObject();

--- a/src/workflow/wfe_custom.c
+++ b/src/workflow/wfe_custom.c
@@ -1,0 +1,415 @@
+/* wfe_custom.c: the config-defined block registry ($AIMEE_HOME/workflows/
+ * blocks.yaml) + node-aware typed-I/O accessors. Built-in blocks stay in
+ * wfe_def.c's catalog; this adds user-defined blocks (one generic WFE_BLK_CUSTOM
+ * type, per-block behavior is data). Part of CORE so the client validates too.
+ *
+ * Lifetime: every string the registry exposes (argv, prompt) is OWNED (strdup'd)
+ * here, so the registry does not depend on the parsed YAML tree staying alive and
+ * a reload/reset can never dangle a previously-returned wfe_custom_block_t field.
+ */
+#include "wfe_def.h"
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "aimee_home.h"
+#include "yaml.h"
+
+#define WFE_CUSTOM_MAX 64
+
+static wfe_custom_block_t g_blocks[WFE_CUSTOM_MAX];
+static int g_count = 0;
+static int g_loaded = 0;
+static int g_allow_command = 0;
+
+static wfe_artifact_type_t artifact_from_name(const char *s)
+{
+   if (!s)
+      return -1;
+   for (wfe_artifact_type_t a = WFE_ART_NONE; a < WFE_ART__COUNT; a++)
+      if (strcmp(wfe_artifact_name(a), s) == 0)
+         return a;
+   return -1;
+}
+
+static void free_block(wfe_custom_block_t *b)
+{
+   for (int i = 0; i < b->argc; i++)
+      free(b->argv[i]);
+   free(b->prompt);
+   memset(b, 0, sizeof *b);
+}
+
+void wfe_custom_registry_reset(void)
+{
+   for (int i = 0; i < g_count; i++)
+      free_block(&g_blocks[i]);
+   g_count = 0;
+   g_loaded = 0;
+   g_allow_command = 0;
+}
+
+int wfe_custom_count(void)
+{
+   return g_count;
+}
+const wfe_custom_block_t *wfe_custom_at(int i)
+{
+   return (i >= 0 && i < g_count) ? &g_blocks[i] : NULL;
+}
+int wfe_custom_commands_allowed(void)
+{
+   return g_allow_command;
+}
+
+const wfe_custom_block_t *wfe_custom_lookup(const char *name)
+{
+   if (!name)
+      return NULL;
+   for (int i = 0; i < g_count; i++)
+      if (strcmp(g_blocks[i].name, name) == 0)
+         return &g_blocks[i];
+   return NULL;
+}
+
+/* copy a string field that must fit a fixed buffer; reject (don't truncate). */
+static int fit(char *dst, size_t cap, const char *src, const char *what, const char *who, char *err,
+               size_t errlen)
+{
+   if (strlen(src) >= cap)
+   {
+      snprintf(err, errlen, "custom block '%s': %s too long (max %zu)", who, what, cap - 1);
+      return -1;
+   }
+   snprintf(dst, cap, "%s", src);
+   return 0;
+}
+
+static int parse_one(const cJSON *b, wfe_custom_block_t *out, char *err, size_t errlen)
+{
+   memset(out, 0, sizeof *out);
+   const cJSON *jn = cJSON_GetObjectItemCaseSensitive(b, "name");
+   if (!cJSON_IsString(jn) || !jn->valuestring[0])
+   {
+      snprintf(err, errlen, "custom block missing 'name'");
+      return -1;
+   }
+   if (fit(out->name, sizeof out->name, jn->valuestring, "name", jn->valuestring, err, errlen) != 0)
+      return -1;
+   /* explicit duplicate scan over already-committed blocks (clear message, and
+    * independent of wfe_block_from_name's registry fall-through). out is
+    * &g_blocks[g_count] (not yet committed), so [0..g_count-1] excludes it. */
+   for (int i = 0; i < g_count; i++)
+      if (strcmp(g_blocks[i].name, out->name) == 0)
+      {
+         snprintf(err, errlen, "duplicate custom block '%s'", out->name);
+         return -1;
+      }
+   /* shadow a built-in? the registry fall-through can only return CUSTOM, which
+    * the duplicate scan above already rejected, so any non-UNKNOWN is built-in. */
+   if (wfe_block_from_name(out->name) != WFE_BLK_UNKNOWN)
+   {
+      snprintf(err, errlen, "custom block '%s' shadows a built-in", out->name);
+      return -1;
+   }
+   const cJSON *jc = cJSON_GetObjectItemCaseSensitive(b, "consumes");
+   const cJSON *jp = cJSON_GetObjectItemCaseSensitive(b, "produces");
+   out->consumes = artifact_from_name(cJSON_IsString(jc) ? jc->valuestring : "none");
+   out->produces = artifact_from_name(cJSON_IsString(jp) ? jp->valuestring : "none");
+   if ((int)out->consumes < 0)
+   {
+      snprintf(err, errlen, "custom block '%s': unknown consumes type", out->name);
+      return -1;
+   }
+   if (out->produces != WFE_ART_BRANCH && out->produces != WFE_ART_NONE)
+   {
+      snprintf(err, errlen, "custom block '%s': produces must be 'branch' or 'none'", out->name);
+      free_block(out);
+      return -1;
+   }
+   const cJSON *je = cJSON_GetObjectItemCaseSensitive(b, "executor");
+   const char *ex = cJSON_IsString(je) ? je->valuestring : "";
+   if (strcmp(ex, "command") == 0)
+   {
+      out->executor = WFE_EXEC_COMMAND;
+      const cJSON *cmd = cJSON_GetObjectItemCaseSensitive(b, "command");
+      if (!cJSON_IsArray(cmd) || cJSON_GetArraySize(cmd) == 0)
+      {
+         snprintf(err, errlen, "custom block '%s': command executor needs a non-empty argv array",
+                  out->name);
+         return -1;
+      }
+      if (cJSON_GetArraySize(cmd) > WFE_CUSTOM_ARGV_MAX)
+      {
+         snprintf(err, errlen, "custom block '%s': command argv exceeds %d elements", out->name,
+                  WFE_CUSTOM_ARGV_MAX);
+         return -1;
+      }
+      const cJSON *arg = NULL;
+      cJSON_ArrayForEach(arg, cmd)
+      {
+         if (!cJSON_IsString(arg))
+         {
+            snprintf(err, errlen,
+                     "custom block '%s': command argv must be all strings (quote bare "
+                     "true/false/numbers)",
+                     out->name);
+            free_block(out);
+            return -1;
+         }
+         if (strlen(arg->valuestring) >= WFE_CUSTOM_ARG_MAX)
+         {
+            snprintf(err, errlen, "custom block '%s': command argv element too long (max %d)",
+                     out->name, WFE_CUSTOM_ARG_MAX - 1);
+            free_block(out);
+            return -1;
+         }
+         out->argv[out->argc] = strdup(arg->valuestring);
+         if (!out->argv[out->argc])
+         {
+            free_block(out);
+            return -1;
+         }
+         out->argc++;
+      }
+      out->argv[out->argc] = NULL;
+   }
+   else if (strcmp(ex, "delegate") == 0)
+   {
+      out->executor = WFE_EXEC_DELEGATE;
+      const cJSON *jper = cJSON_GetObjectItemCaseSensitive(b, "persona");
+      const cJSON *jpr = cJSON_GetObjectItemCaseSensitive(b, "prompt");
+      if (!cJSON_IsString(jper) || !cJSON_IsString(jpr))
+      {
+         snprintf(err, errlen, "custom block '%s': delegate executor needs persona + prompt",
+                  out->name);
+         return -1;
+      }
+      if (fit(out->persona, sizeof out->persona, jper->valuestring, "persona", out->name, err,
+              errlen) != 0)
+         return -1;
+      out->prompt = strdup(jpr->valuestring);
+      if (!out->prompt)
+      {
+         free_block(out);
+         return -1;
+      }
+   }
+   else
+   {
+      snprintf(err, errlen, "custom block '%s': executor must be 'command' or 'delegate'",
+               out->name);
+      return -1;
+   }
+   return 0;
+}
+
+int wfe_custom_registry_load(const char *path, char *err, size_t errlen)
+{
+   if (err && errlen)
+      err[0] = '\0';
+   wfe_custom_registry_reset();
+
+   char *buf = NULL;
+   size_t got = 0;
+#ifndef _WIN32
+   /* POSIX (server + Linux/macOS client): symlink-safe, operator-owned, not
+    * group/world-writable (the approval-key posture). */
+   int fd = open(path, O_RDONLY | O_NOFOLLOW);
+   if (fd < 0)
+   {
+      g_loaded = 1;
+      if (errno == ENOENT)
+         return 0; /* genuinely no registry file => no custom blocks */
+      /* ELOOP (a planted symlink), EACCES, etc. are NOT "no registry": refuse
+       * rather than silently ignore a blocked/inaccessible registry. */
+      snprintf(err, errlen, "%s: cannot open (%s)", path, strerror(errno));
+      return -1;
+   }
+   /* "operator-owned" = owned by the running uid or root, and not group/world-
+    * writable (mode alone would pass a 0700 file owned by another user). */
+   const uid_t me = getuid();
+   struct stat st;
+   if (fstat(fd, &st) != 0 || !S_ISREG(st.st_mode) || (st.st_mode & 0022) ||
+       (st.st_uid != me && st.st_uid != 0))
+   {
+      close(fd);
+      g_loaded = 1;
+      snprintf(err, errlen, "%s: not a regular operator-owned file (wrong owner/group-writable?)",
+               path);
+      return -1;
+   }
+   /* the parent directory must also be operator-owned, else a less-privileged
+    * principal could swap the file under us. */
+   {
+      char dir[1100];
+      snprintf(dir, sizeof dir, "%s", path);
+      char *slash = strrchr(dir, '/');
+      if (slash == dir)
+         dir[1] = '\0'; /* parent is the root directory "/" */
+      else if (slash)
+         *slash = '\0';
+      const char *d = (slash && dir[0]) ? dir : ".";
+      struct stat ds;
+      if (stat(d, &ds) != 0 || !S_ISDIR(ds.st_mode) || (ds.st_mode & 0022) ||
+          (ds.st_uid != me && ds.st_uid != 0))
+      {
+         close(fd);
+         g_loaded = 1;
+         snprintf(err, errlen, "%s: parent dir not operator-owned (wrong owner/group-writable?)",
+                  path);
+         return -1;
+      }
+   }
+   long sz = st.st_size;
+   buf = malloc((size_t)(sz > 0 ? sz : 0) + 1);
+   if (!buf)
+   {
+      close(fd);
+      g_loaded = 1;
+      return -1;
+   }
+   /* robust read: handle partial reads + retry EINTR; never silently treat a
+    * read error as an empty (no-blocks) registry. */
+   size_t want = (size_t)(sz > 0 ? sz : 0);
+   while (got < want)
+   {
+      ssize_t r = read(fd, buf + got, want - got);
+      if (r < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         close(fd);
+         free(buf);
+         g_loaded = 1;
+         snprintf(err, errlen, "%s: read failed (%s)", path, strerror(errno));
+         return -1;
+      }
+      if (r == 0)
+         break; /* EOF (file shrank) */
+      got += (size_t)r;
+   }
+   close(fd);
+   buf[got] = '\0';
+#else
+   /* Windows thin client: no POSIX symlink/permission/ownership model applies
+    * (the operator-owned posture is a server-side, POSIX concern; the Windows
+    * client reads the developer's own config). Plain buffered read. */
+   FILE *f = fopen(path, "rb");
+   if (!f)
+   {
+      g_loaded = 1;
+      if (errno == ENOENT)
+         return 0;
+      snprintf(err, errlen, "%s: cannot open (%s)", path, strerror(errno));
+      return -1;
+   }
+   fseek(f, 0, SEEK_END);
+   long sz = ftell(f);
+   if (sz < 0)
+      sz = 0;
+   fseek(f, 0, SEEK_SET);
+   buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      g_loaded = 1;
+      return -1;
+   }
+   got = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   buf[got] = '\0';
+#endif
+
+   cJSON *root = yaml_parse(buf);
+   free(buf);
+   if (!root || !cJSON_IsObject(root))
+   {
+      if (root)
+         cJSON_Delete(root);
+      g_loaded = 1;
+      snprintf(err, errlen, "blocks.yaml: parse error");
+      return -1;
+   }
+   const cJSON *ac = cJSON_GetObjectItemCaseSensitive(root, "allow_command");
+   int allow = ac && cJSON_IsTrue(ac);
+
+   const cJSON *blocks = cJSON_GetObjectItemCaseSensitive(root, "blocks");
+   int rc = 0;
+   if (blocks && cJSON_IsArray(blocks))
+   {
+      const cJSON *b = NULL;
+      cJSON_ArrayForEach(b, blocks)
+      {
+         if (g_count >= WFE_CUSTOM_MAX)
+         {
+            snprintf(err, errlen, "too many custom blocks (max %d)", WFE_CUSTOM_MAX);
+            rc = -1;
+            break;
+         }
+         /* parse_one rejects a name that duplicates an already-committed block
+          * (explicit scan) or shadows a built-in. */
+         if (parse_one(b, &g_blocks[g_count], err, errlen) != 0)
+         {
+            rc = -1;
+            break;
+         }
+         g_count++;
+      }
+   }
+   cJSON_Delete(root); /* registry no longer references the tree (owns its copies) */
+   if (rc != 0)
+   {
+      wfe_custom_registry_reset();
+      g_loaded = 1;
+      return -1;
+   }
+   g_allow_command = allow;
+   g_loaded = 1; /* set only on the final clean exit */
+   return 0;
+}
+
+int wfe_custom_registry_ensure(char *err, size_t errlen)
+{
+   if (g_loaded)
+      return 0;
+   char path[1100];
+   snprintf(path, sizeof path, "%s/workflows/blocks.yaml", aimee_home());
+   return wfe_custom_registry_load(path, err, errlen);
+}
+
+/* ---- node-aware typed I/O (custom resolves via the registry) ---- */
+wfe_artifact_type_t wfe_node_output(const wfe_node_t *n)
+{
+   if (n && n->block == WFE_BLK_CUSTOM)
+   {
+      const wfe_custom_block_t *c = wfe_custom_lookup(n->custom_name);
+      return c ? c->produces : WFE_ART_NONE;
+   }
+   return wfe_block_output(n ? n->block : WFE_BLK_UNKNOWN);
+}
+
+int wfe_node_accepts_input(const wfe_node_t *n, wfe_artifact_type_t in)
+{
+   if (n && n->block == WFE_BLK_CUSTOM)
+   {
+      const wfe_custom_block_t *c = wfe_custom_lookup(n->custom_name);
+      return c ? (c->consumes == in) : 0;
+   }
+   return wfe_block_accepts_input(n ? n->block : WFE_BLK_UNKNOWN, in);
+}
+
+int wfe_node_requires_input(const wfe_node_t *n)
+{
+   if (n && n->block == WFE_BLK_CUSTOM)
+   {
+      const wfe_custom_block_t *c = wfe_custom_lookup(n->custom_name);
+      return c ? (c->consumes != WFE_ART_NONE) : 0;
+   }
+   return wfe_block_requires_input(n ? n->block : WFE_BLK_UNKNOWN);
+}

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -41,6 +41,9 @@ static const struct
      1,
      {WFE_ART_PROPOSAL, WFE_ART_FROZEN_DIFF, WFE_ART_NONE}},
     {WFE_BLK_MERGE, "merge", WFE_ART_NONE, 1, {WFE_ART_PR, WFE_ART_NONE}},
+    /* safety gates: poll the PR's CI / mergeability (pr -> verdict). */
+    {WFE_BLK_GATE_CI, "gate.ci", WFE_ART_VERDICT, 1, {WFE_ART_PR, WFE_ART_NONE}},
+    {WFE_BLK_CHECK_MERGEABLE, "check.mergeable", WFE_ART_VERDICT, 1, {WFE_ART_PR, WFE_ART_NONE}},
 };
 static const int CATALOG_N = (int)(sizeof(CATALOG) / sizeof(CATALOG[0]));
 
@@ -75,6 +78,11 @@ wfe_block_type_t wfe_block_from_name(const char *name)
    for (int i = 0; i < CATALOG_N; i++)
       if (strcmp(CATALOG[i].name, name) == 0)
          return CATALOG[i].t;
+   /* fall through to the config-defined registry (consults already-loaded
+    * state only -- callers ensure() before parse/validate, never here, to
+    * avoid reentrancy during registry load). */
+   if (wfe_custom_lookup(name))
+      return WFE_BLK_CUSTOM;
    return WFE_BLK_UNKNOWN;
 }
 
@@ -154,6 +162,8 @@ static int parse_node(wfe_node_t *n, const cJSON *jn, char *err, size_t errlen)
       snprintf(err, errlen, "node '%s': unknown block '%s'", n->id, blk ? blk : "");
       return -1;
    }
+   if (n->block == WFE_BLK_CUSTOM)
+      copy_str(n->custom_name, sizeof n->custom_name, blk);
 
    n->params = cJSON_GetObjectItemCaseSensitive(jn, "params");
    copy_str(n->next, sizeof n->next, obj_str(jn, "next"));
@@ -191,6 +201,13 @@ wfe_def_t *wfe_def_parse(const char *yaml_text, char *err, size_t errlen)
 {
    if (err && errlen)
       err[0] = '\0';
+   /* make config-defined block names resolvable before we parse node blocks */
+   char cerr[256];
+   if (wfe_custom_registry_ensure(cerr, sizeof cerr) != 0)
+   {
+      snprintf(err, errlen, "custom block registry: %s", cerr);
+      return NULL;
+   }
    cJSON *root = yaml_parse(yaml_text ? yaml_text : "");
    if (!root || !cJSON_IsObject(root))
    {

--- a/src/workflow/wfe_def.h
+++ b/src/workflow/wfe_def.h
@@ -26,7 +26,8 @@ typedef struct wfe_node
 {
    char id[WFE_ID_LEN];
    wfe_block_type_t block;
-   const cJSON *params; /* borrowed from def->raw; may be NULL */
+   char custom_name[WFE_NAME_LEN]; /* set iff block == WFE_BLK_CUSTOM */
+   const cJSON *params;            /* borrowed from def->raw; may be NULL */
    wfe_binding_t ins[WFE_MAX_INS];
    int n_ins;
    /* control edges (node ids; "" = none) */
@@ -55,6 +56,52 @@ wfe_artifact_type_t wfe_block_output(wfe_block_type_t t);
 int wfe_block_accepts_input(wfe_block_type_t t, wfe_artifact_type_t in);
 /* 1 if the block requires at least one bound input (author.proposal does not). */
 int wfe_block_requires_input(wfe_block_type_t t);
+
+/* Node-aware variants: resolve a custom block's typed I/O from the registry
+ * (by node->custom_name); fall back to the built-in catalog otherwise. The
+ * validator uses these so custom + built-in blocks type-check identically. */
+wfe_artifact_type_t wfe_node_output(const wfe_node_t *n);
+int wfe_node_accepts_input(const wfe_node_t *n, wfe_artifact_type_t in);
+int wfe_node_requires_input(const wfe_node_t *n);
+
+/* ---- Custom block registry (wfe_custom.c): built-ins ∪ $AIMEE_HOME/workflows/
+ * blocks.yaml. Loaded lazily; the artifact type system + validator consult it. */
+typedef enum
+{
+   WFE_EXEC_COMMAND = 0,
+   WFE_EXEC_DELEGATE
+} wfe_custom_exec_t;
+
+#define WFE_CUSTOM_ARGV_MAX 32  /* max argv elements in a command executor */
+#define WFE_CUSTOM_ARG_MAX  512 /* max bytes per argv element (reject, not truncate) */
+
+typedef struct
+{
+   char name[WFE_NAME_LEN];
+   wfe_artifact_type_t consumes; /* WFE_ART_NONE = source */
+   wfe_artifact_type_t produces; /* branch or none only */
+   wfe_custom_exec_t executor;
+   /* OWNED (strdup'd) so the registry does not depend on the parsed YAML tree
+    * staying alive -- no use-after-free if the tree is freed/reloaded. */
+   char *argv[WFE_CUSTOM_ARGV_MAX + 1]; /* NULL-terminated (command executor) */
+   int argc;
+   char persona[WFE_NAME_LEN];
+   char *prompt; /* owned or NULL (delegate executor) */
+} wfe_custom_block_t;
+
+/* Ensure the registry is loaded (idempotent; reads $AIMEE_HOME/workflows/
+ * blocks.yaml if present + operator-owned). Returns 0 on success (incl. no
+ * file), -1 if the file exists but is unsafe/invalid. */
+int wfe_custom_registry_ensure(char *err, size_t errlen);
+/* Force a (re)load from an explicit path (tests). */
+int wfe_custom_registry_load(const char *path, char *err, size_t errlen);
+void wfe_custom_registry_reset(void); /* test helper */
+const wfe_custom_block_t *wfe_custom_lookup(const char *name);
+int wfe_custom_count(void);
+const wfe_custom_block_t *wfe_custom_at(int i);
+/* Whether `command`-executor custom blocks are opt-in enabled (blocks.yaml
+ * top-level allow_command: true). */
+int wfe_custom_commands_allowed(void);
 
 /* ---- Parse / free / lookup ---- */
 wfe_def_t *wfe_def_parse(const char *yaml_text, char *err, size_t errlen);

--- a/src/workflow/wfe_engine.c
+++ b/src/workflow/wfe_engine.c
@@ -155,6 +155,10 @@ static const char *pause_name(wfe_pause_reason_t r)
       return "budget_exceeded";
    case WFE_PAUSE_PANEL_UNREACHABLE:
       return "panel_unreachable";
+   case WFE_PAUSE_CI_PENDING:
+      return "ci_pending";
+   case WFE_PAUSE_MERGE_PENDING:
+      return "merge_pending";
    default:
       return "";
    }
@@ -172,6 +176,10 @@ static wfe_pause_reason_t pause_from_name(const char *s)
       return WFE_PAUSE_BUDGET_EXCEEDED;
    if (strcmp(s, "panel_unreachable") == 0)
       return WFE_PAUSE_PANEL_UNREACHABLE;
+   if (strcmp(s, "ci_pending") == 0)
+      return WFE_PAUSE_CI_PENDING;
+   if (strcmp(s, "merge_pending") == 0)
+      return WFE_PAUSE_MERGE_PENDING;
    return WFE_PAUSE_NONE;
 }
 

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -41,6 +41,9 @@ typedef enum
    WFE_BLK_GATE_HUMAN,
    WFE_BLK_PR_OPEN,
    WFE_BLK_MERGE,
+   WFE_BLK_GATE_CI,         /* built-in: poll the PR's CI, fail-closed */
+   WFE_BLK_CHECK_MERGEABLE, /* built-in: refuse on a merge conflict */
+   WFE_BLK_CUSTOM,          /* config-defined block (spec carried on the node) */
    WFE_BLK__COUNT
 } wfe_block_type_t;
 
@@ -61,7 +64,10 @@ typedef enum
    WFE_PAUSE_PENDING_HUMAN,
    WFE_PAUSE_PANEL_DEGRADED,
    WFE_PAUSE_BUDGET_EXCEEDED,
-   WFE_PAUSE_PANEL_UNREACHABLE
+   WFE_PAUSE_PANEL_UNREACHABLE,
+   WFE_PAUSE_CI_PENDING,   /* gate.ci: CI still running / not yet conclusive */
+   WFE_PAUSE_MERGE_PENDING /* check.mergeable / merge: forge merge state could not
+                            * be determined (transient/unknown) -- re-drive later */
 } wfe_pause_reason_t;
 
 typedef struct

--- a/src/workflow/wfe_validate.c
+++ b/src/workflow/wfe_validate.c
@@ -7,6 +7,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* display name (the custom block's name for WFE_BLK_CUSTOM, else the catalog). */
+static const char *node_block_name(const wfe_node_t *n)
+{
+   return (n->block == WFE_BLK_CUSTOM) ? n->custom_name : wfe_block_name(n->block);
+}
+
 static int param_bool(const cJSON *params, const char *key, int dflt)
 {
    if (!params)
@@ -40,10 +46,9 @@ static int check_inputs(const wfe_def_t *def, const wfe_node_t *n, char *err, si
             return -1;
          }
 
-   if (wfe_block_requires_input(n->block) && n->n_ins == 0)
+   if (wfe_node_requires_input(n) && n->n_ins == 0)
    {
-      snprintf(err, errlen, "node '%s' (%s) requires an input binding", n->id,
-               wfe_block_name(n->block));
+      snprintf(err, errlen, "node '%s' (%s) requires an input binding", n->id, node_block_name(n));
       return -1;
    }
 
@@ -57,14 +62,13 @@ static int check_inputs(const wfe_def_t *def, const wfe_node_t *n, char *err, si
                   b->input_name, b->producer_id);
          return -1;
       }
-      wfe_artifact_type_t out = wfe_block_output(prod->block);
-      if (!wfe_block_accepts_input(n->block, out))
+      wfe_artifact_type_t out = wfe_node_output(prod);
+      if (!wfe_node_accepts_input(n, out))
       {
          snprintf(err, errlen,
                   "node '%s' (%s): input '%s' bound to '%s' which produces %s "
                   "(not an accepted input type)",
-                  n->id, wfe_block_name(n->block), b->input_name, b->producer_id,
-                  wfe_artifact_name(out));
+                  n->id, node_block_name(n), b->input_name, b->producer_id, wfe_artifact_name(out));
          return -1;
       }
    }


### PR DESCRIPTION
## Summary

Two related workflow-engine features, both requested as composable workflow parts:

**A — Config-extensible blocks.** Operators can define their own workflow blocks in `$AIMEE_HOME/workflows/blocks.yaml`, surfaced as one generic `WFE_BLK_CUSTOM` behind the frozen execution vtable. Each custom block declares typed `consumes`/`produces` and an `executor` (`command`|`delegate`). The validator type-checks custom blocks identically to built-ins via node-aware accessors.

**B — Built-in safety blocks** (the three the user asked for: no merge conflict, never push to an already-merged PR, all CI green), behind a mock-injectable forge seam:
- `gate.ci` — only an explicit all-green advances; CI failure loops; pending/unknown parks (fail closed).
- `check.mergeable` — a conflict loops back to fix it; an undeterminable state parks (never advances on unknown).
- `merge` — idempotent + race-safe: confirmed-already-merged is a no-op, and merge is only attempted on a **confirmed-unmerged** PR, so a transient forge error can never double-merge.

The default `build.yaml` chain now ends `… → check.mergeable → gate.ci → merge`.

## Safety / trust invariants
- Custom blocks can only `produce` `branch` or `none` — they can **never** mint trust-bearing `verdict`/`approval`/`pr`.
- `command` executor is opt-in (`allow_command`) and argv-only (no shell), fail-closed.
- `blocks.yaml` must be operator-owned: opened `O_NOFOLLOW`, refused if not a regular file, group/world-writable, or not owned by the running uid/root; the parent directory is checked the same way.
- All registry-exposed strings are owned (`strdup`'d) — no dangle into a freed/reloaded YAML tree.

## Review
Roundtable-reviewed to convergence: a diverse panel (security / architect / qa / reviewer) returned **4/4 PASS** after two rounds of fixes (use-after-free → owned storage; silent truncation → reject; transient-forge-error handling → dedicated `merge_pending` park; symlink/errno/parent-dir hardening; robust read loop). Each fix has a dedicated test.

## Tests
- `test_wfe_custom` — registry load/reject (shadow, duplicate, bad produces/executor, world-writable, symlink, over-long argv), custom-block type-checking, `exec_custom` command opt-in through the engine.
- `test_wfe_safety` — mock forge, 7 scenarios through the engine (all-green→merge, ci-fail→loop, ci-pending→park, conflict→loop, already-merged→no-op, mergeability-unknown→park, merge-state-unknown→park-without-merging).
- Full unit suite green; full client+server+kb build clean (Makefile + CMake); build-integrity / schema-sync / charter-tables / module-boundary gates pass.

Follow-on (separate PR): W7 web visual composer rendering this extensible block catalog.
