### PR TITLE
Credential-vault consolidation P4: vault_only flag (retire legacy credential paths)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -12,7 +12,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (108)
+## CLI-settable keys (109)
 
 | Key | Type |
 |-----|------|
@@ -120,6 +120,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `provider` | string |
 | `reasoning_cap_enabled` | bool |
 | `typed_facts_enabled` | bool |
+| `vault_only` | bool |
 | `verify_cross_project` | bool |
 | `verify_enabled` | bool |
 | `virtual_context_assembly_budget` | int |

--- a/src/config.c
+++ b/src/config.c
@@ -754,6 +754,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->verify_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "vault_only");
+   if (cJSON_IsBool(item))
+      cfg->vault_only = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "claude_cli_delegate_enabled");
    if (cJSON_IsBool(item))
       cfg->claude_cli_delegate_enabled = cJSON_IsTrue(item);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -189,6 +189,7 @@ const config_field_t config_fields[] = {
     {"kb_mining_enabled", offsetof(config_t, kb_mining_enabled), sizeof(int), 0, CFG_BOOL},
     {"kb_mining_min_poll_s", offsetof(config_t, kb_mining_min_poll_s), sizeof(int), 0, CFG_INT},
     {"verify_enabled", offsetof(config_t, verify_enabled), sizeof(int), 1, CFG_BOOL},
+    {"vault_only", offsetof(config_t, vault_only), sizeof(int), 1, CFG_BOOL},
     {"claude_cli_delegate_enabled", offsetof(config_t, claude_cli_delegate_enabled), sizeof(int), 1,
      CFG_BOOL},
     {"verify_cross_project", offsetof(config_t, verify_cross_project), sizeof(int), 1, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -751,6 +751,9 @@ int config_save(const config_t *cfg)
    /* Verify gating: only persist when enabled (default-off is the absence). */
    if (cfg->verify_enabled)
       cJSON_AddBoolToObject(root, "verify_enabled", 1);
+   /* Credential-vault sole-source cutover (WP-4): persist only when set. */
+   if (cfg->vault_only)
+      cJSON_AddBoolToObject(root, "vault_only", 1);
    if (cfg->verify_cross_project)
       cJSON_AddBoolToObject(root, "verify_cross_project", 1);
    if (cfg->claude_cli_delegate_enabled)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -636,6 +636,14 @@ typedef struct config
     * gating + enforce:true auto-generated config for the current project. */
    int verify_enabled;
 
+   /* Credential-vault consolidation (WP-4/D10-D12): when 1, the server vault is
+    * the SOLE credential source — the legacy paths are refused/skipped: the
+    * client `/v1/session/credentials` RAM push is rejected, and the on-disk
+    * codex-auth.json read is bypassed. Default 0 keeps the vault-first behavior
+    * with the legacy paths as fallback (the migration window). Flip to 1 only
+    * after `aimee agent key import` has moved every credential into the vault. */
+   int vault_only;
+
    /* Allow Claude run via the `claude` CLI / tmux login (authenticated by the
     * interactive Claude subscription login, NOT an API key) to be used as a
     * DELEGATE. Default 0: Claude-via-CLI is primary-only, because driving a

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -2,6 +2,7 @@
 #include "aimee.h"
 #include "util.h"
 #include "agent_config.h"
+#include "config.h" /* config_load — vault_only gate on the legacy codex disk read (WP-4/D12) */
 #include "vault_principal.h" /* VAULT_PRINCIPAL_MAX for the per-turn vault principal */
 #include "session_credentials.h"
 #include "model_registry.h"
@@ -1472,6 +1473,15 @@ static int agent_read_codex_oauth_token(char *token, size_t token_len)
    if (!token || token_len == 0)
       return -1;
    token[0] = '\0';
+
+   /* WP-4/D12: under vault_only the codex token comes only from the vault — skip
+    * the legacy on-disk codex-auth.json / ~/.codex/auth.json fallback. */
+   {
+      config_t vc;
+      config_load(&vc);
+      if (vc.vault_only)
+         return -1;
+   }
 
    char path[MAX_PATH_LEN];
    snprintf(path, sizeof(path), "%s/codex-auth.json", config_default_dir());

--- a/src/server/server_runner_endpoints.inc
+++ b/src/server/server_runner_endpoints.inc
@@ -345,6 +345,21 @@ int handle_index_ingest(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 int handle_session_credentials(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
+   /* WP-4/D11: when vault_only is set, the legacy client RAM-push path is retired
+    * — the server vault is the sole credential source. Reject explicitly so an
+    * un-upgraded thin client gets a clear error instead of silently relying on a
+    * push that no longer authenticates anything. */
+   {
+      config_t vc;
+      config_load(&vc);
+      if (vc.vault_only)
+         return server_send_error(
+             conn,
+             "session.credentials disabled: vault_only is set — the server vault is the sole "
+             "credential source (provision with `aimee vault set-server` / `aimee agent key "
+             "import`)",
+             NULL);
+   }
    const char *sid = jo_str(req, "session_id", NULL);
    if (!sid || !sid[0])
       return server_send_error(conn, "session.credentials requires session_id", NULL);

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -71,6 +71,9 @@ int main(void)
       /* directives auto-create ran ungated before the toggle was wired; default-on
        * preserves it. */
       assert(cfg.memory_directives_enabled == 1);
+      /* WP-4: vault_only is the legacy-retirement cutover lever; default off so the
+       * migration window keeps the legacy paths as fallback. */
+      assert(cfg.vault_only == 0);
    }
 
    /* --- config_save + config_load round-trip --- */
@@ -267,6 +270,7 @@ int main(void)
                "--background-index");
       cfg.lsp_servers[0].extension_count = 1;
       snprintf(cfg.lsp_servers[0].extensions[0], sizeof(cfg.lsp_servers[0].extensions[0]), "c");
+      cfg.vault_only = 1; /* WP-4: must survive config_save round-trip */
       config_save(&cfg);
 
       static config_t cfg2;
@@ -283,6 +287,7 @@ int main(void)
       assert(cfg2.server_api_rate_limit_per_min == 60);
       assert(cfg2.server_api_max_event_streams == 512);
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);
+      assert(cfg2.vault_only == 1);
       /* regression: remote_writes used to be parsed but never written by config_save,
        * so any save silently reset it to off. */
       assert(cfg2.server_api_remote_writes == SERVER_REMOTE_WRITES_FULL);


### PR DESCRIPTION
## Credential-vault consolidation P4: `vault_only` — retire the legacy paths

Final packet (after P1 #291, P2a #294, P3 #298). WP-4/D10–D12 — the cutover lever that makes the server vault the sole credential source and retires the legacy paths.

### What this does
A new `vault_only` config bool (default **off**). When set:
- **`/v1/session/credentials` (the legacy client RAM-push) is rejected** (D11) with a clear error pointing at `aimee vault set-server` / `aimee agent key import` — an un-upgraded thin client gets an explicit failure instead of silently relying on a push that no longer authenticates anything.
- **the on-disk `codex-auth.json` / `~/.codex/auth.json` read is skipped** (D12) — codex tokens come only from the vault.

Default **off** keeps today's vault-first-with-legacy-fallback behavior (the migration window). Flip to `1` only after `aimee agent key import` (P3) has moved every credential into the vault; **flipping it back to `0` is the rollback lever**.

### Wiring
- Config field (`config.h`), load parse (`config.c`), save (`config_save.c`), CLI surface (`config_fields.c`), regenerated `docs/gen/configuration.md`.
- Gates: `handle_session_credentials` (`server_runner_endpoints.inc`), `agent_read_codex_oauth_token` (`agent_config.c`).

### Testing
- `make -j1 verify-local` — **ok** (build + config-surface + docs-gen + lint + unit suite).
- `test_config`: `vault_only` default-off + a save/load round-trip (this test caught a real bug — the load path needed a `config.c` parse entry, not just the CLI `config_fields[]` surface).

### Scope / not in this PR (notable deferrals from D10/D13)
- The `vault_only --dry-run` blast-radius enumerator and the formal cutover gate (0 legacy reads for N days) — operational tooling; the flag + rollback are here.
- `.server-master.key` rotation + `agent add --key` upsert semantics (D13) — separable hardening.
- The env-lease (`agent.credentials` pool) path is not gated here (our delegates use the single-key session-push path, which *is* gated).

### After this merges
The consolidation is **code-complete** (P1–P4). It only takes effect live after a **`.254` deploy** of the merged `testing` build (user-gated).
