### PR TITLE
fix(http-retry): cap retries after a budget-consuming stall (provider resilience)

### DIFF
--- a/src/server/http_retry.c
+++ b/src/server/http_retry.c
@@ -7,7 +7,17 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
+
+/* Monotonic milliseconds for measuring how long a single attempt actually took
+ * (used to distinguish a budget-consuming stall from a fast-fail before retry). */
+static int64_t retry_now_ms(void)
+{
+   struct timespec ts = {0, 0};
+   clock_gettime(CLOCK_MONOTONIC, &ts);
+   return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
 
 /* Thread-local progress callback (see http_retry.h). Each connection/turn runs on
  * its own worker thread, so a thread-local matches the delegate run's lifetime. */
@@ -127,8 +137,10 @@ int http_retry_post_context(const char *url, const char *auth_header, const char
                 effective_max_attempts, url ? url : "?", provider ? provider : "?",
                 model ? model : "?", timeout_ms);
 
+      int64_t attempt_start_ms = retry_now_ms();
       http_status =
           agent_http_post(url, auth_header, body, response_buf, timeout_ms, extra_headers);
+      int64_t attempt_ms = retry_now_ms() - attempt_start_ms;
 
       aimee_log(LOG_INFO, "http_retry", "attempt %d/%d: HTTP %d (provider=%s model=%s)",
                 attempt + 1, effective_max_attempts, http_status, provider ? provider : "?",
@@ -170,6 +182,29 @@ int http_retry_post_context(const char *url, const char *auth_header, const char
                       "provider '%s' rate limited; extending retry budget to %d attempts "
                       "(base=%dms, max=%dms)",
                       provider ? provider : "unknown", effective_max_attempts, base_ms, max_ms);
+      }
+
+      /* Bound retries after a budget-consuming STALL. A failed attempt
+       * (http_status < 0 -> FAILOVER_TIMEOUT) that ran for at least half its
+       * timeout_ms already spent the full budget waiting on a stalled provider;
+       * retrying with the same budget usually just re-times-out, wasting another
+       * full timeout. In a deadline-bounded context (e.g. a roundtable panel) that
+       * drags the whole panel to its deadline and abandons/leaks the worker. Allow
+       * at most ONE more attempt (recovers a one-off mid-read drop) instead of the
+       * full budget, capping a stall at ~2x timeout, not Nx. A FAST failure
+       * (connect-refused in ms) is NOT capped — it is cheap to retry — and 429/503
+       * keep their full/extended budget. */
+      /* attempt_ms*2 >= timeout_ms avoids integer truncation (timeout_ms/2 == 0 at
+       * tiny timeouts would miscap a fast failure). */
+      if (http_status < 0 && timeout_ms > 0 && attempt_ms * 2 >= (int64_t)timeout_ms &&
+          effective_max_attempts > attempt + 2)
+      {
+         effective_max_attempts = attempt + 2;
+         aimee_log(LOG_INFO, "http_retry",
+                   "stall on attempt %d (provider=%s, %lldms of %dms budget); capping to %d "
+                   "attempts to bound wall-clock",
+                   attempt + 1, provider ? provider : "unknown", (long long)attempt_ms, timeout_ms,
+                   effective_max_attempts);
       }
 
       /* Success or non-retryable error: return immediately */

--- a/src/tests/test_http_retry.c
+++ b/src/tests/test_http_retry.c
@@ -1,8 +1,12 @@
 /* test_http_retry.c: unit tests for HTTP retry with exponential backoff */
+#include <arpa/inet.h>
 #include <assert.h>
+#include <netinet/in.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 #include "aimee.h"
 #include "failover.h"
 #include "http_retry.h"
@@ -46,6 +50,45 @@ static void test_progress_cb_fires_per_attempt(void)
    free(resp);
    assert(g_progress_calls == 0);
    printf("  PASS: test_progress_cb_fires_per_attempt\n");
+}
+
+/* A budget-consuming STALL (an attempt that runs >= half its timeout waiting on a
+ * stalled peer) caps retries to one extra attempt, so one flaky provider can't
+ * spend Nx its timeout and drag a deadline-bounded roundtable panel. A listening
+ * socket that never accepts/responds simulates the stall: connect + send succeed
+ * (the kernel completes the handshake into the backlog) but the response read
+ * blocks to the deadline. With max_attempts=3 the cap must reduce it to 2 actual
+ * attempts. A FAST connection-refused is NOT capped (the progress test above uses
+ * a refused port and still gets its full 2 attempts). */
+static void test_stall_caps_retries(void)
+{
+   int srv = socket(AF_INET, SOCK_STREAM, 0);
+   assert(srv >= 0);
+   struct sockaddr_in addr;
+   memset(&addr, 0, sizeof(addr));
+   addr.sin_family = AF_INET;
+   addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+   addr.sin_port = 0; /* ephemeral */
+   assert(bind(srv, (struct sockaddr *)&addr, sizeof(addr)) == 0);
+   assert(listen(srv, 8) == 0);
+   socklen_t alen = sizeof(addr);
+   assert(getsockname(srv, (struct sockaddr *)&addr, &alen) == 0);
+   int port = ntohs(addr.sin_port);
+
+   char url[64];
+   snprintf(url, sizeof(url), "http://127.0.0.1:%d/x", port);
+
+   g_progress_calls = 0;
+   http_set_progress_cb(count_progress);
+   char *resp = NULL;
+   /* 200ms timeout, 3 attempts requested -> stall cap reduces to 2. */
+   (void)http_retry_post_context(url, NULL, "{}", &resp, 200, NULL, 3, 1, 1, "test", "test-model",
+                                 NULL);
+   free(resp);
+   http_set_progress_cb(NULL);
+   close(srv);
+   assert(g_progress_calls == 2); /* 3 requested, capped to 2 after the first stall */
+   printf("  PASS: test_stall_caps_retries\n");
 }
 
 /* --- http_should_retry tests --- */
@@ -250,6 +293,7 @@ int main(void)
    test_failover_priority_and_actions();
    test_provider_specific_failover_classification();
    test_progress_cb_fires_per_attempt();
+   test_stall_caps_retries();
 
    printf("all http_retry tests passed.\n");
    return 0;


### PR DESCRIPTION
## Summary

Diagnosed from a roundtable where a panelist (**minimax**) transiently dropped (`participants_failed=1`). Root cause traced through the server logs and code:

- `api.minimax.io` intermittently **stalls the HTTP response read** — the TLS connect and auth succeed and the model works (3/3 direct calls returned fine), but the response body occasionally never arrives.
- aimee waits the full agent `timeout_ms` (180s), `agent_http_post` returns `-1`, `failover_classify` maps `http_status < 0` → `FAILOVER_TIMEOUT` (retryable), and `http_retry` retries with **another full 180s**, up to `HTTP_RETRY_MAX_ATTEMPTS`=3 ≈ **540s**.
- In a roundtable that exceeds the **420s panel deadline**, so the worker is abandoned mid-flight (`agent.parallel: 1/4 worker(s) abandoned … (resources leaked)`) and the panelist misses the round.

The amplifier is aimee-side: a request that already burned its *entire* timeout budget waiting on a stalled provider rarely succeeds on an immediate identical retry — it just re-times-out, spending another full timeout.

## Fix

In `http_retry_post_context`: when a failed attempt (`status < 0`) ran for **≥ half its `timeout_ms`** (a measured, real stall — not a fast failure), allow at most **one** more attempt instead of the full budget. This bounds a stall at ~2× timeout instead of N×, so:
- a roundtable panelist stays under the panel deadline (no abandon/leak) and a one-off mid-read drop still recovers via the single retry;
- **fast** failures are unchanged: a connect-refused (ms) keeps its full attempt count, and `429`/`503` keep their extended budgets — those don't burn the timeout.

General resilience improvement for every provider call (primary + delegates + roundtable), contained to `http_retry.c`.

## Tests

`test_stall_caps_retries`: a listening-but-never-responding socket simulates the stall (the kernel completes the handshake so connect/send succeed; the read blocks to the deadline) — 3 requested attempts cap to 2. The existing fast-fail progress test still gets its full 2 attempts (confirming fast failures aren't capped).

> Note: the upstream `api.minimax.io` flakiness itself is not fixable from aimee; this makes the system degrade gracefully instead of dragging the panel and leaking the worker. The vaulted `minimax` key + model `MiniMax-M3` are verified working (3/3 direct calls succeeded).