### PR TITLE
feat(css): command-driven render backend for #4-full oracle (slice 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -535,6 +535,7 @@ set(DATA_SRCS
     ${AIMEE_SRC_DIR}/extractors.c
     ${AIMEE_SRC_DIR}/css_analyze.c
     ${AIMEE_SRC_DIR}/css_render_oracle.c
+    ${AIMEE_SRC_DIR}/css_render_cmd.c
     ${AIMEE_SRC_DIR}/extractors_extra.c
     ${AIMEE_SRC_DIR}/extractors_new_langs.c
     ${AIMEE_SRC_DIR}/context_discover.c
@@ -927,6 +928,7 @@ set(KB_DATA_SRCS
     ${AIMEE_SRC_DIR}/extractors.c
     ${AIMEE_SRC_DIR}/css_analyze.c
     ${AIMEE_SRC_DIR}/css_render_oracle.c
+    ${AIMEE_SRC_DIR}/css_render_cmd.c
     ${AIMEE_SRC_DIR}/extractors_extra.c
     ${AIMEE_SRC_DIR}/extractors_new_langs.c
     ${AIMEE_SRC_DIR}/dogfood.c

--- a/deploy/css-render/Dockerfile
+++ b/deploy/css-render/Dockerfile
@@ -1,0 +1,21 @@
+# aimee css-render: isolated headless-Chromium sidecar for the #4-full
+# computed-style oracle. Renders UNTRUSTED markup, so it runs as its own
+# container reached only over HTTP (proposal §8) — never inside aimee-kb/server.
+#
+# The official Playwright image bundles Chromium + matching system deps.
+FROM mcr.microsoft.com/playwright:v1.49.0-jammy
+
+ENV CSS_RENDER_PORT=8780
+WORKDIR /opt/css-render
+
+# Playwright is preinstalled in the base image; pin the matching client.
+RUN npm install --omit=dev playwright@1.49.0
+
+COPY render.js /opt/css-render/render.js
+
+EXPOSE 8780
+# Drop privileges — the base image ships a non-root `pwuser`.
+USER pwuser
+HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
+  CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.CSS_RENDER_PORT||8780)+'/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+CMD ["node", "/opt/css-render/render.js"]

--- a/deploy/css-render/README.md
+++ b/deploy/css-render/README.md
@@ -1,0 +1,51 @@
+# aimee css-render sidecar (#4-full render backend)
+
+The render backend for the CSS migration assistant's **rendered computed-style
+oracle** (#4-full). It turns `{html, css}` into a computed-style snapshot by
+rendering in headless Chromium, so the oracle can diff the *computed* style of a
+component before vs. after a conversion — the real correctness signal, stronger
+than the static declaration-set oracle.
+
+Because it renders **untrusted** application/exemplar markup in a browser engine
+(a code-execution surface, proposal §8), it runs as an **isolated sidecar
+container** that aimee-kb reaches only over HTTP. aimee never embeds a browser.
+
+## How aimee talks to it
+
+aimee's render adapter is the configured `css_render_command`: a shell command
+that reads `{"html","css"}` on stdin and writes the snapshot JSON on stdout
+(exactly like `embedding_command` drives the embedder). Point it at this sidecar
+with `curl`:
+
+```yaml
+# aimee.yaml (aimee-kb)
+css_style_graph_enabled: true
+css_render_command: "curl -s --max-time 30 --data-binary @- http://aimee-css-render:8780/render"
+```
+
+With both set, aimee-kb registers the backend at startup and
+`aimee css render-capture <project> <unit> <before|after> <html> <css>` renders +
+stores a snapshot; `aimee css render-verify <project> <unit>` diffs before/after.
+
+## Snapshot contract
+
+Request: `POST /render  {"html":"...","css":"..."}`
+Response:
+```json
+{"nodes":[{"ref":"<selector>","computed":{"<prop>":"<value>", ...}}, ...]}
+```
+Nodes captured = every element with a `data-ref` attribute (the migration
+pipeline tags the elements it cares about). Properties = a fixed, deterministic
+box/visual allowlist (see `render.js` `PROPS`) — kept small so diffs are stable
+and snapshots bounded.
+
+## Build & run
+
+```sh
+docker build -t aimee-css-render deploy/css-render
+docker run --rm -p 8780:8780 --read-only --tmpfs /tmp aimee-css-render
+```
+
+Run it on an isolated network with no access to internal services (it executes
+untrusted CSS/HTML). JavaScript is disabled in the render context; only `<style>`
++ markup are evaluated.

--- a/deploy/css-render/render.js
+++ b/deploy/css-render/render.js
@@ -1,0 +1,104 @@
+/* render.js: reference render backend for aimee's #4-full computed-style oracle.
+ *
+ * A headless-Chromium HTTP service. It renders UNTRUSTED app/exemplar markup, so
+ * it is meant to run as an ISOLATED sidecar container (its own network/namespace)
+ * that the aimee-kb reaches only over HTTP — never in a trusted aimee process
+ * (proposal §8). aimee's `css_render_command` points at it, e.g.:
+ *
+ *   css_render_command: "curl -s --max-time 30 --data-binary @- http://aimee-css-render:8780/render"
+ *
+ * Protocol: POST /render  {"html": "...", "css": "..."}  ->  the snapshot shape
+ * css_render_oracle expects:
+ *   {"nodes":[{"ref":"<selector>","computed":{"<prop>":"<value>",...}}, ...]}
+ *
+ * Which nodes are captured: every element carrying a `data-ref` attribute (the
+ * migration pipeline tags the elements it cares about). Which properties: a fixed
+ * allowlist of box/visual properties (kept small + deterministic so the diff is
+ * stable and the snapshot is bounded). Stdin/stdout is NOT used here; the curl
+ * command bridges aimee's exec-pipe seam to this HTTP endpoint.
+ */
+'use strict';
+
+const http = require('http');
+const { chromium } = require('playwright');
+
+const PORT = parseInt(process.env.CSS_RENDER_PORT || '8780', 10);
+const MAX_BODY = 8 * 1024 * 1024; // 8 MiB request cap
+const NAV_TIMEOUT_MS = parseInt(process.env.CSS_RENDER_TIMEOUT_MS || '15000', 10);
+
+/* Deterministic, bounded property allowlist — the computed values that matter for
+ * migration equivalence. Extend deliberately (every added property widens diffs). */
+const PROPS = [
+  'display', 'position', 'box-sizing',
+  'width', 'height', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+  'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+  'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
+  'color', 'background-color', 'font-family', 'font-size', 'font-weight',
+  'line-height', 'text-align', 'flex-direction', 'justify-content', 'align-items',
+];
+
+let browser = null;
+async function getBrowser() {
+  if (!browser) {
+    browser = await chromium.launch({ args: ['--no-sandbox', '--disable-dev-shm-usage'] });
+  }
+  return browser;
+}
+
+async function snapshot(html, css) {
+  const b = await getBrowser();
+  const ctx = await b.newContext({ javaScriptEnabled: false });
+  const page = await ctx.newPage();
+  try {
+    const doc = `<!doctype html><html><head><meta charset="utf-8"><style>${css || ''}</style></head><body>${html || ''}</body></html>`;
+    await page.setContent(doc, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
+    const nodes = await page.evaluate((props) => {
+      const out = [];
+      for (const el of document.querySelectorAll('[data-ref]')) {
+        const ref = el.getAttribute('data-ref');
+        const cs = window.getComputedStyle(el);
+        const computed = {};
+        for (const p of props) computed[p] = cs.getPropertyValue(p);
+        out.push({ ref, computed });
+      }
+      return out;
+    }, PROPS);
+    return { nodes };
+  } finally {
+    await ctx.close();
+  }
+}
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET' && req.url === '/health') {
+    res.writeHead(200, { 'content-type': 'application/json' });
+    res.end('{"status":"ok"}');
+    return;
+  }
+  if (req.method !== 'POST' || req.url !== '/render') {
+    res.writeHead(404); res.end('not found');
+    return;
+  }
+  let body = '';
+  let aborted = false;
+  req.on('data', (chunk) => {
+    body += chunk;
+    if (body.length > MAX_BODY) { aborted = true; res.writeHead(413); res.end('too large'); req.destroy(); }
+  });
+  req.on('end', async () => {
+    if (aborted) return;
+    let parsed;
+    try { parsed = JSON.parse(body || '{}'); }
+    catch (e) { res.writeHead(400, { 'content-type': 'application/json' }); res.end('{"error":"invalid JSON"}'); return; }
+    try {
+      const snap = await snapshot(parsed.html || '', parsed.css || '');
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify(snap));
+    } catch (e) {
+      res.writeHead(500, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ error: String(e && e.message || e) }));
+    }
+  });
+});
+
+server.listen(PORT, () => { console.log(`aimee css-render listening on :${PORT}`); });

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (106)
+## CLI-settable keys (107)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -36,7 +36,8 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `cost_reward_lambda_pct` | int | Cost-penalty weight (percent) in the reward. |
 | `cost_reward_ref_usd_milli` | int | Reference cost (USD-milli) normalizing the cost reward. |
 | `cross_verify` | bool | Enable cross-model verification of outputs. |
-| `css_style_graph_enabled` | bool | — |
+| `css_render_command` | string | Render backend for the #4-full computed-style oracle: a command reading {html,css} JSON on stdin and writing a computed-style snapshot JSON on stdout (run an isolated headless-browser sidecar). |
+| `css_style_graph_enabled` | bool | Enable the CSS migration assistant's style-graph write path during indexing. |
 | `db2_url` | string | DB2 connection URL (aimee's vector / knowledge-base store). |
 | `dedup_enabled` | bool | Deduplicate near-identical responses. |
 | `dedup_window_seconds` | int | Window (seconds) for response dedup. |
@@ -133,7 +134,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `css_style_graph_enabled`, `server_cli_oauth_enabled`
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `server_cli_oauth_enabled`
 
 ## Config-file sections (48)
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -110,6 +110,8 @@ CFG_KEY_DESC = {
     "cost_reward_lambda_pct": "Cost-penalty weight (percent) in the reward.",
     "cost_reward_ref_usd_milli": "Reference cost (USD-milli) normalizing the cost reward.",
     "cross_verify": "Enable cross-model verification of outputs.",
+    "css_style_graph_enabled": "Enable the CSS migration assistant's style-graph write path during indexing.",
+    "css_render_command": "Render backend for the #4-full computed-style oracle: a command reading {html,css} JSON on stdin and writing a computed-style snapshot JSON on stdout (run an isolated headless-browser sidecar).",
     "db2_url": "DB2 connection URL (aimee's vector / knowledge-base store).",
     "dedup_enabled": "Deduplicate near-identical responses.",
     "dedup_window_seconds": "Window (seconds) for response dedup.",

--- a/src/Makefile
+++ b/src/Makefile
@@ -316,7 +316,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c \
+            index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
@@ -411,7 +411,7 @@ KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
-               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c \
+               index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_PLATFORM_OBJS = $(PLATFORM_BASIC_OBJS) $(filter %/agent_bridge.o %/cli_client.o %/memory.o,$(PLATFORM_EXTRA_OBJS) $(PLATFORM_AGENT_OBJS))

--- a/src/cli_css.c
+++ b/src/cli_css.c
@@ -22,6 +22,7 @@ static const char *const CSS_OPS[] = {"dead-rules",
                                       "assert-conventions",
                                       "conventions",
                                       "render-store",
+                                      "render-capture",
                                       "render-verify",
                                       NULL};
 
@@ -40,6 +41,7 @@ static void css_usage(void)
                    "       duplicate-selectors | unresolved | migrate-enumerate |\n"
                    "       migrate-list | rules-doc | assert-conventions | conventions\n"
                    "  render-store <project> <unit> <before|after> <snapshot.json>\n"
+                   "  render-capture <project> <unit> <before|after> <html-file> <css-file>\n"
                    "  render-verify <project> <unit>\n");
 }
 
@@ -93,7 +95,7 @@ static void css_print_results(const char *op, cJSON *resp)
       printf("asserted %d convention fact(s)\n", cJSON_IsNumber(a) ? a->valueint : 0);
       return;
    }
-   if (strcmp(op, "render-store") == 0)
+   if (strcmp(op, "render-store") == 0 || strcmp(op, "render-capture") == 0)
    {
       cJSON *s = cJSON_GetObjectItemCaseSensitive(resp, "stored");
       int stored = cJSON_IsNumber(s) ? s->valueint : 0;
@@ -206,6 +208,32 @@ int handle_css(int argc, char **argv, int json_output)
       cJSON_AddStringToObject(body, "phase", argv[3]);
       cJSON_AddStringToObject(body, "snapshot", snap);
       free(snap);
+   }
+   else if (strcmp(op, "render-capture") == 0)
+   {
+      if (argc < 6)
+      {
+         fprintf(stderr, "aimee css render-capture needs <project> <unit> <before|after> "
+                         "<html-file> <css-file>\n");
+         cJSON_Delete(body);
+         return 2;
+      }
+      char *html = css_read_file(argv[4]);
+      char *css = css_read_file(argv[5]);
+      if (!html || !css)
+      {
+         fprintf(stderr, "aimee css: cannot read html/css file\n");
+         free(html);
+         free(css);
+         cJSON_Delete(body);
+         return 2;
+      }
+      cJSON_AddStringToObject(body, "unit", argv[2]);
+      cJSON_AddStringToObject(body, "phase", argv[3]);
+      cJSON_AddStringToObject(body, "html", html);
+      cJSON_AddStringToObject(body, "css", css);
+      free(html);
+      free(css);
    }
    else if (strcmp(op, "render-verify") == 0)
    {

--- a/src/config.c
+++ b/src/config.c
@@ -781,6 +781,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->css_style_graph_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "css_render_command");
+   if (cJSON_IsString(item) && item->valuestring)
+      snprintf(cfg->css_render_command, sizeof(cfg->css_render_command), "%s", item->valuestring);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_preinject_assembly_budget");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->ingress_preinject_assembly_budget = (int)item->valuedouble;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -47,6 +47,8 @@ const config_field_t config_fields[] = {
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"css_style_graph_enabled", offsetof(config_t, css_style_graph_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"css_render_command", offsetof(config_t, css_render_command),
+     sizeof(((config_t *)0)->css_render_command), 0, CFG_STRING},
     {"kb_evidence_emit_enabled", offsetof(config_t, kb_evidence_emit_enabled), sizeof(int), 0,
      CFG_BOOL},
     {"fidelity_check_enabled", offsetof(config_t, fidelity_check_enabled), sizeof(int), 0,

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -776,6 +776,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
    if (cfg->css_style_graph_enabled)
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 1);
+   if (cfg->css_render_command[0])
+      cJSON_AddStringToObject(root, "css_render_command", cfg->css_render_command);
    if (cfg->kb_evidence_emit_enabled)
       cJSON_AddBoolToObject(root, "kb_evidence_emit_enabled", 1);
    if (cfg->fidelity_check_enabled)

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -9,6 +9,7 @@
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},
+{"css_render_command", SCHEMA_STRING, 0},
 {"typed_facts_enabled", SCHEMA_BOOL, 0},
 {"ingress_preinject_assembly_budget", SCHEMA_INT, 0},
 {"ingress_max_raw_scans", SCHEMA_INT, 0},

--- a/src/css_render_cmd.c
+++ b/src/css_render_cmd.c
@@ -1,0 +1,81 @@
+/* css_render_cmd.c: command-driven render backend. See css_render_cmd.h. */
+#include "css_render_cmd.h"
+
+#include "cJSON.h"
+#include "config.h"
+#include "css_render_oracle.h"
+#include "log.h"
+#include "platform_process.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Adapter: feed {"html","css"} to css_render_command on stdin, return its stdout
+ * (the computed-style snapshot JSON). Returns 0 on success (*out_json set), non-0
+ * on failure (*err set). Matches css_render_adapter_fn. */
+static int css_render_cmd_adapter(const char *html, const char *css, char **out_json, char **err)
+{
+   if (out_json)
+      *out_json = NULL;
+   if (err)
+      *err = NULL;
+
+   config_t cfg;
+   if (config_load(&cfg) != 0 || !cfg.css_render_command[0])
+   {
+      if (err)
+         *err = strdup("css_render_command not configured");
+      return 1;
+   }
+
+   cJSON *in = cJSON_CreateObject();
+   if (!in)
+      return 1;
+   cJSON_AddStringToObject(in, "html", html ? html : "");
+   cJSON_AddStringToObject(in, "css", css ? css : "");
+   char *input = cJSON_PrintUnformatted(in);
+   cJSON_Delete(in);
+   if (!input)
+      return 1;
+
+   char *out = NULL;
+   size_t out_len = 0;
+   int rc = platform_exec_pipe(cfg.css_render_command, input, strlen(input), &out, &out_len);
+   free(input);
+
+   if (rc != 0)
+   {
+      free(out);
+      if (err)
+      {
+         char msg[128];
+         snprintf(msg, sizeof(msg), "css_render_command failed (exit %d)", rc);
+         *err = strdup(msg);
+      }
+      return 1;
+   }
+   if (!out || out_len == 0)
+   {
+      free(out);
+      if (err)
+         *err = strdup("css_render_command produced no output");
+      return 1;
+   }
+   if (out_json)
+      *out_json = out;
+   else
+      free(out);
+   return 0;
+}
+
+int css_render_cmd_register(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return 0;
+   if (!cfg.css_style_graph_enabled || !cfg.css_render_command[0])
+      return 0;
+   css_render_oracle_set_adapter(css_render_cmd_adapter);
+   LOG_INFO("css_render", "registered command render backend: %s", cfg.css_render_command);
+   return 1;
+}

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -291,6 +291,13 @@ typedef struct config
     * assistant's style-graph write path during indexing (WP-C). When off, the
     * indexer keeps only the legacy lexical CSS class-name scan. */
    int css_style_graph_enabled;
+   /* css_render_command: the render backend for the #4-full computed-style oracle.
+    * A shell command (like embedding_command) that reads a {"html","css"} JSON
+    * object on stdin and writes a computed-style snapshot JSON on stdout. It runs
+    * a headless browser over UNTRUSTED markup, so it must be an isolated,
+    * out-of-process backend (e.g. `curl` to a sandboxed render sidecar). Empty =
+    * no backend (the oracle reports UNAVAILABLE). */
+   char css_render_command[512];
    int memory_salience_enabled;
    double memory_salience_weight;
    int memory_salience_window_size;

--- a/src/headers/css_render_cmd.h
+++ b/src/headers/css_render_cmd.h
@@ -1,0 +1,31 @@
+/* css_render_cmd.h: command-driven render backend for the #4-full rendered
+ * computed-style oracle (slice 3).
+ *
+ * Implements the css_render_oracle adapter seam by shelling out to the configured
+ * `css_render_command` (mirrors how embedding_command drives the embedder): the
+ * command reads a {"html","css"} JSON object on stdin and writes a computed-style
+ * snapshot JSON on stdout. Because it renders UNTRUSTED markup in a browser
+ * engine, the command MUST be an isolated, out-of-process backend — typically a
+ * `curl` to a sandboxed render sidecar container (proposal §8). This subsumes
+ * both the "delegate/local script" and "render sidecar" options behind one
+ * config string; aimee never embeds a browser.
+ */
+#ifndef DEC_CSS_RENDER_CMD_H
+#define DEC_CSS_RENDER_CMD_H 1
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Register the command-driven adapter as the process render backend, IFF both
+    * css_style_graph_enabled is set AND css_render_command is non-empty. Called
+    * once at aimee-kb startup. No-op (leaving the oracle UNAVAILABLE) otherwise.
+    * Returns 1 if an adapter was registered, 0 if not. */
+   int css_render_cmd_register(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CSS_RENDER_CMD_H */

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -2,6 +2,7 @@
 #include "agent_exec.h"
 #include "config.h"
 #include "config_database.h"
+#include "css_render_cmd.h"
 #include "db2/code_index.h"
 #include "kb_auth_oidc.h"
 #include "kb_enroll.h"
@@ -633,6 +634,11 @@ int main(int argc, char **argv)
       return 1;
    }
    g_ctx.worker_count = kb_cfg.kb_connection_workers;
+
+   /* #4-full render backend: register the command-driven computed-style render
+    * adapter when css_render_command is configured (no-op otherwise — the oracle
+    * then reports UNAVAILABLE rather than guessing). */
+   css_render_cmd_register();
 
    int http_port = http_port_override >= 0 ? http_port_override : kb_cfg.kb_api_http_port;
    if (http_port <= 0)

--- a/src/kb/kb_service_css.c
+++ b/src/kb/kb_service_css.c
@@ -185,6 +185,56 @@ int kb_handle_css_signals(int fd, cJSON *req)
       cJSON_AddNumberToObject(resp, "stored", n); /* 1 stored, 0 gated-off */
       return kb_send_response(fd, resp);
    }
+   if (strcmp(op, "render-capture") == 0)
+   {
+      /* #4-full slice 3: render a unit/phase's html+css via the configured render
+       * backend and store the resulting computed-style snapshot. Closes the loop
+       * render -> store -> (render-verify). */
+      cJSON *unit_j = cJSON_GetObjectItemCaseSensitive(req, "unit");
+      cJSON *phase_j = cJSON_GetObjectItemCaseSensitive(req, "phase");
+      cJSON *html_j = cJSON_GetObjectItemCaseSensitive(req, "html");
+      cJSON *css_j = cJSON_GetObjectItemCaseSensitive(req, "css");
+      if (!cJSON_IsString(unit_j) || !cJSON_IsString(phase_j) || !cJSON_IsString(html_j) ||
+          !cJSON_IsString(css_j))
+      {
+         cJSON_Delete(resp);
+         return kb_send_error(fd, "css render-capture requires 'unit', 'phase', 'html', 'css'");
+      }
+      char *snap = NULL, *rerr = NULL;
+      css_render_status_t st =
+          css_render_oracle_render(html_j->valuestring, css_j->valuestring, &snap, &rerr);
+      if (st == CSS_RENDER_UNAVAILABLE)
+      {
+         cJSON_Delete(resp);
+         free(snap);
+         free(rerr);
+         return kb_send_error(fd, "no render backend configured (set css_render_command)");
+      }
+      if (st != CSS_RENDER_OK || !snap)
+      {
+         char msg[160];
+         snprintf(msg, sizeof(msg), "render failed: %s", rerr ? rerr : "unknown");
+         cJSON_Delete(resp);
+         free(snap);
+         free(rerr);
+         return kb_send_error(fd, msg);
+      }
+      free(rerr);
+      char now_iso[40];
+      now_utc(now_iso, sizeof(now_iso));
+      int n = db2_css_render_snapshot_store(project, unit_j->valuestring, phase_j->valuestring,
+                                            snap, now_iso);
+      free(snap);
+      if (n < 0)
+      {
+         cJSON_Delete(resp);
+         return kb_send_error(fd, "css render-capture: store failed (invalid phase or db error)");
+      }
+      cJSON_AddStringToObject(resp, "unit", unit_j->valuestring);
+      cJSON_AddStringToObject(resp, "phase", phase_j->valuestring);
+      cJSON_AddNumberToObject(resp, "stored", n);
+      return kb_send_response(fd, resp);
+   }
    if (strcmp(op, "render-verify") == 0)
    {
       cJSON *unit_j = cJSON_GetObjectItemCaseSensitive(req, "unit");

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -89,7 +89,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-session-search-tool \
                $(TESTPREFIX)/unit-test-working-memory $(TESTPREFIX)/unit-test-working-memory-mock $(TESTPREFIX)/unit-test-local-resolution $(TESTPREFIX)/unit-test-cognify-jobs $(TESTPREFIX)/unit-test-extractors-extra \
-               $(TESTPREFIX)/unit-test-css-analyze $(TESTPREFIX)/unit-test-typed-facts $(TESTPREFIX)/unit-test-css-graph $(TESTPREFIX)/unit-test-css-oracle $(TESTPREFIX)/unit-test-css-render-oracle $(TESTPREFIX)/unit-test-css-migration $(TESTPREFIX)/unit-test-css-render \
+               $(TESTPREFIX)/unit-test-css-analyze $(TESTPREFIX)/unit-test-typed-facts $(TESTPREFIX)/unit-test-css-graph $(TESTPREFIX)/unit-test-css-oracle $(TESTPREFIX)/unit-test-css-render-oracle $(TESTPREFIX)/unit-test-css-migration $(TESTPREFIX)/unit-test-css-render $(TESTPREFIX)/unit-test-css-render-cmd \
                $(TESTPREFIX)/unit-test-compute-pool $(TESTPREFIX)/unit-test-db2-pool $(TESTPREFIX)/unit-test-cli-launch \
                $(TESTPREFIX)/unit-test-server-session-pools \
                $(TESTPREFIX)/unit-test-presence \
@@ -679,6 +679,17 @@ $(TESTPREFIX)/unit-test-css-oracle: $(OBJDIR)/tests/test_css_oracle.o $(OBJDIR)/
 # CSS rendered computed-style oracle core (#4-full) — leaf: css_render_oracle.o + cJSON + libc.
 $(TESTPREFIX)/unit-test-css-render-oracle: $(OBJDIR)/tests/test_css_render_oracle.o $(OBJDIR)/css_render_oracle.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# CSS command-driven render backend (#4-full slice 3) — adapter over platform_exec_pipe.
+$(TESTPREFIX)/unit-test-css-render-cmd: $(OBJDIR)/tests/test_css_render_cmd.o \
+                                       $(OBJDIR)/css_render_cmd.o \
+                                       $(OBJDIR)/css_render_oracle.o \
+                                       $(OBJDIR)/log.o \
+                                       $(OBJDIR)/posix/platform_process.o \
+                                       $(OBJDIR)/linux/platform_process.o \
+                                       $(OBJDIR)/cJSON.o \
+                                       $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
 
 $(TESTPREFIX)/unit-test-text: $(OBJDIR)/tests/test_text.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                      $(OBJDIR)/cJSON.o

--- a/src/tests/test_css_render_cmd.c
+++ b/src/tests/test_css_render_cmd.c
@@ -1,0 +1,106 @@
+/* test_css_render_cmd.c: #4-full slice 3 — the command-driven render backend.
+ * Registers css_render_command as the css_render_oracle adapter and drives it
+ * through platform_exec_pipe (a /bin/sh -c backend), covering success, failure,
+ * and the enable/command gates. */
+#include "cJSON.h"
+#include "config.h"
+#include "css_render_cmd.h"
+#include "css_render_oracle.h"
+#include "platform_path.h"
+#include "platform_test_util.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static char g_home[512];
+
+/* Write an aimee.yaml under an isolated HOME with the given flags/command. */
+static void set_config(int css_enabled, const char *render_cmd)
+{
+   if (!g_home[0])
+   {
+      snprintf(g_home, sizeof(g_home), "%s/aimee-rcmd-XXXXXX", platform_tmpdir());
+      assert(platform_mkdtemp(g_home) != NULL);
+   }
+   platform_setenv("HOME", g_home);
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1");
+   char dir[640];
+   snprintf(dir, sizeof(dir), "%s/.config/aimee", g_home);
+   assert(platform_mkdir_p(dir, 0700) == 0);
+   char path[768];
+   snprintf(path, sizeof(path), "%s/aimee.yaml", dir);
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fprintf(f, "css_style_graph_enabled: %s\n", css_enabled ? "true" : "false");
+   if (render_cmd && render_cmd[0])
+      fprintf(f, "css_render_command: %s\n", render_cmd);
+   fclose(f);
+}
+
+/* Write a tiny shell script (run via `sh <path>`, no exec bit needed). */
+static void write_script(const char *name, const char *body, char *out, size_t cap)
+{
+   snprintf(out, cap, "%s/%s", g_home, name);
+   FILE *f = fopen(out, "w");
+   assert(f);
+   fputs(body, f);
+   fclose(f);
+}
+
+int main(void)
+{
+   /* set_config needs g_home; prime it with an initial (gate-off) config. */
+   set_config(0, NULL);
+
+   /* An OK backend: discard stdin ({html,css}), emit a fixed snapshot. */
+   char ok_sh[640];
+   write_script("render.sh",
+                "cat >/dev/null\n"
+                "printf '%s' '{\"nodes\":[{\"ref\":\".btn\",\"computed\":"
+                "{\"color\":\"rgb(0, 0, 0)\"}}]}'\n",
+                ok_sh, sizeof(ok_sh));
+   char ok_cmd[700];
+   snprintf(ok_cmd, sizeof(ok_cmd), "sh %s", ok_sh);
+
+   /* Gate: flag on but no command -> no adapter. */
+   css_render_oracle_set_adapter(NULL);
+   set_config(1, NULL);
+   assert(css_render_cmd_register() == 0);
+   assert(!css_render_oracle_has_adapter());
+
+   /* Gate: command set but flag off -> no adapter. */
+   set_config(0, ok_cmd);
+   assert(css_render_cmd_register() == 0);
+   assert(!css_render_oracle_has_adapter());
+
+   /* Both set -> adapter registered, render produces a parseable snapshot. */
+   set_config(1, ok_cmd);
+   assert(css_render_cmd_register() == 1);
+   assert(css_render_oracle_has_adapter());
+   char *json = NULL, *err = NULL;
+   assert(css_render_oracle_render("<button class=btn/>", ".btn{color:#000}", &json, &err) ==
+          CSS_RENDER_OK);
+   assert(json && err == NULL);
+   css_render_snapshot_t *s = css_render_snapshot_parse(json);
+   assert(s && s->nnodes == 1 && strcmp(s->nodes[0].ref, ".btn") == 0);
+   css_render_snapshot_free(s);
+   free(json);
+   json = NULL;
+
+   /* A failing backend (non-zero exit) -> CSS_RENDER_ERROR, *err set. */
+   char fail_sh[640];
+   write_script("fail.sh", "cat >/dev/null\nexit 7\n", fail_sh, sizeof(fail_sh));
+   char fail_cmd[700];
+   snprintf(fail_cmd, sizeof(fail_cmd), "sh %s", fail_sh);
+   set_config(1, fail_cmd);
+   assert(css_render_cmd_register() == 1);
+   assert(css_render_oracle_render("<x/>", ".x{}", &json, &err) == CSS_RENDER_ERROR);
+   assert(json == NULL && err != NULL);
+   free(err);
+
+   printf("css_render_cmd: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## What

Slice 3 of **#4-full** — the actual **render backend** that produces computed-style snapshots, plugging into the `css_render_oracle` adapter seam from slice 1. Slices 1–2 (#374, #375) landed the diff core + seam and snapshot storage/verdict wiring. This makes the oracle real **without embedding a browser in aimee**.

The backend is a config'd command — exactly how `embedding_command` drives the embedder:

- **`css_render_command`** config: a shell command that reads `{"html","css"}` JSON on stdin and writes a computed-style snapshot JSON on stdout. Because it renders **untrusted** markup in a browser, it must be an isolated, out-of-process backend (§8) — typically a `curl` to a sandboxed render sidecar. This one string subsumes both the delegate/local-script and render-sidecar options.
- **`src/css_render_cmd.{c,h}`** — bridges that command to the adapter seam via `platform_exec_pipe` (the embedder's exec primitive). `css_render_cmd_register()` runs at aimee-kb startup and installs the adapter **iff** `css_style_graph_enabled` **and** `css_render_command` are both set (no-op otherwise — the oracle reports `UNAVAILABLE` rather than guessing).
- **`aimee css render-capture <project> <unit> <before|after> <html> <css>`** — KB action + CLI that renders via the backend and stores the snapshot, closing the loop `render → store → render-verify`. Clear error when no backend is configured.
- **`deploy/css-render/`** — reference render sidecar: a headless-Chromium Playwright HTTP service (`render.js`), `Dockerfile` (isolated, non-root, JS-disabled render context, healthcheck), and `README` wiring `css_render_command` to it. Captures every `[data-ref]` element over a fixed, deterministic property allowlist.

## Scope / safety

Default-off (empty `css_render_command`). Config plumbing (field + descriptor + save + load + schema allowlist + docs) and CMake/Makefile wiring mirror `css_render_oracle`. The sidecar image is a deploy artifact (not built in CI here).

## Tests / gates

- `test_css_render_cmd`: register gates (flag-only / command-only → no adapter; both → registered), successful render via a `sh` backend producing a parseable snapshot, and non-zero-exit failure → `CSS_RENDER_ERROR`.
- Full `unit-tests` green (all three css-render suites), `build-integrity`, `line-check`, `schema-sync-check`, `format`, `cli-v1-routes-check`, `server-api-conformance-check`, `docs-gen-check` pass; server/kb/cli build clean incl. macOS/Windows CMake.
