### PR TITLE
feat(css): one-shot 'aimee css report' health overview

### DIFF
--- a/src/cli_css.c
+++ b/src/cli_css.c
@@ -11,13 +11,25 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const char *const CSS_OPS[] = {
-    "dead-rules",          "conflicts",        "duplicate-declarations",
-    "duplicate-selectors", "unresolved",       "migrate-enumerate",
-    "migrate-list",        "rules-doc",        "assert-conventions",
-    "conventions",         "render-store",     "render-capture",
-    "render-verify",       "important-audit",  "high-specificity",
-    "unused-vars",         "token-candidates", NULL};
+static const char *const CSS_OPS[] = {"dead-rules",
+                                      "conflicts",
+                                      "duplicate-declarations",
+                                      "duplicate-selectors",
+                                      "unresolved",
+                                      "migrate-enumerate",
+                                      "migrate-list",
+                                      "rules-doc",
+                                      "assert-conventions",
+                                      "conventions",
+                                      "render-store",
+                                      "render-capture",
+                                      "render-verify",
+                                      "important-audit",
+                                      "high-specificity",
+                                      "unused-vars",
+                                      "token-candidates",
+                                      "report",
+                                      NULL};
 
 static int css_op_known(const char *op)
 {
@@ -33,7 +45,8 @@ static void css_usage(void)
                    "  ops: dead-rules | conflicts | duplicate-declarations |\n"
                    "       duplicate-selectors | unresolved | migrate-enumerate |\n"
                    "       migrate-list | rules-doc | assert-conventions | conventions |\n"
-                   "       important-audit | high-specificity | unused-vars | token-candidates\n"
+                   "       important-audit | high-specificity | unused-vars | token-candidates |\n"
+                   "       report  (one-shot CSS-health overview)\n"
                    "  render-store <project> <unit> <before|after> <snapshot.json>\n"
                    "  render-capture <project> <unit> <before|after> <html-file> <css-file>\n"
                    "  render-verify <project> <unit>\n");
@@ -81,6 +94,58 @@ static void css_print_results(const char *op, cJSON *resp)
    {
       cJSON *u = cJSON_GetObjectItemCaseSensitive(resp, "units");
       printf("enumerated %d migration unit(s)\n", cJSON_IsNumber(u) ? u->valueint : 0);
+      return;
+   }
+   if (strcmp(op, "report") == 0)
+   {
+      const cJSON *s = cJSON_GetObjectItemCaseSensitive(resp, "summary");
+      const cJSON *top = cJSON_GetObjectItemCaseSensitive(resp, "top");
+      const cJSON *proj = cJSON_GetObjectItemCaseSensitive(resp, "project");
+      printf("CSS health — %s\n", cJSON_IsString(proj) ? proj->valuestring : "");
+      static const char *const rows[][2] = {
+          {"dead_rules", "dead rules"},
+          {"specificity_conflicts", "specificity conflicts"},
+          {"duplicate_declarations", "duplicate declarations"},
+          {"duplicate_selectors", "duplicate selectors"},
+          {"unresolved_classes", "unresolved classes"},
+          {"high_specificity_rules", "high-specificity (id) rules"},
+          {"important_declarations", "!important declarations"},
+          {"unused_custom_properties", "unused custom properties"},
+          {"token_candidates", "token candidates"},
+          {NULL, NULL}};
+      for (int i = 0; rows[i][0]; i++)
+      {
+         const cJSON *v = cJSON_GetObjectItemCaseSensitive(s, rows[i][0]);
+         printf("  %-28s %d\n", rows[i][1], cJSON_IsNumber(v) ? v->valueint : 0);
+      }
+      const cJSON *imp = top ? cJSON_GetObjectItemCaseSensitive(top, "important") : NULL;
+      if (imp && cJSON_GetArraySize(imp) > 0)
+      {
+         printf("  top !important:");
+         const cJSON *r = NULL;
+         cJSON_ArrayForEach(r, imp)
+         {
+            const cJSON *p = cJSON_GetObjectItemCaseSensitive(r, "property");
+            const cJSON *c = cJSON_GetObjectItemCaseSensitive(r, "count");
+            printf(" %s(%d)", cJSON_IsString(p) ? p->valuestring : "?",
+                   cJSON_IsNumber(c) ? c->valueint : 0);
+         }
+         printf("\n");
+      }
+      const cJSON *tok = top ? cJSON_GetObjectItemCaseSensitive(top, "token_candidates") : NULL;
+      if (tok && cJSON_GetArraySize(tok) > 0)
+      {
+         printf("  top tokens:    ");
+         const cJSON *r = NULL;
+         cJSON_ArrayForEach(r, tok)
+         {
+            const cJSON *val = cJSON_GetObjectItemCaseSensitive(r, "value");
+            const cJSON *c = cJSON_GetObjectItemCaseSensitive(r, "count");
+            printf(" %s(%d)", cJSON_IsString(val) ? val->valuestring : "?",
+                   cJSON_IsNumber(c) ? c->valueint : 0);
+         }
+         printf("\n");
+      }
       return;
    }
    if (strcmp(op, "assert-conventions") == 0)

--- a/src/kb/kb_service_css.c
+++ b/src/kb/kb_service_css.c
@@ -223,6 +223,84 @@ int kb_handle_css_signals(int fd, cJSON *req)
       cJSON_AddNumberToObject(resp, "min_count", min_count);
       return kb_send_response(fd, resp);
    }
+   if (strcmp(op, "report") == 0)
+   {
+      /* One-shot CSS-health overview: run every signal, return counts + the top
+       * few offenders per category. Read-only. */
+      const int RCAP = 2000;
+      cJSON *summary = cJSON_CreateObject();
+      cJSON *top = cJSON_CreateObject();
+#define CSS_REPORT_COUNT(key, type, fn)                                                            \
+   do                                                                                              \
+   {                                                                                               \
+      type *_h = (type *)malloc((size_t)RCAP * sizeof(type));                                      \
+      int _n = _h ? fn(project, _h, RCAP) : 0;                                                     \
+      cJSON_AddNumberToObject(summary, key, _n < 0 ? 0 : _n);                                      \
+      free(_h);                                                                                    \
+   } while (0)
+      CSS_REPORT_COUNT("dead_rules", css_dead_rule_hit_t, db2_css_dead_rules);
+      CSS_REPORT_COUNT("specificity_conflicts", css_spec_conflict_t,
+                       db2_css_graph_specificity_conflicts);
+      CSS_REPORT_COUNT("duplicate_declarations", css_dup_decl_t,
+                       db2_css_graph_duplicate_declarations);
+      CSS_REPORT_COUNT("duplicate_selectors", css_dup_selector_t,
+                       db2_css_graph_duplicate_selectors);
+      CSS_REPORT_COUNT("unresolved_classes", css_unresolved_hit_t, db2_css_component_unresolved);
+      CSS_REPORT_COUNT("high_specificity_rules", css_high_spec_t, db2_css_high_specificity);
+#undef CSS_REPORT_COUNT
+      /* !important: total declarations + top properties. */
+      {
+         css_important_t *h = (css_important_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_important_audit(project, h, RCAP) : 0;
+         int total = 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n; i++)
+         {
+            total += h[i].count;
+            if (i < 5)
+            {
+               cJSON *o = cJSON_CreateObject();
+               cJSON_AddStringToObject(o, "property", h[i].property);
+               cJSON_AddNumberToObject(o, "count", h[i].count);
+               cJSON_AddItemToArray(arr, o);
+            }
+         }
+         cJSON_AddNumberToObject(summary, "important_declarations", total);
+         cJSON_AddItemToObject(top, "important", arr);
+         free(h);
+      }
+      /* unused custom properties: count + top names. */
+      {
+         css_unused_var_t *h = (css_unused_var_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_unused_custom_properties(project, h, RCAP) : 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n && i < 5; i++)
+            cJSON_AddItemToArray(arr, cJSON_CreateString(h[i].name));
+         cJSON_AddNumberToObject(summary, "unused_custom_properties", n < 0 ? 0 : n);
+         cJSON_AddItemToObject(top, "unused_vars", arr);
+         free(h);
+      }
+      /* token candidates (>= 3 repeats): count + top values. */
+      {
+         css_token_cand_t *h = (css_token_cand_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_token_candidates(project, 3, h, RCAP) : 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n && i < 5; i++)
+         {
+            cJSON *o = cJSON_CreateObject();
+            cJSON_AddStringToObject(o, "value", h[i].value);
+            cJSON_AddStringToObject(o, "kind", h[i].kind);
+            cJSON_AddNumberToObject(o, "count", h[i].count);
+            cJSON_AddItemToArray(arr, o);
+         }
+         cJSON_AddNumberToObject(summary, "token_candidates", n < 0 ? 0 : n);
+         cJSON_AddItemToObject(top, "token_candidates", arr);
+         free(h);
+      }
+      cJSON_AddItemToObject(resp, "summary", summary);
+      cJSON_AddItemToObject(resp, "top", top);
+      return kb_send_response(fd, resp);
+   }
    if (strcmp(op, "render-store") == 0)
    {
       /* #4-full evidence ingest: a (sandboxed, out-of-process) render backend's


### PR DESCRIPTION
## Summary
Adds a capstone `aimee css report <project>` op that aggregates every read-only CSS analysis signal into one dashboard, so the user can get a whole-project CSS health snapshot in a single call instead of running nine separate ops.

Categories surfaced (all read-only):
- dead rules, specificity conflicts, duplicate declarations, duplicate selectors
- unresolved classes, high-specificity (id) rules
- !important declarations (total + top properties)
- unused custom properties (count + top names)
- design-token candidates (repeated colors/lengths, count + top values)

## Implementation
- **KB** (`kb_service_css.c`): new `report` op on the existing `POST /v1/css/signals` route — no new route. Runs each existing signal function, returns `summary` (counts) + `top` (top-5 offenders for !important / unused-vars / token-candidates).
- **CLI** (`cli_css.c`): `aimee css report <project>` renders an aligned dashboard with the top !important properties and token candidates.

No new DB2 functions — pure aggregation over already-tested signals (`db2_css_*`).

## Testing
- `make all` green
- `unit-test-css-insights` green (underlying signals)
- format / line-limit / build-integrity gates green

Read-only; default-off-gated behind the existing `css_style_graph_enabled` + populated style graph like the rest of the CSS assistant.