### PR TITLE
docs(proposal): withdraw ingress-compression P1a (no-op); resize next slice as P1b

### DIFF
--- a/docs/proposals/pending/ingress-compression-and-cache-alignment.md
+++ b/docs/proposals/pending/ingress-compression-and-cache-alignment.md
@@ -858,19 +858,34 @@ implementer and do not gate the first phase.
 
 ## §7 Phasing
 
-- **P0 — Envelope IR (§1.1).** Refactor `ingress_preinject_build()` to assemble a
-  typed entry list and render from it. No behavior change, no flag; pure
-  enablement. Blocks everything else.
-- **P1a — Byte-equivalent code fold (§1.2/§1.3)** behind `ingress_compress_enabled`,
-  with the full config/docs/test surface for that flag and the regenerated OpenAPI
-  embed if `X-Aimee-Compress` is public. Blank-line/whitespace collapse only —
-  provably lossless, **no** resolver/authority/handle dependency. Token/latency +
-  net-economics A/B (recovery rate is zero). **This is the first default-flip
-  candidate** and the proposal's earliest real win.
-- **P1b — Lossy code fold (§1.2/§1.3/§1.4)** — comment-strip + signature/span,
-  every fold carrying a `transform` tag and a reachable resolver. Pulls in the
-  span-enrichment fallback, `X-Aimee-Compress` per-call escape, and the per-entry
-  telemetry (#34). No default flip until P2.
+- **P0 — Envelope IR (§1.1). DONE (PR #585).** `ingress_preinject_build()` now
+  assembles a typed entry list and renders from it; no behaviour change, no flag.
+  Blocks everything else.
+- **P1a — Byte-equivalent code fold (§1.2/§1.3). WITHDRAWN — it is a no-op on the
+  current resident form.** A design roundtable (2026-06-21, 3 lenses, unanimous)
+  found that today's resident code form is already a single collapsed line per
+  hit: every `code_hit` snippet is routed through `append_single_line_escaped()`,
+  which strips newlines/tabs and collapses whitespace runs **before** the entry is
+  built. A "blank-line/whitespace collapse" fold therefore has no input to act on,
+  so shipping it would land `ingress_compress_enabled` guarding dead code for zero
+  byte savings. P1a is removed from the phase list; the `ingress_compress_enabled`
+  flag is **not** introduced until a fold with real input exists (P1b). **Precondition
+  carried forward:** audit what `append_single_line_escaped()` already destroys
+  (heredocs, multi-line strings, indentation-sensitive snippets like YAML/Make) —
+  the resident form is already lossy, so the byte-equivalence framing for code
+  snippets is moot and any future fold must be measured against that baseline.
+- **P1b — Lossy code fold + resident-form enrichment (§1.2/§1.3/§1.4).** This is
+  the next real increment, and it is **P1b-sized, not a small win**: to fold
+  anything meaningful the resident form must first carry a **multi-line** code span
+  (signature + relevant lines), which pulls in span enrichment, a reachable
+  rehydrate resolver, `transform` tags, the `X-Aimee-Compress` per-call escape, the
+  per-entry telemetry (#34), and the forced-rehydration accuracy A/B (§6) before any
+  default flip. The roundtable also surfaced an alternative worth A/B-ing here — a
+  `file:line[:span]` reference resolved through the rehydrate path instead of an
+  inline fold — but it is **not** non-lossy-for-free: it shifts bytes to a runtime
+  resolve (latency), changes the P0 IR's inline shape, and depends on the same
+  resolver/reachability infra, so it lives inside P1b's preconditions, not ahead of
+  them. No default flip until P2.
 - **P2 — Durable-read reachability + accuracy A/B for the lossy fold (P1b).** A
   lossy code fold recovers via a durable code-span/range read, so its
   forced-rehydration accuracy A/B and its default-flip candidacy need a real


### PR DESCRIPTION
Acts on a design roundtable verdict (the autonomous loop consulted the panel for the opinion).

**Withdraws ingress-compression P1a** — unanimously found to be a no-op: `append_single_line_escaped()` already collapses every `code_hit` snippet to a single line before the IR entry is built, so a 'blank-line/whitespace collapse' fold has no input and would ship `ingress_compress_enabled` guarding dead code. The flag is deferred until a fold with real input exists.

- Marks **P0 done** (#585).
- Resizes the next increment as **P1b** (multi-line resident-form enrichment + lossy fold + rehydrate resolver + accuracy A/B) — explicitly *not* a small win — and folds the panel's `file:line[:span]` reference alternative into P1b's preconditions (it's not non-lossy-for-free: runtime resolve latency, IR shape change, same resolver infra).
- Carries forward the precondition to audit what `append_single_line_escaped()` already destroys (heredocs, indentation-sensitive snippets).

This is the premise-drift correction the completion-discipline lesson is about — keeping the proposal grounded against the actual tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)