### PR TITLE
feat(audit): P1.5 typed merge_refs_turn primitive

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -54,11 +54,16 @@
   with the legacy `surfaced_ids`/`surfaced_items` kept as DERIVED projections of the
   memory-typed entries (every existing reader byte-identical), plus migration-on-read
   that back-fills `surfaced_refs` for pre-existing events.
-  **Remaining P1.5:** the typed `merge_refs_turn` primitive + an
-  `evidence.merge_retrieval_event` action + having `/v1/audit` resolve code refs
-  (all cleanly testable), then wiring the code-search surface to emit (serving-runtime,
-  needs live-stack verification). Plus the P3 LLM entailment judge *producer*
-  (default-off until validated) and P4 (labelled gold corpus — human, not autonomous).
+  The typed **`merge_refs_turn`** primitive landed next
+  (`db2_demotion_retrieval_event_merge_refs_turn`): merges `{type,ref,v}` code/doc
+  refs into the unified `surfaced_refs` (deduped by `type`+`ref`, idempotent; create
+  path reuses `write_turn` for a bare turn event; same CAS retry contract — the CAS
+  write is now a shared `cas_update_event_payload` helper). **Remaining P1.5:** an
+  `evidence.merge_retrieval_event` action (server-forward, dispatch-testable) + having
+  `/v1/audit` resolve code refs (testable), then wiring the code-search surface to
+  emit (serving-runtime, needs live-stack verification). Plus the P3 LLM entailment
+  judge *producer* (default-off until validated) and P4 (labelled gold corpus — human,
+  not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/db2/demotion.c
+++ b/src/db2/demotion.c
@@ -24,6 +24,10 @@
  * make_memory_ref / project_memory_refs / ensure_surfaced_refs keep that invariant;
  * the writer and both merges go through them. */
 
+/* Event-payload read buffer for the merges (~900 refs). On overflow by_turn
+ * truncates → the CAS old-value can't match → -1 (fail-safe). */
+#define MERGE_EVENT_PAYLOAD_CAP 65536
+
 /* {type:"memory", id, v} — v captured now (omitted when unresolved, mirroring the
  * legacy contract: a missing version means "unknown", not drift). */
 static cJSON *make_memory_ref(int64_t id)
@@ -125,6 +129,31 @@ static cJSON *ensure_surfaced_refs(cJSON *p)
       cJSON_AddItemToArray(refs, r);
    }
    return refs;
+}
+
+/* Compare-and-swap the event payload: land newpayload only if the row's payload
+ * still equals oldpayload (no concurrent change). Returns 1 if updated, 0 if no row
+ * matched (a concurrent merge changed it, or the event was deleted), -1 on error.
+ * Shared by both merges so the CAS retry contract is identical. */
+static int cas_update_event_payload(void *conn, const char *ev_id, const char *oldpayload,
+                                    const char *newpayload)
+{
+   if (!conn || !ev_id || !oldpayload || !newpayload)
+      return -1;
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "UPDATE artifacts SET payload = ?1 WHERE id = ?2 AND payload = ?3", err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", newpayload);
+   aimee_pg_bind_text(st, "?2", ev_id);
+   aimee_pg_bind_text(st, "?3", oldpayload);
+   int step = aimee_pg_step(st, err, sizeof(err));
+   int changes = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   if (step != AIMEE_PG_DONE)
+      return -1;
+   return changes > 0 ? 1 : 0;
 }
 
 int db2_demotion_retrieval_event_write(const char *query_fingerprint, const char *role,
@@ -284,11 +313,7 @@ int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *que
    /* One heap buffer reused across retries (~900 refs); avoids a large per-iteration
     * stack frame. If a payload ever exceeds it, by_turn truncates → the CAS old-value
     * can't match → retries exhaust → -1 (fail-safe, never a silent partial write). */
-   enum
-   {
-      MERGE_PAYLOAD_CAP = 65536
-   };
-   char *payload = malloc(MERGE_PAYLOAD_CAP);
+   char *payload = malloc(MERGE_EVENT_PAYLOAD_CAP);
    if (!payload)
       return -1;
 
@@ -298,7 +323,7 @@ int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *que
       char ev_id[64] = "";
       payload[0] = '\0';
       int rc = db2_demotion_retrieval_event_by_turn(turn_id, ev_id, sizeof(ev_id), payload,
-                                                    MERGE_PAYLOAD_CAP);
+                                                    MERGE_EVENT_PAYLOAD_CAP);
       if (rc < 0)
       {
          result = -1;
@@ -306,16 +331,23 @@ int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *que
       }
       if (rc == 0)
       {
-         /* No event yet — create it, then loop to re-read + merge (so our refs land
-          * even if a concurrent writer won the create race). */
-         char created[64] = "";
+         /* No event yet — create it, then re-read IN THIS iteration so the merge
+          * below still runs (even on the last retry) and our refs land even if a
+          * concurrent writer won the create race. */
          if (db2_demotion_retrieval_event_write_turn(turn_id, query_fingerprint, role, surfaced_ids,
-                                                     n_surfaced, created, sizeof(created)) != 0)
+                                                     n_surfaced, NULL, 0) != 0)
          {
             result = -1;
             break;
          }
-         continue;
+         payload[0] = '\0';
+         rc = db2_demotion_retrieval_event_by_turn(turn_id, ev_id, sizeof(ev_id), payload,
+                                                   MERGE_EVENT_PAYLOAD_CAP);
+         if (rc != 1) /* created but not readable (raced away) — fail this call */
+         {
+            result = -1;
+            break;
+         }
       }
 
       cJSON *p = payload[0] ? cJSON_Parse(payload) : NULL;
@@ -395,29 +427,14 @@ int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *que
       }
 
       /* CAS: land the update only if the payload is still the value we merged from. */
-      char err[256] = "";
-      aimee_pg_stmt_t *st =
-          aimee_pg_prepare(conn, "UPDATE artifacts SET payload = ?1 WHERE id = ?2 AND payload = ?3",
-                           err, sizeof(err));
-      if (!st)
-      {
-         free(newpayload);
-         result = -1;
-         break;
-      }
-      aimee_pg_bind_text(st, "?1", newpayload);
-      aimee_pg_bind_text(st, "?2", ev_id);
-      aimee_pg_bind_text(st, "?3", payload);
-      int step = aimee_pg_step(st, err, sizeof(err));
-      int changes = aimee_pg_stmt_changes(st);
-      aimee_pg_finalize(st);
+      int cas = cas_update_event_payload(conn, ev_id, payload, newpayload);
       free(newpayload);
-      if (step != AIMEE_PG_DONE)
+      if (cas < 0)
       {
          result = -1;
          break;
       }
-      if (changes > 0)
+      if (cas > 0)
       {
          if (id_out && id_out_len > 0)
             snprintf(id_out, (size_t)id_out_len, "%s", ev_id);
@@ -425,6 +442,167 @@ int db2_demotion_retrieval_event_merge_turn(const char *turn_id, const char *que
          break;
       }
       /* 0 rows: concurrent merge or the event vanished — re-read and retry. */
+   }
+   free(payload);
+   return result;
+}
+
+int db2_demotion_retrieval_event_merge_refs_turn(const char *turn_id, const char *query_fingerprint,
+                                                 const char *role, const char *const *types,
+                                                 const char *const *refs_in,
+                                                 const char *const *versions, int n_refs,
+                                                 char *id_out, int id_out_len)
+{
+   if (id_out && id_out_len > 0)
+      id_out[0] = '\0';
+   if (!turn_id || !turn_id[0])
+      return -1;
+
+   /* auditable-correctness P1.5 (D3/D14): merge TYPED refs ({type, ref, v}, e.g.
+    * code:<project>:<file_path> with v=content_hash) into the turn's unified
+    * surfaced_refs, deduped by (type, ref). Same CAS retry + create-then-merge as
+    * the int64 merge; the create path reuses write_turn to make a bare turn event
+    * (with dup-race handling), after which the typed refs merge on the next pass. */
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   char *payload = malloc(MERGE_EVENT_PAYLOAD_CAP);
+   if (!payload)
+      return -1;
+
+   int result = -1;
+   for (int attempt = 0; attempt < 5; attempt++)
+   {
+      char ev_id[64] = "";
+      payload[0] = '\0';
+      int rc = db2_demotion_retrieval_event_by_turn(turn_id, ev_id, sizeof(ev_id), payload,
+                                                    MERGE_EVENT_PAYLOAD_CAP);
+      if (rc < 0)
+      {
+         result = -1;
+         break;
+      }
+      if (rc == 0)
+      {
+         /* No event yet — create a bare turn event (reusing write_turn's dup-race
+          * handling), then re-read IN THIS iteration so the typed merge below runs
+          * even on the last retry. */
+         if (db2_demotion_retrieval_event_write_turn(turn_id, query_fingerprint, role, NULL, 0,
+                                                     NULL, 0) != 0)
+         {
+            result = -1;
+            break;
+         }
+         payload[0] = '\0';
+         rc = db2_demotion_retrieval_event_by_turn(turn_id, ev_id, sizeof(ev_id), payload,
+                                                   MERGE_EVENT_PAYLOAD_CAP);
+         if (rc != 1) /* created but not readable (raced away) — fail this call */
+         {
+            result = -1;
+            break;
+         }
+      }
+
+      cJSON *p = payload[0] ? cJSON_Parse(payload) : NULL;
+      if (!p)
+      {
+         result = -1;
+         break;
+      }
+      cJSON *refs = ensure_surfaced_refs(p);
+      if (!refs)
+      {
+         cJSON_Delete(p);
+         result = -1;
+         break;
+      }
+
+      int added = 0, oom = 0;
+      for (int i = 0; i < n_refs; i++)
+      {
+         const char *type = types ? types[i] : NULL;
+         const char *ref = refs_in ? refs_in[i] : NULL;
+         if (!type || !type[0] || !ref || !ref[0]) /* require a typed identity */
+            continue;
+         /* memory refs are id-keyed and belong to merge_turn (this path dedups by
+          * ref string, which a memory entry lacks) — skip them defensively. */
+         if (strcmp(type, "memory") == 0)
+            continue;
+         /* dedup by (type, ref) — a typed ref never collides with a memory entry
+          * (which has no "ref" field). Idempotent. */
+         int present = 0, m = cJSON_GetArraySize(refs);
+         for (int j = 0; j < m; j++)
+         {
+            cJSON *r = cJSON_GetArrayItem(refs, j);
+            cJSON *t = cJSON_GetObjectItemCaseSensitive(r, "type");
+            cJSON *rf = cJSON_GetObjectItemCaseSensitive(r, "ref");
+            if (cJSON_IsString(t) && strcmp(t->valuestring, type) == 0 && cJSON_IsString(rf) &&
+                strcmp(rf->valuestring, ref) == 0)
+            {
+               present = 1;
+               break;
+            }
+         }
+         if (present)
+            continue;
+         cJSON *r = cJSON_CreateObject();
+         if (!r)
+         {
+            oom = 1;
+            break;
+         }
+         cJSON_AddStringToObject(r, "type", type);
+         cJSON_AddStringToObject(r, "ref", ref);
+         const char *v = versions ? versions[i] : NULL;
+         if (v && v[0])
+            cJSON_AddStringToObject(r, "v", v);
+         cJSON_AddItemToArray(refs, r);
+         added++;
+      }
+      if (oom)
+      {
+         cJSON_Delete(p);
+         result = -1;
+         break;
+      }
+
+      /* typed refs don't change the memory-only legacy projections, but a migrated
+       * legacy event still needs them rebuilt so surfaced_ids/items exist. */
+      if (added > 0)
+         project_memory_refs(p);
+
+      if (added == 0)
+      {
+         cJSON_Delete(p);
+         if (id_out && id_out_len > 0)
+            snprintf(id_out, (size_t)id_out_len, "%s", ev_id);
+         result = 0;
+         break;
+      }
+
+      char *newpayload = cJSON_PrintUnformatted(p);
+      cJSON_Delete(p);
+      if (!newpayload)
+      {
+         result = -1;
+         break;
+      }
+      int cas = cas_update_event_payload(conn, ev_id, payload, newpayload);
+      free(newpayload);
+      if (cas < 0)
+      {
+         result = -1;
+         break;
+      }
+      if (cas > 0)
+      {
+         if (id_out && id_out_len > 0)
+            snprintf(id_out, (size_t)id_out_len, "%s", ev_id);
+         result = 0;
+         break;
+      }
+      /* 0 rows: concurrent change — re-read and retry. */
    }
    free(payload);
    return result;

--- a/src/db2/demotion.h
+++ b/src/db2/demotion.h
@@ -76,6 +76,23 @@ extern "C"
                                                const char *role, const int64_t *surfaced_ids,
                                                int n_surfaced, char *id_out, int id_out_len);
 
+   /* auditable-correctness P1.5 (D3/D14): merge TYPED refs into the turn's unified
+    * surfaced_refs. The three parallel arrays give each ref's `type` (e.g. "code"),
+    * `ref` (the stable identity, e.g. "code:<project>:<file_path>") and `versions`
+    * (e.g. content_hash; `versions` may be NULL, or an entry "" to omit v). Entries
+    * with an empty type or ref are skipped. Deduped by (type, ref) — idempotent, and
+    * a typed ref never collides with a memory entry. Entries with type "memory" are
+    * skipped — memory refs are id-keyed and must use ..._merge_turn. If no event
+    * exists yet a bare turn event is created first (reusing write_turn's dup-race
+    * handling). Same CAS retry/concurrency contract as the int64 merge. `versions`
+    * may be NULL; `n_refs`==0 is a valid no-op. Returns 0 / -1. */
+   int db2_demotion_retrieval_event_merge_refs_turn(const char *turn_id,
+                                                    const char *query_fingerprint, const char *role,
+                                                    const char *const *types,
+                                                    const char *const *refs,
+                                                    const char *const *versions, int n_refs,
+                                                    char *id_out, int id_out_len);
+
    /* Write a retrieval_attribution artifact linking one surfaced row to a verdict.
     * retrieval_event_id: UUID of the originating retrieval_event.
     * surfaced_row_id: memory row id that contributed to the response.

--- a/src/tests/test_demotion.c
+++ b/src/tests/test_demotion.c
@@ -164,6 +164,92 @@ static void test_retrieval_event_merge_turn(void)
    printf("  retrieval_event_merge_turn: ok\n");
 }
 
+static int count_occurrences(const char *hay, const char *needle)
+{
+   int n = 0;
+   for (const char *q = hay; (q = strstr(q, needle)); q += strlen(needle))
+      n++;
+   return n;
+}
+
+/* ---- 1c. retrieval_event_merge_refs_turn (P1.5 D3 typed two-writer merge) ---- */
+static void test_retrieval_event_merge_refs(void)
+{
+   open_db();
+
+   const char *types[2] = {"code", "code"};
+   const char *refs[2] = {"code:proj:src/a.c", "code:proj:src/b.c"};
+   const char *vers[2] = {"h1", "h2"};
+
+   /* code ref on a fresh turn → a bare event is created, then the typed ref merged. */
+   char ev_id[64];
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", types, refs, vers,
+                                                       1, ev_id, sizeof(ev_id)) == 0);
+   char payload[8192];
+   assert(db2_demotion_retrieval_event_by_turn("turn-c", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "\"type\":\"code\"") != NULL);
+   assert(strstr(payload, "code:proj:src/a.c") != NULL);
+   assert(strstr(payload, "\"v\":\"h1\"") != NULL);
+   /* code refs do NOT populate the memory-only legacy projection */
+   assert(strstr(payload, "\"surfaced_ids\":[]") != NULL);
+
+   /* second call: a.c is a dup (skipped), b.c is added; same canonical event. */
+   char got[64];
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", types, refs, vers,
+                                                       2, got, sizeof(got)) == 0);
+   assert(strcmp(got, ev_id) == 0);
+   assert(db2_demotion_retrieval_event_by_turn("turn-c", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "code:proj:src/b.c") != NULL);
+   assert(count_occurrences(payload, "code:proj:src/a.c") == 1); /* deduped, not duplicated */
+
+   /* idempotent: re-merging both refs changes nothing. */
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", types, refs, vers,
+                                                       2, NULL, 0) == 0);
+   assert(db2_demotion_retrieval_event_by_turn("turn-c", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(count_occurrences(payload, "code:proj:src/a.c") == 1);
+   assert(count_occurrences(payload, "code:proj:src/b.c") == 1);
+
+   /* COEXISTENCE: a memory ref merged into the same turn lives alongside the code
+    * refs in surfaced_refs; the legacy projection contains only the memory id. */
+   int64_t mids[1] = {55};
+   assert(db2_demotion_retrieval_event_merge_turn("turn-c", "fp", "Recall", mids, 1, NULL, 0) == 0);
+   assert(db2_demotion_retrieval_event_by_turn("turn-c", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "\"type\":\"memory\"") != NULL);
+   assert(strstr(payload, "\"type\":\"code\"") != NULL);
+   assert(strstr(payload, "\"surfaced_ids\":[55]") != NULL);
+
+   /* empty turn_id rejected; empty type/ref entries skipped (no-op success). */
+   assert(db2_demotion_retrieval_event_merge_refs_turn("", "fp", "Recall", types, refs, vers, 1,
+                                                       NULL, 0) == -1);
+   const char *empty_t[1] = {""};
+   const char *empty_r[1] = {""};
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", empty_t, empty_r,
+                                                       NULL, 1, NULL, 0) == 0);
+
+   /* versions==NULL → v omitted; a fresh code ref still merges. */
+   const char *t2[1] = {"code"};
+   const char *r2[1] = {"code:proj:src/c.c"};
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", t2, r2, NULL, 1,
+                                                       NULL, 0) == 0);
+   assert(db2_demotion_retrieval_event_by_turn("turn-c", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "code:proj:src/c.c") != NULL);
+
+   /* n_refs==0 is a valid no-op on an existing turn. */
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", NULL, NULL, NULL,
+                                                       0, NULL, 0) == 0);
+
+   /* a "memory"-typed entry is skipped here (it must use merge_turn). */
+   const char *tm[1] = {"memory"};
+   const char *rm[1] = {"memory:99"};
+   assert(db2_demotion_retrieval_event_merge_refs_turn("turn-c", "fp", "Recall", tm, rm, NULL, 1,
+                                                       NULL, 0) == 0);
+   assert(db2_demotion_retrieval_event_by_turn("turn-c", NULL, 0, payload, sizeof(payload)) == 1);
+   assert(strstr(payload, "memory:99") == NULL); /* not added */
+
+   close_db();
+   printf("  retrieval_event_merge_refs: ok\n");
+}
+
 /* ---- 2. retrieval_attribution_write ---- */
 static void test_retrieval_attribution_write(void)
 {
@@ -324,6 +410,7 @@ int main(void)
    test_retrieval_event_write();
    test_retrieval_event_turn();
    test_retrieval_event_merge_turn();
+   test_retrieval_event_merge_refs();
    test_retrieval_attribution_write();
    test_demotion_score_empty();
    test_demotion_score_basic();


### PR DESCRIPTION
## What

`db2_demotion_retrieval_event_merge_refs_turn` — merges **typed** refs (`{type,ref,v}`, e.g. `code:<project>:<file_path>` with `v`=content_hash) into the turn's unified `surfaced_refs` (landed in #376), deduped by `(type,ref)` and idempotent. This is the DB primitive the code-search surface will call to contribute to the same turn event; the serving emit + the `evidence.merge_retrieval_event` action are later increments.

## Behaviour
- **Dedup by `(type,ref)`**, idempotent; typed refs never collide with memory entries. **Memory-typed entries are skipped** (id-keyed → they use `merge_turn`).
- **Create path** reuses `write_turn` for a bare turn event (dup-race handling), then **re-reads in the same iteration** so the merge runs even on the last retry (this also fixed the same latent edge in `merge_turn`).
- Same **CAS retry** concurrency contract as the int64 merge — the CAS write is now a shared `cas_update_event_payload` helper (NULL-guarded) used by both merges.
- `versions` may be NULL; `n_refs==0` is a valid no-op.

## Verification
`make all` clean (aimee + aimee-server + aimee-kb), `make lint` ok, `unit-test-demotion` passes: code-ref create, dedup (`a.c` passed twice → exactly one entry), idempotent re-merge, **memory+code coexistence** on one turn (legacy `surfaced_ids` has only the memory id), `versions==NULL`, `n_refs==0`, empty/skip, and memory-type-skip cases.

Local roundtable gate: **0 blocking** (final round returned **0 findings**). Round 1's two leak "blockers" were misreads — `p` is freed in both the OOM and print-failure paths; the real ones (create-on-last-iteration; CAS null-guards; dedup contract for memory-typed entries) are fixed.

## Next P1.5
`evidence.merge_retrieval_event` action (server-forward, dispatch-testable) → `/v1/audit` resolving code refs (testable) → code-search serving emit (live-stack).