### PR TITLE
agent: always-enable server-hosted OAuth CLI setup (drop opt-in gate)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (108)
+## CLI-settable keys (107)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -128,14 +128,11 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
-| `server_cli_oauth_enabled` | bool | — |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
-
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `server_cli_oauth_enabled`
 
 ## Config-file sections (48)
 

--- a/src/cli_agent_setup.c
+++ b/src/cli_agent_setup.c
@@ -248,10 +248,7 @@ static int setup_oauth_cli_cmd(const char *vendor, int json_output)
    cJSON *started = setup_oauth_rpc("agent.cli_oauth_start", vendor, NULL, NULL, 120000);
    if (!started)
    {
-      fprintf(stderr,
-              "Could not start %s setup (is the server reachable and "
-              "server_cli_oauth_enabled=true?).\n",
-              vendor);
+      fprintf(stderr, "Could not start %s setup (is the server reachable?).\n", vendor);
       return 1;
    }
    char session[160] = "";

--- a/src/cmd_agent_setup.c
+++ b/src/cmd_agent_setup.c
@@ -290,10 +290,7 @@ static void setup_server_oauth_cli(const char *vendor)
    cJSON_Delete(start_body);
    if (!started)
    {
-      fprintf(stderr,
-              "Could not start %s setup (is the server reachable and "
-              "server_cli_oauth_enabled=true?).\n",
-              vendor);
+      fprintf(stderr, "Could not start %s setup (is the server reachable?).\n", vendor);
       return;
    }
    char session[128];

--- a/src/config.c
+++ b/src/config.c
@@ -770,10 +770,6 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->claude_cli_delegate_enabled = cJSON_IsTrue(item);
 
-   item = cJSON_GetObjectItemCaseSensitive(root, "server_cli_oauth_enabled");
-   if (cJSON_IsBool(item))
-      cfg->server_cli_oauth_enabled = cJSON_IsTrue(item);
-
    item = cJSON_GetObjectItemCaseSensitive(root, "verify_cross_project");
    if (cJSON_IsBool(item))
       cfg->verify_cross_project = cJSON_IsTrue(item);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -199,8 +199,6 @@ const config_field_t config_fields[] = {
     {"verify_enabled", offsetof(config_t, verify_enabled), sizeof(int), 1, CFG_BOOL},
     {"claude_cli_delegate_enabled", offsetof(config_t, claude_cli_delegate_enabled), sizeof(int), 1,
      CFG_BOOL},
-    {"server_cli_oauth_enabled", offsetof(config_t, server_cli_oauth_enabled), sizeof(int), 1,
-     CFG_BOOL},
     {"verify_cross_project", offsetof(config_t, verify_cross_project), sizeof(int), 1, CFG_BOOL},
     {"roundtable.max_rounds", offsetof(config_t, roundtable_max_rounds), sizeof(int), 0, CFG_INT},
     {"roundtable.converge_threshold", offsetof(config_t, roundtable_converge_threshold),

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -763,8 +763,6 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "verify_cross_project", 1);
    if (cfg->claude_cli_delegate_enabled)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
-   if (cfg->server_cli_oauth_enabled)
-      cJSON_AddBoolToObject(root, "server_cli_oauth_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
    if (cfg->ingress_preinject_assembly_budget != 6144)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -711,13 +711,6 @@ typedef struct config
     * DELEGATES.md). Does not affect API-key/HTTP agents or other CLI agents. */
    int claude_cli_delegate_enabled;
 
-   /* Operator opt-in (default 0) for the server-hosted OAuth CLI agent setup:
-    * `aimee agent add claude-oauth`/`codex-oauth` installs the vendor CLI on the
-    * aimee-server host and drives its OAuth login there. Running vendor CLIs +
-    * holding their OAuth tokens on a shared server is sensitive (and may bump
-    * vendor terms), so the install/login routes refuse unless this is set. */
-   int server_cli_oauth_enabled;
-
    /* Verify scope. When 0 (default), `aimee git verify` and the push/PR verify
     * gate apply only to the session's current project (the repo the session is
     * rooted in). Cross-project repositories are neither auto-configured (no

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -13,7 +13,7 @@
 #include "vault_service.h"    /* vault_service_set / set_server, VAULT_API_KEY_CRED */
 #include "vault_capability.h" /* vault_capability_server_write_allowed (single server-write gate) */
 #include "server_cli_oauth.h" /* server-hosted OAuth CLI agent setup */
-#include "config.h"           /* server_cli_oauth_enabled gate */
+#include "config.h"           /* config_load / config_t */
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -970,13 +970,8 @@ int handle_agent_setup_poll(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 static int sagent_cli_oauth_gate(server_conn_t *conn, cJSON *req, cli_oauth_vendor_t *v)
 {
-   config_t cfg;
-   config_load(&cfg);
-   if (!cfg.server_cli_oauth_enabled)
-      return server_send_error(conn,
-                               "server-hosted OAuth CLI agents are disabled; set "
-                               "server_cli_oauth_enabled=true to opt in (DELEGATES.md)",
-                               NULL);
+   /* Server-hosted OAuth CLI agent setup is always available — there is no
+    * opt-in gate. Only the vendor argument is validated here. */
    cJSON *jv = cJSON_GetObjectItemCaseSensitive(req, "vendor");
    if (!cJSON_IsString(jv) || cli_oauth_vendor_parse(jv->valuestring, v) != 0)
       return server_send_error(conn, "vendor must be 'claude' or 'codex'", NULL);


### PR DESCRIPTION
## Problem

Webchat's default chat provider is `claude`, which the server execs as a local CLI binary. On a server/container without the Claude CLI installed, chatting fails with:

```
Error: claude exited with status 127: aimee: exec(claude) failed: No such file or directory
```

The intended remedy — `aimee agent setup claude-oauth`, which installs the Claude CLI on the server host and drives its OAuth login there — was blocked by the `server_cli_oauth_enabled` opt-in flag (default off):

```
server-hosted OAuth CLI agents are disabled; set server_cli_oauth_enabled=true to opt in (DELEGATES.md)
```

## Change

Remove the opt-in gate entirely — server-hosted OAuth CLI setup is now always available:

- `sagent_cli_oauth_gate()` no longer loads config or rejects when disabled; it still validates the `vendor` argument.
- Drop the `server_cli_oauth_enabled` field from `config_t` and its load (`config.c`), save (`config_save.c`), and field-table (`config_fields.c`) entries.
- Update the two client-side "could not start" hints (`cli_agent_setup.c`, `cmd_agent_setup.c`) that referenced the flag.
- Regenerate `docs/gen/configuration.md` (key count 108 → 107).

## Verification

- `aimee` and `aimee-server` link clean (`-Werror`, LTO).
- `unit-test-config` → `config: all tests passed`.
- `unit-test-server-cli-oauth` → all pass.

> Note: the gate originally existed to flag that running vendor CLIs and holding their OAuth tokens on a shared server is sensitive (and may conflict with vendor terms). That tradeoff is now accepted by default per request.