### PR TITLE
fix(image): install git + openssh-client (git-projects + editor need them)

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -110,6 +110,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        git \
         libpam-modules \
         libpam0g \
         libpq5 \
@@ -118,6 +119,7 @@ RUN apt-get update \
         libzstd1 \
         nodejs \
         npm \
+        openssh-client \
         python3 \
         tmux \
         zlib1g \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -109,6 +109,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        git \
         libpam-modules \
         libpam0g \
         libsqlite3-0 \
@@ -116,6 +117,7 @@ RUN apt-get update \
         libzstd1 \
         nodejs \
         npm \
+        openssh-client \
         tmux \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## "git clone failed (rc=127)" — `git` is not in the image

The webchat **git-projects** feature and the **in-app editor's** integrated git shell out to `git` (and `ssh`/`ssh-agent`/`ssh-add` for SSH-key clones + the WP-C2 in-memory ssh-agent). Neither `git` nor `openssh-client` was installed in the runtime image, so every clone/git op failed `rc=127` — `execvpe` couldn't find the binary.

## Fix
Add `git` + `openssh-client` to the runtime apt install in **both** `Dockerfile.server` and `Dockerfile.combined`.

## Verified live (.254)
Installed the same two packages by hand on the running container, then:
```
POST /v1/workspace/clone {"url":"https://github.com/octocat/Hello-World"}
  → {"ok":true,"name":"Hello-World"}
GET  /v1/workspace/projects → {"projects":["Hello-World"]}
```
The live container is already patched; this PR makes it durable for every rebuild.