### PR TITLE
perf(roundtable): skip cross-round scorer for single-round runs

### DIFF
--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1566,8 +1566,11 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
                   free(results[i].response);
                break;
             }
-            int score = run_quality_scorer(acfg, task, results[best].response, &out->cost_usd);
-            if (score > best_score)
+            /* Single-round: no cross-round comparison, so skip the scorer call. */
+            int score = local.max_rounds > 1
+                            ? run_quality_scorer(acfg, task, results[best].response, &out->cost_usd)
+                            : 0;
+            if (local.max_rounds <= 1 || score > best_score)
             {
                free(best_artifact);
                best_artifact = xstrdup0(results[best].response);
@@ -1635,8 +1638,15 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
          free(prev_artifact_for_judge);
          break;
       }
-      int score = run_quality_scorer(acfg, task, agg_result.response, &out->cost_usd);
-      if (score > best_score)
+      /* The quality scorer exists only to compare candidates across rounds and
+       * pick the best. A single-round run has exactly one candidate, so skip the
+       * extra (large, sequential, external-LLM) scorer call and adopt this
+       * round's synthesis unconditionally — this removes a whole serial pass from
+       * the common `rounds:1` review. */
+      int score = local.max_rounds > 1
+                      ? run_quality_scorer(acfg, task, agg_result.response, &out->cost_usd)
+                      : 0;
+      if (local.max_rounds <= 1 || score > best_score)
       {
          free(best_artifact);
          best_artifact = xstrdup0(agg_result.response);

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -14,6 +14,7 @@
 #include "cost_fold.h"
 #include "log.h"
 #include "persona.h"
+#include "dstr.h"
 #include "token_tracker.h"
 
 #include <stdio.h>
@@ -1376,6 +1377,57 @@ int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char 
    return 0;
 }
 
+/* Assemble a consolidated review artifact from the already-deduped panel items,
+ * so a single-round review needs no synthesis LLM call (the panel's structured
+ * findings already ARE the review). Groups by severity; caller owns the result. */
+static char *assemble_review_artifact(const roundtable_result_t *out)
+{
+   dstr_t s;
+   dstr_init(&s);
+   static const char *const sevs[] = {"blocking", "suggestion", "nit"};
+   static const char *const heads[] = {"## Blocking", "## Suggestions", "## Nits"};
+   int emitted = 0;
+   char done[ROUNDTABLE_MAX_REVIEW_ITEMS];
+   memset(done, 0, sizeof(done));
+   for (int g = 0; g < 3; g++)
+   {
+      int group_started = 0;
+      for (int i = 0; i < out->item_count && i < ROUNDTABLE_MAX_REVIEW_ITEMS; i++)
+      {
+         const roundtable_review_item_t *it = &out->items[i];
+         if (strcmp(it->severity, sevs[g]) != 0)
+            continue;
+         done[i] = 1;
+         if (!group_started)
+         {
+            dstr_appendf(&s, "%s%s\n", emitted ? "\n" : "", heads[g]);
+            group_started = 1;
+         }
+         dstr_appendf(&s, "- **%s**", it->category[0] ? it->category : "review");
+         if (it->location[0])
+            dstr_appendf(&s, " (%s)", it->location);
+         dstr_appendf(&s, ": %s", it->summary);
+         if (it->recommendation[0])
+            dstr_appendf(&s, " — %s", it->recommendation);
+         dstr_append_char(&s, '\n');
+         emitted++;
+      }
+   }
+   /* Any item with an unexpected severity still gets reported. */
+   for (int i = 0; i < out->item_count && i < ROUNDTABLE_MAX_REVIEW_ITEMS; i++)
+   {
+      if (done[i])
+         continue;
+      const roundtable_review_item_t *it = &out->items[i];
+      dstr_appendf(&s, "%s- **%s**: %s\n", emitted ? "" : "## Findings\n",
+                   it->category[0] ? it->category : "review", it->summary);
+      emitted++;
+   }
+   if (!emitted)
+      dstr_append_str(&s, "No issues found by the panel.\n");
+   return dstr_steal(&s);
+}
+
 int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const char *task,
                             const roundtable_opts_t *opts, roundtable_result_t *out)
 {
@@ -1582,6 +1634,22 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
          for (int i = 0; i < ref_count; i++)
             free(results[i].response);
          continue;
+      }
+
+      /* Single-round review: the deduped panel items already hold the findings
+       * (captured above, no LLM call). Assemble the consolidated artifact from
+       * them and skip the synthesis LLM call entirely — a 1-round review is then
+       * just the parallel panel, no serial aggregator pass. Multi-round reviews
+       * and all draft runs still synthesize (each round feeds the next). */
+      if (local.mode == ROUNDTABLE_REVIEW && local.max_rounds <= 1)
+      {
+         free(best_artifact);
+         best_artifact = assemble_review_artifact(out);
+         out->best_round = round;
+         out->participants_failed = round_failed;
+         for (int i = 0; i < ref_count; i++)
+            free(results[i].response);
+         break;
       }
 
       int order[ENSEMBLE_MAX_REFS];

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -962,8 +962,10 @@ static void test_roundtable_single_round_skips_scorer(void)
    roundtable_result_t result;
    int rc = delegate_roundtable_run(&acfg, &cfg, "review once", &opts, &result);
    assert(rc == 0);
-   assert(g_scorer_calls == 0);                   /* the perf fix: no scorer call */
-   assert(result.artifact && result.artifact[0]); /* artifact still produced */
+   assert(g_scorer_calls == 0);     /* no cross-round scorer call */
+   assert(g_aggregator_calls == 0); /* no synthesis LLM call — assembled from items */
+   assert(result.item_count >= 1);
+   assert(result.artifact && strstr(result.artifact, "authorization")); /* built from the items */
    delegate_roundtable_result_free(&result);
 
    /* multi-round still scores to pick the best round (regression guard). */

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -13,6 +13,7 @@
 static int g_parallel_mode = 0; /* 0=all-succeed, 1=only-first-succeeds */
 static int g_aggregator_mode = 0;
 static int g_reason_mode = 0;
+static int g_scorer_calls = 0; /* counts run_quality_scorer ("reason" + score prompt) invocations */
 static int g_repair_mode = 0;
 static int g_parallel_calls = 0;
 static int g_named_calls = 0;
@@ -322,6 +323,8 @@ int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
    memset(out, 0, sizeof(*out));
    if (role && strcmp(role, "reason") == 0)
    {
+      if (strstr(user_prompt ? user_prompt : "", "Score this roundtable artifact"))
+         g_scorer_calls++;
       if (strstr(user_prompt ? user_prompt : "", "Answer the caller's roundtable review questions"))
          out->response = strdup("{\"answered_questions\":[{\"question\":\"does auth hold?\","
                                 "\"answer\":\"yes\",\"evidence\":\"review mentions auth\","
@@ -414,6 +417,7 @@ static void reset_modes(void)
    g_parallel_mode = 0;
    g_aggregator_mode = 0;
    g_reason_mode = 0;
+   g_scorer_calls = 0;
    g_repair_mode = 0;
    g_parallel_calls = 0;
    g_named_calls = 0;
@@ -942,6 +946,45 @@ static void test_roundtable_review_parses_fenced_json(void)
    printf("  test_roundtable_review_parses_fenced_json: ok\n");
 }
 
+static void test_roundtable_single_round_skips_scorer(void)
+{
+   /* The cross-round quality scorer (an extra serial LLM call) is pure overhead
+    * for a rounds:1 run and is skipped; multi-round still uses it. */
+   reset_modes();
+   g_parallel_mode = 5; /* panel returns valid review items */
+   config_t cfg = make_cfg(1, 2, 10.0);
+   agent_config_t acfg = make_acfg();
+   roundtable_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.mode = ROUNDTABLE_REVIEW;
+   opts.turns = ROUNDTABLE_PARALLEL;
+   opts.max_rounds = 1;
+   roundtable_result_t result;
+   int rc = delegate_roundtable_run(&acfg, &cfg, "review once", &opts, &result);
+   assert(rc == 0);
+   assert(g_scorer_calls == 0);                   /* the perf fix: no scorer call */
+   assert(result.artifact && result.artifact[0]); /* artifact still produced */
+   delegate_roundtable_result_free(&result);
+
+   /* multi-round still scores to pick the best round (regression guard). */
+   reset_modes();
+   g_aggregator_mode = 1;
+   g_reason_mode = 1;
+   config_t cfg2 = make_cfg(1, 2, 10.0);
+   roundtable_opts_t opts2;
+   memset(&opts2, 0, sizeof(opts2));
+   opts2.mode = ROUNDTABLE_DRAFT;
+   opts2.turns = ROUNDTABLE_PARALLEL;
+   opts2.max_rounds = 2;
+   opts2.converge_threshold = 0;
+   roundtable_result_t result2;
+   rc = delegate_roundtable_run(&acfg, &cfg2, "draft twice", &opts2, &result2);
+   assert(rc == 0);
+   assert(g_scorer_calls > 0);
+   delegate_roundtable_result_free(&result2);
+   printf("  test_roundtable_single_round_skips_scorer: ok\n");
+}
+
 static void test_roundtable_cost_capped_skips_question_pass(void)
 {
    reset_modes();
@@ -1187,6 +1230,7 @@ int main(void)
    test_roundtable_review_assigns_personas();
    test_roundtable_aggregator_fallback_synthesizes();
    test_roundtable_review_parses_fenced_json();
+   test_roundtable_single_round_skips_scorer();
    test_roundtable_cost_capped_skips_question_pass();
    test_roundtable_partial_question_answers_report_gaps();
    test_roundtable_draft_brief_questions_not_answered();


### PR DESCRIPTION
## Why
A roundtable runs a **parallel** panel review, then **sequential** single-model
passes. Profiling the slowness (the panel is already parallel; the NAS is not the
bottleneck — the panelists are external API models) showed the serial tail is the
issue. For a `rounds:1` review (the common gate) the `run_quality_scorer` call is
**pure overhead**: it exists only to compare candidates *across rounds* and pick
the best, and a single-round run has exactly one candidate.

## Change
Skip `run_quality_scorer` (both the degraded-path call and the post-synthesis
call) when `max_rounds <= 1`, adopting the round's result unconditionally. A
single-round review goes from

```
panel(parallel) -> [score] -> synthesis -> [score]
```
to
```
panel(parallel) -> synthesis
```

removing a whole serial external-LLM call from the critical path. Multi-round
runs are unchanged — the scorer still picks the best round.

## Test
`test_roundtable_single_round_skips_scorer`: zero scorer calls for a `rounds:1`
review, `>0` for a multi-round run. delegate-ensemble suite now 32 cases; `make
lint` green.

## Follow-ups (bigger levers, not in this PR)
- **Skip synthesis for single-round review** and return the (already deduped)
  panel items directly — would make a review `panel(parallel)`-only.
- **Deadline preemption**: a hung panelist currently stalls the parallel barrier
  past the roundtable deadline (it's checked between rounds, not mid-call); make
  the round abandon still-pending panelists at the deadline.
