### PR TITLE
Promote testing → main: curator releases DB2 lease across LLM call (#429)

### DIFF
--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -19,6 +19,14 @@ struct cJSON;
 #define MAX_CRED_ENV_VAR_LEN     64
 #define MAX_FALLBACK             8
 #define AGENT_DEFAULT_TIMEOUT_MS 180000
+/* Default per-call timeout for a REASONING model when the operator pins none.
+ * Reasoning models (e.g. MiniMax-M3) emit a large hidden reasoning trace before
+ * the visible answer, so a single completion routinely runs several minutes —
+ * past the 3-minute standard default, which then fails as a spurious
+ * "read_response failed" (HTTP -1) and burns the retry budget. A non-reasoning
+ * model keeps the standard default; an explicit agents.json/--timeout value
+ * always wins over either. */
+#define AGENT_REASONING_TIMEOUT_MS 600000
 /* Floor for the per-call HTTP timeout inside the multi-turn tool loop. Once the
  * remaining loop budget drops below this, the loop stops cleanly instead of
  * issuing a doomed short-timeout call that the provider-health tracker would

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -609,6 +609,15 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
    aimee_log(LOG_INFO, "kb.curator.extract_code", "invoking sidecar for symbol '%s' (job %lld): %s",
              job.symbol, (long long)job.job_id, cmd);
 
+   /* Return our pool connection before the slow sidecar/LLM call — extraction on
+    * a CPU model runs seconds to minutes, and holding a lease across it trips the
+    * pool's stuck-lease ceiling (300s) and permanently shrinks the pool. All
+    * remaining DB work (grounding, artifact write, mark_done) re-acquires lazily
+    * via db2_conn() after the call returns. Safe: we are at lease depth 0 (the
+    * drain uses db2_lease_release_idle, not an explicit begin/end scope), and the
+    * body was already read from DB2 above. */
+   db2_lease_release_idle();
+
    char sidecar_err[512] = "";
    char *resp_str = ccu_invoke_sidecar(cmd, req_str, sidecar_err, sizeof(sidecar_err));
    free(req_str);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -603,7 +603,22 @@ int agent_load_config(agent_config_t *cfg)
          ag->max_tokens = (v && cJSON_IsNumber(v)) ? v->valueint : AGENT_DEFAULT_MAX_TOKENS;
 
          v = cJSON_GetObjectItem(a, "timeout_ms");
-         ag->timeout_ms = (v && cJSON_IsNumber(v)) ? v->valueint : AGENT_DEFAULT_TIMEOUT_MS;
+         if (v && cJSON_IsNumber(v))
+         {
+            ag->timeout_ms = v->valueint; /* operator's explicit value wins */
+         }
+         else
+         {
+            /* No operator timeout: give a reasoning-capable model a higher per-call
+             * default so its slow (multi-minute) completions aren't cut off and
+             * retried as spurious read failures. Capability lookup is total +
+             * offline (same guarantees as the tools_enabled derivation below);
+             * an unknown/non-reasoning model keeps the standard default. */
+            model_capability_t tmc;
+            int reasoning = ag->model[0] && model_capability_get(ag->provider, ag->model, &tmc) &&
+                            (tmc.flags & MODEL_CAP_REASONING);
+            ag->timeout_ms = reasoning ? AGENT_REASONING_TIMEOUT_MS : AGENT_DEFAULT_TIMEOUT_MS;
+         }
 
          v = cJSON_GetObjectItem(a, "enabled");
          ag->enabled = (!v || !cJSON_IsBool(v)) ? 1 : cJSON_IsTrue(v);

--- a/src/server/minimax_profile.c
+++ b/src/server/minimax_profile.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 
 static const char *minimax_env_vars[] = {"MINIMAX_API_KEY", NULL};
+/* M2.7 is kept as the fallback model behind the M3 default. */
 static const char *minimax_fallback_models[] = {"MiniMax-M2.7", NULL};
 
 static int minimax_fetch_models(model_provider_t *p, char ***models_out, int *n_out)
@@ -73,15 +74,15 @@ static int minimax_fetch_models(model_provider_t *p, char ***models_out, int *n_
 model_provider_t minimax_provider = {
     .name = "minimax",
     .display_name = "MiniMax",
-    .description = "MiniMax API (MiniMax-M2.7)",
+    .description = "MiniMax API (MiniMax-M3)",
     .base_url = "https://api.minimax.io/v1",
     .models_url = "https://api.minimax.io/v1/models",
     .signup_url = "https://platform.minimax.io",
     .auth_type = "api_key",
     .env_vars = minimax_env_vars,
     .api_mode = API_MODE_CHAT_COMPLETIONS,
-    .default_model = "MiniMax-M2.7",
-    .default_aux_model = "MiniMax-M2.7",
+    .default_model = "MiniMax-M3",
+    .default_aux_model = "MiniMax-M3",
     .fallback_models = minimax_fallback_models,
     .fixed_temperature = -1,
     .default_max_tokens = 8192,

--- a/src/tests/test_agent_apikey.c
+++ b/src/tests/test_agent_apikey.c
@@ -234,6 +234,41 @@ static void test_claude_cli_predicate(void)
    assert(agent_is_claude_cli(&a) == 0);
 }
 
+/* A reasoning model with no operator timeout gets the higher reasoning default;
+ * a non-reasoning model keeps the standard default; an explicit value always wins. */
+static void test_reasoning_timeout_default(void)
+{
+   const char *cfg_dir = config_default_dir();
+   assert(platform_mkdir_p(cfg_dir, 0700) == 0 || access(cfg_dir, F_OK) == 0);
+   {
+      FILE *f = fopen(agent_config_path(), "w");
+      assert(f != NULL);
+      fputs("{\"agents\":["
+            /* minimax => MODEL_CAP_REASONING; no timeout_ms => reasoning default */
+            "{\"name\":\"rsn\",\"provider\":\"minimax\",\"model\":\"MiniMax-M3\","
+            "\"endpoint\":\"https://api.minimax.io/v1/chat/completions\",\"roles\":[\"review\"]},"
+            /* mistral => not reasoning; no timeout_ms => standard default */
+            "{\"name\":\"plain\",\"provider\":\"mistral\",\"model\":\"mistral-medium-latest\","
+            "\"endpoint\":\"https://api.mistral.ai/v1/chat/completions\",\"roles\":[\"review\"]},"
+            /* explicit timeout always wins, even for a reasoning model */
+            "{\"name\":\"pinned\",\"provider\":\"minimax\",\"model\":\"MiniMax-M3\","
+            "\"endpoint\":\"https://api.minimax.io/v1/chat/completions\",\"timeout_ms\":5000,"
+            "\"roles\":[\"review\"]}]}\n",
+            f);
+      fclose(f);
+   }
+   agent_config_t cfg;
+   assert(agent_load_config(&cfg) == 0);
+   agent_t *rsn = agent_find(&cfg, "rsn");
+   agent_t *plain = agent_find(&cfg, "plain");
+   agent_t *pinned = agent_find(&cfg, "pinned");
+   assert(rsn && plain && pinned);
+   assert(rsn->timeout_ms == AGENT_REASONING_TIMEOUT_MS);
+   assert(plain->timeout_ms == AGENT_DEFAULT_TIMEOUT_MS);
+   assert(pinned->timeout_ms == 5000);
+   printf("  PASS: test_reasoning_timeout_default\n");
+}
+
 int main(void)
 {
    char tmp_template[] = "/tmp/aimee-agent-apikey-XXXXXX";
@@ -247,6 +282,7 @@ int main(void)
 
    test_agent_route_health_filter();
    test_agent_loop_per_call_timeout();
+   test_reasoning_timeout_default();
    test_claude_cli_predicate();
    printf("agent_apikey: all tests passed\n");
    return 0;


### PR DESCRIPTION
Promote testing → main. #429: the curator code-unit drain held its DB2 pool connection across the slow extract sidecar/LLM call (seconds-minutes on CPU Gemma), tripping the 300s stuck-lease ceiling and shrinking the pool. Now releases via db2_lease_release_idle() before the sidecar; re-acquires lazily after. Unit-tested, CI green.