### PR TITLE
feat(webchat-git): WP-B git-credential vault bridge

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -376,7 +376,7 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c server/pki.c server/server_cert.c \
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/git_forge_vault.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c server/pki.c server/server_cert.c \
               workflow/wfe_engine.c workflow/wfe_blocks.c workflow/wfe_approval.c \
               workflow/wfe_verdict.c workflow/wfe_roundtable.c workflow/wfe_autonomy.c \
               server/server_workflow_api.c

--- a/src/headers/git_forge_vault.h
+++ b/src/headers/git_forge_vault.h
@@ -1,0 +1,37 @@
+#ifndef GIT_FORGE_VAULT_H
+#define GIT_FORGE_VAULT_H 1
+
+#include <stddef.h>
+
+/* git_forge_vault — the convention + autonomous accessor for a webchat user's
+ * git credentials in the sealed per-principal vault (webchat-git WP-B).
+ *
+ * Credential INTAKE already exists end-to-end: a browser user stores a git
+ * credential via webchat `/api/vault/credentials` (POST {agent,cred,secret}) →
+ * `/v1/vault/set` → vault_service_set(`webuser:<name>`, agent, cred, secret),
+ * which DUAL-wraps the secret under the user KEK and the server KEK. The browser
+ * never holds or receives the secret.
+ *
+ * This module pins the canonical (agent, cred) NAMES git uses, and reads them
+ * back via the SERVER wrap — i.e. autonomously, with no client unlock / cached
+ * user KEK — so credential injection (WP-C: GIT_ASKPASS + ssh-agent) and git
+ * operations (WP-D/E) work for background clones and for code-server sessions
+ * after the user's login KEK has expired. The credential stays isolated to the
+ * owning `webuser:` principal's vault namespace. */
+
+/* Canonical vault names. A git HTTPS token (PAT / forge App token / `gh` token)
+ * and an SSH private key live under the "git" agent. */
+#define GIT_FORGE_VAULT_AGENT "git"
+#define GIT_FORGE_TOKEN_CRED  "forge_token"
+#define GIT_FORGE_SSHKEY_CRED "ssh_key"
+
+/* Read `principal`'s git HTTPS token into out[out_len] via the server wrap.
+ * Returns 1 if a token was written, 0 if none is stored (caller falls back to
+ * ambient creds), -1 on a fail-closed crypto/IO error. `out` is empty on a
+ * non-1 return. */
+int git_forge_vault_token(const char *principal, char *out, size_t out_len);
+
+/* As above for the SSH private key (PEM). Same return contract. */
+int git_forge_vault_sshkey(const char *principal, char *out, size_t out_len);
+
+#endif /* GIT_FORGE_VAULT_H */

--- a/src/headers/vault_service.h
+++ b/src/headers/vault_service.h
@@ -91,6 +91,17 @@ vault_status_t vault_service_set_server(const char *agent, const char *cred, con
 vault_status_t vault_service_get_server_principal(const char *agent, const char *cred, char *out,
                                                   size_t out_len);
 
+/* Autonomous per-principal read via the server wrap of a dual-wrapped credential
+ * (vault_service_set stores both a user-KEK and a server-KEK wrap). Resolves
+ * (agent, cred) for ANY `principal` (e.g. a `webuser:` git credential) using the
+ * server master KEK only — NO client unlock / KEK cache, so it works for
+ * background and code-server git operations after the user's session KEK has
+ * expired. VAULT_OK (plaintext written), VAULT_NO_ENTRY (no such cred, or a
+ * legacy user-only entry — caller falls back), or VAULT_ERR_* (fail closed).
+ * `out` is cleansed on non-OK. */
+vault_status_t vault_service_get_server_wrap(const char *principal, const char *agent,
+                                             const char *cred, char *out, size_t out_len);
+
 /* The use-path: resolve (agent, cred) for `principal` into `out`. Returns:
  *   VAULT_OK         + plaintext written;
  *   VAULT_NO_ENTRY   when there is no such credential (or no/blank principal) —

--- a/src/server/git_forge_vault.c
+++ b/src/server/git_forge_vault.c
@@ -1,0 +1,31 @@
+/* git_forge_vault.c — autonomous read of a webuser's git credentials from the
+ * sealed vault (server wrap). See git_forge_vault.h. */
+#include "git_forge_vault.h"
+#include "vault_service.h"
+
+/* Map a vault_service server-wrap read to the 1/0/-1 contract:
+ *   VAULT_OK       -> 1 (token written)
+ *   VAULT_NO_ENTRY -> 0 (none stored — fall back to ambient creds)
+ *   anything else  -> -1 (fail closed; out already cleansed by vault_service). */
+static int read_cred(const char *principal, const char *cred, char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   vault_status_t st =
+       vault_service_get_server_wrap(principal, GIT_FORGE_VAULT_AGENT, cred, out, out_len);
+   if (st == VAULT_OK)
+      return 1;
+   if (st == VAULT_NO_ENTRY)
+      return 0;
+   return -1;
+}
+
+int git_forge_vault_token(const char *principal, char *out, size_t out_len)
+{
+   return read_cred(principal, GIT_FORGE_TOKEN_CRED, out, out_len);
+}
+
+int git_forge_vault_sshkey(const char *principal, char *out, size_t out_len)
+{
+   return read_cred(principal, GIT_FORGE_SSHKEY_CRED, out, out_len);
+}

--- a/src/server/vault_service.c
+++ b/src/server/vault_service.c
@@ -53,8 +53,8 @@ static void vault_service_backfill_server_wraps(const char *principal,
  * client unlock / KEK cache. Returns VAULT_OK (plaintext written), VAULT_NO_ENTRY
  * (no such cred, or a legacy user-only entry — caller falls back to the user KEK
  * path), or VAULT_ERR_* (fail closed). */
-static vault_status_t vault_service_get_server_wrap(const char *principal, const char *agent,
-                                                    const char *cred, char *out, size_t out_len)
+vault_status_t vault_service_get_server_wrap(const char *principal, const char *agent,
+                                             const char *cred, char *out, size_t out_len)
 {
    if (out && out_len)
       out[0] = '\0';

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -215,6 +215,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-kek-cache \
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
+               $(TESTPREFIX)/unit-test-git-forge-vault \
                $(TESTPREFIX)/unit-test-vault-bootstrap \
                $(TESTPREFIX)/unit-test-pki \
                $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
@@ -2121,6 +2122,14 @@ $(TESTPREFIX)/unit-test-vault-kek-cache: $(OBJDIR)/tests/test_vault_kek_cache.o 
 
 $(TESTPREFIX)/unit-test-vault-store: $(OBJDIR)/tests/test_vault_store.o \
                               $(OBJDIR)/server/vault_store.o $(OBJDIR)/server/vault_crypto.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-git-forge-vault: $(OBJDIR)/tests/test_git_forge_vault.o \
+                              $(OBJDIR)/server/git_forge_vault.o \
+                              $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
+                              $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_git_forge_vault.c
+++ b/src/tests/test_git_forge_vault.c
@@ -1,0 +1,84 @@
+/* test_git_forge_vault.c — WP-B: a webchat user's git credential round-trips
+ * through the sealed per-principal vault and is readable AUTONOMOUSLY (server
+ * wrap) after the user's session KEK expires — while staying isolated to the
+ * owning webuser. Mirrors the vault_service harness (tmp AIMEE_HOME). */
+#include "git_forge_vault.h"
+#include "vault_kek_cache.h"
+#include "vault_service.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+int main(void)
+{
+   char home[256];
+   snprintf(home, sizeof(home), "/tmp/aimee-gitforge-test-%d", (int)getpid());
+   char mk[320];
+   snprintf(mk, sizeof(mk), "rm -rf %s && mkdir -p %s", home, home);
+   assert(system(mk) == 0);
+   setenv("AIMEE_HOME", home, 1);
+   vault_kek_cache_clear();
+
+   const long T0 = 100000;
+   const char *alice = "webuser:alice";
+   const char *bob = "webuser:bob";
+   char out[4096];
+
+   /* Nothing stored yet -> 0 (caller falls back to ambient creds), out empty. */
+   assert(git_forge_vault_token(alice, out, sizeof(out)) == 0);
+   assert(out[0] == '\0');
+
+   /* Intake path: unlock alice's webuser vault (webchat-trusted) + store a PAT
+    * and an SSH key under the git convention (this is what /v1/vault/set does). */
+   const uint8_t apw[] = "alice-login-pw";
+   assert(vault_service_unlock_password(alice, ATTEST_WEBCHAT_TRUSTED, apw, sizeof(apw) - 1, T0) ==
+          VAULT_OK);
+   assert(vault_service_set(alice, GIT_FORGE_VAULT_AGENT, GIT_FORGE_TOKEN_CRED, "ghp_alicePAT",
+                            T0) == VAULT_OK);
+   const char *akey = "-----BEGIN OPENSSH PRIVATE KEY-----\naliceKEY\n-----END-----";
+   assert(vault_service_set(alice, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED, akey, T0) ==
+          VAULT_OK);
+
+   /* Readable while unlocked. */
+   assert(git_forge_vault_token(alice, out, sizeof(out)) == 1);
+   assert(strcmp(out, "ghp_alicePAT") == 0);
+
+   /* Simulate a background/idle git op: drop every cached user KEK so the user
+    * vault is LOCKED — the server wrap must STILL read both creds. */
+   vault_kek_cache_clear();
+   assert(vault_service_get(alice, GIT_FORGE_VAULT_AGENT, GIT_FORGE_TOKEN_CRED, out, sizeof(out),
+                            T0) == VAULT_ERR_LOCKED);           /* user path is locked... */
+   assert(git_forge_vault_token(alice, out, sizeof(out)) == 1); /* ...server wrap still reads */
+   assert(strcmp(out, "ghp_alicePAT") == 0);
+   assert(git_forge_vault_sshkey(alice, out, sizeof(out)) == 1);
+   assert(strcmp(out, akey) == 0);
+
+   /* Cross-principal isolation: bob has no git token and cannot read alice's. */
+   assert(git_forge_vault_token(bob, out, sizeof(out)) == 0);
+   assert(out[0] == '\0');
+   const uint8_t bpw[] = "bob-login-pw";
+   assert(vault_service_unlock_password(bob, ATTEST_WEBCHAT_TRUSTED, bpw, sizeof(bpw) - 1, T0) ==
+          VAULT_OK);
+   assert(vault_service_set(bob, GIT_FORGE_VAULT_AGENT, GIT_FORGE_TOKEN_CRED, "ghp_bobPAT", T0) ==
+          VAULT_OK);
+   vault_kek_cache_clear();
+   assert(git_forge_vault_token(bob, out, sizeof(out)) == 1);
+   assert(strcmp(out, "ghp_bobPAT") == 0);
+   /* alice still resolves to alice's token, never bob's. */
+   assert(git_forge_vault_token(alice, out, sizeof(out)) == 1);
+   assert(strcmp(out, "ghp_alicePAT") == 0);
+
+   /* An empty/un-attested principal is NO_ENTRY (0), never a leak. */
+   assert(git_forge_vault_token("", out, sizeof(out)) == 0);
+   assert(out[0] == '\0');
+
+   char clean[320];
+   snprintf(clean, sizeof(clean), "rm -rf %s", home);
+   assert(system(clean) == 0);
+   printf("git_forge_vault: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
WP-B of the approved webchat git-projects feature.

## Finding: intake is already built
On `testing`, the per-user vault is already wired end-to-end: `webchat/vault.go` (`/api/vault/unlock` + `/api/vault/credentials` GET/POST/DELETE) → `/v1/vault/*` with `server.token` + `X-Aimee-Webuser` → `vault_service_set(webuser:<name>, agent, cred, secret)`, which **dual-wraps** under the user KEK *and* the server KEK. Secrets never return to the browser. So a git PAT can already be stored under `{agent:"git", cred:"forge_token"}`.

## What this PR adds — the git↔vault bridge
- **Expose `vault_service_get_server_wrap()`** (was `static`): the autonomous, per-principal server-wrap read of a dual-wrapped credential — **no client unlock / cached user KEK**, so git auth works for background clones and code-server sessions after the user's login KEK has expired.
- **`git_forge_vault` module**: pins the canonical names (`agent="git"`, `cred="forge_token"|"ssh_key"`) and reads them via the server wrap. WP-C (`GIT_ASKPASS` + ssh-agent) and WP-D/E (git ops) consume this.

All credentials stay **only** in the sealed per-`webuser:` vault (dual-wrapped), isolated by principal namespace.

## Test
`unit-test-git-forge-vault`: a webuser stores a PAT + SSH key; after a KEK-cache clear (simulating restart/idle) the **user path is LOCKED yet the server wrap still reads both**; **cross-principal isolation** (bob can't read alice's); empty principal → NO_ENTRY (no leak). Passes locally.

Part of the phased build (WP-A merged in #451). Default-safe: new accessor + module, not yet wired into a git route (WP-C/D/E).