### PR TITLE
feat(embedder): recorded embedding dim is a source, not just a guard (autodim §2a)

### DIFF
--- a/docs/proposals/pending/embedder-runtime-fetch-autodim.plan.md
+++ b/docs/proposals/pending/embedder-runtime-fetch-autodim.plan.md
@@ -1,0 +1,197 @@
+# Implementation plan — embedder auto-dimension §2a: recorded-dim precedence
+
+Plan for [embedder-runtime-fetch-autodim.md](embedder-runtime-fetch-autodim.md),
+**scoped to §2a only**: make the recorded `schema_embedding_dim` an actual
+*source* of the runtime embedding dimension, under the proposal's precedence
+**operator-pin > recorded > probe**. Grounded on `origin/testing`.
+
+## Why this slice (and why now)
+
+`#337` made `kb_meta.schema_embedding_dim` a **guard**: `db_apply_schema_postgres`
+calls `db2_embedding_dim_record_or_check()`, which records the dim on first apply
+and *refuses* a later mismatch. But nothing ever **reads that row back as the
+dimension to use** — there is no `db2_embedding_dim_get()`, and the runtime dim is
+fixed entirely from the operator pin:
+
+- `cmd_core.c:51` and `kb/kb_main.c:544` both call
+  `db2_set_embedding_dim(config_resolve_embedding_dim(cfg))` **before** `db2_init()`.
+- `config_resolve_embedding_dim()` (`config_database.c:67`) returns
+  `AIMEE_EMBEDDING_DIM` (env) ▸ else `cfg->embedding_dim` ▸ else `0` → which
+  `db2_embedding_dim()` reports as the **1024 default**.
+
+Consequence: on a **populated** DB where the operator did *not* pin a dim, the
+recorded dim is ignored. If the recorded corpus is 2560 but the unpinned default
+is 1024, today's guard **refuses the apply** (mismatch) — the operator must
+hand-set the pin to match what the DB already knows. That is the exact
+"keep `embedding_dim` manually in sync" failure the proposal removes (§"What this
+removes", §2 precedence). The recorded value should simply **win over the
+default** when the operator hasn't pinned.
+
+## Scope (and explicit non-scope)
+
+**In:** the *recorded* leg of the precedence, plus the pure selector that encodes
+the full precedence so §2b can drop the probe in with a one-line change.
+
+**Out (separate, live-stack slices — named here so this is a reserved contract,
+not forgotten work):**
+- **§2b** — fresh-DB auto-derive from the embedder `/health` **probe** under
+  `pg_try_advisory_lock`, with a wait budget. Needs a live embedder; this slice
+  leaves the `probed` input wired but always `0` (reserved, exactly as P0 reserved
+  `ING_XF_*`).
+- **§2c** — the **destructive** double-gated auto-reembed
+  (`kb_reembed_on_dim_change` + `--confirm` + `/health=maintenance`). Out of scope;
+  this slice never drops or rewrites a vector.
+
+This slice changes behavior **only** in the populated-DB, operator-did-not-pin,
+recorded-differs-from-default case — which is a *refused/wrong* outcome today.
+Pinned behavior and fresh-DB behavior are byte-identical to today.
+
+## Design
+
+> **Plan-review R1 (2026-06-21, mistral APPROVE / minimax CHANGES) folded in.**
+> Single precedence function (no separate dead-code selector); precise
+> pin-detection; `g_embed_dim_pinned` reset on shutdown; all three call sites
+> enumerated; structured-logger WARN; bounded reader. The reserved-`probed`
+> three-arg selector is **dropped** (YAGNI) — `probed` returns in §2b.
+
+### 1. One precedence function — pure, exported, unit-tested directly (no DB)
+
+The §2a precedence collapses to a single rule. Ship **one** function (kills the
+plan-R1 "selector is dead code, db2_init uses a different helper" blocker — db2_init
+calls *this* function, and the unit test calls it too):
+
+```c
+/* db2/lifecycle.h + db2_init.c — the effective embedding dim under §2a precedence
+ * (pin > recorded > configured-default). `pinned`: operator gave a positive pin.
+ * `configured`: the dim already set pre-init (the pin when pinned, else the
+ * 1024-or-cfg default). `recorded`: kb_meta.schema_embedding_dim, or <=0 if absent.
+ * Pure; no globals, no I/O — the one place §2a's precedence lives. */
+int db2_effective_dim(int pinned, int configured, int recorded);
+```
+
+`if (pinned) return configured;` (pin authoritative) `else if (recorded > 0)
+return recorded;` (recorded wins over default) `else return configured;` (default).
+
+### 2. Recorded-dim reader (one-row read; testable against the sqlite shim)
+
+```c
+/* db2/db_schema.h / .c — read the recorded schema dim. Returns the recorded dim
+ * when in range (1..EMBED_MAX_DIM), else 0 — the "absent" signal db2_effective_dim
+ * treats as not-present. Out-of-range/garbage/overflow → 0 (defends strtol against
+ * operator typos; per plan-R1 SUGG 5). Read-only; never writes. Uses aimee_pg_*
+ * so it works against Postgres and the sqlite test shim. */
+int db2_embedding_dim_get(void *conn);
+```
+
+`SELECT value FROM kb_meta WHERE key = 'schema_embedding_dim'` → `strtol` → return
+the value iff `1 <= v <= EMBED_MAX_DIM`, else 0. (The corrupt/non-numeric *write/
+check* path keeps its loud refusal in `record_or_check`; the *reader* stays quiet
+and returns 0 so the caller falls through to its default — a missing/garbage row
+must not crash a read.)
+
+### 3. "Operator pinned?" signal — defined precisely (plan-R1 BLOCKER 2)
+
+```c
+/* config_database.h / .c — 1 iff the operator pinned a positive dim. Defined as
+ * config_resolve_embedding_dim(cfg) > 0 so "pinned" is exactly consistent with the
+ * value db2_set_embedding_dim received: AIMEE_EMBEDDING_DIM="0"/non-numeric/empty
+ * is NOT a pin (config_resolve already ignores it -> 0), nor is an unset cfg dim. */
+int config_embedding_dim_is_pinned(const config_t *cfg);
+```
+
+The db2 layer stays config-free; the caller passes the bool via a setter mirroring
+`db2_set_embedding_dim`:
+
+```c
+void db2_set_embedding_dim_pinned(int pinned);   /* db2/lifecycle.h + db2_init.c */
+```
+
+`g_embed_dim_pinned` is a file-static in `db2_init.c` (default 0). **Reset to 0 in
+`db2_shutdown()`** (db2_init.c:619) so a daemon reopen / a later test cannot inherit
+a previous run's pinned state (plan-R1 BLOCKER 3).
+
+### 4. Wire the recorded leg at the one post-connect boundary (no pre-init change)
+
+Pre-init ordering is **untouched**: each caller still
+`db2_set_embedding_dim(config_resolve_embedding_dim(cfg))`; it additionally calls
+`db2_set_embedding_dim_pinned(...)` beside it (§Files lists all three sites). Inside
+`db2_init()`, after the connection opens and **before** `db_apply_schema_postgres()`:
+
+```c
+int dim = db2_embedding_dim();                              /* pin or default */
+int rec = g_embed_dim_pinned ? 0 : db2_embedding_dim_get(conn);
+int eff = db2_effective_dim(g_embed_dim_pinned, dim, rec);  /* the one precedence fn */
+if (eff != dim) {
+    LOG_WARN("db2", "using recorded embedding dim %d (no operator pin; configured "
+                    "default was %d)", eff, dim);           /* unmissable; plan-R1 SUGG 4 */
+    dim = eff;
+    db2_set_embedding_dim(dim);                             /* halfvec cols + all readers agree */
+}
+if (db_apply_schema_postgres(conn, dim, ...) ...) ...
+```
+
+`record_or_check(dim)` inside `db_apply_schema_postgres` then sees `dim == recorded`
+(match → no-op) on the populated path, instead of refusing. Fresh DB: `rec == 0`,
+`eff == dim` → identical to today. Pinned: `rec` forced to 0, `eff == dim` →
+identical to today (mismatch still refused downstream, catching a misconfigured pin).
+
+## Files
+
+- `src/config_database.c` / `src/headers/config_database.h` —
+  `config_embedding_dim_is_pinned`.
+- `src/db2/db_schema.c` / `src/db2/db_schema.h` — `db2_embedding_dim_get`.
+- `src/db2/db2_init.c` / `src/db2/lifecycle.h` — `db2_effective_dim` (pure),
+  `db2_set_embedding_dim_pinned`, the `g_embed_dim_pinned` static + its reset in
+  `db2_shutdown`, and the recorded-preference block in `db2_init`.
+- **All three** `db2_set_embedding_dim(...)` call sites get a companion
+  `db2_set_embedding_dim_pinned(...)` (plan-R1 SUGG 2 — the audit found a third):
+  `src/cmd_core.c:51` and `src/kb/kb_main.c:544`
+  (`config_embedding_dim_is_pinned(cfg)`), and `src/cmd_doctor.c:68`
+  (sets the dim from `cfg->embedding_dim`, so pinned = `cfg->embedding_dim > 0`).
+- Tests: extend `src/tests/test_embedding_dim.c` (shim) + `src/tests/test_config.c`
+  (the env/pin block already there). `db2_effective_dim` is pure → unit-test it
+  directly. Preferring to extend existing files avoids a new `Rules.mk` target.
+
+All files stay well under the 2000-line cap.
+
+## Tests (all local, no live stack)
+
+1. **`db2_effective_dim` truth table** (pure, the precedence contract):
+   `(pinned=0, cfg=1024, rec=2560) → 2560` (recorded wins over default);
+   `(1, 1024, 2560) → 1024` (pin authoritative);
+   `(0, 1024, 0) → 1024` (fresh DB, nothing recorded);
+   `(0, 2560, 2560) → 2560` (match — and the *caller* must then NOT log / NOT
+   re-set, since `eff == dim`; plan-R1 SUGG 3);
+   `(0, 1024, -1) → 1024` (non-positive recorded treated as absent).
+2. **`config_embedding_dim_is_pinned`** — `AIMEE_EMBEDDING_DIM="2560"` → 1;
+   `="0"` → 0; `="garbage"` → 0; unset + `cfg->embedding_dim=1024` → 1; unset +
+   `cfg->embedding_dim=0` → 0 (plan-R1 BLOCKER 2 — the env="0"/non-numeric rows are
+   the point). Reuses the setenv/unsetenv block already in `test_config.c`.
+3. **`db2_embedding_dim_get`** (shim) — no row → 0; recorded 2560 → 2560; empty /
+   `garbage` → 0; out-of-range (`5000 > EMBED_MAX_DIM`) → 0 (plan-R1 SUGG 5).
+   Mirrors the existing fixture in `test_embedding_dim.c`.
+4. **Pinned-state isolation** (plan-R1 BLOCKER 3) — set pinned=0 then exercise a
+   path; `db2_shutdown()`; assert a subsequent default read sees pinned reset (a
+   pinned-mismatch case run *after* an unpinned case still refuses).
+5. **Regression** — existing `test_embedding_dim` mismatch-refusal assertions pass
+   unchanged (its direct `record_or_check` calls are unaffected).
+
+## Build / verification
+
+- `make lint` + `make unit-tests` before push (catches the usual generated-surface
+  + test-link gaps — see prior sweep notes). Build the real feature set, not just
+  defaults.
+- **Not verifiable locally (honest deferral):** the live populated-DB-on-Postgres
+  override and the §2b probe handshake need a real PG + embedder. Mitigated by
+  routing the decision through the shim-tested pure helper (#4) so the *logic* is
+  fully covered; the live wiring is a thin call into tested code.
+
+## Risks / rollback
+
+- **Blast radius is the unpinned-populated case only** — today a refused/wrong
+  result, so the change can only improve it. Fresh-DB and pinned paths are
+  unchanged (asserted by the truth-table + integration tests).
+- A recorded row that is **corrupt** makes the reader return 0 → falls through to
+  today's behavior (no regression, no crash).
+- Rollback is a straight revert (one feature, additive symbols + 3 call-site lines).
+- No schema change, no config-file change, no wire/provider dependency.

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -49,6 +49,7 @@ static int bootstrap_db2(const config_t *cfg, int json_output)
    }
 
    db2_set_embedding_dim(config_resolve_embedding_dim(cfg));
+   db2_set_embedding_dim_pinned(config_embedding_dim_is_pinned(cfg));
    if (db2_init(cfg->db2_url) == 0)
    {
       int schema_ok = 0;

--- a/src/cmd_doctor.c
+++ b/src/cmd_doctor.c
@@ -5,6 +5,7 @@
 #include "commands.h"
 #include "db1.h"
 #include "db2/code_index.h"
+#include "config_database.h"
 #include "db2/memory_payload.h"
 #include "db2/memory_query.h"
 #include "hardware_probe.h"
@@ -65,7 +66,14 @@ static doctor_db2_session_t check_database(check_result_t *r, config_t *cfg)
    {
       session.ready = 1;
    }
-   else if ((db2_set_embedding_dim(cfg->embedding_dim), db2_init(cfg->db2_url)) == 0)
+   /* §2a: resolve the dim + pin the same way cmd_core/kb_main do — via
+    * config_resolve_embedding_dim (so doctor now honors AIMEE_EMBEDDING_DIM too,
+    * intentionally uniform) plus the pin flag, so an unpinned doctor run derives
+    * the recorded dim rather than refusing on the 1024 default. A genuine
+    * pin/recorded mismatch still surfaces via #337's record_or_check guard. */
+   else if ((db2_set_embedding_dim(config_resolve_embedding_dim(cfg)),
+             db2_set_embedding_dim_pinned(config_embedding_dim_is_pinned(cfg)),
+             db2_init(cfg->db2_url)) == 0)
    {
       session.ready = 1;
       session.owned = 1;

--- a/src/config_database.c
+++ b/src/config_database.c
@@ -79,3 +79,13 @@ int config_resolve_embedding_dim(const config_t *cfg)
    }
    return dim;
 }
+
+/* §2a: pinned iff the resolved operator dim is positive. Keeping this defined in
+ * terms of config_resolve_embedding_dim guarantees the pin flag agrees with the
+ * dim that was actually set (env "0"/non-numeric/empty and an unset cfg both
+ * resolve to 0 → not pinned), so the recorded-dim override fires on exactly the
+ * deployments that did not pin. */
+int config_embedding_dim_is_pinned(const config_t *cfg)
+{
+   return config_resolve_embedding_dim(cfg) > 0;
+}

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -13,6 +13,7 @@
 #include "db2_pool.h"
 #include "db_postgres.h"
 #include "db_schema.h"
+#include "../headers/log.h" /* LOG_WARN */
 #include "entity_edges.h"
 #include "eval_support.h"
 
@@ -53,6 +54,11 @@ static pthread_mutex_t g_init_lock = PTHREAD_MUTEX_INITIALIZER;
  * reports the 1024 default (the default embedder is pplx-0.6b). */
 static int g_embed_dim = 0;
 
+/* §2a: whether the operator pinned the dim. When 0 (default) and nothing was
+ * pinned, db2_init prefers a recorded kb_meta.schema_embedding_dim over the
+ * default. Reset in db2_shutdown so a reopen / a later test never inherits it. */
+static int g_embed_dim_pinned = 0;
+
 void db2_set_embedding_dim(int dim)
 {
    g_embed_dim = dim;
@@ -61,6 +67,20 @@ void db2_set_embedding_dim(int dim)
 int db2_embedding_dim(void)
 {
    return g_embed_dim > 0 ? g_embed_dim : 1024;
+}
+
+void db2_set_embedding_dim_pinned(int pinned)
+{
+   g_embed_dim_pinned = pinned ? 1 : 0;
+}
+
+int db2_effective_dim(int pinned, int configured, int recorded)
+{
+   if (pinned)
+      return configured; /* operator pin is authoritative */
+   if (recorded > 0)
+      return recorded; /* recorded wins over the configured default */
+   return configured;  /* fresh DB / nothing recorded: the default */
 }
 static pthread_key_t g_thread_conn_key;
 static pthread_once_t g_thread_conn_key_once = PTHREAD_ONCE_INIT;
@@ -379,8 +399,22 @@ int db2_init(const char *libpq_url)
     * embedding_dim drives the dimension of the DB2 halfvec embedding columns.
     * The dimension is supplied by db2_set_embedding_dim() at startup (the server
     * and aimee-kb, which hold the loaded config) so this low-level layer stays
-    * config-free; it defaults to 2560 when unset. */
-   if (db_apply_schema_postgres(conn, db2_embedding_dim(), errbuf, sizeof(errbuf)) != 0)
+    * config-free; it defaults to 1024 when unset. */
+   int configured_dim = db2_embedding_dim();
+   /* §2a precedence: when the operator did NOT pin a dim, prefer the recorded
+    * kb_meta.schema_embedding_dim (the populated-DB source of truth) over the
+    * default, so an unpinned deploy self-derives its dim instead of refusing the
+    * apply. Pinned and fresh-DB paths keep configured_dim → behavior-identical. */
+   int recorded_dim = g_embed_dim_pinned ? 0 : db2_embedding_dim_get(conn);
+   int effective_dim = db2_effective_dim(g_embed_dim_pinned, configured_dim, recorded_dim);
+   if (effective_dim != configured_dim)
+   {
+      LOG_WARN("db2",
+               "using recorded embedding dim %d (no operator pin; configured default was %d)",
+               effective_dim, configured_dim);
+      db2_set_embedding_dim(effective_dim); /* halfvec columns + all readers agree */
+   }
+   if (db_apply_schema_postgres(conn, effective_dim, errbuf, sizeof(errbuf)) != 0)
    {
       /* Surface the postgres error so callers see WHICH statement failed.
        * Silently returning -1 hid bugs like a stale CREATE INDEX referencing
@@ -628,6 +662,12 @@ void db2_shutdown(void)
       g_conn = NULL;
    }
    g_pg_url[0] = '\0';
+   /* §2a: clear the dim + pinned flag so a reopen / a later unit test starts from
+    * the unpinned default rather than inheriting this run's state. db2_init may
+    * have re-set g_embed_dim to a recorded value, so reset it for symmetry — every
+    * real caller sets it again via db2_set_embedding_dim before the next init. */
+   g_embed_dim = 0;
+   g_embed_dim_pinned = 0;
    pthread_mutex_unlock(&g_init_lock);
 }
 

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -169,6 +169,33 @@ int db2_embedding_dim_record_or_check(void *conn, int embed_dim, char *errbuf, s
    return 0; /* recorded == embed_dim — fresh insert or matching existing row */
 }
 
+/* §2a: quiet, read-only companion to record_or_check. Returns the recorded dim
+ * only when it parses cleanly into 1..EMBED_MAX_DIM; any other state (no row,
+ * empty, non-numeric, trailing junk, non-positive, or out of range) returns 0 so
+ * the caller falls through to its configured default. Never sets an error. */
+int db2_embedding_dim_get(void *conn)
+{
+   if (!conn)
+      return 0;
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "SELECT value FROM kb_meta WHERE key = 'schema_embedding_dim'", err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_step_t step = aimee_pg_step(st, err, sizeof(err));
+   int dim = 0;
+   if (step == AIMEE_PG_ROW)
+   {
+      const char *valtxt = aimee_pg_column_text(st, 0);
+      char *endp = NULL;
+      long v = (valtxt && *valtxt) ? strtol(valtxt, &endp, 10) : 0;
+      if (valtxt && *valtxt && endp && *endp == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+         dim = (int)v;
+   }
+   aimee_pg_finalize(st);
+   return dim;
+}
+
 int db_apply_schema_postgres(void *pg_conn, int embed_dim, char *errbuf, size_t errlen)
 {
    if (!pg_conn)

--- a/src/db2/db_schema.h
+++ b/src/db2/db_schema.h
@@ -32,6 +32,17 @@ extern "C"
     * after the schema applies; exposed for direct testing. */
    int db2_embedding_dim_record_or_check(void *conn, int embed_dim, char *errbuf, size_t errlen);
 
+   /* embedder-runtime-fetch-autodim §2a: read the recorded kb_meta
+    * .schema_embedding_dim as the *source* of the runtime dim (the companion read
+    * to record_or_check's write/guard). Returns the recorded dim when in range
+    * (1..EMBED_MAX_DIM), else 0 — the "absent" signal db2_effective_dim() treats
+    * as not-present: no row, empty/non-numeric/non-positive, or out of range
+    * (guards strtol against an operator typo). Read-only; never writes; never
+    * errors loudly (a missing/garbage row must not crash a read). |conn| is the
+    * aimee_pg connection handle; aimee_pg_*-based so it runs on Postgres and the
+    * sqlite shim. */
+   int db2_embedding_dim_get(void *conn);
+
    /* Apply the consolidated SQLite schema for DB2's libpq shim/test
     * compatibility path. Production DB2 remains Postgres-only. */
    int db2_apply_schema_sqlite_shim(struct sqlite3 *db, char *errbuf, size_t errlen);

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -22,6 +22,24 @@ extern "C"
    void db2_set_embedding_dim(int dim);
    int db2_embedding_dim(void);
 
+   /* embedder-runtime-fetch-autodim §2a: mark whether the operator pinned the dim
+    * (see config_embedding_dim_is_pinned). Call beside db2_set_embedding_dim,
+    * before db2_init. When UNpinned (0, the default), db2_init prefers a recorded
+    * kb_meta.schema_embedding_dim over the configured default; when pinned (1) the
+    * operator value is authoritative and a recorded mismatch is refused downstream.
+    * Reset by db2_shutdown so a reopen cannot inherit a previous run's state. */
+   void db2_set_embedding_dim_pinned(int pinned);
+
+   /* §2a precedence, pure (no globals, no I/O): the effective dim under
+    * pin > recorded > configured-default. |pinned|: operator pinned a positive
+    * dim. |configured|: the dim already set pre-init (the pin when pinned, else
+    * the default). |recorded|: kb_meta.schema_embedding_dim, or <=0 if absent.
+    * Returns |configured| when pinned or when nothing is recorded; the recorded
+    * dim otherwise. The one place §2a's precedence lives — db2_init and the unit
+    * test both call it. (A future probe rung, §2b, slots between recorded and the
+    * default.) */
+   int db2_effective_dim(int pinned, int configured, int recorded);
+
    /* Connection-pool size used by db2_init (default 16). Like
     * db2_set_embedding_dim, call before db2_init to keep this layer config-free. */
    void db2_set_pool_size(int size);

--- a/src/headers/config_database.h
+++ b/src/headers/config_database.h
@@ -26,4 +26,13 @@ int config_apply_db2_url_env_override(config_t *cfg);
  * so the schema columns match the running embedder. Non-mutating. */
 int config_resolve_embedding_dim(const config_t *cfg);
 
+/* embedder-runtime-fetch-autodim §2a: 1 iff the operator pinned a positive
+ * embedding dim — defined as config_resolve_embedding_dim(cfg) > 0, so "pinned"
+ * is exactly consistent with the value db2_set_embedding_dim receives. A pinned
+ * dim is authoritative; an UNpinned deployment lets the recorded
+ * kb_meta.schema_embedding_dim win over the default. AIMEE_EMBEDDING_DIM="0" /
+ * non-numeric / empty is NOT a pin (config_resolve already maps it to 0), nor is
+ * an unset cfg->embedding_dim. Pass to db2_set_embedding_dim_pinned(). */
+int config_embedding_dim_is_pinned(const config_t *cfg);
+
 #endif

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -542,6 +542,7 @@ int main(int argc, char **argv)
     * overrides the configured value (containerized deploys without a writable
     * aimee.yaml). */
    db2_set_embedding_dim(config_resolve_embedding_dim(&kb_cfg));
+   db2_set_embedding_dim_pinned(config_embedding_dim_is_pinned(&kb_cfg));
    /* Size the DB2 connection pool (leased by worker threads) before db2_init. */
    db2_set_pool_size(aimee_resolve_db2_pool_size(kb_cfg.db2_connection_pool_size));
 

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -1863,6 +1863,24 @@ int main(void)
       platform_unsetenv("AIMEE_EMBEDDING_DIM");
       assert(config_resolve_embedding_dim(NULL) == 0);
 
+      /* §2a: config_embedding_dim_is_pinned == (config_resolve_embedding_dim > 0).
+       * The env="0"/non-numeric rows are the point — they must NOT count as a pin. */
+      platform_unsetenv("AIMEE_EMBEDDING_DIM");
+      assert(config_embedding_dim_is_pinned(&cfg) == 1); /* cfg->embedding_dim=2560 */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "2560");
+      assert(config_embedding_dim_is_pinned(&cfg) == 1); /* valid env pin */
+      platform_setenv("AIMEE_EMBEDDING_DIM", "0");
+      {
+         config_t unset_cfg;
+         memset(&unset_cfg, 0, sizeof(unset_cfg));                /* embedding_dim = 0 */
+         assert(config_embedding_dim_is_pinned(&unset_cfg) == 0); /* env "0" is not a pin */
+         platform_setenv("AIMEE_EMBEDDING_DIM", "garbage");
+         assert(config_embedding_dim_is_pinned(&unset_cfg) == 0); /* non-numeric is not a pin */
+         platform_unsetenv("AIMEE_EMBEDDING_DIM");
+         assert(config_embedding_dim_is_pinned(&unset_cfg) == 0); /* unset + cfg=0 -> not pinned */
+         assert(config_embedding_dim_is_pinned(&cfg) == 1);       /* unset + cfg=2560 -> pinned */
+      }
+
       if (saved)
       {
          platform_setenv("AIMEE_EMBEDDING_DIM", saved);

--- a/src/tests/test_db2.c
+++ b/src/tests/test_db2.c
@@ -5,6 +5,8 @@
 #include "db_postgres.h"
 #include "db2.h"
 #include "db2_internal.h"
+#include "../headers/log.h" /* log_level_t for the aimee_log stub below */
+#include <stdarg.h>
 
 struct aimee_pg_stmt
 {
@@ -31,6 +33,11 @@ static int g_fail_prepare = 0;
 static int g_schema_present = 1;
 static int g_extension_present = 1;
 static int g_fake_conn = 0;
+/* §2a: knob for the db2_embedding_dim_get stub (the recorded kb_meta dim db2_init
+ * reads) and a capture of the embed_dim db_apply_schema_postgres actually received
+ * — together they exercise the recorded-dim precedence wiring through db2_init. */
+static int g_recorded_dim = 0;
+static int g_schema_dim = -1;
 
 void *aimee_pg_open(const char *conninfo, char *errbuf, size_t errlen)
 {
@@ -55,7 +62,7 @@ void aimee_pg_close(void *pg_conn)
 int db_apply_schema_postgres(void *pg_conn, int embed_dim, char *errbuf, size_t errlen)
 {
    g_schema_calls++;
-   (void)embed_dim;
+   g_schema_dim = embed_dim; /* §2a: capture the effective dim db2_init resolved */
    assert(pg_conn == &g_fake_conn);
    if (g_fail_schema)
    {
@@ -64,6 +71,23 @@ int db_apply_schema_postgres(void *pg_conn, int embed_dim, char *errbuf, size_t 
       return -1;
    }
    return 0;
+}
+
+/* §2a: db2_init now reads the recorded dim (db_schema.o, not linked here — the
+ * real db_apply_schema_postgres is stubbed above) and logs via aimee_log (log.o,
+ * not linked). Stub both so the object links; returning 0 (no recorded dim) keeps
+ * the unpinned path's effective dim == configured, so these tests are unchanged. */
+int db2_embedding_dim_get(void *pg_conn)
+{
+   assert(pg_conn == &g_fake_conn);
+   return g_recorded_dim;
+}
+
+void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
+{
+   (void)level;
+   (void)module;
+   (void)fmt;
 }
 
 int aimee_pg_exec(void *pg_conn, const char *sql, char *errbuf, size_t errlen)
@@ -171,7 +195,11 @@ static void reset_mocks(void)
    g_fail_prepare = 0;
    g_schema_present = 1;
    g_extension_present = 1;
+   g_recorded_dim = 0;
+   g_schema_dim = -1;
    db2_shutdown();
+   db2_set_embedding_dim(0);
+   db2_set_embedding_dim_pinned(0);
 }
 
 static void test_init_shutdown_roundtrip(void)
@@ -199,6 +227,48 @@ static void test_init_shutdown_roundtrip(void)
 
    db2_shutdown();
    assert(g_close_calls == 1);
+}
+
+/* §2a: drive the recorded-dim precedence through db2_init end-to-end (the wiring
+ * the shim/unit helpers don't exercise). g_schema_dim captures the effective dim
+ * that reached db_apply_schema_postgres; g_recorded_dim mocks kb_meta. */
+static void test_recorded_dim_precedence(void)
+{
+   /* Unpinned + a recorded dim that differs from the configured default: the
+    * recorded dim wins and the global is updated so later readers agree. */
+   reset_mocks();
+   db2_set_embedding_dim(1024); /* configured default */
+   g_recorded_dim = 2560;       /* populated DB recorded 2560 */
+   assert(db2_init("postgres://db2.test/aimee") == 0);
+   assert(g_schema_dim == 2560);        /* effective dim, not the 1024 default */
+   assert(db2_embedding_dim() == 2560); /* global re-set so halfvec + readers agree */
+
+   /* Pinned: the operator value is authoritative; the recorded dim is ignored. */
+   reset_mocks();
+   db2_set_embedding_dim(1024);
+   db2_set_embedding_dim_pinned(1);
+   g_recorded_dim = 2560;
+   assert(db2_init("postgres://db2.test/aimee") == 0);
+   assert(g_schema_dim == 1024); /* pin wins over recorded */
+   assert(db2_embedding_dim() == 1024);
+
+   /* Unpinned, nothing recorded: the configured default stands (fresh-DB path). */
+   reset_mocks();
+   db2_set_embedding_dim(1024);
+   g_recorded_dim = 0;
+   assert(db2_init("postgres://db2.test/aimee") == 0);
+   assert(g_schema_dim == 1024);
+
+   /* db2_shutdown clears the pinned flag: a pin set before shutdown must NOT leak
+    * into the next init, or an unpinned deploy would wrongly refuse to self-derive. */
+   reset_mocks();
+   db2_set_embedding_dim_pinned(1);
+   db2_shutdown(); /* resets g_embed_dim_pinned (and g_embed_dim) */
+   db2_set_embedding_dim(1024);
+   g_recorded_dim = 2560;
+   assert(db2_init("postgres://db2.test/aimee") == 0);
+   assert(g_schema_dim == 2560); /* pinned state did not survive shutdown */
+   db2_shutdown();
 }
 
 static void test_init_rejects_url_change_without_shutdown(void)
@@ -321,6 +391,7 @@ static void test_health_probe_fails_without_init_or_query_failure(void)
 int main(void)
 {
    test_init_shutdown_roundtrip();
+   test_recorded_dim_precedence();
    test_init_rejects_url_change_without_shutdown();
    test_init_rejects_empty_url();
    test_open_failure_leaves_db2_closed();

--- a/src/tests/test_embedding_dim.c
+++ b/src/tests/test_embedding_dim.c
@@ -9,6 +9,7 @@
 #include "../db2/db2_test_shim.h"
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
+#include "../db2/lifecycle.h" /* db2_effective_dim */
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -70,6 +71,38 @@ int main(void)
                         sizeof err) == 0);
    err[0] = '\0';
    assert(db2_embedding_dim_record_or_check(conn, 1024, err, sizeof err) == 0);
+
+   /* ---- §2a: db2_effective_dim precedence (pure, pin > recorded > default) ---- */
+   assert(db2_effective_dim(0, 1024, 2560) == 2560); /* unpinned: recorded wins over default */
+   assert(db2_effective_dim(1, 1024, 2560) == 1024); /* pinned: operator value authoritative */
+   assert(db2_effective_dim(0, 1024, 0) == 1024);    /* fresh DB: nothing recorded -> default */
+   assert(db2_effective_dim(0, 2560, 2560) == 2560); /* match: caller sees eff==dim (no-op) */
+   assert(db2_effective_dim(0, 1024, -1) == 1024);   /* non-positive recorded == absent */
+
+   /* ---- §2a: db2_embedding_dim_get reader (quiet, bounded) ---- */
+   /* The row is currently 1024 (record_or_check above). */
+   assert(db2_embedding_dim_get(conn) == 1024);
+   /* No row -> 0 (the "absent" signal). */
+   assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedding_dim'", err,
+                        sizeof err) == 0);
+   assert(db2_embedding_dim_get(conn) == 0);
+   /* A recorded in-range dim is returned verbatim. */
+   assert(aimee_pg_exec(conn,
+                        "INSERT INTO kb_meta (key, value) VALUES ('schema_embedding_dim', '2560')",
+                        err, sizeof err) == 0);
+   assert(db2_embedding_dim_get(conn) == 2560);
+   /* Non-numeric -> 0 (no crash). */
+   assert(aimee_pg_exec(conn,
+                        "UPDATE kb_meta SET value = 'garbage' WHERE key = 'schema_embedding_dim'",
+                        err, sizeof err) == 0);
+   assert(db2_embedding_dim_get(conn) == 0);
+   /* Out of range (> EMBED_MAX_DIM) -> 0 (guards against an operator typo). */
+   assert(aimee_pg_exec(conn,
+                        "UPDATE kb_meta SET value = '5000' WHERE key = 'schema_embedding_dim'", err,
+                        sizeof err) == 0);
+   assert(db2_embedding_dim_get(conn) == 0);
+   /* NULL conn -> 0. */
+   assert(db2_embedding_dim_get(NULL) == 0);
 
    db2_test_shim_close();
    printf("ok\n");


### PR DESCRIPTION
Implements **§2a** of [embedder-runtime-fetch-autodim](docs/proposals/pending/embedder-runtime-fetch-autodim.md): the recorded `kb_meta.schema_embedding_dim` becomes a *source* of the runtime dim, under the proposal's precedence **operator-pin > recorded > probe**.

### Problem
#337 records `schema_embedding_dim` on first schema apply and refuses a later mismatch — but nothing reads it back. The runtime dim is fixed entirely from the operator pin (`config_resolve_embedding_dim`). So on a **populated DB where the operator did not pin**, the recorded dim is ignored, and an unpinned default-vs-recorded difference is *refused* instead of honored — the exact "keep `embedding_dim` manually in sync" failure the proposal removes.

### Change (§2a — recorded leg only)
- `db2_effective_dim(pinned, configured, recorded)` — the one pure precedence fn; called by `db2_init` and unit-tested directly.
- `db2_embedding_dim_get()` — quiet, bounded reader of `schema_embedding_dim` (1..`EMBED_MAX_DIM`, else 0).
- `config_embedding_dim_is_pinned()` := `config_resolve_embedding_dim(cfg) > 0`, so the pin flag agrees exactly with the dim that was set.
- `db2_set_embedding_dim_pinned()` + a recorded-preference block in `db2_init`: when unpinned, prefer the recorded dim over the default (`LOG_WARN`); `db2_shutdown` resets the dim + pinned flag. All three `db2_set_embedding_dim` call sites (cmd_core, kb_main, cmd_doctor) set it.

**Behavior changes only** in the populated-DB + unpinned + recorded-differs case (today a refused/wrong outcome). Pinned and fresh-DB paths are byte-identical.

### Out of scope (separate live-stack slices)
§2b live `/health` probe + advisory-lock auto-derive; §2c destructive double-gated auto-reembed.

### Verification
- `make all` + `make lint` + full `make unit-tests` green.
- New tests: `db2_effective_dim` truth table + `db2_embedding_dim_get` reader (shim) in `test_embedding_dim`; `config_embedding_dim_is_pinned` matrix in `test_config`; **end-to-end `db2_init` wiring** in `test_db2` (`test_recorded_dim_precedence`: recorded-wins, pin-wins, fresh-DB, shutdown-resets-pinned).
- Roundtable: plan-reviewed (mistral + minimax APPROVE after R1 fixes); diff-reviewed (mistral + minimax APPROVE after adding the end-to-end wiring test).

Not validated against a live PG + embedder (deferred, as the proposal notes for §2 runtime work); the precedence logic is fully unit-tested and the `db2_init` glue is exercised end-to-end via the mocked wiring.