### PR TITLE
feat(delegate): expose on-demand delegate peak + cumulative counts in workers

### DIFF
--- a/src/server/server_delegate_ondemand.c
+++ b/src/server/server_delegate_ondemand.c
@@ -12,6 +12,7 @@
  *
  * Split out of server_compute.c to keep that file under the 2000-line limit. */
 #include "server_compute_impl.h"
+#include "cJSON.h"
 #include "config.h"
 #include "log.h"
 
@@ -27,6 +28,13 @@ static pthread_mutex_t g_delegate_inflight_mutex = PTHREAD_MUTEX_INITIALIZER;
 static pthread_cond_t g_delegate_inflight_cond = PTHREAD_COND_INITIALIZER;
 static int g_delegate_inflight = 0;
 static int g_delegate_ceiling = DELEGATE_ONDEMAND_CEILING_DEFAULT;
+/* Cumulative on-demand delegates admitted (≈ spawned) and the peak concurrent
+ * in-flight count, for `aimee workers` diagnostics: together with the live
+ * gauge they let an operator confirm in production that the per-model limiter —
+ * not a thread cap — is the binding throttle (the high-water rises above the old
+ * 2-thread pool ceiling), which is the whole point of on-demand execution. */
+static long g_delegate_spawned_total = 0;
+static int g_delegate_inflight_high_water = 0;
 
 void delegate_ondemand_set_ceiling(int ceiling)
 {
@@ -43,6 +51,25 @@ int delegate_ondemand_inflight(void)
    int n = g_delegate_inflight;
    pthread_mutex_unlock(&g_delegate_inflight_mutex);
    return n;
+}
+
+/* Add the on-demand delegate diagnostics to an `aimee workers` response object:
+ * the live in-flight count, its peak, and the cumulative total. Read together
+ * under one lock for a consistent snapshot. Kept here (not in server_state.c)
+ * so the counters stay private to this module and server_state.c stays under
+ * its line limit. */
+void delegate_ondemand_add_workers_stats(cJSON *out)
+{
+   if (!out)
+      return;
+   pthread_mutex_lock(&g_delegate_inflight_mutex);
+   int inflight = g_delegate_inflight;
+   int high_water = g_delegate_inflight_high_water;
+   long spawned_total = g_delegate_spawned_total;
+   pthread_mutex_unlock(&g_delegate_inflight_mutex);
+   cJSON_AddNumberToObject(out, "delegates_inflight", inflight);
+   cJSON_AddNumberToObject(out, "delegates_inflight_high_water", high_water);
+   cJSON_AddNumberToObject(out, "delegates_spawned_total", (double)spawned_total);
 }
 
 static void delegate_inflight_dec(void)
@@ -82,6 +109,9 @@ int delegate_spawn_ondemand(compute_ctx_t *cctx)
       return -1;
    }
    g_delegate_inflight++;
+   g_delegate_spawned_total++;
+   if (g_delegate_inflight > g_delegate_inflight_high_water)
+      g_delegate_inflight_high_water = g_delegate_inflight;
    pthread_mutex_unlock(&g_delegate_inflight_mutex);
 
    pthread_attr_t attr;
@@ -98,7 +128,16 @@ int delegate_spawn_ondemand(compute_ctx_t *cctx)
       pthread_attr_destroy(attr_p);
    if (rc != 0)
    {
-      delegate_inflight_dec();
+      /* Admitted but the thread never started: roll back the in-flight
+       * reservation AND the cumulative spawned count, so spawned_total only ever
+       * reflects delegates that actually ran (no overcount on create failure). */
+      pthread_mutex_lock(&g_delegate_inflight_mutex);
+      if (g_delegate_inflight > 0)
+         g_delegate_inflight--;
+      if (g_delegate_spawned_total > 0)
+         g_delegate_spawned_total--;
+      pthread_cond_broadcast(&g_delegate_inflight_cond);
+      pthread_mutex_unlock(&g_delegate_inflight_mutex);
       LOG_ERROR("server.delegate", "failed to spawn on-demand delegate thread: %d", rc);
       return -1;
    }

--- a/src/server/server_state.c
+++ b/src/server/server_state.c
@@ -782,7 +782,7 @@ int handle_kb_ingest_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 }
 
 /* Forward decl (server_compute_impl.h drags in unrelated compute internals). */
-int delegate_ondemand_inflight(void);
+void delegate_ondemand_add_workers_stats(cJSON *out);
 
 int handle_workers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
@@ -822,10 +822,10 @@ int handle_workers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
       cJSON_AddItemToObject(resp, "compute", compute_obj);
 
-      /* Sessionless delegates no longer occupy a fixed pool slot; they run on
-       * on-demand threads gated by the per-model limiter. Surface the live
-       * count so `aimee workers` still shows background-delegate load. */
-      cJSON_AddNumberToObject(resp, "delegates_inflight", delegate_ondemand_inflight());
+      /* Sessionless delegates run on on-demand threads gated by the per-model
+       * limiter, not a fixed pool slot. Surface the live count, its peak, and
+       * the cumulative total (confirms the limiter is the binding throttle). */
+      delegate_ondemand_add_workers_stats(resp);
 
       char *session_json = server_session_pools_json(ctx);
       if (session_json)


### PR DESCRIPTION
## What

The on-demand delegate executor (`server_delegate_ondemand.c`) previously reported only the **instantaneous** `delegates_inflight` gauge in `aimee workers`. This adds:

- `delegates_spawned_total` — cumulative on-demand delegates admitted (≈ spawned)
- `delegates_inflight_high_water` — peak concurrent in-flight count

## Why

This is the one genuinely-useful graft from the (shelved, over-engineered) elastic-pool proposal: together with the live gauge, the peak + total let an operator **confirm in production that the per-model concurrency limiter — not a thread cap — is the binding throttle** (the high-water rises above the old 2-thread compute-pool ceiling). That is precisely the property the on-demand change was meant to deliver, and there was previously no way to observe it.

## How

- Two file-static counters updated under the existing in-flight mutex at the spawn-admit site.
- Surfaced via a single `delegate_ondemand_add_workers_stats(cJSON*)` helper in `server_delegate_ondemand.c` — keeps the counters private to that module and keeps `server_state.c` at its 2000-line limit (one call site, net-zero lines there).

## Verification

- `aimee-server` links clean (`-Werror`).
- `line-check: ok` (server_state.c at 2000).
- clang-format-19 clean.
- `unit-test-server-dispatch` + `unit-test-server-compute` pass.

No behavior change to delegate execution itself — observability only. Default-on (it's a read-only gauge).