### PR TITLE
ingest: skip linked git worktrees in workspace discovery

### DIFF
--- a/src/index.c
+++ b/src/index.c
@@ -369,7 +369,7 @@ static int index_is_skip_dir(const char *name)
    static const char *skip[] = {"node_modules", ".git",   "vendor",     "__pycache__", "build",
                                 "dist",         "target", ".worktrees", ".aimee",      "bin",
                                 "obj",          ".cache", ".venv",      "venv",        ".tox",
-                                "coverage",     NULL};
+                                "coverage",     "sdks",   NULL};
    for (int i = 0; skip[i]; i++)
       if (strcmp(name, skip[i]) == 0)
          return 1;

--- a/src/tests/test_workspace.c
+++ b/src/tests/test_workspace.c
@@ -290,8 +290,8 @@ int main(void)
       assert(strcmp(projects[0], real_abs) == 0);
 
       /* A worktree added explicitly (as the scan root) is still honored. */
-      int c2 = workspace_discover_projects(wt, MAX_WORKSPACE_DEPTH, projects,
-                                           MAX_DISCOVERED_PROJECTS);
+      int c2 =
+          workspace_discover_projects(wt, MAX_WORKSPACE_DEPTH, projects, MAX_DISCOVERED_PROJECTS);
       assert(c2 == 1);
       char wt_abs[MAX_PATH_LEN];
       assert(realpath(wt, wt_abs) != NULL);

--- a/src/tests/test_workspace.c
+++ b/src/tests/test_workspace.c
@@ -262,6 +262,42 @@ int main(void)
       assert(strstr(projects[0], "real-proj") != NULL);
    }
 
+   /* --- discovery: skips linked git worktrees, keeps the real checkout --- */
+   {
+      char ws[512];
+      snprintf(ws, sizeof(ws), "%s/wt-ws", tmpdir);
+      mkdir(ws, 0755);
+
+      /* Real checkout: .git is a directory. */
+      char realrepo[512];
+      snprintf(realrepo, sizeof(realrepo), "%s/main", ws);
+      create_git_repo(realrepo);
+
+      /* Linked worktree sibling: .git is a regular file ("gitdir: <path>"),
+       * a duplicate working copy of the same repo — must NOT be discovered. */
+      char wt[512], wtgit[600];
+      snprintf(wt, sizeof(wt), "%s/wt-copy", ws);
+      mkdir(wt, 0755);
+      snprintf(wtgit, sizeof(wtgit), "%s/.git", wt);
+      write_text_file(wtgit, "gitdir: /home/x/main/.git/worktrees/wt-copy\n");
+
+      char projects[MAX_DISCOVERED_PROJECTS][MAX_PATH_LEN];
+      int count =
+          workspace_discover_projects(ws, MAX_WORKSPACE_DEPTH, projects, MAX_DISCOVERED_PROJECTS);
+      assert(count == 1); /* only the real checkout, not the worktree */
+      char real_abs[MAX_PATH_LEN];
+      assert(realpath(realrepo, real_abs) != NULL);
+      assert(strcmp(projects[0], real_abs) == 0);
+
+      /* A worktree added explicitly (as the scan root) is still honored. */
+      int c2 = workspace_discover_projects(wt, MAX_WORKSPACE_DEPTH, projects,
+                                           MAX_DISCOVERED_PROJECTS);
+      assert(c2 == 1);
+      char wt_abs[MAX_PATH_LEN];
+      assert(realpath(wt, wt_abs) != NULL);
+      assert(strcmp(projects[0], wt_abs) == 0);
+   }
+
    /* --- style_read: missing file returns NULL --- */
    {
       char *style = style_read("nonexistent-project-xyz");

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -22,7 +22,7 @@ static int is_skip_dir(const char *name)
    static const char *skip[] = {"node_modules", ".git",   "vendor",     "__pycache__", "build",
                                 "dist",         "target", ".worktrees", ".aimee",      "bin",
                                 "obj",          ".cache", ".venv",      "venv",        ".tox",
-                                "coverage",     NULL};
+                                "coverage",     "sdks",   NULL};
    for (int i = 0; skip[i]; i++)
    {
       if (strcmp(name, skip[i]) == 0)
@@ -31,12 +31,19 @@ static int is_skip_dir(const char *name)
    return 0;
 }
 
-static int is_git_dir(const char *path)
+/* Classify a directory's .git entry: 0 = not a repo, 1 = real checkout (.git is
+ * a directory), 2 = linked worktree (.git is a regular file: "gitdir: <path>").
+ * Linked worktrees are duplicate working copies of an already-tracked repo, so
+ * auto-discovery skips them (see discover_recursive) to avoid indexing the same
+ * codebase once per worktree. */
+static int git_dir_kind(const char *path)
 {
    char git_path[MAX_PATH_LEN];
    struct stat st;
    snprintf(git_path, sizeof(git_path), "%s/.git", path);
-   return (stat(git_path, &st) == 0);
+   if (stat(git_path, &st) != 0)
+      return 0;
+   return S_ISDIR(st.st_mode) ? 1 : 2;
 }
 
 static void discover_recursive(const char *dir, int depth, int max_depth,
@@ -45,8 +52,13 @@ static void discover_recursive(const char *dir, int depth, int max_depth,
    if (depth > max_depth || *count >= max)
       return;
 
-   /* Check if this directory itself is a git repo */
-   if (is_git_dir(dir))
+   /* Register this directory as a project if it's a git repo. A real checkout
+    * (.git dir) always counts. A linked worktree (.git file) is a second working
+    * copy of a repo that's tracked elsewhere — counting each one re-indexes the
+    * same codebase N times — so it's only honored when added explicitly (the
+    * root of the scan, depth 0), never as a sibling found during descent. */
+   int gk = git_dir_kind(dir);
+   if (gk == 1 || (gk == 2 && depth == 0))
    {
       char abs[MAX_PATH_LEN];
       if (realpath(dir, abs))


### PR DESCRIPTION
## Bug (found during the post-deploy testing pass)

`workspace add ~/dev` ingested **83,312 files** — because `~/dev` holds **23 linked git worktrees** of the single `aimee` repo (the standard multi-worktree dev layout). `workspace_discover_projects()` treated every directory with a `.git` entry as its own project, so it indexed the same codebase ~20× → near-duplicate code/semantic hits and ~20× wasted embedding.

## Fix

A linked worktree has `.git` as a **file** (`gitdir: <path>`); a real checkout has `.git` as a **directory**. `discover_recursive` now classifies the two and **skips linked worktrees during descent** — only real checkouts register as projects. A worktree passed as the explicit scan root (depth 0) is still honored, so `workspace add <worktree-path>` keeps working.

Also adds `sdks` to the skip-dir lists (generated OpenAPI client trees like `api/sdks`) in `workspace.c` and `index.c`.

## Test

`unit-test-workspace` gains a case: a linked-worktree sibling (`.git` file) is skipped, the real checkout (`.git` dir) is kept, and an explicitly-added worktree root is still discovered. `make all` clean; full workspace suite green.

## Impact

On `~/dev`, discovery drops from 23 projects to 1 (the real `aimee` checkout) + any genuinely-separate repos — collapsing the corpus to the unique codebase.