### PR TITLE
feat(webchat): top navigation bar + remove Chat's internal tabs (1/4)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,7 @@
 import { Component, useEffect, useState } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
-import { Routes, Route, Navigate, useLocation } from 'react-router-dom';
-import { AppShell, Toast } from '@rakuensoftware/smoothgui';
-import type { NavItem } from '@rakuensoftware/smoothgui';
+import { Routes, Route, Navigate, NavLink, useLocation } from 'react-router-dom';
+import { Toast } from '@rakuensoftware/smoothgui';
 import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
@@ -56,12 +55,13 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
   }
 }
 
-const NAV_ITEMS: NavItem[] = [
-  { label: 'Chat', icon: '💬', route: '/chat', section: 'Main' },
-  { label: 'Dashboard', icon: '📊', route: '/dashboard', section: 'Main' },
-  { label: 'Workflows', icon: '🔀', route: '/workflows', section: 'Main' },
-  { label: 'Projects', icon: '📁', route: '/projects', section: 'Main' },
-  { label: 'Editor', icon: '🖥️', route: '/editor', section: 'Main' },
+type Tab = { label: string; icon: string; route: string };
+const NAV_ITEMS: Tab[] = [
+  { label: 'Chat', icon: '💬', route: '/chat' },
+  { label: 'Dashboard', icon: '📊', route: '/dashboard' },
+  { label: 'Workflows', icon: '🔀', route: '/workflows' },
+  { label: 'Projects', icon: '📁', route: '/projects' },
+  { label: 'Editor', icon: '🖥️', route: '/editor' },
 ];
 
 function LogoutButton() {
@@ -123,23 +123,47 @@ export default function App() {
 
   return (
     <>
-      <AppShell
-        appName="aimee"
-        appNameShort="ai"
-        navItems={NAV_ITEMS}
-        topBarContent={<LogoutButton />}
-      >
-        <ErrorBoundary key={location.pathname}>
-          <Routes>
-            <Route path="/chat" element={<Chat />} />
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/workflows" element={<Workflows />} />
-            <Route path="/projects" element={<Projects />} />
-            <Route path="/editor" element={<Editor />} />
-            <Route path="*" element={<Navigate to="/chat" replace />} />
-          </Routes>
-        </ErrorBoundary>
-      </AppShell>
+      <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
+        {/* Top navigation: one tab per tool. */}
+        <header
+          style={{
+            display: 'flex', alignItems: 'stretch', height: '48px', flexShrink: 0,
+            background: '#13131f', borderBottom: '1px solid #2a2a3a', padding: '0 14px',
+          }}
+        >
+          <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18, alignSelf: 'center', marginRight: 22 }}>aimee</span>
+          <nav style={{ display: 'flex', gap: 2, flex: 1 }}>
+            {NAV_ITEMS.map(it => (
+              <NavLink
+                key={it.route}
+                to={it.route}
+                style={({ isActive }) => ({
+                  display: 'flex', alignItems: 'center', gap: 6, padding: '0 14px',
+                  fontSize: 14, textDecoration: 'none', borderBottom: '2px solid transparent',
+                  color: isActive ? '#8cf' : '#aab', borderBottomColor: isActive ? '#8cf' : 'transparent',
+                  fontWeight: isActive ? 600 : 400,
+                })}
+              >
+                <span aria-hidden>{it.icon}</span> {it.label}
+              </NavLink>
+            ))}
+          </nav>
+          <div style={{ alignSelf: 'center' }}><LogoutButton /></div>
+        </header>
+        {/* Content area: flex:1 + minHeight:0 so pages using height:100% resolve. */}
+        <main style={{ flex: 1, minHeight: 0, overflow: 'auto', background: '#fff' }}>
+          <ErrorBoundary key={location.pathname}>
+            <Routes>
+              <Route path="/chat" element={<Chat />} />
+              <Route path="/dashboard" element={<Dashboard />} />
+              <Route path="/workflows" element={<Workflows />} />
+              <Route path="/projects" element={<Projects />} />
+              <Route path="/editor" element={<Editor />} />
+              <Route path="*" element={<Navigate to="/chat" replace />} />
+            </Routes>
+          </ErrorBoundary>
+        </main>
+      </div>
       <Toast />
     </>
   );

--- a/frontend/src/components/ProjectPicker.tsx
+++ b/frontend/src/components/ProjectPicker.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useState } from 'react';
+
+/* ProjectPicker — a compact "select or clone a project" control embedded in each
+ * tool tab. Each tab passes its own storageKey so its selected project persists
+ * independently (per the per-tab project model). onChange fires with the selected
+ * project name and the user's workspace root (so the tab can act on it — the
+ * editor opens root/<project>, chat sets cwd to it, etc.). */
+
+export interface ProjectSelection {
+  project: string;
+  root: string;
+}
+
+async function api(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window._csrf || '', ...(init?.headers || {}) },
+  });
+}
+
+const input: React.CSSProperties = { padding: '5px 8px', borderRadius: 4, border: '1px solid #ccc', fontSize: 13 };
+const btn: React.CSSProperties = { padding: '5px 10px', borderRadius: 4, border: '1px solid #ccc', background: '#fff', color: '#444', cursor: 'pointer', fontSize: 13 };
+
+export default function ProjectPicker({ storageKey, onChange }: {
+  storageKey: string;
+  onChange: (sel: ProjectSelection | null) => void;
+}) {
+  const [projects, setProjects] = useState<string[]>([]);
+  const [root, setRoot] = useState('');
+  const [selected, setSelected] = useState<string>(() => localStorage.getItem(storageKey) || '');
+  const [cloneOpen, setCloneOpen] = useState(false);
+  const [url, setUrl] = useState('');
+  const [token, setToken] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState('');
+
+  const emit = useCallback((project: string, rootPath: string) => {
+    onChange(project && rootPath ? { project, root: rootPath } : null);
+  }, [onChange]);
+
+  const load = useCallback(async () => {
+    try {
+      const r = await api('/api/git/projects', { method: 'GET' });
+      const d = await r.json();
+      if (!r.ok) { setErr(d.error || 'failed to list projects'); return; }
+      const ps: string[] = d.projects || [];
+      setProjects(ps);
+      setRoot(d.root || '');
+      // keep the persisted selection if still present, else clear
+      setSelected(prev => {
+        const next = prev && ps.includes(prev) ? prev : '';
+        emit(next, d.root || '');
+        return next;
+      });
+    } catch { setErr('aimee-server unavailable'); }
+  }, [emit]);
+
+  useEffect(() => { load(); }, [load]);
+
+  function select(p: string) {
+    setSelected(p);
+    if (p) localStorage.setItem(storageKey, p); else localStorage.removeItem(storageKey);
+    emit(p, root);
+  }
+
+  async function clone() {
+    if (!url.trim()) return;
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/clone', {
+        method: 'POST',
+        body: JSON.stringify({ url: url.trim(), token: token.trim() || undefined }),
+      });
+      const d = await r.json();
+      if (!r.ok) { setErr(d.error || 'clone failed'); return; }
+      setUrl(''); setToken(''); setCloneOpen(false);
+      await load();
+      if (d.name) select(d.name);
+    } finally { setBusy(false); }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '8px 12px', background: '#f6f7f9', borderBottom: '1px solid #e3e6ea' }}>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        <span style={{ fontSize: 13, color: '#666' }}>Project:</span>
+        <select style={{ ...input, minWidth: 180 }} value={selected} onChange={e => select(e.target.value)}>
+          <option value="">— none —</option>
+          {projects.map(p => <option key={p} value={p}>{p}</option>)}
+        </select>
+        <button style={btn} onClick={() => setCloneOpen(o => !o)}>{cloneOpen ? 'Cancel' : '+ Clone repo'}</button>
+        {err && <span style={{ color: '#c62828', fontSize: 12 }}>{err}</span>}
+      </div>
+      {cloneOpen && (
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+          <input style={{ ...input, flex: 2, minWidth: 260 }} placeholder="git remote URL (https or ssh)"
+            value={url} onChange={e => setUrl(e.target.value)} />
+          <input style={{ ...input, flex: 1, minWidth: 160 }} type="password" autoComplete="off"
+            placeholder="access token (private repos)" value={token} onChange={e => setToken(e.target.value)} />
+          <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+            disabled={busy || !url.trim()} onClick={clone}>Clone</button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -251,18 +251,6 @@ function mergeServerSessions(local: TabData[], server: ServerSession[]): TabData
   return pristineDefault ? restored : [...local, ...restored];
 }
 
-// forgetServerSession removes a closed tab's session from the server so it does
-// not reappear on the next restore. Best-effort.
-function forgetServerSession(aimeeSid: string): void {
-  if (!aimeeSid) return;
-  try {
-    fetch(`/api/chat/session?sid=${encodeURIComponent(aimeeSid)}`, {
-      method: 'DELETE',
-      headers: { 'X-CSRF-Token': window._csrf || '' },
-    }).catch(() => {});
-  } catch { /* ignore */ }
-}
-
 function rulesBannerDismissedKey(root: string): string {
   return root ? `${RULES_BANNER_DISMISSED_KEY}:${root}` : RULES_BANNER_DISMISSED_KEY;
 }
@@ -329,66 +317,6 @@ interface QueuedChatSend {
 
 let msgIdCounter = 0;
 function nextId() { return ++msgIdCounter; }
-
-/* ---- Tab bar ---- */
-
-interface TabBarProps {
-  tabs: TabData[];
-  activeIdx: number;
-  onSwitch: (i: number) => void;
-  onNew: () => void;
-  onClose: (i: number) => void;
-}
-
-function TabBar({ tabs, activeIdx, onSwitch, onNew, onClose }: TabBarProps) {
-  return (
-    <div style={{
-      display: 'flex', background: tokens.borderLight, borderBottom: `1px solid ${tokens.borderMedium}`,
-      padding: '0 8px', alignItems: 'stretch', overflowX: 'auto', flexShrink: 0,
-    }}>
-      {tabs.map((t, i) => (
-        <div
-          key={i}
-          onClick={() => onSwitch(i)}
-          style={{
-            padding: '7px 14px', fontSize: '13px',
-            color: i === activeIdx ? tokens.primary : tokens.textSecondary,
-            cursor: 'pointer',
-            borderBottom: i === activeIdx ? `2px solid ${tokens.primary}` : '2px solid transparent',
-            background: i === activeIdx ? tokens.surface : 'transparent',
-            display: 'flex', alignItems: 'center', gap: '6px', whiteSpace: 'nowrap',
-          }}
-        >
-          <span style={{ maxWidth: '120px', overflow: 'hidden', textOverflow: 'ellipsis' }}>
-            {t.title}
-          </span>
-          {tabs.length > 1 && (
-            <span
-              onClick={e => { e.stopPropagation(); onClose(i); }}
-              style={{ fontSize: '11px', color: tokens.textPale, cursor: 'pointer', padding: '2px 4px', borderRadius: '3px' }}
-              onMouseOver={e => (e.currentTarget.style.color = tokens.danger)}
-              onMouseOut={e => (e.currentTarget.style.color = tokens.textPale)}
-            >
-              ×
-            </span>
-          )}
-        </div>
-      ))}
-      <button
-        onClick={onNew}
-        style={{
-          padding: '7px 12px', fontSize: '16px', color: tokens.textPale, cursor: 'pointer',
-          border: 'none', background: 'transparent', lineHeight: 1,
-        }}
-        onMouseOver={e => (e.currentTarget.style.color = tokens.primary)}
-        onMouseOut={e => (e.currentTarget.style.color = tokens.textPale)}
-        title="New tab"
-      >
-        +
-      </button>
-    </div>
-  );
-}
 
 /* ---- Thread Bar (conversation branching) ---- */
 
@@ -2025,56 +1953,6 @@ export default function Chat() {
     } catch { /* ignore */ }
   }
 
-  /* Tab operations */
-  function switchTab(i: number) {
-    if (i === activeIdx) return;
-    abortActiveSends();
-    saveCurrentTabMessages(streamMsgs);
-    setActiveIdx(i);
-  }
-
-  function newTab() {
-    abortActiveSends();
-    saveCurrentTabMessages(streamMsgs);
-    const newIdx = tabs.length;
-    setTabs(prev => [
-      ...prev,
-      { title: `Chat ${prev.length + 1}`, messages: [], sid: '', aimeeSid: newAimeeSessionId() },
-    ]);
-    setActiveIdx(newIdx);
-    setStreamMsgs([]);
-  }
-
-  // Detach a tab's unified-presence surface (best-effort; keepalive lets it
-  // outlive an unload). The server also tears the presence down on session.close,
-  // so a missed detach is harmless.
-  function detachTabPresence(tab: TabData | undefined) {
-    if (!tab?.attachId || !tab.aimeeSid) return;
-    try {
-      fetch('/api/chat/detach', {
-        method: 'POST',
-        keepalive: true,
-        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window._csrf || '' },
-        body: JSON.stringify({ sid: tab.aimeeSid, attach_id: tab.attachId }),
-      }).catch(() => {});
-    } catch { /* ignore */ }
-  }
-
-  function closeTab(i: number) {
-    if (tabs.length <= 1) return;
-    detachTabPresence(tabs[i]);
-    // Forget the server-side session so the closed tab does not reappear on the
-    // next restore (best-effort).
-    forgetServerSession(tabs[i]?.aimeeSid ?? '');
-    if (i === activeIdx) abortActiveSends();
-    setTabs(prev => {
-      const next = [...prev];
-      next.splice(i, 1);
-      return next;
-    });
-    setActiveIdx(prev => Math.min(prev, tabs.length - 2));
-  }
-
   /* Thread operations */
   async function branchThread() {
     try {
@@ -2564,13 +2442,9 @@ export default function Chat() {
       margin: '-24px', overflow: 'hidden', background: tokens.surface,
     }}>
       {/* Tab bar */}
-      <TabBar
-        tabs={tabs}
-        activeIdx={activeIdx}
-        onSwitch={switchTab}
-        onNew={newTab}
-        onClose={closeTab}
-      />
+      {/* Chat session tabs removed: a single conversation per the top-nav
+          restructure. The tabs[] state is retained (locked to one tab) so the
+          session/presence/thread machinery is unaffected. */}
 
       {/* Thread bar (conversation branching) */}
       <ThreadBar

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from 'react';
 import { Spinner, tokens } from '@rakuensoftware/smoothgui';
 import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolBlock, TurnSummaryCard } from './chat/ChatPrimitives';
 import { escHtml, renderMd, renderWithMentions } from './chat/markdown';
+import ProjectPicker from '../components/ProjectPicker';
 
 /* ---- Types ---- */
 
@@ -2439,12 +2440,19 @@ export default function Chat() {
   return (
     <div style={{
       display: 'flex', flexDirection: 'column', height: '100%',
-      margin: '-24px', overflow: 'hidden', background: tokens.surface,
+      overflow: 'hidden', background: tokens.surface,
     }}>
-      {/* Tab bar */}
-      {/* Chat session tabs removed: a single conversation per the top-nav
-          restructure. The tabs[] state is retained (locked to one tab) so the
-          session/presence/thread machinery is unaffected. */}
+      {/* Chat session tabs removed (single conversation). This tab's project
+          space: select/clone a git project; the agent runs with that project as
+          its working directory (cwd). Per-tab persisted selection. */}
+      <ProjectPicker
+        storageKey="aimee_chat_project"
+        onChange={sel => {
+          const r = sel ? `${sel.root}/${sel.project}` : '';
+          setProjectRoot(r);
+          saveProjectRoot(r);
+        }}
+      />
 
       {/* Thread bar (conversation branching) */}
       <ThreadBar

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -1,25 +1,36 @@
-/* In-app VSCode (webchat-git WP-J). Embeds the per-user code-server — served by
- * aimee-server and reverse-proxied at /vscode/ (same origin) — in an iframe so
- * the editor lives inside the webchat shell alongside Chat/Projects. The browser
- * never sees the editor's loopback port or any git credential: webchat ensures
- * the editor and proxies, and the creds stay server-side in the sealed vault.
- *
- * The editor is server-gated (AIMEE_WEBCHAT_EDITOR + a code-server build); when
- * it is off, /vscode/ returns 503 and the iframe shows that page. Same-origin,
- * so framing is allowed and no cross-origin credential exposure is possible. */
+import { useState } from 'react';
+import ProjectPicker from '../components/ProjectPicker';
+import type { ProjectSelection } from '../components/ProjectPicker';
+
+/* In-app VSCode (webchat-git WP-J), bound to this tab's selected project. The
+ * per-user code-server (served by aimee-server, reverse-proxied at /vscode/) is
+ * rooted at the user's workspace; selecting a project opens its folder via
+ * ?folder=<root>/<project>. The browser never sees the editor's loopback port or
+ * any git credential — creds stay server-side in the sealed vault. */
 export default function Editor() {
+  const [sel, setSel] = useState<ProjectSelection | null>(null);
+
+  const folder = sel ? `${sel.root}/${sel.project}` : '';
+  // Re-key the iframe on folder change so code-server reloads at the new folder.
+  const src = folder ? `/vscode/?folder=${encodeURIComponent(folder)}` : '/vscode/';
+
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <iframe
-        title="VSCode"
-        src="/vscode/"
-        style={{ flex: 1, width: '100%', height: '100%', border: 'none' }}
-        /* code-server needs scripts + same-origin; it is served from our own
-         * origin so this is not a cross-origin grant. Clipboard helps copy/paste
-         * in the editor + terminal. */
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
-        allow="clipboard-read; clipboard-write"
-      />
+      <ProjectPicker storageKey="aimee_editor_project" onChange={setSel} />
+      {sel ? (
+        <iframe
+          key={folder}
+          title="VSCode"
+          src={src}
+          style={{ flex: 1, width: '100%', height: '100%', border: 'none' }}
+          sandbox="allow-scripts allow-same-origin allow-forms allow-popups allow-modals allow-downloads"
+          allow="clipboard-read; clipboard-write"
+        />
+      ) : (
+        <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontFamily: 'system-ui' }}>
+          Select or clone a project above to open it in the editor.
+        </div>
+      )}
     </div>
   );
 }

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState, useCallback, useRef } from "react";
 import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
+import ProjectPicker from "../components/ProjectPicker";
+import type { ProjectSelection } from "../components/ProjectPicker";
 
 /* ---- API types (mirror /v1/workflow/* envelopes) ---- */
 
@@ -317,6 +319,10 @@ export default function Workflows() {
   const [personas, setPersonas] = useState<PersonaInfo[]>([]);
   const [agents, setAgents] = useState<AgentInfo[]>([]);
   const [managePersonas, setManagePersonas] = useState(false);
+  // This tab's selected project (per-tab project space). Held so the workflow
+  // context can scope to it; execution-in-project flows through a chat session's
+  // cwd today, so this primarily persists the selection + offers clone here.
+  const [, setWfProject] = useState<ProjectSelection | null>(null);
   const drag = useRef<{ id: string; dx: number; dy: number } | null>(null);
 
   const refreshLists = useCallback(() => {
@@ -534,19 +540,19 @@ export default function Workflows() {
   };
 
   return (
-    <div
-      style={{
-        display: "flex",
-        gap: 12,
-        // Fill the AppShell content area (like the Projects page). The old
-        // calc(100vh - 90px) hard-coded an assumed header height; when it was
-        // wrong the flex row collapsed and the left rail + canvas clipped to
-        // nothing while only the toolbar buttons stayed visible.
-        height: "100%",
-        minHeight: 0,
-        fontFamily: "system-ui",
-      }}
-    >
+    <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
+      <ProjectPicker storageKey="aimee_workflows_project" onChange={setWfProject} />
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          // Fill the remaining height below the project bar. minWidth:0 on the
+          // center keeps the 1600px canvas from collapsing the side rails.
+          flex: 1,
+          minHeight: 0,
+          fontFamily: "system-ui",
+        }}
+      >
       {/* left rail: defs + palette + run items */}
       <div
         style={{
@@ -846,6 +852,7 @@ export default function Workflows() {
           onChanged={refreshPersonas}
         />
       )}
+      </div>
     </div>
   );
 }

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -22,6 +22,7 @@
 #include "git_ops.h"          /* git_ops_run for /v1/workspace/git (WP-E) */
 #include "git_project.h"      /* git_project_clone for /v1/workspace/clone (WP-D) */
 #include "webuser_editor.h"   /* webuser_editor_ensure for /v1/workspace/editor (WP-I) */
+#include "workspace_scope.h"  /* ws_scope_user_root — project workspace root */
 #include "index.h"            /* index_scan_project after a webuser clone (WP-D) */
 
 /* Per-request context handed to a route handler. `id` holds the extracted
@@ -935,6 +936,12 @@ static int rh_workspace_projects(const route_req_t *rq, char *resp, int cap)
    cJSON *arr = cJSON_AddArrayToObject(out, "projects");
    for (int i = 0; i < count; i++)
       cJSON_AddItemToArray(arr, cJSON_CreateString(names[i]));
+   /* The user's scoped workspace root — used by the editor to open a project
+    * folder (root/<project>) and by chat to set its working directory. It is the
+    * caller's own workspace path, returned only to them. */
+   char root[MAX_PATH_LEN];
+   if (ws_scope_user_root(principal, 0, root, sizeof(root)) == 0)
+      cJSON_AddStringToObject(out, "root", root);
    char *s = cJSON_PrintUnformatted(out);
    int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
    free(s);

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -10,6 +10,7 @@
 #include "git_project.h"
 #include "index.h"
 #include "webuser_editor.h"
+#include "workspace_scope.h"
 
 #include <stdio.h>
 
@@ -137,4 +138,13 @@ int git_oauth_github_get_client_id(char *out, size_t out_len)
    if (out && out_len)
       out[0] = '\0';
    return 0;
+}
+
+int ws_scope_user_root(const char *principal, int create, char *out, size_t cap)
+{
+   (void)principal;
+   (void)create;
+   if (out && cap)
+      out[0] = '\0';
+   return -1;
 }

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -31,10 +31,12 @@ func (s *server) gitRelay(w http.ResponseWriter, st int, data []byte, err error)
 		Output   string   `json:"output"`
 		Projects []string `json:"projects"`
 		Hosts    []string `json:"hosts"`
+		Root     string   `json:"root"`
 	}
 	_ = json.Unmarshal(data, &up)
 	out, _ := json.Marshal(map[string]any{
-		"ok": true, "name": up.Name, "output": up.Output, "projects": up.Projects, "hosts": up.Hosts,
+		"ok": true, "name": up.Name, "output": up.Output, "projects": up.Projects,
+		"hosts": up.Hosts, "root": up.Root,
 	})
 	w.Write(out)
 }


### PR DESCRIPTION
First of the tab-restructure series (one tab per tool, nav moved to the top).

- **App.tsx** — replace smoothgui's left-sidebar AppShell with a custom **top nav bar** (one link per tool: Chat / Dashboard / Workflows / Projects / Editor) + Logout. Content area is `flex:1` + `minHeight:0` so pages using `height:100%` still resolve.
- **Chat.tsx** — remove the internal chat-session **TabBar** (+ the now-dead switchTab/newTab/closeTab/detachTabPresence/forgetServerSession). Chat is a single conversation; the `tabs[]` state is retained (locked to one entry) so session/presence/thread machinery is unchanged.

Verified headless against the live backend: top nav at y=0 (48px), pages render full-width below it, no console errors.

Next in the series: (2) per-tab project selector + Editor opens the selected project, (3) Chat binds to the project via `cwd`, (4) Workflows run against the project.
