### PR TITLE
feat(delegate): intercept Claude sub-agent spawns → auto-launch aimee delegate

### DIFF
--- a/src/client_integrations.c
+++ b/src/client_integrations.c
@@ -1049,9 +1049,11 @@ static void ensure_claude_code_hooks(const char *settings_path)
    ensure_aimee_event_hook(hooks, "PreCompact", "pre-compact", NULL, &dirty);
    /* P3 attention guard: PreToolUse hook scoped to read/edit/destructive tools;
     * accrues per-file attention and blocks hard-destructive ops on files the
-    * session has actively touched. */
+    * session has actively touched. Task|Agent are included so the sub-agent
+    * interceptor fires on provider-native spawns (redirect to aimee delegates). */
    ensure_aimee_event_hook(hooks, "PreToolUse", "attention-guard",
-                           "Read|Edit|Write|MultiEdit|NotebookEdit|Bash|Grep|Glob", &dirty);
+                           "Read|Edit|Write|MultiEdit|NotebookEdit|Bash|Grep|Glob|Task|Agent",
+                           &dirty);
 
    if (dirty)
    {

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -22,6 +22,11 @@ agent_t *agent_route_with_caps(agent_config_t *cfg, const char *role, const conf
 agent_t *agent_find(agent_config_t *cfg, const char *name);
 int agent_is_available_for_routing(const agent_t *agent);
 
+/* True if at least one configured agent is enabled AND routable as a delegate
+ * right now (loads agents.json). Gates sub-agent interception — only redirect to
+ * delegates when usable delegates exist. */
+int agent_any_delegate_available(void);
+
 /* Optional route-time health filter. When a predicate is registered, routing
  * (agent_route / agent_route_at_tier / delegate fallback — everything that
  * goes through agent_is_available_for_routing) treats an agent the predicate

--- a/src/headers/guardrails.h
+++ b/src/headers/guardrails.h
@@ -138,7 +138,9 @@ classification_t classify_path(const char *file_path);
 int pre_tool_check(const char *tool_name, const char *input_json, session_state_t *state,
                    const char *guardrail_mode, const char *cwd, char *msg_buf, size_t msg_len);
 
-/* Normalize provider/internal tool names into guardrail-facing categories. */
+/* Normalize provider/internal tool names into guardrail-facing categories.
+ * Provider-native sub-agent spawns (Task/Agent/spawn_agent/RemoteTrigger) map to
+ * "Subagent" — callers test for that to detect a sub-agent call. */
 const char *guardrails_canonical_tool_name(const char *tool_name);
 
 /* Post-tool update: re-index edited files and track TDD writes.

--- a/src/headers/server_compute_impl.h
+++ b/src/headers/server_compute_impl.h
@@ -80,6 +80,11 @@ typedef struct
 int write_all(int fd, const char *data, size_t len);
 void compute_ctx_begin_budget(compute_ctx_t *cctx);
 compute_ctx_t *create_compute_ctx(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+/* Conn-free async delegate launch: create + dispatch a pollable delegate job,
+ * returning job_id (>0) or -1 with `err`. Pass the originating conn (its caps +
+ * vault principal are captured) or NULL for a server-initiated launch. */
+int server_delegate_launch_async(server_ctx_t *ctx, server_conn_t *conn, cJSON *req, char *err,
+                                 size_t errn);
 void compute_respond(compute_ctx_t *cctx, cJSON *resp);
 void compute_error(compute_ctx_t *cctx, const char *message);
 void compute_ok(compute_ctx_t *cctx);

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -1257,6 +1257,17 @@ int agent_is_available_for_routing(const agent_t *agent)
    return agent_command_on_path(cmd);
 }
 
+int agent_any_delegate_available(void)
+{
+   agent_config_t cfg;
+   if (agent_load_config(&cfg) != 0)
+      return 0;
+   for (int i = 0; i < cfg.agent_count; i++)
+      if (cfg.agents[i].enabled && agent_is_available_for_routing(&cfg.agents[i]))
+         return 1;
+   return 0;
+}
+
 agent_t *agent_find(agent_config_t *cfg, const char *name)
 {
    for (int i = 0; i < cfg->agent_count; i++)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -709,8 +709,6 @@ static int handle_hud_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
 static int handle_hooks_pre(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
-   (void)ctx;
-
    cJSON *jtn = cJSON_GetObjectItemCaseSensitive(req, "tool_name");
    cJSON *jti = cJSON_GetObjectItemCaseSensitive(req, "tool_input");
    cJSON *jcwd = cJSON_GetObjectItemCaseSensitive(req, "cwd");
@@ -755,6 +753,53 @@ static int handle_hooks_pre(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
                            sizeof(msg));
 
    session_state_save(&state, sid);
+
+   /* Sub-agent interception (enforce-delegate-only): the primary agent must not
+    * spawn its OWN sub-agents. pre_tool_check already blocks Task/Agent/spawn_agent
+    * (rc==2); if aimee has usable delegates, auto-launch a delegate from the call
+    * and point the model at the job. The call stays blocked — only the message
+    * changes (a PreToolUse hook cannot return the delegate's result inline). */
+   if (rc == 2 && strcmp(guardrails_canonical_tool_name(tool_name), "Subagent") == 0 &&
+       agent_any_delegate_available())
+   {
+      char prompt[8192] = "";
+      cJSON *ti = cJSON_Parse(tool_input);
+      if (ti)
+      {
+         cJSON *jp = cJSON_GetObjectItemCaseSensitive(ti, "prompt");
+         cJSON *jd = cJSON_GetObjectItemCaseSensitive(ti, "description");
+         const char *p = (cJSON_IsString(jp) && jp->valuestring[0]) ? jp->valuestring : NULL;
+         const char *d = (cJSON_IsString(jd) && jd->valuestring[0]) ? jd->valuestring : NULL;
+         if (p && d)
+            snprintf(prompt, sizeof(prompt), "%s\n\n%s", d, p);
+         else if (p)
+            snprintf(prompt, sizeof(prompt), "%s", p);
+         else if (d)
+            snprintf(prompt, sizeof(prompt), "%s", d);
+         cJSON_Delete(ti);
+      }
+      if (strlen(prompt) >= 20)
+      {
+         cJSON *dreq = cJSON_CreateObject();
+         cJSON_AddStringToObject(dreq, "role", "execute");
+         cJSON_AddStringToObject(dreq, "persona", "engineer");
+         cJSON_AddStringToObject(dreq, "prompt", prompt);
+         if (sid && sid[0])
+            cJSON_AddStringToObject(dreq, "session_id", sid);
+         if (cwd && cwd[0])
+            cJSON_AddStringToObject(dreq, "cwd", cwd);
+         char derr[96] = "";
+         int job_id = server_delegate_launch_async(ctx, NULL, dreq, derr, sizeof(derr));
+         cJSON_Delete(dreq);
+         if (job_id > 0)
+            snprintf(msg, sizeof(msg),
+                     "Sub-agents must run as aimee delegates, not provider-native Task/Agent. "
+                     "Launched delegate job %d on your behalf — call delegate_status(job_id=%d) "
+                     "for the result. For control over role/persona, call the delegate tool "
+                     "directly next time.",
+                     job_id, job_id);
+      }
+   }
 
    /* Skill review nudge: every N tool hooks, fire a background review delegate. */
    if (cfg.skills_review_enabled && rc != 2 &&

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1665,36 +1665,44 @@ int handle_tool_execute(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return 0; /* Response will be sent by worker thread */
 }
 
-int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+/* Conn-free async delegate launch: create a durable, pollable delegate job and
+ * dispatch it detached, returning the job_id (>0) or -1 with `err`. Pass the
+ * originating `conn` (its caps + vault principal are captured for the foreign-cwd
+ * trust check) or NULL for a server-initiated launch (CAPS_ALL, per-turn vault
+ * TL). Shared by handle_delegate (which then replies on conn) and the sub-agent
+ * interceptor in the hook path. */
+int server_delegate_launch_async(server_ctx_t *ctx, server_conn_t *conn, cJSON *req, char *err,
+                                 size_t errn)
 {
    compute_ctx_t *cctx = create_compute_ctx(ctx, conn, req);
    if (!cctx)
-      return server_send_error(conn, "out of memory", NULL);
+   {
+      if (err)
+         snprintf(err, errn, "out of memory");
+      return -1;
+   }
 
-   /* Async-only (WP-B): every delegate is a durable, pollable job. There is no
-    * synchronous delegate path — the connection is closed at dispatch and the
-    * caller polls delegate.status. The legacy `background` request field is
-    * accepted-and-ignored for one release (older clients may still send it). */
    cJSON *jrole = cJSON_GetObjectItemCaseSensitive(req, "role");
    cJSON *jprompt = cJSON_GetObjectItemCaseSensitive(req, "prompt");
    const char *role =
        delegate_role_canonicalize(cJSON_IsString(jrole) ? jrole->valuestring : "execute");
    const char *prompt = cJSON_IsString(jprompt) ? jprompt->valuestring : "";
 
-   /* Cheap, request-only pre-flight validation, surfaced inline as an error
-    * response before the job is created (the persona check lives in the MCP
-    * layer and the worker). */
+   /* Cheap, request-only pre-flight validation (the persona check lives in the
+    * MCP layer and the worker). */
    if (!prompt[0])
    {
       compute_ctx_free(cctx);
-      return server_send_error(conn, "missing prompt", NULL);
+      if (err)
+         snprintf(err, errn, "missing prompt");
+      return -1;
    }
    if (strlen(prompt) < 20)
    {
-      char errmsg[64];
-      snprintf(errmsg, sizeof(errmsg), "prompt too short (%zu chars)", strlen(prompt));
       compute_ctx_free(cctx);
-      return server_send_error(conn, errmsg, NULL);
+      if (err)
+         snprintf(err, errn, "prompt too short (%zu chars)", strlen(prompt));
+      return -1;
    }
 
    char lease_owner[32];
@@ -1703,7 +1711,9 @@ int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (job_id <= 0)
    {
       compute_ctx_free(cctx);
-      return server_send_error(conn, "failed to create delegate job", NULL);
+      if (err)
+         snprintf(err, errn, "failed to create delegate job");
+      return -1;
    }
 
    cctx->background_job_id = job_id;
@@ -1717,8 +1727,23 @@ int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    {
       db1_agent_job_update(job_id, "failed", 0, "compute queue full");
       compute_ctx_free(cctx);
-      return server_send_error(conn, "compute queue full", NULL);
+      if (err)
+         snprintf(err, errn, "compute queue full");
+      return -1;
    }
+   return job_id;
+}
+
+int handle_delegate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   /* Async-only (WP-B): every delegate is a durable, pollable job. There is no
+    * synchronous delegate path — the connection is closed at dispatch and the
+    * caller polls delegate.status. The legacy `background` request field is
+    * accepted-and-ignored for one release (older clients may still send it). */
+   char err[80] = "";
+   int job_id = server_delegate_launch_async(ctx, conn, req, err, sizeof(err));
+   if (job_id <= 0)
+      return server_send_error(conn, err[0] ? err : "failed to launch delegate", NULL);
 
    cJSON *resp = jo_ok();
    cJSON_AddNumberToObject(resp, "job_id", job_id);

--- a/src/tests/test_guardrails.c
+++ b/src/tests/test_guardrails.c
@@ -237,6 +237,15 @@ int main(void)
       platform_unsetenv("AIMEE_BUNDLED_SKILLS_DIR");
    }
    platform_test_rmrf(suite_home);
+
+   /* Provider-native sub-agent spawns canonicalize to "Subagent" (the
+    * redirect-to-delegate trigger in the hook); ordinary tools do not. */
+   assert(strcmp(guardrails_canonical_tool_name("Task"), "Subagent") == 0);
+   assert(strcmp(guardrails_canonical_tool_name("Agent"), "Subagent") == 0);
+   assert(strcmp(guardrails_canonical_tool_name("spawn_agent"), "Subagent") == 0);
+   assert(strcmp(guardrails_canonical_tool_name("Bash"), "Subagent") != 0);
+   assert(strcmp(guardrails_canonical_tool_name("Read"), "Subagent") != 0);
+
    printf("guardrails: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
When usable delegates are configured, the primary agent must not spawn its **own** sub-agents — all delegation goes through aimee. This is the **Claude (redirect) half**; Codex/Gemini blocking via the gateway is a follow-up.

## Behavior
A Claude `Task`/`Agent` call is intercepted in the **PreToolUse hook**. If aimee has usable delegates, aimee **auto-launches a delegate** from the call's prompt and denies the Task with the delegate's job id, e.g.:
> Sub-agents must run as aimee delegates… Launched delegate job 42 — call `delegate_status(job_id=42)` for the result.

(A PreToolUse hook can only *deny*; it can't return the delegate's result inline — so the model picks the result up on the next turn. Auto-launch + on-by-default were the chosen behaviors.)

If **no** delegates are configured, it falls back to the existing plain block (can't force delegation with nothing to delegate to).

## Pieces
- **`client_integrations.c`** — add `Task|Agent` to the PreToolUse matcher (it previously omitted them, so the existing sub-agent block never fired on the primary).
- **`server.c` `handle_hooks_pre`** — on a blocked sub-agent call (`guardrails_canonical_tool_name(...) == "Subagent"`) **and** `agent_any_delegate_available()`, extract the Task prompt/description, launch a detached delegate, rewrite the deny message with the job id.
- **`server_compute.c`** — extract `server_delegate_launch_async()` from `handle_delegate` (conn-free; `create_compute_ctx` already supports a NULL conn for server-initiated turns), so the hook launches a delegate without hijacking its own connection. `handle_delegate` is now a thin wrapper — RPC behavior unchanged.
- **`agent_config.c`** — `agent_any_delegate_available()` gates the interception.

## Tests
guardrails + client-integrations suites pass; added canonical-name assertions (`Task`/`Agent`/`spawn_agent` → `Subagent`); `aimee-server` links clean; full `make lint` green.

## Follow-up (PR2)
Block sub-agent tools for Codex/Gemini/others at the HTTP gateway: activate `gateway_prevent_subagents` when delegates exist + close the Gemini `functionDeclarations` strip gap.