### PR TITLE
perf(webchat): memoize chat messages — fix O(messages×tokens) markdown re-parse

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
 import { Spinner, Tabs, tokens } from '@rakuensoftware/smoothgui';
 import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolBlock, TurnSummaryCard } from './chat/ChatPrimitives';
-import { escHtml, renderMd, renderWithMentions } from './chat/markdown';
+import { renderWithMentions } from './chat/markdown';
 import ProjectPicker from '../components/ProjectPicker';
 import { useSessions } from '../SessionContext';
 
@@ -2595,10 +2595,10 @@ export default function Chat() {
       }}>
         {streamMsgs.map(m => {
           if (m.type === 'user') {
-            return <Message key={m.id} role="user" html={escHtml(m.text)} />;
+            return <Message key={m.id} role="user" text={m.text} />;
           }
           if (m.type === 'assistant') {
-            return <Message key={m.id} role="assistant" html={renderMd(m.text)} />;
+            return <Message key={m.id} role="assistant" text={m.text} />;
           }
           if (m.type === 'thinking') {
             return <ThinkingBlock key={m.id} text={m.thinkText ?? ''} />;

--- a/frontend/src/pages/chat/ChatPrimitives.tsx
+++ b/frontend/src/pages/chat/ChatPrimitives.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { memo, useMemo, useState } from 'react';
 import { tokens } from '@rakuensoftware/smoothgui';
+import { escHtml, renderMd } from './markdown';
 
 interface BootstrapStack {
   name: string;
@@ -33,7 +34,13 @@ export function BootstrapBanner({ onGenerate, onDismiss, stacks }: BannerProps) 
   );
 }
 
-export function Message({ role, html }: { role: 'user' | 'assistant'; html: string }) {
+/* A single chat bubble. Takes the RAW text and renders markdown (assistant) or
+ * escapes (user) INTERNALLY, memoized on the text. Combined with React.memo on
+ * the component, this means a streaming turn only re-parses the one message whose
+ * text is growing — the other (unchanged) messages are skipped entirely, instead
+ * of every message being re-parsed on every token. */
+export const Message = memo(function Message({ role, text }: { role: 'user' | 'assistant'; text: string }) {
+  const html = useMemo(() => (role === 'user' ? escHtml(text) : renderMd(text)), [role, text]);
   const styles: React.CSSProperties = {
     maxWidth: '80%',
     padding: '10px 14px',
@@ -52,18 +59,18 @@ export function Message({ role, html }: { role: 'user' | 'assistant'; html: stri
     borderBottomLeftRadius: role === 'assistant' ? 2 : 10,
   };
   return <div style={styles} dangerouslySetInnerHTML={{ __html: html }} />;
-}
+});
 
-export function ThinkingBlock({ text }: { text: string }) {
+export const ThinkingBlock = memo(function ThinkingBlock({ text }: { text: string }) {
   return (
     <details style={{ margin: '4px 0', padding: '8px 10px', background: tokens.surfaceAlt, borderLeft: `3px solid ${tokens.borderMedium}`, borderRadius: '4px', fontSize: '12px', color: tokens.textFaint, alignSelf: 'flex-start', maxWidth: '80%' }}>
       <summary style={{ cursor: 'pointer', color: tokens.textPale, fontStyle: 'italic' }}>Thinking…</summary>
       <pre style={{ marginTop: '6px', fontSize: '11px', color: tokens.textHint, maxHeight: '200px', overflowY: 'auto', whiteSpace: 'pre-wrap' }}>{text}</pre>
     </details>
   );
-}
+});
 
-export function ToolBlock({ name, args, result }: { name: string; args: string; result?: string }) {
+export const ToolBlock = memo(function ToolBlock({ name, args, result }: { name: string; args: string; result?: string }) {
   const pending = result === undefined;
   return (
     <details style={{ margin: '4px 0', padding: '8px 10px', background: tokens.surfaceAlt, borderLeft: `3px solid ${tokens.primary}`, borderRadius: '4px', fontSize: '12px', color: tokens.textFaint, alignSelf: 'flex-start', maxWidth: '80%' }}>
@@ -79,18 +86,18 @@ export function ToolBlock({ name, args, result }: { name: string; args: string; 
       )}
     </details>
   );
-}
+});
 
-export function TurnSummaryCard({ text }: { text: string }) {
+export const TurnSummaryCard = memo(function TurnSummaryCard({ text }: { text: string }) {
   return (
     <details style={{ margin: '2px 0', padding: '6px 10px', background: tokens.surfaceAlt, borderLeft: `3px solid ${tokens.borderMedium}`, borderRadius: '4px', fontSize: '12px', color: tokens.textFaint, alignSelf: 'flex-start', maxWidth: '80%' }}>
       <summary style={{ cursor: 'pointer', color: tokens.textSecondary, fontStyle: 'italic', userSelect: 'none' }}>Turn summary</summary>
       <div style={{ marginTop: '6px', fontSize: '12px', color: tokens.textPale, lineHeight: 1.5 }}>{text}</div>
     </details>
   );
-}
+});
 
-export function DiffBlock({ path, diff }: { path?: string; diff: string }) {
+export const DiffBlock = memo(function DiffBlock({ path, diff }: { path?: string; diff: string }) {
   const lines = diff.split('\n');
   return (
     <details style={{ margin: '4px 0', padding: '8px 10px', background: '#0d1117', borderLeft: '3px solid #444', borderRadius: '4px', fontSize: '12px', alignSelf: 'flex-start', maxWidth: '90%' }}>
@@ -106,7 +113,7 @@ export function DiffBlock({ path, diff }: { path?: string; diff: string }) {
       </pre>
     </details>
   );
-}
+});
 
 export function RewindMarker({ snapshotId, sid }: { snapshotId: number; sid: string }) {
   const [status, setStatus] = useState<'idle' | 'pending' | 'done' | 'error'>('idle');


### PR DESCRIPTION
## Why the web GUI burned CPU

The chat transcript rendered as:
```tsx
{streamMsgs.map(m => <Message html={renderMd(m.text)} />)}
```
`renderMd`/`escHtml` ran **inline in the parent on every render**, and **every streamed token** triggered `setStreamMsgs(...)` → a full parent re-render. So the markdown of **every** message was re-parsed on **every** token: **O(messages × tokens)** full markdown parses per turn. In a long conversation streaming a long reply this is tens of thousands of re-parses — exactly the "enormous CPU for a simple app" symptom.

## Fix

- `Message` now takes the **raw text** and renders markdown **internally** via `useMemo([text])`, wrapped in `React.memo`.
- The streaming update returns the **same object** for unchanged messages, so their `text` prop is referentially stable → `memo` skips them entirely. Only the one message whose text is growing re-parses.
- Memoized the other heavy primitives too (`ThinkingBlock`, `ToolBlock`, `TurnSummaryCard`, `DiffBlock`).

Result: per-turn markdown work drops from **O(messages × tokens)** to **O(tokens)** on the single active message. No behavior change; pure render-path optimization.

`tsc --noEmit` clean; `npm run build` green.

### Possible follow-up
If fast streams still spike CPU, a second optimization is to coalesce stream tokens into one render per animation frame (rAF batching) so the large parent component re-renders ~60×/s instead of once per token. Deferred here to keep this change low-risk and ordering-safe.