### PR TITLE
promote: testing -> main (pool leak, search timing, ephemeral/shim test-only)

### DIFF
--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -137,6 +137,12 @@ sqlite3 *db2_shared_sqlite(void)
 
 void db2_set_ephemeral(int ephemeral)
 {
+   /* Ephemeral is a TEST/EVAL-only mode (the in-memory sqlite shim). A real
+    * libpq instance must never enter it: ephemeral suppresses durable vector
+    * writes (db2_vector_index_sync_suppressed), so flipping it on in production
+    * would silently stop memory embeddings from persisting. Refuse, fail-safe. */
+   if (ephemeral && !aimee_pg_is_shim())
+      return;
    pthread_mutex_lock(&g_shared_sqlite_lock);
    g_shared_ephemeral = ephemeral ? 1 : 0;
    pthread_mutex_unlock(&g_shared_sqlite_lock);
@@ -144,6 +150,11 @@ void db2_set_ephemeral(int ephemeral)
 
 int db2_is_ephemeral(void)
 {
+   /* Belt-and-suspenders with db2_set_ephemeral: a real libpq (production)
+    * instance is NEVER ephemeral, regardless of the stored flag. Ephemeral
+    * only has meaning under the sqlite shim used by tests/evals. */
+   if (!aimee_pg_is_shim())
+      return 0;
    pthread_mutex_lock(&g_shared_sqlite_lock);
    int v = g_shared_ephemeral;
    pthread_mutex_unlock(&g_shared_sqlite_lock);
@@ -662,6 +673,9 @@ void db2_eval_close_temp_store(void)
 {
    if (!g_eval_temp_store_handle)
       return;
+   /* Restore non-ephemeral when the eval scratch store goes away, so the flag
+    * can never outlive the eval that set it. */
+   db2_set_ephemeral(0);
 #ifdef AIMEE_DISABLE_DB2_SQLITE_SHIM
    db2_maybe_clear_sqlite_cache(g_eval_temp_store_handle);
    db2_register_shared_sqlite(NULL);

--- a/src/kb/kb_reflection.c
+++ b/src/kb/kb_reflection.c
@@ -20,6 +20,7 @@
 #include "cJSON.h"
 #include "config.h"
 #include "db2/artifacts.h"
+#include "db2/db2.h" /* db2_lease_release_idle */
 #include "kb_features.h"
 #include "kb_mdl.h"
 #include "kb_service.h"
@@ -269,6 +270,13 @@ static void *reflection_thread_main(void *arg)
 
    while (!ctx->stop)
    {
+      /* Return any pool connection a prior reflection pass acquired lazily
+       * (run_reflection_pass uses db2_conn() at lease depth 0, not an explicit
+       * begin/end scope) before idling, so this long-lived thread does not pin
+       * one pool member for its whole lifetime — the stuck-lease reaper flags it
+       * and it permanently shrinks the bounded pool. Matches the curator drain
+       * (kb_curator_drain.c) and the maintenance timer (kb_service_workers.c). */
+      db2_lease_release_idle();
       sleep(1);
       if (ctx->stop)
          break;

--- a/src/memory_core.c
+++ b/src/memory_core.c
@@ -686,6 +686,7 @@ void memory_coref_stats_reset(void)
 #include "platform_process.h"
 #include "memory_platform.h"
 #include "log.h"
+#include "util.h" /* util_now_ms — memory.search stage timing */
 #include "cJSON.h"
 #include "dogfood.h"
 #include <ctype.h>

--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1732,6 +1732,10 @@ static __thread memory_qembed_entry_t s_qembed[MEMORY_QEMBED_CAP];
  * embedder invocations). requests-minus-misses is the work the memo saved. */
 static __thread int s_qembed_requests = 0;
 static __thread int s_qembed_misses = 0;
+/* Per-search stage-timing probe (read+reset by the memory_search wrapper): wall
+ * time spent in actual embed spawns (cache misses) and how many ran. */
+static __thread long long s_qembed_ms = 0;
+static __thread int s_qembed_spawns = 0;
 
 /* Begin a fresh per-recall memo window. Call at every top-level recall entry
  * point before any lane embeds the query. */
@@ -1766,6 +1770,7 @@ static int memory_embed_text_runtime(const char *text, const char *command, floa
    }
 
    s_qembed_misses++;
+   long long _emb_t0 = util_now_ms();
    int dim = memory_embed_text(text, effective_cmd, out, max_dim);
    if (dim <= 0 && strcmp(effective_cmd, "builtin") != 0)
    {
@@ -1773,6 +1778,8 @@ static int memory_embed_text_runtime(const char *text, const char *command, floa
                 "query embedding failed for configured command; retrying with builtin embeddings");
       dim = memory_embed_text(text, "builtin", out, max_dim);
    }
+   s_qembed_ms += util_now_ms() - _emb_t0;
+   s_qembed_spawns++;
 
    /* Store on the way out so the other lanes / sub-queries of this same recall
     * reuse the vector instead of re-spawning the embedder. */

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -24,7 +24,25 @@ static double time_decay(const char *last_used)
    return exp(-0.02 * days);
 }
 
+static int memory_search_impl(char **clusters, int cluster_count, int limit, search_result_t *out,
+                              int max);
+
+/* Public entry: time the whole search and log a one-line stage breakdown so the
+ * embed-spawn cost (the suspected dominant term) is separable from the rest of
+ * retrieval/rerank. Counters live in memory_core_helpers.inc (same TU). */
 int memory_search(char **clusters, int cluster_count, int limit, search_result_t *out, int max)
+{
+   long long _t0 = util_now_ms();
+   s_qembed_ms = 0;
+   s_qembed_spawns = 0;
+   int n = memory_search_impl(clusters, cluster_count, limit, out, max);
+   aimee_log(LOG_INFO, "memory.search.timing", "total=%lldms embed=%lldms spawns=%d results=%d",
+             util_now_ms() - _t0, s_qembed_ms, s_qembed_spawns, n);
+   return n;
+}
+
+static int memory_search_impl(char **clusters, int cluster_count, int limit, search_result_t *out,
+                              int max)
 {
    if (!clusters || cluster_count <= 0)
       return 0;

--- a/src/tests/aimee_pg_sqlite_shim.c
+++ b/src/tests/aimee_pg_sqlite_shim.c
@@ -23,6 +23,15 @@
  * db2-specific contract tests run against actual Postgres.
  */
 
+/* TEST-ONLY enforcement: this shim makes aimee_pg_is_shim() return 1, which the
+ * ephemeral/vector-sync-suppression path keys off. It must NEVER be compiled
+ * into a production build. Production server/kb objects are built with
+ * AIMEE_DISABLE_DB2_SQLITE_SHIM; test objects are not. Fail the build loudly if
+ * this file is ever pulled into a production (shim-disabled) compilation. */
+#ifdef AIMEE_DISABLE_DB2_SQLITE_SHIM
+#error "aimee_pg_sqlite_shim.c is test-only and must not be compiled into a production build"
+#endif
+
 #include "db_postgres.h"
 #include "../db2/db2.h"
 #include "../db2/db2_internal.h"


### PR DESCRIPTION
Promotes #539 (db2 pool leak), #540 (memory.search timing), #541 (ephemeral + pg-shim test-only) to main so the published images rebuild.