### PR TITLE
feat(audit): emit-time point-in-time version capture + drift (auditable-correctness P2)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -915,10 +915,13 @@ paths:
       description: >-
         Which sources grounded a turn's answer, at which version: given the
         caller-visible turn_id, resolve each source id recorded on the turn's
-        retrieval_event to {id, kind, source, version, present}, where version is
-        the source row's updated_at (read live) and present is false when the
-        source no longer exists (deleted/superseded since the turn). provenance_status
-        is one of the exhaustive states ok / not_instrumented / not_evaluated /
+        retrieval_event to {id, kind, source, version, present, turn_version,
+        drifted}. version is the source row's updated_at read live (current);
+        turn_version is the point-in-time version captured at emit; drifted is true
+        when a still-present source's current version differs from turn_version
+        (version-change drift). present is false when the source no longer exists
+        (deleted/superseded since the turn). provenance_status is one of the
+        exhaustive states ok / not_instrumented / not_evaluated /
         evidence_unavailable (P2 produces ok and evidence_unavailable). Requires
         aimee-kb. Gated by kb_evidence_emit_enabled at emit time.
       requestBody:

--- a/src/db2/demotion.c
+++ b/src/db2/demotion.c
@@ -5,6 +5,7 @@
 #include "artifacts.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
+#include "memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "aimee.h"
 
 #include <cJSON.h>
@@ -14,22 +15,6 @@
 #include <string.h>
 #include <time.h>
 
-/* Build surfaced_ids JSON array string into buf. */
-static void build_ids_array(const int64_t *ids, int n, char *buf, size_t len)
-{
-   size_t off = 0;
-   buf[off++] = '[';
-   for (int i = 0; i < n && off < len - 32; i++)
-   {
-      if (i > 0)
-         buf[off++] = ',';
-      off += (size_t)snprintf(buf + off, len - off, "%lld", (long long)ids[i]);
-   }
-   if (off < len - 1)
-      buf[off++] = ']';
-   buf[off] = '\0';
-}
-
 int db2_demotion_retrieval_event_write(const char *query_fingerprint, const char *role,
                                        const int64_t *surfaced_ids, int n_surfaced, char *id_out,
                                        int id_out_len)
@@ -37,16 +22,41 @@ int db2_demotion_retrieval_event_write(const char *query_fingerprint, const char
    char id[64];
    db2_artifact_gen_id(id, sizeof(id));
 
-   char ids_buf[4096];
-   build_ids_array(surfaced_ids ? surfaced_ids : NULL, surfaced_ids ? n_surfaced : 0, ids_buf,
-                   sizeof(ids_buf));
-
-   char payload[8192];
-   snprintf(payload, sizeof(payload),
-            "{\"query_fingerprint\":\"%s\",\"role\":\"%s\",\"surfaced_ids\":%s}",
-            query_fingerprint ? query_fingerprint : "", role ? role : "", ids_buf);
+   /* Build the payload with cJSON (no fixed-buffer overflow risk). Alongside the
+    * back-compat `surfaced_ids` array, record `surfaced_items` = [{id, v}] where
+    * v is each source's version (memories.updated_at) resolved NOW, at emit time.
+    * That is the source's point-in-time version for this turn, so /v1/audit/
+    * provenance can later flag version drift (turn-time v != current). */
+   cJSON *p = cJSON_CreateObject();
+   if (!p)
+      return -1;
+   cJSON_AddStringToObject(p, "query_fingerprint", query_fingerprint ? query_fingerprint : "");
+   cJSON_AddStringToObject(p, "role", role ? role : "");
+   cJSON *ids = cJSON_AddArrayToObject(p, "surfaced_ids");
+   cJSON *items = cJSON_AddArrayToObject(p, "surfaced_items");
+   /* surfaced_ids may be NULL (proactive/no-surface events); guard it so n is
+    * effectively 0, matching the original build_ids_array(NULL,...) contract. */
+   for (int i = 0; surfaced_ids && ids && items && i < n_surfaced; i++)
+   {
+      cJSON_AddItemToArray(ids, cJSON_CreateNumber((double)surfaced_ids[i]));
+      char version[64] = "";
+      int found =
+          db2_memory_provenance_by_id(surfaced_ids[i], NULL, 0, NULL, 0, version, sizeof version);
+      cJSON *it = cJSON_CreateObject();
+      cJSON_AddNumberToObject(it, "id", (double)surfaced_ids[i]);
+      /* Only record a version when the row resolved; an unresolved id just omits
+       * `v` (provenance treats a missing turn-version as "unknown", not drift). */
+      if (found == 1 && version[0])
+         cJSON_AddStringToObject(it, "v", version);
+      cJSON_AddItemToArray(items, it);
+   }
+   char *payload = cJSON_PrintUnformatted(p);
+   cJSON_Delete(p);
+   if (!payload)
+      return -1;
 
    int rc = db2_artifact_write(id, "retrieval_event", "proposed", "system", "", "", 1.0, payload);
+   free(payload);
    if (rc != 0)
       return -1;
 

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -869,6 +869,10 @@ int kb_handle_evidence_provenance(int fd, cJSON *req)
       cJSON *sources = cJSON_AddArrayToObject(resp, "sources");
       cJSON *ev = payload[0] ? cJSON_Parse(payload) : NULL;
       cJSON *ids = ev ? cJSON_GetObjectItemCaseSensitive(ev, "surfaced_ids") : NULL;
+      /* surfaced_items = [{id, v}] carries each source's point-in-time version
+       * (memories.updated_at at emit). Absent on legacy events (pre emit-capture);
+       * then turn_version is "" and drift is simply not reported. */
+      cJSON *items = ev ? cJSON_GetObjectItemCaseSensitive(ev, "surfaced_items") : NULL;
       int n = cJSON_IsArray(ids) ? cJSON_GetArraySize(ids) : 0;
       for (int i = 0; sources && i < n; i++)
       {
@@ -886,13 +890,36 @@ int kb_handle_evidence_provenance(int fd, cJSON *req)
          cJSON_AddNumberToObject(src, "id", (double)id);
          cJSON_AddStringToObject(src, "kind", kind);
          cJSON_AddStringToObject(src, "source", source);
-         cJSON_AddStringToObject(src, "version", version);
+         cJSON_AddStringToObject(src, "version", version); /* live/current version */
          cJSON_AddBoolToObject(src, "present", found == 1);
          /* Distinguish a source that is genuinely gone (found==0, deleted/
           * superseded since the turn) from one whose lookup errored (found<0):
           * both leave present:false, but only the latter is an unreliable read. */
          if (found < 0)
             cJSON_AddBoolToObject(src, "error", 1);
+         /* Point-in-time version captured at emit (surfaced_items[].v): report it
+          * and flag drift when the source has since changed (turn_version differs
+          * from the current version of a still-present source). */
+         const char *turn_version = "";
+         if (cJSON_IsArray(items))
+         {
+            int m = cJSON_GetArraySize(items);
+            for (int j = 0; j < m; j++)
+            {
+               cJSON *it = cJSON_GetArrayItem(items, j);
+               cJSON *iid = it ? cJSON_GetObjectItemCaseSensitive(it, "id") : NULL;
+               if (cJSON_IsNumber(iid) && (int64_t)iid->valuedouble == id)
+               {
+                  cJSON *v = cJSON_GetObjectItemCaseSensitive(it, "v");
+                  if (cJSON_IsString(v) && v->valuestring)
+                     turn_version = v->valuestring;
+                  break;
+               }
+            }
+         }
+         cJSON_AddStringToObject(src, "turn_version", turn_version);
+         cJSON_AddBoolToObject(src, "drifted",
+                               turn_version[0] && found == 1 && strcmp(turn_version, version) != 0);
          cJSON_AddItemToArray(sources, src);
       }
       if (ev)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -479,7 +479,7 @@ $(TESTPREFIX)/unit-test-cmd-hooks-scope: $(OBJDIR)/tests/test_cmd_hooks_scope.o 
                              $(OBJDIR)/cmd_hooks_scope.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-memory: $(OBJDIR)/tests/test_memory.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o $(OBJDIR)/memory_core.o \
+$(TESTPREFIX)/unit-test-memory: $(OBJDIR)/tests/test_memory.o $(OBJDIR)/kb/kb_bandit.o $(OBJDIR)/kb/kb_bandit_registry.o $(OBJDIR)/db2/bandit.o $(OBJDIR)/db2/demotion.o $(OBJDIR)/memory_core.o \
                         $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db2/kb_payload.o $(OBJDIR)/db2/kb_service_backend.o $(OBJDIR)/db2/kb_service_backend_ingest.o $(OBJDIR)/db2/memory_lifecycle.o $(OBJDIR)/db2/memory_payload.o $(OBJDIR)/db2/memory_promotion.o $(OBJDIR)/db2/memory_query.o $(OBJDIR)/db2/memory_query_bookkeeping.o $(OBJDIR)/db2/memory_entity_graph.o $(OBJDIR)/db2/memory_score_fields.o $(OBJDIR)/db2/memory_scope_query.o $(OBJDIR)/db2/memory_scenes.o $(OBJDIR)/db2/memory_briefing.o $(OBJDIR)/db2/memory_health.o $(OBJDIR)/db2/memory_row_mapper_pg.o $(OBJDIR)/db2/memory_relations.o $(OBJDIR)/db2/memory_conflicts.o $(OBJDIR)/db2/vector_index_ops.o $(OBJDIR)/db2/code_index_ops.o $(OBJDIR)/db2/rules.o $(OBJDIR)/db2/stopwords.o $(OBJDIR)/db2/tool_registry.o $(OBJDIR)/db2/feedback.o $(OBJDIR)/db2/notes.o $(OBJDIR)/db2/anti_patterns.o $(OBJDIR)/db2/curiosity.o $(OBJDIR)/db2/entity_edges.o $(OBJDIR)/db2/entity_profiles.o $(OBJDIR)/db2/epistemic_directives.o $(OBJDIR)/db2/failed_queries.o $(OBJDIR)/db2/kind_lifecycle.o $(OBJDIR)/db2/calibration.o $(OBJDIR)/db2/artifacts.o $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o \
                         $(OBJDIR)/tests/support/mock_agent_http.o \
                         $(OBJDIR)/tests/support/memory_embed_stub.o $(OBJDIR)/tests/support/kb_client_test_stub.o \
@@ -2702,6 +2702,7 @@ $(TESTPREFIX)/unit-test-calibration: $(OBJDIR)/tests/test_calibration.o \
 
 $(TESTPREFIX)/unit-test-demotion: $(OBJDIR)/tests/test_demotion.o \
                      $(OBJDIR)/db2/demotion.o \
+                     $(OBJDIR)/db2/memory_payload.o \
                      $(OBJDIR)/db2/artifacts.o \
                      $(OBJDIR)/db2/feature_rows.o \
                      $(OBJDIR)/kb/kb_mdl.o \

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -20,6 +20,7 @@
 #include "../db2/db2_internal.h"
 #include "../db2/entity_edges.h"
 #include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
+#include "../db2/demotion.h"       /* retrieval_event write/read (auditable-correctness P2) */
 
 int memory_demote_from_failures(void);
 
@@ -375,6 +376,50 @@ static void test_audit_provenance_resolver(void)
    printf("  audit provenance resolver (kind/source/version + miss) OK\n");
 }
 
+/* Auditable-correctness P2 emit-time version capture: writing a retrieval_event
+ * records each surfaced id's point-in-time version (memories.updated_at at emit)
+ * in surfaced_items, so /v1/audit/provenance can later detect version drift. */
+static void test_audit_provenance_emit_captures_version(void)
+{
+   setup();
+
+   const char *ins = "INSERT INTO memories (tier, kind, key, content, confidence, use_count,"
+                     " last_used_at, source_session, created_at, updated_at, sensitivity,"
+                     " evidence_strength, salience, surprise, observation_count)"
+                     " VALUES ('L1', 'fact', 'emit-key-1', 'sky is blue', 0.8, 1,"
+                     " pg_now_text(), 'sess-emit', pg_now_text(), pg_now_text(), 'normal',"
+                     " 0.5, 0.5, 0.5, 1) RETURNING id";
+   char err[128] = "";
+   aimee_pg_stmt_t *s = aimee_pg_prepare(db2_conn(), ins, err, sizeof(err));
+   assert(s);
+   assert(aimee_pg_step(s, err, sizeof(err)) == AIMEE_PG_ROW);
+   int64_t id = aimee_pg_column_int64(s, 0);
+   aimee_pg_finalize(s);
+   assert(id > 0);
+
+   /* Emit a turn-keyed retrieval_event surfacing that memory. */
+   int64_t ids[1] = {id};
+   char evid[64] = "";
+   assert(db2_demotion_retrieval_event_write_turn("p2-emit-turn", "fp", "Recall", ids, 1, evid,
+                                                  sizeof evid) == 0);
+
+   /* Read the stored payload back: it carries surfaced_items with the id and a
+    * captured (point-in-time) version string. */
+   char read_id[64] = "", payload[8192] = "";
+   assert(db2_demotion_retrieval_event_by_turn("p2-emit-turn", read_id, sizeof read_id, payload,
+                                               sizeof payload) == 1);
+   assert(strstr(payload, "\"surfaced_items\"") != NULL);
+   char id_needle[48];
+   snprintf(id_needle, sizeof id_needle, "\"id\":%lld", (long long)id);
+   assert(strstr(payload, id_needle) != NULL);
+   assert(strstr(payload, "\"v\":\"") != NULL); /* a point-in-time version was captured */
+   /* back-compat: surfaced_ids is still present. */
+   assert(strstr(payload, "\"surfaced_ids\"") != NULL);
+
+   teardown();
+   printf("  audit provenance emit captures point-in-time version OK\n");
+}
+
 int main(void)
 {
    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
@@ -396,6 +441,7 @@ int main(void)
    test_memory_promote_uses_calibration_profile();
    test_memory_promote_calibration_ab_slot();
    test_audit_provenance_resolver();
+   test_audit_provenance_emit_captures_version();
    test_expire_l0();
    test_fold_session();
    test_stats();


### PR DESCRIPTION
Completes the **auditable-correctness P2** drift story: provenance previously reported only *current* versions; now it captures each source's version **at emit time** so it can flag **version-change drift**.

## Change
- `db2_demotion_retrieval_event_write` now builds the retrieval_event payload with cJSON and records `surfaced_items=[{id, v}]`, where `v` is the source's `memories.updated_at` resolved **at emit** (`db2_memory_provenance_by_id`). `surfaced_ids` is kept for back-compat; the fixed-buffer `build_ids_array` is removed (no overflow risk).
- `kb_handle_evidence_provenance` adds two per-source fields: `turn_version` (the captured point-in-time version; `""` on legacy pre-capture events) and `drifted` (true when a still-present source's current `version` differs from `turn_version`). `version` remains the live/current value; all previously-shipped fields are unchanged.
- `openapi-server-v1.yaml`: documents `turn_version` + `drifted`.
- `test_memory.c`: asserts the emit round-trip stores `surfaced_items` with a captured version; `Rules.mk` wires `demotion.o`→unit-test-memory and `memory_payload.o`→unit-test-demotion.

## Verification
`make all`, `make lint`, `make build-integrity`, full `make unit-tests` all green. Will additionally verify end-to-end on the live stack (a fresh turn emits a new-format event; provenance shows `turn_version` and, after a source update, `drifted:true`).

Back-compat: legacy events (only `surfaced_ids`) still resolve — `turn_version:""`, `drifted:false`.