### PR TITLE
feat(mcp): agent-callable code-graph hybrid + hubs (P3 §4/§5)

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -132,8 +132,9 @@ Computed over `code_projection_edges` + embeddings, served read-only:
   10k edges; beyond it the ranking is over a deterministic source/target-ordered
   prefix). Unit tested (`unit-test-kb-graph-analytics`: aggregation, tie-break
   determinism under input permutation, self-loops, truncation, empty endpoints) +
-  shim route test (`test_code_graph_hubs_*`). Weighted/betweenness/PageRank
-  centrality and community detection are follow-ups.
+  shim route test (`test_code_graph_hubs_*`). **Agent-callable** via the MCP `index`
+  family — `index({command:"hubs", project})` — through `kb_client_code_graph_hubs`.
+  Weighted/betweenness/PageRank centrality and community detection are follow-ups.
 - **Surprising links** — pairs `(a,b)` with **high embedding similarity AND high
   graph distance**, made precise + gated (R1):
   - *similarity*: cosine(emb a, emb b) at/above the **top percentile** of the
@@ -188,9 +189,11 @@ example "+ the decision that explains X"). Each result is labeled with its
 contributing `signals`, enriched (snippet / caller), and carries `signal_hits` +
 `structural_weight`. Shim-tested end-to-end in `unit-test-kb-http-routes`
 (`test_code_hybrid_*`: both legs fuse + label + enrich, memory why, no-symbol path,
-missing-query 400). **Remaining:** the **vector** leg (`pgvec_code_search`, needs the
-query embedder — integration-tier) as a third fused signal; the MCP tool + client
-bridge so the agent calls it before grepping; config-tunable per-signal weights.
+missing-query 400). **Agent-callable** via the MCP `index` family — `index({command:
+"hybrid", query, symbol?, project?})` — wired through `kb_client_code_hybrid`
+(verbatim JSON forward). **Remaining:** the **vector** leg (`pgvec_code_search`, needs
+the query embedder — integration-tier) as a third fused signal; config-tunable
+per-signal weights.
 
 ## §6 Live + cross-session memory fusion
 

--- a/scripts/check-kb-v1-coverage.py
+++ b/scripts/check-kb-v1-coverage.py
@@ -132,6 +132,7 @@ ALLOWED_INTERNAL_CLIENT_HEADER_USERS = {
     "server/kb_client_docs.c",
     "server/kb_client_index.c",
     "server/kb_client_pdf.c",
+    "server/kb_client_code_graph.c",
     "server/kb_client_ws.c",
     "tests/test_kb_client_docs.c",
     "tests/test_kb_client_search.c",

--- a/src/Makefile
+++ b/src/Makefile
@@ -395,7 +395,7 @@ SERVER_CMD_OBJS = $(OBJDIR)/server/cmd_session_lifecycle.o \
 # kb_client objects — request-side glue from the daemon to the
 # aimee-kb sidecar. The daemon needs these so server_state /
 # server_mcp_learning can route DB2-bound work over the kb socket.
-KB_CLIENT_OBJS = $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_ws.o $(OBJDIR)/server/kb_client_docs.o $(OBJDIR)/kb/kb_doc_hash.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_pdf.o $(OBJDIR)/server/kb_client_code_embed.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o \
+KB_CLIENT_OBJS = $(OBJDIR)/server/kb_client.o $(OBJDIR)/server/kb_client_cache.o $(OBJDIR)/server/kb_client_ws.o $(OBJDIR)/server/kb_client_docs.o $(OBJDIR)/kb/kb_doc_hash.o $(OBJDIR)/server/kb_client_index.o $(OBJDIR)/server/kb_client_index_parse.o $(OBJDIR)/server/kb_client_pdf.o $(OBJDIR)/server/kb_client_code_graph.o $(OBJDIR)/server/kb_client_code_embed.o $(OBJDIR)/server/kb_client_memory.o $(OBJDIR)/server/kb_client_memory_mutations.o $(OBJDIR)/server/kb_client_agent.o $(OBJDIR)/server/kb_client_dashboard.o \
                  $(OBJDIR)/server/kb_client_tasks.o $(OBJDIR)/server/kb_client_data.o \
                  $(OBJDIR)/server/kb_client_tool_registry.o $(OBJDIR)/server/kb_client_prospective.o \
                  $(OBJDIR)/server/kb_client_roadmap.o \

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1092,6 +1092,16 @@ char *kb_client_pdf_open_neighbors(const char *project, long long chunk_id, int 
 char *kb_client_pdf_inspect_structure(const char *project, const char *document_key,
                                       int *status_out);
 
+/* Code-graph retrieval + analytics routes (see kb_client_code_graph.c). Forward
+ * the route's JSON body verbatim (nested fused/ranked shapes the agent consumes
+ * directly); return the malloc'd JSON (caller frees) or NULL, with *status_out
+ * carrying the HTTP status. /v1/code/hybrid fuses code+graph+memory (query
+ * required, symbol/project optional); /v1/code/graph/hubs ranks a project's
+ * most-connected symbols (project required). */
+char *kb_client_code_hybrid(const char *query, const char *symbol, const char *project,
+                            int max_results, int *status_out);
+char *kb_client_code_graph_hubs(const char *project, int max_results, int *status_out);
+
 /* Counts of indexed files / definition-kind terms for one project.
  * Uses /v1 over remote HTTP or local UDS.
  * Returns 0 on success and writes to the out pointers (either may be NULL),

--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -87,6 +87,26 @@ void mcp_add_extended_tools(cJSON *tools)
    ext_prop(t, "project", "string", "Project the file belongs to (optional).");
    ext_require(t, "file_path");
 
+   t = ext_tool(tools, "index_hybrid",
+                "Hybrid code retrieval: fuse lexical code search with the structural call graph "
+                "(callers of a symbol) into one ranking, plus the recorded reasoning ('why') from "
+                "memory. Prefer this over plain search when you have a seed symbol — it surfaces "
+                "files that are both textually relevant AND structurally connected.");
+   ext_prop(t, "query", "string", "Free-text query for the lexical-code and memory legs.");
+   ext_prop(t, "symbol", "string",
+            "Seed symbol whose callers form the graph leg (optional; omit for code+memory only).");
+   ext_prop(t, "project", "string", "Restrict to a project (optional; omit to search all).");
+   ext_prop(t, "max_results", "integer", "Max fused results (default 20, max 100).");
+   ext_require(t, "query");
+
+   t = ext_tool(tools, "index_graph_hubs",
+                "Rank a project's most-connected symbols by degree centrality over the code "
+                "projection graph — a refactor-risk signal ('editing this touches a lot'). Returns "
+                "in/out/weighted degree per hub.");
+   ext_prop(t, "project", "string", "Project to analyze.");
+   ext_prop(t, "max_results", "integer", "Max hubs to return (default 20, max 200).");
+   ext_require(t, "project");
+
    /* ── Memory grounding: explain a retrieval + provenance/history ───────────── */
    t = ext_tool(tools, "memory_explain_match",
                 "Explain WHY a memory matches a query: the per-signal score breakdown "
@@ -225,11 +245,13 @@ static const struct fam_def MCP_FAMILIES[] = {
       {NULL, NULL}}},
     {"index",
      "command",
-     "Code-index navigation. Set 'command'.",
+     "Code-index navigation, hybrid retrieval, and graph analytics. Set 'command'.",
      {{"find_callers", "index_find_callers"},
       {"structure", "index_structure"},
       {"blast_radius", "index_blast_radius"},
       {"preview", "preview_blast_radius"},
+      {"hybrid", "index_hybrid"},
+      {"hubs", "index_graph_hubs"},
       {NULL, NULL}}},
     {"note",
      "command",

--- a/src/server/kb_client_code_graph.c
+++ b/src/server/kb_client_code_graph.c
@@ -1,0 +1,92 @@
+/* kb_client_code_graph.c: server-side client for the KB code-graph retrieval +
+ * analytics routes (/v1/code/hybrid, /v1/code/graph/hubs).
+ *
+ * Like kb_client_pdf.c, these routes return purpose-built JSON — the hybrid
+ * route's fused {results[], why[]} and the hubs route's ranked {hubs[]} — that
+ * the agent consumes directly, so we forward the route's body VERBATIM rather
+ * than round-tripping through flat C structs (which would drop the nested shape).
+ * Each function returns the malloc'd JSON string the caller frees, or NULL on a
+ * parameter/transport/non-2xx failure; *status_out (when non-NULL) carries the
+ * route's HTTP status so the caller can craft a useful message. Every
+ * caller-supplied query-string value is URL-escaped (mirrors kb_client_index.c). */
+#include "kb_client.h"
+#include "kb_client_internal.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS (8 * 1000)
+
+char *kb_client_code_hybrid(const char *query, const char *symbol, const char *project,
+                            int max_results, int *status_out)
+{
+   if (status_out)
+      *status_out = -1;
+   if (!query || !query[0])
+      return NULL;
+
+   char *query_q = kb_client_query_escape(query);
+   char *symbol_q = (symbol && symbol[0]) ? kb_client_query_escape(symbol) : NULL;
+   char *project_q = (project && project[0]) ? kb_client_query_escape(project) : NULL;
+   if (!query_q || ((symbol && symbol[0]) && !symbol_q) || ((project && project[0]) && !project_q))
+   {
+      free(query_q);
+      free(symbol_q);
+      free(project_q);
+      return NULL;
+   }
+   if (max_results < 1)
+      max_results = 1;
+
+   size_t cap = strlen("/v1/code/hybrid?query=&max_results=&symbol=&project=") + strlen(query_q) +
+                (symbol_q ? strlen(symbol_q) : 0) + (project_q ? strlen(project_q) : 0) + 32;
+   char *path = malloc(cap);
+   if (!path)
+   {
+      free(query_q);
+      free(symbol_q);
+      free(project_q);
+      return NULL;
+   }
+   int off = snprintf(path, cap, "/v1/code/hybrid?query=%s&max_results=%d", query_q, max_results);
+   if (symbol_q)
+      off += snprintf(path + off, cap - (size_t)off, "&symbol=%s", symbol_q);
+   if (project_q)
+      snprintf(path + off, cap - (size_t)off, "&project=%s", project_q);
+   free(query_q);
+   free(symbol_q);
+   free(project_q);
+
+   char *json = kb_client_v1_get_json(path, KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS, status_out);
+   free(path);
+   return json;
+}
+
+char *kb_client_code_graph_hubs(const char *project, int max_results, int *status_out)
+{
+   if (status_out)
+      *status_out = -1;
+   if (!project || !project[0])
+      return NULL;
+
+   char *project_q = kb_client_query_escape(project);
+   if (!project_q)
+      return NULL;
+   if (max_results < 1)
+      max_results = 1;
+
+   size_t cap = strlen("/v1/code/graph/hubs?project=&max_results=") + strlen(project_q) + 32;
+   char *path = malloc(cap);
+   if (!path)
+   {
+      free(project_q);
+      return NULL;
+   }
+   snprintf(path, cap, "/v1/code/graph/hubs?project=%s&max_results=%d", project_q, max_results);
+   free(project_q);
+
+   char *json = kb_client_v1_get_json(path, KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS, status_out);
+   free(path);
+   return json;
+}

--- a/src/server/server_mcp_call_table.inc
+++ b/src/server/server_mcp_call_table.inc
@@ -1001,6 +1001,58 @@ static int pdf_arg_pos_int(cJSON *args, const char *key, double max, long long *
    return 1;
 }
 
+/* ── Code-graph retrieval + analytics ─────────────────────────────────────────
+ * /v1/code/hybrid and /v1/code/graph/hubs return purpose-built fused/ranked JSON
+ * the agent consumes directly, so we forward the route body verbatim (see
+ * kb_client_code_graph.c). Shares pdf_arg_pos_int for the bounded max_results. */
+static cJSON *code_graph_passthrough(char *json, int status, const char *tool)
+{
+   if (json)
+   {
+      cJSON *content = text_content(json); /* copies json into the text node */
+      free(json);
+      return content;
+   }
+   char msg[160];
+   if (status == 413)
+      snprintf(msg, sizeof(msg), "error: %s result too large (413) — reduce max_results", tool);
+   else if (status == 403)
+      snprintf(msg, sizeof(msg), "error: %s access denied (403) for that project", tool);
+   else if (status == 400)
+      snprintf(msg, sizeof(msg), "error: %s bad request (400) — check the arguments", tool);
+   else
+      snprintf(msg, sizeof(msg), "error: %s request failed (status %d)", tool, status);
+   return text_content(msg);
+}
+
+static cJSON *mcph_index_hybrid(struct mcp_call *c)
+{
+   cJSON *jq = cJSON_GetObjectItemCaseSensitive(c->jargs, "query");
+   if (!cJSON_IsString(jq) || !jq->valuestring[0])
+      return text_content("error: index_hybrid requires 'query'");
+   cJSON *js = cJSON_GetObjectItemCaseSensitive(c->jargs, "symbol");
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
+   const char *symbol = cJSON_IsString(js) ? js->valuestring : NULL;
+   const char *project = cJSON_IsString(jp) ? jp->valuestring : NULL;
+   long long mr = 0;
+   int max_results = pdf_arg_pos_int(c->jargs, "max_results", 100.0, &mr) ? (int)mr : 20;
+   int status = -1;
+   char *json = kb_client_code_hybrid(jq->valuestring, symbol, project, max_results, &status);
+   return code_graph_passthrough(json, status, "index_hybrid");
+}
+
+static cJSON *mcph_index_graph_hubs(struct mcp_call *c)
+{
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
+   if (!cJSON_IsString(jp) || !jp->valuestring[0])
+      return text_content("error: index_graph_hubs requires 'project'");
+   long long mr = 0;
+   int max_results = pdf_arg_pos_int(c->jargs, "max_results", 200.0, &mr) ? (int)mr : 20;
+   int status = -1;
+   char *json = kb_client_code_graph_hubs(jp->valuestring, max_results, &status);
+   return code_graph_passthrough(json, status, "index_graph_hubs");
+}
+
 static cJSON *mcph_pdf_search_chunks(struct mcp_call *c)
 {
    cJSON *jq = cJSON_GetObjectItemCaseSensitive(c->jargs, "query");
@@ -1128,6 +1180,8 @@ static const struct
     {"task_list", mcph_task_list},
     {"index_find_callers", mcph_index_find_callers},
     {"index_structure", mcph_index_structure},
+    {"index_hybrid", mcph_index_hybrid},
+    {"index_graph_hubs", mcph_index_graph_hubs},
     {"memory_explain_match", mcph_memory_explain_match},
     /* P3b */
     {"index_blast_radius", mcph_index_blast_radius},

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -25,7 +25,7 @@
    "git {action,async,base,body,branch,command,count,depth,diff_stat,files,force,index,job_id,message,mirror,mode,name,number,path,prune,rebase,ref,remote,source,staged,stat_only,state,title,url,wait} req:command\n" \
    "graph {command,entity,episode_key,limit,query} req:command\n" \
    "host {command,name} req:command\n" \
-   "index {command,file_path,paths,project,symbol} req:command\n" \
+   "index {command,file_path,max_results,paths,project,query,symbol} req:command\n" \
    "job {command,job_id,max_concurrent,plan_id} req:command\n" \
    "learning {command,correction_text,description,evidence_refs,limit,polarity,signal_type,sink,state,target_key,target_memory_id,title,workflow_project,workflow_signal_type} req:command\n" \
    "list_curiosity_items {limit,state} req:\n" \


### PR DESCRIPTION
## Summary

Bridges the existing KB code-graph routes into the MCP `index` family so the **primary agent can call them before grepping** — the headline §5 "MCP tool the agent calls before grepping" + §4 hubs surface:

- `index({command:"hybrid", query, symbol?, project?})` → `GET /v1/code/hybrid` — RRF-fused lexical-code + structural-callers, plus the memory `why`.
- `index({command:"hubs", project})` → `GET /v1/code/graph/hubs` — degree-centrality refactor-risk ranking.

## Implementation

New server-side bridge `src/server/kb_client_code_graph.c` forwards each route's purpose-built JSON **verbatim** (the nested fused/ranked shapes the agent consumes directly — flat C structs would drop them), mirroring `kb_client_pdf.c`. URL-escapes every caller value via `kb_client_query_escape`.

Registered the standard 3-site way:
- schema in `mcp_tools_extended.c` (`mcp_add_extended_tools`) + `index` family multiplex rows;
- `mcph_index_hybrid` / `mcph_index_graph_hubs` handlers + call-table rows in `server_mcp_call_table.inc`; bounded `max_results` reuses `pdf_arg_pos_int` (hybrid ≤100, hubs ≤200, default 20); 413/403/400/other mapped to friendly text.

Plumbing: `KB_CLIENT_OBJS` in `src/Makefile`, `kb-v1-coverage` allowlist, golden tools snapshot (`index` family gains `max_results,query`; top-level count unchanged — these are multiplexed sub-commands).

## Review

- **Builds**: `aimee-server` + `aimee-kb` link clean.
- **Tests**: `unit-test-mcp-client-registry` (golden) passes; `kb-v1-coverage-check`, `kb-intelligence-surfaced-check`, `line-check` all ok.
- **Roundtable + two independent code-review finders**: no real defects. The roundtable's speculative "blocking" items (snprintf overflow, project-optional leak, verbatim-JSON UAF) were each verified false against the code — cap math includes all keys + slack; code search is intentionally un-gated (consistent with the existing `/v1/code/search` routes) and the scope gate fires when a project is named; `kb_client_v1_get_json` returns a malloc'd NUL-terminated string that `text_content` copies before `free`.

Part of the **code-graph-intelligence** proposal (P3, §4 analytics + §5 hybrid retrieval — both now agent-callable).