### PR TITLE
feat(delegate): route detached delegate bash to the client (finish reverse-channel exec)

### DIFF
--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -1346,16 +1346,17 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
     * session. Skipped when the target is already inside an aimee worktree or a
     * linked git worktree.
     *
-    * The PATH-tool branch is skipped when a `detached` workspace provider is
-    * active: that workspace is filesystem-authority on the CLIENT, so its file
-    * tools marshal over the reverse channel — forcing them into a server-side
-    * worktree would rewrite paths to a checkout that does not exist on the client.
-    * Shell tools are NOT exempted: bash still forks server-side (not yet
-    * marshalled), so it must keep worktree containment regardless of provider. */
+    * Both file AND shell tools are skipped when a `detached` workspace provider
+    * is active: that workspace is filesystem-authority on the CLIENT, so its
+    * file tools (read/list/stat) and shell commands (tool_bash -> exec_shell)
+    * marshal over the reverse channel and run on the client's tree. Forcing them
+    * into a server-side worktree would rewrite paths/cwd to a checkout that does
+    * not exist on the client. Command-safety and the push/PR verify gate above
+    * run independently of this block, so they still apply. */
    const workspace_provider_t *gr_ws_active = workspace_provider_active();
    int gr_detached_active = gr_ws_active && gr_ws_active->kind == WS_PROVIDER_DETACHED;
-   if ((is_path_tool(tool_name) && !gr_detached_active) ||
-       (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd)))
+   if (!gr_detached_active &&
+       (is_path_tool(tool_name) || (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd))))
    {
       /* Determine target path */
       const char *target = effective_cwd;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -13,6 +13,7 @@
 #include "agent.h"
 #include "agent_config.h"
 #include "agent_tools.h"
+#include "workspace_provider.h"
 #include "agent_adapter.h"
 #include "provider_cli_adapter.h"
 #include "agent_protocol.h"
@@ -856,6 +857,62 @@ static void test_tool_bash(void)
    result = tool_bash("yes x | head -c 65536", 5000);
    assert(result && strstr(result, "\"exit_code\":0") != NULL);
    free(result);
+}
+
+/* A write into a source checkout is redirected into an aimee-managed worktree
+ * by guardrails (pre_tool_check returns 1 with the rewritten path) under the
+ * default (shared) provider. When a `detached` workspace provider is active the
+ * tool marshals to the serving client (file tools + tool_bash -> exec_shell), so
+ * the server-side worktree rewrite must be SKIPPED — otherwise the path/command
+ * would be re-pointed at a checkout that does not exist on the client. This
+ * locks in the guardrails skip that lets detached delegates operate on the
+ * client's live tree. */
+static void test_detached_skips_worktree_rewrite(void)
+{
+   char repo[256];
+   snprintf(repo, sizeof(repo), "/tmp/det_wt_test.XXXXXX");
+   assert(mkdtemp(repo) != NULL);
+   char shellcmd[512];
+   snprintf(shellcmd, sizeof(shellcmd), "git init -q '%s' >/dev/null 2>&1", repo);
+   (void)system(shellcmd);
+
+   session_state_t state;
+   memset(&state, 0, sizeof(state));
+   strcpy(state.guardrail_mode, MODE_APPROVE);
+
+   char input[512];
+   snprintf(input, sizeof(input), "{\"file_path\":\"%s/foo.c\",\"content\":\"int x;\"}", repo);
+   char msg[1024];
+
+   /* Shared (default) provider: the write is redirected into a worktree. */
+   workspace_provider_clear_active();
+   msg[0] = '\0';
+   int rc_shared = pre_tool_check("Write", input, &state, MODE_APPROVE, repo, msg, sizeof(msg));
+   assert(rc_shared == 1);                /* allow-with-rewrite */
+   assert(strstr(msg, ".aimee") != NULL); /* rewritten into an aimee worktree */
+
+   /* Detached provider active: the rewrite is skipped (path left untouched). */
+   workspace_provider_t fake_detached;
+   memset(&fake_detached, 0, sizeof(fake_detached));
+   fake_detached.kind = WS_PROVIDER_DETACHED;
+   workspace_provider_set_active(&fake_detached);
+   msg[0] = '\0';
+   int rc_detached = pre_tool_check("Write", input, &state, MODE_APPROVE, repo, msg, sizeof(msg));
+   workspace_provider_clear_active();
+   assert(rc_detached != 1);              /* allow-with-rewrite did NOT fire */
+   assert(strstr(msg, ".aimee") == NULL); /* no worktree path was injected */
+   /* NB: rc_detached here reflects the orthogonal, config-based write gate
+    * (cwd_is_detached_workspace) which this test's bare temp repo is not
+    * registered for. In production workspace_turn_bind_active and
+    * cwd_is_detached_workspace read the SAME workspace registry, so a real
+    * detached turn lifts both and the write is allowed (rc 0). What this test
+    * pins is the one thing the provider bind controls: the worktree rewrite. */
+
+   snprintf(shellcmd, sizeof(shellcmd), "rm -rf '%s'", repo);
+   (void)system(shellcmd);
+
+   printf("  detached_skips_worktree_rewrite: ok (shared=%d, detached=%d)\n", rc_shared,
+          rc_detached);
 }
 
 static void test_tool_read_file(void)
@@ -1949,6 +2006,7 @@ int main(void)
    test_responses_parser_separates_message_items();
    test_agent_is_exec_role();
    test_tool_bash();
+   test_detached_skips_worktree_rewrite();
    test_tool_read_file();
    test_tool_write_file();
    test_tool_edit_file();


### PR DESCRIPTION
## Summary

Completes the follow-up left by #314: server-side delegates can now **run shell commands against the originating thin client's tree**, not just `read`/`list`/`stat`. This finishes the "C" architecture so a detached delegate (roundtable reviewer, ensemble panelist, or an `execute`/`code` delegate) operates fully on the client's live files.

## Why it was blocked

The transport already existed end to end:
- `tool_bash` routes through the active provider's `exec_shell` when a detached workspace is bound (`agent_tools.c`).
- The detached provider marshals an `exec_shell` op (`cmd` + thread-local `cwd`) over the runner reverse channel.
- The client's runner handle runs it via the shared provider in the marshalled cwd (`cd '<cwd>' && <cmd>`).

What blocked it was **guardrails**: #314 conservatively kept worktree-enforcement ON for shell tools, so a detached delegate's bash command was rewritten to a **server** worktree path that doesn't exist on the client, then marshalled to the client → broken.

## Change

- **`guardrails_orchestrator.c`** — skip the worktree path/cwd rewrite for **both** file and shell tools when a detached provider is active. Command-safety classification and the push/PR verify gate live in **separate** blocks (above this one) and still run.
- `delegate_resolve_worktree` already produces no server-side worktree for a detached cwd (the path is absent server-side), so `run_cmd`'s cwd stays the client path and relative commands resolve correctly on the client.

## Tests

- New `test_detached_skips_worktree_rewrite` (`test_agent.c`): a `Write` into a source checkout is rewritten into an aimee worktree under the shared provider (rc 1, `.aimee` path), but the rewrite is **suppressed** when a detached provider is active.
- `exec_shell` round-trip (incl. cwd + exit code) is already covered by `test_workspace_provider_detached.c`.
- `make -j1 verify-local` green.

## Trust model

Marshalled bash runs on the client as the user, in the client workspace dir — the same model as the existing `claude`-CLI delegate (opt-in `aimee workspace serve`). The server-side worktree rewrite was never a containment boundary for the client; command-safety and verify gates still apply.
