### PR TITLE
feat(curator): health/observability block on kb /v1/health (§4)

### DIFF
--- a/src/kb/kb_curator_queue.c
+++ b/src/kb/kb_curator_queue.c
@@ -164,3 +164,46 @@ int kb_curator_queue_code_units_for_project(const char *project, const char *roo
                 enqueued, project);
    return enqueued;
 }
+
+void kb_curator_queue_counts(kb_curator_queue_counts_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+
+   char err[CQ_ERRBUF] = "";
+   /* extract_doc pending/done from kb_async_jobs (one scan). */
+   static const char *sql_doc = "SELECT"
+                                " COALESCE(SUM(CASE WHEN status='pending' THEN 1 ELSE 0 END),0),"
+                                " COALESCE(SUM(CASE WHEN status='done' THEN 1 ELSE 0 END),0)"
+                                " FROM kb_async_jobs WHERE kind='extract_doc'";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql_doc, err, sizeof(err));
+   if (st)
+   {
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         out->extract_pending = (int)aimee_pg_column_int64(st, 0);
+         out->extract_done = (int)aimee_pg_column_int64(st, 1);
+      }
+      aimee_pg_finalize(st);
+   }
+
+   /* code_unit pending/done from kb_code_unit_jobs. */
+   static const char *sql_code = "SELECT"
+                                 " COALESCE(SUM(CASE WHEN status='pending' THEN 1 ELSE 0 END),0),"
+                                 " COALESCE(SUM(CASE WHEN status='done' THEN 1 ELSE 0 END),0)"
+                                 " FROM kb_code_unit_jobs";
+   st = aimee_pg_prepare(conn, sql_code, err, sizeof(err));
+   if (st)
+   {
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         out->code_unit_pending = (int)aimee_pg_column_int64(st, 0);
+         out->code_unit_done = (int)aimee_pg_column_int64(st, 1);
+      }
+      aimee_pg_finalize(st);
+   }
+}

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -6,6 +6,7 @@
 #include "cJSON.h"
 #include "config.h"
 #include "kb_curator_queue.h"
+#include "kb_curator_provider.h"
 #include "json_fluent.h"
 #include "db2/canonical_index.h"
 #include "db2/kb_maintenance.h"
@@ -222,6 +223,42 @@ char *kb_service_ingest_status_json(void)
    return json;
 }
 
+/* Add a per-tier provider sub-object {configured, base_url, model} (no api_key). */
+static void kb_health_add_curator_tier(cJSON *curator, const char *key, const config_t *cfg,
+                                       kb_curator_stage_t stage)
+{
+   cJSON *t = cJSON_AddObjectToObject(curator, key);
+   if (!t)
+      return;
+   provider_def_t def;
+   int configured = kb_curator_provider_for_stage(cfg, stage, &def);
+   cJSON_AddBoolToObject(t, "configured", configured);
+   cJSON_AddStringToObject(t, "base_url", configured && def.base_url ? def.base_url : "");
+   cJSON_AddStringToObject(t, "model", configured && def.model ? def.model : "");
+}
+
+/* Curator observability block for /v1/health (§4): which tiers have a provider
+ * (Tier-A extract/index, Tier-B reason/judge) and the curator queue depth. */
+static void kb_health_add_curator(cJSON *resp, const config_t *cfg)
+{
+   cJSON *curator = cJSON_AddObjectToObject(resp, "curator");
+   if (!curator)
+      return;
+   kb_health_add_curator_tier(curator, "tier_a", cfg, KB_CURATOR_STAGE_EXTRACT_DOCS);
+   kb_health_add_curator_tier(curator, "tier_b", cfg, KB_CURATOR_STAGE_JUDGE);
+
+   kb_curator_queue_counts_t qc;
+   kb_curator_queue_counts(&qc);
+   cJSON *q = cJSON_AddObjectToObject(curator, "queue");
+   if (q)
+   {
+      cJSON_AddNumberToObject(q, "extract_pending", qc.extract_pending);
+      cJSON_AddNumberToObject(q, "extract_done", qc.extract_done);
+      cJSON_AddNumberToObject(q, "code_unit_pending", qc.code_unit_pending);
+      cJSON_AddNumberToObject(q, "code_unit_done", qc.code_unit_done);
+   }
+}
+
 static cJSON *kb_service_health_object(void)
 {
    cJSON *resp = cJSON_CreateObject();
@@ -270,6 +307,13 @@ static cJSON *kb_service_health_object(void)
    cJSON_AddBoolToObject(resp, "embed_ok", embed_ok);
    cJSON_AddStringToObject(resp, "embed_command",
                            cfg.embedding_command[0] ? cfg.embedding_command : "builtin");
+
+   /* Curator (§4 observability): per-tier provider config + queue depth. The
+    * live four-state reachability probe (ready/loading/gated/down) is deferred to
+    * a follow-up — it needs a bounded async probe so the health path never blocks,
+    * and the gated state needs a custom curator /health (the bundled official
+    * llama.cpp doesn't expose it). api_key is never surfaced. */
+   kb_health_add_curator(resp, &cfg);
 
    /* Freshness: read last_ingest_at from kb_runtime_state */
    char last_ingest_at[64] = "";

--- a/src/kb_curator_queue.h
+++ b/src/kb_curator_queue.h
@@ -15,4 +15,16 @@ int kb_curator_queue_code_unit(const char *project, const char *file_path, const
 /* Bulk-enqueue extract_code_unit jobs for indexed terms in a project. */
 int kb_curator_queue_code_units_for_project(const char *project, const char *root_path);
 
+/* Curator queue depth, for the /v1/health curator block (§4 observability). */
+typedef struct
+{
+   int extract_pending; /* kb_async_jobs kind='extract_doc' status='pending' */
+   int extract_done;    /* kb_async_jobs kind='extract_doc' status='done' */
+   int code_unit_pending;
+   int code_unit_done;
+} kb_curator_queue_counts_t;
+
+/* Fill *out with current curator queue depths (zeroed on any error / no DB). */
+void kb_curator_queue_counts(kb_curator_queue_counts_t *out);
+
 #endif /* DEC_KB_CURATOR_QUEUE_H */


### PR DESCRIPTION
**§4 (observability) — a `curator` block on the kb `/v1/health` response**, so operators can see whether each curator tier has an LLM provider and how deep the curation backlog is.

## What's in the block
```json
"curator": {
  "tier_a": {"configured": true,  "base_url": "http://…/v1", "model": "gemma-3n-e4b"},
  "tier_b": {"configured": false, "base_url": "", "model": ""},
  "queue":  {"extract_pending": N, "extract_done": N, "code_unit_pending": N, "code_unit_done": N}
}
```
- **tier_a / tier_b** resolved via `kb_curator_provider_for_stage` (Tier-A = extract/index, Tier-B = reason/judge). `api_key` is **never** surfaced. With the bundled-Gemma `LLM_ENDPOINT` set, `tier_a` is configured; `tier_b` is configured only when an operator sets a `tier_b.*` provider.
- **queue** via a new `kb_curator_queue_counts()` (COUNT over `kb_async_jobs` `kind='extract_doc'` and `kb_code_unit_jobs`).

## Scope
Deliberately the **cheap, non-blocking** signals. Deferred to a follow-up (noted in code):
- the live **four-state reachability probe** (ready/loading/gated/down) — needs a bounded async probe so `/v1/health` never blocks, and `gated` needs a custom curator `/health` the bundled official llama.cpp doesn't expose (that was §3's container, now moot);
- `aimee kb curator status` CLI (can read this block);
- `dead_letter` counts — no such table (the drain's bounded-retry/dead-letter policy was never implemented).

## Verification
`make all` clean (incl. `aimee-kb`), `make lint` ok (clang-format-19, schema-sync), all curator unit tests pass. No test links `kb_service_kb.o`, so no test-wiring changes. Local roundtable gate run on the diff.
