### PR TITLE
fix(memory): embedder-aware semantic recall — re-enable vector leg for 1024/2560

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (107)
+## CLI-settable keys (108)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -120,6 +120,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `memory_scenes_enabled` | bool | Cluster memories into scenes. |
 | `memory_scenes_min_cluster_size` | int | Min cluster size for a scene. |
 | `memory_scenes_top_m` | int | Top-M scenes to consider. |
+| `memory_semantic_floor_scale` | float | Multiplier on the semantic-recall cosine floors (0 = auto-scale by the active embedder dimension; >0 pins it). |
 | `memory_semantic_weight` | float | Semantic (vector) weight in hybrid recall. |
 | `memory_window_radius` | int | Neighbour radius for memory-window expansion. |
 | `openai_endpoint` | string | OpenAI-compatible endpoint URL. |
@@ -165,7 +166,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`lsp_servers`** — _LSP server definitions (array of objects)._ Keys: `args`, `command`, `extensions`, `name`
 - **`mcp`** — _MCP integration (e.g. OSV)._ Keys: `osv`
 - **`mcp_clients`** — _MCP client connections (array of objects)._ Keys: `bearer_token_env`, `command`, `cwd`, `name`, `transport`, `url`
-- **`memory`** — _Memory subsystem; most children (recall, rerank, lifecycle, …) are nested objects with their own keys._ Keys: `abstain`, `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_weight`
+- **`memory`** — _Memory subsystem; most children (recall, rerank, lifecycle, …) are nested objects with their own keys._ Keys: `abstain`, `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_floor_scale`, `semantic_weight`
 - **`memory_maintenance`** — _Memory maintenance scheduling._ Keys: `enabled`, `interval_seconds`, `summarize_enabled`, `trigger_inserts`, `trigger_secs`
 - **`memory_negation`** — _Negation handling in memory._ Keys: `enabled`
 - **`memory_query_expansion`** — _Recall query expansion._ Keys: `k`, `mode`

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -195,6 +195,7 @@ CFG_KEY_DESC = {
     "memory_scenes_enabled": "Cluster memories into scenes.",
     "memory_scenes_min_cluster_size": "Min cluster size for a scene.",
     "memory_scenes_top_m": "Top-M scenes to consider.",
+    "memory_semantic_floor_scale": "Multiplier on the semantic-recall cosine floors (0 = auto-scale by the active embedder dimension; >0 pins it).",
     "memory_semantic_weight": "Semantic (vector) weight in hybrid recall.",
     "memory_window_radius": "Neighbour radius for memory-window expansion.",
     "openai_endpoint": "OpenAI-compatible endpoint URL.",

--- a/src/config.c
+++ b/src/config.c
@@ -414,6 +414,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_scenes_global_escape_ratio = 0.2;
    cfg->memory_bm25_weight = 0.0;
    cfg->memory_semantic_weight = 0.0;
+   cfg->memory_semantic_floor_scale = 0.0; /* 0 = auto-scale by embedding dim */
    cfg->memory_fetch_budget_enabled = 0;
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -110,6 +110,8 @@ const config_field_t config_fields[] = {
     {"memory_bm25_weight", offsetof(config_t, memory_bm25_weight), sizeof(double), 0, CFG_FLOAT},
     {"memory_semantic_weight", offsetof(config_t, memory_semantic_weight), sizeof(double), 0,
      CFG_FLOAT},
+    {"memory_semantic_floor_scale", offsetof(config_t, memory_semantic_floor_scale), sizeof(double),
+     0, CFG_FLOAT},
     {"memory_fetch_budget_enabled", offsetof(config_t, memory_fetch_budget_enabled), sizeof(int), 0,
      CFG_BOOL},
     {"memory_fetch_budget_base", offsetof(config_t, memory_fetch_budget_base), sizeof(int), 0,

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -383,6 +383,9 @@ void config_parse_memory_section(config_t *cfg, cJSON *root)
       item = cJSON_GetObjectItemCaseSensitive(memory_cfg, "semantic_weight");
       if (cJSON_IsNumber(item) && item->valuedouble >= 0.0)
          cfg->memory_semantic_weight = item->valuedouble;
+      item = cJSON_GetObjectItemCaseSensitive(memory_cfg, "semantic_floor_scale");
+      if (cJSON_IsNumber(item) && item->valuedouble >= 0.0)
+         cfg->memory_semantic_floor_scale = item->valuedouble;
 
       /* Dynamic fetch budget */
       cJSON *fetch_cfg = cJSON_GetObjectItemCaseSensitive(memory_cfg, "fetch_budget");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -577,6 +577,14 @@ typedef struct config
    double memory_bm25_weight;
    double memory_semantic_weight;
 
+   /* Cosine-similarity floor scale for the semantic-memory legs. The floors in
+    * memory_collect_*_semantic_matches were calibrated for the retired 384-d
+    * builtin embedder, whose cosine range runs high; modern embedders compress
+    * that range (pplx-0.6b relevant matches ~0.35-0.40, pplx-4b higher), so a
+    * fixed 384-era floor rejects every real hit. 0 = auto-scale by the active
+    * embedding dimension (db2_embedding_dim()); >0 pins the multiplier. */
+   double memory_semantic_floor_scale;
+
    /* Dynamic fetch budget: total candidate pool size, intent-scaled.
     * memory_fetch_budget_enabled: 0 = use fixed pool (default), 1 = scale by specificity.
     * memory_fetch_budget_base: base candidate count; intent multiplier is applied on top

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -947,6 +947,10 @@ void memory_query_embed_cache_reset_test(void);
 void memory_query_embed_cache_stats_test(int *requests, int *misses);
 void memory_query_embed_prewarm_test(const char *const *texts, int n, const char *command);
 
+/* Test hooks for the embedder-aware semantic-recall gate + floor scale. */
+int memory_semantic_dim_ok_test(int qdim);
+double memory_semantic_floor_scale_test(void);
+
 /* --- Effectiveness Tracking --- */
 
 typedef struct

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -469,10 +469,55 @@ static double memory_unit_semantic_type_boost(const char *unit_type, memory_quer
    return 0.0;
 }
 
+/* Whether the semantic-vector leg can run for a freshly embedded query: it must
+ * have produced a vector AND that vector's dimension must match the dimension
+ * the memory vectors were stored at (db2_embedding_dim()), so pgvector compares
+ * like with like. This generalises the historical `qdim == 384` special-case —
+ * which silently disabled semantic recall for every embedder other than the
+ * retired 384-d builtin — to whatever single embedder the deployment runs. */
+static int memory_semantic_dim_ok(int qdim)
+{
+   return qdim > 0 && qdim == db2_embedding_dim();
+}
+
+/* Cosine-similarity floors below were calibrated for the 384-d builtin embedder.
+ * Different embedders occupy different cosine ranges, so a fixed floor that
+ * keeps the right hits for one rejects them all for another (pplx-0.6b relevant
+ * matches land ~0.35-0.40, well under the 0.62/0.52 builtin-era floors). Scale
+ * the floors to the active embedder. config.memory_semantic_floor_scale > 0
+ * pins the multiplier (live calibration without a rebuild); 0 auto-scales by the
+ * active embedding dimension. Returns a multiplier applied to every floor. */
+static double memory_semantic_floor_scale(void)
+{
+   config_t fs_cfg;
+   if (config_load(&fs_cfg) == 0 && fs_cfg.memory_semantic_floor_scale > 0.0)
+      return fs_cfg.memory_semantic_floor_scale;
+   int dim = db2_embedding_dim();
+   if (dim <= 384)
+      return 1.0; /* 384-d builtin: the floors are calibrated for this range */
+   if (dim <= 1024)
+      return 0.55; /* pplx-0.6b: relevant cosines observed ~0.38 (0.62*0.55=0.34) */
+   if (dim <= 2560)
+      return 0.75; /* pplx-4b: wider than 0.6b but estimated — tune via config */
+   return 0.65;    /* unknown embedder: lean permissive over silently dropping */
+}
+
+/* Test hooks (declared in memory.h): expose the embedder-aware semantic gate +
+ * floor scale so unit tests can pin db2_set_embedding_dim() and assert that the
+ * leg runs and the floor tracks the active embedder dimension. */
+int memory_semantic_dim_ok_test(int qdim)
+{
+   return memory_semantic_dim_ok(qdim);
+}
+double memory_semantic_floor_scale_test(void)
+{
+   return memory_semantic_floor_scale();
+}
+
 /* Visitor state for the ephemeral-mode in-memory cosine scan. The visitor
- * keeps the top hits whose sim >= 0.62, deduplicating by memory_id and
- * resolving the memory row inline. The fixed cap matches the original local
- * array size; once we run out of slots we drop further matches. */
+ * keeps the top hits whose sim >= the embedder-scaled floor, deduplicating by
+ * memory_id and resolving the memory row inline. The fixed cap matches the
+ * original local array size; once we run out of slots we drop further matches. */
 static int memory_collect_semantic_matches(const char *query, const char *command, int limit,
                                            memory_t *out, int count, int max, int64_t *semantic_ids,
                                            double *semantic_scores, int *semantic_hit_count,
@@ -491,8 +536,9 @@ static int memory_collect_semantic_matches(const char *query, const char *comman
    if (qdim <= 0)
       return count;
 
-   if (qdim == 384)
+   if (memory_semantic_dim_ok(qdim))
    {
+      const double floor_scale = memory_semantic_floor_scale();
       int64_t ids[128];
       double scores[128];
       int hit_total = pgvec_memory_vector_search_record_type(
@@ -505,7 +551,7 @@ static int memory_collect_semantic_matches(const char *query, const char *comman
          for (int i = 0; i < hit_total && count < max && appended < limit; i++)
          {
             double sim = scores[i];
-            if (sim < 0.62)
+            if (sim < 0.62 * floor_scale)
                continue;
 
             memory_t candidate;
@@ -549,8 +595,9 @@ static int memory_collect_unit_semantic_matches(const char *query, const char *c
    if (qdim <= 0)
       return count;
 
-   if (qdim == 384)
+   if (memory_semantic_dim_ok(qdim))
    {
+      const double floor_scale = memory_semantic_floor_scale();
       int64_t ids[128];
       double vector_scores[128];
       int q_hits = pgvec_memory_vector_search_record_type(
@@ -592,6 +639,7 @@ static int memory_collect_unit_semantic_matches(const char *query, const char *c
             else if (intent == MEM_QUERY_TEMPORAL &&
                      (strcmp(unit_type, "temporal") == 0 || strcmp(unit_type, "event") == 0))
                threshold = 0.46;
+            threshold *= floor_scale;
             if (sim < threshold)
                continue;
 

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -18,6 +18,7 @@
 #include "platform_test_util.h"
 #include "workspace.h"
 #include "../db2/db2_internal.h"
+#include "../db2/lifecycle.h" /* db2_set_embedding_dim (embedder-aware semantic recall) */
 #include "../db2/entity_edges.h"
 #include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "../db2/demotion.h"       /* retrieval_event write/read (auditable-correctness P2) */
@@ -571,6 +572,39 @@ static void measure_query_embedding_memo_recall(void)
    teardown();
 }
 
+/* The semantic-memory legs were gated on `qdim == 384` (the retired builtin) and
+ * used 384-calibrated cosine floors, so semantic recall was silently dead for
+ * pplx-0.6b (1024) / pplx-4b (2560). Verify the gate now tracks the active
+ * embedding dim and the floor scales down for the compressed-range embedders. */
+static void test_semantic_recall_is_embedder_aware(void)
+{
+   setup();
+
+   db2_set_embedding_dim(384);
+   assert(memory_semantic_dim_ok_test(384) == 1);
+   assert(memory_semantic_dim_ok_test(1024) == 0); /* mismatch must not query */
+   assert(memory_semantic_dim_ok_test(0) == 0);    /* embed failure */
+   assert(fabs(memory_semantic_floor_scale_test() - 1.0) < 1e-9);
+
+   db2_set_embedding_dim(1024); /* pplx-0.6b: the leg must now run */
+   assert(memory_semantic_dim_ok_test(1024) == 1);
+   assert(memory_semantic_dim_ok_test(384) == 0);
+   double s1024 = memory_semantic_floor_scale_test();
+   assert(s1024 > 0.0 && s1024 < 1.0); /* floors relaxed vs the 384 baseline */
+   assert(0.62 * s1024 < 0.45);        /* 384-era 0.62 floor now clears ~0.38 hits */
+
+   db2_set_embedding_dim(2560); /* pplx-4b */
+   assert(memory_semantic_dim_ok_test(2560) == 1);
+   double s2560 = memory_semantic_floor_scale_test();
+   assert(s2560 > s1024 && s2560 <= 1.0); /* 4b range wider than 0.6b, <= builtin */
+
+   db2_set_embedding_dim(9999); /* unknown embedder: permissive, never 1:1 */
+   assert(memory_semantic_floor_scale_test() < 1.0);
+
+   db2_set_embedding_dim(1024); /* restore the deployment default */
+   teardown();
+}
+
 int main(void)
 {
    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
@@ -587,6 +621,7 @@ int main(void)
    test_db1_runtime_state_add_int();
    test_query_embedding_memo_dedupes_embeds();
    test_query_embed_prewarm_batches();
+   test_semantic_recall_is_embedder_aware();
    measure_query_embedding_memo_recall();
    test_insert_memory();
    test_insert_merge();


### PR DESCRIPTION
## The miss

The semantic-vector legs of memory recall were gated on `qdim == 384` — the **retired 384-d builtin embedder**. Every current deployment runs pplx-0.6b (1024) or pplx-4b (2560), so semantic memory recall was **silently dead**: recall fell back to lexical/trigram only, with no embedding-based retrieval. This is a long-standing latent bug (the gate predates the repo's squashed snapshot).

## Fix

**1. Gate on the active embedding dim, not a hardcoded 384.** `memory_semantic_dim_ok(qdim)` runs the leg when `qdim == db2_embedding_dim()` (the dim the memory vectors were stored at), so pgvector compares like with like. Restores semantic recall for 1024/2560; still correct for a 384 deployment; skips safely on a dim mismatch (mid-swap).

**2. Embedder-aware cosine floors.** The floors (`0.62/0.52/0.58/0.46`) were calibrated for the 384 builtin's high cosine range. Modern embedders compress it — pplx-0.6b relevant matches land ~0.38 (measured live on .254 via direct pgvector ANN), well under the old floors. `memory_semantic_floor_scale()` scales them to the active embedder:

| dim | embedder | scale | 0.62 floor → |
|----|----|----|----|
| ≤384 | builtin | 1.00 | 0.62 (unchanged) |
| ≤1024 | pplx-0.6b | 0.55 | 0.34 |
| ≤2560 | pplx-4b | 0.75 (est.) | 0.47 |
| else | unknown | 0.65 | 0.40 |

New config field `memory_semantic_floor_scale` (default `0` = auto) pins the multiplier for **live calibration without a rebuild** — the 4b factor is an estimate pending a 4b deployment to calibrate against; over-filtering is the failure mode we're fixing, so the auto defaults lean permissive (the reranker/fusion do the real ranking downstream).

## Tests
- `test_semantic_recall_is_embedder_aware` (test_memory.c): the gate tracks the active dim and rejects mismatches; the floor scales <1.0 for 1024/2560 and =1.0 at 384.
- Built + ran `unit-test-memory` (all passed) and `unit-test-config` (green); clang-format-19 clean on all touched files.

## Live validation note
Re-enabling the leg needs the new image deployed to .254 to validate end-to-end, and .254's personal-memory store currently holds only 3 episodes (kb corpus is the populated one), so a full recall-relevance test wants both the deploy and a populated store. The retrieval primitives are confirmed working live at 1024 (direct pgvector ANN returns ranked neighbors; reranker scores correctly).