### PR TITLE
feat(vault): make the vault the universal credential source (P4a)

### DIFF
--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -3,6 +3,7 @@
 #include "util.h"
 #include "agent_config.h"
 #include "vault_principal.h" /* VAULT_PRINCIPAL_MAX for the per-turn vault principal */
+#include "vault_service.h"   /* vault_service_* : the permanent credential store (P4) */
 #include "session_credentials.h"
 #include "model_registry.h"
 #include "platform_path.h"
@@ -203,6 +204,8 @@ static int agent_provider_env_value(const char *provider, char *dst, size_t dst_
    return 0;
 }
 
+static int agent_vault_get(const char *agent_name, const char *cred, char *out, size_t out_len);
+
 int agent_has_resolvable_credentials(const agent_t *agent)
 {
    if (!agent)
@@ -211,8 +214,17 @@ int agent_has_resolvable_credentials(const agent_t *agent)
       return 1;
    if (agent->auth_cmd[0] || agent_api_key_literal(agent->api_key))
       return 1;
-   /* A client-pushed session key (or codex-oauth creds) for this turn makes the
-    * agent usable even with no server-stored key. */
+   /* A credential in the permanent vault (this turn's principal or the server
+    * principal) makes the agent usable with no on-disk key — the P4 primary path. */
+   {
+      char k[MAX_API_KEY_LEN];
+      int is_codex = strcmp(agent->auth_type, "codex-oauth") == 0;
+      if (agent_vault_get(agent->name, is_codex ? VAULT_CODEX_TOKEN_CRED : VAULT_API_KEY_CRED, k,
+                          sizeof(k)))
+         return 1;
+   }
+   /* A client-pushed session key (or codex-oauth creds) for this turn also makes
+    * the agent usable (legacy RAM keyring, retired in P4b). */
    if (g_request_session_id[0])
    {
       char k[MAX_API_KEY_LEN];
@@ -260,6 +272,28 @@ void agent_set_request_vault_principal(const char *principal)
 const char *agent_get_request_vault_principal(void)
 {
    return g_request_vault_principal;
+}
+
+/* Read a credential (codex token/account, etc.) for the in-flight turn from the
+ * permanent vault: the turn's attested principal first, then the autonomous
+ * server principal (the path that serves a thin-client TCP/TLS conn with no
+ * per-user identity). Returns 1 + fills out on a hit, 0 on miss/locked/error so
+ * the caller falls through to the remaining (legacy/env) tiers. Never the secret
+ * source of truth's only reader — every server-side cred path consults this. */
+static int agent_vault_get(const char *agent_name, const char *cred, char *out, size_t out_len)
+{
+   if (!agent_name || !agent_name[0] || !out || out_len == 0)
+      return 0;
+   out[0] = '\0';
+   const char *principal = agent_get_request_vault_principal();
+   if (principal && principal[0] &&
+       vault_service_get(principal, agent_name, cred, out, out_len, time(NULL)) == VAULT_OK &&
+       out[0])
+      return 1;
+   if (vault_service_get_server_principal(agent_name, cred, out, out_len) == VAULT_OK && out[0])
+      return 1;
+   out[0] = '\0';
+   return 0;
 }
 
 void agent_set_request_codex_creds(const char *token, const char *account_id)
@@ -347,6 +381,8 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
       acct[0] = '\0';
       if (g_request_codex_account_id[0])
          snprintf(acct, sizeof(acct), "%s", g_request_codex_account_id);
+      else if (agent_vault_get(agent->name, VAULT_CODEX_ACCOUNT_CRED, acct, sizeof(acct)))
+         ; /* resolved from the permanent vault (turn principal -> server principal) */
       else if (g_request_session_id[0])
          session_creds_get_codex(g_request_session_id, NULL, 0, acct, sizeof(acct));
       if (acct[0])
@@ -1500,24 +1536,38 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    if (strcmp(auth_type, "none") == 0)
       return 0;
 
-   /* A client-pushed, session-scoped key for THIS agent (RAM-only keyring,
-    * session_credentials.h) takes precedence over any server-stored api_key — so
-    * agent keys need not live on the server. */
-   char session_key[MAX_API_KEY_LEN];
-   int have_session_key =
-       (g_request_session_id[0] &&
-        session_creds_get(g_request_session_id, agent->name, session_key, sizeof(session_key)));
+   /* Credential precedence for the in-flight turn (P4): the permanent VAULT wins
+    * — resolved for the turn's attested principal with autonomous server-principal
+    * fallback, so EVERY connection (primary chat, webchat, in-model tool, delegate)
+    * is served from the one store. Then a client-pushed session-scoped key (the
+    * legacy RAM keyring, retired in P4b), then the agent's stored api_key / env
+    * below. vault_service_inject_api_key handles the dual-wrap (server-wrap ->
+    * user-KEK -> server principal); a locked/miss result falls through. */
+   char primary_key[MAX_API_KEY_LEN];
+   int have_primary_key =
+       (vault_service_inject_api_key(agent_get_request_vault_principal(), agent->name, primary_key,
+                                     sizeof(primary_key), time(NULL)) == VAULT_OK &&
+        primary_key[0]);
+   if (!have_primary_key && g_request_session_id[0] &&
+       session_creds_get(g_request_session_id, agent->name, primary_key, sizeof(primary_key)))
+      have_primary_key = 1;
 
    if (strcmp(auth_type, "codex-oauth") == 0)
    {
-      /* Codex OAuth token, in precedence: per-turn token (legacy direct push) >
-       * session keyring (pushed once/session) > server-side file. */
+      /* Codex OAuth token, in precedence: per-turn token (set by the vault delegate
+       * path, or legacy direct push) > the permanent VAULT (turn principal, then
+       * server principal) > session keyring (legacy, retired P4b) > server file. */
       if (g_request_codex_token[0])
       {
          snprintf(buf, buf_len, "Authorization: Bearer %s", g_request_codex_token);
          return 0;
       }
       char token[MAX_API_KEY_LEN];
+      if (agent_vault_get(agent->name, VAULT_CODEX_TOKEN_CRED, token, sizeof(token)))
+      {
+         snprintf(buf, buf_len, "Authorization: Bearer %s", token);
+         return 0;
+      }
       if (g_request_session_id[0] &&
           session_creds_get_codex(g_request_session_id, token, sizeof(token), NULL, 0))
       {
@@ -1567,9 +1617,9 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    /* x-api-key auth (Anthropic): resolve via session keyring, auth_cmd or api_key */
    if (strcmp(auth_type, "x-api-key") == 0)
    {
-      if (have_session_key)
+      if (have_primary_key)
       {
-         snprintf(buf, buf_len, "x-api-key: %s", session_key);
+         snprintf(buf, buf_len, "x-api-key: %s", primary_key);
          return 0;
       }
       if (agent->auth_cmd[0])
@@ -1618,9 +1668,9 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    if (strcmp(agent->provider, "gemini") == 0 &&
        (!auth_type[0] || strcmp(auth_type, "api_key") == 0))
    {
-      if (have_session_key)
+      if (have_primary_key)
       {
-         snprintf(buf, buf_len, "x-goog-api-key: %s", session_key);
+         snprintf(buf, buf_len, "x-goog-api-key: %s", primary_key);
          return 0;
       }
       if (agent_api_key_literal(agent->api_key))
@@ -1637,9 +1687,9 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    }
 
    /* Default: bearer token — session keyring first, then stored api_key. */
-   if (have_session_key)
+   if (have_primary_key)
    {
-      snprintf(buf, buf_len, "Authorization: Bearer %s", session_key);
+      snprintf(buf, buf_len, "Authorization: Bearer %s", primary_key);
       return 0;
    }
    if (agent_api_key_literal(agent->api_key))

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -215,7 +215,9 @@ int agent_has_resolvable_credentials(const agent_t *agent)
    if (agent->auth_cmd[0] || agent_api_key_literal(agent->api_key))
       return 1;
    /* A credential in the permanent vault (this turn's principal or the server
-    * principal) makes the agent usable with no on-disk key — the P4 primary path. */
+    * principal) makes the agent usable with no on-disk key — the P4 primary path.
+    * For codex we probe the TOKEN, not the account id: a vaulted account without a
+    * token is NOT a usable credential (the token is what authenticates). */
    {
       char k[MAX_API_KEY_LEN];
       int is_codex = strcmp(agent->auth_type, "codex-oauth") == 0;
@@ -278,8 +280,15 @@ const char *agent_get_request_vault_principal(void)
  * permanent vault: the turn's attested principal first, then the autonomous
  * server principal (the path that serves a thin-client TCP/TLS conn with no
  * per-user identity). Returns 1 + fills out on a hit, 0 on miss/locked/error so
- * the caller falls through to the remaining (legacy/env) tiers. Never the secret
- * source of truth's only reader — every server-side cred path consults this. */
+ * the caller falls through to the remaining (legacy/env) tiers.
+ *
+ * Threat model for the server-principal fallback: the server vault holds the
+ * operator's shared default keys, and aimee-server is a SINGLE-owner personal
+ * agent (the server bearer already gates every /v1 op), so serving the server
+ * key when the turn's principal has no entry is the intended "all agents work
+ * for all connections" behavior, not a cross-tenant leak — a per-user
+ * (webuser:/uid:) entry OVERRIDES it when present. Every request that reaches
+ * here is already bearer-authenticated. */
 static int agent_vault_get(const char *agent_name, const char *cred, char *out, size_t out_len)
 {
    if (!agent_name || !agent_name[0] || !out || out_len == 0)
@@ -381,9 +390,9 @@ void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
       acct[0] = '\0';
       if (g_request_codex_account_id[0])
          snprintf(acct, sizeof(acct), "%s", g_request_codex_account_id);
-      else if (agent_vault_get(agent->name, VAULT_CODEX_ACCOUNT_CRED, acct, sizeof(acct)))
-         ; /* resolved from the permanent vault (turn principal -> server principal) */
-      else if (g_request_session_id[0])
+      else if (!agent_vault_get(agent->name, VAULT_CODEX_ACCOUNT_CRED, acct, sizeof(acct)) &&
+               g_request_session_id[0])
+         /* vault miss (acct left empty by the helper) -> legacy session keyring. */
          session_creds_get_codex(g_request_session_id, NULL, 0, acct, sizeof(acct));
       if (acct[0])
       {
@@ -1536,22 +1545,6 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
    if (strcmp(auth_type, "none") == 0)
       return 0;
 
-   /* Credential precedence for the in-flight turn (P4): the permanent VAULT wins
-    * — resolved for the turn's attested principal with autonomous server-principal
-    * fallback, so EVERY connection (primary chat, webchat, in-model tool, delegate)
-    * is served from the one store. Then a client-pushed session-scoped key (the
-    * legacy RAM keyring, retired in P4b), then the agent's stored api_key / env
-    * below. vault_service_inject_api_key handles the dual-wrap (server-wrap ->
-    * user-KEK -> server principal); a locked/miss result falls through. */
-   char primary_key[MAX_API_KEY_LEN];
-   int have_primary_key =
-       (vault_service_inject_api_key(agent_get_request_vault_principal(), agent->name, primary_key,
-                                     sizeof(primary_key), time(NULL)) == VAULT_OK &&
-        primary_key[0]);
-   if (!have_primary_key && g_request_session_id[0] &&
-       session_creds_get(g_request_session_id, agent->name, primary_key, sizeof(primary_key)))
-      have_primary_key = 1;
-
    if (strcmp(auth_type, "codex-oauth") == 0)
    {
       /* Codex OAuth token, in precedence: per-turn token (set by the vault delegate
@@ -1613,6 +1606,26 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
       snprintf(buf, buf_len, "Authorization: Bearer %s", token);
       return 0;
    }
+
+   /* Credential precedence for the in-flight turn (P4): the permanent VAULT wins
+    * — resolved for the turn's attested principal with autonomous server-principal
+    * fallback, so EVERY connection (primary chat, webchat, in-model tool, delegate)
+    * is served from the one store. Then a client-pushed session-scoped key (the
+    * legacy RAM keyring, retired in P4b), then the agent's stored api_key / env
+    * below. vault_service_inject_api_key handles the dual-wrap (server-wrap ->
+    * user-KEK -> server principal) AND is robust to an empty principal (it just
+    * resolves the server principal); a locked/miss result falls through here, while
+    * the delegate path keeps its own D15 hard-fail-on-locked. Computed only for the
+    * key-bearing auth types below (not codex-oauth / auth_cmd), to avoid a wasted
+    * decrypt on turns that never consult it. */
+   char primary_key[MAX_API_KEY_LEN];
+   int have_primary_key =
+       (vault_service_inject_api_key(agent_get_request_vault_principal(), agent->name, primary_key,
+                                     sizeof(primary_key), time(NULL)) == VAULT_OK &&
+        primary_key[0]);
+   if (!have_primary_key && g_request_session_id[0] &&
+       session_creds_get(g_request_session_id, agent->name, primary_key, sizeof(primary_key)))
+      have_primary_key = 1;
 
    /* x-api-key auth (Anthropic): resolve via session keyring, auth_cmd or api_key */
    if (strcmp(auth_type, "x-api-key") == 0)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -21,7 +21,7 @@ TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/main
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
-                             $(OBJDIR)/server/agent_config.o $(OBJDIR)/server/session_credentials.o $(OBJDIR)/server/agent_adapter.o $(OBJDIR)/cmd_describe.o \
+                             $(OBJDIR)/server/agent_config.o $(OBJDIR)/tests/support/vault_service_stub.o $(OBJDIR)/server/session_credentials.o $(OBJDIR)/server/agent_adapter.o $(OBJDIR)/cmd_describe.o \
                              $(OBJDIR)/posix/cmd_describe.o \
                              $(OBJDIR)/server/agent_runtime.o $(OBJDIR)/server/agent_logging.o $(OBJDIR)/server/request_context.o $(OBJDIR)/server/skill_review.o $(OBJDIR)/server/skill_curator.o $(OBJDIR)/server/agent_context_budget.o $(OBJDIR)/prompts.o $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o $(OBJDIR)/server/cli_acp.o $(OBJDIR)/conversation_context.o $(OBJDIR)/server/provider_catalog.o $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o $(OBJDIR)/server/agent_request_shaping.o $(OBJDIR)/server/agent_policy.o $(OBJDIR)/server/model_sampling.o \
                              $(OBJDIR)/server/agent_tasks.o $(OBJDIR)/server/agent_eval.o $(OBJDIR)/server/agent_eval_memory_support.o $(OBJDIR)/server/agent_eval_baseline.o \
@@ -2011,7 +2011,7 @@ $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
                            $(OBJDIR)/server/openai_shape.o \
                            $(OBJDIR)/server/openai_runs_store.o $(OBJDIR)/server/server_auth.o \
                            $(OBJDIR)/server/compute_pool.o \
-                           $(OBJDIR)/server/agent_config.o $(OBJDIR)/server/session_credentials.o \
+                           $(OBJDIR)/server/agent_config.o $(OBJDIR)/tests/support/vault_service_stub.o $(OBJDIR)/server/session_credentials.o \
                            $(OBJDIR)/persona.o $(OBJDIR)/prompts.o \
                            $(OBJDIR)/role_templates.o \
                            $(OBJDIR)/dstr.o $(OBJDIR)/working_profile.o \

--- a/src/tests/support/vault_service_stub.c
+++ b/src/tests/support/vault_service_stub.c
@@ -1,0 +1,44 @@
+/* vault_service_stub.c: shared no-op stubs for the three vault_service read
+ * functions that agent_config.o now calls during credential resolution (P4: the
+ * vault is the universal credential source). Tests that link agent_config.o but
+ * run keyless (no vault) get a clean VAULT_NO_ENTRY miss here, so resolution
+ * falls through to the session/literal/env tiers exactly as before — without
+ * pulling in the real vault crypto + store chain. Binaries that need real or
+ * controllable vault behavior (unit-test-vault-service, unit-test-server-compute)
+ * link the real object / their own file-local stubs instead and must NOT also
+ * link this TU. */
+#include "vault_service.h"
+#include <string.h>
+
+vault_status_t vault_service_inject_api_key(const char *principal, const char *agent, char *api_key,
+                                            size_t api_key_len, long now_epoch)
+{
+   (void)principal;
+   (void)agent;
+   (void)api_key;
+   (void)api_key_len;
+   (void)now_epoch;
+   return VAULT_NO_ENTRY; /* miss -> caller keeps its config/env key */
+}
+
+vault_status_t vault_service_get(const char *principal, const char *agent, const char *cred,
+                                 char *out, size_t out_cap, long now_epoch)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)now_epoch;
+   if (out && out_cap)
+      out[0] = '\0';
+   return VAULT_NO_ENTRY;
+}
+
+vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
+                                                  size_t out_len)
+{
+   (void)agent;
+   (void)cred;
+   if (out && out_len)
+      out[0] = '\0';
+   return VAULT_NO_ENTRY;
+}


### PR DESCRIPTION
## What

Make the credential **vault** the universal source for *every* connection — the core of "all configured agents, all connections, in the vault, permanently."

Until now the vault was read **only** on the delegate path (`delegate_credential_retry` pre-injects into `agent->api_key`). The universal resolver `agent_resolve_auth` used `session-creds → literal → env` and never consulted the vault, so a **primary chat / webchat / in-model** agent could not be served from it.

## Change

`agent_resolve_auth` now resolves in this precedence:

1. **vault** — the turn's attested principal, then the autonomous **server principal** (the path that serves a thin-client TCP/TLS conn with no per-user identity)
2. client-pushed session key (legacy RAM keyring — **retired in P4b**)
3. `agent->api_key` literal / `$ENV` ref
4. provider env / `$ENV` fallback (**kept by design** — roundtable D11)

- New `agent_vault_get()` helper (codex token + account id); api_key uses `vault_service_inject_api_key` (handles the dual-wrap). Locked/miss falls through.
- `agent_build_extra_headers` + `agent_has_resolvable_credentials` consult the vault first too.

## Non-breaking by design

Nothing is removed here. The vault is **added as the top tier**; session-creds + env remain below, so any path not yet migrated still resolves. **P4b** then deletes the legacy client-held push path (`cli_session_creds_prime`, `/v1/session/credentials`, the `session_credentials` store).

## Tests

`make -j1 verify-local` green. Shared `tests/support/vault_service_stub.c` resolves the three new `vault_service` read symbols (NO_ENTRY miss) for the ~36 keyless test binaries that link `agent_config.o`; wired into `TEST_WORKSPACE_OBJS_EXTRA` + the `unit-test-server-http` link line. Binaries needing real/controllable vault behavior (`unit-test-vault-service`, `unit-test-server-compute`) keep their own objects.

## Deploy note

No live impact until deployed (user-gated). Once `.254` upgrades, agents resolve from the vault; populate it via `agent key import` (over UDS) or native-TLS provisioning (PR #304) first.
