### PR TITLE
feat(gateway): tool-policing — prevent subagents (P2a)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (107)
+## CLI-settable keys (108)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -54,6 +54,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `embedding_endpoint` | string | Embeddings provider endpoint URL. |
 | `embedding_model` | string | Embeddings model name. |
 | `fidelity_check_enabled` | bool | Run the answer-fidelity judge on terminal-text turns (default off; requires kb_evidence_emit_enabled + ingress_preinject_enabled). |
+| `gateway_prevent_subagents` | bool | Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off. |
 | `guardrail_mode` | string | Guardrail enforcement mode (off / warn / block). |
 | `guardrails_semantic_allow_ml_only_block` | bool | Allow blocking on the ML classifier alone. |
 | `guardrails_semantic_block_threshold` | float | Semantic score threshold to block. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -106,6 +106,7 @@ CFG_KEY_DESC = {
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
     "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
     "claude_model": "Default Claude model (empty = CLI default).",
+    "gateway_prevent_subagents": "Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off.",
     "cost_reward_enabled": "Factor token cost into the reward signal.",
     "cost_reward_lambda_pct": "Cost-penalty weight (percent) in the reward.",
     "cost_reward_ref_usd_milli": "Reference cost (USD-milli) normalizing the cost reward.",

--- a/src/Makefile
+++ b/src/Makefile
@@ -317,7 +317,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
-            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c \
+            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c gateway_policy.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
             trajectory_export.c trajectory_batch.c \

--- a/src/config.c
+++ b/src/config.c
@@ -833,6 +833,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "gateway_prevent_subagents");
+   if (cJSON_IsBool(item))
+      cfg->gateway_prevent_subagents = cJSON_IsTrue(item);
+
    /* CSS migration assistant style-graph write path (WP-C). The field +
     * descriptor + save existed, but the YAML load parse was missing, so the
     * flag never took effect during indexing. */

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -41,6 +41,8 @@ const config_field_t config_fields[] = {
     {"memory_rerank_enabled", offsetof(config_t, memory_rerank_enabled), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_enabled", offsetof(config_t, ingress_preinject_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"gateway_prevent_subagents", offsetof(config_t, gateway_prevent_subagents), sizeof(int), 0,
+     CFG_BOOL},
     {"ingress_preinject_assembly_budget", offsetof(config_t, ingress_preinject_assembly_budget),
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -773,6 +773,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
+   if (cfg->gateway_prevent_subagents)
+      cJSON_AddBoolToObject(root, "gateway_prevent_subagents", 1);
    if (cfg->ingress_preinject_assembly_budget != 6144)
       cJSON_AddNumberToObject(root, "ingress_preinject_assembly_budget",
                               cfg->ingress_preinject_assembly_budget);

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -8,6 +8,7 @@
 {"kb_client_bearer_token", SCHEMA_STRING, 0},
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
+{"gateway_prevent_subagents", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},
 {"css_render_command", SCHEMA_STRING, 0},
 {"typed_facts_enabled", SCHEMA_BOOL, 0},

--- a/src/gateway_policy.c
+++ b/src/gateway_policy.c
@@ -1,0 +1,95 @@
+/* gateway_policy.c: per-call gateway request/response policy. See gateway_policy.h.
+ * CORE layer: cJSON + config + guardrails only; no DB, network, or agent state. */
+#include "gateway_policy.h"
+#include "cJSON.h"
+#include "config.h"
+#include "json_fluent.h" /* jo_cstr */
+#include <string.h>
+
+/* From guardrails (guardrails_orchestrator.c). Forward-declared rather than
+ * #include "guardrails.h": that header needs stdint/severity types pre-included,
+ * and this module only needs the canonical-tool-name mapping. */
+const char *guardrails_canonical_tool_name(const char *tool_name);
+
+/* A subagent-spawning tool, via the shared guardrails canonicalization (which maps
+ * Task/Agent/spawn_agent/RemoteTrigger -> "Subagent"). No duplicate name list. */
+static int is_subagent_tool_name(const char *name)
+{
+   return name && name[0] && strcmp(guardrails_canonical_tool_name(name), "Subagent") == 0;
+}
+
+static int prevent_subagents_enabled(void)
+{
+   config_t cfg;
+   config_load(&cfg);
+   return cfg.gateway_prevent_subagents ? 1 : 0;
+}
+
+/* A tool entry's name, regardless of API shape. */
+static const char *tool_entry_name(const cJSON *tool, int openai_shape)
+{
+   if (openai_shape)
+      return jo_cstr(cJSON_GetObjectItemCaseSensitive((cJSON *)tool, "function"), "name");
+   return jo_cstr(tool, "name");
+}
+
+/* The name a tool_choice object forces, or "" if it does not force a named tool. */
+static const char *tool_choice_name(const cJSON *tc, int openai_shape)
+{
+   if (!cJSON_IsObject(tc))
+      return "";
+   if (openai_shape)
+      return jo_cstr(cJSON_GetObjectItemCaseSensitive((cJSON *)tc, "function"), "name");
+   return jo_cstr(tc, "name");
+}
+
+int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
+{
+   cJSON *tools;
+   cJSON *t;
+   int stripped = 0;
+
+   if (!req || !prevent_subagents_enabled())
+      return 0;
+
+   tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+   if (!cJSON_IsArray(tools))
+      return 0;
+
+   for (t = tools->child; t;)
+   {
+      cJSON *next = t->next;
+      const char *name = tool_entry_name(t, tools_openai_shape);
+      if (name && name[0] && is_subagent_tool_name(name))
+      {
+         cJSON_DetachItemViaPointer(tools, t);
+         cJSON_Delete(t);
+         stripped++;
+      }
+      t = next;
+   }
+
+   if (!stripped)
+      return 0;
+
+   if (cJSON_GetArraySize(tools) == 0)
+   {
+      /* No tools left: drop the empty array (providers reject `tools: []`) AND any
+       * tool_choice — a forced/`any`/`required` choice with no tools is a 400
+       * upstream, so leaving it would break the request. */
+      cJSON_DeleteItemFromObjectCaseSensitive(req, "tools");
+      cJSON_DeleteItemFromObjectCaseSensitive(req, "tool_choice");
+   }
+   else
+   {
+      /* Tools remain: relax tool_choice only if it forced a removed tool (absent
+       * = auto). `auto`/`any`/`required` and choices naming a surviving tool are
+       * left untouched. */
+      cJSON *tc = cJSON_GetObjectItemCaseSensitive(req, "tool_choice");
+      const char *forced = tool_choice_name(tc, tools_openai_shape);
+      if (forced && forced[0] && is_subagent_tool_name(forced))
+         cJSON_DeleteItemFromObjectCaseSensitive(req, "tool_choice");
+   }
+
+   return stripped;
+}

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -337,6 +337,12 @@ typedef struct config
    int ingress_preinject_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
+
+   /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
+    * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a
+    * proxied /v1/messages or /v1/chat/completions request, so the served model is
+    * never offered a way to spawn subagents. Default off. */
+   int gateway_prevent_subagents;
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */

--- a/src/headers/gateway_policy.h
+++ b/src/headers/gateway_policy.h
@@ -1,0 +1,21 @@
+/* gateway_policy.h: per-call gateway request/response policy (P2 of the universal
+ * gateway). The proxy ingresses (/v1/messages, /v1/chat/completions) run every
+ * proxied call through these bounded transforms so aimee can inspect and alter
+ * what it forwards — without running the full agent loop. First policy:
+ * tool-policing (strip subagent-spawning tools). Reuses guardrails primitives;
+ * does not duplicate the agent-loop guardrails. */
+#ifndef DEC_GATEWAY_POLICY_H
+#define DEC_GATEWAY_POLICY_H 1
+
+struct cJSON;
+
+/* Apply request-side tool policing to a proxied request, in place. `tools` is read
+ * from `req`; entries are matched by tool name regardless of API shape
+ * (`tools_openai_shape`: 1 = OpenAI [{type:function,function:{name}}], 0 = Anthropic
+ * [{name}]). When config `gateway_prevent_subagents` is on, subagent-spawning tools
+ * (via guardrails_is_subagent_tool) are removed, an empty `tools` array is dropped,
+ * and a `tool_choice` that names a removed tool is relaxed to auto. Returns the
+ * number of tools stripped (0 = no-op / policy off), for the caller's audit row. */
+int gateway_policy_apply_request(struct cJSON *req, int tools_openai_shape);
+
+#endif /* DEC_GATEWAY_POLICY_H */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -21,6 +21,7 @@
 #include "anthropic_ingress.h"
 #include "cJSON.h"
 #include "delegate_driver.h"
+#include "gateway_policy.h"
 #include "ingress_preinject.h"
 #include "json_fluent.h"
 #include "server_http.h"
@@ -340,6 +341,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
    int parity = driver_is_anthropic(driver);
    if (!parity)
       messages_apply_preinject(req);
+   /* Gateway tool policing (e.g. strip subagent tools) on the inbound Anthropic
+    * request, before translate/build. No-op unless a policy is configured. */
+   gateway_policy_apply_request(req, 0);
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -633,6 +637,9 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    int parity = driver_is_anthropic(driver);
    if (!parity)
       messages_apply_preinject(req);
+   /* Gateway tool policing (e.g. strip subagent tools) on the inbound Anthropic
+    * request, before translate/build. No-op unless a policy is configured. */
+   gateway_policy_apply_request(req, 0);
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -177,6 +177,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-sse-parser \
                $(TESTPREFIX)/unit-test-anthropic-ingress \
                $(TESTPREFIX)/unit-test-anthropic-http \
+               $(TESTPREFIX)/unit-test-gateway-policy \
                $(TESTPREFIX)/unit-test-hud \
                $(TESTPREFIX)/unit-test-coord-jobs \
                $(TESTPREFIX)/unit-test-plan-waves \
@@ -1634,6 +1635,9 @@ $(TESTPREFIX)/unit-test-anthropic-ingress: $(OBJDIR)/tests/test_anthropic_ingres
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-gateway-policy: $(OBJDIR)/tests/test_gateway_policy.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(OBJDIR)/tests/%.o: tests/%.c

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -225,6 +225,14 @@ int agent_http_last_retry_after(void)
 {
    return 0;
 }
+/* Gateway policy is no-op in these whitebox shape tests (its own behavior is
+ * covered by test_gateway_policy); keeps the request shape unaltered. */
+int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
+{
+   (void)req;
+   (void)tools_openai_shape;
+   return 0;
+}
 
 #include "../server/anthropic_http.c"
 

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,8 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\ncss_style_graph_enabled: "
+    "true\ningress_preinject_enabled: true\ngateway_prevent_subagents: "
+    "true\ncss_style_graph_enabled: "
     "true\n"
     "ingress_preinject_assembly_budget: 1\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
@@ -82,7 +83,8 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\ncss_style_graph_enabled: "
+    "false\ningress_preinject_enabled: false\ngateway_prevent_subagents: "
+    "false\ncss_style_graph_enabled: "
     "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
@@ -162,6 +164,7 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
+   assert(cfgA.gateway_prevent_subagents == 1 && cfgB.gateway_prevent_subagents == 0);
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);

--- a/src/tests/test_gateway_policy.c
+++ b/src/tests/test_gateway_policy.c
@@ -1,0 +1,114 @@
+/* test_gateway_policy.c: pure tests for gateway request-side tool policing.
+ * config_load and guardrails_is_subagent_tool are stubbed so the link is minimal
+ * (the real ones are covered by their own modules' tests). */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../headers/config.h"
+#include "../headers/gateway_policy.h"
+#include "../vendor/headers/cJSON.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+static int g_prevent = 0;
+int config_load(config_t *cfg)
+{
+   if (cfg)
+   {
+      memset(cfg, 0, sizeof(*cfg));
+      cfg->gateway_prevent_subagents = g_prevent;
+   }
+   return 0;
+}
+const char *guardrails_canonical_tool_name(const char *n)
+{
+   if (n && (strcmp(n, "Task") == 0 || strcmp(n, "Agent") == 0))
+      return "Subagent";
+   return n ? n : "";
+}
+
+static int has_tool(cJSON *req, const char *name, int openai)
+{
+   cJSON *tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+   cJSON *t;
+   if (!cJSON_IsArray(tools))
+      return 0;
+   cJSON_ArrayForEach(t, tools)
+   {
+      const char *n =
+          openai ? cJSON_GetObjectItem(cJSON_GetObjectItem(t, "function"), "name")->valuestring
+                 : cJSON_GetObjectItem(t, "name")->valuestring;
+      if (n && strcmp(n, name) == 0)
+         return 1;
+   }
+   return 0;
+}
+
+/* Anthropic shape: subagent tool stripped, other tools kept, forced tool_choice relaxed. */
+static void test_anthropic_strip(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"name\":\"Read\",\"input_schema\":{}},"
+                            "{\"name\":\"Task\",\"input_schema\":{}}],"
+                            "\"tool_choice\":{\"type\":\"tool\",\"name\":\"Task\"}}");
+   int n = gateway_policy_apply_request(req, 0);
+   assert(n == 1);
+   assert(has_tool(req, "Read", 0));
+   assert(!has_tool(req, "Task", 0));
+   assert(cJSON_GetObjectItemCaseSensitive(req, "tool_choice") == NULL); /* relaxed to auto */
+   cJSON_Delete(req);
+   PASS("anthropic_strip");
+}
+
+/* Empty-after-strip: tools array AND a now-meaningless tool_choice are dropped
+ * (a `required`/`any` choice with no tools would 400 upstream). */
+static void test_empty_tools_dropped(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse(
+       "{\"tools\":[{\"name\":\"Agent\",\"input_schema\":{}}],\"tool_choice\":{\"type\":\"any\"}}");
+   int n = gateway_policy_apply_request(req, 0);
+   assert(n == 1);
+   assert(cJSON_GetObjectItemCaseSensitive(req, "tools") == NULL);
+   assert(cJSON_GetObjectItemCaseSensitive(req, "tool_choice") == NULL);
+   cJSON_Delete(req);
+   PASS("empty_tools_dropped");
+}
+
+/* OpenAI shape: function-name match. */
+static void test_openai_strip(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"Read\"}},"
+                            "{\"type\":\"function\",\"function\":{\"name\":\"Task\"}}]}");
+   int n = gateway_policy_apply_request(req, 1);
+   assert(n == 1);
+   assert(has_tool(req, "Read", 1));
+   assert(!has_tool(req, "Task", 1));
+   cJSON_Delete(req);
+   PASS("openai_strip");
+}
+
+/* Policy off: no-op, request untouched. */
+static void test_policy_off_noop(void)
+{
+   g_prevent = 0;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"name\":\"Task\",\"input_schema\":{}}]}");
+   int n = gateway_policy_apply_request(req, 0);
+   assert(n == 0);
+   assert(has_tool(req, "Task", 0));
+   cJSON_Delete(req);
+   PASS("policy_off_noop");
+}
+
+int main(void)
+{
+   printf("test_gateway_policy:\n");
+   test_anthropic_strip();
+   test_empty_tools_dropped();
+   test_openai_strip();
+   test_policy_off_noop();
+   printf("all gateway_policy tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
P2a of the universal gateway. New CORE `gateway_policy.{c,h}` + `gateway_prevent_subagents` config: strips subagent/Task tools from proxied requests (reusing the guardrails canonicalization), dropping empty tools + meaningless tool_choice. Wired into the Anthropic ingress; both tool shapes. Unit-tested (4 cases) + live-validated (upstream received tools without Task). lint green; roundtable qa APPROVE, security tool_choice edge addressed.