### PR TITLE
perf(webchat): make stream-append O(changed) not O(history) per tab

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -2762,15 +2762,31 @@ export default function Chat() {
       else e.think += u.delta;
       byId.set(u.id, e);
     }
-    const applyDeltas = (msgs: StreamMsg[], byId: Map<number, { text: string; think: string }>): StreamMsg[] =>
-      msgs.map(m => {
-        const e = byId.get(m.id);
-        if (!e) return m;
-        const next = { ...m };
-        if (e.text) next.text = m.text + e.text;
-        if (e.think) next.thinkText = (m.thinkText ?? '') + e.think;
-        return next;
-      });
+    // Only the messages that received a delta change — in practice the 1–2 tail
+    // blocks of the turn (the streaming assistant bubble, maybe a thinking
+    // block). The whole conversation lives in `msgs` (windowing is render-only),
+    // so map()-ing a closure + Map.get over the FULL history every flush is
+    // O(history) of wasted work — and it runs for EVERY streaming tab ~10×/s, so
+    // it scales with running-tab count × session length, pegging a core. Instead
+    // copy the array once (cheap pointer copy) and rewrite only the matching
+    // indices, scanning from the tail and stopping once every delta is placed.
+    const applyDeltas = (msgs: StreamMsg[], byId: Map<number, { text: string; think: string }>): StreamMsg[] => {
+      if (byId.size === 0) return msgs;
+      let next: StreamMsg[] | null = null;
+      let remaining = byId.size;
+      for (let i = msgs.length - 1; i >= 0 && remaining > 0; i--) {
+        const e = byId.get(msgs[i].id);
+        if (!e) continue;
+        if (!next) next = msgs.slice();
+        const m = msgs[i];
+        const nm = { ...m };
+        if (e.text) nm.text = m.text + e.text;
+        if (e.think) nm.thinkText = (m.thinkText ?? '') + e.think;
+        next[i] = nm;
+        remaining--;
+      }
+      return next ?? msgs;
+    };
     const activeSid = tabsRef.current[activeIdxRef.current]?.aimeeSid ?? '';
     for (const [owner, byId] of byOwner) {
       if (owner === activeSid) {


### PR DESCRIPTION
## Symptom
Multiple concurrent **session tabs** streaming at once peg a **browser** CPU core. Only the active tab renders, so the tab-count scaling had to come from non-render work every streaming tab does on each flush.

## Cause
`flushStreamAppends` applied each flush's deltas with `msgs.map()` over the **full** conversation — a closure + `Map.get` for *every* message in the history. `streamMsgs`/`bgStreams` hold the whole conversation (the 150-message window is render-only), and this ran for **every** streaming tab ~10×/s. So the cost was O(history × running-tabs × flush-rate) — it grows with both tab count and session length.

## Fix
Deltas only ever touch the turn's tail (the streaming assistant bubble, maybe a thinking block). Copy the array once (cheap pointer copy — React still gets a new ref) and rewrite only the matching indices, scanning from the tail and stopping once every delta is placed. O(changed) instead of O(history). Unchanged message objects keep their identity, so the committed-transcript reference-comparator (#586) still bails.

## Verification
- Standalone equivalence test vs the old `map()`: 7/7 cases match, including object-identity preservation for unchanged messages.
- `tsc -b` clean.

Complements #632 (which stopped background-tab `status` events from re-rendering the active view). If a core is still hot after this, the next step is a 5–10s DevTools Performance capture to find any remaining hot frames.