### PR TITLE
fix(delegate): bound detached-transport pickup so a clientless workspace can't wedge a turn

### DIFF
--- a/src/headers/workspace_runner_queue.h
+++ b/src/headers/workspace_runner_queue.h
@@ -36,6 +36,7 @@ typedef struct
 {
    pthread_mutex_t mu;
    pthread_cond_t req_cv;            /* signalled when a request is posted (for the runner) */
+   pthread_cond_t req_taken_cv;      /* signalled when the runner claims the request (pickup) */
    pthread_cond_t resp_cv;           /* signalled when a response is posted (for the requester) */
    pthread_cond_t idle_cv;           /* signalled when the in-flight slot frees (single-flight) */
    struct cJSON *req;                /* pending request; queue owns until poll takes it */
@@ -44,6 +45,14 @@ typedef struct
    int has_req;
    int busy;   /* a request cycle is in flight */
    int closed; /* close() called — wake everyone, fail pending */
+   /* Max ms to wait for a runner to *claim* a posted request before giving up.
+    * Guards against a detached workspace with no serving client (e.g. a
+    * backgrounded delegate whose client has disconnected): without it the
+    * transport would block forever and wedge the calling turn. <= 0 selects the
+    * built-in default. Only the pickup is bounded — once a runner claims the
+    * op the response wait stays unbounded, so legit long client commands still
+    * run to completion. */
+   int pickup_timeout_ms;
 } ws_runner_queue_t;
 
 /* Streaming partial callback: invoked (NOT under the queue lock) with each

--- a/src/server/workspace_runner_queue.c
+++ b/src/server/workspace_runner_queue.c
@@ -10,6 +10,7 @@ void ws_runner_queue_init(ws_runner_queue_t *q)
 {
    pthread_mutex_init(&q->mu, NULL);
    pthread_cond_init(&q->req_cv, NULL);
+   pthread_cond_init(&q->req_taken_cv, NULL);
    pthread_cond_init(&q->resp_cv, NULL);
    pthread_cond_init(&q->idle_cv, NULL);
    q->req = NULL;
@@ -18,6 +19,7 @@ void ws_runner_queue_init(ws_runner_queue_t *q)
    q->has_req = 0;
    q->busy = 0;
    q->closed = 0;
+   q->pickup_timeout_ms = 0; /* 0 -> WS_RUNNER_PICKUP_TIMEOUT_MS default */
 }
 
 /* Caller holds q->mu (or has exclusive access during destroy). Frees every
@@ -60,6 +62,7 @@ void ws_runner_queue_destroy(ws_runner_queue_t *q)
    resp_fifo_clear(q);
    pthread_mutex_destroy(&q->mu);
    pthread_cond_destroy(&q->req_cv);
+   pthread_cond_destroy(&q->req_taken_cv);
    pthread_cond_destroy(&q->resp_cv);
    pthread_cond_destroy(&q->idle_cv);
 }
@@ -69,6 +72,7 @@ void ws_runner_queue_close(ws_runner_queue_t *q)
    pthread_mutex_lock(&q->mu);
    q->closed = 1;
    pthread_cond_broadcast(&q->req_cv);
+   pthread_cond_broadcast(&q->req_taken_cv);
    pthread_cond_broadcast(&q->resp_cv);
    pthread_cond_broadcast(&q->idle_cv);
    pthread_mutex_unlock(&q->mu);
@@ -87,6 +91,13 @@ static void deadline_from_now(struct timespec *ts, int timeout_ms)
    }
 }
 
+/* Default pickup deadline: how long the transport waits for *some* runner to
+ * claim a posted request before concluding no client is serving the detached
+ * workspace. Generous enough to ride out a client momentarily between long-poll
+ * cycles, short enough that a truly absent client fails fast instead of wedging
+ * the calling turn until the delegate monitor reaps it (~20 min). */
+#define WS_RUNNER_PICKUP_TIMEOUT_MS 45000
+
 /* Caller holds q->mu. Post `request` into the single-flight slot. Assumes the
  * slot is free (busy==0) and the queue is open. */
 static void post_request_locked(ws_runner_queue_t *q, cJSON *request)
@@ -97,6 +108,31 @@ static void post_request_locked(ws_runner_queue_t *q, cJSON *request)
    /* A fresh op must not see a stale response from a prior aborted cycle. */
    resp_fifo_clear(q);
    pthread_cond_signal(&q->req_cv);
+}
+
+/* Caller holds q->mu, a request was just posted. Block until the runner claims
+ * the request (has_req 1->0), a response is already pending, or the queue
+ * closes — bounded by the pickup deadline. Returns 0 if the op is live (claimed
+ * / response pending / closed — the caller's normal response wait handles those)
+ * or -1 if no runner claimed the request before the deadline (no serving
+ * client). Only the unclaimed window is bounded; a claimed op then waits for its
+ * response without a deadline so a legit long client command isn't cut off. */
+static int wait_for_pickup_locked(ws_runner_queue_t *q)
+{
+   int pickup_ms = q->pickup_timeout_ms > 0 ? q->pickup_timeout_ms : WS_RUNNER_PICKUP_TIMEOUT_MS;
+   struct timespec ts;
+   deadline_from_now(&ts, pickup_ms);
+   while (q->has_req && !q->resp_head && !q->closed)
+   {
+      if (pthread_cond_timedwait(&q->req_taken_cv, &q->mu, &ts) != 0)
+      {
+         /* deadline (or spurious wake): if the request is still unclaimed and
+          * nothing else changed, no runner is serving this queue. */
+         if (q->has_req && !q->resp_head && !q->closed)
+            return -1;
+      }
+   }
+   return 0;
 }
 
 int ws_runner_queue_transport(void *ctx, cJSON *request, cJSON **response)
@@ -119,8 +155,15 @@ int ws_runner_queue_transport(void *ctx, cJSON *request, cJSON **response)
 
    post_request_locked(q, request);
 
-   while (!q->resp_head && !q->closed)
-      pthread_cond_wait(&q->resp_cv, &q->mu);
+   /* Bound only the unclaimed window: if no runner picks the op up, fail fast
+    * rather than block forever (no serving client). Once claimed, the response
+    * wait below is unbounded so a legit long client command runs to completion.
+    * A pickup timeout leaves has_req==1, so the reclaim path below frees it. */
+   if (wait_for_pickup_locked(q) == 0)
+   {
+      while (!q->resp_head && !q->closed)
+         pthread_cond_wait(&q->resp_cv, &q->mu);
+   }
 
    int rc;
    cJSON *resp = resp_fifo_pop(q);
@@ -134,7 +177,8 @@ int ws_runner_queue_transport(void *ctx, cJSON *request, cJSON **response)
    }
    else
    {
-      /* closed before a response arrived; reclaim an untaken request */
+      /* closed, or no runner claimed the op before the pickup deadline; reclaim
+       * an untaken request and fail the transport. */
       rc = -1;
       if (q->has_req)
       {
@@ -171,7 +215,10 @@ int ws_runner_queue_transport_stream(void *ctx, cJSON *request, ws_runner_partia
    post_request_locked(q, request);
 
    int rc = -1;
-   for (;;)
+   /* Bound only the unclaimed window (see ws_runner_queue_transport): a stream
+    * with no serving runner fails fast instead of wedging the turn. Once a
+    * runner claims the op, partials are drained without a deadline. */
+   for (; wait_for_pickup_locked(q) == 0;)
    {
       while (!q->resp_head && !q->closed)
          pthread_cond_wait(&q->resp_cv, &q->mu);
@@ -242,6 +289,9 @@ cJSON *ws_runner_queue_poll(ws_runner_queue_t *q, int timeout_ms)
       r = q->req; /* ownership transfers to the runner */
       q->req = NULL;
       q->has_req = 0;
+      /* Wake the transport's bounded pickup wait so it proceeds to the
+       * (unbounded) response wait the instant the op is claimed. */
+      pthread_cond_signal(&q->req_taken_cv);
    }
    pthread_mutex_unlock(&q->mu);
    return r;

--- a/src/tests/test_workspace_runner_queue.c
+++ b/src/tests/test_workspace_runner_queue.c
@@ -74,6 +74,31 @@ int main(void)
    char fpath[320];
    snprintf(fpath, sizeof(fpath), "%s/q.bin", dir);
 
+   /* No serving runner: a detached workspace whose client never shows up must
+    * fail the transport fast (pickup timeout) rather than deadlock the caller.
+    * This is the delegate-wedge regression: a backgrounded delegate bound to a
+    * detached workspace with no client used to block forever here. */
+   {
+      ws_runner_queue_t nq;
+      ws_runner_queue_init(&nq);
+      nq.pickup_timeout_ms = 100; /* short deadline so the test is quick */
+      ws_detached_provider_t ndp;
+      ws_detached_provider_init_ex(&ndp, ws_runner_queue_transport,
+                                   ws_runner_queue_transport_stream, &nq);
+      const workspace_provider_t *nws = &ndp.base;
+      /* Nothing polls nq, so no runner claims the op -> fail fast, no hang. */
+      char *nout = NULL;
+      size_t nlen = 0;
+      assert(nws->read_all(nws, "/nonexistent", &nout, &nlen) == -1);
+      assert(nout == NULL);
+      /* The streaming transport must fail fast with no runner too. */
+      const char *sargv[] = {"echo", "x", NULL};
+      chunk_collector_t cc = {0};
+      assert(nws->exec_stream(nws, sargv, NULL, 0, "/tmp", collect_chunk, &cc) != 0);
+      free(cc.buf);
+      ws_runner_queue_destroy(&nq);
+   }
+
    ws_runner_queue_init(&g_q);
    pthread_t th;
    assert(pthread_create(&th, NULL, runner_thread, NULL) == 0);


### PR DESCRIPTION
## Problem — the recurring "delegate flakiness"

A delegate that binds its turn to a **detached** workspace marshals bash/file ops over the runner-queue transport to a client-side runner. The **server-side** transport (`ws_runner_queue_transport` / `_stream`) waited on an **unbounded `pthread_cond_wait`** for the runner's response; only the runner-side `poll` used a *timed* wait.

When **no client is serving** the queue — a backgrounded delegate whose dispatching client has disconnected, or a client that drops mid-run — the posted op is never claimed and the transport **blocks forever**. The calling turn's `dispatch_tool_call_ctx` never returns: the job's heartbeat freezes, `cursor` never advances, and it holds a provider slot + lease until the delegate monitor reaps it ~20 min later (`cancelled: stale: in_tool`).

This presents as model flakiness but isn't: the model answers in seconds; the **tool dispatch deadlocks**.

### How it was diagnosed
A live `aimee delegate ... --background` (CLI pointed at `.254`) wedged: one MiniMax-M3 call (HTTP 200, 3s) then `POST /v1/mcp/call -> 200` every ~10s forever, `cursor=''`, heartbeat frozen at the model-call time, `current_tool=bash`, until the 20-min `in_tool` monitor reaped it. Traced through `td_bash` (detached path) → `detached_exec_shell` → `detached_dispatch` → `ws_runner_queue_transport`'s unbounded wait. A turn binds to the detached provider purely from workspace **config** (`workspace_turn.c:238`), with no check that a client is actually serving the queue.

## Fix

Bound only the **unclaimed** window. After posting a request, the transport waits up to a **pickup deadline** (default 45s, per-queue overridable via `pickup_timeout_ms`) for a runner to claim it; if none does, it reclaims the request and fails the op — the bash tool returns an error and the agent recovers — instead of blocking. **Once a runner claims the op the response wait stays unbounded**, so a legitimately long client-side command (build/test) still runs to completion. `poll()` signals a new `req_taken_cv` on claim, so a live runner sees no added latency.

- `workspace_runner_queue.{c,h}`: `req_taken_cv` + `pickup_timeout_ms`; `wait_for_pickup_locked()`; guard both unary and streaming transports; signal on claim.
- `test_workspace_runner_queue.c`: regression — a no-runner transport (unary **and** stream) now fails fast instead of hanging.

## Verification
`unit-test-workspace-runner-queue` (incl. the new no-runner case), `unit-test-workspace-runner-registry`, `unit-test-workspace-turn`, `unit-test-workspace-provider-detached` all pass locally. No positional initializers of the struct exist (all queues go through `ws_runner_queue_init`).

## Deliberately out of scope (follow-up)
Also falling back to the **shared** (co-located) provider when binding a turn whose detached queue has no active subscriber. It's a UX nicety (a background delegate could then run co-located) but riskier — a client that's only briefly between long-polls would wrongly run on the server's filesystem. The pickup timeout already eliminates the deadlock and gives a momentarily-absent client 45s to reappear, so this PR stops there.