### PR TITLE
feat(wfe): autonomous development Phase A — real delegate + forge seams

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -196,7 +196,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 114 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 115 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -387,7 +387,7 @@ The binaries read 114 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`
+`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/docs/proposals/pending/full-autonomous-development.md
+++ b/docs/proposals/pending/full-autonomous-development.md
@@ -1,0 +1,190 @@
+# Full Autonomous Development
+
+**Status:** APPROVED (human proposal gate passed 2026-06-19) — implementing.
+**Builds on:** server-owned turn lifecycle (Phase 1, PR #514) — a turn/workflow
+runs server-side and survives any client disconnect.
+
+**Scope decision (user, 2026-06-19):** aimee must **NEVER self-initiate work**.
+Autonomous execution is strictly *proposal-driven*: a human hands aimee a
+proposal and aimee executes that proposal end-to-end. There is no agent-initiated
+task generation, no background "find work to do" loop. WP-4 intake is the only
+way an autonomous run begins, and it always originates from a human-submitted
+proposal.
+
+**Architecture invariant (user, 2026-06-19):** ALL autonomous action flows
+*through the workflow engine* (`wfe`). The engine's block catalog, gates
+(roundtable/human/CI), autonomy driver, persistence and audit are the single
+substrate for autonomy — there is no side-channel that takes an autonomous
+action outside the engine. The scheduler (WP-3) only ever resumes
+`wfe_autonomy_run()`; intake (WP-4) only ever creates a `wfe` work item. This
+guarantees every autonomous step is gate-governed, budget-bounded, persisted and
+auditable by construction.
+
+## 1. Goal (the user's words)
+
+> "I should be able to hand you a proposal, you implement it in full, going to
+> the roundtable with any questions or other things you need, and you implement
+> it in full. Just because someone closes a tab in the browser doesn't mean
+> stop; development should continue."
+
+Concretely: a user submits a **proposal** (a development task/spec). Aimee then
+drives the *entire* development lifecycle to completion **server-side and
+unattended** — designing, planning, writing code via delegates, reviewing
+itself via the roundtable, opening PRs, reacting to CI — pausing only at the
+human gates the user reserved, and resuming the instant a gate is satisfied. No
+browser tab needs to stay open.
+
+## 2. What already exists (do NOT rebuild)
+
+This proposal is mostly **wiring + hardening of existing parts**, not new
+architecture:
+
+- **Workflow engine (`src/workflow/wfe_*`)** — a block-composed state machine
+  with persisted work-item state (db1 `lifecycle_*` tables), `gate.roundtable`,
+  `gate.human`, `gate.ci`, verdicts, and approvals.
+- **The default dev lifecycle (`config/workflows/build.yaml`)** — already
+  composes: `author.proposal → gate.roundtable → pr.open → gate.human → plan →
+  gate.roundtable → implement → freeze → gate.roundtable → pr.open → gate.human
+  (pass→merge / fail→implement)`. User-editable (`aimee workflow new`).
+- **Autonomy driver (`wfe_autonomy.c`)** — `wfe_autonomy_run()` auto-advances
+  machine gates, auto-satisfies only *preauthorized/optional* human gates, parks
+  (`pending_human`) at every other human gate and at a degraded roundtable, and
+  **never forges a human approval** (gate-override is a signed human-only action,
+  capped at `WFE_MAX_OVERRIDES`).
+- **Server-owned turn lifecycle (PR #514)** — turns publish to the presence ring
+  and run to completion regardless of the connection; `turn_registry` owns
+  cancel + child reaping; reconnect replays from a cursor.
+- **Delegates + roundtable** — `/v1/delegate/{run,roundtable}`, vault-backed
+  multi-model panels, on-demand exec.
+
+## 3. The gap (what makes it NOT yet autonomous)
+
+Three concrete gaps, all surfaced by reading the code:
+
+1. **The delegate-driven blocks are integration-gated stubs.**
+   `wfe_blocks.c`: `author.proposal`, `author.plan`, `implement`, `document`
+   *construct* the delegate commands but do not actually dispatch a delegate to
+   write the artifact/code and commit it to the work item's branch
+   ("In production this dispatches `aimee delegate run`…"). `pr.open`/`merge`
+   are likewise gated. **Without these, the workflow advances but produces no
+   work.**
+
+2. **Nothing drives the workflow forward unattended.** `wfe_autonomy_run()` runs
+   a work item "as far as gate policies allow," then returns. Nothing re-invokes
+   it when an async precondition clears — a delegate turn finishes, CI reports,
+   or a human satisfies a gate. Today that re-invocation is a human action in the
+   webchat. **A server-owned scheduler must resume parked work items on those
+   events** (this is the piece the Phase-1 foundation makes safe: the driving
+   loop and its delegate turns are server-owned, not connection-scoped).
+
+3. **No proposal intake path.** There is no "hand aimee a proposal → spawn an
+   autonomous work item running `build.yaml`" entrypoint. A user must hand-drive
+   the webchat workflows tab.
+
+## 4. Proposed design
+
+### WP-1 — Real delegate-driven block executors
+Wire `author.proposal`, `author.plan`, `implement`, `document` to dispatch real
+delegates (inline `delegate_run_inline` / `/v1/delegate/run`) that produce the
+artifact or code **into the work item's own git worktree/branch**, then commit.
+Reuse the existing worktree isolation + write-guard machinery and the
+source-authority TLS context (per [[delegate-concurrency-env-race]]). `implement`
+is a bounded delegate fan-out over the plan's units; each unit lands on the
+branch; failures are surfaced as a verdict, not a crash.
+
+### WP-1b — Primary MANAGES; delegates DO; primary verifies (user, 2026-06-19)
+The autonomous **primary agent is a manager, not a worker.** It never authors
+artifacts or code itself and never does the hands-on verification labor — it
+decomposes, dispatches, adjudicates, and loops. All production work and all
+verification labor run in delegates (and automated gates). The `implement` stage
+is a manager-driven loop:
+
+1. **Split.** The primary decomposes the plan into independent, file/module-scoped
+   work units sized for one delegate turn (minimal interdependence).
+2. **Dispatch.** Each unit → an `engineer` delegate that implements it in the
+   work-item worktree and commits (reuse `delegate_patch_coordinator` for parallel
+   patch integration; per-delegate source-authority TLS isolates concurrent units,
+   per [[delegate-concurrency-env-race]]).
+3. **Verify as hard as possible — also via delegates/gates, not the primary's own
+   hands.** In ascending cost: (a) mechanical — build compiles, targeted
+   tests/lint pass (`gate.ci` / custom command blocks); (b) review — a
+   `gate.roundtable` / `reviewer` delegate panel checks the unit against its spec;
+   (c) adversarial — N skeptic verifier delegates prompted to *refute* risky
+   changes; majority-refute → reject. The primary only *adjudicates* the verdicts.
+4. **Re-delegate on reject (user, 2026-06-19).** When verification deems a unit
+   unacceptable, the primary may **send it back to a *different* delegate** for
+   rework (fresh perspective), not necessarily the original author — bounded by a
+   per-unit retry cap (Q2); on exhaustion, park per the failure taxonomy (Q4).
+
+Only verified units advance. This is a first-class engine concern built from the
+existing block catalog (`gate.*`, delegate fan-out) — never an out-of-band action,
+consistent with the all-autonomy-through-wfe invariant. The primary's role maps
+to the engine's autonomy driver + a coordinator delegate; the workers are
+ordinary delegates.
+
+### WP-2 — Forge blocks
+Wire `pr.open` and `merge` to the existing git/forge layer (`mcp_git_*`,
+`git_forge_vault`, per-host creds) so the autonomous run opens a real PR and (on
+a passed human gate) merges it. CI is consumed via `gate.ci`.
+
+### WP-3 — Server-owned autonomy scheduler
+A persistent server component that owns the set of active autonomous work items
+and resumes `wfe_autonomy_run()` on the events that clear a park:
+- a delegate/turn for the work item completes (hook off the turn registry);
+- `gate.ci` transitions (CI webhook / poll);
+- a human satisfies a `gate.human` (already an API mutation — fire the resume);
+- a periodic backstop sweep (crash recovery), reusing the work-item persistence.
+Bounded concurrency + per-work-item single-flight (mirror `turn_registry`'s lock
+discipline). Cost/turn caps per work item; respects [[delegates-never-token-limited]]
+for the *model* ceiling but caps *total* spend per run.
+
+### WP-4 — Proposal intake
+`POST /v1/dev/submit {proposal_md, workflow?: "build", limits?}` → creates a
+work item bound to `build.yaml` (or a named workflow), seeds the proposal
+artifact, and registers it with the scheduler. Webchat gets a "Submit for
+autonomous development" affordance; the run is observable live (presence ring)
+and after disconnect (cursor replay). The two human gates (proposal-approval,
+final PR pass/fail) surface as actionable notifications.
+
+### WP-5 — Safety rails (non-negotiable)
+- Human gates are **never** auto-satisfied unless the user marked them
+  preauthorized for that run; gate-override stays human-only and capped.
+- Every autonomous commit/PR is attributed to the run and fully audited.
+- Hard per-run budget ceiling (turns, tokens, wall-clock); on breach → park
+  `pending_human`, never silently continue.
+- Honor [[no-coauthor-trailers]] in all generated commits/PRs.
+- Default branch protection respected: autonomous merges only to `testing`,
+  never directly to `main` (promotion stays a human action).
+
+## 5. Open questions for the roundtable
+
+(Per the directive to consult the roundtable for opinions.)
+
+- **Q1.** Scheduler home: a new server subsystem vs. extending the existing
+  compute-pool/coord-dispatcher? Trade-offs in lock discipline + crash recovery.
+- **Q2.** `implement` granularity: one delegate for the whole change vs. a
+  fan-out over plan units with a patch-coordinator merge — which is more robust
+  for unattended runs, and how to bound retries?
+- **Q3.** CI feedback loop: webhook vs. poll for `gate.ci`; how an autonomous run
+  reacts to a red CI (auto-loop back to `implement` with the failure as input —
+  how many times before parking?).
+- **Q4.** Failure taxonomy: which failures park for a human vs. auto-retry vs.
+  terminal-reject, to avoid both runaway loops and premature abandonment.
+- **Q5.** Multi-run isolation: N concurrent autonomous work items each need their
+  own worktree/branch/session — confirm the worktree-GC + source-authority TLS
+  story holds under this load.
+
+## 6. Human gates for THIS work
+
+1. **This proposal** — approve scope before implementation (current gate).
+2. Implementation plan — roundtable-reviewed, then a brief human ack.
+3. Final PR(s) — human pass/fail before merge to `testing`.
+
+## 7. Phasing
+
+- **Phase A:** WP-1 + WP-2 (real blocks) behind a default-off flag; a human still
+  drives advancement in the webchat. Proves the blocks produce real work.
+- **Phase B:** WP-3 + WP-4 (scheduler + intake) — true unattended end-to-end.
+- **Phase C:** richer policy (failure taxonomy, budget tuning, multi-run scaling).
+
+Each phase is independently shippable and roundtable-gated.

--- a/docs/proposals/pending/full-autonomous-development.plan.md
+++ b/docs/proposals/pending/full-autonomous-development.plan.md
@@ -1,0 +1,133 @@
+# Full Autonomous Development — Implementation Plan
+
+Plan for the approved proposal (`full-autonomous-development.md`). Phased; each
+phase is independently shippable and roundtable-gated. **Scope invariant: aimee
+never self-initiates — every run originates from a human-submitted proposal.**
+
+## Phase A — real delegate-driven blocks + forge (WP-1, WP-2)
+
+Goal: the existing `build.yaml` lifecycle produces *real* work when driven. No
+scheduler yet (a human still advances it in the webchat); this proves the blocks.
+
+### A1. Delegate dispatch seam (mirrors the `g_forge` pattern)
+The wfe library must not hard-depend on `server/` delegate internals
+(module-boundary-check). Add a registered hook, mockable in unit tests:
+
+```c
+/* wfe_iface.h */
+typedef struct {
+  /* Run one bounded delegate turn in `worktree`, role/persona + prompt given,
+   * writing files into the worktree. Returns 0 on success; fills commit_sha if
+   * it committed. Non-zero => the caller emits a verdict/fail, never a crash. */
+  int (*run)(const char *worktree, const char *role, const char *prompt,
+             const char *artifact_path, char commit_sha[64], char *err, size_t n);
+} wfe_delegate_provider_t;
+void wfe_set_delegate_provider(const wfe_delegate_provider_t *p);  /* test mock */
+```
+Server registers a `LIVE_DELEGATE` that calls `delegate_run_inline` (sync core,
+per [[delegate-refactor-and-roundtable-delegate]]) with per-delegate
+source-authority TLS context (race-safe, per [[delegate-concurrency-env-race]]).
+
+### A2. Per-work-item worktree
+Each work item gets an isolated `git worktree` + branch
+(`aimee/wi/<work_item_id>`), created on first `implement`/`author`, reusing the
+existing worktree machinery + worktree-GC (per [[worktree-gc-dead-wired-fix]]).
+`wfe_ctx` gains a resolved `worktree` accessor. All A1 delegate runs and the
+freeze/pr.open git ops act on this worktree, not the server cwd.
+
+### A3. Wire the executors
+- `exec_author` (proposal/plan): dispatch a delegate (role `architect` for
+  proposal, `engineer`/`architect` for plan) to author/edit the artifact at
+  `wfe_ctx_proposal_path` inside the worktree; commit; hash the artifact as the
+  produced handle (keep the existing fail-closed-if-absent behavior).
+- `exec_implement`: the **manager loop** (WP-1b). The primary (autonomy driver +
+  a coordinator delegate) only *manages* — it never writes code or does hands-on
+  verification:
+  1. split the plan into independent work units;
+  2. fan out each unit to an `engineer` delegate (via `delegate_patch_coordinator`);
+  3. verify each unit via delegates/gates — mechanical (build/test/lint), review
+     (`reviewer` panel), adversarial (skeptic refuters); the primary only
+     *adjudicates* the verdicts;
+  4. on reject, **re-delegate the unit to a *different* delegate** (bounded
+     retries, Q2); on exhaustion, park (Q4).
+  Each accepted unit lands a commit on the branch; fail-closed if nothing landed.
+  Decomposition + verification policy are config-driven (fan-out width, retry
+  caps, which verification tiers are mandatory).
+- `exec_document`: delegate writes docs/comments onto the branch; commit.
+- `exec_pr_open`: `git push` the work-item branch, then `g_forge->open(repo,
+  branch, title, body)` (new vtable method) → store the PR ref on the work item
+  so `pr_ref()` resolves a real PR (today it returns the work-item id). Honor
+  [[no-coauthor-trailers]] in commit/PR text.
+
+### A4. Tests
+Unit: mock `wfe_delegate_provider` + `g_forge`; assert author/implement/document
+advance with a commit, pr.open stores a PR ref, failures emit verdict/fail (not
+crash). Integration-gated live path unchanged in spirit.
+
+## Phase B — server-owned scheduler + intake (WP-3, WP-4)
+
+### B1. Autonomy scheduler (Q1)
+A server-owned component that owns active autonomous work items and resumes
+`wfe_autonomy_run()` when a park-clearing event fires:
+- a work-item delegate turn completes (hook off `turn_registry`);
+- `gate.ci` transitions (Q3 — webhook vs poll);
+- a human satisfies a `gate.human` (already an API mutation → fire resume);
+- periodic backstop sweep (crash recovery) over persisted `lifecycle_*`.
+Bounded concurrency; per-work-item single-flight (mirror `turn_registry` lock
+discipline). Built on the Phase-1 server-owned turn lifecycle so the driver and
+its turns survive client disconnect.
+
+### B2. Intake
+`POST /v1/dev/submit {proposal_md, workflow?, limits?}` → create work item bound
+to `build.yaml`, seed the proposal artifact into its worktree, register with the
+scheduler. Webchat "Submit for autonomous development" affordance; live via
+presence ring, post-disconnect via cursor replay. Human gates surface as
+actionable notifications. **Intake is the ONLY way a run begins — no
+self-initiation path exists.**
+
+## Phase C — policy hardening (WP-5 depth)
+Failure taxonomy (Q4: park vs auto-retry vs terminal-reject), budget tuning,
+multi-run isolation validation (Q5), CI-loop retry caps (Q3).
+
+## Safety rails (all phases)
+Human gates never auto-satisfied unless preauthorized; gate-override stays
+human-only + capped; hard per-run budget ceiling → park (never run away);
+autonomous merges only to `testing` (promotion to `main` stays human); every
+commit/PR audited and attributed to the run.
+
+## Open questions → roundtable (Q1–Q5 from the proposal)
+Q1 scheduler home; Q2 implement granularity + retry bound; Q3 CI feedback
+loop + red-CI retry cap; Q4 failure taxonomy; Q5 multi-run worktree/source-auth
+isolation under load.
+
+## Roundtable resolutions (2026-06-19, 2 mistral lenses — architect + security)
+
+Verdict: **no blocking flaws** in Phase A; invariant (all-autonomy-through-wfe)
+**confirmed sound** by both. Converged decisions:
+
+- **Q1 — scheduler home:** Extend the existing **coord-dispatcher / `turn_registry`**,
+  not a new subsystem. The scheduler is "just another turn type" that resumes
+  `wfe_autonomy_run()`; reuse single-flight, crash recovery, and presence
+  integration from PR #514.
+- **Q2 — implement granularity:** Fan-out over plan units (one delegate per
+  file/module unit) + a **patch-coordinator** merge delegate. Retry bound **2–3
+  per unit**; if >50% of units fail, park. Model the patch-coordinator as a
+  sub-block of `implement` (its own verdict/retry, audited) so it stays inside
+  the wfe catalog (the only invariant gap either lens found).
+- **Q3 — CI loop:** **Webhook** for `gate.ci` (not poll), firing the scheduler's
+  resume hook. Red-CI auto-retry cap **1–2**, looping back to `implement` with
+  the CI failure log as input; then park.
+- **Q4 — failure taxonomy:** transient delegate/CI errors → bounded auto-retry;
+  model refusal / permanent error → terminal-reject; roundtable-degraded,
+  budget-breach, git/forge failure → park (`pending_human`); worktree corruption
+  → terminal. **Invariant: never auto-retry without new input** (CI log /
+  roundtable verdict) — prevents infinite loops.
+- **Q5 — multi-run isolation:** existing per-work-item worktree + source-authority
+  TLS holds; **use `git worktree lock` during delegate runs** so worktree-GC
+  can't prune an active run; load-validate (N≈100) in Phase C.
+
+Additional adopted refinements: verdict aggregation must distinguish
+partial-success from total-failure and log partial commits; patch-coordinator
+actions audited + attributed to the work item.
+
+**Plan status: roundtable-approved.** Ready to implement Phase A.

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -108,6 +108,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-autonomy \
                $(TESTPREFIX)/unit-test-wfe-custom \
                $(TESTPREFIX)/unit-test-wfe-safety \
+               $(TESTPREFIX)/unit-test-wfe-delegate-seam \
                $(TESTPREFIX)/unit-test-wfe-webapi \
                $(TESTPREFIX)/unit-test-cli-profile \
                $(TESTPREFIX)/unit-test-cmd-profile \
@@ -1092,6 +1093,16 @@ $(TESTPREFIX)/unit-test-wfe-custom: $(OBJDIR)/tests/test_wfe_custom.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-wfe-safety: $(OBJDIR)/tests/test_wfe_safety.o \
+                                    $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \
+                                    $(OBJDIR)/workflow/wfe_iface.o $(OBJDIR)/workflow/wfe_validate.o \
+                                    $(OBJDIR)/workflow/wfe_canonical.o $(OBJDIR)/workflow/wfe_custom.o \
+                                    $(OBJDIR)/aimee_home.o $(OBJDIR)/util.o $(OBJDIR)/posix/util.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-wfe-delegate-seam: $(OBJDIR)/tests/test_wfe_delegate_seam.o \
                                     $(OBJDIR)/workflow/wfe_blocks.o $(OBJDIR)/workflow/wfe_engine.o \
                                     $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
                                     $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/workflow/wfe_def.o \

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -1,0 +1,151 @@
+/* test_wfe_delegate_seam.c -- the delegate dispatch seam (author/implement/
+ * document) and the forge `open` seam (pr.open), exercised through the engine.
+ *
+ * Phase A of full-autonomous-development: producing blocks dispatch real work
+ * through registered hooks; with no provider they fail closed; tests inject
+ * mocks to assert the wiring. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+
+#include "db1.h"
+#include "wfe_blocks.h"
+#include "wfe_def.h"
+#include "wfe_engine.h"
+#include "wfe_iface.h"
+
+/* ---- mock delegate provider ---- */
+static int g_deleg_calls;
+static int g_deleg_rc; /* 0 success, -1 failure */
+static char g_deleg_last_role[32];
+static int mock_deleg_run(const char *workdir, const char *role, const char *prompt,
+                          const char *artifact_path, char out_commit_sha[64], char *err, size_t n)
+{
+   (void)workdir;
+   (void)prompt;
+   (void)artifact_path;
+   (void)err;
+   (void)n;
+   g_deleg_calls++;
+   snprintf(g_deleg_last_role, sizeof g_deleg_last_role, "%s", role ? role : "");
+   if (out_commit_sha)
+      snprintf(out_commit_sha, 64, "deadbeef");
+   return g_deleg_rc;
+}
+static const wfe_delegate_provider_t MOCK_DELEG = {mock_deleg_run};
+
+/* ---- mock forge with open ---- */
+static int g_open_calls;
+static int g_open_rc; /* 0 success, -1 failure */
+static char g_open_branch[64];
+static wfe_ci_status_t f_ci(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return WFE_CI_SUCCESS;
+}
+static int f_mergeable(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return 1;
+}
+static int f_is_merged(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return 0;
+}
+static wfe_merge_result_t f_merge(const char *r, const char *p)
+{
+   (void)r;
+   (void)p;
+   return WFE_MERGE_OK;
+}
+static int f_open(const char *repo, const char *branch, const char *title, const char *body,
+                  char out_pr_ref[128])
+{
+   (void)repo;
+   (void)title;
+   (void)body;
+   g_open_calls++;
+   snprintf(g_open_branch, sizeof g_open_branch, "%s", branch ? branch : "");
+   if (out_pr_ref)
+      snprintf(out_pr_ref, 128, "PR-7");
+   return g_open_rc;
+}
+static const wfe_forge_t MOCK_FORGE = {f_ci, f_mergeable, f_is_merged, f_merge, f_open};
+
+/* author.proposal -> pr.open (terminal). No git needed (author hashes its
+ * artifact; pr.open uses the forge `open` seam). */
+static const char *WF = "name: ds\nstart: au\nnodes:\n"
+                        "  - id: au\n    block: author.proposal\n    next: pr\n"
+                        "  - id: pr\n    block: pr.open\n    in:\n      src: au.out\n";
+
+static int run_fresh(const char *suffix)
+{
+   char id[80] = "", err[256] = "";
+   if (wfe_work_item_create("ds", "r", suffix, "interactive", id, err, sizeof err) != 0)
+      return -99;
+   if (wfe_engine_run(id, err, sizeof err) != 0)
+      return -98;
+   return 0;
+}
+
+int main(void)
+{
+   printf("wfe-delegate-seam: ");
+   char home[] = "/tmp/wfe_ds_XXXXXX";
+   assert(mkdtemp(home));
+   char wf[160];
+   snprintf(wf, sizeof wf, "%s/workflows", home);
+   mkdir(wf, 0755);
+   char p[256];
+   snprintf(p, sizeof p, "%s/workflows/ds.yaml", home);
+   FILE *f = fopen(p, "wb");
+   assert(f);
+   fputs(WF, f);
+   fclose(f);
+   setenv("AIMEE_HOME", home, 1);
+   assert(db1_init(":memory:") == 0);
+
+   wfe_reset_block_executors();
+   wfe_register_default_executors();
+
+   /* A: provider + forge.open installed -> both seams fire. */
+   wfe_set_delegate_provider(&MOCK_DELEG);
+   wfe_set_forge_provider(&MOCK_FORGE);
+   g_deleg_calls = 0;
+   g_open_calls = 0;
+   g_deleg_rc = 0;
+   g_open_rc = 0;
+   assert(run_fresh("a") == 0);
+   assert(g_deleg_calls == 1);                          /* author dispatched a delegate */
+   assert(strcmp(g_deleg_last_role, "architect") == 0); /* author uses architect */
+   assert(g_open_calls == 1);                           /* pr.open used the forge open seam */
+
+   /* B: no delegate provider installed -> author still advances (fail-open to the
+    *    legacy behavior); pr.open still uses the forge. */
+   wfe_set_delegate_provider(NULL);
+   g_deleg_calls = 0;
+   g_open_calls = 0;
+   assert(run_fresh("b") == 0);
+   assert(g_deleg_calls == 0); /* not called */
+   assert(g_open_calls == 1);  /* forge open still fired */
+
+   /* C: forge without an `open` method -> pr.open preserves prior advance (no
+    *    crash), and the delegate seam still fires for author. */
+   wfe_set_delegate_provider(&MOCK_DELEG);
+   static const wfe_forge_t NO_OPEN = {f_ci, f_mergeable, f_is_merged, f_merge, NULL};
+   wfe_set_forge_provider(&NO_OPEN);
+   g_deleg_calls = 0;
+   g_open_calls = 0;
+   assert(run_fresh("c") == 0);
+   assert(g_deleg_calls == 1);
+   assert(g_open_calls == 0); /* open is NULL -> not called, no crash */
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_wfe_safety.c
+++ b/src/tests/test_wfe_safety.c
@@ -41,7 +41,10 @@ static wfe_merge_result_t m_merge(const char *r, const char *p)
    (void)p;
    return g_merge;
 }
-static const wfe_forge_t MOCK = {m_ci, m_mergeable, m_is_merged, m_merge};
+/* open is unused by the safety blocks (ci/mergeable/merge); NULL it explicitly so
+ * the positional initializer covers every wfe_forge_t field (-Werror=missing-
+ * field-initializers). */
+static const wfe_forge_t MOCK = {m_ci, m_mergeable, m_is_merged, m_merge, NULL};
 
 /* pp -> pr -> check.mergeable -> gate.ci -> merge; gates loop back to pp. */
 static const char *WF = "name: sf\nstart: pp\nnodes:\n"

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -122,12 +122,53 @@ static wfe_merge_result_t live_merge(const char *repo, const char *pr)
    (void)pr;
    return WFE_MERGE_ERROR;
 }
-static const wfe_forge_t LIVE_FORGE = {live_ci_status, live_mergeable, live_is_merged, live_merge};
+/* Default forge open: integration-gated (the live provider — git push + gh pr
+ * create — is registered by the server). Fail closed here so pr.open re-loops. */
+static int live_open(const char *repo, const char *branch, const char *title, const char *body,
+                     char out_pr_ref[128])
+{
+   (void)repo;
+   (void)branch;
+   (void)title;
+   (void)body;
+   if (out_pr_ref)
+      out_pr_ref[0] = '\0';
+   return -1;
+}
+static const wfe_forge_t LIVE_FORGE = {live_ci_status, live_mergeable, live_is_merged, live_merge,
+                                       live_open};
 static const wfe_forge_t *g_forge = &LIVE_FORGE;
 
 void wfe_set_forge_provider(const wfe_forge_t *p)
 {
    g_forge = p ? p : &LIVE_FORGE;
+}
+
+/* Delegate seam (see wfe_blocks.h). Default NULL: producing blocks fail closed
+ * until the server registers a live provider, preserving the integration-gated
+ * behavior the stubs had before. */
+static const wfe_delegate_provider_t *g_delegate = NULL;
+
+void wfe_set_delegate_provider(const wfe_delegate_provider_t *p)
+{
+   g_delegate = p;
+}
+
+/* Dispatch one block's delegate work, if a provider is installed. Returns:
+ *   1  provider ran and succeeded,
+ *   0  no provider installed (caller falls back to its fail-closed path),
+ *  -1  provider ran and failed (caller should loop/retry). */
+static int wfe_delegate_dispatch(const char *role, const char *prompt, const char *artifact_path,
+                                 char out_commit_sha[64])
+{
+   if (out_commit_sha)
+      out_commit_sha[0] = '\0';
+   if (!g_delegate || !g_delegate->run)
+      return 0;
+   char err[256] = "";
+   int rc =
+       g_delegate->run(repo_dir(), role, prompt, artifact_path, out_commit_sha, err, sizeof err);
+   return rc == 0 ? 1 : -1;
 }
 
 /* ---- executors ---- */
@@ -137,9 +178,15 @@ void wfe_set_forge_provider(const wfe_forge_t *p)
 static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
 {
    const char *path = wfe_ctx_proposal_path(ctx);
-   /* In production this dispatches `aimee delegate run` to author/edit `path`.
-    * We hash the artifact file as the produced content. If the artifact is not
-    * present (no delegate ran), the gate that follows will simply re-loop. */
+   /* Dispatch a delegate to author/edit `path` (no-op if no provider installed;
+    * a failed run loops). Then hash the artifact file as the produced content; if
+    * it is absent (no provider ran) the gate that follows simply re-loops. */
+   char commit[64] = "";
+   if (wfe_delegate_dispatch("architect",
+                             "Author or revise the workflow artifact at the given path "
+                             "per the work item, then commit it.",
+                             path, commit) < 0)
+      return wfe_step_looped();
    char hash[65] = "";
    if (path && path[0])
    {
@@ -167,14 +214,21 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
    return wfe_step_advanced(handle, hash, 0.0);
 }
 
-/* implement: produces the work item's branch. In production a delegate fan-out
- * writes the code; that live dispatch is integration-gated (see file header).
- * What this does NOW: captures the current branch head SHA as the produced
- * artifact, and fails closed if the repo is unavailable (never emits an empty
- * artifact). */
+/* implement: the manager loop. The live delegate provider owns decompose -> fan
+ * out -> verify -> re-delegate (see the full-autonomous-development plan); this
+ * executor dispatches it, then captures the branch head SHA as the produced
+ * artifact. A failed dispatch loops (retry); fails closed if the repo is
+ * unavailable. With no provider installed it preserves the prior freeze-only
+ * behavior so the engine remains drivable without a live delegate. */
 static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 {
    (void)ctx;
+   char commit[64] = "";
+   if (wfe_delegate_dispatch("engineer",
+                             "Implement the approved plan on the work-item branch: split into "
+                             "units, delegate each, verify, and commit the accepted work.",
+                             NULL, commit) < 0)
+      return wfe_step_looped();
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
       return wfe_step_failed();
@@ -191,6 +245,12 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 static wfe_step_result_t exec_document(wfe_ctx *ctx, const wfe_node_t *node)
 {
    (void)ctx;
+   char commit[64] = "";
+   if (wfe_delegate_dispatch("engineer",
+                             "Document the change on the work-item branch (README/CHANGELOG/docs "
+                             "+ inline comments), then commit.",
+                             NULL, commit) < 0)
+      return wfe_step_looped();
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
       return wfe_step_failed();
@@ -213,14 +273,23 @@ static wfe_step_result_t exec_freeze(wfe_ctx *ctx, const wfe_node_t *node)
    return wfe_step_advanced(handle, dhash, 0.0);
 }
 
-/* pr.open: push the branch + open a forge PR. */
+/* pr.open: push the branch + open a forge PR via the forge seam. The PR ref the
+ * forge returns becomes the produced content. A failed open loops (retry). With
+ * no live `open` installed (default/mocks) it preserves the prior advance so the
+ * engine stays drivable without a forge. */
 static wfe_step_result_t exec_pr_open(wfe_ctx *ctx, const wfe_node_t *node)
 {
-   (void)ctx;
-   /* Production: `git push` then `gh pr create`; the PR number/url is the
-    * produced handle. Requires a configured forge (gh) — integration-gated. */
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
+   if (g_forge->open)
+   {
+      const char *branch = getenv("AIMEE_WORKFLOW_BRANCH");
+      char pr_ref[128] = "";
+      if (g_forge->open(wfe_ctx_repo(ctx), branch ? branch : "HEAD", wfe_ctx_work_item(ctx), "",
+                        pr_ref) != 0)
+         return wfe_step_looped();
+      return wfe_step_advanced(handle, pr_ref, 0.0);
+   }
    return wfe_step_advanced(handle, "", 0.0);
 }
 

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -42,9 +42,36 @@ typedef struct
    int (*mergeable)(const char *repo, const char *pr_ref); /* 1 yes, 0 conflict, -1 unknown */
    int (*is_merged)(const char *repo, const char *pr_ref); /* 1 merged, 0 open, -1 unknown */
    wfe_merge_result_t (*merge)(const char *repo, const char *pr_ref);
+   /* Push `branch` and open a PR; write its forge ref (number/url) into out_pr_ref.
+    * Returns 0 on success, -1 on failure. May be NULL on a provider that predates
+    * this field (the default live provider and test mocks) -> pr.open fails closed
+    * and the gate that follows re-loops. */
+   int (*open)(const char *repo, const char *branch, const char *title, const char *body,
+               char out_pr_ref[128]);
 } wfe_forge_t;
 
 /* Install a forge provider (NULL restores the default live/gh provider). */
 void wfe_set_forge_provider(const wfe_forge_t *p);
+
+/* ---- Delegate seam for the producing blocks (author/implement/document).
+ * The wfe library must not depend on server/ delegate internals
+ * (module-boundary-check), so blocks dispatch real delegate work through this
+ * registered hook. The default provider is NULL -> producing blocks fail closed
+ * (the gate that follows re-loops), exactly the pre-seam integration-gated
+ * behavior. The server registers a live provider that runs delegates (decompose
+ * -> fan out -> verify -> re-delegate is owned by the live provider; see the
+ * full-autonomous-development plan). Tests inject a mock. ---- */
+typedef struct
+{
+   /* Run the block's delegate work in `workdir` as `role` with `prompt`. If the
+    * block produces a file artifact, `artifact_path` is its path (else NULL). On
+    * success returns 0 and, if a commit was made, fills out_commit_sha (else "").
+    * Non-zero => the caller emits failed/looped, never a crash. */
+   int (*run)(const char *workdir, const char *role, const char *prompt, const char *artifact_path,
+              char out_commit_sha[64], char *err, size_t errlen);
+} wfe_delegate_provider_t;
+
+/* Install a delegate provider (NULL restores the default fail-closed provider). */
+void wfe_set_delegate_provider(const wfe_delegate_provider_t *p);
 
 #endif /* DEC_WFE_BLOCKS_H */


### PR DESCRIPTION
First slice of **full autonomous development** (approved proposal + Phase A/B/C plan included in this PR under `docs/proposals/pending/`).

## What this does
Makes the workflow engine's *producing* blocks dispatch real work through narrow, registered seams — mirroring the existing `g_forge` pattern — so the `wfe` library stays free of `server/` delegate internals (module-boundary clean) and everything stays unit-testable with mocks.

- **`wfe_delegate_provider_t` + `wfe_set_delegate_provider`** — `author`/`implement`/`document` dispatch their delegate work through this hook. Default NULL ⇒ fail closed (the following gate re-loops), exactly the prior integration-gated behavior. The live provider (which owns the manager loop: decompose → fan out → verify → re-delegate) is registered by the server in **Phase B**.
- **`wfe_forge_t.open()`** — `pr.open` pushes + opens a PR via the seam and produces the PR ref. NULL `open` (default/mocks) preserves the prior advance.
- Executors rewired; **no-provider paths preserve existing engine behavior** so the engine stays drivable without live providers.
- **`test_wfe_delegate_seam`** drives `author.proposal → pr.open` through the engine with mock delegate + forge, asserting both seams fire, the no-provider fail-open path, and the NULL-open path.

## Scope invariants (recorded in the docs, per user)
- aimee **never self-initiates** — autonomous runs are proposal-driven only.
- the **primary MANAGES** (decompose/dispatch/verify/re-delegate); delegates DO the work; on unacceptable work the primary re-delegates to a *different* delegate.
- **all autonomy flows through the workflow engine** — no side-channel.

## Verification (local; CI confirms)
`make server` links; **all 8 wfe unit suites pass** (incl. new `unit-test-wfe-delegate-seam`); full `make lint` (clang-format-19) + line-check + module-boundary clean.

Builds on the server-owned turn lifecycle (#514). Plan roundtable-approved (Q1–Q5, no blockers). Default-off in effect: no live provider is registered yet, so production behavior is unchanged until Phase B.