### PR TITLE
feat(audit): D7 re-ingest requeue — enqueue drifted projects into kb_ingest_queue

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -18,12 +18,15 @@
   + per-source drift flag landed in #350. The D7 drift *detection* (a default-off
   `drift` maintenance mode + `db2_code_index_drift_candidates`: count code
   embeddings whose source file was re-scanned after the embedding, with timestamp-
-  format normalization) landed next. **Remaining:** P1.5 (typed doc/code refs +
-  two-writer merge), D7's actual re-ingest *requeue* (rank/feed `kb_ingest_queue`
-  by the drift candidates — currently detect/report only) + populating
-  `code_embeddings.source_hash` so content-hash (not just staleness) drift is
-  detectable, P3 (fidelity_check judge + `fidelity_report`), P4 (labelled gold
-  corpus — needs human curation, not autonomous).
+  format normalization) landed next, and the D7 re-ingest *requeue* landed after
+  it (`db2_code_index_requeue_drifted`: the `drift` maintenance mode now enqueues
+  each distinct drifted project into `kb_ingest_queue` with `force`, deduped
+  against an already pending/running row, skipped under `dry_run`; reported as
+  `drift_requeued` in the maintenance summary). **Remaining:** P1.5 (typed
+  doc/code refs + two-writer merge), populating `code_embeddings.source_hash` so
+  content-hash (not just staleness) drift is detectable, P3 (fidelity_check judge
+  + `fidelity_report`), P4 (labelled gold corpus — needs human curation, not
+  autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/db2/code_index_ops.c
+++ b/src/db2/code_index_ops.c
@@ -140,3 +140,40 @@ int64_t db2_code_index_drift_candidates(void)
    aimee_pg_finalize(st);
    return n;
 }
+
+int db2_code_index_requeue_drifted(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   /* auditable-correctness D7 requeue: enqueue each distinct drifted project for
+    * re-ingest (force) so the ingest drain re-embeds its changed files. A project
+    * is drifted when it has >=1 drift candidate (file re-scanned since embed, with
+    * the SAME timestamp normalization as db2_code_index_drift_candidates: only
+    * f.scanned_at is now_utc() 'T'/'Z' form, while ce.updated_at is already
+    * space-form to_char output) AND has no pending/running queue row yet (dedup).
+    * projects.name is UNIQUE so DISTINCT p.name yields one p.root per project.
+    * RETURNING makes the returned row set EXACTLY the rows inserted, so the count
+    * cannot drift from a separate COUNT query. MUTATING — callers must skip under
+    * dry_run. Returns the number of projects enqueued. */
+   static const char *sql =
+       "INSERT INTO kb_ingest_queue (project, root_path, force, status)"
+       " SELECT DISTINCT p.name, p.root, 1, 'pending'"
+       " FROM code_embeddings ce"
+       " JOIN projects p ON p.name = ce.project"
+       " JOIN files f ON f.project_id = p.id AND f.path = ce.file_path"
+       " WHERE ce.file_path <> ''"
+       "   AND replace(replace(f.scanned_at, 'T', ' '), 'Z', '') > ce.updated_at"
+       "   AND NOT EXISTS (SELECT 1 FROM kb_ingest_queue q"
+       "                   WHERE q.project = p.name AND q.status IN ('pending','running'))"
+       " RETURNING project";
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   int n = 0;
+   while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      n++;
+   aimee_pg_finalize(st);
+   return n;
+}

--- a/src/db2/code_index_ops.h
+++ b/src/db2/code_index_ops.h
@@ -40,6 +40,13 @@ extern "C"
     * Read-only; returns 0 on error / no candidates. */
    int64_t db2_code_index_drift_candidates(void);
 
+   /* auditable-correctness D7 requeue: enqueue each distinct drifted project (one
+    * with >=1 drift candidate, deduped against an already pending/running queue
+    * row) into kb_ingest_queue with force, so the ingest drain re-embeds it.
+    * MUTATING — do not call under dry_run. Returns the number enqueued (0 on
+    * error / nothing to do). */
+   int db2_code_index_requeue_drifted(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -1585,6 +1585,7 @@ typedef struct
    int merged;
    int summarized;
    int drift_candidates; /* D7: code embeddings whose file was re-scanned since embed */
+   int drift_requeued;   /* D7: drifted projects enqueued for re-ingest (0 under dry_run) */
    double elapsed_ms;
    int64_t memory_count_before;
    int64_t memory_count_after;

--- a/src/memory_maintenance.c
+++ b/src/memory_maintenance.c
@@ -146,6 +146,7 @@ cJSON *memory_maintenance_summary_to_json(const memory_maintenance_summary_t *su
    cJSON_AddNumberToObject(j, "merged", summary->merged);
    cJSON_AddNumberToObject(j, "summarized", summary->summarized);
    cJSON_AddNumberToObject(j, "drift_candidates", summary->drift_candidates);
+   cJSON_AddNumberToObject(j, "drift_requeued", summary->drift_requeued);
    cJSON_AddNumberToObject(j, "elapsed_ms", summary->elapsed_ms);
    cJSON_AddNumberToObject(j, "memory_count_before", (double)summary->memory_count_before);
    cJSON_AddNumberToObject(j, "memory_count_after", (double)summary->memory_count_after);
@@ -297,12 +298,19 @@ int memory_maintenance_run(const config_t *cfg, unsigned int modes, int force, i
       }
    }
 
-   /* auditable-correctness D7: read-only drift report — how many code embeddings
-    * have a source file re-scanned since they were embedded (re-ingest backlog by
-    * staleness). Default-off; runs only when the DRIFT mode is explicitly set. No
-    * mutation, so it is safe under dry_run and not counted as a change. */
+   /* auditable-correctness D7: drift report + requeue. The COUNT is read-only —
+    * how many code embeddings have a source file re-scanned since they were
+    * embedded (re-ingest backlog by staleness). The REQUEUE then enqueues each
+    * distinct drifted project into kb_ingest_queue (force, deduped against an
+    * already pending/running row) so the ingest drain re-embeds it — that is a
+    * mutation, so it is skipped under dry_run (the count still reports the
+    * backlog). Default-off: runs only when the DRIFT mode is explicitly set. */
    if (modes & MEMORY_MAINTENANCE_MODE_DRIFT)
+   {
       out->drift_candidates = (int)db2_code_index_drift_candidates();
+      if (!dry_run)
+         out->drift_requeued = db2_code_index_requeue_drifted();
+   }
 
    out->memory_count_after = db2_memory_count();
    clock_gettime(CLOCK_MONOTONIC, &t1);

--- a/src/tests/test_code_index_ops.c
+++ b/src/tests/test_code_index_ops.c
@@ -70,6 +70,49 @@ int main(void)
       int64_t drift = db2_code_index_drift_candidates();
       assert(drift == 1); /* only src/stale.c — format normalization makes the compare correct */
       printf("  drift detector flags re-scanned-since-embed (got %lld) OK\n", (long long)drift);
+
+      /* D7 requeue: the one drifted project ('dproj') gets enqueued for re-ingest
+       * with force, deduped — a second call enqueues nothing (already pending). */
+      int q1 = db2_code_index_requeue_drifted();
+      assert(q1 == 1);
+      aimee_pg_stmt_t *qs = aimee_pg_prepare(conn,
+                                             "SELECT COUNT(*), MAX(force) FROM kb_ingest_queue"
+                                             " WHERE project='dproj' AND status='pending'",
+                                             e, sizeof e);
+      assert(qs);
+      assert(aimee_pg_step(qs, e, sizeof e) == AIMEE_PG_ROW);
+      assert(aimee_pg_column_int64(qs, 0) == 1); /* exactly one queued row */
+      assert(aimee_pg_column_int64(qs, 1) == 1); /* force=1 so the drain re-embeds */
+      aimee_pg_finalize(qs);
+
+      int q2 = db2_code_index_requeue_drifted();
+      assert(q2 == 0); /* dedup: dproj already pending, not re-enqueued */
+      printf("  drift requeue enqueues drifted project once, dedups (q1=%d q2=%d) OK\n", q1, q2);
+
+      /* two MORE distinct drifted projects → one call enqueues both (exercises the
+       * DISTINCT p.name path with >1 RETURNING row; dproj stays deduped). */
+      for (int k = 2; k <= 3; k++)
+      {
+         char ins[512];
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO projects (name, root, scanned_at) VALUES ('dproj%d','/x%d','x')", k,
+                  k);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                  " ((SELECT id FROM projects WHERE name='dproj%d'),'src/s.c','h',"
+                  " '2026-06-02T00:00:00Z')",
+                  k);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
+                  " updated_at) VALUES (%d,'dproj%d','src/s.c','n','2026-06-01 00:00:00')",
+                  200 + k, k);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+      }
+      int q3 = db2_code_index_requeue_drifted();
+      assert(q3 == 2); /* dproj2 + dproj3 new; dproj already pending (deduped) */
+      printf("  drift requeue enqueues multiple distinct drifted projects (q3=%d) OK\n", q3);
    }
 
    db2_test_shim_close();


### PR DESCRIPTION
## What

Completes the **auditable-correctness D7** detect→re-ingest loop. The default-off `drift` maintenance mode already *detects* drift (`db2_code_index_drift_candidates` counts code embeddings whose source file was re-scanned since embed, with timestamp normalization). This PR adds the **requeue**.

## Changes

- **`db2_code_index_requeue_drifted()`** (`src/db2/code_index_ops.c`): a single `INSERT … SELECT … RETURNING` that enqueues each **DISTINCT drifted project** into `kb_ingest_queue` with `force=1`, **deduped** against an already `pending`/`running` queue row. `RETURNING` makes the returned row set exactly the rows inserted, so the reported count cannot drift from a separate `COUNT`. Uses the **same timestamp normalization** as the detector (only `f.scanned_at` is `now_utc()` T/Z form; `ce.updated_at` is already space-form `to_char` output). `projects.name` is `UNIQUE` ⇒ one `root` per name.
- **`drift` maintenance mode** (`src/memory_maintenance.c`): after detection, calls the requeue **unless `dry_run`** (it's a mutation); reports `drift_requeued` in the summary JSON. Still default-off (not in `MODES_DEFAULT`).
- **Test** (`src/tests/test_code_index_ops.c`): single-project enqueue + force=1, dedup (second call enqueues 0), and the multi-distinct-project path (one call enqueues 2).
- **Proposal doc** updated: D7 requeue moved from *remaining* to *landed*.

## Verification

- `make all` clean, `make lint` ok, `unit-test-code-index-ops` passes (q1=1, q2=0 dedup, q3=2 multi-project) over the sqlite shim (RETURNING supported, as `db_schema.c` already relies on).
- Local roundtable review gate: **0 blocking** after addressing round-1 findings (count/insert TOCTOU resolved via `RETURNING`; the 'normalization divergence' finding was a misread — the detector doesn't normalize `ce.updated_at` either).

## Safety

Mutation is gated three ways: default-off mode, explicit `--mode drift`, and skipped under `dry_run`. The enqueue is dedup-guarded so repeat runs don't pile up duplicate pending rows.