### PR TITLE
feat(curator): route judge (Tier-B) through the provider dispatch (§2b)

### DIFF
--- a/src/kb/kb_curator_judge.c
+++ b/src/kb/kb_curator_judge.c
@@ -7,11 +7,22 @@
 
 #include "kb_curator_judge.h"
 #include "kb_curator_sidecar.h"
+#include "kb_curator_llm.h"
 #include "cJSON.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* System prompt for the judge stage (Tier-B) when routed through a configured
+ * provider (§2b). The legacy python sidecar carried its own prompt; the
+ * in-process provider needs one. The request JSON (mention + candidate + score)
+ * is the user turn; tune against the model. */
+#define CJ_SYSTEM_PROMPT                                                                           \
+   "You are an entity-resolution judge for a knowledge base. Given a candidate "                   \
+   "mention and an existing entity as JSON, decide whether they are the same "                     \
+   "canonical thing. Respond with a single JSON object: {\"same_entity\": "                        \
+   "true|false}. When unsure, answer false."
 
 /* Build the request JSON. Returns a malloc'd string (caller frees) or NULL. */
 static char *cj_build_request(const char *mention_name, const char *mention_context,
@@ -37,18 +48,13 @@ static char *cj_build_request(const char *mention_name, const char *mention_cont
    return json;
 }
 
-int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name,
-                                 const char *mention_context, const char *candidate_name,
-                                 double score, int *out_same, char *errbuf, size_t errlen)
+int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
+                                 const char *mention_name, const char *mention_context,
+                                 const char *candidate_name, double score, int *out_same,
+                                 char *errbuf, size_t errlen)
 {
    if (errbuf && errlen)
       errbuf[0] = '\0';
-   if (!judge_cmd || !judge_cmd[0])
-   {
-      if (errbuf)
-         snprintf(errbuf, errlen, "no judge command configured");
-      return -1;
-   }
    if (!out_same)
       return -1;
 
@@ -60,8 +66,12 @@ int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name
       return -1;
    }
 
+   /* Tier-B dispatch: a configured tier_b.* provider runs in-process, else the
+    * judge_cmd sidecar; "neither configured" surfaces as -1 (caller treats as
+    * not-same / create). */
    char local_err[256];
-   char *response = kb_curator_sidecar_run(judge_cmd, request, 0, local_err, sizeof(local_err));
+   char *response = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_JUDGE, CJ_SYSTEM_PROMPT, request,
+                                       judge_cmd, 0, local_err, sizeof(local_err));
    free(request);
    if (!response)
    {

--- a/src/kb/kb_curator_judge.h
+++ b/src/kb/kb_curator_judge.h
@@ -13,21 +13,29 @@
 #ifndef KB_CURATOR_JUDGE_H
 #define KB_CURATOR_JUDGE_H
 
+#include "config.h" /* config_t — for Tier-B provider resolution via kb_curator_llm */
+
 #include <stddef.h>
 
-/* Ask the judge sidecar whether `mention` refers to the same canonical entity
- * as `candidate`. Request JSON:
+/* Ask the judge whether `mention` refers to the same canonical entity as
+ * `candidate`. Request JSON:
  *   {"task":"same_entity","mention":{"name":...,"context":...},
  *    "candidate":{"name":...},"score":<float>}
  * Expected response JSON: {"same_entity": true|false}.
  *
+ * Routes through the §2 dispatch (kb_curator_llm_run): judge is a Tier-B stage,
+ * so it uses a configured tier_b.* provider in-process, else the `judge_cmd`
+ * sidecar, else errors. `cfg` may be NULL (provider resolution skipped → sidecar
+ * only) — the unit tests pass NULL to exercise the shell-sidecar path.
+ *
  * Returns 0 and sets *out_same to 0/1 on a clean decision. Returns -1 on any
- * error (empty command, spawn failure, non-zero exit, unparseable output) and
- * leaves *out_same untouched — the caller MUST treat a judge error as "not the
- * same entity" (i.e. create), never as a merge, so a flaky sidecar can only
- * over-create, never silently collapse distinct entities. */
-int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name,
-                                 const char *mention_context, const char *candidate_name,
-                                 double score, int *out_same, char *errbuf, size_t errlen);
+ * error (no provider and no command, spawn failure, non-zero exit, unparseable
+ * output) and leaves *out_same untouched — the caller MUST treat a judge error
+ * as "not the same entity" (i.e. create), never as a merge, so a flaky judge can
+ * only over-create, never silently collapse distinct entities. */
+int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
+                                 const char *mention_name, const char *mention_context,
+                                 const char *candidate_name, double score, int *out_same,
+                                 char *errbuf, size_t errlen);
 
 #endif /* KB_CURATOR_JUDGE_H */

--- a/src/kb/kb_curator_resolve_entities.c
+++ b/src/kb/kb_curator_resolve_entities.c
@@ -99,12 +99,12 @@ static int resolve_try_match(const char *scope_kind, const char *scope_id, const
       return 1;
    }
    /* Judge the ambiguous band when there's somewhere to send it: a configured
-    * Tier-B provider (§2) or the legacy judge sidecar command. */
+    * Tier-B provider (§2) or the legacy judge sidecar command. The score check is
+    * first so the provider lookup runs only for an actual ambiguous-band match. */
    provider_def_t judge_provider;
-   int judge_available =
-       cfg->kb_curator_judge_command[0] ||
-       kb_curator_provider_for_stage(cfg, KB_CURATOR_STAGE_JUDGE, &judge_provider);
-   if (match_scores[0] >= CURATOR_ENTITY_JUDGE_LOW && judge_available)
+   if (match_scores[0] >= CURATOR_ENTITY_JUDGE_LOW &&
+       (cfg->kb_curator_judge_command[0] ||
+        kb_curator_provider_for_stage(cfg, KB_CURATOR_STAGE_JUDGE, &judge_provider)))
    {
       char cand_name[256];
       if (pgvec_curator_entity_lookup(match_ids[0], NULL, 0, cand_name, sizeof(cand_name)) == 1)

--- a/src/kb/kb_curator_resolve_entities.c
+++ b/src/kb/kb_curator_resolve_entities.c
@@ -17,7 +17,8 @@
 
 #include "kb_curator_resolve_entities.h"
 #include "kb_curator_judge.h"
-#include "kb_curator_promote.h" /* kb_curator_broaden_scope (scope lattice) */
+#include "kb_curator_provider.h" /* kb_curator_provider_for_stage (judge availability) */
+#include "kb_curator_promote.h"  /* kb_curator_broaden_scope (scope lattice) */
 #include "aimee.h"
 #include "config.h"
 #include "cJSON.h"
@@ -97,7 +98,13 @@ static int resolve_try_match(const char *scope_kind, const char *scope_id, const
                 name, scope_kind, scope_id, match_scores[0]);
       return 1;
    }
-   if (match_scores[0] >= CURATOR_ENTITY_JUDGE_LOW && cfg->kb_curator_judge_command[0])
+   /* Judge the ambiguous band when there's somewhere to send it: a configured
+    * Tier-B provider (§2) or the legacy judge sidecar command. */
+   provider_def_t judge_provider;
+   int judge_available =
+       cfg->kb_curator_judge_command[0] ||
+       kb_curator_provider_for_stage(cfg, KB_CURATOR_STAGE_JUDGE, &judge_provider);
+   if (match_scores[0] >= CURATOR_ENTITY_JUDGE_LOW && judge_available)
    {
       char cand_name[256];
       if (pgvec_curator_entity_lookup(match_ids[0], NULL, 0, cand_name, sizeof(cand_name)) == 1)
@@ -105,8 +112,8 @@ static int resolve_try_match(const char *scope_kind, const char *scope_id, const
          int same = 0;
          char jerr[256];
          int jrc =
-             kb_curator_judge_same_entity(cfg->kb_curator_judge_command, name, context, cand_name,
-                                          match_scores[0], &same, jerr, sizeof(jerr));
+             kb_curator_judge_same_entity(cfg, cfg->kb_curator_judge_command, name, context,
+                                          cand_name, match_scores[0], &same, jerr, sizeof(jerr));
          if (jrc == 0 && same)
          {
             aimee_log(LOG_INFO, "kb.curator.resolve",

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1775,6 +1775,7 @@ $(TESTPREFIX)/unit-test-curator-code-unit: \
 $(TESTPREFIX)/unit-test-curator-resolve-entities: \
                                        $(OBJDIR)/tests/test_curator_resolve_entities.o \
                                        $(OBJDIR)/kb/kb_curator_resolve_entities.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
                                        $(OBJDIR)/db2/artifacts.o \
                                        $(OBJDIR)/db2/feature_rows.o \
                                        $(OBJDIR)/kb/kb_mdl.o \
@@ -1835,6 +1836,7 @@ $(TESTPREFIX)/unit-test-curator-index-code-unit: \
 $(TESTPREFIX)/unit-test-curator-pipeline: \
                                        $(OBJDIR)/tests/test_curator_pipeline.o \
                                        $(OBJDIR)/kb/kb_curator_resolve_entities.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
                                        $(OBJDIR)/kb/kb_curator_index_code_unit.o \
                                        $(OBJDIR)/kb/kb_curator_link_artifacts.o \
                                        $(OBJDIR)/kb/kb_curator_serve.o \
@@ -1874,6 +1876,10 @@ $(TESTPREFIX)/unit-test-curator-judge: \
                                        $(OBJDIR)/tests/test_curator_judge.o \
                                        $(OBJDIR)/kb/kb_curator_judge.o \
                                        $(OBJDIR)/kb/kb_curator_sidecar.o \
+                                       $(OBJDIR)/kb/kb_curator_llm.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
+                                       $(OBJDIR)/provider_client.o \
+                                       $(OBJDIR)/tests/support/mock_agent_http.o \
                                        $(OBJDIR)/cJSON.o \
                                        $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_curator_judge.c
+++ b/src/tests/test_curator_judge.c
@@ -13,8 +13,8 @@ static void test_no_command(void)
    /* Empty command -> error, *out_same untouched. */
    int same = 42;
    char err[256];
-   int rc =
-       kb_curator_judge_same_entity("", "Acme", "ctx", "Acme Corp", 0.78, &same, err, sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "", "Acme", "ctx", "Acme Corp", 0.78, &same, err,
+                                         sizeof(err));
    assert(rc == -1);
    assert(same == 42); /* left untouched */
    printf("  no-command -> error OK\n");
@@ -25,8 +25,8 @@ static void test_same_true(void)
    int same = -1;
    char err[256];
    /* The sidecar ignores stdin and emits the canonical affirmative response. */
-   int rc = kb_curator_judge_same_entity("printf '{\"same_entity\": true}'", "Acme", "the vendor",
-                                         "Acme Corp", 0.80, &same, err, sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "printf '{\"same_entity\": true}'", "Acme",
+                                         "the vendor", "Acme Corp", 0.80, &same, err, sizeof(err));
    assert(rc == 0);
    assert(same == 1);
    printf("  same_entity=true parsed OK\n");
@@ -36,8 +36,8 @@ static void test_same_false(void)
 {
    int same = -1;
    char err[256];
-   int rc = kb_curator_judge_same_entity("printf '{\"same_entity\": false}'", "Apple", "the fruit",
-                                         "Apple Inc", 0.72, &same, err, sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "printf '{\"same_entity\": false}'", "Apple",
+                                         "the fruit", "Apple Inc", 0.72, &same, err, sizeof(err));
    assert(rc == 0);
    assert(same == 0);
    printf("  same_entity=false parsed OK\n");
@@ -49,8 +49,8 @@ static void test_prose_wrapped(void)
    int same = -1;
    char err[256];
    int rc = kb_curator_judge_same_entity(
-       "printf 'Sure! Here is my verdict:\\n{\"same_entity\": true}\\n'", "K8s", "orchestrator",
-       "Kubernetes", 0.83, &same, err, sizeof(err));
+       NULL, "printf 'Sure! Here is my verdict:\\n{\"same_entity\": true}\\n'", "K8s",
+       "orchestrator", "Kubernetes", 0.83, &same, err, sizeof(err));
    assert(rc == 0);
    assert(same == 1);
    printf("  prose-wrapped JSON parsed OK\n");
@@ -60,8 +60,8 @@ static void test_garbage_output(void)
 {
    int same = 7;
    char err[256];
-   int rc = kb_curator_judge_same_entity("echo not-json-at-all", "x", "", "y", 0.75, &same, err,
-                                         sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "echo not-json-at-all", "x", "", "y", 0.75, &same,
+                                         err, sizeof(err));
    assert(rc == -1);
    assert(same == 7);
    printf("  garbage output -> error OK\n");
@@ -71,7 +71,8 @@ static void test_nonzero_exit(void)
 {
    int same = 9;
    char err[256];
-   int rc = kb_curator_judge_same_entity("false", "x", "", "y", 0.75, &same, err, sizeof(err));
+   int rc =
+       kb_curator_judge_same_entity(NULL, "false", "x", "", "y", 0.75, &same, err, sizeof(err));
    assert(rc == -1);
    assert(same == 9);
    printf("  non-zero exit -> error OK\n");

--- a/src/tests/test_curator_resolve_entities.c
+++ b/src/tests/test_curator_resolve_entities.c
@@ -96,10 +96,12 @@ int pgvec_curator_entity_lookup(int64_t point_id, char *artifact_id_out, int aid
       name_out[0] = '\0';
    return 0;
 }
-int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name,
-                                 const char *mention_context, const char *candidate_name,
-                                 double score, int *out_same, char *errbuf, size_t errlen)
+int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
+                                 const char *mention_name, const char *mention_context,
+                                 const char *candidate_name, double score, int *out_same,
+                                 char *errbuf, size_t errlen)
 {
+   (void)cfg;
    (void)judge_cmd;
    (void)mention_name;
    (void)mention_context;


### PR DESCRIPTION
**§2b — final curator-LLM migration: the entity-resolution judge (Tier-B).** Completes the §2 migration; all three curator-LLM sites (extract Tier-A, synthesize + judge Tier-B) now route through the shared dispatch.

## Changes
- **`kb_curator_judge_same_entity`** routes through `kb_curator_llm_run`: a configured `tier_b.*` provider runs in-process via `provider_client`, else the legacy `judge_cmd` sidecar, else error. Gains a `const config_t *cfg` first param (`NULL` ⇒ provider skipped → sidecar only; the unit tests pass `NULL`). Dropped the early "no judge command" guard — the dispatch now decides. Added `CJ_SYSTEM_PROMPT` for the in-process path.
- **`resolve_entities`** — the ambiguous-band `[0.70, 0.85)` gate now fires when judge is available via a **Tier-B provider OR** the command (not command-only), and passes `cfg`. Since judge is Tier-B, the bundled Tier-A `LLM_ENDPOINT` does **not** enable it — a `tier_b.*` provider does (no weak model on entity resolution).
- **Safety preserved:** a judge error/idle still falls through to *create* (merge only on `jrc==0 && same`).

## Tests
Updated the judge stub signature in `test_curator_resolve_entities.c`; passed `NULL` cfg in the 6 judge-test calls (sidecar path preserved); added the provider/llm/transport objects to the `curator-judge`, `-resolve-entities`, and `-pipeline` link lines. **All 19 curator unit tests build + pass**; `make all` + `make lint` clean.
