### PR TITLE
fix(cli-oauth): wait out cold server install + bound every setup exec

### DIFF
--- a/src/cli_agent_setup.c
+++ b/src/cli_agent_setup.c
@@ -25,6 +25,13 @@
 #define OAUTH_POLL_DEADLINE_S 600 /* hard wall-clock cap regardless of progress */
 #define OAUTH_MAX_CONSEC_FAIL 5   /* bail if the server is unreachable this many polls in a row */
 
+/* The start call installs the vendor CLI on the server before it returns, which on
+ * a cold host means a full `npm i -g` + the native-binary postinstall. We must
+ * wait longer than the server's worst-case install (npm 180s + postinstall 120s +
+ * version probes + launch/scrape) or a genuinely-working setup is misreported as a
+ * dead server. A re-run after this still succeeds (the install is then cached). */
+#define OAUTH_START_TIMEOUT_MS 420000
+
 /* Best-effort scrub of a sensitive buffer (not optimized away). */
 static void secure_zero(void *p, size_t n)
 {
@@ -244,11 +251,21 @@ static int setup_oauth_cli_cmd(const char *vendor, int json_output)
 
    fprintf(stderr, "\n=== %s server-hosted OAuth setup ===\n", vendor);
    fprintf(stderr, "Installing the %s CLI on aimee-server and starting its login...\n", vendor);
+   fprintf(stderr, "(first-time install downloads the CLI server-side and can take a few "
+                   "minutes — please wait)\n");
 
-   cJSON *started = setup_oauth_rpc("agent.cli_oauth_start", vendor, NULL, NULL, 120000);
+   cJSON *started =
+       setup_oauth_rpc("agent.cli_oauth_start", vendor, NULL, NULL, OAUTH_START_TIMEOUT_MS);
    if (!started)
    {
-      fprintf(stderr, "Could not start %s setup (is the server reachable?).\n", vendor);
+      /* A NULL here is a transport failure or a timeout — not necessarily an
+       * unreachable server. If the server is mid-install it keeps going, so a
+       * plain re-run usually succeeds (the install is then already cached). */
+      fprintf(stderr,
+              "Could not complete %s setup: the server did not respond in time "
+              "(it may still be installing the CLI). Re-run `aimee agent setup %s-oauth` "
+              "in a minute, or check that aimee-server is reachable.\n",
+              vendor, vendor);
       return 1;
    }
    char session[160] = "";

--- a/src/server/server_cli_oauth.c
+++ b/src/server/server_cli_oauth.c
@@ -22,6 +22,15 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+/* Wall-clock ceilings for every spawned process. None of these may run unbounded:
+ * the client that drove the setup may have already disconnected (a cold install
+ * can outlast its dispatch deadline), and the per-vendor lock held across the
+ * login launch must never be wedged by a hung vendor CLI. A timed-out exec is
+ * SIGKILLed and reaped, surfacing a real error instead of a frozen handler. */
+#define OAUTH_NPM_INSTALL_TIMEOUT_MS 180000 /* cold `npm i -g` of one pinned package */
+#define OAUTH_PROBE_TIMEOUT_MS       30000  /* `<cli> --version` / `login status` */
+#define OAUTH_TMUX_TIMEOUT_MS        8000   /* tmux control commands must return promptly */
+
 /* --- vendor table (the one source of truth) ------------------------------- */
 
 typedef struct
@@ -155,10 +164,11 @@ int cli_oauth_install(cli_oauth_vendor_t v, char *err, size_t errn)
    char exe[600];
    exe_path(v, exe, sizeof(exe));
 
-   /* Idempotent: a real version probe (not mere file existence). */
+   /* Idempotent: a real version probe (not mere file existence). Bounded so a
+    * hung launcher can't stall the install (and, via the caller, the lock). */
    const char *probe[] = {exe, "--version", NULL};
    char *out = NULL;
-   if (safe_exec_capture_env(probe, env, &out, 256) == 0)
+   if (safe_exec_capture_cwd_env_timeout(probe, NULL, env, &out, 256, OAUTH_PROBE_TIMEOUT_MS) == 0)
    {
       free(out);
       return 0; /* already installed and runnable */
@@ -170,8 +180,15 @@ int cli_oauth_install(cli_oauth_vendor_t v, char *err, size_t errn)
    /* --ignore-scripts: no package lifecycle scripts run with server privileges. */
    const char *install[] = {"npm", "install", "-g", "--ignore-scripts", pkgspec, NULL};
    out = NULL;
-   int rc = safe_exec_capture_env(install, env, &out, 64 * 1024);
+   int rc = safe_exec_capture_cwd_env_timeout(install, NULL, env, &out, 64 * 1024,
+                                              OAUTH_NPM_INSTALL_TIMEOUT_MS);
    free(out); /* never surface raw npm output (may carry registry/token noise) */
+   if (rc == SAFE_EXEC_TIMEOUT)
+   {
+      snprintf(err, errn, "npm install of %s timed out after %ds", g_vendors[v].npm_pkg,
+               OAUTH_NPM_INSTALL_TIMEOUT_MS / 1000);
+      return -1;
+   }
    if (rc != 0)
    {
       snprintf(err, errn, "npm install of %s failed (exit %d)", g_vendors[v].npm_pkg, rc);
@@ -199,7 +216,7 @@ int cli_oauth_install(cli_oauth_vendor_t v, char *err, size_t errn)
 
    /* Confirm it now runs. */
    out = NULL;
-   rc = safe_exec_capture_env(probe, env, &out, 256);
+   rc = safe_exec_capture_cwd_env_timeout(probe, NULL, env, &out, 256, OAUTH_PROBE_TIMEOUT_MS);
    if (rc != 0)
    {
       char snip[200] = "";
@@ -230,7 +247,7 @@ static int tmux_capture(cli_oauth_vendor_t v, const char *sock, const char *sess
    build_env(v, store, env);
    const char *argv[] = {"tmux", "-S", sock, "capture-pane", "-p", "-t", sess, NULL};
    *out = NULL;
-   return safe_exec_capture_env(argv, env, out, 64 * 1024);
+   return safe_exec_capture_cwd_env_timeout(argv, NULL, env, out, 64 * 1024, OAUTH_TMUX_TIMEOUT_MS);
 }
 
 static void tmux_kill(cli_oauth_vendor_t v, const char *sock, const char *sess)
@@ -240,7 +257,7 @@ static void tmux_kill(cli_oauth_vendor_t v, const char *sock, const char *sess)
    build_env(v, store, env);
    const char *argv[] = {"tmux", "-S", sock, "kill-session", "-t", sess, NULL};
    char *out = NULL;
-   safe_exec_capture_env(argv, env, &out, 256);
+   safe_exec_capture_cwd_env_timeout(argv, NULL, env, &out, 256, OAUTH_TMUX_TIMEOUT_MS);
    free(out);
 }
 
@@ -383,7 +400,7 @@ int cli_oauth_start(cli_oauth_vendor_t v, cli_oauth_start_t *out, char *err, siz
    argv[ai] = NULL;
 
    char *cap = NULL;
-   if (safe_exec_capture_env(argv, env, &cap, 256) != 0)
+   if (safe_exec_capture_cwd_env_timeout(argv, NULL, env, &cap, 256, OAUTH_TMUX_TIMEOUT_MS) != 0)
    {
       free(cap);
       close(lock);
@@ -477,7 +494,7 @@ int cli_oauth_submit_code(cli_oauth_vendor_t v, const char *session, const char 
    /* send-keys is argv: the code is a literal key string, never shell-parsed. */
    const char *keys[] = {"tmux", "-S", sock, "send-keys", "-t", sess, code, "Enter", NULL};
    char *out = NULL;
-   int rc = safe_exec_capture_env(keys, env, &out, 256);
+   int rc = safe_exec_capture_cwd_env_timeout(keys, NULL, env, &out, 256, OAUTH_TMUX_TIMEOUT_MS);
    free(out);
    if (rc != 0)
    {
@@ -515,7 +532,8 @@ int cli_oauth_poll(cli_oauth_vendor_t v, const char *session, cli_oauth_state_t 
    {
       const char *st[] = {exe, "login", "status", NULL};
       char *o = NULL;
-      authed = (safe_exec_capture_env(st, env, &o, 4096) == 0);
+      authed =
+          (safe_exec_capture_cwd_env_timeout(st, NULL, env, &o, 4096, OAUTH_PROBE_TIMEOUT_MS) == 0);
       free(o);
    }
    else

--- a/src/tests/test_server_cli_oauth.c
+++ b/src/tests/test_server_cli_oauth.c
@@ -9,16 +9,6 @@
 #include <string.h>
 
 /* --- stubs for the linked-but-unexercised deps of server_cli_oauth.o --- */
-int safe_exec_capture_env(const char *const argv[], char *const envp[], char **out_buf,
-                          size_t max_out)
-{
-   (void)argv;
-   (void)envp;
-   (void)max_out;
-   if (out_buf)
-      *out_buf = NULL;
-   return -1;
-}
 int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
                                       char **out_buf, size_t max_out, int timeout_ms)
 {


### PR DESCRIPTION
## Problem
`aimee agent setup claude-oauth` reported **"Could not start … (is the server reachable?)"** against a reachable server. The `agent.cli_oauth_start` /v1 route is **synchronous** and installs the vendor CLI on aimee-server (cold `npm i -g @anthropic-ai/claude-code` + native-binary postinstall) *before* responding, but the client only waited **120 s** — shorter than the server's own 120 s postinstall ceiling. So a first-time install timed out, the dispatch returned `NULL`, and that was misreported as a dead server.

Worse, retries then hit a **wedged per-vendor `flock`**: a thread stuck on an *unbounded* `safe_exec_capture_env` (timeout 0) inside `cli_oauth_start` never releases the lock, so every subsequent call returns *"a claude setup is already in progress"* until the server process restarts. (Reproduced live.)

## Fix
**Client (`cli_agent_setup.c`)**
- Wait `OAUTH_START_TIMEOUT_MS` (420 s) for the start call — exceeds the server's worst-case install (npm 180 s + postinstall 120 s + probes + launch/scrape).
- Warn that first-time install is slow.
- On a NULL start, say *"did not respond in time (may still be installing); re-run"* instead of blaming reachability.

**Server (`server_cli_oauth.c`)** — bound **every** spawned process so a hang can't run unbounded after the client disconnects or wedge the lock:
- npm install → 180 s, version/login-status probes → 30 s, all tmux control commands → 8 s, via `safe_exec_capture_cwd_env_timeout`.
- A timed-out exec is SIGKILLed + reaped → surfaces a real error and releases the lock instead of freezing the handler.

**Test** — stub switched to the bounded exec the module now calls.

## Verification
- `-Wall -Wextra -Werror` syntax-check clean on both changed TUs.
- `unit-test-server-cli-oauth` links and passes.

Distinct from the `--ignore-scripts` postinstall bug (#450). Deploy note: clears recurrence; an already-wedged server still needs a restart to release the stuck lock.