### PR TITLE
docs: rewrite QUICKSTART (server + Linux/Windows/macOS clients) + add proposals

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -128,7 +128,10 @@ gates each tool call; PostToolUse re-indexes edited files.
 ## 3. Installation
 
 aimee ships four binaries: the **`aimee`** thin client, **`aimee-server`**,
-**`aimee-kb`**, and **`aimee-webchat`**. There are two ways to stand it up:
+**`aimee-kb`**, and **`aimee-webchat`**. For a guided, step-by-step path (combined
+Docker server + per-OS thin-client setup), see the
+[Quickstart](docs/QUICKSTART.md); this chapter is the exhaustive reference. There
+are two ways to stand it up:
 
 - **Docker services + thin client (recommended, [§3.1](#31-run-the-services-in-docker-recommended) to [§3.2](#32-install-the-thin-client)).**
   Run `aimee-server` and `aimee-kb` as containers (one combined container or two

--- a/README.md
+++ b/README.md
@@ -195,6 +195,9 @@ database and talks to a server over `/v1`. The intended deployment is to run the
 **services in Docker** (one combined container, or two split containers) and
 install only the **thin client** on each developer machine, pointed at the server.
 
+> **In a hurry?** The [Quickstart](docs/QUICKSTART.md) walks the combined Docker
+> server plus the Linux, Windows, and macOS thin-client setup step by step.
+>
 > Prefer everything on one box from source (no Docker)? See
 > [Single-box source install](#single-box-source-install-no-docker) below.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,16 +1,27 @@
-# Quickstart
+# aimee Quickstart
 
-Zero to working in a few minutes. Run the server in Docker, install the thin
-client, point your AI tool at it. Memory, guardrails, and delegation come on
-automatically.
+This guide takes you from nothing to a working aimee install in four parts:
 
-For the full picture, see the [Manual](../MANUAL.md) and
-[How aimee learns](KNOWLEDGE.md).
+1. **[Run the server](#part-1--run-the-server-aimee-combined-in-docker)** — stand up the full stack (server + knowledge base + Postgres + embedder) with the combined Docker image.
+2. **[Install the Linux client](#part-2--linux-client)** — install the thin `aimee` binary, point it at your server, and set up workspaces and agents.
+3. **[Install the Windows client](#part-3--windows-client)** — same, for Windows.
+4. **[Install the macOS client](#part-4--macos-client)** — same, for macOS.
 
-## 1. Run the server
+The model is the same on every developer machine: **the services run in Docker (or on a Linux/macOS host); each developer installs only the thin `aimee` client and points it at the server.** The client holds no database — it talks to the server over the `/v1` HTTP API.
 
-One container runs both binaries — the server and the knowledge base. Postgres
-and the embedder come up alongside it.
+---
+
+## Part 1 — Run the server (aimee-combined in Docker)
+
+The **combined** image co-locates both aimee binaries in one container: the knowledge base (`aimee-kb`) on loopback `:8741` inside the container, and the server (`aimee-server`) fronting `/v1` on `:8740`. Postgres (DB2 + pgvector) and a CPU embedder come up alongside it as separate services.
+
+### Prerequisites
+
+- Docker Engine + the Docker Compose plugin (`docker compose`, v2).
+- ~4 GB free RAM and a few GB of disk for Postgres, the embedder model, and build layers.
+- No credentials or API keys are required for the default build.
+
+### 1.1 Clone and start the stack
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
@@ -18,95 +29,335 @@ cd aimee
 docker compose -f compose.combined.yaml up --build -d
 ```
 
-The server fronts `/v1` on `:8740`; the in-container kb runs on `:8741`. Default
-bearer is `aimee-local-dev`. Confirm it's live:
+This brings up four services:
+
+| Service | What it is | Port |
+|---------|-----------|------|
+| `aimee-server-kb` | Both aimee binaries (server + kb) in one container | `8740` (server `/v1`), `8741` (kb `/v1`) |
+| `postgres` | `pgvector/pgvector:pg16` — DB2 (`aimee_shared`) for knowledge + vectors | internal |
+| `embedder` | CPU embedder sidecar (`all-MiniLM-L6-v2`) | internal |
+| webchat (optional) | Browser UI, enabled by this compose file | `8443` (HTTPS, self-signed) |
+
+The kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first boot. First `--build` takes a few minutes (it compiles the binaries and pulls the embedder model); subsequent starts are fast.
+
+### 1.2 Verify it's healthy
 
 ```bash
+docker compose -f compose.combined.yaml ps          # all services should be "healthy"
+
+# Server /v1 (default bearer is "aimee-local-dev"):
 curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
 curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+
+# In-container kb directly (DB + pgvector status):
+curl 'http://localhost:8741/v1/health?status=1'
 ```
 
-Set a real bearer for anything past loopback. `aimee-local-dev` is a dev
-convenience.
+If the server endpoints return `200` and `kb/status` reports the DB and vector store ready, the stack is up.
 
-The default embedder is the 0.6B (`pplx-embed-v1-0.6b`, 1024-dim), paired with the
-400m reranker — the low-latency tier. For higher fidelity, use the 4B:
-`AIMEE_EMBEDDER_IMAGE=ghcr.io/rakuensoftware/aimee-embedder-4b:latest AIMEE_EMBEDDING_DIM=2560 docker compose -f compose.combined.yaml up --build -d`.
+### 1.3 (Optional) Browser webchat
 
-## 2. Install the client
+`compose.combined.yaml` enables the browser UI for local dev. Open **https://localhost:8443** (accept the self-signed cert) and log in with the default account `aimee` / `aimee-local-dev`. Change `AIMEE_WEBCHAT_USER` / `AIMEE_WEBCHAT_PASSWORD` (or set `AIMEE_WEBCHAT_ENABLED=0` to disable it) in the compose file for anything beyond local dev.
 
-The `aimee` CLI is a thin client. It holds no database and talks to a server
-over `/v1`. Grab a prebuilt binary from the latest
-[release](https://github.com/RakuenSoftware/aimee/releases) (Linux, macOS,
-Windows), put it on your `PATH`, done.
+### 1.4 Before you expose it on a network
 
-Point it at the server:
+- **Override the default bearer.** `aimee-local-dev` is a loopback convenience only. Mount your own `aimee.yaml` at `/var/lib/aimee/aimee.yaml` with a real bearer (see `compose.remote-writes.combined.yaml` for the pattern) and terminate TLS at a reverse proxy.
+- **Remote writes are off by default.** Over the network a remote bearer is **read/query only** until you opt in. To let remote clients write memory, run the index, etc., set `aimee.api.remote_writes` in your mounted `aimee.yaml`:
+  - `data` — allow data-plane writes (`memory store`, `work …`, `rules …`, `skill …`).
+  - `full` — also allow exec/control (`delegate`, `agent`, `provider`, `cron`). **Trusted networks only** — a leaked `full` bearer permits remote code execution.
+
+  (Workspace registration over the network — `workspace add/serve/remove` — is a deliberate, bearer-gated exception and works even with remote writes off.)
+
+### 1.5 Managing the stack
 
 ```bash
-aimee remote set http://localhost:8740 aimee-local-dev
-aimee remote status   # resolved transport + a health probe
+docker compose -f compose.combined.yaml logs -f                 # follow logs
+docker compose -f compose.combined.yaml restart aimee-server-kb # restart just the aimee container
+docker compose -f compose.combined.yaml down                    # stop + remove containers (named volumes persist)
+docker compose -f compose.combined.yaml down -v                 # also DROP data volumes (DESTROYS DB2 + state)
+docker compose -f compose.combined.yaml pull && \
+  docker compose -f compose.combined.yaml up -d --build         # update: rebuild and recreate
 ```
 
-Or per-invocation: `aimee --server http://host:8740 --server-token=aimee-local-dev status`.
-Or via env: `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`.
+Durable state lives in named volumes (`*-postgres`, `*-home`, `*-workspaces`, `*-embedder-models`), so `down` and recreate are safe; only `down -v` erases data.
 
-## 3. Wire your AI tool
+---
 
-From a checkout, run the hook installer on the client machine:
+## Part 2 — Linux client
+
+On Linux you can build and run the whole stack from source, but as a **client against a Docker/remote server** you only need the thin `aimee` binary, which talks to your `aimee-server` over `/v1`. Unlike the Windows and macOS prebuilt binaries, the Linux build links OpenSSL, so it supports `https://` servers out of the box.
+
+### 2.1 Install `aimee`
+
+**Option A — prebuilt binary (no build):**
 
 ```bash
-./configure-hooks.sh        # configure-hooks.ps1 on Windows
+# Download aimee-linux-x86_64 (or aimee-linux-arm64) from the latest GitHub release, then:
+chmod +x aimee-linux-x86_64
+mkdir -p ~/.local/bin
+mv aimee-linux-x86_64 ~/.local/bin/aimee
+# ensure ~/.local/bin is on your PATH (add to ~/.bashrc / ~/.zshrc if needed):
+export PATH="$HOME/.local/bin:$PATH"
 ```
 
-It registers aimee's SessionStart/PreToolUse/PostToolUse hooks and MCP server for
-every tool it finds — Claude Code, Codex CLI, Gemini CLI, Copilot. From here,
-every session starts knowing what the last one learned, sensitive files are
-blocked before a write lands, and you can hand work to cheaper models.
-
-The host AI's own sub-agent tool (Claude's `Task`, Codex's `spawn_agent`) is
-blocked on purpose — fan work out through `aimee delegate` instead, so it stays
-in aimee's session state, cost accounting, and audit trail. See
-[Delegates](DELEGATES.md).
-
-To run your tool's front end on aimee's model instead of its built-in vendor:
+**Option B — build the thin client from source** (needs a C compiler, `make`, and `libsqlite3-dev`; add `libssl-dev` to keep `https://` support):
 
 ```bash
-# Claude Code on any model:
-ANTHROPIC_BASE_URL=http://localhost:8740 ANTHROPIC_AUTH_TOKEN=aimee-local-dev claude
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee/src
+make -j"$(nproc)" ../aimee     # produces ./aimee at the repo root
+cp ../aimee ~/.local/bin/aimee # or anywhere on your PATH
 ```
 
-Codex and any OpenAI-compatible client work the same way — see the
-[README](../README.md#use-your-front-end-on-any-model).
+(Want the full server + kb running locally on this host instead of in Docker? Run `./install-deps.sh` then `./install.sh` from the checkout — that builds everything, bootstraps Postgres, and installs systemd user units. For the client-against-Docker setup in this guide, the thin client above is all you need.)
 
-## 4. Verify
+Confirm the install:
 
 ```bash
 aimee version
-aimee status   # server, DB1, and kb health
 ```
 
-## 5. Use it
+### 2.2 Point the client at your server
 
 ```bash
-# Remember something across every future session
-aimee memory store db-host "PostgreSQL at 10.0.0.5:5432" --tier L2 --kind fact
-aimee memory search "database"
-
-# Hand routine work to a cheaper model
-aimee delegate review "Review this PR for security issues"
-aimee delegate code --tools "Add tests for the auth module"
-
-# Convene a panel of models and synthesize one answer
-aimee delegate roundtable --mode review "Is this migration plan sound?"
+aimee remote set http://YOUR_SERVER:8740 aimee-local-dev
+aimee remote status     # resolved transport + /v1/health probe
+aimee status            # server, DB1, and kb health
 ```
 
-Delegates and the roundtable panel ship configured out of the box. You don't set
-them up. See [Setting Up Delegates](DELEGATES.md) to add your own providers or
-change the panel.
+Use your real bearer token instead of `aimee-local-dev` if you changed it. For an HTTPS server, `https://` works with certificate verification on by default; set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`, or pass `--server http://YOUR_SERVER:8740 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
 
-## Next
+### 2.3 Configure your AI coding tool
 
-- [Manual](../MANUAL.md) — full command contract and configuration.
-- [How aimee learns](KNOWLEDGE.md) — the knowledge base and where this goes at team scale.
-- [Workspaces](WORKSPACES.md) — multi-repo and session isolation.
-- [Security](SECURITY.md) — trust boundaries and the capability model.
+From the cloned checkout, register aimee's hooks and MCP server for every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot):
+
+```bash
+./configure-hooks.sh
+```
+
+This wires SessionStart / PreToolUse / PostToolUse hooks (which call `aimee`) and the `aimee mcp-serve` MCP server into each tool's config.
+
+### 2.4 Set up workspaces
+
+A workspace is a set of repositories aimee indexes and works across as one unit.
+
+```bash
+aimee workspace add /path/to/your/repo                     # register an existing checkout and index it
+aimee workspace add --repo git@github.com:org/repo.git     # clone, register, and index
+aimee workspace list                                       # list roots and the projects under each
+```
+
+You can also drop an `aimee.workspace.yaml` manifest in a directory and run `aimee setup` to clone, install dependencies, index, and generate starter rules for a multi-repo workspace in one shot — see [Workspace Management](WORKSPACES.md).
+
+> Indexing and memory writes are server-side mutations, so they need the server's `aimee.api.remote_writes` to be at least `data` (see [1.4](#14-before-you-expose-it-on-a-network)). Workspace registration itself works regardless.
+
+### 2.5 Add agents (delegates)
+
+Delegates are cheaper/local models aimee routes routine work to. Configure them once:
+
+```bash
+aimee agent setup <provider>          # OAuth/device-flow setup for subscription providers (e.g. chatgpt, mistral-plan)
+aimee agent add <name> --provider openai --model <model> --api-key <key>   # direct API key
+aimee agent local local http://YOUR_LLM_HOST:8080 --model MODEL --slots 4  # local OpenAI-compatible runtime (Ollama / llama.cpp)
+aimee agent list                      # inspect registered agents + routing data
+```
+
+Agent/provider control commands are exec/control operations, so over the network they need the server's `remote_writes` set to `full`. The primary agent (Claude Code, Codex, …) then routes delegateable work automatically; you can also call `aimee delegate <role> "<task>"` directly. See [Setting Up Delegates](DELEGATES.md) for the full agent schema and routing details.
+
+### 2.6 Interactive chat
+
+The data/RPC plane (`memory`, `kb`, `index`, `rules`, `sessions`) works fine over the remote transport. **Interactive `aimee chat` / `aimee launch` need a co-located server** — they run the agent and its tools on the local host and chdir into a local worktree, so they don't run against a purely remote endpoint. Drive aimee from your AI coding tool (configured in [2.3](#23-configure-your-ai-coding-tool)), or use the browser webchat at `https://YOUR_SERVER:8443`.
+
+---
+
+## Part 3 — Windows client
+
+On Windows aimee runs as the **thin client only**: a single `aimee.exe` that talks to your remote `aimee-server` over `/v1`. The server and kb run in Docker (Part 1) or on a Linux/macOS host — never on Windows.
+
+> **TLS note:** the Windows client is built **without TLS** and refuses `https://`. Point it at an `http://` address; if your server is HTTPS, terminate TLS at a reverse proxy and use that proxy's `http://` endpoint.
+
+### 3.1 Install `aimee.exe`
+
+**Option A — prebuilt binary (no build):**
+
+1. Download **`aimee-windows-x86_64.exe`** from the [latest GitHub release](https://github.com/RakuenSoftware/aimee/releases).
+2. Rename it to `aimee.exe` and put it in a folder on your `PATH` (e.g. `%LOCALAPPDATA%\aimee\bin`, then add that folder to your user PATH).
+
+**Option B — build from source** (needs Git, CMake, and a C compiler — Visual Studio Build Tools `cl.exe` or MinGW `gcc`):
+
+```powershell
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+.\install.ps1
+```
+
+`install.ps1` builds the thin client and installs it to `%LOCALAPPDATA%\aimee\bin`, adding that directory to your user `PATH`.
+
+**Open a new PowerShell or Command Prompt** so the PATH change takes effect, then confirm:
+
+```powershell
+aimee version
+```
+
+### 3.2 Point the client at your server
+
+```powershell
+aimee remote set http://YOUR_SERVER:8740 aimee-local-dev
+aimee remote status     # shows the resolved transport + a /v1/health probe
+aimee status            # server, DB1, and kb health
+```
+
+Use your real bearer token instead of `aimee-local-dev` if you changed it. Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` environment variables, or pass `--server http://YOUR_SERVER:8740 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
+
+### 3.3 Configure your AI coding tool
+
+From the cloned checkout, register aimee's hooks and MCP server for every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot):
+
+```powershell
+.\configure-hooks.ps1
+```
+
+This wires SessionStart / PreToolUse / PostToolUse hooks (which call `aimee.exe`) and the `aimee mcp-serve` MCP server into each tool's config.
+
+### 3.4 Set up workspaces
+
+A workspace is a set of repositories aimee indexes and works across as one unit.
+
+```powershell
+aimee workspace add C:\path\to\your\repo        # register an existing checkout and index it
+aimee workspace add --repo https://github.com/org/repo.git   # clone, register, and index
+aimee workspace list                            # list roots and the projects under each
+```
+
+> Indexing and memory writes are server-side mutations, so they need the server's `aimee.api.remote_writes` to be at least `data` (see [1.4](#14-before-you-expose-it-on-a-network)). Workspace registration itself works regardless.
+
+### 3.5 Add agents (delegates)
+
+Delegates are cheaper/local models aimee routes routine work to. Configure them once:
+
+```powershell
+aimee agent setup <provider>          # OAuth/device-flow setup for subscription providers (e.g. chatgpt, mistral-plan)
+aimee agent add <name> --provider openai --model <model> --api-key <key>   # direct API key
+aimee agent local local http://YOUR_LLM_HOST:8080 --model MODEL --slots 4  # local OpenAI-compatible runtime (Ollama / llama.cpp)
+aimee agent list                      # inspect registered agents + routing data
+```
+
+Agent/provider control commands are exec/control operations, so over the network they need the server's `remote_writes` set to `full`. The primary agent (Claude Code, Codex, …) then routes delegateable work automatically; you can also call `aimee delegate <role> "<task>"` directly.
+
+### 3.6 Interactive chat
+
+The data/RPC plane (`memory`, `kb`, `index`, `rules`, `sessions`) works fine over the remote transport. **Interactive `aimee chat` / `aimee launch` need a co-located server** — they run the agent and its tools on the local host and chdir into a local worktree, so they don't run against a purely remote endpoint. Drive aimee from your AI coding tool (configured in [3.3](#33-configure-your-ai-coding-tool)), or use the browser webchat at `https://YOUR_SERVER:8443`.
+
+---
+
+## Part 4 — macOS client
+
+macOS uses the same **thin client** model as Linux and Windows: install `aimee`, point it at your Docker/Linux server, and set up workspaces and agents.
+
+### 4.1 Install `aimee`
+
+**Option A — prebuilt binary (no build):**
+
+```bash
+# Download aimee-macos-universal from the latest GitHub release, then:
+chmod +x aimee-macos-universal
+xattr -d com.apple.quarantine aimee-macos-universal 2>/dev/null || true   # clear Gatekeeper quarantine
+mkdir -p ~/.local/bin
+mv aimee-macos-universal ~/.local/bin/aimee
+# ensure ~/.local/bin is on your PATH (add to ~/.zshrc if needed):
+export PATH="$HOME/.local/bin:$PATH"
+```
+
+The prebuilt macOS binary is a universal (arm64 + x86_64) build and, like Windows, is built **without TLS** — point it at an `http://` server.
+
+**Option B — build the thin client from source** (needs Xcode Command Line Tools + CMake; this build *does* support `https://` via OpenSSL):
+
+```bash
+git clone https://github.com/RakuenSoftware/aimee.git
+cd aimee
+cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
+      -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
+      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF
+cmake --build build --target aimee
+cp build/aimee ~/.local/bin/aimee      # or anywhere on your PATH
+```
+
+(Want the full server + kb running locally on the Mac instead of in Docker? Run `./install-deps.sh` then `./install.sh` — that builds everything and registers launchd agents. For the client-against-Docker setup in this guide, the thin client above is all you need.)
+
+Confirm the install:
+
+```bash
+aimee version
+```
+
+### 4.2 Point the client at your server
+
+```bash
+aimee remote set http://YOUR_SERVER:8740 aimee-local-dev
+aimee remote status     # resolved transport + /v1/health probe
+aimee status            # server, DB1, and kb health
+```
+
+For an HTTPS server with a source-built (OpenSSL) client, `https://` works with cert verification on; set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. The prebuilt (TLS-off) binary supports `http://` only. As on the other platforms, you can use `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` or `--server` instead of `aimee remote set`.
+
+### 4.3 Configure your AI coding tool
+
+```bash
+./configure-hooks.sh
+```
+
+Registers aimee's hooks + MCP server for every detected tool (Claude Code, Codex CLI, Gemini CLI, GitHub Copilot).
+
+### 4.4 Set up workspaces
+
+```bash
+aimee workspace add /path/to/your/repo                     # register an existing checkout and index it
+aimee workspace add --repo git@github.com:org/repo.git     # clone, register, and index
+aimee workspace list
+```
+
+You can also drop an `aimee.workspace.yaml` manifest in a directory and run `aimee setup` to clone, install dependencies, index, and generate starter rules for a multi-repo workspace in one shot — see [Workspace Management](WORKSPACES.md). As on the other platforms, indexing/memory writes require the server's `remote_writes` to be at least `data`.
+
+### 4.5 Add agents (delegates)
+
+```bash
+aimee agent setup <provider>          # OAuth/device-flow for subscription providers
+aimee agent add <name> --provider openai --model <model> --api-key <key>
+aimee agent local local http://YOUR_LLM_HOST:8080 --model MODEL --slots 4   # local Ollama / llama.cpp
+aimee agent list
+```
+
+Agent/provider control over the network requires the server's `remote_writes` to be `full`. See [Setting Up Delegates](DELEGATES.md) for the full agent schema and routing details.
+
+### 4.6 Interactive chat
+
+As on the other platforms, the data plane works over the remote transport, but interactive `aimee chat` / `aimee launch` need a co-located server. Drive aimee from your AI coding tool, or use the browser webchat at `https://YOUR_SERVER:8443`.
+
+---
+
+## Where things live
+
+| Path | What |
+|------|------|
+| `<aimee_home>/remote.conf` | Persisted thin-client remote target (`aimee remote set`). `aimee_home` is `~/.config/aimee` on Linux/macOS; `%LOCALAPPDATA%\aimee` on Windows. |
+| `aimee.yaml` | Server config (bearer, `remote_writes`, kb wiring, agents). In Docker this is inside the `*-home` volume at `/var/lib/aimee/aimee.yaml`. |
+| Named Docker volumes | `*-postgres` (DB2), `*-home` (server/kb state), `*-workspaces`, `*-embedder-models`. |
+
+## TLS support by build
+
+| Client | `https://` support |
+|--------|--------------------|
+| Linux — prebuilt release binary or `make` build | Yes (OpenSSL linked by default) |
+| macOS — source build with OpenSSL | Yes |
+| macOS — prebuilt `aimee-macos-universal` | No — `http://` only |
+| Windows — prebuilt or `install.ps1` build | No — `http://` only (terminate TLS at a proxy) |
+
+For any TLS-off client, terminate TLS at a reverse proxy and point the client at the proxy's `http://` address.
+
+## Next steps
+
+- **[Manual](../MANUAL.md)** — the complete command and configuration reference.
+- **[Workspace Management](WORKSPACES.md)** — manifests, multi-repo workspaces, session isolation.
+- **[Setting Up Delegates](DELEGATES.md)** — configure delegate agents and routing.
+- **[Architecture](ARCHITECTURE.md)** — processes, storage boundaries, and deployment topologies.
+- **Run on any model** — point Claude Code (`aimee claude-proxy enable`), Codex, or any OpenAI-compatible tool at aimee and run every turn on your chosen primary model; see the [README](../README.md#use-your-front-end-on-any-model).

--- a/docs/proposals/pending/auto-vault-provisioning-at-server-standup.md
+++ b/docs/proposals/pending/auto-vault-provisioning-at-server-standup.md
@@ -1,0 +1,124 @@
+# Automatic delegate-vault provisioning at aimee-server standup
+
+- **State:** proposed; awaiting roundtable + user proposal-gate.
+- **Scope:** deterministic / server bootstrap + credential vault. Not an
+  intelligence-surface proposal (no Architecture Charter role).
+- **Author:** JBailes, 2026-06-17.
+- **Origin:** surfaced while trying to run a roundtable against the `.254`
+  server (v0.2.85): every delegate returned `HTTP 401 Unauthorized` because the
+  server's vault held **no delegate credentials**, and the remote client-push
+  path does not populate it. The validated keys exist on the client; the server
+  just never received them at standup.
+
+## Problem
+
+A freshly stood-up `aimee-server` (Docker combined/split image, the SmoothNAS
+plugin, or a bare `docker run`) comes up with an **empty delegate credential
+vault**. Delegates resolve credentials **vault-first**
+(`src/headers/delegate_credential_retry.h`: "vault-FIRST for `vault_principal`"),
+so with an empty vault every `aimee delegate` / roundtable call fails
+`provider '<x>' (HTTP 401): authentication failed`.
+
+Today the only ways to populate the vault are **manual and co-located**:
+
+- `aimee vault set <agent> <name> <secret>` / `aimee agent add --key`, which call
+  `handle_vault_set` and require an **attested local identity** — they refuse the
+  remote TCP transport (`vault: this connection has no attested local identity`).
+- So an operator must shell into the server host/container and run the vault
+  commands by hand after every fresh deploy.
+
+This is the open tail of the cred-vault consolidation (creds → server vault):
+the **sealing/storage mechanism shipped** (`handle_vault_set_server`, the
+server-master-key dual-access wrap), but **nothing provisions the vault at
+standup**, so the directive ("a new server should just work") is unmet. The
+container entrypoints already seed `aimee.yaml` and ship `agents.json`
+(definitions only — no secrets), but there is no equivalent step for secrets.
+
+## Goal
+
+**Standing up a new `aimee-server` provisions its delegate vault automatically**,
+from a declared secret source, with no manual `vault set` and no client push, so
+delegates (and therefore roundtables) work on first boot. Idempotent, secret-safe
+(no plaintext left on disk), and a no-op when the vault is already populated.
+
+## Design
+
+At server startup, after the vault is unsealed under the server master key
+(`.server-master.key` dual-access wrap) and **before** the delegate pool serves
+traffic, run a **vault bootstrap pass** that seals any operator-supplied delegate
+secrets into the per-server vault via the existing **server-principal** write path
+(`handle_vault_set_server` / its internal callee), keyed by the server
+`vault_principal`.
+
+### Secret source (operator-declared, never baked)
+
+Resolve secrets at boot from, in precedence order:
+
+1. **A mounted secrets file** — `AIMEE_DELEGATE_SECRETS_FILE` (default e.g.
+   `/run/secrets/aimee-delegates.json`), a `{ "<agent>": "<key>", … }` map. This
+   is the Docker/compose/SmoothNAS-native path (Docker secret or bind-mounted
+   file), mirroring how `agents.json` already supplies definitions.
+2. **Environment variables** — `AIMEE_DELEGATE_KEY_<AGENT>` (e.g.
+   `AIMEE_DELEGATE_KEY_MISTRAL`), for quick `docker run` / env-only deploys.
+
+For each `(agent, secret)` whose agent exists in `agents.json` and which is **not
+already present** in the vault, seal it under the server principal. Then **scrub
+the source** from the process environment after ingestion (the file stays
+operator-owned/read-only; we never copy plaintext into `$AIMEE_HOME`).
+
+### Where it hooks
+
+- **Server boot** (`src/server/…` startup, after vault unseal, before the compute
+  pool accepts delegate work): the bootstrap pass is in-process so it uses the
+  server principal directly — no attested-client requirement, no RPC.
+- **Container entrypoints** (`deploy/container/combined-entrypoint.sh`,
+  `server-entrypoint.sh`): document/pass `AIMEE_DELEGATE_SECRETS_FILE`; the
+  compose files and the SmoothNAS plugin config gain an optional secrets mount.
+  No secret is ever baked into an image.
+
+### Idempotence & precedence
+
+- Vault-present wins: an already-vaulted `(agent, cred)` is left untouched (the
+  bootstrap never overwrites a rotated/operator-set value unless
+  `AIMEE_DELEGATE_SECRETS_OVERWRITE=1`).
+- Bootstrap runs every boot but is a no-op once the vault is populated, so
+  restarts and recreates are cheap and safe.
+
+## Out of scope
+
+- The vault sealing/storage mechanism itself (already shipped:
+  `handle_vault_set_server`, server-master-key wrap).
+- OAuth/subscription delegates that mint per-request creds (codex OAuth) — those
+  follow their own path; this is for static API-key delegates.
+- Multi-user/`uid:`/`webuser:` principal vaults — this provisions the **server
+  principal** vault that backgrounded delegates and roundtables use.
+- Key rotation UX (covered by existing `vault set` / `vault rekey`).
+
+## Risks
+
+- **Secret hygiene.** The whole point is to avoid plaintext-at-rest: the secrets
+  file must stay operator-owned and read-only, env vars must be scrubbed
+  post-ingestion, and nothing may be written into `$AIMEE_HOME` or logs. An audit
+  line (`vault_audit_server_write`) should record *that* a cred was provisioned,
+  never its value.
+- **Wrong-source clobber.** Default must be non-destructive (never overwrite an
+  existing vaulted cred) so a deploy can't silently revert a rotated key.
+- **Boot ordering.** Must run after vault unseal and before the delegate pool
+  serves, or the first roundtable after a cold start still 401s.
+- **Definition/secret mismatch.** A secret for an agent missing from
+  `agents.json` should warn (not fail boot).
+
+## Acceptance criteria
+
+1. A fresh combined-image stack started with a delegate secrets file/env comes up
+   with a populated vault; `aimee delegate review … --via mistral` succeeds with
+   **zero** manual `vault set`.
+2. No plaintext secret is written to `$AIMEE_HOME`, the image, or logs; env
+   secrets are scrubbed after ingestion; an audit line records the provisioning
+   event without the value.
+3. Re-running/recreating the container does not overwrite an existing vaulted
+   cred (unless the explicit overwrite flag is set) and is otherwise a no-op.
+4. A secret naming an agent absent from `agents.json` warns and is skipped; boot
+   still succeeds.
+5. The remote roundtable path that 401'd against `.254` (v0.2.85) succeeds once
+   the server is re-provisioned this way — verified end to end.

--- a/docs/proposals/pending/auto-vault-provisioning-at-server-standup.plan.md
+++ b/docs/proposals/pending/auto-vault-provisioning-at-server-standup.plan.md
@@ -1,0 +1,101 @@
+# Implementation plan — Automatic delegate-vault provisioning at standup
+
+Plan for [auto-vault-provisioning-at-server-standup.md](auto-vault-provisioning-at-server-standup.md).
+Grounded in `origin/testing` (server v0.2.85 line). Default-safe, no new always-on
+behavior beyond an idempotent boot pass that no-ops when no secret source is set.
+
+## Key existing primitives (already on testing — reuse, don't rebuild)
+
+| Primitive | Where | Use |
+|-----------|-------|-----|
+| `vault_service_set_server(agent, cred, secret)` | `vault_service.c` | **Autonomous seal** under the server principal; derives the server KEK from the master key (`vault_server_kek`), creates the vault file, fail-closed if no KEK. No unlock/attestation needed. |
+| `vault_store_has_entry(principal, agent, cred)` | `vault_store.h` | Idempotence check (don't overwrite an existing cred). |
+| `VAULT_SERVER_PRINCIPAL` (`"server"`), `VAULT_API_KEY_CRED` (`"api_key"`) | `vault_service.h` | Principal + cred name for static API-key delegates. |
+| `server_run_kb_bootstrap()` | `server.c:511`, invoked ~`:668` | **Precedent**: a boot-time bootstrap pass. Mirror it with `server_run_vault_bootstrap()`. |
+| agent definitions loader | `agent_config.c` (`agents.json`) | Validate that a supplied secret names a known agent. |
+| `ATTEST_TLS_BEARER` | `vault_principal.h` | Future complementary remote path (see WP-D). |
+
+Delegates already resolve **vault-first** (`delegate_credential_retry.c`), so once
+the server-principal vault holds `api_key` for an agent, delegate/roundtable calls
+authenticate with no further change.
+
+## Work packets
+
+### WP-A — Boot-time vault bootstrap pass (core)
+- Add `static int server_run_vault_bootstrap(void)` to `src/server/server.c`,
+  invoked from the same boot vicinity as `server_run_kb_bootstrap()` (after the
+  vault subsystem/master key are available, **before** the compute pool serves
+  delegate work, i.e. before `server_run()` starts the HTTP accept thread).
+- Resolve the secret source, in precedence order:
+  1. `AIMEE_DELEGATE_SECRETS_FILE` → a JSON object `{ "<agent>": "<key>", … }`
+     (default unset; e.g. `/run/secrets/aimee-delegates.json`). Parse with cJSON.
+  2. `AIMEE_DELEGATE_KEY_<AGENT>` env vars (uppercased agent name; map back to the
+     real agent name case-insensitively against `agents.json`).
+- For each `(agent, secret)`:
+  - Skip + `LOG_WARN` if `agent` is absent from `agents.json` (don't fail boot).
+  - If `vault_store_has_entry(VAULT_SERVER_PRINCIPAL, agent, VAULT_API_KEY_CRED)`
+    and `AIMEE_DELEGATE_SECRETS_OVERWRITE` is unset → skip (non-destructive).
+  - Else `vault_service_set_server(agent, VAULT_API_KEY_CRED, secret)`; on
+    non-`VAULT_OK`, `LOG_ERROR` and continue (one bad cred must not wedge boot).
+- No-op (return early) when neither source is set — zero behavior change for
+  existing deploys.
+- **Secret hygiene:** after ingestion, `unsetenv` each `AIMEE_DELEGATE_KEY_*`;
+  `OPENSSL_cleanse` the in-memory secret buffers and the parsed JSON strings;
+  never write a secret into `$AIMEE_HOME` or any log. The secrets file stays
+  operator-owned/read-only (we only read it).
+
+### WP-B — Audit + observability
+- Emit one `aimee_log(LOG_INFO, "vault.bootstrap", …)` per provisioned agent with
+  **counts/fingerprints only** (reuse the `vault_cred_fingerprint()` style already
+  in `server_vault.c:168`), never the secret. Summarize: `provisioned=N skipped=M
+  unknown=K`.
+- `aimee status` / kb-style health unaffected; optional: surface
+  `vault_server_creds=N` in a status field (stretch, not required).
+
+### WP-C — Container + compose wiring
+- `deploy/container/combined-entrypoint.sh` and `server-entrypoint.sh`: pass through
+  `AIMEE_DELEGATE_SECRETS_FILE` / `AIMEE_DELEGATE_KEY_*` to the dropped-priv
+  `aimee-server` exec (they already forward env; just document + don't strip).
+- `compose.combined.yaml` / `compose.server.yaml`: add a commented optional Docker
+  secret / read-only bind mount example for `aimee-delegates.json` and the env
+  form. **Never bake a secret into an image.**
+- SmoothNAS plugin config (`deploy/smoothnas/…`): document the secrets-file/env
+  field so a `.254`-style deploy provisions on standup.
+
+### WP-D — (Optional, follow-on) remote provisioning over native TLS
+- Once [native-tls-thin-client-backends.md](native-tls-thin-client-backends.md)
+  lands, `ATTEST_TLS_BEARER` already authorizes server-principal writes over a
+  confidential bearer channel — so an operator could `aimee vault set --server`
+  remotely over `https://` instead of mounting a file. Note as complementary; not
+  required for WP-A..C and not in this plan's critical path.
+
+## Tests (WP-A/B)
+- New `src/tests/test_vault_bootstrap.c`:
+  - temp `AIMEE_HOME` + server master key fixture; fake `agents.json` with one
+    known agent.
+  - secrets-file path: asserts the cred is sealed (`vault_store_has_entry` true
+    afterward) and **decrypts back** to the input via the server KEK.
+  - env path: `AIMEE_DELEGATE_KEY_<AGENT>` provisions; env var is unset afterward.
+  - idempotence: second run does not overwrite (and overwrite flag does).
+  - unknown agent: warns, skips, boot returns success.
+  - hygiene: no plaintext secret present in any file under `$AIMEE_HOME` after the
+    pass (grep the tree in-test).
+- Wire the test into the Makefile test target; stub any server objects the test
+  link pulls in (per the usual test-link discipline).
+
+## Acceptance (maps to proposal criteria)
+1. Fresh combined stack + secrets file/env → populated vault; `aimee delegate
+   review … --via mistral` succeeds with zero manual `vault set`. (WP-A,C)
+2. No plaintext at rest / in logs; env scrubbed; audit records the event w/o value. (WP-A,B + test)
+3. Recreate is a non-destructive no-op unless overwrite flag set. (WP-A + test)
+4. Unknown-agent secret warns + skips; boot still succeeds. (WP-A + test)
+5. The `.254` roundtable that 401'd succeeds after a re-provisioned standup. (live verify, user-gated)
+
+## Risks / sequencing
+- Boot-ordering is the main correctness risk: the pass must run after the master
+  key is loadable (so `vault_server_kek` succeeds) and before delegates serve.
+  `vault_service_set_server` is fail-closed (no KEK → `VAULT_ERR_CRYPTO`, never
+  plaintext), so a too-early call degrades to "not provisioned", not a leak.
+- This is the **gating dependency** for live roundtables — landing WP-A..C and
+  re-provisioning `.254` unblocks the roundtable flow for every other proposal,
+  including [native-tls-thin-client-backends.md](native-tls-thin-client-backends.md).

--- a/docs/proposals/pending/mtls-client-identity.md
+++ b/docs/proposals/pending/mtls-client-identity.md
@@ -1,0 +1,211 @@
+# mTLS client identity: per-client certs as attested principals
+
+- **State:** proposed; awaiting roundtable + user proposal-gate.
+- **Scope:** deterministic / server transport + auth + PKI lifecycle. Not an
+  intelligence-surface proposal (no Architecture Charter role).
+- **Author:** JBailes, 2026-06-17.
+- **Builds on:** the native-TLS thin-client backends (Schannel/Secure
+  Transport/OpenSSL behind `aimee_tls.h`) and the server's existing in-process
+  TLS termination (`server_tls.c`, `server_api_tls_port`).
+
+## Problem
+
+Over the network, every aimee client authenticates with a **single shared
+bearer token**. The bearer is anonymous and all-or-nothing: the server cannot
+tell two TCP/TLS clients apart, and `aimee.api.remote_writes` gates the *whole*
+listener, not per client. The current native-TLS path makes this explicit —
+`ATTEST_TLS_BEARER` collapses every TLS+bearer connection to the **server**
+principal (`server_tls.c`: "plain server TLS — the bearer is the authority").
+
+Consequences:
+- **No attribution.** Audit/`vault_audit_*` over the network records the server
+  principal, not *who* acted.
+- **No per-client scoping.** Every networked client gets the same capabilities
+  and the same (server) vault; there is no per-developer vault or per-client
+  `remote_writes` tier.
+- **No targeted revocation.** A leaked bearer forces a rotation that breaks
+  *every* client at once.
+
+By contrast, the **local** UDS path already has per-user identity
+(`ATTEST_UDS_PEERCRED` → `uid:<n>`), and webchat has `webuser:<name>`. The
+network path is the one place identity degrades to a shared secret.
+
+## Goal
+
+Give each networked client an **individual, attested identity** via mutual TLS
+with a **self-generated** (private) CA: a verified client certificate becomes a
+distinct principal that the *existing* capability / per-principal-vault / audit
+machinery keys off — so attribution, per-client scoping, per-client vaults, and
+**revoke-one-without-rotating-everyone** all follow. No external/public PKI:
+aimee owns both ends and trusts only its own CA.
+
+## Why this fits aimee's existing model
+
+The server already resolves a connection to an attested principal in **one
+place** — `server_http_identity_capture()` calls
+`vault_principal_resolve(is_tcp, is_tls, peer_uid, webuser, webuser_token_ok, …)`
+and writes `conn->attested_transport` + `conn->vault_principal`. Everything
+downstream (capabilities `vault_capability_*`, `remote_writes` gating,
+per-principal vaults, audit) is already principal-keyed. mTLS adds **one more
+identity source** to that resolver; the rest is reuse. The server also already
+terminates TLS in-process (`server_tls_init`/`server_tls_accept`), so this is an
+extension of an existing listener, not a new one.
+
+## Design
+
+### WP-A — Server: request + verify client certs
+- Extend `server_tls_init` (`server_tls.c`) to, when mTLS is enabled, set
+  `SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER | SSL_VERIFY_FAIL_IF_NO_PEER_CERT, cb)`
+  and `SSL_CTX_load_verify_locations(ctx, <config>/tls/client-ca.crt, NULL)` so
+  the chain is verified against aimee's own CA. The verify `cb` also enforces
+  revocation (WP-C) and is **fail-closed** (any verify error → handshake fails).
+- New config `aimee.api.mtls` = `off` (default) | `optional` | `required`.
+  `optional` requests a cert but still allows bearer-only (mixed fleet during
+  rollout); `required` rejects a TLS connection with no/invalid client cert.
+- After `SSL_accept`, expose the peer identity: new
+  `server_tls_peer_identity(SSL *, char *out, size_t)` → the leaf cert's CN (or a
+  designated SAN), plus its serial for revocation.
+
+### WP-B — Identity wiring (the small, high-leverage change)
+- New transport `ATTEST_MTLS_CLIENT` in `vault_principal.h`, mapping to a
+  `cert:<CN>` principal (a namespace distinct from `uid:`/`webuser:`/server).
+- In `server_http_identity_capture()`, when `is_tls` and a verified peer cert is
+  present, pass its CN into `vault_principal_resolve`, which emits
+  `(ATTEST_MTLS_CLIENT, "cert:<CN>")`. Fail-closed: `required` mode with no/invalid
+  cert → empty principal (no access), exactly as a missed hop already collapses to
+  `ATTEST_NONE`.
+- No downstream changes: caps, `remote_writes`, vault, and audit consume the
+  principal unchanged. Per-client `remote_writes`/capability grants become
+  expressible because the principal is now per client.
+
+### WP-C — Self-generated PKI lifecycle
+- **CA**: an aimee-owned CA created on demand; its private key is **sealed in the
+  existing server vault** (reuse `vault_crypto` / the server-master-key wrap) so
+  it is never plaintext at rest. Issuance is operator-gated.
+- **Commands**: `aimee cert issue <client-name>` (CN=`<client-name>`, short-lived,
+  returns cert+key or signs a CSR), `aimee cert list`, `aimee cert revoke <name|serial>`.
+- **Revocation = online DB1 serial denylist** checked in the verify callback (no
+  CRL distribution problem; revoke takes effect on the next handshake). Fail-closed
+  if the denylist can't be read.
+- **Enrollment bootstrap**: a one-time, **bearer-authenticated** `/v1/cert/enroll`
+  that issues a client cert (server-generated keypair or CSR sign), solving the
+  first-hand-off trust problem by leaning on the existing shared bearer for
+  enrollment only. After enrollment the client uses its cert, not the bearer.
+
+### WP-D — Client: present a client certificate
+The thin client loads its identity (`<aimee_home>/tls/client.{crt,key}`) and
+presents it via each `aimee_tls.h` backend:
+- OpenSSL (Linux): `SSL_CTX_use_certificate_file` + `SSL_CTX_use_PrivateKey_file`.
+- Schannel (Windows): supply the client cert in `SCHANNEL_CRED.paCred` (imported
+  from a PFX or the user cert store).
+- Secure Transport (macOS): `SSLSetCertificate` with a `SecIdentityRef` from a
+  PKCS#12.
+This is the piece the native-TLS proposal explicitly deferred (mTLS was out of
+scope there); it is additive, gated on the client actually having a cert.
+
+## Hardening requirements (from roundtable R1: architect + security + QA)
+
+No lens found a design blocker; these are the must-address specifics before
+implementation.
+
+### Identity integrity (security-critical)
+- **CN/SAN sanitization — prevent principal spoofing.** The `cert:<CN>` principal
+  MUST be isolated from `uid:`/`webuser:`/server namespaces and rejected if the CN
+  contains anything outside a strict charset (e.g. `[A-Za-z0-9._-]`, bounded
+  length). A CN like `uid:0`, one embedding `:`/newlines/path-traversal, or one
+  colliding with a real uid/webuser must be **refused at issuance** and, defensively,
+  **re-validated at identity resolution** (a malformed/!charset CN → empty principal,
+  fail-closed). The `cert:` prefix is applied by the server, never taken from the cert.
+- **CN vs SAN precedence.** Pin exactly which field is the identity: use a single
+  designated SAN (e.g. the first DNS/URI SAN) or the CN, documented and consistent;
+  do not silently fall back in a way that lets a cert present two identities.
+
+### Mode + downgrade
+- **`optional` mode is a documented downgrade.** With `optional`, a leaked bearer
+  can omit a client cert and revert to the shared server principal — losing
+  attribution/revocation. Document this explicitly; recommend `required` for
+  production. In `optional`, if a client **does** present a (valid) cert, the
+  cert identity MUST win over bearer-only (no silently ignoring a presented cert).
+
+### Enrollment + revocation
+- **Enrollment is not just the shared bearer.** `/v1/cert/enroll` must add at least
+  one of: operator approval, or **one-time, short-lived enrollment tokens** (not the
+  long-lived shared bearer), so a bearer leak during rollout can't mint rogue client
+  identities. Rate-limit + audit every enrollment. (Also define an out-of-band path
+  for clients that can't present the bearer, e.g. CI runners — operator-issued cert.)
+- **Revocation: atomic + available, still fail-closed.** The denylist read in the
+  verify callback must be consistent (transactional/locked update; atomic read).
+  Balance fail-closed against a DoS: a *transient* DB1 read error should fall back to
+  a recent in-memory denylist snapshot (fail-closed against *known* revocations)
+  rather than blocking **all** handshakes; a missing denylist store at startup is a
+  hard config error. Define revocation propagation latency (single-server: immediate
+  on next handshake).
+
+### Lifecycle (CA + certs)
+- **CA rotation procedure** (issue under a new CA, dual-trust both CAs during
+  migration, reissue clients, retire the old CA) — must not break existing clients.
+- **Cert expiry + renewal.** Short-lived client certs need `aimee cert renew` (or
+  auto-renew before expiry); document the NTP/clock-skew expectation, and make the
+  validity window wide enough that normal drift can't cause a fleet-wide outage.
+- **PKI audit.** `aimee cert issue/revoke/renew` and enrollment each emit an audit
+  record (who/when/serial/CN), never the key material.
+
+### Client-side
+- **Key protection + backend formats.** The client key file is created `0600`
+  (refuse world-readable); optional passphrase. Document the per-backend cert source:
+  OpenSSL PEM cert+key files, Schannel cert from a PFX/the user store, Secure
+  Transport `SecIdentityRef` from a PKCS#12 — with a unified config knob and clear
+  load-failure errors.
+
+## Out of scope
+- **Replacing the bearer.** mTLS + bearer coexist; `optional` mode keeps bearer-only
+  clients working. The UDS path (peercred) is unchanged.
+- **SSE/streaming over TLS** — already unsupported (`server_tls.h` phase 1c: an
+  offloaded SSE worker can't share the `SSL`). Interactive `chat`/event streams over
+  mTLS inherit that limitation until phase 1c lands; the data/RPC plane works now.
+- External/public CAs, ACME, hardware-backed keys (HSM/TPM), cert transparency.
+
+## Risks
+- **CA key compromise = forge any client.** Mitigate: seal the CA key in the vault,
+  operator-gate issuance, keep certs short-lived, support fast revocation. Consider
+  keeping the CA key offline (issue out-of-band) for high-security deployments.
+- **Enrollment bootstrap** still trusts the shared bearer for the *first* cert; a
+  leaked bearer during the rollout window could enroll a rogue client. Scope `/v1/cert/enroll`
+  tightly (rate-limit, audit, optionally operator-approve).
+- **Streaming gap** (phase 1c): mTLS doesn't help interactive chat over the network
+  until SSE-over-TLS exists; set expectations.
+- **Fail-closed everywhere**: a verify-cb error, an unreadable denylist, or an empty
+  CN must deny, never default-allow (mirror the existing `ATTEST_NONE`/no-`uid:0`
+  discipline).
+- **Principal namespace**: `cert:<CN>` must not collide with `uid:`/`webuser:`;
+  CN uniqueness is enforced at issuance.
+- **Clock skew** affects short-lived cert validity; document an NTP expectation.
+
+## Acceptance criteria
+1. A client presenting a valid aimee-CA-issued cert is identified as a distinct
+   `cert:<CN>` principal; audit, capabilities, and the per-principal vault all key
+   off it (two different client certs → two different principals).
+2. `mtls=required`: a TLS connection with no client cert, an expired cert, a cert
+   from an unknown CA, or a **revoked** serial is refused (fail-closed). `mtls=optional`:
+   bearer-only still works.
+3. Per-client scoping demonstrably works: one client can be granted a capability /
+   `remote_writes` tier that another is not, and a revoked client loses access on its
+   next connection without affecting others.
+4. `aimee cert issue/list/revoke` manage the lifecycle; the CA private key is never
+   written in plaintext (sealed in the vault).
+5. Client-cert presentation works across all three backends (OpenSSL/Schannel/Secure
+   Transport), validated like the native-TLS backends (CI build + a runtime mTLS
+   handshake test against a local aimee CA), including the per-backend cert source
+   (PEM / PFX / PKCS#12).
+6. **CN/SAN spoofing is rejected**: a cert whose CN is `uid:0`, contains out-of-charset
+   bytes (`:`/newline/path-traversal), or collides with an existing `uid:`/`webuser:`
+   principal is refused at issuance and yields an empty principal at resolution.
+7. **`optional` mode**: a client that presents a valid cert is identified by it (cert
+   identity wins over bearer); a leaked-bearer client with no cert gets only the
+   downgraded server principal — and this downgrade is documented.
+8. **Enrollment** with a one-time/short-lived token (or operator approval) issues a
+   cert; the long-lived shared bearer alone does not, beyond the documented bootstrap
+   window; every issue/revoke/renew is audited (no key material in the log).
+9. **Revocation availability**: a transient denylist read error still rejects a
+   known-revoked serial (snapshot fallback) without blocking valid handshakes; a CA
+   rotation reissues clients without breaking already-trusted ones.


### PR DESCRIPTION
## QUICKSTART rewrite
Replaces the short quick-tour `docs/QUICKSTART.md` with a comprehensive **four-part** guide (the rewrite that was requested):
1. Run the **combined server** in Docker (services, health checks, bearer/remote-writes notes, lifecycle).
2–4. Install + set up the **Linux / Windows / macOS** thin clients — workspaces, agents/delegates, tool hooks, remote target, and the per-platform TLS reality (Linux prebuilt has TLS; Windows/macOS prebuilt are http-only today — with a TLS-support table).

> Note: `testing` already had a 112-line quick-tour QUICKSTART; this replaces it with the fuller install guide. The README already links `QUICKSTART.md`.

## Also
- `README.md`: an "In a hurry?" Quickstart callout in the Install section.
- `MANUAL.md`: §3 Installation points at the Quickstart.
- `docs/proposals/pending/`: the roundtable-reviewed proposals **auto-vault-provisioning-at-server-standup** (+ `.plan`) and **mtls-client-identity**. (`native-tls-thin-client-backends` already landed via #420.)

Docs-only; `proposal-links-check` passes (6 links across 9 files).