### PR TITLE
feat(webchat): runtime settings panel (autonomous mode, etc.)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import Workflows from './pages/Workflows';
 import Projects from './pages/Projects';
 import Editor from './pages/Editor';
 import { SessionProvider, useSessions } from './SessionContext';
+import SettingsPanel from './components/SettingsPanel';
 
 // A render error in any page used to throw past the root and unmount the whole
 // app, leaving a blank screen (the AppShell, nav, and other pages vanished too).
@@ -196,6 +197,7 @@ export default function App() {
         >
           <span style={{ color: '#8cf', fontWeight: 700, fontSize: 18 }}>aimee</span>
           <SessionTabBar />
+          <SettingsPanel />
           <LogoutButton />
         </header>
         {/* Body: vertical tool nav (left) + content. */}

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,0 +1,110 @@
+import { useEffect, useRef, useState } from 'react';
+
+/* A gear button in the top bar that opens a dropdown of aimee runtime settings
+ * (autonomous mode, etc.). Reads/writes the allowlisted server config via
+ * /api/settings; changes take effect on the next turn. */
+
+interface Field {
+  key: string;
+  label: string;
+  type: string; // "bool" | "int"
+  help?: string;
+  value: unknown;
+}
+
+export default function SettingsPanel() {
+  const [open, setOpen] = useState(false);
+  const [fields, setFields] = useState<Field[]>([]);
+  const [busy, setBusy] = useState('');
+  const [err, setErr] = useState('');
+  const [loaded, setLoaded] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  function load() {
+    fetch('/api/settings', { headers: { 'X-CSRF-Token': window._csrf || '' } })
+      .then(r => r.json())
+      .then((d: { fields?: Field[] }) => { setFields(d.fields || []); setLoaded(true); })
+      .catch(() => setErr('Failed to load settings'));
+  }
+
+  useEffect(() => { if (open && !loaded) load(); }, [open, loaded]);
+
+  // Close on outside click / Escape.
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    document.addEventListener('mousedown', onDoc);
+    document.addEventListener('keydown', onKey);
+    return () => { document.removeEventListener('mousedown', onDoc); document.removeEventListener('keydown', onKey); };
+  }, [open]);
+
+  async function setField(key: string, value: unknown) {
+    setBusy(key); setErr('');
+    const prev = fields;
+    setFields(p => p.map(f => (f.key === key ? { ...f, value } : f))); // optimistic
+    try {
+      const r = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window._csrf || '' },
+        body: JSON.stringify({ key, value }),
+      });
+      if (!r.ok) { setErr(`Failed to set ${key}`); setFields(prev); }
+    } catch {
+      setErr(`Failed to set ${key}`); setFields(prev);
+    } finally {
+      setBusy('');
+    }
+  }
+
+  return (
+    <div ref={ref} style={{ position: 'relative' }}>
+      <button
+        onClick={() => setOpen(o => !o)}
+        title="Runtime settings"
+        style={{ background: 'transparent', border: 'none', color: open ? '#8cf' : '#aab', cursor: 'pointer', fontSize: 18, padding: '0 4px', lineHeight: 1 }}
+      >
+        ⚙
+      </button>
+      {open && (
+        <div
+          style={{
+            position: 'absolute', top: '100%', right: 0, marginTop: 8, width: 300, zIndex: 50,
+            background: '#1a1a28', border: '1px solid #2a2a3a', borderRadius: 8, padding: '12px 14px',
+            boxShadow: '0 8px 24px rgba(0,0,0,0.45)',
+          }}
+        >
+          <div style={{ fontWeight: 600, fontSize: 13, marginBottom: 8, color: '#cde' }}>Runtime settings</div>
+          {err && <div style={{ color: '#e88', fontSize: 12, marginBottom: 6 }}>{err}</div>}
+          {!loaded && <div style={{ color: '#889', fontSize: 12 }}>Loading…</div>}
+          {loaded && fields.length === 0 && <div style={{ color: '#889', fontSize: 12 }}>No settings available.</div>}
+          {fields.map(f => (
+            <div key={f.key} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 10, padding: '6px 0' }}>
+              <div style={{ minWidth: 0 }}>
+                <div style={{ fontSize: 13, color: '#dde' }}>{f.label}</div>
+                {f.help && <div style={{ fontSize: 11, color: '#778' }}>{f.help}</div>}
+              </div>
+              {f.type === 'bool' ? (
+                <input
+                  type="checkbox"
+                  checked={!!f.value}
+                  disabled={busy === f.key}
+                  onChange={e => setField(f.key, e.target.checked)}
+                  style={{ width: 16, height: 16, flexShrink: 0, cursor: 'pointer' }}
+                />
+              ) : (
+                <input
+                  type="number"
+                  value={typeof f.value === 'number' ? f.value : 0}
+                  disabled={busy === f.key}
+                  onChange={e => setField(f.key, parseInt(e.target.value || '0', 10) || 0)}
+                  style={{ width: 64, flexShrink: 0, background: '#13131f', color: '#cde', border: '1px solid #3a3a55', borderRadius: 4, padding: '2px 4px', fontSize: 13 }}
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -144,6 +144,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/chat/personas", s.requireAuth(s.handleChatPersonas))
 	mux.HandleFunc("/api/chat/personas/", s.requireAuth(s.handleChatPersonaItem))
 	mux.HandleFunc("/api/chat/persona", s.requireAuth(s.handleChatPersona))
+	mux.HandleFunc("/api/settings", s.requireAuth(s.handleSettings))
 	mux.HandleFunc("/api/chat/attach", s.requireAuth(s.handleChatAttach))
 	mux.HandleFunc("/api/chat/detach", s.requireAuth(s.handleChatDetach))
 	mux.HandleFunc("/api/chat/session-events", s.requireAuth(s.handleChatSessionEvents))

--- a/webchat/settings.go
+++ b/webchat/settings.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// Curated, safe-to-toggle aimee runtime settings exposed in the webchat Settings
+// UI. This is an ALLOWLIST: the browser may only read/write these keys, never
+// arbitrary/sensitive config (db2_url, *_key_cmd, endpoints, …). Each maps 1:1
+// to an aimee config field reached via /v1/config/{get,set}; changes persist to
+// aimee.yaml and take effect on the next turn (the server reloads config per
+// request).
+type settingField struct {
+	Key   string `json:"key"`
+	Label string `json:"label"`
+	Type  string `json:"type"` // "bool" | "int"
+	Help  string `json:"help,omitempty"`
+}
+
+var settingsAllow = []settingField{
+	{Key: "autonomous", Label: "Autonomous mode", Type: "bool",
+		Help: "Agent acts without per-action confirmation."},
+	{Key: "cross_verify", Label: "Cross-verify", Type: "bool",
+		Help: "Double-check work before reporting done."},
+	{Key: "ecomode", Label: "Eco mode", Type: "bool",
+		Help: "Favor cheaper / shorter reasoning."},
+	{Key: "reasoning_cap_enabled", Label: "Cap reasoning by complexity", Type: "bool",
+		Help: "Lower reasoning effort on simple turns."},
+	{Key: "max_iterations", Label: "Max iterations", Type: "int",
+		Help: "Tool-use loop ceiling per turn (0 = default)."},
+}
+
+func settingAllowed(key string) bool {
+	for _, f := range settingsAllow {
+		if f.Key == key {
+			return true
+		}
+	}
+	return false
+}
+
+// handleSettings serves the webchat Settings panel against aimee runtime config.
+//
+//	GET  /api/settings              -> {"fields":[{key,label,type,help,value}, ...]}
+//	POST /api/settings {key,value}  -> set one allowlisted key
+func (s *server) handleSettings(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+
+	switch r.Method {
+	case http.MethodGet:
+		type outField struct {
+			settingField
+			Value interface{} `json:"value"`
+		}
+		out := make([]outField, 0, len(settingsAllow))
+		for _, f := range settingsAllow {
+			body, _ := json.Marshal(map[string]string{"key": f.Key})
+			st, data, err := s.v1Request(ctx, http.MethodPost, "/v1/config/get", body)
+			var val interface{}
+			if err == nil && st == http.StatusOK {
+				var d struct {
+					Value interface{} `json:"value"`
+				}
+				if json.Unmarshal(data, &d) == nil {
+					val = d.Value
+				}
+			}
+			out = append(out, outField{settingField: f, Value: val})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"fields": out})
+
+	case http.MethodPost:
+		var req struct {
+			Key   string      `json:"key"`
+			Value interface{} `json:"value"`
+		}
+		if json.NewDecoder(r.Body).Decode(&req) != nil || req.Key == "" {
+			writeJSONError(w, http.StatusBadRequest, "key required")
+			return
+		}
+		if !settingAllowed(req.Key) {
+			writeJSONError(w, http.StatusForbidden, "setting not allowed")
+			return
+		}
+		body, _ := json.Marshal(map[string]interface{}{"key": req.Key, "value": req.Value})
+		st, data, err := s.v1Request(ctx, http.MethodPost, "/v1/config/set", body)
+		if err != nil {
+			writeJSONError(w, http.StatusServiceUnavailable, "aimee-server unavailable")
+			return
+		}
+		w.WriteHeader(st)
+		_, _ = w.Write(data)
+
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}


### PR DESCRIPTION
Adds a ⚙ **Settings** dropdown in the top bar to control aimee runtime settings from the GUI.

- **`webchat/settings.go`** — `GET`/`POST /api/settings` over an **allowlist** of curated keys (`autonomous`, `cross_verify`, `ecomode`, `reasoning_cap_enabled`, `max_iterations`). The browser can never touch sensitive config (db2_url, `*_key_cmd`, endpoints). Proxies `/v1/config/{get,set}`.
- **`SettingsPanel`** — gear in the top bar; bools → toggles, ints → number inputs; optimistic with revert-on-failure.

Changes persist to `aimee.yaml` and take effect **next turn** (server reloads config per request — verified `server_compute.c` does `config_load` per request). Go build/vet + tsc/vite clean. Easy to extend the allowlist with more settings.