### PR TITLE
fix(roundtable): gate panel on claude delegate authorization (auto + explicit)

### DIFF
--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -124,6 +124,16 @@ void delegate_roundtable_result_free(roundtable_result_t *r);
  * model. */
 void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg);
 
+/* 1 if `ag` may sit on a panel: enabled + named, and a claude-CLI only when
+ * authorized (claude_cli_delegate_enabled) AND server-hosted (is_server_hosted). */
+int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag);
+
+/* Drop unauthorized/ineligible configured agents (e.g. an unauthorized claude)
+ * from an EXPLICIT ensemble.reference_models list and fix up the aggregator. Run
+ * after ensemble_default_panel_from_agents so both auto and explicit panels are
+ * authorization-gated. */
+void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *acfg);
+
 /* Persona name for review panelist `model_index`: a configured
  * ensemble.reference_personas[model_index] if set, else a round-robin over the
  * engine's diverse default lineup keyed on the stable model index. Returns NULL

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1235,6 +1235,23 @@ static int run_round_sequential(agent_config_t *acfg, const config_t *cfg, const
    return 0;
 }
 
+/* Is `ag` allowed to sit on a roundtable/ensemble panel? Enabled + named, and —
+ * for claude-CLI — AUTHORIZED as a delegate (claude_cli_delegate_enabled, the
+ * explicit, ToS-sensitive operator opt-in) AND able to run server-side
+ * (is_server_hosted, via `aimee agent add claude-oauth`). A client-only claude
+ * has no server endpoint and would just burn a slot on a "failed to build request
+ * URL" participant; server-hosting is capability, NOT authorization, so both are
+ * required. So an unauthorized or disabled claude is never seated, even after a
+ * server-side OAuth setup. Other enabled agents are eligible. */
+int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag)
+{
+   if (!ag || !ag->enabled || !ag->name[0])
+      return 0;
+   if (agent_is_claude_cli(ag) && (!cfg->claude_cli_delegate_enabled || !ag->is_server_hosted))
+      return 0;
+   return 1;
+}
+
 void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acfg)
 {
    if (cfg->ensemble_reference_count > 0)
@@ -1242,25 +1259,49 @@ void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acf
    int n = 0;
    for (int i = 0; i < acfg->agent_count && n < ENSEMBLE_MAX_REFS; i++)
    {
-      if (!acfg->agents[i].enabled || !acfg->agents[i].name[0])
-         continue;
-      /* Seat claude-CLI only when it is AUTHORIZED as a delegate
-       * (claude_cli_delegate_enabled — the explicit operator opt-in; running a
-       * Claude subscription as an automated delegate is ToS-sensitive) AND can
-       * actually run server-side (is_server_hosted, via `aimee agent add
-       * claude-oauth`; a client-only claude has no server endpoint and would just
-       * burn a slot on a "failed to build request URL" participant). Server-
-       * hosting is capability, NOT authorization — both are required. So an
-       * unauthorized claude (delegate gate off) or a disabled one (enabled is
-       * checked above) is never auto-seated, even after a server-side OAuth setup. */
-      if (agent_is_claude_cli(&acfg->agents[i]) &&
-          (!cfg->claude_cli_delegate_enabled || !acfg->agents[i].is_server_hosted))
+      if (!ensemble_panelist_eligible(cfg, &acfg->agents[i]))
          continue;
       snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]), "%s",
                acfg->agents[i].name);
       n++;
    }
    cfg->ensemble_reference_count = n;
+   if (!cfg->ensemble_aggregator[0] && n > 0)
+      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
+               cfg->ensemble_reference_models[0]);
+}
+
+void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *acfg)
+{
+   /* Applies the same eligibility rule to an EXPLICITLY configured
+    * ensemble.reference_models list: drop any entry that names a configured agent
+    * which is not panel-eligible (an unauthorized / disabled / client-only
+    * claude). An entry that is not a configured agent (an ad-hoc model id) is
+    * left as-is. Keeps reference_models and the aggregator consistent. */
+   int n = 0;
+   for (int i = 0; i < cfg->ensemble_reference_count; i++)
+   {
+      const char *name = cfg->ensemble_reference_models[i];
+      const agent_t *ag = agent_find((agent_config_t *)acfg, name);
+      if (ag && !ensemble_panelist_eligible(cfg, ag))
+      {
+         aimee_log(LOG_WARN, "delegate.panel",
+                   "dropping unauthorized panelist '%s' from the roundtable panel", name);
+         continue;
+      }
+      if (n != i)
+         snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]),
+                  "%s", name);
+      n++;
+   }
+   cfg->ensemble_reference_count = n;
+   /* If the aggregator named a now-dropped agent, repoint it to the first seat. */
+   if (cfg->ensemble_aggregator[0])
+   {
+      const agent_t *agg = agent_find((agent_config_t *)acfg, cfg->ensemble_aggregator);
+      if (agg && !ensemble_panelist_eligible(cfg, agg))
+         cfg->ensemble_aggregator[0] = '\0';
+   }
    if (!cfg->ensemble_aggregator[0] && n > 0)
       snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
                cfg->ensemble_reference_models[0]);

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -1244,14 +1244,17 @@ void ensemble_default_panel_from_agents(config_t *cfg, const agent_config_t *acf
    {
       if (!acfg->agents[i].enabled || !acfg->agents[i].name[0])
          continue;
-      /* Skip a CLIENT-ONLY claude-CLI: it has no HTTP endpoint (it runs on the
-       * thin client over the reverse channel, primary-only by default), so
-       * seating it just burns a slot on a "failed to build request URL"
-       * participant. A SERVER-HOSTED, OAuth'd claude (`is_server_hosted`, via
-       * `aimee agent add claude-oauth`) runs on the server and IS seatable.
-       * Otherwise mirror the manual route's gate (claude_cli_delegate_enabled). */
-      if (agent_is_claude_cli(&acfg->agents[i]) && !acfg->agents[i].is_server_hosted &&
-          !cfg->claude_cli_delegate_enabled)
+      /* Seat claude-CLI only when it is AUTHORIZED as a delegate
+       * (claude_cli_delegate_enabled — the explicit operator opt-in; running a
+       * Claude subscription as an automated delegate is ToS-sensitive) AND can
+       * actually run server-side (is_server_hosted, via `aimee agent add
+       * claude-oauth`; a client-only claude has no server endpoint and would just
+       * burn a slot on a "failed to build request URL" participant). Server-
+       * hosting is capability, NOT authorization — both are required. So an
+       * unauthorized claude (delegate gate off) or a disabled one (enabled is
+       * checked above) is never auto-seated, even after a server-side OAuth setup. */
+      if (agent_is_claude_cli(&acfg->agents[i]) &&
+          (!cfg->claude_cli_delegate_enabled || !acfg->agents[i].is_server_hosted))
          continue;
       snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]), "%s",
                acfg->agents[i].name);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1835,6 +1835,9 @@ int handle_delegate_aggregate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
    if (agent_load_config(&acfg) != 0)
       return server_send_error(conn, "could not load agents.json", NULL);
    ensemble_default_panel_from_agents(&cfg, &acfg);
+   /* Also gate an EXPLICIT reference_models list: never run an unauthorized
+    * claude as a panelist, however it got into the panel. */
+   ensemble_filter_panel_authorization(&cfg, &acfg);
    bind_request_session_creds(req);
 
    delegate_ensemble_result_t result;
@@ -1921,6 +1924,9 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
       return server_send_error(conn, "could not load agents.json", NULL);
    }
    ensemble_default_panel_from_agents(&cfg, &acfg);
+   /* Also gate an EXPLICIT reference_models list: never run an unauthorized
+    * claude as a panelist, however it got into the panel. */
+   ensemble_filter_panel_authorization(&cfg, &acfg);
    bind_request_session_creds(req);
 
    roundtable_result_t result;

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -832,20 +832,48 @@ static void test_default_panel_excludes_claude_cli(void)
    assert(strcmp(cfg.ensemble_reference_models[1], "codex") == 0);
    assert(strcmp(cfg.ensemble_aggregator, "mistral") == 0);
 
-   /* opt-in seats claude too */
+   /* claude needs BOTH authorization (claude_cli_delegate_enabled) AND
+    * server-hosting to be seated; neither alone is enough. */
+
+   /* (a) authorized but client-only (not server-hosted) -> still excluded */
    config_t cfg2;
    memset(&cfg2, 0, sizeof(cfg2));
    cfg2.claude_cli_delegate_enabled = 1;
    ensemble_default_panel_from_agents(&cfg2, &acfg);
-   assert(cfg2.ensemble_reference_count == 3);
+   assert(cfg2.ensemble_reference_count == 2);
 
-   /* a configured panel is left untouched (no-op) */
+   /* (b) server-hosted but NOT authorized -> still excluded (the key invariant:
+    * a server-side OAuth setup is not authorization to act as a panelist) */
+   acfg.agents[1].is_server_hosted = 1;
    config_t cfg3;
    memset(&cfg3, 0, sizeof(cfg3));
-   cfg3.ensemble_reference_count = 1;
-   snprintf(cfg3.ensemble_reference_models[0], 128, "preset");
    ensemble_default_panel_from_agents(&cfg3, &acfg);
-   assert(cfg3.ensemble_reference_count == 1);
+   assert(cfg3.ensemble_reference_count == 2);
+
+   /* (c) authorized AND server-hosted -> seated */
+   config_t cfg4;
+   memset(&cfg4, 0, sizeof(cfg4));
+   cfg4.claude_cli_delegate_enabled = 1;
+   ensemble_default_panel_from_agents(&cfg4, &acfg);
+   assert(cfg4.ensemble_reference_count == 3);
+
+   /* (d) disabled claude is never seated, even authorized + server-hosted */
+   acfg.agents[1].enabled = 0;
+   config_t cfg5;
+   memset(&cfg5, 0, sizeof(cfg5));
+   cfg5.claude_cli_delegate_enabled = 1;
+   ensemble_default_panel_from_agents(&cfg5, &acfg);
+   assert(cfg5.ensemble_reference_count == 2);
+   acfg.agents[1].enabled = 1;
+   acfg.agents[1].is_server_hosted = 0;
+
+   /* a configured panel is left untouched (no-op) */
+   config_t cfg6;
+   memset(&cfg6, 0, sizeof(cfg6));
+   cfg6.ensemble_reference_count = 1;
+   snprintf(cfg6.ensemble_reference_models[0], 128, "preset");
+   ensemble_default_panel_from_agents(&cfg6, &acfg);
+   assert(cfg6.ensemble_reference_count == 1);
    printf("  test_default_panel_excludes_claude_cli: ok\n");
 }
 

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -261,8 +261,14 @@ int agent_run_ex(agent_config_t *cfg, const char *role, const char *system_promp
  * stubs above; cost-fold is a no-op in the test (no parent session bound). */
 agent_t *agent_find(agent_config_t *cfg, const char *name)
 {
-   (void)cfg;
-   (void)name;
+   /* Real linear search (matches the production resolver). make_acfg() has zero
+    * agents so existing tests still resolve to NULL (lease path skipped); the
+    * panel-authorization test populates agents to exercise the filter. */
+   if (!cfg || !name)
+      return NULL;
+   for (int i = 0; i < cfg->agent_count; i++)
+      if (strcmp(cfg->agents[i].name, name) == 0)
+         return &cfg->agents[i];
    return NULL;
 }
 /* Stub: treat the agent literally named "claude" as the CLI-only agent. */
@@ -877,6 +883,44 @@ static void test_default_panel_excludes_claude_cli(void)
    printf("  test_default_panel_excludes_claude_cli: ok\n");
 }
 
+static void test_panel_filter_drops_unauthorized_claude(void)
+{
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   acfg.agent_count = 2;
+   acfg.agents[0].enabled = 1;
+   snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "mistral");
+   acfg.agents[1].enabled = 1;
+   snprintf(acfg.agents[1].name, MAX_AGENT_NAME, "claude"); /* claude-CLI per stub */
+
+   /* An EXPLICIT reference_models list naming an unauthorized claude drops it,
+    * keeps an ad-hoc (non-agent) model id, and repoints the aggregator. */
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.ensemble_reference_count = 3;
+   snprintf(cfg.ensemble_reference_models[0], 128, "mistral");
+   snprintf(cfg.ensemble_reference_models[1], 128, "claude");
+   snprintf(cfg.ensemble_reference_models[2], 128, "adhoc-model"); /* not an agent -> kept */
+   snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "claude");
+   ensemble_filter_panel_authorization(&cfg, &acfg);
+   assert(cfg.ensemble_reference_count == 2);
+   assert(strcmp(cfg.ensemble_reference_models[0], "mistral") == 0);
+   assert(strcmp(cfg.ensemble_reference_models[1], "adhoc-model") == 0);
+   assert(strcmp(cfg.ensemble_aggregator, "mistral") == 0); /* repointed off the dropped claude */
+
+   /* Authorized + server-hosted claude survives the explicit-list filter. */
+   acfg.agents[1].is_server_hosted = 1;
+   config_t cfg2;
+   memset(&cfg2, 0, sizeof(cfg2));
+   cfg2.claude_cli_delegate_enabled = 1;
+   cfg2.ensemble_reference_count = 2;
+   snprintf(cfg2.ensemble_reference_models[0], 128, "mistral");
+   snprintf(cfg2.ensemble_reference_models[1], 128, "claude");
+   ensemble_filter_panel_authorization(&cfg2, &acfg);
+   assert(cfg2.ensemble_reference_count == 2);
+   printf("  test_panel_filter_drops_unauthorized_claude: ok\n");
+}
+
 static void test_panel_persona_name_assignment(void)
 {
    config_t cfg;
@@ -1258,6 +1302,7 @@ int main(void)
    test_roundtable_review_saturation_converges();
    test_roundtable_review_brief_and_items_return();
    test_default_panel_excludes_claude_cli();
+   test_panel_filter_drops_unauthorized_claude();
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();
    test_roundtable_aggregator_fallback_synthesizes();


### PR DESCRIPTION
## The gap
The #325 panel-eligibility change let `is_server_hosted` **bypass** the
`claude_cli_delegate_enabled` authorization gate, so an enabled, OAuth'd claude
could be seated in the roundtable panel **even when the operator hadn't
authorized claude to act as a delegate**. Server-hosting is *capability*, not
*authorization*.

## Fix
A shared `ensemble_panelist_eligible(cfg, ag)` helper now gates both panel paths.
A claude-CLI agent is eligible only when **all** of: `enabled`,
`claude_cli_delegate_enabled` (the explicit, ToS-sensitive operator opt-in), and
`is_server_hosted` (it can actually run server-side).

**Auto-panel** (`ensemble_default_panel_from_agents`): an unauthorized or
disabled claude is never auto-seated, even after a successful
`aimee agent add claude-oauth`.

**Explicit panel** (`ensemble_filter_panel_authorization`, run after the
auto-panel in both the roundtable and aggregate handlers): an explicit
`ensemble.reference_models` list that names an unauthorized `claude` now has it
**dropped**, and the aggregator is repointed if it named the dropped agent.
Ad-hoc (non-agent) model ids in the list are kept untouched.

## Tests
- Auto-panel: default-excluded · authorized-but-client-only-excluded ·
  server-hosted-but-unauthorized-excluded · authorized+server-hosted-seated ·
  disabled-never-seated.
- Explicit filter: drops unauthorized claude from a reference_models list,
  keeps an ad-hoc model id, repoints the aggregator, keeps authorized+server-hosted claude.