### PR TITLE
ingest: one project per git repo; skip worktrees, symlink cycles, sdks (client push)

### DIFF
--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -5,7 +5,7 @@
 
 #include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
 #include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
-#include "code_collect.h" /* code_collect_files: thin-client workspace push */
+#include "code_collect.h" /* code_collect_files + code_collect_discover_repos (thin-client push) */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
@@ -7324,6 +7324,39 @@ static int cli_ws_ingest_root(const char *remote, const char *bearer, const char
    return (s.failed || s.oom) ? 1 : 0;
 }
 
+/* Ingest a workspace tree as ONE PROJECT PER GIT REPO: code_collect_discover_repos
+ * finds each real checkout under abs_root (skipping linked worktrees and symlink
+ * cycles) and we ingest each as its own project (cli_ws_ingest_root names a
+ * project by its basename). Falls back to ingesting abs_root itself when it holds
+ * no nested git repo — e.g. adding a single repo directly, or a plain directory. */
+typedef struct
+{
+   const char *remote;
+   const char *bearer;
+   int rc;
+   int count;
+} ws_tree_ctx_t;
+
+static void ws_tree_ingest_cb(const char *repo_abs, void *ctx)
+{
+   ws_tree_ctx_t *t = (ws_tree_ctx_t *)ctx;
+   const char *base = strrchr(repo_abs, '/');
+   base = (base && base[1]) ? base + 1 : repo_abs;
+   printf("indexing project: %s\n", base);
+   if (cli_ws_ingest_root(t->remote, t->bearer, repo_abs) != 0)
+      t->rc = 1;
+   t->count++;
+}
+
+static int cli_ws_ingest_tree(const char *remote, const char *bearer, const char *abs_root)
+{
+   ws_tree_ctx_t t = {remote, bearer, 0, 0};
+   code_collect_discover_repos(abs_root, ws_tree_ingest_cb, &t);
+   if (t.count == 0)
+      return cli_ws_ingest_root(remote, bearer, abs_root); /* no nested repo: ingest root itself */
+   return t.rc;
+}
+
 int cli_workspace_add_remote(const char *path)
 {
    if (!path || !path[0])
@@ -7370,7 +7403,7 @@ int cli_workspace_add_remote(const char *path)
       cJSON_Delete(rresp);
    printf("workspace registered: %s (detached)\n", abs);
 
-   int rc = cli_ws_ingest_root(remote, bearer, abs);
+   int rc = cli_ws_ingest_tree(remote, bearer, abs);
    free(abs);
    free(remote);
    free(bearer);
@@ -7407,7 +7440,7 @@ int cli_index_scan_remote(int argc, char **argv)
          free(bearer);
          return 1;
       }
-      rc = cli_ws_ingest_root(remote, bearer, abs);
+      rc = cli_ws_ingest_tree(remote, bearer, abs);
       free(abs);
       free(remote);
       free(bearer);
@@ -7435,7 +7468,7 @@ int cli_index_scan_remote(int argc, char **argv)
           p->valuestring && p->valuestring[0])
       {
          any = 1;
-         if (cli_ws_ingest_root(remote, bearer, p->valuestring) != 0)
+         if (cli_ws_ingest_tree(remote, bearer, p->valuestring) != 0)
             rc = 1;
       }
    }

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -27,8 +27,8 @@ static int code_ext_ok(const char *name)
 
 static int code_dir_skip(const char *name)
 {
-   static const char *const skip[] = {"node_modules", "__pycache__", "vendor", "target",
-                                      "build",        "dist",        "out",    NULL};
+   static const char *const skip[] = {"node_modules", "__pycache__", "vendor", "target", "build",
+                                      "dist",         "out",         "sdks",   NULL};
    if (name[0] == '.') /* .git, .aimee, .cache, .svn, hidden dirs */
       return 1;
    for (int i = 0; skip[i]; i++)
@@ -67,8 +67,11 @@ static int code_collect_walk(const char *root, const char *rel, code_collect_fil
       char full[4096];
       snprintf(full, sizeof(full), "%s/%s", path, ent->d_name);
 
+      /* lstat (not stat): never follow symlinks. A self-referential dir symlink
+       * (e.g. "src -> .") would otherwise loop until the path-length cap, pushing
+       * the same files repeatedly; symlinked files are skipped as likely dups. */
       struct stat st;
-      if (stat(full, &st) != 0)
+      if (lstat(full, &st) != 0 || S_ISLNK(st.st_mode))
          continue;
 
       char rel_child[4096];
@@ -160,6 +163,62 @@ int code_collect_files(const char *root, cJSON *files_arr)
    return code_collect_files_cb(root, code_collect_append_cb, files_arr);
 }
 
+/* .git classification: 0 = not a repo, 1 = real checkout (.git dir),
+ * 2 = linked worktree (.git regular file: "gitdir: <path>"). */
+static int code_git_kind(const char *path)
+{
+   char g[4096];
+   snprintf(g, sizeof(g), "%s/.git", path);
+   struct stat st;
+   if (stat(g, &st) != 0)
+      return 0;
+   return S_ISDIR(st.st_mode) ? 1 : 2;
+}
+
+static void code_discover_walk(const char *dir, int depth, code_collect_repo_cb cb, void *ctx,
+                               int *n)
+{
+   if (depth > 10)
+      return;
+
+   /* Register real checkouts always; honor a linked worktree only when it is the
+    * explicit scan root (depth 0), never as a sibling found during descent. */
+   int gk = code_git_kind(dir);
+   if (gk == 1 || (gk == 2 && depth == 0))
+   {
+      char abs[4096];
+      cb(realpath(dir, abs) ? abs : dir, ctx);
+      (*n)++;
+   }
+
+   DIR *d = opendir(dir);
+   if (!d)
+      return;
+   struct dirent *ent;
+   while ((ent = readdir(d)) != NULL)
+   {
+      if (ent->d_name[0] == '.' || code_dir_skip(ent->d_name))
+         continue;
+      char sub[4096];
+      snprintf(sub, sizeof(sub), "%s/%s", dir, ent->d_name);
+      /* lstat: never follow symlinks (cycle guard, e.g. "src -> ."). */
+      struct stat st;
+      if (lstat(sub, &st) != 0 || S_ISLNK(st.st_mode) || !S_ISDIR(st.st_mode))
+         continue;
+      code_discover_walk(sub, depth + 1, cb, ctx, n);
+   }
+   closedir(d);
+}
+
+int code_collect_discover_repos(const char *root, code_collect_repo_cb cb, void *ctx)
+{
+   if (!root || !root[0] || !cb)
+      return 0;
+   int n = 0;
+   code_discover_walk(root, 0, cb, ctx, &n);
+   return n;
+}
+
 #else /* !AIMEE_POSIX */
 
 int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx)
@@ -174,6 +233,14 @@ int code_collect_files(const char *root, cJSON *files_arr)
 {
    (void)root;
    (void)files_arr;
+   return 0;
+}
+
+int code_collect_discover_repos(const char *root, code_collect_repo_cb cb, void *ctx)
+{
+   (void)root;
+   (void)cb;
+   (void)ctx;
    return 0;
 }
 

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -37,4 +37,15 @@ int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx);
  * and the tree is known-small. Returns the number of files appended. */
 int code_collect_files(const char *root, cJSON *files_arr);
 
+/* Discover git repositories under `root` for one-project-per-repo ingest: invoke
+ * `cb` once per real checkout (a directory whose `.git` is itself a directory),
+ * with the repo's absolute path. Linked worktrees (`.git` is a regular file) are
+ * skipped — they are duplicate working copies of an already-tracked repo — and
+ * symlinks are never followed (cycle guard). A worktree passed as `root` itself
+ * is honored. Kept here (not workspace.c) so the thin client can use it without
+ * the heavier workspace.o dependency chain. POSIX only; no-op elsewhere. Returns
+ * the number of repos for which `cb` was invoked. */
+typedef void (*code_collect_repo_cb)(const char *repo_abs, void *ctx);
+int code_collect_discover_repos(const char *root, code_collect_repo_cb cb, void *ctx);
+
 #endif /* CODE_COLLECT_H */

--- a/src/tests/test_workspace.c
+++ b/src/tests/test_workspace.c
@@ -298,6 +298,25 @@ int main(void)
       assert(strcmp(projects[0], wt_abs) == 0);
    }
 
+   /* --- discovery: a self-referential dir symlink does not cause re-discovery --- */
+   {
+      char ws[512], repo[512], link[600];
+      snprintf(ws, sizeof(ws), "%s/sym-ws", tmpdir);
+      mkdir(ws, 0755);
+      snprintf(repo, sizeof(repo), "%s/router", ws);
+      create_git_repo(repo);
+      /* "src -> ." inside the repo: following it would loop and re-discover the
+       * repo once per depth level (the smoothrouter bug). */
+      snprintf(link, sizeof(link), "%s/src", repo);
+      assert(symlink(".", link) == 0);
+
+      char projects[MAX_DISCOVERED_PROJECTS][MAX_PATH_LEN];
+      int count =
+          workspace_discover_projects(ws, MAX_WORKSPACE_DEPTH, projects, MAX_DISCOVERED_PROJECTS);
+      assert(count == 1); /* discovered exactly once, not N times */
+      assert(strstr(projects[0], "router") != NULL);
+   }
+
    /* --- style_read: missing file returns NULL --- */
    {
       char *style = style_read("nonexistent-project-xyz");

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -85,8 +85,11 @@ static void discover_recursive(const char *dir, int depth, int max_depth,
       char sub[MAX_PATH_LEN];
       snprintf(sub, sizeof(sub), "%s/%s", dir, ent->d_name);
 
+      /* lstat (not stat): never follow symlinked directories. A self-referential
+       * or parent-pointing symlink (e.g. a repo's "src -> .") otherwise creates a
+       * cycle that re-discovers the same repo once per level up to max_depth. */
       struct stat st;
-      if (stat(sub, &st) != 0 || !S_ISDIR(st.st_mode))
+      if (lstat(sub, &st) != 0 || S_ISLNK(st.st_mode) || !S_ISDIR(st.st_mode))
          continue;
 
       discover_recursive(sub, depth + 1, max_depth, projects, max, count);


### PR DESCRIPTION
## Bug (testing pass)

The thin-client `workspace add <root>` push (`cli_v1_routes.inc` → `cli_ws_ingest_root`) walked the **whole workspace root as one project** and followed everything under it. On `~/dev` (23 linked `aimee` worktrees + a self-referential `smoothrouter/src -> .` symlink) it ingested **~83k files**: the same repo ~20× (one per worktree), generated `api/sdks` trees, and symlink-loop dupes. #399 fixed `workspace_discover_projects`, but **the v1 client push never used it** — wrong layer.

## Fix (all in the thin client's DB-free layer)
- **`code_collect.c`**: new `code_collect_discover_repos()` — one real checkout per git repo (skips **linked worktrees**: `.git` is a *file*), **never follows symlinks** (`lstat` cycle guard). `code_collect_walk()` switched to `lstat` so the file push can't follow a symlink loop; `sdks` added to its skip list.
- **`cli_v1_routes.inc`**: `cli_ws_ingest_tree()` discovers repos under the root and ingests **each as its own project** (named by basename), falling back to the root when it holds no nested repo. `workspace add` and both `index scan` paths use it.
- **`workspace.c`**: `discover_recursive()` also switched to `lstat` (symlink guard), complementing #399's worktree skip.

## Validated live on .254 (real `~/dev`)
**14 projects** (one per repo: `aimee`, `smoothnas`, `LXC2Docker`, …), **3,039 files** (was ~83k — 27× less), **0 worktree files**, **0 sdks files**, repo-relative paths. Embeddings backfilling on 0.6b.

## Tests
`unit-test-workspace` gains worktree-skip and symlink-cycle cases. `make all` clean.