### PR TITLE
feat(sweep): filing-path safety validator (Part B PR-B4a)

### DIFF
--- a/src/headers/sweep.h
+++ b/src/headers/sweep.h
@@ -113,6 +113,15 @@ extern "C"
     * (<= max), or -1 on parse failure. Pure (no IO / no model). */
    int sweep_parse_candidates(const char *json_text, sweep_candidate_t *out, int max);
 
+   /* --- filing-path safety (PR-B4) --- */
+
+   /* 1 if `path` is a safe repo-relative path to reference in a filed work item:
+    * non-empty, not absolute, no ".." component, and only [A-Za-z0-9._/-] (so no
+    * shell metacharacters, NUL, whitespace, globs, or quoting). The first line of
+    * the untrusted-candidate -> work-item gate; the filer adds a realpath/under-root
+    * check on top. Pure (lexical, no IO). */
+   int sweep_path_safe(const char *path);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/sweep_exclude.c
+++ b/src/server/sweep_exclude.c
@@ -19,6 +19,31 @@ void sweep_seam_key(const char *seam_file, const char *seam_symbol, char *out, s
    snprintf(out, cap, "%s:%s", seam_file, seam_symbol);
 }
 
+static int is_dotdot_component(const char *p)
+{
+   /* p points at the start of a path component; true if it is exactly ".." */
+   return p[0] == '.' && p[1] == '.' && (p[2] == '\0' || p[2] == '/');
+}
+
+int sweep_path_safe(const char *path)
+{
+   if (!path || !path[0])
+      return 0;
+   if (path[0] == '/')
+      return 0; /* no absolute paths */
+   for (const char *p = path; *p; p++)
+   {
+      unsigned char c = (unsigned char)*p;
+      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '.' || c == '_' || c == '-' || c == '/';
+      if (!ok)
+         return 0; /* any other byte: shell meta, space, glob, quote, etc. */
+      if (c == '.' && (p == path || p[-1] == '/') && is_dotdot_component(p))
+         return 0; /* a ".." path component */
+   }
+   return 1;
+}
+
 int sweep_excluded(const char *seam_key, const char *const *settled, int n)
 {
    if (!seam_key || !seam_key[0] || !settled)

--- a/src/tests/test_sweep_logic.c
+++ b/src/tests/test_sweep_logic.c
@@ -111,11 +111,38 @@ static void test_edges_from_callers(void)
    assert(e.caller_count == 0 && e.shared_state == 0);
 }
 
+static void test_path_safe(void)
+{
+   assert(sweep_path_safe("src/foo.c") == 1);
+   assert(sweep_path_safe("src/sub_dir/file-2.c") == 1);
+   assert(sweep_path_safe("a.c") == 1);
+   assert(sweep_path_safe("src/a..b.c") == 1); /* dots, not a ".." component */
+
+   /* malicious corpus — all rejected */
+   assert(sweep_path_safe("../../.bashrc") == 0);
+   assert(sweep_path_safe("/etc/passwd") == 0);
+   assert(sweep_path_safe("dir/../../../escape") == 0);
+   assert(sweep_path_safe("..") == 0);
+   assert(sweep_path_safe("src/../x") == 0);
+   assert(sweep_path_safe("a; rm -rf /") == 0);
+   assert(sweep_path_safe("$(touch x)") == 0);
+   assert(sweep_path_safe("`id`") == 0);
+   assert(sweep_path_safe("a|b") == 0);
+   assert(sweep_path_safe("a&b") == 0);
+   assert(sweep_path_safe("src/*.c") == 0);
+   assert(sweep_path_safe("a b.c") == 0);
+   assert(sweep_path_safe("a\tb") == 0);
+   assert(sweep_path_safe("\"q\"") == 0);
+   assert(sweep_path_safe("") == 0);
+   assert(sweep_path_safe(NULL) == 0);
+}
+
 int main(void)
 {
    test_seam_key_and_exclude();
    test_score();
    test_edges_from_callers();
+   test_path_safe();
    printf("sweep_logic: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Pure security core of the candidate→work-item filing gate (continues #563-#566). `sweep_path_safe` — lexical allowlist (no absolute, no `..`, only [A-Za-z0-9._/-]) rejecting shell metachars/globs/quotes/traversal; the filer (PR-B4b) layers realpath+under-root on top. Unit test adds the malicious-path corpus. Full `make lint` + `make unit-tests` green. Filing wire + manual-review.yaml are PR-B4b (where the security roundtable applies).