### PR TITLE
bench(embedder): GPU retrieval probe on LoCoMo — nomic > Qwen3-0.6B (7900XTX/Vulkan)

### DIFF
--- a/benchmarks/embedder_gate.py
+++ b/benchmarks/embedder_gate.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""embedder_gate.py — isolated embedder retrieval-quality probe on LoCoMo.
+
+A precursor to the full ship-floor gate (unified-llm-container §"acceptance
+gates"): it measures *embedder* retrieval quality in isolation (no reranker, no
+fusion, no LLM) so a candidate embedder can be screened before the heavier
+aimee-pipeline sweep. Any OpenAI-compatible `/v1/embeddings` endpoint works, so a
+llama.cpp+Vulkan server (e.g. on the 7900XTX) is a drop-in candidate.
+
+Task (mirrors benchmarks/locomo/bench_aimee_direct.py semantics): for each
+conversation the corpus is its turns (`dia_id` -> "speaker: text"); each `qa`
+question retrieves over those turns by cosine; a turn is relevant iff its
+`dia_id` is in the question's `evidence`. We report Recall@5, Recall@10 and MRR
+averaged over all questions — the same metrics the gate uses.
+
+Usage:
+  python3 embedder_gate.py --dataset locomo10.json --endpoint http://localhost:8899/v1/embeddings \
+      --name qwen3-0.6b --output results_qwen3.json [--max-conversations N] [--query-prefix STR]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+import urllib.request
+from pathlib import Path
+
+
+def load_locomo(path: str, max_conversations: int = 0):
+    """Yield (conversation_id, turns, questions). turns: list[(dia_id, text)];
+    questions: list[(question, set(evidence_dia_ids))]. Replicated from
+    benchmarks/locomo/common/dataset.py so the probe is self-contained."""
+    root = json.loads(Path(path).read_text())
+    out = []
+    for i, sample in enumerate(root):
+        if max_conversations and i >= max_conversations:
+            break
+        conv = sample.get("conversation", {})
+        turns = []
+        for key, val in conv.items():
+            if not key.startswith("session_") or key.endswith("date_time") or not isinstance(val, list):
+                continue
+            for t in val:
+                did = t.get("dia_id")
+                txt = t.get("text", "")
+                if did and txt:
+                    turns.append((did, f"{t.get('speaker', '')}: {txt}".strip()))
+        questions = []
+        for item in sample.get("qa", []):
+            q = str(item.get("question", "")).strip()
+            ev = {str(e) for e in item.get("evidence", []) if isinstance(e, str)}
+            if q and ev:  # adversarial/unanswerable rows carry no evidence -> skip
+                questions.append((q, ev))
+        if turns and questions:
+            out.append((str(sample.get("id") or f"conv-{i+1}"), turns, questions))
+    return out
+
+
+def embed(endpoint: str, texts: list[str], batch: int = 256, prefix: str = "",
+          normalize: bool = True) -> list[list[float]]:
+    """Embed via an OpenAI-compatible /v1/embeddings endpoint. By default vectors
+    are L2-normalized so the dot product in evaluate() is exactly cosine
+    similarity (normalize-then-dot == cosine); --no-normalize disables it for
+    endpoints that already return unit vectors or where raw dot is wanted."""
+    vecs: list[list[float]] = []
+    for i in range(0, len(texts), batch):
+        chunk = [prefix + t for t in texts[i : i + batch]]
+        body = json.dumps({"input": chunk}).encode()
+        req = urllib.request.Request(
+            endpoint, data=body, headers={"Content-Type": "application/json"}
+        )
+        for attempt in range(4):
+            try:
+                with urllib.request.urlopen(req, timeout=600) as r:
+                    data = json.loads(r.read())["data"]
+                break
+            except Exception:  # noqa: BLE001 — transient server/load errors, retried
+                if attempt == 3:
+                    raise
+                time.sleep(2 * (attempt + 1))
+        for row in sorted(data, key=lambda d: d["index"]):
+            v = row["embedding"]
+            if normalize:
+                n = math.sqrt(sum(x * x for x in v)) or 1.0
+                v = [x / n for x in v]
+            vecs.append(v)
+    return vecs
+
+
+def evaluate(cases, endpoint: str, query_prefix: str = "", doc_prefix: str = "", normalize: bool = True):
+    rows = []
+    for cid, turns, questions in cases:
+        dia_ids = [d for d, _ in turns]
+        doc_vecs = embed(endpoint, [t for _, t in turns], prefix=doc_prefix, normalize=normalize)
+        q_vecs = embed(endpoint, [qt for qt, _ in questions], prefix=query_prefix, normalize=normalize)
+        for (_q, evidence), qv in zip(questions, q_vecs):
+            scored = sorted(
+                ((sum(a * b for a, b in zip(qv, dv)), did) for dv, did in zip(doc_vecs, dia_ids)),
+                key=lambda x: x[0],
+                reverse=True,
+            )
+            ranked = [did for _, did in scored]
+            rank = next((i + 1 for i, did in enumerate(ranked) if did in evidence), 0)
+            rows.append(
+                {
+                    "conversation_id": cid,
+                    "recall_5": 1.0 if any(d in evidence for d in ranked[:5]) else 0.0,
+                    "recall_10": 1.0 if any(d in evidence for d in ranked[:10]) else 0.0,
+                    "mrr": (1.0 / rank) if rank else 0.0,
+                }
+            )
+    n = len(rows) or 1
+    return {
+        "questions": len(rows),
+        "conversations": len(cases),
+        "recall_5": sum(r["recall_5"] for r in rows) / n,
+        "recall_10": sum(r["recall_10"] for r in rows) / n,
+        "mrr": sum(r["mrr"] for r in rows) / n,
+    }
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--dataset", required=True)
+    ap.add_argument("--endpoint", required=True, help="OpenAI-compatible /v1/embeddings URL")
+    ap.add_argument("--name", required=True)
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--max-conversations", type=int, default=0)
+    ap.add_argument("--query-prefix", default="", help="instruction prefix for queries (some models)")
+    ap.add_argument("--doc-prefix", default="", help="instruction prefix for documents (some models)")
+    ap.add_argument("--query-prefix-file", help="read the query prefix from a file (preserves "
+                    "embedded newlines, e.g. Qwen3's 'Instruct: ...\\nQuery: ')")
+    ap.add_argument("--no-normalize", action="store_true",
+                    help="do not L2-normalize (endpoint already returns unit vectors)")
+    args = ap.parse_args()
+
+    query_prefix = Path(args.query_prefix_file).read_text() if args.query_prefix_file else args.query_prefix
+
+    cases = load_locomo(args.dataset, args.max_conversations)
+    t0 = time.time()
+    metrics = evaluate(cases, args.endpoint, query_prefix, args.doc_prefix, normalize=not args.no_normalize)
+    metrics["name"] = args.name
+    metrics["endpoint"] = args.endpoint
+    # Persist the exact recipe so the artifact is a fair, reproducible comparison
+    # (each model uses its own prefix; three recipes, one annotated artifact).
+    metrics["query_prefix"] = query_prefix
+    metrics["doc_prefix"] = args.doc_prefix
+    metrics["normalized"] = not args.no_normalize
+    metrics["wall_seconds"] = round(time.time() - t0, 1)
+    Path(args.output).write_text(json.dumps(metrics, indent=2))
+    print(
+        f"{args.name}: Recall@5={metrics['recall_5']:.4f} Recall@10={metrics['recall_10']:.4f} "
+        f"MRR={metrics['mrr']:.4f}  ({metrics['questions']} q / {metrics['conversations']} conv, "
+        f"qprefix={query_prefix!r}, {metrics['wall_seconds']}s)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/embedder-gate/locomo_bge.json
+++ b/benchmarks/results/embedder-gate/locomo_bge.json
@@ -1,0 +1,13 @@
+{
+  "questions": 1982,
+  "conversations": 10,
+  "recall_5": 0.49949545913218973,
+  "recall_10": 0.6104944500504541,
+  "mrr": 0.3681376696048183,
+  "name": "bge-base-en-v1.5",
+  "endpoint": "http://localhost:8900/v1/embeddings",
+  "query_prefix": "Represent this sentence for searching relevant passages: ",
+  "doc_prefix": "",
+  "normalized": true,
+  "wall_seconds": 64.5
+}

--- a/benchmarks/results/embedder-gate/locomo_nomic.json
+++ b/benchmarks/results/embedder-gate/locomo_nomic.json
@@ -1,0 +1,13 @@
+{
+  "questions": 1982,
+  "conversations": 10,
+  "recall_5": 0.6059535822401615,
+  "recall_10": 0.6907164480322906,
+  "mrr": 0.4741458172209976,
+  "name": "nomic-v1.5",
+  "endpoint": "http://localhost:8901/v1/embeddings",
+  "query_prefix": "search_query: ",
+  "doc_prefix": "search_document: ",
+  "normalized": true,
+  "wall_seconds": 63.4
+}

--- a/benchmarks/results/embedder-gate/locomo_qwen3.json
+++ b/benchmarks/results/embedder-gate/locomo_qwen3.json
@@ -1,0 +1,13 @@
+{
+  "questions": 1982,
+  "conversations": 10,
+  "recall_5": 0.5060544904137235,
+  "recall_10": 0.5973763874873865,
+  "mrr": 0.37825656689502557,
+  "name": "qwen3-0.6b",
+  "endpoint": "http://localhost:8899/v1/embeddings",
+  "query_prefix": "Instruct: Given a question, retrieve the conversation turns that answer it\nQuery: ",
+  "doc_prefix": "",
+  "normalized": true,
+  "wall_seconds": 311.2
+}

--- a/docs/validation/embedder-gate-locomo.md
+++ b/docs/validation/embedder-gate-locomo.md
@@ -1,0 +1,103 @@
+# Embedder retrieval-quality probe (LoCoMo)
+
+A reproducible, **embedder-isolated** retrieval benchmark — a precursor to the
+full ship-floor gate in
+[unified-llm-container](../proposals/pending/unified-llm-container.md) (the
+`nDCG/MRR ≥ 95% of pplx baseline` acceptance gate). It screens a candidate
+embedder *in isolation* (no reranker, no fusion, no LLM) so an unviable model is
+caught before the heavier full-pipeline sweep
+([embedder-sweep.md](../embedder-sweep.md)) is stood up.
+
+Harness: [`benchmarks/embedder_gate.py`](../../benchmarks/embedder_gate.py).
+
+## What it measures
+
+LoCoMo (`locomo10.json`, 10 multi-session conversations) as a **direct
+retrieval** task, mirroring `benchmarks/locomo/bench_aimee_direct.py`:
+
+- **Corpus** = the conversation's turns, each `dia_id → "speaker: text"`.
+- **Query** = each `qa` question; a turn is **relevant** iff its `dia_id` is in
+  the question's `evidence`. (Questions with no evidence — adversarial /
+  unanswerable rows — are skipped.)
+- Retrieval is cosine over L2-normalized embeddings, **within each conversation**.
+- **Metrics** (averaged over all questions): **Recall@5, Recall@10, MRR** — the
+  same metrics the ship-floor gate uses.
+
+Any OpenAI-compatible `/v1/embeddings` endpoint is a candidate, so a
+**llama.cpp + Vulkan** server is a drop-in. This is the part the GPU exercises.
+
+## How it was run
+
+- **Hardware:** AMD Radeon RX 7900 XTX (24 GB, RADV/Vulkan) on `.254`.
+- **Runtime:** `llama.cpp` server build `b9754`, prebuilt `…-vulkan-x64`, all
+  layers on GPU (`-ngl 99`). One `llama-server --embeddings` per model.
+- **Candidates** (apples-to-apples — same runtime + hardware, each with its
+  model-recommended query/doc instruction prefix):
+  - `qwen3-0.6b` — `Qwen/Qwen3-Embedding-0.6B-GGUF` Q8_0 (1024-dim) — the
+    proposal's CPU/GPU default embedder slot (0.6B @ 1024).
+  - `bge-base-en-v1.5` — Q8_0 (768-dim) — strong reference.
+  - `nomic-v1.5` — `nomic-embed-text-v1.5` Q8_0 (768-dim) — strong reference.
+
+Reproduce:
+
+```bash
+# on a host with the 7900XTX + the prebuilt llama.cpp vulkan build:
+llama-server -m Qwen3-Embedding-0.6B-Q8_0.gguf --embeddings --port 8899 -ngl 99 --ctx-size 8192 -ub 8192
+python3 benchmarks/embedder_gate.py --dataset locomo10.json \
+    --endpoint http://localhost:8899/v1/embeddings --name qwen3-0.6b --output res_qwen3.json \
+    --query-prefix $'Instruct: Given a question, retrieve the conversation turns that answer it\nQuery: '
+```
+
+## Results
+
+Run 2026-06-22 on the 7900XTX. LoCoMo, 10 conversations, **1982** answerable
+questions. Artifacts: [`benchmarks/results/embedder-gate/`](../../benchmarks/results/embedder-gate/).
+
+| model | dim | Recall@5 | Recall@10 | MRR |
+|---|---|---|---|---|
+| **nomic-embed-text-v1.5** | 768 | **0.6060** | **0.6907** | **0.4741** |
+| qwen3-embedding-0.6b | 1024 | 0.5061 | 0.5974 | 0.3783 |
+| bge-base-en-v1.5 | 768 | 0.4995 | 0.6105 | 0.3681 |
+
+**Finding (actionable for the proposal).** On LoCoMo conversational retrieval,
+**`nomic-embed-text-v1.5` clearly beats the proposal's default embedder slot
+(`Qwen3-Embedding-0.6B`)** — +10.0 pts Recall@5, +9.3 pts Recall@10, +9.6 pts MRR
+— at 768-dim vs 1024-dim (smaller vectors, cheaper storage/scan). `Qwen3-0.6B`
+and `bge-base` are roughly tied. This says the default-embedder choice in
+[unified-llm-container](../proposals/pending/unified-llm-container.md) §"model
+registry" should be **re-examined before cutover**: either adopt nomic for the
+default slot, or justify Qwen3 with a stronger config (see caveats) or a larger
+Qwen3 variant.
+
+**Fairness / reproducibility.** Each model uses its own card-recommended prefix,
+recorded in its result JSON (`query_prefix`/`doc_prefix`): Qwen3 the canonical
+`Instruct: …\nQuery: ` (newline preserved via `--query-prefix-file`), bge the
+`Represent this sentence…` prefix, nomic the `search_query:`/`search_document:`
+pair. All vectors are L2-normalized so the dot product is exactly cosine. Metrics
+are over the **1982 answerable** questions only — a question with empty `evidence`
+(LoCoMo's adversarial/unanswerable rows) has no relevant turn to retrieve, so
+retrieval Recall/MRR are undefined for it; this is answerable-only retrieval by
+construction, not a silent filter.
+
+**Qwen3 prompt-sensitivity check (resolved).** Qwen3-Embedding is prompt
+-sensitive, so the gap was re-tested with the canonical `Instruct:\nQuery:`
+newline restored: **identical** (R@5 0.5061 vs 0.5060) — the gap is **not** a
+prompt-format artifact. The 4B/8B Qwen3 variants remain an open probe (they may
+close it), but at the **0.6B default-slot** size nomic is the stronger choice.
+
+**Caveats (do not over-read).** LoCoMo is one (hard, conversational) benchmark;
+LongMemEval and the full aimee pipeline (rerank + fusion) can reorder these. This
+is an embedder screen, not the production cutover verdict.
+
+## Scope and honesty notes
+
+- This is **embedder-isolated** retrieval, **not** the full aimee pipeline
+  (which adds reranking + fusion). It screens the embedder; it is *not* the
+  production cutover number.
+- It is **not yet the formal ship-floor gate**: that gate is defined against a
+  pinned **pplx/ettin baseline fixture** and run through the aimee retrieval
+  pipeline (`embedder-sweep.sh` → `aimee eval`). Two follow-ups are required for
+  the formal gate: (1) record the pplx/ettin baseline as the comparison anchor;
+  (2) realign `embedder-sweep.sh`/`bench_aimee_direct.py` with the current
+  `aimee eval` interface (it still calls the retired `aimee-client eval <suite>`)
+  and a pgvector DB. This probe is the cheap screen that justifies that effort.


### PR DESCRIPTION
Uses the now-available 7900XTX to make the first empirical progress on the **unified-llm-container** embedder cutover, via an **embedder-isolated** retrieval screen (precursor to the formal ship-floor gate).

### What
`benchmarks/embedder_gate.py` — runs LoCoMo direct retrieval (Recall@5/@10, MRR, the gate's metrics) against any OpenAI-compatible `/v1/embeddings`. So a **llama.cpp + Vulkan** `llama-server` on the 7900XTX is a drop-in candidate. Doc: `docs/validation/embedder-gate-locomo.md`; raw artifacts in `benchmarks/results/embedder-gate/`.

### Result (1982 answerable LoCoMo questions, all on the 7900XTX/Vulkan, each model with its card-recommended prefix — recorded in the artifacts)
| model | dim | R@5 | R@10 | MRR |
|---|---|---|---|---|
| **nomic-embed-text-v1.5** | 768 | **0.606** | **0.691** | **0.474** |
| qwen3-embedding-0.6b | 1024 | 0.506 | 0.597 | 0.378 |
| bge-base-en-v1.5 | 768 | 0.500 | 0.611 | 0.368 |

**Finding:** `nomic-embed` beats the proposal's default embedder slot (`Qwen3-Embedding-0.6B`) by ~10pts R@5 / ~9pts MRR at a smaller dim — the default-embedder choice in unified-llm-container should be **re-examined before cutover**. Re-running qwen3 with its canonical `Instruct:\nQuery:` newline gave an **identical** score, so the gap is a real model property, not a prompt artifact.

### Scope (honest)
Embedder-isolated (no rerank/fusion/LLM), one benchmark. **Not** yet the formal ship-floor gate — that needs the pinned pplx/ettin baseline fixture + the `embedder-sweep.sh`/`bench_aimee_direct.py` pipeline realigned with the current `aimee eval` interface (it still calls the retired `aimee-client eval`). This is the cheap screen that justifies that effort, and it surfaces an actionable model-choice signal now.

Roundtable-reviewed (mistral + minimax APPROVE after one round: qwen3 newline control, prefixes persisted to artifacts, answerable-only scope made explicit).