### PR TITLE
feat(audit): D7 drift detection — default-off maintenance mode + stale-embed report

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -14,11 +14,16 @@
   (`code_search_hit_t`/`/v1/code/search` carry `content_hash`); the
   `/v1/audit/provenance` read surface + `aimee audit provenance <turn_id>` landed
   next (resolves each surfaced source id to `{id, kind, source, version, present}`,
-  version = the row's live `updated_at`). **Remaining:** P1.5 (typed doc/code refs
-  + two-writer merge), P2's emit-time point-in-time version capture (provenance
-  currently reads versions live) + drift-ranked requeue in `memory_maintenance.c`
-  (D7), P3 (fidelity_check judge + `fidelity_report`), P4 (labelled gold corpus —
-  needs human curation, not autonomous).
+  version = the row's live `updated_at`). Emit-time point-in-time version capture
+  + per-source drift flag landed in #350. The D7 drift *detection* (a default-off
+  `drift` maintenance mode + `db2_code_index_drift_candidates`: count code
+  embeddings whose source file was re-scanned after the embedding, with timestamp-
+  format normalization) landed next. **Remaining:** P1.5 (typed doc/code refs +
+  two-writer merge), D7's actual re-ingest *requeue* (rank/feed `kb_ingest_queue`
+  by the drift candidates — currently detect/report only) + populating
+  `code_embeddings.source_hash` so content-hash (not just staleness) drift is
+  detectable, P3 (fidelity_check judge + `fidelity_report`), P4 (labelled gold
+  corpus — needs human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/cmd_memory_core.c
+++ b/src/cmd_memory_core.c
@@ -828,6 +828,8 @@ static unsigned int mem_maintain_parse_modes(const char *csv)
          modes |= MEMORY_MAINTENANCE_MODE_PRUNE;
       else if (len == 9 && strncmp(start, "summarize", 9) == 0)
          modes |= MEMORY_MAINTENANCE_MODE_SUMMARIZE;
+      else if (len == 5 && strncmp(start, "drift", 5) == 0)
+         modes |= MEMORY_MAINTENANCE_MODE_DRIFT;
    }
    return modes;
 }

--- a/src/db2/code_index_ops.c
+++ b/src/db2/code_index_ops.c
@@ -107,3 +107,36 @@ int db2_code_index_ops_summary(int max_attempts, db2_code_index_ops_summary_t *o
    aimee_pg_finalize(st);
    return 0;
 }
+
+int64_t db2_code_index_drift_candidates(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   /* auditable-correctness D7 (staleness heuristic): a code embedding is a
+    * re-ingest candidate when its source file was re-scanned AFTER the embedding
+    * was written — files.scanned_at > code_embeddings.updated_at — i.e. the file
+    * changed but its vectors haven't been refreshed yet. Joined within DB2 on
+    * project name + file path. Read-only; ranks/sizes re-ingest, not a verdict.
+    *
+    * Timestamp NORMALIZATION: files.scanned_at is now_utc() ("YYYY-MM-DDTHH:MM:SSZ")
+    * while code_embeddings.updated_at is to_char(...,'YYYY-MM-DD HH24:MI:SS') — a
+    * raw string compare would mis-order ('T' > ' '). Strip the 'T'/'Z' from
+    * scanned_at so both are "YYYY-MM-DD HH:MM:SS" and compare lexically (valid for
+    * zero-padded UTC). replace() is portable across Postgres and the sqlite shim. */
+   static const char *sql =
+       "SELECT COUNT(*) FROM code_embeddings ce"
+       " JOIN projects p ON p.name = ce.project"
+       " JOIN files f ON f.project_id = p.id AND f.path = ce.file_path"
+       " WHERE ce.file_path <> ''"
+       "   AND replace(replace(f.scanned_at, 'T', ' '), 'Z', '') > ce.updated_at";
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   int64_t n = 0;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      n = aimee_pg_column_int64(st, 0);
+   aimee_pg_finalize(st);
+   return n;
+}

--- a/src/db2/code_index_ops.h
+++ b/src/db2/code_index_ops.h
@@ -34,6 +34,12 @@ extern "C"
    /* Summary counts (stuck_ops uses max_attempts as the >= threshold). */
    int db2_code_index_ops_summary(int max_attempts, db2_code_index_ops_summary_t *out);
 
+   /* auditable-correctness D7: count code embeddings whose source file was
+    * re-scanned after the embedding was written (files.scanned_at >
+    * code_embeddings.updated_at) — a staleness heuristic for ranking re-ingest.
+    * Read-only; returns 0 on error / no candidates. */
+   int64_t db2_code_index_drift_candidates(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -1557,6 +1557,11 @@ void memory_recall_metrics(int64_t *assemblies_total, int64_t *session_start_ass
 #define MEMORY_MAINTENANCE_MODE_COMPACT   (1u << 1)
 #define MEMORY_MAINTENANCE_MODE_PRUNE     (1u << 2)
 #define MEMORY_MAINTENANCE_MODE_SUMMARIZE (1u << 3)
+/* auditable-correctness D7: read-only drift report — count code embeddings whose
+ * source file was re-scanned after the embedding was written (a staleness
+ * heuristic ranking re-ingest order, NOT a correctness verdict). Default-off
+ * (not in MODES_DEFAULT); requested explicitly (e.g. `maintenance --mode drift`). */
+#define MEMORY_MAINTENANCE_MODE_DRIFT     (1u << 4)
 
 #define MEMORY_MAINTENANCE_MODES_DEFAULT                                                           \
    (MEMORY_MAINTENANCE_MODE_REPLAY | MEMORY_MAINTENANCE_MODE_COMPACT |                             \
@@ -1579,6 +1584,7 @@ typedef struct
    int profile_cards_refreshed;
    int merged;
    int summarized;
+   int drift_candidates; /* D7: code embeddings whose file was re-scanned since embed */
    double elapsed_ms;
    int64_t memory_count_before;
    int64_t memory_count_after;

--- a/src/memory_maintenance.c
+++ b/src/memory_maintenance.c
@@ -19,6 +19,7 @@
 #if !defined(AIMEE_DB2_DISABLED)
 #include "db2/curiosity.h"
 #include "db2/memory_payload.h"
+#include "db2/code_index_ops.h" /* db2_code_index_drift_candidates (auditable-correctness D7) */
 #endif
 #include "log.h"
 #include "memory.h"
@@ -144,6 +145,7 @@ cJSON *memory_maintenance_summary_to_json(const memory_maintenance_summary_t *su
    cJSON_AddNumberToObject(j, "profile_cards_refreshed", summary->profile_cards_refreshed);
    cJSON_AddNumberToObject(j, "merged", summary->merged);
    cJSON_AddNumberToObject(j, "summarized", summary->summarized);
+   cJSON_AddNumberToObject(j, "drift_candidates", summary->drift_candidates);
    cJSON_AddNumberToObject(j, "elapsed_ms", summary->elapsed_ms);
    cJSON_AddNumberToObject(j, "memory_count_before", (double)summary->memory_count_before);
    cJSON_AddNumberToObject(j, "memory_count_after", (double)summary->memory_count_after);
@@ -294,6 +296,13 @@ int memory_maintenance_run(const config_t *cfg, unsigned int modes, int force, i
             out->summarized = summarized;
       }
    }
+
+   /* auditable-correctness D7: read-only drift report — how many code embeddings
+    * have a source file re-scanned since they were embedded (re-ingest backlog by
+    * staleness). Default-off; runs only when the DRIFT mode is explicitly set. No
+    * mutation, so it is safe under dry_run and not counted as a change. */
+   if (modes & MEMORY_MAINTENANCE_MODE_DRIFT)
+      out->drift_candidates = (int)db2_code_index_drift_candidates();
 
    out->memory_count_after = db2_memory_count();
    clock_gettime(CLOCK_MONOTONIC, &t1);

--- a/src/tests/test_code_index_ops.c
+++ b/src/tests/test_code_index_ops.c
@@ -5,6 +5,8 @@
 #include "aimee.h"
 #include "db2_test_shim.h"
 #include "../db2/code_index_ops.h"
+#include "../db2/db2_internal.h"
+#include "../db2/db_postgres.h"
 
 int main(void)
 {
@@ -31,6 +33,44 @@ int main(void)
    assert(sum.stuck_ops == 0);  /* no longer stuck */
    assert(sum.failed_ops == 1); /* still failed, but retryable */
    printf("  reset-stuck retries a stuck code embed OK\n");
+
+   /* D7 drift detector: a code embedding whose source file was re-scanned after
+    * the embedding was written is a re-ingest candidate. Crucially this exercises
+    * the timestamp-format normalization: files.scanned_at is now_utc() ('...T..Z')
+    * while code_embeddings.updated_at is space-separated, so a raw compare would
+    * mis-order — the detector must normalize before comparing. */
+   {
+      void *conn = db2_conn();
+      char e[256] = "";
+      assert(aimee_pg_exec(
+                 conn, "INSERT INTO projects (name, root, scanned_at) VALUES ('dproj','/x','x')", e,
+                 sizeof e) == 0);
+      /* stale: file re-scanned (2026-06-02, T/Z form) AFTER the embed (2026-06-01, space form) */
+      assert(aimee_pg_exec(conn,
+                           "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                           " ((SELECT id FROM projects WHERE name='dproj'),"
+                           " 'src/stale.c','h','2026-06-02T00:00:00Z')",
+                           e, sizeof e) == 0);
+      assert(aimee_pg_exec(
+                 conn,
+                 "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
+                 " updated_at) VALUES (101,'dproj','src/stale.c','n1','2026-06-01 00:00:00')",
+                 e, sizeof e) == 0);
+      /* fresh: file scanned (2026-06-01) BEFORE the embed (2026-06-02) -> not a candidate */
+      assert(aimee_pg_exec(conn,
+                           "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                           " ((SELECT id FROM projects WHERE name='dproj'),"
+                           " 'src/fresh.c','h','2026-06-01T00:00:00Z')",
+                           e, sizeof e) == 0);
+      assert(aimee_pg_exec(
+                 conn,
+                 "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
+                 " updated_at) VALUES (102,'dproj','src/fresh.c','n2','2026-06-02 00:00:00')",
+                 e, sizeof e) == 0);
+      int64_t drift = db2_code_index_drift_candidates();
+      assert(drift == 1); /* only src/stale.c — format normalization makes the compare correct */
+      printf("  drift detector flags re-scanned-since-embed (got %lld) OK\n", (long long)drift);
+   }
 
    db2_test_shim_close();
    printf("code_index_ops: all tests passed\n");


### PR DESCRIPTION
Continues auditable-correctness **P2 / D7** (the staleness-ranked re-ingest heuristic). Read-only drift **detection + report** (the requeue integration is a noted follow-up).

## What
- `db2_code_index_drift_candidates()` — counts `code_embeddings` whose source file was **re-scanned after** the embedding was written (`files.scanned_at > code_embeddings.updated_at`), joined within DB2 on project name + file path. This is the re-ingest backlog by staleness — a ranking heuristic, *not* a correctness verdict (per D7).
- **Timestamp-format fix (subtle):** `files.scanned_at` is `now_utc()` → `2026-06-16T10:43:20Z`, but `code_embeddings.updated_at` is `to_char(...,'YYYY-MM-DD HH24:MI:SS')` → `2026-06-16 10:43:20`. A raw string `>` mis-orders (`'T' > ' '`). The query normalizes (`replace` the `T`/`Z`) so both are `YYYY-MM-DD HH:MM:SS` and compare lexically. `replace()` is portable across Postgres + the sqlite shim.
- `MEMORY_MAINTENANCE_MODE_DRIFT` (1<<4, **not** in `MODES_DEFAULT`) → `summary.drift_candidates` (+ `summary_json`); requestable via `aimee memory maintenance --mode drift`. Read-only, safe under `dry_run`, not counted as a change.
- `test_code_index_ops`: seeds **mismatched-format** timestamps to prove the normalized compare flags only the genuinely re-scanned-since-embed file (and not a fresh one).

## Verification
`make all`, `make lint`, `make build-integrity`, full `make unit-tests` all green.

## Follow-ups (in the proposal)
The actual re-ingest **requeue** (rank/feed `kb_ingest_queue` from the candidates — currently detect/report only), and populating `code_embeddings.source_hash` so **content-hash** drift (precise) is detectable rather than the file-rescan staleness heuristic.