### PR TITLE
feat(webchat-git): git credential-management panel (list/add/remove host tokens)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3665,6 +3665,89 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /git/credentials:
+    get:
+      summary: List the git hosts that have a stored credential
+      description: >
+        The git hosts (github.com, gitea.*, ...) for which aimee-server holds an
+        access token. Single-user server: credentials are keyed by host, not by
+        user, and stored in the server vault. Tokens are NEVER returned — only the
+        host names. Identity is the attested `webuser:` principal. Capability:
+        tool:execute.
+      responses:
+        "200":
+          description: Configured hosts
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  hosts: { type: array, items: { type: string } }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+    post:
+      summary: Store (or replace) the git access token for a host
+      description: >
+        Persist `token` for `host` (a hostname or a full repo URL, reduced to its
+        host) in the server vault. Used by clones/ops on that host. Provider-
+        agnostic. Capability: tool:execute.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [host, token]
+              properties:
+                host: { type: string, description: Hostname (or a repo URL) }
+                token: { type: string, description: Access token (write-only) }
+      responses:
+        "200":
+          description: Stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { ok: { type: boolean } }
+        "400":
+          description: Missing host/token
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+    delete:
+      summary: Remove the stored git access token for a host
+      description: >
+        Delete the token aimee-server holds for `host`. Capability: tool:execute.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [host]
+              properties:
+                host: { type: string }
+      responses:
+        "200":
+          description: Removed (or absent)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { ok: { type: boolean } }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /runner/poll:
     post:
       summary: Poll for the next detached-workspace op to execute (reverse channel)

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -39,6 +39,17 @@ export default function Projects() {
   const [token, setToken] = useState('');
   const [commitMsg, setCommitMsg] = useState('');
   const [branch, setBranch] = useState('');
+  const [hosts, setHosts] = useState<string[]>([]);
+  const [credHost, setCredHost] = useState('');
+  const [credToken, setCredToken] = useState('');
+
+  const loadHosts = useCallback(async () => {
+    try {
+      const r = await api('/api/git/credentials', { method: 'GET' });
+      const d = await r.json();
+      if (r.ok) setHosts(d.hosts || []);
+    } catch { /* server unavailable — leave list empty */ }
+  }, []);
 
   const loadProjects = useCallback(async () => {
     setErr('');
@@ -54,7 +65,33 @@ export default function Projects() {
     }
   }, []);
 
-  useEffect(() => { loadProjects(); }, [loadProjects]);
+  useEffect(() => { loadProjects(); loadHosts(); }, [loadProjects, loadHosts]);
+
+  async function addCred() {
+    if (!credHost.trim() || !credToken.trim()) return;
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/credentials', {
+        method: 'POST',
+        body: JSON.stringify({ host: credHost.trim(), token: credToken.trim() }),
+      });
+      const d = await r.json();
+      if (!r.ok) { setErr(d.error || 'could not save credential'); }
+      else { setCredHost(''); setCredToken(''); await loadHosts(); }
+    } finally { setBusy(false); }
+  }
+
+  async function removeCred(host: string) {
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/credentials', {
+        method: 'DELETE',
+        body: JSON.stringify({ host }),
+      });
+      if (!r.ok) { const d = await r.json(); setErr(d.error || 'could not remove credential'); }
+      else { await loadHosts(); }
+    } finally { setBusy(false); }
+  }
 
   async function connect() {
     if (!url.trim()) return;
@@ -66,7 +103,7 @@ export default function Projects() {
       });
       const d = await r.json();
       if (!r.ok) { setErr(d.error || 'clone failed'); }
-      else { setUrl(''); setName(''); setToken(''); await loadProjects(); setSelected(d.name || ''); }
+      else { setUrl(''); setName(''); setToken(''); await loadProjects(); await loadHosts(); setSelected(d.name || ''); }
     } finally { setBusy(false); }
   }
 
@@ -99,6 +136,34 @@ export default function Projects() {
           <input style={{ ...input, width: '100%' }} type="password" autoComplete="off"
             placeholder="access token — only for a private repo (GitHub/Gitea/GitLab…); saved server-side per host"
             value={token} onChange={e => setToken(e.target.value)} />
+        </div>
+      </Panel>
+
+      <Panel title="Git accounts" count={hosts.length}>
+        <div style={{ padding: '12px', display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <div style={{ color: '#888', fontSize: '12px' }}>
+            Access tokens aimee-server uses to reach each git host (one per host, any provider). Tokens are stored server-side and never shown again.
+          </div>
+          {hosts.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+              {hosts.map(h => (
+                <div key={h} style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                  <span style={{ fontSize: '13px', fontFamily: 'monospace', flex: 1 }}>{h}</span>
+                  <span style={{ fontSize: '11px', color: '#2a7' }}>● token set</span>
+                  <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy}
+                    onClick={() => removeCred(h)}>remove</button>
+                </div>
+              ))}
+            </div>
+          )}
+          <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+            <input style={{ ...input, flex: 1, minWidth: '160px' }} placeholder="host (e.g. github.com, gitea.you.com)"
+              value={credHost} onChange={e => setCredHost(e.target.value)} />
+            <input style={{ ...input, flex: 2, minWidth: '200px' }} type="password" autoComplete="off"
+              placeholder="access token" value={credToken} onChange={e => setCredToken(e.target.value)} />
+            <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+              disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}>Save</button>
+          </div>
         </div>
       </Panel>
 

--- a/src/headers/git_host_cred.h
+++ b/src/headers/git_host_cred.h
@@ -29,6 +29,10 @@ int git_host_cred_for_url(const char *url, char *out, size_t out_len);
 /* Delete the stored token for `host`. Returns 0 (deleted or absent), -1 on error. */
 int git_host_cred_delete(const char *host);
 
+/* List the hosts that have a stored token into out[][GIT_HOST_MAX] (up to max).
+ * Tokens are NEVER returned — only the host names. Returns the count, or -1. */
+int git_host_cred_list(char out[][GIT_HOST_MAX], int max);
+
 /* Extract the lowercased host from any git URL form into `out`. Returns 1 on
  * success, 0 on failure. Exposed for the set-from-URL path + tests. */
 int git_host_from_url(const char *url, char *out, size_t out_len);

--- a/src/server/git_host_cred.c
+++ b/src/server/git_host_cred.c
@@ -2,7 +2,8 @@
 #include "git_host_cred.h"
 
 #include "util_url.h"      /* util_url_normalize */
-#include "vault_service.h" /* vault_service_set_server / get_server_wrap / delete */
+#include "vault_service.h" /* vault_service_set_server / get_server_wrap / delete / list */
+#include "vault_store.h"   /* vault_store_entry_t */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -116,4 +117,27 @@ int git_host_cred_delete(const char *host)
       return -1;
    vault_status_t st = vault_service_delete(VAULT_SERVER_PRINCIPAL, GIT_HOST_AGENT, key);
    return (st == VAULT_OK || st == VAULT_NO_ENTRY) ? 0 : -1;
+}
+
+int git_host_cred_list(char out[][GIT_HOST_MAX], int max)
+{
+   if (!out || max <= 0)
+      return -1;
+   vault_store_entry_t entries[64];
+   int count = 0;
+   if (vault_service_list(VAULT_SERVER_PRINCIPAL, entries,
+                          (int)(sizeof(entries) / sizeof(entries[0])), &count) != VAULT_OK)
+      return -1;
+   size_t plen = strlen(GIT_HOST_CRED_PREFIX);
+   int n = 0;
+   for (int i = 0; i < count && n < max; i++)
+   {
+      if (strcmp(entries[i].agent, GIT_HOST_AGENT) != 0 ||
+          strncmp(entries[i].cred, GIT_HOST_CRED_PREFIX, plen) != 0)
+         continue;
+      const char *host = entries[i].cred + plen;
+      if (host[0])
+         snprintf(out[n++], GIT_HOST_MAX, "%s", host);
+   }
+   return n;
 }

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -17,6 +17,7 @@
 
 /* Route-handler deps used below but not needed by server_http.c's own body
  * (kept here, not in server_http.c, to respect its 2000-line limit). */
+#include "git_host_cred.h"  /* per-host git credential store for /v1/git/credentials */
 #include "git_ops.h"        /* git_ops_run for /v1/workspace/git (WP-E) */
 #include "git_project.h"    /* git_project_clone for /v1/workspace/clone (WP-D) */
 #include "webuser_editor.h" /* webuser_editor_ensure for /v1/workspace/editor (WP-I) */
@@ -971,6 +972,74 @@ static int rh_workspace_editor(const route_req_t *rq, char *resp, int cap)
    return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
 }
 
+/* Per-host git credentials (single-user server, many providers). The calling
+ * webchat user manages aimee-server's OWN stored tokens (one per host); the
+ * secret is write-only over the API — listing returns host names only, never
+ * tokens. Identity is the attested X-Aimee-Webuser principal. */
+static int rh_git_credentials(const route_req_t *rq, char *resp, int cap)
+{
+   const char *principal = server_http_identity_principal();
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return err_json(resp, cap, 403, "git credentials require a webchat user");
+
+   /* GET → list configured hosts (no tokens). */
+   if (strcmp(rq->method, "GET") == 0)
+   {
+      char hosts[64][GIT_HOST_MAX];
+      int count = git_host_cred_list(hosts, 64);
+      if (count < 0)
+         count = 0;
+      cJSON *out = cJSON_CreateObject();
+      cJSON *arr = cJSON_AddArrayToObject(out, "hosts");
+      for (int i = 0; i < count; i++)
+         cJSON_AddItemToArray(arr, cJSON_CreateString(hosts[i]));
+      char *s = cJSON_PrintUnformatted(out);
+      int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
+      free(s);
+      cJSON_Delete(out);
+      return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
+   }
+
+   cJSON *body = (rq->body && rq->body[0]) ? cJSON_Parse(rq->body) : NULL;
+   if (!body || !cJSON_IsObject(body))
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400, "invalid JSON body");
+   }
+   const cJSON *jhost = cJSON_GetObjectItemCaseSensitive(body, "host");
+   const cJSON *jtoken = cJSON_GetObjectItemCaseSensitive(body, "token");
+   const char *host = (cJSON_IsString(jhost) && jhost->valuestring) ? jhost->valuestring : NULL;
+   const char *token = (cJSON_IsString(jtoken) && jtoken->valuestring) ? jtoken->valuestring : NULL;
+   /* Accept a full URL in `host` too (convenience) → reduce to its host. */
+   char hostbuf[GIT_HOST_MAX];
+   if (host && strstr(host, "://") && git_host_from_url(host, hostbuf, sizeof(hostbuf)))
+      host = hostbuf;
+   if (!host || !host[0])
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400, "host required");
+   }
+
+   int rc;
+   if (strcmp(rq->method, "DELETE") == 0)
+      rc = git_host_cred_delete(host);
+   else /* POST → set */
+   {
+      if (!token || !token[0])
+      {
+         cJSON_Delete(body);
+         return err_json(resp, cap, 400, "token required");
+      }
+      rc = git_host_cred_set(host, token);
+   }
+   cJSON_Delete(body);
+   if (rc != 0)
+      return err_json(resp, cap, 500, "credential store failed");
+   return snprintf(resp, (size_t)cap, "{\"ok\":true}") < cap
+              ? 200
+              : err_json(resp, cap, 500, "too large");
+}
+
 /* ── detached-runner reverse channel over /v1 (workspace-resource-plane §3) ──
  * The filesystem-authority client serving a `detached` workspace polls for the
  * next op the server needs done against its working tree, executes it locally,
@@ -1444,6 +1513,9 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/workspace/git", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_git},
     {"GET", "/v1/workspace/projects", NULL, RM_EXACT, NULL, CAP_INDEX_READ, rh_workspace_projects},
     {"POST", "/v1/workspace/editor", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_editor},
+    {"GET", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},
+    {"POST", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},
+    {"DELETE", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},
     {"POST", "/v1/workspaces/", "/forge-token", RM_PREFIX, NULL, CAP_TOOL_EXECUTE,
      rh_workspace_forge_token},
     {"GET", "/v1/workspaces/", NULL, RM_PREFIX, "workspace.get", 0, rh_workspace_get},

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -4,6 +4,7 @@
  * only HTTP parsing / routing, not the real git-clone or indexer subsystems.
  * Binaries that need the real behavior (unit-test-git-project) link the real
  * objects and must NOT also link this TU. */
+#include "git_host_cred.h"
 #include "git_ops.h"
 #include "git_project.h"
 #include "index.h"
@@ -67,4 +68,32 @@ int webuser_editor_ensure(const char *principal, int *out_port, char *err, size_
    if (err && errlen)
       err[0] = '\0';
    return 0; /* feature unavailable in the stub */
+}
+
+int git_host_cred_set(const char *host, const char *token)
+{
+   (void)host;
+   (void)token;
+   return -1;
+}
+
+int git_host_cred_delete(const char *host)
+{
+   (void)host;
+   return -1;
+}
+
+int git_host_cred_list(char out[][GIT_HOST_MAX], int max)
+{
+   (void)out;
+   (void)max;
+   return 0;
+}
+
+int git_host_from_url(const char *url, char *out, size_t out_len)
+{
+   (void)url;
+   if (out && out_len)
+      out[0] = '\0';
+   return 0;
 }

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -30,12 +30,41 @@ func (s *server) gitRelay(w http.ResponseWriter, st int, data []byte, err error)
 		Name     string   `json:"name"`
 		Output   string   `json:"output"`
 		Projects []string `json:"projects"`
+		Hosts    []string `json:"hosts"`
 	}
 	_ = json.Unmarshal(data, &up)
 	out, _ := json.Marshal(map[string]any{
-		"ok": true, "name": up.Name, "output": up.Output, "projects": up.Projects,
+		"ok": true, "name": up.Name, "output": up.Output, "projects": up.Projects, "hosts": up.Hosts,
 	})
 	w.Write(out)
+}
+
+// /api/git/credentials — manage aimee-server's per-host git access tokens
+// (GET list hosts, POST {host, token} set, DELETE {host} remove). Tokens are
+// write-only: listing returns host names only, never secrets.
+func (s *server) handleGitCredentials(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	user := currentUser(r)
+	switch r.Method {
+	case http.MethodGet:
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodGet, "/v1/git/credentials", nil)
+		s.gitRelay(w, st, data, err)
+	case http.MethodPost, http.MethodDelete:
+		var req struct {
+			Host  string `json:"host"`
+			Token string `json:"token"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Host == "" {
+			writeJSONError(w, http.StatusBadRequest, "host required")
+			return
+		}
+		body, _ := json.Marshal(map[string]string{"host": req.Host, "token": req.Token})
+		st, data, err := s.v1RequestWebuser(ctx, user, r.Method, "/v1/git/credentials", body)
+		s.gitRelay(w, st, data, err)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
 }
 
 // GET /api/git/projects — list the user's cloned projects.

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -186,6 +186,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/git/projects", s.requireAuth(s.handleGitProjects))
 	mux.HandleFunc("/api/git/clone", s.requireAuth(s.handleGitClone))
 	mux.HandleFunc("/api/git/op", s.requireAuth(s.handleGitOp))
+	mux.HandleFunc("/api/git/credentials", s.requireAuth(s.handleGitCredentials))
 
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))


### PR DESCRIPTION
Makes the per-host git credentials (#486) visible + manageable from the UI — the first of the two follow-ups.

- **`git_host_cred_list()`** — enumerate hosts that have a stored token (`vault_service_list` under the server principal, filtered to agent `git` + the `host:` prefix). Returns **host names only**, never tokens.
- **`/v1/git/credentials`** — `GET` (list hosts) / `POST {host,token}` (set; accepts a full URL and reduces it to its host) / `DELETE {host}` (remove). Webuser-gated, `tool:execute`; documented in OpenAPI (conformance green).
- **webchat `/api/git/credentials`** relay (GET/POST/DELETE).
- **Projects → "Git accounts" panel**: lists configured hosts with a remove button + a host/token add form. Tokens are write-only (never returned or shown).

So you can pre-add a token for any host (not just inline on clone), see what's configured, and revoke one.

Local: server links clean; `server-api-conformance-check`, `line-check`, `unit-test-server-http`/`dispatch`, `go test ./webchat/...` green; frontend builds.

Next PR: GitHub OAuth device-flow sign-in.