### PR TITLE
Promote testing to main: webchat live status line + multi-tab CPU fixes

### DIFF
--- a/benchmarks/results/synth/README.md
+++ b/benchmarks/results/synth/README.md
@@ -1,0 +1,33 @@
+# Synth/curator benchmark harness
+
+The harness behind [`RESULTS.md`](RESULTS.md). Measures the curator's real job —
+**async structured-JSON extraction** — with **sampler-level grammar enforcement** (a
+generic-JSON GBNF), because `response_format: json_object` is silently ignored by
+llama.cpp b9761 and otherwise confounds the scores (it measures freeform-JSON luck).
+
+## Scripts
+- **`synth_bench.py PORT MODEL NAME [CORPUS]`** — runs the corpus through an
+  OpenAI-compatible `/v1/chat/completions` endpoint with grammar-enforced JSON,
+  scores doc/code schema conformance + valid-JSON rate + tok/s, and **saves every raw
+  extraction** into `res4_<NAME>.json` for downstream re-scoring/judging.
+- **`serve_and_bench.sh MODELFILE MODE LABEL`** — driver: starts `llama-server`
+  (`-fa on`, GBNF via the harness), waits for health, runs `synth_bench.py`, tears the
+  server down. `MODE` = `gpu` (`-ngl 99`) | `cpu` (`-ngl 0`). One model at a time.
+- **`rescore_strict.py res4_<NAME>.json`** — re-scores the saved raws with the *strict*
+  rubric (a malformed primary artifact costs points + a validity-rate term), which
+  de-saturates the lenient schema check. No re-generation needed.
+
+## Corpus (not committed)
+The 60-sample corpus is built per-host from the real `~/dev` + `~/gow` workspace (every
+aimee-supported language) and is **not** committed — it is workspace-specific and large.
+`synth_bench.py` takes the corpus path as `argv[4]`. Each sample is:
+```json
+{"role":"extract_doc","lang":"Markdown","project":"...","input":{"file_path","heading_path","content"}}
+{"role":"extract_code","lang":"Rust","project":"...","input":{"file_path","symbol","line","kind","body"}}
+```
+
+## Content judge
+The blind content judge (faithfulness / completeness / structure over a fixed
+one-per-language + docs subset) is run by hand from the saved `res4_*.json` raws; see
+`RESULTS.md` for methodology and scores. Paths in `serve_and_bench.sh` reflect the
+bench-box layout (`/mnt/media/synthbench`).

--- a/benchmarks/results/synth/RESULTS.md
+++ b/benchmarks/results/synth/RESULTS.md
@@ -1,0 +1,97 @@
+# Synthesizer / curator model benchmark (2026-06, grammar-enforced + judged)
+
+The curator/synth LLM does **async structured-JSON extraction** (`scripts/curator-extract.py`:
+doc → `{artifacts:[doc_summary, claim, entity]}`; code → `{artifacts:[code_unit]}`) over an
+OpenAI-compatible `/v1/chat/completions` endpoint. It is **throughput-bound** (drains an
+extraction queue), not latency-bound. So the axes are: **reliable structured JSON +
+schema/content fidelity + tok/s**.
+
+## Why this was redone (the first pass was confounded)
+The original harness scored on `response_format: json_object`, which **llama.cpp b9761
+silently ignores** — models emitted arbitrary JSON and the metric measured *freeform-JSON
+luck, not quality*. It produced false findings ("every Qwen slips structurally", "granite-3b
+regressed", "8B beats 32B"). Proven: granite-3b's raw-parse was 0.5 under `json_object`;
+forcing a **generic-JSON GBNF grammar at the sampler** took it to 1.0 and doc-schema
+0.167 → 0.833. Every old number was discarded and the sweep rerun grammar-enforced.
+
+## Method
+- **Corpus** (`synth_corpus_full.json`, 60 samples) drawn from the **real ~/dev + ~/gow
+  workspace**: 24 doc chunks across 24 projects + 36 code units covering **every
+  aimee-supported language** — C, C++, Rust, Go, Python, TypeScript, JavaScript, Java, C#,
+  Ruby, Bash, Swift, Kotlin, Scala — plus CSS, HTML, Markdown. (Swift/Kotlin/Scala
+  synthesized; the workspace has none.)
+- **Grammar-enforced** JSON (sampler GBNF) so validity is guaranteed; the score measures
+  content/structure, not luck.
+- **Three uniform layers, identical for every model:**
+  1. **Strict schema rubric** (`rescore_strict.py`) — a malformed *primary* artifact
+     (doc_summary / code_unit) costs points, plus a validity-rate term. The lenient rubric
+     saturated at 1.0 even for the 4B model, so it can't rank; the strict one de-saturates.
+  2. **Corpus-wide valid-JSON rate** — exposes truncation/reliability (a model that runs
+     long and gets cut off mid-object).
+  3. **Content judge** — Claude (Opus 4.8), blind, fixed 22-item set (one per language + 6
+     docs), scoring faithfulness / completeness / structure (0–2 each → 0–1).
+- 7900XTX, Q4_K_M, llama.cpp b9761, `-fa on`, **one model at a time**.
+
+## Results — primary sweep (current-gen, 9 distinct models)
+
+| model | judge | strict doc | strict code | valid JSON | tok/s | VRAM |
+|---|---|---|---|---|---|---|
+| **gemma-4-12B** | 0.98 | 1.00 | 1.00 | 1.00 | 53 | ~8 GB |
+| gemma-4-26B-A4B (MoE) | 0.99 | 1.00 | 1.00 | 1.00 | 84 | ~17 GB |
+| gemma-4-31B | 1.00 | 1.00 | 1.00 | 1.00 | 27 | ~19 GB |
+| granite-4.1-8B | 0.95 | 0.94 | 1.00 | 1.00 | 88 | ~6 GB |
+| granite-4.1-30B | 0.99 | 0.95 | 1.00 | 0.98 | 32 | ~17 GB |
+| qwen3.6-35B-A3B | 0.99 | 0.88 | 1.00 | 0.92 | 89 | ~21 GB |
+| qwen3.6-27B | 1.00 | 0.79 | 1.00 | 0.88 | 32 | ~16 GB |
+| **gemma-4-E4B** | 0.91 | 0.64 | 1.00 | 1.00 | 95 / 7.5cpu | ~5 GB |
+| granite-4.1-3B | 0.80 | 0.79 | 0.89 | 0.95 | 140 / 10.5cpu | ~2 GB |
+
+## Results — CPU tier: 2026 ≤4B bake-off
+The user asked whether any current (2026) ≤4B model beats gemma-4-E4B for the CPU tier.
+Seven were run through the identical pipeline (same corpus, grammar, strict rubric, blind
+judge):
+
+| model | params | judge | strict doc | strict code | valid JSON | tok/s | verdict |
+|---|---|---|---|---|---|---|---|
+| **gemma-4-E4B** *(incumbent)* | 4B(E) | **0.91** | 0.64 | **1.00** | **1.00** | 95 | **keep** |
+| granite-4.1-3B | 3B | 0.80 | 0.79 | 0.89 | 0.95 | 140 | runner-up |
+| smollm3-3b | 3B | 0.77 | **0.83** | 0.74 | 0.92 | 165 | doc-heavy only |
+| nemotron-3-nano-4b | 4B | 0.64 | 0.72 | 0.90 | 1.00 | 124 | reject |
+| granite-4.0-h-micro | 3.2B | — | 0.59 | 0.83 | 0.98 | 112 | reject |
+| granite-4.0-micro | 3.4B | — | 0.40 | 0.99 | 1.00 | 143 | reject (doc) |
+| phi-4-mini | 3.8B | — | 0.30 | 0.97 | 0.97 | 140 | reject (doc) |
+| lfm2.5-8b-a1b | 8B/1A | — | 0.19 | 0.28 | 1.00 | 225 | reject |
+| lfm2.5-1.2b | 1.2B | — | 0.02 | 0.22 | 1.00 | 347 | reject |
+
+**No 2026 small model beats gemma-4-E4B.** Each trades gemma's one weakness (doc-flattening)
+for a worse one: smollm3 has the best doc structure of any ≤4B model but its code
+**echoes the schema's placeholder strings** (`"assumptions/guarantees or empty"`, `["concept"]`)
+and truncates ~8%; nemotron **malforms docs** (claim/entity as sibling keys) and also
+placeholder-echoes code; phi-4-mini and granite-4.0-micro have great code but doc 0.30/0.40;
+both LFM2.5 are too weak to structure. gemma-4-E4B's perfect code + 100% reliability + 0.91
+content carry it.
+
+## Findings
+- **Faithfulness is universal** among capable models under grammar enforcement — no
+  hallucination on extraction. The differentiators are **structure** and **reliability**.
+- **gemma-4-E4B flattens `doc_summary`** to a string (strict-doc 0.64); the larger gemma-4
+  variants do not (1.00).
+- **Qwen3.6 is content-capable but reliability-risky** — 8–12% of outputs truncate even
+  under grammar (valid-JSON 0.88–0.92); ~1-in-10 lost extractions for an async curator.
+- **MoE for throughput:** gemma-4-26B-A4B activates ~4B of 26B params/token → faster decode
+  than the dense 12B (84 vs 53 tok/s) despite a larger resident footprint.
+
+## Decision (operator)
+Quality is a three-way tie across gemma-4 12B/26B/31B (all perfect strict + valid-JSON; judge
+deltas sub-noise); the pick splits on **deployment VRAM**, because the *unified* container
+co-hosts the embedder + reranker on the same GPU:
+- **Unified GPU (shared) → gemma-4-12B** — best quality-per-VRAM (~8 GB co-resides cleanly);
+  53 tok/s is ample for a queue drain.
+- **Dedicated synth GPU → gemma-4-26B-A4B** — best quality-per-second when VRAM isn't
+  contended.
+- **CPU → gemma-4-E4B** — best ≤4B option (empirically, vs. the 2026 field); doc-flattening
+  is its one weakness. `smollm3-3b` is the alternative for doc-heavy / code-light workloads.
+- **Dropped:** dense gemma-4-31B (dominated), Qwen3.6 (reliability), granite-4.1-3B and all
+  other ≤4B candidates (weaker on the combined task).
+
+Completes the model-selection trilogy: embedder (#624), reranker (#628), synth (here).

--- a/benchmarks/results/synth/rescore_strict.py
+++ b/benchmarks/results/synth/rescore_strict.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""rescore_strict.py RES4.json — re-score saved raw extractions with a STRICT, intuitive
+rubric: a malformed primary artifact (doc_summary / code_unit) costs points, and a
+validity-rate term penalizes any malformed artifact directly. No re-generation needed."""
+import json, sys, re
+ST={"draft","accepted","done","rejected","deferred"}; PR={"low","medium","high"}
+CK={"fact","requirement","constraint","decision","behavior"}
+EK={"component","system","concept","protocol","data_store","tool"}
+def repair(s):
+    s=s.strip()
+    if "</think>" in s: s=s.rsplit("</think>",1)[1].strip()
+    if s.startswith("```"): s="\n".join(s.splitlines()[1:]); s=s.rsplit("```",1)[0]
+    a=s.find("{")
+    if a<0: return s
+    out=[]; stack=[]; ins=False; esc=False
+    for c in s[a:]:
+        if ins:
+            out.append(c)
+            if esc: esc=False
+            elif c=="\\": esc=True
+            elif c=='"': ins=False
+        else:
+            if c=='"': ins=True; out.append(c)
+            elif c in "{[": stack.append(c); out.append(c)
+            elif c in "}]":
+                want="{" if c=="}" else "["
+                if stack and stack[-1]==want:
+                    stack.pop(); out.append(c)
+                    if not stack: break
+            else: out.append(c)
+    while stack: out.append("}" if stack.pop()=="{" else "]")
+    res="".join(out); return re.sub(r',(\s*[}\]])', r'\1', res)
+
+def art_valid(x):
+    if not isinstance(x,dict): return False
+    k=x.get("kind"); pl=x.get("payload")
+    if not isinstance(pl,dict): return False
+    if k=="doc_summary": return pl.get("status") in ST and pl.get("priority") in PR and isinstance(pl.get("components"),list) and bool(pl.get("summary"))
+    if k=="claim": return pl.get("claim_kind") in CK and all(pl.get(z) for z in ("subject","attribute","value","text"))
+    if k=="entity": return pl.get("entity_kind") in EK and bool(pl.get("name"))
+    return False
+
+def score_doc_strict(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0
+    ds = 1.0 if any(isinstance(x,dict) and x.get("kind")=="doc_summary" and art_valid(x) for x in a) else 0.0
+    cl = 1.0 if any(isinstance(x,dict) and x.get("kind")=="claim" and art_valid(x) for x in a) else 0.0
+    nv = sum(1 for x in a if art_valid(x))
+    prec = nv/len(a)                       # validity rate: malformed artifacts cost directly
+    return (ds+cl+prec)/3.0
+
+def score_code_strict(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0
+    cu=[x for x in a if isinstance(x,dict) and x.get("kind")=="code_unit" and isinstance(x.get("payload"),dict)]
+    if not cu: return 0.0
+    pl=cu[0]["payload"]
+    fields=[bool(pl.get("summary")), isinstance(pl.get("side_effects"),list), isinstance(pl.get("domain_concepts"),list)]
+    base=sum(fields)/3.0                    # fraction of required fields well-formed (no 0.4 floor)
+    # penalty if it emitted junk beyond the one code_unit
+    extra=len(a)-1
+    return base*(1.0 if extra<=0 else max(0.6, 1.0-0.1*extra))
+
+r=json.load(open(sys.argv[1]))
+docs=[d for d in r["detail"] if d.get("role")=="extract_doc"]
+code=[d for d in r["detail"] if d.get("role")=="extract_code"]
+def parse(d):
+    try: return json.loads(repair(d.get("raw","")))
+    except Exception: return None
+dd=[score_doc_strict(parse(d)) for d in docs if d.get("raw") is not None]
+cc=[(d.get("lang"),score_code_strict(parse(d))) for d in code if d.get("raw") is not None]
+import statistics
+ndoc=round(statistics.mean(dd),3) if dd else 0
+ncode=round(statistics.mean([s for _,s in cc]),3) if cc else 0
+by={}
+for lang,s in cc: by.setdefault(lang,[]).append(s)
+by={k:round(statistics.mean(v),3) for k,v in sorted(by.items())}
+print(f"{r['name']}:  OLD doc={r['doc_schema']} code={r['code_schema']}   ->   STRICT doc={ndoc} code={ncode}")
+print(f"  strict code_by_lang: {by}")

--- a/benchmarks/results/synth/serve_and_bench.sh
+++ b/benchmarks/results/synth/serve_and_bench.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# sg4.sh MODELFILE MODE LABEL — serve one model, run grammar-enforced corpus harness, kill.
+set -u
+NAME="$1"; MODE="${2:-gpu}"; LABEL="${3:-$1}"
+DIR=/mnt/media/synthbench
+BIN=$DIR/llama-b9761/llama-server; LIB=$DIR/llama-b9761
+M=$DIR/models/${NAME}.gguf
+PORT=8920
+[ "$MODE" = cpu ] && NGL=0 || NGL=99
+pkill -9 -u "$(id -un)" -f "llama-server.*$PORT" 2>/dev/null; sleep 2
+LD_LIBRARY_PATH=$LIB nohup "$BIN" -m "$M" -ngl $NGL -fa on --jinja --ctx-size 8192 -ub 2048 -np 1 \
+  --host 127.0.0.1 --port $PORT > "$DIR/srv_${LABEL}.log" 2>&1 &
+SRV=$!
+ok=0
+for i in $(seq 1 150); do sleep 2; curl -s http://127.0.0.1:$PORT/health 2>/dev/null | grep -q ok && { ok=1; break; }; done
+if [ "$ok" = 0 ]; then echo "SERVER FAILED ($LABEL): $(tail -3 $DIR/srv_${LABEL}.log)"; kill $SRV 2>/dev/null; pkill -9 -u "$(id -un)" -f "llama-server.*$PORT" 2>/dev/null; exit 1; fi
+python3 "$DIR/synth_bench.py" $PORT "$LABEL" "$LABEL"
+kill $SRV 2>/dev/null; pkill -9 -u "$(id -un)" -f "llama-server.*$PORT" 2>/dev/null
+echo "SG4DONE_${LABEL}"

--- a/benchmarks/results/synth/synth_bench.py
+++ b/benchmarks/results/synth/synth_bench.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""synth_bench.py PORT MODEL NAME [CORPUS] — GRAMMAR-ENFORCED curator/synth benchmark.
+
+Passes a generic JSON GBNF via the `grammar` field so output is *syntactically valid
+JSON by construction* (NOT response_format=json_object, which b9761 silently ignores).
+raw_parse should be 1.0; doc_schema/code_schema then measure content (valid enums /
+required fields) free of any validity confound. Saves every raw extraction for the
+strict re-score (rescore_strict.py) and the content judge.
+
+CORPUS (argv[4]) is the workspace sample set; it is NOT committed (built per-host from
+~/dev + ~/gow). See README.md. Run via serve_and_bench.sh, which starts llama-server
+and invokes this. Output: res4_<NAME>.json + a one-line summary."""
+import json, sys, time, urllib.request, textwrap, re
+PORT,MODEL,NAME=sys.argv[1],sys.argv[2],sys.argv[3]
+CORPUS=sys.argv[4] if len(sys.argv)>4 else "synth_corpus_full.json"
+samples=json.load(open(CORPUS))
+
+# Standard llama.cpp generic-JSON grammar; root is an object => always a parseable JSON object.
+JSON_GBNF = r'''
+root   ::= object
+value  ::= object | array | string | number | ("true" | "false" | "null") ws
+object ::= "{" ws ( string ":" ws value ("," ws string ":" ws value)* )? "}" ws
+array  ::= "[" ws ( value ("," ws value)* )? "]" ws
+string ::= "\"" ( [^"\\\x7F\x00-\x1F] | "\\" (["\\bfnrt/] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]) )* "\"" ws
+number ::= ("-"? ([0-9] | [1-9] [0-9]{0,15})) ("." [0-9]+)? ([eE] [-+]? [0-9]{1,16})? ws
+ws ::= | " " | "\n" [ \t]{0,20}
+'''
+
+def doc_prompt(i):
+    return textwrap.dedent(f"""
+    You are a knowledge extraction assistant. Extract structured knowledge from the
+    document chunk below and return ONLY a valid JSON object — no markdown fences.
+    Document: {i.get('file_path','')}
+    Section:  {i.get('heading_path','') or '(top level)'}
+    Content:
+    {i.get('content','')}
+    Return a JSON object {{"artifacts":[...]}} where each artifact has "kind" in
+    [doc_summary, claim, entity], a "payload", a "confidence" (>=0.70), "citations".
+    doc_summary.payload: summary, source_file, status(draft|accepted|done|rejected|deferred),
+    priority(low|medium|high), components(list). claim.payload: subject, attribute, value,
+    claim_kind(fact|requirement|constraint|decision|behavior), text. entity.payload: name,
+    entity_kind(component|system|concept|protocol|data_store|tool), context. Always include
+    >=1 doc_summary and >=1 claim; one entity per named system/component.""").strip()
+def code_prompt(i):
+    return textwrap.dedent(f"""
+    You are a code analysis assistant. Analyze the {i.get('kind','function')} below and
+    return ONLY a valid JSON object — no markdown fences.
+    File: {i.get('file_path','')}
+    Symbol: {i.get('symbol','')} at line {i.get('line',0)}
+    Body:
+    {i.get('body','')}
+    Return {{"artifacts":[{{"kind":"code_unit","payload":{{"summary":"1-2 sentence intent",
+    "invariants":"assumptions/guarantees or empty","side_effects":["filesystem","allocation"],
+    "domain_concepts":["concept"]}},"confidence":0.82,"citations":[]}}]}}""").strip()
+def repair(s):
+    s=s.strip()
+    if "</think>" in s: s=s.rsplit("</think>",1)[1].strip()
+    if s.startswith("```"): s="\n".join(s.splitlines()[1:]); s=s.rsplit("```",1)[0]
+    a=s.find("{")
+    if a<0: return s
+    out=[]; stack=[]; ins=False; esc=False
+    for c in s[a:]:
+        if ins:
+            out.append(c)
+            if esc: esc=False
+            elif c=="\\": esc=True
+            elif c=='"': ins=False
+        else:
+            if c=='"': ins=True; out.append(c)
+            elif c in "{[": stack.append(c); out.append(c)
+            elif c in "}]":
+                want="{" if c=="}" else "["
+                if stack and stack[-1]==want:
+                    stack.pop(); out.append(c)
+                    if not stack: break
+            else: out.append(c)
+    while stack: out.append("}" if stack.pop()=="{" else "]")
+    res="".join(out)
+    res=re.sub(r',(\s*[}\]])', r'\1', res)
+    return res
+DK={"doc_summary","claim","entity"}; ST={"draft","accepted","done","rejected","deferred"}
+PR={"low","medium","high"}; EK={"component","system","concept","protocol","data_store","tool"}
+CK={"fact","requirement","constraint","decision","behavior"}
+def score_doc(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0,0
+    p=[1.0 if any(isinstance(x,dict) and x.get("kind")=="doc_summary" for x in a) else 0.0,
+       1.0 if any(isinstance(x,dict) and x.get("kind")=="claim" for x in a) else 0.0]
+    nv=0
+    for x in a:
+        if not isinstance(x,dict): continue
+        k=x.get("kind"); pl=x.get("payload",{})
+        if k not in DK or not isinstance(pl,dict): continue
+        ok=True
+        if k=="doc_summary": ok=pl.get("status") in ST and pl.get("priority") in PR and isinstance(pl.get("components"),list) and bool(pl.get("summary"))
+        elif k=="claim": ok=pl.get("claim_kind") in CK and all(pl.get(z) for z in ("subject","attribute","value","text"))
+        elif k=="entity": ok=pl.get("entity_kind") in EK and bool(pl.get("name"))
+        if ok: nv+=1
+    p.append(min(1.0,nv/3.0)); return sum(p)/len(p),nv
+def score_code(o):
+    a=o.get("artifacts") if isinstance(o,dict) else None
+    if not isinstance(a,list) or not a: return 0.0,0
+    cu=[x for x in a if isinstance(x,dict) and x.get("kind")=="code_unit"]
+    if not cu: return 0.0,0
+    pl=cu[0].get("payload",{})
+    ok=isinstance(pl,dict) and bool(pl.get("summary")) and isinstance(pl.get("side_effects"),list) and isinstance(pl.get("domain_concepts"),list)
+    return (1.0 if ok else 0.4),(1 if ok else 0)
+def call(prompt):
+    if "qwen" in NAME.lower(): prompt=prompt+" /no_think"
+    body=json.dumps({"model":MODEL,"messages":[{"role":"user","content":prompt}],"temperature":0,
+      "max_tokens":1536,"chat_template_kwargs":{"enable_thinking":False},"grammar":JSON_GBNF}).encode()
+    req=urllib.request.Request(f"http://127.0.0.1:{PORT}/v1/chat/completions",data=body,headers={"Content-Type":"application/json"})
+    t0=time.time(); d=json.load(urllib.request.urlopen(req,timeout=180)); dt=time.time()-t0
+    return d["choices"][0]["message"]["content"] or "", dt, d.get("usage",{}).get("completion_tokens",0)
+res=[]; TT=0; TOK=0; raw_parse=0; cap=[]
+for s in samples:
+    pr=doc_prompt(s["input"]) if s["role"]=="extract_doc" else code_prompt(s["input"])
+    lang=s.get("lang")
+    try: txt,dt,tk=call(pr)
+    except Exception as e: res.append({"role":s["role"],"lang":lang,"parsed":False,"score":0,"valid":0,"err":str(e)[:80]}); continue
+    TT+=dt; TOK+=tk
+    try: json.loads(txt.strip()); raw_parse+=1
+    except: pass
+    try: o=json.loads(repair(txt)); pa=True
+    except: o={}; pa=False
+    sc,nv=(score_doc(o) if s["role"]=="extract_doc" else score_code(o))
+    res.append({"role":s["role"],"lang":lang,"project":s.get("project"),
+                "file":s["input"].get("file_path"),"parsed":pa,"score":round(sc,2),"valid":nv,"toks":tk,
+                "raw":txt})   # full extraction saved for manual review + future judge round
+    if len(cap)<2: cap.append({"role":s["role"],"raw":txt[:600]})
+d=[r for r in res if r["role"]=="extract_doc"]; c=[r for r in res if r["role"]=="extract_code"]
+av=lambda x,k: round(sum(r.get(k,0) for r in x)/len(x),3) if x else 0
+# per-language code breakdown
+code_by_lang={}
+for r in c:
+    code_by_lang.setdefault(r.get("lang") or "?",[]).append(r["score"])
+code_by_lang={k:round(sum(v)/len(v),3) for k,v in sorted(code_by_lang.items())}
+out={"name":NAME,"doc_schema":av(d,"score"),"code_schema":av(c,"score"),"parse_after_repair":av(res,"parsed"),
+     "raw_parse_rate":round(raw_parse/len(res),3),"tok_per_s":round(TOK/TT,1) if TT else 0,"n":len(res),
+     "n_doc":len(d),"n_code":len(c),"code_by_lang":code_by_lang,"detail":res,"samples":cap}
+json.dump(out,open(f"/mnt/media/synthbench/res4_{NAME}.json","w"),indent=1)
+print(f"{NAME}: doc={out['doc_schema']}(n{out['n_doc']}) code={out['code_schema']}(n{out['n_code']}) raw_parse={out['raw_parse_rate']} {out['tok_per_s']}tok/s | by_lang={out['code_by_lang']}")

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -3,7 +3,9 @@
 - **State:** draft — **rev 7** · **roundtable SIGNED OFF at rev 6** (round 5: 0
   blocking / 0 high / 0 medium, converged). Arc: r1 10 blocking → r2 7 blocking +
   8 high → r3 1 blocking + 1 high + 2 medium → r5 **0 blocking**. rev 7 closes the
-  two open questions (pins the operator's synth models; decouples + shrinks the
+  two open questions (synth models BENCHMARKED grammar-enforced + judged —
+  Gemma-4-E4B CPU / Gemma-4-12B unified-GPU (Gemma-4-26B-A4B dedicated), Qwen3.6
+  dropped on JSON-reliability, dense 31B dominated; decouples + shrinks the
   reranker to Ettin ModernBERT — 400m GPU / 68m CPU, both `-fa on`, Qwen3-Reranker
   dropped from the real-time path; E4B-ungated CPU default). See "Decisions
   taken" and "Changelog".
@@ -241,20 +243,43 @@ per `(query, candidate)` pair, **no chat template and no yes/no-logprob transfor
 dropped from the real-time path; it remains usable only **async** (e.g. background
 memory re-ranking) where its quality is worth seconds of latency.
 
-**Synth ladder** (pinned to your specified models; MoE rows have low active params):
+**Synth ladder** (benchmarked grammar-enforced + judged on the curator's real
+extraction task — see below):
 
-| Install | Synth model (GGUF) |
-|---------|--------------------|
-| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — the mirror is **ungated**, no `HF_TOKEN`) |
-| GPU-S | `unsloth/gemma-4-12B-it-GGUF` (Gemma 4 12B) |
-| GPU-M | `unsloth/gemma-4-26B-A4B-it-GGUF` (Gemma 4 26B-A4B, MoE ~4B active) |
-| GPU-L | `unsloth/Qwen3.6-35B-A3B-GGUF` (Qwen3.6 35B-A3B, MoE ~3B active) |
+| Install | Synth model (GGUF) | arch |
+|---------|--------------------|------|
+| CPU-only (**default**) | **`ggml-org/gemma-4-E4B-it-GGUF`** (Gemma 4 E4B — ungated mirror, no `HF_TOKEN`) | ~7B raw / E4B effective |
+| GPU — unified (**default**) | **`unsloth/gemma-4-12b-it-GGUF`** (Gemma 4 12B) | 12B dense, ~8 GB |
+| GPU — dedicated synth host | **`unsloth/gemma-4-26B-A4B-it-GGUF`** (Gemma 4 26B-A4B) | 26B MoE / ~4B active, ~17 GB |
 
-> **Pinning.** Names are fixed above; implementation pins each to a specific
-> **commit sha** + quant. The CPU default is **Gemma 4 E4B via the ungated
-> `ggml-org` GGUF mirror** (already pulled unauthenticated in the current compose),
-> so there is **no separate "ungated fallback" model and no first-boot `HF_TOKEN`
-> requirement** — E4B is simply the CPU default.
+> **Basis (2026-06-23, grammar-enforced + judged).** The curator does **async
+> structured-JSON extraction** (`scripts/curator-extract.py`: doc/code → a schema'd
+> `{"artifacts":[…]}` object). Throughput-bound (drains a queue), not latency-bound.
+> The first pass was **confounded** — it scored `response_format=json_object`, which
+> b9761 silently ignores, so it measured freeform-JSON luck. Redone with a
+> **sampler-level GBNF grammar** (guaranteed valid JSON) over a **60-sample corpus
+> drawn from the real ~/dev + ~/gow workspace** (every aimee-supported language),
+> scored on three uniform layers: a strict de-saturated schema rubric, a corpus-wide
+> valid-JSON rate, and a **blind Claude content judge**. Full data + harness in
+> [`benchmarks/results/synth/RESULTS.md`](../../benchmarks/results/synth/RESULTS.md).
+>
+> Headline: under grammar enforcement **faithfulness is universal** — no model
+> hallucinates; the differentiators are **structure** and **reliability**. The old
+> "every Qwen slips" / "Granite wins" findings were harness artifacts. Corrected:
+> - **GPU quality ties** across gemma-4 12B/26B-A4B/31B (all perfect schema +
+>   valid-JSON). The pick splits on **deployment VRAM** because this container
+>   co-hosts embed + rerank: **gemma-4-12B** (~8 GB, 53 tok/s) for the *unified* GPU;
+>   **gemma-4-26B-A4B** (MoE, ~4B active → 84 tok/s, ~17 GB) when synth has a GPU to
+>   itself. Dense **gemma-4-31B** is dominated (slower *and* larger).
+> - **Qwen3.6 dropped on reliability** — content is strong but 8–12% of outputs
+>   **truncate** even under grammar (valid-JSON 0.88–0.92) → ~1-in-10 lost extractions.
+> - **CPU stays gemma-4-E4B.** A 2026 ≤4B bake-off (granite-4.0-micro/h-micro,
+>   nemotron-3-nano-4b, phi-4-mini, smollm3-3b, lfm2.5-1.2b/8b-a1b) found **none beats
+>   it** — each trades gemma's one weakness (it flattens `doc_summary`) for a worse one
+>   (placeholder-echoed or malformed code, or sub-0.4 doc). E4B keeps perfect code +
+>   100% valid JSON. `smollm3-3b` is the alternative for doc-heavy / code-light hosts.
+>
+> Pin each to a specific **commit sha + quant**.
 
 #### The 8B truncation — why 4000, and how it must be done
 
@@ -508,8 +533,14 @@ We take the fold but pay down its cost:
 - **Auth default = mTLS**; bearer dev-only.
 - **CPU synth default = Gemma 4 E4B** via the ungated `ggml-org` GGUF mirror (no
   `HF_TOKEN`); the separate "ungated fallback" model is dropped.
-- **Synth models pinned** to the operator's spec: Gemma 4 **E4B (CPU)**, Gemma 4
-  12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Reranker = Ettin (ModernBERT
+- **Synth models — benchmarked grammar-enforced + judged** (2026-06-23; the
+  2026-06-22 pass was confounded by an ignored `json_object` and is superseded):
+  **CPU = Gemma 4 E4B** (best ≤4B vs the 2026 field), **GPU = Gemma 4 12B** for the
+  unified container (~8 GB, co-resides with embed+rerank) / **Gemma 4 26B-A4B** (MoE)
+  for a dedicated synth host. Under grammar enforcement faithfulness is universal;
+  **Qwen3.6 dropped on reliability** (8–12% truncation), **dense Gemma-4-31B dominated**
+  (slower + larger than the 26B MoE at equal quality). Replaces the rev-7 Gemma-12B/26B
+  + Qwen3.6 ladder. See `benchmarks/results/synth/RESULTS.md`. **Reranker = Ettin (ModernBERT
   cross-encoder), NOT Qwen3-Reranker**: GPU default `ettin-reranker-400m`, CPU-only
   `ettin-reranker-68m`, both `--flash-attn on`. Real-time on the 7900XTX (ettin-400m
   top-20 0.34s; ettin-68m top-10 0.60s) and correct/fast via native `/v1/rerank` —
@@ -552,9 +583,12 @@ We take the fold but pay down its cost:
 - **rev 7 (2026-06-21):** reduced the open questions to mechanical items
   (commit-sha/quant pins + a reranker-swap-cost confirmation). **Pinned synth
   models** to the
-  operator's spec — Gemma 4 E4B (CPU, **ungated `ggml-org` mirror → no `HF_TOKEN`**,
-  so the rev-5 "ungated fallback" model is dropped and E4B is the plain CPU
-  default), Gemma 4 12B / 26B-A4B / Qwen3.6 35B-A3B (GPU-S/M/L). **Decoupled the
+  benchmark (re-run grammar-enforced + judged 2026-06-23; the 2026-06-22 pass was
+  confounded by an ignored `json_object`) — **CPU = Gemma 4 E4B** (ungated `ggml-org`
+  mirror → no `HF_TOKEN`; rev-5 "ungated fallback" dropped; best ≤4B vs the 2026 field),
+  **GPU = Gemma 4 12B** (unified) / **Gemma 4 26B-A4B** (dedicated synth host); replaces
+  the rev-7 Gemma-12B/26B + Qwen3.6 ladder (Qwen dropped on JSON-reliability, dense 31B
+  dominated). **Decoupled the
   reranker** from the embed ladder (it is dimension-agnostic): **Ettin ModernBERT
   cross-encoder — `ettin-reranker-400m` (GPU) / `ettin-reranker-68m` (CPU), both
   `-fa on`; Qwen3-Reranker dropped from the real-time path** (too slow + native

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -2762,15 +2762,31 @@ export default function Chat() {
       else e.think += u.delta;
       byId.set(u.id, e);
     }
-    const applyDeltas = (msgs: StreamMsg[], byId: Map<number, { text: string; think: string }>): StreamMsg[] =>
-      msgs.map(m => {
-        const e = byId.get(m.id);
-        if (!e) return m;
-        const next = { ...m };
-        if (e.text) next.text = m.text + e.text;
-        if (e.think) next.thinkText = (m.thinkText ?? '') + e.think;
-        return next;
-      });
+    // Only the messages that received a delta change — in practice the 1–2 tail
+    // blocks of the turn (the streaming assistant bubble, maybe a thinking
+    // block). The whole conversation lives in `msgs` (windowing is render-only),
+    // so map()-ing a closure + Map.get over the FULL history every flush is
+    // O(history) of wasted work — and it runs for EVERY streaming tab ~10×/s, so
+    // it scales with running-tab count × session length, pegging a core. Instead
+    // copy the array once (cheap pointer copy) and rewrite only the matching
+    // indices, scanning from the tail and stopping once every delta is placed.
+    const applyDeltas = (msgs: StreamMsg[], byId: Map<number, { text: string; think: string }>): StreamMsg[] => {
+      if (byId.size === 0) return msgs;
+      let next: StreamMsg[] | null = null;
+      let remaining = byId.size;
+      for (let i = msgs.length - 1; i >= 0 && remaining > 0; i--) {
+        const e = byId.get(msgs[i].id);
+        if (!e) continue;
+        if (!next) next = msgs.slice();
+        const m = msgs[i];
+        const nm = { ...m };
+        if (e.text) nm.text = m.text + e.text;
+        if (e.think) nm.thinkText = (m.thinkText ?? '') + e.think;
+        next[i] = nm;
+        remaining--;
+      }
+      return next ?? msgs;
+    };
     const activeSid = tabsRef.current[activeIdxRef.current]?.aimeeSid ?? '';
     for (const [owner, byId] of byOwner) {
       if (owner === activeSid) {

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -832,7 +832,7 @@ function PluginsPanel({ open, plugins, loading, error, onToggle, onRefresh, onPl
 
 /* ---- Working indicator ---- */
 
-function WorkingIndicator() {
+function WorkingIndicator({ status }: { status?: string }) {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 14px', color: tokens.primary, fontSize: '13px', alignSelf: 'flex-start' }}>
       <div style={{ display: 'inline-flex', gap: '4px' }}>
@@ -846,7 +846,9 @@ function WorkingIndicator() {
           />
         ))}
       </div>
-      Working
+      {/* The condensed live spinner line when the CLI is actively working;
+          plain "Working" otherwise. */}
+      <span style={{ whiteSpace: 'pre-wrap' }}>{status && status.trim() ? status : 'Working'}</span>
       <style>{`
         @keyframes pulse {
           0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
@@ -1448,7 +1450,17 @@ export default function Chat() {
   // aimeeSid, so the busy indicator reflects the ACTIVE tab alone — sending on one
   // tab no longer shows "working" on every other tab. Derived values below.
   const [workBySid, setWorkBySid] = useState<Record<string, SidWork>>({});
+  // Transient live-activity line (condensed tmux-CLI spinner, e.g. "Misting…
+  // (1m 5s · ↓ 2.6k tokens · thinking)") keyed by the owning tab's aimeeSid. Set
+  // from `status` SSE events, cleared at each turn boundary. Shown inside the
+  // working indicator so a long thinking phase reads as live, not frozen.
+  const [statusBySid, setStatusBySid] = useState<Record<string, string>>({});
+  // Every tab's latest live-activity line, kept off the render path so an
+  // off-screen turn's spinner never re-renders the active view. Only the active
+  // tab is mirrored into statusBySid (above); a tab switch hydrates from here.
+  const statusByOwnerRef = useRef<Map<string, string>>(new Map());
   const activeWork = workBySid[tabs[activeIdx]?.aimeeSid ?? ''];
+  const activeStatus = statusBySid[tabs[activeIdx]?.aimeeSid ?? ''] ?? '';
   const working = !!activeWork && (activeWork.pending > 0 || activeWork.queued > 0);
   const iterCur = activeWork?.iterCur ?? 0;
   const iterMax = activeWork?.iterMax ?? 0;
@@ -1830,6 +1842,15 @@ export default function Chat() {
         if (!active && iterCur === 0 && iterMax === 0) continue;
         next[sid] = { pending: p, queued: q, iterCur, iterMax };
       }
+      // Bail if nothing changed: this runs on every drained item, and returning a
+      // fresh object each time forces a needless whole-Chat re-render.
+      const pk = Object.keys(prev);
+      const nk = Object.keys(next);
+      if (pk.length === nk.length && pk.every(k => {
+        const a = prev[k], b = next[k];
+        return b && a.pending === b.pending && a.queued === b.queued &&
+          a.iterCur === b.iterCur && a.iterMax === b.iterMax;
+      })) return prev;
       return next;
     });
   }
@@ -1839,6 +1860,29 @@ export default function Chat() {
     setWorkBySid(prev => {
       const cur = prev[sid] ?? { pending: 0, queued: 0, iterCur: 0, iterMax: 0 };
       return { ...prev, [sid]: { ...cur, iterCur, iterMax } };
+    });
+  }
+
+  /* Set (or clear, with '') the transient live-activity line for a tab.
+   *
+   * Only the ACTIVE tab's status drives React state. A background tab's spinner
+   * is never shown, so calling setState for it would re-render the whole Chat on
+   * every poll of every off-screen turn — that is the cost that scales with tab
+   * count (N concurrent turns → N× wasted full re-renders/s). Instead every tab's
+   * latest status is kept in a ref (no re-render); a tab switch hydrates state
+   * from it, and the entering tab's own live stream repaints within one poll. */
+  function setSidStatus(sid: string, status: string): void {
+    if (!sid) return;
+    if (status) statusByOwnerRef.current.set(sid, status);
+    else statusByOwnerRef.current.delete(sid);
+    const activeSid = tabsRef.current[activeIdxRef.current]?.aimeeSid ?? '';
+    if (sid !== activeSid) return;
+    setStatusBySid(prev => {
+      if ((prev[sid] ?? '') === status) return prev;
+      const next = { ...prev };
+      if (status) next[sid] = status;
+      else delete next[sid];
+      return next;
     });
   }
 
@@ -1854,6 +1898,8 @@ export default function Chat() {
     activeSendAbortRefs.current.forEach((_sid, controller) => controller.abort());
     activeSendAbortRefs.current.clear();
     setWorkBySid({});
+    statusByOwnerRef.current.clear();
+    setStatusBySid({});
   }
 
   useEffect(() => {
@@ -2127,6 +2173,11 @@ export default function Chat() {
     if (oldSid === newSid) return;
     if (oldSid) bgStreamsRef.current.set(oldSid, streamMsgsRef.current);
     renderedSidRef.current = newSid;
+    // Surface the entering tab's latest status (tracked in the ref while it was a
+    // background tab). statusBySid only ever holds the active tab, so reset it to
+    // just this one.
+    const enteringStatus = statusByOwnerRef.current.get(newSid) ?? '';
+    setStatusBySid(enteringStatus ? { [newSid]: enteringStatus } : {});
     skipNextStreamPersistRef.current = true;
     const buffered = bgStreamsRef.current.get(newSid);
     if (buffered) {
@@ -2750,6 +2801,13 @@ export default function Chat() {
         streamRefs.assistantId = null;
         streamRefs.thinkId = null;
         streamRefs.toolId = null;
+        setSidStatus(streamRefs.originSid, '');
+        break;
+      }
+      case 'status': {
+        // Transient live-activity line from a tmux CLI turn: replace in place
+        // (one rolling indicator), never appended to the transcript.
+        setSidStatus(streamRefs.originSid, String(data.content ?? ''));
         break;
       }
       case 'tool_start': {
@@ -2820,6 +2878,7 @@ export default function Chat() {
         streamRefs.assistantId = null;
         streamRefs.thinkId = null;
         streamRefs.toolId = null;
+        setSidStatus(streamRefs.originSid, '');
         break;
       }
       case 'error': {
@@ -2901,6 +2960,7 @@ export default function Chat() {
       }
       case 'done': {
         saveOwnerStream(streamRefs.originSid);
+        setSidStatus(streamRefs.originSid, '');
         void refreshWorkflow();
         /* Refresh LSP diagnostic badge after each completed turn */
         fetch('/api/lsp/diagnostics/summary')
@@ -3034,7 +3094,7 @@ export default function Chat() {
           </button>
         )}
         <Transcript messages={windowedMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
-        {working && <WorkingIndicator />}
+        {working && <WorkingIndicator status={activeStatus} />}
         {remoteTurnActive && !working && (
           <div style={{
             alignSelf: 'flex-start', maxWidth: '85%', padding: '6px 10px',

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -38,6 +38,10 @@ typedef struct
    /* Clean response text already streamed to the caller this turn (so recv emits
     * only the growth as an incremental delta). malloc'd; freed on destroy. */
    char *stream_emitted;
+   /* Last condensed working/status line emitted via the status callback this turn
+    * (so recv emits a status event only when the line actually changes, not every
+    * poll). malloc'd; freed on destroy. */
+   char *status_emitted;
 } cli_session_t;
 
 /* Incremental stream callback: invoked by cli_session_recv with each newly
@@ -48,6 +52,19 @@ void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud);
  * around a nested turn (prevents the inner turn's now-dead context leaking to
  * the outer turn). *ud_out receives the userdata; returns the callback. */
 cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out);
+
+/* Status callback: invoked by cli_session_recv with the latest *condensed*
+ * working/spinner line (e.g. "Misting… (1m 5s · ↓ 2.6k tokens · still thinking)")
+ * while the CLI is producing tokens. The TUI animates this line ~1×/s with a
+ * fresh elapsed counter; recv collapses the whole run into a single rolling
+ * status — emitting only when the line text changes — so the webchat shows live
+ * activity (one updating line) during long thinking phases instead of a frozen
+ * pane, without flooding the transcript. Distinct from the stream callback, which
+ * carries the assistant's actual answer text. Set per-thread; save/restore around
+ * a nested turn like the stream callback. */
+typedef void (*cli_session_status_cb_t)(const char *status, void *ud);
+void cli_session_set_status_cb(cli_session_status_cb_t cb, void *ud);
+cli_session_status_cb_t cli_session_get_status_cb(void **ud_out);
 
 /* Cancel-check callback: cli_session_recv polls it each tick; a non-zero return
  * aborts the wait (the running turn was asked to stop — steering/interrupt or
@@ -130,6 +147,14 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
  * content present in the baseline is excluded so prior turns never leak.
  * Returns newly allocated text; caller frees. Exposed for unit tests. */
 char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline);
+
+/* Extract the latest animated working/status line from a raw pane capture,
+ * condensed to a single line with the leading spinner glyph stripped (claude:
+ * "✢ Misting… (21s · ↑ 493 tokens)" → "Misting… (21s · ↑ 493 tokens)"; codex:
+ * "◦ Working (12s · esc to interrupt)"). Returns newly allocated text — an empty
+ * string when the pane shows no active-work line (idle / answer already done).
+ * Caller frees. Exposed for unit tests. */
+char *cli_session_extract_status(const char *raw, const char *cli_kind);
 
 /* --- Session name helpers --- */
 /* Build a deterministic session name: "aimee-<agent>-<hash(role)>".

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -207,6 +207,8 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
             sess.baseline = NULL;
             free(sess.stream_emitted);
             sess.stream_emitted = NULL;
+            free(sess.status_emitted);
+            sess.status_emitted = NULL;
          }
          else
             cli_session_destroy(&sess);
@@ -244,6 +246,8 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       sess.baseline = NULL;
       free(sess.stream_emitted);
       sess.stream_emitted = NULL;
+      free(sess.status_emitted);
+      sess.status_emitted = NULL;
    }
 
    if (!clean || !clean[0])

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -157,6 +157,14 @@ static int stream_event(compute_ctx_t *cctx, const char *event, const char *key,
    {
       if (event && strcmp(event, "text") == 0 && value && value[0])
          ring_text_append_locked(cctx, value);
+      else if (event && strcmp(event, "status") == 0)
+      {
+         /* Transient live-activity line: deliver on the live socket only, never
+          * persist it in the ring. It animates ~1×/s, so ring-publishing would
+          * bloat the turn history and replay a stale spinner on reconnect; the
+          * next poll re-emits a current line anyway. Leave any buffered text
+          * intact (status never enters the ring, so there is no reorder to guard). */
+      }
       else
       {
          ring_flush_text_locked(cctx); /* preserve order vs. buffered text */
@@ -586,6 +594,19 @@ static void chat_cli_stream_cb(const char *delta, void *ud)
    c->emitted = 1;
 }
 
+/* Forward the tmux CLI's condensed live-activity line as a transient `status`
+ * SSE event so the webchat shows a single rolling indicator ("Misting… (1m 5s ·
+ * …)") during long thinking phases. Not the answer — does not set `emitted`, and
+ * stream_event keeps `status` out of the presence ring (ephemeral; the next poll
+ * re-emits a fresh line, so a reconnect never replays a stale spinner). */
+static void chat_cli_status_cb(const char *status, void *ud)
+{
+   chat_cli_stream_ctx_t *c = (chat_cli_stream_ctx_t *)ud;
+   if (!c || !status || !status[0])
+      return;
+   stream_event(c->cctx, "status", "content", status);
+}
+
 /* Cancel predicate for the tmux CLI driver: reflects this turn's registry cancel
  * flag (set by chat.interrupt / graceful_cancel / session close). Lets
  * cli_session_recv abort a wedged or steered generation promptly without
@@ -678,6 +699,10 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    void *prev_stream_ud = NULL;
    cli_session_stream_cb_t prev_stream_cb = cli_session_get_stream_cb(&prev_stream_ud);
    cli_session_set_stream_cb(chat_cli_stream_cb, &sctx);
+   /* Live-activity status line (condensed spinner) for the same tmux turn. */
+   void *prev_status_ud = NULL;
+   cli_session_status_cb_t prev_status_cb = cli_session_get_status_cb(&prev_status_ud);
+   cli_session_set_status_cb(chat_cli_status_cb, &sctx);
    /* Let the tmux CLI driver observe this turn's cancel flag so a steer/interrupt
     * stops the running generation promptly. Save/restore around any outer turn. */
    void *prev_cancel_ud = NULL;
@@ -699,6 +724,7 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
 
    cli_session_set_error_grace_ms(prev_error_grace);
    cli_session_set_cancel_check(prev_cancel_cb, prev_cancel_ud);
+   cli_session_set_status_cb(prev_status_cb, prev_status_ud);
    cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -83,6 +83,24 @@ cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out)
    return g_stream_cb;
 }
 
+/* Per-thread status sink (set by the chat worker before a turn, cleared after).
+ * Thread-local for the same reason as the stream callback. */
+static __thread cli_session_status_cb_t g_status_cb = NULL;
+static __thread void *g_status_ud = NULL;
+
+void cli_session_set_status_cb(cli_session_status_cb_t cb, void *ud)
+{
+   g_status_cb = cb;
+   g_status_ud = ud;
+}
+
+cli_session_status_cb_t cli_session_get_status_cb(void **ud_out)
+{
+   if (ud_out)
+      *ud_out = g_status_ud;
+   return g_status_cb;
+}
+
 /* Per-thread cancel-check (set by the chat worker to the turn's cancel flag).
  * cli_session.c stays decoupled from the turn registry — the worker supplies the
  * predicate. */
@@ -430,6 +448,8 @@ void cli_session_destroy(cli_session_t *s)
    s->baseline = NULL;
    free(s->stream_emitted);
    s->stream_emitted = NULL;
+   free(s->status_emitted);
+   s->status_emitted = NULL;
    if (!s->active)
       return;
    if (!cli_session_is_alive(s))
@@ -794,6 +814,87 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
    return cli_extract_impl(raw, cli_kind, baseline, 1);
 }
 
+/* Recognize the CLI's animated working/status line. claude renders it as
+ * "<spinner> <Gerund>… (<elapsed> · <arrow> <tokens> tokens[· <state>])",
+ * cycling the spinner glyph (✻ ✢ ✽ · …) and the gerund every frame; codex uses
+ * "◦ Working (<elapsed> · esc to interrupt)". Rather than enumerate the volatile
+ * spinner glyphs we match the line by its stable shape: an open paren PLUS either
+ * an "esc to interrupt" hint or the ellipsis (…) + a token meter. The "to
+ * interrupt" phrase and the ellipsis-with-tokens shape both avoid false-matching
+ * claude's "⎿ Tip: …interrupting…" hint (no paren, no "… (") and ordinary prose. */
+static int cli_line_is_status(const char *t)
+{
+   if (!strchr(t, '('))
+      return 0;
+   if (strstr(t, "to interrupt"))
+      return 1; /* "esc to interrupt" — claude + codex working footer */
+   /* ellipsis (U+2026) accompanied by a token meter = claude's spinner line */
+   if (strstr(t, "\xe2\x80\xa6") && strstr(t, "token"))
+      return 1;
+   return 0;
+}
+
+/* Strip a leading spinner glyph (a whitespace-delimited token with no ASCII
+ * letter — "✢", "·", "◦") plus following spaces, leaving the human-readable
+ * status ("Misting… (21s · ↑ 493 tokens)"). The body is returned verbatim. */
+static const char *cli_status_body(const char *line)
+{
+   const char *b = cli_lstrip(line);
+   const char *sp = b;
+   while (*sp && *sp != ' ')
+      sp++;
+   int tok_has_letter = 0;
+   for (const char *q = b; q < sp; q++)
+      if ((*q >= 'A' && *q <= 'Z') || (*q >= 'a' && *q <= 'z'))
+      {
+         tok_has_letter = 1;
+         break;
+      }
+   if (!tok_has_letter && *sp == ' ')
+   {
+      b = sp;
+      while (*b == ' ')
+         b++;
+   }
+   return b;
+}
+
+char *cli_session_extract_status(const char *raw, const char *cli_kind)
+{
+   (void)cli_kind; /* the shape match covers claude + codex */
+   /* strip_ansi returns a fresh buffer we own, so split it in place (rewrite '\n'
+    * to '\0'), scanning for the LAST status line (the live footer sits at the
+    * bottom of the pane). */
+   char *work = cli_session_strip_ansi(raw ? raw : "");
+   if (!work)
+      return strdup("");
+
+   char *best = NULL; /* malloc'd copy of the most recent status line's body */
+   for (char *p = work;;)
+   {
+      char *nl = strchr(p, '\n');
+      if (nl)
+         *nl = '\0';
+      const char *ls = cli_lstrip(p);
+      if (cli_line_is_status(ls))
+      {
+         const char *body = cli_status_body(ls);
+         char *dup = strdup(body);
+         if (dup)
+         {
+            free(best);
+            best = dup;
+         }
+      }
+      if (!nl)
+         break;
+      p = nl + 1;
+   }
+
+   free(work);
+   return best ? best : strdup("");
+}
+
 /* True when the pane shows the CLI parked in a provider error/retry state.
  * claude renders this on its ✻ status line ("API error · Retrying in Ns ·
  * attempt K/10"); the normal completion status ("✻ Baked for Ns") and the
@@ -842,6 +943,8 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    long long err_start = 0; /* mono_ms when that state began (valid iff err_active) */
    free(s->stream_emitted);
    s->stream_emitted = strdup("");
+   free(s->status_emitted);
+   s->status_emitted = strdup("");
 
    for (;;)
    {
@@ -951,6 +1054,26 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
          }
          else
             free(partial);
+      }
+
+      /* Stream a condensed live-activity line while the CLI works. The TUI has no
+       * answer bullet yet during a thinking phase, so the stream callback above
+       * emits nothing and the webchat would look frozen; the status line ("Misting…
+       * (21s · ↑ 493 tokens)") keeps it alive. The TUI re-renders this line ~1×/s
+       * with a fresh counter, so emit only when the text changes — one rolling
+       * status, not one event per frame. */
+      if (g_status_cb)
+      {
+         char *status = cli_session_extract_status(cap, s->cli_kind);
+         const char *prevst = s->status_emitted ? s->status_emitted : "";
+         if (status && status[0] && strcmp(status, prevst) != 0)
+         {
+            g_status_cb(status, g_status_ud);
+            free(s->status_emitted);
+            s->status_emitted = status;
+         }
+         else
+            free(status);
       }
 
       /* Provider-error bound: if the CLI parks in an error/retry state for longer

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -534,6 +534,66 @@ static void test_extract_baseline_substring_kept(void)
    free(r);
 }
 
+/* --- cli_session_extract_status: condensed live-activity line --- */
+
+/* claude's animated spinner footer is returned verbatim with the leading glyph
+ * stripped, so the webchat shows a single human-readable activity line. */
+static void test_status_claude_spinner(void)
+{
+   const char *pane = "\xe2\x9d\xaf write a poem\n"
+                      "\xe2\x9c\xbb Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)\n";
+   char *r = cli_session_extract_status(pane, "claude");
+   assert(r != NULL);
+   assert(strcmp(r, "Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)") == 0);
+   free(r);
+}
+
+/* When several spinner frames are on the pane (scrollback), the LAST one wins —
+ * that is the current state. */
+static void test_status_picks_last_frame(void)
+{
+   const char *pane =
+       "\xe2\x9c\xbb Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)\n"
+       "\xe2\x9c\xbd Misting\xe2\x80\xa6 (58s \xc2\xb7 \xe2\x86\x93 2.0k tokens \xc2\xb7 "
+       "thinking)\n";
+   char *r = cli_session_extract_status(pane, "claude");
+   assert(r != NULL);
+   assert(
+       strcmp(r, "Misting\xe2\x80\xa6 (58s \xc2\xb7 \xe2\x86\x93 2.0k tokens \xc2\xb7 thinking)") ==
+       0);
+   free(r);
+}
+
+/* The "⎿ Tip: …interrupting…" hint must NOT be mistaken for a status line (no
+ * paren, no "… ("), and an idle pane yields an empty string. */
+static void test_status_ignores_tip_and_idle(void)
+{
+   const char *tip = "\xe2\x8e\xbf Tip: Use /btw to ask a side question without interrupting "
+                     "Claude's current work\n";
+   char *r = cli_session_extract_status(tip, "claude");
+   assert(r != NULL);
+   assert(r[0] == '\0');
+   free(r);
+
+   const char *idle = "\xe2\x97\x8f all done\n\xe2\x9c\xbb Baked for 3s\n";
+   char *r2 = cli_session_extract_status(idle, "claude");
+   assert(r2 != NULL);
+   assert(r2[0] == '\0');
+   free(r2);
+}
+
+/* codex's "Working (Ns · esc to interrupt)" footer is matched via the interrupt
+ * hint and the glyph is stripped. */
+static void test_status_codex_working(void)
+{
+   const char *pane = "\xe2\x80\xba do it\n"
+                      "\xe2\x97\xa6 Working (12s \xc2\xb7 esc to interrupt)\n";
+   char *r = cli_session_extract_status(pane, "codex");
+   assert(r != NULL);
+   assert(strcmp(r, "Working (12s \xc2\xb7 esc to interrupt)") == 0);
+   free(r);
+}
+
 /* --- cli_session_prepare_claude: claude-code first-run gate seeding --- */
 
 static char *slurp(const char *path)
@@ -740,6 +800,22 @@ int main(void)
 
    printf("test_extract_baseline_substring_kept... ");
    test_extract_baseline_substring_kept();
+   printf("OK\n");
+
+   printf("test_status_claude_spinner... ");
+   test_status_claude_spinner();
+   printf("OK\n");
+
+   printf("test_status_picks_last_frame... ");
+   test_status_picks_last_frame();
+   printf("OK\n");
+
+   printf("test_status_ignores_tip_and_idle... ");
+   test_status_ignores_tip_and_idle();
+   printf("OK\n");
+
+   printf("test_status_codex_working... ");
+   test_status_codex_working();
    printf("OK\n");
 
    printf("test_make_name_format... ");


### PR DESCRIPTION
Promote `testing` → `main`. Three commits since the last promote:

- **#633** perf(webchat): stream-append made O(changed) not O(history) per tab — fixes the browser-CPU spike that scaled with the number of concurrently-running session tabs (`applyDeltas` was mapping the full conversation history per streaming tab every flush).
- **#632** feat(webchat): condensed tmux-CLI activity line streams during thinking phases (no more "frozen" pane); background-tab status kept off the render path so it doesn't re-render the active view.
- **#631** docs(synth): re-benchmarked curator on the 60-sample workspace corpus.

Clean fast-merge over `main` (local test-merge had no conflicts). All three already passed full CI on `testing`.