### PR TITLE
feat(persona): add completion/acceptance discipline to the engineer persona

### DIFF
--- a/src/prompts.c
+++ b/src/prompts.c
@@ -502,6 +502,11 @@ static const char *PROMPT_CODE_PRINCIPLES_TEXT =
     "about.\n"
     "- Code outranks your repro: when the system's own source contradicts your "
     "reproduction, treat the repro as guilty until you can explain the gap.\n"
+    "- Done means verified: a task or proposal is finished only when its stated "
+    "acceptance criteria are actually exercised — build, tests, lint, and the "
+    "change's own checks run and pass. A criterion you cannot run (no toolchain, no "
+    "hardware, a deployment you can't perform) is reported as validation-pending, "
+    "never silently marked done.\n"
     "- Be direct about tradeoffs, assumptions, test results, and anything you could "
     "not verify.\n\n";
 


### PR DESCRIPTION
Adds a **completion / acceptance discipline** principle to the engineer persona (`prompts.c` `PROMPT_CODE_PRINCIPLES_TEXT`, served to `AIMEE_MODE_ENGINEER`):

> Done means verified: a task or proposal is finished only when its stated acceptance criteria are actually exercised — build, tests, lint, and the change's own checks run and pass. A criterion you cannot run (no toolchain, no hardware, a deployment you can't perform) is reported as validation-pending, never silently marked done.

Rationale: lessons only reach future aimee engineer delegates if they live in the persona prose — agent-side memory is not visible to aimee. This captures the durable lesson from an autonomous proposal-completion run (the environment/substrate gaps that *block* such verification are the subject of the separate autonomous-dev-execution-substrate proposal, #594).

Verified: `unit-test-persona` passes; clang-format-19 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)