### PR TITLE
feat(compose): unified-llm cutover — kb topologies default to aimee-llm

### DIFF
--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -29,8 +29,12 @@ services:
       timeout: 5s
       retries: 5
 
+  # LEGACY torch embedder — retired from the default topology by the unified-llm
+  # cutover (the kb now uses the `aimee-llm` container via AIMEE_LLM_URL). Kept
+  # behind a profile for rollback: `docker compose --profile legacy-embedder up`.
   embedder:
     restart: unless-stopped
+    profiles: ["legacy-embedder"]
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
     image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
@@ -78,16 +82,12 @@ services:
     environment:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
-      AIMEE_EMBEDDER_URL: http://embedder:8080
-      # Must match the embedder model's output dim (empty = config default 2560).
+      # One knob: embed + rerank + synth (curator Tier-A & B at {url}/v1) via the
+      # unified aimee-llm container. The kb runs no model. Override
+      # AIMEE_EMBEDDER_URL / AIMEE_RERANKER_URL to pin a service elsewhere.
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}
+      # Embedding dim — empty = config default 1024 (CPU tier); set 2560 for GPU.
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
-      # Curator LLM (doc/code extraction, entity/claim passes). Defaults to the
-      # bundled `llm` sidecar (Gemma 3n E4B); BYO by setting LLM_ENDPOINT to your
-      # own OpenAI-compatible endpoint (and drop the `llm` service below). The
-      # curator runs in the background drain, so the kb never blocks on it.
-      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
-      LLM_MODEL: ${LLM_MODEL:-gemma-4-e4b-it}
-      LLM_API_KEY: ${LLM_API_KEY:-}
     # aimee-kb serves /v1 over HTTP only; the legacy --socket transport was retired (#2747).
     command: ["--http-port=8741"]
     ports:
@@ -95,7 +95,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      embedder:
+      aimee-llm:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
@@ -192,6 +192,31 @@ services:
       retries: 5
       # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
       start_period: 1200s
+
+  # Unified llama.cpp+Vulkan container — the kb's single LLM backend (embed +
+  # rerank + synth on :8080). DEFAULT (the unified-llm cutover; the legacy
+  # embedder/llm services moved behind profiles). CPU tier by default; GPU =
+  # AIMEE_LLM_IMAGE=...-gpu + AIMEE_LLM_NGL=99 + /dev/dri (deploy/compose/aimee.gpu.yaml).
+  # Internal only — kb reaches it at aimee-llm:8080; auth-off (kb sends no bearer).
+  # CI/dev: AIMEE_LLM_DOCKERFILE=Dockerfile.aimee-llm-stub + AIMEE_LLM_STUB=1.
+  aimee-llm:
+    restart: unless-stopped
+    image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:cpu}
+    build:
+      context: .
+      dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}
+    environment:
+      AIMEE_LLM_PORT: "8080"
+      AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
+      AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
+      AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
+      AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 300s
 
 volumes:
   aimee-kb-home:

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,8 +14,14 @@ services:
       timeout: 5s
       retries: 5
 
+  # LEGACY torch embedder. Retired from the default topology by the unified-llm
+  # cutover — the kb now embeds/reranks/synthesizes against the `aimee-llm`
+  # container (below) via AIMEE_LLM_URL. Kept behind a profile for rollback /
+  # comparison: `docker compose --profile legacy-embedder up` (and point the kb
+  # back with AIMEE_EMBEDDER_URL=http://embedder:8080).
   embedder:
     restart: unless-stopped
+    profiles: ["legacy-embedder"]
     # Published image (pushed to ghcr on every merge to main); override
     # AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
     image: ${AIMEE_EMBEDDER_IMAGE:-ghcr.io/rakuensoftware/aimee-embedder:latest}
@@ -63,16 +69,13 @@ services:
     environment:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
-      # Real semantic embeddings via the resident embedder service.
-      AIMEE_EMBEDDER_URL: http://embedder:8080
-      # Must match the embedder model's output dim (empty = config default 2560).
+      # One knob: embed (/embed) + rerank (/rerank) + synth (curator Tier-A & B,
+      # at {url}/v1) all via the unified aimee-llm container. The kb runs no model.
+      # Override AIMEE_EMBEDDER_URL / AIMEE_RERANKER_URL to pin a service elsewhere.
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}
+      # Embedding dim — empty = config default 1024 (CPU tier); set 2560 for the
+      # GPU 4B tier (changing it against a populated kb forces a re-embed).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
-      # Curator/synthesis LLM. Defaults to the bundled `llm` sidecar (Gemma 3n
-      # E4B, below); BYO by pointing LLM_ENDPOINT at your own OpenAI-compatible
-      # endpoint (and drop the `llm` service: `docker compose up --scale llm=0`).
-      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
-      LLM_MODEL: ${LLM_MODEL:-gemma-4-e4b-it}
-      LLM_API_KEY: ${LLM_API_KEY:-}
     # aimee-kb serves /v1 over HTTP only; the legacy --socket transport was retired (#2747).
     command: ["--http-port=8741"]
     ports:
@@ -80,7 +83,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      embedder:
+      aimee-llm:
         condition: service_healthy
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8741/v1/health"]
@@ -119,36 +122,34 @@ services:
       # Long: the cold first boot downloads the multi-GB GGUF before /health is OK.
       start_period: 1200s
 
-  # Unified llama.cpp+Vulkan container (P7 cutover target) — collapses `embedder`
-  # + `llm` into one image serving embed+rerank+synth from baked-in GGUFs behind
-  # the gateway (preserves the /embed+/embed_batch+/rerank contract on :8080).
-  # Profile-gated so it does not disturb the default topology pre-cutover. To cut
-  # over (see docs/runbooks/unified-llm-cutover.md): bring this up
-  # (`--profile unified-llm`), point the kb at it
-  # (AIMEE_EMBEDDER_URL=http://aimee-llm:8080, LLM_ENDPOINT=http://aimee-llm:8080/v1),
-  # re-embed the corpus, then drop the `embedder` + `llm` services. CPU image by
-  # default; AIMEE_LLM_IMAGE=...-gpu + a GPU device for the offloaded tier.
+  # Unified llama.cpp+Vulkan container: one image serving embed + rerank + synth
+  # from baked-in GGUFs behind the gateway (the /embed,/embed_batch,/rerank,
+  # /v1/chat/completions contract). The kb's single LLM backend (DEFAULT now —
+  # the unified-llm cutover; the legacy embedder/llm services moved behind
+  # profiles). CPU tier by default; GPU = AIMEE_LLM_IMAGE=...-gpu + AIMEE_LLM_NGL=99
+  # + a /dev/dri device (see deploy/compose/aimee.gpu.yaml). Internal only — the
+  # kb reaches it at aimee-llm:8080. Auth-off (the kb sends no bearer).
+  # CI/dev: AIMEE_LLM_DOCKERFILE=Dockerfile.aimee-llm-stub + AIMEE_LLM_STUB=1
+  # builds a tiny python-only stub (no llama.cpp / GGUFs) — see e2e-matrix.sh.
   aimee-llm:
     restart: unless-stopped
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:cpu}
     build:
       context: .
-      dockerfile: Dockerfile.aimee-llm
-    profiles: ["unified-llm"]
+      dockerfile: ${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm}
     environment:
+      AIMEE_LLM_PORT: "8080"
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-0}
       AIMEE_LLM_AUTH_TOKEN: ${AIMEE_LLM_AUTH_TOKEN:-}
-    volumes:
-      - aimee-llm-models:/root/.cache/llama.cpp
-    ports:
-      - "8080:8080"
+      # CI/dev stub (off in prod): deterministic embed/rerank/synth, no models.
+      AIMEE_LLM_STUB: ${AIMEE_LLM_STUB:-}
+      AIMEE_LLM_STUB_DIM: ${AIMEE_LLM_STUB_DIM:-}
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://127.0.0.1:8080/health"]
-      interval: 30s
+      interval: 10s
       timeout: 5s
       retries: 5
-      # Models are baked into the image, so the cold boot only loads them into
-      # RAM/VRAM (no download); still generous for the largest GPU tier.
+      # Baked GGUFs load into RAM/VRAM (no download); generous for the GPU tier.
       start_period: 300s
 
 volumes:

--- a/scripts/aimee-kb-docker-smoke.sh
+++ b/scripts/aimee-kb-docker-smoke.sh
@@ -133,22 +133,31 @@ check "POST memory.find_facts (fusion)" '"facts"' -X POST -H 'content-type: appl
                                                -d '{"query":"docker smoke test","limit":3,"graph_code_fusion_state":"on"}' \
                                                "${KB_URL}/v1/actions/memory.find_facts"
 
-bold "==> Embedder round-trip (in-network, via the kb container)"
-if "${DC[@]}" ps --format '{{.Service}}' 2>/dev/null | grep -qx embedder; then
+bold "==> Embed backend round-trip (in-network, via the kb container)"
+# Unified topology: the kb embeds against the aimee-llm container (AIMEE_LLM_URL,
+# /embed). Legacy topology: the torch embedder service (AIMEE_EMBEDDER_URL). Probe
+# whichever backend this compose project runs.
+emb_backend=""
+if "${DC[@]}" ps --format '{{.Service}}' 2>/dev/null | grep -qx aimee-llm; then
+  emb_backend='${AIMEE_LLM_URL:-http://aimee-llm:8080}/embed'
+elif "${DC[@]}" ps --format '{{.Service}}' 2>/dev/null | grep -qx embedder; then
+  emb_backend='${AIMEE_EMBEDDER_URL:-http://embedder:8080}/embed'
+fi
+if [[ -n "$emb_backend" ]]; then
   if emb="$("${DC[@]}" exec -T aimee-kb sh -c \
-        'printf "aimee docker smoke test" | curl -fsS --max-time 30 -X POST \
-           --data-binary @- "${AIMEE_EMBEDDER_URL:-http://embedder:8080}/embed"' 2>/dev/null)" \
+        "printf 'aimee docker smoke test' | curl -fsS --max-time 30 -X POST \
+           --data-binary @- \"$emb_backend\"" 2>/dev/null)" \
      && [[ "$emb" == \[* ]]; then
     dims="$(($(printf '%s' "$emb" | tr -cd ',' | wc -c) + 1))"
-    green "  PASS  embedder /embed returned a ${dims}-dim vector"
+    green "  PASS  /embed returned a ${dims}-dim vector"
     PASS=$((PASS + 1))
   else
-    red   "  FAIL  embedder /embed round-trip"
+    red   "  FAIL  /embed round-trip"
     printf '        got: %s\n' "${emb:-<no response>}"
     FAIL=$((FAIL + 1))
   fi
 else
-  printf '  SKIP  embedder service not in this compose project\n'
+  printf '  SKIP  no embed backend service in this compose project\n'
 fi
 
 echo

--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -389,6 +389,11 @@ def build_server():
         def do_GET(self):
             path = self.path.rstrip("/")
             if path == "/health":
+                if STUB:
+                    # Report the dim so the kb's embedder-autodim sizes the schema
+                    # (the embed-remote.py --dim probe reads payload["dim"]).
+                    self._send(200, {"status": "ok", "model": "aimee-llm-stub", "dim": STUB_DIM})
+                    return
                 st = health_state(child_health())
                 self._send(200 if st == "ok" else 503, {"status": st, "model": EMBED_MODEL})
             elif path in ("/health/embed", "/health/rerank", "/health/synth"):

--- a/scripts/check-kb-container-packaging.py
+++ b/scripts/check-kb-container-packaging.py
@@ -42,10 +42,12 @@ REQUIRED_COMPOSE_PATTERNS = {
     "kb-port": r'"?8741:8741"?',
     "postgres-health": r"condition:\s+service_healthy",
     "kb-health": r"(?s)aimee-kb:.*healthcheck:.*http://127\.0\.0\.1:8741/v1/health",
-    # The persistent embedder service backs real semantic embeddings; the kb is
-    # pointed at it by env.
+    # The unified aimee-llm container backs real embeddings/reranking/synthesis;
+    # the kb is pointed at it by AIMEE_LLM_URL (no model runs in the kb). The
+    # legacy torch embedder is retained behind a profile for rollback.
+    "llm-service": r"(?m)^\s{2}aimee-llm:",
     "embedder-service": r"(?m)^\s{2}embedder:",
-    "embedder-url-env": r"AIMEE_EMBEDDER_URL:\s*http://embedder",
+    "llm-url-env": r"AIMEE_LLM_URL:\s*\$\{AIMEE_LLM_URL:-http://aimee-llm",
 }
 
 REQUIRED_DOCKERIGNORE_ENTRIES = {
@@ -156,8 +158,9 @@ def plant_test() -> int:
             "compose.yaml missing kb-port",
             "compose.yaml missing postgres-health",
             "compose.yaml missing kb-health",
+            "compose.yaml missing llm-service",
             "compose.yaml missing embedder-service",
-            "compose.yaml missing embedder-url-env",
+            "compose.yaml missing llm-url-env",
             "missing .dockerignore",
         }
         if not expected.issubset(set(found)):
@@ -201,6 +204,11 @@ def plant_test() -> int:
                     "    build:",
                     "      context: .",
                     "      dockerfile: Dockerfile.embedder",
+                    "    profiles: [\"legacy-embedder\"]",
+                    "  aimee-llm:",
+                    "    build:",
+                    "      context: .",
+                    "      dockerfile: Dockerfile.aimee-llm",
                     "  aimee-kb:",
                     "    build:",
                     "      context: .",
@@ -208,7 +216,7 @@ def plant_test() -> int:
                     "    environment:",
                     "      AIMEE_HOME: /var/lib/aimee",
                     "      AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared",
-                    "      AIMEE_EMBEDDER_URL: http://embedder:8080",
+                    "      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8080}",
                     "    ports:",
                     '      - "8741:8741"',
                     "    depends_on:",

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -62,6 +62,14 @@ done
 export EMBEDDER_STUB="${EMBEDDER_STUB:-1}"
 export EMBEDDER_STUB_DIM="${EMBEDDER_STUB_DIM:-2560}"
 export AIMEE_EMBEDDING_DIM="${AIMEE_EMBEDDING_DIM:-2560}"
+# Unified-llm topologies (T1 kb-only, T2 server+kb) now embed/rerank/synth against
+# the `aimee-llm` container instead of the torch `embedder`. CI builds the tiny
+# STUB image (no llama.cpp / GGUFs) and runs it in stub mode at the same dim, so
+# the kb -> gateway contract is exercised cheaply. (T4 combined still uses the
+# embedder stub above; T3 standalone has no embedder.) compose reads these via ${...}.
+export AIMEE_LLM_STUB="${AIMEE_LLM_STUB:-1}"
+export AIMEE_LLM_STUB_DIM="${AIMEE_LLM_STUB_DIM:-2560}"
+export AIMEE_LLM_DOCKERFILE="${AIMEE_LLM_DOCKERFILE:-Dockerfile.aimee-llm-stub}"
 
 # Disable the bundled curator LLM in CI: the committed .env enables the
 # `curator-llm` profile by default, but the smoke tests don't exercise the


### PR DESCRIPTION
## What
Completes the unified-llm cutover for the kb compose topologies. The kb now uses the unified **`aimee-llm`** container (embed + rerank + synth via `AIMEE_LLM_URL`, the P1 one-knob) instead of the torch `embedder` + `llm` sidecars.

- **`compose.yaml`** (T1 kb) + **`compose.server.yaml`** (T2 server+kb): `aimee-llm` is the default service; kb wired to `AIMEE_LLM_URL=http://aimee-llm:8080`; the legacy `embedder`/`llm` services moved behind a **`legacy-embedder`** / `curator-llm` profile (rollback: `docker compose --profile legacy-embedder up`).
- **e2e-docker**: `e2e-matrix.sh` builds the lightweight **stub** image (`Dockerfile.aimee-llm-stub` + `AIMEE_LLM_STUB=1`, dim 2560) so T1/T2 exercise the real **kb → gateway** contract with no GGUF download. The gateway stub `/health` now reports `dim` so the kb's embedder-autodim sizes the schema. **T4 (combined)** keeps the embedder stub; **T3 (standalone)** has no embedder.
- kb smoke probes whichever embed backend (`aimee-llm` or `embedder`) the project runs.

## Validation
Profile cutover validated against LXC2Docker (`docker compose config`): default services = `postgres + aimee-kb + aimee-llm` (embedder/llm excluded); `--profile legacy-embedder` brings the embedder back; kb resolves `AIMEE_LLM_URL=http://aimee-llm:8080`. Gateway/compose/smoke syntax + the stub (`/embed` 2560, `/health.dim`) verified locally. The full T1–T4 matrix runs in **e2e-docker** on this PR.

Builds on the aimee-llm stub mode (#699). The live deploy (`deploy/compose/`, #697) and `.254` are already on this model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)