### PR TITLE
feat(ingress): span-enrich code hits with the matched line (ingress-compression P1b)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (116)
+## CLI-settable keys (117)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -71,6 +71,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `guardrails_semantic_warn_threshold` | float | Semantic score threshold to warn. |
 | `identity_working_profile_injection_enabled` | bool | Inject the working-profile identity into prompts. |
 | `ingress_audit_async` | bool | Audit ingress requests asynchronously. |
+| `ingress_compress_enabled` | bool | Enable ingress envelope compression: span-enrich code hits and fold code entries into recoverable references (default off). |
 | `ingress_max_raw_scans` | int | Max raw-content scans per ingress request. |
 | `ingress_preinject_assembly_budget` | int | Token budget for ingress context pre-injection. |
 | `ingress_preinject_enabled` | bool | Enable `<aimee-context>` pre-injection on ingress. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -152,6 +152,8 @@ CFG_KEY_DESC = {
     "(session-isolation guard; default off).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress.",
+    "ingress_compress_enabled": "Enable ingress envelope compression: span-enrich code hits and "
+    "fold code entries into recoverable references (default off).",
     "ingress_trusted_proxy_secret": "Shared secret authenticating a trusted ingress proxy.",
     "ingress_usage_accounting_enabled": "Account token usage on ingress requests.",
     "integrity_dry_run": "Run integrity checks without enforcing.",

--- a/src/Makefile
+++ b/src/Makefile
@@ -315,7 +315,7 @@ DB2_SRCS = db2/db2_init.c db2/db2_reembed.c db2/db2_pool.c db2/agent_hints.c db2
 DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Layer 1: Data & policy (memory, index, rules, guardrails, workspace) ---
-DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+DATA_SRCS = code_match.c rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
             index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
             context_discover.c tasks.c learning_router.c learning_implicit.c dogfood.c working_profile.c guardrails.c guardrails_orchestrator.c guardrails_tdd.c workflow_learn.c session_state.c session_briefing.c file_safety.c branch_ownership.c integrity_gate.c conversation_context.c payload_rewrite.c guardrails_semantic.c guardrails_blast_radius.c gateway_policy.c gateway_pipeline.c gateway_delegate.c \
             workspace.c worktree_gc.c workspace_manifest.c workspace_handle.c server/agent_config.c cmd_describe.c \
@@ -410,7 +410,7 @@ KB_CORE_SRCS = $(filter-out db1/%,$(CORE_SRCS))
 KB_CORE_OBJS = $(KB_CORE_SRCS:%.c=$(OBJDIR)/kb/%.o) $(OBJDIR)/cJSON.o
 KB_DB2_PG_OBJS = $(DB2_PG_SRCS:%.c=$(OBJDIR)/kb/%.o)
 KB_DB2_OBJS = $(DB2_SRCS:%.c=$(OBJDIR)/kb/%.o)
-KB_DATA_SRCS = rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
+KB_DATA_SRCS = code_match.c rel_types.c memory_fact_gate.c memory_extract_patterns.c memory_pii_gate.c memory_core.c memory_logic.c memory_effective.c memory_health.c memory_conflict.c memory_context.c memory_assemble.c memory_advanced.c memory_prospective.c memory_lifecycle.c memory_directives.c memory_maintenance.c memory_graph.c memory_graph_fusion.c memory_scan.c memory_improve.c memory_episodes.c \
                index.c extractors.c extractors_extra.c extractors_new_langs.c css_analyze.c css_oracle.c css_render_oracle.c css_render_cmd.c \
                dogfood.c learning_router.c learning_implicit.c integrity_gate.c session_briefing.c workspace.c workspace_manifest.c workspace_handle.c memory_profile_pack.c wiki_render.c kb/kb.c kb/kb_fusion.c kb/kb_neardup.c kb/kb_conventions.c sketch.c learning_evidence.c learning_bundle.c kb/kb_calibrate.c kb/kb_demote.c kb/kb_features.c kb/kb_ranker.c kb/kb_detect.c kb/kb_reasoning.c kb/kb_bandit.c kb/kb_planner.c kb/roadmap.c kb/kb_mdl.c
 KB_DATA_OBJS = $(KB_DATA_SRCS:%.c=$(OBJDIR)/kb/%.o)

--- a/src/code_match.c
+++ b/src/code_match.c
@@ -1,0 +1,37 @@
+/* code_match.c: see code_match.h. */
+#include "code_match.h"
+#include <string.h>
+
+int code_match_line(const char *content, const char *marked_snippet)
+{
+   if (!content || !marked_snippet)
+      return 0;
+   const char *s = strstr(marked_snippet, ">>>");
+   if (!s)
+      return 0;
+   s += 3;
+   const char *e = strstr(s, "<<<");
+   if (!e || e == s)
+      return 0;
+   size_t toklen = (size_t)(e - s);
+
+   /* Find the first verbatim occurrence of the marked token in content. The
+    * token is not NUL-terminated within marked_snippet, so compare bounded. */
+   const char *found = NULL;
+   for (const char *p = content; *p; p++)
+   {
+      if (strncmp(p, s, toklen) == 0)
+      {
+         found = p;
+         break;
+      }
+   }
+   if (!found)
+      return 0;
+
+   int line = 1;
+   for (const char *p = content; p < found; p++)
+      if (*p == '\n')
+         line++;
+   return line;
+}

--- a/src/config.c
+++ b/src/config.c
@@ -844,6 +844,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "ingress_compress_enabled");
+   if (cJSON_IsBool(item))
+      cfg->ingress_compress_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "gateway_prevent_subagents");
    if (cJSON_IsBool(item))
       cfg->gateway_prevent_subagents = cJSON_IsTrue(item);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -41,6 +41,8 @@ const config_field_t config_fields[] = {
     {"memory_rerank_enabled", offsetof(config_t, memory_rerank_enabled), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_enabled", offsetof(config_t, ingress_preinject_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"ingress_compress_enabled", offsetof(config_t, ingress_compress_enabled), sizeof(int), 0,
+     CFG_BOOL},
     {"gateway_prevent_subagents", offsetof(config_t, gateway_prevent_subagents), sizeof(int), 0,
      CFG_BOOL},
     {"gateway_pin_model", offsetof(config_t, gateway_pin_model), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -782,6 +782,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
+   if (cfg->ingress_compress_enabled)
+      cJSON_AddBoolToObject(root, "ingress_compress_enabled", 1);
    if (cfg->gateway_prevent_subagents)
       cJSON_AddBoolToObject(root, "gateway_prevent_subagents", 1);
    if (cfg->gateway_pin_model)

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -8,6 +8,7 @@
 {"kb_client_bearer_token", SCHEMA_STRING, 0},
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
+{"ingress_compress_enabled", SCHEMA_BOOL, 0},
 {"gateway_prevent_subagents", SCHEMA_BOOL, 0},
 {"gateway_pin_model", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},

--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -1507,8 +1507,8 @@ int canonical_index_project_lang_breakdown(const char *project, char *buf, size_
 }
 
 int canonical_index_code_search(const char *query, const char *project, code_search_hit_t *out,
-                                int max)
+                                int max, int enrich)
 {
    /* Forward to db2_code_index — same SQL, same connection. */
-   return db2_code_index_code_search(query, project, out, max);
+   return db2_code_index_code_search(query, project, out, max, enrich);
 }

--- a/src/db2/canonical_index.h
+++ b/src/db2/canonical_index.h
@@ -68,9 +68,11 @@ extern "C"
                                     int max);
 
    /* Full-text code search across file_contents. |project| may be NULL/empty
-    * to search all indexed projects. Returns count of hits, or -1 on error. */
+    * to search all indexed projects. Returns count of hits, or -1 on error.
+    * |enrich| non-zero locates each hit's matched line (ingress-compression P1b);
+    * 0 keeps the query/cost identical to before. */
    int canonical_index_code_search(const char *query, const char *project, code_search_hit_t *out,
-                                   int max);
+                                   int max, int enrich);
 
    /* Count indexed files and definition-kind terms for the project
     * named |project|. Either out pointer may be NULL. Both counts

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -1,7 +1,8 @@
 /* db2/code_index.c: code-index primitives — Postgres via libpq. */
 
 #include "code_index.h"
-#include "../headers/aimee.h" /* MAX_PATH_LEN, now_utc */
+#include "../headers/aimee.h"      /* MAX_PATH_LEN, now_utc */
+#include "../headers/code_match.h" /* code_match_line (P1b span enrichment) */
 #include "db2.h"
 #include "db2_internal.h"
 #include "db_postgres.h"
@@ -723,7 +724,7 @@ int db2_code_index_file_replace(int64_t file_id, const code_index_file_data_t *d
 }
 
 int db2_code_index_code_search(const char *query, const char *project, code_search_hit_t *out,
-                               int max)
+                               int max, int enrich)
 {
    if (!query || !query[0] || !out || max <= 0)
       return query && !query[0] ? 0 : -1;
@@ -734,64 +735,66 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
    const int filter_project = (project && project[0]) ? 1 : 0;
    const int shim = aimee_pg_is_shim();
 
+   /* P1b span enrichment: when `enrich`, also fetch the matched file's content as
+    * a 6th column so the matched line can be located server-side (the int line
+    * crosses the wire, not the content). The pg path already JOINs file_contents
+    * (fc.content); the shim path JOINs it in only when enriching. When !enrich the
+    * composed SQL is the same query (same plan, result set, and cost) as the
+    * prior literals — the default-off guarantee. */
+   const char *sel_content = !enrich ? "" : (shim ? ", fcs.content" : ", fc.content");
+   const char *join_content =
+       (enrich && shim) ? " JOIN file_contents fcs ON fcs.file_id = f.id" : "";
+
    /* The DB2 shim path exposes snippet/rank, while the primary DB2 path uses
     * ts_headline/ts_rank. The same JOIN shape works because `code_fts`
     * presents rowid + fts_tsv columns over file_contents. */
-   const char *sql = NULL;
+   char sql[1400];
    if (shim && filter_project)
-      sql = "SELECT p.name, f.path,"
-            " snippet(code_fts, 0, '>>>', '<<<', '...', 20),"
-            " rank,"
-            " f.hash"
-            " FROM code_fts"
-            " JOIN files f ON f.id = code_fts.rowid"
-            " JOIN projects p ON p.id = f.project_id"
-            " WHERE code_fts MATCH ?1 AND p.name = ?2"
-            "   AND f.path NOT LIKE '.%'"
-            "   AND f.path NOT LIKE '%/.%'"
-            "   AND p.root NOT LIKE '%/.%'"
-            " ORDER BY rank LIMIT ?3";
+      snprintf(sql, sizeof(sql),
+               "SELECT p.name, f.path,"
+               " snippet(code_fts, 0, '>>>', '<<<', '...', 20), rank, f.hash%s"
+               " FROM code_fts JOIN files f ON f.id = code_fts.rowid"
+               " JOIN projects p ON p.id = f.project_id%s"
+               " WHERE code_fts MATCH ?1 AND p.name = ?2"
+               "   AND f.path NOT LIKE '.%%' AND f.path NOT LIKE '%%/.%%'"
+               "   AND p.root NOT LIKE '%%/.%%' ORDER BY rank LIMIT ?3",
+               sel_content, join_content);
    else if (shim)
-      sql = "SELECT p.name, f.path,"
-            " snippet(code_fts, 0, '>>>', '<<<', '...', 20),"
-            " rank,"
-            " f.hash"
-            " FROM code_fts"
-            " JOIN files f ON f.id = code_fts.rowid"
-            " JOIN projects p ON p.id = f.project_id"
-            " WHERE code_fts MATCH ?1"
-            "   AND f.path NOT LIKE '.%'"
-            "   AND f.path NOT LIKE '%/.%'"
-            "   AND p.root NOT LIKE '%/.%'"
-            " ORDER BY rank LIMIT ?2";
+      snprintf(sql, sizeof(sql),
+               "SELECT p.name, f.path,"
+               " snippet(code_fts, 0, '>>>', '<<<', '...', 20), rank, f.hash%s"
+               " FROM code_fts JOIN files f ON f.id = code_fts.rowid"
+               " JOIN projects p ON p.id = f.project_id%s"
+               " WHERE code_fts MATCH ?1"
+               "   AND f.path NOT LIKE '.%%' AND f.path NOT LIKE '%%/.%%'"
+               "   AND p.root NOT LIKE '%%/.%%' ORDER BY rank LIMIT ?2",
+               sel_content, join_content);
    else if (filter_project)
-      sql = "SELECT p.name, f.path,"
-            " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
-            " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
-            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)),"
-            " f.hash"
-            " FROM file_contents fc"
-            " JOIN files f ON f.id = fc.file_id"
-            " JOIN projects p ON p.id = f.project_id"
-            " WHERE fc.code_fts_tsv @@ plainto_tsquery('simple', ?1) AND p.name = ?2"
-            "   AND f.path NOT LIKE '.%'"
-            "   AND f.path NOT LIKE '%/.%'"
-            "   AND p.root NOT LIKE '%/.%'"
-            " ORDER BY ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)) DESC LIMIT ?3";
+      snprintf(sql, sizeof(sql),
+               "SELECT p.name, f.path,"
+               " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
+               " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
+               " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)), f.hash%s"
+               " FROM file_contents fc JOIN files f ON f.id = fc.file_id"
+               " JOIN projects p ON p.id = f.project_id"
+               " WHERE fc.code_fts_tsv @@ plainto_tsquery('simple', ?1) AND p.name = ?2"
+               "   AND f.path NOT LIKE '.%%' AND f.path NOT LIKE '%%/.%%'"
+               "   AND p.root NOT LIKE '%%/.%%'"
+               " ORDER BY ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)) DESC LIMIT ?3",
+               sel_content);
    else
-      sql = "SELECT p.name, f.path,"
-            " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
-            " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
-            " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)),"
-            " f.hash"
-            " FROM file_contents fc"
-            " JOIN files f ON f.id = fc.file_id"
-            " JOIN projects p ON p.id = f.project_id"
-            " WHERE fc.code_fts_tsv @@ plainto_tsquery('simple', ?1)"
-            "   AND f.path NOT LIKE '.%'"
-            "   AND f.path NOT LIKE '%/.%'"
-            "   AND p.root NOT LIKE '%/.%'"
-            " ORDER BY ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)) DESC LIMIT ?2";
+      snprintf(sql, sizeof(sql),
+               "SELECT p.name, f.path,"
+               " ts_headline('simple', fc.content, plainto_tsquery('simple', ?1),"
+               " 'StartSel=>>>, StopSel=<<<, MaxWords=20'),"
+               " ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)), f.hash%s"
+               " FROM file_contents fc JOIN files f ON f.id = fc.file_id"
+               " JOIN projects p ON p.id = f.project_id"
+               " WHERE fc.code_fts_tsv @@ plainto_tsquery('simple', ?1)"
+               "   AND f.path NOT LIKE '.%%' AND f.path NOT LIKE '%%/.%%'"
+               "   AND p.root NOT LIKE '%%/.%%'"
+               " ORDER BY ts_rank(fc.code_fts_tsv, plainto_tsquery('simple', ?1)) DESC LIMIT ?2",
+               sel_content);
 
    char err[CIDX_ERRBUF] = "";
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
@@ -821,6 +824,15 @@ int db2_code_index_code_search(const char *query, const char *project, code_sear
       snprintf(out[count].snippet, sizeof(out[count].snippet), "%s", snip ? snip : "");
       out[count].rank = rnk;
       snprintf(out[count].content_hash, sizeof(out[count].content_hash), "%s", fhash ? fhash : "");
+      /* P1b: locate the matched line from the file content (column 5), without
+       * copying the content out. 0 when not enriching or not locatable. */
+      out[count].line = 0;
+      if (enrich)
+      {
+         const char *content = aimee_pg_column_text(st, 5);
+         if (content && snip)
+            out[count].line = code_match_line(content, snip);
+      }
       count++;
    }
    aimee_pg_finalize(st);

--- a/src/db2/code_index.h
+++ b/src/db2/code_index.h
@@ -122,9 +122,11 @@ extern "C"
     * (FTS5 / plainto_tsquery semantics); empty / NULL returns 0. If
     * |project| is non-empty, restricts to that project. Capped at
     * |max|. Returns count (>=0) on success, -1 on DB / connection
-    * error. */
+    * error. When |enrich| is non-zero, also locates each hit's matched line
+    * (out[].line) from file content; 0 leaves line=0 and keeps the query/cost
+    * identical to before (ingress-compression P1b). */
    int db2_code_index_code_search(const char *query, const char *project, code_search_hit_t *out,
-                                  int max);
+                                  int max, int enrich);
 
 #ifdef __cplusplus
 }

--- a/src/headers/code_match.h
+++ b/src/headers/code_match.h
@@ -1,0 +1,18 @@
+/* code_match.h: locate a code-search match within file content
+ * (ingress-compression P1b span enrichment).
+ *
+ * The code search FTS-matches the whole file; ts_headline / sqlite snippet()
+ * return a fragment with the matched token wrapped in ">>>" / "<<<" markers but
+ * no line offset. code_match_line() recovers the 1-based line of that match so a
+ * hit can carry a span the envelope can fold into a `file:line` reference. Pure
+ * (string-only), so it is unit-tested without a DB. */
+#ifndef DEC_CODE_MATCH_H
+#define DEC_CODE_MATCH_H 1
+
+/* The 1-based line in `content` of the first ">>>…<<<"-marked token in
+ * `marked_snippet`, or 0 when it cannot be located (no markers, empty token, or
+ * the token does not occur in content — ts_headline preserves original text, so
+ * a verbatim match is expected; 0 means "line unknown, fall back to no span"). */
+int code_match_line(const char *content, const char *marked_snippet);
+
+#endif /* DEC_CODE_MATCH_H */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -341,6 +341,11 @@ typedef struct config
     * resolver will return in one call. Bounds the per-call recovery cost and a
     * model-supplied range. */
    int code_span_max_lines;
+   /* ingress-compression master gate (§6.5 B8), default off. When on, code-search
+    * hits are span-enriched (the matched line is located) and the ingress envelope
+    * folds code entries into recoverable references; off keeps the search query,
+    * cost, and envelope byte-identical. */
+   int ingress_compress_enabled;
    /* Session-isolation guard (opt-in): when on, the PreToolUse attention-guard
     * fails closed on a mutating tool whose target is NOT inside an aimee-managed
     * worktree (.aimee/worktrees/...), forcing every mutating session into an

--- a/src/headers/index.h
+++ b/src/headers/index.h
@@ -117,6 +117,13 @@ typedef struct
     * lets drift detection flag a hit whose live source no longer matches its
     * stored hash. Empty when the row has no recorded hash. */
    char content_hash[80];
+   /* 1-based line of the match within the file (ingress-compression P1b span
+    * enrichment), or 0 when not computed. Approximate: the first verbatim
+    * occurrence of the matched token, which for a common token may precede the
+    * true FTS match — treat as a hint. Populated only when the search is asked to
+    * enrich (the lossy-fold path); 0 on the default search, where the query plan
+    * and result set are unchanged. */
+   int line;
 } code_search_hit_t;
 
 /* Lexical search across indexed code. Returns count of results. Ranking and

--- a/src/index.c
+++ b/src/index.c
@@ -872,6 +872,7 @@ int index_code_search(const char *query, const char *project, code_search_hit_t 
    (void)max;
    return -1;
 #else
-   return db2_code_index_code_search(query, project, out, max);
+   /* The direct (non-HTTP) code-search path does not enrich line spans. */
+   return db2_code_index_code_search(query, project, out, max, 0);
 #endif
 }

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -348,7 +348,11 @@ int handle_get_code_search(const char *query_string, char *out_buf, int out_cap)
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
       return 500;
    }
-   int n = canonical_index_code_search(query, project[0] ? project : NULL, hits, max_r);
+   /* Enrich matched-line spans only when ingress compression is enabled (the
+    * lossy-fold consumer). Default-off keeps the query and JSON identical. */
+   config_t scfg;
+   int enrich = (config_load(&scfg) == 0 && scfg.ingress_compress_enabled) ? 1 : 0;
+   int n = canonical_index_code_search(query, project[0] ? project : NULL, hits, max_r, enrich);
    if (n < 0)
    {
       free(hits);
@@ -375,6 +379,9 @@ int handle_get_code_search(const char *query_string, char *out_buf, int out_cap)
       cJSON_AddNumberToObject(hit, "rank", hits[i].rank);
       /* P2 Layer-1: file content hash for citation + drift detection. */
       cJSON_AddStringToObject(hit, "content_hash", hits[i].content_hash);
+      /* P1b span enrichment: 1-based matched line, only when computed (>0). */
+      if (hits[i].line > 0)
+         cJSON_AddNumberToObject(hit, "line", hits[i].line);
       cJSON_AddItemToArray(arr, hit);
    }
    cJSON_AddNullToObject(resp, "next_cursor");
@@ -573,8 +580,9 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       return 500;
    }
 
-   /* Signal A — lexical code (key = file_path). */
-   int nc = canonical_index_code_search(query, proj, chits, HYBRID_PER_SIGNAL);
+   /* Signal A — lexical code (key = file_path). No span enrichment here — hybrid
+    * ranking does not surface matched-line spans. */
+   int nc = canonical_index_code_search(query, proj, chits, HYBRID_PER_SIGNAL, 0);
    if (nc < 0)
       nc = 0;
    for (int i = 0; i < nc; i++)

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -91,6 +91,7 @@ static int kb_index_code_search_parse(cJSON *resp, code_search_hit_t *out, int m
          cJSON *f = cJSON_GetObjectItemCaseSensitive(h, "file_path");
          cJSON *s = cJSON_GetObjectItemCaseSensitive(h, "snippet");
          cJSON *r = cJSON_GetObjectItemCaseSensitive(h, "rank");
+         cJSON *ln = cJSON_GetObjectItemCaseSensitive(h, "line");
          if (cJSON_IsString(p))
             snprintf(out[count].project, sizeof(out[count].project), "%s", p->valuestring);
          if (cJSON_IsString(f))
@@ -98,6 +99,9 @@ static int kb_index_code_search_parse(cJSON *resp, code_search_hit_t *out, int m
          if (cJSON_IsString(s))
             snprintf(out[count].snippet, sizeof(out[count].snippet), "%s", s->valuestring);
          out[count].rank = cJSON_IsNumber(r) ? r->valuedouble : 0.0;
+         /* P1b span enrichment: matched line, present only when the search
+          * enriched (absent -> 0). */
+         out[count].line = (cJSON_IsNumber(ln) && ln->valueint > 0) ? ln->valueint : 0;
          count++;
       }
    }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -776,6 +776,9 @@ $(TESTPREFIX)/unit-test-ingress-preinject: $(OBJDIR)/tests/test_ingress_preinjec
 $(TESTPREFIX)/unit-test-code-span: $(OBJDIR)/tests/test_code_span.o \
                      $(OBJDIR)/server/code_span.o $(OBJDIR)/kb/kb_doc_hash.o \
                      $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-code-match: $(OBJDIR)/tests/test_code_match.o $(OBJDIR)/code_match.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-gw-stage-memory: $(OBJDIR)/tests/test_gw_stage_memory.o \

--- a/src/tests/test_code_match.c
+++ b/src/tests/test_code_match.c
@@ -1,0 +1,60 @@
+/* test_code_match.c: ingress-compression P1b — code_match_line() locates the
+ * 1-based line of a ts_headline/snippet match (">>>token<<<") within file content. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "code_match.h"
+
+#define PASS(name) printf("  PASS: %s\n", (name))
+
+static const char *CONTENT = "#include <stdio.h>\n"         /* line 1 */
+                             "\n"                           /* line 2 */
+                             "int add(int a, int b)\n"      /* line 3 */
+                             "{\n"                          /* line 4 */
+                             "   return a + b;\n"           /* line 5 */
+                             "}\n"                          /* line 6 */
+                             "\n"                           /* line 7 */
+                             "int subtract(int a, int b)\n" /* line 8 */
+                             "{\n"                          /* line 9 */
+                             "   return a - b;\n"           /* line 10 */
+                             "}\n";                         /* line 11 */
+
+int main(void)
+{
+   /* 1. Match on line 3 (the add signature). */
+   assert(code_match_line(CONTENT, "...int >>>add<<<(int a, int b)...") == 3);
+   PASS("match maps to line 3");
+
+   /* 2. Match a token unique to line 10. */
+   assert(code_match_line(CONTENT, ">>>subtract<<<") == 8);
+   PASS("match maps to line 8");
+
+   /* 3. Match on line 1. */
+   assert(code_match_line(CONTENT, ">>>stdio<<<") == 1);
+   PASS("match maps to line 1");
+
+   /* 4. No markers -> 0 (unknown). */
+   assert(code_match_line(CONTENT, "plain snippet no markers") == 0);
+   PASS("no markers -> 0");
+
+   /* 5. Empty token -> 0. */
+   assert(code_match_line(CONTENT, ">>><<<") == 0);
+   PASS("empty token -> 0");
+
+   /* 6. Token not present in content -> 0. */
+   assert(code_match_line(CONTENT, ">>>nonexistent_token_zzz<<<") == 0);
+   PASS("absent token -> 0");
+
+   /* 7. NULL guards. */
+   assert(code_match_line(NULL, ">>>x<<<") == 0);
+   assert(code_match_line(CONTENT, NULL) == 0);
+   PASS("NULL guards");
+
+   /* 8. First occurrence wins (token appears on multiple lines: "return" is on 5 and 10). */
+   assert(code_match_line(CONTENT, ">>>return<<<") == 5);
+   PASS("first occurrence wins");
+
+   printf("All code_match tests passed.\n");
+   return 0;
+}

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,8 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\ngateway_prevent_subagents: "
+    "true\ningress_preinject_enabled: true\ningress_compress_enabled: "
+    "true\ngateway_prevent_subagents: "
     "true\ncss_style_graph_enabled: "
     "true\n"
     "ingress_preinject_assembly_budget: 1\n"
@@ -84,7 +85,8 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\ngateway_prevent_subagents: "
+    "false\ningress_preinject_enabled: false\ningress_compress_enabled: "
+    "false\ngateway_prevent_subagents: "
     "false\ncss_style_graph_enabled: "
     "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
@@ -166,6 +168,7 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
+   assert(cfgA.ingress_compress_enabled == 1 && cfgB.ingress_compress_enabled == 0);
    assert(cfgA.gateway_prevent_subagents == 1 && cfgB.gateway_prevent_subagents == 0);
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -537,8 +537,10 @@ typedef struct
    char content_hash[80];
 } test_code_search_hit_t;
 
-int canonical_index_code_search(const char *query, const char *project, void *out, int max)
+int canonical_index_code_search(const char *query, const char *project, void *out, int max,
+                                int enrich)
 {
+   (void)enrich;
    assert(query);
    assert(out);
    if (strcmp(query, "needle") != 0 || !project || strcmp(project, "proj-alpha") != 0)


### PR DESCRIPTION
## What

Second increment of `ingress-compression-and-cache-alignment` (after #743). Gives each code-search hit a 1-based **matched line** so the next PR's lossy fold can turn an inline snippet into a recoverable `file:line` reference.

Introduces the proposal's **master gate** `ingress_compress_enabled` (§6.5 B8, default **off**). When off, the search query plan, result set, cost, and the `<aimee-context>` envelope are unchanged — the default-off guarantee.

## Changes

- `code_search_hit_t` gains `int line` (0 when not enriched; approximate — first verbatim occurrence of the matched token, a hint).
- `db2_code_index_code_search(..., int enrich)`: when `enrich`, composes `fc.content` into the query (pg already JOINs it; the shim JOINs `file_contents` 1:1 via the FTS external-content rowid) and locates the matched line with `code_match_line()` — **only the integer line crosses the wire, never the content**. When `!enrich` the composed SQL is the same query as before.
- New pure helper `src/code_match.c` (`code_match_line`): finds the first `>>>token<<<` `ts_headline`/`snippet` marker in the file content and counts newlines → 1-based line; returns 0 on no-marker / empty / absent token.
- `/v1/code/search` enriches only when `cfg.ingress_compress_enabled`, emits `line` when `>0`; the client parser surfaces it. The hybrid route and the direct `index_code_search()` path pass `enrich=0`.
- Config `ingress_compress_enabled` (bool, default off) — full surface (load/save/schema/fields/CLI/generated docs/config-surface).

## Design note

Chose computing the matched line **in the KB search** (content already loaded by `ts_headline`) over a secondary `index_structure` lookup per hit — the latter is up to 6 serial 5 s round trips on the per-turn hot path and can't tie a definition to the FTS match. The earlier P1b design roundtable misfired on domain (read "span" as OTel tracing); the one transferable principle — gate enrichment so the default-off hot path is structurally unchanged — is honored.

## Tests

- `test_code_match.c`: line mapping, no-marker/empty/absent → 0, NULL guards, first-occurrence-wins.
- Config-surface coverage for the new flag; canonical search stub updated for the new arity.

## Review

Roundtable + a dedicated correctness pass: SQL composition (`%%` escaping, column-5 index, bind params, no 1400-byte truncation), `code_match_line` bounds (no over-read past either buffer), default-off (`line=0` triple-covered), and the shim INNER JOIN (1:1, no row drop) all confirmed safe.