### PR TITLE
feat(curator): two-tier provider config + stage resolver (§2a)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -289,7 +289,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
-            aimee_home.c shared/kb_paths.c provider_client.c \
+            aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -71,14 +71,36 @@ static void parse_curator_provider(const cJSON *curator, const char *key, char *
       return;
    }
    const cJSON *b = cJSON_GetObjectItemCaseSensitive(p, "base_url");
-   if (b && cJSON_IsString(b) && b->valuestring)
-      snprintf(base_url, bsz, "%s", b->valuestring);
+   if (b)
+   {
+      if (!cJSON_IsString(b) || !b->valuestring)
+         config_issue("\"kb.curator.%s.base_url\" expected string, got %s", key, jo_type_name(b));
+      else
+         snprintf(base_url, bsz, "%s", b->valuestring);
+   }
    const cJSON *m = cJSON_GetObjectItemCaseSensitive(p, "model");
-   if (m && cJSON_IsString(m) && m->valuestring)
-      snprintf(model, msz, "%s", m->valuestring);
+   if (m)
+   {
+      if (!cJSON_IsString(m) || !m->valuestring)
+         config_issue("\"kb.curator.%s.model\" expected string, got %s", key, jo_type_name(m));
+      else
+         snprintf(model, msz, "%s", m->valuestring);
+   }
    const cJSON *k = cJSON_GetObjectItemCaseSensitive(p, "api_key");
-   if (k && cJSON_IsString(k) && k->valuestring)
-      snprintf(api_key, ksz, "%s", k->valuestring);
+   if (k)
+   {
+      if (!cJSON_IsString(k) || !k->valuestring)
+         config_issue("\"kb.curator.%s.api_key\" expected string, got %s", key, jo_type_name(k));
+      else
+         snprintf(api_key, ksz, "%s", k->valuestring);
+   }
+
+   /* A provider is only usable with a base_url + model; warn on a partial object
+    * (e.g. a key/model with no endpoint) so it doesn't silently resolve to idle. */
+   if (base_url[0] && !model[0])
+      config_issue("\"kb.curator.%s\" has base_url but no model (provider unusable)", key);
+   if (!base_url[0] && (model[0] || api_key[0]))
+      config_issue("\"kb.curator.%s\" set without base_url (tier stays idle)", key);
 }
 
 int config_parse_kb_curator(config_t *cfg, const cJSON *root)

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -47,8 +47,38 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_synthesize_k = 8;
    cfg->kb_curator_extract_max_tokens = 2048;
    cfg->kb_curator_max_attempts = 3;
+   cfg->kb_curator_provider_base_url[0] = '\0';
+   cfg->kb_curator_provider_model[0] = '\0';
+   cfg->kb_curator_provider_api_key[0] = '\0';
+   cfg->kb_curator_tier_b_base_url[0] = '\0';
+   cfg->kb_curator_tier_b_model[0] = '\0';
+   cfg->kb_curator_tier_b_api_key[0] = '\0';
    cfg->kb_evidence_embed_enabled = 1;
    cfg->kb_evidence_embed_batch = 32;
+}
+
+/* Parse a curator provider sub-object {base_url, model, api_key} under `curator`
+ * into the given fields. Missing keys leave the field untouched (its default). */
+static void parse_curator_provider(const cJSON *curator, const char *key, char *base_url,
+                                   size_t bsz, char *model, size_t msz, char *api_key, size_t ksz)
+{
+   const cJSON *p = cJSON_GetObjectItemCaseSensitive(curator, key);
+   if (!p)
+      return;
+   if (!cJSON_IsObject(p))
+   {
+      config_issue("\"kb.curator.%s\" expected object, got %s", key, jo_type_name(p));
+      return;
+   }
+   const cJSON *b = cJSON_GetObjectItemCaseSensitive(p, "base_url");
+   if (b && cJSON_IsString(b) && b->valuestring)
+      snprintf(base_url, bsz, "%s", b->valuestring);
+   const cJSON *m = cJSON_GetObjectItemCaseSensitive(p, "model");
+   if (m && cJSON_IsString(m) && m->valuestring)
+      snprintf(model, msz, "%s", m->valuestring);
+   const cJSON *k = cJSON_GetObjectItemCaseSensitive(p, "api_key");
+   if (k && cJSON_IsString(k) && k->valuestring)
+      snprintf(api_key, ksz, "%s", k->valuestring);
 }
 
 int config_parse_kb_curator(config_t *cfg, const cJSON *root)
@@ -222,6 +252,17 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       snprintf(cfg->kb_curator_synthesize_command, sizeof(cfg->kb_curator_synthesize_command), "%s",
                synth_command->valuestring);
 
+   /* Curator LLM providers (§2): default/Tier-A under "provider", reasoning
+    * stages under "tier_b". */
+   parse_curator_provider(curator, "provider", cfg->kb_curator_provider_base_url,
+                          sizeof(cfg->kb_curator_provider_base_url), cfg->kb_curator_provider_model,
+                          sizeof(cfg->kb_curator_provider_model), cfg->kb_curator_provider_api_key,
+                          sizeof(cfg->kb_curator_provider_api_key));
+   parse_curator_provider(curator, "tier_b", cfg->kb_curator_tier_b_base_url,
+                          sizeof(cfg->kb_curator_tier_b_base_url), cfg->kb_curator_tier_b_model,
+                          sizeof(cfg->kb_curator_tier_b_model), cfg->kb_curator_tier_b_api_key,
+                          sizeof(cfg->kb_curator_tier_b_api_key));
+
    const cJSON *max_tokens = cJSON_GetObjectItemCaseSensitive(curator, "extract_max_tokens");
    if (max_tokens)
    {
@@ -284,6 +325,24 @@ static void kb_curator_save_gate(cJSON *cur, const char *name, int enabled)
       cJSON_AddBoolToObject(o, "enabled", 1);
 }
 
+/* Inverse of parse_curator_provider: emit {base_url, model, api_key} under `name`
+ * only when at least one field is set (a clean install writes nothing). */
+static void kb_curator_save_provider(cJSON *cur, const char *name, const char *base_url,
+                                     const char *model, const char *api_key)
+{
+   if (!base_url[0] && !model[0] && !api_key[0])
+      return;
+   cJSON *p = cJSON_AddObjectToObject(cur, name);
+   if (!p)
+      return;
+   if (base_url[0])
+      cJSON_AddStringToObject(p, "base_url", base_url);
+   if (model[0])
+      cJSON_AddStringToObject(p, "model", model);
+   if (api_key[0])
+      cJSON_AddStringToObject(p, "api_key", api_key);
+}
+
 /* Serialize the kb.curator.* and kb.evidence.embed.* config back into `root`,
  * the inverse of config_parse_kb_curator. Only emitted when something differs
  * from the defaults, so a clean install writes nothing. This is what lets the
@@ -299,7 +358,10 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_extract_command[0] || cfg->kb_curator_judge_command[0] ||
        cfg->kb_curator_synthesize_command[0] || cfg->kb_curator_extract_max_tokens != 2048 ||
        cfg->kb_curator_max_attempts != 3 || cfg->kb_curator_synthesize_k != 8 ||
-       cfg->kb_curator_promote_min_sources != 3;
+       cfg->kb_curator_promote_min_sources != 3 || cfg->kb_curator_provider_base_url[0] ||
+       cfg->kb_curator_provider_model[0] || cfg->kb_curator_provider_api_key[0] ||
+       cfg->kb_curator_tier_b_base_url[0] || cfg->kb_curator_tier_b_model[0] ||
+       cfg->kb_curator_tier_b_api_key[0];
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
    if (!curator_any && !evidence_any)
       return;
@@ -355,6 +417,10 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
             cJSON_AddNumberToObject(cur, "extract_max_tokens", cfg->kb_curator_extract_max_tokens);
          if (cfg->kb_curator_max_attempts != 3)
             cJSON_AddNumberToObject(cur, "max_attempts", cfg->kb_curator_max_attempts);
+         kb_curator_save_provider(cur, "provider", cfg->kb_curator_provider_base_url,
+                                  cfg->kb_curator_provider_model, cfg->kb_curator_provider_api_key);
+         kb_curator_save_provider(cur, "tier_b", cfg->kb_curator_tier_b_base_url,
+                                  cfg->kb_curator_tier_b_model, cfg->kb_curator_tier_b_api_key);
       }
    }
 

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -330,9 +330,9 @@ typedef struct config
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */
-   int fidelity_check_enabled; /* auditable-correctness P3: run the fidelity judge on terminal-text
-                                  turns (default off; fail-closed dep on
-                                  kb_evidence_emit_enabled + ingress_preinject_enabled) */
+   int fidelity_check_enabled;   /* auditable-correctness P3: run the fidelity judge on terminal-text
+                                    turns (default off; fail-closed dep on
+                                    kb_evidence_emit_enabled + ingress_preinject_enabled) */
    int memory_pagerank_enabled;
    int memory_pagerank_iterations;
    double memory_pagerank_weight;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -330,9 +330,9 @@ typedef struct config
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */
-   int fidelity_check_enabled;   /* auditable-correctness P3: run the fidelity judge on terminal-text
-                                    turns (default off; fail-closed dep on
-                                    kb_evidence_emit_enabled + ingress_preinject_enabled) */
+   int fidelity_check_enabled; /* auditable-correctness P3: run the fidelity judge on terminal-text
+                                  turns (default off; fail-closed dep on
+                                  kb_evidence_emit_enabled + ingress_preinject_enabled) */
    int memory_pagerank_enabled;
    int memory_pagerank_iterations;
    double memory_pagerank_weight;
@@ -1265,6 +1265,23 @@ typedef struct config
    char kb_curator_extract_command[512];
    int kb_curator_extract_max_tokens;
    int kb_curator_max_attempts;
+   /* Curator LLM provider (curator-llm-backend §2), operator-owned and kb-level
+    * (the shared kb cannot borrow a per-user server's credentials). Two-tier:
+    *   provider.*  — the default / Tier-A provider (mechanical extract/index
+    *                 stages; a small grammar-constrained model suffices).
+    *   tier_b.*    — the reasoning/judge stages (judge, resolve_entities,
+    *                 detect_contradictions, synthesize, promote_entity). NO weak
+    *                 fallback: these stay idle until tier_b is configured, so a
+    *                 small model never poisons the graph.
+    * An empty base_url means that tier is unconfigured (its stages idle). The
+    * api_key is the operator deployment secret; empty => keyless local endpoint.
+    * wire is OpenAI-compatible /chat/completions (the only wire today). */
+   char kb_curator_provider_base_url[256];
+   char kb_curator_provider_model[128];
+   char kb_curator_provider_api_key[256];
+   char kb_curator_tier_b_base_url[256];
+   char kb_curator_tier_b_model[128];
+   char kb_curator_tier_b_api_key[256];
    /* judge_command: LLM sidecar that adjudicates the resolve_entities
     * [0.70, 0.85) ambiguous band (same_entity? merge : create). Empty = off;
     * with no judge configured, ambiguous mentions fall through to "create". */

--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -1,0 +1,56 @@
+/* kb_curator_provider.h: map a curator pipeline stage to its configured LLM
+ * provider (curator-llm-backend §2). Pure resolution over config_t — given a
+ * stage, classify it Tier-A (mechanical extract/index) or Tier-B (reasoning /
+ * judge) and return the provider def for that tier, or report "idle" when the
+ * tier is unconfigured. Tier-B has NO weak fallback to the Tier-A default: a
+ * small model must never run the reasoning stages (it would poison the graph). */
+#ifndef DEC_KB_CURATOR_PROVIDER_H
+#define DEC_KB_CURATOR_PROVIDER_H 1
+
+#include "config.h"          /* config_t */
+#include "provider_client.h" /* provider_def_t */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      /* Tier-A: mechanical, grammar-constrained, high-volume. */
+      KB_CURATOR_STAGE_EXTRACT_DOCS = 0,
+      KB_CURATOR_STAGE_EXTRACT_CODE,
+      KB_CURATOR_STAGE_INDEX_NARRATIVE,
+      KB_CURATOR_STAGE_INDEX_CLAIMS,
+      KB_CURATOR_STAGE_INDEX_CODE_UNIT,
+      KB_CURATOR_STAGE_LINK_ARTIFACTS,
+      /* Tier-B: reasoning over extracted content; needs a capable model. */
+      KB_CURATOR_STAGE_JUDGE,
+      KB_CURATOR_STAGE_RESOLVE_ENTITIES,
+      KB_CURATOR_STAGE_DETECT_CONTRADICTIONS,
+      KB_CURATOR_STAGE_SYNTHESIZE,
+      KB_CURATOR_STAGE_PROMOTE_ENTITY,
+   } kb_curator_stage_t;
+
+   typedef enum
+   {
+      KB_CURATOR_TIER_A = 0,
+      KB_CURATOR_TIER_B = 1,
+   } kb_curator_tier_t;
+
+   /* Which tier a stage belongs to. */
+   kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage);
+
+   /* Fill *out with the provider def for `stage`: Tier-A stages use the default
+    * `provider.*` config, Tier-B stages use `tier_b.*` (never the Tier-A default).
+    * Returns 1 when that tier is configured (out filled; base_url non-empty), 0
+    * when it is unconfigured (out zeroed — the stage must stay idle). The const
+    * char* fields in *out point into *cfg, so keep cfg alive while using *out. */
+   int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
+                                     provider_def_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_KB_CURATOR_PROVIDER_H */

--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -44,8 +44,12 @@ extern "C"
    /* Fill *out with the provider def for `stage`: Tier-A stages use the default
     * `provider.*` config, Tier-B stages use `tier_b.*` (never the Tier-A default).
     * Returns 1 when that tier is configured (out filled; base_url non-empty), 0
-    * when it is unconfigured (out zeroed — the stage must stay idle). The const
-    * char* fields in *out point into *cfg, so keep cfg alive while using *out. */
+    * when it is unconfigured (out zeroed — the stage must stay idle).
+    *
+    * Lifetime: out->base_url/model alias strings inside *cfg, so keep cfg alive
+    * (and unmodified) while using *out — the def is a borrowed view, not a copy.
+    * out->api_key is either a pointer into *cfg or NULL when no key is configured
+    * (a keyless local endpoint); provider_client treats NULL as "no bearer". */
    int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
                                      provider_def_t *out);
 

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -1,0 +1,57 @@
+/* kb_curator_provider.c: stage -> configured curator LLM provider. See header. */
+
+#include "kb_curator_provider.h"
+
+#include <string.h>
+
+kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage)
+{
+   switch (stage)
+   {
+   case KB_CURATOR_STAGE_JUDGE:
+   case KB_CURATOR_STAGE_RESOLVE_ENTITIES:
+   case KB_CURATOR_STAGE_DETECT_CONTRADICTIONS:
+   case KB_CURATOR_STAGE_SYNTHESIZE:
+   case KB_CURATOR_STAGE_PROMOTE_ENTITY:
+      return KB_CURATOR_TIER_B;
+   default:
+      return KB_CURATOR_TIER_A;
+   }
+}
+
+int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
+                                  provider_def_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (!cfg || !out)
+      return 0;
+
+   const char *base_url;
+   const char *model;
+   const char *api_key;
+   if (kb_curator_stage_tier(stage) == KB_CURATOR_TIER_B)
+   {
+      base_url = cfg->kb_curator_tier_b_base_url;
+      model = cfg->kb_curator_tier_b_model;
+      api_key = cfg->kb_curator_tier_b_api_key;
+   }
+   else
+   {
+      base_url = cfg->kb_curator_provider_base_url;
+      model = cfg->kb_curator_provider_model;
+      api_key = cfg->kb_curator_provider_api_key;
+   }
+
+   /* An empty base_url means that tier is unconfigured — the stage stays idle.
+    * Tier-B intentionally does NOT fall back to the Tier-A default. */
+   if (!base_url[0])
+      return 0;
+
+   out->base_url = base_url;
+   out->model = model;
+   out->api_key = api_key[0] ? api_key : NULL; /* keyless local endpoint => no bearer */
+   out->wire = PROVIDER_WIRE_OPENAI_CHAT;
+   out->temperature = -1.0; /* let the provider default */
+   return 1;
+}

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -8,15 +8,26 @@ kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage)
 {
    switch (stage)
    {
+   /* Tier-A: mechanical, grammar-constrained extract/index. */
+   case KB_CURATOR_STAGE_EXTRACT_DOCS:
+   case KB_CURATOR_STAGE_EXTRACT_CODE:
+   case KB_CURATOR_STAGE_INDEX_NARRATIVE:
+   case KB_CURATOR_STAGE_INDEX_CLAIMS:
+   case KB_CURATOR_STAGE_INDEX_CODE_UNIT:
+   case KB_CURATOR_STAGE_LINK_ARTIFACTS:
+      return KB_CURATOR_TIER_A;
+   /* Tier-B: reasoning / judge. */
    case KB_CURATOR_STAGE_JUDGE:
    case KB_CURATOR_STAGE_RESOLVE_ENTITIES:
    case KB_CURATOR_STAGE_DETECT_CONTRADICTIONS:
    case KB_CURATOR_STAGE_SYNTHESIZE:
    case KB_CURATOR_STAGE_PROMOTE_ENTITY:
       return KB_CURATOR_TIER_B;
-   default:
-      return KB_CURATOR_TIER_A;
    }
+   /* Fail safe: an unclassified / future stage routes to the capable tier (which
+    * simply idles when tier_b is unconfigured), NEVER silently to the small
+    * Tier-A model — a weak model on a reasoning stage poisons the graph. */
+   return KB_CURATOR_TIER_B;
 }
 
 int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -183,6 +183,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-token-tracker \
                $(TESTPREFIX)/unit-test-model-pricing \
                $(TESTPREFIX)/unit-test-provider-client \
+               $(TESTPREFIX)/unit-test-kb-curator-provider \
                $(TESTPREFIX)/unit-test-reasoning-cap \
                $(TESTPREFIX)/unit-test-request-context \
                $(TESTPREFIX)/unit-test-response-dedup \
@@ -2278,6 +2279,10 @@ $(TESTPREFIX)/unit-test-model-pricing: $(OBJDIR)/tests/test_model_pricing.o \
 $(TESTPREFIX)/unit-test-provider-client: $(OBJDIR)/tests/test_provider_client.o \
                                   $(OBJDIR)/provider_client.o $(OBJDIR)/cJSON.o \
                                   $(OBJDIR)/tests/support/mock_agent_http.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-kb-curator-provider: $(OBJDIR)/tests/test_kb_curator_provider.o \
+                                  $(OBJDIR)/kb_curator_provider.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-collab-rules: $(OBJDIR)/tests/test_collab_rules.o $(TEST_DATA_OBJS_MOCK)

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -166,6 +166,14 @@ int main(void)
       snprintf(cfg.kb_curator_judge_command, sizeof(cfg.kb_curator_judge_command), "judge --json");
       snprintf(cfg.kb_curator_synthesize_command, sizeof(cfg.kb_curator_synthesize_command),
                "synth --json");
+      /* kb.curator provider/tier_b (§2) — full provider defs must round-trip. */
+      snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+               "http://curator:8080/v1");
+      snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "gemma-4-e4b");
+      snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
+               "https://api.big/v1");
+      snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
+      snprintf(cfg.kb_curator_tier_b_api_key, sizeof(cfg.kb_curator_tier_b_api_key), "sk-secret");
       cfg.kb_evidence_embed_enabled = 0;
       /* profile_cards now defaults on; set it off to prove the disabled state
        * round-trips (regression class: a default-on bool whose save guard only
@@ -354,6 +362,11 @@ int main(void)
       assert(cfg2.kb_curator_synthesize_k == 4);
       assert(strcmp(cfg2.kb_curator_judge_command, "judge --json") == 0);
       assert(strcmp(cfg2.kb_curator_synthesize_command, "synth --json") == 0);
+      assert(strcmp(cfg2.kb_curator_provider_base_url, "http://curator:8080/v1") == 0);
+      assert(strcmp(cfg2.kb_curator_provider_model, "gemma-4-e4b") == 0);
+      assert(strcmp(cfg2.kb_curator_tier_b_base_url, "https://api.big/v1") == 0);
+      assert(strcmp(cfg2.kb_curator_tier_b_model, "big-32b") == 0);
+      assert(strcmp(cfg2.kb_curator_tier_b_api_key, "sk-secret") == 0);
       assert(cfg2.kb_evidence_embed_enabled == 0);
       assert(cfg2.memory_profile_cards_enabled == 0);
       assert(cfg2.memory_improve_dedupe_enabled == 0);

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -1,0 +1,91 @@
+/* test_kb_curator_provider.c: stage->provider resolution (curator-llm-backend §2). */
+#include "kb_curator_provider.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void test_tier_classification(void)
+{
+   /* Tier-A: mechanical extract/index. */
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_EXTRACT_DOCS) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_EXTRACT_CODE) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_INDEX_NARRATIVE) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_INDEX_CLAIMS) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_INDEX_CODE_UNIT) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_LINK_ARTIFACTS) == KB_CURATOR_TIER_A);
+   /* Tier-B: reasoning / judge. */
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_JUDGE) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_RESOLVE_ENTITIES) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_DETECT_CONTRADICTIONS) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_SYNTHESIZE) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_PROMOTE_ENTITY) == KB_CURATOR_TIER_B);
+   printf("kb_curator_provider: tier classification ok\n");
+}
+
+static void test_unconfigured_idle(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg)); /* all providers empty */
+   provider_def_t def;
+   /* Tier-A unconfigured -> idle. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &def) == 0);
+   assert(def.base_url == NULL);
+   /* Tier-B unconfigured -> idle. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &def) == 0);
+   printf("kb_curator_provider: unconfigured tiers idle ok\n");
+}
+
+static void test_tier_a_resolves(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+            "http://curator:8080/v1");
+   snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "gemma-4-e4b");
+   /* no api_key -> keyless */
+
+   provider_def_t def;
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &def) == 1);
+   assert(strcmp(def.base_url, "http://curator:8080/v1") == 0);
+   assert(strcmp(def.model, "gemma-4-e4b") == 0);
+   assert(def.api_key == NULL); /* empty key => no bearer */
+   assert(def.wire == PROVIDER_WIRE_OPENAI_CHAT);
+
+   /* Tier-B still idle (no weak fallback to the Tier-A default). */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &def) == 0);
+   printf("kb_curator_provider: tier-A resolves, tier-B no fallback ok\n");
+}
+
+static void test_tier_b_resolves(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   /* both tiers configured, distinct providers + a tier-B key */
+   snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+            "http://small:8080/v1");
+   snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "small");
+   snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
+            "https://api.big/v1");
+   snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
+   snprintf(cfg.kb_curator_tier_b_api_key, sizeof(cfg.kb_curator_tier_b_api_key), "sk-secret");
+
+   provider_def_t a, b;
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_CODE, &a) == 1);
+   assert(strcmp(a.model, "small") == 0 && a.api_key == NULL);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 1);
+   assert(strcmp(b.base_url, "https://api.big/v1") == 0);
+   assert(strcmp(b.model, "big-32b") == 0);
+   assert(b.api_key && strcmp(b.api_key, "sk-secret") == 0);
+   printf("kb_curator_provider: tier-A and tier-B resolve independently ok\n");
+}
+
+int main(void)
+{
+   test_tier_classification();
+   test_unconfigured_idle();
+   test_tier_a_resolves();
+   test_tier_b_resolves();
+   printf("kb_curator_provider: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
**§2a of curator-llm-backend** — the foundation for routing curator stages through the §1 shared provider client: operator-owned, kb-level LLM provider config + a stage→provider resolver. **No stage rewiring yet** (that's §2b); this adds the config surface and resolution the rewiring will consume.

## Why two-tier + full provider defs
The curator runs in `aimee-kb` (N user-servers : 1 shared kb), so it **cannot** borrow a per-user server's credentials — the provider is an operator/kb-level concern with its own `base_url`/`api_key`. The pipeline splits cleanly:
- **Tier-A** (mechanical, grammar-constrained extract/index) — a small model suffices.
- **Tier-B** (reasoning/judge) — needs a capable model; a weak model here **poisons the graph**.

## Changes
- **Config `kb.curator.*`** — `provider.{base_url,model,api_key}` (default / Tier-A) and `tier_b.{base_url,model,api_key}` (reasoning stages). Parsed/saved/diffed; defaults empty. Empty `base_url` ⇒ that tier is unconfigured (its stages idle); empty `api_key` ⇒ keyless local endpoint. **Tier-B has no weak fallback** to the Tier-A default.
- **`kb_curator_provider.{c,h}`** (CORE, pure over `config_t`) — `kb_curator_stage_t` (11 stages), `kb_curator_stage_tier` (6 Tier-A / 5 Tier-B per the proposal), and `kb_curator_provider_for_stage(cfg, stage, &out)` → fills a `provider_def_t` for the stage's tier or returns 0 (idle) when unconfigured.

## Verification
`make all` clean; `make lint` ok (schema-sync, clang-format, proposal-links); `unit-test-kb-curator-provider` (classification, idle-when-unset, Tier-A-resolves/Tier-B-no-fallback, independent tier resolution) + `config` / `config-surface` / `cmd-config` round-trip tests pass. Local roundtable gate run on the diff.

## Next
§2b rewires the curator stages (`kb_curator_extract`/`judge`/`synthesize`/…) to call `provider_client_complete` with the resolved def, repurposing the `kb_curator_*_command` sidecar hooks. End-to-end validation needs the live curator endpoint on .254.
