### PR TITLE
fix(build): split test_agent.c under the 2000-line hard limit

### DIFF
--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -514,6 +514,7 @@ $(TESTPREFIX)/unit-test-tasks: $(OBJDIR)/tests/test_tasks.o $(OBJDIR)/tasks.o $(
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-agent: $(OBJDIR)/tests/test_agent.o $(OBJDIR)/tests/test_agent_caps.o \
+                      $(OBJDIR)/tests/test_agent_responses.o \
                       $(OBJDIR)/tests/test_agent_delegate_root.o $(OBJDIR)/server/agent_cli_shell.o \
                       $(OBJDIR)/server/tool_call_args.o \
                       $(OBJDIR)/server/session_compact.o $(OBJDIR)/server/compact_prune.o $(OBJDIR)/server/delegate_driver.o \

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -26,6 +26,13 @@ void test_agent_route_with_caps_honors_tools_enabled(void);
 void test_agent_route_with_caps_honors_context_override(void);
 void test_tools_enabled_capability_default(void);
 
+/* Defined in test_agent_responses.c (split out to keep this file under the
+ * 2000-line hard limit); called from main() below. */
+void test_responses_parser_keeps_all_output_text_parts(void);
+void test_responses_parser_accumulates_output_text_deltas(void);
+void test_responses_parser_uses_output_text_done(void);
+void test_responses_parser_separates_message_items(void);
+
 /* --- Expose tool functions for testing via redeclaration --- */
 char *tool_bash(const char *command, int timeout_ms);
 char *tool_read_file(const char *path, int offset, int limit);
@@ -702,95 +709,6 @@ static void test_codex_oauth_auth_resolution(void)
 
    assert(agent_resolve_auth(&ag, auth, sizeof(auth)) == 0);
    assert(strcmp(auth, "Authorization: Bearer codex-cli-token") == 0);
-}
-
-static void test_responses_parser_keeps_all_output_text_parts(void)
-{
-   const char *body =
-       "event: response.output_item.done\n"
-       "data: {\"item\":{\"type\":\"message\",\"content\":["
-       "{\"type\":\"output_text\",\"text\":\"I did not deploy this to `192.\"},"
-       "{\"type\":\"output_text\",\"text\":\"168.0.83`.\"}]}}\n\n"
-       "event: response.completed\n"
-       "data: {\"response\":{\"usage\":{\"input_tokens\":11,\"output_tokens\":22}}}\n\n";
-
-   parsed_response_t parsed;
-   agent_parse_response_responses(body, &parsed);
-   assert(parsed.content != NULL);
-   assert(strcmp(parsed.content, "I did not deploy this to `192.168.0.83`.") == 0);
-   assert(parsed.prompt_tokens == 11);
-   assert(parsed.completion_tokens == 22);
-   agent_free_parsed_response(&parsed);
-}
-
-static void test_responses_parser_accumulates_output_text_deltas(void)
-{
-   const char *body =
-       "event: response.output_text.delta\r\n"
-       "data: {\"delta\":\"The useful model fact here is that Qwen3.\"}\r\n\r\n"
-       "event: response.output_text.delta\r\n"
-       "data: {\"delta\":\"6 keeps scaling KV cache with context length.\"}\r\n\r\n"
-       "event: response.completed\r\n"
-       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":6}}}"
-       "\r\n\r\n";
-
-   parsed_response_t parsed;
-   agent_parse_response_responses(body, &parsed);
-   assert(parsed.content != NULL);
-   assert(strcmp(parsed.content,
-                 "The useful model fact here is that Qwen3.6 keeps scaling KV cache with context "
-                 "length.") == 0);
-   assert(parsed.prompt_tokens == 5);
-   assert(parsed.completion_tokens == 6);
-   agent_free_parsed_response(&parsed);
-}
-
-static void test_responses_parser_uses_output_text_done(void)
-{
-   const char *body =
-       "event: response.content_part.done\n"
-       "data: {\"part\":{\"type\":\"output_text\",\"text\":\"One caveat: the endpoint I could "
-       "reach at `192.168.1.103:8080`.\"}}\n\n"
-       "event: response.output_text.done\n"
-       "data: {\"text\":\"One caveat: the endpoint I could reach at `192.168.1.103:8080`.\"}\n\n"
-       "event: response.completed\n"
-       "data: "
-       "{\"response\":{\"output\":[],\"usage\":{\"input_tokens\":7,\"output_tokens\":8}}}\n\n";
-
-   parsed_response_t parsed;
-   agent_parse_response_responses(body, &parsed);
-   assert(parsed.content != NULL);
-   assert(strcmp(parsed.content,
-                 "One caveat: the endpoint I could reach at `192.168.1.103:8080`.") == 0);
-   assert(parsed.prompt_tokens == 7);
-   assert(parsed.completion_tokens == 8);
-   agent_free_parsed_response(&parsed);
-}
-
-static void test_responses_parser_separates_message_items(void)
-{
-   const char *body =
-       "event: response.output_text.delta\n"
-       "data: {\"delta\":\"PR.\"}\n\n"
-       "event: response.output_text.delta\n"
-       "data: {\"delta\":\"GitHub\"}\n\n"
-       "event: response.output_item.done\n"
-       "data: {\"item\":{\"type\":\"message\",\"content\":["
-       "{\"type\":\"output_text\",\"text\":\"PR.\"}]}}\n\n"
-       "event: response.output_item.done\n"
-       "data: {\"item\":{\"type\":\"message\",\"content\":["
-       "{\"type\":\"output_text\",\"text\":\"GitHub\"}]}}\n\n"
-       "event: response.completed\n"
-       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":9,\"output_tokens\":10}}}"
-       "\n\n";
-
-   parsed_response_t parsed;
-   agent_parse_response_responses(body, &parsed);
-   assert(parsed.content != NULL);
-   assert(strcmp(parsed.content, "PR.\n\nGitHub") == 0);
-   assert(parsed.prompt_tokens == 9);
-   assert(parsed.completion_tokens == 10);
-   agent_free_parsed_response(&parsed);
 }
 
 static void test_agent_is_exec_role(void)

--- a/src/tests/test_agent_responses.c
+++ b/src/tests/test_agent_responses.c
@@ -1,0 +1,100 @@
+/* test_agent_responses.c: OpenAI /responses SSE/JSON parser tests, split out of
+ * test_agent.c to keep that file under the 2000-line hard limit. These functions
+ * are declared in test_agent.c and called from its main(); both objects link into
+ * the single unit-test-agent binary. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "agent.h"
+#include "agent_protocol.h"
+
+void test_responses_parser_keeps_all_output_text_parts(void)
+{
+   const char *body =
+       "event: response.output_item.done\n"
+       "data: {\"item\":{\"type\":\"message\",\"content\":["
+       "{\"type\":\"output_text\",\"text\":\"I did not deploy this to `192.\"},"
+       "{\"type\":\"output_text\",\"text\":\"168.0.83`.\"}]}}\n\n"
+       "event: response.completed\n"
+       "data: {\"response\":{\"usage\":{\"input_tokens\":11,\"output_tokens\":22}}}\n\n";
+
+   parsed_response_t parsed;
+   agent_parse_response_responses(body, &parsed);
+   assert(parsed.content != NULL);
+   assert(strcmp(parsed.content, "I did not deploy this to `192.168.0.83`.") == 0);
+   assert(parsed.prompt_tokens == 11);
+   assert(parsed.completion_tokens == 22);
+   agent_free_parsed_response(&parsed);
+}
+
+void test_responses_parser_accumulates_output_text_deltas(void)
+{
+   const char *body =
+       "event: response.output_text.delta\r\n"
+       "data: {\"delta\":\"The useful model fact here is that Qwen3.\"}\r\n\r\n"
+       "event: response.output_text.delta\r\n"
+       "data: {\"delta\":\"6 keeps scaling KV cache with context length.\"}\r\n\r\n"
+       "event: response.completed\r\n"
+       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":5,\"output_tokens\":6}}}"
+       "\r\n\r\n";
+
+   parsed_response_t parsed;
+   agent_parse_response_responses(body, &parsed);
+   assert(parsed.content != NULL);
+   assert(strcmp(parsed.content,
+                 "The useful model fact here is that Qwen3.6 keeps scaling KV cache with context "
+                 "length.") == 0);
+   assert(parsed.prompt_tokens == 5);
+   assert(parsed.completion_tokens == 6);
+   agent_free_parsed_response(&parsed);
+}
+
+void test_responses_parser_uses_output_text_done(void)
+{
+   const char *body =
+       "event: response.content_part.done\n"
+       "data: {\"part\":{\"type\":\"output_text\",\"text\":\"One caveat: the endpoint I could "
+       "reach at `192.168.1.103:8080`.\"}}\n\n"
+       "event: response.output_text.done\n"
+       "data: {\"text\":\"One caveat: the endpoint I could reach at `192.168.1.103:8080`.\"}\n\n"
+       "event: response.completed\n"
+       "data: "
+       "{\"response\":{\"output\":[],\"usage\":{\"input_tokens\":7,\"output_tokens\":8}}}\n\n";
+
+   parsed_response_t parsed;
+   agent_parse_response_responses(body, &parsed);
+   assert(parsed.content != NULL);
+   assert(strcmp(parsed.content,
+                 "One caveat: the endpoint I could reach at `192.168.1.103:8080`.") == 0);
+   assert(parsed.prompt_tokens == 7);
+   assert(parsed.completion_tokens == 8);
+   agent_free_parsed_response(&parsed);
+}
+
+void test_responses_parser_separates_message_items(void)
+{
+   const char *body =
+       "event: response.output_text.delta\n"
+       "data: {\"delta\":\"PR.\"}\n\n"
+       "event: response.output_text.delta\n"
+       "data: {\"delta\":\"GitHub\"}\n\n"
+       "event: response.output_item.done\n"
+       "data: {\"item\":{\"type\":\"message\",\"content\":["
+       "{\"type\":\"output_text\",\"text\":\"PR.\"}]}}\n\n"
+       "event: response.output_item.done\n"
+       "data: {\"item\":{\"type\":\"message\",\"content\":["
+       "{\"type\":\"output_text\",\"text\":\"GitHub\"}]}}\n\n"
+       "event: response.completed\n"
+       "data: {\"response\":{\"output\":[],\"usage\":{\"input_tokens\":9,\"output_tokens\":10}}}"
+       "\n\n";
+
+   parsed_response_t parsed;
+   agent_parse_response_responses(body, &parsed);
+   assert(parsed.content != NULL);
+   assert(strcmp(parsed.content, "PR.\n\nGitHub") == 0);
+   assert(parsed.prompt_tokens == 9);
+   assert(parsed.completion_tokens == 10);
+   agent_free_parsed_response(&parsed);
+}


### PR DESCRIPTION
**Unblocks CI for all PRs.** PR #315 grew `tests/test_agent.c` to **2058 lines**, over the 2000-line hard limit enforced by `make build-integrity` (required CI). Since `pull_request` CI tests the PR *merged into testing*, every open/new PR now fails build-integrity on this file — even ones that don't touch it (e.g. #339).

Fix: extract the four OpenAI `/responses` parser tests into a new `tests/test_agent_responses.c` (declared in `test_agent.c`, called from its `main()`, linked into the same `unit-test-agent` binary — the established split pattern, cf. `test_agent_caps.c`). `test_agent.c` → 1976 lines. **No test behavior changes** — the assertions are byte-identical, just relocated.

Verified locally: `make all`, `make lint`, `make build-integrity` (now passes), and `unit-test-agent` all green.