### PR TITLE
fix(css): parse css_style_graph_enabled on config load

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -774,6 +774,13 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
+   /* CSS migration assistant style-graph write path (WP-C). The field +
+    * descriptor + save existed, but the YAML load parse was missing, so the
+    * flag never took effect during indexing. */
+   item = cJSON_GetObjectItemCaseSensitive(root, "css_style_graph_enabled");
+   if (cJSON_IsBool(item))
+      cfg->css_style_graph_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_preinject_assembly_budget");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->ingress_preinject_assembly_budget = (int)item->valuedouble;

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,8 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\ningress_preinject_assembly_budget: 1\n"
+    "true\ningress_preinject_enabled: true\ncss_style_graph_enabled: true\n"
+    "ingress_preinject_assembly_budget: 1\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
     "ZZA_val\nembedding_endpoint: ZZA_val\nembedding_dim: 1\nmemory_rerank_mode: "
     "ZZA_val\nmemory_rewrite:\n  enabled: true\n  hyde: true\n  decompose: true\n  max_subqueries: "
@@ -80,7 +81,8 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\ningress_preinject_assembly_budget: 4096\n"
+    "false\ningress_preinject_enabled: false\ncss_style_graph_enabled: false\n"
+    "ingress_preinject_assembly_budget: 4096\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
     "ZZB_val\nembedding_endpoint: ZZB_val\nembedding_dim: 4096\nmemory_rerank_mode: "
     "ZZB_val\nmemory_rewrite:\n  enabled: false\n  hyde: false\n  decompose: false\n  "
@@ -158,6 +160,7 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
+   assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);
    assert(strcmp(cfgA.embedding_command, cfgB.embedding_command) != 0);


### PR DESCRIPTION
Live validation on `.254` surfaced the **third gap** in WP-C's flag wiring: the field (config.h), descriptor (config_fields.c), and save (config_save.c) all existed, but `config.c`'s YAML **load** never read `css_style_graph_enabled` — so `config_load` always returned the default `0`, and the indexer's style-graph write path never ran even with the flag set in `aimee.yaml`.

Fix: add the top-level bool parse next to `ingress_preinject_enabled`. `test_config_surface` now asserts the flag round-trips on/off through `config_load` (it previously only counted the descriptor — why this slipped through). `unit-test-config`/`-config-surface` green.
