### PR TITLE
refactor(git): route every git op through the ONE credential policy (P2)

### DIFF
--- a/docs/proposals/pending/autonomous-dev-execution-substrate.plan.md
+++ b/docs/proposals/pending/autonomous-dev-execution-substrate.plan.md
@@ -37,7 +37,94 @@ reconciler makes the tree's real drift visible (it may re-scope P2–P5).
 
 ---
 
-## P1 — reconciler static core + acceptance-block schema (THIS PR)
+## P2 — route every git op through the ONE credential policy (§2) — THIS PR
+
+**The defect (architectural).** Aimee already has a single credential-resolution policy:
+`git_cred_inject_build_env_for_repo(principal, remote_url, repo_dir, preferred_token, env)`
+— documented as *"the ONE credential-resolution policy every git network op routes through,
+so the precedence can never drift between call sites"* (precedence: `preferred_token`
+[inline / workspace broker §4] → per-host **server vault** → `principal` **webuser vault**
+→ server identity [App-token / `AIMEE_FORGE_TOKEN`]; injects `GH_TOKEN` + `GIT_ASKPASS` +
+`GIT_TERMINAL_PROMPT=0`, wipes the token). `git_ops.c`, `git_project.c`, `webuser_editor.c`
+already route through it.
+
+But **two call sites bypass it and hand-roll their own ladder**, re-deriving the precedence
+(and so drifting from it — they omit the webuser-vault rung, and neither is auditable as a
+single point):
+- `mcp_git_run` (`src/mcp_git_query.c`) — the executor for **every `gh pr create/merge`**
+  (and clone/fetch/push) in the shared-provider path.
+- `ws_mirror_git_runner` (`src/server/workspace_turn.c`) — the workspace-mirror git runner.
+
+Both do `forge_cred_get(broker) → git_host_resolve_token(per-host) →
+forge_cred_build_server_env(identity)` by hand. **No downstream caller should resolve a
+token.** (Directive, 2026-06-23: *Aimee handles git creds, no downstream processes. Full
+stop.*) The earlier draft of this packet proposed teaching `forge_cred_server_identity` to
+read the vault — that was the wrong layer (it spreads token knowledge) and is dropped.
+
+**Premise-drift the reconciler would flag:** §2 also describes the push gap as still-open
+and names `vault_service_get_server_wrap` as the accessor. Both are stale — push was
+centralised by #605, and the server's OWN token is read via
+`vault_service_get_server_principal` (get_server_wrap is for a webuser dual-wrap entry; see
+`git_host_cred.c`). No code change needed for those; noted so the proposal can be corrected.
+
+### Change
+
+Route both call sites through the one policy, passing the workspace broker token as
+`preferred_token`. This **deletes** the hand-rolled ladder at each site (the
+`git_host_resolve_token` + `forge_cred_build_server_env` + `forge_cred_build_env_from_token`
+calls) and replaces it with a single `git_cred_inject_build_env_for_repo(...)` call:
+
+```c
+char tok[FORGE_TOKEN_MAX] = {0};
+const char *pref = NULL;
+if (wsid && wsid[0] && forge_cred_get(wsid, (long)time(NULL), tok, sizeof tok) == 0 && tok[0])
+   pref = tok;                       /* broker token must win — it is preferred_token */
+char **envp = git_cred_inject_build_env_for_repo(NULL, remote, repo_dir, pref, environ);
+secure_wipe(tok, sizeof tok);        /* caller still wipes its own copy */
+/* envp ? exec under envp + free_env : ambient */
+```
+
+- `mcp_git_run`: `remote=NULL`, `repo_dir=cwd` (the policy reads `origin` itself, matching
+  today's `git_host_resolve_token(NULL, cwd)`).
+- `ws_mirror_git_runner`: `remote=rctx->remote`, `repo_dir=NULL`.
+- `principal=NULL` keeps behaviour **identical** to today (the webuser-vault rung was never
+  reached at these sites); wiring a real turn principal — to additionally honour a webchat
+  user's own vaulted token — is a deliberate follow-up, not smuggled into a refactor.
+
+Behaviour is preserved exactly (broker → per-host vault → server identity → ambient), but
+now there is **one** resolver, so precedence can never drift again and a single audit/policy
+point exists for the driver packet. Net: ~20 lines of duplicated credential logic removed.
+
+### Tests (fully in-env)
+
+- `src/tests/test_mcp_git.c` (or a focused `test_git_cred_inject_routing.c`): assert
+  `mcp_git_run`/the runner builds the git child env via the one policy — with a registered
+  per-host vault token the child env carries `GH_TOKEN`+`GIT_ASKPASS`; with a broker token
+  installed it wins; with neither, envp is NULL (ambient). Driven through the existing
+  test seams (`git_host_resolve_register`, `forge_cred_install`) + a captured-exec stub, so
+  no live forge is touched.
+- A regression assertion that **no `forge_cred_build_server_env` / `git_host_resolve_token`
+  call remains** in `mcp_git_query.c` / `workspace_turn.c` (grep gate in the test or a
+  module-boundary check) — locks in the centralisation.
+
+### Deferred, explicitly labelled
+
+Audit + work-item attribution and branch-policy enforcement (base-off-`testing`, squash,
+no-coauthor) belong to the **driver packet P4**, where the work-item context lives — and the
+one policy is now the single place to hook them. The **live-forge e2e** (`gh pr create/merge`
+against GitHub with the vaulted token) needs network egress + a populated server vault and is
+a `deployment`-tier `validation-pending` check, never auto-claimed.
+
+### Acceptance block (dogfoods P1's §4 gate)
+
+```yaml acceptance
+- {id: 10, tier: mechanical,  check: "make unit-tests TEST=test_mcp_git"}
+- {id: 12, tier: deployment,  check: "ci:live-forge-pr-roundtrip"}
+```
+
+---
+
+## P1 — reconciler static core + acceptance-block schema (shipped, #639)
 
 A single Python lint gate, `scripts/reconcile-proposals.py`, in the established
 `scripts/check-*.py` + `--plant-test` pattern (mirrors `check-proposal-links.py`,

--- a/scripts/check-git-cred-centralized.py
+++ b/scripts/check-git-cred-centralized.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Gate: every git/forge credential resolution routes through the ONE policy.
+
+Aimee handles git/forge credentials centrally:
+`git_cred_inject_build_env_for_repo()` (src/server/git_cred_inject.c) is the
+single resolver — preferred/broker → per-host server vault → webuser vault →
+server identity — so the precedence can never drift between call sites and a
+single point exists to audit/extend. No downstream caller may hand-roll the
+credential ladder.
+
+This gate fails if any source file OUTSIDE the policy itself calls a low-level
+credential-ladder primitive:
+
+  git_host_resolve_token            (the per-host vault rung)
+  forge_cred_build_server_env       (server-identity git env builder)
+  forge_cred_build_env_from_token   (token-to-git-env builder)
+  forge_cred_build_env              (broker-token git env builder)
+
+Callers must instead call git_cred_inject_build_env_for_repo() /
+git_cred_inject_build_env() and exec under the returned envp. Tests and the
+files that DEFINE these primitives (or the policy that legitimately composes
+them) are exempt. Run as part of `make lint`.
+
+  --plant-test  inject a known-bad call in-memory and confirm the check fails,
+                proving the gate is wired and not vacuously passing.
+"""
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+
+# Primitives that must live only inside the one policy.
+BANNED = (
+    "git_host_resolve_token",
+    "forge_cred_build_server_env",
+    "forge_cred_build_env_from_token",
+    "forge_cred_build_env",
+)
+# A call: NAME immediately followed by '(' (not a definition prototype, which we
+# allow only in the exempt files anyway).
+CALL_RE = re.compile(r"\b(" + "|".join(BANNED) + r")\s*\(")
+
+# Files allowed to name these primitives: the policy that composes them, the
+# files that define them, and the per-host-vault seam. Paths are repo-relative.
+EXEMPT = {
+    "src/server/git_cred_inject.c",   # THE policy — composes the rungs
+    "src/server/git_host_resolve.c",  # defines git_host_resolve_token
+    "src/forge_credentials.c",        # defines the forge_cred_build_* primitives
+}
+
+
+def _is_test(rel):
+    return "/tests/" in rel or rel.startswith("src/tests/")
+
+
+def scan_text(rel, text):
+    """Yield (rel, lineno, symbol) for each banned call in non-exempt code."""
+    if rel in EXEMPT or _is_test(rel):
+        return
+    for i, line in enumerate(text.splitlines(), 1):
+        # ignore comment-only lines so prose mentioning a symbol doesn't trip it
+        stripped = line.lstrip()
+        if stripped.startswith("*") or stripped.startswith("//") or stripped.startswith("/*"):
+            continue
+        m = CALL_RE.search(line)
+        if m:
+            yield (rel, i, m.group(1))
+
+
+def main():
+    plant = "--plant-test" in sys.argv
+
+    if plant:
+        bad = "   char **e = forge_cred_build_server_env(environ, shim);\n"
+        hits = list(scan_text("src/server/some_new_caller.c", bad))
+        if not hits:
+            print("check-git-cred-centralized: FAIL — plant-test did not catch a "
+                  "hand-rolled credential call")
+            return 1
+        print("check-git-cred-centralized: plant-test ok (hand-rolled call detected)")
+        return 0
+
+    # Scan .c translation units only — credential-ladder *calls* live there; the
+    # headers merely declare the API surface (the point is no .c calls them).
+    failures = []
+    scanned = 0
+    for f in sorted(SRC.rglob("*.c")):
+        rel = f.relative_to(ROOT).as_posix()
+        if rel in EXEMPT or _is_test(rel):
+            continue
+        scanned += 1
+        failures += list(scan_text(rel, f.read_text(encoding="utf-8", errors="replace")))
+
+    if failures:
+        print(f"check-git-cred-centralized: FAIL — {len(failures)} hand-rolled "
+              f"git-credential call(s) outside the one policy:")
+        for rel, ln, sym in failures:
+            print(f"  {rel}:{ln}: {sym}(")
+        print("  Fix: resolve credentials via git_cred_inject_build_env_for_repo() "
+              "and exec under the returned envp. Aimee handles git creds centrally; "
+              "no downstream caller resolves a token.")
+        return 1
+
+    print(f"check-git-cred-centralized: ok (no hand-rolled credential calls in "
+          f"{scanned} source file(s); all route through git_cred_inject)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/Makefile
+++ b/src/Makefile
@@ -439,7 +439,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(MCP_GIT_OBJS) $
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
 DEPS = $(ALL_OBJS:.o=.d)
 
-.PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
+.PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check git-cred-centralized-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_WEBCHAT) $(SERVER) $(KB) $(GATEWAY)
 ifneq ($(HAVE_GO),1)
@@ -1011,6 +1011,12 @@ proposal-reconcile-check:
 	@python3 ../scripts/check-proposal-reconcile.py --plant-test
 	@python3 ../scripts/check-proposal-reconcile.py
 
+# CI gate: every git/forge credential resolution routes through the ONE policy
+# (git_cred_inject); no downstream caller hand-rolls the credential ladder.
+git-cred-centralized-check:
+	@python3 ../scripts/check-git-cred-centralized.py --plant-test
+	@python3 ../scripts/check-git-cred-centralized.py
+
 # Regenerate the day-one client SDKs (api/sdks/<lang>/) from the OpenAPI spec.
 # Self-bootstrapping (portable JRE + openapi-generator); output is gitignored and
 # regenerated on demand / in CI (see .github/workflows/sdk-gen.yml), not committed.
@@ -1064,7 +1070,7 @@ clean:
 # you genuinely need a different binary.
 CLANG_FORMAT ?= clang-format-19
 
-lint: line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check
+lint: line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check git-cred-centralized-check
 
 # Structural guard for the code-vector-graph fusion eval corpus + ablation
 # matrix (>=100 queries, all categories, well-formed; baseline+full_fusion arms).

--- a/src/forge_credentials.c
+++ b/src/forge_credentials.c
@@ -278,14 +278,6 @@ char **forge_cred_build_env(const char *workspace_id, long now_epoch, char *cons
    return envp;
 }
 
-char **forge_cred_build_env_from_token(const char *token, char *const *parent_environ,
-                                       const char *askpass_shim)
-{
-   if (!token || !token[0])
-      return NULL;
-   return build_env_from_token(token, parent_environ, askpass_shim);
-}
-
 /* Optional App installation-token provider, registered by the server at startup
  * (forge_app_token.c). NULL in the thin client and unit tests, where forge
  * identity isn't used — keeping forge_credentials free of any link dependency on

--- a/src/headers/forge_credentials.h
+++ b/src/headers/forge_credentials.h
@@ -71,13 +71,6 @@ int forge_cred_count(void);
 char **forge_cred_build_env(const char *workspace_id, long now_epoch, char *const *parent_environ,
                             const char *askpass_shim);
 
-/* As forge_cred_build_env but with the token supplied directly (e.g. resolved
- * from a `webuser:` vault rather than the in-memory broker — webchat-git WP-C).
- * Same env shape + free contract. The caller wipes its own `token` copy. Returns
- * NULL if `token` is empty/NULL. */
-char **forge_cred_build_env_from_token(const char *token, char *const *parent_environ,
-                                       const char *askpass_shim);
-
 /* Free an envp returned by forge_cred_build_env (frees each entry, then the
  * array; zeroes the GH_TOKEN entry first so the secret does not linger). */
 void forge_cred_free_env(char **envp);

--- a/src/mcp_git_query.c
+++ b/src/mcp_git_query.c
@@ -10,7 +10,7 @@
 #include "headers/util.h"
 #include "headers/workspace_provider.h"
 #include "headers/forge_credentials.h"
-#include "headers/git_host_resolve.h"
+#include "headers/git_cred_inject.h"
 #include <time.h>
 
 extern char **environ;
@@ -85,25 +85,24 @@ char *mcp_git_run(const char *cmd, int *exit_code)
       char wsid[MAX_PATH_LEN];
       if (cwd && forge_workspace_for_cwd(cwd, wsid, sizeof(wsid)) == 0)
       {
-         /* One credential, GH_TOKEN + the GIT_ASKPASS shim: a client-handed
-          * per-workspace broker token (§4) wins, else the per-host vault token
-          * for the checkout's `origin`, else the server's own forge identity
-          * (§6); no credential → fall through to ambient (co-located dev's creds). */
-         char tok[4096];
-         char **envp = NULL;
+         /* Resolve the git credential through the ONE policy
+          * (git_cred_inject_build_env_for_repo) so the precedence never drifts
+          * from the other call sites: a client-handed per-workspace broker token
+          * (§4) is passed as preferred_token and wins, else per-host server vault
+          * → server identity → ambient. The policy injects GH_TOKEN + the
+          * GIT_ASKPASS shim and wipes its own token copy. */
+         char tok[4096] = {0};
+         const char *pref = NULL;
          if (forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
-            envp = forge_cred_build_env_from_token(tok, environ, forge_cred_askpass_shim());
-         else if (git_host_resolve_token(NULL, cwd, tok, sizeof(tok)) == 1)
-            envp = forge_cred_build_env_from_token(tok, environ, forge_cred_askpass_shim());
-         else
-            envp = forge_cred_build_server_env(environ, forge_cred_askpass_shim());
+            pref = tok;
+         char **envp = git_cred_inject_build_env_for_repo(NULL, NULL, cwd, pref, environ);
          volatile char *p = (volatile char *)tok;
          for (size_t i = 0; i < sizeof(tok); i++)
             p[i] = 0;
          if (envp)
          {
             char *out = run_cmd_env(cmd, envp, exit_code);
-            forge_cred_free_env(envp);
+            git_cred_inject_free_env(envp);
             return out;
          }
       }

--- a/src/server/workspace_turn.c
+++ b/src/server/workspace_turn.c
@@ -5,7 +5,7 @@
 #include "workspace_turn.h"
 #include "config.h"
 #include "forge_credentials.h"
-#include "git_host_resolve.h"
+#include "git_cred_inject.h"
 #include "log.h"
 #include "platform_path.h"
 #include "util.h"
@@ -71,17 +71,17 @@ static int ws_mirror_git_runner(void *ctx, const char *const args[], char *out, 
       argv[n++] = args[i];
    argv[n] = NULL;
 
-   /* One credential, GH_TOKEN + the GIT_ASKPASS shim: the workspace's brokered
-    * forge token (§4) wins, else the per-host vault token for the remote's host,
-    * else the server identity (§6); none → ambient via the shared provider. */
-   char tok[4096];
-   char **envp = NULL;
+   /* Resolve the git credential through the ONE policy
+    * (git_cred_inject_build_env_for_repo) so the precedence never drifts from the
+    * other call sites: the workspace's brokered forge token (§4) is passed as
+    * preferred_token and wins, else per-host server vault → server identity →
+    * ambient. The policy injects GH_TOKEN + the GIT_ASKPASS shim and wipes its
+    * own token copy. */
+   char tok[4096] = {0};
+   const char *pref = NULL;
    if (wsid && wsid[0] && forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
-      envp = forge_cred_build_env_from_token(tok, environ, forge_cred_askpass_shim());
-   else if (git_host_resolve_token(remote, NULL, tok, sizeof(tok)) == 1)
-      envp = forge_cred_build_env_from_token(tok, environ, forge_cred_askpass_shim());
-   else
-      envp = forge_cred_build_server_env(environ, forge_cred_askpass_shim());
+      pref = tok;
+   char **envp = git_cred_inject_build_env_for_repo(NULL, remote, NULL, pref, environ);
    {
       volatile char *p = (volatile char *)tok;
       for (size_t i = 0; i < sizeof(tok); i++)
@@ -93,7 +93,7 @@ static int ws_mirror_git_runner(void *ctx, const char *const args[], char *out, 
    if (envp)
    {
       rc = safe_exec_capture_env(argv, envp, &cap, out_cap ? out_cap : 4096);
-      forge_cred_free_env(envp);
+      git_cred_inject_free_env(envp);
    }
    else
    {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1058,7 +1058,7 @@ $(TESTPREFIX)/unit-test-server-compute: $(OBJDIR)/tests/test_server_compute.o $(
                                $(OBJDIR)/aimee_home.o \
                                $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                                $(OBJDIR)/platform_random.o $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o $(OBJDIR)/server/presence.o $(OBJDIR)/server/turn_registry.o $(OBJDIR)/tests/support/agent_cancel_stub.o $(OBJDIR)/delivery_target.o \
-                               $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/server/workspace_provider_detached.o \
+                               $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/server/workspace_provider_detached.o \
                                $(OBJDIR)/server/workspace_runner_registry.o $(OBJDIR)/server/workspace_runner_queue.o \
                                $(OBJDIR)/workspace_mirror.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o \
                                $(OBJDIR)/posix/workspace_provider.o $(OBJDIR)/json_fluent.o
@@ -1205,7 +1205,7 @@ $(TESTPREFIX)/unit-test-trace-analysis: $(OBJDIR)/tests/test_trace_analysis.o $(
 
 $(TESTPREFIX)/unit-test-cmd-branch: $(OBJDIR)/tests/test_cmd_branch.o $(OBJDIR)/cmd_branch.o \
                            $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
-                           $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
+                           $(OBJDIR)/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
                            $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1214,7 +1214,7 @@ $(TESTPREFIX)/unit-test-cmd-core: $(OBJDIR)/tests/test_cmd_core.o $(TEST_DATA_OB
                          $(OBJDIR)/cmd_util.o $(OBJDIR)/cmd_work.o \
                          $(OBJDIR)/cmd_infra.o \
                          $(OBJDIR)/cmd_init.o \
-                         $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
+                         $(OBJDIR)/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
                          $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1226,7 +1226,7 @@ $(TESTPREFIX)/unit-test-cmd-work: $(OBJDIR)/tests/test_cmd_work.o $(TEST_DATA_OB
 $(TESTPREFIX)/unit-test-client-integrations: $(OBJDIR)/tests/test_client_integrations.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
+$(TESTPREFIX)/unit-test-mcp-git: $(OBJDIR)/tests/test_mcp_git.o $(OBJDIR)/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
                         $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o \
                         $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o \
                         $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
@@ -1459,7 +1459,7 @@ $(TESTPREFIX)/unit-test-cmd-doctor: $(OBJDIR)/tests/test_cmd_doctor.o $(OBJDIR)/
                             $(OBJDIR)/cmd_util.o $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
                             $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/code_collect.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o $(OBJDIR)/cli_client.o $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o \
-                            $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
+                            $(OBJDIR)/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
                             $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1470,7 +1470,7 @@ $(TESTPREFIX)/unit-test-cmd-onboard: $(OBJDIR)/tests/test_cmd_onboard.o \
                             $(DB2_OBJS) \
                             $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA) \
                             $(OBJDIR)/client_integrations.o $(OBJDIR)/db1/secrets.o \
-                            $(OBJDIR)/mcp_git_query.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
+                            $(OBJDIR)/mcp_git_query.o $(OBJDIR)/tests/support/git_cred_inject_stub.o $(OBJDIR)/forge_credentials.o $(OBJDIR)/server/git_host_resolve.o $(OBJDIR)/mcp_git_write.o \
                             $(OBJDIR)/mcp_git_branch.o $(OBJDIR)/mcp_git_pr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
@@ -1543,7 +1543,7 @@ $(TESTPREFIX)/unit-test-workspace-runner-registry: \
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-workspace-turn: $(OBJDIR)/tests/test_workspace_turn.o \
-                      $(OBJDIR)/server/workspace_turn.o \
+                      $(OBJDIR)/server/workspace_turn.o $(OBJDIR)/tests/support/git_cred_inject_stub.o \
                       $(OBJDIR)/server/workspace_provider_detached.o \
                       $(OBJDIR)/server/workspace_runner_registry.o \
                       $(OBJDIR)/server/workspace_runner_queue.o \

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -1,0 +1,35 @@
+/* git_cred_inject_stub.c: no-op stub of the ONE git-credential policy, for tests
+ * that link mcp_git_query.o / workspace_turn.o (which now resolve creds through
+ * git_cred_inject_build_env_for_repo) but exercise only routing / turn logic, not
+ * real credential injection. Returning NULL means "no credential" → the caller
+ * falls through to the ambient/shared-provider exec path, which is exactly what
+ * these tests want. Binaries that need the real behaviour
+ * (unit-test-git-cred-inject / -git-ops / -git-project) link the real object and
+ * must NOT also link this TU. */
+#include "git_cred_inject.h"
+
+#include <stddef.h>
+
+char **git_cred_inject_build_env_for_repo(const char *principal, const char *remote_url,
+                                          const char *repo_dir, const char *preferred_token,
+                                          char *const *parent_environ)
+{
+   (void)principal;
+   (void)remote_url;
+   (void)repo_dir;
+   (void)preferred_token;
+   (void)parent_environ;
+   return NULL;
+}
+
+char **git_cred_inject_build_env(const char *principal, char *const *parent_environ)
+{
+   (void)principal;
+   (void)parent_environ;
+   return NULL;
+}
+
+void git_cred_inject_free_env(char **envp)
+{
+   (void)envp;
+}


### PR DESCRIPTION
Packet **P2** of [autonomous-dev-execution-substrate](docs/proposals/pending/autonomous-dev-execution-substrate.md) §2.

## What & why

Aimee handles git/forge credentials **centrally**. `git_cred_inject_build_env_for_repo` is *"the ONE credential-resolution policy every git network op routes through, so the precedence can never drift between call sites"* (precedence: preferred/broker → per-host server vault → webuser vault → server identity; injects `GH_TOKEN` + `GIT_ASKPASS`, wipes the token). `git_ops.c` / `git_project.c` / `webuser_editor.c` already route through it.

But **two call sites bypassed it** and hand-rolled their own ladder (`broker → git_host_resolve_token → forge_cred_build_server_env`) — drifting from the policy (they omit the webuser rung) and leaving no single point to audit/extend:
- `mcp_git_run` (`mcp_git_query.c`) — the executor for **every `gh pr create`/`gh pr merge`** plus clone/fetch/push
- `ws_mirror_git_runner` (`workspace_turn.c`) — the workspace-mirror git runner

**No downstream caller should resolve a token.** This routes both through the one policy (broker token as `preferred_token`) and deletes the ladders.

## Behaviour

Identical: `broker → per-host vault → server identity → ambient`. The rung mappings are exact (`mcp_git_run`: `git_host_resolve_token(NULL, cwd)`; `ws_mirror`: `git_host_resolve_token(remote, NULL)`). `principal=NULL` keeps it equivalent — the webuser-vault and ssh-agent rungs short-circuit on a NULL principal (wiring a real turn principal, to additionally honour a webchat user's own vaulted token, is a deliberate follow-up). The child's `GH_TOKEN` is an independent `strdup` in the policy, so the caller's `tok` wipe + the policy's own wipe can't blank it.

## Lock-in

`scripts/check-git-cred-centralized.py` (in `make lint`, with `--plant-test`) **fails** if any source file outside the policy calls a credential-ladder primitive — permanently enforcing "Aimee handles git creds centrally; no downstream caller resolves a token." Scans 759 files, all clean.

## Cleanup / scope

- Removes the now-unreferenced `forge_cred_build_env_from_token` (zero refs).
- `forge_cred_build_server_env` / `forge_cred_build_env` are now production-dead (test-only). The guard prevents production misuse; their removal (plus the static `build_env_from_token` and their test fixtures) is a **separable dead-code sweep**, kept out of this refactor.
- Test seam: a no-op `git_cred_inject` stub for the tests that link the two runners but don't exercise credential injection.

## Verification

- Server build green (`-Werror`, LTO link).
- Full `make unit-tests` green (incl. `mcp-git`, `workspace-turn`, `server-compute`, `git-cred-inject`, `forge-credentials`, `git-ops`).
- Full `make -C src lint` green, including the new `check-git-cred-centralized` gate.

Premise-drift the proposal text should be corrected on (noted in the plan, no code change): §2 describes the push gap as open (closed by #605) and names `vault_service_get_server_wrap` for the server's own token — that's the webuser dual-wrap accessor; the server identity is read via `vault_service_get_server_principal` (see `git_host_cred.c`). Audit + work-item attribution + branch policy stay with the driver packet (P4), where the one policy is now the single place to hook them.