### PR TITLE
ci: build :testing images on push to testing (non-semver)

### DIFF
--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -1,22 +1,19 @@
-# Build deployable app images on every push to `testing` and publish them under
-# a DELIBERATELY non-semver tag (`:testing` + `:testing-<sha>`), so the testing
+# Build the combined image on every push to `testing` and publish it under a
+# DELIBERATELY non-semver tag (`:testing` + `:testing-<sha>`), so the testing
 # branch can be deployed/validated (e.g. on .254) WITHOUT promoting to main.
 #
-# Versioned + `:latest` publishing stays owned by main (auto-release.yml ->
-# publish-images.yml). Keeping testing on a `:testing` tag — never a version
-# number — avoids any confusion between a tested-but-unreleased build and a real
-# release.
-#
-# Scope: the three C app images only (server, kb, combined). The embedder /
-# css-render images are large, rarely change, and are owned by the versioned
-# release pipeline; pull their `:latest` alongside a `:testing` app image.
-# amd64 only (the .254 deploy target); the release pipeline owns multi-arch.
-name: Publish testing images
+# Only the combined image (aimee-server-kb, Dockerfile.combined) is built here —
+# that is the single unit deployed to .254. Versioned + `:latest` publishing of
+# the full image set stays owned by main (auto-release.yml -> publish-images.yml).
+# Keeping testing on a `:testing` tag — never a version number — avoids confusing
+# a tested-but-unreleased build with a real release. amd64 only (the .254 deploy
+# target); the release pipeline owns multi-arch.
+name: Publish testing image
 
 on:
   push:
     branches: [testing]
-    # Only rebuild when something that affects the images changes.
+    # Only rebuild when something that affects the image changes.
     paths:
       - "src/**"
       - "config/**"
@@ -39,13 +36,6 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        image:
-          - { name: aimee-server,    dockerfile: Dockerfile.server }
-          - { name: aimee-kb,        dockerfile: Dockerfile }
-          - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
     steps:
       - uses: actions/checkout@v4
 
@@ -65,21 +55,21 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push :testing
+      - name: Build and push aimee-server-kb:testing
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ${{ matrix.image.dockerfile }}
+          file: Dockerfile.combined
           platforms: linux/amd64
           push: true
           provenance: false
           # Share the layer cache with the release pipeline (same scope) so testing
           # builds are fast and never start the LTO C build from scratch.
-          cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
-          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
+          cache-from: type=gha,scope=aimee-server-kb-amd64
+          cache-to: type=gha,mode=max,scope=aimee-server-kb-amd64
           build-args: |
             AIMEE_VERSION=testing-${{ env.SHA7 }}
             WITH_WEBCHAT=1
           tags: |
-            ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
-            ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}
+            ghcr.io/${{ env.OWNER }}/aimee-server-kb:testing
+            ghcr.io/${{ env.OWNER }}/aimee-server-kb:testing-${{ env.SHA7 }}

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -1,0 +1,85 @@
+# Build deployable app images on every push to `testing` and publish them under
+# a DELIBERATELY non-semver tag (`:testing` + `:testing-<sha>`), so the testing
+# branch can be deployed/validated (e.g. on .254) WITHOUT promoting to main.
+#
+# Versioned + `:latest` publishing stays owned by main (auto-release.yml ->
+# publish-images.yml). Keeping testing on a `:testing` tag — never a version
+# number — avoids any confusion between a tested-but-unreleased build and a real
+# release.
+#
+# Scope: the three C app images only (server, kb, combined). The embedder /
+# css-render images are large, rarely change, and are owned by the versioned
+# release pipeline; pull their `:latest` alongside a `:testing` app image.
+# amd64 only (the .254 deploy target); the release pipeline owns multi-arch.
+name: Publish testing images
+
+on:
+  push:
+    branches: [testing]
+    # Only rebuild when something that affects the images changes.
+    paths:
+      - "src/**"
+      - "config/**"
+      - "deploy/container/**"
+      - "scripts/**"
+      - "Dockerfile"
+      - "Dockerfile.server"
+      - "Dockerfile.combined"
+      - ".github/workflows/publish-testing.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-testing-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - { name: aimee-server,    dockerfile: Dockerfile.server }
+          - { name: aimee-kb,        dockerfile: Dockerfile }
+          - { name: aimee-server-kb, dockerfile: Dockerfile.combined }
+    steps:
+      - uses: actions/checkout@v4
+
+      # ghcr paths must be lowercase; owners may be mixed-case (e.g. "JBailes").
+      - name: Normalize owner + short sha
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push :testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          # Share the layer cache with the release pipeline (same scope) so testing
+          # builds are fast and never start the LTO C build from scratch.
+          cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
+          cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
+          build-args: |
+            AIMEE_VERSION=testing-${{ env.SHA7 }}
+            WITH_WEBCHAT=1
+          tags: |
+            ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
+            ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}


### PR DESCRIPTION
## What

Adds `publish-testing.yml`: on every push to `testing`, builds the three C app
images (aimee-server, aimee-kb, aimee-server-kb) and pushes them under a
**deliberately non-semver** tag — `:testing` (moving) + `:testing-<sha>`
(traceable).

## Why

Deploying/validating the testing branch (e.g. on .254) currently requires
promoting to main, which triggers a real semver release. This lets us deploy a
testing build directly. Keeping the tag as `:testing` — never a version number —
avoids confusing a tested-but-unreleased build with a real release, which is the
whole point.

- Versioned + `:latest` publishing stays owned by main (`auto-release.yml` →
  `publish-images.yml`); unchanged.
- amd64 only (the .254 deploy target); the release pipeline keeps multi-arch.
- Shares the release layer cache (same scope) so testing builds reuse layers and
  don't restart the LTO C build from scratch.
- `paths` filter so only image-affecting changes rebuild.
- `AIMEE_VERSION=testing-<sha>` so `--version` is clearly a non-release build.

## Follow-up

Once merged, the push to testing builds `aimee-server-kb:testing` (with #554 +
#555), which we deploy to .254 to measure HyDE recall@k off vs on.