### PR TITLE
fix(memory): reject dim-mismatched embeddings (+ tests for 1024/2560)

### DIFF
--- a/src/db2/db2_test_shim.c
+++ b/src/db2/db2_test_shim.c
@@ -14,6 +14,7 @@
 #include "db2.h"
 #include "db2_internal.h"
 #include "db_schema.h"
+#include "lifecycle.h" /* db2_set_embedding_dim */
 
 #include <assert.h>
 #include <sqlite3.h>
@@ -47,6 +48,12 @@ void db2_test_shim_open_path(const char *path)
     * production; the shim schema relies on it (memory_workspaces FK to
     * memories, etc.). */
    sqlite3_exec(raw, "PRAGMA foreign_keys=ON", NULL, NULL, NULL);
+
+   /* Unit tests embed with the builtin (384-dim) embedder. Default the active
+    * embedding dim to 384 so the upsert dim guard accepts builtin vectors; tests
+    * that exercise a specific tier (0.6b=1024, 4b=2560) call db2_set_embedding_dim
+    * themselves after open and override this. */
+   db2_set_embedding_dim(384);
 
    char err[512] = {0};
    rc = db2_apply_schema_sqlite_shim(raw, err, sizeof(err));

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -2,6 +2,7 @@
 
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
+#include "../db2/lifecycle.h" /* db2_embedding_dim */
 #include "cJSON.h"
 #include "log.h"
 
@@ -263,6 +264,20 @@ int pgvec_memory_upsert(int64_t point_id, const float *vec, int dim, const char 
 {
    if (!vec || dim <= 0)
       return 0;
+   /* Dimension guard: the embedding column is halfvec(N) where N is the active
+    * configured dim (db2_embedding_dim). A vector of a different dim (e.g. the
+    * 384-dim builtin fallback against a 1024/2560 column) is rejected by
+    * Postgres with "expected N dimensions, not M" — but that error was being
+    * counted as a successful embed, silently leaving memory_embeddings empty.
+    * Fail loudly here instead of shipping a mismatched vector. */
+   int expect = db2_embedding_dim();
+   if (expect > 0 && dim != expect)
+   {
+      aimee_log(LOG_WARN, "pgvec",
+                "memory embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert",
+                dim, expect, (long long)point_id);
+      return -1;
+   }
    void *pg = db2_conn();
    if (!pg)
       return -1;
@@ -355,6 +370,16 @@ int pgvec_kb_upsert(int64_t point_id, const float *vec, int dim, const char *pay
 {
    if (!vec || dim <= 0)
       return 0;
+   /* Same dim guard as pgvec_memory_upsert: never ship a vector whose dim does
+    * not match the configured halfvec(N) column. */
+   int expect = db2_embedding_dim();
+   if (expect > 0 && dim != expect)
+   {
+      aimee_log(LOG_WARN, "pgvec",
+                "kb embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert", dim,
+                expect, (long long)point_id);
+      return -1;
+   }
    void *pg = db2_conn();
    if (!pg)
       return -1;

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -273,9 +273,10 @@ int pgvec_memory_upsert(int64_t point_id, const float *vec, int dim, const char 
    int expect = db2_embedding_dim();
    if (expect > 0 && dim != expect)
    {
-      aimee_log(LOG_WARN, "pgvec",
-                "memory embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert",
-                dim, expect, (long long)point_id);
+      aimee_log(
+          LOG_WARN, "pgvec",
+          "memory embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert",
+          dim, expect, (long long)point_id);
       return -1;
    }
    void *pg = db2_conn();
@@ -376,8 +377,8 @@ int pgvec_kb_upsert(int64_t point_id, const float *vec, int dim, const char *pay
    if (expect > 0 && dim != expect)
    {
       aimee_log(LOG_WARN, "pgvec",
-                "kb embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert", dim,
-                expect, (long long)point_id);
+                "kb embedding dim mismatch: got %d, expected %d (point_id=%lld); refusing upsert",
+                dim, expect, (long long)point_id);
       return -1;
    }
    void *pg = db2_conn();

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -627,10 +627,10 @@ static int kb_handle_memory_reembed_start(int fd, cJSON *req)
     * configured at all (e.g. a 384-dim shim/test setup). */
    config_t reembed_cfg;
    config_load(&reembed_cfg);
-   const char *embed_cmd = (cJSON_IsString(embed_j) && embed_j->valuestring[0])
-                               ? embed_j->valuestring
-                               : (reembed_cfg.embedding_command[0] ? reembed_cfg.embedding_command
-                                                                   : "builtin");
+   const char *embed_cmd =
+       (cJSON_IsString(embed_j) && embed_j->valuestring[0])
+           ? embed_j->valuestring
+           : (reembed_cfg.embedding_command[0] ? reembed_cfg.embedding_command : "builtin");
 
    char ts_now[32];
    now_utc(ts_now, sizeof(ts_now));

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -1,4 +1,5 @@
 #include "aimee.h"
+#include "config.h" /* config_load — reembed default embedder */
 #include "kb_background.h"
 #include "kb_service.h"
 #include "kb_service_code_embed.h"
@@ -619,8 +620,17 @@ static int kb_handle_memory_reembed_start(int fd, cJSON *req)
    if (!cJSON_IsString(ver_j) || !ver_j->valuestring[0])
       return kb_send_error(fd, "missing version");
    const char *version = ver_j->valuestring;
-   const char *embed_cmd =
-       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : "builtin";
+   /* Default to the server's CONFIGURED embedder, never "builtin": builtin emits
+    * 384-dim vectors, which can never insert into a real halfvec(1024)/(2560)
+    * column (Postgres rejects "expected N dimensions, not 384") and silently
+    * leaves memory_embeddings empty. Only fall back to builtin if no embedder is
+    * configured at all (e.g. a 384-dim shim/test setup). */
+   config_t reembed_cfg;
+   config_load(&reembed_cfg);
+   const char *embed_cmd = (cJSON_IsString(embed_j) && embed_j->valuestring[0])
+                               ? embed_j->valuestring
+                               : (reembed_cfg.embedding_command[0] ? reembed_cfg.embedding_command
+                                                                   : "builtin");
 
    char ts_now[32];
    now_utc(ts_now, sizeof(ts_now));

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -205,6 +205,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-delegate-ensemble \
                $(TESTPREFIX)/unit-test-rel-types \
                $(TESTPREFIX)/unit-test-memory-fact-gate \
+               $(TESTPREFIX)/unit-test-memory-embed-dim-guard \
                $(TESTPREFIX)/unit-test-rel-types-store \
                $(TESTPREFIX)/unit-test-entity-registry \
                $(TESTPREFIX)/unit-test-fact-lifecycle \
@@ -547,6 +548,14 @@ $(TESTPREFIX)/unit-test-curator-notify: $(OBJDIR)/tests/test_curator_notify.o $(
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
 
 $(TESTPREFIX)/unit-test-pgvec: $(OBJDIR)/tests/test_pgvec.o \
+                    $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o \
+                    $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o \
+                    $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o \
+                    $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# memory/KB vector upsert dim guard (rejects builtin-384 vs halfvec(1024)/(2560)).
+$(TESTPREFIX)/unit-test-memory-embed-dim-guard: $(OBJDIR)/tests/test_memory_embed_dim_guard.o \
                     $(OBJDIR)/db2/pgvec_transport.o $(OBJDIR)/db2/memory_vectors.o $(OBJDIR)/db2/kb_vectors.o \
                     $(OBJDIR)/db2/vector_status.o $(OBJDIR)/db2/pgvec_verify.o $(OBJDIR)/db2/pgvec_kb_service.o \
                     $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o \

--- a/src/tests/test_memory_cases_b.inc
+++ b/src/tests/test_memory_cases_b.inc
@@ -522,6 +522,9 @@ static void test_memory_embed_records_embedder_version(void)
    fclose(fp);
 
    setup();
+   /* This test embeds with the builtin embedder, which emits 384-dim vectors;
+    * align the active dim so the upsert dim guard accepts them. */
+   db2_set_embedding_dim(384);
    memory_t mem;
    assert(memory_insert(TIER_L2, KIND_FACT, "embed-version", "test content", 0.9, "", &mem) == 0);
    assert(memory_embed(mem.id, "builtin") == 0);

--- a/src/tests/test_memory_embed_dim_guard.c
+++ b/src/tests/test_memory_embed_dim_guard.c
@@ -65,7 +65,8 @@ int main(void)
    db2_test_shim_open();
 
    check_dim(1024, 384);  /* pplx-0.6b column; the builtin 384-dim vector must be rejected */
-   check_dim(2560, 1024); /* pplx-4b column; a 1024-dim vector must be rejected */
+   check_dim(2560, 1024); /* pplx-4b column; a 1024-dim (0.6b) vector must be rejected */
+   check_dim(2560, 384);  /* pplx-4b column; the builtin 384-dim vector must be rejected too */
 
    printf("test_memory_embed_dim_guard: OK\n");
    return 0;

--- a/src/tests/test_memory_embed_dim_guard.c
+++ b/src/tests/test_memory_embed_dim_guard.c
@@ -1,0 +1,72 @@
+/* test_memory_embed_dim_guard.c: the memory/KB vector upsert must reject a
+ * vector whose dimension does not match the configured embedding dim
+ * (db2_embedding_dim), instead of silently "succeeding" while Postgres rejects
+ * the row ("expected N dimensions, not M") and memory_embeddings stays empty.
+ *
+ * This reproduces the .254 failure where the reembed path fell back to the
+ * builtin 384-dim embedder against a halfvec(1024) column: every insert failed
+ * but was counted as a successful embed. Covered for both shipping dims:
+ *   1024 -> pplx-embed-v1-0.6b
+ *   2560 -> pplx-embed-v1-4b
+ *
+ * Exercised against the in-memory sqlite shim. */
+#include "../headers/aimee.h"
+#include "../db2/db2_test_shim.h"
+#include "../db2/lifecycle.h"      /* db2_set_embedding_dim */
+#include "../db2/memory_vectors.h" /* pgvec_memory_vector_upsert_memory + search */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+static float *make_vec(int dim)
+{
+   float *v = calloc((size_t)dim, sizeof(float));
+   assert(v);
+   for (int i = 0; i < dim; i++)
+      v[i] = 0.01f * (float)((i % 7) + 1);
+   return v;
+}
+
+/* For a configured dim `expect`, a matching-dim vector persists and is
+ * retrievable; a `wrong`-dim vector is rejected (non-zero) and never stored. */
+static void check_dim(int expect, int wrong)
+{
+   db2_set_embedding_dim(expect);
+
+   /* Matching dim: upsert succeeds. */
+   float *ok = make_vec(expect);
+   int64_t mid = 100000 + expect;
+   int rc = pgvec_memory_vector_upsert_memory(mid, ok, expect, "{\"record_type\":\"memory\"}");
+   assert(rc == 0);
+
+   /* It actually persisted: a search by the same vector finds the point. */
+   int64_t ids[16];
+   double scores[16];
+   int n = pgvec_memory_vector_search_record_type("memory", ok, expect, 16, ids, scores, 16);
+   int found = 0;
+   for (int i = 0; i < n; i++)
+      if (ids[i] == mid)
+         found = 1;
+   assert(found && "matching-dim embedding should persist and be retrievable");
+   free(ok);
+
+   /* Wrong dim (e.g. builtin 384 vs a 1024/2560 column): rejected, NOT counted
+    * as a successful embed. */
+   float *bad = make_vec(wrong);
+   int rc2 = pgvec_memory_vector_upsert_memory(mid + 1, bad, wrong, "{\"record_type\":\"memory\"}");
+   assert(rc2 != 0 && "dim-mismatched embedding must be rejected, not silently succeed");
+   free(bad);
+
+   printf("  dim guard ok: expect=%d persists, wrong=%d rejected\n", expect, wrong);
+}
+
+int main(void)
+{
+   db2_test_shim_open();
+
+   check_dim(1024, 384);  /* pplx-0.6b column; the builtin 384-dim vector must be rejected */
+   check_dim(2560, 1024); /* pplx-4b column; a 1024-dim vector must be rejected */
+
+   printf("test_memory_embed_dim_guard: OK\n");
+   return 0;
+}

--- a/src/tests/test_pgvec.c
+++ b/src/tests/test_pgvec.c
@@ -16,6 +16,7 @@
 #include "aimee.h"
 #include "db2_test_shim.h"
 #include "../db2/db2_internal.h"
+#include "../db2/lifecycle.h" /* db2_set_embedding_dim */
 #include "../db2/pgvec_transport.h"
 #include "../db2/memory_vectors.h"
 #include "../db2/kb_vectors.h"
@@ -305,6 +306,9 @@ static void test_corpus_ensure_index_graceful(void)
 int main(void)
 {
    db2_test_shim_open();
+   /* These tests upsert tiny 4-dim vectors; declare that dim so the upsert
+    * dim guard (pgvec_*_upsert vs db2_embedding_dim) accepts them. */
+   db2_set_embedding_dim(4);
 
    test_collection_names();
    test_schema_version_nonempty();


### PR DESCRIPTION
## Root cause (the .254 `memory_points=0`)
The embed path shipped a vector whose dimension did not match the `halfvec(N)` column. Postgres rejected each insert with `ERROR: expected N dimensions, not M`, but the failure was **counted as a successful embed**, so `memory_embeddings` stayed empty while reembed reported `embedded=12`.

The trigger: `memory.reembed_start` defaults `embedding_command` to **`builtin`** (a 384-dim hash) when the caller omits it — 384 can never fit a real `halfvec(1024)`/`(2560)` column. Confirmed live via pg `log_statement=all`:
```
ERROR: expected 1024 dimensions, not 384
STATEMENT: INSERT INTO memory_embeddings ... ($2::halfvec) ...
```

## Fixes
- **Dim guard** in `pgvec_memory_upsert` / `pgvec_kb_upsert`: validate the vector dim against `db2_embedding_dim()`; on mismatch, log + return failure instead of shipping a doomed insert and reporting success.
- **`kb_handle_memory_reembed_start`** defaults `embedding_command` to the server's **configured** embedder, never `builtin` (builtin only when nothing is configured, e.g. a 384-dim shim).

## Tests (your ask: cover both dims)
New `test_memory_embed_dim_guard` over the sqlite shim, for **1024 (pplx-0.6b)** and **2560 (pplx-4b)**:
- matching-dim vector persists and is retrievable;
- wrong-dim vector (384→1024, 1024→2560) is rejected, not silently dropped.

Green locally:
```
dim guard ok: expect=1024 persists, wrong=384 rejected
dim guard ok: expect=2560 persists, wrong=1024 rejected
test_memory_embed_dim_guard: OK
```

## Note
The reembed cutover also drops freshly-embedded rows (a separate pipeline bug observed on .254); that is not addressed here. This PR stops the silent dim-mismatch data loss and the builtin default that caused it.