### PR TITLE
feat(curator): shared LLM-provider client foundation (§1)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -289,7 +289,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
-            aimee_home.c shared/kb_paths.c \
+            aimee_home.c shared/kb_paths.c provider_client.c \
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \

--- a/src/headers/provider_client.h
+++ b/src/headers/provider_client.h
@@ -72,7 +72,8 @@ extern "C"
 
    /* Parse an OpenAI chat-completions response `body` into `out` (zeroed first).
     * Returns 0 when choices[0].message.content is present, -1 otherwise. Usage,
-    * model and finish_reason are filled when present. */
+    * model and finish_reason are filled when present. `http_status` is left 0
+    * here — provider_client_complete sets it after the transport call. */
    int provider_client_parse_openai(const char *body, provider_completion_t *out);
 
    /* Build + POST (with retry) + parse. Returns 0 on success; on failure returns

--- a/src/headers/provider_client.h
+++ b/src/headers/provider_client.h
@@ -1,0 +1,92 @@
+/* provider_client.h: shared LLM-provider client (DRY across aimee-server + aimee-kb).
+ *
+ * Given a provider def (base_url + model + key + wire format) and a request
+ * (messages + optional JSON schema), return a completion — owning the wire
+ * format, transport, and retries in one place. Both aimee-server (per-user
+ * provider defs, client-held credentials) and aimee-kb (operator-owned curator
+ * provider) link this. This is §1 of the curator-llm-backend proposal: the
+ * foundation §2 (curator stages -> providers) and §4 (health) build on.
+ *
+ * Transport is agent_http_post (the platform object both binaries already link),
+ * and the module owns its own small retry loop so aimee-kb does not need the
+ * server-only http_retry/failover modules (which are DB1-coupled).
+ *
+ * Pure domain API: no agent_t, no server config, no provider-registry types in
+ * any signature — only a plain provider def the caller fills from its own config. */
+#ifndef DEC_PROVIDER_CLIENT_H
+#define DEC_PROVIDER_CLIENT_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   struct cJSON;
+
+/* Buffer for a provider-reported model id. Kept local so this header stays
+ * self-contained (matches MAX_MODEL_LEN in agent_types.h). */
+#define PROVIDER_MODEL_LEN 128
+
+   typedef enum
+   {
+      PROVIDER_WIRE_OPENAI_CHAT = 0, /* OpenAI-compatible /chat/completions */
+   } provider_wire_t;
+
+   typedef struct
+   {
+      const char *base_url; /* API base, e.g. "http://host:8080/v1"; the
+                             * "/chat/completions" suffix is appended and a
+                             * trailing slash is tolerated. */
+      const char *model;    /* model id sent in the request body. */
+      const char *api_key;  /* bearer token; NULL/"" for a keyless local endpoint. */
+      provider_wire_t wire; /* wire format. */
+      int timeout_ms;       /* per-attempt timeout; <=0 => default. */
+      double temperature;   /* <0 => omit (let the provider default). */
+      int max_tokens;       /* <=0 => omit. */
+      int max_attempts;     /* total attempts incl. the first; <=0 => default. */
+   } provider_def_t;
+
+   typedef struct
+   {
+      char *content;                  /* malloc'd completion text; NULL if none. Caller frees. */
+      int prompt_tokens;              /* from usage; 0 when absent. */
+      int completion_tokens;          /* from usage; 0 when absent. */
+      char model[PROVIDER_MODEL_LEN]; /* provider-reported model id; "" when absent. */
+      char finish_reason[32];         /* OpenAI finish_reason; "" when absent. */
+      int http_status;                /* last HTTP status (or <0 on a network error). */
+   } provider_completion_t;
+
+#define PROVIDER_CLIENT_DEFAULT_TIMEOUT_MS 120000
+#define PROVIDER_CLIENT_DEFAULT_ATTEMPTS   3
+
+   /* Build the OpenAI chat-completions request body for `def` + `messages` (a
+    * cJSON array of {role, content}). When `json_schema` is non-NULL it is sent as
+    * response_format:{type:"json_schema", json_schema:{name, schema, strict:true}}
+    * so a grammar-capable endpoint (llama.cpp --jinja, OpenAI) returns constrained
+    * JSON. `messages`/`json_schema` are NOT taken over — the result references deep
+    * copies. Returns a new cJSON object (caller cJSON_Delete) or NULL on failure. */
+   struct cJSON *provider_client_build_openai(const provider_def_t *def, struct cJSON *messages,
+                                              struct cJSON *json_schema);
+
+   /* Parse an OpenAI chat-completions response `body` into `out` (zeroed first).
+    * Returns 0 when choices[0].message.content is present, -1 otherwise. Usage,
+    * model and finish_reason are filled when present. */
+   int provider_client_parse_openai(const char *body, provider_completion_t *out);
+
+   /* Build + POST (with retry) + parse. Returns 0 on success; on failure returns
+    * -1 and writes a message into errbuf (when errlen > 0). `out` is zeroed on
+    * entry and is always safe to pass to provider_completion_free afterward. */
+   int provider_client_complete(const provider_def_t *def, struct cJSON *messages,
+                                struct cJSON *json_schema, provider_completion_t *out, char *errbuf,
+                                size_t errlen);
+
+   /* Free heap-owned fields of `out` (idempotent; does not free `out` itself). */
+   void provider_completion_free(provider_completion_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_PROVIDER_CLIENT_H */

--- a/src/provider_client.c
+++ b/src/provider_client.c
@@ -1,0 +1,256 @@
+/* provider_client.c: shared LLM-provider client. See provider_client.h.
+ *
+ * Built on agent_http_post (linked by aimee-server and aimee-kb alike) with a
+ * self-contained retry loop, so the kb need not link the server-only,
+ * DB1-coupled http_retry/failover modules. The retryable-status set mirrors
+ * http_retry's contract (408/409/429/5xx + network errors). */
+
+#include "aimee.h" /* MAX_PATH_LEN etc., pulled in before agent_types.h */
+#include "provider_client.h"
+
+#include "agent_exec.h" /* agent_http_post */
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* --- request building --- */
+
+struct cJSON *provider_client_build_openai(const provider_def_t *def, struct cJSON *messages,
+                                           struct cJSON *json_schema)
+{
+   if (!def || !messages)
+      return NULL;
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return NULL;
+   if (def->model && def->model[0])
+      cJSON_AddStringToObject(req, "model", def->model);
+
+   /* Deep-copy the caller's messages so ownership stays with them. */
+   cJSON *msgs = cJSON_Duplicate(messages, 1);
+   if (!msgs)
+   {
+      cJSON_Delete(req);
+      return NULL;
+   }
+   cJSON_AddItemToObject(req, "messages", msgs);
+
+   if (def->temperature >= 0.0)
+      cJSON_AddNumberToObject(req, "temperature", def->temperature);
+   if (def->max_tokens > 0)
+      cJSON_AddNumberToObject(req, "max_tokens", def->max_tokens);
+
+   if (json_schema)
+   {
+      cJSON *schema_copy = cJSON_Duplicate(json_schema, 1);
+      if (!schema_copy)
+      {
+         cJSON_Delete(req);
+         return NULL;
+      }
+      cJSON *rf = cJSON_CreateObject();
+      cJSON *js = cJSON_CreateObject();
+      if (!rf || !js)
+      {
+         cJSON_Delete(schema_copy);
+         cJSON_Delete(rf);
+         cJSON_Delete(js);
+         cJSON_Delete(req);
+         return NULL;
+      }
+      cJSON_AddStringToObject(rf, "type", "json_schema");
+      cJSON_AddStringToObject(js, "name", "curator_output");
+      cJSON_AddItemToObject(js, "schema", schema_copy);
+      cJSON_AddBoolToObject(js, "strict", 1);
+      cJSON_AddItemToObject(rf, "json_schema", js);
+      cJSON_AddItemToObject(req, "response_format", rf);
+   }
+   return req;
+}
+
+/* --- response parsing --- */
+
+int provider_client_parse_openai(const char *body, provider_completion_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (!body || !out)
+      return -1;
+
+   cJSON *root = cJSON_Parse(body);
+   if (!root)
+      return -1;
+
+   int rc = -1;
+   cJSON *choices = cJSON_GetObjectItemCaseSensitive(root, "choices");
+   cJSON *choice0 = cJSON_IsArray(choices) ? cJSON_GetArrayItem(choices, 0) : NULL;
+   if (choice0)
+   {
+      cJSON *msg = cJSON_GetObjectItemCaseSensitive(choice0, "message");
+      cJSON *content = msg ? cJSON_GetObjectItemCaseSensitive(msg, "content") : NULL;
+      if (cJSON_IsString(content) && content->valuestring)
+      {
+         out->content = strdup(content->valuestring);
+         if (out->content)
+            rc = 0;
+      }
+      cJSON *fr = cJSON_GetObjectItemCaseSensitive(choice0, "finish_reason");
+      if (cJSON_IsString(fr) && fr->valuestring)
+         snprintf(out->finish_reason, sizeof(out->finish_reason), "%s", fr->valuestring);
+   }
+
+   cJSON *usage = cJSON_GetObjectItemCaseSensitive(root, "usage");
+   if (usage)
+   {
+      cJSON *pt = cJSON_GetObjectItemCaseSensitive(usage, "prompt_tokens");
+      cJSON *ct = cJSON_GetObjectItemCaseSensitive(usage, "completion_tokens");
+      if (cJSON_IsNumber(pt))
+         out->prompt_tokens = pt->valueint;
+      if (cJSON_IsNumber(ct))
+         out->completion_tokens = ct->valueint;
+   }
+
+   cJSON *model = cJSON_GetObjectItemCaseSensitive(root, "model");
+   if (cJSON_IsString(model) && model->valuestring)
+      snprintf(out->model, sizeof(out->model), "%s", model->valuestring);
+
+   cJSON_Delete(root);
+   return rc;
+}
+
+/* --- transport + retry --- */
+
+/* Mirrors http_retry's retryable set: transient server/limit statuses and any
+ * network-level error (status < 0). Everything else (2xx, 4xx auth/not-found)
+ * fails fast. */
+static int wire_is_retryable(int http_status)
+{
+   if (http_status < 0)
+      return 1;
+   switch (http_status)
+   {
+   case 408:
+   case 409:
+   case 429:
+   case 500:
+   case 502:
+   case 503:
+   case 504:
+      return 1;
+   default:
+      return 0;
+   }
+}
+
+/* Exponential backoff (base * 2^attempt) clamped to max; overflow-safe. */
+static int wire_backoff_ms(int attempt, int base_ms, int max_ms)
+{
+   long d = base_ms;
+   for (int i = 0; i < attempt; i++)
+   {
+      d *= 2;
+      if (d >= max_ms)
+         return max_ms;
+   }
+   return d > max_ms ? max_ms : (int)d;
+}
+
+int provider_client_complete(const provider_def_t *def, struct cJSON *messages,
+                             struct cJSON *json_schema, provider_completion_t *out, char *errbuf,
+                             size_t errlen)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (errbuf && errlen)
+      errbuf[0] = '\0';
+   if (!def || !def->base_url || !def->base_url[0] || !messages || !out)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "invalid arguments");
+      return -1;
+   }
+   if (def->wire != PROVIDER_WIRE_OPENAI_CHAT)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "unsupported wire format %d", (int)def->wire);
+      return -1;
+   }
+
+   cJSON *req = provider_client_build_openai(def, messages, json_schema);
+   if (!req)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "failed to build request");
+      return -1;
+   }
+   char *body = cJSON_PrintUnformatted(req);
+   cJSON_Delete(req);
+   if (!body)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "failed to serialize request");
+      return -1;
+   }
+
+   /* URL = base_url + "/chat/completions" (tolerate a trailing slash). */
+   size_t bl = strlen(def->base_url);
+   int has_slash = bl > 0 && def->base_url[bl - 1] == '/';
+   char url[1024];
+   snprintf(url, sizeof(url), "%s%schat/completions", def->base_url, has_slash ? "" : "/");
+
+   char auth[1024];
+   const char *auth_header = NULL;
+   if (def->api_key && def->api_key[0])
+   {
+      snprintf(auth, sizeof(auth), "Authorization: Bearer %s", def->api_key);
+      auth_header = auth;
+   }
+
+   int timeout = def->timeout_ms > 0 ? def->timeout_ms : PROVIDER_CLIENT_DEFAULT_TIMEOUT_MS;
+   int attempts = def->max_attempts > 0 ? def->max_attempts : PROVIDER_CLIENT_DEFAULT_ATTEMPTS;
+
+   int status = -1;
+   char *resp = NULL;
+   for (int a = 0; a < attempts; a++)
+   {
+      free(resp);
+      resp = NULL;
+      status = agent_http_post(url, auth_header, body, &resp, timeout, NULL);
+      if (!wire_is_retryable(status))
+         break;
+      if (a + 1 < attempts)
+      {
+         int ms = wire_backoff_ms(a, 1000, 30000);
+         struct timespec ts = {ms / 1000, (long)(ms % 1000) * 1000000L};
+         nanosleep(&ts, NULL);
+      }
+   }
+   free(body);
+
+   if (status < 200 || status >= 300)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "provider HTTP %d", status);
+      free(resp);
+      out->http_status = status;
+      return -1;
+   }
+
+   int rc = provider_client_parse_openai(resp, out); /* zeroes out, then fills */
+   free(resp);
+   out->http_status = status;
+   if (rc != 0 && errbuf && errlen)
+      snprintf(errbuf, errlen, "unparseable provider response");
+   return rc;
+}
+
+void provider_completion_free(provider_completion_t *out)
+{
+   if (!out)
+      return;
+   free(out->content);
+   out->content = NULL;
+}

--- a/src/provider_client.c
+++ b/src/provider_client.c
@@ -195,17 +195,33 @@ int provider_client_complete(const provider_def_t *def, struct cJSON *messages,
       return -1;
    }
 
-   /* URL = base_url + "/chat/completions" (tolerate a trailing slash). */
+   /* URL = base_url + "/chat/completions" (tolerate a trailing slash). snprintf
+    * is bounded (no overflow), but a truncated URL/Bearer would silently hit the
+    * wrong endpoint or 401 with valid creds, so treat truncation as an error. */
    size_t bl = strlen(def->base_url);
    int has_slash = bl > 0 && def->base_url[bl - 1] == '/';
-   char url[1024];
-   snprintf(url, sizeof(url), "%s%schat/completions", def->base_url, has_slash ? "" : "/");
+   char url[2048];
+   int un = snprintf(url, sizeof(url), "%s%schat/completions", def->base_url, has_slash ? "" : "/");
+   if (un < 0 || (size_t)un >= sizeof(url))
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "base_url too long");
+      free(body);
+      return -1;
+   }
 
-   char auth[1024];
+   char auth[1280];
    const char *auth_header = NULL;
    if (def->api_key && def->api_key[0])
    {
-      snprintf(auth, sizeof(auth), "Authorization: Bearer %s", def->api_key);
+      int an = snprintf(auth, sizeof(auth), "Authorization: Bearer %s", def->api_key);
+      if (an < 0 || (size_t)an >= sizeof(auth))
+      {
+         if (errbuf && errlen)
+            snprintf(errbuf, errlen, "api_key too long");
+         free(body);
+         return -1;
+      }
       auth_header = auth;
    }
 

--- a/src/provider_client.c
+++ b/src/provider_client.c
@@ -151,9 +151,11 @@ static int wire_backoff_ms(int attempt, int base_ms, int max_ms)
    long d = base_ms;
    for (int i = 0; i < attempt; i++)
    {
-      d *= 2;
-      if (d >= max_ms)
+      /* Check before doubling so `d` never exceeds max_ms (an int) — no overflow
+       * regardless of attempt count or max_ms magnitude. */
+      if (d >= max_ms || d > max_ms / 2)
          return max_ms;
+      d *= 2;
    }
    return d > max_ms ? max_ms : (int)d;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -182,6 +182,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-windows \
                $(TESTPREFIX)/unit-test-token-tracker \
                $(TESTPREFIX)/unit-test-model-pricing \
+               $(TESTPREFIX)/unit-test-provider-client \
                $(TESTPREFIX)/unit-test-reasoning-cap \
                $(TESTPREFIX)/unit-test-request-context \
                $(TESTPREFIX)/unit-test-response-dedup \
@@ -2272,6 +2273,11 @@ $(TESTPREFIX)/unit-test-model-pricing: $(OBJDIR)/tests/test_model_pricing.o \
                                   $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                   $(OBJDIR)/db1/model_pricing.o \
                                   $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-provider-client: $(OBJDIR)/tests/test_provider_client.o \
+                                  $(OBJDIR)/provider_client.o $(OBJDIR)/cJSON.o \
+                                  $(OBJDIR)/tests/support/mock_agent_http.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-collab-rules: $(OBJDIR)/tests/test_collab_rules.o $(TEST_DATA_OBJS_MOCK)

--- a/src/tests/test_provider_client.c
+++ b/src/tests/test_provider_client.c
@@ -176,7 +176,11 @@ static int flaky_handler(const char *url, const char *auth_header, const char *b
    (void)extra_headers;
    g_post_calls++;
    if (g_post_calls == 1)
-      return 503; /* retryable; mock leaves *response_buf NULL */
+   {
+      if (response_buf)
+         *response_buf = NULL; /* explicit: no body on a transient error */
+      return 503;              /* retryable */
+   }
    if (response_buf)
       *response_buf = strdup("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}");
    return 200;
@@ -289,6 +293,40 @@ static void test_complete_non_retryable(void)
    printf("provider_client: complete non-retryable (no retry) ok\n");
 }
 
+static void test_complete_truncation_guards(void)
+{
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(ok_handler);
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   char err[128];
+
+   /* base_url longer than the URL buffer -> truncation error, no transport call. */
+   char big[4096];
+   memset(big, 'x', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+   provider_def_t d1 = {.base_url = big, .wire = PROVIDER_WIRE_OPENAI_CHAT, .temperature = -1.0};
+   g_post_calls = 0;
+   assert(provider_client_complete(&d1, msgs, NULL, &out, err, sizeof(err)) == -1);
+   assert(g_post_calls == 0 && err[0] != '\0');
+
+   /* api_key longer than the auth buffer -> truncation error, no transport call. */
+   char bigkey[2048];
+   memset(bigkey, 'k', sizeof(bigkey) - 1);
+   bigkey[sizeof(bigkey) - 1] = '\0';
+   provider_def_t d2 = {.base_url = "http://h/v1",
+                        .api_key = bigkey,
+                        .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                        .temperature = -1.0};
+   g_post_calls = 0;
+   assert(provider_client_complete(&d2, msgs, NULL, &out, err, sizeof(err)) == -1);
+   assert(g_post_calls == 0 && err[0] != '\0');
+
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete truncation guards ok\n");
+}
+
 int main(void)
 {
    test_build_basic();
@@ -300,6 +338,7 @@ int main(void)
    test_complete_trailing_slash();
    test_complete_retry_then_ok();
    test_complete_non_retryable();
+   test_complete_truncation_guards();
    printf("provider_client: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_provider_client.c
+++ b/src/tests/test_provider_client.c
@@ -1,0 +1,153 @@
+/* test_provider_client.c: shared provider-client request builder + response parser.
+ * Network-free: exercises the pure build/parse halves (provider_client_complete's
+ * transport is covered by integration once a curator endpoint is wired). */
+#include "provider_client.h"
+#include "cJSON.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static cJSON *two_messages(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "user");
+   cJSON_AddStringToObject(m, "content", "extract entities");
+   cJSON_AddItemToArray(msgs, m);
+   return msgs;
+}
+
+static void test_build_basic(void)
+{
+   provider_def_t def = {
+       .base_url = "http://h:8080/v1",
+       .model = "granite-3b",
+       .wire = PROVIDER_WIRE_OPENAI_CHAT,
+       .temperature = -1.0, /* omit */
+       .max_tokens = 0,     /* omit */
+   };
+   cJSON *msgs = two_messages();
+   cJSON *req = provider_client_build_openai(&def, msgs, NULL);
+   assert(req);
+
+   cJSON *model = cJSON_GetObjectItemCaseSensitive(req, "model");
+   assert(cJSON_IsString(model) && strcmp(model->valuestring, "granite-3b") == 0);
+   /* messages copied, not aliased: mutating the original must not change req. */
+   cJSON *rmsgs = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   assert(cJSON_IsArray(rmsgs) && cJSON_GetArraySize(rmsgs) == 1);
+   /* omitted optionals absent */
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "temperature"));
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "max_tokens"));
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "response_format"));
+
+   cJSON_Delete(req);
+   cJSON_Delete(msgs);
+   printf("provider_client: build basic ok\n");
+}
+
+static void test_build_options_and_schema(void)
+{
+   provider_def_t def = {
+       .base_url = "http://h:8080/v1",
+       .model = "granite-3b",
+       .wire = PROVIDER_WIRE_OPENAI_CHAT,
+       .temperature = 0.2,
+       .max_tokens = 512,
+   };
+   cJSON *msgs = two_messages();
+   cJSON *schema = cJSON_CreateObject();
+   cJSON_AddStringToObject(schema, "type", "object");
+
+   cJSON *req = provider_client_build_openai(&def, msgs, schema);
+   assert(req);
+   cJSON *temp = cJSON_GetObjectItemCaseSensitive(req, "temperature");
+   assert(cJSON_IsNumber(temp) && temp->valuedouble > 0.19 && temp->valuedouble < 0.21);
+   cJSON *mt = cJSON_GetObjectItemCaseSensitive(req, "max_tokens");
+   assert(cJSON_IsNumber(mt) && mt->valueint == 512);
+
+   cJSON *rf = cJSON_GetObjectItemCaseSensitive(req, "response_format");
+   assert(rf);
+   cJSON *rftype = cJSON_GetObjectItemCaseSensitive(rf, "type");
+   assert(cJSON_IsString(rftype) && strcmp(rftype->valuestring, "json_schema") == 0);
+   cJSON *js = cJSON_GetObjectItemCaseSensitive(rf, "json_schema");
+   assert(js);
+   cJSON *strict = cJSON_GetObjectItemCaseSensitive(js, "strict");
+   assert(cJSON_IsBool(strict) && cJSON_IsTrue(strict));
+   cJSON *embedded = cJSON_GetObjectItemCaseSensitive(js, "schema");
+   assert(embedded); /* the caller schema is copied in */
+   cJSON *etype = cJSON_GetObjectItemCaseSensitive(embedded, "type");
+   assert(cJSON_IsString(etype) && strcmp(etype->valuestring, "object") == 0);
+
+   cJSON_Delete(req);
+   cJSON_Delete(msgs);
+   cJSON_Delete(schema); /* still owned by the caller — proves no take-over */
+   printf("provider_client: build options + schema ok\n");
+}
+
+static void test_parse_success(void)
+{
+   const char *body =
+       "{\"model\":\"granite-3b-instruct\",\"choices\":[{\"finish_reason\":\"stop\","
+       "\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"entities\\\":[]}\"}}],"
+       "\"usage\":{\"prompt_tokens\":42,\"completion_tokens\":7}}";
+   provider_completion_t out;
+   int rc = provider_client_parse_openai(body, &out);
+   assert(rc == 0);
+   assert(out.content && strcmp(out.content, "{\"entities\":[]}") == 0);
+   assert(out.prompt_tokens == 42 && out.completion_tokens == 7);
+   assert(strcmp(out.model, "granite-3b-instruct") == 0);
+   assert(strcmp(out.finish_reason, "stop") == 0);
+   provider_completion_free(&out);
+   provider_completion_free(&out); /* idempotent */
+   printf("provider_client: parse success ok\n");
+}
+
+static void test_parse_failures(void)
+{
+   provider_completion_t out;
+   /* not JSON */
+   assert(provider_client_parse_openai("not json", &out) == -1);
+   /* well-formed but no content */
+   assert(provider_client_parse_openai("{\"choices\":[{\"message\":{}}]}", &out) == -1);
+   /* empty choices */
+   assert(provider_client_parse_openai("{\"choices\":[]}", &out) == -1);
+   /* NULL body */
+   assert(provider_client_parse_openai(NULL, &out) == -1);
+   /* out zeroed even on failure */
+   assert(out.content == NULL && out.prompt_tokens == 0);
+   printf("provider_client: parse failures ok\n");
+}
+
+static void test_complete_arg_guards(void)
+{
+   char err[128];
+   provider_completion_t out;
+   cJSON *msgs = two_messages();
+   provider_def_t def = {.base_url = "http://h/v1", .wire = PROVIDER_WIRE_OPENAI_CHAT};
+
+   /* missing base_url */
+   provider_def_t no_url = def;
+   no_url.base_url = "";
+   assert(provider_client_complete(&no_url, msgs, NULL, &out, err, sizeof(err)) == -1);
+   assert(err[0] != '\0');
+
+   /* unsupported wire */
+   provider_def_t bad_wire = def;
+   bad_wire.wire = (provider_wire_t)99;
+   assert(provider_client_complete(&bad_wire, msgs, NULL, &out, err, sizeof(err)) == -1);
+
+   cJSON_Delete(msgs);
+   printf("provider_client: complete arg guards ok\n");
+}
+
+int main(void)
+{
+   test_build_basic();
+   test_build_options_and_schema();
+   test_parse_success();
+   test_parse_failures();
+   test_complete_arg_guards();
+   printf("provider_client: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_provider_client.c
+++ b/src/tests/test_provider_client.c
@@ -3,9 +3,11 @@
  * transport is covered by integration once a curator endpoint is wired). */
 #include "provider_client.h"
 #include "cJSON.h"
+#include "support/mock_agent_http.h"
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 static cJSON *two_messages(void)
@@ -141,6 +143,152 @@ static void test_complete_arg_guards(void)
    printf("provider_client: complete arg guards ok\n");
 }
 
+/* --- complete() over the mocked transport: URL/auth/retry/parse --- */
+
+static char g_seen_url[1024];
+static char g_seen_auth[1024];
+static int g_post_calls;
+
+static int ok_handler(const char *url, const char *auth_header, const char *body,
+                      char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_post_calls++;
+   snprintf(g_seen_url, sizeof(g_seen_url), "%s", url ? url : "");
+   snprintf(g_seen_auth, sizeof(g_seen_auth), "%s", auth_header ? auth_header : "");
+   if (response_buf)
+      *response_buf = strdup("{\"model\":\"m\",\"choices\":[{\"finish_reason\":\"stop\","
+                             "\"message\":{\"content\":\"hi\"}}],"
+                             "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}");
+   return 200;
+}
+
+/* 503 on the first call, 200 on the second — exercises the retry loop. */
+static int flaky_handler(const char *url, const char *auth_header, const char *body,
+                         char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_post_calls++;
+   if (g_post_calls == 1)
+      return 503; /* retryable; mock leaves *response_buf NULL */
+   if (response_buf)
+      *response_buf = strdup("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}");
+   return 200;
+}
+
+static int err_handler(const char *url, const char *auth_header, const char *body,
+                       char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   (void)response_buf;
+   g_post_calls++;
+   return 401; /* non-retryable */
+}
+
+static void test_complete_success(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(ok_handler);
+
+   provider_def_t def = {.base_url = "http://h:8080/v1",
+                         .model = "m",
+                         .api_key = "secret",
+                         .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                         .temperature = -1.0};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   char err[128];
+   int rc = provider_client_complete(&def, msgs, NULL, &out, err, sizeof(err));
+   assert(rc == 0);
+   assert(g_post_calls == 1);
+   /* URL assembled with exactly one slash; auth carries the bearer. */
+   assert(strcmp(g_seen_url, "http://h:8080/v1/chat/completions") == 0);
+   assert(strcmp(g_seen_auth, "Authorization: Bearer secret") == 0);
+   assert(out.content && strcmp(out.content, "hi") == 0);
+   assert(out.prompt_tokens == 3 && out.completion_tokens == 1);
+   assert(out.http_status == 200);
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete success (url/auth/parse) ok\n");
+}
+
+static void test_complete_trailing_slash(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(ok_handler);
+   /* a base_url WITH a trailing slash must not double up. */
+   provider_def_t def = {
+       .base_url = "http://h/v1/", .wire = PROVIDER_WIRE_OPENAI_CHAT, .temperature = -1.0};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   assert(provider_client_complete(&def, msgs, NULL, &out, NULL, 0) == 0);
+   assert(strcmp(g_seen_url, "http://h/v1/chat/completions") == 0);
+   /* keyless: no Authorization header. */
+   assert(g_seen_auth[0] == '\0');
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete trailing-slash + keyless ok\n");
+}
+
+static void test_complete_retry_then_ok(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(flaky_handler);
+   provider_def_t def = {.base_url = "http://h/v1",
+                         .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                         .temperature = -1.0,
+                         .max_attempts = 3};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   int rc = provider_client_complete(&def, msgs, NULL, &out, NULL, 0);
+   assert(rc == 0);
+   assert(g_post_calls == 2); /* retried once after the 503 */
+   assert(out.content && strcmp(out.content, "ok") == 0);
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete retry-then-ok ok\n");
+}
+
+static void test_complete_non_retryable(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(err_handler);
+   provider_def_t def = {.base_url = "http://h/v1",
+                         .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                         .temperature = -1.0,
+                         .max_attempts = 3};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   char err[128];
+   int rc = provider_client_complete(&def, msgs, NULL, &out, err, sizeof(err));
+   assert(rc == -1);
+   assert(g_post_calls == 1); /* 401 is not retried */
+   assert(out.http_status == 401);
+   assert(out.content == NULL);
+   assert(err[0] != '\0');
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete non-retryable (no retry) ok\n");
+}
+
 int main(void)
 {
    test_build_basic();
@@ -148,6 +296,10 @@ int main(void)
    test_parse_success();
    test_parse_failures();
    test_complete_arg_guards();
+   test_complete_success();
+   test_complete_trailing_slash();
+   test_complete_retry_then_ok();
+   test_complete_non_retryable();
    printf("provider_client: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
**§1 of the curator-llm-backend proposal** — the shared LLM-provider client both `aimee-server` and `aimee-kb` can link. Foundation only; this does **not** yet rewire the curator or the server (that's §2).

## Why
The curator (in `aimee-kb`) calls LLMs via `popen` sidecars today, and the server's provider machinery (`server/agent_bridge.c` builders/parsers, `server/http_retry.c`, `server/failover.c`) is `agent_t`/server-config-coupled and lives in server-only `AGENT_SRCS` — `aimee-kb` can't link it (`KB_CORE_SRCS = CORE_SRCS − db1`; `failover.c` pulls in `db1/interaction_events.h`). So there's no shared path for the operator-owned curator provider.

## What
`src/provider_client.{c,h}` in `CORE_SRCS` (so `KB_CORE_SRCS` picks it up — both binaries link it):
- `provider_def_t` (base_url + model + api_key + wire + timeout/temperature/max_tokens/attempts) and `provider_completion_t` (content + usage + model + finish_reason + http_status).
- **OpenAI chat-completions wire**: build (with `response_format: json_schema, strict` for grammar-constrained extraction — llama.cpp `--jinja` / OpenAI) + parse (content/usage/model/finish_reason; `out` zeroed on failure).
- `provider_client_complete`: build + POST + parse with a **self-contained retry loop** on `agent_http_post` (linked by both via `KB_PLATFORM_OBJS`), deliberately **not** reusing the db1-coupled, server-only `http_retry.c`. Retryable set mirrors `http_retry` (408/409/429/5xx + network errors), overflow-safe exponential backoff.
- Pure domain API — no `agent_t` / server config / provider-registry types — so the kb's operator provider and the server's per-user defs share one calling path. Header is self-contained.

## Verification
- `build/obj/kb/provider_client.o` compiles and **`aimee-kb` links clean** — confirms the shared-linkage premise of §1 (an undefined `agent_http_post` would have failed the kb link).
- `make all` clean (aimee + aimee-server + aimee-kb), `make lint` ok (schema-sync, proposal-links, clang-format).
- `unit-test-provider-client`: build (basic, options+schema, caller-ownership) + parse (success, malformed, empty-choices, no-content, NULL) + `complete` arg guards. The live network path is integration-covered once a curator endpoint is wired in §2.

## Next (not in this PR)
§2 routes the curator stages through this client against a configured provider (`kb_curator_provider` + per-stage/tier overrides), pointing at the operator's curator runtime.
