### PR TITLE
feat(gateway): request-pipeline scaffold over a canonical IR (P2a)

### DIFF
--- a/docs/proposals/pending/aimee-universal-gateway.md
+++ b/docs/proposals/pending/aimee-universal-gateway.md
@@ -1,6 +1,10 @@
 # Aimee as the universal LLM gateway: dual-API surface, model-derived proxy/translate, and a general inspect/alter pipeline
 
-- **State:** reviewed — roundtable sign-off (R1 surfaced 3 findings; R2: Findings A
+- **State:** reviewed — roundtable sign-off; **implementing.** P1 (derive
+  proxy/translate, delete the `claude_proxy_parity` flag) is complete (#658); the
+  remaining work is the `gateway_pipeline` core module + tool-policing (P2),
+  memory-as-a-stage (P3), and delegate unification (P4). (R1
+  surfaced 3 findings; R2: Findings A
   & B confirmed RESOLVED by security · architect · qa; Finding C resolved via the
   model-pin decision below). User proposal-gate decisions folded in. *Note: the
   delegate transcripts were truncated by aimee's citation-replay verification
@@ -130,13 +134,15 @@ Properties:
 
 ## Phasing
 
-- **P1 — derive, delete the flag.** Remove `claude_proxy_parity`; gate
-  passthrough/translate purely on the serving model's API (`driver_is_anthropic`)
-  in `anthropic_http.c`. Net behavior: an Anthropic call is forwarded untouched to
-  an Anthropic model, translated to an OpenAI model — automatically. *(Already
-  prototyped and validated end-to-end against a live aimee-server + mock upstream:
-  model honored, headers forwarded, count_tokens proxied, 429+Retry-After
-  relayed.)*
+- **P1 — derive, delete the flag. ✅ SHIPPED (#658, merged to `testing`).** Removed
+  `claude_proxy_parity`; gates passthrough/translate purely on the serving model's
+  API (`driver_is_anthropic`) in `anthropic_http.c`. Net behavior: an Anthropic call
+  is forwarded untouched to an Anthropic model, translated to an OpenAI model —
+  automatically. Covered by `src/tests/test_anthropic_http.c`
+  (`messages_buffered_anthropic_parity_passthrough` honors the inbound model,
+  `messages_buffered_openai_family_translates` + the streaming variant translate +
+  swap). The single-model-shim behavior change (client model forwarded verbatim) is
+  documented; the model-pin that bounds it lands in P2.
 - **P2 — gateway pipeline scaffold + first policy.** Introduce the canonical
   request/response IR and a typed stage interface at the ingress seam; port the
   existing translation into it; add the first policy stage: **tool policing**

--- a/docs/proposals/pending/aimee-universal-gateway.plan.md
+++ b/docs/proposals/pending/aimee-universal-gateway.plan.md
@@ -22,7 +22,36 @@ swap→honor. Live-validated against a mock upstream.
 
 ## P2 — `gateway_pipeline.{c,h}` + tool-policing
 
-New CORE module `src/server/gateway_pipeline.{c,h}`. Canonical request/response IR
+**Split into verifiable slices** (a packet this size is not one safe PR):
+
+- **P2a — request pipeline scaffold (✅ this PR).** New core module
+  `src/gateway_pipeline.{c,h}` (NOT under `src/server/`, alongside the already-core
+  `src/gateway_policy.c`, so the ingresses and `/v1/runs` share one seam). Canonical
+  **request** IR `gw_request_t { cJSON *raw (BORROWED — stages mutate in place, never
+  free); const void *driver, *ag (opaque, so the module never derefs server types —
+  resolves the layering question); gw_api_t serving_api; int parity, stream }`, a
+  typed stage `int(*)(gw_request_t*, void*)` returning an intervention count (≥0) or
+  <0 (short-circuits), and `gw_pipeline_run_request()`. Two phases kept distinct:
+  mutation stages run through the pipeline, then `translate_request` is the **terminal
+  render** (it produces the provider shape rather than mutating `raw`, so stages
+  always see the full untranslated request — lossless for same-API passthrough). The
+  Anthropic ingress's two inline preludes (memory inject + tool policing, both paths)
+  are routed through the pipeline; **zero behavior change** (the existing
+  `test_anthropic_http` passthrough/translate suite still passes). Pure runner tests
+  in `test_gateway_pipeline.c` (order, sum, short-circuit, null-safety). Request-side
+  tool-policing itself (`gateway_policy_apply_request`) was already shipped; P2a only
+  formalizes the seam it plugs into.
+- **P2b — model-pin policy + buffered response policing.** Add the response-side IR
+  + response stages; model-pin policy (pin served model to `ag->model` / allowlist,
+  resolves Finding C); buffered `tool_use` drop/rewrite with an audit row.
+- **P2c — streaming response policing (both SSE shapes).** Anthropic SSE via the
+  block-aware `anthropic_stream_xlate` (buffer a `tool_use` block to
+  `content_block_stop` before emit/drop/rewrite); OpenAI SSE per-`index`
+  `tool_calls` buffering. Per-tool/severity action.
+
+### P2 design reference (carried into P2a/b/c)
+
+New CORE module `src/gateway_pipeline.{c,h}`. Canonical request/response IR
 + a typed stage interface (`apply_request`, `apply_response`, and a streaming
 `on_block` variant). Port the existing translation in behind it; the ingresses call
 the pipeline.

--- a/docs/proposals/pending/aimee-universal-gateway.plan.md
+++ b/docs/proposals/pending/aimee-universal-gateway.plan.md
@@ -6,7 +6,7 @@
 
 ## P1 — derive proxy/translate; delete the flag
 
-**Done (this branch).** Removes `claude_proxy_parity` from the whole config surface
+**✅ SHIPPED (#658, merged to `testing`).** Removes `claude_proxy_parity` from the whole config surface
 (`config.h`, `config.c`, `config_save.c`, `config_fields.c`, `config_schema.inc`,
 generated docs) and gates the `/v1/messages` ingress on `driver_is_anthropic` only:
 Anthropic-API primary → honor inbound model + forward `anthropic-version`/

--- a/src/Makefile
+++ b/src/Makefile
@@ -317,7 +317,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
-            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c gateway_policy.c \
+            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c gateway_policy.c gateway_pipeline.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
             trajectory_export.c trajectory_batch.c \

--- a/src/gateway_pipeline.c
+++ b/src/gateway_pipeline.c
@@ -1,0 +1,27 @@
+/* gateway_pipeline.c: the request-stage runner for the universal gateway (P2a).
+ * Deliberately dependency-free — it only sequences stage callbacks over the IR and
+ * never touches `raw`/`driver`/`ag`, so it stays a core module both the proxy
+ * ingresses and the agentic path can link. See gateway_pipeline.h. */
+#include "gateway_pipeline.h"
+
+int gw_pipeline_run_request(gw_request_t *r, const gw_stage_t *stages, size_t n)
+{
+   int total = 0;
+   size_t i;
+
+   if (!r || !stages)
+      return 0;
+   for (i = 0; i < n; i++)
+   {
+      int rc;
+
+      if (!stages[i].fn)
+         continue;
+      rc = stages[i].fn(r, stages[i].ud);
+      if (rc < 0)
+         return rc; /* a failed transform short-circuits; do not forward a
+                     * half-altered request */
+      total += rc;
+   }
+   return total;
+}

--- a/src/headers/gateway_pipeline.h
+++ b/src/headers/gateway_pipeline.h
@@ -1,0 +1,70 @@
+/* gateway_pipeline.h: the canonical request IR + typed stage interface for the
+ * universal gateway (P2a). Every proxied model call is wrapped in a `gw_request_t`
+ * and run through an ordered list of request stages — bounded, per-call transforms
+ * that inspect/alter the request before it is rendered to the serving model's API.
+ *
+ * This is the SEAM only. The concrete stages (memory/context injection, tool
+ * policing) live where their dependencies are (the ingress / the core
+ * gateway_policy module); this module just defines the IR and runs the stages in
+ * order. It therefore has NO dependency on server types — `driver`/`ag` are carried
+ * as opaque pointers that the stage implementations cast back, and `raw` is an
+ * opaque `cJSON` the stages mutate. So both ingresses AND the agentic /v1/runs path
+ * can share one pipeline without a layering violation.
+ *
+ * Two phases, kept deliberately distinct:
+ *   1. mutation stages  — gw_pipeline_run_request(): each stage rewrites `raw`.
+ *   2. terminal render  — the caller, AFTER the pipeline, translates `raw` to the
+ *      serving provider's message/tool shape. Render is NOT a stage (it produces a
+ *      derived shape rather than mutating `raw`), so stages always see the full,
+ *      un-translated request. A future need for a stage to see the post-translate
+ *      shape is a response-side concern (P2b), not a P2a request stage.
+ */
+#ifndef DEC_GATEWAY_PIPELINE_H
+#define DEC_GATEWAY_PIPELINE_H 1
+
+#include <stddef.h>
+
+struct cJSON;
+
+/* The serving model's wire API — derived from the driver, never configured. */
+typedef enum
+{
+   GW_API_ANTHROPIC = 0,
+   GW_API_OPENAI = 1,
+} gw_api_t;
+
+/* Canonical request IR. `raw` is BORROWED: the caller owns the cJSON request and
+ * frees it; stages mutate it in place and must never free or replace it. `driver`
+ * and `ag` are opaque (the stage implementations own the concrete types). INVARIANT:
+ * `parity` ⇔ the serving API equals the client's API (here: client is always
+ * Anthropic /v1/messages, so `parity == (serving_api == GW_API_ANTHROPIC)`). */
+typedef struct
+{
+   struct cJSON *raw;    /* borrowed; stages mutate in place, never free */
+   const void *driver;   /* opaque delegate_driver_t* for stage impls */
+   const void *ag;       /* opaque agent_t* for stage impls */
+   gw_api_t serving_api; /* derived from the driver */
+   int parity;           /* serving_api == client_api (no translation needed) */
+   int stream;           /* this call is an SSE stream */
+} gw_request_t;
+
+/* A request stage: inspect/alter `r->raw` in place. Returns the number of
+ * interventions it made (≥0, for the caller's audit/accounting) or <0 on a hard
+ * error (which short-circuits the pipeline). A no-op stage (policy off, nothing to
+ * do) returns 0. */
+typedef int (*gw_request_stage_fn)(gw_request_t *r, void *ud);
+
+typedef struct
+{
+   gw_request_stage_fn fn;
+   void *ud;
+   const char *name; /* for audit/trace; not interpreted by the runner */
+} gw_stage_t;
+
+/* Run `stages` (length `n`) over `r` in order. Sums each stage's intervention
+ * count; returns the total (≥0), or the first stage's negative return (stopping
+ * immediately — a failed transform must not let a half-altered request proceed).
+ * `stages` may be NULL/`n==0` (returns 0). */
+int gw_pipeline_run_request(gw_request_t *r, const gw_stage_t *stages, size_t n);
+
+#endif /* DEC_GATEWAY_PIPELINE_H */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -22,6 +22,7 @@
 #include "cJSON.h"
 #include "delegate_driver.h"
 #include "gateway_policy.h"
+#include "gateway_pipeline.h"
 #include "ingress_preinject.h"
 #include "json_fluent.h"
 #include "server_http.h"
@@ -182,6 +183,59 @@ static void translate_request(const cJSON *req, const delegate_driver_t *driver,
    *out_tools = anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 
+static void messages_apply_preinject(cJSON *req); /* defined below; used by the memory stage */
+
+/* ---- Gateway request pipeline (universal-gateway P2a) -------------------------
+ * The two inline request transforms (memory/context injection, tool policing) are
+ * run as ordered stages over a `gw_request_t` rather than hand-sequenced at each
+ * call site, so the seam is one shared, testable pipeline. translate_request stays
+ * a TERMINAL render step after the pipeline (it produces the provider shape rather
+ * than mutating `raw`). Behavior is identical to the previous inline prelude. */
+
+/* Memory/context pre-injection stage. The `if (!r->parity)` guard replicates the
+ * original top-level `if (!parity)` gate: only memory injection is parity-gated (the
+ * Anthropic-native passthrough must not perturb Claude Code's cached prefix). A
+ * future parity-gated stage must carry its own guard — the pipeline runs every
+ * stage; it does not gate them. */
+static int gw_stage_memory(gw_request_t *r, void *ud)
+{
+   (void)ud;
+   if (!r->parity)
+      messages_apply_preinject(r->raw);
+   return 0; /* injection is accounting-neutral here; not an intervention count */
+}
+
+/* Tool-policing stage: strip subagent-spawning tools etc. Returns the number of
+ * tools stripped (already the contract of gateway_policy_apply_request). */
+static int gw_stage_tool_policing(gw_request_t *r, void *ud)
+{
+   (void)ud;
+   return gateway_policy_apply_request(r->raw, 0 /* Anthropic tool shape */);
+}
+
+/* Run the request pipeline over an inbound Anthropic /v1/messages request, in
+ * place, with the same stages and order as the prior inline prelude
+ * (memory → policy). Returns total interventions (≥0) or <0 on a stage error. */
+static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *driver,
+                                         const agent_t *ag, int parity, int stream)
+{
+   gw_request_t r = {
+       .raw = req,
+       .driver = driver,
+       .ag = ag,
+       /* parity == driver_is_anthropic(driver), so serving_api follows it (the
+        * client is always Anthropic /v1/messages here) — no second predicate call. */
+       .serving_api = parity ? GW_API_ANTHROPIC : GW_API_OPENAI,
+       .parity = parity,
+       .stream = stream,
+   };
+   static const gw_stage_t stages[] = {
+       {gw_stage_memory, NULL, "memory"},
+       {gw_stage_tool_policing, NULL, "tool_policing"},
+   };
+   return gw_pipeline_run_request(&r, stages, sizeof(stages) / sizeof(stages[0]));
+}
+
 /* Build the provider request body via the selected delegate driver. `stream`
  * toggles the provider stream flag. Returns a malloc'd JSON string (caller
  * frees), or NULL. */
@@ -339,11 +393,16 @@ static int messages_buffered(const char *body, char *resp, int cap)
    driver = delegate_driver_get(ag->provider);
    /* Exact-parity passthrough only applies to the Anthropic-native path. */
    int parity = driver_is_anthropic(driver);
-   if (!parity)
-      messages_apply_preinject(req);
-   /* Gateway tool policing (e.g. strip subagent tools) on the inbound Anthropic
-    * request, before translate/build. No-op unless a policy is configured. */
-   gateway_policy_apply_request(req, 0);
+   /* Request stages (memory injection, tool policing) over the canonical IR, then
+    * translate as the terminal render step. Same order/behavior as the prior
+    * inline prelude; no-op stages when nothing is configured. A <0 return is a
+    * stage that hard-failed: abort rather than forward a half-altered request (no
+    * stage returns <0 today; the intervention count is plumbed for P2b's audit). */
+   if (messages_run_request_pipeline(req, driver, ag, parity, 0 /* buffered */) < 0)
+   {
+      status = write_error(resp, cap, 500, "api_error", "gateway request pipeline failed");
+      goto cleanup;
+   }
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -635,11 +694,22 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    driver = delegate_driver_get(ag->provider);
    /* Exact-parity passthrough only applies to the Anthropic-native path. */
    int parity = driver_is_anthropic(driver);
-   if (!parity)
-      messages_apply_preinject(req);
-   /* Gateway tool policing (e.g. strip subagent tools) on the inbound Anthropic
-    * request, before translate/build. No-op unless a policy is configured. */
-   gateway_policy_apply_request(req, 0);
+   /* Request stages (memory injection, tool policing) over the canonical IR, then
+    * translate as the terminal render step. Same order/behavior as the prior
+    * inline prelude. A <0 return is a stage that hard-failed: emit a clean empty
+    * stream (matching the setup-failure path) so the client's SSE reader
+    * terminates, then abort rather than forward a half-altered request. (No stage
+    * returns <0 today; the count is plumbed for P2b's audit.) */
+   if (messages_run_request_pipeline(req, driver, ag, parity, 1 /* stream */) < 0)
+   {
+      xl = anthropic_stream_begin(msg_id, model, 0, emit, ctx);
+      if (xl)
+      {
+         anthropic_stream_finish(xl);
+         anthropic_stream_free(xl);
+      }
+      goto cleanup;
+   }
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -178,6 +178,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-anthropic-ingress \
                $(TESTPREFIX)/unit-test-anthropic-http \
                $(TESTPREFIX)/unit-test-gateway-policy \
+               $(TESTPREFIX)/unit-test-gateway-pipeline \
                $(TESTPREFIX)/unit-test-hud \
                $(TESTPREFIX)/unit-test-coord-jobs \
                $(TESTPREFIX)/unit-test-plan-waves \
@@ -1634,11 +1635,14 @@ $(TESTPREFIX)/unit-test-sse-parser: $(OBJDIR)/tests/test_sse_parser.o $(OBJDIR)/
 $(TESTPREFIX)/unit-test-anthropic-ingress: $(OBJDIR)/tests/test_anthropic_ingress.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
-$(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
+$(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-gateway-policy: $(OBJDIR)/tests/test_gateway_policy.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-gateway-pipeline: $(OBJDIR)/tests/test_gateway_pipeline.o $(OBJDIR)/gateway_pipeline.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
 $(OBJDIR)/tests/%.o: tests/%.c
 	@mkdir -p $(dir $@)

--- a/src/tests/test_gateway_pipeline.c
+++ b/src/tests/test_gateway_pipeline.c
@@ -1,0 +1,104 @@
+/* test_gateway_pipeline.c: pure tests for the universal-gateway request-stage
+ * runner (P2a). The runner sequences stage callbacks over a gw_request_t and never
+ * derefs raw/driver/ag, so these tests need no cJSON, no socket, no server. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "../headers/gateway_pipeline.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+/* A recorder: each stage appends its tag to a shared buffer (proving order) and
+ * returns a configurable intervention count. */
+typedef struct
+{
+   char order[16];
+   int ret;
+   char tag;
+} rec_t;
+
+static char g_trace[64];
+static size_t g_trace_len;
+
+static int rec_stage(gw_request_t *r, void *ud)
+{
+   rec_t *rc = (rec_t *)ud;
+   (void)r;
+   if (g_trace_len + 1 < sizeof(g_trace))
+      g_trace[g_trace_len++] = rc->tag;
+   return rc->ret;
+}
+
+static void reset_trace(void)
+{
+   g_trace_len = 0;
+   memset(g_trace, 0, sizeof(g_trace));
+}
+
+/* Stages run in declared order and intervention counts sum. */
+static void test_order_and_sum(void)
+{
+   rec_t a = {.ret = 2, .tag = 'a'}, b = {.ret = 3, .tag = 'b'}, c = {.ret = 0, .tag = 'c'};
+   gw_request_t r = {.raw = NULL, .parity = 1};
+   gw_stage_t stages[] = {{rec_stage, &a, "a"}, {rec_stage, &b, "b"}, {rec_stage, &c, "c"}};
+
+   reset_trace();
+   int total = gw_pipeline_run_request(&r, stages, 3);
+   assert(total == 5);                  /* 2 + 3 + 0 */
+   assert(strcmp(g_trace, "abc") == 0); /* declared order preserved */
+   PASS("order_and_sum");
+}
+
+/* A stage returning <0 short-circuits: later stages do not run, and the negative
+ * is propagated (a half-altered request must not proceed). */
+static void test_short_circuit_on_error(void)
+{
+   rec_t a = {.ret = 1, .tag = 'a'}, b = {.ret = -7, .tag = 'b'}, c = {.ret = 1, .tag = 'c'};
+   gw_request_t r = {.raw = NULL};
+   gw_stage_t stages[] = {{rec_stage, &a, "a"}, {rec_stage, &b, "b"}, {rec_stage, &c, "c"}};
+
+   reset_trace();
+   int rv = gw_pipeline_run_request(&r, stages, 3);
+   assert(rv == -7);                   /* first negative propagated */
+   assert(strcmp(g_trace, "ab") == 0); /* 'c' never ran */
+   PASS("short_circuit_on_error");
+}
+
+/* NULL/empty stage lists and NULL fn slots are no-ops, not crashes. */
+static void test_null_and_empty(void)
+{
+   gw_request_t r = {.raw = NULL};
+   rec_t a = {.ret = 4, .tag = 'a'};
+   gw_stage_t with_hole[] = {{NULL, NULL, "hole"}, {rec_stage, &a, "a"}};
+
+   assert(gw_pipeline_run_request(&r, NULL, 0) == 0);
+   assert(gw_pipeline_run_request(NULL, with_hole, 2) == 0);
+
+   reset_trace();
+   int total = gw_pipeline_run_request(&r, with_hole, 2); /* skips the NULL fn */
+   assert(total == 4);
+   assert(strcmp(g_trace, "a") == 0);
+   PASS("null_and_empty");
+}
+
+/* The IR carries derived state for stages to read (parity/serving_api/stream). */
+static void test_ir_fields_visible(void)
+{
+   gw_request_t r = {.raw = NULL, .serving_api = GW_API_OPENAI, .parity = 0, .stream = 1};
+   assert(r.serving_api == GW_API_OPENAI);
+   assert(r.parity == 0);
+   assert(r.stream == 1);
+   PASS("ir_fields_visible");
+}
+
+int main(void)
+{
+   printf("test_gateway_pipeline:\n");
+   test_order_and_sum();
+   test_short_circuit_on_error();
+   test_null_and_empty();
+   test_ir_fields_visible();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
First slice of **aimee-universal-gateway P2**. Formalizes the Anthropic `/v1/messages` ingress's two inline request transforms (memory/context injection, tool policing) as ordered, typed **stages over a canonical request IR** in a new core module — the seam every model call will flow through. **Zero behavior change.**

## What
- **New core `src/gateway_pipeline.{c,h}`** (alongside the already-core `src/gateway_policy.c`, so the ingresses *and* `/v1/runs` share one seam — resolves the "shared-seam" open question):
  - `gw_request_t { cJSON *raw /*BORROWED — stages mutate in place, never free*/; const void *driver, *ag /*opaque*/; gw_api_t serving_api; int parity, stream; }`. The IR carries the **raw** request, so same-API passthrough is lossless (provider-specific fields untouched) — resolves the "IR fidelity" open question.
  - A typed stage `int(*)(gw_request_t*, void*)` returning an intervention count (≥0) or `<0` (hard error → short-circuits), and `gw_pipeline_run_request()`. The module never derefs `raw`/`driver`/`ag`, so it has no server-type coupling.
- **`anthropic_http.c`**: both the buffered and streaming request preludes now run `[memory, policy]` through the pipeline; `translate_request` stays the **terminal render** step (produces the provider shape rather than mutating `raw`, so stages always see the full untranslated request). A `<0` pipeline return aborts the request rather than forwarding a half-altered one.

## Scope
Request-side tool-policing itself (`gateway_policy_apply_request`) was already shipped; P2a only formalizes the seam it plugs into. **Model-pin policy + response-side (buffered & streaming) tool-policing are P2b/P2c** (plan updated with the split).

## Verification
- `make -j1 server` clean (`-Werror`); `make lint` ok; full `make unit-tests` green.
- New `test_gateway_pipeline.c` (pure runner: order, intervention-sum, short-circuit-on-error, null-safety).
- The existing whitebox `test_anthropic_http.c` suite (14 tests incl. `anthropic_parity_passthrough` honors model, `openai_family_translates`, streaming variants) **passes unchanged** → behavior-identical refactor.

## Roundtables
Design round (0 blocking) + implementation round. The implementation round's one blocking finding — *don't discard the pipeline's `<0` short-circuit return* — is fixed (both call sites now abort on `<0`); folded the suggestions (derive `serving_api` from `parity` to avoid a double predicate call; document the parity guard now living inside the memory stage).