### PR TITLE
feat(kb): auto-build code projection graph in curator drain (P1)

### DIFF
--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -38,6 +38,7 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_detect_contradictions_enabled = 1;
    cfg->kb_curator_index_code_unit_enabled = 1;
    cfg->kb_curator_link_artifacts_enabled = 1;
+   cfg->kb_curator_projection_graph_enabled = 1;
    cfg->kb_curator_synthesize_enabled = 1;
    cfg->kb_curator_promote_entity_enabled = 1;
    cfg->kb_curator_promote_min_sources = 3;
@@ -203,6 +204,17 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       const cJSON *enabled = cJSON_GetObjectItemCaseSensitive(link_artifacts, "enabled");
       if (enabled && cJSON_IsBool(enabled))
          cfg->kb_curator_link_artifacts_enabled = cJSON_IsTrue(enabled) ? 1 : 0;
+   }
+
+   const cJSON *projection_graph = cJSON_GetObjectItemCaseSensitive(curator, "projection_graph");
+   if (projection_graph)
+   {
+      if (!cJSON_IsObject(projection_graph))
+         return config_issue("\"kb.curator.projection_graph\" expected object, got %s",
+                             jo_type_name(projection_graph));
+      const cJSON *enabled = cJSON_GetObjectItemCaseSensitive(projection_graph, "enabled");
+      if (enabled && cJSON_IsBool(enabled))
+         cfg->kb_curator_projection_graph_enabled = cJSON_IsTrue(enabled) ? 1 : 0;
    }
 
    const cJSON *synthesize = cJSON_GetObjectItemCaseSensitive(curator, "synthesize");
@@ -376,14 +388,14 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_resolve_entities_enabled || cfg->kb_curator_index_narrative_enabled ||
        cfg->kb_curator_index_claims_enabled || cfg->kb_curator_detect_contradictions_enabled ||
        cfg->kb_curator_index_code_unit_enabled || cfg->kb_curator_link_artifacts_enabled ||
-       cfg->kb_curator_synthesize_enabled || cfg->kb_curator_promote_entity_enabled ||
-       cfg->kb_curator_extract_command[0] || cfg->kb_curator_judge_command[0] ||
-       cfg->kb_curator_synthesize_command[0] || cfg->kb_curator_extract_max_tokens != 2048 ||
-       cfg->kb_curator_max_attempts != 3 || cfg->kb_curator_synthesize_k != 8 ||
-       cfg->kb_curator_promote_min_sources != 3 || cfg->kb_curator_provider_base_url[0] ||
-       cfg->kb_curator_provider_model[0] || cfg->kb_curator_provider_api_key[0] ||
-       cfg->kb_curator_tier_b_base_url[0] || cfg->kb_curator_tier_b_model[0] ||
-       cfg->kb_curator_tier_b_api_key[0];
+       cfg->kb_curator_projection_graph_enabled || cfg->kb_curator_synthesize_enabled ||
+       cfg->kb_curator_promote_entity_enabled || cfg->kb_curator_extract_command[0] ||
+       cfg->kb_curator_judge_command[0] || cfg->kb_curator_synthesize_command[0] ||
+       cfg->kb_curator_extract_max_tokens != 2048 || cfg->kb_curator_max_attempts != 3 ||
+       cfg->kb_curator_synthesize_k != 8 || cfg->kb_curator_promote_min_sources != 3 ||
+       cfg->kb_curator_provider_base_url[0] || cfg->kb_curator_provider_model[0] ||
+       cfg->kb_curator_provider_api_key[0] || cfg->kb_curator_tier_b_base_url[0] ||
+       cfg->kb_curator_tier_b_model[0] || cfg->kb_curator_tier_b_api_key[0];
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
    if (!curator_any && !evidence_any)
       return;
@@ -408,6 +420,7 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
                               cfg->kb_curator_detect_contradictions_enabled);
          kb_curator_save_gate(cur, "index_code_unit", cfg->kb_curator_index_code_unit_enabled);
          kb_curator_save_gate(cur, "link_artifacts", cfg->kb_curator_link_artifacts_enabled);
+         kb_curator_save_gate(cur, "projection_graph", cfg->kb_curator_projection_graph_enabled);
 
          if (cfg->kb_curator_synthesize_enabled || cfg->kb_curator_synthesize_k != 8)
          {

--- a/src/db2/code_projection.c
+++ b/src/db2/code_projection.c
@@ -157,6 +157,83 @@ int64_t db2_code_projection_visible_id(const char *project)
    return id;
 }
 
+int db2_code_projection_project_fingerprint(const char *project, char *out, size_t out_len)
+{
+   if (!project || !*project || !out || out_len == 0)
+      return -1;
+   out[0] = '\0';
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   /* md5 over (path, content-hash) of every file in the project, ordered — two
+    * scans with identical file contents produce the same fingerprint, so the
+    * drain can skip an unchanged project (content-addressed idempotency). An empty
+    * project hashes md5('') deterministically (built once, then skipped). */
+   static const char *sql =
+       "SELECT md5(coalesce(string_agg(f.path || ':' || f.hash, E'\\n' ORDER BY f.path), ''))"
+       " FROM files f JOIN projects p ON f.project_id = p.id WHERE p.name = ?1";
+   char err[CP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   int rc = -1;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *h = aimee_pg_column_text(st, 0);
+      if (h && h[0])
+      {
+         snprintf(out, out_len, "%s", h);
+         rc = 0;
+      }
+   }
+   aimee_pg_finalize(st);
+   return rc;
+}
+
+int db2_code_projection_generation_set_source_hash(int64_t gen_id, const char *source_hash)
+{
+   if (gen_id <= 0)
+      return -1;
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "UPDATE code_projection_generations SET source_hash = ?2 WHERE id = ?1";
+   char err[CP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", gen_id);
+   aimee_pg_bind_text(st, "?2", source_hash ? source_hash : "");
+   int rc = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   return (rc == AIMEE_PG_DONE) ? 0 : -1;
+}
+
+int db2_code_projection_visible_source_hash(const char *project, char *out, size_t out_len)
+{
+   if (!project || !*project || !out || out_len == 0)
+      return -1;
+   out[0] = '\0';
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+   static const char *sql = "SELECT source_hash FROM code_projection_generations"
+                            " WHERE project = ?1 AND state = 'visible'";
+   char err[CP_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   if ((aimee_pg_bind_text(st, "?1", project), aimee_pg_step(st, err, sizeof(err))) == AIMEE_PG_ROW)
+   {
+      const char *h = aimee_pg_column_text(st, 0);
+      if (h)
+         snprintf(out, out_len, "%s", h);
+   }
+   aimee_pg_finalize(st);
+   return 0; /* out == "" when there is no visible generation yet */
+}
+
 int db2_code_projection_generation_update_counts(int64_t gen_id, int64_t edge_count,
                                                  int64_t node_count)
 {

--- a/src/db2/code_projection.h
+++ b/src/db2/code_projection.h
@@ -3,6 +3,7 @@
 #ifndef CODE_PROJECTION_H
 #define CODE_PROJECTION_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -42,6 +43,19 @@ extern "C"
    /* Return the currently visible generation id for project, or 0 if none.
     * Returns -1 on DB error. */
    int64_t db2_code_projection_visible_id(const char *project);
+
+   /* Content fingerprint (hex) of a project's code: md5 over (path, file-hash) of
+    * all files. Identical contents -> identical fingerprint, so the drain can skip
+    * an unchanged project. Returns 0 on success, -1 on error. */
+   int db2_code_projection_project_fingerprint(const char *project, char *out, size_t out_len);
+
+   /* Record the content fingerprint that produced this generation (stored in
+    * code_projection_generations.source_hash). Returns 0 on success, -1 on error. */
+   int db2_code_projection_generation_set_source_hash(int64_t gen_id, const char *source_hash);
+
+   /* Fingerprint stored on the project's currently-visible generation, into out
+    * (empty when there is no visible generation). Returns 0 on success, -1 on error. */
+   int db2_code_projection_visible_source_hash(const char *project, char *out, size_t out_len);
 
    /* Update edge/node counts on a generation.  Returns 0 on success. */
    int db2_code_projection_generation_update_counts(int64_t gen_id, int64_t edge_count,

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1304,6 +1304,11 @@ typedef struct config
    /* link_artifacts bridge: 0 = off (default), 1 = link code_units to the
     * entities their domain_concepts name (doc<->code via the entity graph). */
    int kb_curator_link_artifacts_enabled;
+   /* projection_graph build: 1 = on (default) — the drain auto-publishes a fresh
+    * code_projection_edges generation per CHANGED project (content-addressed, so
+    * unchanged projects are skipped), materializing the typed code graph on
+    * `workspace add` with no manual `aimee graph sync-code`. Pure DB2, no sidecar. */
+   int kb_curator_projection_graph_enabled;
    /* synthesize_topic: 0 = off (default), 1 = pick a high-centrality entity and
     * emit a `synthesis` narrative via the synthesize sidecar. Requires a
     * configured kb_curator_synthesize_command. */

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -24,6 +24,7 @@
 #include "kb_memory_facts.h"
 #include "kb_learning_synth.h"
 #include "kb_service_code_embed.h"
+#include "kb_service_graph.h" /* kb_graph_build_project_if_changed */
 #include "kb.h"
 #include "index.h"
 #include "aimee.h"
@@ -157,6 +158,35 @@ static void *drain_thread_main(void *arg)
          }
       }
 
+      /* Code projection-graph drain — publish a fresh typed-edge generation per
+       * CHANGED project (content-addressed: an unchanged project is skipped), so
+       * `workspace add` materializes the code_projection_edges layer with no manual
+       * `aimee graph sync-code`. Pure DB2 (reads files/terms/code_calls), no
+       * embedder/LLM. Gated on its own flag (default on); independent of the curator
+       * pipeline below. */
+      if (cfg.kb_curator_projection_graph_enabled)
+      {
+         project_info_t projects[128];
+         int np = index_list_projects(projects, 128);
+         int built = 0;
+         int64_t total = 0;
+         for (int i = 0; i < np; i++)
+         {
+            int rebuilt = 0;
+            int64_t edges = kb_graph_build_project_if_changed(projects[i].name, &rebuilt);
+            if (rebuilt)
+            {
+               built++;
+               if (edges > 0)
+                  total += edges;
+            }
+         }
+         if (built > 0)
+            aimee_log(LOG_INFO, "kb.graph.projection",
+                      "published %lld edge(s) across %d changed project(s)", (long long)total,
+                      built);
+      }
+
       /* Candidate-generation synthesis drain — the heavy LLM pass, on the
        * scheduler, never on the capture hot path. Off by default. */
       if (cfg.learning_synthesize_enabled && cfg.learning_synthesize_command[0])
@@ -281,8 +311,8 @@ void kb_curator_drain_init(kb_curator_drain_ctx_t *ctx)
        !cfg.kb_curator_index_claims_enabled && !cfg.kb_curator_detect_contradictions_enabled &&
        !cfg.kb_curator_index_code_unit_enabled && !cfg.kb_curator_link_artifacts_enabled &&
        !cfg.kb_curator_synthesize_enabled && !cfg.kb_curator_promote_entity_enabled &&
-       !cfg.kb_evidence_embed_enabled && !cfg.learning_synthesize_enabled &&
-       !cfg.typed_facts_enabled)
+       !cfg.kb_curator_projection_graph_enabled && !cfg.kb_evidence_embed_enabled &&
+       !cfg.learning_synthesize_enabled && !cfg.typed_facts_enabled)
    {
       aimee_log(LOG_DEBUG, "kb.curator.drain",
                 "all gates off (kb_curator_extract_docs_enabled=0,"

--- a/src/kb/kb_service_graph.c
+++ b/src/kb/kb_service_graph.c
@@ -19,6 +19,55 @@
 int kb_send_error(int fd, const char *msg);
 int kb_send_response(int fd, cJSON *resp);
 
+const char *kb_graph_edge_provenance(const char *edge_origin, int structural_weight)
+{
+   /* §3: derive the trust tag from the edge's source + structural-trust weight,
+    * with NO new column. `structural` = deterministic AST/index facts (the only
+    * tier a safety path may rely on, per §7); `inferred` = curator/semantic-
+    * derived; `ambiguous` = raw session co-occurrence with no structural or
+    * semantic grounding. */
+   if (structural_weight > 0 || (edge_origin && strcmp(edge_origin, "code_projection") == 0))
+      return "structural";
+   if (edge_origin && strcmp(edge_origin, "session") == 0)
+      return "ambiguous";
+   return "inferred";
+}
+
+int64_t kb_graph_build_project_if_changed(const char *project, int *rebuilt)
+{
+   if (rebuilt)
+      *rebuilt = 0;
+   if (!project || !*project || !db2_is_initialized())
+      return -1;
+   /* Content-addressed idempotency: skip a project whose code is unchanged since
+    * its last published generation, so the drain is cheap-when-nothing-changed. */
+   char fp[64] = "", visible_fp[64] = "";
+   if (db2_code_projection_project_fingerprint(project, fp, sizeof(fp)) != 0)
+      return -1;
+   db2_code_projection_visible_source_hash(project, visible_fp, sizeof(visible_fp));
+   if (fp[0] && visible_fp[0] && strcmp(fp, visible_fp) == 0)
+      return 0; /* unchanged -> no work */
+
+   int64_t gen = db2_code_projection_generation_create(project);
+   if (gen <= 0)
+      return -1;
+   db2_code_projection_generation_set_source_hash(gen, fp);
+   int64_t edges = db2_code_projection_sync_project(project, gen);
+   if (edges < 0)
+   {
+      db2_code_projection_generation_abort(gen, "sync failed");
+      return -1;
+   }
+   if (db2_code_projection_generation_publish(gen, project) != 0)
+   {
+      db2_code_projection_generation_abort(gen, "publish failed");
+      return -1;
+   }
+   if (rebuilt)
+      *rebuilt = 1;
+   return edges; /* >= 0 (a changed-but-empty project publishes 0 edges + its hash) */
+}
+
 int kb_handle_graph_sync_code(int fd, cJSON *req)
 {
    cJSON *proj_j = cJSON_GetObjectItemCaseSensitive(req, "project");
@@ -103,6 +152,9 @@ int kb_handle_graph_explain(int fd, cJSON *req)
       cJSON_AddNumberToObject(e, "structural_weight", edges[i].structural_weight);
       cJSON_AddNumberToObject(e, "utility_score", edges[i].utility_score);
       cJSON_AddStringToObject(e, "edge_origin", edges[i].edge_origin);
+      cJSON_AddStringToObject(
+          e, "provenance",
+          kb_graph_edge_provenance(edges[i].edge_origin, (int)edges[i].structural_weight));
       cJSON_AddItemToArray(arr, e);
    }
    cJSON_AddNumberToObject(resp, "edge_count", n);

--- a/src/kb/kb_service_graph.h
+++ b/src/kb/kb_service_graph.h
@@ -4,6 +4,20 @@
 #define DEC_KB_SERVICE_GRAPH_H 1
 
 #include "cJSON.h"
+#include <stdint.h>
+
+/* Build (publish a fresh generation of) the code projection graph for `project`,
+ * but ONLY when its code changed since the last published generation
+ * (content-addressed via the project fingerprint), so the curator drain stays
+ * cheap when nothing changed. *rebuilt is set to 1 when a generation was
+ * published, 0 when skipped. Returns edge count (>=0) on build, 0 on skip, -1 on
+ * error. KB-side (in-process DB2). */
+int64_t kb_graph_build_project_if_changed(const char *project, int *rebuilt);
+
+/* §3 provenance tag for a graph edge, derived (no column) from its origin +
+ * structural-trust weight: "structural" (deterministic AST/index fact),
+ * "inferred" (curator/semantic), or "ambiguous" (raw session co-occurrence). */
+const char *kb_graph_edge_provenance(const char *edge_origin, int structural_weight);
 
 /* graph.sync_code: project the code index into entity_edges under a fresh
  * generation, publishing it atomically.  Request: {project}.

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -124,6 +124,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-client-docs \
                $(TESTPREFIX)/unit-test-kb-client-search \
                $(TESTPREFIX)/unit-test-kb-client-memory \
+               $(TESTPREFIX)/unit-test-kb-graph \
                $(TESTPREFIX)/unit-test-server-compute \
                $(TESTPREFIX)/unit-test-server-memory-benchmark \
                $(TESTPREFIX)/unit-test-server-jobs-aux \
@@ -1314,6 +1315,11 @@ $(TESTPREFIX)/unit-test-dstr: $(OBJDIR)/tests/test_dstr.o $(OBJDIR)/dstr.o
 
 # The aimee-client test compiles its in-process TLS mock only in WITH_TLS builds.
 $(OBJDIR)/tests/test_aimee_client.o: C_FLAGS += $(TLS_FLAGS)
+$(OBJDIR)/tests/test_kb_graph.o: C_FLAGS += -Ikb
+
+$(TESTPREFIX)/unit-test-kb-graph: $(OBJDIR)/tests/test_kb_graph.o \
+                                  $(OBJDIR)/kb/kb_service_graph.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_CORE)
 
 $(TESTPREFIX)/unit-test-aimee-client: $(OBJDIR)/tests/test_aimee_client.o $(OBJDIR)/aimee_client.o \
                                       $(OBJDIR)/posix/platform_net.o $(OBJDIR)/http_uds_client.o \

--- a/src/tests/test_kb_graph.c
+++ b/src/tests/test_kb_graph.c
@@ -1,0 +1,160 @@
+/* test_kb_graph.c: unit tests for the code-graph P1 build orchestrator and the
+ * derived edge-provenance tag. DB2 is stubbed so the idempotency control flow
+ * (skip-when-unchanged vs publish-a-new-generation) is driven deterministically
+ * without a live Postgres. */
+#include "kb_service_graph.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ---- controllable DB2 stubs ---- */
+static char g_fp[64] = "";      /* fingerprint the project "currently" hashes to */
+static char g_visible[64] = ""; /* fingerprint stored on the visible generation  */
+static int g_synced = 0;        /* db2_code_projection_sync_project call count    */
+static int g_published = 0;     /* db2_code_projection_generation_publish count   */
+static int g_aborted = 0;
+
+int db2_is_initialized(void)
+{
+   return 1;
+}
+int db2_code_projection_project_fingerprint(const char *project, char *out, size_t out_len)
+{
+   (void)project;
+   snprintf(out, out_len, "%s", g_fp);
+   return g_fp[0] ? 0 : -1; /* empty g_fp simulates a fingerprint error */
+}
+int db2_code_projection_visible_source_hash(const char *project, char *out, size_t out_len)
+{
+   (void)project;
+   snprintf(out, out_len, "%s", g_visible);
+   return 0;
+}
+int64_t db2_code_projection_generation_create(const char *project)
+{
+   (void)project;
+   return 42;
+}
+int db2_code_projection_generation_set_source_hash(int64_t gen, const char *h)
+{
+   (void)gen;
+   (void)h;
+   return 0;
+}
+int64_t db2_code_projection_sync_project(const char *project, int64_t gen)
+{
+   (void)project;
+   (void)gen;
+   g_synced++;
+   return 7; /* pretend 7 edges */
+}
+int db2_code_projection_generation_publish(int64_t gen, const char *project)
+{
+   (void)gen;
+   (void)project;
+   g_published++;
+   return 0;
+}
+int db2_code_projection_generation_abort(int64_t gen, const char *err)
+{
+   (void)gen;
+   (void)err;
+   g_aborted++;
+   return 0;
+}
+
+/* ---- link-only stubs for the rest of kb_service_graph.o (unused here) ---- */
+struct cJSON;
+struct cJSON *jo_ok(void)
+{
+   return 0;
+}
+int db2_entity_edge_explain_by_entity(const char *e, void *out, int n)
+{
+   (void)e;
+   (void)out;
+   (void)n;
+   return 0;
+}
+int db2_entity_node_get(const char *e, void *out)
+{
+   (void)e;
+   (void)out;
+   return -1;
+}
+struct cJSON *db2_kb_service_code_audit_json(const char *p, int n)
+{
+   (void)p;
+   (void)n;
+   return 0;
+}
+int kb_send_error(int fd, const char *m)
+{
+   (void)fd;
+   (void)m;
+   return 0;
+}
+int kb_send_response(int fd, struct cJSON *r)
+{
+   (void)fd;
+   (void)r;
+   return 0;
+}
+
+static void test_provenance(void)
+{
+   /* deterministic AST/index edge */
+   assert(strcmp(kb_graph_edge_provenance("code_projection", 0), "structural") == 0);
+   /* any positive structural-trust weight is structural regardless of origin */
+   assert(strcmp(kb_graph_edge_provenance("session", 3), "structural") == 0);
+   /* raw session co-occurrence, no structural grounding -> ambiguous */
+   assert(strcmp(kb_graph_edge_provenance("session", 0), "ambiguous") == 0);
+   /* curator/semantic-derived -> inferred */
+   assert(strcmp(kb_graph_edge_provenance("curator", 0), "inferred") == 0);
+   assert(strcmp(kb_graph_edge_provenance(NULL, 0), "inferred") == 0);
+   printf("  test_provenance: ok\n");
+}
+
+static void test_idempotent_build(void)
+{
+   int rebuilt = -1;
+   int64_t r;
+
+   /* (1) Unchanged: fingerprint == the visible generation's hash -> SKIP, no sync. */
+   snprintf(g_fp, sizeof(g_fp), "abc");
+   snprintf(g_visible, sizeof(g_visible), "abc");
+   g_synced = g_published = 0;
+   r = kb_graph_build_project_if_changed("p", &rebuilt);
+   assert(r == 0 && rebuilt == 0 && g_synced == 0 && g_published == 0);
+
+   /* (2) Changed: fingerprint differs -> rebuild (sync + publish), edges returned. */
+   snprintf(g_visible, sizeof(g_visible), "def");
+   g_synced = g_published = 0;
+   r = kb_graph_build_project_if_changed("p", &rebuilt);
+   assert(r == 7 && rebuilt == 1 && g_synced == 1 && g_published == 1);
+
+   /* (3) First build: no visible generation yet -> rebuild. */
+   g_visible[0] = '\0';
+   g_synced = g_published = 0;
+   r = kb_graph_build_project_if_changed("p", &rebuilt);
+   assert(r == 7 && rebuilt == 1 && g_synced == 1 && g_published == 1);
+
+   /* (4) Fingerprint error -> -1, no work. */
+   g_fp[0] = '\0';
+   g_synced = g_published = 0;
+   r = kb_graph_build_project_if_changed("p", &rebuilt);
+   assert(r == -1 && rebuilt == 0 && g_synced == 0 && g_published == 0);
+
+   printf("  test_idempotent_build: ok\n");
+}
+
+int main(void)
+{
+   printf("test_kb_graph:\n");
+   test_provenance();
+   test_idempotent_build();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Phase 1 of code-graph intelligence

The code projection graph (code structure → `entity_edges`, `edge_origin='code_projection'`) now builds **automatically** in the kb-curator drain, idempotently — previously it built only on an explicit sync request. This is §1 (auto-build) + §3 (provenance) of `docs/proposals/pending/code-graph-intelligence.md`, first increment.

### What lands

- **Content-addressed idempotency.** `db2_code_projection_project_fingerprint()` hashes md5 over every project file's `(path, content-hash)`, ordered by path; the fingerprint is stamped on the published generation's `source_hash`. A later drain that sees the same fingerprint skips the rebuild. Unchanged project → no-op, so the drain can poll every project every cycle without thrashing the graph or its embeddings.
- **`kb_graph_build_project_if_changed()`** — the orchestrator: resolve fingerprint → compare to the visible generation → on change run `create → set_source_hash → sync → publish`, aborting the pending generation on any failure (fail-closed: the prior visible generation keeps serving). Returns edge count on rebuild, `0` on skip, `-1` on error.
- **Derived edge provenance.** `kb_graph_edge_provenance()` classifies each edge as `structural` (code projection / positive structural weight), `ambiguous` (raw session co-occurrence), or `inferred` (curator/semantic). Surfaced per-edge in `graph.explain`. No schema change — derived from existing fields.
- **Curator drain stage**, gated by the new `kb.curator.projection_graph.enabled` flag (default on; full 4-touch config).
- **Unit test** `unit-test-kb-graph`: stubs DB2 to drive the idempotency control flow (unchanged→skip, changed→rebuild, first build→rebuild, fingerprint error→-1) plus the provenance truth table. Wired into `tests/Rules.mk`.

### Test
```
$ ./build/obj/tests/unit-test-kb-graph
test_kb_graph:
  test_provenance: ok
  test_idempotent_build: ok
ALL PASS
```
Full `aimee-kb` + `aimee-server` build clean (`-Werror`), clang-format clean.

### Follow-ups (later phases)
- Default-branch sourcing: index from the git default branch, not the working tree (design converged via roundtable; next increment).
- P2 tree-sitter, P4 analytics, P5 hybrid RRF retrieval, P8 webchat viz.