### PR TITLE
feat(sweep): filing — STRONG candidates → manual-review (Part B PR-B4b)

### DIFF
--- a/config/workflows/manual-review.yaml
+++ b/config/workflows/manual-review.yaml
@@ -1,0 +1,21 @@
+# manual-review: the deepening sweep files its candidates here, NOT "build".
+# The sweep's output is machine-proposed and untrusted, so it must never auto-
+# implement: this workflow only authors the (sweep-provided) proposal and puts it
+# behind a single human gate, then ends. A human who approves promotes it
+# deliberately (re-submit to "build") — nothing the sweep produces reaches
+# implement/merge without an explicit person. (Enforced by a test that asserts no
+# implement/merge node exists here.)
+name: manual-review
+start: draft
+nodes:
+  - id: draft
+    block: author.proposal
+    params:
+      with_user: false
+    next: review
+  - id: review
+    block: gate.human
+    in:
+      src: draft.out
+    params:
+      policy: pr_review

--- a/src/server/server_sweep.c
+++ b/src/server/server_sweep.c
@@ -1,9 +1,11 @@
 /* server_sweep.c: server-side deepening-sweep handler (Part B PR-B3b).
  *
  * Reuses the roundtable's in-process machinery (config + agent fan-out) and the
- * shipped pure sweep logic (sweep.h). Read-only analysis: it proposes seams per
- * area, mechanically re-grounds each against the live code index (kb_client), and
- * returns a JSON report. It does NOT file work items (that is PR-B4) or edit source.
+ * shipped pure sweep logic (sweep.h). It proposes seams per area, mechanically
+ * re-grounds each against the live code index (kb_client), and returns a JSON
+ * report. Default analysis-only; with {"file":true} it files STRONG candidates as
+ * vertical-slice work items onto the manual-review workflow (a human gate — NEVER
+ * "build"), after a lexical + realpath-under-root path check. It never edits source.
  */
 #include "server.h"
 
@@ -15,13 +17,19 @@
 #include "config.h"
 #include "delegate_ensemble.h" /* ensemble_default_panel_from_agents */
 #include "dstr.h"
+#include "aimee_home.h"
 #include "kb_client.h"
 #include "log.h"
 #include "sweep.h"
+#include "wfe_engine.h" /* wfe_work_item_create */
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
 
 #define SWEEP_MAX_FILES    4000
 #define SWEEP_PER_FILE_CAP 4096
@@ -106,10 +114,111 @@ static char *build_area_prompt(const char *root, const char (*paths)[MAX_PATH_LE
    return dstr_steal(&s);
 }
 
+/* Filing context: when do_file, STRONG candidates are filed as work items on the
+ * manual-review workflow (never "build" — a human must promote). */
+typedef struct
+{
+   int do_file;
+   const char *root; /* project root for realpath containment */
+   const char *repo; /* repo identifier for the work item */
+   int filed;
+   int file_rejected; /* skipped: unsafe / out-of-root path */
+} sweep_file_ctx_t;
+
+/* Build a vertical-slice proposal for a STRONG seam, validate the seam path, and
+ * file it onto manual-review. Untrusted candidate strings: sweep_path_safe (lexical)
+ * THEN realpath under root before anything is written or filed. */
+static void file_candidate(sweep_file_ctx_t *fc, const char *key, const sweep_candidate_t *cand,
+                           const sweep_edges_t *edges)
+{
+   if (!fc->do_file)
+      return;
+   /* lexical gate first (rejects shell meta, traversal, absolute, glob, ...) */
+   if (!sweep_path_safe(cand->seam_file))
+   {
+      fc->file_rejected++;
+      aimee_log(LOG_WARN, "sweep", "refused to file '%s': unsafe seam path", cand->seam_file);
+      return;
+   }
+   /* then realpath containment: the resolved seam must live under the project root */
+   char abs[MAX_PATH_LEN * 2];
+   if (snprintf(abs, sizeof(abs), "%s/%s", fc->root, cand->seam_file) >= (int)sizeof(abs))
+   {
+      fc->file_rejected++;
+      return;
+   }
+   char resolved[PATH_MAX];
+   size_t rootlen = strlen(fc->root);
+   if (!realpath(abs, resolved) || strncmp(resolved, fc->root, rootlen) != 0 ||
+       (resolved[rootlen] != '/' && resolved[rootlen] != '\0'))
+   {
+      fc->file_rejected++;
+      aimee_log(LOG_WARN, "sweep", "refused to file '%s': resolves outside the project root",
+                cand->seam_file);
+      return;
+   }
+
+   /* vertical-slice ticket. Body is opaque text consumers must not eval/template. */
+   dstr_t md;
+   dstr_init(&md);
+   dstr_appendf(&md, "# Deepen seam: %s\n\n", key);
+   dstr_appendf(&md,
+                "The deepening sweep found `%s:%s` reproduced across **%d call site(s) in %d "
+                "file(s)** (independent, low shared state). Extract it into one deep module.\n\n",
+                cand->seam_file, cand->seam_symbol, edges->caller_count, edges->distinct_files);
+   if (cand->rationale[0])
+      dstr_appendf(&md, "> Proposer note: %s\n\n", cand->rationale);
+   dstr_append_str(&md, "## Vertical slice (definition of done)\n"
+                        "- Introduce the deep module behind a small interface.\n"
+                        "- Repoint EVERY call site (see the code index for the call sites).\n"
+                        "- Add tests at the new interface (assert behaviour THROUGH it).\n"
+                        "- Delete the old duplicated copies.\n\n"
+                        "_Machine-proposed by the deepening sweep; verified against the live "
+                        "code index. A human must review before this is implemented._\n");
+
+   const char *home = aimee_home();
+   char dir[1024];
+   snprintf(dir, sizeof(dir), "%s/sweeps/proposals", home ? home : "/tmp");
+   /* best-effort dir create (parents from standup) */
+   {
+      char parent[1024];
+      snprintf(parent, sizeof(parent), "%s/sweeps", home ? home : "/tmp");
+      mkdir(parent, 0700);
+      mkdir(dir, 0700);
+   }
+   char ppath[1200];
+   snprintf(ppath, sizeof(ppath), "%s/sw-%ld-%d-%d.md", dir, (long)time(NULL), (int)getpid(),
+            fc->filed + fc->file_rejected);
+   FILE *pf = fopen(ppath, "wb");
+   if (!pf)
+   {
+      dstr_free(&md);
+      fc->file_rejected++;
+      return;
+   }
+   const char *text = dstr_cstr(&md);
+   fwrite(text, 1, strlen(text), pf);
+   fclose(pf);
+   dstr_free(&md);
+
+   char id[80] = "", err[256] = "";
+   /* workflow="manual-review": a human gate, NOT auto-build (see manual-review.yaml). */
+   int rc = wfe_work_item_create("manual-review", fc->repo ? fc->repo : "", ppath, "sweep", id, err,
+                                 sizeof(err));
+   if (rc != 0 || !id[0])
+   {
+      fc->file_rejected++;
+      aimee_log(LOG_WARN, "sweep", "filing '%s' failed: %s", key, err[0] ? err : "unknown");
+      return;
+   }
+   fc->filed++;
+}
+
 /* Score one candidate against the live index; appends a report object. */
 static void score_candidate(cJSON *report, const sweep_candidate_t *cand,
                             const sweep_score_cfg_t *scfg, const char *const *settled,
-                            int settled_n, int *strong, int *worth, int *rejected, int *excluded)
+                            int settled_n, int *strong, int *worth, int *rejected, int *excluded,
+                            sweep_file_ctx_t *fc)
 {
    char key[SWEEP_KEY_MAX];
    sweep_seam_key(cand->seam_file, cand->seam_symbol, key, sizeof(key));
@@ -135,14 +244,25 @@ static void score_candidate(cJSON *report, const sweep_candidate_t *cand,
 
    char reason[160];
    sweep_rank_t rank = sweep_score(&edges, scfg, reason, sizeof(reason));
+   int filed_this = 0;
    if (rank == SWEEP_STRONG)
+   {
       (*strong)++;
+      if (fc && fc->do_file)
+      {
+         int before = fc->filed;
+         file_candidate(fc, key, cand, &edges);
+         filed_this = (fc->filed > before);
+      }
+   }
    else if (rank == SWEEP_WORTH)
       (*worth)++;
    else
       (*rejected)++;
 
    cJSON *o = cJSON_CreateObject();
+   if (filed_this)
+      cJSON_AddBoolToObject(o, "filed", 1);
    cJSON_AddStringToObject(o, "seam", key);
    cJSON_AddStringToObject(o, "rank",
                            rank == SWEEP_STRONG  ? "strong"
@@ -162,6 +282,10 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    (void)ctx;
    const cJSON *jproj = cJSON_GetObjectItemCaseSensitive(req, "project");
    const char *want_proj = (jproj && cJSON_IsString(jproj)) ? jproj->valuestring : "";
+   const cJSON *jfile = cJSON_GetObjectItemCaseSensitive(req, "file");
+   int do_file = cJSON_IsTrue(jfile); /* default false -> analysis-only */
+   const cJSON *jrepo = cJSON_GetObjectItemCaseSensitive(req, "repo");
+   const char *repo = (jrepo && cJSON_IsString(jrepo)) ? jrepo->valuestring : "";
 
    /* Resolve the walk root from the indexed projects (the corpus we verify against).
     * No index -> nothing can be verified -> refuse up front. */
@@ -169,12 +293,17 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    int np = kb_client_index_list(projs, 32);
    if (np <= 0)
       return server_send_error(conn, "no indexed project (run `aimee index scan` first)", NULL);
-   const char *root = projs[0].root;
+   const char *sel = projs[0].root;
    for (int i = 0; i < np; i++)
       if (want_proj[0] && strcmp(projs[i].name, want_proj) == 0)
-         root = projs[i].root;
-   if (!root || !root[0])
+         sel = projs[i].root;
+   if (!sel || !sel[0])
       return server_send_error(conn, "indexed project has no root", NULL);
+   /* Canonicalize the root once so the filing containment check (realpath of a seam
+    * under root) compares against the resolved root, not a symlinked/.. form. */
+   char root[PATH_MAX];
+   if (!realpath(sel, root))
+      return server_send_error(conn, "indexed project root does not resolve", NULL);
 
    config_t cfg;
    config_load(&cfg);
@@ -223,6 +352,8 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const char *const *settled = NULL;
    int settled_n = 0;
 
+   sweep_file_ctx_t fc = {do_file, root, repo, 0, 0};
+
    cJSON *resp = cJSON_CreateObject();
    cJSON *cands = cJSON_AddArrayToObject(resp, "candidates");
    int strong = 0, worth = 0, rejected = 0, excluded = 0, areas_run = 0;
@@ -246,7 +377,7 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          int nc = sweep_parse_candidates(r.response, cand, SWEEP_MAX_CAND);
          for (int i = 0; i < nc && i < caps.max_items_per_area; i++)
             score_candidate(cands, &cand[i], &scfg, settled, settled_n, &strong, &worth, &rejected,
-                            &excluded);
+                            &excluded, &fc);
       }
       free(r.response);
    }
@@ -258,12 +389,19 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    cJSON_AddNumberToObject(resp, "worth_exploring", worth);
    cJSON_AddNumberToObject(resp, "rejected", rejected);
    cJSON_AddNumberToObject(resp, "excluded", excluded);
-   cJSON_AddBoolToObject(resp, "analysis_only", 1);
+   cJSON_AddBoolToObject(resp, "analysis_only", do_file ? 0 : 1);
+   cJSON_AddNumberToObject(resp, "filed", fc.filed);
+   cJSON_AddNumberToObject(resp, "file_rejected", fc.file_rejected);
    /* v1: shared-state (blast radius) is not yet wired, so over-coupling is not
-    * demoted — STRONG here means count+distribution+independence only. */
+    * demoted — STRONG here means count+distribution+independence only. STRONG
+    * candidates are filed onto the manual-review workflow (human gate) only when
+    * file=true; never auto-built. */
    cJSON_AddStringToObject(resp, "note",
-                           "v1: shared-state/blast-radius conservative (0); "
-                           "filing is a later phase — nothing was filed");
+                           do_file
+                               ? "filed STRONG candidates to manual-review (human gate, not "
+                                 "build); shared-state conservative (v1)"
+                               : "analysis-only (pass {\"file\":true} to file STRONG candidates "
+                                 "to manual-review); shared-state conservative (v1)");
 
    free(area);
    free(cc.paths);

--- a/src/tests/test_workflow.c
+++ b/src/tests/test_workflow.c
@@ -211,6 +211,31 @@ int main(void)
       }
    }
 
+   /* --- shipped manual-review.yaml (the sweep's filing target) validates --- */
+   {
+      char err[256];
+      wfe_def_t *d = wfe_def_load_file("../config/workflows/manual-review.yaml", err, sizeof err);
+      if (d)
+      {
+         int rc = wfe_def_validate(d, err, sizeof err);
+         if (rc != 0)
+            printf("\n  manual-review.yaml invalid: %s\n", err);
+         assert(rc == 0);
+         /* security invariant: the sweep's untrusted output must NOT auto-implement —
+          * manual-review contains no implement/merge node, only a human gate. */
+         for (int i = 0; i < d->n_nodes; i++)
+         {
+            assert(d->nodes[i].block != WFE_BLK_IMPLEMENT);
+            assert(d->nodes[i].block != WFE_BLK_MERGE);
+         }
+         wfe_def_free(d);
+      }
+      else
+      {
+         printf("(skip manual-review.yaml: %s) ", err);
+      }
+   }
+
    printf("ok\n");
    return 0;
 }


### PR DESCRIPTION
Turns the analysis-only sweep (#566) into a producer for the dev queue — **behind a human gate**. Continues #563-#567.

- **`config/workflows/manual-review.yaml`** — a new workflow = `author.proposal → gate.human` (terminal). The sweep's machine-proposed, untrusted output files **here, never `build`**, so it can never auto-implement; a human must promote it. `test_workflow` asserts manual-review has **no implement/merge node** (the security invariant).
- **`handle_dev_sweep` `{"file":true}`** (default analysis-only): for each STRONG candidate, gate the seam path through `sweep_path_safe` (lexical, #567) **then `realpath` under the canonicalized project root**; build a vertical-slice `proposal_md` (opaque bytes, written exactly as `/v1/dev/submit` does) and `wfe_work_item_create(workflow="manual-review", …)`. Report adds `filed`/`file_rejected`.
- Workflow string is **hard-coded `"manual-review"`** — callers can't redirect sweep output into build/auto-implement.

## Security
The untrusted-candidate → dev-queue injection point: two-stage path gate (lexical + realpath-under-canonical-root with a `/`-boundary check defeating `/rootEVIL` prefix confusion), default-off filing, hard-coded human-gate workflow, opaque proposal body (never eval'd — same handling as the trusted `/v1/dev/submit`).

## Verification
Full build + `make lint` + `make unit-tests` green. Roundtable (security + engineer) → both APPROVE-WITH-CHANGES, no blockers; folded root-canonicalization (verified `rationale[256]` bounded; body/repo handling matches the established submit path).

Next: B5 (worktree/resume/delta durability) — the last Part B slice.