### PR TITLE
fix(server): never expose /v1 credentials over plaintext to the network

### DIFF
--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -218,8 +218,9 @@ RUN chmod +x /usr/local/bin/aimee-combined-entrypoint
 # Runs as root: the entrypoint bootstraps the webchat PAM user and runs webchat
 # (pam_unix needs /etc/shadow), then drops aimee-kb + aimee-server to "aimee".
 WORKDIR /var/lib/aimee
-# 8740 = server /v1; 8741 = kb /v1; 8443 = aimee-webchat browser UI (HTTPS).
-EXPOSE 8740 8741 8443
+# 8740 = server /v1 (plaintext, loopback-only); 8743 = server /v1 over native TLS
+# (the remote thin-client port); 8741 = kb /v1; 8443 = aimee-webchat UI (HTTPS).
+EXPOSE 8740 8743 8741 8443
 
 # NOTE: the server's/kb's worker threads need a 64 MB stack (the 8 MB container
 # default overflows during startup and the process segfaults). The entrypoint

--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -199,8 +199,9 @@ COPY config/workflows/ /opt/aimee/defaults/workflows/
 # Runs as root: the entrypoint bootstraps the webchat PAM user and runs webchat
 # (pam_unix needs /etc/shadow), then drops aimee-server to the "aimee" user.
 WORKDIR /var/lib/aimee
-# 8740 = server /v1 HTTP API; 8443 = aimee-webchat browser UI (HTTPS).
-EXPOSE 8740 8443
+# 8740 = server /v1 (plaintext, loopback-only); 8743 = server /v1 over native TLS
+# (the remote thin-client port); 8443 = aimee-webchat browser UI (HTTPS).
+EXPOSE 8740 8743 8443
 
 # NOTE: the server's worker threads need a 64 MB stack (the 8 MB container
 # default overflows during startup and the process segfaults). The entrypoint

--- a/README.md
+++ b/README.md
@@ -149,12 +149,14 @@ git clone https://github.com/RakuenSoftware/aimee.git
 cd aimee
 docker compose -f compose.combined.yaml up --build -d
 
-# 2. Confirm it's live (default loopback bearer: aimee-local-dev)
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
+# 2. Confirm it's live (default bearer: aimee-local-dev; -k accepts the self-signed cert)
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
 ```
 
 Then install the thin client (prebuilt Linux/macOS/Windows binaries ship with each
-release), point it at the server with `aimee remote set http://host:8740 <token>`,
+release), point it at the server with `aimee remote set https://host:8743 <token>`
+(the server's `/v1` is TLS-only off-loopback with a self-signed cert, so set
+`AIMEE_TLS_INSECURE=1` or trust the cert),
 and register your tool's hooks with `./configure-hooks.sh`.
 
 The [Quickstart](docs/QUICKSTART.md) walks the Docker server and thin-client setup

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -1,6 +1,6 @@
 # Combined aimee-server+kb stack.
 #
-# One container runs BOTH aimee binaries co-located (server fronts /v1 on :8740;
+# One container runs BOTH aimee binaries co-located (server fronts /v1 over TLS on :8743;
 # the kb runs on loopback :8741 inside the same container and the server reaches
 # it via AIMEE_KB_API_URL=http://127.0.0.1:8741). Postgres (DB2 + pgvector) and
 # the embedder remain separate services — the combined image bundles the two
@@ -12,13 +12,13 @@
 # Or build from source instead of pulling:
 #   docker compose -f compose.combined.yaml up --build
 #
-# Server /v1 on :8740 (bearer "aimee-local-dev"); the in-container kb /v1 is also
+# Server /v1 over TLS on :8743 (bearer "aimee-local-dev"; self-signed, use curl -k); the in-container kb /v1 is also
 # published on :8741 for direct inspection. The default build needs no credentials
 # and ships server+kb only. The optional aimee-webchat browser UI (https://localhost:8443,
 # self-signed; log in as AIMEE_WEBCHAT_USER / AIMEE_WEBCHAT_PASSWORD, default
 # aimee / aimee-local-dev) is included only when built with --build-arg WITH_WEBCHAT=1
 # (needs a GitHub Packages token) or when running a published image.
-#   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
+#   curl -k -H "Authorization: Bearer aimee-local-dev" https://localhost:8743/v1/health
 #   curl http://localhost:8741/v1/health?status=1
 services:
   postgres:
@@ -127,7 +127,8 @@ services:
       #   the container's "aimee" user and point at it:
       # AIMEE_DELEGATE_SECRETS_FILE: /run/secrets/aimee-delegates.json
     ports:
-      - "8740:8740"
+      # /v1 over native TLS on 8743 (plaintext 8740 is loopback-only, not published).
+      - "8743:8743"
       - "8741:8741"
       # webchat UI — on by default; gated off only by AIMEE_WEBCHAT_ENABLED=0 above.
       - "8443:8443"

--- a/compose.server-standalone.yaml
+++ b/compose.server-standalone.yaml
@@ -11,11 +11,11 @@
 #   docker compose -f compose.server-standalone.yaml up --build   # build from source
 #
 # The /v1 API requires a bearer token (baked default: "aimee-local-dev"):
-#   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
+#   curl -k -H "Authorization: Bearer aimee-local-dev" https://localhost:8743/v1/health
 #
 # Plain `docker run` must pass the stack ulimit explicitly; mount a volume at
 # AIMEE_WORKSPACES_DIR to persist the mirror-tier checkouts across recreations:
-#   docker run --rm --ulimit stack=67108864 -p 8740:8740 \
+#   docker run --rm --ulimit stack=67108864 -p 8743:8743 \
 #     -v aimee-workspaces:/var/lib/aimee-workspaces aimee-server
 services:
   aimee-server:
@@ -36,7 +36,8 @@ services:
     ulimits:
       stack: 67108864
     ports:
-      - "8740:8740"
+      # /v1 over native TLS on 8743 (plaintext 8740 is loopback-only, not published).
+      - "8743:8743"
     # An unauthenticated probe gets 401, which still proves the listener is up;
     # treat 200/401 as healthy so this stays correct if the bearer is overridden.
     healthcheck:

--- a/compose.server.yaml
+++ b/compose.server.yaml
@@ -9,10 +9,11 @@
 #
 #   docker compose -f compose.server.yaml up --build
 #
-# Server /v1 on :8740 (bearer "aimee-local-dev"); kb /v1 on :8741. The
-# aimee-webchat browser UI is on https://localhost:8443 (self-signed; log in as
+# Server /v1 on :8743 over native TLS (bearer "aimee-local-dev"; self-signed cert
+# auto-provisioned — pass curl -k or trust it); kb /v1 on :8741. The aimee-webchat
+# browser UI is on https://localhost:8443 (self-signed; log in as
 # AIMEE_WEBCHAT_USER / AIMEE_WEBCHAT_PASSWORD, default aimee / aimee-local-dev).
-#   curl -H "Authorization: Bearer aimee-local-dev" http://localhost:8740/v1/health
+#   curl -k -H "Authorization: Bearer aimee-local-dev" https://localhost:8743/v1/health
 services:
   postgres:
     restart: unless-stopped
@@ -147,7 +148,10 @@ services:
       # AIMEE_DELEGATE_KEY_MISTRAL: ${AIMEE_DELEGATE_KEY_MISTRAL:-}
       # AIMEE_DELEGATE_SECRETS_FILE: /run/secrets/aimee-delegates.json
     ports:
-      - "8740:8740"
+      # Remote /v1 is served over native TLS on 8743 (the server refuses to expose
+      # plaintext /v1 off-loopback). Plaintext 8740 stays bound to 127.0.0.1 inside
+      # the container (the healthcheck below still uses it) and is NOT published.
+      - "8743:8743"
       # webchat UI — on by default; gated off only by AIMEE_WEBCHAT_ENABLED=0 above.
       - "8443:8443"
     depends_on:

--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -88,7 +88,10 @@ services:
       AIMEE_WEBCHAT_USER: ${AIMEE_WEBCHAT_USER:-aimee}
       AIMEE_WEBCHAT_PASSWORD: ${AIMEE_WEBCHAT_PASSWORD:-aimee-local-dev}
     ports:
-      - "8740:8740"
+      # 8740 (plaintext /v1) is loopback-only in the server; do NOT publish it.
+      # Remote thin clients use the TLS /v1 on 8743 (https://, self-signed cert
+      # auto-provisioned). 8443 is the webchat browser UI.
+      - "8743:8743"
       - "8443:8443"
     depends_on:
       aimee-kb:

--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -14,11 +14,20 @@
 # --- server: inbound /v1 HTTP API (binds only with port + bearer set) ---
 aimee:
   api:
+    # Plaintext /v1 is LOOPBACK-ONLY by design: the server refuses to bind it on a
+    # non-loopback interface (the bearer + credentials would cross the wire in
+    # cleartext). Remote thin clients MUST use the TLS listener below.
     http_port: 8740
+    # Native-TLS /v1 for remote access (0.0.0.0 when AIMEE_SERVER_HTTP_BIND=1). The
+    # server auto-provisions a self-signed cert at $AIMEE_HOME/tls/server.{crt,key}
+    # on first start if none exists; supply your own cert there to override. Thin
+    # clients connect with `https://host:8743` (AIMEE_TLS_INSECURE=1 for the
+    # self-signed cert, or pin it).
+    tls_port: 8743
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # This combined all-in-one binds /v1 on 0.0.0.0 so a thin client drives it
-    # remotely, including delegates/roundtables/tools — which require
+    # This combined all-in-one binds the TLS /v1 on 0.0.0.0 so a thin client drives
+    # it remotely, including delegates/roundtables/tools — which require
     # remote_writes="full". The image also forces this via AIMEE_API_REMOTE_WRITES
     # (Dockerfile.combined) so it survives a fresh redeploy that reseeds this file.
     # Trusted networks only (this ships a known dev bearer); for any exposed

--- a/deploy/container/aimee-server-remote-writes.yaml
+++ b/deploy/container/aimee-server-remote-writes.yaml
@@ -3,16 +3,17 @@
 #
 # Enables the server's inbound /v1 HTTP API. The listener binds only when BOTH a
 # port and a bearer token are configured (src/server/server_http.c). The image
-# also sets AIMEE_SERVER_HTTP_BIND=1 so the listener binds 0.0.0.0 instead of
-# loopback, making the published container port reachable; the bearer below is
-# still required on every request.
+# sets AIMEE_SERVER_HTTP_BIND=1 so the TLS listener binds 0.0.0.0 (the published
+# container port); the bearer below is still required on every request.
 #
-# This token is a development default — override it for any real deployment by
-# mounting your own aimee.yaml over /var/lib/aimee/aimee.yaml (and putting the
-# server behind TLS termination if exposed beyond a trusted network).
+# Plaintext /v1 (http_port) is LOOPBACK-ONLY by design; remote thin clients use
+# the TLS listener (tls_port), with a self-signed cert auto-provisioned under
+# $AIMEE_HOME/tls. This token is a development default — override it for any real
+# deployment by mounting your own aimee.yaml over /var/lib/aimee/aimee.yaml.
 aimee:
   api:
     http_port: 8740
+    tls_port: 8743
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
     # Mutating /v1 routes are local-UDS-only by default; over the published TCP

--- a/deploy/container/aimee-server.yaml
+++ b/deploy/container/aimee-server.yaml
@@ -3,19 +3,24 @@
 #
 # Enables the server's inbound /v1 HTTP API. The listener binds only when BOTH a
 # port and a bearer token are configured (src/server/server_http.c). The image
-# also sets AIMEE_SERVER_HTTP_BIND=1 so the listener binds 0.0.0.0 instead of
-# loopback, making the published container port reachable; the bearer below is
-# still required on every request.
+# sets AIMEE_SERVER_HTTP_BIND=1 so the TLS listener binds 0.0.0.0 (the published
+# container port); the bearer below is still required on every request.
+#
+# Plaintext /v1 (http_port) is LOOPBACK-ONLY by design — the server refuses to
+# bind it on a non-loopback interface so the bearer + credentials can never cross
+# the wire in cleartext. Remote thin clients MUST use the TLS listener (tls_port);
+# the server auto-provisions a self-signed cert at $AIMEE_HOME/tls/server.{crt,key}
+# on first start. Mount your own cert there to override.
 #
 # This token is a development default — override it for any real deployment by
-# mounting your own aimee.yaml over /var/lib/aimee/aimee.yaml (and putting the
-# server behind TLS termination if exposed beyond a trusted network).
+# mounting your own aimee.yaml over /var/lib/aimee/aimee.yaml.
 aimee:
   api:
     http_port: 8740
+    tls_port: 8743
     bearer_token: "aimee-local-dev"
     rate_limit_per_min: 0
-    # This image binds /v1 on 0.0.0.0 so a thin client drives it remotely,
+    # This image binds the TLS /v1 on 0.0.0.0 so a thin client drives it remotely,
     # including delegates/roundtables/tools — which require remote_writes="full".
     # The image also forces this via AIMEE_API_REMOTE_WRITES (Dockerfile.server) so
     # it survives a fresh redeploy that reseeds this file. Trusted networks only

--- a/deploy/smoothnas/aimee-server.plugin.yaml
+++ b/deploy/smoothnas/aimee-server.plugin.yaml
@@ -45,8 +45,11 @@ services:
         slot: HDD
         bind: /var/lib/aimee-workspaces
     ports:
+      # Remote /v1 is served over native TLS on 8743 (https://). Plaintext 8740
+      # is loopback-only in the server (it refuses a non-loopback plaintext bind),
+      # so it is not host-exposed.
       - name: api
-        port: 8740
+        port: 8743
         protocol: tcp
         expose: false
         hostExpose: true

--- a/docs/AUTONOMOUS_DEVELOPMENT.md
+++ b/docs/AUTONOMOUS_DEVELOPMENT.md
@@ -52,7 +52,7 @@ execution of a workflow for one proposal. The **primary agent** is the manager
 Submit a proposal for autonomous execution:
 
 ```bash
-curl -sX POST http://127.0.0.1:8740/v1/dev/submit \
+curl -k -sX POST https://127.0.0.1:8743/v1/dev/submit \
   -H "Authorization: Bearer $AIMEE_TOKEN" \
   -H 'Content-Type: application/json' \
   -d '{"proposal_md": "## Add a /healthz route returning {status:ok}\n\nWhy: ...\nAcceptance: GET /healthz returns 200 with {\"status\":\"ok\"}."}'

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -13,7 +13,7 @@ The model is the same on every developer machine: **the services run in Docker (
 
 ## Part 1, Run the server (aimee-combined in Docker)
 
-The **combined** image co-locates both aimee binaries in one container: the knowledge base (`aimee-kb`) on loopback `:8741` inside the container, and the server (`aimee-server`) fronting `/v1` on `:8740`. Postgres (DB2 + pgvector) and a CPU embedder come up alongside it as separate services.
+The **combined** image co-locates both aimee binaries in one container: the knowledge base (`aimee-kb`) on loopback `:8741` inside the container, and the server (`aimee-server`) fronting `/v1` over native TLS on `:8743` (self-signed cert; plaintext `:8740` is loopback-only and not published). Postgres (DB2 + pgvector) and a CPU embedder come up alongside it as separate services.
 
 ### Prerequisites
 
@@ -33,7 +33,7 @@ By default this brings up **three** services. The browser webchat is a first-cla
 
 | Service | What it is | Port |
 |---------|-----------|------|
-| `aimee-server-kb` | Both aimee binaries (server + kb) **and** the browser webchat UI, in one container | `8740` (server `/v1`), `8741` (kb `/v1`), `8443` (webchat HTTPS, self-signed) |
+| `aimee-server-kb` | Both aimee binaries (server + kb) **and** the browser webchat UI, in one container | `8743` (server `/v1`, native TLS self-signed; plaintext `8740` loopback-only), `8741` (kb `/v1`), `8443` (webchat HTTPS, self-signed) |
 | `postgres` | `pgvector/pgvector:pg16`, DB2 (`aimee_shared`) for knowledge + vectors | internal |
 | `embedder` | CPU embedder sidecar (`perplexity-ai/pplx-embed-v1-0.6b`) | internal |
 | `llm` *(optional)* | Curator LLM sidecar (Gemma 3n E4B via `llama.cpp`) for doc/code extraction. Off unless you add `--profile curator-llm`; otherwise the curator stays idle or you point `LLM_ENDPOINT` at your own OpenAI-compatible endpoint. | internal |
@@ -45,9 +45,9 @@ The kb auto-applies its DB2 schema (tables + `pg_trgm`/`vector` extensions) on f
 ```bash
 docker compose -f compose.combined.yaml ps          # all services should be "healthy"
 
-# Server /v1 (default bearer is "aimee-local-dev"):
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+# Server /v1 over TLS (default bearer is "aimee-local-dev"; -k accepts the self-signed cert):
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
 
 # In-container kb directly (DB + pgvector status):
 curl 'http://localhost:8741/v1/health?status=1'
@@ -122,12 +122,12 @@ aimee version
 ### 2.2 Point the client at your server
 
 ```bash
-aimee remote set http://YOUR_SERVER:8740 aimee-local-dev
+aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
 aimee remote status     # resolved transport + /v1/health probe
 aimee status            # server, DB1, and kb health
 ```
 
-Use your real bearer token instead of `aimee-local-dev` if you changed it. For an HTTPS server, `https://` works with certificate verification on by default; set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`, or pass `--server http://YOUR_SERVER:8740 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
+Use your real bearer token instead of `aimee-local-dev` if you changed it. The server's `/v1` is TLS-only off-loopback; certificate verification is on by default, so set `AIMEE_TLS_INSECURE=1` for the auto-provisioned self-signed cert (or trust/pin it). Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN`, or pass `--server https://YOUR_SERVER:8743 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
 
 ### 2.3 Configure your AI coding tool
 
@@ -206,12 +206,12 @@ aimee version
 ### 3.2 Point the client at your server
 
 ```powershell
-aimee remote set http://YOUR_SERVER:8740 aimee-local-dev
+aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
 aimee remote status     # shows the resolved transport + a /v1/health probe
 aimee status            # server, DB1, and kb health
 ```
 
-Use your real bearer token instead of `aimee-local-dev` if you changed it. For an HTTPS server, `https://` works with certificate verification on by default (Schannel against the Windows cert store); set `AIMEE_TLS_INSECURE=1` for a self-signed dev cert. Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` environment variables, or pass `--server http://YOUR_SERVER:8740 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
+Use your real bearer token instead of `aimee-local-dev` if you changed it. The server's `/v1` is TLS-only off-loopback; `https://` works with certificate verification on by default (Schannel against the Windows cert store), so set `AIMEE_TLS_INSECURE=1` for the auto-provisioned self-signed cert (or trust/pin it). Alternatives to `aimee remote set`: set `AIMEE_SERVER_URL` / `AIMEE_SERVER_TOKEN` environment variables, or pass `--server https://YOUR_SERVER:8743 --server-token=...` per command. Precedence is `--server` flag > env > persisted `remote.conf`.
 
 ### 3.3 Configure your AI coding tool
 
@@ -299,7 +299,7 @@ aimee version
 ### 4.2 Point the client at your server
 
 ```bash
-aimee remote set http://YOUR_SERVER:8740 aimee-local-dev
+aimee remote set https://YOUR_SERVER:8743 aimee-local-dev
 aimee remote status     # resolved transport + /v1/health probe
 aimee status            # server, DB1, and kb health
 ```

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -28,9 +28,13 @@ It complements [WORKSPACES.md](WORKSPACES.md), [DELEGATES.md](DELEGATES.md), and
 Point the client at the server once:
 
 ```sh
-aimee remote set http://SERVER:8740 <bearer-token>
+aimee remote set https://SERVER:8743 <bearer-token>
 # or per-invocation: --server / AIMEE_SERVER_URL (+ --server-token / AIMEE_SERVER_TOKEN)
 ```
+
+The server's `/v1` is TLS-only off-loopback (`:8743`, auto-provisioned self-signed
+cert; plaintext `:8740` is loopback-only). Set `AIMEE_TLS_INSECURE=1` for the
+self-signed cert, or trust/pin it.
 
 A remote endpoint is "tcp" (`http(s)://host:port`) vs. a co-located unix socket.
 The behaviors below activate only for a **remote tcp** endpoint; co-located use

--- a/scripts/aimee-combined-docker-smoke.sh
+++ b/scripts/aimee-combined-docker-smoke.sh
@@ -24,7 +24,7 @@
 
 set -euo pipefail
 
-SERVER_URL="${SERVER_URL:-http://localhost:8740}"
+SERVER_URL="${SERVER_URL:-https://localhost:8743}"
 KB_URL="${KB_URL:-http://localhost:8741}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.combined.yaml}"
@@ -65,7 +65,7 @@ FAIL=0
 check() {
   local name="$1" expect="$2"; shift 2
   local body
-  if body="$(curl -fsS --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)" && [[ "$body" == *"$expect"* ]]; then
+  if body="$(curl -fsS -k --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)" && [[ "$body" == *"$expect"* ]]; then
     green "  PASS  $name"; PASS=$((PASS + 1))
   else
     red   "  FAIL  $name"
@@ -77,7 +77,7 @@ check() {
 check_status() {
   local name="$1" want="$2"; shift 2
   local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$@" 2>/dev/null || true)"
+  code="$(curl -s -k -o /dev/null -w '%{http_code}' --max-time 15 "$@" 2>/dev/null || true)"
   if [[ "$code" == "$want" ]]; then
     green "  PASS  $name (HTTP $code)"; PASS=$((PASS + 1))
   else

--- a/scripts/aimee-server-docker-smoke.sh
+++ b/scripts/aimee-server-docker-smoke.sh
@@ -24,7 +24,7 @@
 #   scripts/aimee-server-docker-smoke.sh --up --down # also tear down after
 #
 # Env:
-#   SERVER_URL    base URL of the server /v1 API  (default http://localhost:8740)
+#   SERVER_URL    base URL of the server /v1 API  (default https://localhost:8743)
 #   KB_URL        base URL of the kb /v1 API      (default http://localhost:8741)
 #   BEARER        server bearer token             (default aimee-local-dev)
 #   COMPOSE_FILE  compose file(s), space-separated (default compose.server.yaml);
@@ -36,7 +36,7 @@
 
 set -euo pipefail
 
-SERVER_URL="${SERVER_URL:-http://localhost:8740}"
+SERVER_URL="${SERVER_URL:-https://localhost:8743}"
 KB_URL="${KB_URL:-http://localhost:8741}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.server.yaml}"
@@ -79,7 +79,8 @@ check() {
   # check <name> <expected-substring> <curl-args...>
   local name="$1" expect="$2"; shift 2
   local body
-  if body="$(curl -fsS --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)" && [[ "$body" == *"$expect"* ]]; then
+  # -k: the server's /v1 TLS uses an auto-provisioned self-signed cert (harmless for the kb's http URL).
+  if body="$(curl -fsS -k --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)" && [[ "$body" == *"$expect"* ]]; then
     green "  PASS  $name"
     PASS=$((PASS + 1))
   else
@@ -94,7 +95,7 @@ check_status() {
   # check_status <name> <expected-http-code> <curl-args...>  (no auth header added)
   local name="$1" want="$2"; shift 2
   local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$@" 2>/dev/null || true)"
+  code="$(curl -s -k -o /dev/null -w '%{http_code}' --max-time 15 "$@" 2>/dev/null || true)"
   if [[ "$code" == "$want" ]]; then
     green "  PASS  $name (HTTP $code)"
     PASS=$((PASS + 1))

--- a/scripts/aimee-server-standalone-docker-smoke.sh
+++ b/scripts/aimee-server-standalone-docker-smoke.sh
@@ -17,14 +17,14 @@
 #   scripts/aimee-server-standalone-docker-smoke.sh --up        # build + up first
 #   scripts/aimee-server-standalone-docker-smoke.sh --up --down # tear down after
 #
-# Env: SERVER_URL (default http://localhost:8740), BEARER (default aimee-local-dev),
+# Env: SERVER_URL (default https://localhost:8743), BEARER (default aimee-local-dev),
 #      COMPOSE_FILE (default compose.server-standalone.yaml), WAIT_SECONDS (300).
 #
 # Exit code: 0 = all checks passed.
 
 set -euo pipefail
 
-SERVER_URL="${SERVER_URL:-http://localhost:8740}"
+SERVER_URL="${SERVER_URL:-https://localhost:8743}"
 BEARER="${BEARER:-aimee-local-dev}"
 COMPOSE_FILE="${COMPOSE_FILE:-compose.server-standalone.yaml}"
 WAIT_SECONDS="${WAIT_SECONDS:-300}"
@@ -55,7 +55,7 @@ FAIL=0
 check() {
   local name="$1" expect="$2"; shift 2
   local body
-  if body="$(curl -fsS --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)" && [[ "$body" == *"$expect"* ]]; then
+  if body="$(curl -fsS -k --max-time 20 "${AUTH[@]}" "$@" 2>/dev/null)" && [[ "$body" == *"$expect"* ]]; then
     green "  PASS  $name"; PASS=$((PASS + 1))
   else
     red   "  FAIL  $name"
@@ -67,7 +67,7 @@ check() {
 check_status() {
   local name="$1" want="$2"; shift 2
   local code
-  code="$(curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$@" 2>/dev/null || true)"
+  code="$(curl -s -k -o /dev/null -w '%{http_code}' --max-time 15 "$@" 2>/dev/null || true)"
   if [[ "$code" == "$want" ]]; then
     green "  PASS  $name (HTTP $code)"; PASS=$((PASS + 1))
   else

--- a/scripts/aimee-write-read-e2e.sh
+++ b/scripts/aimee-write-read-e2e.sh
@@ -16,12 +16,12 @@
 # use compose.remote-writes.yaml (or mount a config) to enable it. If writes are
 # refused, this script says so explicitly rather than silently passing.
 #
-# Env: SERVER_URL (default http://localhost:8740), BEARER (default aimee-local-dev).
+# Env: SERVER_URL (default https://localhost:8743), BEARER (default aimee-local-dev).
 # Exit code: 0 = the sentinel round-tripped through store→list→search.
 
 set -uo pipefail
 
-SERVER_URL="${SERVER_URL:-http://localhost:8740}"
+SERVER_URL="${SERVER_URL:-https://localhost:8743}"
 BEARER="${BEARER:-aimee-local-dev}"
 AUTH=(-H "Authorization: Bearer ${BEARER}")
 JSON=(-H 'content-type: application/json')
@@ -43,7 +43,7 @@ bad() { red   "  FAIL  $*"; FAIL=$((FAIL + 1)); }
 bold "==> Write→read round-trip at ${SERVER_URL} (sentinel ${SENT})"
 
 # 1) STORE -----------------------------------------------------------------
-store_body="$(curl -s "${AUTH[@]}" "${JSON[@]}" -X POST \
+store_body="$(curl -s -k "${AUTH[@]}" "${JSON[@]}" -X POST \
   -d "{\"key\":\"${KEY}\",\"content\":\"${CONTENT}\",\"kind\":\"fact\"}" \
   "${SERVER_URL}/v1/memory/store" 2>/dev/null)"
 if [[ "$store_body" == *'"status":"ok"'* && "$store_body" == *'"id"'* ]]; then
@@ -56,7 +56,7 @@ else
 fi
 
 # 2) LIST reads it back verbatim ------------------------------------------
-list_body="$(curl -s "${AUTH[@]}" "${JSON[@]}" -X POST -d '{"limit":50}' \
+list_body="$(curl -s -k "${AUTH[@]}" "${JSON[@]}" -X POST -d '{"limit":50}' \
   "${SERVER_URL}/v1/memory/list" 2>/dev/null)"
 if [[ "$list_body" == *"$SENT"* ]]; then
   ok "list returns the stored content (round-trip persisted)"
@@ -65,7 +65,7 @@ else
 fi
 
 # 3) SEARCH retrieves it by keyword ---------------------------------------
-search_body="$(curl -s "${AUTH[@]}" "${JSON[@]}" -X POST \
+search_body="$(curl -s -k "${AUTH[@]}" "${JSON[@]}" -X POST \
   -d "{\"keywords\":[\"${SENT}\"],\"limit\":10}" \
   "${SERVER_URL}/v1/memory/search" 2>/dev/null)"
 if [[ "$search_body" == *"$SENT"* ]]; then

--- a/scripts/e2e-matrix.sh
+++ b/scripts/e2e-matrix.sh
@@ -84,10 +84,12 @@ have_docker() { command -v docker >/dev/null 2>&1 && docker info >/dev/null 2>&1
 is_linux() { [[ "$(uname -s)" == "Linux" ]]; }
 
 # Published host ports (shift by --port-offset to dodge ports already in use on
-# the host — e.g. an existing aimee-server on :8740). Container ports never move.
-SERVER_PORT=$((8740 + PORT_OFFSET))
+# the host). Container ports never move. The server's published /v1 is native TLS
+# on 8743 (plaintext 8740 is loopback-only inside the container); the kb stays
+# plaintext http on 8741.
+SERVER_PORT=$((8743 + PORT_OFFSET))
 KB_PORT=$((8741 + PORT_OFFSET))
-SERVER_URL="http://localhost:${SERVER_PORT}"
+SERVER_URL="https://localhost:${SERVER_PORT}"
 [[ -z "$KB_URL" ]] && KB_URL="http://localhost:${KB_PORT}"
 
 OVERRIDE_DIR=""
@@ -143,9 +145,9 @@ run_docker_topology() {
 # Trailing svc=host:ctr specs name which published ports to remap by
 # PORT_OFFSET; ignored when --port-offset is 0.
 run_docker_topology T1 "Docker kb-only"            aimee-kb-docker-smoke.sh                compose.yaml                     "aimee-kb=${KB_PORT}:8741"
-run_docker_topology T2 "Docker server+kb split"    aimee-server-docker-smoke.sh            compose.server.yaml              "aimee-server=${SERVER_PORT}:8740" "aimee-kb=${KB_PORT}:8741"
-run_docker_topology T3 "Docker server standalone"  aimee-server-standalone-docker-smoke.sh compose.server-standalone.yaml   "aimee-server=${SERVER_PORT}:8740"
-run_docker_topology T4 "Docker combined server+kb" aimee-combined-docker-smoke.sh          compose.combined.yaml            "aimee-server-kb=${SERVER_PORT}:8740,${KB_PORT}:8741"
+run_docker_topology T2 "Docker server+kb split"    aimee-server-docker-smoke.sh            compose.server.yaml              "aimee-server=${SERVER_PORT}:8743" "aimee-kb=${KB_PORT}:8741"
+run_docker_topology T3 "Docker server standalone"  aimee-server-standalone-docker-smoke.sh compose.server-standalone.yaml   "aimee-server=${SERVER_PORT}:8743"
+run_docker_topology T4 "Docker combined server+kb" aimee-combined-docker-smoke.sh          compose.combined.yaml            "aimee-server-kb=${SERVER_PORT}:8743,${KB_PORT}:8741"
 
 # --- Local topologies (Linux only) ----------------------------------------
 if selected T5; then

--- a/src/README.md
+++ b/src/README.md
@@ -705,12 +705,13 @@ cd aimee
 docker compose -f compose.combined.yaml up --build -d
 ```
 
-The server fronts `/v1` on `:8740` (default bearer `aimee-local-dev`) and reaches
-the in-container kb on `:8741`. Confirm it's live:
+The server fronts `/v1` over native TLS on `:8743` (default bearer `aimee-local-dev`;
+self-signed cert, plaintext `:8740` is loopback-only) and reaches the in-container kb
+on `:8741`. Confirm it's live (`-k` accepts the self-signed cert):
 
 ```bash
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
 ```
 
 **Combined vs. split.** The combined container (`compose.combined.yaml`) is the
@@ -735,15 +736,15 @@ Point the client at the server per-invocation, via the environment, or persist i
 
 ```bash
 # Per-invocation:
-aimee --server http://my-host:8740 --server-token=aimee-local-dev status
+aimee --server https://my-host:8743 --server-token=aimee-local-dev status
 
 # Or via environment (applies to every command):
-export AIMEE_SERVER_URL=http://my-host:8740
+export AIMEE_SERVER_URL=https://my-host:8743
 export AIMEE_SERVER_TOKEN=aimee-local-dev
 aimee status
 
 # Or persist it (stored in <aimee_home>/remote.conf):
-aimee remote set http://my-host:8740 aimee-local-dev
+aimee remote set https://my-host:8743 aimee-local-dev
 aimee remote status   # shows the resolved transport + a /v1/health probe
 aimee remote clear    # revert to a local Unix socket
 ```
@@ -792,7 +793,9 @@ where supported (systemd user units on Linux, launchd agents on macOS), enables
 If a dependency is missing, `install.sh` stops and points you back at
 `install-deps.sh`. On **Windows**, aimee runs as the thin client only (server + kb
 run in Docker or on Linux/macOS): run `install.ps1`, point it at your server with
-`aimee remote set http://host:8740 <token>`, and run `configure-hooks.ps1`.
+`aimee remote set https://host:8743 <token>` (the server's `/v1` is TLS-only
+off-loopback with a self-signed cert, so set `AIMEE_TLS_INSECURE=1` or trust it),
+and run `configure-hooks.ps1`.
 
 The C services (`aimee`, `aimee-server`, `aimee-kb`) need no Go. The browser UI
 (`aimee-webchat`) is the only Go artifact and is **optional**: `install.sh` builds
@@ -948,8 +951,8 @@ Trade-offs: [retrieval-stack.md](../docs/retrieval-stack.md#choosing-a-tier).
 
 | File | Brings up | Use when |
 |------|-----------|----------|
-| `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default**: both binaries co-located; server `/v1` on `:8740`, kb `:8741` |
-| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack: scale/update/place server and kb independently; server `:8740`, kb `:8741` |
+| `compose.combined.yaml` | **`aimee-server+kb`** (one container) + Postgres + embedder | **Recommended default**: both binaries co-located; server `/v1` over TLS on `:8743` (plaintext `:8740` loopback-only), kb `:8741` |
+| `compose.server.yaml` | `aimee-server` + `aimee-kb` + Postgres + embedder | Split stack: scale/update/place server and kb independently; server `/v1` over TLS on `:8743` (plaintext `:8740` loopback-only), kb `:8741` |
 | `compose.yaml` | `aimee-kb` + Postgres (pgvector) + embedder | The knowledge service (DB2 + vectors) on its own: building block for a shared/scaled kb |
 | `compose.server-standalone.yaml` | `aimee-server` only (SQLite DB1, no kb) | DB1-backed `/v1` endpoints with no shared knowledge |
 
@@ -960,13 +963,14 @@ docker compose -f compose.combined.yaml up --build -d
 ```
 
 One `aimee-server+kb` container runs **both** binaries: the kb on loopback `:8741`
-inside the container and the server fronting `:8740` with
-`AIMEE_KB_API_URL=http://127.0.0.1:8741`. Postgres + the embedder stay external.
-Both ports are also published for direct inspection:
+inside the container and the server fronting `/v1` over native TLS on `:8743`
+(plaintext `:8740` is loopback-only) with `AIMEE_KB_API_URL=http://127.0.0.1:8741`.
+Postgres + the embedder stay external. The TLS server and kb ports are published for
+direct inspection (`-k` accepts the self-signed cert):
 
 ```bash
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
 curl 'http://localhost:8741/v1/health?status=1'   # in-container kb: DB + pgvector status
 ```
 
@@ -977,12 +981,13 @@ docker compose -f compose.server.yaml up --build -d
 ```
 
 `aimee-server` and `aimee-kb` run as separate containers (many servers → one shared
-kb). The server fronts `/v1` on `:8740` and reaches the kb over HTTP
+kb). The server fronts `/v1` over native TLS on `:8743` (plaintext `:8740` is
+loopback-only) and reaches the kb over HTTP
 (`AIMEE_KB_API_URL=http://aimee-kb:8741`); the kb owns Postgres + the embedder:
 
 ```bash
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/health
-curl -H 'Authorization: Bearer aimee-local-dev' http://localhost:8740/v1/kb/status
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/health
+curl -k -H 'Authorization: Bearer aimee-local-dev' https://localhost:8743/v1/kb/status
 ```
 
 Both server stacks mount a dedicated **`aimee-server-workspaces`** volume at

--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -213,6 +213,27 @@ static char *read_response(int fd, aimee_tls_t *tls, size_t *out_len)
    return resp;
 }
 
+/* A non-loopback plaintext connection must never carry a credential. localhost,
+ * 127.0.0.0/8, and ::1 are the only hosts where a cleartext bearer stays on the
+ * machine; anything else would put it on the wire. */
+static int host_is_loopback(const char *host)
+{
+   if (!host || !host[0])
+      return 0;
+   if (strcmp(host, "localhost") == 0 || strcmp(host, "::1") == 0 || strcmp(host, "[::1]") == 0)
+      return 1;
+   return strncmp(host, "127.", 4) == 0; /* 127.0.0.0/8 */
+}
+
+/* Security guard (also exposed for tests): 1 when sending |token| to a server at
+ * (|is_https|, |host|) would put the credential on the wire in cleartext — a
+ * non-empty bearer over plaintext http:// to a non-loopback host. tcp_request
+ * refuses such requests rather than leak the bearer. */
+int aimee_client_would_leak_cleartext(int is_https, const char *host, const char *token)
+{
+   return (token && *token && !is_https && !host_is_loopback(host)) ? 1 : 0;
+}
+
 static char *tcp_request(const char *url, const char *token, const char *method, const char *path,
                          const char *body, int *status_out)
 {
@@ -221,6 +242,21 @@ static char *tcp_request(const char *url, const char *token, const char *method,
    if (parse_url(url, host, sizeof(host), port, sizeof(port), &is_https) != 0)
    {
       fprintf(stderr, "aimee: invalid server URL: %s\n", url);
+      return NULL;
+   }
+
+   /* Fail closed: never transmit a bearer credential in cleartext to a
+    * non-loopback host. A plaintext http:// connection to a remote server would
+    * expose the bearer (and every payload) on the wire — the client refuses
+    * rather than leak it. Loopback plaintext is fine (local tooling / a
+    * co-located TLS-terminating proxy); remote access must use https://. */
+   if (aimee_client_would_leak_cleartext(is_https, host, token))
+   {
+      fprintf(stderr,
+              "aimee: refusing to send credentials over plaintext http:// to non-loopback host "
+              "'%s'. Use https:// (the server's TLS port); set AIMEE_TLS_INSECURE=1 if the server "
+              "presents a self-signed certificate.\n",
+              host);
       return NULL;
    }
 #ifndef WITH_TLS

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -850,7 +850,7 @@ static int launch_session_with_input(int json_output, int debug, int default_lau
     * client's working tree over the reverse-channel so those tools act here (the
     * client never absorbs the engine or a DB). A co-located server uses the local
     * socket as before. */
-   int remote = cli_v1_remote_endpoint_is_tcp();
+   int remote = cli_v1_remote_endpoint_is_network();
    const char *sock = NULL;
    if (remote)
    {
@@ -1383,7 +1383,7 @@ static char *acp_dispatch_prompt(const char *content, const char *session_id)
 {
    /* ACP turns run the agent locally (see launch_session_with_input); a remote
     * /v1 endpoint cannot serve them. */
-   if (cli_v1_remote_endpoint_is_tcp())
+   if (cli_v1_remote_endpoint_is_network())
       return NULL;
    const char *sock = cli_ensure_server_for_method("chat.send_stream");
    if (!sock)
@@ -1779,7 +1779,7 @@ int main(int argc, char **argv)
     * root lives on THIS host, which the server cannot read. Resolve + register +
     * ingest from the client rather than forwarding the raw path (which the
     * server would try to realpath against its own filesystem and reject). */
-   if (cli_v1_remote_endpoint_is_tcp())
+   if (cli_v1_remote_endpoint_is_network())
    {
       if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "add") == 0)
          return cli_workspace_add_remote(sub_argc >= 2 ? sub_argv[1] : NULL);

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -6906,21 +6906,25 @@ int cli_v1_has_remote_endpoint(void)
 #endif
 }
 
-/* cli_v1_remote_endpoint_is_tcp: like cli_v1_has_remote_endpoint, but true only
- * for a genuinely remote "tcp:host:port" endpoint (not a local "unix:" one).
- * Interactive/co-located commands (chat, launch) use this to refuse a remote
- * server cleanly — the agent + tools + worktree run on this host. Non-static so
- * cli_main.c can call it. */
-int cli_v1_remote_endpoint_is_tcp(void)
+/* cli_v1_remote_endpoint_is_network: like cli_v1_has_remote_endpoint, but true
+ * only for a genuinely remote network endpoint — "tcp:host:port" (http) OR
+ * "tls:host:port" (https) — never a local "unix:" one. Two callers rely on it:
+ * interactive/co-located commands (chat, launch) refuse a remote server cleanly
+ * (the agent + tools + worktree run on this host); and the thin-client
+ * workspace/index push uses it to detect that the server cannot read this host's
+ * filesystem. A TLS remote is no less remote than a plaintext one — matching
+ * only "tcp:" here silently broke client-side push once remotes went TLS-only.
+ * Non-static so cli_main.c can call it. */
+int cli_v1_remote_endpoint_is_network(void)
 {
 #if !defined(_WIN32) && !defined(_WIN64)
    /* A synthesized aimee_client target (--server / AIMEE_SERVER_URL / remote.conf)
-    * is always "tcp:host:port" (a network host, never a local unix: path), so
-    * chat/launch refuse it here just like an explicit tcp: endpoint. */
+    * is "tcp:host:port" (http) or "tls:host:port" (https) — a network host, never
+    * a local unix: path. Either scheme means the server cannot see this host. */
    char *ep = cli_v1_client_endpoint();
-   int is_tcp = ep && strncmp(ep, "tcp:", 4) == 0;
+   int is_net = ep && (strncmp(ep, "tcp:", 4) == 0 || strncmp(ep, "tls:", 4) == 0);
    free(ep);
-   return is_tcp;
+   return is_net;
 #else
    /* The Windows thin client's only remote target comes from aimee_client
     * (AIMEE_SERVER_URL / --server), which is always a tcp:host:port network

--- a/src/headers/aimee_client.h
+++ b/src/headers/aimee_client.h
@@ -72,6 +72,13 @@ extern "C"
    char *aimee_client_request(const char *method, const char *path, const char *body,
                               int *status_out);
 
+   /* Security guard: returns 1 when transmitting bearer |token| to a server at
+    * (|is_https|, |host|) would expose the credential in cleartext — a non-empty
+    * token over plaintext http:// to a non-loopback host. The remote-TCP request
+    * path refuses such a request rather than leak the bearer on the wire.
+    * Exposed for unit testing of the invariant. */
+   int aimee_client_would_leak_cleartext(int is_https, const char *host, const char *token);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/cli_client.h
+++ b/src/headers/cli_client.h
@@ -218,10 +218,12 @@ int cli_v1_forward(const char *socket_path, const cli_v1_route_t *route, int jso
  * aimee.api.client_endpoint set). Callers skip the local-socket preflight. */
 int cli_v1_has_remote_endpoint(void);
 
-/* True only when the configured endpoint is a remote "tcp:host:port" (not a
- * local "unix:" path). Interactive commands (chat/launch) refuse a remote
- * endpoint because the agent/tools/worktree run on the client host. */
-int cli_v1_remote_endpoint_is_tcp(void);
+/* True only when the configured endpoint is a remote network endpoint —
+ * "tcp:host:port" (http) or "tls:host:port" (https) — not a local "unix:" path.
+ * Interactive commands (chat/launch) refuse a remote endpoint because the
+ * agent/tools/worktree run on the client host; the thin-client workspace/index
+ * push uses it to know the server cannot read this host's files. */
+int cli_v1_remote_endpoint_is_network(void);
 
 /* Resolve the remote /v1 endpoint ("tcp:host:port" / "unix:path") and bearer for
  * the HTTP transport (env AIMEE_API_ENDPOINT / AIMEE_API_BEARER, else aimee.yaml

--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -45,6 +45,12 @@ extern "C"
                            long expires_at, int revoked),
                 void *ctx);
 
+   /* Provision a self-signed EC P-256 server cert at (cert_path, key_path) when
+    * neither exists yet — makes native TLS zero-config when a tls_port is set but
+    * no operator cert is present. Never overwrites an existing cert/key. The key
+    * is written 0600. Returns 0 if a usable cert is in place, -1 on failure. */
+   int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_path);
+
    /* For tests: drop cached CA + snapshot so a fresh AIMEE_HOME is picked up. */
    void pki_reset_for_test(void);
 

--- a/src/headers/server_http.h
+++ b/src/headers/server_http.h
@@ -28,6 +28,15 @@ extern "C"
    int server_http_start(const char *uds_path, int tcp_port, int tls_port, const char *bearer_token,
                          int rate_limit_per_min, int remote_writes);
 
+   /* Pure bind-address decision for a TCP /v1 listener (no I/O — unit-testable).
+    * want_external is 1 when AIMEE_SERVER_HTTP_BIND requests a 0.0.0.0 bind;
+    * allow_external is 1 ONLY for the native-TLS listener. A plaintext listener
+    * (allow_external == 0) is pinned to INADDR_LOOPBACK even when an external
+    * bind is requested, so the bearer and credentials can never face the network
+    * in cleartext. Returns INADDR_ANY only when (want_external && allow_external),
+    * else INADDR_LOOPBACK (both in host byte order). */
+   uint32_t server_http_resolve_bind_addr(int want_external, int allow_external);
+
    /* Pure authorization decision for one HTTP request (no I/O — unit-testable).
     *   is_tcp          : the request arrived on the TCP listener (bearer
     *                     required) vs the UDS (filesystem-permission auth).

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -10,17 +10,20 @@
 #include <sqlite3.h>
 
 #include <openssl/bn.h>
+#include <openssl/crypto.h> /* OPENSSL_cleanse */
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <openssl/pem.h>
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
+#include <fcntl.h> /* open (0600 key file) */
 #include <pthread.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+#include <unistd.h> /* gethostname, close */
 
 #define PKI_CA_AGENT     "__pki_ca__" /* vault agent name under which the CA key is sealed */
 #define PKI_CA_CN        "aimee-client-CA"
@@ -227,6 +230,106 @@ static int set_random_serial(X509 *cert, char *hex_out, size_t hex_len)
    if (back)
       BN_free(back);
    return hex_out[0] ? 0 : -1;
+}
+
+/* Generate a self-signed EC P-256 server certificate at (cert_path, key_path)
+ * when neither already exists. Makes native TLS zero-config: with
+ * aimee.api.tls_port set but no operator cert present, the server provisions its
+ * own rather than fall back to a plaintext-only listener. The channel is secured
+ * regardless of trust; clients pin the cert or pass AIMEE_TLS_INSECURE=1. The key
+ * is written 0600; the cert (public) is world-readable. Returns 0 if a usable
+ * cert exists (already present or freshly written), -1 on failure (logged). */
+int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_path)
+{
+   if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
+      return -1;
+   struct stat st;
+   if (stat(cert_path, &st) == 0 && stat(key_path, &st) == 0)
+      return 0; /* operator- or previously-provisioned cert: never overwrite */
+
+   EVP_PKEY *key = gen_ec_key();
+   if (!key)
+      return -1;
+   X509 *cert = X509_new();
+   if (!cert)
+   {
+      EVP_PKEY_free(key);
+      return -1;
+   }
+   int rc = -1;
+   char serial[64] = "";
+   char cn[200];
+   if (gethostname(cn, sizeof(cn)) != 0 || !cn[0])
+      snprintf(cn, sizeof(cn), "aimee-server");
+   cn[sizeof(cn) - 1] = '\0';
+   char san[300];
+   snprintf(san, sizeof(san), "DNS:%s,DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1", cn);
+
+   X509_set_version(cert, 2);
+   X509_NAME *name = X509_get_subject_name(cert);
+   if (set_random_serial(cert, serial, sizeof(serial)) != 0 || set_name_cn(name, cn) != 0 ||
+       X509_set_issuer_name(cert, name) != 1 || !X509_gmtime_adj(X509_getm_notBefore(cert), 0) ||
+       !X509_gmtime_adj(X509_getm_notAfter(cert), (long)3650 * 24 * 3600) ||
+       X509_set_pubkey(cert, key) != 1 ||
+       add_ext(cert, NULL, NID_basic_constraints, "critical,CA:FALSE") != 0 ||
+       add_ext(cert, NULL, NID_key_usage, "critical,digitalSignature,keyEncipherment") != 0 ||
+       add_ext(cert, NULL, NID_ext_key_usage, "serverAuth") != 0 ||
+       add_ext(cert, NULL, NID_subject_alt_name, san) != 0 ||
+       X509_sign(cert, key, EVP_sha256()) == 0)
+      goto done;
+   {
+      char *key_pem = pem_private_key(key);
+      char *cert_pem = pem_cert(cert);
+      if (!key_pem || !cert_pem)
+      {
+         free(key_pem);
+         free(cert_pem);
+         goto done;
+      }
+      char dir[MAX_PATH_LEN];
+      snprintf(dir, sizeof(dir), "%s/tls", config_default_dir());
+      mkdir(dir, 0700);
+      int ok = 0;
+      int kfd = open(key_path, O_WRONLY | O_CREAT | O_TRUNC, 0600);
+      if (kfd >= 0)
+      {
+         FILE *kf = fdopen(kfd, "w");
+         if (kf)
+         {
+            fputs(key_pem, kf);
+            if (fclose(kf) == 0)
+            {
+               FILE *cf = fopen(cert_path, "w");
+               if (cf)
+               {
+                  fputs(cert_pem, cf);
+                  if (fclose(cf) == 0)
+                     ok = 1;
+               }
+            }
+         }
+         else
+            close(kfd);
+      }
+      OPENSSL_cleanse(key_pem, strlen(key_pem));
+      free(key_pem);
+      free(cert_pem);
+      if (ok)
+      {
+         rc = 0;
+         aimee_log(LOG_INFO, "pki", "generated self-signed server TLS cert (CN=%s) at %s", cn,
+                   cert_path);
+      }
+      else
+         aimee_log(LOG_ERROR, "pki", "failed to write self-signed server TLS cert to %s/%s",
+                   cert_path, key_path);
+   }
+done:
+   if (key)
+      EVP_PKEY_free(key);
+   if (cert)
+      X509_free(cert);
+   return rc;
 }
 
 /* --- CA --- */

--- a/src/server/server_http.c
+++ b/src/server/server_http.c
@@ -1842,17 +1842,16 @@ static void *listener_thread(void *arg)
    return NULL;
 }
 
-/* Bind the optional localhost TCP listener. Returns the fd, or -1 (logged) when
- * disabled or on error — the UDS listener carries on regardless. */
-static int tcp_listen(int tcp_port, const char *bearer_token)
+/* Bind a TCP /v1 listener (fd, or -1 logged; the UDS listener carries on). |allow_external|
+ * gates a 0.0.0.0 bind: 1 ONLY for the TLS listener. The plaintext listener passes 0 and is
+ * ALWAYS loopback-bound, so credentials never cross the wire in cleartext. */
+static int tcp_listen(int tcp_port, const char *bearer_token, int allow_external)
 {
    if (tcp_port <= 0)
       return -1;
    if (!bearer_token || !bearer_token[0])
    {
-      LOG_WARN("server.http",
-               "aimee.api.http_port=%d set but no bearer_token configured; "
-               "refusing to bind TCP listener",
+      LOG_WARN("server.http", "aimee.api port=%d set but no bearer_token; refusing to bind TCP",
                tcp_port);
       return -1;
    }
@@ -1861,14 +1860,16 @@ static int tcp_listen(int tcp_port, const char *bearer_token)
       return -1;
    int yes = 1;
    setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(yes));
-   /* Loopback by default. Set AIMEE_SERVER_HTTP_BIND (any non-empty value) to
-    * bind 0.0.0.0 instead — needed when the listener must be reachable from
-    * outside the host (e.g. a container's published port, where traffic
-    * arrives on a non-loopback interface). Mirrors aimee-kb's
-    * AIMEE_KB_HTTP_BIND. The bearer requirement still applies on every request,
-    * so a wider bind does not weaken auth. */
+   /* AIMEE_SERVER_HTTP_BIND requests 0.0.0.0 — honoured for TLS only (plaintext stays loopback). */
    const char *bind_all = getenv("AIMEE_SERVER_HTTP_BIND");
-   in_addr_t bind_addr = (bind_all && bind_all[0]) ? INADDR_ANY : INADDR_LOOPBACK;
+   int want_external = (bind_all && bind_all[0]) ? 1 : 0;
+   if (want_external && !allow_external)
+      LOG_ERROR("server.http",
+                "AIMEE_SERVER_HTTP_BIND ignored for plaintext /v1 on port %d: a non-loopback "
+                "plaintext bind would expose credentials in cleartext. Set aimee.api.tls_port "
+                "for remote access; binding 127.0.0.1 only.",
+                tcp_port);
+   in_addr_t bind_addr = server_http_resolve_bind_addr(want_external, allow_external);
    struct sockaddr_in addr;
    memset(&addr, 0, sizeof(addr));
    addr.sin_family = AF_INET;
@@ -1917,7 +1918,7 @@ int server_http_start(const char *uds_path, int tcp_port, int tls_port, const ch
    g_remote_writes = remote_writes;
    g_rate_state.window_start = 0;
    g_rate_state.count = 0;
-   g_tcp_fd = tcp_listen(tcp_port, bearer_token);
+   g_tcp_fd = tcp_listen(tcp_port, bearer_token, 0 /* plaintext: loopback only */);
 
    /* Optional native-TLS listener (phase 1b): terminate TLS in-process from
     * <config>/tls/server.{crt,key}. A TLS+bearer conn is the vault's attested
@@ -1925,7 +1926,7 @@ int server_http_start(const char *uds_path, int tcp_port, int tls_port, const ch
    if (tls_port > 0)
    {
       if (server_tls_init_default() == 0)
-         g_tls_fd = tcp_listen(tls_port, bearer_token);
+         g_tls_fd = tcp_listen(tls_port, bearer_token, 1 /* TLS: may bind 0.0.0.0 */);
       else
          /* This is the vault's attested write path — make a misconfigured cert/key
           * loud (the UDS listener still comes up; the operator must fix the cert). */
@@ -1964,14 +1965,12 @@ int server_http_start(const char *uds_path, int tcp_port, int tls_port, const ch
       return -1;
    }
    pthread_detach(g_thread);
+   /* The TLS listener (when up) logs its own "native TLS enabled" line from server_tls. */
    if (g_tcp_fd >= 0)
-   {
-      const char *bind_all = getenv("AIMEE_SERVER_HTTP_BIND");
-      LOG_INFO("server.http", "HTTP /v1 listening on %s and %s:%d (bearer)", uds_path,
-               (bind_all && bind_all[0]) ? "0.0.0.0" : "127.0.0.1", tcp_port);
-   }
+      LOG_INFO("server.http", "HTTP /v1 on %s and 127.0.0.1:%d (bearer, loopback only)", uds_path,
+               tcp_port);
    else
-      LOG_INFO("server.http", "HTTP /v1 listening on %s", uds_path);
+      LOG_INFO("server.http", "HTTP /v1 on %s", uds_path);
    return 0;
 }
 

--- a/src/server/server_http_reqctx.c
+++ b/src/server/server_http_reqctx.c
@@ -10,10 +10,20 @@
 #include "server_http.h"
 #include "request_context.h"
 #include "config.h"
+#include <netinet/in.h> /* INADDR_ANY / INADDR_LOOPBACK */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/socket.h>
+
+/* Pure bind-address decision for a TCP /v1 listener (see server_http.h). A
+ * plaintext listener (allow_external == 0) is pinned to loopback even when an
+ * external bind is requested, so credentials never face the network in cleartext;
+ * only the TLS listener may bind 0.0.0.0. */
+uint32_t server_http_resolve_bind_addr(int want_external, int allow_external)
+{
+   return (want_external && allow_external) ? INADDR_ANY : INADDR_LOOPBACK;
+}
 
 /* Constant-time string compare (avoid leaking the proxy secret via timing). */
 static int reqctx_ct_equal(const char *a, const char *b)

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -194,6 +194,14 @@ int server_tls_init_default(void)
    snprintf(key, sizeof(key), "%s/tls/server.key", config_default_dir());
    config_t cfg;
    config_load(&cfg);
+   /* Secure-by-default: when a tls_port is configured but no cert exists, the
+    * server provisions a self-signed one rather than fall back to a plaintext
+    * listener (the remote path now REQUIRES TLS — plaintext /v1 is loopback-only).
+    * An operator-supplied cert at the same path is left untouched. mTLS still
+    * needs an operator-issued client CA, so this self-signed path is server-TLS
+    * only (mtls==0); when mTLS is required the operator must supply the cert. */
+   if (cfg.server_api_mtls == 0)
+      pki_ensure_self_signed_server_cert(cert, key);
    /* When mTLS is on, ensure aimee's client CA exists (create-or-load) and the
     * revocation snapshot is loaded BEFORE server_tls_init loads the client CA
     * file and the verify callback starts consulting the snapshot. */

--- a/src/tests/test_aimee_client.c
+++ b/src/tests/test_aimee_client.c
@@ -291,6 +291,31 @@ static void test_tls_roundtrip(void)
 }
 #endif /* WITH_TLS */
 
+/* The credential-in-cleartext guard: a non-empty bearer over plaintext http://
+ * to a non-loopback host must be refused; loopback and https are allowed. */
+static void test_cleartext_credential_guard(void)
+{
+   /* Blocked: a real bearer over plaintext http:// to a remote address. */
+   assert(aimee_client_would_leak_cleartext(0, "192.168.1.254", "secret") == 1);
+   assert(aimee_client_would_leak_cleartext(0, "example.com", "secret") == 1);
+   assert(aimee_client_would_leak_cleartext(0, "10.0.0.5", "tok") == 1);
+
+   /* Allowed: TLS carries the bearer confidentially regardless of host. */
+   assert(aimee_client_would_leak_cleartext(1, "192.168.1.254", "secret") == 0);
+
+   /* Allowed: loopback never leaves the machine, plaintext is fine there. */
+   assert(aimee_client_would_leak_cleartext(0, "127.0.0.1", "secret") == 0);
+   assert(aimee_client_would_leak_cleartext(0, "127.5.6.7", "secret") == 0);
+   assert(aimee_client_would_leak_cleartext(0, "localhost", "secret") == 0);
+   assert(aimee_client_would_leak_cleartext(0, "::1", "secret") == 0);
+   assert(aimee_client_would_leak_cleartext(0, "[::1]", "secret") == 0);
+
+   /* Allowed: no credential to leak (empty / NULL token). */
+   assert(aimee_client_would_leak_cleartext(0, "example.com", "") == 0);
+   assert(aimee_client_would_leak_cleartext(0, "example.com", NULL) == 0);
+   PASS("cleartext-credential guard: refuses bearer over plaintext to non-loopback");
+}
+
 int main(void)
 {
    printf("test_aimee_client:\n");
@@ -298,6 +323,7 @@ int main(void)
    test_tcp_set_remote_with_token();
    test_remote_active_reporting();
    test_https_unreachable_null();
+   test_cleartext_credential_guard();
 #ifdef WITH_TLS
    test_tls_roundtrip();
 #endif

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -5,6 +5,7 @@
 #include "openai_runs_store.h"
 #include "platform_path.h"
 #include "platform_test_util.h"
+#include <netinet/in.h> /* INADDR_ANY / INADDR_LOOPBACK for the bind-policy test */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -1077,6 +1078,18 @@ int main(void)
    /* (The /v1/rpc method-allowlist tests were removed with the bridge: each method
     * now has a first-class route whose per-route caps + remote_writes tier are
     * enforced by server_http_route_allowed, covered above.) */
+
+   /* --- /v1 listener bind policy: plaintext is loopback-only, always --- */
+   {
+      /* The plaintext listener passes allow_external=0: a non-loopback bind is
+       * refused even when AIMEE_SERVER_HTTP_BIND requests one, so the bearer can
+       * never face the network in cleartext. */
+      assert(server_http_resolve_bind_addr(0 /*want_ext*/, 0 /*plaintext*/) == INADDR_LOOPBACK);
+      assert(server_http_resolve_bind_addr(1 /*want_ext*/, 0 /*plaintext*/) == INADDR_LOOPBACK);
+      /* The TLS listener (allow_external=1) may face the network when asked. */
+      assert(server_http_resolve_bind_addr(0 /*want_ext*/, 1 /*tls*/) == INADDR_LOOPBACK);
+      assert(server_http_resolve_bind_addr(1 /*want_ext*/, 1 /*tls*/) == INADDR_ANY);
+   }
 
    platform_test_rmrf(home);
    printf("OK\n");


### PR DESCRIPTION
## Why

A thin client was pointed at `http://192.168.1.254:8740` (a `remote.conf` written with an `http://` URL). The bearer token — and every API key forwarded through `/v1` (delegate adds, session credentials, payloads) — crossed the LAN **in cleartext**.

The server permitted this by design: the plaintext `/v1` TCP listener honored `AIMEE_SERVER_HTTP_BIND` and bound `0.0.0.0`, with a code comment rationalizing *"the bearer requirement still applies on every request, so a wider bind does not weaken auth."* That conflates **authentication** with **confidentiality** — the bearer is still checked, but it's now readable by anyone on the wire.

The symptom that surfaced it: `aimee agent add <name> <endpoint> <model> --key …` against that server failed with *"vault: `agent add --key` over a plaintext connection cannot store a credential."* The credential vault already refuses to seal a secret over a plaintext TCP bearer (correct!) — but there was **no secure transport configured** to fall back to, so vaulting a delegate key remotely was impossible.

## What (fail closed on both ends)

**Server — plaintext `/v1` is loopback-only, always** (`server_http.c`, `server_http_reqctx.c`)
`AIMEE_SERVER_HTTP_BIND` can widen the **native-TLS** listener only. A non-loopback plaintext bind is refused (logged at ERROR) and falls back to `127.0.0.1`. The bind decision lives in a new pure `server_http_resolve_bind_addr(want_external, allow_external)` — unit-tested truth table.

**Client — never send a bearer in cleartext to a remote host** (`aimee_client.c`)
The remote-TCP request path refuses a non-empty bearer over plaintext `http://` to a non-loopback host. New pure `aimee_client_would_leak_cleartext(is_https, host, token)` predicate — unit-tested. Loopback (`127.0.0.0/8`, `localhost`, `::1`) and `https://` are unaffected, so local UDS/loopback dev and TLS remotes keep working.

**Server — secure-by-default TLS** (`pki.c`, `server_tls.c`)
When `aimee.api.tls_port` is set but no cert exists, the server auto-provisions a self-signed EC P-256 cert at `$AIMEE_HOME/tls/server.{crt,key}` (CN = hostname; SANs `localhost`/`127.0.0.1`/`::1`; `serverAuth` EKU; `CA:FALSE`; key `0600`) instead of falling back to a plaintext-only listener. An operator-supplied cert at that path is never overwritten. mTLS deployments still require an operator-issued cert.

**Deploy — secure out of the box**
`aimee-combined.yaml` / `aimee-server.yaml` / `aimee-server-remote-writes.yaml` seed `tls_port: 8743`; Dockerfiles `EXPOSE` it; compose + the smoothnas plugin publish the TLS port instead of plaintext `8740` (now loopback-only). Remote thin clients use `https://host:8743` (self-signed → `AIMEE_TLS_INSECURE=1` or pin the cert).

## Migration

A remote `remote.conf` / `--server` of the form `http://host:8740` will now be **refused by the client** (and the server won't expose plaintext off-loopback anyway). Switch to `https://host:8743`:

```
aimee remote set https://host:8743 <bearer>
# self-signed cert: export AIMEE_TLS_INSECURE=1 (or trust/pin the cert)
```

## Tests

- `test_server_http`: `server_http_resolve_bind_addr` truth table — plaintext (`allow_external=0`) is `INADDR_LOOPBACK` even when an external bind is requested; only TLS yields `INADDR_ANY`.
- `test_aimee_client`: `aimee_client_would_leak_cleartext` truth table — blocked for bearer + `http://` + non-loopback; allowed for `https://`, loopback, and empty token.
- Self-signed cert generation validated out-of-band: valid PEM, key/cert match, `0600` key, correct SANs/EKU, idempotent.

## Notes / not in scope

- A pre-existing crash when `aimee-server` starts against a **bare** `AIMEE_HOME` (no DB init) is unrelated to this change — it occurs in early init before any listener/TLS/cert path runs — and is left as-is.
