### PR TITLE
fix(curator): locate the extract sidecar at its real install path

### DIFF
--- a/src/kb/kb_curator_extract.c
+++ b/src/kb/kb_curator_extract.c
@@ -163,17 +163,40 @@ static void ce_mark_retry_or_fail(int64_t job_id, int attempts, int max_attempts
    aimee_pg_finalize(st);
 }
 
-/* Resolve sidecar command: use opts->extract_command if set, else find
- * scripts/curator-extract.py relative to the running binary. */
-static void ce_resolve_command(const kb_curator_extract_opts_t *opts, char *out, size_t len)
+/* Pick the curator-extract sidecar command from a candidate list. Shared by the
+ * doc and code extract stages and exposed for testing. The script is invoked as
+ * `python3 <path>`, so it only needs to be READABLE — the previous code checked
+ * access(X_OK), which rejected the shipped 0644 script. */
+void kb_curator_pick_sidecar_command(const char *explicit_cmd, const char *const *candidates,
+                                     int n_candidates, char *out, size_t len)
 {
-   if (opts->extract_command[0])
+   if (explicit_cmd && explicit_cmd[0])
    {
-      snprintf(out, len, "%s", opts->extract_command);
+      snprintf(out, len, "%s", explicit_cmd);
       return;
    }
+   for (int i = 0; i < n_candidates; i++)
+   {
+      if (candidates[i] && candidates[i][0] && access(candidates[i], R_OK) == 0)
+      {
+         snprintf(out, len, "python3 %s", candidates[i]);
+         return;
+      }
+   }
+   /* Last resort: cwd-relative — only resolves when run from a repo checkout. */
+   snprintf(out, len, "python3 scripts/curator-extract.py");
+}
 
-   /* Try /proc/self/exe on Linux to locate the binary and find scripts/ */
+/* Resolve the sidecar command, searching the real install locations for
+ * curator-extract.py. The container images COPY scripts to /opt/aimee/scripts
+ * (binary at /usr/local/bin), so the old <bindir>/../scripts heuristic computed
+ * /usr/local/scripts and never matched — falling back to a cwd-relative path
+ * that does not resolve from the kb working dir (/var/lib/aimee), stalling every
+ * extract job. Try the image path first, then the dev/build tree. */
+void kb_curator_resolve_sidecar_command(const kb_curator_extract_opts_t *opts, char *out,
+                                        size_t len)
+{
+   char exe_rel[768] = "";
    char exe[512];
    ssize_t n = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
    if (n > 0)
@@ -183,18 +206,15 @@ static void ce_resolve_command(const kb_curator_extract_opts_t *opts, char *out,
       if (slash)
       {
          *slash = '\0';
-         /* binary is in <build>/; scripts/ is at <repo>/scripts/ */
-         char candidate[768];
-         snprintf(candidate, sizeof(candidate), "%s/../scripts/curator-extract.py", exe);
-         if (access(candidate, X_OK) == 0)
-         {
-            snprintf(out, len, "python3 %s", candidate);
-            return;
-         }
+         snprintf(exe_rel, sizeof(exe_rel), "%s/../scripts/curator-extract.py", exe);
       }
    }
-
-   snprintf(out, len, "python3 scripts/curator-extract.py");
+   const char *candidates[] = {
+       "/opt/aimee/scripts/curator-extract.py", /* container image (Dockerfile COPY target) */
+       exe_rel[0] ? exe_rel : NULL,             /* dev/build tree: binary beside scripts/ */
+   };
+   kb_curator_pick_sidecar_command(opts->extract_command, candidates,
+                                   (int)(sizeof(candidates) / sizeof(candidates[0])), out, len);
 }
 
 /* ── Artifact write ─────────────────────────────────────────────────────── */
@@ -344,7 +364,7 @@ int kb_curator_extract_one(const kb_curator_extract_opts_t *opts)
    }
 
    char cmd[768];
-   ce_resolve_command(opts, cmd, sizeof(cmd));
+   kb_curator_resolve_sidecar_command(opts, cmd, sizeof(cmd));
 
    /* Route through the §2 dispatch: a configured Tier-A provider (incl. the
     * bundled-Gemma LLM_ENDPOINT env) runs in-process via provider_client; else

--- a/src/kb/kb_curator_extract_code.c
+++ b/src/kb/kb_curator_extract_code.c
@@ -357,35 +357,8 @@ static char *ccu_invoke_sidecar(const char *cmd, const char *json_input, char *e
    return out;
 }
 
-static void ccu_resolve_command(const kb_curator_extract_opts_t *opts, char *out, size_t len)
-{
-   if (opts->extract_command[0])
-   {
-      snprintf(out, len, "%s", opts->extract_command);
-      return;
-   }
-
-   char exe[512];
-   ssize_t n = readlink("/proc/self/exe", exe, sizeof(exe) - 1);
-   if (n > 0)
-   {
-      exe[n] = '\0';
-      char *slash = strrchr(exe, '/');
-      if (slash)
-      {
-         *slash = '\0';
-         char candidate[768];
-         snprintf(candidate, sizeof(candidate), "%s/../scripts/curator-extract.py", exe);
-         if (access(candidate, X_OK) == 0)
-         {
-            snprintf(out, len, "python3 %s", candidate);
-            return;
-         }
-      }
-   }
-
-   snprintf(out, len, "python3 scripts/curator-extract.py");
-}
+/* Sidecar command resolution is shared with the doc extract stage; see
+ * kb_curator_resolve_sidecar_command() in kb_curator_extract.c. */
 
 /* ── Structural grounding gate ─────────────────────────────────────────────
  * Reject a code_unit whose extracted payload claims the symbol has no side
@@ -604,7 +577,7 @@ int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts)
    }
 
    char cmd[768];
-   ccu_resolve_command(opts, cmd, sizeof(cmd));
+   kb_curator_resolve_sidecar_command(opts, cmd, sizeof(cmd));
 
    aimee_log(LOG_INFO, "kb.curator.extract_code", "invoking sidecar for symbol '%s' (job %lld): %s",
              job.symbol, (long long)job.job_id, cmd);

--- a/src/kb_curator_extract.h
+++ b/src/kb_curator_extract.h
@@ -1,6 +1,8 @@
 #ifndef DEC_KB_CURATOR_EXTRACT_H
 #define DEC_KB_CURATOR_EXTRACT_H 1
 
+#include <stddef.h> /* size_t */
+
 typedef struct
 {
    char extract_command[512];
@@ -18,5 +20,18 @@ int kb_curator_extract_one(const kb_curator_extract_opts_t *opts);
  * role="extract_code_unit", writes code_unit artifacts to DB2.
  * Returns 1 if a job was processed, 0 if queue is empty, -1 on hard error. */
 int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts);
+
+/* Resolve the curator-extract.py sidecar command shared by the doc and code
+ * extract stages. An explicit opts->extract_command wins; otherwise the bundled
+ * script is located at its real install path and run as `python3 <path>`. */
+void kb_curator_resolve_sidecar_command(const kb_curator_extract_opts_t *opts, char *out,
+                                        size_t len);
+
+/* Core selection, exposed for testing: an explicit command wins; else the first
+ * READABLE candidate is run as `python3 <path>` (the script is invoked via
+ * python3, so readability — not the execute bit — is what matters); else a
+ * cwd-relative last resort. NULL/empty candidate entries are skipped. */
+void kb_curator_pick_sidecar_command(const char *explicit_cmd, const char *const *candidates,
+                                     int n_candidates, char *out, size_t len);
 
 #endif /* DEC_KB_CURATOR_EXTRACT_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1900,6 +1900,7 @@ $(TESTPREFIX)/unit-test-curator-code-unit: \
                                        $(OBJDIR)/tests/test_curator_code_unit.o \
                                        $(OBJDIR)/kb/kb_curator_queue.o \
                                        $(OBJDIR)/kb/kb_curator_extract_code.o \
+                                       $(OBJDIR)/kb/kb_curator_extract.o \
                                        $(OBJDIR)/kb/kb_curator_grounding.o \
                                        $(OBJDIR)/db2/artifacts.o \
                                        $(OBJDIR)/db2/feature_rows.o \

--- a/src/tests/test_curator_code_unit.c
+++ b/src/tests/test_curator_code_unit.c
@@ -9,12 +9,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 #include <sqlite3.h>
 
 #include "db2_test_shim.h"
 #include "cJSON.h"
 #include "config.h"
+#include "kb_curator_extract.h"
 #include "kb/kb_curator_grounding.h"
 
 /* The deep-curator code-extract gate is now ON by compiled default, but the
@@ -38,17 +40,12 @@ static void test_force_curator_gate_off(void)
    config_save(&cfg);
 }
 
-/* Forward declarations (headers live in src/, not src/headers/). */
-typedef struct
-{
-   char extract_command[512];
-   int max_tokens;
-   int max_attempts;
-} kb_curator_extract_opts_t;
+/* Forward declarations (headers live in src/, not src/headers/). The opts struct
+ * and kb_curator_extract_code_unit_one come from kb_curator_extract.h (included
+ * above). */
 int kb_curator_queue_code_unit(const char *project, const char *file_path, const char *symbol,
                                int line);
 int kb_curator_queue_code_units_for_project(const char *project, const char *root_path);
-int kb_curator_extract_code_unit_one(const kb_curator_extract_opts_t *opts);
 int db2_artifact_count(const char *kind, const char *state);
 
 /* ── gate-off tests (no DB needed) ─────────────────────────────────────── */
@@ -351,6 +348,43 @@ static void test_extract_reads_body_from_db2_when_file_absent(void)
 
 /* ── main ─────────────────────────────────────────────────────────────── */
 
+/* The sidecar resolver must (a) honour an explicit command, (b) pick a READABLE
+ * candidate even when it is not executable — invoked as `python3 <path>`, the
+ * old access(X_OK) check wrongly rejected the shipped 0644 script and stalled
+ * every extract job — and (c) fall back to the cwd-relative path when none match. */
+static void test_pick_sidecar_command_resolution(void)
+{
+   char out[768];
+
+   /* (a) explicit command wins verbatim, candidates ignored. */
+   const char *none[] = {"/should/not/matter.py"};
+   kb_curator_pick_sidecar_command(
+       "env LLM_ENDPOINT=x python3 /opt/aimee/scripts/curator-extract.py", none, 1, out,
+       sizeof(out));
+   assert(strcmp(out, "env LLM_ENDPOINT=x python3 /opt/aimee/scripts/curator-extract.py") == 0);
+
+   /* (b) first READABLE candidate is chosen; a missing one ahead of it is skipped,
+    *     and a 0644 (non-executable) file still qualifies. */
+   char tmpl[] = "/tmp/aimee_sidecar_XXXXXX";
+   int fd = mkstemp(tmpl);
+   assert(fd >= 0);
+   close(fd);
+   assert(chmod(tmpl, 0644) == 0); /* readable, NOT executable */
+   const char *cands[] = {"/nonexistent/curator-extract.py", tmpl};
+   kb_curator_pick_sidecar_command("", cands, 2, out, sizeof(out));
+   char want[800];
+   snprintf(want, sizeof(want), "python3 %s", tmpl);
+   assert(strcmp(out, want) == 0);
+   unlink(tmpl);
+
+   /* (c) no readable candidate -> cwd-relative fallback. */
+   const char *missing[] = {"/nonexistent/a.py", NULL};
+   kb_curator_pick_sidecar_command("", missing, 2, out, sizeof(out));
+   assert(strcmp(out, "python3 scripts/curator-extract.py") == 0);
+
+   printf("  PASS: test_pick_sidecar_command_resolution\n");
+}
+
 int main(void)
 {
    printf("curator_code_unit:\n");
@@ -370,6 +404,7 @@ int main(void)
    test_extract_accepts_honest_claim();
    test_extract_accepts_pure_function();
    test_extract_reads_body_from_db2_when_file_absent();
+   test_pick_sidecar_command_resolution();
 
    printf("ok\n");
    return 0;


### PR DESCRIPTION
## Why the curator backlog wasn't draining
The curator doc/code extract stages shell out to `scripts/curator-extract.py`. The resolver (`ce_resolve_command` / `ccu_resolve_command`, duplicated) looked for the script **only** at `<bindir>/../scripts/curator-extract.py` and checked `access(X_OK)`.

In a packaged deploy that's doubly broken:
- the binary is `/usr/local/bin/aimee-kb`, so the heuristic computes `/usr/local/scripts/curator-extract.py` — **miss** (the Dockerfiles COPY scripts to `/opt/aimee/scripts/`);
- the script is mode `0644`, so the `X_OK` check would reject it **even if found** (it's run as `python3 <script>`, which needs only read).

So the resolver fell through to a cwd-relative `python3 scripts/curator-extract.py`, which can't open from the kb working dir (`/var/lib/aimee`). **Every `extract_code`/`extract_docs` job failed at launch** (`can't open file …curator-extract.py`), exhausted its retries, and the backlog never drained. Confirmed live on `.254` (jobs 25119–25149 churning at `attempt N/3`).

## Fix
- Search the **real install locations** — `/opt/aimee/scripts` (image) first, then the dev/build tree beside the binary — and use the first **readable** match (`R_OK`, not `X_OK`).
- De-duplicate: the identical resolver was copy-pasted in both extract stages; both now call one shared `kb_curator_resolve_sidecar_command()`, with the selection core `kb_curator_pick_sidecar_command()` exposed for tests.

## Test
`test_pick_sidecar_command_resolution` — explicit command wins / first **readable, non-executable** candidate is chosen / cwd-relative fallback when none match. `unit-test-curator-code-unit` is green; `clang-format` clean.

## Scope / follow-up
This unblocks the script from being **found and run**. For jobs to then **succeed**, a deploy must point the sidecar at a reachable LLM (set `kb.curator.extract_command` or `LLM_ENDPOINT`). Separately, `curator-extract.py` hardcodes `LLM_ENDPOINT` default `http://192.168.1.122:8080` (a dev box) — a stale default worth fixing on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)