### PR TITLE
feat(webchat): run claude/codex OAuth CLI chat over tmux, 1:1 per aimee session

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -145,6 +145,17 @@ void session_id_clear_override(void)
    g_session_override[0] = '\0';
 }
 
+/* True when a real per-session id has been bound on this thread via
+ * session_id_set_override. Callers that key a shared resource on session_id()
+ * (e.g. the tmux CLI session pane) use this to tell a genuine per-session id
+ * apart from the process-wide PPID fallback, which is the SAME value for every
+ * override-less turn in the process and would otherwise collapse them all onto
+ * one pane. */
+int session_id_override_active(void)
+{
+   return g_session_override[0] != '\0';
+}
+
 const char *config_default_dir(void)
 {
    /* Routes through aimee_home() so AIMEE_HOME / AIMEE_PROFILE

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -14,10 +14,30 @@ typedef struct
 {
    char session_name[CLI_SESSION_NAME_MAX]; /* tmux session name */
    char cli_cmd[CLI_SESSION_CMD_MAX];       /* CLI command that was started */
+   char cli_kind[32];                       /* "claude"/"codex"/... drives response parsing */
    int reuse;                               /* 1 = reuse across tasks */
    time_t last_activity;
    int active; /* 1 = session exists */
+   /* Pane snapshot taken just before a prompt is sent. recv diffs against it so
+    * a reused pane returns ONLY this turn's output, never prior turns still on
+    * screen. malloc'd; freed by cli_session_destroy. */
+   char *baseline;
+   /* Clean response text already streamed to the caller this turn (so recv emits
+    * only the growth as an incremental delta). malloc'd; freed on destroy. */
+   char *stream_emitted;
 } cli_session_t;
+
+/* Incremental stream callback: invoked by cli_session_recv with each newly
+ * produced chunk of clean response text as the turn streams. Set per-thread. */
+typedef void (*cli_session_stream_cb_t)(const char *delta, void *ud);
+void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud);
+
+/* Record the CLI kind so recv can pick the right TUI response parser. */
+void cli_session_set_kind(cli_session_t *s, const char *cli_kind);
+
+/* Snapshot the current pane as the baseline for the next recv. Call right
+ * before cli_session_send so the turn's reply is diffed from a clean boundary. */
+void cli_session_mark_baseline(cli_session_t *s);
 
 /* --- Lifecycle --- */
 /* Creates (or attaches to existing) tmux session, starts CLI.
@@ -48,8 +68,17 @@ int cli_session_capture(cli_session_t *s, char *out, size_t out_max);
  * and -2 if it did not stabilise within timeout_ms. timeout_ms <= 0 disables
  * the wall-clock bound (legacy unbounded behaviour). The bound is the only
  * thing that breaks a CLI wedged in a provider retry loop (e.g. an Anthropic
- * outage), whose pane animates forever without the session dying. */
+ * outage), whose pane animates forever without the session dying. recv writes
+ * ONLY this turn's clean response (pane diffed vs the baseline, TUI chrome
+ * stripped) and streams the reply's growth via the thread's stream callback. */
 int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms);
+
+/* Extract the latest assistant turn's clean text from a raw pane capture.
+ * `cli_kind` selects the TUI markers ("claude"/"claude-code" use ●/❯/✻,
+ * "codex" uses •/›). `baseline` is the pre-send pane snapshot (may be NULL);
+ * content present in the baseline is excluded so prior turns never leak.
+ * Returns newly allocated text; caller frees. Exposed for unit tests. */
+char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline);
 
 /* --- Session name helpers --- */
 /* Build a deterministic session name: "aimee-<agent>-<hash(role)>".

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -31,6 +31,10 @@ typedef struct
  * produced chunk of clean response text as the turn streams. Set per-thread. */
 typedef void (*cli_session_stream_cb_t)(const char *delta, void *ud);
 void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud);
+/* Read the current thread's stream callback so a caller can save/restore it
+ * around a nested turn (prevents the inner turn's now-dead context leaking to
+ * the outer turn). *ud_out receives the userdata; returns the callback. */
+cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out);
 
 /* Record the CLI kind so recv can pick the right TUI response parser. */
 void cli_session_set_kind(cli_session_t *s, const char *cli_kind);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1542,6 +1542,10 @@ const char *session_id(void);
 void session_id_set_override(const char *sid);
 void session_id_clear_override(void);
 
+/* True when session_id_set_override bound a real per-session id on this thread
+ * (vs. the process-wide PPID fallback session_id() returns otherwise). */
+int session_id_override_active(void);
+
 /* Drop the per-thread session_id cache so the next session_id() call re-reads
  * ~/.config/aimee/session-ppid-{ppid}. Long-lived MCP / aimee-server request
  * paths should call this at request entry to pick up rotations performed by

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -86,7 +86,18 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       return -1;
    }
 
-   const char *cli_cmd = agent->cli_cmd[0] ? agent->cli_cmd : "claude";
+   /* Honour the agent's model: append `--model <model>` (claude and codex both
+    * accept it) unless the launch command already pins one. The model is the
+    * config default or the per-request override the chat worker wrote onto the
+    * agent — without this the CLI would launch with its own built-in default. */
+   const char *base_cmd = agent->cli_cmd[0] ? agent->cli_cmd : "claude";
+   char cli_cmd_buf[CLI_SESSION_CMD_MAX];
+   const char *cli_cmd = base_cmd;
+   if (agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m "))
+   {
+      snprintf(cli_cmd_buf, sizeof(cli_cmd_buf), "%s --model %s", base_cmd, agent->model);
+      cli_cmd = cli_cmd_buf;
+   }
 
    /* Prefer the turn's bound cwd (the client workspace root on a detached
     * thin-client turn, where the tmux session actually runs); fall back to the

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -44,12 +44,20 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
     * primary pane reuses (the conversation persists across turns); a delegate
     * pane is one-shot and torn down on completion (isolation is the unique
     * name, not reuse) so unique-per-delegation panes don't accumulate — there
-    * is no idle reaper for these sessions. */
+    * is no idle reaper for these sessions.
+    *
+    * The per-session pane is used ONLY when a real session id is bound on this
+    * thread (session_id_override_active). Without an override, session_id()
+    * returns the process-wide PPID fallback — the SAME value for every
+    * override-less turn in the server — which would collapse them all onto one
+    * "<ppid>-cli" pane and cross-contaminate. In that case fall through to the
+    * agent-keyed / unique-per-turn names below. */
    const char *aimee_sid = session_id();
    const char *deleg_id = delegation_active_id();
+   int have_session = aimee_sid && aimee_sid[0] && session_id_override_active();
    int reuse = agent->session_reuse;
    char *sess_name;
-   if (aimee_sid && aimee_sid[0])
+   if (have_session)
    {
       if (deleg_id && deleg_id[0])
       {
@@ -98,6 +106,8 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       snprintf(out->error, sizeof(out->error), "failed to create tmux session for %s", agent->name);
       return -1;
    }
+   /* cli_kind drives the TUI response parser (claude ●/❯/✻ vs codex •/›). */
+   cli_session_set_kind(&sess, agent->cli_kind[0] ? agent->cli_kind : agent->name);
 
    size_t plen = (system_prompt ? strlen(system_prompt) : 0) + strlen(user_prompt) + 4;
    char *full_prompt = malloc(plen);
@@ -111,6 +121,10 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       snprintf(full_prompt, plen, "%s\n\n%s", system_prompt, user_prompt);
    else
       snprintf(full_prompt, plen, "%s", user_prompt);
+
+   /* Snapshot the pane immediately before sending so recv returns ONLY this
+    * turn's reply — never prior turns still visible on a reused pane. */
+   cli_session_mark_baseline(&sess);
 
    if (cli_session_send(&sess, full_prompt) != 0)
    {
@@ -151,11 +165,22 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       return -1;
    }
 
-   char *clean = cli_session_strip_ansi(raw);
+   /* recv already returned this turn's clean, chrome-stripped response. */
+   char *clean = strdup(raw);
    free(raw);
 
+   /* Tear the pane down for a one-shot (delegate / non-reuse) session; for a
+    * reused chat pane keep it alive but free this turn's per-turn scratch
+    * (baseline + stream buffer) so it does not leak across turns. */
    if (!reuse)
       cli_session_destroy(&sess);
+   else
+   {
+      free(sess.baseline);
+      sess.baseline = NULL;
+      free(sess.stream_emitted);
+      sess.stream_emitted = NULL;
+   }
 
    if (!clean || !clean[0])
    {

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -456,7 +456,8 @@ static int chat_agent_has_provider(const agent_config_t *acfg, const char *provi
  * agent was explicitly configured. `name`==`provider` so it is selectable by
  * either. cli_kind drives the response parser; cli_cmd is the launch command. */
 static void chat_agent_add_builtin_tmux_cli(agent_config_t *acfg, const char *name,
-                                            const char *cli_kind, const char *cli_cmd)
+                                            const char *cli_kind, const char *cli_cmd,
+                                            const char *model)
 {
    if (!acfg || acfg->agent_count >= MAX_AGENTS || agent_find(acfg, name) ||
        chat_agent_has_provider(acfg, name))
@@ -470,6 +471,12 @@ static void chat_agent_add_builtin_tmux_cli(agent_config_t *acfg, const char *na
    snprintf(ag->backend, sizeof(ag->backend), "%s", AGENT_BACKEND_TMUX_CLI);
    snprintf(ag->cli_kind, sizeof(ag->cli_kind), "%s", cli_kind);
    snprintf(ag->cli_cmd, sizeof(ag->cli_cmd), "%s", cli_cmd);
+   /* The configured default model; agent_execute_cli_session appends it as
+    * `--model` (claude/codex both accept it). A per-request model_override
+    * replaces this in chat_stream_worker_agent before the turn runs. Without
+    * this, the CLI launched with its own default, silently ignoring config. */
+   if (model && model[0])
+      snprintf(ag->model, sizeof(ag->model), "%s", model);
    ag->cost_tier = 1;
    ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
    ag->timeout_ms = AGENT_DEFAULT_TIMEOUT_MS;
@@ -488,14 +495,16 @@ static void chat_agent_add_builtin_provider(agent_config_t *acfg, const char *pr
 {
    if (!provider)
       return;
+   const char *claude_model = cfg ? cfg->claude_model : "";
+   const char *codex_model = cfg ? cfg->codex_model : "";
    if (strcmp(provider, "openai") == 0)
       chat_agent_add_legacy_openai(acfg, cfg);
    else if (strcmp(provider, "claude-code") == 0)
-      chat_agent_add_builtin_tmux_cli(acfg, "claude-code", "claude-code", "claude");
+      chat_agent_add_builtin_tmux_cli(acfg, "claude-code", "claude-code", "claude", claude_model);
    else if (strcmp(provider, "claude") == 0 || strcmp(provider, "claude-oauth") == 0)
-      chat_agent_add_builtin_tmux_cli(acfg, provider, "claude", "claude");
+      chat_agent_add_builtin_tmux_cli(acfg, provider, "claude", "claude", claude_model);
    else if (strcmp(provider, "codex-oauth") == 0)
-      chat_agent_add_builtin_tmux_cli(acfg, "codex-oauth", "codex", "codex");
+      chat_agent_add_builtin_tmux_cli(acfg, "codex-oauth", "codex", "codex", codex_model);
 }
 
 static int chat_agent_select_provider(agent_config_t *acfg, const char *provider, char *selected,
@@ -642,8 +651,11 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
       stream_event(cctx, "text", "content", drift);
    agent_tools_set_tool_event_cb(chat_tool_event_cb, cctx);
    /* Stream a tmux CLI turn's reply incrementally (no-op for non-tmux agents,
-    * whose runtime never drives a cli_session). */
+    * whose runtime never drives a cli_session). Save/restore any outer cb so a
+    * nested turn on this thread can't leave a dangling context behind. */
    chat_cli_stream_ctx_t sctx = {cctx, 0};
+   void *prev_stream_ud = NULL;
+   cli_session_stream_cb_t prev_stream_cb = cli_session_get_stream_cb(&prev_stream_ud);
    cli_session_set_stream_cb(chat_cli_stream_cb, &sctx);
 
    agent_result_t result;
@@ -651,7 +663,7 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    int rc = agent_run_with_tools(&acfg, "code", system_prompt ? system_prompt : "", message,
                                  AGENT_DEFAULT_MAX_TOKENS, &result);
 
-   cli_session_set_stream_cb(NULL, NULL);
+   cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();
    workspace_turn_unbind_active();

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -5,6 +5,7 @@
 #include "agent_exec.h"
 #include "agent_tools.h" /* agent_tools_set_tool_event_cb — stream tool events */
 #include "cli_codex.h"
+#include "cli_session.h" /* cli_session_set_stream_cb — incremental tmux CLI streaming */
 #include "config.h"
 #include "db1.h"
 #include "log.h"
@@ -49,37 +50,6 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
  *   2. $HOME/.local/bin/claude
  * Falling back to bare "claude" if neither exists (lets PATH work in
  * non-systemd environments). */
-static const char *resolve_claude_bin(char *buf, size_t buf_len)
-{
-   struct stat st;
-
-   /* Probe sibling of the running aimee-server binary */
-   char exe[1024];
-   ssize_t exe_len = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
-   if (exe_len > 0)
-   {
-      exe[exe_len] = '\0';
-      char *slash = strrchr(exe, '/');
-      if (slash)
-      {
-         snprintf(buf, buf_len, "%.*s/claude", (int)(slash - exe), exe);
-         if (stat(buf, &st) == 0 && (st.st_mode & S_IXUSR))
-            return buf;
-      }
-   }
-
-   /* Probe $HOME/.local/bin/claude */
-   const char *home = getenv("HOME");
-   if (home && home[0])
-   {
-      snprintf(buf, buf_len, "%s/.local/bin/claude", home);
-      if (stat(buf, &st) == 0 && (st.st_mode & S_IXUSR))
-         return buf;
-   }
-
-   return "claude";
-}
-
 /* Text-delta coalescing bounds for the presence ring (WP-1): flush accumulated
  * text as one turn_delta on either bound, capping ring-fill rate without
  * reordering relative to non-text events. */
@@ -221,155 +191,6 @@ static int stream_event(compute_ctx_t *cctx, const char *event, const char *key,
    int alive = cctx->conn_alive;
    pthread_mutex_unlock(cctx->write_mutex);
    return (ring_active || alive) ? 0 : -1;
-}
-
-static int stream_event_usage(compute_ctx_t *cctx, int in_tokens, int out_tokens, double cost)
-{
-   pthread_mutex_lock(cctx->write_mutex);
-
-   /* 1) Ring publish — flush pending text first (ordering), then usage. */
-   if (cctx->presence_emit_deltas && cctx->presence_session[0])
-   {
-      ring_flush_text_locked(cctx);
-      cJSON *d = cJSON_CreateObject();
-      cJSON_AddStringToObject(d, "turn_id", cctx->presence_turn_id);
-      cJSON_AddStringToObject(d, "kind", "usage");
-      cJSON_AddNumberToObject(d, "in", (double)in_tokens);
-      cJSON_AddNumberToObject(d, "out", (double)out_tokens);
-      cJSON_AddNumberToObject(d, "cost", cost);
-      char *dj = cJSON_PrintUnformatted(d);
-      cJSON_Delete(d);
-      if (dj)
-      {
-         presence_emit_turn_delta(cctx->presence_session, cctx->presence_turn_id, dj);
-         free(dj);
-      }
-   }
-
-   /* 2) Socket write — best effort. */
-   if (cctx->conn_alive)
-   {
-      cJSON *evt = cJSON_CreateObject();
-      cJSON_AddStringToObject(evt, "event", "usage");
-      cJSON_AddNumberToObject(evt, "in", (double)in_tokens);
-      cJSON_AddNumberToObject(evt, "out", (double)out_tokens);
-      cJSON_AddNumberToObject(evt, "cost", cost);
-      char *json_str = cJSON_PrintUnformatted(evt);
-      cJSON_Delete(evt);
-      if (json_str)
-      {
-         int r = write_all(cctx->conn_fd, json_str, strlen(json_str));
-         if (r == 0)
-            r = write_all(cctx->conn_fd, "\n", 1);
-         free(json_str);
-         if (r != 0)
-            cctx->conn_alive = 0;
-      }
-   }
-
-   int ring_active = cctx->presence_emit_deltas && cctx->presence_session[0];
-   int alive = cctx->conn_alive;
-   pthread_mutex_unlock(cctx->write_mutex);
-   return (ring_active || alive) ? 0 : -1;
-}
-
-/* Cancellable, non-blocking line reader for the provider subprocess pipe.
- *
- * Replaces blocking fgets so the read loop can be interrupted promptly: each
- * poll tick re-checks the per-turn cancel flag (server-owned turn lifecycle —
- * a hung provider must not wedge a detached turn). The fd must be O_NONBLOCK.
- * Returns 1 with a NUL-terminated line (newline stripped) in out; 0 when no
- * more lines (sets *cancelled on cancel, *eof on provider EOF). A line longer
- * than the buffer is emitted truncated (caller may log). */
-typedef struct
-{
-   char buf[CLAUDE_LINE_MAX];
-   size_t len;
-} cli_linereader_t;
-
-static int cli_read_line(int fd, cli_linereader_t *lr, struct turn_entry *e, char *out,
-                         size_t outmax, int *cancelled, int *eof)
-{
-   for (;;)
-   {
-      char *nl = memchr(lr->buf, '\n', lr->len);
-      if (nl)
-      {
-         size_t linelen = (size_t)(nl - lr->buf);
-         size_t copy = linelen < outmax - 1 ? linelen : outmax - 1;
-         memcpy(out, lr->buf, copy);
-         out[copy] = '\0';
-         size_t rem = lr->len - (linelen + 1);
-         memmove(lr->buf, nl + 1, rem);
-         lr->len = rem;
-         return 1;
-      }
-      if (lr->len >= sizeof(lr->buf) - 1)
-      {
-         /* Oversized line with no newline: emit truncated and reset. */
-         memcpy(out, lr->buf, outmax - 1);
-         out[outmax - 1] = '\0';
-         lr->len = 0;
-         LOG_WARN("chat", "provider line exceeded %zu bytes; truncated", sizeof(lr->buf));
-         return 1;
-      }
-      if (turn_entry_cancelled(e))
-      {
-         *cancelled = 1;
-         return 0;
-      }
-      struct pollfd pfd = {.fd = fd, .events = POLLIN};
-      int pr = poll(&pfd, 1, 200);
-      if (pr == 0)
-         continue; /* tick: re-check cancel */
-      if (pr < 0)
-      {
-         if (errno == EINTR)
-            continue;
-         *eof = 1;
-         return 0;
-      }
-      if (turn_entry_cancelled(e))
-      {
-         *cancelled = 1;
-         return 0;
-      }
-      if (pfd.revents & (POLLIN | POLLHUP | POLLERR))
-      {
-         /* Drain whatever is available. On POLLHUP the pipe is closed but may
-          * still hold buffered bytes; read() delivers them before returning 0,
-          * so always attempt the read rather than declaring EOF on POLLHUP. */
-         ssize_t n = read(fd, lr->buf + lr->len, sizeof(lr->buf) - 1 - lr->len);
-         if (n == 0)
-         {
-            if (lr->len > 0)
-            {
-               /* Final line without a trailing newline: deliver it, then EOF. */
-               size_t copy = lr->len < outmax - 1 ? lr->len : outmax - 1;
-               memcpy(out, lr->buf, copy);
-               out[copy] = '\0';
-               lr->len = 0;
-               *eof = 1;
-               return 1;
-            }
-            *eof = 1;
-            return 0;
-         }
-         if (n < 0)
-         {
-            if (errno == EAGAIN || errno == EINTR)
-               continue; /* not really ready / interrupted: re-poll */
-            *eof = 1;
-            return 0;
-         }
-         lr->len += (size_t)n;
-      }
-      else if (pfd.revents & POLLNVAL)
-      {
-         *eof = 1;
-         return 0;
-      }
-   }
 }
 
 static char *read_optional_text_file(const char *path)
@@ -522,114 +343,10 @@ static int chat_model_passthrough_allowed(const char *model)
    return model && model[0] && strcmp(model, "aimee") != 0 && strncmp(model, "aimee:", 6) != 0;
 }
 
-static int chat_claude_effort_allowed(const char *effort)
-{
-   return effort && (strcmp(effort, "low") == 0 || strcmp(effort, "medium") == 0 ||
-                     strcmp(effort, "high") == 0 || strcmp(effort, "xhigh") == 0 ||
-                     strcmp(effort, "max") == 0);
-}
-
-/* `claude --resume <sid>` fails the WHOLE turn ("No conversation found with
- * session ID") when the session transcript is gone — e.g. the client replays a
- * session id from before a container redeploy that cleared ~/.claude. Guard the
- * resume: only pass --resume when the transcript actually exists, otherwise fall
- * back to a fresh session so the user can keep chatting. claude stores each
- * conversation at ~/.claude/projects/<cwd-as-dashes>/<sid>.jsonl; we glob across
- * project dirs so the check is independent of claude's exact cwd encoding (a
- * session id is unique, so it lives in at most one project dir). */
-static int chat_claude_session_exists(const char *sid)
-{
-   if (!sid || !sid[0])
-      return 0;
-   const char *home = getenv("HOME");
-   if (!home || !home[0])
-      return 1; /* can't check — don't block a resume the client asked for */
-   /* A real claude session id is a UUID (alnum + '-'); refuse anything else so
-    * the value can't smuggle glob metacharacters or path traversal. */
-   for (const char *p = sid; *p; p++)
-      if (!(isalnum((unsigned char)*p) || *p == '-' || *p == '_'))
-         return 1;
-   char pattern[2048];
-   snprintf(pattern, sizeof(pattern), "%s/.claude/projects/*/%s.jsonl", home, sid);
-   glob_t g;
-   int rc = glob(pattern, GLOB_NOSORT, NULL, &g);
-   int found = (rc == 0 && g.gl_pathc > 0);
-   globfree(&g);
-   return found;
-}
-
-/* Resolve which Claude session this turn may resume, namespaced to the attested
- * principal + the per-tab aimee_session_id. The client-supplied claude_session_id
- * is advisory only: it is honored on a tab's first use (and never if it already
- * belongs to another tab), but once a tab is bound the server-owned binding wins.
- * This makes a stale or cross-wired client id unable to resume — and thereby
- * merge into — another tab's conversation, even if the browser sends the wrong
- * value. With no per-tab identity (empty aimee_sid) it falls back to the legacy
- * behavior of trusting the client id. */
-static void chat_claude_resolve_resume_sid(const char *principal, const char *aimee_sid,
-                                           const char *client_sid, char *out, size_t out_n)
-{
-   if (out && out_n)
-      out[0] = '\0';
-   if (!out || out_n == 0)
-      return;
-   if (!aimee_sid || !aimee_sid[0])
-   {
-      if (client_sid && client_sid[0])
-         snprintf(out, out_n, "%s", client_sid);
-      return;
-   }
-   char bound[128] = {0};
-   if (db1_webchat_claude_session_get(principal, aimee_sid, bound, sizeof(bound)) == 0 && bound[0])
-   {
-      snprintf(out, out_n, "%s", bound);
-      if (client_sid && client_sid[0] && strcmp(client_sid, bound) != 0)
-         aimee_log(LOG_WARN, "webchat",
-                   "claude session mismatch: tab bound to its own session; ignoring client id");
-      return;
-   }
-   /* No binding yet for this tab: adopt the client's id only if no other tab owns it. */
-   if (client_sid && client_sid[0] &&
-       !db1_webchat_claude_session_owned_by_other(principal, aimee_sid, client_sid))
-      snprintf(out, out_n, "%s", client_sid);
-}
-
 static int chat_codex_effort_allowed(const char *effort)
 {
    return effort && (strcmp(effort, "low") == 0 || strcmp(effort, "medium") == 0 ||
                      strcmp(effort, "high") == 0 || strcmp(effort, "xhigh") == 0);
-}
-
-static void chat_claude_stream_content(compute_ctx_t *cctx, cJSON *content, int *saw_content)
-{
-   if (!cJSON_IsArray(content))
-      return;
-   cJSON *block = NULL;
-   cJSON_ArrayForEach(block, content)
-   {
-      cJSON *type = cJSON_GetObjectItem(block, "type");
-      const char *bt = cJSON_IsString(type) ? type->valuestring : "";
-      if (strcmp(bt, "text") == 0)
-      {
-         cJSON *text = cJSON_GetObjectItem(block, "text");
-         if (cJSON_IsString(text) && text->valuestring[0])
-         {
-            if (saw_content)
-               *saw_content = 1;
-            stream_event(cctx, "text", "content", text->valuestring);
-         }
-      }
-      else if (strcmp(bt, "thinking") == 0)
-      {
-         cJSON *text = cJSON_GetObjectItem(block, "thinking");
-         if (cJSON_IsString(text) && text->valuestring[0])
-         {
-            if (saw_content)
-               *saw_content = 1;
-            stream_event(cctx, "thinking", "content", text->valuestring);
-         }
-      }
-   }
 }
 
 static void chat_stream_worker_codex(compute_ctx_t *cctx, const char *message,
@@ -734,20 +451,25 @@ static int chat_agent_has_provider(const agent_config_t *acfg, const char *provi
    return 0;
 }
 
-static void chat_agent_add_builtin_claude_code(agent_config_t *acfg)
+/* Register a built-in tmux-CLI agent (claude/codex driven as a persistent TUI
+ * over tmux) for an OAuth/CLI provider so webchat can resolve it even when no
+ * agent was explicitly configured. `name`==`provider` so it is selectable by
+ * either. cli_kind drives the response parser; cli_cmd is the launch command. */
+static void chat_agent_add_builtin_tmux_cli(agent_config_t *acfg, const char *name,
+                                            const char *cli_kind, const char *cli_cmd)
 {
-   if (!acfg || acfg->agent_count >= MAX_AGENTS || agent_find(acfg, "claude-code") ||
-       chat_agent_has_provider(acfg, "claude-code"))
+   if (!acfg || acfg->agent_count >= MAX_AGENTS || agent_find(acfg, name) ||
+       chat_agent_has_provider(acfg, name))
       return;
 
    agent_t *ag = &acfg->agents[acfg->agent_count++];
    memset(ag, 0, sizeof(*ag));
-   snprintf(ag->name, sizeof(ag->name), "claude-code");
+   snprintf(ag->name, sizeof(ag->name), "%s", name);
    snprintf(ag->auth_type, sizeof(ag->auth_type), "bearer");
-   snprintf(ag->provider, sizeof(ag->provider), "claude-code");
+   snprintf(ag->provider, sizeof(ag->provider), "%s", name);
    snprintf(ag->backend, sizeof(ag->backend), "%s", AGENT_BACKEND_TMUX_CLI);
-   snprintf(ag->cli_kind, sizeof(ag->cli_kind), "claude-code");
-   snprintf(ag->cli_cmd, sizeof(ag->cli_cmd), "claude");
+   snprintf(ag->cli_kind, sizeof(ag->cli_kind), "%s", cli_kind);
+   snprintf(ag->cli_cmd, sizeof(ag->cli_cmd), "%s", cli_cmd);
    ag->cost_tier = 1;
    ag->max_tokens = AGENT_DEFAULT_MAX_TOKENS;
    ag->timeout_ms = AGENT_DEFAULT_TIMEOUT_MS;
@@ -758,16 +480,22 @@ static void chat_agent_add_builtin_claude_code(agent_config_t *acfg)
    ag->session_reuse = 1;
    chat_agent_add_default_roles(ag);
    if (!acfg->default_agent[0])
-      snprintf(acfg->default_agent, sizeof(acfg->default_agent), "claude-code");
+      snprintf(acfg->default_agent, sizeof(acfg->default_agent), "%s", name);
 }
 
 static void chat_agent_add_builtin_provider(agent_config_t *acfg, const char *provider,
                                             const config_t *cfg)
 {
-   if (provider && strcmp(provider, "openai") == 0)
+   if (!provider)
+      return;
+   if (strcmp(provider, "openai") == 0)
       chat_agent_add_legacy_openai(acfg, cfg);
-   else if (provider && strcmp(provider, "claude-code") == 0)
-      chat_agent_add_builtin_claude_code(acfg);
+   else if (strcmp(provider, "claude-code") == 0)
+      chat_agent_add_builtin_tmux_cli(acfg, "claude-code", "claude-code", "claude");
+   else if (strcmp(provider, "claude") == 0 || strcmp(provider, "claude-oauth") == 0)
+      chat_agent_add_builtin_tmux_cli(acfg, provider, "claude", "claude");
+   else if (strcmp(provider, "codex-oauth") == 0)
+      chat_agent_add_builtin_tmux_cli(acfg, "codex-oauth", "codex", "codex");
 }
 
 static int chat_agent_select_provider(agent_config_t *acfg, const char *provider, char *selected,
@@ -815,8 +543,6 @@ static int chat_agent_select_provider(agent_config_t *acfg, const char *provider
 
 static const char *chat_provider_lookup_name(const char *provider)
 {
-   if (provider && strcmp(provider, "codex-oauth") == 0)
-      return "codex";
    return provider;
 }
 
@@ -828,6 +554,26 @@ static void chat_tool_event_cb(const char *phase, const char *name, void *ud)
    char ev[48];
    snprintf(ev, sizeof(ev), "tool_call.%s", phase ? phase : "");
    stream_event(cctx, ev, "name", name ? name : "");
+}
+
+/* Incremental stream sink for tmux CLI turns: cli_session_recv calls this with
+ * each newly produced chunk of the clean reply, which we forward as a `text`
+ * SSE event so the webchat streams the answer as it is produced (instead of one
+ * blob at turn end). `emitted` records that streaming delivered the reply, so
+ * the worker skips the trailing full-text emit and avoids duplicating it. */
+typedef struct
+{
+   compute_ctx_t *cctx;
+   int emitted;
+} chat_cli_stream_ctx_t;
+
+static void chat_cli_stream_cb(const char *delta, void *ud)
+{
+   chat_cli_stream_ctx_t *c = (chat_cli_stream_ctx_t *)ud;
+   if (!c || !delta || !delta[0])
+      return;
+   stream_event(c->cctx, "text", "content", delta);
+   c->emitted = 1;
 }
 
 static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, const char *cwd,
@@ -895,12 +641,17 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    if (drift)
       stream_event(cctx, "text", "content", drift);
    agent_tools_set_tool_event_cb(chat_tool_event_cb, cctx);
+   /* Stream a tmux CLI turn's reply incrementally (no-op for non-tmux agents,
+    * whose runtime never drives a cli_session). */
+   chat_cli_stream_ctx_t sctx = {cctx, 0};
+   cli_session_set_stream_cb(chat_cli_stream_cb, &sctx);
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
    int rc = agent_run_with_tools(&acfg, "code", system_prompt ? system_prompt : "", message,
                                  AGENT_DEFAULT_MAX_TOKENS, &result);
 
+   cli_session_set_stream_cb(NULL, NULL);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();
    workspace_turn_unbind_active();
@@ -915,7 +666,8 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
       return;
    }
 
-   if (result.response && result.response[0])
+   /* If the reply already streamed incrementally, don't re-emit it whole. */
+   if (!sctx.emitted && result.response && result.response[0])
       stream_event(cctx, "text", "content", result.response);
    stream_event(cctx, "turn_end", NULL, NULL);
    stream_event(cctx, "done", NULL, NULL);
@@ -1035,9 +787,14 @@ static int chat_provider_uses_codex_cli(const char *provider)
 {
    if (!provider)
       return 0;
+   /* codex-oauth runs the codex CLI as a persistent TUI over tmux (1:1 per aimee
+    * session) via the agent worker — NOT the one-shot app-server stream — so it
+    * must NOT be claimed here. */
+   if (strcmp(provider, "codex-oauth") == 0)
+      return 0;
    if (strcmp(provider, "codex-cli") == 0)
       return 1;
-   if (strcmp(provider, "codex") != 0 && strcmp(provider, "codex-oauth") != 0)
+   if (strcmp(provider, "codex") != 0)
       return 0;
 
    agent_config_t acfg;
@@ -1237,530 +994,28 @@ void chat_stream_worker(void *arg)
                                   &cfg);
       return;
    }
-   if (strcmp(provider, "claude") != 0 && strcmp(provider, "claude-code") != 0)
-   {
-      compute_ctx_release_budget(cctx);
-      if (chat_provider_uses_primary_session(provider, &cfg))
-      {
-         if (compact)
-            chat_stream_worker_primary_session_compact(cctx, provider_sid, aimee_sid, provider,
-                                                       model_override, &cfg);
-         else
-            chat_stream_worker_primary_session(cctx, message, provider_sid, cwd, aimee_sid,
-                                               provider, model_override, &cfg);
-      }
-      else
-      {
-         if (compact)
-         {
-            compute_error(cctx, "conversation compaction is not supported for this provider");
-            compute_ctx_free(cctx);
-         }
-         else
-            chat_stream_worker_agent(cctx, message, cwd, aimee_sid, provider, model_override, &cfg);
-      }
-      return;
-   }
-
-   if (compact)
-   {
-      compute_error(cctx, "conversation compaction is not supported for claude CLI chat");
-      compute_ctx_free(cctx);
-      return;
-   }
-
-   /* Detached (thin-client) workspace: the `claude` CLI, its login, tmux, and the
-    * working tree live on the CLIENT, not this (possibly containerized) server.
-    * Run the STANDARD `claude` CLI over tmux on the client — the cli_session
-    * driver marshals its tmux commands over the reverse channel — rather than
-    * the local `claude -p` path below. Co-located turns fall through to the
-    * local claude path. */
-   {
-      int detached_bound = workspace_turn_bind_active(cwd);
-      const workspace_provider_t *wsp = workspace_provider_active();
-      if (detached_bound && wsp && wsp->kind == WS_PROVIDER_DETACHED && wsp->exec_shell)
-      {
-         if (aimee_path_is_absolute(cwd) && !strstr(cwd, "/.."))
-            run_cmd_set_cwd(cwd);
-         if (aimee_sid && aimee_sid[0])
-            session_id_set_override(aimee_sid);
-
-         char *sys = read_webchat_system_prompt(cctx);
-         agent_t cag;
-         memset(&cag, 0, sizeof(cag));
-         snprintf(cag.name, sizeof(cag.name), "claude");
-         snprintf(cag.backend, sizeof(cag.backend), "%s", AGENT_BACKEND_TMUX_CLI);
-         snprintf(cag.cli_kind, sizeof(cag.cli_kind), "claude");
-         if (cfg.claude_model[0])
-            snprintf(cag.cli_cmd, sizeof(cag.cli_cmd), "claude --model %s", cfg.claude_model);
-         else
-            snprintf(cag.cli_cmd, sizeof(cag.cli_cmd), "claude");
-         cag.session_reuse = 1;
-
-         stream_event(cctx, "turn_start", NULL, NULL);
-         agent_result_t result;
-         memset(&result, 0, sizeof(result));
-         int rc = agent_execute_cli_session(&cag, NULL, sys ? sys : "", message,
-                                            AGENT_DEFAULT_MAX_TOKENS, 0.3, &result);
-
-         session_id_clear_override();
-         workspace_turn_unbind_active();
-         run_cmd_set_cwd(NULL);
-         free(sys);
-
-         if (rc != 0)
-         {
-            compute_error(cctx, result.error[0] ? result.error : "claude tmux session failed");
-            free(result.response);
-            compute_ctx_free(cctx);
-            return;
-         }
-         if (result.response && result.response[0])
-            stream_event(cctx, "text", "content", result.response);
-         stream_event(cctx, "turn_end", NULL, NULL);
-         stream_event(cctx, "done", NULL, NULL);
-         free(result.response);
-         compute_ok(cctx);
-         compute_ctx_free(cctx);
-         return;
-      }
-      workspace_turn_unbind_active();
-   }
-
-   /* The session id to `claude --resume` is server-owned and namespaced to
-    * (principal, aimee_session_id) — not taken blindly from the client — so a
-    * stale/cross-wired browser value cannot resume another tab's conversation. */
-   char claude_sid_buf[128];
-   chat_claude_resolve_resume_sid(cctx->vault_principal, aimee_sid, provider_sid, claude_sid_buf,
-                                  sizeof(claude_sid_buf));
-   const char *claude_sid = claude_sid_buf;
-   compute_pool_set_job(POOL_JOB_CHAT, "provider=%s sid=%s", provider,
-                        claude_sid && claude_sid[0] ? claude_sid : "new");
-
-   char *system_prompt = read_webchat_system_prompt(cctx);
-
-   char *argv[32];
-   int argc = 0;
-   argv[argc++] = "claude";
-   argv[argc++] = "-p";
-   argv[argc++] = "--output-format";
-   argv[argc++] = "stream-json";
-   argv[argc++] = "--verbose";
-   argv[argc++] = "--include-partial-messages";
-   /* Do not whitelist tools — allow all configured tools (including aimee MCP)
-    * so the primary-agent chat has the full aimee toolset available. Only
-    * disallow tools that would deadlock or recurse in an unattended context. */
-   argv[argc++] = "--disallowedTools";
-   argv[argc++] = "AskUserQuestion,Agent,RemoteTrigger";
-   if (system_prompt && system_prompt[0])
-   {
-      argv[argc++] = "--append-system-prompt";
-      argv[argc++] = system_prompt;
-   }
-   const char *claude_model =
-       chat_model_passthrough_allowed(model_override) ? model_override : cfg.claude_model;
-   if (claude_model && claude_model[0])
-   {
-      argv[argc++] = "--model";
-      argv[argc++] = (char *)claude_model;
-   }
-   int claude_effort_explicit = chat_claude_effort_allowed(effort_override);
-   const char *claude_effort =
-       claude_effort_explicit ? effort_override : cfg.model_reasoning_effort;
-   /* §5: cap (only lower) the config-derived effort by turn complexity; leave an
-    * explicit per-request override untouched. */
-   if (cfg.reasoning_cap_enabled && !claude_effort_explicit)
-   {
-      int score = reasoning_complexity_score(1, message ? strlen(message) : 0, 1);
-      claude_effort = reasoning_effort_capped(claude_effort, score);
-   }
-   if (chat_claude_effort_allowed(claude_effort))
-   {
-      argv[argc++] = "--effort";
-      argv[argc++] = (char *)claude_effort;
-   }
-   if (claude_sid[0] && chat_claude_session_exists(claude_sid))
-   {
-      argv[argc++] = "--resume";
-      argv[argc++] = (char *)claude_sid;
-   }
-   /* else: the requested session is gone (e.g. cleared by a redeploy) — start a
-    * fresh session instead of letting --resume fail the entire turn. */
-   if (cfg.autonomous)
-      argv[argc++] = "--dangerously-skip-permissions";
-   argv[argc] = NULL;
-
-   /* Create pipes */
-   int in_pipe[2] = {-1, -1};
-   int out_pipe[2] = {-1, -1};
-   if (pipe(in_pipe) < 0 || pipe(out_pipe) < 0)
-   {
-      free(system_prompt);
-      compute_error(cctx, "pipe failed");
-      compute_ctx_free(cctx);
-      return;
-   }
-
-   char err_path[64] = {0};
-   snprintf(err_path, sizeof(err_path), "/tmp/aimee-claude-%d-XXXXXX", (int)getpid());
-   int err_fd = mkstemp(err_path);
-   if (err_fd < 0)
-      err_path[0] = '\0';
-
-   pid_t pid = fork();
-   if (pid < 0)
-   {
-      close(in_pipe[0]);
-      close(in_pipe[1]);
-      close(out_pipe[0]);
-      close(out_pipe[1]);
-      if (err_fd >= 0)
-      {
-         close(err_fd);
-         unlink(err_path);
-      }
-      free(system_prompt);
-      compute_error(cctx, "fork failed");
-      compute_ctx_free(cctx);
-      return;
-   }
-
-   if (pid == 0)
-   {
-      /* Child */
-#ifdef __linux__
-      /* Die when the daemon dies, so a clean redeploy doesn't leave
-       * orphaned shells running streaming sub-processes. */
-      prctl(PR_SET_PDEATHSIG, SIGTERM, 0, 0, 0);
-      if (getppid() == 1)
-         _exit(0);
-#endif
-      close(in_pipe[1]);
-      close(out_pipe[0]);
-      dup2(in_pipe[0], STDIN_FILENO);
-      dup2(out_pipe[1], STDOUT_FILENO);
-      close(in_pipe[0]);
-      close(out_pipe[1]);
-      if (err_fd >= 0)
-      {
-         dup2(err_fd, STDERR_FILENO);
-         close(err_fd);
-      }
-      else
-      {
-         int devnull = open("/dev/null", O_WRONLY);
-         if (devnull >= 0)
-         {
-            dup2(devnull, STDERR_FILENO);
-            close(devnull);
-         }
-      }
-      if (cwd && cwd[0] && chdir(cwd) != 0)
-      {
-         dprintf(STDERR_FILENO, "aimee: chdir(%s) failed: %s\n", cwd, strerror(errno));
-         _exit(126);
-      }
-      /* Expose the aimee session to the MCP server so it can resolve
-       * session context via AIMEE_SESSION_ID rather than the PPID file
-       * (which would be keyed to aimee-server's PID, not the CLI's). */
-      if (aimee_sid && aimee_sid[0])
-         setenv("AIMEE_SESSION_ID", aimee_sid, 1);
-      char claude_bin_buf[1024];
-      const char *claude_bin = resolve_claude_bin(claude_bin_buf, sizeof(claude_bin_buf));
-      execvp(claude_bin, argv);
-      dprintf(STDERR_FILENO, "aimee: exec(%s) failed: %s\n", claude_bin, strerror(errno));
-      _exit(127);
-   }
-
-   /* Parent */
-   close(in_pipe[0]);
-   close(out_pipe[1]);
-   if (err_fd >= 0)
-      close(err_fd);
-   free(system_prompt);
-
-   /* Make the read end non-blocking BEFORE registering the child, so a cancel
-    * racing in right after registration always meets the poll-driven loop in its
-    * non-blocking state (never a blocking read()). pid is the child here (the
-    * fork-failure path returned above), but guard defensively. */
-   {
-      int fl = fcntl(out_pipe[0], F_GETFL, 0);
-      if (fl >= 0)
-         fcntl(out_pipe[0], F_SETFL, fl | O_NONBLOCK);
-   }
-   /* Register the child with the per-turn cancel registry (this worker is the
-    * sole reaper of this pid). */
-   if (pid > 0)
-      turn_registry_set_child(cctx->turn_entry, pid);
-
-   /* Write message to stdin */
-   size_t msg_len = strlen(message);
-   size_t written = 0;
-   while (written < msg_len)
-   {
-      ssize_t w = write(in_pipe[1], message + written, msg_len - written);
-      if (w <= 0)
-         break;
-      written += (size_t)w;
-   }
-   close(in_pipe[1]);
-
-   /* Release the compute budget slot now that the subprocess is running.
-    * The read loop below is pure I/O; holding server compute budget here
-    * would starve MCP/tool callbacks that the provider makes back into
-    * aimee-server while it waits for their results. */
+   /* Everything else — claude-oauth / codex-oauth / claude / claude-code (the
+    * persistent CLI TUIs, driven over tmux 1:1 per aimee session through the
+    * agent worker -> agent_execute_cli_session) and the in-process HTTP API
+    * providers (primary-session adapters). NEVER `claude -p`: a one-shot print
+    * process cannot multiplex concurrent sessions into isolated persistent
+    * panes, which is the whole point of a per-session tmux CLI session. */
    compute_ctx_release_budget(cctx);
-
-   /* Read stream-json output via a cancellable, non-blocking line reader.
-    * NB: the loop no longer consults conn_alive — a dropped client connection
-    * detaches but does NOT abort the turn (server-owned turn lifecycle); the
-    * turn ends only on provider EOF or an explicit cancel. */
-   char *line = malloc(CLAUDE_LINE_MAX);
-   cli_linereader_t *lr = malloc(sizeof(*lr));
-   if (!line || !lr)
+   if (chat_provider_uses_primary_session(provider, &cfg))
    {
-      free(line);
-      free(lr);
-      close(out_pipe[0]);
-      kill(pid, SIGKILL);
-      waitpid(pid, NULL, 0);
-      turn_registry_mark_reaped(cctx->turn_entry);
-      compute_error(cctx, "out of memory");
-      compute_ctx_free(cctx);
-      return;
-   }
-   lr->len = 0;
-
-   int had_tool_result = 0;
-   int first_message = 1;
-   int saw_result = 0;
-   int saw_content = 0;
-   int saw_delta_text = 0;
-   int cancelled = 0;
-   int eof = 0;
-   char provider_error[1024] = "";
-
-   while (cli_read_line(out_pipe[0], lr, cctx->turn_entry, line, CLAUDE_LINE_MAX, &cancelled, &eof))
-   {
-      cJSON *obj = cJSON_Parse(line);
-      if (!obj)
-         continue;
-
-      cJSON *type_j = cJSON_GetObjectItem(obj, "type");
-      const char *type = (type_j && cJSON_IsString(type_j)) ? type_j->valuestring : "";
-
-      if (strcmp(type, "stream_event") == 0)
-      {
-         cJSON *event = cJSON_GetObjectItem(obj, "event");
-         if (event)
-         {
-            cJSON *etype = cJSON_GetObjectItem(event, "type");
-            const char *et = (etype && cJSON_IsString(etype)) ? etype->valuestring : "";
-
-            if (strcmp(et, "message_start") == 0)
-            {
-               if (first_message || had_tool_result)
-               {
-                  stream_event(cctx, "turn_start", NULL, NULL);
-                  first_message = 0;
-               }
-               had_tool_result = 0;
-               saw_delta_text = 0;
-            }
-            else if (strcmp(et, "content_block_delta") == 0)
-            {
-               cJSON *delta = cJSON_GetObjectItem(event, "delta");
-               cJSON *dt = delta ? cJSON_GetObjectItem(delta, "type") : NULL;
-               const char *dts = (dt && cJSON_IsString(dt)) ? dt->valuestring : "";
-
-               if (strcmp(dts, "text_delta") == 0)
-               {
-                  cJSON *text = cJSON_GetObjectItem(delta, "text");
-                  if (text && cJSON_IsString(text) && text->valuestring[0])
-                  {
-                     saw_content = 1;
-                     saw_delta_text = 1;
-                     stream_event(cctx, "text", "content", text->valuestring);
-                  }
-               }
-               else if (strcmp(dts, "thinking_delta") == 0)
-               {
-                  cJSON *text = cJSON_GetObjectItem(delta, "thinking");
-                  if (text && cJSON_IsString(text) && text->valuestring[0])
-                  {
-                     saw_content = 1;
-                     stream_event(cctx, "thinking", "content", text->valuestring);
-                  }
-               }
-            }
-            else if (strcmp(et, "message_stop") == 0)
-            {
-               stream_event(cctx, "turn_end", NULL, NULL);
-            }
-         }
-      }
-      else if (strcmp(type, "tool_result") == 0 || strcmp(type, "user") == 0)
-      {
-         had_tool_result = 1;
-      }
-      else if (strcmp(type, "assistant") == 0)
-      {
-         cJSON *message = cJSON_GetObjectItem(obj, "message");
-         cJSON *content = message ? cJSON_GetObjectItem(message, "content")
-                                  : cJSON_GetObjectItem(obj, "content");
-         if (!saw_delta_text)
-            chat_claude_stream_content(cctx, content, &saw_content);
-         cJSON *err = cJSON_GetObjectItem(obj, "error");
-         if (cJSON_IsString(err) && err->valuestring[0] && !provider_error[0])
-            snprintf(provider_error, sizeof(provider_error), "%s", err->valuestring);
-      }
-      else if (strcmp(type, "result") == 0)
-      {
-         saw_result = 1;
-         cJSON *sid = cJSON_GetObjectItem(obj, "session_id");
-         if (sid && cJSON_IsString(sid) && sid->valuestring[0])
-         {
-            stream_event(cctx, "session", "id", sid->valuestring);
-            /* Bind this Claude session to (principal, tab) so subsequent turns
-             * resume it by server-owned identity, not by client-supplied id. */
-            if (aimee_sid && aimee_sid[0])
-               (void)db1_webchat_claude_session_bind(cctx->vault_principal, aimee_sid,
-                                                     sid->valuestring);
-         }
-         cJSON *is_error = cJSON_GetObjectItem(obj, "is_error");
-         cJSON *api_status = cJSON_GetObjectItem(obj, "api_error_status");
-         if ((cJSON_IsBool(is_error) && cJSON_IsTrue(is_error)) ||
-             (cJSON_IsNumber(api_status) && api_status->valuedouble > 0))
-         {
-            cJSON *result = cJSON_GetObjectItem(obj, "result");
-            if (cJSON_IsString(result) && result->valuestring[0])
-               snprintf(provider_error, sizeof(provider_error), "%s", result->valuestring);
-            else if (!provider_error[0])
-               snprintf(provider_error, sizeof(provider_error), "claude provider request failed");
-         }
-         cJSON *jusage = cJSON_GetObjectItem(obj, "usage");
-         if (cJSON_IsObject(jusage))
-         {
-            token_usage_t tu;
-            memset(&tu, 0, sizeof(tu));
-            cJSON *jin = cJSON_GetObjectItem(jusage, "input_tokens");
-            cJSON *jout = cJSON_GetObjectItem(jusage, "output_tokens");
-            cJSON *jcw = cJSON_GetObjectItem(jusage, "cache_creation_input_tokens");
-            cJSON *jcr = cJSON_GetObjectItem(jusage, "cache_read_input_tokens");
-            if (cJSON_IsNumber(jin))
-               tu.input_tokens = (int)jin->valuedouble;
-            if (cJSON_IsNumber(jout))
-               tu.output_tokens = (int)jout->valuedouble;
-            if (cJSON_IsNumber(jcw))
-               tu.cache_write_tokens = (int)jcw->valuedouble;
-            if (cJSON_IsNumber(jcr))
-               tu.cache_read_tokens = (int)jcr->valuedouble;
-            double cost = token_estimate_cost(
-                claude_model && claude_model[0] ? claude_model : cfg.claude_model, &tu);
-            int in_total = tu.input_tokens + tu.cache_write_tokens + tu.cache_read_tokens;
-            stream_event_usage(cctx, in_total, tu.output_tokens, cost);
-         }
-      }
-
-      cJSON_Delete(obj);
-   }
-
-   (void)eof; /* natural EOF is the normal completion path */
-   free(line);
-   free(lr);
-   close(out_pipe[0]);
-
-   /* Single-reap: this worker is the sole reaper of its child (the racing
-    * disconnect-kill is gone). On cancel, SIGTERM then a bounded wait then
-    * SIGKILL; otherwise reap the naturally-exited child. EINTR is retried;
-    * the reaped flag guards against any double-reap. */
-   int status = 0;
-   if (!cctx->turn_entry || !cctx->turn_entry->reaped)
-   {
-      if (cancelled && pid > 0)
-      {
-         kill(pid, SIGTERM);
-         for (int _w = 0; _w < 50; _w++)
-         {
-            int _ws = 0;
-            int wr = waitpid(pid, &_ws, WNOHANG);
-            if (wr > 0)
-            {
-               status = _ws;
-               pid = -1;
-               break;
-            }
-            if (wr < 0 && errno != EINTR)
-            {
-               pid = -1;
-               break;
-            }
-            usleep(100000); /* 100 ms per try, 5 s total */
-         }
-         if (pid > 0)
-            kill(pid, SIGKILL);
-      }
-      if (pid > 0)
-      {
-         int wr;
-         do
-         {
-            wr = waitpid(pid, &status, 0);
-         } while (wr < 0 && errno == EINTR);
-         if (wr < 0)
-         {
-            /* No child to reap (ECHILD) or an unexpected error: there is no exit
-             * status to classify, so fall back to status=0 and let the
-             * output-presence check below (saw_result/saw_content) decide
-             * success vs. failure. */
-            if (errno != ECHILD)
-               LOG_WARN("chat", "waitpid(%d) failed: %s", (int)pid, strerror(errno));
-            status = 0;
-         }
-      }
-      turn_registry_mark_reaped(cctx->turn_entry);
-   }
-
-   char *stderr_text = err_path[0] ? read_optional_text_file(err_path) : NULL;
-   if (err_path[0])
-      unlink(err_path);
-
-   if (cancelled)
-   {
-      /* The turn was cancelled (session close / shutdown / graceful_cancel). */
-      free(stderr_text);
-      stream_event(cctx, "error", "message", "turn cancelled");
-      compute_error(cctx, "turn cancelled");
-      compute_ctx_free(cctx);
-      return;
-   }
-
-   if (provider_error[0] || !WIFEXITED(status) || WEXITSTATUS(status) != 0 ||
-       (!saw_result && !saw_content))
-   {
-      char msg[1024];
-      if (provider_error[0])
-         snprintf(msg, sizeof(msg), "%s", provider_error);
-      else if (!WIFEXITED(status))
-         snprintf(msg, sizeof(msg), "claude exited abnormally%s%s",
-                  stderr_text && stderr_text[0] ? ": " : "",
-                  stderr_text && stderr_text[0] ? stderr_text : "");
-      else if (WEXITSTATUS(status) != 0)
-         snprintf(msg, sizeof(msg), "claude exited with status %d%s%s", WEXITSTATUS(status),
-                  stderr_text && stderr_text[0] ? ": " : "",
-                  stderr_text && stderr_text[0] ? stderr_text : "");
+      if (compact)
+         chat_stream_worker_primary_session_compact(cctx, provider_sid, aimee_sid, provider,
+                                                    model_override, &cfg);
       else
-         snprintf(msg, sizeof(msg), "claude exited without producing a result%s%s",
-                  stderr_text && stderr_text[0] ? ": " : "",
-                  stderr_text && stderr_text[0] ? stderr_text : "");
-      stream_event(cctx, "error", "message", msg);
-      free(stderr_text);
-      compute_error(cctx, msg);
-      compute_ctx_free(cctx);
-      return;
+         chat_stream_worker_primary_session(cctx, message, provider_sid, cwd, aimee_sid, provider,
+                                            model_override, &cfg);
    }
-   free(stderr_text);
-   stream_event(cctx, "done", NULL, NULL);
-   compute_ok(cctx);
-   compute_ctx_free(cctx);
+   else if (compact)
+   {
+      compute_error(cctx, "conversation compaction is not supported for this provider");
+      compute_ctx_free(cctx);
+   }
+   else
+      chat_stream_worker_agent(cctx, message, cwd, aimee_sid, provider, model_override, &cfg);
+   return;
 }

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -252,8 +252,11 @@ int cli_session_send(cli_session_t *s, const char *message)
    }
    free(buf);
 
-   /* Load temp file as tmux buffer, paste into session, then press Enter */
-   char cmd[512];
+   /* Load temp file as tmux buffer, paste into session, then press Enter. Sized
+    * to hold the longest command (load-buffer with both the per-session buffer
+    * name and the per-session tmpfile, each derived from the session name) with
+    * margin, so a long session name cannot truncate the tmux command. */
+   char cmd[3 * CLI_SESSION_NAME_MAX + 128];
    int rc;
    char *out;
 

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -70,6 +70,13 @@ void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud)
    g_stream_ud = ud;
 }
 
+cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out)
+{
+   if (ud_out)
+      *ud_out = g_stream_ud;
+   return g_stream_cb;
+}
+
 void cli_session_set_kind(cli_session_t *s, const char *cli_kind)
 {
    if (!s)
@@ -197,16 +204,16 @@ int cli_session_send(cli_session_t *s, const char *message)
     * the same host as the tmux session: on a detached workspace that is the
     * CLIENT (write via the provider), else the local fs.
     *
-    * Both the tmpfile and the tmux paste buffer are keyed per session: concurrent
-    * turns on different panes would otherwise race a single shared `aimee_msg`
-    * buffer / `/tmp/aimee_msg_<pid>.txt` and paste each other's prompt into the
-    * wrong pane. */
+    * Both the tmpfile and the tmux paste buffer are keyed on the (unique,
+    * tmux-sanitized) session name: concurrent turns on different panes would
+    * otherwise race a single shared `aimee_msg` buffer / `/tmp/aimee_msg_<pid>.txt`
+    * and paste each other's prompt into the wrong pane. Using the full name (not
+    * a 32-bit hash) rules out a collision reintroducing that exact bleed. */
    int detached = sess_detached();
-   unsigned long skey = djb2(s->session_name) & 0xffffffff;
-   char tmpfile[96];
-   snprintf(tmpfile, sizeof(tmpfile), "/tmp/aimee_msg_%d_%08lx.txt", (int)getpid(), skey);
-   char bufname[48];
-   snprintf(bufname, sizeof(bufname), "aimee_msg_%08lx", skey);
+   char tmpfile[64 + CLI_SESSION_NAME_MAX];
+   snprintf(tmpfile, sizeof(tmpfile), "/tmp/aimee_msg_%d_%s.txt", (int)getpid(), s->session_name);
+   char bufname[16 + CLI_SESSION_NAME_MAX];
+   snprintf(bufname, sizeof(bufname), "aimee_msg_%s", s->session_name);
 
    /* Paste the message verbatim — no trailing newline. A newline inside the
     * pasted buffer lands in the CLI's multi-line composer as a literal line
@@ -351,6 +358,45 @@ static int cli_line_is_chrome(const char *t)
    return 0;
 }
 
+/* True if `body` appears as a whole line in `baseline` (after lstrip and an
+ * optional leading assistant marker). A substring test would false-exclude a
+ * short reply ("ok", "yes", a number) that merely occurs inside a longer prior
+ * line — silently dropping the current turn — so the match is line-exact. */
+static int cli_body_in_baseline(const char *baseline, const char *amark, const char *body)
+{
+   if (!baseline || !*baseline || !body || !*body)
+      return 0;
+   size_t blen = strlen(body);
+   for (const char *p = baseline; p && *p;)
+   {
+      const char *eol = strchr(p, '\n');
+      size_t llen = eol ? (size_t)(eol - p) : strlen(p);
+      const char *ls = p;
+      size_t ll = llen;
+      while (ll && (*ls == ' ' || *ls == '\t'))
+      {
+         ls++;
+         ll--;
+      }
+      if (ll >= 3 && strncmp(ls, amark, 3) == 0)
+      {
+         ls += 3;
+         ll -= 3;
+         while (ll && (*ls == ' ' || *ls == '\t'))
+         {
+            ls++;
+            ll--;
+         }
+      }
+      if (ll == blen && strncmp(ls, body, blen) == 0)
+         return 1;
+      if (!eol)
+         break;
+      p = eol + 1;
+   }
+   return 0;
+}
+
 char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline)
 {
    char *text = cli_session_strip_ansi(raw ? raw : "");
@@ -393,11 +439,14 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
       p = nl + 1;
    }
 
-   /* The answer is the LAST assistant block that is NOT already in the baseline
-    * (pre-send) pane. Anchoring on the assistant marker — not the user prompt —
-    * sidesteps the composer's greyed placeholder, which also carries the user
-    * marker. Excluding baseline lines drops prior turns still on a reused pane
-    * and any startup banner/hook that fired before the turn. */
+   /* The answer is the assistant content of THIS turn: from the FIRST assistant
+    * bullet not already in the baseline (pre-send) pane, through every following
+    * bullet/continuation line, up to the trailing status/composer. Anchoring on
+    * the assistant marker — not the user prompt — sidesteps the composer's greyed
+    * placeholder (which also carries the user marker); excluding baseline bullets
+    * drops prior turns still on a reused pane and any startup banner/hook that
+    * fired before the turn; collecting ALL following bullets (not just the last)
+    * keeps multi-paragraph / multi-bullet answers whole. */
    long block = -1;
    for (size_t i = 0; i < n; i++)
    {
@@ -407,9 +456,10 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
       const char *body = cli_lstrip(t + 3);
       if (!*body)
          continue;
-      if (baseline && baseline[0] && strstr(baseline, body))
-         continue; /* same bullet text was already on the pane before this turn */
+      if (cli_body_in_baseline(baseline, amark, body))
+         continue; /* this bullet was already on the pane before this turn */
       block = (long)i;
+      break;
    }
 
    char *res = NULL;
@@ -427,10 +477,10 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
       for (size_t i = (size_t)block; i < n; i++)
       {
          const char *t = cli_lstrip(lines[i]);
-         if (i != (size_t)block && (strncmp(t, amark, 3) == 0 || strncmp(t, umark, 3) == 0))
-            break; /* next bullet or the composer ends the block */
+         if (strncmp(t, umark, 3) == 0)
+            break; /* composer / next user turn ends the answer */
          if (cli_line_is_chrome(t))
-            break;
+            break; /* status (✻) / separator / footer ends the answer */
          const char *content = (strncmp(t, amark, 3) == 0) ? cli_lstrip(t + 3) : t;
          size_t cl = strlen(content);
          if (rlen + cl + 2 > rcap)

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -58,6 +58,39 @@ static long long mono_ms(void)
    return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
+/* Per-thread incremental stream callback (set by the chat worker before a turn,
+ * cleared after). Thread-local so concurrent turns on the pool never see each
+ * other's sink. */
+static __thread cli_session_stream_cb_t g_stream_cb = NULL;
+static __thread void *g_stream_ud = NULL;
+
+void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud)
+{
+   g_stream_cb = cb;
+   g_stream_ud = ud;
+}
+
+void cli_session_set_kind(cli_session_t *s, const char *cli_kind)
+{
+   if (!s)
+      return;
+   snprintf(s->cli_kind, sizeof(s->cli_kind), "%s", cli_kind ? cli_kind : "");
+}
+
+void cli_session_mark_baseline(cli_session_t *s)
+{
+   if (!s)
+      return;
+   free(s->baseline);
+   s->baseline = NULL;
+   char *cap = malloc(CLI_SESSION_BUF_MAX);
+   if (!cap)
+      return;
+   if (cli_session_capture(s, cap, CLI_SESSION_BUF_MAX) == 0)
+      s->baseline = cli_session_strip_ansi(cap);
+   free(cap);
+}
+
 static void cli_session_capture_cmd(const cli_session_t *s, char *cmd, size_t cmd_len)
 {
    snprintf(cmd, cmd_len, "tmux capture-pane -p -t '%s' 2>/dev/null", s->session_name);
@@ -136,6 +169,10 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
 
 void cli_session_destroy(cli_session_t *s)
 {
+   free(s->baseline);
+   s->baseline = NULL;
+   free(s->stream_emitted);
+   s->stream_emitted = NULL;
    if (!s->active)
       return;
    if (!cli_session_is_alive(s))
@@ -158,21 +195,32 @@ int cli_session_send(cli_session_t *s, const char *message)
 
    /* Write message to a temp file to avoid quoting issues. The file must live on
     * the same host as the tmux session: on a detached workspace that is the
-    * CLIENT (write via the provider), else the local fs. */
+    * CLIENT (write via the provider), else the local fs.
+    *
+    * Both the tmpfile and the tmux paste buffer are keyed per session: concurrent
+    * turns on different panes would otherwise race a single shared `aimee_msg`
+    * buffer / `/tmp/aimee_msg_<pid>.txt` and paste each other's prompt into the
+    * wrong pane. */
    int detached = sess_detached();
-   char tmpfile[64];
-   snprintf(tmpfile, sizeof(tmpfile), "/tmp/aimee_msg_%d.txt", (int)getpid());
+   unsigned long skey = djb2(s->session_name) & 0xffffffff;
+   char tmpfile[96];
+   snprintf(tmpfile, sizeof(tmpfile), "/tmp/aimee_msg_%d_%08lx.txt", (int)getpid(), skey);
+   char bufname[48];
+   snprintf(bufname, sizeof(bufname), "aimee_msg_%08lx", skey);
 
-   /* Build the message with a trailing newline for CLI submission. */
+   /* Paste the message verbatim — no trailing newline. A newline inside the
+    * pasted buffer lands in the CLI's multi-line composer as a literal line
+    * break (codex) rather than a submit; submission is the explicit Enter
+    * keypress below, after a short settle so the TUI has finished ingesting the
+    * bracketed paste. */
    size_t mlen = strlen(message);
-   int need_nl = (mlen == 0 || message[mlen - 1] != '\n');
-   size_t blen = mlen + (need_nl ? 1 : 0);
+   size_t blen = mlen;
+   while (blen > 0 && (message[blen - 1] == '\n' || message[blen - 1] == '\r'))
+      blen--;
    char *buf = malloc(blen + 1);
    if (!buf)
       return -1;
-   memcpy(buf, message, mlen);
-   if (need_nl)
-      buf[mlen] = '\n';
+   memcpy(buf, message, blen);
    buf[blen] = '\0';
 
    if (detached)
@@ -202,7 +250,7 @@ int cli_session_send(cli_session_t *s, const char *message)
    int rc;
    char *out;
 
-   snprintf(cmd, sizeof(cmd), "tmux load-buffer -b aimee_msg '%s' 2>/dev/null", tmpfile);
+   snprintf(cmd, sizeof(cmd), "tmux load-buffer -b %s '%s' 2>/dev/null", bufname, tmpfile);
    out = sess_run(cmd, &rc);
    free(out);
    if (rc != 0)
@@ -217,10 +265,17 @@ int cli_session_send(cli_session_t *s, const char *message)
       return -1;
    }
 
-   snprintf(cmd, sizeof(cmd), "tmux paste-buffer -b aimee_msg -t '%s' -d 2>/dev/null",
+   snprintf(cmd, sizeof(cmd), "tmux paste-buffer -b %s -t '%s' -d 2>/dev/null", bufname,
             s->session_name);
    out = sess_run(cmd, &rc);
    free(out);
+
+   /* Let the TUI finish ingesting the paste before submitting. A fast Enter can
+    * land before the composer has the text — codex in particular leaves the
+    * pasted text on a composer continuation line and ignores the Enter, so the
+    * turn never starts. 500ms reliably clears this for claude and codex;
+    * negligible next to a multi-second turn. */
+   msleep_ms(500);
 
    /* Send Enter to submit */
    snprintf(cmd, sizeof(cmd), "tmux send-keys -t '%s' Enter 2>/dev/null", s->session_name);
@@ -260,6 +315,157 @@ int cli_session_capture(cli_session_t *s, char *out, size_t out_max)
    return 0;
 }
 
+/* --- TUI response extraction --------------------------------------------- */
+
+static const char *cli_lstrip(const char *s)
+{
+   while (*s == ' ' || *s == '\t')
+      s++;
+   return s;
+}
+
+/* A horizontal rule / box edge (run of ─ ╭ ╮ ╰ ╯ │) with no letters/digits. */
+static int cli_line_is_rule(const char *t)
+{
+   if (strncmp(t, "\xe2\x94\x80", 3) != 0 && strncmp(t, "\xe2\x95\xad", 3) != 0 &&
+       strncmp(t, "\xe2\x95\xb0", 3) != 0 && strncmp(t, "\xe2\x94\x82", 3) != 0)
+      return 0;
+   for (const char *p = t; *p; p++)
+      if ((*p >= 'A' && *p <= 'Z') || (*p >= 'a' && *p <= 'z') || (*p >= '0' && *p <= '9'))
+         return 0;
+   return 1;
+}
+
+/* Lines that mark the end of (or are not part of) the assistant's answer:
+ * the claude status star, separators, footers, interrupt hints. */
+static int cli_line_is_chrome(const char *t)
+{
+   if (strncmp(t, "\xe2\x9c\xbb", 3) == 0) /* ✻ claude "Cooked/Baked for Ns" status */
+      return 1;
+   if (cli_line_is_rule(t))
+      return 1;
+   if (strstr(t, "? for shortcuts") || strstr(t, "for agents") || strstr(t, "to interrupt") ||
+       strstr(t, "tmux detected") || strstr(t, "Shell cwd was reset") ||
+       strstr(t, "Update available") || strstr(t, "/model to change"))
+      return 1;
+   return 0;
+}
+
+char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline)
+{
+   char *text = cli_session_strip_ansi(raw ? raw : "");
+   if (!text)
+      return strdup("");
+
+   int codex = (cli_kind && strstr(cli_kind, "codex") != NULL);
+   const char *amark = codex ? "\xe2\x80\xa2" : "\xe2\x97\x8f"; /* • / ● assistant bullet */
+   const char *umark = codex ? "\xe2\x80\xba" : "\xe2\x9d\xaf"; /* › / ❯ user prompt */
+
+   /* Split a COPY into NUL-terminated lines (the split rewrites '\n' to '\0', so
+    * `text` must stay intact for the fallback path and for sizing the result). */
+   size_t textlen = strlen(text);
+   char *work = strdup(text);
+   if (!work)
+      return text;
+   size_t cap_lines = 256, n = 0;
+   char **lines = malloc(cap_lines * sizeof(char *));
+   if (!lines)
+   {
+      free(work);
+      return text; /* degrade: whole stripped pane */
+   }
+   for (char *p = work;;)
+   {
+      char *nl = strchr(p, '\n');
+      if (nl)
+         *nl = '\0';
+      if (n == cap_lines)
+      {
+         cap_lines *= 2;
+         char **t2 = realloc(lines, cap_lines * sizeof(char *));
+         if (!t2)
+            break;
+         lines = t2;
+      }
+      lines[n++] = p;
+      if (!nl)
+         break;
+      p = nl + 1;
+   }
+
+   /* The answer is the LAST assistant block that is NOT already in the baseline
+    * (pre-send) pane. Anchoring on the assistant marker — not the user prompt —
+    * sidesteps the composer's greyed placeholder, which also carries the user
+    * marker. Excluding baseline lines drops prior turns still on a reused pane
+    * and any startup banner/hook that fired before the turn. */
+   long block = -1;
+   for (size_t i = 0; i < n; i++)
+   {
+      const char *t = cli_lstrip(lines[i]);
+      if (strncmp(t, amark, 3) != 0)
+         continue;
+      const char *body = cli_lstrip(t + 3);
+      if (!*body)
+         continue;
+      if (baseline && baseline[0] && strstr(baseline, body))
+         continue; /* same bullet text was already on the pane before this turn */
+      block = (long)i;
+   }
+
+   char *res = NULL;
+   if (block >= 0)
+   {
+      size_t rcap = textlen + 2, rlen = 0;
+      res = malloc(rcap);
+      if (!res)
+      {
+         free(lines);
+         free(work);
+         return text;
+      }
+      res[0] = '\0';
+      for (size_t i = (size_t)block; i < n; i++)
+      {
+         const char *t = cli_lstrip(lines[i]);
+         if (i != (size_t)block && (strncmp(t, amark, 3) == 0 || strncmp(t, umark, 3) == 0))
+            break; /* next bullet or the composer ends the block */
+         if (cli_line_is_chrome(t))
+            break;
+         const char *content = (strncmp(t, amark, 3) == 0) ? cli_lstrip(t + 3) : t;
+         size_t cl = strlen(content);
+         if (rlen + cl + 2 > rcap)
+            break;
+         memcpy(res + rlen, content, cl);
+         rlen += cl;
+         res[rlen++] = '\n';
+         res[rlen] = '\0';
+      }
+      /* Trim trailing/leading blank lines and spaces. */
+      while (rlen > 0 && (res[rlen - 1] == '\n' || res[rlen - 1] == ' ' || res[rlen - 1] == '\t'))
+         res[--rlen] = '\0';
+   }
+
+   free(lines);
+   free(work);
+   if (res && res[0])
+   {
+      free(text);
+      return res;
+   }
+   free(res);
+
+   /* Fallback: no parseable bullet (e.g. a future TUI restyle). Return the
+    * portion not already in the baseline so a reused pane still never replays a
+    * prior turn, even if chrome leaks through. */
+   if (baseline && baseline[0])
+   {
+      char *delta = cli_session_delta(baseline, text);
+      free(text);
+      return delta ? delta : strdup("");
+   }
+   return text;
+}
+
 int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms)
 {
    if (!s->active || !out || out_max == 0)
@@ -268,6 +474,8 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    int stable = 0;
    unsigned long prev_hash = 0;
    long long start = mono_ms();
+   free(s->stream_emitted);
+   s->stream_emitted = strdup("");
 
    for (;;)
    {
@@ -295,13 +503,39 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
       if (cli_session_capture(s, cap, sizeof(cap)) != 0)
          continue;
 
+      /* Stream the clean answer's growth as it is produced: extract this turn's
+       * response so far and emit only the newly appended suffix. */
+      if (g_stream_cb)
+      {
+         char *partial = cli_session_extract_response(cap, s->cli_kind, s->baseline);
+         const char *prev = s->stream_emitted ? s->stream_emitted : "";
+         size_t plen = strlen(prev);
+         if (partial && strncmp(partial, prev, plen) == 0 && partial[plen])
+         {
+            g_stream_cb(partial + plen, g_stream_ud);
+            free(s->stream_emitted);
+            s->stream_emitted = partial;
+         }
+         else if (partial && strcmp(partial, prev) != 0)
+         {
+            /* A redraw rewrote earlier text (rare): adopt it silently, do not
+             * re-emit, so the caller's transcript is not duplicated. */
+            free(s->stream_emitted);
+            s->stream_emitted = partial;
+         }
+         else
+            free(partial);
+      }
+
       unsigned long h = djb2(cap);
       if (h == prev_hash)
       {
          stable++;
          if (stable >= CLI_SESSION_STABLE_N)
          {
-            snprintf(out, out_max, "%s", cap);
+            char *resp = cli_session_extract_response(cap, s->cli_kind, s->baseline);
+            snprintf(out, out_max, "%s", resp ? resp : "");
+            free(resp);
             s->last_activity = time(NULL);
             return 0;
          }

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -250,8 +250,89 @@ static void test_delta_non_prefix_falls_back_to_full(void)
    free(out);
 }
 
+/* --- response extraction (TUI scrape) --------------------------------------
+ * Markers: claude assistant ●(\xe2\x97\x8f) user ❯(\xe2\x9d\xaf) status ✻(\xe2\x9c\xbb);
+ * codex assistant •(\xe2\x80\xa2) user ›(\xe2\x80\xba). Captures mirror the real panes. */
+
+static void test_extract_claude_basic(void)
+{
+   const char *pane = "\xe2\x9d\xaf Reply with three words\n"
+                      "\xe2\x97\x8f alpha bravo charlie\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n"
+                      "\n"
+                      "\xe2\x9d\xaf \n"
+                      "  ? for shortcuts\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   assert(strcmp(r, "alpha bravo charlie") == 0);
+   free(r);
+}
+
+/* Reused pane holding a prior turn: with the prior turn as baseline, only the
+ * NEW turn's reply is returned — the core anti-bleed guarantee. */
+static void test_extract_claude_excludes_prior_turn(void)
+{
+   const char *baseline = "\xe2\x9d\xaf first question\n"
+                          "\xe2\x97\x8f first answer here\n"
+                          "\xe2\x9c\xbb Cooked for 1s\n";
+   const char *pane = "\xe2\x9d\xaf first question\n"
+                      "\xe2\x97\x8f first answer here\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n"
+                      "\xe2\x9d\xaf second question\n"
+                      "\xe2\x97\x8f second answer only\n"
+                      "\xe2\x9c\xbb Baked for 2s\n"
+                      "\xe2\x9d\xaf \n";
+   char *r = cli_session_extract_response(pane, "claude", baseline);
+   assert(r != NULL);
+   assert(strcmp(r, "second answer only") == 0);
+   free(r);
+}
+
+static void test_extract_claude_multiline(void)
+{
+   const char *pane = "\xe2\x9d\xaf q\n"
+                      "\xe2\x97\x8f line one\n"
+                      "  line two\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   assert(strcmp(r, "line one\nline two") == 0);
+   free(r);
+}
+
+static void test_extract_codex_basic(void)
+{
+   /* codex events also use •; the answer is the LAST • block before composer. */
+   const char *pane = "\xe2\x80\xba Reply with three words\n"
+                      "\xe2\x80\xa2 SessionStart hook (completed)\n"
+                      "  hook context noise\n"
+                      "\xe2\x80\xa2 foxtrot golf hotel\n"
+                      "\xe2\x80\xba Find and fix a bug\n"
+                      "  gpt-5.5 default\n";
+   char *r = cli_session_extract_response(pane, "codex", NULL);
+   assert(r != NULL);
+   assert(strcmp(r, "foxtrot golf hotel") == 0);
+   free(r);
+}
+
 int main(void)
 {
+   printf("test_extract_claude_basic... ");
+   test_extract_claude_basic();
+   printf("OK\n");
+
+   printf("test_extract_claude_excludes_prior_turn... ");
+   test_extract_claude_excludes_prior_turn();
+   printf("OK\n");
+
+   printf("test_extract_claude_multiline... ");
+   test_extract_claude_multiline();
+   printf("OK\n");
+
+   printf("test_extract_codex_basic... ");
+   test_extract_codex_basic();
+   printf("OK\n");
+
    printf("test_make_name_format... ");
    test_make_name_format();
    printf("OK\n");

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -302,16 +302,50 @@ static void test_extract_claude_multiline(void)
 
 static void test_extract_codex_basic(void)
 {
-   /* codex events also use •; the answer is the LAST • block before composer. */
+   /* codex events also use •; the SessionStart hook fired before the turn, so it
+    * is in the baseline (captured pre-send) and excluded — the answer is the new
+    * bullet. */
+   const char *baseline = "\xe2\x80\xa2 SessionStart hook (completed)\n"
+                          "  hook context noise\n";
    const char *pane = "\xe2\x80\xba Reply with three words\n"
                       "\xe2\x80\xa2 SessionStart hook (completed)\n"
                       "  hook context noise\n"
                       "\xe2\x80\xa2 foxtrot golf hotel\n"
                       "\xe2\x80\xba Find and fix a bug\n"
                       "  gpt-5.5 default\n";
-   char *r = cli_session_extract_response(pane, "codex", NULL);
+   char *r = cli_session_extract_response(pane, "codex", baseline);
    assert(r != NULL);
    assert(strcmp(r, "foxtrot golf hotel") == 0);
+   free(r);
+}
+
+/* Multi-bullet answer: all bullets of the turn are kept, not just the last. */
+static void test_extract_claude_multibullet(void)
+{
+   const char *pane = "\xe2\x9d\xaf q\n"
+                      "\xe2\x97\x8f paragraph one\n"
+                      "\xe2\x97\x8f paragraph two\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   assert(strcmp(r, "paragraph one\nparagraph two") == 0);
+   free(r);
+}
+
+/* A short reply that merely appears as a SUBSTRING of a prior line must NOT be
+ * excluded — the baseline match is whole-line, not substring. */
+static void test_extract_baseline_substring_kept(void)
+{
+   const char *baseline = "\xe2\x97\x8f that looks ok to me\n"
+                          "\xe2\x9c\xbb Cooked for 1s\n";
+   const char *pane = "\xe2\x97\x8f that looks ok to me\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n"
+                      "\xe2\x9d\xaf next\n"
+                      "\xe2\x97\x8f ok\n"
+                      "\xe2\x9c\xbb Baked for 1s\n";
+   char *r = cli_session_extract_response(pane, "claude", baseline);
+   assert(r != NULL);
+   assert(strcmp(r, "ok") == 0);
    free(r);
 }
 
@@ -331,6 +365,14 @@ int main(void)
 
    printf("test_extract_codex_basic... ");
    test_extract_codex_basic();
+   printf("OK\n");
+
+   printf("test_extract_claude_multibullet... ");
+   test_extract_claude_multibullet();
+   printf("OK\n");
+
+   printf("test_extract_baseline_substring_kept... ");
+   test_extract_baseline_substring_kept();
    printf("OK\n");
 
    printf("test_make_name_format... ");


### PR DESCRIPTION
## Problem
Webchat collapsed concurrent sessions onto one conversation and bled replies across tabs. Root cause: co-located claude chat ran `claude -p` (one-shot print), which cannot multiplex — each turn is a fresh process with no persistent pane. The OAuth CLIs must instead drive a persistent claude/codex TUI inside its own tmux session, one tmux session per aimee session.

## Change
**Routing** — `claude-oauth` / `codex-oauth` (and `claude` / `claude-code`) run as a persistent CLI TUI over tmux via the agent worker (`agent_execute_cli_session`). Built-in `TMUX_CLI` agents so the providers resolve with no explicit config. `codex-oauth` no longer takes the one-shot app-server path. The `claude -p` chat path and its dead helpers are retired. API providers stay on the in-process HTTP path.

**tmux multiplexing layer**
- 1:1 keying: the persistent `<sid>-cli` pane is used only when a real per-session id is bound (`session_id_override_active`), never the process-wide PPID fallback that collapsed every override-less turn onto one pane.
- Per-turn extraction: `cli_session_recv` returns only this turn's reply, parsed from the TUI (claude ●/❯/✻, codex •/›) and diffed against a pre-send pane baseline, so a reused pane never replays prior turns / other conversations. Multi-bullet answers kept whole; baseline exclusion is whole-line (not substring).
- Per-session tmux paste buffer + tmpfile (was a shared `aimee_msg` buffer that cross-pasted concurrent turns' input).
- Submit reliability: paste without trailing newline + settle before Enter (codex otherwise never submits).
- Incremental streaming via a per-thread stream callback; the chat worker forwards it as `text` events. `--model` plumbed from config/override.

## Testing
- Unit tests for the extractor: claude/codex, multiline, multi-bullet, prior-turn exclusion, substring-false-positive. Full unit suite green; lint clean.
- Live: two concurrent real `claude` sessions each extract only their own reply, zero cross-bleed; live codex submit confirmed.

## Review
Two-round roundtable (mistral + minimax). Round 1 (both BLOCK) surfaced real findings — lost `--model`, multi-bullet truncation, substring false-positive, buffer-name hash collision, nested stream-cb safety — all fixed. Round 2: minimax APPROVE with per-finding verification; mistral's remaining findings independently verified false (snprintf bounded; byte-exact UTF-8 compare correct; chrome/composer already bound the turn; `prev_stream_ud` pre-initialized).

## Known follow-ups (documented)
- Per-request reasoning-effort for the tmux path (the prior tmux path never passed it).
- `claude --resume` persistence across a tmux-server restart — continuity is now the persistent pane, per the 1:1 design.
- Streaming fidelity on a TUI word-wrap reflow (final reply is always correct).