### PR TITLE
perf(kb): NOT IN -> NOT EXISTS anti-joins in the index path (overnight sweep)

### DIFF
--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -299,10 +299,10 @@ int db2_curator_reenqueue_extract_all(void)
    /* Two cross-backend statements (the sqlite test shim rejects ON CONFLICT DO
     * UPDATE inside INSERT...SELECT): enqueue any document without an extract_doc
     * job, then re-arm every existing extract_doc job back to pending. */
-   kbp_exec(conn,
-            "INSERT INTO kb_async_jobs (kind, document_id, project, status)"
-            " SELECT 'extract_doc', id, project, 'pending' FROM kb_documents"
-            " WHERE id NOT IN (SELECT document_id FROM kb_async_jobs WHERE kind = 'extract_doc')");
+   kbp_exec(conn, "INSERT INTO kb_async_jobs (kind, document_id, project, status)"
+                  " SELECT 'extract_doc', d.id, d.project, 'pending' FROM kb_documents d"
+                  " WHERE NOT EXISTS (SELECT 1 FROM kb_async_jobs j"
+                  "   WHERE j.kind = 'extract_doc' AND j.document_id = d.id)");
    kbp_exec(conn, "UPDATE kb_async_jobs SET status = 'pending'"
                   " WHERE kind = 'extract_doc' AND status <> 'pending'");
 

--- a/src/kb/kb_curator_queue.c
+++ b/src/kb/kb_curator_queue.c
@@ -122,14 +122,20 @@ int kb_curator_queue_code_units_for_project(const char *project, const char *roo
    if (!conn)
       return -1;
 
+   /* NOT EXISTS (anti-join), not `(f.path, t.name) NOT IN (subquery)`: the
+    * row-constructor NOT IN can't be planned as a hash anti-join (it degrades to a
+    * per-row subquery scan — observed holding a pooled connection for minutes on a
+    * large `terms` table) and is NULL-unsafe (a single NULL file_path/symbol in
+    * kb_code_unit_jobs makes NOT IN drop ALL rows). NOT EXISTS fixes both. */
    static const char *sql = "SELECT f.path, t.name, t.kind, t.line::int"
                             " FROM terms t"
                             " JOIN files f ON t.file_id = f.id"
                             " JOIN projects p ON f.project_id = p.id"
                             " WHERE p.name = ?1"
-                            " AND (f.path, t.name) NOT IN ("
-                            "   SELECT file_path, symbol FROM kb_code_unit_jobs"
-                            "   WHERE project = ?1 AND status IN ('pending','running','done')"
+                            " AND NOT EXISTS ("
+                            "   SELECT 1 FROM kb_code_unit_jobs j"
+                            "   WHERE j.project = ?1 AND j.status IN ('pending','running','done')"
+                            "     AND j.file_path = f.path AND j.symbol = t.name"
                             " )";
 
    char err[CQ_ERRBUF] = "";


### PR DESCRIPTION
From overnight deployment testing. A workspace reindex was saturating the 8-connection DB2 pool with two pathologically-slow `NOT IN (subquery)` anti-joins, hanging concurrent KB searches.

## Fixes
- **`kb_curator_queue.c`** — `(f.path, t.name) NOT IN (...)` over the 106k-row `terms` table planned as a **per-row hashed-SubPlan Join Filter** (observed holding a pooled connection **~5.5 min** under reindex load). → `NOT EXISTS` (Hash Anti Join, confirmed via EXPLAIN).
- **`kb_payload.c`** — `kb_documents.id NOT IN (SELECT document_id FROM kb_async_jobs ...)` in the doc-extract enqueue path (runs over the whole doc spine during ingest/reindex). → `NOT EXISTS`.

Both `NOT IN`s were also **NULL-unsafe** (one NULL in the subquery → drops all rows); `NOT EXISTS` is NULL-safe. Functionally equivalent anti-joins, same indexes.

## Evidence
`EXPLAIN` on the live `aimee` project data: OLD = `Join Filter: NOT(ANY(hashed SubPlan))` per-row over 106,930 rows; NEW = `Hash Anti Join`.

## Not in this PR (findings for the morning report)
- The reindex-induced hang itself is expected (transient pool saturation), not a code bug.
- Webchat (enabled earlier) is reachable on :8443 but has **no login account** until `AIMEE_WEBCHAT_USER/PASSWORD` are set in the manifest — a deployment credential decision, flagged for the user.
- Windows thin-client audit: core paths sound (HTTP client correct w/ SO_RCVTIMEO, Credential-Manager secret store); only expected thin-client limitations (no local agent-tool execution / tunnels).

## Tests
Full `unit-tests` green (168 suites); `format`, `line-check` pass.
