### PR TITLE
Merge testing into main

### DIFF
--- a/docs/proposals/pending/ingress-compression-and-cache-alignment.plan.md
+++ b/docs/proposals/pending/ingress-compression-and-cache-alignment.plan.md
@@ -1,0 +1,233 @@
+# Implementation plan — ingress-compression P0: the Envelope IR
+
+Plan for [ingress-compression-and-cache-alignment.md](ingress-compression-and-cache-alignment.md),
+**scoped to P0 only** per the proposal's §7 phasing ("Envelope IR (§1.1) —
+refactor `ingress_preinject_build()` to assemble a typed entry list and render
+from it. No behavior change, no flag; pure enablement. Blocks everything else.").
+Grounded in `src/server/ingress_preinject.c` on `origin/testing`.
+
+## Invariant (the whole point of P0)
+
+**Byte-for-byte identical output.** For every input, the `<aimee-context>`
+envelope `ingress_preinject_build()` returns after this change must equal the
+envelope it returns today — same block ordering, same group headers, same
+separators, same budget/omission behavior, same footer, same truncation note,
+same confidence tier. No config flag is added; no source, score, or
+retrieval-event emit changes. This is a pure refactor that introduces a typed
+intermediate representation between *gathering* sources and *rendering* the
+string, so later phases (P1a byte-equivalent fold, P1b lossy fold, …) have
+something typed to dispatch a compressor over instead of re-parsing an opaque
+rendered string.
+
+## What exists today (the thing being refactored)
+
+`ingress_preinject_build()` (`ingress_preinject.c:343`) interleaves four
+concerns into one `dstr_t block`:
+
+1. **Gather** — `kb_client_index_code_search` → `hits[6]`,
+   `kb_client_memory_diagnose` → `mems[5]`, `kb_client_memory_facts` → string,
+   `ingress_preinject_read_audit_context` → string.
+2. **Render** — for each source group it formats per-record *candidates*
+   (`format_code_candidate`, `format_memory_preview_candidate`, inline facts /
+   audit blocks), appends each via `append_candidate()` (budget gate +
+   `omitted_count`), with a group header written on the first candidate that
+   actually fits and a single `"\n"` separator before any non-empty later group.
+3. **Score** — a confidence score derived from hit/preview counts.
+4. **Emit** — the auditable-correctness `retrieval_event` (reads `hits[]`/`mems[]`
+   directly), default-off.
+5. **Footer** — `context-budget: …` line + `... (N more available …)` note,
+   each appended only if it fits `block_budget`.
+
+P0 splits **(2) Render** out behind a typed entry list. **(1), (3), (4) are
+untouched** — they keep reading the same `hits[]`/`mems[]`/strings.
+
+## Design
+
+### The IR (new, in `ingress_preinject.h`)
+
+```c
+typedef enum {
+   ING_SRC_CODE,    /* a code_search hit            */
+   ING_SRC_MEMORY,  /* a memory preview             */
+   ING_SRC_FACTS,   /* the typed-facts block        */
+   ING_SRC_AUDIT,   /* the audit-context block      */
+} ingress_source_kind_t;
+
+/* Reserved per proposal §6.5 B2 — one value per lossiness class. P0 sets every
+ * entry to ING_XF_NONE (no folding yet); P1a/P1b populate the rest. Declared now
+ * so the IR is the contract a compressor dispatches over. */
+typedef enum {
+   ING_XF_NONE = 0,
+   ING_XF_CODE_WHITESPACE_COLLAPSE,
+   ING_XF_CODE_COMMENT_STRIP,
+   ING_XF_CODE_SIGNATURE_SPAN,
+   ING_XF_JSON_FOLD,
+} ingress_transform_t;
+
+typedef struct {
+   ingress_source_kind_t kind;
+   ingress_transform_t   transform;  /* P0: always ING_XF_NONE */
+   const char           *header;     /* group header, e.g. "recommended (code):\n";
+                                      * emitted once, on the first entry of a group
+                                      * that fits the budget. "" for single-entry
+                                      * groups that bake their header into preview. */
+   char                 *preview;    /* malloc'd per-record body the renderer frees */
+} ingress_entry_t;
+```
+
+P0 deliberately carries **only** the fields the renderer reads (`kind`,
+`header`, `preview`) plus `transform` (the reserved IR contract). The richer
+§1.1 fields (`record_id`/`handle`, `sensitivity`/`scope`, `original_ref`,
+`budget`, `metrics`) are **not** added in P0 — they would be inert here and are
+introduced by the phase that first consumes them (P1b telemetry, P2e handle
+store), avoiding the "looks reviewed but unread" field risk (proposal §8).
+
+**Deviation from §1.1's enum** noted for review: the proposal lists
+`code_hit | memory_block | audit | (future) tool_result`. Today's envelope also
+emits a **typed-facts** group, so P0's enum includes `ING_SRC_FACTS` to model an
+existing source. `tool_result` is not added until it has a real producer (§1.2
+defers the JSON folder).
+
+### The renderer (new, pure, unit-testable)
+
+```c
+/* Render a typed entry list into the pre-envelope block string, applying the
+ * existing budget gate, group headers, separators, footer, and truncation note.
+ * Pure: no kb, no config, no globals. Frees nothing it does not own. Returns a
+ * malloc'd block (possibly empty -> caller treats "" as no-injection). */
+char *ingress_render_block(const ingress_entry_t *entries, int count,
+                           size_t envelope_budget, int headline_missing_count,
+                           int *omitted_count_out);
+```
+
+Algorithm (reproduces today's bytes exactly):
+
+```
+block_budget = envelope_budget - INGRESS_FOOTER_RESERVE_BYTES   /* same as today */
+prev_kind = sentinel; group_first = 1; omitted = 0
+for each entry e:
+   if e.kind != prev_kind:                 /* group boundary */
+      if dstr_len(block) > 0: append "\n"  /* == today's `if (block.len) "\n"` */
+      group_first = 1; prev_kind = e.kind
+   candidate = (group_first ? e.header : "") + e.preview
+   if dstr_len(block) + strlen(candidate) <= block_budget:
+      append candidate; group_first = 0    /* header rides the first fitting entry */
+   else:
+      omitted++                            /* == today's append_candidate miss */
+   free per-iteration scratch
+if dstr_len(block) > 0:
+   append footer (context-budget: …) if it fits block_budget   /* identical text */
+   if omitted > 0: append "... (N more …)" note if it fits      /* identical text */
+*omitted_count_out = omitted
+return steal(block)
+```
+
+This is byte-equivalent because:
+- The group separator `"\n"` fires on the first entry of each new `kind` when
+  the block is non-empty — exactly today's per-group `if (block.len) "\n"` (the
+  groups are emitted in the same order: code, memory, facts, audit; an entry
+  exists for a group iff that source produced content, so the separator fires on
+  exactly the same turns).
+- The header rides the **first entry that fits** (`group_first` flips only on a
+  successful append) — exactly today's `wrote_header` semantics.
+- `append_candidate`'s budget test, `omitted_count`, and the footer/trunc text
+  are copied verbatim.
+
+### `ingress_preinject_build()` after P0
+
+1. Gather sources into `hits[]`/`mems[]`/`facts`/`audit` (**unchanged**).
+2. Build `ingress_entry_t entries[CAP]` from them:
+   - per code hit: `{CODE, NONE, "recommended (code):\n", format_code_body(hit)}`
+   - per memory preview: `{MEMORY, NONE, "recommended (memory previews):\n",
+     format_memory_body(diag, &headline_missing)}`
+   - facts (if present): `{FACTS, NONE, "", "## Known facts\n<facts>\n"}`
+   - audit (if present): `{AUDIT, NONE, "", "recommended (audit context):\n<audit>\n"}`
+   The existing `format_code_candidate` / `format_memory_preview_candidate`
+   become `..._body` helpers that **omit** the header (header moves into the
+   entry), keeping their escaping/snippet/whitespace logic byte-identical.
+3. Compute `score` from the same counts (**unchanged** — stays in `build`).
+4. Emit the `retrieval_event` from `hits[]`/`mems[]` (**unchanged**).
+5. `block = ingress_render_block(entries, k, envelope_budget,
+   headline_missing_count, &omitted)`; free each `entry.preview`.
+6. Wrap: `ingress_preinject_format_envelope(block,
+   ingress_preinject_confidence(score))` (**unchanged**).
+
+`CAP` = 6 (code) + 5 (memory) + 1 (facts) + 1 (audit) = 13; a fixed stack array,
+no heap list. `score`/footer/headline counting stay where they are.
+
+## File-size & wiring
+
+- `ingress_preinject.c` is 580 lines; the net change is roughly neutral (header
+  text moves from candidate formatters into entry construction; the budget/footer
+  loop moves into `ingress_render_block`). Comfortably under the 2000-line cap.
+- New symbols (`ingress_source_kind_t`, `ingress_transform_t`, `ingress_entry_t`,
+  `ingress_render_block`) go in the existing `ingress_preinject.h`. No Makefile
+  SRCS change (same `.c`/`.o`). The unit test links the existing
+  `ingress_preinject.o` (already built); add the new test target to
+  `src/tests/Rules.mk` if a dedicated test file is used.
+
+## Tests
+
+Extend the existing pure-helper tests (the suite that already covers
+`ingress_preinject_format_code_block` / `_format_envelope` with no kb dep):
+
+1. **Renderer golden** — hand-built `entries[]` covering all four kinds in order;
+   assert the exact block string (headers, `"\n"` separators, footer, trunc note).
+2. **Header-on-first-fit** — a code group whose first entry is omitted by a tight
+   budget; assert the header rides the second (fitting) entry, and `omitted==1`.
+3. **Group-separator suppression** — when an earlier group appended nothing
+   (everything omitted), assert no stray `"\n"` precedes the next group (matches
+   today's `if (block.len)` guard).
+4. **Empty list** → empty string (no footer, no envelope).
+5. **Budget edge** — footer/trunc appended only when they fit `block_budget`.
+6. **Equivalence smoke** — a representative entry set reproduces a known envelope
+   captured from the current code (golden string pinned in the test).
+
+Existing `ingress_preinject` tests must pass unchanged (they exercise the public
+pure helpers, which keep their signatures).
+
+## Plan-review resolutions (R1 — roundtable 2026-06-21)
+
+The first plan-gate raised six items; all are resolved in the design above and
+verified by the implementation's passing byte-equivalence golden:
+
+1. **FACTS/AUDIT header rule (blocking).** `ING_SRC_FACTS` and `ING_SRC_AUDIT`
+   entries set `header = ""` and bake their heading into `preview`
+   (`"## Known facts\n<facts>\n"`, `"recommended (audit context):\n<audit>\n"`),
+   exactly as today emitted them as a single candidate. Only `ING_SRC_CODE` /
+   `ING_SRC_MEMORY` carry a separate group `header` (written once, on the first
+   fitting entry).
+2. **Separator on a fully-omitted prior group (blocking).** The `"\n"` is
+   appended at a group boundary **only when the block is already non-empty**
+   (`if dstr_len(block) > 0`). If an earlier group appended nothing, the block is
+   still empty, so no separator is emitted — byte-identical to today's
+   `if (block.len) "\n"`. Covered by the "group-separator suppression" test.
+3. **`headline_missing_count` (blocking).** It is computed during memory-entry
+   construction and threaded into `ingress_render_block(...,
+   headline_missing_count, ...)`, which renders it verbatim in the footer — part
+   of the golden assertion (`headline_missing_count=1`).
+4. **`explore-with` line (blocking).** This is **not** the block renderer's
+   concern: `ingress_render_block` produces the *pre-envelope block* (groups +
+   footer); the unchanged `ingress_preinject_format_envelope()` wraps it with
+   `<aimee-context …>`, the `explore-with:` line, and `</aimee-context>`. The
+   golden confirms the line is present and unchanged.
+5. **`ingress_transform_t` unused in P0 (suggestion).** Documented in the enum:
+   P0 sets every entry to `ING_XF_NONE`; the enum is the reserved IR contract for
+   P1a/P1b folds.
+6. **Fate of `format_*` callers (nit).** `format_code_candidate` /
+   `format_memory_preview_candidate` are renamed to header-less `_body` helpers
+   and have a single caller (entry construction) — no dead code.
+
+## Risks / rollback
+
+- **Sole risk is a byte drift** vs today. Mitigated by the golden tests above and
+  by leaving gather/score/emit untouched. There is no flag and no behavior toggle
+  to get wrong.
+- Rollback is a straight revert (single commit, one `.c`/`.h` + test).
+- No schema, no config, no wire-shape, no provider-API dependency in P0.
+
+## Out of scope (later phases, separate plans)
+
+P1a byte-equivalent code fold + `ingress_compress_enabled`; P1b lossy folds +
+resolvers/telemetry; P2/P2e durable reachability + handle store; P3 cache-prefix
+placement; P4 failure mining; P5 Anthropic ingress. P0 only lays the IR.

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -1,0 +1,510 @@
+# Proposal: One unified `aimee-llm` container for all LLM use (local CPU/GPU · forward · external)
+
+- **State:** draft — **rev 7** · **roundtable SIGNED OFF at rev 6** (round 5: 0
+  blocking / 0 high / 0 medium, converged). Arc: r1 10 blocking → r2 7 blocking +
+  8 high → r3 1 blocking + 1 high + 2 medium → r5 **0 blocking**. rev 7 closes the
+  two open questions (pins the operator's synth models; decouples + shrinks the
+  reranker to 0.6B-default, 8B dropped; E4B-ungated CPU default). See "Decisions
+  taken" and "Changelog".
+- **Author:** JBailes
+- **Date:** 2026-06-21
+- **Base:** `testing`. Today there are **two** model containers: a torch /
+  sentence-transformers **embedder** (`Dockerfile.embedder` +
+  `scripts/embedder-server.py`, `pplx-embed` + `ettin-reranker` over a custom
+  `/embed` + `/rerank` contract) and a separate **`llm`** container
+  (`llama.cpp:server` running **Gemma E4B** over OpenAI `/v1`).
+- **Companions:**
+  - [curator-llm-backend](curator-llm-backend.md) **(pin: rev as of 2026-06-14
+    READY)** — its **shared LLM-provider client** (§1), **stage→provider routing**
+    (§2), **health four-state contract** (§4), and **drain policy** (§4/§5) are
+    **reused as the foundation**. This proposal **amends its §3 packaging**: the
+    shared client ships as a **library**, and the curator runs as an **isolated
+    s6-supervised process inside `aimee-llm`** (§6). A gateway **contract test**
+    asserts the imported four-state + typed-error shapes match that pinned version.
+  - [embedder-runtime-fetch-autodim](embedder-runtime-fetch-autodim.md) — its
+    runtime-fetch-once posture, the **auto-dim handshake**, and the
+    `schema_embedding_dim` **drift guard** (PR #337) are reused and **extended to a
+    `(model_id, dim)` guard for both embedder and reranker** (§2).
+
+## Goal
+
+**Delete the standalone embedder container and the standalone E4B `llm`
+container.** Replace both with **one** `aimee-llm` container that is the single
+gateway for **every** LLM use in aimee — embeddings, reranking, and synthesis. For
+each use, the container is backed by one of **four modes**, chosen by config:
+
+1. **local-CPU** — run the model in-container on CPU (a `llama-server` GGUF).
+2. **local-GPU** — run it in-container on GPU (`--n-gpu-layers`, by detected VRAM).
+3. **forward** — proxy to *another local* OpenAI-compatible server
+   (llama.cpp / vllm / Ollama / …).
+4. **external** — proxy to an external API (**Codex/OpenAI** = `openai` wire;
+   **Claude** = `anthropic` wire).
+
+aimee-kb and aimee-server always talk to **one endpoint** (the `aimee-llm`
+container); the container decides per-role whether to serve locally or forward.
+
+## Why one container
+
+- **One access layer for credentials, routing, auth, budget, and observability.**
+- **Kills the torch dependency and the two-container split.**
+- **The fold does not block off-box synth.** Running synth on a different GPU host
+  is the `forward`/`external` mode — no second container needed. The unified
+  container is the *control plane*; heavy synth can live elsewhere. Blast-radius
+  tradeoff handled in §6, not waved away.
+
+## Design
+
+### 1. The `aimee-llm` container = gateway + supervised local runtime
+
+One image: the **llama.cpp runtime** + a **role-based gateway** (reworked
+`scripts/embedder-server.py`) under **s6-overlay**. Endpoints:
+
+- **Retrieval (unchanged for the kb):** `POST /embed`, `POST /embed_batch`,
+  `POST /rerank` — `embed-remote.py`, `rerank-remote.py`, kb config defaults, and
+  `AIMEE_EMBEDDER_URL` are **untouched**.
+- **Synthesis:** OpenAI-compatible `POST /v1/chat/completions` (grammar/JSON-schema
+  via `--jinja`). **Streaming is disabled in the first release**: `stream=true`
+  returns a **typed `400 {"error":{"code":"streaming_unsupported"}}`** clients can
+  branch on (documented so SDKs that default to streaming set `stream=false`),
+  rather than an opaque failure. Enabling streaming later must update the audit row
+  + mid-stream circuit-breaker handling in the same change.
+- **Health:** per-role `GET /health/{embed,rerank,synth}` + aggregate `/health`
+  (§4).
+
+**Per-role mode** (`embed` / `rerank` / `synth`):
+
+| Mode | Gateway does | Local proc? | Upstream auth |
+|------|-------------|-------------|---------------|
+| `local-cpu` | supervise a `llama-server` GGUF (CPU) | yes | n/a |
+| `local-gpu` | supervise a `llama-server` GGUF (`--n-gpu-layers`) | yes | n/a |
+| `forward` | proxy/translate to another OpenAI base_url | no | **operator-supplied upstream key in gateway config; gateway authenticates outbound; upstream must be on the internal network or its own auth boundary** |
+| `external` | proxy/translate to Codex (`openai`) / Claude (`anthropic`) | no | per §1a (operator secret or hardened per-user pass-through) |
+
+A **local** role runs its own inner `llama-server` (one model+mode per process). A
+**forward/external** role runs no local process — the gateway translates wire
+formats via curator-llm-backend's shared client. **`/embed_batch`** reuses the
+embed handler with a **concrete per-call cap of 512 vectors/call** and a stated
+p95 latency budget (a distinct bulk-backfill load profile in the sizing table,
+§5), not a separate mode; an oversize batch returns **`413`**. CI tests both the
+cap and the `413` path.
+
+**Process isolation (pays down the SPOF the fold creates).** s6-overlay supervises
+each local role's `llama-server` as an independent service. Two *separate*
+mechanisms (do not conflate):
+
+- **Restart isolation — from s6:** restart-on-failure *per role*; an embed crash
+  restarts embed and does **not** take down rerank or synth. The router maps a
+  dead child to that role's `down` health state.
+- **Memory isolation — from compose, not s6:** cgroup v2 caps come from per-child
+  `mem_reservation`/`mem_limit` in compose (§5), so one role cannot starve the
+  others.
+
+A **kill-a-child smoke test** (CI on every gateway PR **and** a post-deploy hook;
+failure **blocks the deploy**) kills one inner `llama-server` and asserts the
+others keep serving, the dead role reports `down` then recovers within budget
+(inner restart ≤10 s; `loading→ready` ≤30 s). If a deployment cannot provide
+cgroup isolation, synth falls back to a separate sidecar container sharing the
+image (config-only; §6).
+
+**Gateway module decomposition:** `router` · per-role `handlers` · `wire-adapters`
+· `child-supervisor` shim · `observability` — each independently testable.
+
+### 1a. Security & access control (the gateway is privileged)
+
+- **Mutual auth, mTLS by default.** kb/server ↔ `aimee-llm` uses **mTLS** in the
+  shipped compose (self-signed certs are fine for single-host); a shared **bearer
+  token is dev-only opt-in** (bearer-with-TLS-off is a downgrade surface).
+  Unauthenticated requests are rejected.
+- **Network pin, asserted.** A startup **bind-address validator exits non-zero
+  with a typed error if the resolved bind is `0.0.0.0`**, run **before** any
+  privileged op (key load, supervisor bring-up); covered by a CI test.
+- **Rate + budget.** Rate-limit **key = mTLS peer-cert subject (preferred) or
+  bearer-token *hash*, never the raw bearer**; per-IP only as a coarse outer
+  limit. A per-scope **daily token/spend budget** caps `external` spend.
+- **Scope is derived, never trusted from the wire.** Every request's
+  **`X-Aimee-Scope` (`curator|user`) is set by the gateway from the authenticated
+  identity** (mTLS cert CN or bearer identity); a caller-supplied `X-Aimee-Scope`
+  header is **rejected** (fail-closed). Router RBAC keys off the derived scope so
+  an operator key can never attach to a `user` request or vice-versa.
+- **Per-user credential pass-through, hardened** (carries §3). When aimee-server
+  forwards a user's session credential:
+  1. the carrying hop is **mTLS**, never plaintext;
+  2. **`Authorization` redacted** in access *and* error logs; a **canary test**
+     asserts no log line for a synthetic request contains the token;
+  3. container disables **core dumps** and runs **no swap**;
+  4. the credential page is **`mlock`-ed** and **zeroed via `ctypes.memmove` over
+     a `bytearray`** after completion (CPython strings are immutable, and no-swap
+     alone is insufficient — a page can be read back from swap; hence mlock). A CI
+     **memory-scrape test** injects a canary token, then scans post-completion RSS
+     and asserts the canary is absent from every mapped page;
+  5. an `Authorization`-derived value is **never** a cache key;
+  6. user session tokens are **short-lived** (≤5-min TTL);
+  7. **Claude:** recommended posture is operator-issued **admin keys + per-user
+     attribution via Workspaces/metadata**; raw end-user-key passthrough is an
+     opt-in, documented as conflicting with Anthropic's admin-key model.
+- **Escape hatch, narrowed.** aimee-server → provider directly bypasses gateway
+  controls, so it is an **operator flag, off by default, requiring documented
+  justification** (the justification lives as a deploy-time annotation in the
+  config repo / runbook entry; a CI lint **fails if the flag is enabled with an
+  empty justification**). Even on the direct path, aimee-server emits a **thin
+  audit row** — scope, provider, outcome, request-id, byte counts, **and a
+  `user_id` (or salted `session_id_hash`)** so per-user attribution and the §4
+  per-scope spend budget still work on the path that most needs them — **never**
+  creds. A CI assertion requires any non-`curator`-scope direct-path row to carry a
+  non-empty user identifier; retention follows the §4 audit-row lifecycle.
+
+### 2. Model registry — two independent ladders, sized by GPU capability
+
+Embed/rerank and synth scale on **separate** ladders, selected independently at
+install by detected VRAM (§5).
+
+**Embed ladder** (the embed row's dim drives every dim-dependent surface):
+
+| Install | Embed (GGUF) | dim |
+|---------|--------------|-----|
+| CPU-only | `Qwen/Qwen3-Embedding-0.6B-GGUF` | 1024 |
+| GPU (mid) | `Qwen/Qwen3-Embedding-4B-GGUF` | 2560 |
+| GPU (high) | `Qwen/Qwen3-Embedding-8B-GGUF` | **4000** (trunc) |
+
+**Reranker — decoupled, not part of the embed ladder.** The reranker scores
+`(query, candidate)` text pairs, so it is **dimension-agnostic** and need not scale
+with the embedder. Per the Qwen3 paper (Table 4), the **4B matches or beats the
+8B** (MTEB-R 69.76 vs 69.02; FollowIR 14.84 vs 8.05), so **8B is dropped
+entirely**, and the 0.6B is within ~3–4 pts of 4B on general retrieval (the gap is
+larger, ~8 pts, only on *code* retrieval).
+
+| Role | Default | Optional upgrade |
+|------|---------|------------------|
+| Reranker (all tiers) | `Qwen/Qwen3-Reranker-0.6B-GGUF` | `Qwen/Qwen3-Reranker-4B-GGUF` — an **embedder-independent** knob, recommended only for **code-heavy** deployments. **No 8B.** |
+
+**Synth ladder** (pinned to your specified models; MoE rows have low active params):
+
+| Install | Synth model (GGUF) |
+|---------|--------------------|
+| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — the mirror is **ungated**, no `HF_TOKEN`) |
+| GPU-S | `unsloth/gemma-4-12B-it-GGUF` (Gemma 4 12B) |
+| GPU-M | `unsloth/gemma-4-26B-A4B-it-GGUF` (Gemma 4 26B-A4B, MoE ~4B active) |
+| GPU-L | `unsloth/Qwen3.6-35B-A3B-GGUF` (Qwen3.6 35B-A3B, MoE ~3B active) |
+
+> **Pinning.** Names are fixed above; implementation pins each to a specific
+> **commit sha** + quant. The CPU default is **Gemma 4 E4B via the ungated
+> `ggml-org` GGUF mirror** (already pulled unauthenticated in the current compose),
+> so there is **no separate "ungated fallback" model and no first-boot `HF_TOKEN`
+> requirement** — E4B is simply the CPU default.
+
+#### The 8B truncation — why 4000, and how it must be done
+
+Qwen3-Embedding-8B is **MRL-trained** (loss on first 512/1024/2048 + full 4096),
+so information front-loads into early dims; published guidance shows truncating to
+**1024 retains ~95%**. Trimming only **4096→4000 (last 96 dims, ~2.3%)** costs far
+less — expected **<1% nDCG/MRR**. The "safer" alternatives are worse: 2048 is a
+50% cut; capping at 4B/2560 forfeits the 8B→4B gap. **4000 is the most recall the
+index allows.**
+
+- **4000 = pgvector `halfvec` *index* ceiling (inclusive).** `halfvec`
+  HNSW/ivfflat indexes up to **4,000** dims; native 4096 would be **unindexable**.
+- **Storage ≠ index.** A `halfvec` column can *store* >4000 but only ≤4000 is
+  indexable; 4000 sits exactly at the ceiling (zero headroom, fine for a fixed dim).
+- **Truncation-order invariant:** `llama.cpp emits 4096 → proxy slices first-4000
+  + L2-renormalize → kb stores 4000 into halfvec(4000)`. `EMBED_MAX_DIM=4000`
+  (exact) cannot hold 4096, so the slice is in the **proxy**, which **asserts its
+  output ≤ 4000 and fails loudly** otherwise.
+- **Tier-cutoff gate (≥99%):** enabling the 8B tier requires cosine Pearson r
+  (full-4096 vs 4000) **≥ 0.99** and nDCG@10 retention **≥ 99%** vs full-4096.
+- **Metric note:** the post-slice **L2-renormalize changes vector norms**, so it is
+  distance-preserving for **cosine** (the kb's canonical similarity end-to-end) but
+  **not** for raw dot-product / L2-distance. Any consumer using those must account
+  for the renormalization; documented here and in `docs/retrieval-stack.md`.
+
+#### Model-drift guard — embedder `(model_id, dim)`, reranker `(model_id, scoring-contract)`
+
+`pplx-embed` and `Qwen3-Embedding-0.6B` are both 1024-d, so a dim-only guard would
+silently mix spaces. The guard records and compares **embedder model identity
+(repo@sha) + dim** and refuses startup / rejects writes on mismatch, keying the
+re-embed trigger on **model_id change**. **The reranker gets the same guard** (keyed
+on reranker `model_id` + scoring contract): a reranker swap invalidates cached
+scores, so a mismatch forces a re-rank pass rather than serving stale scores
+alongside new-embedder results.
+
+A `schema_embedding_dim_compat` allow-list permits deliberate upgrades **only**
+under a codified admission rule, asserted at load: admit a model iff **cosine ≥
+0.99 on a fixed aimee probe set vs the prior model**, *or* it is a documented
+parameter-identical retraining (same base repo, new sha). A compat-listed model
+that fails the probe is **refused** — so the list cannot re-open the same-dim /
+different-space footgun it exists to manage.
+
+**Migration is a controlled drop-and-rebuild, never an in-place rewrite:**
+snapshot → drop dim-sized `halfvec` tables → recreate at new `(model_id, dim)` →
+replay source rows through the new embedder (bounded batch) → **gate the kb to
+`maintenance` until corpus parity** (pre-drop vs post-backfill counts; divergence
+→ `degraded`). In-place `halfvec` type changes against a live kb are forbidden.
+
+#### Reranker contract + embedding acceptance gates (named, distinct)
+
+The Qwen3-Reranker mapping is **pinned, not deferred**: fixed chat template, fixed
+yes/no target tokens, `temperature=0`, documented logprob→score transform, and a
+query-side instruction prefix (query path only; pooling documented). Two
+**distinct** quality gates (do not conflate):
+
+- **Ship-floor gate (≥95%)** — gates *replacing* pplx/ettin, and it is a
+  **pre-cutover precondition** evaluated in staging/CI against the real corpus
+  **before** the production migration runs (the pplx/ettin baseline numbers are
+  recorded as fixtures once, so nothing needs pplx/ettin running in production):
+  nDCG@10 / MRR@10 ≥ 95% of baseline on a representative set, **plus**
+  rank-agreement (top-k agreement ≥ 0.95 *or* Spearman ≥ 0.9 — distribution-only
+  checks can pass while ranking regresses). **Gate failure → freeze and
+  investigate; do not cut over.** Because the gate is upstream of the cutover,
+  **pplx/ettin is removed completely** with no in-release retention (see "What this
+  removes").
+  - **Reproducibility:** the baseline is a **checked-in fixture**
+    (`tests/fixtures/pplx_baseline.json`) pinned by content hash — pplx/ettin GGUF
+    SHA256s, corpus-snapshot id, the pinned query set + expected metric values, and
+    the staging config (llama.cpp version, quant, hardware class) that produced
+    them; CI asserts the gate evaluates against the pinned hash.
+  - **Staging↔production parity** (what makes the gate predictive): matching
+    hardware class, llama.cpp version pin, the corpus snapshot id at cutover, and
+    the query-set composition — documented as the gate's validity precondition.
+  - **Freeze semantics:** a named operator owns declare/unfreeze; unfreeze requires
+    a root cause **and** a fix re-validated against the same corpus+queries; the
+    staging env is held for investigation. The freeze blocks only the cutover, not
+    ongoing pplx/ettin production serving (which still exists until cutover).
+- **Tier-cutoff gate (≥99%)** — to *enable the 8B truncated tier* (above).
+
+### 3. Synthesis on both credential scopes
+
+- **kb-level curator synth** — operator secret in gateway config; runs in the
+  isolated **curator process** (§6).
+- **per-user `aimee-server` synth** (`reflect`, `synthesize`, MoA) — client-held /
+  session-cached, governed by the §1a pass-through controls + escape hatch.
+
+### 4. Health, degradation & observability
+
+- **Per-role readiness.** `/health/{embed,rerank,synth}` each report the four
+  states (`ready`/`loading`/`gated`/`down`). The **kb readiness check hits
+  `/health/embed`** (+`/health/rerank` if reranking) so it indexes as soon as
+  embed is ready, without waiting for synth to load. Aggregate `/health` (with a
+  `detected_accelerator` field) stays for external monitors. A **contract test**
+  asserts these states/typed-errors match the pinned curator-llm-backend version.
+- **Circuit breakers (a control, not a label).** Per-**provider, per-mode** on
+  `forward`/`external`: **5 consecutive errors OR >50% error rate over 30 s →
+  open**; **60 s recovery-probe interval**; **1 success in half-open → closed**.
+  On open: per-role fallback (e.g. external `down` → `local-cpu` synth if the tier
+  allows) else a **typed `503 provider_unavailable`** the kb/server retry policy
+  consumes. State machine unit-tested.
+- **Observability.** Correlation ID propagated from kb/server; per-role per-mode
+  metrics (count, p50/p95 latency, tokens in/out, error rate); an **audit row per
+  `/v1/chat/completions`**: **metadata-only by default (no prompt/response
+  content)**, `scope`/mode/provider/outcome, **encrypted at rest, operator-only
+  ACL, 30-day hot retention then aggregate-only**.
+
+### 5. GPU detection & sizing
+
+- **Install-time detection, multi-vendor.** `install.sh` probes **NVIDIA
+  (`nvidia-smi`)**, **AMD ROCm (`rocm-smi`/sysfs)**, and **Intel (`lspci -d 8086:`
+  / oneAPI)**; picks the matching llama.cpp build; maps VRAM → registry row. **CPU
+  is the explicit final branch**, not a silent fallthrough; unsupported
+  accelerators are documented. (**Apple Metal** is a *native-dev-only* manual
+  override, not an `install.sh` branch — the Linux/Docker deployment target never
+  exercises it, so it stays out of the tested path.)
+- **Startup validation + swap transition.** At start (before launching `llama-server`)
+  the gateway validates **available VRAM vs the model's need**; if insufficient it
+  **falls back to the CPU-tier model or reports `gated`**, never silently
+  `--n-gpu-layers` on a too-big model. During the swap window the affected
+  `/health/<role>` returns **`loading`** and in-flight requests get a typed
+  **`503 provider_unavailable`**.
+- **Sizing table (published per tier), gateway included.** Peak RSS per inner
+  `llama-server` at its quant **+ gateway/s6 overhead (reserve ~512 MB) + headroom**,
+  reserved in the **container-level `mem_limit`** so three children at their caps
+  cannot OOM the parent. **Startup load order embed → rerank → synth**, each with a
+  per-step memory budget, plus a CI test that the load sequence stays within
+  `mem_limit`. Includes a **batch (`/embed_batch`) load profile**. On a
+  RAM-constrained CPU box, **CPU-synth is opt-in** (default synth → forward/external).
+- **CPU synth = Gemma 4 E4B, ungated, no token.** The CPU default is the
+  **`ggml-org/gemma-4-E4B-it-GGUF`** mirror, already pulled **unauthenticated** in
+  the current compose — so a fresh CPU-only install is turnkey with **no `HF_TOKEN`
+  and no license step** (§2). `HF_TOKEN`-as-a-Docker-secret handling is retained
+  **only** for operators who opt into a *gated* model (e.g. an official Google repo
+  or another gated GGUF): supplied as a **Docker secret / mounted file, not an env
+  var**, **deleted after download + checksum**; an absent/invalid token for a
+  selected gated model → clear **`gated`** health state, never a crash-loop.
+
+### 6. Process isolation & the curator-fold tradeoff (explicit)
+
+We take the fold but pay down its cost:
+
+- **One image, isolated processes.** The shared client is a **library**; curator
+  runs as its **own s6-supervised process** (own restart policy; memory cap from
+  its compose child limits, per §1 wording) — *not* the same process as user-synth.
+- **Cred-path separation by RBAC** — operator-cred (curator) and user-cred
+  (per-user synth) run in **different processes**, separated by the derived
+  `X-Aimee-Scope` (§1a).
+- **Off-box scaling preserved** via `forward`/`external` — no un-folding.
+- **Residual, stated honestly.** A single *container* is one restart/upgrade unit,
+  and RBAC is **logical, not OS-level** — a *kernel-level* exploit in curator has
+  the same blast radius as one in user-synth. The **sidecar fallback** (synth as a
+  separate container sharing the image, config-only) is the **documented response
+  to a suspected kernel-level compromise**.
+
+## Files touched (map, not exhaustive)
+
+- **Delete:** `Dockerfile.embedder`; the `embedder` + `llm` services in
+  `compose.yaml` / `compose.server.yaml` / `compose.combined.yaml` /
+  `deploy/container/aimee*.yaml` collapse into one `aimee-llm` service (per-child
+  mem limits + GPU reservation + mTLS certs).
+- **New/rework:** `Dockerfile.aimee-llm` (llama.cpp + s6-overlay + gateway);
+  `scripts/embedder-server.py` → decomposed gateway. `embed-remote.py` /
+  `rerank-remote.py` **unchanged**.
+- `.github/workflows/publish-images.yml` — one `aimee-llm` image (CPU / CUDA /
+  ROCm variants) + the new CI tests (bind-validator, canary-log, memory-scrape,
+  kill-a-child, load-sequence, contract).
+- `install.sh` — multi-vendor GPU detection + per-role mode/model/dim env.
+- `src/headers/aimee.h` — `EMBED_MAX_DIM` 2560 → **4000 (exact)**.
+- Drift guard → `(model_id, dim)` for embedder **and** reranker + compat-list +
+  admission rule; shared-client library extraction (curator-llm-backend §1).
+- `docs/retrieval-stack.md` — Qwen3 tables; unified container; 4000 truncation +
+  index-vs-storage note.
+
+## What this removes
+
+- The torch embedder container/image and the `pplx`/`ettin` pairing — **removed
+  completely in the cutover release.** No retention, no built-but-non-default
+  image, no in-image rollback flag. Rollback does **not** depend on keeping the old
+  embedder around: the ship-floor gate is a **pre-cutover precondition** (§2,
+  validated in staging against the real corpus *before* the production migration),
+  so a regression never ships; and a post-cutover revert is a **deploy-level
+  rollback to the prior release tag** (which still contains pplx/ettin) plus the
+  reverse re-embed — an explicit maintenance op. This resolves the
+  rollback-vs-removal contradiction by moving the gate upstream of the cutover, not
+  by retaining pplx/ettin.
+- The standalone `llm` container (Gemma 4 E4B is **retained as the default CPU
+  synth model**, now served inside `aimee-llm` via the ungated GGUF mirror).
+- curator-llm-backend's separate `aimee-curator` container (§3 packaging),
+  superseded by the isolated curator *process* (§6).
+- The hand-synced `embedding_dim` footgun **and** the same-dim model-swap footgun
+  (both caught by the `(model_id, dim)` guard).
+
+## Migration
+
+- Adopting the unified container re-embeds the corpus **once** (pplx→Qwen3 is a
+  `model_id` change), via the controlled drop-and-rebuild (§2) with parity gating.
+  **pplx/ettin is removed completely**; the ship-floor gate (§2) is validated
+  **pre-cutover** in staging against the real corpus, so a regression never ships.
+  A post-cutover revert, if ever needed, is a **deploy-level rollback to the prior
+  release tag** (which still contains pplx/ettin) plus the reverse re-embed — an
+  explicit, gated maintenance operation, not an instant in-image toggle.
+- **The deploy-tag-revert is a one-time safety net** for the *initial* cutover
+  only: once the first post-cutover release is validated, no prior tag still
+  contains pplx/ettin, and rollback is no longer deploy-tag-based. The prior
+  release tag is therefore **retained in the registry for a defined post-cutover
+  window** (e.g. 6 months) per image-retention policy.
+- **Re-embed cost (plan the window):** document expected wall-clock per million
+  vectors at the chosen embed model, peak RSS per inner `llama-server`, and whether
+  the backfill runs alongside read traffic or needs a maintenance window (the kb is
+  gated to `maintenance` during parity backfill, §2).
+- CPU synth defaults to Gemma 4 E4B via the ungated GGUF mirror (no `HF_TOKEN`).
+
+## Decisions taken (through rev 7)
+
+- **pplx/ettin is removed completely** in the cutover release — no retention, no
+  in-image rollback flag. The ship-floor gate is a **pre-cutover staging
+  precondition** (freeze-investigate on failure); any post-cutover revert is a
+  deploy-level rollback to the prior release tag + reverse re-embed — a **one-time**
+  safety net for the cutover release, with the prior tag retained in the registry
+  for a defined window.
+
+- **8B truncation: keep 4000**, gated by the **tier-cutoff (≥99%)** gate; proxy
+  truncation + order invariant; `EMBED_MAX_DIM=4000` exact.
+- **Curator fold: take it** as an isolated supervised process + RBAC; off-box
+  synth via forward/external; sidecar fallback = kernel-compromise response.
+- **Per-user synth via the gateway** with §1a hardening; **escape hatch** is an
+  off-by-default operator flag that still audits.
+- **Drift guard → `(model_id, dim)` for embedder and reranker** + admission-gated
+  compat-list.
+- **Auth default = mTLS**; bearer dev-only.
+- **CPU synth default = Gemma 4 E4B** via the ungated `ggml-org` GGUF mirror (no
+  `HF_TOKEN`); the separate "ungated fallback" model is dropped.
+- **Synth models pinned** to the operator's spec: Gemma 4 **E4B (CPU)**, Gemma 4
+  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker decoupled and shrunk:
+  0.6B default everywhere, 4B optional for code-heavy, 8B dropped** (4B ≥ 8B per
+  Qwen3 Table 4); the reranker guard is keyed on `(model_id, scoring-contract)`,
+  not dim.
+- **Streaming disabled** in the first release.
+- **Two named gates:** ship-floor ≥95% (replace pplx/ettin) vs tier-cutoff ≥99%
+  (enable 8B truncated tier).
+
+## Open questions
+
+1. **Commit-sha + quant pins** — model *names* are fixed (§2); implementation pins
+   each to a specific commit sha and selects the quant per tier (Q4_K_M vs Q5/Q6).
+   Mechanical, not a design decision.
+2. **Reranker re-rank pass cost** on a reranker-only swap — confirm recomputing
+   cached top-K rerank scores is cheap (it should be: the reranker writes no corpus
+   vectors, so a swap needs no re-embed/re-index, only a score refresh).
+
+## Risks
+
+- **Embedding-quality regression** pplx/ettin → Qwen3 — gated by the named §2
+  acceptance gates, validated **pre-cutover** in staging (freeze-investigate on
+  failure); post-cutover revert is the one-time deploy-tag rollback (§Migration).
+- **Gateway as privileged single point** — mitigated by §1a (auth/budget/scope),
+  §4 (circuit breakers + per-role health + audit), §6 (process isolation);
+  residual: one restart/upgrade unit + logical-not-kernel RBAC → sidecar fallback.
+- **Per-user credential exposure** — mitigated by §1a controls + canary +
+  memory-scrape tests; residual handled by the audited direct-to-provider escape.
+- **`halfvec` at exactly 4000** — zero index headroom; enforced by the proxy
+  `≤4000` assertion.
+- **Turnkey "no `HF_TOKEN`" depends on the ungated `ggml-org` E4B mirror staying
+  available + ungated.** If the mirror is removed or later gated, the CPU default
+  breaks; mitigate by pinning the mirror by commit sha, caching the GGUF in the
+  model volume, and documenting the gated-official-repo `HF_TOKEN` path (§5) as the
+  fallback.
+
+## Changelog
+
+- **rev 7 (2026-06-21):** reduced the open questions to mechanical items
+  (commit-sha/quant pins + a reranker-swap-cost confirmation). **Pinned synth
+  models** to the
+  operator's spec — Gemma 4 E4B (CPU, **ungated `ggml-org` mirror → no `HF_TOKEN`**,
+  so the rev-5 "ungated fallback" model is dropped and E4B is the plain CPU
+  default), Gemma 4 12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Decoupled the
+  reranker** from the embed ladder (it is dimension-agnostic): **0.6B default on all
+  tiers, 4B optional for code-heavy, 8B dropped** (per Qwen3 Table 4 the 4B ≥ 8B).
+  Embed GGUF repos named. Updated §2 ladders, §5 (retitled "GPU detection &
+  sizing"), "What this removes", Migration, Decisions.
+- **rev 6 (2026-06-21):** roundtable **signed off** (round 5: 0 blocking/high/medium,
+  converged). Folded the round-5 polish: ship-floor baseline pinned as a checked-in
+  hashed fixture; staging↔production parity precondition; freeze semantics
+  (owner/unfreeze criteria); deploy-tag-revert flagged as a **one-time** cutover
+  safety net + image-retention window; re-embed cost/maintenance-window note.
+- **rev 5 (2026-06-21):** operator directive — **pplx/ettin removed completely**
+  (no one-release retention). Resolved the round-3 rollback-vs-removal
+  contradiction by moving the **ship-floor gate upstream of the cutover** (staging
+  precondition, freeze-investigate on failure) instead of retaining the old
+  embedder; post-cutover revert is now a deploy-level rollback to the prior release
+  tag + reverse re-embed. Updated "What this removes", §2 ship-floor gate,
+  Migration, and Decisions.
+- **rev 4 (2026-06-21):** addressed round-3 (1 blocking + 1 high + 2 medium + 4
+  suggestions): **deferred torch/pplx/ettin deletion one release** so the
+  ship-floor **rollback is executable** (resolves the rollback-vs-removal
+  contradiction); **`user_id`/`session_id_hash` on the escape-hatch audit row** +
+  CI assertion; renamed §5 "Runtime re-probe" → **"Startup validation + swap
+  transition"** to match the body; **concrete `/embed_batch` cap (512) + `413`** +
+  CI; typed **`streaming_unsupported` 400**; **Apple Metal demoted** to
+  native-dev-only override; escape-hatch **justification storage + CI lint**;
+  **L2-renorm/cosine-canonical metric note**.
+- **rev 3 (2026-06-21):** addressed round-2 (7 blocking + 8 high): compat-list
+  **admission rule**; **ungated CPU-synth default** + pinned-fallback requirement;
+  **bind-`0.0.0.0` startup assertion**; **circuit-breaker parameters** + state
+  machine; **escape-hatch narrowed** + audited; **forward-mode upstream auth**;
+  **scope-tag derived (anti-spoof)**; **s6-vs-compose isolation wording**;
+  **reranker drift guard** + score caches; **audit-row lifecycle**; **GPU re-probe
+  transition**; **gateway overhead + load order** in sizing; **named ship-floor vs
+  tier-cutoff gates**; **mlock+memmove credential zeroing** + memory-scrape test;
+  rate-limit key, **mTLS default**, **streaming disabled**, rank-agreement metric,
+  contract-test pin, smoke-test ownership, Intel detection, batch profile, kernel
+  residual.
+- **rev 2:** added §1a auth + pass-through hardening, §4 per-role health + circuit
+  breakers + audit, §5 GPU re-probe + sizing + E4B gating, §6 curator fold as
+  isolated process; extended drift guard to `(model_id, dim)`; pinned reranker
+  contract + acceptance gates; expanded 8B-truncation rationale.
+- **rev 1:** initial unified-container draft.

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1506,9 +1506,20 @@ export default function Chat() {
   const queueActive = sending || queuedSends > 0;
   const activePersonaSid = tabs[activeIdx]?.aimeeSid ?? '';
 
-  /* Auto-scroll */
+  /* Auto-scroll. Instant, not smooth: this runs ~10×/s during a stream, and a
+   * smooth scrollIntoView restarts an animated scroll on every call — the
+   * animation never settles, so it pins the main thread/compositor for the
+   * whole turn (a sustained CPU burn the re-render throttle can't touch).
+   * Instant scroll is effectively free. We also skip if the user has scrolled
+   * up to read back, so a live stream doesn't yank them to the bottom. */
+  const atBottomRef = useRef(true);
+  const handleMessagesScroll = useCallback((e: React.UIEvent<HTMLDivElement>) => {
+    const el = e.currentTarget;
+    atBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 80;
+  }, []);
   const scrollToBottom = useCallback(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+    if (!atBottomRef.current) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' });
   }, []);
 
   useEffect(() => { scrollToBottom(); }, [streamMsgs, working, scrollToBottom]);
@@ -2286,6 +2297,9 @@ export default function Chat() {
     }
 
     const userMsgId = nextId();
+    // Sending is an explicit intent to follow the conversation: re-stick to the
+    // bottom even if the user had scrolled up to read back.
+    atBottomRef.current = true;
     setStreamMsgs(prev => [...prev, { id: userMsgId, type: 'user', text }]);
 
     sendQueueRef.current.push({ text, version: sendQueueVersionRef.current });
@@ -2787,10 +2801,13 @@ export default function Chat() {
       )}
 
       {/* Messages */}
-      <div style={{
-        flex: 1, overflowY: 'auto', padding: '16px',
-        display: 'flex', flexDirection: 'column', gap: '12px',
-      }}>
+      <div
+        onScroll={handleMessagesScroll}
+        style={{
+          flex: 1, overflowY: 'auto', padding: '16px',
+          display: 'flex', flexDirection: 'column', gap: '12px',
+        }}
+      >
         <Transcript messages={streamMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
         {working && <WorkingIndicator />}
         {remoteTurnActive && !working && (

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -121,6 +121,12 @@ const CHANNEL_KEY = 'aimee_active_channel';
 const PROJECT_ROOT_KEY = 'aimee_chat_project_root';
 const RULES_BANNER_DISMISSED_KEY = 'aimee_rules_banner_dismissed';
 const STREAM_PERSIST_DEBOUNCE_MS = 1000;
+// How many of a tab's most-recent messages the transcript renders by default.
+// Full history is kept in memory (and persisted), but only this window is mounted
+// to the DOM / reconciled per stream flush, so render cost is bounded by the
+// window, not the whole conversation. Scrolling/"show earlier" reveals the rest.
+const TRANSCRIPT_WINDOW = 150;
+const TRANSCRIPT_WINDOW_STEP = 150;
 // Cap how often streamed deltas trigger a React re-render. Each flush reconciles
 // the whole message list and re-parses the streaming message's markdown, so a
 // per-token (or per-frame) cadence pegs a CPU core during long/continuous turns.
@@ -198,8 +204,36 @@ function loadInitialChatState(): { tabs: TabData[]; activeIdx: number } {
   return { tabs, activeIdx };
 }
 
-function saveTabs(tabs: TabData[]): void {
+/* Persist the tab list to localStorage, but (1) bound each tab's stored history
+ * full history (it's the browser-side restore source and must stay recoverable),
+ * coalesce writes onto an idle callback so the synchronous JSON.stringify +
+ * setItem never runs on the React commit path during a streaming burst. Rapid
+ * tabs changes collapse into one write; a trailing timeout guarantees it still
+ * runs if the main thread stays busy. */
+let pendingTabsToPersist: TabData[] | null = null;
+let tabsWriteScheduled = false;
+
+function writePendingTabs(): void {
+  tabsWriteScheduled = false;
+  const tabs = pendingTabsToPersist;
+  pendingTabsToPersist = null;
+  if (!tabs) return;
   try { localStorage.setItem(TABS_KEY, JSON.stringify(tabs)); } catch { /* ignore */ }
+}
+
+function saveTabs(tabs: TabData[]): void {
+  pendingTabsToPersist = tabs;
+  if (tabsWriteScheduled) return;
+  tabsWriteScheduled = true;
+  const ric = (globalThis as { requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => void }).requestIdleCallback;
+  if (ric) ric(writePendingTabs, { timeout: 1000 });
+  else window.setTimeout(writePendingTabs, 200);
+}
+
+/* Flush any coalesced tabs write synchronously — call before the page unloads so
+ * a pending in-flight write isn't dropped. */
+function flushPendingTabs(): void {
+  if (pendingTabsToPersist) writePendingTabs();
 }
 
 /* Conversation/tab persistence is local (localStorage) and mirrors the top
@@ -1318,51 +1352,72 @@ function ChannelView({ channelName, messages, agents, onSend }: ChannelViewProps
   );
 }
 
-/* Renders the committed transcript. Extracted + memoized so re-renders of the
- * big Chat component that are NOT a message change (textarea typing, the remote-
- * turn preview, the workflow poll, working toggles) skip transcript
- * reconciliation entirely. Only re-renders when `messages`, `working`, or
- * `activeSid` actually change. */
+/* Render one transcript block. `streaming` only matters for an assistant bubble
+ * (it then renders raw growing text and skips the markdown parse); every other
+ * block type ignores it. */
+function renderBlock(m: StreamMsg, activeSid: string, streaming: boolean) {
+  switch (m.type) {
+    case 'user':
+      return <Message key={m.id} role="user" text={m.text} />;
+    case 'assistant':
+      return <Message key={m.id} role="assistant" text={m.text} streaming={streaming} />;
+    case 'thinking':
+      return <ThinkingBlock key={m.id} text={m.thinkText ?? ''} />;
+    case 'tool':
+      return <ToolBlock key={m.id} name={m.toolName ?? ''} args={m.toolArgs ?? ''} result={m.toolResult} />;
+    case 'narration':
+      return <TurnSummaryCard key={m.id} text={m.text} />;
+    case 'diff':
+      return <DiffBlock key={m.id} path={m.diffPath} diff={m.diffContent ?? ''} />;
+    case 'checkpoint':
+      return <RewindMarker key={m.id} snapshotId={m.snapshotId!} sid={activeSid} />;
+    default:
+      return null;
+  }
+}
+
+/* The committed (settled) part of the transcript — everything except the live,
+ * still-streaming tail block. Memoized with a REFERENCE-ONLY comparator: a
+ * stream flush rebuilds the `messages` array but keeps every settled message's
+ * object identity (applyDeltas replaces only the one growing message), so this
+ * subtree bails in an O(n) pointer scan instead of re-mapping and reconciling
+ * the whole conversation as React elements. Without it, each of the ~10 flushes/s
+ * costs O(conversation length) of React work, so a long session steadily pegs a
+ * core — the "gets worse the longer I chat" symptom. It re-renders only when a
+ * block is committed (count changes) or a settled block actually mutates (e.g. a
+ * tool_result lands), both of which change an element reference. */
+const CommittedTranscript = memo(function CommittedTranscript({ messages, count, activeSid }: {
+  messages: StreamMsg[]; count: number; activeSid: string;
+}) {
+  const blocks = [];
+  for (let i = 0; i < count; i++) blocks.push(renderBlock(messages[i], activeSid, false));
+  return <>{blocks}</>;
+}, (prev, next) => {
+  if (prev.count !== next.count || prev.activeSid !== next.activeSid) return false;
+  for (let i = 0; i < next.count; i++) {
+    if (prev.messages[i] !== next.messages[i]) return false;
+  }
+  return true;
+});
+
+/* Renders the transcript. Extracted + memoized so re-renders of the big Chat
+ * component that are NOT a message change (textarea typing, the remote-turn
+ * preview, the workflow poll, working toggles) skip it entirely. During a turn
+ * only the live tail block is re-rendered per flush; the committed history is
+ * gated behind CommittedTranscript's reference comparator. */
 const Transcript = memo(function Transcript({ messages, working, activeSid }: {
   messages: StreamMsg[]; working: boolean; activeSid: string;
 }) {
-  // The growing tail assistant bubble streams as raw text (no markdown re-parse);
-  // it stops being "streaming" the moment another block follows it or the turn
-  // ends (working → false), at which point it renders markdown once.
-  const lastId = messages.length > 0 ? messages[messages.length - 1].id : -1;
+  const n = messages.length;
+  // While a turn is in flight the last block is the live tail (an assistant
+  // bubble streams its raw text; it settles — and renders markdown once — when
+  // another block follows it or the turn ends). Everything before it is settled.
+  const liveTail = working && n > 0;
+  const committedCount = liveTail ? n - 1 : n;
   return (
     <>
-      {messages.map(m => {
-        if (m.type === 'user') {
-          return <Message key={m.id} role="user" text={m.text} />;
-        }
-        if (m.type === 'assistant') {
-          return <Message key={m.id} role="assistant" text={m.text} streaming={working && m.id === lastId} />;
-        }
-        if (m.type === 'thinking') {
-          return <ThinkingBlock key={m.id} text={m.thinkText ?? ''} />;
-        }
-        if (m.type === 'tool') {
-          return (
-            <ToolBlock
-              key={m.id}
-              name={m.toolName ?? ''}
-              args={m.toolArgs ?? ''}
-              result={m.toolResult}
-            />
-          );
-        }
-        if (m.type === 'narration') {
-          return <TurnSummaryCard key={m.id} text={m.text} />;
-        }
-        if (m.type === 'diff') {
-          return <DiffBlock key={m.id} path={m.diffPath} diff={m.diffContent ?? ''} />;
-        }
-        if (m.type === 'checkpoint') {
-          return <RewindMarker key={m.id} snapshotId={m.snapshotId!} sid={activeSid} />;
-        }
-        return null;
-      })}
+      <CommittedTranscript messages={messages} count={committedCount} activeSid={activeSid} />
+      {liveTail && renderBlock(messages[n - 1], activeSid, true)}
     </>
   );
 });
@@ -1522,6 +1577,15 @@ export default function Chat() {
     messagesEndRef.current?.scrollIntoView({ behavior: 'auto', block: 'end' });
   }, []);
 
+  // How many trailing messages the transcript currently renders. Full history
+  // stays in streamMsgs (and persisted); we just don't mount/reconcile all of it.
+  // "Show earlier" grows the window; switching conversations resets it so a fresh
+  // tab opens windowed, not expanded from a previous one.
+  const [visibleCount, setVisibleCount] = useState(TRANSCRIPT_WINDOW);
+  useEffect(() => { setVisibleCount(TRANSCRIPT_WINDOW); }, [activePersonaSid]);
+  const hiddenCount = Math.max(0, streamMsgs.length - visibleCount);
+  const windowedMsgs = hiddenCount > 0 ? streamMsgs.slice(hiddenCount) : streamMsgs;
+
   useEffect(() => { scrollToBottom(); }, [streamMsgs, working, scrollToBottom]);
   useEffect(() => { streamMsgsRef.current = streamMsgs; }, [streamMsgs]);
   useEffect(() => { tabsRef.current = tabs; }, [tabs]);
@@ -1541,7 +1605,7 @@ export default function Chat() {
    * browser doesn't leak attachments until the session is closed. keepalive
    * lets the POSTs survive the unload; best-effort. */
   useEffect(() => {
-    const onUnload = () => {
+    const detachAll = () => {
       for (const tab of tabsRef.current) {
         if (!tab.attachId || !tab.aimeeSid) continue;
         try {
@@ -1554,8 +1618,25 @@ export default function Chat() {
         } catch { /* ignore */ }
       }
     };
-    window.addEventListener('beforeunload', onUnload);
-    return () => window.removeEventListener('beforeunload', onUnload);
+    // Always flush the coalesced tabs write when the page goes away or is hidden
+    // — NOT just on beforeunload. bfcache navigation (back/forward) and OS
+    // background-kill on mobile don't fire beforeunload, and since the transcript
+    // restores SOLELY from localStorage, a dropped write shows up as a gap on
+    // reload. visibilitychange→hidden catches a backgrounded tab before a kill.
+    // Detach presence only on a GENUINE unload: a tab going to the background — or
+    // entering bfcache (pagehide persisted=true, restored without re-mounting) —
+    // is still an active session and must stay attached.
+    const onBeforeUnload = () => { flushPendingTabs(); detachAll(); };
+    const onPageHide = (e: PageTransitionEvent) => { flushPendingTabs(); if (!e.persisted) detachAll(); };
+    const onVisibility = () => { if (document.visibilityState === 'hidden') flushPendingTabs(); };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    window.addEventListener('pagehide', onPageHide);
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => {
+      window.removeEventListener('beforeunload', onBeforeUnload);
+      window.removeEventListener('pagehide', onPageHide);
+      document.removeEventListener('visibilitychange', onVisibility);
+    };
   }, []);
 
   /* Subscribe to the active session's unified-presence event stream so the UI
@@ -2808,7 +2889,20 @@ export default function Chat() {
           display: 'flex', flexDirection: 'column', gap: '12px',
         }}
       >
-        <Transcript messages={streamMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
+        {hiddenCount > 0 && (
+          <button
+            onClick={() => setVisibleCount(c => c + TRANSCRIPT_WINDOW_STEP)}
+            style={{
+              alignSelf: 'center', padding: '4px 12px', margin: '0 0 4px',
+              fontSize: '12px', fontFamily: 'system-ui', cursor: 'pointer',
+              background: tokens.surfaceAlt, color: tokens.textSecondary,
+              border: `1px solid ${tokens.borderMedium}`, borderRadius: '12px',
+            }}
+          >
+            Show earlier messages ({hiddenCount})
+          </button>
+        )}
+        <Transcript messages={windowedMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
         {working && <WorkingIndicator />}
         {remoteTurnActive && !working && (
           <div style={{

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -20,6 +20,66 @@
 
 #include "cJSON.h"
 #include "index.h" /* code_search_hit_t */
+#include <stddef.h>
+
+/* P0 Envelope IR (ingress-compression §1.1). ingress_preinject_build() no longer
+ * appends straight into one opaque string: it gathers its sources into a typed
+ * entry list and renders the <aimee-context> block from that list. This is a
+ * pure refactor — the rendered bytes are identical to before — that gives later
+ * phases a typed thing to dispatch a compressor over instead of re-parsing a
+ * rendered string. */
+
+/* The source a resident entry came from. Rendered in this group order. NB the
+ * proposal's §1.1 enum lists code/memory/audit (+future tool_result); FACTS is
+ * added here because today's envelope already emits a typed-facts group. */
+typedef enum
+{
+   ING_SRC_CODE,   /* a code-search hit          */
+   ING_SRC_MEMORY, /* a memory preview           */
+   ING_SRC_FACTS,  /* the typed-facts block      */
+   ING_SRC_AUDIT,  /* the audit-context block    */
+} ingress_source_kind_t;
+
+/* Which fold produced the resident form — one value per lossiness class, reserved
+ * per proposal §6.5 B2. P0 applies no folding, so every entry is ING_XF_NONE;
+ * P1a/P1b populate the rest. Declared now so the IR is the contract a compressor
+ * dispatches over. */
+typedef enum
+{
+   ING_XF_NONE = 0,
+   ING_XF_CODE_WHITESPACE_COLLAPSE,
+   ING_XF_CODE_COMMENT_STRIP,
+   ING_XF_CODE_SIGNATURE_SPAN,
+   ING_XF_JSON_FOLD,
+} ingress_transform_t;
+
+/* One resident entry. P0 carries only what the renderer reads (kind, header,
+ * preview) plus the reserved transform tag; the richer §1.1 fields
+ * (record_id/handle, sensitivity, original_ref, budget, metrics) are added by the
+ * phase that first consumes them, to avoid unread fields. */
+typedef struct
+{
+   ingress_source_kind_t kind;
+   ingress_transform_t transform; /* P0: always ING_XF_NONE */
+   const char *header;            /* group header (e.g. "recommended (code):\n"). The
+                                   * renderer prepends it to every attempted candidate of
+                                   * the group but keeps it only on the first one that fits
+                                   * the budget, so it lands exactly once (the old
+                                   * `wrote_header` rule). "" when preview is self-headed. */
+   char *preview;                 /* malloc'd per-record body; the renderer reads it,
+                                   * the caller frees it */
+} ingress_entry_t;
+
+/* Render a typed entry list into the pre-envelope block string, applying the
+ * existing budget gate, per-group header, single blank-line separators between
+ * non-empty groups, the context-budget footer, and the truncation note — byte
+ * for byte as ingress_preinject_build() did inline. Pure: no kb, no config, no
+ * globals; frees nothing it is given. Returns a malloc'd block, or NULL when
+ * nothing was rendered (empty list / everything omitted) — the caller treats
+ * NULL or "" as "no injection". Writes the omitted-entry count to
+ * *omitted_count_out when non-NULL. */
+char *ingress_render_block(const ingress_entry_t *entries, int count, size_t envelope_budget,
+                           int headline_missing_count, int *omitted_count_out);
 
 /* Map a recall relevance score in [0,1] to a confidence tier string
  * ("high" | "medium" | "low"). Pure; thresholds documented in the .c. */

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -9,6 +9,7 @@
 #include "kb_client.h"
 #include "dstr.h"
 #include "platform_random.h"
+#include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -189,27 +190,92 @@ static void append_single_line_escaped(dstr_t *d, const char *s, size_t max_char
    }
 }
 
-static int append_candidate(dstr_t *block, const char *candidate, size_t budget, int *omitted_count)
+char *ingress_render_block(const ingress_entry_t *entries, int count, size_t envelope_budget,
+                           int headline_missing_count, int *omitted_count_out)
 {
-   if (!candidate || !candidate[0])
-      return 1;
-   size_t need = strlen(candidate);
-   if (dstr_len(block) + need > budget)
+   /* Reserve the same footer headroom the inline builder did; the per-candidate
+    * budget gate, group headers, separators, footer, and truncation note below
+    * reproduce the old rendering byte for byte. */
+   size_t block_budget = envelope_budget > INGRESS_FOOTER_RESERVE_BYTES
+                             ? envelope_budget - INGRESS_FOOTER_RESERVE_BYTES
+                             : 0;
+   dstr_t block;
+   dstr_init(&block);
+   int omitted = 0;
+   /* have_prev guards prev_kind, so its seed is never read before the first entry
+    * sets it; group_first tracks whether this group's header still needs to land. */
+   bool have_prev = false;
+   ingress_source_kind_t prev_kind = ING_SRC_CODE;
+   bool group_first = true;
+
+   for (int i = 0; i < count; i++)
    {
-      if (omitted_count)
-         (*omitted_count)++;
-      return 0;
+      const ingress_entry_t *e = &entries[i];
+      if (!have_prev || e->kind != prev_kind)
+      {
+         /* A new group: one blank line separates it from a non-empty block,
+          * exactly the old per-group `if (block.len) "\n"`. */
+         if (dstr_len(&block) > 0)
+            dstr_append_str(&block, "\n");
+         group_first = true;
+         prev_kind = e->kind;
+         have_prev = true;
+      }
+
+      dstr_t cand;
+      dstr_init(&cand);
+      if (group_first && e->header)
+         dstr_append_str(&cand, e->header);
+      if (e->preview)
+         dstr_append_str(&cand, e->preview);
+      char *c = dstr_steal(&cand);
+
+      if (c && c[0])
+      {
+         /* The header rides the first candidate that actually fits — the old
+          * `wrote_header`, set only on a successful append. */
+         if (dstr_len(&block) + strlen(c) <= block_budget)
+         {
+            dstr_append_str(&block, c);
+            group_first = false;
+         }
+         else
+         {
+            omitted++;
+         }
+      }
+      free(c);
    }
-   dstr_append_str(block, candidate);
-   return 1;
+
+   if (dstr_len(&block) > 0)
+   {
+      char footer[256];
+      snprintf(footer, sizeof(footer),
+               "context-budget: used_bytes=%zu budget_bytes=%zu omitted_count=%d "
+               "headline_missing_count=%d\n",
+               dstr_len(&block), envelope_budget, omitted, headline_missing_count);
+      if (dstr_len(&block) + strlen(footer) <= block_budget)
+         dstr_append_str(&block, footer);
+      if (omitted > 0)
+      {
+         char trunc[128];
+         snprintf(trunc, sizeof(trunc),
+                  "... (%d more available via get_context_block or memory_get)\n", omitted);
+         if (dstr_len(&block) + strlen(trunc) <= block_budget)
+            dstr_append_str(&block, trunc);
+      }
+   }
+
+   if (omitted_count_out)
+      *omitted_count_out = omitted;
+   return dstr_steal(&block);
 }
 
-static char *format_code_candidate(const code_search_hit_t *hit, int header)
+/* Per-record body for a code hit (no group header — the IR entry carries that). */
+static char *format_code_body(const code_search_hit_t *hit)
 {
    dstr_t d;
    dstr_init(&d);
-   if (header)
-      dstr_append_str(&d, "recommended (code):\n");
    dstr_appendf(&d, "  - %s\n", hit->file_path);
    if (hit->snippet[0])
    {
@@ -220,8 +286,10 @@ static char *format_code_candidate(const code_search_hit_t *hit, int header)
    return dstr_steal(&d);
 }
 
-static char *format_memory_preview_candidate(const memory_diagnostic_t *diag, int header,
-                                             int *headline_missing)
+/* Per-record body for a memory preview (no group header). Returns NULL for an
+ * empty row (id <= 0) — the old NULL candidate, which produced no output and was
+ * not counted. Bumps *headline_missing when the row carries no headline. */
+static char *format_memory_preview_body(const memory_diagnostic_t *diag, int *headline_missing)
 {
    const memory_t *m = &diag->memory;
    if (m->id <= 0)
@@ -234,8 +302,6 @@ static char *format_memory_preview_candidate(const memory_diagnostic_t *diag, in
 
    dstr_t d;
    dstr_init(&d);
-   if (header)
-      dstr_append_str(&d, "recommended (memory previews):\n");
    dstr_appendf(&d, "  - memory:%lld", (long long)m->id);
    if (m->key[0])
    {
@@ -363,12 +429,11 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    size_t envelope_budget = (size_t)configured_budget;
    if (envelope_budget <= INGRESS_FOOTER_RESERVE_BYTES)
       return NULL;
-   size_t block_budget = envelope_budget - INGRESS_FOOTER_RESERVE_BYTES;
-
-   dstr_t block;
-   dstr_init(&block);
+   /* P0 Envelope IR: gather each source into a typed entry, then render the block
+    * from the list. CAP = 6 code + 5 memory + 1 facts + 1 audit. */
+   ingress_entry_t entries[6 + 5 + 1 + 1];
+   int k = 0;
    double score = 0.0;
-   int omitted_count = 0;
    int headline_missing_count = 0;
 
    /* Primary signal: code search over the turn query. The code index is the
@@ -380,19 +445,16 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    int n = preview_on ? kb_client_index_code_search(query, NULL, hits,
                                                     (int)(sizeof(hits) / sizeof(hits[0])))
                       : 0;
+   for (int i = 0; i < n; i++)
+   {
+      entries[k].kind = ING_SRC_CODE;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "recommended (code):\n";
+      entries[k].preview = format_code_body(&hits[i]);
+      k++;
+   }
    if (n > 0)
    {
-      int wrote_header = 0;
-      for (int i = 0; i < n; i++)
-      {
-         char *code = format_code_candidate(&hits[i], !wrote_header);
-         if (code)
-         {
-            if (append_candidate(&block, code, block_budget, &omitted_count))
-               wrote_header = 1;
-            free(code);
-         }
-      }
       double cs = (double)n / 6.0;
       if (cs > score)
          score = cs;
@@ -403,22 +465,19 @@ char *ingress_preinject_build(const char *query, int request_disabled)
     * the advertised memory:<id> handle and the memory_get MCP tool. */
    memory_diagnostic_t mems[5];
    int mem_n = preview_on ? kb_client_memory_diagnose(query, 5, mems, 5) : 0;
+   for (int i = 0; i < mem_n; i++)
+   {
+      char *body = format_memory_preview_body(&mems[i], &headline_missing_count);
+      if (!body)
+         continue; /* empty row (id <= 0): no entry, as the old NULL candidate */
+      entries[k].kind = ING_SRC_MEMORY;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "recommended (memory previews):\n";
+      entries[k].preview = body;
+      k++;
+   }
    if (mem_n > 0)
    {
-      if (block.len)
-         dstr_append_str(&block, "\n");
-      int wrote_header = 0;
-      for (int i = 0; i < mem_n; i++)
-      {
-         char *preview =
-             format_memory_preview_candidate(&mems[i], !wrote_header, &headline_missing_count);
-         if (preview)
-         {
-            if (append_candidate(&block, preview, block_budget, &omitted_count))
-               wrote_header = 1;
-            free(preview);
-         }
-      }
       double ms = mem_n >= 4 ? 0.7 : (mem_n >= 2 ? 0.4 : 0.1);
       if (ms > score)
          score = ms;
@@ -432,17 +491,17 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    char *facts = facts_on ? kb_client_memory_facts(query) : NULL;
    if (facts && facts[0])
    {
-      if (block.len)
-         dstr_append_str(&block, "\n");
       dstr_t f;
       dstr_init(&f);
       dstr_append_str(&f, "## Known facts\n");
       dstr_append_str(&f, facts);
       if (facts[strlen(facts) - 1] != '\n')
          dstr_append_str(&f, "\n");
-      char *fact_candidate = dstr_steal(&f);
-      append_candidate(&block, fact_candidate, block_budget, &omitted_count);
-      free(fact_candidate);
+      entries[k].kind = ING_SRC_FACTS;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "";
+      entries[k].preview = dstr_steal(&f);
+      k++;
       if (score < 0.5)
          score = 0.5;
    }
@@ -510,42 +569,28 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    char *audit = preview_on ? ingress_preinject_read_audit_context() : NULL;
    if (audit && audit[0])
    {
-      if (block.len)
-         dstr_append_str(&block, "\n");
       dstr_t a;
       dstr_init(&a);
       dstr_append_str(&a, "recommended (audit context):\n");
       dstr_append_str(&a, audit);
       if (audit[strlen(audit) - 1] != '\n')
          dstr_append_str(&a, "\n");
-      char *audit_candidate = dstr_steal(&a);
-      append_candidate(&block, audit_candidate, block_budget, &omitted_count);
-      free(audit_candidate);
+      entries[k].kind = ING_SRC_AUDIT;
+      entries[k].transform = ING_XF_NONE;
+      entries[k].header = "";
+      entries[k].preview = dstr_steal(&a);
+      k++;
       if (score < 0.4)
          score = 0.4;
    }
    free(audit);
 
-   if (block.len)
-   {
-      char footer[256];
-      snprintf(footer, sizeof(footer),
-               "context-budget: used_bytes=%zu budget_bytes=%zu omitted_count=%d "
-               "headline_missing_count=%d\n",
-               dstr_len(&block), envelope_budget, omitted_count, headline_missing_count);
-      if (dstr_len(&block) + strlen(footer) <= block_budget)
-         dstr_append_str(&block, footer);
-      if (omitted_count > 0)
-      {
-         char trunc[128];
-         snprintf(trunc, sizeof(trunc),
-                  "... (%d more available via get_context_block or memory_get)\n", omitted_count);
-         if (dstr_len(&block) + strlen(trunc) <= block_budget)
-            dstr_append_str(&block, trunc);
-      }
-   }
+   /* Render the resident block from the typed entry list, then release the
+    * per-entry previews (the renderer copies what it keeps). */
+   char *blk = ingress_render_block(entries, k, envelope_budget, headline_missing_count, NULL);
+   for (int i = 0; i < k; i++)
+      free(entries[i].preview);
 
-   char *blk = dstr_steal(&block);
    if (!blk || !blk[0])
    {
       free(blk);

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -220,8 +220,100 @@ static void test_budgeted_build_uses_memory_previews(void)
    assert(strstr(env, "context-budget:") != NULL);
    assert(strstr(env, "memory_get") != NULL);
    assert(strstr(env, "Fallback preview from content.") != NULL);
+
+   /* P0 byte-equivalence anchor: the Envelope IR refactor must reproduce the
+    * pre-refactor envelope byte for byte for this fixed stub scenario (code hit
+    * + two memory previews under the 1200-byte budget). Captured from the live
+    * pre-refactor code. */
+   static const char *GOLDEN =
+       "<aimee-context confidence=\"medium\">\n"
+       "recommended (code):\n"
+       "  - src/server/ingress_preinject.c\n"
+       "    > builder emits a bounded context envelope\n"
+       "\n"
+       "recommended (memory previews):\n"
+       "  - memory:101 deploy path [L2/fact score=0.880 headline_missing=false]\n"
+       "    > Use the deploy matrix.\n"
+       "  - memory:102 fallback [L2/policy score=0.440 headline_missing=true]\n"
+       "    > Fallback preview from content.\n"
+       "context-budget: used_bytes=342 budget_bytes=1200 omitted_count=0 headline_missing_count=1\n"
+       "explore-with: find_symbol, lsp_references, ast_grep_search, search_graph, "
+       "get_context_block, "
+       "memory_get\n"
+       "</aimee-context>";
+   assert(strcmp(env, GOLDEN) == 0);
    free(env);
    printf("budgeted_build_uses_memory_previews OK\n");
+}
+
+/* P0 Envelope IR: the renderer reproduces the old inline rendering — group
+ * headers, single blank-line separators between non-empty groups, the
+ * header-rides-the-first-fitting-candidate rule, the budget/omitted gate, the
+ * footer, and the truncation note. Synthetic entries keep the expected bytes
+ * easy to compute. The renderer frees nothing it is given. */
+static void test_render_block(void)
+{
+   /* Two groups + footer, no omission: exact bytes. block_budget = 1000-384. */
+   {
+      ingress_entry_t e[2] = {
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("a\n")},
+          {ING_SRC_MEMORY, ING_XF_NONE, "M:\n", strdup("b\n")},
+      };
+      int omitted = -1;
+      char *blk = ingress_render_block(e, 2, 1000, 0, &omitted);
+      assert(blk != NULL);
+      assert(strcmp(blk, "C:\na\n\nM:\nb\ncontext-budget: used_bytes=11 budget_bytes=1000 "
+                         "omitted_count=0 headline_missing_count=0\n") == 0);
+      assert(omitted == 0);
+      free(blk);
+      free(e[0].preview);
+      free(e[1].preview);
+   }
+
+   /* Header rides the first candidate that fits: a too-big first code entry is
+    * omitted, the header appears on the second (fitting) one. block_budget = 10
+    * (envelope_budget 394) is too small for the footer/trunc, so neither lands. */
+   {
+      ingress_entry_t e[2] = {
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("AAAAAAAAAA\n")}, /* 3+11 > 10 */
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("x\n")},          /* 3+2  <= 10 */
+      };
+      int omitted = -1;
+      char *blk = ingress_render_block(e, 2, 394, 0, &omitted);
+      assert(blk != NULL);
+      assert(strcmp(blk, "C:\nx\n") == 0); /* header on the fitting entry, once */
+      assert(omitted == 1);
+      free(blk);
+      free(e[0].preview);
+      free(e[1].preview);
+   }
+
+   /* Separator suppression: when the first group appends nothing, the next group
+    * gets no leading blank line (matches the old `if (block.len)` guard). */
+   {
+      ingress_entry_t e[2] = {
+          {ING_SRC_CODE, ING_XF_NONE, "C:\n", strdup("AAAAAAAAAA\n")}, /* omitted */
+          {ING_SRC_MEMORY, ING_XF_NONE, "M:\n", strdup("y\n")},        /* fits */
+      };
+      int omitted = -1;
+      char *blk = ingress_render_block(e, 2, 394, 0, &omitted);
+      assert(blk != NULL);
+      assert(strcmp(blk, "M:\ny\n") == 0); /* no leading "\n" */
+      assert(omitted == 1);
+      free(blk);
+      free(e[0].preview);
+      free(e[1].preview);
+   }
+
+   /* Empty list -> nothing rendered (NULL or ""), no footer. */
+   {
+      int omitted = -1;
+      char *blk = ingress_render_block(NULL, 0, 1000, 0, &omitted);
+      assert(blk == NULL || blk[0] == '\0');
+      assert(omitted == 0);
+      free(blk);
+   }
+   printf("render_block OK\n");
 }
 
 /* Auditable-correctness P1: the per-turn retrieval-event id seam. */
@@ -260,6 +352,7 @@ int main(void)
    test_format_code_block();
    test_query_from_messages();
    test_apply();
+   test_render_block();
    test_budgeted_build_uses_memory_previews();
    test_turn_id_mint_and_thread_local();
    printf("all tests passed\n");


### PR DESCRIPTION
Promote testing to main. Tree-equal to testing after resolving a squash-divergence conflict in frontend/src/pages/Chat.tsx (main received #582/#583 content via the squash promote #584; testing carries them as real commits plus more, so testing is a content-superset — resolved toward testing, verified identical).

Carries:
- #586 perf(webchat): window the transcript + isolate the stream tail to bound CPU over a session
- #585 feat(ingress): typed Envelope IR for pre-injection
- #583 docs(proposal): unified aimee-llm container
- #582 perf(webchat): instant (not smooth) stream auto-scroll

Frontend tsc + build green; merged tree verified identical to testing.