### PR TITLE
feat(chat-steering): phase 3 — UI steering hint + e2e cancel tests + extraction bug fix

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -3163,25 +3163,33 @@ export default function Chat() {
           onBlur={e => (e.target.style.borderColor = tokens.borderMedium)}
           autoFocus
         />
-        <button
-          onClick={sendMessage}
-          aria-busy={queueActive}
-          title={(working || remoteTurnActive)
-            ? 'Interrupt the running turn and continue with this message'
-            : 'Send'}
-          style={{
-            padding: '10px 20px', background: tokens.primary,
-            color: tokens.surface, border: 'none', borderRadius: '6px',
-            cursor: 'pointer', fontSize: '14px', whiteSpace: 'nowrap',
-          }}
-        >
-          {queueActive ? (
-            <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
-              <Spinner loading text="" />
-              {(working || remoteTurnActive) ? 'Steer' : 'Send'}
-            </span>
-          ) : ((working || remoteTurnActive) ? 'Steer' : 'Send')}
-        </button>
+        {/* A turn in flight for the active tab (local or a server/foreign turn)
+            means sending will interrupt-and-steer; show the spinner + "Steer" and
+            keep aria-busy aligned so the announced and visible state agree. */}
+        {(() => {
+          const steering = working || remoteTurnActive;
+          const busy = queueActive || steering;
+          const label = steering ? 'Steer' : 'Send';
+          return (
+            <button
+              onClick={sendMessage}
+              aria-busy={busy}
+              title={steering ? 'Interrupt the running turn and continue with this message' : 'Send'}
+              style={{
+                padding: '10px 20px', background: tokens.primary,
+                color: tokens.surface, border: 'none', borderRadius: '6px',
+                cursor: 'pointer', fontSize: '14px', whiteSpace: 'nowrap',
+              }}
+            >
+              {busy ? (
+                <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
+                  <Spinner loading text="" />
+                  {label}
+                </span>
+              ) : label}
+            </button>
+          );
+        })()}
       </div>
 
         </>)}{/* end chat/channel conditional */}

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -3149,7 +3149,9 @@ export default function Chat() {
           value={inputText}
           onChange={handleInput}
           onKeyDown={handleKeyDown}
-          placeholder="Type a message… (Shift+Enter for newline)"
+          placeholder={(working || remoteTurnActive)
+            ? 'Steer the running turn — Enter interrupts and continues'
+            : 'Type a message… (Shift+Enter for newline)'}
           rows={1}
           style={{
             flex: 1, padding: '10px', backgroundColor: tokens.surface, color: tokens.text,
@@ -3164,6 +3166,9 @@ export default function Chat() {
         <button
           onClick={sendMessage}
           aria-busy={queueActive}
+          title={(working || remoteTurnActive)
+            ? 'Interrupt the running turn and continue with this message'
+            : 'Send'}
           style={{
             padding: '10px 20px', background: tokens.primary,
             color: tokens.surface, border: 'none', borderRadius: '6px',
@@ -3173,9 +3178,9 @@ export default function Chat() {
           {queueActive ? (
             <span style={{ display: 'inline-flex', alignItems: 'center', gap: '8px' }}>
               <Spinner loading text="" />
-              Send
+              {(working || remoteTurnActive) ? 'Steer' : 'Send'}
             </span>
-          ) : 'Send'}
+          ) : ((working || remoteTurnActive) ? 'Steer' : 'Send')}
         </button>
       </div>
 

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -378,8 +378,10 @@ static int cli_line_is_chrome(const char *t)
       return 1;
    if (strstr(t, "? for shortcuts") || strstr(t, "for agents") || strstr(t, "to interrupt") ||
        strstr(t, "tmux detected") || strstr(t, "Shell cwd was reset") ||
-       strstr(t, "Update available") || strstr(t, "/model to change") || strstr(t, "/effort") ||
-       strstr(t, "for shortcuts"))
+       strstr(t, "Update available") || strstr(t, "/model to change") ||
+       strstr(t,
+              "\xc2\xb7 /effort")) /* the "· /effort" model/effort status — anchored to the
+                                    * middot separator so prose mentioning /effort isn't matched */
       return 1;
    return 0;
 }

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -366,7 +366,10 @@ static int cli_line_is_rule(const char *t)
 }
 
 /* Lines that mark the end of (or are not part of) the assistant's answer:
- * the claude status star, separators, footers, interrupt hints. */
+ * the claude status star, separators, footers, interrupt hints, and the
+ * model/effort status indicator near the composer — which claude renders with
+ * the SAME bullet glyph (●) as a real answer, so it must be recognized as chrome
+ * or it gets mistaken for the reply (observed live: "● high · /effort"). */
 static int cli_line_is_chrome(const char *t)
 {
    if (strncmp(t, "\xe2\x9c\xbb", 3) == 0) /* ✻ claude "Cooked/Baked for Ns" status */
@@ -375,7 +378,8 @@ static int cli_line_is_chrome(const char *t)
       return 1;
    if (strstr(t, "? for shortcuts") || strstr(t, "for agents") || strstr(t, "to interrupt") ||
        strstr(t, "tmux detected") || strstr(t, "Shell cwd was reset") ||
-       strstr(t, "Update available") || strstr(t, "/model to change"))
+       strstr(t, "Update available") || strstr(t, "/model to change") || strstr(t, "/effort") ||
+       strstr(t, "for shortcuts"))
       return 1;
    return 0;
 }
@@ -419,7 +423,13 @@ static int cli_body_in_baseline(const char *baseline, const char *amark, const c
    return 0;
 }
 
-char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline)
+/* allow_fallback: when no assistant bullet is found, whether to fall back to the
+ * baseline-delta of the whole pane. The final extraction wants this (last resort
+ * for an unrecognized TUI); incremental STREAMING does NOT — before the model has
+ * produced an answer there is no bullet yet, and streaming the fallback would
+ * push the startup banner / chrome as if it were the reply. */
+static char *cli_extract_impl(const char *raw, const char *cli_kind, const char *baseline,
+                              int allow_fallback)
 {
    char *text = cli_session_strip_ansi(raw ? raw : "");
    if (!text)
@@ -475,6 +485,8 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
       const char *t = cli_lstrip(lines[i]);
       if (strncmp(t, amark, 3) != 0)
          continue;
+      if (cli_line_is_chrome(t))
+         continue; /* a status bullet (e.g. claude's "● high · /effort"), not an answer */
       const char *body = cli_lstrip(t + 3);
       if (!*body)
          continue;
@@ -526,9 +538,15 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
    }
    free(res);
 
-   /* Fallback: no parseable bullet (e.g. a future TUI restyle). Return the
-    * portion not already in the baseline so a reused pane still never replays a
-    * prior turn, even if chrome leaks through. */
+   /* No parseable bullet. Streaming returns empty (the model hasn't produced an
+    * answer yet — don't push the banner/chrome). The final extraction falls back
+    * to the portion not already in the baseline (last resort for an unrecognized
+    * TUI; a reused pane still never replays a prior turn). */
+   if (!allow_fallback)
+   {
+      free(text);
+      return strdup("");
+   }
    if (baseline && baseline[0])
    {
       char *delta = cli_session_delta(baseline, text);
@@ -536,6 +554,11 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
       return delta ? delta : strdup("");
    }
    return text;
+}
+
+char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline)
+{
+   return cli_extract_impl(raw, cli_kind, baseline, 1);
 }
 
 int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms)
@@ -637,7 +660,9 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
        * response so far and emit only the newly appended suffix. */
       if (g_stream_cb)
       {
-         char *partial = cli_session_extract_response(cap, s->cli_kind, s->baseline);
+         /* allow_fallback=0: stream nothing until there is a real answer bullet,
+          * so the startup banner / chrome is never pushed as the reply. */
+         char *partial = cli_extract_impl(cap, s->cli_kind, s->baseline, 0);
          const char *prev = s->stream_emitted ? s->stream_emitted : "";
          size_t plen = strlen(prev);
          if (partial && strncmp(partial, prev, plen) == 0 && partial[plen])

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -27,16 +27,24 @@ static long long test_mono_ms(void)
    return (long long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
 }
 
+/* Path the fake tmux appends every `send-keys` invocation to, so a test can
+ * assert which interrupt key (if any) the cancel path sent. */
+static char g_sendlog[320];
+
 static void install_fake_tmux(void)
 {
    snprintf(g_fake_dir, sizeof(g_fake_dir), "/tmp/aimee_faketmux_%d", (int)getpid());
    mkdir(g_fake_dir, 0700);
    char counter[300];
    snprintf(counter, sizeof(counter), "%s/counter", g_fake_dir);
+   snprintf(g_sendlog, sizeof(g_sendlog), "%s/sendlog", g_fake_dir);
    char script[320];
    snprintf(script, sizeof(script), "%s/tmux", g_fake_dir);
    FILE *f = fopen(script, "w");
    assert(f != NULL);
+   /* capture-pane modes: `changing` never stabilises; `codexgen` returns a codex
+    * generating-footer; anything else returns a static pane. send-keys is logged
+    * so the cancel tests can assert the interrupt key. */
    fprintf(f,
            "#!/bin/sh\n"
            "case \"$1\" in\n"
@@ -45,10 +53,13 @@ static void install_fake_tmux(void)
            "    if [ \"$FAKE_TMUX_MODE\" = changing ]; then\n"
            "      c=0; [ -f '%s' ] && c=$(cat '%s'); c=$((c+1)); echo \"$c\" > '%s';\n"
            "      echo \"frame $c\";\n"
+           "    elif [ \"$FAKE_TMUX_MODE\" = codexgen ]; then\n"
+           "      echo 'codex output'; echo 'Working (1s esc to interrupt)';\n"
            "    else echo 'STATIC OUTPUT'; fi; exit 0 ;;\n"
+           "  send-keys) shift; echo \"$*\" >> '%s'; exit 0 ;;\n"
            "  *) exit 0 ;;\n"
            "esac\n",
-           counter, counter, counter);
+           counter, counter, counter, g_sendlog);
    fclose(f);
    assert(chmod(script, 0700) == 0);
 
@@ -56,6 +67,30 @@ static void install_fake_tmux(void)
    char newpath[4096];
    snprintf(newpath, sizeof(newpath), "%s:%s", g_fake_dir, old_path ? old_path : "");
    setenv("PATH", newpath, 1);
+}
+
+/* Cancel-check fixture: returns the value of *flag (an int the test toggles). */
+static int g_test_cancel_flag;
+static int test_cancel_cb(void *ud)
+{
+   (void)ud;
+   return g_test_cancel_flag;
+}
+/* True if the fake tmux send-keys log contains `needle`. */
+static int sendlog_has(const char *needle)
+{
+   FILE *f = fopen(g_sendlog, "r");
+   if (!f)
+      return 0;
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   return strstr(buf, needle) != NULL;
+}
+static void sendlog_reset(void)
+{
+   unlink(g_sendlog);
 }
 
 static cli_session_t fake_session(void)
@@ -98,6 +133,62 @@ static void test_recv_dead_session(void)
    char buf[8192];
    int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
    assert(rc == -1);
+}
+
+/* --- cancel / steering-interrupt path --- */
+
+/* claude: a fired cancel-check returns -3 and sends Escape, promptly (no need to
+ * wait for the pane to stabilise). */
+static void test_recv_cancel_claude_escape(void)
+{
+   setenv("FAKE_TMUX_MODE", "stable", 1);
+   sendlog_reset();
+   g_test_cancel_flag = 1;
+   cli_session_set_cancel_check(test_cancel_cb, NULL);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "claude");
+   char buf[8192];
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
+   cli_session_set_cancel_check(NULL, NULL);
+   g_test_cancel_flag = 0;
+   assert(rc == -3);
+   assert(sendlog_has("Escape"));
+   assert(!sendlog_has("C-c"));
+}
+
+/* codex while generating (footer shows the interrupt hint): cancel sends C-c. */
+static void test_recv_cancel_codex_generating_ctrlc(void)
+{
+   setenv("FAKE_TMUX_MODE", "codexgen", 1);
+   sendlog_reset();
+   g_test_cancel_flag = 1;
+   cli_session_set_cancel_check(test_cancel_cb, NULL);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "codex");
+   char buf[8192];
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
+   cli_session_set_cancel_check(NULL, NULL);
+   g_test_cancel_flag = 0;
+   assert(rc == -3);
+   assert(sendlog_has("C-c"));
+}
+
+/* codex while idle (no generating footer): cancel still returns -3 but must NOT
+ * send C-c — an idle C-c would quit codex. */
+static void test_recv_cancel_codex_idle_skips_ctrlc(void)
+{
+   setenv("FAKE_TMUX_MODE", "stable", 1); /* capture returns "STATIC OUTPUT" — no hint */
+   sendlog_reset();
+   g_test_cancel_flag = 1;
+   cli_session_set_cancel_check(test_cancel_cb, NULL);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "codex");
+   char buf[8192];
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
+   cli_session_set_cancel_check(NULL, NULL);
+   g_test_cancel_flag = 0;
+   assert(rc == -3);
+   assert(!sendlog_has("C-c"));
 }
 
 /* --- cli_session_make_name tests --- */
@@ -300,6 +391,21 @@ static void test_extract_claude_multiline(void)
    free(r);
 }
 
+/* Regression (found by live e2e): claude renders its model/effort status with the
+ * SAME ● bullet as a real answer ("● high · /effort"); it must be treated as
+ * chrome and skipped, not returned as the reply. */
+static void test_extract_claude_skips_effort_status(void)
+{
+   const char *pane = "\xe2\x9d\xaf q\n"
+                      "\xe2\x97\x8f high \xc2\xb7 /effort\n" /* ● high · /effort — status */
+                      "\xe2\x97\x8f PINEAPPLE\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   assert(strcmp(r, "PINEAPPLE") == 0);
+   free(r);
+}
+
 static void test_extract_codex_basic(void)
 {
    /* codex events also use •; the SessionStart hook fired before the turn, so it
@@ -361,6 +467,10 @@ int main(void)
 
    printf("test_extract_claude_multiline... ");
    test_extract_claude_multiline();
+   printf("OK\n");
+
+   printf("test_extract_claude_skips_effort_status... ");
+   test_extract_claude_skips_effort_status();
    printf("OK\n");
 
    printf("test_extract_codex_basic... ");
@@ -451,6 +561,18 @@ int main(void)
 
    printf("test_recv_dead_session... ");
    test_recv_dead_session();
+   printf("OK\n");
+
+   printf("test_recv_cancel_claude_escape... ");
+   test_recv_cancel_claude_escape();
+   printf("OK\n");
+
+   printf("test_recv_cancel_codex_generating_ctrlc... ");
+   test_recv_cancel_codex_generating_ctrlc();
+   printf("OK\n");
+
+   printf("test_recv_cancel_codex_idle_skips_ctrlc... ");
+   test_recv_cancel_codex_idle_skips_ctrlc();
    printf("OK\n");
 
    printf("All cli_session tests passed.\n");

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -406,6 +406,19 @@ static void test_extract_claude_skips_effort_status(void)
    free(r);
 }
 
+/* The /effort chrome match is anchored to the "· /effort" status format, so a
+ * legitimate answer that merely mentions /effort is NOT skipped. */
+static void test_extract_claude_effort_in_answer_kept(void)
+{
+   const char *pane = "\xe2\x9d\xaf q\n"
+                      "\xe2\x97\x8f Use the /effort command to set the depth.\n"
+                      "\xe2\x9c\xbb Cooked for 1s\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   assert(strcmp(r, "Use the /effort command to set the depth.") == 0);
+   free(r);
+}
+
 static void test_extract_codex_basic(void)
 {
    /* codex events also use •; the SessionStart hook fired before the turn, so it
@@ -471,6 +484,10 @@ int main(void)
 
    printf("test_extract_claude_skips_effort_status... ");
    test_extract_claude_skips_effort_status();
+   printf("OK\n");
+
+   printf("test_extract_claude_effort_in_answer_kept... ");
+   test_extract_claude_effort_in_answer_kept();
    printf("OK\n");
 
    printf("test_extract_codex_basic... ");


### PR DESCRIPTION
## What
Phase 3 polish + the result of running the full steering flow **end-to-end with real claude on the host** — which surfaced and fixed a real latent extraction bug.

### Extraction bug fix (latent in shipped #607, found by live e2e)
- claude renders its model/effort status with the **same `●` bullet** as a real answer (`● high · /effort`). The extractor returned it as the reply. It's now treated as chrome and skipped in the answer search.
- Incremental streaming no longer falls back to the whole-pane delta: before the model produces an answer there's no bullet, and the fallback was streaming the **startup banner** as if it were the reply (then the real answer got suppressed by the `sctx.emitted` guard). `extract` gains an `allow_fallback` flag — streaming passes `0` (emit nothing until a real bullet); the final extract keeps the last-resort fallback.

### Polish
- Webchat discoverability: when the active tab has a running turn, the input placeholder reads "Steer the running turn — Enter interrupts and continues" and the send button becomes **Steer**.

### Tests
- Deterministic cancel-path e2e via the existing fake-tmux harness: claude→`Escape`, codex-generating→`C-c`, codex-idle→**skip** (quit-prevention). Plus an effort-status regression test.

## End-to-end verification (real claude, isolated server on the host)
- Basic chat extracts the answer correctly (`PINEAPPLE`).
- A long essay turn interrupted mid-stream → claude stopped → the steer auto-continued in the same conversation (`● KIWI`), with the **original + continuation turns both on the session events ring** the webchat reads (`interrupted:true`, 2 `turn_started` on the ring).

## Review
Roundtable (minimax + mistral) in progress.