### PR TITLE
Promote testing → main: per-recall query-embedding memo (#387)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -289,7 +289,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
-            aimee_home.c shared/kb_paths.c provider_client.c \
+            aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \

--- a/src/cli_css.c
+++ b/src/cli_css.c
@@ -11,13 +11,25 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const char *const CSS_OPS[] = {
-    "dead-rules",          "conflicts",        "duplicate-declarations",
-    "duplicate-selectors", "unresolved",       "migrate-enumerate",
-    "migrate-list",        "rules-doc",        "assert-conventions",
-    "conventions",         "render-store",     "render-capture",
-    "render-verify",       "important-audit",  "high-specificity",
-    "unused-vars",         "token-candidates", NULL};
+static const char *const CSS_OPS[] = {"dead-rules",
+                                      "conflicts",
+                                      "duplicate-declarations",
+                                      "duplicate-selectors",
+                                      "unresolved",
+                                      "migrate-enumerate",
+                                      "migrate-list",
+                                      "rules-doc",
+                                      "assert-conventions",
+                                      "conventions",
+                                      "render-store",
+                                      "render-capture",
+                                      "render-verify",
+                                      "important-audit",
+                                      "high-specificity",
+                                      "unused-vars",
+                                      "token-candidates",
+                                      "report",
+                                      NULL};
 
 static int css_op_known(const char *op)
 {
@@ -33,7 +45,8 @@ static void css_usage(void)
                    "  ops: dead-rules | conflicts | duplicate-declarations |\n"
                    "       duplicate-selectors | unresolved | migrate-enumerate |\n"
                    "       migrate-list | rules-doc | assert-conventions | conventions |\n"
-                   "       important-audit | high-specificity | unused-vars | token-candidates\n"
+                   "       important-audit | high-specificity | unused-vars | token-candidates |\n"
+                   "       report  (one-shot CSS-health overview)\n"
                    "  render-store <project> <unit> <before|after> <snapshot.json>\n"
                    "  render-capture <project> <unit> <before|after> <html-file> <css-file>\n"
                    "  render-verify <project> <unit>\n");
@@ -81,6 +94,58 @@ static void css_print_results(const char *op, cJSON *resp)
    {
       cJSON *u = cJSON_GetObjectItemCaseSensitive(resp, "units");
       printf("enumerated %d migration unit(s)\n", cJSON_IsNumber(u) ? u->valueint : 0);
+      return;
+   }
+   if (strcmp(op, "report") == 0)
+   {
+      const cJSON *s = cJSON_GetObjectItemCaseSensitive(resp, "summary");
+      const cJSON *top = cJSON_GetObjectItemCaseSensitive(resp, "top");
+      const cJSON *proj = cJSON_GetObjectItemCaseSensitive(resp, "project");
+      printf("CSS health — %s\n", cJSON_IsString(proj) ? proj->valuestring : "");
+      static const char *const rows[][2] = {
+          {"dead_rules", "dead rules"},
+          {"specificity_conflicts", "specificity conflicts"},
+          {"duplicate_declarations", "duplicate declarations"},
+          {"duplicate_selectors", "duplicate selectors"},
+          {"unresolved_classes", "unresolved classes"},
+          {"high_specificity_rules", "high-specificity (id) rules"},
+          {"important_declarations", "!important declarations"},
+          {"unused_custom_properties", "unused custom properties"},
+          {"token_candidates", "token candidates"},
+          {NULL, NULL}};
+      for (int i = 0; rows[i][0]; i++)
+      {
+         const cJSON *v = cJSON_GetObjectItemCaseSensitive(s, rows[i][0]);
+         printf("  %-28s %d\n", rows[i][1], cJSON_IsNumber(v) ? v->valueint : 0);
+      }
+      const cJSON *imp = top ? cJSON_GetObjectItemCaseSensitive(top, "important") : NULL;
+      if (imp && cJSON_GetArraySize(imp) > 0)
+      {
+         printf("  top !important:");
+         const cJSON *r = NULL;
+         cJSON_ArrayForEach(r, imp)
+         {
+            const cJSON *p = cJSON_GetObjectItemCaseSensitive(r, "property");
+            const cJSON *c = cJSON_GetObjectItemCaseSensitive(r, "count");
+            printf(" %s(%d)", cJSON_IsString(p) ? p->valuestring : "?",
+                   cJSON_IsNumber(c) ? c->valueint : 0);
+         }
+         printf("\n");
+      }
+      const cJSON *tok = top ? cJSON_GetObjectItemCaseSensitive(top, "token_candidates") : NULL;
+      if (tok && cJSON_GetArraySize(tok) > 0)
+      {
+         printf("  top tokens:    ");
+         const cJSON *r = NULL;
+         cJSON_ArrayForEach(r, tok)
+         {
+            const cJSON *val = cJSON_GetObjectItemCaseSensitive(r, "value");
+            const cJSON *c = cJSON_GetObjectItemCaseSensitive(r, "count");
+            printf(" %s(%d)", cJSON_IsString(val) ? val->valuestring : "?",
+                   cJSON_IsNumber(c) ? c->valueint : 0);
+         }
+         printf("\n");
+      }
       return;
    }
    if (strcmp(op, "assert-conventions") == 0)

--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -47,8 +47,60 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_synthesize_k = 8;
    cfg->kb_curator_extract_max_tokens = 2048;
    cfg->kb_curator_max_attempts = 3;
+   cfg->kb_curator_provider_base_url[0] = '\0';
+   cfg->kb_curator_provider_model[0] = '\0';
+   cfg->kb_curator_provider_api_key[0] = '\0';
+   cfg->kb_curator_tier_b_base_url[0] = '\0';
+   cfg->kb_curator_tier_b_model[0] = '\0';
+   cfg->kb_curator_tier_b_api_key[0] = '\0';
    cfg->kb_evidence_embed_enabled = 1;
    cfg->kb_evidence_embed_batch = 32;
+}
+
+/* Parse a curator provider sub-object {base_url, model, api_key} under `curator`
+ * into the given fields. Missing keys leave the field untouched (its default). */
+static void parse_curator_provider(const cJSON *curator, const char *key, char *base_url,
+                                   size_t bsz, char *model, size_t msz, char *api_key, size_t ksz)
+{
+   const cJSON *p = cJSON_GetObjectItemCaseSensitive(curator, key);
+   if (!p)
+      return;
+   if (!cJSON_IsObject(p))
+   {
+      config_issue("\"kb.curator.%s\" expected object, got %s", key, jo_type_name(p));
+      return;
+   }
+   const cJSON *b = cJSON_GetObjectItemCaseSensitive(p, "base_url");
+   if (b)
+   {
+      if (!cJSON_IsString(b) || !b->valuestring)
+         config_issue("\"kb.curator.%s.base_url\" expected string, got %s", key, jo_type_name(b));
+      else
+         snprintf(base_url, bsz, "%s", b->valuestring);
+   }
+   const cJSON *m = cJSON_GetObjectItemCaseSensitive(p, "model");
+   if (m)
+   {
+      if (!cJSON_IsString(m) || !m->valuestring)
+         config_issue("\"kb.curator.%s.model\" expected string, got %s", key, jo_type_name(m));
+      else
+         snprintf(model, msz, "%s", m->valuestring);
+   }
+   const cJSON *k = cJSON_GetObjectItemCaseSensitive(p, "api_key");
+   if (k)
+   {
+      if (!cJSON_IsString(k) || !k->valuestring)
+         config_issue("\"kb.curator.%s.api_key\" expected string, got %s", key, jo_type_name(k));
+      else
+         snprintf(api_key, ksz, "%s", k->valuestring);
+   }
+
+   /* A provider is only usable with a base_url + model; warn on a partial object
+    * (e.g. a key/model with no endpoint) so it doesn't silently resolve to idle. */
+   if (base_url[0] && !model[0])
+      config_issue("\"kb.curator.%s\" has base_url but no model (provider unusable)", key);
+   if (!base_url[0] && (model[0] || api_key[0]))
+      config_issue("\"kb.curator.%s\" set without base_url (tier stays idle)", key);
 }
 
 int config_parse_kb_curator(config_t *cfg, const cJSON *root)
@@ -222,6 +274,17 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       snprintf(cfg->kb_curator_synthesize_command, sizeof(cfg->kb_curator_synthesize_command), "%s",
                synth_command->valuestring);
 
+   /* Curator LLM providers (§2): default/Tier-A under "provider", reasoning
+    * stages under "tier_b". */
+   parse_curator_provider(curator, "provider", cfg->kb_curator_provider_base_url,
+                          sizeof(cfg->kb_curator_provider_base_url), cfg->kb_curator_provider_model,
+                          sizeof(cfg->kb_curator_provider_model), cfg->kb_curator_provider_api_key,
+                          sizeof(cfg->kb_curator_provider_api_key));
+   parse_curator_provider(curator, "tier_b", cfg->kb_curator_tier_b_base_url,
+                          sizeof(cfg->kb_curator_tier_b_base_url), cfg->kb_curator_tier_b_model,
+                          sizeof(cfg->kb_curator_tier_b_model), cfg->kb_curator_tier_b_api_key,
+                          sizeof(cfg->kb_curator_tier_b_api_key));
+
    const cJSON *max_tokens = cJSON_GetObjectItemCaseSensitive(curator, "extract_max_tokens");
    if (max_tokens)
    {
@@ -284,6 +347,24 @@ static void kb_curator_save_gate(cJSON *cur, const char *name, int enabled)
       cJSON_AddBoolToObject(o, "enabled", 1);
 }
 
+/* Inverse of parse_curator_provider: emit {base_url, model, api_key} under `name`
+ * only when at least one field is set (a clean install writes nothing). */
+static void kb_curator_save_provider(cJSON *cur, const char *name, const char *base_url,
+                                     const char *model, const char *api_key)
+{
+   if (!base_url[0] && !model[0] && !api_key[0])
+      return;
+   cJSON *p = cJSON_AddObjectToObject(cur, name);
+   if (!p)
+      return;
+   if (base_url[0])
+      cJSON_AddStringToObject(p, "base_url", base_url);
+   if (model[0])
+      cJSON_AddStringToObject(p, "model", model);
+   if (api_key[0])
+      cJSON_AddStringToObject(p, "api_key", api_key);
+}
+
 /* Serialize the kb.curator.* and kb.evidence.embed.* config back into `root`,
  * the inverse of config_parse_kb_curator. Only emitted when something differs
  * from the defaults, so a clean install writes nothing. This is what lets the
@@ -299,7 +380,10 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_extract_command[0] || cfg->kb_curator_judge_command[0] ||
        cfg->kb_curator_synthesize_command[0] || cfg->kb_curator_extract_max_tokens != 2048 ||
        cfg->kb_curator_max_attempts != 3 || cfg->kb_curator_synthesize_k != 8 ||
-       cfg->kb_curator_promote_min_sources != 3;
+       cfg->kb_curator_promote_min_sources != 3 || cfg->kb_curator_provider_base_url[0] ||
+       cfg->kb_curator_provider_model[0] || cfg->kb_curator_provider_api_key[0] ||
+       cfg->kb_curator_tier_b_base_url[0] || cfg->kb_curator_tier_b_model[0] ||
+       cfg->kb_curator_tier_b_api_key[0];
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
    if (!curator_any && !evidence_any)
       return;
@@ -355,6 +439,10 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
             cJSON_AddNumberToObject(cur, "extract_max_tokens", cfg->kb_curator_extract_max_tokens);
          if (cfg->kb_curator_max_attempts != 3)
             cJSON_AddNumberToObject(cur, "max_attempts", cfg->kb_curator_max_attempts);
+         kb_curator_save_provider(cur, "provider", cfg->kb_curator_provider_base_url,
+                                  cfg->kb_curator_provider_model, cfg->kb_curator_provider_api_key);
+         kb_curator_save_provider(cur, "tier_b", cfg->kb_curator_tier_b_base_url,
+                                  cfg->kb_curator_tier_b_model, cfg->kb_curator_tier_b_api_key);
       }
    }
 

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1265,6 +1265,23 @@ typedef struct config
    char kb_curator_extract_command[512];
    int kb_curator_extract_max_tokens;
    int kb_curator_max_attempts;
+   /* Curator LLM provider (curator-llm-backend §2), operator-owned and kb-level
+    * (the shared kb cannot borrow a per-user server's credentials). Two-tier:
+    *   provider.*  — the default / Tier-A provider (mechanical extract/index
+    *                 stages; a small grammar-constrained model suffices).
+    *   tier_b.*    — the reasoning/judge stages (judge, resolve_entities,
+    *                 detect_contradictions, synthesize, promote_entity). NO weak
+    *                 fallback: these stay idle until tier_b is configured, so a
+    *                 small model never poisons the graph.
+    * An empty base_url means that tier is unconfigured (its stages idle). The
+    * api_key is the operator deployment secret; empty => keyless local endpoint.
+    * wire is OpenAI-compatible /chat/completions (the only wire today). */
+   char kb_curator_provider_base_url[256];
+   char kb_curator_provider_model[128];
+   char kb_curator_provider_api_key[256];
+   char kb_curator_tier_b_base_url[256];
+   char kb_curator_tier_b_model[128];
+   char kb_curator_tier_b_api_key[256];
    /* judge_command: LLM sidecar that adjudicates the resolve_entities
     * [0.70, 0.85) ambiguous band (same_entity? merge : create). Empty = off;
     * with no judge configured, ambiguous mentions fall through to "create". */

--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -1,0 +1,60 @@
+/* kb_curator_provider.h: map a curator pipeline stage to its configured LLM
+ * provider (curator-llm-backend §2). Pure resolution over config_t — given a
+ * stage, classify it Tier-A (mechanical extract/index) or Tier-B (reasoning /
+ * judge) and return the provider def for that tier, or report "idle" when the
+ * tier is unconfigured. Tier-B has NO weak fallback to the Tier-A default: a
+ * small model must never run the reasoning stages (it would poison the graph). */
+#ifndef DEC_KB_CURATOR_PROVIDER_H
+#define DEC_KB_CURATOR_PROVIDER_H 1
+
+#include "config.h"          /* config_t */
+#include "provider_client.h" /* provider_def_t */
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      /* Tier-A: mechanical, grammar-constrained, high-volume. */
+      KB_CURATOR_STAGE_EXTRACT_DOCS = 0,
+      KB_CURATOR_STAGE_EXTRACT_CODE,
+      KB_CURATOR_STAGE_INDEX_NARRATIVE,
+      KB_CURATOR_STAGE_INDEX_CLAIMS,
+      KB_CURATOR_STAGE_INDEX_CODE_UNIT,
+      KB_CURATOR_STAGE_LINK_ARTIFACTS,
+      /* Tier-B: reasoning over extracted content; needs a capable model. */
+      KB_CURATOR_STAGE_JUDGE,
+      KB_CURATOR_STAGE_RESOLVE_ENTITIES,
+      KB_CURATOR_STAGE_DETECT_CONTRADICTIONS,
+      KB_CURATOR_STAGE_SYNTHESIZE,
+      KB_CURATOR_STAGE_PROMOTE_ENTITY,
+   } kb_curator_stage_t;
+
+   typedef enum
+   {
+      KB_CURATOR_TIER_A = 0,
+      KB_CURATOR_TIER_B = 1,
+   } kb_curator_tier_t;
+
+   /* Which tier a stage belongs to. */
+   kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage);
+
+   /* Fill *out with the provider def for `stage`: Tier-A stages use the default
+    * `provider.*` config, Tier-B stages use `tier_b.*` (never the Tier-A default).
+    * Returns 1 when that tier is configured (out filled; base_url non-empty), 0
+    * when it is unconfigured (out zeroed — the stage must stay idle).
+    *
+    * Lifetime: out->base_url/model alias strings inside *cfg, so keep cfg alive
+    * (and unmodified) while using *out — the def is a borrowed view, not a copy.
+    * out->api_key is either a pointer into *cfg or NULL when no key is configured
+    * (a keyless local endpoint); provider_client treats NULL as "no bearer". */
+   int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
+                                     provider_def_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_KB_CURATOR_PROVIDER_H */

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -939,6 +939,13 @@ int memory_embed(int64_t memory_id, const char *command);
 int memory_embed_text(const char *text, const char *command, float *out, int max_dim);
 double cosine_similarity(const float *a, const float *b, int dim);
 
+/* Test hooks for the per-recall query-embedding memo (memory_core_helpers.inc).
+ * Not used in production paths; exposed so unit tests can drive the memoized
+ * runtime embed and reset the cache between cases. */
+int memory_query_embed_runtime_test(const char *text, const char *command, float *out, int max_dim);
+void memory_query_embed_cache_reset_test(void);
+void memory_query_embed_cache_stats_test(int *requests, int *misses);
+
 /* --- Effectiveness Tracking --- */
 
 typedef struct

--- a/src/kb/kb_service_css.c
+++ b/src/kb/kb_service_css.c
@@ -223,6 +223,84 @@ int kb_handle_css_signals(int fd, cJSON *req)
       cJSON_AddNumberToObject(resp, "min_count", min_count);
       return kb_send_response(fd, resp);
    }
+   if (strcmp(op, "report") == 0)
+   {
+      /* One-shot CSS-health overview: run every signal, return counts + the top
+       * few offenders per category. Read-only. */
+      const int RCAP = 2000;
+      cJSON *summary = cJSON_CreateObject();
+      cJSON *top = cJSON_CreateObject();
+#define CSS_REPORT_COUNT(key, type, fn)                                                            \
+   do                                                                                              \
+   {                                                                                               \
+      type *_h = (type *)malloc((size_t)RCAP * sizeof(type));                                      \
+      int _n = _h ? fn(project, _h, RCAP) : 0;                                                     \
+      cJSON_AddNumberToObject(summary, key, _n < 0 ? 0 : _n);                                      \
+      free(_h);                                                                                    \
+   } while (0)
+      CSS_REPORT_COUNT("dead_rules", css_dead_rule_hit_t, db2_css_dead_rules);
+      CSS_REPORT_COUNT("specificity_conflicts", css_spec_conflict_t,
+                       db2_css_graph_specificity_conflicts);
+      CSS_REPORT_COUNT("duplicate_declarations", css_dup_decl_t,
+                       db2_css_graph_duplicate_declarations);
+      CSS_REPORT_COUNT("duplicate_selectors", css_dup_selector_t,
+                       db2_css_graph_duplicate_selectors);
+      CSS_REPORT_COUNT("unresolved_classes", css_unresolved_hit_t, db2_css_component_unresolved);
+      CSS_REPORT_COUNT("high_specificity_rules", css_high_spec_t, db2_css_high_specificity);
+#undef CSS_REPORT_COUNT
+      /* !important: total declarations + top properties. */
+      {
+         css_important_t *h = (css_important_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_important_audit(project, h, RCAP) : 0;
+         int total = 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n; i++)
+         {
+            total += h[i].count;
+            if (i < 5)
+            {
+               cJSON *o = cJSON_CreateObject();
+               cJSON_AddStringToObject(o, "property", h[i].property);
+               cJSON_AddNumberToObject(o, "count", h[i].count);
+               cJSON_AddItemToArray(arr, o);
+            }
+         }
+         cJSON_AddNumberToObject(summary, "important_declarations", total);
+         cJSON_AddItemToObject(top, "important", arr);
+         free(h);
+      }
+      /* unused custom properties: count + top names. */
+      {
+         css_unused_var_t *h = (css_unused_var_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_unused_custom_properties(project, h, RCAP) : 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n && i < 5; i++)
+            cJSON_AddItemToArray(arr, cJSON_CreateString(h[i].name));
+         cJSON_AddNumberToObject(summary, "unused_custom_properties", n < 0 ? 0 : n);
+         cJSON_AddItemToObject(top, "unused_vars", arr);
+         free(h);
+      }
+      /* token candidates (>= 3 repeats): count + top values. */
+      {
+         css_token_cand_t *h = (css_token_cand_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_token_candidates(project, 3, h, RCAP) : 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n && i < 5; i++)
+         {
+            cJSON *o = cJSON_CreateObject();
+            cJSON_AddStringToObject(o, "value", h[i].value);
+            cJSON_AddStringToObject(o, "kind", h[i].kind);
+            cJSON_AddNumberToObject(o, "count", h[i].count);
+            cJSON_AddItemToArray(arr, o);
+         }
+         cJSON_AddNumberToObject(summary, "token_candidates", n < 0 ? 0 : n);
+         cJSON_AddItemToObject(top, "token_candidates", arr);
+         free(h);
+      }
+      cJSON_AddItemToObject(resp, "summary", summary);
+      cJSON_AddItemToObject(resp, "top", top);
+      return kb_send_response(fd, resp);
+   }
    if (strcmp(op, "render-store") == 0)
    {
       /* #4-full evidence ingest: a (sandboxed, out-of-process) render backend's

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -1,0 +1,68 @@
+/* kb_curator_provider.c: stage -> configured curator LLM provider. See header. */
+
+#include "kb_curator_provider.h"
+
+#include <string.h>
+
+kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage)
+{
+   switch (stage)
+   {
+   /* Tier-A: mechanical, grammar-constrained extract/index. */
+   case KB_CURATOR_STAGE_EXTRACT_DOCS:
+   case KB_CURATOR_STAGE_EXTRACT_CODE:
+   case KB_CURATOR_STAGE_INDEX_NARRATIVE:
+   case KB_CURATOR_STAGE_INDEX_CLAIMS:
+   case KB_CURATOR_STAGE_INDEX_CODE_UNIT:
+   case KB_CURATOR_STAGE_LINK_ARTIFACTS:
+      return KB_CURATOR_TIER_A;
+   /* Tier-B: reasoning / judge. */
+   case KB_CURATOR_STAGE_JUDGE:
+   case KB_CURATOR_STAGE_RESOLVE_ENTITIES:
+   case KB_CURATOR_STAGE_DETECT_CONTRADICTIONS:
+   case KB_CURATOR_STAGE_SYNTHESIZE:
+   case KB_CURATOR_STAGE_PROMOTE_ENTITY:
+      return KB_CURATOR_TIER_B;
+   }
+   /* Fail safe: an unclassified / future stage routes to the capable tier (which
+    * simply idles when tier_b is unconfigured), NEVER silently to the small
+    * Tier-A model — a weak model on a reasoning stage poisons the graph. */
+   return KB_CURATOR_TIER_B;
+}
+
+int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
+                                  provider_def_t *out)
+{
+   if (out)
+      memset(out, 0, sizeof(*out));
+   if (!cfg || !out)
+      return 0;
+
+   const char *base_url;
+   const char *model;
+   const char *api_key;
+   if (kb_curator_stage_tier(stage) == KB_CURATOR_TIER_B)
+   {
+      base_url = cfg->kb_curator_tier_b_base_url;
+      model = cfg->kb_curator_tier_b_model;
+      api_key = cfg->kb_curator_tier_b_api_key;
+   }
+   else
+   {
+      base_url = cfg->kb_curator_provider_base_url;
+      model = cfg->kb_curator_provider_model;
+      api_key = cfg->kb_curator_provider_api_key;
+   }
+
+   /* An empty base_url means that tier is unconfigured — the stage stays idle.
+    * Tier-B intentionally does NOT fall back to the Tier-A default. */
+   if (!base_url[0])
+      return 0;
+
+   out->base_url = base_url;
+   out->model = model;
+   out->api_key = api_key[0] ? api_key : NULL; /* keyless local endpoint => no bearer */
+   out->wire = PROVIDER_WIRE_OPENAI_CHAT;
+   out->temperature = -1.0; /* let the provider default */
+   return 1;
+}

--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1696,18 +1696,114 @@ static const char *memory_effective_embedding_cmd(const char *command)
    return (command && command[0]) ? command : "builtin";
 }
 
+/* Per-recall query-embedding memo.
+ *
+ * A single memory_find_facts() embeds the *same* query text once per retrieval
+ * lane (unit-semantic, memory-semantic, summary/fact lanes), and the whole
+ * candidate generator re-runs per HyDE pass and per decomposition sub-query.
+ * Every embed forks a subprocess and round-trips to the embedder, so embedding
+ * identical text repeatedly dominates recall latency. This thread-local memo
+ * embeds each distinct (command,text) once for the duration of a recall and
+ * serves the cached vector to the other lanes. Embedding is deterministic for a
+ * given (command,text), so a cache hit is byte-identical to a fresh embed.
+ *
+ * Reset at each top-level recall entry point. Bounded so a pathological query
+ * (many distinct sub-queries) can't grow it without limit; an overflow or an
+ * over-long key simply falls through to a fresh embed (correct, just no reuse). */
+enum
+{
+   MEMORY_QEMBED_CAP = 32,
+   MEMORY_QEMBED_TEXT_MAX = 1024,
+   MEMORY_QEMBED_CMD_MAX = 512
+};
+
+typedef struct
+{
+   char command[MEMORY_QEMBED_CMD_MAX];
+   char text[MEMORY_QEMBED_TEXT_MAX];
+   float vec[EMBED_MAX_DIM];
+   int dim;
+} memory_qembed_entry_t;
+
+static __thread int s_qembed_count = 0;
+static __thread memory_qembed_entry_t s_qembed[MEMORY_QEMBED_CAP];
+
+/* Per-recall counters: total runtime embed requests vs cache misses (= real
+ * embedder invocations). requests-minus-misses is the work the memo saved. */
+static __thread int s_qembed_requests = 0;
+static __thread int s_qembed_misses = 0;
+
+/* Begin a fresh per-recall memo window. Call at every top-level recall entry
+ * point before any lane embeds the query. */
+static void memory_query_embed_cache_reset(void)
+{
+   s_qembed_count = 0;
+   s_qembed_requests = 0;
+   s_qembed_misses = 0;
+}
+
 static int memory_embed_text_runtime(const char *text, const char *command, float *out, int max_dim)
 {
    const char *effective_cmd = memory_effective_embedding_cmd(command);
-   int dim = memory_embed_text(text, effective_cmd, out, max_dim);
-   if (dim > 0)
-      return dim;
-   if (strcmp(effective_cmd, "builtin") == 0)
-      return 0;
+   s_qembed_requests++;
 
-   aimee_log(LOG_WARN, "memory",
-             "query embedding failed for configured command; retrying with builtin embeddings");
-   return memory_embed_text(text, "builtin", out, max_dim);
+   /* Cacheable only when both keys fit their buffers (so a stored key is exact,
+    * never a truncated prefix that could false-match a different query). */
+   int cacheable = text && command && strlen(text) < MEMORY_QEMBED_TEXT_MAX &&
+                   strlen(effective_cmd) < MEMORY_QEMBED_CMD_MAX;
+
+   if (cacheable)
+   {
+      for (int i = 0; i < s_qembed_count; i++)
+      {
+         if (s_qembed[i].dim > 0 && s_qembed[i].dim <= max_dim &&
+             strcmp(s_qembed[i].command, effective_cmd) == 0 && strcmp(s_qembed[i].text, text) == 0)
+         {
+            memcpy(out, s_qembed[i].vec, (size_t)s_qembed[i].dim * sizeof(float));
+            return s_qembed[i].dim;
+         }
+      }
+   }
+
+   s_qembed_misses++;
+   int dim = memory_embed_text(text, effective_cmd, out, max_dim);
+   if (dim <= 0 && strcmp(effective_cmd, "builtin") != 0)
+   {
+      aimee_log(LOG_WARN, "memory",
+                "query embedding failed for configured command; retrying with builtin embeddings");
+      dim = memory_embed_text(text, "builtin", out, max_dim);
+   }
+
+   /* Store on the way out so the other lanes / sub-queries of this same recall
+    * reuse the vector instead of re-spawning the embedder. */
+   if (cacheable && dim > 0 && dim <= EMBED_MAX_DIM && s_qembed_count < MEMORY_QEMBED_CAP)
+   {
+      memory_qembed_entry_t *e = &s_qembed[s_qembed_count++];
+      snprintf(e->command, sizeof(e->command), "%s", effective_cmd);
+      snprintf(e->text, sizeof(e->text), "%s", text);
+      memcpy(e->vec, out, (size_t)dim * sizeof(float));
+      e->dim = dim;
+   }
+   return dim;
+}
+
+/* Test hooks (declared in memory.h) — expose the static memo to unit tests. */
+int memory_query_embed_runtime_test(const char *text, const char *command, float *out, int max_dim)
+{
+   return memory_embed_text_runtime(text, command, out, max_dim);
+}
+
+void memory_query_embed_cache_stats_test(int *requests, int *misses)
+{
+   if (requests)
+      *requests = s_qembed_requests;
+   if (misses)
+      *misses = s_qembed_misses;
+}
+
+void memory_query_embed_cache_reset_test(void)
+{
+   memory_query_embed_cache_reset();
 }
 
 static int memory_semantic_query_unavailable(void)

--- a/src/memory_core_scope_embed.inc
+++ b/src/memory_core_scope_embed.inc
@@ -366,6 +366,7 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
       return 0;
    }
 
+   int emitted = cJSON_GetArraySize(arr);
    int dim = 0;
    cJSON *el;
    cJSON_ArrayForEach(el, arr)
@@ -376,6 +377,16 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
          out[dim++] = (float)el->valuedouble;
    }
    cJSON_Delete(arr);
+   /* Guard against silent truncation: if the embedder emits more dimensions
+    * than the buffer holds we keep only the first max_dim, which leaves the
+    * stored/query vectors inconsistent with the model's real output and quietly
+    * degrades recall. Warn loudly so an operator raises EMBED_MAX_DIM (and
+    * re-embeds) rather than chasing phantom recall regressions. */
+   if (emitted > max_dim)
+      aimee_log(LOG_WARN, "memory",
+                "embedding truncated: model emitted %d dims > EMBED_MAX_DIM %d; recall degraded "
+                "-- raise EMBED_MAX_DIM and re-embed",
+                emitted, max_dim);
    return dim;
 }
 

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -3976,6 +3976,11 @@ int memory_find_facts_scoped(const char *query, const char *scope_type, const ch
    if (!query || !query[0])
       return 0;
 
+   /* Fresh query-embedding memo for this recall: every lane / HyDE pass /
+    * sub-query below embeds via memory_embed_text_runtime, which reuses vectors
+    * cached here instead of re-spawning the embedder for identical text. */
+   memory_query_embed_cache_reset();
+
    /* Aggregation route — detects "coverage" queries ("list all X", "every
     * Y", "what Xs has ENTITY Ved") and dispatches to memory_aggregate()
     * instead of the hybrid vector path. Runs before the vector readiness
@@ -4344,6 +4349,8 @@ int memory_find_facts_visible(const char *query, const char *workspace, const ch
 {
    if (!query || !query[0])
       return 0;
+   /* Fresh query-embedding memo for this recall (see memory_find_facts_scoped). */
+   memory_query_embed_cache_reset();
    if (!memory_vector_ready())
       return memory_find_facts_visible_lexical_fallback(query, workspace, project, limit, out, max);
    if (limit <= 0)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -183,6 +183,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-token-tracker \
                $(TESTPREFIX)/unit-test-model-pricing \
                $(TESTPREFIX)/unit-test-provider-client \
+               $(TESTPREFIX)/unit-test-kb-curator-provider \
                $(TESTPREFIX)/unit-test-reasoning-cap \
                $(TESTPREFIX)/unit-test-request-context \
                $(TESTPREFIX)/unit-test-response-dedup \
@@ -2290,6 +2291,10 @@ $(TESTPREFIX)/unit-test-model-pricing: $(OBJDIR)/tests/test_model_pricing.o \
 $(TESTPREFIX)/unit-test-provider-client: $(OBJDIR)/tests/test_provider_client.o \
                                   $(OBJDIR)/provider_client.o $(OBJDIR)/cJSON.o \
                                   $(OBJDIR)/tests/support/mock_agent_http.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-kb-curator-provider: $(OBJDIR)/tests/test_kb_curator_provider.o \
+                                  $(OBJDIR)/kb_curator_provider.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-collab-rules: $(OBJDIR)/tests/test_collab_rules.o $(TEST_DATA_OBJS_MOCK)

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -166,6 +166,14 @@ int main(void)
       snprintf(cfg.kb_curator_judge_command, sizeof(cfg.kb_curator_judge_command), "judge --json");
       snprintf(cfg.kb_curator_synthesize_command, sizeof(cfg.kb_curator_synthesize_command),
                "synth --json");
+      /* kb.curator provider/tier_b (§2) — full provider defs must round-trip. */
+      snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+               "http://curator:8080/v1");
+      snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "gemma-4-e4b");
+      snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
+               "https://api.big/v1");
+      snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
+      snprintf(cfg.kb_curator_tier_b_api_key, sizeof(cfg.kb_curator_tier_b_api_key), "sk-secret");
       cfg.kb_evidence_embed_enabled = 0;
       /* profile_cards now defaults on; set it off to prove the disabled state
        * round-trips (regression class: a default-on bool whose save guard only
@@ -354,6 +362,11 @@ int main(void)
       assert(cfg2.kb_curator_synthesize_k == 4);
       assert(strcmp(cfg2.kb_curator_judge_command, "judge --json") == 0);
       assert(strcmp(cfg2.kb_curator_synthesize_command, "synth --json") == 0);
+      assert(strcmp(cfg2.kb_curator_provider_base_url, "http://curator:8080/v1") == 0);
+      assert(strcmp(cfg2.kb_curator_provider_model, "gemma-4-e4b") == 0);
+      assert(strcmp(cfg2.kb_curator_tier_b_base_url, "https://api.big/v1") == 0);
+      assert(strcmp(cfg2.kb_curator_tier_b_model, "big-32b") == 0);
+      assert(strcmp(cfg2.kb_curator_tier_b_api_key, "sk-secret") == 0);
       assert(cfg2.kb_evidence_embed_enabled == 0);
       assert(cfg2.memory_profile_cards_enabled == 0);
       assert(cfg2.memory_improve_dedupe_enabled == 0);

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -1,0 +1,91 @@
+/* test_kb_curator_provider.c: stage->provider resolution (curator-llm-backend §2). */
+#include "kb_curator_provider.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+static void test_tier_classification(void)
+{
+   /* Tier-A: mechanical extract/index. */
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_EXTRACT_DOCS) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_EXTRACT_CODE) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_INDEX_NARRATIVE) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_INDEX_CLAIMS) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_INDEX_CODE_UNIT) == KB_CURATOR_TIER_A);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_LINK_ARTIFACTS) == KB_CURATOR_TIER_A);
+   /* Tier-B: reasoning / judge. */
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_JUDGE) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_RESOLVE_ENTITIES) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_DETECT_CONTRADICTIONS) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_SYNTHESIZE) == KB_CURATOR_TIER_B);
+   assert(kb_curator_stage_tier(KB_CURATOR_STAGE_PROMOTE_ENTITY) == KB_CURATOR_TIER_B);
+   printf("kb_curator_provider: tier classification ok\n");
+}
+
+static void test_unconfigured_idle(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg)); /* all providers empty */
+   provider_def_t def;
+   /* Tier-A unconfigured -> idle. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &def) == 0);
+   assert(def.base_url == NULL);
+   /* Tier-B unconfigured -> idle. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &def) == 0);
+   printf("kb_curator_provider: unconfigured tiers idle ok\n");
+}
+
+static void test_tier_a_resolves(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+            "http://curator:8080/v1");
+   snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "gemma-4-e4b");
+   /* no api_key -> keyless */
+
+   provider_def_t def;
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &def) == 1);
+   assert(strcmp(def.base_url, "http://curator:8080/v1") == 0);
+   assert(strcmp(def.model, "gemma-4-e4b") == 0);
+   assert(def.api_key == NULL); /* empty key => no bearer */
+   assert(def.wire == PROVIDER_WIRE_OPENAI_CHAT);
+
+   /* Tier-B still idle (no weak fallback to the Tier-A default). */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &def) == 0);
+   printf("kb_curator_provider: tier-A resolves, tier-B no fallback ok\n");
+}
+
+static void test_tier_b_resolves(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   /* both tiers configured, distinct providers + a tier-B key */
+   snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+            "http://small:8080/v1");
+   snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "small");
+   snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
+            "https://api.big/v1");
+   snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
+   snprintf(cfg.kb_curator_tier_b_api_key, sizeof(cfg.kb_curator_tier_b_api_key), "sk-secret");
+
+   provider_def_t a, b;
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_CODE, &a) == 1);
+   assert(strcmp(a.model, "small") == 0 && a.api_key == NULL);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 1);
+   assert(strcmp(b.base_url, "https://api.big/v1") == 0);
+   assert(strcmp(b.model, "big-32b") == 0);
+   assert(b.api_key && strcmp(b.api_key, "sk-secret") == 0);
+   printf("kb_curator_provider: tier-A and tier-B resolve independently ok\n");
+}
+
+int main(void)
+{
+   test_tier_classification();
+   test_unconfigured_idle();
+   test_tier_a_resolves();
+   test_tier_b_resolves();
+   printf("kb_curator_provider: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -459,6 +459,87 @@ static void test_audit_provenance_emit_captures_version(void)
    printf("  audit provenance emit captures point-in-time version OK\n");
 }
 
+static long qembed_file_size(const char *path)
+{
+   struct stat st;
+   return stat(path, &st) == 0 ? (long)st.st_size : -1;
+}
+
+/* Per-recall query-embedding memo: an identical (command,text) embeds once and
+ * is served from the thread-local cache on the recall's other lanes/sub-queries;
+ * the memo clears at each recall entry. The "embedder" command records one byte
+ * per real invocation, so the counter file size == number of cache misses. */
+static void test_query_embedding_memo_dedupes_embeds(void)
+{
+   memory_test_ensure_env();
+
+   char counter[512];
+   snprintf(counter, sizeof(counter), "%s/aimee-qembed-counter-XXXXXX", platform_tmpdir());
+   int fd = platform_mkstemp(counter, sizeof(counter), "aim");
+   assert(fd >= 0);
+   close(fd);
+
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd), "printf x >> '%s'; printf '[1.5, 2.5, 3.5, 4.5]'", counter);
+
+   float a[EMBED_MAX_DIM], b[EMBED_MAX_DIM], c[EMBED_MAX_DIM];
+
+   memory_query_embed_cache_reset_test();
+
+   int da = memory_query_embed_runtime_test("alpha query", cmd, a, EMBED_MAX_DIM);
+   assert(da == 4);
+   assert(a[0] == 1.5f && a[3] == 4.5f);
+   assert(qembed_file_size(counter) == 1); /* one real embed */
+
+   /* Same text → served from cache: no new subprocess, byte-identical vector. */
+   int db = memory_query_embed_runtime_test("alpha query", cmd, b, EMBED_MAX_DIM);
+   assert(db == 4);
+   assert(memcmp(a, b, 4 * sizeof(float)) == 0);
+   assert(qembed_file_size(counter) == 1); /* still one embed */
+
+   /* Different text → cache miss → a second embed. */
+   int dc = memory_query_embed_runtime_test("beta query", cmd, c, EMBED_MAX_DIM);
+   assert(dc == 4);
+   assert(qembed_file_size(counter) == 2);
+
+   /* Reset (new recall window) clears the memo → the first text embeds again. */
+   memory_query_embed_cache_reset_test();
+   int dd = memory_query_embed_runtime_test("alpha query", cmd, a, EMBED_MAX_DIM);
+   assert(dd == 4);
+   assert(qembed_file_size(counter) == 3);
+
+   unlink(counter);
+   printf("test_query_embedding_memo_dedupes_embeds: PASS\n");
+}
+
+/* Measurement (not a pass/fail gate): run a real recall and report how many
+ * embed requests the lanes/sub-queries made vs how many actually hit the
+ * embedder, so the per-recall dedup factor is visible. */
+static void measure_query_embedding_memo_recall(void)
+{
+   setup();
+   memory_t a, b;
+   memory_insert(TIER_L2, KIND_DECISION, "transport decision",
+                 "The team chose server sent events for live frontend updates.", 0.92, "s1", &a);
+   memory_insert(TIER_L2, KIND_FACT, "frontend architecture",
+                 "Frontend network architecture uses an event stream transport layer.", 0.87, "s1",
+                 &b);
+
+   memory_t results[8];
+   (void)memory_find_facts(
+       "did we decide to use sse or websockets for the frontend network architecture last week", 5,
+       results, 8);
+
+   int requests = 0, misses = 0;
+   memory_query_embed_cache_stats_test(&requests, &misses);
+   printf("MEASURE query-embed memo (one recall): requests=%d misses=%d saved=%d (%.0f%% fewer "
+          "embeds)\n",
+          requests, misses, requests - misses,
+          requests > 0 ? 100.0 * (requests - misses) / requests : 0.0);
+   assert(requests >= misses);
+   teardown();
+}
+
 int main(void)
 {
    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
@@ -473,6 +554,8 @@ int main(void)
    assert(platform_setenv("AIMEE_NO_CACHE", "1") == 0);
 
    test_db1_runtime_state_add_int();
+   test_query_embedding_memo_dedupes_embeds();
+   measure_query_embedding_memo_recall();
    test_insert_memory();
    test_insert_merge();
    test_touch_memory();


### PR DESCRIPTION
Promote testing → main. #387: per-recall query-embedding memo (embed each distinct query text once per recall instead of per lane) + over-cap embedding-truncation guard. ~54% fewer embeds per recall (measured); behavior-preserving.