### PR TITLE
Promote testing → main: curator reads code-unit body from DB2 (#427)

### DIFF
--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -167,6 +167,74 @@ static void ccu_resolve_path(const char *project, const char *file_path, char *o
       snprintf(out, out_len, "%s", file_path ? file_path : "");
 }
 
+/* Slice CCU_BODY_LINES lines starting at `line` (1-based) out of an in-memory
+ * file `content`. Returns malloc'd string (caller frees) or NULL on OOM. */
+static char *ccu_slice_lines(const char *content, int line)
+{
+   int start = line > 1 ? line - 1 : 0;
+   int end = start + CCU_BODY_LINES;
+   char *body = malloc(strlen(content) + 1); /* a subset never exceeds the whole */
+   if (!body)
+      return NULL;
+   size_t total = 0;
+   int cur = 0;
+   const char *p = content;
+   while (*p)
+   {
+      const char *nl = strchr(p, '\n');
+      size_t n = nl ? (size_t)(nl - p) + 1 : strlen(p);
+      if (cur >= start && cur < end)
+      {
+         memcpy(body + total, p, n);
+         total += n;
+      }
+      cur++;
+      if (!nl || cur >= end)
+         break;
+      p += n;
+   }
+   body[total] = '\0';
+   return body;
+}
+
+/* Read the code-unit body from the file's content stored in DB2 (file_contents),
+ * keyed by project + project-relative path. This is the primary source: the
+ * curator drain runs server-side, where thin-client-ingested files do not exist
+ * on disk (projects.root points at the client's path) — but ingest pushes the
+ * whole file content into file_contents. Returns malloc'd string (caller frees),
+ * or NULL when no stored content exists (caller falls back to an on-disk read for
+ * local deployments). */
+static char *ccu_read_body_db2(const char *project, const char *file_path, int line)
+{
+   void *conn = db2_conn();
+   if (!conn || !project || !project[0] || !file_path || !file_path[0])
+      return NULL;
+   char err[CCU_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "SELECT fc.content FROM file_contents fc"
+                                          " JOIN files f ON f.id = fc.file_id"
+                                          " JOIN projects p ON p.id = f.project_id"
+                                          " WHERE p.name = ?1 AND f.path = ?2 LIMIT 1",
+                                          err, sizeof(err));
+   if (!st)
+      return NULL;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", file_path);
+   char *content = NULL;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *c = aimee_pg_column_text(st, 0);
+      if (c && c[0])
+         content = strdup(c);
+   }
+   aimee_pg_finalize(st);
+   if (!content)
+      return NULL;
+   char *body = ccu_slice_lines(content, line);
+   free(content);
+   return body;
+}
+
 /* Read CCU_BODY_LINES lines starting at line (1-based) from file_path.
  * Returns malloc'd string (caller frees) or NULL on error. */
 static char *ccu_read_body(const char *file_path, int line, char *errbuf, size_t errlen)
@@ -479,11 +547,21 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
              job.symbol, job.file_path);
 
    char body_err[CCU_ERRBUF] = "";
-   char abs_path[2048];
-   ccu_resolve_path(job.project, job.file_path, abs_path, sizeof(abs_path));
-   char *body = ccu_read_body(abs_path, job.line, body_err, sizeof(body_err));
+   /* Primary: the file content stored in DB2 at ingest (works server-side for
+    * thin-client-ingested files). Fallback: an on-disk read for local
+    * deployments whose file_contents may be empty. */
+   char *body = ccu_read_body_db2(job.project, job.file_path, job.line);
    if (!body)
    {
+      char abs_path[2048];
+      ccu_resolve_path(job.project, job.file_path, abs_path, sizeof(abs_path));
+      body = ccu_read_body(abs_path, job.line, body_err, sizeof(body_err));
+   }
+   if (!body)
+   {
+      if (!body_err[0])
+         snprintf(body_err, sizeof(body_err), "no stored content and cannot open %s",
+                  job.file_path);
       aimee_log(LOG_WARN, "kb.curator.extract_code", "cannot read body for job %lld: %s",
                 (long long)job.job_id, body_err);
       ccu_mark_retry_or_fail(job.job_id, opts->max_attempts, opts->max_attempts, body_err);

--- a/src/kb/kb_curator_judge.c
+++ b/src/kb/kb_curator_judge.c
@@ -7,11 +7,22 @@
 
 #include "kb_curator_judge.h"
 #include "kb_curator_sidecar.h"
+#include "kb_curator_llm.h"
 #include "cJSON.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+
+/* System prompt for the judge stage (Tier-B) when routed through a configured
+ * provider (§2b). The legacy python sidecar carried its own prompt; the
+ * in-process provider needs one. The request JSON (mention + candidate + score)
+ * is the user turn; tune against the model. */
+#define CJ_SYSTEM_PROMPT                                                                           \
+   "You are an entity-resolution judge for a knowledge base. Given a candidate "                   \
+   "mention and an existing entity as JSON, decide whether they are the same "                     \
+   "canonical thing. Respond with a single JSON object: {\"same_entity\": "                        \
+   "true|false}. When unsure, answer false."
 
 /* Build the request JSON. Returns a malloc'd string (caller frees) or NULL. */
 static char *cj_build_request(const char *mention_name, const char *mention_context,
@@ -37,18 +48,13 @@ static char *cj_build_request(const char *mention_name, const char *mention_cont
    return json;
 }
 
-int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name,
-                                 const char *mention_context, const char *candidate_name,
-                                 double score, int *out_same, char *errbuf, size_t errlen)
+int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
+                                 const char *mention_name, const char *mention_context,
+                                 const char *candidate_name, double score, int *out_same,
+                                 char *errbuf, size_t errlen)
 {
    if (errbuf && errlen)
       errbuf[0] = '\0';
-   if (!judge_cmd || !judge_cmd[0])
-   {
-      if (errbuf)
-         snprintf(errbuf, errlen, "no judge command configured");
-      return -1;
-   }
    if (!out_same)
       return -1;
 
@@ -60,8 +66,12 @@ int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name
       return -1;
    }
 
+   /* Tier-B dispatch: a configured tier_b.* provider runs in-process, else the
+    * judge_cmd sidecar; "neither configured" surfaces as -1 (caller treats as
+    * not-same / create). */
    char local_err[256];
-   char *response = kb_curator_sidecar_run(judge_cmd, request, 0, local_err, sizeof(local_err));
+   char *response = kb_curator_llm_run(cfg, KB_CURATOR_STAGE_JUDGE, CJ_SYSTEM_PROMPT, request,
+                                       judge_cmd, 0, local_err, sizeof(local_err));
    free(request);
    if (!response)
    {

--- a/src/kb/kb_curator_judge.h
+++ b/src/kb/kb_curator_judge.h
@@ -13,21 +13,29 @@
 #ifndef KB_CURATOR_JUDGE_H
 #define KB_CURATOR_JUDGE_H
 
+#include "config.h" /* config_t — for Tier-B provider resolution via kb_curator_llm */
+
 #include <stddef.h>
 
-/* Ask the judge sidecar whether `mention` refers to the same canonical entity
- * as `candidate`. Request JSON:
+/* Ask the judge whether `mention` refers to the same canonical entity as
+ * `candidate`. Request JSON:
  *   {"task":"same_entity","mention":{"name":...,"context":...},
  *    "candidate":{"name":...},"score":<float>}
  * Expected response JSON: {"same_entity": true|false}.
  *
+ * Routes through the §2 dispatch (kb_curator_llm_run): judge is a Tier-B stage,
+ * so it uses a configured tier_b.* provider in-process, else the `judge_cmd`
+ * sidecar, else errors. `cfg` may be NULL (provider resolution skipped → sidecar
+ * only) — the unit tests pass NULL to exercise the shell-sidecar path.
+ *
  * Returns 0 and sets *out_same to 0/1 on a clean decision. Returns -1 on any
- * error (empty command, spawn failure, non-zero exit, unparseable output) and
- * leaves *out_same untouched — the caller MUST treat a judge error as "not the
- * same entity" (i.e. create), never as a merge, so a flaky sidecar can only
- * over-create, never silently collapse distinct entities. */
-int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name,
-                                 const char *mention_context, const char *candidate_name,
-                                 double score, int *out_same, char *errbuf, size_t errlen);
+ * error (no provider and no command, spawn failure, non-zero exit, unparseable
+ * output) and leaves *out_same untouched — the caller MUST treat a judge error
+ * as "not the same entity" (i.e. create), never as a merge, so a flaky judge can
+ * only over-create, never silently collapse distinct entities. */
+int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
+                                 const char *mention_name, const char *mention_context,
+                                 const char *candidate_name, double score, int *out_same,
+                                 char *errbuf, size_t errlen);
 
 #endif /* KB_CURATOR_JUDGE_H */

--- a/src/kb/kb_curator_queue.c
+++ b/src/kb/kb_curator_queue.c
@@ -164,3 +164,46 @@ int kb_curator_queue_code_units_for_project(const char *project, const char *roo
                 enqueued, project);
    return enqueued;
 }
+
+void kb_curator_queue_counts(kb_curator_queue_counts_t *out)
+{
+   if (!out)
+      return;
+   memset(out, 0, sizeof(*out));
+   void *conn = db2_conn();
+   if (!conn)
+      return;
+
+   char err[CQ_ERRBUF] = "";
+   /* extract_doc pending/done from kb_async_jobs (one scan). */
+   static const char *sql_doc = "SELECT"
+                                " COALESCE(SUM(CASE WHEN status='pending' THEN 1 ELSE 0 END),0),"
+                                " COALESCE(SUM(CASE WHEN status='done' THEN 1 ELSE 0 END),0)"
+                                " FROM kb_async_jobs WHERE kind='extract_doc'";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql_doc, err, sizeof(err));
+   if (st)
+   {
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         out->extract_pending = (int)aimee_pg_column_int64(st, 0);
+         out->extract_done = (int)aimee_pg_column_int64(st, 1);
+      }
+      aimee_pg_finalize(st);
+   }
+
+   /* code_unit pending/done from kb_code_unit_jobs. */
+   static const char *sql_code = "SELECT"
+                                 " COALESCE(SUM(CASE WHEN status='pending' THEN 1 ELSE 0 END),0),"
+                                 " COALESCE(SUM(CASE WHEN status='done' THEN 1 ELSE 0 END),0)"
+                                 " FROM kb_code_unit_jobs";
+   st = aimee_pg_prepare(conn, sql_code, err, sizeof(err));
+   if (st)
+   {
+      if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         out->code_unit_pending = (int)aimee_pg_column_int64(st, 0);
+         out->code_unit_done = (int)aimee_pg_column_int64(st, 1);
+      }
+      aimee_pg_finalize(st);
+   }
+}

--- a/src/kb/kb_curator_resolve_entities.c
+++ b/src/kb/kb_curator_resolve_entities.c
@@ -17,7 +17,8 @@
 
 #include "kb_curator_resolve_entities.h"
 #include "kb_curator_judge.h"
-#include "kb_curator_promote.h" /* kb_curator_broaden_scope (scope lattice) */
+#include "kb_curator_provider.h" /* kb_curator_provider_for_stage (judge availability) */
+#include "kb_curator_promote.h"  /* kb_curator_broaden_scope (scope lattice) */
 #include "aimee.h"
 #include "config.h"
 #include "cJSON.h"
@@ -97,7 +98,13 @@ static int resolve_try_match(const char *scope_kind, const char *scope_id, const
                 name, scope_kind, scope_id, match_scores[0]);
       return 1;
    }
-   if (match_scores[0] >= CURATOR_ENTITY_JUDGE_LOW && cfg->kb_curator_judge_command[0])
+   /* Judge the ambiguous band when there's somewhere to send it: a configured
+    * Tier-B provider (§2) or the legacy judge sidecar command. The score check is
+    * first so the provider lookup runs only for an actual ambiguous-band match. */
+   provider_def_t judge_provider;
+   if (match_scores[0] >= CURATOR_ENTITY_JUDGE_LOW &&
+       (cfg->kb_curator_judge_command[0] ||
+        kb_curator_provider_for_stage(cfg, KB_CURATOR_STAGE_JUDGE, &judge_provider)))
    {
       char cand_name[256];
       if (pgvec_curator_entity_lookup(match_ids[0], NULL, 0, cand_name, sizeof(cand_name)) == 1)
@@ -105,8 +112,8 @@ static int resolve_try_match(const char *scope_kind, const char *scope_id, const
          int same = 0;
          char jerr[256];
          int jrc =
-             kb_curator_judge_same_entity(cfg->kb_curator_judge_command, name, context, cand_name,
-                                          match_scores[0], &same, jerr, sizeof(jerr));
+             kb_curator_judge_same_entity(cfg, cfg->kb_curator_judge_command, name, context,
+                                          cand_name, match_scores[0], &same, jerr, sizeof(jerr));
          if (jrc == 0 && same)
          {
             aimee_log(LOG_INFO, "kb.curator.resolve",

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -6,6 +6,7 @@
 #include "cJSON.h"
 #include "config.h"
 #include "kb_curator_queue.h"
+#include "kb_curator_provider.h"
 #include "json_fluent.h"
 #include "db2/canonical_index.h"
 #include "db2/kb_maintenance.h"
@@ -222,6 +223,42 @@ char *kb_service_ingest_status_json(void)
    return json;
 }
 
+/* Add a per-tier provider sub-object {configured, base_url, model} (no api_key). */
+static void kb_health_add_curator_tier(cJSON *curator, const char *key, const config_t *cfg,
+                                       kb_curator_stage_t stage)
+{
+   cJSON *t = cJSON_AddObjectToObject(curator, key);
+   if (!t)
+      return;
+   provider_def_t def;
+   int configured = kb_curator_provider_for_stage(cfg, stage, &def);
+   cJSON_AddBoolToObject(t, "configured", configured);
+   cJSON_AddStringToObject(t, "base_url", configured && def.base_url ? def.base_url : "");
+   cJSON_AddStringToObject(t, "model", configured && def.model ? def.model : "");
+}
+
+/* Curator observability block for /v1/health (§4): which tiers have a provider
+ * (Tier-A extract/index, Tier-B reason/judge) and the curator queue depth. */
+static void kb_health_add_curator(cJSON *resp, const config_t *cfg)
+{
+   cJSON *curator = cJSON_AddObjectToObject(resp, "curator");
+   if (!curator)
+      return;
+   kb_health_add_curator_tier(curator, "tier_a", cfg, KB_CURATOR_STAGE_EXTRACT_DOCS);
+   kb_health_add_curator_tier(curator, "tier_b", cfg, KB_CURATOR_STAGE_JUDGE);
+
+   kb_curator_queue_counts_t qc;
+   kb_curator_queue_counts(&qc);
+   cJSON *q = cJSON_AddObjectToObject(curator, "queue");
+   if (q)
+   {
+      cJSON_AddNumberToObject(q, "extract_pending", qc.extract_pending);
+      cJSON_AddNumberToObject(q, "extract_done", qc.extract_done);
+      cJSON_AddNumberToObject(q, "code_unit_pending", qc.code_unit_pending);
+      cJSON_AddNumberToObject(q, "code_unit_done", qc.code_unit_done);
+   }
+}
+
 static cJSON *kb_service_health_object(void)
 {
    cJSON *resp = cJSON_CreateObject();
@@ -270,6 +307,13 @@ static cJSON *kb_service_health_object(void)
    cJSON_AddBoolToObject(resp, "embed_ok", embed_ok);
    cJSON_AddStringToObject(resp, "embed_command",
                            cfg.embedding_command[0] ? cfg.embedding_command : "builtin");
+
+   /* Curator (§4 observability): per-tier provider config + queue depth. The
+    * live four-state reachability probe (ready/loading/gated/down) is deferred to
+    * a follow-up — it needs a bounded async probe so the health path never blocks,
+    * and the gated state needs a custom curator /health (the bundled official
+    * llama.cpp doesn't expose it). api_key is never surfaced. */
+   kb_health_add_curator(resp, &cfg);
 
    /* Freshness: read last_ingest_at from kb_runtime_state */
    char last_ingest_at[64] = "";

--- a/src/kb_curator_queue.h
+++ b/src/kb_curator_queue.h
@@ -15,4 +15,16 @@ int kb_curator_queue_code_unit(const char *project, const char *file_path, const
 /* Bulk-enqueue extract_code_unit jobs for indexed terms in a project. */
 int kb_curator_queue_code_units_for_project(const char *project, const char *root_path);
 
+/* Curator queue depth, for the /v1/health curator block (§4 observability). */
+typedef struct
+{
+   int extract_pending; /* kb_async_jobs kind='extract_doc' status='pending' */
+   int extract_done;    /* kb_async_jobs kind='extract_doc' status='done' */
+   int code_unit_pending;
+   int code_unit_done;
+} kb_curator_queue_counts_t;
+
+/* Fill *out with current curator queue depths (zeroed on any error / no DB). */
+void kb_curator_queue_counts(kb_curator_queue_counts_t *out);
+
 #endif /* DEC_KB_CURATOR_QUEUE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1775,6 +1775,7 @@ $(TESTPREFIX)/unit-test-curator-code-unit: \
 $(TESTPREFIX)/unit-test-curator-resolve-entities: \
                                        $(OBJDIR)/tests/test_curator_resolve_entities.o \
                                        $(OBJDIR)/kb/kb_curator_resolve_entities.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
                                        $(OBJDIR)/db2/artifacts.o \
                                        $(OBJDIR)/db2/feature_rows.o \
                                        $(OBJDIR)/kb/kb_mdl.o \
@@ -1835,6 +1836,7 @@ $(TESTPREFIX)/unit-test-curator-index-code-unit: \
 $(TESTPREFIX)/unit-test-curator-pipeline: \
                                        $(OBJDIR)/tests/test_curator_pipeline.o \
                                        $(OBJDIR)/kb/kb_curator_resolve_entities.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
                                        $(OBJDIR)/kb/kb_curator_index_code_unit.o \
                                        $(OBJDIR)/kb/kb_curator_link_artifacts.o \
                                        $(OBJDIR)/kb/kb_curator_serve.o \
@@ -1874,6 +1876,10 @@ $(TESTPREFIX)/unit-test-curator-judge: \
                                        $(OBJDIR)/tests/test_curator_judge.o \
                                        $(OBJDIR)/kb/kb_curator_judge.o \
                                        $(OBJDIR)/kb/kb_curator_sidecar.o \
+                                       $(OBJDIR)/kb/kb_curator_llm.o \
+                                       $(OBJDIR)/kb_curator_provider.o \
+                                       $(OBJDIR)/provider_client.o \
+                                       $(OBJDIR)/tests/support/mock_agent_http.o \
                                        $(OBJDIR)/cJSON.o \
                                        $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -298,6 +298,57 @@ static void test_extract_accepts_pure_function(void)
    printf("  PASS: test_extract_accepts_pure_function\n");
 }
 
+/* The curator drain runs server-side, where thin-client-ingested files do not
+ * exist on disk. The body must come from DB2's file_contents (pushed at ingest),
+ * not an open() of the project-relative path. Seed file_contents but NO disk file
+ * and a non-existent project root: extraction must still succeed, proving the
+ * body was read from DB2. (Regression for ~36k curator jobs failing with
+ * "cannot read body".) */
+static void test_extract_reads_body_from_db2_when_file_absent(void)
+{
+   db2_test_shim_open();
+   sqlite3 *db = (sqlite3 *)db2_test_shim_handle();
+   assert(db != NULL);
+
+   const char *src_body = "int target_fn(void) { return 0; }\n";
+   char resp_path[] = "/tmp/aimee_ccu_resp_XXXXXX";
+   int resp_fd = mkstemp(resp_path);
+   assert(resp_fd >= 0);
+   const char *resp =
+       "{\"status\":\"ok\",\"artifacts\":[{\"kind\":\"code_unit\",\"confidence\":0.9,"
+       "\"payload\":{\"intent\":\"t\",\"side_effects\":[],\"invariants\":[],"
+       "\"domain_concepts\":[\"x\"]}}]}";
+   assert(write(resp_fd, resp, strlen(resp)) == (ssize_t)strlen(resp));
+   close(resp_fd);
+
+   /* Project root that does not exist on disk + a project-relative path with no
+    * on-disk file — only DB2 file_contents has the body. */
+   const char *sql =
+       "INSERT INTO projects (id, name, root, scanned_at)"
+       " VALUES (1,'testproj','/nonexistent-root-xyzzy','t');"
+       "INSERT INTO files (id, project_id, path, scanned_at) VALUES (1,1,'src/foo.c','t');"
+       "INSERT INTO file_contents (file_id, content)"
+       " VALUES (1,'int target_fn(void) { return 0; }\n');"
+       "INSERT INTO kb_code_unit_jobs (project, file_path, symbol, kind, line)"
+       " VALUES ('testproj','src/foo.c','target_fn','function',1);";
+   assert(sqlite3_exec(db, sql, NULL, NULL, NULL) == SQLITE_OK);
+   (void)src_body;
+
+   kb_curator_extract_opts_t opts;
+   memset(&opts, 0, sizeof(opts));
+   opts.max_attempts = 3;
+   opts.max_tokens = 256;
+   snprintf(opts.extract_command, sizeof(opts.extract_command), "cat %s", resp_path);
+
+   int rc = kb_curator_extract_code_unit_one(&opts);
+   assert(rc == 1); /* claimed + processed (body came from DB2, not disk) */
+   assert(db2_artifact_count("code_unit", "proposed") == 1);
+
+   db2_test_shim_close();
+   unlink(resp_path);
+   printf("  PASS: test_extract_reads_body_from_db2_when_file_absent\n");
+}
+
 /* ── main ─────────────────────────────────────────────────────────────── */
 
 int main(void)
@@ -318,6 +369,7 @@ int main(void)
    test_extract_rejects_false_no_side_effects();
    test_extract_accepts_honest_claim();
    test_extract_accepts_pure_function();
+   test_extract_reads_body_from_db2_when_file_absent();
 
    printf("ok\n");
    return 0;

--- a/src/tests/test_curator_judge.c
+++ b/src/tests/test_curator_judge.c
@@ -13,8 +13,8 @@ static void test_no_command(void)
    /* Empty command -> error, *out_same untouched. */
    int same = 42;
    char err[256];
-   int rc =
-       kb_curator_judge_same_entity("", "Acme", "ctx", "Acme Corp", 0.78, &same, err, sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "", "Acme", "ctx", "Acme Corp", 0.78, &same, err,
+                                         sizeof(err));
    assert(rc == -1);
    assert(same == 42); /* left untouched */
    printf("  no-command -> error OK\n");
@@ -25,8 +25,8 @@ static void test_same_true(void)
    int same = -1;
    char err[256];
    /* The sidecar ignores stdin and emits the canonical affirmative response. */
-   int rc = kb_curator_judge_same_entity("printf '{\"same_entity\": true}'", "Acme", "the vendor",
-                                         "Acme Corp", 0.80, &same, err, sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "printf '{\"same_entity\": true}'", "Acme",
+                                         "the vendor", "Acme Corp", 0.80, &same, err, sizeof(err));
    assert(rc == 0);
    assert(same == 1);
    printf("  same_entity=true parsed OK\n");
@@ -36,8 +36,8 @@ static void test_same_false(void)
 {
    int same = -1;
    char err[256];
-   int rc = kb_curator_judge_same_entity("printf '{\"same_entity\": false}'", "Apple", "the fruit",
-                                         "Apple Inc", 0.72, &same, err, sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "printf '{\"same_entity\": false}'", "Apple",
+                                         "the fruit", "Apple Inc", 0.72, &same, err, sizeof(err));
    assert(rc == 0);
    assert(same == 0);
    printf("  same_entity=false parsed OK\n");
@@ -49,8 +49,8 @@ static void test_prose_wrapped(void)
    int same = -1;
    char err[256];
    int rc = kb_curator_judge_same_entity(
-       "printf 'Sure! Here is my verdict:\\n{\"same_entity\": true}\\n'", "K8s", "orchestrator",
-       "Kubernetes", 0.83, &same, err, sizeof(err));
+       NULL, "printf 'Sure! Here is my verdict:\\n{\"same_entity\": true}\\n'", "K8s",
+       "orchestrator", "Kubernetes", 0.83, &same, err, sizeof(err));
    assert(rc == 0);
    assert(same == 1);
    printf("  prose-wrapped JSON parsed OK\n");
@@ -60,8 +60,8 @@ static void test_garbage_output(void)
 {
    int same = 7;
    char err[256];
-   int rc = kb_curator_judge_same_entity("echo not-json-at-all", "x", "", "y", 0.75, &same, err,
-                                         sizeof(err));
+   int rc = kb_curator_judge_same_entity(NULL, "echo not-json-at-all", "x", "", "y", 0.75, &same,
+                                         err, sizeof(err));
    assert(rc == -1);
    assert(same == 7);
    printf("  garbage output -> error OK\n");
@@ -71,7 +71,8 @@ static void test_nonzero_exit(void)
 {
    int same = 9;
    char err[256];
-   int rc = kb_curator_judge_same_entity("false", "x", "", "y", 0.75, &same, err, sizeof(err));
+   int rc =
+       kb_curator_judge_same_entity(NULL, "false", "x", "", "y", 0.75, &same, err, sizeof(err));
    assert(rc == -1);
    assert(same == 9);
    printf("  non-zero exit -> error OK\n");

--- a/src/tests/test_curator_resolve_entities.c
+++ b/src/tests/test_curator_resolve_entities.c
@@ -96,10 +96,12 @@ int pgvec_curator_entity_lookup(int64_t point_id, char *artifact_id_out, int aid
       name_out[0] = '\0';
    return 0;
 }
-int kb_curator_judge_same_entity(const char *judge_cmd, const char *mention_name,
-                                 const char *mention_context, const char *candidate_name,
-                                 double score, int *out_same, char *errbuf, size_t errlen)
+int kb_curator_judge_same_entity(const config_t *cfg, const char *judge_cmd,
+                                 const char *mention_name, const char *mention_context,
+                                 const char *candidate_name, double score, int *out_same,
+                                 char *errbuf, size_t errlen)
 {
+   (void)cfg;
    (void)judge_cmd;
    (void)mention_name;
    (void)mention_context;


### PR DESCRIPTION
Promote testing → main. #427: the deep-curator code-unit extractor read source from the thin-client disk path (projects.root = client path, absent server-side) so all ~36k jobs failed at 'cannot read body'. Now reads the body from DB2 file_contents (where ingest stores it), disk fallback for local deploys. Unit-tested, CI green.