### PR TITLE
feat(sweep): delta-awareness — exclude already-filed seams (Part B PR-B5)

### DIFF
--- a/src/headers/sweep.h
+++ b/src/headers/sweep.h
@@ -122,6 +122,14 @@ extern "C"
     * check on top. Pure (lexical, no IO). */
    int sweep_path_safe(const char *path);
 
+   /* --- delta-awareness (PR-B5) --- */
+
+   /* Extract a filed proposal's seam key from its markdown header line
+    * "# Deepen seam: <key>" into out[cap]. Returns 1 if found, 0 otherwise. The
+    * sweep scans its own previously-filed proposals to build the exclusion set, so
+    * a re-run does not re-file an already-filed seam ("delta-aware"). Pure. */
+   int sweep_extract_seam_key(const char *proposal_md, char *out, size_t cap);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/server_sweep.c
+++ b/src/server/server_sweep.c
@@ -23,6 +23,7 @@
 #include "sweep.h"
 #include "wfe_engine.h" /* wfe_work_item_create */
 
+#include <dirent.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -30,6 +31,59 @@
 #include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
+
+#define SWEEP_MAX_SETTLED 1024
+
+/* Delta-awareness: scan previously-filed sweep proposals for their seam keys so a
+ * re-run excludes already-filed seams. Returns the count; *out is a malloc'd array
+ * of malloc'd keys the caller frees. (Server-side, repo-non-writing design: the
+ * exclusion set is the sweep's own filing trail under $AIMEE_HOME, not a worktree.) */
+static int sweep_load_settled(char ***out)
+{
+   *out = NULL;
+   const char *home = aimee_home();
+   char dir[1024];
+   if (snprintf(dir, sizeof(dir), "%s/sweeps/proposals", home ? home : "/tmp") >= (int)sizeof(dir))
+      return 0; /* AIMEE_HOME absurdly long -> no delta set (re-files; safe, not wrong) */
+   DIR *d = opendir(dir);
+   if (!d)
+      return 0; /* none filed yet */
+   char **arr = calloc(SWEEP_MAX_SETTLED, sizeof(char *));
+   if (!arr)
+   {
+      closedir(d);
+      return 0;
+   }
+   int n = 0;
+   struct dirent *e;
+   while ((e = readdir(d)) && n < SWEEP_MAX_SETTLED)
+   {
+      size_t l = strlen(e->d_name);
+      if (l < 3 || strcmp(e->d_name + l - 3, ".md") != 0)
+         continue;
+      char p[1200];
+      if (snprintf(p, sizeof(p), "%s/%s", dir, e->d_name) >= (int)sizeof(p))
+         continue;
+      FILE *f = fopen(p, "rb");
+      if (!f)
+         continue;
+      /* large enough for the full "# Deepen seam: <key>" line (key <= SWEEP_KEY_MAX) */
+      char buf[SWEEP_KEY_MAX + 64]; /* header is line 1 */
+      size_t rd = fread(buf, 1, sizeof(buf) - 1, f);
+      fclose(f);
+      buf[rd] = '\0';
+      char key[SWEEP_KEY_MAX];
+      if (sweep_extract_seam_key(buf, key, sizeof(key)))
+      {
+         arr[n] = strdup(key);
+         if (arr[n])
+            n++;
+      }
+   }
+   closedir(d);
+   *out = arr;
+   return n;
+}
 
 #define SWEEP_MAX_FILES    4000
 #define SWEEP_PER_FILE_CAP 4096
@@ -347,10 +401,13 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (area_count > caps.max_areas)
       area_count = caps.max_areas; /* cap; remaining areas are a later (delta) sweep */
 
-   /* Exclusion set (proposals/work-queue/typed_facts) is wired in PR-B4; v1 has
-    * an empty settled set so nothing is excluded yet. */
-   const char *const *settled = NULL;
-   int settled_n = 0;
+   /* Delta-awareness: exclude seams already filed by a prior sweep (its own filing
+    * trail under $AIMEE_HOME). typed_facts/architecture_settled exclusion needs a
+    * kb_client recall path that does not exist yet (DB2-disabled server) — deferred;
+    * v1 dedupes against prior filings, which is the dominant re-run case. */
+   char **settled_arr = NULL;
+   int settled_n = sweep_load_settled(&settled_arr);
+   const char *const *settled = (const char *const *)settled_arr;
 
    sweep_file_ctx_t fc = {do_file, root, repo, 0, 0};
 
@@ -403,6 +460,9 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                                : "analysis-only (pass {\"file\":true} to file STRONG candidates "
                                  "to manual-review); shared-state conservative (v1)");
 
+   for (int i = 0; i < settled_n; i++)
+      free(settled_arr[i]);
+   free(settled_arr);
    free(area);
    free(cc.paths);
    return server_send_ok(conn, resp);

--- a/src/server/sweep_exclude.c
+++ b/src/server/sweep_exclude.c
@@ -44,6 +44,29 @@ int sweep_path_safe(const char *path)
    return 1;
 }
 
+int sweep_extract_seam_key(const char *proposal_md, char *out, size_t cap)
+{
+   if (out && cap)
+      out[0] = '\0';
+   if (!proposal_md || !out || cap == 0)
+      return 0;
+   static const char *PREFIX = "# Deepen seam: ";
+   const char *h = strstr(proposal_md, PREFIX);
+   if (!h)
+      return 0;
+   h += strlen(PREFIX);
+   size_t i = 0;
+   while (h[i] && h[i] != '\n' && h[i] != '\r' && i + 1 < cap)
+   {
+      out[i] = h[i];
+      i++;
+   }
+   out[i] = '\0';
+   while (i > 0 && out[i - 1] == ' ') /* defensive trailing-space trim */
+      out[--i] = '\0';
+   return out[0] != '\0';
+}
+
 int sweep_excluded(const char *seam_key, const char *const *settled, int n)
 {
    if (!seam_key || !seam_key[0] || !settled)

--- a/src/tests/test_sweep_logic.c
+++ b/src/tests/test_sweep_logic.c
@@ -137,12 +137,30 @@ static void test_path_safe(void)
    assert(sweep_path_safe(NULL) == 0);
 }
 
+static void test_extract_seam_key(void)
+{
+   char k[SWEEP_KEY_MAX];
+   assert(sweep_extract_seam_key("# Deepen seam: src/foo.c:helper_x\n\nbody", k, sizeof(k)) == 1);
+   assert(strcmp(k, "src/foo.c:helper_x") == 0);
+   assert(sweep_extract_seam_key("# Deepen seam: a.c:g\r\n", k, sizeof(k)) == 1); /* CRLF */
+   assert(strcmp(k, "a.c:g") == 0);
+   assert(sweep_extract_seam_key("## Other\n", k, sizeof(k)) == 0);
+   assert(k[0] == '\0');
+   assert(sweep_extract_seam_key(NULL, k, sizeof(k)) == 0);
+
+   /* round-trip: a filed proposal's key excludes that seam on the next run */
+   sweep_extract_seam_key("# Deepen seam: m/n.c:fn\n", k, sizeof(k));
+   const char *settled[] = {k};
+   assert(sweep_excluded("m/n.c:fn", settled, 1) == 1);
+}
+
 int main(void)
 {
    test_seam_key_and_exclude();
    test_score();
    test_edges_from_callers();
    test_path_safe();
+   test_extract_seam_key();
    printf("sweep_logic: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Final Part B slice (continues #563-#568). Makes re-runs idempotent: `sweep_extract_seam_key` (pure, tested) reads a filed proposal's `# Deepen seam: <key>` header back; `sweep_load_settled` scans the sweep's own prior proposals under `$AIMEE_HOME/sweeps/proposals/` to build the exclusion set, so already-filed seams are `excluded`, not re-filed.

**Scope note:** the planned B5 worktree/resume/committer machinery is **N/A** — the server-side sweep writes nothing into the repo working tree (reads the index, writes proposals to $AIMEE_HOME, files work items), so there's no in-repo write to isolate. The delta signal is the sweep's own filing trail. typed_facts exclusion deferred (no kb_client recall from the DB2-disabled server); prior-filing dedup covers the dominant re-run.

Full `make lint` + `make unit-tests` green (an LTO ICE on an unrelated target was a transient incremental-build artifact; clean rebuild passes). Roundtable (engineer) → APPROVE-WITH-CHANGES, no blockers; folded dir-truncation guard + buffer sizing.