### PR TITLE
feat(audit): /v1/audit/provenance + 'aimee audit provenance' (auditable-correctness P2)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -909,6 +909,38 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /audit/provenance:
+    post:
+      summary: Per-turn source provenance (proxied to aimee-kb)
+      description: >-
+        Which sources grounded a turn's answer, at which version: given the
+        caller-visible turn_id, resolve each source id recorded on the turn's
+        retrieval_event to {id, kind, source, version, present}, where version is
+        the source row's updated_at (read live) and present is false when the
+        source no longer exists (deleted/superseded since the turn). provenance_status
+        is one of the exhaustive states ok / not_instrumented / not_evaluated /
+        evidence_unavailable (P2 produces ok and evidence_unavailable). Requires
+        aimee-kb. Gated by kb_evidence_emit_enabled at emit time.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [turn_id]
+              properties:
+                turn_id: { type: string }
+      responses:
+        "200":
+          description: Provenance bundle ({status, provenance_status, turn_id, retrieval_event_id?, sources?})
+          content:
+            application/json:
+              schema: { type: object }
+        "502":
+          description: Knowledge service (aimee-kb) unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /notes:
     get:
       summary: List notes (proxied to aimee-kb)

--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -10,10 +10,15 @@
   `kb_evidence_emit_enabled` flag, and the `aimee audit trace` CLI. (The P1
   dependency on PR #185 cost-accounting is satisfied — #185 is merged.) **Verify
   P1 functional completeness end-to-end before moving this proposal to done.**
-  **Remaining:** P1.5 (typed doc/code refs + two-writer merge), P2 (versioned
-  provenance + `aimee audit provenance` + drift-ranked requeue — shippable), P3
-  (fidelity_check judge + `fidelity_report`), P4 (labelled gold corpus — needs
-  human curation, not autonomous).
+  **P2 in progress:** Layer-1 code-search provenance landed in #344
+  (`code_search_hit_t`/`/v1/code/search` carry `content_hash`); the
+  `/v1/audit/provenance` read surface + `aimee audit provenance <turn_id>` landed
+  next (resolves each surfaced source id to `{id, kind, source, version, present}`,
+  version = the row's live `updated_at`). **Remaining:** P1.5 (typed doc/code refs
+  + two-writer merge), P2's emit-time point-in-time version capture (provenance
+  currently reads versions live) + drift-ranked requeue in `memory_maintenance.c`
+  (D7), P3 (fidelity_check judge + `fidelity_report`), P4 (labelled gold corpus —
+  needs human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -307,6 +307,7 @@ static const struct
     {"mcp", "audit", "mcp.audit", NULL, "items", 0},
     {"mcp", "recheck", "mcp.recheck", NULL, "items", 300000},
     {"audit", "trace", "evidence.trace_retrieval_event", NULL, NULL, 0},
+    {"audit", "provenance", "evidence.provenance_retrieval_event", NULL, NULL, 0},
     {"get_help", NULL, "get_help", "mcp.call", NULL, 0},
     {"get-help", NULL, "get_help", "mcp.call", NULL, 0},
     {"verify", NULL, "git.verify", "mcp.call", NULL, 900000},
@@ -979,6 +980,18 @@ static cJSON *marshal_audit_trace(int argc, char **argv)
    rpc_parse(argc, argv, NULL, &opts);
 
    cJSON *req = marshal_no_args("evidence.trace_retrieval_event");
+   if (opts.pos_count > 0)
+      cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
+   return req;
+}
+
+/* Auditable-correctness P2: `aimee audit provenance <turn_id>` → the turn_id param. */
+static cJSON *marshal_audit_provenance(int argc, char **argv)
+{
+   rpc_opts_t opts;
+   rpc_parse(argc, argv, NULL, &opts);
+
+   cJSON *req = marshal_no_args("evidence.provenance_retrieval_event");
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
    return req;
@@ -3296,6 +3309,8 @@ static cJSON *marshal_request(const char *method, int argc, char **argv)
       return marshal_config_get(argc, argv);
    if (strcmp(method, "evidence.trace_retrieval_event") == 0)
       return marshal_audit_trace(argc, argv);
+   if (strcmp(method, "evidence.provenance_retrieval_event") == 0)
+      return marshal_audit_provenance(argc, argv);
    if (strcmp(method, "config.set") == 0)
       return marshal_config_set(argc, argv);
    if (strcmp(method, "aux.test") == 0)

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -79,6 +79,7 @@ static const struct
     {"dogfood.tag", "POST", "/v1/dogfood/tag"},
     {"episode.list", "GET", "/v1/episode/list"},
     {"eval.results", "GET", "/v1/eval/results"},
+    {"evidence.provenance_retrieval_event", "POST", "/v1/audit/provenance"},
     {"evidence.trace_retrieval_event", "POST", "/v1/audit/trace"},
     {"graph.explain", "POST", "/v1/graph/explain"},
     {"hooks.post", "POST", "/v1/hooks/post"},

--- a/src/db2/memory_payload.c
+++ b/src/db2/memory_payload.c
@@ -129,6 +129,45 @@ char *db2_memory_build_memory_payload(int64_t memory_id)
    return payload_json;
 }
 
+int db2_memory_provenance_by_id(int64_t memory_id, char *kind_out, int kind_len, char *source_out,
+                                int source_len, char *version_out, int version_len)
+{
+   if (kind_out && kind_len > 0)
+      kind_out[0] = '\0';
+   if (source_out && source_len > 0)
+      source_out[0] = '\0';
+   if (version_out && version_len > 0)
+      version_out[0] = '\0';
+   if (memory_id <= 0)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "SELECT kind, source_session, updated_at FROM memories WHERE id = ?1";
+   char err[MP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", memory_id);
+   int step = aimee_pg_step(st, err, sizeof(err));
+   if (step != AIMEE_PG_ROW)
+   {
+      aimee_pg_finalize(st);
+      return step == AIMEE_PG_DONE ? 0 : -1; /* 0 = no such row (deleted/superseded) */
+   }
+   const char *k = aimee_pg_column_text(st, 0);
+   const char *s = aimee_pg_column_text(st, 1);
+   const char *v = aimee_pg_column_text(st, 2);
+   if (kind_out && kind_len > 0)
+      snprintf(kind_out, (size_t)kind_len, "%s", k ? k : "");
+   if (source_out && source_len > 0)
+      snprintf(source_out, (size_t)source_len, "%s", s ? s : "");
+   if (version_out && version_len > 0)
+      snprintf(version_out, (size_t)version_len, "%s", v ? v : "");
+   aimee_pg_finalize(st);
+   return 1;
+}
+
 char *db2_memory_build_unit_payload(int64_t unit_id, int64_t *memory_id_out)
 {
    if (unit_id <= 0)

--- a/src/db2/memory_payload.h
+++ b/src/db2/memory_payload.h
@@ -39,6 +39,15 @@ extern "C"
    /* Total row count in the memories table. Returns 0 on error. */
    int64_t db2_memory_count(void);
 
+   /* Auditable-correctness P2 (/v1/audit/provenance): resolve a surfaced memory
+    * id to its provenance fields — kind, source (source_session), and version
+    * (the row's updated_at). Any out buffer may be NULL. Returns 1 on hit, 0 when
+    * no such row exists (deleted/superseded since the turn — itself a provenance
+    * signal), -1 on error. */
+   int db2_memory_provenance_by_id(int64_t memory_id, char *kind_out, int kind_len,
+                                   char *source_out, int source_len, char *version_out,
+                                   int version_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -786,6 +786,11 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
  * (malloc'd, caller frees; NULL on bad arg or kb error). */
 char *kb_client_evidence_trace_retrieval_event(const char *turn_id);
 
+/* Auditable-correctness P2: the /v1/audit/provenance read — forward to the KB
+ * evidence.provenance_retrieval_event action and return its JSON response
+ * verbatim (malloc'd, caller frees; NULL on bad arg or kb error). */
+char *kb_client_evidence_provenance_retrieval_event(const char *turn_id);
+
 /* Fetch the entity profile card via aimee-kb.  Returns 0 on success
  * (|out| filled) or -1 if kb is unreachable or the entity is missing.
  * Mirrors memory_get_entity_profile(). */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -283,6 +283,7 @@ int handle_graph_sync_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_graph_explain(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_synthesize(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_contradictions(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1054,6 +1054,7 @@ static const struct
     {"memory.context_block", kb_handle_memory_context_block},
     {"evidence.emit_retrieval_event", kb_handle_evidence_emit_retrieval_event},
     {"evidence.trace_retrieval_event", kb_handle_evidence_trace_retrieval_event},
+    {"evidence.provenance_retrieval_event", kb_handle_evidence_provenance},
     {"memory.entity_profile", kb_handle_memory_entity_profile},
     {"memory.entity_edges", kb_handle_memory_entity_edges},
     {"memory.search_graph", kb_handle_memory_search_graph},

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -11,6 +11,7 @@
 #include "db2/kb_service_backend.h"
 #include "db2/bandit.h"
 #include "db2/demotion.h" /* db2_demotion_retrieval_event_write_turn (auditable-correctness P1) */
+#include "db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "kb_bandit.h"
 #include "kb_bandit_registry.h"
 #include "kb_service_memory.h"
@@ -835,6 +836,70 @@ int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req)
                               rc < 0 ? "lookup error" : "no durable retrieval_event for this turn");
    }
    return kb_reply_or_error(fd, resp, "failed to trace retrieval_event");
+}
+
+/* Auditable-correctness P2: the /v1/audit/provenance read. Look up the turn's
+ * retrieval_event (same four-state status as the trace read) and resolve each
+ * surfaced source id to {id, kind, source, version} — version is the memory row's
+ * updated_at, read live, so a caller can compare it to what trace recorded and a
+ * source no longer present (deleted/superseded since the turn) is flagged
+ * present:false rather than silently dropped. This is a pure read (D8). */
+int kb_handle_evidence_provenance(int fd, cJSON *req)
+{
+   cJSON *turn_j = cJSON_GetObjectItemCaseSensitive(req, "turn_id");
+   if (!cJSON_IsString(turn_j) || !turn_j->valuestring[0])
+      return kb_send_error(fd, "audit.provenance requires turn_id");
+   /* turn_ids are short UUIDs; reject absurd input up front (defense in depth —
+    * downstream binds it as a SQL parameter, not into a fixed buffer). */
+   if (strlen(turn_j->valuestring) > 128)
+      return kb_send_error(fd, "audit.provenance turn_id too long");
+
+   char ev_id[64] = "";
+   char payload[8192] = "";
+   int rc = db2_demotion_retrieval_event_by_turn(turn_j->valuestring, ev_id, sizeof(ev_id), payload,
+                                                 sizeof(payload));
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "turn_id", turn_j->valuestring);
+   if (rc == 1)
+   {
+      cJSON_AddStringToObject(resp, "provenance_status", "ok");
+      cJSON_AddStringToObject(resp, "retrieval_event_id", ev_id);
+      cJSON *sources = cJSON_AddArrayToObject(resp, "sources");
+      cJSON *ev = payload[0] ? cJSON_Parse(payload) : NULL;
+      cJSON *ids = ev ? cJSON_GetObjectItemCaseSensitive(ev, "surfaced_ids") : NULL;
+      int n = cJSON_IsArray(ids) ? cJSON_GetArraySize(ids) : 0;
+      for (int i = 0; sources && i < n; i++)
+      {
+         cJSON *e = cJSON_GetArrayItem(ids, i);
+         if (!cJSON_IsNumber(e) || e->valuedouble <= 0)
+            continue;
+         /* Same cast the emit writer (kb_handle_evidence_emit_retrieval_event)
+          * used to store the id, so the round-trip is lossless for the values
+          * actually persisted. */
+         int64_t id = (int64_t)e->valuedouble;
+         char kind[64] = "", source[128] = "", version[64] = "";
+         int found = db2_memory_provenance_by_id(id, kind, sizeof kind, source, sizeof source,
+                                                 version, sizeof version);
+         cJSON *src = cJSON_CreateObject();
+         cJSON_AddNumberToObject(src, "id", (double)id);
+         cJSON_AddStringToObject(src, "kind", kind);
+         cJSON_AddStringToObject(src, "source", source);
+         cJSON_AddStringToObject(src, "version", version);
+         cJSON_AddBoolToObject(src, "present", found == 1);
+         cJSON_AddItemToArray(sources, src);
+      }
+      if (ev)
+         cJSON_Delete(ev);
+   }
+   else
+   {
+      cJSON_AddStringToObject(resp, "provenance_status", "evidence_unavailable");
+      cJSON_AddStringToObject(resp, "detail",
+                              rc < 0 ? "lookup error" : "no durable retrieval_event for this turn");
+   }
+   return kb_reply_or_error(fd, resp, "failed to read provenance");
 }
 
 int kb_handle_memory_entity_profile(int fd, cJSON *req)

--- a/src/kb_service_memory.h
+++ b/src/kb_service_memory.h
@@ -61,6 +61,8 @@ int kb_handle_memory_context_block(int fd, cJSON *req);
 int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req);
 /* Auditable-correctness P1: the /v1/audit/trace read (four-state status). */
 int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req);
+/* Auditable-correctness P2: the /v1/audit/provenance read (sources at version). */
+int kb_handle_evidence_provenance(int fd, cJSON *req);
 int kb_handle_memory_entity_profile(int fd, cJSON *req);
 int kb_handle_memory_entity_edges(int fd, cJSON *req);
 int kb_handle_memory_search_graph(int fd, cJSON *req);

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1641,6 +1641,17 @@ char *kb_client_evidence_trace_retrieval_event(const char *turn_id)
    return kb_v1_action_request("evidence.trace_retrieval_event", req);
 }
 
+char *kb_client_evidence_provenance_retrieval_event(const char *turn_id)
+{
+   if (!turn_id || !turn_id[0])
+      return NULL;
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "turn_id", turn_id);
+   /* Pass the KB action's response through verbatim (status + provenance_status +
+    * retrieval_event_id + sources[]). kb_v1_action_request owns req. */
+   return kb_v1_action_request("evidence.provenance_retrieval_event", req);
+}
+
 char *kb_client_memory_lint_json(void)
 {
    cJSON *req = cJSON_CreateObject();

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1045,6 +1045,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     /* KB */
     {"kb.search", handle_kb_search},
     {"evidence.trace_retrieval_event", handle_evidence_trace},
+    {"evidence.provenance_retrieval_event", handle_evidence_provenance},
     {"curator.implements", handle_curator_implements},
     {"curator.synthesize", handle_curator_synthesize},
     {"curator.contradictions", handle_curator_contradictions},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -136,6 +136,7 @@ const method_policy_t method_registry[] = {
     /* Knowledge base: search/status read; build/ingest/update rebuild the store. */
     {"kb.search", CAP_INDEX_READ, "knowledge search"},
     {"evidence.trace_retrieval_event", CAP_INDEX_READ, "audit retrieval-evidence trace"},
+    {"evidence.provenance_retrieval_event", CAP_INDEX_READ, "audit source provenance"},
     {"kb.status", CAP_DASHBOARD_READ, "knowledge base status"},
     {"optimize.export", CAP_DASHBOARD_READ, "bandit optimization export"},
     {"optimize.promote", CAP_INDEX_ADMIN, "promote a bandit arm to default"},

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1108,6 +1108,8 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/code/audit", NULL, RM_EXACT, "code.audit", 0, rh_dispatch_op},
     {"POST", "/v1/audit/trace", NULL, RM_EXACT, "evidence.trace_retrieval_event", 0,
      rh_dispatch_op},
+    {"POST", "/v1/audit/provenance", NULL, RM_EXACT, "evidence.provenance_retrieval_event", 0,
+     rh_dispatch_op},
     {"POST", "/v1/trajectory/batch", NULL, RM_EXACT, "trajectory.batch", 0, rh_dispatch_op},
 
     /* work.* / wm.* / skill.* / session.* / toolset.* / mcp.* / trigger.* and

--- a/src/server/server_state_audit.inc
+++ b/src/server/server_state_audit.inc
@@ -21,3 +21,20 @@ int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return server_send_error(conn, "knowledge service audit trace failed", NULL);
    return send_and_free(conn, resp);
 }
+
+/* /v1/audit/provenance handler. Like handle_evidence_trace, its op
+ * (evidence.provenance_retrieval_event) is a KB-only action, so the server
+ * forwards it to aimee-kb via kb_client and passes the JSON response through. */
+int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *turn_id = jo_str(req, "turn_id", "");
+   if (!turn_id[0])
+      return server_send_error(conn, "audit provenance requires turn_id", NULL);
+   char *json = kb_client_evidence_provenance_retrieval_event(turn_id);
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   if (!resp)
+      return server_send_error(conn, "knowledge service audit provenance failed", NULL);
+   return send_and_free(conn, resp);
+}

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -543,6 +543,10 @@ int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "evidence.trace_retrieval_event");
 }
+int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "evidence.provenance_retrieval_event");
+}
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "curator.implements");
@@ -1450,6 +1454,16 @@ static void test_routing(void)
    assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
                  "evidence.trace_retrieval_event") == 0);
    assert(strcmp(g_last_handler, "evidence.trace_retrieval_event") == 0);
+   cJSON_Delete(json);
+
+   /* Auditable-correctness P2: /v1/audit/provenance's op must likewise resolve to
+    * its server-side KB-forward handler. */
+   json = dispatch_json(
+       ctx, conn, "{\"method\":\"evidence.provenance_retrieval_event\",\"turn_id\":\"t1\"}",
+       strlen("{\"method\":\"evidence.provenance_retrieval_event\",\"turn_id\":\"t1\"}"));
+   assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
+                 "evidence.provenance_retrieval_event") == 0);
+   assert(strcmp(g_last_handler, "evidence.provenance_retrieval_event") == 0);
    cJSON_Delete(json);
 
    json = dispatch_json(ctx, conn, "{\"method\":\"rules.delete\",\"id\":1}",


### PR DESCRIPTION
The pure-read **provenance** sibling to `/v1/audit/trace` (D8), continuing auditable-correctness **P2** (after #344's Layer-1 code provenance).

## What
`GET`-style `POST /v1/audit/provenance` (and `aimee audit provenance <turn_id>`): given a turn_id, resolve each source id recorded on the turn's `retrieval_event` to `{id, kind, source, version, present}` —
- **version** = the memory row's `updated_at` (read live), so a caller can compare it to what `trace` recorded;
- **present** = false when the source no longer exists (deleted/superseded since the turn — itself a provenance signal, never silently dropped).

Same four-state status model as trace (`ok` / `evidence_unavailable` reachable now; `not_instrumented` / `not_evaluated` are later phases).

## Full forward chain (mirrors trace)
- `db2_memory_provenance_by_id` (`memory_payload.c`) — lightweight kind/source/version resolver.
- `kb_handle_evidence_provenance` (`kb_service_memory.c`) + KB dispatch registration.
- Server forward: `handle_evidence_provenance` (`server_state_audit.inc`), `kb_client_evidence_provenance_retrieval_event` (`kb_client_memory.c`), `server.c` dispatch entry, `server_auth.c` capability (`CAP_INDEX_READ`).
- Routes: `server_http_routes.inc` + `openapi-server-v1.yaml` + regenerated `cli_v1_routes_gen.inc`; CLI route + positional `turn_id` marshal.
- `test_server_dispatch`: op-routing regression guard (mirrors the trace guard).

## Verification
`make all`, `make lint` (incl. server-api-conformance, cli-v1-routes, v1-method-coverage), `make build-integrity`, and `unit-test-server-dispatch` all green locally.

## Note
Versions are read **live** at provenance-read time. Emit-time point-in-time version capture + drift-ranked requeue (D7) are the next P2 increments (documented in the proposal status).