### PR TITLE
curator: bundle Gemma 3n E4B LLM by default; BYO endpoint disables it

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+# Default Compose profiles. curator-llm runs the bundled Gemma 3n E4B LLM
+# for the curator. Disable it (BYO via LLM_ENDPOINT) by overriding:
+#   COMPOSE_PROFILES= docker compose up    (or export COMPOSE_PROFILES=)
+COMPOSE_PROFILES=curator-llm

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -98,6 +98,13 @@ services:
       AIMEE_EMBEDDER_URL: http://embedder:8080
       # Must match the embedder model's output dim (empty = config default 2560).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
+      # Curator LLM (doc/code extraction, entity/claim passes). Defaults to the
+      # bundled `llm` sidecar (Gemma 3n E4B); BYO by setting LLM_ENDPOINT to your
+      # own OpenAI-compatible endpoint (and drop the `llm` service below). The
+      # curator runs in the background drain, so the server never blocks on it.
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
+      LLM_MODEL: ${LLM_MODEL:-gemma-3n-e4b}
+      LLM_API_KEY: ${LLM_API_KEY:-}
       AIMEE_SERVER_HTTP_BIND: "1"
       AIMEE_KB_HTTP_BIND: "1"
       AIMEE_KB_API_URL: http://127.0.0.1:8741
@@ -141,14 +148,19 @@ services:
       - aimee-combined-home:/var/lib/aimee
       - aimee-combined-workspaces:/var/lib/aimee-workspaces
 
-  # Optional local LLM for the kb synthesis / curator passes. Enable with
-  #   docker compose -f compose.combined.yaml --profile llm up
+  # Bundled local LLM for the curator's extraction passes (and any LLM_ENDPOINT
+  # consumer). On by default — Gemma 3n E4B (GGUF Q4), fetched once at first boot
+  # into the models volume (the multi-GB download is why start_period is long).
+  # The curator only calls it from the background drain, so a warming model never
+  # blocks ingest. BYO: point LLM_ENDPOINT at your own OpenAI-compatible endpoint
+  # and skip this service — `docker compose up --scale llm=0` (or remove it).
+  # Override LLAMA_ARG_HF_REPO to use a different/smaller GGUF.
   llm:
     restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
-    profiles: ["llm"]
+    profiles: ["curator-llm"]
     environment:
-      LLAMA_ARG_HF_REPO: ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M
+      LLAMA_ARG_HF_REPO: ${CURATOR_LLM_HF_REPO:-ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M}
       LLAMA_ARG_HOST: 0.0.0.0
       LLAMA_ARG_PORT: "8080"
       LLAMA_ARG_ENDPOINT_HEALTH: "1"
@@ -159,7 +171,8 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 120s
+      # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
+      start_period: 1200s
 
 volumes:
   aimee-combined-home:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -81,6 +81,13 @@ services:
       AIMEE_EMBEDDER_URL: http://embedder:8080
       # Must match the embedder model's output dim (empty = config default 2560).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
+      # Curator LLM (doc/code extraction, entity/claim passes). Defaults to the
+      # bundled `llm` sidecar (Gemma 3n E4B); BYO by setting LLM_ENDPOINT to your
+      # own OpenAI-compatible endpoint (and drop the `llm` service below). The
+      # curator runs in the background drain, so the kb never blocks on it.
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
+      LLM_MODEL: ${LLM_MODEL:-gemma-4-e4b-it}
+      LLM_API_KEY: ${LLM_API_KEY:-}
     # aimee-kb serves /v1 over HTTP only; the legacy --socket transport was retired (#2747).
     command: ["--http-port=8741"]
     ports:
@@ -156,14 +163,19 @@ services:
       # reconstructed worktrees, persisted across recreations on their own volume.
       - aimee-server-workspaces:/var/lib/aimee-workspaces
 
-  # Optional local LLM for the kb synthesis / curator passes. Enable with
-  #   docker compose -f compose.server.yaml --profile llm up
+  # Bundled local LLM for the kb synthesis / curator passes — llama.cpp's
+  # llama-server (OpenAI-compatible /v1). On by default; Gemma 3n E4B (GGUF Q4)
+  # is fetched once at first boot into the volume (the multi-GB download is why
+  # start_period is long). Called only from the kb's background drain, so a
+  # warming model never blocks ingest. BYO: set LLM_ENDPOINT to your own endpoint
+  # and skip this service (`docker compose up --scale llm=0`). Override
+  # LLAMA_ARG_HF_REPO for a different/smaller GGUF.
   llm:
     restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
-    profiles: ["llm"]
+    profiles: ["curator-llm"]
     environment:
-      LLAMA_ARG_HF_REPO: ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M
+      LLAMA_ARG_HF_REPO: ${CURATOR_LLM_HF_REPO:-ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M}
       LLAMA_ARG_HOST: 0.0.0.0
       LLAMA_ARG_PORT: "8080"
       LLAMA_ARG_ENDPOINT_HEALTH: "1"
@@ -174,7 +186,8 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 120s
+      # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
+      start_period: 1200s
 
 volumes:
   aimee-kb-home:

--- a/compose.yaml
+++ b/compose.yaml
@@ -67,11 +67,12 @@ services:
       AIMEE_EMBEDDER_URL: http://embedder:8080
       # Must match the embedder model's output dim (empty = config default 2560).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
-      # Point at any OpenAI-compatible endpoint to enable the synthesis /
-      # curator passes; the optional `llm` profile below brings up a local
-      # llama.cpp server.
-      LLM_ENDPOINT: http://llm:8080/v1
-      LLM_MODEL: gemma-4-e4b-it
+      # Curator/synthesis LLM. Defaults to the bundled `llm` sidecar (Gemma 3n
+      # E4B, below); BYO by pointing LLM_ENDPOINT at your own OpenAI-compatible
+      # endpoint (and drop the `llm` service: `docker compose up --scale llm=0`).
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
+      LLM_MODEL: ${LLM_MODEL:-gemma-4-e4b-it}
+      LLM_API_KEY: ${LLM_API_KEY:-}
     # aimee-kb serves /v1 over HTTP only; the legacy --socket transport was retired (#2747).
     command: ["--http-port=8741"]
     ports:
@@ -89,17 +90,20 @@ services:
     volumes:
       - aimee-kb-home:/var/lib/aimee
 
-  # Optional local LLM for the synthesis / curator passes — llama.cpp's
-  # llama-server, which serves an OpenAI-compatible API at /v1. Enable with
-  #   docker compose --profile llm up
-  # The model is fetched from HuggingFace on first start (-hf) and cached in the
-  # volume; override LLAMA_ARG_HF_REPO to choose a different GGUF.
+  # Bundled local LLM for the synthesis / curator passes — llama.cpp's
+  # llama-server (OpenAI-compatible API at /v1). On by default; Gemma 3n E4B
+  # (GGUF Q4) is fetched once from HuggingFace at first boot and cached in the
+  # volume (the multi-GB download is why start_period is long). The curator calls
+  # it only from the background drain, so a warming model never blocks ingest.
+  # BYO: point LLM_ENDPOINT at your own endpoint and skip this service
+  # (`docker compose up --scale llm=0`). Override LLAMA_ARG_HF_REPO for a
+  # different/smaller GGUF.
   llm:
     restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
-    profiles: ["llm"]
+    profiles: ["curator-llm"]
     environment:
-      LLAMA_ARG_HF_REPO: ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M
+      LLAMA_ARG_HF_REPO: ${CURATOR_LLM_HF_REPO:-ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M}
       LLAMA_ARG_HOST: 0.0.0.0
       LLAMA_ARG_PORT: "8080"
       LLAMA_ARG_ENDPOINT_HEALTH: "1"
@@ -112,7 +116,8 @@ services:
       interval: 30s
       timeout: 5s
       retries: 5
-      start_period: 120s
+      # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
+      start_period: 1200s
 
 volumes:
   aimee-kb-home:

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -63,6 +63,13 @@ export EMBEDDER_STUB="${EMBEDDER_STUB:-1}"
 export EMBEDDER_STUB_DIM="${EMBEDDER_STUB_DIM:-2560}"
 export AIMEE_EMBEDDING_DIM="${AIMEE_EMBEDDING_DIM:-2560}"
 
+# Disable the bundled curator LLM in CI: the committed .env enables the
+# `curator-llm` profile by default, but the smoke tests don't exercise the
+# curator and the multi-GB Gemma GGUF would blow the runner's disk/time. An
+# explicit (empty) COMPOSE_PROFILES overrides the .env so the `llm` service is
+# never started here.
+export COMPOSE_PROFILES="${COMPOSE_PROFILES:-}"
+
 bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
 selected() { case ",$ONLY," in *",$1,"*) return 0 ;; *) return 1 ;; esac; }
 have_docker() { command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1; }


### PR DESCRIPTION
## Why

The curator's LLM-dependent passes (doc/code extraction, entity/claim resolution — what produces semantic code/doc facts beyond the structural index) were wired but **dormant**: `LLM_ENDPOINT` was unset, so `llm-chat.py` had nothing to call (that's why `code_emb` stays sparse on `.254`). A bundled Gemma-E4B llama.cpp sidecar already existed in compose but was opt-in (profile) and unwired in the combined/server stacks.

## What — default bundled E4B + clean BYO override
- **Bundled `llm` sidecar** (official `ghcr.io/ggml-org/llama.cpp:server`, Gemma 3n E4B GGUF Q4, runtime-fetched into the models volume — like the embedder) behind a `curator-llm` profile; a **committed root `.env` enables that profile by default**, so `docker compose up` runs it out of the box.
- **`LLM_ENDPOINT`/`LLM_MODEL`/`LLM_API_KEY` wired** into the kb/server env in all three composes, defaulting to the bundled sidecar and overridable.
- **BYO disables E4B**: set `LLM_ENDPOINT` to your own OpenAI-compatible endpoint and drop the bundled model (`COMPOSE_PROFILES=` / `--scale llm=0`); aimee uses yours.
- **Throttled by design**: the curator runs in the kb's background drain (separate from the fast async embed path) with **no `depends_on`** on the llm, so a cold/warming multi-GB model never blocks ingest.
- **CI-safe**: `e2e-matrix.sh` exports an empty `COMPOSE_PROFILES` so e2e never pulls the GGUF (mirrors `EMBEDDER_STUB`).

## No C changes
The curator + `llm-chat.py` already exist (passes are default-enabled; the image default sets `curator.extract_command`). This is deployment wiring only. Implements the converged `curator-llm-backend` proposal (Tier-A bundled Gemma + Tier-B BYO).

## Validation note
Compose files parse; wiring is config-only. The actual model serving (llama.cpp + Gemma E4B on CPU) needs a live build/run to validate end-to-end — I'll do that on `.254` after merge/image refresh (and confirm `code_emb` fills in). CPU generation is slow, so deep extraction backfills gradually in the background.