### PR TITLE
fix(webchat): suppress self-echo of originating turn over presence SSE

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1522,10 +1522,19 @@ export default function Chat() {
     es.addEventListener('turn_started', (ev: MessageEvent<string>) => {
       saveCursor(ev);
       curTurnId = turnIdOf(ev.data); observed = ''; wasWorking = workingRef.current;
-      setRemoteTurnActive(true); setRemoteTurnText('');
+      // Self-echo suppression: the server now ALWAYS mirrors the full turn to the
+      // presence ring (durable source of truth for detached recovery), so the
+      // surface that ORIGINATED the turn receives an echo of its own stream here.
+      // Driving remoteTurn* from that echo is pure wasted work — the indicator is
+      // hidden while `working` (see render: remoteTurnActive && !working) and the
+      // native POST stream already renders the turn — and one full re-render per
+      // token, on top of the native one, pegs a core during every response. Only
+      // touch the live UI for a turn THIS surface did not originate.
+      if (!wasWorking) { setRemoteTurnActive(true); setRemoteTurnText(''); }
     });
     es.addEventListener('turn_delta', (ev: MessageEvent<string>) => {
       saveCursor(ev);
+      if (wasWorking) return; // own turn echo: don't accumulate or re-render (see turn_started)
       try {
         // Phase 1 ring schema: { turn_id, kind, content? }. Only text kinds feed
         // the visible turn body; thinking/tool_call/usage are not shown here.


### PR DESCRIPTION
## Problem

A webchat tab pegs a CPU core (laptop fans spin) for the duration of **every** response.

## Root cause

The server-owned-turn-lifecycle work (#514) made the server mirror every turn to the presence ring **unconditionally** (durable source of truth for detached recovery), dropping the prior `attachment_count > 1` gate. Side effect: the surface that **originated** a turn is subscribed to its own `session-events` SSE and now receives a full echo of its own stream. The webchat handler reacted to every echoed token with `setRemoteTurnText(...)` — a second full transcript re-render per token on top of the native POST stream — and that work is entirely wasted: the remote-turn indicator is gated `remoteTurnActive && !working`, so it is never shown for your own turn. Two reconciliations of an un-virtualized message list per token at streaming speed pegs a core.

This is push/observer-based throughout (SSE + a `pthread_cond` ring on the server); the bug was a redundant **subscription to one's own emissions**, not polling.

## Fix

`frontend/src/pages/Chat.tsx`: gate the live `remoteTurn*` updates on `!wasWorking` (snapshot at `turn_started`) so a surface ignores the echo of a turn it originated. Genuinely remote turns (CLI/TUI/another tab) still drive the indicator and still persist on `turn_done`; the server's durable ring behavior is unchanged.

Frontend-only, 1 file. Could not typecheck locally (no `node_modules` in the workspace); relying on CI `lint`/`build`.