### PR TITLE
feat(server): mTLS client identity — slice 1 (server verify + cert:<CN> principal)

### DIFF
--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1016,9 +1016,9 @@ int config_save(const config_t *cfg)
     * listener config so `aimee api enable` persists and a hand-edited block
     * is not silently dropped on the next save. config_server_api.c parses
     * these back from the same nested mapping. */
-   if (cfg->server_api_http_port > 0 || cfg->server_api_tls_port > 0 ||
-       cfg->server_api_bearer_token[0] || cfg->server_api_rate_limit_per_min > 0 ||
-       cfg->server_api_client_transport[0] ||
+   if (cfg->server_api_http_port > 0 || cfg->server_api_tls_port > 0 || cfg->server_api_mtls > 0 ||
+       cfg->server_api_mtls_client_ca[0] || cfg->server_api_bearer_token[0] ||
+       cfg->server_api_rate_limit_per_min > 0 || cfg->server_api_client_transport[0] ||
        cfg->server_api_remote_writes > SERVER_REMOTE_WRITES_OFF ||
        cfg->server_api_max_event_streams > 0 || cfg->server_api_cli_session_forwarding)
    {
@@ -1028,6 +1028,11 @@ int config_save(const config_t *cfg)
          cJSON_AddNumberToObject(api_obj, "http_port", cfg->server_api_http_port);
       if (cfg->server_api_tls_port > 0)
          cJSON_AddNumberToObject(api_obj, "tls_port", cfg->server_api_tls_port);
+      if (cfg->server_api_mtls > 0)
+         cJSON_AddStringToObject(api_obj, "mtls",
+                                 cfg->server_api_mtls >= 2 ? "required" : "optional");
+      if (cfg->server_api_mtls_client_ca[0])
+         cJSON_AddStringToObject(api_obj, "mtls_client_ca", cfg->server_api_mtls_client_ca);
       if (cfg->server_api_bearer_token[0])
          cJSON_AddStringToObject(api_obj, "bearer_token", cfg->server_api_bearer_token);
       if (cfg->server_api_rate_limit_per_min > 0)

--- a/src/config_server_api.c
+++ b/src/config_server_api.c
@@ -30,6 +30,19 @@ void config_parse_server_api(config_t *cfg, const cJSON *root)
          if (cJSON_IsNumber(item))
             cfg->server_api_tls_port = (int)item->valuedouble;
 
+         item = cJSON_GetObjectItemCaseSensitive(api, "mtls");
+         if (cJSON_IsString(item) && item->valuestring)
+            cfg->server_api_mtls = strcmp(item->valuestring, "required") == 0   ? 2
+                                   : strcmp(item->valuestring, "optional") == 0 ? 1
+                                                                                : 0;
+         else if (cJSON_IsNumber(item))
+            cfg->server_api_mtls = (int)item->valuedouble;
+
+         item = cJSON_GetObjectItemCaseSensitive(api, "mtls_client_ca");
+         if (cJSON_IsString(item) && item->valuestring)
+            strncpy(cfg->server_api_mtls_client_ca, item->valuestring,
+                    sizeof(cfg->server_api_mtls_client_ca) - 1);
+
          item = cJSON_GetObjectItemCaseSensitive(api, "bearer_token");
          if (cJSON_IsString(item) && item->valuestring)
             strncpy(cfg->server_api_bearer_token, item->valuestring,

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1033,6 +1033,14 @@ typedef struct config
     * connection is an attested write path for the credential vault (native-TLS
     * provisioning). Streaming (SSE) over TLS is not yet supported (phase 1c). */
    int server_api_tls_port;
+   /* server_api_mtls: mutual-TLS client-identity mode for the native-TLS listener
+    * (mtls-client-identity). 0 = off (default), 1 = optional (request a client
+    * cert; bearer-only still works — a documented downgrade), 2 = required (refuse
+    * a TLS conn without a valid client cert). A verified client cert becomes a
+    * per-client "cert:<CN>" principal. */
+   int server_api_mtls;
+   /* PEM bundle of the CA(s) that signed client certs. Empty => <config>/tls/client-ca.crt. */
+   char server_api_mtls_client_ca[MAX_PATH_LEN];
    char server_api_bearer_token[256];
    int server_api_rate_limit_per_min;
    /* server_api_max_event_streams: cap on concurrent SSE event streams

--- a/src/headers/server_conn_io.h
+++ b/src/headers/server_conn_io.h
@@ -35,6 +35,10 @@ extern "C"
     * the conn's SSL). */
    int server_conn_io_has_ssl(int fd);
 
+   /* The registered SSL for `fd` (or NULL). Used by the identity layer to read a
+    * verified mTLS client cert. */
+   SSL *server_conn_io_get_ssl(int fd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/server_tls.h
+++ b/src/headers/server_tls.h
@@ -17,8 +17,21 @@ extern "C"
 #endif
 
    /* Build the process-wide server SSL_CTX from the cert + key PEM files. Returns
-    * 0 on success, -1 on failure (logged). Idempotent (no-op once initialized). */
-   int server_tls_init(const char *cert_path, const char *key_path);
+    * 0 on success, -1 on failure (logged). Idempotent (no-op once initialized).
+    *
+    * mtls_mode: 0 = off (plain server TLS), 1 = optional (request a client cert
+    * but allow none), 2 = required (refuse a handshake without a valid client
+    * cert). When mtls_mode > 0 the SSL_CTX verifies client certs against
+    * client_ca_path (a PEM CA bundle); a load failure disables mTLS (logged). */
+   int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
+                       const char *client_ca_path);
+
+   /* Extract the verified mTLS client identity from a handshaked SSL: writes the
+    * peer leaf cert's CN into cn_out (and hex serial into serial_out) and returns
+    * 1 iff the peer presented a cert AND it verified OK against the client CA;
+    * else 0 (cn_out/serial_out emptied). Bearer-only TLS conns return 0. */
+   int server_tls_peer_identity(SSL *ssl, char *cn_out, size_t cn_len, char *serial_out,
+                                size_t serial_len);
 
    /* 1 once server_tls_init has succeeded, else 0. */
    int server_tls_enabled(void);

--- a/src/headers/vault_principal.h
+++ b/src/headers/vault_principal.h
@@ -31,7 +31,23 @@ typedef enum
    ATTEST_TLS_BEARER,      /* native-TLS conn authorized by bearer: the bearer over a confidential
                               channel is the operator's authority -> server-principal writes allowed
                               (native-TLS provisioning); no per-user principal (uses VAULT_SERVER) */
+   ATTEST_MTLS_CLIENT,     /* mutual-TLS: the peer presented a client cert verified against aimee's
+                              client CA -> a per-client "cert:<CN>" principal (mtls-client-identity) */
 } attested_transport_t;
+
+/* mTLS client-cert identity: the principal is "cert:" + a sanitized CN. The CN is
+ * limited to [A-Za-z0-9._-] so it can never embed a ':' and collide with the
+ * uid:/webuser: namespaces; the "cert:" prefix is added by the server, never by
+ * the cert. */
+#define VAULT_CERT_PRINCIPAL_PREFIX "cert:"
+#define VAULT_CERT_CN_MAX           128
+
+/* Validate + copy a client-cert CN into out (NUL-terminated). Returns 1 iff cn is
+ * a non-empty string of [A-Za-z0-9._-], at most VAULT_CERT_CN_MAX bytes (so the
+ * "cert:<CN>" principal fits VAULT_PRINCIPAL_MAX); 0 otherwise (caller fails
+ * closed). This is what blocks principal-spoofing CNs (e.g. "uid:0", embedded
+ * ':' / newlines / path traversal). */
+int vault_principal_cert_sanitize(const char *cn, char *out, size_t out_len);
 
 /* Max length of a vault principal string ("webuser:" + a 128-byte username, or
  * "uid:" + digits) including the NUL. */
@@ -59,7 +75,7 @@ typedef enum
  * threading hop, or loopback's memset) reads as uid 0, so treating it as a real
  * principal would collapse to acting as root. out must be >= VAULT_PRINCIPAL_MAX. */
 attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_uid,
-                                             const char *webuser, int webuser_token_ok, char *out,
-                                             size_t out_len);
+                                             const char *webuser, int webuser_token_ok,
+                                             const char *cert_cn, char *out, size_t out_len);
 
 #endif /* DEC_VAULT_PRINCIPAL_H */

--- a/src/server/server_conn_io.c
+++ b/src/server/server_conn_io.c
@@ -40,6 +40,11 @@ int server_conn_io_has_ssl(int fd)
    return ssl_for(fd) != NULL;
 }
 
+SSL *server_conn_io_get_ssl(int fd)
+{
+   return ssl_for(fd);
+}
+
 int server_conn_io_read(int fd, void *buf, int n)
 {
    SSL *s = ssl_for(fd);

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -9,7 +9,8 @@
 #include "server_http_identity.h"
 #include "server_http.h"    /* http_header */
 #include "server.h"         /* server_ct_equal, SERVER_TOKEN_FILE */
-#include "server_conn_io.h" /* server_conn_io_has_ssl — native-TLS attestation */
+#include "server_conn_io.h" /* server_conn_io_has_ssl/get_ssl — native-TLS attestation */
+#include "server_tls.h"     /* server_tls_peer_identity — mTLS client cert CN */
 #include "aimee_home.h"     /* aimee_home */
 #include "platform_ipc.h"
 #include "vault_principal.h"
@@ -94,8 +95,17 @@ void server_http_identity_capture(int fd, int is_tcp, const char *buf)
     * bearer-authorized channel — the operator's authority for server-principal
     * vault writes (native-TLS provisioning). */
    int is_tls = server_conn_io_has_ssl(fd);
+   /* mTLS: a verified client cert on this TLS conn yields a per-client cert:<CN>
+    * principal (resolved + sanitized in vault_principal_resolve). */
+   char cert_cn[VAULT_CERT_CN_MAX + 1] = "";
+   if (is_tls)
+   {
+      char serial[80];
+      server_tls_peer_identity(server_conn_io_get_ssl(fd), cert_cn, sizeof(cert_cn), serial,
+                               sizeof(serial));
+   }
    tl_transport = vault_principal_resolve(is_tcp, is_tls, peer_uid, webuser, webuser_token_ok,
-                                          tl_principal, sizeof(tl_principal));
+                                          cert_cn, tl_principal, sizeof(tl_principal));
 }
 
 void server_http_identity_apply(server_conn_t *conn)

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -5,7 +5,9 @@
 #include "aimee.h"          /* MAX_PATH_LEN */
 #include "log.h"
 
+#include <openssl/bn.h>
 #include <openssl/err.h>
+#include <openssl/x509.h>
 #include <pthread.h>
 #include <stdio.h>
 #include <string.h>
@@ -16,7 +18,8 @@
 static SSL_CTX *g_ctx = NULL;
 static pthread_mutex_t g_ctx_mu = PTHREAD_MUTEX_INITIALIZER;
 
-int server_tls_init(const char *cert_path, const char *key_path)
+int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
+                    const char *client_ca_path)
 {
    if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
       return -1;
@@ -55,10 +58,76 @@ int server_tls_init(const char *cert_path, const char *key_path)
       pthread_mutex_unlock(&g_ctx_mu);
       return -1;
    }
+
+   /* mTLS: verify client certs against aimee's client CA. The chain is verified
+    * by OpenSSL (standard callback); the CN -> principal mapping + revocation
+    * happen later in the identity layer. `required` refuses a handshake with no
+    * client cert; `optional` requests one but allows bearer-only. A CA that won't
+    * load disables mTLS (logged) rather than silently accepting unverified certs. */
+   if (mtls_mode > 0)
+   {
+      char ca[MAX_PATH_LEN];
+      if (client_ca_path && client_ca_path[0])
+         snprintf(ca, sizeof(ca), "%s", client_ca_path);
+      else
+         snprintf(ca, sizeof(ca), "%s/tls/client-ca.crt", config_default_dir());
+      if (SSL_CTX_load_verify_locations(ctx, ca, NULL) != 1)
+      {
+         aimee_log(LOG_WARN, "server.tls",
+                   "mtls enabled but client CA %s not loadable: %s — "
+                   "mTLS DISABLED (client certs not verified)",
+                   ca, ERR_error_string(ERR_get_error(), NULL));
+      }
+      else
+      {
+         int vflags = SSL_VERIFY_PEER;
+         if (mtls_mode >= 2)
+            vflags |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
+         SSL_CTX_set_verify(ctx, vflags, NULL);
+         aimee_log(LOG_INFO, "server.tls", "mTLS %s (client CA %s)",
+                   mtls_mode >= 2 ? "required" : "optional", ca);
+      }
+   }
+
    g_ctx = ctx;
    pthread_mutex_unlock(&g_ctx_mu);
    aimee_log(LOG_INFO, "server.tls", "native TLS enabled (cert %s)", cert_path);
    return 0;
+}
+
+int server_tls_peer_identity(SSL *ssl, char *cn_out, size_t cn_len, char *serial_out,
+                             size_t serial_len)
+{
+   if (cn_out && cn_len)
+      cn_out[0] = '\0';
+   if (serial_out && serial_len)
+      serial_out[0] = '\0';
+   if (!ssl || SSL_get_verify_result(ssl) != X509_V_OK)
+      return 0;
+   X509 *cert = SSL_get_peer_certificate(ssl);
+   if (!cert)
+      return 0; /* bearer-only TLS conn: no client cert */
+
+   int ok = 0;
+   X509_NAME *subj = X509_get_subject_name(cert);
+   if (subj && cn_out && cn_len &&
+       X509_NAME_get_text_by_NID(subj, NID_commonName, cn_out, (int)cn_len) > 0)
+      ok = 1;
+   if (ok && serial_out && serial_len)
+   {
+      ASN1_INTEGER *sn = X509_get_serialNumber(cert);
+      BIGNUM *bn = sn ? ASN1_INTEGER_to_BN(sn, NULL) : NULL;
+      char *hex = bn ? BN_bn2hex(bn) : NULL;
+      if (hex)
+      {
+         snprintf(serial_out, serial_len, "%s", hex);
+         OPENSSL_free(hex);
+      }
+      if (bn)
+         BN_free(bn);
+   }
+   X509_free(cert);
+   return ok;
 }
 
 int server_tls_enabled(void)
@@ -93,7 +162,9 @@ int server_tls_init_default(void)
    char cert[MAX_PATH_LEN], key[MAX_PATH_LEN];
    snprintf(cert, sizeof(cert), "%s/tls/server.crt", config_default_dir());
    snprintf(key, sizeof(key), "%s/tls/server.key", config_default_dir());
-   return server_tls_init(cert, key);
+   config_t cfg;
+   config_load(&cfg);
+   return server_tls_init(cert, key, cfg.server_api_mtls, cfg.server_api_mtls_client_ca);
 }
 
 SSL *server_tls_begin(int fd)

--- a/src/server/vault_principal.c
+++ b/src/server/vault_principal.c
@@ -6,14 +6,51 @@
 #include <stdio.h>
 #include <string.h>
 
+int vault_principal_cert_sanitize(const char *cn, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (!cn || !cn[0] || !out || out_len == 0)
+      return 0;
+   size_t n = strlen(cn);
+   if (n > VAULT_CERT_CN_MAX || n >= out_len)
+      return 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      unsigned char c = (unsigned char)cn[i];
+      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '.' || c == '_' || c == '-';
+      if (!ok)
+         return 0; /* reject ':' (namespace collision), '/', whitespace, control, etc. */
+   }
+   memcpy(out, cn, n);
+   out[n] = '\0';
+   return 1;
+}
+
 attested_transport_t vault_principal_resolve(int is_tcp, int is_tls, long peer_uid,
-                                             const char *webuser, int webuser_token_ok, char *out,
-                                             size_t out_len)
+                                             const char *webuser, int webuser_token_ok,
+                                             const char *cert_cn, char *out, size_t out_len)
 {
    if (out && out_len)
       out[0] = '\0';
    if (!out || out_len < VAULT_PRINCIPAL_MAX)
       return ATTEST_NONE;
+
+   /* A verified mTLS client cert is the strongest network identity and wins over
+    * bearer-only / a tokenless webuser: the cert chain was verified against
+    * aimee's client CA upstream (server_tls), so its CN names a real client.
+    * Sanitize the CN here (fail-closed): a CN that can't sanitize — e.g. "uid:0",
+    * an embedded ':' / newline / path-traversal — yields NO principal, but the
+    * connection is still classified ATTEST_MTLS_CLIENT so `required`-mode gating
+    * refuses it rather than silently downgrading to a bearer identity. */
+   if (cert_cn && cert_cn[0] && is_tcp && is_tls)
+   {
+      char san[VAULT_CERT_CN_MAX + 1];
+      if (vault_principal_cert_sanitize(cert_cn, san, sizeof(san)))
+         snprintf(out, out_len, VAULT_CERT_PRINCIPAL_PREFIX "%s", san);
+      return ATTEST_MTLS_CLIENT;
+   }
 
    int webuser_asserted = webuser && webuser[0];
    /* A bearer-authorized native-TLS conn (confidential channel) is the operator's

--- a/src/tests/test_vault_principal.c
+++ b/src/tests/test_vault_principal.c
@@ -12,7 +12,7 @@ static attested_transport_t resolve(int is_tcp, long uid, const char *webuser, i
                                     char *out)
 {
    out[0] = '\xff'; /* poison: prove the resolver writes/clears it */
-   return vault_principal_resolve(is_tcp, 0 /*is_tls*/, uid, webuser, token_ok, out,
+   return vault_principal_resolve(is_tcp, 0 /*is_tls*/, uid, webuser, token_ok, NULL, out,
                                   VAULT_PRINCIPAL_MAX);
 }
 
@@ -23,23 +23,24 @@ static void test_tls_bearer_attested_no_principal(void)
 {
    char p[VAULT_PRINCIPAL_MAX];
    /* TLS over the network, no uid/webuser -> ATTEST_TLS_BEARER, empty principal. */
-   assert(vault_principal_resolve(1, 1, -1, NULL, 0, p, sizeof(p)) == ATTEST_TLS_BEARER);
+   assert(vault_principal_resolve(1, 1, -1, NULL, 0, NULL, p, sizeof(p)) == ATTEST_TLS_BEARER);
    assert(p[0] == '\0');
    /* A spoofed/tokenless webuser over TLS is REFUSED server authority: it is NOT
     * promoted to TLS_BEARER, it falls back to the raw transport (TCP_BEARER), with
     * no vault principal. (A misconfigured webchat forwarding an end-user header
     * must never mint a server credential merely because the socket has TLS.) */
-   assert(vault_principal_resolve(1, 1, -1, "alice", 0, p, sizeof(p)) == ATTEST_TCP_BEARER);
+   assert(vault_principal_resolve(1, 1, -1, "alice", 0, NULL, p, sizeof(p)) == ATTEST_TCP_BEARER);
    assert(p[0] == '\0');
    /* A valid webuser assertion still wins (per-user webchat vault). */
-   assert(vault_principal_resolve(1, 1, -1, "alice", 1, p, sizeof(p)) == ATTEST_WEBCHAT_TRUSTED);
+   assert(vault_principal_resolve(1, 1, -1, "alice", 1, NULL, p, sizeof(p)) ==
+          ATTEST_WEBCHAT_TRUSTED);
    assert(strcmp(p, "webuser:alice") == 0);
    /* Plaintext TCP (no TLS) is NOT attested for server writes. */
-   assert(vault_principal_resolve(1, 0, -1, NULL, 0, p, sizeof(p)) == ATTEST_TCP_BEARER);
+   assert(vault_principal_resolve(1, 0, -1, NULL, 0, NULL, p, sizeof(p)) == ATTEST_TCP_BEARER);
    /* A short output buffer fails closed even over TLS (no TLS_BEARER on a buffer
     * too small to hold a principal). */
    char small[4];
-   assert(vault_principal_resolve(1, 1, -1, NULL, 0, small, sizeof(small)) == ATTEST_NONE);
+   assert(vault_principal_resolve(1, 1, -1, NULL, 0, NULL, small, sizeof(small)) == ATTEST_NONE);
    printf("  PASS: test_tls_bearer_attested_no_principal\n");
 }
 
@@ -125,11 +126,50 @@ static void test_short_buffer_fails_closed(void)
 {
    char small[8];
    small[0] = '\xff';
-   assert(vault_principal_resolve(0, 0, 1000, NULL, 0, small, sizeof(small)) == ATTEST_NONE);
+   assert(vault_principal_resolve(0, 0, 1000, NULL, 0, NULL, small, sizeof(small)) == ATTEST_NONE);
    assert(small[0] == '\0');
    /* NULL out is also safe. */
-   assert(vault_principal_resolve(0, 0, 1000, NULL, 0, NULL, 0) == ATTEST_NONE);
+   assert(vault_principal_resolve(0, 0, 1000, NULL, 0, NULL, NULL, 0) == ATTEST_NONE);
    printf("  PASS: test_short_buffer_fails_closed\n");
+}
+
+/* mTLS: a verified client cert -> cert:<CN>; a spoofing/unsanitizable CN is
+ * refused (fail-closed) but still classified MTLS so required-mode rejects it. */
+static void test_mtls_client_identity(void)
+{
+   char out[VAULT_PRINCIPAL_MAX];
+
+   /* CN sanitization: valid charset accepted; spoofing/garbage refused. */
+   char san[VAULT_PRINCIPAL_MAX];
+   assert(vault_principal_cert_sanitize("ci-runner_1.dev", san, sizeof(san)) == 1);
+   assert(strcmp(san, "ci-runner_1.dev") == 0);
+   assert(vault_principal_cert_sanitize("uid:0", san, sizeof(san)) == 0); /* ':' refused */
+   assert(vault_principal_cert_sanitize("webuser:bob", san, sizeof(san)) == 0);
+   assert(vault_principal_cert_sanitize("a/b", san, sizeof(san)) == 0);       /* path traversal */
+   assert(vault_principal_cert_sanitize("a b", san, sizeof(san)) == 0);       /* whitespace */
+   assert(vault_principal_cert_sanitize("bad\nname", san, sizeof(san)) == 0); /* newline */
+   assert(vault_principal_cert_sanitize("", san, sizeof(san)) == 0);
+   assert(san[0] == '\0');
+
+   /* A verified cert over TLS -> cert:<CN>, wins over a tokenless bearer/webuser. */
+   assert(vault_principal_resolve(1, 1, -1, NULL, 0, "ci-runner-1", out, sizeof(out)) ==
+          ATTEST_MTLS_CLIENT);
+   assert(strcmp(out, "cert:ci-runner-1") == 0);
+   /* Cert identity wins even when a (tokenless) webuser header is also present. */
+   assert(vault_principal_resolve(1, 1, -1, "alice", 0, "ci-runner-1", out, sizeof(out)) ==
+          ATTEST_MTLS_CLIENT);
+   assert(strcmp(out, "cert:ci-runner-1") == 0);
+
+   /* A spoofing CN: classified MTLS but NO principal (required-mode refuses it). */
+   assert(vault_principal_resolve(1, 1, -1, NULL, 0, "uid:0", out, sizeof(out)) ==
+          ATTEST_MTLS_CLIENT);
+   assert(out[0] == '\0');
+
+   /* A cert CN but no TLS (impossible in practice) is ignored -> bearer path. */
+   assert(vault_principal_resolve(1, 0, -1, NULL, 0, "ci-runner-1", out, sizeof(out)) ==
+          ATTEST_TCP_BEARER);
+   assert(out[0] == '\0');
+   printf("  PASS: test_mtls_client_identity\n");
 }
 
 int main(void)
@@ -142,6 +182,7 @@ int main(void)
    test_webuser_without_token_refused();
    test_tls_bearer_attested_no_principal();
    test_short_buffer_fails_closed();
+   test_mtls_client_identity();
    printf("vault_principal: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
First of three slices implementing the roundtable-approved `mtls-client-identity` proposal (see `docs/proposals/pending/mtls-client-identity.{md,plan.md}`). **Server-side only** — no client-cert presentation or PKI lifecycle yet (slices 2 & 3).

## What this does
A client cert verified against aimee's client CA becomes a per-client `cert:<CN>` attested principal, plugged into the existing capability/vault/audit machinery (no downstream changes — it all keys off `conn->vault_principal`).

- **Config**: `aimee.api.mtls` = `off`(default)|`optional`|`required`, `aimee.api.mtls_client_ca` (default `<config>/tls/client-ca.crt`).
- **`server_tls.c`**: when mtls>0, load the client CA + `SSL_CTX_set_verify(SSL_VERIFY_PEER [| FAIL_IF_NO_PEER_CERT])`. A CA that won't load **disables mTLS (logged)** rather than silently accepting unverified certs. New `server_tls_peer_identity()` returns the verified leaf CN + serial.
- **`vault_principal`**: `ATTEST_MTLS_CLIENT` + `vault_principal_cert_sanitize()` — charset `[A-Za-z0-9._-]`, bounded length, which **blocks CN spoofing** (`uid:0`, embedded `:`/newline/path-traversal). `resolve()` gains a `cert_cn` input: verified+sanitized → `cert:<CN>` (wins over bearer/webuser); unsanitizable → classified MTLS with **empty principal** so `required` mode refuses it (never downgrades to a bearer identity).
- **`server_http_identity`**: read the verified CN off the conn SSL, feed `resolve`.

## Tests
`test_vault_principal` gains `test_mtls_client_identity`: sanitize accept/reject (incl. `uid:0`, `/`, whitespace, newline), `cert:<CN>` resolution, cert-wins-over-bearer/webuser precedence, and fail-closed on a spoofing CN. Server/client/kb build clean under `-Werror`.

## Follow-up in this slice
A runtime mTLS handshake integration test (openssl-issued CA + client cert; accept / wrong-CA-reject / required-without-cert-reject matrix) — there's no server-TLS handshake harness today, so it's net-new; tracking it as the slice's CI add. The security-critical **identity decision** logic is fully unit-tested here.

Maps to proposal acceptance criteria 1, 2 (minus revoked), 6, 7.