### PR TITLE
ci(embedder): stub embedder for e2e — kill the last 384-dim

### DIFF
--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -48,10 +48,6 @@ services:
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
-      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
-      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
-      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
-      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
@@ -59,6 +55,10 @@ services:
     environment:
       EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
       RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
+      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
+      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
+      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -48,6 +48,10 @@ services:
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
+      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
+      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
+      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -40,6 +40,10 @@ services:
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
+      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
+      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
+      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -40,10 +40,6 @@ services:
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
-      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
-      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
-      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
-      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
@@ -51,6 +47,10 @@ services:
     environment:
       EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
       RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
+      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
+      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
+      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,10 +25,6 @@ services:
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
-      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
-      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
-      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
-      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     # Tier is a RUNTIME choice now: the models are fetched at startup into the
     # volume (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with
     # no rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
@@ -36,6 +32,10 @@ services:
     environment:
       EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
       RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
+      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
+      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
+      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     volumes:
       - aimee-embedder-models:/opt/models
     healthcheck:

--- a/compose.yaml
+++ b/compose.yaml
@@ -25,6 +25,10 @@ services:
       args:
         EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
         RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
+      # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
+      EMBEDDER_STUB: ${EMBEDDER_STUB:-}
+      EMBEDDER_STUB_DIM: ${EMBEDDER_STUB_DIM:-}
     # Tier is a RUNTIME choice now: the models are fetched at startup into the
     # volume (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with
     # no rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -54,14 +54,14 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-# Models are fetched at runtime now (not baked into the image), so CI must use a
-# SMALL, ungated model + matching dim — otherwise every e2e run would cold-download
-# the multi-GB 4b/1b default. all-MiniLM-L6-v2 (384-dim, ~90 MB) + a tiny
-# cross-encoder fetch in well under the embedder's start_period. compose reads
-# these via ${...}; exporting here covers every topology + the build args.
-export EMBEDDER_MODEL="${EMBEDDER_MODEL:-sentence-transformers/all-MiniLM-L6-v2}"
-export RERANKER_MODEL="${RERANKER_MODEL:-cross-encoder/ms-marco-MiniLM-L-6-v2}"
-export AIMEE_EMBEDDING_DIM="${AIMEE_EMBEDDING_DIM:-384}"
+# Models are fetched at runtime now (not baked), so CI uses the STUB embedder
+# (EMBEDDER_STUB=1): deterministic fixed-dim vectors, no multi-GB cold download.
+# It exercises the real kb -> embedder -> pgvector wiring at the deployment's
+# real dim (2560 here, matching the 4b default schema_embedding_dim — never the
+# retired 384). compose reads these via ${...}; exporting covers every topology.
+export EMBEDDER_STUB="${EMBEDDER_STUB:-1}"
+export EMBEDDER_STUB_DIM="${EMBEDDER_STUB_DIM:-2560}"
+export AIMEE_EMBEDDING_DIM="${AIMEE_EMBEDDING_DIM:-2560}"
 
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 selected() { case ",$ONLY," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -58,6 +58,13 @@ os.environ.setdefault("OMP_NUM_THREADS", str(EMBEDDER_THREADS))
 # the sole tier. The deep-tier deployment sets this to int8; the default is fp32.
 EMBEDDER_QUANTIZE = os.environ.get("EMBEDDER_QUANTIZE", "fp32").strip().lower()
 
+# CI/test stub: serve deterministic fixed-dimension vectors without downloading
+# or loading any model. e2e-docker uses this so CI exercises the real
+# kb -> embedder -> pgvector wiring (at the deployment's real dim, e.g. 2560 or
+# 1024 — never the retired 384) without a multi-GB cold model fetch. Off in prod.
+EMBEDDER_STUB = os.environ.get("EMBEDDER_STUB", "").strip() not in ("", "0", "false", "no")
+STUB_DIM = int(os.environ.get("EMBEDDER_STUB_DIM", os.environ.get("AIMEE_EMBEDDING_DIM", "2560")) or "2560")
+
 _model = None
 _dim = 0
 _reranker = None
@@ -106,11 +113,37 @@ def load_reranker():
     return _reranker
 
 
+def _stub_embed(text):
+    """Deterministic unit-norm pseudo-embedding of fixed dimension STUB_DIM, with
+    no model. Same text -> same vector (so recall finds it); different text ->
+    different vector. CI-only; not a real semantic embedding."""
+    import hashlib
+    import math
+
+    out = []
+    counter = 0
+    while len(out) < STUB_DIM:
+        h = hashlib.sha256(f"{text}\x00{counter}".encode("utf-8")).digest()
+        for i in range(0, len(h), 2):
+            if len(out) >= STUB_DIM:
+                break
+            out.append((int.from_bytes(h[i : i + 2], "big") / 65535.0) - 0.5)
+        counter += 1
+    norm = math.sqrt(sum(x * x for x in out)) or 1.0
+    return [x / norm for x in out]
+
+
 def _background_load():
     """Fetch (cold volume) + load the models off the request path. The embedder
     is the critical path: once it loads, /health flips to "ok" and /embed serves.
     The reranker is best-effort — a failure degrades reranking, not embedding."""
-    global _load_status, _load_error
+    global _load_status, _load_error, _dim
+    if EMBEDDER_STUB:
+        _dim = STUB_DIM
+        _load_status = "ok"
+        sys.stderr.write(f"embedder-server: STUB mode, dim={STUB_DIM} (no model loaded)\n")
+        sys.stderr.flush()
+        return
     try:
         load_model()
         _load_status = "ok"
@@ -128,6 +161,8 @@ def _background_load():
 
 
 def embed(text: str):
+    if EMBEDDER_STUB:
+        return _stub_embed(text)
     vec = _model.encode(text, normalize_embeddings=True)
     return vec.tolist()
 
@@ -138,6 +173,16 @@ def rerank(pairs):
     contract (memory_core_search.inc: JSON pairs in, JSON float array out)."""
     if not pairs:
         return []
+    if EMBEDDER_STUB:
+        # Deterministic stub score from the embedding cosine — keeps CI's rerank
+        # path exercised without a model.
+        import math
+
+        out = []
+        for q, c in pairs:
+            qv, cv = _stub_embed(str(q)), _stub_embed(str(c))
+            out.append(float(sum(a * b for a, b in zip(qv, cv))))
+        return out
     scores = load_reranker().predict([[str(q), str(c)] for q, c in pairs])
     return [float(s) for s in scores]
 


### PR DESCRIPTION
The schema dim is already parameterized on `testing` (`halfvec(__EMBED_DIM__)` substituted to the configured `embedding_dim` — **2560 (4b) / 1024 (0.6b)**, default 2560, safe NOTICE-based self-heal). The only remaining 384 was the all-MiniLM/384 model I'd set for e2e in §1 — which both violates "no 384" and mismatches the 2560 default.

This replaces it with a **CI stub embedder**:
- `embedder-server.py` `EMBEDDER_STUB` mode: deterministic, unit-norm, fixed-dim (`EMBEDDER_STUB_DIM`, default 2560) pseudo-vectors, **no model load/download**. Same text → same vector (recall finds it); rerank uses the stub cosine; `/health` reports the stub dim, ready immediately.
- `e2e-matrix.sh`: `EMBEDDER_STUB=1` + `EMBEDDER_STUB_DIM=2560` + `AIMEE_EMBEDDING_DIM=2560` (was all-MiniLM/384). e2e now exercises the real kb→embedder→pgvector path at the real **2560 halfvec** dim — no multi-GB cold download, **no 384**.
- compose ×3: pass `EMBEDDER_STUB`/`EMBEDDER_STUB_DIM` through (empty/off in prod).

Real dim support (1024/2560) was delivered by the schema parameterization already on testing; this finishes the job by removing the last 384 (the e2e model) and keeping CI fast. `py_compile`/`bash -n`/yaml clean; e2e-docker validates end-to-end.