### PR TITLE
fix(curator): release DB2 pool lease across the slow extract sidecar call

### DIFF
--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -609,6 +609,15 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
    aimee_log(LOG_INFO, "kb.curator.extract_code", "invoking sidecar for symbol '%s' (job %lld): %s",
              job.symbol, (long long)job.job_id, cmd);
 
+   /* Return our pool connection before the slow sidecar/LLM call — extraction on
+    * a CPU model runs seconds to minutes, and holding a lease across it trips the
+    * pool's stuck-lease ceiling (300s) and permanently shrinks the pool. All
+    * remaining DB work (grounding, artifact write, mark_done) re-acquires lazily
+    * via db2_conn() after the call returns. Safe: we are at lease depth 0 (the
+    * drain uses db2_lease_release_idle, not an explicit begin/end scope), and the
+    * body was already read from DB2 above. */
+   db2_lease_release_idle();
+
    char sidecar_err[512] = "";
    char *resp_str = ccu_invoke_sidecar(cmd, req_str, sidecar_err, sizeof(sidecar_err));
    free(req_str);


### PR DESCRIPTION
## Problem
The code-unit drain held its pooled DB2 connection for the whole job — including the extract sidecar/LLM call (seconds-to-minutes on CPU Gemma 3n E4B). A single long extraction pinned the connection past the pool's **300s stuck-lease ceiling**, so the reaper logged `member N leased >300000ms — missed lease_end?` repeatedly (observed live on .254, climbing 389s→509s) and the pool permanently shrank under sustained backfill.

## Fix
Call `db2_lease_release_idle()` right before invoking the sidecar — the body's already read from DB2, and all remaining DB work (grounding, artifact write, mark_done) re-acquires lazily after the call. The drain runs at lease depth 0 (it uses `db2_lease_release_idle` between cycles, not an explicit begin/end scope), so the release is valid. Same idle-release the drain loop already does between cycles, now also applied across the in-job LLM call where the long hold actually happens.

## Tests
`unit-test-curator-code-unit` (12/12) still passes — the extract path works with the mid-job release. clang-format-19 clean.

Follow-up to #427 (which fixed the body-read), found while watching the .254 backfill drain.