### PR TITLE
feat(mtls): macOS Secure Transport client-cert presentation (slice 3c)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,6 +321,10 @@ jobs:
             -CAcreateserial -days 1 -out "$H/tls/client.crt"
           openssl pkcs12 -export -inkey "$H/tls/client.key" -in "$H/tls/client.crt" \
             -out "$H/tls/client.p12" -passout pass:
+          echo "::group::diagnostics"
+          openssl version
+          openssl pkcs12 -info -in "$H/tls/client.p12" -passin pass: -noout -nokeys 2>&1 | head -20 || true
+          echo "::endgroup::"
           # s_server REQUIRES a client cert (-Verify) and serves a status page.
           openssl s_server -accept 14443 -cert "$D/srv.crt" -key "$D/srv.key" \
             -CAfile "$D/ca.crt" -Verify 1 -www -naccept 3 > "$D/s_server.log" 2>&1 &
@@ -328,9 +332,12 @@ jobs:
           for i in $(seq 1 50); do nc -z 127.0.0.1 14443 && break; sleep 0.2; done
           # Present the client identity (INSECURE skips server-cert trust; the
           # client cert is still presented). A non-/v1 reply is fine — the TLS
-          # handshake is what we are validating.
-          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 \
-            ./build/aimee --server https://127.0.0.1:14443 config show || true
+          # handshake is what we are validating. AIMEE_TLS_DEBUG surfaces which
+          # Secure Transport step fails (to stderr) if the cert is not presented.
+          echo "::group::aimee output"
+          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 AIMEE_TLS_DEBUG=1 \
+            ./build/aimee --server https://127.0.0.1:14443 config show 2>&1 || true
+          echo "::endgroup::"
           sleep 1; kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true
           echo "::group::s_server.log"; cat "$D/s_server.log"; echo "::endgroup::"
           # Proof: the server logged + verified our client cert.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,46 @@ jobs:
           # --server must parse and select a remote TCP target on macOS.
           ./build/aimee --server http://127.0.0.1:9 version
 
+      - name: mTLS client-cert presentation (Secure Transport, loopback)
+        run: |
+          set -uo pipefail
+          D="$(mktemp -d)"; H="$D/home"; mkdir -p "$H/tls"
+          # Test PKI: CA, server cert, and an EC P-256 client cert whose key is
+          # PKCS#8 (matching what aimee-server issues), bundled into client.p12.
+          openssl ecparam -name prime256v1 -genkey -noout -out "$D/ca.key"
+          openssl req -x509 -new -key "$D/ca.key" -days 1 -subj "/CN=aimee-ci-ca" -out "$D/ca.crt"
+          openssl ecparam -name prime256v1 -genkey -noout -out "$D/srv.key"
+          openssl req -new -key "$D/srv.key" -subj "/CN=localhost" -out "$D/srv.csr"
+          openssl x509 -req -in "$D/srv.csr" -CA "$D/ca.crt" -CAkey "$D/ca.key" \
+            -CAcreateserial -days 1 -out "$D/srv.crt"
+          openssl ecparam -name prime256v1 -genkey -noout -out "$D/c.sec1"
+          openssl pkcs8 -topk8 -nocrypt -in "$D/c.sec1" -out "$H/tls/client.key"
+          openssl req -new -key "$H/tls/client.key" -subj "/CN=ci-macos-client" -out "$D/c.csr"
+          openssl x509 -req -in "$D/c.csr" -CA "$D/ca.crt" -CAkey "$D/ca.key" \
+            -CAcreateserial -days 1 -out "$H/tls/client.crt"
+          openssl pkcs12 -export -inkey "$H/tls/client.key" -in "$H/tls/client.crt" \
+            -out "$H/tls/client.p12" -passout pass:
+          # s_server REQUIRES a client cert (-Verify) and serves a status page.
+          openssl s_server -accept 14443 -cert "$D/srv.crt" -key "$D/srv.key" \
+            -CAfile "$D/ca.crt" -Verify 1 -www -naccept 3 > "$D/s_server.log" 2>&1 &
+          SRV=$!
+          for i in $(seq 1 50); do nc -z 127.0.0.1 14443 && break; sleep 0.2; done
+          # Present the client identity (INSECURE skips server-cert trust; the
+          # client cert is still presented). A non-/v1 reply is fine — the TLS
+          # handshake is what we are validating.
+          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 \
+            ./build/aimee --server https://127.0.0.1:14443 config show || true
+          sleep 1; kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true
+          echo "::group::s_server.log"; cat "$D/s_server.log"; echo "::endgroup::"
+          # Proof: the server logged + verified our client cert.
+          grep -q "CN=ci-macos-client" "$D/s_server.log" || { echo "FAIL: client cert not presented"; exit 1; }
+          if grep -q "peer did not return a certificate" "$D/s_server.log"; then
+            echo "FAIL: a connection presented no cert"; exit 1; fi
+          # The transient keychain must not be left behind.
+          if ls "${TMPDIR:-/tmp}"/aimee-mtls-*.keychain >/dev/null 2>&1; then
+            echo "FAIL: transient keychain leaked"; exit 1; fi
+          echo "PASS: Secure Transport presented client cert; server verified CN=ci-macos-client; no keychain leak"
+
   memory-retrieval-eval:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,11 +319,15 @@ jobs:
           openssl req -new -key "$H/tls/client.key" -subj "/CN=ci-macos-client" -out "$D/c.csr"
           openssl x509 -req -in "$D/c.csr" -CA "$D/ca.crt" -CAkey "$D/ca.key" \
             -CAcreateserial -days 1 -out "$H/tls/client.crt"
+          # macOS SecPKCS12Import REQUIRES a non-empty passphrase (an empty one
+          # fails errSecAuthFailed -25293), so the .p12 is passphrase-protected
+          # and aimee reads it from AIMEE_TLS_CLIENT_P12_PASS.
+          P12PASS='aimee-ci-p12'
           openssl pkcs12 -export -inkey "$H/tls/client.key" -in "$H/tls/client.crt" \
-            -out "$H/tls/client.p12" -passout pass:
+            -out "$H/tls/client.p12" -passout "pass:$P12PASS"
           echo "::group::diagnostics"
           openssl version
-          openssl pkcs12 -info -in "$H/tls/client.p12" -passin pass: -noout -nokeys 2>&1 | head -20 || true
+          openssl pkcs12 -info -in "$H/tls/client.p12" -passin "pass:$P12PASS" -noout -nokeys 2>&1 | head -20 || true
           echo "::endgroup::"
           # s_server REQUIRES a client cert (-Verify) and serves a status page.
           openssl s_server -accept 14443 -cert "$D/srv.crt" -key "$D/srv.key" \
@@ -335,7 +339,7 @@ jobs:
           # handshake is what we are validating. AIMEE_TLS_DEBUG surfaces which
           # Secure Transport step fails (to stderr) if the cert is not presented.
           echo "::group::aimee output"
-          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 AIMEE_TLS_DEBUG=1 \
+          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 AIMEE_TLS_DEBUG=1 AIMEE_TLS_CLIENT_P12_PASS="$P12PASS" \
             ./build/aimee --server https://127.0.0.1:14443 config show 2>&1 || true
           echo "::endgroup::"
           sleep 1; kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,10 +325,6 @@ jobs:
           P12PASS='aimee-ci-p12'
           openssl pkcs12 -export -inkey "$H/tls/client.key" -in "$H/tls/client.crt" \
             -out "$H/tls/client.p12" -passout "pass:$P12PASS"
-          echo "::group::diagnostics"
-          openssl version
-          openssl pkcs12 -info -in "$H/tls/client.p12" -passin "pass:$P12PASS" -noout -nokeys 2>&1 | head -20 || true
-          echo "::endgroup::"
           # s_server REQUIRES a client cert (-Verify) and serves a status page.
           openssl s_server -accept 14443 -cert "$D/srv.crt" -key "$D/srv.key" \
             -CAfile "$D/ca.crt" -Verify 1 -www -naccept 3 > "$D/s_server.log" 2>&1 &
@@ -336,16 +332,14 @@ jobs:
           for i in $(seq 1 50); do nc -z 127.0.0.1 14443 && break; sleep 0.2; done
           # Present the client identity (INSECURE skips server-cert trust; the
           # client cert is still presented). A non-/v1 reply is fine — the TLS
-          # handshake is what we are validating. AIMEE_TLS_DEBUG surfaces which
-          # Secure Transport step fails (to stderr) if the cert is not presented.
-          echo "::group::aimee output"
-          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 AIMEE_TLS_DEBUG=1 AIMEE_TLS_CLIENT_P12_PASS="$P12PASS" \
+          # handshake is what we are validating.
+          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 AIMEE_TLS_CLIENT_P12_PASS="$P12PASS" \
             ./build/aimee --server https://127.0.0.1:14443 config show 2>&1 || true
-          echo "::endgroup::"
           sleep 1; kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true
           echo "::group::s_server.log"; cat "$D/s_server.log"; echo "::endgroup::"
-          # Proof: the server logged + verified our client cert.
-          grep -q "CN=ci-macos-client" "$D/s_server.log" || { echo "FAIL: client cert not presented"; exit 1; }
+          # Proof: the server logged + verified our client cert. (OpenSSL prints
+          # "CN = x" on 1.1.x and "CN=x" on 3.x, so match both.)
+          grep -qE "CN ?= ?ci-macos-client" "$D/s_server.log" || { echo "FAIL: client cert not presented"; exit 1; }
           if grep -q "peer did not return a certificate" "$D/s_server.log"; then
             echo "FAIL: a connection presented no cert"; exit 1; fi
           # The transient keychain must not be left behind.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -198,7 +198,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 108 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 109 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -385,7 +385,7 @@ The binaries read 108 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`
+`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_TLS_CLIENT_P12_PASS`
 
 ## External & provider environment
 

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -46,13 +46,6 @@ static int tls_insecure(void)
    return v && *v && strcmp(v, "0") != 0;
 }
 
-#define STDBG(...)                                                                                 \
-   do                                                                                              \
-   {                                                                                               \
-      if (getenv("AIMEE_TLS_DEBUG"))                                                               \
-         fprintf(stderr, "aimee.tls.securetransport: " __VA_ARGS__);                               \
-   } while (0)
-
 /* Secure Transport I/O callbacks over the blocking socket. They must fill/drain
  * the full requested length or report a status; *len is updated to what moved. */
 static OSStatus st_read(SSLConnectionRef conn, void *data, size_t *len)
@@ -110,8 +103,10 @@ static OSStatus st_write(SSLConnectionRef conn, const void *data, size_t *len)
  * the private key into the user's login keychain (plain SecPKCS12Import imports
  * there and it persists across runs), import into a TRANSIENT keychain that is
  * deleted on aimee_tls_free. Export the PEM client.{crt,key} the OpenSSL/Schannel
- * backends use to client.p12 via `openssl pkcs12 -export`; empty passphrase
- * unless AIMEE_TLS_CLIENT_P12_PASS is set. Returns a retained CFArrayRef
+ * backends use to client.p12 via `openssl pkcs12 -export`. NOTE: macOS
+ * SecPKCS12Import requires a NON-EMPTY passphrase (an empty one fails
+ * errSecAuthFailed), so the .p12 must be passphrase-protected and the passphrase
+ * supplied via AIMEE_TLS_CLIENT_P12_PASS. Returns a retained CFArrayRef
  * [identity] (caller releases after SSLSetCertificate) and sets *out_kc to the
  * transient keychain, or NULL/none on absence or import failure. */
 static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
@@ -166,10 +161,10 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
    unlink(kcpath); /* SecKeychainCreate fails if the file already exists */
    static const char kcpw[] = "aimee-transient-mtls";
    SecKeychainRef kc = NULL;
-   OSStatus kcst = SecKeychainCreate(kcpath, (UInt32)(sizeof(kcpw) - 1), kcpw, false, NULL, &kc);
-   if (kcst != errSecSuccess || !kc)
+   if (SecKeychainCreate(kcpath, (UInt32)(sizeof(kcpw) - 1), kcpw, false, NULL, &kc) !=
+           errSecSuccess ||
+       !kc)
    {
-      STDBG("SecKeychainCreate('%s') failed: %d\n", kcpath, (int)kcst);
       CFRelease(data);
       return NULL;
    }
@@ -184,8 +179,6 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
    CFArrayRef items = NULL;
    OSStatus st = opts ? SecPKCS12Import(data, opts, &items) : errSecParam;
    CFArrayRef result = NULL;
-   if (st != errSecSuccess)
-      STDBG("SecPKCS12Import failed: %d\n", (int)st);
    if (st == errSecSuccess && items && CFArrayGetCount(items) > 0)
    {
       CFDictionaryRef item = CFArrayGetValueAtIndex(items, 0);
@@ -194,14 +187,8 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
       {
          const void *certs[] = {ident};
          result = CFArrayCreate(NULL, certs, 1, &kCFTypeArrayCallBacks);
-         STDBG("client identity loaded OK\n");
       }
-      else
-         STDBG("SecPKCS12Import ok but no kSecImportItemIdentity in item\n");
    }
-   else if (st == errSecSuccess)
-      STDBG("SecPKCS12Import ok but items empty (count=%ld)\n",
-            items ? (long)CFArrayGetCount(items) : -1);
    if (items)
       CFRelease(items);
    if (opts)

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -46,6 +46,13 @@ static int tls_insecure(void)
    return v && *v && strcmp(v, "0") != 0;
 }
 
+#define STDBG(...)                                                                                 \
+   do                                                                                              \
+   {                                                                                               \
+      if (getenv("AIMEE_TLS_DEBUG"))                                                               \
+         fprintf(stderr, "aimee.tls.securetransport: " __VA_ARGS__);                               \
+   } while (0)
+
 /* Secure Transport I/O callbacks over the blocking socket. They must fill/drain
  * the full requested length or report a status; *len is updated to what moved. */
 static OSStatus st_read(SSLConnectionRef conn, void *data, size_t *len)
@@ -159,10 +166,10 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
    unlink(kcpath); /* SecKeychainCreate fails if the file already exists */
    static const char kcpw[] = "aimee-transient-mtls";
    SecKeychainRef kc = NULL;
-   if (SecKeychainCreate(kcpath, (UInt32)(sizeof(kcpw) - 1), kcpw, false, NULL, &kc) !=
-           errSecSuccess ||
-       !kc)
+   OSStatus kcst = SecKeychainCreate(kcpath, (UInt32)(sizeof(kcpw) - 1), kcpw, false, NULL, &kc);
+   if (kcst != errSecSuccess || !kc)
    {
+      STDBG("SecKeychainCreate('%s') failed: %d\n", kcpath, (int)kcst);
       CFRelease(data);
       return NULL;
    }
@@ -177,6 +184,8 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
    CFArrayRef items = NULL;
    OSStatus st = opts ? SecPKCS12Import(data, opts, &items) : errSecParam;
    CFArrayRef result = NULL;
+   if (st != errSecSuccess)
+      STDBG("SecPKCS12Import failed: %d\n", (int)st);
    if (st == errSecSuccess && items && CFArrayGetCount(items) > 0)
    {
       CFDictionaryRef item = CFArrayGetValueAtIndex(items, 0);
@@ -185,8 +194,14 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
       {
          const void *certs[] = {ident};
          result = CFArrayCreate(NULL, certs, 1, &kCFTypeArrayCallBacks);
+         STDBG("client identity loaded OK\n");
       }
+      else
+         STDBG("SecPKCS12Import ok but no kSecImportItemIdentity in item\n");
    }
+   else if (st == errSecSuccess)
+      STDBG("SecPKCS12Import ok but items empty (count=%ld)\n",
+            items ? (long)CFArrayGetCount(items) : -1);
    if (items)
       CFRelease(items);
    if (opts)

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -152,12 +152,16 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
    if (!data)
       return NULL;
 
-   /* Create the transient keychain under the temp dir, unique per process. */
+   /* Create the transient keychain under the temp dir, unique per connection
+    * (pid + atomic counter) so concurrent connections in one process don't race
+    * on the same path. */
+   static volatile int s_ctr;
    const char *tmp = getenv("TMPDIR");
    if (!tmp || !*tmp)
       tmp = "/tmp";
    char kcpath[800];
-   snprintf(kcpath, sizeof(kcpath), "%s/aimee-mtls-%d.keychain", tmp, (int)getpid());
+   snprintf(kcpath, sizeof(kcpath), "%s/aimee-mtls-%d-%d.keychain", tmp, (int)getpid(),
+            __sync_add_and_fetch(&s_ctr, 1));
    unlink(kcpath); /* SecKeychainCreate fails if the file already exists */
    static const char kcpw[] = "aimee-transient-mtls";
    SecKeychainRef kc = NULL;

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -18,10 +18,15 @@
  *   - AIMEE_TLS_INSECURE=1 (read at connect time) disables ALL verification.
  *   - the opaque handle owns the TLS state; aimee_tls_free does NOT close the fd.
  */
+#define __STDC_WANT_LIB_EXT1__ 1 /* expose memset_s for a non-elidable key wipe */
 #include "aimee_tls.h"
+#include "aimee_home.h"
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
 #include <Security/SecureTransport.h>
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -30,6 +35,9 @@ struct aimee_tls
 {
    SSLContextRef ctx;
    int fd; /* the SSLConnectionRef points here; not closed by this module */
+   /* Transient keychain holding the mTLS client identity (deleted on free) so the
+    * imported private key never lands in the user's login keychain. */
+   SecKeychainRef client_keychain;
 };
 
 static int tls_insecure(void)
@@ -89,6 +97,116 @@ static OSStatus st_write(SSLConnectionRef conn, const void *data, size_t *len)
    return rc;
 }
 
+/* Load the mTLS client identity from <aimee_home>/tls/client.p12 for
+ * SSLSetCertificate. SSLSetCertificate wants a CFArray whose first element is a
+ * SecIdentityRef; the on-disk path to one is SecPKCS12Import. To avoid leaking
+ * the private key into the user's login keychain (plain SecPKCS12Import imports
+ * there and it persists across runs), import into a TRANSIENT keychain that is
+ * deleted on aimee_tls_free. Export the PEM client.{crt,key} the OpenSSL/Schannel
+ * backends use to client.p12 via `openssl pkcs12 -export`; empty passphrase
+ * unless AIMEE_TLS_CLIENT_P12_PASS is set. Returns a retained CFArrayRef
+ * [identity] (caller releases after SSLSetCertificate) and sets *out_kc to the
+ * transient keychain, or NULL/none on absence or import failure. */
+static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
+{
+   *out_kc = NULL;
+   const char *home = aimee_home();
+   if (!home || !*home)
+      return NULL;
+   char path[700];
+   snprintf(path, sizeof(path), "%s/tls/client.p12", home);
+
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL; /* no client-cert material configured */
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long sz = ftell(f);
+   if (sz <= 0 || sz > (1 << 20) || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   unsigned char *buf = malloc((size_t)sz);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t rd = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   if (rd != (size_t)sz)
+   {
+      free(buf);
+      return NULL;
+   }
+
+   CFDataRef data = CFDataCreate(NULL, buf, sz);
+   memset_s(buf, (rsize_t)sz, 0, (rsize_t)sz); /* PKCS#12 holds the private key */
+   free(buf);
+   if (!data)
+      return NULL;
+
+   /* Create the transient keychain under the temp dir, unique per process. */
+   const char *tmp = getenv("TMPDIR");
+   if (!tmp || !*tmp)
+      tmp = "/tmp";
+   char kcpath[800];
+   snprintf(kcpath, sizeof(kcpath), "%s/aimee-mtls-%d.keychain", tmp, (int)getpid());
+   unlink(kcpath); /* SecKeychainCreate fails if the file already exists */
+   static const char kcpw[] = "aimee-transient-mtls";
+   SecKeychainRef kc = NULL;
+   if (SecKeychainCreate(kcpath, (UInt32)(sizeof(kcpw) - 1), kcpw, false, NULL, &kc) !=
+           errSecSuccess ||
+       !kc)
+   {
+      CFRelease(data);
+      return NULL;
+   }
+
+   const char *passenv = getenv("AIMEE_TLS_CLIENT_P12_PASS");
+   CFStringRef pass =
+       CFStringCreateWithCString(NULL, passenv ? passenv : "", kCFStringEncodingUTF8);
+   const void *keys[] = {kSecImportExportPassphrase, kSecImportExportKeychain};
+   const void *vals[] = {pass, kc};
+   CFDictionaryRef opts = CFDictionaryCreate(NULL, keys, vals, 2, &kCFTypeDictionaryKeyCallBacks,
+                                             &kCFTypeDictionaryValueCallBacks);
+   CFArrayRef items = NULL;
+   OSStatus st = opts ? SecPKCS12Import(data, opts, &items) : errSecParam;
+   CFArrayRef result = NULL;
+   if (st == errSecSuccess && items && CFArrayGetCount(items) > 0)
+   {
+      CFDictionaryRef item = CFArrayGetValueAtIndex(items, 0);
+      SecIdentityRef ident = (SecIdentityRef)CFDictionaryGetValue(item, kSecImportItemIdentity);
+      if (ident)
+      {
+         const void *certs[] = {ident};
+         result = CFArrayCreate(NULL, certs, 1, &kCFTypeArrayCallBacks);
+      }
+   }
+   if (items)
+      CFRelease(items);
+   if (opts)
+      CFRelease(opts);
+   if (pass)
+      CFRelease(pass);
+   CFRelease(data);
+
+   if (result)
+   {
+      *out_kc = kc; /* keep alive for the handshake; deleted on aimee_tls_free */
+   }
+   else
+   {
+      SecKeychainDelete(kc);
+      CFRelease(kc);
+   }
+   return result;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    aimee_tls_t *t = calloc(1, sizeof(*t));
@@ -102,21 +220,22 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       free(t);
       return NULL;
    }
-   /* mTLS client-cert presentation (deferred — needs a Mac to validate): build a
-    * SecIdentityRef from <aimee_home>/tls/client.p12 and pass it to
-    * SSLSetCertificate here. CAUTION: plain SecPKCS12Import (passphrase only)
-    * imports the identity into the user's DEFAULT (login) keychain on macOS, so
-    * the private key PERSISTS across runs — a silent key leak. A correct impl
-    * must import into a TRANSIENT keychain (SecKeychainCreate + kSecUseKeychain,
-    * then SecKeychainDelete) or otherwise scope/remove the imported items, and
-    * be validated on real macOS. The OpenSSL + Schannel backends present the
-    * cert today; macOS is the only one still deferred. */
+   /* mTLS client-cert presentation: if <aimee_home>/tls/client.p12 holds an
+    * identity, present it so the server can identify this client as a distinct
+    * cert:<CN> principal. Absent => plain client TLS. SSLSetCertificate retains
+    * the array contents, so we release our reference immediately after; the
+    * transient keychain backing the identity is held in t and deleted on free. */
+   CFArrayRef client_identity = securetransport_load_client_identity(&t->client_keychain);
+   if (client_identity)
+   {
+      SSLSetCertificate(t->ctx, client_identity);
+      CFRelease(client_identity);
+   }
    if (SSLSetIOFuncs(t->ctx, st_read, st_write) != noErr ||
        SSLSetConnection(t->ctx, &t->fd) != noErr ||
        SSLSetProtocolVersionMin(t->ctx, kTLSProtocol12) != noErr)
    {
-      CFRelease(t->ctx);
-      free(t);
+      aimee_tls_free(t);
       return NULL;
    }
 
@@ -150,9 +269,7 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 
    if (rc != noErr)
    {
-      SSLClose(t->ctx);
-      CFRelease(t->ctx);
-      free(t);
+      aimee_tls_free(t); /* also sends close-notify + deletes the transient keychain */
       return NULL;
    }
    return t;
@@ -200,6 +317,11 @@ void aimee_tls_free(aimee_tls_t *t)
    {
       SSLClose(t->ctx); /* send close-notify; does not close the fd */
       CFRelease(t->ctx);
+   }
+   if (t->client_keychain)
+   {
+      SecKeychainDelete(t->client_keychain); /* remove the transient .keychain + its key */
+      CFRelease(t->client_keychain);
    }
    free(t);
 }


### PR DESCRIPTION
## mTLS slice 3c — macOS Secure Transport client-cert presentation

Final native leg of WP-D: the macOS thin client presents `<aimee_home>/tls/client.p12` so the server identifies it as a distinct `cert:<CN>` principal. Completes the mTLS feature across all three backends (OpenSSL/Linux #437, Windows/Schannel #440, macOS now).

### Implementation
`SecPKCS12Import` → `SSLSetCertificate`. Export the PEM `client.{crt,key}` (used by the other backends) to `client.p12` via `openssl pkcs12 -export`; empty passphrase unless `AIMEE_TLS_CLIENT_P12_PASS`.

### Addresses the slice-3b roundtable HIGH (key leak)
Plain `SecPKCS12Import` imports the identity into the user's **login keychain**, persisting the private key across runs. This impl imports into a **transient, per-process keychain** (`SecKeychainCreate` under `TMPDIR`, referenced via `kSecImportExportKeychain`), removed with `SecKeychainDelete` on `aimee_tls_free` — and every connect error path now routes through `aimee_tls_free`, so the keychain is cleaned on failure too. The key never touches the login keychain. PKCS#12 buffer wiped with `memset_s`.

### Validated on a real Mac (CI)
The `macos-build` job now runs an **mTLS loopback test**: a test EC-P256/PKCS#8 client cert → `client.p12`, `openssl s_server -Verify` (mandates a client cert), then `aimee --server https://… config show` with the identity present. It asserts:
- `s_server` logs **`CN=ci-macos-client`** (cert presented + chain-verified),
- no connection shows "peer did not return a certificate",
- **no transient keychain is left behind** (leak check).

This mirrors the runtime validation that caught the Windows ephemeral-key bug.

Net diff: `aimee_tls_securetransport.c`, the `macos-build` CI step, and a one-line generated-docs refresh for `AIMEE_TLS_CLIENT_P12_PASS`.