### PR TITLE
Promote testing → main: delegate env-race fixes + auditable-correctness P2

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -909,6 +909,38 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /audit/provenance:
+    post:
+      summary: Per-turn source provenance (proxied to aimee-kb)
+      description: >-
+        Which sources grounded a turn's answer, at which version: given the
+        caller-visible turn_id, resolve each source id recorded on the turn's
+        retrieval_event to {id, kind, source, version, present}, where version is
+        the source row's updated_at (read live) and present is false when the
+        source no longer exists (deleted/superseded since the turn). provenance_status
+        is one of the exhaustive states ok / not_instrumented / not_evaluated /
+        evidence_unavailable (P2 produces ok and evidence_unavailable). Requires
+        aimee-kb. Gated by kb_evidence_emit_enabled at emit time.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [turn_id]
+              properties:
+                turn_id: { type: string }
+      responses:
+        "200":
+          description: Provenance bundle ({status, provenance_status, turn_id, retrieval_event_id?, sources?})
+          content:
+            application/json:
+              schema: { type: object }
+        "502":
+          description: Knowledge service (aimee-kb) unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /notes:
     get:
       summary: List notes (proxied to aimee-kb)

--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -10,10 +10,15 @@
   `kb_evidence_emit_enabled` flag, and the `aimee audit trace` CLI. (The P1
   dependency on PR #185 cost-accounting is satisfied — #185 is merged.) **Verify
   P1 functional completeness end-to-end before moving this proposal to done.**
-  **Remaining:** P1.5 (typed doc/code refs + two-writer merge), P2 (versioned
-  provenance + `aimee audit provenance` + drift-ranked requeue — shippable), P3
-  (fidelity_check judge + `fidelity_report`), P4 (labelled gold corpus — needs
-  human curation, not autonomous).
+  **P2 in progress:** Layer-1 code-search provenance landed in #344
+  (`code_search_hit_t`/`/v1/code/search` carry `content_hash`); the
+  `/v1/audit/provenance` read surface + `aimee audit provenance <turn_id>` landed
+  next (resolves each surfaced source id to `{id, kind, source, version, present}`,
+  version = the row's live `updated_at`). **Remaining:** P1.5 (typed doc/code refs
+  + two-writer merge), P2's emit-time point-in-time version capture (provenance
+  currently reads versions live) + drift-ranked requeue in `memory_maintenance.c`
+  (D7), P3 (fidelity_check judge + `fidelity_report`), P4 (labelled gold corpus —
+  needs human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -307,6 +307,7 @@ static const struct
     {"mcp", "audit", "mcp.audit", NULL, "items", 0},
     {"mcp", "recheck", "mcp.recheck", NULL, "items", 300000},
     {"audit", "trace", "evidence.trace_retrieval_event", NULL, NULL, 0},
+    {"audit", "provenance", "evidence.provenance_retrieval_event", NULL, NULL, 0},
     {"get_help", NULL, "get_help", "mcp.call", NULL, 0},
     {"get-help", NULL, "get_help", "mcp.call", NULL, 0},
     {"verify", NULL, "git.verify", "mcp.call", NULL, 900000},
@@ -979,6 +980,18 @@ static cJSON *marshal_audit_trace(int argc, char **argv)
    rpc_parse(argc, argv, NULL, &opts);
 
    cJSON *req = marshal_no_args("evidence.trace_retrieval_event");
+   if (opts.pos_count > 0)
+      cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
+   return req;
+}
+
+/* Auditable-correctness P2: `aimee audit provenance <turn_id>` → the turn_id param. */
+static cJSON *marshal_audit_provenance(int argc, char **argv)
+{
+   rpc_opts_t opts;
+   rpc_parse(argc, argv, NULL, &opts);
+
+   cJSON *req = marshal_no_args("evidence.provenance_retrieval_event");
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
    return req;
@@ -3296,6 +3309,8 @@ static cJSON *marshal_request(const char *method, int argc, char **argv)
       return marshal_config_get(argc, argv);
    if (strcmp(method, "evidence.trace_retrieval_event") == 0)
       return marshal_audit_trace(argc, argv);
+   if (strcmp(method, "evidence.provenance_retrieval_event") == 0)
+      return marshal_audit_provenance(argc, argv);
    if (strcmp(method, "config.set") == 0)
       return marshal_config_set(argc, argv);
    if (strcmp(method, "aux.test") == 0)

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -79,6 +79,7 @@ static const struct
     {"dogfood.tag", "POST", "/v1/dogfood/tag"},
     {"episode.list", "GET", "/v1/episode/list"},
     {"eval.results", "GET", "/v1/eval/results"},
+    {"evidence.provenance_retrieval_event", "POST", "/v1/audit/provenance"},
     {"evidence.trace_retrieval_event", "POST", "/v1/audit/trace"},
     {"graph.explain", "POST", "/v1/graph/explain"},
     {"hooks.post", "POST", "/v1/hooks/post"},

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -741,7 +741,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
    if (shim && filter_project)
       sql = "SELECT p.name, f.path,"
             " snippet(code_fts, 0, '>>>', '<<<', '...', 20),"
-            " rank"
+            " rank,"
+            " f.hash"
             " FROM code_fts"
             " JOIN files f ON f.id = code_fts.rowid"
             " JOIN projects p ON p.id = f.project_id"
@@ -753,7 +754,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
    else if (shim)
       sql = "SELECT p.name, f.path,"
             " snippet(code_fts, 0, '>>>', '<<<', '...', 20),"
-            " rank"
+            " rank,"
+            " f.hash"
             " FROM code_fts"
             " JOIN files f ON f.id = code_fts.rowid"
             " JOIN projects p ON p.id = f.project_id"
@@ -766,7 +768,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       sql = "SELECT p.name, f.path,"
             " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
             " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
-            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1))"
+            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)),"
+            " f.hash"
             " FROM file_contents fc"
             " JOIN files f ON f.id = fc.file_id"
             " JOIN projects p ON p.id = f.project_id"
@@ -779,7 +782,8 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       sql = "SELECT p.name, f.path,"
             " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
             " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
-            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1))"
+            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)),"
+            " f.hash"
             " FROM file_contents fc"
             " JOIN files f ON f.id = fc.file_id"
             " JOIN projects p ON p.id = f.project_id"
@@ -811,10 +815,12 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       const char *fpath = aimee_pg_column_text(st, 1);
       const char *snip = aimee_pg_column_text(st, 2);
       double rnk = aimee_pg_column_double(st, 3);
+      const char *fhash = aimee_pg_column_text(st, 4); /* files.hash — P2 provenance */
       snprintf(out[count].project, sizeof(out[count].project), "%s", pname ? pname : "");
       snprintf(out[count].file_path, sizeof(out[count].file_path), "%s", fpath ? fpath : "");
       snprintf(out[count].snippet, sizeof(out[count].snippet), "%s", snip ? snip : "");
       out[count].rank = rnk;
+      snprintf(out[count].content_hash, sizeof(out[count].content_hash), "%s", fhash ? fhash : "");
       count++;
    }
    aimee_pg_finalize(st);

--- a/src/db2/memory_payload.c
+++ b/src/db2/memory_payload.c
@@ -129,6 +129,45 @@ char *db2_memory_build_memory_payload(int64_t memory_id)
    return payload_json;
 }
 
+int db2_memory_provenance_by_id(int64_t memory_id, char *kind_out, int kind_len, char *source_out,
+                                int source_len, char *version_out, int version_len)
+{
+   if (kind_out && kind_len > 0)
+      kind_out[0] = '\0';
+   if (source_out && source_len > 0)
+      source_out[0] = '\0';
+   if (version_out && version_len > 0)
+      version_out[0] = '\0';
+   if (memory_id <= 0)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "SELECT kind, source_session, updated_at FROM memories WHERE id = ?1";
+   char err[MP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", memory_id);
+   int step = aimee_pg_step(st, err, sizeof(err));
+   if (step != AIMEE_PG_ROW)
+   {
+      aimee_pg_finalize(st);
+      return step == AIMEE_PG_DONE ? 0 : -1; /* 0 = no such row (deleted/superseded) */
+   }
+   const char *k = aimee_pg_column_text(st, 0);
+   const char *s = aimee_pg_column_text(st, 1);
+   const char *v = aimee_pg_column_text(st, 2);
+   if (kind_out && kind_len > 0)
+      snprintf(kind_out, (size_t)kind_len, "%s", k ? k : "");
+   if (source_out && source_len > 0)
+      snprintf(source_out, (size_t)source_len, "%s", s ? s : "");
+   if (version_out && version_len > 0)
+      snprintf(version_out, (size_t)version_len, "%s", v ? v : "");
+   aimee_pg_finalize(st);
+   return 1;
+}
+
 char *db2_memory_build_unit_payload(int64_t unit_id, int64_t *memory_id_out)
 {
    if (unit_id <= 0)

--- a/src/db2/memory_payload.h
+++ b/src/db2/memory_payload.h
@@ -39,6 +39,15 @@ extern "C"
    /* Total row count in the memories table. Returns 0 on error. */
    int64_t db2_memory_count(void);
 
+   /* Auditable-correctness P2 (/v1/audit/provenance): resolve a surfaced memory
+    * id to its provenance fields — kind, source (source_session), and version
+    * (the row's updated_at). Any out buffer may be NULL. Returns 1 on hit, 0 when
+    * no such row exists (deleted/superseded since the turn — itself a provenance
+    * signal), -1 on error. */
+   int db2_memory_provenance_by_id(int64_t memory_id, char *kind_out, int kind_len,
+                                   char *source_out, int source_len, char *version_out,
+                                   int version_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/agent_source_authority.h
+++ b/src/headers/agent_source_authority.h
@@ -8,4 +8,21 @@ void agent_source_add_index_freshness(cJSON *obj, const char *project, const cha
 int agent_source_append_overlay_code_hits(cJSON *arr, const char *query, const char *project,
                                           int max_results);
 
+/* Thread-local source-authority context for an in-process delegate run. Set by
+ * delegate_run_ctx_enter; the code_search overlay reads it (TLS) instead of the
+ * process-global AIMEE_DELEGATE_* env vars, which raced across concurrent
+ * delegates. capture/restore preserve nesting on one thread. The env vars stay
+ * the fallback for cross-process child clients. */
+typedef struct
+{
+   int active;
+   int authority;
+   char root[MAX_PATH_LEN];
+   char *paths; /* heap-owned; restore() frees the live value and adopts this */
+} agent_source_authority_snapshot_t;
+
+void agent_source_authority_tls_set(int authority, const char *worktree_root, const char *paths);
+void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap);
+void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap);
+
 #endif /* DEC_AGENT_SOURCE_AUTHORITY_H */

--- a/src/headers/agent_source_authority.h
+++ b/src/headers/agent_source_authority.h
@@ -25,4 +25,9 @@ void agent_source_authority_tls_set(int authority, const char *worktree_root, co
 void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap);
 void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap);
 
+/* Export this thread's source-authority TLS to the process env. Call ONLY in a
+ * post-fork/pre-exec child (single-threaded → race-free) so a re-exec'd child
+ * inherits the correct context instead of a concurrently-clobbered global. */
+void agent_source_authority_export_env(void);
+
 #endif /* DEC_AGENT_SOURCE_AUTHORITY_H */

--- a/src/headers/index.h
+++ b/src/headers/index.h
@@ -112,6 +112,11 @@ typedef struct
    char file_path[MAX_PATH_LEN];
    char snippet[512];
    double rank;
+   /* files.hash of the matched file — auditable-correctness P2 Layer-1
+    * (file-level provenance): lets a citation name the exact content version and
+    * lets drift detection flag a hit whose live source no longer matches its
+    * stored hash. Empty when the row has no recorded hash. */
+   char content_hash[80];
 } code_search_hit_t;
 
 /* Lexical search across indexed code. Returns count of results. Ranking and

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -786,6 +786,11 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
  * (malloc'd, caller frees; NULL on bad arg or kb error). */
 char *kb_client_evidence_trace_retrieval_event(const char *turn_id);
 
+/* Auditable-correctness P2: the /v1/audit/provenance read — forward to the KB
+ * evidence.provenance_retrieval_event action and return its JSON response
+ * verbatim (malloc'd, caller frees; NULL on bad arg or kb error). */
+char *kb_client_evidence_provenance_retrieval_event(const char *turn_id);
+
 /* Fetch the entity profile card via aimee-kb.  Returns 0 on success
  * (|out| filled) or -1 if kb is unreachable or the entity is missing.
  * Mirrors memory_get_entity_profile(). */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -283,6 +283,7 @@ int handle_graph_sync_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_graph_explain(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_synthesize(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_contradictions(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -368,6 +368,8 @@ int handle_get_code_search(const char *query_string, char *out_buf, int out_cap)
       cJSON_AddStringToObject(hit, "file_path", hits[i].file_path);
       cJSON_AddStringToObject(hit, "snippet", hits[i].snippet);
       cJSON_AddNumberToObject(hit, "rank", hits[i].rank);
+      /* P2 Layer-1: file content hash for citation + drift detection. */
+      cJSON_AddStringToObject(hit, "content_hash", hits[i].content_hash);
       cJSON_AddItemToArray(arr, hit);
    }
    cJSON_AddNullToObject(resp, "next_cursor");

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1054,6 +1054,7 @@ static const struct
     {"memory.context_block", kb_handle_memory_context_block},
     {"evidence.emit_retrieval_event", kb_handle_evidence_emit_retrieval_event},
     {"evidence.trace_retrieval_event", kb_handle_evidence_trace_retrieval_event},
+    {"evidence.provenance_retrieval_event", kb_handle_evidence_provenance},
     {"memory.entity_profile", kb_handle_memory_entity_profile},
     {"memory.entity_edges", kb_handle_memory_entity_edges},
     {"memory.search_graph", kb_handle_memory_search_graph},

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -11,6 +11,7 @@
 #include "db2/kb_service_backend.h"
 #include "db2/bandit.h"
 #include "db2/demotion.h" /* db2_demotion_retrieval_event_write_turn (auditable-correctness P1) */
+#include "db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "kb_bandit.h"
 #include "kb_bandit_registry.h"
 #include "kb_service_memory.h"
@@ -835,6 +836,70 @@ int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req)
                               rc < 0 ? "lookup error" : "no durable retrieval_event for this turn");
    }
    return kb_reply_or_error(fd, resp, "failed to trace retrieval_event");
+}
+
+/* Auditable-correctness P2: the /v1/audit/provenance read. Look up the turn's
+ * retrieval_event (same four-state status as the trace read) and resolve each
+ * surfaced source id to {id, kind, source, version} — version is the memory row's
+ * updated_at, read live, so a caller can compare it to what trace recorded and a
+ * source no longer present (deleted/superseded since the turn) is flagged
+ * present:false rather than silently dropped. This is a pure read (D8). */
+int kb_handle_evidence_provenance(int fd, cJSON *req)
+{
+   cJSON *turn_j = cJSON_GetObjectItemCaseSensitive(req, "turn_id");
+   if (!cJSON_IsString(turn_j) || !turn_j->valuestring[0])
+      return kb_send_error(fd, "audit.provenance requires turn_id");
+   /* turn_ids are short UUIDs; reject absurd input up front (defense in depth —
+    * downstream binds it as a SQL parameter, not into a fixed buffer). */
+   if (strlen(turn_j->valuestring) > 128)
+      return kb_send_error(fd, "audit.provenance turn_id too long");
+
+   char ev_id[64] = "";
+   char payload[8192] = "";
+   int rc = db2_demotion_retrieval_event_by_turn(turn_j->valuestring, ev_id, sizeof(ev_id), payload,
+                                                 sizeof(payload));
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "turn_id", turn_j->valuestring);
+   if (rc == 1)
+   {
+      cJSON_AddStringToObject(resp, "provenance_status", "ok");
+      cJSON_AddStringToObject(resp, "retrieval_event_id", ev_id);
+      cJSON *sources = cJSON_AddArrayToObject(resp, "sources");
+      cJSON *ev = payload[0] ? cJSON_Parse(payload) : NULL;
+      cJSON *ids = ev ? cJSON_GetObjectItemCaseSensitive(ev, "surfaced_ids") : NULL;
+      int n = cJSON_IsArray(ids) ? cJSON_GetArraySize(ids) : 0;
+      for (int i = 0; sources && i < n; i++)
+      {
+         cJSON *e = cJSON_GetArrayItem(ids, i);
+         if (!cJSON_IsNumber(e) || e->valuedouble <= 0)
+            continue;
+         /* Same cast the emit writer (kb_handle_evidence_emit_retrieval_event)
+          * used to store the id, so the round-trip is lossless for the values
+          * actually persisted. */
+         int64_t id = (int64_t)e->valuedouble;
+         char kind[64] = "", source[128] = "", version[64] = "";
+         int found = db2_memory_provenance_by_id(id, kind, sizeof kind, source, sizeof source,
+                                                 version, sizeof version);
+         cJSON *src = cJSON_CreateObject();
+         cJSON_AddNumberToObject(src, "id", (double)id);
+         cJSON_AddStringToObject(src, "kind", kind);
+         cJSON_AddStringToObject(src, "source", source);
+         cJSON_AddStringToObject(src, "version", version);
+         cJSON_AddBoolToObject(src, "present", found == 1);
+         cJSON_AddItemToArray(sources, src);
+      }
+      if (ev)
+         cJSON_Delete(ev);
+   }
+   else
+   {
+      cJSON_AddStringToObject(resp, "provenance_status", "evidence_unavailable");
+      cJSON_AddStringToObject(resp, "detail",
+                              rc < 0 ? "lookup error" : "no durable retrieval_event for this turn");
+   }
+   return kb_reply_or_error(fd, resp, "failed to read provenance");
 }
 
 int kb_handle_memory_entity_profile(int fd, cJSON *req)

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -888,6 +888,11 @@ int kb_handle_evidence_provenance(int fd, cJSON *req)
          cJSON_AddStringToObject(src, "source", source);
          cJSON_AddStringToObject(src, "version", version);
          cJSON_AddBoolToObject(src, "present", found == 1);
+         /* Distinguish a source that is genuinely gone (found==0, deleted/
+          * superseded since the turn) from one whose lookup errored (found<0):
+          * both leave present:false, but only the latter is an unreliable read. */
+         if (found < 0)
+            cJSON_AddBoolToObject(src, "error", 1);
          cJSON_AddItemToArray(sources, src);
       }
       if (ev)

--- a/src/kb_service_memory.h
+++ b/src/kb_service_memory.h
@@ -61,6 +61,8 @@ int kb_handle_memory_context_block(int fd, cJSON *req);
 int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req);
 /* Auditable-correctness P1: the /v1/audit/trace read (four-state status). */
 int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req);
+/* Auditable-correctness P2: the /v1/audit/provenance read (sources at version). */
+int kb_handle_evidence_provenance(int fd, cJSON *req);
 int kb_handle_memory_entity_profile(int fd, cJSON *req);
 int kb_handle_memory_entity_edges(int fd, cJSON *req);
 int kb_handle_memory_search_graph(int fd, cJSON *req);

--- a/src/posix/agent_source_authority.c
+++ b/src/posix/agent_source_authority.c
@@ -60,6 +60,20 @@ void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
    snap->paths = NULL;
 }
 
+/* Mirror this thread's source-authority context into the process env so a
+ * fork()ed child that re-execs (cmd_index, the aimee-client shell-out) inherits
+ * it. Call ONLY in the post-fork/pre-exec child, where the single-threaded child
+ * is immune to the cross-thread env clobber that affects the parent. No-op when
+ * not inside a delegate run (the inherited env is left untouched). */
+void agent_source_authority_export_env(void)
+{
+   if (!tl_sa_active)
+      return;
+   platform_setenv("AIMEE_DELEGATE_SOURCE_AUTHORITY", tl_sa_authority ? "1" : "");
+   platform_setenv("AIMEE_DELEGATE_WORKTREE_ROOT", tl_sa_root);
+   platform_setenv("AIMEE_DELEGATE_SOURCE_PATHS", tl_sa_paths ? tl_sa_paths : "");
+}
+
 static int source_authority_enabled(void)
 {
    if (tl_sa_active)

--- a/src/posix/agent_source_authority.c
+++ b/src/posix/agent_source_authority.c
@@ -6,19 +6,83 @@
 #include "util.h"
 #include "cJSON.h"
 #include <ctype.h>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
+/* Per-delegate source-authority context.
+ *
+ * This was previously read from process-global env vars (AIMEE_DELEGATE_*),
+ * which raced once delegates began running concurrently on detached threads
+ * (on-demand execution): a delegate's code_search overlay would resolve its
+ * staleness/freshness checks against ANOTHER concurrently-running delegate's
+ * worktree root, producing wrong annotations that varied with thread timing.
+ *
+ * The authoritative source for an in-process delegate run is now thread-local,
+ * installed by delegate_run_ctx_enter (see server_compute.c). The env vars
+ * remain the fallback for cross-process child clients (cmd_index, the
+ * aimee-client shell-out), which inherit them and have their own single-
+ * threaded environment. tl_sa_active distinguishes "this thread is running a
+ * delegate" (read TLS) from "not in a delegate" (read env / no-op). */
+static __thread int tl_sa_active = 0;
+static __thread int tl_sa_authority = 0;
+static __thread char tl_sa_root[MAX_PATH_LEN] = {0};
+static __thread char *tl_sa_paths = NULL; /* heap, newline-joined; may be NULL */
+
+void agent_source_authority_tls_set(int authority, const char *worktree_root, const char *paths)
+{
+   tl_sa_active = 1;
+   tl_sa_authority = authority ? 1 : 0;
+   snprintf(tl_sa_root, sizeof(tl_sa_root), "%s", worktree_root ? worktree_root : "");
+   free(tl_sa_paths);
+   tl_sa_paths = (paths && paths[0]) ? strdup(paths) : NULL;
+}
+
+void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap)
+{
+   if (!snap)
+      return;
+   snap->active = tl_sa_active;
+   snap->authority = tl_sa_authority;
+   snprintf(snap->root, sizeof(snap->root), "%s", tl_sa_root);
+   snap->paths = tl_sa_paths ? strdup(tl_sa_paths) : NULL;
+}
+
+void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
+{
+   if (!snap)
+      return;
+   tl_sa_active = snap->active;
+   tl_sa_authority = snap->authority;
+   snprintf(tl_sa_root, sizeof(tl_sa_root), "%s", snap->root);
+   free(tl_sa_paths);
+   tl_sa_paths = snap->paths; /* transfer ownership */
+   snap->paths = NULL;
+}
+
 static int source_authority_enabled(void)
 {
+   if (tl_sa_active)
+      return tl_sa_authority;
    const char *enabled = getenv("AIMEE_DELEGATE_SOURCE_AUTHORITY");
    return enabled && enabled[0] && strcmp(enabled, "0") != 0;
 }
 
 static const char *source_authority_root(void)
 {
+   if (tl_sa_active)
+      return tl_sa_root[0] ? tl_sa_root : NULL;
    const char *root = getenv("AIMEE_DELEGATE_WORKTREE_ROOT");
    return root && root[0] ? root : NULL;
+}
+
+/* Newline-joined source paths for the current delegate (TLS), or the env
+ * fallback for cross-process clients. May return NULL. */
+static const char *source_authority_paths(void)
+{
+   if (tl_sa_active)
+      return tl_sa_paths;
+   return getenv("AIMEE_DELEGATE_SOURCE_PATHS");
 }
 
 static void source_authority_resolve_path(const char *path, char *out, size_t out_len)
@@ -61,7 +125,7 @@ static int source_path_matches_hit(const char *source_path, const char *hit_path
 
 static int source_paths_contains(const char *hit_path)
 {
-   const char *paths = getenv("AIMEE_DELEGATE_SOURCE_PATHS");
+   const char *paths = source_authority_paths();
    if (!paths || !paths[0] || !hit_path || !hit_path[0])
       return 0;
 
@@ -188,7 +252,7 @@ int agent_source_append_overlay_code_hits(cJSON *arr, const char *query, const c
    (void)project;
    if (!arr || !source_authority_enabled() || !query || !query[0] || max_results <= 0)
       return 0;
-   const char *paths = getenv("AIMEE_DELEGATE_SOURCE_PATHS");
+   const char *paths = source_authority_paths();
    if (!paths || !paths[0])
       return 0;
 
@@ -258,7 +322,7 @@ char *tool_find_symbol(const char *identifier)
    int overlay_matches = 0;
    if (source_authority_enabled())
    {
-      const char *paths = getenv("AIMEE_DELEGATE_SOURCE_PATHS");
+      const char *paths = source_authority_paths();
       const char *p = paths && paths[0] ? paths : NULL;
       while (p && *p && overlay_matches < 8 && pos < (int)sizeof(buf) - 512)
       {

--- a/src/server/delegate_backend_local.c
+++ b/src/server/delegate_backend_local.c
@@ -10,6 +10,10 @@
 
 #include "aimee.h" /* MAX_PATH_LEN */
 
+/* Defined in server_compute.c; called post-fork to seed the child's delegate
+ * context env from the forking thread's TLS (race-free). */
+void delegate_child_export_context_env(void);
+
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -223,6 +227,10 @@ static int local_exec(delegate_backend_t *self, void *state, const char *command
       close(err_pipe[1]);
       if (st->cwd[0] && chdir(st->cwd) != 0)
          _exit(126);
+      /* Seed the child's delegate context env from the forking thread's TLS so a
+       * sub-`aimee` invocation inside this command sees the correct depth/parent/
+       * source context, not a concurrently-clobbered global. */
+      delegate_child_export_context_env();
       execlp("bash", "bash", "-c", wrapped, (char *)NULL);
       _exit(127);
    }

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1641,6 +1641,17 @@ char *kb_client_evidence_trace_retrieval_event(const char *turn_id)
    return kb_v1_action_request("evidence.trace_retrieval_event", req);
 }
 
+char *kb_client_evidence_provenance_retrieval_event(const char *turn_id)
+{
+   if (!turn_id || !turn_id[0])
+      return NULL;
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "turn_id", turn_id);
+   /* Pass the KB action's response through verbatim (status + provenance_status +
+    * retrieval_event_id + sources[]). kb_v1_action_request owns req. */
+   return kb_v1_action_request("evidence.provenance_retrieval_event", req);
+}
+
 char *kb_client_memory_lint_json(void)
 {
    cJSON *req = cJSON_CreateObject();

--- a/src/server/provider_cli_adapter.c
+++ b/src/server/provider_cli_adapter.c
@@ -16,6 +16,10 @@
 #include <time.h>
 #include <unistd.h>
 
+/* Defined in server_compute.c; called post-fork to seed the child's delegate
+ * context env from the forking thread's TLS (race-free). */
+void delegate_child_export_context_env(void);
+
 #define PROVIDER_CLI_MAX_ARGS 48
 #define PROVIDER_CLI_POLL_MS  250
 
@@ -396,6 +400,10 @@ int provider_cli_spawn_argv(const provider_cli_cfg_t *cfg, char *const argv[], i
       unsetenv("CLAUDECODE");
       unsetenv("CLAUDE_CODE_SSE_PORT");
       unsetenv("CLAUDE_CODE_ENTRYPOINT");
+      /* Give a cross-process delegate sub-client this delegate's depth/parent/
+       * source context from the forking thread's TLS, immune to the parent-side
+       * concurrent env clobber. */
+      delegate_child_export_context_env();
       execvp(argv[0], argv);
       _exit(127);
    }

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1045,6 +1045,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     /* KB */
     {"kb.search", handle_kb_search},
     {"evidence.trace_retrieval_event", handle_evidence_trace},
+    {"evidence.provenance_retrieval_event", handle_evidence_provenance},
     {"curator.implements", handle_curator_implements},
     {"curator.synthesize", handle_curator_synthesize},
     {"curator.contradictions", handle_curator_contradictions},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -136,6 +136,7 @@ const method_policy_t method_registry[] = {
     /* Knowledge base: search/status read; build/ingest/update rebuild the store. */
     {"kb.search", CAP_INDEX_READ, "knowledge search"},
     {"evidence.trace_retrieval_event", CAP_INDEX_READ, "audit retrieval-evidence trace"},
+    {"evidence.provenance_retrieval_event", CAP_INDEX_READ, "audit source provenance"},
     {"kb.status", CAP_DASHBOARD_READ, "knowledge base status"},
     {"optimize.export", CAP_DASHBOARD_READ, "bandit optimization export"},
     {"optimize.promote", CAP_INDEX_ADMIN, "promote a bandit arm to default"},

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -18,6 +18,7 @@
 #include "delegate_credential_retry.h"
 #include "delegate_launch.h"
 #include "delegate_source_authority.h"
+#include "agent_source_authority.h" /* TLS source-authority context (race-free in-process) */
 #include "server_coord_dispatcher.h"
 #include "delegate_credentials.h"
 #include "vault_service.h" /* WP-C.1 vault-first credential resolution */
@@ -470,6 +471,7 @@ typedef struct
    char saved_env_depth[32];
    char saved_env_parent[64];
    delegate_source_env_snapshot_t source_env;
+   agent_source_authority_snapshot_t sa_snap;
 } delegate_run_ctx_t;
 
 static void delegate_run_ctx_enter(delegate_run_ctx_t *c, const char *deleg_id, const char *sid,
@@ -498,12 +500,21 @@ static void delegate_run_ctx_enter(delegate_run_ctx_t *c, const char *deleg_id, 
       snprintf(c->saved_env_parent, sizeof(c->saved_env_parent), "%s", e);
    platform_setenv("AIMEE_PARENT_DELEGATION_ID", deleg_id);
 
+   /* Env (process-global) is kept for cross-process child clients that inherit
+    * it. The in-process source-authority consumer (code_search overlay) instead
+    * reads the thread-local context below, which does NOT race across the
+    * concurrent delegate threads the way the shared env does. clear_for_worktree
+    * disables authority + clears paths, so mirror that: authority=0, paths=NULL,
+    * worktree=source_env_root. */
    delegate_source_env_capture(&c->source_env);
    delegate_source_env_clear_for_worktree(source_env_root);
+   agent_source_authority_tls_capture(&c->sa_snap);
+   agent_source_authority_tls_set(0, source_env_root, NULL);
 }
 
-static void delegate_run_ctx_restore(const delegate_run_ctx_t *c)
+static void delegate_run_ctx_restore(delegate_run_ctx_t *c)
 {
+   agent_source_authority_tls_restore(&c->sa_snap);
    platform_setenv("AIMEE_DELEGATE_DEPTH", c->saved_env_depth[0] ? c->saved_env_depth : "");
    platform_setenv("AIMEE_PARENT_DELEGATION_ID", c->saved_env_parent[0] ? c->saved_env_parent : "");
    delegate_source_env_restore(&c->source_env);

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -526,6 +526,27 @@ static void delegate_run_ctx_restore(delegate_run_ctx_t *c)
    mailbox_release(c->mb);
 }
 
+/* Export this delegate's context (depth/parent/source-authority) from the
+ * forking thread's TLS into the child's environment. Call ONLY in a freshly
+ * fork()ed child, before exec: the parent-side process-global AIMEE_DELEGATE_*
+ * env races across concurrent delegate threads, so a cross-process sub-client
+ * (a CLI agent that shells out to `aimee delegate`) could inherit a neighbor
+ * delegate's depth/parent. fork() copies the forking thread's TLS into the
+ * (now single-threaded) child, so re-deriving the env here is immune to that
+ * clobber. No-op for primary agents (depth 0, no parent), which keep their
+ * inherited environment. Matches the adjacent post-fork unsetenv() pattern. */
+void delegate_child_export_context_env(void)
+{
+   if (tl_delegation_depth > 0 || tl_parent_delegation_id[0])
+   {
+      char depth_str[32];
+      snprintf(depth_str, sizeof(depth_str), "%d", tl_delegation_depth);
+      platform_setenv("AIMEE_DELEGATE_DEPTH", depth_str);
+      platform_setenv("AIMEE_PARENT_DELEGATION_ID", tl_parent_delegation_id);
+   }
+   agent_source_authority_export_env();
+}
+
 /* Build the delegate result envelope from a finished run. Mirrors the two
  * branches the worker emitted inline: on success the response + turn/token
  * metrics; on failure the (possibly stop-reason) status + augmented message,

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1108,6 +1108,8 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/code/audit", NULL, RM_EXACT, "code.audit", 0, rh_dispatch_op},
     {"POST", "/v1/audit/trace", NULL, RM_EXACT, "evidence.trace_retrieval_event", 0,
      rh_dispatch_op},
+    {"POST", "/v1/audit/provenance", NULL, RM_EXACT, "evidence.provenance_retrieval_event", 0,
+     rh_dispatch_op},
     {"POST", "/v1/trajectory/batch", NULL, RM_EXACT, "trajectory.batch", 0, rh_dispatch_op},
 
     /* work.* / wm.* / skill.* / session.* / toolset.* / mcp.* / trigger.* and

--- a/src/server/server_state_audit.inc
+++ b/src/server/server_state_audit.inc
@@ -21,3 +21,20 @@ int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return server_send_error(conn, "knowledge service audit trace failed", NULL);
    return send_and_free(conn, resp);
 }
+
+/* /v1/audit/provenance handler. Like handle_evidence_trace, its op
+ * (evidence.provenance_retrieval_event) is a KB-only action, so the server
+ * forwards it to aimee-kb via kb_client and passes the JSON response through. */
+int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *turn_id = jo_str(req, "turn_id", "");
+   if (!turn_id[0])
+      return server_send_error(conn, "audit provenance requires turn_id", NULL);
+   char *json = kb_client_evidence_provenance_retrieval_event(turn_id);
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   if (!resp)
+      return server_send_error(conn, "knowledge service audit provenance failed", NULL);
+   return send_and_free(conn, resp);
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -43,6 +43,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/llama_native_profile.o $(OBJDIR)/server/mistral_profile.o \
                              $(OBJDIR)/server/minimax_profile.o \
                              $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
+                             $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                              $(PLATFORM_AGENT_OBJS)
 
 TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \
@@ -566,6 +567,7 @@ $(TESTPREFIX)/unit-test-script-runner: $(OBJDIR)/tests/test_script_runner.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-provider-cli-adapter: $(OBJDIR)/tests/test_provider_cli_adapter.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                       $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o \
                       $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o \
                       $(OBJDIR)/server/cli_acp.o $(OBJDIR)/posix/workspace_provider.o \
@@ -573,6 +575,7 @@ $(TESTPREFIX)/unit-test-provider-cli-adapter: $(OBJDIR)/tests/test_provider_cli_
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-cli-acp: $(OBJDIR)/tests/test_cli_acp.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                       $(OBJDIR)/server/provider_cli_adapter.o $(OBJDIR)/server/cli_codex.o \
                       $(OBJDIR)/server/cli_claude.o $(OBJDIR)/server/cli_gemini.o $(OBJDIR)/server/cli_mistral.o \
                       $(OBJDIR)/server/cli_acp.o $(OBJDIR)/posix/workspace_provider.o \
@@ -811,6 +814,7 @@ $(TESTPREFIX)/unit-test-acp-server: $(OBJDIR)/tests/test_acp_server.o \
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o $(OBJDIR)/server/server.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
 	                                $(OBJDIR)/server/server_config.o $(OBJDIR)/config_fields.o \
 	                                $(OBJDIR)/server/skill_review.o $(OBJDIR)/tests/support/skill_jobs_stub.o \
 	                                $(OBJDIR)/server/server_hooks.o $(OBJDIR)/server/server_http.o $(OBJDIR)/server/server_http_reqctx.o $(OBJDIR)/server/server_http_identity.o $(OBJDIR)/server/vault_principal.o \
@@ -2265,6 +2269,7 @@ $(TESTPREFIX)/unit-test-delegate-backend: $(OBJDIR)/tests/test_delegate_backend.
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-delegate-backend-local: $(OBJDIR)/tests/test_delegate_backend_local.o \
+                      $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
                      $(OBJDIR)/server/delegate_backend.o \
                      $(OBJDIR)/server/delegate_backend_local.o \
                      $(PLATFORM_BASIC_OBJS)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -882,6 +882,7 @@ $(TESTPREFIX)/unit-test-kb-client-memory: $(OBJDIR)/tests/test_kb_client_memory.
 $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o \
                                $(OBJDIR)/tests/support/delegate_role_policy_stub.o \
                                $(OBJDIR)/tests/support/toolset_stub.o \
+                               $(OBJDIR)/tests/support/agent_source_authority_stub.o \
                                $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/delegations.o $(OBJDIR)/db1/agent_jobs.o $(OBJDIR)/db1/session_paths.o $(OBJDIR)/db1/cost_fold.o $(OBJDIR)/db1/token_audit.o $(OBJDIR)/server/delegate_credentials.o $(OBJDIR)/server/delegate_credential_retry.o $(OBJDIR)/db1/delegate_learning.o $(OBJDIR)/db1/interaction_events.o \
                                $(OBJDIR)/db1/execution_plans.o $(OBJDIR)/db1/coord_jobs.o \
 		                               $(OBJDIR)/server/delegate_launch.o $(OBJDIR)/server/delegate_source_authority.o $(OBJDIR)/server/delegate_economics.o $(OBJDIR)/server/server_coord_dispatcher.o \

--- a/src/tests/support/agent_source_authority_stub.c
+++ b/src/tests/support/agent_source_authority_stub.c
@@ -31,3 +31,7 @@ void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
       snap->paths = NULL;
    }
 }
+
+void agent_source_authority_export_env(void)
+{
+}

--- a/src/tests/support/agent_source_authority_stub.c
+++ b/src/tests/support/agent_source_authority_stub.c
@@ -1,0 +1,33 @@
+/* Stub of the source-authority TLS setters for tests that link server_compute.c
+ * (delegate_run_ctx_enter/restore call these) but do not exercise the
+ * code_search overlay. The real implementation lives in
+ * posix/agent_source_authority.c, which pulls in kb_client/agent_tools. */
+#include "agent_source_authority.h"
+#include <stdlib.h>
+
+void agent_source_authority_tls_set(int authority, const char *worktree_root, const char *paths)
+{
+   (void)authority;
+   (void)worktree_root;
+   (void)paths;
+}
+
+void agent_source_authority_tls_capture(agent_source_authority_snapshot_t *snap)
+{
+   if (snap)
+   {
+      snap->active = 0;
+      snap->authority = 0;
+      snap->root[0] = '\0';
+      snap->paths = NULL;
+   }
+}
+
+void agent_source_authority_tls_restore(agent_source_authority_snapshot_t *snap)
+{
+   if (snap)
+   {
+      free(snap->paths);
+      snap->paths = NULL;
+   }
+}

--- a/src/tests/support/delegate_child_env_export_stub.c
+++ b/src/tests/support/delegate_child_env_export_stub.c
@@ -1,0 +1,7 @@
+/* Stub of delegate_child_export_context_env for tests that link the fork-site
+ * objects (provider_cli_adapter.o, delegate_backend_local.o) but not
+ * server_compute.o (where the real implementation lives). The exporter only runs
+ * in a post-fork child, which these unit tests do not exercise. */
+void delegate_child_export_context_env(void)
+{
+}

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1834,6 +1834,7 @@ int main(void)
    test_tool_grep_excludes_heavy_dirs();
    test_dispatch_tool_call();
    test_source_authority_overlay_tools();
+   test_source_authority_tls_thread_isolation();
    test_parse_openai_tool_calls();
    test_path_traversal_rejected();
    test_sensitive_path_rejected();

--- a/src/tests/test_agent_source_authority.inc
+++ b/src/tests/test_agent_source_authority.inc
@@ -1,3 +1,98 @@
+#include "agent_source_authority.h"
+#include <pthread.h>
+
+/* Regression test for the concurrent-delegate source-authority race: each
+ * delegate installs its source context via agent_source_authority_tls_set
+ * (thread-local), and the code_search overlay must read THIS thread's context,
+ * never a neighbor's. Pre-fix the context lived in process-global env vars, so
+ * 8 threads each setting a different worktree/paths clobbered each other and the
+ * overlay resolved against the wrong tree (flakiness that varied with timing).
+ *
+ * Two thread groups (A/B) each own a distinct file whose unique symbol exists
+ * ONLY in their file. Each thread, looping, sets its TLS paths and asserts the
+ * overlay finds ITS symbol (>=1 hit) and NOT the other group's symbol (0 hits).
+ * Any cross-thread TLS leak flips one of those assertions. */
+typedef struct
+{
+   const char *path;      /* this group's source file */
+   const char *own_sym;   /* symbol present only in `path` */
+   const char *other_sym; /* the other group's symbol, absent from `path` */
+   const char *root;
+   int iters;
+   int failed;
+} sa_tls_worker_arg_t;
+
+static void *sa_tls_worker(void *argp)
+{
+   sa_tls_worker_arg_t *a = (sa_tls_worker_arg_t *)argp;
+   for (int i = 0; i < a->iters; i++)
+   {
+      agent_source_authority_tls_set(1, a->root, a->path);
+
+      cJSON *own = cJSON_CreateArray();
+      int own_hits = agent_source_append_overlay_code_hits(own, a->own_sym, NULL, 5);
+      cJSON *other = cJSON_CreateArray();
+      int other_hits = agent_source_append_overlay_code_hits(other, a->other_sym, NULL, 5);
+
+      if (own_hits < 1 || other_hits != 0)
+         a->failed = 1; /* TLS leaked from another thread */
+      cJSON_Delete(own);
+      cJSON_Delete(other);
+   }
+   /* Release the heap-held paths for this thread (zeroed snapshot frees + clears). */
+   agent_source_authority_snapshot_t z;
+   memset(&z, 0, sizeof(z));
+   agent_source_authority_tls_restore(&z);
+   return NULL;
+}
+
+static void test_source_authority_tls_thread_isolation(void)
+{
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-sa-tls-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+
+   char path_a[768], path_b[768];
+   snprintf(path_a, sizeof(path_a), "%s/group_a.c", tmpdir);
+   snprintf(path_b, sizeof(path_b), "%s/group_b.c", tmpdir);
+   FILE *fa = fopen(path_a, "w");
+   assert(fa);
+   fputs("int alpha_unique_marker(void) { return 1; }\n", fa);
+   fclose(fa);
+   FILE *fb = fopen(path_b, "w");
+   assert(fb);
+   fputs("int beta_unique_marker(void) { return 2; }\n", fb);
+   fclose(fb);
+
+   enum
+   {
+      NW = 8,
+      ITERS = 150
+   };
+   pthread_t th[NW];
+   sa_tls_worker_arg_t args[NW];
+   for (int i = 0; i < NW; i++)
+   {
+      int is_a = (i % 2 == 0);
+      args[i].path = is_a ? path_a : path_b;
+      args[i].own_sym = is_a ? "alpha_unique_marker" : "beta_unique_marker";
+      args[i].other_sym = is_a ? "beta_unique_marker" : "alpha_unique_marker";
+      args[i].root = tmpdir;
+      args[i].iters = ITERS;
+      args[i].failed = 0;
+      assert(pthread_create(&th[i], NULL, sa_tls_worker, &args[i]) == 0);
+   }
+   for (int i = 0; i < NW; i++)
+   {
+      pthread_join(th[i], NULL);
+      assert(args[i].failed == 0); /* no cross-thread source-authority leak */
+   }
+
+   unlink(path_a);
+   unlink(path_b);
+   rmdir(tmpdir);
+}
+
 static void test_source_authority_overlay_tools(void)
 {
    char tmpdir[512];

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -416,12 +416,15 @@ int canonical_index_project_lang_breakdown(const char *project, char *buf, size_
    return 0;
 }
 
+/* Must mirror code_search_hit_t (index.h) exactly — the handler casts the out
+ * buffer to it; a layout mismatch would corrupt the read. */
 typedef struct
 {
    char project[128];
    char file_path[MAX_PATH_LEN];
    char snippet[512];
    double rank;
+   char content_hash[80];
 } test_code_search_hit_t;
 
 int canonical_index_code_search(const char *query, const char *project, void *out, int max)
@@ -437,6 +440,7 @@ int canonical_index_code_search(const char *query, const char *project, void *ou
    snprintf(hits[0].file_path, sizeof(hits[0].file_path), "src/search.c");
    snprintf(hits[0].snippet, sizeof(hits[0].snippet), "int needle(void) { return 1; }");
    hits[0].rank = 0.75;
+   snprintf(hits[0].content_hash, sizeof(hits[0].content_hash), "deadbeefcafe");
    return 1;
 }
 

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -36,6 +36,8 @@ static void test_code_search_ok(void)
    assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL);
    assert(strstr(buf, "\"snippet\":\"int needle") != NULL);
    assert(strstr(buf, "\"rank\":0.75") != NULL);
+   /* P2 Layer-1: the file content hash is surfaced for citation/drift. */
+   assert(strstr(buf, "\"content_hash\":\"deadbeefcafe\"") != NULL);
    assert(strstr(buf, "\"next_cursor\":null") != NULL);
 }
 

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -19,6 +19,7 @@
 #include "workspace.h"
 #include "../db2/db2_internal.h"
 #include "../db2/entity_edges.h"
+#include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 
 int memory_demote_from_failures(void);
 
@@ -331,6 +332,49 @@ static void test_memory_promote_calibration_ab_slot(void)
    write_calibration_config(0);
 }
 
+/* Auditable-correctness P2: db2_memory_provenance_by_id resolves a surfaced
+ * source id to {kind, source, version} (the /v1/audit/provenance read path), and
+ * reports 0 for an id with no row (a source deleted/superseded since the turn). */
+static void test_audit_provenance_resolver(void)
+{
+   setup();
+
+   const char *ins = "INSERT INTO memories (tier, kind, key, content, confidence, use_count,"
+                     " last_used_at, source_session, created_at, updated_at, sensitivity,"
+                     " evidence_strength, salience, surprise, observation_count)"
+                     " VALUES ('L1', 'fact', 'prov-key-1', 'caroline lives in portland', 0.8, 1,"
+                     " pg_now_text(), 'sess-prov', pg_now_text(), pg_now_text(), 'normal',"
+                     " 0.5, 0.5, 0.5, 1) RETURNING id";
+   char err[128] = "";
+   aimee_pg_stmt_t *s = aimee_pg_prepare(db2_conn(), ins, err, sizeof(err));
+   assert(s);
+   assert(aimee_pg_step(s, err, sizeof(err)) == AIMEE_PG_ROW);
+   int64_t id = aimee_pg_column_int64(s, 0);
+   aimee_pg_finalize(s);
+   assert(id > 0);
+
+   char kind[64] = "x", source[128] = "x", version[64] = "x";
+   int rc = db2_memory_provenance_by_id(id, kind, sizeof kind, source, sizeof source, version,
+                                        sizeof version);
+   assert(rc == 1);
+   assert(strcmp(kind, "fact") == 0);
+   assert(strcmp(source, "sess-prov") == 0);
+   assert(version[0] != '\0'); /* updated_at is the version */
+
+   /* A missing id resolves to 0 (deleted/superseded), out buffers cleared. */
+   kind[0] = source[0] = version[0] = 'x';
+   rc = db2_memory_provenance_by_id(id + 999999, kind, sizeof kind, source, sizeof source, version,
+                                    sizeof version);
+   assert(rc == 0);
+   assert(kind[0] == '\0' && source[0] == '\0' && version[0] == '\0');
+
+   /* A non-positive id is rejected. */
+   assert(db2_memory_provenance_by_id(0, NULL, 0, NULL, 0, NULL, 0) == -1);
+
+   teardown();
+   printf("  audit provenance resolver (kind/source/version + miss) OK\n");
+}
+
 int main(void)
 {
    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
@@ -351,6 +395,7 @@ int main(void)
    test_promote();
    test_memory_promote_uses_calibration_profile();
    test_memory_promote_calibration_ab_slot();
+   test_audit_provenance_resolver();
    test_expire_l0();
    test_fold_session();
    test_stats();

--- a/src/tests/test_server_compute.c
+++ b/src/tests/test_server_compute.c
@@ -1751,6 +1751,7 @@ static int delegate_current_job(db1_agent_job_t *out_job)
 #include "test_server_compute_delegate_write.inc"
 #include "test_server_compute_liveness.inc"
 #include "test_server_compute_state_invariants.inc"
+#include "test_server_compute_child_env.inc"
 
 /* Pure prompt helpers extracted from delegate_worker (server/delegate_prompt.c). */
 char *delegate_rewrite_prompt_cwd(const char *prompt, const char *cwd, const char *worktree_path,
@@ -1935,6 +1936,7 @@ int main(void)
    test_spawn_record_marks_running();
    test_spawn_limit_descendants_blocks_completed_chain();
    test_depth_context_save_restore();
+   test_child_export_context_env();
    test_delegation_augment_error();
    test_cross_process_depth_propagation();
    test_delegate_provider_route_override();

--- a/src/tests/test_server_compute_child_env.inc
+++ b/src/tests/test_server_compute_child_env.inc
@@ -1,0 +1,34 @@
+/* test_server_compute_child_env.inc: delegate_child_export_context_env coverage.
+ * Split out of test_server_compute.c to keep it under the 2000-line hard limit.
+ * Included into test_server_compute.c so it shares the server_compute.c
+ * translation unit (reaches tl_delegation_depth / tl_parent_delegation_id). */
+
+/* delegate_child_export_context_env mirrors the forking thread's TLS depth/parent
+ * into the env for a post-fork child. It must export the THREAD's values (not a
+ * concurrently-clobbered global) when inside a delegate, and leave the env alone
+ * for a primary agent (depth 0, no parent). */
+static void test_child_export_context_env(void)
+{
+   /* Pre-seed the env with a stale value as if a concurrent delegate had written
+    * it; inside a delegate the export must override with this thread's TLS. */
+   platform_setenv("AIMEE_DELEGATE_DEPTH", "9");
+   platform_setenv("AIMEE_PARENT_DELEGATION_ID", "stale-parent");
+
+   tl_delegation_depth = 3;
+   snprintf(tl_parent_delegation_id, sizeof(tl_parent_delegation_id), "deleg-self");
+   delegate_child_export_context_env();
+   assert(strcmp(getenv("AIMEE_DELEGATE_DEPTH"), "3") == 0);
+   assert(strcmp(getenv("AIMEE_PARENT_DELEGATION_ID"), "deleg-self") == 0);
+
+   /* Primary agent: depth 0, no parent -> no override (inherited env preserved). */
+   platform_setenv("AIMEE_DELEGATE_DEPTH", "7");
+   platform_setenv("AIMEE_PARENT_DELEGATION_ID", "inherited");
+   tl_delegation_depth = 0;
+   tl_parent_delegation_id[0] = '\0';
+   delegate_child_export_context_env();
+   assert(strcmp(getenv("AIMEE_DELEGATE_DEPTH"), "7") == 0);
+   assert(strcmp(getenv("AIMEE_PARENT_DELEGATION_ID"), "inherited") == 0);
+
+   platform_setenv("AIMEE_DELEGATE_DEPTH", "");
+   platform_setenv("AIMEE_PARENT_DELEGATION_ID", "");
+}

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -543,6 +543,10 @@ int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "evidence.trace_retrieval_event");
 }
+int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "evidence.provenance_retrieval_event");
+}
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "curator.implements");
@@ -1450,6 +1454,16 @@ static void test_routing(void)
    assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
                  "evidence.trace_retrieval_event") == 0);
    assert(strcmp(g_last_handler, "evidence.trace_retrieval_event") == 0);
+   cJSON_Delete(json);
+
+   /* Auditable-correctness P2: /v1/audit/provenance's op must likewise resolve to
+    * its server-side KB-forward handler. */
+   json = dispatch_json(
+       ctx, conn, "{\"method\":\"evidence.provenance_retrieval_event\",\"turn_id\":\"t1\"}",
+       strlen("{\"method\":\"evidence.provenance_retrieval_event\",\"turn_id\":\"t1\"}"));
+   assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
+                 "evidence.provenance_retrieval_event") == 0);
+   assert(strcmp(g_last_handler, "evidence.provenance_retrieval_event") == 0);
    cJSON_Delete(json);
 
    json = dispatch_json(ctx, conn, "{\"method\":\"rules.delete\",\"id\":1}",


### PR DESCRIPTION
Promote `testing` → `main`. Individually-reviewed changes since the last promotion:

- **#348 fix(delegate)** — export delegate context (depth/parent/source) to the child env post-fork from the forking thread's TLS, closing the cross-process leg of the concurrent-delegate env race.
- **#347 fix(delegate)** — thread-local source-authority context; in-process `code_search` overlay reads TLS instead of clobberable process-global env. Together #347+#348 fix the "flaky model varies hour-to-hour" concurrent-delegate/roundtable class.
- **#344/#345/#346 feat/test(audit)** — auditable-correctness P2: carry file `content_hash` through code search; `/v1/audit/provenance` + `aimee audit provenance`; provenance-resolver coverage.

All checks were green on each source PR into testing.
