### PR TITLE
feat(webchat-git): WP-K editor-env leak gate + no on-disk credential cache

### DIFF
--- a/src/headers/webuser_editor.h
+++ b/src/headers/webuser_editor.h
@@ -47,4 +47,17 @@ void webuser_editor_shutdown(void);
  * code-server binary is resolvable. Exposed for the route layer / tests. */
 int webuser_editor_available(void);
 
+/* Build the sanitized, fully-owned environment a webuser's code-server is
+ * launched with (webchat-git WP-K): a minimal curated base (PATH/LANG/TERM) +
+ * HOME=<userroot> + the user's vault-backed git env (GH_TOKEN/GIT_ASKPASS/
+ * SSH_AUTH_SOCK when present) + git's on-disk credential cache disabled. It NEVER
+ * contains the server's own environment, so the editor's terminal/extensions
+ * cannot read server secrets (AIMEE_DB2_URL, AIMEE_SERVER_TOKEN, provider keys).
+ * Returns a malloc'd NULL-terminated array (free with webuser_editor_free_env),
+ * or NULL on error. Exposed for the WP-K editor-env leak tests. */
+char **webuser_editor_build_env(const char *principal, const char *userroot);
+
+/* Free an envp from webuser_editor_build_env (zeroes any GH_TOKEN first). */
+void webuser_editor_free_env(char **envp);
+
 #endif /* WEBUSER_EDITOR_H */

--- a/src/server/webuser_editor.c
+++ b/src/server/webuser_editor.c
@@ -173,6 +173,92 @@ static int resolve_drop_uid(drop_ids_t *out)
    return 0;
 }
 
+void webuser_editor_free_env(char **envp)
+{
+   if (!envp)
+      return;
+   for (int i = 0; envp[i]; i++)
+   {
+      /* Zero a GH_TOKEN entry's secret tail before freeing so it does not linger
+       * in freed heap. */
+      if (strncmp(envp[i], "GH_TOKEN=", 9) == 0)
+      {
+         volatile char *p = (volatile char *)envp[i];
+         for (size_t j = 0; p[j]; j++)
+            p[j] = 0;
+      }
+      free(envp[i]);
+   }
+   free(envp);
+}
+
+char **webuser_editor_build_env(const char *principal, const char *userroot)
+{
+   /* code-server gives the user an integrated terminal AND runs untrusted
+    * extensions, so the child must NEVER inherit the server's full environment —
+    * that would expose secrets like AIMEE_DB2_URL (DB password), AIMEE_SERVER_TOKEN,
+    * or provider keys to anything the user (or an extension) runs. Start from a
+    * minimal curated base (PATH/LANG/TERM), layer the user's vault-backed git env
+    * (GH_TOKEN/GIT_ASKPASS/SSH_AUTH_SOCK) on top, pin HOME at the per-user
+    * workspace, and disable git's on-disk credential cache so the token is never
+    * persisted (vault-only at rest). The result is fully owned (every string
+    * strdup'd) for uniform, secret-zeroing teardown. */
+   const char *srv_path = getenv("PATH");
+   const char *srv_lang = getenv("LANG");
+   char path_env[MAX_PATH_LEN + 8], lang_env[256], home_env[MAX_PATH_LEN + 8];
+   snprintf(path_env, sizeof(path_env), "PATH=%s",
+            (srv_path && srv_path[0]) ? srv_path : "/usr/bin:/bin");
+   snprintf(lang_env, sizeof(lang_env), "LANG=%s",
+            (srv_lang && srv_lang[0]) ? srv_lang : "C.UTF-8");
+   snprintf(home_env, sizeof(home_env), "HOME=%s", userroot ? userroot : "/");
+   char *mini[] = {path_env, lang_env, (char *)"TERM=xterm-256color", NULL};
+
+   /* git_cred_inject_build_env copies from the given base (dropping any inherited
+    * GH_TOKEN/SSH_AUTH_SOCK) and appends the vaulted git vars; pass the minimal
+    * base, never environ. Returns NULL when the user has no vaulted creds yet, in
+    * which case the minimal base alone is the editor's env. */
+   char **inner = git_cred_inject_build_env(principal, mini);
+   char *const *src = inner ? inner : mini;
+   int sc = 0;
+   while (src[sc])
+      sc++;
+
+   /* sc inherited + HOME + 3 (GIT_CONFIG_* credential.helper disable) + NULL. */
+   char **out = calloc((size_t)sc + 5, sizeof(char *));
+   if (!out)
+   {
+      git_cred_inject_free_env(inner);
+      return NULL;
+   }
+   int o = 0;
+   for (int i = 0; i < sc; i++)
+   {
+      if (strncmp(src[i], "HOME=", 5) == 0)
+         continue; /* pinned below */
+      if (!(out[o++] = strdup(src[i])))
+         goto oom;
+   }
+   if (!(out[o++] = strdup(home_env)))
+      goto oom;
+   /* Disable on-disk credential storage: an empty credential.helper at high
+    * precedence clears any helper from the user's gitconfig, so neither the
+    * terminal nor an extension can `git config credential.helper store` the token
+    * to ~/.git-credentials. Auth still flows through GIT_ASKPASS each time. */
+   if (!(out[o++] = strdup("GIT_CONFIG_COUNT=1")))
+      goto oom;
+   if (!(out[o++] = strdup("GIT_CONFIG_KEY_0=credential.helper")))
+      goto oom;
+   if (!(out[o++] = strdup("GIT_CONFIG_VALUE_0=")))
+      goto oom;
+   out[o] = NULL;
+   git_cred_inject_free_env(inner); /* zeroes its GH_TOKEN; we kept our own copy */
+   return out;
+oom:
+   webuser_editor_free_env(out);
+   git_cred_inject_free_env(inner);
+   return NULL;
+}
+
 /* Fork+exec code-server bound to 127.0.0.1:<port>, rooted at userroot, hardened.
  * Returns the child pid, or -1. */
 static pid_t spawn_code_server(const char *principal, const char *userroot, int port)
@@ -187,56 +273,14 @@ static pid_t spawn_code_server(const char *principal, const char *userroot, int 
    if (resolve_drop_uid(&drop) != 0)
       return -1;
 
-   char bind_arg[64], data_dir[MAX_PATH_LEN], ext_dir[MAX_PATH_LEN], home_env[MAX_PATH_LEN + 8];
+   char bind_arg[64], data_dir[MAX_PATH_LEN], ext_dir[MAX_PATH_LEN];
    snprintf(bind_arg, sizeof(bind_arg), "127.0.0.1:%d", port);
    snprintf(data_dir, sizeof(data_dir), "%s/.aimee-editor/data", userroot);
    snprintf(ext_dir, sizeof(ext_dir), "%s/.aimee-editor/ext", userroot);
-   snprintf(home_env, sizeof(home_env), "HOME=%s", userroot);
 
-   /* code-server gives the user an integrated terminal, so the child must NOT
-    * inherit the server's full environment — that could expose secrets like
-    * AIMEE_DB2_URL (DB password), AIMEE_SERVER_TOKEN, or provider keys. Start
-    * from a minimal, curated base (PATH/LANG/TERM only) and layer the user's
-    * vault-backed git env (GH_TOKEN+GIT_ASKPASS, SSH_AUTH_SOCK) on top, so the
-    * editor authenticates to git without ever seeing unrelated server env. */
-   const char *srv_path = getenv("PATH");
-   const char *srv_lang = getenv("LANG");
-   char path_env[MAX_PATH_LEN + 8], lang_env[256];
-   snprintf(path_env, sizeof(path_env), "PATH=%s",
-            (srv_path && srv_path[0]) ? srv_path : "/usr/bin:/bin");
-   snprintf(lang_env, sizeof(lang_env), "LANG=%s",
-            (srv_lang && srv_lang[0]) ? srv_lang : "C.UTF-8");
-   char *mini[] = {path_env, lang_env, (char *)"TERM=xterm-256color", NULL};
-
-   /* git_cred_inject_build_env copies from the given base (dropping any
-    * GH_TOKEN/SSH_AUTH_SOCK) and appends the vaulted git vars; pass the minimal
-    * base, not environ. Returns NULL when the user has no vaulted creds yet, in
-    * which case the minimal base alone is the editor's env (still git-prompt
-    * safe via GIT_TERMINAL_PROMPT default). envp ownership: the built array is
-    * freed in the parent after fork. */
-   char **base = git_cred_inject_build_env(principal, mini);
-   int owns_base = (base != NULL);
-   if (!base)
-      base = mini;
-   int bc = 0;
-   while (base[bc])
-      bc++;
-   char **envp = calloc((size_t)bc + 2, sizeof(char *));
+   char **envp = webuser_editor_build_env(principal, userroot);
    if (!envp)
-   {
-      if (owns_base)
-         git_cred_inject_free_env(base);
       return -1;
-   }
-   int eo = 0;
-   for (int i = 0; i < bc; i++)
-   {
-      if (strncmp(base[i], "HOME=", 5) == 0)
-         continue; /* override below */
-      envp[eo++] = base[i];
-   }
-   envp[eo++] = home_env;
-   envp[eo] = NULL;
 
    const char *argv[] = {bin,
                          "--bind-addr",
@@ -256,9 +300,7 @@ static pid_t spawn_code_server(const char *principal, const char *userroot, int 
    pid_t pid = fork();
    if (pid < 0)
    {
-      free(envp);
-      if (owns_base)
-         git_cred_inject_free_env(base);
+      webuser_editor_free_env(envp);
       return -1;
    }
    if (pid == 0)
@@ -291,9 +333,7 @@ static pid_t spawn_code_server(const char *principal, const char *userroot, int 
       _exit(127);
    }
 
-   free(envp);
-   if (owns_base)
-      git_cred_inject_free_env(base); /* zeroes GH_TOKEN; child kept its own copy */
+   webuser_editor_free_env(envp); /* zeroes GH_TOKEN; child kept its own COW copy */
    return pid;
 }
 

--- a/src/tests/test_webuser_editor.c
+++ b/src/tests/test_webuser_editor.c
@@ -1,15 +1,99 @@
-/* test_webuser_editor.c — WP-I: the per-webuser code-server supervisor's gating,
- * identity validation, and bookkeeping. The actual code-server spawn is
- * deploy-validated (CI has no code-server binary), so here we exercise the
- * fail-closed paths: feature off, binary absent, non-webuser principal, and the
- * idle/touch/stop/shutdown bookkeeping on an empty registry. */
+/* test_webuser_editor.c — WP-I/WP-K: the per-webuser code-server supervisor's
+ * gating, identity validation, and bookkeeping, plus the WP-K editor-env leak
+ * gate. The actual code-server spawn is deploy-validated (CI has no code-server
+ * binary), so here we exercise the fail-closed paths and prove the launched
+ * environment carries NO server secrets. */
 #include "webuser_editor.h"
+
+#include "vault_kek_cache.h"
 
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+
+/* 1 iff envp has an entry exactly equal to `want`. */
+static int env_has(char **envp, const char *want)
+{
+   for (int i = 0; envp[i]; i++)
+      if (strcmp(envp[i], want) == 0)
+         return 1;
+   return 0;
+}
+
+/* 1 iff envp has an entry beginning with `prefix`. */
+static int env_has_prefix(char **envp, const char *prefix)
+{
+   size_t n = strlen(prefix);
+   for (int i = 0; envp[i]; i++)
+      if (strncmp(envp[i], prefix, n) == 0)
+         return 1;
+   return 0;
+}
+
+/* 1 iff `needle` appears anywhere in any entry (secret-value leak check). */
+static int env_contains_substr(char **envp, const char *needle)
+{
+   for (int i = 0; envp[i]; i++)
+      if (strstr(envp[i], needle))
+         return 1;
+   return 0;
+}
+
+/* WP-K leak gate: the editor's env must carry the curated base + HOME + git
+ * credential-cache-off, and NONE of the server's own secrets — even when those
+ * are present in the process environment the server runs with. */
+static void test_editor_env_leak(void)
+{
+   char home[256];
+   snprintf(home, sizeof(home), "/tmp/aimee-editor-env-%d", (int)getpid());
+   char mk[320];
+   snprintf(mk, sizeof(mk), "rm -rf %s && mkdir -p %s/ws", home, home);
+   assert(system(mk) == 0);
+   setenv("AIMEE_HOME", home, 1);
+   char ws[300];
+   snprintf(ws, sizeof(ws), "%s/ws", home);
+   setenv("AIMEE_WORKSPACES_DIR", ws, 1);
+   vault_kek_cache_clear();
+
+   /* Secrets the live server may legitimately hold in its own environment — the
+    * editor (terminal + extensions) must never see any of them. */
+   setenv("AIMEE_DB2_URL", "postgres://u:SUPERSECRETPW@db/aimee", 1);
+   setenv("AIMEE_SERVER_TOKEN", "tok-LEAKME-123", 1);
+   setenv("ANTHROPIC_API_KEY", "sk-ant-LEAKME", 1);
+
+   char userroot[400];
+   snprintf(userroot, sizeof(userroot), "%s/ws/webusers/alice", home);
+   char **env = webuser_editor_build_env("webuser:alice", userroot);
+   assert(env != NULL);
+
+   /* Curated base + pinned HOME. */
+   char want_home[460];
+   snprintf(want_home, sizeof(want_home), "HOME=%s", userroot);
+   assert(env_has(env, want_home));
+   assert(env_has_prefix(env, "PATH="));
+   assert(env_has_prefix(env, "LANG="));
+   assert(env_has(env, "TERM=xterm-256color"));
+
+   /* On-disk credential cache disabled (token never persisted to ~/.git-credentials). */
+   assert(env_has(env, "GIT_CONFIG_COUNT=1"));
+   assert(env_has(env, "GIT_CONFIG_KEY_0=credential.helper"));
+   assert(env_has(env, "GIT_CONFIG_VALUE_0="));
+
+   /* No server environment leaks: neither the variable names nor their values. */
+   assert(!env_has_prefix(env, "AIMEE_"));
+   assert(!env_has_prefix(env, "ANTHROPIC_API_KEY="));
+   assert(!env_contains_substr(env, "SUPERSECRETPW"));
+   assert(!env_contains_substr(env, "tok-LEAKME-123"));
+   assert(!env_contains_substr(env, "sk-ant-LEAKME"));
+
+   webuser_editor_free_env(env);
+
+   unsetenv("AIMEE_DB2_URL");
+   unsetenv("AIMEE_SERVER_TOKEN");
+   unsetenv("ANTHROPIC_API_KEY");
+}
 
 int main(void)
 {
@@ -43,6 +127,8 @@ int main(void)
    assert(webuser_editor_reap_idle(0) == 0);  /* idle_secs<=0 reaps nothing */
    assert(webuser_editor_reap_idle(60) == 0); /* empty registry */
    webuser_editor_shutdown();
+
+   test_editor_env_leak();
 
    printf("webuser_editor: ok\n");
    return 0;


### PR DESCRIPTION
## WP-K — editor-env leak gate + extension-host containment (webchat-git Phase 2, final)

The Phase-2 containment gate. Refactors the code-server launch env into a single fully-owned helper and **proves in a unit test** that nothing the user runs in the editor — integrated terminal or an untrusted extension — can read the server's secrets or persist the git token to disk.

### What it does
- **`webuser_editor_build_env()` / `webuser_editor_free_env()`** — build the editor env from a minimal curated base (`PATH`/`LANG`/`TERM`) + `HOME=<userroot>` + the user's vault-backed git env, **never** the server's own `environ`. Deep-copied with secret-zeroing teardown (replaces the prior dual-ownership `envp`/`base` split — also simpler/safer).
- **No on-disk credential cache** — adds `GIT_CONFIG_COUNT=1` / `credential.helper=""` so neither the terminal nor an extension can `git config credential.helper store` the token to `~/.git-credentials`. Auth still flows through the `GIT_ASKPASS` shim each time (vault-only at rest).
- **WP-K leak test** — with `AIMEE_DB2_URL` / `AIMEE_SERVER_TOKEN` / `ANTHROPIC_API_KEY` set in the process env, asserts the built editor env contains the curated base + `HOME` + credential-helper-off and **none** of those names or secret values (no `AIMEE_*`, no provider key, no leaked password).

### Containment model (honest)
The askpass shim does `printf "$GH_TOKEN"` — it reads the token **from the env**, so the token is necessarily present for git to work. Hiding it from the user's *own* extensions would require the socket-askpass that WP-C **deliberately dropped** in favour of **per-UID isolation**: another *user* cannot read the env (`/proc/<pid>/environ` is UID-restricted, and the editor can drop to `AIMEE_WEBCHAT_EDITOR_UID`). WP-K's boundary is therefore: **no unrelated server secrets in the editor env, and no on-disk credential persistence** — both now enforced and tested.

### Testing
`unit-test-webuser-editor` extended with the leak gate (passes); server links clean; existing `unit-test-git-cred-inject` / `unit-test-server-http` still green. The live extension-host behaviour is deploy-validated on .254.

---
This is the final work-packet of the webchat git-projects + in-app VSCode feature (WP-0,A,B,C,C2,D,E,F,F2,G,H,I,J,K).