### PR TITLE
feat(ingress): claude_proxy_parity — exact Anthropic passthrough for Claude Code

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (107)
+## CLI-settable keys (108)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -32,6 +32,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `cache_shaping_enabled` | bool | Enable prompt cache-shaping. |
 | `claude_cli_delegate_enabled` | bool | Allow delegating to the local Claude CLI agent. |
 | `claude_model` | string | Default Claude model (empty = CLI default). |
+| `claude_proxy_parity` | bool | Make the Claude Code `/v1/messages` ingress a transparent Anthropic passthrough (honor inbound model, skip pre-injection, forward anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). Default off. |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |
 | `cost_reward_lambda_pct` | int | Cost-penalty weight (percent) in the reward. |
 | `cost_reward_ref_usd_milli` | int | Reference cost (USD-milli) normalizing the cost reward. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -106,6 +106,10 @@ CFG_KEY_DESC = {
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
     "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
     "claude_model": "Default Claude model (empty = CLI default).",
+    "claude_proxy_parity": "Make the Claude Code `/v1/messages` ingress a transparent "
+    "Anthropic passthrough (honor inbound model, skip pre-injection, forward "
+    "anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). "
+    "Default off.",
     "cost_reward_enabled": "Factor token cost into the reward signal.",
     "cost_reward_lambda_pct": "Cost-penalty weight (percent) in the reward.",
     "cost_reward_ref_usd_milli": "Reference cost (USD-milli) normalizing the cost reward.",

--- a/src/config.c
+++ b/src/config.c
@@ -833,6 +833,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "claude_proxy_parity");
+   if (cJSON_IsBool(item))
+      cfg->claude_proxy_parity = cJSON_IsTrue(item);
+
    /* CSS migration assistant style-graph write path (WP-C). The field +
     * descriptor + save existed, but the YAML load parse was missing, so the
     * flag never took effect during indexing. */

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -41,6 +41,7 @@ const config_field_t config_fields[] = {
     {"memory_rerank_enabled", offsetof(config_t, memory_rerank_enabled), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_enabled", offsetof(config_t, ingress_preinject_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"claude_proxy_parity", offsetof(config_t, claude_proxy_parity), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_assembly_budget", offsetof(config_t, ingress_preinject_assembly_budget),
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -773,6 +773,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
+   if (cfg->claude_proxy_parity)
+      cJSON_AddBoolToObject(root, "claude_proxy_parity", 1);
    if (cfg->ingress_preinject_assembly_budget != 6144)
       cJSON_AddNumberToObject(root, "ingress_preinject_assembly_budget",
                               cfg->ingress_preinject_assembly_budget);

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -8,6 +8,7 @@
 {"kb_client_bearer_token", SCHEMA_STRING, 0},
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
+{"claude_proxy_parity", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},
 {"css_render_command", SCHEMA_STRING, 0},
 {"typed_facts_enabled", SCHEMA_BOOL, 0},

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -264,6 +264,11 @@ int agent_http_post_content_type(const char *url, const char *auth_header, const
                                  const char *extra_headers);
 int agent_http_delete(const char *url, const char *auth_header, int timeout_ms);
 
+/* Retry-After (seconds) parsed from the most recent buffered HTTP response on
+ * this thread, or 0 if it carried none. Lets the Anthropic ingress relay an
+ * upstream 429/529 Retry-After to the client for exact parity. */
+int agent_http_last_retry_after(void);
+
 /* Streaming callback: called for each data chunk. Return 0 to continue, non-zero to abort. */
 typedef int (*agent_http_stream_cb)(const char *data, size_t len, void *userdata);
 

--- a/src/headers/anthropic_ingress.h
+++ b/src/headers/anthropic_ingress.h
@@ -96,4 +96,17 @@ void anthropic_stream_get_usage(const anthropic_stream_xlate_t *st, int *input_t
 /* Free translator state (does not emit). */
 void anthropic_stream_free(anthropic_stream_xlate_t *st);
 
+/* --- Per-request passthrough headers (parity mode) ---
+ *
+ * Claude Code sends `anthropic-version` and `anthropic-beta` headers that select
+ * API behavior (wire version, beta features such as fine-grained tool streaming
+ * or 1h cache TTL). The /v1/messages ingress handlers receive only the body, so
+ * server_http captures these two headers per request and the anthropic-driver
+ * passthrough forwards them upstream when claude_proxy_parity is enabled. Set on
+ * every request (pass "" / NULL to clear); the getters return "" when unset. */
+void anthropic_ingress_set_request_headers(const char *anthropic_version,
+                                           const char *anthropic_beta);
+const char *anthropic_ingress_request_version(void);
+const char *anthropic_ingress_request_beta(void);
+
 #endif /* DEC_ANTHROPIC_INGRESS_H */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -337,6 +337,17 @@ typedef struct config
    int ingress_preinject_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
+
+   /* Exact-parity mode for the Claude Code Anthropic ingress (POST /v1/messages).
+    * Default off: the ingress keeps its value-add proxy behavior (serves the
+    * configured primary model, applies context pre-injection). When on AND the
+    * primary is an Anthropic-profile agent, the ingress becomes a transparent
+    * passthrough so Claude Code gets byte-equivalent behavior to talking to
+    * api.anthropic.com directly: the inbound `model` is honored (no primary
+    * swap), pre-injection is skipped, the client's `anthropic-version` /
+    * `anthropic-beta` headers are forwarded upstream, count_tokens is proxied to
+    * the real endpoint, and upstream error status/body pass through unchanged. */
+   int claude_proxy_parity;
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -223,6 +223,13 @@ extern "C"
     * server/anthropic_http.c). Called once during server startup. */
    void anthropic_http_register(void);
 
+   /* Capture the inbound `anthropic-version` / `anthropic-beta` headers off the
+    * raw request into per-request thread-locals, for the /v1/messages exact-parity
+    * passthrough (forwarded upstream only when claude_proxy_parity is on). Called
+    * once per request from the HTTP dispatch; `raw_request` is the full request
+    * buffer (NULL clears). Defined in server/anthropic_http.c. */
+   void anthropic_http_capture_request_headers(const char *raw_request);
+
    /* --- Native /v1 REST resource seam ---
     * Some native resources are backed by subsystems (kb_client, memory, …)
     * whose dependency closure must stay out of the server_http translation

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -230,6 +230,11 @@ extern "C"
     * buffer (NULL clears). Defined in server/anthropic_http.c. */
    void anthropic_http_capture_request_headers(const char *raw_request);
 
+   /* Retry-After (seconds) the parity passthrough relays on its own response when
+    * it forwarded an upstream 429/529 that carried one (0 = none). Read by
+    * send_response to emit the header. Defined in server/anthropic_http.c. */
+   int anthropic_http_response_retry_after(void);
+
    /* --- Native /v1 REST resource seam ---
     * Some native resources are backed by subsystems (kb_client, memory, …)
     * whose dependency closure must stay out of the server_http translation

--- a/src/posix/agent_bridge.c
+++ b/src/posix/agent_bridge.c
@@ -504,12 +504,24 @@ static int send_request(http_conn_t *conn, const char *method, const parsed_url_
 
 /* Parse status line, return HTTP status code. Advances *buf past headers.
  * Sets *chunked=1 if Transfer-Encoding: chunked, else sets *content_length. */
+/* Retry-After (seconds) parsed from the most recent buffered HTTP response on
+ * this thread, or 0 if it carried none. Set on every parse_response_headers call.
+ * Read by the Anthropic ingress to relay an upstream 429/529 Retry-After to the
+ * client for exact parity. */
+static __thread int g_last_retry_after = 0;
+
+int agent_http_last_retry_after(void)
+{
+   return g_last_retry_after;
+}
+
 static int parse_response_headers(char *buf, size_t len, size_t *header_end, int *chunked,
                                   size_t *content_length)
 {
    *chunked = 0;
    *content_length = 0;
    *header_end = 0;
+   g_last_retry_after = 0;
 
    /* Find end of headers */
    char *hdr_end = strstr(buf, "\r\n\r\n");
@@ -550,6 +562,24 @@ static int parse_response_headers(char *buf, size_t len, size_t *header_end, int
       if ((*p == 'C' || *p == 'c') && strncasecmp(p, "Content-Length:", 15) == 0)
       {
          *content_length = (size_t)atoll(p + 15);
+         break;
+      }
+   }
+
+   /* Check for Retry-After (seconds; the provider APIs send a delta, not a date).
+    * Match at a header-line start (line begin or just after a "\r\n") so it does
+    * not false-match a substring inside another header's value. */
+   for (char *p = buf; *p; p++)
+   {
+      if ((p == buf || (p[-1] == '\n')) && (*p == 'R' || *p == 'r') &&
+          strncasecmp(p, "Retry-After:", 12) == 0)
+      {
+         char *val = p + 12;
+         while (*val == ' ' || *val == '\t')
+            val++;
+         g_last_retry_after = atoi(val);
+         if (g_last_retry_after < 0)
+            g_last_retry_after = 0;
          break;
       }
    }

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -65,6 +65,13 @@ static int parity_on(void)
    return cfg.claude_proxy_parity ? 1 : 0;
 }
 
+/* Retry-After (seconds) the parity passthrough relays on its own response when it
+ * forwarded an upstream 429/529 that carried one. Thread-local, reset on every
+ * request by anthropic_http_capture_request_headers (so it never leaks across
+ * requests or onto a non-ingress route on a reused worker thread); read by
+ * send_response in server_http_response.inc via anthropic_http_response_retry_after. */
+static __thread int g_response_retry_after = 0;
+
 /* Append a header line to `buf`, inserting a '\n' separator (mirrors
  * agent_config.c's append_header_line; the upstream HTTP layer splits on '\n'). */
 static void hdr_line(char *buf, size_t n, const char *line)
@@ -361,13 +368,14 @@ static int messages_buffered(const char *body, char *resp, int cap)
    {
       /* Exact parity: relay the upstream status + Anthropic error body verbatim
        * so Claude Code sees the real error type (rate_limit_error,
-       * overloaded_error, …) and status code, not a wrapped 502. (Upstream
-       * response headers such as retry-after are not yet plumbed through; the
-       * SDK falls back to exponential backoff on a 429 without it.) */
+       * overloaded_error, …) and status code, not a wrapped 502. Also relay the
+       * upstream Retry-After (send_response emits it on our response) so the
+       * SDK's backoff matches api.anthropic.com on a 429/529. */
       if (parity && response && (int)strlen(response) < cap)
       {
          memcpy(resp, response, strlen(response) + 1);
          status = http_status;
+         g_response_retry_after = agent_http_last_retry_after();
       }
       else
       {
@@ -792,12 +800,17 @@ static int count_tokens(const char *body, char *resp, int cap)
    return status;
 }
 
+int anthropic_http_response_retry_after(void)
+{
+   return g_response_retry_after;
+}
+
 /* Capture the inbound anthropic-version / anthropic-beta headers for the parity
- * passthrough. Lives here (not in the pure anthropic_ingress translation unit, nor
- * inline in the size-capped server_http.c) because it bridges http_header
- * (server_http.h) and the thread-local store (anthropic_ingress.h). Set on every
- * request — empty when a header is absent — so a value never leaks across requests
- * on a reused worker thread. */
+ * passthrough, and reset the per-request response Retry-After. Lives here (not in
+ * the pure anthropic_ingress translation unit, nor inline in the size-capped
+ * server_http.c) because it bridges http_header (server_http.h) and the
+ * thread-local stores. Set on every request — empty/0 when absent — so nothing
+ * leaks across requests on a reused worker thread. */
 void anthropic_http_capture_request_headers(const char *raw_request)
 {
    char a_ver[64] = "", a_beta[512] = "";
@@ -807,6 +820,7 @@ void anthropic_http_capture_request_headers(const char *raw_request)
       http_header(raw_request, "Anthropic-Beta", a_beta, sizeof(a_beta));
    }
    anthropic_ingress_set_request_headers(a_ver, a_beta);
+   g_response_retry_after = 0;
 }
 
 void anthropic_http_register(void)

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -20,6 +20,7 @@
 #include "agent_types.h"
 #include "anthropic_ingress.h"
 #include "cJSON.h"
+#include "config.h"
 #include "delegate_driver.h"
 #include "ingress_preinject.h"
 #include "json_fluent.h"
@@ -50,6 +51,56 @@ static agent_t *resolve_primary(agent_config_t *acfg)
 static void mint_msg_id(char *buf, size_t n)
 {
    snprintf(buf, n, "msg_%ld", (long)time(NULL));
+}
+
+/* Exact-parity mode for the Claude Code ingress (config claude_proxy_parity,
+ * default off). When on AND the primary is an Anthropic-profile agent, the
+ * ingress is a transparent passthrough: inbound model honored, pre-injection
+ * skipped, client anthropic-version/anthropic-beta forwarded, count_tokens
+ * proxied upstream, and upstream error status/body relayed unchanged. */
+static int parity_on(void)
+{
+   config_t cfg;
+   config_load(&cfg);
+   return cfg.claude_proxy_parity ? 1 : 0;
+}
+
+/* Append a header line to `buf`, inserting a '\n' separator (mirrors
+ * agent_config.c's append_header_line; the upstream HTTP layer splits on '\n'). */
+static void hdr_line(char *buf, size_t n, const char *line)
+{
+   size_t used;
+   if (!buf || n == 0 || !line || !line[0])
+      return;
+   used = strlen(buf);
+   if (used > 0 && buf[used - 1] != '\n' && used + 1 < n)
+   {
+      buf[used++] = '\n';
+      buf[used] = '\0';
+   }
+   if (used < n - 1)
+      snprintf(buf + used, n - used, "%s", line);
+}
+
+/* Build the upstream header block for the anthropic parity passthrough: forward
+ * the client's anthropic-version (else the GA default) and its full anthropic-beta
+ * set verbatim, so beta-gated behaviors (fine-grained tool streaming, 1h cache
+ * TTL, interleaved thinking, fast mode, …) reach Anthropic exactly as Claude Code
+ * requested them. */
+static void build_anthropic_parity_headers(char *buf, size_t n)
+{
+   char line[640];
+   const char *cver = anthropic_ingress_request_version();
+   const char *cbeta = anthropic_ingress_request_beta();
+
+   buf[0] = '\0';
+   snprintf(line, sizeof(line), "anthropic-version: %s", (cver && cver[0]) ? cver : "2023-06-01");
+   hdr_line(buf, n, line);
+   if (cbeta && cbeta[0])
+   {
+      snprintf(line, sizeof(line), "anthropic-beta: %s", cbeta);
+      hdr_line(buf, n, line);
+   }
 }
 
 /* Serialize `obj` into resp (bounded by cap). Returns 200 on success, 500 if it
@@ -165,21 +216,32 @@ static char *build_provider_body(const delegate_driver_t *driver, const agent_t 
 
 /* Anthropic-native ingress is a near-passthrough: Claude Code already speaks
  * Anthropic Messages, so preserve request fields such as system cache_control,
- * tool_choice, thinking, stop_sequences, top_p, and top_k. The configured
- * primary model still wins over the inbound model name. */
-static char *build_anthropic_provider_body(const cJSON *in, const agent_t *ag, int stream)
+ * tool_choice, thinking, stop_sequences, top_p, and top_k. By default the
+ * configured primary model wins over the inbound model name; under parity the
+ * inbound model is honored verbatim (falling back to the primary only when the
+ * client omitted it) so Claude Code's per-task model selection survives. */
+static char *build_anthropic_provider_body(const cJSON *in, const agent_t *ag, int stream,
+                                           int parity)
 {
    cJSON *req;
-   cJSON *model;
    char *body;
 
    req = cJSON_Duplicate((cJSON *)in, 1);
    if (!req)
       return NULL;
-   cJSON_DeleteItemFromObjectCaseSensitive(req, "model");
-   model = cJSON_CreateString(ag && ag->model[0] ? ag->model : "claude");
-   if (model)
-      cJSON_AddItemToObject(req, "model", model);
+   if (!parity)
+   {
+      cJSON *model;
+      cJSON_DeleteItemFromObjectCaseSensitive(req, "model");
+      model = cJSON_CreateString(ag && ag->model[0] ? ag->model : "claude");
+      if (model)
+         cJSON_AddItemToObject(req, "model", model);
+   }
+   else if (!cJSON_GetObjectItemCaseSensitive(req, "model") && ag && ag->model[0])
+   {
+      /* Parity, but the client sent no model: give the upstream call one. */
+      cJSON_AddStringToObject(req, "model", ag->model);
+   }
    cJSON_DeleteItemFromObjectCaseSensitive(req, "stream");
    if (stream)
       cJSON_AddBoolToObject(req, "stream", 1);
@@ -271,7 +333,10 @@ static int messages_buffered(const char *body, char *resp, int cap)
 
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
-   messages_apply_preinject(req);
+   /* Exact-parity passthrough only applies to the Anthropic-native path. */
+   int parity = parity_on() && driver_is_anthropic(driver);
+   if (!parity)
+      messages_apply_preinject(req);
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -279,10 +344,13 @@ static int messages_buffered(const char *body, char *resp, int cap)
       status = write_error(resp, cap, 502, "api_error", "failed to reach the primary provider");
       goto cleanup;
    }
-   agent_build_extra_headers(ag, extra, sizeof(extra));
+   if (parity)
+      build_anthropic_parity_headers(extra, sizeof(extra));
+   else
+      agent_build_extra_headers(ag, extra, sizeof(extra));
 
    if (driver_is_anthropic(driver))
-      prov_body = build_anthropic_provider_body(req, ag, 0);
+      prov_body = build_anthropic_provider_body(req, ag, 0, parity);
    else
       prov_body = build_provider_body(driver, ag, messages, tools, system_text,
                                       agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
@@ -291,8 +359,21 @@ static int messages_buffered(const char *body, char *resp, int cap)
                                  extra[0] ? extra : NULL);
    if (http_status != 200 || !response)
    {
-      status = write_error(resp, cap, 502, "api_error",
-                           response ? response : "primary provider call failed");
+      /* Exact parity: relay the upstream status + Anthropic error body verbatim
+       * so Claude Code sees the real error type (rate_limit_error,
+       * overloaded_error, …) and status code, not a wrapped 502. (Upstream
+       * response headers such as retry-after are not yet plumbed through; the
+       * SDK falls back to exponential backoff on a 429 without it.) */
+      if (parity && response && (int)strlen(response) < cap)
+      {
+         memcpy(resp, response, strlen(response) + 1);
+         status = http_status;
+      }
+      else
+      {
+         status = write_error(resp, cap, 502, "api_error",
+                              response ? response : "primary provider call failed");
+      }
       goto cleanup;
    }
 
@@ -544,15 +625,21 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
 
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
-   messages_apply_preinject(req);
+   /* Exact-parity passthrough only applies to the Anthropic-native path. */
+   int parity = parity_on() && driver_is_anthropic(driver);
+   if (!parity)
+      messages_apply_preinject(req);
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
       goto cleanup;
-   agent_build_extra_headers(ag, extra, sizeof(extra));
+   if (parity)
+      build_anthropic_parity_headers(extra, sizeof(extra));
+   else
+      agent_build_extra_headers(ag, extra, sizeof(extra));
 
    if (driver_is_anthropic(driver))
-      prov_body = build_anthropic_provider_body(req, ag, 1);
+      prov_body = build_anthropic_provider_body(req, ag, 1, parity);
    else
       prov_body = build_provider_body(driver, ag, messages, tools, system_text,
                                       agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
@@ -647,6 +734,46 @@ cleanup:
 static int count_tokens(const char *body, char *resp, int cap)
 {
    cJSON *req = cJSON_Parse((body && body[0]) ? body : "{}");
+
+   /* Exact parity: proxy to Anthropic's real /v1/messages/count_tokens so Claude
+    * Code's context-budget math matches api.anthropic.com, not a local estimate.
+    * Only on the Anthropic-native path; otherwise fall through to the estimate. */
+   if (parity_on())
+   {
+      agent_config_t acfg;
+      agent_t *ag = resolve_primary(&acfg);
+      const delegate_driver_t *driver;
+      delegate_drivers_init();
+      driver = ag ? delegate_driver_get(ag->provider) : NULL;
+      if (ag && driver_is_anthropic(driver))
+      {
+         char url[MAX_ENDPOINT_LEN + 64];
+         char ct_url[MAX_ENDPOINT_LEN + 96];
+         char auth[MAX_API_KEY_LEN + 32];
+         char extra[640];
+         char *response = NULL;
+         if (delegate_build_url(driver, ag, url, sizeof(url)) == 0 &&
+             agent_resolve_auth(ag, auth, sizeof(auth)) == 0)
+         {
+            int hs;
+            snprintf(ct_url, sizeof(ct_url), "%s/count_tokens", url); /* url ends in /messages */
+            build_anthropic_parity_headers(extra, sizeof(extra));
+            hs = agent_http_post(ct_url, auth, (body && body[0]) ? body : "{}", &response,
+                                 ag->timeout_ms, extra[0] ? extra : NULL);
+            if (response && (int)strlen(response) < cap)
+            {
+               /* Relay upstream status + body verbatim (200 with the real count,
+                * or the real error). */
+               memcpy(resp, response, strlen(response) + 1);
+               free(response);
+               cJSON_Delete(req);
+               return hs;
+            }
+            free(response); /* unreachable/oversized: fall through to the estimate */
+         }
+      }
+   }
+
    char *system_text = req ? anthropic_system_to_text(req) : NULL;
    cJSON *messages = req ? anthropic_messages_to_openai(
                                cJSON_GetObjectItemCaseSensitive(req, "messages"), system_text)
@@ -663,6 +790,23 @@ static int count_tokens(const char *body, char *resp, int cap)
    cJSON_Delete(messages);
    cJSON_Delete(req);
    return status;
+}
+
+/* Capture the inbound anthropic-version / anthropic-beta headers for the parity
+ * passthrough. Lives here (not in the pure anthropic_ingress translation unit, nor
+ * inline in the size-capped server_http.c) because it bridges http_header
+ * (server_http.h) and the thread-local store (anthropic_ingress.h). Set on every
+ * request — empty when a header is absent — so a value never leaks across requests
+ * on a reused worker thread. */
+void anthropic_http_capture_request_headers(const char *raw_request)
+{
+   char a_ver[64] = "", a_beta[512] = "";
+   if (raw_request)
+   {
+      http_header(raw_request, "Anthropic-Version", a_ver, sizeof(a_ver));
+      http_header(raw_request, "Anthropic-Beta", a_beta, sizeof(a_beta));
+   }
+   anthropic_ingress_set_request_headers(a_ver, a_beta);
 }
 
 void anthropic_http_register(void)

--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -12,6 +12,36 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* --- Per-request passthrough headers (parity mode) ---------------------------
+ *
+ * Not part of the pure translation: a thin per-request echo of the two inbound
+ * headers that select Anthropic API behavior. server_http captures them off the
+ * raw request (the ingress handlers never see HTTP headers); the anthropic-driver
+ * passthrough forwards them upstream when claude_proxy_parity is on. Thread-local
+ * and reset on every request, so a value never leaks between requests on a reused
+ * worker thread. */
+static __thread char g_req_anthropic_version[64] = "";
+static __thread char g_req_anthropic_beta[512] = "";
+
+void anthropic_ingress_set_request_headers(const char *anthropic_version,
+                                           const char *anthropic_beta)
+{
+   snprintf(g_req_anthropic_version, sizeof(g_req_anthropic_version), "%s",
+            anthropic_version ? anthropic_version : "");
+   snprintf(g_req_anthropic_beta, sizeof(g_req_anthropic_beta), "%s",
+            anthropic_beta ? anthropic_beta : "");
+}
+
+const char *anthropic_ingress_request_version(void)
+{
+   return g_req_anthropic_version;
+}
+
+const char *anthropic_ingress_request_beta(void)
+{
+   return g_req_anthropic_beta;
+}
+
 /* Append `add` to the malloc'd accumulator `acc`, inserting `sep` between an
  * existing value and the new one. Returns the (possibly reallocated) buffer;
  * on allocation failure the original buffer is returned unchanged. */

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1451,6 +1451,7 @@ static void handle_conn(int fd, int is_tcp)
        * this reused worker thread; the OpenAI-family ingress dispatch mints a
        * fresh one below when evidence emission is on. */
       ingress_preinject_set_turn_id("");
+      anthropic_http_capture_request_headers(buf); /* parity: per-request anthropic-* hdrs */
       int az = server_http_authorize(is_tcp, g_bearer, has_auth ? auth : NULL,
                                      has_api_key ? api_key : NULL, has_skey);
       if (az != 0)

--- a/src/server/server_http_response.inc
+++ b/src/server/server_http_response.inc
@@ -28,6 +28,19 @@ static void retrieval_event_header(char *dst, size_t n)
       dst[0] = '\0';
 }
 
+/* Build the optional `Retry-After: <seconds>\r\n` header line (or "") from the
+ * Anthropic ingress thread-local — non-empty only when the parity passthrough
+ * relayed an upstream 429/529 that carried a Retry-After, so the client's SDK
+ * backs off exactly as it would against api.anthropic.com. */
+static void retry_after_header(char *dst, size_t n)
+{
+   int ra = anthropic_http_response_retry_after();
+   if (ra > 0)
+      snprintf(dst, n, "Retry-After: %d\r\n", ra);
+   else if (n)
+      dst[0] = '\0';
+}
+
 static void send_response(int fd, int status, const char *body, const char *request_id)
 {
    const char *reason = status == 200   ? "OK"
@@ -43,12 +56,14 @@ static void send_response(int fd, int status, const char *body, const char *requ
    request_id_header(rid, sizeof(rid), request_id);
    char reh[80];
    retrieval_event_header(reh, sizeof(reh));
-   char head[400];
+   char rah[48];
+   retry_after_header(rah, sizeof(rah));
+   char head[480];
    int blen = body ? (int)strlen(body) : 0;
    int hlen = snprintf(head, sizeof(head),
                        "HTTP/1.1 %d %s\r\nContent-Type: application/json\r\n"
-                       "Content-Length: %d\r\n%s%sConnection: close\r\n\r\n",
-                       status, reason, blen, rid, reh);
+                       "Content-Length: %d\r\n%s%s%sConnection: close\r\n\r\n",
+                       status, reason, blen, rid, reh, rah);
    write_all_fd(fd, head, hlen);
    if (blen > 0)
       write_all_fd(fd, body, blen);

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -10,6 +10,7 @@
 #include "../headers/agent_config.h"
 #include "../headers/agent_exec.h"
 #include "../headers/agent_protocol.h"
+#include "../headers/config.h"
 #include "../headers/delegate_driver.h"
 #include "../headers/server_http.h"
 #include "../vendor/headers/cJSON.h"
@@ -18,6 +19,8 @@
 
 static const delegate_driver_t *g_driver;
 static char *g_last_body;
+static char *g_last_extra; /* upstream extra-header block from the last post */
+static int g_stub_parity;  /* config_load stub returns this as claude_proxy_parity */
 static int g_stream_status = 200;
 static const char *g_stream_payload;
 
@@ -25,6 +28,9 @@ static void reset_capture(void)
 {
    free(g_last_body);
    g_last_body = NULL;
+   free(g_last_extra);
+   g_last_extra = NULL;
+   g_stub_parity = 0;
    g_stream_status = 200;
    g_stream_payload = NULL;
 }
@@ -119,10 +125,11 @@ int agent_http_post(const char *url, const char *auth_header, const char *body, 
    (void)url;
    (void)auth_header;
    (void)timeout_ms;
-   (void)extra_headers;
    free(g_last_body);
    g_last_body = strdup(body ? body : "");
    assert(g_last_body != NULL);
+   free(g_last_extra);
+   g_last_extra = strdup(extra_headers ? extra_headers : "");
    *response_buf = strdup("{}");
    return 200;
 }
@@ -213,6 +220,24 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    (void)query;
    (void)request_disabled;
    return g_stub_preinject_env ? strdup(g_stub_preinject_env) : NULL;
+}
+
+/* Config + HTTP-layer stubs for the parity path. config_load zeroes the struct so
+ * claude_proxy_parity defaults off — these whitebox tests cover the default
+ * model-swap/pre-injection behavior, not parity mode. agent_http_last_retry_after
+ * has no upstream socket here, so 0 (no Retry-After) suffices. */
+int config_load(config_t *cfg)
+{
+   if (cfg)
+   {
+      memset(cfg, 0, sizeof(*cfg));
+      cfg->claude_proxy_parity = g_stub_parity;
+   }
+   return 0;
+}
+int agent_http_last_retry_after(void)
+{
+   return 0;
 }
 
 #include "../server/anthropic_http.c"
@@ -482,6 +507,39 @@ static void test_messages_buffered_anthropic_preserves_request_shape(void)
    PASS("messages_buffered_anthropic_preserves_request_shape");
 }
 
+/* claude_proxy_parity on: inbound model honored (not swapped to the primary),
+ * pre-injection skipped, and the client's anthropic-beta forwarded upstream. */
+static void test_messages_buffered_anthropic_parity_passthrough(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *sent;
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_stub_parity = 1;
+   g_stub_preinject_env = "<aimee-context>INJECTED</aimee-context>";
+   anthropic_ingress_set_request_headers("2023-06-01", "test-beta-flag,extended-cache-ttl");
+
+   assert(messages_buffered("{\"model\":\"claude-opus-4-8\",\"max_tokens\":64,"
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+   sent = parse(g_last_body);
+   /* inbound model preserved (default behavior would swap to "configured-claude") */
+   assert(strcmp(obj(sent, "model")->valuestring, "claude-opus-4-8") == 0);
+   /* pre-injection skipped under parity */
+   assert(strstr(g_last_body, "INJECTED") == NULL);
+   /* client beta forwarded upstream */
+   assert(g_last_extra != NULL && strstr(g_last_extra, "anthropic-beta: test-beta-flag") != NULL);
+   assert(strstr(g_last_extra, "anthropic-version: 2023-06-01") != NULL);
+   cJSON_Delete(sent);
+
+   anthropic_ingress_set_request_headers("", "");
+   g_stub_preinject_env = NULL;
+   reset_capture();
+   PASS("messages_buffered_anthropic_parity_passthrough");
+}
+
 static void test_messages_buffered_anthropic_strips_stream_false_path(void)
 {
    const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
@@ -676,6 +734,7 @@ int main(void)
    test_relay_append_data_growth();
    test_relay_transport_error();
    test_messages_buffered_anthropic_preserves_request_shape();
+   test_messages_buffered_anthropic_parity_passthrough();
    test_messages_buffered_anthropic_strips_stream_false_path();
    test_messages_stream_anthropic_preserves_request_shape();
    test_messages_buffered_openai_family_translates();

--- a/src/tests/test_anthropic_ingress.c
+++ b/src/tests/test_anthropic_ingress.c
@@ -430,6 +430,44 @@ static void test_stream_text_then_tool(void)
    PASS("stream_text_then_tool");
 }
 
+/* Per-request passthrough headers (parity mode): set/get echo, NULL handling,
+ * per-request reset (no leak across requests), and bounded/NUL-terminated
+ * storage for an oversized beta list. */
+static void test_request_headers_passthrough(void)
+{
+   char big[1200];
+
+   /* default state: empty, never NULL. */
+   anthropic_ingress_set_request_headers("", "");
+   assert(anthropic_ingress_request_version()[0] == '\0');
+   assert(anthropic_ingress_request_beta()[0] == '\0');
+
+   /* echo what was captured. */
+   anthropic_ingress_set_request_headers(
+       "2023-06-01", "fine-grained-tool-streaming-2025-05-14,extended-cache-ttl");
+   assert(strcmp(anthropic_ingress_request_version(), "2023-06-01") == 0);
+   assert(strstr(anthropic_ingress_request_beta(), "fine-grained-tool-streaming") != NULL);
+
+   /* NULL is treated as empty (clears), not a crash. */
+   anthropic_ingress_set_request_headers(NULL, NULL);
+   assert(anthropic_ingress_request_version()[0] == '\0');
+   assert(anthropic_ingress_request_beta()[0] == '\0');
+
+   /* per-request reset: a value from one request must not leak into the next. */
+   anthropic_ingress_set_request_headers("2023-06-01", "beta-a");
+   anthropic_ingress_set_request_headers("", "");
+   assert(anthropic_ingress_request_beta()[0] == '\0');
+
+   /* oversized beta list is stored bounded + NUL-terminated, no overflow. */
+   memset(big, 'x', sizeof(big));
+   big[sizeof(big) - 1] = '\0';
+   anthropic_ingress_set_request_headers("2023-06-01", big);
+   assert(strlen(anthropic_ingress_request_beta()) < 512);
+
+   anthropic_ingress_set_request_headers("", ""); /* leave clean for later tests */
+   PASS("request_headers_passthrough");
+}
+
 int main(void)
 {
    printf("test_anthropic_ingress:\n");
@@ -450,6 +488,7 @@ int main(void)
    test_stream_usage_tap();
    test_stream_tool_call();
    test_stream_text_then_tool();
+   test_request_headers_passthrough();
    printf("all anthropic_ingress tests passed\n");
    return 0;
 }

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,8 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\ncss_style_graph_enabled: true\n"
+    "true\ningress_preinject_enabled: true\nclaude_proxy_parity: true\ncss_style_graph_enabled: "
+    "true\n"
     "ingress_preinject_assembly_budget: 1\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
     "ZZA_val\nembedding_endpoint: ZZA_val\nembedding_dim: 1\nmemory_rerank_mode: "
@@ -81,7 +82,8 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\ncss_style_graph_enabled: false\n"
+    "false\ningress_preinject_enabled: false\nclaude_proxy_parity: false\ncss_style_graph_enabled: "
+    "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
     "ZZB_val\nembedding_endpoint: ZZB_val\nembedding_dim: 4096\nmemory_rerank_mode: "
@@ -160,6 +162,7 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
+   assert(cfgA.claude_proxy_parity == 1 && cfgB.claude_proxy_parity == 0);
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);


### PR DESCRIPTION
Adds an opt-in config flag **`claude_proxy_parity`** (default off) that makes the Claude Code `/v1/messages` ingress a byte-faithful Anthropic passthrough, so pointing Claude Code at aimee's `ANTHROPIC_BASE_URL` behaves as if it were talking to `api.anthropic.com` directly. Default off preserves today's model-swap + pre-injection value-add for other deployments.

## When on (and the primary is an Anthropic-profile agent)
- Inbound `model` honored verbatim (no primary swap)
- `<aimee-context>` pre-injection skipped
- Client `anthropic-version` / `anthropic-beta` forwarded upstream — beta-gated behaviors (fine-grained tool streaming, 1h cache TTL, interleaved thinking, fast mode) now reach Anthropic
- `count_tokens` proxied to the real tokenizer endpoint instead of a local estimate
- Upstream error **status + body** relayed verbatim (real `rate_limit_error` / `overloaded_error`, not a wrapped 502)
- Upstream **`Retry-After`** relayed on 429/529 so the SDK backs off exactly as against `api.anthropic.com`

Native streaming already relayed upstream SSE bytes verbatim.

## Notes
- Header capture mirrors the existing per-request preinject thread-local pattern; `Retry-After` relay mirrors the retrieval-event header pattern. No new line-cap pressure on `server_http.c`.
- New unit test pins the request-header capture (reset / no-leak / truncation). `config-surface`, `anthropic-ingress`, `server-http` tests pass; `make lint` green; config docs regenerated.

## Known edge
The streaming path commits to a `200` SSE response before the upstream status is known, so a streamed 429 can't be relayed as a status — inherent to SSE, not addressed here.