### PR TITLE
docs(proposals): retire delegate-ondemand-execution to done (landed #333)

### DIFF
--- a/docs/proposals/done/delegate-ondemand-execution.md
+++ b/docs/proposals/done/delegate-ondemand-execution.md
@@ -1,7 +1,12 @@
 # Proposal: on-demand delegate execution (retire the CPU-pool gate)
 
-- **State:** implemented on `feat/delegate-io-pool`; self-reviewed (roundtable
-  infra was itself wedged by the bug this fixes).
+- **State:** landed — merged to `testing` via PR #333. The server-only on-demand
+  delegate execution (per-thread spawn + `delegate_max_inflight` backstop, all
+  three call sites converted, the CPU-pool gate retired) is in tree
+  (`src/server/server_delegate_ondemand.c`); session-delegate and aimee-kb worker
+  pools remain the noted fast-follows. (Originally implemented on
+  `feat/delegate-io-pool`; self-reviewed — the roundtable infra was itself wedged
+  by the bug this fixes.)
 - **Author:** JBailes
 - **Date:** 2026-06-15
 - **Scope:** server only (this PR). Session-delegate pools and aimee-kb worker


### PR DESCRIPTION
Pure housekeeping: `delegate-ondemand-execution` was implemented and merged via **PR #333** (`server_delegate_ondemand.c`, per-thread on-demand spawn, `delegate_max_inflight` backstop, all three `delegate_worker` call sites converted off the CPU compute pool, tests in `test_config.c`/`test_server_dispatch.c`). The proposal's stated scope is server-only (session-delegate and aimee-kb worker pools are explicit fast-follows), so the deliverable is complete. This moves the proposal doc pending → done and annotates the landing. No code change; `check-proposal-links` passes.