### PR TITLE
feat(roundtable): dynamic panel from the working delegate roster

### DIFF
--- a/deploy/container/aimee-combined.yaml
+++ b/deploy/container/aimee-combined.yaml
@@ -40,10 +40,9 @@ aimee:
 # roster as the panel; a thin client pushes the per-agent keys per session.
 ensemble:
   enabled: true
-  reference_models:
-    - minimax
-    - mistral
-    - mimo-2.5
+  # No reference_models pinned: the panel is built DYNAMICALLY from the enabled +
+  # currently-available delegates (auto-seeded, then unkeyed/unhealthy ones are
+  # dropped). Pin a list here (or via a workflow) only to override that default.
 
 # --- kb: real semantic embeddings via the persistent embedder service ---
 # No embedding_command here on purpose: when it is unset the server embeds

--- a/deploy/container/aimee-server.yaml
+++ b/deploy/container/aimee-server.yaml
@@ -43,8 +43,7 @@ aimee:
 # (no keys are baked in), so the roundtable works once a client has connected.
 ensemble:
   enabled: true
-  reference_models:
-    - minimax
-    - mistral
-    - mimo-2.5
+  # No reference_models pinned: the panel is built DYNAMICALLY from the enabled +
+  # currently-available delegates (auto-seeded, then unkeyed/unhealthy ones are
+  # dropped). Pin a list here (or via a workflow) only to override that default.
 

--- a/src/headers/delegate_ensemble.h
+++ b/src/headers/delegate_ensemble.h
@@ -167,6 +167,13 @@ int ensemble_panelist_eligible(const config_t *cfg, const agent_t *ag);
  * authorization-gated. */
 void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *acfg);
 
+/* Drop currently-UNAVAILABLE panelists (unkeyed HTTP agent, missing CLI/tmux,
+ * health-breaker DOWN) from the panel — runtime gate via
+ * agent_is_available_for_routing, distinct from the authorization gate above.
+ * Run after the seed + authorization filter so a configured-but-broken or
+ * auto-seeded-but-unkeyed model never burns a seat and degrades the round. */
+void ensemble_filter_panel_availability(config_t *cfg, const agent_config_t *acfg);
+
 /* Persona name for review panelist `model_index`: a configured
  * ensemble.reference_personas[model_index] if set, else a round-robin over the
  * engine's diverse default lineup keyed on the stable model index. Returns NULL

--- a/src/server/delegate_ensemble.c
+++ b/src/server/delegate_ensemble.c
@@ -351,8 +351,8 @@ static int positional_change_0_100(const char *prev, const char *next)
 
 static int token_jaccard_change_0_100(const char *prev, const char *next)
 {
-   char(*a)[64] = calloc(512, sizeof(*a));
-   char(*b)[64] = calloc(512, sizeof(*b));
+   char (*a)[64] = calloc(512, sizeof(*a));
+   char (*b)[64] = calloc(512, sizeof(*b));
    if (!a || !b)
    {
       free(a);
@@ -1360,6 +1360,45 @@ void ensemble_filter_panel_authorization(config_t *cfg, const agent_config_t *ac
    {
       const agent_t *agg = agent_find((agent_config_t *)acfg, cfg->ensemble_aggregator);
       if (agg && !ensemble_panelist_eligible(cfg, agg))
+         cfg->ensemble_aggregator[0] = '\0';
+   }
+   if (!cfg->ensemble_aggregator[0] && n > 0)
+      snprintf(cfg->ensemble_aggregator, sizeof(cfg->ensemble_aggregator), "%s",
+               cfg->ensemble_reference_models[0]);
+}
+
+void ensemble_filter_panel_availability(config_t *cfg, const agent_config_t *acfg)
+{
+   /* Runtime gate (distinct from the authorization gate above): drop any
+    * configured panelist that is not currently USABLE — an HTTP agent with no
+    * resolvable key, a CLI agent whose command/tmux is absent, or one the health
+    * breaker marked DOWN. Otherwise it burns a panel seat on a guaranteed-to-fail
+    * participant and silently degrades the round (the bug that left a roundtable
+    * "2/3 participants failed" with unkeyed models in the list). An ad-hoc model
+    * id that is not a configured agent is left as-is (we cannot check it). Same
+    * predicate single-delegate routing uses: agent_is_available_for_routing. */
+   int n = 0;
+   for (int i = 0; i < cfg->ensemble_reference_count; i++)
+   {
+      const char *name = cfg->ensemble_reference_models[i];
+      const agent_t *ag = agent_find((agent_config_t *)acfg, name);
+      if (ag && !agent_is_available_for_routing(ag))
+      {
+         aimee_log(LOG_WARN, "delegate.panel",
+                   "dropping unavailable panelist '%s' (no key / unhealthy / command missing)",
+                   name);
+         continue;
+      }
+      if (n != i)
+         snprintf(cfg->ensemble_reference_models[n], sizeof(cfg->ensemble_reference_models[n]),
+                  "%s", name);
+      n++;
+   }
+   cfg->ensemble_reference_count = n;
+   if (cfg->ensemble_aggregator[0])
+   {
+      const agent_t *agg = agent_find((agent_config_t *)acfg, cfg->ensemble_aggregator);
+      if (agg && !agent_is_available_for_routing(agg))
          cfg->ensemble_aggregator[0] = '\0';
    }
    if (!cfg->ensemble_aggregator[0] && n > 0)

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -1810,6 +1810,9 @@ int handle_delegate_aggregate(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
    /* Also gate an EXPLICIT reference_models list: never run an unauthorized
     * claude as a panelist, however it got into the panel. */
    ensemble_filter_panel_authorization(&cfg, &acfg);
+   /* Runtime gate: drop unkeyed/unhealthy panelists so the round isn't silently
+    * degraded by a model that is in the list/roster but can't actually run. */
+   ensemble_filter_panel_availability(&cfg, &acfg);
    bind_request_session_creds(req);
 
    delegate_ensemble_result_t result;
@@ -1920,6 +1923,9 @@ int handle_delegate_roundtable(server_ctx_t *ctx, server_conn_t *conn, cJSON *re
    /* Also gate an EXPLICIT reference_models list: never run an unauthorized
     * claude as a panelist, however it got into the panel. */
    ensemble_filter_panel_authorization(&cfg, &acfg);
+   /* Runtime gate: drop unkeyed/unhealthy panelists so the round isn't silently
+    * degraded by a model that is in the list/roster but can't actually run. */
+   ensemble_filter_panel_availability(&cfg, &acfg);
    bind_request_session_creds(req);
 
    roundtable_result_t result;

--- a/src/server/server_sweep.c
+++ b/src/server/server_sweep.c
@@ -366,6 +366,7 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    if (agent_load_config(&acfg) != 0)
       return server_send_error(conn, "could not load agents.json", NULL);
    ensemble_default_panel_from_agents(&cfg, &acfg);
+   ensemble_filter_panel_availability(&cfg, &acfg); /* drop unkeyed/unhealthy proposers */
    if (cfg.ensemble_reference_count <= 0)
       return server_send_error(conn, "no enabled agent to propose with", NULL);
    const char *proposer = cfg.ensemble_reference_models[0];
@@ -417,7 +418,7 @@ int handle_dev_sweep(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 
    for (int a = 0; a < area_count; a++)
    {
-      char *prompt = build_area_prompt(root, (const char(*)[MAX_PATH_LEN])cc.paths, area, cc.n, a);
+      char *prompt = build_area_prompt(root, (const char (*)[MAX_PATH_LEN])cc.paths, area, cc.n, a);
       if (!prompt)
          continue;
       agent_result_t r;

--- a/src/tests/test_delegate_ensemble.c
+++ b/src/tests/test_delegate_ensemble.c
@@ -276,6 +276,16 @@ int agent_is_claude_cli(const agent_t *agent)
 {
    return agent && strcmp(agent->name, "claude") == 0;
 }
+/* Stub: a bearer HTTP agent with no resolvable credentials is "unkeyed" -> not
+ * available (the case the availability filter must drop); everything else is. */
+int agent_is_available_for_routing(const agent_t *agent)
+{
+   if (!agent || !agent->enabled)
+      return 0;
+   if (strcmp(agent->auth_type, "bearer") == 0 && agent->credential_count == 0)
+      return 0;
+   return 1;
+}
 static int g_cost_fold_calls = 0;
 static double g_cost_fold_total = 0.0;
 int db1_cost_fold_record(const char *parent_sid, const char *child_sid, double cost,
@@ -921,6 +931,31 @@ static void test_panel_filter_drops_unauthorized_claude(void)
    printf("  test_panel_filter_drops_unauthorized_claude: ok\n");
 }
 
+static void test_panel_filter_drops_unavailable(void)
+{
+   /* A configured panelist that is enabled but NOT runtime-usable (a bearer HTTP
+    * agent with no resolvable key) is dropped so it can't degrade the round; an
+    * ad-hoc model id that names no configured agent is left as-is. */
+   agent_config_t acfg;
+   memset(&acfg, 0, sizeof(acfg));
+   acfg.agent_count = 1;
+   acfg.agents[0].enabled = 1;
+   snprintf(acfg.agents[0].name, MAX_AGENT_NAME, "unkeyed");
+   snprintf(acfg.agents[0].auth_type, sizeof(acfg.agents[0].auth_type), "bearer"); /* needs a key */
+
+   config_t cfg;
+   memset(&cfg, 0, sizeof(cfg));
+   cfg.ensemble_reference_count = 2;
+   snprintf(cfg.ensemble_reference_models[0], 128, "unkeyed");     /* configured + no key -> drop */
+   snprintf(cfg.ensemble_reference_models[1], 128, "adhoc-model"); /* not an agent -> kept */
+   snprintf(cfg.ensemble_aggregator, sizeof(cfg.ensemble_aggregator), "unkeyed");
+   ensemble_filter_panel_availability(&cfg, &acfg);
+   assert(cfg.ensemble_reference_count == 1);
+   assert(strcmp(cfg.ensemble_reference_models[0], "adhoc-model") == 0);
+   assert(strcmp(cfg.ensemble_aggregator, "adhoc-model") == 0); /* repointed off the dropped seat */
+   printf("  test_panel_filter_drops_unavailable: ok\n");
+}
+
 static void test_panel_persona_name_assignment(void)
 {
    config_t cfg;
@@ -1303,6 +1338,7 @@ int main(void)
    test_roundtable_review_brief_and_items_return();
    test_default_panel_excludes_claude_cli();
    test_panel_filter_drops_unauthorized_claude();
+   test_panel_filter_drops_unavailable();
    test_panel_persona_name_assignment();
    test_roundtable_review_assigns_personas();
    test_roundtable_aggregator_fallback_synthesizes();


### PR DESCRIPTION
## Why
The roundtable/ensemble panel came from a static `ensemble.reference_models` list (shipped: `minimax, mistral, mimo-2.5`). Problems:
- an **unkeyed/unhealthy** entry was still seated and **silently degraded** the round (observed: "2/3 participants failed");
- a newly-added **working** delegate (`mimo-2.5-pro`, `glm-5.2`, `codex`) was **never auto-included**.

## What
Make the panel the **working roster, unless a panel is explicitly pinned**:
- **`ensemble_filter_panel_availability()`** — drops any panelist that isn't runtime-usable (unkeyed HTTP agent, missing CLI/tmux, health-breaker DOWN) via `agent_is_available_for_routing` (the same gate single-delegate routing uses). Runs after the existing seed + authorization filter, so it covers **both** the auto-seeded panel and an explicit `reference_models` list. Wired into both `server_compute` roundtable/ensemble entrypoints and the sweep proposer.
- **Default config ships `reference_models` empty** → `ensemble_default_panel_from_agents` seeds the panel dynamically from enabled + available delegates. Pinning a list (config or workflow) overrides — "dynamic unless specified."

Eligibility (authorization) is unchanged; availability is a **separate** runtime gate, so the existing panel tests stay green. Adds `test_panel_filter_drops_unavailable`. Verified live: re-running the roundtable on the now-working panel went from **2/3 participants failed → 0 failed**.