### PR TITLE
feat(gateway): model-pin policy stage (P2b)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (108)
+## CLI-settable keys (109)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -54,6 +54,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `embedding_endpoint` | string | Embeddings provider endpoint URL. |
 | `embedding_model` | string | Embeddings model name. |
 | `fidelity_check_enabled` | bool | Run the answer-fidelity judge on terminal-text turns (default off; requires kb_evidence_emit_enabled + ingress_preinject_enabled). |
+| `gateway_pin_model` | bool | Gateway forces the proxied /v1/messages served model to the configured primary's model, overriding the client-requested model. Default off (the passthrough honors the client model); enable for single-model Anthropic-compatible shims. |
 | `gateway_prevent_subagents` | bool | Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off. |
 | `guardrail_mode` | string | Guardrail enforcement mode (off / warn / block). |
 | `guardrails_semantic_allow_ml_only_block` | bool | Allow blocking on the ML classifier alone. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -107,6 +107,7 @@ CFG_KEY_DESC = {
     "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
     "claude_model": "Default Claude model (empty = CLI default).",
     "gateway_prevent_subagents": "Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off.",
+    "gateway_pin_model": "Gateway forces the proxied /v1/messages served model to the configured primary's model, overriding the client-requested model. Default off (the passthrough honors the client model); enable for single-model Anthropic-compatible shims.",
     "cost_reward_enabled": "Factor token cost into the reward signal.",
     "cost_reward_lambda_pct": "Cost-penalty weight (percent) in the reward.",
     "cost_reward_ref_usd_milli": "Reference cost (USD-milli) normalizing the cost reward.",

--- a/src/config.c
+++ b/src/config.c
@@ -841,6 +841,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->gateway_prevent_subagents = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "gateway_pin_model");
+   if (cJSON_IsBool(item))
+      cfg->gateway_pin_model = cJSON_IsTrue(item);
+
    /* CSS migration assistant style-graph write path (WP-C). The field +
     * descriptor + save existed, but the YAML load parse was missing, so the
     * flag never took effect during indexing. */

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -43,6 +43,7 @@ const config_field_t config_fields[] = {
      CFG_BOOL},
     {"gateway_prevent_subagents", offsetof(config_t, gateway_prevent_subagents), sizeof(int), 0,
      CFG_BOOL},
+    {"gateway_pin_model", offsetof(config_t, gateway_pin_model), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_assembly_budget", offsetof(config_t, ingress_preinject_assembly_budget),
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -775,6 +775,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
    if (cfg->gateway_prevent_subagents)
       cJSON_AddBoolToObject(root, "gateway_prevent_subagents", 1);
+   if (cfg->gateway_pin_model)
+      cJSON_AddBoolToObject(root, "gateway_pin_model", 1);
    if (cfg->ingress_preinject_assembly_budget != 6144)
       cJSON_AddNumberToObject(root, "ingress_preinject_assembly_budget",
                               cfg->ingress_preinject_assembly_budget);

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -9,6 +9,7 @@
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
 {"gateway_prevent_subagents", SCHEMA_BOOL, 0},
+{"gateway_pin_model", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},
 {"css_render_command", SCHEMA_STRING, 0},
 {"typed_facts_enabled", SCHEMA_BOOL, 0},

--- a/src/gateway_policy.c
+++ b/src/gateway_policy.c
@@ -25,6 +25,13 @@ static int prevent_subagents_enabled(void)
    return cfg.gateway_prevent_subagents ? 1 : 0;
 }
 
+static int pin_model_enabled(void)
+{
+   config_t cfg;
+   config_load(&cfg);
+   return cfg.gateway_pin_model ? 1 : 0;
+}
+
 /* A tool entry's name, regardless of API shape. */
 static const char *tool_entry_name(const cJSON *tool, int openai_shape)
 {
@@ -99,4 +106,18 @@ int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
    }
 
    return stripped;
+}
+
+int gateway_policy_pin_model(cJSON *req, const char *agent_model)
+{
+   const char *cur;
+
+   if (!req || !agent_model || !agent_model[0] || !pin_model_enabled())
+      return 0;
+   cur = jo_cstr(req, "model");
+   if (cur && strcmp(cur, agent_model) == 0)
+      return 0; /* already the pinned model — nothing to change */
+   cJSON_DeleteItemFromObjectCaseSensitive(req, "model");
+   cJSON_AddStringToObject(req, "model", agent_model);
+   return 1;
 }

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -343,6 +343,12 @@ typedef struct config
     * proxied /v1/messages or /v1/chat/completions request, so the served model is
     * never offered a way to spawn subagents. Default off. */
    int gateway_prevent_subagents;
+   /* Gateway model-pin (universal-gateway P2b): when on, the proxied /v1/messages
+    * served model is forced to the configured primary's model, overriding whatever
+    * model the client requested. Default off (the passthrough honors the client
+    * model, P1). Single-model Anthropic-compatible shims (llama.cpp/vLLM) enable
+    * this so an arbitrary client model name is not forwarded and rejected upstream. */
+   int gateway_pin_model;
    int typed_facts_enabled;      /* typed-fact knowledge layer master gate (default off) */
    int kb_evidence_emit_enabled; /* auditable-correctness: emit per-turn retrieval_event (default
                                     off) */

--- a/src/headers/gateway_policy.h
+++ b/src/headers/gateway_policy.h
@@ -27,4 +27,13 @@ int gateway_policy_apply_request(struct cJSON *req, int tools_openai_shape);
  * Returns the number of entries removed (0 = no-op / policy off / not an array). */
 int gateway_policy_strip_tools(struct cJSON *tools, int tools_openai_shape);
 
+/* Model-pin (universal-gateway P2b): when config `gateway_pin_model` is on, force
+ * `req`'s "model" to `agent_model` (the configured primary), overriding whatever
+ * model the client requested. No-op when the policy is off, `agent_model` is empty,
+ * or `req` already names it — so it is byte-neutral by default (the P1 passthrough
+ * still honors the client model). Single-model Anthropic-compatible shims enable it
+ * so an arbitrary client model name is not forwarded and rejected upstream. Returns
+ * 1 if it changed the model, 0 otherwise (for the caller's audit row). */
+int gateway_policy_pin_model(struct cJSON *req, const char *agent_model);
+
 #endif /* DEC_GATEWAY_POLICY_H */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -213,9 +213,22 @@ static int gw_stage_tool_policing(gw_request_t *r, void *ud)
    return gateway_policy_apply_request(r->raw, 0 /* Anthropic tool shape */);
 }
 
+/* Model-pin stage (P2b): force the served model to the configured primary's model
+ * when the policy is on (no-op by default). Resolves the P1 single-model-shim
+ * regression — an operator running a fixed-model Anthropic-compatible shim enables
+ * it so an arbitrary client model name is not forwarded and rejected upstream.
+ * Returns 1 if the model was changed. */
+static int gw_stage_model_pin(gw_request_t *r, void *ud)
+{
+   const agent_t *ag = (const agent_t *)r->ag;
+   (void)ud;
+   return gateway_policy_pin_model(r->raw, ag ? ag->model : NULL);
+}
+
 /* Run the request pipeline over an inbound Anthropic /v1/messages request, in
- * place, with the same stages and order as the prior inline prelude
- * (memory → policy). Returns total interventions (≥0) or <0 on a stage error. */
+ * place, with the same stages and order as the prior inline prelude (memory →
+ * policy), plus the model-pin policy. Returns total interventions (≥0) or <0 on a
+ * stage error. */
 static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *driver,
                                          const agent_t *ag, int parity, int stream)
 {
@@ -232,6 +245,7 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
    static const gw_stage_t stages[] = {
        {gw_stage_memory, NULL, "memory"},
        {gw_stage_tool_policing, NULL, "tool_policing"},
+       {gw_stage_model_pin, NULL, "model_pin"},
    };
    return gw_pipeline_run_request(&r, stages, sizeof(stages) / sizeof(stages[0]));
 }
@@ -403,6 +417,9 @@ static int messages_buffered(const char *body, char *resp, int cap)
       status = write_error(resp, cap, 500, "api_error", "gateway request pipeline failed");
       goto cleanup;
    }
+   /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
+    * the pointer cached above (line ~397) could now dangle. */
+   model = jo_cstr(req, "model");
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -710,6 +727,9 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
       }
       goto cleanup;
    }
+   /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
+    * the pointer cached at the top of this function could now dangle. */
+   model = jo_cstr(req, "model");
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -233,6 +233,12 @@ int gateway_policy_apply_request(cJSON *req, int tools_openai_shape)
    (void)tools_openai_shape;
    return 0;
 }
+int gateway_policy_pin_model(cJSON *req, const char *agent_model)
+{
+   (void)req;
+   (void)agent_model;
+   return 0; /* pin is off in these shape tests; covered by test_gateway_policy */
+}
 
 #include "../server/anthropic_http.c"
 

--- a/src/tests/test_gateway_policy.c
+++ b/src/tests/test_gateway_policy.c
@@ -12,12 +12,14 @@
 #define PASS(name) printf("  PASS: %s\n", (name))
 
 static int g_prevent = 0;
+static int g_pin = 0;
 int config_load(config_t *cfg)
 {
    if (cfg)
    {
       memset(cfg, 0, sizeof(*cfg));
       cfg->gateway_prevent_subagents = g_prevent;
+      cfg->gateway_pin_model = g_pin;
    }
    return 0;
 }
@@ -144,6 +146,45 @@ static void test_strip_tools_off_and_null(void)
    PASS("strip_tools_off_and_null");
 }
 
+/* Model-pin: on -> the served model is forced to the agent's model. */
+static void test_pin_model_on_swaps(void)
+{
+   cJSON *req = cJSON_Parse("{\"model\":\"claude-opus-from-client\",\"max_tokens\":8}");
+   g_pin = 1;
+   int changed = gateway_policy_pin_model(req, "primary-model");
+   assert(changed == 1);
+   assert(strcmp(cJSON_GetObjectItem(req, "model")->valuestring, "primary-model") == 0);
+   g_pin = 0;
+   cJSON_Delete(req);
+   PASS("pin_model_on_swaps");
+}
+
+/* Model-pin off (default) is a byte-neutral no-op: the client model is honored. */
+static void test_pin_model_off_noop(void)
+{
+   cJSON *req = cJSON_Parse("{\"model\":\"client-model\"}");
+   g_pin = 0;
+   int changed = gateway_policy_pin_model(req, "primary-model");
+   assert(changed == 0);
+   assert(strcmp(cJSON_GetObjectItem(req, "model")->valuestring, "client-model") == 0);
+   cJSON_Delete(req);
+   PASS("pin_model_off_noop");
+}
+
+/* Pin on but the request already names the pinned model, or no agent model -> no-op. */
+static void test_pin_model_idempotent_and_guarded(void)
+{
+   cJSON *req = cJSON_Parse("{\"model\":\"primary-model\"}");
+   g_pin = 1;
+   assert(gateway_policy_pin_model(req, "primary-model") == 0);  /* already pinned */
+   assert(gateway_policy_pin_model(req, "") == 0);               /* empty agent model */
+   assert(gateway_policy_pin_model(NULL, "primary-model") == 0); /* null req */
+   assert(strcmp(cJSON_GetObjectItem(req, "model")->valuestring, "primary-model") == 0);
+   g_pin = 0;
+   cJSON_Delete(req);
+   PASS("pin_model_idempotent_and_guarded");
+}
+
 int main(void)
 {
    printf("test_gateway_policy:\n");
@@ -154,6 +195,9 @@ int main(void)
    test_strip_tools_bare_array();
    test_strip_tools_emptied();
    test_strip_tools_off_and_null();
+   test_pin_model_on_swaps();
+   test_pin_model_off_noop();
+   test_pin_model_idempotent_and_guarded();
    printf("all gateway_policy tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Universal-gateway **P2b — model-pin** (the first half of P2b; buffered/streaming response policing is P2c).

## Why
P1 made `/v1/messages` **honor the client's requested model**, which regressed single-model Anthropic-compatible shims (llama.cpp/vLLM `/v1/messages`): an arbitrary client model name is forwarded and rejected upstream. This resolves the proposal's **Finding C** with a config-gated model-pin policy — default **off** (honor); single-model operators turn it **on** to force the served model to the configured primary's.

## What
- **`gateway_pin_model`** config flag (default off), mirrored across `config.h` / `config.c` / `config_fields.c` / `config_schema.inc` / `config_save.c` + regenerated `docs/gen/configuration.md` (+ `CFG_KEY_DESC`).
- **`gateway_policy_pin_model()`** in the core policy module: when on, force `req`'s `model` to the configured primary's model; **no-op** when off / empty agent model / already pinned — so it's byte-neutral by default (the passthrough still honors the client model).
- Wired as a request **stage** (`gw_stage_model_pin`) after memory + tool-policing in the P2a pipeline. Runs before translate; under the Anthropic passthrough it overrides the honored model, under OpenAI-translate it's a harmless no-op (served model is already `ag->model`).

## Verification
- `make -j1 server` clean (`-Werror`); `make lint` ok (config docs regenerated); full `make unit-tests` green.
- New pure tests: `pin_model_on_swaps`, `pin_model_off_noop`, `pin_model_idempotent_and_guarded`. `config_surface` passes (145 fields). The whitebox `test_anthropic_http` suite passes unchanged.

## Roundtable
1 round, 2 verified-blocking — both addressed:
1. **Cached `model` pointer dangles** — the buffered + streaming paths cached `model = jo_cstr(req,"model")` *before* the pipeline and used it *after*; the pin's node replacement would dangle it. **Fixed:** both paths now re-read `model` after the pipeline.
2. *config-load per call* — rejected: mirrors the already-shipped sibling `prevent_subagents_enabled`, and `config_t` is a stack POD (no leak). The NULL-`ag` finding was also rejected (both layers guard NULL).