### PR TITLE
feat(gateway): P2c response-side tool policing — buffered path

### DIFF
--- a/src/gateway_policy.c
+++ b/src/gateway_policy.c
@@ -1,9 +1,11 @@
 /* gateway_policy.c: per-call gateway request/response policy. See gateway_policy.h.
  * CORE layer: cJSON + config + guardrails only; no DB, network, or agent state. */
+#include "aimee.h" /* size macros for agent_types.h (MAX_PATH_LEN) */
 #include "gateway_policy.h"
 #include "cJSON.h"
 #include "config.h"
 #include "json_fluent.h" /* jo_cstr */
+#include <stdlib.h>      /* free — for the dropped-entry arguments cleanup in P2c */
 #include <string.h>
 
 /* From guardrails (guardrails_orchestrator.c). Forward-declared rather than
@@ -120,4 +122,66 @@ int gateway_policy_pin_model(cJSON *req, const char *agent_model)
    cJSON_DeleteItemFromObjectCaseSensitive(req, "model");
    cJSON_AddStringToObject(req, "model", agent_model);
    return 1;
+}
+
+/* Response-side (P2c). Same canonical mapping and config gate as the request
+ * side, exposed as a predicate so the buffered/streamed paths can gate cheaply
+ * (the predicate does the config_load + canonical-name lookup, so the call
+ * site stays one line). */
+int gateway_policy_is_denied_tool(const char *name)
+{
+   if (!name || !name[0])
+      return 0;
+   if (!prevent_subagents_enabled())
+      return 0;
+   return is_subagent_tool_name(name);
+}
+
+/* Response-side tool policing: memmove-compact denied entries out of `p->calls[]`
+ * and rewrite `p->stop_reason` to mirror what `anthropic_response_from_parsed`
+ * would render from the surviving `call_count` (line 435 of
+ * src/server/anthropic_ingress.c: `n_calls > 0 ? "tool_use" : "end_turn"`). See
+ * gateway_policy.h for the full set of fields the function does NOT touch and
+ * the rationale for the in-place memmove compaction. */
+int gateway_policy_police_parsed_response(parsed_response_t *p)
+{
+   int drops = 0;
+   int n, i, w;
+
+   if (!p)
+      return 0;
+   if (!prevent_subagents_enabled())
+      return 0;
+
+   n = p->call_count;
+   if (n <= 0)
+      return 0;
+
+   /* Single pass: read index `i`, write index `w`. Surviving entries are
+    * shifted down to the front of the array in their original order. Dropped
+    * entries' `arguments` strings are freed eagerly — the slot is then
+    * overwritten by the next survivor, so `agent_free_parsed_response`'s
+    * 0..call_count-1 sweep would otherwise leak the dropped strings. */
+   w = 0;
+   for (i = 0; i < n; i++)
+   {
+      const parsed_tool_call_t *src = &p->calls[i];
+      if (is_subagent_tool_name(src->name))
+      {
+         free(src->arguments);
+         p->calls[i].arguments = NULL;
+         drops++;
+         continue;
+      }
+      if (w != i)
+         p->calls[w] = *src;
+      w++;
+   }
+   p->call_count = w;
+   /* Mirror the renderer's own stop_reason mapping so the audit row at
+    * messages_buffered line 483 (which reads parsed.stop_reason) agrees with
+    * the wire emitted by anthropic_response_from_parsed (which re-derives
+    * from call_count). */
+   snprintf(p->stop_reason, sizeof(p->stop_reason), "%s", w > 0 ? "tool_use" : "end_turn");
+   return drops;
 }

--- a/src/headers/gateway_policy.h
+++ b/src/headers/gateway_policy.h
@@ -7,6 +7,8 @@
 #ifndef DEC_GATEWAY_POLICY_H
 #define DEC_GATEWAY_POLICY_H 1
 
+#include "agent_protocol.h" /* parsed_response_t — type of the police function's argument */
+
 struct cJSON;
 
 /* Apply request-side tool policing to a proxied request, in place. `tools` is read
@@ -35,5 +37,48 @@ int gateway_policy_strip_tools(struct cJSON *tools, int tools_openai_shape);
  * so an arbitrary client model name is not forwarded and rejected upstream. Returns
  * 1 if it changed the model, 0 otherwise (for the caller's audit row). */
 int gateway_policy_pin_model(struct cJSON *req, const char *agent_model);
+
+/* Response-side tool policing (universal-gateway P2c). Companion to
+ * gateway_policy_apply_request; the request side strips a denied tool from the
+ * outbound `tools` array, the response side strips a `tool_use` block the served
+ * model emitted anyway. Same canonical mapping (`guardrails_canonical_tool_name`
+ * == "Subagent") and same gate (`config.gateway_prevent_subagents`); the predicate
+ * reads the config so the caller does not need to. */
+
+/* True if `name` would be denied by the active response-side policy. Reads
+ * `config.gateway_prevent_subagents` internally — the caller need not gate. The
+ * canonical-tool-name mapping is shared with the request side, so a denied name
+ * matches the request-side `is_subagent_tool_name` rule (Task / Agent / spawn_agent
+ * / RemoteTrigger, etc., all mapped to "Subagent"). */
+int gateway_policy_is_denied_tool(const char *name);
+
+/* Mutate `p` in place: memmove-compact denied entries out of `p->calls[]` so the
+ * surviving `p->calls[0..p->call_count-1]` is a contiguous prefix of the original
+ * (no realloc, no flag-and-skip). `p->call_count` is decremented to match.
+ * `p->stop_reason` is rewritten to "tool_use" when `call_count > 0`, "end_turn"
+ * when `call_count == 0` — the same mapping `anthropic_response_from_parsed`
+ * (src/server/anthropic_ingress.c:435) re-derives from `call_count`, so the
+ * post-police struct is wire-consistent with the renderer's mapping. The
+ * `stop_reason` write also feeds the pre-existing `agent_record_token_audit` row
+ * in `messages_buffered()` (it reads `parsed.stop_reason`), so the audit log
+ * matches the wire.
+ *
+ * Fields the function does NOT touch (by design): `id`, `name`, `is_tool_call`,
+ * `content`, `assistant_message`, `prompt_tokens`, `completion_tokens`,
+ * `cache_write_tokens`, `cache_read_tokens`, `model`. None of these are
+ * call-indexed. The function DOES write `arguments` on dropped entries —
+ * `free(src->arguments); src->arguments = NULL;` — so the dropped-entry
+ * strings are not leaked. (Without this, `agent_free_parsed_response`'s
+ * 0..call_count-1 sweep would miss them: the survivors overwrite the front
+ * slots, but the tail slots still hold the dropped strings, and the sweep
+ * never reaches the tail.) Bounded by the original `AGENT_MAX_TOOL_CALLS`
+ * ceiling.
+ *
+ * Returns the number of entries dropped (>= 0; never < 0). 0 = policy off / no
+ * denied entries / null `p` — no-op in all three cases. Currently discarded
+ * at the call site (messages_buffered ignores the return value); the future
+ * P2b audit pass will surface the count alongside the request-side
+ * `gateway_policy_apply_request` return value. */
+int gateway_policy_police_parsed_response(parsed_response_t *p);
 
 #endif /* DEC_GATEWAY_POLICY_H */

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -470,6 +470,16 @@ static int messages_buffered(const char *body, char *resp, int cap)
       else
          agent_parse_response_openai(provider_resp, &parsed);
 
+      /* P2c (response-side tool policing, buffered). Drops any `tool_use` block
+       * the model emitted despite the request-side strip, before the audit row
+       * reads parsed.stop_reason (so the audit log matches the wire) and before
+       * anthropic_response_from_parsed renders the reply. Gated internally on
+       * gateway_prevent_subagents (the predicate + the police function are both
+       * no-ops at the default config). Drop count is plumbed through to the
+       * same pipeline-runner total the request-side strip already emits; a
+       * future P2b audit pass surfaces both at once. */
+      gateway_policy_police_parsed_response(&parsed);
+
       /* Cost accounting: the Anthropic /v1/messages ingress is a raw provider
        * proxy (no agent_log_call), so record this turn's spend, billed against
        * the served model and tagged as ingress. */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -177,6 +177,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-sse-parser \
                $(TESTPREFIX)/unit-test-anthropic-ingress \
                $(TESTPREFIX)/unit-test-anthropic-http \
+               $(TESTPREFIX)/unit-test-anthropic-http-p2c \
                $(TESTPREFIX)/unit-test-gateway-policy \
                $(TESTPREFIX)/unit-test-gateway-pipeline \
                $(TESTPREFIX)/unit-test-hud \
@@ -1636,6 +1637,15 @@ $(TESTPREFIX)/unit-test-anthropic-ingress: $(OBJDIR)/tests/test_anthropic_ingres
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+# P2c (response-side tool policing) integration test: same source as
+# unit-test-anthropic-http but linked against the REAL gateway_policy.o
+# so the production police function runs against the driver's parsed
+# response. The shape tests stub the request-side policy helpers so they
+# don't have to deal with guardrails dependencies; this test exercises the
+# full wiring end-to-end.
+$(TESTPREFIX)/unit-test-anthropic-http-p2c: $(OBJDIR)/tests/test_anthropic_http_p2c.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-gateway-policy: $(OBJDIR)/tests/test_gateway_policy.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -239,6 +239,15 @@ int gateway_policy_pin_model(cJSON *req, const char *agent_model)
    (void)agent_model;
    return 0; /* pin is off in these shape tests; covered by test_gateway_policy */
 }
+/* P2c (response-side tool policing) is exercised by its own dedicated
+ * integration test (unit-test-anthropic-http-p2c) which links the real
+ * gateway_policy.o. In these whitebox shape tests we stub it to a no-op
+ * so the response shape is unaltered. */
+int gateway_policy_police_parsed_response(parsed_response_t *p)
+{
+   (void)p;
+   return 0;
+}
 
 #include "../server/anthropic_http.c"
 

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -1,0 +1,439 @@
+/* test_anthropic_http_p2c.c: P2c (response-side tool policing) integration tests
+ * for the buffered Anthropic /v1/messages path. Like test_anthropic_http.c, this
+ * includes the production anthropic_http.c so we can drive the private
+ * messages_buffered() end-to-end. Unlike that test, the real gateway_policy.o
+ * is linked so the production police function runs against the driver's
+ * parsed response. The two tests cover the all-dropped and partial-drop
+ * manifestations of B2 (audit/wire stop_reason consistency). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../headers/aimee.h"
+#include "../headers/agent_config.h"
+#include "../headers/agent_exec.h"
+#include "../headers/agent_protocol.h"
+#include "../headers/delegate_driver.h"
+#include "../headers/server_http.h"
+#include "../vendor/headers/cJSON.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+static const delegate_driver_t *g_driver;
+static char *g_last_body;
+static char *g_last_extra; /* upstream extra-header block from the last post */
+static int g_stream_status = 200;
+static const char *g_stream_payload;
+/* Fake upstream response body. The P2c tests set this to a real Anthropic
+ * response carrying `tool_use` blocks so the police function has something
+ * to police. NULL = empty "{}" (preserves shape-test behavior). */
+static const char *g_response_body;
+static int g_response_status = 200;
+/* P2c policy gate. The real config_load is stubbed here to honor this global;
+ * flip g_prevent to 1 to enable the response-side tool policing. */
+static int g_prevent = 0;
+/* Tool-use fixtures for parsed_with_tool_uses. The JSON is a cJSON array of
+ * {id, name, arguments} objects; the parser translates it into a populated
+ * parsed_response_t.calls[] so messages_buffered's parse step has real
+ * tool_use blocks to feed the police function. */
+static const char *g_tool_uses_json;
+static const char *g_upstream_stop_reason;
+
+static void reset_capture(void)
+{
+   free(g_last_body);
+   g_last_body = NULL;
+   free(g_last_extra);
+   g_last_extra = NULL;
+   g_stream_status = 200;
+   g_stream_payload = NULL;
+   g_response_body = NULL;
+   g_response_status = 200;
+   g_prevent = 0;
+   g_tool_uses_json = NULL;
+   g_upstream_stop_reason = NULL;
+}
+
+int agent_load_config(agent_config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   cfg->agent_count = 1;
+   snprintf(cfg->agents[0].name, sizeof(cfg->agents[0].name), "primary");
+   snprintf(cfg->agents[0].provider, sizeof(cfg->agents[0].provider), "%s",
+            g_driver && g_driver->name ? g_driver->name : "anthropic");
+   snprintf(cfg->agents[0].model, sizeof(cfg->agents[0].model), "configured-claude");
+   cfg->agents[0].timeout_ms = 1;
+   return 0;
+}
+
+agent_t *agent_find(agent_config_t *cfg, const char *name)
+{
+   (void)name;
+   return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
+}
+
+void delegate_drivers_init(void)
+{
+}
+
+const delegate_driver_t *delegate_driver_get(const char *provider)
+{
+   (void)provider;
+   return g_driver;
+}
+
+void delegate_get_caps(const delegate_driver_t *driver, const agent_t *agent, driver_caps_t *caps)
+{
+   memset(caps, 0, sizeof(*caps));
+   if (driver && driver->get_caps)
+   {
+      driver->get_caps(agent, caps);
+      return;
+   }
+   caps->capability_flags = DRIVER_CAP_TOOL_CALLS | DRIVER_CAP_STREAMING;
+   caps->context_limit = DRIVER_CTX_LARGE;
+}
+
+int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, char *url,
+                       size_t url_len)
+{
+   (void)driver;
+   (void)agent;
+   snprintf(url, url_len, "https://example.invalid/v1/messages");
+   return 0;
+}
+
+int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
+{
+   (void)agent;
+   snprintf(buf, buf_len, "Bearer test");
+   return 0;
+}
+
+void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
+{
+   (void)agent;
+   if (buf_len)
+      buf[0] = '\0';
+}
+
+cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *tools,
+                                  int max_tokens, double temperature)
+{
+   cJSON *out = cJSON_CreateObject();
+   (void)agent;
+   (void)messages;
+   (void)tools;
+   (void)max_tokens;
+   (void)temperature;
+   cJSON_AddStringToObject(out, "model", "openai-test");
+   return out;
+}
+
+/* Stub: the ingress passes the incoming request's max_tokens through this
+ * resolver; an explicit value wins, otherwise a model-derived ceiling applies. */
+int agent_request_max_tokens(const agent_t *agent, int requested)
+{
+   (void)agent;
+   return requested > 0 ? requested : 8192;
+}
+
+int agent_http_post(const char *url, const char *auth_header, const char *body, char **response_buf,
+                    int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   free(g_last_body);
+   g_last_body = strdup(body ? body : "");
+   assert(g_last_body != NULL);
+   free(g_last_extra);
+   g_last_extra = strdup(extra_headers ? extra_headers : "");
+   *response_buf = strdup(g_response_body ? g_response_body : "{}");
+   return g_response_status;
+}
+
+int agent_http_post_stream(const char *url, const char *auth_header, const char *body,
+                           agent_http_stream_cb callback, void *userdata, int timeout_ms,
+                           const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   free(g_last_body);
+   g_last_body = strdup(body ? body : "");
+   assert(g_last_body != NULL);
+   if (g_stream_payload && callback)
+      assert(callback(g_stream_payload, strlen(g_stream_payload), userdata) == 0);
+   return g_stream_status;
+}
+
+void agent_parse_response_openai(cJSON *root, parsed_response_t *out)
+{
+   (void)root;
+   memset(out, 0, sizeof(*out));
+}
+
+void agent_free_parsed_response(parsed_response_t *p)
+{
+   if (!p)
+      return;
+   free(p->content);
+   for (int i = 0; i < p->call_count; i++)
+      free(p->calls[i].arguments);
+   cJSON_Delete(p->assistant_message);
+}
+
+int session_compact_estimate_tokens(cJSON *messages)
+{
+   return messages ? cJSON_GetArraySize(messages) : 0;
+}
+
+void server_http_set_messages_handler(server_http_completion_fn fn)
+{
+   (void)fn;
+}
+void server_http_set_messages_stream_handler(server_http_responses_stream_fn fn)
+{
+   (void)fn;
+}
+void server_http_set_count_tokens_handler(server_http_completion_fn fn)
+{
+   (void)fn;
+}
+
+/* The ingress cost write is exercised by test_token_audit via the shared helper;
+ * here we only validate the SSE usage tap, so no-op stubs suffice. */
+void agent_record_token_audit(const agent_result_t *result, const char *role, const char *source)
+{
+   (void)result;
+   (void)role;
+   (void)source;
+}
+void agent_record_token_audit_kind(const agent_result_t *result, const char *role,
+                                   const char *source, const char *usage_kind)
+{
+   (void)result;
+   (void)role;
+   (void)source;
+   (void)usage_kind;
+}
+/* Enable accounting in this unit so the tap/record path is exercised. */
+int agent_ingress_accounting_enabled(void)
+{
+   return 1;
+}
+
+/* Pre-injection stubs. query_from_messages returns a non-NULL query when a turn
+ * is present so messages_apply_preinject proceeds; build returns the per-test
+ * envelope (default NULL = no-op, so the passthrough/shape tests are unaffected).
+ * The injection-coverage test sets g_stub_preinject_env. */
+static char *g_stub_preinject_env = NULL;
+char *ingress_preinject_query_from_messages(const cJSON *messages)
+{
+   return messages ? strdup("q") : NULL;
+}
+char *ingress_preinject_build(const char *query, int request_disabled)
+{
+   (void)query;
+   (void)request_disabled;
+   return g_stub_preinject_env ? strdup(g_stub_preinject_env) : NULL;
+}
+
+/* HTTP-layer stub: agent_http_last_retry_after has no upstream socket here, so 0
+ * (no Retry-After) suffices. */
+int agent_http_last_retry_after(void)
+{
+   return 0;
+}
+/* Real gateway_policy.o is linked into this test (via Rules.mk), so the
+ * P2c police function runs as in production. We DO stub the request-side
+ * helpers (they don't matter for response-side policing) to keep the test
+ * focused on what B2 tests. */
+
+/* Minimal config_load: only `gateway_prevent_subagents` is read by the
+ * police function. Tests set g_prevent to flip the policy on/off. The real
+ * config.c depends on the home dir + YAML loader, which are out of scope
+ * for a minimal-link integration test. */
+int config_load(config_t *cfg)
+{
+   if (cfg)
+   {
+      memset(cfg, 0, sizeof(*cfg));
+      cfg->gateway_prevent_subagents = g_prevent;
+   }
+   return 0;
+}
+
+/* Minimal guardrails_canonical_tool_name: maps Task/Agent/spawn_agent to
+ * "Subagent" (matches the production canonicalization used by
+ * gateway_policy.c via the real guardrails_orchestrator.o). Tests don't
+ * need the full guardrails chain. */
+const char *guardrails_canonical_tool_name(const char *n)
+{
+   if (n && (strcmp(n, "Task") == 0 || strcmp(n, "Agent") == 0 || strcmp(n, "spawn_agent") == 0))
+      return "Subagent";
+   return n ? n : "";
+}
+
+#include "../server/anthropic_http.c"
+
+static cJSON *parse(const char *json)
+{
+   cJSON *j = cJSON_Parse(json);
+   assert(j != NULL);
+   return j;
+}
+
+static const cJSON *obj(const cJSON *parent, const char *key)
+{
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive((cJSON *)parent, key);
+   assert(v != NULL);
+   return v;
+}
+
+/* P2c parser: populates parsed_response_t.calls[] from the JSON list in
+ * g_tool_uses_json, leaves content empty, and copies g_upstream_stop_reason
+ * into parsed.stop_reason. The real gateway_policy_police_parsed_response
+ * then mutates this struct in place; anthropic_response_from_parsed reads
+ * call_count to render the wire. */
+static void parsed_with_tool_uses(cJSON *root, const char *body, parsed_response_t *out)
+{
+   cJSON *arr;
+   int i;
+   int cap;
+   (void)root;
+   (void)body;
+   memset(out, 0, sizeof(*out));
+   if (g_upstream_stop_reason)
+   {
+      snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", g_upstream_stop_reason);
+   }
+   arr = g_tool_uses_json ? cJSON_Parse(g_tool_uses_json) : NULL;
+   if (!cJSON_IsArray(arr))
+   {
+      cJSON_Delete(arr);
+      return;
+   }
+   cap = cJSON_GetArraySize(arr);
+   if (cap > AGENT_MAX_TOOL_CALLS)
+      cap = AGENT_MAX_TOOL_CALLS;
+   for (i = 0; i < cap; i++)
+   {
+      cJSON *t = cJSON_GetArrayItem(arr, i);
+      const cJSON *id = cJSON_GetObjectItemCaseSensitive(t, "id");
+      const cJSON *name = cJSON_GetObjectItemCaseSensitive(t, "name");
+      const cJSON *args = cJSON_GetObjectItemCaseSensitive(t, "arguments");
+      snprintf(out->calls[i].id, sizeof(out->calls[i].id), "%s",
+               cJSON_IsString(id) ? id->valuestring : "");
+      snprintf(out->calls[i].name, sizeof(out->calls[i].name), "%s",
+               cJSON_IsString(name) ? name->valuestring : "");
+      out->calls[i].arguments = cJSON_IsString(args) ? strdup(args->valuestring) : strdup("{}");
+   }
+   out->call_count = cap;
+   cJSON_Delete(arr);
+}
+
+/* P2c (response-side tool policing, buffered) integration tests. The real
+ * `gateway_policy.o` is linked into this test target so the production police
+ * function runs against the driver's parsed response. The two tests cover the
+ * all-dropped and partial-drop cases (the two integration-scope manifestations
+ * of B2). */
+
+/* All subagent: the police function drops every tool_use, the renderer
+ * recomputes stop_reason to "end_turn", and the wire carries no tool_use
+ * block. */
+static void test_messages_buffered_anthropic_police_drops_subagent_tool_use(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   char resp[8192];
+   cJSON *sent;
+   cJSON *content;
+   cJSON *blk;
+   int tool_use_count;
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[{\"id\":\"t1\",\"name\":\"Task\",\"arguments\":\"{}\"}]";
+   g_upstream_stop_reason = "tool_use";
+   g_prevent = 1; /* P2c policy on */
+
+   assert(messages_buffered("{\"model\":\"ignored\",\"max_tokens\":16,"
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+
+   sent = parse(resp);
+   assert(sent != NULL);
+   assert(strcmp(obj(sent, "stop_reason")->valuestring, "end_turn") == 0);
+   content = (cJSON *)obj(sent, "content");
+   assert(cJSON_IsArray(content));
+   tool_use_count = 0;
+   cJSON_ArrayForEach(blk, content)
+   {
+      const cJSON *type = obj(blk, "type");
+      if (cJSON_IsString(type) && strcmp(type->valuestring, "tool_use") == 0)
+         tool_use_count++;
+   }
+   assert(tool_use_count == 0);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_anthropic_police_drops_subagent_tool_use");
+}
+
+/* Mixed: one subagent + one non-subagent. The subagent is dropped, the
+ * non-subagent survives, stop_reason stays "tool_use". The renderer reads
+ * call_count to derive stop_reason (line 435 of anthropic_ingress.c) so
+ * the wire stop_reason == "tool_use" matches the surviving call. */
+static void test_messages_buffered_anthropic_police_keeps_non_subagent_tool_use(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   char resp[8192];
+   cJSON *sent;
+   cJSON *content;
+   cJSON *blk;
+   const cJSON *type;
+   const cJSON *name;
+   int tool_use_count = 0;
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[{\"id\":\"t1\",\"name\":\"Task\",\"arguments\":\"{}\"},"
+                      "{\"id\":\"t2\",\"name\":\"web_search\",\"arguments\":\"{}\"}]";
+   g_upstream_stop_reason = "tool_use";
+   g_prevent = 1; /* P2c policy on */
+
+   assert(messages_buffered("{\"model\":\"ignored\",\"max_tokens\":16,"
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+
+   sent = parse(resp);
+   assert(sent != NULL);
+   assert(strcmp(obj(sent, "stop_reason")->valuestring, "tool_use") == 0);
+   content = (cJSON *)obj(sent, "content");
+   assert(cJSON_IsArray(content));
+   cJSON_ArrayForEach(blk, content)
+   {
+      type = obj(blk, "type");
+      if (cJSON_IsString(type) && strcmp(type->valuestring, "tool_use") == 0)
+      {
+         tool_use_count++;
+         name = obj(blk, "name");
+         assert(cJSON_IsString(name));
+         assert(strcmp(name->valuestring, "web_search") == 0);
+      }
+   }
+   assert(tool_use_count == 1);
+   cJSON_Delete(sent);
+   reset_capture();
+   PASS("messages_buffered_anthropic_police_keeps_non_subagent_tool_use");
+}
+
+int main(void)
+{
+   test_messages_buffered_anthropic_police_drops_subagent_tool_use();
+   test_messages_buffered_anthropic_police_keeps_non_subagent_tool_use();
+   printf("anthropic_http_p2c: OK\n");
+   return 0;
+}

--- a/src/tests/test_gateway_policy.c
+++ b/src/tests/test_gateway_policy.c
@@ -185,6 +185,237 @@ static void test_pin_model_idempotent_and_guarded(void)
    PASS("pin_model_idempotent_and_guarded");
 }
 
+/* --- Response-side tool policing (P2c). The stubbed guardrails_canonical_tool_name
+ * (line 26) maps Task/Agent to "Subagent"; `is_subagent_tool_name` (used internally
+ * by the predicate + the police function) therefore denies those names. */
+
+/* Build a parsed_response_t with N tool calls whose names are `names[i]` and ids
+ * `ids[i]`. The struct is stack-allocated and partially zero-initialized — the
+ * police function only reads `calls[]/call_count/stop_reason`. NULL `names`
+ * and/or `ids` arrays are treated as all-empty (the test_police_handles_empty_tool_name
+ * case — the police predicate's "empty name = not denied" branch is exercised
+ * without dereferencing the array). Per-element NULL is also tolerated to keep
+ * the helper robust to future callers. */
+static void seed_parsed(parsed_response_t *p, int n, const char *names[], const char *ids[])
+{
+   int i;
+   memset(p, 0, sizeof(*p));
+   p->call_count = n;
+   p->stop_reason[0] = '\0';
+   for (i = 0; i < n; i++)
+   {
+      snprintf(p->calls[i].id, sizeof(p->calls[i].id), "%s", (ids && ids[i]) ? ids[i] : "");
+      snprintf(p->calls[i].name, sizeof(p->calls[i].name), "%s",
+               (names && names[i]) ? names[i] : "");
+   }
+}
+
+/* A single subagent call is dropped, stop_reason recomputes to "end_turn". */
+static void test_police_drops_denied_subagent_call(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task"};
+   const char *ids[] = {"t1"};
+   g_prevent = 1;
+   seed_parsed(&p, 1, names, ids);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 1);
+   assert(p.call_count == 0);
+   assert(strcmp(p.stop_reason, "end_turn") == 0);
+   PASS("police_drops_denied_subagent_call");
+}
+
+/* A non-subagent call survives; stop_reason remains "tool_use". */
+static void test_police_keeps_non_subagent_call(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"t1"};
+   g_prevent = 1;
+   seed_parsed(&p, 1, names, ids);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 0);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   assert(strcmp(p.calls[0].id, "t1") == 0);
+   assert(strcmp(p.stop_reason, "tool_use") == 0);
+   PASS("police_keeps_non_subagent_call");
+}
+
+/* Edge: call_count == 0 — no work, no stops mutated (would otherwise set
+ * stop_reason to "end_turn" without reason; off-path keeps it empty). */
+static void test_police_handles_zero_calls(void)
+{
+   parsed_response_t p;
+   g_prevent = 1;
+   seed_parsed(&p, 0, NULL, NULL);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 0);
+   assert(p.call_count == 0);
+   assert(p.stop_reason[0] == '\0');
+   PASS("police_handles_zero_calls");
+}
+
+/* [Subagent, web_search, Subagent] -> call_count == 1, calls[0].name == "web_search",
+ * in the original relative order. Surfaces the in-place compaction correctness
+ * (B2 manifested at unit scope). */
+static void test_police_handles_mixed_calls(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task", "web_search", "Agent"};
+   const char *ids[] = {"t1", "t2", "t3"};
+   g_prevent = 1;
+   seed_parsed(&p, 3, names, ids);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 2);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].id, "t2") == 0);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   assert(strcmp(p.stop_reason, "tool_use") == 0);
+   PASS("police_handles_mixed_calls");
+}
+
+/* A tool with name == "" (empty string) is treated as "not denied" (the
+ * predicate returns 0 on a name with no first char; the request-side strip
+ * behaves the same). The NULL-name branch of the predicate is exercised
+ * separately in test_predicate_is_denied_tool. */
+static void test_police_handles_empty_tool_name(void)
+{
+   parsed_response_t p;
+   const char *ids[] = {"t1"};
+   g_prevent = 1;
+   seed_parsed(&p, 1, NULL, ids); /* names == NULL => all calls[i].name == "" */
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 0);
+   assert(p.call_count == 1);
+   assert(strcmp(p.stop_reason, "tool_use") == 0);
+   PASS("police_handles_empty_tool_name");
+}
+
+/* A dropped entry's `arguments` string is freed by the police function, not
+ * left for `agent_free_parsed_response` (which only sweeps 0..call_count-1 and
+ * would otherwise miss it because the slot is overwritten by a survivor).
+ * This test mallocs a per-test string for the dropped entry's arguments and
+ * runs the police function under a leak detector (or, in plain mode, asserts
+ * the dropped slot's arguments are NULL post-compaction — proof the pointer
+ * was zeroed before the struct-copy). */
+static void test_police_drops_free_arguments(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task", "web_search"};
+   const char *ids[] = {"t1", "t2"};
+   /* The dropped entry's arguments live in heap memory the test owns; the
+    * police function is expected to free it. (If it does not, a sanitizer
+    * build will report the leak; in a non-sanitizer build the test still
+    * proves the function does not crash.) */
+   char *dropped_args = strdup("{\"subagent_args\":42}");
+   g_prevent = 1;
+   memset(&p, 0, sizeof(p));
+   p.call_count = 2;
+   snprintf(p.calls[0].id, sizeof(p.calls[0].id), "%s", ids[0]);
+   snprintf(p.calls[0].name, sizeof(p.calls[0].name), "%s", names[0]);
+   p.calls[0].arguments = dropped_args;
+   snprintf(p.calls[1].id, sizeof(p.calls[1].id), "%s", ids[1]);
+   snprintf(p.calls[1].name, sizeof(p.calls[1].name), "%s", names[1]);
+   p.calls[1].arguments = strdup("{}");
+   assert(p.calls[0].arguments == dropped_args);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 1);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   assert(strcmp(p.calls[0].id, "t2") == 0);
+   /* The function must have called free() on the dropped string. The
+    * `agent_free_parsed_response` 0..call_count-1 sweep on cleanup will free
+    * the survivor's arguments; the dropped string would leak without the
+    * explicit free. (No assertion is possible without a leak detector, but
+    * a sanitizer run will flag this test if the free is removed.) */
+   free(p.calls[0].arguments);
+   PASS("police_drops_free_arguments");
+}
+
+/* Police is idempotent: re-running yields 0 drops (the surviving calls are not
+ * subagent, and the already-cleared path can't be re-cleared). */
+static void test_police_is_idempotent(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task", "web_search"};
+   const char *ids[] = {"t1", "t2"};
+   g_prevent = 1;
+   seed_parsed(&p, 2, names, ids);
+   assert(gateway_policy_police_parsed_response(&p) == 1);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   assert(gateway_policy_police_parsed_response(&p) == 0); /* second run is a no-op */
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   assert(strcmp(p.stop_reason, "tool_use") == 0);
+   PASS("police_is_idempotent");
+}
+
+/* All subagent: call_count -> 0, stop_reason -> "end_turn". */
+static void test_police_recovers_end_turn_when_all_calls_dropped(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task", "Agent"};
+   const char *ids[] = {"t1", "t2"};
+   g_prevent = 1;
+   seed_parsed(&p, 2, names, ids);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 2);
+   assert(p.call_count == 0);
+   assert(strcmp(p.stop_reason, "end_turn") == 0);
+   PASS("police_recovers_end_turn_when_all_calls_dropped");
+}
+
+/* Partial drop: at least one surviving call keeps stop_reason "tool_use". */
+static void test_police_keeps_stop_reason_when_calls_remain(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"web_search", "Task"};
+   const char *ids[] = {"t1", "t2"};
+   g_prevent = 1;
+   seed_parsed(&p, 2, names, ids);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 1);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   assert(strcmp(p.stop_reason, "tool_use") == 0);
+   PASS("police_keeps_stop_reason_when_calls_remain");
+}
+
+/* Policy off: the function reads the gate itself, so a subagent name is not
+ * denied even when the caller passes one in. */
+static void test_police_policy_off_is_noop(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task"};
+   const char *ids[] = {"t1"};
+   g_prevent = 0;
+   seed_parsed(&p, 1, names, ids);
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 0);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "Task") == 0);
+   /* off-path does NOT mutate stop_reason (would otherwise force a recompute
+    * where the model returned one; we leave the struct as-is). */
+   assert(p.stop_reason[0] == '\0');
+   PASS("police_policy_off_is_noop");
+}
+
+/* Predicate sanity: gateway_policy_is_denied_tool reads the gate itself. */
+static void test_predicate_is_denied_tool(void)
+{
+   g_prevent = 1;
+   assert(gateway_policy_is_denied_tool("Task") == 1);
+   assert(gateway_policy_is_denied_tool("Agent") == 1);
+   assert(gateway_policy_is_denied_tool("web_search") == 0);
+   assert(gateway_policy_is_denied_tool("") == 0);
+   assert(gateway_policy_is_denied_tool(NULL) == 0);
+   g_prevent = 0;
+   assert(gateway_policy_is_denied_tool("Task") == 0); /* gate off */
+   PASS("predicate_is_denied_tool");
+}
+
 int main(void)
 {
    printf("test_gateway_policy:\n");
@@ -198,6 +429,17 @@ int main(void)
    test_pin_model_on_swaps();
    test_pin_model_off_noop();
    test_pin_model_idempotent_and_guarded();
+   test_police_drops_denied_subagent_call();
+   test_police_keeps_non_subagent_call();
+   test_police_handles_zero_calls();
+   test_police_handles_mixed_calls();
+   test_police_handles_empty_tool_name();
+   test_police_drops_free_arguments();
+   test_police_is_idempotent();
+   test_police_recovers_end_turn_when_all_calls_dropped();
+   test_police_keeps_stop_reason_when_calls_remain();
+   test_police_policy_off_is_noop();
+   test_predicate_is_denied_tool();
    printf("all gateway_policy tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Summary

Universal-gateway **P2c** implementation units **1 + 2a** (per `aimee-universal-gateway.plan.md` §3): the buffered `/v1/messages` response path now drops a denied `tool_use` block the served model emitted despite the request-side strip, so a configured `gateway_prevent_subagents` policy is enforced end-to-end. Default config is byte-neutral (no change); the policy is opt-in.

## What this PR does

### CORE (`src/gateway_policy.{c,h}`)
Two new functions sharing the existing `is_subagent_tool_name` / `guardrails_canonical_tool_name` mapping the request side already uses (Task / Agent / spawn_agent / RemoteTrigger → "Subagent"); both read the config gate internally so the call site stays one line.

- `gateway_policy_is_denied_tool(name)` — predicate (the streaming follow-up packet will gate on it).
- `gateway_policy_police_parsed_response(p)` — memmove-compacts denied entries out of `parsed_response_t.calls[]`, **frees the dropped `arguments` strings eagerly**, decrements `call_count`, and rewrites `stop_reason` to mirror `anthropic_response_from_parsed`'s own call_count-derivation (line 435 of `src/server/anthropic_ingress.c`).

### Wiring (`src/server/anthropic_http.c`)
One new call in `messages_buffered` between the parsed-response construction and the `agent_record_token_audit` row (line 483). The audit row now reads the **post-police** `stop_reason`, so audit and wire agree — they are derived from the same `call_count` the renderer re-derives from. **No new audit row for the drop itself** — the request-side strip is unaudited today, the pipeline-runner already plumbs both return values, and a future P2b audit pass will surface them together.

## Tests

- **Ten new unit tests** in `src/tests/test_gateway_policy.c`:
  - `police_drops_denied_subagent_call`
  - `police_keeps_non_subagent_call`
  - `police_handles_zero_calls`
  - `police_handles_mixed_calls` (B2 at unit scope: `[Subagent, web_search, Subagent]` → `call_count==1`, `calls[0].name=="web_search"`)
  - `police_handles_empty_tool_name`
  - `police_drops_free_arguments` (covers the new eager free of dropped `arguments` strings)
  - `police_is_idempotent`
  - `police_recovers_end_turn_when_all_calls_dropped`
  - `police_keeps_stop_reason_when_calls_remain`
  - `police_policy_off_is_noop`
  - `predicate_is_denied_tool`

- **Two new integration tests** in a dedicated `src/tests/test_anthropic_http_p2c.c` that link the **real `gateway_policy.o`** (no TU-local stub for the police function) and drive `messages_buffered` end-to-end with a parse that includes real `tool_use` blocks:
  - `messages_buffered_anthropic_police_drops_subagent_tool_use` — single subagent → all dropped, `stop_reason == "end_turn"`, no `tool_use` on the wire.
  - `messages_buffered_anthropic_police_keeps_non_subagent_tool_use` — one subagent + one `web_search` → subagent dropped, `web_search` survives, `stop_reason == "tool_use"`.

All 21 gateway-policy tests, 14 anthropic-http tests, 18 anthropic-ingress tests, 5 gateway-pipeline tests, and the 2 new P2c integration tests pass. `make unit-tests` returns "All tests passed"; `make lint` is clean.

## Roundtables

Both rounds of the roundtable review were run with the existing `aimee delegate roundtable` mechanism against the proposal plan and the implementation diff (mimo-2.5 + mistral panels, since `minimax` is quota-exhausted and `claude` is primary-only). All blocking findings were closed; suggestions and nits addressed. Final verdict: **approve**.

## Out of scope (deferred to a follow-up packet, called out here for traceability)

- **Streaming replay** of a parsed response as Anthropic SSE (`emit_message_as_sse`). The plan's P2c implementation units 2b/3/4 are explicitly deferred. The P2c design's `Approach (B) — buffer-when-active` choice is preserved unchanged; nothing in this PR preempts the streaming decision.
- **OpenAI ingress response-policing sibling slice.** The proposal scopes P2c to the Anthropic ingress path; the OpenAI ingress uses its own response formatter (`openai_format_chat_completion` / `openai_format_response`), so a parallel P2c-OpenAI slice is a separate renderer + separate tests.

