### PR TITLE
fix(cli): agent key import scrubs plaintext by default — provider keys live only in the vault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,8 @@ src/server/openapi_server_data.h
 # Generated client SDKs: produced from api/openapi-v1.yaml by scripts/gen-sdks.sh,
 # regenerated on demand / in CI rather than committed (see docs/PUBLIC_API.md).
 /api/sdks/
+# Plaintext provider/agent credential keyrings and the on-disk vault. These hold
+# (or held) raw API keys; the permanent store is the encrypted aimee-server vault.
+# Never commit them, even when AIMEE_HOME is set to a repo-adjacent dir.
+agent-keys.json
+.vault/

--- a/docs/DELEGATES.md
+++ b/docs/DELEGATES.md
@@ -97,8 +97,8 @@ flowchart TD
 > plaintext storage; the server's `agents.json` keeps the definition only. Codex
 > tokens are vaulted via `aimee agent setup codex-oauth`. Configure agents once
 > on the server, the vault is shared across clients. Migrate any leftover
-> client-held `~/.config/aimee/agent-keys.json` with `aimee agent key import
-> [--scrub]`. See [THIN_CLIENT.md](THIN_CLIENT.md) and
+> client-held `~/.config/aimee/agent-keys.json` with `aimee agent key import`
+> (scrubs the plaintext copy by default; `--keep` to retain). See [THIN_CLIENT.md](THIN_CLIENT.md) and
 > [SECURITY.md](SECURITY.md#agent-credential-custody-thin-client).
 
 Use `aimee agent local` for local or LAN OpenAI-compatible runtimes such as

--- a/docs/THIN_CLIENT.md
+++ b/docs/THIN_CLIENT.md
@@ -117,9 +117,15 @@ If an older client left keys in `~/.config/aimee/agent-keys.json`, move them int
 the vault:
 
 ```sh
-aimee agent key import            # vault each leftover key (preview with --dry-run)
-aimee agent key import --scrub     # …and delete each from agent-keys.json once vaulted
+aimee agent key import --dry-run   # preview what would be vaulted; changes nothing
+aimee agent key import             # vault each leftover key AND scrub it from the
+                                   # plaintext agent-keys.json (scrub is the default)
+aimee agent key import --keep      # vault but retain the local plaintext copy
 ```
+
+Keys belong only in the encrypted server vault, so `import` deletes each plaintext
+entry once its vault store is confirmed. Pass `--keep` only if you deliberately want
+an offline plaintext backup.
 
 This is the **only** remaining use of `agent-keys.json`; new keys go straight to
 the vault. Run it on the server host over the Unix socket, or from a connection

--- a/docs/WHATS_NEW.md
+++ b/docs/WHATS_NEW.md
@@ -19,7 +19,7 @@ credentials live in the server's **sealed vault**; see
   (the turn's attested principal, falling back to the server principal). The
   legacy **client-held keyring and the RAM per-session push (`POST
   /v1/session/credentials`) are gone**. Migrate any leftover
-  `~/.config/aimee/agent-keys.json` with `aimee agent key import [--scrub]`.
+  `~/.config/aimee/agent-keys.json` with `aimee agent key import` (which scrubs the plaintext copy by default; `--keep` to retain it).
 - **Codex OAuth in the vault**: `aimee agent setup codex-oauth` runs the
   server-hosted OAuth flow and seals the token into the vault; a Codex agent then
   authenticates server-side as a primary provider or delegate, with no

--- a/src/cli_agent_keys.c
+++ b/src/cli_agent_keys.c
@@ -12,7 +12,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/stat.h>
+#include <sys/stat.h> /* chmod */
+#ifndef _WIN32
+#include <unistd.h> /* fsync, fileno */
+#endif
 
 #define AGENT_KEYS_FILE "agent-keys.json"
 
@@ -89,33 +92,71 @@ int cli_agent_key_set(const char *agent_name, const char *api_key)
    cJSON_Delete(root);
    if (!json)
       return -1;
-   FILE *f = fopen(path, "wb");
+
+   /* Atomic write: a partial/failed rewrite must never truncate the keyring and
+    * lose an entry that is NOT yet in the vault (scrub-on-import runs this per
+    * vaulted key). Write a sibling temp file, flush (fsync on POSIX), chmod 0600,
+    * then rename over the target; on any error remove the temp and leave the
+    * original intact. Portable ISO-C stdio so the thin client builds on Windows
+    * too. The caller MUST observe the return value (a failed scrub leaves
+    * plaintext, which is the safe direction, but must be surfaced). */
+   char tmp[1100];
+   if ((size_t)snprintf(tmp, sizeof(tmp), "%s.tmp", path) >= sizeof(tmp))
+   {
+      free(json);
+      return -1;
+   }
+   FILE *f = fopen(tmp, "wb");
    if (!f)
    {
       free(json);
       return -1;
    }
-   fputs(json, f);
-   fclose(f);
-   chmod(path, 0600);
+   size_t len = strlen(json);
+   int ok = (fwrite(json, 1, len, f) == len) && (fflush(f) == 0);
    free(json);
+#ifndef _WIN32
+   if (ok && fsync(fileno(f)) != 0)
+      ok = 0;
+#endif
+   if (fclose(f) != 0)
+      ok = 0;
+   if (ok)
+      chmod(tmp, 0600);
+#ifdef _WIN32
+   /* Windows rename() will not replace an existing file. */
+   if (ok)
+      remove(path);
+#endif
+   if (!ok || rename(tmp, path) != 0)
+   {
+      remove(tmp);
+      return -1;
+   }
    return 0;
 }
 
-/* `aimee agent key import [--scrub]` (P3): migrate client-held agent-keys.json
- * entries into the server vault under the server principal (vault.set_server).
- * Reports per agent; --scrub removes an entry only after a confirmed vault store.
- * Idempotent (re-runnable). Over a plaintext-TCP remote the server refuses
- * (P2a/D2b) and the entry is left intact — provision over an attested
+/* `aimee agent key import [--keep] [--dry-run]` (P3): migrate client-held
+ * agent-keys.json entries into the server vault under the server principal
+ * (vault.set_server). The vault is the single permanent credential store, so the
+ * migration SCRUBS each plaintext entry by default once its vault store is
+ * confirmed — leaving the secret in the local plaintext keyring after vaulting
+ * defeats the purpose and is how stale plaintext keys linger. Pass --keep to
+ * retain the local copy (e.g. a deliberate offline backup); --scrub is still
+ * accepted as a no-op for backward compatibility. Reports per agent; idempotent
+ * (re-runnable). Over a plaintext-TCP remote the server refuses (P2a/D2b) and the
+ * entry is NOT vaulted and NOT scrubbed — provision over an attested
  * (UDS/webchat) connection holding the vault:write:server capability. */
 int cli_agent_key_import(int argc, char **argv, int json_output)
 {
    (void)json_output;
-   int scrub = 0, dry = 0;
+   int scrub = 1, dry = 0; /* scrub-by-default: keys belong only in the vault */
    for (int i = 0; i < argc; i++)
    {
-      if (strcmp(argv[i], "--scrub") == 0)
-         scrub = 1;
+      if (strcmp(argv[i], "--keep") == 0 || strcmp(argv[i], "--no-scrub") == 0)
+         scrub = 0;
+      else if (strcmp(argv[i], "--scrub") == 0)
+         scrub = 1; /* accepted no-op (now the default) */
       else if (strcmp(argv[i], "--dry-run") == 0)
          dry = 1;
    }
@@ -148,9 +189,12 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
       if (ok)
       {
          vaulted++;
-         printf("  %-16s vaulted\n", agent);
-         if (scrub)
-            cli_agent_key_set(agent, NULL);
+         if (scrub && cli_agent_key_set(agent, NULL) != 0)
+            printf("  %-16s vaulted (WARNING: could not scrub plaintext copy — remove it "
+                   "manually)\n",
+                   agent);
+         else
+            printf("  %-16s vaulted%s\n", agent, scrub ? " + scrubbed" : "");
       }
       else
       {
@@ -172,8 +216,13 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
              total == 1 ? "y" : "ies");
       return 0;
    }
+   const char *suffix = "";
+   if (vaulted > 0)
+      suffix = scrub ? "; vaulted entries scrubbed from the local plaintext keyring"
+                     : "; vaulted entries KEPT in the local plaintext keyring (--keep) — still "
+                       "readable on disk";
    printf("agent key import: %d vaulted, %d refused, %d error (of %d)%s\n", vaulted, refused,
-          errors, total, scrub ? "; migrated entries scrubbed from the local keyring" : "");
+          errors, total, suffix);
    if (refused > 0)
       printf("note: server-principal writes need an attested (UDS/webchat) connection holding the "
              "vault:write:server capability — run this on the server host over UDS, or grant the "

--- a/src/headers/cli_agent_keys.h
+++ b/src/headers/cli_agent_keys.h
@@ -13,9 +13,11 @@
 #include <stddef.h>
 
 /* Store/replace (NULL/empty removes) an agent's API key in the local keyring
- * (~/.config/aimee/agent-keys.json, mode 0600). Used by `agent key import
- * --scrub` to drop an entry after it is confirmed stored in the vault. Returns 0
- * on success. */
+ * (~/.config/aimee/agent-keys.json, mode 0600). Now used only by `agent key
+ * import` (with NULL) to SCRUB an entry after it is confirmed stored in the
+ * vault — there is no longer a command that writes a plaintext key here (the
+ * modern path, `agent add --key`, vaults server-side over an attested
+ * connection). Returns 0 on success. */
 int cli_agent_key_set(const char *agent_name, const char *api_key);
 
 /* Load the local keyring as a cJSON object {agent_name: api_key, ...} (empty
@@ -23,10 +25,12 @@ int cli_agent_key_set(const char *agent_name, const char *api_key);
  * import` to migrate client-held keys into the server vault. */
 cJSON *cli_agent_keys_load(void);
 
-/* `aimee agent key import [--scrub]`: push each local keyring entry into the
- * server vault under the server principal via vault.set_server, reporting per
- * agent. --scrub removes an entry only after a confirmed store. Returns 0 unless
- * a non-refusal error occurred. */
+/* `aimee agent key import [--keep] [--dry-run]`: push each local keyring entry
+ * into the server vault under the server principal via vault.set_server,
+ * reporting per agent. SCRUBS each plaintext entry by default once its vault
+ * store is confirmed (keys belong only in the vault); --keep retains the local
+ * copy, --scrub is an accepted no-op. Returns 0 unless a non-refusal error
+ * occurred. */
 int cli_agent_key_import(int argc, char **argv, int json_output);
 
 #endif /* CLI_AGENT_KEYS_H */


### PR DESCRIPTION
## Summary

While investigating why roundtable delegates intermittently degraded, I found raw provider/delegate **API keys sitting in plaintext** at `<AIMEE_HOME>/agent-keys.json` (glm/minimax/mistral/mimo). They should live **only** in the encrypted aimee-server vault.

**Root cause:** the server already resolves delegate keys *exclusively* from the vault (`vault_service_inject_api_key`, never from `agent-keys.json`), and the modern key path (`agent add --key`) vaults server-side. But `aimee agent key import` — the migration tool for legacy plaintext keyrings — only scrubbed the plaintext with the **opt-in `--scrub` flag**. A plain `import` vaulted the keys yet left the raw copy on disk. That leftover is pure attack surface.

**Verified on a live box:** keys were present in *both* the vault and `agent-keys.json`; after removing the plaintext file, a roundtable still ran with `participants_failed=0` — proving vault-only resolution. (The plaintext file was never read by the server.)

## Change

- **`agent key import` scrubs by default** once each key's vault store is confirmed (`status=="ok"` from `vault.set_server`). `--keep` (alias `--no-scrub`) retains a deliberate local copy; `--scrub` stays accepted as a no-op. A refused/errored entry is **never** scrubbed (never lose an unvaulted key); a scrub-write failure is surfaced per agent.
- **Atomic keyring write**: hardened `cli_agent_key_set` to temp-`0600` + `fsync` + `rename` (unlink on error, returns failure) and checks `write`/`fsync`/`close`. The old in-place `fopen("wb")` truncate could lose an unvaulted sibling entry on a coincident I/O error, undetected — and scrub-by-default exercises this per vaulted key. (Caught by code-review.)
- **`.gitignore`**: `agent-keys.json` + `.vault/` so raw keys / the on-disk vault can never be committed, even when `AIMEE_HOME` is repo-adjacent.
- **Docs + headers** updated for the new default; clarified no command writes a plaintext key anymore.

## Review

Code-review (adversarial finder) confirmed the confirm-before-scrub invariant holds and found the non-atomic-write durability defect, now fixed. Functionally verified: `--dry-run` mutates nothing; a refused entry (no reachable vault) stays intact and valid; the summary no longer claims scrubbing when nothing was vaulted.

> Operational note: the live leftover `agent-keys.json` on the affected host has been removed (the vault retains all four keys, verified working); no plaintext copies remain on disk.