### PR TITLE
feat(audit): file content_hash through code search (auditable-correctness P2 Layer-1)

### DIFF
--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -741,7 +741,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
    if (shim && filter_project)
       sql = "SELECT p.name, f.path,"
             " snippet(code_fts, 0, '>>>', '<<<', '...', 20),"
-            " rank"
+            " rank,"
+            " f.hash"
             " FROM code_fts"
             " JOIN files f ON f.id = code_fts.rowid"
             " JOIN projects p ON p.id = f.project_id"
@@ -753,7 +754,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
    else if (shim)
       sql = "SELECT p.name, f.path,"
             " snippet(code_fts, 0, '>>>', '<<<', '...', 20),"
-            " rank"
+            " rank,"
+            " f.hash"
             " FROM code_fts"
             " JOIN files f ON f.id = code_fts.rowid"
             " JOIN projects p ON p.id = f.project_id"
@@ -766,7 +768,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       sql = "SELECT p.name, f.path,"
             " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
             " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
-            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1))"
+            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)),"
+            " f.hash"
             " FROM file_contents fc"
             " JOIN files f ON f.id = fc.file_id"
             " JOIN projects p ON p.id = f.project_id"
@@ -779,7 +782,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       sql = "SELECT p.name, f.path,"
             " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
             " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
-            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1))"
+            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)),"
+            " f.hash"
             " FROM file_contents fc"
             " JOIN files f ON f.id = fc.file_id"
             " JOIN projects p ON p.id = f.project_id"
@@ -811,10 +815,12 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       const char *fpath = aimee_pg_column_text(st, 1);
       const char *snip = aimee_pg_column_text(st, 2);
       double rnk = aimee_pg_column_double(st, 3);
+      const char *fhash = aimee_pg_column_text(st, 4); /* files.hash — P2 provenance */
       snprintf(out[count].project, sizeof(out[count].project), "%s", pname ? pname : "");
       snprintf(out[count].file_path, sizeof(out[count].file_path), "%s", fpath ? fpath : "");
       snprintf(out[count].snippet, sizeof(out[count].snippet), "%s", snip ? snip : "");
       out[count].rank = rnk;
+      snprintf(out[count].content_hash, sizeof(out[count].content_hash), "%s", fhash ? fhash : "");
       count++;
    }
    aimee_pg_finalize(st);

--- a/src/headers/index.h
+++ b/src/headers/index.h
@@ -112,6 +112,11 @@ typedef struct
    char file_path[MAX_PATH_LEN];
    char snippet[512];
    double rank;
+   /* files.hash of the matched file — auditable-correctness P2 Layer-1
+    * (file-level provenance): lets a citation name the exact content version and
+    * lets drift detection flag a hit whose live source no longer matches its
+    * stored hash. Empty when the row has no recorded hash. */
+   char content_hash[80];
 } code_search_hit_t;
 
 /* Lexical search across indexed code. Returns count of results. Ranking and

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -368,6 +368,8 @@ int handle_get_code_search(const char *query_string, char *out_buf, int out_cap)
       cJSON_AddStringToObject(hit, "file_path", hits[i].file_path);
       cJSON_AddStringToObject(hit, "snippet", hits[i].snippet);
       cJSON_AddNumberToObject(hit, "rank", hits[i].rank);
+      /* P2 Layer-1: file content hash for citation + drift detection. */
+      cJSON_AddStringToObject(hit, "content_hash", hits[i].content_hash);
       cJSON_AddItemToArray(arr, hit);
    }
    cJSON_AddNullToObject(resp, "next_cursor");

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -416,12 +416,15 @@ int canonical_index_project_lang_breakdown(const char *project, char *buf, size_
    return 0;
 }
 
+/* Must mirror code_search_hit_t (index.h) exactly — the handler casts the out
+ * buffer to it; a layout mismatch would corrupt the read. */
 typedef struct
 {
    char project[128];
    char file_path[MAX_PATH_LEN];
    char snippet[512];
    double rank;
+   char content_hash[80];
 } test_code_search_hit_t;
 
 int canonical_index_code_search(const char *query, const char *project, void *out, int max)
@@ -437,6 +440,7 @@ int canonical_index_code_search(const char *query, const char *project, void *ou
    snprintf(hits[0].file_path, sizeof(hits[0].file_path), "src/search.c");
    snprintf(hits[0].snippet, sizeof(hits[0].snippet), "int needle(void) { return 1; }");
    hits[0].rank = 0.75;
+   snprintf(hits[0].content_hash, sizeof(hits[0].content_hash), "deadbeefcafe");
    return 1;
 }
 

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -36,6 +36,8 @@ static void test_code_search_ok(void)
    assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL);
    assert(strstr(buf, "\"snippet\":\"int needle") != NULL);
    assert(strstr(buf, "\"rank\":0.75") != NULL);
+   /* P2 Layer-1: the file content hash is surfaced for citation/drift. */
+   assert(strstr(buf, "\"content_hash\":\"deadbeefcafe\"") != NULL);
    assert(strstr(buf, "\"next_cursor\":null") != NULL);
 }
 


### PR DESCRIPTION
First increment of **auditable-correctness P2** (Layer-1 versioned provenance). P1 (turn_id + X-Aimee-Retrieval-Event + retrieval_event + audit trace) is already on `testing`.

## What
Surface the matched file's content hash on each code-search hit, so:
- **Citation:** `/v1/audit/{trace,provenance}` (and any client) can name the exact content version of a cited source.
- **Drift detection:** a hit whose live source hash no longer matches its stored `content_hash` is *suspect* (feeds the future drift-ranked requeue, D7).

## Change
- `code_search_hit_t` gains `content_hash`.
- `db2_code_index_code_search` selects `files.hash` (column 4) in all four SQL variants (shim/PG × project-filter) and populates it. `files.hash` is already maintained by the scanner.
- `/v1/code/search` emits `content_hash` per hit.
- `test_kb_http_routes`: the mock struct mirrors the new layout, the mock sets a hash, and `test_code_search_ok` asserts it appears in the response.

## Granularity note (for review)
Code search is **file-level FTS** (`file_contents`), so this is **file-level** provenance (`files.hash`). The proposal's Layer-1 also mentions a `node_key`; node/code-unit-level provenance (via the code-unit index `body_hash`) would be a larger follow-up. File-level is the natural fit for the current search and is immediately useful.

## Verification
`make all`, `make lint`, `make build-integrity`, and `unit-test-kb-http-routes` / `unit-test-code-index-ops` all green locally. Additive struct field — the four other tests that use `code_search_hit_t` use the real type and are unaffected.