### PR TITLE
feat(mcp): tool-list presentation profile (P1 of MCP surface program)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -200,7 +200,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 119 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 120 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -361,6 +361,7 @@ The binaries read 119 `AIMEE_*` environment variables (scanned from `getenv()` i
 | Variable | Description |
 |----------|-------------|
 | `AIMEE_MCP_CWD` | Working-directory hint for MCP git-root resolution. |
+| `AIMEE_MCP_TOOL_PROFILE` | MCP tools/list presentation profile: 'full' (default, all tools) or 'core'/'lean' (Tier-0 high-frequency tools only, shrinking the initial payload). |
 | `AIMEE_VERIFY_PARALLEL` | Run `aimee git verify` steps in parallel. |
 | `AIMEE_VERIFY_STEP_TIMEOUT_MS` | Per-step timeout (ms) for git verify. |
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -544,6 +544,7 @@ ENV_DESC = {
     "AIMEE_VERIFY_PARALLEL": ("Git verify / MCP", "Run `aimee git verify` steps in parallel."),
     "AIMEE_VERIFY_STEP_TIMEOUT_MS": ("Git verify / MCP", "Per-step timeout (ms) for git verify."),
     "AIMEE_MCP_CWD": ("Git verify / MCP", "Working-directory hint for MCP git-root resolution."),
+    "AIMEE_MCP_TOOL_PROFILE": ("Git verify / MCP", "MCP tools/list presentation profile: 'full' (default, all tools) or 'core'/'lean' (Tier-0 high-frequency tools only, shrinking the initial payload)."),
     # Models
     "AIMEE_MODEL_CAPABILITY_OVERRIDES": ("Models", "Override model capability flags (reasoning/tools/vision/…)."),
     # TLS & networking

--- a/src/Makefile
+++ b/src/Makefile
@@ -291,7 +291,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
             compact.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
-            client_integrations.c mcp_tools.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
+            client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
             workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c

--- a/src/headers/mcp_tools.h
+++ b/src/headers/mcp_tools.h
@@ -7,4 +7,13 @@
  * Returns a cJSON array suitable for tools/list responses. */
 cJSON *mcp_build_tools_list(void);
 
+/* Resolve the active MCP presentation profile: the explicit argument if set,
+ * else AIMEE_MCP_TOOL_PROFILE, else "full". Returned string is not owned. */
+const char *mcp_tool_profile_effective(const char *explicit_profile);
+
+/* Filter a served tools/list IN PLACE to the named profile (NULL => resolve via
+ * mcp_tool_profile_effective). "full" / unknown is a no-op (fail open); "core"
+ * or "lean" keeps only the Tier-0 set. Returns the number of tools removed. */
+int mcp_filter_tools_for_profile(cJSON *tools, const char *profile);
+
 #endif /* DEC_MCP_TOOLS_H */

--- a/src/mcp_tool_profile.c
+++ b/src/mcp_tool_profile.c
@@ -1,0 +1,68 @@
+/* mcp_tool_profile.c: MCP tools/list presentation profile (P1).
+ *
+ * Shrinks the initial tools/list shown to an external MCP client. Kept separate
+ * from mcp_tools.c (which is at its line budget) and from the tool definitions
+ * it filters. See AIMEE_MCP_TOOL_PROFILE; default "full" is a no-op. */
+#include "cJSON.h"
+#include "headers/mcp_tools.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* Tier-0 "core" presentation profile (MCP-native tool names): the high-frequency
+ * tools an external MCP client is shown when AIMEE_MCP_TOOL_PROFILE=core|lean.
+ * Everything else — including plugin:* and remote-server tools — is hidden from
+ * the initial tools/list to shrink the upfront payload. The full catalog stays
+ * reachable: P2 adds find_tools/describe_tool for on-demand discovery. Keep this
+ * list short and edit it deliberately; it is the floor of what every lean client
+ * sees. test_tool_profile_filter mirrors this list and must be kept in sync. */
+static const char *const MCP_CORE_TOOLS[] = {
+    "get_help",      "search_docs",                                /* orient / discover */
+    "search_memory", "memory_recall",     "get_identity",          /* grounding */
+    "find_symbol",   "ast_grep_search",                            /* code intel */
+    "git_status",    "git_commit",        "git_diff_summary",      /* common git */
+    "git_branch",    "git_pr",
+    "delegate",      "ensemble_review",                            /* multi-agent */
+    "ask_user",      "send_message",                               /* interaction */
+    "create_note",                                                 /* capture */
+    NULL,
+};
+
+static int mcp_name_in_set(const char *name, const char *const *set)
+{
+   for (int i = 0; set[i]; i++)
+      if (strcmp(name, set[i]) == 0)
+         return 1;
+   return 0;
+}
+
+const char *mcp_tool_profile_effective(const char *explicit_profile)
+{
+   if (explicit_profile && explicit_profile[0])
+      return explicit_profile;
+   const char *e = getenv("AIMEE_MCP_TOOL_PROFILE");
+   return (e && e[0]) ? e : "full";
+}
+
+int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
+{
+   if (!tools || !cJSON_IsArray(tools))
+      return 0;
+   profile = mcp_tool_profile_effective(profile);
+   /* "full" (default) presents everything; an unknown profile fails OPEN to the
+    * full set so a typo never silently hides tools. */
+   if (strcmp(profile, "core") != 0 && strcmp(profile, "lean") != 0)
+      return 0;
+
+   int removed = 0;
+   for (int i = cJSON_GetArraySize(tools) - 1; i >= 0; i--)
+   {
+      cJSON *tool = cJSON_GetArrayItem(tools, i);
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(tool, "name");
+      if (!cJSON_IsString(nm) || !mcp_name_in_set(nm->valuestring, MCP_CORE_TOOLS))
+      {
+         cJSON_DeleteItemFromArray(tools, i);
+         removed++;
+      }
+   }
+   return removed;
+}

--- a/src/mcp_tool_profile.c
+++ b/src/mcp_tool_profile.c
@@ -16,14 +16,23 @@
  * list short and edit it deliberately; it is the floor of what every lean client
  * sees. test_tool_profile_filter mirrors this list and must be kept in sync. */
 static const char *const MCP_CORE_TOOLS[] = {
-    "get_help",      "search_docs",                                /* orient / discover */
-    "search_memory", "memory_recall",     "get_identity",          /* grounding */
-    "find_symbol",   "ast_grep_search",                            /* code intel */
-    "git_status",    "git_commit",        "git_diff_summary",      /* common git */
-    "git_branch",    "git_pr",
-    "delegate",      "ensemble_review",                            /* multi-agent */
-    "ask_user",      "send_message",                               /* interaction */
-    "create_note",                                                 /* capture */
+    "get_help",
+    "search_docs", /* orient / discover */
+    "search_memory",
+    "memory_recall",
+    "get_identity", /* grounding */
+    "find_symbol",
+    "ast_grep_search", /* code intel */
+    "git_status",
+    "git_commit",
+    "git_diff_summary", /* common git */
+    "git_branch",
+    "git_pr",
+    "delegate",
+    "ensemble_review", /* multi-agent */
+    "ask_user",
+    "send_message", /* interaction */
+    "create_note",  /* capture */
     NULL,
 };
 

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -8,7 +8,36 @@
 #include "headers/session_search_tool.h"
 #include "log.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+/* Tier-0 "core" presentation profile (MCP-native tool names): the high-frequency
+ * tools an external MCP client is shown when AIMEE_MCP_TOOL_PROFILE=core|lean.
+ * Everything else — including plugin:* and remote-server tools — is hidden from
+ * the initial tools/list to shrink the upfront payload. The full catalog stays
+ * reachable: P2 adds find_tools/describe_tool for on-demand discovery. Keep this
+ * list short and edit it deliberately; it is the floor of what every client sees
+ * in lean mode. */
+static const char *const MCP_CORE_TOOLS[] = {
+    "get_help",      "search_docs",                                    /* orient / discover */
+    "search_memory", "memory_recall",     "get_identity",             /* grounding */
+    "find_symbol",   "ast_grep_search",                               /* code intel */
+    "git_status",    "git_commit",        "git_diff_summary",         /* common git */
+    "git_branch",    "git_pr",
+    "delegate",      "ensemble_review",                               /* multi-agent */
+    "ask_user",      "send_message",                                  /* interaction */
+    "create_note",                                                    /* capture */
+    NULL,
+};
+
+static int mcp_name_in_set(const char *name, const char *const *set)
+{
+   for (int i = 0; set[i]; i++)
+      if (strcmp(name, set[i]) == 0)
+         return 1;
+   return 0;
+}
+
 static cJSON *build_tool(const char *name, const char *desc, cJSON *schema)
 {
    cJSON *t = cJSON_CreateObject();
@@ -1944,4 +1973,36 @@ cJSON *mcp_build_tools_list(void)
    cJSON_Delete(remote_tools);
 
    return tools;
+}
+
+const char *mcp_tool_profile_effective(const char *explicit_profile)
+{
+   if (explicit_profile && explicit_profile[0])
+      return explicit_profile;
+   const char *e = getenv("AIMEE_MCP_TOOL_PROFILE");
+   return (e && e[0]) ? e : "full";
+}
+
+int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
+{
+   if (!tools || !cJSON_IsArray(tools))
+      return 0;
+   profile = mcp_tool_profile_effective(profile);
+   /* "full" (default) presents everything; an unknown profile fails OPEN to the
+    * full set so a typo never silently hides tools. */
+   if (strcmp(profile, "core") != 0 && strcmp(profile, "lean") != 0)
+      return 0;
+
+   int removed = 0;
+   for (int i = cJSON_GetArraySize(tools) - 1; i >= 0; i--)
+   {
+      cJSON *tool = cJSON_GetArrayItem(tools, i);
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(tool, "name");
+      if (!cJSON_IsString(nm) || !mcp_name_in_set(nm->valuestring, MCP_CORE_TOOLS))
+      {
+         cJSON_DeleteItemFromArray(tools, i);
+         removed++;
+      }
+   }
+   return removed;
 }

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -8,36 +8,7 @@
 #include "headers/session_search_tool.h"
 #include "log.h"
 #include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
-
-/* Tier-0 "core" presentation profile (MCP-native tool names): the high-frequency
- * tools an external MCP client is shown when AIMEE_MCP_TOOL_PROFILE=core|lean.
- * Everything else — including plugin:* and remote-server tools — is hidden from
- * the initial tools/list to shrink the upfront payload. The full catalog stays
- * reachable: P2 adds find_tools/describe_tool for on-demand discovery. Keep this
- * list short and edit it deliberately; it is the floor of what every client sees
- * in lean mode. */
-static const char *const MCP_CORE_TOOLS[] = {
-    "get_help",      "search_docs",                                    /* orient / discover */
-    "search_memory", "memory_recall",     "get_identity",             /* grounding */
-    "find_symbol",   "ast_grep_search",                               /* code intel */
-    "git_status",    "git_commit",        "git_diff_summary",         /* common git */
-    "git_branch",    "git_pr",
-    "delegate",      "ensemble_review",                               /* multi-agent */
-    "ask_user",      "send_message",                                  /* interaction */
-    "create_note",                                                    /* capture */
-    NULL,
-};
-
-static int mcp_name_in_set(const char *name, const char *const *set)
-{
-   for (int i = 0; set[i]; i++)
-      if (strcmp(name, set[i]) == 0)
-         return 1;
-   return 0;
-}
-
 static cJSON *build_tool(const char *name, const char *desc, cJSON *schema)
 {
    cJSON *t = cJSON_CreateObject();
@@ -1973,36 +1944,4 @@ cJSON *mcp_build_tools_list(void)
    cJSON_Delete(remote_tools);
 
    return tools;
-}
-
-const char *mcp_tool_profile_effective(const char *explicit_profile)
-{
-   if (explicit_profile && explicit_profile[0])
-      return explicit_profile;
-   const char *e = getenv("AIMEE_MCP_TOOL_PROFILE");
-   return (e && e[0]) ? e : "full";
-}
-
-int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
-{
-   if (!tools || !cJSON_IsArray(tools))
-      return 0;
-   profile = mcp_tool_profile_effective(profile);
-   /* "full" (default) presents everything; an unknown profile fails OPEN to the
-    * full set so a typo never silently hides tools. */
-   if (strcmp(profile, "core") != 0 && strcmp(profile, "lean") != 0)
-      return 0;
-
-   int removed = 0;
-   for (int i = cJSON_GetArraySize(tools) - 1; i >= 0; i--)
-   {
-      cJSON *tool = cJSON_GetArrayItem(tools, i);
-      cJSON *nm = cJSON_GetObjectItemCaseSensitive(tool, "name");
-      if (!cJSON_IsString(nm) || !mcp_name_in_set(nm->valuestring, MCP_CORE_TOOLS))
-      {
-         cJSON_DeleteItemFromArray(tools, i);
-         removed++;
-      }
-   }
-   return removed;
 }

--- a/src/server/server_mcp_tools.c
+++ b/src/server/server_mcp_tools.c
@@ -6,6 +6,7 @@
 #include "osv_check.h"
 #include "toolset.h"
 #include "cJSON.h"
+#include "log.h"
 
 #include <string.h>
 
@@ -184,6 +185,20 @@ int handle_mcp_tools_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
           "run.");
       cJSON_AddItemToObject(t, "inputSchema", s);
       cJSON_AddItemToArray(tools, t);
+   }
+
+   /* Presentation profile: shrink the initial tools/list for external MCP
+    * clients when AIMEE_MCP_TOOL_PROFILE=core|lean. Default "full" is a no-op,
+    * so existing clients are unaffected; the lean set + on-demand discovery
+    * (find_tools/describe_tool) land in P2. Applied here at the served-list
+    * choke point so mcp_build_tools_list() (and its golden test) stays intact. */
+   {
+      const char *profile = mcp_tool_profile_effective(NULL);
+      int total = cJSON_GetArraySize(tools);
+      int removed = mcp_filter_tools_for_profile(tools, NULL);
+      if (removed > 0)
+         LOG_INFO("mcp-tools", "tools/list profile '%s': presenting %d tools (hid %d)", profile,
+                  total - removed, removed);
    }
 
    cJSON_AddStringToObject(resp, "status", "ok");

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -3240,7 +3240,7 @@ $(TESTPREFIX)/unit-test-mcp-osv-cache: $(OBJDIR)/tests/test_mcp_osv_cache.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-mcp-client-registry: $(OBJDIR)/tests/test_mcp_client_registry.o \
-                     $(OBJDIR)/mcp_tools.o $(OBJDIR)/mcp_skill_tools.o $(OBJDIR)/mcp_tools_gateway.o \
+                     $(OBJDIR)/mcp_tools.o $(OBJDIR)/mcp_tool_profile.o $(OBJDIR)/mcp_skill_tools.o $(OBJDIR)/mcp_tools_gateway.o \
                      $(OBJDIR)/server/session_search_tool.o \
                      $(OBJDIR)/plugin.o \
                      $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/platform_random.o $(OBJDIR)/config_save.o \
@@ -3253,4 +3253,4 @@ $(TESTPREFIX)/unit-test-mcp-client-registry: $(OBJDIR)/tests/test_mcp_client_reg
                      $(OBJDIR)/server/mcp_client_registry.o \
                      $(TEST_MCP_CLIENT_OBJS) \
                      $(TESTPREFIX)/mock-mcp-server
-	$(TESTLINK) -o $@ $(OBJDIR)/tests/test_mcp_client_registry.o $(OBJDIR)/mcp_tools.o $(OBJDIR)/mcp_skill_tools.o $(OBJDIR)/mcp_tools_gateway.o $(OBJDIR)/server/session_search_tool.o $(OBJDIR)/plugin.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/platform_random.o $(OBJDIR)/config_save.o $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/log.o $(OBJDIR)/server/osv_check.o $(OBJDIR)/server/mcp_client_registry.o $(TEST_MCP_CLIENT_OBJS) $(TEST_L_FLAGS)
+	$(TESTLINK) -o $@ $(OBJDIR)/tests/test_mcp_client_registry.o $(OBJDIR)/mcp_tools.o $(OBJDIR)/mcp_tool_profile.o $(OBJDIR)/mcp_skill_tools.o $(OBJDIR)/mcp_tools_gateway.o $(OBJDIR)/server/session_search_tool.o $(OBJDIR)/plugin.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/platform_random.o $(OBJDIR)/config_save.o $(OBJDIR)/aimee_home.o $(OBJDIR)/yaml.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/log.o $(OBJDIR)/server/osv_check.o $(OBJDIR)/server/mcp_client_registry.o $(TEST_MCP_CLIENT_OBJS) $(TEST_L_FLAGS)

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -489,10 +489,62 @@ static void test_tools_list_surface(void)
    cJSON_Delete(tools);
 }
 
+/* P1 presentation profile: "core"/"lean" shrinks the served tools/list to the
+ * Tier-0 set; "full"/unknown/NULL-default fail open (present everything). */
+static int profile_core_has(const char *n, const char *const *set)
+{
+   for (int i = 0; set[i]; i++)
+      if (strcmp(n, set[i]) == 0)
+         return 1;
+   return 0;
+}
+static void test_tool_profile_filter(void)
+{
+   /* Mirror of MCP_CORE_TOOLS in mcp_tools.c — kept in sync intentionally. */
+   static const char *const core[] = {
+       "get_help",        "search_docs",    "search_memory",  "memory_recall",
+       "get_identity",    "find_symbol",    "ast_grep_search", "git_status",
+       "git_commit",      "git_diff_summary", "git_branch",   "git_pr",
+       "delegate",        "ensemble_review", "ask_user",      "send_message",
+       "create_note",     NULL};
+   int expect = 0;
+   for (int i = 0; core[i]; i++)
+      expect++;
+
+   /* "full", an unknown profile, and NULL (no env set in the test) are no-ops. */
+   cJSON *t = mcp_build_tools_list();
+   int full = cJSON_GetArraySize(t);
+   assert(full > expect);
+   assert(mcp_filter_tools_for_profile(t, "full") == 0 && cJSON_GetArraySize(t) == full);
+   assert(mcp_filter_tools_for_profile(t, "nonsense") == 0 && cJSON_GetArraySize(t) == full);
+   assert(mcp_filter_tools_for_profile(t, NULL) == 0 && cJSON_GetArraySize(t) == full);
+   cJSON_Delete(t);
+
+   /* "core" keeps exactly the Tier-0 set — and every named core tool exists in
+    * the built list (kept count == expected count proves none was dropped). */
+   t = mcp_build_tools_list();
+   int removed = mcp_filter_tools_for_profile(t, "core");
+   assert(removed == full - expect);
+   assert(cJSON_GetArraySize(t) == expect);
+   cJSON *tool = NULL;
+   cJSON_ArrayForEach(tool, t)
+   {
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(tool, "name");
+      assert(cJSON_IsString(nm) && profile_core_has(nm->valuestring, core));
+   }
+   cJSON_Delete(t);
+
+   /* "lean" is an alias for "core". */
+   t = mcp_build_tools_list();
+   assert(mcp_filter_tools_for_profile(t, "lean") == full - expect);
+   cJSON_Delete(t);
+}
+
 int main(void)
 {
    printf("test_mcp_client_registry\n");
    test_tools_list_surface();
+   test_tool_profile_filter();
    test_boot_and_lazy_tools();
    test_namespaced_tools_and_dispatch();
    test_failed_client_does_not_abort_boot();

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -501,12 +501,12 @@ static int profile_core_has(const char *n, const char *const *set)
 static void test_tool_profile_filter(void)
 {
    /* Mirror of MCP_CORE_TOOLS in mcp_tools.c — kept in sync intentionally. */
-   static const char *const core[] = {
-       "get_help",        "search_docs",    "search_memory",  "memory_recall",
-       "get_identity",    "find_symbol",    "ast_grep_search", "git_status",
-       "git_commit",      "git_diff_summary", "git_branch",   "git_pr",
-       "delegate",        "ensemble_review", "ask_user",      "send_message",
-       "create_note",     NULL};
+   static const char *const core[] = {"get_help",         "search_docs",     "search_memory",
+                                      "memory_recall",    "get_identity",    "find_symbol",
+                                      "ast_grep_search",  "git_status",      "git_commit",
+                                      "git_diff_summary", "git_branch",      "git_pr",
+                                      "delegate",         "ensemble_review", "ask_user",
+                                      "send_message",     "create_note",     NULL};
    int expect = 0;
    for (int i = 0; core[i]; i++)
       expect++;


### PR DESCRIPTION
## Context
An analysis of aimee's MCP surface found a two-sided problem: the initial `tools/list` is **too big in bytes** (≈99 built-in tools, full schemas, ~53 KB / ~13k tokens, no filtering/pagination/lazy schemas) **and too small in coverage** (the `/v1` dispatch table has 221 methods + a large kb action surface that MCP doesn't reach). These goals — *more capability, smaller payload* — only reconcile through **progressive disclosure**. This is **P1** of that program.

## What this PR does
Adds an MCP-native presentation profile selected by `AIMEE_MCP_TOOL_PROFILE`:
- **`full`** (default) — present everything. **Zero regression** for existing clients.
- **`core` / `lean`** — present only the Tier-0 high-frequency set (`MCP_CORE_TOOLS`), which also drops `plugin:*` and remote-server tools from the initial list.

`mcp_filter_tools_for_profile()` is applied at the **served-list choke point** (`handle_mcp_tools_list`), not inside `mcp_build_tools_list()`, so the builder and its **auto-generated golden test stay intact**. Unknown/`NULL` profiles **fail open** (a typo never silently hides tools).

### Why not reuse `toolset.c`?
Its groups (`core`/`git`/`web`/…) name **agent-surface** tools (`read_file`/`grep`/`bash`/`edit_file`/`respond`…), not MCP tool names — wiring them into the MCP list would mis-filter. The MCP profile is its own deliberately-maintained list.

## Roadmap (this is P1 of 4)
- **P1 (here):** profile mechanism + Tier-0 set, default `full`.
- **P2:** `find_tools`/`describe_tool` on-demand discovery + flip the default to `core` — coverage becomes free, no capability lost.
- **P3:** expand the catalog (index, roadmap/task/work, memory provenance, insights…).
- **P4:** schema `$defs` dedup + description compaction (regenerates the golden).

The lean default is intentionally deferred to P2 so no phase ever reduces capability mid-program.

## Tests
- New `test_tool_profile_filter`: `full`/unknown/`NULL` are no-ops; `core`/`lean` keep **exactly** the Tier-0 set and prove every core tool exists in the built list.
- Existing golden (`mcp_build_tools_list` surface) + `cli-mcp-serve` tests stay green.
- `aimee-server` links clean (`-Werror`); docs regenerated (`AIMEE_MCP_TOOL_PROFILE`).
