### PR TITLE
feat(css): WP-A CSS analyzer core — style graph with specificity (migration assistant #1)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -316,7 +316,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-            index.c extractors.c extractors_extra.c extractors_new_langs.c \
+            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
@@ -411,7 +411,7 @@ KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-               index.c extractors.c extractors_extra.c extractors_new_langs.c \
+               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_PLATFORM_OBJS = $(PLATFORM_BASIC_OBJS) $(filter %/agent_bridge.o %/cli_client.o %/memory.o,$(PLATFORM_EXTRA_OBJS) $(PLATFORM_AGENT_OBJS))

--- a/src/css_analyze.c
+++ b/src/css_analyze.c
@@ -1,0 +1,759 @@
+/* css_analyze.c: CSS structural analyzer. See css_analyze.h. */
+#include "css_analyze.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Hard caps so malformed/adversarial input stays bounded (never crash/over-read;
+ * the existing lexical scanners use fixed buffers — match that discipline). */
+#define CSS_MAX_RULES          200000
+#define CSS_MAX_DECLS_PER_RULE 8192
+#define CSS_MAX_SELECTORS_LIST 512
+
+/* ---- specificity ------------------------------------------------------- */
+
+static int css_ident_char(char c)
+{
+   return isalnum((unsigned char)c) || c == '-' || c == '_' || c == '\\';
+}
+
+/* Index of the ')' that closes the '(' just before s[0..len), respecting nested
+ * parens and quotes. Returns len when unbalanced. */
+static size_t css_find_close_paren(const char *s, size_t len)
+{
+   int depth = 1;
+   for (size_t i = 0; i < len; i++)
+   {
+      char ch = s[i];
+      if (ch == '(')
+         depth++;
+      else if (ch == ')')
+      {
+         if (--depth == 0)
+            return i;
+      }
+      else if (ch == '"' || ch == '\'')
+      {
+         char q = ch;
+         i++;
+         while (i < len && s[i] != q)
+         {
+            if (s[i] == '\\')
+               i++;
+            i++;
+         }
+      }
+   }
+   return len;
+}
+
+static void css_spec_scan(const char *s, size_t len, int *a, int *b, int *c, int *uncertain);
+
+/* Specificity of a selector list (comma-separated) = the most specific single
+ * selector in the list (lexicographic (a,b,c)). Used for :is()/:not()/:has(). */
+static void css_spec_list_max(const char *s, size_t len, int *a, int *b, int *c, int *uncertain)
+{
+   int best_a = 0, best_b = 0, best_c = 0, found = 0;
+   size_t p = 0;
+   while (p <= len)
+   {
+      size_t q = p;
+      int depth = 0;
+      while (q < len)
+      {
+         char ch = s[q];
+         if (ch == '(')
+            depth++;
+         else if (ch == ')')
+            depth--;
+         else if (ch == ',' && depth == 0)
+            break;
+         q++;
+      }
+      int ca = 0, cb = 0, cc = 0;
+      css_spec_scan(s + p, q - p, &ca, &cb, &cc, uncertain);
+      if (!found || ca > best_a || (ca == best_a && cb > best_b) ||
+          (ca == best_a && cb == best_b && cc > best_c))
+      {
+         best_a = ca;
+         best_b = cb;
+         best_c = cc;
+         found = 1;
+      }
+      if (q >= len)
+         break;
+      p = q + 1;
+   }
+   *a += best_a;
+   *b += best_b;
+   *c += best_c;
+}
+
+/* Accumulate the specificity of one complex selector into (a,b,c). */
+static void css_spec_scan(const char *s, size_t len, int *a, int *b, int *c, int *uncertain)
+{
+   size_t i = 0;
+   while (i < len)
+   {
+      char ch = s[i];
+
+      if (isspace((unsigned char)ch) || ch == '>' || ch == '+' || ch == '~' || ch == ',')
+      {
+         i++;
+         continue;
+      }
+      if (ch == '*')
+      { /* universal selector contributes nothing */
+         i++;
+         continue;
+      }
+      if (ch == '&')
+      { /* CSS nesting selector: specificity is context-dependent */
+         *uncertain = 1;
+         i++;
+         continue;
+      }
+      if (ch == '#')
+      {
+         i++;
+         while (i < len && css_ident_char(s[i]))
+            i++;
+         (*a)++;
+         continue;
+      }
+      if (ch == '.')
+      {
+         i++;
+         while (i < len && css_ident_char(s[i]))
+            i++;
+         (*b)++;
+         continue;
+      }
+      if (ch == '[')
+      { /* attribute selector */
+         i++;
+         while (i < len && s[i] != ']')
+         {
+            if (s[i] == '"' || s[i] == '\'')
+            {
+               char q = s[i];
+               i++;
+               while (i < len && s[i] != q)
+               {
+                  if (s[i] == '\\')
+                     i++;
+                  i++;
+               }
+            }
+            i++;
+         }
+         if (i < len)
+            i++; /* consume ']' */
+         (*b)++;
+         continue;
+      }
+      if (ch == ':')
+      {
+         i++;
+         int pseudo_element = 0;
+         if (i < len && s[i] == ':')
+         {
+            pseudo_element = 1;
+            i++;
+         }
+         size_t name_start = i;
+         while (i < len && css_ident_char(s[i]))
+            i++;
+         char name[64];
+         size_t nl = i - name_start;
+         if (nl > sizeof(name) - 1)
+            nl = sizeof(name) - 1;
+         for (size_t k = 0; k < nl; k++)
+            name[k] = (char)tolower((unsigned char)s[name_start + k]);
+         name[nl] = '\0';
+
+         if (i < len && s[i] == '(')
+         { /* functional pseudo */
+            i++;
+            size_t close = css_find_close_paren(s + i, len - i);
+            const char *args = s + i;
+            size_t arg_len = close;
+            if (pseudo_element)
+            {
+               (*c)++; /* functional pseudo-element (rare) */
+            }
+            else if (strcmp(name, "where") == 0)
+            {
+               /* :where() contributes 0 */
+            }
+            else if (strcmp(name, "is") == 0 || strcmp(name, "not") == 0 ||
+                     strcmp(name, "has") == 0 || strcmp(name, "matches") == 0)
+            {
+               css_spec_list_max(args, arg_len, a, b, c, uncertain);
+            }
+            else if (strncmp(name, "nth", 3) == 0)
+            {
+               (*b)++; /* the pseudo-class itself */
+               /* :nth-child(An+B of S) — the S selector list adds specificity */
+               for (size_t k = 0; k + 2 < arg_len; k++)
+               {
+                  if ((args[k] == 'o' || args[k] == 'O') &&
+                      (args[k + 1] == 'f' || args[k + 1] == 'F') &&
+                      isspace((unsigned char)args[k + 2]))
+                  {
+                     *uncertain = 1;
+                     break;
+                  }
+               }
+            }
+            else
+            {
+               (*b)++; /* :lang(), :dir(), other functional pseudo-classes */
+            }
+            i += close;
+            if (i < len && s[i] == ')')
+               i++;
+            continue;
+         }
+         /* simple pseudo */
+         if (pseudo_element)
+            (*c)++;
+         else
+            (*b)++;
+         continue;
+      }
+      if (isalpha((unsigned char)ch) || ch == '-' || ch == '_' || ch == '\\' || ch == '|')
+      { /* type selector (optionally namespaced ns|el) */
+         while (i < len && (css_ident_char(s[i]) || s[i] == '|'))
+            i++;
+         (*c)++;
+         continue;
+      }
+      /* anything else (stray punctuation, '%', '@', ...) is unexpected here */
+      *uncertain = 1;
+      i++;
+   }
+}
+
+void css_selector_specificity(const char *selector, int *a, int *b, int *c, int *uncertain)
+{
+   int la = 0, lb = 0, lc = 0, lu = 0;
+   if (selector)
+      css_spec_scan(selector, strlen(selector), &la, &lb, &lc, &lu);
+   if (a)
+      *a = la;
+   if (b)
+      *b = lb;
+   if (c)
+      *c = lc;
+   if (uncertain)
+      *uncertain = lu;
+}
+
+/* ---- parser ------------------------------------------------------------ */
+
+typedef struct
+{
+   const char *s;
+   size_t len;
+   size_t i;
+   int line;
+} css_parser_t;
+
+/* Append c to buf (cap n) at *pos, truncating silently past the cap. */
+static void css_buf_putc(char *buf, size_t n, size_t *pos, char c)
+{
+   if (*pos < n - 1)
+      buf[(*pos)++] = c;
+}
+
+/* Advance one char, tracking line numbers. */
+static void css_advance(css_parser_t *p)
+{
+   if (p->i >= p->len)
+      return;
+   if (p->s[p->i] == '\n')
+      p->line++;
+   p->i++;
+}
+
+/* Skip a C-style CSS comment if positioned at one; returns 1 if it skipped. */
+static int css_skip_comment(css_parser_t *p)
+{
+   if (p->i + 1 < p->len && p->s[p->i] == '/' && p->s[p->i + 1] == '*')
+   {
+      css_advance(p);
+      css_advance(p);
+      while (p->i + 1 < p->len && !(p->s[p->i] == '*' && p->s[p->i + 1] == '/'))
+         css_advance(p);
+      if (p->i + 1 < p->len)
+      {
+         css_advance(p);
+         css_advance(p);
+      }
+      else
+         p->i = p->len;
+      return 1;
+   }
+   return 0;
+}
+
+static css_stylesheet_t *css_ss_new(void)
+{
+   css_stylesheet_t *ss = calloc(1, sizeof(*ss));
+   return ss;
+}
+
+static css_rule_t *css_ss_add_rule(css_stylesheet_t *ss)
+{
+   if (ss->rule_count >= CSS_MAX_RULES)
+   {
+      ss->truncated = 1;
+      return NULL;
+   }
+   /* Grow geometrically (realloc only at power-of-two counts) so indexing a
+    * large generated stylesheet (e.g. Tailwind output) stays amortized O(n). */
+   if ((ss->rule_count & (ss->rule_count - 1)) == 0)
+   {
+      int newcap = ss->rule_count == 0 ? 1 : ss->rule_count * 2;
+      css_rule_t *grown = realloc(ss->rules, (size_t)newcap * sizeof(css_rule_t));
+      if (!grown)
+         return NULL;
+      ss->rules = grown;
+   }
+   css_rule_t *r = &ss->rules[ss->rule_count];
+   memset(r, 0, sizeof(*r));
+   ss->rule_count++;
+   return r;
+}
+
+/* If the parser is at a quote, append the whole string literal (quotes +
+ * escapes) to buf (buf/pos may be NULL to discard) and advance past it; return
+ * 1. Else return 0. Strings hold structural chars ('{' '}' ';' '(' ')') that
+ * must NOT be treated as syntax (e.g. content: "}", url("a;b")). */
+static int css_consume_string(css_parser_t *p, char *buf, size_t n, size_t *pos)
+{
+   if (p->i >= p->len)
+      return 0;
+   char ch = p->s[p->i];
+   if (ch != '"' && ch != '\'')
+      return 0;
+   char q = ch;
+   if (buf)
+      css_buf_putc(buf, n, pos, ch);
+   css_advance(p);
+   while (p->i < p->len && p->s[p->i] != q)
+   {
+      if (p->s[p->i] == '\\')
+      {
+         if (buf)
+            css_buf_putc(buf, n, pos, p->s[p->i]);
+         css_advance(p);
+         if (p->i >= p->len)
+            break;
+      }
+      if (buf)
+         css_buf_putc(buf, n, pos, p->s[p->i]);
+      css_advance(p);
+   }
+   if (p->i < p->len)
+   {
+      if (buf)
+         css_buf_putc(buf, n, pos, p->s[p->i]);
+      css_advance(p);
+   }
+   return 1;
+}
+
+/* Finalize the current property/value pair into r (trims, strips !important).
+ * Resets the buffers. No-op for an empty property. */
+static void css_emit_decl(css_rule_t *r, char *prop, size_t *prop_pos, char *val, size_t *val_pos)
+{
+   prop[*prop_pos] = '\0';
+   val[*val_pos] = '\0';
+   while (*prop_pos > 0 && isspace((unsigned char)prop[*prop_pos - 1]))
+      prop[--(*prop_pos)] = '\0';
+   while (*val_pos > 0 && isspace((unsigned char)val[*val_pos - 1]))
+      val[--(*val_pos)] = '\0';
+   if (*prop_pos > 0 && r->decl_count < CSS_MAX_DECLS_PER_RULE)
+   {
+      css_declaration_t cur;
+      memset(&cur, 0, sizeof(cur));
+      char *bang = strstr(val, "!");
+      if (bang)
+      {
+         char tail[32];
+         size_t t = 0;
+         for (const char *q = bang + 1; *q && t < sizeof(tail) - 1; q++)
+            if (!isspace((unsigned char)*q))
+               tail[t++] = (char)tolower((unsigned char)*q);
+         tail[t] = '\0';
+         if (strncmp(tail, "important", 9) == 0)
+         {
+            cur.important = 1;
+            *bang = '\0';
+            size_t vl = strlen(val);
+            while (vl > 0 && isspace((unsigned char)val[vl - 1]))
+               val[--vl] = '\0';
+         }
+      }
+      snprintf(cur.property, sizeof(cur.property), "%s", prop);
+      snprintf(cur.value, sizeof(cur.value), "%s", val);
+      css_declaration_t *grown =
+          realloc(r->decls, (size_t)(r->decl_count + 1) * sizeof(css_declaration_t));
+      if (grown)
+      {
+         r->decls = grown;
+         r->decls[r->decl_count++] = cur;
+      }
+   }
+   *prop_pos = 0;
+   *val_pos = 0;
+   prop[0] = val[0] = '\0';
+}
+
+/* Read a balanced declaration block (parser at '{'); fill decls into r. If a
+ * nested rule block is encountered (CSS nesting), stop capturing declarations,
+ * flag uncertainty, and skip to the block end. Leaves parser just past '}'. */
+static void css_parse_decl_block(css_parser_t *p, css_rule_t *r)
+{
+   css_advance(p); /* consume '{' */
+   char prop[CSS_PROPERTY_MAX];
+   char val[CSS_VALUE_MAX];
+   size_t prop_pos = 0, val_pos = 0;
+   int in_value = 0;
+   int paren_depth = 0; /* depth inside value parens, e.g. url(), calc() */
+   prop[0] = val[0] = '\0';
+
+   while (p->i < p->len)
+   {
+      if (css_skip_comment(p))
+         continue;
+      char ch = p->s[p->i];
+
+      /* String literals hold structural chars that are not syntax. */
+      if (ch == '"' || ch == '\'')
+      {
+         if (in_value)
+            css_consume_string(p, val, sizeof(val), &val_pos);
+         else
+            css_consume_string(p, prop, sizeof(prop), &prop_pos);
+         continue;
+      }
+      if (ch == '}' && paren_depth == 0)
+      {
+         css_advance(p);
+         break;
+      }
+      if (ch == '{' && paren_depth == 0)
+      {
+         /* CSS nesting: declarations can't be computed flatly here. */
+         r->specificity_uncertain = 1;
+         int depth = 1;
+         css_advance(p);
+         while (p->i < p->len && depth > 0)
+         {
+            if (css_skip_comment(p))
+               continue;
+            if (p->s[p->i] == '"' || p->s[p->i] == '\'')
+            {
+               css_consume_string(p, NULL, 0, NULL);
+               continue;
+            }
+            if (p->s[p->i] == '{')
+               depth++;
+            else if (p->s[p->i] == '}')
+               depth--;
+            css_advance(p);
+         }
+         prop_pos = val_pos = 0;
+         in_value = 0;
+         continue;
+      }
+      if (ch == ':' && !in_value)
+      {
+         in_value = 1;
+         css_advance(p);
+         continue;
+      }
+      if (ch == '(' && in_value)
+      {
+         paren_depth++;
+         css_buf_putc(val, sizeof(val), &val_pos, ch);
+         css_advance(p);
+         continue;
+      }
+      if (ch == ')' && in_value)
+      {
+         if (paren_depth > 0)
+            paren_depth--;
+         css_buf_putc(val, sizeof(val), &val_pos, ch);
+         css_advance(p);
+         continue;
+      }
+      if (ch == ';' && paren_depth == 0)
+      {
+         css_advance(p);
+         css_emit_decl(r, prop, &prop_pos, val, &val_pos);
+         in_value = 0;
+         continue;
+      }
+      if (in_value)
+      {
+         if (!(val_pos == 0 && isspace((unsigned char)ch)))
+            css_buf_putc(val, sizeof(val), &val_pos, ch);
+      }
+      else if (!isspace((unsigned char)ch) || prop_pos > 0)
+         css_buf_putc(prop, sizeof(prop), &prop_pos, ch);
+      css_advance(p);
+   }
+
+   /* trailing declaration without a closing ';' */
+   if (in_value)
+      css_emit_decl(r, prop, &prop_pos, val, &val_pos);
+}
+
+/* Skip a balanced { ... } block without capturing (for @keyframes etc.). */
+static void css_skip_block(css_parser_t *p)
+{
+   if (p->i >= p->len || p->s[p->i] != '{')
+      return;
+   int depth = 1;
+   css_advance(p);
+   while (p->i < p->len && depth > 0)
+   {
+      if (css_skip_comment(p))
+         continue;
+      if (p->s[p->i] == '{')
+         depth++;
+      else if (p->s[p->i] == '}')
+         depth--;
+      css_advance(p);
+   }
+}
+
+/* Split a selector list on top-level commas and emit one rule per selector,
+ * each sharing a copy of `decls`. */
+static void css_emit_rules(css_stylesheet_t *ss, const char *sel_list, int line,
+                           const char *at_context, css_declaration_t *decls, int decl_count)
+{
+   size_t len = strlen(sel_list);
+   size_t p = 0;
+   int emitted = 0;
+   while (p <= len && emitted < CSS_MAX_SELECTORS_LIST)
+   {
+      size_t q = p;
+      int depth = 0;
+      while (q < len)
+      {
+         char ch = sel_list[q];
+         if (ch == '(' || ch == '[')
+            depth++;
+         else if (ch == ')' || ch == ']')
+            depth--;
+         else if (ch == ',' && depth == 0)
+            break;
+         q++;
+      }
+      /* trim one selector [p,q) */
+      size_t a = p, bnd = q;
+      while (a < bnd && isspace((unsigned char)sel_list[a]))
+         a++;
+      while (bnd > a && isspace((unsigned char)sel_list[bnd - 1]))
+         bnd--;
+      if (bnd > a)
+      {
+         css_rule_t *r = css_ss_add_rule(ss);
+         if (!r)
+            return;
+         size_t sl = bnd - a;
+         if (sl > CSS_SELECTOR_MAX - 1)
+            sl = CSS_SELECTOR_MAX - 1;
+         memcpy(r->selector, sel_list + a, sl);
+         r->selector[sl] = '\0';
+         r->line = line;
+         snprintf(r->at_context, sizeof(r->at_context), "%s", at_context ? at_context : "");
+         int ua = 0, ub = 0, uc = 0, un = 0;
+         css_spec_scan(r->selector, strlen(r->selector), &ua, &ub, &uc, &un);
+         r->spec_a = ua;
+         r->spec_b = ub;
+         r->spec_c = uc;
+         r->specificity_uncertain = un;
+         if (decl_count > 0)
+         {
+            r->decls = malloc((size_t)decl_count * sizeof(css_declaration_t));
+            if (r->decls)
+            {
+               memcpy(r->decls, decls, (size_t)decl_count * sizeof(css_declaration_t));
+               r->decl_count = decl_count;
+            }
+         }
+         emitted++;
+      }
+      if (q >= len)
+         break;
+      p = q + 1;
+   }
+}
+
+css_stylesheet_t *css_analyze(const char *text, size_t len)
+{
+   if (!text)
+      return NULL;
+   css_stylesheet_t *ss = css_ss_new();
+   if (!ss)
+      return NULL;
+
+   css_parser_t p = {text, len, 0, 1};
+
+   /* at-context stack: innermost prelude + the depth at which it was pushed */
+   char atctx[CSS_ATCONTEXT_MAX] = "";
+   int atctx_block_depth[64];
+   char atctx_stack[64][CSS_ATCONTEXT_MAX];
+   int atctx_top = 0;
+   int brace_depth = 0;
+
+   char prelude[CSS_SELECTOR_MAX];
+   size_t prelude_pos = 0;
+   int prelude_line = 1;
+
+   while (p.i < p.len)
+   {
+      if (css_skip_comment(&p))
+         continue;
+      /* A quoted string in a selector (e.g. [data-x="}"]) holds structural
+       * chars that are not syntax — consume it verbatim into the prelude. */
+      if (p.s[p.i] == '"' || p.s[p.i] == '\'')
+      {
+         if (prelude_pos == 0)
+            prelude_line = p.line;
+         css_consume_string(&p, prelude, sizeof(prelude), &prelude_pos);
+         continue;
+      }
+      char ch = p.s[p.i];
+
+      if (ch == '{')
+      {
+         prelude[prelude_pos] = '\0';
+         /* trim prelude */
+         size_t a = 0, b = prelude_pos;
+         while (a < b && isspace((unsigned char)prelude[a]))
+            a++;
+         while (b > a && isspace((unsigned char)prelude[b - 1]))
+            b--;
+         char trimmed[CSS_SELECTOR_MAX];
+         size_t tl = b - a;
+         if (tl > sizeof(trimmed) - 1)
+            tl = sizeof(trimmed) - 1;
+         memcpy(trimmed, prelude + a, tl);
+         trimmed[tl] = '\0';
+
+         if (trimmed[0] == '@')
+         {
+            /* classify the at-rule */
+            char kw[32];
+            size_t k = 0;
+            for (size_t j = 1; j < tl && k < sizeof(kw) - 1 && css_ident_char(trimmed[j]); j++)
+               kw[k++] = (char)tolower((unsigned char)trimmed[j]);
+            kw[k] = '\0';
+            if (strcmp(kw, "media") == 0 || strcmp(kw, "supports") == 0 ||
+                strcmp(kw, "layer") == 0 || strcmp(kw, "container") == 0 ||
+                strcmp(kw, "scope") == 0)
+            {
+               /* context block: push, recurse into inner rules */
+               brace_depth++;
+               if (atctx_top < 64)
+               {
+                  snprintf(atctx_stack[atctx_top], CSS_ATCONTEXT_MAX, "%s", trimmed);
+                  atctx_block_depth[atctx_top] = brace_depth;
+                  atctx_top++;
+               }
+               /* rebuild combined context (innermost shown) */
+               snprintf(atctx, sizeof(atctx), "%s",
+                        atctx_top > 0 ? atctx_stack[atctx_top - 1] : "");
+               css_advance(&p); /* consume '{' */
+               prelude_pos = 0;
+               continue;
+            }
+            if (strcmp(kw, "font-face") == 0 || strcmp(kw, "page") == 0)
+            {
+               /* declaration block with a synthetic selector */
+               css_rule_t *r = css_ss_add_rule(ss);
+               if (r)
+               {
+                  snprintf(r->selector, sizeof(r->selector), "%s", trimmed);
+                  r->line = prelude_line;
+                  snprintf(r->at_context, sizeof(r->at_context), "%s", atctx);
+                  r->specificity_uncertain = 1; /* at-rule, not a real selector */
+                  css_parse_decl_block(&p, r);
+               }
+               else
+                  css_skip_block(&p);
+               prelude_pos = 0;
+               continue;
+            }
+            /* @keyframes / unknown at-rule with a block: skip its contents */
+            css_skip_block(&p);
+            prelude_pos = 0;
+            continue;
+         }
+
+         /* normal selector list → declaration block */
+         {
+            css_rule_t scratch;
+            memset(&scratch, 0, sizeof(scratch));
+            css_parse_decl_block(&p, &scratch);
+            css_emit_rules(ss, trimmed, prelude_line, atctx, scratch.decls, scratch.decl_count);
+            /* propagate nesting-uncertainty to the emitted rules */
+            if (scratch.specificity_uncertain)
+               for (int ri = ss->rule_count - 1; ri >= 0 && ss->rules[ri].line == prelude_line;
+                    ri--)
+                  ss->rules[ri].specificity_uncertain = 1;
+            free(scratch.decls);
+         }
+         prelude_pos = 0;
+         continue;
+      }
+
+      if (ch == '}')
+      {
+         /* pop any at-context opened at this depth */
+         if (atctx_top > 0 && atctx_block_depth[atctx_top - 1] == brace_depth)
+            atctx_top--;
+         if (brace_depth > 0)
+            brace_depth--;
+         snprintf(atctx, sizeof(atctx), "%s", atctx_top > 0 ? atctx_stack[atctx_top - 1] : "");
+         css_advance(&p);
+         prelude_pos = 0;
+         continue;
+      }
+
+      if (ch == ';')
+      {
+         /* a statement at-rule (@import/@charset/@namespace) or stray ';' */
+         css_advance(&p);
+         prelude_pos = 0;
+         continue;
+      }
+
+      if (prelude_pos == 0 && !isspace((unsigned char)ch))
+         prelude_line = p.line;
+      if (!(prelude_pos == 0 && isspace((unsigned char)ch)))
+         css_buf_putc(prelude, sizeof(prelude), &prelude_pos, ch);
+      css_advance(&p);
+   }
+
+   return ss;
+}
+
+void css_stylesheet_free(css_stylesheet_t *ss)
+{
+   if (!ss)
+      return;
+   for (int i = 0; i < ss->rule_count; i++)
+      free(ss->rules[i].decls);
+   free(ss->rules);
+   free(ss);
+}

--- a/src/headers/css_analyze.h
+++ b/src/headers/css_analyze.h
@@ -1,0 +1,73 @@
+/* css_analyze.h: CSS-aware structural analyzer (style graph).
+ *
+ * Parses plain CSS text into a style graph: rules (selector + computed
+ * specificity + at-rule context + source line) and their declarations
+ * (property/value/!important). This is WP-A of the CSS migration assistant
+ * (docs/proposals/pending/css-migration-assistant.md §1) and is a pure leaf
+ * module: it depends only on libc and never touches the DB or the indexer.
+ *
+ * Scope: plain CSS only. SCSS/LESS are supersets whose final declarations and
+ * specificity cannot be computed without compiling them — those are indexed
+ * from their compiled CSS output, not their source (see WP-C). Selector
+ * constructs outside the handled subset set `specificity_uncertain` on the
+ * rule rather than guessing, so downstream signals can treat them
+ * conservatively. The parser never crashes on malformed input; over-long
+ * tokens truncate and pathological input is bounded by hard caps.
+ */
+#ifndef DEC_CSS_ANALYZE_H
+#define DEC_CSS_ANALYZE_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define CSS_SELECTOR_MAX  1024
+#define CSS_PROPERTY_MAX  128
+#define CSS_VALUE_MAX     1024
+#define CSS_ATCONTEXT_MAX 256
+
+   typedef struct
+   {
+      char property[CSS_PROPERTY_MAX];
+      char value[CSS_VALUE_MAX];
+      int important; /* 1 if the declaration carried !important */
+   } css_declaration_t;
+
+   typedef struct
+   {
+      char selector[CSS_SELECTOR_MAX];    /* a single selector; comma lists are split */
+      int spec_a;                         /* specificity: #id count */
+      int spec_b;                         /* specificity: class / attr / pseudo-class count */
+      int spec_c;                         /* specificity: type / pseudo-element count */
+      int specificity_uncertain;          /* 1 = used a construct we cannot weight precisely */
+      char at_context[CSS_ATCONTEXT_MAX]; /* enclosing @media/@supports/@layer prelude, or "" */
+      int line;                           /* 1-based line of the rule's selector */
+      css_declaration_t *decls;
+      int decl_count;
+   } css_rule_t;
+
+   typedef struct
+   {
+      css_rule_t *rules;
+      int rule_count;
+      int truncated; /* 1 = input hit a hard cap and parsing stopped early */
+   } css_stylesheet_t;
+
+   /* Parse CSS source (text, len) into a style graph. Returns NULL only on
+    * allocation failure or NULL input. Free with css_stylesheet_free. */
+   css_stylesheet_t *css_analyze(const char *text, size_t len);
+   void css_stylesheet_free(css_stylesheet_t *ss);
+
+   /* Compute CSS specificity (a,b,c) for ONE selector (no comma lists). Sets
+    * *uncertain to 1 when the selector contains constructs outside the handled
+    * subset. Any out-param may be non-NULL; all are written. Exposed for tests. */
+   void css_selector_specificity(const char *selector, int *a, int *b, int *c, int *uncertain);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CSS_ANALYZE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -89,6 +89,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-session-search-tool \
                $(TESTPREFIX)/unit-test-working-memory $(TESTPREFIX)/unit-test-working-memory-mock $(TESTPREFIX)/unit-test-local-resolution $(TESTPREFIX)/unit-test-cognify-jobs $(TESTPREFIX)/unit-test-extractors-extra \
+               $(TESTPREFIX)/unit-test-css-analyze \
                $(TESTPREFIX)/unit-test-compute-pool $(TESTPREFIX)/unit-test-db2-pool $(TESTPREFIX)/unit-test-cli-launch \
                $(TESTPREFIX)/unit-test-server-session-pools \
                $(TESTPREFIX)/unit-test-presence \
@@ -596,6 +597,10 @@ $(TESTPREFIX)/unit-test-extractors: $(OBJDIR)/tests/test_extractors.o $(OBJDIR)/
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # --- New tests ---
+
+# CSS analyzer (WP-A) — pure leaf, depends only on css_analyze.o + libc.
+$(TESTPREFIX)/unit-test-css-analyze: $(OBJDIR)/tests/test_css_analyze.o $(OBJDIR)/css_analyze.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-text: $(OBJDIR)/tests/test_text.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                      $(OBJDIR)/cJSON.o

--- a/src/tests/test_css_analyze.c
+++ b/src/tests/test_css_analyze.c
@@ -1,0 +1,198 @@
+/* test_css_analyze.c: WP-A CSS analyzer — specificity math, rule/declaration
+ * parsing, at-rule context, !important, and malformed-input resilience. */
+#include "css_analyze.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void spec(const char *sel, int a, int b, int c, int uncertain)
+{
+   int ra, rb, rc, ru;
+   css_selector_specificity(sel, &ra, &rb, &rc, &ru);
+   if (ra != a || rb != b || rc != c || ru != uncertain)
+      fprintf(stderr, "spec('%s') = (%d,%d,%d) u=%d, expected (%d,%d,%d) u=%d\n", sel, ra, rb, rc,
+              ru, a, b, c, uncertain);
+   assert(ra == a && rb == b && rc == c && ru == uncertain);
+}
+
+static void test_specificity(void)
+{
+   spec("#id", 1, 0, 0, 0);
+   spec(".cls", 0, 1, 0, 0);
+   spec("div", 0, 0, 1, 0);
+   spec("*", 0, 0, 0, 0);
+   spec("#a .b div", 1, 1, 1, 0);
+   spec("ul li", 0, 0, 2, 0);
+   spec("a:hover", 0, 1, 1, 0);           /* type + pseudo-class */
+   spec("div::before", 0, 0, 2, 0);       /* type + pseudo-element */
+   spec("[data-x]", 0, 1, 0, 0);          /* attribute */
+   spec("a[href='x']", 0, 1, 1, 0);       /* type + attr (quoted, contains no specials) */
+   spec(".a > .b + .c ~ .d", 0, 4, 0, 0); /* combinators don't add */
+   spec(".a.b.c", 0, 3, 0, 0);            /* compound */
+   /* functional pseudo-classes */
+   spec(":where(#x, .y)", 0, 0, 0, 0);                /* :where contributes 0 */
+   spec(":is(#x, .y)", 1, 0, 0, 0);                   /* :is = max of args = #x */
+   spec(":not(.a, #b)", 1, 0, 0, 0);                  /* :not = max of args = #b */
+   spec("a:is(.x):hover", 0, 2, 1, 0);                /* type + :is(.x)=class + :hover=class */
+   spec(":nth-child(2n+1)", 0, 1, 0, 0);              /* nth-* is one pseudo-class */
+   spec("li:nth-child(odd of .visible)", 0, 1, 1, 1); /* "of S" → uncertain */
+   spec("&.x", 0, 1, 0, 1);                           /* nesting selector → uncertain */
+}
+
+static const css_rule_t *find_rule(const css_stylesheet_t *ss, const char *sel)
+{
+   for (int i = 0; i < ss->rule_count; i++)
+      if (strcmp(ss->rules[i].selector, sel) == 0)
+         return &ss->rules[i];
+   return NULL;
+}
+
+static void test_basic_parse(void)
+{
+   const char *css = ".btn {\n"
+                     "  color: red;\n"
+                     "  margin: 0 auto !important;\n"
+                     "}\n"
+                     "#main, .side > a { display: block; }\n";
+   css_stylesheet_t *ss = css_analyze(css, strlen(css));
+   assert(ss);
+   /* .btn + (#main) + (.side > a) = 3 rules */
+   assert(ss->rule_count == 3);
+
+   const css_rule_t *btn = find_rule(ss, ".btn");
+   assert(btn);
+   assert(btn->spec_a == 0 && btn->spec_b == 1 && btn->spec_c == 0);
+   assert(btn->line == 1);
+   assert(btn->decl_count == 2);
+   assert(strcmp(btn->decls[0].property, "color") == 0);
+   assert(strcmp(btn->decls[0].value, "red") == 0);
+   assert(btn->decls[0].important == 0);
+   assert(strcmp(btn->decls[1].property, "margin") == 0);
+   assert(strcmp(btn->decls[1].value, "0 auto") == 0);
+   assert(btn->decls[1].important == 1);
+
+   /* comma list split into two distinct rules with their own specificity */
+   const css_rule_t *main_r = find_rule(ss, "#main");
+   const css_rule_t *side_r = find_rule(ss, ".side > a");
+   assert(main_r && side_r);
+   assert(main_r->spec_a == 1);
+   assert(side_r->spec_b == 1 && side_r->spec_c == 1);
+   assert(main_r->decl_count == 1 && side_r->decl_count == 1);
+   assert(strcmp(side_r->decls[0].property, "display") == 0);
+
+   css_stylesheet_free(ss);
+}
+
+static void test_at_context(void)
+{
+   const char *css =
+       "@media (min-width: 600px) {\n"
+       "  .col { width: 50%; }\n"
+       "}\n"
+       ".col { width: 100%; }\n"
+       "@font-face { font-family: Foo; src: url(x.woff); }\n"
+       "@keyframes spin { from { transform: rotate(0); } to { transform: rotate(1turn); } }\n";
+   css_stylesheet_t *ss = css_analyze(css, strlen(css));
+   assert(ss);
+
+   /* two `.col` rules: one inside @media, one at top level */
+   int in_media = 0, top = 0;
+   for (int i = 0; i < ss->rule_count; i++)
+   {
+      if (strcmp(ss->rules[i].selector, ".col") == 0)
+      {
+         if (strstr(ss->rules[i].at_context, "@media"))
+            in_media++;
+         else if (ss->rules[i].at_context[0] == '\0')
+            top++;
+      }
+   }
+   assert(in_media == 1 && top == 1);
+
+   /* @font-face captured as a synthetic rule with declarations */
+   const css_rule_t *ff = find_rule(ss, "@font-face");
+   assert(ff && ff->decl_count == 2 && ff->specificity_uncertain == 1);
+
+   /* @keyframes inner blocks are skipped, not parsed as rules */
+   for (int i = 0; i < ss->rule_count; i++)
+      assert(strcmp(ss->rules[i].selector, "from") != 0 &&
+             strcmp(ss->rules[i].selector, "to") != 0);
+
+   css_stylesheet_free(ss);
+}
+
+static void test_malformed_resilience(void)
+{
+   /* Unterminated rule, unbalanced braces/parens, stray chars — must not crash. */
+   const char *bad[] = {".x { color: red",            /* missing close brace + ; */
+                        "}}}{{{ .a { b",              /* garbage braces */
+                        ".y:is(.a, { color: blue; }", /* unbalanced paren in selector */
+                        "/* unclosed comment .z { color: x;",
+                        "",
+                        "@media",
+                        ".w { --v: ; ; ; }",
+                        NULL};
+   for (int i = 0; bad[i]; i++)
+   {
+      css_stylesheet_t *ss = css_analyze(bad[i], strlen(bad[i]));
+      assert(ss); /* returns a (possibly empty) graph, never crashes */
+      css_stylesheet_free(ss);
+   }
+   /* NULL input → NULL, no crash */
+   assert(css_analyze(NULL, 0) == NULL);
+}
+
+static void test_custom_properties_and_important(void)
+{
+   const char *css = ":root { --brand: #fff; --gap: 8px; }\n"
+                     ".a { color: var(--brand) !important; }\n";
+   css_stylesheet_t *ss = css_analyze(css, strlen(css));
+   assert(ss);
+   const css_rule_t *root = find_rule(ss, ":root");
+   assert(root && root->decl_count == 2);
+   assert(strcmp(root->decls[0].property, "--brand") == 0);
+   assert(strcmp(root->decls[0].value, "#fff") == 0);
+   const css_rule_t *a = find_rule(ss, ".a");
+   assert(a && a->decl_count == 1);
+   assert(a->decls[0].important == 1);
+   assert(strcmp(a->decls[0].value, "var(--brand)") == 0);
+   css_stylesheet_free(ss);
+}
+
+/* Structural characters inside strings / url() must not be mis-read as syntax. */
+static void test_strings_and_urls(void)
+{
+   const char *css = ".a {\n"
+                     "  background: url(data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=) no-repeat;\n"
+                     "  color: red;\n"
+                     "}\n"
+                     ".b::before { content: \"};{\"; display: block; }\n";
+   css_stylesheet_t *ss = css_analyze(css, strlen(css));
+   assert(ss);
+
+   const css_rule_t *a = find_rule(ss, ".a");
+   assert(a && a->decl_count == 2); /* the ';' inside url() did not split */
+   assert(strcmp(a->decls[0].property, "background") == 0);
+   assert(strstr(a->decls[0].value, "base64,PHN2Zz48L3N2Zz4=") != NULL);
+   assert(strcmp(a->decls[1].property, "color") == 0);
+
+   const css_rule_t *b = find_rule(ss, ".b::before");
+   assert(b && b->decl_count == 2); /* the '}' and ';' inside content did not break the block */
+   assert(strcmp(b->decls[0].property, "content") == 0);
+   assert(strcmp(b->decls[1].property, "display") == 0);
+   assert(b->spec_b == 1 && b->spec_c == 1); /* .b class + ::before pseudo-element */
+   css_stylesheet_free(ss);
+}
+
+int main(void)
+{
+   test_specificity();
+   test_basic_parse();
+   test_at_context();
+   test_malformed_resilience();
+   test_custom_properties_and_important();
+   test_strings_and_urls();
+   printf("css_analyze: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
**WP-A** of the approved CSS migration assistant (`docs/proposals/pending/css-migration-assistant.md` §1, plan WP-A). First of the buildable-core packets (#1 style graph → #3 join → #4-interim oracle → #5 pipeline).

A pure **leaf** module (`src/css_analyze.{c,h}`, libc only — no DB, no indexer) parsing plain CSS into a **style graph**:
- **Rules**: selector, computed **specificity** `(a,b,c)`, at-rule context (`@media`/`@supports`/`@layer`/`@container`/`@scope`), source line. Comma selector lists → one rule each.
- **Declarations**: property / value / `!important`, bound to their rule.
- **Specificity engine** handles the hard cases the plan flagged as the biggest risk: `:where()`=0, `:is()`/`:not()`/`:has()`=max-of-args, pseudo-element vs pseudo-class weighting, attribute selectors, combinators, `:nth-*(... of S)`. Anything outside the handled subset (CSS nesting `&`, `:nth … of`, stray punctuation) sets `specificity_uncertain` rather than guessing — downstream signals treat uncertain rows conservatively.
- **Real-world-CSS robust**: strings and `url()`/parens consumed verbatim, so structural chars inside `content:"}"` or `url(data:…;base64,…)` aren't mis-read. Never crashes on malformed input (truncates over-long tokens; rule count hard-capped with a `truncated` flag; amortized-O(n) growth for large generated stylesheets like Tailwind output).
- **SCSS explicitly out of scope** (compiled-CSS only; dispatch wired in WP-C).

Not yet called — `css_analyze.{c,h}` is added to `DATA_SRCS` + `KB_DATA_SRCS` (compiles into the indexer object sets); WP-C wires it into the extractor dispatch behind a default-off `css_style_graph_enabled` flag.

**Tests** (`test_css_analyze`, registered in `TEST_TARGETS` so it builds *and* runs): specificity math, parse + at-context, `!important`, strings/url, malformed-input resilience. `aimee-server` links clean.
