### PR TITLE
feat(css): WP-E interim static oracle — declaration-set equivalence (migration assistant #4-interim)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -316,7 +316,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c \
+            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
@@ -411,7 +411,7 @@ KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c \
+               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_PLATFORM_OBJS = $(PLATFORM_BASIC_OBJS) $(filter %/agent_bridge.o %/cli_client.o %/memory.o,$(PLATFORM_EXTRA_OBJS) $(PLATFORM_AGENT_OBJS))

--- a/src/css_oracle.c
+++ b/src/css_oracle.c
@@ -1,0 +1,196 @@
+/* css_oracle.c: interim static declaration-set equivalence oracle. See css_oracle.h. */
+#include "css_oracle.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *CSS_ORACLE_BANNER =
+    "STATIC declaration-set equivalence only: this oracle compares the resolved "
+    "property:value sets and CANNOT see cascade/layout interactions that require "
+    "rendering, nor does it expand shorthands. Differences it cannot prove equal "
+    "are reported as changes (conservative). Use the full computed-style oracle "
+    "for final sign-off.";
+
+const char *css_oracle_limitation_banner(void)
+{
+   return CSS_ORACLE_BANNER;
+}
+
+/* A resolved property entry after cascade collapse. */
+typedef struct
+{
+   char property[CSS_PROPERTY_MAX];
+   char value[CSS_VALUE_MAX];
+   int important;
+} css_resolved_t;
+
+/* Lowercase + trim a property name; collapse internal whitespace in a value.
+ * CSS property names are case-insensitive; values are kept verbatim except for
+ * whitespace normalization (so "0  auto" == "0 auto"). */
+static void css_norm_property(const char *in, char *out, size_t cap)
+{
+   while (*in && isspace((unsigned char)*in))
+      in++;
+   size_t j = 0;
+   for (; *in && j < cap - 1; in++)
+      out[j++] = (char)tolower((unsigned char)*in);
+   while (j > 0 && isspace((unsigned char)out[j - 1]))
+      j--;
+   out[j] = '\0';
+}
+
+static void css_norm_value(const char *in, char *out, size_t cap)
+{
+   while (*in && isspace((unsigned char)*in))
+      in++;
+   size_t j = 0;
+   int prev_space = 0;
+   for (; *in && j < cap - 1; in++)
+   {
+      if (isspace((unsigned char)*in))
+      {
+         if (!prev_space && j > 0)
+            out[j++] = ' ';
+         prev_space = 1;
+      }
+      else
+      {
+         out[j++] = *in;
+         prev_space = 0;
+      }
+   }
+   while (j > 0 && out[j - 1] == ' ')
+      j--;
+   out[j] = '\0';
+}
+
+static css_resolved_t *resolve_find(css_resolved_t *set, int n, const char *prop)
+{
+   for (int i = 0; i < n; i++)
+      if (strcmp(set[i].property, prop) == 0)
+         return &set[i];
+   return NULL;
+}
+
+/* Collapse a declaration list to the cascade-resolved property set. Within one
+ * unit, the winner per property is: !important beats non-important; among equal
+ * importance, later source order wins. Returns the count; set must hold >= n. */
+static int css_oracle_resolve(const css_declaration_t *decls, int n, css_resolved_t *set)
+{
+   int count = 0;
+   for (int i = 0; i < n && decls; i++)
+   {
+      char prop[CSS_PROPERTY_MAX];
+      css_norm_property(decls[i].property, prop, sizeof(prop));
+      if (!prop[0])
+         continue;
+      css_resolved_t *e = resolve_find(set, count, prop);
+      int imp = decls[i].important ? 1 : 0;
+      if (!e)
+      {
+         e = &set[count++];
+         snprintf(e->property, sizeof(e->property), "%s", prop);
+         css_norm_value(decls[i].value, e->value, sizeof(e->value));
+         e->important = imp;
+      }
+      else if (imp || !e->important)
+      {
+         /* new important always wins; equal importance -> later wins; a
+          * non-important never overrides an existing important. */
+         css_norm_value(decls[i].value, e->value, sizeof(e->value));
+         e->important = imp;
+      }
+   }
+   return count;
+}
+
+static void oracle_add_diff(css_oracle_result_t *r, int *cap, const char *prop, const char *bval,
+                            int bimp, const char *aval, int aimp, css_oracle_diff_kind_t kind)
+{
+   if (r->diff_count >= *cap)
+   {
+      int nc = *cap == 0 ? 8 : *cap * 2;
+      css_oracle_diff_t *grown = realloc(r->diffs, (size_t)nc * sizeof(css_oracle_diff_t));
+      if (!grown)
+         return;
+      r->diffs = grown;
+      *cap = nc;
+   }
+   css_oracle_diff_t *d = &r->diffs[r->diff_count++];
+   memset(d, 0, sizeof(*d));
+   snprintf(d->property, sizeof(d->property), "%s", prop);
+   snprintf(d->before_value, sizeof(d->before_value), "%s", bval ? bval : "");
+   snprintf(d->after_value, sizeof(d->after_value), "%s", aval ? aval : "");
+   d->before_important = bimp;
+   d->after_important = aimp;
+   d->kind = kind;
+}
+
+css_oracle_result_t *css_oracle_compare(const css_declaration_t *before, int nbefore,
+                                        const css_declaration_t *after, int nafter)
+{
+   css_oracle_result_t *r = calloc(1, sizeof(*r));
+   if (!r)
+      return NULL;
+   r->limitation = CSS_ORACLE_BANNER;
+   r->equivalent = 1;
+
+   css_resolved_t *bset = NULL, *aset = NULL;
+   int nb = 0, na = 0;
+   if (nbefore > 0)
+   {
+      bset = calloc((size_t)nbefore, sizeof(css_resolved_t));
+      if (!bset)
+      {
+         free(r);
+         return NULL;
+      }
+      nb = css_oracle_resolve(before, nbefore, bset);
+   }
+   if (nafter > 0)
+   {
+      aset = calloc((size_t)nafter, sizeof(css_resolved_t));
+      if (!aset)
+      {
+         free(bset);
+         free(r);
+         return NULL;
+      }
+      na = css_oracle_resolve(after, nafter, aset);
+   }
+
+   int cap = 0;
+   /* changed + removed: walk BEFORE */
+   for (int i = 0; i < nb; i++)
+   {
+      css_resolved_t *a = resolve_find(aset, na, bset[i].property);
+      if (!a)
+         oracle_add_diff(r, &cap, bset[i].property, bset[i].value, bset[i].important, "", 0,
+                         CSS_ORACLE_REMOVED);
+      else if (strcmp(bset[i].value, a->value) != 0 || bset[i].important != a->important)
+         oracle_add_diff(r, &cap, bset[i].property, bset[i].value, bset[i].important, a->value,
+                         a->important, CSS_ORACLE_CHANGED);
+   }
+   /* added: properties in AFTER not in BEFORE */
+   for (int i = 0; i < na; i++)
+   {
+      if (!resolve_find(bset, nb, aset[i].property))
+         oracle_add_diff(r, &cap, aset[i].property, "", 0, aset[i].value, aset[i].important,
+                         CSS_ORACLE_ADDED);
+   }
+
+   r->equivalent = (r->diff_count == 0);
+   free(bset);
+   free(aset);
+   return r;
+}
+
+void css_oracle_result_free(css_oracle_result_t *r)
+{
+   if (!r)
+      return;
+   free(r->diffs);
+   free(r);
+}

--- a/src/headers/css_oracle.h
+++ b/src/headers/css_oracle.h
@@ -1,0 +1,66 @@
+/* css_oracle.h: interim static declaration-set equivalence oracle (WP-E).
+ *
+ * The real correctness signal for a CSS migration is computed style / box model
+ * before vs. after (the full rendered oracle, #4) — that is a deferred follow-on
+ * needing a headless browser. This interim oracle is the static, render-free
+ * approximation the proposal authorizes (§4): for a unit of conversion it
+ * resolves the BEFORE and AFTER declaration sets (cascade collapse: later wins,
+ * !important takes precedence) and diffs them property by property.
+ *
+ * It is STRICTLY WEAKER than the rendered oracle — it cannot see cascade/layout
+ * interactions that only appear when rendered, and it does NOT expand shorthands
+ * (margin vs margin-top/...). Every result therefore carries an explicit
+ * limitation banner, and the oracle is CONSERVATIVE: anything it cannot prove
+ * equal is reported as a difference (no silent "equivalent", proposal §8). A
+ * pure leaf: depends only on libc + css_analyze.h's css_declaration_t.
+ */
+#ifndef DEC_CSS_ORACLE_H
+#define DEC_CSS_ORACLE_H 1
+
+#include "css_analyze.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      CSS_ORACLE_CHANGED = 1, /* property present in both, value/important differs */
+      CSS_ORACLE_REMOVED = 2, /* resolved in BEFORE, absent in AFTER */
+      CSS_ORACLE_ADDED = 3,   /* absent in BEFORE, resolved in AFTER */
+   } css_oracle_diff_kind_t;
+
+   typedef struct
+   {
+      char property[CSS_PROPERTY_MAX];
+      char before_value[CSS_VALUE_MAX];
+      char after_value[CSS_VALUE_MAX];
+      int before_important;
+      int after_important;
+      css_oracle_diff_kind_t kind;
+   } css_oracle_diff_t;
+
+   typedef struct
+   {
+      int equivalent; /* 1 iff the resolved declaration sets are identical */
+      css_oracle_diff_t *diffs;
+      int diff_count;
+      const char *limitation; /* static banner; not owned by the caller */
+   } css_oracle_result_t;
+
+   /* Compare two declaration sets after cascade resolution. Returns NULL only on
+    * allocation failure. Free with css_oracle_result_free. */
+   css_oracle_result_t *css_oracle_compare(const css_declaration_t *before, int nbefore,
+                                           const css_declaration_t *after, int nafter);
+
+   void css_oracle_result_free(css_oracle_result_t *r);
+
+   /* The limitation banner text (also reachable via result->limitation). */
+   const char *css_oracle_limitation_banner(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CSS_ORACLE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -89,7 +89,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-session-search-tool \
                $(TESTPREFIX)/unit-test-working-memory $(TESTPREFIX)/unit-test-working-memory-mock $(TESTPREFIX)/unit-test-local-resolution $(TESTPREFIX)/unit-test-cognify-jobs $(TESTPREFIX)/unit-test-extractors-extra \
-               $(TESTPREFIX)/unit-test-css-analyze $(TESTPREFIX)/unit-test-css-graph \
+               $(TESTPREFIX)/unit-test-css-analyze $(TESTPREFIX)/unit-test-css-graph $(TESTPREFIX)/unit-test-css-oracle \
                $(TESTPREFIX)/unit-test-compute-pool $(TESTPREFIX)/unit-test-db2-pool $(TESTPREFIX)/unit-test-cli-launch \
                $(TESTPREFIX)/unit-test-server-session-pools \
                $(TESTPREFIX)/unit-test-presence \
@@ -611,6 +611,10 @@ $(TESTPREFIX)/unit-test-extractors: $(OBJDIR)/tests/test_extractors.o $(OBJDIR)/
 
 # CSS analyzer (WP-A) — pure leaf, depends only on css_analyze.o + libc.
 $(TESTPREFIX)/unit-test-css-analyze: $(OBJDIR)/tests/test_css_analyze.o $(OBJDIR)/css_analyze.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# CSS interim static oracle (WP-E) — leaf: css_oracle.o + css_analyze.o + libc.
+$(TESTPREFIX)/unit-test-css-oracle: $(OBJDIR)/tests/test_css_oracle.o $(OBJDIR)/css_oracle.o $(OBJDIR)/css_analyze.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-text: $(OBJDIR)/tests/test_text.o $(OBJDIR)/util.o $(OBJDIR)/text.o \

--- a/src/tests/test_css_oracle.c
+++ b/src/tests/test_css_oracle.c
@@ -1,0 +1,128 @@
+/* test_css_oracle.c: WP-E interim static oracle — cascade resolution, equivalence,
+ * change/add/remove diffs, whitespace normalization, conservative shorthand handling. */
+#include "css_analyze.h"
+#include "css_oracle.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* Parse a single rule body and hand back its declarations (owns the stylesheet
+ * via the returned handle; caller frees with css_stylesheet_free). */
+static css_stylesheet_t *decls_of(const char *body, const css_declaration_t **out, int *n)
+{
+   char css[2048];
+   snprintf(css, sizeof(css), ".x { %s }", body);
+   css_stylesheet_t *ss = css_analyze(css, strlen(css));
+   assert(ss && ss->rule_count == 1);
+   *out = ss->rules[0].decls;
+   *n = ss->rules[0].decl_count;
+   return ss;
+}
+
+static const css_oracle_diff_t *find_diff(const css_oracle_result_t *r, const char *prop)
+{
+   for (int i = 0; i < r->diff_count; i++)
+      if (strcmp(r->diffs[i].property, prop) == 0)
+         return &r->diffs[i];
+   return NULL;
+}
+
+static void test_equivalent_reorder_and_whitespace(void)
+{
+   const css_declaration_t *b, *a;
+   int nb, na;
+   css_stylesheet_t *sb = decls_of("color: red; margin: 0  auto;", &b, &nb);
+   css_stylesheet_t *sa = decls_of("margin: 0 auto; color: red;", &a, &na);
+   css_oracle_result_t *r = css_oracle_compare(b, nb, a, na);
+   assert(r);
+   assert(r->equivalent == 1 && r->diff_count == 0);
+   assert(r->limitation && strstr(r->limitation, "STATIC"));
+   css_oracle_result_free(r);
+   css_stylesheet_free(sb);
+   css_stylesheet_free(sa);
+}
+
+static void test_changed_added_removed(void)
+{
+   const css_declaration_t *b, *a;
+   int nb, na;
+   css_stylesheet_t *sb = decls_of("color: red; padding: 4px;", &b, &nb);
+   css_stylesheet_t *sa = decls_of("color: blue; gap: 8px;", &a, &na);
+   css_oracle_result_t *r = css_oracle_compare(b, nb, a, na);
+   assert(r && r->equivalent == 0);
+   const css_oracle_diff_t *col = find_diff(r, "color");
+   assert(col && col->kind == CSS_ORACLE_CHANGED);
+   assert(strcmp(col->before_value, "red") == 0 && strcmp(col->after_value, "blue") == 0);
+   const css_oracle_diff_t *pad = find_diff(r, "padding");
+   assert(pad && pad->kind == CSS_ORACLE_REMOVED);
+   const css_oracle_diff_t *gap = find_diff(r, "gap");
+   assert(gap && gap->kind == CSS_ORACLE_ADDED);
+   css_oracle_result_free(r);
+   css_stylesheet_free(sb);
+   css_stylesheet_free(sa);
+}
+
+static void test_cascade_resolution(void)
+{
+   const css_declaration_t *b, *a;
+   int nb, na;
+   /* before: later non-important wins -> color:green; important beats later -> z-index:1 */
+   css_stylesheet_t *sb =
+       decls_of("color: red; color: green; z-index: 1 !important; z-index: 9;", &b, &nb);
+   /* after resolves to the same effective set written plainly */
+   css_stylesheet_t *sa = decls_of("color: green; z-index: 1 !important;", &a, &na);
+   css_oracle_result_t *r = css_oracle_compare(b, nb, a, na);
+   assert(r && r->equivalent == 1); /* cascade collapse makes them equivalent */
+   css_oracle_result_free(r);
+   css_stylesheet_free(sb);
+   css_stylesheet_free(sa);
+
+   /* !important mismatch alone is a difference */
+   css_stylesheet_t *s1 = decls_of("color: red;", &b, &nb);
+   css_stylesheet_t *s2 = decls_of("color: red !important;", &a, &na);
+   r = css_oracle_compare(b, nb, a, na);
+   assert(r && r->equivalent == 0);
+   const css_oracle_diff_t *c = find_diff(r, "color");
+   assert(c && c->kind == CSS_ORACLE_CHANGED && c->before_important == 0 &&
+          c->after_important == 1);
+   css_oracle_result_free(r);
+   css_stylesheet_free(s1);
+   css_stylesheet_free(s2);
+}
+
+static void test_shorthand_not_expanded_conservative(void)
+{
+   const css_declaration_t *b, *a;
+   int nb, na;
+   /* The static oracle does NOT expand shorthands: margin vs margin-top/... is
+    * reported as a difference, never a false "equivalent" (no silent caps). */
+   css_stylesheet_t *sb = decls_of("margin: 0;", &b, &nb);
+   css_stylesheet_t *sa =
+       decls_of("margin-top: 0; margin-right: 0; margin-bottom: 0; margin-left: 0;", &a, &na);
+   css_oracle_result_t *r = css_oracle_compare(b, nb, a, na);
+   assert(r && r->equivalent == 0);
+   assert(find_diff(r, "margin") && find_diff(r, "margin")->kind == CSS_ORACLE_REMOVED);
+   assert(find_diff(r, "margin-top") && find_diff(r, "margin-top")->kind == CSS_ORACLE_ADDED);
+   css_oracle_result_free(r);
+   css_stylesheet_free(sb);
+   css_stylesheet_free(sa);
+}
+
+static void test_empty_sets(void)
+{
+   css_oracle_result_t *r = css_oracle_compare(NULL, 0, NULL, 0);
+   assert(r && r->equivalent == 1 && r->diff_count == 0);
+   css_oracle_result_free(r);
+}
+
+int main(void)
+{
+   test_equivalent_reorder_and_whitespace();
+   test_changed_added_removed();
+   test_cascade_resolution();
+   test_shorthand_not_expanded_conservative();
+   test_empty_sets();
+   printf("css_oracle: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
**WP-E** — the render-free correctness oracle the proposal authorizes for the migration (§4, plan WP-E). The full computed-style/box-model oracle (#4) needs a headless browser and stays a deferred follow-on; this interim static oracle unblocks the WP-F pipeline without it.

`src/css_oracle.{c,h}` (pure leaf — libc + `css_analyze.h`'s `css_declaration_t`): `css_oracle_compare(before, after)` collapses each declaration set by the **cascade** (later wins; `!important` precedence) and diffs the resolved `property:value` maps — **CHANGED / ADDED / REMOVED** per property. Property names lowercased, value whitespace normalized (`"0  auto" == "0 auto"`).

**Strictly weaker than rendering, and conservative by design:** it does **not** expand shorthands and cannot see cascade/layout interactions, so anything it cannot prove equal is reported as a difference — never a false "equivalent" (§8). Every result carries an explicit **limitation banner** so WP-F must surface, not imply, full equivalence.

Added to `DATA_SRCS` + `KB_DATA_SRCS` (compiles; not yet called — WP-F consumes it). `test_css_oracle`: equivalent-reorder/whitespace, changed/added/removed, cascade + `!important` resolution, conservative shorthand non-expansion, empty sets. `aimee-server`/kb link clean. Next: **WP-F** pipeline driver (#5) + degraded #2 rules doc.
