### PR TITLE
fix(embed): one resolver for the embedding command, never silent builtin in prod

### DIFF
--- a/src/cmd_memory_core.c
+++ b/src/cmd_memory_core.c
@@ -533,7 +533,7 @@ void mem_drain(app_ctx_t *ctx, int argc, char **argv)
    opt_parsed_t opts;
    opt_parse(argc, argv, NULL, &opts);
    int timeout = opt_get_int(&opts, "timeout", 0);
-   const char *embed_cmd = s_mem_cfg.embedding_command[0] ? s_mem_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&s_mem_cfg, NULL);
 
    char *resp_json = kb_client_queue_drain_json(embed_cmd, timeout);
    cJSON *resp = resp_json ? cJSON_Parse(resp_json) : NULL;

--- a/src/cmd_memory_embed.c
+++ b/src/cmd_memory_embed.c
@@ -41,7 +41,7 @@ static cJSON *mem_rpc_unwrap(char *resp_json, const char *what)
 
 void mem_embed(app_ctx_t *ctx, int argc, char **argv)
 {
-   const char *embed_cmd = s_mem_cfg.embedding_command[0] ? s_mem_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&s_mem_cfg, NULL);
 
    int all = 0;
    int64_t single_id = 0;
@@ -197,7 +197,7 @@ void mem_reembed(app_ctx_t *ctx, int argc, char **argv)
    }
 
    /* --start */
-   const char *embed_cmd = s_mem_cfg.embedding_command[0] ? s_mem_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&s_mem_cfg, NULL);
    char ver_buf[256];
    if (target_version)
       snprintf(ver_buf, sizeof(ver_buf), "%s", target_version);

--- a/src/cmd_memory_vector.c
+++ b/src/cmd_memory_vector.c
@@ -85,7 +85,7 @@ void mem_repair(app_ctx_t *ctx, int argc, char **argv)
    if (opts.pos_count > 0)
       single_id = atoll(opts.positional[0]);
 
-   const char *embed_cmd = s_mem_cfg.embedding_command[0] ? s_mem_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&s_mem_cfg, NULL);
    char *resp_json =
        kb_client_memory_repair_json(limit, failed_only, reset_stuck, single_id, embed_cmd);
    cJSON *resp = resp_json ? cJSON_Parse(resp_json) : NULL;
@@ -574,7 +574,7 @@ void mem_verify(app_ctx_t *ctx, int argc, char **argv)
    int do_detail = opt_get_flag(&vopts, "detail");
    int do_timings = opt_get_flag(&vopts, "timings");
 
-   const char *embed_cmd = s_mem_cfg.embedding_command[0] ? s_mem_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&s_mem_cfg, NULL);
 
    char *verify_json = kb_client_memory_verify_json(do_detail, do_timings, embed_cmd);
    cJSON *resp = verify_json ? cJSON_Parse(verify_json) : NULL;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1122,6 +1122,15 @@ const char *config_guardrail_mode(const config_t *cfg)
    return MODE_APPROVE;
 }
 
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}
+
 /* --- Conversation directories --- */
 
 int config_conversation_dirs(const config_t *cfg, char dirs[][MAX_PATH_LEN], int max_dirs)

--- a/src/db2/kb_service_backend.c
+++ b/src/db2/kb_service_backend.c
@@ -471,7 +471,7 @@ int db2_kb_service_async_queue_drain(const char *embedding_cmd, int timeout_secs
                                      void *vector_upsert_ctx,
                                      db2_kb_service_async_queue_stats_t *out)
 {
-   const char *effective_cmd = (embedding_cmd && embedding_cmd[0]) ? embedding_cmd : "builtin";
+   const char *effective_cmd = config_embedding_command(NULL, embedding_cmd);
    int processed = 0;
 
    time_t started = time(NULL);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1511,6 +1511,15 @@ const char *config_output_dir(void);
 /* Effective guardrail mode (defaults to "approve"). */
 const char *config_guardrail_mode(const config_t *cfg);
 
+/* Resolve the embedding command actually used to embed text. Precedence:
+ * a per-call `requested` command (e.g. from a request payload), then the
+ * configured cfg->embedding_command, then "builtin". Either argument may be
+ * NULL. "builtin" is a 384-dim deterministic hash that real halfvec(1024)/
+ * (2560) columns reject, so it is only correct in a 384-dim shim/test setup;
+ * every production path must carry a real embedder via config or request. This
+ * is the single point of truth -- do not re-inline the ternary at call sites. */
+const char *config_embedding_command(const config_t *cfg, const char *requested);
+
 /* Disposition source labels for config reporting. */
 const char *config_disposition_source_name(config_disposition_source_t source);
 

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1200,7 +1200,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       char kb_path[MAX_PATH_LEN] = "";
       char project[128] = "";
-      char embed_cmd[256] = "builtin";
+      char embed_cmd[256] = "";
       if (!json_str(body, "path", kb_path, sizeof(kb_path)) || !kb_path[0])
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing path\"}");
@@ -1213,7 +1213,11 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       (void)json_str(body, "embedding_command", embed_cmd, sizeof(embed_cmd));
       if (!embed_cmd[0])
-         snprintf(embed_cmd, sizeof(embed_cmd), "builtin");
+      {
+         config_t embed_cfg;
+         config_load(&embed_cfg);
+         snprintf(embed_cmd, sizeof(embed_cmd), "%s", config_embedding_command(&embed_cfg, NULL));
+      }
       int force = json_bool(body, "force", 0);
 
       if (!db2_is_initialized())
@@ -1257,7 +1261,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       char kb_path[MAX_PATH_LEN] = "";
       char project[128] = "";
-      char embed_cmd[256] = "builtin";
+      char embed_cmd[256] = "";
       if (!json_str(body, "path", kb_path, sizeof(kb_path)) || !kb_path[0])
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing path\"}");
@@ -1270,7 +1274,11 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       (void)json_str(body, "embedding_command", embed_cmd, sizeof(embed_cmd));
       if (!embed_cmd[0])
-         snprintf(embed_cmd, sizeof(embed_cmd), "builtin");
+      {
+         config_t embed_cfg;
+         config_load(&embed_cfg);
+         snprintf(embed_cmd, sizeof(embed_cmd), "%s", config_embedding_command(&embed_cfg, NULL));
+      }
 
       if (!db2_is_initialized())
       {
@@ -1495,10 +1503,14 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
          return 405;
       }
-      char embed_cmd[256] = "builtin";
+      char embed_cmd[256] = "";
       (void)json_str(body, "embedding_command", embed_cmd, sizeof(embed_cmd));
       if (!embed_cmd[0])
-         snprintf(embed_cmd, sizeof(embed_cmd), "builtin");
+      {
+         config_t embed_cfg;
+         config_load(&embed_cfg);
+         snprintf(embed_cmd, sizeof(embed_cmd), "%s", config_embedding_command(&embed_cfg, NULL));
+      }
       int timeout = json_int(body, "timeout", 0);
       if (timeout < 0)
          timeout = 0;
@@ -1529,7 +1541,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       char kb_path[4096] = "";
       char project[256] = "";
-      char embed_cmd[256] = "builtin";
+      char embed_cmd[256] = "";
       if (!json_str(body, "path", kb_path, sizeof(kb_path)) || !kb_path[0])
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing path\"}");
@@ -1542,7 +1554,11 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       (void)json_str(body, "embedding_command", embed_cmd, sizeof(embed_cmd));
       if (!embed_cmd[0])
-         snprintf(embed_cmd, sizeof(embed_cmd), "builtin");
+      {
+         config_t embed_cfg;
+         config_load(&embed_cfg);
+         snprintf(embed_cmd, sizeof(embed_cmd), "%s", config_embedding_command(&embed_cfg, NULL));
+      }
       if (pgvec_kb_service_ensure_kb_collection(384) != 0)
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"vector store unavailable\"}");

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -589,7 +589,7 @@ int sync_vector_embedding(int64_t doc_id, const float *vec, int dim)
 
 const char *kb_effective_embedding_cmd(const char *embedding_cmd)
 {
-   return (embedding_cmd && embedding_cmd[0]) ? embedding_cmd : "builtin";
+   return config_embedding_command(NULL, embedding_cmd);
 }
 
 /* pgvector owns vector bytes. This hook exists to keep the sync/async call

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -77,7 +77,7 @@ static void *drain_thread_main(void *arg)
        * builder; the builtin embedder needs no external sidecar). */
       if (cfg.kb_evidence_embed_enabled)
       {
-         const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+         const char *embed_cmd = config_embedding_command(&cfg, NULL);
          int n = kb_evidence_embed_drain(cfg.kb_evidence_embed_batch, embed_cmd);
          if (n > 0)
             aimee_log(LOG_DEBUG, "kb.evidence.embed", "drained %d evidence op(s)", n);
@@ -139,7 +139,7 @@ static void *drain_thread_main(void *arg)
        * scheduler, never on the capture hot path. Off by default. */
       if (cfg.learning_synthesize_enabled && cfg.learning_synthesize_command[0])
       {
-         const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+         const char *embed_cmd = config_embedding_command(&cfg, NULL);
          /* Bound LLM calls per poll — each op is one sidecar/LLM round-trip. */
          int n =
              kb_learning_synth_drain(SYNTH_DRAIN_BATCH, cfg.learning_synthesize_command, embed_cmd,

--- a/src/kb/kb_curator_index_claims.c
+++ b/src/kb/kb_curator_index_claims.c
@@ -104,7 +104,7 @@ int kb_curator_index_claims_one(const kb_curator_extract_opts_t *opts)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
    float subj_vec[CURATOR_CLAIM_DIM];
    float val_vec[CURATOR_CLAIM_DIM];
    int d1 = memory_embed_text(subj_attr[0] ? subj_attr : value_text, embed_cmd, subj_vec,

--- a/src/kb/kb_curator_index_code_unit.c
+++ b/src/kb/kb_curator_index_code_unit.c
@@ -102,7 +102,7 @@ int kb_curator_index_code_unit_one(const kb_curator_extract_opts_t *opts)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
    float intent_vec[CURATOR_CODE_UNIT_DIM];
    float sig_vec[CURATOR_CODE_UNIT_DIM];
    float body_vec[CURATOR_CODE_UNIT_DIM];

--- a/src/kb/kb_curator_index_narrative.c
+++ b/src/kb/kb_curator_index_narrative.c
@@ -108,7 +108,7 @@ int kb_curator_index_narrative_one(const kb_curator_extract_opts_t *opts)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
    float vec[CURATOR_NARRATIVE_DIM];
    int dim = memory_embed_text(text, embed_cmd, vec, CURATOR_NARRATIVE_DIM);
    if (dim > 0)

--- a/src/kb/kb_curator_link_artifacts.c
+++ b/src/kb/kb_curator_link_artifacts.c
@@ -163,7 +163,7 @@ int kb_curator_link_artifacts_one(const kb_curator_extract_opts_t *opts)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
 
    static const char *sql = "SELECT id, payload FROM artifacts"
                             " WHERE kind = 'code_unit' AND state = 'committed'"

--- a/src/kb/kb_curator_resolve_entities.c
+++ b/src/kb/kb_curator_resolve_entities.c
@@ -194,7 +194,7 @@ int kb_curator_resolve_entities_one(const kb_curator_extract_opts_t *opts)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
    float vec[CURATOR_ENTITY_DIM];
    int dim = memory_embed_text(embed_text, embed_cmd, vec, CURATOR_ENTITY_DIM);
    if (dim > 0)

--- a/src/kb/kb_evidence_embed.c
+++ b/src/kb/kb_evidence_embed.c
@@ -107,7 +107,7 @@ int kb_evidence_embed_one(const char *embed_cmd)
    if (got == 0)
       return 0;
 
-   const char *model = (embed_cmd && embed_cmd[0]) ? embed_cmd : "builtin";
+   const char *model = config_embedding_command(NULL, embed_cmd);
 
    db2_artifact_row_t row;
    if (db2_artifact_read(pend.artifact_id, &row, NULL, 0, NULL) != 0)

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -126,7 +126,7 @@ static void kbiw_process_job(const db2_kb_ingest_job_t *job)
 
    config_t cfg;
    config_load(&cfg);
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
 
    kb_stats_t stats;
    memset(&stats, 0, sizeof(stats));

--- a/src/kb/kb_service.c
+++ b/src/kb/kb_service.c
@@ -193,8 +193,11 @@ static int kb_handle_memory_repair(int fd, cJSON *req)
    int failed_only = cJSON_IsTrue(failed_only_j) ? 1 : 0;
    int reset_stuck = cJSON_IsTrue(reset_stuck_j) ? 1 : 0;
    int64_t memory_id = cJSON_IsNumber(memory_id_j) ? (int64_t)memory_id_j->valuedouble : 0;
-   const char *embed_cmd =
-       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : "builtin";
+   config_t repair_cfg;
+   config_load(&repair_cfg);
+   const char *embed_cmd = config_embedding_command(
+       &repair_cfg,
+       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : NULL);
 
    if (reset_stuck)
    {
@@ -282,8 +285,11 @@ static int kb_handle_memory_verify(int fd, cJSON *req)
    cJSON *embed_j = cJSON_GetObjectItemCaseSensitive(req, "embedding_command");
    int do_detail = cJSON_IsTrue(detail_j) ? 1 : 0;
    int do_timings = cJSON_IsTrue(timings_j) ? 1 : 0;
-   const char *embed_cmd =
-       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : "builtin";
+   config_t verify_cfg;
+   config_load(&verify_cfg);
+   const char *embed_cmd = config_embedding_command(
+       &verify_cfg,
+       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : NULL);
 
    pgvec_verify_snapshot_t snap;
    memset(&snap, 0, sizeof(snap));
@@ -468,8 +474,11 @@ static int kb_handle_memory_embed(int fd, cJSON *req)
    int64_t memory_id = cJSON_IsNumber(mem_j) ? (int64_t)mem_j->valuedouble : 0;
    int all = cJSON_IsTrue(all_j) ? 1 : 0;
    const char *version = (cJSON_IsString(ver_j) && ver_j->valuestring[0]) ? ver_j->valuestring : "";
-   const char *embed_cmd =
-       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : "builtin";
+   config_t embed_cfg;
+   config_load(&embed_cfg);
+   const char *embed_cmd = config_embedding_command(
+       &embed_cfg,
+       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : NULL);
 
    if (!all && memory_id <= 0)
       return kb_send_error(fd, "memory.embed requires memory_id>0 or all=true");
@@ -620,17 +629,15 @@ static int kb_handle_memory_reembed_start(int fd, cJSON *req)
    if (!cJSON_IsString(ver_j) || !ver_j->valuestring[0])
       return kb_send_error(fd, "missing version");
    const char *version = ver_j->valuestring;
-   /* Default to the server's CONFIGURED embedder, never "builtin": builtin emits
-    * 384-dim vectors, which can never insert into a real halfvec(1024)/(2560)
-    * column (Postgres rejects "expected N dimensions, not 384") and silently
-    * leaves memory_embeddings empty. Only fall back to builtin if no embedder is
-    * configured at all (e.g. a 384-dim shim/test setup). */
+   /* Resolve via the shared policy: request override, then the server's
+    * CONFIGURED embedder, then builtin. Never silently builtin in production:
+    * builtin emits 384-dim vectors that a real halfvec(1024)/(2560) column
+    * rejects, leaving memory_embeddings empty. */
    config_t reembed_cfg;
    config_load(&reembed_cfg);
-   const char *embed_cmd =
-       (cJSON_IsString(embed_j) && embed_j->valuestring[0])
-           ? embed_j->valuestring
-           : (reembed_cfg.embedding_command[0] ? reembed_cfg.embedding_command : "builtin");
+   const char *embed_cmd = config_embedding_command(
+       &reembed_cfg,
+       (cJSON_IsString(embed_j) && embed_j->valuestring[0]) ? embed_j->valuestring : NULL);
 
    char ts_now[32];
    now_utc(ts_now, sizeof(ts_now));

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -385,7 +385,7 @@ int kb_code_embed_refresh(const char *project, const char *scope, const char **p
     * upsert failed and no code vectors were ever stored. */
    config_t ce_cfg;
    config_load(&ce_cfg);
-   const char *embed_command = ce_cfg.embedding_command[0] ? ce_cfg.embedding_command : "builtin";
+   const char *embed_command = config_embedding_command(&ce_cfg, NULL);
    int embed_dim = db2_embedding_dim();
    if (embed_dim <= 0 || embed_dim > CE_EMBED_MAX_DIM)
       embed_dim = 1024;

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -309,8 +309,7 @@ static cJSON *kb_service_health_object(void)
    config_load(&cfg);
    int embed_ok = cfg.embedding_command[0] ? 1 : 0;
    cJSON_AddBoolToObject(resp, "embed_ok", embed_ok);
-   cJSON_AddStringToObject(resp, "embed_command",
-                           cfg.embedding_command[0] ? cfg.embedding_command : "builtin");
+   cJSON_AddStringToObject(resp, "embed_command", config_embedding_command(&cfg, NULL));
 
    /* Curator (§4 observability): per-tier provider config + queue depth. The
     * live four-state reachability probe (ready/loading/gated/down) is deferred to

--- a/src/learning_bundle.c
+++ b/src/learning_bundle.c
@@ -90,7 +90,7 @@ int learning_bundle_build(const char *query, const char *embed_cmd, int k, learn
    if (k > LEARNING_BUNDLE_MAX)
       k = LEARNING_BUNDLE_MAX;
 
-   const char *model = (embed_cmd && embed_cmd[0]) ? embed_cmd : "builtin";
+   const char *model = config_embedding_command(NULL, embed_cmd);
    float qvec[BUNDLE_EMBED_DIM];
    int qdim = memory_embed_text(query, model, qvec, BUNDLE_EMBED_DIM);
    if (qdim <= 0)

--- a/src/memory_core_crud.inc
+++ b/src/memory_core_crud.inc
@@ -353,8 +353,7 @@ int memory_insert_ex(const char *tier, const char *kind, const char *key, const 
          {
             config_t embed_cfg;
             config_load(&embed_cfg);
-            platform_memory_background_embed(
-                dup_id, embed_cfg.embedding_command[0] ? embed_cfg.embedding_command : "builtin");
+            platform_memory_background_embed(dup_id, config_embedding_command(&embed_cfg, NULL));
          }
 
          if (out)
@@ -387,8 +386,7 @@ int memory_insert_ex(const char *tier, const char *kind, const char *key, const 
       {
          config_t embed_cfg;
          config_load(&embed_cfg);
-         platform_memory_background_embed(
-             new_id, embed_cfg.embedding_command[0] ? embed_cfg.embedding_command : "builtin");
+         platform_memory_background_embed(new_id, config_embedding_command(&embed_cfg, NULL));
       }
 
       if (out)

--- a/src/memory_core_helpers.inc
+++ b/src/memory_core_helpers.inc
@@ -1693,7 +1693,10 @@ static int memory_fetch_row_by_unit_id(int64_t unit_id, memory_t *out)
 
 static const char *memory_effective_embedding_cmd(const char *command)
 {
-   return (command && command[0]) ? command : "builtin";
+   /* Single policy point: config_embedding_command (config_save.c). The caller
+    * has already resolved config -> command upstream, so pass it as the request
+    * override; this keeps memory_core consistent with the kb-side resolution. */
+   return config_embedding_command(NULL, command);
 }
 
 /* Per-recall query-embedding memo.
@@ -2032,7 +2035,7 @@ static void memory_refresh_unit_embeddings(int64_t memory_id)
       return;
    config_t cfg;
    config_load(&cfg);
-   const char *embed_command = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_command = config_embedding_command(&cfg, NULL);
 
    db2_memory_unit_row_t units[64];
    int unit_max = (int)(sizeof(units) / sizeof(units[0]));

--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -373,7 +373,7 @@ static int memory_collect_chunk_matches(const char *query, int limit, memory_t *
    int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
    config_t cm_cfg;
    config_load(&cm_cfg);
-   const char *embed_cmd = cm_cfg.embedding_command[0] ? cm_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cm_cfg, NULL);
    int got = memory_collect_memory_matches_via_vector(query, embed_cmd, limit, scratch, cap);
    for (int i = 0; i < got && count < max; i++)
       count = memory_append_unique(out, count, max, &scratch[i]);
@@ -401,7 +401,7 @@ static int memory_collect_unit_matches(const char *query, int limit, memory_t *o
    int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
    config_t mc_cfg;
    config_load(&mc_cfg);
-   const char *embed_cmd = mc_cfg.embedding_command[0] ? mc_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&mc_cfg, NULL);
    int got = memory_collect_unit_matches_via_vector(query, embed_cmd, limit, scratch, cap);
    for (int i = 0; i < got && count < max; i++)
       count = memory_append_unique(out, count, max, &scratch[i]);
@@ -3034,7 +3034,7 @@ static int memory_collect_code_matches(const char *query, int fetch_limit, memor
    int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
    config_t code_cfg;
    config_load(&code_cfg);
-   const char *embed_cmd = code_cfg.embedding_command[0] ? code_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&code_cfg, NULL);
    int got = memory_collect_memory_matches_via_vector(query, embed_cmd, fetch_limit, scratch, cap);
    for (int i = 0; i < got && count < max; i++)
       count = memory_append_unique(out, count, max, &scratch[i]);
@@ -3433,7 +3433,7 @@ static int memory_collect_variant_candidates(const char *raw_query, const char *
 
    if (qe_semantic)
    {
-      const char *embed_cmd = qe_cfg.embedding_command[0] ? qe_cfg.embedding_command : "builtin";
+      const char *embed_cmd = config_embedding_command(&qe_cfg, NULL);
       int k = qe_cfg.memory_query_expansion_k > 0 ? qe_cfg.memory_query_expansion_k : 5;
       if (memory_expand_query_semantic(signal_query[0] ? signal_query : norm_variant, embed_cmd, k,
                                        expanded_signal, sizeof(expanded_signal)) < 0)
@@ -3456,7 +3456,7 @@ static int memory_collect_variant_candidates(const char *raw_query, const char *
    }
    if (qe_semantic)
    {
-      const char *embed_cmd = qe_cfg.embedding_command[0] ? qe_cfg.embedding_command : "builtin";
+      const char *embed_cmd = config_embedding_command(&qe_cfg, NULL);
       int k = qe_cfg.memory_query_expansion_k > 0 ? qe_cfg.memory_query_expansion_k : 5;
       expanded_count =
           memory_expand_query_terms_semantic(signal_query[0] ? signal_query : norm_variant,
@@ -3473,8 +3473,7 @@ static int memory_collect_variant_candidates(const char *raw_query, const char *
    {
       memory_t lexical_scratch[64];
       int lexical_cap = (int)(sizeof(lexical_scratch) / sizeof(lexical_scratch[0]));
-      const char *lexical_embed_cmd =
-          qe_cfg.embedding_command[0] ? qe_cfg.embedding_command : "builtin";
+      const char *lexical_embed_cmd = config_embedding_command(&qe_cfg, NULL);
       config_t lanes_cfg;
       config_load(&lanes_cfg);
       if (lanes_cfg.memory_recall_lanes_enabled)
@@ -3712,7 +3711,7 @@ memory_generate_candidates(const char *query, const char *norm_query, memory_que
 
    config_t embed_cfg;
    config_load(&embed_cfg);
-   const char *embed_cmd = embed_cfg.embedding_command[0] ? embed_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&embed_cfg, NULL);
    int variant_fetch_limit = fetch_limit;
    int semantic_fetch_limit = fetch_limit;
    if (plan && plan->route == MEM_ROUTE_HYBRID)
@@ -3808,8 +3807,7 @@ memory_generate_candidates(const char *query, const char *norm_query, memory_que
          {
             memory_t scratch[64];
             int cap = (int)(sizeof(scratch) / sizeof(scratch[0]));
-            const char *embed_cmd =
-                neg_cfg.embedding_command[0] ? neg_cfg.embedding_command : "builtin";
+            const char *embed_cmd = config_embedding_command(&neg_cfg, NULL);
             /* Negation tokens aren't in the vector payload yet, so this falls
              * back to memory-level semantic search of the synthetic
              * "not_<token>" query. Future work: add negation_tokens to the
@@ -4620,7 +4618,7 @@ int memory_diagnose_scoped(const char *query, const char *scope_type, const char
 
    config_t embed_cfg;
    config_load(&embed_cfg);
-   const char *embed_cmd = embed_cfg.embedding_command[0] ? embed_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&embed_cfg, NULL);
    int64_t semantic_ids[128];
    double semantic_scores[128];
    int semantic_hit_count = 0;
@@ -4685,7 +4683,7 @@ int memory_explain_match(const char *query, int64_t memory_id, memory_diagnostic
 
    config_t embed_cfg;
    config_load(&embed_cfg);
-   const char *embed_cmd = embed_cfg.embedding_command[0] ? embed_cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&embed_cfg, NULL);
    int64_t semantic_ids[128];
    double semantic_scores[128];
    int semantic_hit_count = 0;

--- a/src/memory_logic.c
+++ b/src/memory_logic.c
@@ -418,7 +418,7 @@ void embed_unembedded_l2(void)
 #else
    config_t cfg;
    config_load(&cfg);
-   const char *embed_command = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_command = config_embedding_command(&cfg, NULL);
    const char *embed_ver = cfg.embedding_model[0] ? cfg.embedding_model : embed_command;
 
    int64_t ids[50];

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -1299,9 +1299,8 @@ static char *td_search_docs(cJSON *args, const char *name, const char *dispatch_
       config_t cfg;
       config_load(&cfg);
       int max = (mx && cJSON_IsNumber(mx)) ? mx->valueint : 3;
-      char *envelope = kb_client_search_json(
-          NULL, q->valuestring, cfg.embedding_command[0] ? cfg.embedding_command : "builtin", max,
-          NULL);
+      char *envelope = kb_client_search_json(NULL, q->valuestring,
+                                             config_embedding_command(&cfg, NULL), max, NULL);
       /* The knowledge service returns {"status":"ok","result":"<text>"}; unwrap so the
        * tool sees the same body shape kb_search() used to return. */
       cJSON *resp = envelope ? cJSON_Parse(envelope) : NULL;

--- a/src/server/agent_eval_benchmarks.c
+++ b/src/server/agent_eval_benchmarks.c
@@ -131,7 +131,7 @@ static int mem_eval_drain_async_queues(mem_eval_async_drain_totals_t *totals)
    if (!cfg.memory_cognify_async_enabled && !cognify_enabled)
       return 0;
 
-   const char *embed_cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
    db2_kb_service_async_queue_stats_t queue_stats;
    memory_cognify_queue_stats_t cog_stats;
    memset(&queue_stats, 0, sizeof(queue_stats));

--- a/src/server/agent_eval_memory_support.c
+++ b/src/server/agent_eval_memory_support.c
@@ -983,8 +983,7 @@ int mem_eval_load_corpus(const char *corpus_path, mem_eval_case_t *cases, int ma
       {
          config_t embed_cfg;
          config_load(&embed_cfg);
-         const char *embed_cmd =
-             embed_cfg.embedding_command[0] ? embed_cfg.embedding_command : "builtin";
+         const char *embed_cmd = config_embedding_command(&embed_cfg, NULL);
          if (memory_embed(m.id, embed_cmd) != 0)
          {
             fprintf(stderr, "mem_eval_load_corpus: memory_embed failed for fixture %s\n",

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -458,7 +458,7 @@ static int embeddings_handler(const char *body, char *resp, int cap)
    config_t cfg;
    memset(&cfg, 0, sizeof(cfg));
    config_load(&cfg);
-   const char *cmd = cfg.embedding_command[0] ? cfg.embedding_command : "builtin";
+   const char *cmd = config_embedding_command(&cfg, NULL);
 
    float **vecs = calloc((size_t)n, sizeof(float *));
    int *dims = calloc((size_t)n, sizeof(int));

--- a/src/tests/test_agent_max_turns.c
+++ b/src/tests/test_agent_max_turns.c
@@ -107,3 +107,12 @@ int main(void)
    printf("test_agent_max_turns: all tests passed\n");
    return 0;
 }
+
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}

--- a/src/tests/test_cron_runtime.c
+++ b/src/tests/test_cron_runtime.c
@@ -435,3 +435,12 @@ int main(void)
    printf("cron runtime tests passed\n");
    return 0;
 }
+
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -260,3 +260,12 @@ int main(void)
    printf("all tests passed\n");
    return 0;
 }
+
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -756,6 +756,15 @@ int config_load(config_t *cfg)
    return 0;
 }
 
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}
+
 int db2_calibration_surfaces_with_data(int min_rows)
 {
    assert(min_rows == 200);

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -1719,3 +1719,12 @@ int main(void)
    printf("server_dispatch: all tests passed\n");
    return 0;
 }
+
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}

--- a/src/tests/test_server_jobs_aux.c
+++ b/src/tests/test_server_jobs_aux.c
@@ -275,3 +275,12 @@ int main(void)
    printf("All tests passed.\n");
    return 0;
 }
+
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}

--- a/src/tests/test_trigger.c
+++ b/src/tests/test_trigger.c
@@ -536,3 +536,12 @@ int main(void)
    printf("All tests passed.\n");
    return 0;
 }
+
+const char *config_embedding_command(const config_t *cfg, const char *requested)
+{
+   if (requested && requested[0])
+      return requested;
+   if (cfg && cfg->embedding_command[0])
+      return cfg->embedding_command;
+   return "builtin";
+}


### PR DESCRIPTION
Investigating "fragile parts of other parts of the system" surfaced the real systemic issue behind the `.254` embedding failures: **~22 sites** across kb, db2, memory, CLI and server each independently fell back to `"builtin"` (a 384-dim hash) when no embedder was configured, and several request handlers ignored the configured embedder entirely.

- `memory.repair`, `memory.verify`, `memory.embed` and 4 KB HTTP ingest endpoints resolved the embedder from the request payload **only** — omit it and they used builtin, never the configured embedder.
- In production (halfvec 1024/2560) builtin emits a 384-dim vector the column rejects (`expected N dimensions, not 384`), silently leaving embeddings empty.
- This is exactly the bug #543 fixed for reembed alone; it lived everywhere else.

**Fix:** one resolver `config_embedding_command(cfg, requested)` with precedence **request override → configured embedder → builtin**. Every site routes through it; the two old duplicate resolvers (`kb_effective_embedding_cmd`, `memory_effective_embedding_cmd`) now delegate to it. Request handlers load config so they fall back to the configured embedder, not builtin. builtin remains only for a genuinely unconfigured 384-dim shim/test setup.

Test binaries that stub `config_load` gain a matching `config_embedding_command` stub. Full `make unit-tests` passes locally.

Stacks on #546 (in-process HTTP embedding).