### PR TITLE
Promote testing to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,6 +302,51 @@ jobs:
           # --server must parse and select a remote TCP target on macOS.
           ./build/aimee --server http://127.0.0.1:9 version
 
+      - name: mTLS client-cert presentation (Secure Transport, loopback)
+        run: |
+          set -uo pipefail
+          D="$(mktemp -d)"; H="$D/home"; mkdir -p "$H/tls"
+          # Test PKI: CA, server cert, and an EC P-256 client cert whose key is
+          # PKCS#8 (matching what aimee-server issues), bundled into client.p12.
+          openssl ecparam -name prime256v1 -genkey -noout -out "$D/ca.key"
+          openssl req -x509 -new -key "$D/ca.key" -days 1 -subj "/CN=aimee-ci-ca" -out "$D/ca.crt"
+          openssl ecparam -name prime256v1 -genkey -noout -out "$D/srv.key"
+          openssl req -new -key "$D/srv.key" -subj "/CN=localhost" -out "$D/srv.csr"
+          openssl x509 -req -in "$D/srv.csr" -CA "$D/ca.crt" -CAkey "$D/ca.key" \
+            -CAcreateserial -days 1 -out "$D/srv.crt"
+          openssl ecparam -name prime256v1 -genkey -noout -out "$D/c.sec1"
+          openssl pkcs8 -topk8 -nocrypt -in "$D/c.sec1" -out "$H/tls/client.key"
+          openssl req -new -key "$H/tls/client.key" -subj "/CN=ci-macos-client" -out "$D/c.csr"
+          openssl x509 -req -in "$D/c.csr" -CA "$D/ca.crt" -CAkey "$D/ca.key" \
+            -CAcreateserial -days 1 -out "$H/tls/client.crt"
+          # macOS SecPKCS12Import REQUIRES a non-empty passphrase (an empty one
+          # fails errSecAuthFailed -25293), so the .p12 is passphrase-protected
+          # and aimee reads it from AIMEE_TLS_CLIENT_P12_PASS.
+          P12PASS='aimee-ci-p12'
+          openssl pkcs12 -export -inkey "$H/tls/client.key" -in "$H/tls/client.crt" \
+            -out "$H/tls/client.p12" -passout "pass:$P12PASS"
+          # s_server REQUIRES a client cert (-Verify) and serves a status page.
+          openssl s_server -accept 14443 -cert "$D/srv.crt" -key "$D/srv.key" \
+            -CAfile "$D/ca.crt" -Verify 1 -www -naccept 3 > "$D/s_server.log" 2>&1 &
+          SRV=$!
+          for i in $(seq 1 50); do nc -z 127.0.0.1 14443 && break; sleep 0.2; done
+          # Present the client identity (INSECURE skips server-cert trust; the
+          # client cert is still presented). A non-/v1 reply is fine — the TLS
+          # handshake is what we are validating.
+          AIMEE_HOME="$H" AIMEE_TLS_INSECURE=1 AIMEE_TLS_CLIENT_P12_PASS="$P12PASS" \
+            ./build/aimee --server https://127.0.0.1:14443 config show 2>&1 || true
+          sleep 1; kill "$SRV" 2>/dev/null || true; wait "$SRV" 2>/dev/null || true
+          echo "::group::s_server.log"; cat "$D/s_server.log"; echo "::endgroup::"
+          # Proof: the server logged + verified our client cert. (OpenSSL prints
+          # "CN = x" on 1.1.x and "CN=x" on 3.x, so match both.)
+          grep -qE "CN ?= ?ci-macos-client" "$D/s_server.log" || { echo "FAIL: client cert not presented"; exit 1; }
+          if grep -q "peer did not return a certificate" "$D/s_server.log"; then
+            echo "FAIL: a connection presented no cert"; exit 1; fi
+          # The transient keychain must not be left behind.
+          if ls "${TMPDIR:-/tmp}"/aimee-mtls-*.keychain >/dev/null 2>&1; then
+            echo "FAIL: transient keychain leaked"; exit 1; fi
+          echo "PASS: Secure Transport presented client cert; server verified CN=ci-macos-client; no keychain leak"
+
   memory-retrieval-eval:
     runs-on: ubuntu-latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1211,9 +1211,14 @@ if(WITH_TLS)
         find_library(COREFOUNDATION_FRAMEWORK CoreFoundation REQUIRED)
         target_link_libraries(aimee PRIVATE ${SECURITY_FRAMEWORK} ${COREFOUNDATION_FRAMEWORK})
     elseif(WIN32)
-        # Windows: Schannel/SSPI (no OpenSSL; Windows certificate store).
+        # Windows: Schannel/SSPI (no OpenSSL; Windows certificate store). ncrypt
+        # supplies CNG (NCryptImportKey) for mTLS client-key import. Pin
+        # _WIN32_WINNT>=0x0A00 at the build level too (the schannel TU also sets
+        # it before any include) so the CNG/CERT_NCRYPT_KEY_SPEC symbols are
+        # exposed regardless of header include order.
         target_sources(aimee PRIVATE ${AIMEE_SRC_DIR}/aimee_tls_schannel.c)
-        target_link_libraries(aimee PRIVATE secur32 crypt32)
+        target_compile_definitions(aimee PRIVATE _WIN32_WINNT=0x0A00)
+        target_link_libraries(aimee PRIVATE secur32 crypt32 ncrypt)
     else()
         # Linux/other POSIX: OpenSSL.
         find_package(OpenSSL REQUIRED)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -29,16 +29,16 @@ cd aimee
 docker compose -f compose.combined.yaml up --build -d
 ```
 
-This brings up four services:
+By default this brings up **three** services. The browser webchat is a first-class surface that runs *inside* the combined container (not a separate service), and an optional curator-LLM sidecar can be enabled on top:
 
 | Service | What it is | Port |
 |---------|-----------|------|
-| `aimee-server-kb` | Both aimee binaries (server + kb) in one container | `8740` (server `/v1`), `8741` (kb `/v1`) |
+| `aimee-server-kb` | Both aimee binaries (server + kb) **and** the browser webchat UI, in one container | `8740` (server `/v1`), `8741` (kb `/v1`), `8443` (webchat HTTPS, self-signed) |
 | `postgres` | `pgvector/pgvector:pg16` — DB2 (`aimee_shared`) for knowledge + vectors | internal |
-| `embedder` | CPU embedder sidecar (`all-MiniLM-L6-v2`) | internal |
-| webchat | Browser UI — a first-class surface, on by default | `8443` (HTTPS, self-signed) |
+| `embedder` | CPU embedder sidecar (`perplexity-ai/pplx-embed-v1-0.6b`) | internal |
+| `llm` *(optional)* | Curator LLM sidecar (Gemma 3n E4B via `llama.cpp`) for doc/code extraction. Off unless you add `--profile curator-llm`; otherwise the curator stays idle or you point `LLM_ENDPOINT` at your own OpenAI-compatible endpoint. | internal |
 
-The kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first boot. First `--build` takes a few minutes (it compiles the binaries and pulls the embedder model); subsequent starts are fast.
+The kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on first boot. First `--build` takes a few minutes (it compiles the binaries and pulls the embedder model); subsequent starts are fast. To also run the bundled curator LLM, add the profile: `docker compose -f compose.combined.yaml --profile curator-llm up --build -d`.
 
 ### 1.2 Verify it's healthy
 
@@ -87,7 +87,7 @@ Durable state lives in named volumes (`*-postgres`, `*-home`, `*-workspaces`, `*
 
 ## Part 2 — Linux client
 
-On Linux you can build and run the whole stack from source, but as a **client against a Docker/remote server** you only need the thin `aimee` binary, which talks to your `aimee-server` over `/v1`. Unlike the Windows and macOS prebuilt binaries, the Linux build links OpenSSL, so it supports `https://` servers out of the box.
+On Linux you can build and run the whole stack from source, but as a **client against a Docker/remote server** you only need the thin `aimee` binary, which talks to your `aimee-server` over `/v1`. The Linux build links OpenSSL, so it supports `https://` servers (verified against the system trust store) out of the box — as do the prebuilt Windows and macOS clients via their native TLS backends (see [TLS support by build](#tls-support-by-build)).
 
 ### 2.1 Install `aimee`
 
@@ -178,7 +178,7 @@ Because `launch`/`chat` are exec/control operations, the server's `aimee.api.rem
 
 On Windows aimee runs as the **thin client only**: a single `aimee.exe` that talks to your remote `aimee-server` over `/v1`. The server and kb run in Docker (Part 1) or on a Linux/macOS host — never on Windows.
 
-> **TLS note:** the Windows client is built **without TLS** and refuses `https://`. Point it at an `http://` address; if your server is HTTPS, terminate TLS at a reverse proxy and use that proxy's `http://` endpoint.
+> **TLS note:** the Windows client now speaks `https://` natively via **Schannel**, verifying the chain and hostname against the **Windows certificate store** — no OpenSSL and no bundled CA bundle, just the single self-contained `aimee.exe`. Both the prebuilt release binary and the `install.ps1` build enable it. Set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert.
 
 ### 3.1 Install `aimee.exe`
 
@@ -211,7 +211,7 @@ aimee remote status     # shows the resolved transport + a /v1/health probe
 aimee status            # server, DB1, and kb health
 ```
 
-Use your real bearer token instead of `aimee-local-dev` if you changed it. Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` environment variables, or pass `--server http://YOUR_SERVER:8740 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
+Use your real bearer token instead of `aimee-local-dev` if you changed it. For an HTTPS server, `https://` works with certificate verification on by default (Schannel against the Windows cert store); set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` environment variables, or pass `--server http://YOUR_SERVER:8740 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
 
 ### 3.3 Configure your AI coding tool
 
@@ -274,16 +274,16 @@ mv aimee-macos-universal ~/.local/bin/aimee
 export PATH="$HOME/.local/bin:$PATH"
 ```
 
-The prebuilt macOS binary is a universal (arm64 + x86_64) build and, like Windows, is built **without TLS** — point it at an `http://` server.
+The prebuilt macOS binary is a universal (arm64 + x86_64) build and speaks `https://` natively via **Secure Transport**, evaluating trust against the **Keychain** — no OpenSSL and no bundled CA bundle. Set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert.
 
-**Option B — build the thin client from source** (needs Xcode Command Line Tools + CMake; this build *does* support `https://` via OpenSSL):
+**Option B — build the thin client from source** (needs Xcode Command Line Tools + CMake; TLS uses Secure Transport/Keychain, so no OpenSSL is required):
 
 ```bash
 git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
 cmake -B build -DAIMEE_THIN_CLIENT=ON -DAIMEE_LEAN=ON \
-      -DOPENSSL_ROOT_DIR="$(brew --prefix openssl@3)" \
-      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF
+      -DWITH_PAM=OFF -DWITH_LIBSECRET=OFF -DWITH_UI=OFF -DWITH_TLS=ON \
+      -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64"   # drop for a host-arch-only build
 cmake --build build --target aimee
 cp build/aimee ~/.local/bin/aimee      # or anywhere on your PATH
 ```
@@ -304,7 +304,7 @@ aimee remote status     # resolved transport + /v1/health probe
 aimee status            # server, DB1, and kb health
 ```
 
-For an HTTPS server with a source-built (OpenSSL) client, `https://` works with cert verification on; set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. The prebuilt (TLS-off) binary supports `http://` only. As on the other platforms, you can use `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` or `--server` instead of `aimee remote set`.
+Both the prebuilt universal binary and a source build speak `https://` with certificate verification on by default (Secure Transport against the Keychain); set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. As on the other platforms, you can use `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` or `--server` instead of `aimee remote set`.
 
 ### 4.3 Configure your AI coding tool
 
@@ -351,14 +351,15 @@ As on the other platforms, `aimee chat` and `aimee launch` work against a remote
 
 ## TLS support by build
 
-| Client | `https://` support |
-|--------|--------------------|
-| Linux — prebuilt release binary or `make` build | Yes (OpenSSL linked by default) |
-| macOS — source build with OpenSSL | Yes |
-| macOS — prebuilt `aimee-macos-universal` | No — `http://` only |
-| Windows — prebuilt or `install.ps1` build | No — `http://` only (terminate TLS at a proxy) |
+Every supported client now speaks `https://` out of the box, each using its platform's native trust store — no bundled CA bundle. Certificate verification is on by default; set `AIMEE_TLS_INSECURE=1` to skip it for a self-signed dev cert.
 
-For any TLS-off client, terminate TLS at a reverse proxy and point the client at the proxy's `http://` address.
+| Client | `https://` support | TLS backend / trust store |
+|--------|--------------------|---------------------------|
+| Linux — prebuilt release binary or `make` build | Yes | OpenSSL — system trust store |
+| macOS — prebuilt `aimee-macos-universal` or source build | Yes | Secure Transport — Keychain |
+| Windows — prebuilt or `install.ps1` build | Yes | Schannel — Windows certificate store |
+
+For per-client cryptographic identity (not just a shared bearer), the server also supports **mTLS client certificates** — clients present a cert from `<aimee_home>/tls/client.{crt,key}` and the server maps it to a `cert:<CN>` principal. Issue and manage them with the `aimee cert` CLI (`/v1/cert/issue|list|revoke`); see the [Manual](../MANUAL.md) for setup.
 
 ## Next steps
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -198,7 +198,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 108 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 109 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -385,7 +385,7 @@ The binaries read 108 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`
+`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_TLS_CLIENT_P12_PASS`
 
 ## External & provider environment
 

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -18,16 +18,25 @@
  * record). Mid-stream SEC_I_RENEGOTIATE is handled by re-running the handshake.
  */
 #define SECURITY_WIN32
+/* Ensure CNG / modern crypt32 symbols (NCrypt*, CERT_NCRYPT_KEY_SPEC) are
+ * exposed before any Windows header is pulled in. */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0A00
+#endif
 #include "aimee_tls.h"
+#include "aimee_home.h"
 
 #include <windows.h>
 #include <schannel.h>
 #include <security.h>
 #include <sspi.h>
 #include <wincrypt.h>
+#include <ncrypt.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <wchar.h>
 
 #ifndef SP_PROT_TLS1_2_CLIENT
 #define SP_PROT_TLS1_2_CLIENT 0x00000800
@@ -35,8 +44,20 @@
 #ifndef SCH_USE_STRONG_CRYPTO
 #define SCH_USE_STRONG_CRYPTO 0x00400000
 #endif
+/* CNG / NCrypt fallbacks for older MinGW headers (same defensive pattern as the
+ * SP_PROT_* defines above). */
+#ifndef NCRYPT_PKCS8_PRIVATE_KEY_BLOB
+#define NCRYPT_PKCS8_PRIVATE_KEY_BLOB L"PKCS8_PRIVATEKEY"
+#endif
+#ifndef MS_KEY_STORAGE_PROVIDER
+#define MS_KEY_STORAGE_PROVIDER L"Microsoft Software Key Storage Provider"
+#endif
+#ifndef CERT_NCRYPT_KEY_SPEC
+#define CERT_NCRYPT_KEY_SPEC 0xFFFFFFFF
+#endif
 
-#define ENC_CAP 32768 /* one TLS record fits comfortably; grown via recv loop */
+#define ENC_CAP           32768 /* one TLS record fits comfortably; grown via recv loop */
+#define AIMEE_KEYNAME_LEN 64
 
 struct aimee_tls
 {
@@ -52,6 +73,12 @@ struct aimee_tls
 
    unsigned char *dec; /* decrypted plaintext not yet delivered */
    size_t dec_off, dec_len, dec_cap;
+
+   /* mTLS client identity (present when <aimee_home>/tls/client.{crt,key} loaded). */
+   PCCERT_CONTEXT client_cert;
+   NCRYPT_PROV_HANDLE client_prov;
+   NCRYPT_KEY_HANDLE client_key;
+   WCHAR client_key_name[AIMEE_KEYNAME_LEN]; /* persisted CNG key container (deleted on free) */
 };
 
 static int tls_insecure(void)
@@ -253,6 +280,163 @@ static int do_handshake(aimee_tls_t *t, int initial)
    }
 }
 
+/* Read a whole file (<= 1 MiB) into a malloc'd buffer; *out_len set on success. */
+static unsigned char *read_small_file(const char *path, DWORD *out_len)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long sz = ftell(f);
+   if (sz <= 0 || sz > (1 << 20) || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   unsigned char *b = malloc((size_t)sz);
+   if (!b)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t rd = fread(b, 1, (size_t)sz, f);
+   fclose(f);
+   if (rd != (size_t)sz)
+   {
+      free(b);
+      return NULL;
+   }
+   *out_len = (DWORD)sz;
+   return b;
+}
+
+/* Decode the first base64 PEM block (-----BEGIN/END-----) to DER. */
+static int pem_to_der(const unsigned char *pem, DWORD pem_len, unsigned char **der, DWORD *der_len)
+{
+   DWORD n = 0;
+   if (!CryptStringToBinaryA((LPCSTR)pem, pem_len, CRYPT_STRING_BASE64HEADER, NULL, &n, NULL, NULL))
+      return -1;
+   unsigned char *d = malloc(n ? n : 1);
+   if (!d)
+      return -1;
+   if (!CryptStringToBinaryA((LPCSTR)pem, pem_len, CRYPT_STRING_BASE64HEADER, d, &n, NULL, NULL))
+   {
+      free(d);
+      return -1;
+   }
+   *der = d;
+   *der_len = n;
+   return 0;
+}
+
+/* Load <aimee_home>/tls/client.{crt,key} (PEM cert + PKCS#8 EC key) as this
+ * client's identity: decode to DER, import the key into an ephemeral CNG store,
+ * and bind it to the cert context. Returns 1 (loaded -> t->client_cert set),
+ * 0 (no material configured), or -1 (present but failed to load). The server's
+ * key is PKCS#8 (OpenSSL PEM_write_bio_PrivateKey), so NCRYPT_PKCS8_PRIVATE_KEY_BLOB
+ * imports it directly. (NTFS ACLs, not POSIX mode bits, govern key secrecy here.) */
+static int schannel_load_client_identity(aimee_tls_t *t)
+{
+   const char *home = aimee_home();
+   if (!home || !*home)
+      return 0;
+   char crt[600], key[600];
+   snprintf(crt, sizeof(crt), "%s/tls/client.crt", home);
+   snprintf(key, sizeof(key), "%s/tls/client.key", home);
+   if (GetFileAttributesA(crt) == INVALID_FILE_ATTRIBUTES ||
+       GetFileAttributesA(key) == INVALID_FILE_ATTRIBUTES)
+      return 0; /* no client-cert material configured */
+
+   int rc = -1;
+   unsigned char *cpem = NULL, *kpem = NULL, *cder = NULL, *kder = NULL;
+   DWORD clen = 0, klen = 0, cdl = 0, kdl = 0;
+   PCCERT_CONTEXT cert = NULL;
+   NCRYPT_PROV_HANDLE prov = 0;
+   NCRYPT_KEY_HANDLE hkey = 0;
+
+   cpem = read_small_file(crt, &clen);
+   kpem = read_small_file(key, &klen);
+   if (!cpem || !kpem)
+      goto done;
+   if (pem_to_der(cpem, clen, &cder, &cdl) != 0 || pem_to_der(kpem, klen, &kder, &kdl) != 0)
+      goto done;
+
+   cert = CertCreateCertificateContext(X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, cder, cdl);
+   if (!cert)
+      goto done;
+   {
+      if (NCryptOpenStorageProvider(&prov, MS_KEY_STORAGE_PROVIDER, 0) != ERROR_SUCCESS)
+         goto done;
+      /* Import the key PERSISTED under a unique container name. Schannel signs
+       * the CertificateVerify by opening the key via the cert's PROV_INFO, and
+       * it cannot use an ephemeral (nameless) CNG handle for that — so a named
+       * key + CERT_KEY_PROV_INFO_PROP_ID is required, not CERT_KEY_CONTEXT.
+       * (Runtime-validated on Windows: the ephemeral binding presented no cert.) */
+      static volatile LONG s_ctr;
+      swprintf(t->client_key_name, AIMEE_KEYNAME_LEN, L"aimee-mtls-%lu-%ld",
+               (unsigned long)GetCurrentProcessId(), InterlockedIncrement(&s_ctr));
+      NCryptBuffer nb;
+      nb.BufferType = NCRYPTBUFFER_PKCS_KEY_NAME;
+      nb.cbBuffer = (DWORD)((wcslen(t->client_key_name) + 1) * sizeof(WCHAR));
+      nb.pvBuffer = t->client_key_name;
+      NCryptBufferDesc nbd;
+      nbd.ulVersion = NCRYPTBUFFER_VERSION;
+      nbd.cBuffers = 1;
+      nbd.pBuffers = &nb;
+      if (NCryptImportKey(prov, 0, NCRYPT_PKCS8_PRIVATE_KEY_BLOB, &nbd, &hkey, kder, kdl,
+                          NCRYPT_OVERWRITE_KEY_FLAG | NCRYPT_SILENT_FLAG) != ERROR_SUCCESS)
+      {
+         hkey = 0; /* MSDN: phKey is undefined on failure — don't act on it in done: */
+         t->client_key_name[0] = 0;
+         goto done;
+      }
+   }
+
+   {
+      CRYPT_KEY_PROV_INFO pi;
+      memset(&pi, 0, sizeof(pi));
+      pi.pwszContainerName = t->client_key_name;
+      pi.pwszProvName = (LPWSTR)MS_KEY_STORAGE_PROVIDER;
+      pi.dwProvType = 0; /* 0 + a CNG KSP name => CNG key */
+      pi.dwKeySpec = 0;  /* ignored for CNG */
+      if (!CertSetCertificateContextProperty(cert, CERT_KEY_PROV_INFO_PROP_ID, 0, &pi))
+         goto done;
+   }
+
+   t->client_cert = cert;
+   t->client_prov = prov;
+   t->client_key = hkey;
+   cert = NULL; /* ownership transferred to the handle */
+   prov = 0;
+   hkey = 0;
+   rc = 1;
+
+done:
+   if (kder)
+   {
+      SecureZeroMemory(kder, kdl); /* DER holds the private key */
+      free(kder);
+   }
+   if (kpem)
+   {
+      SecureZeroMemory(kpem, klen);
+      free(kpem);
+   }
+   free(cder);
+   free(cpem);
+   if (hkey)
+      NCryptDeleteKey(hkey, NCRYPT_SILENT_FLAG); /* error path: remove the persisted key + free */
+   if (prov)
+      NCryptFreeObject(prov);
+   if (cert)
+      CertFreeCertificateContext(cert);
+   return rc;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    aimee_tls_t *t = calloc(1, sizeof(*t));
@@ -272,12 +456,16 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    /* We validate the chain + hostname ourselves post-handshake, so tell Schannel
     * not to auto-validate (and never use a machine default client cert). */
    sc.dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_MANUAL_CRED_VALIDATION | SCH_USE_STRONG_CRYPTO;
-   /* mTLS client-cert presentation (slice 3b, follow-up): to present
-    * <aimee_home>/tls/client.{crt,key} as this client's identity, build a
-    * CERT_CONTEXT (PEM -> CertCreateCertificateContext) with an associated CNG
-    * private key and set sc.cCreds/sc.paCred here. Deferred: EC-key import via
-    * CryptoAPI is intricate and must be validated on real Windows (as the
-    * native backend itself was). The OpenSSL backend presents the cert today. */
+   /* mTLS client-cert presentation: if <aimee_home>/tls/client.{crt,key} loads,
+    * hand Schannel the cert (with its CNG key) so the server can identify this
+    * client as a distinct cert:<CN> principal. Absent => plain client TLS. A
+    * load failure (-1) leaves the handshake cert-less; the mTLS server then
+    * rejects it, which is the correct signal for broken client-cert material. */
+   if (schannel_load_client_identity(t) == 1)
+   {
+      sc.cCreds = 1;
+      sc.paCred = &t->client_cert;
+   }
 
    if (AcquireCredentialsHandleA(NULL, (SEC_CHAR *)UNISP_NAME_A, SECPKG_CRED_OUTBOUND, NULL, &sc,
                                  NULL, NULL, &t->cred, NULL) != SEC_E_OK)
@@ -518,6 +706,13 @@ void aimee_tls_free(aimee_tls_t *t)
    }
    if (t->have_cred)
       FreeCredentialsHandle(&t->cred);
+   if (t->client_cert)
+      CertFreeCertificateContext(t->client_cert);
+   if (t->client_key)
+      NCryptDeleteKey(t->client_key,
+                      NCRYPT_SILENT_FLAG); /* delete the persisted key + free handle */
+   if (t->client_prov)
+      NCryptFreeObject(t->client_prov);
    free(t->dec);
    free(t->host);
    free(t);

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -18,10 +18,15 @@
  *   - AIMEE_TLS_INSECURE=1 (read at connect time) disables ALL verification.
  *   - the opaque handle owns the TLS state; aimee_tls_free does NOT close the fd.
  */
+#define __STDC_WANT_LIB_EXT1__ 1 /* expose memset_s for a non-elidable key wipe */
 #include "aimee_tls.h"
+#include "aimee_home.h"
 
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
 #include <Security/SecureTransport.h>
 #include <errno.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -30,6 +35,9 @@ struct aimee_tls
 {
    SSLContextRef ctx;
    int fd; /* the SSLConnectionRef points here; not closed by this module */
+   /* Transient keychain holding the mTLS client identity (deleted on free) so the
+    * imported private key never lands in the user's login keychain. */
+   SecKeychainRef client_keychain;
 };
 
 static int tls_insecure(void)
@@ -89,6 +97,122 @@ static OSStatus st_write(SSLConnectionRef conn, const void *data, size_t *len)
    return rc;
 }
 
+/* Load the mTLS client identity from <aimee_home>/tls/client.p12 for
+ * SSLSetCertificate. SSLSetCertificate wants a CFArray whose first element is a
+ * SecIdentityRef; the on-disk path to one is SecPKCS12Import. To avoid leaking
+ * the private key into the user's login keychain (plain SecPKCS12Import imports
+ * there and it persists across runs), import into a TRANSIENT keychain that is
+ * deleted on aimee_tls_free. Export the PEM client.{crt,key} the OpenSSL/Schannel
+ * backends use to client.p12 via `openssl pkcs12 -export`. NOTE: macOS
+ * SecPKCS12Import requires a NON-EMPTY passphrase (an empty one fails
+ * errSecAuthFailed), so the .p12 must be passphrase-protected and the passphrase
+ * supplied via AIMEE_TLS_CLIENT_P12_PASS. Returns a retained CFArrayRef
+ * [identity] (caller releases after SSLSetCertificate) and sets *out_kc to the
+ * transient keychain, or NULL/none on absence or import failure. */
+static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
+{
+   *out_kc = NULL;
+   const char *home = aimee_home();
+   if (!home || !*home)
+      return NULL;
+   char path[700];
+   snprintf(path, sizeof(path), "%s/tls/client.p12", home);
+
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL; /* no client-cert material configured */
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long sz = ftell(f);
+   if (sz <= 0 || sz > (1 << 20) || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   unsigned char *buf = malloc((size_t)sz);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t rd = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   if (rd != (size_t)sz)
+   {
+      free(buf);
+      return NULL;
+   }
+
+   CFDataRef data = CFDataCreate(NULL, buf, sz);
+   memset_s(buf, (rsize_t)sz, 0, (rsize_t)sz); /* PKCS#12 holds the private key */
+   free(buf);
+   if (!data)
+      return NULL;
+
+   /* Create the transient keychain under the temp dir, unique per connection
+    * (pid + atomic counter) so concurrent connections in one process don't race
+    * on the same path. */
+   static volatile int s_ctr;
+   const char *tmp = getenv("TMPDIR");
+   if (!tmp || !*tmp)
+      tmp = "/tmp";
+   char kcpath[800];
+   snprintf(kcpath, sizeof(kcpath), "%s/aimee-mtls-%d-%d.keychain", tmp, (int)getpid(),
+            __sync_add_and_fetch(&s_ctr, 1));
+   unlink(kcpath); /* SecKeychainCreate fails if the file already exists */
+   static const char kcpw[] = "aimee-transient-mtls";
+   SecKeychainRef kc = NULL;
+   if (SecKeychainCreate(kcpath, (UInt32)(sizeof(kcpw) - 1), kcpw, false, NULL, &kc) !=
+           errSecSuccess ||
+       !kc)
+   {
+      CFRelease(data);
+      return NULL;
+   }
+
+   const char *passenv = getenv("AIMEE_TLS_CLIENT_P12_PASS");
+   CFStringRef pass =
+       CFStringCreateWithCString(NULL, passenv ? passenv : "", kCFStringEncodingUTF8);
+   const void *keys[] = {kSecImportExportPassphrase, kSecImportExportKeychain};
+   const void *vals[] = {pass, kc};
+   CFDictionaryRef opts = CFDictionaryCreate(NULL, keys, vals, 2, &kCFTypeDictionaryKeyCallBacks,
+                                             &kCFTypeDictionaryValueCallBacks);
+   CFArrayRef items = NULL;
+   OSStatus st = opts ? SecPKCS12Import(data, opts, &items) : errSecParam;
+   CFArrayRef result = NULL;
+   if (st == errSecSuccess && items && CFArrayGetCount(items) > 0)
+   {
+      CFDictionaryRef item = CFArrayGetValueAtIndex(items, 0);
+      SecIdentityRef ident = (SecIdentityRef)CFDictionaryGetValue(item, kSecImportItemIdentity);
+      if (ident)
+      {
+         const void *certs[] = {ident};
+         result = CFArrayCreate(NULL, certs, 1, &kCFTypeArrayCallBacks);
+      }
+   }
+   if (items)
+      CFRelease(items);
+   if (opts)
+      CFRelease(opts);
+   if (pass)
+      CFRelease(pass);
+   CFRelease(data);
+
+   if (result)
+   {
+      *out_kc = kc; /* keep alive for the handshake; deleted on aimee_tls_free */
+   }
+   else
+   {
+      SecKeychainDelete(kc);
+      CFRelease(kc);
+   }
+   return result;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    aimee_tls_t *t = calloc(1, sizeof(*t));
@@ -102,21 +226,22 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       free(t);
       return NULL;
    }
-   /* mTLS client-cert presentation (deferred — needs a Mac to validate): build a
-    * SecIdentityRef from <aimee_home>/tls/client.p12 and pass it to
-    * SSLSetCertificate here. CAUTION: plain SecPKCS12Import (passphrase only)
-    * imports the identity into the user's DEFAULT (login) keychain on macOS, so
-    * the private key PERSISTS across runs — a silent key leak. A correct impl
-    * must import into a TRANSIENT keychain (SecKeychainCreate + kSecUseKeychain,
-    * then SecKeychainDelete) or otherwise scope/remove the imported items, and
-    * be validated on real macOS. The OpenSSL + Schannel backends present the
-    * cert today; macOS is the only one still deferred. */
+   /* mTLS client-cert presentation: if <aimee_home>/tls/client.p12 holds an
+    * identity, present it so the server can identify this client as a distinct
+    * cert:<CN> principal. Absent => plain client TLS. SSLSetCertificate retains
+    * the array contents, so we release our reference immediately after; the
+    * transient keychain backing the identity is held in t and deleted on free. */
+   CFArrayRef client_identity = securetransport_load_client_identity(&t->client_keychain);
+   if (client_identity)
+   {
+      SSLSetCertificate(t->ctx, client_identity);
+      CFRelease(client_identity);
+   }
    if (SSLSetIOFuncs(t->ctx, st_read, st_write) != noErr ||
        SSLSetConnection(t->ctx, &t->fd) != noErr ||
        SSLSetProtocolVersionMin(t->ctx, kTLSProtocol12) != noErr)
    {
-      CFRelease(t->ctx);
-      free(t);
+      aimee_tls_free(t);
       return NULL;
    }
 
@@ -150,9 +275,7 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 
    if (rc != noErr)
    {
-      SSLClose(t->ctx);
-      CFRelease(t->ctx);
-      free(t);
+      aimee_tls_free(t); /* also sends close-notify + deletes the transient keychain */
       return NULL;
    }
    return t;
@@ -200,6 +323,11 @@ void aimee_tls_free(aimee_tls_t *t)
    {
       SSLClose(t->ctx); /* send close-notify; does not close the fd */
       CFRelease(t->ctx);
+   }
+   if (t->client_keychain)
+   {
+      SecKeychainDelete(t->client_keychain); /* remove the transient .keychain + its key */
+      CFRelease(t->client_keychain);
    }
    free(t);
 }

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -102,11 +102,15 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       free(t);
       return NULL;
    }
-   /* mTLS client-cert presentation (slice 3b, follow-up): to present
-    * <aimee_home>/tls/client.{crt,key} as this client's identity, build a
-    * SecIdentityRef from the PEM (SecPKCS12Import / SecItem) and pass it to
-    * SSLSetCertificate here. Deferred: identity construction must be validated
-    * on real macOS. The OpenSSL backend presents the cert today. */
+   /* mTLS client-cert presentation (deferred — needs a Mac to validate): build a
+    * SecIdentityRef from <aimee_home>/tls/client.p12 and pass it to
+    * SSLSetCertificate here. CAUTION: plain SecPKCS12Import (passphrase only)
+    * imports the identity into the user's DEFAULT (login) keychain on macOS, so
+    * the private key PERSISTS across runs — a silent key leak. A correct impl
+    * must import into a TRANSIENT keychain (SecKeychainCreate + kSecUseKeychain,
+    * then SecKeychainDelete) or otherwise scope/remove the imported items, and
+    * be validated on real macOS. The OpenSSL + Schannel backends present the
+    * cert today; macOS is the only one still deferred. */
    if (SSLSetIOFuncs(t->ctx, st_read, st_write) != noErr ||
        SSLSetConnection(t->ctx, &t->fd) != noErr ||
        SSLSetProtocolVersionMin(t->ctx, kTLSProtocol12) != noErr)


### PR DESCRIPTION
Routine promotion of `testing` → `main`.

Net changes since the last promotion (#441):
- **mTLS native client-cert presentation** — Windows Schannel + macOS (slice 3b, #440) and macOS Secure Transport (slice 3c, #442).
- **CI** — added coverage in `.github/workflows/ci.yml` for the above.
- **docs** — QUICKSTART synced with current testing (native TLS backends, embedder default, service list) (#445).

Clean merge, no conflicts; all constituent PRs merged green on testing.