### PR TITLE
docs: strip em-dashes and AI-isms from README and autonomous-dev doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ C, sub-10ms, with no cloud dependencies.
 
 It starts as persistent memory for your AI coding tool. One install, and every
 session starts knowing what the last one learned. The same substrate scales to a
-company-wide knowledge base that distills what your whole organization knows — code,
-product, sales, support, ops — and routes work to the cheapest capable model. See
+company-wide knowledge base that distills what your whole organization knows across
+code, product, sales, support, and ops, then routes work to the cheapest capable
+model. See
 [How aimee learns](docs/KNOWLEDGE.md).
 
 ## The problem
@@ -61,7 +62,7 @@ information decays. Every session starts already knowing what matters.
 
 A curator pipeline extracts, synthesizes, judges, and promotes that into a typed
 graph, and reflects on idle time to improve it. Point a team at a shared `aimee-kb`
-and it shares everyone's knowledge with everyone, across all domains, not just code.
+and the whole team shares one knowledge base, across every domain.
 See [How aimee learns](docs/KNOWLEDGE.md).
 
 ### Guardrails

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -1,8 +1,8 @@
 # Autonomous Development
 
 > **Hand aimee a proposal; it builds the change end-to-end.** You submit a
-> written proposal and aimee runs the *entire* development lifecycle —
-> design, plan, implement, review, PR — **server-side and unattended**. Closing
+> written proposal and aimee runs the *entire* development lifecycle (design,
+> plan, implement, review, PR) **server-side and unattended**. Closing
 > the browser tab does not stop it. This is **core functionality and is on by
 > default**; safety comes from the workflow's *gates*, not an off-switch.
 >
@@ -15,16 +15,16 @@ Autonomous development turns a proposal into a finished, reviewed pull request
 without a human driving each step. It is a thin orchestration layer over three
 things aimee already has:
 
-- the **workflow engine** (`wfe`) — a block-composed state machine with durable
+- the **workflow engine** (`wfe`), a block-composed state machine with durable
   per-work-item state, gates, and an audit log;
-- **delegates** — sub-agents that do bounded work (here: write code with tools in
+- **delegates**, sub-agents that do bounded work (here: write code with tools in
   an isolated worktree); and
-- the **server-owned turn lifecycle** — a turn/run is owned by the server, not by
+- the **server-owned turn lifecycle**, a turn/run is owned by the server, not by
   a client connection, so it runs to completion regardless of who is watching.
 
 The **primary agent manages; delegates do the work.** The primary (the engine
 plus a coordinator) decomposes the plan, dispatches each unit to a delegate,
-verifies the result, and — if the work is not acceptable — sends it back to a
+verifies the result, and, if the work is not acceptable, sends it back to a
 *different* delegate. The primary never writes the code itself.
 
 Throughout this page, a **run** and a **work item** are the same thing: one
@@ -34,7 +34,7 @@ execution of a workflow for one proposal. The **primary agent** is the manager
 ## Prerequisites
 
 - A running aimee server (`aimee-server`, or the combined image). The feature is
-  default-on — there is nothing to enable.
+  default-on, there is nothing to enable.
 - An API token for the `/v1` surface (`Authorization: Bearer …`). On a remote
   client this is your configured server token; locally the dev bearer works.
 - The default `build` workflow is **seeded automatically** into
@@ -60,7 +60,7 @@ curl -sX POST http://127.0.0.1:8740/v1/dev/submit \
 ```
 
 A `401` means the token is missing/invalid; `400` means `proposal_md` was empty.
-On success the run proceeds on the server — you can close the connection and it
+On success the run proceeds on the server, you can close the connection and it
 continues. The webchat **Workflows** tab is the GUI for all of this: a **Submit
 proposal** panel (textarea → runs on the chosen workflow), a live **run list**
 with each run's stage/state, and **Approve / Reject** buttons on a run parked at
@@ -76,7 +76,7 @@ Request fields:
 
 ## The lifecycle
 
-A run is a work item bound to a **workflow** — by default `build`
+A run is a work item bound to a **workflow**, by default `build`
 (`config/workflows/build.yaml`), the standard dev lifecycle:
 
 ```
@@ -105,14 +105,14 @@ with a `security` lens before `pr.open` adds a mandatory security review.
 
 1. **Split.** The plan is decomposed into independent, file/module-scoped units.
 2. **Dispatch.** Each unit goes to an `engineer` delegate that runs **with tools
-   pinned to the work item's own git worktree** — it edits files in place — and
+   pinned to the work item's own git worktree**, it edits files in place, and
    the change is committed on the work-item branch.
 3. **Verify, as hard as possible.** Verification runs through the engine's gates
    and delegates, never the primary's own hands, in ascending cost:
-   - mechanical — the build compiles, targeted tests/lint pass (`gate.ci`);
-   - review — a roundtable / `reviewer` panel checks the change against its spec
+   - mechanical, the build compiles, targeted tests/lint pass (`gate.ci`);
+   - review, a roundtable / `reviewer` panel checks the change against its spec
      (`gate.roundtable`);
-   - adversarial — for risky changes, skeptic verifiers attempt to refute it.
+   - adversarial, for risky changes, skeptic verifiers attempt to refute it.
 4. **Re-delegate on reject.** When verification rejects a unit, the engine loops
    back to `implement`, which re-dispatches the unit to a *different* delegate
    (fresh perspective), bounded by a retry cap; on exhaustion it parks for a
@@ -128,7 +128,7 @@ Autonomous does not mean unsupervised. The workflow reserves **human gates**
 - auto-advances *machine* gates (CI, mergeability, roundtable verdicts);
 - auto-satisfies **only** the human gates the submitter explicitly preauthorized;
 - **parks** at every other human gate (`pending_human`) until a person acts;
-- **never forges a human approval** — gate-override is a signed, human-only action
+- **never forges a human approval**, gate-override is a signed, human-only action
   capped at a small number of uses.
 
 Approve or reject a parked gate from the webchat Workflows tab's **Run state**
@@ -144,7 +144,7 @@ The run and its delegate turns are owned by the server, not your connection:
 
 - a turn publishes its full stream to the presence event ring and runs to
   completion even if the client drops;
-- the **autonomy scheduler** — a background thread — drives every active
+- the **autonomy scheduler**, a background thread, drives every active
   autonomous work item forward, waking on a new submission, on a satisfied gate,
   and on a periodic backstop sweep (crash recovery);
 - reconnecting replays the run from a cursor, so you see what happened while you
@@ -159,15 +159,15 @@ Autonomous development is default-on; the guardrails are structural, not a toggl
 - **Human gates** are never auto-satisfied unless preauthorized for that run, and
   gate-override stays human-only and capped.
 - **Per-run budget ceiling.** A work item carries a cost cap; on breach the run
-  **parks** (`budget_exceeded`) for a human — it never silently runs away.
+  **parks** (`budget_exceeded`) for a human, it never silently runs away.
   (Today the cap is a work-item field; setting it *from* `/v1/dev/submit` is not
-  yet exposed — see [Current limitations](#current-limitations).)
+  yet exposed, see [Current limitations](#current-limitations).)
 - **Autonomous merges only target `testing`.** Promotion to `main` is always a
   human action.
 - **Every commit and PR is audited** and attributed to the run. Generated commits
   and PRs carry **no AI co-authorship trailers** (enforced repo-wide by a
   required CI check).
-- **Never auto-retry without new input** (a CI log, a roundtable verdict) — this
+- **Never auto-retry without new input** (a CI log, a roundtable verdict), this
   prevents infinite loops.
 - A delegate's model refusal or a permanent/unrecoverable error terminates the
   unit; transient errors are retried within the cap; degraded panels, budget
@@ -175,16 +175,16 @@ Autonomous development is default-on; the guardrails are structural, not a toggl
 
 ## Observability
 
-- **Webchat Workflows tab** — live progress per work item: current stage, gate
+- **Webchat Workflows tab**, live progress per work item: current stage, gate
   verdicts, parked state, and the actionable approve/reject controls for human
   gates.
-- **Event stream** — a run publishes its full turn stream (text, tool calls,
+- **Event stream**, a run publishes its full turn stream (text, tool calls,
   usage, boundaries) to the presence event ring; the webchat replays it live and,
   after a disconnect, from a cursor.
-- **Durable audit** — every step, verdict, and cost is recorded in the DB1
+- **Durable audit**, every step, verdict, and cost is recorded in the DB1
   `lifecycle_*` tables (per work item), including the commit hashes produced and
   the gate decisions. This is the source of truth for "what did the run do".
-- **Attribution** — autonomous commits and PRs are attributed to the run and
+- **Attribution**, autonomous commits and PRs are attributed to the run and
   carry **no** AI co-authorship trailers.
 
 ## When a run parks (failure modes & recovery)
@@ -204,7 +204,7 @@ The autonomy driver **never forges a human approval**. A stuck human gate can be
 cleared by a signed, human-only **gate-override** (capped at a small number of
 uses); after that it forces a terminal `rejected`. Machine failures follow the
 taxonomy in [Safety and limits](#safety-and-limits): transient → retry,
-permanent/refusal → terminal, degraded/budget/forge → park — and a unit is never
+permanent/refusal → terminal, degraded/budget/forge → park, and a unit is never
 auto-retried without new input (a CI log or a roundtable verdict).
 
 ## Current limitations
@@ -235,7 +235,7 @@ Honest scope of the current implementation (the design allows for more):
 
 | component | role |
 |-----------|------|
-| `POST /v1/dev/submit` (`rh_dev_submit`) | intake — the only entry; creates an autonomous work item, seeds the proposal, notifies the scheduler |
+| `POST /v1/dev/submit` (`rh_dev_submit`) | intake, the only entry; creates an autonomous work item, seeds the proposal, notifies the scheduler |
 | autonomy scheduler (`wfe_scheduler`) | server-owned thread driving active autonomous work items via `wfe_autonomy_run` |
 | workflow engine (`wfe_*`) | block-composed lifecycle, gates, durable state + audit (`lifecycle_*` tables) |
 | live delegate provider (`wfe_live_delegate`) | the engine→delegate bridge: runs a block's role as a tool-using agent in the work-item worktree, then commits. (It uses the same in-process delegate execution as `aimee delegate`/`/v1/delegate/run`, but is invoked *by the engine* per block rather than by a user.) |
@@ -244,12 +244,12 @@ Honest scope of the current implementation (the design allows for more):
 
 **Invariants** (by construction): aimee never self-initiates; the primary manages
 while delegates do the work; rejected work is re-delegated; **all** autonomous
-action flows through the workflow engine — there is no side-channel that takes an
+action flows through the workflow engine, there is no side-channel that takes an
 autonomous action outside the engine's gates, budget, and audit.
 
 ## See also
 
-- [Delegates](DELEGATES.md) — the sub-agents that do the work
-- [Architecture](ARCHITECTURE.md) — where the engine sits in the system
-- `docs/proposals/pending/full-autonomous-development.md` — the design + the
+- [Delegates](DELEGATES.md), the sub-agents that do the work
+- [Architecture](ARCHITECTURE.md), where the engine sits in the system
+- `docs/proposals/pending/full-autonomous-development.md`, the design + the
   roundtable-resolved open questions

--- a/src/README.md
+++ b/src/README.md
@@ -728,7 +728,7 @@ and bearer. See [Run in Docker](#run-in-docker) for every topology.
 Each developer installs only the `aimee` CLI and points it at the server. Prebuilt
 binaries for **Linux, macOS, and Windows** are attached to every GitHub release;
 download one, put it on your `PATH`, and skip the build. To build it yourself,
-configure with `-DAIMEE_THIN_CLIENT=ON` (a C compiler is the only dependency — no
+configure with `-DAIMEE_THIN_CLIENT=ON` (a C compiler is the only dependency; no
 Go, libpq, or zstd); see [Build just the thin client](#build-just-the-thin-client).
 
 Point the client at the server per-invocation, via the environment, or persist it:
@@ -784,7 +784,8 @@ cd aimee
 ```
 
 `install-deps.sh` installs the system packages aimee builds against and bootstraps
-the `aimee_shared` PostgreSQL database — the only steps that need root. `install.sh`
+the `aimee_shared` PostgreSQL database. Those are the only steps that need root.
+`install.sh`
 builds from source, installs binaries to `~/.local/bin/`, installs service units
 where supported (systemd user units on Linux, launchd agents on macOS), enables
 `aimee-kb` then `aimee-server`, and configures hooks + MCP for every detected tool.
@@ -914,7 +915,7 @@ graph TB
   live in one database (`aimee_shared`) with the `pg_trgm` and `vector` (pgvector)
   extensions. Scale it like any Postgres: bigger instance, pooling, read replicas.
   For large vector corpora add **`pgvectorscale`** (StreamingDiskANN) on top of
-  pgvector — identical data and queries, so switching is a reindex, not a migration.
+  pgvector, with identical data and queries, so switching is a reindex, not a migration.
   Small and local installs stay on plain pgvector (HNSW).
 
 See the [Manual](../MANUAL.md#275-scaling-and-multi-user-deployment) and


### PR DESCRIPTION
Removes em-dashes (a clear AI-ism tell) and a few "not just"-style flourishes from the docs I touched this session:

- README.md
- src/README.md
- docs/AUTONOMOUS_DEVELOPMENT.md (28 em-dashes)

Replaced with commas, colons, or restructured sentences. No content changes; em-dash count is now zero in all three.