### PR TITLE
chore(proposals): file auto-vault-provisioning to done (+ WP-C entrypoint parity)

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -63,6 +63,17 @@ trap 'shutdown' TERM INT
 # container down; the server is the contract.
 webchat_start
 
+# Delegate-vault auto-provisioning. aimee-server seals operator-supplied delegate
+# API keys into its server-principal vault at startup, so a fresh deploy's
+# delegates/roundtables work with no manual `aimee vault set`. The source comes
+# from the environment, which runuser preserves into the aimee-server child:
+#   - AIMEE_DELEGATE_SECRETS_FILE=/run/secrets/aimee-delegates.json
+#       a JSON object {"<agent>":"<api-key>", ...}. Mount it readable by the
+#       container's "aimee" user (the server reads it after dropping privileges).
+#   - AIMEE_DELEGATE_KEY_<AGENT>=<api-key>   (env-only convenience; agent name
+#       lowercased, e.g. AIMEE_DELEGATE_KEY_MISTRAL).
+# Non-destructive by default; set AIMEE_DELEGATE_SECRETS_OVERWRITE=1 to replace an
+# existing vaulted key. Secrets are never written to AIMEE_HOME or logs.
 log "starting aimee-server (socket=$SERVER_SOCK) as user aimee"
 runuser -u aimee -- aimee-server --socket="$SERVER_SOCK" &
 server_pid=$!

--- a/docs/proposals/done/auto-vault-provisioning-at-server-standup.md
+++ b/docs/proposals/done/auto-vault-provisioning-at-server-standup.md
@@ -1,6 +1,14 @@
 # Automatic delegate-vault provisioning at aimee-server standup
 
-- **State:** proposed; awaiting roundtable + user proposal-gate.
+- **State:** **DONE / shipped.** Core (WP-A/B) landed in **PR #410**
+  (`server_vault_bootstrap`, env scrub, audit, idempotence, `test_vault_bootstrap`);
+  WP-C container surface is in tree (`combined-entrypoint.sh` + `server-entrypoint.sh`
+  secrets-env docs, `runuser` env passthrough, the `compose.combined.yaml` /
+  `compose.server.yaml` secret examples, and the SmoothNAS plugin field). Acceptance
+  criteria 1–4 met and unit-verified; criterion 5 (re-provision the live `.254`
+  server) is deployment-time validation. WP-D (remote provisioning over native TLS)
+  is an explicit optional follow-on, tracked by
+  [native-tls-thin-client-backends.md](../pending/native-tls-thin-client-backends.md).
 - **Scope:** deterministic / server bootstrap + credential vault. Not an
   intelligence-surface proposal (no Architecture Charter role).
 - **Author:** JBailes, 2026-06-17.

--- a/docs/proposals/done/auto-vault-provisioning-at-server-standup.plan.md
+++ b/docs/proposals/done/auto-vault-provisioning-at-server-standup.plan.md
@@ -63,7 +63,7 @@ authenticate with no further change.
   field so a `.254`-style deploy provisions on standup.
 
 ### WP-D — (Optional, follow-on) remote provisioning over native TLS
-- Once [native-tls-thin-client-backends.md](native-tls-thin-client-backends.md)
+- Once [native-tls-thin-client-backends.md](../pending/native-tls-thin-client-backends.md)
   lands, `ATTEST_TLS_BEARER` already authorizes server-principal writes over a
   confidential bearer channel — so an operator could `aimee vault set --server`
   remotely over `https://` instead of mounting a file. Note as complementary; not
@@ -98,4 +98,4 @@ authenticate with no further change.
   plaintext), so a too-early call degrades to "not provisioned", not a leak.
 - This is the **gating dependency** for live roundtables — landing WP-A..C and
   re-provisioning `.254` unblocks the roundtable flow for every other proposal,
-  including [native-tls-thin-client-backends.md](native-tls-thin-client-backends.md).
+  including [native-tls-thin-client-backends.md](../pending/native-tls-thin-client-backends.md).


### PR DESCRIPTION
## File `auto-vault-provisioning-at-server-standup` to done/ (+ WP-C parity)

This proposal is functionally shipped and is moved `pending/ → done/`.

- **WP-A/B** (core) landed in **PR #410**: `server_vault_bootstrap()` seals operator-supplied delegate keys into the server-principal vault at standup; env scrub, audit-without-value, non-destructive idempotence, and `test_vault_bootstrap` are all in tree.
- **WP-C** (container surface) is in tree: `combined-entrypoint.sh` secrets-env docs, `runuser` env passthrough, the `compose.combined.yaml` / `compose.server.yaml` secret examples, and the SmoothNAS plugin field. This PR adds the matching secrets-env doc block to **`server-entrypoint.sh`** for parity (the proposal's WP-C names both entrypoints; passthrough already worked via `runuser`).
- Acceptance criteria 1–4 are met and unit-verified; **criterion 5** (re-provision the live `.254` server) is deployment-time validation. **WP-D** (remote provisioning over native TLS) is an explicit optional follow-on, tracked by the still-pending `native-tls-thin-client-backends` proposal.

Verified: `check-proposal-links` passes (relative link to native-tls fixed for the new `done/` location); `sh -n server-entrypoint.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
