### PR TITLE
fix(cli-session): bound a tmux CLI stuck in a provider error/retry loop

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -9,6 +9,19 @@
 #define CLI_SESSION_BUF_MAX  (256 * 1024)
 #define CLI_SESSION_POLL_MS  500 /* poll interval for completion detection */
 #define CLI_SESSION_STABLE_N 3   /* consecutive stable polls to declare done */
+/* When the CLI is stuck in a provider error/retry state (claude renders this as
+ * its ✻ status line: "API error · Retrying in Ns · attempt K/10"), the pane
+ * animates the retry counter forever, so the stability heuristic never fires and
+ * only the full idle timeout (often minutes) would break it — a silent "Working"
+ * spinner with no answer. recv bounds that error state separately: after this
+ * many ms continuously in a provider-error state with no answer produced, it
+ * stops the retry and returns -4 with a clear error. claude retries ~10× with
+ * short backoff (well under this default), so a transient blip it recovers from
+ * leaves the error state — and the turn completes normally — before the grace
+ * elapses; the bound only bites on a sustained provider failure.
+ * Opt-in: only applied when the caller sets it via cli_session_set_error_grace_ms
+ * (default 0 = disabled, preserving the legacy timeout-only behaviour). */
+#define CLI_SESSION_DEFAULT_ERROR_GRACE_MS 60000
 
 typedef struct
 {
@@ -45,6 +58,13 @@ typedef int (*cli_session_cancel_cb_t)(void *ud);
 void cli_session_set_cancel_check(cli_session_cancel_cb_t cb, void *ud);
 cli_session_cancel_cb_t cli_session_get_cancel_check(void **ud_out);
 
+/* Provider-error grace (thread-local, ms): how long recv tolerates the CLI
+ * sitting in a provider error/retry state before giving up with -4. 0 disables
+ * the bound (legacy: only the idle timeout applies). Save/restore around a nested
+ * turn like the stream/cancel callbacks. See CLI_SESSION_DEFAULT_ERROR_GRACE_MS. */
+void cli_session_set_error_grace_ms(int ms);
+int cli_session_get_error_grace_ms(void);
+
 /* Record the CLI kind so recv can pick the right TUI response parser. */
 void cli_session_set_kind(cli_session_t *s, const char *cli_kind);
 
@@ -78,8 +98,10 @@ int cli_session_capture(cli_session_t *s, char *out, size_t out_max);
 /* Polls capture-pane until output stabilises (hash-based), the session dies,
  * or timeout_ms elapses. Writes captured text to out (NUL-terminated).
  * Returns 0 on success, -1 if the session exits before output stabilises,
- * -2 if it did not stabilise within timeout_ms, and -3 if the cancel-check
- * fired (the turn was asked to stop). timeout_ms <= 0 disables
+ * -2 if it did not stabilise within timeout_ms, -3 if the cancel-check fired
+ * (the turn was asked to stop), and -4 if the CLI sat in a provider error/retry
+ * state past the error grace (cli_session_set_error_grace_ms). timeout_ms <= 0
+ * disables
  * the wall-clock bound (legacy unbounded behaviour). The bound is the only
  * thing that breaks a CLI wedged in a provider retry loop (e.g. an Anthropic
  * outage), whose pane animates forever without the session dying. recv writes

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -165,12 +165,14 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    if (recv_rc != 0)
    {
       free(raw);
-      if (recv_rc == -3)
+      if (recv_rc == -3 || recv_rc == -4)
       {
-         /* Cancelled (steering/interrupt): recv already sent the interrupt key,
-          * so the CLI stopped generating with the conversation intact. KEEP a
-          * reused pane alive (the steer continuation reuses it); only free this
-          * turn's scratch. A one-shot pane is torn down. */
+         /* -3 cancelled (steering/interrupt); -4 provider error/retry past the
+          * grace. In both, recv already sent the interrupt key, so the CLI stopped
+          * with the conversation intact — KEEP a reused pane alive (a later turn
+          * reuses it); only free this turn's scratch. A one-shot pane is torn
+          * down. -3 ends quietly (the worker sees agent_request_cancelled); -4 is
+          * a real failure → surface a clear provider-error message. */
          if (reuse)
          {
             free(sess.baseline);
@@ -180,7 +182,12 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
          }
          else
             cli_session_destroy(&sess);
-         snprintf(out->error, sizeof(out->error), "turn cancelled");
+         if (recv_rc == -4)
+            snprintf(out->error, sizeof(out->error),
+                     "%s CLI hit a provider error and kept failing on retry (try again)",
+                     agent->name);
+         else
+            snprintf(out->error, sizeof(out->error), "turn cancelled");
          return -1;
       }
       cli_session_destroy(&sess); /* kill the (possibly wedged) session */

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -683,12 +683,21 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    void *prev_cancel_ud = NULL;
    cli_session_cancel_cb_t prev_cancel_cb = cli_session_get_cancel_check(&prev_cancel_ud);
    cli_session_set_cancel_check(chat_cli_cancel_check, NULL);
+   /* Bound a tmux CLI parked in a provider error/retry state so a concurrent-
+    * collision blip surfaces a clear error fast instead of a multi-minute silent
+    * "Working" spinner. Thread-local, like the stream/cancel callbacks above:
+    * agent_run_with_tools dispatches the tmux agent (-> cli_session_recv)
+    * synchronously on THIS worker thread, so the bound is in force for the turn.
+    * Save/restore around any outer turn on this thread. */
+   int prev_error_grace = cli_session_get_error_grace_ms();
+   cli_session_set_error_grace_ms(CLI_SESSION_DEFAULT_ERROR_GRACE_MS);
 
    agent_result_t result;
    memset(&result, 0, sizeof(result));
    int rc = agent_run_with_tools(&acfg, "code", system_prompt ? system_prompt : "", message,
                                  AGENT_DEFAULT_MAX_TOKENS, &result);
 
+   cli_session_set_error_grace_ms(prev_error_grace);
    cli_session_set_cancel_check(prev_cancel_cb, prev_cancel_ud);
    cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -96,6 +96,20 @@ cli_session_cancel_cb_t cli_session_get_cancel_check(void **ud_out)
    return g_cancel_cb;
 }
 
+/* Per-thread provider-error grace (ms); 0 = disabled. Thread-local so concurrent
+ * turns on the pool each carry their own bound. */
+static __thread int g_error_grace_ms = 0;
+
+void cli_session_set_error_grace_ms(int ms)
+{
+   g_error_grace_ms = ms > 0 ? ms : 0;
+}
+
+int cli_session_get_error_grace_ms(void)
+{
+   return g_error_grace_ms;
+}
+
 void cli_session_set_kind(cli_session_t *s, const char *cli_kind)
 {
    if (!s)
@@ -563,6 +577,42 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
    return cli_extract_impl(raw, cli_kind, baseline, 1);
 }
 
+/* True when the pane shows the CLI parked in a provider error/retry state.
+ * claude renders this on its ✻ status line ("API error · Retrying in Ns ·
+ * attempt K/10"); the normal completion status ("✻ Baked for Ns") and the
+ * active-generation status carry no error/retry token, so they don't match.
+ * Anchored on the ✻ status star (a line's first non-space chars) so the welcome
+ * banner's release-notes prose — which also contains "Retrying in …" but on a
+ * │-prefixed box line — can never false-match. claude-only: codex surfaces
+ * errors differently and is left to the idle-timeout backstop. */
+static int cli_pane_provider_error(const char *stripped, const char *cli_kind)
+{
+   if (!stripped || (cli_kind && strstr(cli_kind, "codex")))
+      return 0;
+   for (const char *p = stripped; p && *p;)
+   {
+      const char *eol = strchr(p, '\n');
+      const char *ls = p;
+      while (*ls == ' ' || *ls == '\t')
+         ls++;
+      if (strncmp(ls, "\xe2\x9c\xbb", 3) == 0) /* ✻ claude status star */
+      {
+         size_t llen = eol ? (size_t)(eol - ls) : strlen(ls);
+         char line[512]; /* status lines are short; sized so "attempt …" is never chopped */
+         size_t n = llen < sizeof(line) - 1 ? llen : sizeof(line) - 1;
+         memcpy(line, ls, n);
+         line[n] = '\0';
+         if (strstr(line, "error") || strstr(line, "Error") || strstr(line, "Retry") ||
+             strstr(line, "retry") || strstr(line, "attempt "))
+            return 1;
+      }
+      if (!eol)
+         break;
+      p = eol + 1;
+   }
+   return 0;
+}
+
 int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms)
 {
    if (!s->active || !out || out_max == 0)
@@ -571,6 +621,8 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    int stable = 0;
    unsigned long prev_hash = 0;
    long long start = mono_ms();
+   int err_active = 0;      /* 1 once the pane is in a provider-error state */
+   long long err_start = 0; /* mono_ms when that state began (valid iff err_active) */
    free(s->stream_emitted);
    s->stream_emitted = strdup("");
 
@@ -682,6 +734,43 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
          }
          else
             free(partial);
+      }
+
+      /* Provider-error bound: if the CLI parks in an error/retry state for longer
+       * than the grace, stop it and report -4 rather than waiting out the full
+       * idle timeout as a silent "Working" spinner. Opt-in via
+       * cli_session_set_error_grace_ms (0 = disabled). A transient blip claude
+       * recovers from within a few retries leaves the error state before the
+       * grace elapses, so the turn still completes normally. */
+      if (g_error_grace_ms > 0)
+      {
+         char *stripped = cli_session_strip_ansi(cap);
+         int in_err = stripped && cli_pane_provider_error(stripped, s->cli_kind);
+         free(stripped);
+         if (in_err)
+         {
+            if (!err_active)
+            {
+               err_active = 1;
+               err_start = mono_ms();
+            }
+            else if (mono_ms() - err_start >= g_error_grace_ms)
+            {
+               /* Stop the retry loop so the reused pane is left idle for the next
+                * turn (Escape is harmless whether claude is mid-retry or already
+                * parked on the final error), then report the provider error. */
+               char ic[CLI_SESSION_NAME_MAX + 64];
+               snprintf(ic, sizeof(ic), "tmux send-keys -t '%s' Escape 2>/dev/null",
+                        s->session_name);
+               int erc;
+               free(sess_run(ic, &erc));
+               msleep_ms(300);
+               out[0] = '\0';
+               return -4;
+            }
+         }
+         else
+            err_active = 0; /* recovered / moved on: reset the error timer */
       }
 
       unsigned long h = djb2(cap);

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -43,8 +43,11 @@ static void install_fake_tmux(void)
    FILE *f = fopen(script, "w");
    assert(f != NULL);
    /* capture-pane modes: `changing` never stabilises; `codexgen` returns a codex
-    * generating-footer; anything else returns a static pane. send-keys is logged
-    * so the cancel tests can assert the interrupt key. */
+    * generating-footer; `provider_error` animates claude's ✻ error/retry status
+    * line (never stabilises); `banner_retry` animates a │-prefixed box line whose
+    * prose contains "Retrying in" (mimics the welcome banner — must NOT be read as
+    * a provider error); anything else returns a static pane. send-keys is logged
+    * so the cancel/error tests can assert the interrupt key. */
    fprintf(f,
            "#!/bin/sh\n"
            "case \"$1\" in\n"
@@ -55,11 +58,19 @@ static void install_fake_tmux(void)
            "      echo \"frame $c\";\n"
            "    elif [ \"$FAKE_TMUX_MODE\" = codexgen ]; then\n"
            "      echo 'codex output'; echo 'Working (1s esc to interrupt)';\n"
+           "    elif [ \"$FAKE_TMUX_MODE\" = provider_error ]; then\n"
+           "      c=0; [ -f '%s' ] && c=$(cat '%s'); c=$((c+1)); echo \"$c\" > '%s';\n"
+           "      echo '\xe2\x9c\xbb API error Retrying in 0s attempt '\"$c\"'/10';\n"
+           "    elif [ \"$FAKE_TMUX_MODE\" = banner_retry ]; then\n"
+           "      c=0; [ -f '%s' ] && c=$(cat '%s'); c=$((c+1)); echo \"$c\" > '%s';\n"
+           "      echo '\xe2\x94\x82 stream-stall hint now reads Retrying in seconds frame "
+           "'\"$c\"' end';\n"
            "    else echo 'STATIC OUTPUT'; fi; exit 0 ;;\n"
            "  send-keys) shift; echo \"$*\" >> '%s'; exit 0 ;;\n"
            "  *) exit 0 ;;\n"
            "esac\n",
-           counter, counter, counter, g_sendlog);
+           counter, counter, counter, counter, counter, counter, counter, counter, counter,
+           g_sendlog);
    fclose(f);
    assert(chmod(script, 0700) == 0);
 
@@ -189,6 +200,57 @@ static void test_recv_cancel_codex_idle_skips_ctrlc(void)
    g_test_cancel_flag = 0;
    assert(rc == -3);
    assert(!sendlog_has("C-c"));
+}
+
+/* --- provider-error grace path --- */
+
+/* claude parked in its ✻ error/retry status past the grace: recv returns -4,
+ * stops the retry with Escape, and is bounded by the grace (not the idle
+ * timeout). */
+static void test_recv_provider_error_returns_minus4(void)
+{
+   setenv("FAKE_TMUX_MODE", "provider_error", 1);
+   sendlog_reset();
+   cli_session_set_error_grace_ms(800);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "claude");
+   char buf[8192];
+   long long t0 = test_mono_ms();
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 30000); /* idle bound high; grace fires first */
+   long long elapsed = test_mono_ms() - t0;
+   cli_session_set_error_grace_ms(0);
+   assert(rc == -4);
+   assert(sendlog_has("Escape")); /* stopped the retry loop */
+   assert(elapsed < 5000);        /* bounded by the 800ms grace, not the 30s timeout */
+}
+
+/* grace = 0 (default/opt-in off): the error pane is just a non-stabilising pane,
+ * so recv falls through to the idle timeout (-2) — legacy behaviour preserved. */
+static void test_recv_provider_error_disabled_times_out(void)
+{
+   setenv("FAKE_TMUX_MODE", "provider_error", 1);
+   cli_session_set_error_grace_ms(0);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "claude");
+   char buf[8192];
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 1000);
+   assert(rc == -2);
+}
+
+/* The welcome banner's "Retrying in …" prose (│-prefixed box line, no ✻ status
+ * star) must NOT be read as a provider error: with the grace set, recv still
+ * hits the idle timeout (-2), never -4. Guards the anchoring against a false
+ * positive on banner text. */
+static void test_recv_banner_retry_not_provider_error(void)
+{
+   setenv("FAKE_TMUX_MODE", "banner_retry", 1);
+   cli_session_set_error_grace_ms(800);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "claude");
+   char buf[8192];
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 1500);
+   cli_session_set_error_grace_ms(0);
+   assert(rc == -2);
 }
 
 /* --- cli_session_make_name tests --- */
@@ -590,6 +652,18 @@ int main(void)
 
    printf("test_recv_cancel_codex_idle_skips_ctrlc... ");
    test_recv_cancel_codex_idle_skips_ctrlc();
+   printf("OK\n");
+
+   printf("test_recv_provider_error_returns_minus4... ");
+   test_recv_provider_error_returns_minus4();
+   printf("OK\n");
+
+   printf("test_recv_provider_error_disabled_times_out... ");
+   test_recv_provider_error_disabled_times_out();
+   printf("OK\n");
+
+   printf("test_recv_banner_retry_not_provider_error... ");
+   test_recv_banner_retry_not_provider_error();
    printf("OK\n");
 
    printf("All cli_session tests passed.\n");


### PR DESCRIPTION
## Problem

webchat drives claude as a persistent tmux TUI per session. When two sessions hit the API concurrently, one intermittently gets a transient provider error; claude then retries ~10× with backoff, **animating** its `✻` status line (`API error · Retrying in Ns · attempt K/10`). `cli_session_recv` declares a turn done only when the pane goes **static** for 3 polls — an animating retry counter never stabilises, so recv waits out the full **180s** idle timeout: a silent "Working" spinner for up to 3 minutes.

This is the secondary issue behind the "additional tabs frozen" report (the primary, a global serial send queue, was #618). The provider error itself is an account-wide transient aimee can't prevent — claude's own retry is the recovery.

## Fix

Bound the error state in `cli_session_recv`. When the pane is parked in claude's `✻` error/retry status past a grace (default **60s**, opt-in via a thread-local set by the chat worker; **0 = disabled**, preserving legacy/CLI/test behaviour), recv stops the retry (Escape, like the cancel path) and returns a new code **-4**. `agent_runtime_tmux` surfaces a clear error and keeps a reused pane alive (conversation intact).

- Detection anchors on the `✻` status star at a line's start, so the welcome banner's `Retrying in …` release-notes prose (on a `│`-prefixed box line) **can't** false-match; answer content uses `●`, never `✻`.
- A transient blip claude recovers from within a few retries leaves the error state **before** the grace elapses, so the turn still completes normally; the bound only bites on a sustained failure (60s > claude's ~10× short backoff).
- Thread-local like the existing stream/cancel callbacks; `agent_run_with_tools` calls `cli_session_recv` synchronously on the same worker thread.

## Tests

Fake-tmux harness: `-4` fires + sends Escape + bounded by the grace; `grace=0` → idle timeout `-2`; banner `Retrying in` prose → **not** `-4`. Full unit-test suite + lint green.

## Validation

Reproduced live (claude 2.1.185). Two-round delegate roundtable (minimax + mistral): round 1 minimax APPROVE / mistral BLOCK (off-by-one claim was invalid — `>=` is the correct timeout test; case-sensitivity already handled); minimax's legit low/medium notes (document same-thread assumption, replace `err_start==0` sentinel with an explicit bool, 256→512 buffer, document backoff) applied; **round 2 both APPROVE**. (mimo/codex delegates unavailable in this environment.)

Not yet runtime-verified end-to-end (needs the server image rebuilt + a forced concurrent collision).