### PR TITLE
feat(curator): default in-process provider from LLM_ENDPOINT env (bridge #413)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -442,6 +442,10 @@ Standard and third-party environment variables aimee honors (scanned non-`AIMEE_
 | `CODEX_SANDBOX` | Codex sandbox mode. |
 | `CODEX_THREAD_ID` | Codex conversation/thread id. |
 
+### Undocumented (add to `EXT_DESC`/`EXT_OS_IGNORE` in gen-reference-docs.py)
+
+`LLM_API_KEY`, `LLM_ENDPOINT`, `LLM_MODEL`
+
 ## Workflow engine
 
 Workflows are block-composed YAML definitions under `$AIMEE_HOME/workflows/<name>.yaml`, authored with the `aimee workflow` CLI or the web visual composer and saved in canonical form. A run is a DB1 work item pinned to a definition version.

--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -41,15 +41,20 @@ extern "C"
    /* Which tier a stage belongs to. */
    kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage);
 
-   /* Fill *out with the provider def for `stage`: Tier-A stages use the default
-    * `provider.*` config, Tier-B stages use `tier_b.*` (never the Tier-A default).
-    * Returns 1 when that tier is configured (out filled; base_url non-empty), 0
-    * when it is unconfigured (out zeroed — the stage must stay idle).
+   /* Fill *out with the provider def for `stage`. Resolution per tier:
+    *   1. tier config — Tier-A uses `provider.*`, Tier-B uses `tier_b.*`
+    *      (never the Tier-A config; no weak fallback between config tiers);
+    *   2. else the curator env — LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY (a single
+    *      endpoint that serves both tiers, matching the bundled-model deployment);
+    *   3. else idle.
+    * Returns 1 when configured (out filled; base_url non-empty), 0 when idle
+    * (out zeroed — the stage must not run).
     *
-    * Lifetime: out->base_url/model alias strings inside *cfg, so keep cfg alive
-    * (and unmodified) while using *out — the def is a borrowed view, not a copy.
-    * out->api_key is either a pointer into *cfg or NULL when no key is configured
-    * (a keyless local endpoint); provider_client treats NULL as "no bearer". */
+    * Lifetime: out->base_url/model/api_key alias strings owned elsewhere — either
+    * inside *cfg (config path) or the process environment (env path). Keep *cfg
+    * alive and don't mutate the environment (setenv/putenv) while using *out; the
+    * def is a borrowed view, not a copy. out->api_key is NULL when no key applies
+    * (keyless local endpoint); provider_client treats NULL as "no bearer". */
    int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
                                      provider_def_t *out);
 

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -2,6 +2,7 @@
 
 #include "kb_curator_provider.h"
 
+#include <stdlib.h> /* getenv */
 #include <string.h>
 
 kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage)
@@ -54,10 +55,25 @@ int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
       api_key = cfg->kb_curator_provider_api_key;
    }
 
-   /* An empty base_url means that tier is unconfigured — the stage stays idle.
-    * Tier-B intentionally does NOT fall back to the Tier-A default. */
+   /* Env bridge: when a tier has no config provider, fall back to the curator's
+    * LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY env (the interface the bundled-Gemma
+    * deployment and the python sidecars already use). A config provider for the
+    * tier takes precedence; the env is a single endpoint that, when set, serves
+    * BOTH tiers (matching the short-term "everything on the bundled model"
+    * behavior) until an operator sets a capable tier_b.* in config. This is a
+    * whole-provider fallback (base+model+key together), not field-level mixing —
+    * the config and env providers are distinct units. */
    if (!base_url[0])
-      return 0;
+   {
+      const char *env_ep = getenv("LLM_ENDPOINT");
+      if (!env_ep || !env_ep[0])
+         return 0; /* neither config nor env — the stage stays idle */
+      const char *env_model = getenv("LLM_MODEL");
+      const char *env_key = getenv("LLM_API_KEY");
+      base_url = env_ep;
+      model = (env_model && env_model[0]) ? env_model : "";
+      api_key = (env_key && env_key[0]) ? env_key : "";
+   }
 
    out->base_url = base_url;
    out->model = model;

--- a/src/tests/test_kb_curator_llm.c
+++ b/src/tests/test_kb_curator_llm.c
@@ -111,6 +111,11 @@ static void test_idle_when_unconfigured(void)
 
 int main(void)
 {
+   /* The resolver falls back to LLM_ENDPOINT env; clear it so the idle-path test
+    * is deterministic regardless of the ambient/CI environment. */
+   unsetenv("LLM_ENDPOINT");
+   unsetenv("LLM_MODEL");
+   unsetenv("LLM_API_KEY");
    test_provider_path();
    test_provider_error();
    test_idle_when_unconfigured();

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -94,6 +94,7 @@ static void test_tier_b_resolves(void)
  * (the bundled-deployment interface); a config tier_b still overrides. */
 static void test_env_bridge(void)
 {
+   clear_llm_env(); /* start from a known-clean env, not just clean up at the end */
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    setenv("LLM_ENDPOINT", "http://bundled:8080/v1", 1);

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -3,7 +3,17 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+/* The resolver falls back to LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY env; clear them
+ * so the config-path tests are deterministic regardless of the ambient env. */
+static void clear_llm_env(void)
+{
+   unsetenv("LLM_ENDPOINT");
+   unsetenv("LLM_MODEL");
+   unsetenv("LLM_API_KEY");
+}
 
 static void test_tier_classification(void)
 {
@@ -80,12 +90,50 @@ static void test_tier_b_resolves(void)
    printf("kb_curator_provider: tier-A and tier-B resolve independently ok\n");
 }
 
+/* With no config provider, LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY drive BOTH tiers
+ * (the bundled-deployment interface); a config tier_b still overrides. */
+static void test_env_bridge(void)
+{
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   setenv("LLM_ENDPOINT", "http://bundled:8080/v1", 1);
+   setenv("LLM_MODEL", "gemma-3n-e4b", 1);
+   setenv("LLM_API_KEY", "", 1); /* keyless local */
+
+   provider_def_t a, b;
+   /* Tier-A from env. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 1);
+   assert(strcmp(a.base_url, "http://bundled:8080/v1") == 0);
+   assert(strcmp(a.model, "gemma-3n-e4b") == 0);
+   assert(a.api_key == NULL); /* empty env key => keyless */
+   /* Tier-B ALSO from env (single endpoint serves both until tier_b configured). */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
+   assert(strcmp(b.base_url, "http://bundled:8080/v1") == 0);
+
+   /* A config tier_b overrides the env for Tier-B; Tier-A still uses env. */
+   snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
+            "https://api.big/v1");
+   snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
+   assert(strcmp(b.base_url, "https://api.big/v1") == 0 && strcmp(b.model, "big-32b") == 0);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 1);
+   assert(strcmp(a.base_url, "http://bundled:8080/v1") == 0); /* env still */
+
+   /* No env, no config => idle. */
+   clear_llm_env();
+   memset(&cfg, 0, sizeof(cfg));
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 0);
+   printf("kb_curator_provider: env bridge (LLM_ENDPOINT both tiers; tier_b override) ok\n");
+}
+
 int main(void)
 {
+   clear_llm_env();
    test_tier_classification();
    test_unconfigured_idle();
    test_tier_a_resolves();
    test_tier_b_resolves();
+   test_env_bridge();
    printf("kb_curator_provider: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Bridges the **short-term** bundled-Gemma deployment (#413) to the **long-term** in-process provider path. #413 wires the bundled model via `LLM_ENDPOINT`/`LLM_MODEL`/`LLM_API_KEY` (consumed by the python sidecars the curator stages `popen`). This makes the in-process resolver (`kb_curator_provider_for_stage`, §2) honor those **same env vars**, so a bundled-model deployment transparently drives `provider_client` — no separate config, no python sidecar — as stages migrate.

## Resolution (per tier)
1. **tier config** — Tier-A `provider.*`, Tier-B `tier_b.*` (unchanged; no weak fallback between config tiers);
2. else **`LLM_ENDPOINT`/`LLM_MODEL`/`LLM_API_KEY` env** — a single endpoint serving **both** tiers (matches #413's "everything on the bundled model"), overridable by a config `tier_b.*` for a capable Tier-B;
3. else **idle**.

Whole-provider fallback (base+model+key as a unit), not field-level mixing. `LLM_ENDPOINT` already includes `/v1` (same shape `provider_client` expects).

## Notes
- The out def may now alias the process environment as well as `*cfg` — header lifetime note updated (don't `setenv` while using it).
- Empty `LLM_API_KEY` ⇒ `out->api_key = NULL` (keyless local endpoint, no empty bearer).

## Verification
`make all` clean; `schema-sync` + `clang-format` clean; `unit-test-kb-curator-provider` (new env-bridge case: env drives both tiers, config `tier_b` overrides, no-env+no-config ⇒ idle, plus `clear_llm_env()` for deterministic config-path tests), `unit-test-kb-curator-llm`, and `unit-test-curator-synthesize` pass. Local roundtable gate run on the diff.
