### PR TITLE
feat(css): promote exemplar conventions to typed facts (#2-upgrade)

### DIFF
--- a/src/cli_css.c
+++ b/src/cli_css.c
@@ -13,7 +13,8 @@
 
 static const char *const CSS_OPS[] = {"dead-rules",          "conflicts",  "duplicate-declarations",
                                       "duplicate-selectors", "unresolved", "migrate-enumerate",
-                                      "migrate-list",        "rules-doc",  NULL};
+                                      "migrate-list",        "rules-doc",  "assert-conventions",
+                                      "conventions",         NULL};
 
 static int css_op_known(const char *op)
 {
@@ -28,7 +29,7 @@ static void css_usage(void)
    fprintf(stderr, "usage: aimee css <op> <project> [--json]\n"
                    "  ops: dead-rules | conflicts | duplicate-declarations |\n"
                    "       duplicate-selectors | unresolved | migrate-enumerate |\n"
-                   "       migrate-list | rules-doc\n");
+                   "       migrate-list | rules-doc | assert-conventions | conventions\n");
 }
 
 static void css_print_results(const char *op, cJSON *resp)
@@ -44,6 +45,30 @@ static void css_print_results(const char *op, cJSON *resp)
    {
       cJSON *u = cJSON_GetObjectItemCaseSensitive(resp, "units");
       printf("enumerated %d migration unit(s)\n", cJSON_IsNumber(u) ? u->valueint : 0);
+      return;
+   }
+   if (strcmp(op, "assert-conventions") == 0)
+   {
+      cJSON *a = cJSON_GetObjectItemCaseSensitive(resp, "asserted");
+      printf("asserted %d convention fact(s)\n", cJSON_IsNumber(a) ? a->valueint : 0);
+      return;
+   }
+   if (strcmp(op, "conventions") == 0)
+   {
+      cJSON *results = cJSON_GetObjectItemCaseSensitive(resp, "results");
+      printf("conventions: %d fact(s)\n", cJSON_GetArraySize(results));
+      cJSON *row = NULL;
+      cJSON_ArrayForEach(row, results)
+      {
+         const cJSON *rel = cJSON_GetObjectItemCaseSensitive(row, "relation");
+         const cJSON *val = cJSON_GetObjectItemCaseSensitive(row, "value");
+         const cJSON *src = cJSON_GetObjectItemCaseSensitive(row, "source");
+         printf("  %s = %s", cJSON_IsString(rel) ? rel->valuestring : "?",
+                cJSON_IsString(val) ? val->valuestring : "?");
+         if (cJSON_IsString(src))
+            printf("  (%s)", src->valuestring);
+         printf("\n");
+      }
       return;
    }
    cJSON *results = cJSON_GetObjectItemCaseSensitive(resp, "results");

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -8,6 +8,8 @@
 {"kb_client_bearer_token", SCHEMA_STRING, 0},
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
+{"css_style_graph_enabled", SCHEMA_BOOL, 0},
+{"typed_facts_enabled", SCHEMA_BOOL, 0},
 {"ingress_preinject_assembly_budget", SCHEMA_INT, 0},
 {"ingress_max_raw_scans", SCHEMA_INT, 0},
 {"guardrails", SCHEMA_OBJECT, 0},

--- a/src/db2/css_migration.c
+++ b/src/db2/css_migration.c
@@ -1,9 +1,11 @@
 /* db2/css_migration.c: CSS migration pipeline driver. See css_migration.h. */
 #include "css_migration.h"
 
+#include "config.h" /* typed_facts_enabled gate */
 #include "db2.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
+#include "typed_facts.h" /* #2-upgrade: convention facts */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -243,4 +245,55 @@ int db2_css_migration_rules_doc(const char *exemplar_project, char *buf, size_t 
    if (n < 0)
       return -1;
    return n;
+}
+
+int db2_css_migration_assert_conventions(const char *project, const char *now_iso)
+{
+   if (!project || !project[0])
+      return -1;
+   /* Gate on the typed-fact master flag; off -> the degraded rules-doc is the
+    * spec and we assert nothing. This is what consumes typed_facts_enabled. */
+   config_t cfg;
+   if (config_load(&cfg) != 0 || !cfg.css_style_graph_enabled || !cfg.typed_facts_enabled)
+      return 0;
+
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   int rules = cssm_count(conn,
+                          "SELECT COUNT(*) FROM css_rules c JOIN files f ON f.id = c.file_id"
+                          " JOIN projects p ON p.id = f.project_id WHERE p.name = ?1",
+                          project);
+   if (rules <= 0)
+      return rules < 0 ? -1 : 0; /* nothing indexed -> nothing to assert */
+   int tokens =
+       cssm_count(conn,
+                  "SELECT COUNT(*) FROM css_declarations d JOIN css_rules c ON c.id = d.rule_id"
+                  " JOIN files f ON f.id = c.file_id JOIN projects p ON p.id = f.project_id"
+                  " WHERE p.name = ?1 AND d.property LIKE '--%'",
+                  project);
+   int bem = cssm_count(conn,
+                        "SELECT COUNT(*) FROM css_rules c JOIN files f ON f.id = c.file_id"
+                        " JOIN projects p ON p.id = f.project_id"
+                        " WHERE p.name = ?1 AND (c.selector LIKE '%\\_\\_%' ESCAPE '\\'"
+                        "   OR c.selector LIKE '%--%')",
+                        project);
+
+   /* Assert the machine-derivable conventions as typed facts. The gate dedups /
+    * supersedes, so a re-run only changes what actually changed. Confidence is
+    * heuristic (model/derivation sourced), never user-authority. */
+   int asserted = 0;
+   int r;
+   r = db2_typed_fact_assert(project, "project", "naming_convention",
+                             bem > 0 ? "BEM" : "flat-utility", "scalar", 75, "exemplar-scan",
+                             now_iso);
+   if (r == TYPED_FACT_OK || r == TYPED_FACT_UNCHANGED)
+      asserted++;
+   r = db2_typed_fact_assert(project, "project", "token_strategy",
+                             tokens > 0 ? "css-custom-properties" : "literal-values", "scalar", 75,
+                             "exemplar-scan", now_iso);
+   if (r == TYPED_FACT_OK || r == TYPED_FACT_UNCHANGED)
+      asserted++;
+   return asserted;
 }

--- a/src/db2/css_migration.h
+++ b/src/db2/css_migration.h
@@ -71,6 +71,15 @@ extern "C"
     * naming convention). Returns bytes written (excl. NUL), -1 on error. */
    int db2_css_migration_rules_doc(const char *exemplar_project, char *buf, size_t cap);
 
+   /* #2-UPGRADE: promote the machine-derivable conventions (naming scheme, token
+    * strategy) from the exemplar's style graph into TYPED FACTS — assertions
+    * like (project, naming_convention, "BEM") with provenance + contradiction
+    * detection, via the typed-fact layer. Gated by typed_facts_enabled (returns
+    * 0, a no-op, when off — the degraded rules-doc remains the spec). Idempotent:
+    * a re-run supersedes only changed conventions. Returns the number of
+    * conventions asserted (or already-current), -1 on error. */
+   int db2_css_migration_assert_conventions(const char *project, const char *now_iso);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/kb/kb_service_css.c
+++ b/src/kb/kb_service_css.c
@@ -6,6 +6,7 @@
 #include "cJSON.h"
 #include "db2/css_graph.h"
 #include "db2/css_migration.h"
+#include "db2/typed_facts.h"
 
 #include <string.h>
 
@@ -138,6 +139,43 @@ int kb_handle_css_signals(int fd, cJSON *req)
          return kb_send_error(fd, "css rules-doc failed");
       }
       cJSON_AddStringToObject(resp, "rules_doc", doc);
+      return kb_send_response(fd, resp);
+   }
+   if (strcmp(op, "assert-conventions") == 0)
+   {
+      /* #2-upgrade: promote the exemplar's machine-derivable conventions into
+       * typed facts. No-op (returns 0) unless both css_style_graph_enabled and
+       * typed_facts_enabled are set. */
+      char now_iso[40];
+      now_utc(now_iso, sizeof(now_iso));
+      int n = db2_css_migration_assert_conventions(project, now_iso);
+      if (n < 0)
+      {
+         cJSON_Delete(resp);
+         return kb_send_error(fd, "css assert-conventions failed");
+      }
+      cJSON_AddNumberToObject(resp, "asserted", n);
+      return kb_send_response(fd, resp);
+   }
+   if (strcmp(op, "conventions") == 0)
+   {
+      /* Recall the project's active convention facts (naming_convention,
+       * token_strategy, ...) — every typed fact whose subject is the project. */
+      cJSON *arr = cJSON_CreateArray();
+      typed_fact_t tf[64];
+      int n = db2_typed_fact_recall(project, NULL, tf, 64);
+      for (int i = 0; i < n; i++)
+      {
+         cJSON *o = cJSON_CreateObject();
+         cJSON_AddStringToObject(o, "relation", tf[i].relation);
+         cJSON_AddStringToObject(o, "value", tf[i].object);
+         cJSON_AddNumberToObject(o, "confidence", tf[i].confidence);
+         cJSON_AddStringToObject(o, "source", tf[i].source);
+         cJSON_AddStringToObject(o, "asserted_at", tf[i].asserted_at);
+         cJSON_AddItemToArray(arr, o);
+      }
+      cJSON_AddItemToObject(resp, "results", arr);
+      cJSON_AddNumberToObject(resp, "count", n);
       return kb_send_response(fd, resp);
    }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -453,6 +453,7 @@ $(TESTPREFIX)/unit-test-css-migration: \
                                        $(OBJDIR)/tests/test_css_migration.o \
                                        $(OBJDIR)/db2/css_migration.o \
                                        $(OBJDIR)/db2/css_graph.o \
+                                       $(OBJDIR)/db2/typed_facts.o \
                                        $(OBJDIR)/css_analyze.o \
                                        $(OBJDIR)/db2/code_index.o \
                                        $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \

--- a/src/tests/test_css_migration.c
+++ b/src/tests/test_css_migration.c
@@ -5,11 +5,15 @@
 #include <string.h>
 
 #include "aimee.h"
+#include "config.h"
 #include "css_analyze.h"
 #include "db2_test_shim.h"
+#include "platform_path.h"
+#include "platform_test_util.h"
 #include "../db2/code_index.h"
 #include "../db2/css_graph.h"
 #include "../db2/css_migration.h"
+#include "../db2/typed_facts.h"
 
 static void test_gate(void)
 {
@@ -76,6 +80,41 @@ int main(void)
    assert(strstr(doc, "Convention Rules"));
    assert(strstr(doc, "BEM-like")); /* .card__title triggers the heuristic */
    assert(strstr(doc, "token"));
+
+   /* --- #2-upgrade: typed convention facts (config-gated) --- */
+   /* Off by default (no config) -> no-op, the degraded rules-doc is the spec. */
+   assert(db2_css_migration_assert_conventions("mig", "2026-01-02T00:00:00Z") == 0);
+
+   /* Enable both flags via an isolated config, then assert the conventions. */
+   char home[512];
+   snprintf(home, sizeof(home), "%s/aimee-mig-home-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(home) != NULL);
+   platform_setenv("HOME", home);
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1");
+   char cfgdir[640];
+   snprintf(cfgdir, sizeof(cfgdir), "%s/.config/aimee", home);
+   assert(platform_mkdir_p(cfgdir, 0700) == 0);
+   char cfgpath[768];
+   snprintf(cfgpath, sizeof(cfgpath), "%s/aimee.yaml", cfgdir);
+   FILE *cf = fopen(cfgpath, "w");
+   assert(cf);
+   fputs("css_style_graph_enabled: true\ntyped_facts_enabled: true\n", cf);
+   fclose(cf);
+
+   /* mig has .card__title (BEM __) + :root --brand (custom property). */
+   assert(db2_css_migration_assert_conventions("mig", "2026-01-02T00:00:00Z") == 2);
+
+   typed_fact_t tf[8];
+   int ntf = db2_typed_fact_recall("mig", "naming_convention", tf, 8);
+   assert(ntf == 1 && strcmp(tf[0].object, "BEM") == 0);
+   assert(strcmp(tf[0].source, "exemplar-scan") == 0);
+   ntf = db2_typed_fact_recall("mig", "token_strategy", tf, 8);
+   assert(ntf == 1 && strcmp(tf[0].object, "css-custom-properties") == 0);
+
+   /* idempotent re-assert: same conventions, still 2 (UNCHANGED counts) */
+   assert(db2_css_migration_assert_conventions("mig", "2026-01-03T00:00:00Z") == 2);
+   assert(db2_typed_fact_recall("mig", "naming_convention", tf, 8) == 1);
 
    db2_test_shim_close();
    printf("css_migration: all tests passed\n");


### PR DESCRIPTION
## What

Completes the CSS migration assistant's **#2-upgrade**, the convention model that was deferred as *"BLOCKED on typed-fact layer."* With the typed-fact store landed (#369), this promotes the exemplar's machine-derivable conventions from the degraded MIGRATION.md-style rules document into **typed facts**:

```
(project, naming_convention, "BEM" | "flat-utility")
(project, token_strategy,   "css-custom-properties" | "literal-values")
```

asserted with provenance (`source="exemplar-scan"`) through the typed-fact layer's write gate, so a re-scan that detects a *changed* convention **supersedes** the prior value (active=0 + superseded_by) rather than duplicating it — contradiction detection for free.

## Changes

- **`db2_css_migration_assert_conventions(project, now_iso)`** — derives `naming_convention` (BEM if `__`/`--` selectors present) and `token_strategy` (custom-properties if `--*` declarations present) from the style graph and asserts them via `db2_typed_fact_assert`. Gated by **both** `css_style_graph_enabled` and `typed_facts_enabled` (no-op returning 0 when off — the rules-doc remains the spec). Idempotent (UNCHANGED counts).
- **`aimee css assert-conventions` / `aimee css conventions`** — new ops on the KB `css.signals` action + CLI, over the **existing** `/v1/css/signals` route (no new route, no openapi/dispatch churn).
- **`config_schema.inc`** — allowlist `css_style_graph_enabled` + `typed_facts_enabled`. Pre-existing gap: both parsed on load (#365 / #369) but tripped `unknown key` config-validation warnings.

## Tests / gates

- `unit-test-css-migration` extended: off-by-default no-op; with both flags on → asserts 2 (BEM + css-custom-properties via the existing `.card__title` + `:root{--brand}` fixtures); recall verifies values + provenance; idempotent re-assert.
- Full `unit-tests` green (179 suites), `build-integrity`, `line-check`, `schema-sync-check`, `format`, `cli-v1-routes-check`, `server-api-conformance-check` all pass. `server` + `aimee-kb` build clean.

Default-off; degraded rules-doc path unchanged.
