### PR TITLE
feat(gateway): tool-policing on the OpenAI ingress (P2b)

### DIFF
--- a/src/gateway_policy.c
+++ b/src/gateway_policy.c
@@ -43,17 +43,12 @@ static const char *tool_choice_name(const cJSON *tc, int openai_shape)
    return jo_cstr(tc, "name");
 }
 
-int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
+int gateway_policy_strip_tools(cJSON *tools, int tools_openai_shape)
 {
-   cJSON *tools;
    cJSON *t;
    int stripped = 0;
 
-   if (!req || !prevent_subagents_enabled())
-      return 0;
-
-   tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
-   if (!cJSON_IsArray(tools))
+   if (!cJSON_IsArray(tools) || !prevent_subagents_enabled())
       return 0;
 
    for (t = tools->child; t;)
@@ -68,7 +63,19 @@ int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
       }
       t = next;
    }
+   return stripped;
+}
 
+int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
+{
+   cJSON *tools;
+   int stripped;
+
+   if (!req)
+      return 0;
+
+   tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+   stripped = gateway_policy_strip_tools(tools, tools_openai_shape);
    if (!stripped)
       return 0;
 

--- a/src/headers/gateway_policy.h
+++ b/src/headers/gateway_policy.h
@@ -18,4 +18,13 @@ struct cJSON;
  * number of tools stripped (0 = no-op / policy off), for the caller's audit row. */
 int gateway_policy_apply_request(struct cJSON *req, int tools_openai_shape);
 
+/* Strip subagent-spawning tool entries from a bare `tools` array, in place — the
+ * array core of gateway_policy_apply_request, for ingresses that carry `tools` as a
+ * standalone array rather than inside a request object (e.g. the OpenAI /v1/responses
+ * path). Config-gated identically (no-op unless `gateway_prevent_subagents`). Does
+ * NOT touch any enclosing tool_choice or drop the array when emptied — the caller
+ * owns those (a fully-stripped array should be omitted from the provider request).
+ * Returns the number of entries removed (0 = no-op / policy off / not an array). */
+int gateway_policy_strip_tools(struct cJSON *tools, int tools_openai_shape);
+
 #endif /* DEC_GATEWAY_POLICY_H */

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -32,7 +32,8 @@
 #include "cJSON.h"
 #include "agent_tools.h" /* agent_tools_set_tool_event_cb — /v1/runs tool events */
 #include "agent_types.h"
-#include "memory.h" /* memory_embed_text */
+#include "gateway_policy.h" /* gateway_policy_strip_tools — OpenAI-ingress tool policing */
+#include "memory.h"         /* memory_embed_text */
 #include "request_context.h"
 #include "response_dedup.h"
 #include "token_tracker.h"
@@ -873,8 +874,19 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    char extra_headers[512];
    agent_build_extra_headers(agent, extra_headers, sizeof(extra_headers));
 
+   /* Gateway tool policing on the inbound OpenAI-ingress (/v1/responses) tools,
+    * before the provider request is built — the OpenAI-side counterpart to the
+    * /v1/messages policing in anthropic_http.c. `tools` is a bare OpenAI-shape
+    * function array. No-op unless a policy is configured. If every tool is
+    * stripped, omit the array entirely (don't forward `tools: []`). The stripped
+    * array stays owned/freed by the caller. */
+   cJSON *eff_tools = tools;
+   gateway_policy_strip_tools(eff_tools, 1);
+   if (eff_tools && cJSON_GetArraySize(eff_tools) == 0)
+      eff_tools = NULL;
+
    int tok = agent_request_max_tokens(agent, max_tokens);
-   cJSON *req = driver->build_request(agent, messages, tools, system_prompt, tok, temperature);
+   cJSON *req = driver->build_request(agent, messages, eff_tools, system_prompt, tok, temperature);
    if (!req)
       return -1;
    char *body = cJSON_PrintUnformatted(req);

--- a/src/tests/test_gateway_policy.c
+++ b/src/tests/test_gateway_policy.c
@@ -102,6 +102,48 @@ static void test_policy_off_noop(void)
    PASS("policy_off_noop");
 }
 
+/* Bare-array strip (OpenAI /v1/responses seam): subagent removed in place, count
+ * returned, surviving tools kept, no enclosing req/tool_choice touched. */
+static void test_strip_tools_bare_array(void)
+{
+   g_prevent = 1;
+   cJSON *tools = cJSON_Parse("[{\"type\":\"function\",\"function\":{\"name\":\"Read\"}},"
+                              "{\"type\":\"function\",\"function\":{\"name\":\"Task\"}}]");
+   int n = gateway_policy_strip_tools(tools, 1);
+   assert(n == 1);
+   assert(cJSON_GetArraySize(tools) == 1);
+   assert(strcmp(cJSON_GetObjectItem(cJSON_GetArrayItem(tools, 0), "function")->child->valuestring,
+                 "Read") == 0);
+   cJSON_Delete(tools);
+   PASS("strip_tools_bare_array");
+}
+
+/* Bare-array strip, all removed: returns count, leaves an empty array (the caller
+ * is responsible for omitting it from the provider request). */
+static void test_strip_tools_emptied(void)
+{
+   g_prevent = 1;
+   cJSON *tools = cJSON_Parse("[{\"type\":\"function\",\"function\":{\"name\":\"Agent\"}}]");
+   int n = gateway_policy_strip_tools(tools, 1);
+   assert(n == 1);
+   assert(cJSON_GetArraySize(tools) == 0);
+   cJSON_Delete(tools);
+   PASS("strip_tools_emptied");
+}
+
+/* Bare-array strip, policy off / NULL: no-op. */
+static void test_strip_tools_off_and_null(void)
+{
+   g_prevent = 0;
+   cJSON *tools = cJSON_Parse("[{\"type\":\"function\",\"function\":{\"name\":\"Task\"}}]");
+   assert(gateway_policy_strip_tools(tools, 1) == 0);
+   assert(cJSON_GetArraySize(tools) == 1);
+   cJSON_Delete(tools);
+   g_prevent = 1;
+   assert(gateway_policy_strip_tools(NULL, 1) == 0);
+   PASS("strip_tools_off_and_null");
+}
+
 int main(void)
 {
    printf("test_gateway_policy:\n");
@@ -109,6 +151,9 @@ int main(void)
    test_empty_tools_dropped();
    test_openai_strip();
    test_policy_off_noop();
+   test_strip_tools_bare_array();
+   test_strip_tools_emptied();
+   test_strip_tools_off_and_null();
    printf("all gateway_policy tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Extends `gateway_prevent_subagents` (P2a) to aimee's **OpenAI** ingress, so the subagent guardrail covers both APIs aimee presents.

## What
- `/v1/responses` → `agent_execute_messages` is the **only** OpenAI-ingress path that forwards client tools to the model (`/v1/chat/completions` flattens to a prompt, no tools). That is the single seam.
- `gateway_policy.c`: extract a bare-array `gateway_policy_strip_tools(tools, openai_shape)` core (config-gated). `gateway_policy_apply_request` delegates to it (DRY) and keeps the request-level concerns it alone owns (drop emptied `tools`, relax `tool_choice`).
- `openai_chat.c`: call `gateway_policy_strip_tools(tools, 1)` before `build_request`; omit a fully-stripped array (pass `NULL`) rather than forward `tools: []`. Caller still owns/frees the original array.

## Layering
Applied at the **ingress/proxy** step only (`agent_execute_messages` does not execute tools). aimee's own agent loop and delegates legitimately spawn subagents and are untouched.

## Tests
3 new unit tests for the bare-array path (strip-one, strip-all-emptied, off/NULL). Full `make unit-tests` + `make lint` green.

Roundtable: security / qa / architect all APPROVE.