### PR TITLE
fix(curator): read code-unit body from DB2, not the thin-client disk path

### DIFF
--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -167,6 +167,74 @@ static void ccu_resolve_path(const char *project, const char *file_path, char *o
       snprintf(out, out_len, "%s", file_path ? file_path : "");
 }
 
+/* Slice CCU_BODY_LINES lines starting at `line` (1-based) out of an in-memory
+ * file `content`. Returns malloc'd string (caller frees) or NULL on OOM. */
+static char *ccu_slice_lines(const char *content, int line)
+{
+   int start = line > 1 ? line - 1 : 0;
+   int end = start + CCU_BODY_LINES;
+   char *body = malloc(strlen(content) + 1); /* a subset never exceeds the whole */
+   if (!body)
+      return NULL;
+   size_t total = 0;
+   int cur = 0;
+   const char *p = content;
+   while (*p)
+   {
+      const char *nl = strchr(p, '\n');
+      size_t n = nl ? (size_t)(nl - p) + 1 : strlen(p);
+      if (cur >= start && cur < end)
+      {
+         memcpy(body + total, p, n);
+         total += n;
+      }
+      cur++;
+      if (!nl || cur >= end)
+         break;
+      p += n;
+   }
+   body[total] = '\0';
+   return body;
+}
+
+/* Read the code-unit body from the file's content stored in DB2 (file_contents),
+ * keyed by project + project-relative path. This is the primary source: the
+ * curator drain runs server-side, where thin-client-ingested files do not exist
+ * on disk (projects.root points at the client's path) — but ingest pushes the
+ * whole file content into file_contents. Returns malloc'd string (caller frees),
+ * or NULL when no stored content exists (caller falls back to an on-disk read for
+ * local deployments). */
+static char *ccu_read_body_db2(const char *project, const char *file_path, int line)
+{
+   void *conn = db2_conn();
+   if (!conn || !project || !project[0] || !file_path || !file_path[0])
+      return NULL;
+   char err[CCU_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "SELECT fc.content FROM file_contents fc"
+                                          " JOIN files f ON f.id = fc.file_id"
+                                          " JOIN projects p ON p.id = f.project_id"
+                                          " WHERE p.name = ?1 AND f.path = ?2 LIMIT 1",
+                                          err, sizeof(err));
+   if (!st)
+      return NULL;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", file_path);
+   char *content = NULL;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *c = aimee_pg_column_text(st, 0);
+      if (c && c[0])
+         content = strdup(c);
+   }
+   aimee_pg_finalize(st);
+   if (!content)
+      return NULL;
+   char *body = ccu_slice_lines(content, line);
+   free(content);
+   return body;
+}
+
 /* Read CCU_BODY_LINES lines starting at line (1-based) from file_path.
  * Returns malloc'd string (caller frees) or NULL on error. */
 static char *ccu_read_body(const char *file_path, int line, char *errbuf, size_t errlen)
@@ -479,11 +547,21 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
              job.symbol, job.file_path);
 
    char body_err[CCU_ERRBUF] = "";
-   char abs_path[2048];
-   ccu_resolve_path(job.project, job.file_path, abs_path, sizeof(abs_path));
-   char *body = ccu_read_body(abs_path, job.line, body_err, sizeof(body_err));
+   /* Primary: the file content stored in DB2 at ingest (works server-side for
+    * thin-client-ingested files). Fallback: an on-disk read for local
+    * deployments whose file_contents may be empty. */
+   char *body = ccu_read_body_db2(job.project, job.file_path, job.line);
    if (!body)
    {
+      char abs_path[2048];
+      ccu_resolve_path(job.project, job.file_path, abs_path, sizeof(abs_path));
+      body = ccu_read_body(abs_path, job.line, body_err, sizeof(body_err));
+   }
+   if (!body)
+   {
+      if (!body_err[0])
+         snprintf(body_err, sizeof(body_err), "no stored content and cannot open %s",
+                  job.file_path);
       aimee_log(LOG_WARN, "kb.curator.extract_code", "cannot read body for job %lld: %s",
                 (long long)job.job_id, body_err);
       ccu_mark_retry_or_fail(job.job_id, opts->max_attempts, opts->max_attempts, body_err);

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -298,6 +298,57 @@ static void test_extract_accepts_pure_function(void)
    printf("  PASS: test_extract_accepts_pure_function\n");
 }
 
+/* The curator drain runs server-side, where thin-client-ingested files do not
+ * exist on disk. The body must come from DB2's file_contents (pushed at ingest),
+ * not an open() of the project-relative path. Seed file_contents but NO disk file
+ * and a non-existent project root: extraction must still succeed, proving the
+ * body was read from DB2. (Regression for ~36k curator jobs failing with
+ * "cannot read body".) */
+static void test_extract_reads_body_from_db2_when_file_absent(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   assert(db != NULL);
+
+   const char *src_body = "int target_fn(void) { return 0; }\n";
+   char resp_path[] = "/tmp/aimee_ccu_resp_XXXXXX";
+   int resp_fd = mkstemp(resp_path);
+   assert(resp_fd >= 0);
+   const char *resp =
+       "{\"status\":\"ok\",\"artifacts\":[{\"kind\":\"code_unit\",\"confidence\":0.9,"
+       "\"payload\":{\"intent\":\"t\",\"side_effects\":[],\"invariants\":[],"
+       "\"domain_concepts\":[\"x\"]}}]}";
+   assert(write(resp_fd, resp, strlen(resp)) == (ssize_t)strlen(resp));
+   close(resp_fd);
+
+   /* Project root that does not exist on disk + a project-relative path with no
+    * on-disk file — only DB2 file_contents has the body. */
+   const char *sql =
+       "INSERT INTO projects (id, name, root, scanned_at)"
+       " VALUES (1,'testproj','/nonexistent-root-xyzzy','t');"
+       "INSERT INTO files (id, project_id, path, scanned_at) VALUES (1,1,'src/foo.c','t');"
+       "INSERT INTO file_contents (file_id, content)"
+       " VALUES (1,'int target_fn(void) { return 0; }\n');"
+       "INSERT INTO kb_code_unit_jobs (project, file_path, symbol, kind, line)"
+       " VALUES ('testproj','src/foo.c','target_fn','function',1);";
+   assert(sqlite3_exec(db, sql, NULL, NULL, NULL) == SQLITE_OK);
+   (void)src_body;
+
+   kb_curator_extract_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.max_attempts = 3;
+   opts.max_tokens = 256;
+   snprintf(opts.extract_command, sizeof(opts.extract_command), "cat %s", resp_path);
+
+   int rc = kb_curator_extract_code_unit_one(&opts);
+   assert(rc == 1); /* claimed + processed (body came from DB2, not disk) */
+   assert(db2_artifact_count("code_unit", "proposed") == 1);
+
+   db2_test_shim_close();
+   unlink(resp_path);
+   printf("  PASS: test_extract_reads_body_from_db2_when_file_absent\n");
+}
+
 /* ── main ─────────────────────────────────────────────────────────────── */
 
 int main(void)
@@ -318,6 +369,7 @@ int main(void)
    test_extract_rejects_false_no_side_effects();
    test_extract_accepts_honest_claim();
    test_extract_accepts_pure_function();
+   test_extract_reads_body_from_db2_when_file_absent();
 
    printf("ok\n");
    return 0;


### PR DESCRIPTION
## Bug

The deep-curator code-unit extractor (`kb_curator_extract_code`) resolved each job's `file_path` against `projects.root` and `fopen()`'d it. But the curator drain runs **server-side**, while `projects.root` records the **thin-client's** ingest path (`/home/virant/dev/...`, `/home/virant/gow/...`) — which doesn't exist in the server container. So every job failed at `cannot read body` before ever reaching the LLM.

**Live on `.254`:** 0 done, ~36k pending, ~1,180 failed and climbing, Gemma sitting idle — the queue was never going to drain.

## Fix

The whole file content is **already in DB2** (`file_contents`, keyed via `files`/`projects`) — pushed at ingest, and what kb/search + the 4,597 code embeddings already use. Read the body from there as the **primary** source:

- `ccu_read_body_db2()` — joins `file_contents → files → projects` on `(project, path)` and slices `CCU_BODY_LINES` from the unit's line in-memory (`ccu_slice_lines`).
- Falls back to the on-disk read only when no stored content exists (local deployments).

This mirrors how the **doc** curator already sources its content from DB2. Verified live: the join returns the real content (e.g. 21,675 chars for a failing `aimee :: install.sh` job).

## Test
`test_extract_reads_body_from_db2_when_file_absent`: seeds `file_contents` with **no on-disk file** and a **non-existent project root**; extraction still succeeds (`proposed == 1`), proving the body came from DB2. The three existing on-disk scenarios stay green via the fallback. Built + ran `unit-test-curator-code-unit` (12/12 pass); clang-format-19 clean.

## After merge
Deploy to `.254` and watch `kb_code_unit_jobs` actually drain through Gemma (done climbing, failed flat).