### PR TITLE
fix(worktree): base new sessions on default branch; harden against key collisions

### DIFF
--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -1299,17 +1299,27 @@ void cmd_launch(app_ctx_t *ctx, int argc, char **argv)
     * Set the override BEFORE cmd_session_start so every downstream
     * session_id() call in this process uses the new unique ID. */
    {
-      unsigned char rnd[4];
+      /* 10 random bytes -> 20 hex chars. The per-session worktree key uses the
+       * first 16 chars (64 bits), so the id must carry at least that much
+       * entropy; the old 4-byte (8-hex) id left the key at only 32 bits, where
+       * independent launches collided onto a shared worktree. */
+      unsigned char rnd[10];
       if (platform_random_bytes(rnd, sizeof(rnd)) != 0)
       {
-         /* Fallback: mix PID and time to reduce collision risk */
-         rnd[0] = (unsigned char)(getpid() & 0xff);
-         rnd[1] = (unsigned char)((getpid() >> 8) & 0xff);
-         rnd[2] = (unsigned char)(time(NULL) & 0xff);
-         rnd[3] = (unsigned char)((time(NULL) >> 8) & 0xff);
+         /* Fallback: seed an LCG from PID+time and emit one byte per step.
+          * Advancing the state each byte (rather than shifting a single value)
+          * keeps all bytes distinct without any out-of-range shift. */
+         uint64_t mix = (uint64_t)getpid() * 2654435761u + (uint64_t)time(NULL);
+         for (size_t i = 0; i < sizeof(rnd); i++)
+         {
+            mix = mix * 6364136223846793005ULL + 1442695040888963407ULL;
+            rnd[i] = (unsigned char)(mix >> 56);
+         }
       }
-      char fresh_id[16];
-      snprintf(fresh_id, sizeof(fresh_id), "%02x%02x%02x%02x", rnd[0], rnd[1], rnd[2], rnd[3]);
+      char fresh_id[32];
+      int off = 0;
+      for (size_t i = 0; i < sizeof(rnd); i++)
+         off += snprintf(fresh_id + off, sizeof(fresh_id) - off, "%02x", rnd[i]);
       session_id_set_override(fresh_id);
    }
 

--- a/src/headers/workspace.h
+++ b/src/headers/workspace.h
@@ -57,9 +57,10 @@ char *style_read(const char *project_name);
 int worktree_sibling_path(const char *git_root, const char *sid, const char *work_name, char *out,
                           size_t out_len);
 /* Deterministic per-delegation worktree work-name derived from `sid` (FNV-1a
- * over its first 8 chars), so the dispatch and server-compute paths resolve to
- * one shared sibling worktree instead of two. Writes <=8 hex chars + NUL into
- * out[cap] (cap >= 9). Returns 0 on success, -1 on bad args. */
+ * over the session key — its leading characters; see worktree_session_key in
+ * workspace.c), so the dispatch and server-compute paths resolve to one shared
+ * sibling worktree instead of two. Writes <=8 hex chars + NUL into out[cap]
+ * (cap >= 9). Returns 0 on success, -1 on bad args. */
 int worktree_delegate_work_name(const char *sid, char *out, size_t cap);
 int is_aimee_worktree_path(const char *path);
 int worktree_managed_git_root(const char *path, char *out, size_t out_len);
@@ -91,9 +92,10 @@ int worktree_find_branch_registered(const char *branch, char *out_dir, size_t ou
 int check_merged_pr_for_branch(const char *git_dir);
 const char *worktree_for_cwd(const session_state_t *state, const char *cwd);
 
-/* Detect the best base branch for a new worktree rooted at git_root.
- * Prefers the current checked-out branch; falls back to main/origin/main/HEAD.
- * Writes result into buf (at most buf_len bytes including NUL). */
+/* Detect the base branch for a new worktree rooted at git_root.
+ * Prefers the repository's DEFAULT branch (origin/HEAD), then local
+ * main/master/trunk, then the current HEAD as a last resort. Writes result
+ * into buf (at most buf_len bytes including NUL). */
 void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len);
 
 /* Count active aimee-managed worktrees for git_root. */

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -129,6 +129,7 @@ int main(void)
    test_worktree_prefers_specific_git_root();
    test_worktree_sibling_path();
    test_worktree_detect_base_branch_active();
+   test_worktree_detect_base_branch_local_default();
    test_worktree_detect_base_branch_fallback();
    test_session_isolation_creates_and_returns_worktree();
    test_session_isolation_skips_when_already_in_same_session_worktree();

--- a/src/tests/test_guardrails_cases_a.inc
+++ b/src/tests/test_guardrails_cases_a.inc
@@ -378,21 +378,29 @@ static void test_worktree_sibling_path(void)
 {
    char buf[MAX_PATH_LEN];
 
+   /* The session key is the first 16 chars of the id (WORKTREE_SID_KEY_LEN). */
+
    /* Without work_name: session-level worktree. */
    int rc = worktree_sibling_path("/root/dev/aimee", "fadc648f-1234-5678", NULL, buf, sizeof(buf));
    assert(rc == 0);
-   assert(strcmp(buf, "/root/dev/aimee/.aimee/worktrees/fadc648f/main") == 0);
+   assert(strcmp(buf, "/root/dev/aimee/.aimee/worktrees/fadc648f-1234-56/main") == 0);
 
    /* With work_name: per-delegate worktree. */
    rc = worktree_sibling_path("/root/dev/aimee", "fadc648f-1234-5678", "task01", buf, sizeof(buf));
    assert(rc == 0);
-   assert(strcmp(buf, "/root/dev/aimee/.aimee/worktrees/fadc648f/task01") == 0);
+   assert(strcmp(buf, "/root/dev/aimee/.aimee/worktrees/fadc648f-1234-56/task01") == 0);
+
+   /* A legacy short (<=16 char) id maps to itself, so worktrees created before
+    * the key was widened keep their path. */
+   rc = worktree_sibling_path("/root/dev/aimee", "abcd1234", NULL, buf, sizeof(buf));
+   assert(rc == 0);
+   assert(strcmp(buf, "/root/dev/aimee/.aimee/worktrees/abcd1234/main") == 0);
 }
 
 static void test_worktree_detect_base_branch_active(void)
 {
-   /* Create a temporary git repo, checkout a named branch, and verify
-    * that worktree_detect_base_branch() returns that branch name. */
+   /* A new worktree must be rooted on the repository's DEFAULT branch
+    * (origin/HEAD), NOT on whatever feature branch is currently checked out. */
    char tmpdir[] = "/tmp/test_wt_branch_XXXXXX";
    if (mkdtemp(tmpdir) == NULL)
    {
@@ -400,7 +408,6 @@ static void test_worktree_detect_base_branch_active(void)
       return;
    }
 
-   /* Init repo and create a commit so the branch ref exists */
    char cmd[512];
    snprintf(cmd, sizeof(cmd), "git -C '%s' init -q 2>/dev/null", tmpdir);
    (void)system(cmd);
@@ -412,15 +419,60 @@ static void test_worktree_detect_base_branch_active(void)
             "touch '%s/x' && git -C '%s' add x && git -C '%s' commit -qm 'init' 2>/dev/null",
             tmpdir, tmpdir, tmpdir);
    (void)system(cmd);
-   /* Create and checkout a distinct branch */
+   /* Normalize the default branch name and simulate a configured remote default
+    * (origin/HEAD -> origin/main) without needing a network remote. */
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m main 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' update-ref refs/remotes/origin/main HEAD 2>/dev/null",
+            tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd),
+            "git -C '%s' symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null",
+            tmpdir);
+   (void)system(cmd);
+   /* Check out a distinct feature branch — detection must ignore it. */
    snprintf(cmd, sizeof(cmd), "git -C '%s' checkout -qb 'feat/test-branch' 2>/dev/null", tmpdir);
    (void)system(cmd);
 
    char branch[64];
    worktree_detect_base_branch(tmpdir, branch, sizeof(branch));
-   assert(strcmp(branch, "feat/test-branch") == 0);
+   assert(strcmp(branch, "origin/main") == 0);
 
-   /* Cleanup */
+   snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
+   (void)system(cmd);
+}
+
+static void test_worktree_detect_base_branch_local_default(void)
+{
+   /* With no remote default set, fall back to a local default branch (main),
+    * still in preference to the checked-out feature branch. */
+   char tmpdir[] = "/tmp/test_wt_localdef_XXXXXX";
+   if (mkdtemp(tmpdir) == NULL)
+   {
+      fprintf(stderr, "test_worktree_detect_base_branch_local_default: mkdtemp failed, skipping\n");
+      return;
+   }
+
+   char cmd[512];
+   snprintf(cmd, sizeof(cmd), "git -C '%s' init -q 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' config user.email 'test@test.com' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' config user.name 'Test' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd),
+            "touch '%s/x' && git -C '%s' add x && git -C '%s' commit -qm 'init' 2>/dev/null",
+            tmpdir, tmpdir, tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' branch -m main 2>/dev/null", tmpdir);
+   (void)system(cmd);
+   snprintf(cmd, sizeof(cmd), "git -C '%s' checkout -qb 'feat/test-branch' 2>/dev/null", tmpdir);
+   (void)system(cmd);
+
+   char branch[64];
+   worktree_detect_base_branch(tmpdir, branch, sizeof(branch));
+   assert(strcmp(branch, "main") == 0);
+
    snprintf(cmd, sizeof(cmd), "rm -rf '%s'", tmpdir);
    (void)system(cmd);
 }
@@ -484,7 +536,7 @@ static void test_session_isolation_creates_and_returns_worktree(void)
    assert(rc == 1);
 
    char expected[MAX_PATH_LEN];
-   snprintf(expected, sizeof(expected), "%s/aimee/.aimee/worktrees/fadc648f/main", tmpdir);
+   snprintf(expected, sizeof(expected), "%s/aimee/.aimee/worktrees/fadc648f-1234-56/main", tmpdir);
    assert(strcmp(target, expected) == 0);
 
    /* Worktree must exist on disk after create_if_missing */
@@ -541,7 +593,7 @@ static void test_session_isolation_creates_new_worktree_from_existing_worktree(v
    assert(strcmp(first, second) != 0);
 
    char expected[MAX_PATH_LEN];
-   snprintf(expected, sizeof(expected), "%s/aimee/.aimee/worktrees/ccccdddd/main", tmpdir);
+   snprintf(expected, sizeof(expected), "%s/aimee/.aimee/worktrees/ccccdddd-1234-56/main", tmpdir);
    assert(strcmp(second, expected) == 0);
 
    struct stat st;

--- a/src/tests/test_guardrails_cases_b.inc
+++ b/src/tests/test_guardrails_cases_b.inc
@@ -1685,7 +1685,8 @@ static void test_verify_gate_push_registered_worktree_from_nonrepo_cwd(void)
        maindir, "verify:\n  enforce: true\n  steps:\n    - name: build\n      run: echo ok\n");
 
    const char *sid = "reg12345-1234-5678";
-   const char *branch = "aimee/session/reg12345";
+   /* Session branch is keyed by the first 16 chars of the sid (WORKTREE_SID_KEY_LEN). */
+   const char *branch = "aimee/session/reg12345-1234-56";
    assert(worktree_create_sibling(maindir, sid, NULL) == 0);
 
    char wt_path[MAX_PATH_LEN];
@@ -1762,7 +1763,8 @@ static void test_verify_gate_pr_create_registered_worktree_from_nonrepo_cwd(void
    vy_set_global_yaml(nonrepo, verify_yaml);
 
    const char *sid = "prreg123-1234-5678";
-   const char *branch = "aimee/session/prreg123";
+   /* Session branch is keyed by the first 16 chars of the sid (WORKTREE_SID_KEY_LEN). */
+   const char *branch = "aimee/session/prreg123-1234-56";
    assert(worktree_create_sibling(maindir, sid, NULL) == 0);
 
    char wt_path[MAX_PATH_LEN];

--- a/src/tests/test_mcp_git_session_cwd.inc
+++ b/src/tests/test_mcp_git_session_cwd.inc
@@ -59,7 +59,8 @@ static void test_mcp_chdir_repairs_stale_delegate_tracked_cwd(void)
 
    char session_main[MAX_PATH_LEN];
    char stale_delegate[MAX_PATH_LEN];
-   snprintf(session_main, sizeof(session_main), "%s/.aimee/worktrees/102ee97d/main", g_tmpdir);
+   snprintf(session_main, sizeof(session_main), "%s/.aimee/worktrees/102ee97d-session/main",
+            g_tmpdir);
    snprintf(stale_delegate, sizeof(stale_delegate), "%s/.aimee/worktrees/deleg-24/37368447",
             g_tmpdir);
 
@@ -166,9 +167,10 @@ static void test_mcp_chdir_keeps_explicit_managed_worktree_despite_stale_session
 
    char active_worktree[MAX_PATH_LEN];
    char stale_worktree[MAX_PATH_LEN];
-   snprintf(active_worktree, sizeof(active_worktree), "%s/.aimee/worktrees/102ee97d/main",
+   snprintf(active_worktree, sizeof(active_worktree), "%s/.aimee/worktrees/102ee97d-session/main",
             g_tmpdir);
-   snprintf(stale_worktree, sizeof(stale_worktree), "%s/.aimee/worktrees/6ab82f0e/main", g_tmpdir);
+   snprintf(stale_worktree, sizeof(stale_worktree), "%s/.aimee/worktrees/6ab82f0e-session/main",
+            g_tmpdir);
    init_nested_git_repo(active_worktree, "active");
    init_nested_git_repo(stale_worktree, "stale");
 

--- a/src/tests/test_workspace.c
+++ b/src/tests/test_workspace.c
@@ -578,17 +578,20 @@ int main(void)
       for (int i = 0; i < 8; i++) /* lowercase hex */
          assert((a[i] >= '0' && a[i] <= '9') || (a[i] >= 'a' && a[i] <= 'f'));
 
-      /* Agreement: two sids that share the first 8 chars (the worktree-dir
-       * component both paths use) yield the SAME name — so a dispatch sid of
-       * "deleg-14" and a compute sid of "deleg-14-suffix" still collapse to one
-       * worktree. */
-      assert(worktree_delegate_work_name("deleg-14-suffix", c, sizeof(c)) == 0);
-      assert(strcmp(a, c) == 0);
+      /* Agreement across the dispatch/compute split: dispatch keys the worktree
+       * on session_id(), compute on the delegation id; for one delegation those
+       * resolve to the same id, so the work-names must match. Drift PAST the
+       * session-key width is tolerated — two sids that share the first
+       * WORKTREE_SID_KEY_LEN (16) chars collapse to one worktree. */
+      assert(worktree_delegate_work_name("aimee-task-abcdef0123456789", b, sizeof(b)) == 0);
+      assert(worktree_delegate_work_name("aimee-task-abcdef0123456789-retry", c, sizeof(c)) == 0);
+      assert(strcmp(b, c) == 0);
 
-      /* Distinct delegate ids generally differ (no accidental collapse). */
+      /* Sids that diverge WITHIN the first 16 chars stay distinct — unrelated
+       * delegations never collapse onto one worktree. */
       char d[32] = "";
-      assert(worktree_delegate_work_name("deleg-15", d, sizeof(d)) == 0);
-      assert(strcmp(a, d) != 0);
+      assert(worktree_delegate_work_name("aimee-task-ffffffff00000000", d, sizeof(d)) == 0);
+      assert(strcmp(b, d) != 0);
 
       /* arg guards */
       assert(worktree_delegate_work_name(NULL, a, sizeof(a)) == -1);

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -1042,9 +1042,8 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
    /* Hard failure: isolation could not be established. Log loudly — the caller
     * continues without a per-session worktree, so writes fall to the guardrail
     * that blocks edits outside a managed worktree. */
-   LOG_ERROR("workspace",
-             "failed to create worktree '%s' (base=%s): %s; branch-attach retry: %s", wt_path,
-             base_branch, out ? out : "unknown", out2 ? out2 : "unknown");
+   LOG_ERROR("workspace", "failed to create worktree '%s' (base=%s): %s; branch-attach retry: %s",
+             wt_path, base_branch, out ? out : "unknown", out2 ? out2 : "unknown");
    fprintf(stderr, "aimee: failed to create worktree at %s: %s\n", wt_path, out ? out : "unknown");
    free(out);
    free(out2);

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -479,11 +479,35 @@ char *resolve_proposal_path(const char *proposal)
 /* --- Worktree Lifecycle --- */
 #include <unistd.h>
 
+/* Number of leading session-id characters used to key per-session worktree
+ * paths and branch names. Widened from 8: an 8-hex prefix is only 32 bits of
+ * entropy, so two independent sessions could draw the same key, land on the
+ * same worktree directory / session branch, and end up sharing a checkout.
+ * 16 chars lifts a well-minted id to 64 bits. Session ids shorter than this
+ * (legacy 8-hex launch ids) map to themselves, so worktrees created before the
+ * change keep their existing path. */
+#define WORKTREE_SID_KEY_LEN 16
+
+/* Derive the stable worktree key from a session id: its first
+ * WORKTREE_SID_KEY_LEN characters. All worktree path/branch derivations route
+ * through here so every call site agrees on the same key. out must hold at
+ * least WORKTREE_SID_KEY_LEN + 1 bytes. */
+static void worktree_session_key(const char *sid, char *out, size_t cap)
+{
+   if (!out || cap == 0)
+      return;
+   out[0] = '\0';
+   if (!sid)
+      return;
+   snprintf(out, cap, "%.*s", (int)WORKTREE_SID_KEY_LEN, sid);
+}
+
 /* Compute the expected aimee-managed worktree path for a git repo and session.
  * For git_root="/root/dev/aimee" and session "abc123...", produces
- * "/root/dev/aimee/.aimee/worktrees/abc12345/main".
+ * "/root/dev/aimee/.aimee/worktrees/<key>/main" where <key> is the session
+ * key (see worktree_session_key).
  * If work_name is non-NULL (e.g. "task01"), produces
- * "/root/dev/aimee/.aimee/worktrees/abc12345/task01" to avoid collisions
+ * "/root/dev/aimee/.aimee/worktrees/<key>/task01" to avoid collisions
  * when multiple delegates run in the same session. */
 int worktree_sibling_path(const char *git_root, const char *sid, const char *work_name,
                           char *wt_buf, size_t wt_len)
@@ -491,9 +515,8 @@ int worktree_sibling_path(const char *git_root, const char *sid, const char *wor
    if (!git_root || !sid || !wt_buf)
       return -1;
 
-   /* Use first 8 chars of session ID */
-   char short_id[12];
-   snprintf(short_id, sizeof(short_id), "%.8s", sid);
+   char short_id[WORKTREE_SID_KEY_LEN + 1];
+   worktree_session_key(sid, short_id, sizeof(short_id));
 
    if (work_name && work_name[0])
       snprintf(wt_buf, wt_len, "%s/.aimee/worktrees/%s/%s", git_root, short_id, work_name);
@@ -512,16 +535,16 @@ int worktree_sibling_path(const char *git_root, const char *sid, const char *wor
  * deterministically from the session id makes both paths resolve to the SAME
  * sibling worktree, so whichever runs second idempotently reuses the first's
  * worktree (worktree_create_sibling_at_ref returns the existing one) instead of
- * spawning a duplicate. The hash is over the first 8 chars of the sid — exactly
- * the component both paths already share as the worktree directory — so the two
- * call sites agree even if their full sid strings differ. */
+ * spawning a duplicate. The hash is over the session key (worktree_session_key)
+ * — exactly the component both paths already share as the worktree directory —
+ * so the two call sites agree even if their full sid strings differ. */
 int worktree_delegate_work_name(const char *sid, char *out, size_t cap)
 {
    if (!sid || !out || cap < 9)
       return -1;
-   char short_id[12];
-   snprintf(short_id, sizeof(short_id), "%.8s", sid);
-   /* FNV-1a (32-bit) over the short id — stable across processes and builds. */
+   char short_id[WORKTREE_SID_KEY_LEN + 1];
+   worktree_session_key(sid, short_id, sizeof(short_id));
+   /* FNV-1a (32-bit) over the session key — stable across processes and builds. */
    uint32_t h = 2166136261u;
    for (const char *p = short_id; *p; p++)
    {
@@ -819,51 +842,73 @@ int worktree_find_branch_registered(const char *branch, char *out_dir, size_t ou
    return found;
 }
 
-/* Detect the best base branch for a new worktree rooted at git_root.
- * Prefers the current checked-out branch; falls back to main/origin/main/HEAD. */
+/* Detect the base branch for a NEW worktree rooted at git_root.
+ *
+ * A fresh session must start from the repository's DEFAULT branch, not from
+ * whatever branch the source checkout happens to be sitting on — otherwise a
+ * session forks off a random feature branch and inherits unrelated WIP. Order:
+ *   1. origin/HEAD  — the remote default branch (e.g. "origin/main"); used as
+ *      the base ref directly so the worktree tracks the latest fetched default.
+ *   2. local main / master / trunk — common defaults when no remote HEAD is set.
+ *   3. current HEAD — last resort (detached/empty repo, or a default-less repo).
+ * Callers that want a specific base (delegates inheriting a parent, or the
+ * session-checkout path that bases on origin/<primary>) pass base_ref instead
+ * and never reach here. */
 void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len)
 {
    if (!git_root || !buf || buf_len == 0)
       return;
    snprintf(buf, buf_len, "HEAD"); /* safe default */
 
-   int found = 0;
    char cmd[MAX_PATH_LEN + 128];
    int rc;
 
-   snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --abbrev-ref HEAD 2>/dev/null", git_root);
+   /* 1. Remote default branch via origin/HEAD. symbolic-ref --short yields
+    * e.g. "origin/main"; base directly off that remote-tracking ref. */
+   snprintf(cmd, sizeof(cmd),
+            "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null", git_root);
    char *out = run_cmd(cmd, &rc);
    if (rc == 0 && out && out[0])
    {
-      /* Strip trailing newline */
       size_t len = strlen(out);
-      while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
+      while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r' || out[len - 1] == ' '))
          out[--len] = '\0';
-      /* Use if it's a real branch, not a detached HEAD */
-      if (len > 0 && strcmp(out, "HEAD") != 0)
+      if (len > 0)
       {
          snprintf(buf, buf_len, "%s", out);
-         found = 1;
+         free(out);
+         return;
       }
    }
    free(out);
 
-   if (!found)
+   /* 2. Common local default branches. */
+   const char *candidates[] = {"main", "master", "trunk"};
+   for (int b = 0; b < 3; b++)
    {
-      const char *candidates[] = {"main", "origin/main", "HEAD"};
-      for (int b = 0; b < 3; b++)
+      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
+               git_root, candidates[b]);
+      char *cand_out = run_cmd(cmd, &rc);
+      free(cand_out);
+      if (rc == 0)
       {
-         snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify '%s' 2>/dev/null", git_root,
-                  candidates[b]);
-         char *cand_out = run_cmd(cmd, &rc);
-         free(cand_out);
-         if (rc == 0)
-         {
-            snprintf(buf, buf_len, "%s", candidates[b]);
-            break;
-         }
+         snprintf(buf, buf_len, "%s", candidates[b]);
+         return;
       }
    }
+
+   /* 3. Last resort: the current branch (may be detached -> stays "HEAD"). */
+   snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --abbrev-ref HEAD 2>/dev/null", git_root);
+   out = run_cmd(cmd, &rc);
+   if (rc == 0 && out && out[0])
+   {
+      size_t len = strlen(out);
+      while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r'))
+         out[--len] = '\0';
+      if (len > 0 && strcmp(out, "HEAD") != 0)
+         snprintf(buf, buf_len, "%s", out);
+   }
+   free(out);
 }
 
 static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
@@ -877,8 +922,8 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       return -1;
 
    /* Create branch name from session ID (and optional work name) */
-   char short_id[12];
-   snprintf(short_id, sizeof(short_id), "%.8s", sid);
+   char short_id[WORKTREE_SID_KEY_LEN + 1];
+   worktree_session_key(sid, short_id, sizeof(short_id));
    char branch_name[128];
    if (work_name && work_name[0])
       snprintf(branch_name, sizeof(branch_name), "aimee/session/%s/%s", short_id, work_name);
@@ -909,10 +954,10 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       snprintf(base_branch, sizeof(base_branch), "%s", base_ref);
    else
    {
-      /* Detect base branch: prefer the workspace's current branch so worktrees
-       * are rooted there rather than always on main. Falls back to main /
-       * origin/main / HEAD when in a detached-HEAD state or when the lookup
-       * fails (e.g. empty repo). */
+      /* Detect base branch: root the worktree on the repository's DEFAULT
+       * branch so a fresh session always starts from there rather than from
+       * whatever branch the source checkout happens to have checked out.
+       * Falls back to main / master / trunk / HEAD when no default is known. */
       worktree_detect_base_branch(git_root, base_branch, sizeof(base_branch));
    }
 
@@ -925,11 +970,18 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       platform_mkdir_p(wt_parent, 0755);
    }
 
-   /* Create the worktree */
+   /* Clear stale registrations: a worktree dir removed out-of-band (rmdir
+    * above, manual rm -rf, a crash) leaves an entry under .git/worktrees that
+    * makes `git worktree add` fail with "already exists". Pruning first lets
+    * the add below succeed instead of collapsing into the shared checkout. */
    char cmd[MAX_PATH_LEN * 2 + 256];
+   int rc;
+   snprintf(cmd, sizeof(cmd), "git -C '%s' worktree prune 2>/dev/null", git_root);
+   free(run_cmd(cmd, &rc));
+
+   /* Create the worktree on a fresh session branch. */
    snprintf(cmd, sizeof(cmd), "git -C '%s' worktree add '%s' -b '%s' '%s' 2>&1", git_root, wt_path,
             branch_name, base_branch);
-   int rc;
    char *out = run_cmd(cmd, &rc);
 
    if (rc == 0)
@@ -947,8 +999,55 @@ static int worktree_create_sibling_at_ref(const char *git_root, const char *sid,
       return 0;
    }
 
+   /* Recovery 1 — lost a creation race: another path (e.g. the SessionStart
+    * hook and the launch path both firing) may have just created this exact
+    * worktree. If the path is now a valid worktree, reuse it idempotently
+    * rather than reporting failure. */
+   if (stat(wt_path, &st) == 0 && S_ISDIR(st.st_mode))
+   {
+      char git_file[MAX_PATH_LEN];
+      snprintf(git_file, sizeof(git_file), "%s/.git", wt_path);
+      struct stat git_st;
+      if (stat(git_file, &git_st) == 0)
+      {
+         LOG_INFO("workspace", "worktree '%s' already present (creation race) - reusing", wt_path);
+         free(out);
+         worktree_registry_record(git_root, wt_path, branch_name, sid, work_name);
+         return 0;
+      }
+   }
+
+   /* Recovery 2 — the session branch already exists with no worktree attached
+    * (a prior worktree was force-removed by GC while still ahead, leaving its
+    * branch behind, and this session drew the same key). Attach the existing
+    * branch into a new worktree so the session still gets isolation instead of
+    * silently sharing the source checkout. Preserves the prior branch's work. */
+   snprintf(cmd, sizeof(cmd), "git -C '%s' worktree add '%s' '%s' 2>&1", git_root, wt_path,
+            branch_name);
+   char *out2 = run_cmd(cmd, &rc);
+   if (rc == 0)
+   {
+      LOG_WARN("workspace", "reattached pre-existing branch '%s' to new worktree '%s'", branch_name,
+               wt_path);
+      fprintf(stderr, "aimee: created worktree at %s (reused branch %s)\n", wt_path, branch_name);
+      free(out);
+      free(out2);
+      worktree_registry_record(git_root, wt_path, branch_name, sid, work_name);
+#ifndef AIMEE_DB1_DISABLED
+      mcp_git_branch_own_register(git_root, branch_name);
+#endif
+      return 0;
+   }
+
+   /* Hard failure: isolation could not be established. Log loudly — the caller
+    * continues without a per-session worktree, so writes fall to the guardrail
+    * that blocks edits outside a managed worktree. */
+   LOG_ERROR("workspace",
+             "failed to create worktree '%s' (base=%s): %s; branch-attach retry: %s", wt_path,
+             base_branch, out ? out : "unknown", out2 ? out2 : "unknown");
    fprintf(stderr, "aimee: failed to create worktree at %s: %s\n", wt_path, out ? out : "unknown");
    free(out);
+   free(out2);
    return -1;
 }
 


### PR DESCRIPTION
## What
Two worktree-isolation fixes in the aimee runtime.

### 1. New sessions base off the default branch
`worktree_detect_base_branch()` preferred the source checkout's **current** branch, so a fresh session forked off whatever feature branch happened to be checked out and inherited unrelated WIP. It now prefers the repo **default branch** (`origin/HEAD`) → local `main`/`master`/`trunk` → current HEAD only as a last resort. This is the chokepoint for every fresh-session path (SessionStart hook, server, orchestrator, and the `session_checkout_worktrees` fallback used when no `project.yaml` `primary_branch` is set). Delegates pass an explicit `base_ref` and still intentionally inherit their parent.

### 2. Harden against worktree key collisions
The per-session worktree path and branch were keyed off only the first **8 hex chars** of the session id (32 bits), and `cmd_launch` minted ids from just 4 random bytes — independent sessions could draw the same key, land on the same worktree dir / `aimee/session/<key>` branch, and silently share a checkout.

- Centralized the key in `worktree_session_key()` and widened it to 16 chars (`WORKTREE_SID_KEY_LEN`). Legacy ≤16-char ids map to themselves, so pre-existing worktrees keep their path.
- `cmd_launch` now mints 10-byte (20-hex) ids so the key carries real entropy (UB-free LCG fallback).
- `worktree_create_sibling_at_ref` prunes stale registrations, recovers from creation races and leftover session branches, and logs `LOG_ERROR` loudly on hard failure instead of dropping the session into the shared checkout.

## Tests
Updated `test_worktree_sibling_path` (16-char key + legacy-id case), inverted `test_worktree_detect_base_branch_active` to assert default-over-feature-branch, added `test_worktree_detect_base_branch_local_default`, and realigned the path/branch fixtures in `test_mcp_git_session_cwd.inc` and the two verify-gate tests in `test_guardrails_cases_b.inc` that relied on 8-char truncation.

## Notes
- Built/tested by CI (no local toolchain in the authoring env).
- **Deploy note:** in-flight UUID-keyed sessions relocate their worktree (8→16-char key) on their next hook after deploy — one-time and self-healing; best landed between sessions.
