### PR TITLE
feat(webchat-git): WP-H bundle code-server behind WITH_VSCODE (off by default)

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -16,6 +16,10 @@
 # registry token and NO credentials. Set --build-arg WITH_WEBCHAT=0 to build the
 # server+kb services only (skips the frontend + Go webchat stages entirely).
 ARG WITH_WEBCHAT=1
+# WITH_VSCODE bundles code-server (in-browser VSCode, Open-VSX only). OFF by
+# default (adds ~100 MB; default + CI builds skip the stage). The deployed
+# aimee-server-kb image is built with --build-arg WITH_VSCODE=1.
+ARG WITH_VSCODE=0
 FROM debian:bookworm-slim AS build
 
 # Union of the aimee-server and aimee-kb build deps: server links libsqlite3
@@ -77,6 +81,23 @@ COPY --from=frontend-build /frontend/dist/index.html /webchat/index.html
 FROM debian:bookworm-slim AS webchat-stage-0
 RUN mkdir -p /webchat
 FROM webchat-stage-${WITH_WEBCHAT} AS webchat-stage
+
+# Optional code-server (in-browser VSCode). "1" fetches the pinned, arch-matched
+# .deb under /opt/codeserver (only built when WITH_VSCODE=1); "0" is an empty
+# /opt/codeserver/usr so the final COPY is a no-op. Bundles its own Node; Open VSX.
+FROM debian:bookworm-slim AS code-server-stage-1
+ARG TARGETARCH
+ARG CODE_SERVER_VERSION=4.96.4
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${TARGETARCH}.deb" -o /tmp/cs.deb \
+    && mkdir -p /opt/codeserver \
+    && dpkg-deb -x /tmp/cs.deb /opt/codeserver \
+    && rm /tmp/cs.deb \
+    && rm -rf /var/lib/apt/lists/*
+FROM debian:bookworm-slim AS code-server-stage-0
+RUN mkdir -p /opt/codeserver/usr
+FROM code-server-stage-${WITH_VSCODE} AS code-server-stage
 
 FROM debian:bookworm-slim
 
@@ -172,6 +193,9 @@ RUN if [ -f /tmp/webchat-stage/aimee-webchat ]; then \
         echo "aimee: webchat bundled in image"; \
     else echo "aimee: webchat not bundled (built with WITH_WEBCHAT=0)"; fi; \
     rm -rf /tmp/webchat-stage
+# Optional code-server: empty unless WITH_VSCODE=1 (then code-server -> /usr/bin).
+COPY --from=code-server-stage /opt/codeserver/usr/ /usr/
+RUN if command -v code-server >/dev/null 2>&1; then echo "aimee: code-server bundled ($(code-server --version 2>/dev/null | head -1))"; else echo "aimee: code-server not bundled (built with WITH_VSCODE=0)"; fi
 COPY deploy/container/pam-aimee-webchat /etc/pam.d/aimee-webchat
 COPY deploy/container/webchat-lib.sh /usr/local/bin/webchat-lib.sh
 # Process supervisor: starts kb, waits for kb health, starts the server + webchat.

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -10,6 +10,11 @@
 # registry token and NO credentials. Set --build-arg WITH_WEBCHAT=0 to build the
 # server-only image (skips the frontend + Go webchat stages entirely).
 ARG WITH_WEBCHAT=1
+# WITH_VSCODE bundles code-server (full in-browser VSCode, Open-VSX only) for the
+# webchat Projects/editor surface. OFF by default — it adds ~100 MB, so default +
+# CI image builds skip it (the stage is not in the build graph). The aimee-server
+# deployment image is built with --build-arg WITH_VSCODE=1.
+ARG WITH_VSCODE=0
 FROM debian:bookworm-slim AS build
 
 RUN apt-get update \
@@ -68,6 +73,25 @@ COPY --from=frontend-build /frontend/dist/index.html /webchat/index.html
 FROM debian:bookworm-slim AS webchat-stage-0
 RUN mkdir -p /webchat
 FROM webchat-stage-${WITH_WEBCHAT} AS webchat-stage
+
+# Optional code-server (full VSCode in the browser). The "1" variant fetches the
+# pinned, arch-matched .deb and extracts it under /opt/codeserver (only in the
+# build graph when WITH_VSCODE=1). The "0" variant is an empty /opt/codeserver/usr
+# so the final COPY is a no-op — no download, no size, in the default/CI build.
+# code-server bundles its own Node and defaults to the Open VSX registry.
+FROM debian:bookworm-slim AS code-server-stage-1
+ARG TARGETARCH
+ARG CODE_SERVER_VERSION=4.96.4
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates curl \
+    && curl -fsSL "https://github.com/coder/code-server/releases/download/v${CODE_SERVER_VERSION}/code-server_${CODE_SERVER_VERSION}_${TARGETARCH}.deb" -o /tmp/cs.deb \
+    && mkdir -p /opt/codeserver \
+    && dpkg-deb -x /tmp/cs.deb /opt/codeserver \
+    && rm /tmp/cs.deb \
+    && rm -rf /var/lib/apt/lists/*
+FROM debian:bookworm-slim AS code-server-stage-0
+RUN mkdir -p /opt/codeserver/usr
+FROM code-server-stage-${WITH_VSCODE} AS code-server-stage
 
 FROM debian:bookworm-slim
 
@@ -150,6 +174,11 @@ RUN if [ -f /tmp/webchat-stage/aimee-webchat ]; then \
         echo "aimee: webchat bundled in image"; \
     else echo "aimee: webchat not bundled (built with WITH_WEBCHAT=0)"; fi; \
     rm -rf /tmp/webchat-stage
+# Optional code-server: /opt/codeserver/usr is empty unless WITH_VSCODE=1, so
+# this COPY is a no-op in the default build. When present it lands code-server at
+# /usr/bin/code-server; the webchat supervisor launches a per-user instance.
+COPY --from=code-server-stage /opt/codeserver/usr/ /usr/
+RUN if command -v code-server >/dev/null 2>&1; then echo "aimee: code-server bundled ($(code-server --version 2>/dev/null | head -1))"; else echo "aimee: code-server not bundled (built with WITH_VSCODE=0)"; fi
 COPY deploy/container/pam-aimee-webchat /etc/pam.d/aimee-webchat
 COPY deploy/container/webchat-lib.sh /usr/local/bin/webchat-lib.sh
 COPY deploy/container/server-entrypoint.sh /usr/local/bin/aimee-server-entrypoint


### PR DESCRIPTION
Phase-2 start: optional in-browser VSCode (**code-server**) in both `aimee-server` (`Dockerfile.server`) and `aimee-server-kb` (`Dockerfile.combined` — which isn't `FROM aimee-server`, so it's added to both per the scoping you flagged).

- Gated by `ARG WITH_VSCODE`, **default 0**: `code-server-stage-1` fetches the **pinned, arch-matched** `.deb` (via `TARGETARCH`) under `/opt/codeserver`; `code-server-stage-0` is empty so the final `COPY /opt/codeserver/usr/ /usr/` is a **no-op** — default + CI builds download nothing, gain no size.
- `WITH_VSCODE=1` (the deployment build) lands code-server at `/usr/bin/code-server` (bundles its own Node, **Open VSX** registry). The webchat supervisor (WP-I) launches a per-user instance.

Mirrors the proven `WITH_WEBCHAT` multi-stage pattern. CI's `e2e-docker` validates the default (off) path; the `WITH_VSCODE=1` install is deploy-validated (a 100 MB download isn't worth adding to every CI run).