### PR TITLE
embedder: default to 0.6b/400m tier (was 4b/1b)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -5,7 +5,7 @@
 #   aimee-server     (Dockerfile.server)      ghcr.io/<owner>/aimee-server
 #   aimee-kb         (Dockerfile)             ghcr.io/<owner>/aimee-kb
 #   aimee-server-kb  (Dockerfile.combined)    ghcr.io/<owner>/aimee-server-kb
-#   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -0.6b)
+#   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -4b)
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
@@ -74,10 +74,10 @@ jobs:
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
-          # Lighter alternate tier: same Dockerfile, 0.6b embedder + 400m reranker
-          # baked in. Pair with embedding_dim: 1024 (see docs). Default (above) is
-          # the 4b embedder + 1b reranker.
-          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1" }
+          # Higher-fidelity alternate tier: same Dockerfile, 4b embedder + 1b reranker
+          # baked in. Pair with embedding_dim: 2560 (see docs). Default (above) is
+          # the 0.6b embedder + 400m reranker.
+          - { name: aimee-embedder-4b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -120,8 +120,8 @@ jobs:
           # C-image caches, defeating the purpose. The embedder's real win is the
           # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
           # layer cache.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Published images bundle the optional browser UI (WITH_WEBCHAT=1); the
           # default `docker compose up --build` an end user runs leaves it off so it
           # needs no credentials. The aimee-kb image ignores WITH_WEBCHAT.
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-0.6b, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -4,21 +4,21 @@
 # never bloat the slim kb runtime.
 #
 # Two coherent tiers, embedder paired with a matching-size reranker:
-#   default image (aimee-embedder):     pplx-embed-v1-4b   (2560-dim) + ettin-reranker-1b
-#   light image   (aimee-embedder-0.6b): pplx-embed-v1-0.6b (1024-dim) + ettin-reranker-400m
-# The 4b default is the higher-fidelity tier (embedding throughput is not the
-# bottleneck); the 0.6b image is the low-resource alternate. Override either at
-# build time:
+#   default image (aimee-embedder):   pplx-embed-v1-0.6b (1024-dim) + ettin-reranker-400m
+#   heavy image   (aimee-embedder-4b): pplx-embed-v1-4b   (2560-dim) + ettin-reranker-1b
+# The 0.6b default is the low-latency tier (a 0.6b query embed is ~5x faster than
+# the 4b and the reranker dominates recall cost anyway); the 4b image is the
+# higher-fidelity alternate. Override either at build time:
 #   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
-#     schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024)
+#     schema vector(N) columns — pplx-embed-v1-0.6b is 1024, 4b is 2560)
 #   --build-arg RERANKER_MODEL=<hf id>  (the reranker emits a scalar score, so it
 #     has no dim constraint — size it to match the embedder for a coherent tier).
 FROM python:3.11-slim AS embedder
 
-ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b
+ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
-# stage). Scores top-K (~50) pairs per query; the 1b pairs with the 4b embedder.
-ARG RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1
+# stage). Scores top-K (~50) pairs per query; the 400m pairs with the 0.6b embedder.
+ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \

--- a/README.md
+++ b/README.md
@@ -401,10 +401,10 @@ ship; pick by topology. They build from three reusable images: **`aimee-server`*
 Postgres (DB2) and a CPU embedder sidecar (`Dockerfile.embedder`); the kb
 auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
 boot. The sidecar ships in two tiers — embedder + reranker baked into one image:
-the default `aimee-embedder` (`pplx-embed-v1-4b`, 2560-dim, + `ettin-reranker-1b`)
-and the lighter `aimee-embedder-0.6b` (`pplx-embed-v1-0.6b`, 1024-dim, +
-`ettin-reranker-400m`) for low-memory hosts. Switch with `AIMEE_EMBEDDER_IMAGE`
-plus `embedding_dim: 1024` (or `AIMEE_EMBEDDING_DIM=1024`). Trade-offs:
+the default `aimee-embedder` (`pplx-embed-v1-0.6b`, 1024-dim, + `ettin-reranker-400m`)
+and the higher-fidelity `aimee-embedder-4b` (`pplx-embed-v1-4b`, 2560-dim, +
+`ettin-reranker-1b`) for hosts with RAM to spare. Switch with `AIMEE_EMBEDDER_IMAGE`
+plus `embedding_dim: 2560` (or `AIMEE_EMBEDDING_DIM=2560`). Trade-offs:
 [retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
 
 > **`docker compose ... up --build` needs no credentials.** The default build ships

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -46,15 +46,15 @@ services:
       context: .
       dockerfile: Dockerfile.embedder
       args:
-        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
     # AIMEE_EMBEDDING_DIM=1024 on the server/kb (the 4b is 2560).
     environment:
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
       # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
       # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
       EMBEDDER_STUB: ${EMBEDDER_STUB:-}

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -38,15 +38,15 @@ services:
       context: .
       dockerfile: Dockerfile.embedder
       args:
-        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
     # AIMEE_EMBEDDING_DIM=1024 on the kb (the 4b is 2560).
     environment:
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
       # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
       # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
       EMBEDDER_STUB: ${EMBEDDER_STUB:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,15 +23,15 @@ services:
       context: .
       dockerfile: Dockerfile.embedder
       args:
-        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
     # Tier is a RUNTIME choice now: the models are fetched at startup into the
     # volume (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with
     # no rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
     # AIMEE_EMBEDDING_DIM=1024 on the kb (the 4b is 2560).
     environment:
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
       # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
       # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
       EMBEDDER_STUB: ${EMBEDDER_STUB:-}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,8 +29,9 @@ curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/stat
 Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
 convenience.
 
-The default embedder is the 4B (`pplx-embed-v1-4b`, 2560-dim). On a tight host,
-use the lighter 0.6B: `AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest AIMEE_EMBEDDING_DIM=1024 docker compose -f compose.combined.yaml up --build -d`.
+The default embedder is the 0.6B (`pplx-embed-v1-0.6b`, 1024-dim), paired with the
+400m reranker — the low-latency tier. For higher fidelity, use the 4B:
+`AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-4b:latest AIMEE_EMBEDDING_DIM=2560 docker compose -f compose.combined.yaml up --build -d`.
 
 ## 2. Install the client
 

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -16,44 +16,46 @@ a dimension constraint.)
 
 | Image | Embedder (`embedding_dim`) | Reranker |
 |-------|----------------------------|----------|
-| `aimee-embedder` (default) | `pplx-embed-v1-4b` (`2560`) | `ettin-reranker-1b` |
-| `aimee-embedder-0.6b` | `pplx-embed-v1-0.6b` (`1024`) | `ettin-reranker-400m` |
+| `aimee-embedder` (default) | `pplx-embed-v1-0.6b` (`1024`) | `ettin-reranker-400m` |
+| `aimee-embedder-4b` | `pplx-embed-v1-4b` (`2560`) | `ettin-reranker-1b` |
 
 ### Choosing a tier
 
-Run one tier per deployment. The 4b/1b image is the default; the 0.6b/400m
-image is for hosts that can't spare the memory.
+Run one tier per deployment. The 0.6b/400m image is the default; the 4b/1b
+image is the higher-fidelity alternate for hosts with RAM to spare.
 
-**4b + 1b (default).** Best retrieval quality and reranking. Pick it when the
-host has the RAM and embedding throughput isn't your bottleneck — most server
+**0.6b + 400m (default).** The low-latency tier, and the right default for most
 deployments.
-- Recall and ranking are noticeably better, especially on large or noisy
-  corpora and on queries that lean on meaning over keywords.
-- Costs: the model weights are several GB (slower image pull and first build),
-  the default image holds ~20 GB resident in fp32 (~16 GB embedder + ~4 GB
-  reranker), and a CPU embed runs ~1–2 s versus the 0.6b's ~0.2 s. None of that
-  is in the request hot path — embedding happens at ingest and on the query, not
-  per token — but it sets a RAM floor and slows a cold re-embed of a large corpus.
-
-**0.6b + 400m (light).** Pick it for laptops, small VMs, CI, or any host short
-on memory.
 - ~2 GB of weights (embedder + reranker), a couple of GB resident, embeds in
-  ~0.2 s. Fits a small host; fast to pull, fast to re-embed.
-- Lower recall and weaker reranking than the 4b/1b — fine for smaller corpora
-  and keyword-ish queries, weaker on large-corpus semantic search.
+  ~0.2 s — roughly 5x faster than the 4b on a CPU host. Fast to pull, fast to
+  re-embed.
+- In practice the cross-encoder reranker dominates recall latency, not the
+  embedder, so the larger embedder buys less end-to-end than its size suggests.
+- Recall is slightly weaker than the 4b on large or noisy corpora and on
+  meaning-heavy queries, but fine for most workloads.
 
-Rule of thumb: default to 4b/1b; drop to 0.6b/400m only when RAM or pull size
-forces it. The retrieval pipeline (hybrid search, reranking, fusion) is
-identical either way — only the model sizes differ.
+**4b + 1b (higher fidelity).** Pick it when the host has the RAM and you want
+the best recall/ranking on large or noisy corpora.
+- Recall and ranking are noticeably better on meaning-over-keyword queries.
+- Costs: the model weights are several GB (slower image pull and first build),
+  the image holds ~20 GB resident in fp32 (~16 GB embedder + ~4 GB reranker),
+  and a CPU embed runs ~1–2 s versus the 0.6b's ~0.2 s. None of that is in the
+  request hot path — embedding happens at ingest and on the query, not per
+  token — but it sets a RAM floor and slows a cold re-embed of a large corpus.
+
+Rule of thumb: default to 0.6b/400m; step up to 4b/1b only when you have the RAM
+and need the extra recall. The retrieval pipeline (hybrid search, reranking,
+fusion) is identical either way — only the model sizes differ.
 
 ### Switching tiers
 
-The default `aimee-embedder` image bakes the 4b + 1b. To run the light tier,
-point at the `aimee-embedder-0.6b` image and set the dimension to match:
+The default `aimee-embedder` image bakes the 0.6b + 400m. To run the
+higher-fidelity tier, point at the `aimee-embedder-4b` image and set the
+dimension to match:
 
 ```bash
-AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest
-AIMEE_EMBEDDING_DIM=1024   # or embedding_dim: 1024 in aimee.yaml
+AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-4b:latest
+AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 ```
 
 No rebuild needed — both images are published. On an **empty** database that's
@@ -68,8 +70,8 @@ pairing with `--build-arg EMBEDDER_MODEL=… --build-arg RERANKER_MODEL=…`.
 Two config keys define the embedder:
 
 - `embedding_command` — the command that produces embeddings.
-- `embedding_dim` — the dimension that command emits (1024 for the light image,
-  2560 for the default; any value for a custom-built image). This is the
+- `embedding_dim` — the dimension that command emits (1024 for the default image,
+  2560 for the 4b image; any value for a custom-built image). This is the
   single source of truth for vector-column dimensions.
 
 Keep the two in sync: `embedding_dim` must equal the dimension
@@ -99,8 +101,8 @@ schema, `db_apply_schema_postgres()` substitutes the placeholder with the
 configured dimension — the one place the schema is materialized — so every
 `halfvec` column (`memory_embeddings`, `kb_embeddings`, and the
 `curator_*_vectors` tables) is created at the right size. An unset or
-out-of-range value falls back to the `2560` default (the default embedder is the
-4B) rather than emitting invalid DDL.
+out-of-range value falls back to the `1024` default (the default embedder is the
+0.6B) rather than emitting invalid DDL.
 
 `halfvec` (fp16) is used throughout: it halves index memory versus `vector`
 (fp32) at negligible recall cost, and it lifts the index dimension ceiling from

--- a/src/config.c
+++ b/src/config.c
@@ -418,10 +418,10 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;
    cfg->kb_search_max_results = 50;
-   /* Embedding dimension of the default embedder (pplx-embed-v1-4b = 2560).
+   /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
     * Must match the schema vector(N) columns and the embedder model. Set to
-    * 1024 (with the pplx-embed-v1-0.6b embedder image) for the lighter tier. */
-   cfg->embedding_dim = 2560;
+    * 2560 (with the pplx-embed-v1-4b embedder image) for the higher-fidelity tier. */
+   cfg->embedding_dim = 1024;
    /* The cross-encoder rerank stage (Ettin reranker sized to the embedder tier:
     * 1b with the 4b embedder, 400m with the 0.6b; served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -50,7 +50,7 @@ static pthread_mutex_t g_init_lock = PTHREAD_MUTEX_INITIALIZER;
  * 1024 for pplx-0.6b, 2560 for pplx-4b). Set from the loaded config by the
  * server / aimee-kb startup via db2_set_embedding_dim() before db2_init(), so
  * this layer needs no config dependency. 0 = unset -> db2_embedding_dim()
- * reports the 2560 default (the default embedder is pplx-4b). */
+ * reports the 1024 default (the default embedder is pplx-0.6b). */
 static int g_embed_dim = 0;
 
 void db2_set_embedding_dim(int dim)
@@ -60,7 +60,7 @@ void db2_set_embedding_dim(int dim)
 
 int db2_embedding_dim(void)
 {
-   return g_embed_dim > 0 ? g_embed_dim : 2560;
+   return g_embed_dim > 0 ? g_embed_dim : 1024;
 }
 static pthread_key_t g_thread_conn_key;
 static pthread_once_t g_thread_conn_key_once = PTHREAD_ONCE_INIT;


### PR DESCRIPTION
## Why

The 4B embedder (`pplx-embed-v1-4b`, 2560-dim) + 1B reranker were the default. On a CPU host a 0.6B query embed is **~5x faster** than the 4B (~0.24s vs ~1.3s, measured live on .254), and the **cross-encoder reranker dominates recall latency** — so the larger embedder buys little end-to-end while setting a ~20 GB RAM floor. This flips the default to the **0.6b/400m** tier; 4b/1b stays available as the higher-fidelity alternate.

This also makes the default **durable** on tierd-managed deploys: the embedder model comes from the `aimee-embedder:latest` image's `ENV` default, so flipping the Dockerfile default is what stops a fresh/reconciled install from coming up on 4B.

## Changes
- **Dockerfile.embedder**: `ARG EMBEDDER_MODEL`/`RERANKER_MODEL` defaults → `pplx-embed-v1-0.6b` / `ettin-reranker-400m-v1`. So `aimee-embedder:latest` (used by the aimee-kb plugin) defaults to 0.6b.
- **publish-images.yml**: the explicit alternate build is now `aimee-embedder-4b`; default `aimee-embedder` inherits the 0.6b Dockerfile defaults; cache-exclusion covers both heavy embedder builds.
- **compose{,.combined,.server}.yaml**: `EMBEDDER_MODEL`/`RERANKER_MODEL` fallbacks → 0.6b/400m.
- **config.c**: `embedding_dim` default 2560 → 1024. **db2_init.c**: unset-dim fallback 2560 → 1024.
- **README / QUICKSTART / retrieval-stack.md**: default is now 0.6b/400m (1024); 4b/1b (2560, image `aimee-embedder-4b`) documented as the higher-fidelity alternate.

`EMBED_MAX_DIM` stays 2560 (buffer cap covering both tiers).

## Tests
`unit-test-config` and `unit-test-embedding-dim` green. Both use explicit dims, so they're unaffected by the default flip.

## Deploy note
After this lands on `main` and images rebuild, existing 4B deployments need a re-embed at 1024 to switch (the `halfvec` columns are dim-specific) — see `docs/retrieval-stack.md`. New installs come up on 0.6b automatically.