### PR TITLE
feat(webchat-git): WP-F git-projects backend + webchat /api/git/* proxies

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3562,6 +3562,27 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workspace/projects:
+    get:
+      summary: List the calling webchat user's projects
+      description: >
+        The git projects (cloned repos) under the authenticated `webuser:`
+        principal's scoped workspace. A user only ever sees their own.
+        Capability: index:read.
+      responses:
+        "200":
+          description: Project names
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  projects: { type: array, items: { type: string } }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /workspace/git:
     post:
       summary: Run a git operation on the calling webchat user's project

--- a/src/headers/git_project.h
+++ b/src/headers/git_project.h
@@ -20,4 +20,11 @@
 int git_project_clone(const char *principal, const char *url, const char *name, char *out_path,
                       size_t path_cap, char *out_name, size_t name_cap, char *err, size_t errlen);
 
+/* List `principal`'s project names (the subdirectories of their scoped
+ * workspace) into out[max][GIT_PROJECT_NAME_MAX], sorted is not guaranteed.
+ * Returns the count (>=0), or -1 on a bad principal. A missing scope root is 0
+ * projects, not an error. */
+#define GIT_PROJECT_NAME_MAX 128
+int git_project_list(const char *principal, char out[][GIT_PROJECT_NAME_MAX], int max);
+
 #endif /* GIT_PROJECT_H */

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -4,9 +4,13 @@
 #include "util.h"            /* safe_exec_capture_env */
 #include "workspace_scope.h" /* ws_scope_project_path, ws_scope_name_valid */
 
+#include <dirent.h>
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 extern char **environ;
 
@@ -121,4 +125,38 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
    if (out_name && name_cap)
       snprintf(out_name, name_cap, "%s", pname);
    return 0;
+}
+
+int git_project_list(const char *principal, char out[][GIT_PROJECT_NAME_MAX], int max)
+{
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return -1;
+   /* Open the scope root via the O_NOFOLLOW base fd (TOCTOU-safe); a missing
+    * root just means no projects yet. */
+   int dfd = ws_scope_open_user_root(principal);
+   if (dfd < 0)
+      return 0;
+   DIR *d = fdopendir(dfd);
+   if (!d)
+   {
+      close(dfd);
+      return 0;
+   }
+   int n = 0;
+   struct dirent *e;
+   while (n < max && (e = readdir(d)) != NULL)
+   {
+      if (e->d_name[0] == '.')
+         continue; /* skip . / .. / hidden */
+      if (strlen(e->d_name) >= GIT_PROJECT_NAME_MAX)
+         continue;
+      /* directories only (project dirs); openat avoids re-resolving a path */
+      struct stat st;
+      if (fstatat(dfd, e->d_name, &st, AT_SYMLINK_NOFOLLOW) != 0 || !S_ISDIR(st.st_mode))
+         continue;
+      snprintf(out[n], GIT_PROJECT_NAME_MAX, "%s", e->d_name);
+      n++;
+   }
+   closedir(d); /* closes dfd */
+   return n;
 }

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -912,6 +912,31 @@ static int rh_workspace_git(const route_req_t *rq, char *resp, int cap)
    return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "git output too large");
 }
 
+/* GET /v1/workspace/projects — list the calling webchat user's projects (the
+ * repos cloned under their scoped workspace). Identity is the attested
+ * X-Aimee-Webuser principal, so a user only ever sees their own. */
+static int rh_workspace_projects(const route_req_t *rq, char *resp, int cap)
+{
+   (void)rq;
+   const char *principal = server_http_identity_principal();
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return err_json(resp, cap, 403, "git projects require a webchat user");
+
+   char names[256][GIT_PROJECT_NAME_MAX];
+   int count = git_project_list(principal, names, 256);
+   if (count < 0)
+      count = 0;
+   cJSON *out = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(out, "projects");
+   for (int i = 0; i < count; i++)
+      cJSON_AddItemToArray(arr, cJSON_CreateString(names[i]));
+   char *s = cJSON_PrintUnformatted(out);
+   int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
+   free(s);
+   cJSON_Delete(out);
+   return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
+}
+
 /* ── detached-runner reverse channel over /v1 (workspace-resource-plane §3) ──
  * The filesystem-authority client serving a `detached` workspace polls for the
  * next op the server needs done against its working tree, executes it locally,
@@ -1383,6 +1408,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/workspaces", NULL, RM_EXACT, "workspace.add", 0, rh_workspaces_register},
     {"POST", "/v1/workspace/clone", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_clone},
     {"POST", "/v1/workspace/git", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_git},
+    {"GET", "/v1/workspace/projects", NULL, RM_EXACT, NULL, CAP_INDEX_READ, rh_workspace_projects},
     {"POST", "/v1/workspaces/", "/forge-token", RM_PREFIX, NULL, CAP_TOOL_EXECUTE,
      rh_workspace_forge_token},
     {"GET", "/v1/workspaces/", NULL, RM_PREFIX, "workspace.get", 0, rh_workspace_get},

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -33,6 +33,14 @@ int index_scan_project(const char *name, const char *root, int force)
    return 0;
 }
 
+int git_project_list(const char *principal, char out[][GIT_PROJECT_NAME_MAX], int max)
+{
+   (void)principal;
+   (void)out;
+   (void)max;
+   return 0;
+}
+
 int git_ops_run(const char *principal, const char *project, const char *op, const char *text_arg,
                 int num_arg, char **out, char *err, size_t errlen)
 {

--- a/src/tests/test_git_project.c
+++ b/src/tests/test_git_project.c
@@ -89,6 +89,25 @@ int main(void)
    assert(git_project_clone("webuser:alice", url, "../escape", path, sizeof(path), name,
                             sizeof(name), err, sizeof(err)) == -1); /* bad name */
 
+   /* --- list: alice has srcrepo + myproj; bob has shared; isolated per user --- */
+   char names[64][GIT_PROJECT_NAME_MAX];
+   int an = git_project_list("webuser:alice", names, 64);
+   assert(an == 2);
+   int saw_src = 0, saw_my = 0;
+   for (int i = 0; i < an; i++)
+   {
+      if (strcmp(names[i], "srcrepo") == 0)
+         saw_src = 1;
+      if (strcmp(names[i], "myproj") == 0)
+         saw_my = 1;
+   }
+   assert(saw_src && saw_my);
+   int bn = git_project_list("webuser:bob", names, 64);
+   assert(bn == 1 && strcmp(names[0], "shared") == 0); /* bob sees only his */
+   assert(git_project_list("uid:1000", names, 64) == -1);
+   /* a webuser with no clones lists zero, not an error */
+   assert(git_project_list("webuser:carol", names, 64) == 0);
+
    assert(run("rm -rf %s", home) == 0);
    printf("git_project: all tests passed\n");
    return 0;

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -1,0 +1,98 @@
+package main
+
+// git.go: webchat git-projects proxies (webchat-git WP-F). The browser never
+// holds git credentials or absolute server paths: these handlers forward to
+// aimee-server's first-class /v1/workspace/* routes over the token-bearing,
+// X-Aimee-Webuser-asserted channel (v1RequestWebuser, see vault.go). Credentials
+// live only in the user's sealed server vault; webchat just relays the action.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// gitRelay writes a sanitized browser response from an aimee-server reply,
+// passing through a small allowlist of fields ({ok, name, output, projects})
+// and never the raw upstream body.
+func (s *server) gitRelay(w http.ResponseWriter, st int, data []byte, err error) {
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, "git: aimee-server unavailable")
+		return
+	}
+	if st != http.StatusOK {
+		writeJSONError(w, st, vaultSafeErrorMessage(data))
+		return
+	}
+	var up struct {
+		OK       bool     `json:"ok"`
+		Name     string   `json:"name"`
+		Output   string   `json:"output"`
+		Projects []string `json:"projects"`
+	}
+	_ = json.Unmarshal(data, &up)
+	out, _ := json.Marshal(map[string]any{
+		"ok": true, "name": up.Name, "output": up.Output, "projects": up.Projects,
+	})
+	w.Write(out)
+}
+
+// GET /api/git/projects — list the user's cloned projects.
+func (s *server) handleGitProjects(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodGet, "/v1/workspace/projects", nil)
+	s.gitRelay(w, st, data, err)
+}
+
+// POST /api/git/clone {url, name?} — clone a repo as a project.
+func (s *server) handleGitClone(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req struct {
+		URL  string `json:"url"`
+		Name string `json:"name"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.URL == "" {
+		writeJSONError(w, http.StatusBadRequest, "url required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]string{"url": req.URL, "name": req.Name})
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/clone", body)
+	s.gitRelay(w, st, data, err)
+}
+
+// POST /api/git/op {project, op, message?, branch?, n?} — run a git operation.
+func (s *server) handleGitOp(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req struct {
+		Project string `json:"project"`
+		Op      string `json:"op"`
+		Message string `json:"message"`
+		Branch  string `json:"branch"`
+		N       int    `json:"n"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Project == "" || req.Op == "" {
+		writeJSONError(w, http.StatusBadRequest, "project and op required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]any{
+		"project": req.Project, "op": req.Op, "message": req.Message, "branch": req.Branch, "n": req.N,
+	})
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/git", body)
+	s.gitRelay(w, st, data, err)
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -169,6 +169,12 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/vault/password", s.requireAuth(s.handleVaultPassword))
 	mux.HandleFunc("/api/vault/credentials", s.requireAuth(s.handleVaultCredentials))
 
+	// Git projects (webchat-git WP-F): clone + per-project ops + listing,
+	// forwarded to /v1/workspace/* with the user's webuser: assertion.
+	mux.HandleFunc("/api/git/projects", s.requireAuth(s.handleGitProjects))
+	mux.HandleFunc("/api/git/clone", s.requireAuth(s.handleGitClone))
+	mux.HandleFunc("/api/git/op", s.requireAuth(s.handleGitOp))
+
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))
 	mux.HandleFunc("/api/rules", s.requireAuth(s.handleCollabRulesList))


### PR DESCRIPTION
WP-F (backend half) — the webchat→server git glue. The React Projects tab is split out as WP-F2.

## What
- **`git_project_list`** — a webuser's projects (subdirs of their scoped workspace) via the `O_NOFOLLOW` base fd; missing root → 0.
- **`GET /v1/workspace/projects`** (`CAP_INDEX_READ`) — a user sees **only their own** projects; openapi documented.
- **webchat `git.go`** — `/api/git/projects` (GET), `/api/git/clone` (POST), `/api/git/op` (POST) forward to `/v1/workspace/*` via the token-bearing, `X-Aimee-Webuser`-asserted channel (`v1RequestWebuser`). Responses are sanitized to an `{ok,name,output,projects}` allowlist — **the browser never sees credentials or absolute server paths**.

## Test
`unit-test-git-project` extended: list returns alice's two projects, **bob sees only his** (cross-principal isolation), non-webuser refused, clone-less webuser lists zero. `go build ./webchat` + `server-api-conformance-check` green.

Builds on WP-A..E (merged).