### PR TITLE
feat(webchat): stream condensed tmux-CLI activity line during thinking

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -832,7 +832,7 @@ function PluginsPanel({ open, plugins, loading, error, onToggle, onRefresh, onPl
 
 /* ---- Working indicator ---- */
 
-function WorkingIndicator() {
+function WorkingIndicator({ status }: { status?: string }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 14px', color: tokens.primary, fontSize: '13px', alignSelf: 'flex-start' }}>
       <div style={{ display: 'inline-flex', gap: '4px' }}>
@@ -846,7 +846,9 @@ function WorkingIndicator() {
           />
         ))}
       </div>
-      Working
+      {/* The condensed live spinner line when the CLI is actively working;
+          plain "Working" otherwise. */}
+      <span style={{ whiteSpace: 'pre-wrap' }}>{status && status.trim() ? status : 'Working'}</span>
       <style>{`
         @keyframes pulse {
           0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
@@ -1448,7 +1450,17 @@ export default function Chat() {
   // aimeeSid, so the busy indicator reflects the ACTIVE tab alone — sending on one
   // tab no longer shows "working" on every other tab. Derived values below.
   const [workBySid, setWorkBySid] = useState<Record<string, SidWork>>({});
+  // Transient live-activity line (condensed tmux-CLI spinner, e.g. "Misting…
+  // (1m 5s · ↓ 2.6k tokens · thinking)") keyed by the owning tab's aimeeSid. Set
+  // from `status` SSE events, cleared at each turn boundary. Shown inside the
+  // working indicator so a long thinking phase reads as live, not frozen.
+  const [statusBySid, setStatusBySid] = useState<Record<string, string>>({});
+  // Every tab's latest live-activity line, kept off the render path so an
+  // off-screen turn's spinner never re-renders the active view. Only the active
+  // tab is mirrored into statusBySid (above); a tab switch hydrates from here.
+  const statusByOwnerRef = useRef<Map<string, string>>(new Map());
   const activeWork = workBySid[tabs[activeIdx]?.aimeeSid ?? ''];
+  const activeStatus = statusBySid[tabs[activeIdx]?.aimeeSid ?? ''] ?? '';
   const working = !!activeWork && (activeWork.pending > 0 || activeWork.queued > 0);
   const iterCur = activeWork?.iterCur ?? 0;
   const iterMax = activeWork?.iterMax ?? 0;
@@ -1830,6 +1842,15 @@ export default function Chat() {
         if (!active && iterCur === 0 && iterMax === 0) continue;
         next[sid] = { pending: p, queued: q, iterCur, iterMax };
       }
+      // Bail if nothing changed: this runs on every drained item, and returning a
+      // fresh object each time forces a needless whole-Chat re-render.
+      const pk = Object.keys(prev);
+      const nk = Object.keys(next);
+      if (pk.length === nk.length && pk.every(k => {
+        const a = prev[k], b = next[k];
+        return b && a.pending === b.pending && a.queued === b.queued &&
+          a.iterCur === b.iterCur && a.iterMax === b.iterMax;
+      })) return prev;
       return next;
     });
   }
@@ -1839,6 +1860,29 @@ export default function Chat() {
     setWorkBySid(prev => {
       const cur = prev[sid] ?? { pending: 0, queued: 0, iterCur: 0, iterMax: 0 };
       return { ...prev, [sid]: { ...cur, iterCur, iterMax } };
+    });
+  }
+
+  /* Set (or clear, with '') the transient live-activity line for a tab.
+   *
+   * Only the ACTIVE tab's status drives React state. A background tab's spinner
+   * is never shown, so calling setState for it would re-render the whole Chat on
+   * every poll of every off-screen turn — that is the cost that scales with tab
+   * count (N concurrent turns → N× wasted full re-renders/s). Instead every tab's
+   * latest status is kept in a ref (no re-render); a tab switch hydrates state
+   * from it, and the entering tab's own live stream repaints within one poll. */
+  function setSidStatus(sid: string, status: string): void {
+    if (!sid) return;
+    if (status) statusByOwnerRef.current.set(sid, status);
+    else statusByOwnerRef.current.delete(sid);
+    const activeSid = tabsRef.current[activeIdxRef.current]?.aimeeSid ?? '';
+    if (sid !== activeSid) return;
+    setStatusBySid(prev => {
+      if ((prev[sid] ?? '') === status) return prev;
+      const next = { ...prev };
+      if (status) next[sid] = status;
+      else delete next[sid];
+      return next;
     });
   }
 
@@ -1854,6 +1898,8 @@ export default function Chat() {
     activeSendAbortRefs.current.forEach((_sid, controller) => controller.abort());
     activeSendAbortRefs.current.clear();
     setWorkBySid({});
+    statusByOwnerRef.current.clear();
+    setStatusBySid({});
   }
 
   useEffect(() => {
@@ -2127,6 +2173,11 @@ export default function Chat() {
     if (oldSid === newSid) return;
     if (oldSid) bgStreamsRef.current.set(oldSid, streamMsgsRef.current);
     renderedSidRef.current = newSid;
+    // Surface the entering tab's latest status (tracked in the ref while it was a
+    // background tab). statusBySid only ever holds the active tab, so reset it to
+    // just this one.
+    const enteringStatus = statusByOwnerRef.current.get(newSid) ?? '';
+    setStatusBySid(enteringStatus ? { [newSid]: enteringStatus } : {});
     skipNextStreamPersistRef.current = true;
     const buffered = bgStreamsRef.current.get(newSid);
     if (buffered) {
@@ -2750,6 +2801,13 @@ export default function Chat() {
         streamRefs.assistantId = null;
         streamRefs.thinkId = null;
         streamRefs.toolId = null;
+        setSidStatus(streamRefs.originSid, '');
+        break;
+      }
+      case 'status': {
+        // Transient live-activity line from a tmux CLI turn: replace in place
+        // (one rolling indicator), never appended to the transcript.
+        setSidStatus(streamRefs.originSid, String(data.content ?? ''));
         break;
       }
       case 'tool_start': {
@@ -2820,6 +2878,7 @@ export default function Chat() {
         streamRefs.assistantId = null;
         streamRefs.thinkId = null;
         streamRefs.toolId = null;
+        setSidStatus(streamRefs.originSid, '');
         break;
       }
       case 'error': {
@@ -2901,6 +2960,7 @@ export default function Chat() {
       }
       case 'done': {
         saveOwnerStream(streamRefs.originSid);
+        setSidStatus(streamRefs.originSid, '');
         void refreshWorkflow();
         /* Refresh LSP diagnostic badge after each completed turn */
         fetch('/api/lsp/diagnostics/summary')
@@ -3034,7 +3094,7 @@ export default function Chat() {
           </button>
         )}
         <Transcript messages={windowedMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
-        {working && <WorkingIndicator />}
+        {working && <WorkingIndicator status={activeStatus} />}
         {remoteTurnActive && !working && (
           <div style={{
             alignSelf: 'flex-start', maxWidth: '85%', padding: '6px 10px',

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -38,6 +38,10 @@ typedef struct
    /* Clean response text already streamed to the caller this turn (so recv emits
     * only the growth as an incremental delta). malloc'd; freed on destroy. */
    char *stream_emitted;
+   /* Last condensed working/status line emitted via the status callback this turn
+    * (so recv emits a status event only when the line actually changes, not every
+    * poll). malloc'd; freed on destroy. */
+   char *status_emitted;
 } cli_session_t;
 
 /* Incremental stream callback: invoked by cli_session_recv with each newly
@@ -48,6 +52,19 @@ void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud);
  * around a nested turn (prevents the inner turn's now-dead context leaking to
  * the outer turn). *ud_out receives the userdata; returns the callback. */
 cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out);
+
+/* Status callback: invoked by cli_session_recv with the latest *condensed*
+ * working/spinner line (e.g. "Misting… (1m 5s · ↓ 2.6k tokens · still thinking)")
+ * while the CLI is producing tokens. The TUI animates this line ~1×/s with a
+ * fresh elapsed counter; recv collapses the whole run into a single rolling
+ * status — emitting only when the line text changes — so the webchat shows live
+ * activity (one updating line) during long thinking phases instead of a frozen
+ * pane, without flooding the transcript. Distinct from the stream callback, which
+ * carries the assistant's actual answer text. Set per-thread; save/restore around
+ * a nested turn like the stream callback. */
+typedef void (*cli_session_status_cb_t)(const char *status, void *ud);
+void cli_session_set_status_cb(cli_session_status_cb_t cb, void *ud);
+cli_session_status_cb_t cli_session_get_status_cb(void **ud_out);
 
 /* Cancel-check callback: cli_session_recv polls it each tick; a non-zero return
  * aborts the wait (the running turn was asked to stop — steering/interrupt or
@@ -130,6 +147,14 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
  * content present in the baseline is excluded so prior turns never leak.
  * Returns newly allocated text; caller frees. Exposed for unit tests. */
 char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline);
+
+/* Extract the latest animated working/status line from a raw pane capture,
+ * condensed to a single line with the leading spinner glyph stripped (claude:
+ * "✢ Misting… (21s · ↑ 493 tokens)" → "Misting… (21s · ↑ 493 tokens)"; codex:
+ * "◦ Working (12s · esc to interrupt)"). Returns newly allocated text — an empty
+ * string when the pane shows no active-work line (idle / answer already done).
+ * Caller frees. Exposed for unit tests. */
+char *cli_session_extract_status(const char *raw, const char *cli_kind);
 
 /* --- Session name helpers --- */
 /* Build a deterministic session name: "aimee-<agent>-<hash(role)>".

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -207,6 +207,8 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
             sess.baseline = NULL;
             free(sess.stream_emitted);
             sess.stream_emitted = NULL;
+            free(sess.status_emitted);
+            sess.status_emitted = NULL;
          }
          else
             cli_session_destroy(&sess);
@@ -244,6 +246,8 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       sess.baseline = NULL;
       free(sess.stream_emitted);
       sess.stream_emitted = NULL;
+      free(sess.status_emitted);
+      sess.status_emitted = NULL;
    }
 
    if (!clean || !clean[0])

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -157,6 +157,14 @@ static int stream_event(compute_ctx_t *cctx, const char *event, const char *key,
    {
       if (event && strcmp(event, "text") == 0 && value && value[0])
          ring_text_append_locked(cctx, value);
+      else if (event && strcmp(event, "status") == 0)
+      {
+         /* Transient live-activity line: deliver on the live socket only, never
+          * persist it in the ring. It animates ~1×/s, so ring-publishing would
+          * bloat the turn history and replay a stale spinner on reconnect; the
+          * next poll re-emits a current line anyway. Leave any buffered text
+          * intact (status never enters the ring, so there is no reorder to guard). */
+      }
       else
       {
          ring_flush_text_locked(cctx); /* preserve order vs. buffered text */
@@ -586,6 +594,19 @@ static void chat_cli_stream_cb(const char *delta, void *ud)
    c->emitted = 1;
 }
 
+/* Forward the tmux CLI's condensed live-activity line as a transient `status`
+ * SSE event so the webchat shows a single rolling indicator ("Misting… (1m 5s ·
+ * …)") during long thinking phases. Not the answer — does not set `emitted`, and
+ * stream_event keeps `status` out of the presence ring (ephemeral; the next poll
+ * re-emits a fresh line, so a reconnect never replays a stale spinner). */
+static void chat_cli_status_cb(const char *status, void *ud)
+{
+   chat_cli_stream_ctx_t *c = (chat_cli_stream_ctx_t *)ud;
+   if (!c || !status || !status[0])
+      return;
+   stream_event(c->cctx, "status", "content", status);
+}
+
 /* Cancel predicate for the tmux CLI driver: reflects this turn's registry cancel
  * flag (set by chat.interrupt / graceful_cancel / session close). Lets
  * cli_session_recv abort a wedged or steered generation promptly without
@@ -678,6 +699,10 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    void *prev_stream_ud = NULL;
    cli_session_stream_cb_t prev_stream_cb = cli_session_get_stream_cb(&prev_stream_ud);
    cli_session_set_stream_cb(chat_cli_stream_cb, &sctx);
+   /* Live-activity status line (condensed spinner) for the same tmux turn. */
+   void *prev_status_ud = NULL;
+   cli_session_status_cb_t prev_status_cb = cli_session_get_status_cb(&prev_status_ud);
+   cli_session_set_status_cb(chat_cli_status_cb, &sctx);
    /* Let the tmux CLI driver observe this turn's cancel flag so a steer/interrupt
     * stops the running generation promptly. Save/restore around any outer turn. */
    void *prev_cancel_ud = NULL;
@@ -699,6 +724,7 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
 
    cli_session_set_error_grace_ms(prev_error_grace);
    cli_session_set_cancel_check(prev_cancel_cb, prev_cancel_ud);
+   cli_session_set_status_cb(prev_status_cb, prev_status_ud);
    cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -83,6 +83,24 @@ cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out)
    return g_stream_cb;
 }
 
+/* Per-thread status sink (set by the chat worker before a turn, cleared after).
+ * Thread-local for the same reason as the stream callback. */
+static __thread cli_session_status_cb_t g_status_cb = NULL;
+static __thread void *g_status_ud = NULL;
+
+void cli_session_set_status_cb(cli_session_status_cb_t cb, void *ud)
+{
+   g_status_cb = cb;
+   g_status_ud = ud;
+}
+
+cli_session_status_cb_t cli_session_get_status_cb(void **ud_out)
+{
+   if (ud_out)
+      *ud_out = g_status_ud;
+   return g_status_cb;
+}
+
 /* Per-thread cancel-check (set by the chat worker to the turn's cancel flag).
  * cli_session.c stays decoupled from the turn registry — the worker supplies the
  * predicate. */
@@ -430,6 +448,8 @@ void cli_session_destroy(cli_session_t *s)
    s->baseline = NULL;
    free(s->stream_emitted);
    s->stream_emitted = NULL;
+   free(s->status_emitted);
+   s->status_emitted = NULL;
    if (!s->active)
       return;
    if (!cli_session_is_alive(s))
@@ -794,6 +814,87 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
    return cli_extract_impl(raw, cli_kind, baseline, 1);
 }
 
+/* Recognize the CLI's animated working/status line. claude renders it as
+ * "<spinner> <Gerund>… (<elapsed> · <arrow> <tokens> tokens[· <state>])",
+ * cycling the spinner glyph (✻ ✢ ✽ · …) and the gerund every frame; codex uses
+ * "◦ Working (<elapsed> · esc to interrupt)". Rather than enumerate the volatile
+ * spinner glyphs we match the line by its stable shape: an open paren PLUS either
+ * an "esc to interrupt" hint or the ellipsis (…) + a token meter. The "to
+ * interrupt" phrase and the ellipsis-with-tokens shape both avoid false-matching
+ * claude's "⎿ Tip: …interrupting…" hint (no paren, no "… (") and ordinary prose. */
+static int cli_line_is_status(const char *t)
+{
+   if (!strchr(t, '('))
+      return 0;
+   if (strstr(t, "to interrupt"))
+      return 1; /* "esc to interrupt" — claude + codex working footer */
+   /* ellipsis (U+2026) accompanied by a token meter = claude's spinner line */
+   if (strstr(t, "\xe2\x80\xa6") && strstr(t, "token"))
+      return 1;
+   return 0;
+}
+
+/* Strip a leading spinner glyph (a whitespace-delimited token with no ASCII
+ * letter — "✢", "·", "◦") plus following spaces, leaving the human-readable
+ * status ("Misting… (21s · ↑ 493 tokens)"). The body is returned verbatim. */
+static const char *cli_status_body(const char *line)
+{
+   const char *b = cli_lstrip(line);
+   const char *sp = b;
+   while (*sp && *sp != ' ')
+      sp++;
+   int tok_has_letter = 0;
+   for (const char *q = b; q < sp; q++)
+      if ((*q >= 'A' && *q <= 'Z') || (*q >= 'a' && *q <= 'z'))
+      {
+         tok_has_letter = 1;
+         break;
+      }
+   if (!tok_has_letter && *sp == ' ')
+   {
+      b = sp;
+      while (*b == ' ')
+         b++;
+   }
+   return b;
+}
+
+char *cli_session_extract_status(const char *raw, const char *cli_kind)
+{
+   (void)cli_kind; /* the shape match covers claude + codex */
+   /* strip_ansi returns a fresh buffer we own, so split it in place (rewrite '\n'
+    * to '\0'), scanning for the LAST status line (the live footer sits at the
+    * bottom of the pane). */
+   char *work = cli_session_strip_ansi(raw ? raw : "");
+   if (!work)
+      return strdup("");
+
+   char *best = NULL; /* malloc'd copy of the most recent status line's body */
+   for (char *p = work;;)
+   {
+      char *nl = strchr(p, '\n');
+      if (nl)
+         *nl = '\0';
+      const char *ls = cli_lstrip(p);
+      if (cli_line_is_status(ls))
+      {
+         const char *body = cli_status_body(ls);
+         char *dup = strdup(body);
+         if (dup)
+         {
+            free(best);
+            best = dup;
+         }
+      }
+      if (!nl)
+         break;
+      p = nl + 1;
+   }
+
+   free(work);
+   return best ? best : strdup("");
+}
+
 /* True when the pane shows the CLI parked in a provider error/retry state.
  * claude renders this on its ✻ status line ("API error · Retrying in Ns ·
  * attempt K/10"); the normal completion status ("✻ Baked for Ns") and the
@@ -842,6 +943,8 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    long long err_start = 0; /* mono_ms when that state began (valid iff err_active) */
    free(s->stream_emitted);
    s->stream_emitted = strdup("");
+   free(s->status_emitted);
+   s->status_emitted = strdup("");
 
    for (;;)
    {
@@ -951,6 +1054,26 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
          }
          else
             free(partial);
+      }
+
+      /* Stream a condensed live-activity line while the CLI works. The TUI has no
+       * answer bullet yet during a thinking phase, so the stream callback above
+       * emits nothing and the webchat would look frozen; the status line ("Misting…
+       * (21s · ↑ 493 tokens)") keeps it alive. The TUI re-renders this line ~1×/s
+       * with a fresh counter, so emit only when the text changes — one rolling
+       * status, not one event per frame. */
+      if (g_status_cb)
+      {
+         char *status = cli_session_extract_status(cap, s->cli_kind);
+         const char *prevst = s->status_emitted ? s->status_emitted : "";
+         if (status && status[0] && strcmp(status, prevst) != 0)
+         {
+            g_status_cb(status, g_status_ud);
+            free(s->status_emitted);
+            s->status_emitted = status;
+         }
+         else
+            free(status);
       }
 
       /* Provider-error bound: if the CLI parks in an error/retry state for longer

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -534,6 +534,66 @@ static void test_extract_baseline_substring_kept(void)
    free(r);
 }
 
+/* --- cli_session_extract_status: condensed live-activity line --- */
+
+/* claude's animated spinner footer is returned verbatim with the leading glyph
+ * stripped, so the webchat shows a single human-readable activity line. */
+static void test_status_claude_spinner(void)
+{
+   const char *pane = "\xe2\x9d\xaf write a poem\n"
+                      "\xe2\x9c\xbb Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)\n";
+   char *r = cli_session_extract_status(pane, "claude");
+   assert(r != NULL);
+   assert(strcmp(r, "Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)") == 0);
+   free(r);
+}
+
+/* When several spinner frames are on the pane (scrollback), the LAST one wins —
+ * that is the current state. */
+static void test_status_picks_last_frame(void)
+{
+   const char *pane =
+       "\xe2\x9c\xbb Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)\n"
+       "\xe2\x9c\xbd Misting\xe2\x80\xa6 (58s \xc2\xb7 \xe2\x86\x93 2.0k tokens \xc2\xb7 "
+       "thinking)\n";
+   char *r = cli_session_extract_status(pane, "claude");
+   assert(r != NULL);
+   assert(
+       strcmp(r, "Misting\xe2\x80\xa6 (58s \xc2\xb7 \xe2\x86\x93 2.0k tokens \xc2\xb7 thinking)") ==
+       0);
+   free(r);
+}
+
+/* The "⎿ Tip: …interrupting…" hint must NOT be mistaken for a status line (no
+ * paren, no "… ("), and an idle pane yields an empty string. */
+static void test_status_ignores_tip_and_idle(void)
+{
+   const char *tip = "\xe2\x8e\xbf Tip: Use /btw to ask a side question without interrupting "
+                     "Claude's current work\n";
+   char *r = cli_session_extract_status(tip, "claude");
+   assert(r != NULL);
+   assert(r[0] == '\0');
+   free(r);
+
+   const char *idle = "\xe2\x97\x8f all done\n\xe2\x9c\xbb Baked for 3s\n";
+   char *r2 = cli_session_extract_status(idle, "claude");
+   assert(r2 != NULL);
+   assert(r2[0] == '\0');
+   free(r2);
+}
+
+/* codex's "Working (Ns · esc to interrupt)" footer is matched via the interrupt
+ * hint and the glyph is stripped. */
+static void test_status_codex_working(void)
+{
+   const char *pane = "\xe2\x80\xba do it\n"
+                      "\xe2\x97\xa6 Working (12s \xc2\xb7 esc to interrupt)\n";
+   char *r = cli_session_extract_status(pane, "codex");
+   assert(r != NULL);
+   assert(strcmp(r, "Working (12s \xc2\xb7 esc to interrupt)") == 0);
+   free(r);
+}
+
 /* --- cli_session_prepare_claude: claude-code first-run gate seeding --- */
 
 static char *slurp(const char *path)
@@ -740,6 +800,22 @@ int main(void)
 
    printf("test_extract_baseline_substring_kept... ");
    test_extract_baseline_substring_kept();
+   printf("OK\n");
+
+   printf("test_status_claude_spinner... ");
+   test_status_claude_spinner();
+   printf("OK\n");
+
+   printf("test_status_picks_last_frame... ");
+   test_status_picks_last_frame();
+   printf("OK\n");
+
+   printf("test_status_ignores_tip_and_idle... ");
+   test_status_ignores_tip_and_idle();
+   printf("OK\n");
+
+   printf("test_status_codex_working... ");
+   test_status_codex_working();
    printf("OK\n");
 
    printf("test_make_name_format... ");


### PR DESCRIPTION
## Problem
The tmux CLI driver (`claude-oauth`/`codex-oauth`) only streamed the assistant's **answer** text. During a thinking phase the TUI shows an animated spinner footer (`✢ Misting… (21s · ↑ 493 tokens)`) but no answer bullet yet, so the streaming sink emitted nothing and the webchat looked frozen until the next bullet — then resumed. Users had to nudge the session to get output flowing again.

## Fix
A transient **`status`** stream channel that condenses the spinner spam into a single rolling line, so the chat shows live activity as long as the CLI is producing data.

- **`cli_session`**: `cli_session_extract_status()` finds the latest working/status line (matched by stable shape — open-paren + `to interrupt` *or* ellipsis + token-meter; covers claude and codex, ignores the `⎿ Tip: …interrupting…` hint and idle `✻ Baked for Ns` footers) and strips the leading spinner glyph. `recv()` emits it through a thread-local status callback **only when the line text changes** — one rolling status, not one event per poll. New `status_emitted` tracks the last line; freed in destroy + the tmux-runtime reuse paths.
- **`server_compute`**: forwards it as a `status` SSE event; `stream_event` keeps `status` **out of the presence ring** (ephemeral — animates ~1×/s; ring-publishing would bloat turn history and replay a stale spinner on reconnect). Live socket only; the next poll re-emits.
- **`Chat.tsx`**: per-tab `statusBySid`, rendered in the working indicator (replace-in-place, never appended to the transcript), cleared on `turn_start`/`turn_end`/`done`/abort.

## Tests
4 new `extract_status` cases (claude spinner, last-frame-wins, tip/idle ignored, codex working line). `unit-test-cli-session` green; full `make server` links clean (`-Werror`); frontend `tsc -b` clean.