### PR TITLE
fix(webchat): isolate each session in its own worktree off the default branch

### DIFF
--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -10,6 +10,7 @@
 #include "db1.h"
 #include "log.h"
 #include "primary_session_adapter.h"
+#include "workspace.h" /* session_isolation_target — per-session worktree redirect */
 #include "workspace_provider.h"
 
 /* Defined in agent_runtime_tmux.c (no shared header; agent_runtime.c forward-
@@ -638,6 +639,16 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
     * client-supplied cwd. Otherwise run in the (validated) client cwd. */
    const char *eff_cwd = workspace_turn_active_cwd();
    const char *use_cwd = eff_cwd ? eff_cwd : cwd;
+   /* Plain local project (no detached/mirror remap): isolate this session in its
+    * OWN sibling worktree on a per-session branch off the repo's default branch,
+    * created on demand. Without this, concurrent sessions on the same project
+    * share one checkout and clobber each other. No-op when cwd is not a git repo
+    * or is already a managed worktree (session_isolation_target guards both). */
+   char session_wt[MAX_PATH_LEN];
+   if (!eff_cwd && !detached_bound && aimee_sid && aimee_sid[0] &&
+       session_isolation_target(use_cwd, aimee_sid, session_wt, sizeof(session_wt),
+                                1 /*create_if_missing*/))
+      use_cwd = session_wt;
    if (aimee_path_is_absolute(use_cwd) && !strstr(use_cwd, "/.."))
       run_cmd_set_cwd(use_cwd);
    if (aimee_sid && aimee_sid[0])
@@ -754,6 +765,15 @@ static void chat_stream_worker_primary_session(compute_ctx_t *cctx, const char *
     * worktree; otherwise act in the (validated) client cwd. */
    const char *eff_cwd = workspace_turn_active_cwd();
    const char *use_cwd = eff_cwd ? eff_cwd : cwd;
+   /* Plain local project (no detached/mirror remap): isolate this session in its
+    * OWN sibling worktree on a per-session branch off the repo's default branch,
+    * created on demand — so concurrent sessions on the same project never share a
+    * checkout. No-op when cwd is not a git repo / already a managed worktree. */
+   char session_wt[MAX_PATH_LEN];
+   if (!eff_cwd && !detached_bound && aimee_sid && aimee_sid[0] &&
+       session_isolation_target(use_cwd, aimee_sid, session_wt, sizeof(session_wt),
+                                1 /*create_if_missing*/))
+      use_cwd = session_wt;
 
    stream_event(cctx, "turn_start", NULL, NULL);
 

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -1719,7 +1719,13 @@ int session_isolation_target(const char *cwd, const char *sid, char *target, siz
       if (!create_if_missing)
          return 0;
       if (worktree_create_sibling(gr, sid, NULL) != 0)
+      {
+         /* Could not create the session worktree — the caller falls back to the
+          * shared checkout, so surface it: this is the one path where session
+          * isolation silently does not apply. */
+         LOG_WARN("workspace", "session isolation worktree create failed for %s (sid=%s)", gr, sid);
          return 0;
+      }
       if (stat(wt_path, &wst) != 0)
          return 0;
    }


### PR DESCRIPTION
## Problem

Webchat sessions clobber each other's changes. Each chat turn runs the agent (native tool-loop, or claude/codex CLI over tmux) directly in the selected project checkout (`root/<project>`). Two sessions/tabs on the same project share one working tree → concurrent edits clobber and are mutually visible. The per-session isolation machinery exists but was only wired into the CLI `launch` path and MCP git tools, never the webchat chat turn.

## Fix

Wire the already-implemented (and unit-tested) but **dead-wired** `session_isolation_target` helper into both primary chat-turn workers (`chat_stream_worker_agent`, `chat_stream_worker_primary_session` in `posix/server_compute.c`):

- When a turn is a plain local project (not a `detached`/`mirror` workspace remap), redirect its bound cwd into a **per-session sibling worktree** on a **per-session branch** `aimee/session/<sid-key>` **off the repo's default branch**, created on demand.
- Both paths pick this up: the native loop uses `run_cmd` cwd; the tmux CLI runtime takes its `work_dir` from `run_cmd_get_cwd()`.
- Guards (in the helper): no-op when cwd is not a git repo, is already a managed worktree, or is already this session's worktree. Falls back to the shared checkout only on those cases or a creation failure (now logged via `LOG_WARN`).
- Excluded correctly: `detached`/`mirror` turns (eff_cwd set or `detached_bound`) and remote raw-cwd turns (already rejected upstream).

Distinct tabs carry distinct `aimee_session_id`s → distinct worktrees/branches; same tab reuses its worktree idempotently.

## Review

Roundtabled — minimax / mistral / mimo-2.5 all **APPROVE**, no blockers/majors. The one shared MINOR (same-session worktree-create race) is benign: an existing worktree is treated as success, and presence-turn arbitration serializes same-session turns. Applied minimax's observability nit (warn on creation failure).

## Validation

`make all` clean, `make lint` pass, workspace/workspace-turn/guardrails unit tests pass (the latter already covers `session_isolation_target`).

## Known follow-up (not in this PR)

The webchat **Editor** tab and **git panel** (`git_ops`) still target `root/<project>`, so they show the pristine base rather than a session's worktree branch. Making those surfaces session-aware is a separate change; the agent can already commit/push its session branch from the worktree (it has git tools + vault creds from #605).