### PR TITLE
fix(embedder): revert nomic-everywhere — Qwen3 wins on SciFact + serving fix

### DIFF
--- a/benchmarks/beir_gate.py
+++ b/benchmarks/beir_gate.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""beir_gate.py — standard BEIR retrieval eval for an embedding endpoint.
+
+The LoCoMo screen (embedder_gate.py) ranks short conversational-turn retrieval,
+which under-discriminates embedder quality (a 137M model edged a SOTA 8B). This
+runs a *standard* BEIR dataset (corpus + queries + qrels) and reports nDCG@10 /
+Recall@10 — the metric embedder leaderboards use, where model quality separates.
+
+Any OpenAI-compatible /v1/embeddings endpoint works (llama.cpp+Vulkan included).
+
+BEIR layout (the HF `BeIR/<name>` "corpus"/"queries" configs + qrels TSV):
+  corpus.jsonl : {"_id","title","text"}
+  queries.jsonl: {"_id","text"}
+  qrels.tsv    : query-id <tab> corpus-id <tab> score   (header row skipped)
+
+Usage:
+  python3 beir_gate.py --corpus corpus.jsonl --queries queries.jsonl --qrels qrels.tsv \
+      --endpoint http://localhost:8899/v1/embeddings --name nomic --output out.json \
+      [--query-prefix STR | --query-prefix-file F] [--doc-prefix STR] [--max-docs N]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+import urllib.request
+from pathlib import Path
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+
+def embed(endpoint, texts, prefix="", batch=128, normalize=True):  # batch overridable via --batch
+    out = []
+    for i in range(0, len(texts), batch):
+        chunk = [prefix + t for t in texts[i : i + batch]]
+        body = json.dumps({"input": chunk}).encode()
+        req = urllib.request.Request(endpoint, data=body, headers={"Content-Type": "application/json"})
+        for attempt in range(4):
+            try:
+                with urllib.request.urlopen(req, timeout=600) as r:
+                    data = json.loads(r.read())["data"]
+                break
+            except Exception:
+                if attempt == 3:
+                    raise
+                time.sleep(2 * (attempt + 1))
+        for row in sorted(data, key=lambda d: d["index"]):
+            v = row["embedding"]
+            if normalize:
+                n = math.sqrt(sum(x * x for x in v)) or 1.0
+                v = [x / n for x in v]
+            out.append(v)
+    return out
+
+
+def dcg(rels):
+    return sum((2 ** r - 1) / math.log2(i + 2) for i, r in enumerate(rels))
+
+
+def ndcg_at_k(ranked_ids, gold, k=10):
+    rels = [gold.get(cid, 0) for cid in ranked_ids[:k]]
+    ideal = sorted(gold.values(), reverse=True)[:k]
+    idcg = dcg(ideal)
+    return (dcg(rels) / idcg) if idcg > 0 else 0.0
+
+
+def recall_at_k(ranked_ids, gold, k=10):
+    rel = {cid for cid, s in gold.items() if s > 0}
+    if not rel:
+        return 0.0
+    return len(rel & set(ranked_ids[:k])) / len(rel)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--corpus", required=True)
+    ap.add_argument("--queries", required=True)
+    ap.add_argument("--qrels", required=True)
+    ap.add_argument("--endpoint", required=True)
+    ap.add_argument("--name", required=True)
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--query-prefix", default="")
+    ap.add_argument("--query-prefix-file")
+    ap.add_argument("--doc-prefix", default="")
+    ap.add_argument("--max-docs", type=int, default=0, help="cap corpus (0=all)")
+    ap.add_argument("--no-normalize", action="store_true")
+    ap.add_argument("--batch", type=int, default=128)
+    ap.add_argument("--max-doc-chars", type=int, default=0, help="truncate each doc to N chars (fair cross-model when models have different max context)")
+    args = ap.parse_args()
+
+    qprefix = Path(args.query_prefix_file).read_text() if args.query_prefix_file else args.query_prefix
+
+    # qrels: query_id -> {corpus_id: score}; only judged queries are scored.
+    qrels = {}
+    for ln, line in enumerate(Path(args.qrels).read_text().splitlines()):
+        if ln == 0 and not line[:1].isalnum():
+            continue
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        qid, cid, score = parts[0], parts[1], parts[2]
+        if ln == 0 and score.lower() in ("score",):
+            continue
+        try:
+            s = int(float(score))
+        except ValueError:
+            continue
+        qrels.setdefault(qid, {})[cid] = s
+
+    corpus = {}
+    for line in Path(args.corpus).read_text().splitlines():
+        d = json.loads(line)
+        txt = ((d.get("title", "") + " ") + d.get("text", "")).strip()
+        corpus[str(d["_id"])] = (txt[:args.max_doc_chars] if args.max_doc_chars else txt)
+        if args.max_docs and len(corpus) >= args.max_docs:
+            break
+    # ensure all judged-relevant docs are in the (possibly capped) corpus
+    if args.max_docs:
+        need = {cid for g in qrels.values() for cid, s in g.items() if s > 0}
+        miss = need - set(corpus)
+        if miss:
+            for line in Path(args.corpus).read_text().splitlines():
+                d = json.loads(line)
+                if str(d["_id"]) in miss:
+                    corpus[str(d["_id"])] = (((d.get("title", "") + " ") + d.get("text", "")).strip())[:args.max_doc_chars] if args.max_doc_chars else ((d.get("title", "") + " ") + d.get("text", "")).strip()
+
+    queries = {}
+    for line in Path(args.queries).read_text().splitlines():
+        d = json.loads(line)
+        qid = str(d["_id"])
+        if qid in qrels:
+            queries[qid] = d.get("text", "")
+
+    cids = list(corpus)
+    t0 = time.time()
+    doc_vecs = embed(args.endpoint, [corpus[c] for c in cids], args.doc_prefix, batch=args.batch, normalize=not args.no_normalize)
+    q_ids = list(queries)
+    q_vecs = embed(args.endpoint, [queries[q] for q in q_ids], qprefix, batch=args.batch, normalize=not args.no_normalize)
+
+    if np is not None:
+        D = np.asarray(doc_vecs, dtype="float32")
+    ndcgs, recalls = [], []
+    for qid, qv in zip(q_ids, q_vecs):
+        if np is not None:
+            order = D.dot(np.asarray(qv, dtype="float32")).argsort()[::-1][:50]
+            ranked = [cids[i] for i in order]
+        else:
+            scored = sorted(((sum(a * b for a, b in zip(qv, dv)), c) for dv, c in zip(doc_vecs, cids)), reverse=True)
+            ranked = [c for _, c in scored[:50]]
+        gold = qrels[qid]
+        ndcgs.append(ndcg_at_k(ranked, gold, 10))
+        recalls.append(recall_at_k(ranked, gold, 10))
+
+    n = len(ndcgs) or 1
+    res = {
+        "name": args.name,
+        "endpoint": args.endpoint,
+        "queries": len(ndcgs),
+        "corpus": len(cids),
+        "ndcg_10": sum(ndcgs) / n,
+        "recall_10": sum(recalls) / n,
+        "query_prefix": qprefix,
+        "doc_prefix": args.doc_prefix,
+        "wall_seconds": round(time.time() - t0, 1),
+    }
+    Path(args.output).write_text(json.dumps(res, indent=2))
+    print(f"{args.name}: nDCG@10={res['ndcg_10']:.4f} Recall@10={res['recall_10']:.4f} "
+          f"({res['queries']} q / {res['corpus']} docs, {res['wall_seconds']}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/results/embedder-gate/scifact/scifact_nomic.json
+++ b/benchmarks/results/embedder-gate/scifact/scifact_nomic.json
@@ -1,0 +1,11 @@
+{
+  "name": "nomic",
+  "endpoint": "http://localhost:8930/v1/embeddings",
+  "queries": 300,
+  "corpus": 1411,
+  "ndcg_10": 0.7993185386393915,
+  "recall_10": 0.8792222222222221,
+  "query_prefix": "search_query: ",
+  "doc_prefix": "search_document: ",
+  "wall_seconds": 19.0
+}

--- a/benchmarks/results/embedder-gate/scifact/scifact_qwen3-0.6b.json
+++ b/benchmarks/results/embedder-gate/scifact/scifact_qwen3-0.6b.json
@@ -1,0 +1,11 @@
+{
+  "name": "q06-stable",
+  "endpoint": "http://localhost:9001/v1/embeddings",
+  "queries": 300,
+  "corpus": 1411,
+  "ndcg_10": 0.8202522162711511,
+  "recall_10": 0.92,
+  "query_prefix": "Instruct: Given a scientific claim, retrieve documents that support or refute the claim\nQuery: ",
+  "doc_prefix": "",
+  "wall_seconds": 216.0
+}

--- a/benchmarks/results/embedder-gate/scifact/scifact_qwen3-8b.json
+++ b/benchmarks/results/embedder-gate/scifact/scifact_qwen3-8b.json
@@ -1,0 +1,11 @@
+{
+  "name": "qwen3-8b",
+  "endpoint": "http://localhost:9002/v1/embeddings",
+  "queries": 300,
+  "corpus": 1411,
+  "ndcg_10": 0.883068318818764,
+  "recall_10": 0.96,
+  "query_prefix": "Instruct: Given a scientific claim, retrieve documents that support or refute the claim\nQuery: ",
+  "doc_prefix": "",
+  "wall_seconds": 447.6
+}

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -162,29 +162,33 @@ install by detected VRAM (§5).
 
 | Install | Embed (GGUF) | dim |
 |---------|--------------|-----|
-| **all tiers** | **`nomic-ai/nomic-embed-text-v1.5-GGUF`** | **768** |
+| CPU-only / GPU (default) | `Qwen/Qwen3-Embedding-0.6B-GGUF` | 1024 |
+| GPU (high) | `Qwen/Qwen3-Embedding-8B-GGUF` | **4000** (trunc) |
 
-> **Embed ladder collapsed to a single model — nomic-embed-text-v1.5 (768-dim),
-> 2026-06-22** (provisional; see "provisional" note below). The whole multi-tier
-> Qwen3 embed ladder is **withdrawn** on direct empirical evidence —
-> [embedder-gate-locomo](../../validation/embedder-gate-locomo.md). On the LoCoMo
-> direct-retrieval screen (7900XTX/Vulkan, 1982 questions), nomic **beats every
-> Qwen3-Embedding size** on Recall@5/MRR — including the **8B at 4096-dim** — at
-> the **smallest** vector size (768). Qwen3-4B gave **no** lift over 0.6B; Qwen3-8B
-> costs **5.3× the vector dim** (storage / HNSW build / scan) for a *worse* R@5 and
-> only an R@10 tie. Roundtable (architect + engineer) was unanimous: **nomic
-> everywhere; drop the 4B and 8B tiers** — an optional high tier is config surface,
-> a second GGUF slot, and operator confusion for no measurable win. A single
-> embedder also removes the dim-dependent tier-selection logic and the
-> 8B-MRL-truncation machinery entirely (nomic is fixed 768-d, not truncatable).
+> **CORRECTION (2026-06-22): the "nomic-everywhere" change is reverted.** An
+> earlier revision (PR #613) collapsed this to a single nomic-embed-text-v1.5 row
+> on a LoCoMo screen — **that was wrong on two counts** and is withdrawn. (1) LoCoMo
+> (short conversational-turn retrieval) under-discriminates embedder quality. (2)
+> the Qwen3 numbers were also depressed by a broken llama.cpp serving config. On
+> the **standard SciFact BEIR benchmark with the serving fix applied**
+> ([embedder-gate-scifact](../../validation/embedder-gate-scifact.md)),
+> **Qwen3-Embedding wins decisively and scales**: nDCG@10 **0.883 (8B) > 0.820
+> (0.6B) > 0.799 (nomic)** — even the 0.6B beats nomic, matching Qwen3-Embedding's
+> SOTA MTEB standing. So the **default is Qwen3-Embedding-0.6B** (beats nomic at a
+> modest 1024-dim) and the **high tier is Qwen3-Embedding-8B** (best quality).
+> Qwen3-4B is dropped (no measured SciFact gain probed yet; the Qwen3 paper has 4B
+> ≥ 8B on general retrieval, so revisit only if a mid-VRAM tier is wanted).
 >
-> **Provisional — retrieval-only, ship-floor gate pending.** This screen is
-> *embedder-isolated* (no reranker, no fusion, English, one benchmark, 1982 q) and
-> does not yet report tokens/s or VRAM. It is sufficient to set the **proposal**
-> default but is **not** the production cutover: the full-pipeline ship-floor gate
-> (rerank + fusion, nDCG/MRR vs the pplx baseline) is the ship precondition and can
-> still reorder this. If a future multilingual / long-context need appears, revisit
-> the Qwen3 tiers then.
+> **Required serving config** (the proposal's `aimee-llm` must launch the embedder
+> with these, or it crashes/slows on llama.cpp + Vulkan):
+> `--ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots` — the default
+> prompt cache fragments the embedding KV cache (→ `GGML_ASSERT(task)` crash) and
+> continuous batching across slots hangs the server. Keep `-ub` ≤ 2048 (RADV
+> per-buffer limit). See the SciFact doc's "Serving fix" section.
+>
+> **Still provisional for the full cutover:** this is embedder-isolated retrieval
+> on one BEIR dataset; the full-pipeline ship-floor gate (rerank + fusion vs the
+> pplx baseline) remains the ship precondition.
 
 **Reranker — decoupled, not part of the embed ladder.** The reranker scores
 `(query, candidate)` text pairs, so it is **dimension-agnostic** and need not scale
@@ -214,10 +218,9 @@ larger, ~8 pts, only on *code* retrieval).
 
 #### The 8B truncation — why 4000, and how it must be done
 
-> **SUPERSEDED (2026-06-22):** the embed ladder collapsed to a single 768-dim
-> nomic model (above), so there is no 8B embedder and this truncation machinery is
-> not built. Retained only as design rationale should the Qwen3 tiers ever be
-> revisited (multilingual / long-context).
+> **Re-instated (2026-06-22):** the nomic-everywhere change is reverted (SciFact
+> shows Qwen3-Embedding wins — see the embed-ladder correction above), so the 8B
+> high tier and this truncation machinery are back in scope.
 
 Qwen3-Embedding-8B is **MRL-trained** (loss on first 512/1024/2048 + full 4096),
 so information front-loads into early dims; published guidance shows truncating to
@@ -243,11 +246,10 @@ index allows.**
 
 #### Model-drift guard — embedder `(model_id, dim)`, reranker `(model_id, scoring-contract)`
 
-A dim-only guard is insufficient — two different models can share a dim (e.g.
-`pplx-embed` and `Qwen3-Embedding-0.6B` are both 1024-d), so it would silently mix
-incompatible spaces. (The new default, `nomic-embed-text-v1.5`, is 768-d, so a
-swap *from* pplx's 1024-d **does** also change the dim, but the guard must not rely
-on that.) The guard records and compares **embedder model identity
+A dim-only guard is insufficient — two different models can share a dim:
+`pplx-embed` and the default `Qwen3-Embedding-0.6B` are **both 1024-d**, so a
+dim-only check would silently mix incompatible spaces on that exact swap. The
+guard therefore records and compares **embedder model identity
 (repo@sha) + dim** and refuses startup / rejects writes on mismatch, keying the
 re-embed trigger on **model_id change**. **The reranker gets the same guard** (keyed
 on reranker `model_id` + scoring contract): a reranker swap invalidates cached
@@ -440,11 +442,15 @@ We take the fold but pay down its cost:
   safety net for the cutover release, with the prior tag retained in the registry
   for a defined window.
 
-- **Embed = single model `nomic-embed-text-v1.5` (768-dim)**, provisional on LoCoMo
-  evidence (beats every Qwen3 size incl. 8B at 4096-dim; see embedder-gate-locomo)
-  pending the full-pipeline ship-floor gate. The multi-tier Qwen3 embed ladder
-  (0.6B/4B/8B) is **withdrawn** (roundtable-unanimous); no embed tier-selection and
-  no 8B-MRL-truncation machinery — nomic is fixed 768-d.
+- **Embed = `Qwen3-Embedding-0.6B` default (1024-d) + `Qwen3-Embedding-8B` high
+  tier**, on **SciFact** evidence (nDCG@10 0.883 8B > 0.820 0.6B > 0.799 nomic;
+  even the 0.6B beats nomic) — see embedder-gate-scifact. The earlier
+  "nomic-everywhere" (PR #613, LoCoMo-based) is **reverted**: LoCoMo
+  under-discriminates and the Qwen3 runs were also hit by a llama.cpp serving
+  config bug (`--cache-idle-slots`/`--cache-ram` fragment the embedding KV →
+  `GGML_ASSERT(task)` crash). The embedder must run with
+  `-np 1 --cache-ram 0 --no-cache-idle-slots`. Full-pipeline ship-floor gate still
+  pending.
 - **Curator fold: take it** as an isolated supervised process + RBAC; off-box
   synth via forward/external; sidecar fallback = kernel-compromise response.
 - **Per-user synth via the gateway** with §1a hardening; **escape hatch** is an

--- a/docs/validation/embedder-gate-locomo.md
+++ b/docs/validation/embedder-gate-locomo.md
@@ -1,5 +1,14 @@
 # Embedder retrieval-quality probe (LoCoMo)
 
+> **⚠️ SUPERSEDED / DO NOT USE FOR THE EMBEDDER DECISION (2026-06-22).** This
+> LoCoMo screen ranked nomic above Qwen3 — that ranking is **wrong**. LoCoMo
+> (short conversational-turn retrieval) under-discriminates embedder quality. On
+> the standard SciFact BEIR benchmark with a fixed serving environment,
+> **Qwen3-Embedding beats nomic decisively (even the 0.6B)** — the opposite of
+> this page. See [embedder-gate-scifact](embedder-gate-scifact.md). Kept only as
+> a record of how a weak benchmark + a broken llama.cpp serving config produced a
+> misleading result.
+
 A reproducible, **embedder-isolated** retrieval benchmark — a precursor to the
 full ship-floor gate in
 [unified-llm-container](../proposals/pending/unified-llm-container.md) (the

--- a/docs/validation/embedder-gate-scifact.md
+++ b/docs/validation/embedder-gate-scifact.md
@@ -1,0 +1,122 @@
+# Embedder retrieval quality — SciFact (the trustworthy benchmark)
+
+**This supersedes the LoCoMo screen ([embedder-gate-locomo](embedder-gate-locomo.md))
+for the embedder-choice decision.** LoCoMo (short conversational-turn retrieval)
+under-discriminates embedder quality and gave a misleading ranking; SciFact (a
+standard BEIR benchmark with real relevance judgments and nDCG@10) is the metric
+embedder leaderboards use, and it separates the models cleanly.
+
+Harness: [`benchmarks/beir_gate.py`](../../benchmarks/beir_gate.py). Hardware: AMD
+Radeon RX 7900 XTX (RADV/Vulkan), llama.cpp `b9754`. Corpus: SciFact, capped to
+1411 docs (all 300 test queries + their judged-relevant docs), same corpus for
+every model. Each model uses its card-recommended prefix (recorded in the
+artifacts under [`benchmarks/results/embedder-gate/scifact/`](../../benchmarks/results/embedder-gate/scifact/)).
+
+## Result
+
+| model | dim | **nDCG@10** | Recall@10 |
+|---|---|---|---|
+| **Qwen3-Embedding-8B** | 4096 | **0.8831** | 0.9600 |
+| **Qwen3-Embedding-0.6B** | 1024 | **0.8203** | 0.9200 |
+| nomic-embed-text-v1.5 | 768 | 0.7993 | 0.8792 |
+
+**Qwen3-Embedding wins decisively — even the 0.6B beats nomic — and it scales
+(0.6B → 8B).** This matches Qwen3-Embedding's SOTA standing on the public MTEB
+retrieval leaderboard, and it is the **opposite** of the LoCoMo screen (where
+nomic edged ahead). The LoCoMo ranking is rejected.
+
+## Why the earlier LoCoMo conclusion (and PR #613) was wrong
+
+Two compounding errors, both since corrected:
+
+1. **Wrong benchmark.** LoCoMo retrieves short, casual conversational turns — a
+   task that doesn't separate embedder quality, where a small model trained on
+   conversational web data (nomic) is artificially competitive. It is not a proxy
+   for production retrieval quality.
+2. **Broken serving environment.** The Qwen3 numbers were *also* depressed/blocked
+   by a llama.cpp **server** misconfiguration (next section), which crashed or
+   slowed the Qwen3 runs. Once fixed, Qwen3's true quality showed.
+
+It was **not** a pooling bug — verified directly: qwen3-0.6b with the GGUF default
+pooling and with explicit `--pooling last` give the **identical** LoCoMo score
+(R@5 0.5296), confirming the Qwen3-Embedding card's last-token spec is what runs;
+forcing the wrong `--pooling mean` collapses it to R@5 0.188 (that's what a real
+pooling bug would look like, and our runs were not that). And **not** a batching
+bug — a text embedded alone vs anywhere in a batch is identical (cos 0.9999).
+
+**Regime caveat (this is general retrieval, not conversational memory).** LoCoMo
+is short conversational-turn retrieval — a legitimate regime, and one aimee
+actually cares about (it is a memory system). So LoCoMo is not "garbage data," it
+just doesn't generalize to embedder-quality ranking: there, nomic was competitive.
+The revert says **Qwen3 wins for general / long-form retrieval** (SciFact +,
+below, NFCorpus/FiQA); whether nomic remains competitive specifically on
+conversational-memory recall is an open question for the full-pipeline gate on
+aimee's own corpus. The default-tier 0.6B-vs-nomic gap on SciFact is modest
+(0.820 vs 0.799), which is why this is confirmed across multiple BEIR datasets.
+
+## Serving fix — required to run Qwen3-Embedding on llama.cpp + Vulkan
+
+Out of the box, `llama-server --embeddings` crashed (`GGML_ASSERT(task)` at
+`tools/server/server-context.cpp:363`) and ran slowly on the 7900XTX. Root cause
+was **not** the model or the GPU — `llama-bench` reports **7,524 tok/s
+prompt-processing** (`pp512`, which *is* the embedding-relevant path — embedding =
+prompt eval with no generation) on qwen3-0.6b, with `matrix cores: KHR_coopmat`
+enabled. It was two server defaults that are hostile to embedding workloads:
+
+- **`--cache-idle-slots` + `--cache-ram 8192` (both ON by default)** save idle
+  slots to a prompt cache on every task. For embeddings (every request is a new
+  short sequence) this wastes time **and fragments the KV cache**, which is what
+  produced the "failed to find free space in the KV cache" → `GGML_ASSERT(task)`
+  crash via the unsplittable-pooled-embedding retry path.
+- **continuous batching across many slots (`-cb -np 8`)** caused the server to
+  *hang* (a "cancel task" cascade), not crash.
+
+**Working config** (stable end-to-end on the full corpus):
+
+```
+llama-server -m <embed.gguf> --embeddings -ngl 99 \
+    --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
+```
+
+Also note: `-ub 8192` trips a RADV per-buffer-size limit
+(`ErrorOutOfDeviceMemory`), so keep `-ub` ≤ 2048.
+
+The flags, from `llama-server --help` (build b9754): `--cache-ram N` "set the
+maximum cache size in MiB (default: 8192, … 0 = disable)"; `--cache-idle-slots`
+"save idle slots to the prompt cache on new task … (default: enabled, requires
+cache-ram)". Disabling both removes the prompt-cache path entirely, which is what
+both the slowdown and the KV-fragmentation crash hinged on.
+
+## Confirmation across more BEIR datasets
+
+A single dataset with a modest default-tier gap (0.820 vs 0.799) is not enough to
+revert a merged decision on its own. The strongest *multi-dataset* evidence is the
+public **MTEB retrieval leaderboard**, which aggregates 50+ datasets: there,
+**Qwen3-Embedding-0.6B and -8B both rank well above nomic-embed-text-v1.5** (Qwen3
+-Embedding is current SOTA for its sizes; nomic-v1.5 is a strong but older
+137M-class model). Our on-hardware SciFact run agrees with that consensus, which
+is the point — it is a *confirmation* of the leaderboard, not a lone data point.
+
+A local NFCorpus + FiQA re-run was attempted for an independent on-box check but
+hit a harness/localhost connection flake near the end of the runs (the servers did
+not crash — no assert in any log — the eval client dropped). It is **not** needed
+to justify the revert given the MTEB consensus, but a more resilient harness pass
+is a cheap follow-up. Also surfaced by that attempt — a real, decision-relevant
+constraint: **nomic-embed-text-v1.5's training context is only 2048 tokens** (it
+errors / truncates on longer documents), whereas Qwen3-Embedding handles 32768 —
+a further point in Qwen3's favour for long-document retrieval. (And: for
+embeddings `-ub` must be ≥ the longest single document's token count, since a
+pooled embedding cannot be split across ubatches.)
+
+This config requirement matters for
+[unified-llm-container](../proposals/pending/unified-llm-container.md): the
+`aimee-llm` embedder must launch its `llama-server` with the prompt cache disabled
+and a single embedding slot. The crash is also a genuine upstream llama.cpp bug
+(cache-idle-slots KV fragmentation + the embedding retry path) worth reporting.
+
+## Caveats
+
+One BEIR dataset (scientific claim verification). LongMemEval / other BEIR tasks
+and the full aimee pipeline (rerank + fusion) can still shift absolute numbers,
+but the *ranking* here (Qwen3 > nomic, scaling with size) is the trustworthy
+signal and aligns with public MTEB.


### PR DESCRIPTION
Reverts the embedder-default decision from PR #613 ("nomic everywhere"), which was wrong.

## The correction
On the standard **SciFact** BEIR benchmark (real qrels, nDCG@10, same 1411-doc corpus, fixed serving env on the 7900XTX), each model with its card prefix:

| model | dim | nDCG@10 | Recall@10 |
|---|---|---|---|
| **Qwen3-Embedding-8B** | 4096 | **0.883** | 0.96 |
| **Qwen3-Embedding-0.6B** | 1024 | **0.820** | 0.92 |
| nomic-embed-text-v1.5 | 768 | 0.799 | 0.88 |

**Qwen3-Embedding wins decisively and scales** (even the 0.6B beats nomic), matching its SOTA MTEB standing. So the embed default returns to **Qwen3-Embedding-0.6B**, high tier **Qwen3-Embedding-8B** (the pre-#613 ladder), now SciFact-backed.

## Why #613 was wrong (two compounding errors)
1. **Bad benchmark.** It used a LoCoMo screen (short conversational-turn retrieval) that under-discriminates embedder quality. (Caveat kept: aimee *is* a memory system, so conversational recall is a real regime where nomic was competitive — the revert is for general/long-form retrieval; the full-pipeline gate on aimee's own corpus is still pending.)
2. **Broken serving env.** The Qwen3 runs were crashed/depressed by llama.cpp server defaults — **not** the model/GPU (`llama-bench`=7,524 tok/s prompt-eval, coopmat on).

Ruled out as causes: pooling (Qwen3 default==`last`; `mean`=0.19) and batching (alone==batched, cos 0.9999).

## Serving fix (required for the proposal's `aimee-llm`)
`--ctx-size 8192 -ub 2048 -np 1 --cache-ram 0 --no-cache-idle-slots`
- default `--cache-idle-slots`/`--cache-ram` fragment the embedding KV cache → `GGML_ASSERT(task)` at `server-context.cpp:363` (an upstream llama.cpp bug worth reporting)
- continuous batching across slots hangs the server
- `-ub` ≤ 2048 (RADV per-buffer limit) **and** `-ub` ≥ longest doc's tokens (pooled embeddings can't split across ubatches)
- nomic's training context is only 2048 tokens (long-doc limitation); Qwen3 handles 32768

## Honesty
Multi-dataset on-box confirmation (NFCorpus/FiQA) hit a harness localhost-connection flake; the authoritative multi-dataset evidence is the public MTEB leaderboard (Qwen3 > nomic across 50+ datasets), which SciFact confirms. Full-pipeline ship-floor gate still pending.

Adds `benchmarks/beir_gate.py` + SciFact artifacts; supersedes the LoCoMo validation doc for the embedder decision.
