### PR TITLE
docs: add WORKFLOWS.md + refresh personas/webchat/status for current features

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1118,7 +1118,17 @@ legacy command modules but is not currently routed by the thin CLI.
 `aimee identity show/snapshot/diff` inspects the working profile and tracks how
 it changes over time. **Personas** (see [`docs/personas.md`](docs/personas.md))
 let a session adopt a named voice/behavior profile, settable per session in chat
-and webchat.
+and webchat; the same personas staff roundtable review panels and
+[workflow](docs/WORKFLOWS.md) steps. aimee ships eight built-ins (`engineer`
+default, `novel`, `songwriter`, and the read-only reviewers `qa`, `security`,
+`reviewer`, `reviewer-constructive`, `architect`).
+
+**Workflows** (see [`docs/WORKFLOWS.md`](docs/WORKFLOWS.md)) compose those
+delegates and gates into a declarative dev-lifecycle graph (propose → review →
+plan → implement → PR → merge). The default `build` workflow lives in
+`config/workflows/build.yaml`; author and validate your own with `aimee workflow
+new/validate/show` or the webchat **Workflows** tab. The execution engine is
+implemented but not yet wired to a user-facing run trigger.
 
 ---
 
@@ -1205,6 +1215,25 @@ none is provided), serves the React UI from `frontend/`, streams chat over SSE,
 and proxies dashboard panels, collab-rule review, and a local channel board.
 Treat it as a *semi-trusted*, same-host/trusted-LAN surface, see
 [`docs/SECURITY.md`](docs/SECURITY.md).
+
+The UI is organized as a **top navigation bar**, one tab per tool, and each tab
+selects its own git **project** to operate on:
+
+- **Chat** — the agent conversation (streamed over SSE). The selected project
+  becomes the agent's working directory; webchat scope-validates it to the
+  signed-in user's own workspace.
+- **Dashboard** — memory, reminders, and onboarding panels.
+- **Workflows** — a visual composer for [workflow](docs/WORKFLOWS.md)
+  definitions (blocks rail, graph canvas, per-step persona/delegate assignment,
+  plus a persona manager). Validate/Save persist server-side.
+- **Projects** — connect git repositories. Clone over HTTPS *or* SSH-form URLs
+  (normalized to HTTPS); manage **per-host** credentials in the server vault and
+  sign in to GitHub via OAuth device flow. aimee-server is single-user but talks
+  to many hosts/providers, so credentials are keyed by **host, never per user**.
+- **Editor** — an in-browser **VS Code** (a per-user `code-server`, supervised
+  by the server and reverse-proxied at `/vscode/`) opened on the selected
+  project. Enabled by default (`WITH_VSCODE=1` in the image, `AIMEE_WEBCHAT_
+  EDITOR=1`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ Focused references:
 | [Storage Tiers](docs/STORAGE_TIERS.md) | DB1 + DB2 ownership boundaries (pgvector inside DB2) |
 | [Setting Up Delegates](docs/DELEGATES.md) | Configure delegate agents for task offloading |
 | [Autonomous Development](docs/AUTONOMOUS_DEVELOPMENT.md) | Hand aimee a proposal; it builds the change end-to-end via the workflow engine |
+| [Personas](docs/personas.md) | Built-in and custom agent identities, delegate policy, and how personas staff reviews |
+| [Workflows](docs/WORKFLOWS.md) | The composable dev-lifecycle workflow engine, block catalog, and authoring |
 | [Workspace Management](docs/WORKSPACES.md) | Multi-repo workspaces and session isolation |
 | [Security Model](docs/SECURITY.md) | Threat model, trust boundaries, capability system |
 | [Benchmarks](docs/BENCHMARKS.md) | Latency measurements and performance budget |

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -91,13 +91,14 @@ flowchart TD
 
 ### Configuration
 
-> **Thin client (remote server):** API keys are held on the client, not the
-> server. `aimee agent add <name> <endpoint> <model> --key K` against a remote
-> `aimee-server` stores `K` locally (`~/.config/aimee/agent-keys.json`) and
-> strips it before forwarding the definition; the key is pushed once per session
-> to a RAM-only keyring on the server and never persisted. Codex agents take no
-> key (`--provider codex` sources the OAuth token from `~/.codex/auth.json`). You
-> configure agents per machine. See [THIN_CLIENT.md](THIN_CLIENT.md) and
+> **Credential storage:** API keys and Codex/OAuth tokens are sealed in the
+> server's **vault** (encrypted at rest), not held on clients. `aimee agent add
+> <name> <endpoint> <model> --key K` seals `K` into the vault and refuses
+> plaintext storage; the server's `agents.json` keeps the definition only. Codex
+> tokens are vaulted via `aimee agent setup codex-oauth`. Configure agents once
+> on the server — the vault is shared across clients. Migrate any leftover
+> client-held `~/.config/aimee/agent-keys.json` with `aimee agent key import
+> [--scrub]`. See [THIN_CLIENT.md](THIN_CLIENT.md) and
 > [SECURITY.md](SECURITY.md#agent-credential-custody-thin-client).
 
 Use `aimee agent local` for local or LAN OpenAI-compatible runtimes such as

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -223,29 +223,36 @@ Security implications:
 
 ## Agent Credential Custody (thin client)
 
-Third-party agent/delegate API keys (and Codex OAuth tokens) are **held on the
-client machine, not on the server**, to avoid making `aimee-server` a central
-secret store worth attacking.
+Third-party agent/delegate API keys (and Codex/OAuth tokens) are sealed in the
+server's **credential vault** — encrypted at rest — and are the server's single,
+permanent credential store. The legacy client-held model (client keyring + a
+RAM-only per-session push) was retired.
 
-- **Storage of record is the client.** Keys live in the user's
-  `~/.config/aimee/agent-keys.json` (mode 0600); Codex OAuth lives in the Codex
-  CLI's `~/.codex/auth.json`. `aimee agent add … --key K` against a remote server
-  writes `K` locally and strips it before forwarding the agent definition, so the
-  key is never transmitted to or persisted by the server. The server's
-  `agents.json` holds definitions (endpoint, model, roles) only.
-- **Server caching is RAM-only and session-scoped.** The client pushes its keys
-  once per session to an in-memory keyring (`POST /v1/session/credentials`),
-  keyed by a `cred_session_id`. The keyring is never written to disk, is evicted
-  on an idle TTL / capacity (LRU), and secrets are zeroed on removal — so a
-  server restart or compromise yields no durable key store. Auth resolution
-  prefers the client-pushed session key over any legacy server-stored key/env.
-- **Trade-off.** A user configures their agents/keys on each machine they use.
-  This is intentional: it keeps the blast radius of a server compromise to
-  whatever sessions are live in RAM at that moment, not the full set of keys.
-- **Transport.** The push travels over the same authenticated `/v1` channel as
-  other requests; on a plaintext-HTTP LAN deployment it is only as confidential
-  as that network (consistent with the `remote_writes: full` trusted-network
-  posture). Use TLS / a trusted network for the server endpoint.
+- **Storage of record is the server vault.** Keys are sealed under the server
+  principal, encrypted at rest; `aimee agent add … --key K` writes `K` into the
+  vault and **refuses plaintext storage**. The server's `agents.json` holds
+  definitions (endpoint, model, roles) only — never the key. Codex/OAuth tokens
+  are vaulted the same way (a legacy plaintext token is migrated and scrubbed on
+  first use).
+- **Autonomous unseal, no interactive unlock.** Each data-encryption key is
+  wrapped twice — once for an interactive principal and once under a server
+  master key (`.vault/.server-master.key`) — so the server can decrypt a
+  credential on its own to run a turn without a human unlocking the vault.
+  Credentials are resolved per turn from the vault (the turn's attested
+  principal, falling back to the server principal).
+- **No client custody, no RAM keyring.** The client-held keyring
+  (`~/.config/aimee/agent-keys.json`) and the per-session push (`POST
+  /v1/session/credentials`) are gone; `aimee agent key import` migrates any
+  leftover client keys into the vault. Agents are configured **once on the
+  server** and shared across every client.
+- **Trade-off.** The server is now a durable secret store, so the protection
+  boundary is the server host and especially `.vault/.server-master.key` (the
+  root of the autonomous-unseal capability) — restrict its file mode and host
+  access and threat-model the server host accordingly.
+- **Transport.** `agent add --key` sends the key over the same authenticated
+  `/v1` channel as other requests; on a plaintext-HTTP LAN deployment it is only
+  as confidential as that network. Use TLS / a trusted network for the server
+  endpoint.
 
 See [THIN_CLIENT.md](THIN_CLIENT.md) for operational details.
 
@@ -263,8 +270,9 @@ client runs them locally, with `claude` authenticating via the client's own logi
 - The CLI runs against the client's working tree, under the client user's
   identity — the server gains no new ability to execute binaries it does not have.
 - This keeps the server from being a place where third-party agent logins
-  accumulate, consistent with the broader thin-client custody posture (agent API
-  keys are client-held; see [DELEGATES.md](DELEGATES.md)). On a plaintext-HTTP
+  accumulate (a `claude` CLI subscription login is not an API key and is not
+  vaulted; it stays on the client; see [DELEGATES.md](DELEGATES.md)). On a
+  plaintext-HTTP
   LAN deployment, the prompt relayed to the server is only as confidential as
   that network — use TLS / a trusted network for the server endpoint.
 - Claude run via the `claude` CLI login (not an API key) is **primary-only by

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -31,6 +31,11 @@ feature-tracking reference rather than a complete roadmap.
 | Bootstrap script (setup.sh) | Done | Includes a bootstrap script for initial environment and dependency setup. | setup.sh |
 | Standalone Go webchat | Done | `aimee-webchat` serves the browser UI, handles auth/session storage, and proxies live work to `aimee-server`. | webchat/, server.c |
 | Network inventory | Done | Loads configured network host inventory for delegate routing. | cmd_agent.c, agents.json |
+| Personas (8 built-in + custom) | Done | Named identity/voice + delegate policy, settable per session and used to staff roundtable panels and workflow steps. See [personas.md](personas.md). | persona.c, prompts.c |
+| Webchat top-nav + per-tab projects | Done | One tab per tool (Chat/Dashboard/Workflows/Projects/Editor); each tab selects its own git project. | frontend/src/App.tsx, frontend/src/components/ProjectPicker.tsx |
+| Webchat git projects + per-host credentials | Done | Clone repos (HTTPS or SSH-form URLs normalized to HTTPS); per-host tokens + GitHub OAuth device flow stored in the server vault. | git_project.c, git_host_cred.c, git_oauth_github.c |
+| In-app VS Code editor | Done | Per-user `code-server` supervised by the server, reverse-proxied at `/vscode/`, opened on the selected project. Default-on. | webuser_editor.c, webchat/vscode.go |
+| Workflow engine (authoring + execution) | Partial | Block catalog, typed-graph validation, canonical versioning, advance/gates/roundtable/human-approval, and the webchat composer are done; **no user-facing run trigger yet**. See [WORKFLOWS.md](WORKFLOWS.md). | src/workflow/wfe_*.c |
 
 ## Memory System
 

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -1,15 +1,15 @@
-# Thin Client: Workspaces, Agents & Client-Held Credentials
+# Thin Client: Workspaces, Agents & Credentials
 
 This document describes how the `aimee` thin client works against a **remote**
 `aimee-server` (e.g. a shared server reached over `tcp:`), covering three things
-that are deliberately designed so the *client machine* — not the server — holds
-the working tree and the secrets:
+specific to remote operation:
 
 1. **Workspaces** are ingested *from the client* (the server never reads the
-   client's filesystem).
-2. **Agent/delegate API keys live on the client** and are pushed to a
-   **RAM-only, per-session** keyring on the server that is **never persisted to
-   disk**.
+   client's filesystem) — the client still owns the working tree.
+2. **Agent/delegate credentials live in the server's sealed vault**, encrypted
+   at rest and decryptable by the server autonomously. They are **not** held on
+   the client and there is **no** RAM session keyring (the legacy client-held
+   keyring + per-session push were retired; the vault is the single store).
 3. The **attention guard** is inert by default.
 
 It complements [WORKSPACES.md](WORKSPACES.md), [DELEGATES.md](DELEGATES.md), and
@@ -20,7 +20,8 @@ It complements [WORKSPACES.md](WORKSPACES.md), [DELEGATES.md](DELEGATES.md), and
 | Concern | Thin client (your machine) | aimee-server (remote) |
 | --- | --- | --- |
 | Your working tree / files | yes | no (never reads client fs) |
-| Agent API keys / Codex OAuth | stored here | cached in RAM per session, never on disk |
+| Agent API keys / Codex OAuth | not stored here | **sealed vault**, encrypted at rest |
+| Interactive CLI logins (Claude CLI, Codex CLI) | login lives here | runs against the client's login (see below) |
 | Engine, agent loop, DB1/DB2, KB | — | yes |
 | Code index, memory, chat/delegate execution | — | yes |
 
@@ -41,8 +42,8 @@ Mutating `/v1` calls require the server to allow remote writes. Set it in the
 server's `aimee.yaml` (`aimee.api.remote_writes: off|data|full`) **or** via the
 `AIMEE_API_REMOTE_WRITES` environment variable (deploy truth — applied even when
 the config file is read-only or absent, e.g. a containerized server). `full`
-grants the LAN bearer the capabilities needed for workspace add, ingest, and
-session-credential push; use it only on trusted networks.
+grants the LAN bearer the capabilities needed for workspace add and ingest; use
+it only on trusted networks.
 
 ## Workspaces (client-push ingest)
 
@@ -71,16 +72,21 @@ Notes:
 - VCS/build/hidden directories (`.git`, `node_modules`, `target`, `dist`, …) and
   binary/oversized files are skipped.
 
-## Agents & client-held credentials
+## Agents & credentials (server vault)
 
-API keys for delegates and the primary provider are **held on the client**, not
-stored on the server. The model:
+Credentials for delegates and the primary provider — API keys and Codex/OAuth
+tokens — live in the server's **sealed vault**: encrypted at rest, keyed by
+agent, and decryptable by the server autonomously (a dual-access wrap lets the
+server unseal them without an interactive unlock). They are **not** held on the
+client, and there is **no** per-session RAM keyring or credential push. The
+vault is the single, permanent store. See [SECURITY.md](SECURITY.md).
 
 - `agent add` stores the **definition** (name, endpoint, model, roles, provider)
-  on the server; the **key** stays local.
-- Once per session the client pushes its keys to the server's in-memory keyring;
-  the server uses them for that session's turns and **never writes them to
-  disk** (they evaporate on session end / restart). See [SECURITY.md](SECURITY.md).
+  and, with `--key`, seals the **key into the vault** under the server principal.
+  Plaintext key storage is refused — the key only ever lands encrypted.
+- Every chat/delegate turn resolves the agent's credential from the vault (the
+  in-flight turn's attested principal, falling back to the server principal). No
+  credential is pushed per session and none is cached on the client.
 
 ### Adding an agent
 
@@ -90,49 +96,46 @@ aimee agent add minimax https://api.minimax.io/v1/chat/completions MiniMax-M3 \
       --roles "code,review,explain,refactor,draft,execute,summarize,format,diagnose,validate"
 ```
 
-Against a **remote tcp** server, `--key K`:
-- is written to the local keyring `~/.config/aimee/agent-keys.json` (mode 0600),
-  keyed by the agent name, and
-- is **stripped** from the request before the definition is forwarded — the key
-  never reaches the server.
-
-Set the primary chat provider to any configured agent:
+`--key K` sends `K` to the server once, where it is sealed into the vault; it is
+never stored on the client and never written to disk in plaintext. Set the
+primary chat provider to any configured agent:
 
 ```sh
 aimee config set provider minimax
 ```
 
-### How keys reach the server (per session)
+You configure agents **once on the server** — the vault is shared across every
+client that reaches it, so there is no per-machine key setup.
 
-- A stable per-client **credential-session id** is generated once into
-  `~/.config/aimee/cred-session.id`.
-- The first chat/delegate turn of a session pushes the local keyring (and Codex
-  creds, below) to `POST /v1/session/credentials`, deduplicated (re-pushes at
-  most every ~2 minutes, which also re-syncs after a server restart). Each turn
-  carries a `cred_session_id` so the server resolves the right keyring entry,
-  decoupled from the functional chat session id.
-- Server auth resolution prefers a client-pushed session key (by session + agent
-  name) over any server-stored `api_key` / provider env var.
+### Migrating legacy client-held keys
 
-You set up agents **per machine** you use — that is the intended trade-off for
-not centralizing keys on the server.
+If an older client left keys in `~/.config/aimee/agent-keys.json`, move them into
+the vault:
+
+```sh
+aimee agent key import            # vault each leftover key (preview with --dry-run)
+aimee agent key import --scrub     # …and delete each from agent-keys.json once vaulted
+```
+
+This is the **only** remaining use of `agent-keys.json`; new keys go straight to
+the vault. Run it on the server host over the Unix socket, or from a connection
+holding the `vault:write:server` capability.
 
 ### Codex (ChatGPT OAuth)
 
-The Codex CLI keeps a refreshed OAuth token in `~/.codex/auth.json` on your
-machine. Add a Codex agent with no key — the client reads that file and pushes
-the token (and ChatGPT account id) with the session credentials:
+Codex/OAuth tokens are stored in the vault too, so a Codex agent authenticates
+server-side with no per-session push from the client. Use the server-hosted
+OAuth setup, which installs the CLI and seals the token into the vault:
 
 ```sh
-aimee agent add codex https://chatgpt.com/backend-api/codex gpt-5.5 \
-      --provider codex --roles "code,review,explain,refactor,draft,execute,summarize,format,diagnose,validate"
-aimee config set provider codex     # optional: use Codex as the primary
+aimee agent setup codex-oauth       # server-hosted OAuth → token sealed in the vault
+aimee config set provider codex      # optional: use Codex as the primary
 ```
 
-`--provider codex` is a convenience alias for the Codex adapter (provider
-`chatgpt`, `auth_type` `codex-oauth`, the responses-wire delegate driver). The
-token is sourced live per session, so it stays fresh as the Codex CLI refreshes
-it; it is never stored on the server.
+`provider codex` is the Codex adapter (provider `chatgpt`, `auth_type`
+`codex-oauth`, the responses-wire delegate driver). A legacy plaintext token
+(from an older db1/secrets store) is migrated into the vault and scrubbed on
+first use.
 
 ## Attention guard
 
@@ -154,7 +157,6 @@ the resolved binary.
 | Method | Endpoint | Purpose |
 | --- | --- | --- |
 | POST | `/v1/index/ingest` | Index client-pushed `{rel_path, content}` files for a workspace the server cannot see (relays to aimee-kb). |
-| POST | `/v1/session/credentials` | Receive the once-per-session push of `{session_id, agents{}, codex_oauth_token, codex_account_id}` into the RAM-only keyring. |
 
 Both `/v1/index/scan` and `/v1/index/ingest` run as synchronous handlers under
 the async op-run worker (poll `GET /v1/runs/{id}`).

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -7,20 +7,24 @@ current version and prints it once after an upgrade.
 
 ## Unreleased (testing)
 
-Thin-client hardening — the client machine owns the working tree and the
-secrets; see [THIN_CLIENT.md](THIN_CLIENT.md).
+Thin-client + credential hardening — the client owns the working tree; agent
+credentials live in the server's **sealed vault**; see
+[THIN_CLIENT.md](THIN_CLIENT.md).
 
-- **Client-held agent credentials**: agent/delegate API keys now live on the
-  client (`~/.config/aimee/agent-keys.json`), not on the server. `aimee agent
-  add … --key K` against a remote server keeps `K` local and strips it before
-  forwarding the definition. Keys are pushed once per session to a **RAM-only**
-  keyring on the server (`POST /v1/session/credentials`) and are **never written
-  to disk** — so a compromised server holds no durable secret store. Auth
-  resolution prefers the client-pushed session key over any server-stored key.
-- **Codex OAuth from the thin client**: add a Codex agent with no key
-  (`aimee agent add codex https://chatgpt.com/backend-api/codex gpt-5.5
-  --provider codex`); the client supplies the OAuth token from this machine's
-  `~/.codex/auth.json` per session. Works as a primary provider and a delegate.
+- **Server-sealed credential vault (single store)**: agent/delegate API keys and
+  Codex/OAuth tokens are sealed in the server's vault — encrypted at rest, keyed
+  by agent, and decryptable by the server autonomously (a dual-access wrap, no
+  interactive unlock). `aimee agent add … --key K` seals `K` into the vault;
+  plaintext storage is refused. Every turn resolves the credential from the vault
+  (the turn's attested principal, falling back to the server principal). The
+  legacy **client-held keyring and the RAM per-session push (`POST
+  /v1/session/credentials`) are gone**. Migrate any leftover
+  `~/.config/aimee/agent-keys.json` with `aimee agent key import [--scrub]`.
+- **Codex OAuth in the vault**: `aimee agent setup codex-oauth` runs the
+  server-hosted OAuth flow and seals the token into the vault; a Codex agent then
+  authenticates server-side as a primary provider or delegate, with no
+  per-session push from the client. A legacy plaintext token is migrated and
+  scrubbed on first use.
 - **Workspaces ingested from the client**: `aimee workspace add <path>` resolves
   the path locally, registers it as `detached`, and pushes the files to the
   server (`POST /v1/index/ingest`, chunked under aimee-kb's body cap) — the

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -1,0 +1,249 @@
+# Workflows
+
+A **workflow** is a declarative graph that encodes a development lifecycle —
+*propose → review → approve → plan → implement → freeze → review → PR → merge* —
+as composable, typed steps. aimee ships one default composition (`build`), and
+you can clone and edit it or author your own. The engine that advances a
+workflow run is the same one that drives delegates, roundtable reviews, and
+human approval gates.
+
+> **Status (current):** authoring, validating, and inspecting workflows is fully
+> supported (CLI + the webchat **Workflows** tab). The execution engine —
+> stepping a run through its gates, roundtables, and approvals — is implemented
+> and tested, but **is not yet wired to a user-facing trigger**: there is no
+> `aimee workflow run` command, no Run button in the Workflows tab, and no
+> run-creation API route. Today you compose and validate the graph; running it
+> end-to-end lands in a later slice. See [Limitations](#current-limitations).
+
+## Mental model
+
+A workflow definition (`wfe_def_t`, [src/workflow/wfe_def.h](../src/workflow/wfe_def.h))
+is a named graph:
+
+- **nodes** — each node is one **step**: an `id`, a **block** (the step's type),
+  optional `params`, and typed inputs (`in`).
+- **blocks** — a block is the *kind* of work a step does (write a proposal, run a
+  roundtable, open a PR, …). The catalog is fixed in code; you can also define
+  **custom blocks**. See [Block catalog](#block-catalog).
+- **control edges** — how the run moves between steps:
+  - `next` — unconditional successor.
+  - `on_pass` / `on_fail` — a **gate**'s two outcomes (a gate produces a verdict
+    or approval; pass takes one edge, fail the other).
+- **data edges** (`in`) — bind a step's typed input slot to an upstream step's
+  output (`<producer_id>.<output>`, default output handle `out`). These are
+  *type-checked*: e.g. `implement` only accepts a `plan`, `merge` only a `pr`.
+- **start** — the entry node id (defaults to the first node).
+
+Every block declares the **artifact type** it produces and the types it accepts,
+so the validator rejects a graph that wires a proposal into a step expecting a
+PR. The pipeline of artifact types is:
+
+```
+proposal → plan → branch → frozen_diff → pr → (merged)
+                     │
+   roundtable/CI/mergeable gates emit a `verdict`
+   human gates emit an `approval`
+```
+
+## Block catalog
+
+From the catalog in [src/workflow/wfe_def.c](../src/workflow/wfe_def.c)
+(`aimee workflow blocks` prints the live list):
+
+| Block | Produces | Accepts (input) | Kind | What it does |
+|---|---|---|---|---|
+| `author.proposal` | proposal | — (no input) | action | A delegate drafts a proposal. The usual entry point. |
+| `author.plan` | plan | proposal | action | A delegate turns the proposal into an implementation plan. |
+| `implement` | branch | plan | action | Delegates implement the plan onto a branch (`params.fanout: max` parallelizes). |
+| `document` | branch | branch | action | A delegate writes docs onto the branch. Composes between implement and freeze. |
+| `freeze` | frozen_diff | branch | action | Freezes the branch to an immutable diff for review. |
+| `gate.roundtable` | verdict | proposal · plan · frozen_diff | **gate** | Runs a multi-persona review **panel**; pass/fail on quorum. |
+| `gate.human` | approval | proposal · plan · branch · frozen_diff · pr | **gate** | Parks for a human decision (or auto-passes when preauthorized). |
+| `pr.open` | pr | proposal · frozen_diff | action | Opens a pull request. |
+| `merge` | — (terminal) | pr | action | Merges the PR. |
+| `gate.ci` | verdict | pr | **gate** | Polls the PR's CI; **fail-closed** (no green → fail). |
+| `check.mergeable` | verdict | pr | **gate** | Refuses on a merge conflict. |
+| `custom` | declared | declared | either | A config-defined block (command or delegate), see [Custom blocks](#custom-blocks). |
+
+**Gates** are the blocks that branch: they take `on_pass`/`on_fail` instead of a
+single `next`. Everything else takes `next`.
+
+## The default `build` workflow
+
+[config/workflows/build.yaml](../config/workflows/build.yaml) is the reference
+composition — the full two-gate development lifecycle. The control flow:
+
+```
+draft (author.proposal, with_user)
+  └─next→ proposal_gate (roundtable: security, architect, qa, reviewer; quorum 4)
+            ├─pass→ proposal_pr (pr.open) ─next→ proposal_approve (human: pr_review)
+            │                                        └─next→ plan (author.plan)
+            └─fail→ draft                                       └─next→ plan_gate (roundtable)
+                                                                          ├─pass→ impl (implement, fanout max)
+                                                                          └─fail→ plan
+impl ─next→ document ─next→ freeze ─next→ impl_gate (roundtable)
+                                            ├─pass→ code_pr (pr.open) ─next→ pr_passfail (human)
+                                            └─fail→ impl                        ├─pass→ check_mergeable
+                                                                                └─fail→ impl
+check_mergeable ─pass→ gate_ci ─pass→ merge        (any gate fail → back to impl)
+```
+
+A roundtable node carries its panel in `params`:
+
+```yaml
+- id: proposal_gate
+  block: gate.roundtable
+  in:
+    src: draft.out          # bind this gate's input to draft's output
+  params:
+    panel:
+      required: [security, architect, qa, reviewer]   # persona names
+      eligible: [contrarian]                           # may join if available
+    quorum: 4
+    max_rounds: 6
+  on_pass: proposal_pr
+  on_fail: draft
+```
+
+Panel entries are **persona** names — see [Personas](personas.md). Each panelist
+is a persona run on a delegate model; the gate passes when the quorum of
+panelists approve (or fails after `max_rounds`).
+
+There is **no engine privilege** over a user-authored workflow: `build` is just
+one composition of the same catalog you compose from. Clone it and edit freely.
+
+## Authoring
+
+### Definition format
+
+A workflow is YAML: a `name`, a `start` node id, and a `nodes` list. Each node:
+
+```yaml
+name: my-workflow
+start: draft
+nodes:
+  - id: draft
+    block: author.proposal
+    params: { with_user: true }
+    next: review
+
+  - id: review
+    block: gate.roundtable
+    in: { src: draft.out }          # input slot ← producer.output
+    params:
+      panel: { required: [reviewer, qa] }
+      quorum: 2
+    on_pass: pr
+    on_fail: draft                  # loop back to revise
+
+  - id: pr
+    block: pr.open
+    in: { src: draft.out }
+```
+
+Definitions are **content-addressed**: the engine computes a canonical form and a
+SHA-256 `version` over it ([wfe_canonical.c](../src/workflow/wfe_canonical.c)), so
+a run is pinned to the exact graph it started on.
+
+### CLI
+
+```
+aimee workflow blocks               # list the composable block catalog
+aimee workflow new <file.yaml>      # scaffold a starter workflow
+aimee workflow validate <file.yaml> # typed-graph validation (does it wire up?)
+aimee workflow show <file.yaml>     # print the canonical form + version
+aimee workflow list                 # list workflows under $AIMEE_HOME/workflows
+```
+
+Workflow files live under `$AIMEE_HOME/workflows/`. `validate` runs the same
+type-checker the engine uses: it catches dangling edges, a step fed the wrong
+artifact type, or a missing required input.
+
+### Webchat Workflows tab
+
+The browser **Workflows** tab is a visual composer over the same definitions:
+
+- A **blocks rail** to add steps, a **canvas** that lays the graph out
+  left-to-right by depth with colored edges (solid = `next`, green = `on pass`,
+  red = `on fail`, faint = data dependency), and an **inspector** to set a step's
+  title, block, params, per-step **persona/delegate** assignment, and its
+  `next`/`on_pass`/`on_fail` edges.
+- **Personas** can be created and edited from the same tab (it proxies
+  `/api/chat/personas`).
+- **Validate** and **Save** persist the def server-side via `/api/workflow/*`.
+- Each top-nav tab (including Workflows) selects its own git **project**.
+
+> Note: adding a step from the blocks rail drops it onto the canvas
+> **disconnected** — you wire it into the sequence by selecting it and setting
+> its `next`/`on_pass`/`on_fail` in the inspector. There is no Run button yet.
+
+### Custom blocks
+
+Beyond the built-in catalog you can declare custom blocks in
+`$AIMEE_HOME/workflows/blocks.yaml`
+([wfe_custom.c](../src/workflow/wfe_custom.c)). A custom block has a name, a typed
+I/O signature (so it type-checks like a built-in), and an executor that is either
+a **command** (`WFE_EXEC_COMMAND`, an argv) or a **delegate**
+(`WFE_EXEC_DELEGATE`). The validator and artifact-type system consult the
+registry, so custom and built-in blocks compose identically.
+
+## Execution model
+
+When a run exists, it is a **work-item** (the `lifecycle_work_item` table,
+[src/db1/wfe_store.c](../src/db1/wfe_store.c)) carrying: the workflow name and
+pinned `version`, the target `repo`, `current_stage`, `content_hash`, `state`,
+`mode` (`interactive` | `autonomous`), `pause_reason`, and accumulated cost.
+
+The engine advances it one step at a time
+([wfe_engine.c](../src/workflow/wfe_engine.c) `wfe_engine_advance`):
+
+- An **action** block runs (often dispatching a delegate with a persona) and
+  advances along `next`.
+- A **gate** evaluates and takes `on_pass` or `on_fail`.
+- A **roundtable** gate runs its persona panel as delegates and passes on quorum.
+- A **human gate** **parks** the run (`WFE_STEP_PENDING`) until an approval is
+  recorded. In `autonomous` mode the driver
+  ([wfe_autonomy.c](../src/workflow/wfe_autonomy.c)) may auto-satisfy a gate that
+  is explicitly `policy: preauthorized` or `optional: true`; otherwise it parks.
+- Approvals are **signed** ([wfe_approval.c](../src/workflow/wfe_approval.c)) and
+  recorded against the step's content hash, so an approval is bound to the exact
+  artifact it approved.
+
+A step resolves the working repository from `$AIMEE_WORKFLOW_REPO` (or the
+process cwd) — see [Limitations](#current-limitations) for the
+run-in-a-specific-project gap.
+
+## Inspecting runs
+
+When work-items exist, they are readable (the Workflows tab "Run state" panel and
+the API):
+
+- CLI: `aimee cancel <work-item-id>` cancels a run.
+- Webchat: `GET /api/workflow/items` (and `/items/<id>`) list run state; a run
+  bound to a chat channel can be paused via
+  `POST /api/sessions/workflows/<id>/pause`.
+- Server `/v1/workflow/*` ([server_workflow_api.c](../src/server/server_workflow_api.c))
+  exposes the def read/author surface and the work-item read surface.
+
+## Current limitations
+
+These are real today and worth knowing before you lean on workflows:
+
+1. **No user-facing run trigger.** `wfe_work_item_create` / `wfe_autonomy_run`
+   exist and are exercised by the test suite, but nothing in the CLI, webchat, or
+   API creates and starts a run. You can author, validate, save, and inspect —
+   not yet kick one off. (Tracked in [ROADMAP](ROADMAP.md); the
+   `cmd_workflow.c` header notes the runner "lands in later slices.")
+2. **Run-in-a-specific-project isn't wired.** A work-item has a `repo` field, but
+   the per-step blocks resolve their working directory from
+   `$AIMEE_WORKFLOW_REPO`/cwd rather than the work-item's `repo`, so binding a run
+   to the Workflows tab's selected project is incomplete.
+3. **Composer ergonomics.** New steps are added disconnected; you wire order in
+   the inspector. There is no run/visualize-progress view because runs can't be
+   started from the UI yet.
+
+## See also
+
+- [Personas](personas.md) — the identities that staff roundtable panels and steps.
+- [Delegates](DELEGATES.md) — how steps dispatch model work.
+- [Architecture](ARCHITECTURE.md) — where the workflow engine sits.

--- a/docs/WORKFLOWS.md
+++ b/docs/WORKFLOWS.md
@@ -9,11 +9,13 @@ human approval gates.
 
 > **Status (current):** authoring, validating, and inspecting workflows is fully
 > supported (CLI + the webchat **Workflows** tab). The execution engine —
-> stepping a run through its gates, roundtables, and approvals — is implemented
-> and tested, but **is not yet wired to a user-facing trigger**: there is no
-> `aimee workflow run` command, no Run button in the Workflows tab, and no
-> run-creation API route. Today you compose and validate the graph; running it
-> end-to-end lands in a later slice. See [Limitations](#current-limitations).
+> stepping a run through its gates, roundtables, and approvals — is implemented,
+> tested, and reachable: `POST /v1/dev/submit` seeds a proposal, creates an
+> autonomous work item on the chosen workflow (default `build`), and the
+> scheduler drives it server-side. See
+> [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md). What's still missing is a
+> general per-workflow trigger: no `aimee workflow run` command and no Run button
+> in the Workflows tab for an arbitrary run. See [Limitations](#current-limitations).
 
 ## Mental model
 
@@ -229,11 +231,13 @@ the API):
 
 These are real today and worth knowing before you lean on workflows:
 
-1. **No user-facing run trigger.** `wfe_work_item_create` / `wfe_autonomy_run`
-   exist and are exercised by the test suite, but nothing in the CLI, webchat, or
-   API creates and starts a run. You can author, validate, save, and inspect —
-   not yet kick one off. (Tracked in [ROADMAP](ROADMAP.md); the
-   `cmd_workflow.c` header notes the runner "lands in later slices.")
+1. **Only the autonomous-development trigger is wired.** `POST /v1/dev/submit`
+   creates and starts a run via `wfe_work_item_create` + the scheduler (see
+   [Autonomous Development](AUTONOMOUS_DEVELOPMENT.md)). There is still no general
+   per-workflow trigger — no `aimee workflow run` command and no Run button in the
+   Workflows tab to kick off an arbitrary saved workflow. You can author,
+   validate, save, and inspect any workflow; only `build`-style autonomous runs
+   start today.
 2. **Run-in-a-specific-project isn't wired.** A work-item has a `repo` field, but
    the per-step blocks resolve their working directory from
    `$AIMEE_WORKFLOW_REPO`/cwd rather than the work-item's `repo`, so binding a run

--- a/docs/personas.md
+++ b/docs/personas.md
@@ -3,7 +3,7 @@
 A **persona** is the primary agent's identity, its system-prompt voice, craft
 principles, session-brief hints, the delegate roles it advertises, and its
 **delegate policy**. Personas are server-owned and user-extensible: aimee ships
-seven built-ins and seeds them as editable files, and you can add your own.
+eight built-ins and seeds them as editable files, and you can add your own.
 
 ## Built-in personas
 
@@ -14,13 +14,17 @@ seven built-ins and seeds them as editable files, and you can add your own.
 | `songwriter` | Songwriter / lyricist | **none**, does all the work itself; no delegates |
 | `qa` | Senior QA / test reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 | `security` | Senior application-security reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
-| `reviewer` | Senior contrarian code reviewer (thorough, comprehensive) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
+| `reviewer` | Senior **contrarian** code reviewer (thorough, comprehensive) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
+| `reviewer-constructive` | Senior **constructive** code reviewer (assess as written) | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 | `architect` | Software-architecture reviewer | **readonly**, reviews and reports; read-only delegates only (review, diagnose, validate, research) |
 
-The four reviewer personas (`qa`, `security`, `reviewer`, `architect`) reframe
-the agent as a read-only senior reviewer: it investigates and surfaces findings
-with evidence, never editing the code. They share a common **Review Principles**
-block and each carry their own review methodology.
+The five reviewer personas (`qa`, `security`, `reviewer`,
+`reviewer-constructive`, `architect`) reframe the agent as a read-only senior
+reviewer: it investigates and surfaces findings with evidence, never editing the
+code. They share a common **Review Principles** block and each carry their own
+review methodology. `reviewer` and `reviewer-constructive` are a deliberate pair
+— the former is adversarial (tries to refute), the latter assesses the work as
+written — so a roundtable panel can blend both stances.
 
 ## Where personas live
 
@@ -28,7 +32,8 @@ Single markdown files, resolved project → user → built-in:
 
 - Project: `<project>/.aimee/personas/<name>.md`
 - User: `~/.config/aimee/personas/<name>.md`
-- Built-in fallback (engineer/novel/songwriter/qa/security/reviewer/architect)
+- Built-in fallback
+  (engineer/novel/songwriter/qa/security/reviewer/reviewer-constructive/architect)
 
 `aimee init` seeds the built-ins as editable files under
 `~/.config/aimee/personas/` (idempotent, it never overwrites an existing file),
@@ -115,6 +120,31 @@ The persona name resolves from the built-ins or a user-level persona file (the
 same set as the rest of the persona surface). The delegate's *role* still
 governs tool access and write capability; the *persona* governs its identity and
 principles, and they compose.
+
+## Personas in roundtables and workflows
+
+A **roundtable** review panel is staffed by personas: each panelist is a persona
+run on a delegate model, and the panel pairs personas to models reproducibly run
+to run (the contrarian `reviewer` and constructive `reviewer-constructive` make a
+natural adversarial/constructive split). The default review panel is
+`security`, `architect`, `qa`, `reviewer`.
+
+In a [workflow](WORKFLOWS.md), a `gate.roundtable` step names its panel by
+persona, and any action step can be assigned a persona/delegate pair:
+
+```yaml
+- id: review
+  block: gate.roundtable
+  params:
+    panel:
+      required: [security, architect, qa, reviewer]
+    quorum: 4
+```
+
+The webchat **Workflows** tab includes a persona manager (create/edit personas)
+and a per-step persona picker, both backed by `/api/chat/personas`. So the same
+eight built-ins — plus any you add — are the vocabulary for chat identity,
+delegate assignment, roundtable panels, and per-step workflow roles alike.
 
 ## V1 HTTP API
 


### PR DESCRIPTION
Brings the user-facing docs up to date and adds the two requested documents.

**New**
- `docs/WORKFLOWS.md` — workflow concept, the typed block catalog (`author.proposal`…`merge`, gates), the default `build.yaml` lifecycle, authoring (YAML + `aimee workflow` CLI + the webchat composer + custom blocks), and the execution model (work-items, roundtable/human gates, autonomy). Honestly documents that **runs aren't user-triggerable yet** (`wfe_work_item_create`/`wfe_autonomy_run` are test-only; no CLI/UI/API trigger).

**Refreshed**
- `docs/personas.md` — corrected **7 → 8** built-ins (adds `reviewer-constructive`, the constructive counterpart to the contrarian `reviewer`); documents how personas staff roundtable panels and workflow steps.
- `MANUAL.md` §19/§23 — expanded the webchat section to the current **top-nav tabs** (Chat/Dashboard/Workflows/Projects/Editor), the **in-app VS Code editor**, **per-tab git projects + per-host credentials**, and the workflows composer.
- `docs/STATUS.md` — added rows for personas, webchat top-nav/projects, per-host git creds, the in-app editor, and the workflow engine (marked **Partial**).
- `README.md` — indexed Personas + Workflows.

Docs-only; no image rebuild needed. All referenced source paths verified to exist.
