### PR TITLE
Promote testing → main: SPA no-cache headers

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -153,6 +153,14 @@ ENV AIMEE_KB_HTTP_BIND=1
 ENV AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared
 ENV AIMEE_EMBEDDER_URL=http://embedder:8080
 ENV LLM_ENDPOINT=http://llm:8080/v1
+# Symmetric with LLM_ENDPOINT: the bundled curator LLM (Gemma E4B) also needs a
+# model name. The curator code-extract stage shells out to curator-extract.py ->
+# llm-chat.py, which hard-requires $LLM_MODEL; a non-configurable plugin instance
+# takes its env from this image (not from compose), so without this the extract
+# stage fails on every job and the curator never drains. llama.cpp serves the
+# loaded GGUF regardless of this value; configurable / BYO deploys override it.
+# Kept in sync with compose.combined.yaml's default.
+ENV LLM_MODEL=gemma-3n-e4b
 # Mirror tier (workspace-resource-plane §3): durable bare mirrors + worktrees on
 # a dedicated volume, matching Dockerfile.server.
 ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces

--- a/webchat/pages.go
+++ b/webchat/pages.go
@@ -125,9 +125,16 @@ func (s *server) handleLogout(w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, "/login", http.StatusFound)
 }
 
-// handleSPA serves the React SPA for /chat and /dashboard.
+// handleSPA serves the React SPA. The dist is a single inlined index.html (all
+// JS/CSS embedded), so the browser caches THIS document — and without no-cache it
+// kept serving a stale bundle after a deploy (e.g. a fixed page still looked
+// broken until the cache was manually cleared). Force revalidation so a redeploy
+// is always picked up on the next navigation.
 func (s *server) handleSPA(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "no-cache, no-store, must-revalidate")
+	w.Header().Set("Pragma", "no-cache")
+	w.Header().Set("Expires", "0")
 	w.Write(spaHTML)
 }
 
@@ -204,4 +211,3 @@ func splitCookieParts(s string) []string {
 	}
 	return parts
 }
-


### PR DESCRIPTION
Promotes #490 (SPA no-cache) to main.