### PR TITLE
Promote testing → main: CSS indexer fix (wire style graph into canonical indexer)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -531,6 +531,7 @@ set(DATA_SRCS
     ${AIMEE_SRC_DIR}/trace_analysis.c
     ${AIMEE_SRC_DIR}/index.c
     ${AIMEE_SRC_DIR}/extractors.c
+    ${AIMEE_SRC_DIR}/css_analyze.c
     ${AIMEE_SRC_DIR}/extractors_extra.c
     ${AIMEE_SRC_DIR}/extractors_new_langs.c
     ${AIMEE_SRC_DIR}/context_discover.c
@@ -921,6 +922,7 @@ set(KB_DATA_SRCS
     ${AIMEE_SRC_DIR}/memory_episodes.c
     ${AIMEE_SRC_DIR}/index.c
     ${AIMEE_SRC_DIR}/extractors.c
+    ${AIMEE_SRC_DIR}/css_analyze.c
     ${AIMEE_SRC_DIR}/extractors_extra.c
     ${AIMEE_SRC_DIR}/extractors_new_langs.c
     ${AIMEE_SRC_DIR}/dogfood.c

--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -18,12 +18,15 @@
   + per-source drift flag landed in #350. The D7 drift *detection* (a default-off
   `drift` maintenance mode + `db2_code_index_drift_candidates`: count code
   embeddings whose source file was re-scanned after the embedding, with timestamp-
-  format normalization) landed next. **Remaining:** P1.5 (typed doc/code refs +
-  two-writer merge), D7's actual re-ingest *requeue* (rank/feed `kb_ingest_queue`
-  by the drift candidates — currently detect/report only) + populating
-  `code_embeddings.source_hash` so content-hash (not just staleness) drift is
-  detectable, P3 (fidelity_check judge + `fidelity_report`), P4 (labelled gold
-  corpus — needs human curation, not autonomous).
+  format normalization) landed next, and the D7 re-ingest *requeue* landed after
+  it (`db2_code_index_requeue_drifted`: the `drift` maintenance mode now enqueues
+  each distinct drifted project into `kb_ingest_queue` with `force`, deduped
+  against an already pending/running row, skipped under `dry_run`; reported as
+  `drift_requeued` in the maintenance summary). **Remaining:** P1.5 (typed
+  doc/code refs + two-writer merge), populating `code_embeddings.source_hash` so
+  content-hash (not just staleness) drift is detectable, P3 (fidelity_check judge
+  + `fidelity_report`), P4 (labelled gold corpus — needs human curation, not
+  autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -12,6 +12,8 @@
 
 #include "canonical_index.h"
 #include "code_index.h"
+#include "config.h"
+#include "css_graph.h" /* CSS migration assistant: style graph + component join (WP-C/D) */
 #include "db2.h"
 #include "db2_internal.h"
 
@@ -345,6 +347,42 @@ static void ci_replace_file_data(void *conn, int64_t file_id, const char *ext, c
    {
       LOG_WARN(CI_LOG_TAG, "COMMIT failed: %s", err);
       aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+   }
+}
+
+/* CSS migration assistant (WP-C/D): build the style graph for .css files and the
+ * component->style join for markup files. Called AFTER ci_replace_file_data
+ * (whose transaction has committed) because db2_css_graph_replace /
+ * db2_css_component_resolve run their own transactions — never nest them. Gated
+ * by css_style_graph_enabled (read once per scan). Plain CSS only (.css); SCSS is
+ * indexed from compiled output. Thread-safe (heap token buffer — the KB indexer
+ * runs in worker threads). */
+static void ci_css_index_file(int64_t file_id, const char *ext, const char *content, int css_on)
+{
+   if (!css_on || !ext || !content)
+      return;
+   size_t len = strlen(content);
+   if (strcmp(ext, ".css") == 0)
+   {
+      css_stylesheet_t *ss = css_analyze(content, len);
+      if (ss)
+      {
+         (void)db2_css_graph_replace(file_id, ss->rules, ss->rule_count);
+         css_stylesheet_free(ss);
+      }
+      return;
+   }
+   if (strcmp(ext, ".tsx") == 0 || strcmp(ext, ".jsx") == 0 || strcmp(ext, ".ts") == 0 ||
+       strcmp(ext, ".js") == 0 || strcmp(ext, ".html") == 0 || strcmp(ext, ".vue") == 0 ||
+       strcmp(ext, ".svelte") == 0)
+   {
+      char(*tokens)[CSS_CLASS_TOKEN_MAX] = malloc((size_t)512 * CSS_CLASS_TOKEN_MAX);
+      if (!tokens)
+         return;
+      int nt = css_extract_class_tokens(content, len, tokens, 512);
+      if (nt > 0)
+         (void)db2_css_component_resolve(file_id, tokens, nt);
+      free(tokens);
    }
 }
 
@@ -926,6 +964,10 @@ int canonical_index_scan_project(const char *name, const char *root, int force, 
    if (!conn)
       return -1;
 
+   /* CSS style-graph write path is opt-in; read once per scan (WP-C). */
+   config_t css_cfg;
+   int css_on = (config_load(&css_cfg) == 0) && css_cfg.css_style_graph_enabled;
+
    char abs_root[MAX_PATH_LEN];
    if (realpath(root, abs_root) == NULL)
       snprintf(abs_root, sizeof(abs_root), "%s", root);
@@ -990,7 +1032,9 @@ int canonical_index_scan_project(const char *name, const char *root, int force, 
          continue;
       }
 
-      ci_replace_file_data(conn, file_id, ci_get_extension(full), content);
+      const char *ext = ci_get_extension(full);
+      ci_replace_file_data(conn, file_id, ext, content);
+      ci_css_index_file(file_id, ext, content, css_on);
 
       free(content);
       free(list.paths[i]);
@@ -1010,6 +1054,10 @@ int canonical_index_scan_files(const char *name, const char *root_label,
       *inspected_out = 0;
    if (!name || !name[0] || !files || file_count < 0)
       return -1;
+
+   /* CSS style-graph write path is opt-in; read once per scan (WP-C). */
+   config_t css_cfg;
+   int css_on = (config_load(&css_cfg) == 0) && css_cfg.css_style_graph_enabled;
 
    void *conn = ci_conn();
    if (!conn)
@@ -1037,7 +1085,9 @@ int canonical_index_scan_files(const char *name, const char *root_label,
       if (file_id < 0)
          continue;
 
-      ci_replace_file_data(conn, file_id, ci_get_extension(rel), content);
+      const char *css_ext = ci_get_extension(rel);
+      ci_replace_file_data(conn, file_id, css_ext, content);
+      ci_css_index_file(file_id, css_ext, content, css_on);
       scanned++;
    }
 

--- a/src/db2/code_index_ops.c
+++ b/src/db2/code_index_ops.c
@@ -140,3 +140,40 @@ int64_t db2_code_index_drift_candidates(void)
    aimee_pg_finalize(st);
    return n;
 }
+
+int db2_code_index_requeue_drifted(void)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   /* auditable-correctness D7 requeue: enqueue each distinct drifted project for
+    * re-ingest (force) so the ingest drain re-embeds its changed files. A project
+    * is drifted when it has >=1 drift candidate (file re-scanned since embed, with
+    * the SAME timestamp normalization as db2_code_index_drift_candidates: only
+    * f.scanned_at is now_utc() 'T'/'Z' form, while ce.updated_at is already
+    * space-form to_char output) AND has no pending/running queue row yet (dedup).
+    * projects.name is UNIQUE so DISTINCT p.name yields one p.root per project.
+    * RETURNING makes the returned row set EXACTLY the rows inserted, so the count
+    * cannot drift from a separate COUNT query. MUTATING — callers must skip under
+    * dry_run. Returns the number of projects enqueued. */
+   static const char *sql =
+       "INSERT INTO kb_ingest_queue (project, root_path, force, status)"
+       " SELECT DISTINCT p.name, p.root, 1, 'pending'"
+       " FROM code_embeddings ce"
+       " JOIN projects p ON p.name = ce.project"
+       " JOIN files f ON f.project_id = p.id AND f.path = ce.file_path"
+       " WHERE ce.file_path <> ''"
+       "   AND replace(replace(f.scanned_at, 'T', ' '), 'Z', '') > ce.updated_at"
+       "   AND NOT EXISTS (SELECT 1 FROM kb_ingest_queue q"
+       "                   WHERE q.project = p.name AND q.status IN ('pending','running'))"
+       " RETURNING project";
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   int n = 0;
+   while (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      n++;
+   aimee_pg_finalize(st);
+   return n;
+}

--- a/src/db2/code_index_ops.h
+++ b/src/db2/code_index_ops.h
@@ -40,6 +40,13 @@ extern "C"
     * Read-only; returns 0 on error / no candidates. */
    int64_t db2_code_index_drift_candidates(void);
 
+   /* auditable-correctness D7 requeue: enqueue each distinct drifted project (one
+    * with >=1 drift candidate, deduped against an already pending/running queue
+    * row) into kb_ingest_queue with force, so the ingest drain re-embeds it.
+    * MUTATING — do not call under dry_run. Returns the number enqueued (0 on
+    * error / nothing to do). */
+   int db2_code_index_requeue_drifted(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -1585,6 +1585,7 @@ typedef struct
    int merged;
    int summarized;
    int drift_candidates; /* D7: code embeddings whose file was re-scanned since embed */
+   int drift_requeued;   /* D7: drifted projects enqueued for re-ingest (0 under dry_run) */
    double elapsed_ms;
    int64_t memory_count_before;
    int64_t memory_count_after;

--- a/src/memory_maintenance.c
+++ b/src/memory_maintenance.c
@@ -146,6 +146,7 @@ cJSON *memory_maintenance_summary_to_json(const memory_maintenance_summary_t *su
    cJSON_AddNumberToObject(j, "merged", summary->merged);
    cJSON_AddNumberToObject(j, "summarized", summary->summarized);
    cJSON_AddNumberToObject(j, "drift_candidates", summary->drift_candidates);
+   cJSON_AddNumberToObject(j, "drift_requeued", summary->drift_requeued);
    cJSON_AddNumberToObject(j, "elapsed_ms", summary->elapsed_ms);
    cJSON_AddNumberToObject(j, "memory_count_before", (double)summary->memory_count_before);
    cJSON_AddNumberToObject(j, "memory_count_after", (double)summary->memory_count_after);
@@ -297,12 +298,19 @@ int memory_maintenance_run(const config_t *cfg, unsigned int modes, int force, i
       }
    }
 
-   /* auditable-correctness D7: read-only drift report — how many code embeddings
-    * have a source file re-scanned since they were embedded (re-ingest backlog by
-    * staleness). Default-off; runs only when the DRIFT mode is explicitly set. No
-    * mutation, so it is safe under dry_run and not counted as a change. */
+   /* auditable-correctness D7: drift report + requeue. The COUNT is read-only —
+    * how many code embeddings have a source file re-scanned since they were
+    * embedded (re-ingest backlog by staleness). The REQUEUE then enqueues each
+    * distinct drifted project into kb_ingest_queue (force, deduped against an
+    * already pending/running row) so the ingest drain re-embeds it — that is a
+    * mutation, so it is skipped under dry_run (the count still reports the
+    * backlog). Default-off: runs only when the DRIFT mode is explicitly set. */
    if (modes & MEMORY_MAINTENANCE_MODE_DRIFT)
+   {
       out->drift_candidates = (int)db2_code_index_drift_candidates();
+      if (!dry_run)
+         out->drift_requeued = db2_code_index_requeue_drifted();
+   }
 
    out->memory_count_after = db2_memory_count();
    clock_gettime(CLOCK_MONOTONIC, &t1);

--- a/src/tests/test_code_index_ops.c
+++ b/src/tests/test_code_index_ops.c
@@ -70,6 +70,49 @@ int main(void)
       int64_t drift = db2_code_index_drift_candidates();
       assert(drift == 1); /* only src/stale.c — format normalization makes the compare correct */
       printf("  drift detector flags re-scanned-since-embed (got %lld) OK\n", (long long)drift);
+
+      /* D7 requeue: the one drifted project ('dproj') gets enqueued for re-ingest
+       * with force, deduped — a second call enqueues nothing (already pending). */
+      int q1 = db2_code_index_requeue_drifted();
+      assert(q1 == 1);
+      aimee_pg_stmt_t *qs = aimee_pg_prepare(conn,
+                                             "SELECT COUNT(*), MAX(force) FROM kb_ingest_queue"
+                                             " WHERE project='dproj' AND status='pending'",
+                                             e, sizeof e);
+      assert(qs);
+      assert(aimee_pg_step(qs, e, sizeof e) == AIMEE_PG_ROW);
+      assert(aimee_pg_column_int64(qs, 0) == 1); /* exactly one queued row */
+      assert(aimee_pg_column_int64(qs, 1) == 1); /* force=1 so the drain re-embeds */
+      aimee_pg_finalize(qs);
+
+      int q2 = db2_code_index_requeue_drifted();
+      assert(q2 == 0); /* dedup: dproj already pending, not re-enqueued */
+      printf("  drift requeue enqueues drifted project once, dedups (q1=%d q2=%d) OK\n", q1, q2);
+
+      /* two MORE distinct drifted projects → one call enqueues both (exercises the
+       * DISTINCT p.name path with >1 RETURNING row; dproj stays deduped). */
+      for (int k = 2; k <= 3; k++)
+      {
+         char ins[512];
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO projects (name, root, scanned_at) VALUES ('dproj%d','/x%d','x')", k,
+                  k);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                  " ((SELECT id FROM projects WHERE name='dproj%d'),'src/s.c','h',"
+                  " '2026-06-02T00:00:00Z')",
+                  k);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
+                  " updated_at) VALUES (%d,'dproj%d','src/s.c','n','2026-06-01 00:00:00')",
+                  200 + k, k);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+      }
+      int q3 = db2_code_index_requeue_drifted();
+      assert(q3 == 2); /* dproj2 + dproj3 new; dproj already pending (deduped) */
+      printf("  drift requeue enqueues multiple distinct drifted projects (q3=%d) OK\n", q3);
    }
 
    db2_test_shim_close();


### PR DESCRIPTION
Promote `testing` → `main`: **#362 fix(css)** — wire the CSS style graph into the real (canonical) KB indexer. Live validation on .254 found the WP-C/D hooks were on the test-only index.c path; ported to canonical_index.c so a real index populates the graph and `aimee css` signals are non-empty. All source-PR checks green.
