### PR TITLE
Promote testing → main: cli HTTP Content-Length fix (#478)

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -110,6 +110,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        git \
         libpam-modules \
         libpam0g \
         libpq5 \
@@ -118,6 +119,7 @@ RUN apt-get update \
         libzstd1 \
         nodejs \
         npm \
+        openssh-client \
         python3 \
         tmux \
         zlib1g \

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -109,6 +109,7 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        git \
         libpam-modules \
         libpam0g \
         libsqlite3-0 \
@@ -116,6 +117,7 @@ RUN apt-get update \
         libzstd1 \
         nodejs \
         npm \
+        openssh-client \
         tmux \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*

--- a/deploy/container/webchat-lib.sh
+++ b/deploy/container/webchat-lib.sh
@@ -60,6 +60,41 @@ webchat_is_enabled() {
     esac
 }
 
+# Provision the webchat<->server shared trust secret. Both aimee-server (which
+# validates a webchat `X-Aimee-Webuser` assertion) and aimee-webchat (which sends
+# it, plus uses it as the legacy socket bearer) read $AIMEE_HOME/server.token.
+# Without it EVERY per-user vault/git/editor call fails closed ("aimee-server
+# unavailable" / "editor unavailable"), because webchat short-circuits before it
+# even reaches the server. Generate a strong random secret once, 0600, owned by
+# the aimee user so the privilege-dropped server can read it. Never clobber an
+# operator-provided token. Idempotent — safe to call on every start.
+webchat_ensure_server_token() {
+    _tok_path="${WEBCHAT_HOME}/server.token"
+    if [ -s "$_tok_path" ]; then
+        return 0
+    fi
+    mkdir -p "$WEBCHAT_HOME"
+    _tok=""
+    if command -v openssl >/dev/null 2>&1; then
+        _tok="$(openssl rand -hex 32 2>/dev/null)"
+    fi
+    if [ -z "$_tok" ] && [ -r /dev/urandom ]; then
+        _tok="$(head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n')"
+    fi
+    if [ -z "$_tok" ]; then
+        webchat_log "WARNING: could not generate server.token (no openssl/urandom); per-user vault/git/editor will be unavailable"
+        return 0
+    fi
+    _umask_old="$(umask)"
+    umask 077
+    printf '%s\n' "$_tok" > "$_tok_path"
+    umask "$_umask_old"
+    # aimee-server runs as the unprivileged 'aimee' user and reads this file.
+    chown aimee:aimee "$_tok_path" 2>/dev/null || true
+    chmod 600 "$_tok_path" 2>/dev/null || true
+    webchat_log "generated server.token (webchat<->server trust for per-user vault/git/editor)"
+}
+
 # Launch aimee-webchat in the background (as root, for PAM). Self-signed TLS on
 # :8443 is auto-generated under AIMEE_HOME and persists on the data volume.
 webchat_start() {
@@ -77,6 +112,7 @@ webchat_start() {
         return 0
     fi
     webchat_bootstrap_user
+    webchat_ensure_server_token
     webchat_log "starting aimee-webchat on :$WEBCHAT_PORT (https), socket=$WEBCHAT_HOME/aimee-server.sock"
     HOME=/root aimee-webchat \
         --port "$WEBCHAT_PORT" \

--- a/src/posix/cli_client.c
+++ b/src/posix/cli_client.c
@@ -500,9 +500,52 @@ static long cli_conn_read(int fd, void *tlsp, void *buf, size_t len)
    }
 }
 
-/* Send an HTTP request and read the full response (server closes the conn) over
- * an already-connected transport. Returns a malloc'd NUL-terminated buffer
- * (caller frees) or NULL on error. */
+/* Parse a case-insensitive Content-Length value from the `n`-byte header block.
+ * Returns the declared body length, or -1 if absent/unparseable. */
+static long cli_http_content_length(const char *buf, size_t n)
+{
+   static const char key[] = "content-length:";
+   size_t klen = sizeof(key) - 1;
+   for (size_t i = 0; i + klen <= n; i++)
+   {
+      if (i != 0 && buf[i - 1] != '\n') /* header names start a line */
+         continue;
+      size_t j = 0;
+      for (; j < klen; j++)
+      {
+         char c = buf[i + j];
+         if (c >= 'A' && c <= 'Z')
+            c = (char)(c - 'A' + 'a');
+         if (c != key[j])
+            break;
+      }
+      if (j != klen)
+         continue;
+      const char *p = buf + i + klen;
+      const char *end = buf + n;
+      while (p < end && (*p == ' ' || *p == '\t'))
+         p++;
+      long v = 0;
+      int any = 0;
+      while (p < end && *p >= '0' && *p <= '9')
+      {
+         v = v * 10 + (*p - '0');
+         any = 1;
+         if (v > (long)CLIENT_MAX_RESPONSE_SIZE) /* implausible; avoid overflow */
+            return -1;
+         p++;
+      }
+      return any ? v : -1;
+   }
+   return -1;
+}
+
+/* Send an HTTP request and read the full response over an already-connected
+ * transport. Honors Content-Length and stops at the end of the body; only falls
+ * back to read-until-close for responses that omit it. (Some server paths keep
+ * the connection open after a `Connection: close` request, so waiting for EOF
+ * would otherwise hang until the poll timeout.) Returns a malloc'd
+ * NUL-terminated buffer (caller frees) or NULL on error. */
 static char *cli_http_txn(int fd, void *tlsp, const char *method, const char *path,
                           const char *host, const char *bearer, const char *body_json,
                           int timeout_ms)
@@ -524,8 +567,15 @@ static char *cli_http_txn(int fd, void *tlsp, const char *method, const char *pa
    char *buf = malloc(cap);
    if (!buf)
       return NULL;
+   size_t header_end = 0;    /* offset just past "\r\n\r\n", 0 until seen */
+   long content_length = -1; /* declared body length once headers are parsed */
    for (;;)
    {
+      /* With a known Content-Length, stop once the whole body is in hand rather
+       * than waiting for the server to close the connection. */
+      if (header_end && content_length >= 0 && len >= header_end + (size_t)content_length)
+         break;
+
       struct pollfd pfd = {.fd = fd, .events = POLLIN};
       int rc = poll(&pfd, 1, timeout_ms);
       if (rc <= 0)
@@ -557,8 +607,20 @@ static char *cli_http_txn(int fd, void *tlsp, const char *method, const char *pa
          return NULL;
       }
       if (n == 0)
-         break; /* EOF */
+         break; /* EOF: close-delimited response (no usable Content-Length) */
       len += (size_t)n;
+      buf[len] = '\0';
+      /* Learn the body length as soon as the header terminator arrives so we can
+       * stop at the body's end instead of depending on connection close. */
+      if (!header_end)
+      {
+         const char *hb = strstr(buf, "\r\n\r\n");
+         if (hb)
+         {
+            header_end = (size_t)(hb - buf) + 4;
+            content_length = cli_http_content_length(buf, header_end);
+         }
+      }
    }
    buf[len] = '\0';
    return buf;


### PR DESCRIPTION
Promotes `testing` to `main`. Triggers `auto-release`.

- **fix(cli) #478** — `cli_http_txn` now honors `Content-Length` instead of reading until the server closes the connection. A keep-alive server (which holds the socket open after a `Connection: close` request) was making every sync remote `/v1` call hang until the request timeout; e.g. `agent setup claude-oauth` blocked the full 420s even though the server returned the URL in ~4s. Completes the cli-oauth fix series (#470 timeout/bounds, #474 lock O_CLOEXEC).