### PR TITLE
feat(delegate): bind detached client workspace so server-side delegates read live client files

### DIFF
--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -1346,15 +1346,16 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
     * session. Skipped when the target is already inside an aimee worktree or a
     * linked git worktree.
     *
-    * Also skipped when a `detached` workspace provider is active: that workspace
-    * is filesystem-authority on the CLIENT, so its file/exec tools marshal over
-    * the reverse channel — forcing them into a server-side worktree would rewrite
-    * paths to a checkout that does not exist on the client. Leave the path/command
-    * untouched and let the detached provider route it. */
+    * The PATH-tool branch is skipped when a `detached` workspace provider is
+    * active: that workspace is filesystem-authority on the CLIENT, so its file
+    * tools marshal over the reverse channel — forcing them into a server-side
+    * worktree would rewrite paths to a checkout that does not exist on the client.
+    * Shell tools are NOT exempted: bash still forks server-side (not yet
+    * marshalled), so it must keep worktree containment regardless of provider. */
    const workspace_provider_t *gr_ws_active = workspace_provider_active();
    int gr_detached_active = gr_ws_active && gr_ws_active->kind == WS_PROVIDER_DETACHED;
-   if (!gr_detached_active &&
-       (is_path_tool(tool_name) || (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd))))
+   if ((is_path_tool(tool_name) && !gr_detached_active) ||
+       (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd)))
    {
       /* Determine target path */
       const char *target = effective_cwd;

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -12,6 +12,7 @@
 #include "computer_use.h"
 #include "guardrails_internal.h"
 #include "guardrails_semantic.h"
+#include "workspace_provider.h" /* skip worktree enforcement for a detached (client) workspace */
 #include "headers/config.h"
 #include "headers/git_verify.h"
 #include "headers/skill.h"
@@ -1343,8 +1344,17 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
    /* Worktree enforcement: force file/path tools and all shell commands that
     * would run in the source checkout into the aimee-managed worktree for this
     * session. Skipped when the target is already inside an aimee worktree or a
-    * linked git worktree. */
-   if (is_path_tool(tool_name) || (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd)))
+    * linked git worktree.
+    *
+    * Also skipped when a `detached` workspace provider is active: that workspace
+    * is filesystem-authority on the CLIENT, so its file/exec tools marshal over
+    * the reverse channel — forcing them into a server-side worktree would rewrite
+    * paths to a checkout that does not exist on the client. Leave the path/command
+    * untouched and let the detached provider route it. */
+   const workspace_provider_t *gr_ws_active = workspace_provider_active();
+   int gr_detached_active = gr_ws_active && gr_ws_active->kind == WS_PROVIDER_DETACHED;
+   if (!gr_detached_active &&
+       (is_path_tool(tool_name) || (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd))))
    {
       /* Determine target path */
       const char *target = effective_cwd;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1377,14 +1377,16 @@ void delegate_worker(void *arg)
    if (saved_toolset_env && saved_toolset_env[0])
       snprintf(saved_toolset_buf, sizeof(saved_toolset_buf), "%s", saved_toolset_env);
    platform_setenv("AIMEE_ACTIVE_TOOLSET", toolset_override ? toolset_override : "");
-   /* Keep this background delegate's heartbeat fresh per model turn so a slow
-    * model is not auto-cancelled mid-progress (restores non-minimax models). */
+   /* Bind detached workspace: delegate reads the client's live files (no-op if shared). */
+   int detached_bound = cwd[0] ? workspace_turn_bind_active(cwd) : 0;
    server_delegate_heartbeat_begin(cctx->background_job_id);
    rc = delegate_run_with_credential_retry(&acfg, target_agent, role, system_prompt, run_prompt,
                                            max_tokens, force_tools, delegate_allows_writes,
                                            leased_cred_name, sizeof(leased_cred_name),
                                            credential_state_path, &result);
    server_delegate_heartbeat_end();
+   if (detached_bound)
+      workspace_turn_unbind_active();
    concurrency_release_owner(conc_slot, deleg_id);
    delegate_run_ctx_restore(&run_ctx);
    (void)db1_delegation_spawn_complete(deleg_id);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1385,10 +1385,10 @@ void delegate_worker(void *arg)
                                            leased_cred_name, sizeof(leased_cred_name),
                                            credential_state_path, &result);
    server_delegate_heartbeat_end();
-   if (detached_bound)
-      workspace_turn_unbind_active();
    concurrency_release_owner(conc_slot, deleg_id);
    delegate_run_ctx_restore(&run_ctx);
+   if (detached_bound) /* unbind last: keep the binding live for any teardown that consults it */
+      workspace_turn_unbind_active();
    (void)db1_delegation_spawn_complete(deleg_id);
 
    /* Post-run named-file drift check: verify named existing paths appear in response. */


### PR DESCRIPTION
## Summary

Makes server-side delegates (roundtable reviewers, ensemble panelists) operate on the **thin client's live files** instead of the server filesystem — the fix for "sandbox-blind" roundtables. This is the **C** architecture: agents run on aimee-server, but their file tools marshal back to the originating thin client over the runner reverse channel.

## What changed

- **`server_compute.c` (`delegate_worker`)** — when a delegate's originating `cwd` resolves to a `detached` (client-served) workspace, `workspace_turn_bind_active(cwd)` activates the detached provider for the model turn (unbind after `delegate_run_ctx_restore`). No-op for shared workspaces.
- **`guardrails_orchestrator.c` (`pre_tool_check`)** — skip the worktree path-rewrite **for path tools only** when a detached provider is active. Shell tools keep worktree enforcement (bash still forks server-side; not yet marshalled).

## Validation

- `make -j1 verify-local` green.
- Proven end-to-end locally: a server-side review delegate's `read_file` routed through the detached provider to the client and returned the client's live file contents.

## Roundtable review (minimax/glm/mimo — diverse personas)

Consensus REQUEST-CHANGES; all findings addressed:
- **[MAJOR, unanimous]** skip wrongly covered shell tools -> narrowed to path tools only.
- **[MAJOR]** unbind ordering -> moved after `delegate_run_ctx_restore`.
- **Open questions, resolved by inspection:** `workspace_provider_active()` is `__thread` (concurrent-delegate isolation holds); `workspace_turn_bind_active` returns strictly 0/1 (tested in `test_workspace_turn.c`); path traversal stays contained by the tool-layer `guardrails_validate_file_path` (`../` reject + `classify_path` sensitive-deny), which runs regardless of the worktree skip.

## Known follow-up

`bash` tools still fork server-side (not routed over the reverse channel). `read_file`/`list`/`stat` route correctly, sufficient for review delegates. Routing `bash` via the detached `exec` op is a follow-up.
