### PR TITLE
fix(delegate): bound delegate timeout so a stalled provider can't wedge the pool

### DIFF
--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -71,6 +71,25 @@ static inline int agent_loop_per_call_timeout_ms(int agent_timeout_ms, int total
    return agent_timeout_ms < remaining ? agent_timeout_ms : remaining;
 }
 
+/* Effective per-call timeout for a delegate run. A delegate must NEVER run with
+ * a non-positive timeout: a timeout_ms <= 0 reaching the HTTP layer disables the
+ * read deadline (agent_bridge conn_open sets deadline_ns = 0), so conn_read
+ * loops on its per-recv timeout forever and a stalled provider hangs the worker
+ * permanently — leaking its compute-pool thread + provider concurrency slot and
+ * eventually wedging the whole background-delegate queue (jobs stuck "pending").
+ * Resolve to the explicit request timeout if positive, else the agent's
+ * configured timeout if positive, else a hard default ceiling — guaranteeing a
+ * positive value so the run always returns. Pure function — unit-tested in
+ * test_agent.c. */
+static inline int delegate_effective_timeout_ms(int request_timeout_ms, int agent_timeout_ms)
+{
+   if (request_timeout_ms > 0)
+      return request_timeout_ms;
+   if (agent_timeout_ms > 0)
+      return agent_timeout_ms;
+   return AGENT_DEFAULT_TIMEOUT_MS;
+}
+
 typedef struct
 {
    char name[64];

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1003,8 +1003,13 @@ void delegate_worker(void *arg)
       compute_ctx_free(cctx);
       return;
    }
-   if (target_agent && timeout_ms > 0)
-      target_agent->timeout_ms = timeout_ms;
+   /* Never let a delegate run with a non-positive timeout: timeout_ms <= 0
+    * disables the HTTP read deadline and a stalled provider hangs the worker
+    * forever, leaking its pool thread + concurrency slot (see
+    * delegate_effective_timeout_ms). Resolve request > agent-config > default. */
+   if (target_agent)
+      target_agent->timeout_ms =
+          delegate_effective_timeout_ms(timeout_ms, target_agent->timeout_ms);
    delegate_apply_max_turns_policy(&acfg, role, max_turns);
    if (cctx->background_job_id > 0 && target_agent)
       db1_agent_job_set_agent(cctx->background_job_id, target_agent->name);

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1886,25 +1886,6 @@ static void test_agent_loop_per_call_timeout(void)
    assert(agent_loop_per_call_timeout_ms(10000, 40000, 35000) == -1);
 }
 
-/* Regression: a delegate must never reach the HTTP layer with a non-positive
- * timeout. timeout_ms <= 0 disables the read deadline (conn_open deadline_ns=0)
- * and a stalled provider hangs the worker forever, leaking its pool thread +
- * concurrency slot until the whole background-delegate queue wedges. */
-static void test_delegate_effective_timeout(void)
-{
-   /* Explicit request timeout always wins. */
-   assert(delegate_effective_timeout_ms(30000, 180000) == 30000);
-   assert(delegate_effective_timeout_ms(5000, 0) == 5000);
-   /* No request timeout: fall back to the agent's configured timeout. */
-   assert(delegate_effective_timeout_ms(0, 180000) == 180000);
-   assert(delegate_effective_timeout_ms(-1, 120000) == 120000);
-   /* THE BUG: neither request nor agent configures a timeout (agents with no
-    * timeout_ms zero-init to 0). Must resolve to the default ceiling, NEVER 0. */
-   assert(delegate_effective_timeout_ms(0, 0) == AGENT_DEFAULT_TIMEOUT_MS);
-   assert(delegate_effective_timeout_ms(-1, -1) == AGENT_DEFAULT_TIMEOUT_MS);
-   assert(delegate_effective_timeout_ms(0, 0) > 0);
-}
-
 static void test_claude_cli_predicate(void)
 {
    agent_t a;
@@ -1948,7 +1929,6 @@ int main(void)
    test_agent_route();
    test_claude_cli_predicate();
    test_agent_loop_per_call_timeout();
-   test_delegate_effective_timeout();
    test_agent_route_health_filter();
    test_agent_route_with_caps_honors_tools_enabled();
    test_agent_route_with_caps_honors_context_override();

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1886,6 +1886,25 @@ static void test_agent_loop_per_call_timeout(void)
    assert(agent_loop_per_call_timeout_ms(10000, 40000, 35000) == -1);
 }
 
+/* Regression: a delegate must never reach the HTTP layer with a non-positive
+ * timeout. timeout_ms <= 0 disables the read deadline (conn_open deadline_ns=0)
+ * and a stalled provider hangs the worker forever, leaking its pool thread +
+ * concurrency slot until the whole background-delegate queue wedges. */
+static void test_delegate_effective_timeout(void)
+{
+   /* Explicit request timeout always wins. */
+   assert(delegate_effective_timeout_ms(30000, 180000) == 30000);
+   assert(delegate_effective_timeout_ms(5000, 0) == 5000);
+   /* No request timeout: fall back to the agent's configured timeout. */
+   assert(delegate_effective_timeout_ms(0, 180000) == 180000);
+   assert(delegate_effective_timeout_ms(-1, 120000) == 120000);
+   /* THE BUG: neither request nor agent configures a timeout (agents with no
+    * timeout_ms zero-init to 0). Must resolve to the default ceiling, NEVER 0. */
+   assert(delegate_effective_timeout_ms(0, 0) == AGENT_DEFAULT_TIMEOUT_MS);
+   assert(delegate_effective_timeout_ms(-1, -1) == AGENT_DEFAULT_TIMEOUT_MS);
+   assert(delegate_effective_timeout_ms(0, 0) > 0);
+}
+
 static void test_claude_cli_predicate(void)
 {
    agent_t a;
@@ -1929,6 +1948,7 @@ int main(void)
    test_agent_route();
    test_claude_cli_predicate();
    test_agent_loop_per_call_timeout();
+   test_delegate_effective_timeout();
    test_agent_route_health_filter();
    test_agent_route_with_caps_honors_tools_enabled();
    test_agent_route_with_caps_honors_context_override();

--- a/src/tests/test_agent_apikey.c
+++ b/src/tests/test_agent_apikey.c
@@ -92,6 +92,26 @@ static void test_apikey_ref_fallback_save(void)
    printf("  PASS: test_apikey_ref_fallback_save\n");
 }
 
+/* Regression (also split out of test_agent.c at the 2000-line limit): a delegate
+ * must never reach the HTTP layer with a non-positive timeout. timeout_ms <= 0
+ * disables the read deadline (conn_open deadline_ns=0) and a stalled provider
+ * hangs the worker forever, leaking its pool thread + concurrency slot until the
+ * whole background-delegate queue wedges. */
+static void test_delegate_effective_timeout(void)
+{
+   /* Explicit request timeout always wins. */
+   assert(delegate_effective_timeout_ms(30000, 180000) == 30000);
+   assert(delegate_effective_timeout_ms(5000, 0) == 5000);
+   /* No request timeout: fall back to the agent's configured timeout. */
+   assert(delegate_effective_timeout_ms(0, 180000) == 180000);
+   assert(delegate_effective_timeout_ms(-1, 120000) == 120000);
+   /* THE BUG: neither request nor agent configures a timeout (agents with no
+    * timeout_ms zero-init to 0). Must resolve to the default ceiling, NEVER 0. */
+   assert(delegate_effective_timeout_ms(0, 0) == AGENT_DEFAULT_TIMEOUT_MS);
+   assert(delegate_effective_timeout_ms(-1, -1) == AGENT_DEFAULT_TIMEOUT_MS);
+   assert(delegate_effective_timeout_ms(0, 0) > 0);
+}
+
 int main(void)
 {
    char tmp_template[] = "/tmp/aimee-agent-apikey-XXXXXX";
@@ -101,6 +121,7 @@ int main(void)
 
    test_apikey_ref_not_serialized();
    test_apikey_ref_fallback_save();
+   test_delegate_effective_timeout();
 
    printf("agent_apikey: all tests passed\n");
    return 0;


### PR DESCRIPTION
## Summary

Fixes a wedge where **all** background delegates (roundtable reviews,
`aimee delegate --background`, coord jobs) get stuck in `pending` forever until
the server is restarted — and a restart only defers it.

## Root cause (this PR fixes the permanent-leak vector)

A background delegate whose request carries no timeout reaches the server with
`timeout_ms = 0`. Combined with an agent that has no configured `timeout_ms`
(`claude`/`codex`/`my-*` zero-init to 0), the per-call HTTP timeout is 0. In
`agent_bridge` `conn_open`, `timeout_ms <= 0` sets `deadline_ns = 0`, and
`conn_read` then loops on its 30 s per-recv timeout **forever**
(`conn_past_deadline` is false when `deadline_ns == 0`). A provider that accepts
the TLS connection but never responds (rate-limited / flaky) blocks the
compute-pool worker indefinitely, leaking its thread + provider concurrency
slot. Cancellation and the stale-monitor only update DB rows; neither can
interrupt a blocked `recv`.

**Live forensics:** server had worker threads blocked in `wait_woken` on `ESTAB`
provider TLS connections (recv-q = 0) while jobs sat `pending`.

## Fix

`delegate_effective_timeout_ms(request, agent_config)` — pure helper resolving
`request > agent-config > AGENT_DEFAULT_TIMEOUT_MS`, guaranteeing a positive
timeout so a delegate run always returns (a timeout error then marks the job
`failed` via the existing result path). Applied in `delegate_worker`; scoped to
the delegate path — chat/streaming untouched. Unit-tested
(`test_delegate_effective_timeout`, incl. the `(0,0) -> default` case).

## This is a safety fix, not the architectural cure

The deeper issue (tracked separately): background delegates run on the global
compute pool, which defaults to **2 threads** (`CONFIG_DEFAULT_BACKGROUND_THREADS`).
Delegates are I/O-bound (≈100% network wait, ~0 CPU/RAM), yet each holds a whole
CPU-sized worker thread for the full remote call — so even *non-hung* slow
delegates saturate a 2-thread pool and queue everything behind them. The real
fix is to decouple delegate I/O concurrency from the CPU compute pool (dedicated
elastic I/O pool, or async provider calls). This PR stops a hung call from
holding a thread *forever*; it does not raise the effective concurrency.

## Test

`unit-test-agent` passes (incl. new regression). Changed TUs compile clean under
`-Werror`.
