### PR TITLE
ci(aimee-llm): add unified container to the release cycle (testing + main)

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -6,6 +6,8 @@
 #   aimee-kb         (Dockerfile)             ghcr.io/<owner>/aimee-kb
 #   aimee-server-kb  (Dockerfile.combined)    ghcr.io/<owner>/aimee-server-kb
 #   aimee-embedder   (Dockerfile.embedder)    ghcr.io/<owner>/aimee-embedder (+ -4b)
+#   aimee-llm-cpu    (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-llm-cpu
+#   aimee-llm-gpu    (Dockerfile.aimee-llm)   ghcr.io/<owner>/aimee-llm-gpu
 #   aimee-css-render (deploy/css-render/Dockerfile) ghcr.io/<owner>/aimee-css-render
 #
 # Multi-arch (linux/amd64 + linux/arm64) via the canonical build-by-digest then
@@ -110,6 +112,18 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      # The aimee-llm images bake multi-GB GGUFs (the GPU tier ~11 GB: Qwen3-4B +
+      # gemma-12B) plus a torch conversion stage. That overruns the ~14 GB free on
+      # a stock runner, so reclaim the preinstalled toolchains we don't use first.
+      # Scoped to the llm legs — the C images build fine without paying this cost.
+      - name: Free disk space (aimee-llm legs)
+        if: startsWith(matrix.image.name, 'aimee-llm')
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          df -h /
+
       - name: Build and push by digest
         id: build
         uses: docker/build-push-action@v6
@@ -125,9 +139,11 @@ jobs:
           # would blow the 10 GB GHA cache budget and evict the (small, high-reuse)
           # C-image caches, defeating the purpose. The embedder's real win is the
           # runtime model fetch (embedder-runtime-fetch-autodim proposal), not the
-          # layer cache.
-          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
-          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          # layer cache. Same exclusion for aimee-llm-cpu/-gpu: they BAKE multi-GB
+          # GGUFs (Qwen3-Embedding + gemma) into the image, so caching those layers
+          # would likewise blow the 10 GB GHA budget and evict the C-image caches.
+          cache-from: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-llm-gpu' && matrix.image.name != 'aimee-css-render') && format('type=gha,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
+          cache-to: ${{ (matrix.image.name != 'aimee-embedder' && matrix.image.name != 'aimee-embedder-4b' && matrix.image.name != 'aimee-llm-cpu' && matrix.image.name != 'aimee-llm-gpu' && matrix.image.name != 'aimee-css-render') && format('type=gha,mode=max,scope={0}-{1}', matrix.image.name, matrix.platform.arch) || '' }}
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
@@ -159,7 +175,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-css-render]
+        image: [aimee-server, aimee-kb, aimee-server-kb, aimee-embedder, aimee-embedder-4b, aimee-llm-cpu, aimee-llm-gpu, aimee-css-render]
     steps:
       - name: Normalize owner to lowercase
         run: echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"

--- a/.github/workflows/publish-llm-testing.yml
+++ b/.github/workflows/publish-llm-testing.yml
@@ -1,0 +1,93 @@
+# Build the unified aimee-llm container on `testing` and publish it under the
+# DELIBERATELY non-semver `:testing` tag (+ `:testing-<sha>`), mirroring how
+# publish-testing.yml ships aimee-server-kb. This lets .254 (the GPU deploy
+# target) pull a tested-but-unreleased aimee-llm WITHOUT promoting to main;
+# versioned + `:latest` publishing stays owned by main (auto-release.yml ->
+# publish-images.yml).
+#
+# Kept SEPARATE from publish-testing.yml on purpose: aimee-llm bakes multi-GB
+# GGUFs (no layer cache — see publish-images.yml) and rebuilding it on every
+# server-code push would be wasteful. So it triggers ONLY on the aimee-llm
+# sources (the Dockerfile + the gateway/supervisor scripts).
+#
+# Both tiers are built (operator chose cpu+gpu for testing): aimee-llm-cpu and
+# aimee-llm-gpu. amd64 only (the .254 deploy target); the release pipeline owns
+# multi-arch.
+name: Publish testing aimee-llm
+
+on:
+  push:
+    branches: [testing]
+    paths:
+      - "Dockerfile.aimee-llm"
+      - "scripts/aimee_llm_gateway.py"
+      - "scripts/aimee_llm_rerank_head.py"
+      - "scripts/aimee-llm-supervisor.sh"
+      - ".github/workflows/publish-llm-testing.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: publish-llm-testing-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # CPU tier = Dockerfile defaults (Qwen3-Emb-0.6B + ettin-68m + gemma-4-E4B).
+        # GPU tier overrides to the 4B/400m/12B set; the same vendor-agnostic
+        # Vulkan binary runs CPU or GPU at deploy time via AIMEE_LLM_NGL.
+        tier:
+          - { name: aimee-llm-cpu, extra_args: "" }
+          - { name: aimee-llm-gpu, extra_args: "EMBED_REPO=Qwen/Qwen3-Embedding-4B-GGUF\nEMBED_FILE=Qwen3-Embedding-4B-Q8_0.gguf\nRERANK_REPO=cross-encoder/ettin-reranker-400m-v1\nSYNTH_REPO=unsloth/gemma-4-12b-it-GGUF\nSYNTH_FILE=gemma-4-12b-it-Q4_K_M.gguf" }
+    steps:
+      - uses: actions/checkout@v4
+
+      # ghcr paths must be lowercase; owners may be mixed-case (e.g. "JBailes").
+      - name: Normalize owner + short sha
+        run: |
+          echo "OWNER=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_ENV"
+          echo "SHA7=${GITHUB_SHA::7}" >> "$GITHUB_ENV"
+
+      - name: Log in to ghcr.io
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # The GPU tier bakes ~11 GB of GGUFs (Qwen3-4B + gemma-12B) plus a torch
+      # conversion stage, overrunning the ~14 GB free on a stock runner. Reclaim
+      # the preinstalled toolchains we don't use before building.
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache/CodeQL /usr/local/.ghcup /usr/local/share/boost
+          sudo docker image prune --all --force || true
+          df -h /
+
+      - name: Build and push ${{ matrix.tier.name }}:testing
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.aimee-llm
+          platforms: linux/amd64
+          push: true
+          provenance: false
+          # No layer cache: the baked multi-GB model layers would blow the GHA
+          # cache budget (same rationale as publish-images.yml). Dockerfile.aimee-llm
+          # takes no AIMEE_VERSION/WITH_WEBCHAT arg — only the tier model overrides.
+          build-args: |
+            ${{ matrix.tier.extra_args }}
+          tags: |
+            ghcr.io/${{ env.OWNER }}/${{ matrix.tier.name }}:testing
+            ghcr.io/${{ env.OWNER }}/${{ matrix.tier.name }}:testing-${{ env.SHA7 }}

--- a/deploy/smoothnas/aimee-gpu.profile.yaml
+++ b/deploy/smoothnas/aimee-gpu.profile.yaml
@@ -1,0 +1,45 @@
+# Operator profile: pass the host GPU through to the aimee-llm container for
+# Vulkan/RADV offload (the inner llama-server processes run with AIMEE_LLM_NGL>0).
+#
+# Why a profile and not a manifest field: the SmoothNAS plugin manifest has no
+# `devices` surface (same reason aimee-stack delivers a ulimit this way), so the
+# device plumbing rides on lxc.rawConfig here.
+#
+# Why this is render-node-number-agnostic (the whole point): a hardcoded
+# `/dev/dri/renderD128` breaks easily — the DRM render-node minor is assigned in
+# probe order, so a reboot, a second GPU, or an iGPU+dGPU combo can shift it to
+# renderD129+. Instead this:
+#   1. allows the ENTIRE DRM device major (226 = card* + renderD*) via a wildcard
+#      cgroup rule, so the exact minor never matters for permissions; and
+#   2. bind-mounts the whole /dev/dri directory (card nodes + renderD* + the
+#      stable by-path/ PCI symlinks) `optional`-ly, so whatever node the kernel
+#      enumerated this boot is present and RADV picks it up — nothing names a
+#      specific node. (Single GPU here; for multi-GPU, pin the adapter in the
+#      aimee-llm manifest via MESA_VK_DEVICE_SELECT by PCI/vendor id, still not a
+#      device-node path.)
+# Exposes ONLY the Vulkan render path (/dev/dri); /dev/kfd (ROCm) is deliberately
+# NOT passed through — aimee-llm uses the vendor-agnostic Vulkan build.
+#
+# Install (on the SmoothNAS host), BEFORE installing the aimee-llm plugin:
+#   sudo cp aimee-gpu.profile.yaml /etc/smoothnas/plugin-profiles.d/aimee-gpu.yaml
+# then reference it from the manifest:
+#   profiles:
+#     - aimee-gpu
+# Referencing a profile not present on the host fails the install with
+# `profile "aimee-gpu" not in catalog`, so drop this file in FIRST.
+apiVersion: smoothnas.io/v1
+kind: PluginProfile
+metadata:
+  name: aimee-gpu
+  description: >-
+    Pass the host GPU's DRM render path through to aimee-llm for Vulkan offload,
+    without pinning a specific /dev/dri render-node minor (survives renderD128 ->
+    renderD129 renumbering, reboots, and added GPUs). Vulkan render only; no ROCm
+    /dev/kfd.
+lxc:
+  rawConfig:
+    # Permit the whole DRM device major (226: card* + renderD*) — minor-agnostic.
+    - "lxc.cgroup2.devices.allow = c 226:* rwm"
+    # Bring in every /dev/dri node (render + card + by-path PCI symlinks) at once;
+    # `optional` so a missing node never blocks container start.
+    - "lxc.mount.entry = /dev/dri dev/dri none bind,optional,create=dir 0 0"

--- a/deploy/smoothnas/aimee-llm.plugin.yaml
+++ b/deploy/smoothnas/aimee-llm.plugin.yaml
@@ -1,0 +1,63 @@
+apiVersion: smoothnas.io/v1
+kind: Plugin
+metadata:
+  name: aimee-llm
+  version: 0.2.57
+  description: >-
+    aimee-llm — the unified Vulkan llama.cpp container: one GPU-offloaded
+    runtime + the aimee-llm gateway, serving embeddings (/embed, /embed_batch),
+    reranking (/rerank), and synthesis (/v1/chat/completions) from baked-in
+    GGUFs. Replaces the torch aimee-embedder + the standalone llama.cpp `llm`
+    container. The aimee-kb plugin points AIMEE_EMBEDDER_URL at this service.
+    GPU tier (.254): Qwen3-Embedding-4B (2560-dim) + ettin-reranker-400m +
+    gemma-4-12B, offloaded to the AMD 7900 XTX via Vulkan/RADV (AIMEE_LLM_NGL=99).
+  vendor: RakuenSoftware
+  homepage: https://github.com/RakuenSoftware/aimee
+profiles:
+  - default-limits
+  - aimee-stack
+  # GPU passthrough is delivered as an operator PluginProfile, NOT a manifest
+  # field: the smoothnas plugin manifest has no devices/ulimits surface (see the
+  # aimee-stack profile's own note), so device plumbing rides on lxc.rawConfig in
+  # a profile. Drop deploy/smoothnas/aimee-gpu.profile.yaml into
+  # /etc/smoothnas/plugin-profiles.d/ on the host BEFORE installing this plugin,
+  # else the install fails with `profile "aimee-gpu" not in catalog`. That profile
+  # is render-node-number-AGNOSTIC (binds the whole /dev/dri + a wildcard DRM
+  # cgroup allow), so it survives a renderD128 -> renderD129 renumber, a reboot,
+  # or an added GPU — which a hardcoded /dev/dri/renderD128 would not.
+  - aimee-gpu
+services:
+  - name: llm
+    artifact:
+      type: oci-image
+      # Versioned + :latest publishing is owned by main (auto-release.yml ->
+      # publish-images.yml). On `testing`, pin to :testing instead to validate a
+      # tested-but-unreleased build (publish-llm-testing.yml).
+      image: ghcr.io/rakuensoftware/aimee-llm-gpu:latest
+    container:
+      restartPolicy: unless-stopped
+    env:
+      # Offload all layers to the GPU (the 7900 XTX has the VRAM for the 4B embed
+      # + 12B synth tier). The CPU image defaults this to 0. The aimee-gpu profile
+      # makes the GPU visible; RADV/Vulkan inside the container enumerates whatever
+      # /dev/dri render node is present — no node path is hardcoded anywhere.
+      AIMEE_LLM_NGL: "99"
+      AIMEE_LLM_PORT: "8080"
+      # Multi-GPU disambiguation only (single-GPU hosts need none): pin RADV to a
+      # specific adapter by PCI/vendor id rather than a fragile device-node path.
+      # AIMEE_LLM_VK_DEVICE / MESA_VK_DEVICE_SELECT: "1002:744c"
+      # The gateway requires a bearer token. Provide it via the plugin's env
+      # override at deploy time from the secret store (vault / Docker secret /
+      # .gitignore'd per-host .env) — NEVER a checked-in plaintext value. Document
+      # its rotation alongside the deploy (runbook §3).
+      # AIMEE_LLM_AUTH_TOKEN: "<set-at-deploy-time-not-in-git>"
+    ports:
+      # The embed/rerank/synth gateway. hostExpose so the aimee-kb plugin can reach
+      # it across the runtime bridge gateway at http://10.100.0.1:8080 — set the
+      # kb's AIMEE_EMBEDDER_URL to that (the gateway preserves the /embed,
+      # /embed_batch, /rerank contract). Not exposed off-host.
+      - name: gateway
+        port: 8080
+        protocol: tcp
+        expose: false
+        hostExpose: true

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -31,8 +31,16 @@ release (no in-image rollback flag); a post-cutover revert is a deploy-tag rollb
 
 ## 2. Build + publish the images
 
-CI (`.github/workflows/publish-images.yml`) builds `aimee-llm-cpu` + `aimee-llm-gpu` on
-merge to `main` and pushes to ghcr. To build out-of-band (e.g. on a PVE CT with docker):
+CI builds + publishes both tiers as part of the normal release cycle:
+- **main:** `.github/workflows/publish-images.yml` (via `auto-release.yml`) builds
+  `aimee-llm-cpu` + `aimee-llm-gpu` on every release and tags them `:<version>` + `:latest`
+  (multi-arch). They are in both the `build` and the `merge` matrices — the merge step is
+  what applies the tags, so a build that pushes only by digest leaves `tags:null`.
+- **testing:** `.github/workflows/publish-llm-testing.yml` builds both tiers on `testing`
+  pushes that touch `Dockerfile.aimee-llm` or the gateway/supervisor scripts, tagged
+  `:testing` (+ `:testing-<sha>`, amd64) — a tested-but-unreleased image for `.254`.
+
+To build out-of-band (e.g. on a PVE CT with docker):
 
 ```
 docker build -f Dockerfile.aimee-llm -t aimee-llm:cpu .
@@ -48,7 +56,15 @@ docker build -f Dockerfile.aimee-llm -t aimee-llm:gpu \
 
 `.254` runs containers via **tierd** (LXC), not raw docker, with GPU passthrough via
 `/dev/dri/renderD128` (Vulkan/RADV — **not** ROCm/`kfd`). Deploy the GPU image as a tierd
-plugin (manifest-swap, per the `.254` deploy memory), GPU device + `AIMEE_LLM_NGL=99`.
+plugin (manifest-swap, per the `.254` deploy memory) + `AIMEE_LLM_NGL=99`. The in-repo
+manifest is `deploy/smoothnas/aimee-llm.plugin.yaml` (pin its image to `:testing` for
+staging, `:latest`/`:<version>` for production). GPU passthrough is delivered as an operator
+profile, not a manifest device field (the manifest has no `devices` surface) — install it
+FIRST or the plugin install fails with `profile "aimee-gpu" not in catalog`:
+`sudo cp deploy/smoothnas/aimee-gpu.profile.yaml /etc/smoothnas/plugin-profiles.d/aimee-gpu.yaml`.
+That profile is render-node-number-agnostic (whole-`/dev/dri` bind + a wildcard DRM cgroup
+allow), so it survives a `renderD128` → `renderD129` renumber rather than pinning a node
+path; Vulkan/RADV inside the container enumerates whatever node is present.
 Point the kb at it: `AIMEE_EMBEDDER_URL=http://aimee-llm:8080` (the gateway preserves the
 `/embed`+`/embed_batch`+`/rerank` contract, so `embed-remote.py`/`rerank-remote.py` are
 untouched). Set the kb's `embedding_model` to the new identity (activates the P1 guard) and


### PR DESCRIPTION
## Why
The unified `aimee-llm` container was never reaching `.254` — it's still running the old torch embedder. Root cause: `aimee-llm-cpu`/`-gpu` were in `publish-images.yml`'s **build** matrix but not the **merge** matrix, so releases pushed them *by digest* and never tagged them (ghcr showed `tags:null`). Testing didn't build them at all.

## What
- **`publish-images.yml`** (main): add both tiers to the merge matrix → tagged `:version`/`:latest`/`:sha`; exclude from GHA layer cache (baked multi-GB GGUFs); free runner disk for the ~11 GB GPU build.
- **`publish-llm-testing.yml`** (new): build both tiers `:testing` on testing pushes that touch `Dockerfile.aimee-llm` or the gateway scripts (amd64).
- **`deploy/smoothnas/aimee-llm.plugin.yaml`** (new): tierd plugin manifest so `.254` can pull the GPU container via the normal deploy.
- **`deploy/smoothnas/aimee-gpu.profile.yaml`** (new): GPU passthrough as an operator `PluginProfile` (the manifest schema has no `devices` field). **Render-node-number-agnostic** (whole `/dev/dri` bind + wildcard DRM cgroup) so it survives a `renderD128`→`renderD129` renumber — mirrors how the host's wolf/games-on-whales container already passes the GPU.
- **runbook**: document the testing/main publish paths + the profile-install step.

## Not in scope (operator-gated)
The cutover itself — repointing the kb's `AIMEE_EMBEDDER_URL` + the corpus re-embed — stays manual per `docs/runbooks/unified-llm-cutover.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)