### PR TITLE
fix(db2/pool): release idle pool lease in the reflection thread (stuck-lease leak)

### DIFF
--- a/src/kb/kb_reflection.c
+++ b/src/kb/kb_reflection.c
@@ -20,6 +20,7 @@
 #include "cJSON.h"
 #include "config.h"
 #include "db2/artifacts.h"
+#include "db2/db2.h" /* db2_lease_release_idle */
 #include "kb_features.h"
 #include "kb_mdl.h"
 #include "kb_service.h"
@@ -269,6 +270,13 @@ static void *reflection_thread_main(void *arg)
 
    while (!ctx->stop)
    {
+      /* Return any pool connection a prior reflection pass acquired lazily
+       * (run_reflection_pass uses db2_conn() at lease depth 0, not an explicit
+       * begin/end scope) before idling, so this long-lived thread does not pin
+       * one pool member for its whole lifetime — the stuck-lease reaper flags it
+       * and it permanently shrinks the bounded pool. Matches the curator drain
+       * (kb_curator_drain.c) and the maintenance timer (kb_service_workers.c). */
+      db2_lease_release_idle();
       sleep(1);
       if (ctx->stop)
          break;


### PR DESCRIPTION
## Symptom
On a busy server, interactive `memory search` takes 4-10s (vs the <20ms search target). The DB2 pool reaper logs, continuously and growing for the whole process uptime:
```
aimee: db2.pool: member 0 leased 12810331ms (> 300000ms ceiling)  missed lease_end?
```
The embedder/reranker are fast (~0.3s / ~0.4s direct), so the latency is the search waiting to acquire a DB2 connection from a pool that is permanently down a member.

## Root cause
`reflection_thread_main` (`src/kb/kb_reflection.c`) runs `run_reflection_pass()`, which uses lazy `db2_conn()` leases at lease depth 0, then loops for the life of the process **without ever calling `db2_lease_release_idle()`**. After the first reflection pass it pins one pooled connection forever.

It was the **only** long-lived DB2-touching worker missing lease discipline:

| worker | discipline |
|---|---|
| curator drain (`kb_curator_drain.c`) | `db2_lease_release_idle()` per cycle ✓ |
| maintenance timer + service workers (`kb_service_workers.c`) | `db2_lease_release_idle()` per cycle ✓ |
| ingest workers (`kb_ingest_workers.c`) | `db2_lease_begin/_end` scope ✓ |
| mining (`kb_mining.c`) | `db2_lease_begin/_end` scope ✓ |
| **reflection (`kb_reflection.c`)** | **none — leaks** ✗ |

The `db2_lease_release_idle()` doc comment even names the workers that must call it ("curator drain, maintenance timer"); reflection was overlooked.

## Fix
Call `db2_lease_release_idle()` at the top of the reflection loop, matching the maintenance timer, so a reflection pass's connection is returned on the next tick instead of held for the thread's lifetime. One line + the `db2/db2.h` include.

`make server` builds clean (`-Werror`).