### PR TITLE
Merge testing → main: OpenAI response.created fix + session-isolation guard

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (109)
+## CLI-settable keys (110)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -130,11 +130,14 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
+| `require_session_worktree` | bool | — |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
+
+> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `require_session_worktree`
 
 ## Config-file sections (49)
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -130,14 +130,12 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `openai_model` | string | OpenAI model name. |
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
-| `require_session_worktree` | bool | — |
+| `require_session_worktree` | bool | Fail closed on mutating ops outside an aimee-managed worktree (session-isolation guard; default off). |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |
 | `verify_enabled` | bool | Master gate for `aimee git verify` (default off). |
 | `virtual_context_assembly_budget` | int | Token budget for virtual-context assembly. |
 | `virtual_context_enabled` | bool | Enable virtual-context assembly. |
-
-> **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `require_session_worktree`
 
 ## Config-file sections (49)
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -142,6 +142,8 @@ CFG_KEY_DESC = {
     "identity_working_profile_injection_enabled": "Inject the working-profile identity into prompts.",
     "ingress_audit_async": "Audit ingress requests asynchronously.",
     "ingress_max_raw_scans": "Max raw-content scans per ingress request.",
+    "require_session_worktree": "Fail closed on mutating ops outside an aimee-managed worktree "
+    "(session-isolation guard; default off).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress.",
     "ingress_trusted_proxy_secret": "Shared secret authenticating a trusted ingress proxy.",

--- a/src/cli_attention_guard.c
+++ b/src/cli_attention_guard.c
@@ -25,7 +25,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h> /* strncasecmp */
 #include <time.h>
+#include <unistd.h> /* getcwd */
 
 double attn_score(const attn_record_t *recs, int n, const char *path, long now_ts)
 {
@@ -405,6 +407,192 @@ static int attn_config_ingress_max_raw_scans(void)
    return value;
 }
 
+/* Parse a boolean `require_session_worktree:` line from an aimee.yaml buffer.
+ * Accepts true/1/yes/on (case-insensitive) as true; anything else (incl. a
+ * missing key) is false. Mirrors attn_parse_ingress_max_raw_scans' lean,
+ * link-free YAML-line scan so the guard need not pull in the full config. */
+static int attn_parse_require_session_worktree(const char *buf, int *out)
+{
+   if (!buf || !out)
+      return 0;
+
+   const char *line = buf;
+   while (*line)
+   {
+      const char *p = line;
+      while (*p == ' ' || *p == '\t')
+         p++;
+
+      if (*p && *p != '#')
+      {
+         char quote = 0;
+         if (*p == '"' || *p == '\'')
+            quote = *p++;
+
+         size_t key_len = strlen("require_session_worktree");
+         if (strncmp(p, "require_session_worktree", key_len) == 0)
+         {
+            p += key_len;
+            if (quote)
+            {
+               if (*p != quote)
+                  goto next_line;
+               p++;
+            }
+            while (*p && isspace((unsigned char)*p))
+               p++;
+            if (*p == ':' || *p == '=')
+            {
+               p++;
+               while (*p && (isspace((unsigned char)*p) || *p == '"' || *p == '\''))
+                  p++;
+               *out = (strncasecmp(p, "true", 4) == 0 || strncasecmp(p, "yes", 3) == 0 ||
+                       strncasecmp(p, "on", 2) == 0 || *p == '1');
+               return 1;
+            }
+         }
+      }
+
+   next_line:
+      while (*line && *line != '\n')
+         line++;
+      if (*line == '\n')
+         line++;
+   }
+
+   return 0;
+}
+
+static int attn_config_require_session_worktree(void)
+{
+   const char *home = aimee_home();
+   if (!home || !home[0])
+      return 0;
+
+   char path[1024];
+   snprintf(path, sizeof(path), "%s/aimee.yaml", home);
+
+   char *buf = NULL;
+   if (!attn_read_file(path, &buf))
+      return 0;
+
+   int value = 0;
+   if (!attn_parse_require_session_worktree(buf, &value))
+      value = 0;
+   free(buf);
+   return value;
+}
+
+/* Lexically resolve '.', '..' and '//' in `path` into `out` (purely textual —
+ * the write target may not exist yet, so realpath() is unusable; symlinks are
+ * not followed). Closes the `.aimee/worktrees/../escape` traversal bypass: a
+ * component sequence like ".../worktrees/x/../../src" collapses so the marker
+ * substring no longer survives for an escaped path. A leading '/' is preserved;
+ * '..' that would rise above the root is dropped (cannot escape '/'). */
+static void attn_lexical_normalize(const char *path, char *out, size_t out_n)
+{
+   if (!out || out_n == 0)
+      return;
+   out[0] = '\0';
+   if (!path || !path[0])
+      return;
+
+   int absolute = (path[0] == '/');
+   /* Component start offsets within `out` form a simple stack. 256 components is
+    * far beyond any real path; if exceeded, recording simply stops (a later '..'
+    * may pop to a stale offset, yielding a shorter path) — this only ever drops
+    * the worktree marker, i.e. fails closed (blocks), never opens a bypass. */
+   size_t starts[256];
+   int depth = 0;
+   size_t len = 0;
+   if (absolute && len + 1 < out_n)
+      out[len++] = '/';
+
+   const char *p = path;
+   while (*p)
+   {
+      while (*p == '/')
+         p++;
+      if (!*p)
+         break;
+      const char *seg = p;
+      while (*p && *p != '/')
+         p++;
+      size_t seglen = (size_t)(p - seg);
+
+      if (seglen == 1 && seg[0] == '.')
+         continue; /* current dir: skip */
+      if (seglen == 2 && seg[0] == '.' && seg[1] == '.')
+      {
+         if (depth > 0)
+         {
+            depth--;
+            len = starts[depth]; /* pop last component (and its '/') */
+            if (len > 0 && out[len - 1] == '/' && !(absolute && len == 1))
+               len--;
+            out[len] = '\0';
+         }
+         /* else: '..' at/above root is dropped (absolute) or kept-as-root */
+         continue;
+      }
+
+      /* Push a separator before this component when one is needed. */
+      if (len > 0 && out[len - 1] != '/')
+      {
+         if (len + 1 >= out_n)
+            break;
+         out[len++] = '/';
+      }
+      if (depth < (int)(sizeof(starts) / sizeof(starts[0])))
+         starts[depth++] = len;
+      if (len + seglen >= out_n)
+         break;
+      memcpy(out + len, seg, seglen);
+      len += seglen;
+      out[len] = '\0';
+   }
+   if (len == 0 && out_n > 0)
+   {
+      out[0] = absolute ? '/' : '.';
+      out[1] = '\0';
+   }
+}
+
+/* Returns 1 iff `norm` (an already lexically-normalized path) is inside an
+ * aimee-managed worktree. Matches ONLY the canonical managed location
+ * "/.aimee/worktrees/" — deliberately NOT the looser "/.aimee-" prefix that
+ * is_aimee_worktree_path() also accepts, which would false-match unrelated
+ * dirs like "/home/u/.aimee-notes/...". */
+static int attn_path_in_managed_worktree(const char *norm)
+{
+   return norm && strstr(norm, "/.aimee/worktrees/") != NULL;
+}
+
+/* Pure decision for the session-isolation guard (testable in isolation).
+ * Returns 1 to BLOCK: a mutating op (SOFT/HARD) whose effective target is NOT
+ * inside an aimee-managed worktree. Read / raw-scan ops are never blocked here.
+ * The effective target is `file_path` when given (resolved against `cwd` when
+ * relative), else `cwd` itself (a Bash mutation runs there). The joined path is
+ * lexically normalized before the worktree check so a "../" escape out of the
+ * worktree is blocked even though the raw string still contained the marker. */
+int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const char *cwd)
+{
+   if (op != ATTN_OP_SOFT && op != ATTN_OP_HARD)
+      return 0;
+
+   char joined[2048];
+   if (file_path && file_path[0] == '/')
+      snprintf(joined, sizeof(joined), "%s", file_path);
+   else if (file_path && file_path[0])
+      snprintf(joined, sizeof(joined), "%s/%s", cwd ? cwd : "", file_path);
+   else
+      snprintf(joined, sizeof(joined), "%s", cwd ? cwd : "");
+
+   char norm[2048];
+   attn_lexical_normalize(joined, norm, sizeof(norm));
+   return attn_path_in_managed_worktree(norm) ? 0 : 1;
+}
+
 int handle_attention_guard(void)
 {
    const char *bypass = getenv("AIMEE_GUARD");
@@ -427,6 +615,34 @@ int handle_attention_guard(void)
 
    long now_ts = (long)time(NULL);
    attn_op_t op = attn_classify(tool, bash_cmd);
+
+   /* Session-isolation guard (OPT-IN via require_session_worktree). Fails closed
+    * on a mutating op outside an aimee-managed worktree, so a session that never
+    * ran `session-start` (e.g. a missing SessionStart hook) cannot mutate the
+    * primary checkout / default branch. This is the aimee-level backstop for the
+    * worktree+branch isolation that the SessionStart hook would otherwise set up. */
+   if ((op == ATTN_OP_SOFT || op == ATTN_OP_HARD) && attn_config_require_session_worktree())
+   {
+      char cwd[1024];
+      if (!getcwd(cwd, sizeof(cwd)))
+         cwd[0] = '\0';
+      const char *fp =
+          ti ? cJSON_GetStringValue(cJSON_GetObjectItemCaseSensitive(ti, "file_path")) : NULL;
+      if (attn_session_isolation_blocked(op, fp, cwd))
+      {
+         fprintf(stderr,
+                 "aimee attention-guard: refusing a mutating op outside an aimee session "
+                 "worktree. This session is operating in '%s', which is not an aimee-managed "
+                 "worktree (.aimee/worktrees/...). aimee requires each mutating session to run "
+                 "in an isolated worktree+branch off the default branch; provision one with "
+                 "`aimee session-start` (or restart the client so its SessionStart hook does). "
+                 "Set require_session_worktree:false in aimee.yaml or AIMEE_GUARD=0 to bypass.\n",
+                 cwd[0] ? cwd : "(unknown cwd)");
+         cJSON_Delete(hook);
+         free(stdin_data);
+         return 2;
+      }
+   }
 
    char path[1024];
    attn_log_path(sid, path, sizeof(path));

--- a/src/config.c
+++ b/src/config.c
@@ -508,6 +508,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->integrity_dry_run = 1;
    cfg->ingress_preinject_assembly_budget = 6144;
    cfg->ingress_max_raw_scans = 0;
+   cfg->require_session_worktree = 0;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
     * tool-heavy session fixtures. Rollback: set session.virtual_context.enabled
@@ -864,6 +865,10 @@ int config_load(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_max_raw_scans");
    if (cJSON_IsNumber(item) && item->valuedouble >= 0)
       cfg->ingress_max_raw_scans = (int)item->valuedouble;
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "require_session_worktree");
+   if (cJSON_IsBool(item))
+      cfg->require_session_worktree = cJSON_IsTrue(item);
 
    item = cJSON_GetObjectItemCaseSensitive(root, "typed_facts_enabled");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -47,6 +47,8 @@ const config_field_t config_fields[] = {
     {"ingress_preinject_assembly_budget", offsetof(config_t, ingress_preinject_assembly_budget),
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},
+    {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
+     CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},
     {"css_style_graph_enabled", offsetof(config_t, css_style_graph_enabled), sizeof(int), 0,
      CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -782,6 +782,8 @@ int config_save(const config_t *cfg)
                               cfg->ingress_preinject_assembly_budget);
    if (cfg->ingress_max_raw_scans != 0)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
+   if (cfg->require_session_worktree)
+      cJSON_AddBoolToObject(root, "require_session_worktree", 1);
    if (cfg->typed_facts_enabled)
       cJSON_AddBoolToObject(root, "typed_facts_enabled", 1);
    if (!cfg->css_style_graph_enabled) /* default-on: persist only the opt-out */

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -15,6 +15,7 @@
 {"typed_facts_enabled", SCHEMA_BOOL, 0},
 {"ingress_preinject_assembly_budget", SCHEMA_INT, 0},
 {"ingress_max_raw_scans", SCHEMA_INT, 0},
+{"require_session_worktree", SCHEMA_BOOL, 0},
 {"guardrails", SCHEMA_OBJECT, 0},
 {"toolsets", SCHEMA_OBJECT, 0},
 {"script", SCHEMA_OBJECT, 0},

--- a/src/headers/agent_tools.h
+++ b/src/headers/agent_tools.h
@@ -91,4 +91,11 @@ const char *agent_tools_parent_write_guard_root(void);
 const char *agent_tools_parent_write_guard_write_root(void);
 int agent_tools_parent_write_guard_blocks(const char *path, const char *cwd);
 
+/* Session-isolation backstop (Layer 2, opt-in via require_session_worktree):
+ * returns 1 to BLOCK a server-side agent write whose normalized target is not
+ * inside an aimee-managed worktree, else 0. No-op (returns 0) unless the
+ * require_session_worktree config flag is enabled. Mirrors the client-side
+ * attention-guard isolation policy for aimee's own in-process agent writes. */
+int agent_tools_session_isolation_blocks(const char *path, const char *cwd);
+
 #endif /* DEC_AGENT_TOOLS_H */

--- a/src/headers/cli_attention_guard.h
+++ b/src/headers/cli_attention_guard.h
@@ -56,6 +56,14 @@ int attn_is_raw_scan(const char *tool_name, const char *bash_cmd);
 /* The attention weight to record for a tool call of the given class. Pure. */
 int attn_weight_for(attn_op_t op);
 
+/* Session-isolation decision (pure, testable). Returns 1 to BLOCK a mutating op
+ * (ATTN_OP_SOFT/HARD) whose effective target is NOT inside an aimee-managed
+ * worktree, else 0. The effective target is the absolute `file_path` when given
+ * (Edit/Write), otherwise `cwd` (a relative file_path resolves under cwd; a Bash
+ * mutation runs there). Read/raw-scan ops are never blocked. Used by
+ * handle_attention_guard only when require_session_worktree is enabled. */
+int attn_session_isolation_blocked(attn_op_t op, const char *file_path, const char *cwd);
+
 /* `aimee attention-guard` PreToolUse-hook entry. Reads the host hook JSON from
  * stdin, updates the per-session attention log, and returns the hook exit code
  * (2 = block a hard-destructive op on a high-attention file, or — only when a

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -337,6 +337,11 @@ typedef struct config
    int ingress_preinject_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
+   /* Session-isolation guard (opt-in): when on, the PreToolUse attention-guard
+    * fails closed on a mutating tool whose target is NOT inside an aimee-managed
+    * worktree (.aimee/worktrees/...), forcing every mutating session into an
+    * isolated worktree+branch off the default branch. Default 0 (off). */
+   int require_session_worktree;
 
    /* Gateway tool-policing (P2): when on, the gateway strips subagent-spawning
     * tools (Task/Agent/spawn_agent/RemoteTrigger) from the inbound `tools` of a

--- a/src/headers/openai_shape.h
+++ b/src/headers/openai_shape.h
@@ -222,41 +222,42 @@ extern "C"
     * resp[cap]. Returns bytes written, or -1. */
    int openai_format_error(char *resp, int cap, const char *type, const char *message);
 
-   /* P2c (response-side tool policing, OpenAI streaming): emit the
-    * `response.*` SSE event sequence for a parsed_response_t that carries
-    * `calls[]` (the post-police shape — calls[] may be empty if every
-    * entry was a denied subagent). The wire shape mirrors the existing
-    * tool-call emit loop in responses_stream_handler; this helper
-    * exists for unit-testability (test_openai_chat_policed.c).
-    * - Always emits `response.created` first.
+   /* P2c (response-side tool policing, OpenAI streaming): emit the tool-call
+    * tail of the `response.*` SSE sequence for a parsed_response_t that carries
+    * `calls[]` (the post-police shape — calls[] may be empty if every entry was
+    * a denied subagent). The wire shape mirrors the existing tool-call emit loop
+    * in responses_stream_handler; this helper exists for unit-testability
+    * (test_openai_chat_policed.c).
+    *
+    * Caller contract: the caller MUST emit the leading `response.created`
+    * envelope event exactly once before invoking this helper (every path —
+    * text, tool-call, error — shares that single emit). This helper does NOT
+    * emit `response.created`, so the tool-call path never doubles it on the wire.
     * - If parsed->call_count > 0: emits per-call frames for each surviving
     *   call (output_item.added, function_call_arguments.delta/.done,
-    *   output_item.done), then response.completed with all calls in
-    *   output[].
+    *   output_item.done), then response.completed with all calls in output[].
     * - If parsed->call_count == 0 (the P2c all-dropped case), OR parsed is
-    *   NULL: emits response.created + response.completed with empty output[]
-    *   (a NULL parsed is treated as zero calls / zero usage, never dereferenced).
+    *   NULL: emits a single response.completed with empty output[] (a NULL
+    *   parsed is treated as zero calls / zero usage, never dereferenced).
     *
     * Ownership / lifetime:
     * - The function borrows everything; it takes ownership of nothing and frees
     *   nothing of the caller's. `parsed`, `id`, `model`, and the `ctx` behind
     *   `emit` need only outlive the call (synchronous — `emit` is invoked only
     *   before this function returns; neither `emit` nor `ctx` is retained).
-    * - `frame` / `frame_cap` are caller-owned scratch used only for the
-    *   `response.created` frame; pass a buffer of at least 1024 bytes. That
-    *   frame holds only id + model + a fixed JSON envelope (no tool args), so
-    *   it is bounded by the id/model lengths; 1024 covers the current ids and
-    *   model aliases with wide margin (callers today pass 2048). If
-    *   openai_format_responses_created reports it does not fit, the created
-    *   frame is skipped. Per-call and `response.completed` frames use scratch
-    *   the function mallocs (sized to the args) and frees internally.
+    * - A NULL `emit` is tolerated (the helper returns without emitting) — a guard
+    *   for the public/test surface; the production caller (responses_stream_handler)
+    *   always passes a real emit and has already emitted `response.created`
+    *   through it before calling, so a NULL there is a non-starter. Per-call and
+    *   `response.completed` frames use scratch the function mallocs (sized to the
+    *   id/model/args) and frees internally — no caller scratch is needed.
     * - Emit failures are not the helper's concern: `emit` returns void and the
     *   helper does not roll back or resume a partially-emitted sequence. A
     *   transport that can fail mid-stream must detect it inside `emit`/`ctx`;
     *   the helper always walks the full sequence. */
    void openai_responses_emit_policed(const parsed_response_t *parsed, const char *id,
                                       const char *model, long created, openai_sse_emit_fn emit,
-                                      void *ctx, char *frame, size_t frame_cap);
+                                      void *ctx);
 
 #ifdef __cplusplus
 }

--- a/src/posix/agent_tools_dispatch.c
+++ b/src/posix/agent_tools_dispatch.c
@@ -424,6 +424,11 @@ static char *td_edit_file(cJSON *args, const char *name, const char *dispatch_cw
       {
          result = safe_strdup("error: write blocked: parent worktree is read-only for delegates");
       }
+      else if (agent_tools_session_isolation_blocks(p->valuestring, dispatch_cwd))
+      {
+         result = safe_strdup("error: write blocked: require_session_worktree is enabled and this "
+                              "target is outside an aimee-managed worktree (.aimee/worktrees/...)");
+      }
       else
       {
          /* Auto-snapshot: record pre-edit state in the persistent rewind DB */
@@ -457,6 +462,11 @@ static char *td_write_file(cJSON *args, const char *name, const char *dispatch_c
       if (agent_tools_parent_write_guard_blocks(p->valuestring, dispatch_cwd))
       {
          result = safe_strdup("error: write blocked: parent worktree is read-only for delegates");
+      }
+      else if (agent_tools_session_isolation_blocks(p->valuestring, dispatch_cwd))
+      {
+         result = safe_strdup("error: write blocked: require_session_worktree is enabled and this "
+                              "target is outside an aimee-managed worktree (.aimee/worktrees/...)");
       }
       else
       {

--- a/src/server/agent_tools.c
+++ b/src/server/agent_tools.c
@@ -129,6 +129,35 @@ int agent_tools_parent_write_guard_blocks(const char *path, const char *cwd)
    return agent_tools_path_under_root(norm, g_parent_ro_root);
 }
 
+/* Session-isolation backstop (Layer 2, opt-in via require_session_worktree).
+ * Blocks a server-side agent/delegate write whose normalized target is NOT
+ * inside an aimee-managed worktree (path component .aimee/worktrees/...). This
+ * mirrors the client-side attention-guard
+ * (Layer 1) so aimee's own in-process agent writes obey the same isolation
+ * policy that a thin client's PreToolUse hook enforces — covering the case
+ * where session-start never provisioned a worktree. Default off (the config
+ * flag defaults to 0), so this is a no-op unless explicitly enabled. */
+int agent_tools_session_isolation_blocks(const char *path, const char *cwd)
+{
+   if (!path || !path[0])
+      return 0;
+   /* config_load here mirrors the per-call pattern already used elsewhere in
+    * this file (it is cheap and reads the cached config). Default-off: when the
+    * flag is unset — or the config is unreadable, which leaves the default 0 —
+    * this is a no-op, matching the feature's opt-in nature. */
+   config_t cfg;
+   config_load(&cfg);
+   if (!cfg.require_session_worktree)
+      return 0;
+   /* normalize_path resolves '.'/'..'/relative against cwd, closing traversal
+    * escapes. Match ONLY the canonical managed-worktree location (not the
+    * looser "/.aimee-" prefix is_aimee_worktree_path() accepts), consistent
+    * with the client-side attn_session_isolation_blocked check. */
+   char norm[MAX_PATH_LEN];
+   normalize_path(path, cwd, norm, sizeof(norm));
+   return strstr(norm, "/.aimee/worktrees/") != NULL ? 0 : 1;
+}
+
 static int tools_array_has_name(cJSON *tools, const char *name, int openai_format)
 {
    cJSON *tool = NULL;

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -1052,6 +1052,13 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
    int erc =
        agent_execute_messages(ag, messages, tools, instructions, max_tokens, temperature, &parsed);
 
+   /* `response.created` is the per-response envelope event: emitted exactly
+    * once here for EVERY downstream path (error -> response.failed, text turn,
+    * and the tool-call branch). openai_responses_emit_policed() deliberately
+    * does NOT re-emit it, so the tool-call path never doubles it on the wire.
+    * `frame` is 2048 bytes and this event holds only the minted id (~30 chars)
+    * + model alias + a fixed JSON envelope, so it cannot truncate in practice;
+    * the `> 0` check is belt-and-suspenders, not a real partial-stream path. */
    if (openai_format_responses_created(id, model, created, frame, sizeof(frame)) > 0)
       emit(ctx, "response.created", frame);
 
@@ -1106,7 +1113,7 @@ static int responses_stream_handler(const char *body, server_http_sse_event_emit
                              for the future P2b audit pass; today the only
                              visible effect is the parsed.calls[] mutation. */
 
-      openai_responses_emit_policed(&parsed, id, model, created, emit, ctx, frame, sizeof(frame));
+      openai_responses_emit_policed(&parsed, id, model, created, emit, ctx);
    }
    else
 

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -1373,20 +1373,25 @@ int openai_format_error(char *resp, int cap, const char *type, const char *messa
    return (len < 0 || len >= cap) ? -1 : len;
 }
 
-/* Emit the OpenAI /v1/responses SSE event sequence for a parsed_response_t
+/* Emit the OpenAI /v1/responses tool-call SSE tail for a parsed_response_t
  * that carries `calls[]`. Extracted from the inline emit loop in
  * responses_stream_handler so it is unit-testable in isolation
  * (test_openai_chat_policed.c) without stubbing the entire
  * agent_execute_messages pipeline.
  *
+ * The caller emits the leading `response.created` envelope event exactly once
+ * for EVERY path (error / text / tool-call); this helper emits ONLY the
+ * tool-call tail and must NOT re-emit `response.created`, otherwise the
+ * tool-call path would double it on the wire (an OpenAI/Codex protocol
+ * violation).
+ *
  * Behavior:
- *   - Always emits `response.created` first.
  *   - If parsed.call_count > 0: emits one set of per-call frames
  *     (output_item.added, function_call_arguments.delta, .done,
  *     output_item.done) per surviving call, then `response.completed`
  *     with all calls in `output[]`.
- *   - If parsed.call_count == 0 (P2c all-dropped case): emits
- *     `response.created` + `response.completed` with empty `output[]`.
+ *   - If parsed.call_count == 0 (P2c all-dropped case) or parsed is NULL:
+ *     emits a single `response.completed` with empty `output[]`.
  *
  * The wire shape is what the upstream OpenAI responses backend
  * emits for a tool-call reply; the policed-shape is identical
@@ -1395,13 +1400,12 @@ int openai_format_error(char *resp, int cap, const char *type, const char *messa
  */
 void openai_responses_emit_policed(const parsed_response_t *parsed, const char *id,
                                    const char *model, long created, openai_sse_emit_fn emit,
-                                   void *ctx, char *frame, size_t frame_cap)
+                                   void *ctx)
 {
    int n = parsed ? parsed->call_count : 0;
 
-   /* response.created (always first). */
-   if (openai_format_responses_created(id, model, created, frame, frame_cap) > 0)
-      emit(ctx, "response.created", frame);
+   if (!emit)
+      return; /* fail closed: no transport to emit on */
 
    if (n > 0)
    {
@@ -1442,9 +1446,13 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
                 output, openai_responses_function_call_item(fc_id, cid, name, args, "completed"));
       }
 
-      size_t ccap = 4096;
+      /* ccap: 4096 base (envelope/usage) + id/model, plus per call: args worst-
+       * case JSON-escaped (×6 — a byte can expand to \uXXXX) + name + call_id +
+       * 256 slack for that item's JSON keys/braces/commas/status/fc_id suffix. */
+      size_t ccap = 4096 + strlen(id ? id : "") + strlen(model ? model : "");
       for (int i = 0; i < n; i++)
-         ccap += (parsed->calls[i].arguments ? strlen(parsed->calls[i].arguments) : 0) * 6 + 256;
+         ccap += (parsed->calls[i].arguments ? strlen(parsed->calls[i].arguments) : 0) * 6 +
+                 strlen(parsed->calls[i].name) + strlen(parsed->calls[i].id) + 256;
       char *cf = malloc(ccap);
       if (cf)
       {
@@ -1465,7 +1473,7 @@ void openai_responses_emit_policed(const parsed_response_t *parsed, const char *
       cJSON *empty_output = cJSON_CreateArray();
       int pt = parsed ? parsed->prompt_tokens : 0;
       int ct = parsed ? parsed->completion_tokens : 0;
-      size_t ccap = 4096;
+      size_t ccap = 4096 + strlen(id ? id : "") + strlen(model ? model : "");
       char *cf = malloc(ccap);
       if (cf)
       {

--- a/src/tests/test_agent.c
+++ b/src/tests/test_agent.c
@@ -1805,6 +1805,55 @@ static void test_agent_name_valid(void)
        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")); /* 63 */
 }
 
+/* Layer 2 of the session-isolation guard: the server-side write chokepoint
+ * agent_tools_session_isolation_blocks. Default-off, and when on blocks writes
+ * whose normalized target is outside an aimee-managed worktree. */
+static void test_session_isolation_guard(void)
+{
+   char home[512];
+   snprintf(home, sizeof(home), "%s/aimee_sess_iso_XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(home) != NULL);
+   char cfg[640];
+   snprintf(cfg, sizeof(cfg), "%s/aimee.yaml", home);
+   assert(platform_setenv("AIMEE_HOME", home) == 0);
+
+   const char *primary = "/some/repo/src/x.c";
+   const char *worktree = "/some/repo/.aimee/worktrees/ab12/main/src/x.c";
+
+   /* (1) Default off (no aimee.yaml): never blocks, even on the primary checkout. */
+   remove(cfg);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 0);
+
+   /* (2) Explicit false: still no block. */
+   FILE *f = fopen(cfg, "w");
+   assert(f != NULL);
+   fputs("require_session_worktree: false\n", f);
+   fclose(f);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 0);
+
+   /* (3) Enabled: primary-checkout target blocked, managed-worktree target allowed. */
+   f = fopen(cfg, "w");
+   assert(f != NULL);
+   fputs("require_session_worktree: true\n", f);
+   fclose(f);
+   assert(agent_tools_session_isolation_blocks(primary, NULL) == 1);
+   assert(agent_tools_session_isolation_blocks(worktree, NULL) == 0);
+   /* Traversal escape out of the worktree normalizes + blocks. */
+   assert(agent_tools_session_isolation_blocks(
+              "/some/repo/.aimee/worktrees/ab12/main/../../../src/y.c", NULL) == 1);
+   /* Relative path resolved against cwd (normalize_path): a worktree cwd allows,
+    * a primary-checkout cwd blocks. */
+   assert(agent_tools_session_isolation_blocks("src/x.c",
+                                               "/some/repo/.aimee/worktrees/ab12/main") == 0);
+   assert(agent_tools_session_isolation_blocks("src/x.c", "/some/repo") == 1);
+   /* NULL path is a no-op (returns 0). */
+   assert(agent_tools_session_isolation_blocks(NULL, NULL) == 0);
+
+   remove(cfg);
+   assert(platform_setenv("AIMEE_HOME", "") == 0); /* clear override */
+   printf("session_isolation guard (Layer 2) OK\n");
+}
+
 int main(void)
 {
    char tmp_home[512];
@@ -1844,6 +1893,7 @@ int main(void)
    test_tool_write_file();
    test_tool_edit_file();
    test_parent_write_guard_blocks_parent_writes();
+   test_session_isolation_guard();
    test_parent_write_guard_readonly_pipeline();
    test_parent_write_guard_allows_mkdir_in_delegate_worktree();
    test_parent_write_guard_allows_workspace_file_ops();

--- a/src/tests/test_attention_guard.c
+++ b/src/tests/test_attention_guard.c
@@ -166,6 +166,105 @@ static void test_guard_enforcement(void)
    printf("enforcement OK\n");
 }
 
+/* Pure decision tests for the session-isolation guard. */
+static void test_session_isolation_decision(void)
+{
+   const char *wt = "/home/u/repo/.aimee/worktrees/ab12/main/src/x.c";
+   const char *primary = "/home/u/repo/src/x.c";
+   const char *wt_cwd = "/home/u/repo/.aimee/worktrees/ab12/main";
+   const char *primary_cwd = "/home/u/repo";
+
+   /* Read/raw-scan ops are never blocked, regardless of location. */
+   assert(attn_session_isolation_blocked(ATTN_OP_READ, primary, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_RAW_SCAN, primary, primary_cwd) == 0);
+
+   /* Mutating op with an absolute target inside a managed worktree -> allowed. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, wt, primary_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, wt, primary_cwd) == 0);
+
+   /* Mutating op with an absolute target in the primary checkout -> BLOCKED,
+    * even if cwd happens to be a worktree (escaping the worktree). */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, primary, primary_cwd) == 1);
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, primary, wt_cwd) == 1);
+
+   /* Relative / no file_path -> cwd is authoritative. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", wt_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "src/x.c", primary_cwd) == 1);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, wt_cwd) == 0);
+   assert(attn_session_isolation_blocked(ATTN_OP_HARD, NULL, primary_cwd) == 1);
+
+   /* The loose "/.aimee-" prefix is NOT treated as a managed worktree (only the
+    * canonical "/.aimee/worktrees/" counts) — avoids false-matching e.g. a
+    * user's "/.aimee-notes" dir. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "/tmp/.aimee-xyz/src/x.c", primary_cwd) ==
+          1);
+
+   /* Path-traversal escape OUT of a worktree is blocked (lexically normalized). */
+   assert(attn_session_isolation_blocked(
+              ATTN_OP_SOFT, "/repo/.aimee/worktrees/x/main/../../../src/y.c", primary_cwd) == 1);
+   /* '..' that stays WITHIN the worktree is still allowed. */
+   assert(attn_session_isolation_blocked(
+              ATTN_OP_SOFT, "/repo/.aimee/worktrees/x/main/sub/../file.c", primary_cwd) == 0);
+   /* A relative target whose '..' climbs out of a worktree cwd is blocked. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, "../../../etc/x", wt_cwd) == 1);
+
+   /* Fail-closed when both target and cwd are unknown. */
+   assert(attn_session_isolation_blocked(ATTN_OP_SOFT, NULL, NULL) == 1);
+   printf("isolation decision OK\n");
+}
+
+/* Functional test: the require_session_worktree gate. The handler uses the real
+ * process cwd (the build dir — not a managed worktree), so an Edit with an
+ * absolute file_path drives the decision deterministically. */
+static void test_isolation_enforcement(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee_iso_test_%d", (int)getpid());
+   mkdir(g_home, 0700);
+   char cfgpath[400];
+   snprintf(cfgpath, sizeof(cfgpath), "%s/aimee.yaml", g_home);
+
+#define EDIT_PRIMARY_HOOK                                                                          \
+   "{\"session_id\":\"isotest\",\"tool_name\":\"Edit\","                                           \
+   "\"tool_input\":{\"file_path\":\"/home/u/repo/src/x.c\"}}"
+#define EDIT_WORKTREE_HOOK                                                                         \
+   "{\"session_id\":\"isotest\",\"tool_name\":\"Edit\",\"tool_input\":{\"file_path\":"             \
+   "\"/home/u/repo/.aimee/worktrees/ab/main/src/x.c\"}}"
+#define READ_PRIMARY_HOOK                                                                          \
+   "{\"session_id\":\"isotest\",\"tool_name\":\"Read\","                                           \
+   "\"tool_input\":{\"file_path\":\"/home/u/repo/src/x.c\"}}"
+
+   /* (1) Inert by default: no config -> mutating op on the primary checkout allowed. */
+   rm_path(cfgpath);
+   g_stdin_json = EDIT_PRIMARY_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (2) Explicit false also disabled. */
+   write_config("require_session_worktree: false\n");
+   assert(handle_attention_guard() == 0);
+
+   /* (3) Enabled: an Edit on the primary checkout is BLOCKED. */
+   write_config("require_session_worktree: true\n");
+   assert(handle_attention_guard() == 2);
+
+   /* (4) Enabled: an Edit whose target is inside a managed worktree is allowed. */
+   g_stdin_json = EDIT_WORKTREE_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (5) Enabled: a Read on the primary checkout is allowed (non-mutating). */
+   g_stdin_json = READ_PRIMARY_HOOK;
+   assert(handle_attention_guard() == 0);
+
+   /* (6) AIMEE_GUARD=0 bypasses even a blockable mutating op. */
+   setenv("AIMEE_GUARD", "0", 1);
+   g_stdin_json = EDIT_PRIMARY_HOOK;
+   assert(handle_attention_guard() == 0);
+   unsetenv("AIMEE_GUARD");
+
+   rm_path(cfgpath);
+   g_stdin_json = NULL;
+   printf("isolation enforcement OK\n");
+}
+
 int main(void)
 {
    printf("attention_guard: ");
@@ -173,6 +272,8 @@ int main(void)
    test_weight();
    test_score();
    test_guard_enforcement();
+   test_session_isolation_decision();
+   test_isolation_enforcement();
    printf("all tests passed\n");
    return 0;
 }

--- a/src/tests/test_openai_chat_policed.c
+++ b/src/tests/test_openai_chat_policed.c
@@ -2,7 +2,18 @@
  * tool-policing OpenAI /v1/responses SSE replay helper
  * (openai_responses_emit_policed). Pure shape tests — no agent
  * execution, no real provider, no streaming transport; just the
- * post-police `parsed_response_t` -> SSE event sequence. */
+ * post-police `parsed_response_t` -> SSE event tail.
+ *
+ * The helper emits ONLY the tool-call tail; the leading
+ * `response.created` envelope event is the caller's responsibility
+ * (emitted once per response for every path). These tests guard that
+ * contract — emitting created here too would double it on the wire.
+ *
+ * Scope: these tests exercise the helper's consumption of an already
+ * post-police parsed_response_t (calls[] front-packed, call_count lowered).
+ * The police function itself (gateway_policy_police_parsed_response) is
+ * tested separately in test_anthropic_http.c; seeding the post-police shape
+ * directly here keeps this test free of the config/guardrails link. */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -10,21 +21,20 @@
 
 #include "openai_shape.h"
 /* aimee.h before agent_protocol.h: agent_types.h (pulled by agent_protocol.h)
- * uses MAX_PATH_LEN from aimee.h. Same include convention as the production
- * caller, src/server/openai_chat.c. openai_shape.h itself stays decoupled and
- * forward-declares the types it needs. */
+ * needs the MAX_PATH_LEN size macro from aimee.h. */
 #include "aimee.h"
 #include "agent_protocol.h"
 #include "cJSON.h"
 
 #define PASS(name) printf("  PASS: %s\n", (name))
 
-/* Captured SSE events. */
-#define REPLAY_CAP 64
+/* Captured SSE events. Sized to the worst case these tests exercise (9
+ * events; payloads well under 2KB) to keep the stack object small. */
+#define REPLAY_CAP 16
 typedef struct
 {
    char events[REPLAY_CAP][64];
-   char data[REPLAY_CAP][4096];
+   char data[REPLAY_CAP][2048];
    int count;
 } cap_t;
 
@@ -66,27 +76,38 @@ static void free_parsed(parsed_response_t *p)
       free(p->calls[i].arguments);
 }
 
-/* --- tests --- */
-
-/* response.created is always emitted first, regardless of call_count. */
-static void test_emit_response_created_first(void)
+/* Defense-in-depth: assert no captured event is `response.created` — the
+ * helper must never emit the envelope on ANY path (the caller owns it). */
+static void assert_no_created(const cap_t *c)
 {
-   cap_t cap = {0};
-   parsed_response_t p;
-   seed_parsed(&p, 0, NULL, NULL, NULL, "end_turn");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   assert(cap.count >= 1);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   /* Sanity: the frame contains our id + the model. */
-   assert(strstr(cap.data[0], "\"id\":\"resp_1\"") != NULL);
-   assert(strstr(cap.data[0], "\"model\":\"claude-test\"") != NULL);
-   free_parsed(&p);
-   PASS("emit_response_created_first");
+   for (int i = 0; i < c->count; i++)
+      assert(strcmp(c->events[i], "response.created") != 0);
 }
 
-/* Single surviving tool_call: per-call frames + completed. */
+/* --- tests --- */
+
+/* Regression guard: the helper must NEVER emit `response.created` — the
+ * caller (responses_stream_handler) already emits it once for every path.
+ * A helper that re-emitted it would double `response.created` on the wire,
+ * which OpenAI/Codex clients treat as a protocol violation. */
+static void test_emit_omits_created_envelope(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"query\":\"aimee\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   assert_no_created(&cap);
+   /* First event is the tool-call item, not the envelope. */
+   assert(cap.count >= 1);
+   assert(strcmp(cap.events[0], "response.output_item.added") == 0);
+   free_parsed(&p);
+   PASS("emit_omits_created_envelope");
+}
+
+/* Single surviving tool_call: per-call frames + completed (no created). */
 static void test_emit_surviving_tool_call(void)
 {
    cap_t cap = {0};
@@ -95,23 +116,20 @@ static void test_emit_surviving_tool_call(void)
    const char *args[] = {"{\"query\":\"aimee\"}"};
    parsed_response_t p;
    seed_parsed(&p, 1, names, ids, args, "tool_calls");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
 
-   /* response.created + (output_item.added, args.delta, args.done,
-    * output_item.done) + response.completed = 6 events. */
-   assert(cap.count == 6);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   assert(strcmp(cap.events[1], "response.output_item.added") == 0);
-   assert(strstr(cap.data[1], "\"name\":\"web_search\"") != NULL);
-   assert(strstr(cap.data[1], "\"call_id\":\"call_1\"") != NULL);
-   assert(strcmp(cap.events[2], "response.function_call_arguments.delta") == 0);
-   assert(strstr(cap.data[2], "aimee") != NULL);
-   assert(strcmp(cap.events[3], "response.function_call_arguments.done") == 0);
-   assert(strcmp(cap.events[4], "response.output_item.done") == 0);
-   assert(strcmp(cap.events[5], "response.completed") == 0);
-   assert(strstr(cap.data[5], "\"output\":[") != NULL);
+   /* (output_item.added, args.delta, args.done, output_item.done)
+    * + response.completed = 5 events. */
+   assert(cap.count == 5);
+   assert(strcmp(cap.events[0], "response.output_item.added") == 0);
+   assert(strstr(cap.data[0], "\"name\":\"web_search\"") != NULL);
+   assert(strstr(cap.data[0], "\"call_id\":\"call_1\"") != NULL);
+   assert(strcmp(cap.events[1], "response.function_call_arguments.delta") == 0);
+   assert(strstr(cap.data[1], "aimee") != NULL);
+   assert(strcmp(cap.events[2], "response.function_call_arguments.done") == 0);
+   assert(strcmp(cap.events[3], "response.output_item.done") == 0);
+   assert(strcmp(cap.events[4], "response.completed") == 0);
+   assert(strstr(cap.data[4], "\"output\":[") != NULL);
    free_parsed(&p);
    PASS("emit_surviving_tool_call");
 }
@@ -125,58 +143,123 @@ static void test_emit_multiple_surviving_tool_calls(void)
    const char *args[] = {"{\"q\":\"x\"}", "{\"p\":\"/etc\"}"};
    parsed_response_t p;
    seed_parsed(&p, 2, names, ids, args, "tool_calls");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
 
-   /* response.created + (4 per-call frames × 2) + response.completed = 10. */
-   assert(cap.count == 10);
-   /* The two `output_item.added` events at indices 1 and 5 carry
+   /* (4 per-call frames × 2) + response.completed = 9. */
+   assert(cap.count == 9);
+   /* The two `output_item.added` events at indices 0 and 4 carry
     * fc_id suffixes "-fc-0" and "-fc-1" (built from the loop index). */
-   assert(strstr(cap.data[1], "-fc-0") != NULL);
-   assert(strstr(cap.data[5], "-fc-1") != NULL);
+   assert(strstr(cap.data[0], "-fc-0") != NULL);
+   assert(strstr(cap.data[4], "-fc-1") != NULL);
    /* Names preserved in original order. */
-   assert(strstr(cap.data[1], "web_search") != NULL);
-   assert(strstr(cap.data[5], "Read") != NULL);
+   assert(strstr(cap.data[0], "web_search") != NULL);
+   assert(strstr(cap.data[4], "Read") != NULL);
+   assert(strcmp(cap.events[8], "response.completed") == 0);
    free_parsed(&p);
    PASS("emit_multiple_surviving_tool_calls");
 }
 
-/* All-dropped (call_count == 0): response.created + empty-output
- * response.completed, no per-call frames. */
+/* All-dropped (non-NULL parsed, call_count == 0): a single empty-output
+ * response.completed, no per-call frames and no created. This is the realistic
+ * post-police state (police mutated calls[] to empty in place) — distinct from
+ * the defensive NULL-parsed case below. */
 static void test_emit_all_dropped_empty_output(void)
 {
    cap_t cap = {0};
    parsed_response_t p;
    seed_parsed(&p, 0, NULL, NULL, NULL, "end_turn");
-   char frame[2048];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
 
-   assert(cap.count == 2);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   assert(strcmp(cap.events[1], "response.completed") == 0);
+   assert(cap.count == 1);
+   assert_no_created(&cap);
+   assert(strcmp(cap.events[0], "response.completed") == 0);
    /* Empty output array — `[]`. */
-   assert(strstr(cap.data[1], "\"output\":[]") != NULL);
+   assert(strstr(cap.data[0], "\"output\":[]") != NULL);
+   /* Usage from parsed is preserved even with no surviving calls. */
+   assert(strstr(cap.data[0], "\"input_tokens\":17") != NULL);
+   assert(strstr(cap.data[0], "\"output_tokens\":23") != NULL);
    free_parsed(&p);
    PASS("emit_all_dropped_empty_output");
 }
 
-/* Null parsed is tolerated (no crash, no events emitted except created
- * with default-0 usage). Guards against a future caller passing a
- * police error result. */
+/* A call whose arguments pointer is NULL falls back to "{}" on the wire
+ * (the `arguments ? arguments : "{}"` guard — arguments is the only
+ * heap pointer; name/id are fixed char arrays and never NULL). */
+static void test_emit_null_arguments_fallback(void)
+{
+   cap_t cap = {0};
+   parsed_response_t p;
+   memset(&p, 0, sizeof(p));
+   p.is_tool_call = 1;
+   p.call_count = 1;
+   snprintf(p.calls[0].id, sizeof(p.calls[0].id), "%s", "call_1");
+   snprintf(p.calls[0].name, sizeof(p.calls[0].name), "%s", "f");
+   p.calls[0].arguments = NULL; /* exercise the fallback */
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   assert(cap.count == 5);
+   /* args.delta (index 1) carries the decoded delta "{}" */
+   cJSON *delta_ev = cJSON_Parse(cap.data[1]);
+   assert(delta_ev != NULL);
+   const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
+   assert(cJSON_IsString(delta) && strcmp(delta->valuestring, "{}") == 0);
+   cJSON_Delete(delta_ev);
+   /* .done (index 2) is a separate format path — verify it also carries "{}". */
+   cJSON *done_ev = cJSON_Parse(cap.data[2]);
+   assert(done_ev != NULL);
+   const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
+   assert(cJSON_IsString(full) && strcmp(full->valuestring, "{}") == 0);
+   cJSON_Delete(done_ev);
+   free_parsed(&p); /* arguments was NULL; free(NULL) is a no-op — kept for convention */
+   PASS("emit_null_arguments_fallback");
+}
+
+/* Metadata propagation: id/model/created must appear verbatim in the
+ * response.completed payload so Codex can correlate the streamed turn. */
+static void test_emit_metadata_propagation(void)
+{
+   cap_t cap = {0};
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"q\":\"x\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   openai_responses_emit_policed(&p, "resp_meta_42", "gpt-5.5", 99999L, cap_emit, &cap);
+   const char *completed = cap.data[cap.count - 1];
+   assert(strcmp(cap.events[cap.count - 1], "response.completed") == 0);
+   assert(strstr(completed, "resp_meta_42") != NULL);
+   assert(strstr(completed, "gpt-5.5") != NULL);
+   assert(strstr(completed, "99999") != NULL); /* created timestamp, verbatim */
+   free_parsed(&p);
+   PASS("emit_metadata_propagation");
+}
+
+/* Null parsed is tolerated (no crash): a single empty-output completed.
+ * Guards against a future caller passing a police error result. */
 static void test_emit_null_parsed(void)
 {
    cap_t cap = {0};
-   char frame[2048];
-   openai_responses_emit_policed(NULL, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   /* response.created + empty-output completed. */
-   assert(cap.count == 2);
-   assert(strcmp(cap.events[0], "response.created") == 0);
-   assert(strcmp(cap.events[1], "response.completed") == 0);
-   assert(strstr(cap.data[1], "\"output\":[]") != NULL);
+   openai_responses_emit_policed(NULL, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   assert(cap.count == 1);
+   assert_no_created(&cap);
+   assert(strcmp(cap.events[0], "response.completed") == 0);
+   assert(strstr(cap.data[0], "\"output\":[]") != NULL);
+   /* NULL parsed defaults usage to 0. */
+   assert(strstr(cap.data[0], "\"input_tokens\":0") != NULL);
+   assert(strstr(cap.data[0], "\"output_tokens\":0") != NULL);
    PASS("emit_null_parsed");
+}
+
+/* A NULL emit callback is tolerated (fail closed, no crash). */
+static void test_emit_null_callback(void)
+{
+   const char *names[] = {"web_search"};
+   const char *ids[] = {"call_1"};
+   const char *args[] = {"{\"q\":\"x\"}"};
+   parsed_response_t p;
+   seed_parsed(&p, 1, names, ids, args, "tool_calls");
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, NULL, NULL);
+   free_parsed(&p);
+   PASS("emit_null_callback");
 }
 
 /* Arguments are propagated verbatim (byte-for-byte fidelity for the
@@ -192,24 +275,23 @@ static void test_emit_arguments_byte_fidelity(void)
    const char *args[] = {"{\"b\":2,\"a\":1,\"nested\":{\"x\":\"y\"}}"};
    parsed_response_t p;
    seed_parsed(&p, 1, names, ids, args, "tool_calls");
-   char frame[2048];
    const char *original = args[0];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   /* The args.delta event carries the arguments as the JSON-string `delta`
-    * field (the OpenAI wire shape — inner quotes are escaped on the wire).
-    * Byte fidelity means: after parsing the event JSON, the decoded `delta`
-    * string equals the original arguments byte-for-byte (no key reorder, no
-    * whitespace reflow). Parse it back and compare rather than scanning the
-    * escaped wire bytes. The same fidelity holds for the `.done` event. */
-   cJSON *delta_ev = cJSON_Parse(cap.data[2]);
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+   /* The args.delta event (index 1) carries the arguments as the JSON-string
+    * `delta` field. Byte fidelity: after parsing the event JSON, the decoded
+    * `delta` string equals the original arguments byte-for-byte (no key
+    * reorder, no whitespace reflow). The same holds for the `.done` event
+    * at index 2. */
+   assert(strcmp(cap.events[1], "response.function_call_arguments.delta") == 0);
+   cJSON *delta_ev = cJSON_Parse(cap.data[1]);
    assert(delta_ev != NULL);
    const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
    assert(cJSON_IsString(delta) && delta->valuestring != NULL);
    assert(strcmp(delta->valuestring, original) == 0);
    cJSON_Delete(delta_ev);
 
-   cJSON *done_ev = cJSON_Parse(cap.data[3]);
+   assert(strcmp(cap.events[2], "response.function_call_arguments.done") == 0);
+   cJSON *done_ev = cJSON_Parse(cap.data[2]);
    assert(done_ev != NULL);
    const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
    assert(cJSON_IsString(full) && full->valuestring != NULL);
@@ -220,43 +302,51 @@ static void test_emit_arguments_byte_fidelity(void)
    PASS("emit_arguments_byte_fidelity");
 }
 
-/* Byte fidelity holds for the hard cases too: arguments containing characters
- * that must be JSON-escaped on the wire (embedded quotes/backslashes from a
- * nested JSON string) and multi-byte UTF-8. The decoded delta/arguments must
- * still equal the original byte-for-byte. */
-static void test_emit_arguments_escapes_and_utf8(void)
+/* Escaping / UTF-8 fidelity: arguments containing embedded quotes, a
+ * backslash, a newline, and a multi-byte UTF-8 sequence must decode
+ * byte-for-byte from both the delta and done events (the JSON-string
+ * wire-escaping must round-trip exactly). */
+static void test_emit_arguments_escapes_utf8(void)
 {
    cap_t cap = {0};
    const char *names[] = {"f"};
    const char *ids[] = {"c1"};
-   /* A path with a quote + backslash, and a UTF-8 string value (é, 日本). */
-   const char *args[] = {"{\"path\":\"C:\\\\a\\\"b\",\"note\":\"café 日本\"}"};
+   /* quote, backslash, newline, and "café 日本" (multi-byte UTF-8). */
+   const char *args[] = {"{\"s\":\"a\\\"b\\\\c\\nd café 日本\"}"};
    parsed_response_t p;
    seed_parsed(&p, 1, names, ids, args, "tool_calls");
-   char frame[2048];
    const char *original = args[0];
-   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap, frame,
-                                 sizeof(frame));
-   cJSON *delta_ev = cJSON_Parse(cap.data[2]);
-   assert(delta_ev != NULL); /* the emitted frame is itself valid JSON */
+   openai_responses_emit_policed(&p, "resp_1", "claude-test", 12345L, cap_emit, &cap);
+
+   cJSON *delta_ev = cJSON_Parse(cap.data[1]);
+   assert(delta_ev != NULL);
    const cJSON *delta = cJSON_GetObjectItemCaseSensitive(delta_ev, "delta");
-   assert(cJSON_IsString(delta) && delta->valuestring != NULL);
-   assert(strcmp(delta->valuestring, original) == 0);
+   assert(cJSON_IsString(delta) && strcmp(delta->valuestring, original) == 0);
    cJSON_Delete(delta_ev);
+
+   cJSON *done_ev = cJSON_Parse(cap.data[2]);
+   assert(done_ev != NULL);
+   const cJSON *full = cJSON_GetObjectItemCaseSensitive(done_ev, "arguments");
+   assert(cJSON_IsString(full) && strcmp(full->valuestring, original) == 0);
+   cJSON_Delete(done_ev);
+
    free_parsed(&p);
-   PASS("emit_arguments_escapes_and_utf8");
+   PASS("emit_arguments_escapes_utf8");
 }
 
 int main(void)
 {
    printf("test_openai_chat_policed:\n");
-   test_emit_response_created_first();
+   test_emit_omits_created_envelope();
    test_emit_surviving_tool_call();
    test_emit_multiple_surviving_tool_calls();
    test_emit_all_dropped_empty_output();
+   test_emit_null_arguments_fallback();
+   test_emit_metadata_propagation();
    test_emit_null_parsed();
+   test_emit_null_callback();
    test_emit_arguments_byte_fidelity();
-   test_emit_arguments_escapes_and_utf8();
+   test_emit_arguments_escapes_utf8();
    printf("all openai_chat_policed tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Promotes the current `testing` to `main`. New since the last promotion (#686):

- **#687** fix(gateway): stop double-emitting `response.created` on the OpenAI `/v1/responses` streaming tool-call path (regression from the P2c OpenAI-ingress slice `140c896`; OpenAI/Codex clients reject a doubled `response.created`).
- **#688** feat(guard): aimee-level session-isolation guard — opt-in `require_session_worktree` (default off). Layer 1 (client PreToolUse) and Layer 2 (server agent write chokepoint) fail closed on mutating ops outside an aimee-managed worktree, making the per-session worktree+branch isolation enforceable at the aimee level rather than relying on a client `SessionStart` hook.
- supporting `docs/gen` regeneration for the new config key.

Both merged to `testing` green (full CI) and roundtable-approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)