### PR TITLE
workflow engine W7: web visual composer (/v1/workflow API + React editor)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -804,6 +804,7 @@ set(SERVER_SRCS
     ${AIMEE_SRC_DIR}/server/server_mcp_skill.c
     ${AIMEE_SRC_DIR}/server/server_mcp_learning.c
     ${AIMEE_SRC_DIR}/server/server_mcp_workflows.c
+    ${AIMEE_SRC_DIR}/server/server_workflow_api.c
     ${AIMEE_SRC_DIR}/server/server_mcp_gateway.c
     ${AIMEE_SRC_DIR}/server/session_search_tool.c
     ${AIMEE_SRC_DIR}/server/compute_pool.c
@@ -1337,6 +1338,7 @@ target_include_directories(aimee-server PRIVATE
     ${AIMEE_SRC_DIR}/vendor/headers
     ${AIMEE_SRC_DIR}/db1
     ${AIMEE_SRC_DIR}/db2
+    ${AIMEE_SRC_DIR}/workflow
 )
 target_compile_options(aimee-server PRIVATE ${AIMEE_COMMON_WARNINGS})
 target_compile_definitions(aimee-server PRIVATE AIMEE_DB2_DISABLED)

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -338,6 +338,129 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/blocks:
+    get:
+      summary: Composable workflow block catalog (built-ins + custom registry)
+      responses:
+        "200":
+          description: "{blocks:[{name,produces,accepts[],custom,requires_input,executor?}]}"
+          content:
+            application/json:
+              schema: { type: object }
+  /workflow/defs:
+    get:
+      summary: List saved workflow definitions
+      responses:
+        "200":
+          description: "{defs:[{name,valid,version}]}"
+          content:
+            application/json:
+              schema: { type: object }
+  /workflow/defs/{name}:
+    get:
+      summary: One workflow definition (canonical form, version, node graph)
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: "{valid,name,version,canonical,def,error?}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Invalid workflow name
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: Workflow not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/validate:
+    post:
+      summary: Validate posted workflow YAML without saving
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [yaml]
+              properties:
+                yaml: { type: string }
+      responses:
+        "200":
+          description: "{valid,name,version,canonical,def,error?}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Malformed request
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/save:
+    post:
+      summary: Canonical-normalize + save a workflow (optimistic lock on prev_version)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [name, yaml]
+              properties:
+                name: { type: string }
+                yaml: { type: string }
+                prev_version: { type: string }
+      responses:
+        "200":
+          description: "{name,version}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Invalid definition or name
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "409":
+          description: Version conflict / already exists
+          content:
+            application/json:
+              schema: { type: object }
+  /workflow/items:
+    get:
+      summary: List workflow work items (run-state rows)
+      responses:
+        "200":
+          description: "{items:[{id,workflow,version,stage,state,mode,pause_reason,repo}]}"
+          content:
+            application/json:
+              schema: { type: object }
+  /workflow/items/{id}:
+    get:
+      summary: One work item's run-state
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          description: Work-item run-state
+          content:
+            application/json:
+              schema: { type: object }
+        "404":
+          description: Work item not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /kb/search:
     post:
       summary: Search the knowledge base (proxied to aimee-kb)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,10 +4,12 @@ import { AppShell, Toast } from '@rakuensoftware/smoothgui';
 import type { NavItem } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
+import Workflows from './pages/Workflows';
 
 const NAV_ITEMS: NavItem[] = [
   { label: 'Chat', icon: '💬', route: '/chat', section: 'Main' },
   { label: 'Dashboard', icon: '📊', route: '/dashboard', section: 'Main' },
+  { label: 'Workflows', icon: '🔀', route: '/workflows', section: 'Main' },
 ];
 
 function LogoutButton() {
@@ -77,6 +79,7 @@ export default function App() {
         <Routes>
           <Route path="/chat" element={<Chat />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/workflows" element={<Workflows />} />
           <Route path="*" element={<Navigate to="/chat" replace />} />
         </Routes>
       </AppShell>

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -1,0 +1,911 @@
+import { useEffect, useState, useCallback, useRef } from "react";
+import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+
+/* ---- API types (mirror /v1/workflow/* envelopes) ---- */
+
+interface BlockDef {
+  name: string;
+  produces: string;
+  accepts: string[];
+  custom: boolean;
+  requires_input: boolean;
+  executor?: string;
+}
+interface DefRow {
+  name: string;
+  valid: boolean;
+  version: string;
+}
+interface Binding {
+  input: string;
+  producer: string;
+  output: string;
+}
+interface GNode {
+  id: string;
+  block: string;
+  custom: boolean;
+  produces: string;
+  in: Binding[];
+  next?: string;
+  on_pass?: string;
+  on_fail?: string;
+  params?: Record<string, unknown>;
+}
+interface GraphDef {
+  name: string;
+  start: string;
+  nodes: GNode[];
+}
+interface DefResponse {
+  valid: boolean;
+  name: string;
+  version: string;
+  canonical: string;
+  def: GraphDef;
+  error?: string;
+}
+interface RunItem {
+  id: string;
+  workflow: string;
+  version: string;
+  stage: string;
+  state: string;
+  mode: string;
+  pause_reason: string;
+  repo: string;
+}
+
+/* ---- block-style YAML emitter (aimee's yaml.c is block-style only: no flow
+ *      sequences). The server canonicalizes + validates on save, so this only
+ *      needs to round-trip through wfe_def_parse, not match canonical form. ---- */
+
+// YAML 1.1 reserved words that a bare scalar would be misread as (aimee's yaml.c
+// resolves true/false specially; quote anything that could collide).
+const YAML_RESERVED = new Set([
+  "true",
+  "false",
+  "null",
+  "yes",
+  "no",
+  "on",
+  "off",
+  "y",
+  "n",
+  "~",
+]);
+function isBareSafe(s: string): boolean {
+  return (
+    /^[A-Za-z0-9_./]+$/.test(s) && // no leading '-' (would read as a sequence/scalar)
+    !/^-?\d/.test(s) && // not a number
+    !YAML_RESERVED.has(s.toLowerCase())
+  );
+}
+function scalar(v: unknown): string {
+  if (typeof v === "boolean") return v ? "true" : "false";
+  if (typeof v === "number") return String(v);
+  const s = String(v);
+  return isBareSafe(s) ? s : JSON.stringify(s);
+}
+function emitYamlValue(v: unknown, indent: number, out: string[]): void {
+  const pad = " ".repeat(indent);
+  if (Array.isArray(v)) {
+    for (const item of v) {
+      if (item !== null && typeof item === "object") {
+        out.push(`${pad}-`);
+        emitYamlValue(item, indent + 2, out);
+      } else {
+        out.push(`${pad}- ${scalar(item)}`);
+      }
+    }
+  } else if (v !== null && typeof v === "object") {
+    // quote keys too: params are user-edited JSON, so a key with ':'/'#'/a
+    // reserved word must not be emitted bare (would restructure the parse).
+    for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+      if (val !== null && typeof val === "object") {
+        out.push(`${pad}${scalar(k)}:`);
+        emitYamlValue(val, indent + 2, out);
+      } else {
+        out.push(`${pad}${scalar(k)}: ${scalar(val)}`);
+      }
+    }
+  }
+}
+
+function emitWorkflowYaml(g: GraphDef): string {
+  const out: string[] = [];
+  out.push(`name: ${scalar(g.name)}`);
+  if (g.start) out.push(`start: ${scalar(g.start)}`);
+  out.push("nodes:");
+  for (const n of g.nodes) {
+    out.push(`  - id: ${scalar(n.id)}`);
+    out.push(`    block: ${scalar(n.block)}`);
+    if (n.in.length) {
+      out.push("    in:");
+      // `in` is a MAP (input_name -> "producer.output"); quote each field so an
+      // id/name with YAML-special chars can't break or restructure the parse.
+      for (const b of n.in)
+        out.push(
+          `      ${scalar(b.input)}: ${scalar(`${b.producer}.${b.output || "out"}`)}`,
+        );
+    }
+    if (n.params && Object.keys(n.params).length) {
+      out.push("    params:");
+      emitYamlValue(n.params, 6, out);
+    }
+    if (n.next) out.push(`    next: ${scalar(n.next)}`);
+    if (n.on_pass) out.push(`    on_pass: ${scalar(n.on_pass)}`);
+    if (n.on_fail) out.push(`    on_fail: ${scalar(n.on_fail)}`);
+  }
+  return out.join("\n") + "\n";
+}
+
+/* ---- layered auto-layout (the def carries no coordinates) ---- */
+
+function autoLayout(g: GraphDef): Record<string, { x: number; y: number }> {
+  const depth: Record<string, number> = {};
+  const adj = (n: GNode): string[] =>
+    [n.next, n.on_pass, n.on_fail].filter((x): x is string => !!x);
+  const start = g.start || (g.nodes[0]?.id ?? "");
+  const queue: string[] = start ? [start] : [];
+  depth[start] = 0;
+  while (queue.length) {
+    const cur = queue.shift() as string;
+    const node = g.nodes.find((n) => n.id === cur);
+    if (!node) continue;
+    for (const t of adj(node)) {
+      if (!(t in depth)) {
+        depth[t] = depth[cur] + 1;
+        queue.push(t);
+      }
+    }
+  }
+  let maxd = 0;
+  for (const n of g.nodes) {
+    if (!(n.id in depth)) depth[n.id] = 0;
+    maxd = Math.max(maxd, depth[n.id]);
+  }
+  const rowOf: Record<number, number> = {};
+  const pos: Record<string, { x: number; y: number }> = {};
+  for (const n of g.nodes) {
+    const d = depth[n.id];
+    const row = rowOf[d] || 0;
+    rowOf[d] = row + 1;
+    pos[n.id] = { x: 40 + d * 230, y: 30 + row * 120 };
+  }
+  return pos;
+}
+
+const NODE_W = 160;
+const NODE_H = 56;
+
+async function getJSON<T>(url: string): Promise<T> {
+  const r = await fetch(url, {
+    headers: { "X-CSRF-Token": window._csrf || "" },
+  });
+  return (await r.json()) as T;
+}
+async function postJSON<T>(
+  url: string,
+  body: unknown,
+): Promise<{ status: number; data: T }> {
+  const r = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-CSRF-Token": window._csrf || "",
+    },
+    body: JSON.stringify(body),
+  });
+  return { status: r.status, data: (await r.json()) as T };
+}
+
+export default function Workflows() {
+  const [defs, setDefs] = useState<DefRow[]>([]);
+  const [blocks, setBlocks] = useState<BlockDef[]>([]);
+  const [items, setItems] = useState<RunItem[]>([]);
+  const [graph, setGraph] = useState<GraphDef | null>(null);
+  const [version, setVersion] = useState("");
+  const [pos, setPos] = useState<Record<string, { x: number; y: number }>>({});
+  const [selected, setSelected] = useState<string | null>(null);
+  const [status, setStatus] = useState<{
+    kind: "ok" | "err" | "info";
+    msg: string;
+  } | null>(null);
+  const [runItem, setRunItem] = useState<RunItem | null>(null);
+  const [loading, setLoading] = useState(false);
+  const drag = useRef<{ id: string; dx: number; dy: number } | null>(null);
+
+  const refreshLists = useCallback(() => {
+    getJSON<{ defs: DefRow[] }>("/api/workflow/defs")
+      .then((d) => setDefs(d.defs || []))
+      .catch(() => {});
+    getJSON<{ items: RunItem[] }>("/api/workflow/items")
+      .then((d) => setItems(d.items || []))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    getJSON<{ blocks: BlockDef[] }>("/api/workflow/blocks")
+      .then((d) => setBlocks(d.blocks || []))
+      .catch(() => {});
+    refreshLists();
+  }, [refreshLists]);
+
+  const openDef = useCallback((name: string) => {
+    setLoading(true);
+    getJSON<DefResponse>(`/api/workflow/defs/${encodeURIComponent(name)}`)
+      .then((d) => {
+        if (d.error && !d.def) {
+          setStatus({ kind: "err", msg: d.error });
+          return;
+        }
+        setGraph(d.def);
+        setVersion(d.version);
+        setPos(autoLayout(d.def));
+        setSelected(null);
+        setRunItem(null);
+        setStatus(d.valid ? null : { kind: "err", msg: d.error || "invalid" });
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  const newDef = useCallback(() => {
+    const name = prompt("New workflow name (a-z, 0-9, -_ . ):", "my-workflow");
+    if (!name) return;
+    const g: GraphDef = {
+      name,
+      start: "draft",
+      nodes: [
+        {
+          id: "draft",
+          block: "author.proposal",
+          custom: false,
+          produces: "proposal",
+          in: [],
+        },
+      ],
+    };
+    setGraph(g);
+    setVersion("");
+    setPos(autoLayout(g));
+    setSelected("draft");
+    setStatus({ kind: "info", msg: "new workflow (unsaved)" });
+  }, []);
+
+  const mutate = useCallback((fn: (g: GraphDef) => GraphDef) => {
+    setGraph((g) => (g ? fn(structuredClone(g)) : g));
+  }, []);
+
+  const addNode = useCallback(
+    (b: BlockDef) => {
+      if (!graph) return;
+      let i = 1;
+      let id = b.name.replace(/[^a-z0-9]+/gi, "_");
+      while (graph.nodes.some((n) => n.id === id))
+        id = `${b.name.replace(/[^a-z0-9]+/gi, "_")}_${i++}`;
+      const node: GNode = {
+        id,
+        block: b.name,
+        custom: b.custom,
+        produces: b.produces,
+        in: [],
+      };
+      setPos((p) => ({ ...p, [id]: { x: 60, y: 60 } }));
+      mutate((g) => {
+        g.nodes.push(node);
+        if (!g.start) g.start = id;
+        return g;
+      });
+      setSelected(id);
+    },
+    [graph, mutate],
+  );
+
+  const deleteNode = useCallback(
+    (id: string) => {
+      mutate((g) => {
+        g.nodes = g.nodes.filter((n) => n.id !== id);
+        for (const n of g.nodes) {
+          if (n.next === id) n.next = undefined;
+          if (n.on_pass === id) n.on_pass = undefined;
+          if (n.on_fail === id) n.on_fail = undefined;
+          n.in = n.in.filter((b) => b.producer !== id);
+        }
+        if (g.start === id) g.start = g.nodes[0]?.id ?? "";
+        return g;
+      });
+      setSelected(null);
+    },
+    [mutate],
+  );
+
+  const validate = useCallback(async () => {
+    if (!graph) return;
+    const res = await postJSON<DefResponse>("/api/workflow/validate", {
+      yaml: emitWorkflowYaml(graph),
+    });
+    if (res.data.valid)
+      setStatus({
+        kind: "ok",
+        msg: `valid · version ${res.data.version.slice(0, 12)}`,
+      });
+    else setStatus({ kind: "err", msg: res.data.error || "invalid" });
+  }, [graph]);
+
+  const save = useCallback(async () => {
+    if (!graph) return;
+    const res = await postJSON<{
+      name?: string;
+      version?: string;
+      error?: string;
+      current_version?: string;
+    }>("/api/workflow/save", {
+      name: graph.name,
+      yaml: emitWorkflowYaml(graph),
+      prev_version: version,
+    });
+    if (res.status === 200 && res.data.version) {
+      setVersion(res.data.version);
+      setStatus({
+        kind: "ok",
+        msg: `saved · version ${res.data.version.slice(0, 12)}`,
+      });
+      refreshLists();
+    } else if (res.status === 409) {
+      setStatus({
+        kind: "err",
+        msg: `conflict: on-disk version ${(res.data.current_version || "").slice(0, 12) || "differs"} — reload first`,
+      });
+    } else {
+      setStatus({
+        kind: "err",
+        msg: res.data.error || `save failed (${res.status})`,
+      });
+    }
+  }, [graph, version, refreshLists]);
+
+  /* node dragging */
+  const onNodeDown = (id: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelected(id);
+    const p = pos[id] || { x: 0, y: 0 };
+    drag.current = { id, dx: e.clientX - p.x, dy: e.clientY - p.y };
+  };
+  useEffect(() => {
+    const move = (e: MouseEvent) => {
+      if (!drag.current) return;
+      const { id, dx, dy } = drag.current;
+      setPos((p) => ({
+        ...p,
+        [id]: {
+          x: Math.max(0, e.clientX - dx),
+          y: Math.max(0, e.clientY - dy),
+        },
+      }));
+    };
+    const up = () => {
+      drag.current = null;
+    };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+    return () => {
+      window.removeEventListener("mousemove", move);
+      window.removeEventListener("mouseup", up);
+    };
+  }, []);
+
+  const sel = graph?.nodes.find((n) => n.id === selected) || null;
+  // The editor shows the CURRENT on-disk def. A run is pinned to a specific
+  // version; only when that matches the open def does the graph truly depict
+  // what the run is executing — so only then do we highlight the current stage.
+  const runMatchesOpenDef = !!(
+    runItem &&
+    graph &&
+    runItem.workflow === graph.name &&
+    !!version &&
+    runItem.version === version
+  );
+  const activeStage =
+    runMatchesOpenDef && graph?.nodes.some((n) => n.id === runItem!.stage)
+      ? runItem!.stage
+      : null;
+
+  const center = (id: string) => {
+    const p = pos[id];
+    return p ? { x: p.x + NODE_W / 2, y: p.y + NODE_H / 2 } : { x: 0, y: 0 };
+  };
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 12,
+        height: "calc(100vh - 90px)",
+        fontFamily: "system-ui",
+      }}
+    >
+      {/* left rail: defs + palette + run items */}
+      <div
+        style={{
+          width: 230,
+          overflowY: "auto",
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        <Panel title="Workflows" count={defs.length}>
+          <button onClick={newDef} style={btn}>
+            + New
+          </button>
+          <div style={{ marginTop: 6 }}>
+            {defs.map((d) => (
+              <div
+                key={d.name}
+                onClick={() => openDef(d.name)}
+                style={{
+                  ...row,
+                  fontWeight: graph?.name === d.name ? 600 : 400,
+                }}
+              >
+                <span>{d.name}</span>
+                <Badge
+                  label={d.valid ? "ok" : "bad"}
+                  variant={d.valid ? "success" : "error"}
+                />
+              </div>
+            ))}
+          </div>
+        </Panel>
+        <Panel title="Blocks" count={blocks.length}>
+          {blocks.map((b) => (
+            <div
+              key={b.name}
+              onClick={() => addNode(b)}
+              title={`produces ${b.produces}`}
+              style={row}
+            >
+              <span>{b.name}</span>
+              <Badge
+                label={b.custom ? "custom" : b.produces}
+                variant={b.custom ? "info" : "neutral"}
+              />
+            </div>
+          ))}
+        </Panel>
+        <Panel title="Runs" count={items.length}>
+          {items.map((it) => (
+            <div
+              key={it.id}
+              onClick={() => {
+                setRunItem(it);
+                if (it.workflow !== graph?.name) openDef(it.workflow);
+              }}
+              style={{ ...row, fontWeight: runItem?.id === it.id ? 600 : 400 }}
+            >
+              <span>
+                {it.workflow}/{it.stage}
+              </span>
+              <Badge
+                label={it.state}
+                variant={
+                  it.state === "accepted"
+                    ? "success"
+                    : it.state === "active"
+                      ? "running"
+                      : "neutral"
+                }
+              />
+            </div>
+          ))}
+        </Panel>
+      </div>
+
+      {/* center: canvas */}
+      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            marginBottom: 6,
+          }}
+        >
+          <strong>{graph ? graph.name : "no workflow open"}</strong>
+          {version && (
+            <Badge label={`v ${version.slice(0, 8)}`} variant="neutral" />
+          )}
+          <button onClick={validate} disabled={!graph} style={btn}>
+            Validate
+          </button>
+          <button
+            onClick={save}
+            disabled={!graph}
+            style={{ ...btn, background: "#2563eb", color: "#fff" }}
+          >
+            Save
+          </button>
+          {status && (
+            <span
+              style={{
+                color:
+                  status.kind === "err"
+                    ? "#c00"
+                    : status.kind === "ok"
+                      ? "#070"
+                      : "#666",
+                fontSize: 13,
+              }}
+            >
+              {status.msg}
+            </span>
+          )}
+          <Spinner loading={loading} text="loading…" />
+        </div>
+        <div
+          style={{
+            flex: 1,
+            border: "1px solid #ddd",
+            borderRadius: 6,
+            overflow: "auto",
+            background: "#fafafa",
+          }}
+          onClick={() => setSelected(null)}
+        >
+          <svg width={1600} height={1000} style={{ display: "block" }}>
+            <defs>
+              <marker
+                id="arrow"
+                markerWidth="8"
+                markerHeight="8"
+                refX="7"
+                refY="3"
+                orient="auto"
+              >
+                <path d="M0,0 L7,3 L0,6 Z" fill="#888" />
+              </marker>
+            </defs>
+            {graph?.nodes.map((n) =>
+              (["next", "on_pass", "on_fail"] as const).map((edge) => {
+                const t = n[edge];
+                if (!t || !pos[t]) return null;
+                const a = center(n.id),
+                  b = center(t);
+                const color =
+                  edge === "on_pass"
+                    ? "#22a06b"
+                    : edge === "on_fail"
+                      ? "#d4564f"
+                      : "#888";
+                return (
+                  <line
+                    key={`${n.id}-${edge}`}
+                    x1={a.x}
+                    y1={a.y}
+                    x2={b.x}
+                    y2={b.y}
+                    stroke={color}
+                    strokeWidth={1.5}
+                    markerEnd="url(#arrow)"
+                    strokeDasharray={edge === "next" ? undefined : "5,3"}
+                  />
+                );
+              }),
+            )}
+            {graph?.nodes.flatMap((n) =>
+              n.in.map((b) => {
+                if (!pos[b.producer]) return null;
+                const a = center(b.producer),
+                  c = center(n.id);
+                return (
+                  <line
+                    key={`${n.id}-in-${b.input}`}
+                    x1={a.x}
+                    y1={a.y}
+                    x2={c.x}
+                    y2={c.y}
+                    stroke="#bbb"
+                    strokeWidth={1}
+                    strokeDasharray="2,3"
+                  />
+                );
+              }),
+            )}
+            {graph?.nodes.map((n) => {
+              const p = pos[n.id] || { x: 0, y: 0 };
+              const isSel = n.id === selected;
+              const isActive = n.id === activeStage;
+              return (
+                <g
+                  key={n.id}
+                  transform={`translate(${p.x},${p.y})`}
+                  style={{ cursor: "grab" }}
+                  onMouseDown={(e) => onNodeDown(n.id, e)}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  <rect
+                    width={NODE_W}
+                    height={NODE_H}
+                    rx={6}
+                    fill={isActive ? "#fff7e0" : "#fff"}
+                    stroke={isSel ? "#2563eb" : isActive ? "#e0a800" : "#ccc"}
+                    strokeWidth={isSel || isActive ? 2 : 1}
+                  />
+                  <text x={8} y={20} fontSize={13} fontWeight={600} fill="#222">
+                    {n.id}
+                  </text>
+                  <text x={8} y={38} fontSize={11} fill="#777">
+                    {n.block}
+                    {n.custom ? " ⚙" : ""}
+                  </text>
+                  <text x={8} y={50} fontSize={10} fill="#aaa">
+                    → {n.produces}
+                  </text>
+                  {n.id === graph?.start && (
+                    <circle cx={NODE_W - 10} cy={10} r={4} fill="#22a06b" />
+                  )}
+                </g>
+              );
+            })}
+          </svg>
+        </div>
+      </div>
+
+      {/* right: inspector */}
+      <div style={{ width: 270, overflowY: "auto" }}>
+        <Panel title={sel ? `Node · ${sel.id}` : "Inspector"}>
+          {!sel && (
+            <div style={{ color: "#888", fontSize: 13 }}>
+              Select a node, or click a block to add one.
+            </div>
+          )}
+          {sel && graph && (
+            <NodeInspector
+              node={sel}
+              graph={graph}
+              mutate={mutate}
+              onDelete={() => deleteNode(sel.id)}
+            />
+          )}
+        </Panel>
+        {runItem && (
+          <Panel title="Run state">
+            <Field k="workflow" v={runItem.workflow} />
+            <Field k="stage" v={runItem.stage} />
+            <Field k="state" v={runItem.state} />
+            <Field k="pause" v={runItem.pause_reason || "—"} />
+            <Field k="version" v={runItem.version.slice(0, 12)} />
+            {graph &&
+              runItem.workflow === graph.name &&
+              runItem.version &&
+              version &&
+              runItem.version !== version && (
+                <div style={{ color: "#c80", fontSize: 12, marginTop: 6 }}>
+                  ⚠ This run is pinned to version {runItem.version.slice(0, 12)}
+                  , but the editor is showing the <b>current</b> def (
+                  {version.slice(0, 12)}). The graph may not match what the run
+                  is executing, so the stage highlight is hidden until they
+                  match.
+                </div>
+              )}
+          </Panel>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ k, v }: { k: string; v: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        fontSize: 13,
+        padding: "2px 0",
+      }}
+    >
+      <span style={{ color: "#888" }}>{k}</span>
+      <span style={{ fontFamily: "monospace" }}>{v}</span>
+    </div>
+  );
+}
+
+function NodeInspector({
+  node,
+  graph,
+  mutate,
+  onDelete,
+}: {
+  node: GNode;
+  graph: GraphDef;
+  mutate: (fn: (g: GraphDef) => GraphDef) => void;
+  onDelete: () => void;
+}) {
+  const [paramsText, setParamsText] = useState(
+    node.params ? JSON.stringify(node.params, null, 2) : "",
+  );
+  const [paramsErr, setParamsErr] = useState("");
+  useEffect(() => {
+    setParamsText(node.params ? JSON.stringify(node.params, null, 2) : "");
+    setParamsErr("");
+  }, [node.id]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const setEdge = (edge: "next" | "on_pass" | "on_fail", v: string) =>
+    mutate((g) => {
+      const n = g.nodes.find((x) => x.id === node.id);
+      if (n) n[edge] = v || undefined;
+      return g;
+    });
+  const setStart = () =>
+    mutate((g) => {
+      g.start = node.id;
+      return g;
+    });
+  const others = graph.nodes.filter((n) => n.id !== node.id);
+
+  const commitParams = (text: string) => {
+    setParamsText(text);
+    if (!text.trim()) {
+      setParamsErr("");
+      mutate((g) => {
+        const n = g.nodes.find((x) => x.id === node.id);
+        if (n) n.params = undefined;
+        return g;
+      });
+      return;
+    }
+    try {
+      const obj = JSON.parse(text) as Record<string, unknown>;
+      setParamsErr("");
+      mutate((g) => {
+        const n = g.nodes.find((x) => x.id === node.id);
+        if (n) n.params = obj;
+        return g;
+      });
+    } catch {
+      setParamsErr("invalid JSON");
+    }
+  };
+
+  const addBinding = () =>
+    mutate((g) => {
+      const n = g.nodes.find((x) => x.id === node.id);
+      if (n)
+        n.in.push({
+          input: "src",
+          producer: others[0]?.id || "",
+          output: "out",
+        });
+      return g;
+    });
+  const setBinding = (i: number, field: keyof Binding, v: string) =>
+    mutate((g) => {
+      const n = g.nodes.find((x) => x.id === node.id);
+      if (n) n.in[i] = { ...n.in[i], [field]: v };
+      return g;
+    });
+  const delBinding = (i: number) =>
+    mutate((g) => {
+      const n = g.nodes.find((x) => x.id === node.id);
+      if (n) n.in.splice(i, 1);
+      return g;
+    });
+
+  return (
+    <div style={{ fontSize: 13 }}>
+      <Field k="block" v={node.block + (node.custom ? " (custom)" : "")} />
+      <Field k="produces" v={node.produces} />
+      <div style={{ margin: "6px 0" }}>
+        <button
+          onClick={setStart}
+          disabled={graph.start === node.id}
+          style={btn}
+        >
+          {graph.start === node.id ? "start node ✓" : "set as start"}
+        </button>
+      </div>
+
+      <label style={lbl}>Inputs</label>
+      {node.in.map((b, i) => (
+        <div key={i} style={{ display: "flex", gap: 4, marginBottom: 4 }}>
+          <input
+            value={b.input}
+            onChange={(e) => setBinding(i, "input", e.target.value)}
+            style={{ ...inp, width: 60 }}
+          />
+          <select
+            value={b.producer}
+            onChange={(e) => setBinding(i, "producer", e.target.value)}
+            style={inp}
+          >
+            <option value="">—</option>
+            {others.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.id}
+              </option>
+            ))}
+          </select>
+          <button onClick={() => delBinding(i)} style={btnSmall}>
+            ×
+          </button>
+        </div>
+      ))}
+      <button onClick={addBinding} style={btnSmall}>
+        + input
+      </button>
+
+      {(["next", "on_pass", "on_fail"] as const).map((edge) => (
+        <div key={edge} style={{ marginTop: 6 }}>
+          <label style={lbl}>{edge}</label>
+          <select
+            value={node[edge] || ""}
+            onChange={(e) => setEdge(edge, e.target.value)}
+            style={{ ...inp, width: "100%" }}
+          >
+            <option value="">—</option>
+            {others.map((o) => (
+              <option key={o.id} value={o.id}>
+                {o.id}
+              </option>
+            ))}
+          </select>
+        </div>
+      ))}
+
+      <label style={{ ...lbl, marginTop: 8 }}>params (JSON)</label>
+      <textarea
+        value={paramsText}
+        onChange={(e) => commitParams(e.target.value)}
+        rows={6}
+        style={{ ...inp, width: "100%", fontFamily: "monospace", fontSize: 12 }}
+      />
+      {paramsErr && (
+        <div style={{ color: "#c00", fontSize: 12 }}>{paramsErr}</div>
+      )}
+
+      <button
+        onClick={onDelete}
+        style={{ ...btn, marginTop: 10, color: "#c00", borderColor: "#e0a0a0" }}
+      >
+        Delete node
+      </button>
+    </div>
+  );
+}
+
+/* ---- inline styles ---- */
+const btn: React.CSSProperties = {
+  fontSize: 13,
+  padding: "4px 10px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  background: "#fff",
+  cursor: "pointer",
+};
+const btnSmall: React.CSSProperties = {
+  ...btn,
+  padding: "2px 6px",
+  fontSize: 12,
+};
+const row: React.CSSProperties = {
+  display: "flex",
+  justifyContent: "space-between",
+  alignItems: "center",
+  padding: "4px 2px",
+  cursor: "pointer",
+  fontSize: 13,
+};
+const lbl: React.CSSProperties = {
+  display: "block",
+  color: "#888",
+  fontSize: 12,
+  margin: "4px 0 2px",
+};
+const inp: React.CSSProperties = {
+  fontSize: 13,
+  padding: "3px 5px",
+  border: "1px solid #ccc",
+  borderRadius: 4,
+};

--- a/src/Makefile
+++ b/src/Makefile
@@ -378,7 +378,8 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
               server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/vault_capability.c server/server_vault.c \
               workflow/wfe_engine.c workflow/wfe_blocks.c workflow/wfe_approval.c \
-              workflow/wfe_verdict.c workflow/wfe_roundtable.c workflow/wfe_autonomy.c
+              workflow/wfe_verdict.c workflow/wfe_roundtable.c workflow/wfe_autonomy.c \
+              server/server_workflow_api.c
 SERVER_OBJS = $(SERVER_SRCS:%.c=$(OBJDIR)/%.o)
 SERVER_DATA_SRCS = $(filter-out $(SERVER_SRCS) guardrails_orchestrator.c,$(DATA_SRCS))
 SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \

--- a/src/cmd_workflow.c
+++ b/src/cmd_workflow.c
@@ -13,28 +13,48 @@
 #include <dirent.h>
 #endif
 
+static void print_accepts_builtin(wfe_block_type_t t)
+{
+   int any = 0;
+   for (wfe_artifact_type_t a = WFE_ART_PROPOSAL; a < WFE_ART__COUNT; a++)
+      if (wfe_block_accepts_input(t, a))
+      {
+         printf(" %s", wfe_artifact_name(a));
+         any = 1;
+      }
+   if (!any)
+      printf(" (none)");
+}
+
 static void print_blocks(void)
 {
-   static const wfe_block_type_t order[] = {
-       WFE_BLK_AUTHOR_PROPOSAL, WFE_BLK_AUTHOR_PLAN, WFE_BLK_IMPLEMENT,
-       WFE_BLK_DOCUMENT,        WFE_BLK_FREEZE,      WFE_BLK_GATE_ROUNDTABLE,
-       WFE_BLK_GATE_HUMAN,      WFE_BLK_PR_OPEN,     WFE_BLK_MERGE};
+   /* enumerate the live catalog: every built-in (incl. gate.ci / check.mergeable)
+    * plus the config-defined custom registry, so this never drifts from the
+    * blocks the validator + web composer actually know. */
+   char err[256] = "";
+   wfe_custom_registry_ensure(err, sizeof err);
    printf("Workflow block catalog:\n");
-   for (size_t i = 0; i < sizeof order / sizeof order[0]; i++)
+   for (wfe_block_type_t t = WFE_BLK_UNKNOWN + 1; t < WFE_BLK_CUSTOM; t++)
    {
-      wfe_block_type_t t = order[i];
       printf("  %-18s produces %-12s accepts:", wfe_block_name(t),
              wfe_artifact_name(wfe_block_output(t)));
-      int any = 0;
-      for (wfe_artifact_type_t a = WFE_ART_PROPOSAL; a < WFE_ART__COUNT; a++)
-         if (wfe_block_accepts_input(t, a))
-         {
-            printf(" %s", wfe_artifact_name(a));
-            any = 1;
-         }
-      if (!any)
-         printf(" (none)");
+      print_accepts_builtin(t);
       printf("\n");
+   }
+   int n = wfe_custom_count();
+   if (n > 0)
+      printf("Custom blocks ($AIMEE_HOME/workflows/blocks.yaml):\n");
+   for (int i = 0; i < n; i++)
+   {
+      const wfe_custom_block_t *c = wfe_custom_at(i);
+      if (!c)
+         continue;
+      printf("  %-18s produces %-12s accepts:", c->name, wfe_artifact_name(c->produces));
+      if (c->consumes != WFE_ART_NONE)
+         printf(" %s", wfe_artifact_name(c->consumes));
+      else
+         printf(" (none)");
+      printf("  [%s]\n", c->executor == WFE_EXEC_COMMAND ? "command" : "delegate");
    }
 }
 

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -28,6 +28,7 @@
 #include "presence.h"
 #include "request_context.h"
 #include "server_http_identity.h" /* WP-C.0 attested-identity capture/threading */
+#include "server_workflow_api.h"  /* W7: /v1/workflow read+author handlers */
 #include "cJSON.h"
 #include <arpa/inet.h>
 #include <errno.h>

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -259,6 +259,41 @@ static int rh_session_primary_clear(const route_req_t *rq, char *resp, int cap)
    return route_session_primary_clear(rq->id, resp, cap);
 }
 
+/* ── workflow visual composer (W7) ────────────────────────────────────────
+ * Read+author surface over the wfe_ definition model + DB1 run-state; logic in
+ * server_workflow_api.c (self-contained JSON envelopes). */
+static int rh_wf_blocks(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   return wf_api_blocks(resp, cap);
+}
+static int rh_wf_list(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   return wf_api_list(resp, cap);
+}
+static int rh_wf_get(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_get(rq->id, resp, cap);
+}
+static int rh_wf_validate(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_validate(rq->body, resp, cap);
+}
+static int rh_wf_save(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_save(rq->body, resp, cap);
+}
+static int rh_wf_items(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   return wf_api_items(resp, cap);
+}
+static int rh_wf_item(const route_req_t *rq, char *resp, int cap)
+{
+   return wf_api_item(rq->id, resp, cap);
+}
+
 /* The POST /v1/rpc bridge was retired once every dispatch method gained a
  * first-class /v1 route (op-parity complete; check-v1-method-coverage reports 0
  * excluded). The thin client and all co-located callers now use the dedicated
@@ -1085,6 +1120,17 @@ static const http_route_t g_v1_routes[] = {
 
     /* Unified presence: list / attach / detach / persona / events are
      * session-scoped on the owner's own presence. */
+    /* Workflow visual composer (W7): read+author the wfe_ definition model and
+     * read work-item run-state. Reads (incl. validate, which never mutates) are
+     * dashboard-read; save is session-admin (authoring write). */
+    {"GET", "/v1/workflow/blocks", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_blocks},
+    {"GET", "/v1/workflow/defs", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_list},
+    {"GET", "/v1/workflow/defs/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_get},
+    {"POST", "/v1/workflow/validate", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_validate},
+    {"POST", "/v1/workflow/save", NULL, RM_EXACT, NULL, CAP_SESSION_ADMIN, rh_wf_save},
+    {"GET", "/v1/workflow/items", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_items},
+    {"GET", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item},
+
     {"GET", "/v1/sessions", NULL, RM_EXACT, NULL, CAP_SESSION_READ, rh_sessions_list},
     {"POST", "/v1/sessions/", "/attach", RM_PREFIX, NULL, CAP_SESSION_READ, rh_session_attach},
     {"POST", "/v1/sessions/", "/detach", RM_PREFIX, NULL, CAP_SESSION_READ, rh_session_detach},

--- a/src/server/server_workflow_api.c
+++ b/src/server/server_workflow_api.c
@@ -1,0 +1,433 @@
+/* server_workflow_api.c -- /v1/workflow read+author surface (W7 web composer).
+ * A thin HTTP layer over the wfe_ definition model (CORE: parse / validate /
+ * canonical / version) and the DB1 work-item store (run-state). Definitions are
+ * YAML files under $AIMEE_HOME/workflows; save canonical-normalizes and applies
+ * an optimistic lock on the on-disk version. See server_workflow_api.h. */
+#include "server_workflow_api.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#ifndef _WIN32
+#include <dirent.h>
+#endif
+
+#include "aimee_home.h"
+#include "cJSON.h"
+#include "wfe_def.h"
+#include "wfe_iface.h"
+#include "wfe_store.h"
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+/* Serialize `root` (consumed) into resp; 200 on success, 500 if it overflows the
+ * response buffer. */
+static int emit(cJSON *root, char *resp, int cap)
+{
+   char *s = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   if (!s)
+   {
+      snprintf(resp, (size_t)cap, "{\"error\":\"out of memory\"}");
+      return 500;
+   }
+   int rc = 200;
+   if ((int)strlen(s) >= cap)
+   {
+      snprintf(resp, (size_t)cap, "{\"error\":\"response too large\"}");
+      rc = 500;
+   }
+   else
+   {
+      snprintf(resp, (size_t)cap, "%s", s);
+   }
+   free(s);
+   return rc;
+}
+
+static int err(char *resp, int cap, int status, const char *msg)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "error", msg);
+   char *s = cJSON_PrintUnformatted(o);
+   cJSON_Delete(o);
+   if (s)
+   {
+      snprintf(resp, (size_t)cap, "%s", s);
+      free(s);
+   }
+   else
+   {
+      snprintf(resp, (size_t)cap, "{\"error\":\"%s\"}", "error");
+   }
+   return status;
+}
+
+/* A workflow name must be a single safe path component: [A-Za-z0-9._-], no "..",
+ * non-empty, < 64 bytes. The route layer already strips slashes (one path
+ * segment), but we re-check here so save/get cannot be coerced into traversal. */
+static int safe_name(const char *name)
+{
+   if (!name || !name[0] || strlen(name) >= 64)
+      return 0;
+   if (strcmp(name, ".") == 0 || strcmp(name, "..") == 0)
+      return 0;
+   for (const char *p = name; *p; p++)
+   {
+      char c = *p;
+      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '.' || c == '_' || c == '-';
+      if (!ok)
+         return 0;
+   }
+   if (strstr(name, ".."))
+      return 0;
+   return 1;
+}
+
+static void def_path(const char *name, char *out, size_t cap)
+{
+   snprintf(out, cap, "%s/workflows/%s.yaml", aimee_home(), name);
+}
+
+/* Build a structured node-graph JSON for the editor to render (block names +
+ * typed output + input bindings + control edges + params). */
+static cJSON *def_to_json(const wfe_def_t *def)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "name", def->name);
+   cJSON_AddStringToObject(o, "start", def->start);
+   cJSON *nodes = cJSON_AddArrayToObject(o, "nodes");
+   for (int i = 0; i < def->n_nodes; i++)
+   {
+      const wfe_node_t *nd = &def->nodes[i];
+      cJSON *jn = cJSON_CreateObject();
+      cJSON_AddStringToObject(jn, "id", nd->id);
+      cJSON_AddStringToObject(
+          jn, "block", nd->block == WFE_BLK_CUSTOM ? nd->custom_name : wfe_block_name(nd->block));
+      cJSON_AddBoolToObject(jn, "custom", nd->block == WFE_BLK_CUSTOM);
+      cJSON_AddStringToObject(jn, "produces", wfe_artifact_name(wfe_node_output(nd)));
+      cJSON *ins = cJSON_AddArrayToObject(jn, "in");
+      for (int b = 0; b < nd->n_ins; b++)
+      {
+         cJSON *bd = cJSON_CreateObject();
+         cJSON_AddStringToObject(bd, "input", nd->ins[b].input_name);
+         cJSON_AddStringToObject(bd, "producer", nd->ins[b].producer_id);
+         cJSON_AddStringToObject(bd, "output", nd->ins[b].output_name);
+         cJSON_AddItemToArray(ins, bd);
+      }
+      if (nd->next[0])
+         cJSON_AddStringToObject(jn, "next", nd->next);
+      if (nd->on_pass[0])
+         cJSON_AddStringToObject(jn, "on_pass", nd->on_pass);
+      if (nd->on_fail[0])
+         cJSON_AddStringToObject(jn, "on_fail", nd->on_fail);
+      if (nd->params)
+         cJSON_AddItemToObject(jn, "params", cJSON_Duplicate(nd->params, 1));
+      cJSON_AddItemToArray(nodes, jn);
+   }
+   return o;
+}
+
+/* Fill {valid,error?,name,version,canonical,def} for an already-parsed def. */
+static void add_def_report(cJSON *o, wfe_def_t *def)
+{
+   char verr[256] = "";
+   int rc = wfe_def_validate(def, verr, sizeof verr);
+   cJSON_AddBoolToObject(o, "valid", rc == 0);
+   cJSON_AddStringToObject(o, "name", def->name);
+   char ver[65] = "";
+   wfe_def_compute_version(def, ver);
+   cJSON_AddStringToObject(o, "version", ver);
+   char *canon = wfe_def_canonical(def);
+   cJSON_AddStringToObject(o, "canonical", canon ? canon : "");
+   free(canon);
+   cJSON_AddItemToObject(o, "def", def_to_json(def));
+   if (rc != 0)
+      cJSON_AddStringToObject(o, "error", verr);
+}
+
+/* ── handlers ────────────────────────────────────────────────────────────── */
+
+int wf_api_blocks(char *resp, int cap)
+{
+   char e[256] = "";
+   wfe_custom_registry_ensure(e, sizeof e); /* best-effort; built-ins always listed */
+   cJSON *o = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(o, "blocks");
+   /* built-ins: every catalog entry except UNKNOWN/CUSTOM sentinels */
+   for (wfe_block_type_t t = WFE_BLK_UNKNOWN + 1; t < WFE_BLK_CUSTOM; t++)
+   {
+      cJSON *b = cJSON_CreateObject();
+      cJSON_AddStringToObject(b, "name", wfe_block_name(t));
+      cJSON_AddStringToObject(b, "produces", wfe_artifact_name(wfe_block_output(t)));
+      cJSON_AddBoolToObject(b, "custom", 0);
+      cJSON_AddBoolToObject(b, "requires_input", wfe_block_requires_input(t));
+      cJSON *acc = cJSON_AddArrayToObject(b, "accepts");
+      for (wfe_artifact_type_t a = WFE_ART_NONE; a < WFE_ART__COUNT; a++)
+         if (wfe_block_accepts_input(t, a))
+            cJSON_AddItemToArray(acc, cJSON_CreateString(wfe_artifact_name(a)));
+      cJSON_AddItemToArray(arr, b);
+   }
+   /* config-defined custom blocks */
+   for (int i = 0; i < wfe_custom_count(); i++)
+   {
+      const wfe_custom_block_t *c = wfe_custom_at(i);
+      if (!c)
+         continue;
+      cJSON *b = cJSON_CreateObject();
+      cJSON_AddStringToObject(b, "name", c->name);
+      cJSON_AddStringToObject(b, "produces", wfe_artifact_name(c->produces));
+      cJSON_AddBoolToObject(b, "custom", 1);
+      cJSON_AddStringToObject(b, "executor",
+                              c->executor == WFE_EXEC_COMMAND ? "command" : "delegate");
+      cJSON_AddBoolToObject(b, "requires_input", c->consumes != WFE_ART_NONE);
+      cJSON *acc = cJSON_AddArrayToObject(b, "accepts");
+      if (c->consumes != WFE_ART_NONE)
+         cJSON_AddItemToArray(acc, cJSON_CreateString(wfe_artifact_name(c->consumes)));
+      cJSON_AddItemToArray(arr, b);
+   }
+   return emit(o, resp, cap);
+}
+
+int wf_api_list(char *resp, int cap)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(o, "defs");
+#ifndef _WIN32
+   char dir[1024];
+   snprintf(dir, sizeof dir, "%s/workflows", aimee_home());
+   DIR *d = opendir(dir);
+   if (d)
+   {
+      struct dirent *ent;
+      while ((ent = readdir(d)))
+      {
+         const char *dot = strrchr(ent->d_name, '.');
+         if (!dot || strcmp(dot, ".yaml") != 0)
+            continue;
+         char name[128];
+         size_t nlen = (size_t)(dot - ent->d_name);
+         if (nlen >= sizeof name)
+            continue;
+         memcpy(name, ent->d_name, nlen);
+         name[nlen] = '\0';
+         char path[2048];
+         snprintf(path, sizeof path, "%s/%s", dir, ent->d_name);
+         char lerr[256] = "";
+         wfe_def_t *def = wfe_def_load_file(path, lerr, sizeof lerr);
+         cJSON *row = cJSON_CreateObject();
+         cJSON_AddStringToObject(row, "name", name);
+         int valid = def && wfe_def_validate(def, lerr, sizeof lerr) == 0;
+         cJSON_AddBoolToObject(row, "valid", valid);
+         char ver[65] = "";
+         if (valid)
+            wfe_def_compute_version(def, ver);
+         cJSON_AddStringToObject(row, "version", ver);
+         if (def)
+            wfe_def_free(def);
+         cJSON_AddItemToArray(arr, row);
+      }
+      closedir(d);
+   }
+#endif
+   return emit(o, resp, cap);
+}
+
+int wf_api_get(const char *name, char *resp, int cap)
+{
+   if (!safe_name(name))
+      return err(resp, cap, 400, "invalid workflow name");
+   char path[2048];
+   def_path(name, path, sizeof path);
+   char lerr[256] = "";
+   wfe_def_t *def = wfe_def_load_file(path, lerr, sizeof lerr);
+   if (!def)
+      return err(resp, cap, 404, "workflow not found");
+   cJSON *o = cJSON_CreateObject();
+   add_def_report(o, def);
+   wfe_def_free(def);
+   return emit(o, resp, cap);
+}
+
+int wf_api_validate(const char *body, char *resp, int cap)
+{
+   cJSON *req = (body && body[0]) ? cJSON_Parse(body) : NULL;
+   const cJSON *jy = req ? cJSON_GetObjectItemCaseSensitive(req, "yaml") : NULL;
+   if (!cJSON_IsString(jy))
+   {
+      cJSON_Delete(req);
+      return err(resp, cap, 400, "expected {\"yaml\":\"...\"}");
+   }
+   char perr[256] = "";
+   wfe_def_t *def = wfe_def_parse(jy->valuestring, perr, sizeof perr);
+   if (!def)
+   {
+      cJSON_Delete(req);
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddBoolToObject(o, "valid", 0);
+      cJSON_AddStringToObject(o, "error", perr);
+      return emit(o, resp, cap);
+   }
+   cJSON *o = cJSON_CreateObject();
+   add_def_report(o, def);
+   wfe_def_free(def);
+   cJSON_Delete(req);
+   return emit(o, resp, cap);
+}
+
+int wf_api_save(const char *body, char *resp, int cap)
+{
+   cJSON *req = (body && body[0]) ? cJSON_Parse(body) : NULL;
+   const cJSON *jn = req ? cJSON_GetObjectItemCaseSensitive(req, "name") : NULL;
+   const cJSON *jy = req ? cJSON_GetObjectItemCaseSensitive(req, "yaml") : NULL;
+   const cJSON *jp = req ? cJSON_GetObjectItemCaseSensitive(req, "prev_version") : NULL;
+   if (!cJSON_IsString(jn) || !cJSON_IsString(jy))
+   {
+      cJSON_Delete(req);
+      return err(resp, cap, 400, "expected {\"name\",\"yaml\",\"prev_version\"}");
+   }
+   if (!safe_name(jn->valuestring))
+   {
+      cJSON_Delete(req);
+      return err(resp, cap, 400, "invalid workflow name");
+   }
+   const char *prev = cJSON_IsString(jp) ? jp->valuestring : "";
+
+   /* parse + validate before touching disk */
+   char perr[256] = "";
+   wfe_def_t *def = wfe_def_parse(jy->valuestring, perr, sizeof perr);
+   if (!def)
+   {
+      cJSON_Delete(req);
+      return err(resp, cap, 400, perr);
+   }
+   if (wfe_def_validate(def, perr, sizeof perr) != 0)
+   {
+      wfe_def_free(def);
+      cJSON_Delete(req);
+      return err(resp, cap, 400, perr);
+   }
+
+   char path[2048];
+   def_path(jn->valuestring, path, sizeof path);
+
+   /* optimistic lock: compare prev_version against the on-disk version.
+    * (Single-editor v1: a tiny check->rename race is accepted, per the slice
+    * spec; a multi-writer lock is out of scope.) */
+   /* existence is decided by stat (NOT parse success): a present-but-corrupt
+    * file must still block a create (empty prev_version), so we never silently
+    * overwrite an unparseable workflow. cur stays "" when the file won't parse,
+    * so any non-empty prev_version then correctly fails the version match. */
+   struct stat stx;
+   int exists = (stat(path, &stx) == 0);
+   char cur[65] = "";
+   wfe_def_t *existing = wfe_def_load_file(path, perr, sizeof perr);
+   if (existing)
+   {
+      wfe_def_compute_version(existing, cur);
+      wfe_def_free(existing);
+   }
+   if (!prev[0] && exists)
+   {
+      wfe_def_free(def);
+      cJSON_Delete(req);
+      return err(resp, cap, 409, "workflow already exists (supply prev_version to overwrite)");
+   }
+   if (prev[0] && (!exists || strcmp(prev, cur) != 0))
+   {
+      wfe_def_free(def);
+      cJSON_Delete(req);
+      cJSON *o = cJSON_CreateObject();
+      cJSON_AddStringToObject(o, "error", "version conflict");
+      cJSON_AddStringToObject(o, "current_version", cur);
+      char *s = cJSON_PrintUnformatted(o);
+      cJSON_Delete(o);
+      if (s)
+      {
+         snprintf(resp, (size_t)cap, "%s", s);
+         free(s);
+      }
+      return 409;
+   }
+
+   /* normalize-on-save: write the canonical form (byte-stable round-trip) */
+   char *canon = wfe_def_canonical(def);
+   char ver[65] = "";
+   wfe_def_compute_version(def, ver);
+   wfe_def_free(def);
+   if (!canon)
+   {
+      cJSON_Delete(req);
+      return err(resp, cap, 500, "canonicalization failed");
+   }
+
+   char dir[1024];
+   snprintf(dir, sizeof dir, "%s/workflows", aimee_home());
+   mkdir(dir, 0755); /* best-effort; ok if it exists */
+
+   /* atomic write: temp file in the same dir + rename over the target */
+   char tmp[2100];
+   snprintf(tmp, sizeof tmp, "%s/.%s.yaml.tmp", dir, jn->valuestring);
+   FILE *f = fopen(tmp, "wb");
+   if (!f)
+   {
+      free(canon);
+      cJSON_Delete(req);
+      return err(resp, cap, 500, "cannot write workflow");
+   }
+   size_t clen = strlen(canon);
+   int wok = fwrite(canon, 1, clen, f) == clen;
+   free(canon);
+   if (fclose(f) != 0 || !wok || rename(tmp, path) != 0)
+   {
+      remove(tmp);
+      cJSON_Delete(req);
+      return err(resp, cap, 500, "cannot persist workflow");
+   }
+
+   cJSON_Delete(req);
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "name", jn->valuestring);
+   cJSON_AddStringToObject(o, "version", ver);
+   return emit(o, resp, cap);
+}
+
+/* shared: serialize one work-item row */
+static cJSON *item_to_json(const db1_work_item_t *wi)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "id", wi->work_item_id);
+   cJSON_AddStringToObject(o, "workflow", wi->workflow_name);
+   cJSON_AddStringToObject(o, "version", wi->workflow_version);
+   cJSON_AddStringToObject(o, "stage", wi->current_stage);
+   cJSON_AddStringToObject(o, "state", wi->state);
+   cJSON_AddStringToObject(o, "mode", wi->mode);
+   cJSON_AddStringToObject(o, "pause_reason", wi->pause_reason);
+   cJSON_AddStringToObject(o, "repo", wi->repo);
+   return o;
+}
+
+int wf_api_items(char *resp, int cap)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(o, "items");
+   db1_work_item_t *rows = NULL;
+   int n = db1_work_item_list(&rows);
+   for (int i = 0; i < n; i++)
+      cJSON_AddItemToArray(arr, item_to_json(&rows[i]));
+   free(rows);
+   return emit(o, resp, cap);
+}
+
+int wf_api_item(const char *id, char *resp, int cap)
+{
+   if (!id || !id[0])
+      return err(resp, cap, 400, "missing work item id");
+   db1_work_item_t wi;
+   if (db1_work_item_get(id, &wi) != 1)
+      return err(resp, cap, 404, "work item not found");
+   return emit(item_to_json(&wi), resp, cap);
+}

--- a/src/server/server_workflow_api.h
+++ b/src/server/server_workflow_api.h
@@ -1,0 +1,37 @@
+/* server_workflow_api.h -- /v1/workflow read+author surface for the web visual
+ * composer (W7). Thin HTTP layer over the wfe_ definition model (parse/validate/
+ * canonical/version, all CORE) + the DB1 work-item store for run-state. Each
+ * function fills `resp` with a JSON body and returns the HTTP status. They are
+ * self-contained (own error envelopes) so the route adapters stay one-liners. */
+#ifndef DEC_SERVER_WORKFLOW_API_H
+#define DEC_SERVER_WORKFLOW_API_H 1
+
+/* GET /v1/workflow/blocks -- the composable block catalog (built-ins + the
+ * config-defined custom registry) with each block's typed I/O for the palette. */
+int wf_api_blocks(char *resp, int cap);
+
+/* GET /v1/workflow/defs -- list saved workflow definitions under
+ * $AIMEE_HOME/workflows (name + valid + version). */
+int wf_api_list(char *resp, int cap);
+
+/* GET /v1/workflow/defs/{name} -- one definition: canonical form, version, and a
+ * structured node graph for rendering. 400 on an unsafe name, 404 if missing. */
+int wf_api_get(const char *name, char *resp, int cap);
+
+/* POST /v1/workflow/validate {"yaml":"..."} -- validate posted text without
+ * saving; returns {valid, error?, name, version, canonical, def}. */
+int wf_api_validate(const char *body, char *resp, int cap);
+
+/* POST /v1/workflow/save {"name","yaml","prev_version"} -- canonical-normalize +
+ * write with an optimistic lock on prev_version (409 on mismatch; create requires
+ * an empty prev_version and a non-existent file). 400 on invalid def/name. */
+int wf_api_save(const char *body, char *resp, int cap);
+
+/* GET /v1/workflow/items -- list work items (run-state rows). */
+int wf_api_items(char *resp, int cap);
+
+/* GET /v1/workflow/items/{id} -- one work item's run-state (workflow, pinned
+ * version, current stage, state, pause reason). 404 if unknown. */
+int wf_api_item(const char *id, char *resp, int cap);
+
+#endif /* DEC_SERVER_WORKFLOW_API_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -104,6 +104,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-autonomy \
                $(TESTPREFIX)/unit-test-wfe-custom \
                $(TESTPREFIX)/unit-test-wfe-safety \
+               $(TESTPREFIX)/unit-test-wfe-webapi \
                $(TESTPREFIX)/unit-test-cli-profile \
                $(TESTPREFIX)/unit-test-cmd-profile \
                $(TESTPREFIX)/unit-test-kb-client-index \
@@ -809,6 +810,7 @@ $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o 
 	                                $(OBJDIR)/server/server_config.o $(OBJDIR)/config_fields.o \
 	                                $(OBJDIR)/server/skill_review.o $(OBJDIR)/tests/support/skill_jobs_stub.o \
 	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o \
+	                                $(OBJDIR)/tests/support/workflow_api_stub.o \
 	                                $(OBJDIR)/tests/support/vault_handlers_stub.o \
 	                                $(OBJDIR)/tests/support/toolset_stub.o \
 	                                $(OBJDIR)/cJSON.o $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
@@ -953,6 +955,16 @@ $(TESTPREFIX)/unit-test-wfe-safety: $(OBJDIR)/tests/test_wfe_safety.o \
                                     $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
                                     $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
                                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Workflow visual composer (W7): /v1/workflow read+author handlers.
+$(TESTPREFIX)/unit-test-wfe-webapi: $(OBJDIR)/tests/test_wfe_webapi.o \
+                                    $(OBJDIR)/server/server_workflow_api.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Workflow engine W4: HMAC approval signer + gate.human.
@@ -1992,7 +2004,7 @@ $(TESTPREFIX)/unit-test-persona: $(OBJDIR)/tests/test_persona.o \
 
 $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
                       $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
-                           $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o $(OBJDIR)/server/presence.o \
+                           $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/tests/support/workflow_api_stub.o $(OBJDIR)/server/vault_principal.o $(OBJDIR)/server/presence.o \
                            $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                            $(OBJDIR)/forge_credentials.o \
                            $(OBJDIR)/delivery_target.o \

--- a/src/tests/support/workflow_api_stub.c
+++ b/src/tests/support/workflow_api_stub.c
@@ -1,0 +1,47 @@
+/* workflow_api_stub.c -- trivial wf_api_* implementations for tests that link
+ * server_http.o (which references the W7 /v1/workflow route handlers) but do not
+ * exercise the workflow surface. The real logic is in server_workflow_api.c and
+ * is covered by unit-test-wfe-webapi; here we only need the symbols to resolve
+ * without pulling the wfe_ definition model + DB1 store into the link. */
+#include "server/server_workflow_api.h"
+
+#include <stdio.h>
+
+static int stub(char *resp, int cap)
+{
+   snprintf(resp, (size_t)cap, "{}");
+   return 200;
+}
+
+int wf_api_blocks(char *resp, int cap)
+{
+   return stub(resp, cap);
+}
+int wf_api_list(char *resp, int cap)
+{
+   return stub(resp, cap);
+}
+int wf_api_get(const char *name, char *resp, int cap)
+{
+   (void)name;
+   return stub(resp, cap);
+}
+int wf_api_validate(const char *body, char *resp, int cap)
+{
+   (void)body;
+   return stub(resp, cap);
+}
+int wf_api_save(const char *body, char *resp, int cap)
+{
+   (void)body;
+   return stub(resp, cap);
+}
+int wf_api_items(char *resp, int cap)
+{
+   return stub(resp, cap);
+}
+int wf_api_item(const char *id, char *resp, int cap)
+{
+   (void)id;
+   return stub(resp, cap);
+}

--- a/src/tests/test_wfe_webapi.c
+++ b/src/tests/test_wfe_webapi.c
@@ -1,0 +1,261 @@
+/* test_wfe_webapi.c -- /v1/workflow read+author surface (W7). Drives the
+ * server_workflow_api.c handlers directly (no HTTP) against a temp $AIMEE_HOME:
+ * blocks catalog (built-ins + safety + custom), save/get canonical round-trip
+ * byte-stability (incl. a cyclic graph), optimistic-lock conflicts, path-name
+ * safety, validate, and work-item run-state. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "cJSON.h"
+#include "db1.h"
+#include "server/server_workflow_api.h"
+#include "wfe_def.h"
+
+#define CAP (64 * 1024)
+
+/* a genuinely valid, cyclic workflow (the gates loop back to pp on failure);
+ * typed I/O checks out end-to-end (same shape the engine safety test runs). The
+ * params block exercises nested-object + block-sequence canonical round-trip. */
+static const char *WF = "name: t1\nstart: pp\nnodes:\n"
+                        "  - id: pp\n    block: author.proposal\n    params:\n"
+                        "      with_user: true\n    next: pr\n"
+                        "  - id: pr\n    block: pr.open\n    in:\n      src: pp.out\n    next: cm\n"
+                        "  - id: cm\n    block: check.mergeable\n    in:\n      pr: pr.out\n"
+                        "    on_pass: ci\n    on_fail: pp\n"
+                        "  - id: ci\n    block: gate.ci\n    in:\n      pr: pr.out\n"
+                        "    on_pass: m\n    on_fail: pp\n"
+                        "  - id: m\n    block: merge\n    in:\n      pr: pr.out\n";
+
+static int has_block(cJSON *blocks, const char *name, int *custom_out)
+{
+   cJSON *b = NULL;
+   cJSON_ArrayForEach(b, blocks)
+   {
+      cJSON *jn = cJSON_GetObjectItemCaseSensitive(b, "name");
+      if (cJSON_IsString(jn) && strcmp(jn->valuestring, name) == 0)
+      {
+         if (custom_out)
+            *custom_out = cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(b, "custom"));
+         return 1;
+      }
+   }
+   return 0;
+}
+
+static cJSON *parse_resp(const char *buf)
+{
+   cJSON *o = cJSON_Parse(buf);
+   assert(o);
+   return o;
+}
+
+int main(void)
+{
+   printf("wfe-webapi: ");
+   char home[] = "/tmp/wfe_web_XXXXXX";
+   assert(mkdtemp(home));
+   char wfdir[128];
+   snprintf(wfdir, sizeof wfdir, "%s/workflows", home);
+   mkdir(wfdir, 0755);
+   setenv("AIMEE_HOME", home, 1);
+   assert(db1_init(":memory:") == 0);
+
+   char *buf = malloc(CAP);
+   assert(buf);
+
+   /* --- blocks catalog: built-ins + safety blocks present --- */
+   wfe_custom_registry_reset();
+   assert(wf_api_blocks(buf, CAP) == 200);
+   {
+      cJSON *o = parse_resp(buf);
+      cJSON *blocks = cJSON_GetObjectItemCaseSensitive(o, "blocks");
+      assert(cJSON_IsArray(blocks));
+      assert(has_block(blocks, "author.proposal", NULL));
+      assert(has_block(blocks, "gate.ci", NULL));
+      assert(has_block(blocks, "check.mergeable", NULL));
+      assert(has_block(blocks, "merge", NULL));
+      cJSON_Delete(o);
+   }
+
+   /* --- custom block surfaces in the catalog --- */
+   {
+      char p[256];
+      snprintf(p, sizeof p, "%s/blocks.yaml", wfdir);
+      FILE *f = fopen(p, "wb");
+      assert(f);
+      fputs("allow_command: true\nblocks:\n  - name: lint\n    consumes: branch\n"
+            "    produces: branch\n    executor: command\n    command:\n      - /bin/true\n",
+            f);
+      fclose(f);
+      chmod(p, 0600);
+      wfe_custom_registry_reset();
+      assert(wf_api_blocks(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      int custom = 0;
+      assert(has_block(cJSON_GetObjectItemCaseSensitive(o, "blocks"), "lint", &custom));
+      assert(custom == 1);
+      cJSON_Delete(o);
+   }
+
+   /* --- save a valid (cyclic) workflow --- */
+   char v1[80] = "";
+   {
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "name", "t1");
+      cJSON_AddStringToObject(req, "yaml", WF);
+      cJSON_AddStringToObject(req, "prev_version", "");
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      int rc = wf_api_save(body, buf, CAP);
+      free(body);
+      assert(rc == 200);
+      cJSON *o = parse_resp(buf);
+      const cJSON *jv = cJSON_GetObjectItemCaseSensitive(o, "version");
+      assert(cJSON_IsString(jv) && jv->valuestring[0]);
+      snprintf(v1, sizeof v1, "%s", jv->valuestring);
+      cJSON_Delete(o);
+   }
+
+   /* --- get it back: valid, 3 nodes, canonical present --- */
+   char canon[8192] = "";
+   {
+      assert(wf_api_get("t1", buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(o, "valid")));
+      const cJSON *jc = cJSON_GetObjectItemCaseSensitive(o, "canonical");
+      assert(cJSON_IsString(jc) && jc->valuestring[0]);
+      snprintf(canon, sizeof canon, "%s", jc->valuestring);
+      cJSON *def = cJSON_GetObjectItemCaseSensitive(o, "def");
+      cJSON *nodes = cJSON_GetObjectItemCaseSensitive(def, "nodes");
+      assert(cJSON_GetArraySize(nodes) == 5);
+      /* version of the stored def equals the save's reported version */
+      const cJSON *jv = cJSON_GetObjectItemCaseSensitive(o, "version");
+      assert(strcmp(jv->valuestring, v1) == 0);
+      cJSON_Delete(o);
+   }
+
+   /* --- byte-stable: canonical(parse(canonical)) == canonical --- */
+   {
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "yaml", canon);
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_validate(body, buf, CAP) == 200);
+      free(body);
+      cJSON *o = parse_resp(buf);
+      assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(o, "valid")));
+      const cJSON *jc = cJSON_GetObjectItemCaseSensitive(o, "canonical");
+      assert(strcmp(jc->valuestring, canon) == 0); /* idempotent canonical form */
+      const cJSON *jv = cJSON_GetObjectItemCaseSensitive(o, "version");
+      assert(strcmp(jv->valuestring, v1) == 0); /* stable version */
+      cJSON_Delete(o);
+   }
+
+   /* --- optimistic lock: correct prev_version succeeds; wrong fails (409) --- */
+   {
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "name", "t1");
+      cJSON_AddStringToObject(req, "yaml", canon);
+      cJSON_AddStringToObject(req, "prev_version", v1);
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_save(body, buf, CAP) == 200); /* match → overwrite ok */
+      free(body);
+   }
+   {
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "name", "t1");
+      cJSON_AddStringToObject(req, "yaml", canon);
+      cJSON_AddStringToObject(req, "prev_version", "deadbeefdeadbeef");
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_save(body, buf, CAP) == 409); /* mismatch → conflict */
+      free(body);
+   }
+   {
+      /* create-when-exists (empty prev) → conflict */
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "name", "t1");
+      cJSON_AddStringToObject(req, "yaml", canon);
+      cJSON_AddStringToObject(req, "prev_version", "");
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_save(body, buf, CAP) == 409);
+      free(body);
+   }
+
+   /* --- a present-but-corrupt file blocks a create (empty prev → 409), so it is
+    *     never silently overwritten (existence is by stat, not parse success) --- */
+   {
+      char p[256];
+      snprintf(p, sizeof p, "%s/corrupt.yaml", wfdir);
+      FILE *f = fopen(p, "wb");
+      assert(f);
+      fputs("this: is: not: a: valid: workflow: {[\n", f);
+      fclose(f);
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "name", "corrupt");
+      cJSON_AddStringToObject(req, "yaml", canon);
+      cJSON_AddStringToObject(req, "prev_version", "");
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_save(body, buf, CAP) == 409);
+      free(body);
+   }
+
+   /* --- path-name safety: traversal rejected (400) --- */
+   assert(wf_api_get("../etc/passwd", buf, CAP) == 400);
+   assert(wf_api_get("a/b", buf, CAP) == 400);
+   {
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "name", "../evil");
+      cJSON_AddStringToObject(req, "yaml", WF);
+      cJSON_AddStringToObject(req, "prev_version", "");
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_save(body, buf, CAP) == 400);
+      free(body);
+   }
+
+   /* --- get missing → 404 --- */
+   assert(wf_api_get("nope", buf, CAP) == 404);
+
+   /* --- invalid definition (unknown block) → valid:false --- */
+   {
+      cJSON *req = cJSON_CreateObject();
+      cJSON_AddStringToObject(req, "yaml",
+                              "name: bad\nstart: a\nnodes:\n  - id: a\n    block: nope\n");
+      char *body = cJSON_PrintUnformatted(req);
+      cJSON_Delete(req);
+      assert(wf_api_validate(body, buf, CAP) == 200);
+      free(body);
+      cJSON *o = parse_resp(buf);
+      assert(!cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(o, "valid")));
+      cJSON_Delete(o);
+   }
+
+   /* --- list includes t1 --- */
+   {
+      assert(wf_api_list(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      int custom = 0;
+      assert(has_block(cJSON_GetObjectItemCaseSensitive(o, "defs"), "t1", &custom));
+      cJSON_Delete(o);
+   }
+
+   /* --- run-state: empty list + unknown item 404 --- */
+   {
+      assert(wf_api_items(buf, CAP) == 200);
+      cJSON *o = parse_resp(buf);
+      assert(cJSON_IsArray(cJSON_GetObjectItemCaseSensitive(o, "items")));
+      cJSON_Delete(o);
+   }
+   assert(wf_api_item("no-such-item", buf, CAP) == 404);
+
+   free(buf);
+   printf("ok\n");
+   return 0;
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -119,6 +119,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/", s.requireAuth(s.handleRoot))
 	mux.HandleFunc("/chat", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/dashboard", s.requireAuth(s.handleSPA))
+	mux.HandleFunc("/workflows", s.requireAuth(s.handleSPA))
 
 	// Chat API (session required)
 	mux.HandleFunc("/api/chat/send", s.requireAuth(s.handleChatSend))
@@ -150,6 +151,15 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Aggregate dashboard endpoint — all panels in one server round-trip
 	mux.HandleFunc("/api/dashboard", s.requireAuth(s.handleDashboardAll))
+
+	// Workflow visual composer (W7): proxy to aimee-server /v1/workflow/*.
+	mux.HandleFunc("/api/workflow/blocks", s.requireAuth(s.handleWorkflowBlocks))
+	mux.HandleFunc("/api/workflow/defs", s.requireAuth(s.handleWorkflowDefs))
+	mux.HandleFunc("/api/workflow/defs/", s.requireAuth(s.handleWorkflowDefs))
+	mux.HandleFunc("/api/workflow/validate", s.requireAuth(s.handleWorkflowValidate))
+	mux.HandleFunc("/api/workflow/save", s.requireAuth(s.handleWorkflowSave))
+	mux.HandleFunc("/api/workflow/items", s.requireAuth(s.handleWorkflowItems))
+	mux.HandleFunc("/api/workflow/items/", s.requireAuth(s.handleWorkflowItems))
 
 	// Credential vault (WP-C.2c): the user re-presents their login password to
 	// unlock; calls carry the server.token bearer + X-Aimee-Webuser so

--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -1,0 +1,91 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+// Workflow visual composer (W7) proxy: forwards /api/workflow/* to aimee-server's
+// first-class /v1/workflow/* routes over the UDS, returning status + body
+// verbatim. Mirrors the persona/dashboard proxy pattern; all routes sit behind
+// requireAuth in server.go.
+
+// proxyWorkflow forwards one request to a /v1/workflow route. When stripPrefix is
+// non-empty, the single trailing path segment (a workflow name or work-item id)
+// is appended to v1path; it must be one safe segment (no '/' and no "..").
+func (s *server) proxyWorkflow(w http.ResponseWriter, r *http.Request, method, v1path, stripPrefix string) {
+	if r.Method != method {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	path := v1path
+	if stripPrefix != "" {
+		seg := strings.TrimPrefix(r.URL.Path, stripPrefix)
+		// one safe segment only: no separators, no traversal, no percent-encoding
+		// (which could smuggle a '/' past this check). The server's safe_name is
+		// the authoritative guard; this fails fast and clearly.
+		if seg == "" || strings.Contains(seg, "/") || strings.Contains(seg, "..") || strings.Contains(seg, "%") {
+			http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
+			return
+		}
+		path = v1path + seg
+	}
+	var body []byte
+	if method == http.MethodPost {
+		const maxBody = 1 << 20
+		body, _ = io.ReadAll(io.LimitReader(r.Body, maxBody+1))
+		if len(body) > maxBody {
+			http.Error(w, `{"error":"request too large"}`, http.StatusRequestEntityTooLarge)
+			return
+		}
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	st, data, err := s.v1Request(ctx, method, path, body)
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		w.WriteHeader(http.StatusBadGateway)
+		fmt.Fprintf(w, `{"error":"workflow service unreachable"}`)
+		return
+	}
+	w.WriteHeader(st)
+	w.Write(data)
+}
+
+// GET /api/workflow/blocks — the block palette catalog.
+func (s *server) handleWorkflowBlocks(w http.ResponseWriter, r *http.Request) {
+	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/blocks", "")
+}
+
+// GET /api/workflow/defs        — list definitions
+// GET /api/workflow/defs/<name> — one definition (canonical + version + graph)
+func (s *server) handleWorkflowDefs(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/api/workflow/defs" {
+		s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/defs", "")
+		return
+	}
+	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/defs/", "/api/workflow/defs/")
+}
+
+// POST /api/workflow/validate — validate posted YAML without saving.
+func (s *server) handleWorkflowValidate(w http.ResponseWriter, r *http.Request) {
+	s.proxyWorkflow(w, r, http.MethodPost, "/v1/workflow/validate", "")
+}
+
+// POST /api/workflow/save — canonical-normalize + save (optimistic lock).
+func (s *server) handleWorkflowSave(w http.ResponseWriter, r *http.Request) {
+	s.proxyWorkflow(w, r, http.MethodPost, "/v1/workflow/save", "")
+}
+
+// GET /api/workflow/items       — list work items (run-state)
+// GET /api/workflow/items/<id>  — one work item's run-state
+func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path == "/api/workflow/items" {
+		s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/items", "")
+		return
+	}
+	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/items/", "/api/workflow/items/")
+}


### PR DESCRIPTION
## Summary

The final workflow-engine slice (W7): a **web visual composer** to author and inspect workflows. Closes the engine arc (W1–W6 in #288, config-extensible + safety blocks in #297).

**Three layers:**
- **C server** (`server_workflow_api.c`) — first-class `/v1/workflow/*` routes: `blocks` (palette catalog incl. the safety + custom blocks), `defs` (list), `defs/{name}` (canonical + version + structured graph), `validate`, `save` (canonical-normalize + atomic write + optimistic lock on `prev_version`), `items[/{id}]` (run-state). A thin layer over the existing `wfe_` model + DB1 work-item store. Reads are `dashboard-read`, save is `session-admin`; names are a single safe path component (no traversal). Routes + OpenAPI + cli-v1-routes regenerated.
- **Webchat (Go)** (`workflow.go`) — `/api/workflow/*` → `/v1/workflow/*` UDS proxy behind `requireAuth`; new `/workflows` SPA route. Rejects encoded-slash segments; 413 on oversized bodies.
- **Frontend (React)** (`Workflows.tsx`) — a hand-rolled SVG node-graph editor (no new deps): block palette, draggable nodes, typed control/data edges (`next`/`on_pass`/`on_fail` + input bindings), params-as-JSON inspector, inline validate, optimistic-lock save, and a run-state overlay that highlights the current stage and flags a version mismatch against the pinned run. A block-style YAML emitter (quoted keys/values, reserved-word safe) feeds `wfe_def_parse`; the server canonicalizes on save, so the editor only round-trips. v1 = single editor, no realtime collab.

## Review
Implementation roundtable to convergence: a diverse panel (security / architect / qa / reviewer) reached **4/4 PASS** after one fix round — emitter `scalar()` hardening (incl. params keys), `isBareSafe` reserved-word/leading-`-` rejection, `stat()`-based existence (a corrupt file can't be silently overwritten), and Go proxy `%`-segment + 413 hardening. Each fix has test coverage.

## Tests
`test_wfe_webapi` drives the handlers directly: blocks catalog (built-ins + safety + a custom block), save/get/validate **canonical round-trip byte-stability** (incl. a cyclic graph), optimistic-lock conflicts (mismatch, create-when-exists, corrupt-file), path-traversal rejection, and run-state. A `workflow_api_stub` keeps the `server_http`-linking tests decoupled from the `wfe_` model. Wired into Makefile + CMake (incl. the `workflow` include dir on the `aimee-server` target).

Local: full unit suite, full Makefile build (client+server+kb), frontend `tsc` + `vite build`, Go build, build-integrity, and all static gates (api-conformance, cli-v1-routes, schema-sync, charter-tables, module-boundary) green.

---
**Note:** stacked on `feat/workflow-config-blocks` (#297) for the custom-block catalog; base will retarget to `testing` once #297 merges.
