### PR TITLE
feat(workflow): retry_on_reject gate opt-in + atomic guarded human-gate transition

### DIFF
--- a/docs/proposals/pending/autonomous-dev-webchat-and-random-delegate.plan.md
+++ b/docs/proposals/pending/autonomous-dev-webchat-and-random-delegate.plan.md
@@ -3,6 +3,49 @@
 Two user-requested additions on top of the (API-first) autonomous-development
 feature. Scope-honest: the webchat is currently a read-only run viewer.
 
+## Status: SHIPPED (2026-06-23)
+
+All three slices are implemented and unit-tested:
+
+- **C — `$random` delegate.** `wfe_resolve_delegate` / `wfe_resolve_delegate_seed`
+  (`src/server/wfe_delegate_resolve.c`): CSPRNG uniform pick over enabled agents,
+  seedable, fail-fast on an empty roster; wired into the live delegate + block
+  providers; frontend composer option present. Test
+  `unit-test-wfe-random-delegate`.
+- **B1 — submit form.** `POST /v1/dev/submit` + webchat `POST /api/dev/submit`
+  proxy + the Workflows-tab "Submit proposal" panel.
+- **B2 — operator gate approve/reject.** `POST /v1/workflow/items/<id>/gate`
+  (`CAP_WORKFLOW_ADMIN`, outside `CAPS_AUTHENTICATED`) + proxy + Approve/Reject
+  buttons shown on `pause_reason == pending_human`. The decision is applied via a
+  single guarded `db1_work_item_gate_apply` UPDATE (WHERE current_stage +
+  content_hash match AND pause_reason='pending_human') so a stale / double /
+  concurrent decision returns 409 instead of corrupting state. Approve is
+  idempotent (signed approval pre-check); **reject is terminal by default**, with
+  an opt-in `retry_on_reject: true` gate param that loops back along the gate's
+  `on_fail` edge (`wfe_gate_reject_target`), bounded by `GATE_MAX_REJECT_RETRIES`
+  (default 3) and degrading to terminal if the `on_fail` target no longer
+  resolves. Every decision appends an append-only `lifecycle_event`
+  (`approve | reject | reject_retry`). Tests `unit-test-wfe-gate-reject`,
+  `unit-test-wfe-gate-apply`, `unit-test-workflow-gate-caps`.
+
+This plan addressed the roundtable's five blocking review items (reject-side
+TOCTOU/idempotency, the content-hash invariant, audit-event signing semantics,
+unbounded retries, and pause→reject def staleness). Two follow-ups are tracked,
+not silently deferred:
+
+- **F1 — version-pinned def loading** for in-flight work items (engine-wide; the
+  pause→reject window is one instance). Mitigated here by the helper validating
+  the `on_fail` target against the freshly-loaded def.
+- **F2 — UI discoverability of retry eligibility** (badge / "Reject → loops back"
+  label) so an operator knows a `retry_on_reject` gate's Reject loops rather than
+  terminates. Frontend-only.
+- **F3 — idempotent signed approval.** The approve path records the signed approval
+  before the atomic pause-clear; on a concurrent advance the clear returns 0 (409)
+  and the signed approval is orphaned. Bounded and harmless (it is content-hash-keyed
+  to `(work_item, gate, content_hash)`; a later approve sees it present and returns an
+  idempotent 200). Making `wfe_approval_record` treat a duplicate as success would
+  remove the orphan entirely.
+
 ## B — webchat GUI for autonomous development
 
 ### B1. Submit a proposal (form)

--- a/src/db1/wfe_store.c
+++ b/src/db1/wfe_store.c
@@ -150,6 +150,46 @@ int db1_work_item_set_terminal(const char *wi, const char *state)
    return rc == SQLITE_DONE ? 0 : -1;
 }
 
+int db1_work_item_gate_apply(const char *wi, const char *expect_stage, const char *expect_hash,
+                             const char *new_stage, const char *terminal_state)
+{
+   sqlite3 *db = db1_conn();
+   if (!db || !wi)
+      return -1;
+   int loopback = new_stage && new_stage[0];
+   int terminal = !loopback && terminal_state && terminal_state[0];
+/* The SET clause varies by decision; the WHERE guard is identical in all three
+ * cases (the row must still be parked exactly as the caller observed), so it lives
+ * in one place via compile-time literal concatenation. */
+#define GATE_GUARD                                                                                 \
+   " updated_at=datetime('now') WHERE work_item_id=?2 AND current_stage=?3 AND content_hash=?4 "   \
+   "AND pause_reason='pending_human'"
+   const char *sql;
+   if (loopback)
+      sql = "UPDATE lifecycle_work_item SET current_stage=?1, pause_reason='', "
+            "paused_state=''," GATE_GUARD;
+   else if (terminal)
+      sql = "UPDATE lifecycle_work_item SET state=?1, pause_reason='', paused_state=''," GATE_GUARD;
+   else /* approve: clear pause only, stage unchanged */
+      sql = "UPDATE lifecycle_work_item SET pause_reason='', paused_state=''," GATE_GUARD;
+#undef GATE_GUARD
+   sqlite3_stmt *st = NULL;
+   if (sqlite3_prepare_v2(db, sql, -1, &st, NULL) != SQLITE_OK)
+      return -1;
+   /* ?1 is the variable SET value (stage for loopback, state for terminal, unused
+    * for approve — bound to "" harmlessly since the approve SQL omits ?1). */
+   sqlite3_bind_text(st, 1, loopback ? new_stage : (terminal ? terminal_state : ""), -1,
+                     SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 2, wi, -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 3, expect_stage ? expect_stage : "", -1, SQLITE_TRANSIENT);
+   sqlite3_bind_text(st, 4, expect_hash ? expect_hash : "", -1, SQLITE_TRANSIENT);
+   int rc = sqlite3_step(st);
+   sqlite3_finalize(st);
+   if (rc != SQLITE_DONE)
+      return -1;
+   return sqlite3_changes(db) == 1 ? 1 : 0; /* 0 rows => precondition not met (409) */
+}
+
 int db1_work_item_set_pause(const char *wi, const char *reason, const char *paused_state)
 {
    sqlite3 *db = db1_conn();

--- a/src/db1/wfe_store.h
+++ b/src/db1/wfe_store.h
@@ -58,6 +58,22 @@ int db1_work_item_set_stage(const char *work_item_id, const char *stage, const c
 int db1_work_item_set_pr_ref(const char *work_item_id, const char *pr_ref);
 /* Set terminal state (accepted | rejected | abandoned) and clear pause. */
 int db1_work_item_set_terminal(const char *work_item_id, const char *state);
+
+/* Apply an operator human-gate decision ATOMICALLY, guarded against TOCTOU /
+ * double-action. The row must still be parked exactly as the caller observed:
+ * current_stage == expect_stage AND content_hash == expect_hash AND
+ * pause_reason == 'pending_human'. Content is immutable while parked, so
+ * content_hash is an identity / optimistic-concurrency guard (never re-derived).
+ * Exactly one decision per call:
+ *   - new_stage non-empty   -> loop back (current_stage := new_stage, clear pause)
+ *   - terminal_state non-empty -> state := terminal_state, clear pause
+ *   - both NULL/empty       -> approve (clear pause only; stage unchanged)
+ * (new_stage and terminal_state must not both be set.) Single UPDATE, so two
+ * concurrent operators cannot both apply. Returns 1 = applied, 0 = precondition
+ * not met (caller should report 409 conflict), -1 = error. */
+int db1_work_item_gate_apply(const char *work_item_id, const char *expect_stage,
+                             const char *expect_hash, const char *new_stage,
+                             const char *terminal_state);
 int db1_work_item_set_pause(const char *work_item_id, const char *reason, const char *paused_state);
 int db1_work_item_clear_pause(const char *work_item_id);
 int db1_work_item_add_cost(const char *work_item_id, double cost);

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -238,12 +238,48 @@ static int rh_dev_submit(const route_req_t *rq, char *resp, int cap)
    return 200;
 }
 
+/* Loop-back retry cap for operator rejects on a `retry_on_reject` gate: bounds an
+ * operator who keeps rejecting from churning a work item forever (audit-row blowup
+ * / resource exhaustion). Counted from the immutable lifecycle log, so no schema
+ * change; at/above the cap a reject is forced terminal. */
+#define GATE_MAX_REJECT_RETRIES 3
+
+/* Count prior reject_retry loop-backs at THIS gate for this work item (per-gate
+ * budget: the audit row's stage column is the gate). Returns -1 on a DB read error
+ * so the caller fails CLOSED (a lifecycle-table outage must not silently lift the
+ * cap, since gate_apply on the work_item table would still succeed). */
+static int gate_count_reject_retries(const char *id, const char *gate)
+{
+   db1_lifecycle_event_t *ev = NULL;
+   int n = db1_lifecycle_event_list(id, &ev);
+   if (n < 0)
+      return -1; /* fail closed */
+   int c = 0;
+   for (int i = 0; i < n; i++)
+      if (strcmp(ev[i].kind, "reject_retry") == 0 && strcmp(ev[i].stage, gate) == 0)
+         c++;
+   free(ev);
+   return c;
+}
+
 /* POST /v1/workflow/items/<id>/gate {decision:"approve"|"reject", gate?} —
  * approve or reject the human gate a run is parked at. Operator-level
  * (CAP_WORKFLOW_ADMIN, outside CAPS_AUTHENTICATED) so a mere delegate/authenticated
- * bearer cannot drive a gate. Approve records a non-repudiable, content-hash-bound
- * approval (HMAC-signed server-side with the operator key) and clears the pause;
- * reject is terminal. The scheduler then resumes the run. */
+ * bearer cannot drive a gate.
+ *
+ * The state change is applied via db1_work_item_gate_apply — a single guarded
+ * UPDATE (WHERE current_stage + content_hash match AND pause_reason='pending_human')
+ * so a double-action / reject-after-approve / concurrent-operator race cannot
+ * double-apply: a precondition miss returns 409 instead of corrupting state.
+ * Content is immutable while parked, so content_hash is the row's identity guard.
+ *
+ * Approve records a non-repudiable, content-hash-bound approval (HMAC-signed with
+ * the operator key) then clears the pause. Reject is TERMINAL by default; a gate
+ * may opt into loop-back via `retry_on_reject: true` (following its on_fail edge),
+ * bounded by GATE_MAX_REJECT_RETRIES. Every decision appends a lifecycle audit
+ * event (approve | reject | reject_retry); the append-only log is unsigned by
+ * design (matching all other lifecycle events) — approvals carry their own signed
+ * record for non-repudiation. The scheduler then resumes the run. */
 static int rh_workflow_gate(const route_req_t *rq, char *resp, int cap)
 {
    const char *id = rq->id;
@@ -262,43 +298,135 @@ static int rh_workflow_gate(const route_req_t *rq, char *resp, int cap)
    cJSON *jdec = body ? cJSON_GetObjectItemCaseSensitive(body, "decision") : NULL;
    cJSON *jgate = body ? cJSON_GetObjectItemCaseSensitive(body, "gate") : NULL;
    const char *decision = (jdec && cJSON_IsString(jdec)) ? jdec->valuestring : "";
-   /* Default the gate to the stage the run is parked at. */
-   const char *gate = (jgate && cJSON_IsString(jgate) && jgate->valuestring[0]) ? jgate->valuestring
-                                                                                : wi.current_stage;
    const char *actor = server_http_identity_principal();
    if (!actor || !actor[0])
       actor = "operator";
 
-   int rc;
-   if (strcmp(decision, "approve") == 0)
+   /* The gate is ALWAYS the stage the row is currently parked at (read from the
+    * row, never the request). It is the sole input to the retry decision and the
+    * audit event, closing a confused-deputy where a request could name a different
+    * (terminal-only) gate than the one actually parked. A request naming a
+    * mismatching gate is refused rather than silently retargeted. */
+   const char *gate = wi.current_stage;
+   if (jgate && cJSON_IsString(jgate) && jgate->valuestring[0] &&
+       strcmp(jgate->valuestring, gate) != 0)
    {
-      /* Idempotent: a duplicate approve for the same content hash is success. */
-      if (!wfe_approval_present(id, gate, wi.content_hash))
-         rc = wfe_approval_record(id, gate, wi.content_hash, actor);
-      else
-         rc = 0;
-      if (rc == 0)
-         (void)db1_work_item_clear_pause(id);
+      cJSON_Delete(body);
+      snprintf(resp, cap, "{\"error\":\"run is parked at gate '%s', not '%s'\"}", gate,
+               jgate->valuestring);
+      return 409;
    }
-   else if (strcmp(decision, "reject") == 0)
-   {
-      rc = db1_work_item_set_terminal(id, "rejected");
-   }
-   else
+   if (strcmp(decision, "approve") != 0 && strcmp(decision, "reject") != 0)
    {
       cJSON_Delete(body);
       snprintf(resp, cap, "{\"error\":\"decision must be 'approve' or 'reject'\"}");
       return 400;
    }
-   cJSON_Delete(body);
-   if (rc != 0)
+
+   const char *result_kind = decision; /* audit kind; a reject may become reject_retry */
+   char detail[256] = "";
+
+   if (strcmp(decision, "approve") == 0)
    {
-      snprintf(resp, cap, "{\"error\":\"gate %s failed\"}", decision);
-      return 500;
+      /* Record the non-repudiable approval first (idempotent on a duplicate hash),
+       * THEN atomically clear the pause — so the pause is never cleared without a
+       * preceding signed approval. */
+      int present = wfe_approval_present(id, gate, wi.content_hash);
+      if (!present && wfe_approval_record(id, gate, wi.content_hash, actor) != 0)
+      {
+         cJSON_Delete(body);
+         snprintf(resp, cap, "{\"error\":\"could not record approval\"}");
+         return 500;
+      }
+      int g = db1_work_item_gate_apply(id, wi.current_stage, wi.content_hash, NULL, NULL);
+      if (g < 0)
+      {
+         cJSON_Delete(body);
+         snprintf(resp, cap, "{\"error\":\"gate apply failed\"}");
+         return 500;
+      }
+      if (g == 0)
+      {
+         /* Not in the observed parked state. A prior identical approve having
+          * already resumed it is idempotent success; anything else is a conflict. */
+         cJSON_Delete(body);
+         if (present)
+         {
+            snprintf(resp, cap,
+                     "{\"work_item_id\":\"%s\",\"gate\":\"%s\",\"decision\":\"approve\"}", id,
+                     gate);
+            return 200;
+         }
+         snprintf(resp, cap, "{\"error\":\"run not parked at this gate (state changed)\"}");
+         return 409;
+      }
+      /* No detail: the audit row's gate column already carries the stage. */
    }
+   else /* reject — terminal by default; loop back only on an in-budget opt-in gate */
+   {
+      int retries = gate_count_reject_retries(id, gate); /* per-gate; -1 on DB error */
+      const char *new_stage = NULL, *terminal_state = "rejected";
+      char target[WFE_ID_LEN] = "";
+      /* The atomic gate_apply below serializes rejects per parked state (a
+       * successful loop-back changes current_stage + clears the pause, so any
+       * concurrent reject hits the guard and 409s), so this pre-read retry count
+       * cannot be raced past the cap. A negative count is a DB read error -> fail
+       * closed (terminal), never silently unbounded. */
+      if (retries < 0)
+         LOG_WARN("server.workflow",
+                  "gate reject %s/%s: retry count unavailable; failing closed (terminal)", id,
+                  gate);
+      else if (retries < GATE_MAX_REJECT_RETRIES)
+      {
+         char ferr[256];
+         wfe_def_t *def = wfe_load_workflow(wi.workflow_name, ferr, sizeof ferr);
+         if (def)
+         {
+            if (wfe_gate_reject_target(def, gate, target, sizeof target) == WFE_GATE_REJECT_RETRY)
+            {
+               new_stage = target;
+               terminal_state = NULL;
+               result_kind = "reject_retry";
+            }
+            wfe_def_free(def);
+         }
+         else /* unloadable def degrades to terminal, but loudly so ops can see it */
+            LOG_WARN("server.workflow",
+                     "gate reject %s/%s: workflow '%s' unloadable (%s); terminal", id, gate,
+                     wi.workflow_name, ferr);
+      }
+      int g = db1_work_item_gate_apply(id, wi.current_stage, wi.content_hash, new_stage,
+                                       terminal_state);
+      if (g < 0)
+      {
+         cJSON_Delete(body);
+         snprintf(resp, cap, "{\"error\":\"gate apply failed\"}");
+         return 500;
+      }
+      if (g == 0)
+      {
+         cJSON_Delete(body);
+         snprintf(resp, cap, "{\"error\":\"run not parked at this gate (state changed)\"}");
+         return 409;
+      }
+      if (new_stage)
+         snprintf(detail, sizeof detail, "from=%s to=%s", gate, new_stage);
+      else if (retries < 0)
+         snprintf(detail, sizeof detail, "stage=%s reason=retry_count_unavailable", gate);
+      else if (retries >= GATE_MAX_REJECT_RETRIES)
+         snprintf(detail, sizeof detail, "stage=%s reason=retry_cap_exceeded", gate);
+      else
+         snprintf(detail, sizeof detail, "stage=%s reason=rejected", gate);
+   }
+
+   cJSON_Delete(body);
+   /* Append-only audit event (unsigned by design, like every lifecycle event;
+    * non-repudiation for approvals lives in the signed approval record). The 6th
+    * arg is content_hash (string); the 7th is cost (double). */
+   db1_lifecycle_event_add(id, gate, result_kind, actor, detail, wi.content_hash, 0.0);
    wfe_scheduler_notify(); /* resume the run server-side */
    snprintf(resp, cap, "{\"work_item_id\":\"%s\",\"gate\":\"%s\",\"decision\":\"%s\"}", id, gate,
-            decision);
+            result_kind);
    return 200;
 }
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -112,6 +112,9 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-wfe-delegate-seam \
                $(TESTPREFIX)/unit-test-wfe-scheduler \
                $(TESTPREFIX)/unit-test-wfe-random-delegate \
+               $(TESTPREFIX)/unit-test-wfe-gate-reject \
+               $(TESTPREFIX)/unit-test-wfe-gate-apply \
+               $(TESTPREFIX)/unit-test-workflow-gate-caps \
                $(TESTPREFIX)/unit-test-wfe-webapi \
                $(TESTPREFIX)/unit-test-cli-profile \
                $(TESTPREFIX)/unit-test-cmd-profile \
@@ -1151,6 +1154,25 @@ $(TESTPREFIX)/unit-test-wfe-scheduler: $(OBJDIR)/tests/test_wfe_scheduler.o \
 
 $(TESTPREFIX)/unit-test-wfe-random-delegate: $(OBJDIR)/tests/test_wfe_random_delegate.o \
                                     $(OBJDIR)/server/wfe_delegate_resolve.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+# Human-gate reject routing (retry_on_reject): pure def-query, no DB.
+$(TESTPREFIX)/unit-test-wfe-gate-reject: $(OBJDIR)/tests/test_wfe_gate_reject.o \
+                                    $(OBJDIR)/workflow/wfe_def.o $(OBJDIR)/workflow/wfe_iface.o \
+                                    $(OBJDIR)/workflow/wfe_validate.o $(OBJDIR)/workflow/wfe_canonical.o \
+                                    $(OBJDIR)/workflow/wfe_custom.o $(OBJDIR)/aimee_home.o \
+                                    $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Atomic guarded human-gate transition (DB1-backed).
+$(TESTPREFIX)/unit-test-wfe-gate-apply: $(OBJDIR)/tests/test_wfe_gate_apply.o \
+                                    $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db_schema.o \
+                                    $(OBJDIR)/db1/wfe_store.o $(OBJDIR)/aimee_home.o \
+                                    $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Capability invariant for the gate route (compile-time _Static_assert).
+$(TESTPREFIX)/unit-test-workflow-gate-caps: $(OBJDIR)/tests/test_workflow_gate_caps.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 # Workflow visual composer (W7): /v1/workflow read+author handlers.

--- a/src/tests/test_wfe_gate_apply.c
+++ b/src/tests/test_wfe_gate_apply.c
@@ -1,0 +1,77 @@
+/* test_wfe_gate_apply.c -- db1_work_item_gate_apply: the single guarded UPDATE
+ * behind operator human-gate decisions. Proves the state-precondition guard
+ * (current_stage + content_hash + pause_reason='pending_human') so a stale /
+ * double / concurrent decision returns 0 (409) instead of corrupting state, and
+ * that approve / terminal-reject / retry-loop-back each land correctly. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "db1.h"
+#include "wfe_store.h"
+
+/* Park a fresh work item at gate stage `stage` with content hash `hash`. */
+static void make_parked(const char *id, const char *repo, const char *stage, const char *hash)
+{
+   assert(db1_work_item_create(id, repo, repo /*proposal_path*/, "build", "v1", stage,
+                               "autonomous") == 0);
+   assert(db1_work_item_set_stage(id, stage, hash) == 0);
+   assert(db1_work_item_set_pause(id, "pending_human", "") == 0);
+}
+
+static void get(const char *id, db1_work_item_t *wi)
+{
+   assert(db1_work_item_get(id, wi) == 1);
+}
+
+int main(void)
+{
+   printf("wfe-gate-apply: ");
+   assert(db1_init(":memory:") == 0);
+   db1_work_item_t wi;
+
+   /* --- approve: clears pause, keeps stage + active state. --- */
+   make_parked("wi_a", "r/a", "g", "h1");
+   assert(db1_work_item_gate_apply("wi_a", "g", "h1", NULL, NULL) == 1);
+   get("wi_a", &wi);
+   assert(wi.pause_reason[0] == '\0');         /* pause cleared */
+   assert(strcmp(wi.current_stage, "g") == 0); /* stage unchanged */
+   assert(strcmp(wi.state, "active") == 0);    /* not terminal */
+
+   /* --- TOCTOU: a second identical apply now finds it not parked -> 0. --- */
+   assert(db1_work_item_gate_apply("wi_a", "g", "h1", NULL, NULL) == 0);
+
+   /* --- terminal reject: state=rejected, pause cleared. --- */
+   make_parked("wi_t", "r/t", "g", "h1");
+   assert(db1_work_item_gate_apply("wi_t", "g", "h1", NULL, "rejected") == 1);
+   get("wi_t", &wi);
+   assert(strcmp(wi.state, "rejected") == 0);
+   assert(wi.pause_reason[0] == '\0');
+
+   /* --- retry loop-back: current_stage moves to the on_fail target, pause cleared,
+    *     still active. --- */
+   make_parked("wi_r", "r/r", "g", "h1");
+   assert(db1_work_item_gate_apply("wi_r", "g", "h1", "impl", NULL) == 1);
+   get("wi_r", &wi);
+   assert(strcmp(wi.current_stage, "impl") == 0);
+   assert(wi.pause_reason[0] == '\0');
+   assert(strcmp(wi.state, "active") == 0);
+
+   /* --- guard: a stale content_hash is refused (optimistic-concurrency). --- */
+   make_parked("wi_h", "r/h", "g", "h1");
+   assert(db1_work_item_gate_apply("wi_h", "g", "WRONG", NULL, NULL) == 0);
+   get("wi_h", &wi);
+   assert(strcmp(wi.pause_reason, "pending_human") == 0); /* untouched */
+
+   /* --- guard: a stale stage is refused. --- */
+   assert(db1_work_item_gate_apply("wi_h", "wrongstage", "h1", NULL, NULL) == 0);
+   get("wi_h", &wi);
+   assert(strcmp(wi.pause_reason, "pending_human") == 0); /* still untouched */
+
+   /* --- guard: a not-parked item (pause already cleared) is refused. --- */
+   assert(db1_work_item_gate_apply("wi_h", "g", "h1", NULL, NULL) == 1);   /* clears it */
+   assert(db1_work_item_gate_apply("wi_h", "g", "h1", "impl", NULL) == 0); /* now refused */
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_wfe_gate_reject.c
+++ b/src/tests/test_wfe_gate_reject.c
@@ -1,0 +1,90 @@
+/* test_wfe_gate_reject.c -- wfe_gate_reject_target: how an operator reject at a
+ * human gate routes, decided purely from the parsed workflow def. Reject is
+ * TERMINAL by default; a gate opts into loop-back via params.retry_on_reject:true
+ * following its on_fail edge, but only if that on_fail target still resolves. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "wfe_def.h"
+
+/* A gate `g` that opts into retry and loops back to `impl` (which exists). */
+static const char *WF_RETRY = "name: t\nstart: g\nnodes:\n"
+                              "  - id: g\n    block: gate.human\n    params:\n"
+                              "      retry_on_reject: true\n    on_fail: impl\n    on_pass: m\n"
+                              "  - id: impl\n    block: implement\n    next: g\n"
+                              "  - id: m\n    block: merge\n";
+
+/* Same, but the gate does NOT opt in -> terminal. */
+static const char *WF_NOOPT =
+    "name: t\nstart: g\nnodes:\n"
+    "  - id: g\n    block: gate.human\n    on_fail: impl\n    on_pass: m\n"
+    "  - id: impl\n    block: implement\n    next: g\n"
+    "  - id: m\n    block: merge\n";
+
+/* Opts in but has NO on_fail edge -> nowhere to loop back -> terminal. */
+static const char *WF_NOEDGE = "name: t\nstart: g\nnodes:\n"
+                               "  - id: g\n    block: gate.human\n    params:\n"
+                               "      retry_on_reject: true\n    on_pass: m\n"
+                               "  - id: m\n    block: merge\n";
+
+/* Opts in with an on_fail edge naming a node that does NOT exist -> degrade to
+ * terminal (a removed/renamed target never becomes a dangling stage). */
+static const char *WF_DANGLING = "name: t\nstart: g\nnodes:\n"
+                                 "  - id: g\n    block: gate.human\n    params:\n"
+                                 "      retry_on_reject: true\n    on_fail: gone\n    on_pass: m\n"
+                                 "  - id: m\n    block: merge\n";
+
+static wfe_def_t *parse(const char *yaml)
+{
+   char err[256] = "";
+   wfe_def_t *d = wfe_def_parse(yaml, err, sizeof err);
+   assert(d && "parse failed");
+   return d;
+}
+
+int main(void)
+{
+   printf("wfe-gate-reject: ");
+   char target[WFE_ID_LEN];
+
+   /* (a) opt-in + valid on_fail -> RETRY, target filled. */
+   wfe_def_t *d = parse(WF_RETRY);
+   target[0] = '\0';
+   assert(wfe_gate_reject_target(d, "g", target, sizeof target) == WFE_GATE_REJECT_RETRY);
+   assert(strcmp(target, "impl") == 0);
+   wfe_def_free(d);
+
+   /* (b) no opt-in -> TERMINAL, target untouched. */
+   d = parse(WF_NOOPT);
+   target[0] = '\0';
+   assert(wfe_gate_reject_target(d, "g", target, sizeof target) == WFE_GATE_REJECT_TERMINAL);
+   assert(target[0] == '\0');
+   wfe_def_free(d);
+
+   /* (c) opt-in but no on_fail edge -> TERMINAL. */
+   d = parse(WF_NOEDGE);
+   assert(wfe_gate_reject_target(d, "g", target, sizeof target) == WFE_GATE_REJECT_TERMINAL);
+   wfe_def_free(d);
+
+   /* (d) opt-in but on_fail target does not resolve -> TERMINAL (no dangling stage). */
+   d = parse(WF_DANGLING);
+   assert(wfe_gate_reject_target(d, "g", target, sizeof target) == WFE_GATE_REJECT_TERMINAL);
+   wfe_def_free(d);
+
+   /* (e) unknown gate id -> TERMINAL (safe default). */
+   d = parse(WF_RETRY);
+   assert(wfe_gate_reject_target(d, "nope", target, sizeof target) == WFE_GATE_REJECT_TERMINAL);
+
+   /* (f) NULL def / NULL gate id -> ERR. */
+   assert(wfe_gate_reject_target(NULL, "g", target, sizeof target) == WFE_GATE_REJECT_ERR);
+   assert(wfe_gate_reject_target(d, NULL, target, sizeof target) == WFE_GATE_REJECT_ERR);
+
+   /* (g) out_target too small to hold "impl" -> ERR (refuse rather than mis-route). */
+   char tiny[3];
+   assert(wfe_gate_reject_target(d, "g", tiny, sizeof tiny) == WFE_GATE_REJECT_ERR);
+   wfe_def_free(d);
+
+   printf("ok\n");
+   return 0;
+}

--- a/src/tests/test_workflow_gate_caps.c
+++ b/src/tests/test_workflow_gate_caps.c
@@ -1,0 +1,25 @@
+/* test_workflow_gate_caps.c -- the capability invariant the human-gate route
+ * (POST /v1/workflow/items/<id>/gate, CAP_WORKFLOW_ADMIN) relies on: a mere
+ * authenticated / delegate bearer must NOT carry the operator-level gate cap, so
+ * it can never approve or reject an autonomous-workflow human gate. Verified at
+ * compile time against the cap-set macros the route table consumes. */
+#include <assert.h>
+#include <stdio.h>
+
+#include "server.h"
+
+/* CAP_WORKFLOW_ADMIN is deliberately OUTSIDE CAPS_AUTHENTICATED (UDS / webchat-
+ * admin / full-trust only), while CAP_DELEGATE is inside it. If either drifts,
+ * a delegate bearer could drive a human gate -> fail the build, not production. */
+_Static_assert((CAPS_AUTHENTICATED & CAP_WORKFLOW_ADMIN) == 0,
+               "CAP_WORKFLOW_ADMIN must stay outside CAPS_AUTHENTICATED");
+_Static_assert((CAPS_AUTHENTICATED & CAP_DELEGATE) != 0,
+               "CAP_DELEGATE is expected inside CAPS_AUTHENTICATED");
+_Static_assert(CAP_WORKFLOW_ADMIN != CAP_DELEGATE,
+               "gate-admin and delegate must be distinct capabilities");
+
+int main(void)
+{
+   printf("workflow-gate-caps: ok\n");
+   return 0;
+}

--- a/src/workflow/wfe_def.c
+++ b/src/workflow/wfe_def.c
@@ -312,3 +312,30 @@ const wfe_node_t *wfe_def_node(const wfe_def_t *def, const char *id)
          return &def->nodes[i];
    return NULL;
 }
+
+wfe_gate_reject_t wfe_gate_reject_target(const wfe_def_t *def, const char *gate_id,
+                                         char *out_target, size_t out_n)
+{
+   if (!def || !gate_id || !gate_id[0])
+      return WFE_GATE_REJECT_ERR;
+   const wfe_node_t *node = wfe_def_node(def, gate_id);
+   if (!node)
+      return WFE_GATE_REJECT_TERMINAL; /* unknown gate -> safe default (terminal) */
+   /* Opt-in flag in the gate's params. */
+   const cJSON *rr =
+       node->params ? cJSON_GetObjectItemCaseSensitive(node->params, "retry_on_reject") : NULL;
+   if (!cJSON_IsTrue(rr))
+      return WFE_GATE_REJECT_TERMINAL;
+   /* Must have somewhere to loop back to, and that target must still resolve to a
+    * real node (a removed/renamed on_fail degrades safely to terminal, never a
+    * dangling stage — this also bounds the pause->reject def-staleness window). */
+   if (!node->on_fail[0] || !wfe_def_node(def, node->on_fail))
+      return WFE_GATE_REJECT_TERMINAL;
+   if (out_target && out_n)
+   {
+      if (strlen(node->on_fail) >= out_n)
+         return WFE_GATE_REJECT_ERR; /* would truncate -> refuse rather than mis-route */
+      snprintf(out_target, out_n, "%s", node->on_fail);
+   }
+   return WFE_GATE_REJECT_RETRY;
+}

--- a/src/workflow/wfe_def.h
+++ b/src/workflow/wfe_def.h
@@ -113,6 +113,27 @@ wfe_def_t *wfe_def_load_file(const char *path, char *err, size_t errlen);
 void wfe_def_free(wfe_def_t *def);
 const wfe_node_t *wfe_def_node(const wfe_def_t *def, const char *id);
 
+/* ---- Human-gate reject routing (see §5 of the lifecycle proposal) ----
+ * Reject is terminal by DEFAULT; a gate opts into loop-back retry via
+ * `retry_on_reject: true` in its params, following its `on_fail` edge. */
+typedef enum
+{
+   WFE_GATE_REJECT_TERMINAL = 0, /* default: reject -> terminal `rejected` */
+   WFE_GATE_REJECT_RETRY = 1,    /* opt-in: reject -> loop back to on_fail target */
+   WFE_GATE_REJECT_ERR = -1      /* bad args (NULL def / NULL gate_id / target truncation) */
+} wfe_gate_reject_t;
+
+/* Decide how a reject at gate `gate_id` should route, purely from the parsed def
+ * (no DB — unit-testable). Returns WFE_GATE_REJECT_RETRY iff the gate node exists,
+ * its params set `retry_on_reject: true`, it has a non-empty `on_fail` edge, AND
+ * that on_fail target resolves to a real node in `def` — then `out_target` is
+ * filled with the target node id. In every other in-bounds case (no opt-in, no
+ * on_fail edge, or a dangling/renamed on_fail target) it returns
+ * WFE_GATE_REJECT_TERMINAL and does NOT write `out_target`. NULL `def`/`gate_id`,
+ * or an `out_target` too small to hold the target id, return WFE_GATE_REJECT_ERR. */
+wfe_gate_reject_t wfe_gate_reject_target(const wfe_def_t *def, const char *gate_id,
+                                         char *out_target, size_t out_n);
+
 /* ---- Validate (wfe_validate.c). Returns 0 on success; nonzero + err set. ---- */
 int wfe_def_validate(const wfe_def_t *def, char *err, size_t errlen);
 


### PR DESCRIPTION
Completes the **autonomous-dev-webchat-and-random-delegate** proposal. The bulk
(B1 submit form, B2 gate approve/reject, C \$random delegate) was already shipped;
this PR closes the B2 design gap (`retry_on_reject` opt-in) and hardens the gate
handler against a real reject-side race.

## What
- **`db1_work_item_gate_apply`** — one guarded `UPDATE` (`WHERE current_stage +
  content_hash match AND pause_reason='pending_human'`) behind every operator gate
  decision, returning `1/0/-1`. Fixes a pre-existing TOCTOU/idempotency gap in the
  shipped handler: a stale/double/concurrent decision now returns **409** instead
  of corrupting state. `content_hash` is the parked-row identity guard (content is
  immutable while parked).
- **`wfe_gate_reject_target`** (pure, `wfe_def.c`) — reject is **terminal by
  default**; a gate opts into loop-back via `retry_on_reject: true` following its
  `on_fail` edge, and the target must still resolve in the loaded def (a
  dangling/renamed target degrades safely to terminal).
- **`rh_workflow_gate` rewritten** — the gate is always the actually-parked stage
  (closes a confused-deputy where a request names a different gate); retry bounded
  **per-gate** by `GATE_MAX_REJECT_RETRIES=3` counted from the audit log
  (**fail-closed** on a DB read error); append-only lifecycle audit events
  (`approve | reject | reject_retry`); def-load failure logged.

## Tests (canonical `make unit-tests`)
- `test_wfe_gate_reject` — pure helper matrix (retry / terminal / no-edge /
  dangling-target / unknown-gate / NULL / truncation).
- `test_wfe_gate_apply` — DB1 guards (approve / terminal / retry loop-back +
  TOCTOU / stale-hash / stale-stage / not-parked all → 0).
- `test_workflow_gate_caps` — compile-time `_Static_assert` that
  `CAP_WORKFLOW_ADMIN` stays outside `CAPS_AUTHENTICATED`.

`make unit-tests` + `make lint` green; clang-format clean.

## Process
Plan and implementation both went through the agent roundtable
(`aimee delegate roundtable --mode review`); the plan's 5 blocking items were
resolved in code and the implementation review returned **APPROVE**. Follow-ups
F1 (version-pinned def loading), F2 (UI retry-eligibility hint), and F3
(idempotent signed approval) are recorded in the proposal doc, not silently
deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)