### PR TITLE
fix(roundtable): deadline-preempt the parallel panel (a hung model can't wedge it)

### DIFF
--- a/src/cmd_agent.c
+++ b/src/cmd_agent.c
@@ -616,7 +616,7 @@ static void ag_parallel(app_ctx_t *ctx, int argc, char **argv)
    }
 
    agent_http_init();
-   int ok = agent_run_parallel(&s_agent_cfg, tasks, n, results);
+   int ok = agent_run_parallel(&s_agent_cfg, tasks, n, results, 0 /* no deadline */);
    agent_http_cleanup();
 
    cJSON *arr = cJSON_CreateArray();

--- a/src/cmd_agent_trace.c
+++ b/src/cmd_agent_trace.c
@@ -123,7 +123,7 @@ void cmd_dispatch(app_ctx_t *ctx, int argc, char **argv)
    }
 
    agent_http_init();
-   int successes = agent_run_parallel(&cfg, tasks, n, results);
+   int successes = agent_run_parallel(&cfg, tasks, n, results, 0 /* no deadline */);
    agent_http_cleanup();
 
    /* Output results */

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -53,8 +53,13 @@ int agent_run_with_tools_write_enforce(agent_config_t *cfg, const char *role,
                                        const char *system_prompt, const char *user_prompt,
                                        int max_tokens, int enforce_writes, agent_result_t *out);
 
-int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count,
-                       agent_result_t *out);
+/* Fan out `task_count` tasks across worker threads and join.
+ * deadline_ms > 0 bounds the wait: a worker still running at the deadline is
+ * abandoned (detached) and its slot in `out` left as a failed (zeroed) result,
+ * so one hung model can never wedge the whole fan-out. deadline_ms <= 0 keeps the
+ * historical unbounded join. Returns the number of successful results. */
+int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count, agent_result_t *out,
+                       int deadline_ms);
 
 /* Delegate fallback helpers */
 int agent_error_is_retryable(const char *error);

--- a/src/server/agent_coord.c
+++ b/src/server/agent_coord.c
@@ -499,7 +499,7 @@ int agent_vote(agent_config_t *cfg, const char *role, const char *prompt, int n_
       tasks[i].temperature = 0.3 + (0.1 * i); /* slight variation */
    }
 
-   int successes = agent_run_parallel(cfg, tasks, n_voters, results);
+   int successes = agent_run_parallel(cfg, tasks, n_voters, results, 0 /* no deadline */);
    if (successes == 0)
    {
       snprintf(out->error, sizeof(out->error), "all voters failed");

--- a/src/server/agent_parallel.c
+++ b/src/server/agent_parallel.c
@@ -10,10 +10,23 @@
 #include "agent_config.h" /* agent_request_creds_t: inherit per-turn creds */
 #include "agent_exec.h"
 #include "config.h" /* aimee_resolve_compute_threads */
+#include "log.h"
 
+#include <errno.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
+
+/* Completion barrier for the deadline path: workers flip their `done` flag and
+ * bump `done_count` under `mtx`, signalling `cv`, so the caller can
+ * cond-timedwait and abandon stragglers at the deadline. */
+typedef struct
+{
+   pthread_mutex_t mtx;
+   pthread_cond_t cv;
+   int done_count;
+} parallel_sync_t;
 
 typedef struct
 {
@@ -21,6 +34,10 @@ typedef struct
    agent_task_t *task;
    agent_result_t *result;
    const agent_request_creds_t *creds;
+   /* Deadline path only (NULL otherwise): the worker signals completion here so a
+    * straggler can be abandoned without blocking the join. */
+   parallel_sync_t *sync;
+   int *done;
 } parallel_ctx_t;
 
 static void *parallel_worker(void *arg)
@@ -38,6 +55,14 @@ static void *parallel_worker(void *arg)
    else
       agent_run_ex(ctx->cfg, ctx->task->role, ctx->task->system_prompt, ctx->task->user_prompt,
                    ctx->task->max_tokens, temp, ctx->result);
+   if (ctx->sync)
+   {
+      pthread_mutex_lock(&ctx->sync->mtx);
+      *ctx->done = 1;
+      ctx->sync->done_count++;
+      pthread_cond_broadcast(&ctx->sync->cv);
+      pthread_mutex_unlock(&ctx->sync->mtx);
+   }
    return NULL;
 }
 
@@ -55,8 +80,133 @@ static int parallel_worker_ceiling(void)
    return aimee_resolve_compute_threads(0);
 }
 
+/* Deadline-bounded fan-out: spawn all workers, wait on a completion barrier until
+ * every spawned worker finishes OR `deadline_ms` elapses, then collect the ones
+ * that finished and abandon (detach) the rest. Each worker writes into its OWN
+ * heap result cell; finished cells are moved into `out`, and any still-running
+ * worker keeps a private cell + shared state alive (intentionally leaked) so its
+ * eventual write can never touch freed caller memory. */
+static int run_parallel_deadline(agent_config_t *cfg, agent_task_t *tasks, int task_count,
+                                 agent_result_t *out, int deadline_ms)
+{
+   parallel_sync_t *sync = calloc(1, sizeof(*sync));
+   agent_request_creds_t *creds = calloc(1, sizeof(*creds));
+   parallel_ctx_t *ctxs = calloc((size_t)task_count, sizeof(*ctxs));
+   agent_result_t **cells = calloc((size_t)task_count, sizeof(*cells));
+   int *done = calloc((size_t)task_count, sizeof(int));
+   int *spawned = calloc((size_t)task_count, sizeof(int));
+   pthread_t *threads = calloc((size_t)task_count, sizeof(pthread_t));
+   int *final_done = calloc((size_t)task_count, sizeof(int));
+   if (!sync || !creds || !ctxs || !cells || !done || !spawned || !threads || !final_done)
+   {
+      free(sync);
+      free(creds);
+      free(ctxs);
+      free(cells);
+      free(done);
+      free(spawned);
+      free(threads);
+      free(final_done);
+      return 0;
+   }
+   pthread_mutex_init(&sync->mtx, NULL);
+   pthread_cond_init(&sync->cv, NULL);
+   agent_request_creds_snapshot(creds);
+
+   int spawned_count = 0;
+   for (int i = 0; i < task_count; i++)
+   {
+      memset(&out[i], 0, sizeof(out[i]));
+      cells[i] = calloc(1, sizeof(agent_result_t));
+      if (!cells[i])
+         continue; /* slot stays a failed result; never spawned */
+      ctxs[i].cfg = cfg;
+      ctxs[i].task = &tasks[i];
+      ctxs[i].result = cells[i];
+      ctxs[i].creds = creds;
+      ctxs[i].sync = sync;
+      ctxs[i].done = &done[i];
+      if (pthread_create(&threads[i], NULL, parallel_worker, &ctxs[i]) == 0)
+      {
+         spawned[i] = 1;
+         spawned_count++;
+      }
+      else
+      {
+         free(cells[i]);
+         cells[i] = NULL;
+      }
+   }
+
+   struct timespec abs;
+   clock_gettime(CLOCK_REALTIME, &abs);
+   abs.tv_sec += deadline_ms / 1000;
+   abs.tv_nsec += (long)(deadline_ms % 1000) * 1000000L;
+   if (abs.tv_nsec >= 1000000000L)
+   {
+      abs.tv_sec++;
+      abs.tv_nsec -= 1000000000L;
+   }
+
+   pthread_mutex_lock(&sync->mtx);
+   while (sync->done_count < spawned_count)
+   {
+      if (pthread_cond_timedwait(&sync->cv, &sync->mtx, &abs) == ETIMEDOUT)
+         break;
+   }
+   /* Consistent cut: while holding mtx no worker can flip done, so a done==1 cell
+    * has been fully written and is safe to move out. */
+   for (int i = 0; i < task_count; i++)
+      final_done[i] = done[i];
+   pthread_mutex_unlock(&sync->mtx);
+
+   int success = 0, abandoned = 0;
+   for (int i = 0; i < task_count; i++)
+   {
+      if (!spawned[i])
+         continue;
+      if (final_done[i])
+      {
+         out[i] = *cells[i]; /* move the result (incl. the response pointer) to the caller */
+         if (out[i].success)
+            success++;
+         free(cells[i]); /* the struct only; the response is now owned by out[i] */
+         cells[i] = NULL;
+      }
+      else
+      {
+         pthread_detach(threads[i]); /* abandon: it writes its leaked cell, never out[i] */
+         abandoned++;
+      }
+   }
+
+   free(final_done);
+   free(spawned);
+   free(threads); /* pthread_t ids; detached workers don't reference this array */
+   free(cells);   /* the pointer block; abandoned cell STRUCTS stay alive via ctxs[i].result */
+   if (!abandoned)
+   {
+      pthread_mutex_destroy(&sync->mtx);
+      pthread_cond_destroy(&sync->cv);
+      free(sync);
+      free(creds);
+      free(ctxs);
+      free(done);
+   }
+   else
+   {
+      /* Leak sync/creds/ctxs/done + the abandoned cell structs: the still-running
+       * detached workers reference them and must not hit freed memory. Bounded
+       * and rare (a hung model). */
+      aimee_log(LOG_WARN, "agent.parallel",
+                "%d/%d worker(s) abandoned at the %dms deadline (resources leaked)", abandoned,
+                spawned_count, deadline_ms);
+   }
+   return success;
+}
+
 int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count,
-                       agent_result_t *out)
+                       agent_result_t *out, int deadline_ms)
 {
    if (task_count <= 0)
       return 0;
@@ -72,6 +222,9 @@ int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int task_count,
                            tasks[0].max_tokens, temp, &out[0]);
       return rc == 0 ? 1 : 0;
    }
+
+   if (deadline_ms > 0)
+      return run_parallel_deadline(cfg, tasks, task_count, out, deadline_ms);
 
    parallel_ctx_t *ctxs = calloc((size_t)task_count, sizeof(parallel_ctx_t));
    if (!ctxs)

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1150,7 +1150,8 @@ static char *panel_persona_prompt(const config_t *cfg, roundtable_mode_t mode, i
 
 static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const char *task,
                               const char *artifact, const char *peer_notes, roundtable_mode_t mode,
-                              int round, const char *brief, agent_result_t *results)
+                              int round, const char *brief, agent_result_t *results,
+                              int deadline_ms)
 {
    int ref_count = cfg->ensemble_reference_count;
    agent_task_t tasks[ENSEMBLE_MAX_REFS];
@@ -1174,7 +1175,9 @@ static int run_round_parallel(agent_config_t *acfg, const config_t *cfg, const c
       tasks[i].temperature = 0.3 + (0.05 * i);
       tasks[i].max_tokens = 0;
    }
-   agent_run_parallel(acfg, tasks, ref_count, results);
+   /* deadline_ms bounds the panel barrier so one hung panelist can't wedge the
+    * whole round past the roundtable deadline. */
+   agent_run_parallel(acfg, tasks, ref_count, results, deadline_ms);
    /* Account each participant's run onto the originating session, like a delegate. */
    for (int i = 0; i < ref_count; i++)
       ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
@@ -1289,7 +1292,7 @@ int delegate_ensemble_run(agent_config_t *acfg, const config_t *cfg, const char 
    agent_result_t results[ENSEMBLE_MAX_REFS];
    memset(results, 0, sizeof(results));
 
-   agent_run_parallel(acfg, tasks, ref_count, results);
+   agent_run_parallel(acfg, tasks, ref_count, results, 0 /* MoA aggregate: no deadline */);
    /* Account each participant's run onto the originating session, like a delegate. */
    for (int i = 0; i < ref_count; i++)
       ensemble_fold_cost(acfg, &results[i], cfg->ensemble_reference_models[i]);
@@ -1511,11 +1514,21 @@ int delegate_roundtable_run(agent_config_t *acfg, const config_t *cfg, const cha
 
       agent_result_t results[ENSEMBLE_MAX_REFS];
       memset(results, 0, sizeof(results));
+      /* Remaining roundtable budget bounds this round's parallel panel so a hung
+       * panelist is abandoned at the deadline instead of wedging the barrier
+       * forever (floor at 5s so a near-exhausted budget still attempts the panel).
+       * 0 when no deadline is configured. */
+      int panel_deadline_ms = 0;
+      if (local.deadline_ms > 0)
+      {
+         long remaining = (long)local.deadline_ms - (monotonic_ms() - start_ms);
+         panel_deadline_ms = remaining > 5000 ? (int)remaining : 5000;
+      }
       int rc = local.turns == ROUNDTABLE_SEQUENTIAL
                    ? run_round_sequential(acfg, cfg, task, artifact, &peer_notes, local.mode, round,
                                           local.brief, results)
                    : run_round_parallel(acfg, cfg, task, artifact, peer_notes, local.mode, round,
-                                        local.brief, results);
+                                        local.brief, results, panel_deadline_ms);
       if (rc != 0)
       {
          for (int i = 0; i < ref_count; i++)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -239,6 +239,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-agent-runtime-messages \
                $(TESTPREFIX)/unit-test-minimax-tool-call-args \
                $(TESTPREFIX)/unit-test-delegate-liveness \
+               $(TESTPREFIX)/unit-test-agent-parallel \
                $(TESTPREFIX)/unit-test-workspace-manifest \
                $(TESTPREFIX)/unit-test-lsp \
                $(TESTPREFIX)/unit-test-memory-retrieval-eval \
@@ -1917,6 +1918,10 @@ $(TESTPREFIX)/unit-test-delegate-ensemble: $(OBJDIR)/tests/test_delegate_ensembl
 
 $(TESTPREFIX)/unit-test-delegate-liveness: $(OBJDIR)/tests/test_delegate_liveness.o \
                                     $(OBJDIR)/server/liveness.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-agent-parallel: $(OBJDIR)/tests/test_agent_parallel.o \
+                                    $(OBJDIR)/server/agent_parallel.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-agent-runtime-messages: $(OBJDIR)/tests/test_agent_runtime_messages.o \

--- a/src/tests/test_agent_parallel.c
+++ b/src/tests/test_agent_parallel.c
@@ -1,0 +1,141 @@
+/* test_agent_parallel.c: the real agent_run_parallel deadline-preemption path —
+ * a hung worker must be abandoned at the deadline, not wedge the whole fan-out.
+ * Links the real server/agent_parallel.o against stubbed agent exec functions. */
+#include "aimee.h"
+#include "agent_config.h"
+#include "agent_exec.h"
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* --- stubs for agent_parallel.o's dependencies --- */
+void agent_request_creds_snapshot(agent_request_creds_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+}
+void agent_request_creds_restore(const agent_request_creds_t *creds)
+{
+   (void)creds;
+}
+void aimee_log(int level, const char *tag, const char *fmt, ...)
+{
+   (void)level;
+   (void)tag;
+   (void)fmt;
+}
+/* Referenced by the static-inline aimee_resolve_compute_threads in config.h. */
+__thread int g_aimee_compute_threads_override = 0;
+
+/* A worker named "slow" blocks well past the test deadline; everyone else
+ * returns immediately. */
+static void sleep_ms(int ms)
+{
+   struct timespec ts = {ms / 1000, (long)(ms % 1000) * 1000000L};
+   nanosleep(&ts, NULL);
+}
+int agent_run_named(agent_config_t *cfg, const char *name, const char *role,
+                    const char *system_prompt, const char *user_prompt, int max_tokens,
+                    double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)role;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   if (name && strcmp(name, "slow") == 0)
+      sleep_ms(3000);
+   out->response = strdup("ok");
+   out->success = 1;
+   snprintf(out->agent_name, sizeof(out->agent_name), "%s", name ? name : "");
+   return 0;
+}
+int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_prompt,
+                 const char *user_prompt, int max_tokens, double temperature, agent_result_t *out)
+{
+   (void)cfg;
+   (void)role;
+   (void)system_prompt;
+   (void)user_prompt;
+   (void)max_tokens;
+   (void)temperature;
+   memset(out, 0, sizeof(*out));
+   out->response = strdup("ok");
+   out->success = 1;
+   return 0;
+}
+
+static long now_ms(void)
+{
+   struct timespec t;
+   clock_gettime(CLOCK_MONOTONIC, &t);
+   return t.tv_sec * 1000 + t.tv_nsec / 1000000;
+}
+
+static void test_deadline_abandons_hung_worker(void)
+{
+   agent_task_t tasks[3];
+   memset(tasks, 0, sizeof(tasks));
+   tasks[0].agent = "fast0";
+   tasks[0].role = "review";
+   tasks[1].agent = "slow";
+   tasks[1].role = "review";
+   tasks[2].agent = "fast2";
+   tasks[2].role = "review";
+   agent_result_t out[3];
+   memset(out, 0, sizeof(out));
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+
+   long t0 = now_ms();
+   int succ = agent_run_parallel(&cfg, tasks, 3, out, 200 /* ms deadline */);
+   long elapsed = now_ms() - t0;
+
+   /* Returned at ~the deadline, not after the 3000ms slow worker. */
+   assert(elapsed < 2000);
+   assert(succ == 2);
+   assert(out[0].success == 1 && out[0].response);
+   assert(out[2].success == 1 && out[2].response);
+   assert(out[1].success == 0); /* slow worker abandoned -> failed slot */
+   assert(out[1].response == NULL);
+   free(out[0].response);
+   free(out[2].response);
+   printf("  test_deadline_abandons_hung_worker: ok (%ldms, %d ok)\n", elapsed, succ);
+}
+
+static void test_no_deadline_runs_all(void)
+{
+   agent_task_t tasks[3];
+   memset(tasks, 0, sizeof(tasks));
+   for (int i = 0; i < 3; i++)
+   {
+      tasks[i].agent = "fast";
+      tasks[i].role = "review";
+   }
+   agent_result_t out[3];
+   memset(out, 0, sizeof(out));
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   int succ = agent_run_parallel(&cfg, tasks, 3, out, 0 /* no deadline */);
+   assert(succ == 3);
+   for (int i = 0; i < 3; i++)
+   {
+      assert(out[i].success == 1);
+      free(out[i].response);
+   }
+   printf("  test_no_deadline_runs_all: ok\n");
+}
+
+int main(void)
+{
+   printf("agent_parallel tests\n");
+   test_deadline_abandons_hung_worker();
+   test_no_deadline_runs_all();
+   printf("all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -75,9 +75,11 @@ int model_capability_get(const char *provider, const char *model_id, model_capab
    return 0;
 }
 
-int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agent_result_t *out)
+int agent_run_parallel(agent_config_t *cfg, agent_task_t *tasks, int count, agent_result_t *out,
+                       int deadline_ms)
 {
    (void)cfg;
+   (void)deadline_ms;
    g_parallel_calls++;
    snprintf(g_last_parallel_prompt, sizeof(g_last_parallel_prompt), "%s",
             count > 0 && tasks[0].user_prompt ? tasks[0].user_prompt : "");


### PR DESCRIPTION
## Why
The R2 roundtable wedged ~18 min past its 10-min deadline. Root cause:
`agent_run_parallel` blocks on `pthread_join`, so a panelist whose HTTP call
hangs (codex's OAuth path is the suspect — it didn't honor its timeout) stalls
the whole parallel barrier **forever**. The roundtable deadline is only checked
*between* rounds, so it can't preempt an in-flight stuck call.

## Change
- **`agent_run_parallel` gains a `deadline_ms`** (`<=0` = the historical unbounded
  join, used by the 3 non-roundtable callers and the MoA-aggregate path). When set:
  spawn all workers, wait on a `pthread_cond_timedwait` completion barrier, and at
  the deadline **abandon (detach) any straggler**.
- **Memory-safe abandonment:** each worker writes its OWN heap result cell;
  finished cells are *moved* into the caller's `out[]`, and a still-running worker
  keeps its cell + the shared sync/ctx alive (intentionally leaked — bounded, rare,
  logged) so its eventual write can never touch freed caller memory. Portable
  (`cond_timedwait`, not glibc `timedjoin_np` — `agent_parallel.c` is in the
  cross-platform client build).
- The **roundtable threads its remaining deadline budget** into the panel call, so
  a hung panelist is dropped at the deadline (counted as `participants_failed`) and
  the round proceeds with `min_successful` — no wedge.

## Test
New `test_agent_parallel` links the real object against stubbed agent-exec fns:
with a 3 s "slow" worker and a 200 ms deadline, the call returns at ~the deadline
(< 2 s) with the slow worker abandoned (failed slot, `response == NULL`) and the
fast workers succeeding; the no-deadline path still runs all. `make lint` +
delegate-ensemble + agent-parallel suites pass.
