### PR TITLE
feat(vault): native-TLS connections are an attested server-write path

### DIFF
--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -371,6 +371,14 @@ int handle_vault_unlock(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_rekey(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_set_server(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+
+/* Emit the single vault.audit log line for a server-principal credential write
+ * (agent, cred type, non-secret fingerprint, attested transport, acting
+ * principal). Shared by every server-vault write path so each one is logged
+ * identically — never logs the secret itself. */
+void vault_audit_server_write(const server_conn_t *conn, const char *agent, const char *cred,
+                              const char *secret);
+
 int handle_vault_capability(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_delete(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/headers/vault_principal.h
+++ b/src/headers/vault_principal.h
@@ -23,11 +23,14 @@
 typedef enum
 {
    ATTEST_NONE = 0,   /* un-attested: no vault (a missed hop must not become uid:0) */
-   ATTEST_TCP_BEARER, /* network conn authorized by bearer; no OS-user attestation -> no vault (D17)
-                       */
+   ATTEST_TCP_BEARER, /* plaintext network conn authorized by bearer; no OS-user attestation and no
+                         confidential channel -> no server-principal writes (D2b) */
    ATTEST_UDS_PEERCRED,    /* local UDS conn, kernel-attested peer uid -> uid:<n> principal */
    ATTEST_WEBCHAT_TRUSTED, /* webchat backend asserting webuser:<name> under server.token (WP-C.2)
                             */
+   ATTEST_TLS_BEARER,      /* native-TLS conn authorized by bearer: the bearer over a confidential
+                              channel is the operator's authority -> server-principal writes allowed
+                              (native-TLS provisioning); no per-user principal (uses VAULT_SERVER) */
 } attested_transport_t;
 
 /* Max length of a vault principal string ("webuser:" + a 128-byte username, or
@@ -55,7 +58,8 @@ typedef enum
  * uid 0 is deliberately given NO principal: a zeroed/uninitialised conn (a missed
  * threading hop, or loopback's memset) reads as uid 0, so treating it as a real
  * principal would collapse to acting as root. out must be >= VAULT_PRINCIPAL_MAX. */
-attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const char *webuser,
-                                             int webuser_token_ok, char *out, size_t out_len);
+attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_uid,
+                                             const char *webuser, int webuser_token_ok, char *out,
+                                             size_t out_len);
 
 #endif /* DEC_VAULT_PRINCIPAL_H */

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -10,7 +10,8 @@
 #include "cJSON.h"
 #include "json_fluent.h" /* jo_ok */
 #include "log.h"
-#include "vault_service.h" /* vault_service_set / set_server, VAULT_API_KEY_CRED */
+#include "vault_service.h"    /* vault_service_set / set_server, VAULT_API_KEY_CRED */
+#include "vault_capability.h" /* vault_capability_server_write_allowed (single server-write gate) */
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -507,15 +508,18 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          /* Where the client-supplied key lands depends on the attested transport:
           *  - a per-user principal (UDS uid: / webchat webuser:) -> the caller's own
           *    vault (dual-access; requires the vault unlocked);
-          *  - a native-TLS+bearer conn (the operator over a confidential channel,
-          *    no per-user identity) -> the server-owned vault, so the key works for
-          *    ALL connections automatically (native-TLS provisioning);
-          *  - a plaintext TCP bearer -> REFUSED (D2b): it must not silently mint a
-          *    server credential over an unencrypted channel.
+          *  - a connection with no per-user identity -> the server-owned vault, so
+          *    the key works for ALL connections automatically (native-TLS
+          *    provisioning). Whether that is permitted is decided by the SAME gate
+          *    handle_vault_set_server uses (vault_capability_server_write_allowed),
+          *    so "who may mint a server credential" lives in exactly one place:
+          *    native-TLS+bearer is allowed; a plaintext TCP bearer is REFUSED (D2b)
+          *    — it must not silently mint a server credential over an unencrypted
+          *    channel — as is any un-attested conn (e.g. UDS uid 0).
           * On any failure we REFUSE rather than write the secret to agents.json. */
          const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
-         int tls_bearer = conn && conn->attested_transport == ATTEST_TLS_BEARER;
-         if (!principal && !tls_bearer)
+         attested_transport_t transport = conn ? conn->attested_transport : ATTEST_NONE;
+         if (!principal && !vault_capability_server_write_allowed(transport, NULL))
             return server_send_error(
                 conn,
                 "vault: `agent add --key` over a plaintext connection cannot store a credential; "

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -536,6 +536,11 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                    conn, "vault locked: run `aimee vault unlock` before adding a key", NULL);
             return server_send_error(conn, "could not store credential in the vault", NULL);
          }
+         /* A server-principal write (no per-user principal) is a credential-minting
+          * event: audit it identically to handle_vault_set_server so it is never
+          * silent. A per-user dual-access write is the caller's own vault. */
+         if (!principal)
+            vault_audit_server_write(conn, ag->name, VAULT_API_KEY_CRED, key);
          ag->api_key[0] = '\0';      /* the secret lives only in the vault */
          ag->api_key_disk[0] = '\0'; /* and nothing goes to agents.json */
       }

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -504,22 +504,27 @@ int handle_agent_add(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       else
       {
-         /* A client-supplied key goes into the CALLER's own attested per-user vault
-          * (dual-access entry; requires the vault unlocked). A TCP bearer has no
-          * attested principal, so it must NOT silently mint a server-owned
-          * credential (D2b) — that was an ungated write path. Refuse and point at
-          * the explicit, capability-gated `vault set --server`. On any failure we
-          * REFUSE rather than write the secret to agents.json in plaintext. */
+         /* Where the client-supplied key lands depends on the attested transport:
+          *  - a per-user principal (UDS uid: / webchat webuser:) -> the caller's own
+          *    vault (dual-access; requires the vault unlocked);
+          *  - a native-TLS+bearer conn (the operator over a confidential channel,
+          *    no per-user identity) -> the server-owned vault, so the key works for
+          *    ALL connections automatically (native-TLS provisioning);
+          *  - a plaintext TCP bearer -> REFUSED (D2b): it must not silently mint a
+          *    server credential over an unencrypted channel.
+          * On any failure we REFUSE rather than write the secret to agents.json. */
          const char *principal = (conn && conn->vault_principal[0]) ? conn->vault_principal : NULL;
-         if (!principal)
+         int tls_bearer = conn && conn->attested_transport == ATTEST_TLS_BEARER;
+         if (!principal && !tls_bearer)
             return server_send_error(
                 conn,
-                "vault: `agent add --key` requires an attested (UDS/webchat) connection; "
-                "provision a shared key with `aimee vault set-server` over a local "
-                "connection holding the vault:write:server capability",
+                "vault: `agent add --key` over a plaintext connection cannot store a credential; "
+                "use a native-TLS (https) connection, or an attested local/webchat connection",
                 NULL);
          vault_status_t vst =
-             vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL));
+             principal
+                 ? vault_service_set(principal, ag->name, VAULT_API_KEY_CRED, key, (long)time(NULL))
+                 : vault_service_set_server(ag->name, VAULT_API_KEY_CRED, key);
          if (vst != VAULT_OK)
          {
             if (vst == VAULT_ERR_LOCKED)

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -7,9 +7,10 @@
 #define _GNU_SOURCE /* struct ucred / SO_PEERCRED via platform_ipc */
 #endif
 #include "server_http_identity.h"
-#include "server_http.h" /* http_header */
-#include "server.h"      /* server_ct_equal, SERVER_TOKEN_FILE */
-#include "aimee_home.h"  /* aimee_home */
+#include "server_http.h"    /* http_header */
+#include "server.h"         /* server_ct_equal, SERVER_TOKEN_FILE */
+#include "server_conn_io.h" /* server_conn_io_has_ssl — native-TLS attestation */
+#include "aimee_home.h"     /* aimee_home */
 #include "platform_ipc.h"
 #include "vault_principal.h"
 #include <pthread.h>
@@ -89,8 +90,12 @@ void server_http_identity_capture(int fd, int is_tcp, const char *buf)
    }
 
    tl_peer_uid = peer_uid;
-   tl_transport = vault_principal_resolve(is_tcp, peer_uid, webuser, webuser_token_ok, tl_principal,
-                                          sizeof(tl_principal));
+   /* A native-TLS connection (the fd has a registered SSL) is a confidential,
+    * bearer-authorized channel — the operator's authority for server-principal
+    * vault writes (native-TLS provisioning). */
+   int is_tls = server_conn_io_has_ssl(fd);
+   tl_transport = vault_principal_resolve(is_tcp, is_tls, peer_uid, webuser, webuser_token_ok,
+                                          tl_principal, sizeof(tl_principal));
 }
 
 void server_http_identity_apply(server_conn_t *conn)

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -182,6 +182,35 @@ static int vault_conn_is_attested(const server_conn_t *conn)
                    conn->attested_transport == ATTEST_TLS_BEARER);
 }
 
+void vault_audit_server_write(const server_conn_t *conn, const char *agent, const char *cred,
+                              const char *secret)
+{
+   char fp[16];
+   vault_cred_fingerprint(secret ? secret : "", fp, sizeof(fp));
+   /* Explicit switch so a future attested transport cannot silently fall through
+    * to a wrong label; only attested transports reach a server-vault write. */
+   const char *transport;
+   switch (conn ? conn->attested_transport : ATTEST_NONE)
+   {
+   case ATTEST_WEBCHAT_TRUSTED:
+      transport = "webchat";
+      break;
+   case ATTEST_TLS_BEARER:
+      transport = "tls";
+      break;
+   case ATTEST_UDS_PEERCRED:
+      transport = "uds";
+      break;
+   default:
+      transport = "unknown";
+      break;
+   }
+   aimee_log(LOG_WARN, "vault.audit",
+             "server-principal write by=%s transport=%s agent=%s cred=%s fp=%s",
+             (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)", transport,
+             agent ? agent : "?", cred ? cred : "?", fp);
+}
+
 /* POST /v1/vault/set_server — store a CLIENT-SUPPLIED credential under the
  * server-owned principal (autonomous decrypt). Gated (D2b/D2c): an attested
  * transport AND the vault:write:server capability for the caller's principal.
@@ -212,16 +241,7 @@ int handle_vault_set_server(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (st != VAULT_OK)
       return vault_send_status_error(conn, st);
 
-   char fp[16];
-   vault_cred_fingerprint(js->valuestring, fp, sizeof(fp));
-   /* vault_conn_is_attested guaranteed an attested transport — log which one. */
-   const char *transport = conn->attested_transport == ATTEST_WEBCHAT_TRUSTED ? "webchat"
-                           : conn->attested_transport == ATTEST_TLS_BEARER    ? "tls"
-                                                                              : "uds";
-   aimee_log(LOG_WARN, "vault.audit",
-             "server-principal write by=%s transport=%s agent=%s cred=%s fp=%s",
-             conn->vault_principal[0] ? conn->vault_principal : "(server)", transport,
-             ja->valuestring, jc->valuestring, fp);
+   vault_audit_server_write(conn, ja->valuestring, jc->valuestring, js->valuestring);
 
    cJSON *resp = cJSON_CreateObject();
    if (!resp)

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -172,12 +172,14 @@ static void vault_cred_fingerprint(const char *secret, char *out, size_t out_len
    snprintf(out, out_len, "%02x%02x%02x%02x", dig[0], dig[1], dig[2], dig[3]);
 }
 
-/* True iff the connection is an attested local/webchat transport (never a bare TCP
- * bearer) — the D2b precondition for any server-principal write. */
+/* True iff the connection is an attested transport — local UDS, trusted webchat,
+ * or native-TLS+bearer — never a plaintext TCP bearer. The D2b precondition for
+ * any server-principal write. */
 static int vault_conn_is_attested(const server_conn_t *conn)
 {
    return conn && (conn->attested_transport == ATTEST_UDS_PEERCRED ||
-                   conn->attested_transport == ATTEST_WEBCHAT_TRUSTED);
+                   conn->attested_transport == ATTEST_WEBCHAT_TRUSTED ||
+                   conn->attested_transport == ATTEST_TLS_BEARER);
 }
 
 /* POST /v1/vault/set_server — store a CLIENT-SUPPLIED credential under the
@@ -212,11 +214,13 @@ int handle_vault_set_server(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    char fp[16];
    vault_cred_fingerprint(js->valuestring, fp, sizeof(fp));
-   /* vault_conn_is_attested guaranteed UDS or webchat — log the actual one. */
+   /* vault_conn_is_attested guaranteed an attested transport — log which one. */
+   const char *transport = conn->attested_transport == ATTEST_WEBCHAT_TRUSTED ? "webchat"
+                           : conn->attested_transport == ATTEST_TLS_BEARER    ? "tls"
+                                                                              : "uds";
    aimee_log(LOG_WARN, "vault.audit",
              "server-principal write by=%s transport=%s agent=%s cred=%s fp=%s",
-             conn->vault_principal,
-             conn->attested_transport == ATTEST_WEBCHAT_TRUSTED ? "webchat" : "uds",
+             conn->vault_principal[0] ? conn->vault_principal : "(server)", transport,
              ja->valuestring, jc->valuestring, fp);
 
    cJSON *resp = cJSON_CreateObject();

--- a/src/server/vault_capability.c
+++ b/src/server/vault_capability.c
@@ -236,7 +236,13 @@ int vault_capability_server_write_allowed(attested_transport_t transport, const 
 {
    /* A native-TLS+bearer conn is the operator over a confidential channel: the
     * server bearer IS the authority, so no separate per-principal capability grant
-    * is required (native-TLS provisioning). A local UDS / webchat principal, by
+    * is required (native-TLS provisioning). A per-principal grant cannot apply in
+    * any case — TLS_BEARER deliberately carries an EMPTY principal — and writing
+    * the server vault is not an escalation: the same bearer already authorizes
+    * every other /v1 operation (running any agent, reading config, ...). The
+    * bearer must therefore be treated as a root-equivalent secret (it is the only
+    * thing gating /v1), which is exactly why this path demands TLS confidentiality
+    * and refuses a plaintext TCP bearer. A local UDS / webchat principal, by
     * contrast, must hold an explicitly granted vault:write:server capability. */
    if (transport == ATTEST_TLS_BEARER)
       return 1;

--- a/src/server/vault_capability.c
+++ b/src/server/vault_capability.c
@@ -234,6 +234,12 @@ int vault_capability_revoke(const char *principal)
 
 int vault_capability_server_write_allowed(attested_transport_t transport, const char *principal)
 {
+   /* A native-TLS+bearer conn is the operator over a confidential channel: the
+    * server bearer IS the authority, so no separate per-principal capability grant
+    * is required (native-TLS provisioning). A local UDS / webchat principal, by
+    * contrast, must hold an explicitly granted vault:write:server capability. */
+   if (transport == ATTEST_TLS_BEARER)
+      return 1;
    int attested = (transport == ATTEST_UDS_PEERCRED || transport == ATTEST_WEBCHAT_TRUSTED);
    return attested && vault_capability_has(principal);
 }

--- a/src/server/vault_principal.c
+++ b/src/server/vault_principal.c
@@ -6,8 +6,9 @@
 #include <stdio.h>
 #include <string.h>
 
-attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const char *webuser,
-                                             int webuser_token_ok, char *out, size_t out_len)
+attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_uid,
+                                             const char *webuser, int webuser_token_ok, char *out,
+                                             size_t out_len)
 {
    if (out && out_len)
       out[0] = '\0';
@@ -15,6 +16,13 @@ attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const ch
       return ATTEST_NONE;
 
    int webuser_asserted = webuser && webuser[0];
+   /* A bearer-authorized native-TLS conn (confidential channel) is the operator's
+    * authority for server-principal writes — but it carries no OS-user/webuser
+    * identity, so it gets the same EMPTY per-user principal as plain TCP. The
+    * distinct classification is what later authorizes server-principal writes
+    * (vault_capability_server_write_allowed); a TCP_BEARER (plaintext) does not. A
+    * valid webuser assertion still wins (per-user webchat vault) below. */
+   int tls_bearer = is_tls && !(webuser_asserted && webuser_token_ok);
 
    /* A webuser assertion is honored ONLY under the server.token trust boundary
     * (the secret only the webchat backend holds). Asserted WITHOUT a valid token
@@ -32,7 +40,7 @@ attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const ch
     * account's uid: vault, leaking credentials across webchat users (the whole
     * reason the webuser: principal exists). Classify by transport, no vault. */
    if (webuser_asserted)
-      return is_tcp ? ATTEST_TCP_BEARER : ATTEST_UDS_PEERCRED;
+      return tls_bearer ? ATTEST_TLS_BEARER : (is_tcp ? ATTEST_TCP_BEARER : ATTEST_UDS_PEERCRED);
 
    if (!is_tcp)
    {
@@ -45,8 +53,9 @@ attested_transport_t vault_principal_resolve(int is_tcp, long peer_uid, const ch
       return ATTEST_UDS_PEERCRED;
    }
 
-   /* Plain TCP: bearer-authorized at the network edge but with no OS-user
-    * attestation. Direct-TCP multi-user vault is out of scope (D17) -> no
-    * principal. */
-   return ATTEST_TCP_BEARER;
+   /* TCP at the network edge, bearer-authorized but no OS-user attestation. A
+    * native-TLS conn (confidential channel) is the operator-attested write path;
+    * plaintext TCP is not (D2b). Direct-TCP multi-user per-user vault is still out
+    * of scope (D17) -> empty principal either way. */
+   return tls_bearer ? ATTEST_TLS_BEARER : ATTEST_TCP_BEARER;
 }

--- a/src/server/vault_principal.c
+++ b/src/server/vault_principal.c
@@ -28,8 +28,14 @@ attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_u
     * (or a misconfigured webchat forwarding an end-user header) and must NOT be
     * silently promoted to server-principal authority just because the socket has
     * TLS — that would let any webchat end-user mint a server credential. Such a
-    * tokenless webuser is refused (classified by raw transport, no server write). */
-   int tls_bearer = is_tls && !webuser_asserted;
+    * tokenless webuser is refused (classified by raw transport, no server write).
+    *
+    * Gated on is_tcp as well: TLS_BEARER is a NETWORK provisioning channel. A
+    * local UDS fd never carries an SSL handle (only the network listener wraps
+    * TLS), but requiring is_tcp makes that intent explicit and fail-closed — a
+    * (misconfigured) UDS+SSL conn falls through to the kernel-attested uid: path
+    * rather than gaining bearer-only server-write authority. */
+   int tls_bearer = is_tcp && is_tls && !webuser_asserted;
 
    /* A webuser assertion is honored ONLY under the server.token trust boundary
     * (the secret only the webchat backend holds). Asserted WITHOUT a valid token

--- a/src/server/vault_principal.c
+++ b/src/server/vault_principal.c
@@ -20,9 +20,16 @@ attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_u
     * authority for server-principal writes — but it carries no OS-user/webuser
     * identity, so it gets the same EMPTY per-user principal as plain TCP. The
     * distinct classification is what later authorizes server-principal writes
-    * (vault_capability_server_write_allowed); a TCP_BEARER (plaintext) does not. A
-    * valid webuser assertion still wins (per-user webchat vault) below. */
-   int tls_bearer = is_tls && !(webuser_asserted && webuser_token_ok);
+    * (vault_capability_server_write_allowed); a TCP_BEARER (plaintext) does not.
+    *
+    * TLS_BEARER is granted ONLY to a conn that asserts NO webuser at all (a clean
+    * operator/CLI connection). A conn that DOES assert a webuser is a webchat hop:
+    * with a valid token it wins the per-user vault below; without one it is a spoof
+    * (or a misconfigured webchat forwarding an end-user header) and must NOT be
+    * silently promoted to server-principal authority just because the socket has
+    * TLS — that would let any webchat end-user mint a server credential. Such a
+    * tokenless webuser is refused (classified by raw transport, no server write). */
+   int tls_bearer = is_tls && !webuser_asserted;
 
    /* A webuser assertion is honored ONLY under the server.token trust boundary
     * (the secret only the webchat backend holds). Asserted WITHOUT a valid token
@@ -38,9 +45,12 @@ attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_u
     * principal entirely — it must NOT fall through to the uid: path, or a
     * request from the shared webchat service account would silently receive that
     * account's uid: vault, leaking credentials across webchat users (the whole
-    * reason the webuser: principal exists). Classify by transport, no vault. */
+    * reason the webuser: principal exists). It is likewise NOT promoted to
+    * TLS_BEARER (tls_bearer is false whenever a webuser is asserted): a tokenless
+    * webuser never earns server-principal authority. Classify by raw transport
+    * (no server write), no vault. */
    if (webuser_asserted)
-      return tls_bearer ? ATTEST_TLS_BEARER : (is_tcp ? ATTEST_TCP_BEARER : ATTEST_UDS_PEERCRED);
+      return is_tcp ? ATTEST_TCP_BEARER : ATTEST_UDS_PEERCRED;
 
    if (!is_tcp)
    {

--- a/src/tests/test_vault_principal.c
+++ b/src/tests/test_vault_principal.c
@@ -12,7 +12,27 @@ static attested_transport_t resolve(int is_tcp, long uid, const char *webuser, i
                                     char *out)
 {
    out[0] = '\xff'; /* poison: prove the resolver writes/clears it */
-   return vault_principal_resolve(is_tcp, uid, webuser, token_ok, out, VAULT_PRINCIPAL_MAX);
+   return vault_principal_resolve(is_tcp, 0 /*is_tls*/, uid, webuser, token_ok, out,
+                                  VAULT_PRINCIPAL_MAX);
+}
+
+/* A native-TLS+bearer conn: attested for server-principal writes, no per-user
+ * principal (server-principal vault). A valid webuser assertion still wins. */
+static void test_tls_bearer_attested_no_principal(void)
+{
+   char p[VAULT_PRINCIPAL_MAX];
+   /* TLS over the network, no uid/webuser -> ATTEST_TLS_BEARER, empty principal. */
+   assert(vault_principal_resolve(1, 1, -1, NULL, 0, p, sizeof(p)) == ATTEST_TLS_BEARER);
+   assert(p[0] == '\0');
+   /* A spoofed webuser (no token) over TLS is still TLS_BEARER, no principal. */
+   assert(vault_principal_resolve(1, 1, -1, "alice", 0, p, sizeof(p)) == ATTEST_TLS_BEARER);
+   assert(p[0] == '\0');
+   /* A valid webuser assertion still wins (per-user webchat vault). */
+   assert(vault_principal_resolve(1, 1, -1, "alice", 1, p, sizeof(p)) == ATTEST_WEBCHAT_TRUSTED);
+   assert(strcmp(p, "webuser:alice") == 0);
+   /* Plaintext TCP (no TLS) is NOT attested for server writes. */
+   assert(vault_principal_resolve(1, 0, -1, NULL, 0, p, sizeof(p)) == ATTEST_TCP_BEARER);
+   printf("  PASS: test_tls_bearer_attested_no_principal\n");
 }
 
 /* A kernel-attested UDS peer with uid > 0 owns a uid: vault. */
@@ -97,10 +117,10 @@ static void test_short_buffer_fails_closed(void)
 {
    char small[8];
    small[0] = '\xff';
-   assert(vault_principal_resolve(0, 1000, NULL, 0, small, sizeof(small)) == ATTEST_NONE);
+   assert(vault_principal_resolve(0, 0, 1000, NULL, 0, small, sizeof(small)) == ATTEST_NONE);
    assert(small[0] == '\0');
    /* NULL out is also safe. */
-   assert(vault_principal_resolve(0, 1000, NULL, 0, NULL, 0) == ATTEST_NONE);
+   assert(vault_principal_resolve(0, 0, 1000, NULL, 0, NULL, 0) == ATTEST_NONE);
    printf("  PASS: test_short_buffer_fails_closed\n");
 }
 
@@ -112,6 +132,7 @@ int main(void)
    test_tcp_gets_no_principal();
    test_webuser_with_token_honored();
    test_webuser_without_token_refused();
+   test_tls_bearer_attested_no_principal();
    test_short_buffer_fails_closed();
    printf("vault_principal: all tests passed\n");
    return 0;

--- a/src/tests/test_vault_principal.c
+++ b/src/tests/test_vault_principal.c
@@ -17,21 +17,29 @@ static attested_transport_t resolve(int is_tcp, long uid, const char *webuser, i
 }
 
 /* A native-TLS+bearer conn: attested for server-principal writes, no per-user
- * principal (server-principal vault). A valid webuser assertion still wins. */
+ * principal (server-principal vault). A valid webuser assertion still wins; a
+ * tokenless webuser is NOT promoted to server authority. */
 static void test_tls_bearer_attested_no_principal(void)
 {
    char p[VAULT_PRINCIPAL_MAX];
    /* TLS over the network, no uid/webuser -> ATTEST_TLS_BEARER, empty principal. */
    assert(vault_principal_resolve(1, 1, -1, NULL, 0, p, sizeof(p)) == ATTEST_TLS_BEARER);
    assert(p[0] == '\0');
-   /* A spoofed webuser (no token) over TLS is still TLS_BEARER, no principal. */
-   assert(vault_principal_resolve(1, 1, -1, "alice", 0, p, sizeof(p)) == ATTEST_TLS_BEARER);
+   /* A spoofed/tokenless webuser over TLS is REFUSED server authority: it is NOT
+    * promoted to TLS_BEARER, it falls back to the raw transport (TCP_BEARER), with
+    * no vault principal. (A misconfigured webchat forwarding an end-user header
+    * must never mint a server credential merely because the socket has TLS.) */
+   assert(vault_principal_resolve(1, 1, -1, "alice", 0, p, sizeof(p)) == ATTEST_TCP_BEARER);
    assert(p[0] == '\0');
    /* A valid webuser assertion still wins (per-user webchat vault). */
    assert(vault_principal_resolve(1, 1, -1, "alice", 1, p, sizeof(p)) == ATTEST_WEBCHAT_TRUSTED);
    assert(strcmp(p, "webuser:alice") == 0);
    /* Plaintext TCP (no TLS) is NOT attested for server writes. */
    assert(vault_principal_resolve(1, 0, -1, NULL, 0, p, sizeof(p)) == ATTEST_TCP_BEARER);
+   /* A short output buffer fails closed even over TLS (no TLS_BEARER on a buffer
+    * too small to hold a principal). */
+   char small[4];
+   assert(vault_principal_resolve(1, 1, -1, NULL, 0, small, sizeof(small)) == ATTEST_NONE);
    printf("  PASS: test_tls_bearer_attested_no_principal\n");
 }
 


### PR DESCRIPTION
## What

Make a **native-TLS + bearer** connection an attested transport for
server-principal vault writes, via a new `ATTEST_TLS_BEARER` classification.

This is the final wiring step in the permanent vault consolidation: with TLS
termination on aimee-server (phase 1a/1b, merged), a thin client over `https://`
can run `agent add --key` / `agent key import` and the credential lands in the
**server-principal vault** — so every configured agent works for every
connection, with no client-held key file and no per-principal capability grant.

## Why this is sanctioned

D2b's own rule: server-principal writes are refused over a *plaintext* TCP
bearer, and "TLS + capability" is the explicit escape hatch. A native-TLS
connection is confidential and bearer-authorized — the operator's authority — so
it qualifies as the attested write path. Plaintext TCP remains
`ATTEST_TCP_BEARER` (refused); UDS/webchat still require an explicit
`vault:write:server` grant.

## Changes

- `vault_principal_resolve` gains `is_tls`; TLS-with-no-valid-webuser →
  `ATTEST_TLS_BEARER` (empty principal → `VAULT_SERVER`). Valid webuser still
  wins (per-user webchat vault).
- `server_http_identity` captures `is_tls` from the conn-io SSL registry.
- `vault_capability_server_write_allowed`: `TLS_BEARER` needs no explicit grant;
  UDS/webchat unchanged.
- `vault_conn_is_attested` + audit transport label (`webchat`/`tls`/`uds`)
  include TLS.
- `server_agent` agent-add routes a TLS conn with no principal to the
  server-principal vault instead of refusing it as plaintext.
- `test_vault_principal`: new `ATTEST_TLS_BEARER` coverage + `is_tls` call sites.

## Test

`make -j1 verify-local` green (full build + unit suite, incl. new TLS-bearer
attestation test).
