### PR TITLE
fix(webchat): Workflows page collapsed its side rails (flexbox min-width)

### DIFF
--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -551,6 +551,7 @@ export default function Workflows() {
       <div
         style={{
           width: 230,
+          flexShrink: 0,
           overflowY: "auto",
           display: "flex",
           flexDirection: "column",
@@ -642,8 +643,11 @@ export default function Workflows() {
         </Panel>
       </div>
 
-      {/* center: canvas */}
-      <div style={{ flex: 1, display: "flex", flexDirection: "column" }}>
+      {/* center: canvas. minWidth:0 lets this flex item shrink below the 1600px
+          SVG canvas's intrinsic width (the canvas scrolls inside its overflow
+          box); without it the center refused to shrink and squeezed the side
+          rails to zero width — the page looked like just the canvas + buttons. */}
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
         <div
           style={{
             display: "flex",
@@ -793,7 +797,7 @@ export default function Workflows() {
       </div>
 
       {/* right: inspector */}
-      <div style={{ width: 270, overflowY: "auto" }}>
+      <div style={{ width: 270, flexShrink: 0, overflowY: "auto" }}>
         <Panel title={sel ? `Node · ${sel.id}` : "Inspector"}>
           {!sel && (
             <div style={{ color: "#888", fontSize: 13 }}>


### PR DESCRIPTION
The Workflows page is a flex row: left rail (defs/blocks/runs/personas, 230px) · center canvas · right inspector (270px). The center holds an `<svg width={1600}>` canvas. Default flex items have `min-width: auto` (= min-content), so the center refused to shrink below 1600px and **squeezed both side rails to width 0** — the page rendered as just "no workflow open / Validate / Save" + a blank canvas, with the rails present in the DOM but zero-width.

**Root-caused with a headless browser against the live backend** (screenshot + computed styles): children widths were `0 / 1602 / 0`.

Fix: `minWidth: 0` on the center (so it shrinks and the canvas scrolls in its overflow box) + `flexShrink: 0` on the two fixed-width rails. After the fix the rails render at **230 / 588 / 270** and the full page shows (left rail with 11 blocks + 8 personas, center, inspector).

(My earlier #483 change adjusted *height*; the real problem was *width* — apologies for the mis-diagnosis.)
