### PR TITLE
feat(mcp): P3b — blast-radius, memory provenance/history, dashboard metrics

### DIFF
--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -78,7 +78,14 @@ void mcp_add_extended_tools(cJSON *tools)
    ext_prop(t, "project", "string", "Project the file belongs to (optional).");
    ext_require(t, "file_path");
 
-   /* ── Memory grounding: explain a retrieval ───────────────────────────────── */
+   t = ext_tool(tools, "index_blast_radius",
+                "Impact analysis for one file: the files that depend on it (dependents) and the "
+                "files it depends on (dependencies), from the code index.");
+   ext_prop(t, "file_path", "string", "File path within the indexed project.");
+   ext_prop(t, "project", "string", "Project the file belongs to (optional).");
+   ext_require(t, "file_path");
+
+   /* ── Memory grounding: explain a retrieval + provenance/history ───────────── */
    t = ext_tool(tools, "memory_explain_match",
                 "Explain WHY a memory matches a query: the per-signal score breakdown "
                 "(lexical / semantic / entity / graph / cross-encoder / …).");
@@ -86,4 +93,19 @@ void mcp_add_extended_tools(cJSON *tools)
    ext_prop(t, "memory_id", "integer", "Id of the memory to explain (e.g. from search_memory).");
    ext_require(t, "query");
    ext_require(t, "memory_id");
+
+   t = ext_tool(tools, "memory_provenance",
+                "Provenance trail of a memory: the recorded actions (create / update / supersede / "
+                "…) with session + timestamp, for citing and trust-ranking.");
+   ext_prop(t, "memory_id", "integer", "Id of the memory (e.g. from search_memory).");
+   ext_require(t, "memory_id");
+
+   t = ext_tool(tools, "memory_fact_history",
+                "Version history of a fact by its key: prior + current entries, newest first.");
+   ext_prop(t, "key", "string", "The fact key to fetch history for.");
+   ext_require(t, "key");
+
+   /* ── Observability ───────────────────────────────────────────────────────── */
+   ext_tool(tools, "dashboard_metrics",
+            "Operational snapshot: server metrics plus the vector-store status, as JSON.");
 }

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -9,6 +9,7 @@
 #include "index.h"
 #include "db1.h"
 #include "kb_client.h"
+#include "dashboard.h"
 #include "mcp_git.h"
 #include "git_verify.h"
 #include "workspace_turn.h"

--- a/src/server/server_mcp_call_table.inc
+++ b/src/server/server_mcp_call_table.inc
@@ -776,6 +776,121 @@ static cJSON *mcph_memory_explain_match(struct mcp_call *c)
    return json_result_content(result);
 }
 
+/* ── P3b extended read-only tools: blast radius, memory provenance/history,
+ * dashboard metrics. Same pattern: wrap an existing call, emit JSON. ───────── */
+static cJSON *mcph_index_blast_radius(struct mcp_call *c)
+{
+   cJSON *jf = cJSON_GetObjectItemCaseSensitive(c->jargs, "file_path");
+   if (!cJSON_IsString(jf) || !jf->valuestring[0])
+      return text_content("error: index_blast_radius requires 'file_path'");
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
+   const char *project = cJSON_IsString(jp) ? jp->valuestring : NULL;
+   blast_radius_t *br = calloc(1, sizeof(*br));
+   if (!br)
+      return text_content("error: out of memory");
+   if (kb_client_index_blast_radius(project, jf->valuestring, br) < 0)
+   {
+      free(br);
+      return text_content("error: index_blast_radius failed");
+   }
+   cJSON *result = cJSON_CreateObject();
+   cJSON_AddStringToObject(result, "file", br->file);
+   cJSON *deps = cJSON_AddArrayToObject(result, "dependents");
+   for (int i = 0; i < br->dependent_count && i < 64; i++)
+      cJSON_AddItemToArray(deps, cJSON_CreateString(br->dependents[i]));
+   cJSON *uses = cJSON_AddArrayToObject(result, "dependencies");
+   for (int i = 0; i < br->dependency_count && i < 64; i++)
+      cJSON_AddItemToArray(uses, cJSON_CreateString(br->dependencies[i]));
+   cJSON_AddNumberToObject(result, "dependent_count", br->dependent_count);
+   cJSON_AddNumberToObject(result, "dependency_count", br->dependency_count);
+   free(br);
+   return json_result_content(result);
+}
+
+static cJSON *mcph_memory_provenance(struct mcp_call *c)
+{
+   cJSON *jid = cJSON_GetObjectItemCaseSensitive(c->jargs, "memory_id");
+   if (!cJSON_IsNumber(jid))
+      return text_content("error: memory_provenance requires 'memory_id'");
+   const int max = 200;
+   provenance_entry_t *ents = calloc((size_t)max, sizeof(*ents));
+   if (!ents)
+      return text_content("error: out of memory");
+   int n = kb_client_memory_get_provenance((int64_t)jid->valuedouble, ents, max);
+   if (n < 0)
+   {
+      free(ents);
+      return text_content("error: memory_provenance failed");
+   }
+   cJSON *result = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(result, "provenance");
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *e = cJSON_CreateObject();
+      cJSON_AddNumberToObject(e, "id", (double)ents[i].id);
+      cJSON_AddStringToObject(e, "action", ents[i].action);
+      if (ents[i].session_id[0])
+         cJSON_AddStringToObject(e, "session_id", ents[i].session_id);
+      if (ents[i].details[0])
+         cJSON_AddStringToObject(e, "details", ents[i].details);
+      cJSON_AddStringToObject(e, "created_at", ents[i].created_at);
+      cJSON_AddItemToArray(arr, e);
+   }
+   cJSON_AddNumberToObject(result, "count", n);
+   free(ents);
+   return json_result_content(result);
+}
+
+static cJSON *mcph_memory_fact_history(struct mcp_call *c)
+{
+   cJSON *jk = cJSON_GetObjectItemCaseSensitive(c->jargs, "key");
+   if (!cJSON_IsString(jk) || !jk->valuestring[0])
+      return text_content("error: memory_fact_history requires 'key'");
+   const int max = 100;
+   memory_t *mems = calloc((size_t)max, sizeof(*mems));
+   if (!mems)
+      return text_content("error: out of memory");
+   int n = kb_client_memory_fact_history(jk->valuestring, mems, max);
+   if (n < 0)
+   {
+      free(mems);
+      return text_content("error: memory_fact_history failed");
+   }
+   cJSON *result = cJSON_CreateObject();
+   cJSON *arr = cJSON_AddArrayToObject(result, "history");
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *m = cJSON_CreateObject();
+      cJSON_AddNumberToObject(m, "id", (double)mems[i].id);
+      cJSON_AddStringToObject(m, "tier", mems[i].tier);
+      cJSON_AddStringToObject(m, "kind", mems[i].kind);
+      cJSON_AddStringToObject(m, "content", mems[i].content);
+      cJSON_AddNumberToObject(m, "confidence", mems[i].confidence);
+      cJSON_AddStringToObject(m, "updated_at", mems[i].updated_at);
+      cJSON_AddItemToArray(arr, m);
+   }
+   cJSON_AddNumberToObject(result, "count", n);
+   free(mems);
+   return json_result_content(result);
+}
+
+static cJSON *mcph_dashboard_metrics(struct mcp_call *c)
+{
+   (void)c;
+   cJSON *result = cJSON_CreateObject();
+   char *metrics = api_metrics();
+   cJSON *mj = metrics ? cJSON_Parse(metrics) : NULL;
+   free(metrics);
+   if (mj)
+      cJSON_AddItemToObject(result, "metrics", mj);
+   char *vec = api_vector_status();
+   cJSON *vj = vec ? cJSON_Parse(vec) : NULL;
+   free(vec);
+   if (vj)
+      cJSON_AddItemToObject(result, "vector", vj);
+   return json_result_content(result);
+}
+
 /* ── name → handler table (exact match; order is irrelevant — names unique) ── */
 
 static const struct
@@ -844,6 +959,11 @@ static const struct
     {"index_find_callers", mcph_index_find_callers},
     {"index_structure", mcph_index_structure},
     {"memory_explain_match", mcph_memory_explain_match},
+    /* P3b */
+    {"index_blast_radius", mcph_index_blast_radius},
+    {"memory_provenance", mcph_memory_provenance},
+    {"memory_fact_history", mcph_memory_fact_history},
+    {"dashboard_metrics", mcph_dashboard_metrics},
 };
 
 static mcp_tool_handler_fn mcp_tool_lookup(const char *tool)

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -2,7 +2,7 @@
  * built-in tool surface (name + sorted schema property keys + required), captured
  * via the DUMP_TOOLS path in test_mcp_client_registry.c. Regenerate after an
  * intentional tool change: DUMP_TOOLS=1 ./unit-test-mcp-client-registry 2>&1. */
-#define MCP_TOOLS_GOLDEN_COUNT 103
+#define MCP_TOOLS_GOLDEN_COUNT 107
 #define MCP_TOOLS_GOLDEN \
    "ask_user {choices,question} req:question\n" \
    "ast_grep_search {lang,path,pattern} req:lang,pattern\n" \
@@ -13,6 +13,7 @@
    "create_epistemic_directive {anchor_entity,anchor_file,cause,priority,question,topic,valid_until} req:question\n" \
    "create_note {content,tags,title} req:content,title\n" \
    "create_prospective_memory {action_text,anchor_entity,anchor_file,recurrence,trigger_text,valid_until} req:action_text,trigger_text\n" \
+   "dashboard_metrics {} req:\n" \
    "delegate {branch,cwd,persona,prompt,role} req:persona,prompt,role\n" \
    "delegate_reply {content,delegation_id} req:content,delegation_id\n" \
    "delegate_status {job_id} req:job_id\n" \
@@ -49,6 +50,7 @@
    "git_status {} req:\n" \
    "git_tag {action,message,name,ref} req:\n" \
    "git_verify {action,async,base,job_id,path} req:\n" \
+   "index_blast_radius {file_path,project} req:file_path\n" \
    "index_find_callers {project,symbol} req:symbol\n" \
    "index_structure {file_path,project} req:file_path\n" \
    "job_start {max_concurrent,plan_id} req:plan_id\n" \
@@ -70,8 +72,10 @@
    "memory_alerts {since} req:\n" \
    "memory_briefing {limit_tokens} req:\n" \
    "memory_explain_match {memory_id,query} req:memory_id,query\n" \
+   "memory_fact_history {key} req:key\n" \
    "memory_get {handle,id} req:\n" \
    "memory_maintain {dry_run,force,modes} req:\n" \
+   "memory_provenance {memory_id} req:memory_id\n" \
    "memory_recall {limit_tokens,session_start,task_hint} req:\n" \
    "mutate {confidence,content,id,key,kind,reason,tier,verb} req:verb\n" \
    "payload_rewrite_status {} req:\n" \


### PR DESCRIPTION
## Context
Follow-on to P3 (#708): four more **read-only** MCP tools, same low-risk pattern (wrap an existing call → JSON). Hidden by the default `core` profile, discoverable via `find_tools`/`describe_tool`, callable by name — zero upfront cost.

| Tool | Backed by | Value |
|---|---|---|
| `index_blast_radius` | `kb_client_index_blast_radius` | a file's dependents + dependencies (impact analysis) |
| `memory_provenance` | `kb_client_memory_get_provenance` | a memory's recorded action trail (cite/trust) |
| `memory_fact_history` | `kb_client_memory_fact_history` | a fact key's version history |
| `dashboard_metrics` | `api_metrics()` + `api_vector_status()` | server metrics + vector-store status |

`dashboard_metrics` is the first **server-local** (non-kb) extended tool — added `#include "dashboard.h"` to `server_mcp.c` for its two `char*` JSON sources. Struct handlers heap-allocate (`blast_radius_t` is ~0.5 MB).

Definitions in `mcp_tools_extended.c`; handlers in the line-exempt `server_mcp_call_table.inc`. Consistent with the other table tools, not capability-gated at the MCP layer.

## Tests
- Golden regenerated (103 → 107; all 4 present).
- Profile-filter test is count-relative (new tools are non-core → hidden, discoverable).
- Full server links clean (`-Werror`); full `make lint` green.

## Program status
P1 ✅ · P2 ✅ · P3 ✅ · **P3b ✅ (here)** · P4 (schema `$defs` dedup + description compaction) remaining.

🤖 Generated with [Claude Code](https://claude.com/claude-code)