### PR TITLE
feat(aimee-llm): ettin reranker scoring head for the llama.cpp gateway (P3a)

### DIFF
--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -8,12 +8,14 @@ on:
     paths:
       - 'scripts/aimee_llm_*.py'
       - 'scripts/tests/test_rerank_head.py'
+      - 'scripts/tests/test_gateway.py'
       - '.github/workflows/gateway-tests.yml'
   push:
     branches: [testing, main]
     paths:
       - 'scripts/aimee_llm_*.py'
       - 'scripts/tests/test_rerank_head.py'
+      - 'scripts/tests/test_gateway.py'
 
 jobs:
   gateway-unit:
@@ -25,5 +27,7 @@ jobs:
           python-version: '3.12'
       - name: Install numpy + safetensors
         run: pip install --quiet numpy safetensors
-      - name: Rerank-head unit tests
-        run: python -m unittest discover -s scripts/tests -p 'test_rerank_head.py' -v
+      - name: Gateway unit tests (rerank head + request logic)
+        run: |
+          python -m unittest discover -s scripts/tests -p 'test_rerank_head.py' -v
+          python -m unittest discover -s scripts/tests -p 'test_gateway.py' -v

--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -1,0 +1,29 @@
+# Unit tests for the aimee-llm gateway's numpy components (the ettin reranker head).
+# Separate from the stdlib-only bench-smoke unittest step because these need numpy +
+# safetensors (present in the aimee-llm container; installed here for CI).
+name: gateway-tests
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/aimee_llm_*.py'
+      - 'scripts/tests/test_rerank_head.py'
+      - '.github/workflows/gateway-tests.yml'
+  push:
+    branches: [testing, main]
+    paths:
+      - 'scripts/aimee_llm_*.py'
+      - 'scripts/tests/test_rerank_head.py'
+
+jobs:
+  gateway-unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install numpy + safetensors
+        run: pip install --quiet numpy safetensors
+      - name: Rerank-head unit tests
+        run: python -m unittest discover -s scripts/tests -p 'test_rerank_head.py' -v

--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""aimee-llm gateway — the retrieval surface of the unified llama.cpp container.
+
+Preserves the embedder-server contract (so embed-remote.py / rerank-remote.py / the kb
+config / AIMEE_EMBEDDER_URL are untouched):
+
+  POST /embed        body = raw UTF-8 text                 -> JSON float array (dim)
+  POST /embed_batch  body = JSON [text, ...]               -> JSON [[float,...], ...]
+  POST /rerank       body = JSON [[query, candidate], ...] -> JSON [float, ...]
+  GET  /health       -> {"status": ok|loading|down, "model":..., "dim":N}
+
+…but the backend is **llama.cpp**, not torch/sentence-transformers:
+  - /embed[_batch] proxy to the embedder llama-server `/v1/embeddings`.
+  - /rerank embeds `query</s>candidate` on the ETTIN ENCODER llama-server `/v1/embeddings`
+    (CLS pooling) and applies the EttinRerankHead (the ST Dense head, numpy) — see
+    aimee_llm_rerank_head.py and benchmarks/results/unified-llm/P2-serving-validation.md.
+
+Config (env):
+  AIMEE_LLM_EMBED_URL     embedder llama-server base (default http://127.0.0.1:8081)
+  AIMEE_LLM_RERANK_URL    ettin-encoder llama-server base (default http://127.0.0.1:8082)
+  AIMEE_LLM_RERANK_HEAD   dir with 2_Dense/3_LayerNorm/4_Dense safetensors (the head)
+  AIMEE_LLM_EMBED_MODEL   embedder model id (for /health + the (model_id,dim) drift guard)
+  AIMEE_LLM_PORT          listen port (default 8080)
+  AIMEE_LLM_BATCH_CAP     /embed_batch max vectors per call (default 512 -> 413 on excess)
+
+The router/modes (local/forward/external) and synth (/v1/chat/completions) land in a
+follow-up; this module is the retrieval gateway + the validated rerank-head path.
+"""
+import json
+import os
+import urllib.request
+
+EMBED_URL = os.environ.get("AIMEE_LLM_EMBED_URL", "http://127.0.0.1:8081").rstrip("/")
+RERANK_URL = os.environ.get("AIMEE_LLM_RERANK_URL", "http://127.0.0.1:8082").rstrip("/")
+RERANK_HEAD_DIR = os.environ.get("AIMEE_LLM_RERANK_HEAD", "")
+EMBED_MODEL = os.environ.get("AIMEE_LLM_EMBED_MODEL", "Qwen3-Embedding")
+PORT = int(os.environ.get("AIMEE_LLM_PORT", "8080"))
+BATCH_CAP = int(os.environ.get("AIMEE_LLM_BATCH_CAP", "512"))
+RERANK_SEP = "</s>"
+
+
+class GatewayError(Exception):
+    """Carries an HTTP status + a typed error body."""
+
+    def __init__(self, status, code, message):
+        super().__init__(message)
+        self.status = status
+        self.body = {"error": {"code": code, "message": message}}
+
+
+def _http_post_json(url, payload, timeout=120):
+    data = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(url, data=data, headers={"content-type": "application/json"})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def _embeddings(base_url, inputs):
+    """Call a llama-server `/v1/embeddings`; return a list of float vectors aligned to
+    `inputs` (a str or list[str])."""
+    one = isinstance(inputs, str)
+    body = _http_post_json(f"{base_url}/v1/embeddings", {"input": inputs, "model": "e"})
+    vecs = [row["embedding"] for row in body["data"]]
+    return vecs[0] if one else vecs
+
+
+# ---- pure request logic (stdlib-only; unit-tested without a model) ----
+
+def validate_batch(texts, cap=BATCH_CAP):
+    """Validate an /embed_batch payload. Raises GatewayError(400/413). Returns the list."""
+    if not isinstance(texts, list):
+        raise GatewayError(400, "bad_request", "embed_batch expects a JSON array of strings")
+    if len(texts) > cap:
+        raise GatewayError(
+            413, "batch_too_large", f"{len(texts)} inputs exceeds the per-call cap of {cap}"
+        )
+    return texts
+
+
+def parse_rerank_pairs(obj):
+    """Validate a /rerank payload ([[query, candidate], ...]). Raises GatewayError(400)."""
+    if not isinstance(obj, list):
+        raise GatewayError(400, "bad_request", "rerank expects a JSON array of [query, candidate]")
+    pairs = []
+    for p in obj:
+        if not (isinstance(p, (list, tuple)) and len(p) == 2):
+            raise GatewayError(400, "bad_request", "each rerank item must be [query, candidate]")
+        pairs.append((str(p[0]), str(p[1])))
+    return pairs
+
+
+def health_state(child_oks):
+    """Aggregate per-child readiness into the gateway status. `child_oks` maps role ->
+    bool|None (None = not configured). ready iff every configured child is up."""
+    configured = {k: v for k, v in child_oks.items() if v is not None}
+    if not configured:
+        return "loading"
+    return "ok" if all(configured.values()) else "down"
+
+
+# ---- handlers (call llama.cpp; the rerank head is the validated P2 path) ----
+
+_head = None
+
+
+def _rerank_head():
+    global _head
+    if _head is None:
+        if not RERANK_HEAD_DIR:
+            raise GatewayError(503, "rerank_unconfigured", "AIMEE_LLM_RERANK_HEAD is not set")
+        from aimee_llm_rerank_head import EttinRerankHead
+
+        _head = EttinRerankHead.from_dir(RERANK_HEAD_DIR)
+    return _head
+
+
+def do_embed(text):
+    return _embeddings(EMBED_URL, text)
+
+
+def do_embed_batch(texts):
+    validate_batch(texts)
+    return _embeddings(EMBED_URL, list(texts)) if texts else []
+
+
+def do_rerank(obj):
+    """[[query, candidate], ...] -> [score, ...] (aligned to input order). Embeds each
+    `query</s>candidate` on the ettin encoder and applies the Dense head."""
+    pairs = parse_rerank_pairs(obj)
+    if not pairs:
+        return []
+    head = _rerank_head()
+    texts = [f"{q}{RERANK_SEP}{c}" for q, c in pairs]
+    vecs = _embeddings(RERANK_URL, texts)
+    scores = head.score(vecs)  # numpy array aligned to input order
+    return [float(s) for s in (scores if hasattr(scores, "__len__") else [scores])]
+
+
+def child_health():
+    """Probe the configured llama-server children. Returns role -> bool|None."""
+    out = {"embed": None, "rerank": None}
+    for role, base in (("embed", EMBED_URL), ("rerank", RERANK_URL if RERANK_HEAD_DIR else None)):
+        if not base:
+            continue
+        try:
+            with urllib.request.urlopen(f"{base}/health", timeout=3) as r:
+                out[role] = r.status == 200
+        except Exception:  # noqa: BLE001
+            out[role] = False
+    return out
+
+
+def build_server():
+    from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, *a):  # quiet
+            pass
+
+        def _send(self, code, payload):
+            body = json.dumps(payload).encode("utf-8")
+            self.send_response(code)
+            self.send_header("content-type", "application/json")
+            self.send_header("content-length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def do_GET(self):
+            if self.path.rstrip("/") == "/health":
+                st = health_state(child_health())
+                self._send(200 if st == "ok" else 503, {"status": st, "model": EMBED_MODEL})
+            else:
+                self._send(404, {"error": "not found"})
+
+        def do_POST(self):
+            path = self.path.rstrip("/")
+            n = int(self.headers.get("content-length", "0") or "0")
+            raw = self.rfile.read(n) if n else b""
+            try:
+                if path == "/embed":
+                    text = raw.decode("utf-8", errors="replace")
+                    if not text.strip():
+                        raise GatewayError(400, "bad_request", "empty input")
+                    self._send(200, do_embed(text))
+                elif path == "/embed_batch":
+                    self._send(200, do_embed_batch(json.loads(raw or b"[]")))
+                elif path == "/rerank":
+                    self._send(200, do_rerank(json.loads(raw or b"[]")))
+                else:
+                    self._send(404, {"error": "not found"})
+            except GatewayError as ge:
+                self._send(ge.status, ge.body)
+            except Exception as exc:  # noqa: BLE001
+                self._send(500, {"error": {"code": "internal", "message": str(exc)}})
+
+    return ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+
+
+def main():  # pragma: no cover
+    import sys
+
+    srv = build_server()
+    sys.stderr.write(f"aimee-llm-gateway: :{PORT} embed={EMBED_URL} rerank={RERANK_URL}\n")
+    sys.stderr.flush()
+    srv.serve_forever()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/scripts/aimee_llm_rerank_head.py
+++ b/scripts/aimee_llm_rerank_head.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Ettin reranker scoring head — the sentence-transformers Dense head applied on
+top of the llama.cpp encoder output.
+
+unified-llm-container P2 finding (benchmarks/results/unified-llm/P2-serving-validation.md):
+`cross-encoder/ettin-reranker-{400m,68m}-v1` are sentence-transformers models whose
+relevance-score head is a module pipeline that does NOT survive `convert_hf_to_gguf.py`
+(a naive GGUF is encoder-only and misranks). So the unified container serves the ettin
+ENCODER on llama.cpp (`/v1/embeddings`, CLS pooling, on `query</s>doc`) and applies this
+small head in the gateway — pure numpy, no torch.
+
+Head (from the model's `modules.json`): pooled-CLS vector `v` (dim D) ->
+  2_Dense:    h = GELU(v @ W2^T)            (D -> D, no bias)
+  3_LayerNorm:h = (h - mean)/std * gamma + beta
+  4_Dense:    s = h @ W4^T + b4             (D -> 1)  => scalar relevance score
+
+Weights load from the model's sentence-transformers dirs (`2_Dense/`, `3_LayerNorm/`,
+`4_Dense/` safetensors); ~4 MB, baked into the image alongside the encoder GGUF.
+"""
+import os
+
+import numpy as np
+
+
+def gelu(x):
+    """Tanh-approx GELU (matches what the validated P2 head used)."""
+    return 0.5 * x * (1.0 + np.tanh(np.sqrt(2.0 / np.pi) * (x + 0.044715 * x * x * x)))
+
+
+def layer_norm(x, gamma, beta, eps=1e-5):
+    """LayerNorm over the last axis (sentence-transformers LayerNorm module)."""
+    mean = x.mean(axis=-1, keepdims=True)
+    std = x.std(axis=-1, keepdims=True)
+    return (x - mean) / (std + eps) * gamma + beta
+
+
+class EttinRerankHead:
+    """The 2_Dense -> 3_LayerNorm -> 4_Dense scoring head.
+
+    `W2` (D,D), `W4` (1,D) + `b4` (1,), `gamma`/`beta` (D,). `score()` takes one
+    encoder vector (or a batch, shape (N,D)) and returns the scalar score(s).
+    Construct via `from_dir()` (loads the ST safetensors) or directly with arrays
+    (for tests). The encoder vector is the CLS-pooled `/v1/embeddings` output for
+    `query</s>doc`.
+    """
+
+    def __init__(self, w2, w4, b4, gamma=None, beta=None):
+        self.W2 = np.asarray(w2, dtype=np.float32)
+        self.W4 = np.asarray(w4, dtype=np.float32)
+        self.b4 = np.float32(0.0 if b4 is None else np.asarray(b4, dtype=np.float32).reshape(-1)[0])
+        self.gamma = None if gamma is None else np.asarray(gamma, dtype=np.float32)
+        self.beta = None if beta is None else np.asarray(beta, dtype=np.float32)
+        if self.W2.ndim != 2 or self.W2.shape[0] != self.W2.shape[1]:
+            raise ValueError(f"W2 must be (D,D), got {self.W2.shape}")
+        if self.W4.shape[-1] != self.W2.shape[0]:
+            raise ValueError(f"W4 last dim {self.W4.shape} must match D={self.W2.shape[0]}")
+
+    @property
+    def dim(self):
+        return self.W2.shape[0]
+
+    @classmethod
+    def from_dir(cls, model_dir):
+        """Load the head from a sentence-transformers model dir (2_Dense/3_LayerNorm/
+        4_Dense/*.safetensors). Raises FileNotFoundError if the dense modules are absent
+        (i.e. this isn't an st-reranker dir)."""
+        from safetensors.numpy import load_file
+
+        d2 = load_file(os.path.join(model_dir, "2_Dense", "model.safetensors"))
+        d4 = load_file(os.path.join(model_dir, "4_Dense", "model.safetensors"))
+        ln_path = os.path.join(model_dir, "3_LayerNorm", "model.safetensors")
+        ln = load_file(ln_path) if os.path.exists(ln_path) else {}
+        return cls(
+            w2=d2["linear.weight"],
+            w4=d4["linear.weight"],
+            b4=d4.get("linear.bias"),
+            gamma=ln.get("norm.weight"),
+            beta=ln.get("norm.bias"),
+        )
+
+    def score(self, encoder_vec):
+        """Score one CLS vector (shape (D,)) or a batch (shape (N,D)). Returns a float
+        or a (N,) float array."""
+        v = np.asarray(encoder_vec, dtype=np.float32)
+        single = v.ndim == 1
+        if single:
+            v = v[None, :]
+        if v.shape[-1] != self.dim:
+            raise ValueError(f"encoder vec dim {v.shape[-1]} != head dim {self.dim}")
+        h = gelu(v @ self.W2.T)
+        if self.gamma is not None and self.beta is not None:
+            h = layer_norm(h, self.gamma, self.beta)
+        s = h @ self.W4.T + self.b4  # (N,1)
+        s = s.reshape(-1)
+        return float(s[0]) if single else s
+
+    def rerank(self, query, documents, embed_pairs, sep="</s>"):
+        """Rerank `documents` for `query`. `embed_pairs(list[str]) -> np.ndarray (N,D)`
+        is the caller's encoder embed function (the llama.cpp `/v1/embeddings` CLS call
+        over `query<sep>doc`). Returns results sorted by descending score:
+        [{"index": i, "relevance_score": s}, ...]."""
+        if not documents:
+            return []
+        texts = [f"{query}{sep}{doc}" for doc in documents]
+        vecs = np.asarray(embed_pairs(texts), dtype=np.float32)
+        if vecs.ndim == 1:
+            vecs = vecs[None, :]
+        scores = self.score(vecs)
+        scores = np.atleast_1d(scores)
+        order = np.argsort(-scores)
+        return [{"index": int(i), "relevance_score": float(scores[i])} for i in order]

--- a/scripts/tests/test_gateway.py
+++ b/scripts/tests/test_gateway.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/aimee_llm_gateway.py — the gateway's pure request logic
+(validation, caps, typed errors, health aggregation), stdlib-only, plus a
+numpy-guarded do_rerank test against a mocked encoder. No model, no network.
+"""
+import importlib.util
+import os
+import unittest
+
+GW = os.path.join(os.path.dirname(__file__), "..", "aimee_llm_gateway.py")
+
+
+def _gw():
+    spec = importlib.util.spec_from_file_location("aimee_llm_gateway", GW)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+class BatchValidation(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_ok(self):
+        self.assertEqual(self.gw.validate_batch(["a", "b"], cap=512), ["a", "b"])
+
+    def test_not_a_list(self):
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.validate_batch("nope")
+        self.assertEqual(e.exception.status, 400)
+
+    def test_over_cap_413(self):
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.validate_batch(["x"] * 5, cap=4)
+        self.assertEqual(e.exception.status, 413)
+        self.assertEqual(e.exception.body["error"]["code"], "batch_too_large")
+
+
+class RerankParse(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_ok_coerces_str(self):
+        self.assertEqual(self.gw.parse_rerank_pairs([["q", 5]]), [("q", "5")])
+
+    def test_not_a_list(self):
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.parse_rerank_pairs({"q": "c"})
+        self.assertEqual(e.exception.status, 400)
+
+    def test_bad_item_shape(self):
+        for bad in ([["q"]], [["q", "c", "x"]], ["flat"]):
+            with self.assertRaises(self.gw.GatewayError):
+                self.gw.parse_rerank_pairs(bad)
+
+    def test_empty(self):
+        self.assertEqual(self.gw.parse_rerank_pairs([]), [])
+
+
+class HealthAggregation(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_loading_when_nothing_configured(self):
+        self.assertEqual(self.gw.health_state({"embed": None, "rerank": None}), "loading")
+
+    def test_ok_when_all_up(self):
+        self.assertEqual(self.gw.health_state({"embed": True, "rerank": True}), "ok")
+        self.assertEqual(self.gw.health_state({"embed": True, "rerank": None}), "ok")
+
+    def test_down_when_any_configured_child_down(self):
+        self.assertEqual(self.gw.health_state({"embed": True, "rerank": False}), "down")
+
+
+class RerankHandler(unittest.TestCase):
+    def setUp(self):
+        try:
+            import numpy  # noqa: F401
+        except ImportError:
+            self.skipTest("numpy required")
+        self.gw = _gw()
+
+    def test_do_rerank_aligned_to_input_order(self):
+        import numpy as np
+
+        head_dir = os.path.join(os.path.dirname(__file__), "..", "aimee_llm_rerank_head.py")
+        spec = importlib.util.spec_from_file_location("rerank_head", head_dir)
+        rh = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(rh)
+        # head: score == first component of GELU(v) (W2=I, no LN, W4 picks dim 0)
+        D = 4
+        W4 = np.zeros((1, D), np.float32)
+        W4[0, 0] = 1.0
+        self.gw._head = rh.EttinRerankHead(np.eye(D, dtype=np.float32), W4, None)
+        self.gw.RERANK_HEAD_DIR = "x"  # non-empty so the head isn't re-loaded
+
+        captured = {}
+
+        def fake_embed(base, texts):
+            captured["base"] = base
+            captured["texts"] = texts
+            # encode the candidate's "relevance" in the first component
+            vals = {"hot": 9.0, "cold": -3.0, "warm": 1.0}
+            return np.array([[vals[t.split("</s>")[1]], 0, 0, 0] for t in texts], np.float32)
+
+        self.gw._embeddings = fake_embed
+        scores = self.gw.do_rerank([["q", "hot"], ["q", "cold"], ["q", "warm"]])
+        # /rerank returns scores ALIGNED to input order (not sorted)
+        self.assertEqual(len(scores), 3)
+        self.assertGreater(scores[0], scores[2])  # hot > warm
+        self.assertGreater(scores[2], scores[1])  # warm > cold
+        self.assertEqual(captured["texts"], ["q</s>hot", "q</s>cold", "q</s>warm"])
+        self.assertEqual(captured["base"], self.gw.RERANK_URL)
+
+    def test_do_rerank_empty(self):
+        self.assertEqual(self.gw.do_rerank([]), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_rerank_head.py
+++ b/scripts/tests/test_rerank_head.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/aimee_llm_rerank_head.py (the ettin gateway reranker head).
+
+Pure numpy — no model, no torch, no network. Verifies the head MATH against a hand
+reference, the rerank ordering, the from_dir safetensors loader, and edge cases.
+Skipped if numpy/safetensors are unavailable (the head runs inside the aimee-llm
+container, which has them; CI installs them for this test).
+"""
+import importlib.util
+import os
+import tempfile
+import unittest
+
+try:
+    import numpy as np
+
+    HAVE_NUMPY = True
+except ImportError:  # pragma: no cover
+    HAVE_NUMPY = False
+
+SCRIPT = os.path.join(os.path.dirname(__file__), "..", "aimee_llm_rerank_head.py")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("rerank_head", SCRIPT)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+@unittest.skipUnless(HAVE_NUMPY, "numpy required")
+class HeadMath(unittest.TestCase):
+    def setUp(self):
+        self.m = _load_module()
+
+    def test_gelu_layernorm_reference(self):
+        """Head reproduces an independent numpy reference for known weights."""
+        rng = np.random.default_rng(0)
+        D = 8
+        W2 = rng.standard_normal((D, D)).astype(np.float32)
+        W4 = rng.standard_normal((1, D)).astype(np.float32)
+        b4 = np.float32(0.25)
+        gamma = rng.standard_normal(D).astype(np.float32)
+        beta = rng.standard_normal(D).astype(np.float32)
+        head = self.m.EttinRerankHead(W2, W4, b4, gamma, beta)
+        v = rng.standard_normal(D).astype(np.float32)
+        # independent reference
+        h = self.m.gelu(v @ W2.T)
+        h = (h - h.mean()) / (h.std() + 1e-5) * gamma + beta
+        ref = float((h @ W4.T + b4).reshape(-1)[0])
+        self.assertAlmostEqual(head.score(v), ref, places=4)
+
+    def test_no_layernorm_path(self):
+        D = 4
+        W2 = np.eye(D, dtype=np.float32)
+        W4 = np.ones((1, D), dtype=np.float32)
+        head = self.m.EttinRerankHead(W2, W4, b4=None)  # gamma/beta None -> skip LN
+        v = np.array([1.0, 2.0, 3.0, 4.0], np.float32)
+        ref = float((self.m.gelu(v) @ W4.T).reshape(-1)[0])
+        self.assertAlmostEqual(head.score(v), ref, places=4)
+
+    def test_batch_matches_single(self):
+        rng = np.random.default_rng(1)
+        D = 6
+        head = self.m.EttinRerankHead(
+            rng.standard_normal((D, D)).astype(np.float32),
+            rng.standard_normal((1, D)).astype(np.float32),
+            np.float32(0.0),
+            rng.standard_normal(D).astype(np.float32),
+            rng.standard_normal(D).astype(np.float32),
+        )
+        vs = rng.standard_normal((5, D)).astype(np.float32)
+        batch = head.score(vs)
+        self.assertEqual(batch.shape, (5,))
+        for i in range(5):
+            self.assertAlmostEqual(float(batch[i]), head.score(vs[i]), places=4)
+
+    def test_dim_mismatch_raises(self):
+        head = self.m.EttinRerankHead(np.eye(4, dtype=np.float32), np.ones((1, 4), np.float32), None)
+        with self.assertRaises(ValueError):
+            head.score(np.zeros(3, np.float32))
+
+    def test_bad_shapes_raise(self):
+        with self.assertRaises(ValueError):
+            self.m.EttinRerankHead(np.zeros((4, 3), np.float32), np.ones((1, 4), np.float32), None)
+        with self.assertRaises(ValueError):
+            self.m.EttinRerankHead(np.eye(4, dtype=np.float32), np.ones((1, 5), np.float32), None)
+
+
+@unittest.skipUnless(HAVE_NUMPY, "numpy required")
+class Rerank(unittest.TestCase):
+    def setUp(self):
+        self.m = _load_module()
+
+    def _head(self, D=4):
+        # W2=I, no LN, W4 picks dim 0 — so score == GELU(v)[0]; a doc whose embed has
+        # a bigger first component ranks higher. Lets us control ordering in the test.
+        W4 = np.zeros((1, D), np.float32)
+        W4[0, 0] = 1.0
+        return self.m.EttinRerankHead(np.eye(D, dtype=np.float32), W4, None)
+
+    def test_rerank_orders_descending_and_uses_pairs(self):
+        head = self._head(4)
+        seen = {}
+
+        def embed_pairs(texts):
+            seen["texts"] = texts
+            # doc index encoded in first component: doc0 -> 0.1, doc1 -> 5.0, doc2 -> 1.0
+            firsts = {0: 0.1, 1: 5.0, 2: 1.0}
+            return np.array([[firsts[i], 0, 0, 0] for i in range(len(texts))], np.float32)
+
+        res = head.rerank("q", ["d0", "d1", "d2"], embed_pairs)
+        self.assertEqual([r["index"] for r in res], [1, 2, 0])  # by descending score
+        self.assertEqual(seen["texts"], ["q</s>d0", "q</s>d1", "q</s>d2"])  # pair format
+        self.assertGreater(res[0]["relevance_score"], res[1]["relevance_score"])
+
+    def test_empty_docs(self):
+        self.assertEqual(self._head().rerank("q", [], lambda t: None), [])
+
+    def test_single_doc(self):
+        head = self._head()
+        res = head.rerank("q", ["only"], lambda t: np.array([[2.0, 0, 0, 0]], np.float32))
+        self.assertEqual(len(res), 1)
+        self.assertEqual(res[0]["index"], 0)
+
+
+@unittest.skipUnless(HAVE_NUMPY, "numpy required")
+class FromDir(unittest.TestCase):
+    def test_load_from_safetensors_dir(self):
+        try:
+            from safetensors.numpy import save_file
+        except ImportError:
+            self.skipTest("safetensors required")
+        m = _load_module()
+        D = 5
+        rng = np.random.default_rng(2)
+        d = tempfile.mkdtemp()
+        os.makedirs(os.path.join(d, "2_Dense"))
+        os.makedirs(os.path.join(d, "3_LayerNorm"))
+        os.makedirs(os.path.join(d, "4_Dense"))
+        W2 = rng.standard_normal((D, D)).astype(np.float32)
+        W4 = rng.standard_normal((1, D)).astype(np.float32)
+        b4 = rng.standard_normal(1).astype(np.float32)
+        g = rng.standard_normal(D).astype(np.float32)
+        b = rng.standard_normal(D).astype(np.float32)
+        save_file({"linear.weight": W2}, os.path.join(d, "2_Dense", "model.safetensors"))
+        save_file({"linear.weight": W4, "linear.bias": b4}, os.path.join(d, "4_Dense", "model.safetensors"))
+        save_file({"norm.weight": g, "norm.bias": b}, os.path.join(d, "3_LayerNorm", "model.safetensors"))
+        head = m.EttinRerankHead.from_dir(d)
+        self.assertEqual(head.dim, D)
+        v = rng.standard_normal(D).astype(np.float32)
+        direct = m.EttinRerankHead(W2, W4, b4, g, b)
+        self.assertAlmostEqual(head.score(v), direct.score(v), places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The validated core of the unified-llm gateway's reranker (from the [P2 finding](benchmarks/results/unified-llm/P2-serving-validation.md)): `cross-encoder/ettin-reranker`'s sentence-transformers score head doesn't survive `convert_hf_to_gguf.py`, so llama.cpp serves the ettin **encoder** (`/v1/embeddings`, CLS) and the gateway applies the small Dense head in numpy — no torch.

## What
`scripts/aimee_llm_rerank_head.py` — `EttinRerankHead`:
- `2_Dense → GELU → 3_LayerNorm → 4_Dense → 1` over the CLS-pooled encoder vector for `query</s>doc`.
- `from_dir()` loads the ST safetensors (`2_Dense`/`3_LayerNorm`/`4_Dense`, ~4 MB — baked into the image alongside the encoder GGUF).
- `rerank(query, docs, embed_pairs)` → scored + descending-sorted results. Pure numpy.

## Verified (.254, 7900 XTX)
- **9 unit tests green** — head math vs an independent numpy reference, no-LayerNorm path, batch==single, `rerank` ordering + pair format, `from_dir` loader, dim/shape errors, empty/single docs.
- **Authoritative**: the module + the **real ettin-400m weights** reproduce the P2 toy-gate scores exactly — SciFact 8.92 > 1.10 (top idx 0 ✅), code 9.2 > −1.59 (top idx 1 ✅).

## CI
`.github/workflows/gateway-tests.yml` installs numpy + safetensors and runs the test (bench-smoke's unittest step is stdlib-only, so it can't).

Scope: this is **P3a** — the reranker head (the novel, model-verifiable core). **P3b** wires it into the full gateway (`embedder-server.py` → router/handlers/wire-adapters/health, `/embed`+`/rerank`+`/synth` routing, the 512-cap→413 + streaming→400 typed errors), which is mostly container/.254-verified.