### PR TITLE
feat(smoothnas): aimee-kb plugin embeds against the llama-cpp GPU container

### DIFF
--- a/deploy/smoothnas/aimee-kb.plugin.yaml
+++ b/deploy/smoothnas/aimee-kb.plugin.yaml
@@ -78,10 +78,17 @@ services:
       AIMEE_DB2_URL: postgresql://aimee:aimee@{{service.postgres.host}}:5432/aimee_shared
       # Embed/rerank against the aimee-llm (llama.cpp / Vulkan GPU) container on
       # the runtime bridge — NOT a bundled torch embedder. 10.100.0.1 is the
-      # bridge gateway; 8742 is the aimee-llm host-published gateway port. The kb
-      # autodetects the embedding dim from the gateway /health (2560 for the GPU
-      # 4B tier). Overridable via the config key below.
+      # bridge gateway; 8742 is the aimee-llm host-published gateway port. The dim
+      # is pinned via AIMEE_EMBEDDING_DIM below (the gateway /health reports no
+      # dim, so autodim can't detect it). Overridable via the config key below.
       AIMEE_EMBEDDER_URL: http://10.100.0.1:8742
+      # Pin the embedding dim to the GPU 4B tier's 2560. REQUIRED here: the
+      # aimee-llm gateway /health does not report a `dim`, so the embedder-autodim
+      # probe (embed-remote.py --dim) cannot detect it, and an unset dim defaults
+      # to 1024 (config_database.c / db2_init.c) — which would build the fresh
+      # pgvector schema at the wrong width and reject/truncate the 2560-dim
+      # vectors. AIMEE_EMBEDDING_DIM pins it (config_resolve_embedding_dim).
+      AIMEE_EMBEDDING_DIM: "2560"
       # Bind /v1 on 0.0.0.0 so the published :8741 is reachable from the
       # aimee-server plugin across the bridge.
       AIMEE_KB_HTTP_BIND: "1"

--- a/deploy/smoothnas/aimee-kb.plugin.yaml
+++ b/deploy/smoothnas/aimee-kb.plugin.yaml
@@ -1,0 +1,116 @@
+# aimee-kb — the shared/vector knowledge base (DB2 + pgvector), standalone.
+#
+# This is the kb half of the split deployment: the aimee-server plugin reaches
+# it over the runtime bridge at AIMEE_KB_API_URL=http://10.100.0.1:8741, and it
+# in turn embeds/reranks against the unified **aimee-llm** (llama.cpp / Vulkan)
+# container — NOT a bundled torch embedder. The kb image already defaults to
+# `--http-port=8741` (Dockerfile CMD) + EXPOSE 8741, so no command override is
+# needed; AIMEE_KB_HTTP_BIND=1 makes it bind 0.0.0.0 so the published port is
+# reachable across the bridge.
+#
+# Embedder wiring (the point of this manifest): AIMEE_EMBEDDER_URL points at the
+# aimee-llm gateway at http://10.100.0.1:8742 (the GPU 7900 XTX tier on .254 —
+# Qwen3-Embedding-4B, 2560-dim). The gateway preserves the /embed + /embed_batch
+# + /rerank contract, so the baked embed-remote.py / in-process http embedder is
+# untouched. The kb sends NO bearer on the embed path (memory_embed_http_post
+# passes a NULL auth header), so the aimee-llm gateway MUST run with auth
+# disabled (AIMEE_LLM_AUTH_TOKEN empty) on the internal-only bridge — which is
+# the gateway's documented "deployment network is the boundary" posture
+# (expose:false, bridge-only).
+#
+# Images:
+#   ghcr.io/rakuensoftware/aimee-kb     (kb /v1 on :8741)
+#   pgvector/pgvector:pg17              (Postgres, public)
+apiVersion: smoothnas.io/v1
+kind: Plugin
+metadata:
+  name: aimee-kb
+  version: 0.2.57
+  description: >-
+    aimee knowledge base — DB2 + pgvector shared/vector memory, served on /v1
+    (:8741). Bundles its own pgvector Postgres; embeds + reranks against the
+    external aimee-llm (llama.cpp / Vulkan GPU) container via AIMEE_EMBEDDER_URL,
+    not a torch embedder. The aimee-server plugin points AIMEE_KB_API_URL here.
+  vendor: RakuenSoftware
+  homepage: https://github.com/RakuenSoftware/aimee
+profiles:
+  - default-limits
+  # aimee-stack = the 64 MB worker-thread stack rlimit. The kb entrypoint also
+  # raises it best-effort (ulimit -s), but keep the profile as belt-and-suspenders
+  # for runtimes that forbid an in-container raise.
+  - aimee-stack
+services:
+  - name: postgres
+    artifact:
+      type: oci-image
+      image: pgvector/pgvector:pg17
+    container:
+      restartPolicy: unless-stopped
+      # Run as uid 1000 to match the smoothfs tier's forced owner (the stock
+      # postgres image otherwise drops to its own user and can't access its
+      # uid-1000-owned data dir). Requires SmoothNAS v0.1.20+ runtime.
+      user: "1000:1000"
+    env:
+      POSTGRES_DB: aimee_shared
+      POSTGRES_USER: aimee
+      POSTGRES_PASSWORD: aimee
+    volumes:
+      - name: pgdata
+        mode: tier-bound
+        slot: HDD
+        bind: /var/lib/postgresql/data
+    health:
+      test: ["CMD-SHELL", "pg_isready -U aimee -d aimee_shared"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  - name: kb
+    artifact:
+      type: oci-image
+      image: ghcr.io/rakuensoftware/aimee-kb:latest
+    container:
+      restartPolicy: unless-stopped
+    dependsOn:
+      postgres:
+        condition: service_healthy
+    env:
+      AIMEE_DB2_URL: postgresql://aimee:aimee@{{service.postgres.host}}:5432/aimee_shared
+      # Embed/rerank against the aimee-llm (llama.cpp / Vulkan GPU) container on
+      # the runtime bridge — NOT a bundled torch embedder. 10.100.0.1 is the
+      # bridge gateway; 8742 is the aimee-llm host-published gateway port. The kb
+      # autodetects the embedding dim from the gateway /health (2560 for the GPU
+      # 4B tier). Overridable via the config key below.
+      AIMEE_EMBEDDER_URL: http://10.100.0.1:8742
+      # Bind /v1 on 0.0.0.0 so the published :8741 is reachable from the
+      # aimee-server plugin across the bridge.
+      AIMEE_KB_HTTP_BIND: "1"
+    volumes:
+      - name: home
+        mode: tier-bound
+        slot: HDD
+        bind: /var/lib/aimee
+    ports:
+      # kb /v1 — reached by the aimee-server plugin at http://10.100.0.1:8741.
+      # Not exposed off-host.
+      - name: api
+        port: 8741
+        protocol: tcp
+        expose: false
+        hostExpose: true
+    health:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      startPeriod: 30s
+    config:
+      - key: AIMEE_EMBEDDER_URL
+        type: string
+        label: Embedder/rerank URL (aimee-llm gateway)
+        default: http://10.100.0.1:8742
+        description: >-
+          The aimee-llm (llama.cpp / Vulkan) gateway that serves /embed,
+          /embed_batch and /rerank. Defaults to the GPU container on the runtime
+          bridge. The gateway must run with auth disabled (empty
+          AIMEE_LLM_AUTH_TOKEN) because the kb embed path sends no bearer.

--- a/deploy/smoothnas/aimee-llm.plugin.yaml
+++ b/deploy/smoothnas/aimee-llm.plugin.yaml
@@ -46,10 +46,22 @@ services:
       # Multi-GPU disambiguation only (single-GPU hosts need none): pin RADV to a
       # specific adapter by PCI/vendor id rather than a fragile device-node path.
       # AIMEE_LLM_VK_DEVICE / MESA_VK_DEVICE_SELECT: "1002:744c"
-      # The gateway requires a bearer token. Provide it via the plugin's env
-      # override at deploy time from the secret store (vault / Docker secret /
-      # .gitignore'd per-host .env) — NEVER a checked-in plaintext value. Document
-      # its rotation alongside the deploy (runbook §3).
+      # Bearer auth. When a token is set the gateway requires `Authorization:
+      # Bearer <token>` on every request (401 otherwise); an EMPTY/unset token
+      # disables auth ("deployment network is the boundary" — fine here because
+      # the gateway is expose:false, reachable only on the internal bridge).
+      #
+      # IMPORTANT for the aimee-kb embed path: the kb embeds/reranks against this
+      # gateway with NO bearer (memory_embed_http_post sends a NULL auth header),
+      # so when this container backs aimee-kb's AIMEE_EMBEDDER_URL it MUST run
+      # auth-off — leave AIMEE_LLM_AUTH_TOKEN unset/empty. Only set a token if the
+      # gateway is used solely by bearer-capable callers (e.g. synth via the
+      # curator tier_b config, which can carry one). If you need both, run two
+      # gateways or add an embedder-bearer to the kb first.
+      #
+      # If you do set one, provide it via the plugin's env override at deploy time
+      # from the secret store (vault / Docker secret / .gitignore'd per-host .env)
+      # — NEVER a checked-in plaintext value. Document its rotation (runbook §3).
       # AIMEE_LLM_AUTH_TOKEN: "<set-at-deploy-time-not-in-git>"
     ports:
       # The embed/rerank/synth gateway. hostExpose so the aimee-kb plugin can reach

--- a/docs/runbooks/unified-llm-cutover.md
+++ b/docs/runbooks/unified-llm-cutover.md
@@ -70,9 +70,14 @@ untouched). Set the kb's `embedding_model` to the new identity (activates the P1
 `embedding_dim` to the tier's dim (2560 for the 4B GPU tier). **Verify the URL actually
 serves the named model before re-embedding** — a misrouted `AIMEE_EMBEDDER_URL` (still
 pointing at the old embedder) would silently embed under the new identity and the guard
-would not catch it (it checks identity-vs-corpus, not URL-vs-identity). `AIMEE_LLM_AUTH_TOKEN`
-comes from the secret store (vault / Docker secret / `.gitignore`d per-host `.env`), **never
-a checked-in plaintext compose value**; document its rotation alongside the deploy.
+would not catch it (it checks identity-vs-corpus, not URL-vs-identity). **Auth on the embed
+path:** the kb embeds/reranks with NO bearer (`memory_embed_http_post` sends a NULL auth
+header), so when this gateway backs `AIMEE_EMBEDDER_URL` it MUST run **auth-off** — leave
+`AIMEE_LLM_AUTH_TOKEN` empty/unset. The gateway treats an empty token as "auth disabled,"
+acceptable here because it is `expose:false` (internal bridge only; deployment network is the
+boundary). Only set `AIMEE_LLM_AUTH_TOKEN` when the gateway serves *only* bearer-capable
+callers (e.g. curator `tier_b` synth); if so it comes from the secret store (vault / Docker
+secret / `.gitignore`d per-host `.env`), **never a checked-in plaintext value**.
 
 ## 4. Corpus re-embed (controlled drop-and-rebuild — the `maintenance` window)
 


### PR DESCRIPTION
## What

Adds the standalone **aimee-kb** tierd/smoothnas plugin manifest and repoints the embed/rerank path at the unified **aimee-llm** (llama.cpp / Vulkan) GPU container instead of a bundled torch embedder.

- **New** `deploy/smoothnas/aimee-kb.plugin.yaml` — postgres (pgvector) + kb, no embedder service. `AIMEE_EMBEDDER_URL=http://10.100.0.1:8742` (the aimee-llm gateway on the runtime bridge; GPU 7900 XTX, Qwen3-Embedding-4B / 2560-dim). kb `/v1` host-published on `:8741`; the `aimee-server` plugin already reaches it at `AIMEE_KB_API_URL=http://10.100.0.1:8741`.
- **Fix auth guidance** in `aimee-llm.plugin.yaml` + `docs/runbooks/unified-llm-cutover.md §3`: the kb embed/rerank path sends **no bearer** (`memory_embed_http_post` passes a `NULL` auth header), so when the gateway backs the kb's `AIMEE_EMBEDDER_URL` it **must run auth-off** (empty `AIMEE_LLM_AUTH_TOKEN`) on the internal-only (`expose:false`) bridge.

## Why

Completes the split deployment (separate `aimee-server` + `aimee-kb` plugins) and moves embeddings onto the GPU llama.cpp container, retiring the torch embedder for this deployment.

## Validation

Manifest validated against the live tierd `/api/plugins/parse` schema on `.254`; the referenced `aimee-stack` + `gpu-amd` profiles exist in the catalog. Deploy is operator-gated (this PR is the manifest only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)