### PR TITLE
refactor(cli): rename cli_rpc_* -> cli_v1_* (no behavior change)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -770,7 +770,7 @@ $(WEBCHAT): $(WEBCHAT_GO_SRCS)
 # keep this target free of DB2_OBJS and libpq.
 #
 # aimee_client.o resolves the dependency-free remote-target accessors
-# (aimee_client_remote_active / _token) that cli_rpc_client_endpoint now calls to
+# (aimee_client_remote_active / _token) that cli_v1_client_endpoint now calls to
 # synthesize a tcp: endpoint from a --server / AIMEE_SERVER_URL / remote.conf
 # target. --gc-sections drops the rest of aimee_client (the actual TCP/TLS
 # transport), so no extra net/tls/uds objects are needed here.
@@ -792,7 +792,7 @@ $(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(KB_DA
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_KB)
 
-# aimee_client.o for the same reason as $(SERVER): cli_rpc_client_endpoint calls
+# aimee_client.o for the same reason as $(SERVER): cli_v1_client_endpoint calls
 # the dependency-free remote-target accessors; --gc-sections drops the transport.
 $(GATEWAY): $(GATEWAY_OBJS) $(OBJDIR)/aimee_client.o
 	$(AIMEE_RUNTIME_MUTATION_GUARD)

--- a/src/README.md
+++ b/src/README.md
@@ -763,7 +763,7 @@ unclean-exit forensics (`shutdown_forensics.c`) to DB1.
 ## RPC method catalog
 
 The dispatch table in `src/server/server.c` currently registers 162 typed server
-methods; the thin CLI maps supported commands to them in `cli_rpc_routes.inc`
+methods; the thin CLI maps supported commands to them in `cli_v1_routes.inc`
 (144 routes/aliases at this revision). Commands implemented only in legacy
 `cmd_*` modules are not user-facing until they have a typed route. By family:
 

--- a/src/cli_agent_setup.c
+++ b/src/cli_agent_setup.c
@@ -106,7 +106,7 @@ static int setup_prompt_line(const char *label, char *buf, size_t n)
 static int setup_ensure_server(const char *method, const char **sock)
 {
    *sock = NULL;
-   if (!cli_rpc_has_remote_endpoint())
+   if (!cli_v1_has_remote_endpoint())
    {
       *sock = cli_ensure_server_for_method(method);
       if (!*sock)
@@ -168,8 +168,8 @@ static int setup_api_provider_cmd(const char *provider, int json_output)
    }
 
    int rc;
-   cli_rpc_route_t route;
-   if (!cli_rpc_lookup("agent", n, sub, &route))
+   cli_v1_route_t route;
+   if (!cli_v1_lookup("agent", n, sub, &route))
    {
       fprintf(stderr, "aimee agent setup: no agent.add route available\n");
       rc = 1;
@@ -182,7 +182,7 @@ static int setup_api_provider_cmd(const char *provider, int json_output)
       rc = 1;
       goto done;
    }
-   rc = cli_rpc_forward(sock, &route, json_output, NULL, NULL, n, sub);
+   rc = cli_v1_forward(sock, &route, json_output, NULL, NULL, n, sub);
    if (rc < 0)
    {
       fprintf(stderr, "aimee agent setup: server request failed\n");

--- a/src/cli_code_audit.c
+++ b/src/cli_code_audit.c
@@ -1,6 +1,6 @@
 /* cli_code_audit.c: see cli_code_audit.h. */
 #include "cli_code_audit.h"
-#include "cli_client.h" /* cli_http_request, cli_rpc_client_* */
+#include "cli_client.h" /* cli_http_request, cli_v1_client_* */
 #include "aimee_home.h"
 #include "cJSON.h"
 #include <ctype.h>
@@ -355,14 +355,14 @@ static int stem_in_tests(const audit_acc_t *a, const char *stem)
 
 static cJSON *audit_graph_remote(const char *project, int quiet)
 {
-   char *endpoint = cli_rpc_client_endpoint();
+   char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
    {
       if (!quiet)
          fprintf(stderr, "code audit --graph: no aimee server configured (set `aimee remote`).\n");
       return NULL;
    }
-   char *bearer = cli_rpc_client_bearer();
+   char *bearer = cli_v1_client_bearer();
    cJSON *body = cJSON_CreateObject();
    if (project && project[0])
       cJSON_AddStringToObject(body, "project", project);

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -423,8 +423,8 @@ static int client_delegate_plan(int argc, char **argv, int global_json_output)
       char parbuf[32];
       snprintf(parbuf, sizeof(parbuf), "%d", parallel > 0 ? parallel : 3);
       char *launch_argv[] = {"launch", (char *)output_path, "--parallel", parbuf};
-      cli_rpc_route_t route;
-      if (!cli_rpc_lookup("delegate", 4, launch_argv, &route))
+      cli_v1_route_t route;
+      if (!cli_v1_lookup("delegate", 4, launch_argv, &route))
       {
          cJSON_Delete(plan);
          fprintf(stderr, "aimee: delegate launch route unavailable\n");
@@ -440,7 +440,7 @@ static int client_delegate_plan(int argc, char **argv, int global_json_output)
       }
       if (!json_output)
          printf("Launching reviewed packet plan...\n");
-      int rc = cli_rpc_forward(sock, &route, json_output, NULL, NULL, 4, launch_argv);
+      int rc = cli_v1_forward(sock, &route, json_output, NULL, NULL, 4, launch_argv);
       cJSON_Delete(plan);
       return rc >= 0 ? rc : 1;
    }
@@ -854,7 +854,7 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
     * client's working tree over the reverse-channel so those tools act here (the
     * client never absorbs the engine or a DB). A co-located server uses the local
     * socket as before. */
-   int remote = cli_rpc_remote_endpoint_is_tcp();
+   int remote = cli_v1_remote_endpoint_is_tcp();
    const char *sock = NULL;
    if (remote)
    {
@@ -880,8 +880,8 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
    cJSON *resp;
    if (remote)
    {
-      char *endpoint = cli_rpc_client_endpoint();
-      char *bearer = cli_rpc_client_bearer();
+      char *endpoint = cli_v1_client_endpoint();
+      char *bearer = cli_v1_client_bearer();
       char *body = cJSON_PrintUnformatted(req);
       int status = 0;
       resp = (endpoint && body) ? cli_http_request(endpoint, "POST", "/v1/launch/run", body, bearer,
@@ -1387,7 +1387,7 @@ static char *acp_dispatch_prompt(const char *content, const char *session_id)
 {
    /* ACP turns run the agent locally (see launch_session_with_input); a remote
     * /v1 endpoint cannot serve them. */
-   if (cli_rpc_remote_endpoint_is_tcp())
+   if (cli_v1_remote_endpoint_is_tcp())
       return NULL;
    const char *sock = cli_ensure_server_for_method("chat.send_stream");
    if (!sock)
@@ -1453,7 +1453,7 @@ int main(int argc, char **argv)
 {
    /* Ignore SIGPIPE so write() to a dead aimee-server socket returns EPIPE
     * instead of terminating the CLI mid-RPC. cli_client retries via
-    * cli_rpc_forward; mcp-serve's reconnect loop reuses the same path.
+    * cli_v1_forward; mcp-serve's reconnect loop reuses the same path.
     * Without this, a server restart between two CLI calls killed the
     * caller and (for mcp-serve) showed up to Claude as
     * "MCP server disconnected". */
@@ -1779,7 +1779,7 @@ int main(int argc, char **argv)
     * root lives on THIS host, which the server cannot read. Resolve + register +
     * ingest from the client rather than forwarding the raw path (which the
     * server would try to realpath against its own filesystem and reject). */
-   if (cli_rpc_remote_endpoint_is_tcp())
+   if (cli_v1_remote_endpoint_is_tcp())
    {
       if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "add") == 0)
          return cli_workspace_add_remote(sub_argc >= 2 ? sub_argv[1] : NULL);
@@ -1795,15 +1795,15 @@ int main(int argc, char **argv)
 
    /* Route through native server RPCs when possible. */
    {
-      cli_rpc_route_t route;
-      if (cli_rpc_lookup(cmd, sub_argc, sub_argv, &route))
+      cli_v1_route_t route;
+      if (cli_v1_lookup(cmd, sub_argc, sub_argv, &route))
       {
          const char *server_method = route.server_method ? route.server_method : route.method;
-         /* A configured remote /v1 endpoint is served over TCP by cli_rpc_forward;
+         /* A configured remote /v1 endpoint is served over TCP by cli_v1_forward;
           * there is no local socket to discover, so skip the socket preflight
           * (which would print "server unavailable") in that mode. */
          const char *sock = NULL;
-         if (!cli_rpc_has_remote_endpoint())
+         if (!cli_v1_has_remote_endpoint())
          {
             sock = cli_ensure_server_for_method(server_method);
             if (!sock)
@@ -1812,8 +1812,8 @@ int main(int argc, char **argv)
                return 1;
             }
          }
-         int rc = cli_rpc_forward(sock, &route, json_output, json_fields, response_profile,
-                                  sub_argc, sub_argv);
+         int rc = cli_v1_forward(sock, &route, json_output, json_fields, response_profile, sub_argc,
+                                 sub_argv);
          if (rc >= 0)
             return rc;
          fprintf(stderr, "aimee: server RPC request failed for '%s'\n", cmd);

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -148,10 +148,10 @@ static cJSON *server_request(cJSON *req, int timeout_ms)
     * cwd is a registered detached workspace marshal back to this client over the
     * workspace reverse-channel (Phase 2b); on a non-served cwd they fail safe
     * server-side (the path does not exist there). */
-   if (cli_rpc_has_remote_endpoint())
+   if (cli_v1_has_remote_endpoint())
    {
-      char *endpoint = cli_rpc_client_endpoint();
-      char *bearer = cli_rpc_client_bearer();
+      char *endpoint = cli_v1_client_endpoint();
+      char *bearer = cli_v1_client_bearer();
       /* Route by the request's ACTUAL method, not a hardcoded "mcp.call": e.g.
        * mcp.tools_list -> GET /v1/mcp/tools_list, mcp.call -> POST /v1/mcp/call.
        * Hardcoding mcp.call sent tools/list to /v1/mcp/call (which needs a `tool`

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -77,10 +77,10 @@ static void ss_render_section(struct ss_sbuf *b, const char *title, cJSON *arr)
  * value. Always soft-fails (exit 0) so the host session is never blocked. */
 static int handle_session_start_remote(void)
 {
-   char *endpoint = cli_rpc_client_endpoint();
+   char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
       return 0;
-   char *bearer = cli_rpc_client_bearer();
+   char *bearer = cli_v1_client_bearer();
 
    cJSON *body = cJSON_CreateObject();
    /* task_hint is required by /v1/memory/recall; session_start widens recall. */
@@ -157,7 +157,7 @@ int handle_user_prompt_submit(void)
        hook_json ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(hook_json, "prompt"))
                  : NULL;
 
-   char *endpoint = cli_rpc_client_endpoint();
+   char *endpoint = cli_v1_client_endpoint();
    if (!prompt || !prompt[0] || !endpoint)
    {
       free(endpoint);
@@ -165,7 +165,7 @@ int handle_user_prompt_submit(void)
       free(stdin_data);
       return 0;
    }
-   char *bearer = cli_rpc_client_bearer();
+   char *bearer = cli_v1_client_bearer();
 
    cJSON *body = cJSON_CreateObject();
    cJSON_AddStringToObject(body, "task_hint", prompt);
@@ -232,10 +232,10 @@ int handle_pre_compact(void)
    char *stdin_data = read_stdin();
    free(stdin_data); /* PreCompact payload is informational; recall is broad. */
 
-   char *endpoint = cli_rpc_client_endpoint();
+   char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
       return 0;
-   char *bearer = cli_rpc_client_bearer();
+   char *bearer = cli_v1_client_bearer();
 
    cJSON *body = cJSON_CreateObject();
    cJSON_AddStringToObject(body, "task_hint", "compaction re-prime");
@@ -313,7 +313,7 @@ int handle_session_start(int json_output)
       /* No co-located server. If a remote /v1 endpoint is configured, the thin
        * client serves session-start itself via the read-only recall route — no
        * local aimee-server needed (see handle_session_start_remote). */
-      if (cli_rpc_has_remote_endpoint())
+      if (cli_v1_has_remote_endpoint())
       {
          int rc = handle_session_start_remote();
          cJSON_Delete(hook_json);

--- a/src/cli_tui.c
+++ b/src/cli_tui.c
@@ -128,9 +128,9 @@ static int chat_v1_endpoint(char *out, size_t out_len)
 {
    if (!out || out_len == 0)
       return -1;
-   if (cli_rpc_has_remote_endpoint())
+   if (cli_v1_has_remote_endpoint())
    {
-      char *ep = cli_rpc_client_endpoint();
+      char *ep = cli_v1_client_endpoint();
       if (ep)
       {
          int n = snprintf(out, out_len, "%s", ep);
@@ -150,7 +150,7 @@ static int chat_v1_endpoint(char *out, size_t out_len)
  * NULL for the local UDS (no auth needed). Caller frees. */
 static char *chat_v1_bearer(void)
 {
-   return cli_rpc_has_remote_endpoint() ? cli_rpc_client_bearer() : NULL;
+   return cli_v1_has_remote_endpoint() ? cli_v1_client_bearer() : NULL;
 }
 
 /* Build "/v1/sessions/<pct-encoded session_id><suffix>" into out. Returns 0 on

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -17,7 +17,7 @@
 
 /* Only the POSIX /v1 retry loop calls this now (the Windows path has no retry),
  * so mark it maybe-unused to stay clean under the Windows build's -Werror. */
-static void __attribute__((unused)) cli_rpc_sleep_ms(int ms)
+static void __attribute__((unused)) cli_v1_sleep_ms(int ms)
 {
 #if defined(_WIN32) || defined(_WIN64)
    Sleep((DWORD)ms);
@@ -118,7 +118,7 @@ static int rpc_has_flag(const rpc_opts_t *opts, const char *name)
    return rpc_get(opts, name) != NULL;
 }
 
-static int cli_rpc_args_request_json(int argc, char **argv)
+static int cli_v1_args_request_json(int argc, char **argv)
 {
    for (int i = 0; i < argc; i++)
    {
@@ -345,7 +345,7 @@ static const struct
     {NULL, NULL, NULL, NULL, NULL, 0},
 };
 
-int cli_rpc_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_rpc_route_t *route)
+int cli_v1_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_v1_route_t *route)
 {
    if (!cmd)
       return 0;
@@ -1491,7 +1491,7 @@ static void marshal_preload_append_file(char *block, size_t cap, size_t *pos, co
  * unit-test target that compiles it — need no extra link dependency. */
 /* Caller (marshal_preload_append_symbol) is POSIX-only, so this is unused on the
  * Windows build — mark maybe-unused to stay -Werror-clean there. */
-__attribute__((unused)) static char *cli_rpc_shell_quote_inner(const char *raw)
+__attribute__((unused)) static char *cli_v1_shell_quote_inner(const char *raw)
 {
    if (!raw)
       return NULL;
@@ -1529,7 +1529,7 @@ static void marshal_preload_append_symbol(char *block, size_t cap, size_t *pos, 
       return;
    /* shell_escape the symbol: it is interpolated into a popen() command, so a
     * raw single quote would break out of the quotes and inject shell commands. */
-   char *esc_sym = cli_rpc_shell_quote_inner(sym);
+   char *esc_sym = cli_v1_shell_quote_inner(sym);
    if (!esc_sym)
       return;
    char find_cmd[512];
@@ -1818,7 +1818,7 @@ static cJSON *marshal_delegate(int argc, char **argv)
    /* Foreground delegate streams over a long-lived connection and has no /v1
     * route; against a remote aimee-server force background so the call uses the
     * /v1/delegate/run route (returns a job_id to poll via `aimee jobs`). */
-   if (rpc_get(&opts, "background") || cli_rpc_has_remote_endpoint())
+   if (rpc_get(&opts, "background") || cli_v1_has_remote_endpoint())
       cJSON_AddTrueToObject(req, "background");
    /* --tools forces tools on; --no-tools forces them OFF even for a role that
     * enables tools by default (e.g. `review`) — the right mode for an
@@ -6546,15 +6546,15 @@ static int write_delegate_output_file(const char *path, const char *text)
 }
 
 #if !defined(_WIN32) && !defined(_WIN64)
-/* cli_rpc_http_request: minimal HTTP/1.1 request (any verb) over aimee-server's
+/* cli_v1_http_request: minimal HTTP/1.1 request (any verb) over aimee-server's
  * /v1 Unix socket (<aimee_home>/aimee-http.sock). Kept local to the thin client
  * so the api.client_transport cutover adds no new link dependency
  * (http_uds_client.c is not linked into the CLI). Returns the response body
  * (heap; caller frees) and sets *status_out to the HTTP status; NULL on
  * transport failure. Mirrors http_uds_client.c, which serves the same role for
  * the TUI. */
-static char *cli_rpc_http_request(const char *verb, const char *path, const char *body,
-                                  int *status_out)
+static char *cli_v1_http_request(const char *verb, const char *path, const char *body,
+                                 int *status_out)
 {
    if (status_out)
       *status_out = 0;
@@ -6659,19 +6659,19 @@ static char *cli_rpc_http_request(const char *verb, const char *path, const char
 /* The thin client is a strict /v1 consumer: there is no socket/auto transport
  * selection any more (the legacy NDJSON transport was removed). One-shot
  * commands go over the local aimee-http.sock, or a configured remote /v1
- * endpoint (cli_rpc_client_endpoint) — see cli_rpc_forward below. */
+ * endpoint (cli_v1_client_endpoint) — see cli_v1_forward below. */
 #endif /* !_WIN32 — the aimee-http.sock helpers above are POSIX-only */
 
 /* The remote-endpoint resolvers below are portable (env + aimee.yaml, no UDS)
- * and MUST compile on Windows too: cli_rpc_forward calls them unconditionally
+ * and MUST compile on Windows too: cli_v1_forward calls them unconditionally
  * and the Windows thin client always takes the remote /v1 path. */
 
-/* cli_rpc_aimee_yaml_value: scan <aimee_home>/aimee.yaml for the first
+/* cli_v1_aimee_yaml_value: scan <aimee_home>/aimee.yaml for the first
  * (non-comment) line containing <key> and return its malloc'd, unquoted value,
  * or NULL when absent/empty. The full config_t parser is not linked into the
  * thin client, so the api.client_* settings are read with this lightweight
  * scan. Caller frees. */
-static char *cli_rpc_aimee_yaml_value(const char *key)
+static char *cli_v1_aimee_yaml_value(const char *key)
 {
    const char *home = aimee_home();
    if (!home || !home[0])
@@ -6716,7 +6716,7 @@ static char *cli_rpc_aimee_yaml_value(const char *key)
    return result;
 }
 
-/* cli_rpc_client_endpoint: a remote aimee-server /v1 endpoint for the HTTP
+/* cli_v1_client_endpoint: a remote aimee-server /v1 endpoint for the HTTP
  * transport — "tcp:host:port" (or an explicit "unix:/path"). AIMEE_API_ENDPOINT
  * overrides; otherwise aimee.api.client_endpoint in aimee.yaml. NULL means no
  * remote is configured and the caller falls back to the local aimee-http.sock.
@@ -6727,7 +6727,7 @@ static char *cli_rpc_aimee_yaml_value(const char *key)
  * URL becomes "tls:host:port" (native client TLS to the server's #304 TLS
  * listener); http:// becomes "tcp:host:port"; an explicit tcp:/tls:/unix:
  * endpoint passes through unchanged. Caller frees. */
-static char *cli_rpc_normalize_endpoint(const char *ep)
+static char *cli_v1_normalize_endpoint(const char *ep)
 {
    if (!ep || !ep[0])
       return NULL;
@@ -6764,15 +6764,15 @@ static char *cli_rpc_normalize_endpoint(const char *ep)
    return strdup(out);
 }
 
-char *cli_rpc_client_endpoint(void)
+char *cli_v1_client_endpoint(void)
 {
    const char *env = getenv("AIMEE_API_ENDPOINT");
    if (env && env[0])
-      return cli_rpc_normalize_endpoint(env);
-   char *yaml = cli_rpc_aimee_yaml_value("client_endpoint:");
+      return cli_v1_normalize_endpoint(env);
+   char *yaml = cli_v1_aimee_yaml_value("client_endpoint:");
    if (yaml)
    {
-      char *norm = cli_rpc_normalize_endpoint(yaml);
+      char *norm = cli_v1_normalize_endpoint(yaml);
       free(yaml);
       return norm;
    }
@@ -6792,16 +6792,16 @@ char *cli_rpc_client_endpoint(void)
    return NULL;
 }
 
-/* cli_rpc_client_bearer: bearer token sent with the remote HTTP transport.
+/* cli_v1_client_bearer: bearer token sent with the remote HTTP transport.
  * AIMEE_API_BEARER overrides; otherwise the `bearer_token:` key in aimee.yaml
  * (the same value aimee-server reads for aimee.api.bearer_token). NULL means no
  * Authorization header. Caller frees. */
-char *cli_rpc_client_bearer(void)
+char *cli_v1_client_bearer(void)
 {
    const char *env = getenv("AIMEE_API_BEARER");
    if (env && env[0])
       return strdup(env);
-   char *yaml = cli_rpc_aimee_yaml_value("bearer_token:");
+   char *yaml = cli_v1_aimee_yaml_value("bearer_token:");
    if (yaml)
       return yaml;
    /* Token for a synthesized aimee_client endpoint: --server-token /
@@ -6812,19 +6812,19 @@ char *cli_rpc_client_bearer(void)
    return NULL;
 }
 
-/* cli_rpc_has_remote_endpoint: true when the thin client is configured to reach
+/* cli_v1_has_remote_endpoint: true when the thin client is configured to reach
  * a remote aimee-server over /v1 (client_transport != socket AND an endpoint is
  * set). The dispatcher uses this to skip the local-socket preflight, which would
  * otherwise fail with "server unavailable" because there is no aimee.sock to
  * find. Non-static so cli_main.c (a separate TU) can call it; mirrors the
- * linkage of cli_rpc_forward below. */
-int cli_rpc_has_remote_endpoint(void)
+ * linkage of cli_v1_forward below. */
+int cli_v1_has_remote_endpoint(void)
 {
 #if !defined(_WIN32) && !defined(_WIN64)
-   /* cli_rpc_client_endpoint() also synthesizes a tcp: endpoint from a --server /
+   /* cli_v1_client_endpoint() also synthesizes a tcp: endpoint from a --server /
     * AIMEE_SERVER_URL / remote.conf target (aimee_client), so this transparently
     * reports those too and the dispatcher skips the dead local-socket preflight. */
-   char *ep = cli_rpc_client_endpoint();
+   char *ep = cli_v1_client_endpoint();
    if (ep)
    {
       free(ep);
@@ -6835,23 +6835,23 @@ int cli_rpc_has_remote_endpoint(void)
    /* Windows has no UDS path and no AIMEE_API_ENDPOINT/aimee.yaml config: its
     * remote target comes from aimee_client (AIMEE_SERVER_URL or --server). Report
     * that so the dispatcher skips the (always-failing) local-socket preflight and
-    * lets cli_rpc_forward route over the remote /v1 via aimee_client_request. */
+    * lets cli_v1_forward route over the remote /v1 via aimee_client_request. */
    return aimee_client_has_remote();
 #endif
 }
 
-/* cli_rpc_remote_endpoint_is_tcp: like cli_rpc_has_remote_endpoint, but true only
+/* cli_v1_remote_endpoint_is_tcp: like cli_v1_has_remote_endpoint, but true only
  * for a genuinely remote "tcp:host:port" endpoint (not a local "unix:" one).
  * Interactive/co-located commands (chat, launch) use this to refuse a remote
  * server cleanly — the agent + tools + worktree run on this host. Non-static so
  * cli_main.c can call it. */
-int cli_rpc_remote_endpoint_is_tcp(void)
+int cli_v1_remote_endpoint_is_tcp(void)
 {
 #if !defined(_WIN32) && !defined(_WIN64)
    /* A synthesized aimee_client target (--server / AIMEE_SERVER_URL / remote.conf)
     * is always "tcp:host:port" (a network host, never a local unix: path), so
     * chat/launch refuse it here just like an explicit tcp: endpoint. */
-   char *ep = cli_rpc_client_endpoint();
+   char *ep = cli_v1_client_endpoint();
    int is_tcp = ep && strncmp(ep, "tcp:", 4) == 0;
    free(ep);
    return is_tcp;
@@ -7030,10 +7030,10 @@ const char *cli_v1_async_route_for_method(const char *method, const char **verb_
 }
 
 /* cli_v1_send: one /v1 request over the active transport — a remote endpoint
- * (cli_http_request), the co-located local UDS (cli_rpc_http_request), or the
+ * (cli_http_request), the co-located local UDS (cli_v1_http_request), or the
  * Windows remote client (aimee_client_request) — returning the parsed JSON
  * response (caller frees) or NULL on a transport error. Unifies the platform
- * branches so cli_rpc_forward and the async poller share one code path. */
+ * branches so cli_v1_forward and the async poller share one code path. */
 static cJSON *cli_v1_send(const char *remote, const char *bearer, const char *verb,
                           const char *path, const char *body, int timeout_ms, int *status_out)
 {
@@ -7046,7 +7046,7 @@ static cJSON *cli_v1_send(const char *remote, const char *bearer, const char *ve
    }
    else
    {
-      char *r = cli_rpc_http_request(verb, path, body, &status);
+      char *r = cli_v1_http_request(verb, path, body, &status);
       if (r)
       {
          resp = cJSON_Parse(r);
@@ -7110,7 +7110,7 @@ static cJSON *cli_v1_run_and_poll(const char *remote, const char *bearer, const 
       cJSON_Delete(snap);
       if (timeout_ms > 0 && waited >= timeout_ms)
          return NULL;
-      cli_rpc_sleep_ms(step_ms);
+      cli_v1_sleep_ms(step_ms);
       waited += step_ms;
    }
 }
@@ -7308,8 +7308,8 @@ int cli_workspace_add_remote(const char *path)
       return 1;
    }
 
-   char *remote = cli_rpc_client_endpoint();
-   char *bearer = cli_rpc_client_bearer();
+   char *remote = cli_v1_client_endpoint();
+   char *bearer = cli_v1_client_bearer();
 
    /* Register as detached so the server keeps the client path verbatim (no
     * server-side realpath) and skips its own filesystem scan. */
@@ -7363,8 +7363,8 @@ int cli_index_scan_remote(int argc, char **argv)
    }
    const char *root_arg = (npos >= 2) ? pos[1] : (npos == 1 ? pos[0] : NULL);
 
-   char *remote = cli_rpc_client_endpoint();
-   char *bearer = cli_rpc_client_bearer();
+   char *remote = cli_v1_client_endpoint();
+   char *bearer = cli_v1_client_bearer();
    int rc = 0;
 
    if (root_arg)
@@ -7480,7 +7480,7 @@ cJSON *cli_v1_dispatch_local(cJSON *req, int timeout_ms)
 }
 
 /* cli_v1_dispatch: like cli_v1_dispatch_local, but routes to a configured remote
- * /v1 endpoint when one is set (cli_rpc_client_endpoint), falling back to the
+ * /v1 endpoint when one is set (cli_v1_client_endpoint), falling back to the
  * co-located local UDS otherwise. Flows that must run against the SAME server that
  * will STORE the result — e.g. `agent setup` (codex-auth.json + the server vault) —
  * use this, since on a thin-client deployment that server is the remote, not a
@@ -7509,8 +7509,8 @@ cJSON *cli_v1_dispatch(cJSON *req, int timeout_ms)
    char *body = cJSON_PrintUnformatted(req);
    if (!body)
       return NULL;
-   char *remote = cli_rpc_client_endpoint();
-   char *bearer = remote ? cli_rpc_client_bearer() : NULL;
+   char *remote = cli_v1_client_endpoint();
+   char *bearer = remote ? cli_v1_client_bearer() : NULL;
    cJSON *resp = NULL;
    int status = 0;
    if (async_path)
@@ -7525,8 +7525,8 @@ cJSON *cli_v1_dispatch(cJSON *req, int timeout_ms)
 
 /* --- Main RPC forward function --- */
 
-int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int json_output,
-                    const char *json_fields, const char *response_profile, int argc, char **argv)
+int cli_v1_forward(const char *socket_path, const cli_v1_route_t *route, int json_output,
+                   const char *json_fields, const char *response_profile, int argc, char **argv)
 {
    (void)json_fields;
    (void)response_profile;
@@ -7543,7 +7543,7 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
       fwd_argc--;
       fwd_argv++;
    }
-   int effective_json_output = json_output || cli_rpc_args_request_json(fwd_argc, fwd_argv);
+   int effective_json_output = json_output || cli_v1_args_request_json(fwd_argc, fwd_argv);
 
    cJSON *req = marshal_request(route->method, fwd_argc, fwd_argv);
    if (!req)
@@ -7588,8 +7588,8 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
     * "unix:path", authed by its bearer) reaches an aimee-server on another host;
     * otherwise the co-located server over the local aimee-http.sock. Windows is
     * always remote (resolved from --server / AIMEE_SERVER_URL inside cli_v1_send). */
-   char *remote = cli_rpc_client_endpoint();
-   char *bearer = remote ? cli_rpc_client_bearer() : NULL;
+   char *remote = cli_v1_client_endpoint();
+   char *bearer = remote ? cli_v1_client_bearer() : NULL;
    int http_status = 0; /* last HTTP status from the REST send (0 for the async path) */
 
    if (http_body && async_path)
@@ -7627,7 +7627,7 @@ int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int j
                break;
          }
          if (attempt < max_retries)
-            cli_rpc_sleep_ms(retry_delays_ms[attempt]);
+            cli_v1_sleep_ms(retry_delays_ms[attempt]);
       }
    }
    else if (http_body)

--- a/src/cli_workspace_serve.c
+++ b/src/cli_workspace_serve.c
@@ -196,10 +196,10 @@ int cmd_workspace_serve(const char *workspace_id)
    const char *sock = NULL;
    char *endpoint = NULL;
    char *bearer = NULL;
-   if (cli_rpc_has_remote_endpoint())
+   if (cli_v1_has_remote_endpoint())
    {
-      endpoint = cli_rpc_client_endpoint();
-      bearer = cli_rpc_client_bearer();
+      endpoint = cli_v1_client_endpoint();
+      bearer = cli_v1_client_bearer();
    }
    if (!endpoint)
    {
@@ -308,15 +308,15 @@ static void *rc_thread_main(void *arg)
 
 int cli_workspace_reverse_channel_start(void)
 {
-   if (g_rc_active || !cli_rpc_has_remote_endpoint())
+   if (g_rc_active || !cli_v1_has_remote_endpoint())
       return 0;
    char cwd[CLI_TUI_PATH_MAX];
    if (!getcwd(cwd, sizeof(cwd)) || !cwd[0])
       return 0;
-   char *endpoint = cli_rpc_client_endpoint();
+   char *endpoint = cli_v1_client_endpoint();
    if (!endpoint)
       return 0;
-   char *bearer = cli_rpc_client_bearer();
+   char *bearer = cli_v1_client_bearer();
    int should_unregister = 0;
 
    /* Register the detached workspace. Treat "already registered" as an

--- a/src/cmd_infra.c
+++ b/src/cmd_infra.c
@@ -313,8 +313,8 @@ void cmd_git(app_ctx_t *ctx, int argc, char **argv)
 
       /* CLI path: no server context available — verify_run_waves falls back
        * to an ephemeral pool. The vast majority of verify invocations route
-       * through cli_rpc_lookup and end up server-side via mcp.call (see
-       * cli_rpc_routes.inc), so this branch is only hit when running aimee
+       * through cli_v1_lookup and end up server-side via mcp.call (see
+       * cli_v1_routes.inc), so this branch is only hit when running aimee
        * directly without a live server. */
       resp = handle_git_verify(NULL, args, NULL);
    }

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -198,11 +198,11 @@ typedef struct
    const char *extract;       /* response field to extract (NULL = return object minus "status") */
    int skip_subcmd;           /* number of leading sub-args consumed by route match (0, 1, or 2) */
    int timeout_ms;            /* RPC timeout (0 = CLIENT_DEFAULT_TIMEOUT_MS) */
-} cli_rpc_route_t;
+} cli_v1_route_t;
 
 /* Returns 1 if a matching RPC route was found, 0 otherwise.
  * Tries compound sub-commands first (e.g. "ingest status") before single ones. */
-int cli_rpc_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_rpc_route_t *route);
+int cli_v1_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_v1_route_t *route);
 
 /* Forward a CLI command through the server RPC.
  * Returns 0 on success, >0 on application error, -1 on transport/protocol
@@ -210,24 +210,24 @@ int cli_rpc_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_rpc_route
  * argc/argv are the args AFTER the command name (e.g., for "aimee memory search foo",
  * argv = ["search", "foo"]). The route's skip_subcmd controls whether the first
  * arg is stripped before marshaling. */
-int cli_rpc_forward(const char *socket_path, const cli_rpc_route_t *route, int json_output,
-                    const char *json_fields, const char *response_profile, int argc, char **argv);
+int cli_v1_forward(const char *socket_path, const cli_v1_route_t *route, int json_output,
+                   const char *json_fields, const char *response_profile, int argc, char **argv);
 
 /* True when the thin client is configured to reach a remote aimee-server /v1
  * endpoint (client_transport != socket AND AIMEE_API_ENDPOINT /
  * aimee.api.client_endpoint set). Callers skip the local-socket preflight. */
-int cli_rpc_has_remote_endpoint(void);
+int cli_v1_has_remote_endpoint(void);
 
 /* True only when the configured endpoint is a remote "tcp:host:port" (not a
  * local "unix:" path). Interactive commands (chat/launch) refuse a remote
  * endpoint because the agent/tools/worktree run on the client host. */
-int cli_rpc_remote_endpoint_is_tcp(void);
+int cli_v1_remote_endpoint_is_tcp(void);
 
 /* Resolve the remote /v1 endpoint ("tcp:host:port" / "unix:path") and bearer for
  * the HTTP transport (env AIMEE_API_ENDPOINT / AIMEE_API_BEARER, else aimee.yaml
  * client_endpoint / bearer_token). Caller frees. NULL when unset. POSIX only. */
-char *cli_rpc_client_endpoint(void);
-char *cli_rpc_client_bearer(void);
+char *cli_v1_client_endpoint(void);
+char *cli_v1_client_bearer(void);
 
 /* Thin-client workspace push: when the configured endpoint is a remote
  * "tcp:host:port" the server cannot see this host's filesystem, so

--- a/src/posix/cli_client.c
+++ b/src/posix/cli_client.c
@@ -254,7 +254,7 @@ cli_transport_t cli_transport_parse(const char *s)
 }
 
 /* cli_v1_route_for_method / cli_v1_pathid_route_for_method now live in the shared
- * cli_rpc_routes.inc (included by both posix/ and windows/cli_client.c) so the
+ * cli_v1_routes.inc (included by both posix/ and windows/cli_client.c) so the
  * Windows thin client uses the same first-class /v1 routing. */
 
 /* Percent-encode `in` into `out` (cap incl. NUL): RFC3986 unreserved bytes pass
@@ -291,7 +291,7 @@ int cli_v1_pct_encode(const char *in, char *out, size_t cap)
    return 0;
 }
 
-/* cli_v1_pathid_route_for_method moved to the shared cli_rpc_routes.inc. */
+/* cli_v1_pathid_route_for_method moved to the shared cli_v1_routes.inc. */
 
 int cli_http_build_request(const char *method, const char *path, const char *host,
                            const char *bearer, const char *body, char *buf, size_t cap)
@@ -1068,7 +1068,7 @@ int cli_server_available(const char *socket_path)
    return cli_http_health_ok(CLIENT_CONNECT_TIMEOUT_MS);
 }
 
-/* cli_v1_dispatch_local now lives in the shared cli_rpc_routes.inc — it resolves the
+/* cli_v1_dispatch_local now lives in the shared cli_v1_routes.inc — it resolves the
  * method's first-class /v1 route (no more POST /v1/rpc bridge). */
 
 void cli_close(cli_conn_t *conn)
@@ -1653,4 +1653,4 @@ int cli_start_server(void)
    return 0;
 }
 
-#include "../cli_rpc_routes.inc"
+#include "../cli_v1_routes.inc"

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -123,7 +123,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-client-integrations $(TESTPREFIX)/unit-test-mcp-git \
                $(TESTPREFIX)/unit-test-git-verify-select \
                $(TESTPREFIX)/unit-test-cli-mcp-serve \
-               $(TESTPREFIX)/unit-test-cli-rpc-delegate \
+               $(TESTPREFIX)/unit-test-cli-v1-delegate \
                $(TESTPREFIX)/unit-test-cli-server-compat \
                $(TESTPREFIX)/unit-test-platform-process \
                $(TESTPREFIX)/unit-test-shutdown-forensics \
@@ -455,11 +455,11 @@ $(TESTPREFIX)/unit-test-context-discover: $(OBJDIR)/tests/test_context_discover.
 $(TESTPREFIX)/unit-test-cli-mcp-serve: $(OBJDIR)/tests/test_cli_mcp_serve.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
-# aimee_client.o resolves the remote-target accessors cli_rpc_client_endpoint now
+# aimee_client.o resolves the remote-target accessors cli_v1_client_endpoint now
 # calls (it synthesizes a tcp: endpoint from a --server/AIMEE_SERVER_URL target).
 # --gc-sections drops the rest of the transport, which this marshalling test
 # never calls.
-$(TESTPREFIX)/unit-test-cli-rpc-delegate: $(OBJDIR)/tests/test_cli_rpc_delegate.o \
+$(TESTPREFIX)/unit-test-cli-v1-delegate: $(OBJDIR)/tests/test_cli_v1_delegate.o \
                                   $(OBJDIR)/cJSON.o $(OBJDIR)/posix/util.o $(OBJDIR)/aimee_client.o \
                                   $(OBJDIR)/codex_auth.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)

--- a/src/tests/test_build_integrity.sh
+++ b/src/tests/test_build_integrity.sh
@@ -486,7 +486,7 @@ fi
 
 route_drift=""
 for platform_client in posix/cli_client.c windows/cli_client.c; do
-    if ! grep -q '#include "../cli_rpc_routes.inc"' "$platform_client"; then
+    if ! grep -q '#include "../cli_v1_routes.inc"' "$platform_client"; then
         route_drift="$route_drift $platform_client:missing-shared-routes"
     fi
     if grep -q 'rpc_routes\[\]' "$platform_client"; then

--- a/src/tests/test_cli_mcp_serve.c
+++ b/src/tests/test_cli_mcp_serve.c
@@ -52,17 +52,17 @@ void cli_workspace_reverse_channel_stop(void)
 
 /* Remote-endpoint accessors used by server_request's remote-routing branch.
  * This test drives the local-socket path (cli_ensure_server returns a socket),
- * so cli_rpc_has_remote_endpoint() returns 0 and the rest are never called;
+ * so cli_v1_has_remote_endpoint() returns 0 and the rest are never called;
  * stub them so cli_mcp_serve.o links standalone. */
-int cli_rpc_has_remote_endpoint(void)
+int cli_v1_has_remote_endpoint(void)
 {
    return 0;
 }
-char *cli_rpc_client_endpoint(void)
+char *cli_v1_client_endpoint(void)
 {
    return NULL;
 }
-char *cli_rpc_client_bearer(void)
+char *cli_v1_client_bearer(void)
 {
    return NULL;
 }

--- a/src/tests/test_cli_v1_delegate.c
+++ b/src/tests/test_cli_v1_delegate.c
@@ -1,4 +1,4 @@
-/* test_cli_rpc_delegate.c: thin-client delegate RPC marshaling tests */
+/* test_cli_v1_delegate.c: thin-client delegate RPC marshaling tests */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -15,7 +15,7 @@
 #define RPC_PROTOCOL_VERSION 1
 
 /* Include the route implementation directly so static marshal helpers are testable. */
-#include "../cli_rpc_routes.inc"
+#include "../cli_v1_routes.inc"
 
 static void test_delegate_max_turns_marshaled(void)
 {
@@ -296,25 +296,25 @@ static void test_delegate_depth_requires_parent_env(void)
 
 static void test_provider_routes_and_marshaling(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
 
    char *list_lookup[] = {"list"};
-   assert(cli_rpc_lookup("provider", 1, list_lookup, &route));
+   assert(cli_v1_lookup("provider", 1, list_lookup, &route));
    assert(strcmp(route.method, "provider.list") == 0);
    assert(route.skip_subcmd == 1);
 
    char *show_lookup[] = {"show", "mistral"};
-   assert(cli_rpc_lookup("provider", 2, show_lookup, &route));
+   assert(cli_v1_lookup("provider", 2, show_lookup, &route));
    assert(strcmp(route.method, "provider.show") == 0);
    assert(route.skip_subcmd == 1);
 
    char *models_lookup[] = {"models", "mistral", "--json"};
-   assert(cli_rpc_lookup("provider", 3, models_lookup, &route));
+   assert(cli_v1_lookup("provider", 3, models_lookup, &route));
    assert(strcmp(route.method, "provider.models") == 0);
    assert(route.skip_subcmd == 1);
 
    char *quota_lookup[] = {"quota", "openrouter"};
-   assert(cli_rpc_lookup("provider", 2, quota_lookup, &route));
+   assert(cli_v1_lookup("provider", 2, quota_lookup, &route));
    assert(strcmp(route.method, "provider.quota") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -346,15 +346,15 @@ static void test_provider_routes_and_marshaling(void)
 
 static void test_model_routes_and_marshaling(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
 
    char *show_lookup[] = {"show", "openrouter:anthropic/claude-opus-4.6"};
-   assert(cli_rpc_lookup("model", 2, show_lookup, &route));
+   assert(cli_v1_lookup("model", 2, show_lookup, &route));
    assert(strcmp(route.method, "model.show") == 0);
    assert(route.skip_subcmd == 1);
 
    char *list_lookup[] = {"list", "--capability", "vision"};
-   assert(cli_rpc_lookup("model", 3, list_lookup, &route));
+   assert(cli_v1_lookup("model", 3, list_lookup, &route));
    assert(strcmp(route.method, "model.list") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -390,9 +390,9 @@ static void test_model_routes_and_marshaling(void)
 
 static void test_memory_show_alias_route(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *show_lookup[] = {"show", "181"};
-   assert(cli_rpc_lookup("memory", 2, show_lookup, &route));
+   assert(cli_v1_lookup("memory", 2, show_lookup, &route));
    assert(strcmp(route.method, "memory.get") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -411,9 +411,9 @@ static void test_memory_stats_route(void)
    /* `aimee memory stats` must resolve to a typed server RPC (memory.stats)
     * rather than falling through to unsupported_client_command. Regression
     * guard for the missing route gap from the CLI HTTP transport cutover. */
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *stats_lookup[] = {"stats"};
-   assert(cli_rpc_lookup("memory", 1, stats_lookup, &route));
+   assert(cli_v1_lookup("memory", 1, stats_lookup, &route));
    assert(strcmp(route.method, "memory.stats") == 0);
 
    cJSON *req = marshal_request("memory.stats", 0, NULL);
@@ -426,24 +426,24 @@ static void test_memory_stats_route(void)
 
 static void test_server_status_route_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
 
-   assert(cli_rpc_lookup("status", 0, NULL, &route));
+   assert(cli_v1_lookup("status", 0, NULL, &route));
    assert(strcmp(route.method, "server.health") == 0);
    assert(route.skip_subcmd == 0);
 
    char *top_status_json[] = {"--json"};
-   assert(cli_rpc_lookup("status", 1, top_status_json, &route));
+   assert(cli_v1_lookup("status", 1, top_status_json, &route));
    assert(strcmp(route.method, "server.health") == 0);
    assert(route.skip_subcmd == 0);
 
    char *status_lookup[] = {"status"};
-   assert(cli_rpc_lookup("server", 1, status_lookup, &route));
+   assert(cli_v1_lookup("server", 1, status_lookup, &route));
    assert(strcmp(route.method, "server.health") == 0);
    assert(route.skip_subcmd == 1);
 
    char *health_lookup[] = {"health"};
-   assert(cli_rpc_lookup("server", 1, health_lookup, &route));
+   assert(cli_v1_lookup("server", 1, health_lookup, &route));
    assert(strcmp(route.method, "server.health") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -452,9 +452,9 @@ static void test_server_status_route_lookup(void)
 
 static void test_kb_docs_push_route_and_marshal(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *lookup[] = {"docs", "push", "--scope", "project", "a.md", "b.md"};
-   assert(cli_rpc_lookup("kb", 6, lookup, &route));
+   assert(cli_v1_lookup("kb", 6, lookup, &route));
    assert(strcmp(route.method, "kb.docs.push") == 0);
    assert(route.skip_subcmd == 2);
 
@@ -509,15 +509,15 @@ static void test_git_verify_failure_detection(void)
 
 static void test_git_verify_marshaled_with_session_id(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *top_verify_argv[] = {"--async=false"};
-   assert(cli_rpc_lookup("verify", 1, top_verify_argv, &route));
+   assert(cli_v1_lookup("verify", 1, top_verify_argv, &route));
    assert(strcmp(route.method, "git.verify") == 0);
    assert(strcmp(route.server_method, "mcp.call") == 0);
    assert(route.skip_subcmd == 0);
 
    char *git_verify_argv[] = {"verify", "--async=false"};
-   assert(cli_rpc_lookup("git", 2, git_verify_argv, &route));
+   assert(cli_v1_lookup("git", 2, git_verify_argv, &route));
    assert(strcmp(route.method, "git.verify") == 0);
    assert(strcmp(route.server_method, "mcp.call") == 0);
    assert(route.skip_subcmd == 1);
@@ -553,9 +553,9 @@ static void test_git_verify_marshaled_with_session_id(void)
 
 static void test_get_help_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *topic_lookup[] = {"work", "queue"};
-   assert(cli_rpc_lookup("get_help", 2, topic_lookup, &route));
+   assert(cli_v1_lookup("get_help", 2, topic_lookup, &route));
    assert(strcmp(route.method, "get_help") == 0);
    assert(strcmp(route.server_method, "mcp.call") == 0);
    assert(route.skip_subcmd == 0);
@@ -569,7 +569,7 @@ static void test_get_help_route_marshaled(void)
    assert(strcmp(cJSON_GetObjectItem(args, "topic")->valuestring, "work queue") == 0);
    cJSON_Delete(req);
 
-   assert(cli_rpc_lookup("get-help", 2, topic_lookup, &route));
+   assert(cli_v1_lookup("get-help", 2, topic_lookup, &route));
    assert(strcmp(route.method, "get_help") == 0);
    assert(strcmp(route.server_method, "mcp.call") == 0);
 
@@ -588,27 +588,27 @@ static void test_get_help_route_marshaled(void)
 static void test_subcommand_json_flag_is_output_mode(void)
 {
    char *status_argv[] = {"134", "--json"};
-   assert(cli_rpc_args_request_json(2, status_argv) == 1);
+   assert(cli_v1_args_request_json(2, status_argv) == 1);
 
    char *prefix_argv[] = {"--json", "134"};
-   assert(cli_rpc_args_request_json(2, prefix_argv) == 1);
+   assert(cli_v1_args_request_json(2, prefix_argv) == 1);
 
    char *plain_argv[] = {"134"};
-   assert(cli_rpc_args_request_json(1, plain_argv) == 0);
+   assert(cli_v1_args_request_json(1, plain_argv) == 0);
 
    printf("  PASS: test_subcommand_json_flag_is_output_mode\n");
 }
 
 static void test_trigger_routes_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *list_argv[] = {"list"};
-   assert(cli_rpc_lookup("trigger", 1, list_argv, &route));
+   assert(cli_v1_lookup("trigger", 1, list_argv, &route));
    assert(strcmp(route.method, "trigger.list") == 0);
    assert(route.skip_subcmd == 1);
 
    char *fire_argv[] = {"fire", "--source", "ci", "--task", "debug failure"};
-   assert(cli_rpc_lookup("trigger", 5, fire_argv, &route));
+   assert(cli_v1_lookup("trigger", 5, fire_argv, &route));
    assert(strcmp(route.method, "trigger.fire") == 0);
    assert(route.skip_subcmd == 1);
    printf("  PASS: test_trigger_routes_lookup\n");
@@ -616,15 +616,15 @@ static void test_trigger_routes_lookup(void)
 
 static void test_dogfood_routes_and_marshaling(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *review_lookup[] = {"review", "--month", "2026-04"};
-   assert(cli_rpc_lookup("dogfood", 3, review_lookup, &route));
+   assert(cli_v1_lookup("dogfood", 3, review_lookup, &route));
    assert(strcmp(route.method, "dogfood.review") == 0);
    assert(route.skip_subcmd == 1);
    assert(route.timeout_ms == 300000);
 
    char *report_lookup[] = {"report", "--month", "2026-04"};
-   assert(cli_rpc_lookup("dogfood", 3, report_lookup, &route));
+   assert(cli_v1_lookup("dogfood", 3, report_lookup, &route));
    assert(strcmp(route.method, "dogfood.report") == 0);
    assert(route.timeout_ms == 300000);
 
@@ -642,15 +642,15 @@ static void test_dogfood_routes_and_marshaling(void)
 
 static void test_eval_routes_and_marshaling(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *run_lookup[] = {"run", "evals/delegate", "--ablation", "all"};
-   assert(cli_rpc_lookup("eval", 4, run_lookup, &route));
+   assert(cli_v1_lookup("eval", 4, run_lookup, &route));
    assert(strcmp(route.method, "eval.run") == 0);
    assert(route.skip_subcmd == 1);
    assert(route.timeout_ms == 900000);
 
    char *results_lookup[] = {"results", "delegate-tool-call-reliability"};
-   assert(cli_rpc_lookup("eval", 2, results_lookup, &route));
+   assert(cli_v1_lookup("eval", 2, results_lookup, &route));
    assert(strcmp(route.method, "eval.results") == 0);
    assert(route.timeout_ms == 0);
 
@@ -696,9 +696,9 @@ static void test_trigger_fire_token_marshaled(void)
 
 static void test_cron_routes_and_marshaling(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *add_lookup[] = {"add"};
-   assert(cli_rpc_lookup("cron", 1, add_lookup, &route));
+   assert(cli_v1_lookup("cron", 1, add_lookup, &route));
    assert(strcmp(route.method, "cron.add") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -741,14 +741,14 @@ static void test_cron_routes_and_marshaling(void)
 
 static void test_work_routes_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *claim_argv[] = {"claim"};
-   assert(cli_rpc_lookup("work", 1, claim_argv, &route));
+   assert(cli_v1_lookup("work", 1, claim_argv, &route));
    assert(strcmp(route.method, "work.claim") == 0);
    assert(route.skip_subcmd == 1);
 
    char *sync_argv[] = {"sync-proposals"};
-   assert(cli_rpc_lookup("work", 1, sync_argv, &route));
+   assert(cli_v1_lookup("work", 1, sync_argv, &route));
    assert(strcmp(route.method, "work.sync_proposals") == 0);
    assert(route.skip_subcmd == 1);
    printf("  PASS: test_work_routes_lookup\n");
@@ -756,9 +756,9 @@ static void test_work_routes_lookup(void)
 
 static void test_session_brief_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *lookup[] = {"brief", "--session", "abc123", "--list"};
-   assert(cli_rpc_lookup("session", 4, lookup, &route));
+   assert(cli_v1_lookup("session", 4, lookup, &route));
    assert(strcmp(route.method, "session.brief") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -770,7 +770,7 @@ static void test_session_brief_route_marshaled(void)
    cJSON_Delete(req);
 
    char *pos_lookup[] = {"brief", "def456"};
-   assert(cli_rpc_lookup("session", 2, pos_lookup, &route));
+   assert(cli_v1_lookup("session", 2, pos_lookup, &route));
    req = marshal_request("session.brief", 1, pos_lookup + 1);
    assert(req != NULL);
    assert(strcmp(cJSON_GetObjectItem(req, "session_id")->valuestring, "def456") == 0);
@@ -811,29 +811,29 @@ static void test_work_add_batch_marshaled(void)
 
 static void test_jobs_routes_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *list_argv[] = {"list"};
-   assert(cli_rpc_lookup("jobs", 1, list_argv, &route));
+   assert(cli_v1_lookup("jobs", 1, list_argv, &route));
    assert(strcmp(route.method, "jobs.list") == 0);
    assert(route.skip_subcmd == 1);
 
    char *status_argv[] = {"status", "12"};
-   assert(cli_rpc_lookup("jobs", 2, status_argv, &route));
+   assert(cli_v1_lookup("jobs", 2, status_argv, &route));
    assert(strcmp(route.method, "jobs.status") == 0);
    assert(route.skip_subcmd == 1);
 
    char *show_argv[] = {"show", "12"};
-   assert(cli_rpc_lookup("jobs", 2, show_argv, &route));
+   assert(cli_v1_lookup("jobs", 2, show_argv, &route));
    assert(strcmp(route.method, "jobs.status") == 0);
    assert(route.skip_subcmd == 1);
 
    char *logs_argv[] = {"logs", "12"};
-   assert(cli_rpc_lookup("jobs", 2, logs_argv, &route));
+   assert(cli_v1_lookup("jobs", 2, logs_argv, &route));
    assert(strcmp(route.method, "jobs.logs") == 0);
    assert(route.skip_subcmd == 1);
 
    char *cancel_argv[] = {"cancel", "12"};
-   assert(cli_rpc_lookup("jobs", 2, cancel_argv, &route));
+   assert(cli_v1_lookup("jobs", 2, cancel_argv, &route));
    assert(strcmp(route.method, "jobs.cancel") == 0);
    assert(route.skip_subcmd == 1);
    printf("  PASS: test_jobs_routes_lookup\n");
@@ -874,29 +874,29 @@ static void test_jobs_requests_marshaled(void)
 
 static void test_coord_job_routes_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *start_argv[] = {"start", "7"};
-   assert(cli_rpc_lookup("job", 2, start_argv, &route));
+   assert(cli_v1_lookup("job", 2, start_argv, &route));
    assert(strcmp(route.method, "job.start") == 0);
    assert(route.skip_subcmd == 1);
 
    char *list_argv[] = {"list"};
-   assert(cli_rpc_lookup("job", 1, list_argv, &route));
+   assert(cli_v1_lookup("job", 1, list_argv, &route));
    assert(strcmp(route.method, "job.list") == 0);
    assert(route.skip_subcmd == 1);
 
    char *status_argv[] = {"status", "12"};
-   assert(cli_rpc_lookup("job", 2, status_argv, &route));
+   assert(cli_v1_lookup("job", 2, status_argv, &route));
    assert(strcmp(route.method, "job.status") == 0);
    assert(route.skip_subcmd == 1);
 
    char *show_argv[] = {"show", "12"};
-   assert(cli_rpc_lookup("job", 2, show_argv, &route));
+   assert(cli_v1_lookup("job", 2, show_argv, &route));
    assert(strcmp(route.method, "job.status") == 0);
    assert(route.skip_subcmd == 1);
 
    char *cancel_argv[] = {"cancel", "12"};
-   assert(cli_rpc_lookup("job", 2, cancel_argv, &route));
+   assert(cli_v1_lookup("job", 2, cancel_argv, &route));
    assert(strcmp(route.method, "job.cancel") == 0);
    assert(route.skip_subcmd == 1);
    printf("  PASS: test_coord_job_routes_lookup\n");
@@ -931,19 +931,19 @@ static void test_coord_job_requests_marshaled(void)
 
 static void test_aux_routes_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *config_argv[] = {"config"};
-   assert(cli_rpc_lookup("aux", 1, config_argv, &route));
+   assert(cli_v1_lookup("aux", 1, config_argv, &route));
    assert(strcmp(route.method, "aux.config_show") == 0);
    assert(route.skip_subcmd == 1);
 
    char *show_argv[] = {"config", "show"};
-   assert(cli_rpc_lookup("aux", 2, show_argv, &route));
+   assert(cli_v1_lookup("aux", 2, show_argv, &route));
    assert(strcmp(route.method, "aux.config_show") == 0);
    assert(route.skip_subcmd == 2);
 
    char *test_argv[] = {"test", "title", "summarize this"};
-   assert(cli_rpc_lookup("aux", 3, test_argv, &route));
+   assert(cli_v1_lookup("aux", 3, test_argv, &route));
    assert(strcmp(route.method, "aux.test") == 0);
    assert(route.skip_subcmd == 1);
    printf("  PASS: test_aux_routes_lookup\n");
@@ -964,14 +964,14 @@ static void test_aux_test_marshaled(void)
 
 static void test_mcp_routes_lookup(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *audit_argv[] = {"audit"};
-   assert(cli_rpc_lookup("mcp", 1, audit_argv, &route));
+   assert(cli_v1_lookup("mcp", 1, audit_argv, &route));
    assert(strcmp(route.method, "mcp.audit") == 0);
    assert(route.skip_subcmd == 1);
 
    char *recheck_argv[] = {"recheck", "server"};
-   assert(cli_rpc_lookup("mcp", 2, recheck_argv, &route));
+   assert(cli_v1_lookup("mcp", 2, recheck_argv, &route));
    assert(strcmp(route.method, "mcp.recheck") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -985,8 +985,8 @@ static void test_mcp_routes_lookup(void)
 
 static void test_insights_text_output(void)
 {
-   cli_rpc_route_t route;
-   assert(cli_rpc_lookup("insights", 0, NULL, &route));
+   cli_v1_route_t route;
+   assert(cli_v1_lookup("insights", 0, NULL, &route));
    assert(strcmp(route.method, "insights.overview") == 0);
 
    char *argv[] = {"--days", "7"};
@@ -1037,9 +1037,9 @@ static void test_insights_text_output(void)
 
 static void test_skill_lint_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *all_argv[] = {"lint", "--all"};
-   assert(cli_rpc_lookup("skill", 2, all_argv, &route));
+   assert(cli_v1_lookup("skill", 2, all_argv, &route));
    assert(strcmp(route.method, "skill.lint") == 0);
    cJSON *req = marshal_request(route.method, 1, all_argv + 1);
    assert(req != NULL);
@@ -1048,7 +1048,7 @@ static void test_skill_lint_route_marshaled(void)
    cJSON_Delete(req);
 
    char *one_argv[] = {"lint", "writing-skills"};
-   assert(cli_rpc_lookup("skill", 2, one_argv, &route));
+   assert(cli_v1_lookup("skill", 2, one_argv, &route));
    req = marshal_request(route.method, 1, one_argv + 1);
    assert(req != NULL);
    assert(strcmp(cJSON_GetObjectItem(req, "name")->valuestring, "writing-skills") == 0);
@@ -1058,9 +1058,9 @@ static void test_skill_lint_route_marshaled(void)
 
 static void test_skill_eval_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *argv[] = {"eval", "verification-before-completion", "--json"};
-   assert(cli_rpc_lookup("skill", 3, argv, &route));
+   assert(cli_v1_lookup("skill", 3, argv, &route));
    assert(strcmp(route.method, "skill.eval") == 0);
    cJSON *req = marshal_request(route.method, 2, argv + 1);
    assert(req != NULL);
@@ -1073,9 +1073,9 @@ static void test_skill_eval_route_marshaled(void)
 
 static void test_skill_autostub_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *argv[] = {"autostub", "--force", "--snapshot", "/tmp/tools.json"};
-   assert(cli_rpc_lookup("skill", 4, argv, &route));
+   assert(cli_v1_lookup("skill", 4, argv, &route));
    assert(strcmp(route.method, "skill.autostub") == 0);
    cJSON *req = marshal_request(route.method, 3, argv + 1);
    assert(req != NULL);
@@ -1088,9 +1088,9 @@ static void test_skill_autostub_route_marshaled(void)
 
 static void test_trajectory_export_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *argv[] = {"export", "sess-123", "--no-compress", "--max-result-bytes", "64"};
-   assert(cli_rpc_lookup("trajectory", 5, argv, &route));
+   assert(cli_v1_lookup("trajectory", 5, argv, &route));
    assert(strcmp(route.method, "trajectory.export") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -1107,10 +1107,10 @@ static void test_trajectory_export_route_marshaled(void)
 
 static void test_trajectory_batch_route_marshaled(void)
 {
-   cli_rpc_route_t route;
+   cli_v1_route_t route;
    char *argv[] = {"batch", "--tasks", "/tmp/corpus.jsonl", "--toolset-dist",
                    "mixed", "--out",   "/tmp/traj"};
-   assert(cli_rpc_lookup("trajectory", 7, argv, &route));
+   assert(cli_v1_lookup("trajectory", 7, argv, &route));
    assert(strcmp(route.method, "trajectory.batch") == 0);
    assert(route.skip_subcmd == 1);
 
@@ -1125,7 +1125,7 @@ static void test_trajectory_batch_route_marshaled(void)
    printf("  PASS: test_trajectory_batch_route_marshaled\n");
 }
 
-/* cli_rpc_client_endpoint()/cli_rpc_client_bearer() (in cli_rpc_routes.inc) call
+/* cli_v1_client_endpoint()/cli_v1_client_bearer() (in cli_v1_routes.inc) call
  * aimee_home(), defined in posix/cli_client.c — which cannot be co-linked here
  * because it re-includes the same .inc. Stub it: aimee_home() honors the
  * AIMEE_HOME override exactly as the real one does. (The legacy
@@ -1136,10 +1136,10 @@ const char *aimee_home(void)
    return getenv("AIMEE_HOME");
 }
 
-/* cli_rpc_client_endpoint()/cli_rpc_client_bearer() resolve the remote /v1
+/* cli_v1_client_endpoint()/cli_v1_client_bearer() resolve the remote /v1
  * endpoint + bearer (AIMEE_API_ENDPOINT / AIMEE_API_BEARER env, else aimee.yaml
  * client_endpoint / bearer_token). The thin client is now an unconditional /v1
- * consumer, so cli_rpc_has_remote_endpoint() is true exactly when an endpoint is
+ * consumer, so cli_v1_has_remote_endpoint() is true exactly when an endpoint is
  * configured (the legacy client_transport gate was removed). */
 static void test_client_endpoint_selection(void)
 {
@@ -1152,21 +1152,21 @@ static void test_client_endpoint_selection(void)
    unsetenv("AIMEE_PROFILE");
 
    /* Nothing configured -> no endpoint, no bearer, no remote. */
-   assert(cli_rpc_client_endpoint() == NULL);
-   assert(cli_rpc_client_bearer() == NULL);
-   assert(cli_rpc_has_remote_endpoint() == 0);
+   assert(cli_v1_client_endpoint() == NULL);
+   assert(cli_v1_client_bearer() == NULL);
+   assert(cli_v1_has_remote_endpoint() == 0);
 
    /* Env override wins for both endpoint and bearer; a configured endpoint makes
     * has_remote true on its own. */
    setenv("AIMEE_API_ENDPOINT", "tcp:10.0.0.5:8740", 1);
    setenv("AIMEE_API_BEARER", "env-token", 1);
-   char *ep = cli_rpc_client_endpoint();
+   char *ep = cli_v1_client_endpoint();
    assert(ep && strcmp(ep, "tcp:10.0.0.5:8740") == 0);
    free(ep);
-   char *bt = cli_rpc_client_bearer();
+   char *bt = cli_v1_client_bearer();
    assert(bt && strcmp(bt, "env-token") == 0);
    free(bt);
-   assert(cli_rpc_has_remote_endpoint() == 1);
+   assert(cli_v1_has_remote_endpoint() == 1);
 
    unsetenv("AIMEE_API_ENDPOINT");
    unsetenv("AIMEE_API_BEARER");
@@ -1180,15 +1180,15 @@ static void test_client_endpoint_selection(void)
          "    bearer_token: \"yaml-token\"\n",
          fp);
    fclose(fp);
-   ep = cli_rpc_client_endpoint();
+   ep = cli_v1_client_endpoint();
    assert(ep && strcmp(ep, "tcp:host.example:8740") == 0);
    free(ep);
-   bt = cli_rpc_client_bearer();
+   bt = cli_v1_client_bearer();
    assert(bt && strcmp(bt, "yaml-token") == 0);
    free(bt);
 
    /* yaml endpoint -> remote. */
-   assert(cli_rpc_has_remote_endpoint() == 1);
+   assert(cli_v1_has_remote_endpoint() == 1);
 
    unlink(yaml);
    rmdir(home);
@@ -1247,7 +1247,7 @@ static void test_delegate_context_file_folded_into_prompt(void)
 
 int main(void)
 {
-   printf("test_cli_rpc_delegate\n");
+   printf("test_cli_v1_delegate\n");
    test_delegate_context_file_folded_into_prompt();
    test_delegate_max_turns_marshaled();
    test_delegate_tools_named_toolset_marshaled();

--- a/src/windows/cli_client.c
+++ b/src/windows/cli_client.c
@@ -785,7 +785,7 @@ cJSON *cli_http_request_stream_ndjson(const char *endpoint, const char *method, 
    return final;
 }
 
-/* cli_v1_dispatch_local now lives in the shared cli_rpc_routes.inc — it resolves the
+/* cli_v1_dispatch_local now lives in the shared cli_v1_routes.inc — it resolves the
  * method's first-class /v1 route (no more POST /v1/rpc bridge). On Windows
  * cli_v1_send routes it through aimee_client_request to the configured remote.
  *
@@ -793,4 +793,4 @@ cJSON *cli_http_request_stream_ndjson(const char *endpoint, const char *method, 
  * (cli_workspace_serve.c, native-threaded via _beginthreadex), so the Windows
  * thin client serves its working tree to a remote aimee-server just like POSIX. */
 
-#include "../cli_rpc_routes.inc"
+#include "../cli_v1_routes.inc"


### PR DESCRIPTION
## Why
The thin-client dispatch helpers (`cli_rpc_forward`, `cli_rpc_lookup`, `cli_rpc_route_t`, `cli_rpc_client_endpoint`, …) were named `cli_rpc_*` for historical reasons, which reads like a legacy RPC transport. They are in fact the **strict `/v1` HTTP(S) client surface**: each resolves a method to its first-class `/v1/...` route — native client TLS (HTTPS) for a remote endpoint, HTTP over the local `aimee-http.sock` UDS for a co-located server. The old `/v1/rpc` bridge and socket JSON-RPC were already retired.

This renames the symbols and two files so the names match the transport.

## Scope (pure rename — no functional change)
- Uniform `cli_rpc_* → cli_v1_*` across all `src/` code, the Makefile, `Rules.mk`, `test_build_integrity.sh`, and `src/README.md`.
- `src/cli_rpc_routes.inc → src/cli_v1_routes.inc` (distinct from the generated `cli_v1_routes_gen.inc`).
- `src/tests/test_cli_rpc_delegate.c → src/tests/test_cli_v1_delegate.c`; test target `unit-test-cli-rpc-delegate → unit-test-cli-v1-delegate`.
- Verified **no collisions**: none of the mapped `cli_v1_*` names clash with an existing `cli_v1_*` symbol.
- Historical proposal docs under `docs/proposals/` are left as-is (they record past state).

## Verification
- Thin client + server build clean; `make lint` green.
- `unit-test-cli-v1-delegate`, `unit-test-cli-mcp-serve` pass.
- Behavior unchanged (`agent setup` etc. work identically).
- `git grep cli_rpc -- src/` returns nothing.