### PR TITLE
feat(gateway): P4 — route the delegate model-call loop through the pipeline

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -317,7 +317,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
-            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c gateway_policy.c gateway_pipeline.c \
+            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c gateway_policy.c gateway_pipeline.c gateway_delegate.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
             trajectory_export.c trajectory_batch.c \

--- a/src/gateway_delegate.c
+++ b/src/gateway_delegate.c
@@ -1,0 +1,78 @@
+/* gateway_delegate.c: P4 — wire aimee's own outbound model-call loop into the gateway
+ * pipeline. See gateway_delegate.h for the scope/threat model. This module composes the
+ * shared gw_pipeline_run_request runner (gateway_pipeline.c) with the shared
+ * gateway_policy_* primitives (gateway_policy.c) — one implementation of tool-policing,
+ * called from both the ingresses and here. */
+#include "aimee.h" /* size macros for agent_types.h (MAX_PATH_LEN), via gateway_policy.h */
+#include "gateway_delegate.h"
+
+#include "cJSON.h"
+#include "gateway_pipeline.h"
+#include "gateway_policy.h"
+#include "log.h"
+
+gw_tool_shape_t gateway_delegate_tool_shape(int anthropic, int chatgpt, int gemini)
+{
+   if (gemini)
+      return GW_TOOL_SHAPE_UNSUPPORTED; /* functionDeclarations: name not at tool.name */
+   if (anthropic || chatgpt)
+      return GW_TOOL_SHAPE_NAMED;        /* anthropic + /responses both carry a flat tool.name */
+   return GW_TOOL_SHAPE_FUNCTION_NESTED; /* openai /chat/completions */
+}
+
+/* Per-call userdata for the tool-policing stage: the runtime shape + delegate gate
+ * (a static stage list cannot carry these, so they ride in the stage's ud). */
+typedef struct
+{
+   gw_tool_shape_t shape;
+   int is_delegate;
+} tp_ud_t;
+
+/* The ONLY stage the delegate/primary loop runs. Memory + model-pin are deliberately
+ * omitted (ingress concerns — see header); do not add them here without revisiting the
+ * double-inject / fallback-clobber rationale. No-op for the primary and for an
+ * unsupported tool shape (the latter logs when there was something to police). */
+static int gw_stage_tool_policing(gw_request_t *r, void *ud)
+{
+   const tp_ud_t *u = (const tp_ud_t *)ud;
+
+   if (!u->is_delegate)
+      return 0; /* primary shares the pipeline but is not policed here */
+
+   if (u->shape == GW_TOOL_SHAPE_UNSUPPORTED)
+   {
+      cJSON *tools = cJSON_GetObjectItemCaseSensitive(r->raw, "tools");
+      if (gateway_prevent_subagents_enabled() && cJSON_IsArray(tools) &&
+          cJSON_GetArraySize(tools) > 0)
+         LOG_WARN("gateway", "tool-policing unsupported for this provider's tool shape; "
+                             "subagent-strip skipped on a delegate request");
+      return 0;
+   }
+
+   return gateway_policy_apply_request(r->raw, u->shape == GW_TOOL_SHAPE_FUNCTION_NESTED ? 1 : 0);
+}
+
+int gateway_delegate_run_request_pipeline(cJSON *req, gw_tool_shape_t shape, int is_delegate)
+{
+   tp_ud_t ud = {shape, is_delegate};
+   gw_request_t r = {
+       .raw = req,
+       .driver = NULL,
+       .ag = NULL,
+       /* The tool-policing stage keys off `ud->shape`, NOT these IR fields, so
+        * serving_api/mem_target/parity/stream are inert here — placeholders, not an
+        * accurate label of the provider (gw_api_t has no gemini value, and a NAMED
+        * shape covers both anthropic and openai /responses). If a future stage that
+        * DOES read serving_api/mem_target is added to this loop, derive them properly
+        * from the driver first. */
+       .serving_api = shape == GW_TOOL_SHAPE_FUNCTION_NESTED ? GW_API_OPENAI : GW_API_ANTHROPIC,
+       .mem_target = GW_MEM_ANTHROPIC_MESSAGES,
+       .parity = 0,
+       .stream = 0,
+   };
+   /* One documented stage. (Not a file-scope const because the ud is per-call.) */
+   const gw_stage_t stages[] = {
+       {gw_stage_tool_policing, &ud, "tool_policing"},
+   };
+   return gw_pipeline_run_request(&r, stages, sizeof(stages) / sizeof(stages[0]));
+}

--- a/src/headers/gateway_delegate.h
+++ b/src/headers/gateway_delegate.h
@@ -1,0 +1,45 @@
+/* gateway_delegate.h: P4 of the universal gateway — route aimee's OWN outbound
+ * model-call loop (primary + delegate, the shared agent_execute_with_tools_internal)
+ * through the same gateway_pipeline the proxy ingresses use, so a config-enabled
+ * tool-policing policy applies to delegate calls too.
+ *
+ * Scope is deliberately narrow: the loop runs ONLY the tool-policing stage. The
+ * memory and model-pin stages are ingress concerns and are NOT run here — see
+ * gateway_delegate.c for the rationale (memory would double-inject over the context
+ * agent_build_exec_context_ex already assembles; model-pin would clobber the per-turn
+ * fallback model). Both the request- and response-side policing are gated to delegate
+ * calls (role != NULL); the primary shares the pipeline but is governed by the
+ * agent-loop's own subagent guardrails, so policing it here would neuter aimee's own
+ * delegation. */
+#ifndef DEC_GATEWAY_DELEGATE_H
+#define DEC_GATEWAY_DELEGATE_H 1
+
+struct cJSON;
+
+/* Where a tool entry's name lives in the freshly-built provider request body — the
+ * flag gateway_policy_apply_request needs. Derived from the provider, not configured. */
+typedef enum
+{
+   GW_TOOL_SHAPE_NAMED = 0,           /* anthropic + openai /responses: flat tool.name */
+   GW_TOOL_SHAPE_FUNCTION_NESTED = 1, /* openai /chat/completions: tool.function.name */
+   GW_TOOL_SHAPE_UNSUPPORTED = -1,    /* gemini: functionDeclarations — not policed (logged) */
+} gw_tool_shape_t;
+
+/* Map the provider flags already computed in the loop to a tool-name shape. A future
+ * provider falls through to FUNCTION_NESTED only if it is neither anthropic, chatgpt
+ * (responses), nor gemini — callers that add a provider with a novel tool shape must
+ * extend this. */
+gw_tool_shape_t gateway_delegate_tool_shape(int anthropic, int chatgpt, int gemini);
+
+/* Run the outbound request pipeline (tool-policing only) over a freshly-built provider
+ * request `req`, mutating it in place. `is_delegate` (role != NULL) gates the strip:
+ * for the primary it is a no-op (the call still goes "through the pipeline" — criterion
+ * 5 — but does not police the primary's own tools). `shape` selects where tool names
+ * live; GW_TOOL_SHAPE_UNSUPPORTED logs a warning when there were tools to police and
+ * skips the strip (observable, not silent). `req` is BORROWED: the pipeline never frees
+ * or replaces it (see gateway_pipeline.h). Returns total interventions (>=0) or <0 on a
+ * hard stage error (the caller must then abort the turn without forwarding `req`). */
+int gateway_delegate_run_request_pipeline(struct cJSON *req, gw_tool_shape_t shape,
+                                          int is_delegate);
+
+#endif /* DEC_GATEWAY_DELEGATE_H */

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -13,6 +13,8 @@
 #include "delegate_driver.h"
 #include "delegate_role.h"
 #include "delegate_xml_fallback.h"
+#include "gateway_delegate.h"
+#include "gateway_policy.h"
 #include "http_retry.h"
 #include "log.h"
 #include "middleware.h"
@@ -703,6 +705,20 @@ native_provider_http:
       else
          req = agent_build_request_openai(&fb_agent, messages, active_tools, tok, temperature);
 
+      /* Universal-gateway P4: run aimee's own outbound call through the same request
+       * pipeline the proxy ingresses use, so a config-enabled tool-policing policy
+       * (gateway_prevent_subagents) applies to delegate calls. Mutates req in place;
+       * a <0 return is a hard stage failure — abort rather than forward a half-altered
+       * request (mirrors anthropic_http.c). Gated to delegates (role != NULL); the
+       * primary shares the pipeline but is not policed here. */
+      if (gateway_delegate_run_request_pipeline(
+              req, gateway_delegate_tool_shape(anthropic, chatgpt, gemini), role != NULL) < 0)
+      {
+         snprintf(out->error, sizeof(out->error), "gateway request pipeline failed");
+         cJSON_Delete(req);
+         break;
+      }
+
       char *body = cJSON_PrintUnformatted(req);
       cJSON_Delete(req);
       if (!body)
@@ -889,6 +905,15 @@ native_provider_http:
          }
       }
       free(response_body);
+
+      /* Universal-gateway P4 (response side): police a denied tool_use the model
+       * emitted anyway. Shape-agnostic — operates on the normalized parsed_response_t,
+       * so it covers every provider (incl. gemini). Config-gated internally and gated
+       * to delegate calls here: the primary spawns delegates via the very Task/Subagent
+       * tool this would drop, so policing the primary's response would neuter aimee's
+       * own delegation. Drop count discarded, as in the ingress (anthropic_http.c). */
+      if (role != NULL)
+         gateway_policy_police_parsed_response(&parsed);
 
       /* Log response trace */
       agent_trace_log(0, turn, "response", parsed.content ? parsed.content : "(tool_calls)", NULL,

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -44,6 +44,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/minimax_profile.o \
                              $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o $(OBJDIR)/models_dev_cache.o \
                              $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
+                             $(OBJDIR)/gateway_delegate.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o \
                              $(PLATFORM_AGENT_OBJS)
 
 TEST_MCP_CLIENT_OBJS = $(OBJDIR)/server/mcp_client.o \
@@ -181,6 +182,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-anthropic-http-streaming-p2c \
                $(TESTPREFIX)/unit-test-gateway-policy \
                $(TESTPREFIX)/unit-test-gateway-pipeline \
+               $(TESTPREFIX)/unit-test-gateway-p4-delegate \
                $(TESTPREFIX)/unit-test-hud \
                $(TESTPREFIX)/unit-test-coord-jobs \
                $(TESTPREFIX)/unit-test-plan-waves \
@@ -1668,6 +1670,9 @@ $(TESTPREFIX)/unit-test-gateway-policy: $(OBJDIR)/tests/test_gateway_policy.o $(
 $(TESTPREFIX)/unit-test-gateway-pipeline: $(OBJDIR)/tests/test_gateway_pipeline.o $(OBJDIR)/gateway_pipeline.o
 	$(TESTLINK_MIN) -o $@ $^ $(L_MINIMAL)
 
+$(TESTPREFIX)/unit-test-gateway-p4-delegate: $(OBJDIR)/tests/test_gateway_p4_delegate.o $(OBJDIR)/gateway_delegate.o $(OBJDIR)/gateway_policy.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/json_fluent.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_MINIMAL)
+
 $(OBJDIR)/tests/%.o: tests/%.c
 	@mkdir -p $(dir $@)
 	$(CC) -c $(TEST_C_FLAGS) -o $@ $<
@@ -2705,6 +2710,7 @@ $(TESTPREFIX)/unit-test-otel: $(OBJDIR)/tests/test_otel.o \
                      $(OBJDIR)/server/agent_bridge.o $(OBJDIR)/server/anthropic_shape.o $(OBJDIR)/server/tool_call_args.o \
                      $(OBJDIR)/server/agent_request_shaping.o \
                      $(OBJDIR)/server/http_retry.o \
+                     $(OBJDIR)/gateway_delegate.o $(OBJDIR)/gateway_pipeline.o $(OBJDIR)/gateway_policy.o \
                      $(TEST_CORE_OBJS) \
                      $(PLATFORM_AGENT_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)

--- a/src/tests/test_gateway_p4_delegate.c
+++ b/src/tests/test_gateway_p4_delegate.c
@@ -1,0 +1,222 @@
+/* test_gateway_p4_delegate.c: universal-gateway P4 — the delegate/primary model-call
+ * loop run through the gateway pipeline. Pure tests of gateway_delegate_* plus the
+ * response-side police as the loop invokes it. config_load, guardrails_canonical_tool_name
+ * and aimee_log are stubbed so the link stays minimal (their real impls have their own
+ * tests). */
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../headers/config.h"
+#include "../headers/gateway_delegate.h"
+#include "../headers/gateway_policy.h"
+#include "../vendor/headers/cJSON.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+static int g_prevent = 0;
+int config_load(config_t *cfg)
+{
+   if (cfg)
+   {
+      memset(cfg, 0, sizeof(*cfg));
+      cfg->gateway_prevent_subagents = g_prevent;
+   }
+   return 0;
+}
+const char *guardrails_canonical_tool_name(const char *n)
+{
+   if (n && (strcmp(n, "Task") == 0 || strcmp(n, "Agent") == 0))
+      return "Subagent";
+   return n ? n : "";
+}
+/* LOG_WARN in gateway_delegate.c -> aimee_log; swallow it (and count, for the
+ * gemini-warn assertion). */
+static int g_warns = 0;
+void aimee_log(int level, const char *module, const char *fmt, ...)
+{
+   (void)level;
+   (void)module;
+   (void)fmt;
+   g_warns++;
+}
+
+static int has_tool_named(cJSON *req, const char *name, int openai)
+{
+   cJSON *tools = cJSON_GetObjectItemCaseSensitive(req, "tools");
+   cJSON *t;
+   if (!cJSON_IsArray(tools))
+      return 0;
+   cJSON_ArrayForEach(t, tools)
+   {
+      cJSON *n = openai ? cJSON_GetObjectItem(cJSON_GetObjectItem(t, "function"), "name")
+                        : cJSON_GetObjectItem(t, "name");
+      if (cJSON_IsString(n) && strcmp(n->valuestring, name) == 0)
+         return 1;
+   }
+   return 0;
+}
+
+/* (1) delegate + OpenAI (function-nested) shape, policy ON: Task stripped, benign kept. */
+static void test_delegate_openai_strip(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"type\":\"function\",\"function\":{\"name\":\"Read\"}},"
+                            "{\"type\":\"function\",\"function\":{\"name\":\"Task\"}}]}");
+   int n = gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_FUNCTION_NESTED, 1);
+   assert(n == 1);
+   assert(has_tool_named(req, "Read", 1));
+   assert(!has_tool_named(req, "Task", 1));
+   cJSON_Delete(req);
+   PASS("delegate_openai_strip");
+}
+
+/* (2) delegate + flat NAMED shape (anthropic / responses), policy ON: Task stripped. */
+static void test_delegate_named_strip(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"name\":\"Read\"},{\"name\":\"Task\"}]}");
+   int n = gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_NAMED, 1);
+   assert(n == 1);
+   assert(has_tool_named(req, "Read", 0));
+   assert(!has_tool_named(req, "Task", 0));
+   cJSON_Delete(req);
+   PASS("delegate_named_strip");
+}
+
+/* (3) PRIMARY (is_delegate=0), policy ON: Task PRESERVED, no intervention. */
+static void test_primary_not_policed(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"name\":\"Read\"},{\"name\":\"Task\"}]}");
+   int n = gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_NAMED, 0);
+   assert(n == 0);
+   assert(has_tool_named(req, "Task", 0)); /* primary keeps its delegation tool */
+   cJSON_Delete(req);
+   PASS("primary_not_policed");
+}
+
+/* (4) policy OFF (default): serialized request byte-identical pre/post, delegate+primary. */
+static void test_policy_off_byte_identical(void)
+{
+   g_prevent = 0;
+   const char *src = "{\"tools\":[{\"name\":\"Read\"},{\"name\":\"Task\"}],\"model\":\"m\"}";
+   for (int is_delegate = 0; is_delegate <= 1; is_delegate++)
+   {
+      cJSON *req = cJSON_Parse(src);
+      char *before = cJSON_PrintUnformatted(req);
+      int n = gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_NAMED, is_delegate);
+      char *after = cJSON_PrintUnformatted(req);
+      assert(n == 0);
+      assert(strcmp(before, after) == 0);
+      free(before);
+      free(after);
+      cJSON_Delete(req);
+   }
+   PASS("policy_off_byte_identical");
+}
+
+/* Build a one-tool_use parsed_response_t with the given tool name (heap arguments,
+ * so the drop path's free() is exercised). */
+static void make_parsed(parsed_response_t *p, const char *tool)
+{
+   memset(p, 0, sizeof(*p));
+   p->is_tool_call = 1;
+   p->call_count = 1;
+   snprintf(p->calls[0].name, sizeof(p->calls[0].name), "%s", tool);
+   p->calls[0].arguments = strdup("{}");
+   snprintf(p->stop_reason, sizeof(p->stop_reason), "tool_use");
+}
+
+/* (5) response-side police: denied tool_use dropped ON, kept OFF. Shape-agnostic. */
+static void test_response_police(void)
+{
+   parsed_response_t p;
+
+   g_prevent = 1;
+   make_parsed(&p, "Task");
+   int dropped = gateway_policy_police_parsed_response(&p);
+   assert(dropped == 1);
+   assert(p.call_count == 0);
+   free(p.calls[0].arguments); /* survivors only; here none survive, but slot is reset */
+
+   g_prevent = 0;
+   make_parsed(&p, "Task");
+   int kept = gateway_policy_police_parsed_response(&p);
+   assert(kept == 0);
+   assert(p.call_count == 1);
+   free(p.calls[0].arguments);
+   PASS("response_police");
+}
+
+/* (6) empty-after-strip: the lone Task tool gone -> tools array AND a forcing
+ * tool_choice are dropped (no `tools: []` reaches the provider). */
+static void test_empty_after_strip(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"name\":\"Task\"}],\"tool_choice\":{\"type\":\"any\"}}");
+   int n = gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_NAMED, 1);
+   assert(n == 1);
+   assert(cJSON_GetObjectItemCaseSensitive(req, "tools") == NULL);
+   assert(cJSON_GetObjectItemCaseSensitive(req, "tool_choice") == NULL);
+   cJSON_Delete(req);
+   PASS("empty_after_strip");
+}
+
+/* (7) gemini UNSUPPORTED shape, policy ON, delegate: req unchanged, warning emitted. */
+static void test_gemini_unsupported_noop(void)
+{
+   g_prevent = 1;
+   g_warns = 0;
+   cJSON *req = cJSON_Parse("{\"tools\":[{\"functionDeclarations\":[{\"name\":\"Task\"}]}]}");
+   char *before = cJSON_PrintUnformatted(req);
+   int n = gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_UNSUPPORTED, 1);
+   char *after = cJSON_PrintUnformatted(req);
+   assert(n == 0);
+   assert(strcmp(before, after) == 0); /* not policed */
+   assert(g_warns == 1);               /* but observable, not silent */
+   free(before);
+   free(after);
+   cJSON_Delete(req);
+   PASS("gemini_unsupported_noop");
+}
+
+/* (8) the model field is never touched (model-pin is deliberately not run here). */
+static void test_model_untouched(void)
+{
+   g_prevent = 1;
+   cJSON *req = cJSON_Parse("{\"model\":\"fallback-model\",\"tools\":[{\"name\":\"Read\"}]}");
+   gateway_delegate_run_request_pipeline(req, GW_TOOL_SHAPE_NAMED, 1);
+   cJSON *m = cJSON_GetObjectItemCaseSensitive(req, "model");
+   assert(cJSON_IsString(m) && strcmp(m->valuestring, "fallback-model") == 0);
+   cJSON_Delete(req);
+   PASS("model_untouched");
+}
+
+/* shape derivation maps each provider flag set to the right shape. */
+static void test_shape_derivation(void)
+{
+   assert(gateway_delegate_tool_shape(1, 0, 0) == GW_TOOL_SHAPE_NAMED);           /* anthropic */
+   assert(gateway_delegate_tool_shape(0, 1, 0) == GW_TOOL_SHAPE_NAMED);           /* responses */
+   assert(gateway_delegate_tool_shape(0, 0, 1) == GW_TOOL_SHAPE_UNSUPPORTED);     /* gemini */
+   assert(gateway_delegate_tool_shape(0, 0, 0) == GW_TOOL_SHAPE_FUNCTION_NESTED); /* openai chat */
+   PASS("shape_derivation");
+}
+
+int main(void)
+{
+   printf("gateway P4 delegate-unification tests:\n");
+   test_shape_derivation();
+   test_delegate_openai_strip();
+   test_delegate_named_strip();
+   test_primary_not_policed();
+   test_policy_off_byte_identical();
+   test_response_police();
+   test_empty_after_strip();
+   test_gemini_unsupported_noop();
+   test_model_untouched();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Universal gateway P4 — delegate unification

Final slice of the `aimee-universal-gateway` proposal. Routes aimee's **own** outbound
model-call loop (the shared primary+delegate `agent_execute_with_tools_internal`) through
the same `gateway_pipeline` the proxy ingresses already use, so a config-enabled
tool-policing policy (`gateway_prevent_subagents`) applies to delegate calls —
**acceptance criterion 5** ("primary and delegate calls share the pipeline; a policy
enabled in config applies to a delegate model call, demonstrated by a test").

### What

- New core module `gateway_delegate.{c,h}` composing the shared `gw_pipeline_run_request`
  runner with the shared `gateway_policy_*` primitives — one implementation of
  tool-policing, called from both the ingresses and here.
- **Request side** (after the provider-build switch, before serialize): tool-policing only.
  Memory and model-pin are deliberately omitted — memory would double-inject over the
  context `agent_build_exec_context_ex` already assembles, and model-pin would clobber the
  per-turn fallback model.
- **Response side** (after the parse switch): reuses `gateway_policy_police_parsed_response`
  on the normalized `parsed_response_t` (shape-agnostic, covers every provider).
- Both sides **gated to delegate calls** (`role != NULL`): the primary spawns delegates via
  the very Task/Subagent tool the policy strips, so policing the primary would neuter
  aimee's own delegation. The primary still runs the pipeline (shares it); the stage is a
  no-op for it.
- Tool-name shape is a typed enum: NAMED (anthropic + openai `/responses`), FUNCTION_NESTED
  (openai chat), UNSUPPORTED (gemini `functionDeclarations`). Gemini's request-side strip is
  a logged warning (observable, not silent); the response-side police still covers it.

### Tests

`src/tests/test_gateway_p4_delegate.c` (9 cases, all green): strip on OpenAI + flat shapes,
primary-not-policed, byte-identical request when policy off, response-side police on/off,
empty-tools drop, gemini UNSUPPORTED warn no-op, model untouched, shape derivation.

### Verification

- `make server` + `make ../aimee` build clean; `make lint` passes.
- gateway + agent-runtime test set green (gateway-p4-delegate, gateway-policy,
  gateway-pipeline, anthropic-http-p2c, anthropic-http-streaming-p2c,
  agent-runtime-messages, openai-chat-policed).
- Roundtable: plan reviewed across rounds (findings folded in); implementation review
  **converged with zero blocking findings**.
