### PR TITLE
promote: testing → main (delegate deadlock + dashboard + server-OAuth fixes)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (108)
+## CLI-settable keys (107)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -128,14 +128,11 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
-| `server_cli_oauth_enabled` | bool | — |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
-
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `server_cli_oauth_enabled`
 
 ## Config-file sections (48)
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,58 @@
-import { useEffect, useState } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { Component, useEffect, useState } from 'react';
+import type { ErrorInfo, ReactNode } from 'react';
+import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AppShell, Toast } from '@rakuensoftware/smoothgui';
 import type { NavItem } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
+
+// A render error in any page used to throw past the root and unmount the whole
+// app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
+// This boundary contains the failure to the page being rendered so the shell and
+// other routes keep working, and surfaces the error instead of a blank page.
+class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+  state: { error: Error | null } = { error: null };
+
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error('Page render error', error, info);
+  }
+
+  render() {
+    if (this.state.error) {
+      return (
+        <div style={{ padding: '24px', fontFamily: 'system-ui', color: '#555' }}>
+          <div style={{ fontSize: '15px', fontWeight: 600, color: '#c62828', marginBottom: '8px' }}>
+            This page hit an error and couldn’t render.
+          </div>
+          <div style={{ fontSize: '13px', color: '#888', marginBottom: '12px' }}>
+            Other pages still work — use the navigation to switch. Details below.
+          </div>
+          <pre style={{
+            fontSize: '12px', color: '#a33', background: '#fff3f3', border: '1px solid #ffd2d2',
+            borderRadius: '6px', padding: '10px', overflow: 'auto', whiteSpace: 'pre-wrap',
+          }}>
+            {this.state.error.message}
+          </pre>
+          <button
+            onClick={() => this.setState({ error: null })}
+            style={{
+              marginTop: '12px', padding: '6px 14px', background: '#fff', color: '#666',
+              border: '1px solid #ddd', borderRadius: '4px', cursor: 'pointer', fontSize: '13px',
+            }}
+          >
+            Retry
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
 
 const NAV_ITEMS: NavItem[] = [
   { label: 'Chat', icon: '💬', route: '/chat', section: 'Main' },
@@ -41,6 +89,7 @@ function LogoutButton() {
 
 export default function App() {
   const [ready, setReady] = useState(false);
+  const location = useLocation();
 
   useEffect(() => {
     fetch('/api/chat/session')
@@ -76,12 +125,14 @@ export default function App() {
         navItems={NAV_ITEMS}
         topBarContent={<LogoutButton />}
       >
-        <Routes>
-          <Route path="/chat" element={<Chat />} />
-          <Route path="/dashboard" element={<Dashboard />} />
-          <Route path="/workflows" element={<Workflows />} />
-          <Route path="*" element={<Navigate to="/chat" replace />} />
-        </Routes>
+        <ErrorBoundary key={location.pathname}>
+          <Routes>
+            <Route path="/chat" element={<Chat />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/workflows" element={<Workflows />} />
+            <Route path="*" element={<Navigate to="/chat" replace />} />
+          </Routes>
+        </ErrorBoundary>
       </AppShell>
       <Toast />
     </>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -615,17 +615,35 @@ export default function Dashboard() {
         agents?: Agent[];
         onboard?: OnboardReport;
       };
+      // The server-hosted webchat returns shapes the panels can't all consume:
+      // `onboard` may be an `{error}` stub (truthy, no `steps`) and
+      // `memory_stats` may be an object rather than a flat array. A plain `??`
+      // only guards null/undefined, so a wrong-typed-but-truthy value slips
+      // through and a panel's `.map`/`.steps.map` throws. Coerce every field to
+      // the shape its panel expects so a bad payload renders empty, never blank.
+      const arr = <T,>(v: unknown): T[] => (Array.isArray(v) ? (v as T[]) : []);
+      const plugins = all.plugins;
       setData({
-        delegations: all.delegations ?? [],
-        metrics: all.metrics ?? [],
-        traces: all.traces ?? [],
-        memory: all.memory_stats ?? [],
-        plans: all.plans ?? [],
-        logs: all.logs ?? [],
-        plugins: all.plugins ?? { installed: 0, enabled: 0, hooks_total: 0, tools_total: 0, hook_runs_24h: 0, hook_failures_24h: 0, recent_failures: [] },
+        delegations: arr<Delegation>(all.delegations),
+        metrics: arr<Metric>(all.metrics),
+        traces: arr<Trace>(all.traces),
+        memory: arr<MemoryStat>(all.memory_stats),
+        plans: arr<Plan>(all.plans),
+        logs: arr<LogEntry>(all.logs),
+        plugins: {
+          installed: plugins?.installed ?? 0,
+          enabled: plugins?.enabled ?? 0,
+          hooks_total: plugins?.hooks_total ?? 0,
+          tools_total: plugins?.tools_total ?? 0,
+          hook_runs_24h: plugins?.hook_runs_24h ?? 0,
+          hook_failures_24h: plugins?.hook_failures_24h ?? 0,
+          recent_failures: arr<PluginFailure>(plugins?.recent_failures),
+        },
         lsp: all.lsp ?? null,
-        agents: all.agents ?? [],
-        onboard: all.onboard ?? null,
+        agents: arr<Agent>(all.agents),
+        // Only accept a real onboard report (one that has a `steps` array);
+        // the server's `{error: …}` stub must fall back to null.
+        onboard: Array.isArray(all.onboard?.steps) ? (all.onboard as OnboardReport) : null,
       });
     } catch (err) {
       console.error('Dashboard load failed', err);

--- a/src/cli_agent_setup.c
+++ b/src/cli_agent_setup.c
@@ -248,10 +248,7 @@ static int setup_oauth_cli_cmd(const char *vendor, int json_output)
    cJSON *started = setup_oauth_rpc("agent.cli_oauth_start", vendor, NULL, NULL, 120000);
    if (!started)
    {
-      fprintf(stderr,
-              "Could not start %s setup (is the server reachable and "
-              "server_cli_oauth_enabled=true?).\n",
-              vendor);
+      fprintf(stderr, "Could not start %s setup (is the server reachable?).\n", vendor);
       return 1;
    }
    char session[160] = "";

--- a/src/cmd_agent_setup.c
+++ b/src/cmd_agent_setup.c
@@ -290,10 +290,7 @@ static void setup_server_oauth_cli(const char *vendor)
    cJSON_Delete(start_body);
    if (!started)
    {
-      fprintf(stderr,
-              "Could not start %s setup (is the server reachable and "
-              "server_cli_oauth_enabled=true?).\n",
-              vendor);
+      fprintf(stderr, "Could not start %s setup (is the server reachable?).\n", vendor);
       return;
    }
    char session[128];

--- a/src/config.c
+++ b/src/config.c
@@ -770,10 +770,6 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->claude_cli_delegate_enabled = cJSON_IsTrue(item);
 
-   item = cJSON_GetObjectItemCaseSensitive(root, "server_cli_oauth_enabled");
-   if (cJSON_IsBool(item))
-      cfg->server_cli_oauth_enabled = cJSON_IsTrue(item);
-
    item = cJSON_GetObjectItemCaseSensitive(root, "verify_cross_project");
    if (cJSON_IsBool(item))
       cfg->verify_cross_project = cJSON_IsTrue(item);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -199,8 +199,6 @@ const config_field_t config_fields[] = {
     {"verify_enabled", offsetof(config_t, verify_enabled), sizeof(int), 1, CFG_BOOL},
     {"claude_cli_delegate_enabled", offsetof(config_t, claude_cli_delegate_enabled), sizeof(int), 1,
      CFG_BOOL},
-    {"server_cli_oauth_enabled", offsetof(config_t, server_cli_oauth_enabled), sizeof(int), 1,
-     CFG_BOOL},
     {"verify_cross_project", offsetof(config_t, verify_cross_project), sizeof(int), 1, CFG_BOOL},
     {"roundtable.max_rounds", offsetof(config_t, roundtable_max_rounds), sizeof(int), 0, CFG_INT},
     {"roundtable.converge_threshold", offsetof(config_t, roundtable_converge_threshold),

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -763,8 +763,6 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "verify_cross_project", 1);
    if (cfg->claude_cli_delegate_enabled)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
-   if (cfg->server_cli_oauth_enabled)
-      cJSON_AddBoolToObject(root, "server_cli_oauth_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
    if (cfg->ingress_preinject_assembly_budget != 6144)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -711,13 +711,6 @@ typedef struct config
     * DELEGATES.md). Does not affect API-key/HTTP agents or other CLI agents. */
    int claude_cli_delegate_enabled;
 
-   /* Operator opt-in (default 0) for the server-hosted OAuth CLI agent setup:
-    * `aimee agent add claude-oauth`/`codex-oauth` installs the vendor CLI on the
-    * aimee-server host and drives its OAuth login there. Running vendor CLIs +
-    * holding their OAuth tokens on a shared server is sensitive (and may bump
-    * vendor terms), so the install/login routes refuse unless this is set. */
-   int server_cli_oauth_enabled;
-
    /* Verify scope. When 0 (default), `aimee git verify` and the push/PR verify
     * gate apply only to the session's current project (the repo the session is
     * rooted in). Cross-project repositories are neither auto-configured (no

--- a/src/headers/workspace_runner_queue.h
+++ b/src/headers/workspace_runner_queue.h
@@ -36,6 +36,7 @@ typedef struct
 {
    pthread_mutex_t mu;
    pthread_cond_t req_cv;            /* signalled when a request is posted (for the runner) */
+   pthread_cond_t req_taken_cv;      /* signalled when the runner claims the request (pickup) */
    pthread_cond_t resp_cv;           /* signalled when a response is posted (for the requester) */
    pthread_cond_t idle_cv;           /* signalled when the in-flight slot frees (single-flight) */
    struct cJSON *req;                /* pending request; queue owns until poll takes it */
@@ -44,6 +45,14 @@ typedef struct
    int has_req;
    int busy;   /* a request cycle is in flight */
    int closed; /* close() called — wake everyone, fail pending */
+   /* Max ms to wait for a runner to *claim* a posted request before giving up.
+    * Guards against a detached workspace with no serving client (e.g. a
+    * backgrounded delegate whose client has disconnected): without it the
+    * transport would block forever and wedge the calling turn. <= 0 selects the
+    * built-in default. Only the pickup is bounded — once a runner claims the
+    * op the response wait stays unbounded, so legit long client commands still
+    * run to completion. */
+   int pickup_timeout_ms;
 } ws_runner_queue_t;
 
 /* Streaming partial callback: invoked (NOT under the queue lock) with each

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -13,7 +13,7 @@
 #include "vault_service.h"    /* vault_service_set / set_server, VAULT_API_KEY_CRED */
 #include "vault_capability.h" /* vault_capability_server_write_allowed (single server-write gate) */
 #include "server_cli_oauth.h" /* server-hosted OAuth CLI agent setup */
-#include "config.h"           /* server_cli_oauth_enabled gate */
+#include "config.h"           /* config_load / config_t */
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -970,13 +970,8 @@ int handle_agent_setup_poll(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 static int sagent_cli_oauth_gate(server_conn_t *conn, cJSON *req, cli_oauth_vendor_t *v)
 {
-   config_t cfg;
-   config_load(&cfg);
-   if (!cfg.server_cli_oauth_enabled)
-      return server_send_error(conn,
-                               "server-hosted OAuth CLI agents are disabled; set "
-                               "server_cli_oauth_enabled=true to opt in (DELEGATES.md)",
-                               NULL);
+   /* Server-hosted OAuth CLI agent setup is always available — there is no
+    * opt-in gate. Only the vendor argument is validated here. */
    cJSON *jv = cJSON_GetObjectItemCaseSensitive(req, "vendor");
    if (!cJSON_IsString(jv) || cli_oauth_vendor_parse(jv->valuestring, v) != 0)
       return server_send_error(conn, "vendor must be 'claude' or 'codex'", NULL);

--- a/src/server/workspace_runner_queue.c
+++ b/src/server/workspace_runner_queue.c
@@ -10,6 +10,7 @@ void ws_runner_queue_init(ws_runner_queue_t *q)
 {
    pthread_mutex_init(&q->mu, NULL);
    pthread_cond_init(&q->req_cv, NULL);
+   pthread_cond_init(&q->req_taken_cv, NULL);
    pthread_cond_init(&q->resp_cv, NULL);
    pthread_cond_init(&q->idle_cv, NULL);
    q->req = NULL;
@@ -18,6 +19,7 @@ void ws_runner_queue_init(ws_runner_queue_t *q)
    q->has_req = 0;
    q->busy = 0;
    q->closed = 0;
+   q->pickup_timeout_ms = 0; /* 0 -> WS_RUNNER_PICKUP_TIMEOUT_MS default */
 }
 
 /* Caller holds q->mu (or has exclusive access during destroy). Frees every
@@ -60,6 +62,7 @@ void ws_runner_queue_destroy(ws_runner_queue_t *q)
    resp_fifo_clear(q);
    pthread_mutex_destroy(&q->mu);
    pthread_cond_destroy(&q->req_cv);
+   pthread_cond_destroy(&q->req_taken_cv);
    pthread_cond_destroy(&q->resp_cv);
    pthread_cond_destroy(&q->idle_cv);
 }
@@ -69,6 +72,7 @@ void ws_runner_queue_close(ws_runner_queue_t *q)
    pthread_mutex_lock(&q->mu);
    q->closed = 1;
    pthread_cond_broadcast(&q->req_cv);
+   pthread_cond_broadcast(&q->req_taken_cv);
    pthread_cond_broadcast(&q->resp_cv);
    pthread_cond_broadcast(&q->idle_cv);
    pthread_mutex_unlock(&q->mu);
@@ -87,6 +91,13 @@ static void deadline_from_now(struct timespec *ts, int timeout_ms)
    }
 }
 
+/* Default pickup deadline: how long the transport waits for *some* runner to
+ * claim a posted request before concluding no client is serving the detached
+ * workspace. Generous enough to ride out a client momentarily between long-poll
+ * cycles, short enough that a truly absent client fails fast instead of wedging
+ * the calling turn until the delegate monitor reaps it (~20 min). */
+#define WS_RUNNER_PICKUP_TIMEOUT_MS 45000
+
 /* Caller holds q->mu. Post `request` into the single-flight slot. Assumes the
  * slot is free (busy==0) and the queue is open. */
 static void post_request_locked(ws_runner_queue_t *q, cJSON *request)
@@ -97,6 +108,31 @@ static void post_request_locked(ws_runner_queue_t *q, cJSON *request)
    /* A fresh op must not see a stale response from a prior aborted cycle. */
    resp_fifo_clear(q);
    pthread_cond_signal(&q->req_cv);
+}
+
+/* Caller holds q->mu, a request was just posted. Block until the runner claims
+ * the request (has_req 1->0), a response is already pending, or the queue
+ * closes — bounded by the pickup deadline. Returns 0 if the op is live (claimed
+ * / response pending / closed — the caller's normal response wait handles those)
+ * or -1 if no runner claimed the request before the deadline (no serving
+ * client). Only the unclaimed window is bounded; a claimed op then waits for its
+ * response without a deadline so a legit long client command isn't cut off. */
+static int wait_for_pickup_locked(ws_runner_queue_t *q)
+{
+   int pickup_ms = q->pickup_timeout_ms > 0 ? q->pickup_timeout_ms : WS_RUNNER_PICKUP_TIMEOUT_MS;
+   struct timespec ts;
+   deadline_from_now(&ts, pickup_ms);
+   while (q->has_req && !q->resp_head && !q->closed)
+   {
+      if (pthread_cond_timedwait(&q->req_taken_cv, &q->mu, &ts) != 0)
+      {
+         /* deadline (or spurious wake): if the request is still unclaimed and
+          * nothing else changed, no runner is serving this queue. */
+         if (q->has_req && !q->resp_head && !q->closed)
+            return -1;
+      }
+   }
+   return 0;
 }
 
 int ws_runner_queue_transport(void *ctx, cJSON *request, cJSON **response)
@@ -119,8 +155,15 @@ int ws_runner_queue_transport(void *ctx, cJSON *request, cJSON **response)
 
    post_request_locked(q, request);
 
-   while (!q->resp_head && !q->closed)
-      pthread_cond_wait(&q->resp_cv, &q->mu);
+   /* Bound only the unclaimed window: if no runner picks the op up, fail fast
+    * rather than block forever (no serving client). Once claimed, the response
+    * wait below is unbounded so a legit long client command runs to completion.
+    * A pickup timeout leaves has_req==1, so the reclaim path below frees it. */
+   if (wait_for_pickup_locked(q) == 0)
+   {
+      while (!q->resp_head && !q->closed)
+         pthread_cond_wait(&q->resp_cv, &q->mu);
+   }
 
    int rc;
    cJSON *resp = resp_fifo_pop(q);
@@ -134,7 +177,8 @@ int ws_runner_queue_transport(void *ctx, cJSON *request, cJSON **response)
    }
    else
    {
-      /* closed before a response arrived; reclaim an untaken request */
+      /* closed, or no runner claimed the op before the pickup deadline; reclaim
+       * an untaken request and fail the transport. */
       rc = -1;
       if (q->has_req)
       {
@@ -171,7 +215,10 @@ int ws_runner_queue_transport_stream(void *ctx, cJSON *request, ws_runner_partia
    post_request_locked(q, request);
 
    int rc = -1;
-   for (;;)
+   /* Bound only the unclaimed window (see ws_runner_queue_transport): a stream
+    * with no serving runner fails fast instead of wedging the turn. Once a
+    * runner claims the op, partials are drained without a deadline. */
+   for (; wait_for_pickup_locked(q) == 0;)
    {
       while (!q->resp_head && !q->closed)
          pthread_cond_wait(&q->resp_cv, &q->mu);
@@ -242,6 +289,9 @@ cJSON *ws_runner_queue_poll(ws_runner_queue_t *q, int timeout_ms)
       r = q->req; /* ownership transfers to the runner */
       q->req = NULL;
       q->has_req = 0;
+      /* Wake the transport's bounded pickup wait so it proceeds to the
+       * (unbounded) response wait the instant the op is claimed. */
+      pthread_cond_signal(&q->req_taken_cv);
    }
    pthread_mutex_unlock(&q->mu);
    return r;

--- a/src/tests/test_workspace_runner_queue.c
+++ b/src/tests/test_workspace_runner_queue.c
@@ -74,6 +74,31 @@ int main(void)
    char fpath[320];
    snprintf(fpath, sizeof(fpath), "%s/q.bin", dir);
 
+   /* No serving runner: a detached workspace whose client never shows up must
+    * fail the transport fast (pickup timeout) rather than deadlock the caller.
+    * This is the delegate-wedge regression: a backgrounded delegate bound to a
+    * detached workspace with no client used to block forever here. */
+   {
+      ws_runner_queue_t nq;
+      ws_runner_queue_init(&nq);
+      nq.pickup_timeout_ms = 100; /* short deadline so the test is quick */
+      ws_detached_provider_t ndp;
+      ws_detached_provider_init_ex(&ndp, ws_runner_queue_transport,
+                                   ws_runner_queue_transport_stream, &nq);
+      const workspace_provider_t *nws = &ndp.base;
+      /* Nothing polls nq, so no runner claims the op -> fail fast, no hang. */
+      char *nout = NULL;
+      size_t nlen = 0;
+      assert(nws->read_all(nws, "/nonexistent", &nout, &nlen) == -1);
+      assert(nout == NULL);
+      /* The streaming transport must fail fast with no runner too. */
+      const char *sargv[] = {"echo", "x", NULL};
+      chunk_collector_t cc = {0};
+      assert(nws->exec_stream(nws, sargv, NULL, 0, "/tmp", collect_chunk, &cc) != 0);
+      free(cc.buf);
+      ws_runner_queue_destroy(&nq);
+   }
+
    ws_runner_queue_init(&g_q);
    pthread_t th;
    assert(pthread_create(&th, NULL, runner_thread, NULL) == 0);


### PR DESCRIPTION
Promote `testing` → `main` to cut a release including three `.254`-relevant fixes:

- **`b4320a4` fix(delegate):** bound the detached-transport pickup so a clientless/backgrounded workspace can't wedge a delegate turn (the recurring "delegate flakiness" deadlock). (#446)
- **`3dca72c` agent:** always-enable server-hosted OAuth CLI setup — fixes webchat `exec(claude) failed 127`. (#444)
- **`fc13787` fix(webchat):** dashboard no longer blanks the whole app on a bad `/v1/dashboard/all` payload. (#443)

All three merged to `testing` with green CI. Auto-release will tag the next patch and publish `aimee-server`/`aimee-kb`/`aimee-server-kb` `:<version>` + `:latest`.