### PR TITLE
fix(server): JSON-escape /v1 error messages (fixes misleading "vault: request failed")

### DIFF
--- a/src/headers/server_http_identity.h
+++ b/src/headers/server_http_identity.h
@@ -53,4 +53,10 @@ void server_http_identity_apply(server_conn_t *conn);
 /* Reset the per-thread captured identity to the un-attested, no-vault defaults. */
 void server_http_identity_clear(void);
 
+/* Write a JSON error body {"error":"<msg>"} into resp (cap bytes), JSON-escaping
+ * msg so dynamic content (e.g. git stderr with newlines/quotes, file paths)
+ * cannot produce an invalid body that a client then fails to parse. Always
+ * NUL-terminates when cap > 0; truncates an over-long message safely. */
+void http_error_json(char *resp, size_t cap, const char *msg);
+
 #endif /* DEC_SERVER_HTTP_IDENTITY_H */

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -232,7 +232,7 @@ static int emit(char *resp, int cap, cJSON *obj)
 
 static int err_json(char *resp, int cap, int status, const char *msg)
 {
-   snprintf(resp, (size_t)cap, "{\"error\":\"%s\"}", msg ? msg : "error");
+   http_error_json(resp, (size_t)cap, msg ? msg : "error"); /* escapes msg → valid JSON */
    return status;
 }
 

--- a/src/server/server_http_identity.c
+++ b/src/server/server_http_identity.c
@@ -128,3 +128,52 @@ void server_http_identity_clear(void)
    tl_transport = ATTEST_NONE;
    tl_principal[0] = '\0';
 }
+
+void http_error_json(char *resp, size_t cap, const char *msg)
+{
+   if (!resp || cap == 0)
+      return;
+   if (!msg)
+      msg = "error";
+   if (cap < 16)
+   {
+      resp[0] = '\0';
+      return;
+   }
+   size_t o = (size_t)snprintf(resp, cap, "{\"error\":\"");
+   /* Leave room for the longest single escape (\uXXXX = 6) + closing "\"}" + NUL. */
+   for (const char *p = msg; *p && o + 9 < cap; p++)
+   {
+      unsigned char c = (unsigned char)*p;
+      switch (c)
+      {
+      case '"':
+         resp[o++] = '\\';
+         resp[o++] = '"';
+         break;
+      case '\\':
+         resp[o++] = '\\';
+         resp[o++] = '\\';
+         break;
+      case '\n':
+         resp[o++] = '\\';
+         resp[o++] = 'n';
+         break;
+      case '\r':
+         resp[o++] = '\\';
+         resp[o++] = 'r';
+         break;
+      case '\t':
+         resp[o++] = '\\';
+         resp[o++] = 't';
+         break;
+      default:
+         if (c < 0x20)
+            o += (size_t)snprintf(resp + o, cap - o, "\\u%04x", c);
+         else
+            resp[o++] = (char)c;
+         break;
+      }
+   }
+   snprintf(resp + o, cap - o, "\"}");
+}


### PR DESCRIPTION
## "vault: request failed" on a failing git clone — the error was just mangled

`err_json` built the body with `snprintf("{\"error\":\"%s\"}", msg)` and **never escaped `msg`**. When a handler passes dynamic content containing newlines or quotes — notably git's stderr from a failed clone:
```
fatal: could not read Username for 'https://github.com': No such device or address
```
— the resulting body is **invalid JSON**. webchat's parser fails and falls back to its generic message **"vault: request failed"**, completely hiding the real cause: an **auth-required clone with no stored credential**.

## Fix
Route the message through a new `http_error_json()` that JSON-escapes it (`"`, `\`, control chars → `\uXXXX`, `\n`/`\r`/`\t`). Implemented in `server_http_identity.c` (already included by `server_http.c`) so `server_http.c` stays within its 2000-line cap; `err_json` remains a thin wrapper. This fixes the body for **every** handler that surfaces dynamic content (git errors, file paths, …), not just clone.

Verified — a multi-line git error now yields valid JSON:
```
{"error":"git clone failed (rc=128): Cloning into 'x'...\nfatal: could not read Username for \"https://github.com\": No such device\n"}
```
`unit-test-server-http` + `unit-test-server-dispatch` green; `line-check` ok.

Follow-up (separate): the underlying user issue is cloning a private repo with no vaulted credential — now the UI will show the real "could not read Username" instead of a vault red herring.