### PR TITLE
fix(webchat): make the editor + git panel act on the session's worktree

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -3686,6 +3686,12 @@ paths:
                 message: { type: string, description: Commit message (op=commit) }
                 branch: { type: string, description: Target branch (op=checkout) }
                 n: { type: integer, description: Log entry count (op=log) }
+                session_id:
+                  type: string
+                  description: >
+                    Optional. Run the op in this session's isolated worktree (the
+                    same tree its agent edits) rather than the shared project
+                    checkout.
       responses:
         "200":
           description: Operation ran
@@ -3698,6 +3704,44 @@ paths:
                   output: { type: string }
         "400":
           description: Unknown project/op, invalid argument, or git failure
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /workspace/session-dir:
+    post:
+      summary: Resolve a session's working directory for a project
+      description: >
+        Return the absolute directory the given session acts in for `project`:
+        that session's isolated sibling worktree (off the default branch, created
+        on demand) when `session_id` is non-empty, else the project checkout. Lets
+        the editor open the same tree the session's agent edits. Identity is the
+        authenticated `webuser:` principal. Capability: index:read.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [project]
+              properties:
+                project: { type: string }
+                session_id: { type: string }
+      responses:
+        "200":
+          description: Resolved directory
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  dir: { type: string }
+        "400":
+          description: Unknown project or invalid body
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -1,15 +1,47 @@
+import { useEffect, useState } from 'react';
 import ProjectPicker from '../components/ProjectPicker';
 import { useSessions } from '../SessionContext';
 
 /* In-app VSCode, bound to the active SESSION's project. The per-user code-server
  * (served by aimee-server, reverse-proxied at /vscode/) is rooted at the user's
- * workspace; the session's project opens its folder via ?folder=<root>/<project>.
- * The browser never sees the editor's loopback port or any git credential — creds
- * stay server-side in the sealed vault. Picking a project here binds it to the
- * session, so Chat/Workflows see the same project. */
+ * workspace. To stay consistent with the agent — which works in the session's
+ * isolated worktree (a sibling on aimee/session/<sid> off the default branch) —
+ * the editor opens that same worktree via ?folder=<dir>, resolved server-side
+ * (/api/git/session-dir). Before the session has an aimee id (no turn yet) it
+ * falls back to the project checkout. The browser never sees the editor's
+ * loopback port or any git credential — creds stay server-side in the vault. */
+async function api(path: string, init?: RequestInit): Promise<Response> {
+  return fetch(path, {
+    ...init,
+    headers: { 'Content-Type': 'application/json', 'X-CSRF-Token': window._csrf || '', ...(init?.headers || {}) },
+  });
+}
+
 export default function Editor() {
   const { active, patchSession } = useSessions();
-  const folder = active?.projectRoot || '';
+  const projectRoot = active?.projectRoot || '';
+  const projectName = active?.projectName || '';
+  const aimeeSid = active?.aimeeSid || '';
+  const [folder, setFolder] = useState('');
+
+  // Resolve the folder to open: the session's worktree when it has one, else the
+  // project checkout. Re-resolves when the bound project or session id changes.
+  useEffect(() => {
+    let cancelled = false;
+    if (!projectRoot) { setFolder(''); return; }
+    setFolder(projectRoot); // immediate fallback while the worktree resolves
+    if (projectName && aimeeSid) {
+      api('/api/git/session-dir', {
+        method: 'POST',
+        body: JSON.stringify({ project: projectName, session_id: aimeeSid }),
+      })
+        .then(r => (r.ok ? r.json() : null))
+        .then(d => { if (!cancelled && d && d.dir) setFolder(d.dir); })
+        .catch(() => { /* keep the project-checkout fallback */ });
+    }
+    return () => { cancelled = true; };
+  }, [projectRoot, projectName, aimeeSid]);
+
   // Re-key the iframe on folder change so code-server reloads at the new folder.
   const src = folder ? `/vscode/?folder=${encodeURIComponent(folder)}` : '/vscode/';
 

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Panel } from '@rakuensoftware/smoothgui';
+import { useSessions } from '../SessionContext';
 
 /* Git projects (webchat-git WP-F2). Lists the user's cloned repos, connects a
  * new one, and runs per-project git ops — all via /api/git/* (the server forwards
@@ -29,6 +30,7 @@ const input: React.CSSProperties = {
 };
 
 export default function Projects() {
+  const { active } = useSessions();
   const [projects, setProjects] = useState<string[]>([]);
   const [selected, setSelected] = useState<string>('');
   const [output, setOutput] = useState<string>('');
@@ -162,9 +164,12 @@ export default function Projects() {
     if (!selected) return;
     setBusy(true); setErr(''); setOutput('');
     try {
+      // When operating on the active session's project, act on that session's
+      // isolated worktree (the same tree its agent edits), not the shared base.
+      const session_id = active && active.projectName === selected ? active.aimeeSid : '';
       const r = await api('/api/git/op', {
         method: 'POST',
-        body: JSON.stringify({ project: selected, op, ...extra }),
+        body: JSON.stringify({ project: selected, op, session_id, ...extra }),
       });
       const d = await r.json();
       if (!r.ok) { setErr(d.error || `${op} failed`); }

--- a/src/headers/git_ops.h
+++ b/src/headers/git_ops.h
@@ -18,4 +18,26 @@
 int git_ops_run(const char *principal, const char *project, const char *op, const char *text_arg,
                 int num_arg, char **out, char *err, size_t errlen);
 
+/* Like git_ops_run, but when `session_id` is non-empty the op runs in that
+ * session's isolated sibling worktree of the project (off the default branch,
+ * created on demand) — the same tree the session's agent edits — instead of the
+ * shared project checkout. session_id NULL/"" → identical to git_ops_run.
+ * Requires git_ops_register_session_isolation (else session_id is ignored). */
+int git_ops_run_session(const char *principal, const char *project, const char *session_id,
+                        const char *op, const char *text_arg, int num_arg, char **out, char *err,
+                        size_t errlen);
+
+/* Resolve the absolute working directory a session acts in for `project`: that
+ * session's sibling worktree (off the default branch, created on demand) when
+ * `session_id` is non-empty and a resolver is registered, else the project
+ * checkout. Writes an absolute path to out. Returns 0 on success, -1 + err. */
+int git_ops_session_dir(const char *principal, const char *project, const char *session_id,
+                        char *out, size_t out_len, char *err, size_t errlen);
+
+/* Register the per-session worktree resolver (workspace.c:session_isolation_target).
+ * Called once by the server at startup; unregistered → session ops/dirs fall back
+ * to the shared project checkout. */
+void git_ops_register_session_isolation(int (*fn)(const char *cwd, const char *sid, char *out,
+                                                  size_t out_len, int create_if_missing));
+
 #endif /* GIT_OPS_H */

--- a/src/server/git_ops.c
+++ b/src/server/git_ops.c
@@ -10,6 +10,19 @@
 
 extern char **environ;
 
+/* Per-session worktree resolver (workspace.c:session_isolation_target), wired in
+ * by the server at startup via a registered pointer so this TU carries no link
+ * dependency on the heavyweight workspace.o. Unregistered (thin client / unit
+ * tests) → a session op simply runs in the shared project checkout. */
+static int (*g_session_isolation_target)(const char *cwd, const char *sid, char *out,
+                                         size_t out_len, int create_if_missing);
+
+void git_ops_register_session_isolation(int (*fn)(const char *cwd, const char *sid, char *out,
+                                                  size_t out_len, int create_if_missing))
+{
+   g_session_isolation_target = fn;
+}
+
 #define GO_PATH_MAX    4096
 #define GO_OUT_MAX     (1 << 18) /* 256 KiB of git output */
 #define GO_TIMEOUT_MS  120000    /* a git op (incl. network) may take a while */
@@ -59,8 +72,57 @@ static int run_git(const char *principal, const char *dir, const char *const arg
    return rc;
 }
 
+/* Resolve the working dir for `project`: the project checkout, or — when
+ * `session_id` is non-empty and a session-isolation resolver is registered — that
+ * session's sibling worktree (off the default branch, created on demand) so the
+ * webchat git surfaces act on the SAME tree the session's agent edits. Returns 0
+ * + dir, or -1 with err. */
+static int resolve_session_dir(const char *principal, const char *project, const char *session_id,
+                               char *dir, size_t dir_len, char *err, size_t errlen)
+{
+   if (ws_scope_project_path(principal, project ? project : "", 1 /*must_exist*/, dir, dir_len) !=
+       0)
+   {
+      snprintf(err, errlen, "no such project");
+      return -1;
+   }
+   if (session_id && session_id[0] && g_session_isolation_target)
+   {
+      char wt[GO_PATH_MAX];
+      if (g_session_isolation_target(dir, session_id, wt, sizeof(wt), 1 /*create_if_missing*/) == 1)
+         snprintf(dir, dir_len, "%s", wt);
+   }
+   return 0;
+}
+
+int git_ops_session_dir(const char *principal, const char *project, const char *session_id,
+                        char *out, size_t out_len, char *err, size_t errlen)
+{
+   if (out && out_len)
+      out[0] = '\0';
+   if (err && errlen)
+      err[0] = '\0';
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+   {
+      snprintf(err, errlen, "git projects require a webchat user");
+      return -1;
+   }
+   char dir[GO_PATH_MAX];
+   if (resolve_session_dir(principal, project, session_id, dir, sizeof(dir), err, errlen) != 0)
+      return -1;
+   snprintf(out, out_len, "%s", dir);
+   return 0;
+}
+
 int git_ops_run(const char *principal, const char *project, const char *op, const char *text_arg,
                 int num_arg, char **out, char *err, size_t errlen)
+{
+   return git_ops_run_session(principal, project, NULL, op, text_arg, num_arg, out, err, errlen);
+}
+
+int git_ops_run_session(const char *principal, const char *project, const char *session_id,
+                        const char *op, const char *text_arg, int num_arg, char **out, char *err,
+                        size_t errlen)
 {
    if (out)
       *out = NULL;
@@ -79,12 +141,8 @@ int git_ops_run(const char *principal, const char *project, const char *op, cons
    }
 
    char dir[GO_PATH_MAX];
-   if (ws_scope_project_path(principal, project ? project : "", 1 /*must_exist*/, dir,
-                             sizeof(dir)) != 0)
-   {
-      snprintf(err, errlen, "no such project");
+   if (resolve_session_dir(principal, project, session_id, dir, sizeof(dir), err, errlen) != 0)
       return -1;
-   }
 
    /* --- commit is two steps (stage all, then commit with the message) --- */
    if (strcmp(op, "commit") == 0)

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1025,8 +1025,12 @@ static int rh_workspace_git(const route_req_t *rq, char *resp, int cap)
    const cJSON *jmsg = cJSON_GetObjectItemCaseSensitive(body, "message");
    const cJSON *jbranch = cJSON_GetObjectItemCaseSensitive(body, "branch");
    const cJSON *jn = cJSON_GetObjectItemCaseSensitive(body, "n");
+   const cJSON *jsid = cJSON_GetObjectItemCaseSensitive(body, "session_id");
    const char *project = (cJSON_IsString(jproj) && jproj->valuestring) ? jproj->valuestring : NULL;
    const char *op = (cJSON_IsString(jop) && jop->valuestring) ? jop->valuestring : NULL;
+   /* Optional: run in the calling session's isolated worktree (same tree its
+    * agent edits) rather than the shared project checkout. */
+   const char *session_id = (cJSON_IsString(jsid) && jsid->valuestring) ? jsid->valuestring : NULL;
    /* text_arg is the commit message (commit) or target branch (checkout). */
    const char *text = NULL;
    if (op && strcmp(op, "commit") == 0)
@@ -1036,7 +1040,8 @@ static int rh_workspace_git(const route_req_t *rq, char *resp, int cap)
    int num = (cJSON_IsNumber(jn)) ? (int)jn->valuedouble : 0;
 
    char *git_out = NULL, err[256];
-   int rc = git_ops_run(principal, project, op, text, num, &git_out, err, sizeof(err));
+   int rc = git_ops_run_session(principal, project, session_id, op, text, num, &git_out, err,
+                                sizeof(err));
    cJSON_Delete(body);
    if (rc != 0)
    {
@@ -1078,6 +1083,42 @@ static int rh_workspace_projects(const route_req_t *rq, char *resp, int cap)
    char root[MAX_PATH_LEN];
    if (ws_scope_user_root(principal, 0, root, sizeof(root)) == 0)
       cJSON_AddStringToObject(out, "root", root);
+   char *s = cJSON_PrintUnformatted(out);
+   int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
+   free(s);
+   cJSON_Delete(out);
+   return (n > 0 && n < cap) ? 200 : err_json(resp, cap, 500, "response too large");
+}
+
+/* POST /v1/workspace/session-dir {project, session_id} — resolve the absolute
+ * directory the given session acts in for `project`: that session's isolated
+ * sibling worktree (off the default branch, created on demand) when session_id is
+ * present, else the project checkout. Lets the editor open the same tree the
+ * session's agent edits. Identity is the attested webuser principal. */
+static int rh_workspace_session_dir(const route_req_t *rq, char *resp, int cap)
+{
+   const char *principal = server_http_identity_principal();
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return err_json(resp, cap, 403, "git projects require a webchat user");
+
+   cJSON *body = (rq->body && rq->body[0]) ? cJSON_Parse(rq->body) : NULL;
+   if (!body || !cJSON_IsObject(body))
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400, "invalid JSON body");
+   }
+   const cJSON *jproj = cJSON_GetObjectItemCaseSensitive(body, "project");
+   const cJSON *jsid = cJSON_GetObjectItemCaseSensitive(body, "session_id");
+   const char *project = (cJSON_IsString(jproj) && jproj->valuestring) ? jproj->valuestring : NULL;
+   const char *session_id = (cJSON_IsString(jsid) && jsid->valuestring) ? jsid->valuestring : NULL;
+
+   char dir[MAX_PATH_LEN], err[256];
+   int rc = git_ops_session_dir(principal, project, session_id, dir, sizeof(dir), err, sizeof(err));
+   cJSON_Delete(body);
+   if (rc != 0)
+      return err_json(resp, cap, 400, err);
+   cJSON *out = cJSON_CreateObject();
+   cJSON_AddStringToObject(out, "dir", dir);
    char *s = cJSON_PrintUnformatted(out);
    int n = s ? snprintf(resp, (size_t)cap, "%s", s) : -1;
    free(s);
@@ -1750,6 +1791,8 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/workspaces", NULL, RM_EXACT, "workspace.add", 0, rh_workspaces_register},
     {"POST", "/v1/workspace/clone", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_clone},
     {"POST", "/v1/workspace/git", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_git},
+    {"POST", "/v1/workspace/session-dir", NULL, RM_EXACT, NULL, CAP_INDEX_READ,
+     rh_workspace_session_dir},
     {"GET", "/v1/workspace/projects", NULL, RM_EXACT, NULL, CAP_INDEX_READ, rh_workspace_projects},
     {"POST", "/v1/workspace/editor", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_workspace_editor},
     {"GET", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -7,6 +7,8 @@
 #include "forge_credentials.h"
 #include "git_host_cred.h"
 #include "git_host_resolve.h"
+#include "git_ops.h"
+#include "workspace.h"
 #include "kb_client_cache.h"
 #include "kb_client_ws.h"
 #include "db1.h"
@@ -148,6 +150,11 @@ static int run_server(const char *socket_path, log_level_t log_level)
     * clone/fetch/push/PR authenticate with the stored token for the repo's host
     * (git_host_resolve.c). Without this the per-host step is skipped. */
    git_host_resolve_register(git_host_cred_for_url);
+
+   /* Wire the per-session worktree resolver so the webchat git surfaces (git panel
+    * + editor) act on the SAME isolated worktree the session's agent edits, rather
+    * than the shared project checkout (session_isolation_target, workspace.c). */
+   git_ops_register_session_isolation(session_isolation_target);
 
    config_t cfg;
    config_load(&cfg);

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -62,6 +62,27 @@ int git_ops_run(const char *principal, const char *project, const char *op, cons
    return -1;
 }
 
+int git_ops_run_session(const char *principal, const char *project, const char *session_id,
+                        const char *op, const char *text_arg, int num_arg, char **out, char *err,
+                        size_t errlen)
+{
+   (void)session_id;
+   return git_ops_run(principal, project, op, text_arg, num_arg, out, err, errlen);
+}
+
+int git_ops_session_dir(const char *principal, const char *project, const char *session_id,
+                        char *out, size_t out_len, char *err, size_t errlen)
+{
+   (void)principal;
+   (void)project;
+   (void)session_id;
+   if (out && out_len)
+      out[0] = '\0';
+   if (err && errlen)
+      snprintf(err, errlen, "stub");
+   return -1;
+}
+
 int webuser_editor_ensure(const char *principal, int *out_port, char *err, size_t errlen)
 {
    (void)principal;

--- a/src/tests/test_git_ops.c
+++ b/src/tests/test_git_ops.c
@@ -25,6 +25,16 @@ static int out_has(const char *out, const char *needle)
    return out && strstr(out, needle) != NULL;
 }
 
+/* Fake per-session worktree resolver: maps <cwd> -> <cwd>/wt-<sid>. */
+static int fake_isolation(const char *cwd, const char *sid, char *out, size_t out_len, int create)
+{
+   (void)create;
+   if (!cwd || !sid || !sid[0])
+      return 0;
+   snprintf(out, out_len, "%s/wt-%s", cwd, sid);
+   return 1;
+}
+
 int main(void)
 {
    char home[256];
@@ -107,6 +117,32 @@ int main(void)
           -1);
    /* bob cannot touch alice's project (no such project in bob's scope) */
    assert(git_ops_run("webuser:bob", "proj", "status", NULL, 0, &out, err, sizeof(err)) == -1);
+
+   /* --- session worktree redirect (git_ops_session_dir wiring) --- */
+   char dir[4096];
+   /* no session id -> the project checkout */
+   assert(git_ops_session_dir("webuser:alice", "proj", NULL, dir, sizeof(dir), err, sizeof(err)) ==
+          0);
+   assert(strcmp(dir, proj) == 0);
+   /* session id but no resolver registered -> still the project checkout */
+   assert(git_ops_session_dir("webuser:alice", "proj", "sid-xyz", dir, sizeof(dir), err,
+                              sizeof(err)) == 0);
+   assert(strcmp(dir, proj) == 0);
+   /* with a resolver: a non-empty session id redirects to its worktree */
+   git_ops_register_session_isolation(fake_isolation);
+   assert(git_ops_session_dir("webuser:alice", "proj", "sid-xyz", dir, sizeof(dir), err,
+                              sizeof(err)) == 0);
+   char expect[4200];
+   snprintf(expect, sizeof(expect), "%s/wt-sid-xyz", proj);
+   assert(strcmp(dir, expect) == 0);
+   /* empty session id -> base even with a resolver registered */
+   assert(git_ops_session_dir("webuser:alice", "proj", "", dir, sizeof(dir), err, sizeof(err)) ==
+          0);
+   assert(strcmp(dir, proj) == 0);
+   /* refusal: a non-webuser principal is rejected before any resolution */
+   assert(git_ops_session_dir("uid:1000", "proj", "sid-xyz", dir, sizeof(dir), err, sizeof(err)) ==
+          -1);
+   git_ops_register_session_isolation(NULL);
 
    assert(run("rm -rf %s", home) == 0);
    printf("git_ops: all tests passed\n");

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -132,6 +132,7 @@ int main(void)
    test_worktree_detect_base_branch_local_default();
    test_worktree_detect_base_branch_fallback();
    test_session_isolation_creates_and_returns_worktree();
+   test_session_isolation_sanitizes_malicious_sid();
    test_session_isolation_skips_when_already_in_same_session_worktree();
    test_session_isolation_creates_new_worktree_from_existing_worktree();
    test_session_isolation_skips_when_not_a_git_repo();

--- a/src/tests/test_guardrails_cases_a.inc
+++ b/src/tests/test_guardrails_cases_a.inc
@@ -426,9 +426,10 @@ static void test_worktree_detect_base_branch_active(void)
    snprintf(cmd, sizeof(cmd), "git -C '%s' update-ref refs/remotes/origin/main HEAD 2>/dev/null",
             tmpdir);
    (void)system(cmd);
-   snprintf(cmd, sizeof(cmd),
-            "git -C '%s' symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null",
-            tmpdir);
+   snprintf(
+       cmd, sizeof(cmd),
+       "git -C '%s' symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main 2>/dev/null",
+       tmpdir);
    (void)system(cmd);
    /* Check out a distinct feature branch — detection must ignore it. */
    snprintf(cmd, sizeof(cmd), "git -C '%s' checkout -qb 'feat/test-branch' 2>/dev/null", tmpdir);
@@ -545,6 +546,28 @@ static void test_session_isolation_creates_and_returns_worktree(void)
    char git_file[MAX_PATH_LEN];
    snprintf(git_file, sizeof(git_file), "%s/.git", target);
    assert(stat(git_file, &st) == 0);
+
+   session_isolation_cleanup(tmpdir);
+}
+
+static void test_session_isolation_sanitizes_malicious_sid(void)
+{
+   char tmpdir[MAX_PATH_LEN];
+   session_isolation_make_repo(tmpdir, sizeof(tmpdir));
+   char repo[MAX_PATH_LEN];
+   snprintf(repo, sizeof(repo), "%s/aimee", tmpdir);
+
+   /* A traversal-laden session id (now reachable: the webchat git panel/editor
+    * pass session_id in the request) must NOT escape the worktrees dir. */
+   char target[MAX_PATH_LEN];
+   int rc = session_isolation_target(repo, "../../../../etc/x", target, sizeof(target), 1);
+   assert(rc == 1);
+   char prefix[MAX_PATH_LEN];
+   snprintf(prefix, sizeof(prefix), "%s/aimee/.aimee/worktrees/", tmpdir);
+   assert(strncmp(target, prefix, strlen(prefix)) == 0); /* stays under worktrees/ */
+   assert(strstr(target, "..") == NULL);                 /* no traversal component */
+   struct stat st;
+   assert(stat(target, &st) == 0 && S_ISDIR(st.st_mode)); /* a real, contained worktree */
 
    session_isolation_cleanup(tmpdir);
 }

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -499,7 +499,20 @@ static void worktree_session_key(const char *sid, char *out, size_t cap)
    out[0] = '\0';
    if (!sid)
       return;
-   snprintf(out, cap, "%.*s", (int)WORKTREE_SID_KEY_LEN, sid);
+   /* Sanitize to a path-safe token: the session id can come from an untrusted
+    * request (the webchat git panel / editor pass it in the body), and it is
+    * spliced into the worktree path/branch below — an unsanitized "../.." would
+    * escape the worktrees dir. Keep only [A-Za-z0-9_-]; map anything else to '_'.
+    * Server-minted ids (UUID/hex) are unaffected, so existing keys stay stable. */
+   size_t n = 0;
+   for (size_t i = 0; sid[i] && n < (size_t)WORKTREE_SID_KEY_LEN && n + 1 < cap; i++)
+   {
+      char c = sid[i];
+      int ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') ||
+               c == '_' || c == '-';
+      out[n++] = ok ? c : '_';
+   }
+   out[n] = '\0';
 }
 
 /* Compute the expected aimee-managed worktree path for a git repo and session.

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -195,11 +195,12 @@ func (s *server) handleGitOp(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var req struct {
-		Project string `json:"project"`
-		Op      string `json:"op"`
-		Message string `json:"message"`
-		Branch  string `json:"branch"`
-		N       int    `json:"n"`
+		Project   string `json:"project"`
+		Op        string `json:"op"`
+		Message   string `json:"message"`
+		Branch    string `json:"branch"`
+		N         int    `json:"n"`
+		SessionID string `json:"session_id"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Project == "" || req.Op == "" {
 		writeJSONError(w, http.StatusBadRequest, "project and op required")
@@ -207,9 +208,36 @@ func (s *server) handleGitOp(w http.ResponseWriter, r *http.Request) {
 	}
 	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
 	defer cancel()
+	// session_id (optional): run the op in the calling session's isolated worktree
+	// — the same tree its agent edits — rather than the shared project checkout.
 	body, _ := json.Marshal(map[string]any{
 		"project": req.Project, "op": req.Op, "message": req.Message, "branch": req.Branch, "n": req.N,
+		"session_id": req.SessionID,
 	})
 	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/git", body)
+	s.gitRelay(w, st, data, err)
+}
+
+// POST /api/git/session-dir {project, session_id} — resolve the absolute working
+// directory a session acts in for a project (its isolated worktree when a
+// session_id is given, else the project checkout). Used by the editor to open the
+// same tree the session's agent edits.
+func (s *server) handleGitSessionDir(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	var req struct {
+		Project   string `json:"project"`
+		SessionID string `json:"session_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Project == "" {
+		writeJSONError(w, http.StatusBadRequest, "project required")
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	body, _ := json.Marshal(map[string]any{"project": req.Project, "session_id": req.SessionID})
+	st, data, err := s.v1RequestWebuser(ctx, currentUser(r), http.MethodPost, "/v1/workspace/session-dir", body)
 	s.gitRelay(w, st, data, err)
 }

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -188,6 +188,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/git/projects", s.requireAuth(s.handleGitProjects))
 	mux.HandleFunc("/api/git/clone", s.requireAuth(s.handleGitClone))
 	mux.HandleFunc("/api/git/op", s.requireAuth(s.handleGitOp))
+	mux.HandleFunc("/api/git/session-dir", s.requireAuth(s.handleGitSessionDir))
 	mux.HandleFunc("/api/git/credentials", s.requireAuth(s.handleGitCredentials))
 	mux.HandleFunc("/api/git/oauth/github/start", s.requireAuth(s.handleGitOauthGithubStart))
 	mux.HandleFunc("/api/git/oauth/github/poll", s.requireAuth(s.handleGitOauthGithubPoll))


### PR DESCRIPTION
## What

Follow-up to #608. The agent now works in a per-session worktree, but the **Editor** tab and the **git panel** (Projects → `git_ops`) still targeted the shared project checkout (`root/<project>`), so they showed the pristine base instead of the session's in-progress work. This makes both surfaces act on the same per-session worktree the agent edits.

## Changes (C server, Go webchat, React, OpenAPI)

- **C:** `git_ops` gains `git_ops_run_session()` + `git_ops_session_dir()`; a registered resolver (`session_isolation_target`, wired in `server_main`) redirects a session's ops/dir to its sibling worktree off the default branch. `git_ops_run` is now a thin wrapper (NULL session) — **fully back-compatible**; unregistered or empty `session_id` runs in the shared checkout as before. New `POST /v1/workspace/session-dir` returns the session's working dir; `/v1/workspace/git` accepts optional `session_id`. Reached via the registered-seam pattern so `git_ops.o` keeps no link dep on the heavy `workspace.o`.
- **Go (webchat):** `handleGitOp` forwards `session_id`; new `handleGitSessionDir` proxies `/api/git/session-dir`.
- **React:** `Projects.tsx` passes the active session id when operating on its bound project; `Editor.tsx` resolves the session worktree via `/api/git/session-dir` and opens it with `?folder=` (falls back to the project checkout before a session id is minted / on error, with effect cancellation to avoid stale races).
- **OpenAPI:** documented `/workspace/session-dir` + `session_id` on `/workspace/git` (conformance check).

## Security

`session_id` is now request-supplied, so it can't be trusted as a path component. `worktree_session_key()` — the single chokepoint every worktree path/branch derivation routes through — now whitelists `[A-Za-z0-9_-]` and maps any other byte to `_`, so a crafted `../..` can't escape the worktrees dir. **This also hardens #608**, whose chat worker keys off the request's `aimee_session_id`. Server-minted ids (UUID/hex) are unaffected, so existing keys stay stable. Regression test asserts a malicious sid stays contained under `worktrees/` with no `..`.

## Review

Roundtabled — mistral caught the traversal (the only real finding); fixed + tested. Re-review of the fixed change: mistral APPROVE (full diff), minimax APPROVE (sanitization hunk+test). Verified the chokepoint: all worktree path/branch builders use the sanitized `short_id`.

## Validation

`make all` + `make lint` clean; guardrails (with new traversal test) + git-ops unit tests pass; `go vet`/`go test ./webchat` clean; frontend `tsc -b && vite build` clean.

## Note

Not yet deployed to .254 (this, #605, #608 all sit on `testing`).