### PR TITLE
feat(aimee-llm): activate drift guard + cutover runbook + compose collapse (P7)

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -119,6 +119,38 @@ services:
       # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
       start_period: 1200s
 
+  # Unified llama.cpp+Vulkan container (P7 cutover target) — collapses `embedder`
+  # + `llm` into one image serving embed+rerank+synth from baked-in GGUFs behind
+  # the gateway (preserves the /embed+/embed_batch+/rerank contract on :8080).
+  # Profile-gated so it does not disturb the default topology pre-cutover. To cut
+  # over (see docs/runbooks/unified-llm-cutover.md): bring this up
+  # (`--profile unified-llm`), point the kb at it
+  # (AIMEE_EMBEDDER_URL=http://aimee-llm:8080, LLM_ENDPOINT=http://aimee-llm:8080/v1),
+  # re-embed the corpus, then drop the `embedder` + `llm` services. CPU image by
+  # default; AIMEE_LLM_IMAGE=...-gpu + a GPU device for the offloaded tier.
+  aimee-llm:
+    restart: unless-stopped
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:cpu}
+    build:
+      context: .
+      dockerfile: Dockerfile.aimee-llm
+    profiles: ["unified-llm"]
+    environment:
+      AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    volumes:
+      - aimee-llm-models:/root/.cache/llama.cpp
+    ports:
+      - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      # Models are baked into the image, so the cold boot only loads them into
+      # RAM/VRAM (no download); still generous for the largest GPU tier.
+      start_period: 300s
+
 volumes:
   aimee-kb-home:
   aimee-kb-postgres:

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -1,0 +1,111 @@
+# Runbook: cut over to the unified `aimee-llm` container
+
+The unified-llm-container migration (P7). **Operator-gated** — the production flip
+(deploy + corpus re-embed) is a deliberate maintenance op, never automatic. P1–P6 ship the
+pieces; this runbook is the order of operations + the gates.
+
+Validated before this runbook (`.253`/`.254`, see `benchmarks/results/unified-llm/`):
+the `aimee-llm:cpu`/`:gpu` images build, serve `/embed`+`/rerank`(ettin encoder + gateway
+head)+`/v1/chat/completions`, and offload to the AMD 7900 XTX via Vulkan (`-ngl 99`).
+
+## 0. What changes
+
+- **From:** torch `aimee-embedder` (pplx-embed + ettin via sentence-transformers) + the
+  stock `llm` llama.cpp container (gemma synth).
+- **To:** one `aimee-llm` image (CPU or GPU tier) — Vulkan llama.cpp serving embed
+  (Qwen3-Embedding) + rerank (ettin encoder + the gateway Dense head) + synth (gemma),
+  models baked in.
+- **Corpus re-embed required:** `pplx-embed` → `Qwen3-Embedding` is a **`model_id` change**
+  (and 0.6B→1024 / 4B→2560 a possible **dim** change), so the `kb_meta` drift guard (P1,
+  now activated — `db2_set_embedder_model_id`) will **refuse** to serve the new embedder
+  against the old corpus. The re-embed is the controlled drop-and-rebuild below.
+
+## 1. Pre-cutover ship-floor gate (staging, BEFORE the production flip)
+
+The ship-floor gate is a **pre-cutover precondition** (proposal §2): the new
+embed+rerank+fusion stack must hit **≥95%** of the pplx/ettin baseline (nDCG@10 / MRR@10 +
+top-k rank-agreement ≥0.95) on the real corpus, in staging, against the checked-in fixture
+`tests/fixtures/pplx_baseline.json`. **Gate fail → freeze, investigate, do NOT cut over.**
+Because the gate is upstream of the cutover, pplx/ettin is removed *completely* in the
+release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollback (§5).
+
+## 2. Build + publish the images
+
+CI (`.github/workflows/publish-images.yml`) builds `aimee-llm-cpu` + `aimee-llm-gpu` on
+merge to `main` and pushes to ghcr. To build out-of-band (e.g. on a PVE CT with docker):
+
+```
+docker build -f Dockerfile.aimee-llm -t aimee-llm:cpu .
+docker build -f Dockerfile.aimee-llm -t aimee-llm:gpu \
+  --build-arg EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF \
+  --build-arg EMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf \
+  --build-arg RERANK_REPO=cross-encoder/ettin-reranker-400m-v1 \
+  --build-arg SYNTH_REPO=unsloth/gemma-4-12b-it-GGUF \
+  --build-arg SYNTH_FILE=gemma-4-12b-it-Q4_K_M.gguf .
+```
+
+## 3. Deploy to `.254` (tierd / LXC, GPU)
+
+`.254` runs containers via **tierd** (LXC), not raw docker, with GPU passthrough via
+`/dev/dri/renderD128` (Vulkan/RADV — **not** ROCm/`kfd`). Deploy the GPU image as a tierd
+plugin (manifest-swap, per the `.254` deploy memory), GPU device + `AIMEE_LLM_NGL=99`.
+Point the kb at it: `AIMEE_EMBEDDER_URL=http://aimee-llm:8080` (the gateway preserves the
+`/embed`+`/embed_batch`+`/rerank` contract, so `embed-remote.py`/`rerank-remote.py` are
+untouched). Set the kb's `embedding_model` to the new identity (activates the P1 guard) and
+`embedding_dim` to the tier's dim (2560 for the 4B GPU tier). **Verify the URL actually
+serves the named model before re-embedding** — a misrouted `AIMEE_EMBEDDER_URL` (still
+pointing at the old embedder) would silently embed under the new identity and the guard
+would not catch it (it checks identity-vs-corpus, not URL-vs-identity). `AIMEE_LLM_AUTH_TOKEN`
+comes from the secret store (vault / Docker secret / `.gitignore`d per-host `.env`), **never
+a checked-in plaintext compose value**; document its rotation alongside the deploy.
+
+## 4. Corpus re-embed (controlled drop-and-rebuild — the `maintenance` window)
+
+In-place `halfvec` type changes against a live kb are forbidden. The migration:
+
+1. **Snapshot** the current vector tables.
+2. Gate the kb to **`maintenance`**.
+3. **Drop** the dim-sized `halfvec` tables; **recreate** at the new `(model_id, dim)` (the
+   schema applies at the new dim; `db2_embedding_model_record_or_check` records the new
+   identity on the fresh `kb_meta`).
+4. **Replay** the source rows through the new embedder (bounded batch).
+5. **Parity gate:** pre-drop vs post-backfill counts must match **and** a sampled
+   value-check must pass (row counts alone miss silent corruption — wrong rows re-embedded,
+   off-by-one batch, wrong prompt template, a dim swap). Over a held-out sample (≥1% or 10k
+   rows, whichever is larger): every vector has the expected `array_length`, no NaN/all-zero
+   rows, and — where a stable subset is re-embeddable from the snapshot — cosine vs the
+   snapshot is within tolerance for the *same* model (and `kb_meta.schema_embedder_model_id`
+   is the new identity). Any divergence → `degraded`, hold. On parity → lift `maintenance`.
+
+Plan the window from the corpus size × the new embedder's throughput (record peak RSS per
+inner `llama-server`; the embed model is offloaded so it's GPU-bound).
+
+## 5. Rollback (one-time safety net, initial cutover only)
+
+The ship-floor gate (§1) means a regression never ships. If a post-cutover issue still
+demands it: deploy-tag **rollback to the prior release tag** (which still contains
+pplx/ettin) **+** the **reverse re-embed** (a checked-in, idempotent schema-revert migration
+restoring the prior dim-sized `halfvec` from the §4 snapshot, CI round-tripped before
+cutover). This is a gated maintenance op, not an instant toggle. Once the first
+post-cutover release is validated, no prior tag contains pplx/ettin and rollback is no
+longer deploy-tag-based; retain the prior tag in the registry for a defined window (e.g. 6
+months). **Snapshot retention ≥ tag retention** — the §4 snapshot is the only rollback
+input once the tag ages out, so it must outlive the tag, with a checksum and an expiry
+review. Pre-cutover checklist (all must be true before §3): snapshot present + checksum
+verified; reverse-migration **rehearsed in staging** (round-trips to the prior dim/identity);
+ship-floor gate green.
+
+## 6. Retire the old surfaces
+
+After validation: remove `Dockerfile.embedder` + the `embedder`/`llm` compose/deploy
+services + the `codex-auth`/pplx-ettin references. (Kept until here so the prior tag is a
+working rollback target — §5.)
+
+## Gates summary
+
+| Gate | When | Pass |
+|------|------|------|
+| ship-floor ≥95% | staging, pre-cutover | nDCG/MRR ≥95% of pplx fixture + rank-agreement ≥0.95 |
+| drift guard | kb startup post-deploy | `kb_meta` records the new `(model_id, dim)`; refuses a stale mismatch |
+| parity | post-re-embed | pre-drop == post-backfill counts; else `degraded` |
+| kill-a-child smoke | post-deploy | one inner llama-server killed; others keep serving |

--- a/src/cmd_core.c
+++ b/src/cmd_core.c
@@ -50,6 +50,9 @@ static int bootstrap_db2(const config_t *cfg, int json_output)
 
    db2_set_embedding_dim(config_resolve_embedding_dim(cfg));
    db2_set_embedding_dim_pinned(config_embedding_dim_is_pinned(cfg));
+   /* unified-llm-container §2: activate the model-identity drift guard with the
+    * configured embedder identity (empty => no-op, back-compat). */
+   db2_set_embedder_model_id(cfg->embedding_model);
    if (db2_init(cfg->db2_url) == 0)
    {
       int schema_ok = 0;

--- a/src/cmd_doctor.c
+++ b/src/cmd_doctor.c
@@ -73,6 +73,7 @@ static doctor_db2_session_t check_database(check_result_t *r, config_t *cfg)
     * pin/recorded mismatch still surfaces via #337's record_or_check guard. */
    else if ((db2_set_embedding_dim(config_resolve_embedding_dim(cfg)),
              db2_set_embedding_dim_pinned(config_embedding_dim_is_pinned(cfg)),
+             db2_set_embedder_model_id(cfg->embedding_model), /* unified-llm §2 drift guard */
              db2_init(cfg->db2_url)) == 0)
    {
       session.ready = 1;

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -80,9 +80,13 @@ void db2_set_embedding_dim_pinned(int pinned)
  * incompatible vector spaces. These globals carry the configured embedder model
  * identity (repo@sha), the reranker identity + scoring contract, and the
  * compat-list of admitted transitions, set from config before db2_init like the
- * dim above. ALL DEFAULT EMPTY: an empty embedder model_id makes the guard a
- * no-op, so a deployment that has not yet adopted the unified container (the live
- * torch embedder reports no identity) is unaffected. */
+ * dim above. INVARIANT: set at exactly the sites that call db2_set_embedding_dim()
+ * — the serving config-load paths (cmd_core bootstrap_db2, kb_main, cmd_doctor);
+ * the connectivity-probe path (bootstrap_db2_try_url) and tests deliberately set
+ * neither (a probe shuts down before any serving schema applies). ALL DEFAULT
+ * EMPTY: an empty embedder model_id makes the guard a no-op, so a deployment that
+ * has not yet adopted the unified container (the live torch embedder reports no
+ * identity) is unaffected. */
 static char g_embedder_model_id[160] = "";
 static char g_reranker_model_id[160] = "";
 static char g_reranker_contract[96] = "";

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -543,6 +543,9 @@ int main(int argc, char **argv)
     * aimee.yaml). */
    db2_set_embedding_dim(config_resolve_embedding_dim(&kb_cfg));
    db2_set_embedding_dim_pinned(config_embedding_dim_is_pinned(&kb_cfg));
+   /* unified-llm-container §2: activate the model-identity drift guard (the kb applies
+    * the schema, so this is the load-bearing site). Empty embedding_model => no-op. */
+   db2_set_embedder_model_id(kb_cfg.embedding_model);
    /* Size the DB2 connection pool (leased by worker threads) before db2_init. */
    db2_set_pool_size(aimee_resolve_db2_pool_size(kb_cfg.db2_connection_pool_size));
 


### PR DESCRIPTION
Final packet (P7) of the unified-llm-container migration. The live cutover (GPU deploy + corpus re-embed) is **operator-gated** — this PR ships the activation, the runbook, and the profile-gated service, not the production flip.

## Changes
- **Activate the drift guard** — wire `db2_set_embedder_model_id(cfg->embedding_model)` at the three serving config-load sites (`cmd_core` bootstrap_db2, `kb_main`, `cmd_doctor`), right after the existing `db2_set_embedding_dim*` calls and before `db2_init`. P1 added the `(model_id,dim)` guard but nothing set the identity, so it was inert. Now the kb records `kb_meta.schema_embedder_model_id` and refuses to serve a new embedder against a corpus embedded by a different model. **Empty `embedding_model` ⇒ no-op**, so existing deployments are unaffected; the guard only bites once an operator sets an identity at cutover.
- **compose**: add the profile-gated (`profiles: ["unified-llm"]`) `aimee-llm` service — the cutover target collapsing `embedder`+`llm` into one Vulkan image. Inert in the default topology; `embedder`/`llm` stay until the operator cuts over (so the prior tag remains a rollback target).
- **docs/runbooks/unified-llm-cutover.md**: operator order of operations — ship-floor ≥95% gate, deploy, drop-and-rebuild re-embed with a sampled-value parity gate, rollback, retire.

## Verification
- `make -j1 server kb` green; `make lint` ok; `make unit-tests` ok.
- Guard wiring confirmed complete: the three serving sites are exactly the `db2_set_embedding_dim` sites; the only other `db2_init` caller (`bootstrap_db2_try_url`) is a connectivity probe that sets neither and shuts down before any serving schema applies. Invariant documented at the setter.

## Roundtable
One verified-blocking finding (every `db2_init` caller must set the identity) — resolved: confirmed the call sites are complete + consistent with the established dim precedent, and documented the pre-init invariant. Folded the strongest runbook suggestions into the doc: sampled vector/dim/NaN parity check (not just row counts), `AIMEE_LLM_AUTH_TOKEN` from a secret store (never checked-in plaintext), URL-serves-named-model verification before re-embed, and snapshot-retention ≥ tag-retention with a pre-cutover checklist.