### PR TITLE
fix(combined): bake LLM_MODEL into the combined image

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -153,6 +153,14 @@ ENV AIMEE_KB_HTTP_BIND=1
 ENV AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared
 ENV AIMEE_EMBEDDER_URL=http://embedder:8080
 ENV LLM_ENDPOINT=http://llm:8080/v1
+# Symmetric with LLM_ENDPOINT: the bundled curator LLM (Gemma E4B) also needs a
+# model name. The curator code-extract stage shells out to curator-extract.py ->
+# llm-chat.py, which hard-requires $LLM_MODEL; a non-configurable plugin instance
+# takes its env from this image (not from compose), so without this the extract
+# stage fails on every job and the curator never drains. llama.cpp serves the
+# loaded GGUF regardless of this value; configurable / BYO deploys override it.
+# Kept in sync with compose.combined.yaml's default.
+ENV LLM_MODEL=gemma-3n-e4b
 # Mirror tier (workspace-resource-plane §3): durable bare mirrors + worktrees on
 # a dedicated volume, matching Dockerfile.server.
 ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces


### PR DESCRIPTION
## Problem
`Dockerfile.combined` bakes `ENV LLM_ENDPOINT=http://llm:8080/v1` but never sets `LLM_MODEL`. The `aimee-combined` plugin instance is **non-configurable**, so the `server-kb` container takes its curator env from the image (not from compose, where `LLM_MODEL` is set). The curator code-extract stage shells out to `curator-extract.py` → `llm-chat.py`, which **hard-requires `$LLM_MODEL`** and exits non-zero without it.

Result observed live on the combined deployment: every extract job failed (`sidecar exited 256`), the code-unit backlog never drained, and the curator was effectively stalled — even though the bundled Gemma E4B endpoint was healthy and serving. Supplying `LLM_MODEL` immediately unblocked it (extracts started writing artifacts, `code_unit_done` began climbing).

This recurs on **every `server-kb` recreate** (e.g. an image update), since the image is the env source for the non-configurable instance.

## Fix
Bake `ENV LLM_MODEL=gemma-3n-e4b` next to `LLM_ENDPOINT`, matching `compose.combined.yaml`'s default. llama.cpp serves the loaded GGUF regardless of this value, and configurable / BYO deployments still override it via the plugin's `LLM_MODEL` key.

## Out of scope (different repo)
The companion gap — the `curator-llm` service needs the `llm` network alias (on the live deploy it resolves only as `aimee-curator-llm`) — lives in the smoothnas plugin packaging, not here. Noted so it can be fixed there.
