### PR TITLE
Promote testing → main: per-repo ingest (skip worktrees/symlinks/sdks)

### DIFF
--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -5,7 +5,7 @@
 
 #include "util.h"         /* safe_exec_capture (workspace.mirror-sync ships the client diff) */
 #include "aimee_client.h" /* aimee_client_request: transport-agnostic /v1 client (Windows path) */
-#include "code_collect.h" /* code_collect_files: thin-client workspace push */
+#include "code_collect.h" /* code_collect_files + code_collect_discover_repos (thin-client push) */
 #if !defined(_WIN32) && !defined(_WIN64)
 #include "aimee_home.h"
 #include <dirent.h>
@@ -7324,6 +7324,39 @@ static int cli_ws_ingest_root(const char *remote, const char *bearer, const char
    return (s.failed || s.oom) ? 1 : 0;
 }
 
+/* Ingest a workspace tree as ONE PROJECT PER GIT REPO: code_collect_discover_repos
+ * finds each real checkout under abs_root (skipping linked worktrees and symlink
+ * cycles) and we ingest each as its own project (cli_ws_ingest_root names a
+ * project by its basename). Falls back to ingesting abs_root itself when it holds
+ * no nested git repo — e.g. adding a single repo directly, or a plain directory. */
+typedef struct
+{
+   const char *remote;
+   const char *bearer;
+   int rc;
+   int count;
+} ws_tree_ctx_t;
+
+static void ws_tree_ingest_cb(const char *repo_abs, void *ctx)
+{
+   ws_tree_ctx_t *t = (ws_tree_ctx_t *)ctx;
+   const char *base = strrchr(repo_abs, '/');
+   base = (base && base[1]) ? base + 1 : repo_abs;
+   printf("indexing project: %s\n", base);
+   if (cli_ws_ingest_root(t->remote, t->bearer, repo_abs) != 0)
+      t->rc = 1;
+   t->count++;
+}
+
+static int cli_ws_ingest_tree(const char *remote, const char *bearer, const char *abs_root)
+{
+   ws_tree_ctx_t t = {remote, bearer, 0, 0};
+   code_collect_discover_repos(abs_root, ws_tree_ingest_cb, &t);
+   if (t.count == 0)
+      return cli_ws_ingest_root(remote, bearer, abs_root); /* no nested repo: ingest root itself */
+   return t.rc;
+}
+
 int cli_workspace_add_remote(const char *path)
 {
    if (!path || !path[0])
@@ -7370,7 +7403,7 @@ int cli_workspace_add_remote(const char *path)
       cJSON_Delete(rresp);
    printf("workspace registered: %s (detached)\n", abs);
 
-   int rc = cli_ws_ingest_root(remote, bearer, abs);
+   int rc = cli_ws_ingest_tree(remote, bearer, abs);
    free(abs);
    free(remote);
    free(bearer);
@@ -7407,7 +7440,7 @@ int cli_index_scan_remote(int argc, char **argv)
          free(bearer);
          return 1;
       }
-      rc = cli_ws_ingest_root(remote, bearer, abs);
+      rc = cli_ws_ingest_tree(remote, bearer, abs);
       free(abs);
       free(remote);
       free(bearer);
@@ -7435,7 +7468,7 @@ int cli_index_scan_remote(int argc, char **argv)
           p->valuestring && p->valuestring[0])
       {
          any = 1;
-         if (cli_ws_ingest_root(remote, bearer, p->valuestring) != 0)
+         if (cli_ws_ingest_tree(remote, bearer, p->valuestring) != 0)
             rc = 1;
       }
    }

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -27,8 +27,8 @@ static int code_ext_ok(const char *name)
 
 static int code_dir_skip(const char *name)
 {
-   static const char *const skip[] = {"node_modules", "__pycache__", "vendor", "target",
-                                      "build",        "dist",        "out",    NULL};
+   static const char *const skip[] = {"node_modules", "__pycache__", "vendor", "target", "build",
+                                      "dist",         "out",         "sdks",   NULL};
    if (name[0] == '.') /* .git, .aimee, .cache, .svn, hidden dirs */
       return 1;
    for (int i = 0; skip[i]; i++)
@@ -67,8 +67,11 @@ static int code_collect_walk(const char *root, const char *rel, code_collect_fil
       char full[4096];
       snprintf(full, sizeof(full), "%s/%s", path, ent->d_name);
 
+      /* lstat (not stat): never follow symlinks. A self-referential dir symlink
+       * (e.g. "src -> .") would otherwise loop until the path-length cap, pushing
+       * the same files repeatedly; symlinked files are skipped as likely dups. */
       struct stat st;
-      if (stat(full, &st) != 0)
+      if (lstat(full, &st) != 0 || S_ISLNK(st.st_mode))
          continue;
 
       char rel_child[4096];
@@ -160,6 +163,62 @@ int code_collect_files(const char *root, cJSON *files_arr)
    return code_collect_files_cb(root, code_collect_append_cb, files_arr);
 }
 
+/* .git classification: 0 = not a repo, 1 = real checkout (.git dir),
+ * 2 = linked worktree (.git regular file: "gitdir: <path>"). */
+static int code_git_kind(const char *path)
+{
+   char g[4096];
+   snprintf(g, sizeof(g), "%s/.git", path);
+   struct stat st;
+   if (stat(g, &st) != 0)
+      return 0;
+   return S_ISDIR(st.st_mode) ? 1 : 2;
+}
+
+static void code_discover_walk(const char *dir, int depth, code_collect_repo_cb cb, void *ctx,
+                               int *n)
+{
+   if (depth > 10)
+      return;
+
+   /* Register real checkouts always; honor a linked worktree only when it is the
+    * explicit scan root (depth 0), never as a sibling found during descent. */
+   int gk = code_git_kind(dir);
+   if (gk == 1 || (gk == 2 && depth == 0))
+   {
+      char abs[4096];
+      cb(realpath(dir, abs) ? abs : dir, ctx);
+      (*n)++;
+   }
+
+   DIR *d = opendir(dir);
+   if (!d)
+      return;
+   struct dirent *ent;
+   while ((ent = readdir(d)) != NULL)
+   {
+      if (ent->d_name[0] == '.' || code_dir_skip(ent->d_name))
+         continue;
+      char sub[4096];
+      snprintf(sub, sizeof(sub), "%s/%s", dir, ent->d_name);
+      /* lstat: never follow symlinks (cycle guard, e.g. "src -> ."). */
+      struct stat st;
+      if (lstat(sub, &st) != 0 || S_ISLNK(st.st_mode) || !S_ISDIR(st.st_mode))
+         continue;
+      code_discover_walk(sub, depth + 1, cb, ctx, n);
+   }
+   closedir(d);
+}
+
+int code_collect_discover_repos(const char *root, code_collect_repo_cb cb, void *ctx)
+{
+   if (!root || !root[0] || !cb)
+      return 0;
+   int n = 0;
+   code_discover_walk(root, 0, cb, ctx, &n);
+   return n;
+}
+
 #else /* !AIMEE_POSIX */
 
 int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx)
@@ -174,6 +233,14 @@ int code_collect_files(const char *root, cJSON *files_arr)
 {
    (void)root;
    (void)files_arr;
+   return 0;
+}
+
+int code_collect_discover_repos(const char *root, code_collect_repo_cb cb, void *ctx)
+{
+   (void)root;
+   (void)cb;
+   (void)ctx;
    return 0;
 }
 

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -9,7 +9,6 @@
  *       enabled: false
  *     extract_command: ""
  *     extract_max_tokens: 2048
- *     max_jobs_per_hour: 120
  *     max_attempts: 3
  */
 
@@ -23,10 +22,10 @@
 
 void config_kb_curator_defaults(config_t *cfg)
 {
-   /* The deep-curator (larger LLM) pipeline is default-ON: it drains gradually
-    * in the background (rate-limited by kb_curator_max_jobs_per_hour) and refines
-    * what the 0.6B embedder already indexed. Every stage degrades to a no-op when
-    * its prerequisite (a configured curator/judge/synthesize command, or upstream
+   /* The deep-curator (larger LLM) pipeline is default-ON: it drains the backlog
+    * continuously in the background (no artificial rate cap) and refines what the
+    * 0.6B embedder already indexed. Every stage degrades to a no-op when its
+    * prerequisite (a configured curator/judge/synthesize command, or upstream
     * curator rows) is absent, so default-on is safe on a bare deploy. */
    cfg->kb_curator_extract_docs_enabled = 1;
    cfg->kb_curator_extract_prompt_version[0] = '\0';
@@ -47,7 +46,6 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_synthesize_command[0] = '\0';
    cfg->kb_curator_synthesize_k = 8;
    cfg->kb_curator_extract_max_tokens = 2048;
-   cfg->kb_curator_max_jobs_per_hour = 120;
    cfg->kb_curator_max_attempts = 3;
    cfg->kb_evidence_embed_enabled = 1;
    cfg->kb_evidence_embed_batch = 32;
@@ -233,14 +231,10 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
          cfg->kb_curator_extract_max_tokens = max_tokens->valueint;
    }
 
-   const cJSON *max_jobs = cJSON_GetObjectItemCaseSensitive(curator, "max_jobs_per_hour");
-   if (max_jobs)
-   {
-      if (!cJSON_IsNumber(max_jobs) || max_jobs->valueint <= 0)
-         config_issue("\"kb.curator.max_jobs_per_hour\" must be a positive integer");
-      else
-         cfg->kb_curator_max_jobs_per_hour = max_jobs->valueint;
-   }
+   /* max_jobs_per_hour was the curator rate cap; removed (§5 — the drain now runs
+    * until the backlog is drained, then idles). A leftover key in an existing
+    * config is harmless: the kb.curator section is not schema-validated, so it is
+    * silently ignored. */
 
    const cJSON *max_attempts = cJSON_GetObjectItemCaseSensitive(curator, "max_attempts");
    if (max_attempts)
@@ -304,8 +298,8 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_synthesize_enabled || cfg->kb_curator_promote_entity_enabled ||
        cfg->kb_curator_extract_command[0] || cfg->kb_curator_judge_command[0] ||
        cfg->kb_curator_synthesize_command[0] || cfg->kb_curator_extract_max_tokens != 2048 ||
-       cfg->kb_curator_max_jobs_per_hour != 120 || cfg->kb_curator_max_attempts != 3 ||
-       cfg->kb_curator_synthesize_k != 8 || cfg->kb_curator_promote_min_sources != 3;
+       cfg->kb_curator_max_attempts != 3 || cfg->kb_curator_synthesize_k != 8 ||
+       cfg->kb_curator_promote_min_sources != 3;
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
    if (!curator_any && !evidence_any)
       return;
@@ -359,8 +353,6 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
             cJSON_AddStringToObject(cur, "synthesize_command", cfg->kb_curator_synthesize_command);
          if (cfg->kb_curator_extract_max_tokens != 2048)
             cJSON_AddNumberToObject(cur, "extract_max_tokens", cfg->kb_curator_extract_max_tokens);
-         if (cfg->kb_curator_max_jobs_per_hour != 120)
-            cJSON_AddNumberToObject(cur, "max_jobs_per_hour", cfg->kb_curator_max_jobs_per_hour);
          if (cfg->kb_curator_max_attempts != 3)
             cJSON_AddNumberToObject(cur, "max_attempts", cfg->kb_curator_max_attempts);
       }

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -37,4 +37,15 @@ int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx);
  * and the tree is known-small. Returns the number of files appended. */
 int code_collect_files(const char *root, cJSON *files_arr);
 
+/* Discover git repositories under `root` for one-project-per-repo ingest: invoke
+ * `cb` once per real checkout (a directory whose `.git` is itself a directory),
+ * with the repo's absolute path. Linked worktrees (`.git` is a regular file) are
+ * skipped — they are duplicate working copies of an already-tracked repo — and
+ * symlinks are never followed (cycle guard). A worktree passed as `root` itself
+ * is honored. Kept here (not workspace.c) so the thin client can use it without
+ * the heavier workspace.o dependency chain. POSIX only; no-op elsewhere. Returns
+ * the number of repos for which `cb` was invoked. */
+typedef void (*code_collect_repo_cb)(const char *repo_abs, void *ctx);
+int code_collect_discover_repos(const char *root, code_collect_repo_cb cb, void *ctx);
+
 #endif /* CODE_COLLECT_H */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1223,7 +1223,6 @@ typedef struct config
     * kb_curator_extract_code_enabled:  0 = off (default), 1 = queue extract_code_unit jobs.
     * kb_curator_extract_command[512]:  sidecar command (default: scripts/curator-extract.py).
     * kb_curator_extract_max_tokens:    max_tokens per job stdin payload (default 2048).
-    * kb_curator_max_jobs_per_hour:     sliding-window rate cap on drain completions (default 120).
     * kb_curator_max_attempts:          max drain attempts per job before marking failed (default
     * 3).
     */
@@ -1265,7 +1264,6 @@ typedef struct config
    int kb_curator_promote_min_sources;
    char kb_curator_extract_command[512];
    int kb_curator_extract_max_tokens;
-   int kb_curator_max_jobs_per_hour;
    int kb_curator_max_attempts;
    /* judge_command: LLM sidecar that adjudicates the resolve_entities
     * [0.70, 0.85) ambiguous band (same_entity? merge : create). Empty = off;

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -1,8 +1,8 @@
 /* kb_curator_drain.c: curator drain thread — polls for pending extract_doc
- * jobs, rate-limits via a sliding-window ring buffer, and calls
- * kb_curator_extract_one() to process each job. The same thread also drains
- * the evidence_index_ops embed queue (kb_evidence_embed_drain), independent of
- * the curator extract gates.
+ * jobs and calls kb_curator_extract_one() to process each, draining the backlog
+ * continuously and then idling (no artificial rate cap; §5 of curator-llm-
+ * backend). The same thread also drains the evidence_index_ops embed queue
+ * (kb_evidence_embed_drain), independent of the curator extract gates.
  * No DB1 access from this file. */
 
 #ifndef _GNU_SOURCE
@@ -48,17 +48,9 @@ static void *drain_thread_main(void *arg)
    config_t cfg;
    config_load(&cfg);
 
-   int max_jobs = cfg.kb_curator_max_jobs_per_hour > 0 ? cfg.kb_curator_max_jobs_per_hour : 120;
-
-   /* Ring buffer of completion timestamps for rate limiting */
-   long *ring = calloc((size_t)max_jobs, sizeof(long));
-   if (!ring)
-   {
-      aimee_log(LOG_WARN, "kb.curator.drain", "out of memory; drain thread exiting");
-      return NULL;
-   }
-   int ring_head = 0;
-   int ring_count = 0;
+   /* No artificial rate cap (§5): the curator drains the backlog continuously and
+    * then idles. The natural throttle is backend throughput; cost control for a
+    * paid provider lives at the provider (endpoint choice / its own limits). */
 
    long last_cfg_reload = (long)time(NULL);
 
@@ -78,20 +70,6 @@ static void *drain_thread_main(void *arg)
       {
          config_load(&cfg);
          last_cfg_reload = now;
-         int new_max =
-             cfg.kb_curator_max_jobs_per_hour > 0 ? cfg.kb_curator_max_jobs_per_hour : 120;
-         if (new_max != max_jobs)
-         {
-            long *new_ring = calloc((size_t)new_max, sizeof(long));
-            if (new_ring)
-            {
-               free(ring);
-               ring = new_ring;
-               ring_head = 0;
-               ring_count = 0;
-               max_jobs = new_max;
-            }
-         }
       }
 
       /* Evidence-vector embed drain — runs every poll, independent of the
@@ -180,25 +158,6 @@ static void *drain_thread_main(void *arg)
          continue;
       }
 
-      /* Rate limiting: check if window is full */
-      if (ring_count >= max_jobs)
-      {
-         int oldest_idx = (ring_head - ring_count + max_jobs) % max_jobs;
-         long oldest_ts = ring[oldest_idx];
-         long age = now - oldest_ts;
-         if (age < 3600)
-         {
-            kb_background_set("curator", "rate-limited window=%d/%d", ring_count, max_jobs);
-            aimee_log(LOG_DEBUG, "kb.curator.drain",
-                      "rate limit: %d/%d jobs in last hour; sleeping %lds", ring_count, max_jobs,
-                      3600 - age);
-            sleep((int)(3600 - age));
-            continue;
-         }
-         /* Oldest entry expired — slide the window */
-         ring_count--;
-      }
-
       kb_curator_extract_opts_t opts;
       memset(&opts, 0, sizeof(opts));
       snprintf(opts.extract_command, sizeof(opts.extract_command), "%s",
@@ -210,64 +169,59 @@ static void *drain_thread_main(void *arg)
       int rc = 0;
       if (cfg.kb_curator_extract_docs_enabled)
       {
-         kb_background_set("curator", "extract docs (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "extract docs");
          rc = kb_curator_extract_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_extract_code_enabled)
       {
-         kb_background_set("curator", "extract code (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "extract code");
          rc = kb_curator_extract_code_unit_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_resolve_entities_enabled)
       {
-         kb_background_set("curator", "resolve entities (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "resolve entities");
          rc = kb_curator_resolve_entities_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_index_narrative_enabled)
       {
-         kb_background_set("curator", "index narrative (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "index narrative");
          rc = kb_curator_index_narrative_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_index_claims_enabled)
       {
-         kb_background_set("curator", "index claims (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "index claims");
          rc = kb_curator_index_claims_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_detect_contradictions_enabled)
       {
-         kb_background_set("curator", "detect contradictions (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "detect contradictions");
          rc = kb_curator_detect_contradictions_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_index_code_unit_enabled)
       {
-         kb_background_set("curator", "index code_unit (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "index code_unit");
          rc = kb_curator_index_code_unit_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_link_artifacts_enabled)
       {
-         kb_background_set("curator", "link artifacts (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "link artifacts");
          rc = kb_curator_link_artifacts_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_synthesize_enabled)
       {
-         kb_background_set("curator", "synthesize topic (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "synthesize topic");
          rc = kb_curator_synthesize_one(&opts);
       }
       if (rc == 0 && cfg.kb_curator_promote_entity_enabled)
       {
-         kb_background_set("curator", "promote entity (window=%d/%d)", ring_count, max_jobs);
+         kb_background_set("curator", "promote entity");
          rc = kb_curator_promote_entity_one(&opts);
       }
 
       if (rc == 1)
       {
-         /* Record completion in ring buffer */
-         ring[ring_head % max_jobs] = (long)time(NULL);
-         ring_head = (ring_head + 1) % max_jobs;
-         if (ring_count < max_jobs)
-            ring_count++;
-         aimee_log(LOG_DEBUG, "kb.curator.drain", "job processed (%d/%d in window)", ring_count,
-                   max_jobs);
+         /* Job processed — loop straight back to drain the next one (no cap). */
+         aimee_log(LOG_DEBUG, "kb.curator.drain", "job processed");
       }
       else if (rc == 0)
       {
@@ -277,13 +231,17 @@ static void *drain_thread_main(void *arg)
       }
       else
       {
-         aimee_log(LOG_WARN, "kb.curator.drain", "extractor returned error");
+         /* Stage error: back off a poll interval before retrying. With the rate
+          * cap gone this is the only thing keeping a persistently-failing stage
+          * (bad provider, schema always rejected) from spinning the loop hot. */
+         aimee_log(LOG_WARN, "kb.curator.drain", "extractor returned error; backing off");
+         kb_background_clear("curator");
+         sleep(DRAIN_POLL_SECS);
       }
       kb_background_clear("curator");
    }
 
    kb_background_clear("curator");
-   free(ring);
    return NULL;
 }
 

--- a/src/tests/test_workspace.c
+++ b/src/tests/test_workspace.c
@@ -298,6 +298,25 @@ int main(void)
       assert(strcmp(projects[0], wt_abs) == 0);
    }
 
+   /* --- discovery: a self-referential dir symlink does not cause re-discovery --- */
+   {
+      char ws[512], repo[512], link[600];
+      snprintf(ws, sizeof(ws), "%s/sym-ws", tmpdir);
+      mkdir(ws, 0755);
+      snprintf(repo, sizeof(repo), "%s/router", ws);
+      create_git_repo(repo);
+      /* "src -> ." inside the repo: following it would loop and re-discover the
+       * repo once per depth level (the smoothrouter bug). */
+      snprintf(link, sizeof(link), "%s/src", repo);
+      assert(symlink(".", link) == 0);
+
+      char projects[MAX_DISCOVERED_PROJECTS][MAX_PATH_LEN];
+      int count =
+          workspace_discover_projects(ws, MAX_WORKSPACE_DEPTH, projects, MAX_DISCOVERED_PROJECTS);
+      assert(count == 1); /* discovered exactly once, not N times */
+      assert(strstr(projects[0], "router") != NULL);
+   }
+
    /* --- style_read: missing file returns NULL --- */
    {
       char *style = style_read("nonexistent-project-xyz");

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -85,8 +85,11 @@ static void discover_recursive(const char *dir, int depth, int max_depth,
       char sub[MAX_PATH_LEN];
       snprintf(sub, sizeof(sub), "%s/%s", dir, ent->d_name);
 
+      /* lstat (not stat): never follow symlinked directories. A self-referential
+       * or parent-pointing symlink (e.g. a repo's "src -> .") otherwise creates a
+       * cycle that re-discovers the same repo once per level up to max_depth. */
       struct stat st;
-      if (stat(sub, &st) != 0 || !S_ISDIR(st.st_mode))
+      if (lstat(sub, &st) != 0 || S_ISLNK(st.st_mode) || !S_ISDIR(st.st_mode))
          continue;
 
       discover_recursive(sub, depth + 1, max_depth, projects, max, count);


### PR DESCRIPTION
Promote `testing` → `main`. Includes #401: thin-client `workspace add` now ingests one project per git repo, skipping linked worktrees, symlink cycles, and generated sdks trees. Validated live on .254 (~/dev: 83k→3k files, 14 per-repo projects, 0 worktree files).