### PR TITLE
fix(delegate): inferred modality caps are soft, not fleet-wide hard fails

### DIFF
--- a/src/headers/model_registry.h
+++ b/src/headers/model_registry.h
@@ -30,6 +30,14 @@ enum
    MODEL_CAP_STREAMING = 1 << 5,
 };
 
+/* Modality capabilities (vision/pdf/audio) are INFERRED from prompt TEXT
+ * (delegate_infer_capability_requirements) — a heuristic that over-triggers on a
+ * text task merely mentioning an image/pdf/audio filename. They are therefore
+ * BEST-EFFORT routing preferences: when requiring them would disable every
+ * candidate, the router relaxes them and routes on the hard caps (tools) +
+ * min_context instead, rather than hard-failing the whole task fleet-wide. */
+#define MODEL_CAP_MODALITY_SOFT (MODEL_CAP_VISION | MODEL_CAP_PDF | MODEL_CAP_AUDIO)
+
 typedef struct
 {
    char provider[MODEL_PROVIDER_MAX];

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1354,8 +1354,9 @@ static int agent_satisfies_required_caps(const agent_t *ag, unsigned required_ca
 /* Route to the cheapest capable agent, filtering by required capability flags and minimum context
  * window when sys_cfg->model_meta_capability_routing is enabled.  Falls back to plain agent_route
  * when capability routing is disabled. */
-agent_t *agent_route_with_caps(agent_config_t *cfg, const char *role, const config_t *sys_cfg,
-                               unsigned required_caps, int min_context)
+static agent_t *agent_route_with_caps_inner(agent_config_t *cfg, const char *role,
+                                            const config_t *sys_cfg, unsigned required_caps,
+                                            int min_context)
 {
    if (!sys_cfg || !sys_cfg->model_meta_capability_routing)
       return agent_route(cfg, role);
@@ -1415,6 +1416,21 @@ agent_t *agent_route_with_caps(agent_config_t *cfg, const char *role, const conf
          candidates[count++] = ag;
    }
    return agent_pick_random(candidates, count);
+}
+
+agent_t *agent_route_with_caps(agent_config_t *cfg, const char *role, const config_t *sys_cfg,
+                               unsigned required_caps, int min_context)
+{
+   agent_t *r = agent_route_with_caps_inner(cfg, role, sys_cfg, required_caps, min_context);
+   /* Modality caps (vision/pdf/audio) are inferred from prompt text and are
+    * best-effort: if no model satisfies them, relax them and route on the hard
+    * caps (tools) + min_context rather than returning no route at all. Mirrors
+    * delegate_filter_route_capabilities so both routing gates agree. */
+   if (!r && sys_cfg && sys_cfg->model_meta_capability_routing &&
+       (required_caps & MODEL_CAP_MODALITY_SOFT))
+      r = agent_route_with_caps_inner(cfg, role, sys_cfg, required_caps & ~MODEL_CAP_MODALITY_SOFT,
+                                      min_context);
+   return r;
 }
 
 /* --- Exec role check --- */

--- a/src/server/delegate_routing.c
+++ b/src/server/delegate_routing.c
@@ -2,6 +2,7 @@
 #include "cmd_agent_delegate_impl.h"
 #include "util.h"
 #include "model_registry.h"
+#include "log.h"
 #include <ctype.h>
 #include <string.h>
 
@@ -16,10 +17,14 @@ void delegate_infer_capability_requirements(const char *prompt, int tools_enable
 
    if (prompt && prompt[0])
    {
+      /* Vision is INFERRED from text and is a SOFT routing preference (see
+       * MODEL_CAP_MODALITY_SOFT): the router relaxes it when no model qualifies.
+       * Markdown image syntax ("![") is deliberately NOT a trigger — it appears in
+       * any doc/diff under review and never means the model must decode an image. */
       if (str_contains_ci(prompt, ".png") || str_contains_ci(prompt, ".jpg") ||
           str_contains_ci(prompt, ".jpeg") || str_contains_ci(prompt, ".webp") ||
           str_contains_ci(prompt, ".gif") || str_contains_ci(prompt, "screenshot") ||
-          str_contains_ci(prompt, "image_url") || str_contains_ci(prompt, "!["))
+          str_contains_ci(prompt, "image_url"))
          required |= MODEL_CAP_VISION;
       if (str_contains_ci(prompt, ".pdf") || str_contains_ci(prompt, " pdf "))
          required |= MODEL_CAP_PDF;
@@ -47,6 +52,37 @@ void delegate_infer_capability_requirements(const char *prompt, int tools_enable
       *min_context_out = min_context;
 }
 
+/* Does this agent satisfy the filter (caps + min_context, and not a dropped
+ * deprecated model)? Pure predicate — no mutation — so the relaxation pass below
+ * can dry-run it before deciding which capabilities to actually enforce.
+ * Effective context window prefers the agent's explicit override (agents.json
+ * `middleware.context_window`, via `aimee agent --ctx` or `ag_probe_slots`), then
+ * the model capability catalog, so onboarding a model is a config/catalog change
+ * not a registry code edit. */
+static int agent_meets_filter(const agent_t *ag, unsigned required_caps, int min_context,
+                              int drop_deprecated)
+{
+   model_capability_t cap;
+   int have_cap = model_capability_get(ag->provider, ag->model, &cap);
+   if (drop_deprecated && have_cap && cap.deprecated)
+      return 0;
+   unsigned effective_flags = have_cap ? cap.flags : 0;
+   if (ag->tools_enabled)
+      effective_flags |= MODEL_CAP_TOOLS;
+   else
+      effective_flags &= ~MODEL_CAP_TOOLS;
+   if (required_caps && (effective_flags & required_caps) != required_caps)
+      return 0;
+   if (min_context > 0)
+   {
+      int effective_ctx = ag->middleware.context_window > 0 ? ag->middleware.context_window
+                                                            : (have_cap ? cap.context_window : 0);
+      if (effective_ctx <= 0 || effective_ctx < min_context)
+         return 0;
+   }
+   return 1;
+}
+
 int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
                                        unsigned required_caps, int min_context, int drop_deprecated,
                                        char *errbuf, size_t errbuf_sz)
@@ -59,6 +95,47 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
       return 0;
 
    int role_candidates = 0;
+   for (int i = 0; i < cfg->agent_count; i++)
+   {
+      agent_t *ag = &cfg->agents[i];
+      if (ag->enabled && (agent_has_role(ag, role) || agent_is_exec_role(ag, role)))
+         role_candidates++;
+   }
+   if (role_candidates == 0)
+      return 0;
+
+   /* Modality caps (vision/pdf/audio) are inferred from prompt TEXT and so are
+    * best-effort: if requiring them would disable EVERY role candidate but the
+    * hard caps (tools + min_context) alone would keep some, relax the modality
+    * caps and route on the hard set — never hard-fail a text task fleet-wide just
+    * because it mentioned an image/pdf/audio filename. */
+   unsigned eff = required_caps;
+   if (required_caps & MODEL_CAP_MODALITY_SOFT)
+   {
+      int kept_full = 0, kept_hard = 0;
+      unsigned hard = required_caps & ~MODEL_CAP_MODALITY_SOFT;
+      for (int i = 0; i < cfg->agent_count; i++)
+      {
+         agent_t *ag = &cfg->agents[i];
+         if (!ag->enabled || (!agent_has_role(ag, role) && !agent_is_exec_role(ag, role)))
+            continue;
+         if (agent_meets_filter(ag, required_caps, min_context, drop_deprecated))
+            kept_full++;
+         if (agent_meets_filter(ag, hard, min_context, drop_deprecated))
+            kept_hard++;
+      }
+      if (kept_full == 0 && kept_hard > 0)
+      {
+         char sc[128];
+         model_capability_flags_string(required_caps & MODEL_CAP_MODALITY_SOFT, sc, sizeof(sc));
+         aimee_log(LOG_WARN, "delegate.route",
+                   "no model satisfies inferred modality caps (%s) for role '%s'; routing on hard "
+                   "caps only",
+                   sc[0] ? sc : "-", role);
+         eff = hard;
+      }
+   }
+
    int kept = 0;
    for (int i = 0; i < cfg->agent_count; i++)
    {
@@ -67,56 +144,15 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
          continue;
       if (!agent_has_role(ag, role) && !agent_is_exec_role(ag, role))
          continue;
-      role_candidates++;
-
-      model_capability_t cap;
-      int have_cap = model_capability_get(ag->provider, ag->model, &cap);
-      if (have_cap)
-      {
-         if (ag->tools_enabled)
-            cap.flags |= MODEL_CAP_TOOLS;
-         else
-            cap.flags &= ~MODEL_CAP_TOOLS;
-      }
-      if (drop_deprecated && have_cap && cap.deprecated)
+      if (!agent_meets_filter(ag, eff, min_context, drop_deprecated))
       {
          ag->enabled = 0;
          continue;
       }
-      if (required_caps)
-      {
-         unsigned effective_flags = have_cap ? cap.flags : 0;
-         if (ag->tools_enabled)
-            effective_flags |= MODEL_CAP_TOOLS;
-         else
-            effective_flags &= ~MODEL_CAP_TOOLS;
-         if ((effective_flags & required_caps) != required_caps)
-         {
-            ag->enabled = 0;
-            continue;
-         }
-      }
-      if (min_context > 0)
-      {
-         /* Effective context window: prefer the agent's explicit override
-          * (agents.json `middleware.context_window`, set via `aimee agent
-          * --ctx` or auto-detected by `ag_probe_slots`); fall back to the
-          * model capability catalog (models.dev override/cache, then the
-          * built-in heuristic). This keeps onboarding a new model a config or
-          * catalog change rather than a code edit to the registry table. */
-         int effective_ctx = ag->middleware.context_window > 0
-                                 ? ag->middleware.context_window
-                                 : (have_cap ? cap.context_window : 0);
-         if (effective_ctx <= 0 || effective_ctx < min_context)
-         {
-            ag->enabled = 0;
-            continue;
-         }
-      }
       kept++;
    }
 
-   if (role_candidates > 0 && kept == 0)
+   if (kept == 0)
    {
       char caps[128];
       model_capability_flags_string(required_caps, caps, sizeof(caps));

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -9,6 +9,7 @@
 #include "cmd_agent_delegate_impl.h"
 #include "delegate_role.h"
 #include "model_registry.h"
+#include "log.h"
 #include "posix/agent_tools_internal.h"
 #include "cJSON.h"
 
@@ -103,6 +104,15 @@ int model_capability_get(const char *provider, const char *model_id, model_capab
    if (strstr(model_id, "deprecated"))
       out->deprecated = 1;
    return 1;
+}
+
+/* delegate_routing.c logs a warning when it relaxes an unmet inferred modality
+ * cap; stub it (this test doesn't link log.o). */
+void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
+{
+   (void)level;
+   (void)module;
+   (void)fmt;
 }
 
 void model_capability_flags_string(unsigned flags, char *out, size_t out_len)
@@ -864,6 +874,63 @@ static void test_capability_filter_honors_tools_enabled(void)
    printf("  PASS: test_capability_filter_honors_tools_enabled\n");
 }
 
+/* An inferred modality cap (vision/pdf/audio) that no model satisfies must NOT
+ * hard-fail the fleet: it is relaxed to the hard caps (tools + min_context) so
+ * the text models stay routable. Guards the fleet-wide false-fail where a text
+ * task merely mentioning an image required vision no model had. */
+static void test_capability_filter_relaxes_unmet_modality(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+   snprintf(cfg.agents[0].name, sizeof(cfg.agents[0].name), "text-a");
+   snprintf(cfg.agents[0].model, sizeof(cfg.agents[0].model), "text-model");
+   snprintf(cfg.agents[0].provider, sizeof(cfg.agents[0].provider), "openai");
+   snprintf(cfg.agents[0].roles[0], sizeof(cfg.agents[0].roles[0]), "diagnose");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].enabled = 1;
+   cfg.agents[0].tools_enabled = 1;
+
+   snprintf(cfg.agents[1].name, sizeof(cfg.agents[1].name), "text-b");
+   snprintf(cfg.agents[1].model, sizeof(cfg.agents[1].model), "text-model");
+   snprintf(cfg.agents[1].provider, sizeof(cfg.agents[1].provider), "openai");
+   snprintf(cfg.agents[1].roles[0], sizeof(cfg.agents[1].roles[0]), "diagnose");
+   cfg.agents[1].role_count = 1;
+   cfg.agents[1].enabled = 1;
+   cfg.agents[1].tools_enabled = 1;
+
+   /* Require TOOLS (hard) + VISION (soft); no text-model has vision. The hard
+    * TOOLS must be enforced, the unmet VISION relaxed -> both kept, no error. */
+   char errbuf[128];
+   assert(delegate_filter_route_capabilities(&cfg, "diagnose", MODEL_CAP_TOOLS | MODEL_CAP_VISION,
+                                             0, 0, errbuf, sizeof(errbuf)) == 0);
+   assert(cfg.agents[0].enabled == 1);
+   assert(cfg.agents[1].enabled == 1);
+   printf("  PASS: test_capability_filter_relaxes_unmet_modality\n");
+}
+
+/* A hard capability (tools) that no model satisfies still fails closed — only the
+ * inferred modality caps are soft. */
+static void test_capability_filter_hard_cap_still_fails(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 1;
+   snprintf(cfg.agents[0].name, sizeof(cfg.agents[0].name), "metadata-only");
+   snprintf(cfg.agents[0].model, sizeof(cfg.agents[0].model), "notools-model");
+   snprintf(cfg.agents[0].provider, sizeof(cfg.agents[0].provider), "openai");
+   snprintf(cfg.agents[0].roles[0], sizeof(cfg.agents[0].roles[0]), "diagnose");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].enabled = 1;
+   cfg.agents[0].tools_enabled = 0;
+
+   char errbuf[128];
+   assert(delegate_filter_route_capabilities(&cfg, "diagnose", MODEL_CAP_TOOLS, 0, 0, errbuf,
+                                             sizeof(errbuf)) == -1);
+   assert(cfg.agents[0].enabled == 0);
+   printf("  PASS: test_capability_filter_hard_cap_still_fails\n");
+}
+
 static void test_capability_inference_audio_extension_not_keyword(void)
 {
    /* Regression: prompts describing audio *features* in code (e.g.
@@ -1013,6 +1080,8 @@ int main(void)
    test_capability_filter_drops_deprecated_on_auto_route();
    test_capability_filter_enforces_min_context();
    test_capability_filter_honors_tools_enabled();
+   test_capability_filter_relaxes_unmet_modality();
+   test_capability_filter_hard_cap_still_fails();
    test_capability_inference_audio_extension_not_keyword();
    test_capability_inference_detects_modalities();
    printf("All tests passed.\n");


### PR DESCRIPTION
## Problem

Delegate capability requirements are inferred from the **prompt text** (`delegate_infer_capability_requirements`): a prompt that merely *mentions* `.png`/`screenshot`/`image_url`/`.pdf`/an audio extension was made to **hard-require** vision/pdf/audio. Since the prompt is the only signal (no real image payload is attached to these text delegates), it over-triggers constantly — and because no configured model advertises `vision`, the **whole fleet** got rejected:

```
no configured model supports required capabilities (caps=tools,vision, min_context=7773)
```

Observed live: jobs 179–186 (a "document all config options" review) all hard-failed this way.

## Fix — inferred modality caps are best-effort

- New `MODEL_CAP_MODALITY_SOFT` = vision|pdf|audio.
- `delegate_filter_route_capabilities`: if the full caps would disable every role candidate but the **hard** caps (tools) + `min_context` alone keep some, relax the modality caps and route on the hard set (logs a warning). The per-agent predicate is factored into `agent_meets_filter()` so the relaxation dry-runs before mutating `ag->enabled`.
- `agent_route_with_caps`: same fallback (retry without soft caps); body renamed `_inner`, public fn wraps it — keeps both routing gates in agreement.
- Drop the markdown-image (`![`) vision trigger: it appears in any doc/diff under review and never means the model must decode an image.

`tools` + `min_context` stay **hard** (real constraints); genuine modality routing still works (and is preferred) when a capable model is configured.

## Tests
`make -j1 verify-local` green. New: relaxation keeps text models when an unmet VISION is required alongside a satisfied TOOLS; a truly-unmet hard cap (tools) still fails closed. Existing filter/inference tests unchanged.
