### PR TITLE
fix(webchat): auto-generate a trustable TLS cert (SAN) for the editor webviews

### DIFF
--- a/deploy/container/webchat-lib.sh
+++ b/deploy/container/webchat-lib.sh
@@ -113,12 +113,23 @@ webchat_start() {
     fi
     webchat_bootstrap_user
     webchat_ensure_server_token
+    # Operator-supplied TLS cert (PEM). A browser-trusted cert is required for the
+    # in-app VSCode editor's webviews (the service worker won't register over an
+    # untrusted cert). Without these, webchat self-signs (now with the host's IP +
+    # hostname in the SAN, so the generated cert can be imported + trusted).
+    _wc_tls=""
+    if [ -n "${AIMEE_WEBCHAT_TLS_CERT:-}" ] && [ -n "${AIMEE_WEBCHAT_TLS_KEY:-}" ]; then
+        _wc_tls="--cert $AIMEE_WEBCHAT_TLS_CERT --key $AIMEE_WEBCHAT_TLS_KEY"
+        webchat_log "using operator TLS cert $AIMEE_WEBCHAT_TLS_CERT"
+    fi
     webchat_log "starting aimee-webchat on :$WEBCHAT_PORT (https), socket=$WEBCHAT_HOME/aimee-server.sock"
+    # shellcheck disable=SC2086
     HOME=/root aimee-webchat \
         --port "$WEBCHAT_PORT" \
         --socket "$WEBCHAT_HOME/aimee-server.sock" \
         --db "$WEBCHAT_HOME/webchat.db" \
-        --spa "$WEBCHAT_SPA" &
+        --spa "$WEBCHAT_SPA" \
+        $_wc_tls &
     webchat_pid=$!
 }
 

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -12,9 +12,11 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "github.com/mattn/go-sqlite3"
@@ -277,21 +279,80 @@ func ensureTLSCert(cfg *config) (cert, key string, err error) {
 	return certPath, keyPath, nil
 }
 
+// certSANs builds the Subject Alternative Names for the auto-generated cert so
+// it can actually be trusted for how the browser reaches webchat. A cert with
+// only DNS:localhost cannot validate for https://<LAN-IP>:8443, which (besides
+// the usual warning) makes browsers refuse to register VSCode's service worker
+// ("An SSL certificate error occurred when fetching the script") so the editor's
+// webviews break. We include localhost, every non-loopback interface IP, the
+// hostname, and any operator-supplied AIMEE_WEBCHAT_TLS_SANS (comma-separated
+// IPs/DNS names) so an operator who trusts this cert gets a fully valid context.
+func certSANs() (dnsNames []string, ipAddrs []net.IP) {
+	dnsSeen := map[string]bool{}
+	ipSeen := map[string]bool{}
+	addDNS := func(n string) {
+		n = strings.TrimSpace(n)
+		if n != "" && !dnsSeen[n] {
+			dnsSeen[n] = true
+			dnsNames = append(dnsNames, n)
+		}
+	}
+	addIP := func(ip net.IP) {
+		if ip != nil && !ipSeen[ip.String()] {
+			ipSeen[ip.String()] = true
+			ipAddrs = append(ipAddrs, ip)
+		}
+	}
+
+	addDNS("localhost")
+	addIP(net.ParseIP("127.0.0.1"))
+	addIP(net.ParseIP("::1"))
+	if h, err := os.Hostname(); err == nil {
+		addDNS(h)
+	}
+	if addrs, err := net.InterfaceAddrs(); err == nil {
+		for _, a := range addrs {
+			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
+				addIP(ipnet.IP)
+			}
+		}
+	}
+	// Operator override for names/IPs not derivable here (e.g. a reverse-proxy
+	// hostname): AIMEE_WEBCHAT_TLS_SANS="aimee.lan,10.0.0.5".
+	for _, s := range strings.Split(os.Getenv("AIMEE_WEBCHAT_TLS_SANS"), ",") {
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		if ip := net.ParseIP(s); ip != nil {
+			addIP(ip)
+		} else {
+			addDNS(s)
+		}
+	}
+	return dnsNames, ipAddrs
+}
+
 func generateSelfSignedCert(certPath, keyPath string) error {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
 		return err
 	}
 
+	dnsNames, ipAddrs := certSANs()
+
 	serial, _ := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
 	tmpl := &x509.Certificate{
-		SerialNumber: serial,
-		Subject:      pkix.Name{CommonName: "aimee-webchat"},
-		NotBefore:    time.Now().Add(-time.Minute),
-		NotAfter:     time.Now().Add(10 * 365 * 24 * time.Hour),
-		KeyUsage:     x509.KeyUsageDigitalSignature,
-		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-		DNSNames:     []string{"localhost"},
+		SerialNumber:          serial,
+		Subject:               pkix.Name{CommonName: "aimee-webchat"},
+		NotBefore:             time.Now().Add(-time.Minute),
+		NotAfter:              time.Now().Add(10 * 365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		DNSNames:              dnsNames,
+		IPAddresses:           ipAddrs,
 	}
 
 	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)


### PR DESCRIPTION
## "Could not register service worker … An SSL certificate error occurred"

The in-app VSCode editor registers a **service worker** for its webviews. Browsers refuse to register a service worker over an **untrusted TLS context**, so on webchat's self-signed cert the editor failed and webviews broke.

Worse, the auto-generated cert only had `DNS:localhost` — it didn't even **match the LAN IP** the browser uses (`https://<ip>:8443`), so it could never be trusted for that URL.

## Make it trustable, automatically
- **`generateSelfSignedCert`** now sets SANs = `localhost` + `127.0.0.1` + `::1` + **every non-loopback interface IP** + the **hostname**, plus an operator override `AIMEE_WEBCHAT_TLS_SANS` (comma-separated). The cert is also marked `IsCA` so it can be imported as a trusted root. A fresh deploy self-provisions a cert that is **valid for its own addresses**.
- **`webchat-lib.sh`** forwards `AIMEE_WEBCHAT_TLS_CERT` / `AIMEE_WEBCHAT_TLS_KEY` → webchat's existing `--cert`/`--key`, so dropping in an already-trusted cert needs no rebuild and the editor works with **zero** client-side steps.

## The honest part
A *self-signed* cert is, by definition, not trusted until someone trusts it — that one decision is operator policy and can't be done from inside the container:
- **Easiest hands-off:** point `AIMEE_WEBCHAT_TLS_CERT/KEY` at a cert your clients already trust (real cert, or your org's internal CA), or front webchat with a reverse proxy that has one.
- **Or** trust the generated cert once (now possible because it finally has the right SAN).

## Verified live (.254)
Regenerated webchat's cert with `IP:192.168.1.254` in the SAN and restarted — `openssl s_client -connect 192.168.1.254:8443` now shows `Subject Alternative Name: IP Address:192.168.1.254, DNS:localhost, DNS:smoothnas`. This PR makes that automatic for every deploy.

Companion to #476 (server.token) and #477 (git/openssh) — together a fresh deploy auto-provisions everything the git-projects + editor features need.