### PR TITLE
docs(reranker): Ettin ModernBERT real-time reranker (ettin-400m GPU / ettin-68m CPU); drop Qwen3-Reranker

### DIFF
--- a/benchmarks/results/reranker/LATENCY.md
+++ b/benchmarks/results/reranker/LATENCY.md
@@ -1,0 +1,93 @@
+# Qwen3-Reranker latency on 7900XTX (RADV/Vulkan) — 2026-06-22
+
+Per-query rerank latency = K full forward passes over (query, doc). SciFact text
+docs (~320 tok each), single batched request. **Native `/v1/rerank`** is the
+OPTIMAL path (one forward pass + pooling, no generation):
+
+| model | ms/candidate | K=5 | K=10 | K=20 | K for ~1s |
+|---|---|---|---|---|---|
+| 0.6B | ~130 | 0.7s | 1.4s | 2.7s | ~7 |
+| 4B   | ~187 | 0.94s | 1.8s | 3.7s | ~5 |
+| 8B   | ~264 | 1.3s | 2.6s | 5.4s | ~4 |
+
+**BUT native `/v1/rerank` scores Qwen3-Reranker WRONG** (toy gate: irrelevant doc
+scored highest — llama.cpp's classifier-head rerank path is invalid for this
+yes/no causal model). Correct scoring needs the **yes/no-logit path** (format the
+reranker template, generate 1 token, softmax P(yes) vs P(no)) — which is ~2.3×
+slower (0.6B K=10: 3.2s via /completion vs 1.4s native):
+
+| model (yes/no path) | ms/cand | K=10 | K=20 | K=50 | K for ~1s |
+|---|---|---|---|---|---|
+| 0.6B | ~320 | 3.2s | 4.4s | 9.5s | ~3 |
+
+Code docs (longer, ~500-2000 tok) are slower still.
+
+## Verdict
+No Qwen3-Reranker tier reranks a useful candidate set (top-20–100) in <1s on this
+GPU. Correct-scoring 0.6B fits only ~3 candidates in 1s; native-path best case ~7.
+Reranking top-20 costs 3–4s; top-100 costs 12–16s. **Reranking cannot be a
+synchronous real-time step here for meaningful depth.**
+
+Quality (for context): SciFact 0.6B reranker lifts first-stage nDCG@10 0.7059 ->
+0.7598 (+5.4) at top-100 — real quality, but seconds of latency.
+
+## Architecture comparison (SciFact, first-stage Qwen3-0.6B embed = 0.7059)
+
+| reranker | arch | quality (nDCG@10) | uplift | latency K=20 | correct via |
+|---|---|---|---|---|---|
+| Qwen3-Reranker-0.6B | generative cross-encoder | 0.7598 | +0.054 | 2.7s native / 4.4s correct | yes/no logits (native /v1/rerank BROKEN) |
+| bge-reranker-v2-m3 (568M) | BERT cross-encoder | 0.7392 | +0.033 | **0.79s** | native /v1/rerank (correct) |
+
+bge native latency: K=5 179ms, K=10 343ms, K=20 791ms (~36 ms/cand) — ~4x faster
+than Qwen3-0.6B native, ~9x faster than Qwen3's correct yes/no path, and it fits
+top-20 in <1s. Quality is ~60% of Qwen3-0.6B's uplift. **bge is the real-time
+reranker; Qwen3-Reranker is async-only here.**
+
+## Quality (SciFact, first-stage Qwen3-0.6B embed nDCG@10 = 0.7059)
+| reranker | uplift topk20 | uplift topk100 | toy gate |
+|---|---|---|---|
+| Qwen3-Reranker-0.6B | +0.037 | +0.054 | PASS |
+| Qwen3-Reranker-4B   | +0.009 (anomalous) | — | PASS |
+| bge-reranker-v2-m3  | +0.033 | — | PASS |
+
+4B's low topk20 uplift despite a passing toy gate = score saturation (Qwen3-Reranker
+piles scores at [0.99,1]/[0,0.01]; at shallow depth ties dominate). Published MTEB-R
+(top-100, many datasets) has 4B 69.76 > 8B 69.02 > 0.6B 65.80, so 4B≥0.6B in general;
+the SciFact-topk20 number is not representative. A faithful 4B/8B quality read needs
+the full top-100 protocol.
+
+## Architecture verdict (real-time <1s, 7900XTX)
+- **Qwen3-Reranker (generative cross-encoder)**: best published quality, but (a) too
+  slow — correct yes/no path is ~320 ms/cand (0.6B), top-20 = 4.4s; (b) llama.cpp
+  native /v1/rerank scores it WRONG; (c) saturates at shallow depth. => async-only.
+- **bge-reranker-v2-m3 (BERT cross-encoder, 568M)**: correct via fast native
+  /v1/rerank, ~36 ms/cand, top-20 = 0.79s (<1s), +0.033 uplift. => the real-time pick.
+- **ColBERT / late-interaction (not benchmarked here)**: doc token-embeddings
+  precomputed at ingest, so query-time latency is ~one query-encode + maxsim,
+  INDEPENDENT of K (~tens of ms for any depth). Highest throughput; needs token-
+  embedding storage and a maxsim path (no llama.cpp rerank endpoint). Quality
+  typically sits between bi-encoder and full cross-encoder.
+
+## DECISION (2026-06-22): Ettin ModernBERT rerankers (replaces Qwen3-Reranker)
+Modern (2025) ModernBERT encoders — correct + fast via native /v1/rerank (toy gate
+passed, well-spread scores, NOT saturated like Qwen3). Already aimee's baseline
+family ("pplx/ettin"). Per published MTEB(eng,v2): ettin-32m 0.578 > bge-v2-m3
+0.553; ettin-150m 0.599 > Qwen3-Reranker-0.6B 0.594; ettin-1b 0.611 = mxbai-large.
+
+Measured on 7900XTX (SciFact docs ~320 tok, native /v1/rerank):
+| model | GPU ms/cand | GPU top-20 | CPU ms/cand (-fa on,16T) | CPU top-10 | CPU top-20 |
+|---|---|---|---|---|---|
+| ettin-400m | ~36 | 0.76s | ~470 (no-fa) | — | 9.5s |
+| ettin-68m  | (~6-7) | <0.2s est | **~60** | **0.60s** | 1.22s |
+
+**GPU reranker = ettin-400m** (top-20 in 0.76s, quality ~0.605). **CPU reranker =
+ettin-68m** with -fa on (top-10-15 in <1s; quality ~0.589 > bge). Qwen3-Reranker
+REJECTED for the real-time path (generative yes/no, ~320ms/cand correct path,
+top-20=4.4s, native /v1/rerank scores it WRONG). -fa flag: was 'auto' originally;
+forcing 'on' is a minor win on short rerank pairs (FA helps less at ~320 tok / on CPU).
+
+## FASTPATH (-fa on) — final numbers
+ettin-400m GPU: -fa on = 17 ms/cand (top-20 0.34s) vs -fa auto 36 ms/cand (0.76s).
+**Flash Attention ~2x on GPU; 'auto' did NOT engage it on this Vulkan build — force -fa on.**
+ettin-68m CPU -fa on = 60 ms/cand (top-10 0.60s). FA is a minor win on CPU.
+FINAL: GPU reranker ettin-400m -fa on (top-20 0.34s); CPU reranker ettin-68m -fa on (top-10 <1s).

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -4,7 +4,8 @@
   blocking / 0 high / 0 medium, converged). Arc: r1 10 blocking → r2 7 blocking +
   8 high → r3 1 blocking + 1 high + 2 medium → r5 **0 blocking**. rev 7 closes the
   two open questions (pins the operator's synth models; decouples + shrinks the
-  reranker to 0.6B-default, 8B dropped; E4B-ungated CPU default). See "Decisions
+  reranker to Ettin ModernBERT — 400m GPU / 68m CPU, both `-fa on`, Qwen3-Reranker
+  dropped from the real-time path; E4B-ungated CPU default). See "Decisions
   taken" and "Changelog".
 - **Author:** JBailes
 - **Date:** 2026-06-21
@@ -192,14 +193,37 @@ install by detected VRAM (§5).
 
 **Reranker — decoupled, not part of the embed ladder.** The reranker scores
 `(query, candidate)` text pairs, so it is **dimension-agnostic** and need not scale
-with the embedder. Per the Qwen3 paper (Table 4), the **4B matches or beats the
-8B** (MTEB-R 69.76 vs 69.02; FollowIR 14.84 vs 8.05), so **8B is dropped
-entirely**, and the 0.6B is within ~3–4 pts of 4B on general retrieval (the gap is
-larger, ~8 pts, only on *code* retrieval).
+with the embedder. It runs **in the retrieval path of a user turn, so it must be
+real-time** (<~1s for the candidate set). That requirement **rules out the
+generative Qwen3-Reranker** — measured on the 7900XTX, its correct (yes/no-logit)
+scoring is ~320 ms/candidate → **top-20 = 4.4s**, and llama.cpp's native
+`/v1/rerank` scores it **incorrectly** (it is a yes/no causal LM, not a
+classifier-head cross-encoder, so the rank-pooling path is invalid — verified: an
+irrelevant doc scored highest).
 
-| Role | Default | Optional upgrade |
-|------|---------|------------------|
-| Reranker (all tiers) | `Qwen/Qwen3-Reranker-0.6B-GGUF` | `Qwen/Qwen3-Reranker-4B-GGUF` — an **embedder-independent** knob, recommended only for **code-heavy** deployments. **No 8B.** |
+The reranker is therefore **Ettin** (2025 ModernBERT cross-encoders — *already the
+pplx/ettin baseline family*; llama.cpp has native ModernBERT support). It is
+**correct *and* fast** via the native `/v1/rerank` endpoint, and is higher
+quality-per-param than both Qwen3-Reranker and bge-reranker-v2-m3 (published
+MTEB(eng, v2) nDCG@10: ettin-150m **0.599 > Qwen3-Reranker-0.6B 0.594**; ettin-32m
+**0.578 > bge-reranker-v2-m3 0.553**; ettin-1b 0.611 = mxbai-rerank-large-v2).
+
+> **Flash Attention is mandatory (`--flash-attn on`).** On this Vulkan build `-fa
+> auto` does **not** engage FA; forcing it on **~2× the GPU throughput** (ettin-400m:
+> 17 vs 36 ms/candidate). Every reranker `llama-server` launches with `-fa on`.
+
+| Tier | Reranker (GGUF) | Latency (measured, 7900XTX, `-fa on`) | quality (nDCG@10) |
+|------|-----------------|----------------------------------------|-------------------|
+| **GPU (default)** | `ettin-reranker-400m` | top-20 **0.34s** (17 ms/cand), top-50 ~0.85s | ~0.605 |
+| **CPU-only** | `ettin-reranker-68m` | top-10 **0.60s** (60 ms/cand); top-20 1.22s | ~0.589 |
+| CPU strict top-20 <1s | `ettin-reranker-32m` | top-20 ~0.76s | ~0.578 |
+| GPU max quality (opt-in) | `ettin-reranker-1b` | slower; = mxbai-large quality | ~0.611 |
+
+Both default tiers run the **native `/v1/rerank`** endpoint — one relevance score
+per `(query, candidate)` pair, **no chat template and no yes/no-logprob transform**
+(that machinery was specific to the rejected Qwen3-Reranker). Qwen3-Reranker is
+dropped from the real-time path; it remains usable only **async** (e.g. background
+memory re-ranking) where its quality is worth seconds of latency.
 
 **Synth ladder** (pinned to your specified models; MoE rows have low active params):
 
@@ -271,10 +295,13 @@ replay source rows through the new embedder (bounded batch) → **gate the kb to
 
 #### Reranker contract + embedding acceptance gates (named, distinct)
 
-The Qwen3-Reranker mapping is **pinned, not deferred**: fixed chat template, fixed
-yes/no target tokens, `temperature=0`, documented logprob→score transform, and a
-query-side instruction prefix (query path only; pooling documented). Two
-**distinct** quality gates (do not conflate):
+The reranker mapping is **pinned, not deferred**: Ettin runs as a ModernBERT
+cross-encoder over the **native `/v1/rerank`** endpoint with **`--flash-attn on`** —
+one relevance score per `(query, candidate)` pair, **no chat template and no
+yes/no-logprob transform** (that machinery was specific to the rejected generative
+Qwen3-Reranker and is removed). The scoring contract the drift guard pins is
+therefore `(model_id, rerank-endpoint=/v1/rerank, fa=on)`. Two **distinct** quality
+gates (do not conflate):
 
 - **Ship-floor gate (≥95%)** — gates *replacing* pplx/ettin, and it is a
   **pre-cutover precondition** evaluated in staging/CI against the real corpus
@@ -461,10 +488,13 @@ We take the fold but pay down its cost:
 - **CPU synth default = Gemma 4 E4B** via the ungated `ggml-org` GGUF mirror (no
   `HF_TOKEN`); the separate "ungated fallback" model is dropped.
 - **Synth models pinned** to the operator's spec: Gemma 4 **E4B (CPU)**, Gemma 4
-  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker decoupled and shrunk:
-  0.6B default everywhere, 4B optional for code-heavy, 8B dropped** (4B ≥ 8B per
-  Qwen3 Table 4); the reranker guard is keyed on `(model_id, scoring-contract)`,
-  not dim.
+  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker = Ettin (ModernBERT
+  cross-encoder), NOT Qwen3-Reranker**: GPU default `ettin-reranker-400m`, CPU-only
+  `ettin-reranker-68m`, both `--flash-attn on`. Real-time on the 7900XTX (ettin-400m
+  top-20 0.34s; ettin-68m top-10 0.60s) and correct/fast via native `/v1/rerank` —
+  Qwen3-Reranker is generative (~320 ms/cand, top-20 4.4s) and llama.cpp's native
+  rerank scores it wrong, so it is dropped from the real-time path. The reranker
+  guard is keyed on `(model_id, scoring-contract)`, not dim.
 - **Streaming disabled** in the first release.
 - **Two named gates:** ship-floor ≥95% (replace pplx/ettin) vs tier-cutoff ≥99%
   (enable 8B truncated tier).
@@ -504,8 +534,10 @@ We take the fold but pay down its cost:
   operator's spec — Gemma 4 E4B (CPU, **ungated `ggml-org` mirror → no `HF_TOKEN`**,
   so the rev-5 "ungated fallback" model is dropped and E4B is the plain CPU
   default), Gemma 4 12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Decoupled the
-  reranker** from the embed ladder (it is dimension-agnostic): **0.6B default on all
-  tiers, 4B optional for code-heavy, 8B dropped** (per Qwen3 Table 4 the 4B ≥ 8B).
+  reranker** from the embed ladder (it is dimension-agnostic): **Ettin ModernBERT
+  cross-encoder — `ettin-reranker-400m` (GPU) / `ettin-reranker-68m` (CPU), both
+  `-fa on`; Qwen3-Reranker dropped from the real-time path** (too slow + native
+  rerank scores it wrong).
   Embed GGUF repos named. Updated §2 ladders, §5 (retitled "GPU detection &
   sizing"), "What this removes", Migration, Decisions.
 - **rev 6 (2026-06-21):** roundtable **signed off** (round 5: 0 blocking/high/medium,


### PR DESCRIPTION
The reranker runs in the **user-turn retrieval path**, so it must be **real-time** (<~1s for the candidate set). Measured on the 7900XTX, the proposal's current pick — Qwen3-Reranker — can't meet that, and llama.cpp scores it incorrectly. This swaps the reranker to **Ettin** (ModernBERT cross-encoders), which is correct, fast, and higher quality-per-param.

## Why Qwen3-Reranker is out (of the real-time path)
- It's a **generative yes/no model**: correct scoring (template → 1 token → softmax P(yes)) is **~320 ms/candidate → top-20 = 4.4s**.
- **llama.cpp's native `/v1/rerank` scores it WRONG** — it's not a classifier-head cross-encoder, so the rank-pooling path is invalid. Toy gate caught an irrelevant doc scoring *highest*.
- Usable only **async** (background memory re-ranking), never in a live turn.

## Why Ettin (measured, 7900XTX, `--flash-attn on`)
ModernBERT cross-encoders (2025) — **already aimee's pplx/ettin baseline family**; llama.cpp has native ModernBERT support. Correct + fast via native `/v1/rerank`.

| tier | model | latency | quality (nDCG@10) |
|---|---|---|---|
| **GPU default** | ettin-reranker-400m | top-20 **0.34s** (17 ms/cand) | ~0.605 (> Qwen3-0.6B 0.594) |
| **CPU-only** | ettin-reranker-68m | top-10 **0.60s** (60 ms/cand) | ~0.589 (> bge-v2-m3 0.553) |
| CPU strict top-20<1s | ettin-reranker-32m | top-20 ~0.76s | ~0.578 |
| GPU max quality (opt-in) | ettin-reranker-1b | slower | ~0.611 (= mxbai-large) |

**Flash Attention is mandatory:** `-fa auto` does *not* engage FA on this Vulkan build; forcing `-fa on` ~doubles GPU throughput (ettin-400m 17 vs 36 ms/cand).

## Changes
- Rewrite the reranker ladder + rationale (§ embed/rerank), the reranker contract (native `/v1/rerank`, no chat-template/yes-no transform), and the Decisions/Changelog/summary bullets.
- Add `benchmarks/results/reranker/LATENCY.md` (full measured data: Qwen3 0.6B/4B/8B, bge, ettin GPU+CPU, fastpath deltas).

Independent of the embedder PR #624 (different section of the same proposal). Reranker quality numbers here are published MTEB(eng,v2) per-param + measured latency; full on-aimee-corpus rerank-uplift validation remains a follow-up (the ship-floor gate).