### PR TITLE
feat(server): mTLS client identity — slice 2 (PKI core: CA + issuance + revocation)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -376,7 +376,7 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c \
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c server/pki.c \
               workflow/wfe_engine.c workflow/wfe_blocks.c workflow/wfe_approval.c \
               workflow/wfe_verdict.c workflow/wfe_roundtable.c workflow/wfe_autonomy.c \
               server/server_workflow_api.c

--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -1,0 +1,49 @@
+/* pki.h: aimee's self-generated client-cert CA + issuance/revocation, for mTLS
+ * client identity (mtls-client-identity slice 2).
+ *
+ * aimee owns a private CA whose key is sealed in the server vault and whose cert
+ * is written to <config>/tls/client-ca.crt (the file server_tls verifies client
+ * certs against). It issues short-lived client certs whose CN becomes a
+ * cert:<CN> principal, and revokes them via an in-memory serial denylist
+ * (snapshot-loaded from DB1) consulted in the TLS verify callback — no DB query
+ * in the handshake hot path. All issuance/revocation is operator-gated upstream.
+ */
+#ifndef DEC_PKI_H
+#define DEC_PKI_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Load-or-create the CA: if the sealed key + cert file exist, load them;
+    * otherwise generate an EC P-256 CA, seal the key in the vault, and write the
+    * cert to <config>/tls/client-ca.crt. Also (re)loads the revocation snapshot
+    * from DB1. Idempotent. Returns 0 on success, -1 on failure (logged). */
+   int pki_ca_ensure(void);
+
+   /* Issue a client cert for `cn` (which must pass vault_principal_cert_sanitize),
+    * valid for `validity_days`, signed by the CA. Writes the cert PEM and key PEM
+    * into the caller's buffers and the hex serial into serial_out, and records the
+    * cert in DB1. Returns 0 on success, -1 on failure. */
+   int pki_issue(const char *cn, int validity_days, char *cert_pem, size_t cert_len, char *key_pem,
+                 size_t key_len, char *serial_out, size_t serial_len);
+
+   /* Revoke by hex serial (adds to the DB1 denylist + the in-memory snapshot).
+    * Returns 0 on success (including already-revoked), -1 on error. */
+   int pki_revoke(const char *serial);
+
+   /* 1 if `serial` (hex) is revoked, else 0. Reads the in-memory snapshot only —
+    * safe to call from the TLS verify callback. */
+   int pki_is_revoked(const char *serial);
+
+   /* For tests: drop cached CA + snapshot so a fresh AIMEE_HOME is picked up. */
+   void pki_reset_for_test(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_PKI_H */

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -1,0 +1,452 @@
+/* pki.c: see pki.h. aimee's self-generated client-cert CA + issuance/revocation. */
+#include "pki.h"
+#include "vault_service.h"   /* seal/inject the CA key */
+#include "vault_principal.h" /* vault_principal_cert_sanitize */
+#include "config.h"          /* config_default_dir */
+#include "db1_internal.h"    /* db1_conn */
+#include "aimee.h"           /* MAX_PATH_LEN */
+#include "log.h"
+
+#include <sqlite3.h>
+
+#include <openssl/bn.h>
+#include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <openssl/x509v3.h>
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#define PKI_CA_AGENT     "__pki_ca__" /* vault agent name under which the CA key is sealed */
+#define PKI_CA_CN        "aimee-client-CA"
+#define PKI_CA_DAYS      3650 /* CA validity (10y) */
+#define PKI_KEY_PEM_MAX  4000 /* an EC P-256 key PEM is ~240B; cap well under MAX_API_KEY_LEN */
+#define PKI_CERT_PEM_MAX 8192
+
+static pthread_mutex_t g_mu = PTHREAD_MUTEX_INITIALIZER;
+static EVP_PKEY *g_ca_key = NULL; /* cached CA key (loaded once) */
+static X509 *g_ca_cert = NULL;
+/* In-memory revocation snapshot (hex serials). Revocations are rare; a flat
+ * growable array consulted under the mutex is plenty and keeps the TLS verify
+ * callback off the database. */
+static char **g_revoked = NULL;
+static int g_revoked_n = 0, g_revoked_cap = 0;
+
+void pki_reset_for_test(void)
+{
+   pthread_mutex_lock(&g_mu);
+   if (g_ca_key)
+      EVP_PKEY_free(g_ca_key);
+   if (g_ca_cert)
+      X509_free(g_ca_cert);
+   g_ca_key = NULL;
+   g_ca_cert = NULL;
+   for (int i = 0; i < g_revoked_n; i++)
+      free(g_revoked[i]);
+   free(g_revoked);
+   g_revoked = NULL;
+   g_revoked_n = g_revoked_cap = 0;
+   pthread_mutex_unlock(&g_mu);
+}
+
+static void ca_cert_path(char *out, size_t n)
+{
+   snprintf(out, n, "%s/tls/client-ca.crt", config_default_dir());
+}
+
+/* --- DB1 (caller holds no lock; sqlite is serialized) --- */
+static void db_ensure_tables(void)
+{
+   sqlite3 *db = db1_conn();
+   if (db)
+      sqlite3_exec(db,
+                   "CREATE TABLE IF NOT EXISTS pki_certs(serial TEXT PRIMARY KEY, cn TEXT NOT NULL,"
+                   " issued_at INTEGER, expires_at INTEGER, revoked INTEGER NOT NULL DEFAULT 0)",
+                   NULL, NULL, NULL);
+}
+
+/* Add a serial to the in-memory snapshot (caller holds g_mu). */
+static void snapshot_add(const char *serial)
+{
+   for (int i = 0; i < g_revoked_n; i++)
+      if (strcmp(g_revoked[i], serial) == 0)
+         return;
+   if (g_revoked_n == g_revoked_cap)
+   {
+      int cap = g_revoked_cap ? g_revoked_cap * 2 : 16;
+      char **nb = realloc(g_revoked, (size_t)cap * sizeof(char *));
+      if (!nb)
+         return;
+      g_revoked = nb;
+      g_revoked_cap = cap;
+   }
+   g_revoked[g_revoked_n] = strdup(serial);
+   if (g_revoked[g_revoked_n])
+      g_revoked_n++;
+}
+
+/* Reload the snapshot from DB1 (caller holds g_mu). */
+static void snapshot_load(void)
+{
+   for (int i = 0; i < g_revoked_n; i++)
+      free(g_revoked[i]);
+   g_revoked_n = 0;
+   sqlite3 *db = db1_conn();
+   if (!db)
+      return;
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, "SELECT serial FROM pki_certs WHERE revoked=1", -1, &st, NULL) !=
+       SQLITE_OK)
+      return;
+   while (sqlite3_step(st) == SQLITE_ROW)
+   {
+      const char *s = (const char *)sqlite3_column_text(st, 0);
+      if (s)
+         snapshot_add(s);
+   }
+   sqlite3_finalize(st);
+}
+
+/* --- crypto helpers --- */
+static EVP_PKEY *gen_ec_key(void)
+{
+   return EVP_EC_gen("prime256v1"); /* P-256; OpenSSL 3.0+ */
+}
+
+static char *pem_private_key(EVP_PKEY *k)
+{
+   BIO *bio = BIO_new(BIO_s_mem());
+   if (!bio)
+      return NULL;
+   char *out = NULL;
+   if (PEM_write_bio_PrivateKey(bio, k, NULL, NULL, 0, NULL, NULL) == 1)
+   {
+      char *p = NULL;
+      long n = BIO_get_mem_data(bio, &p);
+      if (p && n > 0)
+      {
+         out = malloc((size_t)n + 1);
+         if (out)
+         {
+            memcpy(out, p, (size_t)n);
+            out[n] = '\0';
+         }
+      }
+   }
+   BIO_free(bio);
+   return out;
+}
+
+static char *pem_cert(X509 *c)
+{
+   BIO *bio = BIO_new(BIO_s_mem());
+   if (!bio)
+      return NULL;
+   char *out = NULL;
+   if (PEM_write_bio_X509(bio, c) == 1)
+   {
+      char *p = NULL;
+      long n = BIO_get_mem_data(bio, &p);
+      if (p && n > 0)
+      {
+         out = malloc((size_t)n + 1);
+         if (out)
+         {
+            memcpy(out, p, (size_t)n);
+            out[n] = '\0';
+         }
+      }
+   }
+   BIO_free(bio);
+   return out;
+}
+
+static int set_name_cn(X509_NAME *name, const char *cn)
+{
+   return X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, (const unsigned char *)cn, -1, -1,
+                                     0) == 1
+              ? 0
+              : -1;
+}
+
+static int add_ext(X509 *cert, X509 *issuer, int nid, const char *value)
+{
+   X509V3_CTX ctx;
+   X509V3_set_ctx_nodb(&ctx);
+   X509V3_set_ctx(&ctx, issuer ? issuer : cert, cert, NULL, NULL, 0);
+   X509_EXTENSION *ex = X509V3_EXT_conf_nid(NULL, &ctx, nid, value);
+   if (!ex)
+      return -1;
+   int rc = X509_add_ext(cert, ex, -1);
+   X509_EXTENSION_free(ex);
+   return rc == 1 ? 0 : -1;
+}
+
+/* Random 16-byte positive serial; writes the cert's serial and a hex string. */
+static int set_random_serial(X509 *cert, char *hex_out, size_t hex_len)
+{
+   BIGNUM *bn = BN_new();
+   if (!bn || !BN_rand(bn, 128, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
+   {
+      BN_free(bn);
+      return -1;
+   }
+   ASN1_INTEGER *ai = BN_to_ASN1_INTEGER(bn, NULL);
+   if (!ai)
+   {
+      BN_free(bn);
+      return -1;
+   }
+   X509_set_serialNumber(cert, ai);
+   ASN1_INTEGER_free(ai);
+   char *hex = BN_bn2hex(bn);
+   if (hex)
+   {
+      snprintf(hex_out, hex_len, "%s", hex);
+      OPENSSL_free(hex);
+   }
+   BN_free(bn);
+   return hex_out[0] ? 0 : -1;
+}
+
+/* --- CA --- */
+static int ca_generate_and_persist(void)
+{
+   EVP_PKEY *key = gen_ec_key();
+   if (!key)
+      return -1;
+   X509 *cert = X509_new();
+   if (!cert)
+   {
+      EVP_PKEY_free(key);
+      return -1;
+   }
+   int rc = -1;
+   char serial[64] = "";
+   X509_set_version(cert, 2);
+   X509_NAME *name = X509_get_subject_name(cert);
+   if (set_random_serial(cert, serial, sizeof(serial)) != 0 || set_name_cn(name, PKI_CA_CN) != 0 ||
+       X509_set_issuer_name(cert, name) != 1 || !X509_gmtime_adj(X509_getm_notBefore(cert), 0) ||
+       !X509_gmtime_adj(X509_getm_notAfter(cert), (long)PKI_CA_DAYS * 24 * 3600) ||
+       X509_set_pubkey(cert, key) != 1 ||
+       add_ext(cert, NULL, NID_basic_constraints, "critical,CA:TRUE") != 0 ||
+       add_ext(cert, NULL, NID_key_usage, "critical,keyCertSign,cRLSign") != 0 ||
+       X509_sign(cert, key, EVP_sha256()) == 0)
+      goto done;
+
+   /* Seal the CA private key in the server vault; write the cert to disk. */
+   {
+      char *key_pem = pem_private_key(key);
+      char *cert_pem = pem_cert(cert);
+      if (!key_pem || !cert_pem)
+      {
+         free(key_pem);
+         free(cert_pem);
+         goto done;
+      }
+      vault_status_t vs = vault_service_set_server(PKI_CA_AGENT, VAULT_API_KEY_CRED, key_pem);
+      OPENSSL_cleanse(key_pem, strlen(key_pem));
+      free(key_pem);
+      if (vs != VAULT_OK)
+      {
+         aimee_log(LOG_ERROR, "pki", "failed to seal CA key in vault: %s", vault_status_str(vs));
+         free(cert_pem);
+         goto done;
+      }
+      char path[MAX_PATH_LEN], dir[MAX_PATH_LEN];
+      snprintf(dir, sizeof(dir), "%s/tls", config_default_dir());
+      mkdir(dir, 0700);
+      ca_cert_path(path, sizeof(path));
+      FILE *f = fopen(path, "w");
+      if (f)
+      {
+         fputs(cert_pem, f);
+         fclose(f);
+      }
+      free(cert_pem);
+      if (!f)
+         goto done;
+   }
+   g_ca_key = key;
+   key = NULL;
+   g_ca_cert = cert;
+   cert = NULL;
+   rc = 0;
+   aimee_log(LOG_INFO, "pki", "generated client CA (%s)", PKI_CA_CN);
+done:
+   if (key)
+      EVP_PKEY_free(key);
+   if (cert)
+      X509_free(cert);
+   return rc;
+}
+
+/* Load the CA from the sealed key + cert file. Returns 0 if both loaded. */
+static int ca_load(void)
+{
+   char key_pem[MAX_API_KEY_LEN] = "";
+   if (vault_service_inject_api_key("", PKI_CA_AGENT, key_pem, sizeof(key_pem), time(NULL)) !=
+           VAULT_OK ||
+       !key_pem[0])
+      return -1;
+   BIO *kb = BIO_new_mem_buf(key_pem, -1);
+   EVP_PKEY *key = kb ? PEM_read_bio_PrivateKey(kb, NULL, NULL, NULL) : NULL;
+   if (kb)
+      BIO_free(kb);
+   OPENSSL_cleanse(key_pem, sizeof(key_pem));
+   if (!key)
+      return -1;
+   char path[MAX_PATH_LEN];
+   ca_cert_path(path, sizeof(path));
+   FILE *f = fopen(path, "r");
+   X509 *cert = f ? PEM_read_X509(f, NULL, NULL, NULL) : NULL;
+   if (f)
+      fclose(f);
+   if (!cert)
+   {
+      EVP_PKEY_free(key);
+      return -1;
+   }
+   g_ca_key = key;
+   g_ca_cert = cert;
+   return 0;
+}
+
+int pki_ca_ensure(void)
+{
+   pthread_mutex_lock(&g_mu);
+   db_ensure_tables();
+   int rc = 0;
+   if (!g_ca_key || !g_ca_cert)
+      rc = (ca_load() == 0) ? 0 : ca_generate_and_persist();
+   snapshot_load();
+   pthread_mutex_unlock(&g_mu);
+   return rc;
+}
+
+int pki_issue(const char *cn, int validity_days, char *cert_pem, size_t cert_len, char *key_pem,
+              size_t key_len, char *serial_out, size_t serial_len)
+{
+   char san[VAULT_CERT_CN_MAX + 1];
+   if (!cn || !vault_principal_cert_sanitize(cn, san, sizeof(san)) || !cert_pem || !key_pem ||
+       !serial_out)
+      return -1;
+   if (validity_days <= 0)
+      validity_days = 90;
+   if (cert_len)
+      cert_pem[0] = '\0';
+   if (key_len)
+      key_pem[0] = '\0';
+   if (serial_len)
+      serial_out[0] = '\0';
+
+   if (pki_ca_ensure() != 0)
+      return -1;
+
+   pthread_mutex_lock(&g_mu);
+   int rc = -1;
+   EVP_PKEY *key = gen_ec_key();
+   X509 *cert = key ? X509_new() : NULL;
+   char serial[64] = "";
+   if (!cert)
+      goto done;
+   X509_set_version(cert, 2);
+   if (set_random_serial(cert, serial, sizeof(serial)) != 0 ||
+       set_name_cn(X509_get_subject_name(cert), san) != 0 ||
+       X509_set_issuer_name(cert, X509_get_subject_name(g_ca_cert)) != 1 ||
+       !X509_gmtime_adj(X509_getm_notBefore(cert), 0) ||
+       !X509_gmtime_adj(X509_getm_notAfter(cert), (long)validity_days * 24 * 3600) ||
+       X509_set_pubkey(cert, key) != 1 ||
+       add_ext(cert, g_ca_cert, NID_basic_constraints, "critical,CA:FALSE") != 0 ||
+       add_ext(cert, g_ca_cert, NID_key_usage, "critical,digitalSignature") != 0 ||
+       add_ext(cert, g_ca_cert, NID_ext_key_usage, "clientAuth") != 0 ||
+       X509_sign(cert, g_ca_key, EVP_sha256()) == 0)
+      goto done;
+
+   {
+      char *cp = pem_cert(cert), *kp = pem_private_key(key);
+      if (cp && kp && strlen(cp) < cert_len && strlen(kp) < key_len)
+      {
+         snprintf(cert_pem, cert_len, "%s", cp);
+         snprintf(key_pem, key_len, "%s", kp);
+         snprintf(serial_out, serial_len, "%s", serial);
+         sqlite3 *db = db1_conn();
+         if (db)
+         {
+            sqlite3_stmt *stm = NULL;
+            if (sqlite3_prepare_v2(db,
+                                   "INSERT OR REPLACE INTO pki_certs(serial,cn,issued_at,"
+                                   "expires_at,revoked) VALUES(?,?,?,?,0)",
+                                   -1, &stm, NULL) == SQLITE_OK)
+            {
+               long now = (long)time(NULL);
+               sqlite3_bind_text(stm, 1, serial, -1, SQLITE_TRANSIENT);
+               sqlite3_bind_text(stm, 2, san, -1, SQLITE_TRANSIENT);
+               sqlite3_bind_int64(stm, 3, now);
+               sqlite3_bind_int64(stm, 4, now + (long)validity_days * 24 * 3600);
+               sqlite3_step(stm);
+               sqlite3_finalize(stm);
+            }
+         }
+         rc = 0;
+      }
+      if (kp)
+         OPENSSL_cleanse(kp, strlen(kp));
+      free(cp);
+      free(kp);
+   }
+done:
+   if (key)
+      EVP_PKEY_free(key);
+   if (cert)
+      X509_free(cert);
+   pthread_mutex_unlock(&g_mu);
+   if (rc == 0)
+      aimee_log(LOG_INFO, "pki.audit", "issued client cert cn=%s serial=%s days=%d", san, serial,
+                validity_days);
+   return rc;
+}
+
+int pki_revoke(const char *serial)
+{
+   if (!serial || !serial[0])
+      return -1;
+   sqlite3 *db = db1_conn();
+   if (db)
+   {
+      sqlite3_stmt *st = NULL;
+      if (sqlite3_prepare_v2(db, "UPDATE pki_certs SET revoked=1 WHERE serial=?", -1, &st, NULL) ==
+          SQLITE_OK)
+      {
+         sqlite3_bind_text(st, 1, serial, -1, SQLITE_TRANSIENT);
+         sqlite3_step(st);
+         sqlite3_finalize(st);
+      }
+   }
+   pthread_mutex_lock(&g_mu);
+   snapshot_add(serial);
+   pthread_mutex_unlock(&g_mu);
+   aimee_log(LOG_INFO, "pki.audit", "revoked client cert serial=%s", serial);
+   return 0;
+}
+
+int pki_is_revoked(const char *serial)
+{
+   if (!serial || !serial[0])
+      return 0;
+   int revoked = 0;
+   pthread_mutex_lock(&g_mu);
+   for (int i = 0; i < g_revoked_n; i++)
+      if (strcmp(g_revoked[i], serial) == 0)
+      {
+         revoked = 1;
+         break;
+      }
+   pthread_mutex_unlock(&g_mu);
+   return revoked;
+}

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -88,6 +88,13 @@ static void snapshot_add(const char *serial)
    g_revoked[g_revoked_n] = strdup(serial);
    if (g_revoked[g_revoked_n])
       g_revoked_n++;
+   else
+      /* Out-of-memory: the revocation IS durable in DB1 and reloads on the next
+       * pki_ca_ensure/snapshot_load; log so an incomplete snapshot isn't silent. */
+      aimee_log(LOG_WARN, "pki",
+                "revocation snapshot insert failed (serial=%s); "
+                "rejection deferred to next snapshot reload",
+                serial);
 }
 
 /* Reload the snapshot from DB1 (caller holds g_mu). */
@@ -187,9 +194,15 @@ static int add_ext(X509 *cert, X509 *issuer, int nid, const char *value)
    return rc == 1 ? 0 : -1;
 }
 
-/* Random 16-byte positive serial; writes the cert's serial and a hex string. */
+/* Set a random 128-bit positive serial on the cert and write its hex form. The
+ * hex is derived by reading the serial BACK off the cert via the exact same
+ * ASN1_INTEGER -> BIGNUM -> BN_bn2hex path the TLS verify callback uses, so the
+ * stored serial and the handshake-time serial are byte-identical (no
+ * leading-zero / sign-byte skew between issuance and the revocation check). */
 static int set_random_serial(X509 *cert, char *hex_out, size_t hex_len)
 {
+   if (hex_len)
+      hex_out[0] = '\0';
    BIGNUM *bn = BN_new();
    if (!bn || !BN_rand(bn, 128, BN_RAND_TOP_ANY, BN_RAND_BOTTOM_ANY))
    {
@@ -197,20 +210,22 @@ static int set_random_serial(X509 *cert, char *hex_out, size_t hex_len)
       return -1;
    }
    ASN1_INTEGER *ai = BN_to_ASN1_INTEGER(bn, NULL);
+   BN_free(bn);
    if (!ai)
-   {
-      BN_free(bn);
       return -1;
-   }
-   X509_set_serialNumber(cert, ai);
+   int set_ok = (X509_set_serialNumber(cert, ai) == 1); /* copies into the cert */
    ASN1_INTEGER_free(ai);
-   char *hex = BN_bn2hex(bn);
+   if (!set_ok)
+      return -1;
+   BIGNUM *back = ASN1_INTEGER_to_BN(X509_get_serialNumber(cert), NULL);
+   char *hex = back ? BN_bn2hex(back) : NULL;
    if (hex)
    {
       snprintf(hex_out, hex_len, "%s", hex);
       OPENSSL_free(hex);
    }
-   BN_free(bn);
+   if (back)
+      BN_free(back);
    return hex_out[0] ? 0 : -1;
 }
 
@@ -320,7 +335,7 @@ static int ca_load(void)
 int pki_ca_ensure(void)
 {
    pthread_mutex_lock(&g_mu);
-   db_ensure_tables();
+   db_ensure_tables(); /* inside the lock: table exists before snapshot_load reads it */
    int rc = 0;
    if (!g_ca_key || !g_ca_cert)
       rc = (ca_load() == 0) ? 0 : ca_generate_and_persist();
@@ -379,8 +394,10 @@ int pki_issue(const char *cn, int validity_days, char *cert_pem, size_t cert_len
          if (db)
          {
             sqlite3_stmt *stm = NULL;
+            /* Plain INSERT (not REPLACE): a (2^-128, impossible) serial collision
+             * must never overwrite/reset an existing cert's revocation row. */
             if (sqlite3_prepare_v2(db,
-                                   "INSERT OR REPLACE INTO pki_certs(serial,cn,issued_at,"
+                                   "INSERT INTO pki_certs(serial,cn,issued_at,"
                                    "expires_at,revoked) VALUES(?,?,?,?,0)",
                                    -1, &stm, NULL) == SQLITE_OK)
             {

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -1,8 +1,10 @@
-/* server_tls.c: see server_tls.h. Plain server-TLS context + handshake. */
+/* server_tls.c: see server_tls.h. Server-TLS context + handshake, incl. mTLS
+ * client-cert verification + revocation. */
 #include "server_tls.h"
 #include "server_conn_io.h" /* register/clear the per-conn SSL on the I/O shim */
-#include "config.h"         /* config_default_dir */
+#include "config.h"         /* config_default_dir, config_load */
 #include "aimee.h"          /* MAX_PATH_LEN */
+#include "pki.h"            /* pki_ca_ensure, pki_is_revoked */
 #include "log.h"
 
 #include <openssl/bn.h>
@@ -17,6 +19,34 @@
 
 static SSL_CTX *g_ctx = NULL;
 static pthread_mutex_t g_ctx_mu = PTHREAD_MUTEX_INITIALIZER;
+
+/* mTLS verify callback: OpenSSL has already checked the chain/validity
+ * (preverify_ok). Additionally reject a revoked leaf (depth 0) by consulting the
+ * in-memory revocation snapshot — no DB query in the handshake path. */
+static int mtls_verify_cb(int preverify_ok, X509_STORE_CTX *ctx)
+{
+   if (!preverify_ok)
+      return 0; /* chain/time/CA failure -> reject */
+   if (X509_STORE_CTX_get_error_depth(ctx) != 0)
+      return 1; /* only the leaf carries the client serial */
+   X509 *cert = X509_STORE_CTX_get_current_cert(ctx);
+   if (!cert)
+      return 1;
+   ASN1_INTEGER *sn = X509_get_serialNumber(cert);
+   BIGNUM *bn = sn ? ASN1_INTEGER_to_BN(sn, NULL) : NULL;
+   char *hex = bn ? BN_bn2hex(bn) : NULL;
+   int revoked = hex ? pki_is_revoked(hex) : 0;
+   if (hex)
+      OPENSSL_free(hex);
+   if (bn)
+      BN_free(bn);
+   if (revoked)
+   {
+      X509_STORE_CTX_set_error(ctx, X509_V_ERR_CERT_REVOKED);
+      return 0;
+   }
+   return 1;
+}
 
 int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
                     const char *client_ca_path)
@@ -83,7 +113,7 @@ int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
          int vflags = SSL_VERIFY_PEER;
          if (mtls_mode >= 2)
             vflags |= SSL_VERIFY_FAIL_IF_NO_PEER_CERT;
-         SSL_CTX_set_verify(ctx, vflags, NULL);
+         SSL_CTX_set_verify(ctx, vflags, mtls_verify_cb);
          aimee_log(LOG_INFO, "server.tls", "mTLS %s (client CA %s)",
                    mtls_mode >= 2 ? "required" : "optional", ca);
       }
@@ -164,6 +194,11 @@ int server_tls_init_default(void)
    snprintf(key, sizeof(key), "%s/tls/server.key", config_default_dir());
    config_t cfg;
    config_load(&cfg);
+   /* When mTLS is on, ensure aimee's client CA exists (create-or-load) and the
+    * revocation snapshot is loaded BEFORE server_tls_init loads the client CA
+    * file and the verify callback starts consulting the snapshot. */
+   if (cfg.server_api_mtls > 0)
+      pki_ca_ensure();
    return server_tls_init(cert, key, cfg.server_api_mtls, cfg.server_api_mtls_client_ca);
 }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -215,6 +215,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
                $(TESTPREFIX)/unit-test-vault-bootstrap \
+               $(TESTPREFIX)/unit-test-pki \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
                $(TESTPREFIX)/unit-test-prompts \
@@ -2127,6 +2128,14 @@ $(TESTPREFIX)/unit-test-vault-bootstrap: $(OBJDIR)/tests/test_vault_bootstrap.o 
                               $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
                               $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
                               $(OBJDIR)/server/vault_server_key.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-pki: $(OBJDIR)/tests/test_pki.o $(OBJDIR)/server/pki.o \
+                              $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
+                              $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o $(OBJDIR)/server/vault_principal.o \
+                              $(DB1_OBJS) \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -1,0 +1,99 @@
+/* test_pki.c: aimee's client-cert CA — CA ensure, issuance (cert chains to the
+ * CA), revocation snapshot, and CN-spoofing refusal (mtls-client-identity slice 2). */
+#include "pki.h"
+#include "vault_principal.h"
+#include "config.h" /* config_default_dir */
+#include "db1.h"    /* db1_init */
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static int verify_chains_to_ca(const char *cert_pem, const char *ca_path)
+{
+   BIO *cb = BIO_new_mem_buf(cert_pem, -1);
+   X509 *cert = cb ? PEM_read_bio_X509(cb, NULL, NULL, NULL) : NULL;
+   if (cb)
+      BIO_free(cb);
+   FILE *f = fopen(ca_path, "r");
+   X509 *ca = f ? PEM_read_X509(f, NULL, NULL, NULL) : NULL;
+   if (f)
+      fclose(f);
+   int ok = 0;
+   if (cert && ca)
+   {
+      X509_STORE *store = X509_STORE_new();
+      X509_STORE_CTX *ctx = X509_STORE_CTX_new();
+      if (store && ctx && X509_STORE_add_cert(store, ca) == 1 &&
+          X509_STORE_CTX_init(ctx, store, cert, NULL) == 1)
+         ok = (X509_verify_cert(ctx) == 1);
+      if (ctx)
+         X509_STORE_CTX_free(ctx);
+      if (store)
+         X509_STORE_free(store);
+   }
+   if (cert)
+      X509_free(cert);
+   if (ca)
+      X509_free(ca);
+   return ok;
+}
+
+int main(void)
+{
+   char home[256];
+   snprintf(home, sizeof(home), "/tmp/aimee-pki-test-%d", (int)getpid());
+   char cmd[600];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", home, home);
+   assert(system(cmd) == 0);
+   setenv("AIMEE_HOME", home, 1);
+   assert(db1_init(":memory:") == 0);
+   pki_reset_for_test();
+
+   /* CA ensure: creates the CA + writes the client-ca.crt the server verifies against. */
+   assert(pki_ca_ensure() == 0);
+   char ca_path[400];
+   snprintf(ca_path, sizeof(ca_path), "%s/tls/client-ca.crt", config_default_dir());
+   assert(access(ca_path, R_OK) == 0);
+
+   /* Issue a client cert; it must be a real PEM with a serial, and chain to the CA. */
+   char cert[8192] = "", key[4096] = "", serial[64] = "";
+   assert(pki_issue("ci-runner-1", 30, cert, sizeof(cert), key, sizeof(key), serial,
+                    sizeof(serial)) == 0);
+   assert(strstr(cert, "BEGIN CERTIFICATE") != NULL);
+   assert(strstr(key, "BEGIN") != NULL && strstr(key, "PRIVATE KEY") != NULL);
+   assert(serial[0] != '\0');
+   assert(verify_chains_to_ca(cert, ca_path) == 1);
+
+   /* Revocation: not revoked, then revoked, reflected in the snapshot. */
+   assert(pki_is_revoked(serial) == 0);
+   assert(pki_revoke(serial) == 0);
+   assert(pki_is_revoked(serial) == 1);
+
+   /* A second cert is independent (distinct serial, still valid). */
+   char cert2[8192] = "", key2[4096] = "", serial2[64] = "";
+   assert(pki_issue("ci-runner-2", 30, cert2, sizeof(cert2), key2, sizeof(key2), serial2,
+                    sizeof(serial2)) == 0);
+   assert(strcmp(serial, serial2) != 0);
+   assert(pki_is_revoked(serial2) == 0);
+
+   /* A spoofing CN (would alias uid:0) is refused at issuance. */
+   char tmp[8192], tkey[4096], tserial[64];
+   assert(pki_issue("uid:0", 30, tmp, sizeof(tmp), tkey, sizeof(tkey), tserial, sizeof(tserial)) ==
+          -1);
+
+   /* Revoke serial2, then drop all caches and reload: the CA survives (sealed key
+    * + cert file) and the revocation snapshot reloads from DB1. */
+   assert(pki_revoke(serial2) == 0);
+   pki_reset_for_test();
+   assert(pki_ca_ensure() == 0);
+   assert(pki_is_revoked(serial2) == 1); /* persisted across reload */
+
+   snprintf(cmd, sizeof(cmd), "rm -rf %s", home);
+   (void)system(cmd);
+   printf("pki: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
Second slice of the roundtable-approved `mtls-client-identity`. The **PKI crypto core** that backs slice 1's verification. The operator CLI / enrollment endpoint are **slice 2b**.

## What this does
- **`server/pki.c`**: aimee owns a self-generated **EC P-256 client CA**. The CA private key is **sealed in the server vault** (`vault_service_set_server` — never plaintext at rest); the CA cert is written to `<config>/tls/client-ca.crt` (the file `server_tls` already verifies client certs against). `pki_issue(cn, days)` signs a `clientAuth` leaf for a **sanitized** CN and records it in a lazily-created DB1 `pki_certs` table. `pki_revoke`/`pki_is_revoked` use an **in-memory serial denylist snapshot** loaded from DB1 — so the TLS verify callback never queries the database (no DoS / latency in the handshake path). Issue/revoke are **audit-logged** (cn/serial only, no key material).
- **`server_tls.c`**: the mTLS verify callback now **rejects a revoked leaf** (`X509_V_ERR_CERT_REVOKED`) via `pki_is_revoked`; `server_tls_init_default` calls `pki_ca_ensure()` when mtls>0 so the CA + revocation snapshot exist before the listener binds.

## Tests
`test_pki`: CA ensure writes a loadable `client-ca.crt`; an issued cert **chains to the CA** (`X509_verify_cert`); serials are distinct; `revoke` flips the snapshot and **persists across a reload** from DB1; a spoofing CN (`uid:0`) is **refused at issuance**. Server/client/kb build clean under `-Werror`; the slice-1 `vault_principal` test stays green.

Maps to proposal acceptance criteria **2 (revoked)**, **4 (CA key never plaintext)**, **9 (revocation persists)**.

## Slice 2b (next)
`aimee cert issue/list/revoke/renew` CLI, the `/v1/cert/*` routes (operator-gated), and the bearer/one-time-token `/v1/cert/enroll` bootstrap — they call this core.