### PR TITLE
fix(roundtable): aggregator fallback + canonicalize engine roundtable in docs

### DIFF
--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -339,6 +339,19 @@ prior round — and returns the best round's artifact. Both run through the dele
 core, so the work stays inside Aimee's session state, cost accounting, and audit
 trail (not the host AI's own sub-agent tools, which are blocked).
 
+> **Use `aimee delegate roundtable --mode review` (or the MCP `delegate.roundtable`
+> tool) for a multi-model review gate — not hand-run per-model `aimee delegate
+> review` jobs.** The roundtable panel runs each model **without file tools** and
+> gives each panelist a **distinct persona** (security, architect, QA, contrarian
+> reviewer, constructive reviewer), so weaker models review the artifact you give
+> them instead of wandering the filesystem, and tool-less models (e.g. codex) can
+> participate. `aimee delegate review --via M` is a *single, exploratory* review
+> that runs tools-on so the reviewer can read the surrounding code — the right
+> tool for "review the auth module", the wrong tool for a panel gate. The panel
+> skips agents that cannot run as a server-side HTTP delegate (e.g. claude-CLI
+> unless `claude_cli_delegate_enabled`) and falls back to another panelist if the
+> aggregator model fails, so one flaky model does not collapse the synthesis.
+
 The panel is configured under `ensemble` in `aimee.yaml`:
 
 | Field | Meaning |

--- a/docs/proposals/pending/roundtable-reliability.md
+++ b/docs/proposals/pending/roundtable-reliability.md
@@ -70,15 +70,16 @@ Probed all six configured models on a tiny self-contained review:
 - **Deploy current `testing` to .254.** This is the single biggest lever — it
   brings #233 + #314 + #317 + this fix. (Operator-gated.)
 
-### Follow-ups (separate changes)
-- **Canonicalise the engine roundtable as THE multi-model gate** in docs/quickstart
-  so users stop hand-running tools-on per-model `aimee delegate review` jobs as a
-  roundtable substitute.
+### Follow-ups
+- **Canonicalise the engine roundtable as THE multi-model gate** in docs — DONE
+  (DELEGATES.md: use `aimee delegate roundtable --mode review`, not hand-run
+  per-model `aimee delegate review` jobs).
+- **Aggregator robustness** — DONE (`run_aggregator` falls back across the
+  panelists if the configured/default aggregator returns empty, instead of
+  collapsing the round to a single best candidate).
 - **Streamed/async progress + a saner default deadline** for the engine roundtable
-  so it is not a multi-minute silent block.
-- **Aggregator robustness:** the synthesis pass defaults to `reference_models[0]`;
-  fall back to the next healthy panelist if it fails, rather than degrading to a
-  single best candidate.
-- **Optional no-tools panel review on the manual path** (e.g. honour a
-  `--no-tools` / artifact-provided hint) so a hand-run per-model review of an
-  inline diff does not wander.
+  so it is not a multi-minute silent block. (Still open — larger change.)
+- **Optional no-tools panel review on the manual path** (a `--no-tools` /
+  artifact-provided hint) so a hand-run per-model review of an inline diff does
+  not wander. (Still open — needs the client-side delegate request builder
+  threaded; lower priority now the engine roundtable is documented as canonical.)

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -464,18 +464,51 @@ static int run_aggregator(agent_config_t *acfg, const config_t *cfg, const char 
     * be dispatched by NAME (agent_run_named): agent_run_ex selects by role and
     * an agent's name is not one of its roles, so a name routed as a role finds
     * nothing and returns empty. A role form (or no aggregator) routes by role. */
+   /* Primary: the configured (or default) aggregator. max_tokens 0 = derive from
+    * the aggregator model's own output ceiling, so a reasoning aggregator isn't
+    * truncated mid-synthesis (was a hard 4096). */
+   const char *primary_name = NULL; /* bare-name aggregator we tried, to not retry it */
    if (cfg->ensemble_aggregator[0])
    {
       const char *agg = cfg->ensemble_aggregator;
       const char *at = strchr(agg, '@');
-      /* max_tokens 0 = derive from the aggregator model's own output ceiling, so
-       * a reasoning aggregator isn't truncated mid-synthesis (was a hard 4096). */
       if (!at)
-         return delegate_run_inline(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out);
-      const char *role = (at[1]) ? at + 1 : "review";
-      return delegate_run_inline(&agg_cfg, NULL, role, NULL, synthesis_prompt, 0, 0.3, out);
+      {
+         primary_name = agg;
+         if (delegate_run_inline(&agg_cfg, agg, "review", NULL, synthesis_prompt, 0, 0.3, out) ==
+                 0 &&
+             out->response && out->response[0])
+            return 0;
+      }
+      else
+      {
+         const char *role = (at[1]) ? at + 1 : "review";
+         if (delegate_run_inline(&agg_cfg, NULL, role, NULL, synthesis_prompt, 0, 0.3, out) == 0 &&
+             out->response && out->response[0])
+            return 0;
+      }
    }
-   return delegate_run_inline(&agg_cfg, NULL, "review", NULL, synthesis_prompt, 0, 0.3, out);
+   else if (delegate_run_inline(&agg_cfg, NULL, "review", NULL, synthesis_prompt, 0, 0.3, out) ==
+                0 &&
+            out->response && out->response[0])
+      return 0;
+
+   /* Fallback: the configured aggregator failed or returned empty. Try each
+    * panelist by name (no-tools) until one synthesizes — a single flaky
+    * aggregator model must not collapse the whole round to an artifact-less
+    * degrade when other capable panelists are available. */
+   for (int i = 0; i < cfg->ensemble_reference_count; i++)
+   {
+      const char *cand = cfg->ensemble_reference_models[i];
+      if (!cand[0] || (primary_name && strcmp(cand, primary_name) == 0))
+         continue;
+      free(out->response);
+      memset(out, 0, sizeof(*out));
+      if (delegate_run_inline(&agg_cfg, cand, "review", NULL, synthesis_prompt, 0, 0.3, out) == 0 &&
+          out->response && out->response[0])
+         return 0;
+   }
+   return -1;
 }
 
 static char *build_round_prompt(const char *task, const char *artifact, const char *peer_notes,

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -17,6 +17,7 @@ static int g_repair_mode = 0;
 static int g_parallel_calls = 0;
 static int g_named_calls = 0;
 static int g_aggregator_calls = 0;
+static char g_aggregator_fallback_who[128] = "";
 static int g_cancel_after_checks = -1;
 static char g_last_parallel_prompt[8192];
 
@@ -205,6 +206,13 @@ static void fill_aggregator_response(agent_result_t *out, const char *who)
       memset(out->response, 'a', n - 2);
       out->response[n - 2] = '\n';
       out->response[n - 1] = '\0';
+   }
+   else if (g_aggregator_mode == 3)
+   {
+      /* The primary aggregator returns empty (fails); a fallback panelist
+       * synthesizes. Records who actually produced the artifact. */
+      out->response = g_aggregator_calls == 1 ? NULL : strdup("fallback synthesized artifact");
+      snprintf(g_aggregator_fallback_who, sizeof(g_aggregator_fallback_who), "%s", who ? who : "");
    }
    else
    {
@@ -879,6 +887,30 @@ static void test_roundtable_review_assigns_personas(void)
    printf("  test_roundtable_review_assigns_personas: ok\n");
 }
 
+static void test_roundtable_aggregator_fallback_synthesizes(void)
+{
+   reset_modes();
+   g_aggregator_mode = 3; /* primary aggregator returns empty; a fallback panelist synthesizes */
+   g_aggregator_fallback_who[0] = '\0';
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_DRAFT;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 2;
+   opts.converge_threshold = 0;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "draft needing synthesis", &opts, &result);
+   assert(rc == 0);
+   /* The primary aggregator returned empty on its first call; a fallback panelist
+    * synthesized rather than collapsing the round to an empty artifact. */
+   assert(result.artifact && result.artifact[0]);
+   assert(g_aggregator_calls >= 2); /* primary (empty) + at least one fallback attempt */
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_aggregator_fallback_synthesizes: ok\n");
+}
+
 static void test_roundtable_cost_capped_skips_question_pass(void)
 {
    reset_modes();
@@ -1122,6 +1154,7 @@ int main(void)
    test_default_panel_excludes_claude_cli();
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();
+   test_roundtable_aggregator_fallback_synthesizes();
    test_roundtable_cost_capped_skips_question_pass();
    test_roundtable_partial_question_answers_report_gaps();
    test_roundtable_draft_brief_questions_not_answered();


### PR DESCRIPTION
Follow-ups to the roundtable reliability work (#318), per the engine-hardening +
docs-canonicalization track.

## Changes

- **Aggregator fallback** (`run_aggregator`, delegate_ensemble.c): if the
  configured/default aggregator (`reference_models[0]`) returns empty or fails,
  fall back across the remaining panelists by name (no-tools) until one
  synthesizes — instead of collapsing the round to a degraded, artifact-less
  single-best result. A single flaky aggregator model no longer sinks the whole
  synthesis. New unit test `test_roundtable_aggregator_fallback_synthesizes`
  (delegate-ensemble suite now 30 cases).
- **Docs canonicalization** (DELEGATES.md): document `aimee delegate roundtable
  --mode review` (and the MCP `delegate.roundtable` tool) as THE multi-model
  review gate — runs each model tools-off with a distinct persona, skips
  claude-CLI, falls back if the aggregator fails. Manual per-model `aimee delegate
  review --via M` is for *single, exploratory* reviews (tools-on), not a panel
  gate.
- **roundtable-reliability.md**: follow-up list updated (aggregator fallback +
  docs done; streamed progress and a manual `--no-tools` flag remain — the latter
  deferred because it needs the client-side delegate request builder threaded and
  is lower priority now the engine roundtable is documented as canonical).

`make lint` (clang-format-19 + line-check + docs-gen + proposal-links) and the
delegate-ensemble suite (30 cases) pass.
