### PR TITLE
fix(gateway): stop double-emitting response.created on OpenAI /v1/responses streaming

### DIFF
--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -222,41 +222,42 @@ extern "C"
     * resp[cap]. Returns bytes written, or -1. */
    int openai_format_error(char *resp, int cap, const char *type, const char *message);
 
-   /* P2c (response-side tool policing, OpenAI streaming): emit the
-    * `response.*` SSE event sequence for a parsed_response_t that carries
-    * `calls[]` (the post-police shape — calls[] may be empty if every
-    * entry was a denied subagent). The wire shape mirrors the existing
-    * tool-call emit loop in responses_stream_handler; this helper
-    * exists for unit-testability (test_openai_chat_policed.c).
-    * - Always emits `response.created` first.
+   /* P2c (response-side tool policing, OpenAI streaming): emit the tool-call
+    * tail of the `response.*` SSE sequence for a parsed_response_t that carries
+    * `calls[]` (the post-police shape — calls[] may be empty if every entry was
+    * a denied subagent). The wire shape mirrors the existing tool-call emit loop
+    * in responses_stream_handler; this helper exists for unit-testability
+    * (test_openai_chat_policed.c).
+    *
+    * Caller contract: the caller MUST emit the leading `response.created`
+    * envelope event exactly once before invoking this helper (every path —
+    * text, tool-call, error — shares that single emit). This helper does NOT
+    * emit `response.created`, so the tool-call path never doubles it on the wire.
     * - If parsed->call_count > 0: emits per-call frames for each surviving
     *   call (output_item.added, function_call_arguments.delta/.done,
-    *   output_item.done), then response.completed with all calls in
-    *   output[].
+    *   output_item.done), then response.completed with all calls in output[].
     * - If parsed->call_count == 0 (the P2c all-dropped case), OR parsed is
-    *   NULL: emits response.created + response.completed with empty output[]
-    *   (a NULL parsed is treated as zero calls / zero usage, never dereferenced).
+    *   NULL: emits a single response.completed with empty output[] (a NULL
+    *   parsed is treated as zero calls / zero usage, never dereferenced).
     *
     * Ownership / lifetime:
     * - The function borrows everything; it takes ownership of nothing and frees
     *   nothing of the caller's. `parsed`, `id`, `model`, and the `ctx` behind
     *   `emit` need only outlive the call (synchronous — `emit` is invoked only
     *   before this function returns; neither `emit` nor `ctx` is retained).
-    * - `frame` / `frame_cap` are caller-owned scratch used only for the
-    *   `response.created` frame; pass a buffer of at least 1024 bytes. That
-    *   frame holds only id + model + a fixed JSON envelope (no tool args), so
-    *   it is bounded by the id/model lengths; 1024 covers the current ids and
-    *   model aliases with wide margin (callers today pass 2048). If
-    *   openai_format_responses_created reports it does not fit, the created
-    *   frame is skipped. Per-call and `response.completed` frames use scratch
-    *   the function mallocs (sized to the args) and frees internally.
+    * - A NULL `emit` is tolerated (the helper returns without emitting) — a guard
+    *   for the public/test surface; the production caller (responses_stream_handler)
+    *   always passes a real emit and has already emitted `response.created`
+    *   through it before calling, so a NULL there is a non-starter. Per-call and
+    *   `response.completed` frames use scratch the function mallocs (sized to the
+    *   id/model/args) and frees internally — no caller scratch is needed.
     * - Emit failures are not the helper's concern: `emit` returns void and the
     *   helper does not roll back or resume a partially-emitted sequence. A
     *   transport that can fail mid-stream must detect it inside `emit`/`ctx`;
     *   the helper always walks the full sequence. */
    void openai_responses_emit_policed(const parsed_response_t *parsed, const char *id,
                                       const char *model, long created, openai_sse_emit_fn emit,
-                                      void *ctx, char *frame, size_t frame_cap);
+                                      void *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1052,6 +1052,13 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
    int erc =
        agent_execute_messages(ag, messages, tools, instructions, max_tokens, temperature, &parsed);
 
+   /* `response.created` is the per-response envelope event: emitted exactly
+    * once here for EVERY downstream path (error -> response.failed, text turn,
+    * and the tool-call branch). openai_responses_emit_policed() deliberately
+    * does NOT re-emit it, so the tool-call path never doubles it on the wire.
+    * `frame` is 2048 bytes and this event holds only the minted id (~30 chars)
+    * + model alias + a fixed JSON envelope, so it cannot truncate in practice;
+    * the `> 0` check is belt-and-suspenders, not a real partial-stream path. */
    if (openai_format_responses_created(id, model, created, frame, sizeof(frame)) > 0)
       emit(ctx, "response.created", frame);
 
@@ -1106,7 +1113,7 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
                              for the future P2b audit pass; today the only
                              visible effect is the parsed.calls[] mutation. */
 
-      openai_responses_emit_policed(&parsed, id, model, created, emit, ctx, frame, sizeof(frame));
+      openai_responses_emit_policed(&parsed, id, model, created, emit, ctx);
    }
    else
 

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -1373,20 +1373,25 @@ int openai_format_error(char *resp, int cap, const char *type, const char *messa
    return (len < 0 || len >= cap) ? -1 : len;
 }
 
-/* Emit the OpenAI /v1/responses SSE event sequence for a parsed_response_t
+/* Emit the OpenAI /v1/responses tool-call SSE tail for a parsed_response_t
  * that carries `calls[]`. Extracted from the inline emit loop in
  * responses_stream_handler so it is unit-testable in isolation
  * (test_openai_chat_policed.c) without stubbing the entire
  * agent_execute_messages pipeline.
  *
+ * The caller emits the leading `response.created` envelope event exactly once
+ * for EVERY path (error / text / tool-call); this helper emits ONLY the
+ * tool-call tail and must NOT re-emit `response.created`, otherwise the
+ * tool-call path would double it on the wire (an OpenAI/Codex protocol
+ * violation).
+ *
  * Behavior:
- *   - Always emits `response.created` first.
  *   - If parsed.call_count > 0: emits one set of per-call frames
  *     (output_item.added, function_call_arguments.delta, .done,
  *     output_item.done) per surviving call, then `response.completed`
  *     with all calls in `output[]`.
- *   - If parsed.call_count == 0 (P2c all-dropped case): emits
- *     `response.created` + `response.completed` with empty `output[]`.
+ *   - If parsed.call_count == 0 (P2c all-dropped case) or parsed is NULL:
+ *     emits a single `response.completed` with empty `output[]`.
  *
  * The wire shape is what the upstream OpenAI responses backend
  * emits for a tool-call reply; the policed-shape is identical
@@ -1395,13 +1400,12 @@ int openai_format_error(char *resp, int cap, const char *type, const char *messa
  */
 void openai_responses_emit_policed(const parsed_response_t *parsed, const char *id,
                                    const char *model, long created, openai_sse_emit_fn emit,
-                                   void *ctx, char *frame, size_t frame_cap)
+                                   void *ctx)
 {
    int n = parsed ? parsed->call_count : 0;
 
-   /* response.created (always first). */
-   if (openai_format_responses_created(id, model, created, frame, frame_cap) > 0)
-      emit(ctx, "response.created", frame);
+   if (!emit)
+      return; /* fail closed: no transport to emit on */
 
    if (n > 0)
    {
@@ -1442,9 +1446,13 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
                 output, openai_responses_function_call_item(fc_id, cid, name, args, "completed"));
       }
 
-      size_t ccap = 4096;
+      /* ccap: 4096 base (envelope/usage) + id/model, plus per call: args worst-
+       * case JSON-escaped (×6 — a byte can expand to \uXXXX) + name + call_id +
+       * 256 slack for that item's JSON keys/braces/commas/status/fc_id suffix. */
+      size_t ccap = 4096 + strlen(id ? id : "") + strlen(model ? model : "");
       for (int i = 0; i < n; i++)
-         ccap += (parsed->calls[i].arguments ? strlen(parsed->calls[i].arguments) : 0) * 6 + 256;
+         ccap += (parsed->calls[i].arguments ? strlen(parsed->calls[i].arguments) : 0) * 6 +
+                 strlen(parsed->calls[i].name) + strlen(parsed->calls[i].id) + 256;
       char *cf = malloc(ccap);
       if (cf)
       {
@@ -1465,7 +1473,7 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
       cJSON *empty_output = cJSON_CreateArray();
       int pt = parsed ? parsed->prompt_tokens : 0;
       int ct = parsed ? parsed->completion_tokens : 0;
-      size_t ccap = 4096;
+      size_t ccap = 4096 + strlen(id ? id : "") + strlen(model ? model : "");
       char *cf = malloc(ccap);
       if (cf)
       {

--- a/src/tests/test_openai_chat_policed.c
+++ b/src/tests/test_openai_chat_policed.c
@@ -2,7 +2,18 @@
  * tool-policing OpenAI /v1/responses SSE replay helper
  * (openai_responses_emit_policed). Pure shape tests — no agent
  * execution, no real provider, no streaming transport; just the
- * post-police `parsed_response_t` -> SSE event sequence. */
+ * post-police `parsed_response_t` -> SSE event tail.
+ *
+ * The helper emits ONLY the tool-call tail; the leading
+ * `response.created` envelope event is the caller's responsibility
+ * (emitted once per response for every path). These tests guard that
+ * contract — emitting created here too would double it on the wire.
+ *
+ * Scope: these tests exercise the helper's consumption of an already
+ * post-police parsed_response_t (calls[] front-packed, call_count lowered).
+ * The police function itself (gateway_policy_police_parsed_response) is
+ * tested separately in test_anthropic_http.c; seeding the post-police shape
+ * directly here keeps this test free of the config/guardrails link. */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,21 +21,20 @@
 
 #include "openai_shape.h"
 /* aimee.h before agent_protocol.h: agent_types.h (pulled by agent_protocol.h)
- * uses MAX_PATH_LEN from aimee.h. Same include convention as the production
- * caller, src/server/openai_chat.c. openai_shape.h itself stays decoupled and
- * forward-declares the types it needs. */
+ * needs the MAX_PATH_LEN size macro from aimee.h. */
 #include "aimee.h"
 #include "agent_protocol.h"
 #include "cJSON.h"
 
 #define PASS(name) printf("  PASS: %s\n", (name))
 
-/* Captured SSE events. */
-#define REPLAY_CAP 64
+/* Captured SSE events. Sized to the worst case these tests exercise (9
+ * events; payloads well under 2KB) to keep the stack object small. */
+#define REPLAY_CAP 16
 typedef struct
 {
    char events[REPLAY_CAP][64];
-   char data[REPLAY_CAP][4096];
+   char data[REPLAY_CAP][2048];
    int count;
 } cap_t;
 
@@ -66,27 +76,38 @@ static void free_parsed(parsed_response_t *p)
       free(p->calls[i].arguments);
 }
 
-/* --- tests --- */
-
-/* response.created is always emitted first, regardless of call_count. */
-static void test_emit_response_created_first(void)
+/* Defense-in-depth: assert no captured event is `response.created` — the
+ * helper must never emit the envelope on ANY path (the caller owns it). */
+static void assert_no_created(const cap_t *c)
 {
-   cap_t cap = {0};
-   parsed_response_t p;
-   seed_parsed(&p, 0, NULL, NULL, NULL, "end_turn");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   assert(cap.count >= 1);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   /* Sanity: the frame contains our id + the model. */
-   assert(strstr(cap.data[0], "\"id\":\"resp_1\"") != NULL);
-   assert(strstr(cap.data[0], "\"model\":\"claude-test\"") != NULL);
-   free_parsed(&p);
-   PASS("emit_response_created_first");
+   for (int i = 0; i < c->count; i++)
+      assert(strcmp(c->events[i], "response.created") != 0);
 }
 
-/* Single surviving tool_call: per-call frames + completed. */
+/* --- tests --- */
+
+/* Regression guard: the helper must NEVER emit `response.created` — the
+ * caller (responses_stream_handler) already emits it once for every path.
+ * A helper that re-emitted it would double `response.created` on the wire,
+ * which OpenAI/Codex clients treat as a protocol violation. */
+static void test_emit_omits_created_envelope(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"query\":\"aimee\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   assert_no_created(&cap);
+   /* First event is the tool-call item, not the envelope. */
+   assert(cap.count >= 1);
+   assert(strcmp(cap.events[0], "response.output_item.added") == 0);
+   free_parsed(&p);
+   PASS("emit_omits_created_envelope");
+}
+
+/* Single surviving tool_call: per-call frames + completed (no created). */
 static void test_emit_surviving_tool_call(void)
 {
    cap_t cap = {0};
@@ -95,23 +116,20 @@ static void test_emit_surviving_tool_call(void)
    const char *args[] = {"{\"query\":\"aimee\"}"};
    parsed_response_t p;
    seed_parsed(&p, 1, names, ids, args, "tool_calls");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
 
-   /* response.created + (output_item.added, args.delta, args.done,
-    * output_item.done) + response.completed = 6 events. */
-   assert(cap.count == 6);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   assert(strcmp(cap.events[1], "response.output_item.added") == 0);
-   assert(strstr(cap.data[1], "\"name\":\"web_search\"") != NULL);
-   assert(strstr(cap.data[1], "\"call_id\":\"call_1\"") != NULL);
-   assert(strcmp(cap.events[2], "response.function_call_arguments.delta") == 0);
-   assert(strstr(cap.data[2], "aimee") != NULL);
-   assert(strcmp(cap.events[3], "response.function_call_arguments.done") == 0);
-   assert(strcmp(cap.events[4], "response.output_item.done") == 0);
-   assert(strcmp(cap.events[5], "response.completed") == 0);
-   assert(strstr(cap.data[5], "\"output\":[") != NULL);
+   /* (output_item.added, args.delta, args.done, output_item.done)
+    * + response.completed = 5 events. */
+   assert(cap.count == 5);
+   assert(strcmp(cap.events[0], "response.output_item.added") == 0);
+   assert(strstr(cap.data[0], "\"name\":\"web_search\"") != NULL);
+   assert(strstr(cap.data[0], "\"call_id\":\"call_1\"") != NULL);
+   assert(strcmp(cap.events[1], "response.function_call_arguments.delta") == 0);
+   assert(strstr(cap.data[1], "aimee") != NULL);
+   assert(strcmp(cap.events[2], "response.function_call_arguments.done") == 0);
+   assert(strcmp(cap.events[3], "response.output_item.done") == 0);
+   assert(strcmp(cap.events[4], "response.completed") == 0);
+   assert(strstr(cap.data[4], "\"output\":[") != NULL);
    free_parsed(&p);
    PASS("emit_surviving_tool_call");
 }
@@ -125,58 +143,123 @@ static void test_emit_multiple_surviving_tool_calls(void)
    const char *args[] = {"{\"q\":\"x\"}", "{\"p\":\"/etc\"}"};
    parsed_response_t p;
    seed_parsed(&p, 2, names, ids, args, "tool_calls");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
 
-   /* response.created + (4 per-call frames × 2) + response.completed = 10. */
-   assert(cap.count == 10);
-   /* The two `output_item.added` events at indices 1 and 5 carry
+   /* (4 per-call frames × 2) + response.completed = 9. */
+   assert(cap.count == 9);
+   /* The two `output_item.added` events at indices 0 and 4 carry
     * fc_id suffixes "-fc-0" and "-fc-1" (built from the loop index). */
-   assert(strstr(cap.data[1], "-fc-0") != NULL);
-   assert(strstr(cap.data[5], "-fc-1") != NULL);
+   assert(strstr(cap.data[0], "-fc-0") != NULL);
+   assert(strstr(cap.data[4], "-fc-1") != NULL);
    /* Names preserved in original order. */
-   assert(strstr(cap.data[1], "web_search") != NULL);
-   assert(strstr(cap.data[5], "Read") != NULL);
+   assert(strstr(cap.data[0], "web_search") != NULL);
+   assert(strstr(cap.data[4], "Read") != NULL);
+   assert(strcmp(cap.events[8], "response.completed") == 0);
    free_parsed(&p);
    PASS("emit_multiple_surviving_tool_calls");
 }
 
-/* All-dropped (call_count == 0): response.created + empty-output
- * response.completed, no per-call frames. */
+/* All-dropped (non-NULL parsed, call_count == 0): a single empty-output
+ * response.completed, no per-call frames and no created. This is the realistic
+ * post-police state (police mutated calls[] to empty in place) — distinct from
+ * the defensive NULL-parsed case below. */
 static void test_emit_all_dropped_empty_output(void)
 {
    cap_t cap = {0};
    parsed_response_t p;
    seed_parsed(&p, 0, NULL, NULL, NULL, "end_turn");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
 
-   assert(cap.count == 2);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   assert(strcmp(cap.events[1], "response.completed") == 0);
+   assert(cap.count == 1);
+   assert_no_created(&cap);
+   assert(strcmp(cap.events[0], "response.completed") == 0);
    /* Empty output array — `[]`. */
-   assert(strstr(cap.data[1], "\"output\":[]") != NULL);
+   assert(strstr(cap.data[0], "\"output\":[]") != NULL);
+   /* Usage from parsed is preserved even with no surviving calls. */
+   assert(strstr(cap.data[0], "\"input_tokens\":17") != NULL);
+   assert(strstr(cap.data[0], "\"output_tokens\":23") != NULL);
    free_parsed(&p);
    PASS("emit_all_dropped_empty_output");
 }
 
-/* Null parsed is tolerated (no crash, no events emitted except created
- * with default-0 usage). Guards against a future caller passing a
- * police error result. */
+/* A call whose arguments pointer is NULL falls back to "{}" on the wire
+ * (the `arguments ? arguments : "{}"` guard — arguments is the only
+ * heap pointer; name/id are fixed char arrays and never NULL). */
+static void test_emit_null_arguments_fallback(void)
+{
+   cap_t cap = {0};
+   parsed_response_t p;
+   memset(&p, 0, sizeof(p));
+   p.is_tool_call = 1;
+   p.call_count = 1;
+   snprintf(p.calls[0].id, sizeof(p.calls[0].id), "%s", "call_1");
+   snprintf(p.calls[0].name, sizeof(p.calls[0].name), "%s", "f");
+   p.calls[0].arguments = NULL; /* exercise the fallback */
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   assert(cap.count == 5);
+   /* args.delta (index 1) carries the decoded delta "{}" */
+   cJSON *delta_ev = cJSON_Parse(cap.data[1]);
+   assert(delta_ev != NULL);
+   const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
+   assert(cJSON_IsString(delta) && strcmp(delta->valuestring, "{}") == 0);
+   cJSON_Delete(delta_ev);
+   /* .done (index 2) is a separate format path — verify it also carries "{}". */
+   cJSON *done_ev = cJSON_Parse(cap.data[2]);
+   assert(done_ev != NULL);
+   const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
+   assert(cJSON_IsString(full) && strcmp(full->valuestring, "{}") == 0);
+   cJSON_Delete(done_ev);
+   free_parsed(&p); /* arguments was NULL; free(NULL) is a no-op — kept for convention */
+   PASS("emit_null_arguments_fallback");
+}
+
+/* Metadata propagation: id/model/created must appear verbatim in the
+ * response.completed payload so Codex can correlate the streamed turn. */
+static void test_emit_metadata_propagation(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"q\":\"x\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   openai_responses_emit_policed(&p, "resp_meta_42", "gpt-5.5", 99999L, cap_emit, &cap);
+   const char *completed = cap.data[cap.count - 1];
+   assert(strcmp(cap.events[cap.count - 1], "response.completed") == 0);
+   assert(strstr(completed, "resp_meta_42") != NULL);
+   assert(strstr(completed, "gpt-5.5") != NULL);
+   assert(strstr(completed, "99999") != NULL); /* created timestamp, verbatim */
+   free_parsed(&p);
+   PASS("emit_metadata_propagation");
+}
+
+/* Null parsed is tolerated (no crash): a single empty-output completed.
+ * Guards against a future caller passing a police error result. */
 static void test_emit_null_parsed(void)
 {
    cap_t cap = {0};
-   char frame[2048];
-   openai_responses_emit_policed(NULL, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   /* response.created + empty-output completed. */
-   assert(cap.count == 2);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   assert(strcmp(cap.events[1], "response.completed") == 0);
-   assert(strstr(cap.data[1], "\"output\":[]") != NULL);
+   openai_responses_emit_policed(NULL, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   assert(cap.count == 1);
+   assert_no_created(&cap);
+   assert(strcmp(cap.events[0], "response.completed") == 0);
+   assert(strstr(cap.data[0], "\"output\":[]") != NULL);
+   /* NULL parsed defaults usage to 0. */
+   assert(strstr(cap.data[0], "\"input_tokens\":0") != NULL);
+   assert(strstr(cap.data[0], "\"output_tokens\":0") != NULL);
    PASS("emit_null_parsed");
+}
+
+/* A NULL emit callback is tolerated (fail closed, no crash). */
+static void test_emit_null_callback(void)
+{
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"q\":\"x\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, NULL, NULL);
+   free_parsed(&p);
+   PASS("emit_null_callback");
 }
 
 /* Arguments are propagated verbatim (byte-for-byte fidelity for the
@@ -192,24 +275,23 @@ static void test_emit_arguments_byte_fidelity(void)
    const char *args[] = {"{\"b\":2,\"a\":1,\"nested\":{\"x\":\"y\"}}"};
    parsed_response_t p;
    seed_parsed(&p, 1, names, ids, args, "tool_calls");
-   char frame[2048];
    const char *original = args[0];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   /* The args.delta event carries the arguments as the JSON-string `delta`
-    * field (the OpenAI wire shape — inner quotes are escaped on the wire).
-    * Byte fidelity means: after parsing the event JSON, the decoded `delta`
-    * string equals the original arguments byte-for-byte (no key reorder, no
-    * whitespace reflow). Parse it back and compare rather than scanning the
-    * escaped wire bytes. The same fidelity holds for the `.done` event. */
-   cJSON *delta_ev = cJSON_Parse(cap.data[2]);
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   /* The args.delta event (index 1) carries the arguments as the JSON-string
+    * `delta` field. Byte fidelity: after parsing the event JSON, the decoded
+    * `delta` string equals the original arguments byte-for-byte (no key
+    * reorder, no whitespace reflow). The same holds for the `.done` event
+    * at index 2. */
+   assert(strcmp(cap.events[1], "response.function_call_arguments.delta") == 0);
+   cJSON *delta_ev = cJSON_Parse(cap.data[1]);
    assert(delta_ev != NULL);
    const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
    assert(cJSON_IsString(delta) && delta->valuestring != NULL);
    assert(strcmp(delta->valuestring, original) == 0);
    cJSON_Delete(delta_ev);
 
-   cJSON *done_ev = cJSON_Parse(cap.data[3]);
+   assert(strcmp(cap.events[2], "response.function_call_arguments.done") == 0);
+   cJSON *done_ev = cJSON_Parse(cap.data[2]);
    assert(done_ev != NULL);
    const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
    assert(cJSON_IsString(full) && full->valuestring != NULL);
@@ -220,43 +302,51 @@ static void test_emit_arguments_byte_fidelity(void)
    PASS("emit_arguments_byte_fidelity");
 }
 
-/* Byte fidelity holds for the hard cases too: arguments containing characters
- * that must be JSON-escaped on the wire (embedded quotes/backslashes from a
- * nested JSON string) and multi-byte UTF-8. The decoded delta/arguments must
- * still equal the original byte-for-byte. */
-static void test_emit_arguments_escapes_and_utf8(void)
+/* Escaping / UTF-8 fidelity: arguments containing embedded quotes, a
+ * backslash, a newline, and a multi-byte UTF-8 sequence must decode
+ * byte-for-byte from both the delta and done events (the JSON-string
+ * wire-escaping must round-trip exactly). */
+static void test_emit_arguments_escapes_utf8(void)
 {
    cap_t cap = {0};
    const char *names[] = {"f"};
    const char *ids[] = {"c1"};
-   /* A path with a quote + backslash, and a UTF-8 string value (é, 日本). */
-   const char *args[] = {"{\"path\":\"C:\\\\a\\\"b\",\"note\":\"café 日本\"}"};
+   /* quote, backslash, newline, and "café 日本" (multi-byte UTF-8). */
+   const char *args[] = {"{\"s\":\"a\\\"b\\\\c\\nd café 日本\"}"};
    parsed_response_t p;
    seed_parsed(&p, 1, names, ids, args, "tool_calls");
-   char frame[2048];
    const char *original = args[0];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   cJSON *delta_ev = cJSON_Parse(cap.data[2]);
-   assert(delta_ev != NULL); /* the emitted frame is itself valid JSON */
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+
+   cJSON *delta_ev = cJSON_Parse(cap.data[1]);
+   assert(delta_ev != NULL);
    const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
-   assert(cJSON_IsString(delta) && delta->valuestring != NULL);
-   assert(strcmp(delta->valuestring, original) == 0);
+   assert(cJSON_IsString(delta) && strcmp(delta->valuestring, original) == 0);
    cJSON_Delete(delta_ev);
+
+   cJSON *done_ev = cJSON_Parse(cap.data[2]);
+   assert(done_ev != NULL);
+   const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
+   assert(cJSON_IsString(full) && strcmp(full->valuestring, original) == 0);
+   cJSON_Delete(done_ev);
+
    free_parsed(&p);
-   PASS("emit_arguments_escapes_and_utf8");
+   PASS("emit_arguments_escapes_utf8");
 }
 
 int main(void)
 {
    printf("test_openai_chat_policed:\n");
-   test_emit_response_created_first();
+   test_emit_omits_created_envelope();
    test_emit_surviving_tool_call();
    test_emit_multiple_surviving_tool_calls();
    test_emit_all_dropped_empty_output();
+   test_emit_null_arguments_fallback();
+   test_emit_metadata_propagation();
    test_emit_null_parsed();
+   test_emit_null_callback();
    test_emit_arguments_byte_fidelity();
-   test_emit_arguments_escapes_and_utf8();
+   test_emit_arguments_escapes_utf8();
    printf("all openai_chat_policed tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Problem
Commit `140c896` (P2c — OpenAI `/v1/responses` response-side tool policing, now on `testing`) extracted the streaming tool-call emit loop into `openai_responses_emit_policed()`. That helper emits `response.created` itself — but `responses_stream_handler` **already** emits the `response.created` envelope unconditionally for every path (error / text / tool-call) right after `agent_execute_messages()`. So the tool-call path emits **`response.created` twice**, which OpenAI/Codex SSE clients treat as a protocol violation.

## Fix
- `openai_responses_emit_policed()` now emits **only the tool-call tail** (per-call frames + `response.completed`, or a single empty-output `response.completed` for the all-dropped / NULL case). `response.created` stays the handler's single per-response envelope emit.
- Dropped the now-unused `frame`/`frame_cap` params; added a fail-closed `!emit` guard for the public/test surface; `response.completed` buffer sizing now includes id/model/name/call_id lengths.

## Tests
`test_openai_chat_policed` rewritten (the prior version asserted the helper emits `created` first — enshrining the bug). New coverage: a no-`response.created` regression guard across the tool-call / all-dropped / NULL paths; NULL-arguments `{}` fallback (delta + done); NULL-emit guard; metadata/usage propagation; escaped + UTF-8 argument byte-fidelity. 10/10 pass; full server links clean.

## Review notes
Reviewed via the aimee roundtable. The substantive findings (helper contract, ownership, buffer sizing, NULL/edge tests) were addressed. A full end-to-end `responses_stream_handler` test (asserting `response.created` exactly once across all paths) is deferred as a follow-up: the handler is `static` and pulls in the entire agent runtime, so a harness is disproportionate here — the invariant is covered structurally (helper provably never emits `created` + the handler's single per-path emit site).

🤖 Generated with [Claude Code](https://claude.com/claude-code)