### PR TITLE
feat(cost): price local delegates (minimax/mistral/mimo) as known-zero

### DIFF
--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -176,6 +176,15 @@ delegates are abundant compute and the primary supervising agent is the scarce
 resource. A run can be token-negative overall while still being useful if it
 reduces paid supervisor attention, manual integration, or serial review time.
 
+The shared cost authority (`token_estimate_cost`) prices the self-hosted /
+open-weight delegates aimee runs locally — minimax, mistral, and mimo — at a
+**known zero**: free, but explicitly *priced* rather than *unknown*. This matters
+because the delegate-economics path flat-rates only genuinely unknown models; a
+known-zero price keeps these local delegates out of that fallback, so their
+realized cost is reported as the $0 it actually is. A deployment that pays per
+token for a hosted variant still overrides the zero with a real model-registry /
+models.dev price.
+
 The report is intentionally approximate. It separates estimated delegate tokens
 from estimated supervisor prompt tokens, records tier distribution, structured
 handoff validity, focused tests, manual integration markers, reviewer blocking

--- a/src/server/token_tracker.c
+++ b/src/server/token_tracker.c
@@ -50,6 +50,22 @@ static const model_price_t pricing[] = {
     {"gpt-4-turbo", 10.00, 30.00, 0.0, 0.0},
     {"gpt-4", 30.00, 60.00, 0.0, 0.0},
     {"gpt-3.5-turbo", 0.50, 1.50, 0.0, 0.0},
+
+    /* Self-hosted / open-weight delegates aimee actually runs (ingress
+     * cost-accounting §1 coverage gap). Priced at 0 = free/local: a KNOWN,
+     * intentional zero (so token_estimate_cost_ex reports priced=1), not
+     * "unknown" — this stops the delegate-economics path from flat-rating them as
+     * unknown spend. These keys match as a PREFIX of the provider-stripped served
+     * model id (find_price is longest-prefix, not arbitrary-substring): "minimax"
+     * matches "MiniMax-M3", "mistral" matches "mistral-medium-latest", "mimo"
+     * matches "mimo-v2.5-pro". The prefixes are deliberately family-wide (any
+     * "mistral-*"/"minimax-*"/"mimo-*" variant aimee self-hosts is free); a
+     * deployment that instead pays a hosted API for one of these still gets the
+     * real price, because a NONZERO model-registry / models.dev price overrides
+     * this static zero base (a 0/0 registry entry means "unknown" and does not). */
+    {"minimax", 0.0, 0.0, 0.0, 0.0},
+    {"mistral", 0.0, 0.0, 0.0, 0.0},
+    {"mimo", 0.0, 0.0, 0.0, 0.0},
 };
 
 #define PRICING_COUNT (int)(sizeof(pricing) / sizeof(pricing[0]))

--- a/src/tests/test_token_tracker.c
+++ b/src/tests/test_token_tracker.c
@@ -224,6 +224,46 @@ static void test_billable_model(void)
    PASS("cost: billable-model precedence (provider > served > requested)");
 }
 
+static int hosted_mistral_price(const char *model, double *in_per_mtok, double *out_per_mtok)
+{
+   /* A deployment that pays a hosted API for one of the otherwise-free families. */
+   if (strcmp(model, "mistral-medium-latest") == 0)
+   {
+      *in_per_mtok = 0.40;
+      *out_per_mtok = 2.00;
+      return 1;
+   }
+   return 0;
+}
+
+static void test_local_delegates_priced_free(void)
+{
+   /* §1 coverage gap: the self-hosted delegates aimee runs (minimax, mistral,
+    * mimo) are free/local — KNOWN (priced=1) at zero cost, so the delegate
+    * economics path stops flat-rating them as unknown spend. The keys match as a
+    * prefix of the provider-stripped served model id. */
+   token_usage_t u = {.input_tokens = 1000, .output_tokens = 1000};
+   const char *models[] = {"MiniMax-M3", "mistral-medium-latest", "mimo-v2.5-pro"};
+   for (size_t i = 0; i < sizeof(models) / sizeof(models[0]); i++)
+   {
+      int priced = -1;
+      double cost = token_estimate_cost_ex(models[i], &u, &priced);
+      assert(priced == 1);           /* known, not "unknown" */
+      assert(near_equal(cost, 0.0)); /* free/local */
+   }
+
+   /* A nonzero registry/models.dev price overrides the static zero, so a hosted
+    * variant of an otherwise-free family is billed at the real price. */
+   token_tracker_set_registry_price_fn(hosted_mistral_price);
+   int priced = -1;
+   double hosted = token_estimate_cost_ex("mistral-medium-latest", &u, &priced);
+   assert(priced == 1);
+   /* 1000 * 0.40/1e6 + 1000 * 2.00/1e6 = 0.0004 + 0.0020 = 0.0024 */
+   assert(near_equal(hosted, 0.0024));
+   token_tracker_set_registry_price_fn(NULL); /* restore for any later tests */
+   PASS("cost: local delegates priced free (known, zero); hosted price overrides");
+}
+
 /* --- Main --- */
 
 int main(void)
@@ -232,6 +272,7 @@ int main(void)
    test_registry_overrides_base_keeps_cache();
    test_cost_shaped_reward();
    test_billable_model();
+   test_local_delegates_priced_free();
 
    test_known_anthropic_model();
    test_cache_tokens_anthropic();


### PR DESCRIPTION
Closes the **ingress cost-accounting §1** coverage gap for the delegates aimee actually runs.

## Problem
`token_estimate_cost_ex()` reports a model as *unpriced* unless the static price table (or a nonzero registry price) knows it. The self-hosted / open-weight delegates aimee runs — `MiniMax-M3`, `mistral-medium-latest`, `mimo-v2.5-pro` — were absent, so they came back **unpriced**, and the delegate-economics path flat-rated their spend as *unknown* (the `0.000015`/token fallback) rather than the $0 they actually cost when self-hosted.

## Change
- `src/server/token_tracker.c`: add three **known-zero** rows (`minimax`, `mistral`, `mimo`). Because a `0` in the static table is an *intentional free price*, `token_estimate_cost_ex` now reports `priced=1, cost=0` for them — known/free, not unknown — so the economics path stops flat-rating them. Matched as provider-stripped **prefixes** (the matcher is prefix-based, so no mid-string false matches).
- A **nonzero** model-registry / models.dev price still overrides the static base, so a deployment paying per token for a hosted variant is unaffected.
- `src/tests/test_token_tracker.c`: assert all three resolve `priced=1, cost=0`.
- `docs/DELEGATES.md`: document known-zero pricing under *Free-Delegate Economics*.

## Verification
`make all`, `make lint`, and the token_tracker unit test all green locally. Roundtable-gated.

Note: per the proposal these are aimee's self-hosted delegates; `glm-5.1` is the same class but was left out pending confirmation it's also free/local.