### PR TITLE
fix: db2 init-order, config data race, mining boolean, gateway webhook overflow

### DIFF
--- a/src/aimee_home.c
+++ b/src/aimee_home.c
@@ -8,7 +8,13 @@
 
 const char *aimee_home(void)
 {
-   static char path[4096];
+   /* Thread-local: this is a per-call scratch buffer whose pointer is returned
+    * to the caller. aimee-kb calls config_load() (which routes here) from
+    * several worker threads concurrently (ingest watch/timer, reflection), so a
+    * process-global static buffer is a data race (TSan-confirmed) and risks a
+    * torn read of the path. Per-thread storage makes each call race-free while
+    * preserving the re-read-getenv-every-call semantics. */
+   static __thread char path[4096];
 
    /* 1. Explicit override wins. Operators or tests set AIMEE_HOME
     *    to an absolute path; we don't validate beyond non-empty. */
@@ -44,7 +50,7 @@ const char *aimee_home(void)
 
 const char *aimee_profiles_dir(void)
 {
-   static char path[4096];
+   static __thread char path[4096]; /* per-call scratch; see aimee_home() */
 
    const char *override = getenv("AIMEE_HOME");
    if (override && override[0])

--- a/src/config.c
+++ b/src/config.c
@@ -159,8 +159,10 @@ const char *config_default_dir(void)
 
 const char *config_default_path(void)
 {
-   static char path[MAX_PATH_LEN];
-   static char cached_dir[MAX_PATH_LEN];
+   /* Thread-local: returned-pointer scratch reachable from config_load() on
+    * several concurrent kb worker threads (TSan data race otherwise). */
+   static __thread char path[MAX_PATH_LEN];
+   static __thread char cached_dir[MAX_PATH_LEN];
    const char *dir = config_default_dir();
 
    if (path[0] && strcmp(cached_dir, dir) == 0)
@@ -173,7 +175,8 @@ const char *config_default_path(void)
 
 const char *config_output_dir(void)
 {
-   static char fallback[MAX_PATH_LEN];
+   /* Thread-local returned-pointer scratch; see config_default_path(). */
+   static __thread char fallback[MAX_PATH_LEN];
    const char *dir = config_default_dir();
 
    if (dir && platform_mkdir_p(dir, 0700) == 0 && access(dir, W_OK) == 0)
@@ -197,7 +200,8 @@ const char *config_default_db1_path(void)
    if (db1_default_path)
       return db1_default_path();
 
-   static char path[MAX_PATH_LEN];
+   /* Thread-local returned-pointer scratch; see config_default_path(). */
+   static __thread char path[MAX_PATH_LEN];
    const char *dir = config_default_dir();
    snprintf(path, sizeof(path), "%s/aimee.db", dir ? dir : "/tmp");
    return path;

--- a/src/db1/maintenance.c
+++ b/src/db1/maintenance.c
@@ -19,8 +19,12 @@
 
 const char *db1_default_path(void)
 {
-   static char path[MAX_PATH_LEN];
-   static char cached_base[MAX_PATH_LEN];
+   /* Thread-local: returned-pointer scratch. This is the db1_default_path hook
+    * config_default_db1_path() delegates to, reached from config_load() on
+    * several concurrent threads — a process-global static buffer is a data race
+    * (see the matching fix in config.c / aimee_home.c). */
+   static __thread char path[MAX_PATH_LEN];
+   static __thread char cached_base[MAX_PATH_LEN];
    const char *base = aimee_home();
    if (!base)
       base = "/tmp/.config/aimee";

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -380,25 +380,6 @@ int db2_init(const char *libpq_url)
       return -1;
    }
 
-   /* The code-graph projection upserts edges with
-    * ON CONFLICT (source, relation, target), which requires a unique index the
-    * base schema.sql deliberately does NOT declare (legacy instances may hold
-    * duplicate triples, which would make a plain CREATE UNIQUE INDEX in the
-    * schema fail on every startup). db2_entity_edge_build_unique_index() had no
-    * caller, so the index never existed and the projection silently produced
-    * zero edges on every instance — graph-code fusion's whole substrate. Build
-    * it best-effort here: on a clean instance it creates the index (projection
-    * works); if a legacy instance still holds duplicate triples it logs and
-    * continues (no startup regression; dedup is a separate migration). The shim
-    * has no real index machinery, so skip it there. */
-   if (!aimee_pg_is_shim())
-   {
-      int ee_idx_existed = 0;
-      if (db2_entity_edge_build_unique_index(&ee_idx_existed) != 0)
-         fprintf(stderr, "aimee: db2_init: entity_edges unique index not built; code-graph "
-                         "projection ON CONFLICT will no-op until duplicate triples are deduped\n");
-   }
-
    /* pg_trgm is required: db2/schema.sql creates a GIN index on
     * memories.memories_code_fts_text using gin_trgm_ops, and the
     * memory_query path issues % / similarity() against memory text.
@@ -439,6 +420,30 @@ int db2_init(const char *libpq_url)
    g_init_thread = pthread_self();
    g_init_thread_set = 1;
    snprintf(g_pg_url, sizeof(g_pg_url), "%s", libpq_url);
+
+   /* The code-graph projection upserts edges with
+    * ON CONFLICT (source, relation, target), which requires a unique index the
+    * base schema.sql deliberately does NOT declare (legacy instances may hold
+    * duplicate triples, which would make a plain CREATE UNIQUE INDEX in the
+    * schema fail on every startup). Build it best-effort here: on a clean
+    * instance it creates the index (projection works); if a legacy instance
+    * still holds duplicate triples it logs and continues (no startup regression;
+    * dedup is a separate migration). The shim has no real index machinery, so
+    * skip it there.
+    *
+    * This MUST run after g_conn/g_init_thread are recorded above: the builder
+    * reaches Postgres through db2_conn(), which returns g_conn only once the init
+    * thread is set. Running it earlier (the original site, before g_conn was
+    * assigned) made db2_conn() return NULL, so the build silently failed and the
+    * index was never created on any instance — graph-code fusion's whole
+    * substrate produced zero edges. */
+   if (!aimee_pg_is_shim())
+   {
+      int ee_idx_existed = 0;
+      if (db2_entity_edge_build_unique_index(&ee_idx_existed) != 0)
+         fprintf(stderr, "aimee: db2_init: entity_edges unique index not built; code-graph "
+                         "projection ON CONFLICT will no-op until duplicate triples are deduped\n");
+   }
    /* Initialize the connection pool that every non-init thread leases from. On
     * failure, db2_conn falls back to private per-thread connections (degraded
     * but functional). Skipped under the sqlite test shim (a shared sqlite handle

--- a/src/db2/mining.c
+++ b/src/db2/mining.c
@@ -28,7 +28,7 @@ static int exec_job_default(const char *id, int interval_s)
    char err[256] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
                                           "INSERT INTO mining_jobs (id, hwm, interval_s, enabled)"
-                                          " VALUES (?1, 0, ?2, 1)"
+                                          " VALUES (?1, 0, ?2, TRUE)"
                                           " ON CONFLICT (id) DO NOTHING",
                                           err, sizeof(err));
    if (!st)

--- a/src/gateway/platform_webhook.c
+++ b/src/gateway/platform_webhook.c
@@ -114,11 +114,22 @@ static int read_http_request(int fd, char *out_buf, size_t out_cap, size_t *body
             }
             sig_out[i] = '\0';
          }
-         /* Read the body if not yet fully received. */
+         /* Read the body if not yet fully received. Content-Length is
+          * attacker-controlled, so the per-read length MUST be clamped to the
+          * remaining buffer capacity — never to (*body_len - have_body), which a
+          * malicious huge Content-Length would make far larger than out_buf,
+          * letting a single read() overflow the heap allocation (one NUL byte is
+          * reserved at out_buf[total]). */
          size_t have_body = total - *body_start;
          while (have_body < *body_len && total + 1 < out_cap)
          {
-            ssize_t m = read(fd, out_buf + total, *body_len - have_body);
+            size_t want = *body_len - have_body;
+            size_t room = out_cap - total - 1;
+            if (want > room)
+               want = room;
+            if (want == 0)
+               break;
+            ssize_t m = read(fd, out_buf + total, want);
             if (m <= 0)
                break;
             total += (size_t)m;

--- a/src/tests/test_db2.c
+++ b/src/tests/test_db2.c
@@ -15,6 +15,7 @@ enum
 {
    STMT_SCHEMA = 1,
    STMT_EXT = 2,
+   STMT_INDEX = 3,
 };
 
 static int g_open_calls = 0;
@@ -91,6 +92,7 @@ aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, 
 {
    static aimee_pg_stmt_t schema_stmt = {.kind = STMT_SCHEMA};
    static aimee_pg_stmt_t ext_stmt = {.kind = STMT_EXT};
+   static aimee_pg_stmt_t index_stmt = {.kind = STMT_INDEX};
 
    g_prepare_calls++;
    assert(pg_conn == &g_fake_conn);
@@ -107,6 +109,12 @@ aimee_pg_stmt_t *aimee_pg_prepare(void *pg_conn, const char *sql, char *errbuf, 
     * uniformly through STMT_EXT and the g_extension_present knob. */
    if (strstr(sql, "pg_extension") != NULL || strstr(sql, "pg_available_extensions") != NULL)
       return &ext_stmt;
+   /* db2_init builds the entity_edges (source,relation,target) unique index
+    * (needed by the code-graph projection's ON CONFLICT). It first probes
+    * pg_indexes for idx_ee_unique_triple; this mock reports the index already
+    * present so the build short-circuits (no CREATE exec). */
+   if (strstr(sql, "pg_indexes") != NULL)
+      return &index_stmt;
    assert(!"unexpected SQL");
    return NULL;
 }
@@ -134,6 +142,8 @@ aimee_pg_step_t aimee_pg_step(aimee_pg_stmt_t *stmt, char *errbuf, size_t errlen
       return g_schema_present ? AIMEE_PG_ROW : AIMEE_PG_DONE;
    if (stmt->kind == STMT_EXT)
       return g_extension_present ? AIMEE_PG_ROW : AIMEE_PG_DONE;
+   if (stmt->kind == STMT_INDEX)
+      return AIMEE_PG_ROW; /* idx_ee_unique_triple already present */
    assert(!"unexpected statement kind");
    return AIMEE_PG_ERR;
 }


### PR DESCRIPTION
Four independent bug fixes found during an exhaustive testing pass. They touch disjoint files and are individually revertable. Each was reproduced and verified before/after.

## fix(db2): build entity_edges unique index after g_conn is set
`db2_init()` called `db2_entity_edge_build_unique_index()` before assigning `g_conn`, so `db2_conn()` returned NULL and `idx_ee_unique_triple` was never created on any instance. Without it, the code-graph projection's `INSERT ... ON CONFLICT (source, relation, target)` errored on every edge, so `db2_code_projection_sync_project()` produced zero edges — graph-code fusion's whole substrate was permanently empty. Moved the build after `g_conn`/`g_init_thread` are recorded. Verified on fresh DBs: index now builds (no warning) and `graph.sync_code` yields real edges (0 → 9 on a 2-file project). Also extends `test_db2`'s PG mock (which ran the production path but never modeled the index build, having been masked by the NULL-conn bug).

## fix(config): thread-local scratch buffers in aimee_home/config path helpers
`aimee_home()`, `aimee_profiles_dir()`, and the `config_default_path` / `config_output_dir` / `config_default_db1_path` / `db1_default_path` helpers each format into a process-global `static char` buffer and return a pointer to it. aimee-kb calls `config_load()` (which routes through these) from several worker threads concurrently — ThreadSanitizer confirms concurrent writes to the `aimee_home()` and `config_default_db1_path()` static buffers from the ingest watch/timer threads and reflection init. Made each per-call scratch buffer `static __thread`, eliminating the shared memory while preserving the re-read-getenv-every-call semantics. TSan-clean after.

## fix(db2): seed mining_jobs.enabled with TRUE, not integer literal 1
The `mining_jobs` seed `INSERT` bound the integer literal `1` to the `BOOLEAN enabled` column. PostgreSQL strictly type-checks literals in `INSERT VALUES`, so it failed on every call (`column "enabled" is of type boolean but expression is of type integer`); SQLite and the db2 test shim treat 0/1 and booleans interchangeably, masking it. `db2_mining_seed_job_defaults()` returned -1 and `kb_mining_run_once()` bails at the seed step, so the actual mining jobs (pattern_cluster, recurrence) never ran on any PostgreSQL instance. Changed `1` → `TRUE`. Verified: mining_jobs now seeds both jobs enabled, zero boolean-type errors. (`bind_int`/`bind_double` to boolean columns elsewhere are safe — params are sent as text and PG coerces "1"/"0"; only in-SQL integer literals hit this.)

## fix(gateway): clamp webhook body read to buffer size (heap overflow)
`read_http_request()` reads the request body into a fixed 65 KB buffer but sizes each `read()` by `*body_len - have_body`, where `*body_len` is the attacker-controlled `Content-Length`. A single `read()` can write far past the allocation: send `Content-Length: 10000000` then >64 KB of body. ASan confirms a ~110 KB write into the 65537-byte buffer. The read happens before the HMAC check, so it is pre-auth. (Currently latent — `gateway_main` never starts the webhook listener — but the adapter is fully implemented and this goes live the moment `startup()` is wired in.) Clamp each read to the remaining buffer room; oversized bodies are truncated and then fail JSON/HMAC. Verified with an ASan repro: overflow before, clean after; all gateway unit tests pass.

The live HTTP parsers (server_http.c, kb_http_conn.c) were audited and correctly clamp Content-Length before allocating — this fixed-buffer-plus-unbounded-read pattern was unique to the webhook adapter.
