### PR TITLE
fix(delegate): export delegate context to child env post-fork (close cross-process race)

### DIFF
--- a/src/headers/agent_source_authority.h
+++ b/src/headers/agent_source_authority.h
@@ -25,4 +25,9 @@ void agent_source_authority_tls_set(int authority, const char *worktree_root, co
 void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap);
 void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap);
 
+/* Export this thread's source-authority TLS to the process env. Call ONLY in a
+ * post-fork/pre-exec child (single-threaded → race-free) so a re-exec'd child
+ * inherits the correct context instead of a concurrently-clobbered global. */
+void agent_source_authority_export_env(void);
+
 #endif /* DEC_AGENT_SOURCE_AUTHORITY_H */

--- a/src/posix/agent_source_authority.c
+++ b/src/posix/agent_source_authority.c
@@ -60,6 +60,20 @@ void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
    snap->paths = NULL;
 }
 
+/* Mirror this thread's source-authority context into the process env so a
+ * fork()ed child that re-execs (cmd_index, the aimee-client shell-out) inherits
+ * it. Call ONLY in the post-fork/pre-exec child, where the single-threaded child
+ * is immune to the cross-thread env clobber that affects the parent. No-op when
+ * not inside a delegate run (the inherited env is left untouched). */
+void agent_source_authority_export_env(void)
+{
+   if (!tl_sa_active)
+      return;
+   platform_setenv("AIMEE_DELEGATE_SOURCE_AUTHORITY", tl_sa_authority ? "1" : "");
+   platform_setenv("AIMEE_DELEGATE_WORKTREE_ROOT", tl_sa_root);
+   platform_setenv("AIMEE_DELEGATE_SOURCE_PATHS", tl_sa_paths ? tl_sa_paths : "");
+}
+
 static int source_authority_enabled(void)
 {
    if (tl_sa_active)

--- a/src/server/delegate_backend_local.c
+++ b/src/server/delegate_backend_local.c
@@ -10,6 +10,10 @@
 
 #include "aimee.h" /* MAX_PATH_LEN */
 
+/* Defined in server_compute.c; called post-fork to seed the child's delegate
+ * context env from the forking thread's TLS (race-free). */
+void delegate_child_export_context_env(void);
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -223,6 +227,10 @@ static int local_exec(delegate_backend_t *self, void *state, const char *command
       close(err_pipe[1]);
       if (st->cwd[0] && chdir(st->cwd) != 0)
          _exit(126);
+      /* Seed the child's delegate context env from the forking thread's TLS so a
+       * sub-`aimee` invocation inside this command sees the correct depth/parent/
+       * source context, not a concurrently-clobbered global. */
+      delegate_child_export_context_env();
       execlp("bash", "bash", "-c", wrapped, (char *)NULL);
       _exit(127);
    }

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -16,6 +16,10 @@
 #include <time.h>
 #include <unistd.h>
 
+/* Defined in server_compute.c; called post-fork to seed the child's delegate
+ * context env from the forking thread's TLS (race-free). */
+void delegate_child_export_context_env(void);
+
 #define PROVIDER_CLI_MAX_ARGS 48
 #define PROVIDER_CLI_POLL_MS  250
 
@@ -396,6 +400,10 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
       unsetenv("CLAUDECODE");
       unsetenv("CLAUDE_CODE_SSE_PORT");
       unsetenv("CLAUDE_CODE_ENTRYPOINT");
+      /* Give a cross-process delegate sub-client this delegate's depth/parent/
+       * source context from the forking thread's TLS, immune to the parent-side
+       * concurrent env clobber. */
+      delegate_child_export_context_env();
       execvp(argv[0], argv);
       _exit(127);
    }

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -526,6 +526,27 @@ static void delegate_run_ctx_restore(delegate_run_ctx_t *c)
    mailbox_release(c->mb);
 }
 
+/* Export this delegate's context (depth/parent/source-authority) from the
+ * forking thread's TLS into the child's environment. Call ONLY in a freshly
+ * fork()ed child, before exec: the parent-side process-global AIMEE_DELEGATE_*
+ * env races across concurrent delegate threads, so a cross-process sub-client
+ * (a CLI agent that shells out to `aimee delegate`) could inherit a neighbor
+ * delegate's depth/parent. fork() copies the forking thread's TLS into the
+ * (now single-threaded) child, so re-deriving the env here is immune to that
+ * clobber. No-op for primary agents (depth 0, no parent), which keep their
+ * inherited environment. Matches the adjacent post-fork unsetenv() pattern. */
+void delegate_child_export_context_env(void)
+{
+   if (tl_delegation_depth > 0 || tl_parent_delegation_id[0])
+   {
+      char depth_str[32];
+      snprintf(depth_str, sizeof(depth_str), "%d", tl_delegation_depth);
+      platform_setenv("AIMEE_DELEGATE_DEPTH", depth_str);
+      platform_setenv("AIMEE_PARENT_DELEGATION_ID", tl_parent_delegation_id);
+   }
+   agent_source_authority_export_env();
+}
+
 /* Build the delegate result envelope from a finished run. Mirrors the two
  * branches the worker emitted inline: on success the response + turn/token
  * metrics; on failure the (possibly stop-reason) status + augmented message,

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -566,6 +566,7 @@ $(TESTPREFIX)/unit-test-script-runner: $(OBJDIR)/tests/test_script_runner.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-provider-cli-adapter: $(OBJDIR)/tests/test_provider_cli_adapter.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                       $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o \
                       $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o \
                       $(OBJDIR)/server/cli_acp.o $(OBJDIR)/posix/workspace_provider.o \
@@ -573,6 +574,7 @@ $(TESTPREFIX)/unit-test-provider-cli-adapter: $(OBJDIR)/tests/test_provider_cli_
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-acp: $(OBJDIR)/tests/test_cli_acp.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                       $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o \
                       $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o \
                       $(OBJDIR)/server/cli_acp.o $(OBJDIR)/posix/workspace_provider.o \
@@ -811,6 +813,7 @@ $(TESTPREFIX)/unit-test-acp-server: $(OBJDIR)/tests/test_acp_server.o \
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o $(OBJDIR)/server/server.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
 	                                $(OBJDIR)/server/server_config.o $(OBJDIR)/config_fields.o \
 	                                $(OBJDIR)/server/skill_review.o $(OBJDIR)/tests/support/skill_jobs_stub.o \
 	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o \
@@ -2265,6 +2268,7 @@ $(TESTPREFIX)/unit-test-delegate-backend: $(OBJDIR)/tests/test_delegate_backend.
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-delegate-backend-local: $(OBJDIR)/tests/test_delegate_backend_local.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                      $(OBJDIR)/server/delegate_backend.o \
                      $(OBJDIR)/server/delegate_backend_local.o \
                      $(PLATFORM_BASIC_OBJS)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -43,6 +43,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/llama_native_profile.o $(OBJDIR)/server/mistral_profile.o \
                              $(OBJDIR)/server/minimax_profile.o \
                              $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
+                             $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                              $(PLATFORM_AGENT_OBJS)
 
 TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \

--- a/src/tests/support/agent_source_authority_stub.c
+++ b/src/tests/support/agent_source_authority_stub.c
@@ -31,3 +31,7 @@ void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
       snap->paths = NULL;
    }
 }
+
+void agent_source_authority_export_env(void)
+{
+}

--- a/src/tests/support/delegate_child_env_export_stub.c
+++ b/src/tests/support/delegate_child_env_export_stub.c
@@ -1,0 +1,7 @@
+/* Stub of delegate_child_export_context_env for tests that link the fork-site
+ * objects (provider_cli_adapter.o, delegate_backend_local.o) but not
+ * server_compute.o (where the real implementation lives). The exporter only runs
+ * in a post-fork child, which these unit tests do not exercise. */
+void delegate_child_export_context_env(void)
+{
+}

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -1751,6 +1751,7 @@ static int delegate_current_job(db1_agent_job_t *out_job)
 #include "test_server_compute_delegate_write.inc"
 #include "test_server_compute_liveness.inc"
 #include "test_server_compute_state_invariants.inc"
+#include "test_server_compute_child_env.inc"
 
 /* Pure prompt helpers extracted from delegate_worker (server/delegate_prompt.c). */
 char *delegate_rewrite_prompt_cwd(const char *prompt, const char *cwd, const char *worktree_path,
@@ -1935,6 +1936,7 @@ int main(void)
    test_spawn_record_marks_running();
    test_spawn_limit_descendants_blocks_completed_chain();
    test_depth_context_save_restore();
+   test_child_export_context_env();
    test_delegation_augment_error();
    test_cross_process_depth_propagation();
    test_delegate_provider_route_override();

--- a/src/tests/test_server_compute_child_env.inc
+++ b/src/tests/test_server_compute_child_env.inc
@@ -1,0 +1,34 @@
+/* test_server_compute_child_env.inc: delegate_child_export_context_env coverage.
+ * Split out of test_server_compute.c to keep it under the 2000-line hard limit.
+ * Included into test_server_compute.c so it shares the server_compute.c
+ * translation unit (reaches tl_delegation_depth / tl_parent_delegation_id). */
+
+/* delegate_child_export_context_env mirrors the forking thread's TLS depth/parent
+ * into the env for a post-fork child. It must export the THREAD's values (not a
+ * concurrently-clobbered global) when inside a delegate, and leave the env alone
+ * for a primary agent (depth 0, no parent). */
+static void test_child_export_context_env(void)
+{
+   /* Pre-seed the env with a stale value as if a concurrent delegate had written
+    * it; inside a delegate the export must override with this thread's TLS. */
+   platform_setenv("AIMEE_DELEGATE_DEPTH", "9");
+   platform_setenv("AIMEE_PARENT_DELEGATION_ID", "stale-parent");
+
+   tl_delegation_depth = 3;
+   snprintf(tl_parent_delegation_id, sizeof(tl_parent_delegation_id), "deleg-self");
+   delegate_child_export_context_env();
+   assert(strcmp(getenv("AIMEE_DELEGATE_DEPTH"), "3") == 0);
+   assert(strcmp(getenv("AIMEE_PARENT_DELEGATION_ID"), "deleg-self") == 0);
+
+   /* Primary agent: depth 0, no parent -> no override (inherited env preserved). */
+   platform_setenv("AIMEE_DELEGATE_DEPTH", "7");
+   platform_setenv("AIMEE_PARENT_DELEGATION_ID", "inherited");
+   tl_delegation_depth = 0;
+   tl_parent_delegation_id[0] = '\0';
+   delegate_child_export_context_env();
+   assert(strcmp(getenv("AIMEE_DELEGATE_DEPTH"), "7") == 0);
+   assert(strcmp(getenv("AIMEE_PARENT_DELEGATION_ID"), "inherited") == 0);
+
+   platform_setenv("AIMEE_DELEGATE_DEPTH", "");
+   platform_setenv("AIMEE_PARENT_DELEGATION_ID", "");
+}


### PR DESCRIPTION
## Problem (follow-on to #347)
`delegate_run_ctx_enter` mirrors a delegate's **depth / parent id / source-authority** context into **process-global** env vars (`AIMEE_DELEGATE_*`) so a cross-process child client inherits it — a CLI agent (claude/codex) that shells out to `aimee delegate`, or the delegate's `bash` backend. Under concurrent on-demand delegates these global writes **race**: between delegate A's `ctx_enter` and A forking its child, delegate B clobbers the env, so A's child inherits **B's** depth/parent → wrong delegation-depth accounting, varying with thread interleaving.

(#347 fixed the *in-process* read of this context via TLS; this closes the remaining *cross-process child* leg.)

## Fix
Re-derive the context **in the child, post-fork/pre-exec**, from the forking thread's TLS — `fork()` copies it into the now single-threaded child, immune to the cross-thread clobber.

- New `delegate_child_export_context_env()` (`server_compute.c`): sets `DEPTH`/`PARENT` from `tl_delegation_depth`/`tl_parent_delegation_id`, then calls `agent_source_authority_export_env()` (the #347 source-authority TLS, exported the same way).
- Called at both delegate-child fork sites — `provider_cli_adapter.c` and `delegate_backend_local.c` — right beside the existing post-fork `unsetenv` calls.
- **No-op for primary agents** (depth 0, no parent): they keep their inherited env, so zero behavior change off the delegate path.

The parent-side global writes are left intact as a belt-and-suspenders fallback for any other inherited-env child; the child override now wins where it matters, so the race no longer has an authoritative reader.

## Test
`test_child_export_context_env` (`test_server_compute_child_env.inc`): asserts the export overrides a stale pre-seeded env with the thread's TLS inside a delegate, and leaves the env untouched for a primary. Split into an `.inc` to keep `test_server_compute.c` under the 2000-line limit.

New no-op stubs for the four test targets that link the fork objects without `server_compute.o` (`unit-test-provider-cli-adapter`, `unit-test-delegate-backend-local`, `unit-test-cli-acp`, `unit-test-server-dispatch`); CMake links the real sources so needs no change.

Verified: `aimee-server` + `unit-test-server-compute` / `-provider-cli-adapter` / `-delegate-backend-local` / `-cli-acp` / `-server-dispatch` all green.

## Note on async-signal-safety
The export runs post-`fork()` before `exec` and calls `setenv` (which mallocs) — the same risk profile as the `unsetenv` calls already present at both sites. Consistent with existing practice.
