### PR TITLE
feat(curator): remove the drain rate limiter (§5)

### DIFF
--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -232,8 +232,9 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
    }
 
    /* max_jobs_per_hour was the curator rate cap; removed (§5 — the drain now runs
-    * to backlog and idles). A leftover key in an existing config is harmless: the
-    * kb.curator section is not schema-validated, so it is silently ignored. */
+    * until the backlog is drained, then idles). A leftover key in an existing
+    * config is harmless: the kb.curator section is not schema-validated, so it is
+    * silently ignored. */
 
    const cJSON *max_attempts = cJSON_GetObjectItemCaseSensitive(curator, "max_attempts");
    if (max_attempts)

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -9,7 +9,6 @@
  *       enabled: false
  *     extract_command: ""
  *     extract_max_tokens: 2048
- *     max_jobs_per_hour: 120
  *     max_attempts: 3
  */
 
@@ -23,10 +22,10 @@
 
 void config_kb_curator_defaults(config_t *cfg)
 {
-   /* The deep-curator (larger LLM) pipeline is default-ON: it drains gradually
-    * in the background (rate-limited by kb_curator_max_jobs_per_hour) and refines
-    * what the 0.6B embedder already indexed. Every stage degrades to a no-op when
-    * its prerequisite (a configured curator/judge/synthesize command, or upstream
+   /* The deep-curator (larger LLM) pipeline is default-ON: it drains the backlog
+    * continuously in the background (no artificial rate cap) and refines what the
+    * 0.6B embedder already indexed. Every stage degrades to a no-op when its
+    * prerequisite (a configured curator/judge/synthesize command, or upstream
     * curator rows) is absent, so default-on is safe on a bare deploy. */
    cfg->kb_curator_extract_docs_enabled = 1;
    cfg->kb_curator_extract_prompt_version[0] = '\0';
@@ -47,7 +46,6 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_synthesize_command[0] = '\0';
    cfg->kb_curator_synthesize_k = 8;
    cfg->kb_curator_extract_max_tokens = 2048;
-   cfg->kb_curator_max_jobs_per_hour = 120;
    cfg->kb_curator_max_attempts = 3;
    cfg->kb_evidence_embed_enabled = 1;
    cfg->kb_evidence_embed_batch = 32;
@@ -233,14 +231,9 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
          cfg->kb_curator_extract_max_tokens = max_tokens->valueint;
    }
 
-   const cJSON *max_jobs = cJSON_GetObjectItemCaseSensitive(curator, "max_jobs_per_hour");
-   if (max_jobs)
-   {
-      if (!cJSON_IsNumber(max_jobs) || max_jobs->valueint <= 0)
-         config_issue("\"kb.curator.max_jobs_per_hour\" must be a positive integer");
-      else
-         cfg->kb_curator_max_jobs_per_hour = max_jobs->valueint;
-   }
+   /* max_jobs_per_hour was the curator rate cap; removed (§5 — the drain now runs
+    * to backlog and idles). A leftover key in an existing config is harmless: the
+    * kb.curator section is not schema-validated, so it is silently ignored. */
 
    const cJSON *max_attempts = cJSON_GetObjectItemCaseSensitive(curator, "max_attempts");
    if (max_attempts)
@@ -304,8 +297,8 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_synthesize_enabled || cfg->kb_curator_promote_entity_enabled ||
        cfg->kb_curator_extract_command[0] || cfg->kb_curator_judge_command[0] ||
        cfg->kb_curator_synthesize_command[0] || cfg->kb_curator_extract_max_tokens != 2048 ||
-       cfg->kb_curator_max_jobs_per_hour != 120 || cfg->kb_curator_max_attempts != 3 ||
-       cfg->kb_curator_synthesize_k != 8 || cfg->kb_curator_promote_min_sources != 3;
+       cfg->kb_curator_max_attempts != 3 || cfg->kb_curator_synthesize_k != 8 ||
+       cfg->kb_curator_promote_min_sources != 3;
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
    if (!curator_any && !evidence_any)
       return;
@@ -359,8 +352,6 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
             cJSON_AddStringToObject(cur, "synthesize_command", cfg->kb_curator_synthesize_command);
          if (cfg->kb_curator_extract_max_tokens != 2048)
             cJSON_AddNumberToObject(cur, "extract_max_tokens", cfg->kb_curator_extract_max_tokens);
-         if (cfg->kb_curator_max_jobs_per_hour != 120)
-            cJSON_AddNumberToObject(cur, "max_jobs_per_hour", cfg->kb_curator_max_jobs_per_hour);
          if (cfg->kb_curator_max_attempts != 3)
             cJSON_AddNumberToObject(cur, "max_attempts", cfg->kb_curator_max_attempts);
       }

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1223,7 +1223,6 @@ typedef struct config
     * kb_curator_extract_code_enabled:  0 = off (default), 1 = queue extract_code_unit jobs.
     * kb_curator_extract_command[512]:  sidecar command (default: scripts/curator-extract.py).
     * kb_curator_extract_max_tokens:    max_tokens per job stdin payload (default 2048).
-    * kb_curator_max_jobs_per_hour:     sliding-window rate cap on drain completions (default 120).
     * kb_curator_max_attempts:          max drain attempts per job before marking failed (default
     * 3).
     */
@@ -1265,7 +1264,6 @@ typedef struct config
    int kb_curator_promote_min_sources;
    char kb_curator_extract_command[512];
    int kb_curator_extract_max_tokens;
-   int kb_curator_max_jobs_per_hour;
    int kb_curator_max_attempts;
    /* judge_command: LLM sidecar that adjudicates the resolve_entities
     * [0.70, 0.85) ambiguous band (same_entity? merge : create). Empty = off;

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -1,8 +1,8 @@
 /* kb_curator_drain.c: curator drain thread — polls for pending extract_doc
- * jobs, rate-limits via a sliding-window ring buffer, and calls
- * kb_curator_extract_one() to process each job. The same thread also drains
- * the evidence_index_ops embed queue (kb_evidence_embed_drain), independent of
- * the curator extract gates.
+ * jobs and calls kb_curator_extract_one() to process each, draining the backlog
+ * continuously and then idling (no artificial rate cap; §5 of curator-llm-
+ * backend). The same thread also drains the evidence_index_ops embed queue
+ * (kb_evidence_embed_drain), independent of the curator extract gates.
  * No DB1 access from this file. */
 
 #ifndef _GNU_SOURCE
@@ -48,17 +48,9 @@ static void *drain_thread_main(void *arg)
    config_t cfg;
    config_load(&cfg);
 
-   int max_jobs = cfg.kb_curator_max_jobs_per_hour > 0 ? cfg.kb_curator_max_jobs_per_hour : 120;
-
-   /* Ring buffer of completion timestamps for rate limiting */
-   long *ring = calloc((size_t)max_jobs, sizeof(long));
-   if (!ring)
-   {
-      aimee_log(LOG_WARN, "kb.curator.drain", "out of memory; drain thread exiting");
-      return NULL;
-   }
-   int ring_head = 0;
-   int ring_count = 0;
+   /* No artificial rate cap (§5): the curator drains the backlog continuously and
+    * then idles. The natural throttle is backend throughput; cost control for a
+    * paid provider lives at the provider (endpoint choice / its own limits). */
 
    long last_cfg_reload = (long)time(NULL);
 
@@ -78,20 +70,6 @@ static void *drain_thread_main(void *arg)
       {
          config_load(&cfg);
          last_cfg_reload = now;
-         int new_max =
-             cfg.kb_curator_max_jobs_per_hour > 0 ? cfg.kb_curator_max_jobs_per_hour : 120;
-         if (new_max != max_jobs)
-         {
-            long *new_ring = calloc((size_t)new_max, sizeof(long));
-            if (new_ring)
-            {
-               free(ring);
-               ring = new_ring;
-               ring_head = 0;
-               ring_count = 0;
-               max_jobs = new_max;
-            }
-         }
       }
 
       /* Evidence-vector embed drain — runs every poll, independent of the
@@ -180,25 +158,6 @@ static void *drain_thread_main(void *arg)
          continue;
       }
 
-      /* Rate limiting: check if window is full */
-      if (ring_count >= max_jobs)
-      {
-         int oldest_idx = (ring_head - ring_count + max_jobs) % max_jobs;
-         long oldest_ts = ring[oldest_idx];
-         long age = now - oldest_ts;
-         if (age < 3600)
-         {
-            kb_background_set("curator", "rate-limited window=%d/%d", ring_count, max_jobs);
-            aimee_log(LOG_DEBUG, "kb.curator.drain",
-                      "rate limit: %d/%d jobs in last hour; sleeping %lds", ring_count, max_jobs,
-                      3600 - age);
-            sleep((int)(3600 - age));
-            continue;
-         }
-         /* Oldest entry expired — slide the window */
-         ring_count--;
-      }
-
       kb_curator_extract_opts_t opts;
       memset(&opts, 0, sizeof(opts));
       snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
@@ -210,64 +169,59 @@ static void *drain_thread_main(void *arg)
       int rc = 0;
       if (cfg.kb_curator_extract_docs_enabled)
       {
-         kb_background_set("curator", "extract docs (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "extract docs");
          rc = kb_curator_extract_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_extract_code_enabled)
       {
-         kb_background_set("curator", "extract code (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "extract code");
          rc = kb_curator_extract_code_unit_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_resolve_entities_enabled)
       {
-         kb_background_set("curator", "resolve entities (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "resolve entities");
          rc = kb_curator_resolve_entities_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_index_narrative_enabled)
       {
-         kb_background_set("curator", "index narrative (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "index narrative");
          rc = kb_curator_index_narrative_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_index_claims_enabled)
       {
-         kb_background_set("curator", "index claims (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "index claims");
          rc = kb_curator_index_claims_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_detect_contradictions_enabled)
       {
-         kb_background_set("curator", "detect contradictions (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "detect contradictions");
          rc = kb_curator_detect_contradictions_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_index_code_unit_enabled)
       {
-         kb_background_set("curator", "index code_unit (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "index code_unit");
          rc = kb_curator_index_code_unit_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_link_artifacts_enabled)
       {
-         kb_background_set("curator", "link artifacts (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "link artifacts");
          rc = kb_curator_link_artifacts_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_synthesize_enabled)
       {
-         kb_background_set("curator", "synthesize topic (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "synthesize topic");
          rc = kb_curator_synthesize_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_promote_entity_enabled)
       {
-         kb_background_set("curator", "promote entity (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "promote entity");
          rc = kb_curator_promote_entity_one(&opts);
       }
 
       if (rc == 1)
       {
-         /* Record completion in ring buffer */
-         ring[ring_head % max_jobs] = (long)time(NULL);
-         ring_head = (ring_head + 1) % max_jobs;
-         if (ring_count < max_jobs)
-            ring_count++;
-         aimee_log(LOG_DEBUG, "kb.curator.drain", "job processed (%d/%d in window)", ring_count,
-                   max_jobs);
+         /* Job processed — loop straight back to drain the next one (no cap). */
+         aimee_log(LOG_DEBUG, "kb.curator.drain", "job processed");
       }
       else if (rc == 0)
       {
@@ -283,7 +237,6 @@ static void *drain_thread_main(void *arg)
    }
 
    kb_background_clear("curator");
-   free(ring);
    return NULL;
 }
 

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -231,7 +231,12 @@ static void *drain_thread_main(void *arg)
       }
       else
       {
-         aimee_log(LOG_WARN, "kb.curator.drain", "extractor returned error");
+         /* Stage error: back off a poll interval before retrying. With the rate
+          * cap gone this is the only thing keeping a persistently-failing stage
+          * (bad provider, schema always rejected) from spinning the loop hot. */
+         aimee_log(LOG_WARN, "kb.curator.drain", "extractor returned error; backing off");
+         kb_background_clear("curator");
+         sleep(DRAIN_POLL_SECS);
       }
       kb_background_clear("curator");
    }


### PR DESCRIPTION
**§5 of curator-llm-backend** — remove the curator drain's artificial rate limiter.

The drain (`kb_curator_drain.c`, a background thread in `aimee-kb`) kept a sliding-window ring buffer of completion timestamps and slept once more than `kb_curator_max_jobs_per_hour` completed in the last hour. §5 drops that: the curator drains the backlog **continuously** and then idles. The natural throttle is backend throughput; cost control for a paid provider belongs at the provider (endpoint choice / its own limits), not an artificial jobs/hour cap. This also simplifies the drain loop.

## Changes
- **`kb_curator_drain.c`** — remove the ring-buffer alloc, the realloc-on-config-reload, the window gate (and its hour-long sleep), and the per-completion bookkeeping. On a processed job (`rc==1`) the loop goes straight to the next; the no-job (`rc==0`) poll-sleep and the error log are unchanged, and the `ctx->stop` exit is preserved. Dropped the now-noise `(window=%d/%d)` from the per-stage status strings.
- **`config_kb_curator.c` + `config.h`** — remove `kb_curator_max_jobs_per_hour` (default/parse/diff/save/doc + struct field). A leftover `max_jobs_per_hour` key in an existing config is harmless: the `kb.curator` section is not schema-validated, so it is silently ignored — no migration breakage.

## Verification
`make all` clean (aimee + aimee-server + aimee-kb), `make lint` ok (schema-sync, clang-format), and `unit-test-config` / `unit-test-cmd-config` / `unit-test-config-surface` pass. Local roundtable gate run on the diff.
