### PR TITLE
docs(unified-llm): P2 .254 Vulkan serving validation + reranker recipe

### DIFF
--- a/benchmarks/results/unified-llm/P2-serving-validation.md
+++ b/benchmarks/results/unified-llm/P2-serving-validation.md
@@ -1,0 +1,63 @@
+# Unified-llm P2 — `.254` Vulkan serving validation (2026-06-23)
+
+Empirical validation of the unified-llm-container model serving on **`.254`**
+(AMD Radeon RX 7900 XTX, RADV/**Vulkan** 1.4.305, 32c/157 GB), llama.cpp build
+**b9761**. Confirms the embedder + reranker decisions before the container is built.
+
+## Embedder — Qwen3-Embedding (Vulkan, `--embeddings --pooling last`)
+
+Serving flags (the proposal's required config): `--ctx-size 8192 -ub 512 -np 1
+--cache-ram 0 --no-cache-idle-slots -ngl 99`.
+
+| model (GGUF) | output dim | Vulkan | crash w/ flags |
+|---|---|---|---|
+| `Qwen/Qwen3-Embedding-0.6B-GGUF` (f16) | **1024** | ✅ RADV NAVI31 | none |
+| `Qwen/Qwen3-Embedding-4B-GGUF` (Q8_0) | **2560** | ✅ | none |
+
+Dims match the proposal (0.6B=1024, 4B=2560). No `GGML_ASSERT(task)` prompt-cache
+fragmentation with `--cache-ram 0 --no-cache-idle-slots`. `-ub 512` honours the RADV
+per-buffer limit.
+
+## Reranker — Ettin (the decisive finding)
+
+**Ettin reranks via llama.cpp as ENCODER + a gateway-side Dense head — NOT native
+`/v1/rerank`.** `cross-encoder/ettin-reranker-{400m,68m}-v1` are sentence-transformers
+models (`config.json` arch `ModernBertModel`, `num_labels:None`); the score head is the ST
+pipeline (`modules.json`): Pooling → `2_Dense` (1024→1024, GELU) → `3_LayerNorm` →
+`4_Dense` (1024→**1**). `convert_hf_to_gguf.py` (even with
+`--sentence-transformers-dense-modules`) does **not** carry this multi-Dense head, so a
+naive GGUF is encoder-only and **misranks**. (Community GGUFs like
+`keisuke-miyako/ettin-reranker-v1-gguf`, tagged `feature-extraction`, are this headless
+encoder — do not use.)
+
+**Working recipe (validated):**
+1. Convert the encoder: `convert_hf_to_gguf.py models/ettin-reranker-400m-v1 --outtype f16`.
+2. Serve: `llama-server -m ettin-400m.gguf --embeddings --pooling cls -fa on -ngl 99`.
+3. Gateway, per `(query, doc)`: `v = /v1/embeddings("query</s>doc")` (1024-d, CLS) →
+   `h = GELU(v @ W2ᵀ)` → `h = LayerNorm(h; γ=norm.weight, β=norm.bias)` →
+   `score = h @ W4ᵀ + b4`. Head ≈ 4 MB (`2_Dense`/`3_LayerNorm`/`4_Dense` safetensors),
+   pure numpy, **no torch**. The LayerNorm (`norm.weight`/`norm.bias`) is essential.
+
+Toy-gate scores (relevant vs irrelevant; higher = more relevant):
+
+| model | SciFact (cardiac claim) | Code (python sort) |
+|---|---|---|
+| **ettin-400m** (GPU) | **8.93** vs 1.10 ✅ | **9.21** vs −1.58 ✅ |
+| **ettin-68m** (CPU)  | **8.26** vs 5.19 ✅ | **10.09** vs 1.07 ✅ |
+| bge-reranker-v2-m3 (ref) | 0.50 vs −10.99 ✅ | 5.61 vs −10.93 ✅ |
+
+Both ettin tiers rank correctly with confident separation. `-fa on` is required on this
+Vulkan build (the prior LATENCY.md: ettin-400m top-20 0.34s with FA vs 0.76s without).
+
+## Synth
+
+The gemma synth GGUFs (E4B / 12B / 26B-A4B) are already on `.254`
+(`/mnt/.../synthbench/models/`) from the curator-synth benchmark (RESULTS.md); not re-run
+here.
+
+## Implication for the container
+
+llama.cpp serves all three roles; the **reranker's Dense head runs in the gateway** (P3) —
+the only non-llama.cpp compute, ~4 MB of weights, baked into the image alongside the
+encoder GGUF. Models are **baked into two images** (`aimee-llm-cpu` / `aimee-llm-gpu`,
+operator-directed) rather than runtime-fetched. Recipe + convert env recorded for reuse.

--- a/docs/proposals/pending/unified-llm-container.md
+++ b/docs/proposals/pending/unified-llm-container.md
@@ -9,6 +9,28 @@
   reranker to Ettin ModernBERT — 400m GPU / 68m CPU, both `-fa on`, Qwen3-Reranker
   dropped from the real-time path; E4B-ungated CPU default). See "Decisions
   taken" and "Changelog".
+- **Implementation update (2026-06-23) — P2 `.254` Vulkan serving validation
+  (see [`benchmarks/results/unified-llm/P2-serving-validation.md`](../../../benchmarks/results/unified-llm/P2-serving-validation.md)).**
+  Two design refinements from empirical validation on the 7900XTX:
+  1. **Reranker is served as ENCODER + a gateway-side Dense head, not native
+     `/v1/rerank`.** `cross-encoder/ettin-reranker-{400m,68m}-v1` are
+     sentence-transformers models whose score head (`2_Dense`→GELU→`3_LayerNorm`→
+     `4_Dense`→1) does **not** survive `convert_hf_to_gguf.py` — a naive GGUF is
+     encoder-only and misranks. The validated path: llama.cpp serves the ettin
+     encoder (`/v1/embeddings --pooling cls` on `query</s>doc`), and the gateway
+     applies the ~4 MB Dense head (pure numpy, no torch). Ettin reranks correctly +
+     confidently this way (400m: relevant 8.9 vs irrelevant 1.1). So §2's "native
+     ModernBERT `/v1/rerank`" is amended to "ettin encoder on llama.cpp + the
+     gateway's reranker handler applies the head."
+  2. **Models are BAKED into two images (`aimee-llm-cpu` / `aimee-llm-gpu`), not
+     runtime-fetched** (operator-directed). This supersedes the
+     embedder-runtime-fetch-once posture for this container: each image ships its
+     tier's GGUFs (CPU: Qwen3-Emb-0.6B + ettin-68m encoder + head + gemma-E4B; GPU:
+     Qwen3-Emb-4B + ettin-400m encoder + head + gemma-12B). Turnkey, reproducible,
+     no HF dependency at runtime. The §5 install-time GPU **detection** still selects
+     which image/tier; the four modes (local/forward/external) are unchanged.
+  Embedder validated: Qwen3-Emb-0.6B→1024, 4B→2560 on Vulkan with the required
+  serving flags (no `GGML_ASSERT` crash). Build pin: llama.cpp **b9761**.
 - **Author:** JBailes
 - **Date:** 2026-06-21
 - **Base:** `testing`. Today there are **two** model containers: a torch /

--- a/docs/proposals/pending/unified-llm-container.plan.md
+++ b/docs/proposals/pending/unified-llm-container.plan.md
@@ -60,10 +60,10 @@ Every packet states which tier verifies it. Nothing GPU- or cutover-tier is auto
 
 | # | Packet | Verifies on |
 |---|--------|-------------|
-| **P1** | **Dim foundation** — `EMBED_MAX_DIM 2560→4000`; extend the drift guard to `(model_id, dim)` for embedder **and** `(model_id, scoring-contract)` for reranker; the `schema_embedding_dim_compat` admission rule | **in-env** (C + unit) |
-| **P2** | **`.254` serving validation (Vulkan)** — run Qwen3-Embedding-0.6B/4B GGUF + Ettin-400m/68m on `.254` GPU via the **Vulkan** llama.cpp build with the pinned flags; confirm dims, `/v1/rerank` correctness + `-fa on`, the no-prompt-cache flags; record a checked-in fixture (`tests/fixtures/pplx_baseline.json` + serving-config hashes) | **.254** (empirical) |
-| **P3** | **Gateway rework** — decompose `embedder-server.py` → router / per-role handlers / wire-adapters (reuse `provider_client`) / child-supervisor shim / observability; `/embed`,`/embed_batch`(512-cap→413),`/rerank`,`/v1/chat/completions`(`stream=true`→typed 400), four-state `/health/{embed,rerank,synth}` | **in-env** (logic unit) + **.254** (against live llama-servers) |
-| **P4** | **`Dockerfile.aimee-llm` (CPU + Vulkan) + compose collapse** — one image (Vulkan llama.cpp + s6 + gateway); delete `Dockerfile.embedder` + the `embedder`/`llm` services → one `aimee-llm` (per-child mem limits, `/dev/dri` GPU passthrough, mTLS) | **CI** (image build + CPU smoke tests) + **.254** (tierd LXC deploy, Vulkan) |
+| **P1** | **Dim foundation** — `EMBED_MAX_DIM 2560→4000`; `(model_id, dim)` embedder + `(model_id, scoring-contract)` reranker drift guard; compat admission rule | **SHIPPED #644** |
+| **P2** | **`.254` Vulkan serving validation** — Qwen3-Emb-0.6B/4B (→1024/2560, flags OK) + Ettin-400m/68m rerank validated; the **reranker recipe = encoder GGUF + gateway Dense head** (native `/v1/rerank` can't carry the ST head); results in `benchmarks/results/unified-llm/P2-serving-validation.md` | **DONE (.254, b9761)** |
+| **P3** | **Gateway rework** — decompose `embedder-server.py` → router / handlers / wire-adapters (reuse `provider_client`) / child-supervisor / observability; `/embed`,`/embed_batch`(512→413),**`/rerank` = embed(CLS) + the ettin Dense head (numpy)**, `/v1/chat/completions`(`stream`→typed 400), four-state health | **in-env** (logic unit) + **.254** |
+| **P4** | **Two BAKED images `aimee-llm-cpu` / `aimee-llm-gpu`** (Vulkan llama.cpp + s6 + gateway + **tier GGUFs + the ettin head weights baked in**); delete `Dockerfile.embedder` + the `embedder`/`llm` services | **CI** (build + CPU smoke) + **.254** (tierd LXC) |
 | **P5** | **`install.sh` GPU detection + model registry/sizing** — detect a GPU + VRAM (sysfs/`rocm-smi`/`nvidia-smi`/`lspci`) → pick the **single Vulkan build** for any vendor (CPU is the explicit final branch); VRAM→registry-row, startup VRAM validation + `gated` state, sizing table + load-order CI test | in-env (logic) + **.254** (AMD/Vulkan branch) |
 | **P6** | **§1a security hardening** — mTLS default + bind-`0.0.0.0` startup assertion, derived `X-Aimee-Scope` RBAC, per-user cred pass-through (`mlock`+memmove zero, no-swap/no-core), circuit breakers, audit row + escape-hatch lint | in-env (unit) + CI (canary/memory-scrape) |
 | **P7** | **Migration / ship-floor gate / cutover** — controlled drop-and-rebuild re-embed, `maintenance`-gate + parity, ship-floor ≥95% (rerank+fusion vs pplx fixture) **pre-cutover in staging on .254**, deploy-tag-revert net | **.254** (live corpus) — operator-gated |
@@ -145,6 +145,15 @@ De-risks every model decision before the gateway/container is built. On `.254`, 
 (`embed`/`embed_batch`/`rerank`/`synth`) · `wire_adapters` (llama.cpp `/v1/*` ↔ aimee
 `/embed`+`/rerank`; openai/anthropic via `provider_client` semantics) · `child_supervisor`
 (shim over s6; mockable) · `observability` (corr-id, per-role/mode metrics, audit row).
+
+- **Rerank handler = encoder embed + the ettin Dense head (P2 finding).** The `/rerank`
+  handler does NOT proxy a native `/v1/rerank` (the ST head doesn't convert). For each
+  `(query, doc)`: call the local ettin **encoder** llama-server `/v1/embeddings`
+  (`query</s>doc`, CLS pooling, batched over the candidate set), then apply the baked-in
+  head `score = (GELU(v @ W2ᵀ) → LayerNorm(γ,β)) @ W4ᵀ + b4` in numpy (~4 MB weights loaded
+  once at startup from the image). Returns the aimee `/rerank` shape. Unit-tested with a
+  recorded encoder-output fixture (no model) asserting the head reproduces the P2 toy-gate
+  scores; `.254`-validated against the live ettin encoder.
 
 - **Pure-logic unit tests (in-env, no model):** mode table (`local-cpu|local-gpu|forward|
   external`) per role; `/embed_batch` **512-cap → 413**; `stream=true` → typed


### PR DESCRIPTION
**Packet P2** of [unified-llm-container](docs/proposals/pending/unified-llm-container.md) — empirical model-serving validation on **.254** (AMD 7900 XTX, **Vulkan**/RADV, llama.cpp **b9761**). Results: `benchmarks/results/unified-llm/P2-serving-validation.md`.

## Validated
- **Embedder** — `Qwen3-Embedding-0.6B`→**1024**, `4B`→**2560** on Vulkan, with the required `--ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots`; no `GGML_ASSERT(task)` prompt-cache crash.
- **Reranker (Ettin)** — the decisive finding. `cross-encoder/ettin-reranker-{400m,68m}-v1` are **sentence-transformers** models; their score head (`2_Dense`→GELU→`3_LayerNorm`→`4_Dense`→1) **doesn't survive `convert_hf_to_gguf.py`** (even with `--sentence-transformers-dense-modules`), so a naive GGUF is encoder-only and **misranks**. **Working recipe:** llama.cpp serves the ettin **encoder** (`/v1/embeddings --pooling cls` on `query</s>doc`); the **gateway** applies the ~4 MB Dense head in numpy (no torch). Ettin then reranks correctly + confidently:

  | model | SciFact | Code |
  |---|---|---|
  | ettin-400m | 8.93 vs 1.10 ✅ | 9.21 vs −1.58 ✅ |
  | ettin-68m | 8.26 vs 5.19 ✅ | 10.09 vs 1.07 ✅ |

## Two design refinements (folded into proposal + plan)
1. **Reranker = encoder + gateway-side Dense head**, not native `/v1/rerank`. The P3 `/rerank` handler embeds the pair and applies the head.
2. **Models baked into two images** (`aimee-llm-cpu` / `aimee-llm-gpu`), not runtime-fetched (operator-directed) — turnkey, reproducible, no HF runtime dependency.

Docs-only (validation record + proposal/plan updates). P1 shipped (#644); P3 (gateway, incl. the rerank-head handler) is next.