### PR TITLE
feat(dev): proposal-reconcile lint gate (P1 of autonomous-dev-execution-substrate)

### DIFF
--- a/docs/proposals/done/aimee-dev-lifecycle-workflow.md
+++ b/docs/proposals/done/aimee-dev-lifecycle-workflow.md
@@ -1,6 +1,6 @@
 # Proposal: aimee workflows — a user-definable, autonomy-first development engine
 
-- **State:** roundtable-converged READY (5 diverse-panel rounds; all lenses incl.
+- **State:** done — roundtable-converged READY (5 diverse-panel rounds; all lenses incl.
   contrarian); user-approved (proposal gate). Implementation remains BLOCKED-ON §0.
 - **Author:** JBailes
 - **Date:** 2026-06-14

--- a/docs/proposals/done/css-migration-assistant.md
+++ b/docs/proposals/done/css-migration-assistant.md
@@ -9,7 +9,7 @@
 
 # Proposal: CSS migration assistant — exemplar-guided structural conversion
 
-- **State:** **APPROVED at human proposal-gate (JBailes, 2026-06-15) on the
+- **State:** done — **APPROVED at human proposal-gate (JBailes, 2026-06-15) on the
   recurring/subsystem path (§9 case 1)** — build #1/#3 as first-class C
   subsystem + #4-interim + #5; #2-upgrade and #4-full remain deferred follow-on
   proposals. Impl plan: `css-migration-assistant.plan.md`. — rev2. Roundtable

--- a/docs/proposals/done/mtls-client-identity.md
+++ b/docs/proposals/done/mtls-client-identity.md
@@ -1,6 +1,6 @@
 # mTLS client identity: per-client certs as attested principals
 
-- **State:** proposed; awaiting roundtable + user proposal-gate.
+- **State:** done
 - **Scope:** deterministic / server transport + auth + PKI lifecycle. Not an
   intelligence-surface proposal (no Architecture Charter role).
 - **Author:** JBailes, 2026-06-17.

--- a/docs/proposals/done/native-tls-thin-client-backends.md
+++ b/docs/proposals/done/native-tls-thin-client-backends.md
@@ -1,6 +1,6 @@
 # Native TLS backends for the Windows and macOS thin clients
 
-- **State:** proposed; awaiting roundtable + user proposal-gate.
+- **State:** done
 - **Scope:** deterministic / build + client transport. Not an intelligence-surface
   proposal (no Architecture Charter role).
 - **Author:** JBailes, 2026-06-17.

--- a/docs/proposals/done/replayable-verification-and-deepening-sweep.md
+++ b/docs/proposals/done/replayable-verification-and-deepening-sweep.md
@@ -1,6 +1,6 @@
 # Replayable-evidence verification + architecture-deepening sweep
 
-- **State:** roundtable-reviewed in two rounds — R1 (3 lenses: architect /
+- **State:** done — roundtable-reviewed in two rounds — R1 (3 lenses: architect /
   security / contrarian → 2 approve-with-changes, 1 rework, all converging),
   R2 (focused consult on the rubric split + the `typed_facts` modeling → both
   sound-with-tweak). Hardened per both rounds; the three formerly-open items are

--- a/docs/proposals/done/roundtable-reliability.md
+++ b/docs/proposals/done/roundtable-reliability.md
@@ -1,6 +1,6 @@
 # Proposal: Roundtable reliability — get the review gate to 100%
 
-- **State:** diagnosis + first fix (claude-CLI panel exclusion) shipping; follow-ups listed
+- **State:** done — diagnosis + first fix (claude-CLI panel exclusion) shipped; follow-ups listed
 - **Author:** JBailes (investigation 2026-06-15)
 - **Motivation:** the roundtable is the project's quality gate, but in practice it
   is unreliable/slow. This is a root-cause diagnosis (empirically validated

--- a/docs/proposals/done/server-owned-turn-lifecycle.md
+++ b/docs/proposals/done/server-owned-turn-lifecycle.md
@@ -1,5 +1,7 @@
 # Server-owned turn lifecycle: a turn outlives the connection that started it
 
+Status: done
+
 ## Problem
 
 A chat turn's execution is today bound to the client connection that started

--- a/docs/proposals/done/typed-fact-knowledge-layer.md
+++ b/docs/proposals/done/typed-fact-knowledge-layer.md
@@ -1,6 +1,6 @@
 # Proposal: typed-fact knowledge layer for identity & world facts
 
-- **State:** draft - reviewed, converged at R3 (reviewer / architect / security
+- **State:** done — reviewed, converged at R3 (reviewer / architect / security
   lenses across minimax + mistral all returned no major issues)
 - **Author:** JBailes
 - **Date:** 2026-06-12

--- a/docs/proposals/done/workflow-config-blocks.md
+++ b/docs/proposals/done/workflow-config-blocks.md
@@ -1,6 +1,6 @@
 # Design: config-extensible workflow blocks (+ CI/merge safety blocks)
 
-- **State:** design converged (2 rounds; reviewer READY, architect design-convincing — code-verification items deferred to the implementation roundtable)
+- **State:** done — design converged (2 rounds; reviewer READY, architect design-convincing — code-verification items deferred to the implementation roundtable)
 - **Builds on:** the merged workflow engine (`aimee-dev-lifecycle-workflow.md`, PR #288).
 - **Goal:** let users **define their own composable blocks via config** (no recompile),
   type-checked by the same validator and run by a generic executor; and add three

--- a/docs/proposals/pending/autonomous-dev-execution-substrate.md
+++ b/docs/proposals/pending/autonomous-dev-execution-substrate.md
@@ -182,6 +182,15 @@ A reconciler (`aimee dev reconcile`, also a lint check) that:
    `done/` filing with zero human steps; one with a `deployment`/`hardware` tier
    stops at an explicit, labelled gate with the CI dispatch recorded.
 
+The §4 machine-checkable shadow of the criteria above (P1 ships the schema gate that
+validates this block; later packets execute each `check` on its tier):
+
+```yaml acceptance
+- {id: 1, tier: mechanical,   check: "make -C src proposal-reconcile-check"}
+- {id: 2, tier: mechanical,   check: "python3 -m unittest discover -s scripts/tests -p test_check_proposal_reconcile.py"}
+- {id: 3, tier: mechanical,   check: "make -C src lint"}
+```
+
 ## Risks
 
 - **Arbitrary build execution.** The runner executes repo build scripts — sandbox

--- a/docs/proposals/pending/autonomous-dev-execution-substrate.plan.md
+++ b/docs/proposals/pending/autonomous-dev-execution-substrate.plan.md
@@ -1,0 +1,197 @@
+# Implementation plan: autonomous-dev execution substrate
+
+Companion to [autonomous-dev-execution-substrate.md](./autonomous-dev-execution-substrate.md)
+(**APPROVED**, human proposal-gate 2026-06-21). Base branch: `testing`. Each packet is
+**independently shippable as its own PR** — built/linted/tested + roundtable-reviewed +
+merged before the next, per the autonomous-proposal loop the proposal itself describes
+(§Origin). Smallest/safest, highest-leverage-with-no-new-infra first.
+
+## Grounding against the current tree (2026-06-23)
+
+The proposal was drafted in a webchat workspace with **no toolchain**; this plan is
+grounded in a checkout that **has** `make gcc clang clang-format-19 psql node gh`
+(docker absent). That changes the packet order: the pure-code reconciler/acceptance
+work (§4/§5) is **fully build-and-test-verifiable in-env today**, so it ships first and
+de-risks every later packet by making proposal↔tree drift machine-visible. Two further
+facts pin the sequencing:
+
+- **§2 is mostly already shipped.** `src/server/git_ops.c` already resolves credentials
+  vault-first for fetch/pull/**push** via `git_cred_inject_build_env_for_repo`
+  (`needs_cred=1` on push, PR #605). The residual §2 work is the **forge vtable**
+  `open`/`merge` path + per-action audit, not the push gap the proposal describes.
+- **§1/§3 need a runner/CI-dispatch substrate** (container or Proxmox-CT); they are only
+  *partly* verifiable in-env. They follow the pure-code packets.
+
+## Packet sequence
+
+| Packet | Component | New infra? | In-env verifiable? |
+|--------|-----------|------------|--------------------|
+| **P1** | §5 reconciler (static core) + §4 acceptance-block schema | none | **fully** |
+| P2 | §2 finish: forge vtable `open`/`merge` vault + audit | none | unit + stub |
+| P3 | §1 build-and-verify runner (ephemeral + managed modes) | runner image/CT | partial (managed mode locally) |
+| P4 | §3 validation tiers + CI-dispatch harness | CI dispatch | partial (dispatch unit-testable) |
+| P5 | §4 full per-tier acceptance evaluation + §5 auto-file shipped-but-unfiled | P3+P4 | integration |
+
+P1 is the only packet detailed here; later packets get their own plan revision once P1's
+reconciler makes the tree's real drift visible (it may re-scope P2–P5).
+
+---
+
+## P1 — reconciler static core + acceptance-block schema (THIS PR)
+
+A single Python lint gate, `scripts/reconcile-proposals.py`, in the established
+`scripts/check-*.py` + `--plant-test` pattern (mirrors `check-proposal-links.py`,
+wired into `make lint`). No C build needed; runs under `python3` directly. Three checks,
+all decidable from the working tree alone — no runner, no CI, no live stack:
+
+### Check A — state↔folder consistency (the safe slice of "shipped-but-unfiled", §5)
+
+The **folder is authoritative** for a proposal's lifecycle state (`pending/` `accepted/`
+`done/` `rejected/` `deferred/`). The `- **State:**` bullet is prose and drifts. Rather
+than substring-match free prose, the State bullet is **classified into a closed enum** by
+case-insensitive keyword (the literal keyword sets live at the top of the script so the
+implementer and reviewer agree):
+
+- `terminal_done` — bullet contains `done` / `shipped` / `merged` / `deployed`.
+- `terminal_closed` — `rejected` / `withdrawn` / `superseded`.
+- `in_flight` — `draft` / `proposed` / `pending` / `accepted` / `approved` / `reviewed` /
+  `ready` / `in progress` / `blocked` / `partial`.
+- `unknown` — no keyword matched, or **no State bullet at all**.
+
+`done`/`deployed` keywords win over `in_flight` ones when both appear (a bullet like
+"merged to testing and deployed; partial rollout" classifies `terminal_done`). The folder
+defines the expected class: `done/`→`terminal_done`, `rejected/`+`deferred/`→`terminal_closed`,
+`pending/`+`accepted/`→`in_flight`. The gate:
+
+- **FAIL (blocking):** a file in `pending/` or `accepted/` classified `terminal_done` —
+  it claims completion while unfiled (the dangerous "shipped-but-unfiled" direction). The
+  tree is **currently clean** of this, so the gate goes green on merge.
+- **WARN (report-only, exit 0):** any other folder↔class mismatch — e.g. a `done/` file
+  classified `in_flight` (cosmetic stale bullet; some exist today, fixed below), or a
+  `pending/` file classified `terminal_closed`. `unknown`/no-bullet is a WARN, never a
+  crash (fail-open).
+
+**This PR re-runs the discovery and fixes whatever `done/` files carry a stale `in_flight`
+State bullet** (≈4 at plan time) so the WARN report is empty, demonstrating the gate's
+WARN→clean transition end-to-end. The PR description calls these cosmetic edits out
+explicitly as bundled-for-demo so a wrong one-line edit can't be confused with gate logic.
+
+Full "acceptance all-green ⇒ auto-file to done/" (the *active* reconcile that moves files)
+needs the §1 runner to evaluate checks; it is **P5**, not here. P1 is detect-and-report +
+the one safe blocking invariant.
+
+### Check B — acceptance-block schema (§4)
+
+Proposals have no YAML front matter (verified across the tree), so the `acceptance:` block
+is embedded as a fenced block with an `acceptance` info-string:
+
+````markdown
+```yaml acceptance
+- {id: 1, tier: mechanical, check: "make unit-tests TEST=test_foo"}
+- {id: 5, tier: deployment, check: "ci:e2e-docker"}
+```
+````
+
+The gate parses **every** such block in a file (`yaml.safe_load`; PyYAML is available in
+the lint CI job — `check-api-conformance.py` already imports it under `make lint`) and
+validates: the block is a list (empty list is valid — a draft may declare the block before
+filling it); each entry is a mapping carrying **at least** the keys `id`/`tier`/`check`;
+`id` is a positive int unique across all blocks in the file; `tier ∈ {mechanical,
+integration, deployment, hardware}`; `check` a non-empty string. **Unknown keys are
+tolerated** (forward-compat: a later packet may add `owner`/`timeout`/`schema_version`
+without a breaking migration). A non-list, a missing required key, an unknown tier, a
+duplicate/non-positive `id`, or a YAML parse error ⇒ **FAIL (blocking)**, with a
+copy-pasteable skeleton + tier legend printed so the author can self-correct.
+
+To make this check non-vacuous on day one (the roundtable flagged it would otherwise ship
+with zero real input), **this PR adds a real `acceptance:` block to the substrate proposal
+itself** — its mechanical criteria (build/lint/unit of this very gate) — so Check B
+validates a genuine document at merge. P1 does **not** execute the checks (that is P3–P5);
+it only validates their shape.
+
+PyYAML import is guarded: an `ImportError` exits with a clear "PyYAML required for the
+acceptance-block check" message rather than a traceback (it will not fire in CI, where
+yaml is present, but keeps the script runnable/diagnosable elsewhere).
+
+### Check C — premise-drift, report-only (§5)
+
+For each `pending/`+`accepted/` proposal, extract high-confidence in-tree references and
+report any that no longer resolve:
+
+- backtick-quoted **repo paths** matching `src/…`, `scripts/…`, `docs/…`,
+  `.github/…`, or a top-level `Makefile`/`Dockerfile*` — flag if the path does not exist;
+- `check:` commands inside an acceptance block that name a `TEST=<id>` — flag if that test
+  id greps nowhere under `src/tests/`.
+
+**Report-only, never blocking, never auto-edits** (proposal Risk: "report-only … a
+renamed-but-equivalent symbol" yields false positives). Bare-symbol/function references
+are deliberately *out of scope* for P1 — too noisy to be a gate; only path/test-id forms,
+which are precise, are reported. `--strict` promotes the report to a failure for callers
+(e.g. a future driver) that want it fatal; `make lint` runs the **non-strict** form.
+**Triage owner:** the drift report is consumed by the next plan revision / the autonomous
+driver, not a human inbox; the script header records "first review at P3" and the condition
+under which `--strict` becomes the lint default (when the drift count reaches zero and
+stays there one packet). If Check C proves unworkably noisy it is removed, not endured.
+
+### CLI / exit contract
+
+`#!/usr/bin/env python3` (requires Python ≥ 3.8 — f-strings only, no walrus/match):
+
+```
+check-proposal-reconcile.py [--proposals-dir DIR] [--strict] [--json] [--plant-test]
+```
+
+- default: run A (blocking)+B (blocking)+C (report-only); exit 1 iff a *blocking* finding;
+  print a human report. `--proposals-dir` defaults to `docs/proposals` resolved from the
+  repo root (script-relative, like `check-proposal-links.py`).
+- `--strict`: Check-C drift findings *also* make exit nonzero. Drift entries always live in
+  the `drift` array regardless of `--strict`; `--strict` changes only the exit code, never
+  where a finding is reported.
+- `--json`: machine-readable `{blocking:[…], warnings:[…], drift:[…]}` — all three keys
+  always present (possibly empty) — for the driver.
+- `--plant-test`: inject one known-bad case per check class in-memory, assert each is
+  caught, exit 0 on success / 1 if any planted fault slips through (proves non-vacuous,
+  same convention as the other gates).
+
+### Files
+
+- **new** `scripts/check-proposal-reconcile.py` — the gate (named to match the established
+  `scripts/check-*.py` lint-gate convention, not the broader `aimee dev reconcile` command
+  that is a later packet).
+- `src/Makefile` — add `proposal-reconcile-check:` target (`python3
+  ../scripts/check-proposal-reconcile.py` then `--plant-test`), append to the `lint`
+  aggregate + the `.PHONY` line, mirroring `proposal-links-check`.
+- **edit (cosmetic)** the `done/` proposals carrying a stale `in_flight` State bullet
+  (discovery re-run at impl time) → State bullet reads `done`, so Check A's WARN report is
+  clean. Called out as bundled-for-demo in the PR body.
+- **edit** `docs/proposals/pending/autonomous-dev-execution-substrate.md` — add the real
+  `acceptance:` block (above) so Check B has a live input.
+- **new** `scripts/tests/test_check_proposal_reconcile.py` — plain `unittest` over
+  synthetic proposal trees in a tmpdir. Cases: Check A FAIL (pending claims done) / WARN
+  (done has in_flight bullet, incl. an *unmodified* stale bullet) / clean / no-State-bullet
+  (unknown→WARN, no crash) / rejected+deferred folders; Check B valid / missing-key /
+  unknown-tier / dup-id / non-positive-id / non-list / empty-list (valid) / YAML parse
+  error / two blocks per file / unknown-key-tolerated; Check C drift present (bad src path)
+  / absent / `--strict` promotes drift to exit 1; `--json` shape with all three classes
+  present simultaneously; `--plant-test` self-check. Self-contained (no network, no live
+  tree).
+
+### Verification (in-env, no human host)
+
+1. `python3 scripts/reconcile-proposals.py --plant-test` → exit 0.
+2. `python3 scripts/reconcile-proposals.py` on the real tree → exit 0, report lists the
+   (now-fixed → empty) stale-state warnings and any path drift, no blocking findings.
+3. `python3 -m unittest scripts/tests/test_reconcile_proposals.py` → all green.
+4. `make -C src proposal-reconcile-check` → green; `make -C src lint` includes it.
+5. `clang-format`/line checks N/A (no C changed); confirm `make -C src lint` stays green.
+
+## Cross-cutting
+
+- **No co-author trailers** (`no-coauthor-trailers` is a required check); branch off
+  `origin/testing`, squash to `testing` with the `(#NNN)` convention; human-only promotion
+  to `main`.
+- **Per-packet loop:** implement → lint+tests green → roundtable review → fix to APPROVE →
+  PR → green CI → squash-merge → next packet.
+- **Scope discipline:** P1 ships *detection*. It never moves a proposal file or edits a
+  proposal body beyond the 4 cosmetic State-bullet fixes. The file-moving reconcile is P5,
+  gated on the §1 runner so "done" is evidence-backed, not guessed.

--- a/scripts/check-proposal-reconcile.py
+++ b/scripts/check-proposal-reconcile.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Gate: reconcile proposal lifecycle state against the directory + the tree.
+
+Companion lint gate for the autonomous-dev-execution-substrate proposal (§4/§5).
+Sibling of check-proposal-links.py; wired into `make lint`. Three checks, all
+decidable from the working tree alone (no build runner, no CI, no live stack):
+
+  A. state<->folder consistency (the safe slice of "shipped-but-unfiled").
+     The FOLDER is authoritative for a proposal's lifecycle. The "- **State:**"
+     bullet is prose and drifts. We classify the bullet into a closed enum and
+     compare it to the class the folder implies:
+       FAIL  - a pending/ or accepted/ proposal classified terminal-done
+               (claims completion while still filed as open work).
+       WARN  - any other folder<->class mismatch (e.g. a done/ file whose bullet
+               still reads draft/proposed/approved). Report-only, exit 0.
+
+  B. acceptance-block schema (the executable shadow of a proposal's criteria).
+     An optional fenced block:
+         ```yaml acceptance
+         - {id: 1, tier: mechanical, check: "make unit-tests TEST=test_foo"}
+         ```
+     Every entry must carry at least id/tier/check; id a positive int unique in
+     the file; tier in {mechanical,integration,deployment,hardware}; check a
+     non-empty string. Unknown keys are tolerated (forward-compat). A non-list,
+     missing key, unknown tier, dup/non-positive id, or YAML parse error => FAIL.
+     We validate the SHAPE only; running the checks is a later packet.
+
+  C. premise-drift (report-only, never blocking by default).
+     Acceptance `check:` targets that reference an in-tree artefact which no
+     longer resolves (a `make ... TEST=<id>` whose test greps nowhere under
+     src/tests, or a `python3 scripts/<f>` / `scripts/<f>` whose file is gone),
+     plus backtick-quoted source paths a proposal names that do not exist and are
+     not flagged as proposed-new. Reported in the `drift` array; --strict makes
+     drift fatal too. Never auto-edits (renamed-but-equivalent => false positive).
+
+  Triage: the drift report is consumed by the next plan revision / the autonomous
+  driver, not a human inbox. --strict becomes the lint default once the drift
+  count reaches zero and holds one packet (first review at P3). If Check C proves
+  unworkably noisy it is removed, not endured.
+
+Usage:
+  check-proposal-reconcile.py [--proposals-dir DIR] [--strict] [--json] [--plant-test]
+
+  --strict      Check-C drift findings also make the exit nonzero (default: only
+                Check-A FAIL and Check-B FAIL are blocking).
+  --json        Emit {blocking:[...], warnings:[...], drift:[...]} (all keys
+                always present) instead of the human report.
+  --plant-test  Inject one known-bad case per check class in-memory and confirm
+                each is caught; proves the gate is wired and not vacuously
+                passing. Exit 0 on success, 1 if any planted fault slips through.
+
+Requires Python >= 3.8 and PyYAML (present in the lint CI job).
+"""
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_PROPOSALS = ROOT / "docs" / "proposals"
+
+# Lifecycle folders -> the state class the folder implies.
+FOLDER_EXPECTED = {
+    "pending": "in_flight",
+    "accepted": "in_flight",
+    "done": "terminal_done",
+    "rejected": "terminal_closed",
+    "deferred": "in_flight",
+}
+
+# State-bullet classification keywords, checked in this priority order (a "done"
+# word wins over an "in_flight" word when both appear). Matched on WORD BOUNDARIES
+# (lowercased) so e.g. "abandoned" does not count as "done".
+TERMINAL_DONE_KW = ("done", "shipped", "merged", "deployed", "landed")
+TERMINAL_CLOSED_KW = ("rejected", "withdrawn", "superseded", "declined")
+IN_FLIGHT_KW = (
+    "draft", "proposed", "pending", "accepted", "approved", "reviewed",
+    "ready", "in progress", "in-progress", "blocked", "partial", "converged",
+    "implementing", "design",
+)
+
+
+def _kw_re(words):
+    return re.compile(r"\b(?:" + "|".join(re.escape(w) for w in words) + r")\b")
+
+
+TERMINAL_DONE_RE = _kw_re(TERMINAL_DONE_KW)
+TERMINAL_CLOSED_RE = _kw_re(TERMINAL_CLOSED_KW)
+IN_FLIGHT_RE = _kw_re(IN_FLIGHT_KW)
+
+VALID_TIERS = {"mechanical", "integration", "deployment", "hardware"}
+
+# The first lifecycle bullet. The corpus uses both `- **State:** X` and bare
+# `Status: X` / `**Status:** X`; accept all forms (and incidental whitespace
+# around the colon), anchored to line start.
+STATE_RE = re.compile(
+    r"^(?:-\s*)?\*{0,2}(?:State|Status)\*{0,2}\s*:\s*\*{0,2}\s*(.*)$", re.IGNORECASE)
+# A fenced block whose info string is `acceptance` or `<lang> acceptance`.
+ACCEPTANCE_FENCE_RE = re.compile(r"^```[ \t]*(?:[A-Za-z0-9_-]+[ \t]+)?acceptance[ \t]*$")
+FENCE_CLOSE_RE = re.compile(r"^```[ \t]*$")
+FENCE_OPEN_RE = re.compile(r"^```")  # any fence delimiter (toggles in/out)
+# Backtick-quoted in-tree source path (concrete file, not a directory).
+SRC_PATH_RE = re.compile(
+    r"`((?:src|scripts|\.github)/[\w./-]+\.(?:c|h|py|sh|inc|ya?ml)|Makefile|Dockerfile[\w.-]*)`"
+)
+# A `make ... TEST=<id>` target inside an acceptance check string.
+TEST_ID_RE = re.compile(r"\bTEST=([A-Za-z0-9_./-]+)")
+# A `python3 scripts/x` or bare `scripts/x` target inside an acceptance check.
+SCRIPT_TARGET_RE = re.compile(r"(scripts/[\w./-]+\.(?:py|sh))")
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - yaml is present in CI
+    print("check-proposal-reconcile: FAIL - PyYAML required for the "
+          "acceptance-block check (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+SKELETON = (
+    "  acceptance block must be:\n"
+    "    ```yaml acceptance\n"
+    "    - {id: 1, tier: mechanical, check: \"make unit-tests TEST=test_foo\"}\n"
+    "    ```\n"
+    "  each entry: id (positive int, unique), tier in "
+    "{mechanical,integration,deployment,hardware}, check (non-empty string).")
+
+
+def is_primary_proposal(path):
+    """A proposal's main file, not its .plan.md / .PR.md companions or .gitkeep."""
+    n = path.name
+    return n.endswith(".md") and not (n.endswith(".plan.md") or n.endswith(".PR.md"))
+
+
+def classify_state(text):
+    """Map a State-bullet's prose to a lifecycle class."""
+    if text is None:
+        return "unknown"
+    low = text.lower()
+    if TERMINAL_DONE_RE.search(low):
+        return "terminal_done"
+    if TERMINAL_CLOSED_RE.search(low):
+        return "terminal_closed"
+    if IN_FLIGHT_RE.search(low):
+        return "in_flight"
+    return "unknown"
+
+
+def extract_state(text):
+    """Return the first State-bullet's prose (or None)."""
+    for line in text.splitlines():
+        m = STATE_RE.match(line)
+        if m:
+            return m.group(1).strip()
+    return None
+
+
+def extract_acceptance_blocks(text):
+    """Yield the raw YAML body of every fenced acceptance block in `text`."""
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        if ACCEPTANCE_FENCE_RE.match(lines[i]):
+            body = []
+            i += 1
+            while i < len(lines) and not FENCE_CLOSE_RE.match(lines[i]):
+                body.append(lines[i])
+                i += 1
+            yield "\n".join(body)
+        i += 1
+
+
+def check_state_folder(folder, rel, text):
+    """Return (blocking, warnings) for one proposal's state<->folder consistency."""
+    expected = FOLDER_EXPECTED.get(folder)
+    if expected is None:
+        return [], []
+    state_text = extract_state(text)
+    cls = classify_state(state_text)
+    if cls == expected:
+        return [], []
+    # The one dangerous direction: open work claiming completion.
+    if folder in ("pending", "accepted") and cls == "terminal_done":
+        return [f"{rel}: in {folder}/ but State bullet reads as DONE "
+                f"({state_text!r}) - file it to done/ or correct the bullet"], []
+    if cls == "unknown":
+        return [], [f"{rel}: State bullet unrecognised or missing "
+                    f"({state_text!r}); expected {expected}"]
+    return [], [f"{rel}: in {folder}/ (expected {expected}) but State bullet "
+                f"classifies {cls} ({state_text!r})"]
+
+
+def validate_acceptance(rel, text):
+    """Return a list of blocking schema errors for one proposal's acceptance blocks."""
+    errors = []
+    seen_ids = set()
+    for raw in extract_acceptance_blocks(text):
+        try:
+            data = yaml.safe_load(raw) if raw.strip() else []
+        except yaml.YAMLError as e:
+            errors.append(f"{rel}: acceptance block is not valid YAML: {e}")
+            continue
+        if data is None:
+            data = []
+        if not isinstance(data, list):
+            errors.append(f"{rel}: acceptance block must be a list, got "
+                          f"{type(data).__name__}")
+            continue
+        for entry in data:
+            if not isinstance(entry, dict):
+                errors.append(f"{rel}: acceptance entry must be a mapping, got "
+                              f"{entry!r}")
+                continue
+            for key in ("id", "tier", "check"):
+                if key not in entry:
+                    errors.append(f"{rel}: acceptance entry missing '{key}': {entry!r}")
+            if errors and errors[-1].startswith(f"{rel}: acceptance entry missing"):
+                continue
+            eid, tier, check = entry.get("id"), entry.get("tier"), entry.get("check")
+            if not isinstance(eid, int) or isinstance(eid, bool) or eid <= 0:
+                errors.append(f"{rel}: acceptance id must be a positive int: {eid!r}")
+            elif eid in seen_ids:
+                errors.append(f"{rel}: duplicate acceptance id {eid}")
+            else:
+                seen_ids.add(eid)
+            if tier not in VALID_TIERS:
+                errors.append(f"{rel}: acceptance tier {tier!r} not in "
+                              f"{sorted(VALID_TIERS)}")
+            if not isinstance(check, str) or not check.strip():
+                errors.append(f"{rel}: acceptance check must be a non-empty "
+                              f"string: {check!r}")
+    return errors
+
+
+def _test_id_exists(test_id, tests_dir):
+    """True if a TEST=<id> resolves to something under src/tests/."""
+    if not tests_dir.is_dir():
+        return True  # can't disprove; don't false-flag
+    for p in tests_dir.rglob("*.c"):
+        if test_id in p.read_text(encoding="utf-8", errors="ignore"):
+            return True
+    return (tests_dir / test_id).exists()
+
+
+def check_drift(rel, text, root, tests_dir):
+    """Return a list of report-only premise-drift findings for one proposal."""
+    drift = []
+    # High-signal: acceptance check targets that don't resolve.
+    for raw in extract_acceptance_blocks(text):
+        try:
+            data = yaml.safe_load(raw) if raw.strip() else []
+        except yaml.YAMLError:
+            continue
+        if not isinstance(data, list):
+            continue
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            check = entry.get("check")
+            if not isinstance(check, str):
+                continue
+            for m in TEST_ID_RE.finditer(check):
+                if not _test_id_exists(m.group(1), tests_dir):
+                    drift.append(f"{rel}: acceptance check TEST={m.group(1)} "
+                                 f"resolves to no test under src/tests/")
+            for m in SCRIPT_TARGET_RE.finditer(check):
+                if not (root / m.group(1)).exists():
+                    drift.append(f"{rel}: acceptance check references "
+                                 f"{m.group(1)} which does not exist")
+    # Lower-signal (advisory): backtick source paths that don't exist. Skip
+    # fenced code examples and lines explicitly marking a proposed-new file
+    # (`**new**`), which are design targets, not drift.
+    in_fence = False
+    for line in text.splitlines():
+        if FENCE_OPEN_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if in_fence or "**new**" in line:
+            continue
+        for m in SRC_PATH_RE.finditer(line):
+            path = m.group(1)
+            if not _within(root, path):
+                continue  # ignore any `..`-escaping reference (never read it)
+            if not (root / path).exists():
+                drift.append(f"{rel}: references `{path}` which does not exist "
+                             f"in the tree (may be proposed-new)")
+    return drift
+
+
+def _within(root, rel_path):
+    """True if root/rel_path resolves inside root (no `..` escape). Any path the
+    filesystem can't resolve (embedded NUL, symlink loop, ...) is treated as
+    'not within' so a garbled prose reference skips rather than aborting the scan."""
+    try:
+        (root / rel_path).resolve().relative_to(root.resolve())
+        return True
+    except (ValueError, OSError, RuntimeError):
+        return False
+
+
+def run(proposals_dir, root, strict):
+    """Run all three checks over the tree. Return (blocking, warnings, drift)."""
+    blocking, warnings, drift = [], [], []
+    tests_dir = root / "src" / "tests"
+    for folder in FOLDER_EXPECTED:
+        d = proposals_dir / folder
+        if not d.is_dir():
+            continue
+        for f in sorted(d.glob("*.md")):
+            if not is_primary_proposal(f):
+                continue
+            try:
+                rel = f.relative_to(root).as_posix()
+            except ValueError:
+                rel = f.as_posix()  # --proposals-dir outside the repo (tests)
+            text = f.read_text(encoding="utf-8", errors="replace")
+            b, w = check_state_folder(folder, rel, text)
+            blocking += b
+            warnings += w
+            blocking += validate_acceptance(rel, text)
+            if folder in ("pending", "accepted"):
+                drift += check_drift(rel, text, root, tests_dir)
+    return _dedup(blocking), _dedup(warnings), _dedup(drift)
+
+
+def _dedup(items):
+    """Drop duplicate findings, preserving first-seen order."""
+    seen, out = set(), []
+    for x in items:
+        if x not in seen:
+            seen.add(x)
+            out.append(x)
+    return out
+
+
+def plant_test(proposals_dir, root):
+    """Confirm each check class catches a known-bad input. Exit-status int."""
+    ok = True
+    # A: a pending file whose bullet reads DONE must be blocking.
+    b, _ = check_state_folder("pending", "x/y.md",
+                              "- **State:** done and shipped to testing\n")
+    if not b:
+        print("check-proposal-reconcile: FAIL - plant-test A (done-in-pending) "
+              "not caught")
+        ok = False
+    # B: an unknown tier must be a schema error.
+    errs = validate_acceptance("x/y.md",
+                               "```yaml acceptance\n- {id: 1, tier: bogus, "
+                               "check: \"x\"}\n```\n")
+    if not errs:
+        print("check-proposal-reconcile: FAIL - plant-test B (bad tier) not caught")
+        ok = False
+    # C: an acceptance check pointing at a missing script must be drift.
+    d = check_drift("x/y.md",
+                    "```yaml acceptance\n- {id: 1, tier: mechanical, "
+                    "check: \"python3 scripts/__no_such__.py\"}\n```\n",
+                    root, root / "src" / "tests")
+    if not d:
+        print("check-proposal-reconcile: FAIL - plant-test C (missing script) "
+              "not caught")
+        ok = False
+    if ok:
+        print("check-proposal-reconcile: plant-test ok (A/B/C all caught)")
+        return 0
+    return 1
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(add_help=True)
+    ap.add_argument("--proposals-dir", default=str(DEFAULT_PROPOSALS))
+    ap.add_argument("--strict", action="store_true")
+    ap.add_argument("--json", action="store_true")
+    ap.add_argument("--plant-test", action="store_true")
+    args = ap.parse_args(argv)
+
+    proposals_dir = Path(args.proposals_dir).resolve()
+    root = ROOT
+
+    if args.plant_test:
+        return plant_test(proposals_dir, root)
+
+    if not proposals_dir.is_dir():
+        print(f"check-proposal-reconcile: FAIL - proposals dir not found: "
+              f"{proposals_dir}", file=sys.stderr)
+        return 2
+
+    blocking, warnings, drift = run(proposals_dir, root, args.strict)
+
+    if args.json:
+        import json
+        print(json.dumps({"blocking": blocking, "warnings": warnings,
+                          "drift": drift}, indent=2))
+    else:
+        if blocking:
+            print(f"check-proposal-reconcile: FAIL - {len(blocking)} blocking "
+                  f"finding(s):")
+            for x in blocking:
+                print(f"  {x}")
+            print(SKELETON)
+        if warnings:
+            print(f"check-proposal-reconcile: {len(warnings)} warning(s) "
+                  f"(report-only):")
+            for x in warnings:
+                print(f"  {x}")
+        if drift:
+            print(f"check-proposal-reconcile: {len(drift)} premise-drift "
+                  f"finding(s) (report-only{', FATAL under --strict' if args.strict else ''}):")
+            for x in drift:
+                print(f"  {x}")
+        if not (blocking or warnings or drift):
+            print("check-proposal-reconcile: ok (state<->folder consistent, "
+                  "acceptance blocks valid, no drift)")
+
+    rc = 1 if blocking else 0
+    if args.strict and drift:
+        rc = 1
+    return rc
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_check_proposal_reconcile.py
+++ b/scripts/tests/test_check_proposal_reconcile.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/check-proposal-reconcile.py.
+
+Self-contained: synthetic proposal trees in a tmpdir, no network, no live tree.
+Run: python3 -m unittest discover -s scripts/tests -p test_check_proposal_reconcile.py
+"""
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "check-proposal-reconcile.py"
+
+spec = importlib.util.spec_from_file_location("reconcile", SCRIPT)
+rec = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(rec)
+
+
+def _block(*entries):
+    body = "\n".join(entries)
+    return f"```yaml acceptance\n{body}\n```\n"
+
+
+class ClassifyState(unittest.TestCase):
+    def test_done_wins_over_in_flight(self):
+        self.assertEqual(rec.classify_state("merged and deployed; partial rollout"),
+                         "terminal_done")
+
+    def test_in_flight(self):
+        self.assertEqual(rec.classify_state("proposed; awaiting roundtable"), "in_flight")
+
+    def test_closed(self):
+        self.assertEqual(rec.classify_state("rejected in favour of X"), "terminal_closed")
+
+    def test_unknown(self):
+        self.assertEqual(rec.classify_state("some prose with no keyword"), "unknown")
+        self.assertEqual(rec.classify_state(None), "unknown")
+
+    def test_mixed_case(self):
+        self.assertEqual(rec.classify_state("DONE and SHIPPED"), "terminal_done")
+        self.assertEqual(rec.classify_state("Proposed"), "in_flight")
+
+    def test_word_boundary_no_false_positive(self):
+        # "abandoned" contains the substring "done" but is not the word "done".
+        self.assertEqual(rec.classify_state("abandoned this approach"), "unknown")
+        # "already" contains "ready" as a substring only.
+        self.assertEqual(rec.classify_state("already underway"), "unknown")
+
+
+class ExtractState(unittest.TestCase):
+    def test_state_bullet(self):
+        self.assertEqual(rec.extract_state("# T\n- **State:** done\n"), "done")
+
+    def test_status_bold(self):
+        self.assertEqual(rec.extract_state("# T\n**Status:** APPROVED\n"), "APPROVED")
+
+    def test_status_bare(self):
+        self.assertEqual(rec.extract_state("# T\nStatus: done — shipped\n"),
+                         "done — shipped")
+
+    def test_missing(self):
+        self.assertIsNone(rec.extract_state("# T\n\n## Problem\nbody\n"))
+
+    def test_multiline_bullet_first_line_only(self):
+        # A bullet that wraps: only the first physical line is the state prose.
+        txt = "# T\n- **State:** done — shipped\n  across many PRs\n"
+        self.assertEqual(rec.extract_state(txt), "done — shipped")
+
+    def test_space_before_colon(self):
+        self.assertEqual(rec.extract_state("# T\n- **State** : done\n"), "done")
+
+
+class CheckStateFolder(unittest.TestCase):
+    def test_fail_pending_claims_done(self):
+        b, w = rec.check_state_folder("pending", "x.md", "- **State:** done, shipped\n")
+        self.assertTrue(b)
+        self.assertFalse(w)
+
+    def test_warn_done_has_in_flight(self):
+        b, w = rec.check_state_folder("done", "x.md", "- **State:** proposed\n")
+        self.assertFalse(b)
+        self.assertTrue(w)
+
+    def test_clean(self):
+        b, w = rec.check_state_folder("done", "x.md", "- **State:** done\n")
+        self.assertFalse(b)
+        self.assertFalse(w)
+
+    def test_no_bullet_warns_not_crashes(self):
+        b, w = rec.check_state_folder("pending", "x.md", "# T\nbody only\n")
+        self.assertFalse(b)
+        self.assertTrue(w)
+
+    def test_rejected_folder_warns_on_live_state(self):
+        b, w = rec.check_state_folder("rejected", "x.md", "- **State:** approved\n")
+        self.assertFalse(b)
+        self.assertTrue(w)
+
+    def test_deferred_in_flight_is_clean(self):
+        b, w = rec.check_state_folder("deferred", "x.md", "- **State:** proposed\n")
+        self.assertFalse(b)
+        self.assertFalse(w)
+
+
+class ValidateAcceptance(unittest.TestCase):
+    def test_valid(self):
+        self.assertEqual(
+            rec.validate_acceptance("x.md",
+                _block('- {id: 1, tier: mechanical, check: "make x"}')), [])
+
+    def test_empty_list_valid(self):
+        self.assertEqual(rec.validate_acceptance("x.md", "```yaml acceptance\n```\n"), [])
+
+    def test_missing_key(self):
+        errs = rec.validate_acceptance("x.md", _block('- {id: 1, tier: mechanical}'))
+        self.assertTrue(any("missing 'check'" in e for e in errs))
+
+    def test_unknown_tier(self):
+        errs = rec.validate_acceptance("x.md",
+            _block('- {id: 1, tier: bogus, check: "x"}'))
+        self.assertTrue(any("tier" in e for e in errs))
+
+    def test_dup_id(self):
+        errs = rec.validate_acceptance("x.md", _block(
+            '- {id: 1, tier: mechanical, check: "a"}',
+            '- {id: 1, tier: mechanical, check: "b"}'))
+        self.assertTrue(any("duplicate" in e for e in errs))
+
+    def test_non_positive_id(self):
+        errs = rec.validate_acceptance("x.md",
+            _block('- {id: 0, tier: mechanical, check: "x"}'))
+        self.assertTrue(any("positive int" in e for e in errs))
+
+    def test_bool_id_rejected(self):
+        # YAML `true` is a bool, not a positive int.
+        errs = rec.validate_acceptance("x.md",
+            _block('- {id: true, tier: mechanical, check: "x"}'))
+        self.assertTrue(any("positive int" in e for e in errs))
+
+    def test_non_list(self):
+        errs = rec.validate_acceptance("x.md",
+            "```yaml acceptance\nid: 1\ntier: mechanical\ncheck: x\n```\n")
+        self.assertTrue(any("must be a list" in e for e in errs))
+
+    def test_null_entry(self):
+        errs = rec.validate_acceptance("x.md", "```yaml acceptance\n- null\n```\n")
+        self.assertTrue(any("must be a mapping" in e for e in errs))
+
+    def test_empty_check_string(self):
+        errs = rec.validate_acceptance("x.md",
+            _block('- {id: 1, tier: mechanical, check: ""}'))
+        self.assertTrue(any("non-empty" in e for e in errs))
+
+    def test_yaml_parse_error(self):
+        errs = rec.validate_acceptance("x.md",
+            "```yaml acceptance\n- {id: 1, tier: : : bad\n```\n")
+        self.assertTrue(any("not valid YAML" in e for e in errs))
+
+    def test_unknown_key_tolerated(self):
+        self.assertEqual(
+            rec.validate_acceptance("x.md",
+                _block('- {id: 1, tier: mechanical, check: "x", owner: jb, '
+                       'schema_version: 1}')), [])
+
+    def test_two_blocks_ids_unique_across_file(self):
+        text = (_block('- {id: 1, tier: mechanical, check: "a"}')
+                + "\nprose\n"
+                + _block('- {id: 1, tier: integration, check: "b"}'))
+        errs = rec.validate_acceptance("x.md", text)
+        self.assertTrue(any("duplicate" in e for e in errs))
+
+
+class CheckDrift(unittest.TestCase):
+    def setUp(self):
+        self.root = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, self.root, ignore_errors=True)
+        (self.root / "scripts").mkdir()
+        (self.root / "src" / "tests").mkdir(parents=True)
+
+    def test_missing_script_target(self):
+        d = rec.check_drift("x.md",
+            _block('- {id: 1, tier: mechanical, check: "python3 scripts/gone.py"}'),
+            self.root, self.root / "src" / "tests")
+        self.assertTrue(any("scripts/gone.py" in x for x in d))
+
+    def test_present_script_target_clean(self):
+        (self.root / "scripts" / "here.py").write_text("x")
+        d = rec.check_drift("x.md",
+            _block('- {id: 1, tier: mechanical, check: "python3 scripts/here.py"}'),
+            self.root, self.root / "src" / "tests")
+        self.assertFalse(d)
+
+    def test_missing_test_id(self):
+        d = rec.check_drift("x.md",
+            _block('- {id: 1, tier: mechanical, check: "make unit-tests TEST=test_nope"}'),
+            self.root, self.root / "src" / "tests")
+        self.assertTrue(any("test_nope" in x for x in d))
+
+    def test_present_test_id_clean(self):
+        (self.root / "src" / "tests" / "test_real.c").write_text("void test_real(){}")
+        d = rec.check_drift("x.md",
+            _block('- {id: 1, tier: mechanical, check: "make unit-tests TEST=test_real"}'),
+            self.root, self.root / "src" / "tests")
+        self.assertFalse(d)
+
+    def test_prose_path_drift(self):
+        d = rec.check_drift("x.md", "It lives in `src/server/gone.c` today.\n",
+                            self.root, self.root / "src" / "tests")
+        self.assertTrue(any("src/server/gone.c" in x for x in d))
+
+    def test_proposed_new_path_skipped(self):
+        d = rec.check_drift("x.md", "- **new** `src/server/future.c` — the gate\n",
+                            self.root, self.root / "src" / "tests")
+        self.assertFalse(d)
+
+    def test_fenced_code_example_skipped(self):
+        d = rec.check_drift("x.md",
+            "Example:\n```\nedit `src/server/gone.c` here\n```\n",
+            self.root, self.root / "src" / "tests")
+        self.assertFalse(d)
+
+    def test_dotdot_escape_ignored(self):
+        # A `..`-escaping path must never be flagged (or filesystem-walked).
+        d = rec.check_drift("x.md", "see `src/../../etc/passwd.c`\n",
+                            self.root, self.root / "src" / "tests")
+        self.assertFalse(d)
+
+
+class EndToEnd(unittest.TestCase):
+    """Drive main() over a synthetic --proposals-dir; assert exit codes + JSON."""
+
+    def _tree(self):
+        base = Path(tempfile.mkdtemp())
+        self.addCleanup(shutil.rmtree, base, ignore_errors=True)
+        d = base / "proposals"
+        for sub in rec.FOLDER_EXPECTED:
+            (d / sub).mkdir(parents=True)
+        return d
+
+    def _run(self, proposals_dir, *extra):
+        p = subprocess.run([sys.executable, str(SCRIPT),
+                            "--proposals-dir", str(proposals_dir), *extra],
+                           capture_output=True, text=True)
+        return p
+
+    def test_clean_tree_exit0(self):
+        d = self._tree()
+        (d / "done" / "a.md").write_text("# A\n- **State:** done\n")
+        (d / "pending" / "b.md").write_text("# B\n- **State:** proposed\n")
+        p = self._run(d)
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+
+    def test_blocking_exit1(self):
+        d = self._tree()
+        (d / "pending" / "c.md").write_text("# C\n- **State:** done and shipped\n")
+        p = self._run(d)
+        self.assertEqual(p.returncode, 1)
+
+    def test_json_has_all_three_classes(self):
+        d = self._tree()
+        # blocking (pending claims done), warning (done in_flight),
+        # drift (bad prose src path) all at once.
+        (d / "pending" / "c.md").write_text(
+            "# C\n- **State:** shipped\n\nuses `src/__no__.c` now\n")
+        (d / "done" / "w.md").write_text("# W\n- **State:** proposed\n")
+        p = self._run(d, "--json")
+        obj = json.loads(p.stdout)
+        self.assertEqual(set(obj), {"blocking", "warnings", "drift"})
+        self.assertTrue(obj["blocking"])
+        self.assertTrue(obj["warnings"])
+        self.assertTrue(obj["drift"])
+
+    def test_strict_promotes_drift(self):
+        d = self._tree()
+        (d / "pending" / "c.md").write_text(
+            "# C\n- **State:** proposed\n\nuses `src/__no__.c` now\n")
+        self.assertEqual(self._run(d).returncode, 0)         # report-only
+        self.assertEqual(self._run(d, "--strict").returncode, 1)  # promoted
+
+    def test_plant_test(self):
+        p = self._run(self._tree(), "--plant-test")
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+
+    def test_missing_proposals_dir_exit2(self):
+        d = self._tree().parent / "does-not-exist"
+        self.assertEqual(self._run(d).returncode, 2)
+
+    def test_non_utf8_file_does_not_crash(self):
+        d = self._tree()
+        (d / "done" / "bad.md").write_bytes(
+            b"# T\n- **State:** done \xff\xfe garbage\n")
+        p = self._run(d)
+        self.assertEqual(p.returncode, 0, p.stdout + p.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -439,7 +439,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(MCP_GIT_OBJS) $
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
 DEPS = $(ALL_OBJS:.o=.d)
 
-.PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
+.PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_WEBCHAT) $(SERVER) $(KB) $(GATEWAY)
 ifneq ($(HAVE_GO),1)
@@ -1002,6 +1002,15 @@ kb-intelligence-surfaced-check:
 proposal-links-check:
 	@python3 ../scripts/check-proposal-links.py
 
+# Reconcile proposal lifecycle state against the directory + the tree:
+# state<->folder consistency (blocks a pending/accepted file that claims done),
+# acceptance-block schema, and report-only premise-drift. See
+# scripts/check-proposal-reconcile.py and the autonomous-dev-execution-substrate
+# proposal (§4/§5). --plant-test proves the gate is not vacuously passing.
+proposal-reconcile-check:
+	@python3 ../scripts/check-proposal-reconcile.py --plant-test
+	@python3 ../scripts/check-proposal-reconcile.py
+
 # Regenerate the day-one client SDKs (api/sdks/<lang>/) from the OpenAPI spec.
 # Self-bootstrapping (portable JRE + openapi-generator); output is gitignored and
 # regenerated on demand / in CI (see .github/workflows/sdk-gen.yml), not committed.
@@ -1055,7 +1064,7 @@ clean:
 # you genuinely need a different binary.
 CLANG_FORMAT ?= clang-format-19
 
-lint: line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check
+lint: line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check
 
 # Structural guard for the code-vector-graph fusion eval corpus + ablation
 # matrix (>=100 queries, all categories, well-formed; baseline+full_fusion arms).


### PR DESCRIPTION
Packet **P1** of [autonomous-dev-execution-substrate](docs/proposals/pending/autonomous-dev-execution-substrate.md) (APPROVED). Adds a callable, in-env-verifiable reconciler that makes proposal lifecycle state machine-checkable — the §4/§5 detection core. Plan: `docs/proposals/pending/autonomous-dev-execution-substrate.plan.md`.

## What

`scripts/check-proposal-reconcile.py` (sibling of `check-proposal-links.py`, wired into `make lint`). Three checks, all decidable from the working tree alone (no runner, no CI, no live stack):

- **A. state↔folder consistency** — the folder is authoritative; the `State:`/`Status:` bullet is classified into a closed enum (`terminal_done`/`terminal_closed`/`in_flight`/`unknown`, word-boundary keywords). **FAIL** only when a `pending/`+`accepted/` proposal classifies done (the dangerous "shipped-but-unfiled" direction); every other folder↔class mismatch is **report-only**.
- **B. acceptance-block schema** — validates the optional ` ```yaml acceptance ` block (`id`/`tier`/`check`; positive unique `id`; tier ∈ {mechanical,integration,deployment,hardware}; unknown keys tolerated for forward-compat). Malformed ⇒ FAIL with a copy-pasteable skeleton.
- **C. premise-drift** — acceptance check targets + backtick source paths that no longer resolve. **Report-only**; `--strict` promotes to fatal. Fence-aware + `**new**`-aware + `..`-escape-guarded to keep it precise.

`--plant-test` injects one known-bad case per check class and asserts each is caught (non-vacuous gate, same convention as the other lint scripts). `--json` emits `{blocking,warnings,drift}` for the autonomous driver.

## Also in this PR

- Reconciles **9 `done/` proposals** whose State bullet was stale (cosmetic one-liners, bundled intentionally to demonstrate the WARN→clean transition end-to-end; a wrong edit can't be confused with gate logic).
- Adds the substrate proposal's own `acceptance:` block so Check B validates a real document on day one.

## Verification

- `python3 scripts/check-proposal-reconcile.py --plant-test` → ok (A/B/C all caught).
- 46 unit tests (`scripts/tests/test_check_proposal_reconcile.py`) green.
- Full `make -C src lint` green; the gate reports 0 blocking, 0 warnings, 4 report-only drift advisories (all genuine proposed-new file references in other pending proposals).

## Scope

The §1 build runner, §2 forge push (largely already shipped via #605), §3 CI-dispatch, and the P5 *active* file-moving reconcile are later packets. P1 ships **detection + the one safe blocking invariant**, per the plan.