### PR TITLE
fix(codex): register the Codex CLI agent's context window so it can delegate

### DIFF
--- a/src/server/cli_codex.c
+++ b/src/server/cli_codex.c
@@ -1981,7 +1981,11 @@ static int codex_adapter_execute(const provider_cli_cfg_t *cfg, agent_result_t *
 const provider_cli_adapter_t codex_provider_cli_adapter = {
     .cli_kind = "codex",
     .display_name = "Codex CLI",
-    .caps = {.max_context_tokens = 0,
+    /* Codex CLI runs the gpt-5-codex family (272k context, tool use). Declaring
+     * the real window lets capability routing keep codex as a delegate for roles
+     * with a min-context floor; 0 here previously dropped it from every such
+     * fleet ("no configured model supports required capabilities"). */
+    .caps = {.max_context_tokens = 272000,
              .supports_tool_use = 1,
              .proto_stability = PROVIDER_CLI_PROTO_STABLE,
              .write_confidence = 0.95f},

--- a/src/server/server_agent.c
+++ b/src/server/server_agent.c
@@ -13,7 +13,8 @@
 #include "vault_service.h"    /* vault_service_set / set_server, VAULT_API_KEY_CRED */
 #include "vault_capability.h" /* vault_capability_server_write_allowed (single server-write gate) */
 #include "server_cli_oauth.h" /* server-hosted OAuth CLI agent setup */
-#include "config.h"           /* config_load / config_t */
+#include "provider_cli_adapter.h" /* provider_cli_adapter_get: declared CLI caps */
+#include "config.h"               /* config_load / config_t */
 #include <pthread.h>
 #include <string.h>
 #include <stdlib.h>
@@ -937,6 +938,15 @@ static void sagent_configure_tmux_cli_agent(agent_t *ag, const char *name, const
    ag->max_turns = -1;
    ag->max_parallel = AGENT_DEFAULT_MAX_PARALLEL;
    ag->session_reuse = 1;
+
+   /* Advertise the CLI's real context window so capability routing (min_context
+    * floors, e.g. the review role) keeps this agent in the fleet. A tmux-CLI
+    * agent has no `model` to resolve a window from — the vendor CLI picks the
+    * model from its own subscription/config — so without this it resolves to 0
+    * and gets dropped. Sourced from the adapter so there's one source of truth. */
+   const provider_cli_adapter_t *adapter = provider_cli_adapter_get(cli_kind);
+   if (adapter && adapter->caps.max_context_tokens > 0)
+      ag->middleware.context_window = adapter->caps.max_context_tokens;
 
    ag->role_count = 0;
    for (int i = 0;

--- a/src/tests/test_provider_cli_adapter.c
+++ b/src/tests/test_provider_cli_adapter.c
@@ -67,6 +67,12 @@ static void test_registry_and_caps(void)
 
    assert(strcmp(codex->cli_kind, "codex") == 0);
    assert(codex->execute != NULL);
+   /* Codex must advertise its real context window + tool use so capability
+    * routing keeps it as a delegate for roles with a min-context floor (e.g.
+    * review). A 0 here silently drops codex from every such fleet. */
+   assert(codex->caps.supports_tool_use == 1);
+   /* Exact value (not a floor) so an accidental drift back toward 0 is caught. */
+   assert(codex->caps.max_context_tokens == 272000);
    assert(claude->spawn != NULL);
    assert(claude->parse_line != NULL);
    assert(claude->caps.proto_stability == PROVIDER_CLI_PROTO_STABLE);


### PR DESCRIPTION
## Problem
The server-hosted `codex` OAuth agent was dropped from any delegate role with a min-context floor (e.g. `review`): *"no configured model supports required capabilities (caps=tools, min_context=5131)"*. This is why codex couldn't serve as a roundtable reviewer.

## Root cause
A tmux-CLI agent has no `model` string — the vendor CLI picks the model from its own subscription/config. `agent_meets_filter` resolves the context window from `ag->middleware.context_window`, else from `model_capability_get(provider, model)`. `sagent_configure_tmux_cli_agent` `memset`s the agent and never set either, so codex's effective window was 0 → filtered out. (`tools` was fine — `tools_enabled` ORs in `MODEL_CAP_TOOLS`.) The codex adapter also declared `caps.max_context_tokens=0`, unlike claude (200000).

## Fix
- **cli_codex.c**: codex adapter declares `caps.max_context_tokens = 272000` (gpt-5-codex family).
- **server_agent.c**: `sagent_configure_tmux_cli_agent` (codex + claude registration) sources `ag->middleware.context_window` from the CLI adapter via `provider_cli_adapter_get()` — one source of truth. No model is pinned, so the vendor CLI keeps choosing its own model.
- **test_provider_cli_adapter.c**: assert codex advertises tool use + its exact context window (regression guard).

## Test
- `make lint` clean; server builds (`-Werror`); `unit-test-provider-cli-adapter`, `unit-test-agent` (incl. `test_agent_caps`), `unit-test-cmd-delegate` (capability filter), `unit-test-model-registry` all pass.
- Roundtable (mistral / MiniMax-M3): MiniMax approved; mistral's 2 blockers verified non-blocking (window is used at routing-time not execute-time, and is consistent with the system's declared-window design; gate already covered by `test_capability_filter_enforces_min_context`). Folded in the exact-value test bound both suggested.