### PR TITLE
feat(roundtable): raise panel cap ENSEMBLE_MAX_REFS 8 -> 32

### DIFF
--- a/src/config_save.c
+++ b/src/config_save.c
@@ -76,13 +76,14 @@ static void config_save_misc_sections(const config_t *cfg, cJSON *root)
          if (cfg->ensemble_reference_count > 0)
          {
             cJSON *refs = cJSON_AddArrayToObject(e, "reference_models");
-            for (int i = 0; refs && i < cfg->ensemble_reference_count && i < 8; i++)
+            /* 32 = ENSEMBLE_MAX_REFS (delegate_ensemble.h). */
+            for (int i = 0; refs && i < cfg->ensemble_reference_count && i < 32; i++)
                cJSON_AddItemToArray(refs, cJSON_CreateString(cfg->ensemble_reference_models[i]));
          }
          if (cfg->ensemble_reference_persona_count > 0)
          {
             cJSON *ps = cJSON_AddArrayToObject(e, "reference_personas");
-            for (int i = 0; ps && i < cfg->ensemble_reference_persona_count && i < 8; i++)
+            for (int i = 0; ps && i < cfg->ensemble_reference_persona_count && i < 32; i++)
                cJSON_AddItemToArray(ps, cJSON_CreateString(cfg->ensemble_reference_personas[i]));
          }
       }

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1165,7 +1165,9 @@ void config_parse_ensemble_section(config_t *cfg, cJSON *root)
          cJSON *ref;
          cJSON_ArrayForEach(ref, refs)
          {
-            if (cJSON_IsString(ref) && ref->valuestring && cfg->ensemble_reference_count < 8)
+            /* 32 = ENSEMBLE_MAX_REFS (delegate_ensemble.h); literal to avoid
+             * config -> ensemble-engine header coupling. */
+            if (cJSON_IsString(ref) && ref->valuestring && cfg->ensemble_reference_count < 32)
             {
                snprintf(cfg->ensemble_reference_models[cfg->ensemble_reference_count],
                         sizeof(cfg->ensemble_reference_models[0]), "%s", ref->valuestring);
@@ -1182,7 +1184,7 @@ void config_parse_ensemble_section(config_t *cfg, cJSON *root)
          cJSON *p;
          cJSON_ArrayForEach(p, personas)
          {
-            if (cJSON_IsString(p) && p->valuestring && cfg->ensemble_reference_persona_count < 8)
+            if (cJSON_IsString(p) && p->valuestring && cfg->ensemble_reference_persona_count < 32)
             {
                snprintf(cfg->ensemble_reference_personas[cfg->ensemble_reference_persona_count],
                         sizeof(cfg->ensemble_reference_personas[0]), "%s", p->valuestring);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1288,12 +1288,16 @@ typedef struct config
     * ensemble_min_successful: min references that must succeed before degrading (default 2).
     * ensemble_max_cost_usd: optional per-run cost cap in USD; 0 (or unset) means
     * no limit, which is the default. Set a positive value to cap a run. */
-   char ensemble_reference_models[8][128];
+   /* First dim = ENSEMBLE_MAX_REFS (delegate_ensemble.h); a _Static_assert in
+    * delegate_ensemble.c enforces they stay in sync. config.h can't include that
+    * header (it would cycle), so the literal is kept here. */
+   char ensemble_reference_models[32][128];
    int ensemble_reference_count;
    /* Optional per-participant review persona, paired by index with
     * ensemble_reference_models. Empty entries fall back to the engine's diverse
-    * default lineup. Width = PERSONA_NAME_MAX (persona.h). */
-   char ensemble_reference_personas[8][64];
+    * default lineup. Width = PERSONA_NAME_MAX (persona.h); first dim =
+    * ENSEMBLE_MAX_REFS. */
+   char ensemble_reference_personas[32][64];
    int ensemble_reference_persona_count;
    char ensemble_aggregator[128];
    int ensemble_min_successful;

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -5,7 +5,12 @@
 #include "agent_config.h"
 #include "config.h"
 
-#define ENSEMBLE_MAX_REFS           8
+/* Max panelists in a roundtable/ensemble fan-out. Must match the
+ * ensemble_reference_models / ensemble_reference_personas array dims in config.h
+ * (a _Static_assert in delegate_ensemble.c enforces this). The fan-out arrays
+ * (agent_result_t results[N] ~1.4KB each, etc.) live on the compute-pool worker
+ * stack, which is 32 MB — so 32 panelists (~50KB frame) is well within budget. */
+#define ENSEMBLE_MAX_REFS           32
 #define ROUNDTABLE_MAX_REVIEW_ITEMS 128
 #define ROUNDTABLE_MAX_QUESTIONS    16
 

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -22,6 +22,18 @@
 #include <time.h>
 #include <ctype.h>
 
+/* The config arrays the engine fans out over must be sized to ENSEMBLE_MAX_REFS.
+ * config.h keeps the dim as a literal (it can't include this header), so catch
+ * any future drift at compile time rather than overrunning the stack arrays. */
+_Static_assert(sizeof(((config_t *)0)->ensemble_reference_models) /
+                       sizeof(((config_t *)0)->ensemble_reference_models[0]) ==
+                   ENSEMBLE_MAX_REFS,
+               "config_t.ensemble_reference_models first dim must equal ENSEMBLE_MAX_REFS");
+_Static_assert(sizeof(((config_t *)0)->ensemble_reference_personas) /
+                       sizeof(((config_t *)0)->ensemble_reference_personas[0]) ==
+                   ENSEMBLE_MAX_REFS,
+               "config_t.ensemble_reference_personas first dim must equal ENSEMBLE_MAX_REFS");
+
 /* Fallback when an ad-hoc model is absent from the capability registry. */
 #define ENSEMBLE_COST_PER_TOKEN 0.000015
 


### PR DESCRIPTION
Raise the roundtable/ensemble panel cap from 8 to 32 so a review can fan out
across a large, diverse model roster.

## Change
- `ENSEMBLE_MAX_REFS` 8 → 32 — auto-resizes the engine's per-round stack arrays
  (`agent_task_t tasks[N]`, `agent_result_t results[N]`, `prompts[N]`,
  `personas[N]`, `order[N]` in delegate_ensemble.c) and `rtp_participant_t
  parts[N]` in server_pipeline.c.
- `config_t.ensemble_reference_models` / `ensemble_reference_personas` first dim
  8 → 32, plus the parse (config_sections.c) and save (config_save.c) guards.
- New `_Static_assert` in delegate_ensemble.c ties the config array dim to
  `ENSEMBLE_MAX_REFS` — config.h keeps the dim as a literal (it can't include the
  engine header without a cycle), so this catches any future drift at compile
  time instead of overrunning the stack arrays.

## Safety
The fan-out arrays live on the compute-pool worker stack, which is an explicit
**32 MB** (`COMPUTE_POOL_THREAD_STACK`). `agent_result_t` is ~1.4 KB (its
`response` is a heap pointer, not inline), so `results[32]` ≈ 45 KB and the whole
frame ≈ 50 KB — negligible against 32 MB.

`make lint` and the delegate-ensemble + config unit suites pass.
