### PR TITLE
Credential-vault consolidation P3: agent key import (migrate keyring into the vault)

### DIFF
--- a/src/cli_agent_keys.c
+++ b/src/cli_agent_keys.c
@@ -68,6 +68,11 @@ static cJSON *load_keys(void)
    return root;
 }
 
+cJSON *cli_agent_keys_load(void)
+{
+   return load_keys();
+}
+
 int cli_agent_key_set(const char *agent_name, const char *api_key)
 {
    if (!agent_name || !agent_name[0])
@@ -241,4 +246,67 @@ void cli_session_creds_prime(cJSON *req)
       touch_push_marker();
    if (resp)
       cJSON_Delete(resp);
+}
+
+/* `aimee agent key import [--scrub]` (P3): migrate client-held agent-keys.json
+ * entries into the server vault under the server principal (vault.set_server).
+ * Reports per agent; --scrub removes an entry only after a confirmed vault store.
+ * Idempotent (re-runnable). Over a plaintext-TCP remote the server refuses
+ * (P2a/D2b) and the entry is left intact — provision over an attested
+ * (UDS/webchat) connection holding the vault:write:server capability. */
+int cli_agent_key_import(int argc, char **argv, int json_output)
+{
+   (void)json_output;
+   int scrub = 0;
+   for (int i = 0; i < argc; i++)
+      if (strcmp(argv[i], "--scrub") == 0)
+         scrub = 1;
+
+   cJSON *keys = cli_agent_keys_load();
+   int total = 0, vaulted = 0, refused = 0, errors = 0;
+   cJSON *entry = NULL;
+   cJSON_ArrayForEach(entry, keys)
+   {
+      const char *agent = entry->string;
+      if (!agent || !agent[0] || !cJSON_IsString(entry) || !entry->valuestring[0])
+         continue;
+      total++;
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "method", "vault.set_server");
+      cJSON_AddStringToObject(req, "agent", agent);
+      cJSON_AddStringToObject(req, "cred", "api_key");
+      cJSON_AddStringToObject(req, "secret", entry->valuestring);
+      cJSON *resp = cli_v1_dispatch(req, 30000);
+      cJSON_Delete(req);
+
+      cJSON *st = resp ? cJSON_GetObjectItemCaseSensitive(resp, "status") : NULL;
+      int ok = st && cJSON_IsString(st) && strcmp(st->valuestring, "ok") == 0;
+      if (ok)
+      {
+         vaulted++;
+         printf("  %-16s vaulted\n", agent);
+         if (scrub)
+            cli_agent_key_set(agent, NULL);
+      }
+      else
+      {
+         cJSON *msg = resp ? cJSON_GetObjectItemCaseSensitive(resp, "message") : NULL;
+         const char *m = (msg && cJSON_IsString(msg)) ? msg->valuestring : "no server response";
+         if (strstr(m, "attested") || strstr(m, "capability"))
+            refused++;
+         else
+            errors++;
+         printf("  %-16s SKIPPED (%s)\n", agent, m);
+      }
+      cJSON_Delete(resp);
+   }
+   cJSON_Delete(keys);
+
+   printf("agent key import: %d vaulted, %d refused, %d error (of %d)%s\n", vaulted, refused,
+          errors, total, scrub ? "; migrated entries scrubbed from the local keyring" : "");
+   if (refused > 0)
+      printf("note: server-principal writes need an attested (UDS/webchat) connection holding the "
+             "vault:write:server capability — run this on the server host over UDS, or grant the "
+             "capability.\n");
+   return errors > 0 ? 1 : 0;
 }

--- a/src/cli_agent_keys.c
+++ b/src/cli_agent_keys.c
@@ -257,10 +257,14 @@ void cli_session_creds_prime(cJSON *req)
 int cli_agent_key_import(int argc, char **argv, int json_output)
 {
    (void)json_output;
-   int scrub = 0;
+   int scrub = 0, dry = 0;
    for (int i = 0; i < argc; i++)
+   {
       if (strcmp(argv[i], "--scrub") == 0)
          scrub = 1;
+      else if (strcmp(argv[i], "--dry-run") == 0)
+         dry = 1;
+   }
 
    cJSON *keys = cli_agent_keys_load();
    int total = 0, vaulted = 0, refused = 0, errors = 0;
@@ -271,6 +275,12 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
       if (!agent || !agent[0] || !cJSON_IsString(entry) || !entry->valuestring[0])
          continue;
       total++;
+      if (dry)
+      {
+         /* Preview only — never send the secret or mutate the keyring. */
+         printf("  %-16s would vault (dry-run)\n", agent);
+         continue;
+      }
       cJSON *req = cJSON_CreateObject();
       cJSON_AddStringToObject(req, "method", "vault.set_server");
       cJSON_AddStringToObject(req, "agent", agent);
@@ -302,6 +312,12 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
    }
    cJSON_Delete(keys);
 
+   if (dry)
+   {
+      printf("agent key import (dry-run): %d entr%s would be sent; nothing changed\n", total,
+             total == 1 ? "y" : "ies");
+      return 0;
+   }
    printf("agent key import: %d vaulted, %d refused, %d error (of %d)%s\n", vaulted, refused,
           errors, total, scrub ? "; migrated entries scrubbed from the local keyring" : "");
    if (refused > 0)

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1915,6 +1915,12 @@ int main(int argc, char **argv)
       return client_help_command(1, help_arg);
    }
 
+   /* agent key import: client-orchestrated migration of the local keyring into the
+    * server vault (P3) — read agent-keys.json here, push each via vault.set_server. */
+   if (strcmp(cmd, "agent") == 0 && sub_argc >= 2 && strcmp(sub_argv[0], "key") == 0 &&
+       strcmp(sub_argv[1], "import") == 0)
+      return cli_agent_key_import(sub_argc - 2, sub_argv + 2, json_output);
+
    /* agent setup: two-step OAuth device flow, needs special client orchestration */
    if (strcmp(cmd, "agent") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "setup") == 0)
       return handle_agent_setup_cmd(sub_argc - 1, sub_argv + 1, json_output);

--- a/src/headers/cli_agent_keys.h
+++ b/src/headers/cli_agent_keys.h
@@ -17,6 +17,17 @@
  * (~/.config/aimee/agent-keys.json, mode 0600). Returns 0 on success. */
 int cli_agent_key_set(const char *agent_name, const char *api_key);
 
+/* Load the local keyring as a cJSON object {agent_name: api_key, ...} (empty
+ * object if none). Caller owns the result (cJSON_Delete). Used by `agent key
+ * import` to migrate client-held keys into the server vault (P3). */
+cJSON *cli_agent_keys_load(void);
+
+/* `aimee agent key import [--scrub]` (P3): push each local keyring entry into the
+ * server vault under the server principal via vault.set_server, reporting per
+ * agent. --scrub removes an entry only after a confirmed store. Returns 0 unless
+ * a non-refusal error occurred. */
+int cli_agent_key_import(int argc, char **argv, int json_output);
+
 /* For `aimee agent add <name> ... --key <K>` against a remote server: store K in
  * the LOCAL keyring (keyed by <name> = argv[1]) and strip `--key <K>` from argv
  * in place (decrementing *argc) so the key is never forwarded to / stored on the


### PR DESCRIPTION
## Credential-vault consolidation P3: `aimee agent key import`

Third packet (after P1 #291, P2a #294). WP-3 — the migration that moves existing client-held delegate keys into the server vault.

### What this does
`aimee agent key import [--scrub]` (client-orchestrated): reads the local `agent-keys.json` and pushes each entry into the **server vault** under the server principal via the P2a `vault.set_server` route, reporting per agent:
- **vaulted** — stored;
- **SKIPPED (…)** — refused (over a plaintext-TCP remote, since P2a/D2b requires an attested transport + the `vault:write:server` capability) or errored; the entry is **left intact**.
- `--scrub` (opt-in, default off): removes an entry from the local keyring **only after** a confirmed store — keys otherwise stay as a backup until P4 retires the legacy path.
- Idempotent / re-runnable.

### Notes
- For the plaintext-TCP thin-client → `.254` deployment, this is **run on the server host over UDS** (or with the capability granted) — consistent with P2a's security model. The command reports clearly when refused and how to proceed.
- The handler lives in `cli_agent_keys.c` (which already has keyring + RPC access) rather than `cli_main.c`, to stay under the 2000-line file cap; `cli_agent_keys_load` is exposed for it.

### Testing
- `make -j1 verify-local` — **ok**. Pure client change: no new server route / openapi / dispatch surface, so no route-coverage or stub changes.
- The migration loop is RPC-orchestration (integration-level, exercised live); the keyring I/O it builds on is pre-existing and covered by the session-push path.

### Follow-up
- **P4:** `vault_only` flag + retire the legacy `agent-keys.json` push + `codex-auth.json` read (this is where `--scrub`/retirement becomes the default).
