### PR TITLE
feat(cli): /v1/kb/curator route for kb curator status + drop the RPC misnomer

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -815,6 +815,25 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /kb/curator:
+    get:
+      summary: Curator LLM provider + queue status (proxied to aimee-kb)
+      responses:
+        "200":
+          description: Curator observability block (tier_a/tier_b providers + queue depth)
+          content:
+            application/json:
+              schema: { type: object }
+        "502":
+          description: Knowledge backend (aimee-kb) unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "503":
+          description: Curator status not available on this server
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /memory/recall:
     post:
       summary: Recall relevant memories (proxied to aimee-kb)

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -526,8 +526,7 @@ static int unsupported_client_command(const char *cmd, int json_output)
 {
    const char *name = (cmd && cmd[0]) ? cmd : "launch";
    char msg[256];
-   snprintf(msg, sizeof(msg), "command '%s' has no typed server RPC route; add a server RPC route",
-            name);
+   snprintf(msg, sizeof(msg), "command '%s' has no /v1 route; add a /v1 route", name);
 
    if (json_output)
    {
@@ -832,14 +831,14 @@ static int handle_hooks(int argc, char **argv, int json_output)
  * subprocess that was spawned by chat_stream_worker.  In that context a
  * failure must not block claude: send "nonblocking": true so the server runs
  * session_start_emit on a background thread and responds immediately, and
- * treat any error (server unavailable, connection failure, RPC timeout) as a
+ * treat any error (server unavailable, connection failure, request timeout) as a
  * soft failure (exit 0) so claude is never aborted by the hook. */
 /* Minimal growing string buffer for assembling the session-start context
  * without depending on open_memstream's feature-test macros. */
 
 /* No-arg `aimee` launch path.
  *
- * Calls the launch.run RPC to mint a fresh session_id, materialize any
+ * Calls the launch.run /v1 call to mint a fresh session_id, materialize any
  * sibling worktrees, and resolve the provider/model/worktree_cwd. The
  * client then writes the session-ppid file (so MCP children spawned by
  * the agent can find their session), chdirs into the worktree, and
@@ -850,7 +849,7 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
    /* Interactive chat/launch runs the agent and its tools on THIS host and
     * chdirs into a server-resolved worktree on the local filesystem, so it needs
     * a co-located aimee-server over the local socket. A remote /v1 endpoint
-    * serves only the data/RPC plane (memory, kb, rules, index, sessions, …). */
+    * serves only the data/control plane (memory, kb, rules, index, sessions, …). */
    /* A remote aimee-server runs the agent + tools on the server; serve THIS
     * client's working tree over the reverse-channel so those tools act here (the
     * client never absorbs the engine or a DB). A co-located server uses the local
@@ -1453,7 +1452,7 @@ static int cli_claude_proxy(int argc, char **argv)
 int main(int argc, char **argv)
 {
    /* Ignore SIGPIPE so write() to a dead aimee-server socket returns EPIPE
-    * instead of terminating the CLI mid-RPC. cli_client retries via
+    * instead of terminating the CLI mid-request. cli_client retries via
     * cli_v1_forward; mcp-serve's reconnect loop reuses the same path.
     * Without this, a server restart between two CLI calls killed the
     * caller and (for mcp-serve) showed up to Claude as
@@ -1776,7 +1775,7 @@ int main(int argc, char **argv)
       return handle_agent_setup_cmd(sub_argc - 1, sub_argv + 1, json_output);
 
    /* workspace serve: a long-running client-side loop (poll -> run -> respond),
-    * not a single forwarded RPC, so it is driven here rather than via a route. */
+    * not a single forwarded /v1 call, so it is driven here rather than via a route. */
    if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "serve") == 0)
       return cmd_workspace_serve(sub_argc >= 2 ? sub_argv[1] : NULL);
 
@@ -1798,7 +1797,7 @@ int main(int argc, char **argv)
        * retired in P4b. */
    }
 
-   /* Route through native server RPCs when possible. */
+   /* Route through the server's native /v1 HTTP endpoints when possible. */
    {
       cli_v1_route_t route;
       if (cli_v1_lookup(cmd, sub_argc, sub_argv, &route))
@@ -1821,7 +1820,7 @@ int main(int argc, char **argv)
                                  sub_argv);
          if (rc >= 0)
             return rc;
-         fprintf(stderr, "aimee: server RPC request failed for '%s'\n", cmd);
+         fprintf(stderr, "aimee: server /v1 request failed for '%s'\n", cmd);
          return 1;
       }
    }

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -849,7 +849,7 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
    /* Interactive chat/launch runs the agent and its tools on THIS host and
     * chdirs into a server-resolved worktree on the local filesystem, so it needs
     * a co-located aimee-server over the local socket. A remote /v1 endpoint
-    * serves only the data/control plane (memory, kb, rules, index, sessions, …). */
+    * serves only the /v1 data plane (memory, kb, rules, index, sessions, …). */
    /* A remote aimee-server runs the agent + tools on the server; serve THIS
     * client's working tree over the reverse-channel so those tools act here (the
     * client never absorbs the engine or a DB). A co-located server uses the local

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -1,5 +1,5 @@
 /* ===================================================================
- * RPC thin-client routing: route CLI subcommands through native server RPCs.
+ * /v1 thin-client routing: route CLI subcommands through the server's native /v1 HTTP endpoints.
  * Unported commands fail in cli_main before reaching the server.
  * =================================================================== */
 
@@ -28,18 +28,18 @@ static void __attribute__((unused)) cli_v1_sleep_ms(int ms)
 
 /* --- Minimal arg parser (no util.h dependency) --- */
 
-#define RPC_MAX_POS   16
-#define RPC_MAX_FLAGS 32
+#define V1_MAX_POS   16
+#define V1_MAX_FLAGS 32
 
 typedef struct
 {
-   const char *positional[RPC_MAX_POS];
+   const char *positional[V1_MAX_POS];
    int pos_count;
    struct
    {
       const char *raw; /* flag name from argv (after --), may include =val */
       const char *value;
-   } flags[RPC_MAX_FLAGS];
+   } flags[V1_MAX_FLAGS];
    int flag_count;
 } rpc_opts_t;
 
@@ -64,7 +64,7 @@ static void rpc_parse(int argc, char **argv, const char **bool_flags, rpc_opts_t
          const char *eq = strchr(flag, '=');
          if (eq)
          {
-            if (out->flag_count < RPC_MAX_FLAGS)
+            if (out->flag_count < V1_MAX_FLAGS)
             {
                out->flags[out->flag_count].raw = flag;
                out->flags[out->flag_count].value = eq + 1;
@@ -73,7 +73,7 @@ static void rpc_parse(int argc, char **argv, const char **bool_flags, rpc_opts_t
          }
          else if (rpc_is_bool(flag, bool_flags))
          {
-            if (out->flag_count < RPC_MAX_FLAGS)
+            if (out->flag_count < V1_MAX_FLAGS)
             {
                out->flags[out->flag_count].raw = flag;
                out->flags[out->flag_count].value = "1";
@@ -82,7 +82,7 @@ static void rpc_parse(int argc, char **argv, const char **bool_flags, rpc_opts_t
          }
          else if (i + 1 < argc)
          {
-            if (out->flag_count < RPC_MAX_FLAGS)
+            if (out->flag_count < V1_MAX_FLAGS)
             {
                out->flags[out->flag_count].raw = flag;
                out->flags[out->flag_count].value = argv[i + 1];
@@ -93,7 +93,7 @@ static void rpc_parse(int argc, char **argv, const char **bool_flags, rpc_opts_t
       }
       else
       {
-         if (out->pos_count < RPC_MAX_POS)
+         if (out->pos_count < V1_MAX_POS)
             out->positional[out->pos_count++] = argv[i];
       }
    }
@@ -138,7 +138,7 @@ static int rpc_get_int(const rpc_opts_t *opts, const char *name, int def)
  * (defined below; forward-declared for the session marshalers above it). */
 static const char *resolve_session_env(const rpc_opts_t *opts);
 
-/* --- RPC route table --- */
+/* --- /v1 route table --- */
 
 static const struct
 {
@@ -216,6 +216,8 @@ static const struct
     {"kb", "ingest", "kb.ingest", NULL, NULL, 30000},
     {"kb", "ingest status", "kb.ingest.status", NULL, NULL, 0},
     {"kb", "status", "kb.status", NULL, NULL, 0},
+    {"kb", "curator status", "kb.curator", NULL, NULL, 0},
+    {"kb", "curator", "kb.curator", NULL, NULL, 0},
     {"kb", "calibrate", "calibration.readiness", NULL, NULL, 0},
     {"kb", "demote", "demotion.check", NULL, NULL, 0},
     {"workers", "", "workers", NULL, NULL, 0},
@@ -334,7 +336,7 @@ static const struct
     {"api", "", "api.status", NULL, NULL, 0},
     {"hud", "", "hud.status", NULL, NULL, 0},
     {"dogfood", "tag", "dogfood.tag", NULL, NULL, 0},
-    /* Month-scale dogfood logs can take longer than the default RPC timeout. */
+    /* Month-scale dogfood logs can take longer than the default request timeout. */
     {"dogfood", "review", "dogfood.review", NULL, NULL, 300000},
     {"dogfood", "report", "dogfood.report", NULL, NULL, 300000},
     {"eval", "run", "eval.run", NULL, NULL, 900000},
@@ -464,7 +466,7 @@ static cJSON *marshal_curator_topic(const char *method, int argc, char **argv)
    rpc_parse(argc, argv, NULL, &opts);
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    if (opts.pos_count > 0)
       cJSON_AddStringToObject(req, "topic", opts.positional[0]);
    return req;
@@ -663,7 +665,7 @@ static cJSON *marshal_index_file_request(const char *method, int argc, char **ar
 {
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    if (argc > 0)
       cJSON_AddStringToObject(req, "project", argv[0]);
    if (argc > 1)
@@ -711,7 +713,7 @@ static cJSON *marshal_session_id_request(const char *method, int argc, char **ar
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
 
    const char *sid = opts.pos_count > 0 ? opts.positional[0] : rpc_get(&opts, "session");
    if (sid && sid[0])
@@ -877,7 +879,7 @@ static cJSON *marshal_no_args(const char *method)
 {
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    return req;
 }
 
@@ -1025,7 +1027,7 @@ static cJSON *marshal_config_set(int argc, char **argv)
 
 /* `aimee primary <name>` sets, `--show` (or no arg) reads, `--clear` clears the
  * session's active primary agent. One route ("primary.set") dispatches here and
- * the real RPC method is chosen from the args. */
+ * the real /v1 method is chosen from the args. */
 static cJSON *marshal_primary(int argc, char **argv)
 {
    static const char *bools[] = {"show", "clear", NULL};
@@ -1033,7 +1035,7 @@ static cJSON *marshal_primary(int argc, char **argv)
    rpc_parse(argc, argv, bools, &opts);
 
    cJSON *req = cJSON_CreateObject();
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
 
    if (rpc_get(&opts, "clear"))
       cJSON_AddStringToObject(req, "method", "primary.clear");
@@ -1255,7 +1257,7 @@ static cJSON *marshal_work_request(const char *method, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
 
    const char *v;
    if (strcmp(method, "work.add") == 0)
@@ -2002,7 +2004,7 @@ static cJSON *marshal_job_id_request(const char *method, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
 
    const char *job_id = opts.pos_count > 0 ? opts.positional[0] : rpc_get(&opts, "job-id");
    if (job_id && job_id[0])
@@ -2089,7 +2091,7 @@ static cJSON *marshal_skill_request(const char *method, int argc, char **argv)
 {
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    char cwd[4096];
    if (getcwd(cwd, sizeof(cwd)))
       cJSON_AddStringToObject(req, "cwd", cwd);
@@ -2254,7 +2256,7 @@ static cJSON *marshal_trigger_id(const char *method, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    cJSON_AddStringToObject(req, "id", id);
    return req;
 }
@@ -2304,7 +2306,7 @@ static cJSON *marshal_cron_id(const char *method, int argc, char **argv)
       {
          cJSON *req = cJSON_CreateObject();
          cJSON_AddStringToObject(req, "method", method);
-         cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+         cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
          cJSON_AddBoolToObject(req, "all", 1);
          return req;
       }
@@ -2323,7 +2325,7 @@ static cJSON *marshal_cron_id(const char *method, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    cJSON_AddStringToObject(req, "job_id", id);
    if (strcmp(method, "cron.history") == 0)
       cJSON_AddNumberToObject(req, "limit", rpc_get_int(&opts, "limit", 20));
@@ -2395,7 +2397,7 @@ static cJSON *marshal_agent_args(const char *method, int argc, char **argv)
 {
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    cJSON *args = cJSON_CreateArray();
    for (int i = 0; i < argc; i++)
       cJSON_AddItemToArray(args, cJSON_CreateString(argv[i]));
@@ -2901,7 +2903,7 @@ static cJSON *marshal_api_enable(int argc, char **argv)
 
 /* graph sync-code <project> → graph.sync_code (server runs the code-graph
  * projection off-thread). Without this marshaler the route table entry existed
- * but the thin CLI reported "no typed server RPC route". */
+ * but the thin CLI reported "no /v1 route". */
 static cJSON *marshal_graph_sync_code(int argc, char **argv)
 {
    rpc_opts_t opts;
@@ -2933,7 +2935,7 @@ static cJSON *marshal_pipeline_request(const char *method, int argc, char **argv
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", method);
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    const char *v;
 
    if (strcmp(method, "pipeline.start") == 0)
@@ -6809,7 +6811,7 @@ char *cli_v1_client_endpoint(void)
    /* Fall back to a --server / AIMEE_SERVER_URL / remote.conf target (aimee_client)
     * by synthesizing the transport endpoint cli_http_request expects: "tls:" for
     * an https:// target (native client TLS, #304), else "tcp:". This makes the
-    * README's headline remote flow drive the WHOLE data/RPC plane (status,
+    * README's headline remote flow drive the WHOLE data/control plane (status,
     * memory, kb, …), not just the lower-level AIMEE_API_ENDPOINT form. */
    char hostport[300];
    int is_https = 0;
@@ -6931,6 +6933,7 @@ const char *cli_v1_route_for_method(const char *method, const char **verb_out)
        {"session.list", "GET", "/v1/sessions"},
        {"kb.search", "POST", "/v1/kb/search"},
        {"kb.status", "GET", "/v1/kb/status"},
+       {"kb.curator", "GET", "/v1/kb/curator"},
        {"memory.recall", "POST", "/v1/memory/recall"},
        {"rules.list", "GET", "/v1/rules"},
        {"notes.list", "GET", "/v1/notes"},
@@ -7586,7 +7589,7 @@ cJSON *cli_v1_dispatch(cJSON *req, int timeout_ms)
    return resp;
 }
 
-/* --- Main RPC forward function --- */
+/* --- Main /v1 forward function --- */
 
 int cli_v1_forward(const char *socket_path, const cli_v1_route_t *route, int json_output,
                    const char *json_fields, const char *response_profile, int argc, char **argv)

--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -952,6 +952,10 @@ static void kb_cmd_curator(app_ctx_t *ctx, int argc, char **argv)
          puts(j);
          free(j);
       }
+      else
+      {
+         puts("{\"status\":\"error\",\"message\":\"curator status serialization failed\"}");
+      }
       cJSON_Delete(root);
       return;
    }

--- a/src/cmd_kb.c
+++ b/src/cmd_kb.c
@@ -890,6 +890,83 @@ static void kb_cmd_pipeline(app_ctx_t *ctx, int argc, char **argv)
 /* Dispatch table                                                       */
 /* ------------------------------------------------------------------ */
 
+/* ------------------------------------------------------------------ */
+/* kb curator status — read the curator block from /v1/health (§4)     */
+/* ------------------------------------------------------------------ */
+
+static void kb_curator_print_tier(const char *label, cJSON *tier)
+{
+   int configured = tier && cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(tier, "configured"));
+   if (!configured)
+   {
+      printf("  %-8s idle (no provider configured)\n", label);
+      return;
+   }
+   cJSON *base = cJSON_GetObjectItemCaseSensitive(tier, "base_url");
+   cJSON *model = cJSON_GetObjectItemCaseSensitive(tier, "model");
+   printf("  %-8s %s  (%s)\n", label,
+          cJSON_IsString(model) && model->valuestring[0] ? model->valuestring : "(model unset)",
+          cJSON_IsString(base) ? base->valuestring : "");
+}
+
+static void kb_cmd_curator(app_ctx_t *ctx, int argc, char **argv)
+{
+   const char *verb = (argc > 0 && argv[0][0] != '-') ? argv[0] : "status";
+   if (strcmp(verb, "status") != 0)
+   {
+      fprintf(stderr, "Usage: aimee kb curator status [--json]\n");
+      return;
+   }
+   int json_out = ctx && ctx->json_output;
+   for (int i = 0; i < argc; i++)
+      if (strcmp(argv[i], "--json") == 0)
+         json_out = 1;
+
+   char *body = kb_client_health_json();
+   if (!body)
+   {
+      if (json_out)
+         puts("{\"status\":\"error\",\"message\":\"aimee-kb is not running\"}");
+      else
+         fprintf(stderr, "curator status: aimee-kb is not running\n");
+      exit(1);
+   }
+   cJSON *root = cJSON_Parse(body);
+   free(body);
+   cJSON *cur = root ? cJSON_GetObjectItemCaseSensitive(root, "curator") : NULL;
+   if (!cur)
+   {
+      if (json_out)
+         puts("{\"status\":\"error\",\"message\":\"curator block unavailable\"}");
+      else
+         fprintf(stderr, "curator status: curator block unavailable (older aimee-kb?)\n");
+      cJSON_Delete(root);
+      exit(1);
+   }
+
+   if (json_out)
+   {
+      char *j = cJSON_Print(cur);
+      if (j)
+      {
+         puts(j);
+         free(j);
+      }
+      cJSON_Delete(root);
+      return;
+   }
+
+   printf("Curator\n");
+   kb_curator_print_tier("tier-A:", cJSON_GetObjectItemCaseSensitive(cur, "tier_a"));
+   kb_curator_print_tier("tier-B:", cJSON_GetObjectItemCaseSensitive(cur, "tier_b"));
+   cJSON *q = cJSON_GetObjectItemCaseSensitive(cur, "queue");
+   if (q)
+      printf("  queue:   extract %d pending / %d done; code_unit %d pending / %d done\n",
+             kb_cmd_json_int(q, "extract_pending", 0), kb_cmd_json_int(q, "extract_done", 0),
+             kb_cmd_json_int(q, "code_unit_pending", 0), kb_cmd_json_int(q, "code_unit_done", 0));
+   cJSON_Delete(root);
+}
+
 static void kb_cmd_curator_profile(app_ctx_t *ctx, int argc, char **argv)
 {
    (void)argc;
@@ -945,6 +1022,8 @@ static const subcmd_t kb_subcmds[] = {
      kb_cmd_import},
     {"terms", "List term_mapping artifacts: [--limit N]", kb_cmd_terms},
     {"gaps", "List corpus gap artifacts: [--limit N]", kb_cmd_gaps},
+    {"curator", "Show curator LLM provider + queue status: curator status [--json]",
+     kb_cmd_curator},
     {"curator-profile", "Show hardware-selected curator backend profile [--endpoint URL] [--json]",
      kb_cmd_curator_profile},
     {NULL, NULL, NULL}};

--- a/src/cmd_trigger.c
+++ b/src/cmd_trigger.c
@@ -8,8 +8,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef RPC_PROTOCOL_VERSION
-#define RPC_PROTOCOL_VERSION 1
+#ifndef V1_PROTOCOL_VERSION
+#define V1_PROTOCOL_VERSION 1
 #endif
 
 /* ------------------------------------------------------------------ */
@@ -124,7 +124,7 @@ static void trigger_cmd_list(app_ctx_t *ctx, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "trigger.list");
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    if (status_filter && status_filter[0])
       cJSON_AddStringToObject(req, "status", status_filter);
 
@@ -187,7 +187,7 @@ static void trigger_cmd_status(app_ctx_t *ctx, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "trigger.status");
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    cJSON_AddStringToObject(req, "id", argv[0]);
 
    cli_conn_t conn;
@@ -251,7 +251,7 @@ static void trigger_cmd_cancel(app_ctx_t *ctx, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "trigger.cancel");
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    cJSON_AddStringToObject(req, "id", argv[0]);
 
    cli_conn_t conn;
@@ -342,7 +342,7 @@ static void trigger_cmd_fire(app_ctx_t *ctx, int argc, char **argv)
 
    cJSON *req = cJSON_CreateObject();
    cJSON_AddStringToObject(req, "method", "trigger.fire");
-   cJSON_AddNumberToObject(req, "protocol_version", RPC_PROTOCOL_VERSION);
+   cJSON_AddNumberToObject(req, "protocol_version", V1_PROTOCOL_VERSION);
    cJSON_AddStringToObject(req, "source", source);
    cJSON_AddStringToObject(req, "task", task);
    if (event && event[0])

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -189,22 +189,22 @@ int cli_restart_server(void);
  * spawn failure. */
 int cli_start_server(void);
 
-/* RPC thin-client routing.
- * Looks up an RPC route for a CLI command+subcommand combination. */
+/* Thin-client /v1 routing.
+ * Looks up the /v1 HTTP route for a CLI command+subcommand combination. */
 typedef struct
 {
    const char *method;        /* logical route/formatter name */
-   const char *server_method; /* actual server RPC method (NULL = method) */
+   const char *server_method; /* actual server /v1 method (NULL = method) */
    const char *extract;       /* response field to extract (NULL = return object minus "status") */
    int skip_subcmd;           /* number of leading sub-args consumed by route match (0, 1, or 2) */
-   int timeout_ms;            /* RPC timeout (0 = CLIENT_DEFAULT_TIMEOUT_MS) */
+   int timeout_ms;            /* request timeout (0 = CLIENT_DEFAULT_TIMEOUT_MS) */
 } cli_v1_route_t;
 
-/* Returns 1 if a matching RPC route was found, 0 otherwise.
+/* Returns 1 if a matching /v1 route was found, 0 otherwise.
  * Tries compound sub-commands first (e.g. "ingest status") before single ones. */
 int cli_v1_lookup(const char *cmd, int sub_argc, char **sub_argv, cli_v1_route_t *route);
 
-/* Forward a CLI command through the server RPC.
+/* Forward a CLI command to the server over its /v1 HTTP surface.
  * Returns 0 on success, >0 on application error, -1 on transport/protocol
  * error (caller should fall back to in-process execution).
  * argc/argv are the args AFTER the command name (e.g., for "aimee memory search foo",

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -797,9 +797,9 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
  * empty type or ref are skipped; `versions` may be NULL). Returns 0 on success,
  * -1 on bad args or kb error. */
 int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
-                                             const char *query_fingerprint,
-                                             const char *const *types, const char *const *refs,
-                                             const char *const *versions, int n);
+                                             const char *query_fingerprint, const char *const *types,
+                                             const char *const *refs, const char *const *versions,
+                                             int n);
 
 /* Auditable-correctness P1: the /v1/audit/trace read — forward to the KB
  * evidence.trace_retrieval_event action and return its JSON response verbatim

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -41,6 +41,16 @@ typedef struct
  * if aimee-kb is unreachable (out->process_ok == 0). */
 int kb_client_health(kb_health_t *out);
 
+/* Returns the raw /v1/health JSON document (caller frees), or NULL if aimee-kb
+ * is unreachable or returns non-2xx. Used by `aimee kb curator status` to read
+ * the curator block (richer than the flat kb_health_t snapshot). */
+char *kb_client_health_json(void);
+
+/* Returns the curator observability block (§4) from aimee-kb's /v1/health as a
+ * standalone heap JSON object (caller frees). Backs the server's GET
+ * /v1/kb/curator surface. Never NULL — a status-error object on failure. */
+char *kb_client_curator_json(void);
+
 /* Returns a heap-allocated JSON document describing kb/vector status.
  * Caller must free the returned string. Never returns NULL. */
 char *kb_client_status_json(void);
@@ -787,9 +797,9 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
  * empty type or ref are skipped; `versions` may be NULL). Returns 0 on success,
  * -1 on bad args or kb error. */
 int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
-                                             const char *query_fingerprint, const char *const *types,
-                                             const char *const *refs, const char *const *versions,
-                                             int n);
+                                             const char *query_fingerprint,
+                                             const char *const *types, const char *const *refs,
+                                             const char *const *versions, int n);
 
 /* Auditable-correctness P1: the /v1/audit/trace read — forward to the KB
  * evidence.trace_retrieval_event action and return its JSON response verbatim

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -240,6 +240,9 @@ extern "C"
    /* GET /v1/kb/status provider (arg-less kb/vector status JSON). */
    void server_http_set_kb_status_provider(server_http_json_provider fn);
 
+   /* GET /v1/kb/curator provider (arg-less curator observability block). */
+   void server_http_set_kb_curator_provider(server_http_json_provider fn);
+
    /* GET /v1/agents provider (arg-less; configured agents + default, built
     * server-side from agent config rather than proxied to aimee-kb). */
    void server_http_set_agents_provider(server_http_json_provider fn);

--- a/src/posix/cli_client.c
+++ b/src/posix/cli_client.c
@@ -13,7 +13,7 @@
 #ifdef WITH_TLS
 #include "aimee_tls.h" /* native-TLS /v1 transport for a tls: endpoint */
 #endif
-#define RPC_PROTOCOL_VERSION 1
+#define V1_PROTOCOL_VERSION 1
 #include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/server/kb_client.c
+++ b/src/server/kb_client.c
@@ -116,6 +116,39 @@ int kb_client_is_live(void)
    return kb_client_v1_base_url() != NULL;
 }
 
+char *kb_client_health_json(void)
+{
+   int http_status = -1;
+   char *body = kb_client_v1_get_json("/v1/health", CLIENT_DEFAULT_TIMEOUT_MS, &http_status);
+   if (!body)
+      return NULL;
+   if (http_status < 200 || http_status >= 300)
+   {
+      free(body);
+      return NULL;
+   }
+   return body;
+}
+
+/* The curator observability block from aimee-kb's /v1/health (§4), returned as a
+ * standalone JSON object for the server's GET /v1/kb/curator surface. Never
+ * returns NULL: an unavailable kb / missing block yields a status-error object. */
+char *kb_client_curator_json(void)
+{
+   char *health = kb_client_health_json();
+   if (!health)
+      return kb_status_unavailable_json("knowledge service /v1/health did not respond");
+   cJSON *root = cJSON_Parse(health);
+   free(health);
+   cJSON *cur = root ? cJSON_DetachItemFromObjectCaseSensitive(root, "curator") : NULL;
+   cJSON_Delete(root);
+   if (!cur)
+      return kb_status_unavailable_json("curator status unavailable");
+   char *out = cJSON_PrintUnformatted(cur);
+   cJSON_Delete(cur);
+   return out ? out : kb_status_unavailable_json("curator status serialization failed");
+}
+
 int kb_client_health(kb_health_t *out)
 {
    if (!out)

--- a/src/server/server_api.c
+++ b/src/server/server_api.c
@@ -44,6 +44,12 @@ static char *kb_status_provider(void)
    return kb_client_status_json();
 }
 
+/* GET /v1/kb/curator provider: the curator observability block (§4). */
+static char *kb_curator_provider(void)
+{
+   return kb_client_curator_json();
+}
+
 /* GET /v1/roadmap provider: the roadmap list as a heap JSON object. */
 static char *roadmap_provider(void)
 {
@@ -232,6 +238,7 @@ void server_native_register(void)
    server_http_set_dashboard_memory_provider(dashboard_memory_provider);
    server_http_set_dashboard_reminders_provider(dashboard_reminders_provider);
    server_http_set_kb_status_provider(kb_status_provider);
+   server_http_set_kb_curator_provider(kb_curator_provider);
    server_http_set_agents_provider(agents_provider);
    server_http_set_roadmap_provider(roadmap_provider);
    server_http_set_curiosity_provider(curiosity_provider);

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -102,6 +102,18 @@ static int rh_kb_status(const route_req_t *rq, char *resp, int cap)
    (void)rq;
    return route_json_provider(g_kb_status_provider, resp, cap, "kb status");
 }
+/* Curator observability provider (§4). Kept here rather than in server_http.c
+ * (which is at its line-count limit); routes.inc is part of the same TU. */
+static server_http_json_provider g_kb_curator_provider = NULL;
+void server_http_set_kb_curator_provider(server_http_json_provider fn)
+{
+   g_kb_curator_provider = fn;
+}
+static int rh_kb_curator(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   return route_json_provider(g_kb_curator_provider, resp, cap, "kb curator");
+}
 static int rh_agents(const route_req_t *rq, char *resp, int cap)
 {
    (void)rq;
@@ -890,6 +902,7 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/dashboard/reminders", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ,
      rh_dashboard_reminders},
     {"GET", "/v1/kb/status", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_kb_status},
+    {"GET", "/v1/kb/curator", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_kb_curator},
     {"GET", "/v1/agents", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_agents},
     {"GET", "/v1/roadmap", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_roadmap},
     {"GET", "/v1/curiosity", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_curiosity},

--- a/src/tests/test_cli_v1_delegate.c
+++ b/src/tests/test_cli_v1_delegate.c
@@ -12,7 +12,7 @@
 #include "platform_path.h"
 #include "cJSON.h"
 
-#define RPC_PROTOCOL_VERSION 1
+#define V1_PROTOCOL_VERSION 1
 
 /* Include the route implementation directly so static marshal helpers are testable. */
 #include "../cli_v1_routes.inc"

--- a/src/windows/cli_client.c
+++ b/src/windows/cli_client.c
@@ -15,7 +15,7 @@
 #include "platform_path.h"
 #include "platform_process.h"
 #include "cJSON.h"
-#define RPC_PROTOCOL_VERSION 1
+#define V1_PROTOCOL_VERSION 1
 #include <direct.h>
 #include <errno.h>
 #include <stdio.h>


### PR DESCRIPTION
## The real problem (not what it looked like)
`aimee kb curator status` failed with *"command 'kb' has no typed server RPC route."* That message is **misleading**: the thin client is already a **strict `/v1` HTTP consumer** (`cli_v1_forward` → `cli_v1_send`; no NDJSON socket; the code asserts *"no /v1/rpc bridge"*). There is **no RPC transport** — "RPC" was just legacy naming. The actual bug: the `kb` subcommand had **no `/v1` route entry** for `curator` (only `search`/`status`/… are routed), so it fell to the dead-end fallback.

## Fix
**1. `GET /v1/kb/curator`** so the thin client forwards `kb curator status` over `/v1` like every other command:
- `kb_client_curator_json()` — pulls the curator block (§4) from aimee-kb's `/v1/health`, returns it standalone.
- `kb_curator_provider` + `rh_kb_curator` route + setter (placed in `server_http_routes.inc` — `server_http.c` is at its 2000-line cap).
- OpenAPI: document `/kb/curator` (satisfies `server-api-conformance`).
- cli_v1: bespoke `kb.curator → GET /v1/kb/curator` + hand cmd-routes for `kb curator [status]`.
- `cmd_kb` gains a `curator` subcommand for the monolith/cmd_table path (same data source).

**2. Drop the "RPC" misnomer** in the thin-client `/v1` path → `/v1`: the unsupported-command message, `cli_v1_route_t` field/struct comments, `cli_main` forward comments + *"server /v1 request failed"*, the route-table/forward-function headers, and the file-local `RPC_MAX_*` / `RPC_PROTOCOL_VERSION` macros (→ `V1_*`). The wire field `protocol_version` is unchanged.

## Verification
`make all` clean; `make lint` clean (`server-api-conformance`, `check-cli-v1-routes`, `clang-format-19`, schema-sync); all curator / cli-v1 / server-http unit tests pass. `aimee kb curator status` now resolves to the `/v1` route (server-unavailable transport error offline) instead of the no-route dead-end. Local roundtable gate run on the diff.
