### PR TITLE
fix(roundtable): raise brief cap 4KB→256KB and make truncation loud

### DIFF
--- a/src/db1/roundtable_pipeline.h
+++ b/src/db1/roundtable_pipeline.h
@@ -59,13 +59,19 @@ extern "C"
 #define RTP_CAP_CANCELLED "cancelled"
 #define RTP_CAP_FAILED    "failed"
 
-#define RTP_TS_LEN     32
-#define RTP_HASH_LEN   72
-#define RTP_SHORT_LEN  32
-#define RTP_NAME_LEN   128
-#define RTP_PATH_LEN   512
-#define RTP_IDEA_LEN   2048
-#define RTP_BRIEF_LEN  4096
+#define RTP_TS_LEN    32
+#define RTP_HASH_LEN  72
+#define RTP_SHORT_LEN 32
+#define RTP_NAME_LEN  128
+#define RTP_PATH_LEN  512
+#define RTP_IDEA_LEN  2048
+/* Inline brief/seed cap. Sized for a full proposal or diff summary in the
+ * large-context era (a few-KB brief was an anachronism vs 1M-token panels).
+ * Truncation past this is now LOGGED (rtp_set_brief), never silent; genuinely
+ * huge artifacts should still ride proposal_ref + chunk_index_ref instead of the
+ * inline brief. NOTE: rtp_run_t embeds this fixed buffer, so any *array* of runs
+ * must be heap-allocated (see handle_pipeline_list), never stack. */
+#define RTP_BRIEF_LEN  262144
 #define RTP_DIGEST_LEN 4096
 #define RTP_SNAP_LEN   8192
 #define RTP_REASON_LEN 1024

--- a/src/server/server_pipeline.c
+++ b/src/server/server_pipeline.c
@@ -185,6 +185,23 @@ static void enter_gate(int id, int gate_no, int pr)
 
 /* ------------------------------------------------------------- handlers ---- */
 
+/* Store a seed brief, logging loudly when it overflows the inline cap so a large
+ * brief never silently loses its tail (the old failure: a 16KB plan cut at 4KB,
+ * making the panel flag phantom "section truncated" items). Truly huge artifacts
+ * should ride proposal_ref + chunk_index_ref rather than the inline brief. */
+static void rtp_set_brief(rtp_run_t *run, const char *src)
+{
+   if (!src)
+      src = "";
+   size_t n = strlen(src);
+   if (n >= sizeof(run->brief))
+      LOG_WARN("pipeline",
+               "brief truncated: kept %zu of %zu bytes (inline cap %d); pass large "
+               "artifacts via proposal_ref + chunk_index_ref",
+               sizeof(run->brief) - 1, n, RTP_BRIEF_LEN);
+   snprintf(run->brief, sizeof(run->brief), "%s", src);
+}
+
 int handle_pipeline_start(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    (void)ctx;
@@ -275,13 +292,13 @@ int handle_pipeline_start(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
          cJSON_Delete(bo);
          if (bs)
          {
-            snprintf(run.brief, sizeof(run.brief), "%s", bs);
+            rtp_set_brief(&run, bs);
             free(bs);
          }
          run.accepted_question_count = qc;
       }
       else if (seed && seed[0])
-         snprintf(run.brief, sizeof(run.brief), "%s", seed);
+         rtp_set_brief(&run, seed);
       else
          snprintf(run.brief, sizeof(run.brief), "goal: %s", idea);
 
@@ -387,7 +404,11 @@ int handle_pipeline_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    const char *filter = jo_str(req, "state", NULL);
    config_t lcfg;
    int have_cfg = (config_load(&lcfg) == 0);
-   rtp_run_t rows[64];
+   /* Heap, not stack: rtp_run_t embeds a large inline brief[] (RTP_BRIEF_LEN), so
+    * an array of 64 would be megabytes on the stack. */
+   rtp_run_t *rows = calloc(64, sizeof(*rows));
+   if (!rows)
+      return server_send_error(conn, "pipeline: out of memory", NULL);
    int n = rtp_run_list(filter, rows, 64);
    if (n < 0)
       n = 0;
@@ -407,6 +428,7 @@ int handle_pipeline_list(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       cJSON_AddNumberToObject(o, "total_cost_usd", rows[i].total_cost_usd);
       cJSON_AddItemToArray(arr, o);
    }
+   free(rows);
    return server_send_ok(conn, resp);
 }
 

--- a/src/tests/test_db1_roundtable_pipeline.c
+++ b/src/tests/test_db1_roundtable_pipeline.c
@@ -112,8 +112,8 @@ static void test_admission(void)
    assert(rtp_run_set_state(a, RTP_STATE_DONE, NULL) == 0);
    assert(rtp_run_count_active() == 0);
 
-   /* list filters */
-   rtp_run_t rows[8];
+   /* list filters. static (off-stack): rtp_run_t embeds a large inline brief[]. */
+   static rtp_run_t rows[8];
    int n = rtp_run_list(NULL, rows, 8); /* non-terminal */
    assert(n == 1);                      /* only parked b is non-terminal */
    n = rtp_run_list(RTP_STATE_DONE, rows, 8);


### PR DESCRIPTION
## Why
The roundtable seed `--brief` was silently truncated at ~4KB — a fixed `char[4096]` field (`RTP_BRIEF_LEN`) in the DB1-persisted run struct. Anything longer was `snprintf`'d and cut with no warning, so the panel never saw the tail and flagged phantom "section truncated / unverified" findings. A 4KB cap is absurd next to the 1M-context models on the panel.

## What
- **`RTP_BRIEF_LEN` 4096 → 262144 (256KB).** Holds a full proposal/diff summary inline; genuinely huge artifacts still ride `proposal_ref` + `chunk_index_ref`.
- **Truncation is now loud** — new `rtp_set_brief()` logs a WARN when a brief overflows the cap.
- **Stack safety:** `rtp_run_t` now embeds a 256KB buffer (~266KB total). `handle_pipeline_list`'s `rtp_run_t[64]` is moved to the **heap** (would've been ~17MB on the stack); the db1 test array is `static`. Single-run stack vars are fine on the 32MB listener stack. Verified no other stack arrays of `rtp_run_t` remain.

DB1 round-trip unchanged (TEXT column, bounded copy on load). `unit-test-db1-roundtable-pipeline` passes.