### PR TITLE
fix(webchat): Workflows tab fills AppShell height (was showing only Validate/Save)

### DIFF
--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -538,7 +538,12 @@ export default function Workflows() {
       style={{
         display: "flex",
         gap: 12,
-        height: "calc(100vh - 90px)",
+        // Fill the AppShell content area (like the Projects page). The old
+        // calc(100vh - 90px) hard-coded an assumed header height; when it was
+        // wrong the flex row collapsed and the left rail + canvas clipped to
+        // nothing while only the toolbar buttons stayed visible.
+        height: "100%",
+        minHeight: 0,
         fontFamily: "system-ui",
       }}
     >


### PR DESCRIPTION
## Workflows tab showed only a greyed Validate + Save button and a blank area

Diagnosed by ruling everything else out on the deployed instance:
- An **authenticated** `/api/workflow/blocks` returns the **full block list** (200); `defs`/`personas` 200 too — the data was never missing.
- The deployed bundle was **current** (had the Editor tab + the full Workflows component).
- All the components (`Panel`/`Badge`/`Spinner`) are exported by the vendored smoothgui.

So it was purely **layout**. The Workflows root used `height: calc(100vh - 90px)`, hard-coding an assumed AppShell header height. When wrong, the flex row collapsed: the center toolbar's buttons stayed visible (overflow), but the left rail (`overflowY: auto`) and the SVG canvas clipped to nothing.

## Fix
Match the working **Projects** page: `height: 100%` + `minHeight: 0`, so the page fills the AppShell content area regardless of the header's real height.

Built the SPA and deployed it to `.254` to verify; this PR makes it durable (the image rebuilds the dist).