### PR TITLE
feat(kb): /v1/code/hybrid — RRF-fused hybrid code retrieval (P2 §5)

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -165,10 +165,21 @@ lists + per-signal weights + the RRF constant `k`, and returns one ranking by
 (structural-trust desc, then id) and a cross-signal-consensus boost. Fully unit
 tested (`unit-test-kb-rrf`): exact rank-blend math, weighting, consensus-beats-single,
 absent-signal robustness, determinism under input-order permutation, truncation.
-The remaining wiring — embedding the query, gathering the three signal lists
-(`db2_entity_edge_*` graph neighborhood, `pgvec_code_search` vector, memory recall),
-the `/v1/code/hybrid` route + MCP tool, and the config-tunable weights — is the next
-increment (needs the live embedder, so it is integration-tier rather than shim-tested).
+
+**Status — route shipped.** `GET /v1/code/hybrid?query&symbol&project` fuses two
+signals in **file-path** space through `kb_rrf_fuse` so consensus is meaningful — a
+file that is both textually relevant to `query` AND structurally connected to
+`symbol` (calls it) ranks highest: `code` (lexical `canonical_index_code_search`) +
+`graph` (`canonical_index_find_callers`, marked structural). Memory recall
+(`db2_memory_find_facts_like`) returns as a separate typed `why` array — the recorded
+reasoning behind the code, context rather than a fused file row (matching the §5
+example "+ the decision that explains X"). Each result is labeled with its
+contributing `signals`, enriched (snippet / caller), and carries `signal_hits` +
+`structural_weight`. Shim-tested end-to-end in `unit-test-kb-http-routes`
+(`test_code_hybrid_*`: both legs fuse + label + enrich, memory why, no-symbol path,
+missing-query 400). **Remaining:** the **vector** leg (`pgvec_code_search`, needs the
+query embedder — integration-tier) as a third fused signal; the MCP tool + client
+bridge so the agent calls it before grepping; config-tunable per-signal weights.
 
 ## §6 Live + cross-session memory fusion
 

--- a/src/headers/kb_http_code.h
+++ b/src/headers/kb_http_code.h
@@ -24,5 +24,8 @@ int handle_get_code_callers_route(const char *method, const char *query_string, 
 int handle_get_code_project_stats(const char *query_string, char *out_buf, int out_cap);
 int handle_get_code_project_stats_route(const char *method, const char *query_string, char *out_buf,
                                         int out_cap);
+int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap);
+int handle_get_code_hybrid_route(const char *method, const char *query_string, char *out_buf,
+                                 int out_cap);
 
 #endif

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1286,6 +1286,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_code_structure_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/search") == 0)
       return handle_get_code_search_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/code/hybrid") == 0)
+      return handle_get_code_hybrid_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/search") == 0)
       return handle_get_pdf_search_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/page") == 0)

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -581,11 +581,15 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       code_items[i].structural_weight = 0;
    }
 
-   /* Signal B — graph callers of `symbol` (key = file_path; structural edge). */
+   /* Signal B — graph callers of `symbol` (key = file_path; structural edge).
+    * Pass `proj` (NULL when absent) to match Signal A and the existing
+    * /v1/code/callers route — canonical_index_find_callers takes its all-projects
+    * SQL path on NULL, so both legs scope identically instead of one searching all
+    * projects (NULL) while the other got "" (which is not the all-projects sentinel). */
    int ng = 0;
    if (symbol[0])
    {
-      ng = canonical_index_find_callers(proj ? proj : "", symbol, ghits, HYBRID_PER_SIGNAL);
+      ng = canonical_index_find_callers(proj, symbol, ghits, HYBRID_PER_SIGNAL);
       if (ng < 0)
          ng = 0;
       for (int i = 0; i < ng; i++)

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -5,6 +5,9 @@
 #include "cJSON.h"
 #include "db2/canonical_index.h"
 #include "db2/lifecycle.h"
+#include "db2/memory_query.h"
+#include "memory.h"
+#include "kb/kb_rrf.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -505,6 +508,214 @@ int handle_get_code_project_stats_route(const char *method, const char *query_st
    if (strcmp(method, "GET") != 0)
       return code_method_not_allowed(out_buf, out_cap);
    return handle_get_code_project_stats(query_string, out_buf, out_cap);
+}
+
+/* GET /v1/code/hybrid?query=<text>&symbol=<sym>&project=<proj>&max_results=N
+ *
+ * Hybrid code retrieval (proposal §5): fuse independently-ranked signals through
+ * Reciprocal Rank Fusion (kb_rrf_fuse) into one ranking, plus a memory "why"
+ * context. Two signals are fused in FILE-PATH space so consensus is meaningful —
+ * a file that is BOTH textually relevant to `query` AND structurally connected to
+ * `symbol` (calls it) rises to the top:
+ *   - "code"  : lexical search over file contents (canonical_index_code_search);
+ *   - "graph" : callers of `symbol` from the structural call graph
+ *               (canonical_index_find_callers), marked structural (tie-break).
+ * Memory recall (db2_memory_find_facts_like) is returned as a separate `why`
+ * array — the recorded reasoning behind the code, not a file, so it is context
+ * rather than a fused row. The vector signal (pgvec_code_search) slots in as a
+ * third fused leg once the query embedder is wired (integration-tier). */
+#define HYBRID_PER_SIGNAL 25
+#define HYBRID_WHY_MAX    5
+
+int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
+{
+   char query[512] = "";
+   char symbol[256] = "";
+   char project[256] = "";
+   if (!code_qparam(query_string, "query", query, sizeof(query)) || !query[0])
+      return code_scan_write_error(out_buf, out_cap, "missing query");
+   code_qparam(query_string, "symbol", symbol, sizeof(symbol));
+   code_qparam(query_string, "project", project, sizeof(project));
+   const char *proj = project[0] ? project : NULL;
+
+   int max_r = 20;
+   char mr[16] = "";
+   if (code_qparam(query_string, "max_results", mr, sizeof(mr)))
+      max_r = atoi(mr);
+   if (max_r < 1)
+      max_r = 1;
+   if (max_r > 100)
+      max_r = 100;
+
+   if (!db2_is_initialized())
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"knowledge service not initialized\"}");
+      return 503;
+   }
+
+   code_search_hit_t *chits = calloc(HYBRID_PER_SIGNAL, sizeof(*chits));
+   caller_hit_t *ghits = calloc(HYBRID_PER_SIGNAL, sizeof(*ghits));
+   memory_t *mems = calloc(HYBRID_PER_SIGNAL, sizeof(*mems));
+   kb_rrf_item_t *code_items = calloc(HYBRID_PER_SIGNAL, sizeof(*code_items));
+   kb_rrf_item_t *graph_items = calloc(HYBRID_PER_SIGNAL, sizeof(*graph_items));
+   kb_rrf_result_t *fused = calloc(HYBRID_PER_SIGNAL * 2, sizeof(*fused));
+   if (!chits || !ghits || !mems || !code_items || !graph_items || !fused)
+   {
+      free(chits);
+      free(ghits);
+      free(mems);
+      free(code_items);
+      free(graph_items);
+      free(fused);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+
+   /* Signal A — lexical code (key = file_path). */
+   int nc = canonical_index_code_search(query, proj, chits, HYBRID_PER_SIGNAL);
+   if (nc < 0)
+      nc = 0;
+   for (int i = 0; i < nc; i++)
+   {
+      snprintf(code_items[i].id, sizeof(code_items[i].id), "%s", chits[i].file_path);
+      code_items[i].structural_weight = 0;
+   }
+
+   /* Signal B — graph callers of `symbol` (key = file_path; structural edge). */
+   int ng = 0;
+   if (symbol[0])
+   {
+      ng = canonical_index_find_callers(proj ? proj : "", symbol, ghits, HYBRID_PER_SIGNAL);
+      if (ng < 0)
+         ng = 0;
+      for (int i = 0; i < ng; i++)
+      {
+         snprintf(graph_items[i].id, sizeof(graph_items[i].id), "%s", ghits[i].file_path);
+         graph_items[i].structural_weight = 1; /* a structural call edge */
+      }
+   }
+
+   kb_rrf_signal_t sigs[2] = {
+       {code_items, nc, 1.0, "code"},
+       {graph_items, ng, 1.0, "graph"},
+   };
+   int nf = kb_rrf_fuse(sigs, 2, KB_RRF_DEFAULT_K, fused, HYBRID_PER_SIGNAL * 2);
+   if (nf < 0)
+      nf = 0;
+   if (nf > max_r)
+      nf = max_r;
+
+   /* Memory "why" context (recorded reasoning, capped). */
+   int nm = db2_memory_find_facts_like(query, HYBRID_WHY_MAX, mems, HYBRID_PER_SIGNAL);
+   if (nm < 0)
+      nm = 0;
+   if (nm > HYBRID_WHY_MAX)
+      nm = HYBRID_WHY_MAX;
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+   {
+      free(chits);
+      free(ghits);
+      free(mems);
+      free(code_items);
+      free(graph_items);
+      free(fused);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "query", query);
+   if (symbol[0])
+      cJSON_AddStringToObject(resp, "symbol", symbol);
+   if (project[0])
+      cJSON_AddStringToObject(resp, "project", project);
+
+   cJSON *results = cJSON_AddArrayToObject(resp, "results");
+   for (int i = 0; results && i < nf; i++)
+   {
+      const char *fp = fused[i].id;
+      cJSON *row = cJSON_CreateObject();
+      if (!row)
+         continue;
+      cJSON_AddStringToObject(row, "file_path", fp);
+      cJSON_AddNumberToObject(row, "score", fused[i].score);
+      cJSON_AddNumberToObject(row, "signal_hits", fused[i].signal_hits);
+      cJSON_AddNumberToObject(row, "structural_weight", fused[i].structural_weight);
+      cJSON *which = cJSON_AddArrayToObject(row, "signals");
+      /* Enrich + label from whichever source(s) carried this file. */
+      for (int j = 0; j < nc; j++)
+         if (strcmp(chits[j].file_path, fp) == 0)
+         {
+            if (which)
+               cJSON_AddItemToArray(which, cJSON_CreateString("code"));
+            cJSON_AddStringToObject(row, "snippet", chits[j].snippet);
+            if (chits[j].content_hash[0])
+               cJSON_AddStringToObject(row, "content_hash", chits[j].content_hash);
+            break;
+         }
+      for (int j = 0; j < ng; j++)
+         if (strcmp(ghits[j].file_path, fp) == 0)
+         {
+            if (which)
+               cJSON_AddItemToArray(which, cJSON_CreateString("graph"));
+            cJSON_AddStringToObject(row, "caller", ghits[j].caller);
+            cJSON_AddNumberToObject(row, "caller_line", ghits[j].line);
+            break;
+         }
+      cJSON_AddItemToArray(results, row);
+   }
+
+   cJSON *why = cJSON_AddArrayToObject(resp, "why");
+   for (int i = 0; why && i < nm; i++)
+   {
+      cJSON *m = cJSON_CreateObject();
+      if (!m)
+         continue;
+      cJSON_AddNumberToObject(m, "id", (double)mems[i].id);
+      cJSON_AddStringToObject(m, "kind", mems[i].kind);
+      if (mems[i].headline[0])
+         cJSON_AddStringToObject(m, "headline", mems[i].headline);
+      cJSON_AddStringToObject(m, "content", mems[i].content);
+      cJSON_AddItemToArray(why, m);
+   }
+
+   char *s = cJSON_PrintUnformatted(resp);
+   int status = 200;
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      status = 500;
+   }
+   else if (strlen(s) >= (size_t)out_cap)
+   {
+      /* Never return truncated (invalid) JSON: signal the caller to narrow. */
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"result too large; reduce max_results or narrow the "
+               "query\",\"code\":\"result_too_large\"}");
+      status = 413;
+   }
+   else
+   {
+      snprintf(out_buf, (size_t)out_cap, "%s", s);
+   }
+   free(s);
+   cJSON_Delete(resp);
+   free(chits);
+   free(ghits);
+   free(mems);
+   free(code_items);
+   free(graph_items);
+   free(fused);
+   return status;
+}
+
+int handle_get_code_hybrid_route(const char *method, const char *query_string, char *out_buf,
+                                 int out_cap)
+{
+   if (strcmp(method, "GET") != 0)
+      return code_method_not_allowed(out_buf, out_cap);
+   return handle_get_code_hybrid(query_string, out_buf, out_cap);
 }
 
 int handle_post_code_scan(const char *body, char *out_buf, int out_cap)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -2999,6 +2999,7 @@ $(TESTPREFIX)/unit-test-kb-http-routes: $(OBJDIR)/tests/test_kb_http_routes.o \
                      $(OBJDIR)/kb/kb_intel_payload.o \
                      $(OBJDIR)/kb/kb_bandit_registry.o \
                      $(OBJDIR)/kb/http/kb_http_code.o \
+                     $(OBJDIR)/kb/kb_rrf.o \
                      $(OBJDIR)/kb/http/kb_http_pdf.o \
                      $(OBJDIR)/kb/http/kb_http_jobs.o \
                      $(OBJDIR)/cJSON.o \

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -578,6 +578,45 @@ int canonical_index_find_callers(const char *project, const char *symbol, void *
    return 1;
 }
 
+/* Full memory_t layout (mirrors headers/memory.h) so the stub writes each field
+ * at the offset the handler — compiled against the real struct — reads. The file
+ * keeps a truncated local memory_t (above) for other stubs, so we cast a void*
+ * here rather than redeclare the type, exactly like canonical_index_code_search. */
+typedef struct
+{
+   int64_t id;
+   char tier[4];
+   char kind[16];
+   char key[512];
+   char headline[512];
+   char content[2048];
+   char use_cases[1024];
+   double confidence;
+   int use_count;
+   char last_used_at[32];
+   char created_at[32];
+   char updated_at[32];
+   char source_session[128];
+   double salience;
+   char provenance_category[32];
+   double retrieval_score;
+   int hybrid_rank;
+} test_full_memory_t;
+
+int db2_memory_find_facts_like(const char *query, int limit, void *out, int max)
+{
+   assert(out);
+   if (!query || strcmp(query, "needle") != 0 || limit < 1 || max < 1)
+      return 0;
+   test_full_memory_t *m = (test_full_memory_t *)out;
+   memset(&m[0], 0, sizeof(m[0]));
+   m[0].id = 7;
+   snprintf(m[0].kind, sizeof(m[0].kind), "decision");
+   snprintf(m[0].headline, sizeof(m[0].headline), "why needle exists");
+   snprintf(m[0].content, sizeof(m[0].content), "chose needle over haystack for O(1) lookup");
+   return 1;
+}
+
 int memory_get_entity_profile(const char *e, void *out)
 {
    (void)e;
@@ -1936,6 +1975,9 @@ int main(void)
    test_code_search_ok();
    test_code_callers_missing_symbol();
    test_code_callers_ok();
+   test_code_hybrid_ok();
+   test_code_hybrid_missing_query();
+   test_code_hybrid_no_symbol();
    test_code_project_stats_missing_project();
    test_code_project_stats_ok();
    test_code_project_stats_error_is_json();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -578,45 +578,6 @@ int canonical_index_find_callers(const char *project, const char *symbol, void *
    return 1;
 }
 
-/* Full memory_t layout (mirrors headers/memory.h) so the stub writes each field
- * at the offset the handler — compiled against the real struct — reads. The file
- * keeps a truncated local memory_t (above) for other stubs, so we cast a void*
- * here rather than redeclare the type, exactly like canonical_index_code_search. */
-typedef struct
-{
-   int64_t id;
-   char tier[4];
-   char kind[16];
-   char key[512];
-   char headline[512];
-   char content[2048];
-   char use_cases[1024];
-   double confidence;
-   int use_count;
-   char last_used_at[32];
-   char created_at[32];
-   char updated_at[32];
-   char source_session[128];
-   double salience;
-   char provenance_category[32];
-   double retrieval_score;
-   int hybrid_rank;
-} test_full_memory_t;
-
-int db2_memory_find_facts_like(const char *query, int limit, void *out, int max)
-{
-   assert(out);
-   if (!query || strcmp(query, "needle") != 0 || limit < 1 || max < 1)
-      return 0;
-   test_full_memory_t *m = (test_full_memory_t *)out;
-   memset(&m[0], 0, sizeof(m[0]));
-   m[0].id = 7;
-   snprintf(m[0].kind, sizeof(m[0].kind), "decision");
-   snprintf(m[0].headline, sizeof(m[0].headline), "why needle exists");
-   snprintf(m[0].content, sizeof(m[0].content), "chose needle over haystack for O(1) lookup");
-   return 1;
-}
-
 int memory_get_entity_profile(const char *e, void *out)
 {
    (void)e;

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -3,6 +3,47 @@
  * unit under the 2000-line hard limit. Included (with
  * test_kb_http_routes_endpoints.inc) just before main(); all helpers and
  * fixtures live in test_kb_http_routes.c above the include point. */
+/* Full memory_t layout (mirrors headers/memory.h) so the stub writes each field
+ * at the offset the handler — compiled against the real struct — reads. The main
+ * file keeps a truncated local memory_t for other stubs, so we cast a void* here
+ * rather than redeclare the type, exactly like canonical_index_code_search. Lives
+ * here (with the hybrid test it feeds) to keep test_kb_http_routes.c under the
+ * 2000-line build-integrity limit. */
+typedef struct
+{
+   int64_t id;
+   char tier[4];
+   char kind[16];
+   char key[512];
+   char headline[512];
+   char content[2048];
+   char use_cases[1024];
+   double confidence;
+   int use_count;
+   char last_used_at[32];
+   char created_at[32];
+   char updated_at[32];
+   char source_session[128];
+   double salience;
+   char provenance_category[32];
+   double retrieval_score;
+   int hybrid_rank;
+} test_full_memory_t;
+
+int db2_memory_find_facts_like(const char *query, int limit, void *out, int max)
+{
+   assert(out);
+   if (!query || strcmp(query, "needle") != 0 || limit < 1 || max < 1)
+      return 0;
+   test_full_memory_t *m = (test_full_memory_t *)out;
+   memset(&m[0], 0, sizeof(m[0]));
+   m[0].id = 7;
+   snprintf(m[0].kind, sizeof(m[0].kind), "decision");
+   snprintf(m[0].headline, sizeof(m[0].headline), "why needle exists");
+   snprintf(m[0].content, sizeof(m[0].content), "chose needle over haystack for O(1) lookup");
+   return 1;
+}
+
 static void test_code_structure_ok(void)
 {
    char buf[512];

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -64,6 +64,49 @@ static void test_code_callers_ok(void)
    assert(strstr(buf, "\"next_cursor\":null") != NULL);
 }
 
+/* §5 hybrid retrieval: fuse lexical-code + graph-callers (RRF) + memory "why". */
+static void test_code_hybrid_ok(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/hybrid",
+                            "query=needle&symbol=target_fn&project=proj-alpha&max_results=10", NULL,
+                            NULL, NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"status\":\"ok\"") != NULL);
+   assert(strstr(buf, "\"results\"") != NULL);
+   /* Both signals contribute a file, each labeled + enriched from its source. */
+   assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL); /* lexical-code leg */
+   assert(strstr(buf, "\"signals\":[\"code\"]") != NULL);
+   assert(strstr(buf, "\"snippet\":\"int needle") != NULL);
+   assert(strstr(buf, "\"file_path\":\"src/caller.c\"") != NULL); /* graph-callers leg */
+   assert(strstr(buf, "\"signals\":[\"graph\"]") != NULL);
+   assert(strstr(buf, "\"caller\":\"caller_fn\"") != NULL);
+   /* Memory recall surfaces as typed "why" context, not a fused row. */
+   assert(strstr(buf, "\"why\"") != NULL);
+   assert(strstr(buf, "why needle exists") != NULL);
+}
+
+static void test_code_hybrid_missing_query(void)
+{
+   char buf[256];
+   int s = kb_http_route_ex("GET", "/v1/code/hybrid", "symbol=target_fn", NULL, NULL, NULL, 0, buf,
+                            sizeof(buf));
+   assert(s == 400);
+   assert(strstr(buf, "missing query") != NULL);
+}
+
+/* No symbol => graph leg empty; lexical-code + memory still fuse/return. */
+static void test_code_hybrid_no_symbol(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/hybrid", "query=needle&project=proj-alpha", NULL, NULL,
+                            NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL);
+   assert(strstr(buf, "\"file_path\":\"src/caller.c\"") == NULL); /* no graph leg */
+   assert(strstr(buf, "why needle exists") != NULL);
+}
+
 static void test_code_project_stats_missing_project(void)
 {
    char buf[256];
@@ -578,4 +621,3 @@ static void test_scope_admin_token_full_access(void)
                             sizeof(buf));
    assert(s != 403 && s != 401);
 }
-


### PR DESCRIPTION
## §5 headline — a working hybrid retrieval endpoint

Wires the RRF fusion core (#733) into a real KB route. `GET /v1/code/hybrid?query&symbol&project` fuses independently-ranked retrieval signals into one ranking + a memory "why" context.

Two signals fuse in **file-path** space so cross-signal **consensus** is meaningful — a file that is *both* textually relevant to `query` AND structurally connected to `symbol` (calls it) rises to the top:
- **`code`** — lexical search over file contents (`canonical_index_code_search`)
- **`graph`** — callers of `symbol` from the structural call graph (`canonical_index_find_callers`), marked structural (RRF tie-break)

`kb_rrf_fuse()` blends them by `Σ_s w_s/(k+rank_s)`. Each result carries its contributing `signals`, source enrichment (code snippet / caller+line), `signal_hits`, and `structural_weight`.

Memory recall (`db2_memory_find_facts_like`) returns as a separate typed **`why`** array — the recorded reasoning behind the code, context rather than a fused file row (matching the §5 example *"+ the decision that explains X"*).

### Robustness
- 413 on oversized responses (never truncated/invalid JSON), 400 missing query, 503 uninitialized store, empty graph leg when no `symbol`.

### Test — `test_code_hybrid_*` in `unit-test-kb-http-routes` (shim-backed)
Both legs fuse + label + enrich; memory `why` surfaces; no-symbol path; missing-query 400. Adds a `db2_memory_find_facts_like` stub (full `memory_t` layout, `void*`-cast like the existing `canonical_index` stubs).

### Remaining for §5 (noted in the proposal)
Vector leg (`pgvec_code_search`, needs the query embedder — integration-tier) as a third fused signal; MCP tool + client bridge so the agent calls this before grepping; config-tunable per-signal weights.

> Stacks on #733 → #732 → #731. Merges cleanly once parents land.