### PR TITLE
feat(audit): P1.5 code-search emit — two-writer code refs into the turn event

### DIFF
--- a/docs/proposals/pending/auditable-correctness-for-the-kb.md
+++ b/docs/proposals/pending/auditable-correctness-for-the-kb.md
@@ -64,11 +64,18 @@
   drifted}` where `drifted` = the live `files.hash` (via the new
   `db2_code_file_hash` resolver) differs from the version captured on the turn.
   (`/v1/audit/trace` already returns the raw payload, so it surfaces code refs for
-  free.) **Remaining P1.5:** wiring the code-search KB surface to *emit* its hits'
-  code refs via `merge_refs_turn` (serving-runtime: needs `turn_id` threaded to the
-  `code.search` path + `kb_evidence_emit_enabled`; live-stack verification). Plus
-  the P3 LLM entailment judge *producer* (default-off until validated) and P4
-  (labelled gold corpus — human, not autonomous).
+  free.) The **code-search emit landed last**: the ingress pre-inject — which
+  already code-searches the turn query and emits the memory `retrieval_event` — now
+  also MERGES its code hits into that same event as typed refs
+  (`code:<project>:<file_path>`, `v`=content_hash) via the new
+  `evidence.merge_retrieval_event` KB action (→ `merge_refs_turn`), gated by the
+  same `kb_evidence_emit_enabled`. **P1.5's code path is now complete** (default-off):
+  the DB/merge core + the audit code-ref resolution are unit-tested; the serving
+  emit (KB action + ingress wiring) is observation-only glue over that tested core,
+  and its end-to-end behaviour is **pending live-stack verification** with the flag
+  enabled (it cannot run in the default-off CI/unit environment). **Remaining:** the
+  P3 LLM entailment judge *producer* (default-off until validated) and P4 (labelled
+  gold corpus — human, not autonomous).
 - **Author:** JBailes
 - **Date:** 2026-06-12
 - **Charter roles:** Recall (provenance + per-turn evidence on the recall /

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -781,6 +781,16 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
                                             const char *query_fingerprint, const int64_t *ids,
                                             int n_ids);
 
+/* Auditable-correctness P1.5: merge typed code/doc refs into the turn's event via
+ * the KB evidence.merge_retrieval_event action (the idempotent two-writer upsert).
+ * `types`/`refs`/`versions` are parallel arrays of length `n` (entries with an
+ * empty type or ref are skipped; `versions` may be NULL). Returns 0 on success,
+ * -1 on bad args or kb error. */
+int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
+                                             const char *query_fingerprint, const char *const *types,
+                                             const char *const *refs, const char *const *versions,
+                                             int n);
+
 /* Auditable-correctness P1: the /v1/audit/trace read — forward to the KB
  * evidence.trace_retrieval_event action and return its JSON response verbatim
  * (malloc'd, caller frees; NULL on bad arg or kb error). */

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1053,6 +1053,7 @@ static const struct
     {"memory.briefing", kb_handle_memory_briefing},
     {"memory.context_block", kb_handle_memory_context_block},
     {"evidence.emit_retrieval_event", kb_handle_evidence_emit_retrieval_event},
+    {"evidence.merge_retrieval_event", kb_handle_evidence_merge_retrieval_event},
     {"evidence.trace_retrieval_event", kb_handle_evidence_trace_retrieval_event},
     {"evidence.provenance_retrieval_event", kb_handle_evidence_provenance},
     {"evidence.fidelity_retrieval_event", kb_handle_evidence_fidelity},

--- a/src/kb/kb_service_memory.c
+++ b/src/kb/kb_service_memory.c
@@ -792,6 +792,76 @@ int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req)
    return kb_reply_or_error(fd, resp, "failed to write retrieval_event");
 }
 
+/* Auditable-correctness P1.5 (D3/D14): the two-writer code-ref merge. A second
+ * surface (the ingress code search) contributes its typed code refs into the SAME
+ * turn's retrieval_event, idempotently merged with whatever the memory surface
+ * already wrote. The emission decision (kb_evidence_emit_enabled) is made
+ * server-side; this is the dumb writer over db2_demotion_retrieval_event_merge_refs_turn. */
+int kb_handle_evidence_merge_retrieval_event(int fd, cJSON *req)
+{
+   cJSON *turn_j = cJSON_GetObjectItemCaseSensitive(req, "turn_id");
+   cJSON *role_j = cJSON_GetObjectItemCaseSensitive(req, "role");
+   cJSON *fp_j = cJSON_GetObjectItemCaseSensitive(req, "query_fingerprint");
+   cJSON *refs_j = cJSON_GetObjectItemCaseSensitive(req, "surfaced_refs");
+   if (!cJSON_IsString(turn_j) || !turn_j->valuestring[0])
+      return kb_send_error(fd, "evidence.merge_retrieval_event requires turn_id");
+   const char *role =
+       cJSON_IsString(role_j) && role_j->valuestring[0] ? role_j->valuestring : "Recall";
+   const char *fp = cJSON_IsString(fp_j) ? fp_j->valuestring : "";
+
+   int n = cJSON_IsArray(refs_j) ? cJSON_GetArraySize(refs_j) : 0;
+   const char **types = NULL, **refs = NULL, **versions = NULL;
+   int m = 0;
+   if (n > 0)
+   {
+      types = (const char **)calloc((size_t)n, sizeof(char *));
+      refs = (const char **)calloc((size_t)n, sizeof(char *));
+      versions = (const char **)calloc((size_t)n, sizeof(char *));
+      if (!types || !refs || !versions)
+      {
+         free(types);
+         free(refs);
+         free(versions);
+         return kb_send_error(fd, "out of memory");
+      }
+      for (int i = 0; i < n; i++)
+      {
+         cJSON *e = cJSON_GetArrayItem(refs_j, i);
+         if (!e)
+            continue;
+         cJSON *t = cJSON_GetObjectItemCaseSensitive(e, "type");
+         cJSON *r = cJSON_GetObjectItemCaseSensitive(e, "ref");
+         cJSON *v = cJSON_GetObjectItemCaseSensitive(e, "v");
+         /* require a non-empty typed identity (defence-in-depth: the merge skips
+          * empties too, but don't forward junk from an adversarial caller). */
+         if (!cJSON_IsString(t) || !t->valuestring[0] || !cJSON_IsString(r) || !r->valuestring[0])
+            continue;
+         types[m] = t->valuestring;
+         refs[m] = r->valuestring;
+         versions[m] = (cJSON_IsString(v) && v->valuestring) ? v->valuestring : "";
+         m++;
+      }
+   }
+
+   char ev_id[64] = "";
+   /* m==0 (no valid refs) is a no-op: don't call the merge, which would otherwise
+    * create a bare turn event for an empty request. */
+   int rc = (m > 0) ? db2_demotion_retrieval_event_merge_refs_turn(turn_j->valuestring, fp, role,
+                                                                   types, refs, versions, m, ev_id,
+                                                                   sizeof(ev_id))
+                    : 0;
+   free(types);
+   free(refs);
+   free(versions);
+   if (rc != 0)
+      return kb_send_error(fd, "failed to merge retrieval_event refs");
+
+   cJSON *resp = cJSON_CreateObject();
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "retrieval_event_id", ev_id);
+   return kb_reply_or_error(fd, resp, "failed to merge retrieval_event refs");
+}
+
 /* Auditable-correctness P1: the /v1/audit/trace read. Look up the per-turn
  * retrieval_event by its caller-visible turn_id and return a four-state status.
  * Only two states are reachable in P1's single-writer foundation:

--- a/src/kb_service_memory.h
+++ b/src/kb_service_memory.h
@@ -59,6 +59,8 @@ int kb_handle_memory_briefing(int fd, cJSON *req);
 int kb_handle_memory_context_block(int fd, cJSON *req);
 /* Auditable-correctness P1: record a per-turn retrieval_event keyed by turn_id. */
 int kb_handle_evidence_emit_retrieval_event(int fd, cJSON *req);
+/* Auditable-correctness P1.5: merge typed code/doc refs into the turn's event. */
+int kb_handle_evidence_merge_retrieval_event(int fd, cJSON *req);
 /* Auditable-correctness P1: the /v1/audit/trace read (four-state status). */
 int kb_handle_evidence_trace_retrieval_event(int fd, cJSON *req);
 /* Auditable-correctness P2: the /v1/audit/provenance read (sources at version). */

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -425,7 +425,7 @@ char *ingress_preinject_build(const char *query, int request_disabled)
     * build call) we mint one here so the event is still reconstructible. This is
     * the dedicated single-writer foundation; P1.5 folds the emit into the
     * retrieval handlers with the idempotent two-writer upsert. */
-   if (cfg.kb_evidence_emit_enabled && mem_n > 0)
+   if (cfg.kb_evidence_emit_enabled && (mem_n > 0 || n > 0))
    {
       const char *tid = ingress_preinject_turn_id();
       char minted[40];
@@ -434,19 +434,44 @@ char *ingress_preinject_build(const char *query, int request_disabled)
          ingress_preinject_mint_turn_id(minted, sizeof(minted));
          tid = minted;
       }
-      /* mems[] holds the full set of memory previews surfaced into this turn
-       * (mem_n <= the diagnose cap of 5), so recording all of them is the
-       * complete memory evidence for the turn, not a truncation. */
+      char fp[32];
+      ingress_query_fingerprint(query, fp, sizeof(fp));
+
+      /* Memory surface (single-writer, P1): mems[] holds the full set of memory
+       * previews surfaced into this turn (mem_n <= the diagnose cap of 5), so
+       * recording all of them is the complete memory evidence, not a truncation. */
       int64_t ids[5];
       int n_ids = 0;
       for (int i = 0; i < mem_n && n_ids < (int)(sizeof(ids) / sizeof(ids[0])); i++)
          if (mems[i].memory.id > 0)
             ids[n_ids++] = mems[i].memory.id;
       if (n_ids > 0)
-      {
-         char fp[32];
-         ingress_query_fingerprint(query, fp, sizeof(fp));
          (void)kb_client_evidence_emit_retrieval_event(tid, "Recall", fp, ids, n_ids);
+
+      /* Code surface (P1.5/D3): MERGE the code hits surfaced into this turn into the
+       * turn's event as typed refs (code:<project>:<file_path>, v=content_hash).
+       * Runs after the memory emit: when memory also surfaced it JOINS that event
+       * (idempotent two-writer); on a code-only turn the merge is the first writer
+       * and creates the event itself. */
+      if (n > 0)
+      {
+         char refbuf[6][MAX_PATH_LEN + 160];
+         const char *types[6], *refs[6], *versions[6];
+         int cn = 0;
+         for (int i = 0; i < n && cn < (int)(sizeof(types) / sizeof(types[0])); i++)
+         {
+            if (!hits[i].project[0] || !hits[i].file_path[0])
+               continue;
+            snprintf(refbuf[cn], sizeof(refbuf[cn]), "code:%s:%s", hits[i].project,
+                     hits[i].file_path);
+            types[cn] = "code";
+            refs[cn] = refbuf[cn];
+            versions[cn] = hits[i].content_hash; /* may be "" (no recorded hash) */
+            cn++;
+         }
+         if (cn > 0)
+            (void)kb_client_evidence_merge_retrieval_event(tid, "Recall", fp, types, refs, versions,
+                                                           cn);
       }
    }
 

--- a/src/server/kb_client_memory.c
+++ b/src/server/kb_client_memory.c
@@ -1630,6 +1630,50 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
    return ok ? 0 : -1;
 }
 
+int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
+                                             const char *query_fingerprint,
+                                             const char *const *types, const char *const *refs,
+                                             const char *const *versions, int n)
+{
+   if (!turn_id || !turn_id[0])
+      return -1;
+
+   cJSON *req = cJSON_CreateObject();
+   cJSON_AddStringToObject(req, "turn_id", turn_id);
+   if (role && role[0])
+      cJSON_AddStringToObject(req, "role", role);
+   if (query_fingerprint && query_fingerprint[0])
+      cJSON_AddStringToObject(req, "query_fingerprint", query_fingerprint);
+   cJSON *arr = cJSON_AddArrayToObject(req, "surfaced_refs");
+   for (int i = 0; arr && types && refs && i < n; i++)
+   {
+      if (!types[i] || !types[i][0] || !refs[i] || !refs[i][0])
+         continue;
+      cJSON *e = cJSON_CreateObject();
+      if (!e)
+         continue;
+      cJSON_AddStringToObject(e, "type", types[i]);
+      cJSON_AddStringToObject(e, "ref", refs[i]);
+      const char *v = versions ? versions[i] : NULL;
+      if (v && v[0])
+         cJSON_AddStringToObject(e, "v", v);
+      cJSON_AddItemToArray(arr, e);
+   }
+
+   char *json = kb_v1_action_request("evidence.merge_retrieval_event", req);
+   if (!json)
+      return -1;
+
+   cJSON *resp = cJSON_Parse(json);
+   free(json);
+   if (!resp)
+      return -1;
+   cJSON *status = cJSON_GetObjectItemCaseSensitive(resp, "status");
+   int ok = cJSON_IsString(status) && strcmp(status->valuestring, "ok") == 0;
+   cJSON_Delete(resp);
+   return ok ? 0 : -1;
+}
+
 char *kb_client_evidence_trace_retrieval_event(const char *turn_id)
 {
    if (!turn_id || !turn_id[0])


### PR DESCRIPTION
## What

Completes the **P1.5 code path**. The ingress pre-inject already code-searches the turn query and emits the memory `retrieval_event`; it now **also merges its code hits into that same turn event** as typed refs (`code:<project>:<file_path>`, `v`=content_hash) — the two-writer model in action — gated by the same `kb_evidence_emit_enabled` (**default-off, observation-only**: answer/envelope byte-identical).

## Changes
- **KB action `evidence.merge_retrieval_event`** (`kb_handle_evidence_merge_retrieval_event` + dispatch + header): parses `{turn_id, role, query_fingerprint, surfaced_refs:[{type,ref,v}]}` (requires non-empty type/ref) into parallel arrays and calls `db2_demotion_retrieval_event_merge_refs_turn` (the tested merge core). `m==0` is a no-op (never creates a bare event).
- **Server client `kb_client_evidence_merge_retrieval_event`**: builds `surfaced_refs` from parallel `(types,refs,versions)` arrays and forwards via the internal `kb_v1_action_request`, mirroring the emit client.
- **`ingress_preinject.c`**: the emit block now gates on `(mem_n>0 || n>0)`; after the memory emit it builds code refs from the code hits and calls the merge client. Runs **after** the memory emit so it joins that event (idempotent two-writer); on a code-only turn it is the first writer (the merge creates the event).

## Verification
`make all` clean (aimee + aimee-server + aimee-kb), `make lint` + build-integrity ok. The **merge core** (`merge_refs_turn`) and the **code-ref provenance resolver** are unit-tested (prior PRs); this PR is observation-only serving glue over that tested core, exercised **end-to-end only when `kb_evidence_emit_enabled` is on** (default-off) — so it's verified on the live stack at flag-enable time, not in CI.

Local roundtable gate: **0 blocking** — round 1's two "blockers" were misreads (arrays are freed *after* the merge call; the partial-alloc path frees all three via `free(NULL)`); the genuine items (non-empty enforcement, `m==0` no-op, comment for the code-only case) are folded in.

## Remaining auditable-correctness
Only the **P3 LLM entailment judge** producer — default-off until the **P4 human-curated gold corpus** validates it.