### PR TITLE
feat(webchat): session tabs + vertical tool nav + chat Clear button

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Component, useEffect, useState } from 'react';
+import { Component, useEffect, useRef, useState } from 'react';
 import type { ErrorInfo, ReactNode } from 'react';
 import { Routes, Route, Navigate, NavLink, useLocation } from 'react-router-dom';
 import { Toast } from '@rakuensoftware/smoothgui';
@@ -7,6 +7,7 @@ import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
 import Projects from './pages/Projects';
 import Editor from './pages/Editor';
+import { SessionProvider, useSessions } from './SessionContext';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -63,6 +64,68 @@ const NAV_ITEMS: Tab[] = [
   { label: 'Projects', icon: '📁', route: '/projects' },
   { label: 'Editor', icon: '🖥️', route: '/editor' },
 ];
+
+/* Top bar: one tab per session. A session bundles a chat + the project it runs
+ * in; every tool operates on the active session's project. */
+function SessionTabBar() {
+  const { sessions, activeId, addSession, closeSession, selectSession, renameSession } = useSessions();
+  const [editing, setEditing] = useState<string>('');
+  const editRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { if (editing) editRef.current?.focus(); }, [editing]);
+
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 4, flex: 1, overflowX: 'auto' }}>
+      {sessions.map(s => {
+        const isActive = s.id === activeId;
+        return (
+          <div
+            key={s.id}
+            onClick={() => selectSession(s.id)}
+            onDoubleClick={() => setEditing(s.id)}
+            title={s.projectName ? `${s.name} · ${s.projectName}` : s.name}
+            style={{
+              display: 'flex', alignItems: 'center', gap: 6, padding: '4px 8px', borderRadius: 6,
+              cursor: 'pointer', fontSize: 13, whiteSpace: 'nowrap', maxWidth: 220,
+              background: isActive ? '#23233a' : 'transparent',
+              color: isActive ? '#cde' : '#889', border: '1px solid', borderColor: isActive ? '#3a3a55' : 'transparent',
+            }}
+          >
+            {editing === s.id ? (
+              <input
+                ref={editRef}
+                defaultValue={s.name}
+                onClick={e => e.stopPropagation()}
+                onBlur={e => { renameSession(s.id, e.target.value); setEditing(''); }}
+                onKeyDown={e => {
+                  if (e.key === 'Enter') { renameSession(s.id, (e.target as HTMLInputElement).value); setEditing(''); }
+                  if (e.key === 'Escape') setEditing('');
+                }}
+                style={{ width: 110, background: '#13131f', color: '#cde', border: '1px solid #3a3a55', borderRadius: 4, fontSize: 13, padding: '1px 4px' }}
+              />
+            ) : (
+              <span style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>
+                {s.name}{s.projectName ? <span style={{ color: '#667', marginLeft: 5 }}>· {s.projectName}</span> : null}
+              </span>
+            )}
+            <span
+              onClick={e => { e.stopPropagation(); closeSession(s.id); }}
+              title="Close session"
+              style={{ color: '#667', fontSize: 14, lineHeight: 1, padding: '0 2px' }}
+              onMouseOver={e => (e.currentTarget.style.color = '#e88')}
+              onMouseOut={e => (e.currentTarget.style.color = '#667')}
+            >×</span>
+          </div>
+        );
+      })}
+      <button
+        onClick={() => addSession()}
+        title="New session"
+        style={{ background: 'transparent', color: '#8cf', border: '1px dashed #3a3a55', borderRadius: 6, cursor: 'pointer', fontSize: 16, lineHeight: 1, padding: '3px 9px' }}
+      >+</button>
+    </div>
+  );
+}
 
 function LogoutButton() {
 
@@ -122,49 +185,59 @@ export default function App() {
   }
 
   return (
-    <>
+    <SessionProvider>
       <div style={{ display: 'flex', flexDirection: 'column', height: '100vh' }}>
-        {/* Top navigation: one tab per tool. */}
+        {/* Top bar: brand + session tabs + logout. */}
         <header
           style={{
-            display: 'flex', alignItems: 'stretch', height: '48px', flexShrink: 0,
+            display: 'flex', alignItems: 'center', height: '46px', flexShrink: 0, gap: 14,
             background: '#13131f', borderBottom: '1px solid #2a2a3a', padding: '0 14px',
           }}
         >
-          <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18, alignSelf: 'center', marginRight: 22 }}>aimee</span>
-          <nav style={{ display: 'flex', gap: 2, flex: 1 }}>
+          <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18 }}>aimee</span>
+          <SessionTabBar />
+          <LogoutButton />
+        </header>
+        {/* Body: vertical tool nav (left) + content. */}
+        <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+          <nav
+            style={{
+              display: 'flex', flexDirection: 'column', gap: 2, width: 132, flexShrink: 0,
+              background: '#1a1a28', borderRight: '1px solid #2a2a3a', padding: '8px 6px',
+            }}
+          >
             {NAV_ITEMS.map(it => (
               <NavLink
                 key={it.route}
                 to={it.route}
                 style={({ isActive }) => ({
-                  display: 'flex', alignItems: 'center', gap: 6, padding: '0 14px',
-                  fontSize: 14, textDecoration: 'none', borderBottom: '2px solid transparent',
-                  color: isActive ? '#8cf' : '#aab', borderBottomColor: isActive ? '#8cf' : 'transparent',
+                  display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderRadius: 6,
+                  fontSize: 14, textDecoration: 'none',
+                  color: isActive ? '#cde' : '#889',
+                  background: isActive ? '#23233a' : 'transparent',
                   fontWeight: isActive ? 600 : 400,
                 })}
               >
-                <span aria-hidden>{it.icon}</span> {it.label}
+                <span aria-hidden style={{ fontSize: 16 }}>{it.icon}</span> {it.label}
               </NavLink>
             ))}
           </nav>
-          <div style={{ alignSelf: 'center' }}><LogoutButton /></div>
-        </header>
-        {/* Content area: flex:1 + minHeight:0 so pages using height:100% resolve. */}
-        <main style={{ flex: 1, minHeight: 0, overflow: 'auto', background: '#fff' }}>
-          <ErrorBoundary key={location.pathname}>
-            <Routes>
-              <Route path="/chat" element={<Chat />} />
-              <Route path="/dashboard" element={<Dashboard />} />
-              <Route path="/workflows" element={<Workflows />} />
-              <Route path="/projects" element={<Projects />} />
-              <Route path="/editor" element={<Editor />} />
-              <Route path="*" element={<Navigate to="/chat" replace />} />
-            </Routes>
-          </ErrorBoundary>
-        </main>
+          {/* Content: flex:1 + minHeight:0 so pages using height:100% resolve. */}
+          <main style={{ flex: 1, minWidth: 0, minHeight: 0, overflow: 'auto', background: '#fff' }}>
+            <ErrorBoundary key={location.pathname}>
+              <Routes>
+                <Route path="/chat" element={<Chat />} />
+                <Route path="/dashboard" element={<Dashboard />} />
+                <Route path="/workflows" element={<Workflows />} />
+                <Route path="/projects" element={<Projects />} />
+                <Route path="/editor" element={<Editor />} />
+                <Route path="*" element={<Navigate to="/chat" replace />} />
+              </Routes>
+            </ErrorBoundary>
+          </main>
+        </div>
       </div>
       <Toast />
-    </>
+    </SessionProvider>
   );
 }

--- a/frontend/src/SessionContext.tsx
+++ b/frontend/src/SessionContext.tsx
@@ -1,0 +1,130 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { ReactNode } from 'react';
+
+/* A "session" is the app-level unit of work: one chat conversation bound to one
+ * git project (plus the provider session ids that carry that conversation). It
+ * is shown as a tab at the very top of the app; the vertical tool nav (Chat /
+ * Editor / Workflows / …) all operate on the ACTIVE session's project. */
+export interface Session {
+  id: string;          // stable local id (also the React key)
+  name: string;        // tab label
+  projectRoot: string; // workspace root of the bound project ("" = none)
+  projectName: string; // project (repo) name within the root ("" = none)
+  claudeSid: string;   // claude provider session id (for --resume); reset by Clear
+  aimeeSid: string;    // aimee session id (server-side per-session state)
+  attachId: string;    // unified-presence attachment id (minted on first send)
+}
+
+interface SessionCtx {
+  sessions: Session[];
+  activeId: string;
+  active: Session | null;
+  addSession: (name?: string) => string;
+  closeSession: (id: string) => void;
+  selectSession: (id: string) => void;
+  renameSession: (id: string, name: string) => void;
+  /* Merge a partial update into one session (project binding, sids, attach id). */
+  patchSession: (id: string, patch: Partial<Session>) => void;
+}
+
+const SESSIONS_KEY = 'aimee_sessions';
+const ACTIVE_KEY = 'aimee_active_session';
+
+let _idSeq = 0;
+function newId(): string {
+  // Unique without Math.random/Date — monotonic counter + a per-load base.
+  _idSeq += 1;
+  return `s${_idSeq}-${performance.now().toString(36).replace('.', '')}`;
+}
+
+function blankSession(name: string): Session {
+  return { id: newId(), name, projectRoot: '', projectName: '', claudeSid: '', aimeeSid: '', attachId: '' };
+}
+
+function loadSessions(): Session[] {
+  try {
+    const raw = localStorage.getItem(SESSIONS_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as Partial<Session>[];
+      if (Array.isArray(parsed) && parsed.length) {
+        return parsed.map((s, i) => ({
+          id: typeof s.id === 'string' && s.id ? s.id : newId(),
+          name: typeof s.name === 'string' && s.name ? s.name : `Session ${i + 1}`,
+          projectRoot: typeof s.projectRoot === 'string' ? s.projectRoot : '',
+          projectName: typeof s.projectName === 'string' ? s.projectName : '',
+          claudeSid: typeof s.claudeSid === 'string' ? s.claudeSid : '',
+          aimeeSid: typeof s.aimeeSid === 'string' ? s.aimeeSid : '',
+          attachId: typeof s.attachId === 'string' ? s.attachId : '',
+        }));
+      }
+    }
+  } catch { /* ignore */ }
+  return [blankSession('Session 1')];
+}
+
+const Ctx = createContext<SessionCtx | null>(null);
+
+export function SessionProvider({ children }: { children: ReactNode }) {
+  const [sessions, setSessions] = useState<Session[]>(loadSessions);
+  const [activeId, setActiveId] = useState<string>(() => {
+    const stored = localStorage.getItem(ACTIVE_KEY);
+    return stored || '';
+  });
+
+  // Keep an always-valid active id.
+  useEffect(() => {
+    if (!sessions.length) return;
+    if (!sessions.some(s => s.id === activeId)) setActiveId(sessions[0].id);
+  }, [sessions, activeId]);
+
+  // Persist.
+  useEffect(() => {
+    try { localStorage.setItem(SESSIONS_KEY, JSON.stringify(sessions)); } catch { /* ignore */ }
+  }, [sessions]);
+  useEffect(() => {
+    try { localStorage.setItem(ACTIVE_KEY, activeId); } catch { /* ignore */ }
+  }, [activeId]);
+
+  const addSession = useCallback((name?: string) => {
+    const s = blankSession(name && name.trim() ? name.trim() : `Session ${Date.now() % 100000}`);
+    setSessions(prev => [...prev, s]);
+    setActiveId(s.id);
+    return s.id;
+  }, []);
+
+  const closeSession = useCallback((id: string) => {
+    setSessions(prev => {
+      const next = prev.filter(s => s.id !== id);
+      const result = next.length ? next : [blankSession('Session 1')];
+      setActiveId(cur => (cur === id ? result[0].id : cur));
+      return result;
+    });
+  }, []);
+
+  const selectSession = useCallback((id: string) => setActiveId(id), []);
+
+  const renameSession = useCallback((id: string, name: string) => {
+    const n = name.trim();
+    if (!n) return;
+    setSessions(prev => prev.map(s => (s.id === id ? { ...s, name: n } : s)));
+  }, []);
+
+  const patchSession = useCallback((id: string, patch: Partial<Session>) => {
+    setSessions(prev => prev.map(s => (s.id === id ? { ...s, ...patch } : s)));
+  }, []);
+
+  const active = useMemo(() => sessions.find(s => s.id === activeId) || sessions[0] || null, [sessions, activeId]);
+
+  const value = useMemo<SessionCtx>(() => ({
+    sessions, activeId: active?.id ?? '', active,
+    addSession, closeSession, selectSession, renameSession, patchSession,
+  }), [sessions, active, addSession, closeSession, selectSession, renameSession, patchSession]);
+
+  return <Ctx.Provider value={value}>{children}</Ctx.Provider>;
+}
+
+export function useSessions(): SessionCtx {
+  const ctx = useContext(Ctx);
+  if (!ctx) throw new Error('useSessions must be used within a SessionProvider');
+  return ctx;
+}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -3,6 +3,7 @@ import { Spinner, tokens } from '@rakuensoftware/smoothgui';
 import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolBlock, TurnSummaryCard } from './chat/ChatPrimitives';
 import { escHtml, renderMd, renderWithMentions } from './chat/markdown';
 import ProjectPicker from '../components/ProjectPicker';
+import { useSessions } from '../SessionContext';
 
 /* ---- Types ---- */
 
@@ -1388,6 +1389,16 @@ export default function Chat() {
   const [allTimeMetrics, setAllTimeMetrics] = useState<MetricRow[]>([]);
   const [promptTier, setPromptTier] = useState<'MINIMAL' | 'STANDARD' | 'EXTENDED'>('STANDARD');
   const [projectRoot, setProjectRoot] = useState(loadProjectRoot);
+  // The active top-level session owns the project this chat runs in. Mirror the
+  // session's project into the chat cwd, and start that session's conversation
+  // fresh when the session (or its project) changes.
+  const { active: activeSession, patchSession } = useSessions();
+  const activeSessionId = activeSession?.id ?? '';
+  const sessionProject = activeSession?.projectRoot ?? '';
+  useEffect(() => {
+    changeProjectRoot(sessionProject);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [activeSessionId, sessionProject]);
   const [projects, setProjects] = useState<ProjectInfo[]>([]);
   const [availableSkills, setAvailableSkills] = useState<string[]>([]);
   const [activeSkill, setActiveSkill] = useState<string>('');
@@ -1939,6 +1950,21 @@ export default function Chat() {
     });
   }
 
+  /* Clear the current conversation: drop the visible transcript and mint a fresh
+   * provider session (empty claude session id + new aimee session id) so the next
+   * turn starts clean — no resume of a stale/gone session. */
+  function clearChat() {
+    setStreamMsgs([]);
+    setTabs(prev => {
+      const next = [...prev];
+      if (next[activeIdx]) {
+        next[activeIdx] = { ...next[activeIdx], sid: '', aimeeSid: newAimeeSessionId(), attachId: undefined, messages: [] };
+      }
+      return next;
+    });
+    if (activeSession) patchSession(activeSession.id, { claudeSid: '', aimeeSid: '', attachId: '' });
+  }
+
   async function pauseWorkflow() {
     if (!workflowInfo) return;
     try {
@@ -2442,17 +2468,32 @@ export default function Chat() {
       display: 'flex', flexDirection: 'column', height: '100%',
       overflow: 'hidden', background: tokens.surface,
     }}>
-      {/* Chat session tabs removed (single conversation). This tab's project
-          space: select/clone a git project; the agent runs with that project as
-          its working directory (cwd). Per-tab persisted selection. */}
-      <ProjectPicker
-        storageKey="aimee_chat_project"
-        onChange={sel => {
-          const r = sel ? `${sel.root}/${sel.project}` : '';
-          setProjectRoot(r);
-          saveProjectRoot(r);
-        }}
-      />
+      {/* The project belongs to the active SESSION (top tab); picking one here
+          binds it to this session, and the agent runs with it as cwd. A Clear
+          button resets this conversation (fresh provider session). */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <ProjectPicker
+            key={activeSessionId}
+            storageKey={`aimee_session_project_${activeSessionId}`}
+            onChange={sel => {
+              const r = sel ? `${sel.root}/${sel.project}` : '';
+              if (activeSession) patchSession(activeSession.id, { projectRoot: r, projectName: sel?.project ?? '' });
+              else { setProjectRoot(r); saveProjectRoot(r); }
+            }}
+          />
+        </div>
+        <button
+          onClick={clearChat}
+          title="Clear this conversation and start a fresh session"
+          style={{
+            flexShrink: 0, padding: '5px 12px', fontSize: 13, cursor: 'pointer',
+            background: '#fff', color: '#666', border: '1px solid #ddd', borderRadius: 6,
+          }}
+        >
+          Clear
+        </button>
+      </div>
 
       {/* Thread bar (conversation branching) */}
       <ThreadBar

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -1,23 +1,29 @@
-import { useState } from 'react';
 import ProjectPicker from '../components/ProjectPicker';
-import type { ProjectSelection } from '../components/ProjectPicker';
+import { useSessions } from '../SessionContext';
 
-/* In-app VSCode (webchat-git WP-J), bound to this tab's selected project. The
- * per-user code-server (served by aimee-server, reverse-proxied at /vscode/) is
- * rooted at the user's workspace; selecting a project opens its folder via
- * ?folder=<root>/<project>. The browser never sees the editor's loopback port or
- * any git credential — creds stay server-side in the sealed vault. */
+/* In-app VSCode, bound to the active SESSION's project. The per-user code-server
+ * (served by aimee-server, reverse-proxied at /vscode/) is rooted at the user's
+ * workspace; the session's project opens its folder via ?folder=<root>/<project>.
+ * The browser never sees the editor's loopback port or any git credential — creds
+ * stay server-side in the sealed vault. Picking a project here binds it to the
+ * session, so Chat/Workflows see the same project. */
 export default function Editor() {
-  const [sel, setSel] = useState<ProjectSelection | null>(null);
-
-  const folder = sel ? `${sel.root}/${sel.project}` : '';
+  const { active, patchSession } = useSessions();
+  const folder = active?.projectRoot || '';
   // Re-key the iframe on folder change so code-server reloads at the new folder.
   const src = folder ? `/vscode/?folder=${encodeURIComponent(folder)}` : '/vscode/';
 
   return (
     <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
-      <ProjectPicker storageKey="aimee_editor_project" onChange={setSel} />
-      {sel ? (
+      <ProjectPicker
+        key={active?.id}
+        storageKey={`aimee_session_project_${active?.id ?? ''}`}
+        onChange={sel => {
+          const r = sel ? `${sel.root}/${sel.project}` : '';
+          if (active) patchSession(active.id, { projectRoot: r, projectName: sel?.project ?? '' });
+        }}
+      />
+      {folder ? (
         <iframe
           key={folder}
           title="VSCode"
@@ -28,7 +34,7 @@ export default function Editor() {
         />
       ) : (
         <div style={{ flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#888', fontFamily: 'system-ui' }}>
-          Select or clone a project above to open it in the editor.
+          Select or clone a project for this session to open it in the editor.
         </div>
       )}
     </div>

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback, useRef } from "react";
 import { Panel, Badge, Spinner } from "@rakuensoftware/smoothgui";
 import ProjectPicker from "../components/ProjectPicker";
 import type { ProjectSelection } from "../components/ProjectPicker";
+import { useSessions } from "../SessionContext";
 
 /* ---- API types (mirror /v1/workflow/* envelopes) ---- */
 
@@ -322,7 +323,7 @@ export default function Workflows() {
   // This tab's selected project (per-tab project space). Held so the workflow
   // context can scope to it; execution-in-project flows through a chat session's
   // cwd today, so this primarily persists the selection + offers clone here.
-  const [, setWfProject] = useState<ProjectSelection | null>(null);
+  const { active: wfSession, patchSession: wfPatch } = useSessions();
   const drag = useRef<{ id: string; dx: number; dy: number } | null>(null);
 
   const refreshLists = useCallback(() => {
@@ -541,7 +542,14 @@ export default function Workflows() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      <ProjectPicker storageKey="aimee_workflows_project" onChange={setWfProject} />
+      <ProjectPicker
+        key={wfSession?.id}
+        storageKey={`aimee_session_project_${wfSession?.id ?? ""}`}
+        onChange={(sel: ProjectSelection | null) => {
+          const r = sel ? `${sel.root}/${sel.project}` : "";
+          if (wfSession) wfPatch(wfSession.id, { projectRoot: r, projectName: sel?.project ?? "" });
+        }}
+      />
       <div
         style={{
           display: "flex",


### PR DESCRIPTION
Restructures the webchat shell so a **session** (chat + its project) is the unit of work, per the confirmed design (session owns the project).

- **`SessionContext`** — app-level session list; each session owns a project + the chat provider session ids. localStorage-persisted.
- **`App.tsx`** — tools move to a **vertical left nav**; the **top bar is session tabs** (add / close / select / double-click-rename; project name shown on the tab).
- **Chat** — runs in the active session's project; the picker binds the project to the session. New **Clear** button resets the conversation (fresh provider session) — also sidesteps a stale `--resume`.
- **Editor / Workflows** — open / act on the active session's project; picking a project in any tool reflects everywhere.

Type-checks + bundles clean. **Known follow-up:** per-session conversation *history* isn't persisted across switches yet (switching gives that session's project + a fresh chat); the structure is in place to add it. Will verify headless on .254 after deploy.
