### PR TITLE
fix(embed): default embedding_command to $AIMEE_EMBEDDER_URL (durable in-process embedding)

### DIFF
--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -37,7 +37,12 @@ ensemble:
     - mimo-2.5
 
 # --- kb: real semantic embeddings via the persistent embedder service ---
-embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"
+# No embedding_command here on purpose: when it is unset the server embeds
+# in-process against $AIMEE_EMBEDDER_URL (Dockerfile.combined / compose set it to
+# the embedder service), speaking http:// directly -- no fork, no python. Leaving
+# it out of the seed means a config reseed can never revert embeddings to the old
+# forking script. Set it explicitly only to override (e.g. "builtin" for a
+# no-embedder setup, or a custom command).
 
 learning:
   synthesize:

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -196,7 +196,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 115 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 116 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -387,7 +387,7 @@ The binaries read 115 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_EMBEDDER_URL`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -12,6 +12,7 @@
 #include "yaml.h"
 #include <fcntl.h>
 #include <stdarg.h>
+#include <stdlib.h> /* getenv — AIMEE_EMBEDDER_URL default */
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -1128,6 +1129,15 @@ const char *config_embedding_command(const config_t *cfg, const char *requested)
       return requested;
    if (cfg && cfg->embedding_command[0])
       return cfg->embedding_command;
+   /* No explicit command: if the deployment points us at an embedder service,
+    * embed against it in-process (memory_embed_text speaks http:// directly, no
+    * fork, no python). This makes a configured embedder the default with zero
+    * config and survives a config reseed -- the combined image always exports
+    * AIMEE_EMBEDDER_URL. Only when nothing is configured do we fall back to the
+    * 384-dim builtin (correct for an unconfigured shim/test setup). */
+   const char *env = getenv("AIMEE_EMBEDDER_URL");
+   if (env && env[0])
+      return env;
    return "builtin";
 }
 


### PR DESCRIPTION
Stops embeddings from reverting to the fragile forked-python path on every redeploy.

The combined image seeded `aimee.yaml` with `embedding_command: python3 .../embed-remote.py`, so a config reseed (fresh container on upgrade) reverted embeddings to a forked python process. On `.254` `python3` isnt reliably on the container exec PATH, so that fork was itself fragile (a contributor to the original embeddings:0).

**Fix:** when `embedding_command` is unset, `config_embedding_command` now falls back to `$AIMEE_EMBEDDER_URL` before `builtin`. `memory_embed_text` speaks `http://` in-process (no fork, no python), so any deployment exporting `AIMEE_EMBEDDER_URL` (the combined image always does) embeds against the real embedder automatically and durably. Also drops the hard-coded `embedding_command` from the seeded combined config so a reseed cant revert it.

Stacks on #546 (in-process HTTP) + #547 (resolver). Full `make unit-tests` passes.