### PR TITLE
feat(webchat-git): WP-J /vscode reverse-proxy + Editor tab

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
 import Projects from './pages/Projects';
+import Editor from './pages/Editor';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -60,6 +61,7 @@ const NAV_ITEMS: NavItem[] = [
   { label: 'Dashboard', icon: '📊', route: '/dashboard', section: 'Main' },
   { label: 'Workflows', icon: '🔀', route: '/workflows', section: 'Main' },
   { label: 'Projects', icon: '📁', route: '/projects', section: 'Main' },
+  { label: 'Editor', icon: '🖥️', route: '/editor', section: 'Main' },
 ];
 
 function LogoutButton() {
@@ -133,6 +135,7 @@ export default function App() {
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/workflows" element={<Workflows />} />
             <Route path="/projects" element={<Projects />} />
+            <Route path="/editor" element={<Editor />} />
             <Route path="*" element={<Navigate to="/chat" replace />} />
           </Routes>
         </ErrorBoundary>

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -1,0 +1,25 @@
+/* In-app VSCode (webchat-git WP-J). Embeds the per-user code-server — served by
+ * aimee-server and reverse-proxied at /vscode/ (same origin) — in an iframe so
+ * the editor lives inside the webchat shell alongside Chat/Projects. The browser
+ * never sees the editor's loopback port or any git credential: webchat ensures
+ * the editor and proxies, and the creds stay server-side in the sealed vault.
+ *
+ * The editor is server-gated (AIMEE_WEBCHAT_EDITOR + a code-server build); when
+ * it is off, /vscode/ returns 503 and the iframe shows that page. Same-origin,
+ * so framing is allowed and no cross-origin credential exposure is possible. */
+export default function Editor() {
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <iframe
+        title="VSCode"
+        src="/vscode/"
+        style={{ flex: 1, width: '100%', height: '100%', border: 'none' }}
+        /* code-server needs scripts + same-origin; it is served from our own
+         * origin so this is not a cross-origin grant. Clipboard helps copy/paste
+         * in the editor + terminal. */
+        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
+        allow="clipboard-read; clipboard-write"
+      />
+    </div>
+  );
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -120,6 +120,16 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/chat", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/dashboard", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/workflows", s.requireAuth(s.handleSPA))
+	mux.HandleFunc("/projects", s.requireAuth(s.handleSPA))
+	// The Editor tab is a SPA page that embeds the in-app VSCode in an iframe, so
+	// the nav shell stays visible. The iframe's src is the /vscode proxy below.
+	mux.HandleFunc("/editor", s.requireAuth(s.handleSPA))
+	// In-app VSCode (code-server) reverse-proxy (WP-J): the iframe document and
+	// all its assets/WebSocket traffic go through /vscode -> aimee-server's
+	// per-user editor port. Not an /api path, so requireAuth redirects to /login
+	// on an expired session (correct for the iframe).
+	mux.HandleFunc("/vscode", s.requireAuth(s.handleVSCode))
+	mux.HandleFunc("/vscode/", s.requireAuth(s.handleVSCode))
 
 	// Chat API (session required)
 	mux.HandleFunc("/api/chat/send", s.requireAuth(s.handleChatSend))

--- a/webchat/vscode.go
+++ b/webchat/vscode.go
@@ -81,6 +81,15 @@ func (s *server) handleVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Bare /vscode must become /vscode/ at OUR origin — otherwise code-server
+	// would answer the slash-less path with a redirect to /vscode/ built from the
+	// upstream Host, leaking the loopback port and bouncing the browser off our
+	// origin. Redirecting here keeps everything same-origin.
+	if r.URL.Path == "/vscode" {
+		http.Redirect(w, r, "/vscode/", http.StatusMovedPermanently)
+		return
+	}
+
 	// A bounded context just for the ensure RPC (the proxied stream itself uses
 	// the request context, which may be long-lived for WebSocket sessions).
 	ectx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
@@ -99,14 +108,15 @@ func (s *server) handleVSCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.proxyToEditor(w, r, port)
+	s.proxyToEditor(w, r, username, port)
 }
 
 // proxyToEditor forwards the request to 127.0.0.1:<port>. httputil.ReverseProxy
 // transparently handles WebSocket upgrades (the "Connection: Upgrade" tunnel
 // code-server uses for the terminal + editor sync).
-func (s *server) proxyToEditor(w http.ResponseWriter, r *http.Request, port int) {
+func (s *server) proxyToEditor(w http.ResponseWriter, r *http.Request, username string, port int) {
 	target := &url.URL{Scheme: "http", Host: "127.0.0.1:" + strconv.Itoa(port)}
+	origHost := r.Host
 	proxy := &httputil.ReverseProxy{
 		Transport: &http.Transport{
 			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
@@ -116,24 +126,43 @@ func (s *server) proxyToEditor(w http.ResponseWriter, r *http.Request, port int)
 		Director: func(req *http.Request) {
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
+			// Preserve the externally-visible host/proto via X-Forwarded-* so
+			// code-server builds correct absolute URLs (asset/WebSocket) for the
+			// proxied sub-path, then point the upstream Host at the loopback peer.
+			req.Header.Set("X-Forwarded-Host", origHost)
+			req.Header.Set("X-Forwarded-Proto", forwardedProto(r))
+			if ip, _, e := net.SplitHostPort(r.RemoteAddr); e == nil {
+				req.Header.Set("X-Forwarded-For", ip)
+			}
 			req.Host = target.Host
 			// code-server runs with --auth none behind our auth gate; it must not
 			// receive webchat's session cookie or bearer.
 			req.Header.Del("Cookie")
 			req.Header.Del("Authorization")
-			req.Header.Set("X-Forwarded-Proto", forwardedProto(r))
 		},
 		ModifyResponse: func(resp *http.Response) error {
 			// The editor is embedded in a same-origin iframe; force SAMEORIGIN so
 			// it frames regardless of what code-server emits, while still blocking
 			// cross-origin clickjacking of the proxy.
 			resp.Header.Set("X-Frame-Options", "SAMEORIGIN")
+			// Belt-and-braces: if code-server emits a redirect to its own loopback
+			// host, strip it to a relative path so the browser stays on our origin
+			// and the port is never exposed.
+			if loc := resp.Header.Get("Location"); loc != "" {
+				if u, e := url.Parse(loc); e == nil && u.Host == target.Host {
+					u.Scheme, u.Host = "", ""
+					resp.Header.Set("Location", u.String())
+				}
+			}
 			return nil
 		},
 		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, e error) {
-			// The cached port may be stale (editor reaped). Drop it so the next
-			// request re-ensures; report a transient error to the browser.
-			editorPorts.Delete(currentUser(req))
+			// The cached port may be stale (editor reaped). Evict ONLY if the cache
+			// still holds the failed port, so we never clobber a fresh port another
+			// goroutine just stored, then report a transient error.
+			if v, ok := editorPorts.Load(username); ok && v.(editorPortEntry).port == port {
+				editorPorts.Delete(username)
+			}
 			rw.WriteHeader(http.StatusBadGateway)
 			_, _ = rw.Write([]byte("editor connection failed"))
 		},

--- a/webchat/vscode.go
+++ b/webchat/vscode.go
@@ -1,0 +1,149 @@
+package main
+
+// vscode.go: the /vscode reverse-proxy (webchat-git WP-J). The browser opens an
+// in-app VSCode (code-server) running on aimee-server. aimee-server owns the
+// editor process (WP-I) — it has the workspace files and the sealed-vault git
+// env — and exposes it on a per-webuser loopback port via POST /v1/workspace/
+// editor. webchat ensures that editor exists, then reverse-proxies /vscode/* to
+// 127.0.0.1:<port> (HTTP + WebSocket). The loopback port never reaches the
+// browser; the user only ever talks to webchat's own origin (so the iframe is
+// same-origin and code-server's git credentials stay server-side, vault-only).
+//
+// Deployment note: this assumes webchat and aimee-server share a network
+// namespace (the combined image / aimee-server image), so 127.0.0.1:<port> is
+// reachable. The editor feature is scoped to those images by design.
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// editorPortTTL bounds how long a resolved per-user editor port is reused before
+// re-confirming with aimee-server (which also keeps the editor's idle timer warm).
+const editorPortTTL = 30 * time.Second
+
+type editorPortEntry struct {
+	port   int
+	expiry time.Time
+}
+
+// editorPorts caches username -> {port, expiry} so we do not call ensure on every
+// asset/WebSocket request. On a dial failure the entry is dropped and re-ensured.
+var editorPorts sync.Map
+
+// ensureEditorPort asks aimee-server to (idempotently) start the user's editor
+// and returns its loopback port. Cached for editorPortTTL. force bypasses the
+// cache (used after a dial failure, in case the editor was reaped/respawned).
+func (s *server) ensureEditorPort(ctx context.Context, username string, force bool) (int, int, error) {
+	if !force {
+		if v, ok := editorPorts.Load(username); ok {
+			e := v.(editorPortEntry)
+			if time.Now().Before(e.expiry) {
+				return e.port, http.StatusOK, nil
+			}
+		}
+	}
+	st, data, err := s.v1RequestWebuser(ctx, username, http.MethodPost, "/v1/workspace/editor", []byte(`{}`))
+	if err != nil {
+		return 0, http.StatusServiceUnavailable, err
+	}
+	if st != http.StatusOK {
+		editorPorts.Delete(username)
+		return 0, st, nil
+	}
+	var up struct {
+		OK   bool `json:"ok"`
+		Port int  `json:"port"`
+	}
+	if json.Unmarshal(data, &up) != nil || up.Port <= 0 {
+		return 0, http.StatusBadGateway, nil
+	}
+	editorPorts.Store(username, editorPortEntry{port: up.Port, expiry: time.Now().Add(editorPortTTL)})
+	return up.Port, http.StatusOK, nil
+}
+
+// handleVSCode reverse-proxies /vscode/* to the calling user's code-server. The
+// path is forwarded UNCHANGED (code-server supports being hosted under a
+// sub-path and derives its asset base from the request path); only the upstream
+// host and scheme are rewritten. The webchat session cookie and bearer are
+// stripped so code-server never sees webchat's auth material.
+func (s *server) handleVSCode(w http.ResponseWriter, r *http.Request) {
+	username := currentUser(r)
+	if username == "" {
+		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	// A bounded context just for the ensure RPC (the proxied stream itself uses
+	// the request context, which may be long-lived for WebSocket sessions).
+	ectx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	port, st, err := s.ensureEditorPort(ectx, username, false)
+	cancel()
+	if err != nil {
+		http.Error(w, "editor unavailable", http.StatusServiceUnavailable)
+		return
+	}
+	if st == http.StatusServiceUnavailable || st == 503 {
+		http.Error(w, "editor not enabled", http.StatusServiceUnavailable)
+		return
+	}
+	if port <= 0 {
+		http.Error(w, "editor unavailable", http.StatusBadGateway)
+		return
+	}
+
+	s.proxyToEditor(w, r, port)
+}
+
+// proxyToEditor forwards the request to 127.0.0.1:<port>. httputil.ReverseProxy
+// transparently handles WebSocket upgrades (the "Connection: Upgrade" tunnel
+// code-server uses for the terminal + editor sync).
+func (s *server) proxyToEditor(w http.ResponseWriter, r *http.Request, port int) {
+	target := &url.URL{Scheme: "http", Host: "127.0.0.1:" + strconv.Itoa(port)}
+	proxy := &httputil.ReverseProxy{
+		Transport: &http.Transport{
+			DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+				return (&net.Dialer{Timeout: 5 * time.Second}).DialContext(ctx, network, target.Host)
+			},
+		},
+		Director: func(req *http.Request) {
+			req.URL.Scheme = target.Scheme
+			req.URL.Host = target.Host
+			req.Host = target.Host
+			// code-server runs with --auth none behind our auth gate; it must not
+			// receive webchat's session cookie or bearer.
+			req.Header.Del("Cookie")
+			req.Header.Del("Authorization")
+			req.Header.Set("X-Forwarded-Proto", forwardedProto(r))
+		},
+		ModifyResponse: func(resp *http.Response) error {
+			// The editor is embedded in a same-origin iframe; force SAMEORIGIN so
+			// it frames regardless of what code-server emits, while still blocking
+			// cross-origin clickjacking of the proxy.
+			resp.Header.Set("X-Frame-Options", "SAMEORIGIN")
+			return nil
+		},
+		ErrorHandler: func(rw http.ResponseWriter, req *http.Request, e error) {
+			// The cached port may be stale (editor reaped). Drop it so the next
+			// request re-ensures; report a transient error to the browser.
+			editorPorts.Delete(currentUser(req))
+			rw.WriteHeader(http.StatusBadGateway)
+			_, _ = rw.Write([]byte("editor connection failed"))
+		},
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func forwardedProto(r *http.Request) string {
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
+}


### PR DESCRIPTION
## WP-J — /vscode reverse-proxy + Editor tab (webchat-git Phase 2)

The browser-side half of the in-app VSCode. aimee-server owns the per-user code-server (WP-I) on a loopback port; webchat ensures it exists and reverse-proxies `/vscode/*` to it. The loopback port never reaches the browser, and the editor's git credentials stay server-side (vault-only) — the user only ever talks to webchat's own origin.

### What it does
- **`webchat/vscode.go`** — `handleVSCode` resolves the user's editor port via `POST /v1/workspace/editor` (cached 30s, re-ensured on dial failure) and reverse-proxies to `127.0.0.1:<port>`. `httputil.ReverseProxy` transparently tunnels the **WebSocket** upgrade code-server uses for the terminal/editor sync. The webchat **session cookie + bearer are stripped** before forwarding (code-server runs `--auth none` behind our auth gate); `X-Frame-Options` is forced to `SAMEORIGIN` so the same-origin iframe frames reliably.
- **`server.go`** — register `/vscode` + `/vscode/` (proxy) and the `/editor` SPA route. Also adds the **`/projects` SPA route** — WP-F2 only added *client-side* routing, so a hard refresh on `/projects` 404'd; this fixes that latent gap.
- **frontend** — `Editor.tsx` embeds `/vscode/` in a same-origin iframe; Editor nav item + `/editor` route in `App.tsx`.

### Security / isolation
- Browser never sees the loopback port or any git credential.
- Same-origin iframe → no cross-origin credential exposure; framing allowed.
- code-server's user-data/extensions live under `<userroot>/.aimee-editor/` (dot-prefixed, so `git_project_list` skips it — no bogus project).
- Editor is server-gated (`AIMEE_WEBCHAT_EDITOR` + a `WITH_VSCODE` build); when off, `/vscode/` returns 503 and the tab shows that.

### Deployment assumption
webchat reaches code-server at `127.0.0.1:<port>`, i.e. they share a network namespace (the combined / aimee-server image). The editor feature is scoped to those images by design.

### Testing
`go build` / `go vet` / `go test ./webchat/...` and frontend `tsc -b && vite build` all green. The live proxy, WebSocket tunneling, and iframe framing/base-path are **deploy-validated on .254** — CI carries no code-server binary or browser. Path is forwarded unchanged (code-server derives its asset base from the sub-path); if a deploy shows base-path issues it's a one-line proxy tweak.