### PR TITLE
fix(responses): emit response.failed/response.incomplete for Codex parity

### DIFF
--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -82,6 +82,21 @@ extern "C"
                                          long created, int prompt_tokens, int completion_tokens,
                                          char *resp, int cap);
 
+   /* Responses-API terminal error events (Codex parity). Codex treats both as
+    * fatal stream errors:
+    *  failed     → {"type":"response.failed","response":{…status:"failed",
+    *               "error":{"code":…,"message":…}}}. Codex maps `code` to a
+    *               typed ApiError (context_length_exceeded, insufficient_quota,
+    *               cyber_policy, invalid_prompt, server_is_overloaded/slow_down,
+    *               rate_limit_exceeded→retry-after); any other code → Retryable.
+    *  incomplete → {"type":"response.incomplete","response":{…status:"incomplete",
+    *               "incomplete_details":{"reason":…}}} (e.g. reason
+    *               "max_output_tokens" on truncation). Returns bytes written or -1. */
+   int openai_format_responses_failed(const char *id, const char *model, long created,
+                                      const char *code, const char *message, char *resp, int cap);
+   int openai_format_responses_incomplete(const char *id, const char *model, long created,
+                                          const char *reason, char *resp, int cap);
+
    /* Responses-API output items + item/argument streaming events (Codex parity).
     * Codex requires output_item.added before any text/arguments delta, and
     * output_item.done + completed carrying the items. The *_item builders return

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1010,6 +1010,22 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
    if (openai_format_responses_created(id, model, created, frame, sizeof(frame)) > 0)
       emit(ctx, "response.created", frame);
 
+   if (erc != 0)
+   {
+      /* Provider/transport failure: surface a real terminal error event the way
+       * the OpenAI backend would, so Codex applies its typed-error handling
+       * (retry/backoff) instead of treating a failed turn as an empty success.
+       * Unknown `code` maps to ApiError::Retryable in Codex's parser. */
+      if (openai_format_responses_failed(id, model, created, "server_error",
+                                         "upstream model request failed", frame, sizeof(frame)) > 0)
+         emit(ctx, "response.failed", frame);
+      agent_free_parsed_response(&parsed);
+      free(instructions);
+      cJSON_Delete(messages);
+      cJSON_Delete(tools);
+      return 0;
+   }
+
    if (erc == 0)
    {
       /* Cost accounting: streaming /v1/responses runs the provider call directly.
@@ -1116,12 +1132,23 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
          free(itf);
       }
 
+      /* OpenAI finish_reason "length" (carried into stop_reason) means the model
+       * was truncated at the token cap. The backend reports that as a terminal
+       * response.incomplete{reason:max_output_tokens}, not response.completed;
+       * mirror it so Codex applies its truncation handling. */
+      int truncated = (parsed.stop_reason[0] && strcmp(parsed.stop_reason, "length") == 0);
       size_t ccap = n * 6 + 1024;
       char *cf = malloc(ccap);
       if (cf)
       {
-         if (openai_format_responses_completed(id, model, txt, created, parsed.prompt_tokens,
-                                               parsed.completion_tokens, cf, (int)ccap) > 0)
+         if (truncated)
+         {
+            if (openai_format_responses_incomplete(id, model, created, "max_output_tokens", cf,
+                                                   (int)ccap) > 0)
+               emit(ctx, "response.incomplete", cf);
+         }
+         else if (openai_format_responses_completed(id, model, txt, created, parsed.prompt_tokens,
+                                                    parsed.completion_tokens, cf, (int)ccap) > 0)
             emit(ctx, "response.completed", cf);
          free(cf);
       }

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -1107,6 +1107,54 @@ int openai_format_responses_completed(const char *id, const char *model, const c
    return emit_json(root, resp, cap);
 }
 
+int openai_format_responses_failed(const char *id, const char *model, long created,
+                                   const char *code, const char *message, char *resp, int cap)
+{
+   if (!resp || cap <= 0)
+      return -1;
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return -1;
+   cJSON_AddStringToObject(root, "type", "response.failed");
+   /* Base response object (output:[] is fine; Codex reads only response.error). */
+   cJSON *obj = build_response_object(id, model, "", created, 0, 0, "failed", 0, "response");
+   if (!obj)
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON *err = cJSON_AddObjectToObject(obj, "error");
+   if (err)
+   {
+      cJSON_AddStringToObject(err, "code", code ? code : "server_error");
+      cJSON_AddStringToObject(err, "message", message ? message : "");
+   }
+   cJSON_AddItemToObject(root, "response", obj);
+   return emit_json(root, resp, cap);
+}
+
+int openai_format_responses_incomplete(const char *id, const char *model, long created,
+                                       const char *reason, char *resp, int cap)
+{
+   if (!resp || cap <= 0)
+      return -1;
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return -1;
+   cJSON_AddStringToObject(root, "type", "response.incomplete");
+   cJSON *obj = build_response_object(id, model, "", created, 0, 0, "incomplete", 0, "response");
+   if (!obj)
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON *det = cJSON_AddObjectToObject(obj, "incomplete_details");
+   if (det)
+      cJSON_AddStringToObject(det, "reason", reason ? reason : "unknown");
+   cJSON_AddItemToObject(root, "response", obj);
+   return emit_json(root, resp, cap);
+}
+
 /* ── Responses API output items (Codex parity) ──────────────────────────────
  *
  * Codex's Responses-API parser requires an *active output item* to exist before

--- a/src/tests/test_openai_shape.c
+++ b/src/tests/test_openai_shape.c
@@ -401,6 +401,25 @@ int main(void)
       assert(strstr(resp, "\"total_tokens\":7"));
    }
 
+   /* --- Codex parity: terminal error events --- */
+   {
+      int len = openai_format_responses_failed("resp_9", "aimee", 1700000000, "server_error",
+                                               "upstream model request failed", resp, sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"type\":\"response.failed\""));
+      assert(strstr(resp, "\"status\":\"failed\""));
+      assert(strstr(resp, "\"error\":{"));
+      assert(strstr(resp, "\"code\":\"server_error\""));
+      assert(strstr(resp, "\"message\":\"upstream model request failed\""));
+
+      len = openai_format_responses_incomplete("resp_9", "aimee", 1700000000, "max_output_tokens",
+                                               resp, sizeof(resp));
+      assert(len > 0);
+      assert(strstr(resp, "\"type\":\"response.incomplete\""));
+      assert(strstr(resp, "\"status\":\"incomplete\""));
+      assert(strstr(resp, "\"incomplete_details\":{\"reason\":\"max_output_tokens\"}"));
+   }
+
    /* --- Codex parity: Responses request -> OpenAI chat conversion --- */
    {
       const char *body =


### PR DESCRIPTION
Audited the `/v1/responses` ingress against Codex's actual SSE parser (`codex-rs/codex-api/src/sse/responses.rs` → `process_responses_event`). Parsing, tool-loop, and SSE framing were already exact. The one real divergence: the streaming handler masked **provider errors** and **token-cap truncation** as successful `response.completed` turns.

Codex gives both terminal events typed handling, so today:
- A provider failure looks like an empty successful turn → Codex does **not** retry.
- A `max_tokens` truncation loses its `incomplete` signal.

## Changes
- `openai_shape.{c,h}`: add `openai_format_responses_failed` (`response.failed` with `response.error.{code,message}`) and `openai_format_responses_incomplete` (`response.incomplete` with `incomplete_details.reason`).
- `responses_stream_handler`: on provider error emit `response.failed` (retryable code) and return; on `stop_reason=="length"` emit `response.incomplete{max_output_tokens}` instead of `completed`.
- `test_openai_shape`: cover both new event shapes.

## Verification
- Compiles clean under `-Wall -Wextra -Werror`; `clang-format-19 --Werror` clean.
- `unit-test-openai-shape`, `unit-test-openai-responses-store`, `unit-test-server-http` all pass on the `testing` base.

Note: `response.incomplete` is fatal in Codex by design — a truncated turn now surfaces as an error rather than partial text, matching real-backend behavior.