### PR TITLE
feat(ingress): default claude_proxy_parity to ON

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -32,7 +32,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `cache_shaping_enabled` | bool | Enable prompt cache-shaping. |
 | `claude_cli_delegate_enabled` | bool | Allow delegating to the local Claude CLI agent. |
 | `claude_model` | string | Default Claude model (empty = CLI default). |
-| `claude_proxy_parity` | bool | Make the Claude Code `/v1/messages` ingress a transparent Anthropic passthrough (honor inbound model, skip pre-injection, forward anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). Default off. |
+| `claude_proxy_parity` | bool | Make the Claude Code `/v1/messages` ingress a transparent Anthropic passthrough (honor inbound model, skip pre-injection, forward anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). Default on. |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |
 | `cost_reward_lambda_pct` | int | Cost-penalty weight (percent) in the reward. |
 | `cost_reward_ref_usd_milli` | int | Reference cost (USD-milli) normalizing the cost reward. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -109,7 +109,7 @@ CFG_KEY_DESC = {
     "claude_proxy_parity": "Make the Claude Code `/v1/messages` ingress a transparent "
     "Anthropic passthrough (honor inbound model, skip pre-injection, forward "
     "anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). "
-    "Default off.",
+    "Default on.",
     "cost_reward_enabled": "Factor token cost into the reward signal.",
     "cost_reward_lambda_pct": "Cost-penalty weight (percent) in the reward.",
     "cost_reward_ref_usd_milli": "Reference cost (USD-milli) normalizing the cost reward.",

--- a/src/config.c
+++ b/src/config.c
@@ -504,6 +504,11 @@ static void config_set_defaults(config_t *cfg)
    cfg->integrity_dry_run = 1;
    cfg->ingress_preinject_assembly_budget = 6144;
    cfg->ingress_max_raw_scans = 0;
+   /* Default ON: the Claude Code /v1/messages ingress is an exact Anthropic
+    * passthrough (honor inbound model, skip pre-injection, forward
+    * anthropic-version/anthropic-beta, proxy count_tokens, relay upstream
+    * errors + Retry-After). Set false to restore the model-swap proxy. */
+   cfg->claude_proxy_parity = 1;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -773,8 +773,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
-   if (cfg->claude_proxy_parity)
-      cJSON_AddBoolToObject(root, "claude_proxy_parity", 1);
+   if (!cfg->claude_proxy_parity) /* default on: persist only the off override */
+      cJSON_AddBoolToObject(root, "claude_proxy_parity", 0);
    if (cfg->ingress_preinject_assembly_budget != 6144)
       cJSON_AddNumberToObject(root, "ingress_preinject_assembly_budget",
                               cfg->ingress_preinject_assembly_budget);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -339,14 +339,14 @@ typedef struct config
    int ingress_max_raw_scans;
 
    /* Exact-parity mode for the Claude Code Anthropic ingress (POST /v1/messages).
-    * Default off: the ingress keeps its value-add proxy behavior (serves the
-    * configured primary model, applies context pre-injection). When on AND the
-    * primary is an Anthropic-profile agent, the ingress becomes a transparent
-    * passthrough so Claude Code gets byte-equivalent behavior to talking to
-    * api.anthropic.com directly: the inbound `model` is honored (no primary
-    * swap), pre-injection is skipped, the client's `anthropic-version` /
-    * `anthropic-beta` headers are forwarded upstream, count_tokens is proxied to
-    * the real endpoint, and upstream error status/body pass through unchanged. */
+    * Default ON. When on AND the primary is an Anthropic-profile agent, the
+    * ingress is a transparent passthrough so Claude Code gets byte-equivalent
+    * behavior to talking to api.anthropic.com directly: the inbound `model` is
+    * honored (no primary swap), pre-injection is skipped, the client's
+    * `anthropic-version` / `anthropic-beta` headers are forwarded upstream,
+    * count_tokens is proxied to the real endpoint, and upstream error status/body
+    * + Retry-After pass through unchanged. Set false to restore the model-swap
+    * proxy that serves the configured primary model and applies pre-injection. */
    int claude_proxy_parity;
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default


### PR DESCRIPTION
Flips the Claude Code `/v1/messages` ingress to exact Anthropic passthrough **by default** (`claude_proxy_parity` was opt-in, now opt-out). The model-swap + pre-injection proxy is now the `claude_proxy_parity: false` opt-out. `config_save` persists only the off override, per the default-on convention (cf. `memory_routing_enabled`).

**Verified end-to-end** against a real aimee-server + mock upstream:
- Default (no config key) → inbound model honored, `anthropic-version`/`anthropic-beta` forwarded upstream, `count_tokens` proxied to the real endpoint, upstream `429` + `Retry-After` relayed verbatim.
- `claude_proxy_parity: false` → model-swap restored (upstream gets the configured primary), betas dropped.

`make unit-tests` green; docs regenerated.