### PR TITLE
feat(ingress): typed Envelope IR for pre-injection (ingress-compression P0)

### DIFF
--- a/docs/proposals/pending/ingress-compression-and-cache-alignment.plan.md
+++ b/docs/proposals/pending/ingress-compression-and-cache-alignment.plan.md
@@ -1,0 +1,233 @@
+# Implementation plan — ingress-compression P0: the Envelope IR
+
+Plan for [ingress-compression-and-cache-alignment.md](ingress-compression-and-cache-alignment.md),
+**scoped to P0 only** per the proposal's §7 phasing ("Envelope IR (§1.1) —
+refactor `ingress_preinject_build()` to assemble a typed entry list and render
+from it. No behavior change, no flag; pure enablement. Blocks everything else.").
+Grounded in `src/server/ingress_preinject.c` on `origin/testing`.
+
+## Invariant (the whole point of P0)
+
+**Byte-for-byte identical output.** For every input, the `<aimee-context>`
+envelope `ingress_preinject_build()` returns after this change must equal the
+envelope it returns today — same block ordering, same group headers, same
+separators, same budget/omission behavior, same footer, same truncation note,
+same confidence tier. No config flag is added; no source, score, or
+retrieval-event emit changes. This is a pure refactor that introduces a typed
+intermediate representation between *gathering* sources and *rendering* the
+string, so later phases (P1a byte-equivalent fold, P1b lossy fold, …) have
+something typed to dispatch a compressor over instead of re-parsing an opaque
+rendered string.
+
+## What exists today (the thing being refactored)
+
+`ingress_preinject_build()` (`ingress_preinject.c:343`) interleaves four
+concerns into one `dstr_t block`:
+
+1. **Gather** — `kb_client_index_code_search` → `hits[6]`,
+   `kb_client_memory_diagnose` → `mems[5]`, `kb_client_memory_facts` → string,
+   `ingress_preinject_read_audit_context` → string.
+2. **Render** — for each source group it formats per-record *candidates*
+   (`format_code_candidate`, `format_memory_preview_candidate`, inline facts /
+   audit blocks), appends each via `append_candidate()` (budget gate +
+   `omitted_count`), with a group header written on the first candidate that
+   actually fits and a single `"\n"` separator before any non-empty later group.
+3. **Score** — a confidence score derived from hit/preview counts.
+4. **Emit** — the auditable-correctness `retrieval_event` (reads `hits[]`/`mems[]`
+   directly), default-off.
+5. **Footer** — `context-budget: …` line + `... (N more available …)` note,
+   each appended only if it fits `block_budget`.
+
+P0 splits **(2) Render** out behind a typed entry list. **(1), (3), (4) are
+untouched** — they keep reading the same `hits[]`/`mems[]`/strings.
+
+## Design
+
+### The IR (new, in `ingress_preinject.h`)
+
+```c
+typedef enum {
+   ING_SRC_CODE,    /* a code_search hit            */
+   ING_SRC_MEMORY,  /* a memory preview             */
+   ING_SRC_FACTS,   /* the typed-facts block        */
+   ING_SRC_AUDIT,   /* the audit-context block      */
+} ingress_source_kind_t;
+
+/* Reserved per proposal §6.5 B2 — one value per lossiness class. P0 sets every
+ * entry to ING_XF_NONE (no folding yet); P1a/P1b populate the rest. Declared now
+ * so the IR is the contract a compressor dispatches over. */
+typedef enum {
+   ING_XF_NONE = 0,
+   ING_XF_CODE_WHITESPACE_COLLAPSE,
+   ING_XF_CODE_COMMENT_STRIP,
+   ING_XF_CODE_SIGNATURE_SPAN,
+   ING_XF_JSON_FOLD,
+} ingress_transform_t;
+
+typedef struct {
+   ingress_source_kind_t kind;
+   ingress_transform_t   transform;  /* P0: always ING_XF_NONE */
+   const char           *header;     /* group header, e.g. "recommended (code):\n";
+                                      * emitted once, on the first entry of a group
+                                      * that fits the budget. "" for single-entry
+                                      * groups that bake their header into preview. */
+   char                 *preview;    /* malloc'd per-record body the renderer frees */
+} ingress_entry_t;
+```
+
+P0 deliberately carries **only** the fields the renderer reads (`kind`,
+`header`, `preview`) plus `transform` (the reserved IR contract). The richer
+§1.1 fields (`record_id`/`handle`, `sensitivity`/`scope`, `original_ref`,
+`budget`, `metrics`) are **not** added in P0 — they would be inert here and are
+introduced by the phase that first consumes them (P1b telemetry, P2e handle
+store), avoiding the "looks reviewed but unread" field risk (proposal §8).
+
+**Deviation from §1.1's enum** noted for review: the proposal lists
+`code_hit | memory_block | audit | (future) tool_result`. Today's envelope also
+emits a **typed-facts** group, so P0's enum includes `ING_SRC_FACTS` to model an
+existing source. `tool_result` is not added until it has a real producer (§1.2
+defers the JSON folder).
+
+### The renderer (new, pure, unit-testable)
+
+```c
+/* Render a typed entry list into the pre-envelope block string, applying the
+ * existing budget gate, group headers, separators, footer, and truncation note.
+ * Pure: no kb, no config, no globals. Frees nothing it does not own. Returns a
+ * malloc'd block (possibly empty -> caller treats "" as no-injection). */
+char *ingress_render_block(const ingress_entry_t *entries, int count,
+                           size_t envelope_budget, int headline_missing_count,
+                           int *omitted_count_out);
+```
+
+Algorithm (reproduces today's bytes exactly):
+
+```
+block_budget = envelope_budget - INGRESS_FOOTER_RESERVE_BYTES   /* same as today */
+prev_kind = sentinel; group_first = 1; omitted = 0
+for each entry e:
+   if e.kind != prev_kind:                 /* group boundary */
+      if dstr_len(block) > 0: append "\n"  /* == today's `if (block.len) "\n"` */
+      group_first = 1; prev_kind = e.kind
+   candidate = (group_first ? e.header : "") + e.preview
+   if dstr_len(block) + strlen(candidate) <= block_budget:
+      append candidate; group_first = 0    /* header rides the first fitting entry */
+   else:
+      omitted++                            /* == today's append_candidate miss */
+   free per-iteration scratch
+if dstr_len(block) > 0:
+   append footer (context-budget: …) if it fits block_budget   /* identical text */
+   if omitted > 0: append "... (N more …)" note if it fits      /* identical text */
+*omitted_count_out = omitted
+return steal(block)
+```
+
+This is byte-equivalent because:
+- The group separator `"\n"` fires on the first entry of each new `kind` when
+  the block is non-empty — exactly today's per-group `if (block.len) "\n"` (the
+  groups are emitted in the same order: code, memory, facts, audit; an entry
+  exists for a group iff that source produced content, so the separator fires on
+  exactly the same turns).
+- The header rides the **first entry that fits** (`group_first` flips only on a
+  successful append) — exactly today's `wrote_header` semantics.
+- `append_candidate`'s budget test, `omitted_count`, and the footer/trunc text
+  are copied verbatim.
+
+### `ingress_preinject_build()` after P0
+
+1. Gather sources into `hits[]`/`mems[]`/`facts`/`audit` (**unchanged**).
+2. Build `ingress_entry_t entries[CAP]` from them:
+   - per code hit: `{CODE, NONE, "recommended (code):\n", format_code_body(hit)}`
+   - per memory preview: `{MEMORY, NONE, "recommended (memory previews):\n",
+     format_memory_body(diag, &headline_missing)}`
+   - facts (if present): `{FACTS, NONE, "", "## Known facts\n<facts>\n"}`
+   - audit (if present): `{AUDIT, NONE, "", "recommended (audit context):\n<audit>\n"}`
+   The existing `format_code_candidate` / `format_memory_preview_candidate`
+   become `..._body` helpers that **omit** the header (header moves into the
+   entry), keeping their escaping/snippet/whitespace logic byte-identical.
+3. Compute `score` from the same counts (**unchanged** — stays in `build`).
+4. Emit the `retrieval_event` from `hits[]`/`mems[]` (**unchanged**).
+5. `block = ingress_render_block(entries, k, envelope_budget,
+   headline_missing_count, &omitted)`; free each `entry.preview`.
+6. Wrap: `ingress_preinject_format_envelope(block,
+   ingress_preinject_confidence(score))` (**unchanged**).
+
+`CAP` = 6 (code) + 5 (memory) + 1 (facts) + 1 (audit) = 13; a fixed stack array,
+no heap list. `score`/footer/headline counting stay where they are.
+
+## File-size & wiring
+
+- `ingress_preinject.c` is 580 lines; the net change is roughly neutral (header
+  text moves from candidate formatters into entry construction; the budget/footer
+  loop moves into `ingress_render_block`). Comfortably under the 2000-line cap.
+- New symbols (`ingress_source_kind_t`, `ingress_transform_t`, `ingress_entry_t`,
+  `ingress_render_block`) go in the existing `ingress_preinject.h`. No Makefile
+  SRCS change (same `.c`/`.o`). The unit test links the existing
+  `ingress_preinject.o` (already built); add the new test target to
+  `src/tests/Rules.mk` if a dedicated test file is used.
+
+## Tests
+
+Extend the existing pure-helper tests (the suite that already covers
+`ingress_preinject_format_code_block` / `_format_envelope` with no kb dep):
+
+1. **Renderer golden** — hand-built `entries[]` covering all four kinds in order;
+   assert the exact block string (headers, `"\n"` separators, footer, trunc note).
+2. **Header-on-first-fit** — a code group whose first entry is omitted by a tight
+   budget; assert the header rides the second (fitting) entry, and `omitted==1`.
+3. **Group-separator suppression** — when an earlier group appended nothing
+   (everything omitted), assert no stray `"\n"` precedes the next group (matches
+   today's `if (block.len)` guard).
+4. **Empty list** → empty string (no footer, no envelope).
+5. **Budget edge** — footer/trunc appended only when they fit `block_budget`.
+6. **Equivalence smoke** — a representative entry set reproduces a known envelope
+   captured from the current code (golden string pinned in the test).
+
+Existing `ingress_preinject` tests must pass unchanged (they exercise the public
+pure helpers, which keep their signatures).
+
+## Plan-review resolutions (R1 — roundtable 2026-06-21)
+
+The first plan-gate raised six items; all are resolved in the design above and
+verified by the implementation's passing byte-equivalence golden:
+
+1. **FACTS/AUDIT header rule (blocking).** `ING_SRC_FACTS` and `ING_SRC_AUDIT`
+   entries set `header = ""` and bake their heading into `preview`
+   (`"## Known facts\n<facts>\n"`, `"recommended (audit context):\n<audit>\n"`),
+   exactly as today emitted them as a single candidate. Only `ING_SRC_CODE` /
+   `ING_SRC_MEMORY` carry a separate group `header` (written once, on the first
+   fitting entry).
+2. **Separator on a fully-omitted prior group (blocking).** The `"\n"` is
+   appended at a group boundary **only when the block is already non-empty**
+   (`if dstr_len(block) > 0`). If an earlier group appended nothing, the block is
+   still empty, so no separator is emitted — byte-identical to today's
+   `if (block.len) "\n"`. Covered by the "group-separator suppression" test.
+3. **`headline_missing_count` (blocking).** It is computed during memory-entry
+   construction and threaded into `ingress_render_block(...,
+   headline_missing_count, ...)`, which renders it verbatim in the footer — part
+   of the golden assertion (`headline_missing_count=1`).
+4. **`explore-with` line (blocking).** This is **not** the block renderer's
+   concern: `ingress_render_block` produces the *pre-envelope block* (groups +
+   footer); the unchanged `ingress_preinject_format_envelope()` wraps it with
+   `<aimee-context …>`, the `explore-with:` line, and `</aimee-context>`. The
+   golden confirms the line is present and unchanged.
+5. **`ingress_transform_t` unused in P0 (suggestion).** Documented in the enum:
+   P0 sets every entry to `ING_XF_NONE`; the enum is the reserved IR contract for
+   P1a/P1b folds.
+6. **Fate of `format_*` callers (nit).** `format_code_candidate` /
+   `format_memory_preview_candidate` are renamed to header-less `_body` helpers
+   and have a single caller (entry construction) — no dead code.
+
+## Risks / rollback
+
+- **Sole risk is a byte drift** vs today. Mitigated by the golden tests above and
+  by leaving gather/score/emit untouched. There is no flag and no behavior toggle
+  to get wrong.
+- Rollback is a straight revert (single commit, one `.c`/`.h` + test).
+- No schema, no config, no wire-shape, no provider-API dependency in P0.
+
+## Out of scope (later phases, separate plans)
+
+P1a byte-equivalent code fold + `ingress_compress_enabled`; P1b lossy folds +
+resolvers/telemetry; P2/P2e durable reachability + handle store; P3 cache-prefix
+placement; P4 failure mining; P5 Anthropic ingress. P0 only lays the IR.

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -20,6 +20,66 @@
 
 #include "cJSON.h"
 #include "index.h" /* code_search_hit_t */
+#include <stddef.h>
+
+/* P0 Envelope IR (ingress-compression §1.1). ingress_preinject_build() no longer
+ * appends straight into one opaque string: it gathers its sources into a typed
+ * entry list and renders the <aimee-context> block from that list. This is a
+ * pure refactor — the rendered bytes are identical to before — that gives later
+ * phases a typed thing to dispatch a compressor over instead of re-parsing a
+ * rendered string. */
+
+/* The source a resident entry came from. Rendered in this group order. NB the
+ * proposal's §1.1 enum lists code/memory/audit (+future tool_result); FACTS is
+ * added here because today's envelope already emits a typed-facts group. */
+typedef enum
+{
+   ING_SRC_CODE,   /* a code-search hit          */
+   ING_SRC_MEMORY, /* a memory preview           */
+   ING_SRC_FACTS,  /* the typed-facts block      */
+   ING_SRC_AUDIT,  /* the audit-context block    */
+} ingress_source_kind_t;
+
+/* Which fold produced the resident form — one value per lossiness class, reserved
+ * per proposal §6.5 B2. P0 applies no folding, so every entry is ING_XF_NONE;
+ * P1a/P1b populate the rest. Declared now so the IR is the contract a compressor
+ * dispatches over. */
+typedef enum
+{
+   ING_XF_NONE = 0,
+   ING_XF_CODE_WHITESPACE_COLLAPSE,
+   ING_XF_CODE_COMMENT_STRIP,
+   ING_XF_CODE_SIGNATURE_SPAN,
+   ING_XF_JSON_FOLD,
+} ingress_transform_t;
+
+/* One resident entry. P0 carries only what the renderer reads (kind, header,
+ * preview) plus the reserved transform tag; the richer §1.1 fields
+ * (record_id/handle, sensitivity, original_ref, budget, metrics) are added by the
+ * phase that first consumes them, to avoid unread fields. */
+typedef struct
+{
+   ingress_source_kind_t kind;
+   ingress_transform_t transform; /* P0: always ING_XF_NONE */
+   const char *header;            /* group header (e.g. "recommended (code):\n"). The
+                                   * renderer prepends it to every attempted candidate of
+                                   * the group but keeps it only on the first one that fits
+                                   * the budget, so it lands exactly once (the old
+                                   * `wrote_header` rule). "" when preview is self-headed. */
+   char *preview;                 /* malloc'd per-record body; the renderer reads it,
+                                   * the caller frees it */
+} ingress_entry_t;
+
+/* Render a typed entry list into the pre-envelope block string, applying the
+ * existing budget gate, per-group header, single blank-line separators between
+ * non-empty groups, the context-budget footer, and the truncation note — byte
+ * for byte as ingress_preinject_build() did inline. Pure: no kb, no config, no
+ * globals; frees nothing it is given. Returns a malloc'd block, or NULL when
+ * nothing was rendered (empty list / everything omitted) — the caller treats
+ * NULL or "" as "no injection". Writes the omitted-entry count to
+ * *omitted_count_out when non-NULL. */
+char *ingress_render_block(const ingress_entry_t *entries, int count, size_t envelope_budget,
+                           int headline_missing_count, int *omitted_count_out);
 
 /* Map a recall relevance score in [0,1] to a confidence tier string
  * ("high" | "medium" | "low"). Pure; thresholds documented in the .c. */

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -9,6 +9,7 @@
 #include "kb_client.h"
 #include "dstr.h"
 #include "platform_random.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -189,27 +190,92 @@ static void append_single_line_escaped(dstr_t *d, const char *s, size_t max_char
    }
 }
 
-static int append_candidate(dstr_t *block, const char *candidate, size_t budget, int *omitted_count)
+char *ingress_render_block(const ingress_entry_t *entries, int count, size_t envelope_budget,
+                           int headline_missing_count, int *omitted_count_out)
 {
-   if (!candidate || !candidate[0])
-      return 1;
-   size_t need = strlen(candidate);
-   if (dstr_len(block) + need > budget)
+   /* Reserve the same footer headroom the inline builder did; the per-candidate
+    * budget gate, group headers, separators, footer, and truncation note below
+    * reproduce the old rendering byte for byte. */
+   size_t block_budget = envelope_budget > INGRESS_FOOTER_RESERVE_BYTES
+                             ? envelope_budget - INGRESS_FOOTER_RESERVE_BYTES
+                             : 0;
+   dstr_t block;
+   dstr_init(&block);
+   int omitted = 0;
+   /* have_prev guards prev_kind, so its seed is never read before the first entry
+    * sets it; group_first tracks whether this group's header still needs to land. */
+   bool have_prev = false;
+   ingress_source_kind_t prev_kind = ING_SRC_CODE;
+   bool group_first = true;
+
+   for (int i = 0; i < count; i++)
    {
-      if (omitted_count)
-         (*omitted_count)++;
-      return 0;
+      const ingress_entry_t *e = &entries[i];
+      if (!have_prev || e->kind != prev_kind)
+      {
+         /* A new group: one blank line separates it from a non-empty block,
+          * exactly the old per-group `if (block.len) "\n"`. */
+         if (dstr_len(&block) > 0)
+            dstr_append_str(&block, "\n");
+         group_first = true;
+         prev_kind = e->kind;
+         have_prev = true;
+      }
+
+      dstr_t cand;
+      dstr_init(&cand);
+      if (group_first && e->header)
+         dstr_append_str(&cand, e->header);
+      if (e->preview)
+         dstr_append_str(&cand, e->preview);
+      char *c = dstr_steal(&cand);
+
+      if (c && c[0])
+      {
+         /* The header rides the first candidate that actually fits — the old
+          * `wrote_header`, set only on a successful append. */
+         if (dstr_len(&block) + strlen(c) <= block_budget)
+         {
+            dstr_append_str(&block, c);
+            group_first = false;
+         }
+         else
+         {
+            omitted++;
+         }
+      }
+      free(c);
    }
-   dstr_append_str(block, candidate);
-   return 1;
+
+   if (dstr_len(&block) > 0)
+   {
+      char footer[256];
+      snprintf(footer, sizeof(footer),
+               "context-budget: used_bytes=%zu budget_bytes=%zu omitted_count=%d "
+               "headline_missing_count=%d\n",
+               dstr_len(&block), envelope_budget, omitted, headline_missing_count);
+      if (dstr_len(&block) + strlen(footer) <= block_budget)
+         dstr_append_str(&block, footer);
+      if (omitted > 0)
+      {
+         char trunc[128];
+         snprintf(trunc, sizeof(trunc),
+                  "... (%d more available via get_context_block or memory_get)\n", omitted);
+         if (dstr_len(&block) + strlen(trunc) <= block_budget)
+            dstr_append_str(&block, trunc);
+      }
+   }
+
+   if (omitted_count_out)
+      *omitted_count_out = omitted;
+   return dstr_steal(&block);
 }
 
-static char *format_code_candidate(const code_search_hit_t *hit, int header)
+/* Per-record body for a code hit (no group header — the IR entry carries that). */
+static char *format_code_body(const code_search_hit_t *hit)
 {
    dstr_t d;
    dstr_init(&d);
-   if (header)
-      dstr_append_str(&d, "recommended (code):\n");
    dstr_appendf(&d, "  - %s\n", hit->file_path);
    if (hit->snippet[0])
    {
@@ -220,8 +286,10 @@ static char *format_code_candidate(const code_search_hit_t *hit, int header)
    return dstr_steal(&d);
 }
 
-static char *format_memory_preview_candidate(const memory_diagnostic_t *diag, int header,
-                                             int *headline_missing)
+/* Per-record body for a memory preview (no group header). Returns NULL for an
+ * empty row (id <= 0) — the old NULL candidate, which produced no output and was
+ * not counted. Bumps *headline_missing when the row carries no headline. */
+static char *format_memory_preview_body(const memory_diagnostic_t *diag, int *headline_missing)
 {
    const memory_t *m = &diag->memory;
    if (m->id <= 0)
@@ -234,8 +302,6 @@ static char *format_memory_preview_candidate(const memory_diagnostic_t *diag, in
 
    dstr_t d;
    dstr_init(&d);
-   if (header)
-      dstr_append_str(&d, "recommended (memory previews):\n");
    dstr_appendf(&d, "  - memory:%lld", (long long)m->id);
    if (m->key[0])
    {
@@ -363,12 +429,11 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    size_t envelope_budget = (size_t)configured_budget;
    if (envelope_budget <= INGRESS_FOOTER_RESERVE_BYTES)
       return NULL;
-   size_t block_budget = envelope_budget - INGRESS_FOOTER_RESERVE_BYTES;
-
-   dstr_t block;
-   dstr_init(&block);
+   /* P0 Envelope IR: gather each source into a typed entry, then render the block
+    * from the list. CAP = 6 code + 5 memory + 1 facts + 1 audit. */
+   ingress_entry_t entries[6 + 5 + 1 + 1];
+   int k = 0;
    double score = 0.0;
-   int omitted_count = 0;
    int headline_missing_count = 0;
 
    /* Primary signal: code search over the turn query. The code index is the
@@ -380,19 +445,16 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    int n = preview_on ? kb_client_index_code_search(query, NULL, hits,
                                                     (int)(sizeof(hits) / sizeof(hits[0])))
                       : 0;
+   for (int i = 0; i < n; i++)
+   {
+      entries[k].kind = ING_SRC_CODE;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "recommended (code):\n";
+      entries[k].preview = format_code_body(&hits[i]);
+      k++;
+   }
    if (n > 0)
    {
-      int wrote_header = 0;
-      for (int i = 0; i < n; i++)
-      {
-         char *code = format_code_candidate(&hits[i], !wrote_header);
-         if (code)
-         {
-            if (append_candidate(&block, code, block_budget, &omitted_count))
-               wrote_header = 1;
-            free(code);
-         }
-      }
       double cs = (double)n / 6.0;
       if (cs > score)
          score = cs;
@@ -403,22 +465,19 @@ char *ingress_preinject_build(const char *query, int request_disabled)
     * the advertised memory:<id> handle and the memory_get MCP tool. */
    memory_diagnostic_t mems[5];
    int mem_n = preview_on ? kb_client_memory_diagnose(query, 5, mems, 5) : 0;
+   for (int i = 0; i < mem_n; i++)
+   {
+      char *body = format_memory_preview_body(&mems[i], &headline_missing_count);
+      if (!body)
+         continue; /* empty row (id <= 0): no entry, as the old NULL candidate */
+      entries[k].kind = ING_SRC_MEMORY;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "recommended (memory previews):\n";
+      entries[k].preview = body;
+      k++;
+   }
    if (mem_n > 0)
    {
-      if (block.len)
-         dstr_append_str(&block, "\n");
-      int wrote_header = 0;
-      for (int i = 0; i < mem_n; i++)
-      {
-         char *preview =
-             format_memory_preview_candidate(&mems[i], !wrote_header, &headline_missing_count);
-         if (preview)
-         {
-            if (append_candidate(&block, preview, block_budget, &omitted_count))
-               wrote_header = 1;
-            free(preview);
-         }
-      }
       double ms = mem_n >= 4 ? 0.7 : (mem_n >= 2 ? 0.4 : 0.1);
       if (ms > score)
          score = ms;
@@ -432,17 +491,17 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    char *facts = facts_on ? kb_client_memory_facts(query) : NULL;
    if (facts && facts[0])
    {
-      if (block.len)
-         dstr_append_str(&block, "\n");
       dstr_t f;
       dstr_init(&f);
       dstr_append_str(&f, "## Known facts\n");
       dstr_append_str(&f, facts);
       if (facts[strlen(facts) - 1] != '\n')
          dstr_append_str(&f, "\n");
-      char *fact_candidate = dstr_steal(&f);
-      append_candidate(&block, fact_candidate, block_budget, &omitted_count);
-      free(fact_candidate);
+      entries[k].kind = ING_SRC_FACTS;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "";
+      entries[k].preview = dstr_steal(&f);
+      k++;
       if (score < 0.5)
          score = 0.5;
    }
@@ -510,42 +569,28 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    char *audit = preview_on ? ingress_preinject_read_audit_context() : NULL;
    if (audit && audit[0])
    {
-      if (block.len)
-         dstr_append_str(&block, "\n");
       dstr_t a;
       dstr_init(&a);
       dstr_append_str(&a, "recommended (audit context):\n");
       dstr_append_str(&a, audit);
       if (audit[strlen(audit) - 1] != '\n')
          dstr_append_str(&a, "\n");
-      char *audit_candidate = dstr_steal(&a);
-      append_candidate(&block, audit_candidate, block_budget, &omitted_count);
-      free(audit_candidate);
+      entries[k].kind = ING_SRC_AUDIT;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "";
+      entries[k].preview = dstr_steal(&a);
+      k++;
       if (score < 0.4)
          score = 0.4;
    }
    free(audit);
 
-   if (block.len)
-   {
-      char footer[256];
-      snprintf(footer, sizeof(footer),
-               "context-budget: used_bytes=%zu budget_bytes=%zu omitted_count=%d "
-               "headline_missing_count=%d\n",
-               dstr_len(&block), envelope_budget, omitted_count, headline_missing_count);
-      if (dstr_len(&block) + strlen(footer) <= block_budget)
-         dstr_append_str(&block, footer);
-      if (omitted_count > 0)
-      {
-         char trunc[128];
-         snprintf(trunc, sizeof(trunc),
-                  "... (%d more available via get_context_block or memory_get)\n", omitted_count);
-         if (dstr_len(&block) + strlen(trunc) <= block_budget)
-            dstr_append_str(&block, trunc);
-      }
-   }
+   /* Render the resident block from the typed entry list, then release the
+    * per-entry previews (the renderer copies what it keeps). */
+   char *blk = ingress_render_block(entries, k, envelope_budget, headline_missing_count, NULL);
+   for (int i = 0; i < k; i++)
+      free(entries[i].preview);
 
-   char *blk = dstr_steal(&block);
    if (!blk || !blk[0])
    {
       free(blk);

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -220,8 +220,100 @@ static void test_budgeted_build_uses_memory_previews(void)
    assert(strstr(env, "context-budget:") != NULL);
    assert(strstr(env, "memory_get") != NULL);
    assert(strstr(env, "Fallback preview from content.") != NULL);
+
+   /* P0 byte-equivalence anchor: the Envelope IR refactor must reproduce the
+    * pre-refactor envelope byte for byte for this fixed stub scenario (code hit
+    * + two memory previews under the 1200-byte budget). Captured from the live
+    * pre-refactor code. */
+   static const char *GOLDEN =
+       "<aimee-context confidence=\"medium\">\n"
+       "recommended (code):\n"
+       "  - src/server/ingress_preinject.c\n"
+       "    > builder emits a bounded context envelope\n"
+       "\n"
+       "recommended (memory previews):\n"
+       "  - memory:101 deploy path [L2/fact score=0.880 headline_missing=false]\n"
+       "    > Use the deploy matrix.\n"
+       "  - memory:102 fallback [L2/policy score=0.440 headline_missing=true]\n"
+       "    > Fallback preview from content.\n"
+       "context-budget: used_bytes=342 budget_bytes=1200 omitted_count=0 headline_missing_count=1\n"
+       "explore-with: find_symbol, lsp_references, ast_grep_search, search_graph, "
+       "get_context_block, "
+       "memory_get\n"
+       "</aimee-context>";
+   assert(strcmp(env, GOLDEN) == 0);
    free(env);
    printf("budgeted_build_uses_memory_previews OK\n");
+}
+
+/* P0 Envelope IR: the renderer reproduces the old inline rendering — group
+ * headers, single blank-line separators between non-empty groups, the
+ * header-rides-the-first-fitting-candidate rule, the budget/omitted gate, the
+ * footer, and the truncation note. Synthetic entries keep the expected bytes
+ * easy to compute. The renderer frees nothing it is given. */
+static void test_render_block(void)
+{
+   /* Two groups + footer, no omission: exact bytes. block_budget = 1000-384. */
+   {
+      ingress_entry_t e[2] = {
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("a\n")},
+          {ING_SRC_MEMORY, ING_XF_NONE, "M:\n", strdup("b\n")},
+      };
+      int omitted = -1;
+      char *blk = ingress_render_block(e, 2, 1000, 0, &omitted);
+      assert(blk != NULL);
+      assert(strcmp(blk, "C:\na\n\nM:\nb\ncontext-budget: used_bytes=11 budget_bytes=1000 "
+                         "omitted_count=0 headline_missing_count=0\n") == 0);
+      assert(omitted == 0);
+      free(blk);
+      free(e[0].preview);
+      free(e[1].preview);
+   }
+
+   /* Header rides the first candidate that fits: a too-big first code entry is
+    * omitted, the header appears on the second (fitting) one. block_budget = 10
+    * (envelope_budget 394) is too small for the footer/trunc, so neither lands. */
+   {
+      ingress_entry_t e[2] = {
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("AAAAAAAAAA\n")}, /* 3+11 > 10 */
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("x\n")},          /* 3+2  <= 10 */
+      };
+      int omitted = -1;
+      char *blk = ingress_render_block(e, 2, 394, 0, &omitted);
+      assert(blk != NULL);
+      assert(strcmp(blk, "C:\nx\n") == 0); /* header on the fitting entry, once */
+      assert(omitted == 1);
+      free(blk);
+      free(e[0].preview);
+      free(e[1].preview);
+   }
+
+   /* Separator suppression: when the first group appends nothing, the next group
+    * gets no leading blank line (matches the old `if (block.len)` guard). */
+   {
+      ingress_entry_t e[2] = {
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("AAAAAAAAAA\n")}, /* omitted */
+          {ING_SRC_MEMORY, ING_XF_NONE, "M:\n", strdup("y\n")},        /* fits */
+      };
+      int omitted = -1;
+      char *blk = ingress_render_block(e, 2, 394, 0, &omitted);
+      assert(blk != NULL);
+      assert(strcmp(blk, "M:\ny\n") == 0); /* no leading "\n" */
+      assert(omitted == 1);
+      free(blk);
+      free(e[0].preview);
+      free(e[1].preview);
+   }
+
+   /* Empty list -> nothing rendered (NULL or ""), no footer. */
+   {
+      int omitted = -1;
+      char *blk = ingress_render_block(NULL, 0, 1000, 0, &omitted);
+      assert(blk == NULL || blk[0] == '\0');
+      assert(omitted == 0);
+      free(blk);
+   }
+   printf("render_block OK\n");
 }
 
 /* Auditable-correctness P1: the per-turn retrieval-event id seam. */
@@ -260,6 +352,7 @@ int main(void)
    test_format_code_block();
    test_query_from_messages();
    test_apply();
+   test_render_block();
    test_budgeted_build_uses_memory_previews();
    test_turn_id_mint_and_thread_local();
    printf("all tests passed\n");


### PR DESCRIPTION
## ingress-compression P0 — typed Envelope IR

First slice (P0) of the `ingress-compression-and-cache-alignment` proposal: refactor `ingress_preinject_build()` to assemble a **typed entry list** and render the `<aimee-context>` block from it, instead of appending into one opaque string. **Behaviour-preserving** — the rendered bytes are identical to before (no flag, no behaviour change). This lays the typed IR that later phases (P1a byte-equivalent fold, P1b lossy fold, …) dispatch a compressor over instead of re-parsing a rendered string.

### Changes
- New `ingress_source_kind_t` / `ingress_transform_t` / `ingress_entry_t` and a pure `ingress_render_block()` in `ingress_preinject.h` (`transform` reserved per §6.5 B2; P0 sets `ING_XF_NONE` on every entry).
- `format_code_candidate` / `format_memory_preview_candidate` become header-less `_body` helpers; the renderer owns group headers, the single blank-line group separator, header-on-first-fit, the budget/omission gate, the `context-budget` footer, and the truncation note — byte for byte as the old inline path.
- `build()` gathers code/memory/facts/audit into the entry list, then renders; score and the (default-off) retrieval-event emit are unchanged. The `explore-with` line + `<aimee-context>` wrapper still come from the unchanged `ingress_preinject_format_envelope()`.

### Tests
- New `test_render_block` edge cases: header-on-first-fit, group-separator suppression, omission/budget, empty list.
- Exact **588-byte golden** asserting byte-equivalence with the pre-refactor envelope (captured from the live pre-refactor code).

### Verification
`make all server`, `make lint` (clang-format-19), the unit tests (incl. the golden), and `valgrind --leak-check=full` are all clean.

Plan and implementation each went through aimee's roundtable review; the implementation pass returned no blocking/major findings (two nits applied: a clarified `header` doc comment and `int`→`bool` render flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
