### PR TITLE
fix(curator): LLM_ENDPOINT env defaults Tier-A only (E4B is Tier-A)

### DIFF
--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -44,9 +44,11 @@ extern "C"
    /* Fill *out with the provider def for `stage`. Resolution per tier:
     *   1. tier config — Tier-A uses `provider.*`, Tier-B uses `tier_b.*`
     *      (never the Tier-A config; no weak fallback between config tiers);
-    *   2. else the curator env — LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY (a single
-    *      endpoint that serves both tiers, matching the bundled-model deployment);
-    *   3. else idle.
+    *   2. else, for TIER-A ONLY, the curator env LLM_ENDPOINT/LLM_MODEL/
+    *      LLM_API_KEY (the bundled-model deployment — Gemma 3n E4B is a Tier-A
+    *      model, so it must not serve the reasoning stages);
+    *   3. else idle. Tier-B has NO env fallback: it needs a capable provider via
+    *      tier_b.* config, or it stays idle.
     * Returns 1 when configured (out filled; base_url non-empty), 0 when idle
     * (out zeroed — the stage must not run).
     *

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -57,14 +57,16 @@ int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
 
    /* Env bridge: when a tier has no config provider, fall back to the curator's
     * LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY env (the interface the bundled-Gemma
-    * deployment and the python sidecars already use). A config provider for the
-    * tier takes precedence; the env is a single endpoint that, when set, serves
-    * BOTH tiers (matching the short-term "everything on the bundled model"
-    * behavior) until an operator sets a capable tier_b.* in config. This is a
-    * whole-provider fallback (base+model+key together), not field-level mixing —
-    * the config and env providers are distinct units. */
+    * deployment and the python sidecars use). This applies to TIER-A ONLY: the
+    * bundled model (Gemma 3n E4B) is a Tier-A model, so letting it serve the
+    * reasoning stages would be exactly the weak-model-poisons-the-graph case §2a
+    * guards against. Tier-B takes a capable provider from tier_b.* config or it
+    * stays idle — no env fallback. A config provider for the tier still takes
+    * precedence. Whole-provider fallback (base+model+key as a unit). */
    if (!base_url[0])
    {
+      if (kb_curator_stage_tier(stage) != KB_CURATOR_TIER_A)
+         return 0; /* Tier-B: capable provider via tier_b.* config, or idle */
       const char *env_ep = getenv("LLM_ENDPOINT");
       if (!env_ep || !env_ep[0])
          return 0; /* neither config nor env — the stage stays idle */

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -108,8 +108,11 @@ static void test_env_bridge(void)
    assert(strcmp(a.base_url, "http://bundled:8080/v1") == 0);
    assert(strcmp(a.model, "gemma-3n-e4b") == 0);
    assert(a.api_key == NULL); /* empty env key => keyless */
-   /* Tier-B does NOT take the Tier-A env endpoint — it stays idle. */
+   /* Tier-B does NOT take the Tier-A env endpoint — it stays idle (out zeroed).
+    * Check two distinct Tier-B stages, not just one. */
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 0);
+   assert(b.base_url == NULL && b.model == NULL); /* idle => out zeroed */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 0);
 
    /* A config tier_b enables Tier-B (capable model); Tier-A still uses env. */
    snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -90,8 +90,9 @@ static void test_tier_b_resolves(void)
    printf("kb_curator_provider: tier-A and tier-B resolve independently ok\n");
 }
 
-/* With no config provider, LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY drive BOTH tiers
- * (the bundled-deployment interface); a config tier_b still overrides. */
+/* LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY drive TIER-A only (the bundled Gemma E4B is
+ * a Tier-A model). Tier-B has no env fallback — it needs tier_b.* config or stays
+ * idle, so a Tier-A model never runs the reasoning stages. */
 static void test_env_bridge(void)
 {
    clear_llm_env(); /* start from a known-clean env, not just clean up at the end */
@@ -107,11 +108,10 @@ static void test_env_bridge(void)
    assert(strcmp(a.base_url, "http://bundled:8080/v1") == 0);
    assert(strcmp(a.model, "gemma-3n-e4b") == 0);
    assert(a.api_key == NULL); /* empty env key => keyless */
-   /* Tier-B ALSO from env (single endpoint serves both until tier_b configured). */
-   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
-   assert(strcmp(b.base_url, "http://bundled:8080/v1") == 0);
+   /* Tier-B does NOT take the Tier-A env endpoint — it stays idle. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 0);
 
-   /* A config tier_b overrides the env for Tier-B; Tier-A still uses env. */
+   /* A config tier_b enables Tier-B (capable model); Tier-A still uses env. */
    snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
             "https://api.big/v1");
    snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
@@ -124,7 +124,7 @@ static void test_env_bridge(void)
    clear_llm_env();
    memset(&cfg, 0, sizeof(cfg));
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 0);
-   printf("kb_curator_provider: env bridge (LLM_ENDPOINT both tiers; tier_b override) ok\n");
+   printf("kb_curator_provider: env bridge (Tier-A only; Tier-B needs config) ok\n");
 }
 
 int main(void)


### PR DESCRIPTION
**Correction to the env bridge (#416):** the bundled Gemma 3n E4B is a **Tier-A** model, so the `LLM_ENDPOINT`/`LLM_MODEL`/`LLM_API_KEY` env fallback must drive **Tier-A only**.

#416 let the single env endpoint serve both tiers. But running the bundled E4B on the **Tier-B reasoning stages** (judge, resolve_entities, detect_contradictions, synthesize, promote_entity) is exactly the *weak-model-poisons-the-graph* case §2a guards against.

## Change
`kb_curator_provider_for_stage`: the env fallback now applies **only when the stage is Tier-A**. Tier-B takes a capable provider from `tier_b.*` config, or stays **idle** — no env fallback. Config providers (`provider.*` / `tier_b.*`) still take precedence, unchanged.

Net effect: a bundled-Gemma deployment drives the Tier-A extract/index stages in-process; the reasoning stages wait for an operator-configured `tier_b` (a capable model) rather than silently running on E4B.

## Verification
`make all` clean; `schema-sync` + `clang-format` clean; `unit-test-kb-curator-provider` updated (Tier-B idle with only `LLM_ENDPOINT`; resolves once `tier_b.*` is set; Tier-A still from env) + `unit-test-kb-curator-llm` pass. Local roundtable gate run on the diff.
