### PR TITLE
fix(webchat): dashboard no longer blanks the whole app on bad payload

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,58 @@
-import { useEffect, useState } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Component, useEffect, useState } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AppShell, Toast } from '@rakuensoftware/smoothgui';
 import type { NavItem } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
+
+// A render error in any page used to throw past the root and unmount the whole
+// app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
+// This boundary contains the failure to the page being rendered so the shell and
+// other routes keep working, and surfaces the error instead of a blank page.
+class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Page render error', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: '24px', fontFamily: 'system-ui', color: '#555' }}>
+          <div style={{ fontSize: '15px', fontWeight: 600, color: '#c62828', marginBottom: '8px' }}>
+            This page hit an error and couldn’t render.
+          </div>
+          <div style={{ fontSize: '13px', color: '#888', marginBottom: '12px' }}>
+            Other pages still work — use the navigation to switch. Details below.
+          </div>
+          <pre style={{
+            fontSize: '12px', color: '#a33', background: '#fff3f3', border: '1px solid #ffd2d2',
+            borderRadius: '6px', padding: '10px', overflow: 'auto', whiteSpace: 'pre-wrap',
+          }}>
+            {this.state.error.message}
+          </pre>
+          <button
+            onClick={() => this.setState({ error: null })}
+            style={{
+              marginTop: '12px', padding: '6px 14px', background: '#fff', color: '#666',
+              border: '1px solid #ddd', borderRadius: '4px', cursor: 'pointer', fontSize: '13px',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 const NAV_ITEMS: NavItem[] = [
   { label: 'Chat', icon: '💬', route: '/chat', section: 'Main' },
@@ -41,6 +89,7 @@ function LogoutButton() {
 
 export default function App() {
   const [ready, setReady] = useState(false);
+  const location = useLocation();
 
   useEffect(() => {
     fetch('/api/chat/session')
@@ -76,12 +125,14 @@ export default function App() {
         navItems={NAV_ITEMS}
         topBarContent={<LogoutButton />}
       >
-        <Routes>
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/workflows" element={<Workflows />} />
-          <Route path="*" element={<Navigate to="/chat" replace />} />
-        </Routes>
+        <ErrorBoundary key={location.pathname}>
+          <Routes>
+            <Route path="/chat" element={<Chat />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/workflows" element={<Workflows />} />
+            <Route path="*" element={<Navigate to="/chat" replace />} />
+          </Routes>
+        </ErrorBoundary>
       </AppShell>
       <Toast />
     </>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -615,17 +615,35 @@ export default function Dashboard() {
         agents?: Agent[];
         onboard?: OnboardReport;
       };
+      // The server-hosted webchat returns shapes the panels can't all consume:
+      // `onboard` may be an `{error}` stub (truthy, no `steps`) and
+      // `memory_stats` may be an object rather than a flat array. A plain `??`
+      // only guards null/undefined, so a wrong-typed-but-truthy value slips
+      // through and a panel's `.map`/`.steps.map` throws. Coerce every field to
+      // the shape its panel expects so a bad payload renders empty, never blank.
+      const arr = <T,>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : []);
+      const plugins = all.plugins;
       setData({
-        delegations: all.delegations ?? [],
-        metrics: all.metrics ?? [],
-        traces: all.traces ?? [],
-        memory: all.memory_stats ?? [],
-        plans: all.plans ?? [],
-        logs: all.logs ?? [],
-        plugins: all.plugins ?? { installed: 0, enabled: 0, hooks_total: 0, tools_total: 0, hook_runs_24h: 0, hook_failures_24h: 0, recent_failures: [] },
+        delegations: arr<Delegation>(all.delegations),
+        metrics: arr<Metric>(all.metrics),
+        traces: arr<Trace>(all.traces),
+        memory: arr<MemoryStat>(all.memory_stats),
+        plans: arr<Plan>(all.plans),
+        logs: arr<LogEntry>(all.logs),
+        plugins: {
+          installed: plugins?.installed ?? 0,
+          enabled: plugins?.enabled ?? 0,
+          hooks_total: plugins?.hooks_total ?? 0,
+          tools_total: plugins?.tools_total ?? 0,
+          hook_runs_24h: plugins?.hook_runs_24h ?? 0,
+          hook_failures_24h: plugins?.hook_failures_24h ?? 0,
+          recent_failures: arr<PluginFailure>(plugins?.recent_failures),
+        },
         lsp: all.lsp ?? null,
-        agents: all.agents ?? [],
-        onboard: all.onboard ?? null,
+        agents: arr<Agent>(all.agents),
+        // Only accept a real onboard report (one that has a `steps` array);
+        // the server's `{error: …}` stub must fall back to null.
+        onboard: Array.isArray(all.onboard?.steps) ? (all.onboard as OnboardReport) : null,
       });
     } catch (err) {
       console.error('Dashboard load failed', err);


### PR DESCRIPTION
## Problem

On the server-hosted webchat (e.g. `.254`), `/dashboard` rendered a **fully blank page** while `/chat` worked.

Root cause (confirmed against the live `.254` deployment): `/chat` and `/dashboard` serve the same single-file SPA, routed client-side. The Dashboard component **threw during render**, and with **no React error boundary** the throw unmounted the entire app → blank. Chat survived because it never renders the crashing panels.

The throw is a server/client contract mismatch in `GET /v1/dashboard/all` (probed live over the server's UDS):

- `onboard` is returned as `{"error":"onboard report is not available from the server-hosted webchat"}` — a **truthy** stub with no `steps`. `load()` did `onboard: all.onboard ?? null` (`??` only guards null/undefined), so `OnboardPanel`'s `if (!data)` guard was skipped and `data.steps.map()` threw.
- `memory_stats` comes back as an **object** (`{tiers, tier_kinds, scopes}`), not the `MemoryStat[]` the frontend expects → `MemoryPanel`'s `data.map()` would also throw.

Not caused by missing smoothgui components or a stale build — the deployed bundle contains the Dashboard code and smoothgui's `Panel`/`Badge`.

## Fix

- **`Dashboard.tsx`** — coerce every dashboard field to the shape its panel expects (`Array.isArray` guards; `onboard` kept only when it carries a `steps` array). A bad/partial payload now renders **empty**, never blank.
- **`App.tsx`** — add an `ErrorBoundary` (keyed by route) wrapping `<Routes>`. Any future render error in any page (Dashboard, Workflows, Chat) now shows an inline error + Retry instead of blanking the whole shell. This is the real robustness gap.

## Verification

- `npm run build` (tsc + vite) green.
- Replayed the exact live `.254` payload through the new guards: `onboard → null` (panel shows "unavailable", no crash), `memory_stats → []` (no crash), `recent_failures → []`.

## Follow-up (not in this PR)

Optional server-side change: have `/v1/dashboard/all` emit `onboard: null` and a flat `memory_stats[]` in server-hosted mode so those two panels show real data instead of rendering empty.