### PR TITLE
feat(kb): AIMEE_LLM_URL one-knob endpoint config for embed/rerank/synth (P1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,11 +36,17 @@ RUN apt-get update \
 
 ENV AIMEE_HOME=/var/lib/aimee
 ENV AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared
-# Defaults; compose overrides. The embedder service backs embeddings; point
-# LLM_ENDPOINT at an OpenAI-compatible model (e.g. the llama.cpp `llm` service)
-# to enable the synthesis / curator passes.
-ENV AIMEE_EMBEDDER_URL=http://embedder:8080
-ENV LLM_ENDPOINT=http://llm:8080/v1
+# No baked embedder/LLM endpoint defaults. The kb runs NO model runtime; it calls
+# an external aimee-llm container (CPU/GPU) or endpoint. Point it with ONE of:
+#   AIMEE_LLM_URL       unified container -> embed + rerank + synth (one knob)
+#   AIMEE_EMBEDDER_URL  pin the embedder (/embed) independently
+#   AIMEE_RERANKER_URL  pin the reranker (/rerank) independently
+#   LLM_ENDPOINT        Tier-A synth only (small-model interface)
+# Unset, embeddings fall back to the 384-dim builtin (test/shim only). The deploy
+# unit (compose / smoothnas plugin) sets these and brings up a default CPU
+# aimee-llm sibling when nothing is configured. (Old combined leftovers
+# AIMEE_EMBEDDER_URL=embedder:8080 / LLM_ENDPOINT=llm:8080 were removed: on a
+# split deploy they silently pointed at non-existent services.)
 # Bind the /v1 HTTP API on 0.0.0.0 (not the 127.0.0.1 default), so the published
 # port and container-IP access reach it from outside the container.
 ENV AIMEE_KB_HTTP_BIND=1

--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ aimee status
 |----------|-------------|
 | [Quickstart](docs/QUICKSTART.md) | Run the combined server in Docker, then install the Linux/Windows/macOS thin client. |
 | [How aimee learns](docs/KNOWLEDGE.md) | The knowledge base, self-learning pipeline, cross-domain synthesis, and delegation economics. |
+| [kb LLM backends](docs/KB_LLM_BACKENDS.md) | Pointing aimee-kb at its embedding/reranking/synthesis backend (CPU/GPU `aimee-llm` container or external), the config surface, and tiers/dims. |
 | [Manual](MANUAL.md) | Full user reference: install, config, command contract, feature guides. |
 | [Architecture](docs/ARCHITECTURE.md) | Processes, storage/trust boundaries, layering, request lifecycles. |
 | [Technical Reference](src/README.md) | Code internals, module map, server internals, RPC/HTTP surfaces, build system, and deployment/operations. |

--- a/deploy/smoothnas/aimee-kb.plugin.yaml
+++ b/deploy/smoothnas/aimee-kb.plugin.yaml
@@ -76,18 +76,18 @@ services:
         condition: service_healthy
     env:
       AIMEE_DB2_URL: postgresql://aimee:aimee@{{service.postgres.host}}:5432/aimee_shared
-      # Embed/rerank against the aimee-llm (llama.cpp / Vulkan GPU) container on
-      # the runtime bridge — NOT a bundled torch embedder. 10.100.0.1 is the
-      # bridge gateway; 8742 is the aimee-llm host-published gateway port. The dim
-      # is pinned via AIMEE_EMBEDDING_DIM below (the gateway /health reports no
-      # dim, so autodim can't detect it). Overridable via the config key below.
-      AIMEE_EMBEDDER_URL: http://10.100.0.1:8742
-      # Pin the embedding dim to the GPU 4B tier's 2560. REQUIRED here: the
-      # aimee-llm gateway /health does not report a `dim`, so the embedder-autodim
-      # probe (embed-remote.py --dim) cannot detect it, and an unset dim defaults
-      # to 1024 (config_database.c / db2_init.c) — which would build the fresh
-      # pgvector schema at the wrong width and reject/truncate the 2560-dim
-      # vectors. AIMEE_EMBEDDING_DIM pins it (config_resolve_embedding_dim).
+      # ONE knob: point the kb at a unified aimee-llm container and it drives
+      # embedding (/embed), reranking (/rerank) AND synthesis (curator Tier-A +
+      # Tier-B, at {url}/v1). The kb runs NO model itself — this is just the URL it
+      # calls. 10.100.0.1:8742 is the GPU aimee-llm on the runtime bridge here.
+      #   - Pin only the embedder or reranker elsewhere with AIMEE_EMBEDDER_URL /
+      #     AIMEE_RERANKER_URL (they take precedence over AIMEE_LLM_URL).
+      #   - The gateway runs auth-off (empty AIMEE_LLM_AUTH_TOKEN) — the kb embed
+      #     path sends no bearer.
+      AIMEE_LLM_URL: http://10.100.0.1:8742
+      # Embedding dim is explicit. Default (unset) = 1024 (the CPU / 0.6B tier).
+      # This deploy uses the GPU 4B tier → set 2560. Changing it against a
+      # populated kb is a drop-and-rebuild re-embed (kb_meta drift guard).
       AIMEE_EMBEDDING_DIM: "2560"
       # Bind /v1 on 0.0.0.0 so the published :8741 is reachable from the
       # aimee-server plugin across the bridge.
@@ -112,12 +112,33 @@ services:
       retries: 3
       startPeriod: 30s
     config:
-      - key: AIMEE_EMBEDDER_URL
+      - key: AIMEE_LLM_URL
         type: string
-        label: Embedder/rerank URL (aimee-llm gateway)
+        label: LLM container URL (embed + rerank + synth)
         default: http://10.100.0.1:8742
         description: >-
-          The aimee-llm (llama.cpp / Vulkan) gateway that serves /embed,
-          /embed_batch and /rerank. Defaults to the GPU container on the runtime
-          bridge. The gateway must run with auth disabled (empty
-          AIMEE_LLM_AUTH_TOKEN) because the kb embed path sends no bearer.
+          One knob. The unified aimee-llm container the kb calls for embedding,
+          reranking and synthesis (Tier-A + Tier-B). CPU tier = Tier-A synth +
+          1024-dim embed; GPU tier = Tier-A+B synth + higher-dim embed (set
+          AIMEE_EMBEDDING_DIM=2560). Must run auth-off (the kb sends no bearer).
+      - key: AIMEE_EMBEDDER_URL
+        type: string
+        label: Embedder URL (override)
+        default: ""
+        description: >-
+          Optional. Pin the embedder (/embed) at a specific endpoint, overriding
+          AIMEE_LLM_URL for embedding only.
+      - key: AIMEE_RERANKER_URL
+        type: string
+        label: Reranker URL (override)
+        default: ""
+        description: >-
+          Optional. Pin the reranker (/rerank) at a specific endpoint, overriding
+          AIMEE_EMBEDDER_URL / AIMEE_LLM_URL for reranking only.
+      - key: AIMEE_EMBEDDING_DIM
+        type: string
+        label: Embedding dimension
+        default: ""
+        description: >-
+          Embedding vector dim. Blank = 1024 (CPU / 0.6B tier). Set 2560 for the
+          GPU / 4B tier. Changing it against a populated kb forces a re-embed.

--- a/docs/KB_LLM_BACKENDS.md
+++ b/docs/KB_LLM_BACKENDS.md
@@ -1,0 +1,101 @@
+# aimee-kb LLM backends: embedding, reranking & synthesis
+
+How to point `aimee-kb` at the model backend that does its **embedding**,
+**reranking**, and **synthesis**.
+
+## Principle: the kb runs no model
+
+`aimee-kb` is a thin DB2 / curator service. It **never** runs an LLM or embedder
+in-process — it *calls* one over HTTP. Inference lives in a separate **`aimee-llm`
+container** (the unified Vulkan llama.cpp image, CPU or GPU tier) or any external
+OpenAI-compatible endpoint. You only ever give the kb a **URL**.
+
+## Tiers — what each backend provides
+
+| Backend | Embedding / reranking | Synthesis | Embedding dim |
+| --- | --- | --- | --- |
+| **CPU `aimee-llm`** (default) | yes (Qwen3-0.6B + ettin) | **Tier-A** only (small model) | **1024** |
+| **GPU `aimee-llm`** | yes, higher quality (Qwen3-4B) | **Tier-A + Tier-B** | **2560** (set explicitly) |
+| **External LLM** | per the endpoint | per the endpoint | per the endpoint |
+
+*Tier-A* = mechanical extract/index passes. *Tier-B* = reasoning passes (judge,
+resolve-entities, contradictions, **synthesize**, promote). A small CPU model is
+deliberately **not** allowed to run Tier-B (the weak-model-poisons-the-graph
+guard), so CPU-only deployments get retrieval + Tier-A synthesis; Tier-B turns on
+when you point the kb at a capable container via `AIMEE_LLM_URL`.
+
+## Zero-config default
+
+If **no** LLM is configured, the kb deployment brings up a **CPU `aimee-llm`
+container beside it** and points itself at it — embedding, reranking, and Tier-A
+synthesis work out of the box with nothing to set. The operator only opts *up*:
+configure a GPU container or an external LLM and the CPU sibling is not started.
+
+> The default CPU sibling is owned by the **deploy unit** (the smoothnas plugin /
+> compose), not the kb process — the kb never touches a container runtime.
+
+## Config surface
+
+All optional. Precedence is **per service**: an explicit per-service URL wins,
+then `AIMEE_LLM_URL`, then the zero-config CPU default.
+
+| Variable | Drives | Default |
+| --- | --- | --- |
+| `AIMEE_LLM_URL` | embedding **+** reranking **+** synthesis (Tier-A + Tier-B, at `{url}/v1`) | the auto CPU sibling |
+| `AIMEE_EMBEDDER_URL` | embedding (`/embed`, `/embed_batch`) | `AIMEE_LLM_URL` |
+| `AIMEE_RERANKER_URL` | reranking (`/rerank`) | `AIMEE_EMBEDDER_URL` → `AIMEE_LLM_URL` |
+| `AIMEE_EMBEDDING_DIM` | pgvector schema width | `1024` (CPU); set `2560` for the GPU tier |
+| `AIMEE_LLM_MODEL` | model label sent to `AIMEE_LLM_URL` | `aimee-synth` (gateways ignore it) |
+| `LLM_ENDPOINT` | **Tier-A synth only** (small-model interface) | unset |
+
+- **`AIMEE_LLM_URL` is the one knob.** Point it at a container and embedding,
+  reranking, and synthesis all use it. `{AIMEE_LLM_URL}` serves `/embed`,
+  `/embed_batch`, `/rerank`; `{AIMEE_LLM_URL}/v1` serves chat completions for the
+  curator. Give the base URL **without** `/v1` (a trailing `/v1` or `/` is
+  tolerated).
+- **Split a service out** by setting `AIMEE_EMBEDDER_URL` and/or
+  `AIMEE_RERANKER_URL` — they override `AIMEE_LLM_URL` for just that service.
+- **Auth:** the kb sends **no bearer** on the embed/rerank/synth path, so the
+  container must run **auth-off** (empty `AIMEE_LLM_AUTH_TOKEN`). This is safe on
+  the internal deployment network (the `aimee-llm` gateway is not exposed
+  off-host).
+
+### Embedding dimension
+
+The dim is **explicit**, not auto-detected:
+
+- **Unset → 1024** — the CPU / Qwen3-0.6B tier.
+- **GPU / 4B tier → set `AIMEE_EMBEDDING_DIM=2560`.**
+
+Changing the dim against a **populated** kb is a **drop-and-rebuild re-embed**:
+1024 and 2560 are a different model identity *and* width, and the `kb_meta` drift
+guard refuses to serve a new embedder against a mismatched corpus. Plan a
+re-embed (snapshot → drop dim-sized `halfvec` tables → rebuild at the new dim →
+parity gate) when moving between CPU and GPU tiers. See
+[runbooks/unified-llm-cutover.md](runbooks/unified-llm-cutover.md).
+
+## Examples
+
+**GPU container (this deployment's `.254`):**
+```
+AIMEE_LLM_URL=http://10.100.0.1:8742      # embed + rerank + Tier-A&B synth
+AIMEE_EMBEDDING_DIM=2560                   # GPU / 4B tier
+```
+
+**External embedder, GPU for synth:**
+```
+AIMEE_LLM_URL=http://10.100.0.1:8742       # synth (+ rerank, unless split)
+AIMEE_EMBEDDER_URL=https://embed.internal  # pin embedding elsewhere
+AIMEE_EMBEDDING_DIM=<that model's dim>
+```
+
+**Default (nothing set):** the deploy brings up the CPU `aimee-llm` sibling;
+retrieval + Tier-A synthesis work at 1024-dim with no configuration.
+
+## Notes for plugin / compose operators
+
+The `aimee-kb` smoothnas plugin and the compose topologies expose `AIMEE_LLM_URL`
+/ `AIMEE_EMBEDDER_URL` / `AIMEE_RERANKER_URL` / `AIMEE_EMBEDDING_DIM` as config.
+The kb image carries **no** baked embedder/LLM endpoint defaults — an unset
+backend falls back to the 384-dim builtin embedder (test/shim only), so a real
+deployment either relies on the default CPU sibling or sets one of the URLs above.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -199,7 +199,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 117 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 119 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -260,6 +260,7 @@ The binaries read 117 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 | Variable | Description |
 |----------|-------------|
+| `AIMEE_EMBEDDER_URL` | Embedder endpoint override (/embed, /embed_batch); takes precedence over AIMEE_LLM_URL for embedding. |
 | `AIMEE_KB_API_BEARER_TOKEN` | Bearer token for the aimee-kb API. |
 | `AIMEE_KB_API_CA_BUNDLE` | CA bundle path for verifying the aimee-kb TLS certificate. |
 | `AIMEE_KB_API_URL` | aimee-kb HTTP API base URL. |
@@ -275,6 +276,8 @@ The binaries read 117 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_KB_OIDC_JWKS_FILE` | OIDC JWKS file for KB API auth. |
 | `AIMEE_KB_OIDC_SCOPE_CLAIM` | OIDC claim carrying the scope. |
 | `AIMEE_KB_OIDC_SCOPE_KIND` | OIDC scope-kind interpretation. |
+| `AIMEE_LLM_MODEL` | Model label sent to AIMEE_LLM_URL's chat endpoint (single-model gateways ignore it). Default 'aimee-synth'. |
+| `AIMEE_LLM_URL` | One knob: base URL of the aimee-llm container the kb calls for embedding (/embed), reranking (/rerank) AND synthesis (curator Tier-A + Tier-B at {url}/v1). The kb runs no model itself. AIMEE_EMBEDDER_URL/AIMEE_RERANKER_URL override per service. See docs/KB_LLM_BACKENDS.md. |
 | `AIMEE_VECTOR_KB_BATCH_SIZE` | Embedding batch size for KB vector ingest. |
 
 ### Database & vectors
@@ -390,7 +393,7 @@ The binaries read 117 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_EMBEDDER_URL`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/docs/proposals/pending/kb-llm-endpoints-and-default-cpu.md
+++ b/docs/proposals/pending/kb-llm-endpoints-and-default-cpu.md
@@ -1,0 +1,74 @@
+# Proposal: aimee-kb LLM endpoint config + zero-config default CPU container
+
+**Status:** pending
+**Owner:** deploy/kb
+
+## Principle
+
+**aimee-kb runs no LLM runtime — ever.** It is a thin DB2/curator service that
+*calls* an LLM container over HTTP for embedding, reranking, and synthesis. The
+inference always lives in a separate `aimee-llm` container (the unified Vulkan
+llama.cpp image, CPU or GPU tier) or an external OpenAI-compatible endpoint. The
+kb never bundles, bakes, or spawns-in-process any model runtime.
+
+## Desired UX
+
+- **No LLM configured → a CPU `aimee-llm` container is brought up beside the kb
+  and the kb points itself at it.** Embedding + reranking + Tier-A synthesis work
+  with zero operator config.
+- **A GPU or external LLM configured → the CPU container is NOT brought up;** the
+  kb uses the configured endpoint (GPU adds higher-dim embed/rerank + Tier-B
+  synthesis).
+- The operator only ever opts *up* (GPU container or external LLM). CPU is
+  automatic.
+
+## Config surface
+
+| Knob | Drives | Default |
+| --- | --- | --- |
+| `AIMEE_LLM_URL` | embed **+** rerank **+** synth (curator `provider` + `tier_b`, `+/v1`) | the auto-managed CPU sibling |
+| `AIMEE_EMBEDDER_URL` | `/embed`, `/embed_batch` | `AIMEE_LLM_URL` |
+| `AIMEE_RERANKER_URL` | `/rerank` (split from the embedder) | `AIMEE_EMBEDDER_URL` → `AIMEE_LLM_URL` |
+
+**Precedence (per service):** explicit per-service URL > `AIMEE_LLM_URL` >
+auto-CPU default. One `AIMEE_LLM_URL` moves everything to a chosen container;
+per-service vars pin one independently.
+
+**Synthesis tiers (Tier-A vs Tier-B).** `AIMEE_LLM_URL` is the "capable container"
+knob: it wires **both** Tier-A and Tier-B synthesis to that container's `/v1`. The
+zero-config **CPU default does not set `AIMEE_LLM_URL`** — the deploy wires its
+embedder + `LLM_ENDPOINT` (Tier-A only), so Tier-B stays idle on the small CPU
+model (the weak-model-poisons-the-graph guard, kept). Result: **CPU → embed +
+rerank + Tier-A; GPU/external `AIMEE_LLM_URL` → + Tier-B.** No `/health` tier
+probe needed.
+
+**Dimension is explicit (default 1024 / CPU).** The embedding dim is operator-set:
+**default 1024** (CPU / Qwen3-0.6B, the existing `db2` default); set
+`AIMEE_EMBEDDING_DIM=2560` when pointing at the GPU / 4B container. No auto-detect
+— the operator who picks the GPU sets the dim and accepts the re-embed.
+
+**Re-embed guard:** CPU = 1024-dim, GPU = 2560-dim — different `model_id` + dim,
+so switching a populated kb between tiers is a drop-and-rebuild re-embed (existing
+`kb_meta` drift guard); fail closed, never embed under a mismatched dim.
+
+## Phases
+
+- **P1 — config surface (kb code, runtime-independent).** Central resolution of
+  embedder / reranker / synth endpoints with the precedence above; `AIMEE_LLM_URL`
+  + `AIMEE_RERANKER_URL` consumed by the C in-process embed path, `embed-remote.py`,
+  `rerank-remote.py`, and `kb_curator_provider` (Tier-A + Tier-B). Remove the dead
+  `embedder:8080` / `llm:8080` baked `ENV` defaults from the **kb image**
+  (`Dockerfile`) — on a split deploy they point at non-existent services.
+  (`Dockerfile.combined` keeps them: the combined topology ships those services.)
+  Unit tests for precedence. *No packaging change.*
+- **P2 — zero-config default CPU sibling (packaging).** The `aimee-kb` plugin /
+  compose brings up an `aimee-llm-cpu` sibling **by default** and points the kb at
+  it; when the operator sets `AIMEE_LLM_URL` to a GPU/external endpoint the CPU
+  sibling is not started. The kb does not touch the container runtime — the deploy
+  unit owns the sibling's lifecycle.
+
+## Notes
+- `.254` stays on the GPU (`AIMEE_LLM_URL=http://10.100.0.1:8742`, 2560-dim) —
+  already deployed; this is the durable, general mechanism.
+- Supersedes the manual `aimee.yaml` curator wiring done live on `.254`, and the
+  earlier (rejected) idea of baking a runtime into the kb image.

--- a/scripts/embed-remote.py
+++ b/scripts/embed-remote.py
@@ -11,8 +11,11 @@ Contract (platform_exec_pipe in src/memory_core_scope_embed.inc):
   stdout: JSON float array  [0.123, -0.456, ...]  (384-dim, L2-normalised)
   exit 0 on success; non-zero on error (C caller logs a warning and skips)
 
-Config (env):
-  AIMEE_EMBEDDER_URL  base URL of embedder-server (default http://embedder:8080)
+Config (env), in precedence order:
+  AIMEE_EMBEDDER_URL  base URL of the embedder service (pins the embedder)
+  AIMEE_LLM_URL       base URL of the unified aimee-llm container (one knob for
+                      embed + rerank + synth); used when AIMEE_EMBEDDER_URL is unset
+  (fallback)          http://embedder:8080 (legacy compose embedder service)
 
 Usage:
   embedding_command: "python3 /opt/aimee/scripts/embed-remote.py"
@@ -24,7 +27,11 @@ import sys
 import urllib.error
 import urllib.request
 
-ENDPOINT = os.environ.get("AIMEE_EMBEDDER_URL", "http://embedder:8080").rstrip("/")
+ENDPOINT = (
+    os.environ.get("AIMEE_EMBEDDER_URL")
+    or os.environ.get("AIMEE_LLM_URL")
+    or "http://embedder:8080"
+).rstrip("/")
 TIMEOUT = int(os.environ.get("AIMEE_EMBEDDER_TIMEOUT", "30"))
 
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -468,6 +468,9 @@ ENV_DESC = {
     "AIMEE_WORKTREE_GC_DAYS": ("Server runtime", "Age threshold (days) for worktree GC."),
     "AIMEE_SOCK": ("Server runtime", "Sandbox helper socket path."),
     # Knowledge base
+    "AIMEE_LLM_URL": ("Knowledge base (aimee-kb)", "One knob: base URL of the aimee-llm container the kb calls for embedding (/embed), reranking (/rerank) AND synthesis (curator Tier-A + Tier-B at {url}/v1). The kb runs no model itself. AIMEE_EMBEDDER_URL/AIMEE_RERANKER_URL override per service. See docs/KB_LLM_BACKENDS.md."),
+    "AIMEE_LLM_MODEL": ("Knowledge base (aimee-kb)", "Model label sent to AIMEE_LLM_URL's chat endpoint (single-model gateways ignore it). Default 'aimee-synth'."),
+    "AIMEE_EMBEDDER_URL": ("Knowledge base (aimee-kb)", "Embedder endpoint override (/embed, /embed_batch); takes precedence over AIMEE_LLM_URL for embedding."),
     "AIMEE_KB_API_URL": ("Knowledge base (aimee-kb)", "aimee-kb HTTP API base URL."),
     "AIMEE_KB_API_BEARER_TOKEN": ("Knowledge base (aimee-kb)", "Bearer token for the aimee-kb API."),
     "AIMEE_KB_API_CA_BUNDLE": ("Knowledge base (aimee-kb)", "CA bundle path for verifying the aimee-kb TLS certificate."),

--- a/scripts/rerank-remote.py
+++ b/scripts/rerank-remote.py
@@ -18,8 +18,13 @@ Contract:
   stdout: JSON [score0, score1, ...]   (same length/order)
   exit 0 on success; non-zero on error (C caller logs + falls back).
 
-Config (env):
-  AIMEE_EMBEDDER_URL  base URL of embedder-server (default http://embedder:8080)
+Config (env), in precedence order:
+  AIMEE_RERANKER_URL  base URL of the reranker service (pins rerank independently
+                      of the embedder)
+  AIMEE_EMBEDDER_URL  base URL of the embedder service (rerank shares it by default)
+  AIMEE_LLM_URL       base URL of the unified aimee-llm container (one knob for
+                      embed + rerank + synth)
+  (fallback)          http://embedder:8080 (legacy compose embedder service)
   AIMEE_RERANK_TIMEOUT  request timeout seconds (default 30)
 
 Usage:
@@ -31,7 +36,12 @@ import sys
 import urllib.error
 import urllib.request
 
-ENDPOINT = os.environ.get("AIMEE_EMBEDDER_URL", "http://embedder:8080").rstrip("/")
+ENDPOINT = (
+    os.environ.get("AIMEE_RERANKER_URL")
+    or os.environ.get("AIMEE_EMBEDDER_URL")
+    or os.environ.get("AIMEE_LLM_URL")
+    or "http://embedder:8080"
+).rstrip("/")
 TIMEOUT = int(os.environ.get("AIMEE_RERANK_TIMEOUT", "30"))
 
 

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -1144,6 +1144,12 @@ const char *config_embedding_command(const config_t *cfg, const char *requested)
    const char *env = getenv("AIMEE_EMBEDDER_URL");
    if (env && env[0])
       return env;
+   /* AIMEE_LLM_URL: the single unified-container knob also drives embedding (the
+    * same aimee-llm container serves /embed). AIMEE_EMBEDDER_URL takes precedence
+    * when an operator pins the embedder somewhere else. */
+   env = getenv("AIMEE_LLM_URL");
+   if (env && env[0])
+      return env;
    return "builtin";
 }
 

--- a/src/kb_curator_provider.c
+++ b/src/kb_curator_provider.c
@@ -2,8 +2,14 @@
 
 #include "kb_curator_provider.h"
 
+#include <stdio.h>  /* snprintf — AIMEE_LLM_URL -> {base}/v1 */
 #include <stdlib.h> /* getenv */
 #include <string.h>
+
+/* Model name sent to the unified aimee-llm gateway when none is configured. The
+ * gateway serves a single baked model and ignores the request's model field, so
+ * this is a label; an operator can override it with AIMEE_LLM_MODEL. */
+#define AIMEE_LLM_DEFAULT_MODEL "aimee-synth"
 
 kb_curator_tier_t kb_curator_stage_tier(kb_curator_stage_t stage)
 {
@@ -55,26 +61,53 @@ int kb_curator_provider_for_stage(const config_t *cfg, kb_curator_stage_t stage,
       api_key = cfg->kb_curator_provider_api_key;
    }
 
-   /* Env bridge: when a tier has no config provider, fall back to the curator's
-    * LLM_ENDPOINT/LLM_MODEL/LLM_API_KEY env (the interface the bundled-Gemma
-    * deployment and the python sidecars use). This applies to TIER-A ONLY: the
-    * bundled model (Gemma 3n E4B) is a Tier-A model, so letting it serve the
-    * reasoning stages would be exactly the weak-model-poisons-the-graph case §2a
-    * guards against. Tier-B takes a capable provider from tier_b.* config or it
-    * stays idle — no env fallback. A config provider for the tier still takes
-    * precedence. Whole-provider fallback (base+model+key as a unit). */
+   /* Env fallback when a tier has no config provider, in precedence order:
+    *
+    *  1. AIMEE_LLM_URL — the single "point me at the unified aimee-llm container"
+    *     knob. It is the operator explicitly designating one CAPABLE container
+    *     for the whole LLM surface, so it drives BOTH tiers via that container's
+    *     OpenAI chat endpoint ({AIMEE_LLM_URL}/v1). This is the only env fallback
+    *     Tier-B accepts — see (2).
+    *  2. LLM_ENDPOINT — TIER-A ONLY. It is the small-model interface (the
+    *     zero-config CPU sibling points Tier-A here); letting a small model serve
+    *     the reasoning stages is the weak-model-poisons-the-graph case the tier
+    *     split guards against, so Tier-B never falls back to it.
+    *
+    * A config provider for the tier (checked above) still wins. Whole-provider
+    * fallback: base+model+key move as a unit. */
+   static __thread char synth_url[512];
    if (!base_url[0])
    {
-      if (kb_curator_stage_tier(stage) != KB_CURATOR_TIER_A)
-         return 0; /* Tier-B: capable provider via tier_b.* config, or idle */
-      const char *env_ep = getenv("LLM_ENDPOINT");
-      if (!env_ep || !env_ep[0])
-         return 0; /* neither config nor env — the stage stays idle */
-      const char *env_model = getenv("LLM_MODEL");
-      const char *env_key = getenv("LLM_API_KEY");
-      base_url = env_ep;
-      model = (env_model && env_model[0]) ? env_model : "";
-      api_key = (env_key && env_key[0]) ? env_key : "";
+      const char *llm_url = getenv("AIMEE_LLM_URL");
+      if (llm_url && llm_url[0])
+      {
+         /* AIMEE_LLM_URL is the container base (no /v1); derive the chat endpoint
+          * unless the operator already included it. */
+         size_t n = strlen(llm_url);
+         while (n > 0 && llm_url[n - 1] == '/')
+            n--;
+         int has_v1 = (n >= 3 && strncmp(llm_url + n - 3, "/v1", 3) == 0);
+         snprintf(synth_url, sizeof(synth_url), "%.*s%s", (int)n, llm_url, has_v1 ? "" : "/v1");
+         const char *env_model = getenv("AIMEE_LLM_MODEL");
+         base_url = synth_url;
+         model = (env_model && env_model[0]) ? env_model : AIMEE_LLM_DEFAULT_MODEL;
+         api_key = ""; /* keyless container on a trusted network */
+      }
+      else if (kb_curator_stage_tier(stage) == KB_CURATOR_TIER_A)
+      {
+         const char *env_ep = getenv("LLM_ENDPOINT");
+         if (!env_ep || !env_ep[0])
+            return 0; /* neither config nor env — the stage stays idle */
+         const char *env_model = getenv("LLM_MODEL");
+         const char *env_key = getenv("LLM_API_KEY");
+         base_url = env_ep;
+         model = (env_model && env_model[0]) ? env_model : "";
+         api_key = (env_key && env_key[0]) ? env_key : "";
+      }
+      else
+      {
+         return 0; /* Tier-B with no config and no AIMEE_LLM_URL — stays idle */
+      }
    }
 
    out->base_url = base_url;

--- a/src/tests/test_kb_curator_provider.c
+++ b/src/tests/test_kb_curator_provider.c
@@ -13,6 +13,8 @@ static void clear_llm_env(void)
    unsetenv("LLM_ENDPOINT");
    unsetenv("LLM_MODEL");
    unsetenv("LLM_API_KEY");
+   unsetenv("AIMEE_LLM_URL");
+   unsetenv("AIMEE_LLM_MODEL");
 }
 
 static void test_tier_classification(void)
@@ -130,6 +132,53 @@ static void test_env_bridge(void)
    printf("kb_curator_provider: env bridge (Tier-A only; Tier-B needs config) ok\n");
 }
 
+/* AIMEE_LLM_URL — the single "capable container" knob — drives BOTH tiers via
+ * {AIMEE_LLM_URL}/v1, deriving the chat endpoint + a default model (keyless). It
+ * is the only env fallback Tier-B accepts. A config provider still wins. */
+static void test_aimee_llm_url(void)
+{
+   clear_llm_env();
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   setenv("AIMEE_LLM_URL", "http://10.100.0.1:8742", 1);
+
+   provider_def_t a, b;
+   /* Tier-A derives {url}/v1 + default model, keyless. */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 1);
+   assert(strcmp(a.base_url, "http://10.100.0.1:8742/v1") == 0);
+   assert(strcmp(a.model, "aimee-synth") == 0);
+   assert(a.api_key == NULL); /* keyless container => no bearer */
+   /* Tier-B also resolves to the same capable container (the one env fallback
+    * Tier-B accepts). */
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_SYNTHESIZE, &b) == 1);
+   assert(strcmp(b.base_url, "http://10.100.0.1:8742/v1") == 0);
+   assert(strcmp(b.model, "aimee-synth") == 0);
+
+   /* Trailing slash and an already-/v1 URL both normalize to exactly one /v1. */
+   setenv("AIMEE_LLM_URL", "http://host:8742/", 1);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 1);
+   assert(strcmp(b.base_url, "http://host:8742/v1") == 0);
+   setenv("AIMEE_LLM_URL", "http://host:8742/v1", 1);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_JUDGE, &b) == 1);
+   assert(strcmp(b.base_url, "http://host:8742/v1") == 0);
+
+   /* AIMEE_LLM_MODEL overrides the default model label. */
+   setenv("AIMEE_LLM_URL", "http://host:8742", 1);
+   setenv("AIMEE_LLM_MODEL", "gemma-4-12b", 1);
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 1);
+   assert(strcmp(a.model, "gemma-4-12b") == 0);
+
+   /* A config provider still wins over AIMEE_LLM_URL. */
+   snprintf(cfg.kb_curator_provider_base_url, sizeof(cfg.kb_curator_provider_base_url),
+            "http://pinned:9000/v1");
+   snprintf(cfg.kb_curator_provider_model, sizeof(cfg.kb_curator_provider_model), "pinned");
+   assert(kb_curator_provider_for_stage(&cfg, KB_CURATOR_STAGE_EXTRACT_DOCS, &a) == 1);
+   assert(strcmp(a.base_url, "http://pinned:9000/v1") == 0);
+
+   clear_llm_env();
+   printf("kb_curator_provider: AIMEE_LLM_URL drives both tiers ok\n");
+}
+
 int main(void)
 {
    clear_llm_env();
@@ -138,6 +187,7 @@ int main(void)
    test_tier_a_resolves();
    test_tier_b_resolves();
    test_env_bridge();
+   test_aimee_llm_url();
    printf("kb_curator_provider: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
Implements **P1** of the kb LLM-backend redesign (proposal: `docs/proposals/pending/kb-llm-endpoints-and-default-cpu.md`).

## Principle
aimee-kb runs **no** model runtime — it calls an external `aimee-llm` container (CPU/GPU) or endpoint. This PR is the **config surface** so the kb points at a backend with one knob, and removes the dead baked defaults that silently broke split deploys.

## Config surface (all optional, precedence: per-service > `AIMEE_LLM_URL` > builtin/auto)
| Var | Drives |
| --- | --- |
| `AIMEE_LLM_URL` | embed `/embed` + rerank `/rerank` + synth (curator Tier-A **and** Tier-B at `{url}/v1`) |
| `AIMEE_EMBEDDER_URL` | embedder only (override) |
| `AIMEE_RERANKER_URL` | reranker only (split from embedder) |
| `AIMEE_EMBEDDING_DIM` | dim — default **1024** (CPU/0.6B); set **2560** for GPU/4B |
| `LLM_ENDPOINT` | Tier-A synth only (legacy small-model interface) |

- **Tier-B** accepts only the `AIMEE_LLM_URL` fallback (operator explicitly naming one *capable* container); `LLM_ENDPOINT` stays Tier-A-only (weak-model-poisons-the-graph guard preserved).
- Consumed by the C in-process embed path, `embed-remote.py`, `rerank-remote.py`, and `kb_curator_provider` (both tiers).
- Removes dead `embedder:8080`/`llm:8080` `ENV` from the **kb `Dockerfile`** (`Dockerfile.combined` keeps them — its topology ships those services).

## Tests
Extend `unit-test-kb-curator-provider`: `AIMEE_LLM_URL` drives both tiers, `/v1` normalization (trailing slash / already-`/v1`), `AIMEE_LLM_MODEL` override, config-provider-wins. Built + passing; clang-format clean; python sidecars syntax-checked and precedence verified.

## Docs
`docs/KB_LLM_BACKENDS.md` (operator reference: tiers, zero-config default, precedence, dim/re-embed, examples, auth-off), README link, and the proposal (which also covers **P2** — the zero-config default-CPU-sibling packaging, deploy-layer, not in this PR).

## Notes
`.254` stays on the GPU; the `aimee-kb` plugin manifest is updated to the one-knob `AIMEE_LLM_URL=http://10.100.0.1:8742` + `AIMEE_EMBEDDING_DIM=2560`. Supersedes proposal PR #693 (rejected baked-into-image approach).

🤖 Generated with [Claude Code](https://claude.com/claude-code)