### PR TITLE
Promote testing to main: autonomous-gated claude skip-perms (#629) + reranker docs (#628)

### DIFF
--- a/benchmarks/beir_cli.py
+++ b/benchmarks/beir_cli.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""beir_cli.py — BEIR retrieval eval via the `llama-embedding` CLI (no HTTP server).
+
+The llama-server HTTP path was flaky for bulk embedding (connection drops, slot/
+batch scheduling, fallback storms). `llama-embedding` embeds a whole file in one
+GPU-batched process — reliable. This wraps it: write the corpus/queries to files,
+run the CLI, parse the JSON, compute nDCG@10 / Recall@10.
+
+Usage (on the box with the model + llama-embedding):
+  python3 beir_cli.py --bin /path/llama-embedding --model m.gguf \
+      --corpus corpus.jsonl --queries queries.jsonl --qrels test.tsv \
+      --name qwen3-0.6b --output out.json --pooling last \
+      [--query-prefix STR | --query-prefix-file F] [--doc-prefix STR] [--ctx 4096]
+"""
+import argparse, json, math, subprocess, tempfile, time, os
+from pathlib import Path
+
+try:
+    import numpy as np
+except ImportError:
+    np = None
+
+
+def load_qrels(p):
+    qrels = {}
+    for ln, line in enumerate(Path(p).read_text().splitlines()):
+        parts = line.split("\t")
+        if len(parts) < 3:
+            continue
+        qid, cid, score = parts[0], parts[1], parts[2]
+        try:
+            s = int(float(score))
+        except ValueError:
+            continue
+        qrels.setdefault(qid, {})[cid] = s
+    return qrels
+
+
+def dcg(rels):
+    return sum((2 ** r - 1) / math.log2(i + 2) for i, r in enumerate(rels))
+
+
+def ndcg_at_k(ranked, gold, k=10):
+    idcg = dcg(sorted(gold.values(), reverse=True)[:k])
+    return (dcg([gold.get(c, 0) for c in ranked[:k]]) / idcg) if idcg > 0 else 0.0
+
+
+def recall_at_k(ranked, gold, k=10):
+    rel = {c for c, s in gold.items() if s > 0}
+    return (len(rel & set(ranked[:k])) / len(rel)) if rel else 0.0
+
+
+def embed_file(bin_path, model, texts, prefix, pooling, ctx, ngl, ub, b):
+    """Write texts (newlines flattened) to a temp file, run llama-embedding, return
+    the list of (already L2-normalized) embedding vectors."""
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as f:
+        for t in texts:
+            f.write((prefix + " ".join(t.split())) + "\n")  # one prompt per line
+        fn = f.name
+    out = tempfile.NamedTemporaryFile("w", suffix=".json", delete=False).name
+    env = {**os.environ, "LD_LIBRARY_PATH": str(Path(bin_path).parent)}
+    cmd = [bin_path, "-m", model, "-f", fn, "--pooling", pooling,
+           "--embd-output-format", "json", "--embd-normalize", "2",
+           "-ngl", str(ngl), "-c", str(ctx), "-ub", str(ub), "-b", str(b), "--no-warmup"]
+    with open(out, "w") as o:
+        subprocess.run(cmd, stdout=o, stderr=subprocess.DEVNULL, env=env, check=True)
+    data = json.loads(Path(out).read_text())
+    rows = data["data"] if isinstance(data, dict) else data
+    os.unlink(fn); os.unlink(out)
+    return [(r["embedding"] if isinstance(r, dict) else r) for r in rows]
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--bin", required=True)
+    ap.add_argument("--model", required=True)
+    ap.add_argument("--corpus", required=True)
+    ap.add_argument("--queries", required=True)
+    ap.add_argument("--qrels", required=True)
+    ap.add_argument("--name", required=True)
+    ap.add_argument("--output", required=True)
+    ap.add_argument("--pooling", default="last")
+    ap.add_argument("--query-prefix", default="")
+    ap.add_argument("--query-prefix-file")
+    ap.add_argument("--doc-prefix", default="")
+    ap.add_argument("--ctx", type=int, default=4096)
+    ap.add_argument("--ngl", type=int, default=99)
+    ap.add_argument("--ub", type=int, default=2048)
+    ap.add_argument("--b", type=int, default=8192)
+    ap.add_argument("--max-docs", type=int, default=0)
+    args = ap.parse_args()
+
+    qprefix = Path(args.query_prefix_file).read_text() if args.query_prefix_file else args.query_prefix
+    qrels = load_qrels(args.qrels)
+
+    corpus = {}
+    for line in Path(args.corpus).read_text().splitlines():
+        d = json.loads(line)
+        corpus[str(d["_id"])] = ((d.get("title", "") + " ") + d.get("text", "")).strip()
+        if args.max_docs and len(corpus) >= args.max_docs:
+            break
+    if args.max_docs:
+        need = {c for g in qrels.values() for c, s in g.items() if s > 0}
+        for line in Path(args.corpus).read_text().splitlines():
+            d = json.loads(line)
+            if str(d["_id"]) in (need - set(corpus)):
+                corpus[str(d["_id"])] = ((d.get("title", "") + " ") + d.get("text", "")).strip()
+
+    queries = {}
+    for line in Path(args.queries).read_text().splitlines():
+        d = json.loads(line)
+        if str(d["_id"]) in qrels:
+            queries[str(d["_id"])] = d.get("text", "")
+
+    cids = list(corpus)
+    t0 = time.time()
+    dv = embed_file(args.bin, args.model, [corpus[c] for c in cids], args.doc_prefix,
+                    args.pooling, args.ctx, args.ngl, args.ub, args.b)
+    qids = list(queries)
+    qv = embed_file(args.bin, args.model, [queries[q] for q in qids], qprefix,
+                    args.pooling, args.ctx, args.ngl, args.ub, args.b)
+    assert len(dv) == len(cids), f"doc embeddings {len(dv)} != {len(cids)} docs"
+    assert len(qv) == len(qids), f"query embeddings {len(qv)} != {len(qids)} queries"
+
+    D = np.asarray(dv, dtype="float32")
+    ndcgs, recalls = [], []
+    for qid, v in zip(qids, qv):
+        order = D.dot(np.asarray(v, dtype="float32")).argsort()[::-1][:50]
+        ranked = [cids[i] for i in order]
+        ndcgs.append(ndcg_at_k(ranked, qrels[qid], 10))
+        recalls.append(recall_at_k(ranked, qrels[qid], 10))
+    n = len(ndcgs) or 1
+    res = {"name": args.name, "model": args.model, "pooling": args.pooling,
+           "queries": len(ndcgs), "corpus": len(cids),
+           "ndcg_10": sum(ndcgs) / n, "recall_10": sum(recalls) / n,
+           "query_prefix": qprefix, "doc_prefix": args.doc_prefix,
+           "wall_seconds": round(time.time() - t0, 1)}
+    Path(args.output).write_text(json.dumps(res, indent=2))
+    print(f"{args.name}: nDCG@10={res['ndcg_10']:.4f} Recall@10={res['recall_10']:.4f} "
+          f"({res['queries']} q / {res['corpus']} docs, {res['wall_seconds']}s)")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/beir_gate.py
+++ b/benchmarks/beir_gate.py
@@ -33,23 +33,46 @@ except ImportError:
     np = None
 
 
-def embed(endpoint, texts, prefix="", batch=128, normalize=True):  # batch overridable via --batch
-    out = []
+def _post(endpoint, chunk):
+    body = json.dumps({"input": chunk}).encode()
+    req = urllib.request.Request(endpoint, data=body, headers={"Content-Type": "application/json"})
+    for attempt in range(4):
+        try:
+            with urllib.request.urlopen(req, timeout=600) as r:
+                data = json.loads(r.read())["data"]
+            return [row["embedding"] for row in sorted(data, key=lambda d: d["index"])]
+        except Exception:
+            if attempt == 3:
+                raise
+            time.sleep(2 * (attempt + 1))
+
+
+_skipped = 0
+
+
+def embed(endpoint, texts, prefix="", batch=128, normalize=True, dim=None, suffix=""):
+    """Robust: on a batch error (e.g. one doc too long for the ubatch, or a
+    transient drop) fall back to one-at-a-time; a single text that still errors is
+    skipped with a zero vector so a few pathological docs cannot kill a long run."""
+    global _skipped
+    out, d = [], dim
     for i in range(0, len(texts), batch):
-        chunk = [prefix + t for t in texts[i : i + batch]]
-        body = json.dumps({"input": chunk}).encode()
-        req = urllib.request.Request(endpoint, data=body, headers={"Content-Type": "application/json"})
-        for attempt in range(4):
-            try:
-                with urllib.request.urlopen(req, timeout=600) as r:
-                    data = json.loads(r.read())["data"]
-                break
-            except Exception:
-                if attempt == 3:
-                    raise
-                time.sleep(2 * (attempt + 1))
-        for row in sorted(data, key=lambda d: d["index"]):
-            v = row["embedding"]
+        chunk = [prefix + t + suffix for t in texts[i : i + batch]]
+        try:
+            vecs = _post(endpoint, chunk)
+        except Exception:
+            vecs = []
+            for t in chunk:
+                try:
+                    vecs.append(_post(endpoint, [t])[0])
+                except Exception:
+                    _skipped += 1
+                    vecs.append(None)
+        for v in vecs:
+            if v is None:
+                out.append([0.0] * (d or 1))
+                continue
+            d = d or len(v)
             if normalize:
                 n = math.sqrt(sum(x * x for x in v)) or 1.0
                 v = [x / n for x in v]
@@ -89,6 +112,7 @@ def main():
     ap.add_argument("--max-docs", type=int, default=0, help="cap corpus (0=all)")
     ap.add_argument("--no-normalize", action="store_true")
     ap.add_argument("--batch", type=int, default=128)
+    ap.add_argument("--suffix", default="", help="appended to every input text (e.g. <|endoftext|> for Qwen3 last-token pooling)")
     ap.add_argument("--max-doc-chars", type=int, default=0, help="truncate each doc to N chars (fair cross-model when models have different max context)")
     args = ap.parse_args()
 
@@ -137,9 +161,9 @@ def main():
 
     cids = list(corpus)
     t0 = time.time()
-    doc_vecs = embed(args.endpoint, [corpus[c] for c in cids], args.doc_prefix, batch=args.batch, normalize=not args.no_normalize)
+    doc_vecs = embed(args.endpoint, [corpus[c] for c in cids], args.doc_prefix, batch=args.batch, normalize=not args.no_normalize, suffix=args.suffix)
     q_ids = list(queries)
-    q_vecs = embed(args.endpoint, [queries[q] for q in q_ids], qprefix, batch=args.batch, normalize=not args.no_normalize)
+    q_vecs = embed(args.endpoint, [queries[q] for q in q_ids], qprefix, batch=args.batch, normalize=not args.no_normalize, suffix=args.suffix)
 
     if np is not None:
         D = np.asarray(doc_vecs, dtype="float32")
@@ -161,15 +185,17 @@ def main():
         "endpoint": args.endpoint,
         "queries": len(ndcgs),
         "corpus": len(cids),
+        "docs_skipped": _skipped,  # docs the server could not embed (e.g. > model context)
         "ndcg_10": sum(ndcgs) / n,
         "recall_10": sum(recalls) / n,
         "query_prefix": qprefix,
         "doc_prefix": args.doc_prefix,
+        "max_doc_chars": args.max_doc_chars,
         "wall_seconds": round(time.time() - t0, 1),
     }
     Path(args.output).write_text(json.dumps(res, indent=2))
     print(f"{args.name}: nDCG@10={res['ndcg_10']:.4f} Recall@10={res['recall_10']:.4f} "
-          f"({res['queries']} q / {res['corpus']} docs, {res['wall_seconds']}s)")
+          f"({res['queries']} q / {res['corpus']} docs, skipped={_skipped}, {res['wall_seconds']}s)")
 
 
 if __name__ == "__main__":

--- a/benchmarks/results/embedder-gate/aimee-code/README.md
+++ b/benchmarks/results/embedder-gate/aimee-code/README.md
@@ -1,0 +1,48 @@
+# Embedder eval on aimee's OWN code (2026-06-22)
+
+Task: NL doc-comment -> code-body retrieval over 1864 functions extracted from
+aimee `src/**/*.c` (a leading block comment = query, the function signature+body =
+the relevant doc; 1:1). Mirrors aimee's real operation: match a code unit's intent
+(NL) to its body (`kb_curator_index_code_unit.c` intent_vec vs body_vec). Docs
+capped to 2000 chars so each is one clean sequence. Harness: beir_cli.py via
+llama-embedding (Vulkan, 7900XTX), **--no-escape** (code's literal \n/\t in string
+literals were being expanded into newlines, splitting one prompt into many).
+
+| model | nDCG@10 | Recall@10 | wall |
+|---|---|---|---|
+| nomic-embed-text-v1.5 (mean, 768-d) | 0.5700 | 0.7167 | 20s |
+| Qwen3-Embedding-0.6B-f16 (last, 1024-d) | 0.6970 | 0.8165 | 217s |
+
+Qwen3-0.6B wins by +12.7 nDCG@10 / +10 Recall@10 on aimee's own code, consistent
+with the published MTEB code-retrieval gap (nomic is text-only, no code training).
+~10x slower to embed (ingest-time cost). This is the decision-relevant axis: aimee
+embeds raw code bodies/signatures, so the default embedder must be code-capable.
+
+## + Qwen3-8B (high tier)
+| model | nDCG@10 | Recall@10 | wall | dim |
+|---|---|---|---|---|
+| Qwen3-Embedding-8B-f16 (last) | 0.7608 | 0.8804 | 474.8s | 4096 |
+
+8B beats 0.6B by +6.4 nDCG@10 / +6.4 Recall@10 on aimee code. ~2.2x slower than
+0.6B (NOT 13x; GPU compute-bound, sublinear), ~24x nomic. Real cost is dimension:
+4096-d = 4x pgvector storage/scan vs 0.6B's 1024-d, + 15GB VRAM resident.
+
+## + Qwen3-4B (Q8) — the high-tier sweet spot
+| model | nDCG@10 | Recall@10 | wall | dim |
+|---|---|---|---|---|
+| Qwen3-Embedding-4B-Q8 (last) | 0.7592 | 0.8739 | 343.3s | 2560 |
+
+4B ~= 8B on nDCG (0.7592 vs 0.7608 = +0.16, noise) at 2560-d vs 4096-d (1.6x
+smaller index) and 1.4x faster — and 4B here is Q8 vs 8B f16, so f16-4B likely
+edges 8B. 0.6B->4B = +6.2 nDCG; 4B->8B = +0.16. => high tier should be 4B, not 8B.
+Ladder: default Qwen3-0.6B (1024-d), high Qwen3-4B (2560-d). nomic dropped.
+
+## 4B-f16 (settles the Q8 caveat + the 4B-vs-8B call)
+| model | nDCG@10 | Recall@10 | wall | dim |
+|---|---|---|---|---|
+| Qwen3-4B-f16 (last) | 0.7592 | 0.8777 | 332.9s | 2560 |
+
+4B-f16 nDCG == 4B-Q8 nDCG (0.7592) -> Q8 is lossless here. 4B-f16 vs 8B-f16:
+8B leads by only +0.16 nDCG / +0.27 R@10 (noise). 8B's 4096-d (1.6x 4B's 2560-d
+pgvector cost) + 1.4x embed time + 2x VRAM buys nothing. FINAL: default Qwen3-0.6B
+(1024-d), high Qwen3-4B (2560-d, Q8 fine); nomic dropped.

--- a/benchmarks/results/embedder-gate/aimee-code/res_nomic.json
+++ b/benchmarks/results/embedder-gate/aimee-code/res_nomic.json
@@ -1,0 +1,12 @@
+{
+  "name": "aimee_code-nomic",
+  "model": "models/nomic-embed-v1.5.Q8_0.gguf",
+  "pooling": "mean",
+  "queries": 1864,
+  "corpus": 1864,
+  "ndcg_10": 0.5700112410172118,
+  "recall_10": 0.7167381974248928,
+  "query_prefix": "search_query: ",
+  "doc_prefix": "search_document: ",
+  "wall_seconds": 20.0
+}

--- a/benchmarks/results/embedder-gate/aimee-code/res_qwen06.json
+++ b/benchmarks/results/embedder-gate/aimee-code/res_qwen06.json
@@ -1,0 +1,12 @@
+{
+  "name": "aimee_code-qwen06",
+  "model": "models/qwen3-emb-0.6b-f16.gguf",
+  "pooling": "last",
+  "queries": 1864,
+  "corpus": 1864,
+  "ndcg_10": 0.697027537698416,
+  "recall_10": 0.8165236051502146,
+  "query_prefix": "Instruct: Given a natural language description of a function, retrieve the source code that implements it Query: ",
+  "doc_prefix": "",
+  "wall_seconds": 217.0
+}

--- a/benchmarks/results/embedder-gate/aimee-code/res_qwen4b-f16.json
+++ b/benchmarks/results/embedder-gate/aimee-code/res_qwen4b-f16.json
@@ -1,0 +1,12 @@
+{
+  "name": "aimee_code-qwen4bf16",
+  "model": "models/qwen3-emb-4b-f16.gguf",
+  "pooling": "last",
+  "queries": 1864,
+  "corpus": 1864,
+  "ndcg_10": 0.7591972356836706,
+  "recall_10": 0.8776824034334764,
+  "query_prefix": "Instruct: Given a natural language description of a function, retrieve the source code that implements it Query: ",
+  "doc_prefix": "",
+  "wall_seconds": 332.9
+}

--- a/benchmarks/results/embedder-gate/aimee-code/res_qwen4b.json
+++ b/benchmarks/results/embedder-gate/aimee-code/res_qwen4b.json
@@ -1,0 +1,12 @@
+{
+  "name": "aimee_code-qwen4b",
+  "model": "models/qwen3-emb-4b-q8.gguf",
+  "pooling": "last",
+  "queries": 1864,
+  "corpus": 1864,
+  "ndcg_10": 0.7591825244473007,
+  "recall_10": 0.8739270386266095,
+  "query_prefix": "Instruct: Given a natural language description of a function, retrieve the source code that implements it Query: ",
+  "doc_prefix": "",
+  "wall_seconds": 343.3
+}

--- a/benchmarks/results/embedder-gate/aimee-code/res_qwen8b.json
+++ b/benchmarks/results/embedder-gate/aimee-code/res_qwen8b.json
@@ -1,0 +1,12 @@
+{
+  "name": "aimee_code-qwen8b",
+  "model": "models/qwen3-emb-8b-f16.gguf",
+  "pooling": "last",
+  "queries": 1864,
+  "corpus": 1864,
+  "ndcg_10": 0.7607810185999376,
+  "recall_10": 0.8803648068669528,
+  "query_prefix": "Instruct: Given a natural language description of a function, retrieve the source code that implements it Query: ",
+  "doc_prefix": "",
+  "wall_seconds": 474.8
+}

--- a/benchmarks/results/embedder-gate/multi-beir/SUMMARY.md
+++ b/benchmarks/results/embedder-gate/multi-beir/SUMMARY.md
@@ -1,0 +1,39 @@
+# Embedder baseline-gated multi-dataset eval (2026-06-22)
+
+Harness: `benchmarks/beir_cli.py` via `llama-embedding` (Vulkan, 7900XTX). My
+numbers vs published MTEB nDCG@10. nomic = mean-pool 768-d (docs truncated to its
+~2048-tok limit); Qwen3-0.6B = last-pool fp16 1024-d, task-instruction prefix.
+
+## Text BEIR (my harness vs published)
+| dataset | nomic (mine) | nomic (pub) | Qwen3-0.6B (mine) | Qwen3-0.6B (pub) |
+|---|---|---|---|---|
+| SciFact  | 0.7034 | 0.7028 | 0.7059 | 0.6972 |
+| NFCorpus | 0.3466 | 0.3467 | 0.3701 | 0.3671 |
+| ArguAna  | 0.3556 | 0.5202 | 0.4856 | 0.7097 |
+
+SciFact + NFCorpus reproduce published within ~0.3pt for BOTH models -> harness
+validated. ArguAna is a symmetric argument-retrieval task; asymmetric query/doc
+prefixes depress BOTH models' absolute scores, but Qwen3 still wins (+13pt mine,
++19pt published). On text, Qwen3-0.6B ties nomic on SciFact/NFCorpus and wins the
+rest (per published: FiQA +9, SCIDOCS +7, ArguAna +19, TREC-COVID +27).
+
+## Code retrieval (published MTEB nDCG@10) -- the domain aimee embeds code in
+| task | nomic | Qwen3-0.6B | Qwen3-4B | Qwen3-8B |
+|---|---|---|---|---|
+| CodeSearchNet        | 0.856 | 0.943 | 0.960 | 0.966 |
+| CodeSearchNet-CC     | 0.489 | 0.933 | 0.967 | 0.971 |
+| CosQA                | 0.261 | 0.365 | 0.380 | 0.380 |
+| CodeFeedback-ST      | 0.543 | 0.864 | 0.895 | 0.899 |
+| CodeFeedback-MT      | 0.282 | 0.908 | 0.932 | 0.937 |
+| CodeTransOcean-Cont. | 0.368 | 0.861 | 0.910 | 0.937 |
+| SyntheticText2SQL    | 0.481 | 0.767 | 0.782 | 0.788 |
+| StackOverflowQA      | 0.636 | 0.900 | 0.943 | 0.948 |
+
+nomic is text-only (no code training); Qwen3 beats it by +10..+63 on code. The
+0.6B->8B gain is small (+1.5..+7.7). Dims: 0.6B=1024, 4B=2560, 8B=4096->4000(trunc).
+
+## Decision relevance
+aimee embeds raw code (kb_curator_index_code_unit.c body_vec/sig_vec) and code
+chunks (kb_service_code_embed.c) with the SAME configured embedder. Code-retrieval
+quality is therefore first-class -> Qwen3-0.6B default is justified (code + multi-
+dataset text), NOT the capped-SciFact artifact cited in #617.

--- a/benchmarks/results/embedder-gate/scifact-full/cli_nomic-full.json
+++ b/benchmarks/results/embedder-gate/scifact-full/cli_nomic-full.json
@@ -1,0 +1,12 @@
+{
+  "name": "nomic",
+  "model": "models/nomic-embed-v1.5.Q8_0.gguf",
+  "pooling": "mean",
+  "queries": 300,
+  "corpus": 5183,
+  "ndcg_10": 0.7034462747080099,
+  "recall_10": 0.8462222222222222,
+  "query_prefix": "search_query: ",
+  "doc_prefix": "search_document: ",
+  "wall_seconds": 69.0
+}

--- a/benchmarks/results/embedder-gate/scifact-full/cli_qwen3-0.6b-full.json
+++ b/benchmarks/results/embedder-gate/scifact-full/cli_qwen3-0.6b-full.json
@@ -1,0 +1,12 @@
+{
+  "name": "qwen3-0.6b-f16",
+  "model": "models/qwen3-emb-0.6b-f16.gguf",
+  "pooling": "last",
+  "queries": 300,
+  "corpus": 5183,
+  "ndcg_10": 0.7058511441435118,
+  "recall_10": 0.8398888888888889,
+  "query_prefix": "Instruct: Given a scientific claim, retrieve documents that support or refute the claim Query: ",
+  "doc_prefix": "",
+  "wall_seconds": 744.6
+}

--- a/benchmarks/results/reranker/LATENCY.md
+++ b/benchmarks/results/reranker/LATENCY.md
@@ -1,0 +1,93 @@
+# Qwen3-Reranker latency on 7900XTX (RADV/Vulkan) — 2026-06-22
+
+Per-query rerank latency = K full forward passes over (query, doc). SciFact text
+docs (~320 tok each), single batched request. **Native `/v1/rerank`** is the
+OPTIMAL path (one forward pass + pooling, no generation):
+
+| model | ms/candidate | K=5 | K=10 | K=20 | K for ~1s |
+|---|---|---|---|---|---|
+| 0.6B | ~130 | 0.7s | 1.4s | 2.7s | ~7 |
+| 4B   | ~187 | 0.94s | 1.8s | 3.7s | ~5 |
+| 8B   | ~264 | 1.3s | 2.6s | 5.4s | ~4 |
+
+**BUT native `/v1/rerank` scores Qwen3-Reranker WRONG** (toy gate: irrelevant doc
+scored highest — llama.cpp's classifier-head rerank path is invalid for this
+yes/no causal model). Correct scoring needs the **yes/no-logit path** (format the
+reranker template, generate 1 token, softmax P(yes) vs P(no)) — which is ~2.3×
+slower (0.6B K=10: 3.2s via /completion vs 1.4s native):
+
+| model (yes/no path) | ms/cand | K=10 | K=20 | K=50 | K for ~1s |
+|---|---|---|---|---|---|
+| 0.6B | ~320 | 3.2s | 4.4s | 9.5s | ~3 |
+
+Code docs (longer, ~500-2000 tok) are slower still.
+
+## Verdict
+No Qwen3-Reranker tier reranks a useful candidate set (top-20–100) in <1s on this
+GPU. Correct-scoring 0.6B fits only ~3 candidates in 1s; native-path best case ~7.
+Reranking top-20 costs 3–4s; top-100 costs 12–16s. **Reranking cannot be a
+synchronous real-time step here for meaningful depth.**
+
+Quality (for context): SciFact 0.6B reranker lifts first-stage nDCG@10 0.7059 ->
+0.7598 (+5.4) at top-100 — real quality, but seconds of latency.
+
+## Architecture comparison (SciFact, first-stage Qwen3-0.6B embed = 0.7059)
+
+| reranker | arch | quality (nDCG@10) | uplift | latency K=20 | correct via |
+|---|---|---|---|---|---|
+| Qwen3-Reranker-0.6B | generative cross-encoder | 0.7598 | +0.054 | 2.7s native / 4.4s correct | yes/no logits (native /v1/rerank BROKEN) |
+| bge-reranker-v2-m3 (568M) | BERT cross-encoder | 0.7392 | +0.033 | **0.79s** | native /v1/rerank (correct) |
+
+bge native latency: K=5 179ms, K=10 343ms, K=20 791ms (~36 ms/cand) — ~4x faster
+than Qwen3-0.6B native, ~9x faster than Qwen3's correct yes/no path, and it fits
+top-20 in <1s. Quality is ~60% of Qwen3-0.6B's uplift. **bge is the real-time
+reranker; Qwen3-Reranker is async-only here.**
+
+## Quality (SciFact, first-stage Qwen3-0.6B embed nDCG@10 = 0.7059)
+| reranker | uplift topk20 | uplift topk100 | toy gate |
+|---|---|---|---|
+| Qwen3-Reranker-0.6B | +0.037 | +0.054 | PASS |
+| Qwen3-Reranker-4B   | +0.009 (anomalous) | — | PASS |
+| bge-reranker-v2-m3  | +0.033 | — | PASS |
+
+4B's low topk20 uplift despite a passing toy gate = score saturation (Qwen3-Reranker
+piles scores at [0.99,1]/[0,0.01]; at shallow depth ties dominate). Published MTEB-R
+(top-100, many datasets) has 4B 69.76 > 8B 69.02 > 0.6B 65.80, so 4B≥0.6B in general;
+the SciFact-topk20 number is not representative. A faithful 4B/8B quality read needs
+the full top-100 protocol.
+
+## Architecture verdict (real-time <1s, 7900XTX)
+- **Qwen3-Reranker (generative cross-encoder)**: best published quality, but (a) too
+  slow — correct yes/no path is ~320 ms/cand (0.6B), top-20 = 4.4s; (b) llama.cpp
+  native /v1/rerank scores it WRONG; (c) saturates at shallow depth. => async-only.
+- **bge-reranker-v2-m3 (BERT cross-encoder, 568M)**: correct via fast native
+  /v1/rerank, ~36 ms/cand, top-20 = 0.79s (<1s), +0.033 uplift. => the real-time pick.
+- **ColBERT / late-interaction (not benchmarked here)**: doc token-embeddings
+  precomputed at ingest, so query-time latency is ~one query-encode + maxsim,
+  INDEPENDENT of K (~tens of ms for any depth). Highest throughput; needs token-
+  embedding storage and a maxsim path (no llama.cpp rerank endpoint). Quality
+  typically sits between bi-encoder and full cross-encoder.
+
+## DECISION (2026-06-22): Ettin ModernBERT rerankers (replaces Qwen3-Reranker)
+Modern (2025) ModernBERT encoders — correct + fast via native /v1/rerank (toy gate
+passed, well-spread scores, NOT saturated like Qwen3). Already aimee's baseline
+family ("pplx/ettin"). Per published MTEB(eng,v2): ettin-32m 0.578 > bge-v2-m3
+0.553; ettin-150m 0.599 > Qwen3-Reranker-0.6B 0.594; ettin-1b 0.611 = mxbai-large.
+
+Measured on 7900XTX (SciFact docs ~320 tok, native /v1/rerank):
+| model | GPU ms/cand | GPU top-20 | CPU ms/cand (-fa on,16T) | CPU top-10 | CPU top-20 |
+|---|---|---|---|---|---|
+| ettin-400m | ~36 | 0.76s | ~470 (no-fa) | — | 9.5s |
+| ettin-68m  | (~6-7) | <0.2s est | **~60** | **0.60s** | 1.22s |
+
+**GPU reranker = ettin-400m** (top-20 in 0.76s, quality ~0.605). **CPU reranker =
+ettin-68m** with -fa on (top-10-15 in <1s; quality ~0.589 > bge). Qwen3-Reranker
+REJECTED for the real-time path (generative yes/no, ~320ms/cand correct path,
+top-20=4.4s, native /v1/rerank scores it WRONG). -fa flag: was 'auto' originally;
+forcing 'on' is a minor win on short rerank pairs (FA helps less at ~320 tok / on CPU).
+
+## FASTPATH (-fa on) — final numbers
+ettin-400m GPU: -fa on = 17 ms/cand (top-20 0.34s) vs -fa auto 36 ms/cand (0.76s).
+**Flash Attention ~2x on GPU; 'auto' did NOT engage it on this Vulkan build — force -fa on.**
+ettin-68m CPU -fa on = 60 ms/cand (top-10 0.60s). FA is a minor win on CPU.
+FINAL: GPU reranker ettin-400m -fa on (top-20 0.34s); CPU reranker ettin-68m -fa on (top-10 <1s).

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -160,35 +160,51 @@ install by detected VRAM (§5).
 
 **Embed ladder** (the embed row's dim drives every dim-dependent surface):
 
-| Install | Embed (GGUF) | dim |
-|---------|--------------|-----|
-| CPU-only / GPU (default) | `Qwen/Qwen3-Embedding-0.6B-GGUF` | 1024 |
-| GPU (high) | `Qwen/Qwen3-Embedding-8B-GGUF` | **4000** (trunc) |
+| Install | Embed (GGUF) | dim | selection |
+|---------|--------------|-----|-----------|
+| CPU-only (**default**) | `Qwen/Qwen3-Embedding-0.6B-GGUF` | 1024 | auto |
+| GPU (**default**) | `Qwen/Qwen3-Embedding-4B-GGUF` | 2560 | auto (any GPU install) |
+| GPU (**opt-in**) | `Qwen/Qwen3-Embedding-8B-GGUF` | **4000** (trunc 4096→4000) | operator must explicitly configure |
 
-> **CORRECTION (2026-06-22): the "nomic-everywhere" change is reverted.** An
-> earlier revision (PR #613) collapsed this to a single nomic-embed-text-v1.5 row
-> on a LoCoMo screen — **that was wrong on two counts** and is withdrawn. (1) LoCoMo
-> (short conversational-turn retrieval) under-discriminates embedder quality. (2)
-> the Qwen3 numbers were also depressed by a broken llama.cpp serving config. On
-> the **standard SciFact BEIR benchmark with the serving fix applied**
-> ([embedder-gate-scifact](../../validation/embedder-gate-scifact.md)),
-> **Qwen3-Embedding wins decisively and scales**: nDCG@10 **0.883 (8B) > 0.820
-> (0.6B) > 0.799 (nomic)** — even the 0.6B beats nomic, matching Qwen3-Embedding's
-> SOTA MTEB standing. So the **default is Qwen3-Embedding-0.6B** (beats nomic at a
-> modest 1024-dim) and the **high tier is Qwen3-Embedding-8B** (best quality).
-> Qwen3-4B is dropped (no measured SciFact gain probed yet; the Qwen3 paper has 4B
-> ≥ 8B on general retrieval, so revisit only if a mid-VRAM tier is wanted).
+> **Basis (2026-06-22, baseline-gated — supersedes every earlier embed-ladder note,
+> including PR #613's "nomic-everywhere" and #617's capped-SciFact revert).** The
+> embedder was re-validated end-to-end against **published** baselines; full data,
+> the four-model ladder, and the harness are in
+> [embedder-gate-scifact](../../validation/embedder-gate-scifact.md). Headline:
+> - **aimee embeds code** (`kb_curator_index_code_unit.c` body/signature vectors,
+>   `kb_service_code_embed.c` code chunks) through the same configured embedder, so
+>   **code retrieval is the decisive axis**. **nomic-embed is text-only** (never
+>   trained on code): on aimee's *own* 1864-function code set Qwen3-0.6B beats nomic
+>   by **+12.7 nDCG@10 / +10 Recall@10**; on published MTEB code tasks the gap is
+>   **+9 to +63**. **nomic is dropped.**
+> - **Text is a wash-to-win for Qwen3.** Both reproduce their published BEIR numbers
+>   within ~1pt (harness validated): they tie on SciFact (0.703 vs 0.706) and
+>   NFCorpus, and Qwen3 wins the rest (FiQA +9, SCIDOCS +7, ArguAna +19,
+>   TREC-COVID +27). The earlier "0.820 > 0.799 SciFact" was a **capped-corpus
+>   artifact** and is withdrawn.
+> - **Quality scales then plateaus.** aimee-code nDCG@10: 0.6B **0.697** → 4B
+>   **0.759** → 8B **0.761**. The **0.6B→4B step is +6.2; 4B→8B is +0.16 (noise)** —
+>   confirmed f16-vs-f16, and 4B-Q8 == 4B-f16 (quantization lossless here). So **4B
+>   is the GPU default**: it delivers 8B-grade quality at **2560-d vs 4096-d**
+>   (1.6× smaller pgvector index, indexed natively under the 4000-d `halfvec`
+>   ceiling — no truncation), ~1.4× faster embed, ~½ the VRAM.
+> - **8B is an operator opt-in**, not auto-selected by VRAM. It buys only the last
+>   ~0.2 nDCG and costs a 4000-d (truncated) index; a deployment that wants it must
+>   **explicitly configure** the 8B tier (see "The 8B truncation" below). 0.6B and
+>   4B need no truncation.
 >
 > **Required serving config** (the proposal's `aimee-llm` must launch the embedder
 > with these, or it crashes/slows on llama.cpp + Vulkan):
 > `--ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots` — the default
 > prompt cache fragments the embedding KV cache (→ `GGML_ASSERT(task)` crash) and
 > continuous batching across slots hangs the server. Keep `-ub` ≤ 2048 (RADV
-> per-buffer limit). See the SciFact doc's "Serving fix" section.
+> per-buffer limit). (The HTTP `/v1/embeddings` path returns one vector per input by
+> construction; the `--no-escape` benchmark gotcha is CLI-only and does not affect
+> the server.)
 >
 > **Still provisional for the full cutover:** this is embedder-isolated retrieval
-> on one BEIR dataset; the full-pipeline ship-floor gate (rerank + fusion vs the
-> pplx baseline) remains the ship precondition.
+> (BEIR text + aimee's own code), not yet the full-pipeline ship-floor gate
+> (rerank + fusion vs the pplx baseline), which remains the ship precondition.
 
 **Reranker — decoupled, not part of the embed ladder.** The reranker scores
 `(query, candidate)` text pairs, so it is **dimension-agnostic** and need not scale
@@ -218,9 +234,11 @@ larger, ~8 pts, only on *code* retrieval).
 
 #### The 8B truncation — why 4000, and how it must be done
 
-> **Re-instated (2026-06-22):** the nomic-everywhere change is reverted (SciFact
-> shows Qwen3-Embedding wins — see the embed-ladder correction above), so the 8B
-> high tier and this truncation machinery are back in scope.
+> **Scope (2026-06-22):** the **GPU default is Qwen3-4B at 2560-d, which needs no
+> truncation** (it is under the 4000-d `halfvec` ceiling). This 4096→4000 machinery
+> applies **only when an operator opts into the 8B tier** (see the embed-ladder
+> "Basis" above — 8B buys ~0.2 nDCG over 4B for a 4096-d native vector). It is kept
+> because the 8B opt-in must store an indexable vector.
 
 Qwen3-Embedding-8B is **MRL-trained** (loss on first 512/1024/2048 + full 4096),
 so information front-loads into early dims; published guidance shows truncating to
@@ -442,14 +460,17 @@ We take the fold but pay down its cost:
   safety net for the cutover release, with the prior tag retained in the registry
   for a defined window.
 
-- **Embed = `Qwen3-Embedding-0.6B` default (1024-d) + `Qwen3-Embedding-8B` high
-  tier**, on **SciFact** evidence (nDCG@10 0.883 8B > 0.820 0.6B > 0.799 nomic;
-  even the 0.6B beats nomic) — see embedder-gate-scifact. The earlier
-  "nomic-everywhere" (PR #613, LoCoMo-based) is **reverted**: LoCoMo
-  under-discriminates and the Qwen3 runs were also hit by a llama.cpp serving
-  config bug (`--cache-idle-slots`/`--cache-ram` fragment the embedding KV →
-  `GGML_ASSERT(task)` crash). The embedder must run with
-  `-np 1 --cache-ram 0 --no-cache-idle-slots`. Full-pipeline ship-floor gate still
+- **Embed = `Qwen3-Embedding-0.6B` CPU default (1024-d), `Qwen3-Embedding-4B` GPU
+  default (2560-d), `Qwen3-Embedding-8B` operator opt-in (4000-d trunc).** Baseline-
+  gated against published numbers — see embedder-gate-scifact. Decisive axis is
+  **code** (aimee embeds raw code): nomic is text-only and loses by +9..+63 nDCG on
+  code (and +12.7 on aimee's own code), so **nomic is dropped**. On aimee-code the
+  ladder is 0.6B 0.697 → 4B 0.759 → 8B 0.761, i.e. **4B≈8B (+0.16, noise)** so 4B is
+  the GPU default (8B's 4096-d isn't worth ~0.2 nDCG); 8B is opt-in only. Both the
+  earlier "nomic-everywhere" (#613, LoCoMo) and the capped-SciFact "0.883/0.820/0.799"
+  revert (#617) are **withdrawn** as wrong/artifactual. Serving must run with
+  `-np 1 --cache-ram 0 --no-cache-idle-slots` (else the prompt cache fragments the
+  embedding KV → `GGML_ASSERT(task)` crash). Full-pipeline ship-floor gate still
   pending.
 - **Curator fold: take it** as an isolated supervised process + RBAC; off-box
   synth via forward/external; sidecar fallback = kernel-compromise response.

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -4,7 +4,8 @@
   blocking / 0 high / 0 medium, converged). Arc: r1 10 blocking → r2 7 blocking +
   8 high → r3 1 blocking + 1 high + 2 medium → r5 **0 blocking**. rev 7 closes the
   two open questions (pins the operator's synth models; decouples + shrinks the
-  reranker to 0.6B-default, 8B dropped; E4B-ungated CPU default). See "Decisions
+  reranker to Ettin ModernBERT — 400m GPU / 68m CPU, both `-fa on`, Qwen3-Reranker
+  dropped from the real-time path; E4B-ungated CPU default). See "Decisions
   taken" and "Changelog".
 - **Author:** JBailes
 - **Date:** 2026-06-21
@@ -208,14 +209,37 @@ install by detected VRAM (§5).
 
 **Reranker — decoupled, not part of the embed ladder.** The reranker scores
 `(query, candidate)` text pairs, so it is **dimension-agnostic** and need not scale
-with the embedder. Per the Qwen3 paper (Table 4), the **4B matches or beats the
-8B** (MTEB-R 69.76 vs 69.02; FollowIR 14.84 vs 8.05), so **8B is dropped
-entirely**, and the 0.6B is within ~3–4 pts of 4B on general retrieval (the gap is
-larger, ~8 pts, only on *code* retrieval).
+with the embedder. It runs **in the retrieval path of a user turn, so it must be
+real-time** (<~1s for the candidate set). That requirement **rules out the
+generative Qwen3-Reranker** — measured on the 7900XTX, its correct (yes/no-logit)
+scoring is ~320 ms/candidate → **top-20 = 4.4s**, and llama.cpp's native
+`/v1/rerank` scores it **incorrectly** (it is a yes/no causal LM, not a
+classifier-head cross-encoder, so the rank-pooling path is invalid — verified: an
+irrelevant doc scored highest).
 
-| Role | Default | Optional upgrade |
-|------|---------|------------------|
-| Reranker (all tiers) | `Qwen/Qwen3-Reranker-0.6B-GGUF` | `Qwen/Qwen3-Reranker-4B-GGUF` — an **embedder-independent** knob, recommended only for **code-heavy** deployments. **No 8B.** |
+The reranker is therefore **Ettin** (2025 ModernBERT cross-encoders — *already the
+pplx/ettin baseline family*; llama.cpp has native ModernBERT support). It is
+**correct *and* fast** via the native `/v1/rerank` endpoint, and is higher
+quality-per-param than both Qwen3-Reranker and bge-reranker-v2-m3 (published
+MTEB(eng, v2) nDCG@10: ettin-150m **0.599 > Qwen3-Reranker-0.6B 0.594**; ettin-32m
+**0.578 > bge-reranker-v2-m3 0.553**; ettin-1b 0.611 = mxbai-rerank-large-v2).
+
+> **Flash Attention is mandatory (`--flash-attn on`).** On this Vulkan build `-fa
+> auto` does **not** engage FA; forcing it on **~2× the GPU throughput** (ettin-400m:
+> 17 vs 36 ms/candidate). Every reranker `llama-server` launches with `-fa on`.
+
+| Tier | Reranker (GGUF) | Latency (measured, 7900XTX, `-fa on`) | quality (nDCG@10) |
+|------|-----------------|----------------------------------------|-------------------|
+| **GPU (default)** | `ettin-reranker-400m` | top-20 **0.34s** (17 ms/cand), top-50 ~0.85s | ~0.605 |
+| **CPU-only** | `ettin-reranker-68m` | top-10 **0.60s** (60 ms/cand); top-20 1.22s | ~0.589 |
+| CPU strict top-20 <1s | `ettin-reranker-32m` | top-20 ~0.76s | ~0.578 |
+| GPU max quality (opt-in) | `ettin-reranker-1b` | slower; = mxbai-large quality | ~0.611 |
+
+Both default tiers run the **native `/v1/rerank`** endpoint — one relevance score
+per `(query, candidate)` pair, **no chat template and no yes/no-logprob transform**
+(that machinery was specific to the rejected Qwen3-Reranker). Qwen3-Reranker is
+dropped from the real-time path; it remains usable only **async** (e.g. background
+memory re-ranking) where its quality is worth seconds of latency.
 
 **Synth ladder** (pinned to your specified models; MoE rows have low active params):
 
@@ -289,10 +313,13 @@ replay source rows through the new embedder (bounded batch) → **gate the kb to
 
 #### Reranker contract + embedding acceptance gates (named, distinct)
 
-The Qwen3-Reranker mapping is **pinned, not deferred**: fixed chat template, fixed
-yes/no target tokens, `temperature=0`, documented logprob→score transform, and a
-query-side instruction prefix (query path only; pooling documented). Two
-**distinct** quality gates (do not conflate):
+The reranker mapping is **pinned, not deferred**: Ettin runs as a ModernBERT
+cross-encoder over the **native `/v1/rerank`** endpoint with **`--flash-attn on`** —
+one relevance score per `(query, candidate)` pair, **no chat template and no
+yes/no-logprob transform** (that machinery was specific to the rejected generative
+Qwen3-Reranker and is removed). The scoring contract the drift guard pins is
+therefore `(model_id, rerank-endpoint=/v1/rerank, fa=on)`. Two **distinct** quality
+gates (do not conflate):
 
 - **Ship-floor gate (≥95%)** — gates *replacing* pplx/ettin, and it is a
   **pre-cutover precondition** evaluated in staging/CI against the real corpus
@@ -482,10 +509,13 @@ We take the fold but pay down its cost:
 - **CPU synth default = Gemma 4 E4B** via the ungated `ggml-org` GGUF mirror (no
   `HF_TOKEN`); the separate "ungated fallback" model is dropped.
 - **Synth models pinned** to the operator's spec: Gemma 4 **E4B (CPU)**, Gemma 4
-  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker decoupled and shrunk:
-  0.6B default everywhere, 4B optional for code-heavy, 8B dropped** (4B ≥ 8B per
-  Qwen3 Table 4); the reranker guard is keyed on `(model_id, scoring-contract)`,
-  not dim.
+  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker = Ettin (ModernBERT
+  cross-encoder), NOT Qwen3-Reranker**: GPU default `ettin-reranker-400m`, CPU-only
+  `ettin-reranker-68m`, both `--flash-attn on`. Real-time on the 7900XTX (ettin-400m
+  top-20 0.34s; ettin-68m top-10 0.60s) and correct/fast via native `/v1/rerank` —
+  Qwen3-Reranker is generative (~320 ms/cand, top-20 4.4s) and llama.cpp's native
+  rerank scores it wrong, so it is dropped from the real-time path. The reranker
+  guard is keyed on `(model_id, scoring-contract)`, not dim.
 - **Streaming disabled** in the first release.
 - **Two named gates:** ship-floor ≥95% (replace pplx/ettin) vs tier-cutoff ≥99%
   (enable 8B truncated tier).
@@ -525,8 +555,10 @@ We take the fold but pay down its cost:
   operator's spec — Gemma 4 E4B (CPU, **ungated `ggml-org` mirror → no `HF_TOKEN`**,
   so the rev-5 "ungated fallback" model is dropped and E4B is the plain CPU
   default), Gemma 4 12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Decoupled the
-  reranker** from the embed ladder (it is dimension-agnostic): **0.6B default on all
-  tiers, 4B optional for code-heavy, 8B dropped** (per Qwen3 Table 4 the 4B ≥ 8B).
+  reranker** from the embed ladder (it is dimension-agnostic): **Ettin ModernBERT
+  cross-encoder — `ettin-reranker-400m` (GPU) / `ettin-reranker-68m` (CPU), both
+  `-fa on`; Qwen3-Reranker dropped from the real-time path** (too slow + native
+  rerank scores it wrong).
   Embed GGUF repos named. Updated §2 ladders, §5 (retitled "GPU detection &
   sizing"), "What this removes", Migration, Decisions.
 - **rev 6 (2026-06-21):** roundtable **signed off** (round 5: 0 blocking/high/medium,

--- a/docs/validation/embedder-gate-locomo.md
+++ b/docs/validation/embedder-gate-locomo.md
@@ -1,13 +1,13 @@
 # Embedder retrieval-quality probe (LoCoMo)
 
 > **⚠️ SUPERSEDED / DO NOT USE FOR THE EMBEDDER DECISION (2026-06-22).** This
-> LoCoMo screen ranked nomic above Qwen3 — that ranking is **wrong**. LoCoMo
-> (short conversational-turn retrieval) under-discriminates embedder quality. On
-> the standard SciFact BEIR benchmark with a fixed serving environment,
-> **Qwen3-Embedding beats nomic decisively (even the 0.6B)** — the opposite of
-> this page. See [embedder-gate-scifact](embedder-gate-scifact.md). Kept only as
-> a record of how a weak benchmark + a broken llama.cpp serving config produced a
-> misleading result.
+> LoCoMo screen ranked nomic above Qwen3 on conversational-turn retrieval, which
+> under-discriminates embedder quality. The decision is made on **baseline-gated
+> BEIR text + code retrieval** — see [embedder-gate-scifact](embedder-gate-scifact.md).
+> Summary there: on text the two tie on SciFact/NFCorpus and Qwen3 wins the rest;
+> on **code** (which aimee embeds) Qwen3 beats text-only nomic by +9..+63 nDCG, so
+> nomic is dropped and the ladder is Qwen3-0.6B (CPU) / 4B (GPU) / 8B (opt-in).
+> Kept only as a record of how a weak benchmark produced a misleading ranking.
 
 A reproducible, **embedder-isolated** retrieval benchmark — a precursor to the
 full ship-floor gate in

--- a/docs/validation/embedder-gate-scifact.md
+++ b/docs/validation/embedder-gate-scifact.md
@@ -1,122 +1,135 @@
-# Embedder retrieval quality — SciFact (the trustworthy benchmark)
+# Embedder choice — baseline-gated validation (text BEIR + code)
 
-**This supersedes the LoCoMo screen ([embedder-gate-locomo](embedder-gate-locomo.md))
-for the embedder-choice decision.** LoCoMo (short conversational-turn retrieval)
-under-discriminates embedder quality and gave a misleading ranking; SciFact (a
-standard BEIR benchmark with real relevance judgments and nDCG@10) is the metric
-embedder leaderboards use, and it separates the models cleanly.
+**Decision: drop nomic; use Qwen3-Embedding — 0.6B (CPU default, 1024-d), 4B (GPU
+default, 2560-d), 8B (operator opt-in, 4000-d trunc).** This supersedes the LoCoMo
+screen ([embedder-gate-locomo](embedder-gate-locomo.md)) **and** the earlier
+capped-corpus SciFact numbers that once lived in this file (the "0.883 / 0.820 /
+0.799" table — withdrawn; it was a capped-corpus artifact, see below).
 
-Harness: [`benchmarks/beir_gate.py`](../../benchmarks/beir_gate.py). Hardware: AMD
-Radeon RX 7900 XTX (RADV/Vulkan), llama.cpp `b9754`. Corpus: SciFact, capped to
-1411 docs (all 300 test queries + their judged-relevant docs), same corpus for
-every model. Each model uses its card-recommended prefix (recorded in the
-artifacts under [`benchmarks/results/embedder-gate/scifact/`](../../benchmarks/results/embedder-gate/scifact/)).
+Every number below is **baseline-gated**: each model's score is trusted only after
+it reproduces its *published* result on the same harness. Harness:
+[`benchmarks/beir_cli.py`](../../benchmarks/beir_cli.py) driving llama.cpp
+`llama-embedding` on an AMD RX 7900 XTX (RADV/Vulkan). Artifacts in
+[`benchmarks/results/embedder-gate/`](../../benchmarks/results/embedder-gate/)
+(`scifact-full/`, `multi-beir/`, `aimee-code/`).
 
-## Result
+## Why this matters: aimee embeds code
 
-| model | dim | **nDCG@10** | Recall@10 |
+The configured embedder is used for **code**, not just memory text:
+`kb_service_code_embed.c` writes code-chunk vectors (`code_embeddings`), and
+`kb_curator_index_code_unit.c` writes three named vectors per code unit —
+`intent_vec` (NL summary), `sig_vec` (signature), **`body_vec` (raw code body)**.
+So **code-retrieval quality is a first-class selection axis**, and a text-only
+model is the wrong tool.
+
+## Headline
+
+1. **nomic-embed-text-v1.5 is text-only** (no code training) and loses on code by a
+   wide margin → **dropped**.
+2. **On text**, nomic and Qwen3-0.6B both reproduce their published BEIR baselines
+   (harness validated); they tie on SciFact/NFCorpus and Qwen3 wins the rest.
+3. **On code**, Qwen3 dominates, and **quality plateaus at 4B**: 4B ≈ 8B, so 4B is
+   the GPU default and 8B is an opt-in for the last ~0.2 nDCG.
+
+## Text BEIR — baseline reproduction (full corpus)
+
+Mine (this harness) vs **published** MTEB nDCG@10. nomic = mean-pool 768-d (docs
+truncated to its ~2048-token limit, its real behavior); Qwen3-0.6B = last-pool
+fp16 1024-d with the card instruction prefix.
+
+| dataset | nomic (mine / pub) | Qwen3-0.6B (mine / pub) |
+|---|---|---|
+| SciFact  | **0.7034** / 0.7028 | **0.7059** / 0.6972 |
+| NFCorpus | **0.3466** / 0.3467 | **0.3701** / 0.3671 |
+| ArguAna  | 0.3556 / 0.5202 | 0.4856 / 0.7097 |
+
+SciFact and NFCorpus reproduce published within **~0.3pt for both models** → the
+harness is sound. ArguAna is a *symmetric* argument-retrieval task; asymmetric
+query/doc prefixes depress **both** models' absolute scores, but Qwen3 still wins
+(+13pt mine, +19pt published). Per published BEIR, Qwen3-0.6B also wins FiQA (+9),
+SCIDOCS (+7), ArguAna (+19), TREC-COVID (+27); SciFact/NFCorpus are the rare ties.
+
+> **The withdrawn capped result.** An earlier version of this page reported Qwen3
+> beating nomic on SciFact 0.820 vs 0.799 (and 8B 0.883). Those were measured on a
+> **capped 1411-doc corpus**, which inflates nDCG and flipped the ranking. On the
+> **full 5183-doc corpus** the gap vanishes (0.706 vs 0.703 ≈ tie) and both match
+> their published numbers. SciFact alone does **not** justify Qwen3; the code
+> evidence does.
+
+## Code retrieval — the decisive axis
+
+### Published MTEB code tasks (nDCG@10)
+
+| task | nomic | Qwen3-0.6B | Qwen3-4B | Qwen3-8B |
+|---|---|---|---|---|
+| CodeSearchNet | 0.856 | 0.943 | 0.960 | 0.966 |
+| CodeSearchNet-CC | 0.489 | 0.933 | 0.967 | 0.971 |
+| CosQA | 0.261 | 0.365 | 0.380 | 0.380 |
+| CodeFeedback-ST | 0.543 | 0.864 | 0.895 | 0.899 |
+| CodeFeedback-MT | 0.282 | 0.908 | 0.932 | 0.937 |
+| CodeTransOcean-Contest | 0.368 | 0.861 | 0.910 | 0.937 |
+| SyntheticText2SQL | 0.481 | 0.767 | 0.782 | 0.788 |
+| StackOverflowQA | 0.636 | 0.900 | 0.943 | 0.948 |
+
+nomic trails Qwen3 by **+9 to +63**. The **0.6B→4B** gains are real (e.g.
+CodeSearchNet-CC +3.4, CodeTransOcean +4.9); **4B→8B is ≤+0.5** everywhere.
+
+### On aimee's OWN code (the real proxy)
+
+1864 functions from `src/**/*.c`: a leading block comment is the query, the
+function signature+body is the relevant doc (1:1) — i.e. NL-intent → code-body
+retrieval, exactly the `intent_vec`→`body_vec` match aimee performs. Docs capped
+to 2000 chars (one clean sequence per doc). Artifacts in
+[`benchmarks/results/embedder-gate/aimee-code/`](../../benchmarks/results/embedder-gate/aimee-code/).
+
+| model | nDCG@10 | Recall@10 | embed time | dim | VRAM |
+|---|---|---|---|---|---|
+| nomic-v1.5 | 0.570 | 0.717 | 20s (1×) | 768 | 0.2 GB |
+| **Qwen3-0.6B** (f16) | **0.697** | 0.817 | 217s (11×) | 1024 | 1.2 GB |
+| Qwen3-4B (Q8) | 0.7592 | 0.874 | 343s | 2560 | 6 GB |
+| **Qwen3-4B** (f16) | **0.7592** | 0.878 | 333s (17×) | 2560 | 8 GB |
+| Qwen3-8B (f16) | 0.7608 | 0.880 | 475s (24×) | 4096 | 15 GB |
+
+- **Qwen3-0.6B beats nomic by +12.7 nDCG / +10 Recall@10.**
+- **0.6B→4B = +6.2 nDCG (real); 4B→8B = +0.16 (noise)**, confirmed f16-vs-f16.
+- **4B-Q8 nDCG == 4B-f16 nDCG (0.7592)** → Q8 is lossless here; 4B-Q8 (4.3 GB) is a
+  free option for the GPU default.
+
+## The ladder this produces
+
+| tier | model | dim | when |
 |---|---|---|---|
-| **Qwen3-Embedding-8B** | 4096 | **0.8831** | 0.9600 |
-| **Qwen3-Embedding-0.6B** | 1024 | **0.8203** | 0.9200 |
-| nomic-embed-text-v1.5 | 768 | 0.7993 | 0.8792 |
+| CPU default | Qwen3-Embedding-0.6B | 1024 | auto (no GPU) — matches pplx-embed's 1024-d, no schema change |
+| GPU default | Qwen3-Embedding-4B | 2560 | auto (any GPU) — 8B-grade quality, indexed natively (<4000-d `halfvec` ceiling) |
+| GPU opt-in | Qwen3-Embedding-8B | 4000 (trunc 4096→4000) | operator must explicitly configure — buys ~0.2 nDCG for 4096-d native + 2× VRAM |
 
-**Qwen3-Embedding wins decisively — even the 0.6B beats nomic — and it scales
-(0.6B → 8B).** This matches Qwen3-Embedding's SOTA standing on the public MTEB
-retrieval leaderboard, and it is the **opposite** of the LoCoMo screen (where
-nomic edged ahead). The LoCoMo ranking is rejected.
+8B is **not** auto-selected by VRAM: 4B already captures its quality at 1.6× smaller
+vectors and ~1.4× faster embed. See
+[unified-llm-container](../proposals/pending/unified-llm-container.md) for the
+truncation machinery (only the 8B opt-in needs it).
 
-## Why the earlier LoCoMo conclusion (and PR #613) was wrong
+## Serving / harness gotchas
 
-Two compounding errors, both since corrected:
-
-1. **Wrong benchmark.** LoCoMo retrieves short, casual conversational turns — a
-   task that doesn't separate embedder quality, where a small model trained on
-   conversational web data (nomic) is artificially competitive. It is not a proxy
-   for production retrieval quality.
-2. **Broken serving environment.** The Qwen3 numbers were *also* depressed/blocked
-   by a llama.cpp **server** misconfiguration (next section), which crashed or
-   slowed the Qwen3 runs. Once fixed, Qwen3's true quality showed.
-
-It was **not** a pooling bug — verified directly: qwen3-0.6b with the GGUF default
-pooling and with explicit `--pooling last` give the **identical** LoCoMo score
-(R@5 0.5296), confirming the Qwen3-Embedding card's last-token spec is what runs;
-forcing the wrong `--pooling mean` collapses it to R@5 0.188 (that's what a real
-pooling bug would look like, and our runs were not that). And **not** a batching
-bug — a text embedded alone vs anywhere in a batch is identical (cos 0.9999).
-
-**Regime caveat (this is general retrieval, not conversational memory).** LoCoMo
-is short conversational-turn retrieval — a legitimate regime, and one aimee
-actually cares about (it is a memory system). So LoCoMo is not "garbage data," it
-just doesn't generalize to embedder-quality ranking: there, nomic was competitive.
-The revert says **Qwen3 wins for general / long-form retrieval** (SciFact +,
-below, NFCorpus/FiQA); whether nomic remains competitive specifically on
-conversational-memory recall is an open question for the full-pipeline gate on
-aimee's own corpus. The default-tier 0.6B-vs-nomic gap on SciFact is modest
-(0.820 vs 0.799), which is why this is confirmed across multiple BEIR datasets.
-
-## Serving fix — required to run Qwen3-Embedding on llama.cpp + Vulkan
-
-Out of the box, `llama-server --embeddings` crashed (`GGML_ASSERT(task)` at
-`tools/server/server-context.cpp:363`) and ran slowly on the 7900XTX. Root cause
-was **not** the model or the GPU — `llama-bench` reports **7,524 tok/s
-prompt-processing** (`pp512`, which *is* the embedding-relevant path — embedding =
-prompt eval with no generation) on qwen3-0.6b, with `matrix cores: KHR_coopmat`
-enabled. It was two server defaults that are hostile to embedding workloads:
-
-- **`--cache-idle-slots` + `--cache-ram 8192` (both ON by default)** save idle
-  slots to a prompt cache on every task. For embeddings (every request is a new
-  short sequence) this wastes time **and fragments the KV cache**, which is what
-  produced the "failed to find free space in the KV cache" → `GGML_ASSERT(task)`
-  crash via the unsplittable-pooled-embedding retry path.
-- **continuous batching across many slots (`-cb -np 8`)** caused the server to
-  *hang* (a "cancel task" cascade), not crash.
-
-**Working config** (stable end-to-end on the full corpus):
-
-```
-llama-server -m <embed.gguf> --embeddings -ngl 99 \
-    --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
-```
-
-Also note: `-ub 8192` trips a RADV per-buffer-size limit
-(`ErrorOutOfDeviceMemory`), so keep `-ub` ≤ 2048.
-
-The flags, from `llama-server --help` (build b9754): `--cache-ram N` "set the
-maximum cache size in MiB (default: 8192, … 0 = disable)"; `--cache-idle-slots`
-"save idle slots to the prompt cache on new task … (default: enabled, requires
-cache-ram)". Disabling both removes the prompt-cache path entirely, which is what
-both the slowdown and the KV-fragmentation crash hinged on.
-
-## Confirmation across more BEIR datasets
-
-A single dataset with a modest default-tier gap (0.820 vs 0.799) is not enough to
-revert a merged decision on its own. The strongest *multi-dataset* evidence is the
-public **MTEB retrieval leaderboard**, which aggregates 50+ datasets: there,
-**Qwen3-Embedding-0.6B and -8B both rank well above nomic-embed-text-v1.5** (Qwen3
--Embedding is current SOTA for its sizes; nomic-v1.5 is a strong but older
-137M-class model). Our on-hardware SciFact run agrees with that consensus, which
-is the point — it is a *confirmation* of the leaderboard, not a lone data point.
-
-A local NFCorpus + FiQA re-run was attempted for an independent on-box check but
-hit a harness/localhost connection flake near the end of the runs (the servers did
-not crash — no assert in any log — the eval client dropped). It is **not** needed
-to justify the revert given the MTEB consensus, but a more resilient harness pass
-is a cheap follow-up. Also surfaced by that attempt — a real, decision-relevant
-constraint: **nomic-embed-text-v1.5's training context is only 2048 tokens** (it
-errors / truncates on longer documents), whereas Qwen3-Embedding handles 32768 —
-a further point in Qwen3's favour for long-document retrieval. (And: for
-embeddings `-ub` must be ≥ the longest single document's token count, since a
-pooled embedding cannot be split across ubatches.)
-
-This config requirement matters for
-[unified-llm-container](../proposals/pending/unified-llm-container.md): the
-`aimee-llm` embedder must launch its `llama-server` with the prompt cache disabled
-and a single embedding slot. The crash is also a genuine upstream llama.cpp bug
-(cache-idle-slots KV fragmentation + the embedding retry path) worth reporting.
+- **Serving (production, HTTP):** `llama-server --embeddings -np 1 --cache-ram 0
+  --no-cache-idle-slots` — the default prompt cache fragments the embedding KV cache
+  (`GGML_ASSERT(task)` crash); keep `-ub` ≤ 2048 (RADV per-buffer limit). The
+  `/v1/embeddings` endpoint returns one vector per input by construction.
+- **Code embedding via the CLI harness needs `--no-escape`.** `llama-embedding`
+  expands literal `\n`/`\t` (ubiquitous in C string literals) into real newlines,
+  splitting one code prompt into many embeddings (1864 docs → 2889). `--no-escape`
+  fixes it. **CLI-only** — the HTTP server is unaffected (JSON inputs are discrete).
+- **Token density:** C code is ~1.8 chars/token; cap code docs ~2000 chars so each
+  stays one sequence (else llama-embedding chunk-splits >ctx prompts).
+- **The Qwen3 query instruction contains a newline** (`Instruct: …\nQuery: `);
+  the line-based CLI needs it collapsed to a space (negligible quality effect).
+- **Sizing:** `ctx 2048` is correct for these corpora; `ctx 8192` made the 0.6B run
+  ~20× slower (KV thrash, GPU 15%) for no benefit.
 
 ## Caveats
 
-One BEIR dataset (scientific claim verification). LongMemEval / other BEIR tasks
-and the full aimee pipeline (rerank + fusion) can still shift absolute numbers,
-but the *ranking* here (Qwen3 > nomic, scaling with size) is the trustworthy
-signal and aligns with public MTEB.
+Embedder-isolated retrieval (BEIR text + aimee's own code), **not** the full aimee
+pipeline (rerank + fusion). The aimee-code task uses comment↔function pairs as
+relevance (constructed, not human-judged), so absolute numbers are indicative; the
+**gaps** are the signal and they agree with published MTEB. The formal ship-floor
+gate (≥95% of the pplx baseline through `aimee eval`) remains the cutover
+precondition.

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -86,8 +86,13 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
  * (fresh) worktree, so the trust dialog re-appears every session and wedges the
  * pane; this trusts `work_dir`. Best-effort and idempotent — never fails the
  * turn (a worst case just re-shows a prompt). Call before creating a claude
- * session. No-op for non-claude providers (caller gates on cli_kind). */
-void cli_session_prepare_claude(const char *work_dir);
+ * session. No-op for non-claude providers (caller gates on cli_kind).
+ *
+ * `autonomous`: when nonzero the launch passes --dangerously-skip-permissions,
+ * so also pre-accept its one-time warning (skipDangerousModePermissionPrompt).
+ * When zero, only onboarding + per-folder trust are seeded (those are required
+ * for the TUI to start at all); the bypass warning is left untouched. */
+void cli_session_prepare_claude(const char *work_dir, int autonomous);
 
 /* Kills the tmux session. No-op if already dead. */
 void cli_session_destroy(cli_session_t *s);

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -99,12 +99,18 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    char cli_cmd_buf[CLI_SESSION_CMD_MAX];
    const char *cli_cmd = base_cmd;
    int need_model = agent->model[0] && !strstr(base_cmd, "--model") && !strstr(base_cmd, " -m ");
-   /* claude runs autonomously here (no human to approve tools) inside a
-    * sandboxed container, so bypass its permission prompts — unless the launch
-    * command already selects a permission mode. Mirrors the legacy `claude -p`
-    * path, which always passed this. The matching first-run acceptances are
-    * seeded by cli_session_prepare_claude() below. */
-   int need_skip = is_claude && !strstr(base_cmd, "--dangerously-skip-permissions") &&
+   /* Autonomous = bypass claude's interactive permission prompts (there is no
+    * human at the detached tmux pane to answer them; aimee's own guardrails are
+    * the safety layer). Driven by the global `autonomous` config — EXCEPT a
+    * primary webchat turn (a real bound session, not a delegate), which is
+    * always autonomous: it is the interactive UI a user is waiting on, and a
+    * non-autonomous claude would wedge forever on its first tool prompt. */
+   int deleg = deleg_id && deleg_id[0];
+   int webchat_primary = have_session && !deleg;
+   int autonomous = agent->autonomous || webchat_primary;
+   /* Pass --dangerously-skip-permissions only when autonomous, and only if the
+    * launch command doesn't already select a permission mode. */
+   int need_skip = is_claude && autonomous && !strstr(base_cmd, "--dangerously-skip-permissions") &&
                    !strstr(base_cmd, "--permission-mode");
    if (need_model || need_skip)
    {
@@ -124,11 +130,12 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    else if (getcwd(cwd, sizeof(cwd)) == NULL)
       cwd[0] = '\0';
 
-   /* Seed claude-code's first-run gates (onboarding / bypass warning / per-
-    * folder trust for this worktree) so its interactive TUI starts at the
-    * prompt instead of wedging the pane. Best-effort; no-op for other CLIs. */
+   /* Seed claude-code's first-run gates (onboarding / per-folder trust for this
+    * worktree, + the bypass warning when autonomous) so its interactive TUI
+    * starts at the prompt instead of wedging the pane. Best-effort; no-op for
+    * other CLIs. */
    if (is_claude)
-      cli_session_prepare_claude(cwd);
+      cli_session_prepare_claude(cwd, autonomous);
 
    cli_session_t sess;
    int rc = cli_session_create(&sess, sess_name, cli_cmd, cwd, reuse);

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -264,7 +264,7 @@ static cJSON *cli_claude_cfg_load(const char *path, int *skip)
    return root ? root : cJSON_CreateObject();
 }
 
-void cli_session_prepare_claude(const char *work_dir)
+void cli_session_prepare_claude(const char *work_dir, int autonomous)
 {
    const char *home = cli_claude_home();
    char claude_dir[PATH_MAX], lockpath[PATH_MAX], jsonpath[PATH_MAX], setpath[PATH_MAX];
@@ -325,20 +325,26 @@ void cli_session_prepare_claude(const char *work_dir)
    }
 
    /* ~/.claude/settings.json: pre-accept the bypass-permissions warning so a
-    * --dangerously-skip-permissions launch starts straight at the prompt. */
-   cJSON *sroot = cli_claude_cfg_load(setpath, &skip);
-   if (sroot)
+    * --dangerously-skip-permissions launch starts straight at the prompt. Only
+    * when autonomous — without the flag the warning never appears, and we must
+    * not silently pre-accept a dangerous-mode prompt the operator didn't opt
+    * into. */
+   if (autonomous)
    {
-      if (cli_json_set_true(sroot, "skipDangerousModePermissionPrompt"))
+      cJSON *sroot = cli_claude_cfg_load(setpath, &skip);
+      if (sroot)
       {
-         char *out = cJSON_Print(sroot);
-         if (out)
+         if (cli_json_set_true(sroot, "skipDangerousModePermissionPrompt"))
          {
-            cli_write_file_atomic(setpath, out);
-            free(out);
+            char *out = cJSON_Print(sroot);
+            if (out)
+            {
+               cli_write_file_atomic(setpath, out);
+               free(out);
+            }
          }
+         cJSON_Delete(sroot);
       }
-      cJSON_Delete(sroot);
    }
 
    if (lf >= 0)

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -559,7 +559,7 @@ static void test_prepare_claude_seeds_gates(void)
    setenv("AIMEE_HOME", home, 1);
    const char *wt = "/tmp/aimee_clitest_wt/session-abc";
 
-   cli_session_prepare_claude(wt);
+   cli_session_prepare_claude(wt, 1);
 
    char p[512];
    snprintf(p, sizeof(p), "%s/.claude.json", home);
@@ -587,7 +587,7 @@ static void test_prepare_claude_seeds_gates(void)
    cJSON_Delete(sroot);
 
    /* Idempotent: a second call leaves the same state (and must not throw). */
-   cli_session_prepare_claude(wt);
+   cli_session_prepare_claude(wt, 1);
    snprintf(p, sizeof(p), "%s/.claude.json", home);
    j = slurp(p);
    root = cJSON_Parse(j);
@@ -612,7 +612,7 @@ static void test_prepare_claude_preserves_existing_settings(void)
    fputs("{\"theme\":\"dark\"}", f);
    fclose(f);
 
-   cli_session_prepare_claude("/tmp/aimee_clitest_wt2");
+   cli_session_prepare_claude("/tmp/aimee_clitest_wt2", 1);
 
    char *s = slurp(p);
    cJSON *sroot = cJSON_Parse(s);
@@ -645,12 +645,51 @@ static void test_prepare_claude_skips_unparseable_config(void)
    fputs(corrupt, f);
    fclose(f);
 
-   cli_session_prepare_claude("/tmp/aimee_clitest_wt3");
+   cli_session_prepare_claude("/tmp/aimee_clitest_wt3", 1);
 
    char *after = slurp(jp);
    assert(after != NULL);
    assert(strcmp(after, corrupt) == 0); /* untouched, not wiped to {} */
    free(after);
+}
+
+/* Non-autonomous: onboarding + trust ARE seeded (the TUI needs them to start),
+ * but the --dangerously-skip-permissions warning is NOT pre-accepted (the flag
+ * isn't passed, so the operator's dangerous-mode prompt is left untouched). */
+static void test_prepare_claude_nonautonomous_skips_bypass_seed(void)
+{
+   char home[] = "/tmp/aimee_clitest_XXXXXX";
+   assert(mkdtemp(home) != NULL);
+   setenv("HOME", home, 1);
+   setenv("AIMEE_HOME", home, 1);
+   const char *wt = "/tmp/aimee_clitest_wt4";
+
+   cli_session_prepare_claude(wt, 0); /* not autonomous */
+
+   /* onboarding + trust seeded */
+   char p[600];
+   snprintf(p, sizeof(p), "%s/.claude.json", home);
+   char *j = slurp(p);
+   assert(j != NULL);
+   cJSON *root = cJSON_Parse(j);
+   free(j);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(root, "hasCompletedOnboarding")));
+   cJSON *proj =
+       cJSON_GetObjectItemCaseSensitive(cJSON_GetObjectItemCaseSensitive(root, "projects"), wt);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(proj, "hasTrustDialogAccepted")));
+   cJSON_Delete(root);
+
+   /* bypass warning NOT pre-accepted: settings.json absent or flag unset */
+   snprintf(p, sizeof(p), "%s/.claude/settings.json", home);
+   char *s = slurp(p);
+   if (s)
+   {
+      cJSON *sroot = cJSON_Parse(s);
+      free(s);
+      assert(sroot == NULL || !cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(
+                                  sroot, "skipDangerousModePermissionPrompt")));
+      cJSON_Delete(sroot);
+   }
 }
 
 int main(void)
@@ -665,6 +704,10 @@ int main(void)
 
    printf("test_prepare_claude_skips_unparseable_config... ");
    test_prepare_claude_skips_unparseable_config();
+   printf("OK\n");
+
+   printf("test_prepare_claude_nonautonomous_skips_bypass_seed... ");
+   test_prepare_claude_nonautonomous_skips_bypass_seed();
    printf("OK\n");
 
    printf("test_extract_claude_basic... ");


### PR DESCRIPTION
Promote testing → main. Headline: #629 gates claude `--dangerously-skip-permissions` on autonomous mode (webchat primary turns always autonomous; aimee guardrails are the safety layer) — follow-up to the #626 tmux-CLI claude-TUI fix already on main. Also folds in #628 (Ettin reranker docs).