### PR TITLE
docs(config): complete configuration reference (config keys + env + workflow)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -1,6 +1,15 @@
 # Configuration Reference
 
-> Auto-generated from `src/config_fields.c` and the `src/config*.c` parsers by `scripts/gen-reference-docs.py`. Do not edit by hand; run `make -C src docs-gen` to regenerate.
+> Auto-generated from the canonical source tables by `scripts/gen-reference-docs.py` — config keys from `src/config_fields.c` + `src/config*.c`, env vars scanned from `getenv()` in `src/`, and the workflow surface from `src/workflow/`. Do not edit by hand; run `make -C src docs-gen` to regenerate.
+
+This reference covers every configurable surface:
+
+1. **Config-store keys** — the `aimee config` keys + config-file sections (below).
+2. **Environment variables** — `AIMEE_*` runtime/deployment overrides.
+3. **External & provider environment** — provider keys, endpoints, proxy, editor.
+4. **Workflow engine** — workflow definition + custom-block (`blocks.yaml`) schema.
+
+CLI commands + flags are documented separately in [`cli-commands.md`](cli-commands.md).
 
 Configuration lives in the per-`AIMEE_HOME` config store. Scalar keys in the table below are settable from the CLI:
 
@@ -12,7 +21,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (108)
+## CLI-settable keys (103)
 
 | Key | Type |
 |-----|------|
@@ -94,15 +103,10 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `memory_profile_cards_min_obs` | int |
 | `memory_profile_cards_stale_secs` | int |
 | `memory_query_expansion_k` | int |
-| `memory_query_expansion_k` | int |
-| `memory_query_expansion_mode` | string |
 | `memory_query_expansion_mode` | string |
 | `memory_rerank_command` | string |
-| `memory_rerank_command` | string |
-| `memory_rerank_enabled` | bool |
 | `memory_rerank_enabled` | bool |
 | `memory_rerank_mode` | string |
-| `memory_rerank_top_k` | int |
 | `memory_rerank_top_k` | int |
 | `memory_rewrite_command` | string |
 | `memory_rewrite_decompose` | bool |
@@ -125,7 +129,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_assembly_budget` | int |
 | `virtual_context_enabled` | bool |
 
-## Config-file sections (43)
+## Config-file sections (48)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`.
 
@@ -138,6 +142,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`concurrency`** — `default`, `per_model`, `per_provider`, `preempt`
 - **`context`** — `engine`
 - **`cost_reward`** — `enabled`, `lambda_pct`, `ref_usd_milli`
+- **`cron_jobs`** — `context_from`, `deliver`, `enabled`, `id`, `mode`, `pre_wake_gate`, `prompt`, `schedule`, `script`, `skills`, `when_context_contains`, `workdir`
 - **`cross_verify`** — `enabled`, `prompt`, `role`, `verify_cmd`
 - **`db2`** — `vector`
 - **`dedup`** — `enabled`, `window_seconds`
@@ -150,7 +155,9 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`intelligence`** — `bandit`, `bandit_optimize_command`, `calibrate`, `constraint_solver_command`, `demotion`, `kb`, `planner`, `planner_search_command`, `ranker_fuse_command`, `ranking`, `reasoning`, `reasoning_datalog_command`, `synthesize`
 - **`kb`** — `api`, `background_ingest`, `connection_workers`, `curator`, `evidence`, `maintenance`, `mining`, `search_max_results`, `worker_count`
 - **`learning`** — `embed`, `implicit`, `router`, `synthesize`
+- **`lsp_servers`** — `args`, `command`, `extensions`, `name`
 - **`mcp`** — `osv`
+- **`mcp_clients`** — `bearer_token_env`, `command`, `cwd`, `name`, `transport`, `url`
 - **`memory`** — `abstain`, `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_weight`
 - **`memory_maintenance`** — `enabled`, `interval_seconds`, `summarize_enabled`, `trigger_inserts`, `trigger_secs`
 - **`memory_negation`** — `enabled`
@@ -172,9 +179,332 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`skills`** — `capability`, `curator`, `dispatch`, `eval`, `manage`, `review`
 - **`transport`** — `cache_aware_rewrite`
 - **`trigger`** — `auth_token`, `max_concurrent`
+- **`trigger_rules`** — `event`, `pipeline`, `schedule`, `source`
+- **`workspaces`** — `head`, `path`, `provider`, `remote`
 
-## Other top-level config-file keys (11)
+## Other top-level config-file keys (5)
 
 Scalar keys read directly from the config root (not via the CLI allowlist above):
 
-`cron_jobs`, `db2_pool_size`, `db2_url`, `kb_client_bearer_token`, `kb_client_url`, `lsp_servers`, `mcp_clients`, `proxy_token`, `toolsets`, `trigger_rules`, `workspaces`
+`db2_pool_size`, `kb_client_bearer_token`, `kb_client_url`, `proxy_token`, `toolsets`
+
+## Environment variables
+
+The binaries read 106 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+
+### Paths & assets
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_BUNDLED_SKILLS_DIR` | Override directory for the bundled skills. |
+| `AIMEE_FORENSICS_DIR` | Directory for shutdown-forensics dumps. |
+| `AIMEE_GUARDRAILS_PATH` | Path to the guardrails policy file. |
+| `AIMEE_HOME` | Root of the per-user state/config store (config, DB1, `workflows/`, keys). Overrides the platform default. |
+| `AIMEE_INSTALL_PREFIX` | Install prefix used to locate bundled assets and plugins. |
+| `AIMEE_MODELS_DEV_SNAPSHOT` | Path to an offline models.dev catalog snapshot. |
+| `AIMEE_PACK_DIR` | Directory of memory profile packs. |
+| `AIMEE_TOOLSETS_CONFIG` | Path to a toolsets config file (overrides the default tool allowlists). |
+| `AIMEE_WORKSPACES_DIR` | Root directory for mirrored/registered workspaces. |
+
+### Client & session
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_ACTIVE_TOOLSET` | Active toolset (tool allowlist) for the session. |
+| `AIMEE_API_BEARER` | Bearer token for the `/v1` API endpoint. |
+| `AIMEE_API_ENDPOINT` | Override the `/v1` API endpoint used by the client RPC layer. |
+| `AIMEE_ATTACH_ID` | Presence attach id used when joining an existing session. |
+| `AIMEE_EFFORT` | Reasoning-effort hint for the session/model. |
+| `AIMEE_GUARD` | Attention-guard control; set to bypass the guard hook. |
+| `AIMEE_HOOK_CLIENT` | Identifies the calling hook client (e.g. claude/codex) for hook routing. |
+| `AIMEE_MODE` | Operating-mode override (e.g. interactive / autonomous). |
+| `AIMEE_MODEL` | Override the primary model for the session. |
+| `AIMEE_NO_AUTOSTART` | If set, the client does not auto-start a local aimee-server. |
+| `AIMEE_PROFILE` | Active working-profile name. |
+| `AIMEE_SERVER_TOKEN` | Bearer token presented to aimee-server over TCP. |
+| `AIMEE_SERVER_URL` | aimee-server endpoint the thin client connects to (UDS path or `tcp:host:port`). |
+| `AIMEE_SESSION_ID` | Pre-set the session id (enables non-blocking session attach). |
+| `AIMEE_SESSION_START_VERBOSE` | Verbose logging during session start. |
+| `AIMEE_TUI_SESSION` | Identifies the TUI session. |
+
+### Server runtime
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_API_REMOTE_WRITES` | Gate remote (TCP) write methods: `off` | `data` | `full`. |
+| `AIMEE_BACKGROUND_THREADS` | Background worker thread count. |
+| `AIMEE_COMPUTE_THREADS` | Compute-pool thread count. |
+| `AIMEE_INGRESS_PROXY_SECRET` | Shared secret authenticating a trusted ingress proxy's identity headers. |
+| `AIMEE_PARALLEL_MAX` | Maximum parallel agent fan-out. |
+| `AIMEE_SERVER_HTTP_BIND` | TCP bind address for the server `/v1` HTTP listener (else UDS-only). |
+| `AIMEE_SERVER_STARTUP_FD` | Inherited fd for startup-readiness signalling (service launch). |
+| `AIMEE_SESSION_THREADS` | Per-session worker thread count. |
+| `AIMEE_SOCK` | Sandbox helper socket path. |
+| `AIMEE_WORKTREE_GC` | Enable/disable delegate-worktree garbage collection. |
+| `AIMEE_WORKTREE_GC_DAYS` | Age threshold (days) for worktree GC. |
+
+### Knowledge base (aimee-kb)
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_KB_API_BEARER_TOKEN` | Bearer token for the aimee-kb API. |
+| `AIMEE_KB_API_CA_BUNDLE` | CA bundle path for verifying the aimee-kb TLS certificate. |
+| `AIMEE_KB_API_URL` | aimee-kb HTTP API base URL. |
+| `AIMEE_KB_CACHE_TTL_S` | KB client cache TTL (seconds). |
+| `AIMEE_KB_CONN` | KB connection string (mTLS transport). |
+| `AIMEE_KB_EMIT_ENROLL` | Emit a client enrollment token on KB start. |
+| `AIMEE_KB_EMIT_SCOPE` | Scope for the emitted enrollment token. |
+| `AIMEE_KB_HTTP_BIND` | aimee-kb HTTP listener bind address. |
+| `AIMEE_KB_MTLS_HOST` | aimee-kb mTLS listener host. |
+| `AIMEE_KB_MTLS_PORT` | aimee-kb mTLS listener port. |
+| `AIMEE_KB_OIDC_AUDIENCE` | OIDC audience for KB API auth. |
+| `AIMEE_KB_OIDC_ISSUER` | OIDC issuer for KB API auth. |
+| `AIMEE_KB_OIDC_JWKS_FILE` | OIDC JWKS file for KB API auth. |
+| `AIMEE_KB_OIDC_SCOPE_CLAIM` | OIDC claim carrying the scope. |
+| `AIMEE_KB_OIDC_SCOPE_KIND` | OIDC scope-kind interpretation. |
+| `AIMEE_VECTOR_KB_BATCH_SIZE` | Embedding batch size for KB vector ingest. |
+
+### Database & vectors
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_DB2_URL` | Postgres (DB2) connection URL for the KB store. |
+| `AIMEE_EMBEDDING_DIM` | Embedding dimension (drives halfvec column sizing). |
+| `AIMEE_PGVEC_SLOW_QUERY_MS` | Slow-query log threshold (ms) for the pgvector transport. |
+
+### Memory
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_CONTEXT_NO_KB` | Skip KB lookups during context assembly. |
+| `AIMEE_MEMORY_CITATIONS_MODE` | Citation rendering mode for memory recall. |
+| `AIMEE_MEMORY_CITATIONS_STRIP_UNVERIFIED` | Strip unverified citations from recall output. |
+| `AIMEE_MEMORY_COGNIFY_ASYNC_ENABLED` | Enable the async cognify pipeline. |
+| `AIMEE_MEMORY_COREF_MODE` | Coreference-resolution mode. |
+| `AIMEE_MEMORY_MAINTENANCE_TRIGGER_INSERTS` | Inserts before a maintenance cycle triggers. |
+| `AIMEE_MEMORY_MAINTENANCE_TRIGGER_SECS` | Seconds before a maintenance cycle triggers. |
+| `AIMEE_MEMORY_PAGERANK_RELATIONS` | Relation types included in memory PageRank. |
+| `AIMEE_MEMORY_RERANK_FORCE_OFF` | Force the cross-encoder reranker off. |
+| `AIMEE_MEMORY_RERANK_MODE` | Reranker mode. |
+| `AIMEE_MEMORY_WEIGHT_PROFILE` | Recall scoring weight profile. |
+| `AIMEE_NO_CACHE` | Disable the memory-assembly cache. |
+
+### Delegates & backends
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_DELEGATE_DEPTH` | Current delegation depth (recursion guard). |
+| `AIMEE_DELEGATE_HEARTBEAT_MONITOR` | Enable the delegate heartbeat monitor. |
+| `AIMEE_DELEGATE_SOURCE_AUTHORITY` | Enable source-authority gating for delegate edits. |
+| `AIMEE_DELEGATE_SOURCE_PATHS` | Allowed source paths for delegate edits. |
+| `AIMEE_DELEGATE_WORKTREE_ROOT` | Root directory for delegate worktrees. |
+| `AIMEE_DOCKER_BIN` | Docker delegate-backend binary. |
+| `AIMEE_DOCKER_WORKDIR` | Docker delegate-backend working directory. |
+| `AIMEE_OPENCODE_BIN` | opencode CLI frontend binary. |
+| `AIMEE_PARENT_DELEGATION_ID` | Parent delegation id (threading). |
+| `AIMEE_SSH_BIN` | SSH delegate-backend binary. |
+
+### Forge (GitHub App / tokens)
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_FORGE_API_BASE` | Forge API base URL. |
+| `AIMEE_FORGE_APP_ID` | GitHub App id for minting forge tokens. |
+| `AIMEE_FORGE_APP_INSTALLATION_ID` | GitHub App installation id. |
+| `AIMEE_FORGE_APP_PRIVATE_KEY` | GitHub App private key (PEM or path). |
+| `AIMEE_FORGE_SCOPE` | Scope for the minted forge token. |
+| `AIMEE_FORGE_TOKEN` | Static forge access token (bypasses App auth). |
+
+### Gateway (voice / webhooks / push)
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_GATEWAY_NTFY_BASE_URL` | ntfy push base URL. |
+| `AIMEE_GATEWAY_NTFY_TOKEN` | ntfy push token. |
+| `AIMEE_GATEWAY_STT_MODEL` | Speech-to-text model. |
+| `AIMEE_GATEWAY_STT_PROVIDER` | Speech-to-text provider. |
+| `AIMEE_GATEWAY_TTS_BASE_URL` | Text-to-speech base URL. |
+| `AIMEE_GATEWAY_TTS_MODEL` | Text-to-speech model. |
+| `AIMEE_GATEWAY_TTS_PROVIDER` | Text-to-speech provider. |
+| `AIMEE_GATEWAY_TTS_VOICE` | Text-to-speech voice. |
+| `AIMEE_GATEWAY_WEBHOOK_DELIVER_ONLY` | Webhook deliver-only mode (no reply path). |
+| `AIMEE_GATEWAY_WEBHOOK_INSECURE` | Allow the webhook listener without TLS (dev). |
+| `AIMEE_GATEWAY_WEBHOOK_PORT` | Inbound webhook listener port. |
+| `AIMEE_GATEWAY_WEBHOOK_SECRET` | Inbound webhook HMAC secret. |
+
+### Workflow engine
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_WORKFLOW_BASE` | Base branch for the engine's freeze/diff. |
+| `AIMEE_WORKFLOW_REPO` | Local repository directory the workflow engine operates on. |
+
+### Git verify / MCP
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_MCP_CWD` | Working-directory hint for MCP git-root resolution. |
+| `AIMEE_VERIFY_PARALLEL` | Run `aimee git verify` steps in parallel. |
+| `AIMEE_VERIFY_STEP_TIMEOUT_MS` | Per-step timeout (ms) for git verify. |
+
+### Models
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_MODEL_CAPABILITY_OVERRIDES` | Override model capability flags (reasoning/tools/vision/…). |
+
+### TLS & networking
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_NET_DEBUG` | Verbose network debug logging. |
+| `AIMEE_TLS_INSECURE` | Disable TLS certificate verification (development only). |
+
+### Plugins
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_ENABLE_PROJECT_PLUGINS` | Allow loading project-local plugins. |
+
+### Diagnostics & misc
+
+| Variable | Description |
+|----------|-------------|
+| `AIMEE_ANTIPATTERNS_BYPASS` | Bypass the guardrail antipattern checks. |
+| `AIMEE_LOG_LEVEL` | Log level: `error` | `warn` | `info` | `debug`. |
+
+## External & provider environment
+
+Standard and third-party environment variables aimee honors (scanned non-`AIMEE_*` `getenv()` reads, plus provider keys resolved via `api_key_env`). Provider API keys are credentials — prefer the credential vault; the env var is the per-provider fallback and its name is overridable per agent via `api_key_env`. Standard OS variables (`HOME`, `PATH`, `TMPDIR`, `XDG_*`, …) are used for their usual purposes and are not aimee configuration.
+
+### Provider credentials
+
+| Variable | Description |
+|----------|-------------|
+| `ANTHROPIC_API_KEY` | Anthropic API key (read via the agent's `api_key_env`). |
+| `GEMINI_API_KEY` | Google Gemini API key (read via the agent's `api_key_env`). |
+| `GEMINI_API_KEY_AUTH_MECHANISM` | Selects the Gemini key auth mechanism. |
+| `GOOGLE_API_KEY` | Google API key fallback for Gemini (via `api_key_env`). |
+| `MINIMAX_API_KEY` | MiniMax API key. |
+| `MISTRAL_API_KEY` | Mistral API key. |
+| `OPENAI_API_KEY` | OpenAI API key (default for OpenAI-family agents). |
+| `OPENROUTER_API_KEY` | OpenRouter API key. |
+
+### Provider endpoints
+
+| Variable | Description |
+|----------|-------------|
+| `LLAMA_HOST` | llama.cpp server host/URL. |
+| `OLLAMA_HOST` | Ollama server host/URL for local models. |
+
+### Reasoning effort
+
+| Variable | Description |
+|----------|-------------|
+| `CODEX_REASONING_EFFORT` | Reasoning-effort passed through the Codex frontend. |
+| `OPENAI_REASONING_EFFORT` | Reasoning-effort default for OpenAI-family models. |
+
+### Network / proxy
+
+| Variable | Description |
+|----------|-------------|
+| `HTTPS_PROXY` | HTTPS proxy for outbound provider/API calls. |
+| `NO_PROXY` | Hosts excluded from proxying. |
+
+### Editor
+
+| Variable | Description |
+|----------|-------------|
+| `EDITOR` | Editor invoked for interactive edits. |
+| `VISUAL` | Editor invoked for interactive edits (preferred over `EDITOR`). |
+
+### Codex / Claude integration
+
+| Variable | Description |
+|----------|-------------|
+| `CLAUDE_SESSION_ID` | Claude Code session id when aimee runs as its backend. |
+| `CODEX_CWD` | Working directory reported by the Codex frontend. |
+| `CODEX_HOME` | Codex home directory (Codex-frontend integration). |
+| `CODEX_MODEL` | Model the Codex frontend requests. |
+| `CODEX_SANDBOX` | Codex sandbox mode. |
+| `CODEX_THREAD_ID` | Codex conversation/thread id. |
+
+## Workflow engine
+
+Workflows are block-composed YAML definitions under `$AIMEE_HOME/workflows/<name>.yaml`, authored with the `aimee workflow` CLI or the web visual composer and saved in canonical form. A run is a DB1 work item pinned to a definition version.
+
+### Workflow definition schema
+
+```yaml
+name: <id>                 # workflow name
+start: <node-id>           # entry node (default: first node)
+nodes:
+  - id: <node-id>          # unique within the workflow
+    block: <block-name>    # a built-in or custom block (see catalog)
+    in:                    # typed input bindings (map: slot -> producer.output)
+      <slot>: <node-id>.<output>
+    params: { ... }        # block-specific params (see below)
+    next: <node-id>        # unconditional successor
+    on_pass: <node-id>     # gate verdict pass edge
+    on_fail: <node-id>     # gate verdict fail edge (loop-back)
+```
+
+### Built-in block catalog
+
+| Block | Produces | Accepts inputs |
+|-------|----------|----------------|
+| `author.proposal` | `proposal` | _(source: none)_ |
+| `author.plan` | `plan` | `proposal` |
+| `implement` | `branch` | `plan` |
+| `document` | `branch` | `branch` |
+| `freeze` | `frozen_diff` | `branch` |
+| `gate.roundtable` | `verdict` | `proposal`, `plan`, `frozen_diff` |
+| `gate.human` | `approval` | `proposal`, `plan`, `branch`, `frozen_diff`, `pr` |
+| `pr.open` | `pr` | `proposal`, `frozen_diff` |
+| `merge` | `none` | `pr` |
+| `gate.ci` | `verdict` | `pr` |
+| `check.mergeable` | `verdict` | `pr` |
+
+### Block parameters (`params:`)
+
+- **`gate.roundtable`** — `panel.required` (list of required reviewer personas), `panel.eligible` (list of additional eligible personas), `quorum` (int; effective quorum is `max(2, quorum)` and at least the required-panel size).
+- **`gate.human`** — `policy: preauthorized` (auto-approve in autonomous mode) and/or `optional: true` (skippable). Without these, an autonomous run parks at the gate for a human.
+- Other blocks take no params today; unknown params are ignored by the validator.
+
+### Custom blocks — `$AIMEE_HOME/workflows/blocks.yaml`
+
+Operator-owned (refused if a symlink or group/world-writable). Adds blocks to the catalog above:
+
+```yaml
+allow_command: false       # opt-in gate for the `command` executor (no-shell, argv-only)
+blocks:
+  - name: <block-name>     # must not shadow a built-in or duplicate
+    consumes: <artifact>   # input artifact type, or none (a source)
+    produces: branch|none  # custom blocks may NOT mint verdict/approval/pr
+    executor: command|delegate
+    command: [ argv0, arg1, ... ]   # executor: command (run in the repo, no shell)
+    persona: <name>        # executor: delegate
+    prompt: <text>         # executor: delegate
+```
+
+### Run-level controls (not in the definition)
+
+- **Per-stage loop cap** — a gate that loops back via `on_fail` is retried at most `20` times (`WFE_MAX_ATTEMPTS`) before the run parks; fixed, not configurable.
+- **Gate-override cap** — a parked human gate may be overridden at most `2` times (`WFE_MAX_OVERRIDES`) before the run is forced terminal.
+- **Cost cap** — an optional per-work-item USD ceiling set at run creation (`work_item_max_cost_usd`); the engine parks the run when cumulative cost reaches it.
+- **Trigger / autonomy mode** — `interactive` vs `autonomous`, set when the run is created.
+
+### Workflow environment overrides
+
+`AIMEE_WORKFLOW_REPO` (repo the engine operates on) and `AIMEE_WORKFLOW_BASE` (base branch for freeze/diff) — see Environment variables above.
+
+## Coverage & limitations
+
+This reference is generated by scanning the canonical source tables, which covers the scalar/keyed config surface but has known blind spots — listed here so a reader can tell *deliberately out of scope* from *not auto-derived*:
+
+- **Array/object element fields** are captured when the parser iterates with `cJSON_ArrayForEach` over a section's array; fields read through other access patterns (`cJSON_GetArrayItem`, indexing) or nested more than one object deep may appear only under their parent section name.
+- **Env vars built at runtime** (a name assembled with `snprintf`/concatenation and passed to `getenv(var)`) are not discoverable by the string-literal scan. Provider API-key vars are the known case and are handled via each agent's `api_key_env`; only the common defaults are listed.
+- **Compile-time `-D` defines** used as build-level configuration are not scanned (they are not runtime-overridable config).
+- **Separate config files** — agent definitions (`agents.json`), toolsets, guardrails policy, and per-workflow definitions — have their own schemas. Custom workflow blocks (`blocks.yaml`) and the workflow definition schema are documented above; the others are out of this reference's stated scope.
+
+If the scan ever finds a config var with no description, it is emitted under an **Undocumented** heading in the relevant section — so a new option cannot silently bypass this reference.

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -108,11 +108,12 @@ def parse_config_fields():
     # entry — robust to CFG_* uses in helper functions below the table.
     start = text.index("config_fields[] = {")
     text = text[start:text.index("\n};", start)]
-    fields = []
+    fields, seen = [], set()
     for chunk in text.split("},"):
         km = re.search(r'"([a-z0-9_]+)"\s*,\s*offsetof', chunk)
         tm = re.search(r'(CFG_\w+)', chunk)
-        if km and tm:
+        if km and tm and km.group(1) not in seen:  # a key may be registered twice
+            seen.add(km.group(1))
             fields.append((km.group(1), CFG_TYPE.get(tm.group(1), tm.group(1))))
     return fields
 
@@ -125,6 +126,9 @@ ASSIGN_RE = re.compile(
     r'(\w+)\s*=\s*cJSON_GetObjectItemCaseSensitive\(\s*root\s*,\s*"([^"]+)"\s*\)')
 CHILD_RE = re.compile(
     r'cJSON_GetObjectItemCaseSensitive\(\s*(\w+)\s*,\s*"([^"]+)"\s*\)')
+# `cJSON_ArrayForEach(<item>, <arr>)` — element fields of an array-valued section
+# are read off <item>; map <item> to the array's section so they're captured too.
+FOREACH_RE = re.compile(r'cJSON_ArrayForEach\(\s*(\w+)\s*,\s*(\w+)\s*\)')
 
 
 def parse_config_sections():
@@ -138,6 +142,11 @@ def parse_config_sections():
             if var == "root":
                 continue
             var_to_section[var] = sect
+        # array iteration: the loop var inherits the array's section
+        for m in FOREACH_RE.finditer(text):
+            item, arr = m.group(1), m.group(2)
+            if arr in var_to_section:
+                var_to_section[item] = var_to_section[arr]
         # collect child keys per section-var
         used_as_parent = set()
         for m in CHILD_RE.finditer(text):
@@ -157,9 +166,21 @@ def parse_config_sections():
 def render_config(fields, sections, flat):
     out = ["# Configuration Reference",
            "",
-           "> Auto-generated from `src/config_fields.c` and the `src/config*.c` "
-           "parsers by `scripts/gen-reference-docs.py`. Do not edit by hand; run "
+           "> Auto-generated from the canonical source tables by "
+           "`scripts/gen-reference-docs.py` — config keys from `src/config_fields.c` + "
+           "`src/config*.c`, env vars scanned from `getenv()` in `src/`, and the "
+           "workflow surface from `src/workflow/`. Do not edit by hand; run "
            "`make -C src docs-gen` to regenerate.",
+           "",
+           "This reference covers every configurable surface:",
+           "",
+           "1. **Config-store keys** — the `aimee config` keys + config-file sections (below).",
+           "2. **Environment variables** — `AIMEE_*` runtime/deployment overrides.",
+           "3. **External & provider environment** — provider keys, endpoints, proxy, editor.",
+           "4. **Workflow engine** — workflow definition + custom-block (`blocks.yaml`) schema.",
+           "",
+           "CLI commands + flags are documented separately in "
+           "[`cli-commands.md`](cli-commands.md).",
            "",
            "Configuration lives in the per-`AIMEE_HOME` config store. Scalar keys "
            "in the table below are settable from the CLI:",
@@ -205,11 +226,459 @@ def render_config(fields, sections, flat):
     return "\n".join(out).rstrip() + "\n"
 
 
+# ─── Environment variables (getenv("AIMEE_*") across src/, excluding tests) ────
+# Every env var the binaries actually read. The scan is the completeness anchor;
+# ENV_DESC supplies the (group, description) for each. A scanned var missing from
+# ENV_DESC is surfaced under "Undocumented" so a new var can never silently slip
+# the reference — keeping this gate honest is the whole point.
+
+ENV_RE = re.compile(r'getenv\(\s*"(AIMEE_[A-Z0-9_]+)"')
+
+# group order controls section order in the doc
+ENV_GROUP_ORDER = [
+    "Paths & assets", "Client & session", "Server runtime", "Knowledge base (aimee-kb)",
+    "Database & vectors", "Memory", "Delegates & backends", "Forge (GitHub App / tokens)",
+    "Gateway (voice / webhooks / push)", "Workflow engine", "Git verify / MCP",
+    "Models", "TLS & networking", "Plugins", "Diagnostics & misc",
+]
+
+ENV_DESC = {
+    # Paths & assets
+    "AIMEE_HOME": ("Paths & assets", "Root of the per-user state/config store (config, DB1, `workflows/`, keys). Overrides the platform default."),
+    "AIMEE_INSTALL_PREFIX": ("Paths & assets", "Install prefix used to locate bundled assets and plugins."),
+    "AIMEE_BUNDLED_SKILLS_DIR": ("Paths & assets", "Override directory for the bundled skills."),
+    "AIMEE_TOOLSETS_CONFIG": ("Paths & assets", "Path to a toolsets config file (overrides the default tool allowlists)."),
+    "AIMEE_GUARDRAILS_PATH": ("Paths & assets", "Path to the guardrails policy file."),
+    "AIMEE_FORENSICS_DIR": ("Paths & assets", "Directory for shutdown-forensics dumps."),
+    "AIMEE_PACK_DIR": ("Paths & assets", "Directory of memory profile packs."),
+    "AIMEE_WORKSPACES_DIR": ("Paths & assets", "Root directory for mirrored/registered workspaces."),
+    "AIMEE_MODELS_DEV_SNAPSHOT": ("Paths & assets", "Path to an offline models.dev catalog snapshot."),
+    # Client & session
+    "AIMEE_SERVER_URL": ("Client & session", "aimee-server endpoint the thin client connects to (UDS path or `tcp:host:port`)."),
+    "AIMEE_SERVER_TOKEN": ("Client & session", "Bearer token presented to aimee-server over TCP."),
+    "AIMEE_API_ENDPOINT": ("Client & session", "Override the `/v1` API endpoint used by the client RPC layer."),
+    "AIMEE_API_BEARER": ("Client & session", "Bearer token for the `/v1` API endpoint."),
+    "AIMEE_SESSION_ID": ("Client & session", "Pre-set the session id (enables non-blocking session attach)."),
+    "AIMEE_TUI_SESSION": ("Client & session", "Identifies the TUI session."),
+    "AIMEE_ATTACH_ID": ("Client & session", "Presence attach id used when joining an existing session."),
+    "AIMEE_HOOK_CLIENT": ("Client & session", "Identifies the calling hook client (e.g. claude/codex) for hook routing."),
+    "AIMEE_NO_AUTOSTART": ("Client & session", "If set, the client does not auto-start a local aimee-server."),
+    "AIMEE_MODEL": ("Client & session", "Override the primary model for the session."),
+    "AIMEE_EFFORT": ("Client & session", "Reasoning-effort hint for the session/model."),
+    "AIMEE_MODE": ("Client & session", "Operating-mode override (e.g. interactive / autonomous)."),
+    "AIMEE_PROFILE": ("Client & session", "Active working-profile name."),
+    "AIMEE_ACTIVE_TOOLSET": ("Client & session", "Active toolset (tool allowlist) for the session."),
+    "AIMEE_SESSION_START_VERBOSE": ("Client & session", "Verbose logging during session start."),
+    "AIMEE_GUARD": ("Client & session", "Attention-guard control; set to bypass the guard hook."),
+    # Server runtime
+    "AIMEE_SERVER_HTTP_BIND": ("Server runtime", "TCP bind address for the server `/v1` HTTP listener (else UDS-only)."),
+    "AIMEE_SERVER_STARTUP_FD": ("Server runtime", "Inherited fd for startup-readiness signalling (service launch)."),
+    "AIMEE_API_REMOTE_WRITES": ("Server runtime", "Gate remote (TCP) write methods: `off` | `data` | `full`."),
+    "AIMEE_INGRESS_PROXY_SECRET": ("Server runtime", "Shared secret authenticating a trusted ingress proxy's identity headers."),
+    "AIMEE_PARALLEL_MAX": ("Server runtime", "Maximum parallel agent fan-out."),
+    "AIMEE_BACKGROUND_THREADS": ("Server runtime", "Background worker thread count."),
+    "AIMEE_COMPUTE_THREADS": ("Server runtime", "Compute-pool thread count."),
+    "AIMEE_SESSION_THREADS": ("Server runtime", "Per-session worker thread count."),
+    "AIMEE_WORKTREE_GC": ("Server runtime", "Enable/disable delegate-worktree garbage collection."),
+    "AIMEE_WORKTREE_GC_DAYS": ("Server runtime", "Age threshold (days) for worktree GC."),
+    "AIMEE_SOCK": ("Server runtime", "Sandbox helper socket path."),
+    # Knowledge base
+    "AIMEE_KB_API_URL": ("Knowledge base (aimee-kb)", "aimee-kb HTTP API base URL."),
+    "AIMEE_KB_API_BEARER_TOKEN": ("Knowledge base (aimee-kb)", "Bearer token for the aimee-kb API."),
+    "AIMEE_KB_API_CA_BUNDLE": ("Knowledge base (aimee-kb)", "CA bundle path for verifying the aimee-kb TLS certificate."),
+    "AIMEE_KB_CACHE_TTL_S": ("Knowledge base (aimee-kb)", "KB client cache TTL (seconds)."),
+    "AIMEE_KB_CONN": ("Knowledge base (aimee-kb)", "KB connection string (mTLS transport)."),
+    "AIMEE_KB_HTTP_BIND": ("Knowledge base (aimee-kb)", "aimee-kb HTTP listener bind address."),
+    "AIMEE_KB_MTLS_HOST": ("Knowledge base (aimee-kb)", "aimee-kb mTLS listener host."),
+    "AIMEE_KB_MTLS_PORT": ("Knowledge base (aimee-kb)", "aimee-kb mTLS listener port."),
+    "AIMEE_KB_EMIT_ENROLL": ("Knowledge base (aimee-kb)", "Emit a client enrollment token on KB start."),
+    "AIMEE_KB_EMIT_SCOPE": ("Knowledge base (aimee-kb)", "Scope for the emitted enrollment token."),
+    "AIMEE_KB_OIDC_ISSUER": ("Knowledge base (aimee-kb)", "OIDC issuer for KB API auth."),
+    "AIMEE_KB_OIDC_AUDIENCE": ("Knowledge base (aimee-kb)", "OIDC audience for KB API auth."),
+    "AIMEE_KB_OIDC_JWKS_FILE": ("Knowledge base (aimee-kb)", "OIDC JWKS file for KB API auth."),
+    "AIMEE_KB_OIDC_SCOPE_CLAIM": ("Knowledge base (aimee-kb)", "OIDC claim carrying the scope."),
+    "AIMEE_KB_OIDC_SCOPE_KIND": ("Knowledge base (aimee-kb)", "OIDC scope-kind interpretation."),
+    "AIMEE_VECTOR_KB_BATCH_SIZE": ("Knowledge base (aimee-kb)", "Embedding batch size for KB vector ingest."),
+    # Database & vectors
+    "AIMEE_DB2_URL": ("Database & vectors", "Postgres (DB2) connection URL for the KB store."),
+    "AIMEE_EMBEDDING_DIM": ("Database & vectors", "Embedding dimension (drives halfvec column sizing)."),
+    "AIMEE_PGVEC_SLOW_QUERY_MS": ("Database & vectors", "Slow-query log threshold (ms) for the pgvector transport."),
+    # Memory
+    "AIMEE_MEMORY_CITATIONS_MODE": ("Memory", "Citation rendering mode for memory recall."),
+    "AIMEE_MEMORY_CITATIONS_STRIP_UNVERIFIED": ("Memory", "Strip unverified citations from recall output."),
+    "AIMEE_MEMORY_COGNIFY_ASYNC_ENABLED": ("Memory", "Enable the async cognify pipeline."),
+    "AIMEE_MEMORY_COREF_MODE": ("Memory", "Coreference-resolution mode."),
+    "AIMEE_MEMORY_MAINTENANCE_TRIGGER_INSERTS": ("Memory", "Inserts before a maintenance cycle triggers."),
+    "AIMEE_MEMORY_MAINTENANCE_TRIGGER_SECS": ("Memory", "Seconds before a maintenance cycle triggers."),
+    "AIMEE_MEMORY_PAGERANK_RELATIONS": ("Memory", "Relation types included in memory PageRank."),
+    "AIMEE_MEMORY_RERANK_FORCE_OFF": ("Memory", "Force the cross-encoder reranker off."),
+    "AIMEE_MEMORY_RERANK_MODE": ("Memory", "Reranker mode."),
+    "AIMEE_MEMORY_WEIGHT_PROFILE": ("Memory", "Recall scoring weight profile."),
+    "AIMEE_NO_CACHE": ("Memory", "Disable the memory-assembly cache."),
+    "AIMEE_CONTEXT_NO_KB": ("Memory", "Skip KB lookups during context assembly."),
+    # Delegates & backends
+    "AIMEE_DELEGATE_DEPTH": ("Delegates & backends", "Current delegation depth (recursion guard)."),
+    "AIMEE_PARENT_DELEGATION_ID": ("Delegates & backends", "Parent delegation id (threading)."),
+    "AIMEE_DELEGATE_HEARTBEAT_MONITOR": ("Delegates & backends", "Enable the delegate heartbeat monitor."),
+    "AIMEE_DELEGATE_SOURCE_AUTHORITY": ("Delegates & backends", "Enable source-authority gating for delegate edits."),
+    "AIMEE_DELEGATE_SOURCE_PATHS": ("Delegates & backends", "Allowed source paths for delegate edits."),
+    "AIMEE_DELEGATE_WORKTREE_ROOT": ("Delegates & backends", "Root directory for delegate worktrees."),
+    "AIMEE_DOCKER_BIN": ("Delegates & backends", "Docker delegate-backend binary."),
+    "AIMEE_DOCKER_WORKDIR": ("Delegates & backends", "Docker delegate-backend working directory."),
+    "AIMEE_SSH_BIN": ("Delegates & backends", "SSH delegate-backend binary."),
+    "AIMEE_OPENCODE_BIN": ("Delegates & backends", "opencode CLI frontend binary."),
+    # Forge
+    "AIMEE_FORGE_API_BASE": ("Forge (GitHub App / tokens)", "Forge API base URL."),
+    "AIMEE_FORGE_APP_ID": ("Forge (GitHub App / tokens)", "GitHub App id for minting forge tokens."),
+    "AIMEE_FORGE_APP_INSTALLATION_ID": ("Forge (GitHub App / tokens)", "GitHub App installation id."),
+    "AIMEE_FORGE_APP_PRIVATE_KEY": ("Forge (GitHub App / tokens)", "GitHub App private key (PEM or path)."),
+    "AIMEE_FORGE_SCOPE": ("Forge (GitHub App / tokens)", "Scope for the minted forge token."),
+    "AIMEE_FORGE_TOKEN": ("Forge (GitHub App / tokens)", "Static forge access token (bypasses App auth)."),
+    # Gateway
+    "AIMEE_GATEWAY_NTFY_BASE_URL": ("Gateway (voice / webhooks / push)", "ntfy push base URL."),
+    "AIMEE_GATEWAY_NTFY_TOKEN": ("Gateway (voice / webhooks / push)", "ntfy push token."),
+    "AIMEE_GATEWAY_STT_PROVIDER": ("Gateway (voice / webhooks / push)", "Speech-to-text provider."),
+    "AIMEE_GATEWAY_STT_MODEL": ("Gateway (voice / webhooks / push)", "Speech-to-text model."),
+    "AIMEE_GATEWAY_TTS_PROVIDER": ("Gateway (voice / webhooks / push)", "Text-to-speech provider."),
+    "AIMEE_GATEWAY_TTS_BASE_URL": ("Gateway (voice / webhooks / push)", "Text-to-speech base URL."),
+    "AIMEE_GATEWAY_TTS_MODEL": ("Gateway (voice / webhooks / push)", "Text-to-speech model."),
+    "AIMEE_GATEWAY_TTS_VOICE": ("Gateway (voice / webhooks / push)", "Text-to-speech voice."),
+    "AIMEE_GATEWAY_WEBHOOK_PORT": ("Gateway (voice / webhooks / push)", "Inbound webhook listener port."),
+    "AIMEE_GATEWAY_WEBHOOK_SECRET": ("Gateway (voice / webhooks / push)", "Inbound webhook HMAC secret."),
+    "AIMEE_GATEWAY_WEBHOOK_INSECURE": ("Gateway (voice / webhooks / push)", "Allow the webhook listener without TLS (dev)."),
+    "AIMEE_GATEWAY_WEBHOOK_DELIVER_ONLY": ("Gateway (voice / webhooks / push)", "Webhook deliver-only mode (no reply path)."),
+    # Workflow engine
+    "AIMEE_WORKFLOW_REPO": ("Workflow engine", "Local repository directory the workflow engine operates on."),
+    "AIMEE_WORKFLOW_BASE": ("Workflow engine", "Base branch for the engine's freeze/diff."),
+    # Git verify / MCP
+    "AIMEE_VERIFY_PARALLEL": ("Git verify / MCP", "Run `aimee git verify` steps in parallel."),
+    "AIMEE_VERIFY_STEP_TIMEOUT_MS": ("Git verify / MCP", "Per-step timeout (ms) for git verify."),
+    "AIMEE_MCP_CWD": ("Git verify / MCP", "Working-directory hint for MCP git-root resolution."),
+    # Models
+    "AIMEE_MODEL_CAPABILITY_OVERRIDES": ("Models", "Override model capability flags (reasoning/tools/vision/…)."),
+    # TLS & networking
+    "AIMEE_TLS_INSECURE": ("TLS & networking", "Disable TLS certificate verification (development only)."),
+    "AIMEE_NET_DEBUG": ("TLS & networking", "Verbose network debug logging."),
+    # Plugins
+    "AIMEE_ENABLE_PROJECT_PLUGINS": ("Plugins", "Allow loading project-local plugins."),
+    # Diagnostics & misc
+    "AIMEE_ANTIPATTERNS_BYPASS": ("Diagnostics & misc", "Bypass the guardrail antipattern checks."),
+    "AIMEE_LOG_LEVEL": ("Diagnostics & misc", "Log level: `error` | `warn` | `info` | `debug`."),
+}
+
+
+def parse_env_vars():
+    """Every AIMEE_* env var read outside src/tests/ (test-only vars excluded)."""
+    found = set()
+    for f in sorted(SRC.rglob("*")):
+        if f.suffix not in (".c", ".h", ".inc") or "/tests/" in f.as_posix():
+            continue
+        for m in ENV_RE.finditer(f.read_text(encoding="utf-8", errors="ignore")):
+            found.add(m.group(1))
+    return found
+
+
+def render_env(found):
+    out = ["## Environment variables",
+           "",
+           f"The binaries read {len(found)} `AIMEE_*` environment variables (scanned "
+           "from `getenv()` in `src/`, excluding tests). They override config-store "
+           "values and are mostly for deployment/runtime wiring. Secrets/tokens should "
+           "be supplied via the environment or the credential vault, never committed.",
+           ""]
+    by_group = {}
+    undocumented = []
+    for v in sorted(found):
+        if v in ENV_DESC:
+            g, d = ENV_DESC[v]
+            by_group.setdefault(g, []).append((v, d))
+        else:
+            undocumented.append(v)
+    for g in ENV_GROUP_ORDER:
+        rows = by_group.get(g)
+        if not rows:
+            continue
+        out.append(f"### {g}")
+        out.append("")
+        out.append("| Variable | Description |")
+        out.append("|----------|-------------|")
+        for v, d in rows:
+            out.append(f"| `{v}` | {d} |")
+        out.append("")
+    # any group present in ENV_DESC but not in the order list (defensive)
+    for g in sorted(set(by_group) - set(ENV_GROUP_ORDER)):
+        out.append(f"### {g}")
+        out.append("")
+        out.append("| Variable | Description |")
+        out.append("|----------|-------------|")
+        for v, d in by_group[g]:
+            out.append(f"| `{v}` | {d} |")
+        out.append("")
+    if undocumented:
+        out.append("### Undocumented (add to `ENV_DESC` in gen-reference-docs.py)")
+        out.append("")
+        out.append("> These are read by the code but have no description yet — the "
+                   "generator surfaces them so the reference can't silently fall behind.")
+        out.append("")
+        out.append(", ".join(f"`{v}`" for v in undocumented))
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+# ─── External / provider environment (non-AIMEE_ getenv, OS-internal filtered) ─
+# Third-party + standard env vars aimee honors. Provider API-key var NAMES are
+# resolved per-agent via the agent's `api_key_env` (so the defaults below can be
+# overridden); ANTHROPIC/GEMINI/GOOGLE keys are read through that indirection
+# rather than as getenv() literals, so they are added explicitly.
+
+EXT_RE = re.compile(r'getenv\(\s*"([A-Za-z_][A-Za-z0-9_]*)"\s*\)')
+
+# standard OS / platform vars aimee reads but does not define as configuration
+EXT_OS_IGNORE = {
+    "HOME", "PATH", "PWD", "TEMP", "TMP", "TMPDIR", "LOCALAPPDATA", "APPDATA",
+    "USER", "USERNAME", "USERPROFILE", "SHELL", "PYTHONPATH",
+    "XDG_CACHE_HOME", "XDG_DATA_HOME", "XDG_CONFIG_HOME", "XDG_RUNTIME_DIR",
+}
+# provider keys resolved via per-agent api_key_env (not getenv literals) — added so
+# the reference lists them even though the static scan can't see them
+EXT_DYNAMIC = {"ANTHROPIC_API_KEY", "GEMINI_API_KEY", "GOOGLE_API_KEY"}
+
+EXT_GROUP_ORDER = ["Provider credentials", "Provider endpoints", "Reasoning effort",
+                   "Network / proxy", "Editor", "Codex / Claude integration"]
+
+EXT_DESC = {
+    "OPENAI_API_KEY": ("Provider credentials", "OpenAI API key (default for OpenAI-family agents)."),
+    "ANTHROPIC_API_KEY": ("Provider credentials", "Anthropic API key (read via the agent's `api_key_env`)."),
+    "GEMINI_API_KEY": ("Provider credentials", "Google Gemini API key (read via the agent's `api_key_env`)."),
+    "GOOGLE_API_KEY": ("Provider credentials", "Google API key fallback for Gemini (via `api_key_env`)."),
+    "GEMINI_API_KEY_AUTH_MECHANISM": ("Provider credentials", "Selects the Gemini key auth mechanism."),
+    "MISTRAL_API_KEY": ("Provider credentials", "Mistral API key."),
+    "MINIMAX_API_KEY": ("Provider credentials", "MiniMax API key."),
+    "OPENROUTER_API_KEY": ("Provider credentials", "OpenRouter API key."),
+    "OLLAMA_HOST": ("Provider endpoints", "Ollama server host/URL for local models."),
+    "LLAMA_HOST": ("Provider endpoints", "llama.cpp server host/URL."),
+    "OPENAI_REASONING_EFFORT": ("Reasoning effort", "Reasoning-effort default for OpenAI-family models."),
+    "CODEX_REASONING_EFFORT": ("Reasoning effort", "Reasoning-effort passed through the Codex frontend."),
+    "HTTPS_PROXY": ("Network / proxy", "HTTPS proxy for outbound provider/API calls."),
+    "NO_PROXY": ("Network / proxy", "Hosts excluded from proxying."),
+    "EDITOR": ("Editor", "Editor invoked for interactive edits."),
+    "VISUAL": ("Editor", "Editor invoked for interactive edits (preferred over `EDITOR`)."),
+    "CODEX_HOME": ("Codex / Claude integration", "Codex home directory (Codex-frontend integration)."),
+    "CODEX_MODEL": ("Codex / Claude integration", "Model the Codex frontend requests."),
+    "CODEX_SANDBOX": ("Codex / Claude integration", "Codex sandbox mode."),
+    "CODEX_CWD": ("Codex / Claude integration", "Working directory reported by the Codex frontend."),
+    "CODEX_THREAD_ID": ("Codex / Claude integration", "Codex conversation/thread id."),
+    "CLAUDE_SESSION_ID": ("Codex / Claude integration", "Claude Code session id when aimee runs as its backend."),
+}
+
+
+def parse_external_env():
+    found = set()
+    for f in sorted(SRC.rglob("*")):
+        if f.suffix not in (".c", ".h", ".inc") or "/tests/" in f.as_posix():
+            continue
+        for m in EXT_RE.finditer(f.read_text(encoding="utf-8", errors="ignore")):
+            v = m.group(1)
+            if v.startswith("AIMEE_") or v in EXT_OS_IGNORE:
+                continue
+            found.add(v)
+    return found | EXT_DYNAMIC
+
+
+def render_external_env(found):
+    out = ["## External & provider environment",
+           "",
+           "Standard and third-party environment variables aimee honors (scanned "
+           "non-`AIMEE_*` `getenv()` reads, plus provider keys resolved via "
+           "`api_key_env`). Provider API keys are credentials — prefer the credential "
+           "vault; the env var is the per-provider fallback and its name is "
+           "overridable per agent via `api_key_env`. Standard OS variables (`HOME`, "
+           "`PATH`, `TMPDIR`, `XDG_*`, …) are used for their usual purposes and are "
+           "not aimee configuration.",
+           ""]
+    by_group, undocumented = {}, []
+    for v in sorted(found):
+        if v in EXT_DESC:
+            g, d = EXT_DESC[v]
+            by_group.setdefault(g, []).append((v, d))
+        else:
+            undocumented.append(v)
+    for g in EXT_GROUP_ORDER + sorted(set(by_group) - set(EXT_GROUP_ORDER)):
+        rows = by_group.get(g)
+        if not rows:
+            continue
+        out.append(f"### {g}")
+        out.append("")
+        out.append("| Variable | Description |")
+        out.append("|----------|-------------|")
+        for v, d in rows:
+            out.append(f"| `{v}` | {d} |")
+        out.append("")
+    if undocumented:
+        out.append("### Undocumented (add to `EXT_DESC`/`EXT_OS_IGNORE` in gen-reference-docs.py)")
+        out.append("")
+        out.append(", ".join(f"`{v}`" for v in undocumented))
+        out.append("")
+    return "\n".join(out).rstrip() + "\n"
+
+
+# ─── Workflow engine config (src/workflow/) ───────────────────────────────────
+
+ART = {f"WFE_ART_{k.upper()}": k for k in
+       ("none", "proposal", "plan", "branch", "frozen_diff", "pr", "verdict", "approval")}
+BLOCK_ENTRY_RE = re.compile(
+    r'\{\s*WFE_BLK_\w+\s*,\s*"([^"]+)"\s*,\s*(WFE_ART_\w+)\s*,\s*\d+\s*,\s*\{([^}]*)\}')
+
+
+def parse_block_catalog():
+    text = (SRC / "workflow" / "wfe_def.c").read_text(encoding="utf-8")
+    body = text[text.index("CATALOG[] = {"):text.index("\n};", text.index("CATALOG[] = {"))]
+    cat = []
+    for m in BLOCK_ENTRY_RE.finditer(body):
+        name, produces, accepts_raw = m.groups()
+        accepts = [ART[a] for a in re.findall(r'WFE_ART_\w+', accepts_raw)
+                   if ART.get(a) and ART[a] != "none"]
+        cat.append((name, ART.get(produces, produces), accepts))
+    return cat
+
+
+def parse_engine_consts():
+    eng = (SRC / "workflow" / "wfe_engine.c").read_text(encoding="utf-8")
+    auto = (SRC / "workflow" / "wfe_autonomy.h").read_text(encoding="utf-8")
+    att = re.search(r'#define\s+WFE_MAX_ATTEMPTS\s+(\d+)', eng)
+    ovr = re.search(r'#define\s+WFE_MAX_OVERRIDES\s+(\d+)', auto)
+    return (att.group(1) if att else "?"), (ovr.group(1) if ovr else "?")
+
+
+def render_workflow(catalog, consts):
+    max_att, max_ovr = consts
+    out = ["## Workflow engine",
+           "",
+           "Workflows are block-composed YAML definitions under "
+           "`$AIMEE_HOME/workflows/<name>.yaml`, authored with the `aimee workflow` "
+           "CLI or the web visual composer and saved in canonical form. A run is a "
+           "DB1 work item pinned to a definition version.",
+           "",
+           "### Workflow definition schema",
+           "",
+           "```yaml",
+           "name: <id>                 # workflow name",
+           "start: <node-id>           # entry node (default: first node)",
+           "nodes:",
+           "  - id: <node-id>          # unique within the workflow",
+           "    block: <block-name>    # a built-in or custom block (see catalog)",
+           "    in:                    # typed input bindings (map: slot -> producer.output)",
+           "      <slot>: <node-id>.<output>",
+           "    params: { ... }        # block-specific params (see below)",
+           "    next: <node-id>        # unconditional successor",
+           "    on_pass: <node-id>     # gate verdict pass edge",
+           "    on_fail: <node-id>     # gate verdict fail edge (loop-back)",
+           "```",
+           "",
+           "### Built-in block catalog",
+           "",
+           "| Block | Produces | Accepts inputs |",
+           "|-------|----------|----------------|"]
+    for name, produces, accepts in catalog:
+        acc = ", ".join(f"`{a}`" for a in accepts) if accepts else "_(source: none)_"
+        out.append(f"| `{name}` | `{produces}` | {acc} |")
+    out += [
+        "",
+        "### Block parameters (`params:`)",
+        "",
+        "- **`gate.roundtable`** — `panel.required` (list of required reviewer "
+        "personas), `panel.eligible` (list of additional eligible personas), "
+        "`quorum` (int; effective quorum is `max(2, quorum)` and at least the "
+        "required-panel size).",
+        "- **`gate.human`** — `policy: preauthorized` (auto-approve in autonomous "
+        "mode) and/or `optional: true` (skippable). Without these, an autonomous run "
+        "parks at the gate for a human.",
+        "- Other blocks take no params today; unknown params are ignored by the "
+        "validator.",
+        "",
+        "### Custom blocks — `$AIMEE_HOME/workflows/blocks.yaml`",
+        "",
+        "Operator-owned (refused if a symlink or group/world-writable). Adds blocks "
+        "to the catalog above:",
+        "",
+        "```yaml",
+        "allow_command: false       # opt-in gate for the `command` executor (no-shell, argv-only)",
+        "blocks:",
+        "  - name: <block-name>     # must not shadow a built-in or duplicate",
+        "    consumes: <artifact>   # input artifact type, or none (a source)",
+        "    produces: branch|none  # custom blocks may NOT mint verdict/approval/pr",
+        "    executor: command|delegate",
+        "    command: [ argv0, arg1, ... ]   # executor: command (run in the repo, no shell)",
+        "    persona: <name>        # executor: delegate",
+        "    prompt: <text>         # executor: delegate",
+        "```",
+        "",
+        "### Run-level controls (not in the definition)",
+        "",
+        f"- **Per-stage loop cap** — a gate that loops back via `on_fail` is retried "
+        f"at most `{max_att}` times (`WFE_MAX_ATTEMPTS`) before the run parks; fixed, "
+        "not configurable.",
+        f"- **Gate-override cap** — a parked human gate may be overridden at most "
+        f"`{max_ovr}` times (`WFE_MAX_OVERRIDES`) before the run is forced terminal.",
+        "- **Cost cap** — an optional per-work-item USD ceiling set at run creation "
+        "(`work_item_max_cost_usd`); the engine parks the run when cumulative cost "
+        "reaches it.",
+        "- **Trigger / autonomy mode** — `interactive` vs `autonomous`, set when the "
+        "run is created.",
+        "",
+        "### Workflow environment overrides",
+        "",
+        "`AIMEE_WORKFLOW_REPO` (repo the engine operates on) and "
+        "`AIMEE_WORKFLOW_BASE` (base branch for freeze/diff) — see Environment "
+        "variables above.",
+    ]
+    return "\n".join(out).rstrip() + "\n"
+
+
+def render_limitations():
+    return "\n".join([
+        "## Coverage & limitations",
+        "",
+        "This reference is generated by scanning the canonical source tables, which "
+        "covers the scalar/keyed config surface but has known blind spots — listed "
+        "here so a reader can tell *deliberately out of scope* from *not auto-derived*:",
+        "",
+        "- **Array/object element fields** are captured when the parser iterates with "
+        "`cJSON_ArrayForEach` over a section's array; fields read through other access "
+        "patterns (`cJSON_GetArrayItem`, indexing) or nested more than one object deep "
+        "may appear only under their parent section name.",
+        "- **Env vars built at runtime** (a name assembled with `snprintf`/concatenation "
+        "and passed to `getenv(var)`) are not discoverable by the string-literal scan. "
+        "Provider API-key vars are the known case and are handled via each agent's "
+        "`api_key_env`; only the common defaults are listed.",
+        "- **Compile-time `-D` defines** used as build-level configuration are not "
+        "scanned (they are not runtime-overridable config).",
+        "- **Separate config files** — agent definitions (`agents.json`), toolsets, "
+        "guardrails policy, and per-workflow definitions — have their own schemas. "
+        "Custom workflow blocks (`blocks.yaml`) and the workflow definition schema are "
+        "documented above; the others are out of this reference's stated scope.",
+        "",
+        "If the scan ever finds a config var with no description, it is emitted under "
+        "an **Undocumented** heading in the relevant section — so a new option cannot "
+        "silently bypass this reference.",
+    ]).rstrip() + "\n"
+
+
 def main():
     check = "--check" in sys.argv
     GEN.mkdir(parents=True, exist_ok=True)
     cli = render_cli(parse_cli_commands())
-    cfg = render_config(parse_config_fields(), *parse_config_sections())
+    fields = parse_config_fields()
+    sections, flat = parse_config_sections()
+    # a key that is a CLI-settable scalar (or a section name) is not also a stray
+    # "other top-level" key — subtract both so nothing is double-listed.
+    flat = flat - {k for k, _ in fields} - set(sections)
+    cfg = render_config(fields, sections, flat)
+    cfg = (cfg.rstrip() + "\n\n"
+           + render_env(parse_env_vars()).rstrip() + "\n\n"
+           + render_external_env(parse_external_env()).rstrip() + "\n\n"
+           + render_workflow(parse_block_catalog(), parse_engine_consts()).rstrip() + "\n\n"
+           + render_limitations())
     targets = {GEN / "cli-commands.md": cli, GEN / "configuration.md": cfg}
 
     if check:


### PR DESCRIPTION
## Summary

Extends the auto-generated configuration reference (`docs/gen/configuration.md`) to cover **every** configurable surface, not just config-store keys — so "what can I configure?" has one complete, non-drifting answer. Generated from canonical source tables by `scripts/gen-reference-docs.py` (part of `make docs-gen` / `lint`'s `docs-gen-check`).

Now documented (counts auto-derived):
- **Config-store keys** — 103 CLI-settable scalars (`config get/set`) + 48 config-file sections + 5 other top-level keys, from `config_fields.c` + the `config*.c` cJSON parsers.
- **`AIMEE_*` environment** — 106 vars scanned from `getenv()` across `src/` (tests excluded), grouped (paths, client/session, server, KB, DB/vectors, memory, delegates, forge, gateway, workflow, verify/MCP, models, TLS, plugins, diagnostics) with a one-line description each.
- **External / provider environment** — provider API keys, endpoints (`OLLAMA_HOST`/`LLAMA_HOST`), proxy, editor, Codex/Claude integration (non-`AIMEE_` `getenv` literals, OS-internal filtered, + the `api_key_env`-resolved provider keys).
- **Workflow engine** — workflow definition schema, the built-in block catalog (parsed from `wfe_def.c CATALOG`), per-block params (`gate.roundtable` panel/quorum, `gate.human` policy/optional), the `blocks.yaml` custom-block schema, and run-level caps (`WFE_MAX_ATTEMPTS`, `WFE_MAX_OVERRIDES`, cost cap).
- **Coverage & limitations** — honestly discloses scan blind spots (runtime-built env names, `-D` defines, deeper nesting, separate config files like `agents.json`/toolsets/guardrails) so deliberate-omission ≠ silently-missed. Any scanned var lacking a description is emitted under an "Undocumented" heading, so a new option can't bypass the reference.

CLI commands/flags remain in the companion generated `docs/gen/cli-commands.md`.

## Generation, not hand-authoring

The point is that completeness is **structural**: the doc is derived from the same tables the binaries use, so it can't silently drift. Generator changes: de-dupe keys registered twice in `config_fields.c`; subtract CLI/section keys from the "other top-level" set; follow `cJSON_ArrayForEach` so array-valued keys (`lsp_servers`, `mcp_clients`, `cron_jobs`, `trigger_rules`, `workspaces`, …) carry their element schema.

## Validation

Run through a completeness roundtable (the explicit ask). Round 1 (4 personas) found real generator defects — 5 duplicate CLI rows, `db2_url` double-listed, array-element fields shown by name only, undisclosed blind spots — all fixed. Round 2 converged: a full-doc reviewer returned COMPLETE with every count reconciled (103 + 48 + 5 + 106), and a focused re-review of the env/workflow/limitations tail returned COMPLETE from both reviewers. `docs-gen-check` (part of `make lint`) is green.
