### PR TITLE
fix(tmux): one tmux session per aimee session, not per agent

### DIFF
--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -22,8 +22,24 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    (void)max_tokens;
    (void)temperature;
 
+   /* One tmux session per aimee session, keyed purely on the session id and
+    * agent-agnostic: every CLI agent driven through tmux for a given session
+    * shares that session's own tmux session, and DIFFERENT aimee sessions get
+    * DIFFERENT tmux sessions — so concurrent sessions can never paste into or
+    * capture from (or kill, on a recv timeout) each other's pane. The bound
+    * session id is the webchat/turn session via session_id_set_override; embed
+    * it literally (cli_session_make_name sanitizes chars tmux rejects). When a
+    * session id is in play we always reuse so the CLI persists across the
+    * session's turns. */
+   const char *aimee_sid = session_id();
+   int reuse = agent->session_reuse;
    char *sess_name;
-   if (agent->session_reuse)
+   if (aimee_sid && aimee_sid[0])
+   {
+      sess_name = cli_session_make_name(aimee_sid, "cli");
+      reuse = 1;
+   }
+   else if (agent->session_reuse)
       sess_name = cli_session_make_name(agent->name, "shared");
    else
    {
@@ -52,7 +68,7 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       cwd[0] = '\0';
 
    cli_session_t sess;
-   int rc = cli_session_create(&sess, sess_name, cli_cmd, cwd, agent->session_reuse);
+   int rc = cli_session_create(&sess, sess_name, cli_cmd, cwd, reuse);
    free(sess_name);
    if (rc != 0)
    {
@@ -115,7 +131,7 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    char *clean = cli_session_strip_ansi(raw);
    free(raw);
 
-   if (!agent->session_reuse)
+   if (!reuse)
       cli_session_destroy(&sess);
 
    if (!clean || !clean[0])


### PR DESCRIPTION
## Problem

Any CLI agent driven through the tmux runtime (`agent_runtime_tmux.c`) keyed its tmux session on the **agent name** — `<agent>-shared` under `session_reuse`. So every aimee session that drove a given agent shared **one tmux pane**. As you open more sessions concurrently they:

- interleave `load-buffer`/`paste-buffer`/`send-keys` and `capture-pane` on the same pane (the input buffer name `aimee_msg` and `/tmp/aimee_msg_<pid>.txt` are also shared within the one server process), and
- on any one session's recv timeout, run `cli_session_destroy` → `tmux kill-session` on the **shared** name, tearing the pane out from under every other concurrent session.

Symptom: sessions die mid-turn, worse the more you run at once.

## Fix

Key the tmux session purely on the bound aimee session id (`session_id()`, set via `session_id_set_override` on the turn worker) — agent/model-agnostic. Different aimee sessions get different tmux sessions; a `kill-session` only ever targets the offending session's own pane. Reuse is forced on when a session id is in play so the CLI persists across the session's turns; the create/cleanup paths follow the computed `reuse` flag. With no session id bound, falls back to the legacy agent-keyed/unique naming.

One file, `src/posix/agent_runtime_tmux.c`.

## Test

- `make -C src lint` → ok
- `make -C src unit-tests` → all passed

## Note

Concurrent same-session *delegates* would share the session pane under this rule (the primary turn is serialized by the presence turn-lock, so it's collision-free). Isolating those too is a follow-up: extend the key to `session-id + delegation-id`.