### PR TITLE
feat(mcp): collapse 11 coherent tool families into multiplexed tools (P4)

### DIFF
--- a/src/headers/mcp_tools.h
+++ b/src/headers/mcp_tools.h
@@ -2,6 +2,7 @@
 #define DEC_MCP_TOOLS_H 1
 
 #include "cJSON.h"
+#include <stddef.h>
 
 /* Build the complete MCP tools list (core + git tools).
  * Returns a cJSON array suitable for tools/list responses. */
@@ -25,5 +26,15 @@ void mcp_add_discovery_tools(cJSON *tools);
  * a tools list. Definitions live in mcp_tools_extended.c; the matching content
  * handlers live in server_mcp_call_table.inc. Called by mcp_build_tools_list. */
 void mcp_add_extended_tools(cJSON *tools);
+
+/* Collapse coherent tool families (pipeline/diagnose/session/lsp/note/…) IN
+ * PLACE: each family's member tools are merged into one tool with a command/
+ * action discriminator. Called by mcp_build_tools_list after all members exist. */
+void mcp_collapse_families(cJSON *tools);
+
+/* If `tool` is a collapsed family name, resolve args[command|action] to the
+ * legacy member tool name into `out`. Returns 1 (rewritten), 0 (not a family),
+ * or -1 (family but missing/unknown command). */
+int mcp_family_demux(const char *tool, cJSON *args, char *out, size_t n);
 
 #endif /* DEC_MCP_TOOLS_H */

--- a/src/mcp_tool_profile.c
+++ b/src/mcp_tool_profile.c
@@ -32,7 +32,7 @@ static const char *const MCP_CORE_TOOLS[] = {
     "ensemble_review", /* multi-agent */
     "ask_user",
     "send_message", /* interaction */
-    "create_note",  /* capture */
+    "note",         /* capture (note family: create/list/search) */
     NULL,
 };
 

--- a/src/mcp_tools.c
+++ b/src/mcp_tools.c
@@ -1569,6 +1569,11 @@ cJSON *mcp_build_tools_list(void)
 
    add_session_context_tools(tools);
 
+   /* Collapse coherent families into single multiplexed tools (P4). Runs after
+    * every builtin member exists, before plugin/remote tools (which are left as
+    * separate, namespaced entries). */
+   mcp_collapse_families(tools);
+
    /* Plugin tools: load registry + project-local, add enabled tools */
    {
       plugin_t plugins[PLUGIN_MAX_PLUGINS];

--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -10,6 +10,8 @@
  * are discoverable via find_tools/describe_tool and callable by name. */
 #include "cJSON.h"
 #include "headers/mcp_tools.h"
+#include <stdio.h>
+#include <string.h>
 
 /* Append a {name, description, inputSchema:{type:object, properties:{}}} tool and
  * return it so the caller can attach properties / required entries. */
@@ -117,4 +119,192 @@ void mcp_add_extended_tools(cJSON *tools)
 
    ext_tool(tools, "work_board",
             "The work queue grouped by status (pending / claimed / done / failed / cancelled).");
+}
+
+/* ── Tool-family multiplexing (P4) ────────────────────────────────────────────
+ * Several coherent families (a noun with verb operations) are presented as ONE
+ * tool with a discriminator property whose value selects the operation, instead
+ * of N separate tools. At build time mcp_collapse_families() folds each family's
+ * member tools into one (merging their schemas); at dispatch time
+ * mcp_family_demux() rewrites <family>({command|action:"verb"}) to the legacy
+ * <family>_<verb> name so the existing handlers + capability gating run
+ * unchanged. The legacy names stay directly callable. Discriminator is "command"
+ * except where a member already owns a "command" param (background → "action"). */
+struct fam_member
+{
+   const char *command;
+   const char *tool;
+};
+struct fam_def
+{
+   const char *name;
+   const char *cmd_key;
+   const char *description;
+   struct fam_member members[12];
+};
+static const struct fam_def MCP_FAMILIES[] = {
+    {"pipeline",
+     "command",
+     "Roundtable authoring pipeline. Set 'command' to the operation; other params apply per "
+     "command (see describe_tool).",
+     {{"start", "pipeline_start"},
+      {"advance", "pipeline_advance"},
+      {"status", "pipeline_status"},
+      {"list", "pipeline_list"},
+      {"gate", "pipeline_gate"},
+      {"resume", "pipeline_resume"},
+      {"cancel", "pipeline_cancel"},
+      {NULL, NULL}}},
+    {"diagnose",
+     "command",
+     "Structured diagnosis session (observe → hypothesize → weigh evidence). Set 'command'.",
+     {{"start", "diagnose_start"},
+      {"observe", "diagnose_observe"},
+      {"hypothesize", "diagnose_hypothesize"},
+      {"evidence", "diagnose_evidence"},
+      {"status", "diagnose_status"},
+      {NULL, NULL}}},
+    {"session",
+     "command",
+     "Session operations: workflow sessions (start/status/pause/advance/list), conversation "
+     "transcript search (transcript_search), and current-session virtual-context stubs "
+     "(context_search/context_expand/context_status). Set 'command'.",
+     {{"start", "session_start"},
+      {"status", "session_status"},
+      {"pause", "session_pause"},
+      {"advance", "session_advance"},
+      {"list", "session_list"},
+      {"transcript_search", "session_search"},
+      {"context_search", "session_context_search"},
+      {"context_expand", "session_context_expand"},
+      {"context_status", "session_context_status"},
+      {NULL, NULL}}},
+    {"lsp",
+     "command",
+     "Language-server queries over the workspace. Set 'command'.",
+     {{"diagnostics", "lsp_diagnostics"},
+      {"definition", "lsp_definition"},
+      {"references", "lsp_references"},
+      {NULL, NULL}}},
+    {"index",
+     "command",
+     "Code-index navigation. Set 'command'.",
+     {{"find_callers", "index_find_callers"},
+      {"structure", "index_structure"},
+      {"blast_radius", "index_blast_radius"},
+      {NULL, NULL}}},
+    {"note",
+     "command",
+     "Investigation notes. Set 'command'.",
+     {{"create", "create_note"}, {"list", "list_notes"}, {"search", "search_notes"}, {NULL, NULL}}},
+    {"prospective_memory",
+     "command",
+     "'When X, surface Y' reminders. Set 'command'.",
+     {{"create", "create_prospective_memory"},
+      {"list", "list_prospective_memories"},
+      {"complete", "complete_prospective_memory"},
+      {NULL, NULL}}},
+    {"epistemic_directive",
+     "command",
+     "Open 'ask the user' directives. Set 'command'.",
+     {{"create", "create_epistemic_directive"},
+      {"list", "list_epistemic_directives"},
+      {"resolve", "resolve_epistemic_directive"},
+      {NULL, NULL}}},
+    {"background",
+     "action",
+     "Background shell processes. Set 'action'; run also takes 'command' (the shell command).",
+     {{"run", "run_background_process"},
+      {"output", "get_background_output"},
+      {"kill", "kill_background_process"},
+      {"list", "list_background_processes"},
+      {NULL, NULL}}},
+    {NULL, NULL, NULL, {{NULL, NULL}}},
+};
+
+static cJSON *family_detach_member(cJSON *tools, const char *name)
+{
+   int n = cJSON_GetArraySize(tools);
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *t = cJSON_GetArrayItem(tools, i);
+      cJSON *nm = cJSON_GetObjectItemCaseSensitive(t, "name");
+      if (cJSON_IsString(nm) && strcmp(nm->valuestring, name) == 0)
+         return cJSON_DetachItemFromArray(tools, i);
+   }
+   return NULL;
+}
+
+void mcp_collapse_families(cJSON *tools)
+{
+   if (!tools || !cJSON_IsArray(tools))
+      return;
+   for (const struct fam_def *f = MCP_FAMILIES; f->name; f++)
+   {
+      cJSON *ft = cJSON_CreateObject();
+      cJSON_AddStringToObject(ft, "name", f->name);
+      cJSON_AddStringToObject(ft, "description", f->description);
+      cJSON *s = cJSON_CreateObject();
+      cJSON_AddStringToObject(s, "type", "object");
+      cJSON *props = cJSON_AddObjectToObject(s, "properties");
+      cJSON *disc = cJSON_AddObjectToObject(props, f->cmd_key);
+      cJSON_AddStringToObject(disc, "type", "string");
+      cJSON *en = cJSON_AddArrayToObject(disc, "enum");
+
+      char clist[256] = "";
+      size_t cl = 0;
+      int found = 0;
+      for (const struct fam_member *m = f->members; m->command; m++)
+      {
+         cJSON_AddItemToArray(en, cJSON_CreateString(m->command));
+         if (cl < sizeof(clist))
+            cl += (size_t)snprintf(clist + cl, sizeof(clist) - cl, "%s%s", cl ? ", " : "",
+                                   m->command);
+         cJSON *mt = family_detach_member(tools, m->tool);
+         if (!mt)
+            continue;
+         found++;
+         cJSON *ms = cJSON_GetObjectItemCaseSensitive(mt, "inputSchema");
+         cJSON *mp = ms ? cJSON_GetObjectItemCaseSensitive(ms, "properties") : NULL;
+         cJSON *pr = NULL;
+         cJSON_ArrayForEach(pr, mp)
+         {
+            if (!pr->string || strcmp(pr->string, f->cmd_key) == 0)
+               continue;
+            if (!cJSON_GetObjectItemCaseSensitive(props, pr->string))
+               cJSON_AddItemToObject(props, pr->string, cJSON_Duplicate(pr, 1));
+         }
+         cJSON_Delete(mt);
+      }
+      char dbuf[320];
+      snprintf(dbuf, sizeof(dbuf), "Operation to run (one of: %s).", clist);
+      cJSON_AddStringToObject(disc, "description", dbuf);
+      cJSON *req = cJSON_AddArrayToObject(s, "required");
+      cJSON_AddItemToArray(req, cJSON_CreateString(f->cmd_key));
+      cJSON_AddItemToObject(ft, "inputSchema", s);
+      if (found)
+         cJSON_AddItemToArray(tools, ft);
+      else
+         cJSON_Delete(ft); /* members absent (e.g. partial build) — leave list as-is */
+   }
+}
+
+int mcp_family_demux(const char *tool, cJSON *args, char *out, size_t n)
+{
+   for (const struct fam_def *f = MCP_FAMILIES; f->name; f++)
+   {
+      if (strcmp(tool, f->name) != 0)
+         continue;
+      cJSON *jc = cJSON_GetObjectItemCaseSensitive(args, f->cmd_key);
+      if (!cJSON_IsString(jc) || !jc->valuestring[0])
+         return -1;
+      for (const struct fam_member *m = f->members; m->command; m++)
+         if (strcmp(jc->valuestring, m->command) == 0)
+         {
+            snprintf(out, n, "%s", m->tool);
+            return 1;
+         }
+      return -1;
+   }
+   return 0;
 }

--- a/src/server/server_mcp.c
+++ b/src/server/server_mcp.c
@@ -11,6 +11,7 @@
 #include "kb_client.h"
 #include "dashboard.h"
 #include "work_queue.h"
+#include "mcp_tools.h"
 #include "mcp_git.h"
 #include "git_verify.h"
 #include "workspace_turn.h"
@@ -1635,6 +1636,24 @@ int handle_mcp_call(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const char *tool = jtool->valuestring;
    cJSON *content = NULL;
    cJSON *structured = NULL;
+
+   /* Family multiplex (P4): if `tool` is a collapsed family (pipeline/diagnose/
+    * session/lsp/note/…), rewrite it to the legacy <family>_<command> name so all
+    * downstream routing + capability gating runs unchanged. */
+   char fam_tool[96];
+   {
+      int fd = mcp_family_demux(tool, jargs, fam_tool, sizeof(fam_tool));
+      if (fd < 0)
+      {
+         char emsg[160];
+         snprintf(emsg, sizeof(emsg), "%s requires a valid 'command' (see describe_tool)", tool);
+         if (owns_jargs)
+            cJSON_Delete(jargs);
+         return server_send_error(conn, emsg, NULL);
+      }
+      if (fd == 1)
+         tool = fam_tool;
+   }
 
    if (strcmp(tool, "delegate") == 0)
    {

--- a/src/tests/test_mcp_client_registry.c
+++ b/src/tests/test_mcp_client_registry.c
@@ -506,7 +506,7 @@ static void test_tool_profile_filter(void)
        "get_help",        "find_tools",    "describe_tool", "search_docs",
        "search_memory",   "memory_recall", "get_identity",  "find_symbol",
        "ast_grep_search", "git",           "delegate",      "ensemble_review",
-       "ask_user",        "send_message",  "create_note",   NULL};
+       "ask_user",        "send_message",  "note",          NULL};
    int expect = 0;
    for (int i = 0; core[i]; i++)
       expect++;

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -2,31 +2,24 @@
  * built-in tool surface (name + sorted schema property keys + required), captured
  * via the DUMP_TOOLS path in test_mcp_client_registry.c. Regenerate after an
  * intentional tool change: DUMP_TOOLS=1 ./unit-test-mcp-client-registry 2>&1. */
-#define MCP_TOOLS_GOLDEN_COUNT 94
+#define MCP_TOOLS_GOLDEN_COUNT 63
 #define MCP_TOOLS_GOLDEN \
    "ask_user {choices,question} req:question\n" \
    "ast_grep_search {lang,path,pattern} req:lang,pattern\n" \
    "autopilot {action,job_id,pipeline_id,plan_depth,plan_id,task} req:action\n" \
+   "background {action,command,cwd,id,tail_lines} req:action\n" \
    "clarify_answer {answer,session_id} req:answer,session_id\n" \
    "clarify_start {description} req:description\n" \
-   "complete_prospective_memory {id} req:id\n" \
-   "create_epistemic_directive {anchor_entity,anchor_file,cause,priority,question,topic,valid_until} req:question\n" \
-   "create_note {content,tags,title} req:content,title\n" \
-   "create_prospective_memory {action_text,anchor_entity,anchor_file,recurrence,trigger_text,valid_until} req:action_text,trigger_text\n" \
    "dashboard_metrics {} req:\n" \
    "delegate {branch,cwd,persona,prompt,role} req:persona,prompt,role\n" \
    "delegate_reply {content,delegation_id} req:content,delegation_id\n" \
    "delegate_status {job_id} req:job_id\n" \
    "describe_tool {name} req:name\n" \
-   "diagnose_evidence {content,diagnosis_id,hypothesis_id,rank,source,stance} req:content,diagnosis_id,hypothesis_id,stance\n" \
-   "diagnose_hypothesize {content,diagnosis_id} req:content,diagnosis_id\n" \
-   "diagnose_observe {content,diagnosis_id,source} req:content,diagnosis_id\n" \
-   "diagnose_start {symptom} req:symptom\n" \
-   "diagnose_status {diagnosis_id} req:diagnosis_id\n" \
+   "diagnose {command,content,diagnosis_id,hypothesis_id,rank,source,stance,symptom} req:command\n" \
    "ensemble_review {brief,diff,rounds,turns} req:diff\n" \
+   "epistemic_directive {anchor_entity,anchor_file,cause,command,id,limit,note,priority,question,resolution_memory_id,state,suppress,topic,valid_until} req:command\n" \
    "find_symbol {identifier} req:identifier\n" \
    "find_tools {limit,query} req:\n" \
-   "get_background_output {id,tail_lines} req:id\n" \
    "get_context_block {block_type,limit,query} req:query\n" \
    "get_entity {entity} req:entity\n" \
    "get_entity_edges {entity,limit} req:entity\n" \
@@ -35,25 +28,16 @@
    "get_host {name} req:name\n" \
    "get_identity {} req:\n" \
    "git {action,async,base,body,branch,command,count,depth,diff_stat,files,force,index,job_id,message,mirror,mode,name,number,path,prune,rebase,ref,remote,source,staged,stat_only,state,title,url,wait} req:command\n" \
-   "index_blast_radius {file_path,project} req:file_path\n" \
-   "index_find_callers {project,symbol} req:symbol\n" \
-   "index_structure {file_path,project} req:file_path\n" \
+   "index {command,file_path,project,symbol} req:command\n" \
    "job_start {max_concurrent,plan_id} req:plan_id\n" \
    "job_status {job_id} req:job_id\n" \
-   "kill_background_process {id} req:id\n" \
    "learning_propose {correction_text,description,evidence_refs,polarity,signal_type,target_key,target_memory_id,title,workflow_project,workflow_signal_type} req:signal_type\n" \
    "learning_review {limit,sink,state} req:\n" \
    "list_attempts {filter} req:\n" \
-   "list_background_processes {} req:\n" \
    "list_curiosity_items {limit,state} req:\n" \
-   "list_epistemic_directives {cause,limit,state} req:\n" \
    "list_facts {} req:\n" \
    "list_hosts {} req:\n" \
-   "list_notes {limit,tag} req:\n" \
-   "list_prospective_memories {limit,state} req:\n" \
-   "lsp_definition {col,file,line,workspace} req:col,file,line\n" \
-   "lsp_diagnostics {file,workspace} req:\n" \
-   "lsp_references {col,file,line,workspace} req:col,file,line\n" \
+   "lsp {col,command,file,line,workspace} req:command\n" \
    "memory_alerts {since} req:\n" \
    "memory_briefing {limit_tokens} req:\n" \
    "memory_explain_match {memory_id,query} req:memory_id,query\n" \
@@ -63,36 +47,21 @@
    "memory_provenance {memory_id} req:memory_id\n" \
    "memory_recall {limit_tokens,session_start,task_hint} req:\n" \
    "mutate {confidence,content,id,key,kind,reason,tier,verb} req:verb\n" \
+   "note {command,content,limit,query,tag,tags,title} req:command\n" \
    "payload_rewrite_status {} req:\n" \
-   "pipeline_advance {artifact,pipeline_id} req:pipeline_id\n" \
-   "pipeline_cancel {pipeline_id} req:pipeline_id\n" \
-   "pipeline_gate {admin,operator_principal,pipeline_id,reason,verdict} req:operator_principal,pipeline_id,verdict\n" \
-   "pipeline_list {state} req:\n" \
-   "pipeline_resume {head_branch,pipeline_id,remote,repo_root,worktree_path} req:pipeline_id\n" \
-   "pipeline_start {base_branch,brief,done_bar,head_branch,idea,questions,remote,repo_root} req:idea,repo_root\n" \
-   "pipeline_status {pipeline_id} req:pipeline_id\n" \
+   "pipeline {admin,artifact,base_branch,brief,command,done_bar,head_branch,idea,operator_principal,pipeline_id,questions,reason,remote,repo_root,state,verdict,worktree_path} req:command\n" \
    "preview_blast_radius {paths,project} req:paths,project\n" \
+   "prospective_memory {action_text,anchor_entity,anchor_file,command,id,limit,recurrence,state,trigger_text,valid_until} req:command\n" \
    "record_attempt {approach,lesson,outcome,task_context} req:approach,outcome\n" \
-   "resolve_epistemic_directive {id,note,resolution_memory_id,suppress} req:id\n" \
    "roadmap_list {} req:\n" \
    "roadmap_show {roadmap_id} req:roadmap_id\n" \
    "rules_list {} req:\n" \
    "rules_propose {reason,text} req:text\n" \
-   "run_background_process {command,cwd} req:command\n" \
    "search_docs {max_results,query} req:query\n" \
    "search_graph {limit,query} req:query\n" \
    "search_memory {filter,query} req:query\n" \
-   "search_notes {query} req:query\n" \
    "send_message {target,text} req:target,text\n" \
-   "session_advance {id,message,speaker} req:id,speaker\n" \
-   "session_context_expand {chain_id} req:chain_id\n" \
-   "session_context_search {limit,query} req:query\n" \
-   "session_context_status {} req:\n" \
-   "session_list {limit} req:\n" \
-   "session_pause {id,reason} req:id\n" \
-   "session_search {around_message_id,include_sources,limit,query,session_id,window} req:\n" \
-   "session_start {assignments,channel,template} req:assignments,template\n" \
-   "session_status {id} req:id\n" \
+   "session {around_message_id,assignments,chain_id,channel,command,id,include_sources,limit,message,query,reason,session_id,speaker,template,window} req:command\n" \
    "skill_manage {absorbed_into,action,content,cwd,file_path,name,new_string,old_string,replace_all} req:action,name\n" \
    "store_workflow {project,rule,signal_type} req:rule,signal_type\n" \
    "task_list {limit,session_id,state} req:\n" \


### PR DESCRIPTION
Generalizes the `git` multiplex to **11 families**, cutting the listed catalog from **94 → 63** tools.

## Mechanism (one generic router)
A single table maps `family → {command → existing handler}`:
- **Build time** — `mcp_collapse_families()` folds each family's member tools into one, **merging their existing schemas** (no hand-written unions) under a `command`/`action` discriminator enum.
- **Dispatch time** — `mcp_family_demux()` rewrites `<family>({command:"verb"})` → the legacy `<family>_<verb>` name, so all existing routing **and capability gating** (e.g. `pipeline`) run unchanged. The legacy member names stay directly callable.

## Families collapsed (39 → 11)
`pipeline`(7) · `diagnose`(5) · `lsp`(3) · `index`(3) · `note`(3) · `prospective_memory`(3) · `epistemic_directive`(3) · `background`(4) · **`session`(9)**.

Per your question, **`session` now absorbs all three "session" subsystems** — workflow (`start`/`status`/`pause`/`advance`/`list`), transcript search (`transcript_search`, was `session_search`), and virtual context (`context_search`/`context_expand`/`context_status`, was `session_context_*`) — disambiguated by command name (the `status` vs `context_status` collision is resolved).

Discriminator is `command` except `background` (`action`), whose `run` member already owns a `command` param. Core profile: `create_note` → the `note` family.

## What's left untouched (deliberate)
High-frequency core singletons — `search_memory`, `memory_recall`, `find_symbol`, `ast_grep_search`, `delegate` — stay discrete; burying them in unions would hurt the most-used paths.

## `$ref`/`$defs` dedup — evaluated, rejected
Tool `inputSchema`s pass through to Claude/OpenAI tool-use APIs whose `$ref` support is unreliable; inlined schemas are safer. Not worth risking tool-use to shrink the opt-in `full` profile.

## Tests
Golden regenerated (94 → 63); profile-filter core mirror updated (`create_note` → `note`); full server links clean (`-Werror`); full `make lint` green.
