### PR TITLE
promote: on-demand css-render sidecar + publish (+ P1.5 provenance ref-resolve)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -5,6 +5,8 @@
 #   aimee-server     (Dockerfile.server)      ghcr.io/<owner>/aimee-server
 #   aimee-kb         (Dockerfile)             ghcr.io/<owner>/aimee-kb
 #   aimee-server-kb  (Dockerfile.combined)    ghcr.io/<owner>/aimee-server-kb
+#   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -0.6b)
+#   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
 # merge-manifest pattern, on native runners (no QEMU emulation of the C build).
@@ -76,6 +78,10 @@ jobs:
           # baked in. Pair with embedding_dim: 1024 (see docs). Default (above) is
           # the 4b embedder + 1b reranker.
           - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1" }
+          # #4-full render backend (headless-Chromium sidecar). Self-contained
+          # under deploy/css-render (its own build context); independent of the C
+          # build, so a failure here never blocks the aimee images (fail-fast off).
+          - { name: aimee-css-render, dockerfile: deploy/css-render/Dockerfile, context: deploy/css-render }
         platform:
           - { arch: amd64, runner: ubuntu-latest }
           - { arch: arm64, runner: ubuntu-24.04-arm }
@@ -102,7 +108,7 @@ jobs:
         id: build
         uses: docker/build-push-action@v6
         with:
-          context: .
+          context: ${{ matrix.image.context || '.' }}
           file: ${{ matrix.image.dockerfile }}
           platforms: linux/${{ matrix.platform.arch }}
           provenance: false
@@ -114,8 +120,8 @@ jobs:
           # C-image caches, defeating the purpose. The embedder's real win is the
           # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
           # layer cache.
-          cache-from: ${{ matrix.image.name != 'aimee-embedder' && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ matrix.image.name != 'aimee-embedder' && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Published images bundle the optional browser UI (WITH_WEBCHAT=1); the
           # default `docker compose up --build` an end user runs leaves it off so it
           # needs no credentials. The aimee-kb image ignores WITH_WEBCHAT.
@@ -154,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-0.6b]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-0.6b, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/deploy/css-render/Dockerfile
+++ b/deploy/css-render/Dockerfile
@@ -6,16 +6,22 @@
 FROM mcr.microsoft.com/playwright:v1.49.0-jammy
 
 ENV CSS_RENDER_PORT=8780
+# The base image already bundles the browser binaries (at PLAYWRIGHT_BROWSERS_PATH);
+# installing the client must NOT re-download Chromium.
+ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 WORKDIR /opt/css-render
 
-# Playwright is preinstalled in the base image; pin the matching client.
+# Pin the JS client matching the base image's bundled browsers.
 RUN npm install --omit=dev playwright@1.49.0
 
-COPY render.js /opt/css-render/render.js
+# snapshot.js (shared) + render.js (HTTP server, default) + oneshot.js (stdin->
+# stdout, the on-demand per-render mode: `docker run --rm -i <img> node oneshot.js`).
+COPY snapshot.js render.js oneshot.js /opt/css-render/
 
 EXPOSE 8780
 # Drop privileges — the base image ships a non-root `pwuser`.
 USER pwuser
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \
   CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.CSS_RENDER_PORT||8780)+'/health',r=>process.exit(r.statusCode===200?0:1)).on('error',()=>process.exit(1))"
+# Default = long-running HTTP sidecar. Override for one-shot: node oneshot.js.
 CMD ["node", "/opt/css-render/render.js"]

--- a/deploy/css-render/README.md
+++ b/deploy/css-render/README.md
@@ -7,45 +7,101 @@ component before vs. after a conversion — the real correctness signal, stronge
 than the static declaration-set oracle.
 
 Because it renders **untrusted** application/exemplar markup in a browser engine
-(a code-execution surface, proposal §8), it runs as an **isolated sidecar
-container** that aimee-kb reaches only over HTTP. aimee never embeds a browser.
+(a code-execution surface, proposal §8), it runs as an **isolated container** that
+aimee-kb reaches only over HTTP (or stdin/stdout). aimee never embeds a browser.
 
 ## How aimee talks to it
 
 aimee's render adapter is the configured `css_render_command`: a shell command
 that reads `{"html","css"}` on stdin and writes the snapshot JSON on stdout
-(exactly like `embedding_command` drives the embedder). Point it at this sidecar
-with `curl`:
+(exactly like `embedding_command` drives the embedder). Two shapes:
 
-```yaml
-# aimee.yaml (aimee-kb)
-css_style_graph_enabled: true
-css_render_command: "curl -s --max-time 30 --data-binary @- http://aimee-css-render:8780/render"
-```
+- **HTTP sidecar** — a long-running container; the command `curl`s it.
+- **One-shot** — an ephemeral container per render reading stdin → stdout → exit
+  (`oneshot.js`); zero idle footprint.
 
-With both set, aimee-kb registers the backend at startup and
+With it configured, aimee-kb registers the backend at startup and
 `aimee css render-capture <project> <unit> <before|after> <html> <css>` renders +
 stores a snapshot; `aimee css render-verify <project> <unit>` diffs before/after.
 
+## Files
+
+- `snapshot.js` — shared headless render (the `[data-ref]` capture + property
+  allowlist).
+- `render.js` — long-running HTTP server (`POST /render`, `GET /health`).
+- `oneshot.js` — stdin `{html,css}` → stdout snapshot → exit.
+- `css-render-ctl.sh` — on-demand lifecycle (`up` / `down` / `status` / `reap` /
+  `render`).
+- `Dockerfile` — isolated, non-root, JS-disabled render context.
+
 ## Snapshot contract
 
-Request: `POST /render  {"html":"...","css":"..."}`
-Response:
+Request: `{"html":"...","css":"..."}` → 
 ```json
 {"nodes":[{"ref":"<selector>","computed":{"<prop>":"<value>", ...}}, ...]}
 ```
-Nodes captured = every element with a `data-ref` attribute (the migration
-pipeline tags the elements it cares about). Properties = a fixed, deterministic
-box/visual allowlist (see `render.js` `PROPS`) — kept small so diffs are stable
-and snapshots bounded.
+Nodes captured = every element with a `data-ref` attribute. Properties = a fixed
+box/visual allowlist (`snapshot.js` `PROPS`) — small so diffs stay stable and
+snapshots bounded.
 
-## Build & run
+## Build
 
 ```sh
 docker build -t aimee-css-render deploy/css-render
-docker run --rm -p 8780:8780 --read-only --tmpfs /tmp aimee-css-render
 ```
 
-Run it on an isolated network with no access to internal services (it executes
-untrusted CSS/HTML). JavaScript is disabled in the render context; only `<style>`
-+ markup are evaluated.
+## On-demand deployment (don't run Chromium 24/7)
+
+Pick one of three patterns. All keep Chromium off except while migrating.
+
+### 1. Session-scoped (recommended — no privilege change to aimee-kb)
+
+Start the sidecar only around a migration session; aimee-kb just `curl`s it.
+
+```sh
+deploy/css-render/css-render-ctl.sh up            # before migrating
+# aimee.yaml (aimee-kb):
+#   css_style_graph_enabled: true
+#   css_render_command: "curl -s --max-time 30 --data-binary @- http://<host>:8780/render"
+# ... run `aimee css render-capture ...` / render-verify ...
+deploy/css-render/css-render-ctl.sh down          # after
+```
+
+aimee-kb needs **no** container privileges — it only makes an HTTP call. The
+oracle reports `UNAVAILABLE` (never a fake verdict) whenever the sidecar is down.
+
+### 2. Lazy-start + idle-stop
+
+As (1), but leave it warm during active work and let a cron reap it after idle
+(render.js stamps a marker on every render):
+
+```cron
+*/5 * * * *  /path/css-render-ctl.sh reap 900     # stop after 15 min idle
+```
+
+### 3. Per-render ephemeral (zero idle)
+
+A fresh container per render via `oneshot.js`. Point `css_render_command` straight
+at it:
+
+```yaml
+css_render_command: "/path/css-render-ctl.sh render"   # == docker run --rm -i aimee-css-render node oneshot.js
+```
+
+This is the most "as-needed" (no idle container at all) but pays Chromium
+cold-start (~1–3 s) per render, and **requires container-launch access wherever
+`css_render_command` runs** (i.e. a Docker socket reachable from aimee-kb) — a
+privilege surface to weigh vs. patterns 1–2.
+
+### Non-default runtimes
+
+`css-render-ctl.sh` honours `DOCKER` and `DOCKER_HOST`. For the smoothnas
+LXC2Docker runtime:
+
+```sh
+DOCKER_HOST=unix:///run/smoothnas-runtime/docker.sock deploy/css-render/css-render-ctl.sh up
+```
+
+Run the sidecar on an isolated network with no access to internal services (it
+executes untrusted CSS/HTML). JavaScript is disabled in the render context; only
+`<style>` + markup are evaluated.

--- a/deploy/css-render/css-render-ctl.sh
+++ b/deploy/css-render/css-render-ctl.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+# css-render-ctl.sh: on-demand lifecycle for the aimee css-render sidecar so a
+# headless-Chromium container only runs while you are doing CSS-migration work
+# (not 24/7). Three patterns — pick per the README "On-demand" section:
+#
+#   1. Session-scoped (recommended, no privilege change to aimee-kb):
+#        css-render-ctl.sh up        # before a migration session
+#        ... run `aimee css render-capture` / render-verify ...
+#        css-render-ctl.sh down      # after
+#      `css_render_command` points at the running sidecar over HTTP (curl).
+#
+#   2. Lazy-start + idle-stop: as (1) plus a cron that reaps after idle:
+#        */5 * * * *  css-render-ctl.sh reap 900   # stop after 15 min idle
+#
+#   3. Per-render ephemeral (zero idle, needs container-launch access wherever
+#      css_render_command runs):
+#        css_render_command: ".../css-render-ctl.sh render"   # stdin -> stdout
+#
+# Runtime-agnostic: set DOCKER (default `docker`) and/or DOCKER_HOST for a
+# non-default container runtime (e.g. the smoothnas LXC2Docker socket:
+#   DOCKER_HOST=unix:///run/smoothnas-runtime/docker.sock).
+set -eu
+
+IMAGE="${CSS_RENDER_IMAGE:-aimee-css-render}"
+NAME="${CSS_RENDER_NAME:-aimee-css-render}"
+PORT="${CSS_RENDER_PORT:-8780}"
+DOCKER="${DOCKER:-docker}"
+MARKER="${CSS_RENDER_MARKER:-/tmp/.css-render-last}"
+
+is_running() { $DOCKER ps --format '{{.Names}}' 2>/dev/null | grep -qx "$NAME"; }
+exists()     { $DOCKER ps -a --format '{{.Names}}' 2>/dev/null | grep -qx "$NAME"; }
+
+up() {
+  if is_running; then echo "css-render: already running"; return 0; fi
+  if exists; then $DOCKER start "$NAME" >/dev/null; echo "css-render: started"; return 0; fi
+  # Isolated: read-only rootfs, writable /tmp only, no extra caps. Runs UNTRUSTED
+  # markup — keep it off internal networks (proposal §8).
+  $DOCKER run -d --name "$NAME" --read-only --tmpfs /tmp \
+    -e "CSS_RENDER_MARKER=$MARKER" -p "$PORT:8780" "$IMAGE" >/dev/null
+  echo "css-render: created on :$PORT"
+}
+
+down() { $DOCKER stop "$NAME" >/dev/null 2>&1 || true; echo "css-render: stopped"; }
+
+status() {
+  if is_running; then $DOCKER ps --filter "name=^/$NAME$" --format '{{.Names}}  {{.Status}}';
+  else echo "css-render: not running"; fi
+}
+
+# reap IDLE_SECS: stop the sidecar if no render in the last IDLE_SECS.
+reap() {
+  idle="${1:?usage: css-render-ctl.sh reap <idle-seconds>}"
+  is_running || { echo "css-render: not running"; return 0; }
+  last="$($DOCKER exec "$NAME" cat "$MARKER" 2>/dev/null || echo 0)"
+  now_ms="$(( $(date +%s) * 1000 ))"
+  if [ "$last" = "0" ] || [ "$(( now_ms - last ))" -gt "$(( idle * 1000 ))" ]; then
+    echo "css-render: idle > ${idle}s -> stopping"; down
+  else
+    echo "css-render: active, keeping"
+  fi
+}
+
+# render: one-shot ephemeral container; pipes stdin ({html,css}) to stdout
+# (snapshot). The zero-idle css_render_command target.
+render() { exec $DOCKER run --rm -i "$IMAGE" node /opt/css-render/oneshot.js; }
+
+case "${1:-}" in
+  up) up ;;
+  down) down ;;
+  status) status ;;
+  reap) shift; reap "${1:-}" ;;
+  render) render ;;
+  *) echo "usage: $0 {up|down|status|reap <idle-seconds>|render}" >&2; exit 2 ;;
+esac

--- a/deploy/css-render/oneshot.js
+++ b/deploy/css-render/oneshot.js
@@ -1,0 +1,52 @@
+/* oneshot.js: one-shot render CLI for aimee's #4-full computed-style oracle —
+ * the ON-DEMAND (zero-idle) mode.
+ *
+ * Reads a {"html","css"} JSON object from STDIN, renders it in headless Chromium,
+ * writes the computed-style snapshot JSON to STDOUT, and EXITS. So a container
+ * exists only for the duration of one render — no idle Chromium. This is the
+ * shape aimee's css_render_command expects directly (stdin -> stdout), so it can
+ * be wired as a per-render ephemeral container, e.g.:
+ *
+ *   css_render_command: "docker run --rm -i aimee-css-render-oneshot"
+ *
+ * (see css-render-ctl.sh `render` and the README "On-demand" section). Renders
+ * UNTRUSTED markup, so the container must stay isolated (proposal §8).
+ *
+ * Exit codes: 0 = snapshot on stdout; non-zero = error message on stderr (which
+ * aimee surfaces as a render failure / UNKNOWN verdict — never a fake result).
+ */
+'use strict';
+
+const { snapshot, closeBrowser } = require('./snapshot');
+
+const MAX_INPUT = 8 * 1024 * 1024; // 8 MiB stdin cap
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    let size = 0;
+    process.stdin.setEncoding('utf8');
+    process.stdin.on('data', (chunk) => {
+      size += Buffer.byteLength(chunk);
+      if (size > MAX_INPUT) { reject(new Error('stdin too large')); process.stdin.destroy(); return; }
+      data += chunk;
+    });
+    process.stdin.on('end', () => resolve(data));
+    process.stdin.on('error', reject);
+  });
+}
+
+(async () => {
+  try {
+    const raw = await readStdin();
+    const input = JSON.parse(raw || '{}');
+    const snap = await snapshot(input.html || '', input.css || '');
+    process.stdout.write(JSON.stringify(snap));
+    await closeBrowser();
+    process.exit(0);
+  } catch (e) {
+    process.stderr.write('css-render oneshot failed: ' + String(e && e.message || e) + '\n');
+    try { await closeBrowser(); } catch (_) { /* ignore */ }
+    process.exit(1);
+  }
+})();

--- a/deploy/css-render/render.js
+++ b/deploy/css-render/render.js
@@ -1,72 +1,32 @@
-/* render.js: reference render backend for aimee's #4-full computed-style oracle.
+/* render.js: long-running HTTP render backend for aimee's #4-full computed-style
+ * oracle (the always-on / session-scoped sidecar mode).
  *
- * A headless-Chromium HTTP service. It renders UNTRUSTED app/exemplar markup, so
- * it is meant to run as an ISOLATED sidecar container (its own network/namespace)
- * that the aimee-kb reaches only over HTTP — never in a trusted aimee process
- * (proposal §8). aimee's `css_render_command` points at it, e.g.:
+ * Headless-Chromium HTTP service rendering UNTRUSTED markup — run it as an
+ * ISOLATED sidecar container the aimee-kb reaches only over HTTP (proposal §8).
+ * aimee's `css_render_command` points at it, e.g.:
  *
  *   css_render_command: "curl -s --max-time 30 --data-binary @- http://aimee-css-render:8780/render"
  *
- * Protocol: POST /render  {"html": "...", "css": "..."}  ->  the snapshot shape
- * css_render_oracle expects:
- *   {"nodes":[{"ref":"<selector>","computed":{"<prop>":"<value>",...}}, ...]}
+ * For a ZERO-IDLE, per-render container instead of a long-running one, see
+ * oneshot.js + css-render-ctl.sh (on-demand mode). Both share snapshot.js.
  *
- * Which nodes are captured: every element carrying a `data-ref` attribute (the
- * migration pipeline tags the elements it cares about). Which properties: a fixed
- * allowlist of box/visual properties (kept small + deterministic so the diff is
- * stable and the snapshot is bounded). Stdin/stdout is NOT used here; the curl
- * command bridges aimee's exec-pipe seam to this HTTP endpoint.
+ * Protocol: POST /render {"html":"...","css":"..."} -> the snapshot shape
+ * css_render_oracle expects. GET /health -> {"status":"ok"}.
  */
 'use strict';
 
 const http = require('http');
-const { chromium } = require('playwright');
+const fs = require('fs');
+const { snapshot } = require('./snapshot');
 
 const PORT = parseInt(process.env.CSS_RENDER_PORT || '8780', 10);
 const MAX_BODY = 8 * 1024 * 1024; // 8 MiB request cap
-const NAV_TIMEOUT_MS = parseInt(process.env.CSS_RENDER_TIMEOUT_MS || '15000', 10);
+// Touched on each render so an external reaper (css-render-ctl.sh reap) can stop
+// an idle sidecar — the basis of the lazy-start / idle-stop on-demand pattern.
+const LAST_RENDER_MARKER = process.env.CSS_RENDER_MARKER || '/tmp/.css-render-last';
 
-/* Deterministic, bounded property allowlist — the computed values that matter for
- * migration equivalence. Extend deliberately (every added property widens diffs). */
-const PROPS = [
-  'display', 'position', 'box-sizing',
-  'width', 'height', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
-  'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
-  'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
-  'color', 'background-color', 'font-family', 'font-size', 'font-weight',
-  'line-height', 'text-align', 'flex-direction', 'justify-content', 'align-items',
-];
-
-let browser = null;
-async function getBrowser() {
-  if (!browser) {
-    browser = await chromium.launch({ args: ['--no-sandbox', '--disable-dev-shm-usage'] });
-  }
-  return browser;
-}
-
-async function snapshot(html, css) {
-  const b = await getBrowser();
-  const ctx = await b.newContext({ javaScriptEnabled: false });
-  const page = await ctx.newPage();
-  try {
-    const doc = `<!doctype html><html><head><meta charset="utf-8"><style>${css || ''}</style></head><body>${html || ''}</body></html>`;
-    await page.setContent(doc, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
-    const nodes = await page.evaluate((props) => {
-      const out = [];
-      for (const el of document.querySelectorAll('[data-ref]')) {
-        const ref = el.getAttribute('data-ref');
-        const cs = window.getComputedStyle(el);
-        const computed = {};
-        for (const p of props) computed[p] = cs.getPropertyValue(p);
-        out.push({ ref, computed });
-      }
-      return out;
-    }, PROPS);
-    return { nodes };
-  } finally {
-    await ctx.close();
-  }
+function markRender() {
+  try { fs.writeFileSync(LAST_RENDER_MARKER, String(Date.now())); } catch (_) { /* best effort */ }
 }
 
 const server = http.createServer((req, res) => {
@@ -92,6 +52,7 @@ const server = http.createServer((req, res) => {
     catch (e) { res.writeHead(400, { 'content-type': 'application/json' }); res.end('{"error":"invalid JSON"}'); return; }
     try {
       const snap = await snapshot(parsed.html || '', parsed.css || '');
+      markRender();
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify(snap));
     } catch (e) {

--- a/deploy/css-render/snapshot.js
+++ b/deploy/css-render/snapshot.js
@@ -1,0 +1,69 @@
+/* snapshot.js: the shared headless-Chromium render used by both the long-running
+ * HTTP server (render.js) and the one-shot CLI (oneshot.js).
+ *
+ * Renders UNTRUSTED app/exemplar markup, so it must run inside an isolated
+ * container (proposal §8). Produces the snapshot shape css_render_oracle expects:
+ *   {"nodes":[{"ref":"<selector>","computed":{"<prop>":"<value>",...}}, ...]}
+ * Nodes captured = every element carrying a `data-ref` attribute. Properties =
+ * a fixed, deterministic box/visual allowlist (kept small so diffs stay stable
+ * and snapshots bounded; extend deliberately).
+ */
+'use strict';
+
+const { chromium } = require('playwright');
+
+const NAV_TIMEOUT_MS = parseInt(process.env.CSS_RENDER_TIMEOUT_MS || '15000', 10);
+
+const PROPS = [
+  'display', 'position', 'box-sizing',
+  'width', 'height', 'margin-top', 'margin-right', 'margin-bottom', 'margin-left',
+  'padding-top', 'padding-right', 'padding-bottom', 'padding-left',
+  'border-top-width', 'border-right-width', 'border-bottom-width', 'border-left-width',
+  'color', 'background-color', 'font-family', 'font-size', 'font-weight',
+  'line-height', 'text-align', 'flex-direction', 'justify-content', 'align-items',
+];
+
+let sharedBrowser = null;
+
+/* Reuse one browser per process (the HTTP server renders many times); the
+ * one-shot CLI launches, renders once, and closes it explicitly. */
+async function getBrowser() {
+  if (!sharedBrowser) {
+    sharedBrowser = await chromium.launch({ args: ['--no-sandbox', '--disable-dev-shm-usage'] });
+  }
+  return sharedBrowser;
+}
+
+async function closeBrowser() {
+  if (sharedBrowser) {
+    const b = sharedBrowser;
+    sharedBrowser = null;
+    await b.close();
+  }
+}
+
+async function snapshot(html, css) {
+  const b = await getBrowser();
+  const ctx = await b.newContext({ javaScriptEnabled: false });
+  const page = await ctx.newPage();
+  try {
+    const doc = `<!doctype html><html><head><meta charset="utf-8"><style>${css || ''}</style></head><body>${html || ''}</body></html>`;
+    await page.setContent(doc, { waitUntil: 'load', timeout: NAV_TIMEOUT_MS });
+    const nodes = await page.evaluate((props) => {
+      const out = [];
+      for (const el of document.querySelectorAll('[data-ref]')) {
+        const ref = el.getAttribute('data-ref');
+        const cs = window.getComputedStyle(el);
+        const computed = {};
+        for (const p of props) computed[p] = cs.getPropertyValue(p);
+        out.push({ ref, computed });
+      }
+      return out;
+    }, PROPS);
+    return { nodes };
+  } finally {
+    await ctx.close();
+  }
+}
+
+module.exports = { snapshot, getBrowser, closeBrowser, PROPS };

--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -58,12 +58,17 @@
   (`db2_demotion_retrieval_event_merge_refs_turn`): merges `{type,ref,v}` code/doc
   refs into the unified `surfaced_refs` (deduped by `type`+`ref`, idempotent; create
   path reuses `write_turn` for a bare turn event; same CAS retry contract — the CAS
-  write is now a shared `cas_update_event_payload` helper). **Remaining P1.5:** an
-  `evidence.merge_retrieval_event` action (server-forward, dispatch-testable) + having
-  `/v1/audit` resolve code refs (testable), then wiring the code-search surface to
-  emit (serving-runtime, needs live-stack verification). Plus the P3 LLM entailment
-  judge *producer* (default-off until validated) and P4 (labelled gold corpus — human,
-  not autonomous).
+  write is now a shared `cas_update_event_payload` helper). **`/v1/audit/provenance`
+  code-ref resolution landed next**: it now resolves the unified `surfaced_refs`
+  code entries into a `code_sources[]` — each `{ref, version, live_hash, present,
+  drifted}` where `drifted` = the live `files.hash` (via the new
+  `db2_code_file_hash` resolver) differs from the version captured on the turn.
+  (`/v1/audit/trace` already returns the raw payload, so it surfaces code refs for
+  free.) **Remaining P1.5:** wiring the code-search KB surface to *emit* its hits'
+  code refs via `merge_refs_turn` (serving-runtime: needs `turn_id` threaded to the
+  `code.search` path + `kb_evidence_emit_enabled`; live-stack verification). Plus
+  the P3 LLM entailment judge *producer* (default-off until validated) and P4
+  (labelled gold corpus — human, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/db2/code_index_ops.c
+++ b/src/db2/code_index_ops.c
@@ -187,3 +187,36 @@ int db2_code_index_requeue_drifted(void)
 }
 
 #undef D7_DRIFT_FROM_WHERE
+
+int db2_code_file_hash(const char *project, const char *file_path, char *out, int out_len)
+{
+   if (out && out_len > 0)
+      out[0] = '\0';
+   if (!project || !project[0] || !file_path || !file_path[0])
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "SELECT f.hash FROM files f"
+                            " JOIN projects p ON p.id = f.project_id"
+                            " WHERE p.name = ?1 AND f.path = ?2 LIMIT 1";
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", file_path);
+   int rc = aimee_pg_step(st, err, sizeof(err));
+   int found = 0;
+   if (rc == AIMEE_PG_ROW)
+   {
+      found = 1;
+      const char *h = aimee_pg_column_text(st, 0);
+      if (out && out_len > 0)
+         snprintf(out, (size_t)out_len, "%s", h ? h : "");
+   }
+   aimee_pg_finalize(st);
+   if (rc == AIMEE_PG_ERR)
+      return -1;
+   return found;
+}

--- a/src/db2/code_index_ops.h
+++ b/src/db2/code_index_ops.h
@@ -47,6 +47,12 @@ extern "C"
     * error / nothing to do). */
    int db2_code_index_requeue_drifted(void);
 
+   /* auditable-correctness P1.5/D8: resolve a code ref's LIVE source hash —
+    * files.hash for (project, file_path). Writes the hash into out (cleared first);
+    * the CALLER compares it to the turn-captured version to flag drift. Returns
+    * 1 (found), 0 (no such file), -1 (bad arg / error). */
+   int db2_code_file_hash(const char *project, const char *file_path, char *out, int out_len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -13,6 +13,7 @@
 #include "db2/demotion.h" /* db2_demotion_retrieval_event_write_turn (auditable-correctness P1) */
 #include "db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "db2/fidelity.h"       /* db2_fidelity_report_by_turn (auditable-correctness P3) */
+#include "db2/code_index_ops.h" /* db2_code_file_hash (auditable-correctness P1.5 code provenance) */
 #include "kb_bandit.h"
 #include "kb_bandit_registry.h"
 #include "kb_service_memory.h"
@@ -922,6 +923,68 @@ int kb_handle_evidence_provenance(int fd, cJSON *req)
          cJSON_AddBoolToObject(src, "drifted",
                                turn_version[0] && found == 1 && strcmp(turn_version, version) != 0);
          cJSON_AddItemToArray(sources, src);
+      }
+      /* auditable-correctness P1.5 (D3): resolve typed CODE refs from the unified
+       * surfaced_refs. Each {type:"code", ref:"code:<project>:<file_path>", v} is
+       * reported in a separate code_sources[] with present + drift (live files.hash
+       * != the version captured on the turn). Memory refs already came through
+       * sources[] above (the legacy projection), so only code is resolved here. */
+      /* Always present (possibly empty) for a stable API contract, mirroring how
+       * `sources` is always present — even for a legacy event with no surfaced_refs. */
+      cJSON *code_sources = cJSON_AddArrayToObject(resp, "code_sources");
+      cJSON *refs = ev ? cJSON_GetObjectItemCaseSensitive(ev, "surfaced_refs") : NULL;
+      if (cJSON_IsArray(refs))
+      {
+         int rn = cJSON_GetArraySize(refs);
+         for (int i = 0; i < rn; i++)
+         {
+            cJSON *r = cJSON_GetArrayItem(refs, i);
+            cJSON *t = cJSON_GetObjectItemCaseSensitive(r, "type");
+            cJSON *rfj = cJSON_GetObjectItemCaseSensitive(r, "ref");
+            if (!cJSON_IsString(t) || strcmp(t->valuestring, "code") != 0 || !cJSON_IsString(rfj))
+               continue;
+            const char *ref = rfj->valuestring;
+            if (strncmp(ref, "code:", 5) != 0)
+               continue;
+            /* parse code:<project>:<file_path> — split on the FIRST colon after the
+             * "code:" prefix (project has no colon; file_path keeps any remaining). */
+            const char *rest = ref + 5;
+            const char *colon = strchr(rest, ':');
+            if (!colon || colon == rest || !colon[1])
+               continue;
+            char project[128] = "";
+            size_t plen = (size_t)(colon - rest);
+            if (plen >= sizeof(project))
+               plen = sizeof(project) - 1;
+            memcpy(project, rest, plen);
+            project[plen] = '\0';
+            const char *file_path = colon + 1;
+
+            cJSON *vj = cJSON_GetObjectItemCaseSensitive(r, "v");
+            const char *turn_v = (cJSON_IsString(vj) && vj->valuestring) ? vj->valuestring : "";
+            /* >= content_hash[80] (the source width) with margin, so a live hash is
+             * never truncated into a spurious mismatch. */
+            char live[128] = "";
+            int found = db2_code_file_hash(project, file_path, live, sizeof(live));
+
+            if (!code_sources)
+               continue; /* array alloc failed — skip rather than leak */
+            cJSON *cs = cJSON_CreateObject();
+            if (!cs)
+               continue;
+            cJSON_AddStringToObject(cs, "ref", ref);
+            cJSON_AddStringToObject(cs, "version", turn_v); /* captured on the turn */
+            cJSON_AddStringToObject(cs, "live_hash", live);
+            cJSON_AddBoolToObject(cs, "present", found == 1);
+            if (found < 0) /* lookup error — distinct from a genuinely absent file */
+               cJSON_AddBoolToObject(cs, "error", 1);
+            /* drift only when BOTH versions are known and differ; an empty live or
+             * turn version means "unknown", not drift (matches memory provenance). */
+            cJSON_AddBoolToObject(cs, "drifted",
+                                  found == 1 && turn_v[0] && live[0] && strcmp(turn_v, live) != 0);
+            if (!cJSON_AddItemToArray(code_sources, cs))
+               cJSON_Delete(cs);
+         }
       }
       if (ev)
          cJSON_Delete(ev);

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -21,6 +21,7 @@
 #include "../db2/entity_edges.h"
 #include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "../db2/demotion.h"       /* retrieval_event write/read (auditable-correctness P2) */
+#include "../db2/code_index_ops.h" /* db2_code_file_hash (auditable-correctness P1.5) */
 
 int memory_demote_from_failures(void);
 
@@ -376,6 +377,44 @@ static void test_audit_provenance_resolver(void)
    printf("  audit provenance resolver (kind/source/version + miss) OK\n");
 }
 
+/* Auditable-correctness P1.5/D8: db2_code_file_hash resolves a code ref's LIVE
+ * source hash (files.hash for project+path) — the /v1/audit/provenance code-ref
+ * drift check (live hash != the version captured on the turn). */
+static void test_audit_code_file_hash_resolver(void)
+{
+   setup();
+
+   char err[128] = "";
+   assert(aimee_pg_exec(db2_conn(),
+                        "INSERT INTO projects (name, root, scanned_at)"
+                        " VALUES ('provproj','/r','x')",
+                        err, sizeof err) == 0);
+   assert(aimee_pg_exec(db2_conn(),
+                        "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                        " ((SELECT id FROM projects WHERE name='provproj'),"
+                        " 'src/x.c','HASHV1','x')",
+                        err, sizeof err) == 0);
+
+   char hash[80] = "z";
+   int rc = db2_code_file_hash("provproj", "src/x.c", hash, sizeof hash);
+   assert(rc == 1 && strcmp(hash, "HASHV1") == 0);
+
+   /* unknown file → 0, out cleared. */
+   hash[0] = 'z';
+   assert(db2_code_file_hash("provproj", "src/missing.c", hash, sizeof hash) == 0);
+   assert(hash[0] == '\0');
+
+   /* unknown project → 0. */
+   assert(db2_code_file_hash("noproj", "src/x.c", hash, sizeof hash) == 0);
+
+   /* bad args rejected. */
+   assert(db2_code_file_hash("", "src/x.c", hash, sizeof hash) == -1);
+   assert(db2_code_file_hash("provproj", "", hash, sizeof hash) == -1);
+
+   teardown();
+   printf("  audit code-file-hash resolver (live hash + miss) OK\n");
+}
+
 /* Auditable-correctness P2 emit-time version capture: writing a retrieval_event
  * records each surfaced id's point-in-time version (memories.updated_at at emit)
  * in surfaced_items, so /v1/audit/provenance can later detect version drift. */
@@ -441,6 +480,7 @@ int main(void)
    test_memory_promote_uses_calibration_profile();
    test_memory_promote_calibration_ab_slot();
    test_audit_provenance_resolver();
+   test_audit_code_file_hash_resolver();
    test_audit_provenance_emit_captures_version();
    test_expire_l0();
    test_fold_session();


### PR DESCRIPTION
Promotes `testing` to `main`. Batches two green PRs:

- **#382** deploy(css-render): on-demand render sidecar — one-shot mode (zero-idle per-render container), `css-render-ctl.sh` lifecycle (up/down/status/reap/render), three documented on-demand patterns, and `publish-images.yml` now builds+pushes the `aimee-css-render` image (isolated leg, fail-fast off). Deploy-only.
- **#381** feat(audit): P1.5 /v1/audit/provenance resolves code refs.

Both merged to testing with full CI green. The promotion's auto-release publishes the new aimee-css-render image to ghcr for the first time.
