### PR TITLE
docs(synth): re-benchmark curator on 60-sample workspace corpus (grammar-enforced + judged) — gemma-4-12B GPU / gemma-4-E4B CPU

### DIFF
--- a/benchmarks/results/synth/README.md
+++ b/benchmarks/results/synth/README.md
@@ -1,0 +1,33 @@
+# Synth/curator benchmark harness
+
+The harness behind [`RESULTS.md`](RESULTS.md). Measures the curator's real job —
+**async structured-JSON extraction** — with **sampler-level grammar enforcement** (a
+generic-JSON GBNF), because `response_format: json_object` is silently ignored by
+llama.cpp b9761 and otherwise confounds the scores (it measures freeform-JSON luck).
+
+## Scripts
+- **`synth_bench.py PORT MODEL NAME [CORPUS]`** — runs the corpus through an
+  OpenAI-compatible `/v1/chat/completions` endpoint with grammar-enforced JSON,
+  scores doc/code schema conformance + valid-JSON rate + tok/s, and **saves every raw
+  extraction** into `res4_<NAME>.json` for downstream re-scoring/judging.
+- **`serve_and_bench.sh MODELFILE MODE LABEL`** — driver: starts `llama-server`
+  (`-fa on`, GBNF via the harness), waits for health, runs `synth_bench.py`, tears the
+  server down. `MODE` = `gpu` (`-ngl 99`) | `cpu` (`-ngl 0`). One model at a time.
+- **`rescore_strict.py res4_<NAME>.json`** — re-scores the saved raws with the *strict*
+  rubric (a malformed primary artifact costs points + a validity-rate term), which
+  de-saturates the lenient schema check. No re-generation needed.
+
+## Corpus (not committed)
+The 60-sample corpus is built per-host from the real `~/dev` + `~/gow` workspace (every
+aimee-supported language) and is **not** committed — it is workspace-specific and large.
+`synth_bench.py` takes the corpus path as `argv[4]`. Each sample is:
+```json
+{"role":"extract_doc","lang":"Markdown","project":"...","input":{"file_path","heading_path","content"}}
+{"role":"extract_code","lang":"Rust","project":"...","input":{"file_path","symbol","line","kind","body"}}
+```
+
+## Content judge
+The blind content judge (faithfulness / completeness / structure over a fixed
+one-per-language + docs subset) is run by hand from the saved `res4_*.json` raws; see
+`RESULTS.md` for methodology and scores. Paths in `serve_and_bench.sh` reflect the
+bench-box layout (`/mnt/media/synthbench`).

--- a/benchmarks/results/synth/RESULTS.md
+++ b/benchmarks/results/synth/RESULTS.md
@@ -1,47 +1,97 @@
-# Synthesizer / curator model benchmark (2026-06-22)
+# Synthesizer / curator model benchmark (2026-06, grammar-enforced + judged)
 
 The curator/synth LLM does **async structured-JSON extraction** (`scripts/curator-extract.py`:
-doc → {entities, claims, doc_summary}; code → {code_unit: summary, side_effects,
-domain_concepts}; story-continuity) via an OpenAI-compatible `/chat/completions`
-endpoint, parsing the first JSON object. So the model must: produce **reliable
-structured JSON**, follow the schema, and keep **throughput** up (queue drain; async,
-not latency-bound).
+doc → `{artifacts:[doc_summary, claim, entity]}`; code → `{artifacts:[code_unit]}`) over an
+OpenAI-compatible `/v1/chat/completions` endpoint. It is **throughput-bound** (drains an
+extraction queue), not latency-bound. So the axes are: **reliable structured JSON +
+schema/content fidelity + tok/s**.
 
-Benchmark: the real `curator-extract` doc + code prompts over 12 samples (6 doc from
-aimee docs, 6 code units from `src/`), `temperature=0`, `enable_thinking=false`,
-`response_format=json_object`. Scored: schema conformance (doc + code), parse rate,
-tok/s. Hardware: 7900XTX (24GB, Vulkan, llama.cpp b9761), Q4_K_M, **one model at a
-time**.
+## Why this was redone (the first pass was confounded)
+The original harness scored on `response_format: json_object`, which **llama.cpp b9761
+silently ignores** — models emitted arbitrary JSON and the metric measured *freeform-JSON
+luck, not quality*. It produced false findings ("every Qwen slips structurally", "granite-3b
+regressed", "8B beats 32B"). Proven: granite-3b's raw-parse was 0.5 under `json_object`;
+forcing a **generic-JSON GBNF grammar at the sampler** took it to 1.0 and doc-schema
+0.167 → 0.833. Every old number was discarded and the sweep rerun grammar-enforced.
 
-| tier | model | doc_schema | code_schema | parse | tok/s | JSON |
+## Method
+- **Corpus** (`synth_corpus_full.json`, 60 samples) drawn from the **real ~/dev + ~/gow
+  workspace**: 24 doc chunks across 24 projects + 36 code units covering **every
+  aimee-supported language** — C, C++, Rust, Go, Python, TypeScript, JavaScript, Java, C#,
+  Ruby, Bash, Swift, Kotlin, Scala — plus CSS, HTML, Markdown. (Swift/Kotlin/Scala
+  synthesized; the workspace has none.)
+- **Grammar-enforced** JSON (sampler GBNF) so validity is guaranteed; the score measures
+  content/structure, not luck.
+- **Three uniform layers, identical for every model:**
+  1. **Strict schema rubric** (`rescore_strict.py`) — a malformed *primary* artifact
+     (doc_summary / code_unit) costs points, plus a validity-rate term. The lenient rubric
+     saturated at 1.0 even for the 4B model, so it can't rank; the strict one de-saturates.
+  2. **Corpus-wide valid-JSON rate** — exposes truncation/reliability (a model that runs
+     long and gets cut off mid-object).
+  3. **Content judge** — Claude (Opus 4.8), blind, fixed 22-item set (one per language + 6
+     docs), scoring faithfulness / completeness / structure (0–2 each → 0–1).
+- 7900XTX, Q4_K_M, llama.cpp b9761, `-fa on`, **one model at a time**.
+
+## Results — primary sweep (current-gen, 9 distinct models)
+
+| model | judge | strict doc | strict code | valid JSON | tok/s | VRAM |
 |---|---|---|---|---|---|---|
-| CPU | **gemma-4-E4B** (current) | 1.0 | 1.0 | 1.0 | 98 | clean |
-| CPU/small | granite-4.0-h-tiny | 0.96 | 1.0 | 1.0 | 130 | clean |
-| small-GPU | qwen3-4b | 0.41 | 0.17 | 0.33 | 134 | malformed |
-| small-GPU | qwen3-8b | 1.0 | 0.33 | 0.67 | 102 | malformed (code) |
-| GPU | **granite-4.0-h-small** (32B-A9B) | 1.0 | 1.0 | 1.0 | 64 | clean |
-| GPU | Qwen3.6-35B-A3B | 0.33 | 1.0 | 0.67 | 90 | malformed |
-| GPU | Qwen3.6-27B (dense) | 0.0 | 1.0 | 0.5 | 33 | malformed; slowest |
+| **gemma-4-12B** | 0.98 | 1.00 | 1.00 | 1.00 | 53 | ~8 GB |
+| gemma-4-26B-A4B (MoE) | 0.99 | 1.00 | 1.00 | 1.00 | 84 | ~17 GB |
+| gemma-4-31B | 1.00 | 1.00 | 1.00 | 1.00 | 27 | ~19 GB |
+| granite-4.1-8B | 0.95 | 0.94 | 1.00 | 1.00 | 88 | ~6 GB |
+| granite-4.1-30B | 0.99 | 0.95 | 1.00 | 0.98 | 32 | ~17 GB |
+| qwen3.6-35B-A3B | 0.99 | 0.88 | 1.00 | 0.92 | 89 | ~21 GB |
+| qwen3.6-27B | 1.00 | 0.79 | 1.00 | 0.88 | 32 | ~16 GB |
+| **gemma-4-E4B** | 0.91 | 0.64 | 1.00 | 1.00 | 95 / 7.5cpu | ~5 GB |
+| granite-4.1-3B | 0.80 | 0.79 | 0.89 | 0.95 | 140 / 10.5cpu | ~2 GB |
+
+## Results — CPU tier: 2026 ≤4B bake-off
+The user asked whether any current (2026) ≤4B model beats gemma-4-E4B for the CPU tier.
+Seven were run through the identical pipeline (same corpus, grammar, strict rubric, blind
+judge):
+
+| model | params | judge | strict doc | strict code | valid JSON | tok/s | verdict |
+|---|---|---|---|---|---|---|---|
+| **gemma-4-E4B** *(incumbent)* | 4B(E) | **0.91** | 0.64 | **1.00** | **1.00** | 95 | **keep** |
+| granite-4.1-3B | 3B | 0.80 | 0.79 | 0.89 | 0.95 | 140 | runner-up |
+| smollm3-3b | 3B | 0.77 | **0.83** | 0.74 | 0.92 | 165 | doc-heavy only |
+| nemotron-3-nano-4b | 4B | 0.64 | 0.72 | 0.90 | 1.00 | 124 | reject |
+| granite-4.0-h-micro | 3.2B | — | 0.59 | 0.83 | 0.98 | 112 | reject |
+| granite-4.0-micro | 3.4B | — | 0.40 | 0.99 | 1.00 | 143 | reject (doc) |
+| phi-4-mini | 3.8B | — | 0.30 | 0.97 | 0.97 | 140 | reject (doc) |
+| lfm2.5-8b-a1b | 8B/1A | — | 0.19 | 0.28 | 1.00 | 225 | reject |
+| lfm2.5-1.2b | 1.2B | — | 0.02 | 0.22 | 1.00 | 347 | reject |
+
+**No 2026 small model beats gemma-4-E4B.** Each trades gemma's one weakness (doc-flattening)
+for a worse one: smollm3 has the best doc structure of any ≤4B model but its code
+**echoes the schema's placeholder strings** (`"assumptions/guarantees or empty"`, `["concept"]`)
+and truncates ~8%; nemotron **malforms docs** (claim/entity as sibling keys) and also
+placeholder-echoes code; phi-4-mini and granite-4.0-micro have great code but doc 0.30/0.40;
+both LFM2.5 are too weak to structure. gemma-4-E4B's perfect code + 100% reliability + 0.91
+content carry it.
 
 ## Findings
-- **Function-calling-tuned models (Granite, Gemma) produce reliable curator JSON**
-  (parse 1.0, schema 0.96–1.0). **Every Qwen model slips structurally** — malformed
-  JSON (e.g. an extra closing brace `...}}]}`) on code-heavy content → parse 0.33–0.67,
-  despite `response_format=json_object`. This is the curator's exact job (parse JSON),
-  so reliability matters.
-- **gemma-4-E4B**: perfect (1.0/1.0/1.0), reliable, 98 tok/s.
-- **granite-4.0-h-small**: perfect (1.0/1.0/1.0), reliable, 64 tok/s — best GPU pick.
-- granite-4.0-h-tiny is the fastest (130 tok/s) and clean — a strong CPU/small option.
-- The pinned **Qwen3.6 tiers underperform here** (JSON reliability + the 27B is slowest
-  at 33 tok/s).
+- **Faithfulness is universal** among capable models under grammar enforcement — no
+  hallucination on extraction. The differentiators are **structure** and **reliability**.
+- **gemma-4-E4B flattens `doc_summary`** to a string (strict-doc 0.64); the larger gemma-4
+  variants do not (1.00).
+- **Qwen3.6 is content-capable but reliability-risky** — 8–12% of outputs truncate even
+  under grammar (valid-JSON 0.88–0.92); ~1-in-10 lost extractions for an async curator.
+- **MoE for throughput:** gemma-4-26B-A4B activates ~4B of 26B params/token → faster decode
+  than the dense 12B (84 vs 53 tok/s) despite a larger resident footprint.
 
-## Fairness caveat
-Qwen's failures are **JSON-validity**, not necessarily content — *when* Qwen parses,
-schema can be perfect (qwen3-8b doc=1.0). **Grammar-constrained decoding** (the curator's
-planned enhancement, `kb_curator_extract.c:35`) would force valid JSON for all models and
-shift the comparison to content quality. A grammar-constrained content re-run is the
-definitive tiebreaker if Qwen3.6 is reconsidered.
+## Decision (operator)
+Quality is a three-way tie across gemma-4 12B/26B/31B (all perfect strict + valid-JSON; judge
+deltas sub-noise); the pick splits on **deployment VRAM**, because the *unified* container
+co-hosts the embedder + reranker on the same GPU:
+- **Unified GPU (shared) → gemma-4-12B** — best quality-per-VRAM (~8 GB co-resides cleanly);
+  53 tok/s is ample for a queue drain.
+- **Dedicated synth GPU → gemma-4-26B-A4B** — best quality-per-second when VRAM isn't
+  contended.
+- **CPU → gemma-4-E4B** — best ≤4B option (empirically, vs. the 2026 field); doc-flattening
+  is its one weakness. `smollm3-3b` is the alternative for doc-heavy / code-light workloads.
+- **Dropped:** dense gemma-4-31B (dominated), Qwen3.6 (reliability), granite-4.1-3B and all
+  other ≤4B candidates (weaker on the combined task).
 
-## Decision (operator, 2026-06-22)
-**CPU = gemma-4-E4B; GPU = granite-4.0-h-small.** Both reliable, perfect schema. Drops
-the Gemma-12B/26B and Qwen3.6 GPU tiers in favor of a single Granite GPU model.
+Completes the model-selection trilogy: embedder (#624), reranker (#628), synth (here).

--- a/benchmarks/results/synth/RESULTS.md
+++ b/benchmarks/results/synth/RESULTS.md
@@ -1,0 +1,47 @@
+# Synthesizer / curator model benchmark (2026-06-22)
+
+The curator/synth LLM does **async structured-JSON extraction** (`scripts/curator-extract.py`:
+doc → {entities, claims, doc_summary}; code → {code_unit: summary, side_effects,
+domain_concepts}; story-continuity) via an OpenAI-compatible `/chat/completions`
+endpoint, parsing the first JSON object. So the model must: produce **reliable
+structured JSON**, follow the schema, and keep **throughput** up (queue drain; async,
+not latency-bound).
+
+Benchmark: the real `curator-extract` doc + code prompts over 12 samples (6 doc from
+aimee docs, 6 code units from `src/`), `temperature=0`, `enable_thinking=false`,
+`response_format=json_object`. Scored: schema conformance (doc + code), parse rate,
+tok/s. Hardware: 7900XTX (24GB, Vulkan, llama.cpp b9761), Q4_K_M, **one model at a
+time**.
+
+| tier | model | doc_schema | code_schema | parse | tok/s | JSON |
+|---|---|---|---|---|---|---|
+| CPU | **gemma-4-E4B** (current) | 1.0 | 1.0 | 1.0 | 98 | clean |
+| CPU/small | granite-4.0-h-tiny | 0.96 | 1.0 | 1.0 | 130 | clean |
+| small-GPU | qwen3-4b | 0.41 | 0.17 | 0.33 | 134 | malformed |
+| small-GPU | qwen3-8b | 1.0 | 0.33 | 0.67 | 102 | malformed (code) |
+| GPU | **granite-4.0-h-small** (32B-A9B) | 1.0 | 1.0 | 1.0 | 64 | clean |
+| GPU | Qwen3.6-35B-A3B | 0.33 | 1.0 | 0.67 | 90 | malformed |
+| GPU | Qwen3.6-27B (dense) | 0.0 | 1.0 | 0.5 | 33 | malformed; slowest |
+
+## Findings
+- **Function-calling-tuned models (Granite, Gemma) produce reliable curator JSON**
+  (parse 1.0, schema 0.96–1.0). **Every Qwen model slips structurally** — malformed
+  JSON (e.g. an extra closing brace `...}}]}`) on code-heavy content → parse 0.33–0.67,
+  despite `response_format=json_object`. This is the curator's exact job (parse JSON),
+  so reliability matters.
+- **gemma-4-E4B**: perfect (1.0/1.0/1.0), reliable, 98 tok/s.
+- **granite-4.0-h-small**: perfect (1.0/1.0/1.0), reliable, 64 tok/s — best GPU pick.
+- granite-4.0-h-tiny is the fastest (130 tok/s) and clean — a strong CPU/small option.
+- The pinned **Qwen3.6 tiers underperform here** (JSON reliability + the 27B is slowest
+  at 33 tok/s).
+
+## Fairness caveat
+Qwen's failures are **JSON-validity**, not necessarily content — *when* Qwen parses,
+schema can be perfect (qwen3-8b doc=1.0). **Grammar-constrained decoding** (the curator's
+planned enhancement, `kb_curator_extract.c:35`) would force valid JSON for all models and
+shift the comparison to content quality. A grammar-constrained content re-run is the
+definitive tiebreaker if Qwen3.6 is reconsidered.
+
+## Decision (operator, 2026-06-22)
+**CPU = gemma-4-E4B; GPU = granite-4.0-h-small.** Both reliable, perfect schema. Drops
+the Gemma-12B/26B and Qwen3.6 GPU tiers in favor of a single Granite GPU model.

--- a/benchmarks/results/synth/rescore_strict.py
+++ b/benchmarks/results/synth/rescore_strict.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""rescore_strict.py RES4.json — re-score saved raw extractions with a STRICT, intuitive
+rubric: a malformed primary artifact (doc_summary / code_unit) costs points, and a
+validity-rate term penalizes any malformed artifact directly. No re-generation needed."""
+import json, sys, re
+ST={"draft","accepted","done","rejected","deferred"}; PR={"low","medium","high"}
+CK={"fact","requirement","constraint","decision","behavior"}
+EK={"component","system","concept","protocol","data_store","tool"}
+def repair(s):
+    s=s.strip()
+    if "</think>" in s: s=s.rsplit("</think>",1)[1].strip()
+    if s.startswith("```"): s="\n".join(s.splitlines()[1:]); s=s.rsplit("```",1)[0]
+    a=s.find("{")
+    if a<0: return s
+    out=[]; stack=[]; ins=False; esc=False
+    for c in s[a:]:
+        if ins:
+            out.append(c)
+            if esc: esc=False
+            elif c=="\\": esc=True
+            elif c=='"': ins=False
+        else:
+            if c=='"': ins=True; out.append(c)
+            elif c in "{[": stack.append(c); out.append(c)
+            elif c in "}]":
+                want="{" if c=="}" else "["
+                if stack and stack[-1]==want:
+                    stack.pop(); out.append(c)
+                    if not stack: break
+            else: out.append(c)
+    while stack: out.append("}" if stack.pop()=="{" else "]")
+    res="".join(out); return re.sub(r',(\s*[}\]])', r'\1', res)
+
+def art_valid(x):
+    if not isinstance(x,dict): return False
+    k=x.get("kind"); pl=x.get("payload")
+    if not isinstance(pl,dict): return False
+    if k=="doc_summary": return pl.get("status") in ST and pl.get("priority") in PR and isinstance(pl.get("components"),list) and bool(pl.get("summary"))
+    if k=="claim": return pl.get("claim_kind") in CK and all(pl.get(z) for z in ("subject","attribute","value","text"))
+    if k=="entity": return pl.get("entity_kind") in EK and bool(pl.get("name"))
+    return False
+
+def score_doc_strict(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0
+    ds = 1.0 if any(isinstance(x,dict) and x.get("kind")=="doc_summary" and art_valid(x) for x in a) else 0.0
+    cl = 1.0 if any(isinstance(x,dict) and x.get("kind")=="claim" and art_valid(x) for x in a) else 0.0
+    nv = sum(1 for x in a if art_valid(x))
+    prec = nv/len(a)                       # validity rate: malformed artifacts cost directly
+    return (ds+cl+prec)/3.0
+
+def score_code_strict(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0
+    cu=[x for x in a if isinstance(x,dict) and x.get("kind")=="code_unit" and isinstance(x.get("payload"),dict)]
+    if not cu: return 0.0
+    pl=cu[0]["payload"]
+    fields=[bool(pl.get("summary")), isinstance(pl.get("side_effects"),list), isinstance(pl.get("domain_concepts"),list)]
+    base=sum(fields)/3.0                    # fraction of required fields well-formed (no 0.4 floor)
+    # penalty if it emitted junk beyond the one code_unit
+    extra=len(a)-1
+    return base*(1.0 if extra<=0 else max(0.6, 1.0-0.1*extra))
+
+r=json.load(open(sys.argv[1]))
+docs=[d for d in r["detail"] if d.get("role")=="extract_doc"]
+code=[d for d in r["detail"] if d.get("role")=="extract_code"]
+def parse(d):
+    try: return json.loads(repair(d.get("raw","")))
+    except Exception: return None
+dd=[score_doc_strict(parse(d)) for d in docs if d.get("raw") is not None]
+cc=[(d.get("lang"),score_code_strict(parse(d))) for d in code if d.get("raw") is not None]
+import statistics
+ndoc=round(statistics.mean(dd),3) if dd else 0
+ncode=round(statistics.mean([s for _,s in cc]),3) if cc else 0
+by={}
+for lang,s in cc: by.setdefault(lang,[]).append(s)
+by={k:round(statistics.mean(v),3) for k,v in sorted(by.items())}
+print(f"{r['name']}:  OLD doc={r['doc_schema']} code={r['code_schema']}   ->   STRICT doc={ndoc} code={ncode}")
+print(f"  strict code_by_lang: {by}")

--- a/benchmarks/results/synth/serve_and_bench.sh
+++ b/benchmarks/results/synth/serve_and_bench.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# sg4.sh MODELFILE MODE LABEL — serve one model, run grammar-enforced corpus harness, kill.
+set -u
+NAME="$1"; MODE="${2:-gpu}"; LABEL="${3:-$1}"
+DIR=/mnt/media/synthbench
+BIN=$DIR/llama-b9761/llama-server; LIB=$DIR/llama-b9761
+M=$DIR/models/${NAME}.gguf
+PORT=8920
+[ "$MODE" = cpu ] && NGL=0 || NGL=99
+pkill -9 -u "$(id -un)" -f "llama-server.*$PORT" 2>/dev/null; sleep 2
+LD_LIBRARY_PATH=$LIB nohup "$BIN" -m "$M" -ngl $NGL -fa on --jinja --ctx-size 8192 -ub 2048 -np 1 \
+  --host 127.0.0.1 --port $PORT > "$DIR/srv_${LABEL}.log" 2>&1 &
+SRV=$!
+ok=0
+for i in $(seq 1 150); do sleep 2; curl -s http://127.0.0.1:$PORT/health 2>/dev/null | grep -q ok && { ok=1; break; }; done
+if [ "$ok" = 0 ]; then echo "SERVER FAILED ($LABEL): $(tail -3 $DIR/srv_${LABEL}.log)"; kill $SRV 2>/dev/null; pkill -9 -u "$(id -un)" -f "llama-server.*$PORT" 2>/dev/null; exit 1; fi
+python3 "$DIR/synth_bench.py" $PORT "$LABEL" "$LABEL"
+kill $SRV 2>/dev/null; pkill -9 -u "$(id -un)" -f "llama-server.*$PORT" 2>/dev/null
+echo "SG4DONE_${LABEL}"

--- a/benchmarks/results/synth/synth_bench.py
+++ b/benchmarks/results/synth/synth_bench.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""synth_bench.py PORT MODEL NAME [CORPUS] — GRAMMAR-ENFORCED curator/synth benchmark.
+
+Passes a generic JSON GBNF via the `grammar` field so output is *syntactically valid
+JSON by construction* (NOT response_format=json_object, which b9761 silently ignores).
+raw_parse should be 1.0; doc_schema/code_schema then measure content (valid enums /
+required fields) free of any validity confound. Saves every raw extraction for the
+strict re-score (rescore_strict.py) and the content judge.
+
+CORPUS (argv[4]) is the workspace sample set; it is NOT committed (built per-host from
+~/dev + ~/gow). See README.md. Run via serve_and_bench.sh, which starts llama-server
+and invokes this. Output: res4_<NAME>.json + a one-line summary."""
+import json, sys, time, urllib.request, textwrap, re
+PORT,MODEL,NAME=sys.argv[1],sys.argv[2],sys.argv[3]
+CORPUS=sys.argv[4] if len(sys.argv)>4 else "synth_corpus_full.json"
+samples=json.load(open(CORPUS))
+
+# Standard llama.cpp generic-JSON grammar; root is an object => always a parseable JSON object.
+JSON_GBNF = r'''
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+object ::= "{" ws ( string ":" ws value ("," ws string ":" ws value)* )? "}" ws
+array  ::= "[" ws ( value ("," ws value)* )? "]" ws
+string ::= "\"" ( [^"\\\x7F\x00-\x1F] | "\\" (["\\bfnrt/] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) )* "\"" ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9]{1,16})? ws
+ws ::= | " " | "\n" [ \t]{0,20}
+'''
+
+def doc_prompt(i):
+    return textwrap.dedent(f"""
+    You are a knowledge extraction assistant. Extract structured knowledge from the
+    document chunk below and return ONLY a valid JSON object — no markdown fences.
+    Document: {i.get('file_path','')}
+    Section:  {i.get('heading_path','') or '(top level)'}
+    Content:
+    {i.get('content','')}
+    Return a JSON object {{"artifacts":[...]}} where each artifact has "kind" in
+    [doc_summary, claim, entity], a "payload", a "confidence" (>=0.70), "citations".
+    doc_summary.payload: summary, source_file, status(draft|accepted|done|rejected|deferred),
+    priority(low|medium|high), components(list). claim.payload: subject, attribute, value,
+    claim_kind(fact|requirement|constraint|decision|behavior), text. entity.payload: name,
+    entity_kind(component|system|concept|protocol|data_store|tool), context. Always include
+    >=1 doc_summary and >=1 claim; one entity per named system/component.""").strip()
+def code_prompt(i):
+    return textwrap.dedent(f"""
+    You are a code analysis assistant. Analyze the {i.get('kind','function')} below and
+    return ONLY a valid JSON object — no markdown fences.
+    File: {i.get('file_path','')}
+    Symbol: {i.get('symbol','')} at line {i.get('line',0)}
+    Body:
+    {i.get('body','')}
+    Return {{"artifacts":[{{"kind":"code_unit","payload":{{"summary":"1-2 sentence intent",
+    "invariants":"assumptions/guarantees or empty","side_effects":["filesystem","allocation"],
+    "domain_concepts":["concept"]}},"confidence":0.82,"citations":[]}}]}}""").strip()
+def repair(s):
+    s=s.strip()
+    if "</think>" in s: s=s.rsplit("</think>",1)[1].strip()
+    if s.startswith("```"): s="\n".join(s.splitlines()[1:]); s=s.rsplit("```",1)[0]
+    a=s.find("{")
+    if a<0: return s
+    out=[]; stack=[]; ins=False; esc=False
+    for c in s[a:]:
+        if ins:
+            out.append(c)
+            if esc: esc=False
+            elif c=="\\": esc=True
+            elif c=='"': ins=False
+        else:
+            if c=='"': ins=True; out.append(c)
+            elif c in "{[": stack.append(c); out.append(c)
+            elif c in "}]":
+                want="{" if c=="}" else "["
+                if stack and stack[-1]==want:
+                    stack.pop(); out.append(c)
+                    if not stack: break
+            else: out.append(c)
+    while stack: out.append("}" if stack.pop()=="{" else "]")
+    res="".join(out)
+    res=re.sub(r',(\s*[}\]])', r'\1', res)
+    return res
+DK={"doc_summary","claim","entity"}; ST={"draft","accepted","done","rejected","deferred"}
+PR={"low","medium","high"}; EK={"component","system","concept","protocol","data_store","tool"}
+CK={"fact","requirement","constraint","decision","behavior"}
+def score_doc(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0,0
+    p=[1.0 if any(isinstance(x,dict) and x.get("kind")=="doc_summary" for x in a) else 0.0,
+       1.0 if any(isinstance(x,dict) and x.get("kind")=="claim" for x in a) else 0.0]
+    nv=0
+    for x in a:
+        if not isinstance(x,dict): continue
+        k=x.get("kind"); pl=x.get("payload",{})
+        if k not in DK or not isinstance(pl,dict): continue
+        ok=True
+        if k=="doc_summary": ok=pl.get("status") in ST and pl.get("priority") in PR and isinstance(pl.get("components"),list) and bool(pl.get("summary"))
+        elif k=="claim": ok=pl.get("claim_kind") in CK and all(pl.get(z) for z in ("subject","attribute","value","text"))
+        elif k=="entity": ok=pl.get("entity_kind") in EK and bool(pl.get("name"))
+        if ok: nv+=1
+    p.append(min(1.0,nv/3.0)); return sum(p)/len(p),nv
+def score_code(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0,0
+    cu=[x for x in a if isinstance(x,dict) and x.get("kind")=="code_unit"]
+    if not cu: return 0.0,0
+    pl=cu[0].get("payload",{})
+    ok=isinstance(pl,dict) and bool(pl.get("summary")) and isinstance(pl.get("side_effects"),list) and isinstance(pl.get("domain_concepts"),list)
+    return (1.0 if ok else 0.4),(1 if ok else 0)
+def call(prompt):
+    if "qwen" in NAME.lower(): prompt=prompt+" /no_think"
+    body=json.dumps({"model":MODEL,"messages":[{"role":"user","content":prompt}],"temperature":0,
+      "max_tokens":1536,"chat_template_kwargs":{"enable_thinking":False},"grammar":JSON_GBNF}).encode()
+    req=urllib.request.Request(f"http://127.0.0.1:{PORT}/v1/chat/completions",data=body,headers={"Content-Type":"application/json"})
+    t0=time.time(); d=json.load(urllib.request.urlopen(req,timeout=180)); dt=time.time()-t0
+    return d["choices"][0]["message"]["content"] or "", dt, d.get("usage",{}).get("completion_tokens",0)
+res=[]; TT=0; TOK=0; raw_parse=0; cap=[]
+for s in samples:
+    pr=doc_prompt(s["input"]) if s["role"]=="extract_doc" else code_prompt(s["input"])
+    lang=s.get("lang")
+    try: txt,dt,tk=call(pr)
+    except Exception as e: res.append({"role":s["role"],"lang":lang,"parsed":False,"score":0,"valid":0,"err":str(e)[:80]}); continue
+    TT+=dt; TOK+=tk
+    try: json.loads(txt.strip()); raw_parse+=1
+    except: pass
+    try: o=json.loads(repair(txt)); pa=True
+    except: o={}; pa=False
+    sc,nv=(score_doc(o) if s["role"]=="extract_doc" else score_code(o))
+    res.append({"role":s["role"],"lang":lang,"project":s.get("project"),
+                "file":s["input"].get("file_path"),"parsed":pa,"score":round(sc,2),"valid":nv,"toks":tk,
+                "raw":txt})   # full extraction saved for manual review + future judge round
+    if len(cap)<2: cap.append({"role":s["role"],"raw":txt[:600]})
+d=[r for r in res if r["role"]=="extract_doc"]; c=[r for r in res if r["role"]=="extract_code"]
+av=lambda x,k: round(sum(r.get(k,0) for r in x)/len(x),3) if x else 0
+# per-language code breakdown
+code_by_lang={}
+for r in c:
+    code_by_lang.setdefault(r.get("lang") or "?",[]).append(r["score"])
+code_by_lang={k:round(sum(v)/len(v),3) for k,v in sorted(code_by_lang.items())}
+out={"name":NAME,"doc_schema":av(d,"score"),"code_schema":av(c,"score"),"parse_after_repair":av(res,"parsed"),
+     "raw_parse_rate":round(raw_parse/len(res),3),"tok_per_s":round(TOK/TT,1) if TT else 0,"n":len(res),
+     "n_doc":len(d),"n_code":len(c),"code_by_lang":code_by_lang,"detail":res,"samples":cap}
+json.dump(out,open(f"/mnt/media/synthbench/res4_{NAME}.json","w"),indent=1)
+print(f"{NAME}: doc={out['doc_schema']}(n{out['n_doc']}) code={out['code_schema']}(n{out['n_code']}) raw_parse={out['raw_parse_rate']} {out['tok_per_s']}tok/s | by_lang={out['code_by_lang']}")

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -3,8 +3,9 @@
 - **State:** draft — **rev 7** · **roundtable SIGNED OFF at rev 6** (round 5: 0
   blocking / 0 high / 0 medium, converged). Arc: r1 10 blocking → r2 7 blocking +
   8 high → r3 1 blocking + 1 high + 2 medium → r5 **0 blocking**. rev 7 closes the
-  two open questions (synth models BENCHMARKED — Gemma-4-E4B CPU / Granite-4.0-h-small
-  GPU, Qwen3.6 dropped on JSON-reliability; decouples + shrinks the
+  two open questions (synth models BENCHMARKED grammar-enforced + judged —
+  Gemma-4-E4B CPU / Gemma-4-12B unified-GPU (Gemma-4-26B-A4B dedicated), Qwen3.6
+  dropped on JSON-reliability, dense 31B dominated; decouples + shrinks the
   reranker to Ettin ModernBERT — 400m GPU / 68m CPU, both `-fa on`, Qwen3-Reranker
   dropped from the real-time path; E4B-ungated CPU default). See "Decisions
   taken" and "Changelog".
@@ -242,38 +243,43 @@ per `(query, candidate)` pair, **no chat template and no yes/no-logprob transfor
 dropped from the real-time path; it remains usable only **async** (e.g. background
 memory re-ranking) where its quality is worth seconds of latency.
 
-**Synth ladder** (benchmarked on the curator's real extraction task — see below):
+**Synth ladder** (benchmarked grammar-enforced + judged on the curator's real
+extraction task — see below):
 
-| Install | Synth model (GGUF) | dim/arch |
-|---------|--------------------|----------|
-| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — ungated mirror, no `HF_TOKEN`) | ~7B raw |
-| GPU (**default**) | **`unsloth/granite-4.0-h-small-GGUF`** (IBM Granite 4.0 h-small) | 32B-A9B hybrid Mamba/MoE |
+| Install | Synth model (GGUF) | arch |
+|---------|--------------------|------|
+| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — ungated mirror, no `HF_TOKEN`) | ~7B raw / E4B effective |
+| GPU — unified (**default**) | **`unsloth/gemma-4-12b-it-GGUF`** (Gemma 4 12B) | 12B dense, ~8 GB |
+| GPU — dedicated synth host | **`unsloth/gemma-4-26B-A4B-it-GGUF`** (Gemma 4 26B-A4B) | 26B MoE / ~4B active, ~17 GB |
 
-> **Basis (2026-06-22, benchmarked).** The curator/synth model does **async
-> structured-JSON extraction** (`scripts/curator-extract.py`: doc/code/story → a
-> schema'd `{"artifacts":[…]}` object over `/v1/chat/completions`, parsing the first
-> JSON object). So the axes are **reliable structured JSON + schema conformance +
-> throughput** (it drains a queue; async, not latency-bound). Seven Q4_K_M models
-> were run on the 7900XTX over the real `curator-extract` prompts (6 doc + 6 code);
-> full table in
+> **Basis (2026-06-23, grammar-enforced + judged).** The curator does **async
+> structured-JSON extraction** (`scripts/curator-extract.py`: doc/code → a schema'd
+> `{"artifacts":[…]}` object). Throughput-bound (drains a queue), not latency-bound.
+> The first pass was **confounded** — it scored `response_format=json_object`, which
+> b9761 silently ignores, so it measured freeform-JSON luck. Redone with a
+> **sampler-level GBNF grammar** (guaranteed valid JSON) over a **60-sample corpus
+> drawn from the real ~/dev + ~/gow workspace** (every aimee-supported language),
+> scored on three uniform layers: a strict de-saturated schema rubric, a corpus-wide
+> valid-JSON rate, and a **blind Claude content judge**. Full data + harness in
 > [`benchmarks/results/synth/RESULTS.md`](../../benchmarks/results/synth/RESULTS.md).
-> Headline: **function-calling-tuned models (Gemma, IBM Granite) produce reliable
-> curator JSON (parse 1.0, schema 0.96–1.0); every Qwen model — including the
-> previously-pinned Qwen3.6-35B-A3B and 27B — slipped structurally** (malformed
-> JSON on code-heavy content → parse 0.33–0.67, despite `response_format=json_object`;
-> the 27B was also the slowest at 33 tok/s). Winners:
-> - **gemma-4-E4B** — perfect (doc 1.0 / code 1.0 / parse 1.0), 98 tok/s → CPU default.
-> - **granite-4.0-h-small** — perfect (1.0 / 1.0 / 1.0), 64 tok/s → GPU default.
 >
-> This **drops the rev-7 Gemma-12B/26B and Qwen3.6 GPU tiers** in favour of a single
-> Granite GPU model. The CPU default stays **Gemma 4 E4B via the ungated `ggml-org`
-> mirror** (no first-boot `HF_TOKEN`). Pin each to a specific **commit sha + quant**.
+> Headline: under grammar enforcement **faithfulness is universal** — no model
+> hallucinates; the differentiators are **structure** and **reliability**. The old
+> "every Qwen slips" / "Granite wins" findings were harness artifacts. Corrected:
+> - **GPU quality ties** across gemma-4 12B/26B-A4B/31B (all perfect schema +
+>   valid-JSON). The pick splits on **deployment VRAM** because this container
+>   co-hosts embed + rerank: **gemma-4-12B** (~8 GB, 53 tok/s) for the *unified* GPU;
+>   **gemma-4-26B-A4B** (MoE, ~4B active → 84 tok/s, ~17 GB) when synth has a GPU to
+>   itself. Dense **gemma-4-31B** is dominated (slower *and* larger).
+> - **Qwen3.6 dropped on reliability** — content is strong but 8–12% of outputs
+>   **truncate** even under grammar (valid-JSON 0.88–0.92) → ~1-in-10 lost extractions.
+> - **CPU stays gemma-4-E4B.** A 2026 ≤4B bake-off (granite-4.0-micro/h-micro,
+>   nemotron-3-nano-4b, phi-4-mini, smollm3-3b, lfm2.5-1.2b/8b-a1b) found **none beats
+>   it** — each trades gemma's one weakness (it flattens `doc_summary`) for a worse one
+>   (placeholder-echoed or malformed code, or sub-0.4 doc). E4B keeps perfect code +
+>   100% valid JSON. `smollm3-3b` is the alternative for doc-heavy / code-light hosts.
 >
-> **Fairness note:** the Qwen failures are *JSON-validity*, not necessarily content
-> (when Qwen parsed, schema could be perfect). **Grammar-constrained decoding** (the
-> curator's planned enhancement, `kb_curator_extract.c:35`) would force valid JSON for
-> all models; a grammar-constrained content re-run is the tiebreaker if Qwen3.6 is ever
-> reconsidered.
+> Pin each to a specific **commit sha + quant**.
 
 #### The 8B truncation — why 4000, and how it must be done
 
@@ -527,13 +533,14 @@ We take the fold but pay down its cost:
 - **Auth default = mTLS**; bearer dev-only.
 - **CPU synth default = Gemma 4 E4B** via the ungated `ggml-org` GGUF mirror (no
   `HF_TOKEN`); the separate "ungated fallback" model is dropped.
-- **Synth models — benchmarked, not pinned-on-spec** (2026-06-22, on the curator's
-  real extraction task): **CPU = Gemma 4 E4B** (perfect schema, 98 tok/s), **GPU =
-  IBM Granite 4.0 h-small** (perfect schema, 64 tok/s). Function-calling-tuned models
-  (Gemma, Granite) produce reliable curator JSON; **every Qwen model — incl. the old
-  Qwen3.6-35B-A3B/27B GPU tiers — slipped on JSON validity and is dropped** (the rev-7
-  Gemma-12B/26B + Qwen3.6 GPU ladder is replaced by single Granite GPU). See
-  `benchmarks/results/synth/RESULTS.md`. **Reranker = Ettin (ModernBERT
+- **Synth models — benchmarked grammar-enforced + judged** (2026-06-23; the
+  2026-06-22 pass was confounded by an ignored `json_object` and is superseded):
+  **CPU = Gemma 4 E4B** (best ≤4B vs the 2026 field), **GPU = Gemma 4 12B** for the
+  unified container (~8 GB, co-resides with embed+rerank) / **Gemma 4 26B-A4B** (MoE)
+  for a dedicated synth host. Under grammar enforcement faithfulness is universal;
+  **Qwen3.6 dropped on reliability** (8–12% truncation), **dense Gemma-4-31B dominated**
+  (slower + larger than the 26B MoE at equal quality). Replaces the rev-7 Gemma-12B/26B
+  + Qwen3.6 ladder. See `benchmarks/results/synth/RESULTS.md`. **Reranker = Ettin (ModernBERT
   cross-encoder), NOT Qwen3-Reranker**: GPU default `ettin-reranker-400m`, CPU-only
   `ettin-reranker-68m`, both `--flash-attn on`. Real-time on the 7900XTX (ettin-400m
   top-20 0.34s; ettin-68m top-10 0.60s) and correct/fast via native `/v1/rerank` —
@@ -576,10 +583,12 @@ We take the fold but pay down its cost:
 - **rev 7 (2026-06-21):** reduced the open questions to mechanical items
   (commit-sha/quant pins + a reranker-swap-cost confirmation). **Pinned synth
   models** to the
-  benchmark (2026-06-22) — **CPU = Gemma 4 E4B** (ungated `ggml-org` mirror → no
-  `HF_TOKEN`; rev-5 "ungated fallback" dropped, E4B is the plain CPU default),
-  **GPU = IBM Granite 4.0 h-small** (replaces the rev-7 Gemma-12B/26B + Qwen3.6 GPU
-  tiers; Qwen dropped on JSON-reliability). **Decoupled the
+  benchmark (re-run grammar-enforced + judged 2026-06-23; the 2026-06-22 pass was
+  confounded by an ignored `json_object`) — **CPU = Gemma 4 E4B** (ungated `ggml-org`
+  mirror → no `HF_TOKEN`; rev-5 "ungated fallback" dropped; best ≤4B vs the 2026 field),
+  **GPU = Gemma 4 12B** (unified) / **Gemma 4 26B-A4B** (dedicated synth host); replaces
+  the rev-7 Gemma-12B/26B + Qwen3.6 ladder (Qwen dropped on JSON-reliability, dense 31B
+  dominated). **Decoupled the
   reranker** from the embed ladder (it is dimension-agnostic): **Ettin ModernBERT
   cross-encoder — `ettin-reranker-400m` (GPU) / `ettin-reranker-68m` (CPU), both
   `-fa on`; Qwen3-Reranker dropped from the real-time path** (too slow + native

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -3,7 +3,8 @@
 - **State:** draft — **rev 7** · **roundtable SIGNED OFF at rev 6** (round 5: 0
   blocking / 0 high / 0 medium, converged). Arc: r1 10 blocking → r2 7 blocking +
   8 high → r3 1 blocking + 1 high + 2 medium → r5 **0 blocking**. rev 7 closes the
-  two open questions (pins the operator's synth models; decouples + shrinks the
+  two open questions (synth models BENCHMARKED — Gemma-4-E4B CPU / Granite-4.0-h-small
+  GPU, Qwen3.6 dropped on JSON-reliability; decouples + shrinks the
   reranker to Ettin ModernBERT — 400m GPU / 68m CPU, both `-fa on`, Qwen3-Reranker
   dropped from the real-time path; E4B-ungated CPU default). See "Decisions
   taken" and "Changelog".
@@ -241,20 +242,38 @@ per `(query, candidate)` pair, **no chat template and no yes/no-logprob transfor
 dropped from the real-time path; it remains usable only **async** (e.g. background
 memory re-ranking) where its quality is worth seconds of latency.
 
-**Synth ladder** (pinned to your specified models; MoE rows have low active params):
+**Synth ladder** (benchmarked on the curator's real extraction task — see below):
 
-| Install | Synth model (GGUF) |
-|---------|--------------------|
-| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — the mirror is **ungated**, no `HF_TOKEN`) |
-| GPU-S | `unsloth/gemma-4-12B-it-GGUF` (Gemma 4 12B) |
-| GPU-M | `unsloth/gemma-4-26B-A4B-it-GGUF` (Gemma 4 26B-A4B, MoE ~4B active) |
-| GPU-L | `unsloth/Qwen3.6-35B-A3B-GGUF` (Qwen3.6 35B-A3B, MoE ~3B active) |
+| Install | Synth model (GGUF) | dim/arch |
+|---------|--------------------|----------|
+| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — ungated mirror, no `HF_TOKEN`) | ~7B raw |
+| GPU (**default**) | **`unsloth/granite-4.0-h-small-GGUF`** (IBM Granite 4.0 h-small) | 32B-A9B hybrid Mamba/MoE |
 
-> **Pinning.** Names are fixed above; implementation pins each to a specific
-> **commit sha** + quant. The CPU default is **Gemma 4 E4B via the ungated
-> `ggml-org` GGUF mirror** (already pulled unauthenticated in the current compose),
-> so there is **no separate "ungated fallback" model and no first-boot `HF_TOKEN`
-> requirement** — E4B is simply the CPU default.
+> **Basis (2026-06-22, benchmarked).** The curator/synth model does **async
+> structured-JSON extraction** (`scripts/curator-extract.py`: doc/code/story → a
+> schema'd `{"artifacts":[…]}` object over `/v1/chat/completions`, parsing the first
+> JSON object). So the axes are **reliable structured JSON + schema conformance +
+> throughput** (it drains a queue; async, not latency-bound). Seven Q4_K_M models
+> were run on the 7900XTX over the real `curator-extract` prompts (6 doc + 6 code);
+> full table in
+> [`benchmarks/results/synth/RESULTS.md`](../../benchmarks/results/synth/RESULTS.md).
+> Headline: **function-calling-tuned models (Gemma, IBM Granite) produce reliable
+> curator JSON (parse 1.0, schema 0.96–1.0); every Qwen model — including the
+> previously-pinned Qwen3.6-35B-A3B and 27B — slipped structurally** (malformed
+> JSON on code-heavy content → parse 0.33–0.67, despite `response_format=json_object`;
+> the 27B was also the slowest at 33 tok/s). Winners:
+> - **gemma-4-E4B** — perfect (doc 1.0 / code 1.0 / parse 1.0), 98 tok/s → CPU default.
+> - **granite-4.0-h-small** — perfect (1.0 / 1.0 / 1.0), 64 tok/s → GPU default.
+>
+> This **drops the rev-7 Gemma-12B/26B and Qwen3.6 GPU tiers** in favour of a single
+> Granite GPU model. The CPU default stays **Gemma 4 E4B via the ungated `ggml-org`
+> mirror** (no first-boot `HF_TOKEN`). Pin each to a specific **commit sha + quant**.
+>
+> **Fairness note:** the Qwen failures are *JSON-validity*, not necessarily content
+> (when Qwen parsed, schema could be perfect). **Grammar-constrained decoding** (the
+> curator's planned enhancement, `kb_curator_extract.c:35`) would force valid JSON for
+> all models; a grammar-constrained content re-run is the tiebreaker if Qwen3.6 is ever
+> reconsidered.
 
 #### The 8B truncation — why 4000, and how it must be done
 
@@ -508,8 +527,13 @@ We take the fold but pay down its cost:
 - **Auth default = mTLS**; bearer dev-only.
 - **CPU synth default = Gemma 4 E4B** via the ungated `ggml-org` GGUF mirror (no
   `HF_TOKEN`); the separate "ungated fallback" model is dropped.
-- **Synth models pinned** to the operator's spec: Gemma 4 **E4B (CPU)**, Gemma 4
-  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker = Ettin (ModernBERT
+- **Synth models — benchmarked, not pinned-on-spec** (2026-06-22, on the curator's
+  real extraction task): **CPU = Gemma 4 E4B** (perfect schema, 98 tok/s), **GPU =
+  IBM Granite 4.0 h-small** (perfect schema, 64 tok/s). Function-calling-tuned models
+  (Gemma, Granite) produce reliable curator JSON; **every Qwen model — incl. the old
+  Qwen3.6-35B-A3B/27B GPU tiers — slipped on JSON validity and is dropped** (the rev-7
+  Gemma-12B/26B + Qwen3.6 GPU ladder is replaced by single Granite GPU). See
+  `benchmarks/results/synth/RESULTS.md`. **Reranker = Ettin (ModernBERT
   cross-encoder), NOT Qwen3-Reranker**: GPU default `ettin-reranker-400m`, CPU-only
   `ettin-reranker-68m`, both `--flash-attn on`. Real-time on the 7900XTX (ettin-400m
   top-20 0.34s; ettin-68m top-10 0.60s) and correct/fast via native `/v1/rerank` —
@@ -552,9 +576,10 @@ We take the fold but pay down its cost:
 - **rev 7 (2026-06-21):** reduced the open questions to mechanical items
   (commit-sha/quant pins + a reranker-swap-cost confirmation). **Pinned synth
   models** to the
-  operator's spec — Gemma 4 E4B (CPU, **ungated `ggml-org` mirror → no `HF_TOKEN`**,
-  so the rev-5 "ungated fallback" model is dropped and E4B is the plain CPU
-  default), Gemma 4 12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Decoupled the
+  benchmark (2026-06-22) — **CPU = Gemma 4 E4B** (ungated `ggml-org` mirror → no
+  `HF_TOKEN`; rev-5 "ungated fallback" dropped, E4B is the plain CPU default),
+  **GPU = IBM Granite 4.0 h-small** (replaces the rev-7 Gemma-12B/26B + Qwen3.6 GPU
+  tiers; Qwen dropped on JSON-reliability). **Decoupled the
   reranker** from the embed ladder (it is dimension-agnostic): **Ettin ModernBERT
   cross-encoder — `ettin-reranker-400m` (GPU) / `ettin-reranker-68m` (CPU), both
   `-fa on`; Qwen3-Reranker dropped from the real-time path** (too slow + native


### PR DESCRIPTION
The synth/curator model was the one tier **pinned on spec, never benchmarked**. The first pass at this was **confounded** and is fully redone here.

## What broke in the first pass
The harness scored on `response_format: json_object` — which **b9761 silently ignores**, so models emitted whatever JSON they liked and the metric measured *freeform-JSON luck, not quality*. It produced false findings ("every Qwen slips structurally", "granite-3b regressed", "8B beats 32B"). Proven: `raw_parse` was 0.5 for granite-3b under `json_object`; forcing a **generic-JSON GBNF grammar** at the sampler took it to 1.0 and doc-schema 0.167→0.833. Every old number was suspect, so the whole sweep was rerun grammar-enforced.

## Method (real, not spec)
- **Corpus:** 60 samples drawn from the **actual ~/dev + ~/gow workspace** (24 doc chunks across 24 projects + 36 code units), covering **every aimee-supported language** — C, C++, Rust, Go, Python, TypeScript, JavaScript, Java, C#, Ruby, Bash, Swift, Kotlin, Scala — plus CSS, HTML, Markdown. (Swift/Kotlin/Scala synthesized; the workspace has none.)
- **Grammar-enforced** JSON (sampler-level GBNF) so validity is guaranteed and the score measures content/structure, not luck.
- **Three uniform layers, same setup for every model:** (1) strict schema rubric — a malformed primary artifact costs points + a validity-rate term (the lenient rubric saturated at 1.0 even for the 4B model); (2) corpus-wide **valid-JSON rate** (truncation/reliability); (3) a **content judge** (Claude Opus 4.8, blind, fixed 22-item set — one per language + 6 docs) scoring faithfulness / completeness / structure.
- 7900XTX, Q4_K_M, llama.cpp b9761, `-fa on`, **one model at a time**.

## Results — primary sweep (current-gen, 9 distinct models)

| model | judge | strict doc | strict code | valid JSON | tok/s | VRAM |
|---|---|---|---|---|---|---|
| **gemma-4-12B** | 0.98 | 1.00 | 1.00 | 1.00 | 53 | ~8 GB |
| gemma-4-26B-A4B (MoE) | 0.99 | 1.00 | 1.00 | 1.00 | 84 | ~17 GB |
| gemma-4-31B | 1.00 | 1.00 | 1.00 | 1.00 | 27 | ~19 GB |
| granite-4.1-8B | 0.95 | 0.94 | 1.00 | 1.00 | 88 | ~6 GB |
| granite-4.1-30B | 0.99 | 0.95 | 1.00 | 0.98 | 32 | ~17 GB |
| qwen3.6-35B-A3B | 0.99 | 0.88 | 1.00 | **0.92** | 89 | ~21 GB |
| qwen3.6-27B | 1.00 | 0.79 | 1.00 | **0.88** | 32 | ~16 GB |
| **gemma-4-E4B** | 0.91 | **0.64** | 1.00 | 1.00 | 95 / 7.5cpu | ~5 GB |
| granite-4.1-3B | 0.80 | 0.79 | **0.89** | 0.95 | 140 / 10.5cpu | ~2 GB |

## Results — CPU tier: 2026 ≤4B bake-off
Tested whether any current (2026) ≤4B model beats gemma-4-E4B, same pipeline throughout:

| model | params | judge | strict doc | strict code | valid JSON | tok/s |
|---|---|---|---|---|---|---|
| **gemma-4-E4B** *(incumbent)* | 4B(E) | **0.91** | 0.64 | **1.00** | **1.00** | 95 |
| granite-4.1-3B | 3B | 0.80 | 0.79 | 0.89 | 0.95 | 140 |
| smollm3-3b | 3B | 0.77 | **0.83** | 0.74 | 0.92 | 165 |
| nemotron-3-nano-4b | 4B | 0.64 | 0.72 | 0.90 | 1.00 | 124 |
| granite-4.0-micro | 3.4B | — | 0.40 | 0.99 | 1.00 | 143 |
| phi-4-mini | 3.8B | — | 0.30 | 0.97 | 0.97 | 140 |
| granite-4.0-h-micro | 3.2B | — | 0.59 | 0.83 | 0.98 | 112 |
| lfm2.5-8b-a1b | 8B/1A | — | 0.19 | 0.28 | 1.00 | 225 |
| lfm2.5-1.2b | 1.2B | — | 0.02 | 0.22 | 1.00 | 347 |

**No 2026 small model beats gemma-4-E4B.** Each trades gemma's one weakness (doc-flattening) for a worse one: **smollm3** has the best ≤4B doc structure but its code *echoes the schema's placeholder strings* (`"assumptions/guarantees or empty"`, `["concept"]`) and truncates ~8%; **nemotron** malforms docs (claim/entity as sibling keys) and also placeholder-echoes code; **phi-4-mini / granite-4.0-micro** have great code but doc 0.30/0.40; **both LFM2.5** are too weak to structure. gemma-4-E4B's perfect code + 100% reliability + 0.91 content carry it.

## Findings
- **Faithfulness is universal** under grammar enforcement — no model hallucinates on extraction; the judge confirms content accuracy is *not* the differentiator. **Structure and reliability are.**
- **gemma-4-E4B flattens `doc_summary`** to a string (judge 0.91 / strict-doc 0.64); the larger gemma-4 variants don't (1.00).
- **Qwen3.6 is content-capable but reliability-risky** — 8–12% truncation even under grammar; ~1-in-10 lost extractions for an async curator.
- **MoE for throughput:** gemma-4-26B-A4B activates ~4B of 26B params/token → faster decode than the dense 12B (84 vs 53 tok/s) despite a larger footprint.

## Decision (operator)
Quality is a three-way tie across gemma-4 12B/26B/31B (all perfect strict + valid-JSON; judge deltas sub-noise). The pick splits on **deployment VRAM**, because this is the *unified* container — the GPU also hosts the embedder + reranker:
- **Unified GPU (shared) → gemma-4-12B** — best quality-per-VRAM; ~8 GB co-resides cleanly; 53 tok/s ample for a queue drain.
- **Dedicated/roomy synth GPU → gemma-4-26B-A4B** — best quality-per-second when VRAM isn't contended.
- **CPU → gemma-4-E4B** — best ≤4B option vs. the 2026 field; doc-flattening documented as its weakness; smollm3-3b is the alternative for doc-heavy/code-light workloads.
- **Dropped:** dense gemma-4-31B (dominated), Qwen3.6 (reliability), granite-4.1-3B and the other ≤4B candidates (weaker on the combined task).

Replaces the rev-7 Gemma-12B/26B + Qwen3.6 GPU ladder. Docs-only; completes the model-selection trilogy (embedder #624, reranker #628, synth here). Full data + harness in `benchmarks/results/synth/`.
