### PR TITLE
fix(codex): resolve tmux-CLI context window at routing time too

### DIFF
--- a/src/server/delegate_routing.c
+++ b/src/server/delegate_routing.c
@@ -2,6 +2,7 @@
 #include "cmd_agent_delegate_impl.h"
 #include "util.h"
 #include "model_registry.h"
+#include "provider_cli_adapter.h" /* declared context window for tmux-CLI agents */
 #include "log.h"
 #include <ctype.h>
 #include <string.h>
@@ -77,6 +78,18 @@ static int agent_meets_filter(const agent_t *ag, unsigned required_caps, int min
    {
       int effective_ctx = ag->middleware.context_window > 0 ? ag->middleware.context_window
                                                             : (have_cap ? cap.context_window : 0);
+      /* Still no window: a tmux-CLI agent (codex/claude-oauth) usually carries no
+       * `model` to resolve one from — the vendor CLI picks the model itself — so
+       * fall back to the window its CLI adapter declares. Reached only when the
+       * model produced nothing (effective_ctx<=0), so model-backed agents are
+       * untouched. Covers records written before context_window was persisted
+       * onto the agent (no re-registration needed). */
+      if (effective_ctx <= 0 && ag->cli_kind[0])
+      {
+         const provider_cli_adapter_t *adapter = provider_cli_adapter_get(ag->cli_kind);
+         if (adapter && adapter->caps.max_context_tokens > 0)
+            effective_ctx = adapter->caps.max_context_tokens;
+      }
       if (effective_ctx <= 0 || effective_ctx < min_context)
          return 0;
    }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1044,6 +1044,7 @@ $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(
                                $(OBJDIR)/tests/support/delegate_role_policy_stub.o \
                                $(OBJDIR)/tests/support/toolset_stub.o \
                                $(OBJDIR)/tests/support/agent_source_authority_stub.o \
+                               $(OBJDIR)/tests/support/provider_cli_adapter_stub.o \
                                $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/delegations.o $(OBJDIR)/db1/agent_jobs.o $(OBJDIR)/db1/session_paths.o $(OBJDIR)/db1/cost_fold.o $(OBJDIR)/db1/token_audit.o $(OBJDIR)/server/delegate_credentials.o $(OBJDIR)/server/delegate_credential_retry.o $(OBJDIR)/db1/delegate_learning.o $(OBJDIR)/db1/interaction_events.o \
                                $(OBJDIR)/db1/execution_plans.o $(OBJDIR)/db1/coord_jobs.o \
 		                               $(OBJDIR)/server/delegate_launch.o $(OBJDIR)/server/delegate_source_authority.o $(OBJDIR)/server/delegate_economics.o $(OBJDIR)/server/server_coord_dispatcher.o \

--- a/src/tests/support/provider_cli_adapter_stub.c
+++ b/src/tests/support/provider_cli_adapter_stub.c
@@ -1,0 +1,14 @@
+/* Minimal stub of provider_cli_adapter_get for test targets that link
+ * delegate_routing.o — it calls this for the tmux-CLI context-window fallback in
+ * agent_meets_filter — but do not exercise that path and must not pull in the
+ * full CLI adapter machinery (cli_codex.o et al.). Returning NULL makes the
+ * fallback a no-op, preserving each test's pre-fallback behavior. The real
+ * lookup is covered by unit-test-provider-cli-adapter and unit-test-cmd-delegate
+ * (the latter stubs it with a codex window to exercise the fallback). */
+#include "provider_cli_adapter.h"
+
+const provider_cli_adapter_t *provider_cli_adapter_get(const char *cli_kind)
+{
+   (void)cli_kind;
+   return NULL;
+}

--- a/src/tests/test_cmd_delegate.c
+++ b/src/tests/test_cmd_delegate.c
@@ -11,6 +11,7 @@
 #include "model_registry.h"
 #include "log.h"
 #include "posix/agent_tools_internal.h"
+#include "provider_cli_adapter.h"
 #include "cJSON.h"
 
 /* Pull in only the declarations we need. */
@@ -113,6 +114,18 @@ void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
    (void)level;
    (void)module;
    (void)fmt;
+}
+
+/* delegate_routing.c falls back to the CLI adapter's declared window for tmux-CLI
+ * agents; stub the lookup so this test doesn't link the adapter machinery. Only
+ * "codex" resolves (272k) — an unknown cli_kind returns NULL (stays dropped). */
+const provider_cli_adapter_t *provider_cli_adapter_get(const char *cli_kind)
+{
+   static const provider_cli_adapter_t codex = {.cli_kind = "codex",
+                                                .caps = {.max_context_tokens = 272000}};
+   if (cli_kind && strcmp(cli_kind, "codex") == 0)
+      return &codex;
+   return NULL;
 }
 
 void model_capability_flags_string(unsigned flags, char *out, size_t out_len)
@@ -874,6 +887,44 @@ static void test_capability_filter_honors_tools_enabled(void)
    printf("  PASS: test_capability_filter_honors_tools_enabled\n");
 }
 
+/* A tmux-CLI agent (codex) has no `model` and may have context_window=0 (records
+ * registered before the window was persisted). The filter must fall back to the
+ * CLI adapter's declared window so it survives a min-context floor — and still
+ * drop a CLI agent whose adapter is unknown / declares no window. */
+static void test_capability_filter_cli_agent_uses_adapter_context(void)
+{
+   agent_config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.agent_count = 2;
+
+   /* codex: no model, no explicit window — resolves via the codex adapter (272k). */
+   snprintf(cfg.agents[0].name, sizeof(cfg.agents[0].name), "codex");
+   snprintf(cfg.agents[0].provider, sizeof(cfg.agents[0].provider), "codex");
+   snprintf(cfg.agents[0].cli_kind, sizeof(cfg.agents[0].cli_kind), "codex");
+   snprintf(cfg.agents[0].roles[0], sizeof(cfg.agents[0].roles[0]), "review");
+   cfg.agents[0].role_count = 1;
+   cfg.agents[0].enabled = 1;
+   cfg.agents[0].tools_enabled = 1;
+   cfg.agents[0].middleware.context_window = 0;
+
+   /* unknown CLI kind, no model/window — must NOT resolve a window, so dropped. */
+   snprintf(cfg.agents[1].name, sizeof(cfg.agents[1].name), "mystery-cli");
+   snprintf(cfg.agents[1].provider, sizeof(cfg.agents[1].provider), "mystery");
+   snprintf(cfg.agents[1].cli_kind, sizeof(cfg.agents[1].cli_kind), "no-such-cli");
+   snprintf(cfg.agents[1].roles[0], sizeof(cfg.agents[1].roles[0]), "review");
+   cfg.agents[1].role_count = 1;
+   cfg.agents[1].enabled = 1;
+   cfg.agents[1].tools_enabled = 1;
+   cfg.agents[1].middleware.context_window = 0;
+
+   char errbuf[128];
+   assert(delegate_filter_route_capabilities(&cfg, "review", MODEL_CAP_TOOLS, 5131, 0, errbuf,
+                                             sizeof(errbuf)) == 0);
+   assert(cfg.agents[0].enabled == 1); /* codex kept via adapter window */
+   assert(cfg.agents[1].enabled == 0); /* unknown CLI dropped */
+   printf("  PASS: test_capability_filter_cli_agent_uses_adapter_context\n");
+}
+
 /* An inferred modality cap (vision/pdf/audio) that no model satisfies must NOT
  * hard-fail the fleet: it is relaxed to the hard caps (tools + min_context) so
  * the text models stay routable. Guards the fleet-wide false-fail where a text
@@ -1080,6 +1131,7 @@ int main(void)
    test_capability_filter_drops_deprecated_on_auto_route();
    test_capability_filter_enforces_min_context();
    test_capability_filter_honors_tools_enabled();
+   test_capability_filter_cli_agent_uses_adapter_context();
    test_capability_filter_relaxes_unmet_modality();
    test_capability_filter_hard_cap_still_fails();
    test_capability_inference_audio_extension_not_keyword();


### PR DESCRIPTION
Follow-up to #574. That fix set `context_window` only for **newly-registered** codex agents; records already in `agents.json` (`context_window=0`) stayed dropped from min-context delegate roles (review) until re-registered.

## Fix
Resolve the window at the routing gate (`agent_meets_filter`): when the effective context window is still `<=0` and the agent has a `cli_kind`, fall back to the CLI adapter's declared `caps.max_context_tokens` via `provider_cli_adapter_get()`. Reached only when the model produced no window, so **model-backed agents are untouched**. Covers pre-existing records — no re-registration needed.

Adds a unit test (codex record with empty model + `context_window=0` survives `min_context=5131`; unknown `cli_kind` stays dropped) using an inline stub of `provider_cli_adapter_get` to keep the minimal test link set.

## Test
- `make lint` clean; full server builds (`-Werror`, real adapter linked); `unit-test-cmd-delegate` passes incl. the new `test_capability_filter_cli_agent_uses_adapter_context`.
- Roundtable (mistral / MiniMax-M3): MiniMax APPROVE; mistral's 3 blockers verified non-blocking (guard correctness confirmed by both; validation `>0` already present; stub scope adequate — real caps covered by `test_provider_cli_adapter` + server build). Comment-accuracy nit folded in.