### PR TITLE
fix(kb): embed_ok, canonical-scan success check, and whole-corpus search

### DIFF
--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -68,21 +68,29 @@ int db2_kb_document_fetch(int64_t id, const char *project, db2_kb_document_row_t
    if (!out)
       return 0;
    memset(out, 0, sizeof(*out));
-   if (id <= 0 || !project || !project[0])
+   if (id <= 0)
       return 0;
    void *conn = db2_conn();
    if (!conn)
       return 0;
 
-   static const char *sql =
-       "SELECT id, file_path, file_hash, heading_path, line_start, line_end, content"
-       " FROM kb_documents WHERE id = ?1 AND project = ?2";
+   /* id is the kb_documents primary key (globally unique), so an absent project
+    * fetches by id alone — this lets a project-less (whole-corpus) kb/search
+    * resolve the rows pgvec_kb_search returns across all projects. A named
+    * project still scopes the lookup. */
+   int has_project = (project && project[0]);
+   const char *sql =
+       has_project ? "SELECT id, file_path, file_hash, heading_path, line_start, line_end, content"
+                     " FROM kb_documents WHERE id = ?1 AND project = ?2"
+                   : "SELECT id, file_path, file_hash, heading_path, line_start, line_end, content"
+                     " FROM kb_documents WHERE id = ?1";
    char err[KBP_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
    if (!st)
       return 0;
    aimee_pg_bind_int64(st, "?1", id);
-   aimee_pg_bind_text(st, "?2", project);
+   if (has_project)
+      aimee_pg_bind_text(st, "?2", project);
    int hit = 0;
    if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
    {

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -646,11 +646,22 @@ int pgvec_kb_search(const char *project, const float *vec, int dim, int limit, i
    if (!vec_text)
       return -1;
 
-   static const char *sql = "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
-                            "FROM kb_embeddings "
-                            "WHERE project = :project "
-                            "ORDER BY embedding <=> :qvec::halfvec "
-                            "LIMIT :lim";
+   /* A named project scopes the search to it; a NULL/empty project searches the
+    * WHOLE corpus (all projects). The old code always bound `WHERE project =
+    * :project` with "" for the NULL case, which matched no rows (every chunk has
+    * a real project) — so a project-less /v1/kb/search silently returned zero
+    * hits instead of searching everything. Mirrors pgvec_curator_entity_search,
+    * which already exposes its scope filters as optional. */
+   int has_project = (project && project[0]);
+   const char *sql = has_project ? "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
+                                   "FROM kb_embeddings "
+                                   "WHERE project = :project "
+                                   "ORDER BY embedding <=> :qvec::halfvec "
+                                   "LIMIT :lim"
+                                 : "SELECT point_id, 1.0 - (embedding <=> :qvec::halfvec) AS score "
+                                   "FROM kb_embeddings "
+                                   "ORDER BY embedding <=> :qvec::halfvec "
+                                   "LIMIT :lim";
 
    char errbuf[256];
    aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
@@ -660,7 +671,8 @@ int pgvec_kb_search(const char *project, const float *vec, int dim, int limit, i
       return 0; /* pgvector not available — no vector results */
    }
    aimee_pg_bind_text(stmt, "qvec", vec_text);
-   aimee_pg_bind_text(stmt, "project", project ? project : "");
+   if (has_project)
+      aimee_pg_bind_text(stmt, "project", project);
    aimee_pg_bind_int(stmt, "lim", limit > 0 ? limit : max);
 
    int64_t t0 = monotonic_us();

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1341,7 +1341,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       /* Canonical code index scan (symbols/definitions), mirroring the async
        * ingest worker so build and ingest produce the same index. */
       int inspected = 0;
-      if (canonical_index_scan_project(project, kb_path, force, &inspected) != 0)
+      /* >= 0 is the scanned-file count (success); only a negative is an error. */
+      if (canonical_index_scan_project(project, kb_path, force, &inspected) < 0)
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"canonical index scan failed\"}");
          return 500;
@@ -1394,7 +1395,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          return 500;
       }
       int inspected = 0;
-      if (canonical_index_scan_project(project, kb_path, 0, &inspected) != 0)
+      /* >= 0 is the scanned-file count (success); only a negative is an error. */
+      if (canonical_index_scan_project(project, kb_path, 0, &inspected) < 0)
       {
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"canonical index scan failed\"}");
          return 500;

--- a/src/kb/kb.c
+++ b/src/kb/kb.c
@@ -1540,8 +1540,18 @@ static char *kb_search_gather(const char *project, const char *query, const char
       return safe_strdup("error: db2 not initialized");
    const char *effective_cmd = kb_effective_embedding_cmd(embedding_cmd);
 
+   /* An explicit project scopes the search; omitting it means whole-corpus (all
+    * projects), NOT the server's cwd-basename. kb_resolve_project would default
+    * an empty project to getcwd()'s basename, which inside the kb SERVER is
+    * always its WORKDIR (/var/lib/aimee -> "aimee") and matches no real corpus —
+    * so an API /v1/kb/search that omits `project` silently returned nothing. The
+    * CLI resolves its own cwd project before calling, so it always sends an
+    * explicit name and is unaffected. Empty proj flows to the legs as "all". */
    char proj[256];
-   kb_resolve_project(project, NULL, proj, sizeof(proj));
+   if (project && project[0])
+      kb_resolve_project(project, NULL, proj, sizeof(proj));
+   else
+      proj[0] = '\0';
 
    /* Determine fusion mode: explicit override > bandit sample > config > default.
     * When no override is given and live bandit decisions are enabled, sample the

--- a/src/kb/kb_ingest_workers.c
+++ b/src/kb/kb_ingest_workers.c
@@ -141,7 +141,12 @@ static void kbiw_process_job(const db2_kb_ingest_job_t *job)
 
    kb_background_set("ingest", "project=%s phase=scan", job->project);
    int inspected = 0;
-   if (canonical_index_scan_project(job->project, job->root_path, job->force, &inspected) != 0)
+   /* canonical_index_scan_project returns the number of files scanned (>= 0) on
+    * success and a negative value on error — only a negative is a failure. The
+    * old `!= 0` check wrongly failed every project that scanned >= 1 file (i.e.
+    * any non-empty project), marking the ingest job "failed" even though the
+    * embeddings landed. Match the contract the HTTP scan route already uses. */
+   if (canonical_index_scan_project(job->project, job->root_path, job->force, &inspected) < 0)
    {
       aimee_log(LOG_WARN, "kb.ingest.worker", "canonical index scan failed for project='%s'",
                 job->project);

--- a/src/kb/kb_service_kb.c
+++ b/src/kb/kb_service_kb.c
@@ -322,12 +322,18 @@ static cJSON *kb_service_health_object(void)
    cJSON_AddNumberToObject(resp, "pgvec_vectors", pgvec_vectors);
    cJSON_AddNumberToObject(resp, "pgvec_indexed_vectors", pgvec_indexed);
 
-   /* Embed: check if the configured command is reachable (no actual probe) */
+   /* Embed: report whether an embedder is configured. The command can come from
+    * the config file OR the AIMEE_EMBEDDER_URL env (the combined image always
+    * exports the latter), so resolve it the same way embed_command does instead
+    * of reading the raw config field — otherwise an env-configured embedder is
+    * wrongly reported embed_ok:false while embed_command shows a real URL. The
+    * "builtin" fallback (nothing configured) still reports false, as before. */
    config_t cfg;
    config_load(&cfg);
-   int embed_ok = cfg.embedding_command[0] ? 1 : 0;
+   const char *embed_cmd = config_embedding_command(&cfg, NULL);
+   int embed_ok = (embed_cmd[0] && strcmp(embed_cmd, "builtin") != 0) ? 1 : 0;
    cJSON_AddBoolToObject(resp, "embed_ok", embed_ok);
-   cJSON_AddStringToObject(resp, "embed_command", config_embedding_command(&cfg, NULL));
+   cJSON_AddStringToObject(resp, "embed_command", embed_cmd);
 
    /* Curator (§4 observability): per-tier provider config + queue depth. The
     * live four-state reachability probe (ready/loading/gated/down) is deferred to


### PR DESCRIPTION
Three aimee-kb bugs surfaced while validating a **CPU `aimee-llm`** deployment on a fresh pve LXC, where the embedder is configured via `AIMEE_EMBEDDER_URL` (the combined image's default) rather than the `aimee.yaml` `embedding_command` field. Each was root-caused and **re-validated live** on the running stack.

## 1. `/v1/health` reported `embed_ok:false` with a working embedder
`kb_service_kb.c` derived `embed_ok` from the raw `cfg.embedding_command` field, but the embedder URL comes from the `AIMEE_EMBEDDER_URL` env (resolved by `config_embedding_command()`, which is also what populates the adjacent `embed_command`). It now resolves the same way. The `"builtin"` fallback still reports `false`, as before.

## 2. Project ingest marked `"failed"` whenever it scanned ≥1 file
`canonical_index_scan_project()` returns the **scanned-file count** (`>= 0` on success, `< 0` on error) — the contract `kb_http_code.c` already checks. But the async ingest worker (`kb_ingest_workers.c`) and two `kb_http.c` routes checked `!= 0`, so any non-empty project was marked `"failed"` even though its embeddings landed (`kb_points` incremented). Changed all three to `< 0`.

## 3. Project-less `/v1/kb/search` silently returned nothing
`kb_search_gather()` defaulted an empty project to `getcwd()`'s basename, which **inside the kb server** is always its WORKDIR (`/var/lib/aimee` → `"aimee"`) — a non-existent corpus; `pgvec_kb_search` and `db2_kb_document_fetch` then hard-filtered on that name. An omitted `project` now searches the **whole corpus** (all projects), mirroring `pgvec_curator_entity_search`'s optional filters. The CLI resolves its own cwd project client-side, so it is unaffected.

## Validation
Built into the combined image and redeployed; an automated check passes 4/4: `embed_ok=true`; a doc-project ingest completes (`status=done`) instead of `failed`; a keyword-disjoint semantic query returns the ingested doc both **with** an explicit project and **project-less** (whole-corpus).