### PR TITLE
feat(code-index): source code indexing from the git default branch

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -200,7 +200,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 121 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 122 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -395,7 +395,7 @@ The binaries read 121 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -33,6 +33,53 @@ visualization for humans.
 - **Parse — hand-rolled.** `extractors.c` / `extractors_extra.c` / `extractors_new_langs.c`
   — limited language set, brittle vs real grammars.
 
+## §0.5 Source of truth: the git default branch
+
+**Principle.** Code indexing — the graph **and** the embeddings — is sourced from
+the repository's **git default branch** (e.g. `origin/main`), not the user's
+working tree, current checkout, or a feature branch they are mid-edit on. The kb's
+code view must be **stable and canonical**: a developer's WIP, an uncommitted edit,
+or a throwaway branch must never thrash the graph/embeddings or pollute what other
+sessions retrieve as "the code."
+
+**Resolution order** (`code_collect.c`, `git_resolve_default_ref`):
+1. `git symbolic-ref --short refs/remotes/origin/HEAD` — the remote's advertised
+   default (kept in `origin/<branch>` form end-to-end, no prefix mixing).
+2. If unset (common when the remote was added after clone), repair **once** with
+   `git remote set-head origin -a` and retry — don't surface the transient state.
+3. First existing of `origin/main`, `origin/master`, `main`, `master`.
+4. **No fall-through to the current HEAD or working tree.** A git repo with no
+   resolvable default branch is **skipped** with a diagnostic — silently indexing
+   the checkout would re-introduce the exact WIP-thrash this eliminates.
+
+**Non-git dirs** fall back to the working-tree walk unconditionally. An explicit
+opt-in `AIMEE_CODE_INDEX_SOURCE=worktree` indexes the working tree for a user who
+*wants* their WIP indexed (documented as team-unsafe, since it re-introduces
+thrash); `default`/`auto` (the default) honor the chain above.
+
+**Read mechanism.** One `git ls-tree -r -z <ref>` enumerates `(oid, path)` pairs;
+one `git cat-file --batch` (fed the wanted oids from a temp file, so our side only
+reads — no bidirectional-pipe deadlock) streams content in request order. Content
+is paired to path **by sequence**, so a newline in a path can't misattribute a
+blob. The same extension/skip-dir/size/binary filters as the worktree walk apply.
+
+**Code-vs-edit-tool split (invariant).** Graph + embedding **indexing** reads the
+default branch. **Edit-time** tools that ask "what does *this in-progress change*
+touch" — blast-radius (§7), and the sweep proposer when proposing from
+staged/unstaged changes — read the **working tree** via their own reader and
+deliberately do **not** route through the indexing collector. Conflating the two
+would make a blast-radius query against the default-branch graph silently miss the
+very edit the user is asking about. The choice is documented per tool, never
+inferred. (Today only `kb_client_index` and `server_sweep` use the canonical
+collector; blast-radius already has its own working-tree reader, so the split
+holds structurally.)
+
+**Idempotency interaction.** §1's content fingerprint (md5 over file `(path,hash)`)
+is unaffected — it already captures "did the default-branch content change." A
+future optimization can use the branch tree SHA (`git rev-parse <ref>^{tree}`) as a
+cheaper outer skip-gate, with the per-file `(path,hash)` set still driving
+upsert/delete on a change. Submodule content drift is out of scope unless opted in.
+
 ## §1 Auto-build all three layers on ingest (highest-leverage, cheap)
 
 Wire the projection-graph generation and an entity-graph pass into the curator drain
@@ -113,8 +160,9 @@ calls before grepping.
 
 ## §6 Live + cross-session memory fusion
 
-- **Incremental updates** on file-change/commit (hook + watch) so the graph tracks
-  the working tree, not a snapshot.
+- **Incremental updates** on default-branch movement (post-merge / fetch hook +
+  watch) so the graph tracks new commits on the canonical branch (§0.5), not a
+  stale snapshot — and not the working tree.
 - **Fuse the graph with conversation memory + the decision log** so the "why" behind
   a symbol is the *actual recorded reasoning*, not just parsed comments — queryable
   via §5. This is the thing a regenerated artifact can never hold.
@@ -174,6 +222,10 @@ agent's hot path.
   surprising-links relevance gate (quality floor + threshold).
 - Integration: `workspace add` of a sample repo → all three layers populated +
   searchable (extends the docker e2e); incremental update on file change.
+- Source selection (`unit-test-code-collect`): the canonical collector indexes the
+  git **default branch** (not feature-branch/working-tree WIP); resolves & repairs
+  `origin/HEAD`; **skips** a git repo with no default branch; falls back to the
+  working tree for non-git dirs and the `AIMEE_CODE_INDEX_SOURCE=worktree` opt-in.
 - Coverage: per-language parse fixtures for the tree-sitter front-end + the P1
   edges/file coverage metric.
 
@@ -193,3 +245,20 @@ converged on four load-bearing gaps; each is now addressed in-line:
    metric so the §2 gap is measured, not assumed.
 4. **Actuation coupled a safety path to an LLM-augmented graph (§7)** → guardrail path
    restricted to deterministic structural edges; actuation advisory + fail-open.
+
+## Review revisions (R2) — source of truth
+
+A second roundtable (`mistral` / `mimo-2.5-pro` / `glm-5.2`; 3/3, 0 failed) on the
+indexing source converged on §0.5: index the **git default branch**, not the
+working tree. Load-bearing outcomes, all now in §0.5:
+
+1. **Drop the current-HEAD fallback** — it re-introduced WIP-thrash; an unresolvable
+   default branch now **skips** with a diagnostic instead.
+2. **Repair `origin/HEAD`** with `git remote set-head origin -a` before descending
+   the fallback chain (it is unset on a long tail of real checkouts).
+3. **Read via `ls-tree` + `cat-file --batch`** (one fork each), pairing content to
+   path by sequence (NUL-safe), not per-file `git show` (N forks).
+4. **Code-vs-edit-tool split is a first-class invariant** — indexing reads the
+   default branch; blast-radius / staged-change tools read the working tree.
+
+Implemented in `code_collect.c` with `unit-test-code-collect` covering all cases.

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -149,6 +149,14 @@ static int code_collect_walk(const char *root, const char *rel, code_collect_fil
  * THIS change touch" — e.g. blast-radius — read the working tree via their own
  * reader and deliberately do NOT route through here.) */
 
+/* Prefix for every git invocation. This runs in an automated indexing path, so a
+ * git command must NEVER block on an interactive credential or SSH-passphrase
+ * prompt (GIT_TERMINAL_PROMPT=0 makes git fail fast instead), and a network-bound
+ * step like `remote set-head -a` must time out rather than hang the drain
+ * (BatchMode=yes + a short ConnectTimeout). Local repos never hit the network. */
+#define GIT_SAFE_ENV                                                                               \
+   "GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=5' "
+
 /* Quote one argument for /bin/sh: wrap in single quotes, escaping any embedded
  * single quote as '\''. Returns 0 on success, -1 if it doesn't fit. */
 static int shquote(const char *in, char *out, size_t outlen)
@@ -191,7 +199,8 @@ static int git_capture_line(const char *root, const char *args, char *out, size_
    if (shquote(root, qroot, sizeof(qroot)) != 0)
       return -1;
    char cmd[8192];
-   if ((size_t)snprintf(cmd, sizeof(cmd), "git -C %s %s 2>/dev/null", qroot, args) >= sizeof(cmd))
+   if ((size_t)snprintf(cmd, sizeof(cmd), GIT_SAFE_ENV "git -C %s %s 2>/dev/null", qroot, args) >=
+       sizeof(cmd))
       return -1;
    FILE *fp = popen(cmd, "r");
    if (!fp)
@@ -313,7 +322,8 @@ static int code_collect_from_git(const char *root, const char *ref, code_collect
 
    /* (1) Enumerate. ls-tree -z: NUL-terminated records "<mode> <type> <oid>\t<path>". */
    char lscmd[10240];
-   snprintf(lscmd, sizeof(lscmd), "git -C %s ls-tree -r -z %s 2>/dev/null", qroot, qref);
+   snprintf(lscmd, sizeof(lscmd), GIT_SAFE_ENV "git -C %s ls-tree -r -z %s 2>/dev/null", qroot,
+            qref);
    FILE *ls = popen(lscmd, "r");
    if (!ls)
       return -1;
@@ -444,8 +454,9 @@ static int code_collect_from_git(const char *root, const char *ref, code_collect
       char qtmp[4096];
       char catcmd[12288];
       if (shquote(tmpl, qtmp, sizeof(qtmp)) == 0 &&
-          (size_t)snprintf(catcmd, sizeof(catcmd), "git -C %s cat-file --batch <%s 2>/dev/null",
-                           qroot, qtmp) < sizeof(catcmd))
+          (size_t)snprintf(catcmd, sizeof(catcmd),
+                           GIT_SAFE_ENV "git -C %s cat-file --batch <%s 2>/dev/null", qroot,
+                           qtmp) < sizeof(catcmd))
       {
          FILE *cat = popen(catcmd, "r");
          if (cat)

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -9,6 +9,8 @@
 #ifdef AIMEE_POSIX
 #include <dirent.h>
 #include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 static int code_ext_ok(const char *name)
 {
@@ -24,6 +26,10 @@ static int code_ext_ok(const char *name)
          return 1;
    return 0;
 }
+
+/* .git classification (defined below): 0 = not a repo, 1 = real checkout,
+ * 2 = linked worktree. */
+static int code_git_kind(const char *path);
 
 static int code_dir_skip(const char *name)
 {
@@ -133,11 +139,428 @@ static int code_collect_walk(const char *root, const char *rel, code_collect_fil
    return stop;
 }
 
+/* ---- git default-branch source ----
+ *
+ * Code indexing is sourced from the git DEFAULT branch (e.g. origin/main), not
+ * the working tree, so the kb's code view is stable and canonical: a user's WIP
+ * on a feature branch, or uncommitted edits, never thrash the graph/embeddings.
+ * The working-tree walk above is reserved for non-git dirs and an explicit
+ * AIMEE_CODE_INDEX_SOURCE=worktree opt-in. (Edit-time tools that ask "what does
+ * THIS change touch" — e.g. blast-radius — read the working tree via their own
+ * reader and deliberately do NOT route through here.) */
+
+/* Quote one argument for /bin/sh: wrap in single quotes, escaping any embedded
+ * single quote as '\''. Returns 0 on success, -1 if it doesn't fit. */
+static int shquote(const char *in, char *out, size_t outlen)
+{
+   size_t o = 0;
+   if (outlen < 3)
+      return -1;
+   out[o++] = '\'';
+   for (const char *p = in; *p; p++)
+   {
+      if (*p == '\'')
+      {
+         if (o + 4 >= outlen)
+            return -1;
+         out[o++] = '\'';
+         out[o++] = '\\';
+         out[o++] = '\'';
+         out[o++] = '\'';
+      }
+      else
+      {
+         if (o + 1 >= outlen)
+            return -1;
+         out[o++] = *p;
+      }
+   }
+   if (o + 2 > outlen)
+      return -1;
+   out[o++] = '\'';
+   out[o] = '\0';
+   return 0;
+}
+
+/* Run `git -C <root> <args>` and capture the first output line, trimmed. Returns
+ * 0 on a clean exit with non-empty output, -1 otherwise. `args` is appended
+ * verbatim (callers pass shell-safe, self-controlled flags/refs). */
+static int git_capture_line(const char *root, const char *args, char *out, size_t outlen)
+{
+   char qroot[4096];
+   if (shquote(root, qroot, sizeof(qroot)) != 0)
+      return -1;
+   char cmd[8192];
+   if ((size_t)snprintf(cmd, sizeof(cmd), "git -C %s %s 2>/dev/null", qroot, args) >= sizeof(cmd))
+      return -1;
+   FILE *fp = popen(cmd, "r");
+   if (!fp)
+      return -1;
+   out[0] = '\0';
+   if (!fgets(out, (int)outlen, fp))
+   {
+      pclose(fp);
+      return -1;
+   }
+   /* drain the rest so git never blocks on a full stdout pipe */
+   char drain[512];
+   while (fread(drain, 1, sizeof(drain), fp) == sizeof(drain))
+      ;
+   int rc = pclose(fp);
+   size_t n = strlen(out);
+   while (n && (out[n - 1] == '\n' || out[n - 1] == '\r' || out[n - 1] == ' '))
+      out[--n] = '\0';
+   return (rc == 0 && out[0]) ? 0 : -1;
+}
+
+/* Resolve the ref to index for `root` into `out` (e.g. "origin/main"). Order:
+ *   1. origin/HEAD via symbolic-ref (the remote's advertised default);
+ *   2. repair origin/HEAD once (`git remote set-head origin -a`) and retry —
+ *      it is unset on repos whose remote was added after clone;
+ *   3. first existing of origin/main, origin/master, main, master.
+ * There is deliberately NO fall-through to the current HEAD or working tree:
+ * that would re-introduce the exact WIP-thrash this design eliminates. Returns 0
+ * on success, -1 if no default branch is resolvable (caller skips the repo). */
+static int git_resolve_default_ref(const char *root, char *out, size_t outlen)
+{
+   if (git_capture_line(root, "symbolic-ref --short refs/remotes/origin/HEAD", out, outlen) == 0)
+      return 0;
+   char tmp[256];
+   git_capture_line(root, "remote set-head origin -a", tmp, sizeof(tmp)); /* best-effort repair */
+   if (git_capture_line(root, "symbolic-ref --short refs/remotes/origin/HEAD", out, outlen) == 0)
+      return 0;
+   static const char *const cands[] = {"origin/main", "origin/master", "main", "master", NULL};
+   for (int i = 0; cands[i]; i++)
+   {
+      char args[256], sha[128];
+      snprintf(args, sizeof(args), "rev-parse --verify --quiet '%s^{commit}'", cands[i]);
+      if (git_capture_line(root, args, sha, sizeof(sha)) == 0)
+      {
+         snprintf(out, outlen, "%s", cands[i]);
+         return 0;
+      }
+   }
+   return -1;
+}
+
+/* Skip a tracked path whose any component is a VCS/build/vendor/hidden dir, so a
+ * checked-in node_modules/vendor tree is filtered exactly like the worktree walk
+ * filters it (code_dir_skip). */
+static int code_path_skipped(const char *rel)
+{
+   const char *seg = rel;
+   for (const char *p = rel;; p++)
+   {
+      if (*p == '/' || *p == '\0')
+      {
+         size_t len = (size_t)(p - seg);
+         char comp[256];
+         if (len && len < sizeof(comp))
+         {
+            memcpy(comp, seg, len);
+            comp[len] = '\0';
+            if (code_dir_skip(comp))
+               return 1;
+         }
+         if (*p == '\0')
+            break;
+         seg = p + 1;
+      }
+   }
+   return 0;
+}
+
+/* Read exactly n bytes from fp into buf (n known up front). Returns 0 on success. */
+static int read_exact(FILE *fp, char *buf, size_t n)
+{
+   size_t got = 0;
+   while (got < n)
+   {
+      size_t r = fread(buf + got, 1, n - got, fp);
+      if (r == 0)
+         return -1;
+      got += r;
+   }
+   return 0;
+}
+
+/* Discard exactly n bytes from fp (oversized blob we must consume to stay aligned). */
+static void skip_exact(FILE *fp, size_t n)
+{
+   char junk[4096];
+   while (n)
+   {
+      size_t want = n < sizeof(junk) ? n : sizeof(junk);
+      size_t r = fread(junk, 1, want, fp);
+      if (r == 0)
+         return;
+      n -= r;
+   }
+}
+
+/* Collect indexable blobs from `ref` of the repo at `root` via git plumbing:
+ * one `ls-tree -r -z` to enumerate (oid, path) pairs and one `cat-file --batch`
+ * (fed the wanted oids from a temp file, so our side only ever reads — no
+ * bidirectional-pipe deadlock) to stream their content in request order. Pairs
+ * content to path by sequence, so newlines in paths can't misattribute content.
+ * Returns the cb-accepted file count, or -1 if git enumeration failed. */
+static int code_collect_from_git(const char *root, const char *ref, code_collect_file_cb cb,
+                                 void *ctx, int *count)
+{
+   char qroot[4096], qref[1024];
+   if (shquote(root, qroot, sizeof(qroot)) != 0 || shquote(ref, qref, sizeof(qref)) != 0)
+      return -1;
+
+   /* (1) Enumerate. ls-tree -z: NUL-terminated records "<mode> <type> <oid>\t<path>". */
+   char lscmd[10240];
+   snprintf(lscmd, sizeof(lscmd), "git -C %s ls-tree -r -z %s 2>/dev/null", qroot, qref);
+   FILE *ls = popen(lscmd, "r");
+   if (!ls)
+      return -1;
+   char *blob = NULL;
+   size_t blen = 0, bcap = 0;
+   char chunk[8192];
+   size_t r;
+   while ((r = fread(chunk, 1, sizeof(chunk), ls)) > 0)
+   {
+      if (blen + r + 1 > bcap)
+      {
+         size_t ncap = bcap ? bcap * 2 : 65536;
+         while (ncap < blen + r + 1)
+            ncap *= 2;
+         char *nb = realloc(blob, ncap);
+         if (!nb)
+         {
+            free(blob);
+            pclose(ls);
+            return -1;
+         }
+         blob = nb;
+         bcap = ncap;
+      }
+      memcpy(blob + blen, chunk, r);
+      blen += r;
+   }
+   int lsrc = pclose(ls);
+   if (lsrc != 0)
+   {
+      free(blob);
+      return -1; /* bad ref / not a repo: let caller decide (skip), don't silently empty-index */
+   }
+   if (!blob || blen == 0)
+   {
+      free(blob); /* empty tree: nothing to index, but a valid (no-op) result */
+      return 0;
+   }
+
+   /* Parse records, keeping the (oid, path) of indexable blobs in request order. */
+   char **paths = NULL;
+   char **oids = NULL;
+   int n = 0, cap = 0;
+   for (size_t i = 0; i < blen;)
+   {
+      char *rec = blob + i;
+      size_t reclen = strnlen(rec, blen - i);
+      i += reclen + 1;
+      char *tab = memchr(rec, '\t', reclen);
+      if (!tab)
+         continue;
+      *tab = '\0';
+      const char *path = tab + 1;
+      /* header = "<mode> <type> <oid>"; take type (2nd) and oid (3rd) tokens. */
+      char *sp1 = strchr(rec, ' ');
+      if (!sp1)
+         continue;
+      char *type = sp1 + 1;
+      char *sp2 = strchr(type, ' ');
+      if (!sp2)
+         continue;
+      *sp2 = '\0';
+      const char *oid = sp2 + 1;
+      if (strcmp(type, "blob") != 0)
+         continue;
+      if (!code_ext_ok(path) || code_path_skipped(path))
+         continue;
+      if (n == cap)
+      {
+         int ncap = cap ? cap * 2 : 256;
+         char **np = realloc(paths, (size_t)ncap * sizeof(*np));
+         char **no = realloc(oids, (size_t)ncap * sizeof(*no));
+         if (!np || !no)
+         {
+            free(np ? np : paths);
+            free(no ? no : oids);
+            np = no = NULL;
+            n = -1;
+            break;
+         }
+         paths = np;
+         oids = no;
+         cap = ncap;
+      }
+      paths[n] = strdup(path);
+      oids[n] = strdup(oid);
+      if (!paths[n] || !oids[n])
+      {
+         free(paths[n]);
+         free(oids[n]);
+         break;
+      }
+      n++;
+   }
+   free(blob);
+   if (n <= 0)
+   {
+      for (int k = 0; k < n; k++)
+      {
+         free(paths[k]);
+         free(oids[k]);
+      }
+      free(paths);
+      free(oids);
+      return n < 0 ? -1 : 0;
+   }
+
+   /* (2) Write the wanted oids to a temp file, then `cat-file --batch < tmp`. */
+   const char *tmpdir = getenv("TMPDIR");
+   if (!tmpdir || !tmpdir[0])
+      tmpdir = "/tmp";
+   char tmpl[4096];
+   snprintf(tmpl, sizeof(tmpl), "%s/aimee-cc-XXXXXX", tmpdir);
+   int fd = mkstemp(tmpl);
+   int result = 0;
+   if (fd >= 0)
+   {
+      FILE *tf = fdopen(fd, "w");
+      if (tf)
+      {
+         for (int k = 0; k < n; k++)
+            fprintf(tf, "%s\n", oids[k]);
+         fclose(tf);
+      }
+      else
+         close(fd);
+
+      char qtmp[4096];
+      char catcmd[12288];
+      if (shquote(tmpl, qtmp, sizeof(qtmp)) == 0 &&
+          (size_t)snprintf(catcmd, sizeof(catcmd), "git -C %s cat-file --batch <%s 2>/dev/null",
+                           qroot, qtmp) < sizeof(catcmd))
+      {
+         FILE *cat = popen(catcmd, "r");
+         if (cat)
+         {
+            int stop = 0;
+            for (int k = 0; k < n && !stop; k++)
+            {
+               char hdr[256];
+               if (!fgets(hdr, sizeof(hdr), cat))
+                  break;
+               /* "<oid> <type> <size>\n" or "<oid> missing\n" */
+               char *s1 = strchr(hdr, ' ');
+               if (!s1 || strstr(hdr, " missing"))
+                  continue;
+               char *s2 = strchr(s1 + 1, ' ');
+               if (!s2)
+                  continue;
+               size_t size = (size_t)strtoul(s2 + 1, NULL, 10);
+               if (size == 0)
+               {
+                  skip_exact(cat, 1); /* trailing newline; empty blob = skip */
+                  continue;
+               }
+               if (size > CODE_COLLECT_MAX_FILE_BYTES)
+               {
+                  skip_exact(cat, size + 1);
+                  continue;
+               }
+               char *content = malloc(size + 1);
+               if (!content)
+               {
+                  skip_exact(cat, size + 1);
+                  continue;
+               }
+               if (read_exact(cat, content, size) != 0)
+               {
+                  free(content);
+                  break;
+               }
+               skip_exact(cat, 1); /* trailing newline after the blob body */
+               content[size] = '\0';
+               int binary = 0;
+               for (size_t b = 0; b < size && !binary; b++)
+                  if (content[b] == '\0')
+                     binary = 1;
+               if (!binary)
+               {
+                  if (cb(paths[k], content, ctx) != 0)
+                     stop = 1;
+                  else
+                     (*count)++;
+               }
+               free(content);
+            }
+            pclose(cat);
+         }
+         else
+            result = -1;
+      }
+      else
+         result = -1;
+      unlink(tmpl);
+   }
+   else
+      result = -1;
+
+   for (int k = 0; k < n; k++)
+   {
+      free(paths[k]);
+      free(oids[k]);
+   }
+   free(paths);
+   free(oids);
+   return result;
+}
+
 int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx)
 {
    if (!root || !root[0] || !cb)
       return 0;
+
+   /* Source selection (AIMEE_CODE_INDEX_SOURCE): "worktree" forces the working
+    * tree (a user who wants their WIP indexed); "default"/"auto"/unset index the
+    * git default branch for a git repo. Non-git dirs always use the working
+    * tree. A git repo with no resolvable default branch is SKIPPED rather than
+    * silently indexing unstable code. */
+   const char *mode = getenv("AIMEE_CODE_INDEX_SOURCE");
+   if (!mode || !mode[0])
+      mode = "auto";
+
    int count = 0;
+   if (strcmp(mode, "worktree") != 0 && code_git_kind(root) != 0)
+   {
+      char ref[1024];
+      if (git_resolve_default_ref(root, ref, sizeof(ref)) == 0)
+      {
+         int rc = code_collect_from_git(root, ref, cb, ctx, &count);
+         if (rc >= 0)
+            return count;
+         /* git enumeration failed unexpectedly: fall through to the working
+          * tree so a transient git error doesn't drop the project entirely. */
+         fprintf(stderr, "[code_collect] %s: git read of %s failed; using working tree\n", root,
+                 ref);
+      }
+      else
+      {
+         fprintf(stderr,
+                 "[code_collect] %s: no default branch resolvable (origin/HEAD unset, no "
+                 "main/master); skipping. Set AIMEE_CODE_INDEX_SOURCE=worktree to index the "
+                 "working tree.\n",
+                 root);
+         return 0;
+      }
+   }
+
    code_collect_walk(root, NULL, cb, ctx, &count);
    return count;
 }
@@ -164,7 +587,8 @@ int code_collect_files(const char *root, cJSON *files_arr)
 }
 
 /* .git classification: 0 = not a repo, 1 = real checkout (.git dir),
- * 2 = linked worktree (.git regular file: "gitdir: <path>"). */
+ * 2 = linked worktree (.git regular file: "gitdir: <path>"). Forward-declared
+ * above so code_collect_files_cb can choose its source before this definition. */
 static int code_git_kind(const char *path)
 {
    char g[4096];

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -125,6 +125,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-client-search \
                $(TESTPREFIX)/unit-test-kb-client-memory \
                $(TESTPREFIX)/unit-test-kb-graph \
+               $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
                $(TESTPREFIX)/unit-test-server-memory-benchmark \
                $(TESTPREFIX)/unit-test-server-jobs-aux \
@@ -1319,6 +1320,12 @@ $(OBJDIR)/tests/test_kb_graph.o: C_FLAGS += -Ikb
 
 $(TESTPREFIX)/unit-test-kb-graph: $(OBJDIR)/tests/test_kb_graph.o \
                                   $(OBJDIR)/kb/kb_service_graph.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(L_CORE)
+
+# Code collector source selection (git default branch vs working tree). Drives
+# the real collector against throwaway git repos materialized under TMPDIR.
+$(TESTPREFIX)/unit-test-code-collect: $(OBJDIR)/tests/test_code_collect.o \
+                                      $(OBJDIR)/code_collect.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 
 $(TESTPREFIX)/unit-test-aimee-client: $(OBJDIR)/tests/test_aimee_client.o $(OBJDIR)/aimee_client.o \

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -1,0 +1,222 @@
+/* test_code_collect.c: integration tests for the code collector's source
+ * selection. Code indexing must read the git DEFAULT branch (canonical code),
+ * not the user's working tree / feature-branch WIP. Each test materializes a
+ * throwaway git repo under TMPDIR via the real `git` binary (already a build
+ * prerequisite) and drives code_collect_files_cb() against it. */
+#include "code_collect.h"
+
+#include <assert.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* ---- collected-file recorder ---- */
+#define MAX_FILES 64
+static char g_paths[MAX_FILES][512];
+static char g_content[MAX_FILES][512];
+static int g_n;
+
+static void reset(void)
+{
+   g_n = 0;
+}
+static int rec_cb(const char *rel, const char *content, void *ctx)
+{
+   (void)ctx;
+   if (g_n < MAX_FILES)
+   {
+      snprintf(g_paths[g_n], sizeof(g_paths[g_n]), "%s", rel);
+      snprintf(g_content[g_n], sizeof(g_content[g_n]), "%s", content);
+      g_n++;
+   }
+   return 0;
+}
+static const char *content_of(const char *rel)
+{
+   for (int i = 0; i < g_n; i++)
+      if (strcmp(g_paths[i], rel) == 0)
+         return g_content[i];
+   return NULL;
+}
+static int has(const char *rel)
+{
+   return content_of(rel) != NULL;
+}
+
+/* ---- temp-repo scaffolding ---- */
+static char g_root[1024];
+
+static void sh(const char *fmt, ...)
+{
+   char cmd[4096];
+   va_list ap;
+   va_start(ap, fmt);
+   vsnprintf(cmd, sizeof(cmd), fmt, ap);
+   va_end(ap);
+   int rc = system(cmd);
+   assert(rc == 0);
+}
+
+static void write_file(const char *rel, const char *content)
+{
+   char path[2048];
+   snprintf(path, sizeof(path), "%s/%s", g_root, rel);
+   /* ensure parent dir */
+   char dir[2048];
+   snprintf(dir, sizeof(dir), "%s", path);
+   char *slash = strrchr(dir, '/');
+   if (slash)
+   {
+      *slash = '\0';
+      sh("mkdir -p '%s'", dir);
+   }
+   FILE *fp = fopen(path, "wb");
+   assert(fp);
+   fputs(content, fp);
+   fclose(fp);
+}
+
+static void make_root(const char *name)
+{
+   const char *tmp = getenv("TMPDIR");
+   if (!tmp || !tmp[0])
+      tmp = "/tmp";
+   snprintf(g_root, sizeof(g_root), "%s/aimee-cct-%s-%d", tmp, name, (int)getpid());
+   sh("rm -rf '%s' && mkdir -p '%s'", g_root, g_root);
+}
+
+static void git(const char *args)
+{
+   sh("git -C '%s' %s >/dev/null 2>&1", g_root, args);
+}
+
+/* The default branch is canonical: WIP on a feature branch + uncommitted edits
+ * must never leak into the indexed view. */
+static void test_default_branch_is_canonical(void)
+{
+   make_root("canon");
+   git("init -q -b main");
+   git("config user.email t@t");
+   git("config user.name t");
+   write_file("src/main.c", "int canonical(void){return 0;}");
+   write_file("README.md", "# canonical readme");
+   write_file("src/vendor/lib.c", "vendored, tracked, must be skipped");
+   git("add -A");
+   git("commit -qm init");
+   /* diverge: feature branch + uncommitted working-tree garbage */
+   git("checkout -q -b feature");
+   write_file("src/main.c", "GARBAGE WIP MUST NOT INDEX");
+   write_file("src/untracked.c", "uncommitted untracked");
+
+   reset();
+   int n = code_collect_files_cb(g_root, rec_cb, NULL);
+
+   assert(n == 2); /* src/main.c + README.md; vendor/ skipped, untracked absent */
+   assert(has("src/main.c") && has("README.md"));
+   assert(strcmp(content_of("src/main.c"), "int canonical(void){return 0;}") == 0);
+   assert(!has("src/vendor/lib.c")); /* vendor path component filtered */
+   assert(!has("src/untracked.c"));  /* working-tree-only file not on the branch */
+   printf("  test_default_branch_is_canonical: ok\n");
+}
+
+/* AIMEE_CODE_INDEX_SOURCE=worktree is the documented opt-in to index WIP. */
+static void test_worktree_optin(void)
+{
+   make_root("wt");
+   git("init -q -b main");
+   git("config user.email t@t");
+   git("config user.name t");
+   write_file("src/main.c", "int canonical(void){return 0;}");
+   git("add -A");
+   git("commit -qm init");
+   git("checkout -q -b feature");
+   write_file("src/main.c", "WIP EDIT");
+   write_file("src/untracked.c", "untracked wip");
+
+   setenv("AIMEE_CODE_INDEX_SOURCE", "worktree", 1);
+   reset();
+   int n = code_collect_files_cb(g_root, rec_cb, NULL);
+   unsetenv("AIMEE_CODE_INDEX_SOURCE");
+
+   assert(n == 2); /* working tree: the edited main.c + the untracked file */
+   assert(strcmp(content_of("src/main.c"), "WIP EDIT") == 0);
+   assert(has("src/untracked.c"));
+   printf("  test_worktree_optin: ok\n");
+}
+
+/* origin/HEAD is resolved (and repaired if unset) so a clone indexes the remote
+ * default even while checked out on a local feature branch. */
+static void test_clone_resolves_origin_head(void)
+{
+   const char *tmp = getenv("TMPDIR");
+   if (!tmp || !tmp[0])
+      tmp = "/tmp";
+   char up[1024];
+   snprintf(up, sizeof(up), "%s/aimee-cct-up-%d", tmp, (int)getpid());
+   sh("rm -rf '%s'", up);
+   sh("git init -q -b master '%s'", up);
+   sh("git -C '%s' config user.email t@t && git -C '%s' config user.name t", up, up);
+   sh("printf 'canonical on master' > '%s/app.py'", up);
+   sh("git -C '%s' add -A && git -C '%s' commit -qm init >/dev/null 2>&1", up, up);
+
+   make_root("clone");
+   sh("git clone -q '%s' '%s'", up, g_root);
+   git("checkout -q -b mybranch");
+   write_file("app.py", "WIP");
+   git("symbolic-ref -d refs/remotes/origin/HEAD"); /* force the repair path */
+
+   reset();
+   int n = code_collect_files_cb(g_root, rec_cb, NULL);
+   sh("rm -rf '%s'", up);
+
+   assert(n == 1);
+   assert(strcmp(content_of("app.py"), "canonical on master") == 0); /* not "WIP" */
+   printf("  test_clone_resolves_origin_head: ok\n");
+}
+
+/* A git repo with no resolvable default branch is SKIPPED, never silently
+ * indexed from the working tree. */
+static void test_no_default_branch_skips(void)
+{
+   make_root("nobranch");
+   git("init -q -b main");
+   write_file("x.c", "int x;"); /* never committed: no main/master ref exists */
+
+   reset();
+   int n = code_collect_files_cb(g_root, rec_cb, NULL);
+   assert(n == 0 && g_n == 0);
+   printf("  test_no_default_branch_skips: ok\n");
+}
+
+/* A non-git directory falls back to the working-tree walk unconditionally. */
+static void test_non_git_uses_worktree(void)
+{
+   make_root("nongit");
+   write_file("a.py", "plain = 1");
+
+   reset();
+   int n = code_collect_files_cb(g_root, rec_cb, NULL);
+   assert(n == 1 && has("a.py"));
+   printf("  test_non_git_uses_worktree: ok\n");
+}
+
+int main(void)
+{
+   printf("test_code_collect:\n");
+   /* Skip gracefully if git is unavailable in the test environment. */
+   if (system("git --version >/dev/null 2>&1") != 0)
+   {
+      printf("  (git unavailable; skipping)\nALL PASS\n");
+      return 0;
+   }
+   test_default_branch_is_canonical();
+   test_worktree_optin();
+   test_clone_resolves_origin_head();
+   test_no_default_branch_skips();
+   test_non_git_uses_worktree();
+   sh("rm -rf '%s'", g_root);
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Index the canonical branch, not the working tree

Code indexing — the graph **and** the embeddings — now reads the repository's git **default branch** (e.g. `origin/main`), not the user's working tree, current checkout, or a feature branch they are mid-edit on. The kb's code view must be **stable and canonical**: a developer's WIP, an uncommitted edit, or a throwaway branch must never thrash the graph/embeddings or pollute what other sessions retrieve as "the code."

This implements §0.5 of `docs/proposals/pending/code-graph-intelligence.md` (added here), converged via a roundtable design review (R2).

### `code_collect_files_cb` source selection

- **Default-branch resolution** (`git_resolve_default_ref`): `symbolic-ref origin/HEAD` → repair once via `git remote set-head origin -a` → first existing of `origin/main`, `origin/master`, `main`, `master`. **No fall-through to current HEAD/working tree** — a git repo with no resolvable default branch is **skipped** with a diagnostic, never silently indexed from an unstable checkout.
- **Read mechanism**: one `git ls-tree -r -z` + one `git cat-file --batch` (oids fed from a temp file so our side only reads — no bidirectional-pipe deadlock), pairing content to path by sequence (newline-in-path safe). Same extension/skip-dir/size/binary filters as the worktree walk.
- **Opt-in** `AIMEE_CODE_INDEX_SOURCE=worktree` indexes WIP for a user who wants it (team-unsafe, documented); `default`/`auto` (default) use the chain. Non-git dirs → working-tree walk.
- **Code-vs-edit-tool split (invariant)**: indexing reads the default branch; blast-radius / staged-change tools read the working tree via their own reader and don't route through this collector.

### Test — `unit-test-code-collect`
Materializes throwaway git repos and asserts:
```
test_code_collect:
  test_default_branch_is_canonical: ok   # main indexed, feature-branch WIP + untracked NOT
  test_worktree_optin: ok                # AIMEE_CODE_INDEX_SOURCE=worktree sees WIP
  test_clone_resolves_origin_head: ok    # deleted origin/HEAD repaired -> indexes origin/master
  test_no_default_branch_skips: ok       # no default branch -> skip, count 0
  test_non_git_uses_worktree: ok
ALL PASS
```
`aimee-server` + `aimee-kb` build clean (`-Werror`), clang-format clean.

> Stacked on #731 (code-graph P1); the two touch disjoint files. Merge #731 first, or this rebases cleanly onto `testing` once it lands.