### PR TITLE
fix(cli-oauth): pre-warm codex/claude CLIs on aimee-server boot

### DIFF
--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -49,6 +49,21 @@ chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspac
 [ -f "$AIMEE_HOME/aimee.yaml" ] && chown aimee:aimee "$AIMEE_HOME/aimee.yaml" 2>/dev/null || true
 [ -f "$AIMEE_HOME/agents.json" ] && chown aimee:aimee "$AIMEE_HOME/agents.json" 2>/dev/null || true
 
+# The server-hosted OAuth CLIs (claude/codex) and their npm prefix live under the
+# aimee home and MUST be writable by the unprivileged 'aimee' user that runs the
+# login: codex writes auth.json into $CODEX_HOME ($AIMEE_HOME/.codex) and claude
+# into $AIMEE_HOME/.claude on a successful device/browser login. If one of those
+# dirs is root-owned (e.g. left behind by a root `docker exec ... codex login`),
+# the CLI's token write fails and the login process exits WITHOUT persisting,
+# surfacing to the operator only as "<vendor> login session ended without
+# authenticating". Force them (and the npm install prefix) to the aimee user at
+# boot so both `aimee agent setup codex-oauth` and `claude-oauth` can persist.
+# Best-effort + only touches dirs that exist; the auth/config dirs are tiny and
+# the npm prefix is chowned in place (cheap relative to the install it backs).
+for cli_dir in .codex .claude .config .npm-global; do
+    [ -e "$AIMEE_HOME/$cli_dir" ] && chown -R aimee:aimee "$AIMEE_HOME/$cli_dir" 2>/dev/null || true
+done
+
 . /usr/local/bin/webchat-lib.sh
 
 log() { printf '[server-entrypoint] %s\n' "$*"; }

--- a/deploy/container/server-entrypoint.sh
+++ b/deploy/container/server-entrypoint.sh
@@ -74,6 +74,16 @@ webchat_start
 #       lowercased, e.g. AIMEE_DELEGATE_KEY_MISTRAL).
 # Non-destructive by default; set AIMEE_DELEGATE_SECRETS_OVERWRITE=1 to replace an
 # existing vaulted key. Secrets are never written to AIMEE_HOME or logs.
+# Pre-warm the server-hosted OAuth CLIs (claude/codex) in the BACKGROUND so the
+# first `aimee agent setup *-oauth` is instant instead of waiting on (or timing
+# out against) a cold `npm i -g` — the failure mode on a freshly-deployed,
+# empty-home container. Idempotent (probe-first) + best-effort: it never blocks
+# or fails the server start, and runs as the same 'aimee' user that owns the
+# install prefix ($AIMEE_HOME/.npm-global). The lazy install on first setup still
+# covers it if this hasn't finished yet.
+log "pre-warming server-hosted OAuth CLIs (background)"
+runuser -u aimee -- aimee-server --prewarm-cli-oauth >/dev/null 2>&1 &
+
 log "starting aimee-server (socket=$SERVER_SOCK) as user aimee"
 runuser -u aimee -- aimee-server --socket="$SERVER_SOCK" &
 server_pid=$!

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -26,6 +26,7 @@
 #include "shutdown_forensics.h"
 #include "headers/plugin_loader.h"
 #include "headers/context_engine.h"
+#include "headers/server_cli_oauth.h"
 #include <signal.h>
 #include <errno.h>
 #include <stdio.h>
@@ -279,6 +280,29 @@ int main(int argc, char **argv)
    {
       fprintf(stderr, "aimee-server: --run-command is retired; add a typed server RPC instead.\n");
       return 1;
+   }
+
+   /* Pre-warm the server-hosted OAuth CLIs (claude/codex) so the FIRST
+    * `aimee agent setup *-oauth` doesn't wait on (or time out against) a cold
+    * `npm i -g`. The deploy entrypoint runs this once at boot, backgrounded, as
+    * the server's runtime user. It reuses cli_oauth_install (same pinned
+    * versions + probe-first idempotency as the lazy path — no drift) and is
+    * best-effort: a registry/network hiccup must NOT fail boot, and the lazy
+    * install on first setup still covers it. Exits without starting the server. */
+   if (argc >= 2 && strcmp(argv[1], "--prewarm-cli-oauth") == 0)
+   {
+      const cli_oauth_vendor_t vendors[] = {CLI_OAUTH_CLAUDE, CLI_OAUTH_CODEX};
+      for (size_t k = 0; k < sizeof(vendors) / sizeof(vendors[0]); k++)
+      {
+         char err[256] = "";
+         if (cli_oauth_install(vendors[k], err, sizeof(err)) == 0)
+            fprintf(stderr, "aimee-server: prewarm %s CLI ready\n",
+                    cli_oauth_vendor_name(vendors[k]));
+         else
+            fprintf(stderr, "aimee-server: prewarm %s CLI skipped: %s\n",
+                    cli_oauth_vendor_name(vendors[k]), err);
+      }
+      return 0; /* best-effort — never fail the boot that backgrounds this */
    }
 
    const char *socket_path = NULL;


### PR DESCRIPTION
## Problem
The first `aimee agent setup codex-oauth` / `claude-oauth` on a **freshly-deployed** `aimee-server` (empty home volume) could fail with *"the server did not respond in time (it may still be installing the CLI)"*. The server-hosted OAuth RPC lazily `npm i -g`s the vendor CLI; a **cold first install** (npm/registry/DNS warming on a brand-new container — e.g. right after the `.254` compose migration) outran the request.

## Fix
`aimee-server --prewarm-cli-oauth` installs both CLIs up front via `cli_oauth_install` (the **same pinned versions + probe-first idempotency** as the lazy path — no version drift) and exits. `deploy/container/server-entrypoint.sh` runs it once at boot, **backgrounded + best-effort** (never blocks or fails the server start), as the `aimee` user that owns `$AIMEE_HOME/.npm-global`. So the first `agent setup` is instant; the lazy install still covers the brief prewarm window.

## Verified
On `.254`: install runs as `aimee` in ~3–6s; the `cli_oauth_start` RPC then returns the device URL in ~1s (codex `…/codex/device`, claude `…/oauth/authorize`). `aimee-server` compiles + links clean (`-Werror`); entrypoint `sh -n` clean. (`.254` itself is already warmed — this prevents recurrence on future fresh deploys.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)