### PR TITLE
fix(delegate): per-turn heartbeat so slow models aren't auto-cancelled

### DIFF
--- a/src/headers/http_retry.h
+++ b/src/headers/http_retry.h
@@ -50,4 +50,13 @@ int http_retry_post_context(const char *url, const char *auth_header, const char
                             int max_attempts, int base_ms, int max_ms, const char *provider,
                             const char *model, const char *session_id);
 
+/* Register a thread-local progress callback invoked after every model HTTP
+ * attempt (decoupled from db1: the server side installs a callback that bumps the
+ * running delegate job's heartbeat). This keeps a slow-but-progressing delegate —
+ * any model whose run exceeds the stale-monitor idle threshold across multiple
+ * turns — from being auto-cancelled as "stalled" (the reason only the fastest
+ * model survived the fleet). Pass NULL to clear. */
+typedef void (*http_progress_cb_t)(void);
+void http_set_progress_cb(http_progress_cb_t cb);
+
 #endif /* DEC_HTTP_RETRY_H */

--- a/src/headers/server_delegate_monitor.h
+++ b/src/headers/server_delegate_monitor.h
@@ -32,6 +32,16 @@ extern "C"
     * without spawning the thread. */
    int server_delegate_monitor_sweep(int idle_threshold_secs, int in_tool_threshold_secs);
 
+   /* Bind/unbind a per-turn heartbeat for the in-flight background delegate on
+    * THIS thread. begin() registers an http_retry progress callback that bumps
+    * agent_jobs.heartbeat_at after every model HTTP attempt, so a slow-but-
+    * progressing delegate (each turn bounded by the agent timeout, under the
+    * stale idle threshold) is not auto-cancelled as stalled — the reason only the
+    * fastest model used to survive the fleet. job_id <= 0 is a no-op. Always pair
+    * begin() with end(). */
+   void server_delegate_heartbeat_begin(int job_id);
+   void server_delegate_heartbeat_end(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/http_retry.c
+++ b/src/server/http_retry.c
@@ -9,6 +9,15 @@
 #include <string.h>
 #include <unistd.h>
 
+/* Thread-local progress callback (see http_retry.h). Each connection/turn runs on
+ * its own worker thread, so a thread-local matches the delegate run's lifetime. */
+static _Thread_local http_progress_cb_t g_progress_cb;
+
+void http_set_progress_cb(http_progress_cb_t cb)
+{
+   g_progress_cb = cb;
+}
+
 int http_should_retry(int http_status)
 {
    failover_reason_t reason = failover_classify(NULL, http_status, NULL);
@@ -124,6 +133,12 @@ int http_retry_post_context(const char *url, const char *auth_header, const char
       aimee_log(LOG_INFO, "http_retry", "attempt %d/%d: HTTP %d (provider=%s model=%s)",
                 attempt + 1, effective_max_attempts, http_status, provider ? provider : "?",
                 model ? model : "?");
+
+      /* A completed model attempt is forward progress: refresh the running
+       * delegate's heartbeat so a slow-but-progressing job (any model slower than
+       * the stale-monitor idle threshold) is not auto-cancelled as stalled. */
+      if (g_progress_cb)
+         g_progress_cb();
 
       failover_reason_t reason =
           failover_classify(provider, http_status, response_buf ? *response_buf : NULL);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -5,6 +5,7 @@
 #include "aimee.h"
 #include "json_fluent.h" /* jo_ok */
 #include "db1.h"
+#include "server_delegate_monitor.h" /* delegate heartbeat begin/end (keep slow delegates alive) */
 #include "server_compute_impl.h"
 #include "presence.h"
 #include "compute_pool.h"
@@ -1376,10 +1377,14 @@ void delegate_worker(void *arg)
    if (saved_toolset_env && saved_toolset_env[0])
       snprintf(saved_toolset_buf, sizeof(saved_toolset_buf), "%s", saved_toolset_env);
    platform_setenv("AIMEE_ACTIVE_TOOLSET", toolset_override ? toolset_override : "");
+   /* Keep this background delegate's heartbeat fresh per model turn so a slow
+    * model is not auto-cancelled mid-progress (restores non-minimax models). */
+   server_delegate_heartbeat_begin(cctx->background_job_id);
    rc = delegate_run_with_credential_retry(&acfg, target_agent, role, system_prompt, run_prompt,
                                            max_tokens, force_tools, delegate_allows_writes,
                                            leased_cred_name, sizeof(leased_cred_name),
                                            credential_state_path, &result);
+   server_delegate_heartbeat_end();
    concurrency_release_owner(conc_slot, deleg_id);
    delegate_run_ctx_restore(&run_ctx);
    (void)db1_delegation_spawn_complete(deleg_id);

--- a/src/server/server_delegate_monitor.c
+++ b/src/server/server_delegate_monitor.c
@@ -1,6 +1,7 @@
 /* server_delegate_monitor.c: see server_delegate_monitor.h */
 
 #include "server_delegate_monitor.h"
+#include "http_retry.h" /* http_set_progress_cb */
 #include "log.h"
 
 #include <pthread.h>
@@ -18,6 +19,30 @@ int db1_agent_job_list_running_ids(int *out_ids, int max);
 int db1_agent_job_classify_stale(int job_id, int idle_threshold_secs, int in_tool_threshold_secs,
                                  char *out_state, size_t out_state_cap);
 int db1_agent_job_cancel_by_id(int job_id, const char *reason);
+void db1_agent_job_heartbeat(int job_id);
+
+/* Per-turn heartbeat for the in-flight background delegate on this thread. The
+ * http_retry progress callback fires after every model HTTP attempt; bumping the
+ * heartbeat there keeps a slow-but-progressing delegate alive (see header). */
+static _Thread_local int g_hb_job_id;
+
+static void delegate_heartbeat_cb(void)
+{
+   if (g_hb_job_id > 0)
+      db1_agent_job_heartbeat(g_hb_job_id);
+}
+
+void server_delegate_heartbeat_begin(int job_id)
+{
+   g_hb_job_id = job_id > 0 ? job_id : 0;
+   http_set_progress_cb(job_id > 0 ? delegate_heartbeat_cb : NULL);
+}
+
+void server_delegate_heartbeat_end(void)
+{
+   http_set_progress_cb(NULL);
+   g_hb_job_id = 0;
+}
 
 /* Defaults from delegate-reliability-heartbeat-and-cost-rollup.md §1. */
 #define DEFAULT_IDLE_THRESHOLD_SECS    450

--- a/src/tests/test_http_retry.c
+++ b/src/tests/test_http_retry.c
@@ -1,10 +1,52 @@
 /* test_http_retry.c: unit tests for HTTP retry with exponential backoff */
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "aimee.h"
 #include "failover.h"
 #include "http_retry.h"
+
+/* http_retry_post_context records failover events via interaction_events.o ->
+ * db1_conn; this test binary doesn't link db1. Stub it to NULL so recording
+ * no-ops (the real path guards on a NULL connection). */
+void *db1_conn(void)
+{
+   return NULL;
+}
+
+/* --- progress callback (per-turn delegate heartbeat seam) --- */
+
+static int g_progress_calls;
+static void count_progress(void)
+{
+   g_progress_calls++;
+}
+
+/* The progress callback fires once per HTTP attempt while registered, and not at
+ * all after it is cleared — the seam that lets a slow delegate bump its heartbeat
+ * each turn so the stale-monitor doesn't cancel it. Uses an unreachable endpoint
+ * so each attempt fails fast (connection refused) with a tiny backoff. */
+static void test_progress_cb_fires_per_attempt(void)
+{
+   g_progress_calls = 0;
+   http_set_progress_cb(count_progress);
+   char *resp = NULL;
+   (void)http_retry_post_context("http://127.0.0.1:1/x", NULL, "{}", &resp, 500, NULL, 2, 1, 1,
+                                 "test", "test-model", NULL);
+   free(resp);
+   http_set_progress_cb(NULL);
+   assert(g_progress_calls == 2); /* one per attempt */
+
+   /* Cleared: no further callbacks. */
+   g_progress_calls = 0;
+   resp = NULL;
+   (void)http_retry_post_context("http://127.0.0.1:1/x", NULL, "{}", &resp, 500, NULL, 1, 1, 1,
+                                 "test", "test-model", NULL);
+   free(resp);
+   assert(g_progress_calls == 0);
+   printf("  PASS: test_progress_cb_fires_per_attempt\n");
+}
 
 /* --- http_should_retry tests --- */
 
@@ -207,6 +249,7 @@ int main(void)
    test_failover_status_classification();
    test_failover_priority_and_actions();
    test_provider_specific_failover_classification();
+   test_progress_cb_fires_per_attempt();
 
    printf("all http_retry tests passed.\n");
    return 0;

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -166,6 +166,15 @@ const char *agent_get_request_vault_principal(void)
    return g_stub_vault_principal;
 }
 
+/* Delegate per-turn heartbeat (server_delegate_monitor.o not linked here). */
+void server_delegate_heartbeat_begin(int job_id)
+{
+   (void)job_id;
+}
+void server_delegate_heartbeat_end(void)
+{
+}
+
 int agent_load_config(agent_config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));


### PR DESCRIPTION
## Root cause

The degraded fleet (only minimax reliably completed roundtable reviews) was **not** the models — it was the stale monitor. A background delegate's heartbeat is bumped only at compute **setup** (`server_compute` bind/concurrency-slot), never during the agent loop. `server_delegate_monitor` auto-cancels any running job whose `updated_at` is idle past the threshold (default **450s**):

```
stale: <state> (no heartbeat progress)
```

So any model whose run exceeds ~450s — glm (slow reasoning), mistral, mimo on a large review — was cancelled **mid-progress**, while minimax finished just fast enough to survive. That made every roundtable single-model.

## Fix — bump the heartbeat once per model turn

- `http_retry` gains a **thread-local progress callback** (`http_set_progress_cb`) invoked after every model HTTP attempt — decoupled from db1.
- `server_delegate_monitor` owns the binding: `server_delegate_heartbeat_begin/end()` register a callback that bumps `db1_agent_job_heartbeat` (refreshes `updated_at`, what `classify_stale` reads) for the running job.
- `server_compute` wraps the delegate run with `begin()/end()`.

Each turn is bounded by the agent timeout (`AGENT_DEFAULT_TIMEOUT_MS=180s`), well under the 450s idle threshold — so a slow-but-progressing delegate stays alive across many turns, while a genuinely hung job (a single call exceeding the threshold, or a stuck loop) is **still reaped**. The callback lives in `server_delegate_monitor.c` to keep `server_compute.c` under the 2000-line cap.

## Test
`make -j1 verify-local` green. `unit-test-http-retry` asserts the progress callback fires once per HTTP attempt and not after it's cleared.

## Impact
Restores glm / mistral / mimo as reliable reviewers (fleet diversity), not just minimax. (codex 401 is a separate, deploy-gated vault item.)
