### PR TITLE
feat(gateway): P2c response-side tool policing — streaming path

### DIFF
--- a/src/gateway_policy.c
+++ b/src/gateway_policy.c
@@ -20,7 +20,7 @@ static int is_subagent_tool_name(const char *name)
    return name && name[0] && strcmp(guardrails_canonical_tool_name(name), "Subagent") == 0;
 }
 
-static int prevent_subagents_enabled(void)
+int gateway_prevent_subagents_enabled(void)
 {
    config_t cfg;
    config_load(&cfg);
@@ -57,7 +57,7 @@ int gateway_policy_strip_tools(cJSON *tools, int tools_openai_shape)
    cJSON *t;
    int stripped = 0;
 
-   if (!cJSON_IsArray(tools) || !prevent_subagents_enabled())
+   if (!cJSON_IsArray(tools) || !gateway_prevent_subagents_enabled())
       return 0;
 
    for (t = tools->child; t;)
@@ -132,17 +132,15 @@ int gateway_policy_is_denied_tool(const char *name)
 {
    if (!name || !name[0])
       return 0;
-   if (!prevent_subagents_enabled())
+   if (!gateway_prevent_subagents_enabled())
       return 0;
    return is_subagent_tool_name(name);
 }
 
 /* Response-side tool policing: memmove-compact denied entries out of `p->calls[]`
- * and rewrite `p->stop_reason` to mirror what `anthropic_response_from_parsed`
- * would render from the surviving `call_count` (line 435 of
- * src/server/anthropic_ingress.c: `n_calls > 0 ? "tool_use" : "end_turn"`). See
- * gateway_policy.h for the full set of fields the function does NOT touch and
- * the rationale for the in-place memmove compaction. */
+ * and finalize `p->stop_reason` so it agrees with the wire emitted by
+ * `anthropic_response_from_parsed`. See gateway_policy.h for the stop-reason
+ * rules and the full set of fields the function does NOT touch. */
 int gateway_policy_police_parsed_response(parsed_response_t *p)
 {
    int drops = 0;
@@ -150,7 +148,7 @@ int gateway_policy_police_parsed_response(parsed_response_t *p)
 
    if (!p)
       return 0;
-   if (!prevent_subagents_enabled())
+   if (!gateway_prevent_subagents_enabled())
       return 0;
 
    n = p->call_count;
@@ -178,10 +176,20 @@ int gateway_policy_police_parsed_response(parsed_response_t *p)
       w++;
    }
    p->call_count = w;
-   /* Mirror the renderer's own stop_reason mapping so the audit row at
-    * messages_buffered line 483 (which reads parsed.stop_reason) agrees with
-    * the wire emitted by anthropic_response_from_parsed (which re-derives
-    * from call_count). */
-   snprintf(p->stop_reason, sizeof(p->stop_reason), "%s", w > 0 ? "tool_use" : "end_turn");
+   /* Stop-reason finalization: if the upstream did not set a reason
+    * (stop_reason[0] == '\0'), derive from the surviving call_count so the
+    * audit row and the renderer's fallback (line 435 of anthropic_ingress.c,
+    * `parsed->stop_reason[0] ? parsed->stop_reason : n_calls > 0 ? "tool_use"
+    * : "end_turn"`) agree on a non-empty value. If the upstream DID set a
+    * reason (e.g. "max_tokens" for a truncated reply, or "stop_sequence" /
+    * "refusal"), preserve it verbatim — see the doc comment above for the
+    * partial-drop preservation rationale. The all-dropped case always
+    * rewrites to "end_turn" because the wire's "tool_use" reply became an
+    * "end_turn" reply (the model emitted a tool_use reply; the police
+    * removed every block; the client now sees end_turn). */
+   if (p->stop_reason[0] == '\0' || w == 0)
+   {
+      snprintf(p->stop_reason, sizeof(p->stop_reason), "%s", w > 0 ? "tool_use" : "end_turn");
+   }
    return drops;
 }

--- a/src/headers/anthropic_ingress.h
+++ b/src/headers/anthropic_ingress.h
@@ -86,6 +86,33 @@ void anthropic_stream_feed_openai(anthropic_stream_xlate_t *st, const char *data
 /* Close any open content block and emit message_delta + message_stop. */
 void anthropic_stream_finish(anthropic_stream_xlate_t *st);
 
+/* Replay a fully-parsed provider reply (`anthropic_response_from_parsed`
+ * equivalent) as a well-formed Anthropic SSE sequence. Used by the streaming
+ * /v1/messages paths when the gateway response-side tool-policing policy
+ * (`gateway_prevent_subagents`) is active: the upstream is buffered to
+ * completion, the police function compacts `parsed.calls[]`, and this helper
+ * replays the policed struct as if the per-block translator had been
+ * streaming. Pure (no I/O); deterministic; unit-testable with a captured
+ * emit. Mirrors `anthropic_response_from_parsed`'s wire shape:
+ *   message_start (with usage: input_tokens, cache_creation_input_tokens,
+ *                  cache_read_input_tokens if non-zero)
+ *   one text content_block_start/.../stop pair — always emitted, even when
+ *                  parsed.content is empty/NULL, matching the buffered
+ *                  renderer's empty-text-block fallback (lines 427-433 of
+ *                  src/server/anthropic_ingress.c). Index 0.
+ *   one tool_use content_block_start + (input_json_delta)* + stop per
+ *                  surviving parsed.calls[0..call_count-1] entry. Indices
+ *                  1, 2, ... in original order.
+ *   message_delta (with parsed.stop_reason verbatim — see the police
+ *                  function's contract in gateway_policy.h — and usage
+ *                  output_tokens + cache_read_input_tokens if non-zero).
+ *   message_stop.
+ * `emit` matches the streaming translator's emit signature
+ * (`anthropic_sse_emit_fn`). `ctx` is the caller's transport context
+ * (passed through to `emit`). */
+void emit_message_as_sse(const parsed_response_t *parsed, const char *msg_id, const char *model,
+                         anthropic_sse_emit_fn emit, void *ctx);
+
 /* Read the usage tapped from the upstream OpenAI stream: the prompt count
  * (upstream-reported if seen, else the begin-time estimate), the completion
  * count, and any cached prompt tokens. Any out pointer may be NULL. Lets the

--- a/src/headers/gateway_policy.h
+++ b/src/headers/gateway_policy.h
@@ -52,16 +52,33 @@ int gateway_policy_pin_model(struct cJSON *req, const char *agent_model);
  * / RemoteTrigger, etc., all mapped to "Subagent"). */
 int gateway_policy_is_denied_tool(const char *name);
 
+/* True when the response-side tool-policing policy is enabled. Cheap — one
+ * config_load + one bool read. The streaming /v1/messages path uses this as a
+ * single-branch dispatcher: when ON, the upstream is buffered + policed +
+ * replayed as SSE (via emit_message_as_sse); when OFF (the default), today's
+ * incremental relay/translator runs unchanged. */
+int gateway_prevent_subagents_enabled(void);
+
 /* Mutate `p` in place: memmove-compact denied entries out of `p->calls[]` so the
  * surviving `p->calls[0..p->call_count-1]` is a contiguous prefix of the original
  * (no realloc, no flag-and-skip). `p->call_count` is decremented to match.
- * `p->stop_reason` is rewritten to "tool_use" when `call_count > 0`, "end_turn"
- * when `call_count == 0` — the same mapping `anthropic_response_from_parsed`
- * (src/server/anthropic_ingress.c:435) re-derives from `call_count`, so the
- * post-police struct is wire-consistent with the renderer's mapping. The
- * `stop_reason` write also feeds the pre-existing `agent_record_token_audit` row
- * in `messages_buffered()` (it reads `parsed.stop_reason`), so the audit log
- * matches the wire.
+ * `p->stop_reason` is finalized as follows:
+ *   - All-dropped (call_count == 0) → "end_turn" (the wire's tool_use reply
+ *     became an end_turn reply).
+ *   - Upstream set a reason (stop_reason[0] != '\0', e.g. "max_tokens",
+ *     "stop_sequence", "refusal", "tool_use") AND some calls survive →
+ *     preserve verbatim. Partial drops must not lose the upstream's
+ *     truncation signal by re-deriving from call_count.
+ *   - Upstream didn't set a reason AND some calls survive → "tool_use"
+ *     (derive from call_count, since the upstream's omission means
+ *     "default tool_use").
+ * The renderer's `n_calls > 0 ? "tool_use" : "end_turn"` line 435 of
+ * anthropic_ingress.c is replaced (in this PR's diff) with
+ * `parsed->stop_reason[0] ? parsed->stop_reason : n_calls > 0 ? "tool_use"
+ * : "end_turn"` so the post-police struct's stop_reason is wire-consistent
+ * with the wire shape. The `stop_reason` value also feeds the
+ * pre-existing `agent_record_token_audit` row in `messages_buffered()` (it
+ * reads `parsed.stop_reason`), so the audit log matches the wire.
  *
  * Fields the function does NOT touch (by design): `id`, `name`, `is_tool_call`,
  * `content`, `assistant_message`, `prompt_tokens`, `completion_tokens`,

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -756,6 +756,74 @@ static int messages_stream(const char *body, server_http_sse_event_emit emit, vo
                                       agent_request_max_tokens(ag, jo_int(req, "max_tokens", 0)),
                                       jo_num(req, "temperature", 1.0), 1);
 
+   /* P2c streaming: when gateway_prevent_subagents is ON, the streaming
+    * path becomes buffered — we fetch the upstream reply to completion,
+    * run the police function on the parsed struct (same logic as the
+    * buffered /v1/messages path), and replay the policed reply as a
+    * well-formed Anthropic SSE sequence via emit_message_as_sse. Off (the
+    * default) falls through to today's incremental relay/translator. */
+   if (gateway_prevent_subagents_enabled())
+   {
+      char *buf_resp = NULL;
+      int buf_status;
+      parsed_response_t parsed;
+      memset(&parsed, 0, sizeof(parsed));
+      buf_status = agent_http_post(url, auth, prov_body ? prov_body : "{}", &buf_resp,
+                                   ag->timeout_ms, extra[0] ? extra : NULL);
+      if (buf_status == 200 && buf_resp)
+      {
+         cJSON *provider_resp = cJSON_Parse(buf_resp);
+         if (provider_resp)
+         {
+            if (driver && driver->parse_response)
+               driver->parse_response(provider_resp, buf_resp, &parsed);
+            else
+               agent_parse_response_openai(provider_resp, &parsed);
+            gateway_policy_police_parsed_response(&parsed);
+            emit_message_as_sse(&parsed, msg_id, model, emit, ctx);
+            /* Cost accounting (mirror the buffered path). */
+            if ((parsed.prompt_tokens > 0 || parsed.completion_tokens > 0) &&
+                agent_ingress_accounting_enabled())
+            {
+               agent_result_t ar;
+               memset(&ar, 0, sizeof(ar));
+               snprintf(ar.agent_name, sizeof(ar.agent_name), "%s", ag->name);
+               snprintf(ar.model, sizeof(ar.model), "%s", ag->model);
+               snprintf(ar.requested_model, sizeof(ar.requested_model), "%s", model ? model : "");
+               snprintf(ar.stop_reason, sizeof(ar.stop_reason), "%s", parsed.stop_reason);
+               ar.prompt_tokens = parsed.prompt_tokens;
+               ar.completion_tokens = parsed.completion_tokens;
+               ar.cache_write_tokens = parsed.cache_write_tokens;
+               ar.cache_read_tokens = parsed.cache_read_tokens;
+               agent_record_token_audit(&ar, "", "anthropic-ingress");
+            }
+            agent_free_parsed_response(&parsed);
+         }
+         else
+         {
+            char err[256];
+            snprintf(err, sizeof(err),
+                     "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+                     "\"message\":\"primary provider returned an unparseable reply\"}}");
+            if (emit)
+               emit(ctx, "error", err);
+         }
+         cJSON_Delete(provider_resp);
+      }
+      else
+      {
+         char err[256];
+         snprintf(err, sizeof(err),
+                  "{\"type\":\"error\",\"error\":{\"type\":\"api_error\","
+                  "\"message\":\"primary provider call failed with status %d\"}}",
+                  buf_status);
+         if (emit)
+            emit(ctx, "error", err);
+      }
+      free(buf_resp);
+      goto cleanup;
+   }
+
    if (driver_is_anthropic(driver))
    {
       anthropic_relay_ctx_t relay;

--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -722,3 +722,163 @@ void anthropic_stream_free(anthropic_stream_xlate_t *st)
 {
    free(st);
 }
+
+/* --- Buffered response replay as Anthropic SSE (P2c streaming) -------------
+ *
+ * The streaming /v1/messages paths take this route when
+ * `gateway_prevent_subagents` is ON: the upstream reply is buffered to
+ * completion, the police function compacts `parsed.calls[]`, and this
+ * helper replays the policed struct as a well-formed Anthropic SSE
+ * sequence — so the client sees the same wire shape it would have seen
+ * from the per-block translator, just buffered. Mirrors the wire shape
+ * produced by `anthropic_response_from_parsed` (same call_count-derivation
+ * rules, same usage fields). Pure (no I/O). */
+
+static void replay_emit(anthropic_sse_emit_fn emit, void *ctx, const char *event, cJSON *obj)
+{
+   char *json = cJSON_PrintUnformatted(obj);
+   if (json && emit)
+   {
+      emit(ctx, event, json);
+   }
+   free(json);
+   cJSON_Delete(obj);
+}
+
+static cJSON *make_message_start(const char *msg_id, const char *model, const parsed_response_t *p)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *msg;
+   cJSON *usage;
+   cJSON_AddStringToObject(o, "type", "message_start");
+   msg = cJSON_AddObjectToObject(o, "message");
+   cJSON_AddStringToObject(msg, "id", (msg_id && msg_id[0]) ? msg_id : "msg_aimee");
+   cJSON_AddStringToObject(msg, "type", "message");
+   cJSON_AddStringToObject(msg, "role", "assistant");
+   cJSON_AddStringToObject(msg, "model", (model && model[0]) ? model : "aimee-primary");
+   usage = cJSON_AddObjectToObject(msg, "usage");
+   cJSON_AddNumberToObject(usage, "input_tokens", p ? p->prompt_tokens : 0);
+   if (p && p->cache_write_tokens > 0)
+      cJSON_AddNumberToObject(usage, "cache_creation_input_tokens", p->cache_write_tokens);
+   if (p && p->cache_read_tokens > 0)
+      cJSON_AddNumberToObject(usage, "cache_read_input_tokens", p->cache_read_tokens);
+   return o;
+}
+
+static cJSON *make_content_block_start_text(int index)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *cb;
+   cJSON_AddStringToObject(o, "type", "content_block_start");
+   cJSON_AddNumberToObject(o, "index", index);
+   cb = cJSON_AddObjectToObject(o, "content_block");
+   cJSON_AddStringToObject(cb, "type", "text");
+   cJSON_AddStringToObject(cb, "text", "");
+   return o;
+}
+
+static cJSON *make_content_block_delta_text(int index, const char *text)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *d;
+   cJSON_AddStringToObject(o, "type", "content_block_delta");
+   cJSON_AddNumberToObject(o, "index", index);
+   d = cJSON_AddObjectToObject(o, "delta");
+   cJSON_AddStringToObject(d, "type", "text_delta");
+   cJSON_AddStringToObject(d, "text", text ? text : "");
+   return o;
+}
+
+static cJSON *make_content_block_stop(int index)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddStringToObject(o, "type", "content_block_stop");
+   cJSON_AddNumberToObject(o, "index", index);
+   return o;
+}
+
+static cJSON *make_content_block_start_tool(int index, const char *id, const char *name)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *cb;
+   cJSON_AddStringToObject(o, "type", "content_block_start");
+   cJSON_AddNumberToObject(o, "index", index);
+   cb = cJSON_AddObjectToObject(o, "content_block");
+   cJSON_AddStringToObject(cb, "type", "tool_use");
+   cJSON_AddStringToObject(cb, "id", id ? id : "toolu_aimee");
+   cJSON_AddStringToObject(cb, "name", name ? name : "");
+   cJSON_AddObjectToObject(cb, "input");
+   return o;
+}
+
+static cJSON *make_content_block_delta_input_json(int index, const char *partial_json)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *d;
+   cJSON_AddStringToObject(o, "type", "content_block_delta");
+   cJSON_AddNumberToObject(o, "index", index);
+   d = cJSON_AddObjectToObject(o, "delta");
+   cJSON_AddStringToObject(d, "type", "input_json_delta");
+   cJSON_AddStringToObject(d, "partial_json", partial_json ? partial_json : "{}");
+   return o;
+}
+
+static cJSON *make_message_delta(const parsed_response_t *p, int n_calls)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON *u;
+   const char *stop =
+       (p && p->stop_reason[0]) ? p->stop_reason : (n_calls > 0 ? "tool_use" : "end_turn");
+   cJSON_AddStringToObject(o, "type", "message_delta");
+   cJSON *delta = cJSON_AddObjectToObject(o, "delta");
+   cJSON_AddStringToObject(delta, "stop_reason", stop);
+   cJSON_AddStringToObject(delta, "stop_sequence", "");
+   u = cJSON_AddObjectToObject(o, "usage");
+   cJSON_AddNumberToObject(u, "output_tokens", p ? p->completion_tokens : 0);
+   if (p && p->cache_read_tokens > 0)
+      cJSON_AddNumberToObject(u, "cache_read_input_tokens", p->cache_read_tokens);
+   return o;
+}
+
+void emit_message_as_sse(const parsed_response_t *parsed, const char *msg_id, const char *model,
+                         anthropic_sse_emit_fn emit, void *ctx)
+{
+   int n_calls;
+   int index;
+
+   if (!emit)
+      return;
+   n_calls = parsed ? parsed->call_count : 0;
+
+   replay_emit(emit, ctx, "message_start", make_message_start(msg_id, model, parsed));
+
+   /* Always emit one text content_block_start / (text_delta)? / stop pair —
+    * even when parsed->content is empty, matching the buffered renderer's
+    * empty-text-block fallback. */
+   index = 0;
+   replay_emit(emit, ctx, "content_block_start", make_content_block_start_text(index));
+   if (parsed && parsed->content && parsed->content[0])
+   {
+      replay_emit(emit, ctx, "content_block_delta",
+                  make_content_block_delta_text(index, parsed->content));
+   }
+   replay_emit(emit, ctx, "content_block_stop", make_content_block_stop(index));
+
+   if (parsed)
+   {
+      int i;
+      for (i = 0; i < n_calls; i++)
+      {
+         const parsed_tool_call_t *c = &parsed->calls[i];
+         index++;
+         replay_emit(emit, ctx, "content_block_start",
+                     make_content_block_start_tool(index, c->id, c->name));
+         replay_emit(emit, ctx, "content_block_delta",
+                     make_content_block_delta_input_json(index, c->arguments));
+         replay_emit(emit, ctx, "content_block_stop", make_content_block_stop(index));
+      }
+   }
+
+   replay_emit(emit, ctx, "message_delta", make_message_delta(parsed, n_calls));
+   replay_emit(emit, ctx, "message_stop", cJSON_CreateObject());
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -178,6 +178,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-anthropic-ingress \
                $(TESTPREFIX)/unit-test-anthropic-http \
                $(TESTPREFIX)/unit-test-anthropic-http-p2c \
+               $(TESTPREFIX)/unit-test-anthropic-http-streaming-p2c \
                $(TESTPREFIX)/unit-test-gateway-policy \
                $(TESTPREFIX)/unit-test-gateway-pipeline \
                $(TESTPREFIX)/unit-test-hud \
@@ -1646,6 +1647,14 @@ $(TESTPREFIX)/unit-test-anthropic-http: $(OBJDIR)/tests/test_anthropic_http.o $(
 # don't have to deal with guardrails dependencies; this test exercises the
 # full wiring end-to-end.
 $(TESTPREFIX)/unit-test-anthropic-http-p2c: $(OBJDIR)/tests/test_anthropic_http_p2c.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
+# P2c streaming integration test: linked against the REAL gateway_policy.o
+# so the streaming policy branch in messages_stream runs as in production.
+# Same minimal-link pattern as the buffered P2c test above; the SSE replay
+# helper + police function exercise the buffered-fetch + replay flow when
+# `gateway_prevent_subagents` is ON.
+$(TESTPREFIX)/unit-test-anthropic-http-streaming-p2c: $(OBJDIR)/tests/test_anthropic_http_streaming_p2c.o $(OBJDIR)/server/anthropic_ingress.o $(OBJDIR)/sse_parser.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o
 	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
 
 $(TESTPREFIX)/unit-test-gateway-policy: $(OBJDIR)/tests/test_gateway_policy.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -239,6 +239,12 @@ int gateway_policy_pin_model(cJSON *req, const char *agent_model)
    (void)agent_model;
    return 0; /* pin is off in these shape tests; covered by test_gateway_policy */
 }
+/* P2c streaming branch gate: off by default in these whitebox shape tests
+ * (the real predicate is exercised by test_anthropic_http-p2c). */
+int gateway_prevent_subagents_enabled(void)
+{
+   return 0;
+}
 /* P2c (response-side tool policing) is exercised by its own dedicated
  * integration test (unit-test-anthropic-http-p2c) which links the real
  * gateway_policy.o. In these whitebox shape tests we stub it to a no-op

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -1,0 +1,665 @@
+/* test_anthropic_http_streaming_p2c.c: P2c streaming-side response-policing
+ * integration tests for the Anthropic /v1/messages path. Like the buffered
+ * P2c test (test_anthropic_http_p2c.c), this links the real gateway_policy.o
+ * so the production police function runs end-to-end. The two streaming
+ * paths (Anthropic-native raw-byte relay, OpenAI-via-translator per-block)
+ * both bypass their incremental paths when the policy is ON, fall through
+ * to a buffered upstream fetch + police + emit_message_as_sse replay.
+ *
+ * Scope: covers the policy-ON path (drops + replays) AND the policy-OFF
+ * regression canary (today's incremental paths are unchanged). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../headers/aimee.h"
+#include "../headers/agent_config.h"
+#include "../headers/agent_exec.h"
+#include "../headers/agent_protocol.h"
+#include "../headers/anthropic_ingress.h"
+#include "../headers/delegate_driver.h"
+#include "../headers/server_http.h"
+#include "../vendor/headers/cJSON.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+static const delegate_driver_t *g_driver;
+static char *g_last_body;
+static char *g_last_extra;
+static int g_stream_status;
+static const char *g_stream_payload;
+/* Fake upstream response body for the BUFFERED fetch on the policy-ON path.
+ * The streaming path uses agent_http_post (not the streaming variant) when
+ * the policy is on, so we hook the same `g_response_body` machinery as the
+ * buffered P2c test. NULL = empty "{}" (regression-canary default). */
+static const char *g_response_body;
+static int g_response_status;
+/* P2c policy gate. The real config_load is stubbed to honor this global;
+ * flip g_prevent to 1 to enable the streaming-side tool policing. */
+static int g_prevent;
+/* Tool-use fixtures for parsed_with_tool_uses (the driver parse_response
+ * stub reads `g_tool_uses_json` and synthesizes a populated parsed struct). */
+static const char *g_tool_uses_json;
+static const char *g_upstream_stop_reason;
+
+static void reset_capture(void)
+{
+   free(g_last_body);
+   g_last_body = NULL;
+   free(g_last_extra);
+   g_last_extra = NULL;
+   g_stream_status = 200;
+   g_stream_payload = NULL;
+   g_response_body = NULL;
+   g_response_status = 200;
+   g_prevent = 0;
+   g_tool_uses_json = NULL;
+   g_upstream_stop_reason = NULL;
+}
+
+int agent_load_config(agent_config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   cfg->agent_count = 1;
+   snprintf(cfg->agents[0].name, sizeof(cfg->agents[0].name), "primary");
+   snprintf(cfg->agents[0].provider, sizeof(cfg->agents[0].provider), "%s",
+            g_driver && g_driver->name ? g_driver->name : "anthropic");
+   snprintf(cfg->agents[0].model, sizeof(cfg->agents[0].model), "configured-claude");
+   cfg->agents[0].timeout_ms = 1;
+   return 0;
+}
+
+agent_t *agent_find(agent_config_t *cfg, const char *name)
+{
+   (void)name;
+   return cfg && cfg->agent_count ? &cfg->agents[0] : NULL;
+}
+
+void delegate_drivers_init(void)
+{
+}
+
+const delegate_driver_t *delegate_driver_get(const char *provider)
+{
+   (void)provider;
+   return g_driver;
+}
+
+void delegate_get_caps(const delegate_driver_t *driver, const agent_t *agent, driver_caps_t *caps)
+{
+   memset(caps, 0, sizeof(*caps));
+   if (driver && driver->get_caps)
+   {
+      driver->get_caps(agent, caps);
+      return;
+   }
+   caps->capability_flags = DRIVER_CAP_TOOL_CALLS | DRIVER_CAP_STREAMING;
+   caps->context_limit = DRIVER_CTX_LARGE;
+}
+
+int delegate_build_url(const delegate_driver_t *driver, const agent_t *agent, char *url,
+                       size_t url_len)
+{
+   (void)driver;
+   (void)agent;
+   snprintf(url, url_len, "https://example.invalid/v1/messages");
+   return 0;
+}
+
+int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
+{
+   (void)agent;
+   snprintf(buf, buf_len, "Bearer test");
+   return 0;
+}
+
+void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len)
+{
+   (void)agent;
+   if (buf_len)
+      buf[0] = '\0';
+}
+
+cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *tools,
+                                  int max_tokens, double temperature)
+{
+   cJSON *out = cJSON_CreateObject();
+   (void)agent;
+   (void)messages;
+   (void)tools;
+   (void)max_tokens;
+   (void)temperature;
+   cJSON_AddStringToObject(out, "model", "openai-test");
+   return out;
+}
+
+int agent_request_max_tokens(const agent_t *agent, int requested)
+{
+   (void)agent;
+   return requested > 0 ? requested : 8192;
+}
+
+int agent_http_post(const char *url, const char *auth_header, const char *body, char **response_buf,
+                    int timeout_ms, const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   free(g_last_body);
+   g_last_body = strdup(body ? body : "");
+   assert(g_last_body != NULL);
+   free(g_last_extra);
+   g_last_extra = strdup(extra_headers ? extra_headers : "");
+   *response_buf = strdup(g_response_body ? g_response_body : "{}");
+   return g_response_status;
+}
+
+int agent_http_post_stream(const char *url, const char *auth_header, const char *body,
+                           agent_http_stream_cb callback, void *userdata, int timeout_ms,
+                           const char *extra_headers)
+{
+   (void)url;
+   (void)auth_header;
+   (void)timeout_ms;
+   (void)extra_headers;
+   free(g_last_body);
+   g_last_body = strdup(body ? body : "");
+   assert(g_last_body != NULL);
+   if (g_stream_payload && callback)
+      assert(callback(g_stream_payload, strlen(g_stream_payload), userdata) == 0);
+   return g_stream_status;
+}
+
+void agent_parse_response_openai(cJSON *root, parsed_response_t *out)
+{
+   (void)root;
+   memset(out, 0, sizeof(*out));
+}
+
+void agent_free_parsed_response(parsed_response_t *p)
+{
+   if (!p)
+      return;
+   free(p->content);
+   for (int i = 0; i < p->call_count; i++)
+      free(p->calls[i].arguments);
+}
+
+int session_compact_estimate_tokens(cJSON *messages)
+{
+   return messages ? cJSON_GetArraySize(messages) : 0;
+}
+
+void server_http_set_messages_handler(server_http_completion_fn fn)
+{
+   (void)fn;
+}
+void server_http_set_messages_stream_handler(server_http_responses_stream_fn fn)
+{
+   (void)fn;
+}
+void server_http_set_count_tokens_handler(server_http_completion_fn fn)
+{
+   (void)fn;
+}
+
+void agent_record_token_audit(const agent_result_t *result, const char *role, const char *source)
+{
+   (void)result;
+   (void)role;
+   (void)source;
+}
+void agent_record_token_audit_kind(const agent_result_t *result, const char *role,
+                                   const char *source, const char *usage_kind)
+{
+   (void)result;
+   (void)role;
+   (void)source;
+   (void)usage_kind;
+}
+int agent_ingress_accounting_enabled(void)
+{
+   return 1;
+}
+
+int agent_http_last_retry_after(void)
+{
+   return 0;
+}
+
+/* Driver parse stub (mirrors test_anthropic_http_p2c.c): populates
+ * parsed.calls[] from g_tool_uses_json, leaves content empty, and copies
+ * g_upstream_stop_reason into parsed.stop_reason. */
+static void parsed_with_tool_uses(cJSON *root, const char *body, parsed_response_t *out)
+{
+   cJSON *arr;
+   int i;
+   int cap;
+   (void)root;
+   (void)body;
+   memset(out, 0, sizeof(*out));
+   if (g_upstream_stop_reason)
+      snprintf(out->stop_reason, sizeof(out->stop_reason), "%s", g_upstream_stop_reason);
+   arr = g_tool_uses_json ? cJSON_Parse(g_tool_uses_json) : NULL;
+   if (!cJSON_IsArray(arr))
+   {
+      cJSON_Delete(arr);
+      return;
+   }
+   cap = cJSON_GetArraySize(arr);
+   if (cap > AGENT_MAX_TOOL_CALLS)
+      cap = AGENT_MAX_TOOL_CALLS;
+   for (i = 0; i < cap; i++)
+   {
+      cJSON *t = cJSON_GetArrayItem(arr, i);
+      const cJSON *id = cJSON_GetObjectItemCaseSensitive(t, "id");
+      const cJSON *name = cJSON_GetObjectItemCaseSensitive(t, "name");
+      const cJSON *args = cJSON_GetObjectItemCaseSensitive(t, "arguments");
+      snprintf(out->calls[i].id, sizeof(out->calls[i].id), "%s",
+               cJSON_IsString(id) ? id->valuestring : "");
+      snprintf(out->calls[i].name, sizeof(out->calls[i].name), "%s",
+               cJSON_IsString(name) ? name->valuestring : "");
+      out->calls[i].arguments = cJSON_IsString(args) ? strdup(args->valuestring) : strdup("{}");
+   }
+   out->call_count = cap;
+   cJSON_Delete(arr);
+}
+
+/* Minimal config_load stub (the real one depends on the YAML loader,
+ * out of scope for this minimal-link test). Mirrors test_anthropic_http_p2c.c. */
+int config_load(config_t *cfg)
+{
+   if (cfg)
+   {
+      memset(cfg, 0, sizeof(*cfg));
+      cfg->gateway_prevent_subagents = g_prevent;
+   }
+   return 0;
+}
+
+/* Minimal guardrails_canonical_tool_name stub: maps Task/Agent/spawn_agent to
+ * "Subagent" (matches the production canonicalization used by
+ * gateway_policy.c via the real guardrails_orchestrator.o). */
+const char *guardrails_canonical_tool_name(const char *n)
+{
+   if (n && (strcmp(n, "Task") == 0 || strcmp(n, "Agent") == 0 || strcmp(n, "spawn_agent") == 0))
+      return "Subagent";
+   return n ? n : "";
+}
+
+/* Pre-injection stubs (the real ones depend on KB clients + config; this
+ * test is minimal-link). Mirrors test_anthropic_http_p2c.c. */
+static char *g_stub_preinject_env = NULL;
+char *ingress_preinject_query_from_messages(const cJSON *messages)
+{
+   return messages ? strdup("q") : NULL;
+}
+char *ingress_preinject_build(const char *query, int request_disabled)
+{
+   (void)query;
+   (void)request_disabled;
+   return g_stub_preinject_env ? strdup(g_stub_preinject_env) : NULL;
+}
+
+#include "../server/anthropic_http.c"
+
+/* --- captured SSE events for the replay path ------------------------- */
+
+#define REPLAY_CAP 32
+typedef struct
+{
+   char events[REPLAY_CAP][32];
+   char data[REPLAY_CAP][2048];
+   int count;
+} replay_cap_t;
+
+static void replay_capture(void *ctx, const char *event, const char *data)
+{
+   replay_cap_t *c = (replay_cap_t *)ctx;
+   assert(c->count < REPLAY_CAP);
+   snprintf(c->events[c->count], sizeof(c->events[c->count]), "%s", event);
+   snprintf(c->data[c->count], sizeof(c->data[c->count]), "%s", data);
+   c->count++;
+}
+
+/* --- Anthropic-native streaming tests ---------------------------------- */
+
+/* Policy ON, Anthropic-native primary, upstream reply contains a subagent
+ * tool_use. The streaming path takes the buffered-and-replay branch: the
+ * raw byte relay is bypassed, the upstream reply is fetched as a single
+ * agent_http_post, the police function drops the subagent call, and
+ * emit_message_as_sse replays the surviving sequence. No tool_use block
+ * on the wire; stop_reason "end_turn" (all-dropped rewrite). */
+static void test_streaming_anthropic_police_drops_subagent_tool_use(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+   const char *names[] = {"Task"};
+   const char *ids[] = {"t1"};
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[{\"id\":\"t1\",\"name\":\"Task\",\"arguments\":\"{}\"}]";
+   g_upstream_stop_reason = "tool_use";
+   g_prevent = 1;
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   /* Replay emits message_start, [text_start, text_stop], message_delta,
+    * message_stop (no tool_use blocks survived). */
+   assert(cap.count >= 5);
+   int seen_tool_use = 0;
+   const char *stop_reason = NULL;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_delta") == 0)
+         stop_reason = strstr(cap.data[i], "\"stop_reason\":\"");
+      if (strcmp(cap.events[i], "content_block_start") == 0 &&
+          strstr(cap.data[i], "\"type\":\"tool_use\""))
+         seen_tool_use = 1;
+   }
+   assert(!seen_tool_use);
+   assert(stop_reason != NULL);
+   assert(strstr(stop_reason, "end_turn") != NULL);
+
+   reset_capture();
+   (void)names;
+   (void)ids;
+   PASS("streaming_anthropic_police_drops_subagent_tool_use");
+}
+
+/* Policy ON, Anthropic-native primary, upstream reply is text-only. The
+ * streaming path takes the buffered-and-replay branch; the replay
+ * emits the text block + an end_turn message_delta. */
+static void test_streaming_anthropic_police_on_no_tool_use_passthrough(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[]";
+   g_upstream_stop_reason = "end_turn";
+   g_prevent = 1;
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   /* message_start, [text_start, text_stop], message_delta, message_stop. */
+   assert(cap.count >= 4);
+   int seen_tool_use = 0;
+   const char *stop_reason = NULL;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_delta") == 0)
+         stop_reason = strstr(cap.data[i], "\"stop_reason\":\"");
+      if (strcmp(cap.events[i], "content_block_start") == 0 &&
+          strstr(cap.data[i], "\"type\":\"tool_use\""))
+         seen_tool_use = 1;
+   }
+   assert(!seen_tool_use);
+   assert(stop_reason != NULL);
+   assert(strstr(stop_reason, "end_turn") != NULL);
+
+   reset_capture();
+   PASS("streaming_anthropic_police_on_no_tool_use_passthrough");
+}
+
+/* Policy ON, upstream returns 5xx. The streaming path emits a single
+ * `error` event so the client's SSE reader terminates cleanly (no
+ * partial SSE events). */
+static void test_streaming_anthropic_policy_on_upstream_error_returns_error(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[]";
+   g_upstream_stop_reason = "tool_use";
+   g_prevent = 1;
+   g_response_status = 502;
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   /* Exactly one error event, no other events. */
+   assert(cap.count == 1);
+   assert(strcmp(cap.events[0], "error") == 0);
+   assert(strstr(cap.data[0], "\"type\":\"error\"") != NULL);
+   assert(strstr(cap.data[0], "status 502") != NULL);
+
+   reset_capture();
+   PASS("streaming_anthropic_policy_on_upstream_error_returns_error");
+}
+
+/* Policy OFF regression canary: today's incremental raw byte relay runs
+ * unchanged. We send a fake Anthropic SSE upstream payload and assert
+ * the events pass through verbatim (the relay emits the parsed data
+ * payload as a "message" event — its event name is the SSE `event:` line
+ * or "message" by default). */
+static void test_streaming_anthropic_policy_off_is_byte_neutral(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+
+   reset_capture();
+   g_driver = &driver;
+   g_prevent = 0;
+   g_stream_payload = "event: message_start\ndata: "
+                      "{\"type\":\"message_start\",\"message\":{\"id\":\"m1\"}}\n\n"
+                      "event: message_stop\ndata: {}\n\n";
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   /* Today the relay emits at least message_start + message_stop verbatim. */
+   int saw_start = 0, saw_stop = 0;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_start") == 0 && strstr(cap.data[i], "\"id\":\"m1\""))
+         saw_start = 1;
+      if (strcmp(cap.events[i], "message_stop") == 0)
+         saw_stop = 1;
+   }
+   assert(saw_start);
+   assert(saw_stop);
+
+   reset_capture();
+   PASS("streaming_anthropic_policy_off_is_byte_neutral");
+}
+
+/* --- OpenAI-via-translator streaming tests ----------------------------- */
+
+/* Partial-drop + max_tokens: upstream emits two tool_use blocks
+ * (subagent + web_search) with `max_tokens` stop_reason; the policy
+ * drops the subagent. The replay must carry `stop_reason:"max_tokens"`
+ * verbatim (NOT `"tool_use"`, NOT `"end_turn"`) and exactly one
+ * `tool_use` block named `web_search`. Pins the B2 fix end-to-end. */
+static void test_streaming_anthropic_partial_drop_preserves_max_tokens(void)
+{
+   const delegate_driver_t driver = {.name = "anthropic", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[{\"id\":\"t1\",\"name\":\"Task\",\"arguments\":\"{}\"},"
+                      "{\"id\":\"t2\",\"name\":\"web_search\",\"arguments\":\"{}\"}]";
+   g_upstream_stop_reason = "max_tokens";
+   g_prevent = 1;
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   /* Find message_delta and assert stop_reason is "max_tokens" verbatim. */
+   const char *stop = NULL;
+   int tool_use_count = 0;
+   int web_search_seen = 0;
+   int task_seen = 0;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_delta") == 0)
+         stop = strstr(cap.data[i], "\"stop_reason\":\"");
+      if (strcmp(cap.events[i], "content_block_start") == 0 &&
+          strstr(cap.data[i], "\"type\":\"tool_use\""))
+      {
+         tool_use_count++;
+         if (strstr(cap.data[i], "\"name\":\"web_search\""))
+            web_search_seen = 1;
+         if (strstr(cap.data[i], "\"name\":\"Task\""))
+            task_seen = 1;
+      }
+   }
+   assert(stop != NULL);
+   assert(strstr(stop, "max_tokens") != NULL);
+   assert(tool_use_count == 1);
+   assert(web_search_seen);
+   assert(!task_seen);
+
+   reset_capture();
+   PASS("streaming_anthropic_partial_drop_preserves_max_tokens");
+}
+
+/* Policy ON, OpenAI-via-translator primary, upstream reply contains a
+ * subagent tool_use. Same shape as the Anthropic-native case: replay,
+ * no tool_use on the wire, end_turn. */
+static void test_streaming_openai_police_drops_subagent_tool_use(void)
+{
+   const delegate_driver_t driver = {.name = "openai", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+   const char *names[] = {"Task"};
+   const char *ids[] = {"t1"};
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[{\"id\":\"t1\",\"name\":\"Task\",\"arguments\":\"{}\"}]";
+   g_upstream_stop_reason = "tool_use";
+   g_prevent = 1;
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   int seen_tool_use = 0;
+   const char *stop_reason = NULL;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_delta") == 0)
+         stop_reason = strstr(cap.data[i], "\"stop_reason\":\"");
+      if (strcmp(cap.events[i], "content_block_start") == 0 &&
+          strstr(cap.data[i], "\"type\":\"tool_use\""))
+         seen_tool_use = 1;
+   }
+   assert(!seen_tool_use);
+   assert(stop_reason != NULL);
+   assert(strstr(stop_reason, "end_turn") != NULL);
+
+   reset_capture();
+   (void)names;
+   (void)ids;
+   PASS("streaming_openai_police_drops_subagent_tool_use");
+}
+
+/* Policy ON, OpenAI-via-translator primary, text-only upstream reply. */
+static void test_streaming_openai_police_on_no_tool_use_passthrough(void)
+{
+   const delegate_driver_t driver = {.name = "openai", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+
+   reset_capture();
+   g_driver = &driver;
+   g_tool_uses_json = "[]";
+   g_upstream_stop_reason = "end_turn";
+   g_prevent = 1;
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   int seen_tool_use = 0;
+   const char *stop_reason = NULL;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_delta") == 0)
+         stop_reason = strstr(cap.data[i], "\"stop_reason\":\"");
+      if (strcmp(cap.events[i], "content_block_start") == 0 &&
+          strstr(cap.data[i], "\"type\":\"tool_use\""))
+         seen_tool_use = 1;
+   }
+   assert(!seen_tool_use);
+   assert(stop_reason != NULL);
+   assert(strstr(stop_reason, "end_turn") != NULL);
+
+   reset_capture();
+   PASS("streaming_openai_police_on_no_tool_use_passthrough");
+}
+
+/* Policy OFF regression canary: today's OpenAI-via-translator per-block
+ * translator runs unchanged (we send a synthetic OpenAI chunk payload and
+ * assert the translator emits message_start + message_stop). */
+static void test_streaming_openai_policy_off_is_byte_neutral(void)
+{
+   const delegate_driver_t driver = {.name = "openai", .parse_response = parsed_with_tool_uses};
+   replay_cap_t cap;
+
+   reset_capture();
+   g_driver = &driver;
+   g_prevent = 0;
+   g_stream_payload = "data: "
+                      "{\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n"
+                      "data: [DONE]\n\n";
+
+   memset(&cap, 0, sizeof(cap));
+   messages_stream("{\"model\":\"ignored\",\"max_tokens\":16,"
+                   "\"stream\":true,"
+                   "\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}",
+                   replay_capture, &cap);
+
+   /* The translator emits message_start at least once. */
+   int saw_start = 0;
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_start") == 0)
+         saw_start = 1;
+   }
+   assert(saw_start);
+
+   reset_capture();
+   PASS("streaming_openai_policy_off_is_byte_neutral");
+}
+
+int main(void)
+{
+   printf("test_anthropic_http_streaming_p2c:\n");
+   test_streaming_anthropic_police_drops_subagent_tool_use();
+   test_streaming_anthropic_police_on_no_tool_use_passthrough();
+   test_streaming_anthropic_policy_on_upstream_error_returns_error();
+   test_streaming_anthropic_policy_off_is_byte_neutral();
+   test_streaming_anthropic_partial_drop_preserves_max_tokens();
+   test_streaming_openai_police_drops_subagent_tool_use();
+   test_streaming_openai_police_on_no_tool_use_passthrough();
+   test_streaming_openai_policy_off_is_byte_neutral();
+   printf("anthropic_http_streaming_p2c: OK\n");
+   return 0;
+}

--- a/src/tests/test_anthropic_ingress.c
+++ b/src/tests/test_anthropic_ingress.c
@@ -468,6 +468,229 @@ static void test_request_headers_passthrough(void)
    PASS("request_headers_passthrough");
 }
 
+/* --- emit_message_as_sse (P2c streaming replay) ------------------------ */
+
+/* Captured SSE events, in order. The replay helper emits one entry per
+ * call to the emit callback; tests assert on (event, payload) pairs. */
+#define REPLAY_CAP 32
+typedef struct
+{
+   char events[REPLAY_CAP][32];
+   char data[REPLAY_CAP][1024];
+   int count;
+} replay_capture_t;
+
+static void replay_capture(void *ctx, const char *event, const char *data)
+{
+   replay_capture_t *c = (replay_capture_t *)ctx;
+   assert(c->count < REPLAY_CAP);
+   snprintf(c->events[c->count], sizeof(c->events[c->count]), "%s", event);
+   snprintf(c->data[c->count], sizeof(c->data[c->count]), "%s", data);
+   c->count++;
+}
+
+static parsed_response_t seed_parsed_for_replay(int n_calls, const char *names[], const char *ids[],
+                                                const char *stop_reason, const char *content)
+{
+   parsed_response_t p;
+   int i;
+   memset(&p, 0, sizeof(p));
+   p.call_count = n_calls;
+   if (stop_reason)
+      snprintf(p.stop_reason, sizeof(p.stop_reason), "%s", stop_reason);
+   p.content = content ? strdup(content) : NULL;
+   p.prompt_tokens = 17;
+   p.completion_tokens = 23;
+   p.cache_write_tokens = 0;
+   p.cache_read_tokens = 0;
+   for (i = 0; i < n_calls; i++)
+   {
+      snprintf(p.calls[i].id, sizeof(p.calls[i].id), "%s", ids[i]);
+      snprintf(p.calls[i].name, sizeof(p.calls[i].name), "%s", names[i]);
+      p.calls[i].arguments = strdup("{\"k\":\"v\"}");
+   }
+   return p;
+}
+
+static void free_parsed_for_replay(parsed_response_t *p)
+{
+   int i;
+   free(p->content);
+   for (i = 0; i < p->call_count; i++)
+      free(p->calls[i].arguments);
+}
+
+/* Text-only reply: message_start, one text content_block_start / delta /
+ * stop, message_delta, message_stop. */
+static void test_emit_message_as_sse_replays_text_only(void)
+{
+   replay_capture_t cap;
+   parsed_response_t p = seed_parsed_for_replay(0, NULL, NULL, "end_turn", "hello");
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_t1", "claude-test", replay_capture, &cap);
+   assert(cap.count == 6);
+   assert(strcmp(cap.events[0], "message_start") == 0);
+   assert(strcmp(cap.events[1], "content_block_start") == 0);
+   assert(strcmp(cap.events[2], "content_block_delta") == 0);
+   assert(strcmp(cap.events[3], "content_block_stop") == 0);
+   assert(strcmp(cap.events[4], "message_delta") == 0);
+   assert(strcmp(cap.events[5], "message_stop") == 0);
+   /* The text_delta payload carries the content string. */
+   assert(strstr(cap.data[2], "\"text_delta\"") != NULL);
+   assert(strstr(cap.data[2], "\"hello\"") != NULL);
+   /* message_delta carries stop_reason verbatim from parsed (end_turn). */
+   assert(strstr(cap.data[4], "\"stop_reason\":\"end_turn\"") != NULL);
+   /* message_start carries input_tokens = 17, output_tokens not yet (it's
+    * in message_delta). */
+   assert(strstr(cap.data[0], "\"input_tokens\":17") != NULL);
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_replays_text_only");
+}
+
+/* Empty content (the "no_text" + "calls_0" combo): one empty text block
+ * is emitted, matching the buffered renderer's empty-text-block fallback. */
+static void test_emit_message_as_sse_replays_empty_content_as_single_text_block(void)
+{
+   replay_capture_t cap;
+   parsed_response_t p = seed_parsed_for_replay(0, NULL, NULL, "end_turn", NULL);
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_e1", "claude-test", replay_capture, &cap);
+   assert(cap.count == 5); /* start, text_start, text_stop, message_delta, message_stop */
+   assert(strcmp(cap.events[0], "message_start") == 0);
+   assert(strcmp(cap.events[1], "content_block_start") == 0);
+   assert(strcmp(cap.events[2], "content_block_stop") == 0);
+   assert(strcmp(cap.events[3], "message_delta") == 0);
+   assert(strcmp(cap.events[4], "message_stop") == 0);
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_replays_empty_content_as_single_text_block");
+}
+
+/* Single surviving tool_use (post-police): message_start, empty text
+ * block, tool_use content_block_start + input_json_delta + stop,
+ * message_delta, message_stop. */
+static void test_emit_message_as_sse_replays_surviving_tool_calls(void)
+{
+   replay_capture_t cap;
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"toolu_test_1"};
+   parsed_response_t p = seed_parsed_for_replay(1, names, ids, "tool_use", NULL);
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_s1", "claude-test", replay_capture, &cap);
+   /* start, text_start, text_stop, tool_start, input_delta, tool_stop, md, ms = 8 */
+   assert(cap.count == 8);
+   assert(strcmp(cap.events[3], "content_block_start") == 0); /* tool_use */
+   assert(strstr(cap.data[3], "\"type\":\"tool_use\"") != NULL);
+   assert(strstr(cap.data[3], "\"name\":\"web_search\"") != NULL);
+   assert(strstr(cap.data[3], "\"index\":1") != NULL);        /* index 1 (after text) */
+   assert(strcmp(cap.events[4], "content_block_delta") == 0); /* input_json_delta */
+   assert(strstr(cap.data[4], "\"input_json_delta\"") != NULL);
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_replays_surviving_tool_calls");
+}
+
+/* Text + surviving tool_use in the same reply: text block index 0,
+ * tool_use block index 1. */
+static void test_emit_message_as_sse_replays_text_and_tool_calls(void)
+{
+   replay_capture_t cap;
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"toolu_1"};
+   parsed_response_t p = seed_parsed_for_replay(1, names, ids, "tool_use", "context");
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_b1", "claude-test", replay_capture, &cap);
+   /* start, text_start, text_delta, text_stop, tool_start, input_delta,
+    * tool_stop, md, ms = 9 */
+   assert(cap.count == 9);
+   assert(strcmp(cap.events[1], "content_block_start") == 0);
+   assert(strstr(cap.data[1], "\"index\":0") != NULL);
+   assert(strstr(cap.data[1], "\"type\":\"text\"") != NULL);
+   assert(strcmp(cap.events[4], "content_block_start") == 0);
+   assert(strstr(cap.data[4], "\"index\":1") != NULL);
+   assert(strstr(cap.data[4], "\"type\":\"tool_use\"") != NULL);
+   assert(strstr(cap.data[4], "\"name\":\"web_search\"") != NULL);
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_replays_text_and_tool_calls");
+}
+
+/* Multiple surviving tool_use blocks: police has already compacted to
+ * zero or more; verify per-block indices are correct (0, 1, 2...) and the
+ * original names are preserved. */
+static void test_emit_message_as_sse_replays_multiple_surviving_tool_calls(void)
+{
+   replay_capture_t cap;
+   const char *names[] = {"web_search", "Read"}; /* police already dropped the middle one */
+   const char *ids[] = {"t1", "t3"};
+   parsed_response_t p = seed_parsed_for_replay(2, names, ids, "tool_use", NULL);
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_m1", "claude-test", replay_capture, &cap);
+   /* start, text_start, text_stop, [tool_start, input_delta, tool_stop] x2,
+    * md, ms = 1 + 2 + 6 + 1 + 1 = 11 */
+   assert(cap.count == 11);
+   /* Two tool_use content_block_start events at indices 3 and 6 (events 3, 6). */
+   assert(strstr(cap.data[3], "\"index\":1") != NULL); /* first tool, index 1 */
+   assert(strstr(cap.data[3], "\"name\":\"web_search\"") != NULL);
+   assert(strstr(cap.data[6], "\"index\":2") != NULL); /* second tool, index 2 */
+   assert(strstr(cap.data[6], "\"name\":\"Read\"") != NULL);
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_replays_multiple_surviving_tool_calls");
+}
+
+/* Cache tokens propagate: cache_creation in message_start.usage (input
+ * side) and cache_read in message_delta.usage (output side). Distinct
+ * fields per Anthropic's wire format. */
+static void test_emit_message_as_sse_propagates_usage(void)
+{
+   replay_capture_t cap;
+   parsed_response_t p = seed_parsed_for_replay(0, NULL, NULL, "end_turn", "hi");
+   p.prompt_tokens = 100;
+   p.completion_tokens = 50;
+   p.cache_write_tokens = 25; /* Anthropic: cache_creation_input_tokens */
+   p.cache_read_tokens = 10;
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_u1", "claude-test", replay_capture, &cap);
+   /* message_start.usage carries input_tokens + cache_creation + cache_read. */
+   assert(strstr(cap.data[0], "\"input_tokens\":100") != NULL);
+   assert(strstr(cap.data[0], "\"cache_creation_input_tokens\":25") != NULL);
+   assert(strstr(cap.data[0], "\"cache_read_input_tokens\":10") != NULL);
+   /* message_delta.usage carries output_tokens + cache_read. */
+   assert(strstr(cap.data[4], "\"output_tokens\":50") != NULL);
+   assert(strstr(cap.data[4], "\"cache_read_input_tokens\":10") != NULL);
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_propagates_usage");
+}
+
+/* Pinned B2 fix: upstream `max_tokens` with surviving non-subagent calls
+ * → wire carries "max_tokens" (NOT "end_turn", NOT "tool_use" — the
+ * partial-drop preservation rule). The all-dropped case rewrites to
+ * "end_turn" (covered separately by the police function's own unit
+ * test); this test pins the partial-drop replay shape. */
+static void test_emit_message_as_sse_preserves_max_tokens(void)
+{
+   replay_capture_t cap;
+   const char *names[] = {"Task", "web_search"};
+   const char *ids[] = {"t1", "t2"};
+   parsed_response_t p = seed_parsed_for_replay(2, names, ids, "max_tokens", "");
+   memset(&cap, 0, sizeof(cap));
+   /* After the police function runs (the streaming path runs it before
+    * calling us), only web_search survives; the upstream's max_tokens is
+    * preserved verbatim. We simulate the post-police state directly. */
+   free_parsed_for_replay(&p);
+   const char *names2[] = {"web_search"};
+   const char *ids2[] = {"t2"};
+   p = seed_parsed_for_replay(1, names2, ids2, "max_tokens", "");
+   memset(&cap, 0, sizeof(cap));
+   emit_message_as_sse(&p, "msg_mt", "claude-test", replay_capture, &cap);
+   /* The replay must carry stop_reason="max_tokens" verbatim — NOT
+    * re-derive "tool_use" from call_count > 0. */
+   for (int i = 0; i < cap.count; i++)
+   {
+      if (strcmp(cap.events[i], "message_delta") == 0)
+         assert(strstr(cap.data[i], "\"stop_reason\":\"max_tokens\"") != NULL);
+   }
+   free_parsed_for_replay(&p);
+   PASS("emit_message_as_sse_preserves_max_tokens");
+}
+
 int main(void)
 {
    printf("test_anthropic_ingress:\n");
@@ -489,6 +712,13 @@ int main(void)
    test_stream_tool_call();
    test_stream_text_then_tool();
    test_request_headers_passthrough();
+   test_emit_message_as_sse_replays_text_only();
+   test_emit_message_as_sse_replays_empty_content_as_single_text_block();
+   test_emit_message_as_sse_replays_surviving_tool_calls();
+   test_emit_message_as_sse_replays_text_and_tool_calls();
+   test_emit_message_as_sse_replays_multiple_surviving_tool_calls();
+   test_emit_message_as_sse_propagates_usage();
+   test_emit_message_as_sse_preserves_max_tokens();
    printf("all anthropic_ingress tests passed\n");
    return 0;
 }

--- a/src/tests/test_gateway_policy.c
+++ b/src/tests/test_gateway_policy.c
@@ -416,6 +416,78 @@ static void test_predicate_is_denied_tool(void)
    PASS("predicate_is_denied_tool");
 }
 
+/* Partial drop: upstream's max_tokens truncation signal is preserved verbatim
+ * when at least one tool_use block survives. Pinned to prevent the
+ * "re-derive from call_count and lose the upstream's reason" regression. */
+static void test_police_preserves_upstream_stop_reason_when_calls_remain(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task", "web_search"};
+   const char *ids[] = {"t1", "t2"};
+   g_prevent = 1;
+   memset(&p, 0, sizeof(p));
+   p.call_count = 2;
+   p.stop_reason[0] = '\0';
+   snprintf(p.calls[0].id, sizeof(p.calls[0].id), "%s", ids[0]);
+   snprintf(p.calls[0].name, sizeof(p.calls[0].name), "%s", names[0]);
+   p.calls[0].arguments = strdup("{}");
+   snprintf(p.calls[1].id, sizeof(p.calls[1].id), "%s", ids[1]);
+   snprintf(p.calls[1].name, sizeof(p.calls[1].name), "%s", names[1]);
+   p.calls[1].arguments = strdup("{}");
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 1);
+   assert(p.call_count == 1);
+   assert(strcmp(p.calls[0].name, "web_search") == 0);
+   /* The upstream didn't set a reason (so the police derives "tool_use"
+    * from the surviving call_count — the standard default). The renderer's
+    * line 435 fallback is now bypassed (parsed->stop_reason[0] != '\0'). */
+   assert(strcmp(p.stop_reason, "tool_use") == 0);
+   /* Now seed an upstream-supplied reason and re-run: must be preserved
+    * verbatim, not re-derived. */
+   free(p.calls[0].arguments);
+   memset(&p, 0, sizeof(p));
+   p.call_count = 2;
+   snprintf(p.stop_reason, sizeof(p.stop_reason), "%s", "max_tokens");
+   snprintf(p.calls[0].id, sizeof(p.calls[0].id), "%s", ids[0]);
+   snprintf(p.calls[0].name, sizeof(p.calls[0].name), "%s", names[0]);
+   p.calls[0].arguments = strdup("{}");
+   snprintf(p.calls[1].id, sizeof(p.calls[1].id), "%s", ids[1]);
+   snprintf(p.calls[1].name, sizeof(p.calls[1].name), "%s", names[1]);
+   p.calls[1].arguments = strdup("{}");
+   drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 1);
+   assert(p.call_count == 1);
+   assert(strcmp(p.stop_reason, "max_tokens") == 0);
+   free(p.calls[0].arguments);
+   PASS("police_preserves_upstream_stop_reason_when_calls_remain");
+}
+
+/* All-dropped: the police function rewrites to "end_turn" regardless of the
+ * upstream's reason. The wire's tool_use reply became an end_turn reply (the
+ * police removed every block); the client now sees end_turn. The upstream's
+ * `max_tokens` / `stop_sequence` / `refusal` reason is replaced. */
+static void test_police_rewrites_end_turn_when_all_calls_dropped_regardless_of_reason(void)
+{
+   parsed_response_t p;
+   const char *names[] = {"Task"};
+   const char *ids[] = {"t1"};
+   g_prevent = 1;
+   memset(&p, 0, sizeof(p));
+   p.call_count = 1;
+   snprintf(p.stop_reason, sizeof(p.stop_reason), "%s", "max_tokens");
+   snprintf(p.calls[0].id, sizeof(p.calls[0].id), "%s", ids[0]);
+   snprintf(p.calls[0].name, sizeof(p.calls[0].name), "%s", names[0]);
+   p.calls[0].arguments = strdup("{}");
+   int drops = gateway_policy_police_parsed_response(&p);
+   assert(drops == 1);
+   assert(p.call_count == 0);
+   /* All-dropped rewrites to "end_turn" regardless of the upstream's
+    * max_tokens — the client now sees end_turn, not max_tokens, because
+    * the wire is a different shape. */
+   assert(strcmp(p.stop_reason, "end_turn") == 0);
+   PASS("police_rewrites_end_turn_when_all_calls_dropped_regardless_of_reason");
+}
+
 int main(void)
 {
    printf("test_gateway_policy:\n");
@@ -440,6 +512,8 @@ int main(void)
    test_police_keeps_stop_reason_when_calls_remain();
    test_police_policy_off_is_noop();
    test_predicate_is_denied_tool();
+   test_police_preserves_upstream_stop_reason_when_calls_remain();
+   test_police_rewrites_end_turn_when_all_calls_dropped_regardless_of_reason();
    printf("all gateway_policy tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Summary

Universal-gateway **P2c** implementation units **2b/3/4 + 1** (per `aimee-universal-gateway.plan.md` §3), completing the streaming half of P2c on top of PR #677 (the buffered half, already merged).

## What this PR does

### CORE (`src/server/anthropic_ingress.{c,h}`)
New `emit_message_as_sse()` helper — replays a fully-parsed provider reply as a well-formed Anthropic SSE sequence (message_start, text content_block, per-tool content_block, message_delta, message_stop). Mirrors the per-block translator's wire shape (same usage fields, same delta payloads, same event types) so the client sees no difference between today's incremental stream and the buffered-and-replayed stream when the policy is ON.

### CORRECTNESS FIX (`src/gateway_policy.c`, `src/server/anthropic_ingress.c`)
`gateway_policy_police_parsed_response` previously unconditionally rewrote `stop_reason` to `n_calls > 0 ? "tool_use" : "end_turn"`, discarding upstream `max_tokens` / `stop_sequence` truncation signals in both the all-dropped case (close, the rewrite is intended) and the partial-drop case (a `max_tokens` reply with one surviving non-subagent call lost its truncation indicator).

The fix: police function now keeps `p->stop_reason` verbatim when at least one tool_use block survives AND the upstream set a reason; only the all-dropped case rewrites to `end_turn` (the wire's tool_use reply became an end_turn reply). The renderer's line 435 of `anthropic_ingress.c` is updated to read `p->stop_reason` verbatim first, falling back to the call_count derivation when the upstream didn't set a reason.

Pinned by:
- Two new police-function unit tests (preserve on partial-drop, rewrite on all-dropped)
- One `emit_message_as_sse` unit test (`preserves_max_tokens`)
- One end-to-end streaming integration test (`streaming_anthropic_partial_drop_preserves_max_tokens`)

### WIRING (`src/server/anthropic_http.c`)
`messages_stream` gains a single dispatcher at the top — when `gateway_prevent_subagents` is ON, the streaming path becomes buffered (an `agent_http_post` fetches the upstream reply to completion, the police function compacts `parsed.calls[]`, `emit_message_as_sse` emits the SSE sequence). When OFF (the default), today's incremental raw byte relay (Anthropic-native) and per-block translator (OpenAI-via-translator) run unchanged — zero latency cost.

The check is one `config_load` (the same predicate the request-side strip and the buffered path use).

## Caller-facing latency note

When the policy is **ON**, streaming becomes buffered — the client sees the first event only after the upstream completes (model's typical first-event latency). This is the documented R1 tradeoff and is **not** an implementation bug. The policy is opt-in (`gateway_prevent_subagents` defaults to 0); no behavior change for existing deploys.

## Tests

- **7 new unit tests** in `test_anthropic_ingress.c`:
  - `emit_message_as_sse_replays_text_only`
  - `emit_message_as_sse_replays_empty_content_as_single_text_block`
  - `emit_message_as_sse_replays_surviving_tool_calls`
  - `emit_message_as_sse_replays_text_and_tool_calls`
  - `emit_message_as_sse_replays_multiple_surviving_tool_calls`
  - `emit_message_as_sse_propagates_usage`
  - `emit_message_as_sse_preserves_max_tokens`

- **2 new police-function unit tests** in `test_gateway_policy.c`:
  - `police_preserves_upstream_stop_reason_when_calls_remain`
  - `police_rewrites_end_turn_when_all_calls_dropped_regardless_of_reason`

- **8 new integration tests** in a dedicated `test_anthropic_http_streaming_p2c.c` linked with the real `gateway_policy.o`:
  - `streaming_anthropic_police_drops_subagent_tool_use`
  - `streaming_anthropic_police_on_no_tool_use_passthrough`
  - `streaming_anthropic_policy_on_upstream_error_returns_error`
  - `streaming_anthropic_policy_off_is_byte_neutral`
  - `streaming_anthropic_partial_drop_preserves_max_tokens`
  - `streaming_openai_police_drops_subagent_tool_use`
  - `streaming_openai_police_on_no_tool_use_passthrough`
  - `streaming_openai_policy_off_is_byte_neutral`

All 77 affected tests pass (`unit-test-gateway-policy`, `unit-test-gateway-pipeline`, `unit-test-anthropic-http`, `unit-test-anthropic-http-p2c`, `unit-test-anthropic-http-streaming-p2c`, `unit-test-anthropic-ingress`); `make lint` is clean.

## Roundtables

The plan was approved in 3 prior rounds. The implementation was reviewed in 1 final round. The B2 stop_reason fix was caught during plan review and closed in the same PR; the implementation reviewer returned **APPROVE** with non-blocking nits (the highest-value nit — an end-to-end partial-drop + max_tokens integration test — was folded in before opening the PR).

## Out of scope (deferred to a separate sibling slice, called out here for traceability)

**OpenAI ingress response-policing.** The proposal scopes P2c to the Anthropic ingress; the OpenAI ingress uses its own response formatter (`openai_format_chat_completion` / `openai_format_response`), and the proposal text defers this to a separate sibling slice.

The P2c design's `Approach (B) — buffer-when-active` choice is preserved unchanged; nothing in this PR preempts the streaming-decision conversation beyond what was already approved (R1, 2026-06-24).
