### PR TITLE
fix(memory/kb): key db2 index + memory scope by repo identity, not checkout path

### DIFF
--- a/scripts/migrations/2026-06-rekey-project-identity.py
+++ b/scripts/migrations/2026-06-rekey-project-identity.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Re-key the shared db2/aimee-kb index from checkout-path basenames to canonical
+repository identity.
+
+Companion migration to the code change that routes every db2 scope/index key
+through workspace_repo_identity() (canonical remote URL, e.g.
+https://github.com/owner/repo, or local:<root> for remote-less repos) instead of
+the local checkout's directory basename. Existing rows were written under the old
+basename keys and stay orphaned until re-keyed here.
+
+Tables re-keyed (all in db2 / Postgres):
+  - projects(name, workspace)            name basename -> identity, workspace -> org parent
+  - kb_documents(project)                project basename -> identity
+  - memory_scopes(scope_value)           scope_type='project'  : basename -> identity
+                                         scope_type='workspace': old ws label -> org parent
+  - memory_workspaces(workspace)         old ws label -> org parent
+
+Identity is derived from each project's stored `root` via `git -C <root> remote
+get-url origin`, normalized identically to src/util_url.c. The migration must run
+ON THE KB HOST, where the project roots exist on disk and db2 creds are present.
+
+Safety:
+  * DRY-RUN BY DEFAULT — prints the planned UPDATEs and a per-project mapping.
+    Nothing is written without --apply.
+  * --apply runs everything in a SINGLE TRANSACTION (all-or-nothing).
+  * Idempotent: a row already keyed by an identity (https://... or local:...) is
+    left untouched, so re-running is safe.
+  * Take a db2 snapshot/backup and run a dry-run first. Review the mapping —
+    especially any project whose root has no git remote (becomes local:<root>)
+    or could not be resolved (skipped, reported).
+
+Usage:
+  AIMEE_DB2_URL=postgres://... python3 2026-06-rekey-project-identity.py            # dry run
+  AIMEE_DB2_URL=postgres://... python3 2026-06-rekey-project-identity.py --apply    # commit
+  python3 2026-06-rekey-project-identity.py --dsn "postgres://..." [--apply]
+
+Requires psycopg2 (or psycopg). If neither is installed, falls back to emitting a
+.sql plan file you can review and run with psql.
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+# Hosts whose path segments route case-insensitively — must match
+# util_url_host_is_case_insensitive() in src/util_url.c.
+CASE_INSENSITIVE_HOSTS = ("github.com", "gitlab.com", "bitbucket.org")
+CASE_INSENSITIVE_SUFFIXES = (".github.com", ".gitlab.com", ".bitbucket.org")
+
+
+def host_is_case_insensitive(host: str) -> bool:
+    if not host:
+        return False
+    if host in CASE_INSENSITIVE_HOSTS:
+        return True
+    return any(host.endswith(s) for s in CASE_INSENSITIVE_SUFFIXES)
+
+
+def normalize_url(url: str):
+    """Port of util_url_normalize(): any transport/case -> https://host/owner/repo.
+    Returns None for empty/unrecognized/malformed input."""
+    if not url:
+        return None
+    proto = url.find("://")
+    colon = url.find(":")
+    if proto != -1:
+        scheme = url[:proto].lower()
+        if scheme not in ("https", "http", "ssh", "git"):
+            return None
+        authority = url[proto + 3:]
+        slash = authority.find("/")
+        if slash <= 0:
+            return None  # must have a host before the path
+        at = authority.find("@")
+        host_start = at + 1 if (at != -1 and at < slash) else 0
+        host = authority[host_start:slash]
+        path = authority[slash + 1:]
+    elif colon != -1:
+        # scp-like: user@host:path (must have '@' before ':')
+        at = url.find("@")
+        if at == -1 or at > colon:
+            return None
+        host = url[at + 1:colon]
+        path = url[colon + 1:]
+    else:
+        return None
+
+    host = host.split(":", 1)[0].lower()  # drop port, lowercase
+    if not host:
+        return None
+
+    # Collapse '//' runs, optional case-lower, strip trailing '/', strip one '.git'.
+    segs = [s for s in path.split("/") if s != ""]
+    path = "/".join(segs)
+    if host_is_case_insensitive(host):
+        path = path.lower()
+    if path.endswith(".git"):
+        path = path[:-4]
+    if not path:
+        return None
+    return f"https://{host}/{path}"
+
+
+def workspace_parent(identity: str):
+    """Port of util_url_workspace_parent(): https://host/a/b -> https://host/a.
+    Returns None when there is no parent (host root, local:, non-https)."""
+    if not identity or identity.startswith("local:") or not identity.startswith("https://"):
+        return None
+    rest = identity[len("https://"):]
+    first = rest.find("/")
+    last = rest.rfind("/")
+    if first == -1 or last <= first:
+        return None  # already host/leaf
+    return identity[: len("https://") + last]
+
+
+def repo_identity(root: str):
+    """Mirror workspace_repo_identity(): (project_identity, workspace_identity).
+    Returns (None, None) if root missing/unreadable."""
+    if not root or not os.path.isdir(root):
+        return (None, None)
+    try:
+        out = subprocess.run(
+            ["git", "-C", root, "remote", "get-url", "origin"],
+            capture_output=True, text=True, timeout=15,
+        )
+        remote = out.stdout.strip() if out.returncode == 0 else ""
+    except Exception:
+        remote = ""
+    identity = normalize_url(remote) if remote else None
+    if not identity:
+        identity = f"local:{os.path.realpath(root)}"
+    return (identity, workspace_parent(identity) or identity)
+
+
+def is_already_identity(name: str) -> bool:
+    return bool(name) and (name.startswith("https://") or name.startswith("local:"))
+
+
+def build_plan(rows):
+    """rows: list of (id, name, root, workspace). Returns (statements, mapping, skipped)."""
+    stmts, mapping, skipped = [], [], []
+    for pid, name, root, ws in rows:
+        if is_already_identity(name):
+            continue  # idempotent: leave identity-keyed rows alone
+        identity, org = repo_identity(root)
+        if identity is None:
+            skipped.append((pid, name, root, "root missing/unreadable on this host"))
+            continue
+        mapping.append((name, identity, ws, org))
+        # Order matters only for readability; all run in one transaction.
+        stmts.append(("kb_documents",
+                      "UPDATE kb_documents SET project=%s WHERE project=%s", (identity, name)))
+        stmts.append(("memory_scopes(project)",
+                      "UPDATE memory_scopes SET scope_value=%s "
+                      "WHERE scope_type='project' AND scope_value=%s", (identity, name)))
+        if ws:
+            stmts.append(("memory_scopes(workspace)",
+                          "UPDATE memory_scopes SET scope_value=%s "
+                          "WHERE scope_type='workspace' AND scope_value=%s", (org, ws)))
+            stmts.append(("memory_workspaces",
+                          "UPDATE memory_workspaces SET workspace=%s WHERE workspace=%s", (org, ws)))
+        stmts.append(("projects",
+                      "UPDATE projects SET name=%s, workspace=%s WHERE id=%s", (identity, org, pid)))
+    return stmts, mapping, skipped
+
+
+def render_sql(stmts) -> str:
+    def lit(v):
+        return "'" + str(v).replace("'", "''") + "'"
+    lines = ["BEGIN;"]
+    for _, sql, params in stmts:
+        rendered = sql
+        for p in params:
+            rendered = rendered.replace("%s", lit(p), 1)
+        lines.append(rendered + ";")
+    lines.append("COMMIT;")
+    return "\n".join(lines)
+
+
+def connect(dsn):
+    try:
+        import psycopg2  # type: ignore
+        return ("psycopg2", psycopg2.connect(dsn))
+    except ImportError:
+        pass
+    try:
+        import psycopg  # type: ignore
+        return ("psycopg", psycopg.connect(dsn))
+    except ImportError:
+        return (None, None)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--dsn", default=os.environ.get("AIMEE_DB2_URL", ""),
+                    help="Postgres conninfo (default: $AIMEE_DB2_URL)")
+    ap.add_argument("--apply", action="store_true", help="commit changes (default: dry run)")
+    ap.add_argument("--sql-out", default="", help="write the plan as a .sql file and exit")
+    args = ap.parse_args()
+
+    if not args.dsn:
+        sys.exit("error: no DSN — set AIMEE_DB2_URL or pass --dsn")
+
+    driver, conn = connect(args.dsn)
+    if conn is None:
+        sys.exit("error: no psycopg2/psycopg installed. Re-run with --sql-out plan.sql on a host "
+                 "that can read the projects table, then apply with psql.")
+
+    cur = conn.cursor()
+    cur.execute("SELECT id, name, root, COALESCE(workspace,'') FROM projects ORDER BY id")
+    rows = cur.fetchall()
+    stmts, mapping, skipped = build_plan(rows)
+
+    print(f"# {len(rows)} projects; {len(mapping)} to re-key; "
+          f"{len(rows) - len(mapping) - len(skipped)} already identity-keyed; "
+          f"{len(skipped)} skipped (driver={driver})\n")
+    for old, new, ws, org in mapping:
+        print(f"  project  {old!r:40} -> {new}")
+        if ws:
+            print(f"  workspace{ws!r:40} -> {org}")
+    for pid, name, root, why in skipped:
+        print(f"  SKIP id={pid} name={name!r} root={root!r}: {why}")
+
+    if args.sql_out:
+        with open(args.sql_out, "w") as f:
+            f.write(render_sql(stmts) + "\n")
+        print(f"\nwrote {len(stmts)} statements to {args.sql_out}")
+        return
+
+    if not args.apply:
+        print(f"\nDRY RUN — {len(stmts)} UPDATE statements not executed. Re-run with --apply.")
+        return
+
+    try:
+        for _, sql, params in stmts:
+            cur.execute(sql, params)
+        conn.commit()
+        print(f"\nAPPLIED {len(stmts)} statements in one transaction.")
+    except Exception as e:
+        conn.rollback()
+        sys.exit(f"\nROLLED BACK on error: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cmd_hooks_scope.c
+++ b/src/cmd_hooks_scope.c
@@ -94,6 +94,13 @@ void hook_scope_labels_for_cwd(const config_t *cfg, const char *cwd, char *works
    if (!cwd || !cwd[0])
       return;
 
+   /* Path-independent repository identity, kept consistent with the recall side
+    * (memory_scope_labels_for_cwd) so scope tags written here match on lookup
+    * across clones/machines. Falls through to the legacy workspace/basename
+    * labels below when cwd is not inside a resolvable git repo. */
+   if (workspace_repo_identity(cwd, project_out, project_len, workspace_out, workspace_len) == 0)
+      return;
+
    if (workspace_out && workspace_len > 0 && cfg)
    {
       for (int i = 0; i < cfg->workspace_count; i++)

--- a/src/headers/workspace.h
+++ b/src/headers/workspace.h
@@ -22,6 +22,30 @@ char *workspace_build_context_from_config(const config_t *cfg);
  * workspace containing cwd, then cwd itself. Returns 0 on success. */
 int workspace_active_root(const config_t *cfg, const char *cwd, char *out, size_t out_len);
 
+/* Resolve a path-independent repository identity for memory scoping.
+ *
+ * For a git repo this yields the canonical remote identity rather than the
+ * local checkout path, so two clones of the same repo on different machines
+ * resolve to the same scope (the cross-environment recall bug otherwise):
+ *   project_out   = canonical repo URL  (https://host/owner/repo) or
+ *                   local:<repo-root> for a repo with no usable remote.
+ *   workspace_out = the repo's org/namespace parent (https://host/owner) when
+ *                   it has one, else the repo identity itself.
+ * Either out pointer may be NULL. Returns 0 when a repo identity was resolved,
+ * -1 otherwise (cwd is not inside a resolvable git repo) — callers then keep
+ * their legacy path/basename labels. */
+int workspace_repo_identity(const char *cwd, char *project_out, size_t project_len,
+                            char *workspace_out, size_t workspace_len);
+
+/* Canonical index keys for a discovered repo root: the project name and its
+ * workspace, used to key the shared db2 index (projects.name, kb_documents.project)
+ * and the ingest queue. Prefers the repository identity (workspace_repo_identity)
+ * so a repo indexed from any machine resolves to one project; falls back to the
+ * directory basename and `fallback_workspace` for non-repo roots. Always writes
+ * both outputs (never fails). */
+void workspace_repo_index_keys(const char *root, const char *fallback_workspace, char *name_out,
+                               size_t name_len, char *ws_out, size_t ws_len);
+
 /* Resolve a proposal path: try path as is, then search docs/proposals/ subdirectories.
  * Returns newly allocated absolute path string, or NULL if not found. Caller frees. */
 char *resolve_proposal_path(const char *proposal);

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -85,9 +85,11 @@ static void kbiw_enqueue_all(kb_service_ctx_t *ctx)
       int n = workspace_discover_projects(cfg.workspaces[w], 3, projects, MAX_DISCOVERED_PROJECTS);
       for (int i = 0; i < n; i++)
       {
-         const char *pname = strrchr(projects[i], '/');
-         pname = pname ? pname + 1 : projects[i];
-         db2_kb_ingest_queue_enqueue(pname, projects[i], cfg.workspaces[w], 0);
+         char pname[256];
+         char pws[256];
+         workspace_repo_index_keys(projects[i], cfg.workspaces[w], pname, sizeof(pname), pws,
+                                   sizeof(pws));
+         db2_kb_ingest_queue_enqueue(pname, projects[i], pws, 0);
          total++;
       }
    }
@@ -346,9 +348,11 @@ static void *kbiw_watch_thread(void *arg)
                continue;
             if (now - watches[j].last_queued < debounce)
                break;
-            const char *pname = strrchr(watches[j].root, '/');
-            pname = pname ? pname + 1 : watches[j].root;
-            db2_kb_ingest_queue_enqueue(pname, watches[j].root, watches[j].workspace, 0);
+            char pname[256];
+            char pws[256];
+            workspace_repo_index_keys(watches[j].root, watches[j].workspace, pname, sizeof(pname),
+                                      pws, sizeof(pws));
+            db2_kb_ingest_queue_enqueue(pname, watches[j].root, pws, 0);
             watches[j].last_queued = now;
             kb_worker_notify(ctx);
             break;

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -119,15 +119,17 @@ int kb_handle_ingest(int fd, cJSON *req)
       int n = workspace_discover_projects(ws_j->valuestring, 3, projects, MAX_DISCOVERED_PROJECTS);
       for (int i = 0; i < n; i++)
       {
-         const char *pname = strrchr(projects[i], '/');
-         pname = pname ? pname + 1 : projects[i];
+         char pname[256];
+         char pws[256];
+         workspace_repo_index_keys(projects[i], ws_j->valuestring, pname, sizeof(pname), pws,
+                                   sizeof(pws));
          if (force)
          {
             db2_kb_service_clear_project(pname);
             pgvec_kb_vector_delete_project(pname);
             db2_kb_file_index_delete_project(pname);
          }
-         db2_kb_ingest_queue_enqueue(pname, projects[i], ws_j->valuestring, force);
+         db2_kb_ingest_queue_enqueue(pname, projects[i], pws, force);
          total_queued++;
       }
    }
@@ -139,15 +141,17 @@ int kb_handle_ingest(int fd, cJSON *req)
              workspace_discover_projects(cfg.workspaces[w], 3, projects, MAX_DISCOVERED_PROJECTS);
          for (int i = 0; i < n; i++)
          {
-            const char *pname = strrchr(projects[i], '/');
-            pname = pname ? pname + 1 : projects[i];
+            char pname[256];
+            char pws[256];
+            workspace_repo_index_keys(projects[i], cfg.workspaces[w], pname, sizeof(pname), pws,
+                                      sizeof(pws));
             if (force)
             {
                db2_kb_service_clear_project(pname);
                pgvec_kb_vector_delete_project(pname);
                db2_kb_file_index_delete_project(pname);
             }
-            db2_kb_ingest_queue_enqueue(pname, projects[i], cfg.workspaces[w], force);
+            db2_kb_ingest_queue_enqueue(pname, projects[i], pws, force);
             total_queued++;
          }
       }

--- a/src/memory_assemble.c
+++ b/src/memory_assemble.c
@@ -170,6 +170,27 @@ static void memory_scope_labels_for_cwd(const char *workspace_hint, char *worksp
    if (!getcwd(cwd, sizeof(cwd)))
       cwd[0] = '\0';
 
+   /* Prefer a path-independent repository identity (canonical remote URL) so
+    * recall matches across clones/machines instead of keying on the local
+    * checkout path. Falls through to the legacy path/basename labels below when
+    * cwd is not inside a resolvable git repo. An explicit workspace_hint still
+    * wins for the workspace label. */
+   if (cwd[0])
+   {
+      char repo_project[MAX_PATH_LEN];
+      char repo_workspace[MAX_PATH_LEN];
+      if (workspace_repo_identity(cwd, repo_project, sizeof(repo_project), repo_workspace,
+                                  sizeof(repo_workspace)) == 0)
+      {
+         if (workspace_out && workspace_len > 0)
+            snprintf(workspace_out, workspace_len, "%s",
+                     (workspace_hint && workspace_hint[0]) ? workspace_hint : repo_workspace);
+         if (project_out && project_len > 0)
+            snprintf(project_out, project_len, "%s", repo_project);
+         return;
+      }
+   }
+
    if (!workspace || !workspace[0])
    {
       workspace = cwd;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -606,7 +606,7 @@ $(TESTPREFIX)/unit-test-memory: $(OBJDIR)/tests/test_memory.o $(OBJDIR)/kb/kb_ba
                         $(OBJDIR)/extractors_extra.o $(OBJDIR)/extractors_new_langs.o \
                         $(OBJDIR)/kb/kb.o $(OBJDIR)/kb/kb_neardup.o $(OBJDIR)/kb/kb_conventions.o $(OBJDIR)/kb/kb_mdl.o \
                         $(OBJDIR)/db2/feature_rows.o \
-                        $(OBJDIR)/workspace.o $(DB1_OBJS) \
+                        $(OBJDIR)/workspace.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(DB1_OBJS) \
                         $(OBJDIR)/render.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_memory_cases_a.inc
+++ b/src/tests/test_memory_cases_a.inc
@@ -858,21 +858,24 @@ static void test_context_budget_prefers_project_scope_over_global_l5(void)
 
    assert(getcwd(cwd, sizeof(cwd)) != NULL);
    {
-      /* Project label resolves from the repo root (workspace_active_root)
-       * rather than raw cwd so tests pass regardless of which subdirectory
-       * they run from.  Matches the convention used by
-       * memory_scope_labels_for_cwd() in production. */
-      char project_root[MAX_PATH_LEN];
-      if (workspace_active_root(NULL, cwd, project_root, sizeof(project_root)) == 0 &&
-          project_root[0])
+      /* Project label keys on the repository identity (canonical remote URL)
+       * so recall matches across clones/machines, with a repo-root basename
+       * fallback for remote-less roots.  Mirrors memory_scope_labels_for_cwd()
+       * in production. */
+      if (workspace_repo_identity(cwd, project, sizeof(project), NULL, 0) != 0 || !project[0])
       {
-         const char *slash = strrchr(project_root, '/');
-         snprintf(project, sizeof(project), "%s", slash ? slash + 1 : project_root);
-      }
-      else
-      {
-         const char *slash = strrchr(cwd, '/');
-         snprintf(project, sizeof(project), "%s", slash ? slash + 1 : cwd);
+         char project_root[MAX_PATH_LEN];
+         if (workspace_active_root(NULL, cwd, project_root, sizeof(project_root)) == 0 &&
+             project_root[0])
+         {
+            const char *slash = strrchr(project_root, '/');
+            snprintf(project, sizeof(project), "%s", slash ? slash + 1 : project_root);
+         }
+         else
+         {
+            const char *slash = strrchr(cwd, '/');
+            snprintf(project, sizeof(project), "%s", slash ? slash + 1 : cwd);
+         }
       }
    }
 

--- a/src/tests/test_workspace_memory.c
+++ b/src/tests/test_workspace_memory.c
@@ -442,8 +442,20 @@ static void test_ws_context_prefers_project_scope_when_available(void)
    char project_root[MAX_PATH_LEN];
    assert(getcwd(cwd, sizeof(cwd)) != NULL);
    assert(workspace_active_root(NULL, cwd, project_root, sizeof(project_root)) == 0);
-   const char *slash = strrchr(project_root, '/');
-   const char *project_name = slash ? slash + 1 : project_root;
+   /* Project scope keys on the repo identity (canonical remote) with a
+    * basename fallback, matching memory_scope_labels_for_cwd() in production. */
+   char project_buf[MAX_PATH_LEN];
+   const char *project_name;
+   if (workspace_repo_identity(cwd, project_buf, sizeof(project_buf), NULL, 0) == 0 &&
+       project_buf[0])
+   {
+      project_name = project_buf;
+   }
+   else
+   {
+      const char *slash = strrchr(project_root, '/');
+      project_name = slash ? slash + 1 : project_root;
+   }
 
    memory_insert(TIER_L2, KIND_FACT, "scope-order-global", "scope order global", 0.9, "s1",
                  &global_mem);

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -8,6 +8,8 @@
 #include "headers/config.h"
 #include "headers/platform_path.h"
 #include "headers/util.h"
+#include "report_enrichment.h" /* report_subject_from_project_root — canonical repo identity */
+#include "util_url.h"          /* util_url_workspace_parent — org/namespace parent */
 #include <dirent.h>
 #include <stdint.h>
 #include <errno.h>
@@ -179,6 +181,55 @@ int workspace_active_root(const config_t *cfg, const char *cwd, char *out, size_
    }
 
    return -1;
+}
+
+int workspace_repo_identity(const char *cwd, char *project_out, size_t project_len,
+                            char *workspace_out, size_t workspace_len)
+{
+   if (project_out && project_len > 0)
+      project_out[0] = '\0';
+   if (workspace_out && workspace_len > 0)
+      workspace_out[0] = '\0';
+   if (!cwd || !cwd[0])
+      return -1;
+
+   /* Canonical repo identity: reads `origin` and normalizes any transport/case
+    * to https://host/owner/repo; a repo with no usable remote falls back to a
+    * stable local:<repo-root> subject. */
+   report_subject_t subj;
+   if (report_subject_from_project_root(cwd, &subj) != 0 || !subj.id[0])
+      return -1;
+
+   /* Project scope = the repository itself, not its checkout path, so clones on
+    * different machines share one scope. */
+   if (project_out && project_len > 0)
+      snprintf(project_out, project_len, "%s", subj.id);
+
+   /* Workspace scope = the org/namespace parent (https://host/owner) when the
+    * identity has one; local-only repos have no parent, so scope the workspace
+    * to the repo identity itself rather than reintroducing a machine path. */
+   if (workspace_out && workspace_len > 0)
+   {
+      char *parent = util_url_workspace_parent(subj.id);
+      snprintf(workspace_out, workspace_len, "%s", parent ? parent : subj.id);
+      free(parent);
+   }
+   return 0;
+}
+
+void workspace_repo_index_keys(const char *root, const char *fallback_workspace, char *name_out,
+                               size_t name_len, char *ws_out, size_t ws_len)
+{
+   if (workspace_repo_identity(root, name_out, name_len, ws_out, ws_len) == 0 && name_out &&
+       name_out[0])
+      return;
+
+   /* Non-repo root: legacy basename project key + the configured workspace. */
+   const char *base = root ? strrchr(root, '/') : NULL;
+   if (name_out && name_len > 0)
+      snprintf(name_out, name_len, "%s", base ? base + 1 : (root ? root : ""));
+   if (ws_out && ws_len > 0)
+      snprintf(ws_out, ws_len, "%s", fallback_workspace ? fallback_workspace : "");
 }
 
 /* --- context generation --- */


### PR DESCRIPTION
## Problem

The shared **db2/aimee-kb** store keyed both memory scopes and the code/doc index by the **local checkout's directory basename** (project) and **absolute path** (workspace), derived from the cwd. Two clones of the same repo on different machines therefore resolved to different scope keys — so memory/index built in one environment did not surface in another (the cross-environment recall bug).

## Fix

Key against the **repository identity** instead. New `workspace_repo_identity()` resolves the canonical remote (`https://host/owner/repo` via `report_subject_from_project_root`, or `local:<root>` for remote-less repos) and the org parent (`util_url_workspace_parent`); `workspace_repo_index_keys()` wraps it with a basename fallback for non-repo roots. Every db2 key now flows through them:

- **memory scope** (`memory_scopes`): `memory_scope_labels_for_cwd` (recall), `hook_scope_labels_for_cwd` (store)
- **code/doc index** (`projects.name`, `kb_documents.project`): both ingest enqueue sites (`kb_ingest_workers.c`) + both clear/enqueue sites (`kb_service_kb.c`)

Non-repo roots keep the legacy basename/path labels, so behavior is unchanged outside git repos.

## Migration

`scripts/migrations/2026-06-rekey-project-identity.py` re-keys existing basename rows across `projects`, `kb_documents`, `memory_scopes`, `memory_workspaces`. Dry-run by default, single transaction, idempotent. Normalization logic unit-tested; must run on the kb host (needs project roots + db2 creds) after a snapshot.

## Verification

- URL-normalization parity (scp/ssh/https, case-folding, `.git`, gitlab subgroups, `local:`) unit-tested locally.
- **Not built locally** (no toolchain in the authoring env) — relying on CI (`make all server` + unit-tests with the Postgres sidecar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
