### PR TITLE
fix(delegate): thread-local source-authority context (kill concurrent-delegate race)

### DIFF
--- a/src/headers/agent_source_authority.h
+++ b/src/headers/agent_source_authority.h
@@ -8,4 +8,21 @@ void agent_source_add_index_freshness(cJSON *obj, const char *project, const cha
 int agent_source_append_overlay_code_hits(cJSON *arr, const char *query, const char *project,
                                           int max_results);
 
+/* Thread-local source-authority context for an in-process delegate run. Set by
+ * delegate_run_ctx_enter; the code_search overlay reads it (TLS) instead of the
+ * process-global AIMEE_DELEGATE_* env vars, which raced across concurrent
+ * delegates. capture/restore preserve nesting on one thread. The env vars stay
+ * the fallback for cross-process child clients. */
+typedef struct
+{
+   int active;
+   int authority;
+   char root[MAX_PATH_LEN];
+   char *paths; /* heap-owned; restore() frees the live value and adopts this */
+} agent_source_authority_snapshot_t;
+
+void agent_source_authority_tls_set(int authority, const char *worktree_root, const char *paths);
+void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap);
+void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap);
+
 #endif /* DEC_AGENT_SOURCE_AUTHORITY_H */

--- a/src/posix/agent_source_authority.c
+++ b/src/posix/agent_source_authority.c
@@ -6,19 +6,83 @@
 #include "util.h"
 #include "cJSON.h"
 #include <ctype.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
+/* Per-delegate source-authority context.
+ *
+ * This was previously read from process-global env vars (AIMEE_DELEGATE_*),
+ * which raced once delegates began running concurrently on detached threads
+ * (on-demand execution): a delegate's code_search overlay would resolve its
+ * staleness/freshness checks against ANOTHER concurrently-running delegate's
+ * worktree root, producing wrong annotations that varied with thread timing.
+ *
+ * The authoritative source for an in-process delegate run is now thread-local,
+ * installed by delegate_run_ctx_enter (see server_compute.c). The env vars
+ * remain the fallback for cross-process child clients (cmd_index, the
+ * aimee-client shell-out), which inherit them and have their own single-
+ * threaded environment. tl_sa_active distinguishes "this thread is running a
+ * delegate" (read TLS) from "not in a delegate" (read env / no-op). */
+static __thread int tl_sa_active = 0;
+static __thread int tl_sa_authority = 0;
+static __thread char tl_sa_root[MAX_PATH_LEN] = {0};
+static __thread char *tl_sa_paths = NULL; /* heap, newline-joined; may be NULL */
+
+void agent_source_authority_tls_set(int authority, const char *worktree_root, const char *paths)
+{
+   tl_sa_active = 1;
+   tl_sa_authority = authority ? 1 : 0;
+   snprintf(tl_sa_root, sizeof(tl_sa_root), "%s", worktree_root ? worktree_root : "");
+   free(tl_sa_paths);
+   tl_sa_paths = (paths && paths[0]) ? strdup(paths) : NULL;
+}
+
+void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap)
+{
+   if (!snap)
+      return;
+   snap->active = tl_sa_active;
+   snap->authority = tl_sa_authority;
+   snprintf(snap->root, sizeof(snap->root), "%s", tl_sa_root);
+   snap->paths = tl_sa_paths ? strdup(tl_sa_paths) : NULL;
+}
+
+void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
+{
+   if (!snap)
+      return;
+   tl_sa_active = snap->active;
+   tl_sa_authority = snap->authority;
+   snprintf(tl_sa_root, sizeof(tl_sa_root), "%s", snap->root);
+   free(tl_sa_paths);
+   tl_sa_paths = snap->paths; /* transfer ownership */
+   snap->paths = NULL;
+}
+
 static int source_authority_enabled(void)
 {
+   if (tl_sa_active)
+      return tl_sa_authority;
    const char *enabled = getenv("AIMEE_DELEGATE_SOURCE_AUTHORITY");
    return enabled && enabled[0] && strcmp(enabled, "0") != 0;
 }
 
 static const char *source_authority_root(void)
 {
+   if (tl_sa_active)
+      return tl_sa_root[0] ? tl_sa_root : NULL;
    const char *root = getenv("AIMEE_DELEGATE_WORKTREE_ROOT");
    return root && root[0] ? root : NULL;
+}
+
+/* Newline-joined source paths for the current delegate (TLS), or the env
+ * fallback for cross-process clients. May return NULL. */
+static const char *source_authority_paths(void)
+{
+   if (tl_sa_active)
+      return tl_sa_paths;
+   return getenv("AIMEE_DELEGATE_SOURCE_PATHS");
 }
 
 static void source_authority_resolve_path(const char *path, char *out, size_t out_len)
@@ -61,7 +125,7 @@ static int source_path_matches_hit(const char *source_path, const char *hit_path
 
 static int source_paths_contains(const char *hit_path)
 {
-   const char *paths = getenv("AIMEE_DELEGATE_SOURCE_PATHS");
+   const char *paths = source_authority_paths();
    if (!paths || !paths[0] || !hit_path || !hit_path[0])
       return 0;
 
@@ -188,7 +252,7 @@ int agent_source_append_overlay_code_hits(cJSON *arr, const char *query, const c
    (void)project;
    if (!arr || !source_authority_enabled() || !query || !query[0] || max_results <= 0)
       return 0;
-   const char *paths = getenv("AIMEE_DELEGATE_SOURCE_PATHS");
+   const char *paths = source_authority_paths();
    if (!paths || !paths[0])
       return 0;
 
@@ -258,7 +322,7 @@ char *tool_find_symbol(const char *identifier)
    int overlay_matches = 0;
    if (source_authority_enabled())
    {
-      const char *paths = getenv("AIMEE_DELEGATE_SOURCE_PATHS");
+      const char *paths = source_authority_paths();
       const char *p = paths && paths[0] ? paths : NULL;
       while (p && *p && overlay_matches < 8 && pos < (int)sizeof(buf) - 512)
       {

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -18,6 +18,7 @@
 #include "delegate_credential_retry.h"
 #include "delegate_launch.h"
 #include "delegate_source_authority.h"
+#include "agent_source_authority.h" /* TLS source-authority context (race-free in-process) */
 #include "server_coord_dispatcher.h"
 #include "delegate_credentials.h"
 #include "vault_service.h" /* WP-C.1 vault-first credential resolution */
@@ -470,6 +471,7 @@ typedef struct
    char saved_env_depth[32];
    char saved_env_parent[64];
    delegate_source_env_snapshot_t source_env;
+   agent_source_authority_snapshot_t sa_snap;
 } delegate_run_ctx_t;
 
 static void delegate_run_ctx_enter(delegate_run_ctx_t *c, const char *deleg_id, const char *sid,
@@ -498,12 +500,21 @@ static void delegate_run_ctx_enter(delegate_run_ctx_t *c, const char *deleg_id, 
       snprintf(c->saved_env_parent, sizeof(c->saved_env_parent), "%s", e);
    platform_setenv("AIMEE_PARENT_DELEGATION_ID", deleg_id);
 
+   /* Env (process-global) is kept for cross-process child clients that inherit
+    * it. The in-process source-authority consumer (code_search overlay) instead
+    * reads the thread-local context below, which does NOT race across the
+    * concurrent delegate threads the way the shared env does. clear_for_worktree
+    * disables authority + clears paths, so mirror that: authority=0, paths=NULL,
+    * worktree=source_env_root. */
    delegate_source_env_capture(&c->source_env);
    delegate_source_env_clear_for_worktree(source_env_root);
+   agent_source_authority_tls_capture(&c->sa_snap);
+   agent_source_authority_tls_set(0, source_env_root, NULL);
 }
 
-static void delegate_run_ctx_restore(const delegate_run_ctx_t *c)
+static void delegate_run_ctx_restore(delegate_run_ctx_t *c)
 {
+   agent_source_authority_tls_restore(&c->sa_snap);
    platform_setenv("AIMEE_DELEGATE_DEPTH", c->saved_env_depth[0] ? c->saved_env_depth : "");
    platform_setenv("AIMEE_PARENT_DELEGATION_ID", c->saved_env_parent[0] ? c->saved_env_parent : "");
    delegate_source_env_restore(&c->source_env);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -882,6 +882,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
                                $(OBJDIR)/tests/support/delegate_role_policy_stub.o \
                                $(OBJDIR)/tests/support/toolset_stub.o \
+                               $(OBJDIR)/tests/support/agent_source_authority_stub.o \
                                $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/delegations.o $(OBJDIR)/db1/agent_jobs.o $(OBJDIR)/db1/session_paths.o $(OBJDIR)/db1/cost_fold.o $(OBJDIR)/db1/token_audit.o $(OBJDIR)/server/delegate_credentials.o $(OBJDIR)/server/delegate_credential_retry.o $(OBJDIR)/db1/delegate_learning.o $(OBJDIR)/db1/interaction_events.o \
                                $(OBJDIR)/db1/execution_plans.o $(OBJDIR)/db1/coord_jobs.o \
 		                               $(OBJDIR)/server/delegate_launch.o $(OBJDIR)/server/delegate_source_authority.o $(OBJDIR)/server/delegate_economics.o $(OBJDIR)/server/server_coord_dispatcher.o \

--- a/src/tests/support/agent_source_authority_stub.c
+++ b/src/tests/support/agent_source_authority_stub.c
@@ -1,0 +1,33 @@
+/* Stub of the source-authority TLS setters for tests that link server_compute.c
+ * (delegate_run_ctx_enter/restore call these) but do not exercise the
+ * code_search overlay. The real implementation lives in
+ * posix/agent_source_authority.c, which pulls in kb_client/agent_tools. */
+#include "agent_source_authority.h"
+#include <stdlib.h>
+
+void agent_source_authority_tls_set(int authority, const char *worktree_root, const char *paths)
+{
+   (void)authority;
+   (void)worktree_root;
+   (void)paths;
+}
+
+void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap)
+{
+   if (snap)
+   {
+      snap->active = 0;
+      snap->authority = 0;
+      snap->root[0] = '\0';
+      snap->paths = NULL;
+   }
+}
+
+void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
+{
+   if (snap)
+   {
+      free(snap->paths);
+      snap->paths = NULL;
+   }
+}

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1834,6 +1834,7 @@ int main(void)
    test_tool_grep_excludes_heavy_dirs();
    test_dispatch_tool_call();
    test_source_authority_overlay_tools();
+   test_source_authority_tls_thread_isolation();
    test_parse_openai_tool_calls();
    test_path_traversal_rejected();
    test_sensitive_path_rejected();

--- a/src/tests/test_agent_source_authority.inc
+++ b/src/tests/test_agent_source_authority.inc
@@ -1,3 +1,98 @@
+#include "agent_source_authority.h"
+#include <pthread.h>
+
+/* Regression test for the concurrent-delegate source-authority race: each
+ * delegate installs its source context via agent_source_authority_tls_set
+ * (thread-local), and the code_search overlay must read THIS thread's context,
+ * never a neighbor's. Pre-fix the context lived in process-global env vars, so
+ * 8 threads each setting a different worktree/paths clobbered each other and the
+ * overlay resolved against the wrong tree (flakiness that varied with timing).
+ *
+ * Two thread groups (A/B) each own a distinct file whose unique symbol exists
+ * ONLY in their file. Each thread, looping, sets its TLS paths and asserts the
+ * overlay finds ITS symbol (>=1 hit) and NOT the other group's symbol (0 hits).
+ * Any cross-thread TLS leak flips one of those assertions. */
+typedef struct
+{
+   const char *path;      /* this group's source file */
+   const char *own_sym;   /* symbol present only in `path` */
+   const char *other_sym; /* the other group's symbol, absent from `path` */
+   const char *root;
+   int iters;
+   int failed;
+} sa_tls_worker_arg_t;
+
+static void *sa_tls_worker(void *argp)
+{
+   sa_tls_worker_arg_t *a = (sa_tls_worker_arg_t *)argp;
+   for (int i = 0; i < a->iters; i++)
+   {
+      agent_source_authority_tls_set(1, a->root, a->path);
+
+      cJSON *own = cJSON_CreateArray();
+      int own_hits = agent_source_append_overlay_code_hits(own, a->own_sym, NULL, 5);
+      cJSON *other = cJSON_CreateArray();
+      int other_hits = agent_source_append_overlay_code_hits(other, a->other_sym, NULL, 5);
+
+      if (own_hits < 1 || other_hits != 0)
+         a->failed = 1; /* TLS leaked from another thread */
+      cJSON_Delete(own);
+      cJSON_Delete(other);
+   }
+   /* Release the heap-held paths for this thread (zeroed snapshot frees + clears). */
+   agent_source_authority_snapshot_t z;
+   memset(&z, 0, sizeof(z));
+   agent_source_authority_tls_restore(&z);
+   return NULL;
+}
+
+static void test_source_authority_tls_thread_isolation(void)
+{
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-sa-tls-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+
+   char path_a[768], path_b[768];
+   snprintf(path_a, sizeof(path_a), "%s/group_a.c", tmpdir);
+   snprintf(path_b, sizeof(path_b), "%s/group_b.c", tmpdir);
+   FILE *fa = fopen(path_a, "w");
+   assert(fa);
+   fputs("int alpha_unique_marker(void) { return 1; }\n", fa);
+   fclose(fa);
+   FILE *fb = fopen(path_b, "w");
+   assert(fb);
+   fputs("int beta_unique_marker(void) { return 2; }\n", fb);
+   fclose(fb);
+
+   enum
+   {
+      NW = 8,
+      ITERS = 150
+   };
+   pthread_t th[NW];
+   sa_tls_worker_arg_t args[NW];
+   for (int i = 0; i < NW; i++)
+   {
+      int is_a = (i % 2 == 0);
+      args[i].path = is_a ? path_a : path_b;
+      args[i].own_sym = is_a ? "alpha_unique_marker" : "beta_unique_marker";
+      args[i].other_sym = is_a ? "beta_unique_marker" : "alpha_unique_marker";
+      args[i].root = tmpdir;
+      args[i].iters = ITERS;
+      args[i].failed = 0;
+      assert(pthread_create(&th[i], NULL, sa_tls_worker, &args[i]) == 0);
+   }
+   for (int i = 0; i < NW; i++)
+   {
+      pthread_join(th[i], NULL);
+      assert(args[i].failed == 0); /* no cross-thread source-authority leak */
+   }
+
+   unlink(path_a);
+   unlink(path_b);
+   rmdir(tmpdir);
+}
+
 static void test_source_authority_overlay_tools(void)
 {
    char tmpdir[512];


### PR DESCRIPTION
## Problem
Once delegates began running concurrently on detached threads (on-demand execution), *which* model/delegate appeared "flaky" varied hour-to-hour — the signature of a harness race, not a provider issue.

**Root cause (confirmed end-to-end):** per-delegate **source-authority context** (worktree root, authority flag, source paths) was carried in **process-global env vars** (`AIMEE_DELEGATE_SOURCE_AUTHORITY/SOURCE_PATHS/WORKTREE_ROOT`):
- **Write** (no lock, per-delegate, detached threads): `delegate_run_ctx_enter` (`server_compute.c`) `platform_setenv`.
- **Read in-process** during the delegate's own `code_search`: `agent_tools.c` → `agent_source_authority.c` `getenv(...)`.
- **Race:** delegate A sets `WORKTREE_ROOT=A`; delegate B's enter/restore overwrites it; A then calls `code_search` and resolves staleness/freshness against **B's worktree** → wrong overlay annotations. Which delegate loses is pure interleaving → flaky roundtables.

## Fix
The authoritative source-authority context for an **in-process** delegate run is now **thread-local**:
- `agent_source_authority.c` gains `tl_sa_*` thread-locals + `agent_source_authority_tls_set/capture/restore`; the three overlay getters read TLS first, env only when not inside a delegate.
- `delegate_run_ctx_enter/restore` install/restore the TLS (nesting-safe).
- The process-global env writes are **kept untouched** as the fallback for cross-process child clients (`cmd_index`, the `aimee-client` shell-out) — **zero change** to cross-process delegation-depth propagation.

## What was ruled out
- **Credential path is already safe**: pool is mutex-locked (`delegate_credentials.c` `g_mu`); `api_key` lives on a **per-delegate** `agent_load_config(&acfg)` copy, not shared. (The one live `"no API key"` failure observed was a placeholder agent with no key configured — a misconfig, not a race.)

## Test
`test_source_authority_tls_thread_isolation`: 8 threads in two groups each install distinct TLS source paths and assert the overlay finds their **own** symbol and **not** the neighbor's. Pre-fix this fails via env clobbering.

Verified: `unit-test-agent` + `unit-test-server-compute` green; `aimee-server` links clean.

## Follow-on (separate, already-mitigated)
The depth/parent env mirror for cross-process children still races, but the depth check already ignores stale completed parents, so impact is bounded. Tracked for a later pass.
