### PR TITLE
feat(audit): P1.5 /v1/audit/provenance resolves code refs

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -58,12 +58,17 @@
   (`db2_demotion_retrieval_event_merge_refs_turn`): merges `{type,ref,v}` code/doc
   refs into the unified `surfaced_refs` (deduped by `type`+`ref`, idempotent; create
   path reuses `write_turn` for a bare turn event; same CAS retry contract — the CAS
-  write is now a shared `cas_update_event_payload` helper). **Remaining P1.5:** an
-  `evidence.merge_retrieval_event` action (server-forward, dispatch-testable) + having
-  `/v1/audit` resolve code refs (testable), then wiring the code-search surface to
-  emit (serving-runtime, needs live-stack verification). Plus the P3 LLM entailment
-  judge *producer* (default-off until validated) and P4 (labelled gold corpus — human,
-  not autonomous).
+  write is now a shared `cas_update_event_payload` helper). **`/v1/audit/provenance`
+  code-ref resolution landed next**: it now resolves the unified `surfaced_refs`
+  code entries into a `code_sources[]` — each `{ref, version, live_hash, present,
+  drifted}` where `drifted` = the live `files.hash` (via the new
+  `db2_code_file_hash` resolver) differs from the version captured on the turn.
+  (`/v1/audit/trace` already returns the raw payload, so it surfaces code refs for
+  free.) **Remaining P1.5:** wiring the code-search KB surface to *emit* its hits'
+  code refs via `merge_refs_turn` (serving-runtime: needs `turn_id` threaded to the
+  `code.search` path + `kb_evidence_emit_enabled`; live-stack verification). Plus
+  the P3 LLM entailment judge *producer* (default-off until validated) and P4
+  (labelled gold corpus — human, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/db2/code_index_ops.c
+++ b/src/db2/code_index_ops.c
@@ -187,3 +187,36 @@ int db2_code_index_requeue_drifted(void)
 }
 
 #undef D7_DRIFT_FROM_WHERE
+
+int db2_code_file_hash(const char *project, const char *file_path, char *out, int out_len)
+{
+   if (out && out_len > 0)
+      out[0] = '\0';
+   if (!project || !project[0] || !file_path || !file_path[0])
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "SELECT f.hash FROM files f"
+                            " JOIN projects p ON p.id = f.project_id"
+                            " WHERE p.name = ?1 AND f.path = ?2 LIMIT 1";
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", file_path);
+   int rc = aimee_pg_step(st, err, sizeof(err));
+   int found = 0;
+   if (rc == AIMEE_PG_ROW)
+   {
+      found = 1;
+      const char *h = aimee_pg_column_text(st, 0);
+      if (out && out_len > 0)
+         snprintf(out, (size_t)out_len, "%s", h ? h : "");
+   }
+   aimee_pg_finalize(st);
+   if (rc == AIMEE_PG_ERR)
+      return -1;
+   return found;
+}

--- a/src/db2/code_index_ops.h
+++ b/src/db2/code_index_ops.h
@@ -47,6 +47,12 @@ extern "C"
     * error / nothing to do). */
    int db2_code_index_requeue_drifted(void);
 
+   /* auditable-correctness P1.5/D8: resolve a code ref's LIVE source hash —
+    * files.hash for (project, file_path). Writes the hash into out (cleared first);
+    * the CALLER compares it to the turn-captured version to flag drift. Returns
+    * 1 (found), 0 (no such file), -1 (bad arg / error). */
+   int db2_code_file_hash(const char *project, const char *file_path, char *out, int out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -13,6 +13,7 @@
 #include "db2/demotion.h" /* db2_demotion_retrieval_event_write_turn (auditable-correctness P1) */
 #include "db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "db2/fidelity.h"       /* db2_fidelity_report_by_turn (auditable-correctness P3) */
+#include "db2/code_index_ops.h" /* db2_code_file_hash (auditable-correctness P1.5 code provenance) */
 #include "kb_bandit.h"
 #include "kb_bandit_registry.h"
 #include "kb_service_memory.h"
@@ -922,6 +923,68 @@ int kb_handle_evidence_provenance(int fd, cJSON *req)
          cJSON_AddBoolToObject(src, "drifted",
                                turn_version[0] && found == 1 && strcmp(turn_version, version) != 0);
          cJSON_AddItemToArray(sources, src);
+      }
+      /* auditable-correctness P1.5 (D3): resolve typed CODE refs from the unified
+       * surfaced_refs. Each {type:"code", ref:"code:<project>:<file_path>", v} is
+       * reported in a separate code_sources[] with present + drift (live files.hash
+       * != the version captured on the turn). Memory refs already came through
+       * sources[] above (the legacy projection), so only code is resolved here. */
+      /* Always present (possibly empty) for a stable API contract, mirroring how
+       * `sources` is always present — even for a legacy event with no surfaced_refs. */
+      cJSON *code_sources = cJSON_AddArrayToObject(resp, "code_sources");
+      cJSON *refs = ev ? cJSON_GetObjectItemCaseSensitive(ev, "surfaced_refs") : NULL;
+      if (cJSON_IsArray(refs))
+      {
+         int rn = cJSON_GetArraySize(refs);
+         for (int i = 0; i < rn; i++)
+         {
+            cJSON *r = cJSON_GetArrayItem(refs, i);
+            cJSON *t = cJSON_GetObjectItemCaseSensitive(r, "type");
+            cJSON *rfj = cJSON_GetObjectItemCaseSensitive(r, "ref");
+            if (!cJSON_IsString(t) || strcmp(t->valuestring, "code") != 0 || !cJSON_IsString(rfj))
+               continue;
+            const char *ref = rfj->valuestring;
+            if (strncmp(ref, "code:", 5) != 0)
+               continue;
+            /* parse code:<project>:<file_path> — split on the FIRST colon after the
+             * "code:" prefix (project has no colon; file_path keeps any remaining). */
+            const char *rest = ref + 5;
+            const char *colon = strchr(rest, ':');
+            if (!colon || colon == rest || !colon[1])
+               continue;
+            char project[128] = "";
+            size_t plen = (size_t)(colon - rest);
+            if (plen >= sizeof(project))
+               plen = sizeof(project) - 1;
+            memcpy(project, rest, plen);
+            project[plen] = '\0';
+            const char *file_path = colon + 1;
+
+            cJSON *vj = cJSON_GetObjectItemCaseSensitive(r, "v");
+            const char *turn_v = (cJSON_IsString(vj) && vj->valuestring) ? vj->valuestring : "";
+            /* >= content_hash[80] (the source width) with margin, so a live hash is
+             * never truncated into a spurious mismatch. */
+            char live[128] = "";
+            int found = db2_code_file_hash(project, file_path, live, sizeof(live));
+
+            if (!code_sources)
+               continue; /* array alloc failed — skip rather than leak */
+            cJSON *cs = cJSON_CreateObject();
+            if (!cs)
+               continue;
+            cJSON_AddStringToObject(cs, "ref", ref);
+            cJSON_AddStringToObject(cs, "version", turn_v); /* captured on the turn */
+            cJSON_AddStringToObject(cs, "live_hash", live);
+            cJSON_AddBoolToObject(cs, "present", found == 1);
+            if (found < 0) /* lookup error — distinct from a genuinely absent file */
+               cJSON_AddBoolToObject(cs, "error", 1);
+            /* drift only when BOTH versions are known and differ; an empty live or
+             * turn version means "unknown", not drift (matches memory provenance). */
+            cJSON_AddBoolToObject(cs, "drifted",
+                                  found == 1 && turn_v[0] && live[0] && strcmp(turn_v, live) != 0);
+            if (!cJSON_AddItemToArray(code_sources, cs))
+               cJSON_Delete(cs);
+         }
       }
       if (ev)
          cJSON_Delete(ev);

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -21,6 +21,7 @@
 #include "../db2/entity_edges.h"
 #include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "../db2/demotion.h"       /* retrieval_event write/read (auditable-correctness P2) */
+#include "../db2/code_index_ops.h" /* db2_code_file_hash (auditable-correctness P1.5) */
 
 int memory_demote_from_failures(void);
 
@@ -376,6 +377,44 @@ static void test_audit_provenance_resolver(void)
    printf("  audit provenance resolver (kind/source/version + miss) OK\n");
 }
 
+/* Auditable-correctness P1.5/D8: db2_code_file_hash resolves a code ref's LIVE
+ * source hash (files.hash for project+path) — the /v1/audit/provenance code-ref
+ * drift check (live hash != the version captured on the turn). */
+static void test_audit_code_file_hash_resolver(void)
+{
+   setup();
+
+   char err[128] = "";
+   assert(aimee_pg_exec(db2_conn(),
+                        "INSERT INTO projects (name, root, scanned_at)"
+                        " VALUES ('provproj','/r','x')",
+                        err, sizeof err) == 0);
+   assert(aimee_pg_exec(db2_conn(),
+                        "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                        " ((SELECT id FROM projects WHERE name='provproj'),"
+                        " 'src/x.c','HASHV1','x')",
+                        err, sizeof err) == 0);
+
+   char hash[80] = "z";
+   int rc = db2_code_file_hash("provproj", "src/x.c", hash, sizeof hash);
+   assert(rc == 1 && strcmp(hash, "HASHV1") == 0);
+
+   /* unknown file → 0, out cleared. */
+   hash[0] = 'z';
+   assert(db2_code_file_hash("provproj", "src/missing.c", hash, sizeof hash) == 0);
+   assert(hash[0] == '\0');
+
+   /* unknown project → 0. */
+   assert(db2_code_file_hash("noproj", "src/x.c", hash, sizeof hash) == 0);
+
+   /* bad args rejected. */
+   assert(db2_code_file_hash("", "src/x.c", hash, sizeof hash) == -1);
+   assert(db2_code_file_hash("provproj", "", hash, sizeof hash) == -1);
+
+   teardown();
+   printf("  audit code-file-hash resolver (live hash + miss) OK\n");
+}
+
 /* Auditable-correctness P2 emit-time version capture: writing a retrieval_event
  * records each surfaced id's point-in-time version (memories.updated_at at emit)
  * in surfaced_items, so /v1/audit/provenance can later detect version drift. */
@@ -441,6 +480,7 @@ int main(void)
    test_memory_promote_uses_calibration_profile();
    test_memory_promote_calibration_ab_slot();
    test_audit_provenance_resolver();
+   test_audit_code_file_hash_resolver();
    test_audit_provenance_emit_captures_version();
    test_expire_l0();
    test_fold_session();


### PR DESCRIPTION
## What

`/v1/audit/provenance` now resolves the unified `surfaced_refs` **code** entries (landed in #376/#378), so code provenance + drift surface alongside memory provenance. The consumer for code refs in the same turn event — ready for when the code-search emit (the remaining serving piece) lands.

## Changes
- **`db2_code_file_hash(project, file_path, out, len)`** — the code resolver: `files.hash` via `files JOIN projects`; `1` found / `0` miss / `-1` bad-arg|err; clears `out` first.
- **`kb_handle_evidence_provenance`** — after the memory `sources` loop, walks `surfaced_refs`; for each `{type:'code', ref:'code:<project>:<file_path>', v}` it parses the ref (bounded; mis-format → fail-safe `present:false`), resolves the live hash, and appends to a new **`code_sources[]`** (always present, like `sources[]`): `{ref, version (turn-captured), live_hash, present, error?, drifted}`. `drifted` only when **both** versions are known and differ (empty = "unknown", matching memory-provenance semantics). Memory `sources[]` is unchanged (back-compat). `/v1/audit/trace` already returns the raw payload, so it surfaces code refs for free.
- **Test** — `db2_code_file_hash` over the shim (live-hash hit; missing file/project → 0 with `out` cleared; empty args → -1).

## Verification
`make all` clean (aimee + aimee-server + aimee-kb), `make lint` ok, `unit-test-memory` passes (resolver + the existing memory provenance resolver). Local roundtable gate: **0 blocking** — round 1's two "blockers" were a confabulation (the project buffer **is** clamped before `memcpy`) and the ref-parse fragility (bounded + fail-safe + producer-formatted colon-free project); the genuine items (always-present `code_sources`, drift-guard on unknown hashes, checked append, wider live buffer) are folded in.

## Remaining P1.5
Only the **code-search serving emit** — wire the KB `code.search` handler to call `merge_refs_turn` with its hits' code refs (needs `turn_id` threaded to that path + `kb_evidence_emit_enabled`); serving-runtime, **live-stack verification**.