### PR TITLE
fix(webchat): stop banner-as-answer + premature-finalize freeze on tmux turns

### DIFF
--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -907,6 +907,39 @@ static int cli_line_is_status(const char *t)
    return 0;
 }
 
+/* True when the pane's FOOTER shows the CLI is still mid-turn: the "esc to
+ * interrupt" hint (shown for the whole active turn, generation AND tool runs) or
+ * an animated spinner/status line. recv uses this to avoid finalizing a turn that
+ * has merely gone momentarily static — a long-running tool ("⎿ Waiting…") or a
+ * thinking pause — which would otherwise ship the half-rendered tool call as the
+ * reply and freeze the webchat. Footer-band only (last ~800 bytes) so the same
+ * words in the answer body or scrollback can't false-match; once claude finishes,
+ * the footer redraws to "✻ Baked for Ns" (no hint, no spinner) and recv finalizes. */
+static int cli_pane_is_working(const char *stripped)
+{
+   if (!stripped)
+      return 0;
+   size_t plen = strlen(stripped);
+   const char *foot = plen > 800 ? stripped + (plen - 800) : stripped;
+   if (strstr(foot, "to interrupt")) /* "esc to interrupt" working footer */
+      return 1;
+   for (const char *p = foot; p && *p;)
+   {
+      const char *eol = strchr(p, '\n');
+      char line[1024];
+      size_t llen = eol ? (size_t)(eol - p) : strlen(p);
+      size_t n = llen < sizeof(line) - 1 ? llen : sizeof(line) - 1;
+      memcpy(line, p, n);
+      line[n] = '\0';
+      if (cli_line_is_status(cli_lstrip(line)))
+         return 1;
+      if (!eol)
+         break;
+      p = eol + 1;
+   }
+   return 0;
+}
+
 /* True when the pane shows the CLI parked in a provider error/retry state.
  * claude renders this on its ✻ status line ("API error · Retrying in Ns ·
  * attempt K/10"); the normal completion status ("✻ Baked for Ns") and the
@@ -1109,11 +1142,29 @@ int cli_session_recv(cli_session_t *s, char *out, size_t out_max, int timeout_ms
          stable++;
          if (stable >= CLI_SESSION_STABLE_N)
          {
-            char *resp = cli_session_extract_response(cap, s->cli_kind, s->baseline);
-            snprintf(out, out_max, "%s", resp ? resp : "");
-            free(resp);
-            s->last_activity = time(NULL);
-            return 0;
+            /* A static pane is NOT necessarily a finished turn: claude can sit on
+             * a long-running tool ("⎿ Waiting…") or a thinking pause with its
+             * elapsed counter momentarily unchanged. Finalizing then cuts the turn
+             * off and ships the half-rendered tool call as the answer (observed
+             * live: the webchat freezes on a "Bash(…) ⎿ Waiting…" frame, the
+             * Working indicator clears). Only finalize when the footer shows NO
+             * active-work indicator; otherwise keep polling (re-arm) until claude
+             * finishes — footer → "✻ Baked for Ns" — or the wall-clock bound fires. */
+            char *stripped = cli_session_strip_ansi(cap);
+            int busy = stripped && cli_pane_is_working(stripped);
+            free(stripped);
+            if (busy)
+            {
+               stable = 0; /* still working; the wall-clock timeout backstops a wedge */
+            }
+            else
+            {
+               char *resp = cli_session_extract_response(cap, s->cli_kind, s->baseline);
+               snprintf(out, out_max, "%s", resp ? resp : "");
+               free(resp);
+               s->last_activity = time(NULL);
+               return 0;
+            }
          }
       }
       else

--- a/src/server/cli_session.c
+++ b/src/server/cli_session.c
@@ -406,17 +406,40 @@ int cli_session_create(cli_session_t *s, const char *session_name, const char *c
    if (rc != 0)
       return -1;
 
-   /* Wait for CLI to produce output (up to 5s) */
-   for (int i = 0; i < 10; i++)
+   /* Wait for the CLI to render AND settle — not just for the first byte. claude's
+    * fresh-session welcome box renders progressively and rotates its placeholder
+    * tips; pasting the first prompt mid-render races the input handler, so the
+    * keystrokes get eaten and the turn comes back as the (static) welcome banner —
+    * the user has to resend until the session warms up. Waiting for two identical
+    * captures means the baseline snapshot and the first submit both land on a
+    * settled, input-ready composer. Capped (~10s) so a CLI that animates a startup
+    * spinner forever still proceeds. */
+   unsigned long prev_hash = 0;
+   int stable = 0;
+   for (int i = 0; i < 20; i++)
    {
       msleep_ms(500);
       char cap_cmd[256];
       snprintf(cap_cmd, sizeof(cap_cmd), "tmux capture-pane -p -t '%s' 2>/dev/null", session_name);
       char *cap = sess_run(cap_cmd, &rc);
-      int has_output = (cap && strlen(cap) > 2);
+      if (cap && strlen(cap) > 2)
+      {
+         unsigned long h = djb2(cap);
+         if (h == prev_hash)
+         {
+            if (++stable >= 2) /* two consecutive identical captures = settled */
+            {
+               free(cap);
+               break;
+            }
+         }
+         else
+         {
+            stable = 0;
+            prev_hash = h;
+         }
+      }
       free(cap);
-      if (has_output)
-         break;
    }
 
    s->active = 1;
@@ -669,6 +692,55 @@ static int cli_body_in_baseline(const char *baseline, const char *amark, const c
    return 0;
 }
 
+/* Strip TUI noise from a pane, line by line, keeping only plausible answer text:
+ * box-drawing lines (the welcome/dialog boxes ─│╭╮╰╯…), the composer prompt
+ * (❯ / ›), blank lines, and anything cli_line_is_chrome rejects (rules, status,
+ * footers, hints). Used ONLY by the no-bullet fallback so a chrome-only pane —
+ * most often claude's fresh-session welcome box — yields empty instead of the
+ * banner. The box CONTENT lines (│ Welcome… │) carry letters so they aren't
+ * rules; keyed on the leading box glyph they're dropped too. Returns malloc'd
+ * text; caller frees. */
+static char *cli_filter_noise(const char *in)
+{
+   if (!in)
+      return strdup("");
+   size_t len = strlen(in);
+   char *out = malloc(len + 1);
+   if (!out)
+      return strdup("");
+   size_t olen = 0;
+   for (const char *p = in; p && *p;)
+   {
+      const char *eol = strchr(p, '\n');
+      size_t llen = eol ? (size_t)(eol - p) : strlen(p);
+      char line[2048]; /* 220-col pane × ≤4 bytes/glyph fits; longer is truncated
+                        * only for the predicate test, never for kept output */
+      size_t n = llen < sizeof(line) - 1 ? llen : sizeof(line) - 1;
+      memcpy(line, p, n);
+      line[n] = '\0';
+      const char *t = cli_lstrip(line);
+      int noise = !*t || strncmp(t, "\xe2\x94", 2) == 0 || /* ─│ box drawing U+25xx */
+                  strncmp(t, "\xe2\x95", 2) == 0 ||        /* ╭╮╰╯ box drawing */
+                  strncmp(t, "\xe2\x9d\xaf", 3) == 0 ||    /* ❯ claude composer */
+                  strncmp(t, "\xe2\x80\xba", 3) == 0 ||    /* › codex composer */
+                  cli_line_is_chrome(t);
+      if (!noise)
+      {
+         size_t tl = strlen(t);
+         memcpy(out + olen, t, tl);
+         olen += tl;
+         out[olen++] = '\n';
+      }
+      if (!eol)
+         break;
+      p = eol + 1;
+   }
+   while (olen > 0 && (out[olen - 1] == '\n' || out[olen - 1] == ' ' || out[olen - 1] == '\t'))
+      olen--;
+   out[olen] = '\0';
+   return out;
+}
+
 /* allow_fallback: when no assistant bullet is found, whether to fall back to the
  * baseline-delta of the whole pane. The final extraction wants this (last resort
  * for an unrecognized TUI); incremental STREAMING does NOT — before the model has
@@ -787,7 +859,9 @@ static char *cli_extract_impl(const char *raw, const char *cli_kind, const char 
    /* No parseable bullet. Streaming returns empty (the model hasn't produced an
     * answer yet — don't push the banner/chrome). The final extraction falls back
     * to the portion not already in the baseline (last resort for an unrecognized
-    * TUI; a reused pane still never replays a prior turn). */
+    * TUI; a reused pane still never replays a prior turn) — but noise-filtered, so
+    * a chrome-only pane (the fresh-session welcome box, captured before the prompt
+    * was processed) yields empty rather than shipping the banner. */
    if (!allow_fallback)
    {
       free(text);
@@ -797,9 +871,13 @@ static char *cli_extract_impl(const char *raw, const char *cli_kind, const char 
    {
       char *delta = cli_session_delta(baseline, text);
       free(text);
-      return delta ? delta : strdup("");
+      char *filtered = cli_filter_noise(delta ? delta : "");
+      free(delta);
+      return filtered;
    }
-   return text;
+   char *filtered = cli_filter_noise(text);
+   free(text);
+   return filtered;
 }
 
 char *cli_session_extract_response(const char *raw, const char *cli_kind, const char *baseline)

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -50,8 +50,10 @@ static void install_fake_tmux(void)
     * generating-footer; `provider_error` animates claude's ✻ error/retry status
     * line (never stabilises); `banner_retry` animates a │-prefixed box line whose
     * prose contains "Retrying in" (mimics the welcome banner — must NOT be read as
-    * a provider error); anything else returns a static pane. send-keys is logged
-    * so the cancel/error tests can assert the interrupt key. */
+    * a provider error); `busy_tool` returns a STATIC pane whose footer still shows
+    * "esc to interrupt" (a long-running tool — recv must NOT finalize it); anything
+    * else returns a static pane. send-keys is logged so the cancel/error tests can
+    * assert the interrupt key. */
    fprintf(f,
            "#!/bin/sh\n"
            "case \"$1\" in\n"
@@ -62,6 +64,9 @@ static void install_fake_tmux(void)
            "      echo \"frame $c\";\n"
            "    elif [ \"$FAKE_TMUX_MODE\" = codexgen ]; then\n"
            "      echo 'codex output'; echo 'Working (1s esc to interrupt)';\n"
+           "    elif [ \"$FAKE_TMUX_MODE\" = busy_tool ]; then\n"
+           "      printf '%%s\\n' '\xe2\x97\x8f Bash(sed -n 1,80p f)' '  \xe2\x8e\xbf Waiting'"
+           " 'esc to interrupt';\n"
            "    elif [ \"$FAKE_TMUX_MODE\" = provider_error ]; then\n"
            "      c=0; [ -f '%s' ] && c=$(cat '%s'); c=$((c+1)); echo \"$c\" > '%s';\n"
            "      echo '\xe2\x9c\xbb API error Retrying in 0s attempt '\"$c\"'/10';\n"
@@ -148,6 +153,23 @@ static void test_recv_dead_session(void)
    char buf[8192];
    int rc = cli_session_recv(&s, buf, sizeof(buf), 10000);
    assert(rc == -1);
+}
+
+/* A pane that is STATIC but whose footer still says "esc to interrupt" is a turn
+ * mid-tool (a long-running Bash), not a finished one: recv must NOT finalize it
+ * (which would ship the half-rendered tool call and freeze the webchat). With no
+ * completion it rides the wall-clock bound to -2 instead of a premature rc 0. */
+static void test_recv_busy_footer_not_finalized(void)
+{
+   setenv("FAKE_TMUX_MODE", "busy_tool", 1);
+   cli_session_t s = fake_session();
+   cli_session_set_kind(&s, "claude");
+   char buf[8192];
+   long long t0 = test_mono_ms();
+   int rc = cli_session_recv(&s, buf, sizeof(buf), 1000);
+   long long elapsed = test_mono_ms() - t0;
+   assert(rc == -2); /* never finalized; hit the wall-clock bound */
+   assert(elapsed < 5000);
 }
 
 /* --- cancel / steering-interrupt path --- */
@@ -922,6 +944,10 @@ int main(void)
 
    printf("test_recv_dead_session... ");
    test_recv_dead_session();
+   printf("OK\n");
+
+   printf("test_recv_busy_footer_not_finalized... ");
+   test_recv_busy_footer_not_finalized();
    printf("OK\n");
 
    printf("test_recv_cancel_claude_escape... ");

--- a/src/tests/test_cli_session.c
+++ b/src/tests/test_cli_session.c
@@ -581,6 +581,43 @@ static void test_extract_excludes_interrupt_footer(void)
    free(r);
 }
 
+/* The fresh-session welcome box (box-drawing + composer + footer, no answer
+ * bullet) must NEVER be returned as the reply — the no-bullet fallback
+ * noise-filters it to empty. Reproduces the live "webchat sends the Claude
+ * banner" bug on the first turn before claude has processed the prompt. */
+static void test_extract_welcome_banner_empty(void)
+{
+   const char *pane =
+       "\xe2\x95\xad\xe2\x94\x80\xe2\x94\x80 Claude Code v2.1.186 "
+       "\xe2\x94\x80\xe2\x94\x80\xe2\x95\xae\n"
+       "\xe2\x94\x82 Welcome back Jared!                  \xe2\x94\x82\n"
+       "\xe2\x94\x82 Run /init to create a CLAUDE.md file  \xe2\x94\x82\n"
+       "\xe2\x95\xb0\xe2\x94\x80\xe2\x94\x80\xe2\x94\x80\xe2\x95\xaf\n"
+       "\xe2\x9d\xaf Try \"edit serverhttproutes.inc to...\"\n"
+       "gh auth login \xc2\xb7 \xe2\x86\x90 for agents \xe2\x97\x8f high \xc2\xb7 /effort\n";
+   char *r = cli_session_extract_response(pane, "claude", NULL);
+   assert(r != NULL);
+   assert(r[0] == '\0');
+   free(r);
+}
+
+/* A real answer whose ● bullet has scrolled off the top of the pane still
+ * survives the fallback (its body is plain text, not chrome) — the noise filter
+ * must not over-strip. */
+static void test_extract_scrolled_answer_survives_fallback(void)
+{
+   const char *baseline = "\xe2\x95\xad\xe2\x94\x80 Claude Code \xe2\x94\x80\xe2\x95\xae\n"
+                          "\xe2\x9d\xaf Try something\n";
+   const char *pane = "the second half of a long answer\n"
+                      "that wrapped past the top of the pane\n"
+                      "\xe2\x9c\xbb Baked for 4s\n";
+   char *r = cli_session_extract_response(pane, "claude", baseline);
+   assert(r != NULL);
+   assert(strcmp(r, "the second half of a long answer\n"
+                    "that wrapped past the top of the pane") == 0);
+   free(r);
+}
+
 /* --- cli_session_prepare_claude: claude-code first-run gate seeding --- */
 
 static char *slurp(const char *path)
@@ -799,6 +836,14 @@ int main(void)
 
    printf("test_extract_excludes_interrupt_footer... ");
    test_extract_excludes_interrupt_footer();
+   printf("OK\n");
+
+   printf("test_extract_welcome_banner_empty... ");
+   test_extract_welcome_banner_empty();
+   printf("OK\n");
+
+   printf("test_extract_scrolled_answer_survives_fallback... ");
+   test_extract_scrolled_answer_survives_fallback();
    printf("OK\n");
 
    printf("test_make_name_format... ");


### PR DESCRIPTION
Two related robustness fixes for the tmux-CLI (claude/codex) webchat path, both surfaced live after a claude-code update.

### 1. Webchat answers with the Claude startup banner
On a fresh per-session worktree, the first prompt(s) raced claude's welcome box. The no-bullet fallback shipped the raw baseline-delta — which on a fresh session is the whole "Welcome back / Tips for getting started" banner — so the user got the banner as the reply until they resent enough times to warm the session.
- **`cli_filter_noise`** strips TUI noise from the fallback: box-drawing lines (welcome/dialog boxes), the composer prompt (`❯`/`›`), blanks, and anything `cli_line_is_chrome` rejects. A chrome-only pane → empty (caller surfaces a clean "empty response", never the banner). A real answer whose `●` bullet has scrolled off the top still survives (its body is plain text).
- **`cli_session_create` now waits for the pane to *settle*** (two identical captures) instead of the first byte, so the baseline snapshot and the first paste+Enter land on a fully-rendered, input-ready composer rather than mid-render (which ate the keystrokes).

### 2. Webchat freezes mid-turn on a long-running tool
`recv` finalized whenever the pane was static for 1.5s — but a static pane isn't a finished turn. When claude sits on a long Bash tool (`⎿ Waiting…`) or a thinking pause, recv shipped the half-rendered tool call as the answer and sent `done`, so the webchat froze on a `Bash(…) ⎿ Waiting…` frame with the **Working** indicator cleared.
- **`cli_pane_is_working`** — finalization is now gated on the footer: while it still shows `esc to interrupt` or an animated spinner/status line, recv re-arms and keeps polling until claude actually finishes (footer → `✻ Baked for Ns`) or the wall-clock bound fires. Footer-band only, so answer-body text can't false-match.

### Tests
- welcome-banner pane → empty; scrolled-off answer → body survives.
- static "esc to interrupt" footer → rides the wall-clock bound (`-2`), not a premature `rc 0`; the plain static pane still finalizes (`rc 0`).

Verified: `unit-test-cli-session` green, full `make server` links clean (`-Werror`), `make lint` ok.