### PR TITLE
perf(webchat): isolate transcript render + skip markdown re-parse while streaming

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from 'react';
+import { useEffect, useRef, useState, useCallback, memo } from 'react';
 import { Spinner, Tabs, tokens } from '@rakuensoftware/smoothgui';
 import { BootstrapBanner, DiffBlock, Message, RewindMarker, ThinkingBlock, ToolBlock, TurnSummaryCard } from './chat/ChatPrimitives';
 import { renderWithMentions } from './chat/markdown';
@@ -1317,6 +1317,55 @@ function ChannelView({ channelName, messages, agents, onSend }: ChannelViewProps
     </div>
   );
 }
+
+/* Renders the committed transcript. Extracted + memoized so re-renders of the
+ * big Chat component that are NOT a message change (textarea typing, the remote-
+ * turn preview, the workflow poll, working toggles) skip transcript
+ * reconciliation entirely. Only re-renders when `messages`, `working`, or
+ * `activeSid` actually change. */
+const Transcript = memo(function Transcript({ messages, working, activeSid }: {
+  messages: StreamMsg[]; working: boolean; activeSid: string;
+}) {
+  // The growing tail assistant bubble streams as raw text (no markdown re-parse);
+  // it stops being "streaming" the moment another block follows it or the turn
+  // ends (working → false), at which point it renders markdown once.
+  const lastId = messages.length > 0 ? messages[messages.length - 1].id : -1;
+  return (
+    <>
+      {messages.map(m => {
+        if (m.type === 'user') {
+          return <Message key={m.id} role="user" text={m.text} />;
+        }
+        if (m.type === 'assistant') {
+          return <Message key={m.id} role="assistant" text={m.text} streaming={working && m.id === lastId} />;
+        }
+        if (m.type === 'thinking') {
+          return <ThinkingBlock key={m.id} text={m.thinkText ?? ''} />;
+        }
+        if (m.type === 'tool') {
+          return (
+            <ToolBlock
+              key={m.id}
+              name={m.toolName ?? ''}
+              args={m.toolArgs ?? ''}
+              result={m.toolResult}
+            />
+          );
+        }
+        if (m.type === 'narration') {
+          return <TurnSummaryCard key={m.id} text={m.text} />;
+        }
+        if (m.type === 'diff') {
+          return <DiffBlock key={m.id} path={m.diffPath} diff={m.diffContent ?? ''} />;
+        }
+        if (m.type === 'checkpoint') {
+          return <RewindMarker key={m.id} snapshotId={m.snapshotId!} sid={activeSid} />;
+        }
+        return null;
+      })}
+    </>
+  );
+});
 
 /* ---- Main Chat component ---- */
 
@@ -2742,37 +2791,7 @@ export default function Chat() {
         flex: 1, overflowY: 'auto', padding: '16px',
         display: 'flex', flexDirection: 'column', gap: '12px',
       }}>
-        {streamMsgs.map(m => {
-          if (m.type === 'user') {
-            return <Message key={m.id} role="user" text={m.text} />;
-          }
-          if (m.type === 'assistant') {
-            return <Message key={m.id} role="assistant" text={m.text} />;
-          }
-          if (m.type === 'thinking') {
-            return <ThinkingBlock key={m.id} text={m.thinkText ?? ''} />;
-          }
-          if (m.type === 'tool') {
-            return (
-              <ToolBlock
-                key={m.id}
-                name={m.toolName ?? ''}
-                args={m.toolArgs ?? ''}
-                result={m.toolResult}
-              />
-            );
-          }
-          if (m.type === 'narration') {
-            return <TurnSummaryCard key={m.id} text={m.text} />;
-          }
-          if (m.type === 'diff') {
-            return <DiffBlock key={m.id} path={m.diffPath} diff={m.diffContent ?? ''} />;
-          }
-          if (m.type === 'checkpoint') {
-            return <RewindMarker key={m.id} snapshotId={m.snapshotId!} sid={tabs[activeIdx]?.aimeeSid ?? ''} />;
-          }
-          return null;
-        })}
+        <Transcript messages={streamMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
         {working && <WorkingIndicator />}
         {remoteTurnActive && !working && (
           <div style={{

--- a/frontend/src/pages/chat/ChatPrimitives.tsx
+++ b/frontend/src/pages/chat/ChatPrimitives.tsx
@@ -39,8 +39,15 @@ export function BootstrapBanner({ onGenerate, onDismiss, stacks }: BannerProps) 
  * the component, this means a streaming turn only re-parses the one message whose
  * text is growing — the other (unchanged) messages are skipped entirely, instead
  * of every message being re-parsed on every token. */
-export const Message = memo(function Message({ role, text }: { role: 'user' | 'assistant'; text: string }) {
-  const html = useMemo(() => (role === 'user' ? escHtml(text) : renderMd(text)), [role, text]);
+export const Message = memo(function Message({ role, text, streaming }: { role: 'user' | 'assistant'; text: string; streaming?: boolean }) {
+  // While an assistant bubble is the actively-growing tail, render its RAW text
+  // and SKIP the markdown parse: re-parsing the whole growing body on every
+  // streamed flush is the dominant streaming CPU cost. Markdown is rendered once,
+  // when the bubble stops streaming (the turn ends or another block follows it).
+  const html = useMemo(
+    () => (streaming ? '' : role === 'user' ? escHtml(text) : renderMd(text)),
+    [role, text, streaming],
+  );
   const styles: React.CSSProperties = {
     maxWidth: '80%',
     padding: '10px 14px',
@@ -58,6 +65,7 @@ export const Message = memo(function Message({ role, text }: { role: 'user' | 'a
     borderBottomRightRadius: role === 'user' ? 2 : 10,
     borderBottomLeftRadius: role === 'assistant' ? 2 : 10,
   };
+  if (streaming) return <div style={{ ...styles, whiteSpace: 'pre-wrap' }}>{text}</div>;
   return <div style={styles} dangerouslySetInnerHTML={{ __html: html }} />;
 });
 


### PR DESCRIPTION
Follow-up to the stream-flush throttle (#576), targeting the structural per-render cost a Performance capture exposed (Scripting + GC dominated; the app's React work showed as `[unattributed]` because the bundle is inlined into index.html).

## Changes

1. **Skip markdown for the actively-streaming tail bubble.** `Message` renders raw `pre-wrap` text while `streaming` and runs `renderMd` **once** when the bubble settles (turn ends, or another block follows it). Removes the O(L) markdown re-parse — the dominant per-flush cost — from the hot path. The formatted result still lands when the turn settles.
2. **Memoize the transcript** (`<Transcript>`). Chat re-renders that are *not* a message change (textarea typing, the throttled remote-turn preview, the 10s workflow poll, `working` toggles) now skip transcript reconciliation entirely.

A bubble is "streaming" when `working && it is the last message`, so it settles to markdown as soon as a tool/thinking block follows or the turn ends — minor, self-correcting cosmetic tradeoff (the growing tail shows raw text for its last instant) in exchange for the CPU win.

Preserves the owning-tab stream routing (#573): only *how* `streamMsgs` is rendered changed, not how it is populated.

**Verified locally:** `tsc -b` clean, `vite build` clean (could finally install node_modules this round).