### PR TITLE
feat(gateway): P2c response-side tool policing — OpenAI /v1/responses ingress

### DIFF
--- a/src/headers/agent_protocol.h
+++ b/src/headers/agent_protocol.h
@@ -15,7 +15,9 @@ typedef struct
    char *arguments; /* malloc'd */
 } parsed_tool_call_t;
 
-typedef struct
+/* Named tag so low-level headers (e.g. openai_shape.h) can forward-declare
+ * `parsed_response_t` by pointer without including this agent-pipeline header. */
+typedef struct parsed_response
 {
    int is_tool_call;
    char *content; /* malloc'd, NULL if tool call */

--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -11,6 +11,24 @@ extern "C"
 {
 #endif
 
+   /* Forward declarations keep this low-level shaping header decoupled from the
+    * agent pipeline and the server HTTP layer — it must not pull those headers
+    * in (the original transitive include also had a fragile load-bearing order:
+    * aimee.h before agent_protocol.h for the MAX_PATH_LEN macro). The .c units
+    * that define or call the P2c helper below (openai_shape.c, openai_chat.c,
+    * server_http.c) include the full definitions themselves.
+    *   - parsed_response_t: forward-declared by tag only (the full
+    *     `struct parsed_response` definition lives in agent_protocol.h and must
+    *     be visible in any TU that *dereferences* it — callers passing the
+    *     pointer through need only this forward decl).
+    *   - openai_sse_emit_fn: signature-compatible with server_http_sse_event_emit;
+    *     a distinct name avoids depending on server_http.h here.
+    * DO NOT re-add #include "aimee.h" / "server_http.h" / "agent_protocol.h"
+    * here — that re-introduces the inverted dependency and load-bearing order
+    * this forward-decl block was created to remove. */
+   typedef struct parsed_response parsed_response_t;
+   typedef void (*openai_sse_emit_fn)(void *ctx, const char *event, const char *data_json);
+
    /* Parse an OpenAI /v1/chat/completions request body. Copies the model id into
     * model[model_n] (defaults to "aimee" if absent/empty), flattens messages[]
     * into a newline-joined "role: content" transcript heap-allocated into
@@ -203,6 +221,42 @@ extern "C"
    /* Build an OpenAI error envelope {"error":{"message":msg,"type":type}} into
     * resp[cap]. Returns bytes written, or -1. */
    int openai_format_error(char *resp, int cap, const char *type, const char *message);
+
+   /* P2c (response-side tool policing, OpenAI streaming): emit the
+    * `response.*` SSE event sequence for a parsed_response_t that carries
+    * `calls[]` (the post-police shape — calls[] may be empty if every
+    * entry was a denied subagent). The wire shape mirrors the existing
+    * tool-call emit loop in responses_stream_handler; this helper
+    * exists for unit-testability (test_openai_chat_policed.c).
+    * - Always emits `response.created` first.
+    * - If parsed->call_count > 0: emits per-call frames for each surviving
+    *   call (output_item.added, function_call_arguments.delta/.done,
+    *   output_item.done), then response.completed with all calls in
+    *   output[].
+    * - If parsed->call_count == 0 (the P2c all-dropped case), OR parsed is
+    *   NULL: emits response.created + response.completed with empty output[]
+    *   (a NULL parsed is treated as zero calls / zero usage, never dereferenced).
+    *
+    * Ownership / lifetime:
+    * - The function borrows everything; it takes ownership of nothing and frees
+    *   nothing of the caller's. `parsed`, `id`, `model`, and the `ctx` behind
+    *   `emit` need only outlive the call (synchronous — `emit` is invoked only
+    *   before this function returns; neither `emit` nor `ctx` is retained).
+    * - `frame` / `frame_cap` are caller-owned scratch used only for the
+    *   `response.created` frame; pass a buffer of at least 1024 bytes. That
+    *   frame holds only id + model + a fixed JSON envelope (no tool args), so
+    *   it is bounded by the id/model lengths; 1024 covers the current ids and
+    *   model aliases with wide margin (callers today pass 2048). If
+    *   openai_format_responses_created reports it does not fit, the created
+    *   frame is skipped. Per-call and `response.completed` frames use scratch
+    *   the function mallocs (sized to the args) and frees internally.
+    * - Emit failures are not the helper's concern: `emit` returns void and the
+    *   helper does not roll back or resume a partially-emitted sequence. A
+    *   transport that can fail mid-stream must detect it inside `emit`/`ctx`;
+    *   the helper always walks the full sequence. */
+   void openai_responses_emit_policed(const parsed_response_t *parsed, const char *id,
+                                      const char *model, long created, openai_sse_emit_fn emit,
+                                      void *ctx, char *frame, size_t frame_cap);
 
 #ifdef __cplusplus
 }

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1107,60 +1107,24 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
 
    if (erc == 0 && parsed.is_tool_call && parsed.call_count > 0)
    {
-      /* Tool calls: relay each as a function_call item for Codex to execute. */
-      cJSON *output = cJSON_CreateArray();
-      for (int i = 0; i < parsed.call_count; i++)
-      {
-         const char *name = parsed.calls[i].name;
-         const char *cid = parsed.calls[i].id;
-         const char *args = parsed.calls[i].arguments ? parsed.calls[i].arguments : "{}";
-         char fc_id[80];
-         snprintf(fc_id, sizeof(fc_id), "%s-fc-%d", id, i);
+      /* P2c streaming: when gateway_prevent_subagents is ON, run the police
+       * function on the parsed struct first (drops denied subagent tool_call
+       * entries in place; preserves upstream stop_reason in partial-drop,
+       * rewrites to "end_turn" on all-dropped). When OFF, this is a no-op
+       * and the dispatch below runs byte-for-byte identical to today's loop.
+       * Police contract is finalized in PR #677 (buffered) and PR #679
+       * (streaming Anthropic). */
+      int police_drops = 0;
+      if (gateway_prevent_subagents_enabled())
+         police_drops = gateway_policy_police_parsed_response(&parsed);
+      (void)police_drops; /* drop count plumbed through the pipeline total
+                             for the future P2b audit pass; today the only
+                             visible effect is the parsed.calls[] mutation. */
 
-         char added[256];
-         if (openai_format_responses_fc_item_added(fc_id, cid, name, i, added, sizeof(added)) > 0)
-            emit(ctx, "response.output_item.added", added);
-
-         size_t acap = strlen(args) * 6 + 256;
-         char *af = malloc(acap);
-         if (af)
-         {
-            if (openai_format_responses_fc_args_delta(fc_id, i, args, af, (int)acap) > 0)
-               emit(ctx, "response.function_call_arguments.delta", af);
-            if (openai_format_responses_fc_args_done(fc_id, i, args, af, (int)acap) > 0)
-               emit(ctx, "response.function_call_arguments.done", af);
-            free(af);
-         }
-
-         size_t dcap = strlen(args) * 6 + strlen(name) + strlen(cid) + 512;
-         char *df = malloc(dcap);
-         if (df)
-         {
-            if (openai_format_responses_fc_item_done(fc_id, cid, name, args, i, df, (int)dcap) > 0)
-               emit(ctx, "response.output_item.done", df);
-            free(df);
-         }
-         if (output)
-            cJSON_AddItemToArray(
-                output, openai_responses_function_call_item(fc_id, cid, name, args, "completed"));
-      }
-
-      size_t ccap = 4096;
-      for (int i = 0; i < parsed.call_count; i++)
-         ccap += (parsed.calls[i].arguments ? strlen(parsed.calls[i].arguments) : 0) * 6 + 256;
-      char *cf = malloc(ccap);
-      if (cf)
-      {
-         if (openai_format_responses_completed_items(id, model, created, output,
-                                                     parsed.prompt_tokens, parsed.completion_tokens,
-                                                     cf, (int)ccap) > 0)
-            emit(ctx, "response.completed", cf);
-         free(cf);
-      }
-      else
-         cJSON_Delete(output);
+      openai_responses_emit_policed(&parsed, id, model, created, emit, ctx, frame, sizeof(frame));
    }
    else
+
    {
       /* Text turn: a single assistant message item carrying the content. */
       const char *txt =

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -1,6 +1,12 @@
 /* openai_shape.c: OpenAI-compatible JSON shaping helpers (no sockets, no network). */
 #include "openai_shape.h"
 #include "cJSON.h"
+/* openai_responses_emit_policed needs the full parsed_response_t definition.
+ * aimee.h must precede agent_protocol.h (the MAX_PATH_LEN macro agent_types.h
+ * uses) — kept local to this .c rather than forced on every openai_shape.h
+ * includer. */
+#include "aimee.h"
+#include "agent_protocol.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1365,4 +1371,113 @@ int openai_format_error(char *resp, int cap, const char *type, const char *messa
    int len = snprintf(resp, (size_t)cap, "%s", s);
    free(s);
    return (len < 0 || len >= cap) ? -1 : len;
+}
+
+/* Emit the OpenAI /v1/responses SSE event sequence for a parsed_response_t
+ * that carries `calls[]`. Extracted from the inline emit loop in
+ * responses_stream_handler so it is unit-testable in isolation
+ * (test_openai_chat_policed.c) without stubbing the entire
+ * agent_execute_messages pipeline.
+ *
+ * Behavior:
+ *   - Always emits `response.created` first.
+ *   - If parsed.call_count > 0: emits one set of per-call frames
+ *     (output_item.added, function_call_arguments.delta, .done,
+ *     output_item.done) per surviving call, then `response.completed`
+ *     with all calls in `output[]`.
+ *   - If parsed.call_count == 0 (P2c all-dropped case): emits
+ *     `response.created` + `response.completed` with empty `output[]`.
+ *
+ * The wire shape is what the upstream OpenAI responses backend
+ * emits for a tool-call reply; the policed-shape is identical
+ * (the police function only drops denied entries, never re-orders
+ * or adds).
+ */
+void openai_responses_emit_policed(const parsed_response_t *parsed, const char *id,
+                                   const char *model, long created, openai_sse_emit_fn emit,
+                                   void *ctx, char *frame, size_t frame_cap)
+{
+   int n = parsed ? parsed->call_count : 0;
+
+   /* response.created (always first). */
+   if (openai_format_responses_created(id, model, created, frame, frame_cap) > 0)
+      emit(ctx, "response.created", frame);
+
+   if (n > 0)
+   {
+      cJSON *output = cJSON_CreateArray();
+      for (int i = 0; i < n; i++)
+      {
+         const char *name = parsed->calls[i].name;
+         const char *cid = parsed->calls[i].id;
+         const char *args = parsed->calls[i].arguments ? parsed->calls[i].arguments : "{}";
+         char fc_id[80];
+         snprintf(fc_id, sizeof(fc_id), "%s-fc-%d", id, i);
+
+         char added[256];
+         if (openai_format_responses_fc_item_added(fc_id, cid, name, i, added, sizeof(added)) > 0)
+            emit(ctx, "response.output_item.added", added);
+
+         size_t acap = strlen(args) * 6 + 256;
+         char *af = malloc(acap);
+         if (af)
+         {
+            if (openai_format_responses_fc_args_delta(fc_id, i, args, af, (int)acap) > 0)
+               emit(ctx, "response.function_call_arguments.delta", af);
+            if (openai_format_responses_fc_args_done(fc_id, i, args, af, (int)acap) > 0)
+               emit(ctx, "response.function_call_arguments.done", af);
+            free(af);
+         }
+
+         size_t dcap = strlen(args) * 6 + strlen(name) + strlen(cid) + 512;
+         char *df = malloc(dcap);
+         if (df)
+         {
+            if (openai_format_responses_fc_item_done(fc_id, cid, name, args, i, df, (int)dcap) > 0)
+               emit(ctx, "response.output_item.done", df);
+            free(df);
+         }
+         if (output)
+            cJSON_AddItemToArray(
+                output, openai_responses_function_call_item(fc_id, cid, name, args, "completed"));
+      }
+
+      size_t ccap = 4096;
+      for (int i = 0; i < n; i++)
+         ccap += (parsed->calls[i].arguments ? strlen(parsed->calls[i].arguments) : 0) * 6 + 256;
+      char *cf = malloc(ccap);
+      if (cf)
+      {
+         if (openai_format_responses_completed_items(id, model, created, output,
+                                                     parsed->prompt_tokens,
+                                                     parsed->completion_tokens, cf, (int)ccap) > 0)
+            emit(ctx, "response.completed", cf);
+         free(cf);
+      }
+      else
+         cJSON_Delete(output);
+   }
+   else
+   {
+      /* P2c all-dropped: police removed every tool_call. Emit a clean
+       * empty-output `response.completed` so the client's SSE reader
+       * terminates cleanly with a recognizable end-of-turn shape. */
+      cJSON *empty_output = cJSON_CreateArray();
+      int pt = parsed ? parsed->prompt_tokens : 0;
+      int ct = parsed ? parsed->completion_tokens : 0;
+      size_t ccap = 4096;
+      char *cf = malloc(ccap);
+      if (cf)
+      {
+         /* completed_items takes ownership of empty_output (attaches it to
+          * the response object it serializes, and frees it on every error
+          * path), so we must NOT delete it here — that was a double free. */
+         if (openai_format_responses_completed_items(id, model, created, empty_output, pt, ct, cf,
+                                                     (int)ccap) > 0)
+            emit(ctx, "response.completed", cf);
+         free(cf);
+      }
+      else
+         cJSON_Delete(empty_output);
+   }
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
                $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
-               $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-responses-store \
+               $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
                $(TESTPREFIX)/unit-test-memory-lanes \
@@ -2425,6 +2425,11 @@ $(TESTPREFIX)/unit-test-server-http: $(OBJDIR)/tests/test_server_http.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-openai-shape: $(OBJDIR)/tests/test_openai_shape.o \
+                           $(OBJDIR)/server/openai_shape.o \
+                           $(OBJDIR)/cJSON.o
+	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
+
+$(TESTPREFIX)/unit-test-openai-chat-policed: $(OBJDIR)/tests/test_openai_chat_policed.o \
                            $(OBJDIR)/server/openai_shape.o \
                            $(OBJDIR)/cJSON.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)

--- a/src/tests/test_openai_chat_policed.c
+++ b/src/tests/test_openai_chat_policed.c
@@ -1,0 +1,262 @@
+/* test_openai_chat_policed.c: unit tests for the P2c response-side
+ * tool-policing OpenAI /v1/responses SSE replay helper
+ * (openai_responses_emit_policed). Pure shape tests — no agent
+ * execution, no real provider, no streaming transport; just the
+ * post-police `parsed_response_t` -> SSE event sequence. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "openai_shape.h"
+/* aimee.h before agent_protocol.h: agent_types.h (pulled by agent_protocol.h)
+ * uses MAX_PATH_LEN from aimee.h. Same include convention as the production
+ * caller, src/server/openai_chat.c. openai_shape.h itself stays decoupled and
+ * forward-declares the types it needs. */
+#include "aimee.h"
+#include "agent_protocol.h"
+#include "cJSON.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+/* Captured SSE events. */
+#define REPLAY_CAP 64
+typedef struct
+{
+   char events[REPLAY_CAP][64];
+   char data[REPLAY_CAP][4096];
+   int count;
+} cap_t;
+
+static void cap_emit(void *ctx, const char *event, const char *data)
+{
+   cap_t *c = (cap_t *)ctx;
+   assert(c->count < REPLAY_CAP);
+   snprintf(c->events[c->count], sizeof(c->events[c->count]), "%s", event);
+   snprintf(c->data[c->count], sizeof(c->data[c->count]), "%s", data);
+   c->count++;
+}
+
+/* Build a parsed_response_t with N tool calls (caller-supplied names +
+ * ids + arguments). is_tool_call=1 so the dispatcher takes the
+ * tool-call branch. */
+static void seed_parsed(parsed_response_t *p, int n, const char *names[], const char *ids[],
+                        const char *args[], const char *stop_reason)
+{
+   int i;
+   memset(p, 0, sizeof(*p));
+   p->call_count = n;
+   p->is_tool_call = 1;
+   if (stop_reason)
+      snprintf(p->stop_reason, sizeof(p->stop_reason), "%s", stop_reason);
+   p->prompt_tokens = 17;
+   p->completion_tokens = 23;
+   for (i = 0; i < n; i++)
+   {
+      snprintf(p->calls[i].id, sizeof(p->calls[i].id), "%s", ids[i]);
+      snprintf(p->calls[i].name, sizeof(p->calls[i].name), "%s", names[i]);
+      p->calls[i].arguments = strdup(args[i] ? args[i] : "{}");
+   }
+}
+
+static void free_parsed(parsed_response_t *p)
+{
+   int i;
+   for (i = 0; i < p->call_count; i++)
+      free(p->calls[i].arguments);
+}
+
+/* --- tests --- */
+
+/* response.created is always emitted first, regardless of call_count. */
+static void test_emit_response_created_first(void)
+{
+   cap_t cap = {0};
+   parsed_response_t p;
+   seed_parsed(&p, 0, NULL, NULL, NULL, "end_turn");
+   char frame[2048];
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+   assert(cap.count >= 1);
+   assert(strcmp(cap.events[0], "response.created") == 0);
+   /* Sanity: the frame contains our id + the model. */
+   assert(strstr(cap.data[0], "\"id\":\"resp_1\"") != NULL);
+   assert(strstr(cap.data[0], "\"model\":\"claude-test\"") != NULL);
+   free_parsed(&p);
+   PASS("emit_response_created_first");
+}
+
+/* Single surviving tool_call: per-call frames + completed. */
+static void test_emit_surviving_tool_call(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"query\":\"aimee\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   char frame[2048];
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+
+   /* response.created + (output_item.added, args.delta, args.done,
+    * output_item.done) + response.completed = 6 events. */
+   assert(cap.count == 6);
+   assert(strcmp(cap.events[0], "response.created") == 0);
+   assert(strcmp(cap.events[1], "response.output_item.added") == 0);
+   assert(strstr(cap.data[1], "\"name\":\"web_search\"") != NULL);
+   assert(strstr(cap.data[1], "\"call_id\":\"call_1\"") != NULL);
+   assert(strcmp(cap.events[2], "response.function_call_arguments.delta") == 0);
+   assert(strstr(cap.data[2], "aimee") != NULL);
+   assert(strcmp(cap.events[3], "response.function_call_arguments.done") == 0);
+   assert(strcmp(cap.events[4], "response.output_item.done") == 0);
+   assert(strcmp(cap.events[5], "response.completed") == 0);
+   assert(strstr(cap.data[5], "\"output\":[") != NULL);
+   free_parsed(&p);
+   PASS("emit_surviving_tool_call");
+}
+
+/* Two surviving tool_calls: indices in `output[]` are 0 and 1. */
+static void test_emit_multiple_surviving_tool_calls(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"web_search", "Read"};
+   const char *ids[] = {"call_1", "call_2"};
+   const char *args[] = {"{\"q\":\"x\"}", "{\"p\":\"/etc\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 2, names, ids, args, "tool_calls");
+   char frame[2048];
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+
+   /* response.created + (4 per-call frames × 2) + response.completed = 10. */
+   assert(cap.count == 10);
+   /* The two `output_item.added` events at indices 1 and 5 carry
+    * fc_id suffixes "-fc-0" and "-fc-1" (built from the loop index). */
+   assert(strstr(cap.data[1], "-fc-0") != NULL);
+   assert(strstr(cap.data[5], "-fc-1") != NULL);
+   /* Names preserved in original order. */
+   assert(strstr(cap.data[1], "web_search") != NULL);
+   assert(strstr(cap.data[5], "Read") != NULL);
+   free_parsed(&p);
+   PASS("emit_multiple_surviving_tool_calls");
+}
+
+/* All-dropped (call_count == 0): response.created + empty-output
+ * response.completed, no per-call frames. */
+static void test_emit_all_dropped_empty_output(void)
+{
+   cap_t cap = {0};
+   parsed_response_t p;
+   seed_parsed(&p, 0, NULL, NULL, NULL, "end_turn");
+   char frame[2048];
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+
+   assert(cap.count == 2);
+   assert(strcmp(cap.events[0], "response.created") == 0);
+   assert(strcmp(cap.events[1], "response.completed") == 0);
+   /* Empty output array — `[]`. */
+   assert(strstr(cap.data[1], "\"output\":[]") != NULL);
+   free_parsed(&p);
+   PASS("emit_all_dropped_empty_output");
+}
+
+/* Null parsed is tolerated (no crash, no events emitted except created
+ * with default-0 usage). Guards against a future caller passing a
+ * police error result. */
+static void test_emit_null_parsed(void)
+{
+   cap_t cap = {0};
+   char frame[2048];
+   openai_responses_emit_policed(NULL, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+   /* response.created + empty-output completed. */
+   assert(cap.count == 2);
+   assert(strcmp(cap.events[0], "response.created") == 0);
+   assert(strcmp(cap.events[1], "response.completed") == 0);
+   assert(strstr(cap.data[1], "\"output\":[]") != NULL);
+   PASS("emit_null_parsed");
+}
+
+/* Arguments are propagated verbatim (byte-for-byte fidelity for the
+ * tool_use contract — Codex's executor stringifies and re-parses the
+ * JSON; a re-serialization that re-ordered keys or reformatted
+ * whitespace would still parse but could break string equality
+ * assertions in client code). */
+static void test_emit_arguments_byte_fidelity(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"f"};
+   const char *ids[] = {"c1"};
+   const char *args[] = {"{\"b\":2,\"a\":1,\"nested\":{\"x\":\"y\"}}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   char frame[2048];
+   const char *original = args[0];
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+   /* The args.delta event carries the arguments as the JSON-string `delta`
+    * field (the OpenAI wire shape — inner quotes are escaped on the wire).
+    * Byte fidelity means: after parsing the event JSON, the decoded `delta`
+    * string equals the original arguments byte-for-byte (no key reorder, no
+    * whitespace reflow). Parse it back and compare rather than scanning the
+    * escaped wire bytes. The same fidelity holds for the `.done` event. */
+   cJSON *delta_ev = cJSON_Parse(cap.data[2]);
+   assert(delta_ev != NULL);
+   const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
+   assert(cJSON_IsString(delta) && delta->valuestring != NULL);
+   assert(strcmp(delta->valuestring, original) == 0);
+   cJSON_Delete(delta_ev);
+
+   cJSON *done_ev = cJSON_Parse(cap.data[3]);
+   assert(done_ev != NULL);
+   const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
+   assert(cJSON_IsString(full) && full->valuestring != NULL);
+   assert(strcmp(full->valuestring, original) == 0);
+   cJSON_Delete(done_ev);
+
+   free_parsed(&p);
+   PASS("emit_arguments_byte_fidelity");
+}
+
+/* Byte fidelity holds for the hard cases too: arguments containing characters
+ * that must be JSON-escaped on the wire (embedded quotes/backslashes from a
+ * nested JSON string) and multi-byte UTF-8. The decoded delta/arguments must
+ * still equal the original byte-for-byte. */
+static void test_emit_arguments_escapes_and_utf8(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"f"};
+   const char *ids[] = {"c1"};
+   /* A path with a quote + backslash, and a UTF-8 string value (é, 日本). */
+   const char *args[] = {"{\"path\":\"C:\\\\a\\\"b\",\"note\":\"café 日本\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   char frame[2048];
+   const char *original = args[0];
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
+                                 sizeof(frame));
+   cJSON *delta_ev = cJSON_Parse(cap.data[2]);
+   assert(delta_ev != NULL); /* the emitted frame is itself valid JSON */
+   const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
+   assert(cJSON_IsString(delta) && delta->valuestring != NULL);
+   assert(strcmp(delta->valuestring, original) == 0);
+   cJSON_Delete(delta_ev);
+   free_parsed(&p);
+   PASS("emit_arguments_escapes_and_utf8");
+}
+
+int main(void)
+{
+   printf("test_openai_chat_policed:\n");
+   test_emit_response_created_first();
+   test_emit_surviving_tool_call();
+   test_emit_multiple_surviving_tool_calls();
+   test_emit_all_dropped_empty_output();
+   test_emit_null_parsed();
+   test_emit_arguments_byte_fidelity();
+   test_emit_arguments_escapes_and_utf8();
+   printf("all openai_chat_policed tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Universal-gateway P2c — OpenAI `/v1/responses` ingress

The OpenAI-ingress sibling slice that #677 (buffered) and #679 (streaming
Anthropic) named as the deferred follow-up. The streaming `/v1/responses`
path now runs the same `gateway_policy_police_parsed_response()` over the
parsed response, so a configured `gateway_prevent_subagents` policy drops
denied subagent `tool_call`s on the OpenAI ingress too. **Gated off and
byte-neutral by default.**

### Core
- New shaping helper `openai_responses_emit_policed()` emits the Responses-API
  `response.*` SSE sequence for a (post-police) `parsed_response_t`:
  `response.created` → per surviving call (`output_item.added`,
  `function_call_arguments.delta`/`.done`, `output_item.done`) →
  `response.completed` with the calls in `output[]`.
- All-dropped (`call_count == 0`) **and** `NULL parsed` both emit
  `response.created` + empty-output `response.completed` so the client SSE
  reader terminates cleanly.
- Helper lives in `openai_shape.c` (the no-network shaping TU) so it unit-tests
  in isolation without linking the agent pipeline.

### Wiring
- `responses_stream_handler` (`openai_chat.c`) replaces its inline tool-call
  emit loop with one call to the helper, after police runs on the parsed
  struct when the subagent gate is on.

### Header hygiene
- `openai_shape.h` stays a low-level shaping header: it forward-declares
  `parsed_response_t` (via a new struct tag on `agent_protocol.h`) and a
  signature-compatible `openai_sse_emit_fn` typedef instead of pulling in
  `aimee.h` / `server_http.h` / `agent_protocol.h`. Removes the inverted
  dependency and the fragile load-bearing include order; the `.c` units include
  the real definitions themselves.

### Tests
- `test_openai_chat_policed.c`: seven shape tests — `response.created`-first,
  single/multiple surviving calls, all-dropped empty output, NULL parsed, and
  byte-fidelity of the arguments string (plain + escaped-JSON + UTF-8) verified
  by parsing the emitted event JSON and comparing the decoded `delta`/`arguments`
  to the original.
- All pass; server builds + links; `unit-test-openai-shape` /
  `-openai-responses-store` / `-server-http` / `-agent` pass; `make lint` clean.

### Review
Roundtable-reviewed (two rounds). Round 1 surfaced a cJSON double-free and a
NULL-deref (both fixed) plus the header-coupling theme (addressed via the
forward-decl decoupling). Round 2 returned no blocking findings; its doc
suggestions (forward-decl-only note, emit-failure semantics, frame-buffer
sizing rationale, and an explicit "do not re-add these includes" guard) are
folded into the header comments.

Closes the P2c OpenAI-ingress slice of `aimee-universal-gateway`.
