### PR TITLE
perf(memory): in-process HTTP embedding when embedding_command is a URL

### DIFF
--- a/src/memory_core.c
+++ b/src/memory_core.c
@@ -686,7 +686,8 @@ void memory_coref_stats_reset(void)
 #include "platform_process.h"
 #include "memory_platform.h"
 #include "log.h"
-#include "util.h" /* util_now_ms — memory.search stage timing */
+#include "util.h"       /* util_now_ms — memory.search stage timing */
+#include "agent_exec.h" /* agent_http_post: in-process HTTP embedding (no fork) */
 #include "cJSON.h"
 #include "dogfood.h"
 #include <ctype.h>

--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1714,8 +1714,49 @@ enum
 {
    MEMORY_QEMBED_CAP = 32,
    MEMORY_QEMBED_TEXT_MAX = 1024,
-   MEMORY_QEMBED_CMD_MAX = 512
+   MEMORY_QEMBED_CMD_MAX = 512,
+   MEMORY_EMBED_HTTP_TIMEOUT_MS = 30000
 };
+
+/* In-process HTTP embedding. When embedding_command is an http(s):// URL we POST
+ * to the embedder directly instead of forking an interpreter, so a query embed is
+ * a ~10ms round-trip rather than a process spawn. Under host CPU load (curator,
+ * indexing) the spawn dominates memory-search latency, so this is the difference
+ * between a fast search and a multi-second one. Non-URL commands keep the exec
+ * path. Endpoints match scripts/embedder-server.py: POST {base}/embed (raw text)
+ * and {base}/embed_batch (JSON array of strings); the server ignores Content-Type
+ * and reads the raw body, so agent_http_post's default header is fine. */
+static int memory_embed_command_is_http(const char *cmd)
+{
+   return cmd && (strncmp(cmd, "http://", 7) == 0 || strncmp(cmd, "https://", 8) == 0);
+}
+
+/* Join an embedder base URL and an endpoint path, dropping a trailing slash on
+ * the base so "http://e:8080/" + "/embed" -> "http://e:8080/embed". */
+static void memory_embed_http_url(const char *base, const char *path, char *out, size_t out_len)
+{
+   size_t n = strlen(base);
+   while (n > 0 && base[n - 1] == '/')
+      n--;
+   snprintf(out, out_len, "%.*s%s", (int)n, base, path);
+}
+
+/* POST body to {base}{path}; on success returns 0 with the response body in
+ * *resp (caller frees). Any transport error or non-2xx leaves *resp NULL. */
+static int memory_embed_http_post(const char *base, const char *path, const char *body, char **resp)
+{
+   char url[1024];
+   memory_embed_http_url(base, path, url, sizeof(url));
+   *resp = NULL;
+   int status = agent_http_post(url, NULL, body, resp, MEMORY_EMBED_HTTP_TIMEOUT_MS, NULL);
+   if (status < 200 || status >= 300 || !*resp)
+   {
+      free(*resp);
+      *resp = NULL;
+      return -1;
+   }
+   return 0;
+}
 
 typedef struct
 {
@@ -1865,10 +1906,20 @@ static void memory_query_embed_prewarm(const char *const *texts, int n, const ch
    if (!input)
       return;
    char *buf = NULL;
-   size_t buf_len = 0;
-   int rc = platform_exec_pipe(cmd, input, strlen(input), &buf, &buf_len);
+   int rc;
+   if (memory_embed_command_is_http(cmd))
+   {
+      rc = memory_embed_http_post(cmd, "/embed_batch", input, &buf);
+   }
+   else
+   {
+      size_t buf_len = 0;
+      rc = platform_exec_pipe(cmd, input, strlen(input), &buf, &buf_len);
+      if (rc == 0 && (!buf || buf_len == 0))
+         rc = -1;
+   }
    free(input);
-   if (rc != 0 || !buf || buf_len == 0)
+   if (rc != 0 || !buf)
    {
       free(buf);
       return; /* lanes fall back to individual embeds */

--- a/src/memory_core_scope_embed.inc
+++ b/src/memory_core_scope_embed.inc
@@ -343,12 +343,26 @@ int memory_embed_text(const char *text, const char *command, float *out, int max
 
    char *buf = NULL;
    size_t buf_len = 0;
-   int rc = platform_exec_pipe(command, text, strlen(text), &buf, &buf_len);
-   if (rc != 0)
+   if (memory_embed_command_is_http(command))
    {
-      aimee_log(LOG_WARN, "memory", "embedding command failed (exit %d)", rc);
-      free(buf);
-      return 0;
+      /* In-process HTTP embed: POST raw text to {base}/embed, no fork. */
+      if (memory_embed_http_post(command, "/embed", text, &buf) != 0 || !buf)
+      {
+         aimee_log(LOG_WARN, "memory", "embedding HTTP request failed");
+         free(buf);
+         return 0;
+      }
+      buf_len = strlen(buf);
+   }
+   else
+   {
+      int rc = platform_exec_pipe(command, text, strlen(text), &buf, &buf_len);
+      if (rc != 0)
+      {
+         aimee_log(LOG_WARN, "memory", "embedding command failed (exit %d)", rc);
+         free(buf);
+         return 0;
+      }
    }
    if (!buf || buf_len == 0)
    {


### PR DESCRIPTION
Each query embed forked `python3 embed-remote.py`, which then POSTed to the embedder. Under host CPU load the fork dominates memory-search latency: `find_facts` spends ~80% of its time in 5 embed spawns (~48ms warm, up to ~0.4s under load).

When `embedding_command` is an `http(s)://` URL, POST to the embedder directly via `agent_http_post` (already linked into server and kb through `agent_bridge`): `{base}/embed` for one text, `{base}/embed_batch` for the prewarm batch. No fork, so a query embed is a ~10ms round-trip and is immune to host load. Endpoints match `scripts/embedder-server.py` (reads raw body, ignores Content-Type). Non-URL commands keep the exec path unchanged.

Activate by setting `embedding_command` to e.g. `http://embedder:8080`.

Full `make unit-tests` passes locally (including `test_query_embed_prewarm_batches` and the qembed memo).