### PR TITLE
feat(aimee-llm): §1a security hardening for the gateway (P6)

### DIFF
--- a/.github/workflows/gateway-tests.yml
+++ b/.github/workflows/gateway-tests.yml
@@ -9,6 +9,7 @@ on:
       - 'scripts/aimee_llm_*.py'
       - 'scripts/tests/test_rerank_head.py'
       - 'scripts/tests/test_gateway.py'
+      - 'scripts/tests/test_gateway_security.py'
       - '.github/workflows/gateway-tests.yml'
   push:
     branches: [testing, main]
@@ -31,3 +32,4 @@ jobs:
         run: |
           python -m unittest discover -s scripts/tests -p 'test_rerank_head.py' -v
           python -m unittest discover -s scripts/tests -p 'test_gateway.py' -v
+          python -m unittest discover -s scripts/tests -p 'test_gateway_security.py' -v

--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -28,6 +28,7 @@ follow-up; this module is the retrieval gateway + the validated rerank-head path
 """
 import json
 import os
+import urllib.error
 import urllib.request
 
 EMBED_URL = os.environ.get("AIMEE_LLM_EMBED_URL", "http://127.0.0.1:8081").rstrip("/")
@@ -37,6 +38,13 @@ EMBED_MODEL = os.environ.get("AIMEE_LLM_EMBED_MODEL", "Qwen3-Embedding")
 PORT = int(os.environ.get("AIMEE_LLM_PORT", "8080"))
 BATCH_CAP = int(os.environ.get("AIMEE_LLM_BATCH_CAP", "512"))
 RERANK_SEP = "</s>"
+# Synth role: AIMEE_LLM_SYNTH_URL is the upstream OpenAI-compatible base; empty = no
+# synth configured (the role reports `gated`/unconfigured). Mode is informational here
+# (local = a baked llama-server; forward/external = an off-box upstream) — both just
+# proxy /v1/chat/completions to AIMEE_LLM_SYNTH_URL, which is why one code path serves
+# all three. Streaming is disabled in the first release (typed 400).
+SYNTH_URL = os.environ.get("AIMEE_LLM_SYNTH_URL", "").rstrip("/")
+SYNTH_MODE = os.environ.get("AIMEE_LLM_SYNTH_MODE", "local")
 
 
 class GatewayError(Exception):
@@ -136,17 +144,53 @@ def do_rerank(obj):
     return [float(s) for s in (scores if hasattr(scores, "__len__") else [scores])]
 
 
+def do_synth(body):
+    """Proxy a /v1/chat/completions request to the configured synth upstream
+    (AIMEE_LLM_SYNTH_URL — a local baked llama-server, or a forwarded/external base).
+    Streaming is disabled in the first release: `stream:true` -> a typed 400 the client
+    can branch on (rather than an opaque failure)."""
+    if not isinstance(body, dict):
+        raise GatewayError(400, "bad_request", "chat/completions expects a JSON object")
+    if body.get("stream"):
+        raise GatewayError(
+            400, "streaming_unsupported",
+            "streaming is disabled in this release; set stream=false")
+    if not SYNTH_URL:
+        raise GatewayError(503, "synth_unconfigured", "AIMEE_LLM_SYNTH_URL is not set")
+    return _http_post_json(f"{SYNTH_URL}/v1/chat/completions", body, timeout=300)
+
+
+def role_state(base, configured=True):
+    """Four-state readiness for one role (unified-llm §4): `gated` (role not configured
+    / upstream absent), `ready` (child serving), `loading` (child up but model warming,
+    503), `down` (configured but unreachable)."""
+    if not configured or not base:
+        return "gated"
+    try:
+        with urllib.request.urlopen(f"{base}/health", timeout=3) as r:
+            return "ready" if r.status == 200 else "loading"
+    except urllib.error.HTTPError as e:  # 503 while a model loads
+        return "loading" if e.code == 503 else "down"
+    except Exception:  # noqa: BLE001
+        return "down"
+
+
+def role_states():
+    """Per-role state for /health/{embed,rerank,synth}."""
+    return {
+        "embed": role_state(EMBED_URL),
+        "rerank": role_state(RERANK_URL, configured=bool(RERANK_HEAD_DIR)),
+        "synth": role_state(SYNTH_URL, configured=bool(SYNTH_URL)),
+    }
+
+
 def child_health():
-    """Probe the configured llama-server children. Returns role -> bool|None."""
-    out = {"embed": None, "rerank": None}
-    for role, base in (("embed", EMBED_URL), ("rerank", RERANK_URL if RERANK_HEAD_DIR else None)):
-        if not base:
-            continue
-        try:
-            with urllib.request.urlopen(f"{base}/health", timeout=3) as r:
-                out[role] = r.status == 200
-        except Exception:  # noqa: BLE001
-            out[role] = False
+    """Probe the configured llama-server children for the AGGREGATE /health. Returns
+    role -> bool|None (None = not configured, excluded from the aggregate)."""
+    states = role_states()
+    out = {}
+    for role, st in states.items():
+        out[role] = None if st == "gated" else (st == "ready")
     return out
 
 
@@ -166,9 +210,16 @@ def build_server():
             self.wfile.write(body)
 
         def do_GET(self):
-            if self.path.rstrip("/") == "/health":
+            path = self.path.rstrip("/")
+            if path == "/health":
                 st = health_state(child_health())
                 self._send(200 if st == "ok" else 503, {"status": st, "model": EMBED_MODEL})
+            elif path in ("/health/embed", "/health/rerank", "/health/synth"):
+                role = path.rsplit("/", 1)[1]
+                st = role_states()[role]
+                # ready=200 so a probe can gate on a single role (the kb hits
+                # /health/embed so it indexes as soon as embed is ready).
+                self._send(200 if st == "ready" else 503, {"status": st, "role": role})
             else:
                 self._send(404, {"error": "not found"})
 
@@ -186,6 +237,8 @@ def build_server():
                     self._send(200, do_embed_batch(json.loads(raw or b"[]")))
                 elif path == "/rerank":
                     self._send(200, do_rerank(json.loads(raw or b"[]")))
+                elif path == "/v1/chat/completions":
+                    self._send(200, do_synth(json.loads(raw or b"{}")))
                 else:
                     self._send(404, {"error": "not found"})
             except GatewayError as ge:

--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -26,8 +26,12 @@ Config (env):
 The router/modes (local/forward/external) and synth (/v1/chat/completions) land in a
 follow-up; this module is the retrieval gateway + the validated rerank-head path.
 """
+import hmac
 import json
 import os
+import sys
+import threading
+import time
 import urllib.error
 import urllib.request
 
@@ -46,6 +50,22 @@ RERANK_SEP = "</s>"
 SYNTH_URL = os.environ.get("AIMEE_LLM_SYNTH_URL", "").rstrip("/")
 SYNTH_MODE = os.environ.get("AIMEE_LLM_SYNTH_MODE", "local")
 
+# ---- §1a security: the gateway is privileged (it holds upstream creds + routes) ----
+# Bearer auth (constant-time). mTLS is the documented production posture; bearer-with-the
+# controls below is the in-container default. Empty token = auth disabled (dev only),
+# which the bind guard then refuses to expose on 0.0.0.0.
+AUTH_TOKEN = os.environ.get("AIMEE_LLM_AUTH_TOKEN", "")
+# The container binds 0.0.0.0 (reachable by kb/server on the deployment network, as the
+# embedder does today). With no auth the deployment network is the boundary; STRICT_BIND
+# turns the §1a "no unauthenticated wildcard" into a hard startup refuse for operators who
+# want it enforced rather than warned.
+BIND = os.environ.get("AIMEE_LLM_BIND", "0.0.0.0")
+STRICT_BIND = os.environ.get("AIMEE_LLM_STRICT_BIND", "") not in ("", "0", "false")
+# Scope is DERIVED from the authenticated identity, never trusted from the wire. With a
+# single bearer the gateway runs the operator/curator scope; per-user scope arrives with
+# mTLS cert CN / per-user tokens. A caller-supplied X-Aimee-Scope is always rejected.
+SCOPE_DEFAULT = os.environ.get("AIMEE_LLM_SCOPE", "curator")
+
 
 class GatewayError(Exception):
     """Carries an HTTP status + a typed error body."""
@@ -54,6 +74,115 @@ class GatewayError(Exception):
         super().__init__(message)
         self.status = status
         self.body = {"error": {"code": code, "message": message}}
+
+
+# ---- §1a controls (pure; unit-tested without a model/network) ----
+
+def validate_bind(bind, auth_token, strict=False):
+    """The gateway is privileged. A wildcard bind (0.0.0.0 / ::) with NO auth exposes an
+    unauthenticated surface — fine when the deployment network is the boundary (today's
+    posture), but flagged. Returns "ok" / "warn"; raises RuntimeError under `strict` so an
+    operator can enforce §1a's "no unauthenticated wildcard" as a hard startup failure."""
+    wildcard = bind in ("0.0.0.0", "::", "", "0")  # "0" is also INADDR_ANY on Linux
+    if wildcard and not auth_token:
+        if strict:
+            raise RuntimeError(
+                f"STRICT_BIND: refusing wildcard '{bind}' with no AIMEE_LLM_AUTH_TOKEN — set a "
+                "token (or mTLS); this is the §1a bind-address guard")
+        return "warn"
+    return "ok"
+
+
+def check_auth(auth_header):
+    """Constant-time bearer check. No token configured -> open (dev). Configured ->
+    require `Authorization: Bearer <token>`; mismatch/absent -> 401. Never logs the token."""
+    if not AUTH_TOKEN:
+        return
+    presented = ""
+    if auth_header and auth_header[:7].lower() == "bearer ":  # scheme is case-insensitive
+        presented = auth_header[7:].strip()
+    if not hmac.compare_digest(presented, AUTH_TOKEN):
+        raise GatewayError(401, "unauthorized", "missing or invalid bearer token")
+
+
+def derive_scope(get_header):
+    """Scope is DERIVED from the authenticated identity, never trusted from the wire. A
+    caller-supplied X-Aimee-Scope is rejected (anti-spoof). `get_header(name)` returns the
+    request header or None."""
+    if get_header("X-Aimee-Scope"):
+        raise GatewayError(403, "scope_spoof", "X-Aimee-Scope is set by the gateway, not the caller")
+    return SCOPE_DEFAULT
+
+
+_AUDIT_DENY = ("authorization", "cookie", "token", "secret", "key", "body", "prompt",
+               "content", "message", "input", "password")
+
+
+def audit(event, scope, outcome, **meta):
+    """Metadata-only audit line to the named sink (stderr, 'AIMEE-AUDIT' prefix). NEVER
+    content or credentials — only scope/outcome/byte-counts/request-id. A sanitizer drops
+    any meta key that looks credential/content-bearing so the guarantee holds even if a
+    future caller passes the wrong field. The kb/operator log pipeline ships these;
+    encryption + retention are the sink's concern."""
+    rec = {"audit": event, "scope": scope, "outcome": outcome}
+    for k, v in meta.items():
+        if any(bad in k.lower() for bad in _AUDIT_DENY):
+            continue  # never audit a credential/content-bearing field
+        rec[k] = v
+    sys.stderr.write("AIMEE-AUDIT " + json.dumps(rec, sort_keys=True) + "\n")
+    sys.stderr.flush()
+
+
+class CircuitBreaker:
+    """Per-upstream breaker for forward/external (§4): `threshold` consecutive errors OR
+    >50% error rate over `window`s -> open; after `recovery`s a half-open probe; one
+    success closes it. `allow()` is checked before a call; record the outcome after.
+    Clock injected for testing."""
+
+    def __init__(self, threshold=5, window=30.0, recovery=60.0, clock=time.monotonic):
+        self.threshold = threshold
+        self.window = window
+        self.recovery = recovery
+        self.clock = clock
+        self.state = "closed"
+        self._consec = 0
+        self._events = []  # (t, ok) within the window
+        self._opened_at = 0.0
+        self._lock = threading.Lock()  # the gateway is multi-threaded
+
+    def _prune(self, now):
+        self._events = [(t, ok) for (t, ok) in self._events if now - t <= self.window]
+
+    def allow(self):
+        with self._lock:
+            now = self.clock()
+            if self.state == "open":
+                if now - self._opened_at >= self.recovery:
+                    self.state = "half-open"
+                    return True  # single probe
+                return False
+            return True
+
+    def record(self, ok):
+        with self._lock:
+            now = self.clock()
+            self._events.append((now, ok))
+            self._prune(now)
+            if self.state == "half-open":
+                self.state = "closed" if ok else "open"
+                self._opened_at = now
+                if ok:
+                    self._consec = 0
+                return
+            if ok:
+                self._consec = 0
+                return
+            self._consec += 1
+            n = len(self._events)
+            err_rate = sum(1 for _, o in self._events if not o) / n if n else 0
+            if self._consec >= self.threshold or (n >= 4 and err_rate > 0.5):
+                self.state = "open"
+                self._opened_at = now
 
 
 def _http_post_json(url, payload, timeout=120):
@@ -144,11 +273,14 @@ def do_rerank(obj):
     return [float(s) for s in (scores if hasattr(scores, "__len__") else [scores])]
 
 
+_synth_breaker = CircuitBreaker()
+
+
 def do_synth(body):
     """Proxy a /v1/chat/completions request to the configured synth upstream
     (AIMEE_LLM_SYNTH_URL — a local baked llama-server, or a forwarded/external base).
     Streaming is disabled in the first release: `stream:true` -> a typed 400 the client
-    can branch on (rather than an opaque failure)."""
+    can branch on. A circuit breaker (§4) opens on repeated upstream errors -> typed 503."""
     if not isinstance(body, dict):
         raise GatewayError(400, "bad_request", "chat/completions expects a JSON object")
     if body.get("stream"):
@@ -157,7 +289,15 @@ def do_synth(body):
             "streaming is disabled in this release; set stream=false")
     if not SYNTH_URL:
         raise GatewayError(503, "synth_unconfigured", "AIMEE_LLM_SYNTH_URL is not set")
-    return _http_post_json(f"{SYNTH_URL}/v1/chat/completions", body, timeout=300)
+    if not _synth_breaker.allow():
+        raise GatewayError(503, "provider_unavailable", "synth upstream circuit is open")
+    try:
+        out = _http_post_json(f"{SYNTH_URL}/v1/chat/completions", body, timeout=300)
+    except Exception:
+        _synth_breaker.record(False)
+        raise
+    _synth_breaker.record(True)
+    return out
 
 
 def role_state(base, configured=True):
@@ -228,6 +368,10 @@ def build_server():
             n = int(self.headers.get("content-length", "0") or "0")
             raw = self.rfile.read(n) if n else b""
             try:
+                # §1a: every work request is authenticated; the scope is DERIVED from the
+                # identity (a caller-supplied X-Aimee-Scope is rejected).
+                check_auth(self.headers.get("Authorization"))
+                scope = derive_scope(self.headers.get)
                 if path == "/embed":
                     text = raw.decode("utf-8", errors="replace")
                     if not text.strip():
@@ -238,22 +382,31 @@ def build_server():
                 elif path == "/rerank":
                     self._send(200, do_rerank(json.loads(raw or b"[]")))
                 elif path == "/v1/chat/completions":
-                    self._send(200, do_synth(json.loads(raw or b"{}")))
+                    out = do_synth(json.loads(raw or b"{}"))
+                    # §4 audit: metadata-only (scope/outcome/bytes), never content/creds.
+                    audit("chat", scope, "ok", bytes_in=len(raw),
+                          bytes_out=len(json.dumps(out)))
+                    self._send(200, out)
                 else:
                     self._send(404, {"error": "not found"})
             except GatewayError as ge:
+                if path == "/v1/chat/completions":
+                    audit("chat", SCOPE_DEFAULT, "error", code=ge.body["error"]["code"])
                 self._send(ge.status, ge.body)
             except Exception as exc:  # noqa: BLE001
                 self._send(500, {"error": {"code": "internal", "message": str(exc)}})
 
-    return ThreadingHTTPServer(("0.0.0.0", PORT), Handler)
+    return ThreadingHTTPServer((BIND, PORT), Handler)
 
 
 def main():  # pragma: no cover
-    import sys
-
+    # §1a bind guard: refuse (strict) or warn on an unauthenticated wildcard bind.
+    if validate_bind(BIND, AUTH_TOKEN, STRICT_BIND) == "warn":
+        audit("startup", SCOPE_DEFAULT, "warn", bind=BIND, auth="off",
+              note="unauthenticated wildcard bind; deployment network is the boundary")
     srv = build_server()
-    sys.stderr.write(f"aimee-llm-gateway: :{PORT} embed={EMBED_URL} rerank={RERANK_URL}\n")
+    sys.stderr.write(f"aimee-llm-gateway: {BIND}:{PORT} embed={EMBED_URL} rerank={RERANK_URL} "
+                     f"auth={'on' if AUTH_TOKEN else 'off'}\n")
     sys.stderr.flush()
     srv.serve_forever()
 

--- a/scripts/tests/test_gateway.py
+++ b/scripts/tests/test_gateway.py
@@ -116,5 +116,76 @@ class RerankHandler(unittest.TestCase):
         self.assertEqual(self.gw.do_rerank([]), [])
 
 
+class Synth(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_streaming_unsupported_400(self):
+        self.gw.SYNTH_URL = "http://x"
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.do_synth({"messages": [], "stream": True})
+        self.assertEqual(e.exception.status, 400)
+        self.assertEqual(e.exception.body["error"]["code"], "streaming_unsupported")
+
+    def test_unconfigured_503(self):
+        self.gw.SYNTH_URL = ""
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.do_synth({"messages": []})
+        self.assertEqual(e.exception.status, 503)
+
+    def test_not_a_dict_400(self):
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.do_synth(["nope"])
+        self.assertEqual(e.exception.status, 400)
+
+    def test_proxies_non_streaming(self):
+        self.gw.SYNTH_URL = "http://synth:8083"
+        captured = {}
+
+        def fake_post(url, payload, timeout=120):
+            captured["url"] = url
+            captured["payload"] = payload
+            return {"choices": [{"message": {"content": "hi"}}]}
+
+        self.gw._http_post_json = fake_post
+        out = self.gw.do_synth({"messages": [{"role": "user", "content": "hi"}], "stream": False})
+        self.assertEqual(captured["url"], "http://synth:8083/v1/chat/completions")
+        self.assertIn("choices", out)
+
+
+class RoleHealth(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_gated_when_unconfigured(self):
+        self.assertEqual(self.gw.role_state("", configured=False), "gated")
+        self.assertEqual(self.gw.role_state("http://x", configured=False), "gated")
+
+    def test_ready_loading_down(self):
+        import urllib.error
+        from unittest import mock
+
+        class FakeResp:
+            def __init__(self, status):
+                self.status = status
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+        cases = [
+            (lambda *a, **k: FakeResp(200), "ready"),
+            (lambda *a, **k: FakeResp(503), "loading"),
+            (mock.Mock(side_effect=urllib.error.HTTPError("u", 503, "loading", {}, None)), "loading"),
+            (mock.Mock(side_effect=urllib.error.HTTPError("u", 500, "err", {}, None)), "down"),
+            (mock.Mock(side_effect=OSError("refused")), "down"),
+        ]
+        for fn, expected in cases:
+            with mock.patch("urllib.request.urlopen", fn):
+                self.assertEqual(self.gw.role_state("http://x"), expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_gateway_security.py
+++ b/scripts/tests/test_gateway_security.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Unit tests for the aimee-llm gateway's §1a security controls (auth, bind guard,
+derived scope, audit, circuit breaker). Pure stdlib — no model, no network."""
+import importlib.util
+import io
+import os
+import unittest
+from unittest import mock
+
+GW = os.path.join(os.path.dirname(__file__), "..", "aimee_llm_gateway.py")
+
+
+def _gw():
+    spec = importlib.util.spec_from_file_location("aimee_llm_gateway", GW)
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+class Auth(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_open_when_no_token(self):
+        self.gw.AUTH_TOKEN = ""
+        self.gw.check_auth(None)  # no raise
+
+    def test_valid_bearer(self):
+        self.gw.AUTH_TOKEN = "s3cr3t"
+        self.gw.check_auth("Bearer s3cr3t")
+        self.gw.check_auth("bearer s3cr3t")  # scheme is case-insensitive
+
+    def test_missing_or_wrong_401(self):
+        self.gw.AUTH_TOKEN = "s3cr3t"
+        for h in (None, "", "s3cr3t", "Bearer nope", "Basic s3cr3t"):
+            with self.assertRaises(self.gw.GatewayError) as e:
+                self.gw.check_auth(h)
+            self.assertEqual(e.exception.status, 401)
+
+
+class Scope(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_rejects_caller_supplied(self):
+        with self.assertRaises(self.gw.GatewayError) as e:
+            self.gw.derive_scope({"X-Aimee-Scope": "curator"}.get)
+        self.assertEqual(e.exception.status, 403)
+        self.assertEqual(e.exception.body["error"]["code"], "scope_spoof")
+
+    def test_derives_default(self):
+        self.gw.SCOPE_DEFAULT = "curator"
+        self.assertEqual(self.gw.derive_scope({}.get), "curator")
+
+
+class Bind(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_loopback_ok(self):
+        self.assertEqual(self.gw.validate_bind("127.0.0.1", ""), "ok")
+
+    def test_wildcard_with_auth_ok(self):
+        self.assertEqual(self.gw.validate_bind("0.0.0.0", "tok"), "ok")
+
+    def test_wildcard_no_auth_warns(self):
+        self.assertEqual(self.gw.validate_bind("0.0.0.0", ""), "warn")
+
+    def test_strict_wildcard_no_auth_raises(self):
+        for b in ("0.0.0.0", "::", ""):
+            with self.assertRaises(RuntimeError):
+                self.gw.validate_bind(b, "", strict=True)
+
+
+class Audit(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_metadata_only_no_creds(self):
+        buf = io.StringIO()
+        with mock.patch.object(self.gw.sys, "stderr", buf):
+            self.gw.audit("chat", "curator", "ok", bytes_in=10, bytes_out=20)
+        line = buf.getvalue()
+        self.assertIn("AIMEE-AUDIT", line)
+        self.assertIn('"scope": "curator"', line)
+        self.assertIn('"bytes_in": 10', line)
+        # no token/content fields leak
+        self.assertNotIn("Authorization", line)
+        self.assertNotIn("Bearer", line)
+
+    def test_sanitizer_drops_sensitive_meta(self):
+        buf = io.StringIO()
+        with mock.patch.object(self.gw.sys, "stderr", buf):
+            self.gw.audit("chat", "curator", "ok", bytes_in=5,
+                          authorization="Bearer leak", prompt="secret text",
+                          messages=[{"x": 1}], api_key="k")
+        line = buf.getvalue()
+        self.assertIn('"bytes_in": 5', line)
+        for leaked in ("leak", "secret text", "authorization", "prompt", "messages", "api_key"):
+            self.assertNotIn(leaked, line)
+
+
+class Breaker(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def _clock(self):
+        return self.t
+
+    def test_opens_on_consecutive_failures(self):
+        self.t = 0.0
+        cb = self.gw.CircuitBreaker(threshold=3, recovery=60, clock=self._clock)
+        for _ in range(2):
+            self.assertTrue(cb.allow())
+            cb.record(False)
+        self.assertEqual(cb.state, "closed")
+        self.assertTrue(cb.allow())
+        cb.record(False)  # 3rd consecutive
+        self.assertEqual(cb.state, "open")
+        self.assertFalse(cb.allow())  # blocked while open
+
+    def test_half_open_probe_then_close(self):
+        self.t = 0.0
+        cb = self.gw.CircuitBreaker(threshold=2, recovery=30, clock=self._clock)
+        cb.record(False)
+        cb.record(False)
+        self.assertEqual(cb.state, "open")
+        self.assertFalse(cb.allow())
+        self.t = 31.0  # recovery elapsed
+        self.assertTrue(cb.allow())  # half-open probe allowed
+        self.assertEqual(cb.state, "half-open")
+        cb.record(True)
+        self.assertEqual(cb.state, "closed")
+
+    def test_half_open_failure_reopens(self):
+        self.t = 0.0
+        cb = self.gw.CircuitBreaker(threshold=1, recovery=10, clock=self._clock)
+        cb.record(False)
+        self.assertEqual(cb.state, "open")
+        self.t = 11.0
+        self.assertTrue(cb.allow())
+        cb.record(False)  # probe fails
+        self.assertEqual(cb.state, "open")
+
+    def test_success_resets_consecutive(self):
+        self.t = 0.0
+        cb = self.gw.CircuitBreaker(threshold=3, clock=self._clock)
+        for _ in range(4):  # dilute so the windowed error-rate stays <=50%
+            cb.record(True)
+        cb.record(False)
+        cb.record(False)  # consec=2 (< threshold)
+        cb.record(True)   # resets consec to 0
+        cb.record(False)
+        cb.record(False)  # consec=2 again — never reaches 3
+        self.assertEqual(cb.state, "closed")
+
+    def test_error_rate_trip(self):
+        """>50% error rate over the window opens even without N consecutive."""
+        self.t = 0.0
+        cb = self.gw.CircuitBreaker(threshold=99, clock=self._clock)
+        cb.record(False)
+        cb.record(True)
+        cb.record(False)
+        cb.record(False)  # 3 of 4 = 75% > 50%
+        self.assertEqual(cb.state, "open")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The §1a controls for the privileged gateway — all **opt-in / non-breaking** so today's network-isolated embedder contract still works. 34 gateway unit tests green (15 new security).

## Controls
- **Auth** — constant-time bearer (`hmac.compare_digest`), case-insensitive scheme. No token = open (dev); configured ⇒ **401** on missing/invalid. Applied to the work POSTs; `/health*` stay open for liveness.
- **Bind guard** — default `0.0.0.0` (container reachability, as today). An unauthenticated wildcard bind **WARNS** (audited) by default; `AIMEE_LLM_STRICT_BIND` makes it a **hard startup refuse** (§1a's "no unauthenticated wildcard"). Wildcard set incl. `0`/`::`.
- **Derived scope** — a caller-supplied `X-Aimee-Scope` is **rejected (403, anti-spoof)**; scope is derived from the identity (static curator default with a single bearer; per-user arrives with mTLS CN).
- **Audit** — a **metadata-only** line per `/v1/chat/completions` (scope/outcome/bytes), with a **sanitizer** that drops any credential/content-bearing meta key so "no creds" holds even for a future caller — never `Authorization`/content.
- **Circuit breaker** — per-upstream state machine (N consecutive **or** >50%/window → open; recovery → half-open probe; success closes), **thread-safe** → typed `503 provider_unavailable` on the synth path.

## Review
Roundtable-reviewed (security lens). Folded the audit **sanitizer**, the breaker **lock**, and case-insensitive/extra-wildcard fixes; the rest of the panel's concerns were replay-contradicted (fail-open is documented dev-mode behind the network boundary; http.server normalizes header case; the breaker race is benign — now locked anyway).

## Deferred (documented)
Per-source 401 throttle + **mTLS** (the production posture) + the per-user cred **mlock/memmove** zeroing (C aimee-server tier) + the escape-hatch CI lint — these are cross-tier / the proposal's separate rate-limit + passthrough controls.