### PR TITLE
Promote testing → main: css flag load-parse fix + audit D7

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -22,11 +22,16 @@
   it (`db2_code_index_requeue_drifted`: the `drift` maintenance mode now enqueues
   each distinct drifted project into `kb_ingest_queue` with `force`, deduped
   against an already pending/running row, skipped under `dry_run`; reported as
-  `drift_requeued` in the maintenance summary). **Remaining:** P1.5 (typed
-  doc/code refs + two-writer merge), populating `code_embeddings.source_hash` so
-  content-hash (not just staleness) drift is detectable, P3 (fidelity_check judge
-  + `fidelity_report`), P4 (labelled gold corpus — needs human curation, not
-  autonomous).
+  `drift_requeued` in the maintenance summary). **Precise content-hash drift
+  landed next**: the code-embed write path now captures `code_embeddings.source_hash`
+  (the source file's `files.hash` at embed time, threaded through
+  `pgvec_code_upsert`/`pgvec_kb_service_code_upsert` from `kb_service_code_embed`),
+  and the D7 detector + requeue use a hybrid predicate — precise `files.hash <>
+  source_hash` for embeddings that have it (no false positives from a re-scan that
+  changed nothing), falling back to the scanned-since-embed staleness heuristic only
+  for legacy rows with `source_hash=''`. **Remaining:** P1.5 (typed doc/code refs +
+  two-writer merge), P3 (fidelity_check judge + `fidelity_report`), P4 (labelled
+  gold corpus — needs human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/config.c
+++ b/src/config.c
@@ -774,6 +774,13 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
+   /* CSS migration assistant style-graph write path (WP-C). The field +
+    * descriptor + save existed, but the YAML load parse was missing, so the
+    * flag never took effect during indexing. */
+   item = cJSON_GetObjectItemCaseSensitive(root, "css_style_graph_enabled");
+   if (cJSON_IsBool(item))
+      cfg->css_style_graph_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_preinject_assembly_budget");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->ingress_preinject_assembly_budget = (int)item->valuedouble;

--- a/src/db2/code_index_ops.c
+++ b/src/db2/code_index_ops.c
@@ -108,28 +108,43 @@ int db2_code_index_ops_summary(int max_attempts, db2_code_index_ops_summary_t *o
    return 0;
 }
 
+/* auditable-correctness D7 drift predicate (shared by the detector and the
+ * requeue so they can never diverge). A code embedding is a re-ingest candidate
+ * when its source file has DRIFTED:
+ *  - PRECISE (preferred): the stored source_hash — the file's hash (files.hash)
+ *    captured at embed time — differs from the file's CURRENT hash. This is real
+ *    content drift, with no false positives from a re-scan that didn't change
+ *    anything.
+ *  - LEGACY FALLBACK: embeddings written before source_hash was captured carry
+ *    source_hash='' ; for those only, fall back to the staleness heuristic (file
+ *    re-scanned after the embedding was written). Timestamp NORMALIZATION:
+ *    files.scanned_at is now_utc() ('YYYY-MM-DDTHH:MM:SSZ') while ce.updated_at is
+ *    to_char(...,'YYYY-MM-DD HH24:MI:SS'); a raw compare mis-orders ('T' > ' '),
+ *    so strip 'T'/'Z' and compare lexically (valid for zero-padded UTC). replace()
+ *    is portable across Postgres and the sqlite shim.
+ * NULL semantics: if f.hash IS NULL the precise compare is UNKNOWN (row NOT
+ * flagged), same as a NULL scanned_at in the legacy branch — consistent, and the
+ * row is picked up once the file gets a hash. The precise branch is the contract;
+ * the legacy branch is best-effort (it only fires once a re-scan bumps scanned_at).
+ * The OR-group is fully parenthesized so callers may AND further conditions after
+ * it (the requeue appends an AND NOT EXISTS). */
+#define D7_DRIFT_FROM_WHERE                                                                        \
+   " FROM code_embeddings ce"                                                                      \
+   " JOIN projects p ON p.name = ce.project"                                                       \
+   " JOIN files f ON f.project_id = p.id AND f.path = ce.file_path"                                \
+   " WHERE ce.file_path <> ''"                                                                     \
+   "   AND ((ce.source_hash <> '' AND f.hash <> ce.source_hash)"                                   \
+   "        OR (ce.source_hash = ''"                                                               \
+   "            AND replace(replace(f.scanned_at, 'T', ' '), 'Z', '') > ce.updated_at))"
+
 int64_t db2_code_index_drift_candidates(void)
 {
    void *conn = db2_conn();
    if (!conn)
       return 0;
-   /* auditable-correctness D7 (staleness heuristic): a code embedding is a
-    * re-ingest candidate when its source file was re-scanned AFTER the embedding
-    * was written — files.scanned_at > code_embeddings.updated_at — i.e. the file
-    * changed but its vectors haven't been refreshed yet. Joined within DB2 on
-    * project name + file path. Read-only; ranks/sizes re-ingest, not a verdict.
-    *
-    * Timestamp NORMALIZATION: files.scanned_at is now_utc() ("YYYY-MM-DDTHH:MM:SSZ")
-    * while code_embeddings.updated_at is to_char(...,'YYYY-MM-DD HH24:MI:SS') — a
-    * raw string compare would mis-order ('T' > ' '). Strip the 'T'/'Z' from
-    * scanned_at so both are "YYYY-MM-DD HH:MM:SS" and compare lexically (valid for
-    * zero-padded UTC). replace() is portable across Postgres and the sqlite shim. */
-   static const char *sql =
-       "SELECT COUNT(*) FROM code_embeddings ce"
-       " JOIN projects p ON p.name = ce.project"
-       " JOIN files f ON f.project_id = p.id AND f.path = ce.file_path"
-       " WHERE ce.file_path <> ''"
-       "   AND replace(replace(f.scanned_at, 'T', ' '), 'Z', '') > ce.updated_at";
+   /* Read-only count of drift candidates (see D7_DRIFT_FROM_WHERE). Ranks/sizes
+    * re-ingest, not a verdict. */
+   static const char *sql = "SELECT COUNT(*)" D7_DRIFT_FROM_WHERE;
    char err[256] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
@@ -146,27 +161,20 @@ int db2_code_index_requeue_drifted(void)
    void *conn = db2_conn();
    if (!conn)
       return 0;
-   /* auditable-correctness D7 requeue: enqueue each distinct drifted project for
-    * re-ingest (force) so the ingest drain re-embeds its changed files. A project
-    * is drifted when it has >=1 drift candidate (file re-scanned since embed, with
-    * the SAME timestamp normalization as db2_code_index_drift_candidates: only
-    * f.scanned_at is now_utc() 'T'/'Z' form, while ce.updated_at is already
-    * space-form to_char output) AND has no pending/running queue row yet (dedup).
-    * projects.name is UNIQUE so DISTINCT p.name yields one p.root per project.
-    * RETURNING makes the returned row set EXACTLY the rows inserted, so the count
-    * cannot drift from a separate COUNT query. MUTATING — callers must skip under
-    * dry_run. Returns the number of projects enqueued. */
-   static const char *sql =
-       "INSERT INTO kb_ingest_queue (project, root_path, force, status)"
-       " SELECT DISTINCT p.name, p.root, 1, 'pending'"
-       " FROM code_embeddings ce"
-       " JOIN projects p ON p.name = ce.project"
-       " JOIN files f ON f.project_id = p.id AND f.path = ce.file_path"
-       " WHERE ce.file_path <> ''"
-       "   AND replace(replace(f.scanned_at, 'T', ' '), 'Z', '') > ce.updated_at"
-       "   AND NOT EXISTS (SELECT 1 FROM kb_ingest_queue q"
-       "                   WHERE q.project = p.name AND q.status IN ('pending','running'))"
-       " RETURNING project";
+   /* auditable-correctness D7 requeue: enqueue each distinct drifted project (see
+    * D7_DRIFT_FROM_WHERE) for re-ingest (force) so the ingest drain re-embeds its
+    * changed files, AND it has no pending/running queue row yet (dedup). The OR-
+    * group in the predicate is parenthesized, so the trailing AND NOT EXISTS binds
+    * correctly. projects.name is UNIQUE so DISTINCT p.name yields one p.root per
+    * project. RETURNING makes the returned row set EXACTLY the rows inserted, so
+    * the count cannot drift from a separate COUNT query. MUTATING — callers must
+    * skip under dry_run. Returns the number of projects enqueued. */
+   static const char *sql = "INSERT INTO kb_ingest_queue (project, root_path, force, status)"
+                            " SELECT DISTINCT p.name, p.root, 1, 'pending'" D7_DRIFT_FROM_WHERE
+                            "   AND NOT EXISTS (SELECT 1 FROM kb_ingest_queue q"
+                            "                   WHERE q.project = p.name"
+                            "                     AND q.status IN ('pending','running'))"
+                            " RETURNING project";
    char err[256] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
@@ -177,3 +185,5 @@ int db2_code_index_requeue_drifted(void)
    aimee_pg_finalize(st);
    return n;
 }
+
+#undef D7_DRIFT_FROM_WHERE

--- a/src/db2/pgvec_kb_service.c
+++ b/src/db2/pgvec_kb_service.c
@@ -117,10 +117,10 @@ int pgvec_kb_service_ensure_code_collection(int dim)
 int pgvec_kb_service_code_upsert(int64_t point_id, const float *vec, int dim, const char *project,
                                  const char *node_key, const char *file_path, const char *symbol,
                                  const char *content_hash, const char *body_hash,
-                                 const char *payload_json)
+                                 const char *source_hash, const char *payload_json)
 {
    return pgvec_code_upsert(point_id, vec, dim, project, node_key, file_path, symbol, content_hash,
-                            body_hash, payload_json);
+                            body_hash, source_hash, payload_json);
 }
 
 int pgvec_kb_service_code_exists_by_hash(const char *project, const char *node_key,

--- a/src/db2/pgvec_kb_service.h
+++ b/src/db2/pgvec_kb_service.h
@@ -37,7 +37,7 @@ extern "C"
                                     const char *project, const char *node_key,
                                     const char *file_path, const char *symbol,
                                     const char *content_hash, const char *body_hash,
-                                    const char *payload_json);
+                                    const char *source_hash, const char *payload_json);
    int pgvec_kb_service_code_exists_by_hash(const char *project, const char *node_key,
                                             const char *content_hash, const char *body_hash);
 

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1320,7 +1320,8 @@ int pgvec_curator_code_unit_search(const char *which_vec, const char *def_kind, 
 
 int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *project,
                       const char *node_key, const char *file_path, const char *symbol,
-                      const char *content_hash, const char *body_hash, const char *payload_json)
+                      const char *content_hash, const char *body_hash, const char *source_hash,
+                      const char *payload_json)
 {
    if (!vec || dim <= 0)
       return 0;
@@ -1332,14 +1333,17 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
    if (!vec_text)
       return -1;
 
+   /* source_hash = the SOURCE FILE's hash (files.hash) at embed time, captured so
+    * a later scan can detect *content* drift precisely (files.hash <> source_hash)
+    * rather than by re-scan timestamp alone (auditable-correctness D7). */
    static const char *sql =
        "INSERT INTO code_embeddings"
        "  (point_id, embedding, project, node_key, file_path, symbol,"
-       "   content_hash, body_hash, payload_json,"
+       "   content_hash, body_hash, source_hash, payload_json,"
        "   updated_at)"
        " VALUES"
        "  (:point_id, :embedding::halfvec, :project, :node_key, :file_path, :symbol,"
-       "   :content_hash, :body_hash, :payload,"
+       "   :content_hash, :body_hash, :source_hash, :payload,"
        "   to_char(CURRENT_TIMESTAMP,'YYYY-MM-DD HH24:MI:SS'))"
        " ON CONFLICT (point_id) DO UPDATE SET"
        "  embedding = EXCLUDED.embedding,"
@@ -1349,6 +1353,7 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
        "  symbol = EXCLUDED.symbol,"
        "  content_hash = EXCLUDED.content_hash,"
        "  body_hash = EXCLUDED.body_hash,"
+       "  source_hash = EXCLUDED.source_hash,"
        "  payload_json = EXCLUDED.payload_json,"
        "  updated_at = EXCLUDED.updated_at";
 
@@ -1367,6 +1372,7 @@ int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *p
    aimee_pg_bind_text(stmt, "symbol", symbol ? symbol : "");
    aimee_pg_bind_text(stmt, "content_hash", content_hash ? content_hash : "");
    aimee_pg_bind_text(stmt, "body_hash", body_hash ? body_hash : "");
+   aimee_pg_bind_text(stmt, "source_hash", source_hash ? source_hash : "");
    aimee_pg_bind_text(stmt, "payload", payload_json ? payload_json : "");
 
    aimee_pg_step_t rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf));

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -176,7 +176,8 @@ void pgvec_search_latency_snapshot(int64_t *total_us, int64_t *count, int64_t *m
 /* Code vector operations (Phase 5). */
 int pgvec_code_upsert(int64_t point_id, const float *vec, int dim, const char *project,
                       const char *node_key, const char *file_path, const char *symbol,
-                      const char *content_hash, const char *body_hash, const char *payload_json);
+                      const char *content_hash, const char *body_hash, const char *source_hash,
+                      const char *payload_json);
 int pgvec_code_delete(int64_t point_id);
 int pgvec_code_delete_project(const char *project);
 int pgvec_code_search(const char *project, const float *vec, int dim, int limit, int64_t *ids,

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -459,8 +459,14 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
          continue;
       }
 
+      /* content_hash and source_hash are intentionally the SAME value here —
+       * rows[i].hash, the source file's hash (files.hash) at embed time. They serve
+       * different roles: content_hash backs the (project,node_key,content_hash)
+       * dedup index, while source_hash is the D7 drift contract (files.hash <>
+       * source_hash ⇒ content drift). Code embeds are file-granular today, so the
+       * two coincide; node-level hashing later would split them. */
       int up = pgvec_kb_service_code_upsert(point_id, vec, dim, project, node_key, rows[i].path, "",
-                                            rows[i].hash, body_hash, payload);
+                                            rows[i].hash, body_hash, rows[i].hash, payload);
       /* Per-chunk replay bookkeeping so a failed embed is retried by
        * `memory repair --reset-stuck`, not orphaned. */
       db2_code_index_op_record(point_id, project, node_key, rows[i].path, up == 0,

--- a/src/tests/test_code_index_ops.c
+++ b/src/tests/test_code_index_ops.c
@@ -34,11 +34,16 @@ int main(void)
    assert(sum.failed_ops == 1); /* still failed, but retryable */
    printf("  reset-stuck retries a stuck code embed OK\n");
 
-   /* D7 drift detector: a code embedding whose source file was re-scanned after
-    * the embedding was written is a re-ingest candidate. Crucially this exercises
-    * the timestamp-format normalization: files.scanned_at is now_utc() ('...T..Z')
-    * while code_embeddings.updated_at is space-separated, so a raw compare would
-    * mis-order — the detector must normalize before comparing. */
+   /* D7 drift detector — covers both predicate branches:
+    *  - LEGACY staleness fallback (source_hash=''): src/stale.c (re-scanned after
+    *    embed) flags; src/fresh.c does not. Exercises the timestamp-format
+    *    normalization (files.scanned_at is now_utc() '...T..Z' vs space-separated
+    *    code_embeddings.updated_at — a raw compare would mis-order).
+    *  - PRECISE content hash (source_hash<>''): src/changed.c flags because
+    *    files.hash differs from the stored source_hash EVEN THOUGH it was scanned
+    *    BEFORE the embed (staleness alone would miss it); src/same.c does NOT flag
+    *    because the hashes match EVEN THOUGH it was re-scanned after the embed
+    *    (staleness alone would false-positive). */
    {
       void *conn = db2_conn();
       char e[256] = "";
@@ -67,9 +72,36 @@ int main(void)
                  "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
                  " updated_at) VALUES (102,'dproj','src/fresh.c','n2','2026-06-02 00:00:00')",
                  e, sizeof e) == 0);
+      /* precise: file hash CHANGED (hNEW) vs stored source_hash (hOLD), but the
+       * file was scanned (06-01) BEFORE the embed (06-02) — staleness alone misses
+       * it; the hash branch flags it. */
+      assert(aimee_pg_exec(conn,
+                           "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                           " ((SELECT id FROM projects WHERE name='dproj'),"
+                           " 'src/changed.c','hNEW','2026-06-01T00:00:00Z')",
+                           e, sizeof e) == 0);
+      assert(aimee_pg_exec(conn,
+                           "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
+                           " source_hash, updated_at) VALUES"
+                           " (103,'dproj','src/changed.c','n3','hOLD','2026-06-02 00:00:00')",
+                           e, sizeof e) == 0);
+      /* precise no-false-positive: hashes MATCH (hX), but the file was re-scanned
+       * (06-02) AFTER the embed (06-01) — staleness alone would flag it; the hash
+       * branch correctly does not. */
+      assert(aimee_pg_exec(conn,
+                           "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                           " ((SELECT id FROM projects WHERE name='dproj'),"
+                           " 'src/same.c','hX','2026-06-02T00:00:00Z')",
+                           e, sizeof e) == 0);
+      assert(aimee_pg_exec(conn,
+                           "INSERT INTO code_embeddings (point_id, project, file_path, node_key,"
+                           " source_hash, updated_at) VALUES"
+                           " (104,'dproj','src/same.c','n4','hX','2026-06-01 00:00:00')",
+                           e, sizeof e) == 0);
       int64_t drift = db2_code_index_drift_candidates();
-      assert(drift == 1); /* only src/stale.c — format normalization makes the compare correct */
-      printf("  drift detector flags re-scanned-since-embed (got %lld) OK\n", (long long)drift);
+      assert(drift == 2); /* src/stale.c (staleness) + src/changed.c (hash); fresh+same excluded */
+      printf("  drift detector flags staleness + precise hash drift (got %lld) OK\n",
+             (long long)drift);
 
       /* D7 requeue: the one drifted project ('dproj') gets enqueued for re-ingest
        * with force, deduped — a second call enqueues nothing (already pending). */

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,8 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\ningress_preinject_assembly_budget: 1\n"
+    "true\ningress_preinject_enabled: true\ncss_style_graph_enabled: true\n"
+    "ingress_preinject_assembly_budget: 1\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
     "ZZA_val\nembedding_endpoint: ZZA_val\nembedding_dim: 1\nmemory_rerank_mode: "
     "ZZA_val\nmemory_rewrite:\n  enabled: true\n  hyde: true\n  decompose: true\n  max_subqueries: "
@@ -80,7 +81,8 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\ningress_preinject_assembly_budget: 4096\n"
+    "false\ningress_preinject_enabled: false\ncss_style_graph_enabled: false\n"
+    "ingress_preinject_assembly_budget: 4096\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
     "ZZB_val\nembedding_endpoint: ZZB_val\nembedding_dim: 4096\nmemory_rerank_mode: "
     "ZZB_val\nmemory_rewrite:\n  enabled: false\n  hyde: false\n  decompose: false\n  "
@@ -158,6 +160,7 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
+   assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);
    assert(strcmp(cfgA.embedding_command, cfgB.embedding_command) != 0);


### PR DESCRIPTION
Promote `testing` → `main`: **#365 fix(css)** — parse `css_style_graph_enabled` on config load (the indexer flag never took effect without it); plus accumulated audit D7 commits. All source-PR checks green.
