### PR TITLE
fix(lint): trim server_compute.c to the 2000-line limit

### DIFF
--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -525,10 +525,7 @@ static void bind_request_session_creds(cJSON *req)
    agent_set_request_codex_creds(NULL, NULL);
 }
 
-/* On-demand delegate execution (delegate_spawn_ondemand / _drain /
- * _set_ceiling / _inflight) lives in server_delegate_ondemand.c to keep this
- * file under the line limit; declarations are in server_compute_impl.h. */
-
+/* On-demand delegate execution: server_delegate_ondemand.c. */
 static int delegate_dispatch(server_ctx_t *ctx, compute_ctx_t *cctx)
 {
    if (g_delegate_dispatch_override)
@@ -550,7 +547,7 @@ static int delegate_dispatch(server_ctx_t *ctx, compute_ctx_t *cctx)
    }
 
    /* Sessionless/background delegates run on their own on-demand thread, not the
-    * CPU compute pool — see the on-demand block above. */
+    * CPU compute pool (server_delegate_ondemand.c). */
    return delegate_spawn_ondemand(cctx);
 }
 


### PR DESCRIPTION
The clang-format-19 pass in #333 left `server_compute.c` at 2003 lines (over the
hard limit); the `testing → main` promotion (#335) line-check caught it. Condense
the on-demand pointer comments back to 2000. No behavior change.
