### PR TITLE
feat(mcp): on-demand tool discovery + lean default (P2 of MCP surface program)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -361,7 +361,7 @@ The binaries read 120 `AIMEE_*` environment variables (scanned from `getenv()` i
 | Variable | Description |
 |----------|-------------|
 | `AIMEE_MCP_CWD` | Working-directory hint for MCP git-root resolution. |
-| `AIMEE_MCP_TOOL_PROFILE` | MCP tools/list presentation profile: 'full' (default, all tools) or 'core'/'lean' (Tier-0 high-frequency tools only, shrinking the initial payload). |
+| `AIMEE_MCP_TOOL_PROFILE` | MCP tools/list presentation profile: 'core'/'lean' (default — Tier-0 high-frequency tools only, with find_tools/describe_tool reaching the rest) or 'full' (present every tool upfront). |
 | `AIMEE_VERIFY_PARALLEL` | Run `aimee git verify` steps in parallel. |
 | `AIMEE_VERIFY_STEP_TIMEOUT_MS` | Per-step timeout (ms) for git verify. |
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -544,7 +544,7 @@ ENV_DESC = {
     "AIMEE_VERIFY_PARALLEL": ("Git verify / MCP", "Run `aimee git verify` steps in parallel."),
     "AIMEE_VERIFY_STEP_TIMEOUT_MS": ("Git verify / MCP", "Per-step timeout (ms) for git verify."),
     "AIMEE_MCP_CWD": ("Git verify / MCP", "Working-directory hint for MCP git-root resolution."),
-    "AIMEE_MCP_TOOL_PROFILE": ("Git verify / MCP", "MCP tools/list presentation profile: 'full' (default, all tools) or 'core'/'lean' (Tier-0 high-frequency tools only, shrinking the initial payload)."),
+    "AIMEE_MCP_TOOL_PROFILE": ("Git verify / MCP", "MCP tools/list presentation profile: 'core'/'lean' (default — Tier-0 high-frequency tools only, with find_tools/describe_tool reaching the rest) or 'full' (present every tool upfront)."),
     # Models
     "AIMEE_MODEL_CAPABILITY_OVERRIDES": ("Models", "Override model capability flags (reasoning/tools/vision/…)."),
     # TLS & networking

--- a/src/cli_mcp_serve.c
+++ b/src/cli_mcp_serve.c
@@ -275,7 +275,10 @@ static void handle_initialize(cJSON *id)
 
    cJSON *caps = cJSON_CreateObject();
    cJSON *tools_cap = cJSON_CreateObject();
-   cJSON_AddBoolToObject(tools_cap, "listChanged", 0);
+   /* The presented list is dynamic (presentation profile + plugin/remote tools +
+    * runtime config), so advertise listChanged: a client may re-list to pick up
+    * changes. */
+   cJSON_AddBoolToObject(tools_cap, "listChanged", 1);
    cJSON_AddItemToObject(caps, "tools", tools_cap);
    cJSON *res_cap = cJSON_CreateObject();
    cJSON_AddBoolToObject(res_cap, "subscribe", 0);
@@ -291,14 +294,17 @@ static void handle_initialize(cJSON *id)
    cJSON_AddStringToObject(info, "version", MCP_VERSION);
    cJSON_AddItemToObject(result, "serverInfo", info);
 
-   cJSON_AddStringToObject(result, "instructions",
-                           "When you are unsure how aimee works — work queue, "
-                           "delegation, memory, git, build, conventions — call "
-                           "get_help() before trying anything else. It returns "
-                           "the authoritative topic index. Pass a topic name "
-                           "for details (e.g. get_help(\"work queue\")). Do not use "
-                           "provider-native sub-agent tools such as spawn_agent or Agent; "
-                           "use the aimee delegate tool for delegated work.");
+   cJSON_AddStringToObject(
+       result, "instructions",
+       "When you are unsure how aimee works — work queue, delegation, memory, git, "
+       "build, conventions — call get_help() before trying anything else. It "
+       "returns the authoritative topic index. Pass a topic name for details "
+       "(e.g. get_help(\"work queue\")). The tools/list is a curated core set; the "
+       "full catalog is larger — call find_tools(\"<keyword>\") to discover more "
+       "tools and describe_tool(\"<name>\") for a tool's full input schema, then "
+       "call any discovered tool by name (it need not appear in tools/list). Do "
+       "not use provider-native sub-agent tools such as spawn_agent or Agent; use "
+       "the aimee delegate tool for delegated work.");
 
    mcp_respond(id, result);
 }

--- a/src/headers/mcp_tools.h
+++ b/src/headers/mcp_tools.h
@@ -8,12 +8,17 @@
 cJSON *mcp_build_tools_list(void);
 
 /* Resolve the active MCP presentation profile: the explicit argument if set,
- * else AIMEE_MCP_TOOL_PROFILE, else "full". Returned string is not owned. */
+ * else AIMEE_MCP_TOOL_PROFILE, else "core" (the lean default). Not owned. */
 const char *mcp_tool_profile_effective(const char *explicit_profile);
 
 /* Filter a served tools/list IN PLACE to the named profile (NULL => resolve via
  * mcp_tool_profile_effective). "full" / unknown is a no-op (fail open); "core"
  * or "lean" keeps only the Tier-0 set. Returns the number of tools removed. */
 int mcp_filter_tools_for_profile(cJSON *tools, const char *profile);
+
+/* Append the find_tools / describe_tool discovery meta-tools to a tools list.
+ * Called by mcp_build_tools_list so they are always present (and in the core
+ * profile), keeping a lean presentation lossless. */
+void mcp_add_discovery_tools(cJSON *tools);
 
 #endif /* DEC_MCP_TOOLS_H */

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -447,6 +447,9 @@ int handle_agent_cli_oauth_poll(server_ctx_t *ctx, server_conn_t *conn, cJSON *r
 
 /* MCP proxy handler (server_mcp.c) */
 int handle_mcp_tools_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+/* Full served tool surface (built-ins + discovery + server-only), unfiltered;
+ * caller owns the returned cJSON array (server_mcp_tools.c). */
+cJSON *mcp_build_full_served_list(void);
 int handle_mcp_audit(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_mcp_recheck(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/mcp_tool_profile.c
+++ b/src/mcp_tool_profile.c
@@ -1,23 +1,27 @@
-/* mcp_tool_profile.c: MCP tools/list presentation profile (P1).
+/* mcp_tool_profile.c: MCP tools/list presentation profile + discovery (P1/P2).
  *
  * Shrinks the initial tools/list shown to an external MCP client. Kept separate
  * from mcp_tools.c (which is at its line budget) and from the tool definitions
- * it filters. See AIMEE_MCP_TOOL_PROFILE; default "full" is a no-op. */
+ * it filters. See AIMEE_MCP_TOOL_PROFILE; the default is "core" (P2) — lossless
+ * because the find_tools/describe_tool discovery meta-tools (also defined here)
+ * surface the full catalog on demand. Set it to "full" to present everything. */
 #include "cJSON.h"
 #include "headers/mcp_tools.h"
 #include <stdlib.h>
 #include <string.h>
 
 /* Tier-0 "core" presentation profile (MCP-native tool names): the high-frequency
- * tools an external MCP client is shown when AIMEE_MCP_TOOL_PROFILE=core|lean.
- * Everything else — including plugin:* and remote-server tools — is hidden from
- * the initial tools/list to shrink the upfront payload. The full catalog stays
- * reachable: P2 adds find_tools/describe_tool for on-demand discovery. Keep this
- * list short and edit it deliberately; it is the floor of what every lean client
- * sees. test_tool_profile_filter mirrors this list and must be kept in sync. */
+ * tools an external MCP client is shown when AIMEE_MCP_TOOL_PROFILE=core|lean
+ * (the default). Everything else — including plugin:* and remote-server tools —
+ * is hidden from the initial tools/list to shrink the upfront payload, but stays
+ * callable and is reachable via find_tools/describe_tool. Keep this list short
+ * and edit it deliberately; it is the floor of what every lean client sees.
+ * test_tool_profile_filter mirrors this list and must be kept in sync. */
 static const char *const MCP_CORE_TOOLS[] = {
     "get_help",
-    "search_docs", /* orient / discover */
+    "find_tools",    /* discovery: the rest of the catalog is reachable via these */
+    "describe_tool", /* discovery */
+    "search_docs",   /* orient */
     "search_memory",
     "memory_recall",
     "get_identity", /* grounding */
@@ -49,7 +53,60 @@ const char *mcp_tool_profile_effective(const char *explicit_profile)
    if (explicit_profile && explicit_profile[0])
       return explicit_profile;
    const char *e = getenv("AIMEE_MCP_TOOL_PROFILE");
-   return (e && e[0]) ? e : "full";
+   /* P2 default: "core" — lean is now the out-of-the-box presentation, kept
+    * lossless by find_tools/describe_tool. Operators set "full" to opt out. */
+   return (e && e[0]) ? e : "core";
+}
+
+/* Add the discovery meta-tools to a tools list. These keep the lean default
+ * lossless: find_tools surfaces the catalog by keyword, describe_tool returns a
+ * tool's full input schema, and the client may then call a tool by name even
+ * when it is not in tools/list. Always present (in MCP_CORE_TOOLS above). */
+void mcp_add_discovery_tools(cJSON *tools)
+{
+   if (!tools)
+      return;
+   {
+      cJSON *t = cJSON_CreateObject();
+      cJSON_AddStringToObject(t, "name", "find_tools");
+      cJSON_AddStringToObject(
+          t, "description",
+          "Discover aimee tools beyond the curated core set shown in tools/list. Returns "
+          "matching tool names + one-line descriptions (not full schemas). Call "
+          "describe_tool(name) for a match's input schema, then call the tool by name. Omit "
+          "'query' to list the whole catalog.");
+      cJSON *s = cJSON_CreateObject();
+      cJSON_AddStringToObject(s, "type", "object");
+      cJSON *p = cJSON_AddObjectToObject(s, "properties");
+      cJSON *q = cJSON_AddObjectToObject(p, "query");
+      cJSON_AddStringToObject(q, "type", "string");
+      cJSON_AddStringToObject(q, "description",
+                              "Case-insensitive keyword matched against tool name + description. "
+                              "Omit for the full catalog.");
+      cJSON *lim = cJSON_AddObjectToObject(p, "limit");
+      cJSON_AddStringToObject(lim, "type", "integer");
+      cJSON_AddStringToObject(lim, "description", "Max matches to return (default 50).");
+      cJSON_AddItemToObject(t, "inputSchema", s);
+      cJSON_AddItemToArray(tools, t);
+   }
+   {
+      cJSON *t = cJSON_CreateObject();
+      cJSON_AddStringToObject(t, "name", "describe_tool");
+      cJSON_AddStringToObject(t, "description",
+                              "Return the full definition (description + input schema) of a single "
+                              "tool by name, including tools not shown in tools/list. Pair with "
+                              "find_tools to discover names.");
+      cJSON *s = cJSON_CreateObject();
+      cJSON_AddStringToObject(s, "type", "object");
+      cJSON *p = cJSON_AddObjectToObject(s, "properties");
+      cJSON *nm = cJSON_AddObjectToObject(p, "name");
+      cJSON_AddStringToObject(nm, "type", "string");
+      cJSON_AddStringToObject(nm, "description", "Exact tool name (e.g. from find_tools).");
+      cJSON *req = cJSON_AddArrayToObject(s, "required");
+      cJSON_AddItemToArray(req, cJSON_CreateString("name"));
+      cJSON_AddItemToObject(t, "inputSchema", s);
+      cJSON_AddItemToArray(tools, t);
+   }
 }
 
 int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
@@ -57,8 +114,8 @@ int mcp_filter_tools_for_profile(cJSON *tools, const char *profile)
    if (!tools || !cJSON_IsArray(tools))
       return 0;
    profile = mcp_tool_profile_effective(profile);
-   /* "full" (default) presents everything; an unknown profile fails OPEN to the
-    * full set so a typo never silently hides tools. */
+   /* "full" presents everything; an unknown profile fails OPEN to the full set so
+    * a typo never silently hides tools. "core"/"lean" keep only the Tier-0 set. */
    if (strcmp(profile, "core") != 0 && strcmp(profile, "lean") != 0)
       return 0;
 

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -63,6 +63,7 @@ static void add_session_context_tools(cJSON *tools)
 cJSON *mcp_build_tools_list(void)
 {
    cJSON *tools = cJSON_CreateArray();
+   mcp_add_discovery_tools(tools); /* find_tools / describe_tool (P2) */
    {
       cJSON *s = cJSON_CreateObject();
       cJSON_AddStringToObject(s, "type", "object");

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -1517,6 +1517,96 @@ static cJSON *dispatch_git_tool(server_ctx_t *ctx, server_conn_t *conn, const ch
 
 #include "server_mcp_call_table.inc"
 
+/* ── Discovery meta-tools (P2) ────────────────────────────────────────────────
+ * find_tools / describe_tool introspect the FULL served catalog (unfiltered by
+ * the presentation profile) so a lean tools/list loses no reach: the model can
+ * discover any tool's name + schema and then call it by name. Read-only; they
+ * return MCP `content` like any other content-producing tool. */
+static int mcp_ci_contains(const char *haystack, const char *needle)
+{
+   if (!needle || !needle[0])
+      return 1; /* empty query matches everything */
+   if (!haystack)
+      return 0;
+   size_t nlen = strlen(needle);
+   for (const char *h = haystack; *h; h++)
+      if (strncasecmp(h, needle, nlen) == 0)
+         return 1;
+   return 0;
+}
+
+static cJSON *mcp_tool_find_tools(cJSON *args)
+{
+   cJSON *jq = cJSON_GetObjectItemCaseSensitive(args, "query");
+   const char *q = cJSON_IsString(jq) ? jq->valuestring : NULL;
+   int limit = 50;
+   cJSON *jl = cJSON_GetObjectItemCaseSensitive(args, "limit");
+   if (cJSON_IsNumber(jl) && jl->valueint > 0)
+      limit = jl->valueint;
+
+   cJSON *all = mcp_build_full_served_list();
+   cJSON *result = cJSON_CreateObject();
+   cJSON *matches = cJSON_AddArrayToObject(result, "tools");
+   int shown = 0, total = 0;
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, all)
+   {
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(t, "name");
+      cJSON *ds = cJSON_GetObjectItemCaseSensitive(t, "description");
+      const char *name = cJSON_IsString(nm) ? nm->valuestring : "";
+      const char *desc = cJSON_IsString(ds) ? ds->valuestring : "";
+      if (!mcp_ci_contains(name, q) && !mcp_ci_contains(desc, q))
+         continue;
+      total++;
+      if (shown >= limit)
+         continue;
+      cJSON *m = cJSON_CreateObject();
+      cJSON_AddStringToObject(m, "name", name);
+      cJSON_AddStringToObject(m, "description", desc);
+      cJSON_AddItemToArray(matches, m);
+      shown++;
+   }
+   cJSON_AddNumberToObject(result, "count", shown);
+   cJSON_AddNumberToObject(result, "total", total);
+   if (total > shown)
+      cJSON_AddBoolToObject(result, "truncated", 1);
+   cJSON_AddStringToObject(
+       result, "hint",
+       "Call describe_tool(name) for a tool's input schema, then call the tool by name.");
+   cJSON_Delete(all);
+   return json_result_content(result);
+}
+
+static cJSON *mcp_tool_describe_tool(cJSON *args)
+{
+   cJSON *jn = cJSON_GetObjectItemCaseSensitive(args, "name");
+   if (!cJSON_IsString(jn) || !jn->valuestring[0])
+      return text_content("error: describe_tool requires a 'name'");
+   const char *want = jn->valuestring;
+
+   cJSON *all = mcp_build_full_served_list();
+   cJSON *found = NULL;
+   cJSON *t = NULL;
+   cJSON_ArrayForEach(t, all)
+   {
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(t, "name");
+      if (cJSON_IsString(nm) && strcmp(nm->valuestring, want) == 0)
+      {
+         found = cJSON_Duplicate(t, 1);
+         break;
+      }
+   }
+   cJSON_Delete(all);
+   if (!found)
+   {
+      char msg[160];
+      snprintf(msg, sizeof(msg), "error: unknown tool '%s' (use find_tools to discover names)",
+               want);
+      return text_content(msg);
+   }
+   return json_result_content(found);
+}
+
 int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    cJSON *jtool = cJSON_GetObjectItemCaseSensitive(req, "tool");
@@ -1625,8 +1715,15 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       }
    }
 
+   /* Discovery meta-tools (P2): pure introspection of the full catalog; set
+    * content and fall through to the normal send path. */
+   if (strcmp(tool, "find_tools") == 0)
+      content = mcp_tool_find_tools(jargs);
+   else if (strcmp(tool, "describe_tool") == 0)
+      content = mcp_tool_describe_tool(jargs);
+
    struct mcp_call call = {ctx, conn, jargs, sid, tool, &structured};
-   mcp_tool_handler_fn handler = mcp_tool_lookup(tool);
+   mcp_tool_handler_fn handler = content ? NULL : mcp_tool_lookup(tool);
    if (handler)
    {
       content = handler(&call);

--- a/src/server/server_mcp_tools.c
+++ b/src/server/server_mcp_tools.c
@@ -60,23 +60,10 @@ static cJSON *server_mcp_audit_item(const config_mcp_client_t *client, const osv
    return obj;
 }
 
-int handle_mcp_tools_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+/* Server-only tools (not in the shared mcp_build_tools_list): primary-session,
+ * persona, and role admin that only the server can service. */
+static void append_server_only_tools(cJSON *tools)
 {
-   (void)ctx;
-   (void)req;
-
-   cJSON *resp = cJSON_CreateObject();
-   if (!resp)
-      return server_send_error(conn, "out of memory", NULL);
-
-   cJSON *tools = mcp_build_tools_list();
-   if (!tools)
-   {
-      cJSON_Delete(resp);
-      return server_send_error(conn, "out of memory", NULL);
-   }
-
-   /* Server-only tools not in the shared list */
    {
       cJSON *s = cJSON_CreateObject();
       cJSON_AddStringToObject(s, "type", "object");
@@ -186,12 +173,40 @@ int handle_mcp_tools_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       cJSON_AddItemToObject(t, "inputSchema", s);
       cJSON_AddItemToArray(tools, t);
    }
+}
+
+/* The full served tool surface (shared built-ins + discovery + server-only),
+ * BEFORE any presentation-profile filtering. Used by tools/list and by the
+ * find_tools/describe_tool discovery handlers so discovery sees every tool. */
+cJSON *mcp_build_full_served_list(void)
+{
+   cJSON *tools = mcp_build_tools_list();
+   if (tools)
+      append_server_only_tools(tools);
+   return tools;
+}
+
+int handle_mcp_tools_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+   (void)req;
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+      return server_send_error(conn, "out of memory", NULL);
+
+   cJSON *tools = mcp_build_full_served_list();
+   if (!tools)
+   {
+      cJSON_Delete(resp);
+      return server_send_error(conn, "out of memory", NULL);
+   }
 
    /* Presentation profile: shrink the initial tools/list for external MCP
-    * clients when AIMEE_MCP_TOOL_PROFILE=core|lean. Default "full" is a no-op,
-    * so existing clients are unaffected; the lean set + on-demand discovery
-    * (find_tools/describe_tool) land in P2. Applied here at the served-list
-    * choke point so mcp_build_tools_list() (and its golden test) stays intact. */
+    * clients. Default "core" (lean) is lossless — find_tools/describe_tool reach
+    * the rest; set AIMEE_MCP_TOOL_PROFILE=full to present everything. Applied at
+    * the served-list choke point so mcp_build_tools_list() (and its golden test)
+    * stays intact. */
    {
       const char *profile = mcp_tool_profile_effective(NULL);
       int total = cJSON_GetArraySize(tools);

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -489,8 +489,8 @@ static void test_tools_list_surface(void)
    cJSON_Delete(tools);
 }
 
-/* P1 presentation profile: "core"/"lean" shrinks the served tools/list to the
- * Tier-0 set; "full"/unknown/NULL-default fail open (present everything). */
+/* P1/P2 presentation profile: "core"/"lean" (the P2 default) shrinks the served
+ * tools/list to the Tier-0 set; explicit "full"/unknown fail open. */
 static int profile_core_has(const char *n, const char *const *set)
 {
    for (int i = 0; set[i]; i++)
@@ -500,24 +500,34 @@ static int profile_core_has(const char *n, const char *const *set)
 }
 static void test_tool_profile_filter(void)
 {
-   /* Mirror of MCP_CORE_TOOLS in mcp_tools.c — kept in sync intentionally. */
-   static const char *const core[] = {"get_help",         "search_docs",     "search_memory",
-                                      "memory_recall",    "get_identity",    "find_symbol",
-                                      "ast_grep_search",  "git_status",      "git_commit",
-                                      "git_diff_summary", "git_branch",      "git_pr",
-                                      "delegate",         "ensemble_review", "ask_user",
-                                      "send_message",     "create_note",     NULL};
+   /* Mirror of MCP_CORE_TOOLS in mcp_tool_profile.c — kept in sync intentionally.
+    * Includes the P2 discovery meta-tools find_tools/describe_tool. */
+   static const char *const core[] = {
+       "get_help",        "find_tools",       "describe_tool", "search_docs",     "search_memory",
+       "memory_recall",   "get_identity",     "find_symbol",   "ast_grep_search", "git_status",
+       "git_commit",      "git_diff_summary", "git_branch",    "git_pr",          "delegate",
+       "ensemble_review", "ask_user",         "send_message",  "create_note",     NULL};
    int expect = 0;
    for (int i = 0; core[i]; i++)
       expect++;
+   assert(profile_core_has("find_tools", core) && profile_core_has("describe_tool", core));
 
-   /* "full", an unknown profile, and NULL (no env set in the test) are no-ops. */
+   /* Control the env so the default is deterministic across CI runners. */
+   unsetenv("AIMEE_MCP_TOOL_PROFILE");
+
+   /* Explicit "full" and an unknown profile are no-ops (fail open). */
    cJSON *t = mcp_build_tools_list();
    int full = cJSON_GetArraySize(t);
    assert(full > expect);
    assert(mcp_filter_tools_for_profile(t, "full") == 0 && cJSON_GetArraySize(t) == full);
    assert(mcp_filter_tools_for_profile(t, "nonsense") == 0 && cJSON_GetArraySize(t) == full);
-   assert(mcp_filter_tools_for_profile(t, NULL) == 0 && cJSON_GetArraySize(t) == full);
+   cJSON_Delete(t);
+
+   /* P2 default: env unset + NULL profile resolves to "core" and filters. */
+   assert(strcmp(mcp_tool_profile_effective(NULL), "core") == 0);
+   t = mcp_build_tools_list();
+   assert(mcp_filter_tools_for_profile(t, NULL) == full - expect);
+   assert(cJSON_GetArraySize(t) == expect);
    cJSON_Delete(t);
 
    /* "core" keeps exactly the Tier-0 set — and every named core tool exists in

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -2,7 +2,7 @@
  * built-in tool surface (name + sorted schema property keys + required), captured
  * via the DUMP_TOOLS path in test_mcp_client_registry.c. Regenerate after an
  * intentional tool change: DUMP_TOOLS=1 ./unit-test-mcp-client-registry 2>&1. */
-#define MCP_TOOLS_GOLDEN_COUNT 95
+#define MCP_TOOLS_GOLDEN_COUNT 97
 #define MCP_TOOLS_GOLDEN \
    "ask_user {choices,question} req:question\n" \
    "ast_grep_search {lang,path,pattern} req:lang,pattern\n" \
@@ -16,6 +16,7 @@
    "delegate {branch,cwd,persona,prompt,role} req:persona,prompt,role\n" \
    "delegate_reply {content,delegation_id} req:content,delegation_id\n" \
    "delegate_status {job_id} req:job_id\n" \
+   "describe_tool {name} req:name\n" \
    "diagnose_evidence {content,diagnosis_id,hypothesis_id,rank,source,stance} req:content,diagnosis_id,hypothesis_id,stance\n" \
    "diagnose_hypothesize {content,diagnosis_id} req:content,diagnosis_id\n" \
    "diagnose_observe {content,diagnosis_id,source} req:content,diagnosis_id\n" \
@@ -23,6 +24,7 @@
    "diagnose_status {diagnosis_id} req:diagnosis_id\n" \
    "ensemble_review {brief,diff,rounds,turns} req:diff\n" \
    "find_symbol {identifier} req:identifier\n" \
+   "find_tools {limit,query} req:\n" \
    "get_background_output {id,tail_lines} req:id\n" \
    "get_context_block {block_type,limit,query} req:query\n" \
    "get_entity {entity} req:entity\n" \


### PR DESCRIPTION
## Context
P1 (#704) added the `AIMEE_MCP_TOOL_PROFILE` presentation profile, defaulting to `full` so nothing regressed. **P2** adds the discovery mechanism that makes a lean list *lossless*, then flips the default to lean.

## What this PR does
**Discovery meta-tools** (always in the core profile):
- **`find_tools(query[, limit])`** — search the **full** catalog (built-ins + `plugin:*` + remote + server-only) by case-insensitive keyword; returns `name` + one-line `description` (not schemas) plus `count`/`total`/`truncated`. Omit `query` for the whole catalog.
- **`describe_tool(name)`** — return a single tool's full definition (description + input schema), **including tools not shown in `tools/list`**.

Both are pure/read-only, handled in `server_mcp.c` against the unfiltered `mcp_build_full_served_list()`. Tool **execution was never gated by the presentation profile**, so a client can call any discovered tool by name even when it isn't listed — coverage is free.

**Lean by default:** `mcp_tool_profile_effective` default flips `full → core`. A fresh client now sees the ~19-tool Tier-0 set (down from ~99 full-schema tools) and reaches everything else via `find_tools`/`describe_tool`. `AIMEE_MCP_TOOL_PROFILE=full` restores the old behavior.

**Protocol:** `initialize` now advertises `tools.listChanged=true` (the list is genuinely dynamic) and its `instructions` teach the model to use `find_tools`/`describe_tool`.

**Refactor:** server-only tools moved into `append_server_only_tools()`; new exported `mcp_build_full_served_list()` (built-ins + discovery + server-only) backs both `tools/list` and discovery so they never drift.

## Roadmap
P1 ✅ profile mechanism · **P2 ✅ discovery + lean default (here)** · P3 expand catalog (index/roadmap/task/work/provenance/insights) · P4 schema `$defs` dedup + description compaction.

## Tests
- Golden regenerated (95 → 97; adds `find_tools`/`describe_tool`).
- `test_tool_profile_filter` updated for the `core` default (env-controlled via `unsetenv`) + the two new core tools.
- `cli-mcp-serve` initialize assertions still hold (`get_help`/`spawn_agent`/`delegate tool` present).
- Full server links clean (`-Werror`); full `make lint` green; docs regenerated for the new default.
