### PR TITLE
Promote testing → main: 0.6b/400m default embedder

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -5,7 +5,7 @@
 #   aimee-server     (Dockerfile.server)      ghcr.io/<owner>/aimee-server
 #   aimee-kb         (Dockerfile)             ghcr.io/<owner>/aimee-kb
 #   aimee-server-kb  (Dockerfile.combined)    ghcr.io/<owner>/aimee-server-kb
-#   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -0.6b)
+#   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -4b)
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
@@ -74,10 +74,10 @@ jobs:
           - { name: aimee-kb,        dockerfile: Dockerfile }
           - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
           - { name: aimee-embedder,  dockerfile: Dockerfile.embedder }
-          # Lighter alternate tier: same Dockerfile, 0.6b embedder + 400m reranker
-          # baked in. Pair with embedding_dim: 1024 (see docs). Default (above) is
-          # the 4b embedder + 1b reranker.
-          - { name: aimee-embedder-0.6b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1" }
+          # Higher-fidelity alternate tier: same Dockerfile, 4b embedder + 1b reranker
+          # baked in. Pair with embedding_dim: 2560 (see docs). Default (above) is
+          # the 0.6b embedder + 400m reranker.
+          - { name: aimee-embedder-4b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -120,8 +120,8 @@ jobs:
           # C-image caches, defeating the purpose. The embedder's real win is the
           # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
           # layer cache.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Published images bundle the optional browser UI (WITH_WEBCHAT=1); the
           # default `docker compose up --build` an end user runs leaves it off so it
           # needs no credentials. The aimee-kb image ignores WITH_WEBCHAT.
@@ -160,7 +160,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-0.6b, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/Dockerfile.embedder
+++ b/Dockerfile.embedder
@@ -4,21 +4,21 @@
 # never bloat the slim kb runtime.
 #
 # Two coherent tiers, embedder paired with a matching-size reranker:
-#   default image (aimee-embedder):     pplx-embed-v1-4b   (2560-dim) + ettin-reranker-1b
-#   light image   (aimee-embedder-0.6b): pplx-embed-v1-0.6b (1024-dim) + ettin-reranker-400m
-# The 4b default is the higher-fidelity tier (embedding throughput is not the
-# bottleneck); the 0.6b image is the low-resource alternate. Override either at
-# build time:
+#   default image (aimee-embedder):   pplx-embed-v1-0.6b (1024-dim) + ettin-reranker-400m
+#   heavy image   (aimee-embedder-4b): pplx-embed-v1-4b   (2560-dim) + ettin-reranker-1b
+# The 0.6b default is the low-latency tier (a 0.6b query embed is ~5x faster than
+# the 4b and the reranker dominates recall cost anyway); the 4b image is the
+# higher-fidelity alternate. Override either at build time:
 #   --build-arg EMBEDDER_MODEL=<hf id>  (must match config embedding_dim + the
-#     schema vector(N) columns — pplx-embed-v1-4b is 2560, 0.6b is 1024)
+#     schema vector(N) columns — pplx-embed-v1-0.6b is 1024, 4b is 2560)
 #   --build-arg RERANKER_MODEL=<hf id>  (the reranker emits a scalar score, so it
 #     has no dim constraint — size it to match the embedder for a coherent tier).
 FROM python:3.11-slim AS embedder
 
-ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b
+ARG EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-0.6b
 # Cross-encoder reranker served from the same process (aimee's memory rerank
-# stage). Scores top-K (~50) pairs per query; the 1b pairs with the 4b embedder.
-ARG RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1
+# stage). Scores top-K (~50) pairs per query; the 400m pairs with the 0.6b embedder.
+ARG RERANKER_MODEL=cross-encoder/ettin-reranker-400m-v1
 ENV PIP_NO_CACHE_DIR=1 \
     HF_HOME=/opt/models \
     EMBEDDER_MODEL=${EMBEDDER_MODEL} \

--- a/README.md
+++ b/README.md
@@ -401,10 +401,10 @@ ship; pick by topology. They build from three reusable images: **`aimee-server`*
 Postgres (DB2) and a CPU embedder sidecar (`Dockerfile.embedder`); the kb
 auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first
 boot. The sidecar ships in two tiers — embedder + reranker baked into one image:
-the default `aimee-embedder` (`pplx-embed-v1-4b`, 2560-dim, + `ettin-reranker-1b`)
-and the lighter `aimee-embedder-0.6b` (`pplx-embed-v1-0.6b`, 1024-dim, +
-`ettin-reranker-400m`) for low-memory hosts. Switch with `AIMEE_EMBEDDER_IMAGE`
-plus `embedding_dim: 1024` (or `AIMEE_EMBEDDING_DIM=1024`). Trade-offs:
+the default `aimee-embedder` (`pplx-embed-v1-0.6b`, 1024-dim, + `ettin-reranker-400m`)
+and the higher-fidelity `aimee-embedder-4b` (`pplx-embed-v1-4b`, 2560-dim, +
+`ettin-reranker-1b`) for hosts with RAM to spare. Switch with `AIMEE_EMBEDDER_IMAGE`
+plus `embedding_dim: 2560` (or `AIMEE_EMBEDDING_DIM=2560`). Trade-offs:
 [retrieval-stack.md](docs/retrieval-stack.md#choosing-a-tier).
 
 > **`docker compose ... up --build` needs no credentials.** The default build ships

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -46,15 +46,15 @@ services:
       context: .
       dockerfile: Dockerfile.embedder
       args:
-        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
     # AIMEE_EMBEDDING_DIM=1024 on the server/kb (the 4b is 2560).
     environment:
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
       # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
       # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
       EMBEDDER_STUB: ${EMBEDDER_STUB:-}

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -38,15 +38,15 @@ services:
       context: .
       dockerfile: Dockerfile.embedder
       args:
-        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
     # Tier is a RUNTIME choice now: models are fetched at startup into the volume
     # (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with no
     # rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
     # AIMEE_EMBEDDING_DIM=1024 on the kb (the 4b is 2560).
     environment:
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
       # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
       # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
       EMBEDDER_STUB: ${EMBEDDER_STUB:-}

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,15 +23,15 @@ services:
       context: .
       dockerfile: Dockerfile.embedder
       args:
-        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+        EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+        RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
     # Tier is a RUNTIME choice now: the models are fetched at startup into the
     # volume (not baked), so EMBEDDER_MODEL / RERANKER_MODEL select the tier with
     # no rebuild. Light tier: EMBEDDER_MODEL=...-0.6b, RERANKER_MODEL=...-400m-v1,
     # AIMEE_EMBEDDING_DIM=1024 on the kb (the 4b is 2560).
     environment:
-      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-4b}
-      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-1b-v1}
+      EMBEDDER_MODEL: ${EMBEDDER_MODEL:-perplexity-ai/pplx-embed-v1-0.6b}
+      RERANKER_MODEL: ${RERANKER_MODEL:-cross-encoder/ettin-reranker-400m-v1}
       # CI stub embedder (off in prod): e2e sets these to serve fixed-dim
       # vectors with no model download. EMBEDDER_STUB_DIM matches the schema dim.
       EMBEDDER_STUB: ${EMBEDDER_STUB:-}

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,8 +29,9 @@ curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/stat
 Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
 convenience.
 
-The default embedder is the 4B (`pplx-embed-v1-4b`, 2560-dim). On a tight host,
-use the lighter 0.6B: `AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest AIMEE_EMBEDDING_DIM=1024 docker compose -f compose.combined.yaml up --build -d`.
+The default embedder is the 0.6B (`pplx-embed-v1-0.6b`, 1024-dim), paired with the
+400m reranker — the low-latency tier. For higher fidelity, use the 4B:
+`AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-4b:latest AIMEE_EMBEDDING_DIM=2560 docker compose -f compose.combined.yaml up --build -d`.
 
 ## 2. Install the client
 

--- a/docs/proposals/done/ingress-cost-accounting-and-optimizations.md
+++ b/docs/proposals/done/ingress-cost-accounting-and-optimizations.md
@@ -1,32 +1,47 @@
 # Proposal: ingress cost-accounting coverage + request-level cost optimizations
 
-- **State:** reviewed — design-ready (2026-06-16). §1–§2 foundations landed
-  (#185/#339); the design roundtable's 12 blockers on the remaining §2–§7 work are
-  resolved in §8. Implementation-ready with **no external dependency**: per-delegate
-  pricing is stored on aimee-server in the DB1 `model_pricing` table (default 0 for
-  subscriptions; operator-configurable; authoritative over the static table /
-  registry — landed). (Consolidated after PR #180 review + twelve file-by-file
-  codebase audits; findings integrated below.)
-- **Implementation status (2026-06-16):** §1–§2 LARGELY LANDED, design-roundtable
-  run on the rest. **Merged:** §1 (one pricing authority — `token_estimate_cost`
-  + registry-fallback hook, `token_estimate_cost_ex` is_priced free-vs-unknown,
-  `delegate_ensemble` routed through it; static table reconciled with the model
-  registry) and the §2 **schema/foundations** (`usage_kind`
-  realized/estimated/avoided/partial + realized-only filter + spend-breakdown,
-  `requested_model`/`stop_reason`/`agent_log_id`, billable-model resolution,
-  `request_context.h`) shipped in **PR #185**; the §1 local-delegate pricing
-  coverage gap (minimax/mistral/mimo as known-zero) closed in **PR #339**.
-  **Design roundtable (2026-06-16):** ran twice; the second pass enumerated 12
-  blockers on the remaining §2/§3–§7 work — **all now RESOLVED in §8** (the key
-  decision: v1 audit writes are synchronous, dissolving the async-queue + reward-
-  barrier blocker class; dedup fail-closed excludes shared principals; HMAC-bound
-  proxy credential; enumerated dedup-key allowlist; scoped thread-local reset;
-  capability-gated flag). **Remaining (implementation, now unblocked):** §2
-  ingress-writes to the six no-log handlers, §3 cache-aware shaping, §4 dedup, §5
-  reasoning-effort cap (still recommend defer), §6 cost-shaped reward, §7
-  `/v1/usage/*`. **No external dependency:** per-delegate pricing is stored on
-  aimee-server in the DB1 `model_pricing` table (default 0 for subscriptions;
-  operator-configurable; landed), authoritative over the static table / registry.
+- **State:** DONE (2026-06-16). §1–§7 are implemented and merged to `testing`
+  behind default-off rollout flags; the only deferred items are §5 (complexity →
+  reasoning-effort cap — deferred by design, see §5) and a *standalone* `/v1/usage/*`
+  route (deferred in favor of the implemented `insights.overview` extension, §7).
+  Per-delegate pricing is stored on aimee-server in the DB1 `model_pricing` table
+  (default 0 for subscriptions; operator-configurable; authoritative over the
+  static table / registry — landed). (Consolidated after PR #180 review + twelve
+  file-by-file codebase audits; findings integrated below.)
+- **Implementation status (2026-06-16 — COMPLETE except deferred §5 / standalone
+  `/v1/usage`):**
+  - **§1 one pricing authority** — `token_estimate_cost` + registry-fallback hook,
+    `token_estimate_cost_ex` is_priced free-vs-unknown, `delegate_ensemble` routed
+    through it; static table reconciled with the model registry (**PR #185**); the
+    local-delegate known-zero gap (minimax/mistral/mimo) closed in **PR #339**; the
+    DB1 `model_pricing` authoritative price-of-record landed in **PR #391**.
+  - **§2 ingress audit coverage** — schema/foundations (`usage_kind`
+    realized/estimated/avoided/partial + realized-only filter + spend-breakdown,
+    `requested_model`/`stop_reason`/`agent_log_id`, `request_context.h`) in **PR
+    #185**; realized audit writes wired into all six no-log handlers via
+    `agent_record_token_audit` (`openai_chat.c`) plus the native Anthropic relay
+    tap (`relay_capture_usage`, `anthropic_http.c`) and the OpenAI-via-translator
+    streaming usage tap; idempotency is a partial UNIQUE index on
+    `(source, principal, idempotency_key, attempt)` with `INSERT OR IGNORE`
+    (`token_audit.c`); `by_model`/`by_source` relabel empty rows `(unattributed)`
+    rather than dropping them. Master gate `ingress_usage_accounting_enabled`
+    (default off) + `ingress_audit_async` knob.
+  - **§2a billable-model precedence** (provider > served > requested),
+    `token_billable_model` — **PR #273**.
+  - **§3 cache-aware shaping** — `anthropic_shape.c` (structured Anthropic system
+    block with `cache_control: ephemeral`, volatile `<aimee-context>` kept outside
+    the cache boundary); flag `cache_shaping_enabled` (default off).
+  - **§4 short-window dedup** — buffered-only, full behavior-affecting key,
+    `usage_kind=avoided` (default off).
+  - **§6 cost-shaped reward** — `cost_shaped_reward` on the `delegate_routing`
+    close, flag `cost_reward_enabled` + `cost_reward_lambda_pct` /
+    `cost_reward_ref_usd_milli` (default off).
+  - **§7 usage surface** — `insights.overview` reports realized/estimated/avoided/
+    partial separately; `api/openapi-server-v1.yaml` documents the breakdown;
+    webchat usage SSE carries `usage_kind`. A separate `/v1/usage/*` route is
+    intentionally **not** added (would overlap `insights.overview`).
+  - **Deferred:** §5 reasoning-effort cap (proposal recommends defer; not
+    implemented) and any standalone `/v1/usage/*` route.
 - **Author:** JBailes
 - **Date:** 2026-06-11
 - **Charter roles:** Evaluate-Optimize (cost-shaped reward into the existing

--- a/docs/proposals/pending/ingress-compression-and-cache-alignment.md
+++ b/docs/proposals/pending/ingress-compression-and-cache-alignment.md
@@ -86,7 +86,7 @@ This proposal sits between three siblings and must not duplicate them:
   in what shape* enter the envelope. This proposal's envelope IR (§1) and
   recovery resolver contract (§3) are designed to **be** that proposal's
   preview/read contract where it has one, not a parallel scheme.
-- `docs/proposals/pending/ingress-cost-accounting-and-optimizations.md` owns
+- `docs/proposals/done/ingress-cost-accounting-and-optimizations.md` owns
   **provider usage extraction, USD pricing, the ledger, `/v1/usage/*`, generic
   cached-token reporting, and the `cache_control` *marking* mechanism**
   (`ingress_cache_marking_enabled` / `ingress_cache_min_chars`). This proposal

--- a/docs/retrieval-stack.md
+++ b/docs/retrieval-stack.md
@@ -16,44 +16,46 @@ a dimension constraint.)
 
 | Image | Embedder (`embedding_dim`) | Reranker |
 |-------|----------------------------|----------|
-| `aimee-embedder` (default) | `pplx-embed-v1-4b` (`2560`) | `ettin-reranker-1b` |
-| `aimee-embedder-0.6b` | `pplx-embed-v1-0.6b` (`1024`) | `ettin-reranker-400m` |
+| `aimee-embedder` (default) | `pplx-embed-v1-0.6b` (`1024`) | `ettin-reranker-400m` |
+| `aimee-embedder-4b` | `pplx-embed-v1-4b` (`2560`) | `ettin-reranker-1b` |
 
 ### Choosing a tier
 
-Run one tier per deployment. The 4b/1b image is the default; the 0.6b/400m
-image is for hosts that can't spare the memory.
+Run one tier per deployment. The 0.6b/400m image is the default; the 4b/1b
+image is the higher-fidelity alternate for hosts with RAM to spare.
 
-**4b + 1b (default).** Best retrieval quality and reranking. Pick it when the
-host has the RAM and embedding throughput isn't your bottleneck — most server
+**0.6b + 400m (default).** The low-latency tier, and the right default for most
 deployments.
-- Recall and ranking are noticeably better, especially on large or noisy
-  corpora and on queries that lean on meaning over keywords.
-- Costs: the model weights are several GB (slower image pull and first build),
-  the default image holds ~20 GB resident in fp32 (~16 GB embedder + ~4 GB
-  reranker), and a CPU embed runs ~1–2 s versus the 0.6b's ~0.2 s. None of that
-  is in the request hot path — embedding happens at ingest and on the query, not
-  per token — but it sets a RAM floor and slows a cold re-embed of a large corpus.
-
-**0.6b + 400m (light).** Pick it for laptops, small VMs, CI, or any host short
-on memory.
 - ~2 GB of weights (embedder + reranker), a couple of GB resident, embeds in
-  ~0.2 s. Fits a small host; fast to pull, fast to re-embed.
-- Lower recall and weaker reranking than the 4b/1b — fine for smaller corpora
-  and keyword-ish queries, weaker on large-corpus semantic search.
+  ~0.2 s — roughly 5x faster than the 4b on a CPU host. Fast to pull, fast to
+  re-embed.
+- In practice the cross-encoder reranker dominates recall latency, not the
+  embedder, so the larger embedder buys less end-to-end than its size suggests.
+- Recall is slightly weaker than the 4b on large or noisy corpora and on
+  meaning-heavy queries, but fine for most workloads.
 
-Rule of thumb: default to 4b/1b; drop to 0.6b/400m only when RAM or pull size
-forces it. The retrieval pipeline (hybrid search, reranking, fusion) is
-identical either way — only the model sizes differ.
+**4b + 1b (higher fidelity).** Pick it when the host has the RAM and you want
+the best recall/ranking on large or noisy corpora.
+- Recall and ranking are noticeably better on meaning-over-keyword queries.
+- Costs: the model weights are several GB (slower image pull and first build),
+  the image holds ~20 GB resident in fp32 (~16 GB embedder + ~4 GB reranker),
+  and a CPU embed runs ~1–2 s versus the 0.6b's ~0.2 s. None of that is in the
+  request hot path — embedding happens at ingest and on the query, not per
+  token — but it sets a RAM floor and slows a cold re-embed of a large corpus.
+
+Rule of thumb: default to 0.6b/400m; step up to 4b/1b only when you have the RAM
+and need the extra recall. The retrieval pipeline (hybrid search, reranking,
+fusion) is identical either way — only the model sizes differ.
 
 ### Switching tiers
 
-The default `aimee-embedder` image bakes the 4b + 1b. To run the light tier,
-point at the `aimee-embedder-0.6b` image and set the dimension to match:
+The default `aimee-embedder` image bakes the 0.6b + 400m. To run the
+higher-fidelity tier, point at the `aimee-embedder-4b` image and set the
+dimension to match:
 
 ```bash
-AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-0.6b:latest
-AIMEE_EMBEDDING_DIM=1024   # or embedding_dim: 1024 in aimee.yaml
+AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-4b:latest
+AIMEE_EMBEDDING_DIM=2560   # or embedding_dim: 2560 in aimee.yaml
 ```
 
 No rebuild needed — both images are published. On an **empty** database that's
@@ -68,8 +70,8 @@ pairing with `--build-arg EMBEDDER_MODEL=… --build-arg RERANKER_MODEL=…`.
 Two config keys define the embedder:
 
 - `embedding_command` — the command that produces embeddings.
-- `embedding_dim` — the dimension that command emits (1024 for the light image,
-  2560 for the default; any value for a custom-built image). This is the
+- `embedding_dim` — the dimension that command emits (1024 for the default image,
+  2560 for the 4b image; any value for a custom-built image). This is the
   single source of truth for vector-column dimensions.
 
 Keep the two in sync: `embedding_dim` must equal the dimension
@@ -99,8 +101,8 @@ schema, `db_apply_schema_postgres()` substitutes the placeholder with the
 configured dimension — the one place the schema is materialized — so every
 `halfvec` column (`memory_embeddings`, `kb_embeddings`, and the
 `curator_*_vectors` tables) is created at the right size. An unset or
-out-of-range value falls back to the `2560` default (the default embedder is the
-4B) rather than emitting invalid DDL.
+out-of-range value falls back to the `1024` default (the default embedder is the
+0.6B) rather than emitting invalid DDL.
 
 `halfvec` (fp16) is used throughout: it halves index memory versus `vector`
 (fp32) at negligible recall cost, and it lifts the index dimension ceiling from

--- a/src/Makefile
+++ b/src/Makefile
@@ -289,7 +289,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
-            aimee_home.c shared/kb_paths.c \
+            aimee_home.c shared/kb_paths.c provider_client.c \
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \

--- a/src/config.c
+++ b/src/config.c
@@ -418,10 +418,10 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;
    cfg->kb_search_max_results = 50;
-   /* Embedding dimension of the default embedder (pplx-embed-v1-4b = 2560).
+   /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
     * Must match the schema vector(N) columns and the embedder model. Set to
-    * 1024 (with the pplx-embed-v1-0.6b embedder image) for the lighter tier. */
-   cfg->embedding_dim = 2560;
+    * 2560 (with the pplx-embed-v1-4b embedder image) for the higher-fidelity tier. */
+   cfg->embedding_dim = 1024;
    /* The cross-encoder rerank stage (Ettin reranker sized to the embedder tier:
     * 1b with the 4b embedder, 400m with the 0.6b; served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -50,7 +50,7 @@ static pthread_mutex_t g_init_lock = PTHREAD_MUTEX_INITIALIZER;
  * 1024 for pplx-0.6b, 2560 for pplx-4b). Set from the loaded config by the
  * server / aimee-kb startup via db2_set_embedding_dim() before db2_init(), so
  * this layer needs no config dependency. 0 = unset -> db2_embedding_dim()
- * reports the 2560 default (the default embedder is pplx-4b). */
+ * reports the 1024 default (the default embedder is pplx-0.6b). */
 static int g_embed_dim = 0;
 
 void db2_set_embedding_dim(int dim)
@@ -60,7 +60,7 @@ void db2_set_embedding_dim(int dim)
 
 int db2_embedding_dim(void)
 {
-   return g_embed_dim > 0 ? g_embed_dim : 2560;
+   return g_embed_dim > 0 ? g_embed_dim : 1024;
 }
 static pthread_key_t g_thread_conn_key;
 static pthread_once_t g_thread_conn_key_once = PTHREAD_ONCE_INIT;

--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -299,10 +299,10 @@ int db2_curator_reenqueue_extract_all(void)
    /* Two cross-backend statements (the sqlite test shim rejects ON CONFLICT DO
     * UPDATE inside INSERT...SELECT): enqueue any document without an extract_doc
     * job, then re-arm every existing extract_doc job back to pending. */
-   kbp_exec(conn,
-            "INSERT INTO kb_async_jobs (kind, document_id, project, status)"
-            " SELECT 'extract_doc', id, project, 'pending' FROM kb_documents"
-            " WHERE id NOT IN (SELECT document_id FROM kb_async_jobs WHERE kind = 'extract_doc')");
+   kbp_exec(conn, "INSERT INTO kb_async_jobs (kind, document_id, project, status)"
+                  " SELECT 'extract_doc', d.id, d.project, 'pending' FROM kb_documents d"
+                  " WHERE NOT EXISTS (SELECT 1 FROM kb_async_jobs j"
+                  "   WHERE j.kind = 'extract_doc' AND j.document_id = d.id)");
    kbp_exec(conn, "UPDATE kb_async_jobs SET status = 'pending'"
                   " WHERE kind = 'extract_doc' AND status <> 'pending'");
 

--- a/src/headers/provider_client.h
+++ b/src/headers/provider_client.h
@@ -1,0 +1,93 @@
+/* provider_client.h: shared LLM-provider client (DRY across aimee-server + aimee-kb).
+ *
+ * Given a provider def (base_url + model + key + wire format) and a request
+ * (messages + optional JSON schema), return a completion — owning the wire
+ * format, transport, and retries in one place. Both aimee-server (per-user
+ * provider defs, client-held credentials) and aimee-kb (operator-owned curator
+ * provider) link this. This is §1 of the curator-llm-backend proposal: the
+ * foundation §2 (curator stages -> providers) and §4 (health) build on.
+ *
+ * Transport is agent_http_post (the platform object both binaries already link),
+ * and the module owns its own small retry loop so aimee-kb does not need the
+ * server-only http_retry/failover modules (which are DB1-coupled).
+ *
+ * Pure domain API: no agent_t, no server config, no provider-registry types in
+ * any signature — only a plain provider def the caller fills from its own config. */
+#ifndef DEC_PROVIDER_CLIENT_H
+#define DEC_PROVIDER_CLIENT_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   struct cJSON;
+
+/* Buffer for a provider-reported model id. Kept local so this header stays
+ * self-contained (matches MAX_MODEL_LEN in agent_types.h). */
+#define PROVIDER_MODEL_LEN 128
+
+   typedef enum
+   {
+      PROVIDER_WIRE_OPENAI_CHAT = 0, /* OpenAI-compatible /chat/completions */
+   } provider_wire_t;
+
+   typedef struct
+   {
+      const char *base_url; /* API base, e.g. "http://host:8080/v1"; the
+                             * "/chat/completions" suffix is appended and a
+                             * trailing slash is tolerated. */
+      const char *model;    /* model id sent in the request body. */
+      const char *api_key;  /* bearer token; NULL/"" for a keyless local endpoint. */
+      provider_wire_t wire; /* wire format. */
+      int timeout_ms;       /* per-attempt timeout; <=0 => default. */
+      double temperature;   /* <0 => omit (let the provider default). */
+      int max_tokens;       /* <=0 => omit. */
+      int max_attempts;     /* total attempts incl. the first; <=0 => default. */
+   } provider_def_t;
+
+   typedef struct
+   {
+      char *content;                  /* malloc'd completion text; NULL if none. Caller frees. */
+      int prompt_tokens;              /* from usage; 0 when absent. */
+      int completion_tokens;          /* from usage; 0 when absent. */
+      char model[PROVIDER_MODEL_LEN]; /* provider-reported model id; "" when absent. */
+      char finish_reason[32];         /* OpenAI finish_reason; "" when absent. */
+      int http_status;                /* last HTTP status (or <0 on a network error). */
+   } provider_completion_t;
+
+#define PROVIDER_CLIENT_DEFAULT_TIMEOUT_MS 120000
+#define PROVIDER_CLIENT_DEFAULT_ATTEMPTS   3
+
+   /* Build the OpenAI chat-completions request body for `def` + `messages` (a
+    * cJSON array of {role, content}). When `json_schema` is non-NULL it is sent as
+    * response_format:{type:"json_schema", json_schema:{name, schema, strict:true}}
+    * so a grammar-capable endpoint (llama.cpp --jinja, OpenAI) returns constrained
+    * JSON. `messages`/`json_schema` are NOT taken over — the result references deep
+    * copies. Returns a new cJSON object (caller cJSON_Delete) or NULL on failure. */
+   struct cJSON *provider_client_build_openai(const provider_def_t *def, struct cJSON *messages,
+                                              struct cJSON *json_schema);
+
+   /* Parse an OpenAI chat-completions response `body` into `out` (zeroed first).
+    * Returns 0 when choices[0].message.content is present, -1 otherwise. Usage,
+    * model and finish_reason are filled when present. `http_status` is left 0
+    * here — provider_client_complete sets it after the transport call. */
+   int provider_client_parse_openai(const char *body, provider_completion_t *out);
+
+   /* Build + POST (with retry) + parse. Returns 0 on success; on failure returns
+    * -1 and writes a message into errbuf (when errlen > 0). `out` is zeroed on
+    * entry and is always safe to pass to provider_completion_free afterward. */
+   int provider_client_complete(const provider_def_t *def, struct cJSON *messages,
+                                struct cJSON *json_schema, provider_completion_t *out, char *errbuf,
+                                size_t errlen);
+
+   /* Free heap-owned fields of `out` (idempotent; does not free `out` itself). */
+   void provider_completion_free(provider_completion_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_PROVIDER_CLIENT_H */

--- a/src/kb/kb_curator_queue.c
+++ b/src/kb/kb_curator_queue.c
@@ -122,14 +122,20 @@ int kb_curator_queue_code_units_for_project(const char *project, const char *roo
    if (!conn)
       return -1;
 
+   /* NOT EXISTS (anti-join), not `(f.path, t.name) NOT IN (subquery)`: the
+    * row-constructor NOT IN can't be planned as a hash anti-join (it degrades to a
+    * per-row subquery scan — observed holding a pooled connection for minutes on a
+    * large `terms` table) and is NULL-unsafe (a single NULL file_path/symbol in
+    * kb_code_unit_jobs makes NOT IN drop ALL rows). NOT EXISTS fixes both. */
    static const char *sql = "SELECT f.path, t.name, t.kind, t.line::int"
                             " FROM terms t"
                             " JOIN files f ON t.file_id = f.id"
                             " JOIN projects p ON f.project_id = p.id"
                             " WHERE p.name = ?1"
-                            " AND (f.path, t.name) NOT IN ("
-                            "   SELECT file_path, symbol FROM kb_code_unit_jobs"
-                            "   WHERE project = ?1 AND status IN ('pending','running','done')"
+                            " AND NOT EXISTS ("
+                            "   SELECT 1 FROM kb_code_unit_jobs j"
+                            "   WHERE j.project = ?1 AND j.status IN ('pending','running','done')"
+                            "     AND j.file_path = f.path AND j.symbol = t.name"
                             " )";
 
    char err[CQ_ERRBUF] = "";

--- a/src/provider_client.c
+++ b/src/provider_client.c
@@ -1,0 +1,274 @@
+/* provider_client.c: shared LLM-provider client. See provider_client.h.
+ *
+ * Built on agent_http_post (linked by aimee-server and aimee-kb alike) with a
+ * self-contained retry loop, so the kb need not link the server-only,
+ * DB1-coupled http_retry/failover modules. The retryable-status set mirrors
+ * http_retry's contract (408/409/429/5xx + network errors). */
+
+#include "aimee.h" /* MAX_PATH_LEN etc., pulled in before agent_types.h */
+#include "provider_client.h"
+
+#include "agent_exec.h" /* agent_http_post */
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* --- request building --- */
+
+struct cJSON *provider_client_build_openai(const provider_def_t *def, struct cJSON *messages,
+                                           struct cJSON *json_schema)
+{
+   if (!def || !messages)
+      return NULL;
+   cJSON *req = cJSON_CreateObject();
+   if (!req)
+      return NULL;
+   if (def->model && def->model[0])
+      cJSON_AddStringToObject(req, "model", def->model);
+
+   /* Deep-copy the caller's messages so ownership stays with them. */
+   cJSON *msgs = cJSON_Duplicate(messages, 1);
+   if (!msgs)
+   {
+      cJSON_Delete(req);
+      return NULL;
+   }
+   cJSON_AddItemToObject(req, "messages", msgs);
+
+   if (def->temperature >= 0.0)
+      cJSON_AddNumberToObject(req, "temperature", def->temperature);
+   if (def->max_tokens > 0)
+      cJSON_AddNumberToObject(req, "max_tokens", def->max_tokens);
+
+   if (json_schema)
+   {
+      cJSON *schema_copy = cJSON_Duplicate(json_schema, 1);
+      if (!schema_copy)
+      {
+         cJSON_Delete(req);
+         return NULL;
+      }
+      cJSON *rf = cJSON_CreateObject();
+      cJSON *js = cJSON_CreateObject();
+      if (!rf || !js)
+      {
+         cJSON_Delete(schema_copy);
+         cJSON_Delete(rf);
+         cJSON_Delete(js);
+         cJSON_Delete(req);
+         return NULL;
+      }
+      cJSON_AddStringToObject(rf, "type", "json_schema");
+      cJSON_AddStringToObject(js, "name", "curator_output");
+      cJSON_AddItemToObject(js, "schema", schema_copy);
+      cJSON_AddBoolToObject(js, "strict", 1);
+      cJSON_AddItemToObject(rf, "json_schema", js);
+      cJSON_AddItemToObject(req, "response_format", rf);
+   }
+   return req;
+}
+
+/* --- response parsing --- */
+
+int provider_client_parse_openai(const char *body, provider_completion_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (!body || !out)
+      return -1;
+
+   cJSON *root = cJSON_Parse(body);
+   if (!root)
+      return -1;
+
+   int rc = -1;
+   cJSON *choices = cJSON_GetObjectItemCaseSensitive(root, "choices");
+   cJSON *choice0 = cJSON_IsArray(choices) ? cJSON_GetArrayItem(choices, 0) : NULL;
+   if (choice0)
+   {
+      cJSON *msg = cJSON_GetObjectItemCaseSensitive(choice0, "message");
+      cJSON *content = msg ? cJSON_GetObjectItemCaseSensitive(msg, "content") : NULL;
+      if (cJSON_IsString(content) && content->valuestring)
+      {
+         out->content = strdup(content->valuestring);
+         if (out->content)
+            rc = 0;
+      }
+      cJSON *fr = cJSON_GetObjectItemCaseSensitive(choice0, "finish_reason");
+      if (cJSON_IsString(fr) && fr->valuestring)
+         snprintf(out->finish_reason, sizeof(out->finish_reason), "%s", fr->valuestring);
+   }
+
+   cJSON *usage = cJSON_GetObjectItemCaseSensitive(root, "usage");
+   if (usage)
+   {
+      cJSON *pt = cJSON_GetObjectItemCaseSensitive(usage, "prompt_tokens");
+      cJSON *ct = cJSON_GetObjectItemCaseSensitive(usage, "completion_tokens");
+      if (cJSON_IsNumber(pt))
+         out->prompt_tokens = pt->valueint;
+      if (cJSON_IsNumber(ct))
+         out->completion_tokens = ct->valueint;
+   }
+
+   cJSON *model = cJSON_GetObjectItemCaseSensitive(root, "model");
+   if (cJSON_IsString(model) && model->valuestring)
+      snprintf(out->model, sizeof(out->model), "%s", model->valuestring);
+
+   cJSON_Delete(root);
+   return rc;
+}
+
+/* --- transport + retry --- */
+
+/* Mirrors http_retry's retryable set: transient server/limit statuses and any
+ * network-level error (status < 0). Everything else (2xx, 4xx auth/not-found)
+ * fails fast. */
+static int wire_is_retryable(int http_status)
+{
+   if (http_status < 0)
+      return 1;
+   switch (http_status)
+   {
+   case 408:
+   case 409:
+   case 429:
+   case 500:
+   case 502:
+   case 503:
+   case 504:
+      return 1;
+   default:
+      return 0;
+   }
+}
+
+/* Exponential backoff (base * 2^attempt) clamped to max; overflow-safe. */
+static int wire_backoff_ms(int attempt, int base_ms, int max_ms)
+{
+   long d = base_ms;
+   for (int i = 0; i < attempt; i++)
+   {
+      /* Check before doubling so `d` never exceeds max_ms (an int) — no overflow
+       * regardless of attempt count or max_ms magnitude. */
+      if (d >= max_ms || d > max_ms / 2)
+         return max_ms;
+      d *= 2;
+   }
+   return d > max_ms ? max_ms : (int)d;
+}
+
+int provider_client_complete(const provider_def_t *def, struct cJSON *messages,
+                             struct cJSON *json_schema, provider_completion_t *out, char *errbuf,
+                             size_t errlen)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (errbuf && errlen)
+      errbuf[0] = '\0';
+   if (!def || !def->base_url || !def->base_url[0] || !messages || !out)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "invalid arguments");
+      return -1;
+   }
+   if (def->wire != PROVIDER_WIRE_OPENAI_CHAT)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "unsupported wire format %d", (int)def->wire);
+      return -1;
+   }
+
+   cJSON *req = provider_client_build_openai(def, messages, json_schema);
+   if (!req)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "failed to build request");
+      return -1;
+   }
+   char *body = cJSON_PrintUnformatted(req);
+   cJSON_Delete(req);
+   if (!body)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "failed to serialize request");
+      return -1;
+   }
+
+   /* URL = base_url + "/chat/completions" (tolerate a trailing slash). snprintf
+    * is bounded (no overflow), but a truncated URL/Bearer would silently hit the
+    * wrong endpoint or 401 with valid creds, so treat truncation as an error. */
+   size_t bl = strlen(def->base_url);
+   int has_slash = bl > 0 && def->base_url[bl - 1] == '/';
+   char url[2048];
+   int un = snprintf(url, sizeof(url), "%s%schat/completions", def->base_url, has_slash ? "" : "/");
+   if (un < 0 || (size_t)un >= sizeof(url))
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "base_url too long");
+      free(body);
+      return -1;
+   }
+
+   char auth[1280];
+   const char *auth_header = NULL;
+   if (def->api_key && def->api_key[0])
+   {
+      int an = snprintf(auth, sizeof(auth), "Authorization: Bearer %s", def->api_key);
+      if (an < 0 || (size_t)an >= sizeof(auth))
+      {
+         if (errbuf && errlen)
+            snprintf(errbuf, errlen, "api_key too long");
+         free(body);
+         return -1;
+      }
+      auth_header = auth;
+   }
+
+   int timeout = def->timeout_ms > 0 ? def->timeout_ms : PROVIDER_CLIENT_DEFAULT_TIMEOUT_MS;
+   int attempts = def->max_attempts > 0 ? def->max_attempts : PROVIDER_CLIENT_DEFAULT_ATTEMPTS;
+
+   int status = -1;
+   char *resp = NULL;
+   for (int a = 0; a < attempts; a++)
+   {
+      free(resp);
+      resp = NULL;
+      status = agent_http_post(url, auth_header, body, &resp, timeout, NULL);
+      if (!wire_is_retryable(status))
+         break;
+      if (a + 1 < attempts)
+      {
+         int ms = wire_backoff_ms(a, 1000, 30000);
+         struct timespec ts = {ms / 1000, (long)(ms % 1000) * 1000000L};
+         nanosleep(&ts, NULL);
+      }
+   }
+   free(body);
+
+   if (status < 200 || status >= 300)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "provider HTTP %d", status);
+      free(resp);
+      out->http_status = status;
+      return -1;
+   }
+
+   int rc = provider_client_parse_openai(resp, out); /* zeroes out, then fills */
+   free(resp);
+   out->http_status = status;
+   if (rc != 0 && errbuf && errlen)
+      snprintf(errbuf, errlen, "unparseable provider response");
+   return rc;
+}
+
+void provider_completion_free(provider_completion_t *out)
+{
+   if (!out)
+      return;
+   free(out->content);
+   out->content = NULL;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -182,6 +182,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-windows \
                $(TESTPREFIX)/unit-test-token-tracker \
                $(TESTPREFIX)/unit-test-model-pricing \
+               $(TESTPREFIX)/unit-test-provider-client \
                $(TESTPREFIX)/unit-test-reasoning-cap \
                $(TESTPREFIX)/unit-test-request-context \
                $(TESTPREFIX)/unit-test-response-dedup \
@@ -2272,6 +2273,11 @@ $(TESTPREFIX)/unit-test-model-pricing: $(OBJDIR)/tests/test_model_pricing.o \
                                   $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                   $(OBJDIR)/db1/model_pricing.o \
                                   $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-provider-client: $(OBJDIR)/tests/test_provider_client.o \
+                                  $(OBJDIR)/provider_client.o $(OBJDIR)/cJSON.o \
+                                  $(OBJDIR)/tests/support/mock_agent_http.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-collab-rules: $(OBJDIR)/tests/test_collab_rules.o $(TEST_DATA_OBJS_MOCK)

--- a/src/tests/test_provider_client.c
+++ b/src/tests/test_provider_client.c
@@ -1,0 +1,344 @@
+/* test_provider_client.c: shared provider-client request builder + response parser.
+ * Network-free: exercises the pure build/parse halves (provider_client_complete's
+ * transport is covered by integration once a curator endpoint is wired). */
+#include "provider_client.h"
+#include "cJSON.h"
+#include "support/mock_agent_http.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static cJSON *two_messages(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "user");
+   cJSON_AddStringToObject(m, "content", "extract entities");
+   cJSON_AddItemToArray(msgs, m);
+   return msgs;
+}
+
+static void test_build_basic(void)
+{
+   provider_def_t def = {
+       .base_url = "http://h:8080/v1",
+       .model = "granite-3b",
+       .wire = PROVIDER_WIRE_OPENAI_CHAT,
+       .temperature = -1.0, /* omit */
+       .max_tokens = 0,     /* omit */
+   };
+   cJSON *msgs = two_messages();
+   cJSON *req = provider_client_build_openai(&def, msgs, NULL);
+   assert(req);
+
+   cJSON *model = cJSON_GetObjectItemCaseSensitive(req, "model");
+   assert(cJSON_IsString(model) && strcmp(model->valuestring, "granite-3b") == 0);
+   /* messages copied, not aliased: mutating the original must not change req. */
+   cJSON *rmsgs = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   assert(cJSON_IsArray(rmsgs) && cJSON_GetArraySize(rmsgs) == 1);
+   /* omitted optionals absent */
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "temperature"));
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "max_tokens"));
+   assert(!cJSON_GetObjectItemCaseSensitive(req, "response_format"));
+
+   cJSON_Delete(req);
+   cJSON_Delete(msgs);
+   printf("provider_client: build basic ok\n");
+}
+
+static void test_build_options_and_schema(void)
+{
+   provider_def_t def = {
+       .base_url = "http://h:8080/v1",
+       .model = "granite-3b",
+       .wire = PROVIDER_WIRE_OPENAI_CHAT,
+       .temperature = 0.2,
+       .max_tokens = 512,
+   };
+   cJSON *msgs = two_messages();
+   cJSON *schema = cJSON_CreateObject();
+   cJSON_AddStringToObject(schema, "type", "object");
+
+   cJSON *req = provider_client_build_openai(&def, msgs, schema);
+   assert(req);
+   cJSON *temp = cJSON_GetObjectItemCaseSensitive(req, "temperature");
+   assert(cJSON_IsNumber(temp) && temp->valuedouble > 0.19 && temp->valuedouble < 0.21);
+   cJSON *mt = cJSON_GetObjectItemCaseSensitive(req, "max_tokens");
+   assert(cJSON_IsNumber(mt) && mt->valueint == 512);
+
+   cJSON *rf = cJSON_GetObjectItemCaseSensitive(req, "response_format");
+   assert(rf);
+   cJSON *rftype = cJSON_GetObjectItemCaseSensitive(rf, "type");
+   assert(cJSON_IsString(rftype) && strcmp(rftype->valuestring, "json_schema") == 0);
+   cJSON *js = cJSON_GetObjectItemCaseSensitive(rf, "json_schema");
+   assert(js);
+   cJSON *strict = cJSON_GetObjectItemCaseSensitive(js, "strict");
+   assert(cJSON_IsBool(strict) && cJSON_IsTrue(strict));
+   cJSON *embedded = cJSON_GetObjectItemCaseSensitive(js, "schema");
+   assert(embedded); /* the caller schema is copied in */
+   cJSON *etype = cJSON_GetObjectItemCaseSensitive(embedded, "type");
+   assert(cJSON_IsString(etype) && strcmp(etype->valuestring, "object") == 0);
+
+   cJSON_Delete(req);
+   cJSON_Delete(msgs);
+   cJSON_Delete(schema); /* still owned by the caller — proves no take-over */
+   printf("provider_client: build options + schema ok\n");
+}
+
+static void test_parse_success(void)
+{
+   const char *body =
+       "{\"model\":\"granite-3b-instruct\",\"choices\":[{\"finish_reason\":\"stop\","
+       "\"message\":{\"role\":\"assistant\",\"content\":\"{\\\"entities\\\":[]}\"}}],"
+       "\"usage\":{\"prompt_tokens\":42,\"completion_tokens\":7}}";
+   provider_completion_t out;
+   int rc = provider_client_parse_openai(body, &out);
+   assert(rc == 0);
+   assert(out.content && strcmp(out.content, "{\"entities\":[]}") == 0);
+   assert(out.prompt_tokens == 42 && out.completion_tokens == 7);
+   assert(strcmp(out.model, "granite-3b-instruct") == 0);
+   assert(strcmp(out.finish_reason, "stop") == 0);
+   provider_completion_free(&out);
+   provider_completion_free(&out); /* idempotent */
+   printf("provider_client: parse success ok\n");
+}
+
+static void test_parse_failures(void)
+{
+   provider_completion_t out;
+   /* not JSON */
+   assert(provider_client_parse_openai("not json", &out) == -1);
+   /* well-formed but no content */
+   assert(provider_client_parse_openai("{\"choices\":[{\"message\":{}}]}", &out) == -1);
+   /* empty choices */
+   assert(provider_client_parse_openai("{\"choices\":[]}", &out) == -1);
+   /* NULL body */
+   assert(provider_client_parse_openai(NULL, &out) == -1);
+   /* out zeroed even on failure */
+   assert(out.content == NULL && out.prompt_tokens == 0);
+   printf("provider_client: parse failures ok\n");
+}
+
+static void test_complete_arg_guards(void)
+{
+   char err[128];
+   provider_completion_t out;
+   cJSON *msgs = two_messages();
+   provider_def_t def = {.base_url = "http://h/v1", .wire = PROVIDER_WIRE_OPENAI_CHAT};
+
+   /* missing base_url */
+   provider_def_t no_url = def;
+   no_url.base_url = "";
+   assert(provider_client_complete(&no_url, msgs, NULL, &out, err, sizeof(err)) == -1);
+   assert(err[0] != '\0');
+
+   /* unsupported wire */
+   provider_def_t bad_wire = def;
+   bad_wire.wire = (provider_wire_t)99;
+   assert(provider_client_complete(&bad_wire, msgs, NULL, &out, err, sizeof(err)) == -1);
+
+   cJSON_Delete(msgs);
+   printf("provider_client: complete arg guards ok\n");
+}
+
+/* --- complete() over the mocked transport: URL/auth/retry/parse --- */
+
+static char g_seen_url[1024];
+static char g_seen_auth[1024];
+static int g_post_calls;
+
+static int ok_handler(const char *url, const char *auth_header, const char *body,
+                      char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_post_calls++;
+   snprintf(g_seen_url, sizeof(g_seen_url), "%s", url ? url : "");
+   snprintf(g_seen_auth, sizeof(g_seen_auth), "%s", auth_header ? auth_header : "");
+   if (response_buf)
+      *response_buf = strdup("{\"model\":\"m\",\"choices\":[{\"finish_reason\":\"stop\","
+                             "\"message\":{\"content\":\"hi\"}}],"
+                             "\"usage\":{\"prompt_tokens\":3,\"completion_tokens\":1}}");
+   return 200;
+}
+
+/* 503 on the first call, 200 on the second — exercises the retry loop. */
+static int flaky_handler(const char *url, const char *auth_header, const char *body,
+                         char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   g_post_calls++;
+   if (g_post_calls == 1)
+   {
+      if (response_buf)
+         *response_buf = NULL; /* explicit: no body on a transient error */
+      return 503;              /* retryable */
+   }
+   if (response_buf)
+      *response_buf = strdup("{\"choices\":[{\"message\":{\"content\":\"ok\"}}]}");
+   return 200;
+}
+
+static int err_handler(const char *url, const char *auth_header, const char *body,
+                       char **response_buf, int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)body;
+   (void)timeout_ms;
+   (void)extra_headers;
+   (void)response_buf;
+   g_post_calls++;
+   return 401; /* non-retryable */
+}
+
+static void test_complete_success(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(ok_handler);
+
+   provider_def_t def = {.base_url = "http://h:8080/v1",
+                         .model = "m",
+                         .api_key = "secret",
+                         .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                         .temperature = -1.0};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   char err[128];
+   int rc = provider_client_complete(&def, msgs, NULL, &out, err, sizeof(err));
+   assert(rc == 0);
+   assert(g_post_calls == 1);
+   /* URL assembled with exactly one slash; auth carries the bearer. */
+   assert(strcmp(g_seen_url, "http://h:8080/v1/chat/completions") == 0);
+   assert(strcmp(g_seen_auth, "Authorization: Bearer secret") == 0);
+   assert(out.content && strcmp(out.content, "hi") == 0);
+   assert(out.prompt_tokens == 3 && out.completion_tokens == 1);
+   assert(out.http_status == 200);
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete success (url/auth/parse) ok\n");
+}
+
+static void test_complete_trailing_slash(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(ok_handler);
+   /* a base_url WITH a trailing slash must not double up. */
+   provider_def_t def = {
+       .base_url = "http://h/v1/", .wire = PROVIDER_WIRE_OPENAI_CHAT, .temperature = -1.0};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   assert(provider_client_complete(&def, msgs, NULL, &out, NULL, 0) == 0);
+   assert(strcmp(g_seen_url, "http://h/v1/chat/completions") == 0);
+   /* keyless: no Authorization header. */
+   assert(g_seen_auth[0] == '\0');
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete trailing-slash + keyless ok\n");
+}
+
+static void test_complete_retry_then_ok(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(flaky_handler);
+   provider_def_t def = {.base_url = "http://h/v1",
+                         .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                         .temperature = -1.0,
+                         .max_attempts = 3};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   int rc = provider_client_complete(&def, msgs, NULL, &out, NULL, 0);
+   assert(rc == 0);
+   assert(g_post_calls == 2); /* retried once after the 503 */
+   assert(out.content && strcmp(out.content, "ok") == 0);
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete retry-then-ok ok\n");
+}
+
+static void test_complete_non_retryable(void)
+{
+   mock_agent_http_reset();
+   g_post_calls = 0;
+   mock_agent_http_set_post_handler(err_handler);
+   provider_def_t def = {.base_url = "http://h/v1",
+                         .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                         .temperature = -1.0,
+                         .max_attempts = 3};
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   char err[128];
+   int rc = provider_client_complete(&def, msgs, NULL, &out, err, sizeof(err));
+   assert(rc == -1);
+   assert(g_post_calls == 1); /* 401 is not retried */
+   assert(out.http_status == 401);
+   assert(out.content == NULL);
+   assert(err[0] != '\0');
+   provider_completion_free(&out);
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete non-retryable (no retry) ok\n");
+}
+
+static void test_complete_truncation_guards(void)
+{
+   mock_agent_http_reset();
+   mock_agent_http_set_post_handler(ok_handler);
+   cJSON *msgs = two_messages();
+   provider_completion_t out;
+   char err[128];
+
+   /* base_url longer than the URL buffer -> truncation error, no transport call. */
+   char big[4096];
+   memset(big, 'x', sizeof(big) - 1);
+   big[sizeof(big) - 1] = '\0';
+   provider_def_t d1 = {.base_url = big, .wire = PROVIDER_WIRE_OPENAI_CHAT, .temperature = -1.0};
+   g_post_calls = 0;
+   assert(provider_client_complete(&d1, msgs, NULL, &out, err, sizeof(err)) == -1);
+   assert(g_post_calls == 0 && err[0] != '\0');
+
+   /* api_key longer than the auth buffer -> truncation error, no transport call. */
+   char bigkey[2048];
+   memset(bigkey, 'k', sizeof(bigkey) - 1);
+   bigkey[sizeof(bigkey) - 1] = '\0';
+   provider_def_t d2 = {.base_url = "http://h/v1",
+                        .api_key = bigkey,
+                        .wire = PROVIDER_WIRE_OPENAI_CHAT,
+                        .temperature = -1.0};
+   g_post_calls = 0;
+   assert(provider_client_complete(&d2, msgs, NULL, &out, err, sizeof(err)) == -1);
+   assert(g_post_calls == 0 && err[0] != '\0');
+
+   cJSON_Delete(msgs);
+   mock_agent_http_reset();
+   printf("provider_client: complete truncation guards ok\n");
+}
+
+int main(void)
+{
+   test_build_basic();
+   test_build_options_and_schema();
+   test_parse_success();
+   test_parse_failures();
+   test_complete_arg_guards();
+   test_complete_success();
+   test_complete_trailing_slash();
+   test_complete_retry_then_ok();
+   test_complete_non_retryable();
+   test_complete_truncation_guards();
+   printf("provider_client: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
Promote `testing` to `main`.

Headline change: **default retrieval tier flipped to 0.6b/400m** (was 4b/1b) — #396. Makes `aimee-embedder:latest` (and the aimee-kb plugin's embedder) default to `pplx-embed-v1-0.6b` (1024-dim) + `ettin-reranker-400m`; 4b/1b remains as `aimee-embedder-4b`. Plus a docs proposal retirement (#394).

Once merged, `auto-release` rebuilds the images so the published `latest` tags ship 0.6b by default.