### PR TITLE
fix(git): clone over HTTPS, never SSH (fixes "Host key verification failed")

### DIFF
--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -4,6 +4,7 @@
 #include "git_cred_inject.h"   /* git_cred_inject_build_env / _free_env */
 #include "git_host_cred.h"     /* per-host token store (single-user, many hosts) */
 #include "util.h"              /* safe_exec_capture_env */
+#include "util_url.h"          /* util_url_normalize (ssh/scp/git -> https) */
 #include "workspace_scope.h"   /* ws_scope_project_path, ws_scope_name_valid */
 
 #include <dirent.h>
@@ -119,9 +120,17 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
    char **envp =
        forge_built ? forge_cred_build_env_from_token(eff_token, environ, forge_cred_askpass_shim())
                    : git_cred_inject_build_env(principal, environ);
-   const char *argv[] = {"git", "clone", "--", url, dest, NULL};
+   /* Clone over HTTPS, never SSH: our credential model is per-host HTTPS tokens
+    * (+ OAuth), and a non-interactive server has no seeded known_hosts, so an
+    * ssh://, git@host:path, or git:// URL would die on "Host key verification
+    * failed". Normalize any such form to https://host/path; fall back to the raw
+    * URL only for forms util_url_normalize can't parse (e.g. a local file path). */
+   char *clone_url_norm = util_url_normalize(url);
+   const char *clone_url = clone_url_norm ? clone_url_norm : url;
+   const char *argv[] = {"git", "clone", "--", clone_url, dest, NULL};
    char *out = NULL;
    int rc = safe_exec_capture_env(argv, envp ? envp : environ, &out, 1 << 16);
+   free(clone_url_norm);
    if (envp)
    {
       if (forge_built)


### PR DESCRIPTION
**Symptom:** cloning a project failed with `git clone failed (rc=128): ... Host key verification failed. fatal: Could not read from remote repository.`

**Cause:** `git_project_clone` passed the URL verbatim to `git clone`, so an SSH-form URL (`ssh://`, `git@host:path`, `git://`) made git use the SSH transport. A non-interactive server has no seeded `known_hosts`, so host-key verification fails.

**Fix:** our credential model is per-host **HTTPS** tokens (+ GitHub OAuth) — there's no git SSH key management. The clone path already normalizes the URL via `util_url_normalize()` for *credential lookup*, just not for the clone URL. Now we normalize the clone URL too (`ssh`/`scp`/`git` → `https://host/path`), falling back to the raw URL only for forms it can't parse (e.g. a local `file://`/path, exercised by the integration test). The per-host token then applies via `GIT_ASKPASS` and there's no host-key step.

**Tests:** `unit-test-git-project` (real local clone) passes; the ssh/scp/git→https conversions are covered by `unit-test-util` (`test_util_url`).
