### PR TITLE
fix(agent): validate agent/model slugs so junk names can't reach /v1/models

### DIFF
--- a/src/cmd_agent.c
+++ b/src/cmd_agent.c
@@ -3,6 +3,7 @@
 #include "util.h"
 #include "db1.h"
 #include "agent.h"
+#include "agent_config.h"
 #include "agent_tunnel.h"
 #include "commands.h"
 #include "hardware_probe.h"
@@ -716,6 +717,11 @@ static void ag_add(app_ctx_t *ctx, int argc, char **argv)
             "[--ctx N] [--timeout-ms N] [--exec-roles r1,r2,...]\n"
             "  --max-turns: per-agent delegate turn cap; 0 = unlimited "
             "(frontier agents), omitted = inherit the role floor.");
+
+   if (!agent_name_valid(argv[0]))
+      fatal("invalid agent name '%s': use 1–48 chars, starting alphanumeric, then "
+            "alphanumeric or . _ -",
+            argv[0]);
 
    char old_model[MAX_MODEL_LEN] = {0};
    int was_empty = cfg->agent_count == 0;

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -7,6 +7,12 @@
 
 int agent_load_config(agent_config_t *cfg);
 int agent_save_config(const agent_config_t *cfg);
+
+/* A valid agent/model slug: 1–48 chars, starting alphanumeric, then alphanumeric
+ * or . _ - . Agent names surface as model ids in /v1/models, so this keeps junk
+ * (over-long or non-identifier) names out of agents.json and the model list.
+ * Returns 1 if valid, 0 otherwise. */
+int agent_name_valid(const char *name);
 const char *agent_config_path(void);
 agent_t *agent_route(agent_config_t *cfg, const char *role);
 agent_t *agent_route_at_tier(agent_config_t *cfg, const char *role, int tier);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -9,9 +9,28 @@
 #include "provider_cli_adapter.h"
 #include "cJSON.h"
 #include "json_fluent.h"
+#include <ctype.h>
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+
+int agent_name_valid(const char *name)
+{
+   if (!name || !name[0])
+      return 0;
+   size_t len = strlen(name);
+   if (len > 48)
+      return 0;
+   if (!isalnum((unsigned char)name[0]))
+      return 0;
+   for (size_t i = 0; i < len; i++)
+   {
+      char c = name[i];
+      if (!isalnum((unsigned char)c) && c != '.' && c != '_' && c != '-')
+         return 0;
+   }
+   return 1;
+}
 
 /* Per-turn session id, set from the request in the chat/delegate workers (setter
  * below) and carried in the creds snapshot so a fan-out worker inherits the

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -294,6 +294,8 @@ static int models_provider(char ids[][SERVER_HTTP_MODEL_ID_MAX], int max)
    {
       if (!acfg.agents[i].name[0] || strcmp(acfg.agents[i].name, "aimee") == 0)
          continue; /* "aimee" is already advertised by the route */
+      if (!agent_name_valid(acfg.agents[i].name))
+         continue; /* never surface junk/over-long names as models (defensive) */
       snprintf(ids[k], SERVER_HTTP_MODEL_ID_MAX, "%s", acfg.agents[i].name);
       k++;
    }

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1786,6 +1786,25 @@ static void test_agent_trace_log_uses_db1_execution_trace(void)
    sqlite3_close(db);
 }
 
+static void test_agent_name_valid(void)
+{
+   /* legit agent/model slugs accepted */
+   assert(agent_name_valid("minimax"));
+   assert(agent_name_valid("mimo-2.5"));
+   assert(agent_name_valid("my-gpt"));
+   assert(agent_name_valid("a"));
+   assert(agent_name_valid("gpt_4.1-mini"));
+   /* junk rejected: empty, leading non-alnum, spaces, illegal chars, over-long */
+   assert(!agent_name_valid(""));
+   assert(!agent_name_valid(NULL));
+   assert(!agent_name_valid("-leading"));
+   assert(!agent_name_valid(".dot"));
+   assert(!agent_name_valid("has space"));
+   assert(!agent_name_valid("bad/slash"));
+   assert(!agent_name_valid(
+       "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); /* 63 */
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -1796,6 +1815,7 @@ int main(void)
    assert(config_output_dir()[0] != '\0');
    session_id_set_override("unit-test-agent");
    test_tool_surface_single_source();
+   test_agent_name_valid();
    test_agent_expand_env();
    test_agent_has_role();
    test_agent_find();


### PR DESCRIPTION
## What

Validation finding #2: a deployment had an agent named with 63 `a` characters in `agents.json`, surfacing as a garbage model in `GET /v1/models`. This adds slug validation so it can't recur.

## Changes

- **`agent_name_valid()`** (shared, in `agent_config.c`): a valid slug is 1–48 chars, starts alphanumeric, then alphanumeric or `. _ -`. Accepts existing names (`minimax`, `mimo-2.5`, `my-gpt`, …); rejects empty, over-long, spaced, or non-identifier names.
- **`aimee agent add`** rejects an invalid `<name>` up front.
- **`models_provider`** (server `/v1/models`) skips any agent whose name fails the check — defensive, so even a hand-edited `agents.json` can't surface junk as a model.
- `test_agent`: covers accepted + rejected slugs.

## Notes

The offending entry was already removed from the affected deployment's `agents.json` (live), and `/v1/models` there is now clean. This PR is the code hardening that prevents recurrence. Default-safe; no behavior change for valid names.

Gates: `format`, `line-check`, `build-integrity`, `unit-test-agent` all pass.
