### PR TITLE
deploy(compose): split aimee stack for docker-compose (CPU default + GPU override)

### DIFF
--- a/deploy/compose/aimee.gpu.yaml
+++ b/deploy/compose/aimee.gpu.yaml
@@ -1,0 +1,20 @@
+# GPU override for the aimee split stack. Layer on top of aimee.yaml:
+#
+#   docker compose -f deploy/compose/aimee.yaml -f deploy/compose/aimee.gpu.yaml up -d
+#
+# Runs the unified aimee-llm GPU tier (Qwen3-Embedding-4B / 2560-dim + gemma
+# synth, offloaded via Vulkan/RADV) and re-points the kb's embedding dim to 2560.
+# Passes the host AMD render path (/dev/dri) into the LLM container. Switching a
+# POPULATED kb between the CPU (1024) and GPU (2560) tier is a drop-and-rebuild
+# re-embed (the kb_meta drift guard refuses a stale mismatch).
+services:
+  aimee-llm:
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:gpu}
+    environment:
+      AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}
+    devices:
+      - "/dev/dri:/dev/dri"
+
+  aimee-kb:
+    environment:
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-2560}

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -1,0 +1,110 @@
+# aimee split stack via docker-compose (postgres + aimee-llm + aimee-kb +
+# aimee-server). Runs on Docker or any Docker-API daemon (e.g. LXC2Docker).
+#
+#   docker compose -f deploy/compose/aimee.yaml up -d                 # CPU LLM
+#   docker compose -f deploy/compose/aimee.yaml -f deploy/compose/aimee.gpu.yaml up -d   # GPU LLM
+#
+# The kb runs NO model — it calls the aimee-llm container for embedding,
+# reranking and synthesis via AIMEE_LLM_URL (the one knob; see
+# docs/KB_LLM_BACKENDS.md). aimee-llm is the unified Vulkan llama.cpp container;
+# this base uses the CPU tier (1024-dim). Layer aimee.gpu.yaml for the GPU tier
+# (2560-dim + /dev/dri passthrough). Server /v1 on :8740, kb /v1 on :8741,
+# webchat on :8443.
+name: aimee
+services:
+  postgres:
+    restart: unless-stopped
+    image: pgvector/pgvector:pg17
+    environment:
+      POSTGRES_DB: aimee_shared
+      POSTGRES_USER: aimee
+      POSTGRES_PASSWORD: aimee
+    volumes:
+      - aimee-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aimee -d aimee_shared"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  # Unified llama.cpp/Vulkan container: embed (/embed,/embed_batch), rerank
+  # (/rerank) and synth (/v1/chat/completions). CPU tier here; the kb sends no
+  # bearer, so it runs auth-off (AIMEE_LLM_AUTH_TOKEN empty) on the internal net.
+  aimee-llm:
+    restart: unless-stopped
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:cpu}
+    environment:
+      AIMEE_LLM_PORT: "8742"
+      AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8742/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      # Cold boot loads the baked GGUFs into RAM before /health is OK.
+      start_period: 600s
+
+  aimee-kb:
+    restart: unless-stopped
+    image: ${AIMEE_KB_IMAGE:-ghcr.io/rakuensoftware/aimee-kb:latest}
+    ulimits:
+      stack: 67108864
+    environment:
+      AIMEE_HOME: /var/lib/aimee
+      AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
+      # One knob: embed + rerank + synth all via the aimee-llm container.
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8742}
+      # Embedding dim — CPU tier default 1024; the GPU override sets 2560.
+      AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-1024}
+      AIMEE_KB_HTTP_BIND: "1"
+    command: ["--http-port=8741"]
+    ports:
+      - "8741:8741"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      aimee-llm:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - aimee-kb-home:/var/lib/aimee
+
+  aimee-server:
+    restart: unless-stopped
+    image: ${AIMEE_SERVER_IMAGE:-ghcr.io/rakuensoftware/aimee-server:latest}
+    ulimits:
+      stack: 67108864
+    environment:
+      AIMEE_HOME: /var/lib/aimee
+      AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
+      AIMEE_KB_API_URL: http://aimee-kb:8741
+      AIMEE_SERVER_HTTP_BIND: "1"
+      AIMEE_WEBCHAT_ENABLED: "1"
+      AIMEE_WEBCHAT_USER: ${AIMEE_WEBCHAT_USER:-aimee}
+      AIMEE_WEBCHAT_PASSWORD: ${AIMEE_WEBCHAT_PASSWORD:-aimee-local-dev}
+    ports:
+      - "8740:8740"
+      - "8443:8443"
+    depends_on:
+      aimee-kb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL",
+             "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - aimee-server-home:/var/lib/aimee
+      - aimee-server-workspaces:/var/lib/aimee-workspaces
+
+volumes:
+  aimee-postgres:
+  aimee-kb-home:
+  aimee-server-home:
+  aimee-server-workspaces:


### PR DESCRIPTION
## What
`deploy/compose/aimee.yaml` (CPU default) + `deploy/compose/aimee.gpu.yaml` (GPU override) — the split aimee stack (postgres + aimee-llm + aimee-kb + aimee-server) deployable via `docker compose` against Docker **or LXC2Docker**.

- The kb runs **no model**; it calls the unified `aimee-llm` container via `AIMEE_LLM_URL` (the P1 one-knob) for embed/rerank/synth.
- Base = CPU tier (1024-dim). GPU override → `aimee-llm-gpu` image, `ngl=99`, `/dev/dri` passthrough, `AIMEE_EMBEDDING_DIM=2560`.
- `docker compose -f deploy/compose/aimee.yaml [-f deploy/compose/aimee.gpu.yaml] up -d`.

## Validated live on .254
Migrated `.254` off the tierd plugins to this compose stack against LXC2Docker:
- GPU **Vulkan (RADV GFX1100)** init under compose `devices: /dev/dri`; `/embed`→2560-dim, auth-off.
- kb `halfvec(2560)`, `embed_ok` via the GPU; server `/v1` auth-enforced; **server→kb** ok; webchat `:8443` (admin) login 200.

## Notes
This is the deploy artifact. The broader unified-llm cutover of the *root* `compose.yaml`/`compose.server.yaml` (retire the torch embedder default) + the e2e-docker stub plumbing for the unified container is tracked separately (it needs an `aimee-llm` CI stub mode so e2e can build it cheaply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)