### PR TITLE
docs(proposal): reconcile autonomous-dev-execution-substrate against the tree

### DIFF
--- a/docs/proposals/pending/autonomous-dev-execution-substrate.md
+++ b/docs/proposals/pending/autonomous-dev-execution-substrate.md
@@ -2,6 +2,61 @@
 
 - **State:** **APPROVED** (human proposal-gate passed 2026-06-21) — implementing,
   phased (see the companion `.plan.md`).
+- **Implementation status (2026-06-23) — reconciled against the tree.** This
+  proposal was drafted in a webchat workspace that had **no toolchain** and was
+  **unaware of two subsystems that already implement its core**. Grounding it
+  against the real `aimee` checkout (which *does* carry `make`/`gcc`/`clang-format-19`/
+  `psql`) shows most of the substrate already exists; the named blockers were
+  largely **environmental**, not missing code. Per-component status:
+  - **§1 build-and-verify runner — ALREADY IMPLEMENTED.** `aimee git verify`
+    (`git_verify.c` / `git_verify_ops.c`) is the callable verify gate: it
+    **auto-generates** `.aimee/project.yaml` from the project's Makefile on first
+    run (`find_makefile_subdir` detects aimee's `src/Makefile`; it prefers a
+    `verify-local` target — which aimee defines as `lint check-linking` +
+    `unit-tests`), runs the steps **dependency-aware** with
+    per-step pass/fail + timing, gates push/PR via `verify_gate_blocks`
+    (already wired into `mcp_git_write.c` + `guardrails_orchestrator.c`, `enforce`
+    flag, tree-hash freshness so squash/rebase stays verified). When no `verify:`
+    section exists it **degrades to a no-op gate** (`verify_check` returns 1 = no
+    gate; push allowed) — safe for humans, but the proposal's stricter
+    `unavailable` *status* (so the autonomous driver never reads "unconfigured" as a
+    pass, and a structured `{tier,step,status,log_ref}` shape) is **part of the
+    residual**, alongside the **ephemeral sandboxed runner image** (Docker) + the
+    managed/ephemeral *provisioning* abstraction. What exists today: the gate, the
+    Makefile auto-config, dependency-aware step execution, per-step pass/fail. What
+    does not: the structured driver-facing contract + the sandboxed runner.
+    (Blocker 1 "no in-environment build/verify" was the webchat workspace lacking a
+    toolchain, not a missing gate.)
+  - **§2 vault-backed forge push + PR — DONE.** `git_cred_inject_build_env_for_repo`
+    is the single credential policy every git op routes through (vault-first:
+    broker → per-host server vault → webuser vault → server identity; injects
+    `GH_TOKEN` + `GIT_ASKPASS`); push was centralised in #605 and the last two
+    drifted call sites (`mcp_git_run`, `ws_mirror_git_runner`) in **PR #641 (P2,
+    testing `af0418d`)**, now guarded by `scripts/check-git-cred-centralized.py`.
+    Blocker 2's "git_push ignores the vault / manual token decryption" is closed.
+    Residual: **per-PR audit attribution to the work item** — a §2-scope item, but it
+    needs the driver's work-item context, so it lands with the driver packet (P4).
+  - **§4 machine-checkable acceptance — schema gate SHIPPED (PR #639, P1, testing
+    `c412f23`).** `scripts/check-proposal-reconcile.py` parses + validates the
+    `acceptance:` block (`id`/`tier`/`check`, tiers, unique id) in `make lint`.
+    Residual: **executing** each check on its tier + the all-green **auto-file to
+    `done/`** (needs §1's runner + §3 dispatch).
+  - **§5 proposal↔code reconciliation — detection SHIPPED (PR #639, P1, testing
+    `c412f23`).** The same `scripts/check-proposal-reconcile.py` flags state↔folder
+    drift (shipped-but-unfiled) + premise-drift, report-only. Residual: the
+    **active** auto-file/move (P5), gated on machine-acceptance.
+  - **§3 validation tiers + deployment harness — OPEN.** The `mechanical`/
+    `integration` tier is `aimee git verify`; the **`deployment`/`hardware` CI-matrix
+    dispatch** (trigger + gate on the Actions matrix) and the tier router are the
+    real new work, and need CI/Docker the agent host can't supply.
+
+  **Net:** §2 done; §1 core + §4-schema + §5-detection done (this run + #639/#641);
+  the open work is the **integration** — CI-matrix dispatch (§3), per-tier
+  acceptance *execution* + auto-file (§4/§5), the ephemeral sandboxed runner image
+  (§1), and wiring these into the `full-autonomous-development` driver (§5/criterion 5)
+  — all **deployment/CI/Docker-tier**, deferred to an environment that can exercise
+  them. The prose below is the original proposal, kept for context; read it through
+  this status.
 - **Scope:** deterministic / autonomous-dev plumbing. Not an intelligence-surface
   proposal (no Architecture Charter role). It is the execution substrate that
   [full-autonomous-development.md](full-autonomous-development.md) assumes but does

--- a/docs/proposals/pending/autonomous-dev-execution-substrate.plan.md
+++ b/docs/proposals/pending/autonomous-dev-execution-substrate.plan.md
@@ -24,16 +24,22 @@ facts pin the sequencing:
 
 ## Packet sequence
 
-| Packet | Component | New infra? | In-env verifiable? |
-|--------|-----------|------------|--------------------|
-| **P1** | §5 reconciler (static core) + §4 acceptance-block schema | none | **fully** |
-| P2 | §2 finish: forge vtable `open`/`merge` vault + audit | none | unit + stub |
-| P3 | §1 build-and-verify runner (ephemeral + managed modes) | runner image/CT | partial (managed mode locally) |
-| P4 | §3 validation tiers + CI-dispatch harness | CI dispatch | partial (dispatch unit-testable) |
-| P5 | §4 full per-tier acceptance evaluation + §5 auto-file shipped-but-unfiled | P3+P4 | integration |
+| Packet | Component | Status |
+|--------|-----------|--------|
+| **P1** | §5 reconciler (static core) + §4 acceptance-block schema | **SHIPPED #639** |
+| **P2** | §2 — route every git op through the one credential policy + guard | **SHIPPED #641** |
+| ~~P3~~ | §1 build-and-verify runner | **mostly pre-existing** — `aimee git verify` (see proposal Implementation-status §1); residual = ephemeral sandboxed runner **image** (Docker) only |
+| P4 | §3 `deployment`/`hardware` CI-matrix **dispatch** + tier router + per-PR audit attribution | OPEN — needs CI/Docker the agent host can't supply |
+| P5 | §4 per-tier acceptance **execution** + §5 **active** auto-file to `done/` + wire into the full-autonomous-development driver | OPEN — depends on P3-image + P4 |
 
-P1 is the only packet detailed here; later packets get their own plan revision once P1's
-reconciler makes the tree's real drift visible (it may re-scope P2–P5).
+**Re-scoped after the P1 reconciler + a hands-on grounding pass (2026-06-23).** The
+reconciler (P1) and three operator corrections surfaced that §1 (`aimee git verify`) and
+§2 (`git_cred_inject`) **already existed** — the proposal's "blockers" were the webchat
+workspace's missing toolchain, not missing code. So P3 collapses to a Docker-only residual
+and the remaining open work (P4/P5) is the **deployment/CI integration** that genuinely
+needs an environment able to dispatch the Actions matrix and stand up sandboxed runners.
+Those packets get their own plan revision in such an environment. See the proposal's
+**Implementation status** block for the per-component grounding.
 
 ---
 


### PR DESCRIPTION
Applies P1's reconciler philosophy to its own parent proposal: ground it against the real codebase instead of building things that already exist.

## Why

The proposal was drafted in a webchat workspace with **no toolchain** and **unaware of two subsystems that already implement its core**. Three hands-on corrections this session (and the P1 reconciler) surfaced that its "blockers" were largely **environmental**, not missing code.

## Per-component grounding (added as an Implementation-status block, with PR SHAs + gate paths)

| § | Proposal claim | Reality |
|---|---|---|
| **§1** build-and-verify runner | "no in-environment build/verify" | **`aimee git verify`** (`git_verify.c`) — auto-configs from `src/Makefile` (prefers `verify-local` = `lint check-linking` + `unit-tests`), runs steps dependency-aware, gates push/PR (`verify_gate_blocks`). Core done; residual = structured driver contract + **ephemeral sandboxed runner image** (Docker). |
| **§2** vault forge push/PR | "git_push ignores the vault" | **`git_cred_inject`** one-policy (#605) + **P2** (#641, `af0418d`). Done; residual = per-PR audit attribution (→ P4). |
| **§4** acceptance | new | schema gate **shipped P1** (#639, `c412f23`); residual = per-tier *execution* + auto-file. |
| **§5** reconciler | new | drift/state detection **shipped P1** (#639); residual = *active* auto-file. |
| **§3** validation tiers | new | the `deployment`/`hardware` **CI-matrix dispatch** is the real new work — needs CI/Docker. |

## What this PR does / doesn't

- **Does:** add the Implementation-status block (grounded, SHA/path-anchored), correct the degrade claim (no `verify:` section = no-op gate, not the structured `unavailable` the proposal wants — that's residual), re-scope the plan's packet table (P3 → Docker-only residual; P4/P5 = the deployment/CI integration).
- **Doesn't:** change any code, or move the proposal to `done` — the integration residual (§3 dispatch, §4-execution, §5-autofile, ephemeral runner, driver wiring) is real and **deployment/CI/Docker-tier**, deferrable only to an environment that can exercise it.

Roundtable-reviewed (replay contradicted the substantive doubts; applied its hardening — SHAs/paths + the degrade-claim precision). `check-proposal-reconcile` + `check-proposal-links` lint gates pass; the reconciler even dogfood-flagged an imprecise `Makefile` reference in my own draft, now fixed to `src/Makefile`.