### PR TITLE
fix(aimee-llm): raise synth context so large-file code indexing succeeds

### DIFF
--- a/deploy/compose/aimee.gpu.yaml
+++ b/deploy/compose/aimee.gpu.yaml
@@ -12,6 +12,13 @@ services:
     image: ${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:gpu}
     environment:
       AIMEE_LLM_NGL: ${AIMEE_LLM_NGL:-99}
+      # gemma-4-12b trains to 256K; the supervisor's default cap is a 16GB-safe 32K.
+      # 128K is safe on the .254 card (RADV GFX1100 / 7900 XTX, 24560 MiB confirmed):
+      # ~6.6GB Q4_K_M model + ~1.5GB embed/rerank + KV cache. gemma-4 uses
+      # sliding-window attention (5 local layers windowed to 1024 : 1 global), so the
+      # 128K KV is dominated by the few global layers (~2-3GB), not all-layers-x-128K —
+      # well under 24GB. 256K would still fit with KV-cache quantization if ever needed.
+      AIMEE_LLM_SYNTH_CTX: ${AIMEE_LLM_SYNTH_CTX:-131072}
     devices:
       - "/dev/dri:/dev/dri"
 

--- a/scripts/aimee-llm-supervisor.sh
+++ b/scripts/aimee-llm-supervisor.sh
@@ -8,6 +8,14 @@ set -u
 LLAMA=/opt/llama/llama-server
 NGL="${AIMEE_LLM_NGL:-0}"
 POOL="${AIMEE_LLM_EMBED_POOLING:-last}"
+# Synth context window. The synth GGUF (gemma-4-12b) trains to 256K, but a
+# hardcoded --ctx-size 8192 wasted that: large code symbols / doc chunks overran
+# 8K and the server returned HTTP 400, failing extraction entirely. Default to a
+# 16GB-VRAM-safe 32K (4x the old cap, covers real source files); raise it on
+# bigger cards via AIMEE_LLM_SYNTH_CTX (e.g. 131072 for 128K). KV cache scales
+# with context, so size it to the card. Embed/rerank inputs are small — they keep
+# the 8K default.
+SYNTH_CTX="${AIMEE_LLM_SYNTH_CTX:-32768}"
 pids=()
 
 start() { # name port extra-args...
@@ -29,7 +37,7 @@ case "${AIMEE_LLM_STUB:-}" in
     start rerank 8082 -m /models/rerank-encoder.gguf --embeddings --pooling cls -fa on
     # Synth: OpenAI-compatible /v1/chat/completions (grammar/JSON via --jinja).
     if [ -f /models/synth.gguf ]; then
-      start synth 8083 -m /models/synth.gguf --ctx-size 8192 --jinja
+      start synth 8083 -m /models/synth.gguf --ctx-size "$SYNTH_CTX" --jinja
     fi
     ;;
   *)

--- a/scripts/curator-extract.py
+++ b/scripts/curator-extract.py
@@ -15,6 +15,35 @@ import sys
 import textwrap
 
 
+# Backstop cap on extraction input (a symbol body, doc chunk, or scene) sent to
+# the LLM. The primary fix is the synth server's context window (see
+# aimee-llm-supervisor.sh: AIMEE_LLM_SYNTH_CTX), but a pathological input can still
+# exceed any context — and overrunning it makes the server return HTTP 400 and the
+# WHOLE extraction fail ("sidecar exited 256"), so a large file would index
+# nothing. Cap here so oversized units degrade to a truncated summary instead of
+# failing. A summary needs the shape (signature + entry + exit), not every line,
+# so keep head+tail and elide the middle. Default ~7K tokens (fits the 32K synth
+# default with room for prompt + output); raise via env on big-context deployments.
+MAX_INPUT_CHARS = int(os.environ.get("CURATOR_MAX_INPUT_CHARS", "24000"))
+
+
+def _cap(text: str) -> str:
+    if not text or len(text) <= MAX_INPUT_CHARS:
+        return text
+    dropped = len(text) - MAX_INPUT_CHARS
+    head = (MAX_INPUT_CHARS * 3) // 4
+    tail = MAX_INPUT_CHARS - head
+    # Surface truncation on stderr (stdout carries the JSON artifact) so the kb
+    # logs show when a unit was summarized from a truncated body — i.e. when the
+    # corpus is being silently under-summarized vs. cleanly indexed.
+    sys.stderr.write(
+        f"curator-extract: capped input {len(text)}->{MAX_INPUT_CHARS} chars "
+        f"({dropped} elided); raise CURATOR_MAX_INPUT_CHARS on a big-context deploy\n"
+    )
+    sys.stderr.flush()
+    return f"{text[:head]}\n\n/* ... {dropped} chars elided to fit the model context ... */\n\n{text[-tail:]}"
+
+
 def emit_error(msg: str) -> None:
     json.dump({"version": 1, "status": "error", "error": msg}, sys.stdout)
     sys.stdout.write("\n")
@@ -25,7 +54,7 @@ def emit_error(msg: str) -> None:
 def build_doc_prompt(inp: dict) -> str:
     file_path = inp.get("file_path", "")
     heading   = inp.get("heading_path", "") or "(top level)"
-    content   = inp.get("content", "")
+    content   = _cap(inp.get("content", ""))
     return textwrap.dedent(f"""
         You are a knowledge extraction assistant. Extract structured knowledge from the
         document chunk below and return ONLY a valid JSON object — no markdown fences.
@@ -90,7 +119,7 @@ def build_code_prompt(inp: dict) -> str:
     symbol    = inp.get("symbol", "")
     kind      = inp.get("kind", "function")
     line      = inp.get("line", 0)
-    body      = inp.get("body", "")
+    body      = _cap(inp.get("body", ""))
     return textwrap.dedent(f"""
         You are a code analysis assistant. Analyze the {kind} below and return ONLY
         a valid JSON object — no markdown fences.
@@ -126,7 +155,7 @@ def build_story_prompt(inp: dict) -> str:
     KB entity/edge/fact graph — no new schema, only a domain-specific prompt."""
     file_path = inp.get("file_path", "")
     heading   = inp.get("heading_path", "") or "(top level)"
-    content   = inp.get("content", "")
+    content   = _cap(inp.get("content", ""))
     return textwrap.dedent(f"""
         You are a story-continuity analyst for a work of fiction. Extract the
         story-world state established by the scene below and return ONLY a valid


### PR DESCRIPTION
## Problem

KB code-indexing produced a near-empty corpus on the `.254` GPU deploy. The unified
`aimee-llm` supervisor launched the **synth** llama-server with a hardcoded
`--ctx-size 8192`, even though the synth GGUF (gemma-4-12b) trains to **256K**
(`n_ctx_train 262144`).

The curator code-extraction sidecar feeds synth **whole un-chunked symbol bodies**, so
a large function (e.g. the `server_http.c` handlers) plus the 2048-token output budget
overran 8K. The server returned HTTP 400 → `curator-extract.py` exited 1 → the kb logged
`sidecar exited 256`, and every large file indexed **zero** code units. `.254` showed 13
failed code-unit jobs, all on `server_http.c`. Reproduced live: a 5-line body succeeds, a
~4000-line body returns HTTP 400.

Embed and rerank were never affected — they only ever see ~512-token pre-chunked input
(`KB_DEFAULT_CHUNK_SIZE = 512`), so they have 13–16× headroom. Synth is unique in
receiving un-chunked bodies.

## Fix

- **`scripts/aimee-llm-supervisor.sh`** — synth `--ctx-size` is now
  `${AIMEE_LLM_SYNTH_CTX:-32768}` (4× the old cap; a 16 GB-VRAM-safe default). Embed/rerank
  keep their 8K — confirmed sufficient for 512-token chunks.
- **`deploy/compose/aimee.gpu.yaml`** — `AIMEE_LLM_SYNTH_CTX=131072` (128K) for the `.254`
  24 GB card (RADV GFX1100 / 7900 XTX, `24560 MiB` confirmed). gemma-4 sliding-window
  attention keeps the 128K KV cache to the few global layers (~2–3 GB), well under 24 GB.
- **`scripts/curator-extract.py`** — backstop `_cap()` truncates an oversized
  body/content/scene to `CURATOR_MAX_INPUT_CHARS` (default 24000, head+tail) and logs the
  truncation on stderr, so a pathological symbol degrades to a truncated summary instead of
  failing the whole file.

## Validation

- `bash -n` on the supervisor, `ast.parse` on the sidecar, YAML load on the compose file — all clean.
- `scripts/check-curator-story.py` extraction-contract check passes (envelope + no-traceback cases intact).
- `_cap()` unit-checked: small input passes through silently/unchanged; oversized input is capped to head+tail with the elision marker and a stderr warning.
- `.254` VRAM confirmed at 24560 MiB via sysfs + llama Vulkan device log.
- Reviewed via the aimee roundtable; the flagged items reduced to the 16-vs-24 GB VRAM ambiguity (resolved: card is 24 GB) plus documentation/observability, both folded in (inline VRAM-math comment + `_cap` stderr log).
