### PR TITLE
feat(guardrails): structural blast-radius advisory for edits (code-graph §7)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (111)
+## CLI-settable keys (112)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -57,6 +57,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `gateway_pin_model` | bool | Gateway forces the proxied /v1/messages served model to the configured primary's model, overriding the client-requested model. Default off (the passthrough honors the client model); enable for single-model Anthropic-compatible shims. |
 | `gateway_prevent_subagents` | bool | Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off. |
 | `guardrail_mode` | string | Guardrail enforcement mode (off / warn / block). |
+| `guardrails_blast_radius_advisory_enabled` | bool | Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open). |
 | `guardrails_semantic_allow_ml_only_block` | bool | Allow blocking on the ML classifier alone. |
 | `guardrails_semantic_block_threshold` | float | Semantic score threshold to block. |
 | `guardrails_semantic_command` | string | External semantic-guardrail classifier command. |
@@ -157,7 +158,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`dedup`** — _Response deduplication._ Keys: `enabled`, `window_seconds`
 - **`dogfood`** — _Session capture for dogfood data._ Keys: `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
 - **`ensemble`** — _Roundtable ensemble panel + aggregator._ Keys: `aggregator`, `max_cost_usd`, `min_successful`, `reference_models`, `reference_personas`
-- **`guardrails`** — _Semantic guardrail policy._ Keys: `semantic`
+- **`guardrails`** — _Semantic guardrail policy._ Keys: `blast_radius`, `semantic`
 - **`identity`** — _Working-profile identity injection._ Keys: `working_profile_injection`
 - **`ingress`** — _Ingress (proxy frontends) behavior._ Keys: `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`
 - **`integrity`** — _Integrity gate._ Keys: `dry_run`, `enabled`

--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -208,9 +208,27 @@ per-signal weights.
 
 - **Blast-radius-aware edits**: before a write, surface graph-impacted files into the
   guardrail/context path (`guardrails_orchestrator.c`).
+  **Status — shipped.** `pre_tool_check` now emits a structural blast-radius
+  **ADVISORY** before an `Edit`/`Write`/`MultiEdit`: it lists the dependent files
+  that the edited file structurally affects (from the KB sidecar's
+  `/v1/code/blast-radius`, i.e. the call graph + typed projection edges — never the
+  LLM entity graph), and appends a high-centrality **hub** note at/above the
+  refactor-risk threshold (≥5 dependents), folding the stale-edge guard below into
+  the same surface. Advisory + **fail-open**: gated behind
+  `guardrails.blast_radius.advisory_enabled` (default **off**, opt-in); never
+  blocks; any miss (flag off, no indexed project owns the path, sidecar error, no
+  dependents) leaves the existing guardrail decision untouched, and it never
+  clobbers a higher-priority guardrail message. The decision is a pure, testable
+  core (`blast_radius_advisory_format` in `src/guardrails_blast_radius.c`) over an
+  already-fetched `blast_radius_t`, with the sidecar I/O resolver kept thin and
+  shared with `classify_path`'s existing severity check (no duplicate fetch path).
+  Unit tested hermetically (`unit-test-guardrails-blast-radius`: listing, ellipsis
+  cap, singular/plural, hub note, truncation-safety, project resolution + path
+  boundary, fail-open on no-match/sidecar-error, flag gate, message precedence).
 - **Graph-informed delegation**: route a delegate task with the relevant subgraph as
-  context automatically.
+  context automatically. *(Follow-up — not yet wired.)*
 - **Stale-edge guard**: warn when an edit touches a high-centrality/hub symbol.
+  *(Shipped as the hub note within the blast-radius advisory above.)*
 
 **Safety constraint (R1).** Anything on the safety-critical guardrail path uses ONLY
 the **deterministic structural layers** — the call graph + typed projection edges

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -132,6 +132,7 @@ CFG_KEY_DESC = {
     "fidelity_check_enabled": "Run the answer-fidelity judge on terminal-text turns "
     "(default off; requires kb_evidence_emit_enabled + ingress_preinject_enabled).",
     "guardrail_mode": "Guardrail enforcement mode (off / warn / block).",
+    "guardrails_blast_radius_advisory_enabled": "Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open).",
     "guardrails_semantic_allow_ml_only_block": "Allow blocking on the ML classifier alone.",
     "guardrails_semantic_block_threshold": "Semantic score threshold to block.",
     "guardrails_semantic_command": "External semantic-guardrail classifier command.",

--- a/src/Makefile
+++ b/src/Makefile
@@ -317,7 +317,7 @@ DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
 DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
-            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c gateway_policy.c gateway_pipeline.c gateway_delegate.c \
+            context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c guardrails_blast_radius.c gateway_policy.c gateway_pipeline.c gateway_delegate.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
             history.c role_templates.c skill.c skill_rollback.c skill_review.c skill_curator.c conversation.c \
             trajectory_export.c trajectory_batch.c \
@@ -708,7 +708,7 @@ BENCH_BASELINE = ../benchmarks/baseline.json
 
 BENCH_OBJS = $(OBJDIR)/tests/bench_perf.o $(OBJDIR)/guardrails.o $(OBJDIR)/file_safety.o \
              $(OBJDIR)/workspace.o \
-             $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o \
+             $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_blast_radius.o \
              $(OBJDIR)/server/agent_config.o $(OBJDIR)/cmd_describe.o \
              $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_step.o $(OBJDIR)/branch_ownership.o \
              $(OBJDIR)/tests/support/kb_client_test_stub.o \

--- a/src/config.c
+++ b/src/config.c
@@ -539,6 +539,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->guardrails_semantic_prompt_threshold = 0.70;
    cfg->guardrails_semantic_block_threshold = 0.90;
    cfg->guardrails_semantic_allow_ml_only_block = 0;
+   cfg->guardrails_blast_radius_advisory_enabled = 0;
    cfg->kb_api_http_port = 0;
    cfg->kb_api_bearer_token[0] = '\0';
    cfg->kb_worker_count = CONFIG_DEFAULT_KB_WORKER_THREADS;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -185,6 +185,8 @@ const config_field_t config_fields[] = {
     {"cache_min_chars", offsetof(config_t, cache_min_chars), sizeof(int), 0, CFG_INT},
     {"guardrails_semantic_enabled", offsetof(config_t, guardrails_semantic_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"guardrails_blast_radius_advisory_enabled",
+     offsetof(config_t, guardrails_blast_radius_advisory_enabled), sizeof(int), 0, CFG_BOOL},
     {"guardrails_semantic_dry_run", offsetof(config_t, guardrails_semantic_dry_run), sizeof(int), 0,
      CFG_BOOL},
     {"guardrails_semantic_command", offsetof(config_t, guardrails_semantic_command),

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -462,6 +462,15 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(semantic, "allow_ml_only_block",
                             cfg->guardrails_semantic_allow_ml_only_block ? 1 : 0);
    }
+   if (cfg->guardrails_blast_radius_advisory_enabled)
+   {
+      /* Reuse the guardrails object if the semantic block above created it. */
+      cJSON *guardrails = cJSON_GetObjectItemCaseSensitive(root, "guardrails");
+      if (!guardrails)
+         guardrails = cJSON_AddObjectToObject(root, "guardrails");
+      cJSON *br = cJSON_AddObjectToObject(guardrails, "blast_radius");
+      cJSON_AddBoolToObject(br, "advisory_enabled", 1);
+   }
    if (cfg->memory_maintenance_trigger_inserts > 0 || cfg->memory_maintenance_trigger_secs > 0 ||
        cfg->memory_maintenance_enabled || cfg->memory_maintenance_interval_seconds > 0 ||
        cfg->memory_maintenance_summarize_enabled)

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1077,6 +1077,13 @@ void config_parse_guardrails_section(config_t *cfg, cJSON *root)
          if (cJSON_IsBool(item))
             cfg->guardrails_semantic_allow_ml_only_block = cJSON_IsTrue(item) ? 1 : 0;
       }
+      cJSON *br = cJSON_GetObjectItemCaseSensitive(gr, "blast_radius");
+      if (cJSON_IsObject(br))
+      {
+         item = cJSON_GetObjectItemCaseSensitive(br, "advisory_enabled");
+         if (cJSON_IsBool(item))
+            cfg->guardrails_blast_radius_advisory_enabled = cJSON_IsTrue(item) ? 1 : 0;
+      }
    }
 }
 void config_parse_auxiliary_section(config_t *cfg, cJSON *root)

--- a/src/guardrails.c
+++ b/src/guardrails.c
@@ -8,6 +8,7 @@
 #include "aimee_home.h"
 #include "cJSON.h"
 #include "guardrails_internal.h"
+#include "guardrails_blast_radius.h"
 #include "headers/git_verify.h"
 #include "kb_client.h"
 #include "log.h"
@@ -471,40 +472,25 @@ classification_t classify_path(const char *file_path)
       return result;
    }
 
-   /* Check blast radius via index */
-
+   /* Check blast radius via the structural code index (shared resolver — also
+    * used by the §7 blast-radius advisory; see guardrails_blast_radius.c). */
    {
       blast_radius_t br;
-      memset(&br, 0, sizeof(br));
-      /* Try to find what project this file belongs to */
-      project_info_t projects[32];
-      int pcount = kb_client_index_list(projects, 32);
-      for (int p = 0; p < pcount; p++)
+      if (guardrails_blast_radius_for_abs_path(file_path, &br) == 0)
       {
-         /* Check if file_path starts with project root (with boundary check) */
-         size_t rlen = strlen(projects[p].root);
-         if (strncmp(file_path, projects[p].root, rlen) == 0 &&
-             (file_path[rlen] == '/' || file_path[rlen] == '\0'))
+         if (br.dependent_count >= 5)
          {
-            const char *rel = file_path + rlen;
-            if (*rel == '/')
-               rel++;
-            kb_client_index_blast_radius(projects[p].name, rel, &br);
-            if (br.dependent_count >= 5)
-            {
-               result.severity = SEV_RED;
-               snprintf(result.reason, sizeof(result.reason), "High blast radius: %d dependents",
-                        br.dependent_count);
-               return result;
-            }
-            if (br.dependent_count >= 1)
-            {
-               result.severity = SEV_YELLOW;
-               snprintf(result.reason, sizeof(result.reason),
-                        "Moderate blast radius: %d dependents", br.dependent_count);
-               return result;
-            }
-            break;
+            result.severity = SEV_RED;
+            snprintf(result.reason, sizeof(result.reason), "High blast radius: %d dependents",
+                     br.dependent_count);
+            return result;
+         }
+         if (br.dependent_count >= 1)
+         {
+            result.severity = SEV_YELLOW;
+            snprintf(result.reason, sizeof(result.reason), "Moderate blast radius: %d dependents",
+                     br.dependent_count);
+            return result;
          }
       }
    }

--- a/src/guardrails_blast_radius.c
+++ b/src/guardrails_blast_radius.c
@@ -1,0 +1,105 @@
+/* guardrails_blast_radius.c: structural blast-radius advisory for edits (§7).
+ * See guardrails_blast_radius.h for the safety contract (structural-only,
+ * advisory, fail-open). */
+#include "guardrails_blast_radius.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "kb_client.h" /* kb_client_index_list, kb_client_index_blast_radius */
+
+int blast_radius_advisory_format(const blast_radius_t *br, const char *edited_path,
+                                 int hub_threshold, char *msg_buf, size_t msg_len)
+{
+   if (!br || !msg_buf || msg_len == 0)
+      return 0;
+   int n = br->dependent_count;
+   if (n < 0)
+      n = 0;
+   if (n > 64) /* dependents[] is fixed-size; never read past it */
+      n = 64;
+   if (n == 0)
+      return 0; /* nothing structurally impacted — stay silent */
+
+   const char *path = (edited_path && edited_path[0]) ? edited_path : "this file";
+
+   /* Header: "ADVISORY: editing <path> has structural blast radius — N
+    * dependent file(s) may be affected:" */
+   int off = snprintf(msg_buf, msg_len,
+                      "ADVISORY: editing %s has structural blast radius — %d dependent file%s "
+                      "may be affected:",
+                      path, n, n == 1 ? "" : "s");
+   if (off < 0 || (size_t)off >= msg_len)
+      return 1; /* header alone filled the buffer; still a valid advisory */
+
+   int listed = n < BR_ADVISORY_MAX_NAMES ? n : BR_ADVISORY_MAX_NAMES;
+   for (int i = 0; i < listed; i++)
+   {
+      const char *dep = br->dependents[i][0] ? br->dependents[i] : "(unknown)";
+      int w =
+          snprintf(msg_buf + off, msg_len - (size_t)off, " %s%s", dep, (i + 1 < listed) ? "," : "");
+      if (w < 0 || (size_t)w >= msg_len - (size_t)off)
+         return 1; /* ran out of room mid-list — truncated but valid */
+      off += w;
+   }
+   if (n > listed)
+   {
+      int w = snprintf(msg_buf + off, msg_len - (size_t)off, " (+%d more)", n - listed);
+      if (w < 0 || (size_t)w >= msg_len - (size_t)off)
+         return 1;
+      off += w;
+   }
+
+   /* High-centrality hub note (refactor-risk). */
+   if (n >= hub_threshold)
+      snprintf(msg_buf + off, msg_len - (size_t)off,
+               " — high-centrality hub; review callers before changing its interface.");
+   return 1;
+}
+
+int guardrails_blast_radius_for_abs_path(const char *abs_path, blast_radius_t *out)
+{
+   if (!abs_path || !abs_path[0] || !out)
+      return -1;
+
+   project_info_t projects[32];
+   int pcount = kb_client_index_list(projects, 32);
+   for (int p = 0; p < pcount; p++)
+   {
+      /* Match the project whose root is a path-boundary prefix of abs_path
+       * (mirrors classify_path in guardrails.c). */
+      size_t rlen = strlen(projects[p].root);
+      if (strncmp(abs_path, projects[p].root, rlen) == 0 &&
+          (abs_path[rlen] == '/' || abs_path[rlen] == '\0'))
+      {
+         const char *rel = abs_path + rlen;
+         if (*rel == '/')
+            rel++;
+         memset(out, 0, sizeof(*out));
+         if (kb_client_index_blast_radius(projects[p].name, rel, out) != 0)
+            return -1; /* FAIL-OPEN: sidecar error -> no advisory */
+         return 0;
+      }
+   }
+   return -1; /* no indexed project owns this path */
+}
+
+void guardrails_blast_radius_advisory(const char *abs_path, char *msg_buf, size_t msg_len)
+{
+   /* Don't clobber a higher-priority guardrail message. */
+   if (!msg_buf || msg_len == 0 || msg_buf[0] != '\0')
+      return;
+   if (!abs_path || !abs_path[0])
+      return;
+
+   config_t cfg;
+   config_load(&cfg);
+   if (!cfg.guardrails_blast_radius_advisory_enabled)
+      return;
+
+   blast_radius_t br;
+   if (guardrails_blast_radius_for_abs_path(abs_path, &br) != 0)
+      return; /* FAIL-OPEN */
+   blast_radius_advisory_format(&br, abs_path, BR_ADVISORY_HUB_THRESHOLD, msg_buf, msg_len);
+}

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -12,6 +12,7 @@
 #include "computer_use.h"
 #include "guardrails_internal.h"
 #include "guardrails_semantic.h"
+#include "guardrails_blast_radius.h"
 #include "workspace_provider.h" /* skip worktree enforcement for a detached (client) workspace */
 #include "headers/config.h"
 #include "headers/git_verify.h"
@@ -1944,7 +1945,6 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
       LOG_INFO("guardrails", "orchestrator discipline: delegation nudge after %d calls",
                state->hook_call_count);
    }
-
    /* Semantic scoring (Phase 0/1): runs after all deterministic checks.
     * Default: enabled=false, dry_run=true — no behavioral change until opted in.
     * When dry_run=true, scores are logged and stored but never affect msg_buf or rc. */
@@ -1992,7 +1992,9 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
          }
       }
    }
-
+   if (is_edit_tool(tool_name) && fp && cJSON_IsString(fp)) /* §7 advisory: LAST, fail-open */
+      guardrails_blast_radius_advisory(
+          normalize_path(fp->valuestring, effective_cwd, norm, sizeof(norm)), msg_buf, msg_len);
    cJSON_Delete(root);
    return 0;
 }

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1023,6 +1023,10 @@ typedef struct config
    double guardrails_semantic_prompt_threshold;
    double guardrails_semantic_block_threshold;
    int guardrails_semantic_allow_ml_only_block;
+   /* §7 code-graph actuation: surface a structural blast-radius advisory (the
+    * graph-impacted dependent files) before an edit. Advisory + fail-open;
+    * default off (opt-in). See docs/proposals/pending/code-graph-intelligence.md §7. */
+   int guardrails_blast_radius_advisory_enabled;
 
    /* aimee-kb public HTTP API (kb.api.*).
     * kb_api_http_port: TCP port for the /v1/... REST API (0 = disabled, default).

--- a/src/headers/guardrails_blast_radius.h
+++ b/src/headers/guardrails_blast_radius.h
@@ -1,0 +1,50 @@
+/* guardrails_blast_radius.h: structural blast-radius ADVISORY for edits (§7).
+ *
+ * Proposal "code-graph intelligence" §7 (agent actuation) with the R1 safety
+ * constraint: anything on the guardrail path uses ONLY the deterministic
+ * structural layers (call graph + typed projection edges via the KB sidecar's
+ * /v1/code/blast-radius), never the LLM-synthesised entity graph; the actuation
+ * is ADVISORY and FAIL-OPEN — it surfaces context, never blocks, and a
+ * missing/empty graph adds no restriction. The graph can only ADD caution.
+ *
+ * Split for testability: blast_radius_advisory_format() is a PURE function over
+ * an already-fetched blast_radius_t (the testable gate core); the I/O glue that
+ * resolves the project and queries the sidecar is kept thin and separate. */
+#ifndef GUARDRAILS_BLAST_RADIUS_H
+#define GUARDRAILS_BLAST_RADIUS_H
+
+#include <stddef.h>
+
+#include "index.h" /* blast_radius_t */
+
+/* At/above this dependent count the edited symbol is treated as a high-centrality
+ * hub and the advisory appends a refactor-risk note (matches classify_path's
+ * SEV_RED threshold in guardrails.c). */
+#define BR_ADVISORY_HUB_THRESHOLD 5
+/* Cap the number of dependent file names listed in the advisory string. */
+#define BR_ADVISORY_MAX_NAMES 8
+
+/* PURE. Format a structural blast-radius advisory for an edit to `edited_path`
+ * from its already-fetched structural dependents. Writes an "ADVISORY: ..."
+ * string into msg_buf and returns 1 when an advisory is warranted (>=1
+ * dependent); otherwise leaves msg_buf untouched and returns 0. Lists up to
+ * BR_ADVISORY_MAX_NAMES dependents (then an ellipsis), and appends a hub note
+ * at/above hub_threshold. Never blocks; truncation-safe. */
+int blast_radius_advisory_format(const blast_radius_t *br, const char *edited_path,
+                                 int hub_threshold, char *msg_buf, size_t msg_len);
+
+/* I/O glue (FAIL-OPEN). Resolve `abs_path` to (project, relpath) over the
+ * indexed project list and fetch its structural blast radius from the KB
+ * sidecar. Returns 0 with *out filled on a project match + successful fetch,
+ * -1 otherwise (caller skips the advisory on -1). */
+int guardrails_blast_radius_for_abs_path(const char *abs_path, blast_radius_t *out);
+
+/* Orchestrator hook (single call site, FAIL-OPEN). When the
+ * `guardrails_blast_radius_advisory_enabled` config flag is on and msg_buf is
+ * still empty (no higher-priority guardrail message), fetch + format a
+ * structural blast-radius advisory for an edit to abs_path. Any error — flag
+ * off, no project match, sidecar failure, no dependents — leaves msg_buf
+ * untouched. Never blocks. */
+void guardrails_blast_radius_advisory(const char *abs_path, char *msg_buf, size_t msg_len);
+
+#endif /* GUARDRAILS_BLAST_RADIUS_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -30,7 +30,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
-	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
+	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
                              $(OBJDIR)/server/web_search.o \
@@ -127,6 +127,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-kb-graph \
                $(TESTPREFIX)/unit-test-kb-rrf \
                $(TESTPREFIX)/unit-test-kb-graph-analytics \
+               $(TESTPREFIX)/unit-test-guardrails-blast-radius \
                $(TESTPREFIX)/unit-test-code-collect \
                $(TESTPREFIX)/unit-test-server-compute \
                $(TESTPREFIX)/unit-test-server-memory-benchmark \
@@ -1333,6 +1334,12 @@ $(TESTPREFIX)/unit-test-kb-rrf: $(OBJDIR)/tests/test_kb_rrf.o $(OBJDIR)/kb/kb_rr
 # Graph analytics: degree-centrality hub ranking (§4). Pure: no DB.
 $(TESTPREFIX)/unit-test-kb-graph-analytics: $(OBJDIR)/tests/test_kb_graph_analytics.o \
                                             $(OBJDIR)/kb/kb_graph_analytics.o
+	$(TESTLINK) -o $@ $^ $(L_CORE)
+
+# Blast-radius advisory: structural §7 actuation. Hermetic — config_load and the
+# kb_client_index_* sidecar calls are stubbed in the test, so no DB/sidecar.
+$(TESTPREFIX)/unit-test-guardrails-blast-radius: $(OBJDIR)/tests/test_guardrails_blast_radius.o \
+                                                 $(OBJDIR)/guardrails_blast_radius.o
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 
 # Code collector source selection (git default branch vs working tree). Drives

--- a/src/tests/test_guardrails_blast_radius.c
+++ b/src/tests/test_guardrails_blast_radius.c
@@ -1,0 +1,266 @@
+/* test_guardrails_blast_radius.c: unit tests for the §7 structural blast-radius
+ * advisory (proposal "code-graph intelligence" §7). Covers the pure formatter
+ * (gate, listing, ellipsis, hub note, truncation-safety), the abs-path -> project
+ * resolver, and the fail-open advisory gate. Hermetic: config_load + the two
+ * kb_client_index_* calls are stubbed below, so no DB / sidecar is needed. */
+#include "guardrails_blast_radius.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "config.h"
+#include "kb_client.h"
+
+/* ── Stubs: controllable KB sidecar + config ─────────────────────────────── */
+static project_info_t g_projects[4];
+static int g_project_count = 0;
+static blast_radius_t g_blast;
+static int g_blast_rc = 0;       /* what kb_client_index_blast_radius returns */
+static int g_advisory_flag = 0;  /* what config_load reports for the §7 flag */
+static char g_last_project[128]; /* project passed to the blast-radius fetch */
+static char g_last_rel[256];     /* relpath passed to the blast-radius fetch */
+
+int kb_client_index_list(project_info_t *out, int max)
+{
+   int n = g_project_count < max ? g_project_count : max;
+   for (int i = 0; i < n; i++)
+      out[i] = g_projects[i];
+   return n;
+}
+
+int kb_client_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out)
+{
+   snprintf(g_last_project, sizeof(g_last_project), "%s", project ? project : "");
+   snprintf(g_last_rel, sizeof(g_last_rel), "%s", file_path ? file_path : "");
+   if (g_blast_rc != 0)
+      return g_blast_rc;
+   *out = g_blast;
+   return 0;
+}
+
+int config_load(config_t *cfg)
+{
+   memset(cfg, 0, sizeof(*cfg));
+   cfg->guardrails_blast_radius_advisory_enabled = g_advisory_flag;
+   return 0;
+}
+
+/* ── Helpers ─────────────────────────────────────────────────────────────── */
+static void set_blast(int count, const char *const *deps)
+{
+   memset(&g_blast, 0, sizeof(g_blast));
+   g_blast.dependent_count = count;
+   for (int i = 0; i < count && i < 64; i++)
+      snprintf(g_blast.dependents[i], sizeof(g_blast.dependents[i]), "%s", deps[i]);
+   g_blast_rc = 0;
+}
+
+/* ── Pure formatter ──────────────────────────────────────────────────────── */
+static void test_format_no_dependents_is_silent(void)
+{
+   blast_radius_t br;
+   memset(&br, 0, sizeof(br));
+   char msg[256] = "";
+   int rc =
+       blast_radius_advisory_format(&br, "src/a.c", BR_ADVISORY_HUB_THRESHOLD, msg, sizeof(msg));
+   assert(rc == 0);
+   assert(msg[0] == '\0'); /* untouched */
+   printf("  ok: no dependents -> silent\n");
+}
+
+static void test_format_lists_dependents(void)
+{
+   const char *deps[] = {"src/x.c", "src/y.c"};
+   blast_radius_t br;
+   memset(&br, 0, sizeof(br));
+   br.dependent_count = 2;
+   snprintf(br.dependents[0], sizeof(br.dependents[0]), "%s", deps[0]);
+   snprintf(br.dependents[1], sizeof(br.dependents[1]), "%s", deps[1]);
+   char msg[256] = "";
+   int rc =
+       blast_radius_advisory_format(&br, "src/a.c", BR_ADVISORY_HUB_THRESHOLD, msg, sizeof(msg));
+   assert(rc == 1);
+   assert(strstr(msg, "ADVISORY") != NULL);
+   assert(strstr(msg, "src/a.c") != NULL); /* the edited file */
+   assert(strstr(msg, "2 dependent files") != NULL);
+   assert(strstr(msg, "src/x.c") != NULL && strstr(msg, "src/y.c") != NULL);
+   assert(strstr(msg, "hub") == NULL); /* below hub threshold */
+   printf("  ok: lists dependents, no hub note below threshold\n");
+}
+
+static void test_format_singular_count(void)
+{
+   const char *deps[] = {"src/only.c"};
+   blast_radius_t br;
+   memset(&br, 0, sizeof(br));
+   br.dependent_count = 1;
+   snprintf(br.dependents[0], sizeof(br.dependents[0]), "%s", deps[0]);
+   char msg[256] = "";
+   blast_radius_advisory_format(&br, "src/a.c", BR_ADVISORY_HUB_THRESHOLD, msg, sizeof(msg));
+   assert(strstr(msg, "1 dependent file ") != NULL); /* singular, no trailing 's' */
+   printf("  ok: singular 'dependent file'\n");
+}
+
+static void test_format_hub_note_and_ellipsis(void)
+{
+   /* 10 dependents: caps the list at BR_ADVISORY_MAX_NAMES, appends "(+N more)"
+    * and the hub note (10 >= threshold). */
+   char names[10][32];
+   const char *deps[10];
+   for (int i = 0; i < 10; i++)
+   {
+      snprintf(names[i], sizeof(names[i]), "src/dep%d.c", i);
+      deps[i] = names[i];
+   }
+   blast_radius_t br;
+   memset(&br, 0, sizeof(br));
+   br.dependent_count = 10;
+   for (int i = 0; i < 10; i++)
+      snprintf(br.dependents[i], sizeof(br.dependents[i]), "%s", deps[i]);
+   char msg[512] = "";
+   int rc =
+       blast_radius_advisory_format(&br, "src/core.c", BR_ADVISORY_HUB_THRESHOLD, msg, sizeof(msg));
+   assert(rc == 1);
+   assert(strstr(msg, "10 dependent files") != NULL);
+   char more[32];
+   snprintf(more, sizeof(more), "(+%d more)", 10 - BR_ADVISORY_MAX_NAMES);
+   assert(strstr(msg, more) != NULL);
+   assert(strstr(msg, "high-centrality hub") != NULL);
+   /* the (BR_ADVISORY_MAX_NAMES+1)-th name must NOT appear in the listed names */
+   assert(strstr(msg, "src/dep9.c") == NULL);
+   printf("  ok: caps list, ellipsis, hub note at/above threshold\n");
+}
+
+static void test_format_truncation_safe(void)
+{
+   /* A tiny buffer must never overflow and still returns 1 (advisory warranted). */
+   const char *deps[] = {"src/aaaaaaaaaaaaaaaaaaaa.c", "src/bbbbbbbbbbbbbbbbbbbb.c"};
+   blast_radius_t br;
+   memset(&br, 0, sizeof(br));
+   br.dependent_count = 2;
+   snprintf(br.dependents[0], sizeof(br.dependents[0]), "%s", deps[0]);
+   snprintf(br.dependents[1], sizeof(br.dependents[1]), "%s", deps[1]);
+   char msg[24] = "";
+   int rc =
+       blast_radius_advisory_format(&br, "src/a.c", BR_ADVISORY_HUB_THRESHOLD, msg, sizeof(msg));
+   assert(rc == 1);
+   assert(strlen(msg) < sizeof(msg)); /* NUL-terminated within bounds */
+   printf("  ok: truncation-safe on a tiny buffer\n");
+}
+
+static void test_format_null_safe(void)
+{
+   char msg[64] = "";
+   assert(blast_radius_advisory_format(NULL, "x", 5, msg, sizeof(msg)) == 0);
+   blast_radius_t br;
+   memset(&br, 0, sizeof(br));
+   br.dependent_count = 1;
+   snprintf(br.dependents[0], sizeof(br.dependents[0]), "x.c");
+   assert(blast_radius_advisory_format(&br, "x", 5, NULL, 0) == 0);
+   printf("  ok: null/zero-length args handled\n");
+}
+
+/* ── Resolver: abs path -> project + relpath ─────────────────────────────── */
+static void test_resolve_matches_project(void)
+{
+   memset(g_projects, 0, sizeof(g_projects));
+   snprintf(g_projects[0].name, sizeof(g_projects[0].name), "aimee");
+   snprintf(g_projects[0].root, sizeof(g_projects[0].root), "/home/u/aimee");
+   g_project_count = 1;
+   const char *one[] = {"src/dep.c"};
+   set_blast(1, one);
+
+   blast_radius_t out;
+   int rc = guardrails_blast_radius_for_abs_path("/home/u/aimee/src/file.c", &out);
+   assert(rc == 0);
+   assert(strcmp(g_last_project, "aimee") == 0);
+   assert(strcmp(g_last_rel, "src/file.c") == 0); /* root stripped, no leading slash */
+   assert(out.dependent_count == 1);
+   printf("  ok: resolves project + strips root to relpath\n");
+}
+
+static void test_resolve_no_match_fails_open(void)
+{
+   memset(g_projects, 0, sizeof(g_projects));
+   snprintf(g_projects[0].name, sizeof(g_projects[0].name), "aimee");
+   snprintf(g_projects[0].root, sizeof(g_projects[0].root), "/home/u/aimee");
+   g_project_count = 1;
+   blast_radius_t out;
+   /* Path under a different root, and a prefix that is NOT a path boundary. */
+   assert(guardrails_blast_radius_for_abs_path("/home/u/other/x.c", &out) == -1);
+   assert(guardrails_blast_radius_for_abs_path("/home/u/aimee-evil/x.c", &out) == -1);
+   printf("  ok: no project match -> -1 (fail-open)\n");
+}
+
+static void test_resolve_sidecar_error_fails_open(void)
+{
+   memset(g_projects, 0, sizeof(g_projects));
+   snprintf(g_projects[0].name, sizeof(g_projects[0].name), "aimee");
+   snprintf(g_projects[0].root, sizeof(g_projects[0].root), "/home/u/aimee");
+   g_project_count = 1;
+   g_blast_rc = -1; /* sidecar failure */
+   blast_radius_t out;
+   assert(guardrails_blast_radius_for_abs_path("/home/u/aimee/a.c", &out) == -1);
+   g_blast_rc = 0;
+   printf("  ok: sidecar error -> -1 (fail-open)\n");
+}
+
+/* ── Advisory gate (config flag + msg_buf precedence) ────────────────────── */
+static void test_advisory_disabled_is_silent(void)
+{
+   memset(g_projects, 0, sizeof(g_projects));
+   snprintf(g_projects[0].name, sizeof(g_projects[0].name), "aimee");
+   snprintf(g_projects[0].root, sizeof(g_projects[0].root), "/home/u/aimee");
+   g_project_count = 1;
+   const char *five[] = {"a.c", "b.c", "c.c", "d.c", "e.c"};
+   set_blast(5, five);
+   g_advisory_flag = 0; /* flag OFF */
+   char msg[256] = "";
+   guardrails_blast_radius_advisory("/home/u/aimee/src/file.c", msg, sizeof(msg));
+   assert(msg[0] == '\0'); /* opt-in: nothing when disabled */
+   printf("  ok: flag off -> no advisory\n");
+}
+
+static void test_advisory_enabled_emits(void)
+{
+   const char *five[] = {"a.c", "b.c", "c.c", "d.c", "e.c"};
+   set_blast(5, five);
+   g_advisory_flag = 1; /* flag ON */
+   char msg[256] = "";
+   guardrails_blast_radius_advisory("/home/u/aimee/src/file.c", msg, sizeof(msg));
+   assert(strstr(msg, "ADVISORY") != NULL);
+   assert(strstr(msg, "high-centrality hub") != NULL); /* 5 >= hub threshold */
+   printf("  ok: flag on + dependents -> advisory emitted\n");
+}
+
+static void test_advisory_respects_existing_message(void)
+{
+   const char *five[] = {"a.c", "b.c", "c.c", "d.c", "e.c"};
+   set_blast(5, five);
+   g_advisory_flag = 1;
+   char msg[256];
+   snprintf(msg, sizeof(msg), "BLOCKED: something higher priority");
+   guardrails_blast_radius_advisory("/home/u/aimee/src/file.c", msg, sizeof(msg));
+   assert(strcmp(msg, "BLOCKED: something higher priority") == 0); /* not clobbered */
+   printf("  ok: non-empty msg_buf is not clobbered\n");
+}
+
+int main(void)
+{
+   printf("test_guardrails_blast_radius\n");
+   test_format_no_dependents_is_silent();
+   test_format_lists_dependents();
+   test_format_singular_count();
+   test_format_hub_note_and_ellipsis();
+   test_format_truncation_safe();
+   test_format_null_safe();
+   test_resolve_matches_project();
+   test_resolve_no_match_fails_open();
+   test_resolve_sidecar_error_fails_open();
+   test_advisory_disabled_is_silent();
+   test_advisory_enabled_emits();
+   test_advisory_respects_existing_message();
+   printf("  all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

Implements proposal **code-graph-intelligence §7** (agent actuation, the graph changes behavior). Before an `Edit`/`Write`/`MultiEdit`, `pre_tool_check` now surfaces a structural **blast-radius ADVISORY**: the dependent files the edited file affects — sourced from the KB sidecar's `/v1/code/blast-radius` (call graph + typed projection edges, **never** the LLM entity graph) — plus a high-centrality **hub** note at/above the refactor-risk threshold (≥5 dependents). This folds in §7's "stale-edge guard".

## Safety contract (R1) — upheld

- **Structural-only**: uses only the deterministic call-graph/projection edges.
- **Advisory**: the hook is `void`; `pre_tool_check` still returns 0 — it can never block an edit.
- **Fail-open**: any miss (flag off, no indexed project owns the path, sidecar error, zero dependents) leaves the existing guardrail decision untouched.
- **Never removes a check**: the advisory runs **last** — after the deterministic checks *and* the opt-in semantic guardrail block — and is gated on `msg_buf[0]=='\0'`, so it can never pre-empt a higher-priority decision (review caught an earlier placement that could suppress the semantic block; relocated so a semantic `return 2` always wins).
- **Opt-in**: gated behind `guardrails.blast_radius.advisory_enabled`, default **off**.

## Design (testability)

- Pure core `blast_radius_advisory_format(const blast_radius_t*, edited_path, hub_threshold, msg_buf, msg_len)` in new `src/guardrails_blast_radius.c` — formats the advisory over an already-fetched `blast_radius_t`; returns 1 if warranted else 0; truncation-safe.
- The sidecar I/O resolver `guardrails_blast_radius_for_abs_path` (abs→project prefix/boundary match → `kb_client_index_blast_radius`) is now **shared** with `classify_path`'s existing severity check — replaces its inline copy (behavior-preserving: SEV_RED ≥5, SEV_YELLOW ≥1, else GREEN), so there's no duplicate fetch path.
- Orchestrator gains a single fail-open call line.

## Tests & gates

- Hermetic `unit-test-guardrails-blast-radius` (config + `kb_client_index_*` stubbed — no DB/sidecar): listing, ellipsis cap, singular/plural, hub note, truncation-safety, project resolution + path-boundary (`/home/u/aimee-evil` does **not** match root `/home/u/aimee`), fail-open on no-match/sidecar-error, flag gate, message precedence.
- `unit-test-guardrails` regression passes; binary + server + bench link.
- New CLI config key (6-touch + `make docs-gen`). `make lint`, `build-integrity`, `docs-gen-check`, `line-check` all green.

## Review

Roundtable + adversarial code-review (fail-open safety auditor + memory-safety finder). Memory-safety: clean (snprintf `off` accumulation provably can't underflow; dependent_count clamped to [0,64]; boundary read in-bounds). Safety auditor confirmed the contract holds after the relocation; the classify_path refactor verified exactly behavior-preserving.

Part of the **code-graph-intelligence** proposal (P4 §7 actuation).