### PR TITLE
feat(db2): embedder-autodim §2b — fresh-DB embedding dim from the /health probe

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -196,7 +196,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 116 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 117 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -387,7 +387,7 @@ The binaries read 116 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_EMBEDDER_URL`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_EMBEDDER_URL`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/docs/proposals/pending/embedder-runtime-fetch-autodim.md
+++ b/docs/proposals/pending/embedder-runtime-fetch-autodim.md
@@ -10,12 +10,20 @@
   the `operator-pin > recorded > (probe)` precedence at the `db2_init` schema-apply
   boundary, so an unpinned populated DB self-derives its dim instead of refusing on
   the default. See [the §2a plan](embedder-runtime-fetch-autodim.plan.md).
-  **Remaining (not done):** §2b — the fresh-DB auto-derive from the embedder
-  `/health` probe under `pg_try_advisory_lock` (the `probed` precedence rung,
-  reserved but always 0 today); §2c — the double-gated auto-reembed
-  (`kb_reembed_on_dim_change` off-by-default + `--confirm` + `/health=maintenance`
-  + count-divergence → degraded). Both are runtime/bootstrap work that needs the
-  live embedder+kb stack to validate.
+  **§2b (fresh-DB probe) landed in PR #NNN:** the `probed` precedence rung is now
+  wired — `db2_init` derives a fresh DB's dim from the embedder `/health` probe
+  under `pg_try_advisory_lock`, fail-fast + never-poison, via a registered probe
+  seam (`db2_set_embedder_probe`, `src/server/embedder_probe.c`, `embed-remote.py
+  --dim`). **Validated live** on a real postgres+embedder+kb stack: fresh DB +
+  embedder dim=768 → records 768 / `halfvec(768)` (vs the 1024-default baseline);
+  operator pin wins; a bad/zero probe dim fails fast and records nothing. The same
+  work fixed a latent defect that had silently disabled BOTH §2a and §2b: the
+  config default `embedding_dim=1024` made `config_embedding_dim_is_pinned` report
+  "pinned" in every deployment — now defaulted to 0 (unset), so "pinned" means the
+  operator explicitly set it. **Remaining (not done):** §2c — the double-gated
+  auto-reembed (`kb_reembed_on_dim_change` off-by-default + `--confirm` +
+  `/health=maintenance` + count-divergence → degraded). Runtime/bootstrap work
+  validated against the live embedder+kb stack.
 - **Author:** JBailes
 - **Date:** 2026-06-14
 - **Base:** `origin/main` (v0.2.65). The embedder ships in two **baked** images

--- a/scripts/embed-remote.py
+++ b/scripts/embed-remote.py
@@ -36,7 +36,35 @@ def _post(path: str, data: bytes, content_type: str) -> str:
         return resp.read().decode("utf-8")
 
 
+def probe_dim() -> int:
+    """embedder-autodim §2b: GET /health and return the loaded model's output dim.
+    Exit 0 + print the integer dim ONLY when the embedder reports status=ok with a
+    positive integer dim; exit non-zero (caller treats as 'not ready') while the
+    model is still loading, on any HTTP/parse error, or on a missing/non-positive
+    dim. Single GET, no embedding — cheap enough to poll."""
+    try:
+        with urllib.request.urlopen(f"{ENDPOINT}/health", timeout=TIMEOUT) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, OSError) as exc:
+        sys.stderr.write(f"embed-remote --dim: /health at {ENDPOINT} unreachable: {exc}\n")
+        return 1
+    except (json.JSONDecodeError, ValueError) as exc:
+        sys.stderr.write(f"embed-remote --dim: bad /health payload: {exc}\n")
+        return 1
+    if not isinstance(payload, dict) or payload.get("status") != "ok":
+        sys.stderr.write(f"embed-remote --dim: embedder not ready (status={payload.get('status')!r})\n")
+        return 1
+    dim = payload.get("dim")
+    if not isinstance(dim, int) or dim <= 0:
+        sys.stderr.write(f"embed-remote --dim: no positive integer dim (got {dim!r})\n")
+        return 1
+    print(dim)
+    return 0
+
+
 def main() -> None:
+    if "--dim" in sys.argv[1:]:
+        sys.exit(probe_dim())
     raw = sys.stdin.read()
     if not raw.strip():
         sys.stderr.write("embed-remote: empty input\n")

--- a/src/Makefile
+++ b/src/Makefile
@@ -788,7 +788,7 @@ $(SERVER): $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(AGENT_OBJS) $(SERVER_DATA_O
 # oauth_pkce.o provides the base64url encoder kb/enroll.c uses to mint
 # enrollment tokens (now reachable from `aimee-kb enroll`). It is a leaf crypto
 # util (openssl + platform_random only), so the kb sidecar links it directly.
-$(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_PLATFORM_OBJS)
+$(KB): $(KB_OBJS) $(OBJDIR)/dashboard_kb.o $(OBJDIR)/server/oauth_pkce.o $(OBJDIR)/server/embedder_probe.o $(KB_DATA_OBJS) $(KB_CORE_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(KB_PLATFORM_OBJS)
 	$(AIMEE_RUNTIME_MUTATION_GUARD)
 	$(CC) -o $@ $^ $(L_KB)
 

--- a/src/config.c
+++ b/src/config.c
@@ -434,10 +434,14 @@ static void config_set_defaults(config_t *cfg)
    cfg->memory_fetch_budget_base = 128;
    cfg->memory_fetch_budget_shape_aware = 1;
    cfg->kb_search_max_results = 50;
-   /* Embedding dimension of the default embedder (pplx-embed-v1-0.6b = 1024).
-    * Must match the schema vector(N) columns and the embedder model. Set to
-    * 2560 (with the pplx-embed-v1-4b embedder image) for the higher-fidelity tier. */
-   cfg->embedding_dim = 1024;
+   /* Embedding dimension. 0 = UNSET (the operator did not pin a dim): readers fall
+    * back to 1024 (db2_embedding_dim(), kb_main, kb_ingest_workers), and — crucially
+    * — config_embedding_dim_is_pinned() reports NOT-pinned, so §2a's recorded-dim
+    * preference and §2b's fresh-DB embedder /health probe can derive the real dim.
+    * A non-zero value here means the operator explicitly pinned it (yaml/env), which
+    * is authoritative and refuses a mismatch. (Was defaulted to 1024, which made
+    * every deployment look "pinned" and silently disabled §2a/§2b.) */
+   cfg->embedding_dim = 0;
    /* The cross-encoder rerank stage (Ettin reranker sized to the embedder tier:
     * 1b with the 4b embedder, 400m with the 0.6b; served by the
     * embedder service /rerank, client scripts/rerank-remote.py) is the third

--- a/src/db2/db2_init.c
+++ b/src/db2/db2_init.c
@@ -27,6 +27,7 @@ typedef struct sqlite3 sqlite3;
 #include <stddef.h>
 #include <stdio.h>
 #include <string.h>
+#include <time.h> /* §2b: CLOCK_MONOTONIC poll budget + nanosleep between lock polls */
 
 #if !defined(AIMEE_DISABLE_DB2_SQLITE_SHIM) && (defined(__GNUC__) || defined(__clang__))
 #pragma weak sqlite3_close
@@ -72,6 +73,23 @@ int db2_embedding_dim(void)
 void db2_set_embedding_dim_pinned(int pinned)
 {
    g_embed_dim_pinned = pinned ? 1 : 0;
+}
+
+/* §2b: the embedder /health probe seam + its wall-clock budget. NULL/0 by default
+ * (the §2b path is skipped → behavior identical to §2a). Both reset in
+ * db2_shutdown so a reopen / a later test never inherits them. */
+static db2_embedder_probe_fn g_embedder_probe = NULL;
+static int g_dim_probe_budget_ms = 120000;
+
+void db2_set_embedder_probe(db2_embedder_probe_fn fn)
+{
+   g_embedder_probe = fn;
+}
+
+void db2_set_dim_probe_budget_ms(int ms)
+{
+   if (ms > 0)
+      g_dim_probe_budget_ms = ms;
 }
 
 /* Model-identity drift guard (unified-llm-container §2). A dim-only guard is
@@ -136,6 +154,93 @@ int db2_effective_dim(int pinned, int configured, int recorded)
       return recorded; /* recorded wins over the configured default */
    return configured;  /* fresh DB / nothing recorded: the default */
 }
+
+/* §2b precedence (pure): pin > recorded > probe > default. */
+db2_dim_source_t db2_dim_source(int pinned, int recorded_present, int probe_available)
+{
+   if (pinned)
+      return DB2_DIM_SRC_PIN;
+   if (recorded_present)
+      return DB2_DIM_SRC_RECORDED;
+   if (probe_available)
+      return DB2_DIM_SRC_PROBE;
+   return DB2_DIM_SRC_DEFAULT;
+}
+
+/* §2b: a Postgres advisory lock serialises fresh-DB dim bootstrap across racing kb
+ * starts. Keyed by hashtext of this string (the mining.c pattern). Bump the _vN
+ * suffix only on a semantics-changing lock change (added waiters / xact-scoped),
+ * never on a code refactor — the value is a wire contract between concurrent kbs. */
+#define DB2_DIM_LOCK_KEY "aimee_dim_bootstrap_v1"
+
+static long db2_mono_ms(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* Acquire the dim-bootstrap advisory lock, polling pg_try_advisory_lock every
+ * ~250ms up to budget_ms. Returns 0 = acquired, 1 = timed out (another session
+ * holds it for the whole budget), -1 = query error. *elapsed_ms (optional) gets
+ * the wall time spent so the caller can subtract it from the probe budget. On the
+ * sqlite test shim there is no advisory lock (single-process tests) → acquired. */
+static int db2_dim_lock_acquire(void *conn, int budget_ms, int *elapsed_ms)
+{
+   long start = db2_mono_ms();
+   if (aimee_pg_is_shim())
+   {
+      if (elapsed_ms)
+         *elapsed_ms = 0;
+      return 0;
+   }
+   for (;;)
+   {
+      char err[256] = "";
+      /* ::int — pg_try_advisory_lock returns BOOLEAN; aimee_pg_column_int does
+       * atoi(PQgetvalue) and atoi("t")==0, so the bool must be cast to 1/0 text or
+       * the lock would never read as acquired. */
+      aimee_pg_stmt_t *st = aimee_pg_prepare(conn, "SELECT pg_try_advisory_lock(hashtext(?1))::int",
+                                             err, sizeof(err));
+      int got = 0, ok = 0;
+      if (st)
+      {
+         aimee_pg_bind_text(st, "?1", DB2_DIM_LOCK_KEY);
+         if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+         {
+            ok = 1;
+            got = aimee_pg_column_int(st, 0) ? 1 : 0;
+         }
+         aimee_pg_finalize(st);
+      }
+      int spent = (int)(db2_mono_ms() - start);
+      if (elapsed_ms)
+         *elapsed_ms = spent;
+      if (!ok)
+         return -1;
+      if (got)
+         return 0;
+      if (spent >= budget_ms)
+         return 1;
+      struct timespec ts = {0, 250L * 1000 * 1000};
+      nanosleep(&ts, NULL);
+   }
+}
+
+static void db2_dim_lock_release(void *conn)
+{
+   if (aimee_pg_is_shim())
+      return;
+   char err[256] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, "SELECT pg_advisory_unlock(hashtext(?1))", err, sizeof(err));
+   if (!st)
+      return;
+   aimee_pg_bind_text(st, "?1", DB2_DIM_LOCK_KEY);
+   (void)aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+}
+
 static pthread_key_t g_thread_conn_key;
 static pthread_once_t g_thread_conn_key_once = PTHREAD_ONCE_INIT;
 /* The thread that ran db2_init() owns g_conn and uses it directly; every other
@@ -455,17 +560,109 @@ int db2_init(const char *libpq_url)
     * and aimee-kb, which hold the loaded config) so this low-level layer stays
     * config-free; it defaults to 1024 when unset. */
    int configured_dim = db2_embedding_dim();
-   /* §2a precedence: when the operator did NOT pin a dim, prefer the recorded
-    * kb_meta.schema_embedding_dim (the populated-DB source of truth) over the
-    * default, so an unpinned deploy self-derives its dim instead of refusing the
-    * apply. Pinned and fresh-DB paths keep configured_dim → behavior-identical. */
-   int recorded_dim = g_embed_dim_pinned ? 0 : db2_embedding_dim_get(conn);
-   int effective_dim = db2_effective_dim(g_embed_dim_pinned, configured_dim, recorded_dim);
+   /* §2a/§2b precedence: pin > recorded > probe > default. When the operator did
+    * NOT pin, prefer the recorded kb_meta.schema_embedding_dim (the populated-DB
+    * source of truth); on a FRESH DB (nothing recorded) §2b derives the dim from
+    * the embedder /health probe under an advisory lock. Pinned + recorded paths
+    * keep §2a behavior. A DB read ERROR fails fast (never guess a default). */
+   int recorded_dim = 0;
+   db2_dim_read_t rd =
+       g_embed_dim_pinned ? DB2_DIM_ABSENT : db2_embedding_dim_read(conn, &recorded_dim);
+   if (rd == DB2_DIM_ERROR)
+   {
+      fprintf(stderr, "aimee: db2_init: reading recorded embedding dim failed\n");
+      aimee_pg_close(conn);
+      pthread_mutex_unlock(&g_init_lock);
+      return -1;
+   }
+   int effective_dim = db2_effective_dim(g_embed_dim_pinned, configured_dim,
+                                         rd == DB2_DIM_FOUND ? recorded_dim : 0);
+
+   /* §2b fresh-DB probe leg: unpinned + nothing recorded + a probe registered. The
+    * advisory lock serialises racing kb starts; FAIL-FAST on any probe/lock/read
+    * failure and record NOTHING (kb_main retries; never poison the recorded dim). */
+   int dim_lock_held = 0, derived_via_probe = 0;
+   if (!g_embed_dim_pinned && rd == DB2_DIM_ABSENT && g_embedder_probe)
+   {
+      /* Wait up to the FULL budget for the lock: a peer mid-bootstrap can take the
+       * whole budget (cold embedder), so the waiter must be at least as patient —
+       * by the time it acquires (or the peer releases) the dim is recorded and the
+       * waiter's double-check below sees it. A genuine budget-long timeout means a
+       * stuck/dead holder → fail fast; kb_main.c's bounded retry (24×5s) is the
+       * outer safety net so a transient stall self-heals without thrash. */
+      int total = g_dim_probe_budget_ms;
+      int elapsed = 0;
+      int lrc = db2_dim_lock_acquire(conn, total, &elapsed);
+      if (lrc != 0)
+      {
+         /* Timed out or a lock query error: another starter may have bootstrapped
+          * in the meantime. Re-read; use a now-recorded dim, else fail fast. */
+         int rec2 = 0;
+         if (db2_embedding_dim_read(conn, &rec2) == DB2_DIM_FOUND)
+            effective_dim = rec2;
+         else
+         {
+            LOG_WARN("db2",
+                     "embedder dim bootstrap: advisory lock not acquired in %dms and no dim "
+                     "recorded; not derived (kb will retry)",
+                     total);
+            aimee_pg_close(conn);
+            pthread_mutex_unlock(&g_init_lock);
+            return -1;
+         }
+      }
+      else
+      {
+         dim_lock_held = 1;
+         int rec2 = 0;
+         db2_dim_read_t rd2 = db2_embedding_dim_read(conn, &rec2); /* double-check under the lock */
+         if (rd2 == DB2_DIM_ERROR)
+         {
+            db2_dim_lock_release(conn);
+            aimee_pg_close(conn);
+            pthread_mutex_unlock(&g_init_lock);
+            return -1;
+         }
+         if (rd2 == DB2_DIM_FOUND)
+         {
+            effective_dim = rec2; /* another starter bootstrapped between our reads */
+         }
+         else
+         {
+            int probed = 0;
+            char perr[DB2_PROBE_ERR_LEN] = "";
+            /* Remaining budget after the lock wait, floored so a late acquirer
+             * (rare: a crashed peer that never recorded) still gets one attempt. */
+            int pbudget = total - elapsed;
+            if (pbudget < 1000)
+               pbudget = 1000;
+            int prc = g_embedder_probe(&probed, pbudget, perr, sizeof(perr));
+            /* Bound to a valid halfvec width: an out-of-range value must NOT fall
+             * through to db_apply's clamp-to-1024 (that would record a wrong dim). */
+            if (prc != 0 || probed <= 0 || probed > EMBED_MAX_DIM)
+            {
+               LOG_WARN("db2", "embedder dim probe failed/out-of-range (got %d, max %d): %s",
+                        probed, EMBED_MAX_DIM, perr[0] ? perr : "(no detail)");
+               db2_dim_lock_release(conn);
+               aimee_pg_close(conn);
+               pthread_mutex_unlock(&g_init_lock);
+               return -1;
+            }
+            effective_dim = probed;
+            derived_via_probe = 1;
+         }
+      }
+   }
+
    if (effective_dim != configured_dim)
    {
-      LOG_WARN("db2",
-               "using recorded embedding dim %d (no operator pin; configured default was %d)",
-               effective_dim, configured_dim);
+      if (derived_via_probe)
+         LOG_WARN("db2", "fresh DB: derived embedding dim %d from the embedder /health probe",
+                  effective_dim);
+      else
+         LOG_WARN("db2",
+                  "using recorded embedding dim %d (no operator pin; configured default was %d)",
+                  effective_dim, configured_dim);
       db2_set_embedding_dim(effective_dim); /* halfvec columns + all readers agree */
    }
    if (db_apply_schema_postgres(conn, effective_dim, errbuf, sizeof(errbuf)) != 0)
@@ -474,10 +671,16 @@ int db2_init(const char *libpq_url)
        * Silently returning -1 hid bugs like a stale CREATE INDEX referencing
        * a table that lives in a different tier's schema. */
       fprintf(stderr, "aimee: db2_init: schema apply failed: %s\n", errbuf);
+      if (dim_lock_held)
+         db2_dim_lock_release(conn);
       aimee_pg_close(conn);
       pthread_mutex_unlock(&g_init_lock);
       return -1;
    }
+   /* Schema (incl. the halfvec columns) is now applied AND the dim recorded last
+    * (record-after-DDL), so the lock can release: a later starter reads the dim. */
+   if (dim_lock_held)
+      db2_dim_lock_release(conn);
 
    /* unified-llm-container §2: model-identity drift guard, applied here (where the
     * configured identity globals live) rather than in the lower db_schema layer.
@@ -740,6 +943,10 @@ void db2_shutdown(void)
     * real caller sets it again via db2_set_embedding_dim before the next init. */
    g_embed_dim = 0;
    g_embed_dim_pinned = 0;
+   /* §2b: defensively clear the probe seam + budget (the caller SHOULD deregister
+    * before db2_shutdown, but back it up here, mirroring g_embed_dim_pinned). */
+   g_embedder_probe = NULL;
+   g_dim_probe_budget_ms = 120000;
    g_embedder_model_id[0] = '\0';
    g_reranker_model_id[0] = '\0';
    g_reranker_contract[0] = '\0';

--- a/src/db2/db_schema.c
+++ b/src/db2/db_schema.c
@@ -196,6 +196,71 @@ int db2_embedding_dim_get(void *conn)
    return dim;
 }
 
+db2_dim_read_t db2_embedding_dim_read(void *conn, int *out)
+{
+   if (out)
+      *out = 0;
+   if (!conn)
+      return DB2_DIM_ERROR;
+   char err[256] = "";
+   /* A FRESH DB has no kb_meta yet — it is created by db_apply_schema_postgres,
+    * which runs AFTER this read. On real Postgres a SELECT against a missing table
+    * errors (at step, not prepare), so a naive read would misreport ERROR and
+    * fail-fast the §2b cold path before the schema is ever applied — deadlocking
+    * the kb_main retry loop. Probe the catalog first with to_regclass (returns NULL
+    * rather than erroring when the table is absent) and report ABSENT, never ERROR.
+    * The sqlite test shim always has kb_meta (it pre-applies the schema) and lacks
+    * to_regclass, so the guard is skipped there. */
+   if (!aimee_pg_is_shim())
+   {
+      aimee_pg_stmt_t *chk = aimee_pg_prepare(
+          conn, "SELECT (to_regclass('kb_meta') IS NOT NULL)::int", err, sizeof(err));
+      if (!chk)
+         return DB2_DIM_ERROR;
+      int exists = 0, ok = 0;
+      if (aimee_pg_step(chk, err, sizeof(err)) == AIMEE_PG_ROW)
+      {
+         ok = 1;
+         exists = aimee_pg_column_int(chk, 0);
+      }
+      aimee_pg_finalize(chk);
+      if (!ok)
+         return DB2_DIM_ERROR; /* a real query/connection error */
+      if (!exists)
+         return DB2_DIM_ABSENT; /* fresh DB: kb_meta not created yet */
+   }
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "SELECT value FROM kb_meta WHERE key = 'schema_embedding_dim'", err, sizeof(err));
+   if (!st)
+      return DB2_DIM_ERROR; /* kb_meta exists (or shim): a prepare failure is real */
+   aimee_pg_step_t step = aimee_pg_step(st, err, sizeof(err));
+   db2_dim_read_t rc;
+   if (step == AIMEE_PG_ROW)
+   {
+      const char *valtxt = aimee_pg_column_text(st, 0);
+      char *endp = NULL;
+      long v = (valtxt && *valtxt) ? strtol(valtxt, &endp, 10) : 0;
+      if (valtxt && *valtxt && endp && *endp == '\0' && v >= 1 && v <= EMBED_MAX_DIM)
+      {
+         if (out)
+            *out = (int)v;
+         rc = DB2_DIM_FOUND;
+      }
+      else
+         rc = DB2_DIM_ABSENT; /* garbage / out-of-range row: quiet, as §2a */
+   }
+   else if (step == AIMEE_PG_DONE)
+   {
+      rc = DB2_DIM_ABSENT; /* no row: the expected fresh-DB signal */
+   }
+   else
+   {
+      rc = DB2_DIM_ERROR; /* step error (lost conn etc.): do not misread as absent */
+   }
+   aimee_pg_finalize(st);
+   return rc;
+}
+
 /* True if compat_csv (a comma-separated list of "old_id->new_id" transitions)
  * admits the transition old_id -> new_id. Whitespace around tokens is trimmed.
  * unified-llm-container §2: a compat-list entry only EXISTS once an operator has

--- a/src/db2/db_schema.h
+++ b/src/db2/db_schema.h
@@ -43,6 +43,20 @@ extern "C"
     * sqlite shim. */
    int db2_embedding_dim_get(void *conn);
 
+   /* §2b: tri-state read distinguishing a genuinely-absent recorded dim (expected
+    * on a fresh DB) from a DB query ERROR — the §2b probe path must NOT treat a
+    * lost connection / missing table as "absent" and bootstrap over it. *out is
+    * set only on FOUND (an in-range 1..EMBED_MAX_DIM value); a no-row or
+    * garbage/out-of-range row → ABSENT (quiet, as §2a); a prepare/step failure →
+    * ERROR. (db2_embedding_dim_get stays as the value-or-0 wrapper for §2a.) */
+   typedef enum
+   {
+      DB2_DIM_FOUND = 0,
+      DB2_DIM_ABSENT = 1,
+      DB2_DIM_ERROR = -1
+   } db2_dim_read_t;
+   db2_dim_read_t db2_embedding_dim_read(void *conn, int *out);
+
    /* unified-llm-container §2: record/check the EMBEDDER model identity
     * (repo@sha) in kb_meta.schema_embedder_model_id alongside the dim. A dim-only
     * guard is insufficient (two models can share a dim — pplx-embed and

--- a/src/db2/lifecycle.h
+++ b/src/db2/lifecycle.h
@@ -40,6 +40,40 @@ extern "C"
     * default.) */
    int db2_effective_dim(int pinned, int configured, int recorded);
 
+   /* embedder-runtime-fetch-autodim §2b: fresh-DB probe rung. On a fresh DB2 (no
+    * operator pin, no recorded schema_embedding_dim) db2_init derives the dim from
+    * the running embedder's /health, under a Postgres advisory lock, instead of the
+    * default. db2 stays config-free via a registered probe seam (mirrors the
+    * wfe_set_delegate_provider / g_forge pattern). */
+#define DB2_PROBE_ERR_LEN 256
+   /* Probe the embedder for its loaded-model output dim. Return 0 and set *out_dim
+    * (>0) ONLY when the embedder reports a loaded model with a STABLE dim within
+    * budget_ms; return -1 otherwise (still loading / unreachable / unstable /
+    * timeout), filling err. Called only from db2_init (single-threaded, under the
+    * init lock); not required to be reentrant. */
+   typedef int (*db2_embedder_probe_fn)(int *out_dim, int budget_ms, char *err, size_t errlen);
+   /* Register/clear the probe. The caller (kb/server) MUST call
+    * db2_set_embedder_probe(NULL) BEFORE db2_shutdown(); db2_shutdown also NULLs it
+    * defensively (mirrors the g_embed_dim_pinned reset discipline). With no probe
+    * registered (cmd_core, tools) the §2b path is skipped — behavior is unchanged. */
+   void db2_set_embedder_probe(db2_embedder_probe_fn fn);
+   /* Total wall-clock budget (ms) for the §2b lock-acquire + probe. Set from config
+    * (kb.embedder.dim_probe_budget_ms; default 120000) before db2_init, beside
+    * db2_set_embedding_dim, so db2 stays config-free. */
+   void db2_set_dim_probe_budget_ms(int ms);
+
+   /* §2b precedence, pure (no globals, no I/O): which source supplies the dim, given
+    * whether the operator pinned, a dim is recorded, and a probe is available.
+    * Encodes pin > recorded > probe > default; unit-tested directly. */
+   typedef enum
+   {
+      DB2_DIM_SRC_PIN = 0,      /* operator pin authoritative */
+      DB2_DIM_SRC_RECORDED = 1, /* recorded kb_meta dim wins over probe/default */
+      DB2_DIM_SRC_PROBE = 2,    /* fresh DB: derived from the embedder /health probe */
+      DB2_DIM_SRC_DEFAULT = 3   /* fresh DB, no probe available: configured default */
+   } db2_dim_source_t;
+   db2_dim_source_t db2_dim_source(int pinned, int recorded_present, int probe_available);
+
    /* Model-identity drift guard (unified-llm-container §2). Set from config
     * before db2_init, beside db2_set_embedding_dim, so this layer stays
     * config-free. ALL default empty -> the guard is a no-op (a deployment whose

--- a/src/headers/embedder_probe.h
+++ b/src/headers/embedder_probe.h
@@ -1,0 +1,18 @@
+/* embedder_probe.h -- embedder-runtime-fetch-autodim §2b: register the kb-side
+ * embedder /health dim probe with the db2 layer (which stays config-free). The
+ * probe shells `<embed_command> --dim` and polls until the embedder reports a
+ * loaded model with a stable output dim, or the budget expires. */
+#ifndef DEC_EMBEDDER_PROBE_H
+#define DEC_EMBEDDER_PROBE_H 1
+
+/* Capture the configured embed command + read the probe budget from
+ * AIMEE_DIM_PROBE_BUDGET_MS (default 120000) and register the probe seam via
+ * db2_set_embedder_probe + db2_set_dim_probe_budget_ms. Call once at kb startup,
+ * BEFORE db2_init. A NULL/empty embed_command leaves the probe unregistered (the
+ * §2b fresh-DB path then falls back to the default dim, as before). */
+void embedder_probe_register(const char *embed_command);
+
+/* Deregister the probe (call before db2_shutdown). */
+void embedder_probe_unregister(void);
+
+#endif /* DEC_EMBEDDER_PROBE_H */

--- a/src/kb/kb_main.c
+++ b/src/kb/kb_main.c
@@ -12,6 +12,7 @@
 #include "kb_service.h"
 #include "log.h"
 #include "lifecycle.h"
+#include "embedder_probe.h"
 #include "shutdown_forensics.h"
 #include "util.h"
 #include "cJSON.h"
@@ -546,6 +547,15 @@ int main(int argc, char **argv)
    /* unified-llm-container §2: activate the model-identity drift guard (the kb applies
     * the schema, so this is the load-bearing site). Empty embedding_model => no-op. */
    db2_set_embedder_model_id(kb_cfg.embedding_model);
+   /* §2b: on a FRESH DB with no pin, let db2_init derive the dim from the running
+    * embedder's /health instead of the default — but only when a REAL remote embed
+    * command is configured (the lexical "builtin" has no /health and a fixed dim,
+    * so probing it would never succeed and would stall the retry loop). */
+   {
+      const char *embed_cmd = config_embedding_command(&kb_cfg, NULL);
+      if (embed_cmd && strcmp(embed_cmd, "builtin") != 0)
+         embedder_probe_register(embed_cmd);
+   }
    /* Size the DB2 connection pool (leased by worker threads) before db2_init. */
    db2_set_pool_size(aimee_resolve_db2_pool_size(kb_cfg.db2_connection_pool_size));
 
@@ -712,6 +722,7 @@ int main(int argc, char **argv)
    kb_http_stop();
    kb_service_shutdown(&g_ctx);
    (void)shutdown_forensics_mark_stopped("kb", getpid());
+   embedder_probe_unregister(); /* §2b: deregister the probe before db2_shutdown */
    db2_shutdown();
    agent_http_cleanup();
    return rc == 0 ? 0 : 1;

--- a/src/server/embedder_probe.c
+++ b/src/server/embedder_probe.c
@@ -1,0 +1,111 @@
+/* embedder_probe.c -- §2b kb-side embedder /health dim probe. Registered with the
+ * db2 layer so db2_init can derive a fresh DB's embedding dim from the running
+ * embedder without db2 learning the embed transport (db2 stays config-free). */
+#include "embedder_probe.h"
+
+#include "lifecycle.h"
+#include "log.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+
+/* The configured embed command (e.g. "python3 /opt/aimee/scripts/embed-remote.py"),
+ * captured at registration. Operator-trusted config, run via /bin/sh with --dim. */
+static char g_embed_cmd[1024] = "";
+
+static long probe_mono_ms(void)
+{
+   struct timespec ts;
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (long)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* One probe attempt: run `<embed_cmd> --dim`, return the parsed positive dim, or
+ * <=0 if the embedder is not ready / the command failed / output was not a single
+ * positive integer. */
+static int probe_once(void)
+{
+   if (!g_embed_cmd[0])
+      return -1;
+   char cmd[1100];
+   snprintf(cmd, sizeof(cmd), "%s --dim", g_embed_cmd);
+   FILE *p = popen(cmd, "r");
+   if (!p)
+      return -1;
+   char buf[64] = "";
+   size_t n = fread(buf, 1, sizeof(buf) - 1, p);
+   buf[n] = '\0';
+   int status = pclose(p);
+   if (status != 0)
+      return -1; /* command signalled "not ready" / error */
+   char *endp = NULL;
+   long v = strtol(buf, &endp, 10);
+   /* accept only a clean positive integer (trailing whitespace/newline ok) */
+   while (endp && (*endp == '\n' || *endp == '\r' || *endp == ' ' || *endp == '\t'))
+      endp++;
+   if (!endp || *endp != '\0' || v <= 0)
+      return -1;
+   return (int)v;
+}
+
+/* db2_embedder_probe_fn: poll the embedder until two CONSECUTIVE reads agree on a
+ * positive dim (guards a flapping load), or budget_ms elapses. ~2s between reads;
+ * a mismatch or not-ready resets the streak and keeps polling within budget. */
+static int embedder_probe_run(int *out_dim, int budget_ms, char *err, size_t errlen)
+{
+   long start = probe_mono_ms();
+   int last = 0; /* last positive read; 0 = none yet */
+   for (;;)
+   {
+      int d = probe_once();
+      if (d > 0)
+      {
+         if (d == last)
+         {
+            if (out_dim)
+               *out_dim = d;
+            return 0; /* two consecutive equal positive reads -> stable */
+         }
+         last = d; /* first sighting (or changed) -> require one more match */
+      }
+      else
+      {
+         last = 0; /* not ready / error -> reset the streak */
+      }
+      if ((int)(probe_mono_ms() - start) >= budget_ms)
+      {
+         if (err && errlen)
+            snprintf(err, errlen, "embedder not ready within %dms (cmd=%s)", budget_ms,
+                     g_embed_cmd[0] ? g_embed_cmd : "(unset)");
+         return -1;
+      }
+      struct timespec ts = {2, 0}; /* 2s between reads */
+      nanosleep(&ts, NULL);
+   }
+}
+
+void embedder_probe_register(const char *embed_command)
+{
+   if (!embed_command || !embed_command[0])
+   {
+      LOG_WARN("db2", "embedder dim probe: no embed command configured; §2b probe disabled");
+      return;
+   }
+   snprintf(g_embed_cmd, sizeof(g_embed_cmd), "%s", embed_command);
+   const char *env = getenv("AIMEE_DIM_PROBE_BUDGET_MS");
+   if (env && env[0])
+   {
+      int ms = (int)strtol(env, NULL, 10);
+      if (ms > 0)
+         db2_set_dim_probe_budget_ms(ms);
+   }
+   db2_set_embedder_probe(embedder_probe_run);
+}
+
+void embedder_probe_unregister(void)
+{
+   db2_set_embedder_probe(NULL);
+   g_embed_cmd[0] = '\0';
+}

--- a/src/tests/test_db2.c
+++ b/src/tests/test_db2.c
@@ -5,6 +5,7 @@
 #include "db_postgres.h"
 #include "db2.h"
 #include "db2_internal.h"
+#include "db2/db_schema.h"  /* §2b: db2_dim_read_t / DB2_DIM_* for the dim-read stub */
 #include "../headers/log.h" /* log_level_t for the aimee_log stub below */
 #include <stdarg.h>
 
@@ -81,6 +82,22 @@ int db2_embedding_dim_get(void *pg_conn)
 {
    assert(pg_conn == &g_fake_conn);
    return g_recorded_dim;
+}
+
+/* §2b: db2_init now reads the recorded dim via the tri-state reader. Mirror the
+ * get stub off the same g_recorded_dim knob: >0 → FOUND (recorded wins), else
+ * ABSENT (fresh DB). With no probe registered (the default here) db2_init's §2b
+ * block is skipped, so these tests stay on the §2a path — unchanged. */
+db2_dim_read_t db2_embedding_dim_read(void *pg_conn, int *out)
+{
+   assert(pg_conn == &g_fake_conn);
+   if (g_recorded_dim > 0)
+   {
+      if (out)
+         *out = g_recorded_dim;
+      return DB2_DIM_FOUND;
+   }
+   return DB2_DIM_ABSENT;
 }
 
 /* unified-llm-container §2: db2_init now also calls the model-identity guards
@@ -205,6 +222,42 @@ int aimee_pg_bind_text(aimee_pg_stmt_t *stmt, const char *name, const char *valu
    assert(strcmp(name, "t") == 0);
    assert(strcmp(value, "memories") == 0);
    return 0;
+}
+
+/* §2b: db2_init's advisory-lock + probe path pulls these aimee_pg accessors into
+ * db2_init.o's kept symbol set. They are NEVER called on this test's path (no
+ * embedder probe is registered, so the §2b block is skipped), so trivial stubs
+ * suffice for linking. */
+int aimee_pg_bind_int64(aimee_pg_stmt_t *stmt, const char *name, int64_t value)
+{
+   (void)stmt;
+   (void)name;
+   (void)value;
+   return 0;
+}
+int aimee_pg_column_int(aimee_pg_stmt_t *stmt, int col)
+{
+   (void)stmt;
+   (void)col;
+   return 0;
+}
+int64_t aimee_pg_column_int64(aimee_pg_stmt_t *stmt, int col)
+{
+   (void)stmt;
+   (void)col;
+   return 0;
+}
+double aimee_pg_column_double(aimee_pg_stmt_t *stmt, int col)
+{
+   (void)stmt;
+   (void)col;
+   return 0.0;
+}
+const char *aimee_pg_column_text(aimee_pg_stmt_t *stmt, int col)
+{
+   (void)stmt;
+   (void)col;
+   return "";
 }
 
 static void reset_mocks(void)

--- a/src/tests/test_embedding_dim.c
+++ b/src/tests/test_embedding_dim.c
@@ -104,6 +104,35 @@ int main(void)
    /* NULL conn -> 0. */
    assert(db2_embedding_dim_get(NULL) == 0);
 
+   /* ---- §2b: db2_dim_source precedence (pure: pin > recorded > probe > default) ---- */
+   assert(db2_dim_source(1, 1, 1) == DB2_DIM_SRC_PIN);      /* pin wins over all */
+   assert(db2_dim_source(1, 0, 0) == DB2_DIM_SRC_PIN);      /* pin even with nothing else */
+   assert(db2_dim_source(0, 1, 1) == DB2_DIM_SRC_RECORDED); /* recorded beats probe */
+   assert(db2_dim_source(0, 0, 1) == DB2_DIM_SRC_PROBE);    /* fresh DB + probe -> probe */
+   assert(db2_dim_source(0, 0, 0) == DB2_DIM_SRC_DEFAULT);  /* fresh DB, no probe -> default */
+
+   /* ---- §2b: db2_embedding_dim_read tri-state (FOUND / ABSENT / ERROR) ---- */
+   assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedding_dim'", err,
+                        sizeof err) == 0);
+   int rdim = -1;
+   assert(db2_embedding_dim_read(conn, &rdim) == DB2_DIM_ABSENT); /* no row -> ABSENT */
+   assert(rdim == 0);                                             /* out untouched on non-FOUND */
+   assert(aimee_pg_exec(conn,
+                        "INSERT INTO kb_meta (key, value) VALUES ('schema_embedding_dim', '768')",
+                        err, sizeof err) == 0);
+   rdim = 0;
+   assert(db2_embedding_dim_read(conn, &rdim) == DB2_DIM_FOUND); /* in-range -> FOUND */
+   assert(rdim == 768);
+   assert(aimee_pg_exec(conn,
+                        "UPDATE kb_meta SET value = 'garbage' WHERE key = 'schema_embedding_dim'",
+                        err, sizeof err) == 0);
+   rdim = 7;
+   assert(db2_embedding_dim_read(conn, &rdim) == DB2_DIM_ABSENT); /* garbage -> ABSENT (quiet) */
+   assert(rdim == 0);
+   assert(db2_embedding_dim_read(NULL, &rdim) == DB2_DIM_ERROR); /* NULL conn -> ERROR */
+   assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedding_dim'", err,
+                        sizeof err) == 0);
+
    /* ---- EMBED_MAX_DIM bumped to 4000 (unified-llm-container §"8B truncation"):
     * a 4000-d dim now records cleanly (was rejected when the cap was 2560). ---- */
    assert(aimee_pg_exec(conn, "DELETE FROM kb_meta WHERE key = 'schema_embedding_dim'", err,


### PR DESCRIPTION
Completes embedder-runtime-fetch-autodim **§2b**: the precedence `pin > recorded >
probe > default`. On a fresh DB2 (no operator pin, no recorded `schema_embedding_dim`)
`db2_init` now derives the embedding dim from the running embedder's `/health` under
a Postgres advisory lock — instead of sizing the `halfvec` columns to the 1024 default
and silently mismatching the corpus (the `.254`-class outage).

## What
- **Registered probe seam** (db2 stays config-free): `db2_set_embedder_probe` +
  `db2_set_dim_probe_budget_ms`; the kb registers a poller
  (`src/server/embedder_probe.c`) that shells the configured embed command `--dim`
  (`embed-remote.py --dim` → `GET /health`), requiring two consecutive stable reads.
- **Fresh-DB block in `db2_init`**: advisory lock serialises racing kb starts;
  **fail-fast on any probe/lock/read failure and record NOTHING** (kb_main's retry
  loop + compose `depends_on` recover — never poison the recorded dim). Probed dim
  bounded to `1..EMBED_MAX_DIM`. Dim recorded **last** (record-after-DDL), so a crash
  never leaves a recorded dim without matching columns. Double-check-under-lock +
  the `ON CONFLICT DO UPDATE SET value=kb_meta.value` upsert prevent concurrent clobber.
- **Tri-state `db2_embedding_dim_read`** distinguishes a fresh DB's missing `kb_meta`
  (ABSENT, via `to_regclass`) from a genuine query error.

## Three defects found by live validation (a real postgres+embedder+kb stack)
- config default `embedding_dim=1024` made `config_embedding_dim_is_pinned` report
  "pinned" in **every** deployment, silently disabling both §2a's recorded-preference
  and §2b's probe → defaulted to **0** (unset; readers fall back to 1024 via
  `db2_embedding_dim()`). "Pinned" now means the operator explicitly set it.
- a missing `kb_meta` on a fresh DB surfaces at *step*, not prepare → `to_regclass` guard.
- `pg_try_advisory_lock` returns BOOLEAN; `aimee_pg_column_int` does `atoi("t")==0` →
  cast `::int` (mining.c has the same latent bug).

## Validation
**Live (pve docker, stub embedder):** fresh DB + embedder dim=768 → records 768 /
`halfvec(768)` (vs 1024 baseline); operator pin=1024 → 1024; embedder dim=0 → probe
fails, nothing recorded, kb retries. **Unit:** `db2_dim_source` truth table,
`db2_embedding_dim_read` tri-state, + existing §2a guards. `make unit-tests` +
`make lint` green; clang-format clean.

Plan + implementation both roundtable-reviewed to APPROVE. §2c (double-gated
auto-reembed) is the next PR; the proposal moves to `done/` after §2c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)