### PR TITLE
fix(coord): don't mangle diffs/code in @-file-reference resolution

### DIFF
--- a/src/server/agent_coord.c
+++ b/src/server/agent_coord.c
@@ -51,7 +51,10 @@ char *resolve_file_references(const char *prompt, const char *project_root)
       }
 
       const char *path_start = p + 1;
-      if (!*path_start || !is_path_char(*path_start))
+      /* Not a file reference: end-of-string, a non-path char, or a doubled '@'
+       * (a unified-diff hunk header "@@ -a,b +c,d @@"). Emit the '@' literally so
+       * diffs/code carried in the prompt are never corrupted. */
+      if (!*path_start || !is_path_char(*path_start) || *path_start == '@')
       {
          dstr_append_char(&out, *p++);
          continue;
@@ -71,14 +74,6 @@ char *resolve_file_references(const char *prompt, const char *project_root)
       memcpy(rel_path, path_start, path_len);
       rel_path[path_len] = '\0';
 
-      /* Past the limit: leave the reference unresolved with an explicit marker. */
-      if (refs_resolved >= FILE_REF_MAX_REFS)
-      {
-         dstr_appendf(&out, "[file reference limit reached: @%s left unresolved]", rel_path);
-         p = path_end;
-         continue;
-      }
-
       char abs_path[MAX_PATH_LEN];
       if (rel_path[0] == '/')
          snprintf(abs_path, sizeof(abs_path), "%s", rel_path);
@@ -87,30 +82,33 @@ char *resolve_file_references(const char *prompt, const char *project_root)
       else
          snprintf(abs_path, sizeof(abs_path), "%s", rel_path);
 
+      /* Only an EXISTING, in-project file is treated as a reference. A @token that
+       * escapes the root or doesn't resolve to a real file is emitted LITERALLY
+       * and is NOT counted against the budget: prompts routinely carry diffs and
+       * code whose '@' tokens (decorators like @property, emails, doc tags, diff
+       * hunk headers) are not file references, and rewriting them as markers
+       * corrupted the content and exhausted the ref budget (the roundtable
+       * "sandbox-blind" failure). */
       size_t abs_len = strlen(abs_path);
-      if (strstr(abs_path, "/../") != NULL ||
-          (abs_len >= 3 && strcmp(abs_path + abs_len - 3, "/..") == 0))
-      {
-         dstr_appendf(&out, "[file outside project: @%s]", rel_path);
-         p = path_end;
-         refs_resolved++;
-         continue;
-      }
-
-      if (project_root && project_root[0] && !path_within_root(project_root, abs_path))
-      {
-         dstr_appendf(&out, "[file outside project: @%s]", rel_path);
-         p = path_end;
-         refs_resolved++;
-         continue;
-      }
-
-      FILE *f = fopen(abs_path, "r");
+      int escapes = (strstr(abs_path, "/../") != NULL ||
+                     (abs_len >= 3 && strcmp(abs_path + abs_len - 3, "/..") == 0));
+      int in_root = !(project_root && project_root[0]) || path_within_root(project_root, abs_path);
+      FILE *f = (!escapes && in_root) ? fopen(abs_path, "r") : NULL;
       if (!f)
       {
-         dstr_appendf(&out, "[file not found: @%s]", rel_path);
+         dstr_append_char(&out, '@');
+         dstr_append(&out, rel_path, path_len);
          p = path_end;
-         refs_resolved++;
+         continue;
+      }
+
+      /* A real file past the per-prompt budget: explicit marker (diff/code never
+       * reaches here — its non-file @tokens are left literal above). */
+      if (refs_resolved >= FILE_REF_MAX_REFS)
+      {
+         dstr_appendf(&out, "[file reference limit reached: @%s left unresolved]", rel_path);
+         fclose(f);
+         p = path_end;
          continue;
       }
 

--- a/src/tests/test_file_ref.c
+++ b/src/tests/test_file_ref.c
@@ -64,43 +64,63 @@ static void test_no_references_passthrough(void)
    printf("  no_references_passthrough: ok\n");
 }
 
-static void test_nonexistent_file_error(void)
+static void test_nonexistent_file_literal(void)
 {
+   /* A @token that isn't a real in-project file is left LITERAL (not a marker),
+    * so diffs/code carried in a prompt are never corrupted. */
    char *out = resolve_file_references("see @nonexistent.c for details", g_tmpdir);
    assert(out != NULL);
-   assert(strstr(out, "[file not found: @nonexistent.c]") != NULL);
+   assert(strstr(out, "@nonexistent.c") != NULL);
+   assert(strstr(out, "[file not found") == NULL);
    free(out);
 
-   printf("  nonexistent_file_error: ok\n");
+   printf("  nonexistent_file_literal: ok\n");
 }
 
-static void test_path_outside_project_rejected(void)
+static void test_path_outside_project_literal(void)
 {
-   /* Absolute path clearly outside tmpdir */
-   char prompt[256];
-   snprintf(prompt, sizeof(prompt), "read @/etc/passwd please");
-
-   char *out = resolve_file_references(prompt, g_tmpdir);
+   /* An absolute path outside the project is left literal and NEVER inlined. */
+   char *out = resolve_file_references("read @/etc/passwd please", g_tmpdir);
    assert(out != NULL);
-   assert(strstr(out, "[file outside project: @/etc/passwd]") != NULL);
-   /* Must NOT contain file content */
+   assert(strstr(out, "@/etc/passwd") != NULL);
+   assert(strstr(out, "root:") == NULL); /* content must not leak */
+   assert(strstr(out, "[file outside project") == NULL);
+   free(out);
+
+   printf("  path_outside_project_literal: ok\n");
+}
+
+static void test_traversal_literal(void)
+{
+   /* A path-traversal @token is left literal and never inlined. */
+   char *out = resolve_file_references("read @../../../etc/shadow", g_tmpdir);
+   assert(out != NULL);
+   assert(strstr(out, "@../../../etc/shadow") != NULL);
    assert(strstr(out, "root:") == NULL);
    free(out);
 
-   printf("  path_outside_project_rejected: ok\n");
+   printf("  traversal_literal: ok\n");
 }
 
-static void test_traversal_rejected(void)
+static void test_diff_passthrough(void)
 {
-   char prompt[256];
-   snprintf(prompt, sizeof(prompt), "read @../../../etc/shadow");
-
-   char *out = resolve_file_references(prompt, g_tmpdir);
+   /* The regression that made roundtables "sandbox-blind": a unified diff in the
+    * prompt must pass through unmangled — @@ hunk headers, decorators and emails
+    * are not file references. */
+   const char *diff = "diff --git a/x.py b/x.py\n"
+                      "@@ -1,3 +1,4 @@\n"
+                      " @property\n"
+                      "-old\n"
+                      "+new  # ping a@b.com\n";
+   char *out = resolve_file_references(diff, g_tmpdir);
    assert(out != NULL);
-   assert(strstr(out, "[file outside project:") != NULL);
+   assert(strstr(out, "@@ -1,3 +1,4 @@") != NULL); /* hunk header intact */
+   assert(strstr(out, "@property") != NULL);       /* decorator intact */
+   assert(strstr(out, "a@b.com") != NULL);         /* email intact */
+   assert(strstr(out, "[file") == NULL);           /* no markers injected */
    free(out);
 
-   printf("  traversal_rejected: ok\n");
+   printf("  diff_passthrough: ok\n");
 }
 
 static void test_max_3_refs_respected(void)
@@ -108,17 +128,18 @@ static void test_max_3_refs_respected(void)
    write_file("a.txt", "file A");
    write_file("b.txt", "file B");
    write_file("c.txt", "file C");
+   write_file("d.txt", "file D");
 
-   /* 4 references — first 3 should be resolved, 4th left as-is */
+   /* 4 references to REAL files — first 3 resolve, 4th hits the budget. (The
+    * limit applies only to real files now; a non-file 4th token would just be
+    * left literal.) */
    char *out = resolve_file_references("read @a.txt and @b.txt and @c.txt and @d.txt", g_tmpdir);
    assert(out != NULL);
    assert(strstr(out, "file A") != NULL);
    assert(strstr(out, "file B") != NULL);
    assert(strstr(out, "file C") != NULL);
-   /* 4th reference: d.txt is not resolved and the truncation is explicit */
+   assert(strstr(out, "file D") == NULL); /* 4th not inlined */
    assert(strstr(out, "[file reference limit reached: @d.txt left unresolved]") != NULL);
-   /* 4th reference must NOT produce a [file not found] marker */
-   assert(strstr(out, "[file not found: @d.txt]") == NULL);
    free(out);
 
    printf("  max_3_refs_respected: ok\n");
@@ -162,9 +183,10 @@ int main(void)
 
    test_valid_reference_inlined();
    test_no_references_passthrough();
-   test_nonexistent_file_error();
-   test_path_outside_project_rejected();
-   test_traversal_rejected();
+   test_nonexistent_file_literal();
+   test_path_outside_project_literal();
+   test_traversal_literal();
+   test_diff_passthrough();
    test_max_3_refs_respected();
    test_large_file_truncated();
    test_at_without_path_literal();


### PR DESCRIPTION
## Problem

`resolve_file_references` treated **every** `@<token>` in a prompt as a file reference. A unified diff carried in a delegate prompt was therefore corrupted:
- `@@ -1,3 +1,4 @@` hunk headers → parsed as refs
- decorators (`@property`), emails (`a@b.com`), doc tags → parsed as refs
- each emitted `[file not found]` / `[file reference limit reached: @@ ...]` markers and burned the 3-ref budget

This is a primary cause of roundtable reviews coming back **"sandbox-blind"** — the reviewer received a mangled, marker-riddled diff it couldn't read, so it (correctly) refused to invent findings.

## Fix

A `@token` is only treated as a reference when it resolves to an **existing, in-project file**:
- `@@` (diff hunk header) → emitted literally.
- A `@token` that isn't a real in-root file → left **literal** and **not counted** against the budget (escape/outside-root tokens too; content still never inlined).
- The inline + the 3-ref limit apply only to real files, so a genuine `@src/foo.c` still resolves exactly as before.

## Tests
`make -j1 verify-local` green. `nonexistent`/`outside`/`traversal` now assert literal passthrough; the max-refs test uses 4 real files; new **`diff_passthrough`** asserts a unified diff (hunk headers + decorator + email) survives unmangled with no markers injected.

## Note
This stops prompt-carried diffs/code from being corrupted — worth landing on its own. It is **not** the full roundtable fix (the reviewer still has no *live* access to the client's files); that's the separate "reverse-channel file tools" (C) work.
