### PR TITLE
fix(roundtable): parse fenced/prose-wrapped JSON from panelists

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -56,6 +56,34 @@ static int count_successful(const agent_result_t *results, int count)
    return n;
 }
 
+/* Parse JSON from a model response, tolerating a markdown code fence
+ * (```json ... ```) or surrounding prose. Panelists given a persona system
+ * prompt tend to wrap their JSON in a fence, which a strict cJSON_Parse rejects
+ * — leaving the review with zero items and an empty artifact. Try a strict parse
+ * first (bare JSON), then fall back to the substring from the first '{' to the
+ * last '}'. Returns NULL if neither yields valid JSON; caller owns the result. */
+static cJSON *parse_model_json_lenient(const char *text)
+{
+   if (!text || !text[0])
+      return NULL;
+   cJSON *root = cJSON_Parse(text);
+   if (root)
+      return root;
+   const char *open = strchr(text, '{');
+   const char *close = strrchr(text, '}');
+   if (!open || !close || close < open)
+      return NULL;
+   size_t len = (size_t)(close - open) + 1;
+   char *buf = (char *)malloc(len + 1);
+   if (!buf)
+      return NULL;
+   memcpy(buf, open, len);
+   buf[len] = '\0';
+   root = cJSON_Parse(buf);
+   free(buf);
+   return root;
+}
+
 static int best_candidate(const agent_result_t *results, int count)
 {
    int best = -1;
@@ -521,6 +549,7 @@ static char *build_round_prompt(const char *task, const char *artifact, const ch
              "\"category\":\"correctness|security|performance|maintainability|style\","
              "\"location\":\"file:line or artifact section\",\"summary\":\"one-sentence issue\","
              "\"recommendation\":\"...\"}],\"overall\":\"...\"}. "
+             "Output raw JSON only — no markdown, no ``` code fences, no prose. "
              "Do not invent stable keys; the engine computes identity keys."
            : "Return the next complete draft. Incorporate useful peer input and do not describe "
              "the process.";
@@ -665,7 +694,7 @@ static int run_convergence_tiebreak(agent_config_t *acfg, const char *task, cons
    {
       if (cost_usd)
          *cost_usd += result_token_cost(acfg, &res, "reason");
-      cJSON *j = cJSON_Parse(res.response);
+      cJSON *j = parse_model_json_lenient(res.response);
       cJSON *c = j ? cJSON_GetObjectItemCaseSensitive(j, "completion") : NULL;
       if (cJSON_IsNumber(c))
          completion = (int)c->valuedouble;
@@ -747,7 +776,7 @@ static int parse_review_issue_keys(const char *text, char keys[][128], int *coun
 {
    if (!text || !count || max <= 0)
       return -1;
-   cJSON *root = cJSON_Parse(text);
+   cJSON *root = parse_model_json_lenient(text);
    if (!root)
       return -1;
    cJSON *issues = cJSON_GetObjectItemCaseSensitive(root, "issues");
@@ -825,7 +854,7 @@ static void capture_review_items_from_text(const char *text, const char *source,
 {
    if (!text || !out)
       return;
-   cJSON *root = cJSON_Parse(text);
+   cJSON *root = parse_model_json_lenient(text);
    if (!root)
       return;
    cJSON *issues = review_items_array(root);
@@ -929,7 +958,7 @@ static void parse_question_answers(const char *text, const roundtable_opts_t *op
     * answer set never silently drops a question (§5). */
    mark_question_gaps(opts, out);
    int n = out->answered_question_count;
-   cJSON *root = text ? cJSON_Parse(text) : NULL;
+   cJSON *root = text ? parse_model_json_lenient(text) : NULL;
    if (!root)
       return; /* keep the gap-seeded result */
    cJSON *answers = cJSON_GetObjectItemCaseSensitive(root, "answered_questions");

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -119,6 +119,14 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agen
              "\"summary\":\"missing authorization check before write\"}],\"overall\":\"block\"}");
       else if (g_parallel_mode == 6 && tasks[i].role && strcmp(tasks[i].role, "review") == 0)
          out[i].response = strdup("{\"items\":[],\"overall\":\"ok\"}");
+      else if (g_parallel_mode == 8 && tasks[i].role && strcmp(tasks[i].role, "review") == 0)
+         /* review JSON wrapped in a markdown code fence + prose, as a persona'd
+          * panelist actually returns it — the lenient parser must still extract it. */
+         out[i].response =
+             strdup("Here is my review:\n```json\n"
+                    "{\"items\":[{\"severity\":\"blocking\",\"category\":\"correctness\","
+                    "\"location\":\"src/a.c:1\",\"summary\":\"subtracts instead of adding\","
+                    "\"recommendation\":\"use +\"}],\"overall\":\"block\"}\n```\n");
       else if (g_parallel_mode == 7 && tasks[i].role && strcmp(tasks[i].role, "review") == 0)
          out[i].response =
              strdup(i == 0 ? "{\"items\":[{\"severity\":\"blocking\",\"category\":\"correctness\","
@@ -911,6 +919,29 @@ static void test_roundtable_aggregator_fallback_synthesizes(void)
    printf("  test_roundtable_aggregator_fallback_synthesizes: ok\n");
 }
 
+static void test_roundtable_review_parses_fenced_json(void)
+{
+   reset_modes();
+   g_parallel_mode = 8; /* panelists return review JSON wrapped in a ```json fence + prose */
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_REVIEW;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "review fenced", &opts, &result);
+   assert(rc == 0);
+   /* the lenient parser strips the markdown fence/prose, so the review items are
+    * captured instead of being dropped (which left artifact empty + degraded). */
+   assert(result.item_count >= 1);
+   assert(strcmp(result.items[0].severity, "blocking") == 0);
+   assert(strstr(result.items[0].summary, "subtract") != NULL);
+   delegate_roundtable_result_free(&result);
+   printf("  test_roundtable_review_parses_fenced_json: ok\n");
+}
+
 static void test_roundtable_cost_capped_skips_question_pass(void)
 {
    reset_modes();
@@ -1155,6 +1186,7 @@ int main(void)
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();
    test_roundtable_aggregator_fallback_synthesizes();
+   test_roundtable_review_parses_fenced_json();
    test_roundtable_cost_capped_skips_question_pass();
    test_roundtable_partial_question_answers_report_gaps();
    test_roundtable_draft_brief_questions_not_answered();


### PR DESCRIPTION
## The bug (found while validating the roundtable live)

I deployed current `testing` on .253 with 4 real models (minimax, mistral,
mimo-2.5, glm) and ran the engine roundtable in review mode. The panel worked —
`participants_total: 4, participants_failed: 0` — but the result was
**`item_count: 0`, empty artifact, `degraded: true`**.

Root cause: a review panelist given a **persona system prompt** (the
per-participant personas added in #317) wraps its review JSON in a ` ```json `
markdown fence / surrounds it with prose. `capture_review_items_from_text` (and
the issue-key, question-answer, and convergence-score parsers) called
`cJSON_Parse` on the **raw** response, which rejects a fenced/prose-wrapped body
— so every panelist "succeeded" yet zero review items were captured and the round
synthesized nothing. In other words, the personas silently produced empty reviews.

## The fix

- `parse_model_json_lenient()`: strict parse first (bare JSON fast path), then
  fall back to the substring from the first `{` to the last `}`. Applied at all
  four model-response parse sites in `delegate_ensemble.c`.
- The review round prompt now also asks for raw JSON with no code fences (belt
  and suspenders).

## Live validation (current testing + this fix, 4 real models)

| | before | after |
|---|---|---|
| participants_total / failed | 4 / 0 | 4 / 0 |
| item_count | **0** | **5** |
| artifact | empty | **2.4 KB synthesized** |
| degraded | **true** | **false** |

Items included the obvious subtraction bug *and* a signed-overflow UB finding —
genuine multi-lens depth. Unit test `test_roundtable_review_parses_fenced_json`
covers the fenced case (delegate-ensemble suite now 31 cases). `make lint` green.
