### PR TITLE
feat(webchat-git): WP-C vault-sourced git credential injection (HTTPS token)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -376,7 +376,7 @@ SERVER_SRCS = server/server_main.c server/server.c server/server_http.c server/s
               server/compute_concurrency.c server/provider_catalog.c \
               server/dashboard_server.c hud.c cmd_identity.c prompts.c persona.c working_profile.c \
               server/delegate_role.c server/delegate_depth.c server/delegate_prompt.c server/delegate_run_phases.c server/delegate_routing.c server/delegate_launch.c server/delegate_source_authority.c server/delegate_economics.c server/delegate_credentials.c server/delegate_credential_retry.c server/delegate_patch_coordinator.c server/delegate_ensemble.c server/delegate_checkout.c cmd_init.c \
-              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/git_forge_vault.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c server/pki.c server/server_cert.c \
+              server/trigger_scheduler.c server/server_trigger.c server/server_cron.c server/server_trajectory.c server/server_config.c server/vault_principal.c server/vault_crypto.c server/vault_kek_cache.c server/vault_server_key.c server/vault_store.c server/vault_service.c server/git_forge_vault.c server/git_cred_inject.c server/vault_capability.c server/server_vault.c server/server_vault_bootstrap.c server/pki.c server/server_cert.c \
               workflow/wfe_engine.c workflow/wfe_blocks.c workflow/wfe_approval.c \
               workflow/wfe_verdict.c workflow/wfe_roundtable.c workflow/wfe_autonomy.c \
               server/server_workflow_api.c

--- a/src/forge_credentials.c
+++ b/src/forge_credentials.c
@@ -278,6 +278,14 @@ char **forge_cred_build_env(const char *workspace_id, long now_epoch, char *cons
    return envp;
 }
 
+char **forge_cred_build_env_from_token(const char *token, char *const *parent_environ,
+                                       const char *askpass_shim)
+{
+   if (!token || !token[0])
+      return NULL;
+   return build_env_from_token(token, parent_environ, askpass_shim);
+}
+
 /* Optional App installation-token provider, registered by the server at startup
  * (forge_app_token.c). NULL in the thin client and unit tests, where forge
  * identity isn't used — keeping forge_credentials free of any link dependency on

--- a/src/headers/forge_credentials.h
+++ b/src/headers/forge_credentials.h
@@ -71,6 +71,13 @@ int forge_cred_count(void);
 char **forge_cred_build_env(const char *workspace_id, long now_epoch, char *const *parent_environ,
                             const char *askpass_shim);
 
+/* As forge_cred_build_env but with the token supplied directly (e.g. resolved
+ * from a `webuser:` vault rather than the in-memory broker — webchat-git WP-C).
+ * Same env shape + free contract. The caller wipes its own `token` copy. Returns
+ * NULL if `token` is empty/NULL. */
+char **forge_cred_build_env_from_token(const char *token, char *const *parent_environ,
+                                       const char *askpass_shim);
+
 /* Free an envp returned by forge_cred_build_env (frees each entry, then the
  * array; zeroes the GH_TOKEN entry first so the secret does not linger). */
 void forge_cred_free_env(char **envp);

--- a/src/headers/git_cred_inject.h
+++ b/src/headers/git_cred_inject.h
@@ -1,0 +1,29 @@
+#ifndef GIT_CRED_INJECT_H
+#define GIT_CRED_INJECT_H 1
+
+/* git_cred_inject — assemble the execve() environment for a webchat user's git
+ * operation, injecting their HTTPS forge token from the sealed vault (webchat-git
+ * WP-C). The token is read autonomously (server wrap) from the `webuser:`
+ * principal's vault and crosses ONLY in the git child's environment (GH_TOKEN) +
+ * a GIT_ASKPASS shim — never on disk, never on the command line, never logged,
+ * vault-only at rest.
+ *
+ * Cross-tenant safety: the git child runs as the owning user's own OS UID
+ * (WP-I), and the kernel restricts /proc/<pid>/environ to that UID, so another
+ * webuser cannot read the token from the environment. Per-principal isolation +
+ * vault-at-rest is the security boundary.
+ *
+ * SSH-key injection (in-memory ssh-agent) is WP-C2. */
+
+/* Build a NULL-terminated envp for an execve() of a git command run as
+ * `principal` (a `webuser:<name>`): a copy of `parent_environ` with any
+ * inherited GH_TOKEN/GIT_ASKPASS dropped, plus GH_TOKEN=<vault token>,
+ * GIT_ASKPASS=<shim>, GIT_TERMINAL_PROMPT=0. Returns a malloc'd array (free with
+ * git_cred_inject_free_env), or NULL if the principal has no vaulted git token
+ * (caller falls back to ambient creds) or on error. */
+char **git_cred_inject_build_env(const char *principal, char *const *parent_environ);
+
+/* Free an envp from git_cred_inject_build_env (zeroes the GH_TOKEN entry first). */
+void git_cred_inject_free_env(char **envp);
+
+#endif /* GIT_CRED_INJECT_H */

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -1,0 +1,31 @@
+/* git_cred_inject.c — vault-sourced git credential env. See git_cred_inject.h. */
+#include "git_cred_inject.h"
+#include "forge_credentials.h" /* forge_cred_build_env_from_token, askpass_shim, free_env */
+#include "git_forge_vault.h"   /* git_forge_vault_token */
+
+#include <string.h>
+
+/* Token plaintext buffer — sized to the forge broker's token cap. */
+#define GIT_CRED_TOKEN_MAX 4096
+
+char **git_cred_inject_build_env(const char *principal, char *const *parent_environ)
+{
+   char token[GIT_CRED_TOKEN_MAX];
+   /* Autonomous server-wrap read: works for background / code-server git ops
+    * after the user's session KEK has expired. 1 = token, 0 = none, -1 = error. */
+   if (git_forge_vault_token(principal, token, sizeof(token)) != 1)
+      return NULL; /* no vaulted token (or fail-closed error) -> ambient creds */
+
+   char **envp = forge_cred_build_env_from_token(token, parent_environ, forge_cred_askpass_shim());
+   /* Wipe our stack copy; the only remaining plaintext is the GH_TOKEN entry in
+    * envp, which git_cred_inject_free_env zeroes. */
+   volatile char *p = (volatile char *)token;
+   for (size_t i = 0; i < sizeof(token); i++)
+      p[i] = 0;
+   return envp;
+}
+
+void git_cred_inject_free_env(char **envp)
+{
+   forge_cred_free_env(envp); /* zeroes the GH_TOKEN entry, then frees */
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -217,6 +217,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
                $(TESTPREFIX)/unit-test-git-forge-vault \
+               $(TESTPREFIX)/unit-test-git-cred-inject \
                $(TESTPREFIX)/unit-test-vault-bootstrap \
                $(TESTPREFIX)/unit-test-pki \
                $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
@@ -2131,6 +2132,15 @@ $(TESTPREFIX)/unit-test-vault-kek-cache: $(OBJDIR)/tests/test_vault_kek_cache.o 
 
 $(TESTPREFIX)/unit-test-vault-store: $(OBJDIR)/tests/test_vault_store.o \
                               $(OBJDIR)/server/vault_store.o $(OBJDIR)/server/vault_crypto.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-git-cred-inject: $(OBJDIR)/tests/test_git_cred_inject.o \
+                              $(OBJDIR)/server/git_cred_inject.o $(OBJDIR)/server/git_forge_vault.o \
+                              $(OBJDIR)/forge_credentials.o $(OBJDIR)/config.o $(OBJDIR)/aimee_home.o \
+                              $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
+                              $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_git_cred_inject.c
+++ b/src/tests/test_git_cred_inject.c
@@ -1,0 +1,98 @@
+/* test_git_cred_inject.c — WP-C: a webchat user's git op gets their vaulted
+ * forge token injected into the git child env (GH_TOKEN + GIT_ASKPASS), sourced
+ * autonomously from the sealed vault, with any inherited GH_TOKEN dropped. */
+#include "git_cred_inject.h"
+#include "git_forge_vault.h"
+#include "vault_kek_cache.h"
+#include "vault_service.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Return the value of `key=` in envp, or NULL; also count matches into *count. */
+static const char *env_val(char *const *envp, const char *key, int *count)
+{
+   size_t kl = strlen(key);
+   const char *found = NULL;
+   int n = 0;
+   for (int i = 0; envp && envp[i]; i++)
+   {
+      if (strncmp(envp[i], key, kl) == 0 && envp[i][kl] == '=')
+      {
+         found = envp[i] + kl + 1;
+         n++;
+      }
+   }
+   if (count)
+      *count = n;
+   return found;
+}
+
+int main(void)
+{
+   char home[256];
+   snprintf(home, sizeof(home), "/tmp/aimee-gci-test-%d", (int)getpid());
+   char mk[320];
+   snprintf(mk, sizeof(mk), "rm -rf %s && mkdir -p %s", home, home);
+   assert(system(mk) == 0);
+   setenv("AIMEE_HOME", home, 1);
+   vault_kek_cache_clear();
+
+   const long T0 = 100000;
+   const char *alice = "webuser:alice";
+   const char *bob = "webuser:bob";
+
+   char *const parent[] = {(char *)"PATH=/usr/bin", (char *)"GH_TOKEN=INHERITED-MUST-BE-DROPPED",
+                           (char *)"GIT_ASKPASS=/inherited/should/be/dropped",
+                           (char *)"HOME=/whatever", NULL};
+
+   /* No vaulted token yet -> NULL (caller uses ambient creds). */
+   assert(git_cred_inject_build_env(alice, parent) == NULL);
+
+   /* Store alice's PAT in her sealed vault (the WP-B intake path). */
+   const uint8_t apw[] = "alice-pw";
+   assert(vault_service_unlock_password(alice, ATTEST_WEBCHAT_TRUSTED, apw, sizeof(apw) - 1, T0) ==
+          VAULT_OK);
+   assert(vault_service_set(alice, GIT_FORGE_VAULT_AGENT, GIT_FORGE_TOKEN_CRED, "ghp_aliceSECRET",
+                            T0) == VAULT_OK);
+
+   /* Simulate a background git op: clear the KEK cache so only the server wrap
+    * can read it — the injected env must STILL carry alice's token. */
+   vault_kek_cache_clear();
+   char **env = git_cred_inject_build_env(alice, parent);
+   assert(env != NULL);
+
+   int n = 0;
+   const char *tok = env_val(env, "GH_TOKEN", &n);
+   assert(n == 1); /* exactly one GH_TOKEN — the inherited one was dropped */
+   assert(tok && strcmp(tok, "ghp_aliceSECRET") == 0);
+
+   const char *askpass = env_val(env, "GIT_ASKPASS", &n);
+   assert(n == 1 && askpass && askpass[0] == '/'); /* our shim, not the inherited */
+   assert(strcmp(askpass, "/inherited/should/be/dropped") != 0);
+
+   const char *prompt = env_val(env, "GIT_TERMINAL_PROMPT", &n);
+   assert(n == 1 && prompt && strcmp(prompt, "0") == 0);
+
+   /* PATH/HOME carried through. */
+   assert(env_val(env, "PATH", &n) && n == 1);
+   assert(env_val(env, "HOME", &n) && n == 1);
+
+   git_cred_inject_free_env(env);
+
+   /* Cross-principal: bob has no token -> NULL, never alice's. */
+   assert(git_cred_inject_build_env(bob, parent) == NULL);
+
+   /* Empty / NULL principal -> NULL (no leak). */
+   assert(git_cred_inject_build_env("", parent) == NULL);
+
+   char clean[320];
+   snprintf(clean, sizeof(clean), "rm -rf %s", home);
+   assert(system(clean) == 0);
+   printf("git_cred_inject: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
WP-C (HTTPS-token half) of the approved webchat git-projects feature — the credential-injection bridge consumed by WP-D/E.

## What
New `git_cred_inject` module builds the `execve()` env for a webchat user's git op, injecting their HTTPS forge token **from the sealed vault**:
- token read **autonomously** (`git_forge_vault_token` → server wrap) so it works for background / code-server git after the session KEK expires;
- env built via the proven forge builder (newly exposed `forge_cred_build_env_from_token`): `GH_TOKEN` + `GIT_ASKPASS` shim + `GIT_TERMINAL_PROMPT=0`, with any **inherited `GH_TOKEN`/`GIT_ASKPASS` dropped**;
- the token crosses **only** in the child env + askpass shim — never on disk, never on the command line, never logged, **vault-only at rest**; the stack copy is wiped and `free_env` zeroes the `GH_TOKEN` entry.

## Security note (cross-tenant)
The git child runs as the owning user's **OS UID** (WP-I), and the kernel restricts `/proc/<pid>/environ` to that UID — so another webuser **cannot** read the token from the env. Per-principal isolation + vault-at-rest is the boundary, consistent with aimee's existing `forge_cred_build_env` posture. (A socket-based askpass is possible defense-in-depth but adds a fragile runtime dependency; not needed under the UID model.)

## Scope
HTTPS token only. **SSH-key injection via an in-memory ssh-agent is WP-C2** (split out to keep this PR focused).

## Test
`unit-test-git-cred-inject`: no token → NULL (ambient); after vault set + KEK-cache clear the env still carries **exactly one** `GH_TOKEN` = the vault token (inherited dropped), a `GIT_ASKPASS` shim ≠ the inherited one, `GIT_TERMINAL_PROMPT=0`, PATH/HOME passthrough; cross-principal (bob) → NULL; empty principal → NULL. Passes locally.

Builds on WP-A/B/L (merged). Default-safe: new module, not yet called by a route (WP-D/E).