### PR TITLE
fix(delegate): reasoning-aware per-call timeout default; minimax default model M3

### DIFF
--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -19,6 +19,14 @@ struct cJSON;
 #define MAX_CRED_ENV_VAR_LEN     64
 #define MAX_FALLBACK             8
 #define AGENT_DEFAULT_TIMEOUT_MS 180000
+/* Default per-call timeout for a REASONING model when the operator pins none.
+ * Reasoning models (e.g. MiniMax-M3) emit a large hidden reasoning trace before
+ * the visible answer, so a single completion routinely runs several minutes —
+ * past the 3-minute standard default, which then fails as a spurious
+ * "read_response failed" (HTTP -1) and burns the retry budget. A non-reasoning
+ * model keeps the standard default; an explicit agents.json/--timeout value
+ * always wins over either. */
+#define AGENT_REASONING_TIMEOUT_MS 600000
 /* Floor for the per-call HTTP timeout inside the multi-turn tool loop. Once the
  * remaining loop budget drops below this, the loop stops cleanly instead of
  * issuing a doomed short-timeout call that the provider-health tracker would

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -603,7 +603,23 @@ int agent_load_config(agent_config_t *cfg)
          ag->max_tokens = (v && cJSON_IsNumber(v)) ? v->valueint : AGENT_DEFAULT_MAX_TOKENS;
 
          v = cJSON_GetObjectItem(a, "timeout_ms");
-         ag->timeout_ms = (v && cJSON_IsNumber(v)) ? v->valueint : AGENT_DEFAULT_TIMEOUT_MS;
+         if (v && cJSON_IsNumber(v))
+         {
+            ag->timeout_ms = v->valueint; /* operator's explicit value wins */
+         }
+         else
+         {
+            /* No operator timeout: give a reasoning-capable model a higher per-call
+             * default so its slow (multi-minute) completions aren't cut off and
+             * retried as spurious read failures. Capability lookup is total +
+             * offline (same guarantees as the tools_enabled derivation below);
+             * an unknown/non-reasoning model keeps the standard default. */
+            model_capability_t tmc;
+            int reasoning = ag->model[0] &&
+                            model_capability_get(ag->provider, ag->model, &tmc) &&
+                            (tmc.flags & MODEL_CAP_REASONING);
+            ag->timeout_ms = reasoning ? AGENT_REASONING_TIMEOUT_MS : AGENT_DEFAULT_TIMEOUT_MS;
+         }
 
          v = cJSON_GetObjectItem(a, "enabled");
          ag->enabled = (!v || !cJSON_IsBool(v)) ? 1 : cJSON_IsTrue(v);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -615,8 +615,7 @@ int agent_load_config(agent_config_t *cfg)
              * offline (same guarantees as the tools_enabled derivation below);
              * an unknown/non-reasoning model keeps the standard default. */
             model_capability_t tmc;
-            int reasoning = ag->model[0] &&
-                            model_capability_get(ag->provider, ag->model, &tmc) &&
+            int reasoning = ag->model[0] && model_capability_get(ag->provider, ag->model, &tmc) &&
                             (tmc.flags & MODEL_CAP_REASONING);
             ag->timeout_ms = reasoning ? AGENT_REASONING_TIMEOUT_MS : AGENT_DEFAULT_TIMEOUT_MS;
          }

--- a/src/server/minimax_profile.c
+++ b/src/server/minimax_profile.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 static const char *minimax_env_vars[] = {"MINIMAX_API_KEY", NULL};
+/* M2.7 is kept as the fallback model behind the M3 default. */
 static const char *minimax_fallback_models[] = {"MiniMax-M2.7", NULL};
 
 static int minimax_fetch_models(model_provider_t *p, char ***models_out, int *n_out)
@@ -73,15 +74,15 @@ static int minimax_fetch_models(model_provider_t *p, char ***models_out, int *n_
 model_provider_t minimax_provider = {
     .name = "minimax",
     .display_name = "MiniMax",
-    .description = "MiniMax API (MiniMax-M2.7)",
+    .description = "MiniMax API (MiniMax-M3)",
     .base_url = "https://api.minimax.io/v1",
     .models_url = "https://api.minimax.io/v1/models",
     .signup_url = "https://platform.minimax.io",
     .auth_type = "api_key",
     .env_vars = minimax_env_vars,
     .api_mode = API_MODE_CHAT_COMPLETIONS,
-    .default_model = "MiniMax-M2.7",
-    .default_aux_model = "MiniMax-M2.7",
+    .default_model = "MiniMax-M3",
+    .default_aux_model = "MiniMax-M3",
     .fallback_models = minimax_fallback_models,
     .fixed_temperature = -1,
     .default_max_tokens = 8192,

--- a/src/tests/test_agent_apikey.c
+++ b/src/tests/test_agent_apikey.c
@@ -234,6 +234,41 @@ static void test_claude_cli_predicate(void)
    assert(agent_is_claude_cli(&a) == 0);
 }
 
+/* A reasoning model with no operator timeout gets the higher reasoning default;
+ * a non-reasoning model keeps the standard default; an explicit value always wins. */
+static void test_reasoning_timeout_default(void)
+{
+   const char *cfg_dir = config_default_dir();
+   assert(platform_mkdir_p(cfg_dir, 0700) == 0 || access(cfg_dir, F_OK) == 0);
+   {
+      FILE *f = fopen(agent_config_path(), "w");
+      assert(f != NULL);
+      fputs("{\"agents\":["
+            /* minimax => MODEL_CAP_REASONING; no timeout_ms => reasoning default */
+            "{\"name\":\"rsn\",\"provider\":\"minimax\",\"model\":\"MiniMax-M3\","
+            "\"endpoint\":\"https://api.minimax.io/v1/chat/completions\",\"roles\":[\"review\"]},"
+            /* mistral => not reasoning; no timeout_ms => standard default */
+            "{\"name\":\"plain\",\"provider\":\"mistral\",\"model\":\"mistral-medium-latest\","
+            "\"endpoint\":\"https://api.mistral.ai/v1/chat/completions\",\"roles\":[\"review\"]},"
+            /* explicit timeout always wins, even for a reasoning model */
+            "{\"name\":\"pinned\",\"provider\":\"minimax\",\"model\":\"MiniMax-M3\","
+            "\"endpoint\":\"https://api.minimax.io/v1/chat/completions\",\"timeout_ms\":5000,"
+            "\"roles\":[\"review\"]}]}\n",
+            f);
+      fclose(f);
+   }
+   agent_config_t cfg;
+   assert(agent_load_config(&cfg) == 0);
+   agent_t *rsn = agent_find(&cfg, "rsn");
+   agent_t *plain = agent_find(&cfg, "plain");
+   agent_t *pinned = agent_find(&cfg, "pinned");
+   assert(rsn && plain && pinned);
+   assert(rsn->timeout_ms == AGENT_REASONING_TIMEOUT_MS);
+   assert(plain->timeout_ms == AGENT_DEFAULT_TIMEOUT_MS);
+   assert(pinned->timeout_ms == 5000);
+   printf("  PASS: test_reasoning_timeout_default\n");
+}
+
 int main(void)
 {
    char tmp_template[] = "/tmp/aimee-agent-apikey-XXXXXX";
@@ -247,6 +282,7 @@ int main(void)
 
    test_agent_route_health_filter();
    test_agent_loop_per_call_timeout();
+   test_reasoning_timeout_default();
    test_claude_cli_predicate();
    printf("agent_apikey: all tests passed\n");
    return 0;


### PR DESCRIPTION
Two related fixes so **slow reasoning-model delegates aren't truncated/retried into a false hang**. Surfaced while running roundtables via MiniMax-M3.

## Root cause
MiniMax-M3 is a reasoning model: it emits a large hidden reasoning trace before the visible answer, so one completion routinely runs **several minutes**. The default per-call timeout `AGENT_DEFAULT_TIMEOUT_MS = 180000` (3 min) is too short → the HTTP read deadline fires → `agent_http: read_response failed` (HTTP -1) → wasted retries (~3 min each) → the delegate looks hung and the monitor auto-cancels it.

## Fixes
1. **Reasoning-aware timeout default** (`agent_config.c`, `agent_types.h`). When the operator pins no `timeout_ms`, a model flagged `MODEL_CAP_REASONING` now gets `AGENT_REASONING_TIMEOUT_MS = 600000` (10 min); non-reasoning models keep 180s; an explicit `agents.json`/`--timeout` value always wins. The capability lookup is the same **total, offline** `model_capability_get` the `tools_enabled` default already uses (unknown models fail safe to the standard default).
2. **Bump minimax default model** `MiniMax-M2.7 → MiniMax-M3` (`minimax_profile.c`) — M3 is the current flagship (the API `/v1/models` list leads with it). M2.7 kept as the fallback.

## Not a token cap
Worth stating explicitly: token sizing was already correct — `AGENT_DEFAULT_MAX_TOKENS = 0`, so the request layer derives the ceiling from `model_max_output` (32768 for reasoning models), not a hardcoded default. The truncation that kicked this off was a caller passing a small `--max-tokens`, not an aimee default.

## Test
`test_reasoning_timeout_default`: a minimax (reasoning) agent with no `timeout_ms` → 600s; a mistral (non-reasoning) agent → 180s; an explicit `timeout_ms` → honored. Server builds clean under `-Werror`; the agent-apikey unit suite passes.