### PR TITLE
Promote testing → main: configure GitHub sign-in from UI

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3799,6 +3799,61 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /git/oauth/github/config:
+    get:
+      summary: Read the configured GitHub OAuth App client ID
+      description: >
+        Whether a GitHub OAuth App client ID is configured (set from the UI or the
+        AIMEE_GITHUB_OAUTH_CLIENT_ID env), and the value (public). Capability:
+        tool:execute.
+      responses:
+        "200":
+          description: Config
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  configured: { type: boolean }
+                  client_id: { type: string }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+    post:
+      summary: Set the GitHub OAuth App client ID
+      description: >
+        Persist the client ID server-side so the "Sign in with GitHub" button
+        works without an env var. The client ID is public (device flow needs no
+        secret). Capability: tool:execute.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [client_id]
+              properties:
+                client_id: { type: string }
+      responses:
+        "200":
+          description: Stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { ok: { type: boolean } }
+        "400":
+          description: Missing client_id
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /runner/poll:
     post:
       summary: Poll for the next detached-workspace op to execute (reverse channel)

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -44,6 +44,29 @@ export default function Projects() {
   const [credToken, setCredToken] = useState('');
   const [ghCode, setGhCode] = useState('');
   const [ghUri, setGhUri] = useState('');
+  const [ghConfigured, setGhConfigured] = useState(false);
+  const [ghClientId, setGhClientId] = useState('');
+
+  const loadGhConfig = useCallback(async () => {
+    try {
+      const r = await api('/api/git/oauth/github/config', { method: 'GET' });
+      const d = await r.json();
+      if (r.ok) { setGhConfigured(!!d.configured); setGhClientId(d.client_id || ''); }
+    } catch { /* leave unconfigured */ }
+  }, []);
+
+  async function saveGhConfig() {
+    if (!ghClientId.trim()) return;
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/oauth/github/config', {
+        method: 'POST', body: JSON.stringify({ client_id: ghClientId.trim() }),
+      });
+      const d = await r.json();
+      if (!r.ok) setErr(d.error || 'could not save client ID');
+      else await loadGhConfig();
+    } finally { setBusy(false); }
+  }
 
   const loadHosts = useCallback(async () => {
     try {
@@ -67,7 +90,7 @@ export default function Projects() {
     }
   }, []);
 
-  useEffect(() => { loadProjects(); loadHosts(); }, [loadProjects, loadHosts]);
+  useEffect(() => { loadProjects(); loadHosts(); loadGhConfig(); }, [loadProjects, loadHosts, loadGhConfig]);
 
   // GitHub device-flow: once a user code is shown, poll until the user authorizes.
   useEffect(() => {
@@ -173,8 +196,8 @@ export default function Projects() {
             Access tokens aimee-server uses to reach each git host (one per host, any provider). Tokens are stored server-side and never shown again.
           </div>
           <div style={{ display: 'flex', alignItems: 'center', gap: '10px', flexWrap: 'wrap' }}>
-            <button style={{ ...btn, background: '#24292e', color: '#fff', borderColor: '#24292e' }}
-              disabled={busy || !!ghCode} onClick={startGithub}>Sign in with GitHub</button>
+            <button style={{ ...btn, background: ghConfigured ? '#24292e' : '#888', color: '#fff', borderColor: '#24292e' }}
+              disabled={busy || !!ghCode || !ghConfigured} onClick={startGithub}>Sign in with GitHub</button>
             {ghCode && (
               <span style={{ fontSize: '13px', color: '#444' }}>
                 Go to <a href={ghUri} target="_blank" rel="noreferrer">{ghUri}</a> and enter code{' '}
@@ -183,6 +206,21 @@ export default function Projects() {
               </span>
             )}
           </div>
+          <details style={{ fontSize: '12px', color: '#666' }} open={!ghConfigured}>
+            <summary style={{ cursor: 'pointer' }}>
+              GitHub OAuth App {ghConfigured ? '(configured ✓ — click to change)' : '— set this to enable the button'}
+            </summary>
+            <div style={{ marginTop: '6px' }}>
+              <div style={{ marginBottom: '4px' }}>
+                Create a GitHub OAuth App (<a href="https://github.com/settings/developers" target="_blank" rel="noreferrer">github.com/settings/developers</a> → New OAuth App → enable <b>Device flow</b>), then paste its <b>Client ID</b> here:
+              </div>
+              <div style={{ display: 'flex', gap: '8px', flexWrap: 'wrap', alignItems: 'center' }}>
+                <input style={{ ...input, flex: 1, minWidth: '200px' }} placeholder="GitHub OAuth App Client ID (e.g. Iv1.xxxxxxxx)"
+                  value={ghClientId} onChange={e => setGhClientId(e.target.value)} />
+                <button style={btn} disabled={busy || !ghClientId.trim()} onClick={saveGhConfig}>Save</button>
+              </div>
+            </div>
+          </details>
           {hosts.length > 0 && (
             <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
               {hosts.map(h => (

--- a/src/headers/git_oauth_github.h
+++ b/src/headers/git_oauth_github.h
@@ -10,8 +10,16 @@
  * no secret needed for device flow). Other providers (Gitea/GitLab/...) use the
  * token field instead. */
 
-/* 1 iff AIMEE_GITHUB_OAUTH_CLIENT_ID is configured (the flow is usable). */
+/* 1 iff a client ID is configured (stored from the UI, or the env) — flow usable. */
 int git_oauth_github_available(void);
+
+/* Store the GitHub OAuth App client ID (set from the web UI; persisted in the
+ * server vault). Returns 0 on success, -1 on error. The client ID is public. */
+int git_oauth_github_set_client_id(const char *client_id);
+
+/* Read the configured client ID into out (the stored value, else the env).
+ * Returns 1 (found) or 0 (none). */
+int git_oauth_github_get_client_id(char *out, size_t out_len);
 
 /* Begin device flow: request a user code. On success returns 0 and fills
  * user_code (shown to the user) + verify_uri (where they enter it) + *interval

--- a/src/server/git_oauth_github.c
+++ b/src/server/git_oauth_github.c
@@ -5,6 +5,7 @@
 #include "agent_exec.h" /* agent_http_post_content_type */
 #include "cJSON.h"
 #include "git_host_cred.h" /* git_host_cred_set */
+#include "vault_service.h" /* store the client_id server-side (set from the UI) */
 
 #include <pthread.h>
 #include <stdio.h>
@@ -22,15 +23,50 @@ static pthread_mutex_t g_lock = PTHREAD_MUTEX_INITIALIZER;
 static char g_device_code[256];
 static char g_principal[256];
 
-static const char *client_id(void)
+#define GH_CLIENT_ID_AGENT "git"
+#define GH_CLIENT_ID_CRED  "github_oauth_client_id"
+
+/* Resolve the GitHub OAuth App client_id: a value set from the UI (stored in the
+ * server vault) takes precedence, else the AIMEE_GITHUB_OAUTH_CLIENT_ID env. The
+ * client_id is public (device flow needs no secret). Returns 1 + fills buf, or 0. */
+static int get_client_id(char *buf, size_t cap)
 {
-   const char *id = getenv("AIMEE_GITHUB_OAUTH_CLIENT_ID");
-   return (id && id[0]) ? id : NULL;
+   if (buf && cap)
+      buf[0] = '\0';
+   if (!buf || cap == 0)
+      return 0;
+   if (vault_service_get_server_wrap(VAULT_SERVER_PRINCIPAL, GH_CLIENT_ID_AGENT, GH_CLIENT_ID_CRED,
+                                     buf, cap) == VAULT_OK &&
+       buf[0])
+      return 1;
+   const char *env = getenv("AIMEE_GITHUB_OAUTH_CLIENT_ID");
+   if (env && env[0])
+   {
+      snprintf(buf, cap, "%s", env);
+      return 1;
+   }
+   buf[0] = '\0';
+   return 0;
 }
 
 int git_oauth_github_available(void)
 {
-   return client_id() != NULL;
+   char id[256];
+   return get_client_id(id, sizeof(id));
+}
+
+int git_oauth_github_set_client_id(const char *client_id)
+{
+   if (!client_id || !client_id[0])
+      return -1;
+   return vault_service_set_server(GH_CLIENT_ID_AGENT, GH_CLIENT_ID_CRED, client_id) == VAULT_OK
+              ? 0
+              : -1;
+}
+
+int git_oauth_github_get_client_id(char *out, size_t out_len)
+{
+   return get_client_id(out, out_len);
 }
 
 int git_oauth_github_start(const char *principal, char *user_code, size_t uc_len, char *verify_uri,
@@ -40,10 +76,10 @@ int git_oauth_github_start(const char *principal, char *user_code, size_t uc_len
       user_code[0] = '\0';
    if (verify_uri && vu_len)
       verify_uri[0] = '\0';
-   const char *cid = client_id();
-   if (!cid)
+   char cid[256];
+   if (!get_client_id(cid, sizeof(cid)))
    {
-      snprintf(err, errlen, "GitHub sign-in is not configured (set AIMEE_GITHUB_OAUTH_CLIENT_ID)");
+      snprintf(err, errlen, "GitHub sign-in is not configured (set a client ID)");
       return -1;
    }
    char body[512];
@@ -90,8 +126,8 @@ int git_oauth_github_start(const char *principal, char *user_code, size_t uc_len
 
 int git_oauth_github_poll(const char *principal, char *err, size_t errlen)
 {
-   const char *cid = client_id();
-   if (!cid)
+   char cid[256];
+   if (!get_client_id(cid, sizeof(cid)))
    {
       snprintf(err, errlen, "GitHub sign-in is not configured");
       return -1;

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1092,6 +1092,42 @@ static int rh_git_oauth_github_poll(const route_req_t *rq, char *resp, int cap)
    return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
 }
 
+/* GET/POST /v1/git/oauth/github/config — read or set the GitHub OAuth App client
+ * ID from the UI (public; persisted server-side), so the "Sign in with GitHub"
+ * button can be configured without touching env vars. */
+static int rh_git_oauth_github_config(const route_req_t *rq, char *resp, int cap)
+{
+   const char *principal = server_http_identity_principal();
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return err_json(resp, cap, 403, "git sign-in requires a webchat user");
+
+   if (strcmp(rq->method, "POST") == 0)
+   {
+      cJSON *body = (rq->body && rq->body[0]) ? cJSON_Parse(rq->body) : NULL;
+      const cJSON *jid = body ? cJSON_GetObjectItemCaseSensitive(body, "client_id") : NULL;
+      const char *id = (cJSON_IsString(jid) && jid->valuestring) ? jid->valuestring : NULL;
+      int rc = (id && id[0]) ? git_oauth_github_set_client_id(id) : -1;
+      cJSON_Delete(body);
+      if (rc != 0)
+         return err_json(resp, cap, 400, "client_id required");
+      return snprintf(resp, (size_t)cap, "{\"ok\":true}") < cap
+                 ? 200
+                 : err_json(resp, cap, 500, "too large");
+   }
+
+   /* GET → report whether configured (the client ID is public, so return it). */
+   char id[256];
+   int have = git_oauth_github_get_client_id(id, sizeof(id));
+   cJSON *out = cJSON_CreateObject();
+   cJSON_AddBoolToObject(out, "configured", have);
+   cJSON_AddStringToObject(out, "client_id", have ? id : "");
+   char *s = cJSON_PrintUnformatted(out);
+   int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
+   free(s);
+   cJSON_Delete(out);
+   return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
+}
+
 /* ── detached-runner reverse channel over /v1 (workspace-resource-plane §3) ──
  * The filesystem-authority client serving a `detached` workspace polls for the
  * next op the server needs done against its working tree, executes it locally,
@@ -1572,6 +1608,10 @@ static const http_route_t g_v1_routes[] = {
      rh_git_oauth_github_start},
     {"POST", "/v1/git/oauth/github/poll", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,
      rh_git_oauth_github_poll},
+    {"GET", "/v1/git/oauth/github/config", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,
+     rh_git_oauth_github_config},
+    {"POST", "/v1/git/oauth/github/config", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,
+     rh_git_oauth_github_config},
     {"POST", "/v1/workspaces/", "/forge-token", RM_PREFIX, NULL, CAP_TOOL_EXECUTE,
      rh_workspace_forge_token},
     {"GET", "/v1/workspaces/", NULL, RM_PREFIX, "workspace.get", 0, rh_workspace_get},

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -125,3 +125,16 @@ int git_oauth_github_poll(const char *principal, char *err, size_t errlen)
       err[0] = '\0';
    return -1;
 }
+
+int git_oauth_github_set_client_id(const char *client_id)
+{
+   (void)client_id;
+   return -1;
+}
+
+int git_oauth_github_get_client_id(char *out, size_t out_len)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   return 0;
+}

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -58,13 +58,42 @@ func (s *server) gitOAuthRelay(w http.ResponseWriter, st int, data []byte, err e
 		Interval        int    `json:"interval"`
 		Status          string `json:"status"`
 		Error           string `json:"error"`
+		Configured      bool   `json:"configured"`
+		ClientID        string `json:"client_id"`
 	}
 	_ = json.Unmarshal(data, &up)
 	out, _ := json.Marshal(map[string]any{
 		"ok": true, "user_code": up.UserCode, "verification_uri": up.VerificationURI,
 		"interval": up.Interval, "status": up.Status, "error": up.Error,
+		"configured": up.Configured, "client_id": up.ClientID,
 	})
 	w.Write(out)
+}
+
+// /api/git/oauth/github/config — read (GET) or set (POST {client_id}) the GitHub
+// OAuth App client ID so "Sign in with GitHub" can be configured from the UI.
+func (s *server) handleGitOauthGithubConfig(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	user := currentUser(r)
+	switch r.Method {
+	case http.MethodGet:
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodGet, "/v1/git/oauth/github/config", nil)
+		s.gitOAuthRelay(w, st, data, err)
+	case http.MethodPost:
+		var req struct {
+			ClientID string `json:"client_id"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.ClientID == "" {
+			writeJSONError(w, http.StatusBadRequest, "client_id required")
+			return
+		}
+		body, _ := json.Marshal(map[string]string{"client_id": req.ClientID})
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/git/oauth/github/config", body)
+		s.gitOAuthRelay(w, st, data, err)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
 }
 
 // POST /api/git/oauth/github/start — begin GitHub device-flow sign-in.

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -189,6 +189,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/git/credentials", s.requireAuth(s.handleGitCredentials))
 	mux.HandleFunc("/api/git/oauth/github/start", s.requireAuth(s.handleGitOauthGithubStart))
 	mux.HandleFunc("/api/git/oauth/github/poll", s.requireAuth(s.handleGitOauthGithubPoll))
+	mux.HandleFunc("/api/git/oauth/github/config", s.requireAuth(s.handleGitOauthGithubConfig))
 
 	// Live endpoints backed by aimee-server socket
 	mux.HandleFunc("/api/agents", s.requireAuth(s.handleAgents))


### PR DESCRIPTION
Promotes the in-UI GitHub OAuth client-id config (#489) to main.