### PR TITLE
docs(proposal): four-part harness taxonomy + runnable reference tools

### DIFF
--- a/docs/PROPOSALS.md
+++ b/docs/PROPOSALS.md
@@ -48,6 +48,20 @@ umbrella document plus two platform-wide contracts.
 
 ## Pending
 
+### Four-part harness taxonomy
+
+[Name the parts, attribute the failures, delete the
+scaffolding](proposals/pending/four-part-harness-taxonomy.md). Adopts one
+vocabulary for the whole harness — loop, tool interface, context management,
+control — and builds two measurements on it: a failure classifier that attributes
+each bad run to one of the four parts (shipped runnable in
+`scripts/harness/classify_failures.py`, C port into `trace_analysis.c` specced),
+and a delete-pressure metric that ranks the per-tool prompt scaffolding by how much
+it bets against the model (shipped runnable in `scripts/harness/delete_pressure.py`).
+Classifies every major subsystem as a durable bet (memory, KB, guardrails,
+isolation) or a delete-pressure candidate (tool prompts, anti-pattern advisories,
+packing heuristics), so the harness can shrink as models improve.
+
 ### Evidence pipeline: aimee-kb + curator + learning + ingest
 
 These proposals together implement the charter's one data pipeline.

--- a/docs/proposals/pending/four-part-harness-taxonomy.md
+++ b/docs/proposals/pending/four-part-harness-taxonomy.md
@@ -1,0 +1,248 @@
+# Four-part harness taxonomy: name the parts, attribute the failures, delete the scaffolding
+
+Status: pending
+Owner: harness / observability
+Scope: vocabulary + two measurement tools (one shipped runnable, one C port specced)
+
+## 0. Summary
+
+aimee *is* a harness — the runtime layer between the model and the world. It
+intercepts every action through hooks and MCP, assembles context, routes
+delegates, and gates writes. That machinery is spread across ~400 files in
+[`src/`](../../../src) with no shared vocabulary for *which kind of thing* each
+subsystem is. This proposal adopts one framing and builds two measurements on top
+of it.
+
+The framing: **every agent harness is made of exactly four parts.**
+
+1. **Agent loop** — reason → call a tool → read the result → reason again. ReAct.
+2. **Tool interface** — what the model may touch, and how calls are described,
+   dispatched, and returned.
+3. **Context management** — what enters the window each turn (write / select /
+   compress / isolate).
+4. **Control** — budgets, retry policy, circuit breakers, observability.
+
+Two consequences drive everything below:
+
+- **Failures are attributable.** When an agent misbehaves it is almost always one
+  of the four, not "the model." Looped forever or quit early → loop/control.
+  Wrong tool or mangled args → tool interface. Ignored what you gave it → context.
+  Worked in the demo, melted in prod → control. We can *measure* this distribution
+  instead of guessing it.
+- **A good harness shrinks as models improve.** Every component encodes an
+  assumption about what the model can't do on its own. As models get better, some
+  of those assumptions expire and the component becomes pure context tax. We can
+  put *delete-pressure* on the parts that bet against the model, while protecting
+  the parts that don't.
+
+This proposal ships:
+
+- **A canonical vocabulary** (§1) and a **subsystem map** (§2) classifying every
+  major aimee subsystem as one of the four parts and as a **durable bet** vs a
+  **delete-pressure candidate**.
+- **A failure classifier** (§3) — runnable today as
+  [`scripts/harness/classify_failures.py`](../../../scripts/harness/classify_failures.py),
+  with the in-process C port into [`trace_analysis.c`](../../../src/trace_analysis.c)
+  specced here.
+- **A delete-pressure metric** (§4) — runnable today as
+  [`scripts/harness/delete_pressure.py`](../../../scripts/harness/delete_pressure.py),
+  with the runtime hit-rate counter specced here.
+- **An explicit defense of the durable bets** (§5): memory, KB, guardrails, and
+  worktree isolation are *not* betting against the model and are exempt from
+  delete-pressure.
+
+## 1. The vocabulary (canonical names)
+
+These four words become the standard way aimee talks about harness failures and
+harness code, in `MANUAL.md`, in trace output, and in review.
+
+| Part | One-line | Owns the question |
+|------|----------|-------------------|
+| **loop** | ReAct turn cycle | "did it keep going the right amount?" |
+| **tool** | tool surface + dispatch | "was the right call made correctly?" |
+| **context** | what's in the window | "did it use what it was given?" |
+| **control** | budgets, limits, observability | "is it safe and bounded in prod?" |
+
+The triage move, stated as a function: **symptom → part.**
+
+| Symptom | Part |
+|---------|------|
+| Looped forever / quit early / stuck redoing | loop (or control, if no limit existed) |
+| Called the wrong tool / mangled the args | tool |
+| Ignored a fact, file, or instruction you clearly provided | context |
+| Worked in the demo, melted under load / cost / concurrency | control |
+
+## 2. Subsystem map
+
+Each subsystem is one of the four parts, and is either a **durable bet** (provides
+something the model structurally cannot do for itself — state, authority, economics)
+or a **delete-pressure candidate** (compensates for a current model weakness and
+should be re-tested, and likely trimmed, as models improve).
+
+| Subsystem | Files (representative) | Part | Class |
+|-----------|------------------------|------|-------|
+| Turn execution / ingress translation | [`conversation.c`](../../../src/conversation.c), [`proxy_bootstrap.c`](../../../src/proxy_bootstrap.c), [`server`](../../../src/server) | loop | durable (wire-format bridge) |
+| Retry / recovery loop detection | [`trace_analysis.c`](../../../src/trace_analysis.c) | loop | durable (observability) |
+| MCP tool surface | [`mcp_tools.c`](../../../src/mcp_tools.c), [`toolset.c`](../../../src/toolset.c) | tool | durable (the bridge itself) |
+| Per-tool prompt augmentation | [`src/tool_prompts/`](../../../src/tool_prompts), [`gen_tool_prompts.py`](../../../src/gen_tool_prompts.py) | tool | **delete-pressure** |
+| Anti-pattern warnings | [`guardrails_semantic.c`](../../../src/guardrails_semantic.c), `db2/anti_patterns` | tool/context | **delete-pressure** (the advisory half) |
+| Delegate router | [`cmd_agent_delegate.c`](../../../src/cmd_agent_delegate.c), [`learning_router.c`](../../../src/learning_router.c) | tool | durable (economics, not capability) |
+| 4-tier memory | [`memory_core.c`](../../../src/memory_core.c), `memory_*.c` | context | **durable (state the model can't have)** |
+| Knowledge base + curator | [`src/kb/`](../../../src/kb), `kb_curator_*` | context | **durable** |
+| Context assembly / briefing | [`memory_assemble.c`](../../../src/memory_assemble.c), [`session_briefing.c`](../../../src/session_briefing.c) | context | durable mechanism, **delete-pressure** on its hand-tuned heuristics |
+| Compaction | [`compact.c`](../../../src/compact.c) | context | durable (fights context rot) |
+| Sensitive-file blocking | [`file_safety.c`](../../../src/file_safety.c), [`guardrails.c`](../../../src/guardrails.c) | control | **durable (authority, not capability)** |
+| Git verify / branch ownership | [`git_verify.c`](../../../src/git_verify.c), [`branch_ownership.c`](../../../src/branch_ownership.c) | control | durable |
+| Worktree isolation | [`workspace.c`](../../../src/workspace.c), [`worktree_gc.c`](../../../src/worktree_gc.c) | control | durable (blast radius) |
+| Budgets / cost + success tracking | delegate status, `learning_router.c` | control | durable |
+
+The single most important reading of this table: **aimee's delete-pressure
+candidates are concentrated in `tool` and `context` scaffolding (tool prompts,
+anti-pattern advisories, packing heuristics), while every `control` subsystem and
+the memory/KB core are durable.** That is the correct shape — the harness is thin
+where it doubts the model's intelligence and thick where it supplies state and
+authority the model cannot have on its own. The job is to keep it that shape as
+models improve.
+
+## 3. Failure classifier
+
+**Goal:** turn "context management is our biggest tax" from a hunch into a measured
+distribution, automatically, from data aimee already records.
+
+**Input:** execution-trace rows — the exact shape
+[`trace_analysis.c`](../../../src/trace_analysis.c) already mines
+(`db1_execution_trace_mining_row_t`: `plan_id, turn, direction, tool_name,
+tool_args, tool_result`).
+
+**Heuristics** (priority order; specific → general), reusing the constants and
+error indicators already in `trace_analysis.c`:
+
+- **loop — `retry-loop`:** same tool ≥ `RETRY_THRESHOLD` (3) consecutive on one
+  plan with ≥ 2 errors. This is verbatim the rule `detect_retry_loops()` already
+  implements; we relabel its output as a *loop* failure.
+- **control — `runaway-length`:** turn count exceeds a cap with no budget/limit
+  marker observed → the stop condition was missing.
+- **control — `limit-marker`:** an error result naming a boundary (`429`,
+  `rate limit`, `timeout`, `context length`, `budget`, `circuit`, …). Outranks
+  everything: a 429 is never a tool-design bug.
+- **context — `redundant-refetch`:** a `(tool, args)` call that already succeeded
+  earlier in the plan is re-issued and *nothing had changed* → the prior result was
+  in context and ignored. "Nothing changed" is made precise to exclude the
+  legitimate read-edit-reread cycle: the signal fires when the re-issue **errors**,
+  or when it **returns a byte-identical result** to the earlier success. A re-issue
+  that returns a *different* result is a valid re-read after a mutation and is not
+  flagged. (Known false positive: an idempotent poll loop returning identical bytes
+  also matches; this is the lowest-confidence non-unclassified signal — a
+  nomination, not a verdict.)
+- **tool — `dispatch-or-arg-fault`:** an error result that is dispatch/arg-shaped
+  (`command not found`, `unknown tool`, `invalid argument`, `usage:`,
+  `missing required`, parse/schema errors) → the call was malformed or misdirected.
+- **unclassified:** an error with no distinguishing signal. Surfaced, not dropped —
+  hiding it would understate the tax.
+
+**Shipped now:**
+[`scripts/harness/classify_failures.py`](../../../scripts/harness/classify_failures.py)
+implements this end to end with a `--self-test` (synthetic plan per part, red/green)
+and reads `aimee trajectory export --json` or any trace JSON. This is the reference
+the C port must match.
+
+**C port (specced):** add `harness_classify_failure()` alongside `trace_mine()` in
+[`trace_analysis.c`](../../../src/trace_analysis.c). Note the existing in-memory
+`trace_row_t` keeps only `int has_error` and **discards `tool_result`**, so it is
+insufficient: the `control`/`tool`/`context` sub-classification needs the raw
+result string (for the boundary and dispatch markers and the byte-identical
+refetch check). The faithful port must therefore classify off
+`db1_execution_trace_mining_row_t` — which retains `tool_result` — or precompute the
+marker bits at load time, rather than reuse the `has_error`-only buffer. It should
+also lift the retry rule's bare `errors >= 2` into a named `RETRY_MIN_ERRORS`
+`#define` (the Python keeps `RETRY_MIN_ERRORS = 2` explicitly) so the two stay in
+lockstep symmetrically. Surface via
+a `aimee trajectory classify [--json]` subcommand
+([`cmd_trajectory.c`](../../../src/cmd_trajectory.c)) and persist the rolling
+distribution so `aimee doctor` / [`cmd_diagnose.c`](../../../src/cmd_diagnose.c) can
+report "this week's failures: 58% context, 19% tool, …". The evidence-ranked
+diagnosis store (`DIAG_RANK_*`) is the natural place to attach a classified
+incident as `evidence_for` a hypothesis.
+
+## 4. Delete-pressure metric
+
+**Goal:** make "delete harness code as models improve" a maintenance ritual with a
+number, not a slogan. Focus first on the per-tool prompt augmentations in
+[`src/tool_prompts/`](../../../src/tool_prompts) — the most literal "betting against
+the model" surface, injected into context every single turn.
+
+**Two signals, deliberately separated:**
+
+- **Static (shipped):**
+  [`scripts/harness/delete_pressure.py`](../../../scripts/harness/delete_pressure.py)
+  scores each scaffold by per-turn token tax and *doubt density* (imperative
+  hedges — "Always", "Never", "Avoid", "Do not" — each encoding "the model won't
+  do this unless told"). On the current 8 scaffolds it reports ~207 tokens of
+  fixed per-turn tax and ranks `run_background_process`, `list_files`, and
+  `write_file` as the top re-test-then-likely-trim candidates. Static signals only
+  **nominate**.
+- **Runtime (authoritative, specced):** the real test is whether *removing* a
+  scaffold changes an outcome. Two data sources:
+  - **anti-pattern hit-rate** — `db2/anti_patterns` already has
+    `db2_anti_pattern_bump()`. A pattern that has never bumped is dead weight. The
+    tool already ingests this via `--anti-patterns export.json`; we need a
+    `aimee guardrails anti-patterns export --json` that emits `{pattern, hits}`.
+  - **scaffold A/B** — gate each tool prompt behind a flag and compare tool-call
+    validity (the `tool` failure rate from §3) with and without it. A scaffold
+    whose removal doesn't move the failure rate has expired.
+
+**Guardrail on the metric:** delete-pressure ranks *candidates for re-testing*, not
+deletions. Nothing is removed without the runtime signal confirming the model no
+longer needs it. The static score points the camera; the A/B pulls the trigger.
+
+## 5. The durable bets (exempt from delete-pressure)
+
+These are not betting against the model's intelligence, so model improvement does
+not erode them. They are explicitly out of scope for §4 and should keep getting
+investment:
+
+- **Memory + KB** (`memory_*.c`, [`src/kb/`](../../../src/kb)). A smarter model still
+  has zero memory of *your* last session — that is a state problem, not an
+  intelligence problem. This is aimee's strongest bet, and the framing validates
+  it: state is the one part that doesn't evaporate as models improve. See
+  [How aimee learns](../../KNOWLEDGE.md).
+- **Guardrails / file-safety / git-verify / isolation** (`file_safety.c`,
+  `guardrails.c`, `git_verify.c`, `worktree_gc.c`). These govern *authority and
+  blast radius*, not capability. A more capable model that is *allowed* to clobber
+  `.env` or another session's worktree is more dangerous, not less. Authority
+  bounds should track trust and concurrency, never model IQ.
+- **Delegate routing economics** ([`learning_router.c`](../../../src/learning_router.c)).
+  Routing to the cheapest capable model is an economic bet that survives model
+  improvement. Only the router's *complexity* is subject to pressure — the routing
+  itself is durable.
+
+## 6. Rollout
+
+1. **Vocabulary** — land §1 in `MANUAL.md` and reference the four parts in
+   trace/diagnose output. (cheap, unblocks the rest)
+2. **Classifier** — ship the Python reference (done), then port to
+   `trace_analysis.c` + `aimee trajectory classify`, then persist the rolling
+   distribution into `aimee doctor`.
+3. **Delete-pressure** — ship the static tool (done), add
+   `aimee guardrails anti-patterns export --json`, wire `delete_pressure.py` into
+   `make lint` as a non-failing report, then build the scaffold A/B harness.
+4. **Quarterly ritual** — on each model upgrade, run delete-pressure, A/B the top
+   candidates, and trim. The harness should be smaller after a model upgrade than
+   before it.
+
+## 7. Verification status
+
+- `scripts/harness/classify_failures.py` — **verified**: `--self-test` is green
+  (exit 0). Beyond one synthetic plan per part, it asserts the read-edit-reread
+  cycle is *not* flagged, that a benign `room`-containing error is not mis-attributed
+  to control (word-boundary marker matching), the erroring-refetch path, and the
+  empty-trace / all-success / runaway-length edge cases. Each assertion fails loudly,
+  so a degenerate classifier cannot pass.
+- `scripts/harness/delete_pressure.py` — **verified**: `--self-test` green; the test
+  holds word count fixed and varies only prescriptiveness (length and doubt are not
+  confounded) and asserts substrings of doubt terms (`commonly`/`mustard`) score
+  zero. A live scan of the real `src/tool_prompts/` reports the 8-scaffold inventory
+  (~207 tokens/turn fixed tax).
+- C port into `trace_analysis.c`, the `trajectory classify` / `anti-patterns
+  export` subcommands, and the scaffold A/B harness — **design only, unverified.**
+  Not built or run in this change.

--- a/docs/proposals/pending/four-part-harness-taxonomy.plan.md
+++ b/docs/proposals/pending/four-part-harness-taxonomy.plan.md
@@ -1,0 +1,234 @@
+# Impl plan: four-part harness taxonomy
+
+> **Plan-roundtable status:** converged in two rounds. The automated multi-model
+> panel is unavailable in this environment (no built `aimee` binary, no
+> forge-brokered delegate endpoints), so the gate ran as a four-lens adversarial
+> review panel of subagents — grounding/correctness, scope/altitude, contrarian
+> skeptic, and tests/verification. Round 1 returned 2 approve / 2 request_changes
+> with two real code bugs surfaced (bare-substring marker matching, and a context
+> classifier that missed the successful-refetch case). All blocking and major
+> findings were folded (see "Review findings folded" below) and the reference tools
+> re-verified green. **Round 2 returned 4 approve / 0 request_changes (unanimous),
+> with reviewers running the self-tests.** Its non-blocking findings were also
+> folded: a polling false-positive caveat on the byte-identical refetch rule (doc +
+> code comment), `unrecognized arguments` (plural) for argparse, high-frequency
+> inflected control markers, and two new self-tests (runaway-suppression path,
+> argparse plural). A 2nd independent-model review remains available once a healthy
+> delegate worker is reachable.
+>
+> **Round 3 (live multi-model roundtable):** the real panel became reachable over
+> the `/v1` UDS, so the code was re-reviewed by the API agents (two focused parallel
+> runs, one per tool; 2 of 3 panelists answered each). Findings triaged on merit —
+> the deciding ones folded, the misreads rejected with rationale (see "Review
+> findings folded — round 3" below). Both tools re-verified green: `classify_failures`
+> now 15 self-test assertions, `delete_pressure` 6.
+
+Plan for [`four-part-harness-taxonomy.md`](four-part-harness-taxonomy.md). This is
+a **vocabulary + measurement-tooling** proposal, not an intelligence-surface
+proposal, so it does not inherit the Architecture Charter review gate. Its concrete,
+shippable deliverable is a **canonical vocabulary** plus **two runnable reference
+tools** that turn two slogans ("context is our biggest tax", "delete harness code
+as models improve") into measured numbers. The in-process C ports are **specced as
+explicit follow-ons** and are out of scope for this PR — they require the build
+toolchain and a live DB1/DB2 runtime that the reference tools deliberately do not.
+
+## Scope of THIS PR (`docs(proposal)` + reference tooling)
+
+In scope, all verifiable without a build:
+
+1. The proposal document (vocabulary §1, subsystem map §2, classifier §3,
+   delete-pressure §4, durable bets §5, rollout §6, verification status §7).
+2. [`scripts/harness/classify_failures.py`](../../../scripts/harness/classify_failures.py)
+   — the failure classifier, with `--self-test`.
+3. [`scripts/harness/delete_pressure.py`](../../../scripts/harness/delete_pressure.py)
+   — the delete-pressure metric, with `--self-test`.
+4. [`scripts/harness/README.md`](../../../scripts/harness/README.md) — how to run
+   both, what they do and do not claim.
+5. The `docs/PROPOSALS.md` index entry under **Pending**.
+
+**Explicitly out of scope** (named here so the boundary is a decision, not a
+silent gap), each a follow-on once this lands and the proposal is accepted:
+
+- The C port `harness_classify_failure()` in `src/trace_analysis.c` and the
+  `aimee trajectory classify [--json]` subcommand — needs build + DB1.
+- The `aimee guardrails anti-patterns export --json` emitter — needs build + DB2.
+- The scaffold A/B harness (flag-gating each tool prompt, comparing the §3 tool
+  failure rate with/without) — needs a runtime and an eval loop.
+- Landing the vocabulary into `MANUAL.md` and trace/diagnose output (rollout §6.1).
+  Cheap, but it is a doc-surface change with its own review; kept separate so this
+  PR stays "proposal + verified reference tools". See **WP-D decision** below.
+
+## Grounded integration points (verified in tree)
+
+The reference tools are faithful to code that exists today; each claim was checked,
+not assumed:
+
+- **Classifier input shape** — `db1_execution_trace_mining_row_t`
+  (`src/db1/execution_trace.h:66-75`) is exactly
+  `{id, plan_id, turn, direction, tool_name, tool_args, tool_result}`. The Python
+  reads `{plan_id, turn, direction, tool_name, tool_args, tool_result}` — a subset
+  of the same row. **Verified.**
+- **Retry-loop rule** — `detect_retry_loops()` (`src/trace_analysis.c:91-139`)
+  flags `run >= RETRY_THRESHOLD (3)` consecutive same-tool calls with `errors >= 2`.
+  The Python `RETRY_THRESHOLD = 3` / `RETRY_MIN_ERRORS = 2` are kept in lockstep and
+  the script says so in a comment. **Verified identical.**
+- **Error markers** — the Python `ERROR_MARKERS` tuple is a verbatim copy of the
+  substrings in `result_looks_like_error()` (`src/trace_analysis.c:38-52`):
+  `error/Error/ERROR`, `failed/Failed/FAILED`, `No such file`, `not found`,
+  `Permission denied`, `command not found`. **Verified identical.**
+- **Anti-pattern hit-rate** — `src/db2/anti_patterns.h` exposes `int hit_count`
+  (`:27`), `db2_anti_pattern_list()` (`:38`), `db2_anti_pattern_bump()` (`:55`).
+  `delete_pressure.py`'s `load_anti_patterns()` keys on `hit_count` (with
+  `bumps`/`hits` fallbacks) and treats `hit_count == 0` as a removal candidate —
+  consistent with "a pattern that has never bumped is dead weight." **Verified.**
+- **Delete-pressure target** — `src/tool_prompts/` holds exactly 8 `*.md`
+  scaffolds (bash, code_search, grep, list_files, read_file,
+  run_background_process, verify, write_file). The static scan runs against the
+  real directory. **Verified.**
+
+## Review findings folded (round 1)
+
+1. **The C port cannot run off the reduced `trace_row_t` buffer.** [doc]
+   `src/trace_analysis.c` loads each row into an in-memory `trace_row_t` that keeps
+   only `int has_error` (`:25`, `:75`) and discards the raw `tool_result`. The
+   classifier's `control`/`tool`/`context` sub-classification needs the raw result
+   string (for `CONTROL_MARKERS`, `TOOL_FAULT_MARKERS`, and refetch detection), so a
+   faithful port **must classify off `db1_execution_trace_mining_row_t`** (which
+   retains `tool_result`) or precompute the marker bits at load time. **Resolved:**
+   proposal §3 C-port paragraph rewritten to say this, plus a note to lift the bare
+   `errors >= 2` into a named `RETRY_MIN_ERRORS` `#define`.
+
+2. **The context classifier missed the canonical "ignored context" case.** [code]
+   The original code only raised `redundant-refetch` when the re-issue *itself
+   errored*, so a **successful** redundant refetch — the textbook "you re-read what
+   was already in your window" failure — produced zero incidents. **Resolved:** the
+   classifier now records each success's result bytes and flags a re-issue whose
+   result is **byte-identical** to the earlier success (confidence 0.5), in addition
+   to the erroring re-issue (0.65). Byte-identity cleanly excludes the legitimate
+   read-edit-reread cycle: a real edit changes the bytes, so the re-read is not
+   flagged. Proposal §3 and both self-tests updated to match; the dangling
+   `# success refetch, see note` comment is gone.
+
+3. **Bare-substring marker matching corrupted the distribution.** [code, bug]
+   `CONTROL_MARKERS` / `TOOL_FAULT_MARKERS` were matched as raw substrings, so
+   `'oom'` matched `'room-service'`, `'must'` would match `'mustard'`, etc. Because
+   the control band *outranks everything*, a false control hit silently misattributes
+   a failure. **Resolved:** markers are now compiled with word boundaries on their
+   word-character edges (phrase/colon markers like `usage:` and `rate-limit` still
+   match), and a self-test asserts a benign `'room'` error is **not** classified as
+   control. The same whole-word fix was applied to `delete_pressure.py`'s doubt
+   terms (`'only'` no longer matches `'commonly'`), with its own negative self-test.
+
+4. **Self-tests were happy-path only / confounded.** [tests]
+   **Resolved:** `classify_failures.py --self-test` now also asserts read-edit-reread
+   is not flagged, the `'room'` false-positive guard, the erroring-refetch path,
+   empty-trace, all-success (+ the "no failures detected" render path), and
+   runaway-length; each assertion fails loudly so a degenerate classifier cannot
+   pass. `delete_pressure.py --self-test` now holds word count fixed and varies only
+   prescriptiveness (length/doubt no longer confounded), asserts plain prose scores
+   zero doubt, and asserts the `commonly`/`mustard`/`preferences` substring trap
+   scores zero.
+
+## Review findings folded (round 3 — live roundtable)
+
+Folded (legitimate):
+
+1. **Non-scalar `tool_args` could crash the classifier.** [code] The `(tool, args)`
+   dict key assumed `tool_args` is a string (it is in `db1` `char[]`), but the tool
+   ingests arbitrary JSON, so a list/dict arg made the key unhashable. **Resolved:**
+   a `_key_args()` helper coerces non-scalars to a canonical JSON string; a new
+   self-test feeds a list arg and asserts both no-crash and that a true refetch is
+   still detected.
+2. **`control` did not actually outrank the success-refetch path.** [code] A
+   non-error result carrying a control marker (e.g. `deadline exceeded`, which has no
+   error word) re-issued byte-identically was tagged `context/redundant-refetch`,
+   violating the stated "control outranks everything" invariant. **Resolved:** the
+   per-row loop hoists the `consumed` skip and the `CONTROL_PATTERNS` check above both
+   the success and refetch branches; a new self-test locks it.
+3. **`delete_pressure` turned malformed exports into bulk deletions.** [code] A row
+   with none of `hit_count`/`bumps`/`hits` defaulted to `hits=0`, which `render()`
+   reads as "never matched = removal candidate" — a schema mismatch would recommend
+   deleting every live pattern. **Resolved:** missing count is now `None`
+   ("unknown"), kept distinct from a genuine `0`; only present-and-zero rows are
+   removal candidates, unknown rows are excluded and flagged as a schema issue.
+   `load_anti_patterns` also now uses `with open`, returns `None` on unreadable/
+   non-JSON/non-array input, and `main()` exits 2 rather than silently degrading.
+   A new self-test asserts the zero-vs-unknown split.
+4. **Lockstep coupling was asserted but not pinpointed.** [doc] The `RETRY_THRESHOLD`
+   / `RETRY_MIN_ERRORS` comment now cites the exact `src/trace_analysis.c` defines and
+   states that, like `detect_retry_loops()`, the run is keyed on `tool_name` only and
+   the trace `direction` field is intentionally not a grouping key.
+
+Rejected (panel misread; the deadline-hit/degraded runs produced some spurious
+items), with rationale so the boundary is a decision:
+
+- *"runaway-length fires when a control marker appears after the first N rows"* —
+  false: the check is `not any(... for r in rows)` over **all** rows, and self-test
+  8b already asserts a late control marker suppresses runaway-length.
+- *"`rate-limit` vs `rate limit` inconsistency"* — both forms are already listed in
+  `CONTROL_MARKERS`.
+- *"`\bmust\b` false-matches `mustn't`"* — it does not (`t`→`n` is not a word
+  boundary); the only contrived match (`only's`) is not real prose. The remaining
+  LOW doc nits are already covered by the docstring's explicit STATIC-vs-RUNTIME and
+  "only NOMINATES" caveats.
+
+## Work packets
+
+Each WP is independently verifiable; together they are one `docs(proposal)` PR onto
+`docs/four-part-harness-taxonomy` → `testing` (never `main` directly).
+
+### WP-A — proposal document (DONE)
+`docs/proposals/pending/four-part-harness-taxonomy.md`. §3 edits applied: the
+C-port paragraph now states the port classifies off the mining row that retains
+`tool_result` (+ the `RETRY_MIN_ERRORS` `#define` note), and the `redundant-refetch`
+bullet now states the byte-identical / error-gated rule and the read-edit-reread
+exclusion. No new claims.
+
+### WP-B — classifier reference (DONE)
+`scripts/harness/classify_failures.py`. Word-boundary marker matching and
+byte-identical successful-refetch detection added (findings 2-3); the self-test was
+rebuilt with 11 loud assertions (findings 4). `--self-test` is green, exit 0.
+
+### WP-C — delete-pressure reference (DONE)
+`scripts/harness/delete_pressure.py`. Whole-word doubt matching added (finding 3);
+self-test rebuilt to separate length from prescriptiveness (finding 4). `--self-test`
+green; a plain scan of `src/tool_prompts/` still reports the 8-scaffold inventory,
+~207 tok/turn fixed tax, and the same top-3 ranked candidates.
+
+### WP-D — README + index (DONE)
+`scripts/harness/README.md` and the `docs/PROPOSALS.md` Pending entry.
+**WP-D decision (review, contrarian lens):** do **not** fold the `MANUAL.md`
+vocabulary landing (rollout §6.1) into this PR. It is a change to a 85 KB core doc
+with its own review surface and is logically the *first rollout step after
+acceptance*, not part of shipping the reference tools. Keeping it out holds this PR
+to one reviewable claim: "here is the framing and two tools that measure it."
+
+## Verification
+
+- `python3 scripts/harness/classify_failures.py --self-test` → 4/4 PASS, exit 0.
+- `python3 scripts/harness/delete_pressure.py --self-test` → PASS, exit 0.
+- `python3 scripts/harness/delete_pressure.py` → 8 scaffolds, ~200 tok/turn fixed
+  tax, ranked candidates printed.
+- `python3 scripts/harness/classify_failures.py --json <trace>` → well-formed
+  incidents + distribution; an all-success trace yields "no failures detected".
+- Grounding re-checked against `src/trace_analysis.c`,
+  `src/db1/execution_trace.h`, `src/db2/anti_patterns.h`, `src/tool_prompts/`.
+- **Not verified (honest boundary):** the C ports, the two new subcommands, and the
+  A/B harness are design-only and not built or run in this change — matching the
+  proposal's own §7. The deciding test for those is an in-process run that this
+  environment (no build) cannot perform; they stay "specced, unverified" rather than
+  being claimed as working.
+
+## Done-state for the proposal
+
+This PR ships the proposal's **Phase 1 / reference-tooling slice**: the vocabulary,
+the subsystem map, and the two verified reference tools. On merge the proposal moves
+to `docs/proposals/done/` annotated **"reference tools shipped; C ports + A/B
+harness are specced follow-ons"** — the same "shipped phase + named follow-ons"
+done-state used across the proposal tree — e.g.
+[`optimization-surface.md`](../done/optimization-surface.md) shipped its CLI with
+the remainder carried in
+[`optimization-surface-residual.md`](../done/optimization-surface-residual.md), and
+[`agent-roundtable-authoring-pipeline.md`](../done/agent-roundtable-authoring-pipeline.md)
+landed with named deferred follow-ons. The follow-on C work here is tracked by the
+proposal's §6 rollout list.

--- a/scripts/harness/README.md
+++ b/scripts/harness/README.md
@@ -1,0 +1,48 @@
+# Harness analysis tools
+
+Tooling for the **four-part harness** framing: every agent runtime is *loop +
+tool interface + context management + control*. When an agent misbehaves it is
+almost always one part, not "the model"; and as models improve, the parts that
+bet against the model should shrink. See
+[`docs/proposals/pending/four-part-harness-taxonomy.md`](../../docs/proposals/pending/four-part-harness-taxonomy.md)
+for the full design, the subsystem map, and the durable-vs-delete classification.
+
+Both tools are pure analysis — no build, no running aimee server required.
+
+## `classify_failures.py` — attribute failures to one of the four parts
+
+Reads execution-trace rows (the shape `src/trace_analysis.c` mines) and tags each
+detected failure as **loop**, **tool**, **context**, or **control**, then prints
+the distribution. Turns "context is our biggest tax" into a measured number.
+
+```sh
+python3 classify_failures.py --self-test            # red/green: one plan per part + edge cases
+python3 classify_failures.py traces.json            # classify a trace dump
+aimee trajectory export --json | python3 classify_failures.py -
+python3 classify_failures.py traces.json --json     # machine-readable
+```
+
+Heuristics mirror the constants in `src/trace_analysis.c` (retry-loop threshold,
+error indicators) so the in-process C port stays faithful. This script is the
+reference that port must match.
+
+## `delete_pressure.py` — rank scaffolding for deletion as models improve
+
+Scores the per-tool prompt augmentations in `src/tool_prompts/` by per-turn token
+tax and *doubt density* (imperative hedges that encode "the model won't do this
+unless told"). High score = re-test against a current model, then likely trim.
+
+```sh
+python3 delete_pressure.py                          # scan src/tool_prompts/
+python3 delete_pressure.py --json
+python3 delete_pressure.py --anti-patterns export.json   # fold in runtime hit-rate
+python3 delete_pressure.py --self-test
+```
+
+Doubt density is a deliberately weak, whole-word-matched heuristic (it counts
+imperative hedges), not a measurement. Static pressure only **nominates**
+candidates. The authoritative signal is whether *removing* a scaffold changes an
+outcome — anti-pattern hit-rate (`--anti-patterns`,
+needs `aimee guardrails anti-patterns export --json`) or a scaffold A/B against the
+`tool` failure rate from `classify_failures.py`. The static score points the
+camera; the runtime signal pulls the trigger.

--- a/scripts/harness/classify_failures.py
+++ b/scripts/harness/classify_failures.py
@@ -1,0 +1,493 @@
+#!/usr/bin/env python3
+"""classify_failures.py: attribute agent-run failures to one of the four harness
+parts — loop, tool, context, or control.
+
+Framing (the "four-part harness"): every agent runtime is loop + tool interface +
+context management + control. When a run misbehaves it is almost always ONE part,
+not "the model". This tool turns that triage move into a mechanical classifier so
+"context management is our biggest tax" becomes a measured distribution instead of
+a hunch.
+
+It is the runnable reference implementation of the classifier specced in
+docs/proposals/pending/four-part-harness-taxonomy.md. The heuristics mirror the
+signals aimee already computes in src/trace_analysis.c (the retry-loop detector,
+the error-result indicators) so a later in-process port stays faithful.
+
+Input is execution-trace rows — the same shape src/trace_analysis.c mines
+(db1_execution_trace_mining_row_t): one JSON array of
+  {plan_id, turn, direction, tool_name, tool_args, tool_result}
+read from a file or stdin. Output is one incident per detected failure, each
+tagged with its harness part, the signal that fired, and a confidence, plus an
+aggregate distribution.
+
+Pure analysis, no build and no aimee runtime needed. Run --self-test for a
+red/green check against synthetic traces that exercise each of the four parts.
+
+Usage:
+  classify_failures.py traces.json
+  aimee trajectory export --json | classify_failures.py -
+  classify_failures.py --self-test
+"""
+import argparse
+import json
+import re
+import sys
+
+# Mirror src/trace_analysis.c: RETRY_THRESHOLD consecutive same-tool calls with
+# >=2 errors is a retry loop. Keep these in lockstep with the C constants
+# (src/trace_analysis.c: `#define RETRY_THRESHOLD 3` and the `errors >= 2` in
+# detect_retry_loops()). Like the C, the run is keyed on tool_name only; the
+# trace `direction` field is intentionally NOT a grouping key (detect_retry_loops()
+# ignores it too), so a port off db1_execution_trace_mining_row_t stays faithful.
+RETRY_THRESHOLD = 3
+RETRY_MIN_ERRORS = 2
+# A run with more turns than this and no explicit budget/limit marker reads as a
+# missing stop condition (control), not as the model "being dumb".
+RUNAWAY_TURNS = 50
+
+# The four parts. Order matters: classification walks specific -> general.
+PART_LOOP = "loop"
+PART_TOOL = "tool"
+PART_CONTEXT = "context"
+PART_CONTROL = "control"
+PARTS = (PART_LOOP, PART_TOOL, PART_CONTEXT, PART_CONTROL)
+
+PART_BLURB = {
+    PART_LOOP: "agent loop — looped forever or quit early",
+    PART_TOOL: "tool interface — wrong tool, bad args, or dispatch fault",
+    PART_CONTEXT: "context management — ignored information it was given",
+    PART_CONTROL: "control — a budget/limit/timeout/circuit-breaker boundary",
+}
+
+# Error indicators, copied from result_looks_like_error() in src/trace_analysis.c
+# so "is this row a failure" matches what the C miner already flags.
+ERROR_MARKERS = (
+    "error", "Error", "ERROR", "failed", "Failed", "FAILED",
+    "No such file", "not found", "Permission denied", "command not found",
+)
+
+# A control boundary was hit: budget, rate, timeout, context-window, circuit.
+# These outrank every other signal — a 429 is not a tool-design problem.
+CONTROL_MARKERS = (
+    "rate limit", "rate-limit", "429", "too many requests",
+    "timeout", "timeouts", "timed out", "timed-out", "deadline exceeded",
+    "context length", "context window", "token limit", "token limits",
+    "maximum context", "budget", "quota", "quotas", "circuit",
+    "max turns", "max steps",
+    "killed", "oom", "out of memory", "cancelled", "canceled", "aborted",
+)
+# Note: markers are word-bounded (see _compile_markers), so inflected forms that
+# are not listed (e.g. "rate-limited") fall through to 'unclassified' rather than
+# being mis-attributed. The high-frequency plurals/participles above are listed
+# explicitly; the trade-off is deliberate (under-count over corrupt).
+
+# A tool-interface fault: the call itself was malformed or misdirected, as opposed
+# to the world legitimately saying "that thing is not here".
+TOOL_FAULT_MARKERS = (
+    "command not found", "unknown tool", "no such tool", "unknown command",
+    "invalid argument", "unexpected argument", "unrecognized argument",
+    "unrecognized arguments",  # argparse's canonical message is always plural
+    "usage:", "missing required", "required argument", "invalid arguments",
+    "json parse", "could not parse", "malformed", "schema", "bad request",
+    "permission denied",
+)
+
+
+def _compile_markers(markers):
+    """Word-boundary matchers for the lowercased markers. Bare substring matching
+    mis-fires on short alphabetic markers ('oom' inside 'room-service', 'aborted'
+    inside ...), and because the control band outranks everything that corrupts the
+    very distribution this tool exists to produce. Boundaries are added only on the
+    word-character edges so phrase/colon markers ('usage:', 'rate-limit') still
+    match. Returns (marker, compiled) pairs, order preserved for _first_marker."""
+    out = []
+    for m in markers:
+        left = r"\b" if m[0].isalnum() else ""
+        right = r"\b" if m[-1].isalnum() else ""
+        out.append((m, re.compile(left + re.escape(m) + right)))
+    return out
+
+
+CONTROL_PATTERNS = _compile_markers(CONTROL_MARKERS)
+TOOL_FAULT_PATTERNS = _compile_markers(TOOL_FAULT_MARKERS)
+
+
+def looks_like_error(result):
+    # Case-sensitive substring match, kept byte-for-byte identical to
+    # result_looks_like_error() in src/trace_analysis.c (the C miner's own rule).
+    if not result:
+        return False
+    return any(m in result for m in ERROR_MARKERS)
+
+
+def has_any(result, patterns):
+    if not result:
+        return False
+    low = result.lower()
+    return any(p.search(low) for _, p in patterns)
+
+
+def _key_args(args):
+    """Stable, hashable key for tool_args. In real traces tool_args is a string
+    (db1 char[]), but this tool ingests arbitrary JSON, so a list/dict arg would
+    make the (tool, args) dict key unhashable and crash the run. Coerce anything
+    non-scalar to a canonical JSON string so refetch detection still keys cleanly."""
+    if isinstance(args, (str, bytes, int, float, bool)) or args is None:
+        return args
+    return json.dumps(args, sort_keys=True, default=str)
+
+
+def _incident(part, signal, confidence, plan_id, turn, tool, detail):
+    return {
+        "part": part,
+        "signal": signal,
+        "confidence": round(confidence, 2),
+        "plan_id": plan_id,
+        "turn": turn,
+        "tool": tool,
+        "detail": detail,
+    }
+
+
+def classify_plan(rows):
+    """Classify failures within a single plan's ordered trace rows.
+
+    Returns a list of incident dicts. A retry loop is reported once for the run,
+    not once per row, so a single stuck loop does not drown out everything else.
+    """
+    incidents = []
+    consumed = [False] * len(rows)
+
+    # 1. Runaway length with no explicit limit marker -> control (no stop cond).
+    if rows:
+        turns = {r.get("turn") for r in rows if r.get("turn") is not None}
+        if len(turns) > RUNAWAY_TURNS and not any(
+            has_any(r.get("tool_result"), CONTROL_PATTERNS) for r in rows
+        ):
+            incidents.append(_incident(
+                PART_CONTROL, "runaway-length", 0.6,
+                rows[0].get("plan_id"), max(turns), None,
+                f"{len(turns)} turns with no budget/limit boundary observed",
+            ))
+
+    # 2. Retry loops: same tool >=RETRY_THRESHOLD consecutive with >=2 errors.
+    #    This is the loop/control failure — the model is stuck, not wrong.
+    i = 0
+    n = len(rows)
+    while i < n:
+        if consumed[i] or not rows[i].get("tool_name"):
+            i += 1
+            continue
+        run = 1
+        errors = 1 if looks_like_error(rows[i].get("tool_result")) else 0
+        j = i + 1
+        while j < n and rows[j].get("tool_name") == rows[i].get("tool_name"):
+            run += 1
+            if looks_like_error(rows[j].get("tool_result")):
+                errors += 1
+            j += 1
+        if run >= RETRY_THRESHOLD and errors >= RETRY_MIN_ERRORS:
+            for k in range(i, j):
+                consumed[k] = True
+            incidents.append(_incident(
+                PART_LOOP, "retry-loop", 0.8,
+                rows[i].get("plan_id"), rows[i].get("turn"), rows[i].get("tool_name"),
+                f"'{rows[i].get('tool_name')}' called {run}x consecutively, {errors} errors",
+            ))
+            i = j
+            continue
+        i += 1
+
+    # 3. Remaining rows in temporal order. Track (tool, args) pairs that already
+    #    SUCCEEDED, with their result bytes, so a later re-issue with nothing changed
+    #    is a re-fetch of something already in context (context failure). Storing the
+    #    result lets us exclude the legitimate read-edit-reread cycle: a re-read that
+    #    returns DIFFERENT bytes is a valid re-read after a mutation, not ignored
+    #    context.
+    succeeded = {}  # key -> (idx, result_string)
+    for idx, r in enumerate(rows):
+        # Rows already attributed to a retry loop above are spoken for; skipping
+        # them up front keeps a stuck loop from being double-counted here.
+        if consumed[idx]:
+            continue
+        tool = r.get("tool_name")
+        key = (tool, _key_args(r.get("tool_args")))
+        result = r.get("tool_result")
+        plan_id, turn = r.get("plan_id"), r.get("turn")
+
+        # Control boundary outranks EVERYTHING — a limit/timeout/quota was hit,
+        # whether or not the generic error-marker heuristic also fired. Checking it
+        # before the success and refetch paths keeps the "control wins" invariant
+        # honest: a result that says "deadline exceeded" but contains no error word
+        # is still a control incident, not a clean success or a context refetch.
+        if has_any(result, CONTROL_PATTERNS):
+            incidents.append(_incident(
+                PART_CONTROL, "limit-marker", 0.75, plan_id, turn, tool,
+                _first_marker(result, CONTROL_PATTERNS),
+            ))
+            continue
+
+        if not looks_like_error(result):
+            if tool:
+                prior = succeeded.get(key)
+                # Byte-identical successful refetch: the prior result was in context
+                # and re-fetched. Known false positive: an idempotent poll loop
+                # (re-issuing the same call, same bytes, while waiting for state to
+                # change) also matches. That is why this is the lowest-confidence
+                # (0.5) non-unclassified signal — a nomination, not a verdict.
+                if prior is not None and prior[1] == result:
+                    incidents.append(_incident(
+                        PART_CONTEXT, "redundant-refetch", 0.5, plan_id, turn, tool,
+                        f"'{tool}' re-issued with identical args and byte-identical "
+                        f"result; the prior result was already in context",
+                    ))
+                # Record the latest success so a changed re-read updates the baseline.
+                succeeded[key] = (idx, result)
+            continue
+
+        # An erroring re-issue of a call that already succeeded = ignored context.
+        if key in succeeded:
+            incidents.append(_incident(
+                PART_CONTEXT, "redundant-refetch", 0.65, plan_id, turn, tool,
+                f"'{tool}' re-called with identical args after an earlier success",
+            ))
+            continue
+
+        # Dispatch/arg-shaped error = the call was malformed or misdirected.
+        if has_any(result, TOOL_FAULT_PATTERNS):
+            incidents.append(_incident(
+                PART_TOOL, "dispatch-or-arg-fault", 0.6, plan_id, turn, tool,
+                _first_marker(result, TOOL_FAULT_PATTERNS),
+            ))
+            continue
+
+        # A generic error we cannot attribute with confidence. Surfacing it as
+        # unclassified is honest; silently dropping it would understate the tax.
+        incidents.append(_incident(
+            "unclassified", "generic-error", 0.2, plan_id, turn, tool,
+            "error result with no distinguishing signal",
+        ))
+
+    return incidents
+
+
+def _first_marker(result, patterns):
+    low = result.lower()
+    for m, p in patterns:
+        if p.search(low):
+            return f"matched '{m}'"
+    return ""
+
+
+def classify(rows):
+    by_plan = {}
+    for r in rows:
+        by_plan.setdefault(r.get("plan_id"), []).append(r)
+    incidents = []
+    for plan_rows in by_plan.values():
+        incidents.extend(classify_plan(plan_rows))
+    return incidents
+
+
+def distribution(incidents):
+    counts = {p: 0 for p in PARTS}
+    counts["unclassified"] = 0
+    tools = {p: {} for p in list(PARTS) + ["unclassified"]}
+    for inc in incidents:
+        part = inc["part"]
+        counts[part] = counts.get(part, 0) + 1
+        if inc.get("tool"):
+            tools[part][inc["tool"]] = tools[part].get(inc["tool"], 0) + 1
+    return counts, tools
+
+
+def render(incidents):
+    counts, tools = distribution(incidents)
+    total = sum(counts.values())
+    out = []
+    out.append(f"Failure attribution across {total} incident(s):\n")
+    if total == 0:
+        out.append("  (no failures detected)")
+        return "\n".join(out)
+    width = max(len(p) for p in counts)
+    for part in list(PARTS) + ["unclassified"]:
+        c = counts.get(part, 0)
+        if c == 0:
+            continue
+        pct = 100.0 * c / total
+        bar = "#" * int(round(pct / 5))
+        blurb = PART_BLURB.get(part, "unclassified — no distinguishing signal")
+        out.append(f"  {part.ljust(width)}  {c:3d}  {pct:5.1f}%  {bar}")
+        out.append(f"  {' '.ljust(width)}        {blurb}")
+        top = sorted(tools[part].items(), key=lambda kv: -kv[1])[:3]
+        if top:
+            out.append(f"  {' '.ljust(width)}        top tools: "
+                       + ", ".join(f"{t}({n})" for t, n in top))
+    out.append("")
+    biggest = max(counts.items(), key=lambda kv: kv[1])
+    if biggest[1]:
+        out.append(f"Biggest tax: {biggest[0]} ({biggest[1]}/{total}). "
+                   "Fix that part before blaming the model.")
+    return "\n".join(out)
+
+
+# --- self-test: synthetic plans, one per part (red/green) --------------------
+
+def _row(plan, turn, tool, args="", result=""):
+    return {"plan_id": plan, "turn": turn, "direction": "result",
+            "tool_name": tool, "tool_args": args, "tool_result": result}
+
+
+def _self_test_traces():
+    plans = []
+    # LOOP: same tool 3x consecutive, 3 errors.
+    plans += [_row(1, t, "grep", "pat", "Error: bad regex") for t in range(3)]
+    # TOOL: a single dispatch/arg fault.
+    plans += [_row(2, 0, "bash", "frobnicate", "bash: frobnicate: command not found")]
+    # CONTEXT: read a file successfully, then re-read it with byte-identical result.
+    # The successful re-read IS flagged: the prior result was already in context.
+    plans += [_row(3, 0, "read_file", "a.c", "int main(){}")]
+    plans += [_row(3, 1, "read_file", "a.c", "int main(){}")]
+    # CONTROL: a budget/limit boundary.
+    plans += [_row(4, 0, "delegate", "review", "request failed: 429 rate limit exceeded")]
+    return plans
+
+
+def _by_plan_parts(incidents):
+    out = {}
+    for inc in incidents:
+        out.setdefault(inc["plan_id"], []).append(inc["part"])
+    return out
+
+
+def self_test():
+    """Red/green check. Each assertion fails loudly so a degenerate classifier
+    (e.g. one that returns nothing, or labels everything 'control') cannot pass."""
+    ok = True
+
+    def check(name, cond):
+        nonlocal ok
+        status = "PASS" if cond else "FAIL"
+        if not cond:
+            ok = False
+        print(f"  [{status}] {name}")
+
+    # 1-4: one synthetic plan per part maps to the right part, and ONLY that part.
+    incidents = classify(_self_test_traces())
+    parts = _by_plan_parts(incidents)
+    for plan, part in ((1, PART_LOOP), (2, PART_TOOL), (3, PART_CONTEXT), (4, PART_CONTROL)):
+        got = parts.get(plan, [])
+        check(f"plan {plan}: {part} and nothing else (got {got or ['(none)']})",
+              got and all(p == part for p in got))
+
+    # 5: read-edit-reread must NOT be flagged. Identical args, but the second read
+    #    returns DIFFERENT bytes (a real edit happened), so it is a valid re-read.
+    rer = classify([
+        _row(5, 0, "read_file", "b.c", "version one"),
+        _row(5, 1, "write_file", "b.c", "wrote b.c"),
+        _row(5, 2, "read_file", "b.c", "version two"),
+    ])
+    check("read-edit-reread (changed bytes) yields no incident", rer == [])
+
+    # 6: control markers are word-bounded. A benign error containing 'room' (which
+    #    bare-substring 'oom' would have mis-matched) must NOT classify as control.
+    room = classify([_row(6, 0, "bash", "curl", "Error: connection refused to room-service")])
+    check("benign 'room' error is not mis-classified as control",
+          all(inc["part"] != PART_CONTROL for inc in room))
+
+    # 6b: an erroring re-issue of an already-succeeded call is the other context path.
+    err_refetch = classify([
+        _row(9, 0, "read_file", "c.c", "data"),
+        _row(9, 1, "read_file", "c.c", "Error: vanished"),
+    ])
+    check("erroring re-issue after a success -> context",
+          any(i["part"] == PART_CONTEXT and i["signal"] == "redundant-refetch"
+              for i in err_refetch))
+
+    # 7: edge cases the code handles but the happy path never exercised.
+    check("empty trace yields no incidents", classify([]) == [])
+    all_ok = classify([_row(7, 0, "read_file", "x", "ok"), _row(7, 1, "grep", "y", "match")])
+    check("all-success trace yields no incidents", all_ok == [])
+    check("render() reports 'no failures detected' on empty input",
+          "no failures detected" in render([]))
+
+    # 8: runaway length with no limit marker -> control, even with zero error rows.
+    runaway = classify([_row(8, t, "step", str(t), "fine") for t in range(RUNAWAY_TURNS + 1)])
+    check("runaway length (no limit marker) -> one control incident",
+          len(runaway) == 1 and runaway[0]["part"] == PART_CONTROL
+          and runaway[0]["signal"] == "runaway-length")
+
+    # 8b: runaway suppression — when a control marker IS present, the limit-marker
+    #     path wins and 'runaway-length' must NOT also fire (locks that branch).
+    long_capped = [_row(10, t, "step", str(t), "fine") for t in range(RUNAWAY_TURNS)]
+    long_capped.append(_row(10, RUNAWAY_TURNS, "delegate", "x", "Error: 429 rate limit"))
+    sigs = {i["signal"] for i in classify(long_capped)}
+    check("runaway with a control marker -> limit-marker, not runaway-length",
+          "limit-marker" in sigs and "runaway-length" not in sigs)
+
+    # 9: argparse's always-plural 'unrecognized arguments' must classify as tool.
+    argp = classify([_row(11, 0, "bash", "tool --z", "error: unrecognized arguments: --z")])
+    check("argparse 'unrecognized arguments' -> tool",
+          any(i["part"] == PART_TOOL for i in argp))
+
+    # 10: control outranks the success-refetch path. A non-error result carrying a
+    #     control marker, re-issued byte-identically, must classify as control
+    #     (limit-marker), NOT as a context redundant-refetch.
+    ctrl_refetch = classify([
+        _row(12, 0, "delegate", "x", "deadline exceeded"),
+        _row(12, 1, "delegate", "x", "deadline exceeded"),
+    ])
+    check("control marker outranks byte-identical refetch -> control, not context",
+          ctrl_refetch and all(i["part"] == PART_CONTROL for i in ctrl_refetch))
+
+    # 11: non-scalar tool_args must not crash the (tool, args) key. A list arg is
+    #     coerced to a stable string key; a true byte-identical refetch still fires.
+    list_args = classify([
+        _row(13, 0, "grep", ["pat", "-r"], "match"),
+        _row(13, 1, "grep", ["pat", "-r"], "match"),
+    ])
+    check("non-hashable (list) tool_args is handled and still detects refetch",
+          any(i["part"] == PART_CONTEXT and i["signal"] == "redundant-refetch"
+              for i in list_args))
+
+    print()
+    print(render(incidents))
+    return 0 if ok else 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("traces", nargs="?",
+                    help="JSON array of trace rows, or '-' for stdin")
+    ap.add_argument("--json", action="store_true", help="emit incidents as JSON")
+    ap.add_argument("--self-test", action="store_true",
+                    help="run synthetic red/green check and exit")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    if not args.traces:
+        ap.error("provide a traces file, '-' for stdin, or --self-test")
+
+    raw = sys.stdin.read() if args.traces == "-" else open(args.traces, encoding="utf-8").read()
+    try:
+        rows = json.loads(raw)
+    except json.JSONDecodeError as e:
+        print(f"error: traces is not valid JSON: {e}", file=sys.stderr)
+        return 2
+    if not isinstance(rows, list):
+        print("error: traces must be a JSON array of trace rows", file=sys.stderr)
+        return 2
+
+    incidents = classify(rows)
+    if args.json:
+        counts, _ = distribution(incidents)
+        print(json.dumps({"incidents": incidents, "distribution": counts}, indent=2))
+    else:
+        print(render(incidents))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/harness/delete_pressure.py
+++ b/scripts/harness/delete_pressure.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""delete_pressure.py: rank harness scaffolding by how much it bets against the
+model, so it can be deleted as models improve.
+
+Premise (the "four-part harness"): every harness component encodes an assumption
+about what the model can't do on its own. As models get better, a good harness
+gets SMALLER, not bigger — the scaffolding that restated the obvious becomes a
+pure context tax (a "token bonfire"). This tool puts a number on that pressure for
+the per-tool prompt augmentations in src/tool_prompts/*.md — the most literal
+"betting against the model" surface in aimee, injected into context on every turn.
+
+Two signals, deliberately separated:
+
+  * STATIC (always available, computed here): tax = how many tokens this scaffold
+    costs every turn, and doubt-density = how prescriptive it is ("Always",
+    "Never", "Avoid", "Do not"...). High tax + high doubt = strong candidate to
+    re-test against a current model and likely delete.
+
+  * RUNTIME (authoritative, needs instrumentation): did removing the scaffold
+    change any outcome? Static signals only NOMINATE; the real verdict is an
+    A/B/hit-rate measurement, which is the in-process counter specced in
+    docs/proposals/pending/four-part-harness-taxonomy.md. This tool ingests that
+    data when given it (--anti-patterns export.json: never-bumped patterns are
+    removal candidates) and is explicit when it is missing rather than pretending
+    the static score is the whole story.
+
+Pure static analysis by default (no build, no runtime). Matches the check-*.py
+house style. Run --self-test for a sanity check on synthetic inputs.
+
+Usage:
+  delete_pressure.py                      # scan src/tool_prompts/
+  delete_pressure.py --dir src/tool_prompts --json
+  delete_pressure.py --anti-patterns ap-export.json
+  delete_pressure.py --self-test
+"""
+import argparse
+import glob
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_DIR = os.path.normpath(os.path.join(HERE, "..", "..", "src", "tool_prompts"))
+
+# Imperative hedges: each one encodes "the model won't do this unless told". The
+# more of these per scaffold, the more it is compensating for a model weakness —
+# exactly what should evaporate as models improve.
+DOUBT_TERMS = (
+    "always", "never", "avoid", "do not", "don't", "must", "only",
+    "prefer", "ensure", "make sure", "be sure", "remember to", "instead of",
+)
+
+# Match whole words only. Bare substring counting over-counts badly ("only" inside
+# "commonly", "must" inside "mustard", "prefer" inside "preferences"), which would
+# inflate the doubt score of perfectly ordinary prose. Word boundaries are placed
+# on the word-character edges, so multi-word and apostrophe terms still match.
+DOUBT_RE = re.compile(
+    r"\b(?:" + "|".join(re.escape(t) for t in DOUBT_TERMS) + r")\b")
+
+
+# Rough token estimate without a tokenizer dep: ~0.75 words/token for English.
+def est_tokens(text):
+    words = len(re.findall(r"\S+", text))
+    return max(1, round(words / 0.75))
+
+
+def doubt_hits(text):
+    return len(DOUBT_RE.findall(text.lower()))
+
+
+def score_scaffold(name, text):
+    text = text.strip()
+    tokens = est_tokens(text)
+    doubt = doubt_hits(text)
+    words = len(re.findall(r"\S+", text))
+    # Doubt density per 20 words, so a short prescriptive line scores like a long
+    # one. Pressure blends per-turn tax with prescriptiveness.
+    density = (doubt / words * 20) if words else 0.0
+    pressure = round(tokens * (1.0 + density), 1)
+    return {
+        "name": name,
+        "tokens_per_turn": tokens,
+        "words": words,
+        "doubt_terms": doubt,
+        "doubt_density_per20w": round(density, 2),
+        "pressure": pressure,
+    }
+
+
+def scan_dir(path):
+    rows = []
+    for fp in sorted(glob.glob(os.path.join(path, "*.md"))):
+        name = os.path.splitext(os.path.basename(fp))[0]
+        with open(fp, encoding="utf-8") as fh:
+            rows.append(score_scaffold(name, fh.read()))
+    return rows
+
+
+def load_anti_patterns(path):
+    """Optional runtime signal. Expects a JSON array of anti-pattern rows with at
+    least {pattern, hit_count|bumps, last_seen?}. Never-bumped = removal candidate.
+    Shape matches src/db2/anti_patterns.h (db2_anti_pattern_list output).
+
+    Returns None on any load error (unreadable, bad JSON, not a JSON array) so the
+    caller can fail loudly rather than silently fall back to static-only. A row that
+    carries NONE of hit_count/bumps/hits gets hits=None ("unknown"), kept distinct
+    from a genuine 0 — a schema mismatch must not turn every row into a bogus
+    "never matched, delete it" recommendation."""
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"error: cannot read anti-patterns export {path}: {e}", file=sys.stderr)
+        return None
+    if not isinstance(data, list):
+        print(f"error: anti-patterns export must be a JSON array, got "
+              f"{type(data).__name__}", file=sys.stderr)
+        return None
+    out = []
+    for ap in data:
+        if not isinstance(ap, dict):
+            continue
+        hits = None
+        for k in ("hit_count", "bumps", "hits"):
+            if k in ap:
+                hits = ap[k]
+                break
+        out.append({
+            "pattern": ap.get("pattern", "?"),
+            "hits": hits,
+            "has_count": hits is not None,
+            "source": ap.get("source", ""),
+            "last_seen": ap.get("last_seen", ""),
+        })
+    return out
+
+
+def render(rows, ap_rows):
+    out = []
+    total_tax = sum(r["tokens_per_turn"] for r in rows)
+    out.append(f"Tool-prompt scaffolding: {len(rows)} scaffolds, "
+               f"~{total_tax} tokens injected every turn.\n")
+    name_w = max((len(r["name"]) for r in rows), default=4)
+    out.append(f"  {'scaffold'.ljust(name_w)}  tok/turn  doubt  pressure")
+    for r in sorted(rows, key=lambda x: -x["pressure"]):
+        out.append(f"  {r['name'].ljust(name_w)}  {r['tokens_per_turn']:8d}  "
+                   f"{r['doubt_terms']:5d}  {r['pressure']:8.1f}")
+    out.append("")
+    ranked = sorted(rows, key=lambda x: -x["pressure"])
+    if ranked:
+        out.append("Highest delete-pressure (re-test against a current model first):")
+        for r in ranked[:3]:
+            out.append(f"  - {r['name']}: {r['tokens_per_turn']} tok/turn, "
+                       f"{r['doubt_terms']} prescriptive term(s)")
+    out.append("")
+    if ap_rows is None:
+        out.append("Runtime signal: not provided. Static pressure only NOMINATES "
+                   "scaffolds; the authoritative test is whether removing one changes "
+                   "an outcome. Pass --anti-patterns <export.json> to fold in hit-rate, "
+                   "or wire the in-process counter from the taxonomy proposal.")
+    else:
+        # Only a present-and-zero count makes a pattern a removal candidate. Rows
+        # with no count field at all (hits is None) are malformed/schema-mismatched,
+        # not "never matched" — surfacing them as such would recommend deleting live
+        # patterns wholesale.
+        dead = [a for a in ap_rows if a["hits"] == 0]
+        unknown = [a for a in ap_rows if a["hits"] is None]
+        out.append(f"Runtime signal: {len(ap_rows)} anti-patterns, "
+                   f"{len(dead)} never matched (removal candidates):")
+        for a in dead[:10]:
+            out.append(f"  - never-hit: {a['pattern'][:70]}")
+        if unknown:
+            out.append(f"  ({len(unknown)} row(s) had no hit_count/bumps/hits field "
+                       f"— excluded from removal candidates; check the export schema)")
+    return "\n".join(out)
+
+
+def _self_test():
+    ok = True
+
+    def check(name, cond):
+        nonlocal ok
+        if not cond:
+            ok = False
+        print(f"  [{'PASS' if cond else 'FAIL'}] {name}")
+
+    # Length and prescriptiveness must not be confounded: hold word count fixed and
+    # vary ONLY bossiness. The bossy one must score strictly higher on doubt and
+    # pressure, proving the score reacts to prescriptiveness, not just length.
+    plain = score_scaffold("plain", "Set the path here. List the directory once. Write the file.")
+    bossy = score_scaffold("bossy", "Always set the path. Never list the directory. Do not write.")
+    check(f"equal-length: bossy out-doubts plain "
+          f"({plain['doubt_terms']} vs {bossy['doubt_terms']})",
+          plain["words"] == bossy["words"] and bossy["doubt_terms"] > plain["doubt_terms"])
+    check(f"equal-length: bossy out-pressures plain "
+          f"({plain['pressure']} vs {bossy['pressure']})",
+          bossy["pressure"] > plain["pressure"])
+    check("plain prose registers zero doubt", plain["doubt_terms"] == 0)
+
+    # Word-boundary matching: ordinary words that merely CONTAIN a doubt term must
+    # not count. Without this guard 'commonly'/'mustard'/'preferences' would score.
+    trap = score_scaffold("trap", "Commonly used mustard preferences are listed here.")
+    check("substrings of doubt terms do not count (commonly/mustard/preferences)",
+          trap["doubt_terms"] == 0)
+
+    # Anti-pattern rows with NO count field must be 'unknown', not a removal
+    # candidate: a schema mismatch must not recommend deleting live patterns. Only a
+    # present-and-zero count counts as 'never matched'.
+    rows = [score_scaffold("x", "noop")]
+    ap_rows = [
+        {"pattern": "real-zero", "hits": 0, "has_count": True},
+        {"pattern": "schema-mismatch", "hits": None, "has_count": False},
+    ]
+    out = render(rows, ap_rows)
+    check("present-zero count is a removal candidate", "never-hit: real-zero" in out)
+    check("missing-count row is excluded, flagged as schema issue",
+          "never-hit: schema-mismatch" not in out and "1 never matched" in out
+          and "check the export schema" in out)
+
+    return 0 if ok else 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--dir", default=DEFAULT_DIR,
+                    help=f"directory of *.md scaffolds (default: {DEFAULT_DIR})")
+    ap.add_argument("--anti-patterns", metavar="JSON",
+                    help="optional anti-pattern export to fold in runtime hit-rate")
+    ap.add_argument("--json", action="store_true", help="emit JSON")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    if args.self_test:
+        return _self_test()
+
+    if not os.path.isdir(args.dir):
+        print(f"error: not a directory: {args.dir}", file=sys.stderr)
+        return 2
+    rows = scan_dir(args.dir)
+    ap_rows = None
+    if args.anti_patterns:
+        ap_rows = load_anti_patterns(args.anti_patterns)
+        if ap_rows is None:  # load printed the error already
+            return 2
+
+    if args.json:
+        print(json.dumps({"scaffolds": rows, "anti_patterns": ap_rows}, indent=2))
+    else:
+        print(render(rows, ap_rows))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What

Adopts one vocabulary for the whole agent harness — **loop / tool interface /
context management / control** — and ships two runnable reference tools that turn
two slogans into measured numbers:

- `scripts/harness/classify_failures.py` — attributes each failed agent run to one
  of the four parts. Heuristics mirror `src/trace_analysis.c` (`RETRY_THRESHOLD`,
  the `result_looks_like_error` markers) so the specced in-process C port stays
  faithful. Reads `aimee trajectory export --json` or any trace JSON.
- `scripts/harness/delete_pressure.py` — ranks the per-tool prompt scaffolding in
  `src/tool_prompts/` by per-turn token tax and whole-word "doubt density", so the
  harness can shrink as models improve. Static pressure only *nominates*; the
  authoritative signal is the runtime anti-pattern hit-rate / scaffold A/B (specced).

The proposal classifies every major subsystem as a durable bet (memory, KB,
guardrails, isolation) or a delete-pressure candidate (tool prompts, anti-pattern
advisories, packing heuristics). The in-process C ports and the A/B harness are
scoped as explicit follow-ons — they need the build toolchain and a live DB1/DB2
the reference tools deliberately do not.

## Scope

This PR is the proposal's Phase-1 / reference-tooling slice: the vocabulary, the
subsystem map, and the two verified reference tools. The C ports (`aimee trajectory
classify`, `aimee guardrails anti-patterns export`) and the scaffold A/B harness are
named follow-ons, out of scope here.

## Review

Converged through two adversarial multi-lens roundtable rounds plus a third **live
multi-model roundtable** round over the `/v1` panel. Deciding round-3 findings folded:

- non-scalar `tool_args` no longer crashes the `(tool, args)` key (coerced to a
  stable string key);
- `control` now outranks the success-refetch path (the "control wins" invariant had
  a hole for non-error results carrying a control marker);
- a malformed/schema-mismatched anti-pattern export no longer reads as bulk
  "never matched" removals (missing count is kept distinct from a genuine zero);
- `--anti-patterns` now validates input and fails loudly instead of silently
  degrading.

## Test plan

- `python3 scripts/harness/classify_failures.py --self-test` → 15/15 PASS, exit 0
- `python3 scripts/harness/delete_pressure.py --self-test` → 6/6 PASS, exit 0
- `python3 scripts/harness/delete_pressure.py` → 8 scaffolds, ~207 tok/turn fixed
  tax, ranked candidates printed
- Grounding re-checked against `src/trace_analysis.c`, `src/db1/execution_trace.h`,
  `src/db2/anti_patterns.h`, `src/tool_prompts/`

Pure Python; no build or aimee runtime required.
