### PR TITLE
feat(server): auto-provision delegate vault at standup

### DIFF
--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -106,10 +106,25 @@ services:
       # beyond local dev. Leave both unset to serve webchat with no account.
       AIMEE_WEBCHAT_USER: aimee
       AIMEE_WEBCHAT_PASSWORD: aimee-local-dev
+      # Delegate-vault auto-provisioning (optional). aimee-server seals these
+      # delegate API keys into its server-principal vault at startup, so a fresh
+      # deploy's delegates/roundtables work with no manual `aimee vault set`.
+      # Non-destructive by default (set AIMEE_DELEGATE_SECRETS_OVERWRITE=1 to
+      # replace an existing key); secrets never touch AIMEE_HOME or logs.
+      #   Env form (agent name lowercased):
+      # AIMEE_DELEGATE_KEY_MISTRAL: ${AIMEE_DELEGATE_KEY_MISTRAL:-}
+      #   File form (a JSON object {"<agent>":"<key>", ...}); mount it readable by
+      #   the container's "aimee" user and point at it:
+      # AIMEE_DELEGATE_SECRETS_FILE: /run/secrets/aimee-delegates.json
     ports:
       - "8740:8740"
       - "8741:8741"
       - "8443:8443"
+    # To use the file form above, mount the secrets file read-only, e.g.:
+    # secrets:
+    #   - aimee_delegates
+    # (and a top-level `secrets: { aimee_delegates: { file: ./aimee-delegates.json } }`,
+    #  or a bind mount under volumes:). Keep it out of the image and VCS.
     depends_on:
       postgres:
         condition: service_healthy

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -129,6 +129,13 @@ services:
       # beyond local dev. Leave both unset to serve webchat with no account.
       AIMEE_WEBCHAT_USER: aimee
       AIMEE_WEBCHAT_PASSWORD: aimee-local-dev
+      # Delegate-vault auto-provisioning (optional): seal delegate API keys into
+      # the server-principal vault at startup so delegates work with no manual
+      # `aimee vault set`. Env form (agent lowercased) or a mounted JSON file;
+      # non-destructive unless AIMEE_DELEGATE_SECRETS_OVERWRITE=1. See
+      # compose.combined.yaml for the full notes.
+      # AIMEE_DELEGATE_KEY_MISTRAL: ${AIMEE_DELEGATE_KEY_MISTRAL:-}
+      # AIMEE_DELEGATE_SECRETS_FILE: /run/secrets/aimee-delegates.json
     ports:
       - "8740:8740"
       - "8443:8443"

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -89,6 +89,17 @@ while :; do
     sleep 1
 done
 
+# Delegate-vault auto-provisioning. aimee-server seals operator-supplied delegate
+# API keys into its server-principal vault at startup, so a fresh deploy's
+# delegates/roundtables work with no manual `aimee vault set`. The source comes
+# from the environment, which runuser preserves into the aimee-server child:
+#   - AIMEE_DELEGATE_SECRETS_FILE=/run/secrets/aimee-delegates.json
+#       a JSON object {"<agent>":"<api-key>", ...}. Mount it readable by the
+#       container's "aimee" user (the server reads it after dropping privileges).
+#   - AIMEE_DELEGATE_KEY_<AGENT>=<api-key>   (env-only convenience; agent name
+#       lowercased, e.g. AIMEE_DELEGATE_KEY_MISTRAL).
+# Non-destructive by default; set AIMEE_DELEGATE_SECRETS_OVERWRITE=1 to replace an
+# existing vaulted key. Secrets are never written to AIMEE_HOME or logs.
 log "starting aimee-server (socket=$SERVER_SOCK kb=$AIMEE_KB_API_URL) as user aimee"
 runuser -u aimee -- aimee-server --socket="$SERVER_SOCK" &
 server_pid=$!

--- a/src/Makefile
+++ b/src/Makefile
@@ -376,7 +376,7 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/vault_capability.c server/server_vault.c \
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c \
               workflow/wfe_engine.c workflow/wfe_blocks.c workflow/wfe_approval.c \
               workflow/wfe_verdict.c workflow/wfe_roundtable.c workflow/wfe_autonomy.c \
               server/server_workflow_api.c

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -209,6 +209,18 @@ typedef struct
 /* Lifecycle */
 int server_init(server_ctx_t *ctx, const char *socket_path);
 int server_run(server_ctx_t *ctx);
+/* Boot-time delegate-vault provisioning: seal operator-supplied delegate API
+ * keys ($AIMEE_DELEGATE_SECRETS_FILE / AIMEE_DELEGATE_KEY_<AGENT>) into the
+ * server-principal vault so a fresh server's delegates work with no manual
+ * `vault set`. No-op when no source is set; returns the count provisioned. */
+int server_vault_bootstrap(void);
+/* Resolve a delegate name to its canonical agents.json name: returns 1 and
+ * writes `canon` (NUL-terminated, capped at `cap`) when known, else 0. The
+ * provisioning module calls this through an injected pointer so it carries no
+ * link dependency on the agent-config layer; production wires an agents.json
+ * resolver, unit tests wire a trivial one. */
+typedef int (*aimee_agent_resolver_fn)(const char *name, char *canon, size_t cap);
+void server_vault_bootstrap_set_resolver(aimee_agent_resolver_fn fn);
 void server_shutdown(server_ctx_t *ctx);
 int server_compute_budget_acquire(server_ctx_t *ctx);
 void server_compute_budget_release(server_ctx_t *ctx, int granted);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1482,6 +1482,21 @@ static int server_agent_route_is_down(const char *agent_name)
    return provider_catalog_get_health(agent_name) == CATALOG_HEALTH_DOWN;
 }
 
+/* Production agent-name resolver for the vault bootstrap: validate against
+ * agents.json and return the canonical agent name. agent_load_config is cached,
+ * so the per-secret calls are cheap. */
+static int server_bootstrap_resolve_agent(const char *name, char *canon, size_t cap)
+{
+   agent_config_t cfg;
+   if (agent_load_config(&cfg) != 0)
+      return 0;
+   agent_t *a = agent_find(&cfg, name);
+   if (!a)
+      return 0;
+   snprintf(canon, cap, "%s", a->name);
+   return 1;
+}
+
 int server_init(server_ctx_t *ctx, const char *socket_path)
 {
    memset(ctx, 0, sizeof(*ctx));
@@ -1655,6 +1670,11 @@ int server_init(server_ctx_t *ctx, const char *socket_path)
    trigger_scheduler_init();
    server_delegate_monitor_init();
    server_coord_dispatcher_init(ctx);
+   /* Provision the delegate vault from operator-supplied secrets before serving,
+    * so a freshly stood-up server's delegates/roundtables work without a manual
+    * `vault set`. No-op unless a secret source is configured. */
+   server_vault_bootstrap_set_resolver(server_bootstrap_resolve_agent);
+   server_vault_bootstrap();
    return 0;
 }
 int server_run(server_ctx_t *ctx)

--- a/src/server/server_vault_bootstrap.c
+++ b/src/server/server_vault_bootstrap.c
@@ -1,0 +1,236 @@
+/* server_vault_bootstrap.c — boot-time delegate-vault provisioning.
+ *
+ * A freshly stood-up aimee-server comes up with an EMPTY delegate vault, so
+ * every delegate / roundtable call fails 401 (delegate credentials resolve
+ * vault-first, delegate_credential_retry.c). This pass seals operator-supplied
+ * delegate API keys into the server-principal vault at boot, autonomously:
+ * vault_service_set_server() derives the server KEK from the master key
+ * (.vault/.server-master.key, auto-minted on first run) — no unlock, no attested
+ * connection required. The result is that a new server provisions its own
+ * delegates with zero manual `aimee vault set`.
+ *
+ * Secret sources (precedence, both optional):
+ *   1. $AIMEE_DELEGATE_SECRETS_FILE — a JSON object { "<agent>": "<key>", ... }
+ *      (the Docker-secret / bind-mount path).
+ *   2. AIMEE_DELEGATE_KEY_<AGENT> environment variables (the env-only path;
+ *      the suffix is lowercased and matched against agents.json).
+ *
+ * Safety properties:
+ *   - No-op when neither source is set — existing deploys are unchanged.
+ *   - Idempotent + non-destructive: an already-vaulted (agent, api_key) is left
+ *     untouched unless AIMEE_DELEGATE_SECRETS_OVERWRITE is set, so a redeploy
+ *     never silently reverts a rotated key.
+ *   - A secret naming an agent absent from agents.json warns and is skipped; it
+ *     never fails boot.
+ *   - Secrets are never written to $AIMEE_HOME or logs; in-memory copies are
+ *     OPENSSL_cleanse()d and AIMEE_DELEGATE_KEY_* env vars are unset after use.
+ */
+#include "server.h"
+#include "vault_service.h"
+#include "vault_store.h"
+#include "log.h"
+#include "cJSON.h"
+#include <openssl/crypto.h>
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Agent-name resolver seam. Production injects an agents.json-backed resolver
+ * (server.c); unit tests inject a trivial one — so this module carries no link
+ * dependency on the (heavy) agent config layer. A NULL resolver means every
+ * agent is treated as unknown (fail-safe: nothing is sealed). */
+static aimee_agent_resolver_fn g_resolver = NULL;
+
+void server_vault_bootstrap_set_resolver(aimee_agent_resolver_fn fn)
+{
+   g_resolver = fn;
+}
+
+#define VAULT_BOOTSTRAP_SECRETS_FILE_ENV "AIMEE_DELEGATE_SECRETS_FILE"
+#define VAULT_BOOTSTRAP_KEY_PREFIX       "AIMEE_DELEGATE_KEY_"
+#define VAULT_BOOTSTRAP_OVERWRITE_ENV    "AIMEE_DELEGATE_SECRETS_OVERWRITE"
+#define VAULT_BOOTSTRAP_MAX_FILE_BYTES   (1u << 20) /* 1 MB cap on the secrets file */
+#define VAULT_BOOTSTRAP_MAX_ENV_VARS     64
+
+typedef struct
+{
+   int provisioned;
+   int skipped;
+   int unknown;
+   int failed;
+} prov_counts_t;
+
+/* Truthy unless empty / "0" / "false" / "no". */
+static int env_flag(const char *name)
+{
+   const char *v = getenv(name);
+   return v && v[0] && strcmp(v, "0") != 0 && strcasecmp(v, "false") != 0 &&
+          strcasecmp(v, "no") != 0;
+}
+
+/* Seal one (agent, secret) under the server principal. The agent must exist in
+ * agents.json; the canonical agent->name is what we key the vault by, so a
+ * delegate resolves it later regardless of the source's casing. */
+static void provision_one(const char *name, const char *secret, int overwrite, prov_counts_t *c)
+{
+   if (!name || !name[0] || !secret || !secret[0])
+      return;
+   char canon[128];
+   if (!g_resolver || !g_resolver(name, canon, sizeof(canon)) || !canon[0])
+   {
+      LOG_WARN("vault.bootstrap", "secret for unknown agent '%s' — skipped (not in agents.json)",
+               name);
+      c->unknown++;
+      return;
+   }
+   if (!overwrite && vault_store_has_entry(VAULT_SERVER_PRINCIPAL, canon, VAULT_API_KEY_CRED))
+   {
+      c->skipped++;
+      return;
+   }
+   vault_status_t st = vault_service_set_server(canon, VAULT_API_KEY_CRED, secret);
+   if (st == VAULT_OK)
+   {
+      /* Agent name only — never the secret or a fingerprint of it. */
+      LOG_INFO("vault.bootstrap", "provisioned server-vault api_key for agent '%s'", canon);
+      c->provisioned++;
+   }
+   else
+   {
+      LOG_ERROR("vault.bootstrap", "failed to seal api_key for agent '%s': %s", canon,
+                vault_status_str(st));
+      c->failed++;
+   }
+}
+
+/* Read a small file fully; caller frees (and should cleanse). NULL on error or
+ * over-cap. */
+static char *slurp_file(const char *path, size_t *len_out)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long sz = ftell(f);
+   if (sz < 0 || (unsigned long)sz > VAULT_BOOTSTRAP_MAX_FILE_BYTES || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t n = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   buf[n] = '\0';
+   if (len_out)
+      *len_out = n;
+   return buf;
+}
+
+static void provision_from_file(const char *path, int overwrite, prov_counts_t *c)
+{
+   size_t len = 0;
+   char *buf = slurp_file(path, &len);
+   if (!buf)
+   {
+      LOG_WARN("vault.bootstrap", "secrets file '%s' unreadable or too large — skipped", path);
+      return;
+   }
+   cJSON *root = cJSON_Parse(buf);
+   OPENSSL_cleanse(buf, len ? len : 1);
+   free(buf);
+   if (!root || !cJSON_IsObject(root))
+   {
+      LOG_WARN("vault.bootstrap", "secrets file '%s' is not a JSON object — skipped", path);
+      if (root)
+         cJSON_Delete(root);
+      return;
+   }
+   for (cJSON *it = root->child; it; it = it->next)
+      if (cJSON_IsString(it) && it->string)
+         provision_one(it->string, it->valuestring, overwrite, c);
+   /* Cleanse the decoded secret strings before freeing the tree. */
+   for (cJSON *it = root->child; it; it = it->next)
+      if (cJSON_IsString(it) && it->valuestring)
+         OPENSSL_cleanse(it->valuestring, strlen(it->valuestring));
+   cJSON_Delete(root);
+}
+
+static void provision_from_env(int overwrite, prov_counts_t *c)
+{
+   extern char **environ;
+   const size_t plen = strlen(VAULT_BOOTSTRAP_KEY_PREFIX);
+   /* Snapshot matching var NAMES first: unsetenv() mutates environ, so we must
+    * not iterate it and modify it at the same time. */
+   char names[VAULT_BOOTSTRAP_MAX_ENV_VARS][128];
+   int n = 0;
+   for (char **e = environ; *e && n < VAULT_BOOTSTRAP_MAX_ENV_VARS; e++)
+   {
+      if (strncmp(*e, VAULT_BOOTSTRAP_KEY_PREFIX, plen) != 0)
+         continue;
+      const char *eq = strchr(*e, '=');
+      if (!eq)
+         continue;
+      size_t klen = (size_t)(eq - *e);
+      if (klen == plen || klen >= sizeof(names[0]))
+         continue; /* empty suffix or oversize name */
+      memcpy(names[n], *e, klen);
+      names[n][klen] = '\0';
+      n++;
+   }
+   for (int i = 0; i < n; i++)
+   {
+      const char *val = getenv(names[i]);
+      if (val && val[0])
+      {
+         char agent[128];
+         const char *suf = names[i] + plen;
+         size_t j = 0;
+         for (; suf[j] && j < sizeof(agent) - 1; j++)
+            agent[j] = (char)tolower((unsigned char)suf[j]);
+         agent[j] = '\0';
+         provision_one(agent, val, overwrite, c);
+      }
+      unsetenv(names[i]); /* scrub the plaintext from the environment */
+   }
+}
+
+int server_vault_bootstrap(void)
+{
+   const char *file = getenv(VAULT_BOOTSTRAP_SECRETS_FILE_ENV);
+   int have_file = file && file[0];
+   int have_env = 0;
+   {
+      extern char **environ;
+      const size_t plen = strlen(VAULT_BOOTSTRAP_KEY_PREFIX);
+      for (char **e = environ; *e; e++)
+         if (strncmp(*e, VAULT_BOOTSTRAP_KEY_PREFIX, plen) == 0)
+         {
+            have_env = 1;
+            break;
+         }
+   }
+   if (!have_file && !have_env)
+      return 0; /* no secret source configured — nothing to do */
+
+   int overwrite = env_flag(VAULT_BOOTSTRAP_OVERWRITE_ENV);
+   prov_counts_t c = {0, 0, 0, 0};
+   if (have_file)
+      provision_from_file(file, overwrite, &c);
+   provision_from_env(overwrite, &c);
+
+   if (c.provisioned || c.skipped || c.unknown || c.failed)
+      LOG_INFO("vault.bootstrap",
+               "delegate vault provisioning: provisioned=%d skipped=%d unknown=%d failed=%d",
+               c.provisioned, c.skipped, c.unknown, c.failed);
+   return c.provisioned;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -212,6 +212,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-kek-cache \
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
+               $(TESTPREFIX)/unit-test-vault-bootstrap \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
                $(TESTPREFIX)/unit-test-prompts \
@@ -2103,6 +2104,14 @@ $(TESTPREFIX)/unit-test-vault-store: $(OBJDIR)/tests/test_vault_store.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-vault-service: $(OBJDIR)/tests/test_vault_service.o \
+                              $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
+                              $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-vault-bootstrap: $(OBJDIR)/tests/test_vault_bootstrap.o \
+                              $(OBJDIR)/server/server_vault_bootstrap.o \
                               $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
                               $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
                               $(OBJDIR)/server/vault_server_key.o \

--- a/src/tests/test_vault_bootstrap.c
+++ b/src/tests/test_vault_bootstrap.c
@@ -1,0 +1,165 @@
+/* test_vault_bootstrap.c — boot-time delegate-vault provisioning (WP-A/B).
+ *
+ * Pins the behavior of server_vault_bootstrap(): it seals operator-supplied
+ * delegate API keys (a JSON secrets file or AIMEE_DELEGATE_KEY_<AGENT> env vars)
+ * into the SERVER-principal vault autonomously, is idempotent + non-destructive,
+ * skips unknown agents without failing, no-ops with no source, scrubs the env,
+ * and never leaves a plaintext secret under $AIMEE_HOME.
+ *
+ * The module resolves agent names through an injected resolver, so this test
+ * provides a trivial one and needs no agent-config link. */
+#include "server.h"
+#include "vault_service.h"
+#include "vault_store.h"
+#include "vault_kek_cache.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <unistd.h>
+
+static char g_root[256]; /* test sandbox: <root>/home is AIMEE_HOME */
+static char g_home[320];
+static const long T0 = 100000;
+
+/* Trivial resolver: knows "mistral" and "claude" (case-insensitive), canonical
+ * form is lowercase. Everything else is unknown. */
+static int fake_resolver(const char *name, char *canon, size_t cap)
+{
+   if (strcasecmp(name, "mistral") == 0)
+   {
+      snprintf(canon, cap, "mistral");
+      return 1;
+   }
+   if (strcasecmp(name, "claude") == 0)
+   {
+      snprintf(canon, cap, "claude");
+      return 1;
+   }
+   return 0;
+}
+
+static void write_file(const char *path, const char *content)
+{
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(content, f);
+   fclose(f);
+}
+
+/* True if `needle` appears verbatim in any file under $AIMEE_HOME. */
+static int plaintext_under_home(const char *needle)
+{
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "grep -rqF -- '%s' '%s' 2>/dev/null", needle, g_home);
+   return system(cmd) == 0;
+}
+
+/* File source: known agent is sealed + resolves; unknown agent is skipped. */
+static void test_file_source(void)
+{
+   char secrets[400];
+   snprintf(secrets, sizeof(secrets), "%s/secrets.json", g_root); /* OUTSIDE home */
+   write_file(secrets, "{\"mistral\":\"sk-mistral-ALPHA\",\"ghostagent\":\"sk-nope\"}");
+   setenv("AIMEE_DELEGATE_SECRETS_FILE", secrets, 1);
+
+   int n = server_vault_bootstrap();
+   assert(n == 1); /* only mistral provisioned; ghostagent unknown */
+
+   assert(vault_store_has_entry(VAULT_SERVER_PRINCIPAL, "mistral", VAULT_API_KEY_CRED) == 1);
+   assert(vault_store_has_entry(VAULT_SERVER_PRINCIPAL, "ghostagent", VAULT_API_KEY_CRED) == 0);
+
+   char key[64] = "PRESET";
+   assert(vault_service_inject_api_key("", "mistral", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-mistral-ALPHA") == 0);
+
+   unlink(secrets);
+   unsetenv("AIMEE_DELEGATE_SECRETS_FILE");
+   printf("  PASS: test_file_source\n");
+}
+
+/* Re-running is non-destructive by default; the overwrite flag forces an update. */
+static void test_idempotent_and_overwrite(void)
+{
+   char secrets[400];
+   snprintf(secrets, sizeof(secrets), "%s/secrets2.json", g_root);
+   write_file(secrets, "{\"mistral\":\"sk-mistral-BETA\"}");
+   setenv("AIMEE_DELEGATE_SECRETS_FILE", secrets, 1);
+
+   /* Default: existing mistral cred is left untouched (provisioned count 0). */
+   assert(server_vault_bootstrap() == 0);
+   char key[64];
+   assert(vault_service_inject_api_key("", "mistral", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-mistral-ALPHA") == 0); /* unchanged */
+
+   /* Overwrite flag: the cred is replaced. */
+   setenv("AIMEE_DELEGATE_SECRETS_OVERWRITE", "1", 1);
+   assert(server_vault_bootstrap() == 1);
+   assert(vault_service_inject_api_key("", "mistral", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-mistral-BETA") == 0);
+
+   unsetenv("AIMEE_DELEGATE_SECRETS_OVERWRITE");
+   unlink(secrets);
+   unsetenv("AIMEE_DELEGATE_SECRETS_FILE");
+   printf("  PASS: test_idempotent_and_overwrite\n");
+}
+
+/* Env source: AIMEE_DELEGATE_KEY_<AGENT> provisions, and the var is scrubbed. */
+static void test_env_source(void)
+{
+   setenv("AIMEE_DELEGATE_KEY_CLAUDE", "sk-claude-GAMMA", 1);
+   assert(server_vault_bootstrap() == 1);
+
+   char key[64];
+   assert(vault_service_inject_api_key("", "claude", key, sizeof(key), T0) == VAULT_OK);
+   assert(strcmp(key, "sk-claude-GAMMA") == 0);
+
+   /* The plaintext env var is unset after ingestion. */
+   assert(getenv("AIMEE_DELEGATE_KEY_CLAUDE") == NULL);
+   printf("  PASS: test_env_source\n");
+}
+
+/* No secret source configured -> no-op (and no crash). */
+static void test_no_source_noop(void)
+{
+   assert(getenv("AIMEE_DELEGATE_SECRETS_FILE") == NULL);
+   assert(getenv("AIMEE_DELEGATE_KEY_CLAUDE") == NULL);
+   assert(server_vault_bootstrap() == 0);
+   printf("  PASS: test_no_source_noop\n");
+}
+
+/* Hygiene: no provisioned secret value is present in plaintext under AIMEE_HOME
+ * (the vault stores ciphertext; the secrets file lives outside home). */
+static void test_no_plaintext_at_rest(void)
+{
+   assert(!plaintext_under_home("sk-mistral-ALPHA"));
+   assert(!plaintext_under_home("sk-mistral-BETA"));
+   assert(!plaintext_under_home("sk-claude-GAMMA"));
+   printf("  PASS: test_no_plaintext_at_rest\n");
+}
+
+int main(void)
+{
+   snprintf(g_root, sizeof(g_root), "/tmp/aimee-vaultboot-test-%d", (int)getpid());
+   snprintf(g_home, sizeof(g_home), "%s/home", g_root);
+   char mk[700];
+   snprintf(mk, sizeof(mk), "rm -rf %s && mkdir -p %s", g_root, g_home);
+   assert(system(mk) == 0);
+   setenv("AIMEE_HOME", g_home, 1);
+   vault_kek_cache_clear();
+   server_vault_bootstrap_set_resolver(fake_resolver);
+
+   test_file_source();
+   test_idempotent_and_overwrite();
+   test_env_source();
+   test_no_source_noop();
+   test_no_plaintext_at_rest();
+
+   vault_kek_cache_clear();
+   char rm[400];
+   snprintf(rm, sizeof(rm), "rm -rf %s", g_root);
+   (void)system(rm);
+   printf("vault_bootstrap: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Problem

A freshly stood-up `aimee-server` comes up with an **empty delegate vault**, so every `aimee delegate` / roundtable call fails `provider '<x>' (HTTP 401): authentication failed` — delegate creds resolve **vault-first** (`delegate_credential_retry.c`). The server-sealed vault shipped (`vault_service_set_server`, the `.server-master.key` wrap), but nothing populated it on a fresh deploy, so operators had to shell into the host and `aimee vault set` by hand (the vault refuses the remote TCP transport — "no attested local identity"). This surfaced when a roundtable against `.254` (v0.2.85) 401'd on every delegate despite valid local keys.

## Change

Add a boot-time provisioning pass, `server_vault_bootstrap()`, run at the end of `server_init` **before serving**. It seals operator-supplied delegate API keys into the **server-principal** vault via `vault_service_set_server` (autonomous: derives the server KEK from the master key — no unlock, no attested connection).

Sources (both optional, precedence file > env):
- `AIMEE_DELEGATE_SECRETS_FILE` — a JSON object `{"<agent>":"<api-key>", ...}` (Docker-secret / bind-mount path).
- `AIMEE_DELEGATE_KEY_<AGENT>` — env var (suffix lowercased → agent name).

### Safety
- **No-op** when no source is set — existing deploys unchanged.
- **Idempotent + non-destructive**: an already-vaulted `(agent, api_key)` is left untouched unless `AIMEE_DELEGATE_SECRETS_OVERWRITE=1`, so a redeploy never reverts a rotated key.
- A secret naming an agent absent from `agents.json` **warns and is skipped** (never fails boot).
- Secrets are never written to `$AIMEE_HOME` or logs; in-memory copies are `OPENSSL_cleanse`d and `AIMEE_DELEGATE_KEY_*` env vars are unset after ingestion.

### Design note
Agent validation goes through an injected resolver (`aimee_agent_resolver_fn`), so the provisioning module carries **no link dependency** on the (heavy) agent-config layer: production wires an `agents.json`-backed resolver in `server.c`; the unit test wires a trivial one.

### Container wiring
`combined-entrypoint.sh` documents the env passthrough (`runuser` preserves it) and the secrets-file readability requirement; the combined + split compose files carry commented env/secrets-mount examples.

## Tests
`test_vault_bootstrap` (new `unit-test-vault-bootstrap`) covers: file + env sources, idempotence + overwrite, unknown-agent skip, no-source no-op, env scrubbing, and **no-plaintext-at-rest** (greps `$AIMEE_HOME`).

Verified locally: `aimee-server` / `aimee` / `aimee-kb` build clean under `-Werror`; all 6 vault unit tests pass; `line-check` clean. Also exercised end-to-end against a local server with the real delegate keys (provision at boot → delegate authenticates 200).

## Why

This is the open tail of the cred-vault consolidation (creds → server vault): the sealing mechanism shipped, but standup never provisioned the vault. It is also the prerequisite that unblocks live roundtables (an empty vault is why they 401).