### PR TITLE
docs(autonomous-dev): correct webchat GUI claims (API-first)

### DIFF
--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -61,8 +61,11 @@ curl -sX POST http://127.0.0.1:8740/v1/dev/submit \
 
 A `401` means the token is missing/invalid; `400` means `proposal_md` was empty.
 On success the run proceeds on the server — you can close the connection and it
-continues. The webchat **Workflows** tab shows live progress and surfaces the
-human gates as actionable approvals.
+continues. The webchat **Workflows** tab lists the run and highlights its current
+stage on the lifecycle diagram. (Submitting a proposal and approving/rejecting
+its human gates are currently done via the API — see
+[Current limitations](#current-limitations); a webchat submit form + in-tab gate
+approvals are in progress.)
 
 Request fields:
 
@@ -129,7 +132,11 @@ Autonomous does not mean unsupervised. The workflow reserves **human gates**
 - **never forges a human approval** — gate-override is a signed, human-only action
   capped at a small number of uses.
 
-Approve or reject a parked gate from the webchat Workflows tab (or the gate API).
+A human approval is non-repudiable: it's HMAC-signed with an operator key
+(`$AIMEE_HOME/.approval-key`, mode 0600) that delegate processes cannot read, so
+a delegate can never forge one. Approvals are recorded as `approve` lifecycle
+events. (Granting an approval is currently an operator/API action; an in-tab
+approve/reject control is in progress.)
 
 ## Server-owned execution
 
@@ -168,9 +175,9 @@ Autonomous development is default-on; the guardrails are structural, not a toggl
 
 ## Observability
 
-- **Webchat Workflows tab** — live progress per work item: current stage, gate
-  verdicts, parked state, and the actionable approve/reject controls for human
-  gates.
+- **Webchat Workflows tab** — lists work items with their run state and
+  highlights the current stage on the lifecycle diagram (read-only run viewer
+  today; submit + in-tab gate approvals are in progress).
 - **Event stream** — a run publishes its full turn stream (text, tool calls,
   usage, boundaries) to the presence event ring; the webchat replays it live and,
   after a disconnect, from a cursor.
@@ -187,7 +194,7 @@ resumes it automatically once the blocker clears:
 
 | pause reason | what it means | how it resumes |
 |--------------|---------------|----------------|
-| `pending_human` | waiting at a human gate (proposal approval / final pass-fail) | approve or reject in the webchat Workflows tab → the scheduler re-drives |
+| `pending_human` | waiting at a human gate (proposal approval / final pass-fail) | record an approval (operator/API today) → the scheduler re-drives |
 | `panel_degraded` / `panel_unreachable` | the roundtable couldn't reach a quorum | retried on the next sweep; a human can approve to proceed |
 | `ci_pending` | the PR's CI hasn't concluded | re-checked on the next sweep |
 | `merge_pending` | the forge merge state is undeterminable | re-checked on the next sweep |
@@ -205,8 +212,12 @@ auto-retried without new input (a CI log or a roundtable verdict).
 Honest scope of the current implementation (the design allows for more):
 
 - **Submit takes `proposal_md`, `workflow`, `repo` only.** Per-run `limits` and
-  gate **preauthorization** are not yet accepted at `/v1/dev/submit`; gates are
-  handled interactively via the webchat, and the cost cap is a work-item field.
+  gate **preauthorization** are not yet accepted at `/v1/dev/submit`, and the
+  cost cap is a work-item field.
+- **Webchat is API-first for now.** The Workflows tab is a read-only run viewer;
+  there is **no submit form and no in-tab gate approve/reject control yet** —
+  submit a proposal and record gate approvals via the API. (Both are in
+  progress.)
 - **No dedicated `resume`/`abort`/`audit` HTTP endpoints yet.** Resume is
   event-driven (gate approval + the scheduler sweep); drive and inspect runs via
   the webchat Workflows tab and the `lifecycle_*` audit tables.

--- a/docs/proposals/pending/autonomous-dev-webchat-and-random-delegate.plan.md
+++ b/docs/proposals/pending/autonomous-dev-webchat-and-random-delegate.plan.md
@@ -1,0 +1,88 @@
+# Autonomous-dev webchat GUI + Random delegate — plan
+
+Two user-requested additions on top of the (API-first) autonomous-development
+feature. Scope-honest: the webchat is currently a read-only run viewer.
+
+## B — webchat GUI for autonomous development
+
+### B1. Submit a proposal (form)
+- **Backend:** webchat Go proxy `POST /api/dev/submit` → `/v1/dev/submit`
+  (carrying the attested webuser identity, like the other `/api/*` proxies). The
+  `/v1/dev/submit` route already exists.
+- **Frontend:** a "Submit proposal" panel in the **Workflows** tab — a Markdown
+  textarea (`proposal_md`) + a workflow `<select>` (default `build`, from
+  `/api/workflow/defs`) + a Submit button. On success show the new
+  `work_item_id` and refresh the run list.
+
+### B2. Approve / reject a parked human gate
+- **Backend (new):** `POST /v1/workflow/items/<id>/gate {gate, decision}` where
+  decision ∈ {approve, reject}. Approve → `wfe_approval_sign` +
+  `wfe_approval_record` (HMAC with the operator key, **server-side** — the
+  webchat user never sees the key); reject → record a `reject` lifecycle event
+  and drive the gate's fail path. Then `wfe_scheduler_notify()` to resume.
+  Webchat proxy `POST /api/workflow/items/<id>/gate`. Capability: CAP_DELEGATE
+  (webuser-attested), matching `/v1/dev/submit`.
+- **Frontend:** in the Workflows run viewer, when a run's `pause_reason` is
+  `pending_human`, show **Approve** / **Reject** buttons that call the proxy and
+  refresh.
+
+### B3. Docs
+Flip the doc's "in progress" notes (just corrected in #527) to describe the
+shipped submit form + in-tab gate controls.
+
+## C — "Random" delegate
+
+A workflow step (panel lens / producing step) can be assigned the delegate
+**`$random`**; at runtime it resolves to a uniformly-random agent from the
+configured roster.
+
+- **Composer (frontend):** add `Random` to the delegate picker suggestions in
+  `Workflows.tsx` (stored as the sentinel `$random`).
+- **Runtime (backend):** a small resolver `wfe_resolve_delegate(name, acfg)` —
+  if `name == "$random"`, pick a uniformly-random enabled agent from `acfg`
+  (seedable for tests); else return `name`. Wire it everywhere a step's delegate
+  name becomes an agent: the panel provider and the live delegate provider.
+
+## Open questions → roundtable
+
+- **Q1 (authz).** The approval key is operator-only by design; the webchat is
+  single-principal. Is "any authenticated webchat user may approve a gate via the
+  server-side signer" acceptable, or should gate-approval require a stronger
+  attestation than `/v1/dev/submit`?
+- **Q2 (reject semantics).** Should `reject` loop the gate's `on_fail` (retry) or
+  force terminal `rejected`? Per-gate, or a fixed policy?
+- **Q3 (random scope + fairness).** Should `$random` exclude the primary/just-used
+  delegate (avoid repeats) or be pure-uniform? Does it apply to panels only, or
+  also producing steps? How does it behave while the live panel provider is still
+  `DEGRADED` (not yet composable)?
+- **Q4 (idempotency).** Double-approve / approve-after-resume races — the signed
+  approval is content-hash-bound; confirm a stale approval can't re-fire.
+
+## Roundtable resolutions (2026-06-19, security + architect lenses — CHANGES-REQUESTED → incorporated)
+
+Both lenses flagged the same blockers; adopted:
+
+- **Q1 / B2 authz (BLOCKING — privilege escalation):** the operator-only gate
+  signer must NOT be reachable by a mere `CAP_DELEGATE` webuser. Gate approval
+  requires a **distinct operator-level capability** (`CAP_OPERATOR`), separate
+  from `/v1/dev/submit`'s `CAP_DELEGATE`. The signing key stays server-side; the
+  webchat (single-principal) maps its admin to the operator cap. Documented as a
+  single-principal assumption with per-gate ACLs as a future extension.
+- **Q2 reject semantics (BLOCKING):** `reject` is **terminal (`rejected`) by
+  default**; a gate may opt into retry via `retry_on_reject: true` in its def
+  (follow `on_fail`). Prevents unintended loops/DoS.
+- **Q3 `$random` (BLOCKING — degraded/empty behavior):** resolver picks a
+  uniformly-random **enabled** agent via a CSPRNG, **seedable for tests**; **pure
+  uniform** (no exclusions); applies to producing steps and panels. If the roster
+  is empty it **fails fast with a clear error** — it never leaks the literal
+  `$random` sentinel downstream. (The live panel provider is still DEGRADED, so
+  `$random` is effective on producing steps now; panel use lands when the panel
+  provider is wired.)
+- **Q4 idempotency:** approvals are content-hash-bound; additionally **guard with
+  `wfe_approval_present`** before recording, and return success (not an error) on
+  a duplicate approve so the UI is race-safe.
+
+**Design status: resolved.** Implementation order: C (random resolver + composer
+option, lowest risk) → B1 (submit proxy + form) → B2 (operator-capped gate
+endpoint + approve/reject UI), each compiled + tested, then the doc flips from
+"in progress" to shipped.


### PR DESCRIPTION
Corrects the autonomous-development guide which overclaimed the webchat GUI. Reality: the Workflows tab is a read-only run viewer; submitting a proposal and recording gate approvals are API/operator actions today (submit form + in-tab gate approve/reject are in progress). Approvals are HMAC-signed with the operator key (delegate-unforgeable).