### PR TITLE
feat(audit): P3 /v1/audit/fidelity read endpoint

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -944,6 +944,39 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /audit/fidelity:
+    post:
+      summary: Per-turn answer-fidelity report (proxied to aimee-kb)
+      description: >-
+        How faithful a turn's answer was to its own injected evidence: given the
+        caller-visible turn_id, return the answer-level fidelity_report (supported
+        / unsupported / abstained claim buckets) plus the per-chunk
+        attribution_count. fidelity_status is one of the exhaustive states ok /
+        not_instrumented / not_evaluated / evidence_unavailable. This read produces
+        ok, not_evaluated (the honest default when the default-off fidelity judge
+        has not run for the turn), and evidence_unavailable (lookup error);
+        not_instrumented is reserved for paths that emit no evidence and is set at
+        emit time. Requires aimee-kb. Gated by fidelity_check_enabled at emit time.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [turn_id]
+              properties:
+                turn_id: { type: string }
+      responses:
+        "200":
+          description: Fidelity bundle ({status, fidelity_status, turn_id, report?, attribution_count?})
+          content:
+            application/json:
+              schema: { type: object }
+        "502":
+          description: Knowledge service (aimee-kb) unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /css/signals:
     post:
       summary: CSS migration assistant signals (proxied to aimee-kb)

--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -35,11 +35,16 @@
   per-chunk `fidelity_attribution` (`accepted`/`irrelevant`, `operator_id`
   `fidelity-judge`) as **non-scored** artifact kinds — structurally invisible to
   `db2_demotion_score` (which reads only `retrieval_attribution`), so fidelity is
-  demotion-inert by construction. The LLM entailment judge that *produces* these
-  rows, and the `fidelity_check_enabled` flag + audit-read surface, are the next
-  increments. **Remaining:** P1.5 (typed doc/code refs + two-writer merge), P3
-  judge + `fidelity_check_enabled` flag + `/v1/audit` fidelity read, P4 (labelled
-  gold corpus — needs human curation, not autonomous).
+  demotion-inert by construction. The `fidelity_check_enabled` flag + the
+  fail-closed eligibility gate (`fidelity_check_eligible`, deps on
+  `kb_evidence_emit_enabled` + `ingress_preinject_enabled`) landed next, and then
+  the **`/v1/audit/fidelity` read** (`aimee audit fidelity <turn_id>`) — the full
+  server→kb-forward vertical mirroring `/v1/audit/provenance`, returning the
+  turn's `fidelity_report` buckets + `attribution_count` with a four-state
+  `fidelity_status` (`not_evaluated` when the default-off judge has not run).
+  **Remaining:** P1.5 (typed doc/code refs + two-writer merge), the P3 LLM
+  entailment judge *producer* (default-off until validated), P4 (labelled gold
+  corpus — needs human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -308,6 +308,7 @@ static const struct
     {"mcp", "recheck", "mcp.recheck", NULL, "items", 300000},
     {"audit", "trace", "evidence.trace_retrieval_event", NULL, NULL, 0},
     {"audit", "provenance", "evidence.provenance_retrieval_event", NULL, NULL, 0},
+    {"audit", "fidelity", "evidence.fidelity_retrieval_event", NULL, NULL, 0},
     {"get_help", NULL, "get_help", "mcp.call", NULL, 0},
     {"get-help", NULL, "get_help", "mcp.call", NULL, 0},
     {"verify", NULL, "git.verify", "mcp.call", NULL, 900000},
@@ -992,6 +993,18 @@ static cJSON *marshal_audit_provenance(int argc, char **argv)
    rpc_parse(argc, argv, NULL, &opts);
 
    cJSON *req = marshal_no_args("evidence.provenance_retrieval_event");
+   if (opts.pos_count > 0)
+      cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
+   return req;
+}
+
+/* Auditable-correctness P3: `aimee audit fidelity <turn_id>` → the turn_id param. */
+static cJSON *marshal_audit_fidelity(int argc, char **argv)
+{
+   rpc_opts_t opts;
+   rpc_parse(argc, argv, NULL, &opts);
+
+   cJSON *req = marshal_no_args("evidence.fidelity_retrieval_event");
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "turn_id", opts.positional[0]);
    return req;
@@ -3311,6 +3324,8 @@ static cJSON *marshal_request(const char *method, int argc, char **argv)
       return marshal_audit_trace(argc, argv);
    if (strcmp(method, "evidence.provenance_retrieval_event") == 0)
       return marshal_audit_provenance(argc, argv);
+   if (strcmp(method, "evidence.fidelity_retrieval_event") == 0)
+      return marshal_audit_fidelity(argc, argv);
    if (strcmp(method, "config.set") == 0)
       return marshal_config_set(argc, argv);
    if (strcmp(method, "aux.test") == 0)

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -80,6 +80,7 @@ static const struct
     {"dogfood.tag", "POST", "/v1/dogfood/tag"},
     {"episode.list", "GET", "/v1/episode/list"},
     {"eval.results", "GET", "/v1/eval/results"},
+    {"evidence.fidelity_retrieval_event", "POST", "/v1/audit/fidelity"},
     {"evidence.provenance_retrieval_event", "POST", "/v1/audit/provenance"},
     {"evidence.trace_retrieval_event", "POST", "/v1/audit/trace"},
     {"graph.explain", "POST", "/v1/graph/explain"},

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -791,6 +791,11 @@ char *kb_client_evidence_trace_retrieval_event(const char *turn_id);
  * verbatim (malloc'd, caller frees; NULL on bad arg or kb error). */
 char *kb_client_evidence_provenance_retrieval_event(const char *turn_id);
 
+/* Auditable-correctness P3: the /v1/audit/fidelity read — forward to the KB
+ * evidence.fidelity_retrieval_event action and return its JSON response verbatim
+ * (malloc'd, caller frees; NULL on bad arg or kb error). */
+char *kb_client_evidence_fidelity_retrieval_event(const char *turn_id);
+
 /* Fetch the entity profile card via aimee-kb.  Returns 0 on success
  * (|out| filled) or -1 if kb is unreachable or the entity is missing.
  * Mirrors memory_get_entity_profile(). */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -284,6 +284,7 @@ int handle_graph_explain(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_kb_search(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_evidence_trace(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_evidence_fidelity(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_css_signals(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_implements(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_curator_synthesize(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1055,6 +1055,7 @@ static const struct
     {"evidence.emit_retrieval_event", kb_handle_evidence_emit_retrieval_event},
     {"evidence.trace_retrieval_event", kb_handle_evidence_trace_retrieval_event},
     {"evidence.provenance_retrieval_event", kb_handle_evidence_provenance},
+    {"evidence.fidelity_retrieval_event", kb_handle_evidence_fidelity},
     {"css.signals", kb_handle_css_signals},
     {"memory.entity_profile", kb_handle_memory_entity_profile},
     {"memory.entity_edges", kb_handle_memory_entity_edges},

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -12,6 +12,7 @@
 #include "db2/bandit.h"
 #include "db2/demotion.h" /* db2_demotion_retrieval_event_write_turn (auditable-correctness P1) */
 #include "db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
+#include "db2/fidelity.h"       /* db2_fidelity_report_by_turn (auditable-correctness P3) */
 #include "kb_bandit.h"
 #include "kb_bandit_registry.h"
 #include "kb_service_memory.h"
@@ -932,6 +933,53 @@ int kb_handle_evidence_provenance(int fd, cJSON *req)
                               rc < 0 ? "lookup error" : "no durable retrieval_event for this turn");
    }
    return kb_reply_or_error(fd, resp, "failed to read provenance");
+}
+
+/* Auditable-correctness P3: the /v1/audit/fidelity read. Return the turn's
+ * answer-level fidelity_report (supported/unsupported/abstained buckets) plus the
+ * per-chunk attribution_count. A pure read of the non-scored fidelity artifacts.
+ * When no report exists the status is not_evaluated (the default-off judge has not
+ * run for the turn) — distinct from a lookup error (evidence_unavailable). */
+int kb_handle_evidence_fidelity(int fd, cJSON *req)
+{
+   cJSON *turn_j = cJSON_GetObjectItemCaseSensitive(req, "turn_id");
+   if (!cJSON_IsString(turn_j) || !turn_j->valuestring[0])
+      return kb_send_error(fd, "audit.fidelity requires turn_id");
+   if (strlen(turn_j->valuestring) > 128)
+      return kb_send_error(fd, "audit.fidelity turn_id too long");
+
+   char fstatus[32] = "";
+   int sup = 0, uns = 0, abst = 0;
+   int rc = db2_fidelity_report_by_turn(turn_j->valuestring, fstatus, sizeof(fstatus), &sup, &uns,
+                                        &abst);
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "turn_id", turn_j->valuestring);
+   if (rc == 1)
+   {
+      cJSON_AddStringToObject(resp, "fidelity_status", fstatus[0] ? fstatus : "ok");
+      cJSON *rep = cJSON_AddObjectToObject(resp, "report");
+      cJSON_AddNumberToObject(rep, "supported", sup);
+      cJSON_AddNumberToObject(rep, "unsupported", uns);
+      cJSON_AddNumberToObject(rep, "abstained", abst);
+      /* Emit the count only when it read cleanly; on a count error omit it (rather
+       * than clamp to 0, which would conflate "no attributions" with "count
+       * failed") and flag the error — honesty over a silent zero on an audit read. */
+      int ac = db2_fidelity_attribution_count_by_turn(turn_j->valuestring);
+      if (ac >= 0)
+         cJSON_AddNumberToObject(resp, "attribution_count", ac);
+      else
+         cJSON_AddBoolToObject(resp, "attribution_count_error", 1);
+   }
+   else
+   {
+      cJSON_AddStringToObject(resp, "fidelity_status",
+                              rc < 0 ? "evidence_unavailable" : "not_evaluated");
+      cJSON_AddStringToObject(resp, "detail",
+                              rc < 0 ? "lookup error" : "no fidelity report for this turn");
+   }
+   return kb_reply_or_error(fd, resp, "failed to read fidelity report");
 }
 
 int kb_handle_memory_entity_profile(int fd, cJSON *req)

--- a/src/kb_service_memory.h
+++ b/src/kb_service_memory.h
@@ -63,6 +63,8 @@ int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req);
 int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req);
 /* Auditable-correctness P2: the /v1/audit/provenance read (sources at version). */
 int kb_handle_evidence_provenance(int fd, cJSON *req);
+/* Auditable-correctness P3: the /v1/audit/fidelity read (answer-level report). */
+int kb_handle_evidence_fidelity(int fd, cJSON *req);
 int kb_handle_css_signals(int fd, cJSON *req);
 int kb_handle_memory_entity_profile(int fd, cJSON *req);
 int kb_handle_memory_entity_edges(int fd, cJSON *req);

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1652,6 +1652,17 @@ char *kb_client_evidence_provenance_retrieval_event(const char *turn_id)
    return kb_v1_action_request("evidence.provenance_retrieval_event", req);
 }
 
+char *kb_client_evidence_fidelity_retrieval_event(const char *turn_id)
+{
+   if (!turn_id || !turn_id[0])
+      return NULL;
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "turn_id", turn_id);
+   /* Pass the KB action's response through verbatim (status + fidelity_status +
+    * report + attribution_count). kb_v1_action_request owns req. */
+   return kb_v1_action_request("evidence.fidelity_retrieval_event", req);
+}
+
 char *kb_client_memory_lint_json(void)
 {
    cJSON *req = cJSON_CreateObject();

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1046,6 +1046,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"kb.search", handle_kb_search},
     {"evidence.trace_retrieval_event", handle_evidence_trace},
     {"evidence.provenance_retrieval_event", handle_evidence_provenance},
+    {"evidence.fidelity_retrieval_event", handle_evidence_fidelity},
     {"css.signals", handle_css_signals},
     {"curator.implements", handle_curator_implements},
     {"curator.synthesize", handle_curator_synthesize},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -137,6 +137,7 @@ const method_policy_t method_registry[] = {
     {"kb.search", CAP_INDEX_READ, "knowledge search"},
     {"evidence.trace_retrieval_event", CAP_INDEX_READ, "audit retrieval-evidence trace"},
     {"evidence.provenance_retrieval_event", CAP_INDEX_READ, "audit source provenance"},
+    {"evidence.fidelity_retrieval_event", CAP_INDEX_READ, "audit answer fidelity"},
     {"css.signals", CAP_INDEX_READ, "css migration signals (read + enumerate)"},
     {"kb.status", CAP_DASHBOARD_READ, "knowledge base status"},
     {"optimize.export", CAP_DASHBOARD_READ, "bandit optimization export"},

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1110,6 +1110,8 @@ static const http_route_t g_v1_routes[] = {
      rh_dispatch_op},
     {"POST", "/v1/audit/provenance", NULL, RM_EXACT, "evidence.provenance_retrieval_event", 0,
      rh_dispatch_op},
+    {"POST", "/v1/audit/fidelity", NULL, RM_EXACT, "evidence.fidelity_retrieval_event", 0,
+     rh_dispatch_op},
     {"POST", "/v1/css/signals", NULL, RM_EXACT, "css.signals", 0, rh_dispatch_op},
     {"POST", "/v1/trajectory/batch", NULL, RM_EXACT, "trajectory.batch", 0, rh_dispatch_op},
 

--- a/src/server/server_state_audit.inc
+++ b/src/server/server_state_audit.inc
@@ -38,3 +38,21 @@ int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
       return server_send_error(conn, "knowledge service audit provenance failed", NULL);
    return send_and_free(conn, resp);
 }
+
+/* /v1/audit/fidelity handler. Like the trace/provenance handlers, its op
+ * (evidence.fidelity_retrieval_event) is a KB-only action (the fidelity_report /
+ * fidelity_attribution artifacts live in DB2), so the server forwards it to
+ * aimee-kb via kb_client and passes the JSON response through. */
+int handle_evidence_fidelity(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   const char *turn_id = jo_str(req, "turn_id", "");
+   if (!turn_id[0])
+      return server_send_error(conn, "audit fidelity requires turn_id", NULL);
+   char *json = kb_client_evidence_fidelity_retrieval_event(turn_id);
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   if (!resp)
+      return server_send_error(conn, "knowledge service audit fidelity failed", NULL);
+   return send_and_free(conn, resp);
+}

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -547,6 +547,10 @@ int handle_evidence_provenance(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
 {
    return stub_handler(conn, "evidence.provenance_retrieval_event");
 }
+int handle_evidence_fidelity(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "evidence.fidelity_retrieval_event");
+}
 int handle_css_signals(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "css.signals");
@@ -1468,6 +1472,16 @@ static void test_routing(void)
    assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
                  "evidence.provenance_retrieval_event") == 0);
    assert(strcmp(g_last_handler, "evidence.provenance_retrieval_event") == 0);
+   cJSON_Delete(json);
+
+   /* Auditable-correctness P3: /v1/audit/fidelity's op must likewise resolve to
+    * its server-side KB-forward handler. */
+   json = dispatch_json(
+       ctx, conn, "{\"method\":\"evidence.fidelity_retrieval_event\",\"turn_id\":\"t1\"}",
+       strlen("{\"method\":\"evidence.fidelity_retrieval_event\",\"turn_id\":\"t1\"}"));
+   assert(strcmp(cJSON_GetObjectItem(json, "route")->valuestring,
+                 "evidence.fidelity_retrieval_event") == 0);
+   assert(strcmp(g_last_handler, "evidence.fidelity_retrieval_event") == 0);
    cJSON_Delete(json);
 
    json = dispatch_json(ctx, conn, "{\"method\":\"rules.delete\",\"id\":1}",


### PR DESCRIPTION
## What

Surfaces the P3 `fidelity_report` storage (landed in #367) over the audit API — the full **server→kb-forward vertical**, mirroring `/v1/audit/provenance` (#345) exactly across the same files. Read-only.

`POST /v1/audit/fidelity {turn_id}` → `aimee audit fidelity <turn_id>` returns:
```
{ status, fidelity_status, turn_id, report{supported,unsupported,abstained}, attribution_count }
```

## The vertical

- **KB handler** `kb_handle_evidence_fidelity` (`kb_service_memory.c`): reads `db2_fidelity_report_by_turn` + `db2_fidelity_attribution_count_by_turn`. `fidelity_status` is the four-state contract — **`not_evaluated`** is the honest default when the (default-off) judge hasn't run, **`evidence_unavailable`** on a lookup error. `turn_id` required + `<=128` guard. `attribution_count` is emitted only on a clean read; a count error flags `attribution_count_error` rather than a misleading `0`. + `kb_service.c` dispatch, header decl, `fidelity.h` include.
- **Server forward**: `kb_client_evidence_fidelity_retrieval_event` (`kb_client_memory.c` + `kb_client.h`); `handle_evidence_fidelity` (`server_state_audit.inc` + `server.h`); `server.c` dispatch; `server_auth.c` cap `CAP_INDEX_READ`; route `POST /v1/audit/fidelity`.
- **CLI**: `marshal_audit_fidelity` + dispatch + route-table entry; `cli_v1_routes_gen.inc` regenerated; `openapi-server-v1.yaml` + `openapi_server_data.h`.
- **Test**: `test_server_dispatch.c` stub + routing assertion (mirrors the provenance routing test; the 4-state data logic is covered by `unit-test-fidelity`).

## Verification

`make all` clean (aimee + aimee-server + aimee-kb); `make lint` ok — incl. `api-conformance`, `server-api-conformance`, `v1-method-coverage`, `cli-v1-routes-check`; `unit-test-server-dispatch` + build-integrity pass. Local roundtable gate: **0 blocking** (its suggestions were either consistency-with-the-provenance-sibling — envelope `status` vs domain `fidelity_status`, opaque object schema, KB-side length guard, routing-only dispatch test — or folded in: the attribution-count error honesty and the openapi state-contract clarification).

## Remaining P3

Only the **LLM entailment judge** that *populates* fidelity reports — default-off until the P4 human-curated gold corpus validates it (not autonomous). Until then this endpoint correctly returns `not_evaluated`.