### PR TITLE
fix(deploy-bugsweep): unknown-model 404 + DB2 pool lease release + pool-return ROLLBACK noise

### DIFF
--- a/src/db2/db2.h
+++ b/src/db2/db2.h
@@ -34,6 +34,7 @@ extern "C"
     * begin/end, a lazily-leased connection is returned when the thread exits. */
    void db2_lease_begin(void);
    void db2_lease_end(void);
+   void db2_lease_release_idle(void);
 
    /* Snapshot the DB2 connection URL for forked child reopen. Returns 1 when
     * a URL is available, else 0. */

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -267,6 +267,30 @@ void db2_lease_end(void)
    }
 }
 
+void db2_lease_release_idle(void)
+{
+   /* Release a connection acquired lazily by db2_conn() OUTSIDE any
+    * db2_lease_begin/_end scope (depth 0). Long-lived periodic workers (curator
+    * drain, maintenance timer) otherwise pin a pool connection for their whole
+    * lifetime — the reaper flags it as a stuck lease and it permanently shrinks
+    * the pool. They call this at a job boundary (between cycles) to return the
+    * connection while idle. No-op inside a lease scope or on the init thread. */
+   if (!g_init_thread_set || pthread_equal(pthread_self(), g_init_thread))
+      return;
+   if (g_lease_depth != 0)
+      return; /* inside an explicit begin/end unit — leave it owned */
+   db2_thread_lease_t *L = (db2_thread_lease_t *)pthread_getspecific(g_thread_conn_key);
+   if (L && L->conn)
+   {
+      if (L->pooled)
+         db2_pool_return(L->conn);
+      else
+         aimee_pg_close(L->conn);
+      L->conn = NULL;
+      L->pooled = 0;
+   }
+}
+
 void *db2_thread_conn_open(char *errbuf, size_t errlen)
 {
    pthread_once(&g_thread_conn_key_once, thread_conn_key_init);

--- a/src/db2/db2_internal.h
+++ b/src/db2/db2_internal.h
@@ -42,6 +42,7 @@ extern "C"
     * pool between units (refcounted; see lifecycle.h). */
    void db2_lease_begin(void);
    void db2_lease_end(void);
+   void db2_lease_release_idle(void);
 
    /* Open a new dedicated DB2 connection for the calling thread and set
     * it as the thread's active connection (returned by db2_conn()).

--- a/src/db2/db2_pool.c
+++ b/src/db2/db2_pool.c
@@ -51,7 +51,12 @@ static void *db2_pool_reaper_main(void *arg);
 static int member_reset_real(void *conn)
 {
    char e[256];
-   (void)aimee_pg_exec(conn, "ROLLBACK", e, sizeof(e)); /* best-effort */
+   /* Only ROLLBACK when a txn is actually open/aborted: an unconditional ROLLBACK
+    * on an idle connection makes postgres log "no transaction in progress" on
+    * every pool return (noise). DISCARD ALL below still cannot run inside a txn,
+    * so any open one must be cleared first. */
+   if (aimee_pg_in_transaction(conn))
+      (void)aimee_pg_exec(conn, "ROLLBACK", e, sizeof(e));
    if (aimee_pg_exec(conn, "RESET SESSION AUTHORIZATION", e, sizeof(e)) != 0)
       return -1;
    if (aimee_pg_exec(conn, "DISCARD ALL", e, sizeof(e)) != 0)

--- a/src/db2/db_postgres.c
+++ b/src/db2/db_postgres.c
@@ -1072,6 +1072,14 @@ int aimee_pg_exec(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
    return aimee_pg_exec_with_changes(pg_conn, sql, errbuf, errlen, NULL);
 }
 
+int aimee_pg_in_transaction(void *pg_conn)
+{
+   if (!pg_conn)
+      return 0;
+   PGTransactionStatusType t = PQtransactionStatus((PGconn *)pg_conn);
+   return (t == PQTRANS_INTRANS || t == PQTRANS_INERROR) ? 1 : 0;
+}
+
 int aimee_pg_exec_with_changes(void *pg_conn, const char *sql, char *errbuf, size_t errlen,
                                int *affected_out)
 {

--- a/src/db2/db_postgres.h
+++ b/src/db2/db_postgres.h
@@ -51,6 +51,10 @@ int aimee_pg_is_shim(void);
 int aimee_pg_exec(void *pg_conn, const char *sql, char *errbuf, size_t errlen);
 int aimee_pg_exec_with_changes(void *pg_conn, const char *sql, char *errbuf, size_t errlen,
                                int *affected_out);
+/* 1 if the connection currently has an open (or failed-open) transaction, else 0.
+ * Lets callers skip a no-op ROLLBACK (which makes postgres log "no transaction in
+ * progress" on every clean pool return). */
+int aimee_pg_in_transaction(void *pg_conn);
 int aimee_pg_stmt_changes(aimee_pg_stmt_t *stmt);
 int aimee_pg_ping(void *pg_conn, char *errbuf, size_t errlen);
 

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -9,6 +9,7 @@
 #define _GNU_SOURCE
 #endif
 
+#include "db2/db2.h"
 #include "kb_curator_drain.h"
 #include "kb_curator_extract.h"
 #include "kb_curator_resolve_entities.h"
@@ -63,6 +64,9 @@ static void *drain_thread_main(void *arg)
 
    while (!ctx->stop)
    {
+      /* Return any pool connection acquired last cycle before sleeping, so this
+       * long-lived thread doesn't pin one while idle (stuck-lease reaper). */
+      db2_lease_release_idle();
       sleep(DRAIN_POLL_SECS);
       if (ctx->stop)
          break;

--- a/src/kb/kb_service_workers.c
+++ b/src/kb/kb_service_workers.c
@@ -18,6 +18,7 @@
 #include "kb_reflection.h"
 #include "kb_service.h"
 #include "config.h"
+#include "db2/db2.h"
 #include "db2/kb_service_backend.h"
 #include "db2/kb_maintenance.h"
 #include "db2/kb_runtime_state.h"
@@ -71,6 +72,9 @@ static void *kb_maintenance_timer_thread(void *arg)
    long elapsed = 0;
    while (!g_maintenance_stop)
    {
+      /* Drop any pool connection held from the last maintenance run so this
+       * long-lived timer doesn't pin one while idle (stuck-lease reaper). */
+      db2_lease_release_idle();
       sleep(1);
       elapsed++;
       if (elapsed < interval_secs)

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -155,7 +155,8 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
     * provider/model — two requests resolving to a different backend must not
     * collide even with an identical body. Honour the requested model: "aimee"
     * (or empty) means the default agent; any other value selects a configured
-    * agent by name, falling back to the default when it doesn't match one. */
+    * agent by name, and is rejected with model_not_found when it matches none
+    * (never silently falls back to a different model). */
    agent_config_t acfg;
    if (agent_load_config(&acfg) != 0)
    {
@@ -166,7 +167,19 @@ static int run_completion(int chat, const char *body, char *resp, int cap)
    }
    agent_t *ag = NULL;
    if (model[0] && strcmp(model, "aimee") != 0)
+   {
+      /* An explicitly requested model must match a configured agent — never
+       * silently fall back to the default (that would run a different model than
+       * the client asked for and echo the wrong name back). */
       ag = agent_find(&acfg, model);
+      if (!ag)
+      {
+         free(pi_env);
+         free(prompt);
+         openai_format_error(resp, cap, "model_not_found", "the requested model is not available");
+         return 404;
+      }
+   }
    if (!ag)
       ag = agent_find(&acfg, acfg.default_agent);
    if (!ag && acfg.agent_count > 0)
@@ -569,7 +582,16 @@ static int responses_handler(const char *body, char *resp, int cap)
    }
    agent_t *ag = NULL;
    if (model[0] && strcmp(model, "aimee") != 0)
+   {
+      /* Explicit model must match a configured agent — no silent fallback. */
       ag = agent_find(&acfg, model);
+      if (!ag)
+      {
+         free(prompt);
+         openai_format_error(resp, cap, "model_not_found", "the requested model is not available");
+         return 404;
+      }
+   }
    if (!ag)
       ag = agent_find(&acfg, acfg.default_agent);
    if (!ag && acfg.agent_count > 0)
@@ -673,11 +695,12 @@ static agent_t *stream_pick_agent(agent_config_t *acfg, const char *model)
 {
    if (agent_load_config(acfg) != 0)
       return NULL;
-   agent_t *ag = NULL;
+   /* An explicitly requested model must match a configured agent. Returning NULL
+    * (rather than falling back to the default) makes callers refuse instead of
+    * silently streaming a different model than the client asked for. */
    if (model[0] && strcmp(model, "aimee") != 0)
-      ag = agent_find(acfg, model);
-   if (!ag)
-      ag = agent_find(acfg, acfg->default_agent);
+      return agent_find(acfg, model);
+   agent_t *ag = agent_find(acfg, acfg->default_agent);
    if (!ag && acfg->agent_count > 0)
       ag = &acfg->agents[0];
    return ag;

--- a/src/tests/aimee_pg_sqlite_shim.c
+++ b/src/tests/aimee_pg_sqlite_shim.c
@@ -578,6 +578,13 @@ int aimee_pg_ping(void *pg_conn, char *errbuf, size_t errlen)
    return 0;
 }
 
+int aimee_pg_in_transaction(void *pg_conn)
+{
+   sqlite3 *db = (sqlite3 *)pg_conn;
+   /* sqlite3_get_autocommit returns 0 while a transaction is open. */
+   return (db && sqlite3_get_autocommit(db) == 0) ? 1 : 0;
+}
+
 int aimee_pg_exec(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
 {
    sqlite3 *db = (sqlite3 *)pg_conn;

--- a/src/tests/test_db2.c
+++ b/src/tests/test_db2.c
@@ -79,6 +79,14 @@ int aimee_pg_exec(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
    return 0;
 }
 
+/* member_reset_real (in db2_pool.o, not exercised by these pool tests — they shim
+ * g_reset) references this; provide a stub so the object links. */
+int aimee_pg_in_transaction(void *pg_conn)
+{
+   (void)pg_conn;
+   return 0;
+}
+
 aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
 {
    static aimee_pg_stmt_t schema_stmt = {.kind = STMT_SCHEMA};

--- a/src/tests/test_db2_pool.c
+++ b/src/tests/test_db2_pool.c
@@ -24,6 +24,11 @@ void aimee_pg_close(void *c)
 {
    (void)c;
 }
+int aimee_pg_in_transaction(void *c)
+{
+   (void)c;
+   return 0; /* member_reset_real is shimmed (g_reset) in these tests */
+}
 int aimee_pg_exec(void *c, const char *s, char *e, size_t n)
 {
    (void)c;


### PR DESCRIPTION
Three fixes from exploratory testing of the live deployment (memory-search latency is owned by another worker, excluded).

## #4 — Unknown model → 404 (was silent fallback)
`/v1/chat/completions` with an unregistered model silently ran the primary and echoed the bogus name back as `model`. Now an explicitly-requested model that matches no configured agent → **`model_not_found` (404)**. Fixed in all three resolution sites: `run_completion` (chat+completions), `responses_handler` (/v1/responses), and `stream_pick_agent` (streaming refuses instead of falling back).

## #2 — DB2 pool lease leak (2 of 8 connections pinned ~58 min)
The curator-drain + maintenance-timer background threads `db2_conn()` lazily (via helpers) but never `db2_lease_end`, so each pinned a pool connection for its whole lifetime — the reaper logged them stuck and they permanently shrank the pool. Added **`db2_lease_release_idle()`** (returns a depth-0 lazy lease) called at the top of each periodic loop, freeing the connection while the thread sleeps. Continue-safe; no `db2_lease_begin/_end` balancing needed.

## #6 — Spurious "no transaction in progress"
Every clean pool return ran an unconditional best-effort `ROLLBACK`, so postgres logged the warning on each return. `member_reset_real` now checks `aimee_pg_in_transaction()` (`PQtransactionStatus`) and only ROLLBACKs when a txn is actually open.

## Investigated, intentionally not changed
- **Embedder serialization** is CPU saturation of the 4b model (no GPU; no serializing lock) — mitigations are ops (GPU / 0.6b tier / batching), not code.
- **css/memory returning 200 + `{status:error}`** is aimee's KB-action RPC envelope convention (the CLI depends on it); the OpenAI-compat chat endpoints already use proper 4xx. Mapping it to 4xx would break the client contract.

## Tests
Full `unit-tests` green (167 suites), `build-integrity`, `format`, `line-check`, `schema-sync-check` pass. Added `aimee_pg_in_transaction` test stubs to the pool tests. #2/#6 live in production-only paths (background threads / real-libpq reset) — to be live-validated on deploy.
