### PR TITLE
feat(wfe): operator-gated human-gate approve/reject from the webchat (B2)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -461,6 +461,34 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workflow/items/{id}/gate:
+    post:
+      summary: Approve or reject the human gate a run is parked at (operator-only)
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [decision]
+              properties:
+                decision: { type: string, enum: [approve, reject] }
+                gate: { type: string, description: Gate name (defaults to the parked stage) }
+      responses:
+        "200":
+          description: "{work_item_id, gate, decision}"
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Bad decision
+        "404":
+          description: Work item not found
   /kb/search:
     post:
       summary: Search the knowledge base (proxied to aimee-kb)

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -61,8 +61,10 @@ curl -sX POST http://127.0.0.1:8740/v1/dev/submit \
 
 A `401` means the token is missing/invalid; `400` means `proposal_md` was empty.
 On success the run proceeds on the server — you can close the connection and it
-continues. The webchat **Workflows** tab shows live progress and surfaces the
-human gates as actionable approvals.
+continues. The webchat **Workflows** tab is the GUI for all of this: a **Submit
+proposal** panel (textarea → runs on the chosen workflow), a live **run list**
+with each run's stage/state, and **Approve / Reject** buttons on a run parked at
+a human gate (operator-only). You can also drive it purely via the API as above.
 
 Request fields:
 
@@ -129,7 +131,12 @@ Autonomous does not mean unsupervised. The workflow reserves **human gates**
 - **never forges a human approval** — gate-override is a signed, human-only action
   capped at a small number of uses.
 
-Approve or reject a parked gate from the webchat Workflows tab (or the gate API).
+Approve or reject a parked gate from the webchat Workflows tab's **Run state**
+panel, or via `POST /v1/workflow/items/<id>/gate {decision}`. The endpoint is
+**operator-gated** (`CAP_WORKFLOW_ADMIN`, outside the ordinary authenticated
+capability set), and approvals are HMAC-signed server-side with the operator key
+(`$AIMEE_HOME/.approval-key`) and content-hash-bound, so a delegate can never
+forge one. `reject` is terminal; `approve` resumes the run.
 
 ## Server-owned execution
 

--- a/docs/proposals/pending/autonomous-dev-webchat-and-random-delegate.plan.md
+++ b/docs/proposals/pending/autonomous-dev-webchat-and-random-delegate.plan.md
@@ -1,0 +1,88 @@
+# Autonomous-dev webchat GUI + Random delegate — plan
+
+Two user-requested additions on top of the (API-first) autonomous-development
+feature. Scope-honest: the webchat is currently a read-only run viewer.
+
+## B — webchat GUI for autonomous development
+
+### B1. Submit a proposal (form)
+- **Backend:** webchat Go proxy `POST /api/dev/submit` → `/v1/dev/submit`
+  (carrying the attested webuser identity, like the other `/api/*` proxies). The
+  `/v1/dev/submit` route already exists.
+- **Frontend:** a "Submit proposal" panel in the **Workflows** tab — a Markdown
+  textarea (`proposal_md`) + a workflow `<select>` (default `build`, from
+  `/api/workflow/defs`) + a Submit button. On success show the new
+  `work_item_id` and refresh the run list.
+
+### B2. Approve / reject a parked human gate
+- **Backend (new):** `POST /v1/workflow/items/<id>/gate {gate, decision}` where
+  decision ∈ {approve, reject}. Approve → `wfe_approval_sign` +
+  `wfe_approval_record` (HMAC with the operator key, **server-side** — the
+  webchat user never sees the key); reject → record a `reject` lifecycle event
+  and drive the gate's fail path. Then `wfe_scheduler_notify()` to resume.
+  Webchat proxy `POST /api/workflow/items/<id>/gate`. Capability: CAP_DELEGATE
+  (webuser-attested), matching `/v1/dev/submit`.
+- **Frontend:** in the Workflows run viewer, when a run's `pause_reason` is
+  `pending_human`, show **Approve** / **Reject** buttons that call the proxy and
+  refresh.
+
+### B3. Docs
+Flip the doc's "in progress" notes (just corrected in #527) to describe the
+shipped submit form + in-tab gate controls.
+
+## C — "Random" delegate
+
+A workflow step (panel lens / producing step) can be assigned the delegate
+**`$random`**; at runtime it resolves to a uniformly-random agent from the
+configured roster.
+
+- **Composer (frontend):** add `Random` to the delegate picker suggestions in
+  `Workflows.tsx` (stored as the sentinel `$random`).
+- **Runtime (backend):** a small resolver `wfe_resolve_delegate(name, acfg)` —
+  if `name == "$random"`, pick a uniformly-random enabled agent from `acfg`
+  (seedable for tests); else return `name`. Wire it everywhere a step's delegate
+  name becomes an agent: the panel provider and the live delegate provider.
+
+## Open questions → roundtable
+
+- **Q1 (authz).** The approval key is operator-only by design; the webchat is
+  single-principal. Is "any authenticated webchat user may approve a gate via the
+  server-side signer" acceptable, or should gate-approval require a stronger
+  attestation than `/v1/dev/submit`?
+- **Q2 (reject semantics).** Should `reject` loop the gate's `on_fail` (retry) or
+  force terminal `rejected`? Per-gate, or a fixed policy?
+- **Q3 (random scope + fairness).** Should `$random` exclude the primary/just-used
+  delegate (avoid repeats) or be pure-uniform? Does it apply to panels only, or
+  also producing steps? How does it behave while the live panel provider is still
+  `DEGRADED` (not yet composable)?
+- **Q4 (idempotency).** Double-approve / approve-after-resume races — the signed
+  approval is content-hash-bound; confirm a stale approval can't re-fire.
+
+## Roundtable resolutions (2026-06-19, security + architect lenses — CHANGES-REQUESTED → incorporated)
+
+Both lenses flagged the same blockers; adopted:
+
+- **Q1 / B2 authz (BLOCKING — privilege escalation):** the operator-only gate
+  signer must NOT be reachable by a mere `CAP_DELEGATE` webuser. Gate approval
+  requires a **distinct operator-level capability** (`CAP_OPERATOR`), separate
+  from `/v1/dev/submit`'s `CAP_DELEGATE`. The signing key stays server-side; the
+  webchat (single-principal) maps its admin to the operator cap. Documented as a
+  single-principal assumption with per-gate ACLs as a future extension.
+- **Q2 reject semantics (BLOCKING):** `reject` is **terminal (`rejected`) by
+  default**; a gate may opt into retry via `retry_on_reject: true` in its def
+  (follow `on_fail`). Prevents unintended loops/DoS.
+- **Q3 `$random` (BLOCKING — degraded/empty behavior):** resolver picks a
+  uniformly-random **enabled** agent via a CSPRNG, **seedable for tests**; **pure
+  uniform** (no exclusions); applies to producing steps and panels. If the roster
+  is empty it **fails fast with a clear error** — it never leaks the literal
+  `$random` sentinel downstream. (The live panel provider is still DEGRADED, so
+  `$random` is effective on producing steps now; panel use lands when the panel
+  provider is wired.)
+- **Q4 idempotency:** approvals are content-hash-bound; additionally **guard with
+  `wfe_approval_present`** before recording, and return success (not an error) on
+  a duplicate approve so the UI is race-safe.
+
+**Design status: resolved.** Implementation order: C (random resolver + composer
+option, lowest risk) → B1 (submit proxy + form) → B2 (operator-capped gate
+endpoint + approve/reject UI), each compiled + tested, then the doc flips from
+"in progress" to shipped.

--- a/frontend/src/pages/Workflows.tsx
+++ b/frontend/src/pages/Workflows.tsx
@@ -324,6 +324,7 @@ export default function Workflows() {
   const [proposalMd, setProposalMd] = useState("");
   const [submitMsg, setSubmitMsg] = useState("");
   const [submitting, setSubmitting] = useState(false);
+  const [gateMsg, setGateMsg] = useState("");
   // This tab's selected project (per-tab project space). Held so the workflow
   // context can scope to it; execution-in-project flows through a chat session's
   // cwd today, so this primarily persists the selection + offers clone here.
@@ -368,6 +369,30 @@ export default function Workflows() {
       setSubmitting(false);
     }
   }, [proposalMd, graph, refreshLists]);
+
+  // Approve / reject the human gate the selected run is parked at. Operator-only
+  // server-side (CAP_WORKFLOW_ADMIN); the scheduler resumes the run on approve.
+  const decideGate = useCallback(
+    async (decision: "approve" | "reject") => {
+      if (!runItem) return;
+      setGateMsg("");
+      try {
+        const { status, data } = await postJSON<{ error?: string }>(
+          `/api/workflow/items/${encodeURIComponent(runItem.id)}/gate`,
+          { decision },
+        );
+        if (status >= 200 && status < 300) {
+          setGateMsg(decision === "approve" ? "Approved — resuming." : "Rejected.");
+          refreshLists();
+        } else {
+          setGateMsg(data.error || `failed (HTTP ${status})`);
+        }
+      } catch {
+        setGateMsg("failed");
+      }
+    },
+    [runItem, refreshLists],
+  );
 
   // The persona list feeds both the per-step persona pickers and the manager;
   // refreshed after any persona create/edit/delete.
@@ -887,6 +912,20 @@ export default function Workflows() {
             <Field k="state" v={runItem.state} />
             <Field k="pause" v={runItem.pause_reason || "—"} />
             <Field k="version" v={runItem.version.slice(0, 12)} />
+            {runItem.pause_reason === "pending_human" && (
+              <div style={{ display: "flex", alignItems: "center", gap: 8, marginTop: 8 }}>
+                <button onClick={() => void decideGate("approve")} style={btn}>
+                  Approve
+                </button>
+                <button
+                  onClick={() => void decideGate("reject")}
+                  style={{ ...btn, background: "#fbeaea", color: "#a33" }}
+                >
+                  Reject
+                </button>
+                {gateMsg && <span style={{ fontSize: 11, color: "#667" }}>{gateMsg}</span>}
+              </div>
+            )}
             {graph &&
               runItem.workflow === graph.name &&
               runItem.version &&

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -73,9 +73,13 @@ typedef struct cJSON cJSON;
 #define CAP_SESSION_READ   (1u << 13)
 #define CAP_SESSION_ADMIN  (1u << 14)
 #define CAP_DASHBOARD_READ (1u << 15)
+/* Operator-level: approve/reject autonomous-workflow human gates. Deliberately
+ * OUTSIDE CAPS_AUTHENTICATED (full-trust / UDS / webchat-admin only), so a mere
+ * authenticated/delegate bearer cannot drive a human gate. */
+#define CAP_WORKFLOW_ADMIN (1u << 16)
 
 /* Composite capability sets */
-#define CAPS_ALL 0xFFFFu
+#define CAPS_ALL 0x1FFFFu
 #define CAPS_READ_ONLY                                                                             \
    (CAP_CHAT | CAP_MEMORY_READ | CAP_RULES_READ | CAP_INDEX_READ | CAP_SESSION_READ |              \
     CAP_DASHBOARD_READ | CAP_DESCRIBE_READ)

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -27,6 +27,8 @@
 #include "aimee_home.h"       /* aimee_home — proposal artifact dir for /v1/dev/submit */
 #include "wfe_engine.h"       /* wfe_work_item_create — POST /v1/dev/submit intake */
 #include "wfe_scheduler.h"    /* wfe_scheduler_notify — resume the autonomy driver */
+#include "wfe_approval.h"     /* wfe_approval_record/present — human-gate approval */
+#include "wfe_store.h"        /* db1_work_item_* — gate approve/reject */
 #include <sys/stat.h>         /* mkdir for the proposal artifact dir */
 #include <time.h>             /* unique proposal artifact filename */
 
@@ -189,8 +191,8 @@ static int rh_dev_submit(const route_req_t *rq, char *resp, int cap)
    }
    cJSON *jwf = cJSON_GetObjectItemCaseSensitive(body, "workflow");
    cJSON *jrepo = cJSON_GetObjectItemCaseSensitive(body, "repo");
-   const char *workflow = (jwf && cJSON_IsString(jwf) && jwf->valuestring[0]) ? jwf->valuestring
-                                                                              : "build";
+   const char *workflow =
+       (jwf && cJSON_IsString(jwf) && jwf->valuestring[0]) ? jwf->valuestring : "build";
    const char *repo = (jrepo && cJSON_IsString(jrepo)) ? jrepo->valuestring : "";
 
    /* Persist the submitted proposal to a unique artifact path. */
@@ -233,6 +235,70 @@ static int rh_dev_submit(const route_req_t *rq, char *resp, int cap)
    snprintf(resp, cap, "%s", s ? s : "{}");
    free(s);
    cJSON_Delete(ok);
+   return 200;
+}
+
+/* POST /v1/workflow/items/<id>/gate {decision:"approve"|"reject", gate?} —
+ * approve or reject the human gate a run is parked at. Operator-level
+ * (CAP_WORKFLOW_ADMIN, outside CAPS_AUTHENTICATED) so a mere delegate/authenticated
+ * bearer cannot drive a gate. Approve records a non-repudiable, content-hash-bound
+ * approval (HMAC-signed server-side with the operator key) and clears the pause;
+ * reject is terminal. The scheduler then resumes the run. */
+static int rh_workflow_gate(const route_req_t *rq, char *resp, int cap)
+{
+   const char *id = rq->id;
+   if (!id || !id[0])
+   {
+      snprintf(resp, cap, "{\"error\":\"missing work item id\"}");
+      return 400;
+   }
+   db1_work_item_t wi;
+   if (db1_work_item_get(id, &wi) != 1)
+   {
+      snprintf(resp, cap, "{\"error\":\"no such work item\"}");
+      return 404;
+   }
+   cJSON *body = rq->body ? cJSON_Parse(rq->body) : NULL;
+   cJSON *jdec = body ? cJSON_GetObjectItemCaseSensitive(body, "decision") : NULL;
+   cJSON *jgate = body ? cJSON_GetObjectItemCaseSensitive(body, "gate") : NULL;
+   const char *decision = (jdec && cJSON_IsString(jdec)) ? jdec->valuestring : "";
+   /* Default the gate to the stage the run is parked at. */
+   const char *gate = (jgate && cJSON_IsString(jgate) && jgate->valuestring[0]) ? jgate->valuestring
+                                                                                : wi.current_stage;
+   const char *actor = server_http_identity_principal();
+   if (!actor || !actor[0])
+      actor = "operator";
+
+   int rc;
+   if (strcmp(decision, "approve") == 0)
+   {
+      /* Idempotent: a duplicate approve for the same content hash is success. */
+      if (!wfe_approval_present(id, gate, wi.content_hash))
+         rc = wfe_approval_record(id, gate, wi.content_hash, actor);
+      else
+         rc = 0;
+      if (rc == 0)
+         (void)db1_work_item_clear_pause(id);
+   }
+   else if (strcmp(decision, "reject") == 0)
+   {
+      rc = db1_work_item_set_terminal(id, "rejected");
+   }
+   else
+   {
+      cJSON_Delete(body);
+      snprintf(resp, cap, "{\"error\":\"decision must be 'approve' or 'reject'\"}");
+      return 400;
+   }
+   cJSON_Delete(body);
+   if (rc != 0)
+   {
+      snprintf(resp, cap, "{\"error\":\"gate %s failed\"}", decision);
+      return 500;
+   }
+   wfe_scheduler_notify(); /* resume the run server-side */
+   snprintf(resp, cap, "{\"work_item_id\":\"%s\",\"gate\":\"%s\",\"decision\":\"%s\"}", id, gate,
+            decision);
    return 200;
 }
 
@@ -1649,6 +1715,9 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/workflow/validate", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_validate},
     {"POST", "/v1/workflow/save", NULL, RM_EXACT, NULL, CAP_SESSION_ADMIN, rh_wf_save},
     {"GET", "/v1/workflow/items", NULL, RM_EXACT, NULL, CAP_DASHBOARD_READ, rh_wf_items},
+    /* Operator-only: approve/reject the human gate a run is parked at. The
+     * suffix row precedes the bare /<id> row. */
+    {"POST", "/v1/workflow/items/", "/gate", RM_PREFIX, NULL, CAP_WORKFLOW_ADMIN, rh_workflow_gate},
     {"GET", "/v1/workflow/items/", NULL, RM_PREFIX, NULL, CAP_DASHBOARD_READ, rh_wf_item},
 
     {"GET", "/v1/sessions", NULL, RM_EXACT, NULL, CAP_SESSION_READ, rh_sessions_list},

--- a/webchat/workflow.go
+++ b/webchat/workflow.go
@@ -87,5 +87,32 @@ func (s *server) handleWorkflowItems(w http.ResponseWriter, r *http.Request) {
 		s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/items", "")
 		return
 	}
+	// POST /api/workflow/items/<id>/gate -> operator approve/reject of a parked
+	// human gate. <id> must be one safe segment.
+	if r.Method == http.MethodPost && strings.HasSuffix(r.URL.Path, "/gate") {
+		id := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/workflow/items/"), "/gate")
+		if id == "" || strings.ContainsAny(id, "/.%") {
+			http.Error(w, `{"error":"bad path"}`, http.StatusBadRequest)
+			return
+		}
+		const maxBody = 1 << 20
+		body, _ := io.ReadAll(io.LimitReader(r.Body, maxBody+1))
+		if len(body) > maxBody {
+			http.Error(w, `{"error":"request too large"}`, http.StatusRequestEntityTooLarge)
+			return
+		}
+		ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+		defer cancel()
+		st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost,
+			"/v1/workflow/items/"+id+"/gate", body)
+		if err != nil {
+			http.Error(w, `{"error":"aimee-server unavailable"}`, http.StatusBadGateway)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(st)
+		_, _ = w.Write(data)
+		return
+	}
 	s.proxyWorkflow(w, r, http.MethodGet, "/v1/workflow/items/", "/api/workflow/items/")
 }


### PR DESCRIPTION
Completes the autonomous-development webchat GUI (B2 of the A/B/C work): approve or reject a parked human gate from the Workflows tab.

## Security model (per the roundtable, which flagged a privilege-escalation in the naive design)
- **New `CAP_WORKFLOW_ADMIN`** (operator-level, **outside `CAPS_AUTHENTICATED`**) gates the endpoint — a mere `CAP_DELEGATE`/authenticated bearer **cannot** drive a gate; only a full-trust/webchat-operator caller can. (`CAPS_ALL` widened to `0x1FFFF`; verified no hardcoded `0xFFFF`, all `== CAPS_ALL` checks use the macro.)
- Approvals are **HMAC-signed server-side** with the operator key (`$AIMEE_HOME/.approval-key`) and **content-hash-bound** — a delegate can never forge one. **Idempotent** (guarded by `wfe_approval_present`). `reject` is **terminal**.

## Endpoint + UI
- `POST /v1/workflow/items/<id>/gate {decision:"approve"|"reject", gate?}` → records approval + clears pause (approve) or sets terminal `rejected`; `wfe_scheduler_notify` resumes. Documented in `openapi-server-v1.yaml`.
- webchat `/api/workflow/items/<id>/gate` proxy (webuser identity); **Approve / Reject** buttons in the Workflows tab's Run state panel.
- Docs flipped to the shipped GUI (this supersedes the API-first correction in #527).

## Verification
`make server` links; **full lint (clang-format-19) + server-api conformance green**; wfe suites + server-http/dispatch capability tests pass; frontend `tsc` clean.

With this, **A + B + C are all complete**: doc accurate, Random delegate, submit form, and gate approve/reject.