### PR TITLE
feat(css): default css_render_command to the css-render sidecar

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -549,6 +549,10 @@ static void config_set_defaults(config_t *cfg)
    cfg->css_style_graph_enabled = 1; /* default-on: the indexer builds the CSS style
                                         graph so the read-only css signals/report work
                                         out of the box (set false to opt out) */
+   snprintf(cfg->css_render_command, sizeof(cfg->css_render_command), "%s",
+            CONFIG_DEFAULT_CSS_RENDER_COMMAND); /* default-on render backend (inert
+                                                   until the sidecar is up); set empty
+                                                   to disable */
    cfg->worktree_gc_enabled = 0;
    cfg->worktree_gc_max_age_days = 14;
    cfg->model_meta_refresh_minutes = 60;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -776,7 +776,9 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
    if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */
       cJSON_AddBoolToObject(root, "css_style_graph_enabled", 0);
-   if (cfg->css_render_command[0])
+   /* default-on render backend: persist only a non-default value (a custom command
+    * OR an empty string to disable) so both round-trip; the default isn't written. */
+   if (strcmp(cfg->css_render_command, CONFIG_DEFAULT_CSS_RENDER_COMMAND) != 0)
       cJSON_AddStringToObject(root, "css_render_command", cfg->css_render_command);
    if (cfg->kb_evidence_emit_enabled)
       cJSON_AddBoolToObject(root, "kb_evidence_emit_enabled", 1);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -35,6 +35,13 @@
 #define CONFIG_DEFAULT_DELEGATE_MAX_INFLIGHT           512
 #define CONFIG_DEFAULT_CONCURRENCY_PREEMPT_REQUEUE_MAX 1
 
+/* Default render backend for the #4-full computed-style oracle: curl the
+ * conventional css-render sidecar (deploy/css-render, reachable as
+ * `aimee-css-render:8780` on the shared container network). Inert when the
+ * sidecar is down (oracle = UNAVAILABLE); set css_render_command empty to off. */
+#define CONFIG_DEFAULT_CSS_RENDER_COMMAND                                                          \
+   "curl -s --max-time 30 --data-binary @- http://aimee-css-render:8780/render"
+
 /* Concurrency config: per-model and per-provider overrides */
 #define CONFIG_CONCURRENCY_KEY_LEN     128
 #define CONFIG_CONCURRENCY_MAX_ENTRIES 16
@@ -295,8 +302,11 @@ typedef struct config
     * A shell command (like embedding_command) that reads a {"html","css"} JSON
     * object on stdin and writes a computed-style snapshot JSON on stdout. It runs
     * a headless browser over UNTRUSTED markup, so it must be an isolated,
-    * out-of-process backend (e.g. `curl` to a sandboxed render sidecar). Empty =
-    * no backend (the oracle reports UNAVAILABLE). */
+    * out-of-process backend (e.g. `curl` to a sandboxed render sidecar). Defaults
+    * to the conventional css-render sidecar (CONFIG_DEFAULT_CSS_RENDER_COMMAND) so
+    * render-capture works the moment the sidecar is up (on-demand); inert when it
+    * is down (the oracle reports UNAVAILABLE, never a fake verdict). Set empty to
+    * disable. */
    char css_render_command[512];
    int memory_salience_enabled;
    double memory_salience_weight;

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -74,6 +74,9 @@ int main(void)
       /* CSS style graph now defaults on so the read-only css signals/report work
        * out of the box (the indexer populates css_rules/css_declarations). */
       assert(cfg.css_style_graph_enabled == 1);
+      /* css_render_command defaults to the conventional sidecar curl (inert until
+       * the sidecar is up), so render-capture works out of the box on-demand. */
+      assert(strcmp(cfg.css_render_command, CONFIG_DEFAULT_CSS_RENDER_COMMAND) == 0);
    }
 
    /* --- config_save + config_load round-trip --- */
@@ -194,6 +197,10 @@ int main(void)
       /* css_style_graph now defaults on; set off to prove the opt-out round-trips
        * (default-on save-guard regression class). */
       cfg.css_style_graph_enabled = 0;
+      /* css_render_command defaults non-empty; set empty to prove the disable
+       * override round-trips (string default-on save-guard: save must emit the
+       * non-default empty, not drop it and silently re-default on reload). */
+      cfg.css_render_command[0] = '\0';
       /* kb.maintenance.* — must survive config_save (same drop class as curator). */
       cfg.kb_maintenance_enabled = 1;
       cfg.kb_maintenance_interval_hours = 12;
@@ -380,7 +387,8 @@ int main(void)
       assert(cfg2.memory_improve_min_cluster == 5);
       assert(fabs(cfg2.memory_improve_max_confidence - 0.42) < 0.0001);
       assert(cfg2.memory_directives_enabled == 0);
-      assert(cfg2.css_style_graph_enabled == 0); /* opt-out survives save/reload */
+      assert(cfg2.css_style_graph_enabled == 0);  /* opt-out survives save/reload */
+      assert(cfg2.css_render_command[0] == '\0'); /* disable (empty) survives save/reload */
       /* regression: kb.maintenance.* used to be parsed but never saved -> dropped on save. */
       assert(cfg2.kb_maintenance_enabled == 1);
       assert(cfg2.kb_maintenance_interval_hours == 12);

--- a/src/tests/test_css_render_cmd.c
+++ b/src/tests/test_css_render_cmd.c
@@ -35,8 +35,12 @@ static void set_config(int css_enabled, const char *render_cmd)
    FILE *f = fopen(path, "w");
    assert(f);
    fprintf(f, "css_style_graph_enabled: %s\n", css_enabled ? "true" : "false");
+   /* NULL = omit the key (the non-empty default command applies); "" = write an
+    * explicit empty value to DISABLE the now-default-on backend; else the command. */
    if (render_cmd && render_cmd[0])
       fprintf(f, "css_render_command: %s\n", render_cmd);
+   else if (render_cmd)
+      fprintf(f, "css_render_command: \"\"\n");
    fclose(f);
 }
 
@@ -65,9 +69,10 @@ int main(void)
    char ok_cmd[700];
    snprintf(ok_cmd, sizeof(ok_cmd), "sh %s", ok_sh);
 
-   /* Gate: flag on but no command -> no adapter. */
+   /* Gate: flag on but command explicitly emptied -> no adapter. (css_render_command
+    * is default-on, so "no backend" means an explicit empty override, not omission.) */
    css_render_oracle_set_adapter(NULL);
-   set_config(1, NULL);
+   set_config(1, "");
    assert(css_render_cmd_register() == 0);
    assert(!css_render_oracle_has_adapter());
 
@@ -75,6 +80,12 @@ int main(void)
    set_config(0, ok_cmd);
    assert(css_render_cmd_register() == 0);
    assert(!css_render_oracle_has_adapter());
+
+   /* Default: flag on, command omitted -> the default sidecar command registers. */
+   css_render_oracle_set_adapter(NULL);
+   set_config(1, NULL);
+   assert(css_render_cmd_register() == 1);
+   assert(css_render_oracle_has_adapter());
 
    /* Both set -> adapter registered, render produces a parseable snapshot. */
    set_config(1, ok_cmd);


### PR DESCRIPTION
## Summary
Makes the **#4-full rendered computed-style oracle** (your *snapshot → refactor → snapshot → compare* workflow) work out of the box. `css_render_command` now defaults to the conventional css-render sidecar curl, so `aimee css render-capture` / `render-verify` work the moment the sidecar is up — no per-install config.

Inert when the sidecar is down (the oracle reports `UNAVAILABLE`, never a fake verdict), so it composes cleanly with the on-demand sidecar lifecycle (`css-render-ctl.sh up`/`down`). Pairs with the already-default-on `css_style_graph_enabled`.

## Changes
- `config_set_defaults`: `css_render_command = CONFIG_DEFAULT_CSS_RENDER_COMMAND` (`curl -s --max-time 30 --data-binary @- http://aimee-css-render:8780/render`)
- `config_save`: persist only a **non-default** value (custom command OR empty-to-disable) so both round-trip; the default isn't written
- `config.h`: macro + doc
- `test_config`: assert default + empty-disable round-trip
- `test_css_render_cmd`: 'no backend' now = an explicit empty override; added a default-omitted-registers case

## Live validation on .254
Deployed the `css-render` sidecar (headless Chromium, isolated container on veth0), set the command, and ran a **real** loop on a card component:
- computed-style-preserving refactor (custom props, hex shortening, padding shorthand) → `equivalent`, `diff_count: 0`
- `width 300→320` + `color #666→#777` → `not equivalent`, `diff_count: 4` (catches the cascade to children too)
- missing snapshot → `unknown` (conservative)

## Testing
`make all` + `unit-test-config` + `unit-test-css-render-cmd` green; build-integrity + docs-gen (no churn) green.