### PR TITLE
feat(gateway): serve /v1/messages from a tmux claude-oauth CLI (warm-pool, streaming)

### DIFF
--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -24,6 +24,16 @@ int agent_execute_session_with_tools(const agent_t *agent, const agent_network_t
 int agent_execute(const agent_t *agent, const char *system_prompt, const char *user_prompt,
                   int max_tokens, double temperature, agent_result_t *out);
 
+/* Run one turn against a tmux-hosted CLI agent (backend AGENT_BACKEND_TMUX_CLI):
+ * drives the vendor CLI (e.g. `claude`, logged in via subscription OAuth) over a
+ * tmux pane, scrapes the reply, and returns it as plain text in out->response
+ * (caller frees). Returns 0 on success; <0 on failure (out->error set). The pane
+ * is keyed on the bound session id (session_id_set_override) so concurrent turns
+ * are isolated. Defined in posix/agent_runtime_tmux.c. */
+int agent_execute_cli_session(const agent_t *agent, const agent_network_t *network,
+                              const char *system_prompt, const char *user_prompt, int max_tokens,
+                              double temperature, agent_result_t *out);
+
 int agent_run(agent_config_t *cfg, const char *role, const char *system_prompt,
               const char *user_prompt, int max_tokens, agent_result_t *out);
 

--- a/src/headers/anthropic_ingress.h
+++ b/src/headers/anthropic_ingress.h
@@ -37,6 +37,15 @@ char *anthropic_system_to_text(const struct cJSON *req);
  * Returns NULL on malformed input (messages not an array). */
 struct cJSON *anthropic_messages_to_openai(const struct cJSON *messages, const char *system_text);
 
+/* Flatten an Anthropic "messages" array into a single plain-text transcript
+ * suitable for a one-shot CLI turn (the tmux claude-oauth ingress path). Each
+ * turn is rendered as "User: <text>" / "Assistant: <text>", turns joined with
+ * "\n\n". Only {type:"text"} content blocks are included; image / tool_use /
+ * tool_result blocks are skipped (the CLI cannot round-trip the Anthropic tool
+ * protocol). Returns a newly malloc'd string (caller frees), or NULL when there
+ * is no renderable text. */
+char *anthropic_messages_to_transcript(const struct cJSON *messages);
+
 /* Convert an Anthropic "tools" array ([{name,description,input_schema}]) into
  * an OpenAI tools array ([{type:"function",function:{name,description,
  * parameters}}]). Returns a new array (caller owns), or NULL when there are no
@@ -83,8 +92,42 @@ anthropic_stream_xlate_t *anthropic_stream_begin(const char *msg_id, const char 
  * ignored (terminal closure happens in anthropic_stream_finish). */
 void anthropic_stream_feed_openai(anthropic_stream_xlate_t *st, const char *data_json);
 
+/* Emit `text` as a text content block on an in-progress stream: opens a text
+ * block (closing any open tool block first), then emits one text_delta. The
+ * block is left open for anthropic_stream_finish to close. For producers that
+ * already hold the full assembled text (e.g. the CLI-backed ingress path)
+ * rather than OpenAI chunks. No-op on NULL/empty input. */
+void anthropic_stream_emit_text(anthropic_stream_xlate_t *st, const char *text);
+
 /* Close any open content block and emit message_delta + message_stop. */
 void anthropic_stream_finish(anthropic_stream_xlate_t *st);
+
+/* Replay a fully-parsed provider reply (`anthropic_response_from_parsed`
+ * equivalent) as a well-formed Anthropic SSE sequence. Used by the streaming
+ * /v1/messages paths when the gateway response-side tool-policing policy
+ * (`gateway_prevent_subagents`) is active: the upstream is buffered to
+ * completion, the police function compacts `parsed.calls[]`, and this helper
+ * replays the policed struct as if the per-block translator had been
+ * streaming. Pure (no I/O); deterministic; unit-testable with a captured
+ * emit. Mirrors `anthropic_response_from_parsed`'s wire shape:
+ *   message_start (with usage: input_tokens, cache_creation_input_tokens,
+ *                  cache_read_input_tokens if non-zero)
+ *   one text content_block_start/.../stop pair — always emitted, even when
+ *                  parsed.content is empty/NULL, matching the buffered
+ *                  renderer's empty-text-block fallback (lines 427-433 of
+ *                  src/server/anthropic_ingress.c). Index 0.
+ *   one tool_use content_block_start + (input_json_delta)* + stop per
+ *                  surviving parsed.calls[0..call_count-1] entry. Indices
+ *                  1, 2, ... in original order.
+ *   message_delta (with parsed.stop_reason verbatim — see the police
+ *                  function's contract in gateway_policy.h — and usage
+ *                  output_tokens + cache_read_input_tokens if non-zero).
+ *   message_stop.
+ * `emit` matches the streaming translator's emit signature
+ * (`anthropic_sse_emit_fn`). `ctx` is the caller's transport context
+ * (passed through to `emit`). */
+void emit_message_as_sse(const parsed_response_t *parsed, const char *msg_id,
+                         const char *model, anthropic_sse_emit_fn emit, void *ctx);
 
 /* Read the usage tapped from the upstream OpenAI stream: the prompt count
  * (upstream-reported if seen, else the begin-time estimate), the completion

--- a/src/posix/agent_runtime_tmux.c
+++ b/src/posix/agent_runtime_tmux.c
@@ -66,8 +66,14 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
       }
       else
       {
+         /* Bound session, no delegation: a persistent per-session pane keyed
+          * "<sid>-cli". Honor the agent's session_reuse: a webchat primary turn
+          * (session_reuse=1) keeps the conversation pane alive across turns; a
+          * stateless caller that binds a unique per-request session id with
+          * session_reuse=0 (the /v1/messages CLI ingress) gets a one-shot pane
+          * that is torn down on completion, so unique-id panes don't accumulate. */
          sess_name = cli_session_make_name(aimee_sid, "cli");
-         reuse = 1;
+         reuse = agent->session_reuse;
       }
    }
    else if (agent->session_reuse)

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -187,6 +187,29 @@ static void agent_normalize_legacy_claude_cli(agent_t *ag)
    ag->cli_kind[0] = '\0';
 }
 
+/* A bare `provider: "claude"` / "claude-oauth" / "claude-code" agent with no
+ * explicit backend is the server-hosted Claude Code CLI driven over tmux — there
+ * is no HTTP Anthropic-subscription driver, and its endpoint is empty. Normalize
+ * it to the tmux-cli backend so every consumer (delegate dispatch in
+ * agent_runtime.c, and the /v1/messages ingress in anthropic_http.c) routes it to
+ * agent_execute_cli_session instead of attempting an HTTP call against an empty
+ * endpoint. Mirrors the field defaults of chat_agent_add_builtin_tmux_cli
+ * (server_compute.c). An explicitly configured backend (http/provider-cli/
+ * tmux-cli) always wins. */
+static void agent_normalize_claude_provider_cli(agent_t *ag)
+{
+   if (!ag || ag->backend[0])
+      return;
+   if (strcmp(ag->provider, "claude") != 0 && strcmp(ag->provider, "claude-oauth") != 0 &&
+       strcmp(ag->provider, "claude-code") != 0)
+      return;
+   snprintf(ag->backend, sizeof(ag->backend), "%s", AGENT_BACKEND_TMUX_CLI);
+   if (!ag->cli_cmd[0])
+      snprintf(ag->cli_cmd, sizeof(ag->cli_cmd), "%s", "claude");
+   if (!ag->auth_type[0])
+      snprintf(ag->auth_type, sizeof(ag->auth_type), "%s", "none");
+}
+
 static void agent_normalize_builtin_cost_tier(agent_t *ag)
 {
    if (!ag)
@@ -791,6 +814,7 @@ int agent_load_config(agent_config_t *cfg)
             ag->is_server_hosted = cJSON_IsTrue(v);
 
          agent_normalize_legacy_claude_cli(ag);
+         agent_normalize_claude_provider_cli(ag);
          agent_normalize_builtin_cost_tier(ag);
          cfg->agent_count++;
       }

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -467,6 +467,36 @@ static int ingress_write_tmp(const char *path, const char *data)
    return (w == n) ? 0 : -1;
 }
 
+/* Create a fresh, unpredictable, 0600 temp file (mkstemp: O_CREAT|O_EXCL, no
+ * symlink-follow) and write `data`; returns its path in `path_out`. Avoids the
+ * symlink/TOCTOU hazard of a predictable /tmp name on a shared host. Returns 0
+ * on success. */
+static int ingress_mktemp_write(char *path_out, size_t cap, const char *data)
+{
+   char tmpl[] = "/tmp/aimee-cli-sys-XXXXXX";
+   int fd = mkstemp(tmpl);
+   FILE *f;
+   size_t n, w;
+   if (fd < 0)
+      return -1;
+   f = fdopen(fd, "w");
+   if (!f)
+   {
+      close(fd);
+      unlink(tmpl);
+      return -1;
+   }
+   n = data ? strlen(data) : 0;
+   w = n ? fwrite(data, 1, n, f) : 0;
+   if (fclose(f) != 0 || w != n)
+   {
+      unlink(tmpl);
+      return -1;
+   }
+   snprintf(path_out, cap, "%s", tmpl);
+   return 0;
+}
+
 /* --- Warm CLI pane pool (latency, opt-in) --------------------------------
  *
  * Cold-starting a claude TUI per /v1/messages turn costs ~10-30s (process spawn
@@ -595,7 +625,7 @@ static int ingress_pool_checkout(const char *sys, const char *model, const char 
       snprintf(s->agent, sizeof(s->agent), "%s", agent ? agent : "");
       snprintf(s->name, sizeof(s->name), "aimee-pool-%u-%d",
                ingress_pool_key_hash(sys, model, agent), free_idx);
-      snprintf(s->path, sizeof(s->path), "/tmp/aimee-pool-sys-%d.txt", free_idx);
+      /* s->path stays empty: a secure temp file is mkstemp'd lazily on first use. */
       snprintf(name_out, name_cap, "%s", s->name);
       snprintf(path_out, path_cap, "%s", s->path);
       *is_reuse = 0;
@@ -699,15 +729,31 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
    exec_system = sysp ? sysp : "";
    if (sysp && sysp[0] && ingress_agent_is_claude_cli(ag))
    {
-      if (pool_idx < 0) /* one-shot: temp path keyed by request id (pool fills its own) */
-         snprintf(sys_path, sizeof(sys_path), "/tmp/aimee-ingress-sys-%s.txt", msg_id);
-      if (ingress_write_tmp(sys_path, sysp) == 0)
+      int okfile;
+      if (pool_idx >= 0)
+      {
+         /* The slot owns a secure temp file for its lifetime: mkstemp it on first
+          * use, then rewrite content in place on reuse (sticky /tmp + 0600 keep
+          * it ours). Unlinked when the slot is evicted. */
+         if (g_pool[pool_idx].path[0] == '\0')
+            okfile = ingress_mktemp_write(g_pool[pool_idx].path, sizeof(g_pool[pool_idx].path),
+                                          sysp) == 0;
+         else
+            okfile = ingress_write_tmp(g_pool[pool_idx].path, sysp) == 0;
+         if (okfile)
+            snprintf(sys_path, sizeof(sys_path), "%s", g_pool[pool_idx].path);
+      }
+      else
+      {
+         okfile = ingress_mktemp_write(sys_path, sizeof(sys_path), sysp) == 0;
+         have_sys_file = okfile; /* one-shot: unlinked after the turn */
+      }
+      if (okfile)
       {
          const char *base = ag->cli_cmd[0] ? ag->cli_cmd : "claude";
          snprintf(cli_agent.cli_cmd, sizeof(cli_agent.cli_cmd),
                   "%s --append-system-prompt \"$(cat %s)\"", base, sys_path);
          exec_system = ""; /* applied via the flag; do not also concat */
-         have_sys_file = 1;
       }
    }
 

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -30,7 +30,8 @@
 #include "server_http.h"
 #include "session_compact.h"
 #include "sse_parser.h"
-#include <stdio.h> /* temp-file write for --append-system-prompt */
+#include <pthread.h> /* warm-pane pool mutex */
+#include <stdio.h>   /* temp-file write for --append-system-prompt */
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
@@ -466,6 +467,184 @@ static int ingress_write_tmp(const char *path, const char *data)
    return (w == n) ? 0 : -1;
 }
 
+/* --- Warm CLI pane pool (latency, opt-in) --------------------------------
+ *
+ * Cold-starting a claude TUI per /v1/messages turn costs ~10-30s (process spawn
+ * + welcome-box settle). When AIMEE_INGRESS_CLI_POOL is set, panes are kept warm
+ * and reused across turns sharing the SAME (system prompt, model, agent) — the
+ * system prompt is a launch-time flag (--append-system-prompt), so it MUST be
+ * part of the key. Between reuses the conversation is reset with `/clear` so no
+ * history bleeds between unrelated turns; if that reset is at all uncertain the
+ * pane is discarded (the turn then retries onto a fresh pane). Off by default:
+ * the `/clear` reset is correctness-critical and wants E2E validation against
+ * the real CLI before it is trusted with multi-client data.
+ *
+ * Concurrency: a slot is exclusively held (in_use) between checkout and checkin,
+ * so concurrent turns with the same key take different slots (different tmux
+ * session names) and never share a pane. */
+#define INGRESS_POOL_MAX 8
+#define INGRESS_POOL_REUSE_CAP 50
+#define INGRESS_POOL_IDLE_TTL_SEC 300
+
+typedef struct
+{
+   int in_use;
+   int alive; /* a pane has been (or will be) created for this slot */
+   char *sys; /* full system prompt for exact match (heap); NULL when none */
+   char model[MAX_MODEL_LEN];
+   char agent[MAX_AGENT_NAME];
+   char name[CLI_SESSION_NAME_MAX]; /* stable tmux session id (the override) */
+   char path[MAX_PATH_LEN];         /* temp file backing --append-system-prompt */
+   int turns;                       /* reuse count */
+   long last_used;                  /* time() for idle reaping */
+} ingress_pool_slot_t;
+
+static ingress_pool_slot_t g_pool[INGRESS_POOL_MAX];
+static pthread_mutex_t g_pool_mu = PTHREAD_MUTEX_INITIALIZER;
+
+/* Kill a warm pane. Indirected through a pointer so unit tests can substitute a
+ * no-op and not depend on a live tmux. */
+static void ingress_pool_kill_real(const char *name)
+{
+   char cmd[CLI_SESSION_NAME_MAX + 64];
+   int rc;
+   snprintf(cmd, sizeof(cmd), "tmux kill-session -t '%s' 2>/dev/null", name);
+   rc = system(cmd);
+   (void)rc; /* best-effort */
+}
+static void (*g_pool_kill_fn)(const char *) = ingress_pool_kill_real;
+
+static int ingress_pool_enabled(void)
+{
+   const char *v = getenv("AIMEE_INGRESS_CLI_POOL");
+   return v && v[0] && v[0] != '0';
+}
+
+static int ingress_streq(const char *a, const char *b)
+{
+   return strcmp(a ? a : "", b ? b : "") == 0;
+}
+
+static unsigned ingress_pool_key_hash(const char *sys, const char *model, const char *agent)
+{
+   unsigned h = 5381;
+   const char *p;
+   for (p = sys ? sys : ""; *p; p++)
+      h = ((h << 5) + h) ^ (unsigned char)*p;
+   h = ((h << 5) + h) ^ '|';
+   for (p = model ? model : ""; *p; p++)
+      h = ((h << 5) + h) ^ (unsigned char)*p;
+   h = ((h << 5) + h) ^ '|';
+   for (p = agent ? agent : ""; *p; p++)
+      h = ((h << 5) + h) ^ (unsigned char)*p;
+   return h;
+}
+
+/* Kill the pane, drop the temp file, and clear the slot. Caller holds g_pool_mu. */
+static void ingress_pool_evict_locked(ingress_pool_slot_t *s)
+{
+   if (s->alive && s->name[0])
+      g_pool_kill_fn(s->name);
+   if (s->path[0])
+      unlink(s->path);
+   free(s->sys);
+   memset(s, 0, sizeof(*s));
+}
+
+/* Reserve a warm or fresh slot for (sys, model, agent). Returns the slot index
+ * (fills name/path) or -1 when the pool is full of in-use/non-matching slots
+ * (caller falls back to a one-shot pane). *is_reuse is 1 when the slot already
+ * has a live pane, so the caller must /clear before sending the real prompt. */
+static int ingress_pool_checkout(const char *sys, const char *model, const char *agent,
+                                 char *name_out, size_t name_cap, char *path_out, size_t path_cap,
+                                 int *is_reuse)
+{
+   long now = (long)time(NULL);
+   int i, free_idx = -1;
+
+   pthread_mutex_lock(&g_pool_mu);
+   for (i = 0; i < INGRESS_POOL_MAX; i++)
+      if (g_pool[i].alive && !g_pool[i].in_use &&
+          now - g_pool[i].last_used > INGRESS_POOL_IDLE_TTL_SEC)
+         ingress_pool_evict_locked(&g_pool[i]);
+
+   for (i = 0; i < INGRESS_POOL_MAX; i++)
+   {
+      ingress_pool_slot_t *s = &g_pool[i];
+      if (s->alive && !s->in_use && s->turns < INGRESS_POOL_REUSE_CAP && ingress_streq(s->sys, sys) &&
+          ingress_streq(s->model, model) && ingress_streq(s->agent, agent))
+      {
+         s->in_use = 1;
+         snprintf(name_out, name_cap, "%s", s->name);
+         snprintf(path_out, path_cap, "%s", s->path);
+         *is_reuse = 1;
+         pthread_mutex_unlock(&g_pool_mu);
+         return i;
+      }
+      if (free_idx < 0 && !s->in_use && !s->alive)
+         free_idx = i;
+   }
+   if (free_idx >= 0)
+   {
+      ingress_pool_slot_t *s = &g_pool[free_idx];
+      memset(s, 0, sizeof(*s));
+      s->in_use = 1;
+      s->alive = 1; /* the pane is created lazily by the first turn */
+      s->sys = (sys && sys[0]) ? strdup(sys) : NULL;
+      snprintf(s->model, sizeof(s->model), "%s", model ? model : "");
+      snprintf(s->agent, sizeof(s->agent), "%s", agent ? agent : "");
+      snprintf(s->name, sizeof(s->name), "aimee-pool-%u-%d",
+               ingress_pool_key_hash(sys, model, agent), free_idx);
+      snprintf(s->path, sizeof(s->path), "/tmp/aimee-pool-sys-%d.txt", free_idx);
+      snprintf(name_out, name_cap, "%s", s->name);
+      snprintf(path_out, path_cap, "%s", s->path);
+      *is_reuse = 0;
+      pthread_mutex_unlock(&g_pool_mu);
+      return free_idx;
+   }
+   pthread_mutex_unlock(&g_pool_mu);
+   return -1;
+}
+
+/* Return a slot: ok keeps it warm (turns++), !ok evicts it (pane dead/suspect). */
+static void ingress_pool_checkin(int idx, int ok)
+{
+   if (idx < 0 || idx >= INGRESS_POOL_MAX)
+      return;
+   pthread_mutex_lock(&g_pool_mu);
+   if (ok)
+   {
+      g_pool[idx].in_use = 0;
+      g_pool[idx].turns++;
+      g_pool[idx].last_used = (long)time(NULL);
+   }
+   else
+   {
+      ingress_pool_evict_locked(&g_pool[idx]);
+   }
+   pthread_mutex_unlock(&g_pool_mu);
+}
+
+/* Reset a reused pane's conversation with `/clear` so no history bleeds into the
+ * next turn. Streaming is suppressed for this throwaway turn. Returns the
+ * executor rc; a non-zero rc means the pane is gone/suspect and must NOT be
+ * reused. */
+static int ingress_cli_clear(agent_t *cli_agent)
+{
+   agent_result_t car;
+   cli_session_stream_cb_t pcb;
+   void *pud;
+   int crc;
+
+   memset(&car, 0, sizeof(car));
+   pcb = cli_session_get_stream_cb(&pud);
+   cli_session_set_stream_cb(NULL, NULL);
+   crc = agent_execute_cli_session(cli_agent, NULL, "", "/clear", 0, 0.0, &car);
+   cli_session_set_stream_cb(pcb, pud);
+   free(car.response);
+   return crc;
+}
+
 static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *err, size_t errlen,
                              int *rc_out)
 {
@@ -475,7 +654,7 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
    char *transcript =
        anthropic_messages_to_transcript(cJSON_GetObjectItemCaseSensitive(req, "messages"));
    const char *exec_system;
-   char sid[96];
+   char sid[CLI_SESSION_NAME_MAX];
    char sys_path[MAX_PATH_LEN];
    int have_sys_file = 0;
    int rc;
@@ -500,6 +679,17 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
       return NULL;
    }
 
+   /* Choose the pane: a warm pool slot (reused across turns sharing the same
+    * system prompt/model/agent) when pooling is enabled, else a unique one-shot
+    * pane torn down after the turn. */
+   int pool_idx = -1, is_reuse = 0;
+   if (ingress_pool_enabled() && ingress_agent_is_claude_cli(ag))
+      pool_idx = ingress_pool_checkout(sysp, ag->model, ag->name, sid, sizeof(sid), sys_path,
+                                       sizeof(sys_path), &is_reuse);
+   if (pool_idx < 0)
+      snprintf(sid, sizeof(sid), "aimee-ingress-%s", msg_id);
+   cli_agent.session_reuse = (pool_idx >= 0) ? 1 : 0;
+
    /* System-prompt fidelity for the claude CLI: deliver the client's system
     * prompt as a real --append-system-prompt rather than pasting it into the
     * user text. It is read from a temp file at launch ("$(cat <file>)") so
@@ -509,7 +699,8 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
    exec_system = sysp ? sysp : "";
    if (sysp && sysp[0] && ingress_agent_is_claude_cli(ag))
    {
-      snprintf(sys_path, sizeof(sys_path), "/tmp/aimee-ingress-sys-%s.txt", msg_id);
+      if (pool_idx < 0) /* one-shot: temp path keyed by request id (pool fills its own) */
+         snprintf(sys_path, sizeof(sys_path), "/tmp/aimee-ingress-sys-%s.txt", msg_id);
       if (ingress_write_tmp(sys_path, sysp) == 0)
       {
          const char *base = ag->cli_cmd[0] ? ag->cli_cmd : "claude";
@@ -520,15 +711,34 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
       }
    }
 
-   memset(&ar, 0, sizeof(ar));
-   snprintf(sid, sizeof(sid), "aimee-ingress-%s", msg_id);
    session_id_set_override(sid);
+
+   /* A reused warm pane carries the prior turn's conversation: reset it first. If
+    * the reset fails the pane is gone/suspect — discard it and fail this turn as
+    * retryable so the retry lands on a fresh pane; never send the real prompt
+    * onto a possibly-dirty pane. */
+   if (is_reuse && ingress_cli_clear(&cli_agent) != 0)
+   {
+      session_id_clear_override();
+      ingress_pool_checkin(pool_idx, 0);
+      free(sysp);
+      free(transcript);
+      snprintf(err, errlen, "warm pane reset failed");
+      *rc_out = -1;
+      return NULL;
+   }
+
+   memset(&ar, 0, sizeof(ar));
    rc = agent_execute_cli_session(&cli_agent, NULL, exec_system, transcript,
                                   agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
                                   jo_num(req, "temperature", 1.0), &ar);
    session_id_clear_override();
-   if (have_sys_file)
+
+   if (pool_idx >= 0)
+      ingress_pool_checkin(pool_idx, rc == 0 && ar.response && ar.response[0]);
+   else if (have_sys_file)
       unlink(sys_path);
+
    free(sysp);
    free(transcript);
 

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -29,10 +29,11 @@
 #include "server_http.h"
 #include "session_compact.h"
 #include "sse_parser.h"
+#include <stdio.h> /* temp-file write for --append-system-prompt */
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
-#include <unistd.h> /* access() for the claude-login pre-flight */
+#include <unistd.h> /* access()/unlink() for the claude-login pre-flight + sys-prompt temp */
 
 /* Resolve aimee's primary agent (the configured default, else the first
  * agent). Claude Code's requested model is intentionally ignored — switching
@@ -440,14 +441,34 @@ static void ingress_cli_record_audit(const agent_t *ag, const char *model)
  * panes; the agent's session_reuse is 0). On success returns the malloc'd reply
  * text (caller frees) and sets *rc_out = 0; on failure returns NULL, sets
  * *rc_out < 0, and fills `err`. */
+/* Write `data` to `path` (truncating). Returns 0 on success. Stages the system
+ * prompt for --append-system-prompt so arbitrary content never has to be escaped
+ * onto a command line. */
+static int ingress_write_tmp(const char *path, const char *data)
+{
+   FILE *f = fopen(path, "w");
+   size_t n, w;
+   if (!f)
+      return -1;
+   n = data ? strlen(data) : 0;
+   w = n ? fwrite(data, 1, n, f) : 0;
+   if (fclose(f) != 0)
+      return -1;
+   return (w == n) ? 0 : -1;
+}
+
 static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *err, size_t errlen,
                              int *rc_out)
 {
    agent_result_t ar;
+   agent_t cli_agent = *ag; /* per-request copy so cli_cmd can be shaped */
    char *sysp = anthropic_system_to_text(req);
    char *transcript =
        anthropic_messages_to_transcript(cJSON_GetObjectItemCaseSensitive(req, "messages"));
+   const char *exec_system;
    char sid[96];
+   char sys_path[MAX_PATH_LEN];
+   int have_sys_file = 0;
    int rc;
 
    err[0] = '\0';
@@ -458,13 +479,36 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
       *rc_out = -1;
       return NULL;
    }
+
+   /* System-prompt fidelity for the claude CLI: deliver the client's system
+    * prompt as a real --append-system-prompt rather than pasting it into the
+    * user text. It is read from a temp file at launch ("$(cat <file>)") so
+    * arbitrary content (newlines, quotes, $) is never re-parsed by the shell and
+    * never hits a command-line length limit. Falls back to concatenation
+    * (exec_system = sysp) for a non-claude CLI or when there is no system prompt. */
+   exec_system = sysp ? sysp : "";
+   if (sysp && sysp[0] && ingress_agent_is_claude_cli(ag))
+   {
+      snprintf(sys_path, sizeof(sys_path), "/tmp/aimee-ingress-sys-%s.txt", msg_id);
+      if (ingress_write_tmp(sys_path, sysp) == 0)
+      {
+         const char *base = ag->cli_cmd[0] ? ag->cli_cmd : "claude";
+         snprintf(cli_agent.cli_cmd, sizeof(cli_agent.cli_cmd),
+                  "%s --append-system-prompt \"$(cat %s)\"", base, sys_path);
+         exec_system = ""; /* applied via the flag; do not also concat */
+         have_sys_file = 1;
+      }
+   }
+
    memset(&ar, 0, sizeof(ar));
    snprintf(sid, sizeof(sid), "aimee-ingress-%s", msg_id);
    session_id_set_override(sid);
-   rc = agent_execute_cli_session(ag, NULL, sysp ? sysp : "", transcript,
+   rc = agent_execute_cli_session(&cli_agent, NULL, exec_system, transcript,
                                   agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
                                   jo_num(req, "temperature", 1.0), &ar);
    session_id_clear_override();
+   if (have_sys_file)
+      unlink(sys_path);
    free(sysp);
    free(transcript);
 

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -20,7 +20,8 @@
 #include "agent_types.h"
 #include "anthropic_ingress.h"
 #include "cJSON.h"
-#include "config.h" /* session_id_set_override / session_id_clear_override */
+#include "cli_session.h" /* stream-cb bridge for live CLI-ingress streaming */
+#include "config.h"      /* session_id_set_override / session_id_clear_override */
 #include "delegate_driver.h"
 #include "gateway_policy.h"
 #include "gateway_pipeline.h"
@@ -395,6 +396,14 @@ static void messages_apply_preinject(cJSON *req)
  * as an Anthropic buffered response / SSE stream. tools[]/tool_use round-trips
  * are out of scope; stop_reason is always "end_turn". */
 
+/* One retry on a transient empty/dead CLI turn (rc -1) — a cold pane that ate
+ * the first paste, etc. Bounded so a persistently-failing CLI fails fast. */
+#define INGRESS_MAX_ATTEMPTS 2
+/* Pathological-input guard for the rendered system+transcript bytes. The prompt
+ * is fed via a tmux load-buffer (file-backed, so not ARG_MAX-bound), so this is
+ * generous — it exists to reject absurd payloads, not to clamp real contexts. */
+#define INGRESS_MAX_PROMPT_BYTES (4 * 1024 * 1024)
+
 /* True when the agent launches a claude-family CLI — mirrors the is_claude
  * derivation in agent_execute_cli_session (cli_kind, else the agent name). */
 static int ingress_agent_is_claude_cli(const agent_t *ag)
@@ -480,6 +489,17 @@ static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *
       return NULL;
    }
 
+   /* Pathological-input guard: reject an absurd rendered prompt rather than risk
+    * wedging the paste / CLI. -100 maps to a 413 (buffered) / error event (stream). */
+   if ((sysp ? strlen(sysp) : 0) + strlen(transcript) > INGRESS_MAX_PROMPT_BYTES)
+   {
+      free(sysp);
+      free(transcript);
+      snprintf(err, errlen, "request too large (limit %d bytes)", INGRESS_MAX_PROMPT_BYTES);
+      *rc_out = -100;
+      return NULL;
+   }
+
    /* System-prompt fidelity for the claude CLI: deliver the client's system
     * prompt as a real --append-system-prompt rather than pasting it into the
     * user text. It is read from a temp file at launch ("$(cat <file>)") so
@@ -529,8 +549,8 @@ static int messages_cli_buffered(cJSON *req, agent_t *ag, const char *model, cha
    const cJSON *messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
    char msg_id[48];
    char err[512];
-   char *reply;
-   int rc, status;
+   char *reply = NULL;
+   int rc = -1, status;
    parsed_response_t parsed;
    cJSON *out;
 
@@ -541,9 +561,19 @@ static int messages_cli_buffered(cJSON *req, agent_t *ag, const char *model, cha
                          "the server-hosted claude CLI is not logged in");
 
    mint_msg_id(msg_id, sizeof(msg_id));
-   reply = ingress_cli_run(req, ag, msg_id, err, sizeof(err), &rc);
+   /* Retry once on a transient empty/dead turn (rc -1); other failures fail fast. */
+   for (int attempt = 0; attempt < INGRESS_MAX_ATTEMPTS; attempt++)
+   {
+      reply = ingress_cli_run(req, ag, msg_id, err, sizeof(err), &rc);
+      if (reply || rc != -1)
+         break;
+   }
    if (!reply)
+   {
+      if (rc == -100)
+         return write_error(resp, cap, 413, "request_too_large", err[0] ? err : "request too large");
       return write_error(resp, cap, 502, "api_error", err[0] ? err : "claude CLI turn failed");
+   }
 
    ingress_cli_record_audit(ag, model);
 
@@ -578,16 +608,51 @@ static void cli_stream_emit_error(server_http_sse_event_emit emit, void *ctx, co
    cJSON_Delete(o);
 }
 
-/* Streaming (stream:true) CLI ingress. Runs the CLI to completion, then emits the
- * reply as one Anthropic text block. Does NOT own `req` (caller frees). */
+/* Live-streaming bridge: the tmux executor invokes the thread-local stream cb
+ * with incremental clean-text deltas during recv; each is forwarded as an
+ * Anthropic text_delta. The Anthropic stream is begun lazily on the first delta,
+ * so a turn that fails before producing any output can still surface a standalone
+ * error event instead of a silent empty success stream. */
+typedef struct
+{
+   anthropic_stream_xlate_t *xl;
+   const char *msg_id;
+   const char *model;
+   server_http_sse_event_emit emit;
+   void *ctx;
+   size_t emitted;
+   int begun;
+} ingress_stream_bridge_t;
+
+static void ingress_stream_cb(const char *delta, void *ud)
+{
+   ingress_stream_bridge_t *b = (ingress_stream_bridge_t *)ud;
+   if (!delta || !delta[0])
+      return;
+   if (!b->begun)
+   {
+      b->xl = anthropic_stream_begin(b->msg_id, b->model, 0, b->emit, b->ctx);
+      b->begun = 1;
+   }
+   if (b->xl)
+   {
+      anthropic_stream_emit_text(b->xl, delta);
+      b->emitted += strlen(delta);
+   }
+}
+
+/* Streaming (stream:true) CLI ingress. Streams the CLI's incremental output live
+ * as Anthropic text deltas (see ingress_stream_bridge_t). Does NOT own `req`. */
 static void messages_cli_stream(cJSON *req, agent_t *ag, const char *model, const char *msg_id,
                                 server_http_sse_event_emit emit, void *ctx)
 {
    const cJSON *messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
    char err[512];
-   char *reply;
-   int rc;
-   anthropic_stream_xlate_t *xl;
+   char *reply = NULL;
+   int rc = -1, attempt;
+   ingress_stream_bridge_t bridge;
+   cli_session_stream_cb_t prev_cb;
+   void *prev_ud;
 
    if (!cJSON_IsArray(messages) || cJSON_GetArraySize(messages) == 0)
    {
@@ -601,23 +666,60 @@ static void messages_cli_stream(cJSON *req, agent_t *ag, const char *model, cons
       return;
    }
 
-   reply = ingress_cli_run(req, ag, msg_id, err, sizeof(err), &rc);
-   if (!reply)
+   memset(&bridge, 0, sizeof(bridge));
+   bridge.msg_id = msg_id;
+   bridge.model = model;
+   bridge.emit = emit;
+   bridge.ctx = ctx;
+
+   /* The stream cb is thread-local, so this only affects this ingress turn; save
+    * and restore any prior cb defensively. */
+   prev_cb = cli_session_get_stream_cb(&prev_ud);
+   cli_session_set_stream_cb(ingress_stream_cb, &bridge);
+   /* Retry a transient empty/dead turn only while nothing has streamed yet, so a
+    * retry can never duplicate already-emitted deltas. */
+   for (attempt = 0; attempt < INGRESS_MAX_ATTEMPTS; attempt++)
    {
-      cli_stream_emit_error(emit, ctx, "api_error", err[0] ? err : "claude CLI turn failed");
-      return;
+      reply = ingress_cli_run(req, ag, msg_id, err, sizeof(err), &rc);
+      if (reply || rc != -1 || bridge.begun)
+         break;
+   }
+   cli_session_set_stream_cb(prev_cb, prev_ud);
+
+   if (reply)
+   {
+      if (!bridge.begun)
+      {
+         /* Output arrived without an intermediate delta (a fast turn whose text
+          * only appeared in the final extract): begin now and emit it. */
+         bridge.xl = anthropic_stream_begin(msg_id, model, 0, emit, ctx);
+         bridge.begun = 1;
+         if (bridge.xl)
+            anthropic_stream_emit_text(bridge.xl, reply);
+      }
+      else if (bridge.xl && strlen(reply) > bridge.emitted)
+      {
+         /* Defensive: emit any tail the live deltas didn't cover by completion. */
+         anthropic_stream_emit_text(bridge.xl, reply + bridge.emitted);
+      }
+      ingress_cli_record_audit(ag, model);
+      free(reply);
    }
 
-   ingress_cli_record_audit(ag, model);
-
-   xl = anthropic_stream_begin(msg_id, model, 0, emit, ctx);
-   if (xl)
+   if (bridge.begun)
    {
-      anthropic_stream_emit_text(xl, reply);
-      anthropic_stream_finish(xl);
-      anthropic_stream_free(xl);
+      if (bridge.xl)
+      {
+         anthropic_stream_finish(bridge.xl);
+         anthropic_stream_free(bridge.xl);
+      }
    }
-   free(reply);
+   else
+   {
+      /* Hard failure, nothing streamed: a typed error, not a silent empty stream. */
+      cli_stream_emit_error(emit, ctx, rc == -100 ? "request_too_large" : "api_error",
+                            err[0] ? err : "claude CLI turn failed");
+   }
 }
 
 static int messages_buffered(const char *body, char *resp, int cap)

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -20,6 +20,7 @@
 #include "agent_types.h"
 #include "anthropic_ingress.h"
 #include "cJSON.h"
+#include "config.h" /* session_id_set_override / session_id_clear_override */
 #include "delegate_driver.h"
 #include "gateway_policy.h"
 #include "gateway_pipeline.h"
@@ -31,6 +32,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>
+#include <unistd.h> /* access() for the claude-login pre-flight */
 
 /* Resolve aimee's primary agent (the configured default, else the first
  * agent). Claude Code's requested model is intentionally ignored — switching
@@ -48,10 +50,15 @@ static agent_t *resolve_primary(agent_config_t *acfg)
    return ag;
 }
 
-/* Mint a "msg_<epoch>" id for the response/stream. */
+/* Mint a unique "msg_<epoch>_<seq>" id for the response/stream. The atomic
+ * sequence disambiguates concurrent requests within the same second — required
+ * for response-id uniqueness and, on the CLI ingress path, to key a distinct
+ * per-request tmux session id (so concurrent turns never share a pane). */
 static void mint_msg_id(char *buf, size_t n)
 {
-   snprintf(buf, n, "msg_%ld", (long)time(NULL));
+   static volatile int s_seq = 0;
+   int seq = __sync_fetch_and_add(&s_seq, 1);
+   snprintf(buf, n, "msg_%ld_%d", (long)time(NULL), seq);
 }
 
 /* Passthrough vs. translate is a property of the serving model, not a setting:
@@ -376,6 +383,199 @@ static void messages_apply_preinject(cJSON *req)
 
 /* --- Buffered: POST /v1/messages (stream:false) ------------------------- */
 
+/* --- CLI-backed ingress (tmux claude-oauth) -------------------------------
+ *
+ * When the resolved primary is a tmux-CLI agent (backend AGENT_BACKEND_TMUX_CLI,
+ * e.g. the server-hosted `claude` logged in via subscription OAuth), the
+ * /v1/messages turn is served by driving that CLI rather than an HTTP provider
+ * call. The request's system + message history are flattened into one prompt
+ * (the CLI is stateless per turn and cannot round-trip the Anthropic tool
+ * protocol), a one-shot tmux turn runs, and the plain-text reply is re-encoded
+ * as an Anthropic buffered response / SSE stream. tools[]/tool_use round-trips
+ * are out of scope; stop_reason is always "end_turn". */
+
+/* True when the agent launches a claude-family CLI — mirrors the is_claude
+ * derivation in agent_execute_cli_session (cli_kind, else the agent name). */
+static int ingress_agent_is_claude_cli(const agent_t *ag)
+{
+   const char *kind = ag->cli_kind[0] ? ag->cli_kind : ag->name;
+   return strcmp(ag->backend, AGENT_BACKEND_TMUX_CLI) == 0 &&
+          (strcmp(kind, "claude") == 0 || strncmp(kind, "claude-", 7) == 0);
+}
+
+/* Best-effort: has the server-hosted claude CLI completed its OAuth login (which
+ * writes ~/.claude/.credentials.json)? Returns 1 when logged in OR when we can't
+ * tell (never false-deny a working setup); 0 only when the agent is a claude CLI
+ * and the credential file is definitively absent. */
+static int ingress_claude_logged_in(const agent_t *ag)
+{
+   const char *home;
+   char path[MAX_PATH_LEN];
+   if (!ingress_agent_is_claude_cli(ag))
+      return 1;
+   home = getenv("HOME");
+   if (!home || !home[0])
+      return 1;
+   snprintf(path, sizeof(path), "%s/.claude/.credentials.json", home);
+   return access(path, R_OK) == 0;
+}
+
+/* Record a 0-token ingress audit row for a CLI-served turn (subscription-billed,
+ * no per-token usage), tagged distinctly so dashboards separate CLI from API. */
+static void ingress_cli_record_audit(const agent_t *ag, const char *model)
+{
+   agent_result_t aud;
+   if (!agent_ingress_accounting_enabled())
+      return;
+   memset(&aud, 0, sizeof(aud));
+   snprintf(aud.agent_name, sizeof(aud.agent_name), "%s", ag->name);
+   snprintf(aud.model, sizeof(aud.model), "%s", ag->model);
+   snprintf(aud.requested_model, sizeof(aud.requested_model), "%s", model ? model : "");
+   snprintf(aud.stop_reason, sizeof(aud.stop_reason), "end_turn");
+   agent_record_token_audit(&aud, "", "anthropic-ingress-cli");
+}
+
+/* Render system+messages into one prompt and run a single tmux CLI turn under a
+ * unique per-request session id (so concurrent turns get isolated, one-shot
+ * panes; the agent's session_reuse is 0). On success returns the malloc'd reply
+ * text (caller frees) and sets *rc_out = 0; on failure returns NULL, sets
+ * *rc_out < 0, and fills `err`. */
+static char *ingress_cli_run(cJSON *req, agent_t *ag, const char *msg_id, char *err, size_t errlen,
+                             int *rc_out)
+{
+   agent_result_t ar;
+   char *sysp = anthropic_system_to_text(req);
+   char *transcript =
+       anthropic_messages_to_transcript(cJSON_GetObjectItemCaseSensitive(req, "messages"));
+   char sid[96];
+   int rc;
+
+   err[0] = '\0';
+   if (!transcript)
+   {
+      free(sysp);
+      snprintf(err, errlen, "no renderable text in messages");
+      *rc_out = -1;
+      return NULL;
+   }
+   memset(&ar, 0, sizeof(ar));
+   snprintf(sid, sizeof(sid), "aimee-ingress-%s", msg_id);
+   session_id_set_override(sid);
+   rc = agent_execute_cli_session(ag, NULL, sysp ? sysp : "", transcript,
+                                  agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
+                                  jo_num(req, "temperature", 1.0), &ar);
+   session_id_clear_override();
+   free(sysp);
+   free(transcript);
+
+   if (rc == 0 && ar.response && ar.response[0])
+   {
+      *rc_out = 0;
+      return ar.response; /* caller frees */
+   }
+   snprintf(err, errlen, "%s", ar.error[0] ? ar.error : "claude CLI produced no response");
+   free(ar.response);
+   *rc_out = rc != 0 ? rc : -1; /* an empty reply is a failure */
+   return NULL;
+}
+
+/* Buffered (stream:false) CLI ingress. Does NOT own `req` (caller frees). */
+static int messages_cli_buffered(cJSON *req, agent_t *ag, const char *model, char *resp, int cap)
+{
+   const cJSON *messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   char msg_id[48];
+   char err[512];
+   char *reply;
+   int rc, status;
+   parsed_response_t parsed;
+   cJSON *out;
+
+   if (!cJSON_IsArray(messages) || cJSON_GetArraySize(messages) == 0)
+      return write_error(resp, cap, 400, "invalid_request_error", "messages is required");
+   if (!ingress_claude_logged_in(ag))
+      return write_error(resp, cap, 401, "authentication_error",
+                         "the server-hosted claude CLI is not logged in");
+
+   mint_msg_id(msg_id, sizeof(msg_id));
+   reply = ingress_cli_run(req, ag, msg_id, err, sizeof(err), &rc);
+   if (!reply)
+      return write_error(resp, cap, 502, "api_error", err[0] ? err : "claude CLI turn failed");
+
+   ingress_cli_record_audit(ag, model);
+
+   memset(&parsed, 0, sizeof(parsed));
+   parsed.content = reply; /* transfer ownership; freed by agent_free_parsed_response */
+   snprintf(parsed.stop_reason, sizeof(parsed.stop_reason), "end_turn");
+   out = anthropic_response_from_parsed(msg_id, model, &parsed);
+   status = write_json(out, resp, cap);
+   cJSON_Delete(out);
+   agent_free_parsed_response(&parsed);
+   return status;
+}
+
+/* Emit a standalone Anthropic SSE `error` event (mirrors relay_emit_transport_error's
+ * shape) so the client's stream reader sees a typed error rather than hanging. */
+static void cli_stream_emit_error(server_http_sse_event_emit emit, void *ctx, const char *type,
+                                  const char *message)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *e;
+   char *json;
+   cJSON_AddStringToObject(o, "type", "error");
+   e = cJSON_AddObjectToObject(o, "error");
+   cJSON_AddStringToObject(e, "type", type);
+   cJSON_AddStringToObject(e, "message", message);
+   json = cJSON_PrintUnformatted(o);
+   if (json)
+   {
+      emit(ctx, "error", json);
+      free(json);
+   }
+   cJSON_Delete(o);
+}
+
+/* Streaming (stream:true) CLI ingress. Runs the CLI to completion, then emits the
+ * reply as one Anthropic text block. Does NOT own `req` (caller frees). */
+static void messages_cli_stream(cJSON *req, agent_t *ag, const char *model, const char *msg_id,
+                                server_http_sse_event_emit emit, void *ctx)
+{
+   const cJSON *messages = cJSON_GetObjectItemCaseSensitive(req, "messages");
+   char err[512];
+   char *reply;
+   int rc;
+   anthropic_stream_xlate_t *xl;
+
+   if (!cJSON_IsArray(messages) || cJSON_GetArraySize(messages) == 0)
+   {
+      cli_stream_emit_error(emit, ctx, "invalid_request_error", "messages is required");
+      return;
+   }
+   if (!ingress_claude_logged_in(ag))
+   {
+      cli_stream_emit_error(emit, ctx, "authentication_error",
+                            "the server-hosted claude CLI is not logged in");
+      return;
+   }
+
+   reply = ingress_cli_run(req, ag, msg_id, err, sizeof(err), &rc);
+   if (!reply)
+   {
+      cli_stream_emit_error(emit, ctx, "api_error", err[0] ? err : "claude CLI turn failed");
+      return;
+   }
+
+   ingress_cli_record_audit(ag, model);
+
+   xl = anthropic_stream_begin(msg_id, model, 0, emit, ctx);
+   if (xl)
+   {
+      anthropic_stream_emit_text(xl, reply);
+      anthropic_stream_finish(xl);
+      anthropic_stream_free(xl);
+   }
+   free(reply);
+}
+
 static int messages_buffered(const char *body, char *resp, int cap)
 {
    cJSON *req = cJSON_Parse((body && body[0]) ? body : "{}");
@@ -420,6 +620,14 @@ static int messages_buffered(const char *body, char *resp, int cap)
    /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
     * the pointer cached above (line ~397) could now dangle. */
    model = jo_cstr(req, "model");
+   /* CLI-backed primary (tmux claude-oauth): serve from the CLI, not an HTTP
+    * provider call. The request pipeline (memory pre-injection, tool policing)
+    * has already run over req, so the rendered prompt sees any injected context. */
+   if (strcmp(ag->backend, AGENT_BACKEND_TMUX_CLI) == 0)
+   {
+      status = messages_cli_buffered(req, ag, model, resp, cap);
+      goto cleanup;
+   }
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -740,6 +948,14 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
    /* Re-read `model`: the model-pin stage may have replaced req's "model" node, so
     * the pointer cached at the top of this function could now dangle. */
    model = jo_cstr(req, "model");
+   /* CLI-backed primary (tmux claude-oauth): serve from the CLI. Always emits a
+    * well-formed Anthropic SSE sequence (or a typed error event) so the client's
+    * stream reader terminates cleanly. */
+   if (strcmp(ag->backend, AGENT_BACKEND_TMUX_CLI) == 0)
+   {
+      messages_cli_stream(req, ag, model, msg_id, emit, ctx);
+      goto cleanup;
+   }
    translate_request(req, driver, ag, &messages, &tools, &system_text);
    if (delegate_build_url(driver, ag, url, sizeof(url)) != 0 ||
        agent_resolve_auth(ag, auth, sizeof(auth)) != 0)
@@ -755,6 +971,77 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
       prov_body = build_provider_body(driver, ag, messages, tools, system_text,
                                       agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
                                       jo_num(req, "temperature", 1.0), 1);
+
+   /* P2c streaming: when gateway_prevent_subagents is ON, the streaming
+    * path becomes buffered — we fetch the upstream reply to completion,
+    * run the police function on the parsed struct (same logic as the
+    * buffered /v1/messages path), and replay the policed reply as a
+    * well-formed Anthropic SSE sequence via emit_message_as_sse. Off (the
+    * default) falls through to today's incremental relay/translator. */
+   if (gateway_prevent_subagents_enabled())
+   {
+      char *buf_resp = NULL;
+      int buf_status;
+      parsed_response_t parsed;
+      memset(&parsed, 0, sizeof(parsed));
+      buf_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &buf_resp,
+                                   ag->timeout_ms, extra[0] ? extra : NULL);
+      if (buf_status == 200 && buf_resp)
+      {
+         cJSON *provider_resp = cJSON_Parse(buf_resp);
+         if (provider_resp)
+         {
+            if (driver && driver->parse_response)
+               driver->parse_response(provider_resp, buf_resp, &parsed);
+            else
+               agent_parse_response_openai(provider_resp, &parsed);
+            gateway_policy_police_parsed_response(&parsed);
+            emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
+            /* Cost accounting (mirror the buffered path). */
+            if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&
+                agent_ingress_accounting_enabled())
+            {
+               agent_result_t ar;
+               memset(&ar, 0, sizeof(ar));
+               snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
+               snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
+               snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
+               snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
+               ar.prompt_tokens = parsed.prompt_tokens;
+               ar.completion_tokens = parsed.completion_tokens;
+               ar.cache_write_tokens = parsed.cache_write_tokens;
+               ar.cache_read_tokens = parsed.cache_read_tokens;
+               agent_record_token_audit(&ar, "", "anthropic-ingress");
+            }
+            agent_free_parsed_response(&parsed);
+         }
+         else
+         {
+            /* Parse failure on the buffered reply: emit a clean error event so
+             * the client's SSE reader terminates. */
+            char err[256];
+            snprintf(err, sizeof(err),
+                     "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+                     "\"message\":\"primary provider returned an unparseable reply\"}}");
+            if (emit)
+               emit(ctx, "error", err);
+         }
+         cJSON_Delete(provider_resp);
+      }
+      else
+      {
+         /* Upstream error: relay a transport-level error event. */
+         char err[256];
+         snprintf(err, sizeof(err),
+                  "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+                  "\"message\":\"primary provider call failed with status %d\"}}",
+                  buf_status);
+         if (emit)
+            emit(ctx, "error", err);
+      }
+      free(buf_resp);
+      goto cleanup;
+   }
 
    if (driver_is_anthropic(driver))
    {

--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -337,6 +337,51 @@ cJSON *anthropic_messages_to_openai(const cJSON *messages, const char *system_te
    return out;
 }
 
+char *anthropic_messages_to_transcript(const cJSON *messages)
+{
+   const cJSON *msg;
+   char *acc = NULL;
+
+   if (!cJSON_IsArray(messages))
+      return NULL;
+
+   cJSON_ArrayForEach(msg, messages)
+   {
+      const char *role = jo_cstr(msg, "role");
+      const cJSON *content = cJSON_GetObjectItemCaseSensitive(msg, "content");
+      const char *label = (strcmp(role, "assistant") == 0) ? "Assistant" : "User";
+      char *turn = NULL;
+
+      if (cJSON_IsString(content))
+      {
+         if (content->valuestring && content->valuestring[0])
+            turn = strdup(content->valuestring);
+      }
+      else if (cJSON_IsArray(content))
+      {
+         const cJSON *blk;
+         cJSON_ArrayForEach(blk, content)
+         {
+            const cJSON *t;
+            if (strcmp(jo_cstr(blk, "type"), "text") != 0)
+               continue; /* skip image / tool_use / tool_result */
+            t = cJSON_GetObjectItemCaseSensitive(blk, "text");
+            if (cJSON_IsString(t) && t->valuestring[0])
+               turn = str_append_join(turn, t->valuestring, turn ? "\n" : NULL);
+         }
+      }
+
+      if (!turn)
+         continue; /* a turn with no renderable text (e.g. tool-only) */
+
+      acc = str_append_join(acc, label, acc ? "\n\n" : NULL);
+      acc = str_append_join(acc, ": ", NULL);
+      acc = str_append_join(acc, turn, NULL);
+      free(turn);
+   }
+   return acc;
+}
+
 cJSON *anthropic_tools_to_openai(const cJSON *anthropic_tools)
 {
    const cJSON *tool;
@@ -432,7 +477,9 @@ cJSON *anthropic_response_from_parsed(const char *resp_id, const char *model,
       cJSON_AddItemToArray(content, tb);
    }
 
-   cJSON_AddStringToObject(obj, "stop_reason", n_calls > 0 ? "tool_use" : "end_turn");
+   cJSON_AddStringToObject(
+       obj, "stop_reason",
+       parsed && parsed->stop_reason[0] ? parsed->stop_reason : (n_calls > 0 ? "tool_use" : "end_turn"));
    cJSON_AddNullToObject(obj, "stop_sequence");
 
    usage = cJSON_AddObjectToObject(obj, "usage");
@@ -591,6 +638,19 @@ anthropic_stream_xlate_t *anthropic_stream_begin(const char *msg_id, const char 
    return st;
 }
 
+void anthropic_stream_emit_text(anthropic_stream_xlate_t *st, const char *text)
+{
+   if (!st || !text || !text[0])
+      return;
+   /* Open a fresh text block if none is open or a tool block is current. */
+   if (!st->block_open || st->block_is_tool)
+   {
+      xlate_close_block(st);
+      xlate_open_text_block(st);
+   }
+   xlate_emit_text_delta(st, text);
+}
+
 /* Process the OpenAI delta.tool_calls array of one chunk. */
 static void xlate_feed_tool_calls(anthropic_stream_xlate_t *st, const cJSON *tool_calls)
 {
@@ -721,4 +781,188 @@ void anthropic_stream_get_usage(const anthropic_stream_xlate_t *st, int *input_t
 void anthropic_stream_free(anthropic_stream_xlate_t *st)
 {
    free(st);
+}
+
+/* --- Buffered response replay as Anthropic SSE (P2c streaming) -------------
+ *
+ * The streaming /v1/messages paths take this route when
+ * `gateway_prevent_subagents` is ON: the upstream reply is buffered to
+ * completion, the police function compacts `parsed.calls[]`, and this
+ * helper replays the policed struct as a well-formed Anthropic SSE
+ * sequence — so the client sees the same wire shape it would have seen
+ * from the per-block translator, just buffered. Mirrors the wire shape
+ * produced by `anthropic_response_from_parsed` (same call_count-derivation
+ * rules, same usage fields). Pure (no I/O). */
+
+/* Emit one cJSON object as `event` on the SSE stream. Caller owns the
+ * object on entry; this function prints + emits + deletes. */
+static void replay_emit(anthropic_sse_emit_fn emit, void *ctx, const char *event,
+                        cJSON *obj)
+{
+   char *json = cJSON_PrintUnformatted(obj);
+   if (json && emit)
+   {
+      emit(ctx, event, json);
+   }
+   free(json);
+   cJSON_Delete(obj);
+}
+
+static cJSON *make_message_start(const char *msg_id, const char *model,
+                                 const parsed_response_t *p)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *msg;
+   cJSON *usage;
+   cJSON_AddStringToObject(o, "type", "message_start");
+   msg = cJSON_AddObjectToObject(o, "message");
+   cJSON_AddStringToObject(msg, "id", (msg_id && msg_id[0]) ? msg_id : "msg_aimee");
+   cJSON_AddStringToObject(msg, "type", "message");
+   cJSON_AddStringToObject(msg, "role", "assistant");
+   cJSON_AddStringToObject(msg, "model", (model && model[0]) ? model : "aimee-primary");
+   /* The translator carries usage.input_tokens in message_start; match it
+    * here so the replayed SSE has the same shape. cache_creation / cache_read
+    * are also surfaced at message_start by the native Anthropic provider. */
+   usage = cJSON_AddObjectToObject(msg, "usage");
+   cJSON_AddNumberToObject(usage, "input_tokens", p ? p->prompt_tokens : 0);
+   if (p && p->cache_write_tokens > 0)
+      cJSON_AddNumberToObject(usage, "cache_creation_input_tokens", p->cache_write_tokens);
+   if (p && p->cache_read_tokens > 0)
+      cJSON_AddNumberToObject(usage, "cache_read_input_tokens", p->cache_read_tokens);
+   return o;
+}
+
+static cJSON *make_content_block_start_text(int index)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *cb;
+   cJSON_AddStringToObject(o, "type", "content_block_start");
+   cJSON_AddNumberToObject(o, "index", index);
+   cb = cJSON_AddObjectToObject(o, "content_block");
+   cJSON_AddStringToObject(cb, "type", "text");
+   cJSON_AddStringToObject(cb, "text", "");
+   return o;
+}
+
+static cJSON *make_content_block_delta_text(int index, const char *text)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *d;
+   cJSON_AddStringToObject(o, "type", "content_block_delta");
+   cJSON_AddNumberToObject(o, "index", index);
+   d = cJSON_AddObjectToObject(o, "delta");
+   cJSON_AddStringToObject(d, "type", "text_delta");
+   cJSON_AddStringToObject(d, "text", text ? text : "");
+   return o;
+}
+
+static cJSON *make_content_block_stop(int index)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "type", "content_block_stop");
+   cJSON_AddNumberToObject(o, "index", index);
+   return o;
+}
+
+static cJSON *make_content_block_start_tool(int index, const char *id, const char *name)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *cb;
+   cJSON_AddStringToObject(o, "type", "content_block_start");
+   cJSON_AddNumberToObject(o, "index", index);
+   cb = cJSON_AddObjectToObject(o, "content_block");
+   cJSON_AddStringToObject(cb, "type", "tool_use");
+   cJSON_AddStringToObject(cb, "id", id ? id : "toolu_aimee");
+   cJSON_AddStringToObject(cb, "name", name ? name : "");
+   /* `input` is an object; we emit it as {} at start and let the deltas
+    * fill it. Matches the translator's per-block tool-block opening. */
+   cJSON_AddObjectToObject(cb, "input");
+   return o;
+}
+
+static cJSON *make_content_block_delta_input_json(int index, const char *partial_json)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *d;
+   cJSON_AddStringToObject(o, "type", "content_block_delta");
+   cJSON_AddNumberToObject(o, "index", index);
+   d = cJSON_AddObjectToObject(o, "delta");
+   cJSON_AddStringToObject(d, "type", "input_json_delta");
+   cJSON_AddStringToObject(d, "partial_json", partial_json ? partial_json : "{}");
+   return o;
+}
+
+static cJSON *make_message_delta(const parsed_response_t *p, int n_calls)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *u;
+   const char *stop = (p && p->stop_reason[0])
+                          ? p->stop_reason
+                          : (n_calls > 0 ? "tool_use" : "end_turn");
+   cJSON_AddStringToObject(o, "type", "message_delta");
+   cJSON *delta = cJSON_AddObjectToObject(o, "delta");
+   cJSON_AddStringToObject(delta, "stop_reason", stop);
+   cJSON_AddStringToObject(delta, "stop_sequence", "");
+   u = cJSON_AddObjectToObject(o, "usage");
+   cJSON_AddNumberToObject(u, "output_tokens", p ? p->completion_tokens : 0);
+   if (p && p->cache_read_tokens > 0)
+      cJSON_AddNumberToObject(u, "cache_read_input_tokens", p->cache_read_tokens);
+   return o;
+}
+
+void emit_message_as_sse(const parsed_response_t *parsed, const char *msg_id,
+                         const char *model, anthropic_sse_emit_fn emit, void *ctx)
+{
+   int n_calls;
+   int index;
+
+   if (!emit)
+      return;
+   n_calls = parsed ? parsed->call_count : 0;
+
+   /* message_start */
+   replay_emit(emit, ctx, "message_start", make_message_start(msg_id, model, parsed));
+
+   /* Always emit one text content_block_start / (text_delta)? / stop pair —
+    * even when parsed->content is empty, matching the buffered renderer's
+    * empty-text-block fallback (lines 427-433 of anthropic_ingress.c). The
+    * SSE wire shape stays identical to today's per-block translator's
+    * output, so clients (Claude Code) see no difference. */
+   index = 0;
+   replay_emit(emit, ctx, "content_block_start", make_content_block_start_text(index));
+   if (parsed && parsed->content && parsed->content[0])
+   {
+      replay_emit(emit, ctx, "content_block_delta",
+                  make_content_block_delta_text(index, parsed->content));
+   }
+   replay_emit(emit, ctx, "content_block_stop", make_content_block_stop(index));
+
+   /* Per surviving tool_use block: content_block_start + (input_json_delta) +
+    * content_block_stop, in original order, indices 1, 2, ... */
+   if (parsed)
+   {
+      int i;
+      for (i = 0; i < n_calls; i++)
+      {
+         const parsed_tool_call_t *c = &parsed->calls[i];
+         index++;
+         replay_emit(emit, ctx, "content_block_start",
+                     make_content_block_start_tool(index, c->id, c->name));
+         /* Always emit at least one input_json_delta carrying the full
+          * arguments. The translator emits one delta per OpenAI chunk; the
+          * buffered replay condenses to a single delta per tool_use, which
+          * is a wire-valid Anthropic SSE shape (the client reassembles the
+          * full input from partial_json strings). */
+         replay_emit(emit, ctx, "content_block_delta",
+                     make_content_block_delta_input_json(index, c->arguments));
+         replay_emit(emit, ctx, "content_block_stop", make_content_block_stop(index));
+      }
+   }
+
+   /* message_delta: stop_reason verbatim from parsed (the police function
+    * already finalized it — see gateway_policy.h), plus the usage block
+    * (output_tokens + cache_read_input_tokens). */
+   replay_emit(emit, ctx, "message_delta", make_message_delta(parsed, n_calls));
+   /* message_stop */
+   replay_emit(emit, ctx, "message_stop", cJSON_CreateObject());
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -279,6 +279,7 @@ static char g_cli_seen_sid[128];
 static char g_cli_seen_cmd[256];
 static int g_override_set;
 static int g_override_clear;
+static int g_cli_clear_seen; /* count of "/clear" reset turns (warm-pool reuse) */
 /* Live-streaming: when nparts>0 the executor stub fires the registered stream cb
  * with each part (exercising the real-time delta bridge) and returns their concat. */
 static const char *g_cli_stream_parts[4];
@@ -306,6 +307,8 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    (void)network;
    (void)max_tokens;
    (void)temperature;
+   if (user_prompt && strcmp(user_prompt, "/clear") == 0)
+      g_cli_clear_seen++;
    snprintf(g_cli_seen_system, sizeof(g_cli_seen_system), "%s", system_prompt ? system_prompt : "");
    snprintf(g_cli_seen_user, sizeof(g_cli_seen_user), "%s", user_prompt ? user_prompt : "");
    snprintf(g_cli_seen_cmd, sizeof(g_cli_seen_cmd), "%s", agent->cli_cmd);
@@ -1187,6 +1190,99 @@ static void test_messages_buffered_cli_too_large(void)
    PASS("messages_buffered_cli_too_large");
 }
 
+static int g_pool_kill_calls;
+static void test_pool_kill_noop(const char *name)
+{
+   (void)name;
+   g_pool_kill_calls++;
+}
+
+/* Warm pool: a second turn with the same (system, model, agent) key reuses the
+ * first turn's pane (same tmux session name) and resets it with /clear first. */
+static void test_messages_cli_pool_reuse(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   char first_sid[CLI_SESSION_NAME_MAX];
+   void (*saved_kill)(const char *) = g_pool_kill_fn;
+   const char *home = getenv("HOME");
+   char saved[512];
+   char tmphome[] = "/tmp/aimee-pool-home-XXXXXX";
+   char dir[600];
+   char creds[700];
+   FILE *cf;
+   int i;
+
+   saved[0] = '\0';
+   if (home)
+      snprintf(saved, sizeof(saved), "%s", home);
+   assert(mkdtemp(tmphome) != NULL);
+   snprintf(dir, sizeof(dir), "%s/.claude", tmphome);
+   assert(mkdir(dir, 0700) == 0);
+   snprintf(creds, sizeof(creds), "%s/.claude/.credentials.json", tmphome);
+   cf = fopen(creds, "w");
+   assert(cf != NULL);
+   fputs("{}", cf);
+   fclose(cf);
+   setenv("HOME", tmphome, 1);
+
+   /* The test owns the file-local pool; start clean and avoid real tmux kills. */
+   for (i = 0; i < INGRESS_POOL_MAX; i++)
+   {
+      if (g_pool[i].path[0])
+         unlink(g_pool[i].path);
+      free(g_pool[i].sys);
+   }
+   memset(g_pool, 0, sizeof(g_pool));
+   g_pool_kill_fn = test_pool_kill_noop;
+   setenv("AIMEE_INGRESS_CLI_POOL", "1", 1);
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "claude"; /* pool is gated on a claude-family CLI */
+   g_cli_rc = 0;
+   g_cli_reply = "ok";
+   g_cli_clear_seen = 0;
+
+   /* Turn 1: fresh slot, no reset. */
+   assert(messages_buffered("{\"model\":\"claude-x\",\"system\":\"POOLSYS\","
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"one\"}]}",
+                            resp, sizeof(resp)) == 200);
+   assert(strncmp(g_cli_seen_sid, "aimee-pool-", 11) == 0);
+   assert(g_cli_clear_seen == 0);
+   snprintf(first_sid, sizeof(first_sid), "%s", g_cli_seen_sid);
+
+   /* Turn 2: same key -> reuse the same pane, reset it first. */
+   assert(messages_buffered("{\"model\":\"claude-x\",\"system\":\"POOLSYS\","
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"two\"}]}",
+                            resp, sizeof(resp)) == 200);
+   assert(strcmp(g_cli_seen_sid, first_sid) == 0); /* same warm pane */
+   assert(g_cli_clear_seen >= 1);                  /* conversation reset before reuse */
+
+   /* cleanup */
+   unsetenv("AIMEE_INGRESS_CLI_POOL");
+   for (i = 0; i < INGRESS_POOL_MAX; i++)
+   {
+      if (g_pool[i].path[0])
+         unlink(g_pool[i].path);
+      free(g_pool[i].sys);
+   }
+   memset(g_pool, 0, sizeof(g_pool));
+   g_pool_kill_fn = saved_kill;
+   if (saved[0])
+      setenv("HOME", saved, 1);
+   else
+      unsetenv("HOME");
+   unlink(creds);
+   rmdir(dir);
+   rmdir(tmphome);
+   g_cli_mode = 0;
+   g_cli_agent_name = "primary";
+   reset_capture();
+   PASS("messages_cli_pool_reuse");
+}
+
 int main(void)
 {
    test_translate_request_anthropic_passthrough();
@@ -1213,6 +1309,7 @@ int main(void)
    test_messages_stream_cli_error();
    test_messages_stream_cli_live_deltas();
    test_messages_buffered_cli_too_large();
+   test_messages_cli_pool_reuse();
    printf("anthropic_http: OK\n");
    return 0;
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -12,6 +12,7 @@
 #include "../headers/agent_config.h"
 #include "../headers/agent_exec.h"
 #include "../headers/agent_protocol.h"
+#include "../headers/cli_session.h"
 #include "../headers/delegate_driver.h"
 #include "../headers/server_http.h"
 #include "../vendor/headers/cJSON.h"
@@ -278,6 +279,24 @@ static char g_cli_seen_sid[128];
 static char g_cli_seen_cmd[256];
 static int g_override_set;
 static int g_override_clear;
+/* Live-streaming: when nparts>0 the executor stub fires the registered stream cb
+ * with each part (exercising the real-time delta bridge) and returns their concat. */
+static const char *g_cli_stream_parts[4];
+static int g_cli_stream_nparts;
+static cli_session_stream_cb_t g_test_stream_cb;
+static void *g_test_stream_ud;
+
+void cli_session_set_stream_cb(cli_session_stream_cb_t cb, void *ud)
+{
+   g_test_stream_cb = cb;
+   g_test_stream_ud = ud;
+}
+cli_session_stream_cb_t cli_session_get_stream_cb(void **ud_out)
+{
+   if (ud_out)
+      *ud_out = g_test_stream_ud;
+   return g_test_stream_cb;
+}
 
 int agent_execute_cli_session(const agent_t *agent, const agent_network_t *network,
                               const char *system_prompt, const char *user_prompt, int max_tokens,
@@ -313,7 +332,21 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
    memset(out, 0, sizeof(*out));
    if (g_cli_rc == 0)
    {
-      out->response = strdup(g_cli_reply ? g_cli_reply : "");
+      if (g_cli_stream_nparts > 0)
+      {
+         char buf[1024] = "";
+         for (int i = 0; i < g_cli_stream_nparts; i++)
+         {
+            if (g_test_stream_cb)
+               g_test_stream_cb(g_cli_stream_parts[i], g_test_stream_ud);
+            strncat(buf, g_cli_stream_parts[i], sizeof(buf) - strlen(buf) - 1);
+         }
+         out->response = strdup(buf);
+      }
+      else
+      {
+         out->response = strdup(g_cli_reply ? g_cli_reply : "");
+      }
       out->success = 1;
       out->turns = 1;
    }
@@ -1081,6 +1114,79 @@ static void test_messages_buffered_cli_appends_system_prompt(void)
    PASS("messages_buffered_cli_appends_system_prompt");
 }
 
+static void test_messages_stream_cli_live_deltas(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   emit_capture_t cap;
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary";
+   g_cli_rc = 0;
+   g_cli_stream_parts[0] = "Hello ";
+   g_cli_stream_parts[1] = "world";
+   g_cli_stream_nparts = 2;
+
+   assert(messages_stream(
+              "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+              cap_emit, &cap) == 0);
+   /* Each CLI delta is forwarded live as its own text_delta (not one block at the
+    * end): start, block_start, delta("Hello "), delta("world"), block_stop, msg_delta, stop. */
+   assert(cap.count == 7);
+   assert(strcmp(cap.events[0], "message_start") == 0);
+   assert(strcmp(cap.events[1], "content_block_start") == 0);
+   assert(strcmp(cap.events[2], "content_block_delta") == 0);
+   assert(strstr(cap.data[2], "Hello ") != NULL);
+   assert(strcmp(cap.events[3], "content_block_delta") == 0);
+   assert(strstr(cap.data[3], "world") != NULL);
+   assert(strcmp(cap.events[4], "content_block_stop") == 0);
+   assert(strcmp(cap.events[5], "message_delta") == 0);
+   assert(strcmp(cap.events[6], "message_stop") == 0);
+
+   g_cli_stream_nparts = 0;
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_stream_cli_live_deltas");
+}
+
+static void test_messages_buffered_cli_too_large(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *out;
+   /* Build a > INGRESS_MAX_PROMPT_BYTES user message. */
+   size_t big = (size_t)INGRESS_MAX_PROMPT_BYTES + 16;
+   char *huge = malloc(big + 1);
+   char *body;
+
+   assert(huge != NULL);
+   memset(huge, 'x', big);
+   huge[big] = '\0';
+   body = malloc(big + 128);
+   assert(body != NULL);
+   snprintf(body, big + 128,
+            "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"%s\"}]}", huge);
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary";
+   g_cli_rc = 0;
+
+   assert(messages_buffered(body, resp, sizeof(resp)) == 413);
+   out = parse(resp);
+   assert(strcmp(obj(obj(out, "error"), "type")->valuestring, "request_too_large") == 0);
+   cJSON_Delete(out);
+
+   free(huge);
+   free(body);
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_buffered_cli_too_large");
+}
+
 int main(void)
 {
    test_translate_request_anthropic_passthrough();
@@ -1105,6 +1211,8 @@ int main(void)
    test_messages_buffered_cli_not_logged_in();
    test_messages_stream_cli_success();
    test_messages_stream_cli_error();
+   test_messages_stream_cli_live_deltas();
+   test_messages_buffered_cli_too_large();
    printf("anthropic_http: OK\n");
    return 0;
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -22,6 +22,12 @@ static char *g_last_extra; /* upstream extra-header block from the last post */
 static int g_stream_status = 200;
 static const char *g_stream_payload;
 
+/* CLI-backed ingress (tmux claude-oauth) test controls: g_cli_mode makes
+ * agent_load_config yield a tmux-cli primary; the rest drive/observe the
+ * agent_execute_cli_session stub below. */
+static int g_cli_mode = 0;
+static const char *g_cli_agent_name = "primary";
+
 static void reset_capture(void)
 {
    free(g_last_body);
@@ -41,6 +47,12 @@ int agent_load_config(agent_config_t *cfg)
             g_driver && g_driver->name ? g_driver->name : "anthropic");
    snprintf(cfg->agents[0].model, sizeof(cfg->agents[0].model), "configured-claude");
    cfg->agents[0].timeout_ms = 1;
+   if (g_cli_mode)
+   {
+      snprintf(cfg->agents[0].name, sizeof(cfg->agents[0].name), "%s", g_cli_agent_name);
+      snprintf(cfg->agents[0].backend, sizeof(cfg->agents[0].backend), "%s", AGENT_BACKEND_TMUX_CLI);
+      cfg->agents[0].session_reuse = 0;
+   }
    return 0;
 }
 
@@ -239,6 +251,12 @@ int gateway_policy_pin_model(cJSON *req, const char *agent_model)
    (void)agent_model;
    return 0; /* pin is off in these shape tests; covered by test_gateway_policy */
 }
+/* P2c streaming branch: off by default in these whitebox shape tests
+ * (the real predicate is exercised by test_anthropic_http-p2c). */
+int gateway_prevent_subagents_enabled(void)
+{
+   return 0;
+}
 /* P2c (response-side tool policing) is exercised by its own dedicated
  * integration test (unit-test-anthropic-http-p2c) which links the real
  * gateway_policy.o. In these whitebox shape tests we stub it to a no-op
@@ -247,6 +265,49 @@ int gateway_policy_police_parsed_response(parsed_response_t *p)
 {
    (void)p;
    return 0;
+}
+
+/* --- CLI-backed ingress stubs (tmux claude-oauth path) ------------------- */
+static int g_cli_rc = 0; /* agent_execute_cli_session return code */
+static const char *g_cli_reply = "hello from CLI";
+static char g_cli_seen_system[4096];
+static char g_cli_seen_user[8192];
+static char g_cli_seen_sid[128];
+static int g_override_set;
+static int g_override_clear;
+
+int agent_execute_cli_session(const agent_t *agent, const agent_network_t *network,
+                              const char *system_prompt, const char *user_prompt, int max_tokens,
+                              double temperature, agent_result_t *out)
+{
+   (void)agent;
+   (void)network;
+   (void)max_tokens;
+   (void)temperature;
+   snprintf(g_cli_seen_system, sizeof(g_cli_seen_system), "%s", system_prompt ? system_prompt : "");
+   snprintf(g_cli_seen_user, sizeof(g_cli_seen_user), "%s", user_prompt ? user_prompt : "");
+   memset(out, 0, sizeof(*out));
+   if (g_cli_rc == 0)
+   {
+      out->response = strdup(g_cli_reply ? g_cli_reply : "");
+      out->success = 1;
+      out->turns = 1;
+   }
+   else
+   {
+      snprintf(out->error, sizeof(out->error), "stub cli error");
+   }
+   return g_cli_rc;
+}
+
+void session_id_set_override(const char *sid)
+{
+   g_override_set++;
+   snprintf(g_cli_seen_sid, sizeof(g_cli_seen_sid), "%s", sid ? sid : "");
+}
+void session_id_clear_override(void)
+{
+   g_override_clear++;
 }
 
 #include "../server/anthropic_http.c"
@@ -735,6 +796,214 @@ static void test_messages_preinject_appends_system_block(void)
    PASS("messages_preinject_appends_system_block");
 }
 
+/* --- CLI-backed ingress (tmux claude-oauth) tests ------------------------ */
+
+static void test_cli_transcript_render(void)
+{
+   cJSON *msgs = parse("[{\"role\":\"user\",\"content\":\"first\"},"
+                       "{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"reply\"}]},"
+                       "{\"role\":\"user\",\"content\":["
+                       "{\"type\":\"tool_result\",\"tool_use_id\":\"t\",\"content\":\"TOOLONLY\"},"
+                       "{\"type\":\"text\",\"text\":\"second\"}]}]");
+   char *t = anthropic_messages_to_transcript(msgs);
+   cJSON *empty = parse("[]");
+
+   assert(t != NULL);
+   assert(strstr(t, "User: first") != NULL);
+   assert(strstr(t, "Assistant: reply") != NULL);
+   assert(strstr(t, "User: second") != NULL);
+   assert(strstr(t, "TOOLONLY") == NULL); /* tool_result text skipped */
+   free(t);
+
+   assert(anthropic_messages_to_transcript(empty) == NULL); /* nothing renderable */
+   cJSON_Delete(empty);
+   cJSON_Delete(msgs);
+   PASS("cli_transcript_render");
+}
+
+static void test_messages_buffered_cli_success(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *out;
+   const cJSON *content, *blk;
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary"; /* non-claude name -> login gate bypassed */
+   g_cli_rc = 0;
+   g_cli_reply = "hello from CLI";
+   g_override_set = g_override_clear = 0;
+   g_cli_seen_system[0] = g_cli_seen_user[0] = g_cli_seen_sid[0] = '\0';
+
+   assert(messages_buffered("{\"model\":\"claude-x\",\"max_tokens\":64,\"system\":\"SYSTEXT\","
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi there\"}]}",
+                            resp, sizeof(resp)) == 200);
+   out = parse(resp);
+   assert(strcmp(obj(out, "type")->valuestring, "message") == 0);
+   assert(strcmp(obj(out, "role")->valuestring, "assistant") == 0);
+   assert(strcmp(obj(out, "model")->valuestring, "claude-x") == 0); /* requested model echoed */
+   assert(strcmp(obj(out, "stop_reason")->valuestring, "end_turn") == 0);
+   content = obj(out, "content");
+   assert(cJSON_IsArray(content) && cJSON_GetArraySize((cJSON *)content) == 1);
+   blk = cJSON_GetArrayItem((cJSON *)content, 0);
+   assert(strcmp(obj(blk, "type")->valuestring, "text") == 0);
+   assert(strcmp(obj(blk, "text")->valuestring, "hello from CLI") == 0);
+   /* prompt rendering: system passed verbatim, transcript carries labeled user text */
+   assert(strcmp(g_cli_seen_system, "SYSTEXT") == 0);
+   assert(strstr(g_cli_seen_user, "User: hi there") != NULL);
+   /* per-request session override set + cleared exactly once, unique id shape */
+   assert(g_override_set == 1 && g_override_clear == 1);
+   assert(strncmp(g_cli_seen_sid, "aimee-ingress-msg_", 18) == 0);
+
+   cJSON_Delete(out);
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_buffered_cli_success");
+}
+
+static void test_messages_buffered_cli_error(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *out;
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary";
+   g_cli_rc = -2; /* executor timeout */
+   g_override_set = g_override_clear = 0;
+
+   assert(messages_buffered(
+              "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}", resp,
+              sizeof(resp)) == 502);
+   out = parse(resp);
+   assert(strcmp(obj(out, "type")->valuestring, "error") == 0);
+   assert(g_override_set == 1 && g_override_clear == 1); /* override cleared even on failure */
+
+   cJSON_Delete(out);
+   g_cli_rc = 0;
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_buffered_cli_error");
+}
+
+static void test_messages_buffered_cli_empty_reply(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary";
+   g_cli_rc = 0;
+   g_cli_reply = ""; /* success rc but empty text -> treated as failure */
+
+   assert(messages_buffered(
+              "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}", resp,
+              sizeof(resp)) == 502);
+
+   g_cli_reply = "hello from CLI";
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_buffered_cli_empty_reply");
+}
+
+static void test_messages_buffered_cli_not_logged_in(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   cJSON *out;
+   const char *home = getenv("HOME");
+   char saved[512];
+
+   saved[0] = '\0';
+   if (home)
+      snprintf(saved, sizeof(saved), "%s", home);
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "claude"; /* claude-family -> login pre-flight applies */
+   setenv("HOME", "/nonexistent-aimee-cli-home", 1);
+
+   assert(messages_buffered(
+              "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}", resp,
+              sizeof(resp)) == 401);
+   out = parse(resp);
+   assert(strcmp(obj(out, "type")->valuestring, "error") == 0);
+   assert(strcmp(obj(obj(out, "error"), "type")->valuestring, "authentication_error") == 0);
+
+   cJSON_Delete(out);
+   if (saved[0])
+      setenv("HOME", saved, 1);
+   else
+      unsetenv("HOME");
+   g_cli_mode = 0;
+   g_cli_agent_name = "primary";
+   reset_capture();
+   PASS("messages_buffered_cli_not_logged_in");
+}
+
+static void test_messages_stream_cli_success(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   emit_capture_t cap;
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary";
+   g_cli_rc = 0;
+   g_cli_reply = "streamed reply";
+
+   assert(messages_stream(
+              "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+              cap_emit, &cap) == 0);
+   /* full Anthropic SSE sequence for a single text block */
+   assert(cap.count == 6);
+   assert(strcmp(cap.events[0], "message_start") == 0);
+   assert(strcmp(cap.events[1], "content_block_start") == 0);
+   assert(strcmp(cap.events[2], "content_block_delta") == 0);
+   assert(strstr(cap.data[2], "streamed reply") != NULL);
+   assert(strcmp(cap.events[3], "content_block_stop") == 0);
+   assert(strcmp(cap.events[4], "message_delta") == 0);
+   assert(strstr(cap.data[4], "end_turn") != NULL);
+   assert(strcmp(cap.events[5], "message_stop") == 0);
+
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_stream_cli_success");
+}
+
+static void test_messages_stream_cli_error(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   emit_capture_t cap;
+
+   reset_capture();
+   memset(&cap, 0, sizeof(cap));
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "primary";
+   g_cli_rc = -1; /* executor failure -> single typed error event, stream terminates */
+
+   assert(messages_stream(
+              "{\"model\":\"claude-x\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+              cap_emit, &cap) == 0);
+   assert(cap.count == 1);
+   assert(strcmp(cap.events[0], "error") == 0);
+
+   g_cli_rc = 0;
+   g_cli_mode = 0;
+   reset_capture();
+   PASS("messages_stream_cli_error");
+}
+
 int main(void)
 {
    test_translate_request_anthropic_passthrough();
@@ -751,6 +1020,13 @@ int main(void)
    test_messages_buffered_system_prompt_driver_no_duplicate_system();
    test_messages_buffered_system_prompt_capability_no_duplicate_system();
    test_messages_stream_openai_family_translates();
+   test_cli_transcript_render();
+   test_messages_buffered_cli_success();
+   test_messages_buffered_cli_error();
+   test_messages_buffered_cli_empty_reply();
+   test_messages_buffered_cli_not_logged_in();
+   test_messages_stream_cli_success();
+   test_messages_stream_cli_error();
    printf("anthropic_http: OK\n");
    return 0;
 }

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -5,6 +5,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "../headers/aimee.h"
 #include "../headers/agent_config.h"
@@ -273,6 +275,7 @@ static const char *g_cli_reply = "hello from CLI";
 static char g_cli_seen_system[4096];
 static char g_cli_seen_user[8192];
 static char g_cli_seen_sid[128];
+static char g_cli_seen_cmd[256];
 static int g_override_set;
 static int g_override_clear;
 
@@ -280,12 +283,33 @@ int agent_execute_cli_session(const agent_t *agent, const agent_network_t *netwo
                               const char *system_prompt, const char *user_prompt, int max_tokens,
                               double temperature, agent_result_t *out)
 {
-   (void)agent;
+   const char *catp;
    (void)network;
    (void)max_tokens;
    (void)temperature;
    snprintf(g_cli_seen_system, sizeof(g_cli_seen_system), "%s", system_prompt ? system_prompt : "");
    snprintf(g_cli_seen_user, sizeof(g_cli_seen_user), "%s", user_prompt ? user_prompt : "");
+   snprintf(g_cli_seen_cmd, sizeof(g_cli_seen_cmd), "%s", agent->cli_cmd);
+   /* When the system prompt was delivered via --append-system-prompt "$(cat P)",
+    * read P back so the test can assert the content actually reached the CLI. */
+   catp = strstr(agent->cli_cmd, "$(cat ");
+   if (catp)
+   {
+      const char *end = strchr(catp + 6, ')');
+      if (end && (size_t)(end - (catp + 6)) < 256)
+      {
+         char path[256];
+         FILE *pf;
+         snprintf(path, sizeof(path), "%.*s", (int)(end - (catp + 6)), catp + 6);
+         pf = fopen(path, "r");
+         if (pf)
+         {
+            size_t got = fread(g_cli_seen_system, 1, sizeof(g_cli_seen_system) - 1, pf);
+            g_cli_seen_system[got] = '\0';
+            fclose(pf);
+         }
+      }
+   }
    memset(out, 0, sizeof(*out));
    if (g_cli_rc == 0)
    {
@@ -1004,6 +1028,59 @@ static void test_messages_stream_cli_error(void)
    PASS("messages_stream_cli_error");
 }
 
+static void test_messages_buffered_cli_appends_system_prompt(void)
+{
+   const delegate_driver_t anthropic = {.name = "anthropic", .parse_response = parsed_text};
+   char resp[4096];
+   const char *home = getenv("HOME");
+   char saved[512];
+   char tmphome[] = "/tmp/aimee-cli-home-XXXXXX";
+   char dir[600];
+   char creds[700];
+   FILE *cf;
+
+   saved[0] = '\0';
+   if (home)
+      snprintf(saved, sizeof(saved), "%s", home);
+   assert(mkdtemp(tmphome) != NULL);
+   snprintf(dir, sizeof(dir), "%s/.claude", tmphome);
+   assert(mkdir(dir, 0700) == 0);
+   snprintf(creds, sizeof(creds), "%s/.claude/.credentials.json", tmphome);
+   cf = fopen(creds, "w");
+   assert(cf != NULL);
+   fputs("{}", cf);
+   fclose(cf);
+   setenv("HOME", tmphome, 1); /* claude-login pre-flight now passes */
+
+   reset_capture();
+   g_driver = &anthropic;
+   g_cli_mode = 1;
+   g_cli_agent_name = "claude"; /* claude-family -> --append-system-prompt path */
+   g_cli_rc = 0;
+   g_cli_reply = "ok";
+   g_cli_seen_system[0] = g_cli_seen_cmd[0] = '\0';
+
+   assert(messages_buffered("{\"model\":\"claude-x\",\"system\":\"MYSYS-12345\","
+                            "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                            resp, sizeof(resp)) == 200);
+   /* system delivered as a flag (not pasted), and its content reached the CLI */
+   assert(strstr(g_cli_seen_cmd, "--append-system-prompt") != NULL);
+   assert(strstr(g_cli_seen_cmd, "$(cat ") != NULL);
+   assert(strcmp(g_cli_seen_system, "MYSYS-12345") == 0);
+
+   if (saved[0])
+      setenv("HOME", saved, 1);
+   else
+      unsetenv("HOME");
+   unlink(creds);
+   rmdir(dir);
+   rmdir(tmphome);
+   g_cli_mode = 0;
+   g_cli_agent_name = "primary";
+   reset_capture();
+   PASS("messages_buffered_cli_appends_system_prompt");
+}
+
 int main(void)
 {
    test_translate_request_anthropic_passthrough();
@@ -1022,6 +1099,7 @@ int main(void)
    test_messages_stream_openai_family_translates();
    test_cli_transcript_render();
    test_messages_buffered_cli_success();
+   test_messages_buffered_cli_appends_system_prompt();
    test_messages_buffered_cli_error();
    test_messages_buffered_cli_empty_reply();
    test_messages_buffered_cli_not_logged_in();


### PR DESCRIPTION
## Summary
Serve the Anthropic `POST /v1/messages` gateway ingress from a **tmux-hosted `claude` CLI logged in via subscription OAuth**, instead of a raw HTTP provider call that 502s on the CLI agent's empty endpoint. End-to-end: `Anthropic client → aimee /v1/messages → tmux claude-oauth → Anthropic`.

Five commits:
1. **Bridge** — `messages_buffered`/`messages_stream` route `backend == tmux-cli` agents to `agent_execute_cli_session`; CLI text re-encoded as Anthropic buffered JSON / SSE. `provider: claude` normalizes to the tmux-cli backend on load.
2. **System-prompt fidelity** — client system prompt delivered via `--append-system-prompt` (not pasted as user text).
3. **Live streaming + retry + size cap** — CLI deltas stream live as `text_delta` events; one retry on transient empty/dead turns; 413 on pathological payloads; hard failures emit a typed SSE `error` event (no silent empty stream).
4. **Warm pane pool (opt-in)** — `AIMEE_INGRESS_CLI_POOL=1` reuses panes keyed on `(system prompt, model, agent)`, `/clear`-resets between reuses, mutex-guarded, bounded, idle-reaped. **Default off.**
5. **Security fix** — `mkstemp` (0600, O_EXCL) for the system-prompt temp files instead of predictable `/tmp` paths.

Scope: v1 serves **plain-text turns only**; `tools[]`/`tool_use` round-trips are out of scope (`stop_reason` always `end_turn`). Full-agent tool access on the gateway is intentional.

## Review
Roundtable review: **APPROVE** (after re-running with the full diff inlined; it confirmed memory ownership, pool locking/isolation, the `mkstemp` fix, and SSE shape). The `mkstemp` hardening was added in response to its one valid finding.

## Tests
`unit-test-anthropic-http`: **25/25 pass** — buffered/stream success+error, system-prompt delivery, 401-not-logged-in, 413-too-large, live deltas, and warm-pool reuse with `/clear`.

## Caveats (not blocking, tracked for follow-up)
- Three things want **E2E validation against the real `claude` CLI** before relying on them (require the server-side OAuth login + deploy): interactive `--append-system-prompt`, the `/clear` reset (the warm pool's isolation guarantee — hence default-off), and streaming-callback timing.
- A concurrent branch is mid-edit on `gateway_policy.c`; a full `make server` is red on **that** unrelated change. This PR's test target builds/passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
