### PR TITLE
feat(ingress): model-derived proxy/translate (delete claude_proxy_parity) + gateway proposal (P1)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (108)
+## CLI-settable keys (107)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -32,7 +32,6 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `cache_shaping_enabled` | bool | Enable prompt cache-shaping. |
 | `claude_cli_delegate_enabled` | bool | Allow delegating to the local Claude CLI agent. |
 | `claude_model` | string | Default Claude model (empty = CLI default). |
-| `claude_proxy_parity` | bool | Make the Claude Code `/v1/messages` ingress a transparent Anthropic passthrough (honor inbound model, skip pre-injection, forward anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). Default off. |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |
 | `cost_reward_lambda_pct` | int | Cost-penalty weight (percent) in the reward. |
 | `cost_reward_ref_usd_milli` | int | Reference cost (USD-milli) normalizing the cost reward. |

--- a/docs/proposals/pending/aimee-universal-gateway.md
+++ b/docs/proposals/pending/aimee-universal-gateway.md
@@ -1,0 +1,231 @@
+# Aimee as the universal LLM gateway: dual-API surface, model-derived proxy/translate, and a general inspect/alter pipeline
+
+- **State:** reviewed — roundtable sign-off (R1 surfaced 3 findings; R2: Findings A
+  & B confirmed RESOLVED by security · architect · qa; Finding C resolved via the
+  model-pin decision below). User proposal-gate decisions folded in. *Note: the
+  delegate transcripts were truncated by aimee's citation-replay verification
+  (stale code index on the review host); verdicts were front-loaded and captured.*
+  One non-blocking item carried to the plan: spell out the OpenAI streaming
+  block-buffering mechanism (criterion 3 demands it; only the Anthropic path is
+  detailed here).
+- **Scope:** the inbound model ingresses (`/v1/messages`, `/v1/chat/completions`,
+  `/v1/completions`, `/v1/responses`) and the outbound provider call path
+  (primary + delegate drivers). Intelligence-surface adjacent (it is the seam
+  memory and guardrails attach to) but the proposal itself is plumbing.
+- **Author:** JBailes (drafted by the engineer agent, 2026-06-23).
+- **Origin:** follow-up to the `claude_proxy_parity` work (#648/#651 shipped a
+  config flag to `main`; #654 to flip its default was closed). That flag was the
+  **wrong model** — it made "passthrough vs. translate" a human-set toggle when it
+  is really a derived property of the serving model. This proposal replaces the
+  flag with the correct architecture and names the layer the flag was groping at.
+
+## Thesis
+
+**Aimee sits at the center of every model call. It is a translation layer, a
+memory layer, and a guardrail/policy layer — and every call, from any client, to
+any model (primary or delegate), passes through it.** The client's API and the
+model's API are independent axes; aimee speaks the client's API on one side, the
+model's API on the other, translating between them when they differ, and can
+inspect and alter anything in between.
+
+"Parity" is not a setting. It is the degenerate case where the client API equals
+the model API and no transform is required — pure passthrough. Everything else is
+a transform aimee applies.
+
+## Problem — where aimee is today
+
+Most of the surface already exists, which is why the right move is consolidation,
+not green-field:
+
+1. **Both client APIs are already served.** `/v1/messages` (Anthropic) and
+   `/v1/chat/completions` + `/v1/completions` + `/v1/responses` (OpenAI) are live
+   ingresses (`src/server/anthropic_http.c`, `src/server/openai_chat.c`).
+2. **Model-side translation already exists.** Per-provider delegate drivers
+   (`src/server/delegate_driver.c`, `delegate_openai.c`) own `build_request` /
+   `parse_response`, so each speaks its model's native API. The Anthropic ingress
+   already translates to OpenAI-family models via `anthropic_ingress.c`; the
+   OpenAI ingress already reaches Anthropic models via the anthropic driver's
+   `build_request`. The 2×2 (client-API × model-API) is largely wired.
+
+The three real defects:
+
+3. **Proxy/translate is bolted to a manual flag.** `claude_proxy_parity`
+   (`src/headers/config.h`, gated in `anthropic_http.c` via `parity_on()`) layered
+   a human toggle on top of a choice that is fully determined by the serving
+   model's API (`driver_is_anthropic`). Wrong axis of control.
+4. **The ingresses are deliberately stateless — calls do NOT go through aimee's
+   systems.** `anthropic_http.c`'s own contract: *"does NOT run aimee's agent
+   loop, memory, persona, or toolset."* The lone exception already bolted on is
+   context pre-injection (`ingress_preinject_build`, wired ad-hoc into *both*
+   ingresses) — proof that per-call alteration is wanted, but done as a one-off,
+   not a general mechanism. Tool use still cannot be policed (e.g. prevent a model
+   from spawning subagents), and full guardrails (`guardrails.h`, `guardrail_mode`)
+   run only on the **agentic** path (`/v1/runs`) and the internal loop, not the
+   proxy.
+5. **No general interception point.** There is no single place where aimee
+   normalizes a call and runs a defined sequence of inspect/transform stages.
+   Translation is hand-coded per ingress; preinject is a one-off; guardrails are a
+   separate subsystem. They should be stages of one pipeline.
+
+## Target architecture
+
+A single **gateway pipeline** every model call flows through:
+
+```
+client call (any API)
+   │  normalize → canonical request IR
+   ▼
+[ request stages ]  inspect / alter the full request
+   ├─ memory / context injection
+   ├─ policy / guardrails (tool allow-deny, subagent policing, …)
+   └─ (accounting, audit)
+   │  render to the SERVING model's API  (passthrough if same API, else translate)
+   ▼
+provider call (primary OR delegate)
+   │  normalize → canonical response IR
+   ▼
+[ response stages ]  inspect / alter the full response
+   ├─ policy / guardrails (reject/rewrite disallowed tool_use, …)
+   └─ (accounting, audit)
+   │  render to the CLIENT's API
+   ▼
+client response (same API it called with)
+```
+
+Properties:
+
+- **Two independent axes.** Client API ∈ {Anthropic, OpenAI}; model API ∈
+  {Anthropic, OpenAI, …}. Passthrough on the diagonal, translate off it. The
+  choice is **derived**, never configured.
+- **General, not guardrail-specific.** A stage is a typed transform over the
+  canonical IR that may read everything and rewrite anything (system, messages,
+  tools, tool_choice, params; and on the way back, content/tool_use/usage). Tool
+  policing (strip the subagent/`Task` tool from `tools`; reject a disallowed
+  `tool_use`) is the *first* concrete policy, not a special case.
+- **Bounded, not the agent loop.** The pipeline is per-call request/response
+  transforms — it does not hijack the client's multi-turn loop or context
+  ownership. This preserves the original reason the ingress was stateless ("don't
+  corrupt the context the client builds") while still letting aimee inspect and
+  alter each call. Memory injection stays cache-safe (append after the client's
+  cached prefix, as today's preinject does).
+- **Same path for primary and delegate.** A delegate call is just a gateway call
+  whose serving model is the delegate. Aimee→model communication is already the
+  driver layer; this unifies it with the inbound path so policy applies uniformly.
+
+## Current state → target (gap analysis)
+
+| Capability | Today | Target |
+|---|---|---|
+| Anthropic API in | ✅ `/v1/messages` | ✅ (through pipeline) |
+| OpenAI API in | ✅ `/v1/chat/completions` etc. | ✅ (through pipeline) |
+| Anthropic-in → Anthropic-model | ✅ passthrough | ✅ passthrough (derived) |
+| Anthropic-in → OpenAI-model | ✅ translate | ✅ translate (derived) |
+| OpenAI-in → OpenAI-model | ✅ passthrough | ✅ passthrough (derived) |
+| OpenAI-in → Anthropic-model | ✅ via driver | ✅ translate (derived) |
+| Proxy/translate selection | ❌ manual `claude_proxy_parity` | ✅ derived from serving model API |
+| Inspect/alter proxied calls | ❌ stateless ingress | ✅ pipeline stages |
+| Tool policing / prevent subagents | ❌ none | ✅ policy stage |
+| Memory injection on proxy | ⚠️ ad-hoc `ingress_preinject_build` on **both** ingresses (anthropic_http.c ×2, openai_chat.c ×5) | ✅ one shared pipeline stage |
+| Same path for delegates | ⚠️ driver layer, separate | ✅ unified |
+
+## Phasing
+
+- **P1 — derive, delete the flag.** Remove `claude_proxy_parity`; gate
+  passthrough/translate purely on the serving model's API (`driver_is_anthropic`)
+  in `anthropic_http.c`. Net behavior: an Anthropic call is forwarded untouched to
+  an Anthropic model, translated to an OpenAI model — automatically. *(Already
+  prototyped and validated end-to-end against a live aimee-server + mock upstream:
+  model honored, headers forwarded, count_tokens proxied, 429+Retry-After
+  relayed.)*
+- **P2 — gateway pipeline scaffold + first policy.** Introduce the canonical
+  request/response IR and a typed stage interface at the ingress seam; port the
+  existing translation into it; add the first policy stage: **tool policing**
+  (configurable tool allow/deny; the subagent/`Task` strip on request + disallowed
+  `tool_use` rejection on response). Bounded, per-call, opt-in by policy.
+- **P3 — memory as a stage.** Both ingresses already call
+  `ingress_preinject_build` ad-hoc (anthropic_http.c, openai_chat.c). Fold those
+  into **one** shared memory/context pipeline stage (DRY), cache-safe, identical
+  rendered bytes.
+- **P4 — unify delegates + symmetric coverage.** Route the OpenAI ingress and the
+  delegate call path through the same pipeline so policy/memory/translation apply
+  uniformly to every model call.
+
+## Acceptance criteria
+
+1. `claude_proxy_parity` is removed from the config surface
+   (`config.h`/`config.c`/`config_save.c`/`config_fields.c`/`config_schema.inc`/docs);
+   passthrough vs. translate on `/v1/messages` is decided solely by the serving
+   model's API, verified by unit tests for both an Anthropic-model primary (model
+   honored, betas forwarded, count_tokens proxied) and an OpenAI-model primary
+   (translated, model swapped to the configured model).
+2. A canonical request/response IR + stage interface exists with ≥1 translation
+   stage and ≥1 policy stage, unit-tested in isolation (pure, no socket).
+3. A tool-policing policy can, by config, strip a named tool (default target: the
+   subagent/`Task` tool) from an inbound request's `tools` and police a matching
+   `tool_use` in the response, on **both** the Anthropic and OpenAI ingresses,
+   with an audit row per intervention. Response policing is implemented for the
+   **buffered and streaming paths together** (not buffered-first); the action is
+   **per-tool and per-severity** — e.g. a high-severity tool is blocked/rewritten
+   even mid-SSE-stream, a low-severity one may be flagged/audited only.
+4. The two ad-hoc `ingress_preinject_build` call paths (anthropic_http.c,
+   openai_chat.c) are replaced by **one** shared pipeline stage with byte-identical
+   rendered output, cache-safe (appended after the client's last `cache_control`
+   breakpoint; `cache_read_input_tokens` unaffected on a repeated prefix).
+5. Primary and delegate calls share the pipeline: a policy enabled in config
+   applies to a delegate model call, demonstrated by a test.
+6. No regression to the stateless guarantee that matters: the pipeline performs
+   per-call transforms only and does not run the multi-turn agent loop; the
+   client's cached prefix is preserved.
+
+## Decisions (user proposal-gate, 2026-06-23)
+
+- **Streaming + buffered policing together, per-tool/per-severity.** Response
+  policing is implemented for both the buffered and streaming paths in the same
+  phase — not buffered-first. The action is a function of the tool and the
+  severity: a high-severity tool is blocked/rewritten even mid-SSE-stream; a
+  low-severity one may be audited/flagged only.
+  *Feasibility (resolves the security finding that mid-stream rewrite is
+  impossible under today's byte relay):* when a tool-policing policy is active, the
+  Anthropic streaming path stops using the raw byte relay
+  (`anthropic_http.c` `relay_flush`/`relay_append_data`, which passes SSE bytes
+  through unparsed) and instead drives a **block-aware translator** — the same
+  `anthropic_stream_xlate` machinery already used for the OpenAI→Anthropic path.
+  A `tool_use` content block streams its arguments as `input_json_delta`s and is
+  fully bounded by `content_block_start`/`content_block_stop`; the translator
+  **buffers the whole block before emitting `content_block_start` for it**, so the
+  policy can drop or rewrite it before any byte reaches the client. Text blocks
+  stream through unbuffered. So policing is feasible mid-stream **per content
+  block** (not per arbitrary byte), at the cost of buffering one tool_use block;
+  the byte relay remains the fast path when no policy is active.
+- **The pipeline is a new CORE module `gateway_pipeline.{c,h}`** that the ingresses
+  call — not grown into the size-capped `anthropic_http.c`/`openai_chat.c`.
+- **Do not duplicate `/v1/runs`.** The agentic endpoint and this per-call pipeline
+  **share** the policy/memory primitives (one implementation of tool-policing and
+  memory injection, called from both); the pipeline must not re-implement them.
+
+## Decisions, cont. — single-model Anthropic endpoints (resolves the qa finding)
+
+P1 makes passthrough automatic for any Anthropic-API primary, which **honors the
+client's requested model** (the parity path forwards `model` verbatim) instead of
+swapping to the agent's configured `ag->model`. For a primary that is a
+single-model Anthropic-*compatible* shim (llama.cpp / vLLM `/v1/messages`), an
+arbitrary client model name would be forwarded and rejected upstream — a behavior
+change vs. today's default (model-swap).
+
+Resolution: **P1 honors the client model (the stated intent) and the P1 PR
+documents the behavior change.** The fixed-model case is served by a **model-pin /
+allowlist policy** — a P2 pipeline stage (config: pin to `ag->model`, or an
+allowlist with swap-or-reject on miss). Default is honor; single-model operators
+enable the pin. P1 keeps the existing fallback: when the client omits `model`, the
+agent's model is used. This is a real but bounded regression window (P1→P2) for
+the single-model-shim deployment class only; api.anthropic.com / multi-model
+primaries are unaffected.
+
+## Open questions (for roundtable)
+- **IR fidelity.** A canonical IR must not lose provider-specific fields
+  (thinking/signature blocks, cache_control, beta-gated features). The IR should be
+  lossless for same-API passthrough (carry the raw blocks) and best-effort for
+  cross-API translation, matching today's behavior.
+- **Shared-seam location.** Where the shared policy/memory primitives live so both
+  `/v1/runs` and `gateway_pipeline` call them without a layering violation
+  (module-boundary check).

--- a/docs/proposals/pending/aimee-universal-gateway.plan.md
+++ b/docs/proposals/pending/aimee-universal-gateway.plan.md
@@ -1,0 +1,70 @@
+# Implementation plan — Aimee universal gateway
+
+- **State:** draft plan; tracks `aimee-universal-gateway.md` (roundtable-signed). Each
+  packet is its own build → live-test → unit-tests → lint → roundtable → PR →
+  merge cycle.
+
+## P1 — derive proxy/translate; delete the flag
+
+**Done (this branch).** Removes `claude_proxy_parity` from the whole config surface
+(`config.h`, `config.c`, `config_save.c`, `config_fields.c`, `config_schema.inc`,
+generated docs) and gates the `/v1/messages` ingress on `driver_is_anthropic` only:
+Anthropic-API primary → honor inbound model + forward `anthropic-version`/
+`anthropic-beta` + proxy `count_tokens` + relay upstream error status/body +
+`Retry-After`; OpenAI primary → translate + swap model. Whitebox tests flipped
+swap→honor. Live-validated against a mock upstream.
+
+- **AC:** `claude_proxy_parity` gone; passthrough/translate decided solely by the
+  serving model's API; unit tests green for both primary kinds; live test shows
+  model honored on an Anthropic primary.
+- **Behavior-change note for the PR:** single-model Anthropic-compatible shims now
+  receive the client's model verbatim (model-pin lands in P2).
+
+## P2 — `gateway_pipeline.{c,h}` + tool-policing
+
+New CORE module `src/server/gateway_pipeline.{c,h}`. Canonical request/response IR
++ a typed stage interface (`apply_request`, `apply_response`, and a streaming
+`on_block` variant). Port the existing translation in behind it; the ingresses call
+the pipeline.
+
+First policy: **tool-policing** (config: per-tool allow/deny + severity).
+- Request side: strip a denied tool (default target: the subagent / `Task` tool)
+  from `tools` (and `tool_choice` if it names it).
+- Response side, **buffered**: drop/rewrite a denied `tool_use` block.
+- Response side, **streaming** (both API shapes, per the carried-forward note):
+  - **Anthropic SSE:** when a policy is active, drive the block-aware
+    `anthropic_stream_xlate` instead of the byte relay; buffer a `tool_use` block
+    (args = `input_json_delta`s bounded by `content_block_start/stop`) until
+    `content_block_stop`, then emit/drop/rewrite. Text blocks stream unbuffered.
+  - **OpenAI SSE:** a `tool_calls` delta carries `index` + incremental
+    `function.arguments`; buffer per-index until the call is complete (next index,
+    or `finish_reason`), then emit/drop/rewrite. Same per-block-not-per-byte rule.
+  - Per-tool/severity: high-severity → buffer+block/rewrite; low-severity →
+    pass-through + audit row.
+- **Model-pin policy** (resolves proposal Finding C): config to pin the served
+  model to `ag->model` or an allowlist (swap-or-reject on miss); default off.
+- Shared with `/v1/runs`: the tool-policing + model-pin primitives live in one
+  module both the pipeline and the agentic path call (no duplication).
+
+- **AC:** IR + stages unit-tested pure; subagent strip + buffered & streaming
+  response policing on both API shapes, audited; model-pin tested; a policy enabled
+  in config applies via both ingresses.
+
+## P3 — memory injection as a stage
+
+Replace the two ad-hoc `ingress_preinject_build` call paths (anthropic_http.c ×2,
+openai_chat.c ×5) with **one** shared pipeline memory stage; byte-identical,
+cache-safe (append after the client's last `cache_control` breakpoint).
+
+- **AC:** both ingresses route memory injection through the one stage; rendered
+  bytes identical to today; `cache_read_input_tokens` unaffected on a repeated
+  prefix; the old call sites are gone.
+
+## P4 — unify OpenAI ingress + delegates
+
+Route `openai_chat.c` and the delegate call path through the same pipeline so
+translation + policy + memory apply uniformly to every model call, primary or
+delegate.
+
+- **AC:** a config-enabled policy applies to a delegate call (test); OpenAI ingress
+  goes through the pipeline; no behavior change when no policy/memory is active.

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -106,10 +106,6 @@ CFG_KEY_DESC = {
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
     "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
     "claude_model": "Default Claude model (empty = CLI default).",
-    "claude_proxy_parity": "Make the Claude Code `/v1/messages` ingress a transparent "
-    "Anthropic passthrough (honor inbound model, skip pre-injection, forward "
-    "anthropic-version/anthropic-beta, proxy count_tokens, relay upstream errors). "
-    "Default off.",
     "cost_reward_enabled": "Factor token cost into the reward signal.",
     "cost_reward_lambda_pct": "Cost-penalty weight (percent) in the reward.",
     "cost_reward_ref_usd_milli": "Reference cost (USD-milli) normalizing the cost reward.",

--- a/src/config.c
+++ b/src/config.c
@@ -833,10 +833,6 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
-   item = cJSON_GetObjectItemCaseSensitive(root, "claude_proxy_parity");
-   if (cJSON_IsBool(item))
-      cfg->claude_proxy_parity = cJSON_IsTrue(item);
-
    /* CSS migration assistant style-graph write path (WP-C). The field +
     * descriptor + save existed, but the YAML load parse was missing, so the
     * flag never took effect during indexing. */

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -41,7 +41,6 @@ const config_field_t config_fields[] = {
     {"memory_rerank_enabled", offsetof(config_t, memory_rerank_enabled), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_enabled", offsetof(config_t, ingress_preinject_enabled), sizeof(int), 0,
      CFG_BOOL},
-    {"claude_proxy_parity", offsetof(config_t, claude_proxy_parity), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_assembly_budget", offsetof(config_t, ingress_preinject_assembly_budget),
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -773,8 +773,6 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
-   if (cfg->claude_proxy_parity)
-      cJSON_AddBoolToObject(root, "claude_proxy_parity", 1);
    if (cfg->ingress_preinject_assembly_budget != 6144)
       cJSON_AddNumberToObject(root, "ingress_preinject_assembly_budget",
                               cfg->ingress_preinject_assembly_budget);

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -8,7 +8,6 @@
 {"kb_client_bearer_token", SCHEMA_STRING, 0},
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
-{"claude_proxy_parity", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},
 {"css_render_command", SCHEMA_STRING, 0},
 {"typed_facts_enabled", SCHEMA_BOOL, 0},

--- a/src/headers/anthropic_ingress.h
+++ b/src/headers/anthropic_ingress.h
@@ -102,7 +102,7 @@ void anthropic_stream_free(anthropic_stream_xlate_t *st);
  * API behavior (wire version, beta features such as fine-grained tool streaming
  * or 1h cache TTL). The /v1/messages ingress handlers receive only the body, so
  * server_http captures these two headers per request and the anthropic-driver
- * passthrough forwards them upstream when claude_proxy_parity is enabled. Set on
+ * passthrough forwards them upstream when the primary speaks the Anthropic API. Set on
  * every request (pass "" / NULL to clear); the getters return "" when unset. */
 void anthropic_ingress_set_request_headers(const char *anthropic_version,
                                            const char *anthropic_beta);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -337,17 +337,6 @@ typedef struct config
    int ingress_preinject_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
-
-   /* Exact-parity mode for the Claude Code Anthropic ingress (POST /v1/messages).
-    * Default off: the ingress keeps its value-add proxy behavior (serves the
-    * configured primary model, applies context pre-injection). When on AND the
-    * primary is an Anthropic-profile agent, the ingress becomes a transparent
-    * passthrough so Claude Code gets byte-equivalent behavior to talking to
-    * api.anthropic.com directly: the inbound `model` is honored (no primary
-    * swap), pre-injection is skipped, the client's `anthropic-version` /
-    * `anthropic-beta` headers are forwarded upstream, count_tokens is proxied to
-    * the real endpoint, and upstream error status/body pass through unchanged. */
-   int claude_proxy_parity;
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -225,7 +225,7 @@ extern "C"
 
    /* Capture the inbound `anthropic-version` / `anthropic-beta` headers off the
     * raw request into per-request thread-locals, for the /v1/messages exact-parity
-    * passthrough (forwarded upstream only when claude_proxy_parity is on). Called
+    * passthrough (forwarded upstream only when the primary speaks the Anthropic API). Called
     * once per request from the HTTP dispatch; `raw_request` is the full request
     * buffer (NULL clears). Defined in server/anthropic_http.c. */
    void anthropic_http_capture_request_headers(const char *raw_request);

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -20,7 +20,6 @@
 #include "agent_types.h"
 #include "anthropic_ingress.h"
 #include "cJSON.h"
-#include "config.h"
 #include "delegate_driver.h"
 #include "ingress_preinject.h"
 #include "json_fluent.h"
@@ -53,17 +52,14 @@ static void mint_msg_id(char *buf, size_t n)
    snprintf(buf, n, "msg_%ld", (long)time(NULL));
 }
 
-/* Exact-parity mode for the Claude Code ingress (config claude_proxy_parity,
- * default off). When on AND the primary is an Anthropic-profile agent, the
- * ingress is a transparent passthrough: inbound model honored, pre-injection
- * skipped, client anthropic-version/anthropic-beta forwarded, count_tokens
- * proxied upstream, and upstream error status/body relayed unchanged. */
-static int parity_on(void)
-{
-   config_t cfg;
-   config_load(&cfg);
-   return cfg.claude_proxy_parity ? 1 : 0;
-}
+/* Passthrough vs. translate is a property of the serving model, not a setting:
+ * when the primary speaks the Anthropic Messages API natively (the anthropic
+ * driver), the /v1/messages ingress is a transparent passthrough — inbound model
+ * honored, pre-injection skipped, client anthropic-version/anthropic-beta
+ * forwarded, count_tokens proxied upstream, upstream error status/body +
+ * Retry-After relayed unchanged. When the primary speaks OpenAI, the request is
+ * translated (and the model swapped to the configured one). Derived below from
+ * driver_is_anthropic(); there is no config flag. */
 
 /* Retry-After (seconds) the parity passthrough relays on its own response when it
  * forwarded an upstream 429/529 that carried one. Thread-local, reset on every
@@ -341,7 +337,7 @@ static int messages_buffered(const char *body, char *resp, int cap)
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
    /* Exact-parity passthrough only applies to the Anthropic-native path. */
-   int parity = parity_on() && driver_is_anthropic(driver);
+   int parity = driver_is_anthropic(driver);
    if (!parity)
       messages_apply_preinject(req);
    translate_request(req, driver, ag, &messages, &tools, &system_text);
@@ -634,7 +630,7 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    delegate_drivers_init();
    driver = delegate_driver_get(ag->provider);
    /* Exact-parity passthrough only applies to the Anthropic-native path. */
-   int parity = parity_on() && driver_is_anthropic(driver);
+   int parity = driver_is_anthropic(driver);
    if (!parity)
       messages_apply_preinject(req);
    translate_request(req, driver, ag, &messages, &tools, &system_text);
@@ -743,10 +739,10 @@ static int count_tokens(const char *body, char *resp, int cap)
 {
    cJSON *req = cJSON_Parse((body && body[0]) ? body : "{}");
 
-   /* Exact parity: proxy to Anthropic's real /v1/messages/count_tokens so Claude
-    * Code's context-budget math matches api.anthropic.com, not a local estimate.
-    * Only on the Anthropic-native path; otherwise fall through to the estimate. */
-   if (parity_on())
+   /* Proxy to Anthropic's real /v1/messages/count_tokens so Claude Code's
+    * context-budget math matches api.anthropic.com, not a local estimate — only
+    * when the primary speaks the Anthropic API; otherwise fall through to the
+    * estimate. */
    {
       agent_config_t acfg;
       agent_t *ag = resolve_primary(&acfg);

--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -17,7 +17,7 @@
  * Not part of the pure translation: a thin per-request echo of the two inbound
  * headers that select Anthropic API behavior. server_http captures them off the
  * raw request (the ingress handlers never see HTTP headers); the anthropic-driver
- * passthrough forwards them upstream when claude_proxy_parity is on. Thread-local
+ * passthrough forwards them upstream when the primary speaks the Anthropic API. Thread-local
  * and reset on every request, so a value never leaks between requests on a reused
  * worker thread. */
 static __thread char g_req_anthropic_version[64] = "";

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -10,7 +10,6 @@
 #include "../headers/agent_config.h"
 #include "../headers/agent_exec.h"
 #include "../headers/agent_protocol.h"
-#include "../headers/config.h"
 #include "../headers/delegate_driver.h"
 #include "../headers/server_http.h"
 #include "../vendor/headers/cJSON.h"
@@ -20,7 +19,6 @@
 static const delegate_driver_t *g_driver;
 static char *g_last_body;
 static char *g_last_extra; /* upstream extra-header block from the last post */
-static int g_stub_parity;  /* config_load stub returns this as claude_proxy_parity */
 static int g_stream_status = 200;
 static const char *g_stream_payload;
 
@@ -30,7 +28,6 @@ static void reset_capture(void)
    g_last_body = NULL;
    free(g_last_extra);
    g_last_extra = NULL;
-   g_stub_parity = 0;
    g_stream_status = 200;
    g_stream_payload = NULL;
 }
@@ -222,19 +219,8 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    return g_stub_preinject_env ? strdup(g_stub_preinject_env) : NULL;
 }
 
-/* Config + HTTP-layer stubs for the parity path. config_load zeroes the struct so
- * claude_proxy_parity defaults off — these whitebox tests cover the default
- * model-swap/pre-injection behavior, not parity mode. agent_http_last_retry_after
- * has no upstream socket here, so 0 (no Retry-After) suffices. */
-int config_load(config_t *cfg)
-{
-   if (cfg)
-   {
-      memset(cfg, 0, sizeof(*cfg));
-      cfg->claude_proxy_parity = g_stub_parity;
-   }
-   return 0;
-}
+/* HTTP-layer stub: agent_http_last_retry_after has no upstream socket here, so 0
+ * (no Retry-After) suffices. */
 int agent_http_last_retry_after(void)
 {
    return 0;
@@ -492,7 +478,8 @@ static void test_messages_buffered_anthropic_preserves_request_shape(void)
                          resp, sizeof(resp)) == 200);
    assert(g_last_body != NULL);
    sent = parse(g_last_body);
-   assert(strcmp(obj(sent, "model")->valuestring, "configured-claude") == 0);
+   /* Anthropic primary speaks the Anthropic API -> inbound model honored verbatim. */
+   assert(strcmp(obj(sent, "model")->valuestring, "ignored") == 0);
    system = obj(sent, "system");
    assert(cJSON_IsArray(system));
    cc = obj(cJSON_GetArrayItem((cJSON *)system, 0), "cache_control");
@@ -507,8 +494,8 @@ static void test_messages_buffered_anthropic_preserves_request_shape(void)
    PASS("messages_buffered_anthropic_preserves_request_shape");
 }
 
-/* claude_proxy_parity on: inbound model honored (not swapped to the primary),
- * pre-injection skipped, and the client's anthropic-beta forwarded upstream. */
+/* Anthropic primary -> passthrough: inbound model honored, pre-injection skipped,
+ * and the client's anthropic-beta forwarded upstream. */
 static void test_messages_buffered_anthropic_parity_passthrough(void)
 {
    const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
@@ -517,7 +504,6 @@ static void test_messages_buffered_anthropic_parity_passthrough(void)
 
    reset_capture();
    g_driver = &anthropic;
-   g_stub_parity = 1;
    g_stub_preinject_env = "<aimee-context>INJECTED</aimee-context>";
    anthropic_ingress_set_request_headers("2023-06-01", "test-beta-flag,extended-cache-ttl");
 
@@ -525,9 +511,9 @@ static void test_messages_buffered_anthropic_parity_passthrough(void)
                             "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
                             resp, sizeof(resp)) == 200);
    sent = parse(g_last_body);
-   /* inbound model preserved (default behavior would swap to "configured-claude") */
+   /* inbound model honored (an OpenAI primary would translate + swap the model) */
    assert(strcmp(obj(sent, "model")->valuestring, "claude-opus-4-8") == 0);
-   /* pre-injection skipped under parity */
+   /* pre-injection skipped on the passthrough path */
    assert(strstr(g_last_body, "INJECTED") == NULL);
    /* client beta forwarded upstream */
    assert(g_last_extra != NULL && strstr(g_last_extra, "anthropic-beta: test-beta-flag") != NULL);
@@ -578,7 +564,8 @@ static void test_messages_stream_anthropic_preserves_request_shape(void)
                           cap_emit, &cap) == 0);
    assert(g_last_body != NULL);
    sent = parse(g_last_body);
-   assert(strcmp(obj(sent, "model")->valuestring, "configured-claude") == 0);
+   /* Anthropic primary speaks the Anthropic API -> inbound model honored verbatim. */
+   assert(strcmp(obj(sent, "model")->valuestring, "ignored") == 0);
    assert(cJSON_IsArray(obj(sent, "system")));
    assert(cJSON_IsObject(obj(sent, "tool_choice")));
    assert(cJSON_IsObject(obj(sent, "thinking")));

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,7 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\nclaude_proxy_parity: true\ncss_style_graph_enabled: "
+    "true\ningress_preinject_enabled: true\ncss_style_graph_enabled: "
     "true\n"
     "ingress_preinject_assembly_budget: 1\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
@@ -82,7 +82,7 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\nclaude_proxy_parity: false\ncss_style_graph_enabled: "
+    "false\ningress_preinject_enabled: false\ncss_style_graph_enabled: "
     "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
@@ -162,7 +162,6 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
-   assert(cfgA.claude_proxy_parity == 1 && cfgB.claude_proxy_parity == 0);
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);


### PR DESCRIPTION
First phase of the **aimee universal gateway** proposal (docs included, roundtable-signed).

**P1:** Passthrough vs. translate on `/v1/messages` is now derived purely from the serving model's API (`driver_is_anthropic`), not a config flag. Anthropic-API primary → honor inbound model + forward `anthropic-version`/`anthropic-beta` + proxy `count_tokens` + relay upstream errors/`Retry-After`. OpenAI primary → translate + swap model. `claude_proxy_parity` removed from the entire config surface. Whitebox tests flipped swap→honor; live-validated end-to-end with no config present (upstream model honored).

Roundtable: security APPROVE on the implementation; proposal R1/R2 signed off (findings A/B resolved, C via the P2 model-pin). Build clean; `unit-test-anthropic-http`/`config-surface`/`anthropic-ingress`/`server-http` pass.

**Behavior change:** a single-model Anthropic-compatible shim now receives the client's model verbatim (model-pin policy lands in P2).

Docs: `docs/proposals/pending/aimee-universal-gateway.md` + `.plan.md`.