### PR TITLE
Promote testing → main: embedder-aware semantic memory recall (#422)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,10 +285,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       # macOS ships ONE universal (arm64 + x86_64) thin client, matching the
-      # release build. WITH_TLS=OFF means the binary links only Threads, so the
-      # fat build needs no arch-specific brew libraries.
+      # release build. TLS uses Secure Transport (system frameworks, already
+      # universal), so the fat build needs no arch-specific brew libraries.
       - name: Configure with CMake (universal arm64+x86_64)
-        run: cmake -B build -DAIMEE_THIN_CLIENT=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
+        run: cmake -B build -DAIMEE_THIN_CLIENT=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"
       - name: Build the thin client
         run: |
           cmake --build build --parallel 3 --target aimee

--- a/.github/workflows/release-thin-client.yml
+++ b/.github/workflows/release-thin-client.yml
@@ -49,8 +49,8 @@ jobs:
             kind: linux
             asset: aimee-linux-arm64
           # macOS: one universal (arm64 + x86_64) binary, built on macos-latest.
-          # Avoids the scarce/deprecating Intel runner; the thin client links only
-          # Threads (WITH_TLS=OFF, as on Windows), so a fat build needs no
+          # Avoids the scarce/deprecating Intel runner; TLS uses Secure Transport
+          # (system frameworks, already universal), so a fat build still needs no
           # arch-specific brew libraries.
           - os: macos-latest
             kind: macos
@@ -104,7 +104,7 @@ jobs:
       - name: Build (macOS, CMake -- universal arm64+x86_64)
         if: matrix.kind == 'macos'
         run: |
-          cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
+          cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 3 --target aimee
           # Fail the build unless the artifact is a true fat binary.
           echo "archs: $(lipo -archs build/aimee)"
@@ -156,7 +156,7 @@ jobs:
       - name: Build (Windows, CMake)
         if: matrix.kind == 'windows'
         run: |
-          cmake -B build -G "MinGW Makefiles" -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=OFF -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
+          cmake -B build -G "MinGW Makefiles" -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON -DAIMEE_VERSION_STR="${{ steps.ver.outputs.version != '' && format('v{0}', steps.ver.outputs.version) || '' }}"
           cmake --build build --parallel 2 --target aimee
       - name: Stage artifact (Windows)
         if: matrix.kind == 'windows'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,10 +22,12 @@ option(WITH_PAM "Enable PAM authentication support" ON)
 option(WITH_LIBSECRET "Enable libsecret integration" ON)
 option(WITH_UI "Enable embedded dashboard UI" OFF)
 option(WITH_TLS "Enable in-client TLS for https:// remote aimee-servers" ON)
-if(WIN32)
-    # MinGW thin client has no OpenSSL; https:// is refused there.
-    set(WITH_TLS OFF CACHE BOOL "Enable in-client TLS" FORCE)
-endif()
+# TLS backend by platform (all behind the same 4-function aimee_tls.h interface):
+#   Linux   -> OpenSSL    (aimee_tls.c)
+#   macOS   -> Secure Transport (aimee_tls_securetransport.c) — universal-safe, Keychain trust
+#   Windows -> Schannel/SSPI    (aimee_tls_schannel.c)        — no OpenSSL, Windows cert store
+# Each uses the OS trust store, so the single-binary thin client needs no bundled
+# CA bundle and no external TLS library.
 option(AIMEE_LEAN "Lean build profile: size-optimized, no UI" OFF)
 # Thin-client-only profile: configure and build ONLY the `aimee` CLI target,
 # skipping aimee-server / aimee-kb / aimee-gateway / aimee-webchat and the test
@@ -1197,10 +1199,27 @@ if(WIN32)
     set_target_properties(aimee PROPERTIES INTERPROCEDURAL_OPTIMIZATION FALSE)
 endif()
 if(WITH_TLS)
-    find_package(OpenSSL REQUIRED)
-    target_sources(aimee PRIVATE ${AIMEE_SRC_DIR}/aimee_tls.c)
     target_compile_definitions(aimee PRIVATE WITH_TLS)
-    target_link_libraries(aimee PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    if(APPLE)
+        # macOS: Secure Transport (system frameworks; universal-binary safe; Keychain
+        # trust). Deprecated since 10.15 -> silence the deprecation warning for THIS
+        # TU only (the build is -Werror); never globally.
+        target_sources(aimee PRIVATE ${AIMEE_SRC_DIR}/aimee_tls_securetransport.c)
+        set_source_files_properties(${AIMEE_SRC_DIR}/aimee_tls_securetransport.c
+            PROPERTIES COMPILE_OPTIONS "-Wno-deprecated-declarations")
+        find_library(SECURITY_FRAMEWORK Security REQUIRED)
+        find_library(COREFOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
+        target_link_libraries(aimee PRIVATE ${SECURITY_FRAMEWORK} ${COREFOUNDATION_FRAMEWORK})
+    elseif(WIN32)
+        # Windows: Schannel/SSPI (no OpenSSL; Windows certificate store).
+        target_sources(aimee PRIVATE ${AIMEE_SRC_DIR}/aimee_tls_schannel.c)
+        target_link_libraries(aimee PRIVATE secur32 crypt32)
+    else()
+        # Linux/other POSIX: OpenSSL.
+        find_package(OpenSSL REQUIRED)
+        target_sources(aimee PRIVATE ${AIMEE_SRC_DIR}/aimee_tls.c)
+        target_link_libraries(aimee PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    endif()
 endif()
 
 # aimee-webchat (Go) and aimee-gateway are full-build-only components; the

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (107)
+## CLI-settable keys (108)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -120,6 +120,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `memory_scenes_enabled` | bool | Cluster memories into scenes. |
 | `memory_scenes_min_cluster_size` | int | Min cluster size for a scene. |
 | `memory_scenes_top_m` | int | Top-M scenes to consider. |
+| `memory_semantic_floor_scale` | float | Multiplier on the semantic-recall cosine floors (0 = auto-scale by the active embedder dimension; >0 pins it). |
 | `memory_semantic_weight` | float | Semantic (vector) weight in hybrid recall. |
 | `memory_window_radius` | int | Neighbour radius for memory-window expansion. |
 | `openai_endpoint` | string | OpenAI-compatible endpoint URL. |
@@ -165,7 +166,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`lsp_servers`** — _LSP server definitions (array of objects)._ Keys: `args`, `command`, `extensions`, `name`
 - **`mcp`** — _MCP integration (e.g. OSV)._ Keys: `osv`
 - **`mcp_clients`** — _MCP client connections (array of objects)._ Keys: `bearer_token_env`, `command`, `cwd`, `name`, `transport`, `url`
-- **`memory`** — _Memory subsystem; most children (recall, rerank, lifecycle, …) are nested objects with their own keys._ Keys: `abstain`, `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_weight`
+- **`memory`** — _Memory subsystem; most children (recall, rerank, lifecycle, …) are nested objects with their own keys._ Keys: `abstain`, `aggregation`, `bm25_weight`, `briefing`, `citations`, `cognify`, `context_budget`, `coref`, `derive_facts`, `directives`, `dispositions`, `episode_summaries`, `failure_detection`, `fetch_budget`, `hard_negative_log`, `improve`, `lifecycle`, `pagerank`, `profile_cards`, `prospective`, `recall`, `rewrite`, `routing`, `salience`, `scenes`, `semantic_floor_scale`, `semantic_weight`
 - **`memory_maintenance`** — _Memory maintenance scheduling._ Keys: `enabled`, `interval_seconds`, `summarize_enabled`, `trigger_inserts`, `trigger_secs`
 - **`memory_negation`** — _Negation handling in memory._ Keys: `enabled`
 - **`memory_query_expansion`** — _Recall query expansion._ Keys: `k`, `mode`

--- a/docs/proposals/pending/native-tls-thin-client-backends.md
+++ b/docs/proposals/pending/native-tls-thin-client-backends.md
@@ -1,0 +1,248 @@
+# Native TLS backends for the Windows and macOS thin clients
+
+- **State:** proposed; awaiting roundtable + user proposal-gate.
+- **Scope:** deterministic / build + client transport. Not an intelligence-surface
+  proposal (no Architecture Charter role).
+- **Author:** JBailes, 2026-06-17.
+
+## Problem
+
+The prebuilt **Windows** and **macOS** thin-client release binaries are built with
+`-DWITH_TLS=OFF` and therefore **refuse `https://` servers**. Only the Linux
+prebuilt links TLS (system OpenSSL, `WITH_TLS` defaults to `1` on POSIX in
+`src/Makefile:154`). A user who downloads `aimee-windows-x86_64.exe` or
+`aimee-macos-universal` and points it at an HTTPS `aimee-server` cannot connect;
+the documented stopgap is to terminate TLS at a reverse proxy and use its
+`http://` address (`docs/QUICKSTART.md`, "TLS support by build").
+
+The two are off for concrete, *different* reasons — both rooted in OpenSSL
+packaging, not in the TLS code:
+
+- **macOS**: the release artifact is a **universal (arm64 + x86_64) fat binary**.
+  Homebrew OpenSSL is per-arch (separate arm64/x86_64 kegs), so one OpenSSL cannot
+  be linked into a fat build. The release workflow disables TLS specifically to
+  avoid arch-specific brew libraries (`.github/workflows/release-thin-client.yml`,
+  macOS step comment).
+- **Windows**: the MinGW build has no OpenSSL on the runner, so it is built
+  `WITH_TLS=OFF` and refuses `https://` instead
+  (`.github/workflows/release-thin-client.yml`, Windows step).
+
+## Goal
+
+Ship Windows and macOS prebuilt thin clients that speak `https://` **out of the
+box**, with **certificate verification against the OS trust store** and no
+configuration, no bundled CA bundle, and no extra runtime dependencies — i.e. the
+binary stays a single self-contained file, which is the defining property of the
+thin client.
+
+## Secondary benefit: remote vault provisioning
+
+The vault already defines an `ATTEST_TLS_BEARER` transport
+(`src/headers/vault_principal.h`): "native-TLS conn authorized by bearer … the
+bearer over a confidential channel is the operator's authority → server-principal
+writes allowed (native-TLS provisioning); no per-user principal (uses
+VAULT_SERVER)." Today no client can exercise it on Windows/macOS because those
+prebuilts have no TLS. Shipping native TLS therefore also enables an operator to
+provision the server vault **remotely over `https://`** (an `aimee vault
+set --server` path), complementing the boot-time delegate-vault provisioning
+shipped separately (the auto-vault-provisioning-at-standup work, PR #410).
+
+## Why not just link OpenSSL (rejected alternative)
+
+Keeping OpenSSL and fixing packaging was considered and rejected:
+
+- **macOS**: would require building two per-arch binaries each linking its arch's
+  OpenSSL and `lipo`-merging them, or vendoring a universal static OpenSSL. Worse,
+  OpenSSL on macOS does not read the Keychain, so `SSL_CTX_set_default_verify_paths`
+  finds no trust anchors — we would have to **bundle a CA bundle** (which rots) or
+  write Keychain glue anyway.
+- **Windows**: static-linking MSYS2 OpenSSL keeps a single exe, but OpenSSL has no
+  default trust store on Windows either, so we would again bundle a CA bundle or
+  load the system `ROOT` store into an `X509_STORE` by hand.
+
+Net: bigger binaries, a stale CA bundle (or cert-store glue we'd have to write
+regardless), and OpenSSL CVE-tracking on two more platforms — for a result that is
+still not truly "automatic." If we're writing trust-store glue anyway, the native
+backends are simpler and use the OS store directly.
+
+## Design
+
+The TLS surface is already abstracted behind a **4-function interface**
+(`src/headers/aimee_tls.h`):
+
+```c
+aimee_tls_t *aimee_tls_connect(int fd, const char *host);
+int          aimee_tls_write_all(aimee_tls_t *t, const void *buf, size_t len);
+long         aimee_tls_read(aimee_tls_t *t, void *buf, size_t len);
+void         aimee_tls_free(aimee_tls_t *t);
+```
+
+with a **single consumer** (`src/aimee_client.c`) and one implementation today
+(`src/aimee_tls.c`, OpenSSL, 104 lines). Add two more implementations of the same
+interface, selected at build time by platform:
+
+| Platform | Backend | Links | Trust store |
+|----------|---------|-------|-------------|
+| Linux | OpenSSL (`aimee_tls.c`, unchanged) | `-lssl -lcrypto` | system PEM paths |
+| Windows | **Schannel (SSPI)** — new `aimee_tls_schannel.c` | `secur32`, `crypt32` (in the Windows SDK; no external libs) | Windows certificate store (automatic) |
+| macOS | **Secure Transport** (`SSLContext`) — new `aimee_tls_securetransport.c` | `Security`, `CoreFoundation` frameworks (universal) | Keychain (automatic) |
+
+Backend selection is mechanical: extend the `WITH_TLS=1` branch in the build to
+pick the source file and link flags by target OS, replacing the single hardcoded
+OpenSSL path. `aimee_client.c` is unchanged — the new backends honor the existing
+contract exactly:
+
+- TLS ≥ 1.2 minimum, SNI from `host`, hostname verification on by default.
+- The `AIMEE_TLS_INSECURE=1` escape hatch (skip verification for self-signed/dev
+  servers) — already honored by `aimee_tls.c:tls_insecure()` — is reproduced in
+  both new backends.
+- Opaque handle owns the TLS state, does **not** close the underlying `fd`
+  (matches the header contract); partial reads/writes and clean shutdown handled.
+
+### Notes on the macOS backend choice
+
+`SSLContext`/Secure Transport is deprecated since macOS 10.15 but still ships and
+is the simplest C-friendly TLS API on the platform; the alternative,
+**Network.framework** (`nw_connection_t`), is modern but async/block-based and
+would not map as cleanly onto the synchronous `connect/read/write` interface.
+Recommendation: Secure Transport for v1 (lowest blast radius), with
+Network.framework noted as a future migration if Apple removes Secure Transport.
+Either way the framework is universal, so the fat-binary problem disappears
+entirely — this is the strongest single argument for the native route.
+
+### Release-workflow changes
+
+- macOS job: drop `-DWITH_TLS=OFF` (build `WITH_TLS=ON`); the `CMAKE_OSX_ARCHITECTURES`
+  universal build still links because `Security`/`CoreFoundation` are universal.
+- Windows job: drop `-DWITH_TLS=OFF`; link `secur32`/`crypt32`.
+- Keep the existing `aimee <asset> version` smoke test; add an `https://` handshake
+  smoke test against a known-good endpoint per platform.
+
+### Documentation changes
+
+- Update `docs/QUICKSTART.md` "TLS support by build" table: Windows and macOS
+  prebuilts move to **Yes**.
+- Update the Windows/macOS install notes (and `install.ps1`'s "TLS is off on
+  Windows" comment, README/MANUAL "Windows thin client is built without TLS")
+  to reflect native TLS.
+
+## Out of scope
+
+- Server/kb TLS termination (they already require OpenSSL; unchanged).
+- mTLS / client certificates.
+- Replacing the Linux OpenSSL backend.
+
+## Risks and effort
+
+- Two new platform backends (~300–400 lines each) to write and test for **parity**
+  with the OpenSSL backend: handshake, SNI, hostname check, min-version, the
+  insecure escape hatch, partial I/O, shutdown.
+- Per-platform CI must actually exercise an `https://` handshake, not just
+  `version`, or a broken backend ships silently.
+- Schannel and Secure Transport have fiddly buffering/renegotiation semantics;
+  the abstraction is small but the handshake loops need care.
+- Blast radius on the rest of the codebase is **nil**: additive new files behind an
+  existing interface with a single caller; no change to `aimee_client.c` or the
+  Linux build.
+
+## Implementation requirements (must address before coding)
+
+Consolidated from an interim self-review and a 3-lens roundtable (architecture,
+security, QA). No design blockers were found; these are the specifics each backend
+must implement to match the OpenSSL backend's behavior and security posture.
+
+### A. Security-critical (a miss here is a silent MITM hole)
+
+1. **Schannel does NOT verify the hostname for you.** `InitializeSecurityContext`
+   validates the chain but performs **no** hostname check. After the handshake the
+   backend MUST call `CertGetCertificateChain` then
+   `CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, …)` with an
+   `SSL_EXTRA_CERT_CHAIN_POLICY_PARA` whose `pwszServerName` is the connect `host`,
+   and fail closed on any non-`SEC_E_OK`/non-zero policy status. This is the single
+   most important parity item: without it, any cert from any CA (or a valid cert for
+   a different host) is accepted. Use `SCH_CRED_AUTO_CRED_VALIDATION` for the chain,
+   not `MANUAL`, in the secure path.
+2. **Secure Transport hostname check requires `SSLSetPeerDomainName`** (with the
+   connect `host`) **before** the handshake. If it is not set, no hostname check is
+   performed. Do not set `kSSLSessionOptionBreakOnServerAuth` in the secure path (it
+   suppresses the built-in evaluation); let Secure Transport evaluate trust + name.
+3. **Protocol floor: disable TLS 1.0/1.1.** Schannel: set
+   `grbitEnabledProtocols = SP_PROT_TLS1_2_PLUS` (and TLS 1.3 where available) in the
+   `SCHANNEL_CRED`/`TLS_PARAMETERS`. Secure Transport: `SSLSetProtocolVersionMin`
+   `kTLSProtocol12`. Matches the OpenSSL backend's `TLS1_2_VERSION` floor.
+4. **`AIMEE_TLS_INSECURE` semantics + blast radius.** Read it via `getenv` **at
+   connect time** (per-connection, exactly like the OpenSSL backend's
+   `tls_insecure()` — not a compile-time flag, not a one-shot startup read). When
+   set it disables **all** verification — chain AND hostname — so the proposal must
+   document it as a dev-only MITM-accepting switch. Insecure path per backend:
+   Schannel `SCH_CRED_MANUAL_CRED_VALIDATION` + skip the policy check; Secure
+   Transport `kSSLSessionOptionBreakOnServerAuth` + accept without evaluating. Secure
+   default = full verify; insecure = full skip; no middle state.
+
+### B. Correctness / parity (a miss here is a hang, truncation, or crash)
+
+5. **The 4-function interface hides record framing.** Neither API transparently
+   wraps a raw `fd`. Schannel needs an explicit `InitializeSecurityContext` handshake
+   loop + `EncryptMessage`/`DecryptMessage`, and `DecryptMessage` returns leftover
+   *ciphertext* in a `SECBUFFER_EXTRA` that must be carried into the next read.
+   Secure Transport drives raw I/O through `SSLSetIOFuncs` callbacks. Therefore
+   `struct aimee_tls` MUST hold **two** carry-over buffers: decrypted-but-unconsumed
+   **plaintext** (when the caller's `read` buf is smaller than a record) and
+   leftover **ciphertext** (`SECBUFFER_EXTRA`). `aimee_tls_read` drains plaintext
+   first, then decrypts more. This is the main parity risk.
+6. **Mid-stream renegotiation.** `DecryptMessage` can return `SEC_I_RENEGOTIATE`
+   (and `SEC_I_CONTEXT_EXPIRED` on close); the read path must loop back through the
+   handshake on the former and report clean EOF on the latter. Secure Transport
+   surfaces `errSSLPeerAuthCompleted`/renegotiation similarly. Do not treat these as
+   errors.
+7. **Blocking-socket semantics + clean shutdown.** `aimee_client.c` uses a blocking
+   socket, one TLS handle per connection, single-threaded per handle (no locking
+   needed). Map cleanly: `aimee_tls_read` returns `0` only on a genuine TLS
+   close-notify/EOF and `-1` on error (distinguish Secure Transport
+   `errSSLClosedGraceful` → 0 vs other `OSStatus` → -1; Schannel `SEC_I_CONTEXT_EXPIRED`
+   → 0 vs `SEC_E_*` → -1). `aimee_tls_free` MUST send close-notify and tear down the
+   context (`DeleteSecurityContext`/`FreeCredentialsHandle`; `SSLClose` +
+   `CFRelease`) but MUST NOT close the underlying `fd` (per the header contract).
+
+### C. Build / CI
+
+8. **`-Werror` + Secure Transport deprecation = build break.** `SSLContext`/Secure
+   Transport is deprecated since macOS 10.15 and emits `-Wdeprecated-declarations`,
+   which `-Werror` makes fatal. Apply `-Wno-deprecated-declarations` **only to the
+   `aimee_tls_securetransport.c` translation unit** (a per-file CMake
+   `set_source_files_properties(... COMPILE_OPTIONS ...)`, never globally — that would
+   mask other deprecations). Long-term migration to Network.framework noted if Apple
+   removes Secure Transport.
+9. **CMake is the release build for Win/macOS** (the Makefile is the Linux path).
+   Wire backend selection there:
+   ```cmake
+   if(WITH_TLS)
+     if(APPLE)       target_sources(aimee PRIVATE src/aimee_tls_securetransport.c)
+                     target_link_libraries(aimee "-framework Security" "-framework CoreFoundation")
+     elseif(WIN32)   target_sources(aimee PRIVATE src/aimee_tls_schannel.c)
+                     target_link_libraries(aimee secur32 crypt32)
+     else()          target_sources(aimee PRIVATE src/aimee_tls.c)        # OpenSSL
+                     target_link_libraries(aimee OpenSSL::SSL OpenSSL::Crypto)
+     endif()
+   endif()
+   ```
+   MinGW prerequisites for the Schannel TU: `#define SECURITY_WIN32` before
+   `<security.h>`/`<schannel.h>` (MinGW-w64 ships both); link `-lsecur32 -lcrypt32`.
+   Confirm in CI that the macOS artifact stays a true universal binary (`lipo -archs`).
+10. **Tests must catch a broken backend, not just a happy path.** Per-platform CI
+    must run, against a **local self-signed server** (deterministic; not a public
+    badssl endpoint): (a) good cert → handshake + round-trip; (b) expired cert →
+    rejected; (c) wrong-hostname cert → rejected (this is the test that catches the
+    Schannel hostname footgun in A.1); (d) `AIMEE_TLS_INSECURE=1` → (a)–(c) all
+    accepted; (e) a payload larger than one TLS record + a 1-byte-at-a-time read loop
+    to exercise the plaintext/ciphertext carry-over buffers (B.5).
+
+## Acceptance criteria
+
+1. `aimee-windows-x86_64.exe` and `aimee-macos-universal` connect to an `https://`
+   `aimee-server` with verification on, no bundled CA bundle, no extra runtime deps.
+2. `AIMEE_TLS_INSECURE=1` works identically on all three platforms.
+3. Invalid/expired/hostname-mismatched certs are rejected by default on all three.
+4. macOS artifact remains a true universal (`lipo -archs` shows arm64 + x86_64).
+5. CI runs a real `https://` handshake smoke test per platform.
+6. Quickstart/README/MANUAL TLS notes updated.

--- a/install.ps1
+++ b/install.ps1
@@ -43,9 +43,9 @@ try {
     Push-Location $repoRoot
     try {
         # Thin-client profile: only aimee.exe (no server/kb/gateway/webchat, so no
-        # libpq / Go / PAM). TLS is off on Windows — terminate TLS at a reverse
-        # proxy and point the client at its http:// address. Matches the CI and
-        # release Windows builds.
+        # libpq / Go / PAM). TLS uses Schannel (Windows cert store), so https://
+        # remote aimee-servers work with no OpenSSL. Matches the CI and release
+        # Windows builds.
         $cfgArgs = @(
             "-B", $buildDir,
             "-DAIMEE_THIN_CLIENT=ON",
@@ -53,7 +53,7 @@ try {
             "-DWITH_PAM=OFF",
             "-DWITH_LIBSECRET=OFF",
             "-DWITH_UI=OFF",
-            "-DWITH_TLS=OFF"
+            "-DWITH_TLS=ON"
         )
         # MinGW gcc needs an explicit Makefiles generator; MSVC uses its default.
         if ($gcc -and -not $cl) {

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -195,6 +195,7 @@ CFG_KEY_DESC = {
     "memory_scenes_enabled": "Cluster memories into scenes.",
     "memory_scenes_min_cluster_size": "Min cluster size for a scene.",
     "memory_scenes_top_m": "Top-M scenes to consider.",
+    "memory_semantic_floor_scale": "Multiplier on the semantic-recall cosine floors (0 = auto-scale by the active embedder dimension; >0 pins it).",
     "memory_semantic_weight": "Semantic (vector) weight in hybrid recall.",
     "memory_window_radius": "Neighbour radius for memory-window expansion.",
     "openai_endpoint": "OpenAI-compatible endpoint URL.",

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -1,0 +1,518 @@
+/* aimee_tls_schannel.c: Windows TLS client backend (WITH_TLS builds).
+ *
+ * Implements the aimee_tls.h 4-function contract on Schannel/SSPI, so the Windows
+ * thin client speaks https:// with verification against the Windows certificate
+ * store — no OpenSSL, no bundled CA bundle, single self-contained exe.
+ *
+ * Contract parity with the OpenSSL backend (aimee_tls.c):
+ *   - TLS >= 1.2 (SCHANNEL_CRED.grbitEnabledProtocols = TLS 1.2[/1.3]; 1.0/1.1 off).
+ *   - chain AND hostname verified post-handshake. Schannel does NOT check the host
+ *     name itself, so we do CertGetCertificateChain +
+ *     CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, pwszServerName=host).
+ *   - AIMEE_TLS_INSECURE=1 (read at connect time) skips that verification entirely.
+ *   - opaque handle owns the security context; aimee_tls_free does NOT close the fd.
+ *
+ * Read path keeps two carry-over buffers in the handle: leftover ciphertext
+ * (SECBUFFER_EXTRA from DecryptMessage / the tail of the handshake) and
+ * decrypted-but-undelivered plaintext (when the caller's buffer is smaller than a
+ * record). Mid-stream SEC_I_RENEGOTIATE is handled by re-running the handshake.
+ */
+#define SECURITY_WIN32
+#include "aimee_tls.h"
+
+#include <windows.h>
+#include <schannel.h>
+#include <security.h>
+#include <sspi.h>
+#include <wincrypt.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef SP_PROT_TLS1_2_CLIENT
+#define SP_PROT_TLS1_2_CLIENT 0x00000800
+#endif
+#ifndef SCH_USE_STRONG_CRYPTO
+#define SCH_USE_STRONG_CRYPTO 0x00400000
+#endif
+
+#define ENC_CAP 32768 /* one TLS record fits comfortably; grown via recv loop */
+
+struct aimee_tls
+{
+   int fd;
+   CredHandle cred;
+   CtxtHandle ctx;
+   int have_cred, have_ctx;
+   SecPkgContext_StreamSizes sizes;
+   char *host; /* for hostname verification + renegotiation re-verify */
+
+   unsigned char enc[ENC_CAP]; /* leftover ciphertext */
+   size_t enc_len;
+
+   unsigned char *dec; /* decrypted plaintext not yet delivered */
+   size_t dec_off, dec_len, dec_cap;
+};
+
+static int tls_insecure(void)
+{
+   const char *v = getenv("AIMEE_TLS_INSECURE");
+   return v && *v && strcmp(v, "0") != 0;
+}
+
+/* Blocking socket helpers. */
+static int send_all(int fd, const void *buf, size_t len)
+{
+   const char *p = buf;
+   size_t off = 0;
+   while (off < len)
+   {
+      int n = send(fd, p + off, (int)(len - off), 0);
+      if (n > 0)
+      {
+         off += (size_t)n;
+         continue;
+      }
+      if (n == SOCKET_ERROR && WSAGetLastError() == WSAEINTR)
+         continue;
+      return -1;
+   }
+   return 0;
+}
+
+/* Append up to one recv() of ciphertext into t->enc. Returns bytes read, 0 on a
+ * clean close, -1 on error. */
+static int recv_more(aimee_tls_t *t)
+{
+   if (t->enc_len >= ENC_CAP)
+      return -1; /* a single record should never exceed ENC_CAP */
+   int n = recv(t->fd, (char *)t->enc + t->enc_len, (int)(ENC_CAP - t->enc_len), 0);
+   if (n > 0)
+   {
+      t->enc_len += (size_t)n;
+      return n;
+   }
+   if (n == 0)
+      return 0;
+   if (WSAGetLastError() == WSAEINTR)
+      return recv_more(t);
+   return -1;
+}
+
+/* Verify the server certificate chain + hostname against the Windows store.
+ * Returns 0 on success, -1 on any failure. */
+static int verify_server_cert(aimee_tls_t *t)
+{
+   /* Fail closed if there is no hostname to verify against: a NULL pwszServerName
+    * makes CERT_CHAIN_POLICY_SSL skip the name check, which would accept any
+    * otherwise-valid cert (MITM). aimee_client.c always passes the URL host. */
+   if (!t->host || !t->host[0])
+      return -1;
+
+   PCCERT_CONTEXT cert = NULL;
+   if (QueryContextAttributes(&t->ctx, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert) != SEC_E_OK || !cert)
+      return -1;
+
+   int ok = -1;
+   PCCERT_CHAIN_CONTEXT chain = NULL;
+   CERT_CHAIN_PARA chain_para;
+   memset(&chain_para, 0, sizeof(chain_para));
+   chain_para.cbSize = sizeof(chain_para);
+
+   if (CertGetCertificateChain(NULL, cert, NULL, cert->hCertStore, &chain_para, 0, NULL, &chain))
+   {
+      /* Widen the hostname for the SSL policy. A DNS hostname is <= 253 chars, so
+       * 256 wide chars suffices; a 0 return means truncation/encoding error -> fail
+       * closed rather than verify against a truncated name. */
+      wchar_t whost[256];
+      if (MultiByteToWideChar(CP_UTF8, 0, t->host, -1, whost, 256) == 0)
+      {
+         CertFreeCertificateChain(chain);
+         CertFreeCertificateContext(cert);
+         return -1;
+      }
+
+      SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_para;
+      memset(&ssl_para, 0, sizeof(ssl_para));
+      ssl_para.cbSize = sizeof(ssl_para);
+      ssl_para.dwAuthType = AUTHTYPE_SERVER;
+      ssl_para.pwszServerName = whost;
+
+      CERT_CHAIN_POLICY_PARA policy_para;
+      memset(&policy_para, 0, sizeof(policy_para));
+      policy_para.cbSize = sizeof(policy_para);
+      policy_para.pvExtraPolicyPara = &ssl_para;
+
+      CERT_CHAIN_POLICY_STATUS policy_status;
+      memset(&policy_status, 0, sizeof(policy_status));
+      policy_status.cbSize = sizeof(policy_status);
+
+      if (CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain, &policy_para,
+                                           &policy_status) &&
+          policy_status.dwError == 0)
+         ok = 0;
+
+      CertFreeCertificateChain(chain);
+   }
+   CertFreeCertificateContext(cert);
+   return ok;
+}
+
+/* Drive the client handshake to completion. |initial| flags the first call (no
+ * input token). Returns 0 on success, -1 on failure. Any ciphertext past the
+ * Finished message is left in t->enc for the read path. */
+static int do_handshake(aimee_tls_t *t, int initial)
+{
+   DWORD req = ISC_REQ_SEQUENCE_DETECT | ISC_REQ_REPLAY_DETECT | ISC_REQ_CONFIDENTIALITY |
+               ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_STREAM;
+   SECURITY_STATUS ss;
+   int first = initial;
+
+   for (;;)
+   {
+      SecBuffer inbuf[2];
+      SecBufferDesc indesc;
+      SecBuffer outbuf[1];
+      SecBufferDesc outdesc;
+      DWORD out_flags = 0;
+
+      if (!first)
+      {
+         /* Need at least some bytes to feed ISC. */
+         if (t->enc_len == 0)
+         {
+            int n = recv_more(t);
+            if (n <= 0)
+               return -1;
+         }
+      }
+
+      inbuf[0].pvBuffer = t->enc;
+      inbuf[0].cbBuffer = (unsigned long)t->enc_len;
+      inbuf[0].BufferType = SECBUFFER_TOKEN;
+      inbuf[1].pvBuffer = NULL;
+      inbuf[1].cbBuffer = 0;
+      inbuf[1].BufferType = SECBUFFER_EMPTY;
+      indesc.ulVersion = SECBUFFER_VERSION;
+      indesc.cBuffers = 2;
+      indesc.pBuffers = inbuf;
+
+      outbuf[0].pvBuffer = NULL;
+      outbuf[0].cbBuffer = 0;
+      outbuf[0].BufferType = SECBUFFER_TOKEN;
+      outdesc.ulVersion = SECBUFFER_VERSION;
+      outdesc.cBuffers = 1;
+      outdesc.pBuffers = outbuf;
+
+      ss = InitializeSecurityContextA(&t->cred, (first || !t->have_ctx) ? NULL : &t->ctx,
+                                      (SEC_CHAR *)t->host, req, 0, 0, first ? NULL : &indesc, 0,
+                                      &t->ctx, &outdesc, &out_flags, NULL);
+      if (first)
+         t->have_ctx = 1;
+      first = 0;
+
+      /* Send any token Schannel produced (even on CONTINUE / OK). */
+      if ((ss == SEC_E_OK || ss == SEC_I_CONTINUE_NEEDED ||
+           (FAILED(ss) && (out_flags & ISC_RET_EXTENDED_ERROR))) &&
+          outbuf[0].cbBuffer && outbuf[0].pvBuffer)
+      {
+         int rc = send_all(t->fd, outbuf[0].pvBuffer, outbuf[0].cbBuffer);
+         FreeContextBuffer(outbuf[0].pvBuffer);
+         if (rc != 0)
+            return -1;
+      }
+      else if (outbuf[0].pvBuffer)
+      {
+         FreeContextBuffer(outbuf[0].pvBuffer);
+      }
+
+      if (ss == SEC_E_INCOMPLETE_MESSAGE)
+      {
+         int n = recv_more(t);
+         if (n <= 0)
+            return -1;
+         continue; /* feed the larger buffer back in */
+      }
+
+      /* Carry over any unconsumed ciphertext (SECBUFFER_EXTRA). */
+      if (inbuf[1].BufferType == SECBUFFER_EXTRA && inbuf[1].cbBuffer)
+      {
+         memmove(t->enc, t->enc + (t->enc_len - inbuf[1].cbBuffer), inbuf[1].cbBuffer);
+         t->enc_len = inbuf[1].cbBuffer;
+      }
+      else if (ss != SEC_E_INCOMPLETE_MESSAGE)
+      {
+         t->enc_len = 0;
+      }
+
+      if (ss == SEC_I_CONTINUE_NEEDED)
+         continue;
+      if (ss == SEC_E_OK)
+         return 0;
+      return -1; /* any hard error */
+   }
+}
+
+aimee_tls_t *aimee_tls_connect(int fd, const char *host)
+{
+   aimee_tls_t *t = calloc(1, sizeof(*t));
+   if (!t)
+      return NULL;
+   t->fd = fd;
+   if (host && *host)
+      t->host = _strdup(host);
+
+   SCHANNEL_CRED sc;
+   memset(&sc, 0, sizeof(sc));
+   sc.dwVersion = SCHANNEL_CRED_VERSION;
+   sc.grbitEnabledProtocols = SP_PROT_TLS1_2_CLIENT;
+#ifdef SP_PROT_TLS1_3_CLIENT
+   sc.grbitEnabledProtocols |= SP_PROT_TLS1_3_CLIENT;
+#endif
+   /* We validate the chain + hostname ourselves post-handshake, so tell Schannel
+    * not to auto-validate (and never use a machine default client cert). */
+   sc.dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_MANUAL_CRED_VALIDATION | SCH_USE_STRONG_CRYPTO;
+
+   if (AcquireCredentialsHandleA(NULL, (SEC_CHAR *)UNISP_NAME_A, SECPKG_CRED_OUTBOUND, NULL, &sc,
+                                 NULL, NULL, &t->cred, NULL) != SEC_E_OK)
+   {
+      aimee_tls_free(t);
+      return NULL;
+   }
+   t->have_cred = 1;
+
+   if (do_handshake(t, 1) != 0)
+   {
+      aimee_tls_free(t);
+      return NULL;
+   }
+   if (!tls_insecure() && verify_server_cert(t) != 0)
+   {
+      aimee_tls_free(t);
+      return NULL;
+   }
+   if (QueryContextAttributes(&t->ctx, SECPKG_ATTR_STREAM_SIZES, &t->sizes) != SEC_E_OK)
+   {
+      aimee_tls_free(t);
+      return NULL;
+   }
+   return t;
+}
+
+int aimee_tls_write_all(aimee_tls_t *t, const void *buf, size_t len)
+{
+   if (!t || !t->have_ctx)
+      return -1;
+   const unsigned char *p = buf;
+   size_t off = 0;
+   unsigned long maxmsg = t->sizes.cbMaximumMessage;
+   if (maxmsg == 0)
+      return -1; /* guard against a zero chunk size -> would never make progress */
+   size_t reclen = (size_t)t->sizes.cbHeader + maxmsg + t->sizes.cbTrailer;
+   unsigned char *rec = malloc(reclen);
+   if (!rec)
+      return -1;
+
+   int rc = 0;
+   while (off < len)
+   {
+      unsigned long chunk = (unsigned long)((len - off) < maxmsg ? (len - off) : maxmsg);
+      memcpy(rec + t->sizes.cbHeader, p + off, chunk);
+
+      SecBuffer b[4];
+      b[0].pvBuffer = rec;
+      b[0].cbBuffer = t->sizes.cbHeader;
+      b[0].BufferType = SECBUFFER_STREAM_HEADER;
+      b[1].pvBuffer = rec + t->sizes.cbHeader;
+      b[1].cbBuffer = chunk;
+      b[1].BufferType = SECBUFFER_DATA;
+      b[2].pvBuffer = rec + t->sizes.cbHeader + chunk;
+      b[2].cbBuffer = t->sizes.cbTrailer;
+      b[2].BufferType = SECBUFFER_STREAM_TRAILER;
+      b[3].pvBuffer = NULL;
+      b[3].cbBuffer = 0;
+      b[3].BufferType = SECBUFFER_EMPTY;
+      SecBufferDesc d;
+      d.ulVersion = SECBUFFER_VERSION;
+      d.cBuffers = 4;
+      d.pBuffers = b;
+
+      if (EncryptMessage(&t->ctx, 0, &d, 0) != SEC_E_OK)
+      {
+         rc = -1;
+         break;
+      }
+      if (send_all(t->fd, rec, b[0].cbBuffer + b[1].cbBuffer + b[2].cbBuffer) != 0)
+      {
+         rc = -1;
+         break;
+      }
+      off += chunk;
+   }
+   free(rec);
+   return rc;
+}
+
+long aimee_tls_read(aimee_tls_t *t, void *buf, size_t len)
+{
+   if (!t || !t->have_ctx)
+      return -1;
+   if (len == 0)
+      return 0;
+
+   /* Deliver any buffered plaintext first. */
+   if (t->dec_len > t->dec_off)
+   {
+      size_t n = t->dec_len - t->dec_off;
+      if (n > len)
+         n = len;
+      memcpy(buf, t->dec + t->dec_off, n);
+      t->dec_off += n;
+      if (t->dec_off >= t->dec_len)
+         t->dec_off = t->dec_len = 0;
+      return (long)n;
+   }
+
+   for (;;)
+   {
+      if (t->enc_len == 0)
+      {
+         int n = recv_more(t);
+         if (n == 0)
+            return 0; /* EOF */
+         if (n < 0)
+            return -1;
+      }
+
+      SecBuffer b[4];
+      b[0].pvBuffer = t->enc;
+      b[0].cbBuffer = (unsigned long)t->enc_len;
+      b[0].BufferType = SECBUFFER_DATA;
+      b[1].BufferType = SECBUFFER_EMPTY;
+      b[2].BufferType = SECBUFFER_EMPTY;
+      b[3].BufferType = SECBUFFER_EMPTY;
+      SecBufferDesc d;
+      d.ulVersion = SECBUFFER_VERSION;
+      d.cBuffers = 4;
+      d.pBuffers = b;
+
+      SECURITY_STATUS ss = DecryptMessage(&t->ctx, &d, 0, NULL);
+
+      if (ss == SEC_E_INCOMPLETE_MESSAGE)
+      {
+         int n = recv_more(t);
+         if (n <= 0)
+            return (n == 0) ? 0 : -1;
+         continue;
+      }
+      if (ss == SEC_I_CONTEXT_EXPIRED)
+         return 0; /* peer sent close-notify */
+      if (ss == SEC_I_RENEGOTIATE)
+      {
+         /* Server asked to renegotiate: continue the handshake, then re-verify. */
+         if (do_handshake(t, 0) != 0)
+            return -1;
+         if (!tls_insecure() && verify_server_cert(t) != 0)
+            return -1;
+         continue;
+      }
+      if (ss != SEC_E_OK)
+         return -1;
+
+      /* Locate decrypted plaintext + leftover ciphertext. */
+      SecBuffer *data = NULL, *extra = NULL;
+      for (int i = 0; i < 4; i++)
+      {
+         if (b[i].BufferType == SECBUFFER_DATA && !data)
+            data = &b[i];
+         else if (b[i].BufferType == SECBUFFER_EXTRA && !extra)
+            extra = &b[i];
+      }
+
+      size_t produced = data ? data->cbBuffer : 0;
+      long delivered = 0;
+      if (produced)
+      {
+         size_t give = produced < len ? produced : len;
+         memcpy(buf, data->pvBuffer, give);
+         delivered = (long)give;
+         if (give < produced)
+         {
+            /* Stash the remainder for the next read. */
+            size_t rem = produced - give;
+            if (rem > t->dec_cap)
+            {
+               unsigned char *nb = realloc(t->dec, rem);
+               if (!nb)
+                  return -1;
+               t->dec = nb;
+               t->dec_cap = rem;
+            }
+            memcpy(t->dec, (unsigned char *)data->pvBuffer + give, rem);
+            t->dec_off = 0;
+            t->dec_len = rem;
+         }
+      }
+
+      /* Carry leftover ciphertext to the front of enc for the next record. */
+      if (extra && extra->cbBuffer)
+      {
+         memmove(t->enc, extra->pvBuffer, extra->cbBuffer);
+         t->enc_len = extra->cbBuffer;
+      }
+      else
+      {
+         t->enc_len = 0;
+      }
+
+      if (delivered > 0)
+         return delivered;
+      /* A record with zero application bytes (e.g. a handshake message): loop. */
+   }
+}
+
+void aimee_tls_free(aimee_tls_t *t)
+{
+   if (!t)
+      return;
+   if (t->have_ctx)
+   {
+      /* Best-effort close-notify. */
+      DWORD type = SCHANNEL_SHUTDOWN;
+      SecBuffer sb;
+      sb.pvBuffer = &type;
+      sb.cbBuffer = sizeof(type);
+      sb.BufferType = SECBUFFER_TOKEN;
+      SecBufferDesc sd;
+      sd.ulVersion = SECBUFFER_VERSION;
+      sd.cBuffers = 1;
+      sd.pBuffers = &sb;
+      if (ApplyControlToken(&t->ctx, &sd) == SEC_E_OK)
+      {
+         DWORD req = ISC_REQ_SEQUENCE_DETECT | ISC_REQ_REPLAY_DETECT | ISC_REQ_CONFIDENTIALITY |
+                     ISC_REQ_ALLOCATE_MEMORY | ISC_REQ_STREAM;
+         SecBuffer ob;
+         ob.pvBuffer = NULL;
+         ob.cbBuffer = 0;
+         ob.BufferType = SECBUFFER_TOKEN;
+         SecBufferDesc od;
+         od.ulVersion = SECBUFFER_VERSION;
+         od.cBuffers = 1;
+         od.pBuffers = &ob;
+         DWORD of = 0;
+         if (InitializeSecurityContextA(&t->cred, &t->ctx, NULL, req, 0, 0, NULL, 0, &t->ctx, &od,
+                                        &of, NULL) == SEC_E_OK &&
+             ob.cbBuffer && ob.pvBuffer)
+         {
+            (void)send_all(t->fd, ob.pvBuffer, ob.cbBuffer);
+            FreeContextBuffer(ob.pvBuffer);
+         }
+      }
+      DeleteSecurityContext(&t->ctx);
+   }
+   if (t->have_cred)
+      FreeCredentialsHandle(&t->cred);
+   free(t->dec);
+   free(t->host);
+   free(t);
+}

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -1,0 +1,196 @@
+/* aimee_tls_securetransport.c: macOS TLS client backend (WITH_TLS builds).
+ *
+ * Implements the aimee_tls.h 4-function contract on Apple Secure Transport
+ * (SSLContextRef). Chosen over OpenSSL on macOS because the release artifact is a
+ * universal (arm64+x86_64) binary and the system framework is already universal,
+ * so no per-arch OpenSSL is needed; trust is evaluated against the Keychain with
+ * no bundled CA bundle.
+ *
+ * Secure Transport is deprecated since macOS 10.15 but still ships; the single
+ * translation unit is built with -Wno-deprecated-declarations (see CMakeLists.txt)
+ * so the deprecation warnings don't trip -Werror. If Apple removes it, migrate to
+ * Network.framework behind this same interface.
+ *
+ * Contract parity with the OpenSSL backend (aimee_tls.c):
+ *   - TLS >= 1.2 (SSLSetProtocolVersionMin).
+ *   - hostname verification on by default via SSLSetPeerDomainName (Secure
+ *     Transport evaluates the chain AND the name during the handshake).
+ *   - AIMEE_TLS_INSECURE=1 (read at connect time) disables ALL verification.
+ *   - the opaque handle owns the TLS state; aimee_tls_free does NOT close the fd.
+ */
+#include "aimee_tls.h"
+
+#include <Security/SecureTransport.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+struct aimee_tls
+{
+   SSLContextRef ctx;
+   int fd; /* the SSLConnectionRef points here; not closed by this module */
+};
+
+static int tls_insecure(void)
+{
+   const char *v = getenv("AIMEE_TLS_INSECURE");
+   return v && *v && strcmp(v, "0") != 0;
+}
+
+/* Secure Transport I/O callbacks over the blocking socket. They must fill/drain
+ * the full requested length or report a status; *len is updated to what moved. */
+static OSStatus st_read(SSLConnectionRef conn, void *data, size_t *len)
+{
+   int fd = *(const int *)conn;
+   size_t want = *len, got = 0;
+   OSStatus rc = noErr;
+   while (got < want)
+   {
+      ssize_t n = read(fd, (char *)data + got, want - got);
+      if (n > 0)
+      {
+         got += (size_t)n;
+         continue;
+      }
+      if (n == 0)
+      {
+         rc = errSSLClosedGraceful;
+         break;
+      }
+      if (errno == EINTR)
+         continue;
+      rc = (errno == EAGAIN || errno == EWOULDBLOCK) ? errSSLWouldBlock : errSSLClosedAbort;
+      break;
+   }
+   *len = got;
+   return rc;
+}
+
+static OSStatus st_write(SSLConnectionRef conn, const void *data, size_t *len)
+{
+   int fd = *(const int *)conn;
+   size_t want = *len, sent = 0;
+   OSStatus rc = noErr;
+   while (sent < want)
+   {
+      ssize_t n = write(fd, (const char *)data + sent, want - sent);
+      if (n > 0)
+      {
+         sent += (size_t)n;
+         continue;
+      }
+      if (n < 0 && errno == EINTR)
+         continue;
+      rc = (errno == EAGAIN || errno == EWOULDBLOCK) ? errSSLWouldBlock : errSSLClosedAbort;
+      break;
+   }
+   *len = sent;
+   return rc;
+}
+
+aimee_tls_t *aimee_tls_connect(int fd, const char *host)
+{
+   aimee_tls_t *t = calloc(1, sizeof(*t));
+   if (!t)
+      return NULL;
+   t->fd = fd;
+
+   t->ctx = SSLCreateContext(NULL, kSSLClientSide, kSSLStreamType);
+   if (!t->ctx)
+   {
+      free(t);
+      return NULL;
+   }
+   if (SSLSetIOFuncs(t->ctx, st_read, st_write) != noErr ||
+       SSLSetConnection(t->ctx, &t->fd) != noErr ||
+       SSLSetProtocolVersionMin(t->ctx, kTLSProtocol12) != noErr)
+   {
+      CFRelease(t->ctx);
+      free(t);
+      return NULL;
+   }
+
+   int insecure = tls_insecure();
+   if (insecure)
+   {
+      /* Break on server auth so we can accept the cert WITHOUT evaluating it. */
+      SSLSetSessionOption(t->ctx, kSSLSessionOptionBreakOnServerAuth, true);
+   }
+   else
+   {
+      /* Fail closed if there is no hostname: without SSLSetPeerDomainName, Secure
+       * Transport verifies the chain but NOT the name, accepting any otherwise-valid
+       * cert (MITM). aimee_client.c always passes the URL host. */
+      if (!host || !*host)
+      {
+         CFRelease(t->ctx);
+         free(t);
+         return NULL;
+      }
+      /* Set the expected name: Secure Transport then verifies chain + hostname
+       * (SAN/CN, wildcards) against the Keychain trust during the handshake. */
+      SSLSetPeerDomainName(t->ctx, host, strlen(host));
+   }
+
+   OSStatus rc;
+   do
+   {
+      rc = SSLHandshake(t->ctx);
+   } while (rc == errSSLWouldBlock || (insecure && rc == errSSLPeerAuthCompleted));
+
+   if (rc != noErr)
+   {
+      SSLClose(t->ctx);
+      CFRelease(t->ctx);
+      free(t);
+      return NULL;
+   }
+   return t;
+}
+
+int aimee_tls_write_all(aimee_tls_t *t, const void *buf, size_t len)
+{
+   if (!t || !t->ctx)
+      return -1;
+   size_t off = 0;
+   while (off < len)
+   {
+      size_t wrote = 0;
+      OSStatus rc = SSLWrite(t->ctx, (const char *)buf + off, len - off, &wrote);
+      off += wrote;
+      if (rc == noErr || rc == errSSLWouldBlock)
+         continue; /* blocking transport: keep going until all bytes are out */
+      return -1;
+   }
+   return 0;
+}
+
+long aimee_tls_read(aimee_tls_t *t, void *buf, size_t len)
+{
+   if (!t || !t->ctx)
+      return -1;
+   /* SSLRead buffers undelivered plaintext internally, so no manual carry-over is
+    * needed here (unlike Schannel). */
+   size_t got = 0;
+   OSStatus rc = SSLRead(t->ctx, buf, len, &got);
+   if (got > 0)
+      return (long)got; /* deliver available bytes even if the call also signalled */
+   if (rc == noErr)
+      return 0;
+   if (rc == errSSLClosedGraceful || rc == errSSLClosedNoNotify)
+      return 0; /* clean EOF */
+   return -1;
+}
+
+void aimee_tls_free(aimee_tls_t *t)
+{
+   if (!t)
+      return;
+   if (t->ctx)
+   {
+      SSLClose(t->ctx); /* send close-notify; does not close the fd */
+      CFRelease(t->ctx);
+   }
+   free(t);
+}

--- a/src/config.c
+++ b/src/config.c
@@ -414,6 +414,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_scenes_global_escape_ratio = 0.2;
    cfg->memory_bm25_weight = 0.0;
    cfg->memory_semantic_weight = 0.0;
+   cfg->memory_semantic_floor_scale = 0.0; /* 0 = auto-scale by embedding dim */
    cfg->memory_fetch_budget_enabled = 0;
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -110,6 +110,8 @@ const config_field_t config_fields[] = {
     {"memory_bm25_weight", offsetof(config_t, memory_bm25_weight), sizeof(double), 0, CFG_FLOAT},
     {"memory_semantic_weight", offsetof(config_t, memory_semantic_weight), sizeof(double), 0,
      CFG_FLOAT},
+    {"memory_semantic_floor_scale", offsetof(config_t, memory_semantic_floor_scale), sizeof(double),
+     0, CFG_FLOAT},
     {"memory_fetch_budget_enabled", offsetof(config_t, memory_fetch_budget_enabled), sizeof(int), 0,
      CFG_BOOL},
     {"memory_fetch_budget_base", offsetof(config_t, memory_fetch_budget_base), sizeof(int), 0,

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -383,6 +383,9 @@ void config_parse_memory_section(config_t *cfg, cJSON *root)
       item = cJSON_GetObjectItemCaseSensitive(memory_cfg, "semantic_weight");
       if (cJSON_IsNumber(item) && item->valuedouble >= 0.0)
          cfg->memory_semantic_weight = item->valuedouble;
+      item = cJSON_GetObjectItemCaseSensitive(memory_cfg, "semantic_floor_scale");
+      if (cJSON_IsNumber(item) && item->valuedouble >= 0.0)
+         cfg->memory_semantic_floor_scale = item->valuedouble;
 
       /* Dynamic fetch budget */
       cJSON *fetch_cfg = cJSON_GetObjectItemCaseSensitive(memory_cfg, "fetch_budget");

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -577,6 +577,14 @@ typedef struct config
    double memory_bm25_weight;
    double memory_semantic_weight;
 
+   /* Cosine-similarity floor scale for the semantic-memory legs. The floors in
+    * memory_collect_*_semantic_matches were calibrated for the retired 384-d
+    * builtin embedder, whose cosine range runs high; modern embedders compress
+    * that range (pplx-0.6b relevant matches ~0.35-0.40, pplx-4b higher), so a
+    * fixed 384-era floor rejects every real hit. 0 = auto-scale by the active
+    * embedding dimension (db2_embedding_dim()); >0 pins the multiplier. */
+   double memory_semantic_floor_scale;
+
    /* Dynamic fetch budget: total candidate pool size, intent-scaled.
     * memory_fetch_budget_enabled: 0 = use fixed pool (default), 1 = scale by specificity.
     * memory_fetch_budget_base: base candidate count; intent multiplier is applied on top

--- a/src/headers/kb_curator_provider.h
+++ b/src/headers/kb_curator_provider.h
@@ -44,9 +44,11 @@ extern "C"
    /* Fill *out with the provider def for `stage`. Resolution per tier:
     *   1. tier config — Tier-A uses `provider.*`, Tier-B uses `tier_b.*`
     *      (never the Tier-A config; no weak fallback between config tiers);
-    *   2. else the curator env — LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY (a single
-    *      endpoint that serves both tiers, matching the bundled-model deployment);
-    *   3. else idle.
+    *   2. else, for TIER-A ONLY, the curator env LLM_ENDPOINT/LLM_MODEL/
+    *      LLM_API_KEY (the bundled-model deployment — Gemma 3n E4B is a Tier-A
+    *      model, so it must not serve the reasoning stages);
+    *   3. else idle. Tier-B has NO env fallback: it needs a capable provider via
+    *      tier_b.* config, or it stays idle.
     * Returns 1 when configured (out filled; base_url non-empty), 0 when idle
     * (out zeroed — the stage must not run).
     *

--- a/src/headers/memory.h
+++ b/src/headers/memory.h
@@ -947,6 +947,10 @@ void memory_query_embed_cache_reset_test(void);
 void memory_query_embed_cache_stats_test(int *requests, int *misses);
 void memory_query_embed_prewarm_test(const char *const *texts, int n, const char *command);
 
+/* Test hooks for the embedder-aware semantic-recall gate + floor scale. */
+int memory_semantic_dim_ok_test(int qdim);
+double memory_semantic_floor_scale_test(void);
+
 /* --- Effectiveness Tracking --- */
 
 typedef struct

--- a/src/kb/kb_curator_extract.c
+++ b/src/kb/kb_curator_extract.c
@@ -7,8 +7,9 @@
 #endif
 
 #include "kb_curator_extract.h"
+#include "kb_curator_llm.h"
 #include "aimee.h"
-#include "config.h" /* config_current_mode, aimee_mode_t */
+#include "config.h" /* config_current_mode, aimee_mode_t, config_load */
 #include "cJSON.h"
 #include "log.h"
 #include "db2/artifacts.h"
@@ -26,6 +27,18 @@
 #define CE_ERRBUF 256
 #define CE_DOCBUF 65536
 #define CE_OUTBUF (256 * 1024)
+
+/* System prompt for the extract stage (Tier-A) when routed through a configured
+ * provider (§2b). The legacy python sidecar carried its own prompt; the in-process
+ * provider needs one here. The request JSON's `role`/`prompt_version` select the
+ * extraction shape (engineering doc vs novel story); keep this generic and let the
+ * request drive specifics. Grammar-constrained output is a future enhancement
+ * (kb_curator_llm_run does not yet pass a JSON schema). Tune against the model. */
+#define CE_SYSTEM_PROMPT                                                                           \
+   "You are a knowledge-base extractor. Read the JSON request (a document chunk "                  \
+   "with a `role` and `input.content`) and emit the requested entities, claims, "                  \
+   "and relations grounded only in that content. Respond with a single JSON "                      \
+   "object matching the request's role. Do not invent facts."
 
 typedef struct
 {
@@ -148,73 +161,6 @@ static void ce_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempts
    aimee_pg_bind_int64(st, "?3", job_id);
    (void)aimee_pg_step(st, err, sizeof(err));
    aimee_pg_finalize(st);
-}
-
-/* ── Sidecar invocation ─────────────────────────────────────────────────── */
-
-static char *ce_invoke_sidecar(const char *cmd, const char *json_input, char *errbuf, size_t errlen)
-{
-   /* Write input JSON to a temp file then pipe it into the command. */
-   char tmppath[256];
-   snprintf(tmppath, sizeof(tmppath), "/tmp/aimee_curator_XXXXXX");
-   int fd = mkstemp(tmppath);
-   if (fd < 0)
-   {
-      snprintf(errbuf, errlen, "mkstemp failed");
-      return NULL;
-   }
-
-   size_t inlen = strlen(json_input);
-   if (write(fd, json_input, inlen) != (ssize_t)inlen)
-   {
-      close(fd);
-      unlink(tmppath);
-      snprintf(errbuf, errlen, "write to tmpfile failed");
-      return NULL;
-   }
-   close(fd);
-
-   /* Build command: <cmd> < <tmpfile> */
-   char full_cmd[1024];
-   snprintf(full_cmd, sizeof(full_cmd), "%s < %s", cmd, tmppath);
-
-   FILE *fp = popen(full_cmd, "r");
-   if (!fp)
-   {
-      unlink(tmppath);
-      snprintf(errbuf, errlen, "popen failed for: %s", full_cmd);
-      return NULL;
-   }
-
-   char *out = malloc(CE_OUTBUF);
-   if (!out)
-   {
-      pclose(fp);
-      unlink(tmppath);
-      snprintf(errbuf, errlen, "out of memory");
-      return NULL;
-   }
-
-   size_t total = 0;
-   size_t n;
-   while ((n = fread(out + total, 1, CE_OUTBUF - total - 1, fp)) > 0)
-   {
-      total += n;
-      if (total >= CE_OUTBUF - 1)
-         break;
-   }
-   out[total] = '\0';
-   int rc = pclose(fp);
-   unlink(tmppath);
-
-   if (rc != 0)
-   {
-      snprintf(errbuf, errlen, "sidecar exited %d", rc);
-      free(out);
-      return NULL;
-   }
-
-   return out;
 }
 
 /* Resolve sidecar command: use opts->extract_command if set, else find
@@ -400,11 +346,18 @@ int kb_curator_extract_one(const kb_curator_extract_opts_t *opts)
    char cmd[768];
    ce_resolve_command(opts, cmd, sizeof(cmd));
 
-   aimee_log(LOG_INFO, "kb.curator.extract", "invoking sidecar for doc %lld: %s",
+   /* Route through the §2 dispatch: a configured Tier-A provider (incl. the
+    * bundled-Gemma LLM_ENDPOINT env) runs in-process via provider_client; else
+    * the resolved sidecar command. extract_docs is Tier-A. */
+   config_t cfg;
+   config_load(&cfg);
+
+   aimee_log(LOG_INFO, "kb.curator.extract", "invoking curator LLM for doc %lld (cmd fallback: %s)",
              (long long)job.document_id, cmd);
 
    char sidecar_err[512] = "";
-   char *resp_str = ce_invoke_sidecar(cmd, req_str, sidecar_err, sizeof(sidecar_err));
+   char *resp_str = kb_curator_llm_run(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, CE_SYSTEM_PROMPT,
+                                       req_str, cmd, CE_OUTBUF, sidecar_err, sizeof(sidecar_err));
    free(req_str);
 
    if (!resp_str)

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -57,14 +57,16 @@ int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
 
    /* Env bridge: when a tier has no config provider, fall back to the curator's
     * LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY env (the interface the bundled-Gemma
-    * deployment and the python sidecars already use). A config provider for the
-    * tier takes precedence; the env is a single endpoint that, when set, serves
-    * BOTH tiers (matching the short-term "everything on the bundled model"
-    * behavior) until an operator sets a capable tier_b.* in config. This is a
-    * whole-provider fallback (base+model+key together), not field-level mixing —
-    * the config and env providers are distinct units. */
+    * deployment and the python sidecars use). This applies to TIER-A ONLY: the
+    * bundled model (Gemma 3n E4B) is a Tier-A model, so letting it serve the
+    * reasoning stages would be exactly the weak-model-poisons-the-graph case §2a
+    * guards against. Tier-B takes a capable provider from tier_b.* config or it
+    * stays idle — no env fallback. A config provider for the tier still takes
+    * precedence. Whole-provider fallback (base+model+key as a unit). */
    if (!base_url[0])
    {
+      if (kb_curator_stage_tier(stage) != KB_CURATOR_TIER_A)
+         return 0; /* Tier-B: capable provider via tier_b.* config, or idle */
       const char *env_ep = getenv("LLM_ENDPOINT");
       if (!env_ep || !env_ep[0])
          return 0; /* neither config nor env — the stage stays idle */

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -469,10 +469,55 @@ static double memory_unit_semantic_type_boost(const char *unit_type, memory_quer
    return 0.0;
 }
 
+/* Whether the semantic-vector leg can run for a freshly embedded query: it must
+ * have produced a vector AND that vector's dimension must match the dimension
+ * the memory vectors were stored at (db2_embedding_dim()), so pgvector compares
+ * like with like. This generalises the historical `qdim == 384` special-case —
+ * which silently disabled semantic recall for every embedder other than the
+ * retired 384-d builtin — to whatever single embedder the deployment runs. */
+static int memory_semantic_dim_ok(int qdim)
+{
+   return qdim > 0 && qdim == db2_embedding_dim();
+}
+
+/* Cosine-similarity floors below were calibrated for the 384-d builtin embedder.
+ * Different embedders occupy different cosine ranges, so a fixed floor that
+ * keeps the right hits for one rejects them all for another (pplx-0.6b relevant
+ * matches land ~0.35-0.40, well under the 0.62/0.52 builtin-era floors). Scale
+ * the floors to the active embedder. config.memory_semantic_floor_scale > 0
+ * pins the multiplier (live calibration without a rebuild); 0 auto-scales by the
+ * active embedding dimension. Returns a multiplier applied to every floor. */
+static double memory_semantic_floor_scale(void)
+{
+   config_t fs_cfg;
+   if (config_load(&fs_cfg) == 0 && fs_cfg.memory_semantic_floor_scale > 0.0)
+      return fs_cfg.memory_semantic_floor_scale;
+   int dim = db2_embedding_dim();
+   if (dim <= 384)
+      return 1.0; /* 384-d builtin: the floors are calibrated for this range */
+   if (dim <= 1024)
+      return 0.55; /* pplx-0.6b: relevant cosines observed ~0.38 (0.62*0.55=0.34) */
+   if (dim <= 2560)
+      return 0.75; /* pplx-4b: wider than 0.6b but estimated — tune via config */
+   return 0.65;    /* unknown embedder: lean permissive over silently dropping */
+}
+
+/* Test hooks (declared in memory.h): expose the embedder-aware semantic gate +
+ * floor scale so unit tests can pin db2_set_embedding_dim() and assert that the
+ * leg runs and the floor tracks the active embedder dimension. */
+int memory_semantic_dim_ok_test(int qdim)
+{
+   return memory_semantic_dim_ok(qdim);
+}
+double memory_semantic_floor_scale_test(void)
+{
+   return memory_semantic_floor_scale();
+}
+
 /* Visitor state for the ephemeral-mode in-memory cosine scan. The visitor
- * keeps the top hits whose sim >= 0.62, deduplicating by memory_id and
- * resolving the memory row inline. The fixed cap matches the original local
- * array size; once we run out of slots we drop further matches. */
+ * keeps the top hits whose sim >= the embedder-scaled floor, deduplicating by
+ * memory_id and resolving the memory row inline. The fixed cap matches the
+ * original local array size; once we run out of slots we drop further matches. */
 static int memory_collect_semantic_matches(const char *query, const char *command, int limit,
                                            memory_t *out, int count, int max, int64_t *semantic_ids,
                                            double *semantic_scores, int *semantic_hit_count,
@@ -491,8 +536,9 @@ static int memory_collect_semantic_matches(const char *query, const char *comman
    if (qdim <= 0)
       return count;
 
-   if (qdim == 384)
+   if (memory_semantic_dim_ok(qdim))
    {
+      const double floor_scale = memory_semantic_floor_scale();
       int64_t ids[128];
       double scores[128];
       int hit_total = pgvec_memory_vector_search_record_type(
@@ -505,7 +551,7 @@ static int memory_collect_semantic_matches(const char *query, const char *comman
          for (int i = 0; i < hit_total && count < max && appended < limit; i++)
          {
             double sim = scores[i];
-            if (sim < 0.62)
+            if (sim < 0.62 * floor_scale)
                continue;
 
             memory_t candidate;
@@ -549,8 +595,9 @@ static int memory_collect_unit_semantic_matches(const char *query, const char *c
    if (qdim <= 0)
       return count;
 
-   if (qdim == 384)
+   if (memory_semantic_dim_ok(qdim))
    {
+      const double floor_scale = memory_semantic_floor_scale();
       int64_t ids[128];
       double vector_scores[128];
       int q_hits = pgvec_memory_vector_search_record_type(
@@ -592,6 +639,7 @@ static int memory_collect_unit_semantic_matches(const char *query, const char *c
             else if (intent == MEM_QUERY_TEMPORAL &&
                      (strcmp(unit_type, "temporal") == 0 || strcmp(unit_type, "event") == 0))
                threshold = 0.46;
+            threshold *= floor_scale;
             if (sim < threshold)
                continue;
 

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -90,8 +90,9 @@ static void test_tier_b_resolves(void)
    printf("kb_curator_provider: tier-A and tier-B resolve independently ok\n");
 }
 
-/* With no config provider, LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY drive BOTH tiers
- * (the bundled-deployment interface); a config tier_b still overrides. */
+/* LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY drive TIER-A only (the bundled Gemma E4B is
+ * a Tier-A model). Tier-B has no env fallback — it needs tier_b.* config or stays
+ * idle, so a Tier-A model never runs the reasoning stages. */
 static void test_env_bridge(void)
 {
    clear_llm_env(); /* start from a known-clean env, not just clean up at the end */
@@ -107,11 +108,13 @@ static void test_env_bridge(void)
    assert(strcmp(a.base_url, "http://bundled:8080/v1") == 0);
    assert(strcmp(a.model, "gemma-3n-e4b") == 0);
    assert(a.api_key == NULL); /* empty env key => keyless */
-   /* Tier-B ALSO from env (single endpoint serves both until tier_b configured). */
-   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
-   assert(strcmp(b.base_url, "http://bundled:8080/v1") == 0);
+   /* Tier-B does NOT take the Tier-A env endpoint — it stays idle (out zeroed).
+    * Check two distinct Tier-B stages, not just one. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 0);
+   assert(b.base_url == NULL && b.model == NULL); /* idle => out zeroed */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 0);
 
-   /* A config tier_b overrides the env for Tier-B; Tier-A still uses env. */
+   /* A config tier_b enables Tier-B (capable model); Tier-A still uses env. */
    snprintf(cfg.kb_curator_tier_b_base_url, sizeof(cfg.kb_curator_tier_b_base_url),
             "https://api.big/v1");
    snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
@@ -124,7 +127,7 @@ static void test_env_bridge(void)
    clear_llm_env();
    memset(&cfg, 0, sizeof(cfg));
    assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 0);
-   printf("kb_curator_provider: env bridge (LLM_ENDPOINT both tiers; tier_b override) ok\n");
+   printf("kb_curator_provider: env bridge (Tier-A only; Tier-B needs config) ok\n");
 }
 
 int main(void)

--- a/src/tests/test_memory.c
+++ b/src/tests/test_memory.c
@@ -18,6 +18,7 @@
 #include "platform_test_util.h"
 #include "workspace.h"
 #include "../db2/db2_internal.h"
+#include "../db2/lifecycle.h" /* db2_set_embedding_dim (embedder-aware semantic recall) */
 #include "../db2/entity_edges.h"
 #include "../db2/memory_payload.h" /* db2_memory_provenance_by_id (auditable-correctness P2) */
 #include "../db2/demotion.h"       /* retrieval_event write/read (auditable-correctness P2) */
@@ -571,6 +572,39 @@ static void measure_query_embedding_memo_recall(void)
    teardown();
 }
 
+/* The semantic-memory legs were gated on `qdim == 384` (the retired builtin) and
+ * used 384-calibrated cosine floors, so semantic recall was silently dead for
+ * pplx-0.6b (1024) / pplx-4b (2560). Verify the gate now tracks the active
+ * embedding dim and the floor scales down for the compressed-range embedders. */
+static void test_semantic_recall_is_embedder_aware(void)
+{
+   setup();
+
+   db2_set_embedding_dim(384);
+   assert(memory_semantic_dim_ok_test(384) == 1);
+   assert(memory_semantic_dim_ok_test(1024) == 0); /* mismatch must not query */
+   assert(memory_semantic_dim_ok_test(0) == 0);    /* embed failure */
+   assert(fabs(memory_semantic_floor_scale_test() - 1.0) < 1e-9);
+
+   db2_set_embedding_dim(1024); /* pplx-0.6b: the leg must now run */
+   assert(memory_semantic_dim_ok_test(1024) == 1);
+   assert(memory_semantic_dim_ok_test(384) == 0);
+   double s1024 = memory_semantic_floor_scale_test();
+   assert(s1024 > 0.0 && s1024 < 1.0); /* floors relaxed vs the 384 baseline */
+   assert(0.62 * s1024 < 0.45);        /* 384-era 0.62 floor now clears ~0.38 hits */
+
+   db2_set_embedding_dim(2560); /* pplx-4b */
+   assert(memory_semantic_dim_ok_test(2560) == 1);
+   double s2560 = memory_semantic_floor_scale_test();
+   assert(s2560 > s1024 && s2560 <= 1.0); /* 4b range wider than 0.6b, <= builtin */
+
+   db2_set_embedding_dim(9999); /* unknown embedder: permissive, never 1:1 */
+   assert(memory_semantic_floor_scale_test() < 1.0);
+
+   db2_set_embedding_dim(1024); /* restore the deployment default */
+   teardown();
+}
+
 int main(void)
 {
    char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
@@ -587,6 +621,7 @@ int main(void)
    test_db1_runtime_state_add_int();
    test_query_embedding_memo_dedupes_embeds();
    test_query_embed_prewarm_batches();
+   test_semantic_recall_is_embedder_aware();
    measure_query_embedding_memo_recall();
    test_insert_memory();
    test_insert_merge();


### PR DESCRIPTION
Promote testing → main. #422: re-enable the semantic-vector leg of memory recall for the 1024/2560 embedders (it was gated to the retired 384-d builtin, silently disabling semantic recall) + embedder-aware cosine floors with a config override. Unit-tested, lint/docs-gen green.