### PR TITLE
fix(cli-oauth): O_CLOEXEC the per-vendor lock so the tmux daemon can't hold it

### DIFF
--- a/src/server/server_cli_oauth.c
+++ b/src/server/server_cli_oauth.c
@@ -324,7 +324,15 @@ static int lock_acquire(cli_oauth_vendor_t v)
    snprintf(dir, sizeof(dir), "%s/lock", home_dir());
    platform_mkdir_p(dir, 0700);
    snprintf(path, sizeof(path), "%s/cli-oauth-%s.lock", dir, g_vendors[v].name);
-   int fd = open(path, O_CREAT | O_RDWR, 0600);
+   /* O_CLOEXEC is load-bearing: cli_oauth_start holds this fd across the
+    * fork+exec that launches the login in a detached tmux session. tmux
+    * daemonizes (re-parents to init) and would INHERIT a non-CLOEXEC lock fd,
+    * keeping the flock held for the daemon's whole lifetime — long after
+    * cli_oauth_start close()s its own copy. The result was a permanent "a setup
+    * is already in progress" wedge after any abandoned login, clearable only by
+    * killing the tmux server or restarting aimee-server. Closing the fd on exec
+    * means only this process holds the lock, so close() here fully releases it. */
+   int fd = open(path, O_CREAT | O_RDWR | O_CLOEXEC, 0600);
    if (fd < 0)
       return -1;
    if (flock(fd, LOCK_EX | LOCK_NB) != 0)


### PR DESCRIPTION
## The real wedge
This is the actual root cause of the permanent **"a claude setup is already in progress"** wedge. The bounded-exec change in #470 was good hardening but fixed a different failure mode.

`cli_oauth_start` holds the per-vendor lock fd across the `fork`+`exec` that launches the vendor login in a **detached tmux session**. tmux daemonizes and re-parents to init, **inheriting every non-CLOEXEC fd — including the lock**. When `cli_oauth_start` `close()`s its own copy on return, the tmux daemon still holds an inherited copy of the *same open file description*, so the `flock` stays held for the daemon's whole lifetime. Any abandoned login (start without finishing the paste-back) wedged every later setup until the tmux server was killed or aimee-server restarted.

## Fix
Open the lock with `O_CLOEXEC` so the fd is dropped on `exec`; only this process holds it, and `close()` fully releases the `flock`.

## Verification
- `-Wall -Wextra -Werror` clean, clang-format clean, `unit-test-server-cli-oauth` passes.
- Diagnosed live on a v0.2.99 server: `/proc/<pid>/exe -> /usr/bin/tmux` (the daemonized `claude setup-token` session) was the holder of the `cli-oauth-claude.lock` fd; killing it released the flock.

Follow-up to #470.