### PR TITLE
fix(db2): ephemeral mode (and the pg shim) are test-only, never production

### DIFF
--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -137,6 +137,12 @@ sqlite3 *db2_shared_sqlite(void)
 
 void db2_set_ephemeral(int ephemeral)
 {
+   /* Ephemeral is a TEST/EVAL-only mode (the in-memory sqlite shim). A real
+    * libpq instance must never enter it: ephemeral suppresses durable vector
+    * writes (db2_vector_index_sync_suppressed), so flipping it on in production
+    * would silently stop memory embeddings from persisting. Refuse, fail-safe. */
+   if (ephemeral && !aimee_pg_is_shim())
+      return;
    pthread_mutex_lock(&g_shared_sqlite_lock);
    g_shared_ephemeral = ephemeral ? 1 : 0;
    pthread_mutex_unlock(&g_shared_sqlite_lock);
@@ -144,6 +150,11 @@ void db2_set_ephemeral(int ephemeral)
 
 int db2_is_ephemeral(void)
 {
+   /* Belt-and-suspenders with db2_set_ephemeral: a real libpq (production)
+    * instance is NEVER ephemeral, regardless of the stored flag. Ephemeral
+    * only has meaning under the sqlite shim used by tests/evals. */
+   if (!aimee_pg_is_shim())
+      return 0;
    pthread_mutex_lock(&g_shared_sqlite_lock);
    int v = g_shared_ephemeral;
    pthread_mutex_unlock(&g_shared_sqlite_lock);
@@ -662,6 +673,9 @@ void db2_eval_close_temp_store(void)
 {
    if (!g_eval_temp_store_handle)
       return;
+   /* Restore non-ephemeral when the eval scratch store goes away, so the flag
+    * can never outlive the eval that set it. */
+   db2_set_ephemeral(0);
 #ifdef AIMEE_DISABLE_DB2_SQLITE_SHIM
    db2_maybe_clear_sqlite_cache(g_eval_temp_store_handle);
    db2_register_shared_sqlite(NULL);

--- a/src/tests/aimee_pg_sqlite_shim.c
+++ b/src/tests/aimee_pg_sqlite_shim.c
@@ -23,6 +23,15 @@
  * db2-specific contract tests run against actual Postgres.
  */
 
+/* TEST-ONLY enforcement: this shim makes aimee_pg_is_shim() return 1, which the
+ * ephemeral/vector-sync-suppression path keys off. It must NEVER be compiled
+ * into a production build. Production server/kb objects are built with
+ * AIMEE_DISABLE_DB2_SQLITE_SHIM; test objects are not. Fail the build loudly if
+ * this file is ever pulled into a production (shim-disabled) compilation. */
+#ifdef AIMEE_DISABLE_DB2_SQLITE_SHIM
+#error "aimee_pg_sqlite_shim.c is test-only and must not be compiled into a production build"
+#endif
+
 #include "db_postgres.h"
 #include "../db2/db2.h"
 #include "../db2/db2_internal.h"


### PR DESCRIPTION
## Directive
Ephemeral mode, and the pg shim it keys off, must be test-only and can never occur in a production instance.

## Why it matters
`db2_vector_index_sync_suppressed()` returns `db2_is_ephemeral()`. In ephemeral mode, memory-vector upserts silently no-op (return success, write nothing). If a real instance ever entered ephemeral mode, memory embeddings would stop persisting with no error, exactly the kind of silent failure that wastes hours to diagnose.

## Changes
- `db2_set_ephemeral()` refuses to enable ephemeral when the backend is real libpq (`aimee_pg_is_shim() == 0`).
- `db2_is_ephemeral()` always returns 0 on a real-libpq instance (belt-and-suspenders).
- `db2_eval_close_temp_store()` clears the flag when the eval scratch store closes, so it can never outlive the eval.
- `aimee_pg_sqlite_shim.c` (the only TU that makes `aimee_pg_is_shim()` return 1) now `#error`s if compiled with `AIMEE_DISABLE_DB2_SQLITE_SHIM` — the flag every production server/kb object is built with. Tests build without it and are unaffected; a production build can never pull the shim in.

## Verified
- `make server` clean.
- Shim compiles in test context (no flag); guard fires under the production flag.
- In tests `aimee_pg_is_shim()`→1, so `db2_set_ephemeral(1)` / `db2_is_ephemeral()` still work for the eval/test path.

## Note
Production binaries already never link the shim and `db_postgres.c` hardcodes `aimee_pg_is_shim()=0`, so production was already structurally non-ephemeral. This makes the invariant *enforced* rather than incidental. (It is a safety hardening; it is not the cause of the .254 `memory_points=0`, which is a separate reembed-persistence issue still being chased.)