### PR TITLE
feat(css): default css_style_graph_enabled on

### DIFF
--- a/src/cli_css.c
+++ b/src/cli_css.c
@@ -11,13 +11,25 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const char *const CSS_OPS[] = {
-    "dead-rules",          "conflicts",        "duplicate-declarations",
-    "duplicate-selectors", "unresolved",       "migrate-enumerate",
-    "migrate-list",        "rules-doc",        "assert-conventions",
-    "conventions",         "render-store",     "render-capture",
-    "render-verify",       "important-audit",  "high-specificity",
-    "unused-vars",         "token-candidates", NULL};
+static const char *const CSS_OPS[] = {"dead-rules",
+                                      "conflicts",
+                                      "duplicate-declarations",
+                                      "duplicate-selectors",
+                                      "unresolved",
+                                      "migrate-enumerate",
+                                      "migrate-list",
+                                      "rules-doc",
+                                      "assert-conventions",
+                                      "conventions",
+                                      "render-store",
+                                      "render-capture",
+                                      "render-verify",
+                                      "important-audit",
+                                      "high-specificity",
+                                      "unused-vars",
+                                      "token-candidates",
+                                      "report",
+                                      NULL};
 
 static int css_op_known(const char *op)
 {
@@ -33,7 +45,8 @@ static void css_usage(void)
                    "  ops: dead-rules | conflicts | duplicate-declarations |\n"
                    "       duplicate-selectors | unresolved | migrate-enumerate |\n"
                    "       migrate-list | rules-doc | assert-conventions | conventions |\n"
-                   "       important-audit | high-specificity | unused-vars | token-candidates\n"
+                   "       important-audit | high-specificity | unused-vars | token-candidates |\n"
+                   "       report  (one-shot CSS-health overview)\n"
                    "  render-store <project> <unit> <before|after> <snapshot.json>\n"
                    "  render-capture <project> <unit> <before|after> <html-file> <css-file>\n"
                    "  render-verify <project> <unit>\n");
@@ -81,6 +94,58 @@ static void css_print_results(const char *op, cJSON *resp)
    {
       cJSON *u = cJSON_GetObjectItemCaseSensitive(resp, "units");
       printf("enumerated %d migration unit(s)\n", cJSON_IsNumber(u) ? u->valueint : 0);
+      return;
+   }
+   if (strcmp(op, "report") == 0)
+   {
+      const cJSON *s = cJSON_GetObjectItemCaseSensitive(resp, "summary");
+      const cJSON *top = cJSON_GetObjectItemCaseSensitive(resp, "top");
+      const cJSON *proj = cJSON_GetObjectItemCaseSensitive(resp, "project");
+      printf("CSS health — %s\n", cJSON_IsString(proj) ? proj->valuestring : "");
+      static const char *const rows[][2] = {
+          {"dead_rules", "dead rules"},
+          {"specificity_conflicts", "specificity conflicts"},
+          {"duplicate_declarations", "duplicate declarations"},
+          {"duplicate_selectors", "duplicate selectors"},
+          {"unresolved_classes", "unresolved classes"},
+          {"high_specificity_rules", "high-specificity (id) rules"},
+          {"important_declarations", "!important declarations"},
+          {"unused_custom_properties", "unused custom properties"},
+          {"token_candidates", "token candidates"},
+          {NULL, NULL}};
+      for (int i = 0; rows[i][0]; i++)
+      {
+         const cJSON *v = cJSON_GetObjectItemCaseSensitive(s, rows[i][0]);
+         printf("  %-28s %d\n", rows[i][1], cJSON_IsNumber(v) ? v->valueint : 0);
+      }
+      const cJSON *imp = top ? cJSON_GetObjectItemCaseSensitive(top, "important") : NULL;
+      if (imp && cJSON_GetArraySize(imp) > 0)
+      {
+         printf("  top !important:");
+         const cJSON *r = NULL;
+         cJSON_ArrayForEach(r, imp)
+         {
+            const cJSON *p = cJSON_GetObjectItemCaseSensitive(r, "property");
+            const cJSON *c = cJSON_GetObjectItemCaseSensitive(r, "count");
+            printf(" %s(%d)", cJSON_IsString(p) ? p->valuestring : "?",
+                   cJSON_IsNumber(c) ? c->valueint : 0);
+         }
+         printf("\n");
+      }
+      const cJSON *tok = top ? cJSON_GetObjectItemCaseSensitive(top, "token_candidates") : NULL;
+      if (tok && cJSON_GetArraySize(tok) > 0)
+      {
+         printf("  top tokens:    ");
+         const cJSON *r = NULL;
+         cJSON_ArrayForEach(r, tok)
+         {
+            const cJSON *val = cJSON_GetObjectItemCaseSensitive(r, "value");
+            const cJSON *c = cJSON_GetObjectItemCaseSensitive(r, "count");
+            printf(" %s(%d)", cJSON_IsString(val) ? val->valuestring : "?",
+                   cJSON_IsNumber(c) ? c->valueint : 0);
+         }
+         printf("\n");
+      }
       return;
    }
    if (strcmp(op, "assert-conventions") == 0)

--- a/src/config.c
+++ b/src/config.c
@@ -545,6 +545,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->skills_capability_autostub = 0;
    cfg->skills_eval_gate_enabled = 0;
    cfg->skills_eval_threshold = 0.01;
+   cfg->css_style_graph_enabled = 1; /* default-on: the indexer builds the CSS style
+                                        graph so the read-only css signals/report work
+                                        out of the box (set false to opt out) */
    cfg->worktree_gc_enabled = 0;
    cfg->worktree_gc_max_age_days = 14;
    cfg->model_meta_refresh_minutes = 60;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -774,8 +774,8 @@ int config_save(const config_t *cfg)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
    if (cfg->typed_facts_enabled)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
-   if (cfg->css_style_graph_enabled)
-      cJSON_AddBoolToObject(root, "css_style_graph_enabled", 1);
+   if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */
+      cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
    if (cfg->css_render_command[0])
       cJSON_AddStringToObject(root, "css_render_command", cfg->css_render_command);
    if (cfg->kb_evidence_emit_enabled)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -287,7 +287,7 @@ typedef struct config
    int memory_maintenance_enabled;
    int memory_maintenance_interval_seconds;
    int memory_maintenance_summarize_enabled;
-   /* css_style_graph_enabled: opt-in gate (default 0) for the CSS migration
+   /* css_style_graph_enabled: gate (default 1, on) for the CSS migration
     * assistant's style-graph write path during indexing (WP-C). When off, the
     * indexer keeps only the legacy lexical CSS class-name scan. */
    int css_style_graph_enabled;
@@ -330,9 +330,9 @@ typedef struct config
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */
-   int fidelity_check_enabled;   /* auditable-correctness P3: run the fidelity judge on terminal-text
-                                    turns (default off; fail-closed dep on
-                                    kb_evidence_emit_enabled + ingress_preinject_enabled) */
+   int fidelity_check_enabled; /* auditable-correctness P3: run the fidelity judge on terminal-text
+                                  turns (default off; fail-closed dep on
+                                  kb_evidence_emit_enabled + ingress_preinject_enabled) */
    int memory_pagerank_enabled;
    int memory_pagerank_iterations;
    double memory_pagerank_weight;

--- a/src/kb/kb_service_css.c
+++ b/src/kb/kb_service_css.c
@@ -223,6 +223,84 @@ int kb_handle_css_signals(int fd, cJSON *req)
       cJSON_AddNumberToObject(resp, "min_count", min_count);
       return kb_send_response(fd, resp);
    }
+   if (strcmp(op, "report") == 0)
+   {
+      /* One-shot CSS-health overview: run every signal, return counts + the top
+       * few offenders per category. Read-only. */
+      const int RCAP = 2000;
+      cJSON *summary = cJSON_CreateObject();
+      cJSON *top = cJSON_CreateObject();
+#define CSS_REPORT_COUNT(key, type, fn)                                                            \
+   do                                                                                              \
+   {                                                                                               \
+      type *_h = (type *)malloc((size_t)RCAP * sizeof(type));                                      \
+      int _n = _h ? fn(project, _h, RCAP) : 0;                                                     \
+      cJSON_AddNumberToObject(summary, key, _n < 0 ? 0 : _n);                                      \
+      free(_h);                                                                                    \
+   } while (0)
+      CSS_REPORT_COUNT("dead_rules", css_dead_rule_hit_t, db2_css_dead_rules);
+      CSS_REPORT_COUNT("specificity_conflicts", css_spec_conflict_t,
+                       db2_css_graph_specificity_conflicts);
+      CSS_REPORT_COUNT("duplicate_declarations", css_dup_decl_t,
+                       db2_css_graph_duplicate_declarations);
+      CSS_REPORT_COUNT("duplicate_selectors", css_dup_selector_t,
+                       db2_css_graph_duplicate_selectors);
+      CSS_REPORT_COUNT("unresolved_classes", css_unresolved_hit_t, db2_css_component_unresolved);
+      CSS_REPORT_COUNT("high_specificity_rules", css_high_spec_t, db2_css_high_specificity);
+#undef CSS_REPORT_COUNT
+      /* !important: total declarations + top properties. */
+      {
+         css_important_t *h = (css_important_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_important_audit(project, h, RCAP) : 0;
+         int total = 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n; i++)
+         {
+            total += h[i].count;
+            if (i < 5)
+            {
+               cJSON *o = cJSON_CreateObject();
+               cJSON_AddStringToObject(o, "property", h[i].property);
+               cJSON_AddNumberToObject(o, "count", h[i].count);
+               cJSON_AddItemToArray(arr, o);
+            }
+         }
+         cJSON_AddNumberToObject(summary, "important_declarations", total);
+         cJSON_AddItemToObject(top, "important", arr);
+         free(h);
+      }
+      /* unused custom properties: count + top names. */
+      {
+         css_unused_var_t *h = (css_unused_var_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_unused_custom_properties(project, h, RCAP) : 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n && i < 5; i++)
+            cJSON_AddItemToArray(arr, cJSON_CreateString(h[i].name));
+         cJSON_AddNumberToObject(summary, "unused_custom_properties", n < 0 ? 0 : n);
+         cJSON_AddItemToObject(top, "unused_vars", arr);
+         free(h);
+      }
+      /* token candidates (>= 3 repeats): count + top values. */
+      {
+         css_token_cand_t *h = (css_token_cand_t *)malloc((size_t)RCAP * sizeof(*h));
+         int n = h ? db2_css_token_candidates(project, 3, h, RCAP) : 0;
+         cJSON *arr = cJSON_CreateArray();
+         for (int i = 0; i < n && i < 5; i++)
+         {
+            cJSON *o = cJSON_CreateObject();
+            cJSON_AddStringToObject(o, "value", h[i].value);
+            cJSON_AddStringToObject(o, "kind", h[i].kind);
+            cJSON_AddNumberToObject(o, "count", h[i].count);
+            cJSON_AddItemToArray(arr, o);
+         }
+         cJSON_AddNumberToObject(summary, "token_candidates", n < 0 ? 0 : n);
+         cJSON_AddItemToObject(top, "token_candidates", arr);
+         free(h);
+      }
+      cJSON_AddItemToObject(resp, "summary", summary);
+      cJSON_AddItemToObject(resp, "top", top);
+      return kb_send_response(fd, resp);
+   }
    if (strcmp(op, "render-store") == 0)
    {
       /* #4-full evidence ingest: a (sandboxed, out-of-process) render backend's

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -71,6 +71,9 @@ int main(void)
       /* directives auto-create ran ungated before the toggle was wired; default-on
        * preserves it. */
       assert(cfg.memory_directives_enabled == 1);
+      /* CSS style graph now defaults on so the read-only css signals/report work
+       * out of the box (the indexer populates css_rules/css_declarations). */
+      assert(cfg.css_style_graph_enabled == 1);
    }
 
    /* --- config_save + config_load round-trip --- */
@@ -180,6 +183,9 @@ int main(void)
       /* directives defaults on; set off to prove the disabled state round-trips
        * (same default-on save-guard regression class as profile_cards). */
       cfg.memory_directives_enabled = 0;
+      /* css_style_graph now defaults on; set off to prove the opt-out round-trips
+       * (default-on save-guard regression class). */
+      cfg.css_style_graph_enabled = 0;
       /* kb.maintenance.* — must survive config_save (same drop class as curator). */
       cfg.kb_maintenance_enabled = 1;
       cfg.kb_maintenance_interval_hours = 12;
@@ -361,6 +367,7 @@ int main(void)
       assert(cfg2.memory_improve_min_cluster == 5);
       assert(fabs(cfg2.memory_improve_max_confidence - 0.42) < 0.0001);
       assert(cfg2.memory_directives_enabled == 0);
+      assert(cfg2.css_style_graph_enabled == 0); /* opt-out survives save/reload */
       /* regression: kb.maintenance.* used to be parsed but never saved -> dropped on save. */
       assert(cfg2.kb_maintenance_enabled == 1);
       assert(cfg2.kb_maintenance_interval_hours == 12);


### PR DESCRIPTION
## Summary
Flips `css_style_graph_enabled` to **default-on** so the read-only CSS signals + `aimee css report` work out of the box after indexing, instead of returning all-zeros until a user finds the opt-in flag.

## Changes
- `config_set_defaults`: `css_style_graph_enabled = 1`
- `config_save`: invert the save guard — persist only the **opt-out** (`false`), so a user's disable round-trips through save/reload (the default-on save-guard pattern used by `memory_profile_cards` / `directives`)
- `config.h`: document the new default
- `test_config`: assert default-on + opt-out round-trip

## Testing
- `make all` green
- `unit-test-config`, `unit-test-config-surface`, all `unit-test-css-*` green
- docs-gen (no churn) + build-integrity green

Read-only analysis; the indexer now populates css_rules/css_declarations during a normal scan.