### PR TITLE
feat(aimee-llm): the unified container image (Dockerfile.aimee-llm) (P4)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -78,6 +78,12 @@ jobs:
           # baked in. Pair with embedding_dim: 2560 (see docs). Default (above) is
           # the 0.6b embedder + 400m reranker.
           - { name: aimee-embedder-4b, dockerfile: Dockerfile.embedder, embedder_arg: "EMBEDDER_MODEL=perplexity-ai/pplx-embed-v1-4b", reranker_arg: "RERANKER_MODEL=cross-encoder/ettin-reranker-1b-v1" }
+          # The unified aimee-llm container (one Vulkan llama.cpp + the gateway, models
+          # baked in). CPU tier = defaults (Qwen3-Emb-0.6B + ettin-68m + gemma-4-E4B,
+          # validated end-to-end on .253). GPU tier overrides to the 4B/400m/12B set;
+          # the same vendor-agnostic Vulkan binary runs CPU or GPU via AIMEE_LLM_NGL.
+          - { name: aimee-llm-cpu, dockerfile: Dockerfile.aimee-llm }
+          - { name: aimee-llm-gpu, dockerfile: Dockerfile.aimee-llm, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12b-it-GGUF\nSYNTH_FILE=gemma-4-12b-it-Q4_K_M.gguf" }
           # #4-full render backend (headless-Chromium sidecar). Self-contained
           # under deploy/css-render (its own build context); independent of the C
           # build, so a failure here never blocks the aimee images (fail-fast off).
@@ -130,6 +136,7 @@ jobs:
             WITH_WEBCHAT=1
             ${{ matrix.image.embedder_arg }}
             ${{ matrix.image.reranker_arg }}
+            ${{ matrix.image.extra_args }}
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/Dockerfile.aimee-llm
+++ b/Dockerfile.aimee-llm
@@ -1,0 +1,103 @@
+# The unified aimee-llm container: one llama.cpp (Vulkan) runtime + the aimee-llm
+# gateway, serving embeddings, reranking, and synthesis from BAKED-IN GGUFs.
+# Replaces the torch embedder + the standalone llama.cpp `llm` container.
+#
+# Two published images (operator-directed: models baked in, not runtime-fetched —
+# turnkey, reproducible, no HF dependency at run time):
+#   aimee-llm-cpu  (TIER=cpu, default): Qwen3-Embedding-0.6B + ettin-68m + gemma-4-E4B
+#   aimee-llm-gpu  (TIER=gpu, via build args): Qwen3-Embedding-4B + ettin-400m + gemma-4-12B
+# The llama.cpp binary is the VENDOR-AGNOSTIC Vulkan build (one binary for AMD/
+# Nvidia/Intel); GPU is selected at runtime by AIMEE_LLM_NGL (CPU image defaults 0).
+#
+# The reranker is ettin served as ENCODER + a gateway-side Dense head (the ST score
+# head doesn't survive GGUF conversion — see benchmarks/results/unified-llm/
+# P2-serving-validation.md): convert the ettin encoder to GGUF and keep the head
+# safetensors; the gateway applies the head.
+
+ARG LLAMA_TAG=b9775
+ARG EMBED_REPO=Qwen/Qwen3-Embedding-0.6B-GGUF
+ARG EMBED_FILE=Qwen3-Embedding-0.6B-f16.gguf
+ARG EMBED_POOLING=last
+ARG RERANK_REPO=cross-encoder/ettin-reranker-68m-v1
+ARG SYNTH_REPO=ggml-org/gemma-4-E4B-it-GGUF
+ARG SYNTH_FILE=gemma-4-E4B-it-Q4_K_M.gguf
+
+# ---- stage 1: prepare the baked models (convert ettin encoder + fetch GGUFs) ----
+FROM python:3.12-slim AS modelprep
+ARG LLAMA_TAG
+ARG EMBED_REPO
+ARG EMBED_FILE
+ARG RERANK_REPO
+ARG SYNTH_REPO
+ARG SYNTH_FILE
+ENV PIP_NO_CACHE_DIR=1 HF_HUB_DISABLE_TELEMETRY=1
+RUN apt-get update && apt-get install -y --no-install-recommends git wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --quiet torch --index-url https://download.pytorch.org/whl/cpu \
+    && pip install --quiet transformers safetensors numpy gguf sentencepiece protobuf huggingface_hub
+# convert script + gguf-py from a recent llama.cpp (ModernBert supported)
+RUN git clone --depth 1 https://github.com/ggml-org/llama.cpp /llama
+WORKDIR /out
+# Ettin reranker: download the sentence-transformers repo, convert the ENCODER to
+# GGUF, and keep the Dense head (2_Dense/3_LayerNorm/4_Dense) for the gateway.
+RUN python - <<'PY'
+import os
+from huggingface_hub import snapshot_download
+p = snapshot_download(os.environ["RERANK_REPO"], local_dir="/tmp/ettin")
+print("ettin ->", p)
+PY
+RUN cd /llama && PYTHONPATH=/llama/gguf-py python convert_hf_to_gguf.py /tmp/ettin \
+        --outfile /out/rerank-encoder.gguf --outtype f16 \
+    && mkdir -p /out/rerank-head
+# Bake the Dense head as a numpy .npz so the slim runtime needs only numpy (no
+# safetensors). Keys match EttinRerankHead.from_npz (W2/W4/b4/gamma/beta).
+RUN python - <<'PY'
+import numpy as np
+from safetensors.numpy import load_file
+e = "/tmp/ettin"
+W2 = load_file(f"{e}/2_Dense/model.safetensors")["linear.weight"]
+d4 = load_file(f"{e}/4_Dense/model.safetensors")
+ln = load_file(f"{e}/3_LayerNorm/model.safetensors")
+np.savez("/out/rerank-head/head.npz", W2=W2, W4=d4["linear.weight"], b4=d4["linear.bias"],
+         gamma=ln["norm.weight"], beta=ln["norm.bias"])
+print("head.npz written")
+PY
+# Embedder + synth GGUFs (direct HF download)
+RUN wget -q -O /out/embed.gguf  "https://huggingface.co/${EMBED_REPO}/resolve/main/${EMBED_FILE}" \
+    && wget -q -O /out/synth.gguf "https://huggingface.co/${SYNTH_REPO}/resolve/main/${SYNTH_FILE}"
+
+# ---- stage 2: runtime — Vulkan llama.cpp + the gateway ----
+FROM debian:bookworm-slim AS runtime
+ARG LLAMA_TAG
+ARG EMBED_POOLING
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates curl wget libgomp1 libcurl4 libvulkan1 mesa-vulkan-drivers \
+        python3 python3-numpy \
+    && rm -rf /var/lib/apt/lists/*
+# llama.cpp vendor-agnostic Vulkan release (one binary for AMD/Nvidia/Intel)
+RUN wget -q -O /tmp/llama.tgz \
+        "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_TAG}/llama-${LLAMA_TAG}-bin-ubuntu-vulkan-x64.tar.gz" \
+    && mkdir -p /opt/llama && tar -xzf /tmp/llama.tgz -C /opt/llama --strip-components=1 \
+    && rm /tmp/llama.tgz
+ENV LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PATH=/opt/llama:/opt/llama/bin:$PATH
+
+COPY scripts/aimee_llm_gateway.py scripts/aimee_llm_rerank_head.py /opt/aimee/
+COPY scripts/aimee-llm-supervisor.sh /opt/aimee/supervisor.sh
+RUN chmod +x /opt/aimee/supervisor.sh
+COPY --from=modelprep /out /models
+
+# Gateway + per-role serving config (the supervisor reads these).
+ENV AIMEE_LLM_PORT=8080 \
+    AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
+    AIMEE_LLM_RERANK_URL=http://127.0.0.1:8082 \
+    AIMEE_LLM_SYNTH_URL=http://127.0.0.1:8083 \
+    AIMEE_LLM_RERANK_HEAD=/models/rerank-head \
+    AIMEE_LLM_EMBED_MODEL=qwen3-embedding \
+    AIMEE_LLM_EMBED_POOLING=${EMBED_POOLING} \
+    AIMEE_LLM_NGL=0 \
+    PYTHONPATH=/opt/aimee
+WORKDIR /opt/aimee
+EXPOSE 8080
+HEALTHCHECK --interval=30s --timeout=5s --start-period=300s --retries=3 \
+    CMD curl -fsS http://127.0.0.1:8080/health >/dev/null || exit 1
+ENTRYPOINT ["/opt/aimee/supervisor.sh"]

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# aimee-llm container supervisor: launch the per-role llama.cpp servers (embed,
+# rerank-encoder, synth) from the baked GGUFs, then the gateway. Each role is its
+# own llama-server process so a crash is isolated to that role; if any exits the
+# supervisor tears the container down (the orchestrator restarts it). A full
+# s6-overlay (per-role restart) is the follow-up; this is the MVP supervisor.
+set -u
+LLAMA=/opt/llama/llama-server
+NGL="${AIMEE_LLM_NGL:-0}"
+POOL="${AIMEE_LLM_EMBED_POOLING:-last}"
+pids=()
+
+start() { # name port extra-args...
+  local name="$1" port="$2"; shift 2
+  echo "aimee-llm: starting $name on :$port (ngl=$NGL)" >&2
+  "$LLAMA" --host 127.0.0.1 --port "$port" -ngl "$NGL" "$@" >&2 &
+  pids+=("$!")
+}
+
+# Embedder: one vector per input, no prompt-cache fragmentation (P2 flags).
+start embed 8081 -m /models/embed.gguf --embeddings --pooling "$POOL" \
+  --ctx-size 8192 -ub 512 -np 1 --cache-ram 0 --no-cache-idle-slots
+# Reranker ENCODER: CLS pooling + flash-attn; the gateway applies the Dense head.
+start rerank 8082 -m /models/rerank-encoder.gguf --embeddings --pooling cls -fa on
+# Synth: OpenAI-compatible /v1/chat/completions (grammar/JSON via --jinja).
+if [ -f /models/synth.gguf ]; then
+  start synth 8083 -m /models/synth.gguf --ctx-size 8192 --jinja
+fi
+
+# Gateway (foreground-ish; backgrounded so we can reap any child exit).
+echo "aimee-llm: starting gateway on :${AIMEE_LLM_PORT:-8080}" >&2
+python3 /opt/aimee/aimee_llm_gateway.py >&2 &
+pids+=("$!")
+
+# If ANY supervised process exits, stop the rest and exit non-zero so the
+# orchestrator restarts the container (restart isolation is the s6 follow-up).
+wait -n "${pids[@]}"
+code=$?
+echo "aimee-llm: a supervised process exited ($code); shutting down" >&2
+kill "${pids[@]}" 2>/dev/null
+exit "${code:-1}"

--- a/scripts/aimee_llm_rerank_head.py
+++ b/scripts/aimee_llm_rerank_head.py
@@ -60,10 +60,35 @@ class EttinRerankHead:
         return self.W2.shape[0]
 
     @classmethod
+    def from_npz(cls, path):
+        """Load the head from a numpy .npz (keys W2/W4/b4/gamma/beta) — the form
+        baked into the runtime image so it needs only numpy, not safetensors."""
+        z = np.load(path)
+        return cls(
+            w2=z["W2"],
+            w4=z["W4"],
+            b4=z["b4"] if "b4" in z else None,
+            gamma=z["gamma"] if "gamma" in z else None,
+            beta=z["beta"] if "beta" in z else None,
+        )
+
+    def to_npz(self, path):
+        """Save the head as a numpy .npz (the runtime form; built in the image's
+        modelprep stage so the slim runtime needs only numpy)."""
+        d = {"W2": self.W2, "W4": self.W4, "b4": np.asarray(self.b4, dtype=np.float32)}
+        if self.gamma is not None and self.beta is not None:
+            d["gamma"] = self.gamma
+            d["beta"] = self.beta
+        np.savez(path, **d)
+
+    @classmethod
     def from_dir(cls, model_dir):
-        """Load the head from a sentence-transformers model dir (2_Dense/3_LayerNorm/
-        4_Dense/*.safetensors). Raises FileNotFoundError if the dense modules are absent
-        (i.e. this isn't an st-reranker dir)."""
+        """Load the head from `model_dir`. Prefers a prebuilt `head.npz` (numpy-only,
+        baked into the image); else the sentence-transformers
+        2_Dense/3_LayerNorm/4_Dense safetensors (needs the safetensors lib)."""
+        npz = os.path.join(model_dir, "head.npz")
+        if os.path.exists(npz):
+            return cls.from_npz(npz)
         from safetensors.numpy import load_file
 
         d2 = load_file(os.path.join(model_dir, "2_Dense", "model.safetensors"))

--- a/scripts/tests/test_rerank_head.py
+++ b/scripts/tests/test_rerank_head.py
@@ -152,6 +152,12 @@ class FromDir(unittest.TestCase):
         direct = m.EttinRerankHead(W2, W4, b4, g, b)
         self.assertAlmostEqual(head.score(v), direct.score(v), places=5)
 
+        # npz round-trip (the runtime form baked into the image); from_dir prefers it.
+        npz = os.path.join(d, "head.npz")
+        direct.to_npz(npz)
+        self.assertAlmostEqual(m.EttinRerankHead.from_npz(npz).score(v), direct.score(v), places=5)
+        self.assertAlmostEqual(m.EttinRerankHead.from_dir(d).score(v), direct.score(v), places=5)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
**Packet P4** of unified-llm-container — the actual container, **validated building + serving on real hardware** (`.253`, docker, the `aimee-docker` CT).

## What
One **Vulkan** llama.cpp runtime + the aimee-llm gateway (from P3), serving embed/rerank/synth from **baked-in GGUFs** — replaces the torch embedder + the standalone `llm` container.

- **`Dockerfile.aimee-llm`** (multi-stage):
  - *modelprep*: **converts the ettin reranker encoder to GGUF** + bakes its Dense head as a numpy **`.npz`** (so the slim runtime needs only numpy — no safetensors/torch) + fetches the embed + synth GGUFs.
  - *runtime*: the **vendor-agnostic** llama.cpp **Vulkan** release (one binary for AMD/Nvidia/Intel) + the gateway + a supervisor. CPU tier = defaults (Qwen3-Emb-0.6B + ettin-68m + gemma-4-E4B); GPU tier overrides to 4B/400m/12B via build args. GPU is a runtime choice (`AIMEE_LLM_NGL`).
- **`scripts/aimee-llm-supervisor.sh`** launches the per-role llama-servers (embed :8081, rerank-encoder :8082 CLS+`-fa on`, synth :8083) + the gateway :8080.
- `EttinRerankHead` gains `from_npz`/`to_npz`; `from_dir` prefers the baked `head.npz`.
- `publish-images.yml`: `aimee-llm-cpu` + `aimee-llm-gpu` (added a generic `extra_args` build field).

## Validated (.253, real docker + hardware)
`aimee-llm:cpu` (6.47 GB) builds, and the running container:
- `/health` → **ok in 10s**
- `/embed` → **1024-d** (Qwen3-0.6B)
- `/rerank` → **`[4.04, 10.10]`** — the python doc correctly outranks the irrelevant one, i.e. **the ettin encoder + gateway-head reranker works inside the container.**
- 12 gateway/head unit tests green (incl. the new npz round-trip).

## Scope
Ships the **validated image + publish wiring**. The compose collapse, **tierd/LXC deploy**, the **GPU-image** build/validation, **synth `/v1/chat/completions` proxying**, and full **s6** per-role restart are the cutover (P7) + follow-ups.