### PR TITLE
fix(webchat): gate claude --dangerously-skip-permissions on autonomous mode

### DIFF
--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -86,8 +86,13 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
  * (fresh) worktree, so the trust dialog re-appears every session and wedges the
  * pane; this trusts `work_dir`. Best-effort and idempotent — never fails the
  * turn (a worst case just re-shows a prompt). Call before creating a claude
- * session. No-op for non-claude providers (caller gates on cli_kind). */
-void cli_session_prepare_claude(const char *work_dir);
+ * session. No-op for non-claude providers (caller gates on cli_kind).
+ *
+ * `autonomous`: when nonzero the launch passes --dangerously-skip-permissions,
+ * so also pre-accept its one-time warning (skipDangerousModePermissionPrompt).
+ * When zero, only onboarding + per-folder trust are seeded (those are required
+ * for the TUI to start at all); the bypass warning is left untouched. */
+void cli_session_prepare_claude(const char *work_dir, int autonomous);
 
 /* Kills the tmux session. No-op if already dead. */
 void cli_session_destroy(cli_session_t *s);

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -99,12 +99,18 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    char cli_cmd_buf[CLI_SESSION_CMD_MAX];
    const char *cli_cmd = base_cmd;
    int need_model = agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m ");
-   /* claude runs autonomously here (no human to approve tools) inside a
-    * sandboxed container, so bypass its permission prompts — unless the launch
-    * command already selects a permission mode. Mirrors the legacy `claude -p`
-    * path, which always passed this. The matching first-run acceptances are
-    * seeded by cli_session_prepare_claude() below. */
-   int need_skip = is_claude && !strstr(base_cmd, "--dangerously-skip-permissions") &&
+   /* Autonomous = bypass claude's interactive permission prompts (there is no
+    * human at the detached tmux pane to answer them; aimee's own guardrails are
+    * the safety layer). Driven by the global `autonomous` config — EXCEPT a
+    * primary webchat turn (a real bound session, not a delegate), which is
+    * always autonomous: it is the interactive UI a user is waiting on, and a
+    * non-autonomous claude would wedge forever on its first tool prompt. */
+   int deleg = deleg_id && deleg_id[0];
+   int webchat_primary = have_session && !deleg;
+   int autonomous = agent->autonomous || webchat_primary;
+   /* Pass --dangerously-skip-permissions only when autonomous, and only if the
+    * launch command doesn't already select a permission mode. */
+   int need_skip = is_claude && autonomous && !strstr(base_cmd, "--dangerously-skip-permissions") &&
                    !strstr(base_cmd, "--permission-mode");
    if (need_model || need_skip)
    {
@@ -124,11 +130,12 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    else if (getcwd(cwd, sizeof(cwd)) == NULL)
       cwd[0] = '\0';
 
-   /* Seed claude-code's first-run gates (onboarding / bypass warning / per-
-    * folder trust for this worktree) so its interactive TUI starts at the
-    * prompt instead of wedging the pane. Best-effort; no-op for other CLIs. */
+   /* Seed claude-code's first-run gates (onboarding / per-folder trust for this
+    * worktree, + the bypass warning when autonomous) so its interactive TUI
+    * starts at the prompt instead of wedging the pane. Best-effort; no-op for
+    * other CLIs. */
    if (is_claude)
-      cli_session_prepare_claude(cwd);
+      cli_session_prepare_claude(cwd, autonomous);
 
    cli_session_t sess;
    int rc = cli_session_create(&sess, sess_name, cli_cmd, cwd, reuse);

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -264,7 +264,7 @@ static cJSON *cli_claude_cfg_load(const char *path, int *skip)
    return root ? root : cJSON_CreateObject();
 }
 
-void cli_session_prepare_claude(const char *work_dir)
+void cli_session_prepare_claude(const char *work_dir, int autonomous)
 {
    const char *home = cli_claude_home();
    char claude_dir[PATH_MAX], lockpath[PATH_MAX], jsonpath[PATH_MAX], setpath[PATH_MAX];
@@ -325,20 +325,26 @@ void cli_session_prepare_claude(const char *work_dir)
    }
 
    /* ~/.claude/settings.json: pre-accept the bypass-permissions warning so a
-    * --dangerously-skip-permissions launch starts straight at the prompt. */
-   cJSON *sroot = cli_claude_cfg_load(setpath, &skip);
-   if (sroot)
+    * --dangerously-skip-permissions launch starts straight at the prompt. Only
+    * when autonomous — without the flag the warning never appears, and we must
+    * not silently pre-accept a dangerous-mode prompt the operator didn't opt
+    * into. */
+   if (autonomous)
    {
-      if (cli_json_set_true(sroot, "skipDangerousModePermissionPrompt"))
+      cJSON *sroot = cli_claude_cfg_load(setpath, &skip);
+      if (sroot)
       {
-         char *out = cJSON_Print(sroot);
-         if (out)
+         if (cli_json_set_true(sroot, "skipDangerousModePermissionPrompt"))
          {
-            cli_write_file_atomic(setpath, out);
-            free(out);
+            char *out = cJSON_Print(sroot);
+            if (out)
+            {
+               cli_write_file_atomic(setpath, out);
+               free(out);
+            }
          }
+         cJSON_Delete(sroot);
       }
-      cJSON_Delete(sroot);
    }
 
    if (lf >= 0)

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -559,7 +559,7 @@ static void test_prepare_claude_seeds_gates(void)
    setenv("AIMEE_HOME", home, 1);
    const char *wt = "/tmp/aimee_clitest_wt/session-abc";
 
-   cli_session_prepare_claude(wt);
+   cli_session_prepare_claude(wt, 1);
 
    char p[512];
    snprintf(p, sizeof(p), "%s/.claude.json", home);
@@ -587,7 +587,7 @@ static void test_prepare_claude_seeds_gates(void)
    cJSON_Delete(sroot);
 
    /* Idempotent: a second call leaves the same state (and must not throw). */
-   cli_session_prepare_claude(wt);
+   cli_session_prepare_claude(wt, 1);
    snprintf(p, sizeof(p), "%s/.claude.json", home);
    j = slurp(p);
    root = cJSON_Parse(j);
@@ -612,7 +612,7 @@ static void test_prepare_claude_preserves_existing_settings(void)
    fputs("{\"theme\":\"dark\"}", f);
    fclose(f);
 
-   cli_session_prepare_claude("/tmp/aimee_clitest_wt2");
+   cli_session_prepare_claude("/tmp/aimee_clitest_wt2", 1);
 
    char *s = slurp(p);
    cJSON *sroot = cJSON_Parse(s);
@@ -645,12 +645,51 @@ static void test_prepare_claude_skips_unparseable_config(void)
    fputs(corrupt, f);
    fclose(f);
 
-   cli_session_prepare_claude("/tmp/aimee_clitest_wt3");
+   cli_session_prepare_claude("/tmp/aimee_clitest_wt3", 1);
 
    char *after = slurp(jp);
    assert(after != NULL);
    assert(strcmp(after, corrupt) == 0); /* untouched, not wiped to {} */
    free(after);
+}
+
+/* Non-autonomous: onboarding + trust ARE seeded (the TUI needs them to start),
+ * but the --dangerously-skip-permissions warning is NOT pre-accepted (the flag
+ * isn't passed, so the operator's dangerous-mode prompt is left untouched). */
+static void test_prepare_claude_nonautonomous_skips_bypass_seed(void)
+{
+   char home[] = "/tmp/aimee_clitest_XXXXXX";
+   assert(mkdtemp(home) != NULL);
+   setenv("HOME", home, 1);
+   setenv("AIMEE_HOME", home, 1);
+   const char *wt = "/tmp/aimee_clitest_wt4";
+
+   cli_session_prepare_claude(wt, 0); /* not autonomous */
+
+   /* onboarding + trust seeded */
+   char p[600];
+   snprintf(p, sizeof(p), "%s/.claude.json", home);
+   char *j = slurp(p);
+   assert(j != NULL);
+   cJSON *root = cJSON_Parse(j);
+   free(j);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(root, "hasCompletedOnboarding")));
+   cJSON *proj =
+       cJSON_GetObjectItemCaseSensitive(cJSON_GetObjectItemCaseSensitive(root, "projects"), wt);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(proj, "hasTrustDialogAccepted")));
+   cJSON_Delete(root);
+
+   /* bypass warning NOT pre-accepted: settings.json absent or flag unset */
+   snprintf(p, sizeof(p), "%s/.claude/settings.json", home);
+   char *s = slurp(p);
+   if (s)
+   {
+      cJSON *sroot = cJSON_Parse(s);
+      free(s);
+      assert(sroot == NULL || !cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(
+                                  sroot, "skipDangerousModePermissionPrompt")));
+      cJSON_Delete(sroot);
+   }
 }
 
 int main(void)
@@ -665,6 +704,10 @@ int main(void)
 
    printf("test_prepare_claude_skips_unparseable_config... ");
    test_prepare_claude_skips_unparseable_config();
+   printf("OK\n");
+
+   printf("test_prepare_claude_nonautonomous_skips_bypass_seed... ");
+   test_prepare_claude_nonautonomous_skips_bypass_seed();
    printf("OK\n");
 
    printf("test_extract_claude_basic... ");


### PR DESCRIPTION
Follow-up to #626. Per operator direction: `--dangerously-skip-permissions` should only be used when **autonomous mode** is on (aimee's own guardrails are the safety layer); and the webchat should always run autonomous.

## Change
- `agent_runtime_tmux.c`: the claude flag is now gated on an `autonomous` decision = global `autonomous` config **OR** a primary webchat turn. A primary webchat turn (a bound session, not a delegate) is always autonomous — there's no human at the detached tmux pane to answer claude's prompts, and a non-autonomous claude would wedge on its first tool prompt. (Mirrors the codex path, which already keys approval behaviour on `autonomous`.)
- `cli_session_prepare_claude(work_dir, autonomous)`: onboarding + per-folder trust are **always** seeded (the TUI needs them to start at all); the bypass-permissions warning is pre-accepted (`skipDangerousModePermissionPrompt`) **only when autonomous** — without the flag that warning never appears, and we shouldn't silently pre-accept a dangerous-mode prompt the operator didn't opt into.

## Tests
- New `test_prepare_claude_nonautonomous_skips_bypass_seed`: autonomous=0 seeds onboarding+trust but not the bypass acceptance.
- Existing prepare tests updated for the new arg.
- `make lint` + full `make unit-tests` + `make all` green.

No behaviour change on deployments with `autonomous: true` (e.g. the live box): the flag is still passed there.