### PR TITLE
feat(audit): P1.5 two-writer merge core for the retrieval_event (D14)

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -42,9 +42,15 @@
   server→kb-forward vertical mirroring `/v1/audit/provenance`, returning the
   turn's `fidelity_report` buckets + `attribution_count` with a four-state
   `fidelity_status` (`not_evaluated` when the default-off judge has not run).
-  **Remaining:** P1.5 (typed doc/code refs + two-writer merge), the P3 LLM
-  entailment judge *producer* (default-off until validated), P4 (labelled gold
-  corpus — needs human curation, not autonomous).
+  The **P1.5 two-writer merge core** landed next:
+  `db2_demotion_retrieval_event_merge_turn` (D14) — the first writer creates the
+  turn's `retrieval_event`; a later writer (e.g. the code-search surface) MERGES its
+  surfaced refs into that same event (deduped by id, point-in-time version captured
+  per merged ref) instead of being dropped, and re-merging is idempotent.
+  **Remaining:** the rest of P1.5 (widen the two `/v1` contracts to carry typed
+  doc/code refs + the `..._typed` attribution writer + wire the code-search surface
+  to call the merge), the P3 LLM entailment judge *producer* (default-off until
+  validated), P4 (labelled gold corpus — needs human curation, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/db2/demotion.c
+++ b/src/db2/demotion.c
@@ -153,6 +153,179 @@ int db2_demotion_retrieval_event_by_turn(const char *turn_id, char *id_out, int 
    return found;
 }
 
+int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *query_fingerprint,
+                                            const char *role, const int64_t *surfaced_ids,
+                                            int n_surfaced, char *id_out, int id_out_len)
+{
+   if (id_out && id_out_len > 0)
+      id_out[0] = '\0';
+   if (!turn_id || !turn_id[0])
+      return -1;
+
+   /* auditable-correctness P1.5 (D14): the two-writer idempotent merge. A turn's
+    * retrieval_event may be contributed to by more than one surface (the memory
+    * recall AND the code-search surface). The first writer creates the event; any
+    * later writer MERGES its surfaced refs into that same event rather than being
+    * dropped (the plain write_turn dup path only returns the existing id). Dedup by
+    * id makes it idempotent — re-merging the same refs is a no-op.
+    *
+    * Concurrency: a compare-and-swap retry loop (budget of 5 attempts; on exhaustion
+    * returns -1). The UPDATE lands only if the row's payload still equals what we
+    * read; a concurrent merge (or the event being deleted) yields 0 rows-affected,
+    * so we re-read and retry. The CREATE path also loops: after write_turn we
+    * `continue` and re-merge, so even if we lost a create race (write_turn wrote an
+    * un-stamped orphan and returned the winner's id) our refs still land in the
+    * canonical event on the next pass. Portable across Postgres and the sqlite shim
+    * (no FOR UPDATE / jsonb needed). */
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* One heap buffer reused across retries (~900 refs); avoids a large per-iteration
+    * stack frame. If a payload ever exceeds it, by_turn truncates → the CAS old-value
+    * can't match → retries exhaust → -1 (fail-safe, never a silent partial write). */
+   enum
+   {
+      MERGE_PAYLOAD_CAP = 65536
+   };
+   char *payload = malloc(MERGE_PAYLOAD_CAP);
+   if (!payload)
+      return -1;
+
+   int result = -1;
+   for (int attempt = 0; attempt < 5; attempt++)
+   {
+      char ev_id[64] = "";
+      payload[0] = '\0';
+      int rc = db2_demotion_retrieval_event_by_turn(turn_id, ev_id, sizeof(ev_id), payload,
+                                                    MERGE_PAYLOAD_CAP);
+      if (rc < 0)
+      {
+         result = -1;
+         break;
+      }
+      if (rc == 0)
+      {
+         /* No event yet — create it, then loop to re-read + merge (so our refs land
+          * even if a concurrent writer won the create race). */
+         char created[64] = "";
+         if (db2_demotion_retrieval_event_write_turn(turn_id, query_fingerprint, role, surfaced_ids,
+                                                     n_surfaced, created, sizeof(created)) != 0)
+         {
+            result = -1;
+            break;
+         }
+         continue;
+      }
+
+      cJSON *p = payload[0] ? cJSON_Parse(payload) : NULL;
+      if (!p)
+      {
+         result = -1; /* present row, unparseable payload — surface the error */
+         break;
+      }
+      cJSON *ids = cJSON_GetObjectItemCaseSensitive(p, "surfaced_ids");
+      cJSON *items = cJSON_GetObjectItemCaseSensitive(p, "surfaced_items");
+      if (!cJSON_IsArray(ids))
+         ids = cJSON_AddArrayToObject(p, "surfaced_ids");
+      if (!cJSON_IsArray(items))
+         items = cJSON_AddArrayToObject(p, "surfaced_items");
+      if (!ids || !items) /* allocation failure */
+      {
+         cJSON_Delete(p);
+         result = -1;
+         break;
+      }
+
+      int added = 0;
+      for (int i = 0; surfaced_ids && i < n_surfaced; i++)
+      {
+         int64_t id = surfaced_ids[i];
+         if (id <= 0) /* non-positive ids are ignored (documented in the header) */
+            continue;
+         /* dedup: skip ids already recorded on the event (idempotency). ids are
+          * stored as JSON numbers by the writer (cJSON_CreateNumber((double)id)),
+          * so compare the same way — lossless for memory ids (well under 2^53). */
+         int present = 0, m = cJSON_GetArraySize(ids);
+         for (int j = 0; j < m; j++)
+         {
+            cJSON *e = cJSON_GetArrayItem(ids, j);
+            if (cJSON_IsNumber(e) && (int64_t)e->valuedouble == id)
+            {
+               present = 1;
+               break;
+            }
+         }
+         if (present)
+            continue;
+         cJSON_AddItemToArray(ids, cJSON_CreateNumber((double)id));
+         /* Capture this ref's point-in-time version at merge, mirroring the writer's
+          * surfaced_items=[{id,v}] (v omitted when unresolved — provenance treats a
+          * missing turn-version as "unknown", not drift) so the shape is identical. */
+         char version[64] = "";
+         int found = db2_memory_provenance_by_id(id, NULL, 0, NULL, 0, version, sizeof(version));
+         cJSON *it = cJSON_CreateObject();
+         cJSON_AddNumberToObject(it, "id", (double)id);
+         if (found == 1 && version[0])
+            cJSON_AddStringToObject(it, "v", version);
+         cJSON_AddItemToArray(items, it);
+         added++;
+      }
+
+      if (added == 0)
+      {
+         /* All refs already present — idempotent no-op, no write needed. */
+         cJSON_Delete(p);
+         if (id_out && id_out_len > 0)
+            snprintf(id_out, (size_t)id_out_len, "%s", ev_id);
+         result = 0;
+         break;
+      }
+
+      char *newpayload = cJSON_PrintUnformatted(p);
+      cJSON_Delete(p);
+      if (!newpayload)
+      {
+         result = -1;
+         break;
+      }
+
+      /* CAS: land the update only if the payload is still the value we merged from. */
+      char err[256] = "";
+      aimee_pg_stmt_t *st =
+          aimee_pg_prepare(conn, "UPDATE artifacts SET payload = ?1 WHERE id = ?2 AND payload = ?3",
+                           err, sizeof(err));
+      if (!st)
+      {
+         free(newpayload);
+         result = -1;
+         break;
+      }
+      aimee_pg_bind_text(st, "?1", newpayload);
+      aimee_pg_bind_text(st, "?2", ev_id);
+      aimee_pg_bind_text(st, "?3", payload);
+      int step = aimee_pg_step(st, err, sizeof(err));
+      int changes = aimee_pg_stmt_changes(st);
+      aimee_pg_finalize(st);
+      free(newpayload);
+      if (step != AIMEE_PG_DONE)
+      {
+         result = -1;
+         break;
+      }
+      if (changes > 0)
+      {
+         if (id_out && id_out_len > 0)
+            snprintf(id_out, (size_t)id_out_len, "%s", ev_id);
+         result = 0;
+         break;
+      }
+      /* 0 rows: concurrent merge or the event vanished — re-read and retry. */
+   }
+   free(payload);
+   return result;
+}
+
 int db2_demotion_retrieval_attribution_write(const char *retrieval_event_id,
                                              int64_t surfaced_row_id, const char *verdict,
                                              double weight)

--- a/src/db2/demotion.h
+++ b/src/db2/demotion.h
@@ -59,6 +59,23 @@ extern "C"
    int db2_demotion_retrieval_event_by_turn(const char *turn_id, char *id_out, int id_out_len,
                                             char *payload_out, int payload_out_len);
 
+   /* auditable-correctness P1.5 (D14): the idempotent two-writer merge. If no event
+    * exists for `turn_id` yet, behaves exactly like ..._write_turn (first writer
+    * creates it). If one exists, MERGES the new `surfaced_ids` into that same event
+    * (deduped by id, with each ref's point-in-time version captured into
+    * surfaced_items) instead of dropping them — so a second surface (e.g. code
+    * search) contributes to the same turn event. Idempotent: re-merging refs already
+    * present is a no-op. Concurrency-safe via a compare-and-swap retry (budget of 5
+    * attempts, then -1; no FOR UPDATE needed; portable to the sqlite shim). The
+    * create path also retries so refs land even if a concurrent writer wins the
+    * initial create. Non-positive ids in `surfaced_ids` are
+    * ignored. `query_fingerprint`/`role` are used ONLY on the first-writer create
+    * path (a later writer contributes refs, not a new fingerprint). Writes the
+    * canonical event id into id_out (may be NULL). Returns 0 / -1. */
+   int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *query_fingerprint,
+                                               const char *role, const int64_t *surfaced_ids,
+                                               int n_surfaced, char *id_out, int id_out_len);
+
    /* Write a retrieval_attribution artifact linking one surfaced row to a verdict.
     * retrieval_event_id: UUID of the originating retrieval_event.
     * surfaced_row_id: memory row id that contributed to the response.

--- a/src/tests/test_demotion.c
+++ b/src/tests/test_demotion.c
@@ -96,6 +96,46 @@ static void test_retrieval_event_turn(void)
    printf("  retrieval_event_turn: ok\n");
 }
 
+/* ---- 1b. retrieval_event_merge_turn (P1.5 idempotent two-writer merge) ---- */
+static void test_retrieval_event_merge_turn(void)
+{
+   open_db();
+
+   /* First writer on a fresh turn → behaves like write_turn (creates the event). */
+   int64_t a[2] = {11, 22};
+   char ev_id[64];
+   assert(db2_demotion_retrieval_event_merge_turn("turn-m", "fp", "Recall", a, 2, ev_id,
+                                                  sizeof(ev_id)) == 0);
+   char payload[8192];
+   assert(db2_demotion_retrieval_event_by_turn("turn-m", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "\"surfaced_ids\":[11,22]") != NULL);
+
+   /* Second writer on the SAME turn → merges new refs into the same event (22 is a
+    * dup and is skipped; 33 is added). Returns the same canonical event id. */
+   int64_t b[2] = {22, 33};
+   char got[64];
+   assert(db2_demotion_retrieval_event_merge_turn("turn-m", "fp2", "Recall", b, 2, got,
+                                                  sizeof(got)) == 0);
+   assert(strcmp(got, ev_id) == 0); /* same event, not a new one */
+   assert(db2_demotion_retrieval_event_by_turn("turn-m", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "\"surfaced_ids\":[11,22,33]") != NULL);
+   /* the merged ref also gets a surfaced_items entry (same shape as the writer) */
+   assert(strstr(payload, "\"surfaced_items\":") != NULL);
+   assert(strstr(payload, "{\"id\":33}") != NULL); /* id-only (no v: id 33 unresolved) */
+
+   /* Idempotent: re-merging refs already present changes nothing. */
+   int64_t c[2] = {11, 33};
+   assert(db2_demotion_retrieval_event_merge_turn("turn-m", "fp3", "Recall", c, 2, NULL, 0) == 0);
+   assert(db2_demotion_retrieval_event_by_turn("turn-m", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "\"surfaced_ids\":[11,22,33]") != NULL); /* unchanged */
+
+   /* bad arg. */
+   assert(db2_demotion_retrieval_event_merge_turn("", "fp", "Recall", a, 2, NULL, 0) == -1);
+
+   close_db();
+   printf("  retrieval_event_merge_turn: ok\n");
+}
+
 /* ---- 2. retrieval_attribution_write ---- */
 static void test_retrieval_attribution_write(void)
 {
@@ -255,6 +295,7 @@ int main(void)
 
    test_retrieval_event_write();
    test_retrieval_event_turn();
+   test_retrieval_event_merge_turn();
    test_retrieval_attribution_write();
    test_demotion_score_empty();
    test_demotion_score_basic();


### PR DESCRIPTION
## What

Lands the **DB-specific core of P1.5** — `db2_demotion_retrieval_event_merge_turn`, the idempotent two-writer merge (D14). A turn's `retrieval_event` can be contributed to by more than one surface (memory recall **and** the code-search surface). The first writer creates the event; a later writer now **merges** its surfaced refs into that same event instead of being dropped (the plain `write_turn` dup path only returns the existing id, losing the second writer's refs).

The serving-side wiring (widening the two `/v1` contracts to carry typed doc/code refs + the `..._typed` attribution writer + wiring the code-search surface to call this) is a later P1.5 increment; this PR is the isolated, unit-tested core.

## Behaviour

- **Merge + dedup**: new `surfaced_ids` are appended deduped-by-id; each gets a `surfaced_items` `{id,v}` entry with the ref's point-in-time version captured at merge — **identical shape** to the writer (`v` omitted when unresolved). Re-merging refs already present is a **no-op** (idempotent).
- **Concurrency-safe** via a compare-and-swap retry loop: `UPDATE … WHERE id=? AND payload=<old>`; on 0 rows-affected (a concurrent merge changed it, or the event vanished) it re-reads and retries (budget 5, then -1). The **create path also loops** (`write_turn` then `continue`), so refs land even if a concurrent writer wins the initial create race. Portable across Postgres + the sqlite shim (no `FOR UPDATE`/`jsonb`).
- One reused heap buffer (no large per-iteration stack frame); non-positive ids ignored; `query_fingerprint`/`role` used only on create.

## Verification

`make all` clean (aimee + aimee-server + aimee-kb), `make lint` ok, `unit-test-demotion` passes — first-writer-creates, second-writer-merges-with-dedup (`[11,22]+[22,33]=[11,22,33]`, incl. `surfaced_items`), idempotent re-merge unchanged, empty turn_id rejected.

Local roundtable gate: **0 blocking**. Round 1's three "blocking" were either confabulated or consistency-with-the-existing-writer (the `v`-omission and int64→double both mirror `db2_demotion_retrieval_event_write` exactly; the cJSON-leak and test-isolation claims were misreads — `cJSON_Delete` precedes the return and `open_db()` uses a fresh shim). The real ones — the read-modify-write race and rows-affected — are fixed by the CAS loop; round 2's create-race and stack-buffer majors are folded in (create-path retry + heap buffer).

## Note on test coverage

True multi-process concurrency can't be exercised under the single-connection sqlite shim, so the CAS retry's contended branch is covered by construction + review rather than a concurrent unit test; the happy, idempotent, and create paths are tested.