### PR TITLE
fix(roundtable): exclude claude-CLI from the auto-panel + reliability diagnosis

### DIFF
--- a/docs/proposals/pending/roundtable-reliability.md
+++ b/docs/proposals/pending/roundtable-reliability.md
@@ -1,0 +1,84 @@
+# Proposal: Roundtable reliability — get the review gate to 100%
+
+- **State:** diagnosis + first fix (claude-CLI panel exclusion) shipping; follow-ups listed
+- **Author:** JBailes (investigation 2026-06-15)
+- **Motivation:** the roundtable is the project's quality gate, but in practice it
+  is unreliable/slow. This is a root-cause diagnosis (empirically validated
+  against the live .254 server) plus the fixes to reach 100%.
+
+## How the roundtable is wired (so the failure modes make sense)
+
+- **Engine roundtable** — `aimee delegate roundtable` / MCP `delegate.roundtable`
+  / the authoring pipeline → `handle_delegate_roundtable` → `delegate_roundtable_run`
+  (`delegate_ensemble.c`). Fans out over `ensemble.reference_models`; when unset,
+  `ensemble_default_panel_from_agents` seats **all enabled agents**. Each panelist
+  runs via `agent_run_named` → `agent_execute` — **tools OFF**. (As of #317 each
+  review panelist also gets a distinct persona.)
+- **Manual per-model review** — `aimee delegate review --persona X --via M`.
+  Routes by role; `review` is in `delegate_role_enable_tools_by_default`, so it
+  runs **tools ON** unless `--max-turns 1` or the model lacks a tools capability.
+
+## Root causes (empirically validated, 2026-06-15)
+
+Probed all six configured models on a tiny self-contained review:
+
+| model | tools-OFF review | tools-ON review |
+|---|---|---|
+| mistral | ✅ correct | wanders / 429s |
+| minimax | ✅ correct | wanders (read_file/bash), exhausts turns → no output |
+| mimo-2.5 | ✅ correct | wanders / context-limited on big prompts |
+| glm | ✅ (has `review` role) | tool-capable |
+| codex (gpt-5.5) | ✅ correct | no tools cap → excluded by the `caps=tools` gate |
+| claude (sonnet) | ❌ **"failed to build request URL"** | n/a |
+
+1. **The manual review path runs tools-ON, and that is the main failure.**
+   Tool-capable but weaker models (minimax, mimo) burn all their turns calling
+   `read_file`/`bash` instead of reviewing the artifact in front of them, and
+   return nothing. **Tools-off, every HTTP model returns a correct review.** A
+   *standalone* review (`review the auth module`) legitimately needs tools to go
+   read the code, so `review` defaulting to tools-on is not wrong in general — it
+   is wrong for an **artifact-provided panel review**. The engine roundtable
+   already does the right thing (tools-off); the manual per-model path used *as* a
+   roundtable does not.
+2. **`caps=tools` excludes tool-less reviewers.** codex/claude advertise no
+   `tools` capability, so the role-routed (manual) path with tools required drops
+   them — yet **codex reviews perfectly tools-off**. The engine fan-out
+   (`agent_run_named`, by name) bypasses this gate, so it is a manual-path issue.
+3. **claude-CLI poisons the auto-panel.** `ensemble_default_panel_from_agents`
+   seats claude even though it has no HTTP endpoint (it runs on the thin client
+   over the reverse channel, primary-only by default). Server-side it fails fast
+   with "failed to build request URL", wasting a panel slot. **← fixed here.**
+4. **The live .254 server runs an OLD build.** It predates #233 (model-derived
+   output caps — the prior 4096 cap starved reasoning models into empty
+   artifacts), #314 (detached-workspace bind so delegates can read client files),
+   and #317 (per-participant personas). Much of the *observed* degradation is
+   deploy-lag, not current-code behavior.
+5. **The engine roundtable is slow + opaque.** Multi-round, synchronous, up to a
+   10-minute deadline, no streamed progress — a 4-minute probe returned nothing
+   and looked hung. A correctness-neutral UX problem, but it is why it "feels
+   broken".
+
+## Fixes
+
+### Shipped in this change
+- **Exclude claude-CLI from the auto-panel** (`ensemble_default_panel_from_agents`)
+  unless `claude_cli_delegate_enabled`, mirroring the manual route's existing
+  gate. The engine roundtable's default panel becomes the five HTTP models
+  (minimax, mistral, mimo-2.5, codex, glm), all of which return reviews tools-off.
+
+### Required to actually see the fix live
+- **Deploy current `testing` to .254.** This is the single biggest lever — it
+  brings #233 + #314 + #317 + this fix. (Operator-gated.)
+
+### Follow-ups (separate changes)
+- **Canonicalise the engine roundtable as THE multi-model gate** in docs/quickstart
+  so users stop hand-running tools-on per-model `aimee delegate review` jobs as a
+  roundtable substitute.
+- **Streamed/async progress + a saner default deadline** for the engine roundtable
+  so it is not a multi-minute silent block.
+- **Aggregator robustness:** the synthesis pass defaults to `reference_models[0]`;
+  fall back to the next healthy panelist if it fails, rather than degrading to a
+  single best candidate.
+- **Optional no-tools panel review on the manual path** (e.g. honour a
+  `--no-tools` / artifact-provided hint) so a hand-run per-model review of an
+  inline diff does not wander.

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -112,6 +112,13 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
                             const roundtable_opts_t *opts, roundtable_result_t *out);
 void delegate_roundtable_result_free(roundtable_result_t *r);
 
+/* Seed cfg->ensemble_reference_models from the enabled agents when no panel is
+ * configured (no-op if ensemble_reference_count > 0). Skips agents that cannot
+ * run as a server-side HTTP delegate (claude-CLI unless
+ * claude_cli_delegate_enabled). Defaults the aggregator to the first seated
+ * model. */
+void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg);
+
 /* Persona name for review panelist `model_index`: a configured
  * ensemble.reference_personas[model_index] if set, else a round-robin over the
  * engine's diverse default lineup keyed on the stable model index. Returns NULL

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1157,6 +1157,33 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
    return 0;
 }
 
+void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg)
+{
+   if (cfg->ensemble_reference_count > 0)
+      return;
+   int n = 0;
+   for (int i = 0; i < acfg->agent_count && n < ENSEMBLE_MAX_REFS; i++)
+   {
+      if (!acfg->agents[i].enabled || !acfg->agents[i].name[0])
+         continue;
+      /* Skip agents that cannot run as a server-side HTTP delegate. claude-CLI
+       * has no HTTP endpoint (it runs on the thin client over the reverse
+       * channel and is primary-only by default), so seating it in the auto-panel
+       * just burns a slot on a "failed to build request URL" participant. Mirror
+       * the manual delegate route's gate: include it only when the operator opts
+       * in via claude_cli_delegate_enabled. */
+      if (agent_is_claude_cli(&acfg->agents[i]) && !cfg->claude_cli_delegate_enabled)
+         continue;
+      snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]), "%s",
+               acfg->agents[i].name);
+      n++;
+   }
+   cfg->ensemble_reference_count = n;
+   if (!cfg->ensemble_aggregator[0] && n > 0)
+      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
+               cfg->ensemble_reference_models[0]);
+}
+
 int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char *prompt,
                           delegate_ensemble_result_t *out)
 {

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1806,25 +1806,6 @@ int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 /* Convene the ensemble panel from enabled registry agents when no explicit
  * ensemble.reference_models is set. Caps at ENSEMBLE_MAX_REFS; aggregator -> 0. */
-static void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg)
-{
-   if (cfg->ensemble_reference_count > 0)
-      return;
-   int n = 0;
-   for (int i = 0; i < acfg->agent_count && n < ENSEMBLE_MAX_REFS; i++)
-   {
-      if (!acfg->agents[i].enabled || !acfg->agents[i].name[0])
-         continue;
-      snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]), "%s",
-               acfg->agents[i].name);
-      n++;
-   }
-   cfg->ensemble_reference_count = n;
-   if (!cfg->ensemble_aggregator[0] && n > 0)
-      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
-               cfg->ensemble_reference_models[0]);
-}
-
 /* Mixture-of-Agents ensemble aggregate. Reached over the first-class
  * POST /v1/delegate/aggregate route (method "delegate.aggregate"), dispatched
  * async via rh_dispatch_op_async onto a detached op-run worker (never the

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -246,6 +246,11 @@ agent_t *agent_find(agent_config_t *cfg, const char *name)
    (void)name;
    return NULL;
 }
+/* Stub: treat the agent literally named "claude" as the CLI-only agent. */
+int agent_is_claude_cli(const agent_t *agent)
+{
+   return agent && strcmp(agent->name, "claude") == 0;
+}
 static int g_cost_fold_calls = 0;
 static double g_cost_fold_total = 0.0;
 int db1_cost_fold_record(const char *parent_sid, const char *child_sid, double cost,
@@ -784,6 +789,44 @@ static void test_roundtable_review_brief_and_items_return(void)
    printf("  test_roundtable_review_brief_and_items_return: ok\n");
 }
 
+static void test_default_panel_excludes_claude_cli(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   acfg.agent_count = 3;
+   acfg.agents[0].enabled = 1;
+   snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "mistral");
+   acfg.agents[1].enabled = 1;
+   snprintf(acfg.agents[1].name, MAX_AGENT_NAME, "claude"); /* CLI-only per stub */
+   acfg.agents[2].enabled = 1;
+   snprintf(acfg.agents[2].name, MAX_AGENT_NAME, "codex");
+
+   /* default: claude-CLI is skipped, aggregator defaults to the first seated */
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   ensemble_default_panel_from_agents(&cfg, &acfg);
+   assert(cfg.ensemble_reference_count == 2);
+   assert(strcmp(cfg.ensemble_reference_models[0], "mistral") == 0);
+   assert(strcmp(cfg.ensemble_reference_models[1], "codex") == 0);
+   assert(strcmp(cfg.ensemble_aggregator, "mistral") == 0);
+
+   /* opt-in seats claude too */
+   config_t cfg2;
+   memset(&cfg2, 0, sizeof(cfg2));
+   cfg2.claude_cli_delegate_enabled = 1;
+   ensemble_default_panel_from_agents(&cfg2, &acfg);
+   assert(cfg2.ensemble_reference_count == 3);
+
+   /* a configured panel is left untouched (no-op) */
+   config_t cfg3;
+   memset(&cfg3, 0, sizeof(cfg3));
+   cfg3.ensemble_reference_count = 1;
+   snprintf(cfg3.ensemble_reference_models[0], 128, "preset");
+   ensemble_default_panel_from_agents(&cfg3, &acfg);
+   assert(cfg3.ensemble_reference_count == 1);
+   printf("  test_default_panel_excludes_claude_cli: ok\n");
+}
+
 static void test_panel_persona_name_assignment(void)
 {
    config_t cfg;
@@ -1076,6 +1119,7 @@ int main(void)
    test_roundtable_summarize_forward_sets_truncated();
    test_roundtable_review_saturation_converges();
    test_roundtable_review_brief_and_items_return();
+   test_default_panel_excludes_claude_cli();
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();
    test_roundtable_cost_capped_skips_question_pass();


### PR DESCRIPTION
## Diagnosis (the ask: get the roundtable to 100%)

I probed all six configured models on a self-contained review. **Run tools-off,
mistral / minimax / mimo-2.5 / codex / glm all return correct reviews.** The
failures the roundtable exhibits trace to:

1. **The manual `aimee delegate review` path runs tools-ON** (review is in
   `delegate_role_enable_tools_by_default`). Tool-capable-but-weaker models
   (minimax, mimo) then burn every turn calling `read_file`/`bash` instead of
   reviewing the artifact in front of them, and return nothing. The **engine
   roundtable** (`delegate_roundtable_run`) already runs tools-off and is the
   correct multi-model gate; hand-running per-model reviews as a roundtable is
   the wrong tool.
2. **`caps=tools` excludes tool-less reviewers** (codex/claude) on the manual
   path — yet codex reviews perfectly tools-off. The engine fan-out
   (`agent_run_named`, by name) bypasses that gate, so codex is already a usable
   panelist there.
3. **claude-CLI poisoned the auto-panel** — it has no HTTP endpoint and fails
   server-side with "failed to build request URL", wasting a slot. **← fixed here.**
4. **The live .254 server runs an OLD build** — predating #233 (model-derived
   output caps), #314 (workspace bind), and #317 (per-participant personas). Much
   of the observed degradation is deploy-lag.

Full write-up + follow-ups: `docs/proposals/pending/roundtable-reliability.md`.

## This change

- **Exclude claude-CLI from the auto-panel** (`ensemble_default_panel_from_agents`)
  unless `claude_cli_delegate_enabled`, mirroring the manual route's existing
  gate. The default panel becomes the five HTTP models, all of which review
  reliably tools-off.
- Relocated `ensemble_default_panel_from_agents` from `server_compute.c` (pinned
  at the 2000-line hard cap) into `delegate_ensemble.c` where the ensemble logic
  lives, and exposed it via the header — net **−19 lines** in server_compute.c.
- **New unit test** `test_default_panel_excludes_claude_cli`: claude skipped by
  default, seated under opt-in, aggregator defaults to the first seated model, and
  a configured panel is left untouched.

`make lint` (clang-format-19 + line-check + docs-gen + proposal-links) and the
`delegate-ensemble` suite (29 cases) pass.

## To see it live

Deploy current `testing` to .254 — that brings #233 + #314 + #317 + this fix.
(Operator-gated; flagged because it is the single biggest reliability lever.)
