### PR TITLE
docs(proposals): annotate implementation status of partially-landed proposals

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -3,6 +3,17 @@
 - **State:** reviewed — roundtable sign-off (rev. 9). Eight review rounds (R1–R8);
   R4–R8 cleared the bar (no blockers, all six seats endorse), R8 zero-major.
   Ready for implementation per the phasing below.
+- **Implementation status (2026-06-16):** PARTIAL — **P1 appears landed**. The
+  P1 surface is present on `testing`: the dispatch-layer `turn_id` mint +
+  `X-Aimee-Retrieval-Event` header (`server_http.c`, `ingress_preinject.h`), the
+  single-writer `retrieval_event` (schema + `kb_service`/`demotion`), the
+  `kb_evidence_emit_enabled` flag, and the `aimee audit trace` CLI. (The P1
+  dependency on PR #185 cost-accounting is satisfied — #185 is merged.) **Verify
+  P1 functional completeness end-to-end before moving this proposal to done.**
+  **Remaining:** P1.5 (typed doc/code refs + two-writer merge), P2 (versioned
+  provenance + `aimee audit provenance` + drift-ranked requeue — shippable), P3
+  (fidelity_check judge + `fidelity_report`), P4 (labelled gold corpus — needs
+  human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/docs/proposals/pending/embedder-runtime-fetch-autodim.md
+++ b/docs/proposals/pending/embedder-runtime-fetch-autodim.md
@@ -1,6 +1,16 @@
 # Proposal: Embedder runtime model fetch + auto-dimension
 
 - **State:** reviewed — READY (roundtable 2026-06-14: security · architect · QA · contrarian; 4 rounds to convergence)
+- **Implementation status (2026-06-16):** PARTIAL. §1 (thin image / runtime
+  model fetch) is in tree. §2's safety-critical core — the `kb_meta`
+  `schema_embedding_dim` record + dim-drift **refusal** (`db2_embedding_dim_record_or_check`,
+  atomic upsert) — landed in **PR #337**. **Remaining (not done):** §2's
+  pin > recorded > probe precedence wiring (`config_resolve_embedding_dim` is
+  still pin-only), the fresh-DB auto-derive from the embedder `/health` probe
+  under `pg_try_advisory_lock`, and the double-gated auto-reembed
+  (`kb_reembed_on_dim_change` off-by-default + `--confirm` + `/health=maintenance`
+  + count-divergence → degraded). These are runtime/bootstrap work best done with
+  the live embedder+kb stack.
 - **Author:** JBailes
 - **Date:** 2026-06-14
 - **Base:** `origin/main` (v0.2.65). The embedder ships in two **baked** images

--- a/docs/proposals/pending/ingress-compression-and-cache-alignment.md
+++ b/docs/proposals/pending/ingress-compression-and-cache-alignment.md
@@ -1,6 +1,17 @@
 # Proposal: Envelope compression, cache-prefix alignment, reversible rehydration, and failure-mined corrections
 
 - **State:** draft — pending review
+- **Design roundtable (2026-06-16):** NOT READY — 9 blocking / 12 major. Key
+  blockers: the `X-Aimee-Compress` override uses thread-local state (unsafe in the
+  threaded server); P1b/P2 lossy folds depend on `code_span_get` / `memory_get`
+  MCP tools that don't exist; the in-process rehydration handle store breaks in
+  multi-replica deployments; durable resolvers take model-supplied path/line args
+  (prompt-injection / path-traversal); several validation gates are unfalsifiable
+  ("task class" undefined, no independent rehydration oracle). Panel recommends
+  splitting into three independently-reviewable units: (1) P0+P1a+config behind
+  span-propagation fixes, (2) P2 behind the MCP tools + a deployment-shape
+  decision, (3) P3–P5 behind cost-accounting. **Next step: revise to address the
+  blockers before implementation.**
 - **Author:** JBailes
 - **Date:** 2026-06-11 (consolidated after eight PR-#181 review rounds; all 35
   findings verified in-tree and folded into the body)

--- a/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/pending/ingress-cost-accounting-and-optimizations.md
@@ -2,6 +2,22 @@
 
 - **State:** draft - pending review (consolidated after PR #180 review + twelve
   file-by-file codebase audits; findings integrated below)
+- **Implementation status (2026-06-16):** §1–§2 LARGELY LANDED, design-roundtable
+  run on the rest. **Merged:** §1 (one pricing authority — `token_estimate_cost`
+  + registry-fallback hook, `token_estimate_cost_ex` is_priced free-vs-unknown,
+  `delegate_ensemble` routed through it; static table reconciled with the model
+  registry) and the §2 **schema/foundations** (`usage_kind`
+  realized/estimated/avoided/partial + realized-only filter + spend-breakdown,
+  `requested_model`/`stop_reason`/`agent_log_id`, billable-model resolution,
+  `request_context.h`) shipped in **PR #185**; the §1 local-delegate pricing
+  coverage gap (minimax/mistral/mimo as known-zero) closed in **PR #339**.
+  **Design roundtable (2026-06-16):** NOT-READY, 10 blocking / 5 major — §1–§2
+  "sound in direction"; blockers are in the *remaining* §2/§3–§6 work. **Remaining
+  (blocked on design decisions):** §2 ingress-writes to the six no-log handlers
+  (async-write durability/backpressure, tenant-scoped idempotency, partial-row
+  policy), §3 cache-aware shaping, §4 dedup, §5 reasoning-effort cap (recommend
+  defer), §6 cost-shaped reward, §7 `/v1/usage/*`. See the roundtable findings for
+  the per-blocker fixes.
 - **Author:** JBailes
 - **Date:** 2026-06-11
 - **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing


### PR DESCRIPTION
Makes the `pending/` list reflect reality. After ground-truthing the code, several 'pending' proposals already have their **foundation phases merged** but weren't annotated — and the two ingress drafts now carry their **2026-06-16 design-roundtable verdicts**.

- **embedder-runtime-fetch-autodim** — §2 dim-drift guard core landed (#337); probe/precedence/auto-reembed remain.
- **auditable-correctness-for-the-kb** — P1 surface present on `testing` (turn_id, X-Aimee-Retrieval-Event, retrieval_event, kb_evidence_emit_enabled, `aimee audit trace`); P1.5/P2/P3/P4 remain (P4 needs a human gold corpus). The PR #185 dependency is satisfied.
- **ingress-cost-accounting** — §1 + §2 schema/foundations landed (#185) + local-delegate pricing (#339); records the design roundtable (not-ready, 10 blocking) for the remaining §2-writes/§3–6.
- **ingress-compression** — records the design roundtable (not-ready, 9 blocking) + the recommended 3-unit split.

Docs-only. No proposal moved to done/ (none is fully complete). `check-proposal-links` passes.