### PR TITLE
perf(memory): stage timing for memory.search (localize 4-12s search latency)

### DIFF
--- a/src/memory_core.c
+++ b/src/memory_core.c
@@ -686,6 +686,7 @@ void memory_coref_stats_reset(void)
 #include "platform_process.h"
 #include "memory_platform.h"
 #include "log.h"
+#include "util.h" /* util_now_ms — memory.search stage timing */
 #include "cJSON.h"
 #include "dogfood.h"
 #include <ctype.h>

--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1732,6 +1732,10 @@ static __thread memory_qembed_entry_t s_qembed[MEMORY_QEMBED_CAP];
  * embedder invocations). requests-minus-misses is the work the memo saved. */
 static __thread int s_qembed_requests = 0;
 static __thread int s_qembed_misses = 0;
+/* Per-search stage-timing probe (read+reset by the memory_search wrapper): wall
+ * time spent in actual embed spawns (cache misses) and how many ran. */
+static __thread long long s_qembed_ms = 0;
+static __thread int s_qembed_spawns = 0;
 
 /* Begin a fresh per-recall memo window. Call at every top-level recall entry
  * point before any lane embeds the query. */
@@ -1766,6 +1770,7 @@ static int memory_embed_text_runtime(const char *text, const char *command, floa
    }
 
    s_qembed_misses++;
+   long long _emb_t0 = util_now_ms();
    int dim = memory_embed_text(text, effective_cmd, out, max_dim);
    if (dim <= 0 && strcmp(effective_cmd, "builtin") != 0)
    {
@@ -1773,6 +1778,8 @@ static int memory_embed_text_runtime(const char *text, const char *command, floa
                 "query embedding failed for configured command; retrying with builtin embeddings");
       dim = memory_embed_text(text, "builtin", out, max_dim);
    }
+   s_qembed_ms += util_now_ms() - _emb_t0;
+   s_qembed_spawns++;
 
    /* Store on the way out so the other lanes / sub-queries of this same recall
     * reuse the vector instead of re-spawning the embedder. */

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -24,7 +24,25 @@ static double time_decay(const char *last_used)
    return exp(-0.02 * days);
 }
 
+static int memory_search_impl(char **clusters, int cluster_count, int limit, search_result_t *out,
+                              int max);
+
+/* Public entry: time the whole search and log a one-line stage breakdown so the
+ * embed-spawn cost (the suspected dominant term) is separable from the rest of
+ * retrieval/rerank. Counters live in memory_core_helpers.inc (same TU). */
 int memory_search(char **clusters, int cluster_count, int limit, search_result_t *out, int max)
+{
+   long long _t0 = util_now_ms();
+   s_qembed_ms = 0;
+   s_qembed_spawns = 0;
+   int n = memory_search_impl(clusters, cluster_count, limit, out, max);
+   aimee_log(LOG_INFO, "memory.search.timing", "total=%lldms embed=%lldms spawns=%d results=%d",
+             util_now_ms() - _t0, s_qembed_ms, s_qembed_spawns, n);
+   return n;
+}
+
+static int memory_search_impl(char **clusters, int cluster_count, int limit, search_result_t *out,
+                              int max)
 {
    if (!clusters || cluster_count <= 0)
       return 0;


### PR DESCRIPTION
Instrumentation to root-cause the slow live memory search (4-12s) honestly instead of guessing.

Established so far: embedder ~0.3s and reranker ~0.4s in isolation, host not CPU-bound, and the DB2 pool leak (#539) was **not** the cause (clearing it did not help). A single `memory_search` runs at least **two** query embeds (the `memory` and `unit` record-type collectors each call `memory_embed_text_runtime`, which spawns the embed command), with retry-to-builtin on failure.

This adds a one-line-per-search breakdown:
```
memory.search.timing total=<ms> embed=<ms> spawns=<n> results=<n>
```
via a thin wrapper around `memory_search` + two thread-local accumulators updated on the embed cache-miss path. It separates the embed-spawn cost from the rest, so the dominant term is measurable. Pure instrumentation, no behavior change. `make server` clean.