### PR TITLE
fix(worktree-gc): wire worktree_gc.enabled config + default auto-GC on

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -134,7 +134,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
 
-## Config-file sections (48)
+## Config-file sections (49)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
@@ -186,6 +186,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`trigger`** — _Trigger listener (auth, concurrency)._ Keys: `auth_token`, `max_concurrent`
 - **`trigger_rules`** — _Trigger rule definitions (array of objects)._ Keys: `event`, `pipeline`, `schedule`, `source`
 - **`workspaces`** — _Workspace definitions (array of objects)._ Keys: `head`, `path`, `provider`, `remote`
+- **`worktree_gc`** — `enabled`, `max_age_days`
 
 ## Other top-level config-file keys (5)
 

--- a/src/config.c
+++ b/src/config.c
@@ -553,7 +553,7 @@ static void config_set_defaults(config_t *cfg)
             CONFIG_DEFAULT_CSS_RENDER_COMMAND); /* default-on render backend (inert
                                                    until the sidecar is up); set empty
                                                    to disable */
-   cfg->worktree_gc_enabled = 0;
+   cfg->worktree_gc_enabled = 1;
    cfg->worktree_gc_max_age_days = 14;
    cfg->model_meta_refresh_minutes = 60;
    cfg->model_meta_capability_routing = 0;
@@ -849,6 +849,8 @@ int config_load(config_t *cfg)
    config_parse_kb_section(cfg, root);
 
    config_parse_memory_maintenance_section(cfg, root);
+
+   config_parse_worktree_gc_section(cfg, root);
 
    config_parse_memory_section(cfg, root);
    config_apply_learning_settings(cfg, root);

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -515,6 +515,13 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(eval, "gate_enabled", cfg->skills_eval_gate_enabled ? 1 : 0);
       cJSON_AddNumberToObject(eval, "threshold", cfg->skills_eval_threshold);
    }
+   /* worktree_gc defaults: enabled=1, max_age_days=14. Persist only when changed. */
+   if (!cfg->worktree_gc_enabled || cfg->worktree_gc_max_age_days != 14)
+   {
+      cJSON *wt = cJSON_AddObjectToObject(root, "worktree_gc");
+      cJSON_AddBoolToObject(wt, "enabled", cfg->worktree_gc_enabled ? 1 : 0);
+      cJSON_AddNumberToObject(wt, "max_age_days", cfg->worktree_gc_max_age_days);
+   }
    if (cfg->disposition_count > 0 || cfg->disposition_global_count > 0 ||
        cfg->disposition_workspace_count > 0 || cfg->disposition_project_count > 0 ||
        cfg->memory_salience_enabled || cfg->memory_salience_weight > 0.0 ||

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -164,6 +164,21 @@ void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root)
          cfg->memory_maintenance_summarize_enabled = cJSON_IsTrue(item) ? 1 : 0;
    }
 }
+void config_parse_worktree_gc_section(config_t *cfg, cJSON *root)
+{
+   cJSON *item = NULL;
+   cJSON *wt = cJSON_GetObjectItemCaseSensitive(root, "worktree_gc");
+   if (cJSON_IsObject(wt))
+   {
+      item = cJSON_GetObjectItemCaseSensitive(wt, "enabled");
+      if (cJSON_IsBool(item))
+         cfg->worktree_gc_enabled = cJSON_IsTrue(item) ? 1 : 0;
+
+      item = cJSON_GetObjectItemCaseSensitive(wt, "max_age_days");
+      if (cJSON_IsNumber(item) && item->valuedouble > 0)
+         cfg->worktree_gc_max_age_days = (int)item->valuedouble;
+   }
+}
 void config_parse_memory_section(config_t *cfg, cJSON *root)
 {
    cJSON *item = NULL;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1340,8 +1340,10 @@ typedef struct config
     * by design; the GC removes ones with no commits ahead of base branch
     * AND idle for `worktree_gc_max_age_days`.
     *
-    * worktree_gc_enabled:        0 = manual only (default), 1 = auto-run at session-start once/day.
-    * worktree_gc_max_age_days:   threshold for "idle"; default 14.
+    * worktree_gc_enabled:        1 = auto-run at session-start once/day (default), 0 = manual only.
+    *                             The AIMEE_WORKTREE_GC env var overrides this either way.
+    * worktree_gc_max_age_days:   threshold for "idle"; default 14. Overridable via
+    *                             AIMEE_WORKTREE_GC_DAYS.
     */
    int worktree_gc_enabled;
    int worktree_gc_max_age_days;

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -19,6 +19,7 @@ void config_parse_memory_recall_lanes_section(config_t *cfg, cJSON *root);
 void config_parse_memory_window_section(config_t *cfg, cJSON *root);
 void config_parse_kb_section(config_t *cfg, cJSON *root);
 void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
+void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);
 void config_parse_retry_section(config_t *cfg, cJSON *root);

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -839,8 +839,15 @@ static void *session_start_bg_worker(void *arg)
 
 static void session_start_worktree_gc(const char *hook_input)
 {
+   /* Auto-GC is gated on config (worktree_gc.enabled). The AIMEE_WORKTREE_GC
+    * env var, when present, overrides the config flag in either direction. */
+   config_t cfg;
+   config_load(&cfg);
+   int enabled = cfg.worktree_gc_enabled;
    const char *gc_env = getenv("AIMEE_WORKTREE_GC");
-   if (!gc_env || (gc_env[0] != '1' && gc_env[0] != 't' && gc_env[0] != 'T'))
+   if (gc_env && gc_env[0])
+      enabled = (gc_env[0] == '1' || gc_env[0] == 't' || gc_env[0] == 'T');
+   if (!enabled)
       return;
 
    cJSON *hi_json = hook_input && hook_input[0] ? cJSON_Parse(hook_input) : NULL;
@@ -862,6 +869,8 @@ static void session_start_worktree_gc(const char *hook_input)
          {
             worktree_gc_options_t opts;
             worktree_gc_options_init(&opts);
+            if (cfg.worktree_gc_max_age_days > 0)
+               opts.max_age_days = cfg.worktree_gc_max_age_days;
             const char *days_env = getenv("AIMEE_WORKTREE_GC_DAYS");
             if (days_env && days_env[0])
             {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -820,6 +820,7 @@ $(TESTPREFIX)/unit-test-memory-lanes: $(OBJDIR)/tests/test_memory_lanes.o $(TEST
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-workspace: $(OBJDIR)/tests/test_workspace.o \
+                          $(OBJDIR)/worktree_gc.o \
                           $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -59,6 +59,9 @@ int main(void)
       assert(cfg.skills_capability_autostub == 0);
       assert(cfg.skills_eval_gate_enabled == 0);
       assert(fabs(cfg.skills_eval_threshold - 0.01) < 0.0001);
+      /* worktree auto-GC defaults on (once/day at session-start, 14d idle). */
+      assert(cfg.worktree_gc_enabled == 1);
+      assert(cfg.worktree_gc_max_age_days == 14);
       assert(cfg.ingress_max_raw_scans == 0);
       assert(cfg.concurrency_preempt_requeue_max == CONFIG_DEFAULT_CONCURRENCY_PREEMPT_REQUEUE_MAX);
       /* profile-card refresh ran ungated in maintenance before the enable-gate was
@@ -149,6 +152,11 @@ int main(void)
       cfg.skills_capability_autostub = 1;
       cfg.skills_eval_gate_enabled = 1;
       cfg.skills_eval_threshold = 0.25;
+      /* worktree_gc.* — regression: enabled/max_age_days used to be parse/save
+       * gaps, so the documented auto-GC knob was inert. Prove the off state +
+       * non-default age round-trip (default enabled=1 → flip to 0 to test). */
+      cfg.worktree_gc_enabled = 0;
+      cfg.worktree_gc_max_age_days = 21;
       cfg.concurrency_preempt_enabled = 1;
       cfg.concurrency_preempt_single_slot_only = 0;
       cfg.concurrency_preempt_requeue_max = 2;
@@ -324,6 +332,8 @@ int main(void)
       assert(strcmp(cfg2.workspace_providers[2], "mirror") == 0);
       assert(strcmp(cfg2.workspace_vcs_remote[2], "https://example.com/r.git") == 0);
       assert(strcmp(cfg2.workspace_vcs_head[2], "abc123def456") == 0);
+      assert(cfg2.worktree_gc_enabled == 0);
+      assert(cfg2.worktree_gc_max_age_days == 21);
       assert(cfg2.memory_maintenance_trigger_inserts == 7);
       assert(cfg2.memory_maintenance_trigger_secs == 90);
       assert(cfg2.memory_cognify_async_enabled == 1);

--- a/src/tests/test_workspace.c
+++ b/src/tests/test_workspace.c
@@ -7,6 +7,7 @@
 #include <unistd.h>
 #include "aimee.h"
 #include "workspace.h"
+#include "worktree_gc.h"
 #include "platform_test_util.h"
 
 static void remove_tree(const char *path)
@@ -59,6 +60,14 @@ static void write_text_file(const char *path, const char *text)
    assert(f != NULL);
    fputs(text, f);
    fclose(f);
+}
+
+static int branch_exists(const char *repo, const char *name)
+{
+   char cmd[1024];
+   snprintf(cmd, sizeof(cmd),
+            "git -C '%s' rev-parse --verify --quiet 'refs/heads/%s' >/dev/null 2>&1", repo, name);
+   return system(cmd) == 0;
 }
 
 static int file_contains(const char *path, const char *needle)
@@ -586,6 +595,66 @@ int main(void)
       assert(worktree_delegate_work_name("x", NULL, 32) == -1);
       char tiny[4];
       assert(worktree_delegate_work_name("x", tiny, sizeof(tiny)) == -1);
+   }
+
+   /* --- worktree GC deletes the branch of a merged worktree it removes, but
+    *     preserves the branch when a worktree is removed only under --force
+    *     (commits ahead of base). This is what stops merged branches from
+    *     piling up after their worktrees are GC'd. --- */
+   {
+      char repo[512], cmd[2048], path[640], wt[640];
+      snprintf(repo, sizeof(repo), "%s/gc-repo", tmpdir);
+      init_real_git_repo(repo);
+      snprintf(path, sizeof(path), "%s/base.txt", repo);
+      write_text_file(path, "base\n");
+      snprintf(cmd, sizeof(cmd),
+               "git -C '%s' add -A && git -C '%s' commit -q -m base && git -C '%s' branch -M main",
+               repo, repo, repo);
+      assert(system(cmd) == 0);
+
+      /* Merged session worktree: a branch sitting exactly at main (0 ahead). */
+      snprintf(cmd, sizeof(cmd), "mkdir -p '%s/.aimee/worktrees/sessA'", repo);
+      assert(system(cmd) == 0);
+      snprintf(wt, sizeof(wt), "%s/.aimee/worktrees/sessA/main", repo);
+      snprintf(cmd, sizeof(cmd), "git -C '%s' worktree add -q -b feat/merged '%s' main", repo, wt);
+      assert(system(cmd) == 0);
+      assert(branch_exists(repo, "feat/merged"));
+
+      worktree_gc_options_t opts;
+      worktree_gc_options_init(&opts);
+      opts.max_age_days = 0; /* don't gate on idle time in the test */
+      worktree_gc_candidate_t cands[WORKTREE_GC_MAX_CANDIDATES];
+      int n = worktree_gc_scan(repo, &opts, cands, WORKTREE_GC_MAX_CANDIDATES);
+      assert(n == 1);
+      assert(cands[0].eligible == 1);
+      assert(cands[0].commits_ahead == 0);
+      assert(worktree_gc_apply(repo, cands, n, &opts) == 1);
+      assert(access(wt, F_OK) != 0);               /* worktree removed */
+      assert(!branch_exists(repo, "feat/merged")); /* merged branch deleted too */
+      assert(branch_exists(repo, "main"));         /* base branch untouched */
+
+      /* Ahead session worktree: removed only because of --force; its branch
+       * carries unmerged commits and MUST survive. */
+      snprintf(cmd, sizeof(cmd), "mkdir -p '%s/.aimee/worktrees/sessB'", repo);
+      assert(system(cmd) == 0);
+      snprintf(wt, sizeof(wt), "%s/.aimee/worktrees/sessB/main", repo);
+      snprintf(cmd, sizeof(cmd), "git -C '%s' worktree add -q -b feat/ahead '%s' main", repo, wt);
+      assert(system(cmd) == 0);
+      snprintf(path, sizeof(path), "%s/extra.txt", wt);
+      write_text_file(path, "ahead\n");
+      snprintf(cmd, sizeof(cmd), "git -C '%s' add -A && git -C '%s' commit -q -m ahead", wt, wt);
+      assert(system(cmd) == 0);
+
+      worktree_gc_options_init(&opts);
+      opts.max_age_days = 0;
+      opts.force = 1; /* remove despite commits ahead */
+      n = worktree_gc_scan(repo, &opts, cands, WORKTREE_GC_MAX_CANDIDATES);
+      assert(n == 1);
+      assert(cands[0].eligible == 1);
+      assert(cands[0].commits_ahead == 1);
+      assert(worktree_gc_apply(repo, cands, n, &opts) == 1);
+      assert(access(wt, F_OK) != 0);             /* worktree removed under force */
+      assert(branch_exists(repo, "feat/ahead")); /* unmerged branch preserved */
    }
 
    /* Cleanup */

--- a/src/worktree_gc.c
+++ b/src/worktree_gc.c
@@ -258,11 +258,41 @@ int worktree_gc_scan(const char *git_root, const worktree_gc_options_t *opts,
    return count;
 }
 
+/* After a merged worktree is removed, delete its branch too — leaving merged
+ * branches behind is what lets `git branch` accumulate hundreds of dead refs.
+ * Only called for candidates with 0 commits ahead of base, so `-D` discards
+ * nothing. Refuses the base branch, obvious protected names, a detached-HEAD
+ * sentinel, and any name unsafe to interpolate into a shell command. */
+static void worktree_gc_delete_branch(const char *git_root, const char *branch,
+                                      const char *base_branch)
+{
+   if (!branch || !branch[0])
+      return;
+   if (strcmp(branch, "HEAD") == 0 || strcmp(branch, "main") == 0 ||
+       strcmp(branch, "master") == 0 || strcmp(branch, "trunk") == 0)
+      return;
+   if (base_branch && base_branch[0] && strcmp(branch, base_branch) == 0)
+      return;
+   if (branch[0] == '-' || strchr(branch, '\'') != NULL)
+      return;
+
+   char cmd[MAX_PATH_LEN + 256];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -D '%s' 2>&1", git_root, branch);
+   int rc;
+   char *o = run_cmd(cmd, &rc);
+   if (rc == 0)
+      LOG_INFO("worktree_gc", "deleted merged branch '%s'", branch);
+   free(o);
+}
+
 int worktree_gc_apply(const char *git_root, const worktree_gc_candidate_t *cands, int n,
                       const worktree_gc_options_t *opts)
 {
    if (!git_root || !cands || !opts || n <= 0)
       return 0;
+
+   char base_branch[WORKTREE_GC_BRANCH_LEN];
+   detect_base_branch(git_root, base_branch, sizeof(base_branch));
 
    int removed = 0;
    for (int i = 0; i < n; i++)
@@ -307,7 +337,15 @@ int worktree_gc_apply(const char *git_root, const worktree_gc_candidate_t *cands
        * the directory is gone afterwards. */
       struct stat st;
       if (stat(c->path, &st) != 0)
+      {
          removed++;
+         /* The worktree is gone and merged (0 commits ahead of base, so
+          * nothing is lost) — delete its now-orphaned branch as well. A
+          * candidate removed only because of --force (commits ahead) keeps
+          * its branch. */
+         if (c->commits_ahead == 0)
+            worktree_gc_delete_branch(git_root, c->branch, base_branch);
+      }
    }
    return removed;
 }

--- a/src/worktree_gc.h
+++ b/src/worktree_gc.h
@@ -50,7 +50,10 @@ int worktree_gc_scan(const char *git_root, const worktree_gc_options_t *opts,
                      worktree_gc_candidate_t *out, int max_out);
 
 /* Remove every eligible candidate via the existing `worktree_cleanup`
- * primitive (which itself refuses on uncommitted / unpushed work).
+ * primitive (which itself refuses on uncommitted / unpushed work). For a
+ * candidate that was fully merged (0 commits ahead of base), its now-orphaned
+ * branch is deleted too, so merged branches don't accumulate; a candidate
+ * removed only under `--force` (commits ahead) keeps its branch.
  * Returns the count actually removed. When `opts->dry_run` is set,
  * returns the count that would be removed without touching anything. */
 int worktree_gc_apply(const char *git_root, const worktree_gc_candidate_t *cands, int n,


### PR DESCRIPTION
## Problem

Aimee is supposed to self-clean session worktrees under `.aimee/worktrees/`, but it never did — they accumulated to ~100+ on this host, and their (merged) branches piled up to ~230+. Two related gaps:

1. **Auto-GC was unreachable.** `session_start_worktree_gc()` gated only on the env var `AIMEE_WORKTREE_GC`, which nothing (installer, systemd, hooks, compose) ever sets. The documented `worktree_gc.enabled` config flag was a **dead field** — initialized but never loaded and never read as a gate, so setting it did nothing.
2. **The GC never deleted branches.** Even when it removed a worktree, `worktree_gc_apply` left the branch behind, so merged branches kept accumulating.

## Fix

**Wire the config knob + default on (commit 1):**
- `session_start_worktree_gc()` now honors `cfg.worktree_gc_enabled` (env var kept as an override either way) and `cfg.worktree_gc_max_age_days`.
- Add `config_parse_worktree_gc_section()`; wire into `config_load`; persist in `config_save`.
- Default `worktree_gc_enabled = 1` so Aimee self-cleans out of the box (once/day at session-start, 14d idle; GC still refuses dirty/ahead worktrees).

**Delete merged branches with their worktrees (commit 2):**
- When a GC'd candidate is fully merged (0 commits ahead of base, so nothing is lost), its orphaned branch is now deleted too. A worktree removed only under `--force` (commits ahead) keeps its branch.
- Guards: never deletes the detected base branch, `main`/`master`/`trunk`, a detached-HEAD sentinel, or a name unsafe to shell-interpolate.

## Tests

- `test_config.c`: defaults (on/14d) + a disabled/21d `config_save`->`config_load` round-trip.
- `test_workspace.c`: real git-fixture coverage (links `worktree_gc.o`) — a merged branch is deleted with its worktree; a force-removed *ahead* branch is preserved; the base branch is untouched.
- `unit-test-config`, `unit-test-config-surface`, `unit-test-server-dispatch`, `unit-test-workspace` all pass; clean against pinned `clang-format-19`.
