### PR TITLE
feat(guard): aimee-level session-isolation guard (require_session_worktree)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (109)
+## CLI-settable keys (110)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -130,11 +130,14 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
+| `require_session_worktree` | bool | — |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
+
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `require_session_worktree`
 
 ## Config-file sections (49)
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -130,14 +130,12 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
-| `require_session_worktree` | bool | — |
+| `require_session_worktree` | bool | Fail closed on mutating ops outside an aimee-managed worktree (session-isolation guard; default off). |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
-
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `require_session_worktree`
 
 ## Config-file sections (49)
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -142,6 +142,8 @@ CFG_KEY_DESC = {
     "identity_working_profile_injection_enabled": "Inject the working-profile identity into prompts.",
     "ingress_audit_async": "Audit ingress requests asynchronously.",
     "ingress_max_raw_scans": "Max raw-content scans per ingress request.",
+    "require_session_worktree": "Fail closed on mutating ops outside an aimee-managed worktree "
+    "(session-isolation guard; default off).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress.",
     "ingress_trusted_proxy_secret": "Shared secret authenticating a trusted ingress proxy.",

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -25,7 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h> /* strncasecmp */
 #include <time.h>
+#include <unistd.h> /* getcwd */
 
 double attn_score(const attn_record_t *recs, int n, const char *path, long now_ts)
 {
@@ -405,6 +407,192 @@ static int attn_config_ingress_max_raw_scans(void)
    return value;
 }
 
+/* Parse a boolean `require_session_worktree:` line from an aimee.yaml buffer.
+ * Accepts true/1/yes/on (case-insensitive) as true; anything else (incl. a
+ * missing key) is false. Mirrors attn_parse_ingress_max_raw_scans' lean,
+ * link-free YAML-line scan so the guard need not pull in the full config. */
+static int attn_parse_require_session_worktree(const char *buf, int *out)
+{
+   if (!buf || !out)
+      return 0;
+
+   const char *line = buf;
+   while (*line)
+   {
+      const char *p = line;
+      while (*p == ' ' || *p == '\t')
+         p++;
+
+      if (*p && *p != '#')
+      {
+         char quote = 0;
+         if (*p == '"' || *p == '\'')
+            quote = *p++;
+
+         size_t key_len = strlen("require_session_worktree");
+         if (strncmp(p, "require_session_worktree", key_len) == 0)
+         {
+            p += key_len;
+            if (quote)
+            {
+               if (*p != quote)
+                  goto next_line;
+               p++;
+            }
+            while (*p && isspace((unsigned char)*p))
+               p++;
+            if (*p == ':' || *p == '=')
+            {
+               p++;
+               while (*p && (isspace((unsigned char)*p) || *p == '"' || *p == '\''))
+                  p++;
+               *out = (strncasecmp(p, "true", 4) == 0 || strncasecmp(p, "yes", 3) == 0 ||
+                       strncasecmp(p, "on", 2) == 0 || *p == '1');
+               return 1;
+            }
+         }
+      }
+
+   next_line:
+      while (*line && *line != '\n')
+         line++;
+      if (*line == '\n')
+         line++;
+   }
+
+   return 0;
+}
+
+static int attn_config_require_session_worktree(void)
+{
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return 0;
+
+   char path[1024];
+   snprintf(path, sizeof(path), "%s/aimee.yaml", home);
+
+   char *buf = NULL;
+   if (!attn_read_file(path, &buf))
+      return 0;
+
+   int value = 0;
+   if (!attn_parse_require_session_worktree(buf, &value))
+      value = 0;
+   free(buf);
+   return value;
+}
+
+/* Lexically resolve '.', '..' and '//' in `path` into `out` (purely textual —
+ * the write target may not exist yet, so realpath() is unusable; symlinks are
+ * not followed). Closes the `.aimee/worktrees/../escape` traversal bypass: a
+ * component sequence like ".../worktrees/x/../../src" collapses so the marker
+ * substring no longer survives for an escaped path. A leading '/' is preserved;
+ * '..' that would rise above the root is dropped (cannot escape '/'). */
+static void attn_lexical_normalize(const char *path, char *out, size_t out_n)
+{
+   if (!out || out_n == 0)
+      return;
+   out[0] = '\0';
+   if (!path || !path[0])
+      return;
+
+   int absolute = (path[0] == '/');
+   /* Component start offsets within `out` form a simple stack. 256 components is
+    * far beyond any real path; if exceeded, recording simply stops (a later '..'
+    * may pop to a stale offset, yielding a shorter path) — this only ever drops
+    * the worktree marker, i.e. fails closed (blocks), never opens a bypass. */
+   size_t starts[256];
+   int depth = 0;
+   size_t len = 0;
+   if (absolute && len + 1 < out_n)
+      out[len++] = '/';
+
+   const char *p = path;
+   while (*p)
+   {
+      while (*p == '/')
+         p++;
+      if (!*p)
+         break;
+      const char *seg = p;
+      while (*p && *p != '/')
+         p++;
+      size_t seglen = (size_t)(p - seg);
+
+      if (seglen == 1 && seg[0] == '.')
+         continue; /* current dir: skip */
+      if (seglen == 2 && seg[0] == '.' && seg[1] == '.')
+      {
+         if (depth > 0)
+         {
+            depth--;
+            len = starts[depth]; /* pop last component (and its '/') */
+            if (len > 0 && out[len - 1] == '/' && !(absolute && len == 1))
+               len--;
+            out[len] = '\0';
+         }
+         /* else: '..' at/above root is dropped (absolute) or kept-as-root */
+         continue;
+      }
+
+      /* Push a separator before this component when one is needed. */
+      if (len > 0 && out[len - 1] != '/')
+      {
+         if (len + 1 >= out_n)
+            break;
+         out[len++] = '/';
+      }
+      if (depth < (int)(sizeof(starts) / sizeof(starts[0])))
+         starts[depth++] = len;
+      if (len + seglen >= out_n)
+         break;
+      memcpy(out + len, seg, seglen);
+      len += seglen;
+      out[len] = '\0';
+   }
+   if (len == 0 && out_n > 0)
+   {
+      out[0] = absolute ? '/' : '.';
+      out[1] = '\0';
+   }
+}
+
+/* Returns 1 iff `norm` (an already lexically-normalized path) is inside an
+ * aimee-managed worktree. Matches ONLY the canonical managed location
+ * "/.aimee/worktrees/" — deliberately NOT the looser "/.aimee-" prefix that
+ * is_aimee_worktree_path() also accepts, which would false-match unrelated
+ * dirs like "/home/u/.aimee-notes/...". */
+static int attn_path_in_managed_worktree(const char *norm)
+{
+   return norm && strstr(norm, "/.aimee/worktrees/") != NULL;
+}
+
+/* Pure decision for the session-isolation guard (testable in isolation).
+ * Returns 1 to BLOCK: a mutating op (SOFT/HARD) whose effective target is NOT
+ * inside an aimee-managed worktree. Read / raw-scan ops are never blocked here.
+ * The effective target is `file_path` when given (resolved against `cwd` when
+ * relative), else `cwd` itself (a Bash mutation runs there). The joined path is
+ * lexically normalized before the worktree check so a "../" escape out of the
+ * worktree is blocked even though the raw string still contained the marker. */
+int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const char *cwd)
+{
+   if (op != ATTN_OP_SOFT && op != ATTN_OP_HARD)
+      return 0;
+
+   char joined[2048];
+   if (file_path && file_path[0] == '/')
+      snprintf(joined, sizeof(joined), "%s", file_path);
+   else if (file_path && file_path[0])
+      snprintf(joined, sizeof(joined), "%s/%s", cwd ? cwd : "", file_path);
+   else
+      snprintf(joined, sizeof(joined), "%s", cwd ? cwd : "");
+
+   char norm[2048];
+   attn_lexical_normalize(joined, norm, sizeof(norm));
+   return attn_path_in_managed_worktree(norm) ? 0 : 1;
+}
+
 int handle_attention_guard(void)
 {
    const char *bypass = getenv("AIMEE_GUARD");
@@ -427,6 +615,34 @@ int handle_attention_guard(void)
 
    long now_ts = (long)time(NULL);
    attn_op_t op = attn_classify(tool, bash_cmd);
+
+   /* Session-isolation guard (OPT-IN via require_session_worktree). Fails closed
+    * on a mutating op outside an aimee-managed worktree, so a session that never
+    * ran `session-start` (e.g. a missing SessionStart hook) cannot mutate the
+    * primary checkout / default branch. This is the aimee-level backstop for the
+    * worktree+branch isolation that the SessionStart hook would otherwise set up. */
+   if ((op == ATTN_OP_SOFT || op == ATTN_OP_HARD) && attn_config_require_session_worktree())
+   {
+      char cwd[1024];
+      if (!getcwd(cwd, sizeof(cwd)))
+         cwd[0] = '\0';
+      const char *fp =
+          ti ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(ti, "file_path")) : NULL;
+      if (attn_session_isolation_blocked(op, fp, cwd))
+      {
+         fprintf(stderr,
+                 "aimee attention-guard: refusing a mutating op outside an aimee session "
+                 "worktree. This session is operating in '%s', which is not an aimee-managed "
+                 "worktree (.aimee/worktrees/...). aimee requires each mutating session to run "
+                 "in an isolated worktree+branch off the default branch; provision one with "
+                 "`aimee session-start` (or restart the client so its SessionStart hook does). "
+                 "Set require_session_worktree:false in aimee.yaml or AIMEE_GUARD=0 to bypass.\n",
+                 cwd[0] ? cwd : "(unknown cwd)");
+         cJSON_Delete(hook);
+         free(stdin_data);
+         return 2;
+      }
+   }
 
    char path[1024];
    attn_log_path(sid, path, sizeof(path));

--- a/src/config.c
+++ b/src/config.c
@@ -508,6 +508,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->integrity_dry_run = 1;
    cfg->ingress_preinject_assembly_budget = 6144;
    cfg->ingress_max_raw_scans = 0;
+   cfg->require_session_worktree = 0;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled
@@ -864,6 +865,10 @@ int config_load(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_max_raw_scans");
    if (cJSON_IsNumber(item) && item->valuedouble >= 0)
       cfg->ingress_max_raw_scans = (int)item->valuedouble;
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "require_session_worktree");
+   if (cJSON_IsBool(item))
+      cfg->require_session_worktree = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "typed_facts_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -47,6 +47,8 @@ const config_field_t config_fields[] = {
     {"ingress_preinject_assembly_budget", offsetof(config_t, ingress_preinject_assembly_budget),
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},
+    {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
+     CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"css_style_graph_enabled", offsetof(config_t, css_style_graph_enabled), sizeof(int), 0,
      CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -782,6 +782,8 @@ int config_save(const config_t *cfg)
                               cfg->ingress_preinject_assembly_budget);
    if (cfg->ingress_max_raw_scans != 0)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
+   if (cfg->require_session_worktree)
+      cJSON_AddBoolToObject(root, "require_session_worktree", 1);
    if (cfg->typed_facts_enabled)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
    if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -15,6 +15,7 @@
 {"typed_facts_enabled", SCHEMA_BOOL, 0},
 {"ingress_preinject_assembly_budget", SCHEMA_INT, 0},
 {"ingress_max_raw_scans", SCHEMA_INT, 0},
+{"require_session_worktree", SCHEMA_BOOL, 0},
 {"guardrails", SCHEMA_OBJECT, 0},
 {"toolsets", SCHEMA_OBJECT, 0},
 {"script", SCHEMA_OBJECT, 0},

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -91,4 +91,11 @@ const char *agent_tools_parent_write_guard_root(void);
 const char *agent_tools_parent_write_guard_write_root(void);
 int agent_tools_parent_write_guard_blocks(const char *path, const char *cwd);
 
+/* Session-isolation backstop (Layer 2, opt-in via require_session_worktree):
+ * returns 1 to BLOCK a server-side agent write whose normalized target is not
+ * inside an aimee-managed worktree, else 0. No-op (returns 0) unless the
+ * require_session_worktree config flag is enabled. Mirrors the client-side
+ * attention-guard isolation policy for aimee's own in-process agent writes. */
+int agent_tools_session_isolation_blocks(const char *path, const char *cwd);
+
 #endif /* DEC_AGENT_TOOLS_H */

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -56,6 +56,14 @@ int attn_is_raw_scan(const char *tool_name, const char *bash_cmd);
 /* The attention weight to record for a tool call of the given class. Pure. */
 int attn_weight_for(attn_op_t op);
 
+/* Session-isolation decision (pure, testable). Returns 1 to BLOCK a mutating op
+ * (ATTN_OP_SOFT/HARD) whose effective target is NOT inside an aimee-managed
+ * worktree, else 0. The effective target is the absolute `file_path` when given
+ * (Edit/Write), otherwise `cwd` (a relative file_path resolves under cwd; a Bash
+ * mutation runs there). Read/raw-scan ops are never blocked. Used by
+ * handle_attention_guard only when require_session_worktree is enabled. */
+int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const char *cwd);
+
 /* `aimee attention-guard` PreToolUse-hook entry. Reads the host hook JSON from
  * stdin, updates the per-session attention log, and returns the hook exit code
  * (2 = block a hard-destructive op on a high-attention file, or — only when a

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -337,6 +337,11 @@ typedef struct config
    int ingress_preinject_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
+   /* Session-isolation guard (opt-in): when on, the PreToolUse attention-guard
+    * fails closed on a mutating tool whose target is NOT inside an aimee-managed
+    * worktree (.aimee/worktrees/...), forcing every mutating session into an
+    * isolated worktree+branch off the default branch. Default 0 (off). */
+   int require_session_worktree;
 
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
     * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -424,6 +424,11 @@ static char *td_edit_file(cJSON *args, const char *name, const char *dispatch_cw
       {
          result = safe_strdup("error: write blocked: parent worktree is read-only for delegates");
       }
+      else if (agent_tools_session_isolation_blocks(p->valuestring, dispatch_cwd))
+      {
+         result = safe_strdup("error: write blocked: require_session_worktree is enabled and this "
+                              "target is outside an aimee-managed worktree (.aimee/worktrees/...)");
+      }
       else
       {
          /* Auto-snapshot: record pre-edit state in the persistent rewind DB */
@@ -457,6 +462,11 @@ static char *td_write_file(cJSON *args, const char *name, const char *dispatch_c
       if (agent_tools_parent_write_guard_blocks(p->valuestring, dispatch_cwd))
       {
          result = safe_strdup("error: write blocked: parent worktree is read-only for delegates");
+      }
+      else if (agent_tools_session_isolation_blocks(p->valuestring, dispatch_cwd))
+      {
+         result = safe_strdup("error: write blocked: require_session_worktree is enabled and this "
+                              "target is outside an aimee-managed worktree (.aimee/worktrees/...)");
       }
       else
       {

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -129,6 +129,35 @@ int agent_tools_parent_write_guard_blocks(const char *path, const char *cwd)
    return agent_tools_path_under_root(norm, g_parent_ro_root);
 }
 
+/* Session-isolation backstop (Layer 2, opt-in via require_session_worktree).
+ * Blocks a server-side agent/delegate write whose normalized target is NOT
+ * inside an aimee-managed worktree (path component .aimee/worktrees/...). This
+ * mirrors the client-side attention-guard
+ * (Layer 1) so aimee's own in-process agent writes obey the same isolation
+ * policy that a thin client's PreToolUse hook enforces — covering the case
+ * where session-start never provisioned a worktree. Default off (the config
+ * flag defaults to 0), so this is a no-op unless explicitly enabled. */
+int agent_tools_session_isolation_blocks(const char *path, const char *cwd)
+{
+   if (!path || !path[0])
+      return 0;
+   /* config_load here mirrors the per-call pattern already used elsewhere in
+    * this file (it is cheap and reads the cached config). Default-off: when the
+    * flag is unset — or the config is unreadable, which leaves the default 0 —
+    * this is a no-op, matching the feature's opt-in nature. */
+   config_t cfg;
+   config_load(&cfg);
+   if (!cfg.require_session_worktree)
+      return 0;
+   /* normalize_path resolves '.'/'..'/relative against cwd, closing traversal
+    * escapes. Match ONLY the canonical managed-worktree location (not the
+    * looser "/.aimee-" prefix is_aimee_worktree_path() accepts), consistent
+    * with the client-side attn_session_isolation_blocked check. */
+   char norm[MAX_PATH_LEN];
+   normalize_path(path, cwd, norm, sizeof(norm));
+   return strstr(norm, "/.aimee/worktrees/") != NULL ? 0 : 1;
+}
+
 static int tools_array_has_name(cJSON *tools, const char *name, int openai_format)
 {
    cJSON *tool = NULL;

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1805,6 +1805,55 @@ static void test_agent_name_valid(void)
        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); /* 63 */
 }
 
+/* Layer 2 of the session-isolation guard: the server-side write chokepoint
+ * agent_tools_session_isolation_blocks. Default-off, and when on blocks writes
+ * whose normalized target is outside an aimee-managed worktree. */
+static void test_session_isolation_guard(void)
+{
+   char home[512];
+   snprintf(home, sizeof(home), "%s/aimee_sess_iso_XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(home) != NULL);
+   char cfg[640];
+   snprintf(cfg, sizeof(cfg), "%s/aimee.yaml", home);
+   assert(platform_setenv("AIMEE_HOME", home) == 0);
+
+   const char *primary = "/some/repo/src/x.c";
+   const char *worktree = "/some/repo/.aimee/worktrees/ab12/main/src/x.c";
+
+   /* (1) Default off (no aimee.yaml): never blocks, even on the primary checkout. */
+   remove(cfg);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 0);
+
+   /* (2) Explicit false: still no block. */
+   FILE *f = fopen(cfg, "w");
+   assert(f != NULL);
+   fputs("require_session_worktree: false\n", f);
+   fclose(f);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 0);
+
+   /* (3) Enabled: primary-checkout target blocked, managed-worktree target allowed. */
+   f = fopen(cfg, "w");
+   assert(f != NULL);
+   fputs("require_session_worktree: true\n", f);
+   fclose(f);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 1);
+   assert(agent_tools_session_isolation_blocks(worktree, NULL) == 0);
+   /* Traversal escape out of the worktree normalizes + blocks. */
+   assert(agent_tools_session_isolation_blocks(
+              "/some/repo/.aimee/worktrees/ab12/main/../../../src/y.c", NULL) == 1);
+   /* Relative path resolved against cwd (normalize_path): a worktree cwd allows,
+    * a primary-checkout cwd blocks. */
+   assert(agent_tools_session_isolation_blocks("src/x.c",
+                                               "/some/repo/.aimee/worktrees/ab12/main") == 0);
+   assert(agent_tools_session_isolation_blocks("src/x.c", "/some/repo") == 1);
+   /* NULL path is a no-op (returns 0). */
+   assert(agent_tools_session_isolation_blocks(NULL, NULL) == 0);
+
+   remove(cfg);
+   assert(platform_setenv("AIMEE_HOME", "") == 0); /* clear override */
+   printf("session_isolation guard (Layer 2) OK\n");
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -1844,6 +1893,7 @@ int main(void)
    test_tool_write_file();
    test_tool_edit_file();
    test_parent_write_guard_blocks_parent_writes();
+   test_session_isolation_guard();
    test_parent_write_guard_readonly_pipeline();
    test_parent_write_guard_allows_mkdir_in_delegate_worktree();
    test_parent_write_guard_allows_workspace_file_ops();

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -166,6 +166,105 @@ static void test_guard_enforcement(void)
    printf("enforcement OK\n");
 }
 
+/* Pure decision tests for the session-isolation guard. */
+static void test_session_isolation_decision(void)
+{
+   const char *wt = "/home/u/repo/.aimee/worktrees/ab12/main/src/x.c";
+   const char *primary = "/home/u/repo/src/x.c";
+   const char *wt_cwd = "/home/u/repo/.aimee/worktrees/ab12/main";
+   const char *primary_cwd = "/home/u/repo";
+
+   /* Read/raw-scan ops are never blocked, regardless of location. */
+   assert(attn_session_isolation_blocked(ATTN_OP_READ, primary, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_RAW_SCAN, primary, primary_cwd) == 0);
+
+   /* Mutating op with an absolute target inside a managed worktree -> allowed. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, wt, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, wt, primary_cwd) == 0);
+
+   /* Mutating op with an absolute target in the primary checkout -> BLOCKED,
+    * even if cwd happens to be a worktree (escaping the worktree). */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, primary, primary_cwd) == 1);
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, primary, wt_cwd) == 1);
+
+   /* Relative / no file_path -> cwd is authoritative. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", wt_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", primary_cwd) == 1);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, wt_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, primary_cwd) == 1);
+
+   /* The loose "/.aimee-" prefix is NOT treated as a managed worktree (only the
+    * canonical "/.aimee/worktrees/" counts) — avoids false-matching e.g. a
+    * user's "/.aimee-notes" dir. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/tmp/.aimee-xyz/src/x.c", primary_cwd) ==
+          1);
+
+   /* Path-traversal escape OUT of a worktree is blocked (lexically normalized). */
+   assert(attn_session_isolation_blocked(
+              ATTN_OP_SOFT, "/repo/.aimee/worktrees/x/main/../../../src/y.c", primary_cwd) == 1);
+   /* '..' that stays WITHIN the worktree is still allowed. */
+   assert(attn_session_isolation_blocked(
+              ATTN_OP_SOFT, "/repo/.aimee/worktrees/x/main/sub/../file.c", primary_cwd) == 0);
+   /* A relative target whose '..' climbs out of a worktree cwd is blocked. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "../../../etc/x", wt_cwd) == 1);
+
+   /* Fail-closed when both target and cwd are unknown. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, NULL, NULL) == 1);
+   printf("isolation decision OK\n");
+}
+
+/* Functional test: the require_session_worktree gate. The handler uses the real
+ * process cwd (the build dir — not a managed worktree), so an Edit with an
+ * absolute file_path drives the decision deterministically. */
+static void test_isolation_enforcement(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee_iso_test_%d", (int)getpid());
+   mkdir(g_home, 0700);
+   char cfgpath[400];
+   snprintf(cfgpath, sizeof(cfgpath), "%s/aimee.yaml", g_home);
+
+#define EDIT_PRIMARY_HOOK                                                                          \
+   "{\"session_id\":\"isotest\",\"tool_name\":\"Edit\","                                           \
+   "\"tool_input\":{\"file_path\":\"/home/u/repo/src/x.c\"}}"
+#define EDIT_WORKTREE_HOOK                                                                         \
+   "{\"session_id\":\"isotest\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":"             \
+   "\"/home/u/repo/.aimee/worktrees/ab/main/src/x.c\"}}"
+#define READ_PRIMARY_HOOK                                                                          \
+   "{\"session_id\":\"isotest\",\"tool_name\":\"Read\","                                           \
+   "\"tool_input\":{\"file_path\":\"/home/u/repo/src/x.c\"}}"
+
+   /* (1) Inert by default: no config -> mutating op on the primary checkout allowed. */
+   rm_path(cfgpath);
+   g_stdin_json = EDIT_PRIMARY_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (2) Explicit false also disabled. */
+   write_config("require_session_worktree: false\n");
+   assert(handle_attention_guard() == 0);
+
+   /* (3) Enabled: an Edit on the primary checkout is BLOCKED. */
+   write_config("require_session_worktree: true\n");
+   assert(handle_attention_guard() == 2);
+
+   /* (4) Enabled: an Edit whose target is inside a managed worktree is allowed. */
+   g_stdin_json = EDIT_WORKTREE_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (5) Enabled: a Read on the primary checkout is allowed (non-mutating). */
+   g_stdin_json = READ_PRIMARY_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (6) AIMEE_GUARD=0 bypasses even a blockable mutating op. */
+   setenv("AIMEE_GUARD", "0", 1);
+   g_stdin_json = EDIT_PRIMARY_HOOK;
+   assert(handle_attention_guard() == 0);
+   unsetenv("AIMEE_GUARD");
+
+   rm_path(cfgpath);
+   g_stdin_json = NULL;
+   printf("isolation enforcement OK\n");
+}
+
 int main(void)
 {
    printf("attention_guard: ");
@@ -173,6 +272,8 @@ int main(void)
    test_weight();
    test_score();
    test_guard_enforcement();
+   test_session_isolation_decision();
+   test_isolation_enforcement();
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Why
The per-session worktree+branch isolation was enforced **only** by a client `SessionStart` hook invoking `aimee session-start` (which pulls the default branch and provisions a per-session worktree). When that hook is missing from a client's settings — as happened recently — `session-start` never runs, and a session silently inherits and mutates the **stale primary checkout** on whatever branch it happens to be on. There was no aimee-level fallback.

This makes the guarantee enforceable at the aimee level, independent of whether a client wired the hook.

## What
New **opt-in** config flag `require_session_worktree` (default **off**, mirroring `ingress_max_raw_scans`). When enabled, mutating ops must occur inside an aimee-managed worktree (path component `/.aimee/worktrees/...`):

- **Layer 1 — client PreToolUse attention-guard** (`cli_attention_guard.c`): fails closed (exit 2) on a mutating op (Edit/Write/MultiEdit/rm/truncate/…) whose target is outside a managed worktree. Decision is the pure, tested `attn_session_isolation_blocked(op, file_path, cwd)`; the effective target (file_path resolved against cwd when relative) is **lexically normalized** first, so a `…/.aimee/worktrees/x/../../src` escape is still blocked.
- **Layer 2 — server-side agent write chokepoint** (`agent_tools.c` + `agent_tools_dispatch.c`): `agent_tools_session_isolation_blocks` blocks aimee's own agent/delegate `write_file`/`edit_file` under the same rule, wired alongside the existing parent-write guard.

Both layers match **only** the canonical `/.aimee/worktrees/` marker (not the looser `/.aimee-` prefix `is_aimee_worktree_path` accepts, which would false-match unrelated dirs). Both are **no-ops when the flag is off**, so default behavior is unchanged; `AIMEE_GUARD=0` still bypasses Layer 1.

## Tests
- Layer 1 (`test_attention_guard.c`): pure decision (no-`response.created`… er, no-`created` n/a; worktree/primary/relative/NULL, traversal-escape blocked, within-worktree `..` allowed) + functional gate (default-off, explicit-false, enabled block/allow, Read allowed, `AIMEE_GUARD=0` bypass).
- Layer 2 (`test_agent.c`): config-driven (default-off, explicit-false, enabled block/allow, traversal-escape, relative-vs-cwd, NULL).

All build clean (`-Werror`), full server links, `unit-test-attention-guard` / `unit-test-agent` / `unit-test-config` / schema-sync pass. Reviewed via the aimee roundtable (converged, APPROVE).

## Follow-up (non-blocking)
The guard recognizes aimee-managed worktrees specifically; manually-created `git worktree`s outside `.aimee/worktrees/` are treated as non-isolated by design (use `aimee session-start` or the bypass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)