### PR TITLE
memory: batch query-variant embeds into one embedder call per recall

### DIFF
--- a/scripts/embed-remote.py
+++ b/scripts/embed-remote.py
@@ -28,36 +28,54 @@ ENDPOINT = os.environ.get("AIMEE_EMBEDDER_URL", "http://embedder:8080").rstrip("
 TIMEOUT = int(os.environ.get("AIMEE_EMBEDDER_TIMEOUT", "30"))
 
 
+def _post(path: str, data: bytes, content_type: str) -> str:
+    req = urllib.request.Request(
+        f"{ENDPOINT}{path}", data=data, headers={"content-type": content_type}, method="POST"
+    )
+    with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
+        return resp.read().decode("utf-8")
+
+
 def main() -> None:
-    text = sys.stdin.read()
-    if not text.strip():
+    raw = sys.stdin.read()
+    if not raw.strip():
         sys.stderr.write("embed-remote: empty input\n")
         sys.exit(1)
 
-    req = urllib.request.Request(
-        f"{ENDPOINT}/embed",
-        data=text.encode("utf-8"),
-        headers={"content-type": "text/plain; charset=utf-8"},
-        method="POST",
-    )
+    # Batch mode: a JSON array of strings on stdin -> /embed_batch -> JSON array
+    # of vectors (one per input). Anything else is one raw text -> /embed -> one
+    # vector. (The C single-embed path always sends raw text, so it is unaffected.)
+    batch_texts = None
+    if raw.lstrip()[:1] == "[":
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list) and all(isinstance(t, str) for t in parsed):
+                batch_texts = parsed
+        except json.JSONDecodeError:
+            batch_texts = None
+
     try:
-        with urllib.request.urlopen(req, timeout=TIMEOUT) as resp:
-            body = resp.read().decode("utf-8")
+        if batch_texts is not None:
+            body = _post(
+                "/embed_batch", json.dumps(batch_texts).encode("utf-8"), "application/json"
+            )
+        else:
+            body = _post("/embed", raw.encode("utf-8"), "text/plain; charset=utf-8")
     except urllib.error.URLError as exc:
         sys.stderr.write(f"embed-remote: request to {ENDPOINT} failed: {exc}\n")
         sys.exit(1)
 
     try:
-        vec = json.loads(body)
+        out = json.loads(body)
     except json.JSONDecodeError as exc:
         sys.stderr.write(f"embed-remote: bad response: {exc}: {body[:200]}\n")
         sys.exit(1)
 
-    if not isinstance(vec, list):
+    if not isinstance(out, list):
         sys.stderr.write(f"embed-remote: expected a JSON array, got {body[:200]}\n")
         sys.exit(1)
 
-    json.dump(vec, sys.stdout)
+    json.dump(out, sys.stdout)
     sys.stdout.write("\n")
 
 

--- a/scripts/embedder-server.py
+++ b/scripts/embedder-server.py
@@ -167,6 +167,18 @@ def embed(text: str):
     return vec.tolist()
 
 
+def embed_batch(texts):
+    """Embed a list of texts in one batched model.encode() call — one HTTP
+    round-trip and one batched inference instead of N separate /embed calls.
+    Returns a list of float vectors aligned 1:1 with `texts`."""
+    if EMBEDDER_STUB:
+        return [_stub_embed(t) for t in texts]
+    if not texts:
+        return []
+    vecs = _model.encode(list(texts), normalize_embeddings=True)
+    return [v.tolist() for v in vecs]
+
+
 def rerank(pairs):
     """pairs: [[query, candidate], ...] -> [score, ...] (one cross-encoder score
     per pair, higher = more relevant). Matches the aimee memory_rerank_command
@@ -219,7 +231,7 @@ class Handler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         path = self.path.rstrip("/")
-        if path not in ("/embed", "/rerank"):
+        if path not in ("/embed", "/embed_batch", "/rerank"):
             self._send(404, {"error": "not found"})
             return
         # Refuse work until the model is loaded — never serve against a not-yet-
@@ -233,6 +245,16 @@ class Handler(BaseHTTPRequestHandler):
             try:
                 pairs = json.loads(raw.decode("utf-8", errors="replace") or "[]")
                 self._send(200, rerank(pairs))
+            except Exception as exc:  # noqa: BLE001
+                self._send(500, {"error": str(exc)})
+            return
+        if path == "/embed_batch":
+            try:
+                texts = json.loads(raw.decode("utf-8", errors="replace") or "[]")
+                if not isinstance(texts, list):
+                    self._send(400, {"error": "embed_batch expects a JSON array of strings"})
+                    return
+                self._send(200, embed_batch(texts))
             except Exception as exc:  # noqa: BLE001
                 self._send(500, {"error": str(exc)})
             return

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -945,6 +945,7 @@ double cosine_similarity(const float *a, const float *b, int dim);
 int memory_query_embed_runtime_test(const char *text, const char *command, float *out, int max_dim);
 void memory_query_embed_cache_reset_test(void);
 void memory_query_embed_cache_stats_test(int *requests, int *misses);
+void memory_query_embed_prewarm_test(const char *const *texts, int n, const char *command);
 
 /* --- Effectiveness Tracking --- */
 
@@ -1568,7 +1569,7 @@ void memory_recall_metrics(int64_t *assemblies_total, int64_t *session_start_ass
  * source file was re-scanned after the embedding was written (a staleness
  * heuristic ranking re-ingest order, NOT a correctness verdict). Default-off
  * (not in MODES_DEFAULT); requested explicitly (e.g. `maintenance --mode drift`). */
-#define MEMORY_MAINTENANCE_MODE_DRIFT     (1u << 4)
+#define MEMORY_MAINTENANCE_MODE_DRIFT (1u << 4)
 
 #define MEMORY_MAINTENANCE_MODES_DEFAULT                                                           \
    (MEMORY_MAINTENANCE_MODE_REPLAY | MEMORY_MAINTENANCE_MODE_COMPACT |                             \

--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1787,6 +1787,113 @@ static int memory_embed_text_runtime(const char *text, const char *command, floa
    return dim;
 }
 
+/* Store one (command,text)->vector entry into the per-recall memo (used by the
+ * batch prewarm to seed vectors it embedded in bulk). */
+static void memory_query_embed_cache_put(const char *command, const char *text, const float *vec,
+                                         int dim)
+{
+   if (!command || !text || !vec || dim <= 0 || dim > EMBED_MAX_DIM)
+      return;
+   if (strlen(text) >= MEMORY_QEMBED_TEXT_MAX || strlen(command) >= MEMORY_QEMBED_CMD_MAX)
+      return;
+   for (int i = 0; i < s_qembed_count; i++)
+      if (strcmp(s_qembed[i].command, command) == 0 && strcmp(s_qembed[i].text, text) == 0)
+         return; /* already cached */
+   if (s_qembed_count >= MEMORY_QEMBED_CAP)
+      return;
+   memory_qembed_entry_t *e = &s_qembed[s_qembed_count++];
+   snprintf(e->command, sizeof(e->command), "%s", command);
+   snprintf(e->text, sizeof(e->text), "%s", text);
+   memcpy(e->vec, vec, (size_t)dim * sizeof(float));
+   e->dim = dim;
+}
+
+/* Embed-batching: embed up to `n` query texts in ONE batched embedder call and
+ * seed them into the per-recall memo, so the retrieval lanes hit the memo
+ * instead of making one HTTP round-trip per distinct text. Best-effort: skips
+ * builtin (in-process, nothing to batch) and texts already cached / too long;
+ * any failure (command error, count mismatch) leaves the memo untouched so the
+ * lanes simply embed individually. The embedding command must accept a JSON
+ * array of strings on stdin and return a JSON array of float arrays
+ * (scripts/embed-remote.py batch mode → embedder /embed_batch). */
+static void memory_query_embed_prewarm(const char *const *texts, int n, const char *command)
+{
+   const char *cmd = memory_effective_embedding_cmd(command);
+   if (n <= 0 || !texts || strcmp(cmd, "builtin") == 0)
+      return;
+
+   const char *picked[MEMORY_QEMBED_CAP];
+   int np = 0;
+   cJSON *arr = cJSON_CreateArray();
+   if (!arr)
+      return;
+   for (int i = 0; i < n && np < MEMORY_QEMBED_CAP; i++)
+   {
+      const char *t = texts[i];
+      if (!t || !t[0] || strlen(t) >= MEMORY_QEMBED_TEXT_MAX)
+         continue;
+      int dup = 0;
+      for (int j = 0; j < s_qembed_count && !dup; j++)
+         if (strcmp(s_qembed[j].command, cmd) == 0 && strcmp(s_qembed[j].text, t) == 0)
+            dup = 1;
+      for (int j = 0; j < np && !dup; j++)
+         if (strcmp(picked[j], t) == 0)
+            dup = 1;
+      if (dup)
+         continue;
+      picked[np++] = t;
+      cJSON_AddItemToArray(arr, cJSON_CreateString(t));
+   }
+   if (np < 2) /* one text: a single /embed is no slower than a batch of one */
+   {
+      cJSON_Delete(arr);
+      return;
+   }
+
+   char *input = cJSON_PrintUnformatted(arr);
+   cJSON_Delete(arr);
+   if (!input)
+      return;
+   char *buf = NULL;
+   size_t buf_len = 0;
+   int rc = platform_exec_pipe(cmd, input, strlen(input), &buf, &buf_len);
+   free(input);
+   if (rc != 0 || !buf || buf_len == 0)
+   {
+      free(buf);
+      return; /* lanes fall back to individual embeds */
+   }
+   cJSON *resp = cJSON_Parse(buf);
+   free(buf);
+   if (!cJSON_IsArray(resp) || cJSON_GetArraySize(resp) != np)
+   {
+      cJSON_Delete(resp);
+      return;
+   }
+   int idx = 0;
+   cJSON *vecj;
+   cJSON_ArrayForEach(vecj, resp)
+   {
+      if (cJSON_IsArray(vecj))
+      {
+         float vec[EMBED_MAX_DIM];
+         int dim = 0;
+         cJSON *el;
+         cJSON_ArrayForEach(el, vecj)
+         {
+            if (dim >= EMBED_MAX_DIM)
+               break;
+            if (cJSON_IsNumber(el))
+               vec[dim++] = (float)el->valuedouble;
+         }
+         if (dim > 0)
+            memory_query_embed_cache_put(cmd, picked[idx], vec, dim);
+      }
+      idx++;
+   }
+   cJSON_Delete(resp);
+}
+
 /* Test hooks (declared in memory.h) — expose the static memo to unit tests. */
 int memory_query_embed_runtime_test(const char *text, const char *command, float *out, int max_dim)
 {
@@ -1804,6 +1911,11 @@ void memory_query_embed_cache_stats_test(int *requests, int *misses)
 void memory_query_embed_cache_reset_test(void)
 {
    memory_query_embed_cache_reset();
+}
+
+void memory_query_embed_prewarm_test(const char *const *texts, int n, const char *command)
+{
+   memory_query_embed_prewarm(texts, n, command);
 }
 
 static int memory_semantic_query_unavailable(void)

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -4047,6 +4047,41 @@ int memory_find_facts_scoped(const char *query, const char *scope_type, const ch
    }
 
    memory_query_intent_t intent = memory_query_intent(query, norm_query);
+
+   /* Embed-batching: warm the per-recall memo with the query texts the semantic
+    * lanes will embed — the base query plus its semantic form, for the main query
+    * and any decomposition sub-questions — in ONE batched embedder call. The
+    * lanes then hit the memo instead of one embedder round-trip each. Best-effort:
+    * texts are built with the same helpers the lanes use (so they match and hit);
+    * any that don't match simply fall back to an individual embed. */
+   {
+      config_t pw_cfg;
+      if (config_load(&pw_cfg) == 0 && pw_cfg.embedding_command[0])
+      {
+         const char *bt[3 + 2 * MEMORY_REWRITE_MAX_SUBQUERIES];
+         char sem_main[1024];
+         char sem_sub[MEMORY_REWRITE_MAX_SUBQUERIES][1024];
+         int bn = 0;
+         bt[bn++] = query;
+         memory_build_semantic_query_text(query, memory_query_intent(query, query), sem_main,
+                                          sizeof(sem_main));
+         if (sem_main[0])
+            bt[bn++] = sem_main;
+         if (rewrite.has_hyde && rewrite.hyde_answer[0])
+            bt[bn++] = rewrite.hyde_answer;
+         for (int q = 0; q < rewrite.sub_question_count; q++)
+         {
+            const char *sq = rewrite.sub_questions[q];
+            bt[bn++] = sq;
+            memory_build_semantic_query_text(sq, memory_query_intent(sq, sq), sem_sub[q],
+                                             sizeof(sem_sub[q]));
+            if (sem_sub[q][0])
+               bt[bn++] = sem_sub[q];
+         }
+         memory_query_embed_prewarm(bt, bn, pw_cfg.embedding_command);
+      }
+   }
+
    memory_query_plan_t plan;
    if (memory_query_plan(query, limit, MEMORY_RERANK_BUFFER, &plan) != 0)
       memset(&plan, 0, sizeof(plan));

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -512,6 +512,37 @@ static void test_query_embedding_memo_dedupes_embeds(void)
    printf("test_query_embedding_memo_dedupes_embeds: PASS\n");
 }
 
+/* Embed-batching: memory_query_embed_prewarm embeds N texts in one batched call
+ * and seeds the per-recall memo, so subsequent runtime embeds of those texts are
+ * served from the memo (no further embedder calls). The mock "embedder" reads a
+ * JSON array of texts and returns a JSON array of fixed vectors. */
+static void test_query_embed_prewarm_batches(void)
+{
+   memory_test_ensure_env();
+   const char *cmd = "python3 -c 'import sys,json; a=json.load(sys.stdin); "
+                     "print(json.dumps([[1.5,2.5,3.5,4.5] for _ in a]))'";
+
+   memory_query_embed_cache_reset_test();
+   const char *texts[2] = {"alpha query", "beta query"};
+   memory_query_embed_prewarm_test(texts, 2, cmd);
+
+   int req0 = 0, miss0 = 0;
+   memory_query_embed_cache_stats_test(&req0, &miss0);
+
+   float a[EMBED_MAX_DIM], b[EMBED_MAX_DIM];
+   int da = memory_query_embed_runtime_test("alpha query", cmd, a, EMBED_MAX_DIM);
+   int db = memory_query_embed_runtime_test("beta query", cmd, b, EMBED_MAX_DIM);
+
+   int req1 = 0, miss1 = 0;
+   memory_query_embed_cache_stats_test(&req1, &miss1);
+
+   assert(da == 4 && a[0] == 1.5f && a[3] == 4.5f);
+   assert(db == 4);
+   /* Both were served from the prewarmed batch — no individual embeds happened. */
+   assert(miss1 == miss0);
+   printf("test_query_embed_prewarm_batches: PASS\n");
+}
+
 /* Measurement (not a pass/fail gate): run a real recall and report how many
  * embed requests the lanes/sub-queries made vs how many actually hit the
  * embedder, so the per-recall dedup factor is visible. */
@@ -555,6 +586,7 @@ int main(void)
 
    test_db1_runtime_state_add_int();
    test_query_embedding_memo_dedupes_embeds();
+   test_query_embed_prewarm_batches();
    measure_query_embedding_memo_recall();
    test_insert_memory();
    test_insert_merge();


### PR DESCRIPTION
## Why

With the per-recall memo (#387), each *distinct* query text (base query + its semantic form, plus a base+semantic pair per decomposition sub-question) was still a separate embedder round-trip. This batches them into **one** call.

## What
- **`embedder-server.py`**: new `POST /embed_batch` (JSON array of texts → JSON array of vectors) via one batched `model.encode([...])` — one HTTP round-trip + one batched inference instead of N. `/embed` unchanged.
- **`embed-remote.py`**: a JSON array on stdin → `/embed_batch`; raw text → `/embed` (C single-embed path unchanged).
- **`memory_query_embed_prewarm()`** (`memory_core_helpers.inc`): builds the JSON array, calls the batch command, seeds each vector into the memo. Best-effort — skips builtin/<2 texts/over-long; any failure leaves the memo untouched so lanes embed individually.
- **`memory_find_facts_scoped`**: prewarm pass collects the texts (using the same helpers the lanes use, so they match and hit the memo).

## Safety / back-compat
Purely additive: single-embed and `/embed` are unchanged; batching degrades gracefully to individual embeds on any mismatch/failure.

## Tests
`unit-test-memory` gains a prewarm case (mock batch embedder; asserts prewarmed texts are served from the memo with zero further embeds). `make all` clean, all memory tests green.

## Deploy
Needs the embedder + kb images rebuilt (the `/embed_batch` endpoint + `embed-remote` batch mode). I'll validate live on `.254` after the image refresh before relying on it.