### PR TITLE
feat(webchat-git): make the in-app editor on by default

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -16,10 +16,10 @@
 # registry token and NO credentials. Set --build-arg WITH_WEBCHAT=0 to build the
 # server+kb services only (skips the frontend + Go webchat stages entirely).
 ARG WITH_WEBCHAT=1
-# WITH_VSCODE bundles code-server (in-browser VSCode, Open-VSX only). OFF by
-# default (adds ~100 MB; default + CI builds skip the stage). The deployed
-# aimee-server-kb image is built with --build-arg WITH_VSCODE=1.
-ARG WITH_VSCODE=0
+# WITH_VSCODE bundles code-server (in-browser VSCode, Open-VSX only). ON by
+# default — the editor is a first-class feature; build with --build-arg
+# WITH_VSCODE=0 to omit it (saves ~100 MB).
+ARG WITH_VSCODE=1
 FROM debian:bookworm-slim AS build
 
 # Union of the aimee-server and aimee-kb build deps: server links libsqlite3

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -11,10 +11,9 @@
 # server-only image (skips the frontend + Go webchat stages entirely).
 ARG WITH_WEBCHAT=1
 # WITH_VSCODE bundles code-server (full in-browser VSCode, Open-VSX only) for the
-# webchat Projects/editor surface. OFF by default — it adds ~100 MB, so default +
-# CI image builds skip it (the stage is not in the build graph). The aimee-server
-# deployment image is built with --build-arg WITH_VSCODE=1.
-ARG WITH_VSCODE=0
+# webchat Projects/editor surface. ON by default — the editor is a first-class
+# feature; build with --build-arg WITH_VSCODE=0 to omit it (saves ~100 MB).
+ARG WITH_VSCODE=1
 FROM debian:bookworm-slim AS build
 
 RUN apt-get update \

--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3634,9 +3634,9 @@ paths:
         Spawn (or reuse) a code-server for the authenticated `webuser:` principal,
         rooted at their scoped workspace and launched with their vault-backed git
         environment, and return its loopback port. The port reaches only webchat
-        (the trusted reverse-proxy), never the browser. Disabled by default
-        (AIMEE_WEBCHAT_EDITOR) and unavailable on images without code-server.
-        Capability: tool:execute.
+        (the trusted reverse-proxy), never the browser. On by default (set
+        AIMEE_WEBCHAT_EDITOR=0 to disable); unavailable on images built without a
+        code-server binary. Capability: tool:execute.
       responses:
         "200":
           description: Editor ready

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -246,7 +246,7 @@ The binaries read 113 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_SERVER_STARTUP_FD` | Inherited fd for startup-readiness signalling (service launch). |
 | `AIMEE_SESSION_THREADS` | Per-session worker thread count. |
 | `AIMEE_SOCK` | Sandbox helper socket path. |
-| `AIMEE_WEBCHAT_EDITOR` | Enable the per-webuser in-browser code-server editor (default off; requires a WITH_VSCODE=1 image). |
+| `AIMEE_WEBCHAT_EDITOR` | Per-webuser in-browser code-server editor (on by default; set to 0 to disable; needs a code-server binary, shipped by WITH_VSCODE images). |
 | `AIMEE_WEBCHAT_EDITOR_BIN` | Override path to the code-server binary used for the in-browser editor. |
 | `AIMEE_WEBCHAT_EDITOR_UID` | Dedicated service user the per-webuser code-server drops to (defence in depth; only honoured when aimee-server runs as root). |
 | `AIMEE_WORKTREE_GC` | Enable/disable delegate-worktree garbage collection. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -451,7 +451,7 @@ ENV_DESC = {
     "AIMEE_SERVER_HTTP_BIND": ("Server runtime", "TCP bind address for the server `/v1` HTTP listener (else UDS-only)."),
     "AIMEE_SERVER_STARTUP_FD": ("Server runtime", "Inherited fd for startup-readiness signalling (service launch)."),
     "AIMEE_API_REMOTE_WRITES": ("Server runtime", "Gate remote (TCP) write methods: `off` | `data` | `full`."),
-    "AIMEE_WEBCHAT_EDITOR": ("Server runtime", "Enable the per-webuser in-browser code-server editor (default off; requires a WITH_VSCODE=1 image)."),
+    "AIMEE_WEBCHAT_EDITOR": ("Server runtime", "Per-webuser in-browser code-server editor (on by default; set to 0 to disable; needs a code-server binary, shipped by WITH_VSCODE images)."),
     "AIMEE_WEBCHAT_EDITOR_BIN": ("Server runtime", "Override path to the code-server binary used for the in-browser editor."),
     "AIMEE_WEBCHAT_EDITOR_UID": ("Server runtime", "Dedicated service user the per-webuser code-server drops to (defence in depth; only honoured when aimee-server runs as root)."),
     "AIMEE_INGRESS_PROXY_SECRET": ("Server runtime", "Shared secret authenticating a trusted ingress proxy's identity headers."),

--- a/src/headers/webuser_editor.h
+++ b/src/headers/webuser_editor.h
@@ -14,10 +14,12 @@
  * path to the returned port (WP-J); the loopback port is never sent to the
  * browser.
  *
- * Fail-closed by default: ensure() returns 0 (feature unavailable) unless
- * AIMEE_WEBCHAT_EDITOR is set AND a code-server binary is present (WITH_VSCODE=1
- * images). It binds only to loopback and runs each child hardened (no core dump,
- * no new privs, detached session, stdio to /dev/null). */
+ * On by default, fail-closed: ensure() serves the editor unless
+ * AIMEE_WEBCHAT_EDITOR=0 disables it, and returns 0 (unavailable) when no
+ * code-server binary is present (a WITH_VSCODE=0 / dev build), so enabling it
+ * never breaks an image that does not ship the editor. It binds only to loopback
+ * and runs each child hardened (no core dump, no new privs, detached session,
+ * stdio to /dev/null). */
 
 #define WEBUSER_EDITOR_MAX 64 /* max concurrent per-user editors */
 
@@ -43,7 +45,7 @@ int webuser_editor_reap_idle(long idle_secs);
 /* Stop every running editor (server shutdown). */
 void webuser_editor_shutdown(void);
 
-/* Whether the editor feature is enabled (AIMEE_WEBCHAT_EDITOR set) AND a
+/* Whether the editor feature is enabled (on unless AIMEE_WEBCHAT_EDITOR=0) AND a
  * code-server binary is resolvable. Exposed for the route layer / tests. */
 int webuser_editor_available(void);
 

--- a/src/server/webuser_editor.c
+++ b/src/server/webuser_editor.c
@@ -100,8 +100,11 @@ static const char *editor_binary_path(void)
 
 int webuser_editor_available(void)
 {
+   /* On by default; AIMEE_WEBCHAT_EDITOR=0 explicitly disables. Still fail-closed
+    * when no code-server binary is present (e.g. a WITH_VSCODE=0 / dev build), so
+    * enabling it never breaks an image that doesn't ship the editor. */
    const char *en = getenv("AIMEE_WEBCHAT_EDITOR");
-   if (!en || !en[0] || en[0] == '0')
+   if (en && en[0] == '0' && en[1] == '\0')
       return 0;
    return editor_binary_path() != NULL;
 }

--- a/src/tests/test_webuser_editor.c
+++ b/src/tests/test_webuser_editor.c
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 /* 1 iff envp has an entry exactly equal to `want`. */
@@ -100,21 +101,31 @@ int main(void)
    int port = -1;
    char err[256];
 
-   /* Feature OFF by default (AIMEE_WEBCHAT_EDITOR unset). */
+   /* A dummy executable stands in for the code-server binary so the gate logic
+    * can be tested without a real editor. It is resolved + cached on the first
+    * availability check (AIMEE_WEBCHAT_EDITOR_BIN is tried first). */
+   char fakebin[256];
+   snprintf(fakebin, sizeof(fakebin), "/tmp/aimee-fake-code-server-%d", (int)getpid());
+   FILE *fb = fopen(fakebin, "w");
+   assert(fb);
+   fputs("#!/bin/sh\nexit 0\n", fb);
+   fclose(fb);
+   assert(chmod(fakebin, 0755) == 0);
+   setenv("AIMEE_WEBCHAT_EDITOR_BIN", fakebin, 1);
+
+   /* Feature ON by default (AIMEE_WEBCHAT_EDITOR unset) when a binary is present. */
    unsetenv("AIMEE_WEBCHAT_EDITOR");
+   assert(webuser_editor_available() == 1);
+
+   /* AIMEE_WEBCHAT_EDITOR=0 explicitly disables it. */
+   setenv("AIMEE_WEBCHAT_EDITOR", "0", 1);
    assert(webuser_editor_available() == 0);
+   /* Disabled → ensure fails closed (returns 0), never spawns. */
    assert(webuser_editor_ensure("webuser:alice", &port, err, sizeof(err)) == 0);
 
-   /* Enabled but no code-server binary → still unavailable (fail closed). The
-    * override points at a path that cannot be executed. */
-   setenv("AIMEE_WEBCHAT_EDITOR", "1", 1);
-   setenv("AIMEE_WEBCHAT_EDITOR_BIN", "/nonexistent/code-server", 1);
-   assert(webuser_editor_available() == 0);
-   /* (binary path is cached after the first resolve, so ensure() also returns 0) */
-   assert(webuser_editor_ensure("webuser:alice", &port, err, sizeof(err)) == 0);
-
-   /* Identity guard: only webuser: principals may drive an editor. NULL/non
-    * webuser → -1, never a spawn. */
+   /* Identity guard runs before the availability check: only webuser: principals
+    * may drive an editor. NULL / non-webuser / missing out_port → -1, never a
+    * spawn (kept disabled here as belt-and-braces). */
    assert(webuser_editor_ensure("uid:1000", &port, err, sizeof(err)) == -1);
    assert(webuser_editor_ensure(NULL, &port, err, sizeof(err)) == -1);
    assert(webuser_editor_ensure("webuser:bob", NULL, err, sizeof(err)) == -1);


### PR DESCRIPTION
Makes the in-browser VSCode (code-server) a **first-class, default-on** feature, per request.

- **`Dockerfile.server` + `Dockerfile.combined`** — `ARG WITH_VSCODE` default `0` → `1`, so the published `aimee-server` / combined images bundle code-server. Build with `--build-arg WITH_VSCODE=0` to omit it (saves ~100 MB).
- **`webuser_editor_available()`** — on by default; `AIMEE_WEBCHAT_EDITOR=0` disables. Still **fail-closed** when no code-server binary is present (a `WITH_VSCODE=0` / dev build), so enabling-by-default never breaks an image that doesn't ship the editor.
- Docs / openapi / header comments + the unit test updated for the new default (the test now resolves a dummy binary to prove default-on and the `=0` opt-out).

### Heads-up
CI's `e2e-docker` build now **downloads + bundles code-server** (pinned 4.96.4), so image builds are ~100 MB larger and depend on the `coder/code-server` release asset. That's the cost of shipping it by default.

Builds on the now-merged WP-H…WP-K. After this merges, deploying the combined image to `.254` brings the editor up with no extra flags.