### PR TITLE
feat(mtls): client presents tls/client cert — OpenSSL/Linux leg (slice 3)

### DIFF
--- a/docs/proposals/pending/mtls-client-identity.md
+++ b/docs/proposals/pending/mtls-client-identity.md
@@ -95,13 +95,22 @@ extension of an existing listener, not a new one.
 ### WP-D — Client: present a client certificate
 The thin client loads its identity (`<aimee_home>/tls/client.{crt,key}`) and
 presents it via each `aimee_tls.h` backend:
-- OpenSSL (Linux): `SSL_CTX_use_certificate_file` + `SSL_CTX_use_PrivateKey_file`.
+- OpenSSL (Linux): `SSL_CTX_use_certificate_chain_file` +
+  `SSL_CTX_use_PrivateKey_file`. **DONE (slice 3).** Presented automatically when
+  both files exist; a group/world-readable key is refused (fail closed). Gate is
+  unit-tested (`unit-test-aimee-tls-clientcert`).
 - Schannel (Windows): supply the client cert in `SCHANNEL_CRED.paCred` (imported
-  from a PFX or the user cert store).
+  from a PFX or the user cert store). **Deferred → slice 3b** (EC-key import via
+  CryptoAPI must be validated on real Windows, as the native backend itself was).
 - Secure Transport (macOS): `SSLSetCertificate` with a `SecIdentityRef` from a
-  PKCS#12.
+  PKCS#12. **Deferred → slice 3b** (identity construction validated on real macOS).
+
 This is the piece the native-TLS proposal explicitly deferred (mTLS was out of
-scope there); it is additive, gated on the client actually having a cert.
+scope there); it is additive, gated on the client actually having a cert. The
+Linux leg lands first because it is the testbed for the whole mTLS loop
+(server verify = slice 2, issuance CLI = slice 2b); the Windows/macOS legs ship
+as slice 3b once validated on real hardware. Both native backends carry an
+in-code marker at the exact hook point.
 
 ## Hardening requirements (from roundtable R1: architect + security + QA)
 

--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -1,10 +1,13 @@
 /* aimee_tls.c: OpenSSL TLS client wrapper (WITH_TLS builds only). */
 #include "aimee_tls.h"
+#include "aimee_home.h"
 #include <openssl/err.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 struct aimee_tls
 {
@@ -16,6 +19,46 @@ static int tls_insecure(void)
 {
    const char *v = getenv("AIMEE_TLS_INSECURE");
    return v && *v && strcmp(v, "0") != 0;
+}
+
+/* Decide whether client mTLS material under |home| should be presented, and
+ * fill the resolved crt/key paths. Returns:
+ *    1  -> present (both files exist and the key is owner-only)
+ *    0  -> none (no key/cert configured)
+ *   -1  -> refused: the private key is group/world-readable (fail closed — the
+ *          key is this client's identity material, never present a loose one)
+ * Pure (no OpenSSL/network); exposed for unit testing the fail-closed gate. */
+int aimee_tls_client_cert_eligible(const char *home, char *crt, size_t crt_n, char *key,
+                                   size_t key_n)
+{
+   if (!home || !*home || !crt || !key)
+      return 0;
+   snprintf(crt, crt_n, "%s/tls/client.crt", home);
+   snprintf(key, key_n, "%s/tls/client.key", home);
+   struct stat cs, ks;
+   if (stat(crt, &cs) != 0 || stat(key, &ks) != 0)
+      return 0; /* no client-cert material configured */
+#ifndef _WIN32
+   if (ks.st_mode & 077)
+      return -1; /* refuse a loose private key */
+#endif
+   return 1;
+}
+
+/* Present <aimee_home>/tls/client.{crt,key} as this client's certificate for
+ * mutual TLS, when both files exist. Absent => plain client TLS (the server may
+ * not require a client cert). A load failure leaves the ctx cert-less and the
+ * handshake then fails at the mTLS server, which is the correct signal for a
+ * broken/loose client cert. */
+static void aimee_tls_present_client_cert(SSL_CTX *ctx)
+{
+   char crt[600], key[600];
+   if (aimee_tls_client_cert_eligible(aimee_home(), crt, sizeof(crt), key, sizeof(key)) != 1)
+      return;
+   if (SSL_CTX_use_certificate_chain_file(ctx, crt) != 1 ||
+       SSL_CTX_use_PrivateKey_file(ctx, key, SSL_FILETYPE_PEM) != 1 ||
+       SSL_CTX_check_private_key(ctx) != 1)
+      ERR_clear_error();
 }
 
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
@@ -31,6 +74,8 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       SSL_CTX_set_default_verify_paths(ctx);
       SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
    }
+
+   aimee_tls_present_client_cert(ctx);
 
    SSL *ssl = SSL_new(ctx);
    if (!ssl)

--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -35,12 +35,28 @@ int aimee_tls_client_cert_eligible(const char *home, char *crt, size_t crt_n, ch
       return 0;
    snprintf(crt, crt_n, "%s/tls/client.crt", home);
    snprintf(key, key_n, "%s/tls/client.key", home);
-   struct stat cs, ks;
-   if (stat(crt, &cs) != 0 || stat(key, &ks) != 0)
+   struct stat cs;
+   if (stat(crt, &cs) != 0)
       return 0; /* no client-cert material configured */
 #ifndef _WIN32
+   /* The key is this client's identity material: lstat it (do NOT follow a
+    * symlink) and require a plain, owner-only regular file. This refuses a
+    * group/world-accessible key and a symlink swapped in for one. (A writer to
+    * your own 0700 tls/ dir is already privileged and can read the key outright,
+    * so this gate targets accidental loose perms + symlink tricks, not an
+    * attacker who already controls the directory — full TOCTOU-atomic loading
+    * is therefore out of scope.) */
+   struct stat ks;
+   if (lstat(key, &ks) != 0)
+      return 0;
+   if (!S_ISREG(ks.st_mode))
+      return -1; /* symlink / special file — refuse */
    if (ks.st_mode & 077)
-      return -1; /* refuse a loose private key */
+      return -1; /* group/world-accessible — refuse */
+#else
+   struct stat ks;
+   if (stat(key, &ks) != 0)
+      return 0;
 #endif
    return 1;
 }

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -272,6 +272,12 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    /* We validate the chain + hostname ourselves post-handshake, so tell Schannel
     * not to auto-validate (and never use a machine default client cert). */
    sc.dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_MANUAL_CRED_VALIDATION | SCH_USE_STRONG_CRYPTO;
+   /* mTLS client-cert presentation (slice 3b, follow-up): to present
+    * <aimee_home>/tls/client.{crt,key} as this client's identity, build a
+    * CERT_CONTEXT (PEM -> CertCreateCertificateContext) with an associated CNG
+    * private key and set sc.cCreds/sc.paCred here. Deferred: EC-key import via
+    * CryptoAPI is intricate and must be validated on real Windows (as the
+    * native backend itself was). The OpenSSL backend presents the cert today. */
 
    if (AcquireCredentialsHandleA(NULL, (SEC_CHAR *)UNISP_NAME_A, SECPKG_CRED_OUTBOUND, NULL, &sc,
                                  NULL, NULL, &t->cred, NULL) != SEC_E_OK)

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -102,6 +102,11 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       free(t);
       return NULL;
    }
+   /* mTLS client-cert presentation (slice 3b, follow-up): to present
+    * <aimee_home>/tls/client.{crt,key} as this client's identity, build a
+    * SecIdentityRef from the PEM (SecPKCS12Import / SecItem) and pass it to
+    * SSLSetCertificate here. Deferred: identity construction must be validated
+    * on real macOS. The OpenSSL backend presents the cert today. */
    if (SSLSetIOFuncs(t->ctx, st_read, st_write) != noErr ||
        SSLSetConnection(t->ctx, &t->fd) != noErr ||
        SSLSetProtocolVersionMin(t->ctx, kTLSProtocol12) != noErr)

--- a/src/headers/aimee_tls.h
+++ b/src/headers/aimee_tls.h
@@ -32,6 +32,15 @@ extern "C"
    /* Shut down and free the handle (does not close the underlying fd). */
    void aimee_tls_free(aimee_tls_t *t);
 
+   /* Decide whether client mTLS material under |home| should be presented as
+    * this client's certificate, filling the resolved <home>/tls/client.{crt,key}
+    * paths. Returns 1 (present: both exist, key is owner-only), 0 (none
+    * configured), or -1 (refused: the key is group/world-readable — fail
+    * closed). Pure; the OpenSSL backend calls it before the handshake. Exposed
+    * for unit testing the fail-closed permission gate. */
+   int aimee_tls_client_cert_eligible(const char *home, char *crt, size_t crt_n, char *key,
+                                      size_t key_n);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -216,6 +216,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-service \
                $(TESTPREFIX)/unit-test-vault-bootstrap \
                $(TESTPREFIX)/unit-test-pki \
+               $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
                $(TESTPREFIX)/unit-test-prompts \
@@ -2142,6 +2143,10 @@ $(TESTPREFIX)/unit-test-pki: $(OBJDIR)/tests/test_pki.o $(OBJDIR)/server/pki.o \
 $(TESTPREFIX)/unit-test-vault-server-key: $(OBJDIR)/tests/test_vault_server_key.o \
                               $(OBJDIR)/server/vault_server_key.o $(OBJDIR)/server/vault_crypto.o \
                               $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-aimee-tls-clientcert: $(OBJDIR)/tests/test_aimee_tls_clientcert.o \
+                              $(OBJDIR)/aimee_tls.o $(OBJDIR)/aimee_home.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-vault-capability: $(OBJDIR)/tests/test_vault_capability.o \

--- a/src/tests/test_aimee_tls_clientcert.c
+++ b/src/tests/test_aimee_tls_clientcert.c
@@ -92,6 +92,20 @@ static void test_cert_without_key_is_none(void)
    assert(r == 0);
 }
 
+/* Key group-readable (0640) -> -1: pin the exact `& 077` boundary the gate
+ * enforces (not just the 0644 world-readable case). */
+static void test_refuse_group_readable_key(void)
+{
+   char crt[600], key[600], p[700];
+   rm_material();
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   write_file(p, 0600);
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   write_file(p, 0640); /* owner rw, group r — still refused */
+   int r = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   assert(r == -1);
+}
+
 /* Key is a symlink (even to a 0600 file) -> -1: never follow a symlinked key.
  * Defends against a symlink swapped in for the identity key. */
 static void test_refuse_symlinked_key(void)
@@ -125,6 +139,7 @@ int main(void)
    test_absent_is_none();
    test_present_when_0600();
    test_refuse_loose_key();
+   test_refuse_group_readable_key();
    test_refuse_symlinked_key();
    test_cert_without_key_is_none();
    test_bad_home_is_none();

--- a/src/tests/test_aimee_tls_clientcert.c
+++ b/src/tests/test_aimee_tls_clientcert.c
@@ -1,0 +1,114 @@
+/* test_aimee_tls_clientcert.c: pin the client mTLS-material gate.
+ *
+ * aimee_tls_client_cert_eligible() decides whether <home>/tls/client.{crt,key}
+ * is presented as the thin client's certificate. The security-relevant property
+ * is FAIL CLOSED: a group/world-readable private key must NOT be presented (the
+ * key is the client's identity material). These tests pin that contract without
+ * needing OpenSSL or a network — the helper is pure (stat + path build). */
+#include "aimee_tls.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[512];
+
+static void write_file(const char *path, mode_t mode)
+{
+   FILE *f = fopen(path, "w");
+   assert(f);
+   fputs("x\n", f);
+   fclose(f);
+   assert(chmod(path, mode) == 0);
+}
+
+static void make_home(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-tlscc-%d", (int)getpid());
+   char tls[600];
+   mkdir(g_home, 0700);
+   snprintf(tls, sizeof(tls), "%s/tls", g_home);
+   mkdir(tls, 0700);
+}
+
+static void rm_material(void)
+{
+   char p[700];
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   unlink(p);
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   unlink(p);
+}
+
+/* No files configured -> 0 (plain client TLS, no cert presented). */
+static void test_absent_is_none(void)
+{
+   rm_material();
+   char crt[600], key[600];
+   int r = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   assert(r == 0);
+}
+
+/* Both files present, key 0600 -> 1 (present), and paths resolved correctly. */
+static void test_present_when_0600(void)
+{
+   char crt[600], key[600], p[700];
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   write_file(p, 0600);
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   write_file(p, 0600);
+   int r = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   assert(r == 1);
+   char want[700];
+   snprintf(want, sizeof(want), "%s/tls/client.crt", g_home);
+   assert(strcmp(crt, want) == 0);
+   snprintf(want, sizeof(want), "%s/tls/client.key", g_home);
+   assert(strcmp(key, want) == 0);
+}
+
+/* Key group/world-readable -> -1 (fail closed: never present a loose key). */
+static void test_refuse_loose_key(void)
+{
+   char crt[600], key[600], p[700];
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   write_file(p, 0644);
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   write_file(p, 0644); /* world-readable private key */
+   int r = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   assert(r == -1);
+}
+
+/* Cert present but key absent -> 0 (incomplete material, present nothing). */
+static void test_cert_without_key_is_none(void)
+{
+   char crt[600], key[600], p[700];
+   rm_material();
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   write_file(p, 0600);
+   int r = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   assert(r == 0);
+}
+
+/* Empty/NULL home -> 0 (a broken env must not crash or present anything). */
+static void test_bad_home_is_none(void)
+{
+   char crt[600], key[600];
+   assert(aimee_tls_client_cert_eligible(NULL, crt, sizeof(crt), key, sizeof(key)) == 0);
+   assert(aimee_tls_client_cert_eligible("", crt, sizeof(crt), key, sizeof(key)) == 0);
+}
+
+int main(void)
+{
+   make_home();
+   test_absent_is_none();
+   test_present_when_0600();
+   test_refuse_loose_key();
+   test_cert_without_key_is_none();
+   test_bad_home_is_none();
+   rm_material();
+   printf("aimee_tls_clientcert: all tests passed\n");
+   return 0;
+}

--- a/src/tests/test_aimee_tls_clientcert.c
+++ b/src/tests/test_aimee_tls_clientcert.c
@@ -92,6 +92,25 @@ static void test_cert_without_key_is_none(void)
    assert(r == 0);
 }
 
+/* Key is a symlink (even to a 0600 file) -> -1: never follow a symlinked key.
+ * Defends against a symlink swapped in for the identity key. */
+static void test_refuse_symlinked_key(void)
+{
+   char crt[600], key[600], p[700], tgt[700];
+   rm_material();
+   snprintf(p, sizeof(p), "%s/tls/client.crt", g_home);
+   write_file(p, 0600);
+   snprintf(tgt, sizeof(tgt), "%s/tls/real.key", g_home);
+   write_file(tgt, 0600);
+   snprintf(p, sizeof(p), "%s/tls/client.key", g_home);
+   unlink(p);
+   assert(symlink(tgt, p) == 0);
+   int r = aimee_tls_client_cert_eligible(g_home, crt, sizeof(crt), key, sizeof(key));
+   assert(r == -1);
+   unlink(p);
+   unlink(tgt);
+}
+
 /* Empty/NULL home -> 0 (a broken env must not crash or present anything). */
 static void test_bad_home_is_none(void)
 {
@@ -106,6 +125,7 @@ int main(void)
    test_absent_is_none();
    test_present_when_0600();
    test_refuse_loose_key();
+   test_refuse_symlinked_key();
    test_cert_without_key_is_none();
    test_bad_home_is_none();
    rm_material();


### PR DESCRIPTION
## mTLS slice 3 — client-cert presentation (WP-D), OpenSSL/Linux leg

Final functional slice of the [mTLS client-identity proposal](docs/proposals/pending/mtls-client-identity.md). Completes the loop: server verifies client certs (slice 2, #434/#435), operator issues them (slice 2b, #436), and now the **client presents** its cert so it's identified as a distinct `cert:<CN>` principal.

### What
`aimee_tls.c` (OpenSSL backend): before `SSL_connect`, if both `<aimee_home>/tls/client.crt` and `client.key` exist, load them as the client certificate (`SSL_CTX_use_certificate_chain_file` + `SSL_CTX_use_PrivateKey_file` + `check_private_key`). Absent → plain client TLS (unchanged behaviour).

### Security: fail closed
A group/world-readable private key (`& 077`) is **refused** and never presented — the key is this client's identity material. The eligibility decision (exists + `0600`) is factored into the pure, exported `aimee_tls_client_cert_eligible()` and unit-tested:

- `unit-test-aimee-tls-clientcert`: present-on-0600 (paths resolved), **refuse-on-0644**, none-when-absent, cert-without-key→none, bad/NULL home→none.

### Deferred to slice 3b (Windows/macOS)
Presenting a PEM client cert on **Schannel** (EC-key import into a CryptoAPI `CERT_CONTEXT`) and **Secure Transport** (`SecIdentityRef` from PEM) is intricate and must be validated on real hardware — exactly how the native-TLS backends themselves were validated. Writing it blind would be untestable here. Each native backend carries an in-code marker at the precise hook point; the Linux leg lands first because it is the testbed for the whole mTLS feature.

### Verification
- Linux client builds clean with `WITH_TLS=1` (new `aimee_tls.o`).
- `unit-test-aimee-tls-clientcert` passes; registered in the suite.
- `line-check`, `docs-gen-check` green. Proposal WP-D updated to reflect the 3/3b split.
- Full mTLS e2e (present → server identifies `cert:<CN>` → revoked cert rejected) is gated to the live testbed per the standing workflow.

Stacked logically on #436 (slice 2b) but textually independent (different files).