### PR TITLE
feat(embedder): default to nomic-embed-text-v1.5; Qwen3 4B/8B LoCoMo numbers

### DIFF
--- a/benchmarks/embedder_gate.py
+++ b/benchmarks/embedder_gate.py
@@ -88,6 +88,25 @@ def embed(endpoint: str, texts: list[str], batch: int = 256, prefix: str = "",
     return vecs
 
 
+try:
+    import numpy as _np
+except ImportError:  # pure-python fallback (slow at high dim, but dependency-free)
+    _np = None
+
+
+def _rank_dia_ids(qv, doc_vecs, dia_ids):
+    """Return doc dia_ids ranked by descending cosine to query vector qv."""
+    if _np is not None:
+        order = _np.asarray(doc_vecs).dot(_np.asarray(qv)).argsort()[::-1]
+        return [dia_ids[i] for i in order]
+    scored = sorted(
+        ((sum(a * b for a, b in zip(qv, dv)), did) for dv, did in zip(doc_vecs, dia_ids)),
+        key=lambda x: x[0],
+        reverse=True,
+    )
+    return [did for _, did in scored]
+
+
 def evaluate(cases, endpoint: str, query_prefix: str = "", doc_prefix: str = "", normalize: bool = True):
     rows = []
     for cid, turns, questions in cases:
@@ -95,12 +114,7 @@ def evaluate(cases, endpoint: str, query_prefix: str = "", doc_prefix: str = "",
         doc_vecs = embed(endpoint, [t for _, t in turns], prefix=doc_prefix, normalize=normalize)
         q_vecs = embed(endpoint, [qt for qt, _ in questions], prefix=query_prefix, normalize=normalize)
         for (_q, evidence), qv in zip(questions, q_vecs):
-            scored = sorted(
-                ((sum(a * b for a, b in zip(qv, dv)), did) for dv, did in zip(doc_vecs, dia_ids)),
-                key=lambda x: x[0],
-                reverse=True,
-            )
-            ranked = [did for _, did in scored]
+            ranked = _rank_dia_ids(qv, doc_vecs, dia_ids)
             rank = next((i + 1 for i, did in enumerate(ranked) if did in evidence), 0)
             rows.append(
                 {

--- a/benchmarks/results/embedder-gate/locomo_qwen3_4b.json
+++ b/benchmarks/results/embedder-gate/locomo_qwen3_4b.json
@@ -1,0 +1,13 @@
+{
+  "questions": 1982,
+  "conversations": 10,
+  "recall_5": 0.5040363269424823,
+  "recall_10": 0.5943491422805247,
+  "mrr": 0.3887839919970584,
+  "name": "qwen3-4b",
+  "endpoint": "http://localhost:8902/v1/embeddings",
+  "query_prefix": "Instruct: Given a question, retrieve the conversation turns that answer it\nQuery: ",
+  "doc_prefix": "",
+  "normalized": true,
+  "wall_seconds": 612.7
+}

--- a/benchmarks/results/embedder-gate/locomo_qwen3_8b.json
+++ b/benchmarks/results/embedder-gate/locomo_qwen3_8b.json
@@ -1,0 +1,13 @@
+{
+  "questions": 1982,
+  "conversations": 10,
+  "recall_5": 0.5908173562058526,
+  "recall_10": 0.6917255297679112,
+  "mrr": 0.45100092291057853,
+  "name": "qwen3-8b",
+  "endpoint": "http://localhost:8903/v1/embeddings",
+  "query_prefix": "Instruct: Given a question, retrieve the conversation turns that answer it\nQuery: ",
+  "doc_prefix": "",
+  "normalized": true,
+  "wall_seconds": 665.4
+}

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -162,9 +162,29 @@ install by detected VRAM (§5).
 
 | Install | Embed (GGUF) | dim |
 |---------|--------------|-----|
-| CPU-only | `Qwen/Qwen3-Embedding-0.6B-GGUF` | 1024 |
-| GPU (mid) | `Qwen/Qwen3-Embedding-4B-GGUF` | 2560 |
-| GPU (high) | `Qwen/Qwen3-Embedding-8B-GGUF` | **4000** (trunc) |
+| **all tiers** | **`nomic-ai/nomic-embed-text-v1.5-GGUF`** | **768** |
+
+> **Embed ladder collapsed to a single model — nomic-embed-text-v1.5 (768-dim),
+> 2026-06-22** (provisional; see "provisional" note below). The whole multi-tier
+> Qwen3 embed ladder is **withdrawn** on direct empirical evidence —
+> [embedder-gate-locomo](../../validation/embedder-gate-locomo.md). On the LoCoMo
+> direct-retrieval screen (7900XTX/Vulkan, 1982 questions), nomic **beats every
+> Qwen3-Embedding size** on Recall@5/MRR — including the **8B at 4096-dim** — at
+> the **smallest** vector size (768). Qwen3-4B gave **no** lift over 0.6B; Qwen3-8B
+> costs **5.3× the vector dim** (storage / HNSW build / scan) for a *worse* R@5 and
+> only an R@10 tie. Roundtable (architect + engineer) was unanimous: **nomic
+> everywhere; drop the 4B and 8B tiers** — an optional high tier is config surface,
+> a second GGUF slot, and operator confusion for no measurable win. A single
+> embedder also removes the dim-dependent tier-selection logic and the
+> 8B-MRL-truncation machinery entirely (nomic is fixed 768-d, not truncatable).
+>
+> **Provisional — retrieval-only, ship-floor gate pending.** This screen is
+> *embedder-isolated* (no reranker, no fusion, English, one benchmark, 1982 q) and
+> does not yet report tokens/s or VRAM. It is sufficient to set the **proposal**
+> default but is **not** the production cutover: the full-pipeline ship-floor gate
+> (rerank + fusion, nDCG/MRR vs the pplx baseline) is the ship precondition and can
+> still reorder this. If a future multilingual / long-context need appears, revisit
+> the Qwen3 tiers then.
 
 **Reranker — decoupled, not part of the embed ladder.** The reranker scores
 `(query, candidate)` text pairs, so it is **dimension-agnostic** and need not scale
@@ -194,6 +214,11 @@ larger, ~8 pts, only on *code* retrieval).
 
 #### The 8B truncation — why 4000, and how it must be done
 
+> **SUPERSEDED (2026-06-22):** the embed ladder collapsed to a single 768-dim
+> nomic model (above), so there is no 8B embedder and this truncation machinery is
+> not built. Retained only as design rationale should the Qwen3 tiers ever be
+> revisited (multilingual / long-context).
+
 Qwen3-Embedding-8B is **MRL-trained** (loss on first 512/1024/2048 + full 4096),
 so information front-loads into early dims; published guidance shows truncating to
 **1024 retains ~95%**. Trimming only **4096→4000 (last 96 dims, ~2.3%)** costs far
@@ -218,8 +243,11 @@ index allows.**
 
 #### Model-drift guard — embedder `(model_id, dim)`, reranker `(model_id, scoring-contract)`
 
-`pplx-embed` and `Qwen3-Embedding-0.6B` are both 1024-d, so a dim-only guard would
-silently mix spaces. The guard records and compares **embedder model identity
+A dim-only guard is insufficient — two different models can share a dim (e.g.
+`pplx-embed` and `Qwen3-Embedding-0.6B` are both 1024-d), so it would silently mix
+incompatible spaces. (The new default, `nomic-embed-text-v1.5`, is 768-d, so a
+swap *from* pplx's 1024-d **does** also change the dim, but the guard must not rely
+on that.) The guard records and compares **embedder model identity
 (repo@sha) + dim** and refuses startup / rejects writes on mismatch, keying the
 re-embed trigger on **model_id change**. **The reranker gets the same guard** (keyed
 on reranker `model_id` + scoring contract): a reranker swap invalidates cached
@@ -412,8 +440,11 @@ We take the fold but pay down its cost:
   safety net for the cutover release, with the prior tag retained in the registry
   for a defined window.
 
-- **8B truncation: keep 4000**, gated by the **tier-cutoff (≥99%)** gate; proxy
-  truncation + order invariant; `EMBED_MAX_DIM=4000` exact.
+- **Embed = single model `nomic-embed-text-v1.5` (768-dim)**, provisional on LoCoMo
+  evidence (beats every Qwen3 size incl. 8B at 4096-dim; see embedder-gate-locomo)
+  pending the full-pipeline ship-floor gate. The multi-tier Qwen3 embed ladder
+  (0.6B/4B/8B) is **withdrawn** (roundtable-unanimous); no embed tier-selection and
+  no 8B-MRL-truncation machinery — nomic is fixed 768-d.
 - **Curator fold: take it** as an isolated supervised process + RBAC; off-box
   synth via forward/external; sidecar fallback = kernel-compromise response.
 - **Per-user synth via the gateway** with §1a hardening; **escape hatch** is an

--- a/docs/validation/embedder-gate-locomo.md
+++ b/docs/validation/embedder-gate-locomo.md
@@ -55,19 +55,27 @@ questions. Artifacts: [`benchmarks/results/embedder-gate/`](../../benchmarks/res
 
 | model | dim | Recall@5 | Recall@10 | MRR |
 |---|---|---|---|---|
-| **nomic-embed-text-v1.5** | 768 | **0.6060** | **0.6907** | **0.4741** |
+| **nomic-embed-text-v1.5** | 768 | **0.6060** | 0.6907 | **0.4741** |
+| qwen3-embedding-8b | 4096 | 0.5908 | **0.6917** | 0.4510 |
 | qwen3-embedding-0.6b | 1024 | 0.5061 | 0.5974 | 0.3783 |
+| qwen3-embedding-4b | 2560 | 0.5040 | 0.5943 | 0.3888 |
 | bge-base-en-v1.5 | 768 | 0.4995 | 0.6105 | 0.3681 |
 
-**Finding (actionable for the proposal).** On LoCoMo conversational retrieval,
-**`nomic-embed-text-v1.5` clearly beats the proposal's default embedder slot
-(`Qwen3-Embedding-0.6B`)** — +10.0 pts Recall@5, +9.3 pts Recall@10, +9.6 pts MRR
-— at 768-dim vs 1024-dim (smaller vectors, cheaper storage/scan). `Qwen3-0.6B`
-and `bge-base` are roughly tied. This says the default-embedder choice in
-[unified-llm-container](../proposals/pending/unified-llm-container.md) §"model
-registry" should be **re-examined before cutover**: either adopt nomic for the
-default slot, or justify Qwen3 with a stronger config (see caveats) or a larger
-Qwen3 variant.
+**Finding (decisive for the proposal).** On LoCoMo conversational retrieval,
+**`nomic-embed-text-v1.5` (768-dim) beats every Qwen3-Embedding size** — including
+the 8B at 4096-dim — on Recall@5 (0.606 vs 0.591) and MRR (0.474 vs 0.451), and
+ties the 8B on Recall@10. Two more facts sharpen this:
+- **Scaling Qwen3 0.6B→4B buys nothing here** (R@5 0.504 vs 0.506; MRR 0.389 vs
+  0.378) — the 4B is not a meaningful upgrade on this benchmark.
+- Only **Qwen3-8B** closes most of the gap, and it does so at **4096-dim (5.3×
+  nomic's vector size)** — far more storage, scan, and HNSW cost for *worse* R@5.
+
+So nomic wins on **both** axes that matter for the default slot: quality **and**
+dimension. The proposal's all-Qwen3 embed ladder
+([unified-llm-container](../proposals/pending/unified-llm-container.md) §"model
+registry") is dominated by a single 768-dim model on this benchmark; the default
+should be **nomic-embed-text-v1.5**, and the GPU tiers warrant re-examination
+(an 8B at 4096-dim that loses R@5 to a 768-dim model is a poor high tier here).
 
 **Fairness / reproducibility.** Each model uses its own card-recommended prefix,
 recorded in its result JSON (`query_prefix`/`doc_prefix`): Qwen3 the canonical
@@ -79,15 +87,18 @@ are over the **1982 answerable** questions only — a question with empty `evide
 retrieval Recall/MRR are undefined for it; this is answerable-only retrieval by
 construction, not a silent filter.
 
-**Qwen3 prompt-sensitivity check (resolved).** Qwen3-Embedding is prompt
--sensitive, so the gap was re-tested with the canonical `Instruct:\nQuery:`
-newline restored: **identical** (R@5 0.5061 vs 0.5060) — the gap is **not** a
-prompt-format artifact. The 4B/8B Qwen3 variants remain an open probe (they may
-close it), but at the **0.6B default-slot** size nomic is the stronger choice.
+**Qwen3 prompt-sensitivity + size checks (resolved).** Qwen3-Embedding is
+prompt-sensitive, so the gap was re-tested with the canonical `Instruct:\nQuery:`
+newline restored: **identical** (R@5 0.5061 vs 0.5060) — not a prompt-format
+artifact. The "try a bigger Qwen3" hypothesis was also tested directly: 4B gives
+no lift over 0.6B, and 8B (4096-dim) still trails nomic on R@5/MRR. So neither
+prompt format nor model size rescues Qwen3 to nomic's level on this benchmark.
+All Qwen3 runs use the same canonical prefix (recorded in each artifact).
 
 **Caveats (do not over-read).** LoCoMo is one (hard, conversational) benchmark;
 LongMemEval and the full aimee pipeline (rerank + fusion) can reorder these. This
-is an embedder screen, not the production cutover verdict.
+is an embedder screen, not the production cutover verdict — but it is now a
+5-model screen across the whole Qwen3 ladder, which is a strong signal.
 
 ## Scope and honesty notes
 


### PR DESCRIPTION
Per request: ran Qwen3-Embedding **4B** and **8B** on the 7900XTX and switched the unified-llm-container default embedder to **nomic-embed-text-v1.5**.

### Full 5-model LoCoMo screen (1982 q, embedder-isolated, all on 7900XTX/Vulkan, each model with its card prefix — recorded in the artifacts)
| model | dim | R@5 | R@10 | MRR |
|---|---|---|---|---|
| **nomic-embed-text-v1.5** | 768 | **0.606** | 0.691 | **0.474** |
| qwen3-embedding-8b | 4096 | 0.591 | **0.692** | 0.451 |
| qwen3-embedding-0.6b | 1024 | 0.506 | 0.597 | 0.378 |
| qwen3-embedding-4b | 2560 | 0.504 | 0.594 | 0.389 |
| bge-base-en-v1.5 | 768 | 0.500 | 0.611 | 0.368 |

**nomic (768d) beats every Qwen3 size — including 8B at 4096d — on R@5/MRR, at the smallest dim.** Qwen3-4B gives no lift over 0.6B; Qwen3-8B costs 5.3x the vector dim for a *worse* R@5 and an R@10 tie.

### Change
- unified-llm-container embed ladder -> **single model, nomic-embed-text-v1.5 (768d)**; the whole Qwen3 embed ladder (0.6B/4B/8B) **withdrawn** (roundtable-unanimous: nomic-everywhere, drop the tiers). Removes embed tier-selection + the 8B-MRL-truncation machinery.
- Labeled **provisional / retrieval-only**: the screen has no rerank/fusion, one benchmark, English, no latency/VRAM — sufficient to set the *proposal* default, **not** the production cutover (the full-pipeline ship-floor gate is still the ship precondition).
- `embedder_gate.py`: added a numpy fast-path (vectorized ranking) so the 4B/8B (2560/4096-dim) runs are tractable; pure-python fallback kept.

Roundtable: mistral APPROVE / minimax CHANGES -> both fixes applied (drop 8B too; provisional framing). Builds on merged #609.
