### PR TITLE
fix(hyde): fire in-process rewrite without a subprocess command

### DIFF
--- a/src/memory_core_search.inc
+++ b/src/memory_core_search.inc
@@ -4174,7 +4174,12 @@ int memory_find_facts_scoped(const char *query, const char *scope_type, const ch
    memset(&rewrite, 0, sizeof(rewrite));
    {
       config_t cfg;
-      if (config_load(&cfg) == 0 && cfg.memory_rewrite_enabled && cfg.memory_rewrite_command[0])
+      /* Fire when enabled and a rewrite mechanism exists: either the legacy
+       * subprocess command, or the in-process curator-LLM seam (KB build). The
+       * in-process path needs no command, so requiring one would silently
+       * disable HyDE on an accelerated backend that only configures a provider. */
+      if (config_load(&cfg) == 0 && cfg.memory_rewrite_enabled &&
+          (cfg.memory_rewrite_command[0] || memory_rewrite_llm_inproc))
          memory_query_rewrite(query, &cfg, &rewrite);
    }
 


### PR DESCRIPTION
## What

The HyDE rewrite's outer guard in `memory_find_facts_scoped` required
`memory_rewrite_command[0]` to be non-empty:

```c
if (config_load(&cfg) == 0 && cfg.memory_rewrite_enabled && cfg.memory_rewrite_command[0])
```

The in-process curator-LLM rewrite (the production path) needs **no** subprocess
command. So on an accelerated backend that only configures a provider — exactly
what the backend-gating (#561) yields when it auto-enables `memory_rewrite` —
HyDE was silently disabled unless a (dead) command was also set.

## Caught by

Verifying #561's auto-gating on .254: with a non-E4B model + no explicit config,
typed_facts flipped on (extraction job created) but `find_facts` stayed fast
(1.08s, no rewrite) because no command was configured.

## Fix

Fire when enabled AND a rewrite mechanism exists — command **or** the in-process
seam (`memory_rewrite_llm_inproc`, weak: defined in the KB build, NULL elsewhere
→ falls back to the command). Matches the inner guard already in
`memory_query_rewrite`.

`make server` clean.