### PR TITLE
perf(memory): find_facts stage timing (embed vs rerank)

### DIFF
--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1736,6 +1736,9 @@ static __thread int s_qembed_misses = 0;
  * time spent in actual embed spawns (cache misses) and how many ran. */
 static __thread long long s_qembed_ms = 0;
 static __thread int s_qembed_spawns = 0;
+/* Cross-encoder rerank spawn time + count, same per-recall probe. */
+static __thread long long s_rerank_ms = 0;
+static __thread int s_rerank_calls = 0;
 
 /* Begin a fresh per-recall memo window. Call at every top-level recall entry
  * point before any lane embeds the query. */

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -2571,7 +2571,10 @@ static int memory_cross_encoder_scores(const char *command, const char *query,
 
    char *buf = NULL;
    size_t buf_len = 0;
+   long long _rr_t0 = util_now_ms();
    int rc = platform_exec_pipe(command, input_json, strlen(input_json), &buf, &buf_len);
+   s_rerank_ms += util_now_ms() - _rr_t0;
+   s_rerank_calls++;
    free(input_json);
    if (rc != 0)
    {
@@ -3949,7 +3952,18 @@ void memory_query_rewrite(const char *query, const config_t *cfg, memory_query_r
 
 int memory_find_facts(const char *query, int limit, memory_t *out, int max)
 {
+   /* Stage timing: separate the embed-spawn and rerank-spawn costs (the suspected
+    * dominant terms in live find_facts latency) from the rest, one line per call.
+    * Counters live in memory_core_helpers.inc (same TU). */
+   long long _ff_t0 = util_now_ms();
+   s_qembed_ms = 0;
+   s_qembed_spawns = 0;
+   s_rerank_ms = 0;
+   s_rerank_calls = 0;
    int n = memory_find_facts_scoped(query, NULL, NULL, limit, out, max);
+   aimee_log(LOG_INFO, "memory.find_facts.timing",
+             "total=%lldms embed=%lldms/%d rerank=%lldms/%d results=%d", util_now_ms() - _ff_t0,
+             s_qembed_ms, s_qembed_spawns, s_rerank_ms, s_rerank_calls, n);
    /* Dogfood record at the non-scoped entry point so MCP/agent callers land
     * here; scoped callers (CLI cmd_memory_find_facts) log themselves. */
    if (n > 0 && out)


### PR DESCRIPTION
Instrumentation to pin the live `find_facts` latency (~1.5-2.4s, of which Postgres is only ~26ms). Adds a one-line-per-call breakdown:
```
memory.find_facts.timing total=<ms> embed=<ms>/<spawns> rerank=<ms>/<calls> results=<n>
```
at the public `memory_find_facts` entry, reusing the embed accumulator (#540) and adding a rerank accumulator around the cross-encoder `platform_exec_pipe`. Pure instrumentation. Once deployed it tells us whether the per-lane embed spawns or the cross-encoder rerank spawn dominate, so the fix targets the right one.