### PR TITLE
feat(kb): structured-PDF §5 evidence escalation routes (open_page/neighbors/structure)

### DIFF
--- a/src/db2/kb_payload.c
+++ b/src/db2/kb_payload.c
@@ -802,3 +802,130 @@ int db2_kb_pdf_quarantine_reject(const char *project, const char *document_key)
                             " RETURNING id";
    return kb_pdf_quarantine_apply(sql, project, document_key);
 }
+
+static void fill_region_row(aimee_pg_stmt_t *st, db2_kb_pdf_region_t *r)
+{
+   memset(r, 0, sizeof(*r));
+   r->page_no = aimee_pg_column_int(st, 0);
+   r->x0 = aimee_pg_column_double(st, 1);
+   r->y0 = aimee_pg_column_double(st, 2);
+   r->x1 = aimee_pg_column_double(st, 3);
+   r->y1 = aimee_pg_column_double(st, 4);
+   const char *q = aimee_pg_column_text(st, 5);
+   r->line_index = aimee_pg_column_int(st, 6);
+   const char *ct = aimee_pg_column_text(st, 7);
+   snprintf(r->quote, sizeof(r->quote), "%s", q ? q : "");
+   snprintf(r->content_type, sizeof(r->content_type), "%s", ct ? ct : "");
+}
+
+int db2_kb_pdf_open_page(const char *project, const char *document_key, int page_no,
+                         db2_kb_pdf_region_t *out, int max)
+{
+   if (!out || max <= 0 || !project || !*project || !document_key || !*document_key)
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   /* Join to kb_documents so the chunk's quarantine gate applies — a pending (restricted)
+    * document's page is withheld even though kb_doc_regions has no quarantine column. */
+   static const char *sql =
+       "SELECT r.page_no, r.x0, r.y0, r.x1, r.y1, r.quote, r.line_index, r.content_type"
+       " FROM kb_doc_regions r JOIN kb_documents d ON d.id = r.chunk_id"
+       " WHERE r.document_key = ?1 AND r.page_no = ?2 AND d.project = ?3"
+       "   AND d.doc_kind = 'pdf' AND d.quarantine_state <> 'pending'"
+       " ORDER BY r.line_index LIMIT ?4";
+   char err[KBP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_text(st, "?1", document_key);
+   aimee_pg_bind_int(st, "?2", page_no);
+   aimee_pg_bind_text(st, "?3", project);
+   aimee_pg_bind_int(st, "?4", max);
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      fill_region_row(st, &out[n++]);
+   aimee_pg_finalize(st);
+   return n;
+}
+
+int db2_kb_pdf_open_neighbors(const char *project, int64_t chunk_id, db2_kb_pdf_chunk_t *out,
+                              int max)
+{
+   if (!out || max <= 0 || chunk_id <= 0 || !project || !*project)
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   /* The prev/next chunks of chunk_id in reading order (via prev_chunk_id/next_chunk_id), each
+    * subject to the quarantine gate AND scoped to `project` — without the project predicate a
+    * caller could enumerate chunk_ids and read another scope's PDF content (cross-scope IDOR),
+    * so both the anchor chunk and its neighbours must be in the caller's project. */
+   static const char *sql =
+       "SELECT n.id, n.file_path, n.content, n.page_start, n.page_end, n.sensitivity_class"
+       " FROM kb_documents c JOIN kb_documents n"
+       "   ON (n.id = c.prev_chunk_id OR n.id = c.next_chunk_id)"
+       " WHERE c.id = ?1 AND c.project = ?2 AND n.project = ?2"
+       "   AND c.quarantine_state <> 'pending'" /* don't navigate FROM a quarantined chunk */
+       "   AND n.doc_kind = 'pdf' AND n.quarantine_state <> 'pending'"
+       " ORDER BY n.chunk_index LIMIT ?3";
+   char err[KBP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_int64(st, "?1", chunk_id);
+   aimee_pg_bind_text(st, "?2", project);
+   aimee_pg_bind_int(st, "?3", max);
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      memset(&out[n], 0, sizeof(out[n]));
+      out[n].chunk_id = aimee_pg_column_int64(st, 0);
+      const char *fp = aimee_pg_column_text(st, 1);
+      const char *ct = aimee_pg_column_text(st, 2);
+      const char *sc = aimee_pg_column_text(st, 5);
+      snprintf(out[n].document_key, sizeof(out[n].document_key), "%s", fp ? fp : "");
+      snprintf(out[n].content, sizeof(out[n].content), "%s", ct ? ct : "");
+      out[n].page_start = aimee_pg_column_int(st, 3);
+      out[n].page_end = aimee_pg_column_int(st, 4);
+      snprintf(out[n].sensitivity_class, sizeof(out[n].sensitivity_class), "%s", sc ? sc : "");
+      n++;
+   }
+   aimee_pg_finalize(st);
+   return n;
+}
+
+int db2_kb_pdf_inspect_structure(const char *project, const char *document_key,
+                                 db2_kb_pdf_outline_t *out, int max)
+{
+   if (!out || max <= 0 || !project || !*project || !document_key || !*document_key)
+      return 0;
+   void *conn = db2_conn();
+   if (!conn)
+      return 0;
+   static const char *sql =
+       "SELECT chunk_index, page_start, page_end, heading_path FROM kb_documents"
+       " WHERE project = ?1 AND file_path = ?2 AND doc_kind = 'pdf'"
+       "   AND quarantine_state <> 'pending'"
+       " ORDER BY chunk_index LIMIT ?3";
+   char err[KBP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return 0;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", document_key);
+   aimee_pg_bind_int(st, "?3", max);
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      memset(&out[n], 0, sizeof(out[n]));
+      out[n].chunk_index = aimee_pg_column_int(st, 0);
+      out[n].page_start = aimee_pg_column_int(st, 1);
+      out[n].page_end = aimee_pg_column_int(st, 2);
+      const char *hp = aimee_pg_column_text(st, 3);
+      snprintf(out[n].heading_path, sizeof(out[n].heading_path), "%s", hp ? hp : "");
+      n++;
+   }
+   aimee_pg_finalize(st);
+   return n;
+}

--- a/src/db2/kb_payload.h
+++ b/src/db2/kb_payload.h
@@ -197,6 +197,31 @@ extern "C"
    int db2_kb_pdf_quarantine_confirm(const char *project, const char *document_key);
    int db2_kb_pdf_quarantine_reject(const char *project, const char *document_key);
 
+   /* §5 evidence escalation reads. All withhold quarantine_state='pending' (restricted)
+    * documents. Return the number written (<= max). */
+
+   /* open_page: every coordinate region on (project, document_key, page_no), ordered by
+    * line_index — the full set of citations for a page. */
+   int db2_kb_pdf_open_page(const char *project, const char *document_key, int page_no,
+                            db2_kb_pdf_region_t *out, int max);
+
+   /* open_neighbors: the prev/next reading-order chunks of `chunk_id`, scoped to `project`
+    * (the project predicate prevents cross-scope chunk-id enumeration). 0-2 results. */
+   int db2_kb_pdf_open_neighbors(const char *project, int64_t chunk_id, db2_kb_pdf_chunk_t *out,
+                                 int max);
+
+   /* inspect_structure: a document's chunk outline (chunk_index + page span + heading_path),
+    * ordered by chunk_index. */
+   typedef struct
+   {
+      int chunk_index;
+      int page_start;
+      int page_end;
+      char heading_path[256];
+   } db2_kb_pdf_outline_t;
+   int db2_kb_pdf_inspect_structure(const char *project, const char *document_key,
+                                    db2_kb_pdf_outline_t *out, int max);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/kb_http_pdf.h
+++ b/src/headers/kb_http_pdf.h
@@ -18,4 +18,16 @@ int handle_get_pdf_search_route(const char *method, const char *query_string, ch
 int handle_post_pdf_quarantine_route(const char *method, const char *body, int body_len,
                                      char *out_buf, int out_cap);
 
+/* §5 evidence escalation read routes (all GET, all withhold quarantined PDFs; the caller's
+ * token scope is enforced by kb_http_route_ex before dispatch):
+ *   GET /v1/pdf/page?project=&document_key=&page_no=   - a page's full citation set
+ *   GET /v1/pdf/neighbors?chunk_id=                    - the prev/next reading-order chunks
+ *   GET /v1/pdf/structure?project=&document_key=       - the document's chunk/page outline */
+int handle_get_pdf_page_route(const char *method, const char *query_string, char *out_buf,
+                              int out_cap);
+int handle_get_pdf_neighbors_route(const char *method, const char *query_string, char *out_buf,
+                                   int out_cap);
+int handle_get_pdf_structure_route(const char *method, const char *query_string, char *out_buf,
+                                   int out_cap);
+
 #endif /* DEC_KB_HTTP_PDF_H */

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1288,6 +1288,12 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_code_search_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/search") == 0)
       return handle_get_pdf_search_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/pdf/page") == 0)
+      return handle_get_pdf_page_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/pdf/neighbors") == 0)
+      return handle_get_pdf_neighbors_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/pdf/structure") == 0)
+      return handle_get_pdf_structure_route(method, query_string, out_buf, out_cap);
    /* POST /v1/pdf/quarantine — §6 owner action to release/purge a pending restricted PDF.
     * Owner-only: a scoped bearer cannot transition a document's access state (the auth is
     * checked here where the verified scope `vr` lives; the handler does body + state work). */

--- a/src/kb/http/kb_http_pdf.c
+++ b/src/kb/http/kb_http_pdf.c
@@ -213,3 +213,158 @@ int handle_post_pdf_quarantine_route(const char *method, const char *body, int b
             dk_copy, action_copy, rc);
    return 200;
 }
+
+/* Emit a cJSON root to out_buf, returning 200, 500 (oom), or 413 (too large for the buffer —
+ * never truncated/invalid JSON). Frees `root`. */
+static int pdf_emit_json(cJSON *root, char *out_buf, int out_cap)
+{
+   char *s = cJSON_PrintUnformatted(root);
+   int status = 200;
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      status = 500;
+   }
+   else if (strlen(s) >= (size_t)out_cap)
+   {
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"result too large\",\"code\":\"result_too_large\"}");
+      status = 413;
+   }
+   else
+   {
+      snprintf(out_buf, (size_t)out_cap, "%s", s);
+   }
+   free(s);
+   cJSON_Delete(root);
+   return status;
+}
+
+static void pdf_add_citation(cJSON *arr, const db2_kb_pdf_region_t *r)
+{
+   cJSON *cit = cJSON_CreateObject();
+   cJSON_AddNumberToObject(cit, "page_no", r->page_no);
+   cJSON *bbox = cJSON_AddArrayToObject(cit, "bbox");
+   cJSON_AddItemToArray(bbox, cJSON_CreateNumber(r->x0));
+   cJSON_AddItemToArray(bbox, cJSON_CreateNumber(r->y0));
+   cJSON_AddItemToArray(bbox, cJSON_CreateNumber(r->x1));
+   cJSON_AddItemToArray(bbox, cJSON_CreateNumber(r->y1));
+   cJSON_AddStringToObject(cit, "quote", r->quote);
+   cJSON_AddNumberToObject(cit, "line_index", r->line_index);
+   cJSON_AddStringToObject(cit, "content_type", r->content_type);
+   cJSON_AddItemToArray(arr, cit);
+}
+
+int handle_get_pdf_page_route(const char *method, const char *query_string, char *out_buf,
+                              int out_cap)
+{
+   if (!method || strcmp(method, "GET") != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+      return 405;
+   }
+   char project[128] = "", dk[1024] = "", pages[16] = "";
+   if (!pdf_qparam(query_string, "project", project, sizeof(project)) || !project[0] ||
+       !pdf_qparam(query_string, "document_key", dk, sizeof(dk)) || !dk[0] ||
+       !pdf_qparam(query_string, "page_no", pages, sizeof(pages)) || !pages[0])
+   {
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"project, document_key, and page_no are required\"}");
+      return 400;
+   }
+   db2_kb_pdf_region_t *regs = malloc((size_t)PDF_MAX_REGIONS * sizeof(*regs));
+   if (!regs)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+   int n = db2_kb_pdf_open_page(project, dk, atoi(pages), regs, PDF_MAX_REGIONS);
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "document_key", dk);
+   cJSON_AddNumberToObject(root, "page_no", atoi(pages));
+   cJSON *cits = cJSON_AddArrayToObject(root, "citations");
+   for (int i = 0; i < n; i++)
+      pdf_add_citation(cits, &regs[i]);
+   cJSON_AddNumberToObject(root, "total", n);
+   free(regs);
+   return pdf_emit_json(root, out_buf, out_cap);
+}
+
+int handle_get_pdf_neighbors_route(const char *method, const char *query_string, char *out_buf,
+                                   int out_cap)
+{
+   if (!method || strcmp(method, "GET") != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+      return 405;
+   }
+   char project[128] = "", ids[32] = "";
+   /* project is REQUIRED: it scopes the lookup AND makes the kb_http_route_ex token-scope gate
+    * fire (that gate only acts when the request names a project/scope), closing a cross-scope
+    * chunk-id enumeration leak. */
+   if (!pdf_qparam(query_string, "project", project, sizeof(project)) || !project[0] ||
+       !pdf_qparam(query_string, "chunk_id", ids, sizeof(ids)) || !ids[0])
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"project and chunk_id are required\"}");
+      return 400;
+   }
+   db2_kb_pdf_chunk_t neigh[4];
+   int n = db2_kb_pdf_open_neighbors(project, (int64_t)atoll(ids), neigh, 4);
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddNumberToObject(root, "chunk_id", (double)atoll(ids));
+   cJSON *arr = cJSON_AddArrayToObject(root, "neighbors");
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *c = cJSON_CreateObject();
+      cJSON_AddNumberToObject(c, "chunk_id", (double)neigh[i].chunk_id);
+      cJSON_AddStringToObject(c, "document_key", neigh[i].document_key);
+      cJSON_AddNumberToObject(c, "page_start", neigh[i].page_start);
+      cJSON_AddNumberToObject(c, "page_end", neigh[i].page_end);
+      cJSON_AddStringToObject(c, "content", neigh[i].content);
+      cJSON_AddStringToObject(c, "sensitivity_class", neigh[i].sensitivity_class);
+      cJSON_AddItemToArray(arr, c);
+   }
+   cJSON_AddNumberToObject(root, "total", n);
+   return pdf_emit_json(root, out_buf, out_cap);
+}
+
+#define PDF_MAX_OUTLINE 2000
+
+int handle_get_pdf_structure_route(const char *method, const char *query_string, char *out_buf,
+                                   int out_cap)
+{
+   if (!method || strcmp(method, "GET") != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"method not allowed\"}");
+      return 405;
+   }
+   char project[128] = "", dk[1024] = "";
+   if (!pdf_qparam(query_string, "project", project, sizeof(project)) || !project[0] ||
+       !pdf_qparam(query_string, "document_key", dk, sizeof(dk)) || !dk[0])
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"project and document_key are required\"}");
+      return 400;
+   }
+   db2_kb_pdf_outline_t *ol = malloc((size_t)PDF_MAX_OUTLINE * sizeof(*ol));
+   if (!ol)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+   int n = db2_kb_pdf_inspect_structure(project, dk, ol, PDF_MAX_OUTLINE);
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddStringToObject(root, "document_key", dk);
+   cJSON *arr = cJSON_AddArrayToObject(root, "chunks");
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *c = cJSON_CreateObject();
+      cJSON_AddNumberToObject(c, "chunk_index", ol[i].chunk_index);
+      cJSON_AddNumberToObject(c, "page_start", ol[i].page_start);
+      cJSON_AddNumberToObject(c, "page_end", ol[i].page_end);
+      cJSON_AddStringToObject(c, "heading_path", ol[i].heading_path);
+      cJSON_AddItemToArray(arr, c);
+   }
+   cJSON_AddNumberToObject(root, "total", n);
+   free(ol);
+   return pdf_emit_json(root, out_buf, out_cap);
+}

--- a/src/tests/test_kb_doc_pdf.c
+++ b/src/tests/test_kb_doc_pdf.c
@@ -390,6 +390,72 @@ static void test_pdf_quarantine_admin(void)
    PASS("pdf_quarantine_admin");
 }
 
+/* §5 evidence escalation: open_page / open_neighbors / inspect_structure, with quarantine
+ * withholding on each. */
+static void test_pdf_evidence_tools(void)
+{
+   db2_test_shim_open();
+   kb_pdf_ingest_stats_t stats;
+   char buf[8192];
+   assert(kb_doc_pdf_ingest_xhtml("proj", "report.pdf", "h1", FIXTURE_2PAGE, "internal", &stats) ==
+          2);
+
+   /* open_page: page 1 has 2 line-regions, page 2 has 1. */
+   assert(handle_get_pdf_page_route("GET", "project=proj&document_key=report.pdf&page_no=1", buf,
+                                    sizeof(buf)) == 200);
+   assert(strstr(buf, "Hello world") != NULL);
+   assert(strstr(buf, "\"total\":2") != NULL);
+   assert(strstr(buf, "\"bbox\"") != NULL);
+   assert(handle_get_pdf_page_route("GET", "project=proj&document_key=report.pdf&page_no=2", buf,
+                                    sizeof(buf)) == 200);
+   assert(strstr(buf, "Second page") != NULL && strstr(buf, "\"total\":1") != NULL);
+
+   /* open_neighbors: the page-1 chunk's next is the page-2 chunk. */
+   db2_kb_pdf_chunk_t ch[4];
+   assert(db2_kb_pdf_search_chunks("proj", "Hello", 4, ch) == 1);
+   char nq[80];
+   snprintf(nq, sizeof(nq), "project=proj&chunk_id=%lld", (long long)ch[0].chunk_id);
+   assert(handle_get_pdf_neighbors_route("GET", nq, buf, sizeof(buf)) == 200);
+   assert(strstr(buf, "Second page") != NULL && strstr(buf, "\"total\":1") != NULL);
+   /* cross-scope: the same chunk_id under a DIFFERENT project returns nothing (no IDOR). */
+   snprintf(nq, sizeof(nq), "project=other&chunk_id=%lld", (long long)ch[0].chunk_id);
+   assert(handle_get_pdf_neighbors_route("GET", nq, buf, sizeof(buf)) == 200);
+   assert(strstr(buf, "\"total\":0") != NULL);
+
+   /* inspect_structure: a 2-chunk outline, one per page. */
+   assert(handle_get_pdf_structure_route("GET", "project=proj&document_key=report.pdf", buf,
+                                         sizeof(buf)) == 200);
+   assert(strstr(buf, "\"total\":2") != NULL);
+   assert(strstr(buf, "\"page_start\":1") != NULL && strstr(buf, "\"page_start\":2") != NULL);
+
+   /* Quarantine withholding on every tool. */
+   assert(kb_doc_pdf_ingest_xhtml("proj", "secret.pdf", "h2", FIXTURE_2PAGE, "restricted",
+                                  &stats) == 2);
+   assert(handle_get_pdf_page_route("GET", "project=proj&document_key=secret.pdf&page_no=1", buf,
+                                    sizeof(buf)) == 200);
+   assert(strstr(buf, "\"total\":0") != NULL);
+   assert(handle_get_pdf_structure_route("GET", "project=proj&document_key=secret.pdf", buf,
+                                         sizeof(buf)) == 200);
+   assert(strstr(buf, "\"total\":0") != NULL);
+   /* open_neighbors of a restricted chunk withholds its (also-restricted) neighbour. */
+   int64_t sid =
+       count_rows("SELECT id FROM kb_documents WHERE file_path='secret.pdf' AND chunk_index=0");
+   assert(sid > 0);
+   snprintf(nq, sizeof(nq), "project=proj&chunk_id=%lld", (long long)sid);
+   assert(handle_get_pdf_neighbors_route("GET", nq, buf, sizeof(buf)) == 200);
+   assert(strstr(buf, "\"total\":0") != NULL);
+
+   /* error paths. */
+   assert(handle_get_pdf_page_route("POST", "project=proj&document_key=x&page_no=1", buf,
+                                    sizeof(buf)) == 405);
+   assert(handle_get_pdf_page_route("GET", "project=proj", buf, sizeof(buf)) == 400);
+   assert(handle_get_pdf_neighbors_route("GET", "", buf, sizeof(buf)) == 400);
+   assert(handle_get_pdf_structure_route("GET", "document_key=x", buf, sizeof(buf)) == 400);
+
+   db2_test_shim_close();
+   PASS("pdf_evidence_tools");
+}
+
 int main(void)
 {
    printf("structured-pdf (kb_doc_pdf) tests:\n");
@@ -401,6 +467,7 @@ int main(void)
    test_ingest_shim();
    test_search_chunks_shim();
    test_pdf_quarantine_admin();
+   test_pdf_evidence_tools();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -303,31 +303,35 @@ int db2_reembed_in_progress_get(int *target_dim, long *started_epoch)
  * to resolve so the route table compiles). The struct args are taken as void* to avoid
  * pulling in db2/kb_payload.h (which conflicts with this file's simplified db2 stubs);
  * C links by symbol name, so the pointer type is immaterial. */
+/* structured-PDF db2 stubs — the routes are exercised against real SQL in test_kb_doc_pdf.c;
+ * these just resolve the link (build uses -Wno-unused-parameter, so no (void) casts needed). */
 int db2_kb_pdf_search_chunks(const char *project, const char *query, int max, void *out)
 {
-   (void)project;
-   (void)query;
-   (void)max;
-   (void)out;
    return 0;
 }
 int db2_kb_doc_regions_for_chunk(int64_t chunk_id, void *out, int max)
 {
-   (void)chunk_id;
-   (void)out;
-   (void)max;
    return 0;
 }
 int db2_kb_pdf_quarantine_confirm(const char *project, const char *document_key)
 {
-   (void)project;
-   (void)document_key;
    return 0;
 }
 int db2_kb_pdf_quarantine_reject(const char *project, const char *document_key)
 {
-   (void)project;
-   (void)document_key;
+   return 0;
+}
+int db2_kb_pdf_open_page(const char *project, const char *document_key, int page_no, void *out,
+                         int max)
+{
+   return 0;
+}
+int db2_kb_pdf_open_neighbors(const char *project, int64_t chunk_id, void *out, int max)
+{
+   return 0;
+}
+int db2_kb_pdf_inspect_structure(const char *project, const char *document_key, void *out, int max)
+{
    return 0;
 }
 int db2_dim_change_reset(int target_dim, int force, int dry_run, db2_reembed_plan_t *out)


### PR DESCRIPTION
Adds the three read tools a `search_chunks` citation escalates to, completing the §5 evidence surface. All GET, read-only, access-gated like search_chunks (token scope inherited; `quarantine_state='pending'` withheld). **open_page** returns a page's full citation set (JOINs kb_documents for the quarantine gate); **open_neighbors** returns the prev/next reading-order chunks; **inspect_structure** returns the chunk/page outline. db2 helpers are bound-param + carry `doc_kind='pdf' AND quarantine_state<>'pending'`; responses share a 413-safe emit helper. Tests cover citations+bbox, neighbor traversal, outline, quarantine withholding on all three, and 405/400 paths. Builds clean; lint + tests green. Follow-up: the ingress wiring naming these in explore-with.