### PR TITLE
fix(webchat): treat cycling spinner line as chrome; drop the status bar

### DIFF
--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -832,7 +832,7 @@ function PluginsPanel({ open, plugins, loading, error, onToggle, onRefresh, onPl
 
 /* ---- Working indicator ---- */
 
-function WorkingIndicator({ status }: { status?: string }) {
+function WorkingIndicator() {
   return (
     <div style={{ display: 'flex', alignItems: 'center', gap: '8px', padding: '8px 14px', color: tokens.primary, fontSize: '13px', alignSelf: 'flex-start' }}>
       <div style={{ display: 'inline-flex', gap: '4px' }}>
@@ -846,9 +846,7 @@ function WorkingIndicator({ status }: { status?: string }) {
           />
         ))}
       </div>
-      {/* The condensed live spinner line when the CLI is actively working;
-          plain "Working" otherwise. */}
-      <span style={{ whiteSpace: 'pre-wrap' }}>{status && status.trim() ? status : 'Working'}</span>
+      Working
       <style>{`
         @keyframes pulse {
           0%, 80%, 100% { opacity: 0.2; transform: scale(0.8); }
@@ -1450,17 +1448,7 @@ export default function Chat() {
   // aimeeSid, so the busy indicator reflects the ACTIVE tab alone — sending on one
   // tab no longer shows "working" on every other tab. Derived values below.
   const [workBySid, setWorkBySid] = useState<Record<string, SidWork>>({});
-  // Transient live-activity line (condensed tmux-CLI spinner, e.g. "Misting…
-  // (1m 5s · ↓ 2.6k tokens · thinking)") keyed by the owning tab's aimeeSid. Set
-  // from `status` SSE events, cleared at each turn boundary. Shown inside the
-  // working indicator so a long thinking phase reads as live, not frozen.
-  const [statusBySid, setStatusBySid] = useState<Record<string, string>>({});
-  // Every tab's latest live-activity line, kept off the render path so an
-  // off-screen turn's spinner never re-renders the active view. Only the active
-  // tab is mirrored into statusBySid (above); a tab switch hydrates from here.
-  const statusByOwnerRef = useRef<Map<string, string>>(new Map());
   const activeWork = workBySid[tabs[activeIdx]?.aimeeSid ?? ''];
-  const activeStatus = statusBySid[tabs[activeIdx]?.aimeeSid ?? ''] ?? '';
   const working = !!activeWork && (activeWork.pending > 0 || activeWork.queued > 0);
   const iterCur = activeWork?.iterCur ?? 0;
   const iterMax = activeWork?.iterMax ?? 0;
@@ -1863,29 +1851,6 @@ export default function Chat() {
     });
   }
 
-  /* Set (or clear, with '') the transient live-activity line for a tab.
-   *
-   * Only the ACTIVE tab's status drives React state. A background tab's spinner
-   * is never shown, so calling setState for it would re-render the whole Chat on
-   * every poll of every off-screen turn — that is the cost that scales with tab
-   * count (N concurrent turns → N× wasted full re-renders/s). Instead every tab's
-   * latest status is kept in a ref (no re-render); a tab switch hydrates state
-   * from it, and the entering tab's own live stream repaints within one poll. */
-  function setSidStatus(sid: string, status: string): void {
-    if (!sid) return;
-    if (status) statusByOwnerRef.current.set(sid, status);
-    else statusByOwnerRef.current.delete(sid);
-    const activeSid = tabsRef.current[activeIdxRef.current]?.aimeeSid ?? '';
-    if (sid !== activeSid) return;
-    setStatusBySid(prev => {
-      if ((prev[sid] ?? '') === status) return prev;
-      const next = { ...prev };
-      if (status) next[sid] = status;
-      else delete next[sid];
-      return next;
-    });
-  }
-
   function abortActiveSends(): void {
     sendQueueVersionRef.current++;
     sendQueuesRef.current.clear();
@@ -1898,8 +1863,6 @@ export default function Chat() {
     activeSendAbortRefs.current.forEach((_sid, controller) => controller.abort());
     activeSendAbortRefs.current.clear();
     setWorkBySid({});
-    statusByOwnerRef.current.clear();
-    setStatusBySid({});
   }
 
   useEffect(() => {
@@ -2173,11 +2136,6 @@ export default function Chat() {
     if (oldSid === newSid) return;
     if (oldSid) bgStreamsRef.current.set(oldSid, streamMsgsRef.current);
     renderedSidRef.current = newSid;
-    // Surface the entering tab's latest status (tracked in the ref while it was a
-    // background tab). statusBySid only ever holds the active tab, so reset it to
-    // just this one.
-    const enteringStatus = statusByOwnerRef.current.get(newSid) ?? '';
-    setStatusBySid(enteringStatus ? { [newSid]: enteringStatus } : {});
     skipNextStreamPersistRef.current = true;
     const buffered = bgStreamsRef.current.get(newSid);
     if (buffered) {
@@ -2817,13 +2775,6 @@ export default function Chat() {
         streamRefs.assistantId = null;
         streamRefs.thinkId = null;
         streamRefs.toolId = null;
-        setSidStatus(streamRefs.originSid, '');
-        break;
-      }
-      case 'status': {
-        // Transient live-activity line from a tmux CLI turn: replace in place
-        // (one rolling indicator), never appended to the transcript.
-        setSidStatus(streamRefs.originSid, String(data.content ?? ''));
         break;
       }
       case 'tool_start': {
@@ -2894,7 +2845,6 @@ export default function Chat() {
         streamRefs.assistantId = null;
         streamRefs.thinkId = null;
         streamRefs.toolId = null;
-        setSidStatus(streamRefs.originSid, '');
         break;
       }
       case 'error': {
@@ -2976,7 +2926,6 @@ export default function Chat() {
       }
       case 'done': {
         saveOwnerStream(streamRefs.originSid);
-        setSidStatus(streamRefs.originSid, '');
         void refreshWorkflow();
         /* Refresh LSP diagnostic badge after each completed turn */
         fetch('/api/lsp/diagnostics/summary')
@@ -3110,7 +3059,7 @@ export default function Chat() {
           </button>
         )}
         <Transcript messages={windowedMsgs} working={working} activeSid={tabs[activeIdx]?.aimeeSid ?? ''} />
-        {working && <WorkingIndicator status={activeStatus} />}
+        {working && <WorkingIndicator />}
         {remoteTurnActive && !working && (
           <div style={{
             alignSelf: 'flex-start', maxWidth: '85%', padding: '6px 10px',

--- a/src/headers/cli_session.h
+++ b/src/headers/cli_session.h
@@ -38,10 +38,6 @@ typedef struct
    /* Clean response text already streamed to the caller this turn (so recv emits
     * only the growth as an incremental delta). malloc'd; freed on destroy. */
    char *stream_emitted;
-   /* Last condensed working/status line emitted via the status callback this turn
-    * (so recv emits a status event only when the line actually changes, not every
-    * poll). malloc'd; freed on destroy. */
-   char *status_emitted;
 } cli_session_t;
 
 /* Incremental stream callback: invoked by cli_session_recv with each newly
@@ -52,19 +48,6 @@ void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud);
  * around a nested turn (prevents the inner turn's now-dead context leaking to
  * the outer turn). *ud_out receives the userdata; returns the callback. */
 cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out);
-
-/* Status callback: invoked by cli_session_recv with the latest *condensed*
- * working/spinner line (e.g. "Misting… (1m 5s · ↓ 2.6k tokens · still thinking)")
- * while the CLI is producing tokens. The TUI animates this line ~1×/s with a
- * fresh elapsed counter; recv collapses the whole run into a single rolling
- * status — emitting only when the line text changes — so the webchat shows live
- * activity (one updating line) during long thinking phases instead of a frozen
- * pane, without flooding the transcript. Distinct from the stream callback, which
- * carries the assistant's actual answer text. Set per-thread; save/restore around
- * a nested turn like the stream callback. */
-typedef void (*cli_session_status_cb_t)(const char *status, void *ud);
-void cli_session_set_status_cb(cli_session_status_cb_t cb, void *ud);
-cli_session_status_cb_t cli_session_get_status_cb(void **ud_out);
 
 /* Cancel-check callback: cli_session_recv polls it each tick; a non-zero return
  * aborts the wait (the running turn was asked to stop — steering/interrupt or
@@ -147,14 +130,6 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
  * content present in the baseline is excluded so prior turns never leak.
  * Returns newly allocated text; caller frees. Exposed for unit tests. */
 char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline);
-
-/* Extract the latest animated working/status line from a raw pane capture,
- * condensed to a single line with the leading spinner glyph stripped (claude:
- * "✢ Misting… (21s · ↑ 493 tokens)" → "Misting… (21s · ↑ 493 tokens)"; codex:
- * "◦ Working (12s · esc to interrupt)"). Returns newly allocated text — an empty
- * string when the pane shows no active-work line (idle / answer already done).
- * Caller frees. Exposed for unit tests. */
-char *cli_session_extract_status(const char *raw, const char *cli_kind);
 
 /* --- Session name helpers --- */
 /* Build a deterministic session name: "aimee-<agent>-<hash(role)>".

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -207,8 +207,6 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
             sess.baseline = NULL;
             free(sess.stream_emitted);
             sess.stream_emitted = NULL;
-            free(sess.status_emitted);
-            sess.status_emitted = NULL;
          }
          else
             cli_session_destroy(&sess);
@@ -246,8 +244,6 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       sess.baseline = NULL;
       free(sess.stream_emitted);
       sess.stream_emitted = NULL;
-      free(sess.status_emitted);
-      sess.status_emitted = NULL;
    }
 
    if (!clean || !clean[0])

--- a/src/posix/server_compute.c
+++ b/src/posix/server_compute.c
@@ -157,14 +157,6 @@ static int stream_event(compute_ctx_t *cctx, const char *event, const char *key,
    {
       if (event && strcmp(event, "text") == 0 && value && value[0])
          ring_text_append_locked(cctx, value);
-      else if (event && strcmp(event, "status") == 0)
-      {
-         /* Transient live-activity line: deliver on the live socket only, never
-          * persist it in the ring. It animates ~1×/s, so ring-publishing would
-          * bloat the turn history and replay a stale spinner on reconnect; the
-          * next poll re-emits a current line anyway. Leave any buffered text
-          * intact (status never enters the ring, so there is no reorder to guard). */
-      }
       else
       {
          ring_flush_text_locked(cctx); /* preserve order vs. buffered text */
@@ -594,19 +586,6 @@ static void chat_cli_stream_cb(const char *delta, void *ud)
    c->emitted = 1;
 }
 
-/* Forward the tmux CLI's condensed live-activity line as a transient `status`
- * SSE event so the webchat shows a single rolling indicator ("Misting… (1m 5s ·
- * …)") during long thinking phases. Not the answer — does not set `emitted`, and
- * stream_event keeps `status` out of the presence ring (ephemeral; the next poll
- * re-emits a fresh line, so a reconnect never replays a stale spinner). */
-static void chat_cli_status_cb(const char *status, void *ud)
-{
-   chat_cli_stream_ctx_t *c = (chat_cli_stream_ctx_t *)ud;
-   if (!c || !status || !status[0])
-      return;
-   stream_event(c->cctx, "status", "content", status);
-}
-
 /* Cancel predicate for the tmux CLI driver: reflects this turn's registry cancel
  * flag (set by chat.interrupt / graceful_cancel / session close). Lets
  * cli_session_recv abort a wedged or steered generation promptly without
@@ -699,10 +678,6 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
    void *prev_stream_ud = NULL;
    cli_session_stream_cb_t prev_stream_cb = cli_session_get_stream_cb(&prev_stream_ud);
    cli_session_set_stream_cb(chat_cli_stream_cb, &sctx);
-   /* Live-activity status line (condensed spinner) for the same tmux turn. */
-   void *prev_status_ud = NULL;
-   cli_session_status_cb_t prev_status_cb = cli_session_get_status_cb(&prev_status_ud);
-   cli_session_set_status_cb(chat_cli_status_cb, &sctx);
    /* Let the tmux CLI driver observe this turn's cancel flag so a steer/interrupt
     * stops the running generation promptly. Save/restore around any outer turn. */
    void *prev_cancel_ud = NULL;
@@ -724,7 +699,6 @@ static void chat_stream_worker_agent(compute_ctx_t *cctx, const char *message, c
 
    cli_session_set_error_grace_ms(prev_error_grace);
    cli_session_set_cancel_check(prev_cancel_cb, prev_cancel_ud);
-   cli_session_set_status_cb(prev_status_cb, prev_status_ud);
    cli_session_set_stream_cb(prev_stream_cb, prev_stream_ud);
    agent_tools_set_tool_event_cb(NULL, NULL);
    session_id_clear_override();

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -83,24 +83,6 @@ cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out)
    return g_stream_cb;
 }
 
-/* Per-thread status sink (set by the chat worker before a turn, cleared after).
- * Thread-local for the same reason as the stream callback. */
-static __thread cli_session_status_cb_t g_status_cb = NULL;
-static __thread void *g_status_ud = NULL;
-
-void cli_session_set_status_cb(cli_session_status_cb_t cb, void *ud)
-{
-   g_status_cb = cb;
-   g_status_ud = ud;
-}
-
-cli_session_status_cb_t cli_session_get_status_cb(void **ud_out)
-{
-   if (ud_out)
-      *ud_out = g_status_ud;
-   return g_status_cb;
-}
-
 /* Per-thread cancel-check (set by the chat worker to the turn's cancel flag).
  * cli_session.c stays decoupled from the turn registry — the worker supplies the
  * predicate. */
@@ -448,8 +430,6 @@ void cli_session_destroy(cli_session_t *s)
    s->baseline = NULL;
    free(s->stream_emitted);
    s->stream_emitted = NULL;
-   free(s->status_emitted);
-   s->status_emitted = NULL;
    if (!s->active)
       return;
    if (!cli_session_is_alive(s))
@@ -616,6 +596,10 @@ static int cli_line_is_rule(const char *t)
    return 1;
 }
 
+/* Defined further down with the status extractor; forward-declared so chrome
+ * detection can reuse it (the animated working line is chrome, not answer). */
+static int cli_line_is_status(const char *t);
+
 /* Lines that mark the end of (or are not part of) the assistant's answer:
  * the claude status star, separators, footers, interrupt hints, and the
  * model/effort status indicator near the composer — which claude renders with
@@ -624,6 +608,15 @@ static int cli_line_is_rule(const char *t)
 static int cli_line_is_chrome(const char *t)
 {
    if (strncmp(t, "\xe2\x9c\xbb", 3) == 0) /* ✻ claude "Cooked/Baked for Ns" status */
+      return 1;
+   /* The animated working line — "<spinner> <Gerund>… (<Ns> · <arrow> <N> tokens
+    * · <state>)". claude CYCLES the spinner glyph (✻ ✽ ✢ · …) and the gerund word
+    * every frame, so anchoring on a single glyph (the ✻ above) misses most frames
+    * and the line leaks into the streamed answer as spam — and, because each
+    * captured frame differs, it poisons the incremental prefix-diff so real answer
+    * growth stops emitting once claude enters its thinking phase. Match it by its
+    * stable shape instead (see cli_line_is_status), which is glyph-independent. */
+   if (cli_line_is_status(t))
       return 1;
    if (cli_line_is_rule(t))
       return 1;
@@ -814,14 +807,16 @@ char *cli_session_extract_response(const char *raw, const char *cli_kind, const 
    return cli_extract_impl(raw, cli_kind, baseline, 1);
 }
 
-/* Recognize the CLI's animated working/status line. claude renders it as
+/* Recognize the CLI's animated working/status line so the answer extractor can
+ * treat it as chrome (see cli_line_is_chrome). claude renders it as
  * "<spinner> <Gerund>… (<elapsed> · <arrow> <tokens> tokens[· <state>])",
- * cycling the spinner glyph (✻ ✢ ✽ · …) and the gerund every frame; codex uses
- * "◦ Working (<elapsed> · esc to interrupt)". Rather than enumerate the volatile
- * spinner glyphs we match the line by its stable shape: an open paren PLUS either
- * an "esc to interrupt" hint or the ellipsis (…) + a token meter. The "to
- * interrupt" phrase and the ellipsis-with-tokens shape both avoid false-matching
- * claude's "⎿ Tip: …interrupting…" hint (no paren, no "… (") and ordinary prose. */
+ * CYCLING the spinner glyph (✻ ✢ ✽ · …) and the gerund word every frame; codex
+ * uses "◦ Working (<elapsed> · esc to interrupt)". Anchoring on a single glyph
+ * misses most frames and lets the line leak into the streamed answer (spam +
+ * poisoned prefix-diff), so match by the stable shape instead: an open paren PLUS
+ * either an "esc to interrupt" hint or the ellipsis (…) + a token meter. Both
+ * avoid false-matching claude's "⎿ Tip: …interrupting…" hint (no paren) and
+ * ordinary prose. */
 static int cli_line_is_status(const char *t)
 {
    if (!strchr(t, '('))
@@ -832,67 +827,6 @@ static int cli_line_is_status(const char *t)
    if (strstr(t, "\xe2\x80\xa6") && strstr(t, "token"))
       return 1;
    return 0;
-}
-
-/* Strip a leading spinner glyph (a whitespace-delimited token with no ASCII
- * letter — "✢", "·", "◦") plus following spaces, leaving the human-readable
- * status ("Misting… (21s · ↑ 493 tokens)"). The body is returned verbatim. */
-static const char *cli_status_body(const char *line)
-{
-   const char *b = cli_lstrip(line);
-   const char *sp = b;
-   while (*sp && *sp != ' ')
-      sp++;
-   int tok_has_letter = 0;
-   for (const char *q = b; q < sp; q++)
-      if ((*q >= 'A' && *q <= 'Z') || (*q >= 'a' && *q <= 'z'))
-      {
-         tok_has_letter = 1;
-         break;
-      }
-   if (!tok_has_letter && *sp == ' ')
-   {
-      b = sp;
-      while (*b == ' ')
-         b++;
-   }
-   return b;
-}
-
-char *cli_session_extract_status(const char *raw, const char *cli_kind)
-{
-   (void)cli_kind; /* the shape match covers claude + codex */
-   /* strip_ansi returns a fresh buffer we own, so split it in place (rewrite '\n'
-    * to '\0'), scanning for the LAST status line (the live footer sits at the
-    * bottom of the pane). */
-   char *work = cli_session_strip_ansi(raw ? raw : "");
-   if (!work)
-      return strdup("");
-
-   char *best = NULL; /* malloc'd copy of the most recent status line's body */
-   for (char *p = work;;)
-   {
-      char *nl = strchr(p, '\n');
-      if (nl)
-         *nl = '\0';
-      const char *ls = cli_lstrip(p);
-      if (cli_line_is_status(ls))
-      {
-         const char *body = cli_status_body(ls);
-         char *dup = strdup(body);
-         if (dup)
-         {
-            free(best);
-            best = dup;
-         }
-      }
-      if (!nl)
-         break;
-      p = nl + 1;
-   }
-
-   free(work);
-   return best ? best : strdup("");
 }
 
 /* True when the pane shows the CLI parked in a provider error/retry state.
@@ -943,8 +877,6 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
    long long err_start = 0; /* mono_ms when that state began (valid iff err_active) */
    free(s->stream_emitted);
    s->stream_emitted = strdup("");
-   free(s->status_emitted);
-   s->status_emitted = strdup("");
 
    for (;;)
    {
@@ -1054,26 +986,6 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
          }
          else
             free(partial);
-      }
-
-      /* Stream a condensed live-activity line while the CLI works. The TUI has no
-       * answer bullet yet during a thinking phase, so the stream callback above
-       * emits nothing and the webchat would look frozen; the status line ("Misting…
-       * (21s · ↑ 493 tokens)") keeps it alive. The TUI re-renders this line ~1×/s
-       * with a fresh counter, so emit only when the text changes — one rolling
-       * status, not one event per frame. */
-      if (g_status_cb)
-      {
-         char *status = cli_session_extract_status(cap, s->cli_kind);
-         const char *prevst = s->status_emitted ? s->status_emitted : "";
-         if (status && status[0] && strcmp(status, prevst) != 0)
-         {
-            g_status_cb(status, g_status_ud);
-            free(s->status_emitted);
-            s->status_emitted = status;
-         }
-         else
-            free(status);
       }
 
       /* Provider-error bound: if the CLI parks in an error/retry state for longer

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -534,63 +534,50 @@ static void test_extract_baseline_substring_kept(void)
    free(r);
 }
 
-/* --- cli_session_extract_status: condensed live-activity line --- */
+/* --- spinner/working line is chrome, never answer text --- */
 
-/* claude's animated spinner footer is returned verbatim with the leading glyph
- * stripped, so the webchat shows a single human-readable activity line. */
-static void test_status_claude_spinner(void)
+/* claude cycles the spinner glyph + gerund every frame (✻ ✽ ✢ · …, Misting /
+ * Channeling / …). The footer the capture happens to catch must NOT leak into the
+ * extracted answer — anchoring on the ✻ glyph alone missed the other frames and
+ * spammed the transcript. Here the footer carries the ✽ frame: the answer is
+ * still just the bullet text. */
+static void test_extract_excludes_gerund_spinner(void)
 {
    const char *pane = "\xe2\x9d\xaf write a poem\n"
-                      "\xe2\x9c\xbb Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)\n";
-   char *r = cli_session_extract_status(pane, "claude");
+                      "\xe2\x97\x8f Here is the poem\n"
+                      "\xe2\x9c\xbd Channeling\xe2\x80\xa6 (14s \xc2\xb7 \xe2\x86\x91 823 tokens "
+                      "\xc2\xb7 thinking)\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
    assert(r != NULL);
-   assert(strcmp(r, "Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)") == 0);
+   assert(strcmp(r, "Here is the poem") == 0);
    free(r);
 }
 
-/* When several spinner frames are on the pane (scrollback), the LAST one wins —
- * that is the current state. */
-static void test_status_picks_last_frame(void)
+/* The "·"-glyph frame (U+00B7, no leading star at all) is also a working line and
+ * must be excluded — plus the "⎿ Tip" hint that trails it. */
+static void test_extract_excludes_middot_spinner_and_tip(void)
 {
    const char *pane =
-       "\xe2\x9c\xbb Misting\xe2\x80\xa6 (21s \xc2\xb7 \xe2\x86\x91 493 tokens)\n"
-       "\xe2\x9c\xbd Misting\xe2\x80\xa6 (58s \xc2\xb7 \xe2\x86\x93 2.0k tokens \xc2\xb7 "
-       "thinking)\n";
-   char *r = cli_session_extract_status(pane, "claude");
+       "\xe2\x9d\xaf q\n"
+       "\xe2\x97\x8f real answer\n"
+       "\xc2\xb7 Misting\xe2\x80\xa6 (31s \xc2\xb7 \xe2\x86\x93 2.5k tokens \xc2\xb7 thinking)\n"
+       "\xe2\x8e\xbf Tip: Use /btw to ask a quick side question\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
    assert(r != NULL);
-   assert(
-       strcmp(r, "Misting\xe2\x80\xa6 (58s \xc2\xb7 \xe2\x86\x93 2.0k tokens \xc2\xb7 thinking)") ==
-       0);
+   assert(strcmp(r, "real answer") == 0);
    free(r);
 }
 
-/* The "⎿ Tip: …interrupting…" hint must NOT be mistaken for a status line (no
- * paren, no "… ("), and an idle pane yields an empty string. */
-static void test_status_ignores_tip_and_idle(void)
+/* The "esc to interrupt" footer (the first ~30s before the gerund spinner) was
+ * already excluded; keep that covered so the fix doesn't regress it. */
+static void test_extract_excludes_interrupt_footer(void)
 {
-   const char *tip = "\xe2\x8e\xbf Tip: Use /btw to ask a side question without interrupting "
-                     "Claude's current work\n";
-   char *r = cli_session_extract_status(tip, "claude");
+   const char *pane = "\xe2\x9d\xaf q\n"
+                      "\xe2\x97\x8f answer body\n"
+                      "  esc to interrupt\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
    assert(r != NULL);
-   assert(r[0] == '\0');
-   free(r);
-
-   const char *idle = "\xe2\x97\x8f all done\n\xe2\x9c\xbb Baked for 3s\n";
-   char *r2 = cli_session_extract_status(idle, "claude");
-   assert(r2 != NULL);
-   assert(r2[0] == '\0');
-   free(r2);
-}
-
-/* codex's "Working (Ns · esc to interrupt)" footer is matched via the interrupt
- * hint and the glyph is stripped. */
-static void test_status_codex_working(void)
-{
-   const char *pane = "\xe2\x80\xba do it\n"
-                      "\xe2\x97\xa6 Working (12s \xc2\xb7 esc to interrupt)\n";
-   char *r = cli_session_extract_status(pane, "codex");
-   assert(r != NULL);
-   assert(strcmp(r, "Working (12s \xc2\xb7 esc to interrupt)") == 0);
+   assert(strcmp(r, "answer body") == 0);
    free(r);
 }
 
@@ -802,20 +789,16 @@ int main(void)
    test_extract_baseline_substring_kept();
    printf("OK\n");
 
-   printf("test_status_claude_spinner... ");
-   test_status_claude_spinner();
+   printf("test_extract_excludes_gerund_spinner... ");
+   test_extract_excludes_gerund_spinner();
    printf("OK\n");
 
-   printf("test_status_picks_last_frame... ");
-   test_status_picks_last_frame();
+   printf("test_extract_excludes_middot_spinner_and_tip... ");
+   test_extract_excludes_middot_spinner_and_tip();
    printf("OK\n");
 
-   printf("test_status_ignores_tip_and_idle... ");
-   test_status_ignores_tip_and_idle();
-   printf("OK\n");
-
-   printf("test_status_codex_working... ");
-   test_status_codex_working();
+   printf("test_extract_excludes_interrupt_footer... ");
+   test_extract_excludes_interrupt_footer();
    printf("OK\n");
 
    printf("test_make_name_format... ");


### PR DESCRIPTION
Fixes two live bugs reported after #632:

### 1. Spinner spam + streaming stalls after ~30s
`cli_line_is_chrome` only recognized the `✻` glyph, but claude **cycles** the spinner glyph *and* gerund word every frame (`✻ ✽ ✢ ·` …, "Channeling"/"Misting"/…). When the captured frame wasn't `✻`, the working line — `✽ Channeling… (14s · ↑ 823 tokens · thinking)` — wasn't detected as chrome, so it **leaked into the extracted answer text**. That:
- spammed the transcript with every animation frame, and
- poisoned the incremental prefix-diff: once a frame's text landed in `stream_emitted`, the next (different) frame diverged from the prefix, so real answer growth **stopped emitting**.

The first ~30s worked because the footer was `esc to interrupt` (already caught); it broke when claude entered its thinking phase and the footer switched to the gerund+token spinner.

**Fix:** `cli_line_is_chrome` now also matches the working line by its glyph-independent **shape** (`cli_line_is_status`: open-paren + `esc to interrupt` *or* ellipsis + token-meter), so every frame is excluded from the answer regardless of which glyph/gerund the capture caught.

### 2. Remove the status bar from the webchat
Per the user, the spinner text should not appear at all — the existing **"Working"** indicator is enough while the CLI works. Reverted the #632 status SSE channel end-to-end (cli_session status callback + `extract_status` condenser, the server emission + ring special-case, and the frontend `statusBySid` plumbing). `WorkingIndicator` shows plain "Working" again.

### Tests
Replaced the `extract_status` tests with `extract_response` cases proving the cycled spinner frames (`✽`-glyph, `·`-glyph) and the trailing `⎿ Tip` hint are excluded from the answer, plus a regression guard for the `esc to interrupt` footer.

Verified: `unit-test-cli-session` green, full `make server` links clean (`-Werror`), frontend `tsc -b` clean, `make lint` ok.