### PR TITLE
feat(chat): steering — interrupt a turn and auto-continue with a follow-up

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3004,6 +3004,41 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /chat/interrupt:
+    post:
+      summary: Steer an in-flight chat turn
+      description: >
+        Stop the in-flight turn for a session and queue a follow-up `message`
+        the server auto-continues as the next, server-initiated turn (streamed
+        to the session's /events presence stream). Owner-authorized like
+        chat.graceful_cancel. When no turn is in flight, nothing is queued and
+        `interrupted` is false. Requires CAP_CHAT.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [aimee_session_id, message]
+              properties:
+                aimee_session_id: { type: string }
+                message: { type: string }
+      responses:
+        "200":
+          description: Interrupt accepted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status: { type: string }
+                  session_id: { type: string }
+                  interrupted: { type: boolean }
+        "403":
+          description: Caller lacks CAP_CHAT or is not the session owner
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /completions:
     post:
       summary: Create a text completion

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1553,6 +1553,14 @@ export default function Chat() {
   // THIS surface originated the turn (skip persist) or is merely observing a
   // turn that ran/completed while detached (persist it into history).
   const workingRef = useRef(working);
+  // Live mirror of remoteTurnActive so sendMessage can synchronously tell whether
+  // a server/foreign turn (e.g. a steer auto-continue) is in flight for the tab.
+  const remoteTurnActiveRef = useRef(false);
+  // Set when we just sent a steer (chat.interrupt): the next turn_started on the
+  // events stream is the server-initiated continuation — render it even though
+  // this surface may still look "working" while the cancelled turn's stream
+  // closes (otherwise the wasWorking self-echo guard would drop the steered reply).
+  const expectSteerRef = useRef(false);
   // turn_ids already committed to history from the presence ring this session.
   // The ring replays turn_started→deltas→turn_done from cursor 0 on EVERY new
   // subscription (reconnect / tab switch back), so dedup is required to avoid
@@ -1722,6 +1730,9 @@ export default function Chat() {
     es.addEventListener('turn_started', (ev: MessageEvent<string>) => {
       saveCursor(ev);
       curTurnId = turnIdOf(ev.data); observed = ''; wasWorking = workingRef.current;
+      // A steer continuation is server-initiated: render it even if this surface
+      // still looks "working" from the just-cancelled turn's closing stream.
+      if (expectSteerRef.current) { wasWorking = false; expectSteerRef.current = false; }
       // Self-echo suppression: the server now ALWAYS mirrors the full turn to the
       // presence ring (durable source of truth for detached recovery), so the
       // surface that ORIGINATED the turn receives an echo of its own stream here.
@@ -1730,7 +1741,7 @@ export default function Chat() {
       // native POST stream already renders the turn — and one full re-render per
       // token, on top of the native one, pegs a core during every response. Only
       // touch the live UI for a turn THIS surface did not originate.
-      if (!wasWorking) { clearRemoteFlush(); setRemoteTurnActive(true); setRemoteTurnText(''); }
+      if (!wasWorking) { clearRemoteFlush(); remoteTurnActiveRef.current = true; setRemoteTurnActive(true); setRemoteTurnText(''); }
     });
     es.addEventListener('turn_delta', (ev: MessageEvent<string>) => {
       saveCursor(ev);
@@ -1770,9 +1781,10 @@ export default function Chat() {
       }
       observed = ''; curTurnId = ''; wasWorking = false;
       clearRemoteFlush();
+      remoteTurnActiveRef.current = false;
       setRemoteTurnActive(false); setRemoteTurnText('');
     });
-    es.onerror = () => { clearRemoteFlush(); setRemoteTurnActive(false); setRemoteTurnText(''); };
+    es.onerror = () => { clearRemoteFlush(); remoteTurnActiveRef.current = false; setRemoteTurnActive(false); setRemoteTurnText(''); };
     return () => { clearRemoteFlush(); es.close(); presenceSseRef.current = null; };
   }, [activeAimeeSid, activeAttachId]);
   useEffect(() => { activeIdxRef.current = activeIdx; }, [activeIdx]);
@@ -2402,7 +2414,51 @@ export default function Chat() {
       textareaRef.current.style.height = 'auto';
     }
 
+    // Steering: if a turn is already in flight for the active tab — a local send
+    // (client stream open) or a server/foreign turn (events stream) — sending
+    // INTERRUPTS the running turn and submits this message as the steer, which the
+    // server auto-continues as the next turn (it arrives on the events stream).
+    const sid = tabsRef.current[activeIdxRef.current]?.aimeeSid ?? '';
+    let clientInflight = false;
+    activeSendAbortRefs.current.forEach(s => { if (s === sid) clientInflight = true; });
+    if (sid && (clientInflight || remoteTurnActiveRef.current)) {
+      // Optimistically show the steer in the transcript and re-stick to bottom.
+      atBottomRef.current = true;
+      setStreamMsgs(prev => [...prev, { id: nextId(), type: 'user', text }]);
+      void steerInterrupt(sid, text);
+      return;
+    }
+
     enqueueChatMessage(text);
+  }
+
+  // Stop the in-flight turn for `sid` and queue `text` as the steer continuation.
+  // The server only honours the steer when a turn was actually in flight; on the
+  // race where it just finished (interrupted:false), fall back to a normal send.
+  async function steerInterrupt(sid: string, text: string) {
+    expectSteerRef.current = true;
+    try {
+      const resp = await fetch('/api/chat/interrupt', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window._csrf || '' },
+        body: JSON.stringify({ aimee_session_id: sid, message: text }),
+      });
+      if (resp.status === 401) { window.location.href = '/login'; return; }
+      const j = resp.ok ? await resp.json().catch(() => ({})) as { interrupted?: boolean } : {};
+      if (!j.interrupted) {
+        // No turn was in flight server-side: send normally instead.
+        expectSteerRef.current = false;
+        sendQueueRef.current.push({ text, version: sendQueueVersionRef.current, originSid: sid });
+        recomputeWorkCounts();
+        void drainSendQueue();
+      }
+    } catch {
+      // Interrupt failed: fall back to a normal send so the message isn't lost.
+      expectSteerRef.current = false;
+      sendQueueRef.current.push({ text, version: sendQueueVersionRef.current, originSid: sid });
+      recomputeWorkCounts();
+      void drainSendQueue();
+    }
   }
 
   function enqueueChatMessage(text: string) {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -2437,6 +2437,9 @@ export default function Chat() {
   // race where it just finished (interrupted:false), fall back to a normal send.
   async function steerInterrupt(sid: string, text: string) {
     expectSteerRef.current = true;
+    // Safety net: if the server continuation never starts (dispatch failed), clear
+    // the one-shot so it can't force-render a later own turn as a foreign one.
+    window.setTimeout(() => { expectSteerRef.current = false; }, 12000);
     try {
       const resp = await fetch('/api/chat/interrupt', {
         method: 'POST',

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1556,11 +1556,13 @@ export default function Chat() {
   // Live mirror of remoteTurnActive so sendMessage can synchronously tell whether
   // a server/foreign turn (e.g. a steer auto-continue) is in flight for the tab.
   const remoteTurnActiveRef = useRef(false);
-  // Set when we just sent a steer (chat.interrupt): the next turn_started on the
-  // events stream is the server-initiated continuation — render it even though
-  // this surface may still look "working" while the cancelled turn's stream
-  // closes (otherwise the wasWorking self-echo guard would drop the steered reply).
-  const expectSteerRef = useRef(false);
+  // Holds the aimeeSid we just sent a steer for (chat.interrupt). The next
+  // turn_started on THAT session's events stream is the server-initiated
+  // continuation — render it even though this surface may still look "working"
+  // while the cancelled turn's stream closes (otherwise the wasWorking self-echo
+  // guard would drop the steered reply). Keyed by sid so switching tabs can't
+  // make a different tab's turn consume it. '' = none.
+  const expectSteerRef = useRef<string>('');
   // turn_ids already committed to history from the presence ring this session.
   // The ring replays turn_started→deltas→turn_done from cursor 0 on EVERY new
   // subscription (reconnect / tab switch back), so dedup is required to avoid
@@ -1731,8 +1733,11 @@ export default function Chat() {
       saveCursor(ev);
       curTurnId = turnIdOf(ev.data); observed = ''; wasWorking = workingRef.current;
       // A steer continuation is server-initiated: render it even if this surface
-      // still looks "working" from the just-cancelled turn's closing stream.
-      if (expectSteerRef.current) { wasWorking = false; expectSteerRef.current = false; }
+      // still looks "working" from the just-cancelled turn's closing stream. Only
+      // for the session this events stream is bound to (the one we steered).
+      if (expectSteerRef.current && expectSteerRef.current === activeAimeeSid) {
+        wasWorking = false; expectSteerRef.current = '';
+      }
       // Self-echo suppression: the server now ALWAYS mirrors the full turn to the
       // presence ring (durable source of truth for detached recovery), so the
       // surface that ORIGINATED the turn receives an echo of its own stream here.
@@ -2436,10 +2441,16 @@ export default function Chat() {
   // The server only honours the steer when a turn was actually in flight; on the
   // race where it just finished (interrupted:false), fall back to a normal send.
   async function steerInterrupt(sid: string, text: string) {
-    expectSteerRef.current = true;
+    expectSteerRef.current = sid;
     // Safety net: if the server continuation never starts (dispatch failed), clear
-    // the one-shot so it can't force-render a later own turn as a foreign one.
-    window.setTimeout(() => { expectSteerRef.current = false; }, 12000);
+    // the one-shot so it can't force-render a later turn on this session.
+    window.setTimeout(() => { if (expectSteerRef.current === sid) expectSteerRef.current = ''; }, 12000);
+    const sendNormally = () => {
+      if (expectSteerRef.current === sid) expectSteerRef.current = '';
+      sendQueueRef.current.push({ text, version: sendQueueVersionRef.current, originSid: sid });
+      recomputeWorkCounts();
+      void drainSendQueue();
+    };
     try {
       const resp = await fetch('/api/chat/interrupt', {
         method: 'POST',
@@ -2447,20 +2458,12 @@ export default function Chat() {
         body: JSON.stringify({ aimee_session_id: sid, message: text }),
       });
       if (resp.status === 401) { window.location.href = '/login'; return; }
-      const j = resp.ok ? await resp.json().catch(() => ({})) as { interrupted?: boolean } : {};
-      if (!j.interrupted) {
-        // No turn was in flight server-side: send normally instead.
-        expectSteerRef.current = false;
-        sendQueueRef.current.push({ text, version: sendQueueVersionRef.current, originSid: sid });
-        recomputeWorkCounts();
-        void drainSendQueue();
-      }
+      const j = resp.ok ? (await resp.json().catch(() => ({})) as { interrupted?: boolean }) : {};
+      // No turn was actually in flight (or the steer couldn't be queued): send it
+      // as an ordinary turn instead so the message is never lost.
+      if (!j.interrupted) sendNormally();
     } catch {
-      // Interrupt failed: fall back to a normal send so the message isn't lost.
-      expectSteerRef.current = false;
-      sendQueueRef.current.push({ text, version: sendQueueVersionRef.current, originSid: sid });
-      recomputeWorkCounts();
-      void drainSendQueue();
+      sendNormally();
     }
   }
 

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -40,6 +40,7 @@ static const struct
     {"cert.issue", "POST", "/v1/cert/issue"},
     {"cert.list", "POST", "/v1/cert/list"},
     {"cert.revoke", "POST", "/v1/cert/revoke"},
+    {"chat.interrupt", "POST", "/v1/chat/interrupt"},
     {"code.audit", "POST", "/v1/code/audit"},
     {"collab_rules.approve", "POST", "/v1/collab_rules/approve"},
     {"collab_rules.list", "GET", "/v1/collab_rules"},

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -36,6 +36,15 @@ void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud);
  * the outer turn). *ud_out receives the userdata; returns the callback. */
 cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out);
 
+/* Cancel-check callback: cli_session_recv polls it each tick; a non-zero return
+ * aborts the wait (the running turn was asked to stop — steering/interrupt or
+ * session close). recv then sends an interrupt key to the pane so the CLI stops
+ * generating (the conversation stays intact for the next turn) and returns the
+ * cancelled status. Thread-local, like the stream callback. */
+typedef int (*cli_session_cancel_cb_t)(void *ud);
+void cli_session_set_cancel_check(cli_session_cancel_cb_t cb, void *ud);
+cli_session_cancel_cb_t cli_session_get_cancel_check(void **ud_out);
+
 /* Record the CLI kind so recv can pick the right TUI response parser. */
 void cli_session_set_kind(cli_session_t *s, const char *cli_kind);
 
@@ -69,7 +78,8 @@ int cli_session_capture(cli_session_t *s, char *out, size_t out_max);
 /* Polls capture-pane until output stabilises (hash-based), the session dies,
  * or timeout_ms elapses. Writes captured text to out (NUL-terminated).
  * Returns 0 on success, -1 if the session exits before output stabilises,
- * and -2 if it did not stabilise within timeout_ms. timeout_ms <= 0 disables
+ * -2 if it did not stabilise within timeout_ms, and -3 if the cancel-check
+ * fired (the turn was asked to stop). timeout_ms <= 0 disables
  * the wall-clock bound (legacy unbounded behaviour). The bound is the only
  * thing that breaks a CLI wedged in a provider retry loop (e.g. an Anthropic
  * outage), whose pane animates forever without the session dying. recv writes

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -273,6 +273,7 @@ int handle_session_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_get(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_close(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_chat_graceful_cancel(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_chat_interrupt(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_brief(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_attach(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_session_detach(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/headers/turn_registry.h
+++ b/src/headers/turn_registry.h
@@ -89,6 +89,16 @@ extern "C"
     * number flagged. Sets flags only; the owning workers do the reaping. */
    int turn_registry_cancel_all(void);
 
+   /* --- pending-steer store (chat.interrupt) ---
+    * One pending steering message per session. chat.interrupt stashes the
+    * message (and cancels the in-flight turn); the worker that ran the cancelled
+    * turn takes it and dispatches it as the next, server-initiated turn. */
+   void chat_steer_set(const char *session_id, const char *message);
+   /* Take + clear the pending steer. Returns 1 with *out_message (malloc'd,
+    * caller frees) if one was pending, 0 otherwise. */
+   int chat_steer_take(const char *session_id, char **out_message);
+   void chat_steer_clear(const char *session_id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/turn_registry.h
+++ b/src/headers/turn_registry.h
@@ -93,7 +93,9 @@ extern "C"
     * One pending steering message per session. chat.interrupt stashes the
     * message (and cancels the in-flight turn); the worker that ran the cancelled
     * turn takes it and dispatches it as the next, server-initiated turn. */
-   void chat_steer_set(const char *session_id, const char *message);
+   /* Returns 0 on success, -1 if the message could not be stored (OOM or the
+    * table is full) — the caller must then NOT report a queued steer. */
+   int chat_steer_set(const char *session_id, const char *message);
    /* Take + clear the pending steer. Returns 1 with *out_message (malloc'd,
     * caller frees) if one was pending, 0 otherwise. */
    int chat_steer_take(const char *session_id, char **out_message);

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -165,6 +165,24 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    if (recv_rc != 0)
    {
       free(raw);
+      if (recv_rc == -3)
+      {
+         /* Cancelled (steering/interrupt): recv already sent the interrupt key,
+          * so the CLI stopped generating with the conversation intact. KEEP a
+          * reused pane alive (the steer continuation reuses it); only free this
+          * turn's scratch. A one-shot pane is torn down. */
+         if (reuse)
+         {
+            free(sess.baseline);
+            sess.baseline = NULL;
+            free(sess.stream_emitted);
+            sess.stream_emitted = NULL;
+         }
+         else
+            cli_session_destroy(&sess);
+         snprintf(out->error, sizeof(out->error), "turn cancelled");
+         return -1;
+      }
       cli_session_destroy(&sess); /* kill the (possibly wedged) session */
       if (recv_rc == -2)
          snprintf(out->error, sizeof(out->error),

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -585,6 +585,16 @@ static void chat_cli_stream_cb(const char *delta, void *ud)
    c->emitted = 1;
 }
 
+/* Cancel predicate for the tmux CLI driver: reflects this turn's registry cancel
+ * flag (set by chat.interrupt / graceful_cancel / session close). Lets
+ * cli_session_recv abort a wedged or steered generation promptly without
+ * coupling cli_session.c to the turn registry. */
+static int chat_cli_cancel_check(void *ud)
+{
+   (void)ud;
+   return agent_request_cancelled();
+}
+
 static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, const char *cwd,
                                      const char *aimee_sid, const char *provider,
                                      const char *model_override, const config_t *cfg)
@@ -657,12 +667,18 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    void *prev_stream_ud = NULL;
    cli_session_stream_cb_t prev_stream_cb = cli_session_get_stream_cb(&prev_stream_ud);
    cli_session_set_stream_cb(chat_cli_stream_cb, &sctx);
+   /* Let the tmux CLI driver observe this turn's cancel flag so a steer/interrupt
+    * stops the running generation promptly. Save/restore around any outer turn. */
+   void *prev_cancel_ud = NULL;
+   cli_session_cancel_cb_t prev_cancel_cb = cli_session_get_cancel_check(&prev_cancel_ud);
+   cli_session_set_cancel_check(chat_cli_cancel_check, NULL);
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
    int rc = agent_run_with_tools(&acfg, "code", system_prompt ? system_prompt : "", message,
                                  AGENT_DEFAULT_MAX_TOKENS, &result);
 
+   cli_session_set_cancel_check(prev_cancel_cb, prev_cancel_ud);
    cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();
@@ -672,6 +688,18 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
 
    if (rc != 0)
    {
+      /* A cancelled turn (steering/interrupt) ends quietly: the running CLI was
+       * stopped with the conversation intact, and the steer continuation streams
+       * as the next turn. Emit a clean turn boundary, not an error event. */
+      if (agent_request_cancelled())
+      {
+         stream_event(cctx, "turn_end", NULL, NULL);
+         stream_event(cctx, "done", NULL, NULL);
+         free(result.response);
+         compute_ok(cctx);
+         compute_ctx_free(cctx);
+         return;
+      }
       compute_error(cctx, result.error[0] ? result.error : "agent provider failed");
       free(result.response);
       compute_ctx_free(cctx);

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -696,6 +696,9 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
          stream_event(cctx, "turn_end", NULL, NULL);
          stream_event(cctx, "done", NULL, NULL);
          free(result.response);
+         /* compute_ok is a no-op for a server-initiated turn (compute_respond
+          * early-returns on conn_fd < 0); the pooled wrapper still emits the
+          * presence-ring turn_done that the webchat events stream listens for. */
          compute_ok(cctx);
          compute_ctx_free(cctx);
          return;

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -77,6 +77,25 @@ cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out)
    return g_stream_cb;
 }
 
+/* Per-thread cancel-check (set by the chat worker to the turn's cancel flag).
+ * cli_session.c stays decoupled from the turn registry — the worker supplies the
+ * predicate. */
+static __thread cli_session_cancel_cb_t g_cancel_cb = NULL;
+static __thread void *g_cancel_ud = NULL;
+
+void cli_session_set_cancel_check(cli_session_cancel_cb_t cb, void *ud)
+{
+   g_cancel_cb = cb;
+   g_cancel_ud = ud;
+}
+
+cli_session_cancel_cb_t cli_session_get_cancel_check(void **ud_out)
+{
+   if (ud_out)
+      *ud_out = g_cancel_ud;
+   return g_cancel_cb;
+}
+
 void cli_session_set_kind(cli_session_t *s, const char *cli_kind)
 {
    if (!s)
@@ -536,6 +555,20 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
       {
          out[0] = '\0';
          return -1;
+      }
+
+      /* Cancellation (steering/interrupt or session close): stop the CLI mid-
+       * generation with an interrupt key so the pane goes idle with the
+       * conversation intact, then report cancelled. Checked before the wall-clock
+       * and poll so a cancel is honoured promptly. */
+      if (g_cancel_cb && g_cancel_cb(g_cancel_ud))
+      {
+         char esc[CLI_SESSION_NAME_MAX + 64];
+         snprintf(esc, sizeof(esc), "tmux send-keys -t '%s' Escape 2>/dev/null", s->session_name);
+         int erc;
+         free(sess_run(esc, &erc));
+         out[0] = '\0';
+         return -3;
       }
 
       /* Wall-clock backstop. Completion is detected by the pane going static

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -563,10 +563,21 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
        * and poll so a cancel is honoured promptly. */
       if (g_cancel_cb && g_cancel_cb(g_cancel_ud))
       {
-         char esc[CLI_SESSION_NAME_MAX + 64];
-         snprintf(esc, sizeof(esc), "tmux send-keys -t '%s' Escape 2>/dev/null", s->session_name);
+         /* Per-CLI interrupt key (verified live): claude stops a response on
+          * Escape (harmless when idle); codex ignores Escape and interrupts on
+          * Ctrl-C (a single C-c mid-generation stops it without quitting). The
+          * cancel fires while recv is polling — i.e. during generation — so the
+          * codex C-c lands while it is working. Default to Escape (the safe key:
+          * ignored CLIs just clear their input). */
+         const char *intr = (strstr(s->cli_kind, "codex") != NULL) ? "C-c" : "Escape";
+         char ic[CLI_SESSION_NAME_MAX + 64];
+         snprintf(ic, sizeof(ic), "tmux send-keys -t '%s' %s 2>/dev/null", s->session_name, intr);
          int erc;
-         free(sess_run(esc, &erc));
+         free(sess_run(ic, &erc));
+         /* Let the TUI settle out of its animating state before the turn ends, so
+          * the next (steer) turn captures a clean baseline and pastes into a
+          * stable prompt rather than a half-rendered one. */
+         msleep_ms(300);
          out[0] = '\0';
          return -3;
       }
@@ -641,10 +652,19 @@ char *cli_session_make_name(const char *agent_name, const char *role)
    if (!name)
       return NULL;
    snprintf(name, CLI_SESSION_NAME_MAX, "aimee-%s-%08lx", agent_name, h & 0xffffffff);
-   /* Replace chars invalid in tmux session names */
+   /* Sanitize: the session name is interpolated into single-quoted tmux shell
+    * commands ('%s') throughout this file, so beyond the chars tmux rejects in a
+    * session name we must also neutralize anything that could break out of the
+    * quoting (single quote, backslash, control/shell metacharacters). The name is
+    * derived from the aimee session id, which can be client-influenced, so this
+    * is the single chokepoint that keeps every tmux sink injection-safe. Keep
+    * only [A-Za-z0-9_-]; map everything else to '-'. */
    for (char *p = name; *p; p++)
    {
-      if (*p == ' ' || *p == '.' || *p == ':' || *p == '/')
+      unsigned char c = (unsigned char)*p;
+      int ok = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') ||
+               c == '_' || c == '-';
+      if (!ok)
          *p = '-';
    }
    return name;

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1032,6 +1032,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"session.get", handle_session_get},
     {"session.close", handle_session_close},
     {"chat.graceful_cancel", handle_chat_graceful_cancel},
+    {"chat.interrupt", handle_chat_interrupt},
     {"session.brief", handle_session_brief},
     {"session.attach", handle_session_attach},
     {"session.detach", handle_session_detach},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -122,6 +122,7 @@ const method_policy_t method_registry[] = {
     {"eval.*", CAP_DELEGATE, "eval harness"},
     {"chat.send_stream", CAP_CHAT, "chat stream"},
     {"chat.graceful_cancel", CAP_CHAT, "cancel an in-flight chat turn (owner-authz)"},
+    {"chat.interrupt", CAP_CHAT, "stop an in-flight turn and queue a steer (owner-authz)"},
     {"mcp.tools_list", CAP_TOOL_EXECUTE, "MCP tool list"},
     {"mcp.audit", CAP_TOOL_EXECUTE, "MCP OSV audit"},
     {"mcp.recheck", CAP_TOOL_EXECUTE, "MCP OSV recheck"},

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1599,15 +1599,24 @@ compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON 
     * handshake and causing "server dropped connection" errors for other
     * clients.  With dup, close(conn->fd) merely frees the fd-table slot;
     * the underlying socket description stays alive until we close our copy. */
-#ifdef AIMEE_POSIX
+   /* A NULL conn is a server-initiated turn (no client socket): it streams to the
+    * session's presence-event ring only. Used by chat.interrupt's auto-continue,
+    * which dispatches the queued steer with no requesting connection. */
+   if (!conn)
    {
+      cctx->conn_fd = -1;
+      cctx->conn_alive = 0;
+   }
+   else
+   {
+#ifdef AIMEE_POSIX
       int duped = dup(conn->fd);
       cctx->conn_fd = (duped >= 0) ? duped : conn->fd;
-   }
 #else
-   cctx->conn_fd = conn->fd;
+      cctx->conn_fd = conn->fd;
 #endif
-   cctx->conn_alive = 1;
+      cctx->conn_alive = 1;
+   }
    /* Capture the peer's caps for the foreign-cwd trust check (AC #6). A UDS peer
     * is CAPS_ALL (same filesystem); a remote/TCP peer is less, and its cwd must
     * not be opened on the server's own fs. A NULL conn is an in-process caller. */

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -539,6 +539,9 @@ static void chat_stream_worker_pooled(void *arg)
       /* Carry the session's principal into create_compute_ctx's thread-local
        * fallback (the NULL-conn path reads it for vault identity). */
       agent_set_request_vault_principal(steer_principal);
+      /* create_compute_ctx DUPLICATES req (cJSON_Duplicate) — it does not adopt
+       * steer_tmpl — so steer_tmpl remains ours to free below, and the new ctx
+       * owns its own copy that its worker frees. */
       compute_ctx_t *nctx = create_compute_ctx(steer_ctx, NULL, steer_tmpl);
       agent_set_request_vault_principal(NULL);
       if (nctx && chat_stream_dispatch(steer_ctx, nctx) != 0)

--- a/src/server/server_compute_async.c
+++ b/src/server/server_compute_async.c
@@ -401,10 +401,22 @@ cJSON *server_compute_async_json(server_ctx_t *ctx)
 /* Monotonic per-chat-turn id source for the presence-event stream. */
 static atomic_ulong g_chat_turn_seq;
 
+static int chat_stream_dispatch(server_ctx_t *ctx, compute_ctx_t *cctx);
+static char *chat_sanitize_message_transcript_tail(const char *message);
+
 static void chat_stream_worker_pooled(void *arg)
 {
    compute_ctx_t *cctx = (compute_ctx_t *)arg;
    int async_slot = cctx->async_slot;
+
+   /* Capture what the steer auto-continue needs BEFORE chat_stream_worker frees
+    * cctx: the request template (to clone with the steer message swapped in), the
+    * session's attested principal, and the server ctx. Cheap clone per turn;
+    * freed below unless a steer is dispatched. */
+   cJSON *steer_tmpl = cJSON_Duplicate(cctx->req, 1);
+   char steer_principal[128];
+   snprintf(steer_principal, sizeof(steer_principal), "%s", cctx->vault_principal);
+   server_ctx_t *steer_ctx = cctx->server;
 
    /* Copy what we need before chat_stream_worker runs — its sub-workers free
     * cctx (and its req) on completion.
@@ -508,6 +520,32 @@ static void chat_stream_worker_pooled(void *arg)
     * turn registry table (NOT into cctx, which the worker already freed), so
     * this is not a use-after-free. */
    turn_registry_clear(cancel_entry);
+
+   /* Steering auto-continue: if chat.interrupt queued a follow-up for this
+    * session (it only does so when it cancelled an in-flight turn), dispatch it
+    * now as a server-initiated turn. It reuses the cancelled turn's request
+    * (same session / cwd / provider) with the steer message swapped in, runs with
+    * no client connection (streams to the presence-event ring), and — for a tmux
+    * CLI provider — reuses the same pane, so the conversation continues from where
+    * the interrupt stopped it. */
+   char *steer_msg = NULL;
+   if (sid[0] && steer_tmpl && chat_steer_take(sid, &steer_msg) && steer_msg)
+   {
+      char *clean = chat_sanitize_message_transcript_tail(steer_msg);
+      cJSON *m = cJSON_CreateString(clean ? clean : steer_msg);
+      free(clean);
+      if (m)
+         cJSON_ReplaceItemInObjectCaseSensitive(steer_tmpl, "message", m);
+      /* Carry the session's principal into create_compute_ctx's thread-local
+       * fallback (the NULL-conn path reads it for vault identity). */
+      agent_set_request_vault_principal(steer_principal);
+      compute_ctx_t *nctx = create_compute_ctx(steer_ctx, NULL, steer_tmpl);
+      agent_set_request_vault_principal(NULL);
+      if (nctx && chat_stream_dispatch(steer_ctx, nctx) != 0)
+         compute_ctx_free(nctx);
+      free(steer_msg);
+   }
+   cJSON_Delete(steer_tmpl);
 
    async_slot_release(async_slot);
    chat_thread_release();

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1666,6 +1666,9 @@ static const http_route_t g_v1_routes[] = {
     /* Streaming chat over HTTP: dispatched by handle_conn; row exists for the
      * capability gate + conformance scan. */
     {"POST", "/v1/chat/stream", NULL, RM_EXACT, "chat.send_stream", 0, NULL},
+    /* Steering: stop the in-flight turn + queue a follow-up the server
+     * auto-continues (streamed to the session's /events). */
+    {"POST", "/v1/chat/interrupt", NULL, RM_EXACT, "chat.interrupt", 0, rh_dispatch_op},
 
     /* Server-hosted Claude PTY session (terminal forwarding). All consume model
      * budget (spawn/drive claude), so they map to the chat capability. The

--- a/src/server/server_session.c
+++ b/src/server/server_session.c
@@ -130,16 +130,33 @@ int handle_chat_interrupt(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return server_send_error(conn, "forbidden: not the session owner", NULL);
 
    /* A turn was flagged: stash the steer for its worker to auto-continue. Order
-    * matters for security AND correctness: authorize+cancel FIRST, then stash.
-    * Stashing before the authz check would let an unauthorized caller's steer be
-    * picked up by a legitimate turn that happens to end in the race window. The
-    * reverse race (worker takes before this set, losing the steer) cannot happen:
-    * the worker only reaches the take after observing the cancel flag (a >=500ms
-    * recv poll) + interrupting + tearing the turn down, long after this set. */
+    * matters for security: authorize+cancel FIRST, then stash. Stashing before
+    * the authz check would let an unauthorized caller's steer be picked up by a
+    * legitimate turn that happens to end in the race window.
+    *
+    * Two corner cases turn rc=1 back into "not interrupted" so the caller sends
+    * the message as an ordinary turn instead of silently losing it:
+    *  - the steer table is full / OOM (chat_steer_set fails); or
+    *  - the turn finished (its registry entry is already gone) in the narrow
+    *    window between cancel and set, so no worker will pick the steer up. We
+    *    reclaim it; if the worker already took it (it dispatched), leave rc=1. */
    if (rc == 1)
-      chat_steer_set(sid, message);
-   aimee_log(LOG_INFO, "chat_interrupt", "session=%s interrupted=%d (queued steer=%d)", sid,
-             rc == 1, rc == 1);
+   {
+      if (chat_steer_set(sid, message) != 0)
+      {
+         rc = 0;
+      }
+      else if (!turn_registry_find(sid))
+      {
+         char *reclaimed = NULL;
+         if (chat_steer_take(sid, &reclaimed))
+         {
+            free(reclaimed);
+            rc = 0;
+         }
+      }
+   }
+   aimee_log(LOG_INFO, "chat_interrupt", "session=%s interrupted=%d", sid, rc == 1);
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "session_id", sid);

--- a/src/server/server_session.c
+++ b/src/server/server_session.c
@@ -129,11 +129,17 @@ int handle_chat_interrupt(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (rc < 0)
       return server_send_error(conn, "forbidden: not the session owner", NULL);
 
-   /* A turn was flagged: stash the steer for its worker to auto-continue. The
-    * cancel flag is observed asynchronously (the worker polls it), so the worker
-    * reaches the steer-take well after this set — no race. */
+   /* A turn was flagged: stash the steer for its worker to auto-continue. Order
+    * matters for security AND correctness: authorize+cancel FIRST, then stash.
+    * Stashing before the authz check would let an unauthorized caller's steer be
+    * picked up by a legitimate turn that happens to end in the race window. The
+    * reverse race (worker takes before this set, losing the steer) cannot happen:
+    * the worker only reaches the take after observing the cancel flag (a >=500ms
+    * recv poll) + interrupting + tearing the turn down, long after this set. */
    if (rc == 1)
       chat_steer_set(sid, message);
+   aimee_log(LOG_INFO, "chat_interrupt", "session=%s interrupted=%d (queued steer=%d)", sid,
+             rc == 1, rc == 1);
 
    cJSON *resp = jo_ok();
    cJSON_AddStringToObject(resp, "session_id", sid);

--- a/src/server/server_session.c
+++ b/src/server/server_session.c
@@ -92,6 +92,55 @@ int handle_chat_graceful_cancel(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
    return server_send_ok(conn, resp);
 }
 
+/* chat.interrupt: steering. Stop the in-flight turn for a session AND queue a
+ * follow-up `message` that the cancelled turn's worker auto-dispatches as the
+ * next, server-initiated turn (streamed to the session's presence-event stream).
+ * Same owner-authz as chat.graceful_cancel. When no turn is in flight, nothing is
+ * queued and `interrupted` is false — the caller should send the message as an
+ * ordinary turn instead. */
+int handle_chat_interrupt(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   cJSON *jsid = cJSON_GetObjectItemCaseSensitive(req, "aimee_session_id");
+   if (!cJSON_IsString(jsid))
+      jsid = cJSON_GetObjectItemCaseSensitive(req, "session_id");
+   const char *sid = (jsid && cJSON_IsString(jsid)) ? jsid->valuestring : NULL;
+   if (!sid || !sid[0])
+      return server_send_error(conn, "missing aimee_session_id", NULL);
+   cJSON *jmsg = cJSON_GetObjectItemCaseSensitive(req, "message");
+   const char *message = (jmsg && cJSON_IsString(jmsg)) ? jmsg->valuestring : NULL;
+   if (!message || !message[0])
+      return server_send_error(conn, "missing message", NULL);
+
+   /* Authorize + cancel exactly like graceful_cancel (owner-authz; a trusted
+    * local peer — the co-located webchat backend over the UDS — is allowed and
+    * binds session id to its authenticated caller before forwarding). */
+   int rc;
+   int trusted_local = (conn->capabilities == CAPS_ALL);
+   aimee_log(LOG_INFO, "chat_interrupt",
+             "interrupt request: session=%s trusted_local=%d principal=%s", sid, trusted_local,
+             conn->vault_principal[0] ? conn->vault_principal : "(none)");
+   if (trusted_local)
+      rc = turn_registry_cancel(sid, NULL);
+   else if (conn->vault_principal[0])
+      rc = turn_registry_cancel(sid, conn->vault_principal);
+   else
+      return server_send_error(conn, "forbidden: unattested caller", NULL);
+   if (rc < 0)
+      return server_send_error(conn, "forbidden: not the session owner", NULL);
+
+   /* A turn was flagged: stash the steer for its worker to auto-continue. The
+    * cancel flag is observed asynchronously (the worker polls it), so the worker
+    * reaches the steer-take well after this set — no race. */
+   if (rc == 1)
+      chat_steer_set(sid, message);
+
+   cJSON *resp = jo_ok();
+   cJSON_AddStringToObject(resp, "session_id", sid);
+   cJSON_AddBoolToObject(resp, "interrupted", rc == 1 ? 1 : 0);
+   return server_send_ok(conn, resp);
+}
+
 /* session.attach: register a surface as an attachment of a presence (creating
  * the presence on first attach), per the unified-presence model. Mirrors the
  * REST POST /v1/sessions/{id}/attach, for the NDJSON/CLI transport. */

--- a/src/server/turn_registry.c
+++ b/src/server/turn_registry.c
@@ -180,13 +180,13 @@ static steer_slot_t *steer_find_locked(const char *session_id)
    return NULL;
 }
 
-void chat_steer_set(const char *session_id, const char *message)
+int chat_steer_set(const char *session_id, const char *message)
 {
    if (!session_id || !session_id[0] || !message)
-      return;
+      return -1;
    char *copy = strdup(message);
    if (!copy)
-      return;
+      return -1;
    pthread_mutex_lock(&g_lock);
    steer_slot_t *slot = steer_find_locked(session_id);
    if (!slot)
@@ -206,7 +206,8 @@ void chat_steer_set(const char *session_id, const char *message)
       copy = NULL;
    }
    pthread_mutex_unlock(&g_lock);
-   free(copy); /* table full: drop */
+   free(copy);           /* non-NULL only when the table was full */
+   return slot ? 0 : -1; /* -1 => caller must report interrupted=false */
 }
 
 int chat_steer_take(const char *session_id, char **out_message)

--- a/src/server/turn_registry.c
+++ b/src/server/turn_registry.c
@@ -155,3 +155,82 @@ int turn_registry_cancel_all(void)
    pthread_mutex_unlock(&g_lock);
    return n;
 }
+
+/* --- pending-steer store -------------------------------------------------
+ * One pending steering message per session: chat.interrupt stashes it and
+ * cancels the in-flight turn; the worker that ran the cancelled turn takes it
+ * and dispatches it as the next (server-initiated) turn. Same leaf lock as the
+ * turn table; the message is a malloc'd copy owned by the slot until taken. */
+typedef struct
+{
+   char session_id[PRESENCE_SESSION_ID_MAX];
+   char *message;
+   int in_use;
+} steer_slot_t;
+
+static steer_slot_t g_steers[TURN_MAX];
+
+static steer_slot_t *steer_find_locked(const char *session_id)
+{
+   if (!session_id || !session_id[0])
+      return NULL;
+   for (int i = 0; i < TURN_MAX; i++)
+      if (g_steers[i].in_use && strcmp(g_steers[i].session_id, session_id) == 0)
+         return &g_steers[i];
+   return NULL;
+}
+
+void chat_steer_set(const char *session_id, const char *message)
+{
+   if (!session_id || !session_id[0] || !message)
+      return;
+   char *copy = strdup(message);
+   if (!copy)
+      return;
+   pthread_mutex_lock(&g_lock);
+   steer_slot_t *slot = steer_find_locked(session_id);
+   if (!slot)
+      for (int i = 0; i < TURN_MAX; i++)
+         if (!g_steers[i].in_use)
+         {
+            slot = &g_steers[i];
+            slot->in_use = 1;
+            snprintf(slot->session_id, sizeof(slot->session_id), "%s", session_id);
+            slot->message = NULL;
+            break;
+         }
+   if (slot)
+   {
+      free(slot->message); /* a newer steer supersedes an untaken one */
+      slot->message = copy;
+      copy = NULL;
+   }
+   pthread_mutex_unlock(&g_lock);
+   free(copy); /* table full: drop */
+}
+
+int chat_steer_take(const char *session_id, char **out_message)
+{
+   if (out_message)
+      *out_message = NULL;
+   if (!session_id || !session_id[0] || !out_message)
+      return 0;
+   pthread_mutex_lock(&g_lock);
+   steer_slot_t *slot = steer_find_locked(session_id);
+   int got = 0;
+   if (slot)
+   {
+      *out_message = slot->message; /* transfer ownership to caller */
+      memset(slot, 0, sizeof(*slot));
+      got = *out_message ? 1 : 0;
+   }
+   pthread_mutex_unlock(&g_lock);
+   return got;
+}
+
+void chat_steer_clear(const char *session_id)
+{
+   char *msg = NULL;
+   (void)chat_steer_take(session_id, &msg);
+   free(msg);
+}

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -416,6 +416,10 @@ int handle_chat_graceful_cancel(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
 {
    return stub_handler(conn, "chat.graceful_cancel");
 }
+int handle_chat_interrupt(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "chat.interrupt");
+}
 int handle_session_brief(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "session.brief");

--- a/src/tests/test_turn_registry.c
+++ b/src/tests/test_turn_registry.c
@@ -105,17 +105,20 @@ static void test_steer_set_take(void)
 {
    char *msg = NULL;
    assert(chat_steer_take("sess-S", &msg) == 0 && msg == NULL); /* nothing pending */
-   chat_steer_set("sess-S", "focus on the parser");
+   assert(chat_steer_set("sess-S", "focus on the parser") == 0);
    assert(chat_steer_take("sess-S", &msg) == 1);
    assert(msg && strcmp(msg, "focus on the parser") == 0);
    free(msg);
    msg = NULL;
    assert(chat_steer_take("sess-S", &msg) == 0 && msg == NULL); /* cleared by take */
    /* a newer steer supersedes an untaken one */
-   chat_steer_set("sess-S", "first");
-   chat_steer_set("sess-S", "second");
+   assert(chat_steer_set("sess-S", "first") == 0);
+   assert(chat_steer_set("sess-S", "second") == 0);
    assert(chat_steer_take("sess-S", &msg) == 1 && msg && strcmp(msg, "second") == 0);
    free(msg);
+   /* invalid args fail */
+   assert(chat_steer_set(NULL, "x") == -1);
+   assert(chat_steer_set("sess-S", NULL) == -1);
    /* per-session isolation */
    char *ma = NULL, *mb = NULL;
    chat_steer_set("sess-A", "a");

--- a/src/tests/test_turn_registry.c
+++ b/src/tests/test_turn_registry.c
@@ -3,6 +3,7 @@
 #include <assert.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "turn_registry.h"
@@ -100,6 +101,37 @@ static void test_reaped(void)
    printf("ok: mark_reaped\n");
 }
 
+static void test_steer_set_take(void)
+{
+   char *msg = NULL;
+   assert(chat_steer_take("sess-S", &msg) == 0 && msg == NULL); /* nothing pending */
+   chat_steer_set("sess-S", "focus on the parser");
+   assert(chat_steer_take("sess-S", &msg) == 1);
+   assert(msg && strcmp(msg, "focus on the parser") == 0);
+   free(msg);
+   msg = NULL;
+   assert(chat_steer_take("sess-S", &msg) == 0 && msg == NULL); /* cleared by take */
+   /* a newer steer supersedes an untaken one */
+   chat_steer_set("sess-S", "first");
+   chat_steer_set("sess-S", "second");
+   assert(chat_steer_take("sess-S", &msg) == 1 && msg && strcmp(msg, "second") == 0);
+   free(msg);
+   /* per-session isolation */
+   char *ma = NULL, *mb = NULL;
+   chat_steer_set("sess-A", "a");
+   chat_steer_set("sess-B", "b");
+   assert(chat_steer_take("sess-A", &ma) == 1 && ma && strcmp(ma, "a") == 0);
+   assert(chat_steer_take("sess-B", &mb) == 1 && mb && strcmp(mb, "b") == 0);
+   free(ma);
+   free(mb);
+   /* clear drops an untaken steer */
+   chat_steer_set("sess-C", "c");
+   chat_steer_clear("sess-C");
+   msg = NULL;
+   assert(chat_steer_take("sess-C", &msg) == 0);
+   printf("ok: steer_set_take\n");
+}
+
 int main(void)
 {
    turn_registry_init();
@@ -108,6 +140,7 @@ int main(void)
    test_cancel_authz();
    test_cancel_all();
    test_reaped();
+   test_steer_set_take();
    printf("all turn_registry tests passed\n");
    return 0;
 }

--- a/webchat/chat.go
+++ b/webchat/chat.go
@@ -360,6 +360,42 @@ func (s *server) handleChatClear(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, `{"status":"ok"}`)
 }
 
+// handleChatInterrupt handles POST /api/chat/interrupt: stop the in-flight turn
+// for a session and queue a steering message the server auto-continues as the
+// next turn (streamed to the session's /events). The reply is small JSON
+// ({interrupted:bool}); the steered turn itself arrives on the events stream.
+func (s *server) handleChatInterrupt(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, `{"error":"method not allowed"}`, http.StatusMethodNotAllowed)
+		return
+	}
+	var req struct {
+		AimeeSessionID string `json:"aimee_session_id"`
+		Message        string `json:"message"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, `{"error":"bad request"}`, http.StatusBadRequest)
+		return
+	}
+	if req.AimeeSessionID == "" || req.Message == "" {
+		http.Error(w, `{"error":"aimee_session_id and message required"}`, http.StatusBadRequest)
+		return
+	}
+	body, _ := json.Marshal(map[string]string{
+		"aimee_session_id": req.AimeeSessionID,
+		"message":          req.Message,
+	})
+	st, data, err := s.v1RequestWebuser(r.Context(), currentUser(r), http.MethodPost,
+		"/v1/chat/interrupt", body)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(st)
+	w.Write(data)
+}
+
 // handleChatThreads is a stub for GET /api/chat/threads (in-tab conversation
 // branching — a separate, not-yet-implemented feature). It returns the empty
 // shape the SPA's ThreadBar expects. The per-user persisted tab list lives at

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -135,6 +135,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Chat API (session required)
 	mux.HandleFunc("/api/chat/send", s.requireAuth(s.handleChatSend))
+	mux.HandleFunc("/api/chat/interrupt", s.requireAuth(s.handleChatInterrupt))
 	mux.HandleFunc("/api/chat/session", s.requireAuth(s.handleChatSession))
 	mux.HandleFunc("/api/chat/projects", s.requireAuth(s.handleChatProjects))
 	mux.HandleFunc("/api/chat/bootstrap-status", s.requireAuth(s.handleBootstrapStatus))


### PR DESCRIPTION
## What
`chat.interrupt {aimee_session_id, message}` — stop the in-flight turn for a session and queue `message` as the next, **server-initiated** turn. In webchat, typing+sending while a turn is running now *steers* it instead of being blocked; the steered reply streams in on the session's `/events` presence stream.

## How
- **Cancel observed in tmux:** `cli_session_recv` polls a thread-local cancel predicate (the turn's registry cancel flag, supplied by the chat worker so `cli_session` stays decoupled). On cancel it sends the CLI's interrupt key — **verified live**: claude=`Escape`, codex=`Ctrl-C` — so generation stops with the conversation intact, then returns cancelled. Previously only a wall-clock timeout could stop a tmux turn. The cancelled turn ends quietly (clean turn boundary, no error event) and the reused pane is kept alive for the continuation.
- **Pending-steer store** (one slot/session, in `turn_registry`): `chat.interrupt` (owner-authz like `graceful_cancel`) cancels + stashes; the worker that ran the cancelled turn takes it and dispatches a server-initiated turn — reusing the cancelled turn's request (same session/cwd/provider) with the steer swapped in, no client conn, streamed to the presence ring. `create_compute_ctx` gains a NULL-conn path.
- **Route** `chat.interrupt` (CAP_CHAT) + HTTP `/v1/chat/interrupt` + OpenAPI + CLI-routes regen; webchat `/api/chat/interrupt`; frontend type-send-while-busy → interrupt, with a per-session one-shot to render the continuation past the self-echo guard, and a fallback to a normal send when nothing was actually in flight.

## Review
Two-round roundtable (mistral + minimax). Round-1 fixes + round-2 (minimax, grounded) fixes: per-CLI interrupt key, steer-never-lost (table-full/race → fall back to normal send), session-name quote-injection sanitized at the chokepoint, `expectSteerRef` keyed per-session, settle after the interrupt key. Mistral's findings and minimax's #1/#2/#3/#7/#9 were verified false (comments added).

## Tests
Steer-store unit tests (set/take/supersede/isolation/clear/return-value/invalid-args) + dispatch stub; live: Escape stops claude, Ctrl-C interrupts codex. Full unit suite + lint green; webchat Go builds.

## Known follow-ups (documented)
- codex C-c has a narrow tail-of-generation window where it could quit instead of interrupt (cancel only fires during active generation, so rare).
- Frontend type-check runs in CI (deps not installed locally).