### PR TITLE
fix(webchat-git): clone/editor use aimee-server's own git credential (no per-user PAT)

### DIFF
--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -73,9 +73,16 @@ oom:
 char **git_cred_inject_build_env(const char *principal, char *const *parent_environ)
 {
    char token[GIT_CRED_TOKEN_MAX];
-   /* Autonomous server-wrap read: works for background / code-server git ops
-    * after the user's session KEK has expired. 1 = token, 0 = none. */
+   /* Autonomous server-wrap read of the webuser's OWN vaulted forge token (an
+    * optional personal override). 1 = token, 0 = none. */
    int have_token = (git_forge_vault_token(principal, token, sizeof(token)) == 1);
+
+   /* Default for a personal-agent server: when the user has no personal token,
+    * use aimee-server's OWN configured git identity (a GitHub App installation
+    * token or AIMEE_FORGE_TOKEN). The clone/editor then authenticates with the
+    * server's credential, so a webchat user never has to store a PAT. */
+   if (!have_token)
+      have_token = (forge_cred_server_identity(token, sizeof(token), NULL, 0) == 1);
 
    /* Start (or reuse) the user's in-memory ssh-agent if they have a vaulted SSH
     * key (WP-C2); the key never touches disk. 1 = sock ready. */


### PR DESCRIPTION
## A webchat user should not have to store a PAT to clone a private repo

The git operations run **on aimee-server**, so they should use **aimee-server's own** git identity. But `git_cred_inject_build_env` only ever read the **per-webuser vaulted forge token**. With an empty user vault, every private clone failed auth (`could not read Username`), and the only "fix" was a per-user PAT flow that has **no UI** and needs a **vault unlock** — exactly the wrong model for a personal-agent server.

## Fix
When the user has no personal vaulted token, fall back to **`forge_cred_server_identity()`** — aimee-server's configured git credential (a **GitHub App** installation token, or **`AIMEE_FORGE_TOKEN`**). The per-webuser vaulted token stays an optional personal override.

Result: configure the owner's git credential **once on aimee-server** (`AIMEE_FORGE_TOKEN=...` or the GitHub App env), and **all** webchat clones + the editor's integrated git authenticate with the server's credential — no PAT, no per-user vault, no unlock, no UI.

This also flows to the in-app editor's terminal git, since it uses the same env builder.

`unit-test-git-cred-inject` + `unit-test-webuser-editor` green; server links clean. (Companion to #481, which makes the *error message* legible when no credential is configured at all.)