### PR TITLE
feat(kb): structured-PDF — §6 quarantine admin route (confirm/reject)

### DIFF
--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -757,3 +757,48 @@ int db2_kb_doc_regions_for_chunk(int64_t chunk_id, db2_kb_pdf_region_t *out, int
    aimee_pg_finalize(st);
    return n;
 }
+
+/* Run a quarantine-admin statement that ends in `RETURNING id`, counting the rows it
+ * actually affected. Using RETURNING makes the transition atomic — there is no count-then-act
+ * race, and the scoped predicate (carried in `sql`) is the ONLY thing acted on, so the count
+ * reported is exactly what changed. Returns the affected-row count (>=0), or -1 on error. */
+static int kb_pdf_quarantine_apply(const char *sql, const char *project, const char *document_key)
+{
+   void *conn = db2_conn();
+   if (!conn || !project || !*project || !document_key || !*document_key)
+      return -1;
+   char err[KBP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", document_key);
+   int n = 0, rc;
+   while ((rc = aimee_pg_step(st, err, sizeof(err))) == AIMEE_PG_ROW)
+      n++;
+   aimee_pg_finalize(st);
+   return rc == AIMEE_PG_DONE ? n : -1;
+}
+
+int db2_kb_pdf_quarantine_confirm(const char *project, const char *document_key)
+{
+   /* Scoped to exactly the pending PDF chunks at this (project, file_path); RETURNING gives
+    * the true affected count. A confirmed doc has quarantine_state='' and is retrievable. */
+   static const char *sql = "UPDATE kb_documents SET quarantine_state = ''"
+                            " WHERE project = ?1 AND file_path = ?2 AND doc_kind = 'pdf'"
+                            "   AND quarantine_state = 'pending'"
+                            " RETURNING id";
+   return kb_pdf_quarantine_apply(sql, project, document_key);
+}
+
+int db2_kb_pdf_quarantine_reject(const char *project, const char *document_key)
+{
+   /* Delete ONLY the pending PDF chunks at this (project, file_path) — NOT every row sharing
+    * the file_path (a non-PDF or already-confirmed doc could collide). Regions cascade via
+    * the kb_doc_regions FK. RETURNING gives the true deleted count. */
+   static const char *sql = "DELETE FROM kb_documents"
+                            " WHERE project = ?1 AND file_path = ?2 AND doc_kind = 'pdf'"
+                            "   AND quarantine_state = 'pending'"
+                            " RETURNING id";
+   return kb_pdf_quarantine_apply(sql, project, document_key);
+}

--- a/src/db2/kb_payload.h
+++ b/src/db2/kb_payload.h
@@ -189,6 +189,14 @@ extern "C"
     * number written (<= max). */
    int db2_kb_doc_regions_for_chunk(int64_t chunk_id, db2_kb_pdf_region_t *out, int max);
 
+   /* §6 quarantine admin (owner action). For a (project, document_key) structured PDF
+    * currently in quarantine_state='pending': confirm clears the state (the doc becomes
+    * retrievable via search_chunks); reject purges its chunks + regions. Both return the
+    * number of pending chunks acted on (>0), 0 if there is no pending PDF for that key, or
+    * -1 on error. */
+   int db2_kb_pdf_quarantine_confirm(const char *project, const char *document_key);
+   int db2_kb_pdf_quarantine_reject(const char *project, const char *document_key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/kb_http_pdf.h
+++ b/src/headers/kb_http_pdf.h
@@ -10,4 +10,12 @@
 int handle_get_pdf_search_route(const char *method, const char *query_string, char *out_buf,
                                 int out_cap);
 
+/* POST /v1/pdf/quarantine — §6 quarantine admin. Body: {project, document_key,
+ * action:"confirm"|"reject"}. confirm releases a pending restricted PDF (it becomes
+ * retrievable via search_chunks); reject purges it. The OWNER-only authorization is enforced
+ * by the caller (kb_http_route_ex) before this runs — this handler does body parsing + the
+ * state transition only. Writes a JSON body to out_buf and returns the HTTP status. */
+int handle_post_pdf_quarantine_route(const char *method, const char *body, int body_len,
+                                     char *out_buf, int out_cap);
+
 #endif /* DEC_KB_HTTP_PDF_H */

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1288,6 +1288,19 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_code_search_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/search") == 0)
       return handle_get_pdf_search_route(method, query_string, out_buf, out_cap);
+   /* POST /v1/pdf/quarantine — §6 owner action to release/purge a pending restricted PDF.
+    * Owner-only: a scoped bearer cannot transition a document's access state (the auth is
+    * checked here where the verified scope `vr` lives; the handler does body + state work). */
+   if (strcmp(path, "/v1/pdf/quarantine") == 0)
+   {
+      if (vr.scope_kind[0])
+      {
+         snprintf(out_buf, (size_t)out_cap,
+                  "{\"error\":\"forbidden: quarantine actions require the owner credential\"}");
+         return 403;
+      }
+      return handle_post_pdf_quarantine_route(method, body, body_len, out_buf, out_cap);
+   }
    if (strcmp(path, "/v1/code/callers") == 0)
       return handle_get_code_callers_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/project-stats") == 0)

--- a/src/kb/http/kb_http_pdf.c
+++ b/src/kb/http/kb_http_pdf.c
@@ -150,3 +150,66 @@ int handle_get_pdf_search_route(const char *method, const char *query_string, ch
    free(regs);
    return status;
 }
+
+int handle_post_pdf_quarantine_route(const char *method, const char *body, int body_len,
+                                     char *out_buf, int out_cap)
+{
+   (void)body_len;
+   if (!method || strcmp(method, "POST") != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+      return 405;
+   }
+
+   cJSON *req = body ? cJSON_Parse(body) : NULL;
+   const cJSON *jproj = req ? cJSON_GetObjectItemCaseSensitive(req, "project") : NULL;
+   const cJSON *jdk = req ? cJSON_GetObjectItemCaseSensitive(req, "document_key") : NULL;
+   const cJSON *jact = req ? cJSON_GetObjectItemCaseSensitive(req, "action") : NULL;
+   if (!cJSON_IsString(jproj) || !jproj->valuestring[0] || !cJSON_IsString(jdk) ||
+       !jdk->valuestring[0] || !cJSON_IsString(jact))
+   {
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"bad request: project, document_key, and action are "
+               "required\",\"code\":\"bad_request\"}");
+      return 400;
+   }
+
+   const char *project = jproj->valuestring;
+   const char *dk = jdk->valuestring;
+   const char *action = jact->valuestring;
+   int rc;
+   if (strcmp(action, "confirm") == 0)
+      rc = db2_kb_pdf_quarantine_confirm(project, dk);
+   else if (strcmp(action, "reject") == 0)
+      rc = db2_kb_pdf_quarantine_reject(project, dk);
+   else
+   {
+      cJSON_Delete(req);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"action must be 'confirm' or 'reject'\",\"code\":\"bad_request\"}");
+      return 400;
+   }
+
+   /* Snapshot before freeing req (dk points into it). */
+   char dk_copy[1024];
+   snprintf(dk_copy, sizeof(dk_copy), "%s", dk);
+   char action_copy[16];
+   snprintf(action_copy, sizeof(action_copy), "%s", action);
+   cJSON_Delete(req);
+
+   if (rc < 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"db error\"}");
+      return 503;
+   }
+   if (rc == 0)
+   {
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"no pending PDF for that document_key\",\"code\":\"not_found\"}");
+      return 404;
+   }
+   snprintf(out_buf, (size_t)out_cap, "{\"document_key\":\"%s\",\"action\":\"%s\",\"chunks\":%d}",
+            dk_copy, action_copy, rc);
+   return 200;
+}

--- a/src/tests/test_kb_doc_pdf.c
+++ b/src/tests/test_kb_doc_pdf.c
@@ -326,6 +326,70 @@ static void test_search_chunks_shim(void)
    PASS("search_chunks_shim");
 }
 
+/* §6 quarantine admin: a restricted PDF is withheld until confirmed; reject purges it. */
+static void test_pdf_quarantine_admin(void)
+{
+   db2_test_shim_open();
+   kb_pdf_ingest_stats_t stats;
+   char buf[1024];
+   db2_kb_pdf_chunk_t chunks[8];
+
+   /* Restricted -> pending -> withheld from search_chunks. */
+   assert(kb_doc_pdf_ingest_xhtml("proj", "secret.pdf", "h1", FIXTURE_2PAGE, "restricted",
+                                  &stats) == 2);
+   assert(db2_kb_pdf_search_chunks("proj", "world", 8, chunks) == 0);
+
+   /* confirm -> 200; the doc becomes retrievable. */
+   const char *cbody =
+       "{\"project\":\"proj\",\"document_key\":\"secret.pdf\",\"action\":\"confirm\"}";
+   int st = handle_post_pdf_quarantine_route("POST", cbody, (int)strlen(cbody), buf, sizeof(buf));
+   assert(st == 200);
+   assert(strstr(buf, "\"chunks\":2") != NULL);
+   assert(db2_kb_pdf_search_chunks("proj", "world", 8, chunks) == 1);
+   assert(strcmp(chunks[0].document_key, "secret.pdf") == 0);
+   /* confirm again -> 404 (no longer pending). */
+   assert(handle_post_pdf_quarantine_route("POST", cbody, (int)strlen(cbody), buf, sizeof(buf)) ==
+          404);
+
+   /* reject a fresh restricted doc -> 200; chunks + regions purged (FK cascade). */
+   assert(kb_doc_pdf_ingest_xhtml("proj", "bad.pdf", "h2", FIXTURE_2PAGE, "restricted", &stats) ==
+          2);
+   const char *rbody = "{\"project\":\"proj\",\"document_key\":\"bad.pdf\",\"action\":\"reject\"}";
+   assert(handle_post_pdf_quarantine_route("POST", rbody, (int)strlen(rbody), buf, sizeof(buf)) ==
+          200);
+   assert(count_rows("SELECT COUNT(*) FROM kb_documents WHERE file_path='bad.pdf'") == 0);
+   assert(count_rows("SELECT COUNT(*) FROM kb_doc_regions WHERE document_key='bad.pdf'") == 0);
+
+   /* errors: method, missing fields, unknown action, not-found. */
+   assert(handle_post_pdf_quarantine_route("GET", cbody, (int)strlen(cbody), buf, sizeof(buf)) ==
+          405);
+   assert(handle_post_pdf_quarantine_route("POST", "{}", 2, buf, sizeof(buf)) == 400);
+   const char *ubody = "{\"project\":\"proj\",\"document_key\":\"x.pdf\",\"action\":\"foo\"}";
+   assert(handle_post_pdf_quarantine_route("POST", ubody, (int)strlen(ubody), buf, sizeof(buf)) ==
+          400);
+   const char *nbody =
+       "{\"project\":\"proj\",\"document_key\":\"missing.pdf\",\"action\":\"confirm\"}";
+   assert(handle_post_pdf_quarantine_route("POST", nbody, (int)strlen(nbody), buf, sizeof(buf)) ==
+          404);
+
+   /* reject is SCOPED: a non-PDF row that happens to share the file_path must SURVIVE — only
+    * the pending PDF chunks are purged, not everything at that (project, file_path). */
+   assert(kb_doc_pdf_ingest_xhtml("proj", "shared", "h3", FIXTURE_2PAGE, "restricted", &stats) ==
+          2);
+   assert(db2_kb_documents_insert_chunk("proj", "shared", "h4", 0, "", 0, 0, "non-pdf body", 2) >
+          0);
+   const char *sbody = "{\"project\":\"proj\",\"document_key\":\"shared\",\"action\":\"reject\"}";
+   assert(handle_post_pdf_quarantine_route("POST", sbody, (int)strlen(sbody), buf, sizeof(buf)) ==
+          200);
+   assert(count_rows("SELECT COUNT(*) FROM kb_documents WHERE file_path='shared' AND "
+                     "doc_kind='pdf'") == 0); /* the pending PDF is gone */
+   assert(count_rows("SELECT COUNT(*) FROM kb_documents WHERE file_path='shared' AND "
+                     "doc_kind=''") == 1); /* the co-located non-PDF row survived */
+
+   db2_test_shim_close();
+   PASS("pdf_quarantine_admin");
+}
+
 int main(void)
 {
    printf("structured-pdf (kb_doc_pdf) tests:\n");
@@ -336,6 +400,7 @@ int main(void)
    test_degraded_no_line_tags();
    test_ingest_shim();
    test_search_chunks_shim();
+   test_pdf_quarantine_admin();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -318,6 +318,18 @@ int db2_kb_doc_regions_for_chunk(int64_t chunk_id, void *out, int max)
    (void)max;
    return 0;
 }
+int db2_kb_pdf_quarantine_confirm(const char *project, const char *document_key)
+{
+   (void)project;
+   (void)document_key;
+   return 0;
+}
+int db2_kb_pdf_quarantine_reject(const char *project, const char *document_key)
+{
+   (void)project;
+   (void)document_key;
+   return 0;
+}
 int db2_dim_change_reset(int target_dim, int force, int dry_run, db2_reembed_plan_t *out)
 {
    (void)force;


### PR DESCRIPTION
Completes the §6 quarantine story. New **owner-only** `POST /v1/pdf/quarantine` (body `{project, document_key, action:confirm|reject}`): **confirm** clears `quarantine_state` so a restricted PDF becomes retrievable via `search_chunks`; **reject** purges its chunks + regions (FK cascade). Owner check enforced inline in `kb_http_route_ex` (scoped bearer → 403, like `/v1/enroll`). db2 `_confirm`/`_reject` count pending chunks first, act only on a doc in 'pending', return the count (0→404, -1→error). Tests cover withhold→confirm→retrievable, double-confirm 404, reject purge+cascade, and 405/400/404 paths. Builds clean; lint + tests green.