### PR TITLE
fix(client): native-TLS /v1 dispatch on Linux (tls: endpoint)

### DIFF
--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -306,8 +306,10 @@ static char *tcp_request(const char *url, const char *token, const char *method,
    return out;
 }
 
-int aimee_client_remote_active(char *desc_out, unsigned long desc_sz)
+int aimee_client_remote_active_scheme(char *desc_out, unsigned long desc_sz, int *is_https_out)
 {
+   if (is_https_out)
+      *is_https_out = 0;
    char url[512], tok[256];
    if (!resolve_remote(url, sizeof(url), tok, sizeof(tok)))
       return 0;
@@ -316,11 +318,20 @@ int aimee_client_remote_active(char *desc_out, unsigned long desc_sz)
       char host[256], port[16];
       int is_https = 0;
       if (parse_url(url, host, sizeof(host), port, sizeof(port), &is_https) == 0)
+      {
          snprintf(desc_out, desc_sz, "%s:%s", host, port);
+         if (is_https_out)
+            *is_https_out = is_https;
+      }
       else
          snprintf(desc_out, desc_sz, "%s", url);
    }
    return 1;
+}
+
+int aimee_client_remote_active(char *desc_out, unsigned long desc_sz)
+{
+   return aimee_client_remote_active_scheme(desc_out, desc_sz, NULL);
 }
 
 int aimee_client_remote_token(char *tok_out, unsigned long tok_sz)

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6697,28 +6697,67 @@ static char *cli_rpc_aimee_yaml_value(const char *key)
  * This is the only client path that reaches an aimee-server on another host
  * (e.g. a container's published port); the aimee-http.sock helpers above are
  * loopback-only. Caller frees. */
+/* Normalize a configured endpoint to a cli_http transport scheme. An https://
+ * URL becomes "tls:host:port" (native client TLS to the server's #304 TLS
+ * listener); http:// becomes "tcp:host:port"; an explicit tcp:/tls:/unix:
+ * endpoint passes through unchanged. Caller frees. */
+static char *cli_rpc_normalize_endpoint(const char *ep)
+{
+   if (!ep || !ep[0])
+      return NULL;
+   const char *scheme = NULL;
+   const char *rest = NULL;
+   if (strncmp(ep, "https://", 8) == 0)
+   {
+      scheme = "tls:";
+      rest = ep + 8;
+   }
+   else if (strncmp(ep, "http://", 7) == 0)
+   {
+      scheme = "tcp:";
+      rest = ep + 7;
+   }
+   if (!scheme)
+      return strdup(ep); /* tcp:/tls:/unix:/host:port already */
+   /* Take host[:port], dropping any trailing path; default the port by scheme. */
+   char hostport[300];
+   size_t n = strcspn(rest, "/");
+   if (n >= sizeof(hostport))
+      n = sizeof(hostport) - 1;
+   memcpy(hostport, rest, n);
+   hostport[n] = '\0';
+   char out[320];
+   if (strchr(hostport, ':'))
+      snprintf(out, sizeof(out), "%s%s", scheme, hostport);
+   else
+      snprintf(out, sizeof(out), "%s%s:%s", scheme, hostport,
+               strcmp(scheme, "tls:") == 0 ? "443" : "80");
+   return strdup(out);
+}
+
 char *cli_rpc_client_endpoint(void)
 {
    const char *env = getenv("AIMEE_API_ENDPOINT");
    if (env && env[0])
-      return strdup(env);
+      return cli_rpc_normalize_endpoint(env);
    char *yaml = cli_rpc_aimee_yaml_value("client_endpoint:");
    if (yaml)
-      return yaml;
+   {
+      char *norm = cli_rpc_normalize_endpoint(yaml);
+      free(yaml);
+      return norm;
+   }
    /* Fall back to a --server / AIMEE_SERVER_URL / remote.conf target (aimee_client)
-    * by synthesizing the "tcp:host:port" endpoint cli_http_request expects. This
-    * is what makes the README's headline remote flow drive the WHOLE data/RPC
-    * plane (status, memory, kb, …), not just the lower-level AIMEE_API_ENDPOINT
-    * form. http reaches the published container port directly; an https:// target
-    * needs a TLS-terminating proxy, the same as the AIMEE_API_ENDPOINT tcp:
-    * transport. Keeping the bridge here (vs. cli_v1_send) means the shared
-    * dispatcher references no networking symbols, so the server/gateway/tests that
-    * link it pull only the dependency-free aimee_client resolver. */
+    * by synthesizing the transport endpoint cli_http_request expects: "tls:" for
+    * an https:// target (native client TLS, #304), else "tcp:". This makes the
+    * README's headline remote flow drive the WHOLE data/RPC plane (status,
+    * memory, kb, …), not just the lower-level AIMEE_API_ENDPOINT form. */
    char hostport[300];
-   if (aimee_client_remote_active(hostport, sizeof(hostport)))
+   int is_https = 0;
+   if (aimee_client_remote_active_scheme(hostport, sizeof(hostport), &is_https))
    {
       char ep[320];
-      snprintf(ep, sizeof(ep), "tcp:%s", hostport);
+      snprintf(ep, sizeof(ep), "%s%s", is_https ? "tls:" : "tcp:", hostport);
       return strdup(ep);
    }
    return NULL;

--- a/src/cli_rpc_routes.inc
+++ b/src/cli_rpc_routes.inc
@@ -6726,12 +6726,15 @@ static char *cli_rpc_normalize_endpoint(const char *ep)
       n = sizeof(hostport) - 1;
    memcpy(hostport, rest, n);
    hostport[n] = '\0';
+   /* Strip any userinfo ("user:pass@host") so it can't corrupt the host:port the
+    * TLS/connect layer parses; credentials belong in the bearer, not the URL. */
+   char *at = strrchr(hostport, '@');
+   char *hp = at ? at + 1 : hostport;
    char out[320];
-   if (strchr(hostport, ':'))
-      snprintf(out, sizeof(out), "%s%s", scheme, hostport);
+   if (strchr(hp, ':'))
+      snprintf(out, sizeof(out), "%s%s", scheme, hp);
    else
-      snprintf(out, sizeof(out), "%s%s:%s", scheme, hostport,
-               strcmp(scheme, "tls:") == 0 ? "443" : "80");
+      snprintf(out, sizeof(out), "%s%s:%s", scheme, hp, strcmp(scheme, "tls:") == 0 ? "443" : "80");
    return strdup(out);
 }
 

--- a/src/headers/aimee_client.h
+++ b/src/headers/aimee_client.h
@@ -53,6 +53,11 @@ extern "C"
     * diagnostics; desc_sz is its buffer size. */
    int aimee_client_remote_active(char *desc_out, unsigned long desc_sz);
 
+   /* Like aimee_client_remote_active, but also reports via *is_https_out whether
+    * the resolved target is an https:// URL (so callers can select the tls:
+    * vs tcp: transport scheme). is_https_out may be NULL. */
+   int aimee_client_remote_active_scheme(char *desc_out, unsigned long desc_sz, int *is_https_out);
+
    /* Returns 1 if a remote target is in effect and copies its bearer token (the
     * second remote.conf line / --server-token / AIMEE_SERVER_TOKEN) into *tok_out
     * (empty string when the target has no token), else 0. Dependency-free (no

--- a/src/posix/cli_client.c
+++ b/src/posix/cli_client.c
@@ -10,6 +10,9 @@
 #include "cli_server_compat.h"
 #include "platform_path.h"
 #include "cJSON.h"
+#ifdef WITH_TLS
+#include "aimee_tls.h" /* native-TLS /v1 transport for a tls: endpoint */
+#endif
 #define RPC_PROTOCOL_VERSION 1
 #include <signal.h>
 #include <stdio.h>
@@ -366,9 +369,11 @@ static int cli_http_connect(const char *endpoint, char *host_out, size_t host_n,
       return fd;
    }
 
-   /* TCP: "[tcp:]host:port". Split host (DNS / IPv4 / bracketed IPv6) and port. */
+   /* TCP: "[tcp:|tls:]host:port". Split host (DNS / IPv4 / bracketed IPv6) and
+    * port. A "tls:" endpoint connects the same TCP socket; the caller wraps it in
+    * a TLS handshake (cli_http_request). */
    const char *hp = endpoint;
-   if (strncmp(hp, "tcp:", 4) == 0)
+   if (strncmp(hp, "tcp:", 4) == 0 || strncmp(hp, "tls:", 4) == 0)
       hp += 4;
    char host[256];
    const char *port_str;
@@ -452,6 +457,113 @@ static int cli_http_connect(const char *endpoint, char *host_out, size_t host_n,
    return out_fd;
 }
 
+/* Transport write/read over either a plaintext fd or a TLS session (tlsp set).
+ * Mirrors aimee_client.c's io abstraction so the same request/response loop
+ * serves both a tcp: and a tls: endpoint. */
+static int cli_conn_write_all(int fd, void *tlsp, const void *buf, size_t len)
+{
+#ifdef WITH_TLS
+   if (tlsp)
+      return aimee_tls_write_all((aimee_tls_t *)tlsp, buf, len);
+#else
+   (void)tlsp;
+#endif
+   size_t total = 0;
+   while (total < len)
+   {
+      ssize_t n = write(fd, (const char *)buf + total, len - total);
+      if (n < 0)
+      {
+         if (errno == EINTR)
+            continue;
+         return -1;
+      }
+      total += (size_t)n;
+   }
+   return 0;
+}
+
+static long cli_conn_read(int fd, void *tlsp, void *buf, size_t len)
+{
+#ifdef WITH_TLS
+   if (tlsp)
+      return aimee_tls_read((aimee_tls_t *)tlsp, buf, len);
+#else
+   (void)tlsp;
+#endif
+   for (;;)
+   {
+      ssize_t n = read(fd, buf, len);
+      if (n < 0 && errno == EINTR)
+         continue;
+      return n;
+   }
+}
+
+/* Send an HTTP request and read the full response (server closes the conn) over
+ * an already-connected transport. Returns a malloc'd NUL-terminated buffer
+ * (caller frees) or NULL on error. */
+static char *cli_http_txn(int fd, void *tlsp, const char *method, const char *path,
+                          const char *host, const char *bearer, const char *body_json,
+                          int timeout_ms)
+{
+   size_t blen = body_json ? strlen(body_json) : 0;
+   size_t reqcap = blen + strlen(path) + strlen(host) + (bearer ? strlen(bearer) : 0) + 256;
+   char *req = malloc(reqcap);
+   if (!req)
+      return NULL;
+   int reqlen = cli_http_build_request(method, path, host, bearer, body_json, req, reqcap);
+   if (reqlen < 0 || cli_conn_write_all(fd, tlsp, req, (size_t)reqlen) != 0)
+   {
+      free(req);
+      return NULL;
+   }
+   free(req);
+
+   size_t cap = 8192, len = 0;
+   char *buf = malloc(cap);
+   if (!buf)
+      return NULL;
+   for (;;)
+   {
+      struct pollfd pfd = {.fd = fd, .events = POLLIN};
+      int rc = poll(&pfd, 1, timeout_ms);
+      if (rc <= 0)
+      {
+         free(buf);
+         return NULL;
+      }
+      if (len + 4096 > cap)
+      {
+         if (cap >= CLIENT_MAX_RESPONSE_SIZE)
+         {
+            free(buf);
+            return NULL;
+         }
+         size_t next = cap * 2;
+         char *grown = realloc(buf, next);
+         if (!grown)
+         {
+            free(buf);
+            return NULL;
+         }
+         buf = grown;
+         cap = next;
+      }
+      long n = cli_conn_read(fd, tlsp, buf + len, cap - len - 1);
+      if (n < 0)
+      {
+         free(buf);
+         return NULL;
+      }
+      if (n == 0)
+         break; /* EOF */
+      len += (size_t)n;
+   }
+   buf[len] = '\0';
+   return buf;
+}
+
 cJSON *cli_http_request(const char *endpoint, const char *method, const char *path,
                         const char *body_json, const char *bearer, int timeout_ms, int *http_status)
 {
@@ -463,95 +575,38 @@ cJSON *cli_http_request(const char *endpoint, const char *method, const char *pa
       timeout_ms = CLIENT_DEFAULT_TIMEOUT_MS;
 
    char host[256];
+   int is_tls = (strncmp(endpoint, "tls:", 4) == 0);
    int fd = cli_http_connect(endpoint, host, sizeof(host), timeout_ms);
    if (fd < 0)
       return NULL;
 
-   /* Build the request (sized for headers + body + slack). */
-   size_t blen = body_json ? strlen(body_json) : 0;
-   size_t reqcap = blen + strlen(path) + strlen(host) + (bearer ? strlen(bearer) : 0) + 256;
-   char *req = malloc(reqcap);
-   if (!req)
+   /* A tls: endpoint terminates TLS natively in the client (the server's
+    * native-TLS listener, #304). The TLS session wraps the connected fd; without
+    * WITH_TLS a tls: endpoint is unsupported. */
+   void *tls = NULL;
+   if (is_tls)
    {
+#ifdef WITH_TLS
+      tls = aimee_tls_connect(fd, host);
+      if (!tls)
+      {
+         close(fd);
+         return NULL;
+      }
+#else
       close(fd);
       return NULL;
-   }
-   int reqlen = cli_http_build_request(method, path, host, bearer, body_json, req, reqcap);
-   if (reqlen < 0)
-   {
-      free(req);
-      close(fd);
-      return NULL;
+#endif
    }
 
-   size_t total = 0;
-   while (total < (size_t)reqlen)
-   {
-      ssize_t n = write(fd, req + total, (size_t)reqlen - total);
-      if (n < 0)
-      {
-         if (errno == EINTR)
-            continue;
-         free(req);
-         close(fd);
-         return NULL;
-      }
-      total += (size_t)n;
-   }
-   free(req);
-
-   /* Read the full response (server sends Connection: close, so read to EOF). */
-   size_t cap = 8192, len = 0;
-   char *buf = malloc(cap);
-   if (!buf)
-   {
-      close(fd);
-      return NULL;
-   }
-   for (;;)
-   {
-      struct pollfd pfd = {.fd = fd, .events = POLLIN};
-      int rc = poll(&pfd, 1, timeout_ms);
-      if (rc <= 0)
-      {
-         free(buf);
-         close(fd);
-         return NULL;
-      }
-      if (len + 4096 > cap)
-      {
-         if (cap >= CLIENT_MAX_RESPONSE_SIZE)
-         {
-            free(buf);
-            close(fd);
-            return NULL;
-         }
-         size_t next = cap * 2;
-         char *grown = realloc(buf, next);
-         if (!grown)
-         {
-            free(buf);
-            close(fd);
-            return NULL;
-         }
-         buf = grown;
-         cap = next;
-      }
-      ssize_t n = read(fd, buf + len, cap - len - 1);
-      if (n < 0)
-      {
-         if (errno == EINTR)
-            continue;
-         free(buf);
-         close(fd);
-         return NULL;
-      }
-      if (n == 0)
-         break; /* EOF */
-      len += (size_t)n;
-   }
+   char *buf = cli_http_txn(fd, tls, method, path, host, bearer, body_json, timeout_ms);
+#ifdef WITH_TLS
+   if (tls)
+      aimee_tls_free(tls);
+#endif
    close(fd);
-   buf[len] = '\0';
+   if (!buf)
+      return NULL;
 
    /* Status line: "HTTP/1.1 <code> <reason>". */
    int status = 0;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -29,7 +29,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/tests/server/kb_client_tool_registry.o $(OBJDIR)/server/kb_client_prospective.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cli_client.o \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
-                             $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
+                             $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
 	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
@@ -773,7 +773,7 @@ $(TESTPREFIX)/unit-test-workspace-memory: $(OBJDIR)/tests/test_workspace_memory.
 
 $(TESTPREFIX)/unit-test-dashboard: $(OBJDIR)/tests/test_dashboard.o \
                           $(OBJDIR)/dashboard.o $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/dashboard_server.o $(OBJDIR)/plugin.o $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o \
-                          $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o $(DB1_OBJS) \
+                          $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(DB1_OBJS) \
                           $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/decision_log.o \
                           $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \
                           $(OBJDIR)/yaml.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
@@ -853,7 +853,7 @@ $(TESTPREFIX)/unit-test-kb-client-search: $(OBJDIR)/tests/test_kb_client_search.
 	                                  $(OBJDIR)/server/kb_client_cache.o \
 	                                  $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/server/kb_client_index_parse.o \
-	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
+	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS)
@@ -865,7 +865,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 	                                  $(OBJDIR)/server/kb_client_memory.o \
 	                                  $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o \
 	                                  $(OBJDIR)/server/kb_client_index_parse.o \
-	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
+	                                  $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
 	                                  $(OBJDIR)/tests/support/mock_agent_http.o \
 	                                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o $(OBJDIR)/cJSON.o \
 	                                  $(PLATFORM_BASIC_OBJS)
@@ -1137,7 +1137,7 @@ $(TESTPREFIX)/unit-test-gateway-telegram: $(OBJDIR)/tests/test_gateway_telegram.
                                           $(OBJDIR)/gateway/tts.o \
                                           $(OBJDIR)/delivery_target.o \
                                           $(OBJDIR)/posix/agent_bridge.o \
-                                          $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
+                                          $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                                           $(OBJDIR)/proxy_bootstrap.o \
                                           $(OBJDIR)/cJSON.o \
                                           $(OBJDIR)/log.o \
@@ -1161,7 +1161,7 @@ $(TESTPREFIX)/unit-test-gateway-ntfy-webhook: $(OBJDIR)/tests/test_gateway_ntfy_
                                               $(OBJDIR)/gateway/tts.o \
                                               $(OBJDIR)/delivery_target.o \
                                               $(OBJDIR)/posix/agent_bridge.o \
-                                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
+                                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                                               $(OBJDIR)/proxy_bootstrap.o \
                                               $(OBJDIR)/cJSON.o \
                                               $(OBJDIR)/log.o \
@@ -1228,7 +1228,7 @@ $(TESTPREFIX)/unit-test-openai-runs-store: $(OBJDIR)/tests/test_openai_runs_stor
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-http-transport: $(OBJDIR)/tests/test_cli_http_transport.o \
-                                            $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
+                                            $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                                             $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1258,7 +1258,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(DB2_OBJS) \
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
-                            $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/codex_auth.o \
+                            $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
                             $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/mcp_git_write.o \
                             $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)


### PR DESCRIPTION
## Problem

The Linux thin client can't speak **native TLS** to the server's `/v1` surface. `cli_v1_send` routes a configured remote through `cli_http_request` (plaintext `tcp:` or UDS) and only uses the TLS-capable `aimee_client_request` on **Windows** (`#else` branch). So `aimee agent key import` — and every `/v1` dispatch — over the server's native-TLS listener (#304) fails on Linux with:

```
could not reach the aimee-server /v1 endpoint
```

This broke the documented **TLS credential-provisioning flow** (the only network path allowed to write the server-principal vault). Discovered while deploying the vault consolidation to the live server, where I had to provision via raw `python+ssl` POSTs as a workaround.

## Fix

- **`cli_http_request` (posix) is TLS-aware**: a `tls:host:port` endpoint wraps the connected socket in `aimee_tls` (under `WITH_TLS`). Send/recv factored into `cli_http_txn` + `cli_conn_write_all`/`cli_conn_read` so one request/response loop serves both plaintext and TLS (mirrors `aimee_client.c`'s io abstraction).
- **`cli_http_connect`** accepts the `tls:` scheme (connects the same TCP socket; the caller does the handshake).
- **`cli_rpc_client_endpoint`** normalizes `https://` → `tls:host:port` (and `http://` → `tcp:`); the `--server`/`AIMEE_SERVER_URL` fallback selects `tls:` vs `tcp:` by scheme via the new `aimee_client_remote_active_scheme()`.
- Without `WITH_TLS`, a `tls:` endpoint fails cleanly.

## Tests / verification
- `make -j1 verify-local` green. Tests that link `posix/cli_client.o` now also link `aimee_tls.o` (it references TLS under `WITH_TLS`; `L_FULL` already provides `-lssl/-lcrypto`).
- **Live**: built `WITH_TLS`; `agent list` and `agent key import` over `tls:<server>:8742` (insecure-verify + bearer) reach the native-TLS listener and vault all 4 keys — the same calls previously failed on Linux.

## Follow-up
Native-TLS provisioning is now first-class on Linux: `AIMEE_API_ENDPOINT=tls:host:port` (or `https://`) + `AIMEE_API_BEARER` + `AIMEE_TLS_INSECURE` for a self-signed cert.
