### PR TITLE
feat(db2): EMBED_MAX_DIM 4000 + model-identity drift guard (unified-llm P1)

### DIFF
--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -74,6 +74,56 @@ void db2_set_embedding_dim_pinned(int pinned)
    g_embed_dim_pinned = pinned ? 1 : 0;
 }
 
+/* Model-identity drift guard (unified-llm-container §2). A dim-only guard is
+ * insufficient: two different models can share a dim (pplx-embed and the default
+ * Qwen3-Embedding-0.6B are BOTH 1024-d), so a same-dim swap would silently mix
+ * incompatible vector spaces. These globals carry the configured embedder model
+ * identity (repo@sha), the reranker identity + scoring contract, and the
+ * compat-list of admitted transitions, set from config before db2_init like the
+ * dim above. ALL DEFAULT EMPTY: an empty embedder model_id makes the guard a
+ * no-op, so a deployment that has not yet adopted the unified container (the live
+ * torch embedder reports no identity) is unaffected. */
+static char g_embedder_model_id[160] = "";
+static char g_reranker_model_id[160] = "";
+static char g_reranker_contract[96] = "";
+static char g_embedding_compat[1024] = ""; /* CSV of "old_id->new_id" transitions */
+
+void db2_set_embedder_model_id(const char *model_id)
+{
+   snprintf(g_embedder_model_id, sizeof(g_embedder_model_id), "%s", model_id ? model_id : "");
+}
+
+const char *db2_embedder_model_id(void)
+{
+   return g_embedder_model_id;
+}
+
+void db2_set_reranker_identity(const char *model_id, const char *contract)
+{
+   snprintf(g_reranker_model_id, sizeof(g_reranker_model_id), "%s", model_id ? model_id : "");
+   snprintf(g_reranker_contract, sizeof(g_reranker_contract), "%s", contract ? contract : "");
+}
+
+const char *db2_reranker_model_id(void)
+{
+   return g_reranker_model_id;
+}
+
+const char *db2_reranker_contract(void)
+{
+   return g_reranker_contract;
+}
+
+void db2_set_embedding_compat(const char *compat_csv)
+{
+   snprintf(g_embedding_compat, sizeof(g_embedding_compat), "%s", compat_csv ? compat_csv : "");
+}
+
+const char *db2_embedding_compat(void)
+{
+   return g_embedding_compat;
+}
+
 int db2_effective_dim(int pinned, int configured, int recorded)
 {
    if (pinned)
@@ -425,6 +475,24 @@ int db2_init(const char *libpq_url)
       return -1;
    }
 
+   /* unified-llm-container §2: model-identity drift guard, applied here (where the
+    * configured identity globals live) rather than in the lower db_schema layer.
+    * Record/check the EMBEDDER model identity alongside the dim — closing the
+    * same-dim different-model footgun (two models can share a dim) — and record
+    * the reranker identity. Both no-op when the identity is unset (the legacy
+    * torch embedder reports none), so existing deployments are unaffected; they
+    * activate when the unified container supplies the identity via the setters. */
+   if (db2_embedding_model_record_or_check(conn, g_embedder_model_id, g_embedding_compat, errbuf,
+                                           sizeof(errbuf)) != 0 ||
+       db2_reranker_model_record(conn, g_reranker_model_id, g_reranker_contract, errbuf,
+                                 sizeof(errbuf)) != 0)
+   {
+      fprintf(stderr, "aimee: db2_init: model-identity guard failed: %s\n", errbuf);
+      aimee_pg_close(conn);
+      pthread_mutex_unlock(&g_init_lock);
+      return -1;
+   }
+
    /* pg_trgm is required: db2/schema.sql creates a GIN index on
     * memories.memories_code_fts_text using gin_trgm_ops, and the
     * memory_query path issues % / similarity() against memory text.
@@ -668,6 +736,10 @@ void db2_shutdown(void)
     * real caller sets it again via db2_set_embedding_dim before the next init. */
    g_embed_dim = 0;
    g_embed_dim_pinned = 0;
+   g_embedder_model_id[0] = '\0';
+   g_reranker_model_id[0] = '\0';
+   g_reranker_contract[0] = '\0';
+   g_embedding_compat[0] = '\0';
    pthread_mutex_unlock(&g_init_lock);
 }
 

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -196,6 +196,184 @@ int db2_embedding_dim_get(void *conn)
    return dim;
 }
 
+/* True if compat_csv (a comma-separated list of "old_id->new_id" transitions)
+ * admits the transition old_id -> new_id. Whitespace around tokens is trimmed.
+ * unified-llm-container §2: a compat-list entry only EXISTS once an operator has
+ * validated the upgrade (cosine >= 0.99 on a fixed probe set vs the prior model,
+ * or a same-repo retrain); this function checks membership, the validation is the
+ * admission criterion for adding the entry. */
+static int compat_admits(const char *compat_csv, const char *old_id, const char *new_id)
+{
+   if (!compat_csv || !*compat_csv || !old_id || !new_id)
+      return 0;
+   const char *p = compat_csv;
+   while (*p)
+   {
+      while (*p == ',' || *p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+         p++;
+      const char *entry = p;
+      while (*p && *p != ',' && *p != '\n' && *p != '\r')
+         p++;
+      const char *entry_end = p; /* [entry, entry_end) is one CSV token */
+      const char *arrow = entry;
+      while (arrow + 1 < entry_end && !(arrow[0] == '-' && arrow[1] == '>'))
+         arrow++;
+      if (arrow + 1 < entry_end && arrow[0] == '-' && arrow[1] == '>')
+      {
+         /* trim spaces around each side */
+         const char *ls = entry, *le = arrow;
+         while (ls < le && (*ls == ' ' || *ls == '\t'))
+            ls++;
+         while (le > ls && (le[-1] == ' ' || le[-1] == '\t'))
+            le--;
+         const char *rs = arrow + 2, *re = entry_end;
+         while (rs < re && (*rs == ' ' || *rs == '\t'))
+            rs++;
+         while (re > rs && (re[-1] == ' ' || re[-1] == '\t'))
+            re--;
+         if ((size_t)(le - ls) == strlen(old_id) && strncmp(ls, old_id, (size_t)(le - ls)) == 0 &&
+             (size_t)(re - rs) == strlen(new_id) && strncmp(rs, new_id, (size_t)(re - rs)) == 0)
+            return 1;
+      }
+   }
+   return 0;
+}
+
+/* Read kb_meta[key] into out[outlen] (out[0]='\0' if absent). Returns 0 on
+ * success (incl. absent), -1 on DB/prepare error. */
+static int kb_meta_get(void *conn, const char *key, char *out, size_t outlen)
+{
+   if (out && outlen)
+      out[0] = '\0';
+   char err[256] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, "SELECT value FROM kb_meta WHERE key = ?1", err, sizeof(err));
+   if (!st)
+      return -1;
+   if (aimee_pg_bind_text(st, "?1", key) != 0)
+   {
+      aimee_pg_finalize(st);
+      return -1;
+   }
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *v = aimee_pg_column_text(st, 0);
+      if (v && out && outlen)
+         snprintf(out, outlen, "%s", v);
+   }
+   aimee_pg_finalize(st);
+   return 0;
+}
+
+/* Upsert kb_meta[key] = value (overwriting). Returns 0 / -1. */
+static int kb_meta_set(void *conn, const char *key, const char *value)
+{
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn,
+                                          "INSERT INTO kb_meta (key, value) VALUES (?1, ?2)"
+                                          " ON CONFLICT (key) DO UPDATE SET value = ?2",
+                                          err, sizeof(err));
+   if (!st)
+      return -1;
+   if (aimee_pg_bind_text(st, "?1", key) != 0 || aimee_pg_bind_text(st, "?2", value) != 0)
+   {
+      aimee_pg_finalize(st);
+      return -1;
+   }
+   aimee_pg_step_t step = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   return (step == AIMEE_PG_DONE || step == AIMEE_PG_ROW) ? 0 : -1;
+}
+
+/* unified-llm-container §2: record/check the EMBEDDER model identity (repo@sha)
+ * alongside the dim, so a same-dim different-model swap (pplx-embed 1024 ↔
+ * Qwen3-0.6B 1024) is refused rather than silently mixing vector spaces.
+ *   - model_id NULL/empty   -> no-op (return 0): a deployment whose embedder
+ *     reports no identity (the legacy torch embedder) is unaffected.
+ *   - kb_meta.schema_embedder_model_id absent or == model_id -> record / match.
+ *   - recorded != model_id, transition admitted by compat_csv -> update + 0.
+ *   - recorded != model_id, not admitted -> refuse (-1, remediation set).
+ * Keyed re-embed triggers on a model_id change (the migration, §Migration). */
+int db2_embedding_model_record_or_check(void *conn, const char *model_id, const char *compat_csv,
+                                        char *errbuf, size_t errlen)
+{
+   if (!conn)
+      return -1;
+   if (!model_id || !*model_id)
+      return 0; /* identity unknown -> guard is a no-op (back-compat) */
+
+   char recorded[160] = "";
+   if (kb_meta_get(conn, "schema_embedder_model_id", recorded, sizeof(recorded)) != 0)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "kb_meta read failed for schema_embedder_model_id");
+      return -1;
+   }
+   if (!recorded[0])
+   {
+      if (kb_meta_set(conn, "schema_embedder_model_id", model_id) != 0)
+      {
+         if (errbuf && errlen)
+            snprintf(errbuf, errlen, "kb_meta write failed for schema_embedder_model_id");
+         return -1;
+      }
+      return 0;
+   }
+   if (strcmp(recorded, model_id) == 0)
+      return 0; /* match */
+
+   if (compat_admits(compat_csv, recorded, model_id))
+   {
+      if (kb_meta_set(conn, "schema_embedder_model_id", model_id) != 0)
+      {
+         if (errbuf && errlen)
+            snprintf(errbuf, errlen, "kb_meta write failed promoting admitted embedder upgrade");
+         return -1;
+      }
+      return 0; /* admitted same-dim upgrade */
+   }
+
+   /* Kept concise so it survives the caller's conventional 256-byte errbuf after
+    * both ids are substituted (the full remediation lives in retrieval-stack.md). */
+   if (errbuf && errlen)
+      snprintf(
+          errbuf, errlen,
+          "embedder model mismatch: corpus '%s' vs configured '%s' (same dim != same vector "
+          "space). Re-embed the corpus or compat-list the transition (docs/retrieval-stack.md).",
+          recorded, model_id);
+   return -1;
+}
+
+/* unified-llm-container §2: record the RERANKER identity + scoring contract. The
+ * reranker writes no corpus vectors and there is no persisted score cache, so a
+ * swap is safe — this is record-only (drift observability), never a refusal. On a
+ * change it refreshes the recorded value (a future score cache would key its
+ * invalidation off this). model_id NULL/empty -> no-op. Returns 0 / -1 (DB err). */
+int db2_reranker_model_record(void *conn, const char *model_id, const char *contract, char *errbuf,
+                              size_t errlen)
+{
+   if (!conn)
+      return -1;
+   if (!model_id || !*model_id)
+      return 0;
+   const char *want_contract = contract ? contract : "";
+   /* Skip the writes when the recorded identity already matches, so a steady-state
+    * restart incurs no redundant kb_meta writes (mirrors the embedder short-circuit). */
+   char rec_id[160] = "", rec_contract[96] = "";
+   if (kb_meta_get(conn, "schema_reranker_model_id", rec_id, sizeof(rec_id)) == 0 &&
+       kb_meta_get(conn, "schema_reranker_contract", rec_contract, sizeof(rec_contract)) == 0 &&
+       strcmp(rec_id, model_id) == 0 && strcmp(rec_contract, want_contract) == 0)
+      return 0;
+   if (kb_meta_set(conn, "schema_reranker_model_id", model_id) != 0 ||
+       kb_meta_set(conn, "schema_reranker_contract", want_contract) != 0)
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "kb_meta write failed for reranker identity");
+      return -1;
+   }
+   return 0;
+}
+
 int db_apply_schema_postgres(void *pg_conn, int embed_dim, char *errbuf, size_t errlen)
 {
    if (!pg_conn)
@@ -222,7 +400,10 @@ int db_apply_schema_postgres(void *pg_conn, int embed_dim, char *errbuf, size_t 
    free(sql);
    if (rc != 0)
       return rc;
-   /* §2: record the dim on first apply / refuse a mismatch (kb_meta now exists). */
+   /* §2: record the dim on first apply / refuse a mismatch (kb_meta now exists).
+    * The unified-llm-container §2 model-identity guards (embedder + reranker) run
+    * in db2_init right after this, where the configured identity globals live —
+    * keeping this lower schema layer free of an upward dependency on them. */
    return db2_embedding_dim_record_or_check(pg_conn, embed_dim, errbuf, errlen);
 }
 

--- a/src/db2/db_schema.h
+++ b/src/db2/db_schema.h
@@ -43,6 +43,25 @@ extern "C"
     * sqlite shim. */
    int db2_embedding_dim_get(void *conn);
 
+   /* unified-llm-container §2: record/check the EMBEDDER model identity
+    * (repo@sha) in kb_meta.schema_embedder_model_id alongside the dim. A dim-only
+    * guard is insufficient (two models can share a dim — pplx-embed and
+    * Qwen3-0.6B are both 1024-d), so a same-dim swap would silently mix vector
+    * spaces. model_id NULL/empty -> no-op (legacy torch embedder reports no
+    * identity). compat_csv is a comma-separated list of admitted "old->new"
+    * transitions (membership only; the cosine>=0.99 validation is the operator's
+    * criterion for adding an entry). Returns 0 (recorded/match/admitted), -1
+    * (unadmitted mismatch / DB error, errbuf set). Called by
+    * db_apply_schema_postgres; exposed for direct testing. */
+   int db2_embedding_model_record_or_check(void *conn, const char *model_id, const char *compat_csv,
+                                           char *errbuf, size_t errlen);
+
+   /* unified-llm-container §2: record the RERANKER identity + scoring contract in
+    * kb_meta. Record-only (no corpus vectors, no persisted score cache to
+    * invalidate) — never refuses. model_id NULL/empty -> no-op. Returns 0 / -1. */
+   int db2_reranker_model_record(void *conn, const char *model_id, const char *contract,
+                                 char *errbuf, size_t errlen);
+
    /* Apply the consolidated SQLite schema for DB2's libpq shim/test
     * compatibility path. Production DB2 remains Postgres-only. */
    int db2_apply_schema_sqlite_shim(struct sqlite3 *db, char *errbuf, size_t errlen);

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -40,6 +40,22 @@ extern "C"
     * default.) */
    int db2_effective_dim(int pinned, int configured, int recorded);
 
+   /* Model-identity drift guard (unified-llm-container §2). Set from config
+    * before db2_init, beside db2_set_embedding_dim, so this layer stays
+    * config-free. ALL default empty -> the guard is a no-op (a deployment whose
+    * embedder reports no identity, e.g. the legacy torch embedder, is
+    * unaffected). The embedder model_id is repo@sha; the reranker carries its
+    * scoring contract (e.g. "/v1/rerank,fa=on"); compat_csv is a comma-separated
+    * list of admitted "old_id->new_id" transitions (see
+    * db2_embedding_model_record_or_check). Reset by db2_shutdown. */
+   void db2_set_embedder_model_id(const char *model_id);
+   const char *db2_embedder_model_id(void);
+   void db2_set_reranker_identity(const char *model_id, const char *contract);
+   const char *db2_reranker_model_id(void);
+   const char *db2_reranker_contract(void);
+   void db2_set_embedding_compat(const char *compat_csv);
+   const char *db2_embedding_compat(void);
+
    /* Connection-pool size used by db2_init (default 16). Like
     * db2_set_embedding_dim, call before db2_init to keep this layer config-free. */
    void db2_set_pool_size(int size);

--- a/src/headers/aimee.h
+++ b/src/headers/aimee.h
@@ -88,11 +88,14 @@
 #define EFFECTIVENESS_MIN_SAMPLES      10
 
 /* Embedding retrieval.
- * EMBED_MAX_DIM is the largest embedder output we buffer for: 2560 covers the
- * deep pplx-embed-v1-4b (2560-dim) as well as the default 0.6b (1024-dim). A
- * deployment runs ONE embedder; config.embedding_dim selects which, and the
- * DB2 halfvec columns are created at that dimension (see db2/schema.sql). */
-#define EMBED_MAX_DIM              2560
+ * EMBED_MAX_DIM is the largest embedder output we buffer for: 4000 covers the
+ * Qwen3-Embedding ladder (0.6b=1024, 4b=2560, 8b truncated 4096->4000) as well
+ * as the legacy pplx-embed (0.6b=1024 / 4b=2560). A deployment runs ONE embedder;
+ * config.embedding_dim selects which, and the DB2 halfvec columns are created at
+ * that dimension (see db2/schema.sql). 4000 is the pgvector halfvec INDEX ceiling
+ * (inclusive) — native 4096 would be unindexable, so the 8b tier truncates to
+ * 4000 in the embedding proxy (see unified-llm-container §"The 8B truncation"). */
+#define EMBED_MAX_DIM              4000
 #define EMBED_SIMILARITY_THRESHOLD 0.7
 #define EMBED_ALPHA                0.5 /* hybrid blend: alpha*lexical + (1-alpha)*embed */
 #define EMBED_MAX_OUTPUT           (EMBED_MAX_DIM * 16)

--- a/src/kb/kb_service_code_embed.c
+++ b/src/kb/kb_service_code_embed.c
@@ -5,6 +5,7 @@
  * directly. */
 
 #include "kb_service_code_embed.h"
+#include "aimee.h" /* EMBED_MAX_DIM */
 #include "db2/code_index_ops.h"
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
@@ -21,9 +22,11 @@
 
 #define CE_ERRBUF   256
 #define CE_TEXT_CAP 4096
-/* Upper bound on the embedding dimension we will buffer: 1024 for the default
- * 0.6B embedder, 2560 for the 4B deep tier. */
-#define CE_EMBED_MAX_DIM        2560
+/* Upper bound on the embedding dimension we will buffer. Tied to the global
+ * EMBED_MAX_DIM (4000 — the pgvector halfvec index ceiling) so the code-embed
+ * buffer + cap track the embed ladder (0.6B=1024 / 4B=2560 / 8B-trunc=4000) and
+ * never silently reject or overflow a larger-dim model. */
+#define CE_EMBED_MAX_DIM        EMBED_MAX_DIM
 #define CE_FALLBACK_MAX_CALLS   5
 #define CE_FALLBACK_MAX_IMPORTS 5
 

--- a/src/tests/test_db2.c
+++ b/src/tests/test_db2.c
@@ -83,6 +83,32 @@ int db2_embedding_dim_get(void *pg_conn)
    return g_recorded_dim;
 }
 
+/* unified-llm-container §2: db2_init now also calls the model-identity guards
+ * (db_schema.o, not linked here). Stub them as no-ops (the real guards likewise
+ * no-op on the empty identity these tests run with), so db2_init's apply path is
+ * unchanged. */
+int db2_embedding_model_record_or_check(void *pg_conn, const char *model_id, const char *compat_csv,
+                                        char *errbuf, size_t errlen)
+{
+   (void)model_id;
+   (void)compat_csv;
+   (void)errbuf;
+   (void)errlen;
+   assert(pg_conn == &g_fake_conn);
+   return 0;
+}
+
+int db2_reranker_model_record(void *pg_conn, const char *model_id, const char *contract,
+                              char *errbuf, size_t errlen)
+{
+   (void)model_id;
+   (void)contract;
+   (void)errbuf;
+   (void)errlen;
+   assert(pg_conn == &g_fake_conn);
+   return 0;
+}
+
 void aimee_log(log_level_t level, const char *module, const char *fmt, ...)
 {
    (void)level;

--- a/src/tests/test_embedding_dim.c
+++ b/src/tests/test_embedding_dim.c
@@ -104,6 +104,94 @@ int main(void)
    /* NULL conn -> 0. */
    assert(db2_embedding_dim_get(NULL) == 0);
 
+   /* ---- EMBED_MAX_DIM bumped to 4000 (unified-llm-container §"8B truncation"):
+    * a 4000-d dim now records cleanly (was rejected when the cap was 2560). ---- */
+   assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedding_dim'", err,
+                        sizeof err) == 0);
+   err[0] = '\0';
+   assert(db2_embedding_dim_record_or_check(conn, 4000, err, sizeof err) == 0);
+   assert(db2_embedding_dim_get(conn) == 4000);
+
+   /* ================= unified-llm-container §2: model-identity drift guard ====== */
+   /* No-op when the embedder reports no identity (the legacy torch embedder). */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, NULL, NULL, err, sizeof err) == 0);
+   assert(db2_embedding_model_record_or_check(conn, "", NULL, err, sizeof err) == 0);
+
+   /* Fresh record, then a matching check is a no-op. */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "Qwen/Qwen3-Embedding-0.6B@abc", NULL, err,
+                                              sizeof err) == 0);
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "Qwen/Qwen3-Embedding-0.6B@abc", NULL, err,
+                                              sizeof err) == 0);
+
+   /* The same-dim DIFFERENT-model swap is REFUSED (the footgun: pplx-embed and
+    * Qwen3-0.6B are both 1024-d, so a dim-only guard would miss this). */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "perplexity-ai/pplx-embed-v1-0.6b", NULL, err,
+                                              sizeof err) == -1);
+   assert(err[0] != '\0');
+   assert(strstr(err, "Qwen/Qwen3-Embedding-0.6B@abc") != NULL); /* names recorded */
+   assert(strstr(err, "pplx-embed") != NULL);                    /* and configured */
+   /* The refusal did not change the recorded identity. */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "Qwen/Qwen3-Embedding-0.6B@abc", NULL, err,
+                                              sizeof err) == 0);
+
+   /* A transition on the compat-list is ADMITTED (operator-validated cosine>=0.99)
+    * and updates the recorded identity. Whitespace + multiple entries tolerated. */
+   const char *compat =
+       " other->x , Qwen/Qwen3-Embedding-0.6B@abc -> Qwen/Qwen3-Embedding-0.6B@def ";
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "Qwen/Qwen3-Embedding-0.6B@def", compat, err,
+                                              sizeof err) == 0);
+   /* Now the recorded id is @def; the old @abc would itself be a mismatch. */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "Qwen/Qwen3-Embedding-0.6B@abc", NULL, err,
+                                              sizeof err) == -1);
+   /* A compat entry that doesn't match the actual transition does NOT admit. */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "totally/different@ghi", "a->b,c->d", err,
+                                              sizeof err) == -1);
+
+   /* compat_admits edge cases (via the public guard; recorded id is @def now).
+    * Malformed entries (no arrow, empty side) are silently skipped (not admitted);
+    * newline-separated entries are tolerated. */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(conn, "Qwen/Qwen3-Embedding-0.6B@xyz",
+                                              "no_arrow_here, ->, -> , a-->b", err,
+                                              sizeof err) == -1); /* none admit */
+   err[0] = '\0';
+   assert(db2_embedding_model_record_or_check(
+              conn, "Qwen/Qwen3-Embedding-0.6B@xyz",
+              "junk->junk\nQwen/Qwen3-Embedding-0.6B@def->Qwen/Qwen3-Embedding-0.6B@xyz", err,
+              sizeof err) == 0); /* newline-separated entry admits */
+
+   /* Reranker identity is record-only (no corpus vectors / no score cache): a
+    * swap never refuses, and the recorded value tracks the latest. */
+   err[0] = '\0';
+   assert(db2_reranker_model_record(conn, NULL, NULL, err, sizeof err) == 0); /* no-op */
+   assert(db2_reranker_model_record(conn, "ettin-reranker-400m@v1", "/v1/rerank,fa=on", err,
+                                    sizeof err) == 0);
+   assert(db2_reranker_model_record(conn, "ettin-reranker-68m@v1", "/v1/rerank,fa=on", err,
+                                    sizeof err) == 0); /* swap is fine */
+   {
+      char rr[160];
+      assert(aimee_pg_exec(conn, "SELECT 1", err, sizeof err) == 0); /* conn ok */
+      aimee_pg_stmt_t *st =
+          aimee_pg_prepare(conn, "SELECT value FROM kb_meta WHERE key = 'schema_reranker_model_id'",
+                           err, sizeof err);
+      assert(st && aimee_pg_step(st, err, sizeof err) == AIMEE_PG_ROW);
+      snprintf(rr, sizeof rr, "%s", aimee_pg_column_text(st, 0));
+      aimee_pg_finalize(st);
+      assert(strcmp(rr, "ettin-reranker-68m@v1") == 0);
+   }
+
+   /* NULL conn -> -1 for both guards. */
+   assert(db2_embedding_model_record_or_check(NULL, "x", NULL, err, sizeof err) == -1);
+   assert(db2_reranker_model_record(NULL, "x", "y", err, sizeof err) == -1);
+
    db2_test_shim_close();
    printf("ok\n");
    return 0;


### PR DESCRIPTION
**Packet P1** of [unified-llm-container](docs/proposals/pending/unified-llm-container.md) — the dim/identity foundation every later packet rests on. Pure C, **fully in-env verifiable** (no Docker/GPU needed).

## What

- **`EMBED_MAX_DIM` 2560 → 4000** — the pgvector `halfvec` *index* ceiling (native 4096 is unindexable; the 8B tier truncates 4096→4000 in the embedding proxy). Tied **`CE_EMBED_MAX_DIM`** (the code-embed cap + `float vec[...]` stack buffer) to it so a larger-dim model is never silently rejected or overflowed. Audited the tree: no other embedding buffer hard-codes 2560 (`KB_DEFAULT_DIM` is a default collection size, not a cap; the two `char[2560]` are an unrelated string buffer + HTTP payload).
- **Model-identity drift guard** — a dim-only guard is insufficient: `pplx-embed` and `Qwen3-Embedding-0.6B` are **both 1024-d**, so a same-dim swap would silently mix incompatible vector spaces.
  - `db2_embedding_model_record_or_check` records `kb_meta.schema_embedder_model_id` and **refuses** a same-dim different-model swap; an operator-validated transition on the compat-list (admitted once cosine ≥ 0.99 vs the prior model) is allowed.
  - `db2_reranker_model_record` records the reranker identity + scoring contract (record-only — no corpus vectors, no score cache — skipping redundant writes per init).
  - Called from **`db2_init`** (which owns the identity statics) right after the schema applies — **not** from the lower `db_schema` layer, so there's no upward dependency.

## Safety / scope

The guard is a **no-op when the embedder reports no identity** — the **live torch embedder reports none**, so this is safe to ship to `testing` now (no path newly refuses). **Activation** (config/gateway supplying the identity via `db2_set_embedder_model_id`) lands with the gateway packet (P3/P4) that actually knows the model; P1 ships the mechanism + the full test surface.

## Verification

- Full `make unit-tests` green (extended `test_embedding_dim` covers: 4000-d records; model record/match; **same-dim different-model refused**; compat admit + edge cases — no-arrow / empty-side / newline-separated; reranker record-only + isolation; NULL-conn).
- `make lint` green; clean build (`-Werror`, LTO).
- Roundtable-reviewed; folded: concise refusal message (fits the 256-byte `errbuf`), newline-tolerant compat CSV, reranker skip-if-unchanged, compat edge-case tests. (The "blocking" parser-OOB / range / injection items were replay-contradicted — params are bound, the arrow deref is guarded, the range check uses `EMBED_MAX_DIM`.)