### PR TITLE
fix(webchat): make the tmux CLI path work for the claude TUI on a fresh container

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -79,6 +79,16 @@ void cli_session_mark_baseline(cli_session_t *s);
 int cli_session_create(cli_session_t *s, const char *session_name, const char *cli_cmd,
                        const char *work_dir, int reuse);
 
+/* Pre-seed claude-code's config so its interactive TUI starts straight at the
+ * prompt instead of blocking on first-run gates the headless `claude -p` path
+ * skipped: onboarding, the --dangerously-skip-permissions warning, and the
+ * per-workspace "trust this folder?" dialog. aimee runs each session in its own
+ * (fresh) worktree, so the trust dialog re-appears every session and wedges the
+ * pane; this trusts `work_dir`. Best-effort and idempotent — never fails the
+ * turn (a worst case just re-shows a prompt). Call before creating a claude
+ * session. No-op for non-claude providers (caller gates on cli_kind). */
+void cli_session_prepare_claude(const char *work_dir);
+
 /* Kills the tmux session. No-op if already dead. */
 void cli_session_destroy(cli_session_t *s);
 

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -91,11 +91,23 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
     * config default or the per-request override the chat worker wrote onto the
     * agent — without this the CLI would launch with its own built-in default. */
    const char *base_cmd = agent->cli_cmd[0] ? agent->cli_cmd : "claude";
+   const char *kind = agent->cli_kind[0] ? agent->cli_kind : agent->name;
+   int is_claude = strstr(kind, "claude") != NULL;
    char cli_cmd_buf[CLI_SESSION_CMD_MAX];
    const char *cli_cmd = base_cmd;
-   if (agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m "))
+   int need_model = agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m ");
+   /* claude runs autonomously here (no human to approve tools) inside a
+    * sandboxed container, so bypass its permission prompts — unless the launch
+    * command already selects a permission mode. Mirrors the legacy `claude -p`
+    * path, which always passed this. The matching first-run acceptances are
+    * seeded by cli_session_prepare_claude() below. */
+   int need_skip = is_claude && !strstr(base_cmd, "--dangerously-skip-permissions") &&
+                   !strstr(base_cmd, "--permission-mode");
+   if (need_model || need_skip)
    {
-      snprintf(cli_cmd_buf, sizeof(cli_cmd_buf), "%s --model %s", base_cmd, agent->model);
+      snprintf(cli_cmd_buf, sizeof(cli_cmd_buf), "%s%s%s%s", base_cmd,
+               need_model ? " --model " : "", need_model ? agent->model : "",
+               need_skip ? " --dangerously-skip-permissions" : "");
       cli_cmd = cli_cmd_buf;
    }
 
@@ -108,6 +120,12 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       snprintf(cwd, sizeof(cwd), "%s", turn_cwd);
    else if (getcwd(cwd, sizeof(cwd)) == NULL)
       cwd[0] = '\0';
+
+   /* Seed claude-code's first-run gates (onboarding / bypass warning / per-
+    * folder trust for this worktree) so its interactive TUI starts at the
+    * prompt instead of wedging the pane. Best-effort; no-op for other CLIs. */
+   if (is_claude)
+      cli_session_prepare_claude(cwd);
 
    cli_session_t sess;
    int rc = cli_session_create(&sess, sess_name, cli_cmd, cwd, reuse);

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -92,7 +92,10 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
     * agent — without this the CLI would launch with its own built-in default. */
    const char *base_cmd = agent->cli_cmd[0] ? agent->cli_cmd : "claude";
    const char *kind = agent->cli_kind[0] ? agent->cli_kind : agent->name;
-   int is_claude = strstr(kind, "claude") != NULL;
+   /* Exact "claude" or a "claude-*" variant (claude-code / claude-oauth) — NOT a
+    * substring match: this gates --dangerously-skip-permissions and the config
+    * seeding, so it must not fire for an unrelated agent named e.g. "claudette". */
+   int is_claude = strcmp(kind, "claude") == 0 || strncmp(kind, "claude-", 7) == 0;
    char cli_cmd_buf[CLI_SESSION_CMD_MAX];
    const char *cli_cmd = base_cmd;
    int need_model = agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m ");

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -3,12 +3,16 @@
 #define _GNU_SOURCE
 #endif
 #include "aimee.h"
+#include "cJSON.h"
 #include "cli_session.h"
 #include "util.h"
 #include "workspace_provider.h"
+#include <fcntl.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/file.h>
+#include <sys/stat.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -146,6 +150,162 @@ int cli_session_is_alive(const cli_session_t *s)
    return rc == 0;
 }
 
+/* --- claude-code TUI first-run gate seeding ------------------------------- */
+
+/* HOME the CLI agents run under: $AIMEE_HOME (where server_cli_oauth installs
+ * the npm prefix + ~/.claude tokens) else the image default. Mirrors
+ * server_cli_oauth.c's home_dir(). */
+static const char *cli_claude_home(void)
+{
+   const char *h = getenv("AIMEE_HOME");
+   return (h && h[0]) ? h : "/var/lib/aimee";
+}
+
+/* Read an entire file into a malloc'd NUL-terminated string (caller frees), or
+ * NULL if it does not exist / cannot be read. */
+static char *cli_read_file(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long n = ftell(f);
+   if (n < 0 || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = malloc((size_t)n + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t rd = fread(buf, 1, (size_t)n, f);
+   fclose(f);
+   buf[rd] = '\0';
+   return buf;
+}
+
+/* Atomically replace `path` with `data` (temp sibling + rename). 0 on success. */
+static int cli_write_file_atomic(const char *path, const char *data)
+{
+   char tmp[1280];
+   snprintf(tmp, sizeof(tmp), "%s.aimee.tmp.%d", path, (int)getpid());
+   FILE *f = fopen(tmp, "wb");
+   if (!f)
+      return -1;
+   size_t len = strlen(data);
+   int ok = (fwrite(data, 1, len, f) == len);
+   if (fclose(f) != 0)
+      ok = 0;
+   if (!ok || rename(tmp, path) != 0)
+   {
+      unlink(tmp);
+      return -1;
+   }
+   return 0;
+}
+
+/* Ensure an object has a boolean key set to true; returns 1 if it changed it. */
+static int cli_json_set_true(cJSON *obj, const char *key)
+{
+   cJSON *cur = cJSON_GetObjectItemCaseSensitive(obj, key);
+   if (cJSON_IsTrue(cur))
+      return 0;
+   cJSON_DeleteItemFromObject(obj, key);
+   cJSON_AddTrueToObject(obj, key);
+   return 1;
+}
+
+void cli_session_prepare_claude(const char *work_dir)
+{
+   const char *home = cli_claude_home();
+   char claude_dir[1024], lockpath[1100], jsonpath[1100], setpath[1100];
+   snprintf(claude_dir, sizeof(claude_dir), "%s/.claude", home);
+   snprintf(lockpath, sizeof(lockpath), "%s/.aimee-prep.lock", claude_dir);
+   snprintf(jsonpath, sizeof(jsonpath), "%s/.claude.json", home);
+   snprintf(setpath, sizeof(setpath), "%s/settings.json", claude_dir);
+
+   /* Best-effort: an unwritable home just means claude shows its prompts —
+    * never fail the turn over it. */
+   mkdir(claude_dir, 0700); /* ignore EEXIST */
+
+   /* Concurrent turns all read-modify-write the same two files; serialize. */
+   int lf = open(lockpath, O_CREAT | O_RDWR | O_CLOEXEC, 0600);
+   if (lf >= 0)
+      flock(lf, LOCK_EX);
+
+   /* ~/.claude.json: mark onboarding done + trust this (per-session) worktree. */
+   char *txt = cli_read_file(jsonpath);
+   cJSON *root = txt ? cJSON_Parse(txt) : NULL;
+   free(txt);
+   if (!root)
+      root = cJSON_CreateObject();
+   if (root)
+   {
+      int changed = cli_json_set_true(root, "hasCompletedOnboarding");
+      if (work_dir && work_dir[0])
+      {
+         cJSON *projects = cJSON_GetObjectItemCaseSensitive(root, "projects");
+         if (!cJSON_IsObject(projects))
+         {
+            cJSON_DeleteItemFromObject(root, "projects");
+            projects = cJSON_AddObjectToObject(root, "projects");
+         }
+         cJSON *proj = projects ? cJSON_GetObjectItemCaseSensitive(projects, work_dir) : NULL;
+         if (projects && !cJSON_IsObject(proj))
+         {
+            cJSON_DeleteItemFromObject(projects, work_dir);
+            proj = cJSON_AddObjectToObject(projects, work_dir);
+         }
+         if (proj)
+            changed |= cli_json_set_true(proj, "hasTrustDialogAccepted");
+      }
+      if (changed)
+      {
+         char *out = cJSON_Print(root);
+         if (out)
+         {
+            cli_write_file_atomic(jsonpath, out);
+            free(out);
+         }
+      }
+      cJSON_Delete(root);
+   }
+
+   /* ~/.claude/settings.json: pre-accept the bypass-permissions warning so a
+    * --dangerously-skip-permissions launch starts straight at the prompt. */
+   char *stxt = cli_read_file(setpath);
+   cJSON *sroot = stxt ? cJSON_Parse(stxt) : NULL;
+   free(stxt);
+   if (!sroot)
+      sroot = cJSON_CreateObject();
+   if (sroot)
+   {
+      if (cli_json_set_true(sroot, "skipDangerousModePermissionPrompt"))
+      {
+         char *out = cJSON_Print(sroot);
+         if (out)
+         {
+            cli_write_file_atomic(setpath, out);
+            free(out);
+         }
+      }
+      cJSON_Delete(sroot);
+   }
+
+   if (lf >= 0)
+   {
+      flock(lf, LOCK_UN);
+      close(lf);
+   }
+}
+
 int cli_session_create(cli_session_t *s, const char *session_name, const char *cli_cmd,
                        const char *work_dir, int reuse)
 {
@@ -165,21 +325,29 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
    /* Create new tmux session running the CLI directly rather than via an
     * interactive shell prompt. That avoids a race where the first user
     * message lands before the CLI is fully attached and also keeps shell
-    * prompts out of captured output. */
+    * prompts out of captured output.
+    *
+    * Use `/bin/sh -c` (NOT `-lc`): a login shell sources /etc/profile, which on
+    * Debian resets PATH to a bare default and discards the image's
+    * `ENV PATH=.../.npm-global/bin:$PATH`. The on-demand CLI agents (claude /
+    * codex) install into that npm prefix, so a login shell can no longer find
+    * them and the pane exits instantly ("failed to send prompt to tmux
+    * session"). A non-login shell inherits the tmux server's env (= aimee-
+    * server's, which carries the image PATH), so the CLI resolves. */
    char create_cmd[512];
    char *esc_cli = shell_escape(cli_cmd && cli_cmd[0] ? cli_cmd : "claude");
    if (work_dir && work_dir[0])
    {
       char *esc_dir = shell_escape(work_dir);
       snprintf(create_cmd, sizeof(create_cmd),
-               "tmux new-session -d -s '%s' -x 220 -y 50 -c %s /bin/sh -lc %s 2>/dev/null",
+               "tmux new-session -d -s '%s' -x 220 -y 50 -c %s /bin/sh -c %s 2>/dev/null",
                session_name, esc_dir, esc_cli);
       free(esc_dir);
    }
    else
    {
       snprintf(create_cmd, sizeof(create_cmd),
-               "tmux new-session -d -s '%s' -x 220 -y 50 /bin/sh -lc %s 2>/dev/null", session_name,
+               "tmux new-session -d -s '%s' -x 220 -y 50 /bin/sh -c %s 2>/dev/null", session_name,
                esc_cli);
    }
    free(esc_cli);

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -8,6 +8,8 @@
 #include "util.h"
 #include "workspace_provider.h"
 #include <fcntl.h>
+#include <limits.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -152,17 +154,25 @@ int cli_session_is_alive(const cli_session_t *s)
 
 /* --- claude-code TUI first-run gate seeding ------------------------------- */
 
-/* HOME the CLI agents run under: $AIMEE_HOME (where server_cli_oauth installs
- * the npm prefix + ~/.claude tokens) else the image default. Mirrors
- * server_cli_oauth.c's home_dir(). */
+/* HOME the claude TUI reads its config from. The pane inherits the server's
+ * env, and claude-code resolves ~/.claude{,.json} via $HOME — so seed there to
+ * be sure the TUI sees it. Prefer $HOME (what claude reads), then $AIMEE_HOME
+ * (where server_cli_oauth installs the npm prefix + tokens; equals $HOME on the
+ * standard image), then the image default. */
 static const char *cli_claude_home(void)
 {
-   const char *h = getenv("AIMEE_HOME");
+   const char *h = getenv("HOME");
+   if (h && h[0])
+      return h;
+   h = getenv("AIMEE_HOME");
    return (h && h[0]) ? h : "/var/lib/aimee";
 }
 
 /* Read an entire file into a malloc'd NUL-terminated string (caller frees), or
- * NULL if it does not exist / cannot be read. */
+ * NULL if it does not exist / cannot be read. ~/.claude.json accumulates session
+ * history and can grow large; cap the read (oversize → NULL → seeding skipped,
+ * per the best-effort contract) rather than slurp unbounded. */
+#define CLI_CLAUDE_CFG_MAX (16 * 1024 * 1024)
 static char *cli_read_file(const char *path)
 {
    FILE *f = fopen(path, "rb");
@@ -174,7 +184,7 @@ static char *cli_read_file(const char *path)
       return NULL;
    }
    long n = ftell(f);
-   if (n < 0 || fseek(f, 0, SEEK_SET) != 0)
+   if (n < 0 || n > CLI_CLAUDE_CFG_MAX || fseek(f, 0, SEEK_SET) != 0)
    {
       fclose(f);
       return NULL;
@@ -191,14 +201,25 @@ static char *cli_read_file(const char *path)
    return buf;
 }
 
-/* Atomically replace `path` with `data` (temp sibling + rename). 0 on success. */
+/* Atomically replace `path` with `data` (temp sibling + rename). The file holds
+ * claude's oauth account/trust state, so create the temp 0600 (rename keeps the
+ * temp's mode, not the destination's — a plain fopen()+umask would downgrade an
+ * existing 0600 config to 0644). 0 on success. */
 static int cli_write_file_atomic(const char *path, const char *data)
 {
-   char tmp[1280];
-   snprintf(tmp, sizeof(tmp), "%s.aimee.tmp.%d", path, (int)getpid());
-   FILE *f = fopen(tmp, "wb");
-   if (!f)
+   char tmp[PATH_MAX];
+   if ((size_t)snprintf(tmp, sizeof(tmp), "%s.aimee.tmp.%d", path, (int)getpid()) >= sizeof(tmp))
       return -1;
+   int fd = open(tmp, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0600);
+   if (fd < 0)
+      return -1;
+   FILE *f = fdopen(fd, "wb");
+   if (!f)
+   {
+      close(fd);
+      unlink(tmp);
+      return -1;
+   }
    size_t len = strlen(data);
    int ok = (fwrite(data, 1, len, f) == len);
    if (fclose(f) != 0)
@@ -222,10 +243,31 @@ static int cli_json_set_true(cJSON *obj, const char *key)
    return 1;
 }
 
+/* Load a claude config file for read-modify-write. Returns the parsed object
+ * (caller cJSON_Delete's), or NULL with *skip=1 when the file EXISTS but won't
+ * parse — claude-code writes ~/.claude.json non-atomically, so a concurrent
+ * read can catch it mid-write; clobbering it with a fresh {} would wipe the
+ * oauth account, trust map, and session history. In that case do nothing and
+ * try again next turn. A genuinely absent file returns a fresh object. */
+static cJSON *cli_claude_cfg_load(const char *path, int *skip)
+{
+   *skip = 0;
+   char *txt = cli_read_file(path);
+   int existed = (txt != NULL);
+   cJSON *root = txt ? cJSON_Parse(txt) : NULL;
+   free(txt);
+   if (existed && !root)
+   {
+      *skip = 1;
+      return NULL;
+   }
+   return root ? root : cJSON_CreateObject();
+}
+
 void cli_session_prepare_claude(const char *work_dir)
 {
    const char *home = cli_claude_home();
-   char claude_dir[1024], lockpath[1100], jsonpath[1100], setpath[1100];
+   char claude_dir[PATH_MAX], lockpath[PATH_MAX], jsonpath[PATH_MAX], setpath[PATH_MAX];
    snprintf(claude_dir, sizeof(claude_dir), "%s/.claude", home);
    snprintf(lockpath, sizeof(lockpath), "%s/.aimee-prep.lock", claude_dir);
    snprintf(jsonpath, sizeof(jsonpath), "%s/.claude.json", home);
@@ -235,17 +277,21 @@ void cli_session_prepare_claude(const char *work_dir)
     * never fail the turn over it. */
    mkdir(claude_dir, 0700); /* ignore EEXIST */
 
-   /* Concurrent turns all read-modify-write the same two files; serialize. */
+   /* Two layers of mutual exclusion for the read-modify-write below:
+    *  - g_prep_mu serializes threads in THIS process. flock(2) alone does not:
+    *    each thread open()s its own description, and while a second flock would
+    *    block on the first, the temp path in cli_write_file_atomic keys on pid
+    *    only — same-process threads would collide on it. The mutex closes that.
+    *  - flock serializes across processes (a second server / a manual edit). */
+   static pthread_mutex_t g_prep_mu = PTHREAD_MUTEX_INITIALIZER;
+   pthread_mutex_lock(&g_prep_mu);
    int lf = open(lockpath, O_CREAT | O_RDWR | O_CLOEXEC, 0600);
    if (lf >= 0)
       flock(lf, LOCK_EX);
 
    /* ~/.claude.json: mark onboarding done + trust this (per-session) worktree. */
-   char *txt = cli_read_file(jsonpath);
-   cJSON *root = txt ? cJSON_Parse(txt) : NULL;
-   free(txt);
-   if (!root)
-      root = cJSON_CreateObject();
+   int skip = 0;
+   cJSON *root = cli_claude_cfg_load(jsonpath, &skip);
    if (root)
    {
       int changed = cli_json_set_true(root, "hasCompletedOnboarding");
@@ -280,11 +326,7 @@ void cli_session_prepare_claude(const char *work_dir)
 
    /* ~/.claude/settings.json: pre-accept the bypass-permissions warning so a
     * --dangerously-skip-permissions launch starts straight at the prompt. */
-   char *stxt = cli_read_file(setpath);
-   cJSON *sroot = stxt ? cJSON_Parse(stxt) : NULL;
-   free(stxt);
-   if (!sroot)
-      sroot = cJSON_CreateObject();
+   cJSON *sroot = cli_claude_cfg_load(setpath, &skip);
    if (sroot)
    {
       if (cli_json_set_true(sroot, "skipDangerousModePermissionPrompt"))
@@ -304,6 +346,7 @@ void cli_session_prepare_claude(const char *work_dir)
       flock(lf, LOCK_UN);
       close(lf);
    }
+   pthread_mutex_unlock(&g_prep_mu);
 }
 
 int cli_session_create(cli_session_t *s, const char *session_name, const char *cli_cmd,
@@ -334,7 +377,7 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
     * them and the pane exits instantly ("failed to send prompt to tmux
     * session"). A non-login shell inherits the tmux server's env (= aimee-
     * server's, which carries the image PATH), so the CLI resolves. */
-   char create_cmd[512];
+   char create_cmd[1024];
    char *esc_cli = shell_escape(cli_cmd && cli_cmd[0] ? cli_cmd : "claude");
    if (work_dir && work_dir[0])
    {

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -555,6 +555,7 @@ static void test_prepare_claude_seeds_gates(void)
 {
    char home[] = "/tmp/aimee_clitest_XXXXXX";
    assert(mkdtemp(home) != NULL);
+   setenv("HOME", home, 1); /* cli_claude_home() resolves HOME first */
    setenv("AIMEE_HOME", home, 1);
    const char *wt = "/tmp/aimee_clitest_wt/session-abc";
 
@@ -599,6 +600,7 @@ static void test_prepare_claude_preserves_existing_settings(void)
 {
    char home[] = "/tmp/aimee_clitest_XXXXXX";
    assert(mkdtemp(home) != NULL);
+   setenv("HOME", home, 1); /* cli_claude_home() resolves HOME first */
    setenv("AIMEE_HOME", home, 1);
 
    char dir[512], p[600];
@@ -624,6 +626,33 @@ static void test_prepare_claude_preserves_existing_settings(void)
    cJSON_Delete(sroot);
 }
 
+/* B1 regression: a config file that EXISTS but won't parse (claude-code writes
+ * ~/.claude.json non-atomically, so a concurrent read can catch it mid-write)
+ * must NOT be clobbered with a fresh {} — that would wipe the oauth account,
+ * trust map, and history. prepare must leave it byte-for-byte untouched. */
+static void test_prepare_claude_skips_unparseable_config(void)
+{
+   char home[] = "/tmp/aimee_clitest_XXXXXX";
+   assert(mkdtemp(home) != NULL);
+   setenv("HOME", home, 1);
+   setenv("AIMEE_HOME", home, 1);
+
+   const char *corrupt = "{\"oauthAccount\":{\"emailAddress\":\"u@x\"},\"projects\":{ truncated";
+   char jp[600];
+   snprintf(jp, sizeof(jp), "%s/.claude.json", home);
+   FILE *f = fopen(jp, "wb");
+   assert(f != NULL);
+   fputs(corrupt, f);
+   fclose(f);
+
+   cli_session_prepare_claude("/tmp/aimee_clitest_wt3");
+
+   char *after = slurp(jp);
+   assert(after != NULL);
+   assert(strcmp(after, corrupt) == 0); /* untouched, not wiped to {} */
+   free(after);
+}
+
 int main(void)
 {
    printf("test_prepare_claude_seeds_gates... ");
@@ -632,6 +661,10 @@ int main(void)
 
    printf("test_prepare_claude_preserves_existing_settings... ");
    test_prepare_claude_preserves_existing_settings();
+   printf("OK\n");
+
+   printf("test_prepare_claude_skips_unparseable_config... ");
+   test_prepare_claude_skips_unparseable_config();
    printf("OK\n");
 
    printf("test_extract_claude_basic... ");

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -1,4 +1,7 @@
 /* test_cli_session.c: unit tests for cli_session pure-C functions */
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
 #include <assert.h>
 #include <stdio.h>
 #include <string.h>
@@ -6,6 +9,7 @@
 #include <unistd.h>
 #include <time.h>
 #include <sys/stat.h>
+#include "cJSON.h"
 #include "cli_session.h"
 
 /* --- cli_session_recv timeout tests ---
@@ -530,8 +534,106 @@ static void test_extract_baseline_substring_kept(void)
    free(r);
 }
 
+/* --- cli_session_prepare_claude: claude-code first-run gate seeding --- */
+
+static char *slurp(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   fseek(f, 0, SEEK_END);
+   long n = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   char *b = malloc((size_t)n + 1);
+   size_t rd = fread(b, 1, (size_t)n, f);
+   fclose(f);
+   b[rd] = '\0';
+   return b;
+}
+
+static void test_prepare_claude_seeds_gates(void)
+{
+   char home[] = "/tmp/aimee_clitest_XXXXXX";
+   assert(mkdtemp(home) != NULL);
+   setenv("AIMEE_HOME", home, 1);
+   const char *wt = "/tmp/aimee_clitest_wt/session-abc";
+
+   cli_session_prepare_claude(wt);
+
+   char p[512];
+   snprintf(p, sizeof(p), "%s/.claude.json", home);
+   char *j = slurp(p);
+   assert(j != NULL);
+   cJSON *root = cJSON_Parse(j);
+   free(j);
+   assert(root != NULL);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(root, "hasCompletedOnboarding")));
+   cJSON *projects = cJSON_GetObjectItemCaseSensitive(root, "projects");
+   assert(cJSON_IsObject(projects));
+   cJSON *proj = cJSON_GetObjectItemCaseSensitive(projects, wt);
+   assert(cJSON_IsObject(proj));
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(proj, "hasTrustDialogAccepted")));
+   cJSON_Delete(root);
+
+   snprintf(p, sizeof(p), "%s/.claude/settings.json", home);
+   char *s = slurp(p);
+   assert(s != NULL);
+   cJSON *sroot = cJSON_Parse(s);
+   free(s);
+   assert(sroot != NULL);
+   assert(
+       cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(sroot, "skipDangerousModePermissionPrompt")));
+   cJSON_Delete(sroot);
+
+   /* Idempotent: a second call leaves the same state (and must not throw). */
+   cli_session_prepare_claude(wt);
+   snprintf(p, sizeof(p), "%s/.claude.json", home);
+   j = slurp(p);
+   root = cJSON_Parse(j);
+   free(j);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(root, "hasCompletedOnboarding")));
+   cJSON_Delete(root);
+}
+
+static void test_prepare_claude_preserves_existing_settings(void)
+{
+   char home[] = "/tmp/aimee_clitest_XXXXXX";
+   assert(mkdtemp(home) != NULL);
+   setenv("AIMEE_HOME", home, 1);
+
+   char dir[512], p[600];
+   snprintf(dir, sizeof(dir), "%s/.claude", home);
+   assert(mkdir(dir, 0700) == 0);
+   snprintf(p, sizeof(p), "%s/settings.json", dir);
+   FILE *f = fopen(p, "wb");
+   assert(f != NULL);
+   fputs("{\"theme\":\"dark\"}", f);
+   fclose(f);
+
+   cli_session_prepare_claude("/tmp/aimee_clitest_wt2");
+
+   char *s = slurp(p);
+   cJSON *sroot = cJSON_Parse(s);
+   free(s);
+   assert(sroot != NULL);
+   /* pre-existing key kept, new acceptance added */
+   cJSON *theme = cJSON_GetObjectItemCaseSensitive(sroot, "theme");
+   assert(cJSON_IsString(theme) && strcmp(theme->valuestring, "dark") == 0);
+   assert(
+       cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(sroot, "skipDangerousModePermissionPrompt")));
+   cJSON_Delete(sroot);
+}
+
 int main(void)
 {
+   printf("test_prepare_claude_seeds_gates... ");
+   test_prepare_claude_seeds_gates();
+   printf("OK\n");
+
+   printf("test_prepare_claude_preserves_existing_settings... ");
+   test_prepare_claude_preserves_existing_settings();
+   printf("OK\n");
+
    printf("test_extract_claude_basic... ");
    test_extract_claude_basic();
    printf("OK\n");


### PR DESCRIPTION
## Problem

The #607 tmux TUI path launches `claude` as an interactive terminal. On a freshly-built container (e.g. after a clean image deploy) it fails **every** webchat turn with `Error: server: failed to send prompt to tmux session`. Two first-run gates the old `claude -p` path never hit:

1. **Login shell strips the image PATH.** `cli_session_create` launched the CLI via `/bin/sh -lc`. A login shell sources `/etc/profile`, which on Debian resets `PATH` to a bare default and discards the image's `ENV PATH=.../.npm-global/bin:$PATH`. The on-demand-installed `claude`/`codex` live in that npm prefix, so the login shell can't find them → the pane exits instantly → the tmux session dies → `tmux load-buffer` fails → the error above.

2. **claude-code TUI first-run gates.** The interactive TUI blocks autonomous use behind onboarding, the `--dangerously-skip-permissions` warning, and a per-workspace **"trust this folder?"** dialog. aimee runs each session in its own (fresh) worktree, so the trust dialog re-appears every session and wedges the pane. `claude -p` (print mode) skipped all of these.

## Fix

- `cli_session.c`: launch the CLI via `/bin/sh -c` (non-login) so the pane inherits the server's env (which carries the image PATH). Fixes `claude` and `codex` alike.
- `cli_session_prepare_claude(work_dir)`: before launching a claude session, seed its config (idempotent, `flock`'d, atomic, best-effort — never fails the turn): `hasCompletedOnboarding`, `settings.skipDangerousModePermissionPrompt`, and `projects[work_dir].hasTrustDialogAccepted` for the session worktree.
- `agent_runtime_tmux.c`: append `--dangerously-skip-permissions` to the claude launch (unless a permission mode is already set), matching the legacy `claude -p` path; call the prep before create.

No image/Dockerfile change needed — the image already sets the npm-prefix PATH; the login shell was the only thing discarding it.

## Test

- New unit tests (`test_cli_session.c`): `prepare_claude` seeds all three gates, is idempotent, and preserves pre-existing settings.
- Verified live on PVE: after the equivalent config, claude answers through the tmux path in a fresh worktree (`6×7 → 42`).
- `make lint`, `make unit-tests`, full `make all` green.