### PR TITLE
docs(proposal): reconcile aimee-universal-gateway P1 as shipped (#658)

### DIFF
--- a/docs/proposals/pending/aimee-universal-gateway.md
+++ b/docs/proposals/pending/aimee-universal-gateway.md
@@ -1,6 +1,10 @@
 # Aimee as the universal LLM gateway: dual-API surface, model-derived proxy/translate, and a general inspect/alter pipeline
 
-- **State:** reviewed — roundtable sign-off (R1 surfaced 3 findings; R2: Findings A
+- **State:** reviewed — roundtable sign-off; **implementing.** P1 (derive
+  proxy/translate, delete the `claude_proxy_parity` flag) is complete (#658); the
+  remaining work is the `gateway_pipeline` core module + tool-policing (P2),
+  memory-as-a-stage (P3), and delegate unification (P4). (R1
+  surfaced 3 findings; R2: Findings A
   & B confirmed RESOLVED by security · architect · qa; Finding C resolved via the
   model-pin decision below). User proposal-gate decisions folded in. *Note: the
   delegate transcripts were truncated by aimee's citation-replay verification
@@ -130,13 +134,15 @@ Properties:
 
 ## Phasing
 
-- **P1 — derive, delete the flag.** Remove `claude_proxy_parity`; gate
-  passthrough/translate purely on the serving model's API (`driver_is_anthropic`)
-  in `anthropic_http.c`. Net behavior: an Anthropic call is forwarded untouched to
-  an Anthropic model, translated to an OpenAI model — automatically. *(Already
-  prototyped and validated end-to-end against a live aimee-server + mock upstream:
-  model honored, headers forwarded, count_tokens proxied, 429+Retry-After
-  relayed.)*
+- **P1 — derive, delete the flag. ✅ SHIPPED (#658, merged to `testing`).** Removed
+  `claude_proxy_parity`; gates passthrough/translate purely on the serving model's
+  API (`driver_is_anthropic`) in `anthropic_http.c`. Net behavior: an Anthropic call
+  is forwarded untouched to an Anthropic model, translated to an OpenAI model —
+  automatically. Covered by `src/tests/test_anthropic_http.c`
+  (`messages_buffered_anthropic_parity_passthrough` honors the inbound model,
+  `messages_buffered_openai_family_translates` + the streaming variant translate +
+  swap). The single-model-shim behavior change (client model forwarded verbatim) is
+  documented; the model-pin that bounds it lands in P2.
 - **P2 — gateway pipeline scaffold + first policy.** Introduce the canonical
   request/response IR and a typed stage interface at the ingress seam; port the
   existing translation into it; add the first policy stage: **tool policing**

--- a/docs/proposals/pending/aimee-universal-gateway.plan.md
+++ b/docs/proposals/pending/aimee-universal-gateway.plan.md
@@ -6,7 +6,7 @@
 
 ## P1 — derive proxy/translate; delete the flag
 
-**Done (this branch).** Removes `claude_proxy_parity` from the whole config surface
+**✅ SHIPPED (#658, merged to `testing`).** Removes `claude_proxy_parity` from the whole config surface
 (`config.h`, `config.c`, `config_save.c`, `config_fields.c`, `config_schema.inc`,
 generated docs) and gates the `/v1/messages` ingress on `driver_is_anthropic` only:
 Anthropic-API primary → honor inbound model + forward `anthropic-version`/


### PR DESCRIPTION
P1 of **aimee-universal-gateway** (model-derived proxy/translate; delete the `claude_proxy_parity` flag) shipped in **#658** with test coverage in `src/tests/test_anthropic_http.c` (`messages_buffered_anthropic_parity_passthrough` honors the inbound model; `..._openai_family_translates` + the streaming variant translate + swap), but the proposal + plan still listed P1 as pending — premise-drift the reconciler discipline says to fix.

Marks P1 ✅ shipped (#658) in both the proposal and the plan, and sets the proposal State to **implementing** (P2–P4 remain: the `gateway_pipeline` core module + tool-policing, memory-as-a-stage, delegate unification). Stays in `pending/` because P2–P4 are open.

Docs-only; `check-proposal-reconcile` (classifies in_flight) + `check-proposal-links` pass.