### PR TITLE
feat(css): rendered computed-style oracle core + adapter seam (#4-full, slice 1)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -316,7 +316,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c \
+            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
@@ -411,7 +411,7 @@ KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c \
+               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_PLATFORM_OBJS = $(PLATFORM_BASIC_OBJS) $(filter %/agent_bridge.o %/cli_client.o %/memory.o,$(PLATFORM_EXTRA_OBJS) $(PLATFORM_AGENT_OBJS))

--- a/src/css_render_oracle.c
+++ b/src/css_render_oracle.c
@@ -1,0 +1,290 @@
+/* css_render_oracle.c: rendered computed-style equivalence oracle (#4-full core).
+ * See css_render_oracle.h. Pure leaf: libc + cJSON. */
+#include "css_render_oracle.h"
+
+#include "cJSON.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *CSS_RENDER_BANNER =
+    "RENDERED computed-style equivalence for the captured DOM/viewport/state set "
+    "ONLY: nodes are matched by ref, and any unmatched node or differing computed "
+    "value is reported as a change (conservative). It does NOT cover viewports, "
+    "pseudo-states, or interactions the render adapter did not capture. A missing "
+    "or unparseable snapshot yields an UNKNOWN verdict, never 'equivalent'.";
+
+const char *css_render_oracle_limitation_banner(void)
+{
+   return CSS_RENDER_BANNER;
+}
+
+/* CSS property names are case-insensitive; lowercase + trim. */
+static void norm_property(const char *in, char *out, size_t cap)
+{
+   while (*in && isspace((unsigned char)*in))
+      in++;
+   size_t j = 0;
+   for (; *in && j < cap - 1; in++)
+      out[j++] = (char)tolower((unsigned char)*in);
+   while (j > 0 && isspace((unsigned char)out[j - 1]))
+      j--;
+   out[j] = '\0';
+}
+
+/* Computed values are compared verbatim except for whitespace normalization, so
+ * "rgb(0,  0, 0)" == "rgb(0, 0, 0)" but colors/units are otherwise untouched. */
+static void norm_value(const char *in, char *out, size_t cap)
+{
+   while (*in && isspace((unsigned char)*in))
+      in++;
+   size_t j = 0;
+   int prev_space = 0;
+   for (; *in && j < cap - 1; in++)
+   {
+      if (isspace((unsigned char)*in))
+      {
+         if (!prev_space && j > 0)
+            out[j++] = ' ';
+         prev_space = 1;
+      }
+      else
+      {
+         out[j++] = *in;
+         prev_space = 0;
+      }
+   }
+   while (j > 0 && out[j - 1] == ' ')
+      j--;
+   out[j] = '\0';
+}
+
+/* ---- snapshot parsing ---------------------------------------------------- */
+
+css_render_snapshot_t *css_render_snapshot_parse(const char *json)
+{
+   if (!json)
+      return NULL;
+   cJSON *root = cJSON_Parse(json);
+   if (!root)
+      return NULL;
+   cJSON *nodes = cJSON_GetObjectItemCaseSensitive(root, "nodes");
+   if (!cJSON_IsArray(nodes))
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   css_render_snapshot_t *s = calloc(1, sizeof(*s));
+   if (!s)
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   int nn = cJSON_GetArraySize(nodes);
+   if (nn > 0)
+   {
+      s->nodes = calloc((size_t)nn, sizeof(css_render_node_t));
+      if (!s->nodes)
+      {
+         free(s);
+         cJSON_Delete(root);
+         return NULL;
+      }
+   }
+   cJSON *node = NULL;
+   cJSON_ArrayForEach(node, nodes)
+   {
+      if (!cJSON_IsObject(node))
+         continue;
+      cJSON *ref = cJSON_GetObjectItemCaseSensitive(node, "ref");
+      cJSON *computed = cJSON_GetObjectItemCaseSensitive(node, "computed");
+      if (!cJSON_IsString(ref) || !cJSON_IsObject(computed))
+         continue;
+      css_render_node_t *n = &s->nodes[s->nnodes];
+      snprintf(n->ref, sizeof(n->ref), "%s", ref->valuestring);
+      int np = cJSON_GetArraySize(computed);
+      if (np > 0)
+      {
+         n->props = calloc((size_t)np, sizeof(css_render_prop_t));
+         if (!n->props)
+            continue; /* drop this node's props; keep going (conservative) */
+      }
+      cJSON *prop = NULL;
+      cJSON_ArrayForEach(prop, computed)
+      {
+         if (!cJSON_IsString(prop) || !prop->string)
+            continue;
+         css_render_prop_t *p = &n->props[n->nprops];
+         norm_property(prop->string, p->property, sizeof(p->property));
+         if (!p->property[0])
+            continue;
+         norm_value(prop->valuestring, p->value, sizeof(p->value));
+         n->nprops++;
+      }
+      s->nnodes++;
+   }
+   cJSON_Delete(root);
+   return s;
+}
+
+void css_render_snapshot_free(css_render_snapshot_t *s)
+{
+   if (!s)
+      return;
+   for (int i = 0; i < s->nnodes; i++)
+      free(s->nodes[i].props);
+   free(s->nodes);
+   free(s);
+}
+
+/* ---- comparison ---------------------------------------------------------- */
+
+static const css_render_node_t *find_node(const css_render_snapshot_t *s, const char *ref)
+{
+   for (int i = 0; i < s->nnodes; i++)
+      if (strcmp(s->nodes[i].ref, ref) == 0)
+         return &s->nodes[i];
+   return NULL;
+}
+
+static const css_render_prop_t *find_prop(const css_render_node_t *n, const char *prop)
+{
+   for (int i = 0; i < n->nprops; i++)
+      if (strcmp(n->props[i].property, prop) == 0)
+         return &n->props[i];
+   return NULL;
+}
+
+static void add_diff(css_render_result_t *r, int *cap, const char *ref, const char *prop,
+                     const char *bval, const char *aval, css_render_diff_kind_t kind)
+{
+   if (r->diff_count >= *cap)
+   {
+      int nc = *cap == 0 ? 8 : *cap * 2;
+      css_render_diff_t *grown = realloc(r->diffs, (size_t)nc * sizeof(css_render_diff_t));
+      if (!grown)
+         return; /* drop this diff; equivalence already false once any diff seen */
+      r->diffs = grown;
+      *cap = nc;
+   }
+   css_render_diff_t *d = &r->diffs[r->diff_count++];
+   memset(d, 0, sizeof(*d));
+   snprintf(d->ref, sizeof(d->ref), "%s", ref ? ref : "");
+   snprintf(d->property, sizeof(d->property), "%s", prop ? prop : "");
+   snprintf(d->before_value, sizeof(d->before_value), "%s", bval ? bval : "");
+   snprintf(d->after_value, sizeof(d->after_value), "%s", aval ? aval : "");
+   d->kind = kind;
+}
+
+css_render_result_t *css_render_oracle_compare(const css_render_snapshot_t *before,
+                                               const css_render_snapshot_t *after)
+{
+   css_render_result_t *r = calloc(1, sizeof(*r));
+   if (!r)
+      return NULL;
+   r->limitation = CSS_RENDER_BANNER;
+
+   /* Conservative: a missing snapshot is an UNKNOWN verdict, never equivalent. */
+   if (!before || !after)
+   {
+      r->available = 0;
+      r->equivalent = 0;
+      return r;
+   }
+   r->available = 1;
+
+   int cap = 0;
+   /* Walk BEFORE nodes: structural-missing, changed, and removed properties. */
+   for (int i = 0; i < before->nnodes; i++)
+   {
+      const css_render_node_t *bn = &before->nodes[i];
+      const css_render_node_t *an = find_node(after, bn->ref);
+      if (!an)
+      {
+         add_diff(r, &cap, bn->ref, "", "", "", CSS_RENDER_DIFF_NODE_MISSING);
+         continue;
+      }
+      for (int j = 0; j < bn->nprops; j++)
+      {
+         const css_render_prop_t *ap = find_prop(an, bn->props[j].property);
+         if (!ap)
+            add_diff(r, &cap, bn->ref, bn->props[j].property, bn->props[j].value, "",
+                     CSS_RENDER_DIFF_REMOVED);
+         else if (strcmp(bn->props[j].value, ap->value) != 0)
+            add_diff(r, &cap, bn->ref, bn->props[j].property, bn->props[j].value, ap->value,
+                     CSS_RENDER_DIFF_CHANGED);
+      }
+   }
+   /* Walk AFTER nodes: structural-new nodes and added properties. */
+   for (int i = 0; i < after->nnodes; i++)
+   {
+      const css_render_node_t *an = &after->nodes[i];
+      const css_render_node_t *bn = find_node(before, an->ref);
+      if (!bn)
+      {
+         add_diff(r, &cap, an->ref, "", "", "", CSS_RENDER_DIFF_NODE_NEW);
+         continue;
+      }
+      for (int j = 0; j < an->nprops; j++)
+      {
+         if (!find_prop(bn, an->props[j].property))
+            add_diff(r, &cap, an->ref, an->props[j].property, "", an->props[j].value,
+                     CSS_RENDER_DIFF_ADDED);
+      }
+   }
+
+   r->equivalent = (r->diff_count == 0);
+   return r;
+}
+
+void css_render_result_free(css_render_result_t *r)
+{
+   if (!r)
+      return;
+   free(r->diffs);
+   free(r);
+}
+
+/* ---- render adapter seam ------------------------------------------------- */
+
+static css_render_adapter_fn g_render_adapter = NULL;
+
+void css_render_oracle_set_adapter(css_render_adapter_fn fn)
+{
+   g_render_adapter = fn;
+}
+
+int css_render_oracle_has_adapter(void)
+{
+   return g_render_adapter != NULL;
+}
+
+css_render_status_t css_render_oracle_render(const char *html, const char *css, char **out_json,
+                                             char **err)
+{
+   if (out_json)
+      *out_json = NULL;
+   if (err)
+      *err = NULL;
+   if (!g_render_adapter)
+      return CSS_RENDER_UNAVAILABLE;
+   char *local_err = NULL;
+   int rc = g_render_adapter(html ? html : "", css ? css : "", out_json, &local_err);
+   if (rc != 0)
+   {
+      if (err)
+         *err = local_err;
+      else
+         free(local_err);
+      if (out_json && *out_json)
+      {
+         free(*out_json);
+         *out_json = NULL;
+      }
+      return CSS_RENDER_ERROR;
+   }
+   free(local_err);
+   return CSS_RENDER_OK;
+}

--- a/src/headers/css_render_oracle.h
+++ b/src/headers/css_render_oracle.h
@@ -1,0 +1,139 @@
+/* css_render_oracle.h: rendered computed-style equivalence oracle (#4-full core).
+ *
+ * The interim oracle (css_oracle.h) compares static declaration sets and is
+ * STRICTLY WEAKER than the real correctness signal for a CSS migration, which is
+ * the *computed style* of the rendered DOM before vs. after — cascade,
+ * inheritance, and shorthand expansion already applied by a browser engine. This
+ * module is the render-free CORE of that #4-full oracle: it operates over
+ * computed-style SNAPSHOTS (per-node property->value maps produced by a real
+ * render) and diffs them node-by-node, property-by-property.
+ *
+ * Producing the snapshots requires a headless browser running UNTRUSTED app/
+ * exemplar code, which must run OUT-OF-PROCESS and SANDBOXED (proposal §8) — and
+ * no such engine ships with aimee today. So the render itself is behind a
+ * pluggable ADAPTER SEAM (css_render_oracle_set_adapter): a backend (a delegate-
+ * driven renderer or a render sidecar) registers a function that turns html+css
+ * into a snapshot JSON; with no adapter the oracle reports UNAVAILABLE rather
+ * than guessing. The comparison logic here is a pure leaf (libc + cJSON) and is
+ * fully testable without any browser.
+ *
+ * CONSERVATIVE, like the interim oracle: a missing/unparseable snapshot yields
+ * available=0 (verdict unknown, never "equivalent"); unmatched nodes and any
+ * property difference are reported as non-equivalence. Every result carries an
+ * explicit limitation banner (no silent "equivalent", proposal §8). The snapshot
+ * JSON (the captured computed styles) is the origin artifact and is retained by
+ * the storage layer (see db2/css_render.*), never re-derived for diffing.
+ */
+#ifndef DEC_CSS_RENDER_ORACLE_H
+#define DEC_CSS_RENDER_ORACLE_H 1
+
+#include "css_analyze.h" /* CSS_PROPERTY_MAX, CSS_VALUE_MAX */
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define CSS_RENDER_REF_MAX 256 /* a node's stable ref (selector / DOM path) */
+
+   /* One computed property of one rendered node. */
+   typedef struct
+   {
+      char property[CSS_PROPERTY_MAX];
+      char value[CSS_VALUE_MAX];
+   } css_render_prop_t;
+
+   /* One rendered node: a stable ref plus its computed-style map. */
+   typedef struct
+   {
+      char ref[CSS_RENDER_REF_MAX];
+      css_render_prop_t *props;
+      int nprops;
+   } css_render_node_t;
+
+   /* A computed-style snapshot of one conversion unit (a set of nodes). Parsed
+    * from the render adapter's JSON; the whole JSON is the retained origin. */
+   typedef struct
+   {
+      css_render_node_t *nodes;
+      int nnodes;
+   } css_render_snapshot_t;
+
+   typedef enum
+   {
+      CSS_RENDER_DIFF_CHANGED = 1,      /* node in both, computed value differs */
+      CSS_RENDER_DIFF_REMOVED = 2,      /* property in BEFORE node, absent in AFTER node */
+      CSS_RENDER_DIFF_ADDED = 3,        /* property in AFTER node, absent in BEFORE node */
+      CSS_RENDER_DIFF_NODE_MISSING = 4, /* node ref in BEFORE, absent in AFTER (structural) */
+      CSS_RENDER_DIFF_NODE_NEW = 5,     /* node ref in AFTER, absent in BEFORE (structural) */
+   } css_render_diff_kind_t;
+
+   typedef struct
+   {
+      char ref[CSS_RENDER_REF_MAX];
+      char property[CSS_PROPERTY_MAX]; /* empty for NODE_MISSING / NODE_NEW */
+      char before_value[CSS_VALUE_MAX];
+      char after_value[CSS_VALUE_MAX];
+      css_render_diff_kind_t kind;
+   } css_render_diff_t;
+
+   typedef struct
+   {
+      int available;  /* 0 iff a snapshot was missing/unparseable -> verdict unknown */
+      int equivalent; /* 1 iff available AND every node's computed map is identical */
+      css_render_diff_t *diffs;
+      int diff_count;
+      const char *limitation; /* static banner; not owned by the caller */
+   } css_render_result_t;
+
+   /* Parse a computed-style snapshot from the render adapter's JSON. Expected
+    * shape: {"nodes":[{"ref":"<sel>","computed":{"<prop>":"<value>",...}},...]}.
+    * Other top-level fields (viewport, states, ...) are ignored (forward-compat).
+    * Returns NULL on allocation failure or malformed JSON. Free with
+    * css_render_snapshot_free. */
+   css_render_snapshot_t *css_render_snapshot_parse(const char *json);
+   void css_render_snapshot_free(css_render_snapshot_t *s);
+
+   /* Compare two computed-style snapshots node-by-node. If either is NULL the
+    * result is available=0 / equivalent=0 (conservative: unknown != equivalent).
+    * Returns NULL only on allocation failure. Free with css_render_result_free. */
+   css_render_result_t *css_render_oracle_compare(const css_render_snapshot_t *before,
+                                                  const css_render_snapshot_t *after);
+   void css_render_result_free(css_render_result_t *r);
+
+   /* The limitation banner text (also reachable via result->limitation). */
+   const char *css_render_oracle_limitation_banner(void);
+
+   /* ---- Render adapter seam -------------------------------------------------
+    * A render backend implements this signature: given a unit's html + css,
+    * produce a computed-style snapshot JSON (caller frees *out_json). Returns 0
+    * on success; non-zero sets *err (caller frees) and leaves *out_json NULL.
+    * The backend MUST run the browser engine out-of-process and sandboxed —
+    * it renders untrusted code (proposal §8). */
+   typedef int (*css_render_adapter_fn)(const char *html, const char *css, char **out_json,
+                                        char **err);
+
+   typedef enum
+   {
+      CSS_RENDER_OK = 0,
+      CSS_RENDER_UNAVAILABLE = -1, /* no adapter registered — verdict stays unknown */
+      CSS_RENDER_ERROR = -2,       /* adapter ran but failed (*err set) */
+   } css_render_status_t;
+
+   /* Register (or clear, with NULL) the process-wide render adapter. */
+   void css_render_oracle_set_adapter(css_render_adapter_fn fn);
+   int css_render_oracle_has_adapter(void);
+
+   /* Render a unit via the registered adapter. With no adapter, returns
+    * CSS_RENDER_UNAVAILABLE and leaves *out_json NULL — callers MUST treat that
+    * as "unknown", never "equivalent". On CSS_RENDER_ERROR, *err is set. */
+   css_render_status_t css_render_oracle_render(const char *html, const char *css, char **out_json,
+                                                char **err);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CSS_RENDER_ORACLE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -89,7 +89,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-session-search-tool \
                $(TESTPREFIX)/unit-test-working-memory $(TESTPREFIX)/unit-test-working-memory-mock $(TESTPREFIX)/unit-test-local-resolution $(TESTPREFIX)/unit-test-cognify-jobs $(TESTPREFIX)/unit-test-extractors-extra \
-               $(TESTPREFIX)/unit-test-css-analyze $(TESTPREFIX)/unit-test-typed-facts $(TESTPREFIX)/unit-test-css-graph $(TESTPREFIX)/unit-test-css-oracle $(TESTPREFIX)/unit-test-css-migration \
+               $(TESTPREFIX)/unit-test-css-analyze $(TESTPREFIX)/unit-test-typed-facts $(TESTPREFIX)/unit-test-css-graph $(TESTPREFIX)/unit-test-css-oracle $(TESTPREFIX)/unit-test-css-render-oracle $(TESTPREFIX)/unit-test-css-migration \
                $(TESTPREFIX)/unit-test-compute-pool $(TESTPREFIX)/unit-test-db2-pool $(TESTPREFIX)/unit-test-cli-launch \
                $(TESTPREFIX)/unit-test-server-session-pools \
                $(TESTPREFIX)/unit-test-presence \
@@ -657,6 +657,10 @@ $(TESTPREFIX)/unit-test-css-analyze: $(OBJDIR)/tests/test_css_analyze.o $(OBJDIR
 
 # CSS interim static oracle (WP-E) — leaf: css_oracle.o + css_analyze.o + libc.
 $(TESTPREFIX)/unit-test-css-oracle: $(OBJDIR)/tests/test_css_oracle.o $(OBJDIR)/css_oracle.o $(OBJDIR)/css_analyze.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# CSS rendered computed-style oracle core (#4-full) — leaf: css_render_oracle.o + cJSON + libc.
+$(TESTPREFIX)/unit-test-css-render-oracle: $(OBJDIR)/tests/test_css_render_oracle.o $(OBJDIR)/css_render_oracle.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-text: $(OBJDIR)/tests/test_text.o $(OBJDIR)/util.o $(OBJDIR)/text.o \

--- a/src/tests/test_css_render_oracle.c
+++ b/src/tests/test_css_render_oracle.c
@@ -1,0 +1,196 @@
+/* test_css_render_oracle.c: #4-full core — computed-style snapshot parsing,
+ * node/property diffs, conservative unknown verdict, and the render adapter seam. */
+#include "css_render_oracle.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+static const css_render_diff_t *find_diff(const css_render_result_t *r, const char *ref,
+                                          const char *prop)
+{
+   for (int i = 0; i < r->diff_count; i++)
+      if (strcmp(r->diffs[i].ref, ref) == 0 && strcmp(r->diffs[i].property, prop) == 0)
+         return &r->diffs[i];
+   return NULL;
+}
+
+static void test_identical_equivalent(void)
+{
+   const char *j = "{\"nodes\":[{\"ref\":\".btn\",\"computed\":"
+                   "{\"color\":\"rgb(0, 0, 0)\",\"display\":\"inline-block\"}}]}";
+   css_render_snapshot_t *a = css_render_snapshot_parse(j);
+   css_render_snapshot_t *b = css_render_snapshot_parse(j);
+   assert(a && b && a->nnodes == 1 && a->nodes[0].nprops == 2);
+   css_render_result_t *r = css_render_oracle_compare(a, b);
+   assert(r && r->available == 1 && r->equivalent == 1 && r->diff_count == 0);
+   assert(r->limitation && strstr(r->limitation, "RENDERED"));
+   css_render_result_free(r);
+   css_render_snapshot_free(a);
+   css_render_snapshot_free(b);
+}
+
+static void test_value_changed(void)
+{
+   css_render_snapshot_t *a = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".btn\",\"computed\":{\"color\":\"rgb(0, 0, 0)\"}}]}");
+   css_render_snapshot_t *b = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".btn\",\"computed\":{\"color\":\"rgb(255, 0, 0)\"}}]}");
+   css_render_result_t *r = css_render_oracle_compare(a, b);
+   assert(r->available == 1 && r->equivalent == 0 && r->diff_count == 1);
+   const css_render_diff_t *d = find_diff(r, ".btn", "color");
+   assert(d && d->kind == CSS_RENDER_DIFF_CHANGED);
+   assert(strcmp(d->before_value, "rgb(0, 0, 0)") == 0);
+   assert(strcmp(d->after_value, "rgb(255, 0, 0)") == 0);
+   css_render_result_free(r);
+   css_render_snapshot_free(a);
+   css_render_snapshot_free(b);
+}
+
+static void test_removed_and_added(void)
+{
+   css_render_snapshot_t *a = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".x\",\"computed\":{\"color\":\"black\",\"margin\":\"0px\"}}]}");
+   css_render_snapshot_t *b = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".x\",\"computed\":{\"color\":\"black\",\"padding\":\"4px\"}}]}");
+   css_render_result_t *r = css_render_oracle_compare(a, b);
+   assert(r->equivalent == 0 && r->diff_count == 2);
+   const css_render_diff_t *rem = find_diff(r, ".x", "margin");
+   const css_render_diff_t *add = find_diff(r, ".x", "padding");
+   assert(rem && rem->kind == CSS_RENDER_DIFF_REMOVED && strcmp(rem->before_value, "0px") == 0);
+   assert(add && add->kind == CSS_RENDER_DIFF_ADDED && strcmp(add->after_value, "4px") == 0);
+   css_render_result_free(r);
+   css_render_snapshot_free(a);
+   css_render_snapshot_free(b);
+}
+
+static void test_node_missing_and_new(void)
+{
+   css_render_snapshot_t *a = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".a\",\"computed\":{\"color\":\"black\"}}]}");
+   css_render_snapshot_t *b = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".b\",\"computed\":{\"color\":\"black\"}}]}");
+   css_render_result_t *r = css_render_oracle_compare(a, b);
+   assert(r->equivalent == 0 && r->diff_count == 2);
+   const css_render_diff_t *miss = find_diff(r, ".a", "");
+   const css_render_diff_t *neu = find_diff(r, ".b", "");
+   assert(miss && miss->kind == CSS_RENDER_DIFF_NODE_MISSING);
+   assert(neu && neu->kind == CSS_RENDER_DIFF_NODE_NEW);
+   css_render_result_free(r);
+   css_render_snapshot_free(a);
+   css_render_snapshot_free(b);
+}
+
+static void test_whitespace_normalized_equivalent(void)
+{
+   /* "rgb(0,  0,   0)" collapses to "rgb(0, 0, 0)" -> equivalent; property case
+    * is normalized too (COLOR == color). */
+   css_render_snapshot_t *a = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".x\",\"computed\":{\"COLOR\":\"rgb(0,  0,   0)\"}}]}");
+   css_render_snapshot_t *b = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".x\",\"computed\":{\"color\":\"rgb(0, 0, 0)\"}}]}");
+   css_render_result_t *r = css_render_oracle_compare(a, b);
+   assert(r->available == 1 && r->equivalent == 1 && r->diff_count == 0);
+   css_render_result_free(r);
+   css_render_snapshot_free(a);
+   css_render_snapshot_free(b);
+}
+
+static void test_missing_snapshot_is_unknown(void)
+{
+   css_render_snapshot_t *a = css_render_snapshot_parse(
+       "{\"nodes\":[{\"ref\":\".x\",\"computed\":{\"color\":\"black\"}}]}");
+   /* one side NULL (e.g. render unavailable) -> available=0, NOT equivalent */
+   css_render_result_t *r = css_render_oracle_compare(a, NULL);
+   assert(r->available == 0 && r->equivalent == 0);
+   css_render_result_free(r);
+   r = css_render_oracle_compare(NULL, NULL);
+   assert(r->available == 0 && r->equivalent == 0);
+   css_render_result_free(r);
+   css_render_snapshot_free(a);
+}
+
+static void test_malformed_json_rejected(void)
+{
+   assert(css_render_snapshot_parse("not json") == NULL);
+   assert(css_render_snapshot_parse("{\"nodes\":\"oops\"}") == NULL); /* nodes not array */
+   assert(css_render_snapshot_parse("{}") == NULL);                   /* no nodes */
+   assert(css_render_snapshot_parse(NULL) == NULL);
+   /* a node missing ref/computed is skipped, not fatal */
+   css_render_snapshot_t *s =
+       css_render_snapshot_parse("{\"nodes\":[{\"ref\":\".ok\",\"computed\":{}},{\"bad\":1}]}");
+   assert(s && s->nnodes == 1 && s->nodes[0].nprops == 0);
+   css_render_snapshot_free(s);
+}
+
+/* ---- render adapter seam ------------------------------------------------- */
+
+static int g_adapter_calls;
+
+static int fake_adapter_ok(const char *html, const char *css, char **out_json, char **err)
+{
+   (void)html;
+   (void)css;
+   (void)err;
+   g_adapter_calls++;
+   const char *json = "{\"nodes\":[{\"ref\":\".x\",\"computed\":{\"color\":\"black\"}}]}";
+   *out_json = strdup(json);
+   return 0;
+}
+
+static int fake_adapter_fail(const char *html, const char *css, char **out_json, char **err)
+{
+   (void)html;
+   (void)css;
+   (void)out_json;
+   *err = strdup("render boom");
+   return 1;
+}
+
+static void test_adapter_seam(void)
+{
+   char *json = NULL, *err = NULL;
+   /* No adapter registered by default -> UNAVAILABLE, never a fabricated result. */
+   assert(!css_render_oracle_has_adapter());
+   assert(css_render_oracle_render("<div/>", ".x{}", &json, &err) == CSS_RENDER_UNAVAILABLE);
+   assert(json == NULL && err == NULL);
+
+   /* Register a working backend -> OK + a parseable snapshot. */
+   css_render_oracle_set_adapter(fake_adapter_ok);
+   assert(css_render_oracle_has_adapter());
+   g_adapter_calls = 0;
+   assert(css_render_oracle_render("<div/>", ".x{}", &json, &err) == CSS_RENDER_OK);
+   assert(g_adapter_calls == 1 && json != NULL && err == NULL);
+   css_render_snapshot_t *s = css_render_snapshot_parse(json);
+   assert(s && s->nnodes == 1);
+   css_render_snapshot_free(s);
+   free(json);
+   json = NULL;
+
+   /* A failing backend -> ERROR + err set, no snapshot. */
+   css_render_oracle_set_adapter(fake_adapter_fail);
+   assert(css_render_oracle_render("<div/>", ".x{}", &json, &err) == CSS_RENDER_ERROR);
+   assert(json == NULL && err != NULL && strcmp(err, "render boom") == 0);
+   free(err);
+   err = NULL;
+
+   /* Clearing returns to UNAVAILABLE. */
+   css_render_oracle_set_adapter(NULL);
+   assert(!css_render_oracle_has_adapter());
+   assert(css_render_oracle_render("<div/>", ".x{}", &json, &err) == CSS_RENDER_UNAVAILABLE);
+}
+
+int main(void)
+{
+   test_identical_equivalent();
+   test_value_changed();
+   test_removed_and_added();
+   test_node_missing_and_new();
+   test_whitespace_normalized_equivalent();
+   test_missing_snapshot_is_unknown();
+   test_malformed_json_rejected();
+   test_adapter_seam();
+   printf("css_render_oracle: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## What

First slice of the CSS migration assistant's **#4-full** (rendered computed-style oracle) — the feature the proposal deliberately deferred as *"the largest and most speculative,"* needing a headless browser. This lands the **render-free core + the seam a browser backend plugs into**, with **no browser embedded** and **no new dependency** — fully testable today.

The interim oracle (`css_oracle`, WP-E) compares static declaration sets and is strictly weaker than the real correctness signal: the *computed style* of the rendered DOM before vs. after (cascade, inheritance, shorthand already applied by a browser). This module operates over computed-style **snapshots** and diffs them.

## Changes

- **`src/css_render_oracle.{c,h}`** — pure leaf (libc + cJSON):
  - `css_render_snapshot_parse` — parse a snapshot `{"nodes":[{"ref","computed":{prop:value,...}}]}`. Forward-compatible (extra top-level fields ignored); malformed → `NULL`.
  - `css_render_oracle_compare` — node-by-node, property-by-property diff: `CHANGED`/`REMOVED`/`ADDED` + structural `NODE_MISSING`/`NODE_NEW`. **Conservative** like the interim oracle — a missing/unparseable snapshot → `available=0` (verdict **UNKNOWN, never "equivalent"**); property names case-normalized, values whitespace-normalized; explicit limitation banner (no silent equivalence, §8).
  - **Render adapter seam** (`css_render_oracle_set_adapter` / `_render`) — a backend turns html+css into snapshot JSON **out-of-process and sandboxed** (it renders untrusted code, §8). With no adapter, `_render` returns `CSS_RENDER_UNAVAILABLE` so callers report "unknown".

## Why a seam (the deferred-backend decision)

Producing computed styles needs a browser engine that isn't in aimee today (verified: zero puppeteer/playwright/chromium/node anywhere in `src`/`deploy`/`scripts`/Dockerfiles; KB & server images have no browser runtime). Rather than block on that heavy dependency + sandboxing surface, this slice builds everything that's needed **under any backend** and exposes the integration point. The render backend (delegate-driven vs. a render sidecar) is the follow-on.

## Scope / safety

Default-off / inert until a consumer + render backend land (next slices: snapshot storage + verdict wiring into `css_migration_units.oracle_equivalent`; then the chosen render backend). Mirrors the WP-E `css_oracle` landing pattern (its own PR before WP-F consumed it).

## Tests / gates

- `test_css_render_oracle`: identical/changed/removed/added, structural node missing/new, whitespace+case normalization, conservative unknown verdict, malformed-JSON rejection, full adapter-seam lifecycle (unavailable → ok → error → cleared).
- Full `unit-tests` green (165 suites), `build-integrity`, `line-check`, `schema-sync-check`, `format` all pass; compiles into both server + kb binaries.
