### PR TITLE
feat(kb): vector leg fused into /v1/code/hybrid (code-graph §5)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (117)
+## CLI-settable keys (118)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -35,6 +35,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `code_hybrid_rrf_k` | float | Reciprocal Rank Fusion rank constant k for /v1/code/hybrid (default 60). |
 | `code_hybrid_weight_code` | float | RRF weight for the lexical-code signal in /v1/code/hybrid (default 1.0; <=0 disables it). |
 | `code_hybrid_weight_graph` | float | RRF weight for the structural call-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it). |
+| `code_hybrid_weight_vector` | float | RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder). |
 | `code_span_max_lines` | int | Max line span the code_span_get recovery resolver returns per call (default 400). |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |
 | `cost_reward_lambda_pct` | int | Cost-penalty weight (percent) in the reward. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -134,6 +134,7 @@ CFG_KEY_DESC = {
     "guardrail_mode": "Guardrail enforcement mode (off / warn / block).",
     "code_hybrid_weight_code": "RRF weight for the lexical-code signal in /v1/code/hybrid (default 1.0; <=0 disables it).",
     "code_hybrid_weight_graph": "RRF weight for the structural call-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it).",
+    "code_hybrid_weight_vector": "RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder).",
     "code_hybrid_rrf_k": "Reciprocal Rank Fusion rank constant k for /v1/code/hybrid (default 60).",
     "guardrails_blast_radius_advisory_enabled": "Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open).",
     "guardrails_semantic_allow_ml_only_block": "Allow blocking on the ML classifier alone.",

--- a/src/config.c
+++ b/src/config.c
@@ -547,6 +547,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->kb_connection_workers = 2;
    cfg->code_hybrid_weight_code = 1.0;
    cfg->code_hybrid_weight_graph = 1.0;
+   cfg->code_hybrid_weight_vector = 1.0;
    cfg->code_hybrid_rrf_k = 60.0; /* KB_RRF_DEFAULT_K */
    cfg->kb_bg_ingest_enabled = 1;
    cfg->kb_bg_ingest_interval_hours = 6;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -121,6 +121,8 @@ const config_field_t config_fields[] = {
      CFG_FLOAT},
     {"code_hybrid_weight_graph", offsetof(config_t, code_hybrid_weight_graph), sizeof(double), 0,
      CFG_FLOAT},
+    {"code_hybrid_weight_vector", offsetof(config_t, code_hybrid_weight_vector), sizeof(double), 0,
+     CFG_FLOAT},
     {"code_hybrid_rrf_k", offsetof(config_t, code_hybrid_rrf_k), sizeof(double), 0, CFG_FLOAT},
     {"memory_semantic_weight", offsetof(config_t, memory_semantic_weight), sizeof(double), 0,
      CFG_FLOAT},

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1351,6 +1351,9 @@ void config_parse_kb_section2(config_t *cfg, cJSON *root)
          item = cJSON_GetObjectItemCaseSensitive(ch, "weight_graph");
          if (cJSON_IsNumber(item))
             cfg->code_hybrid_weight_graph = item->valuedouble;
+         item = cJSON_GetObjectItemCaseSensitive(ch, "weight_vector");
+         if (cJSON_IsNumber(item))
+            cfg->code_hybrid_weight_vector = item->valuedouble;
          item = cJSON_GetObjectItemCaseSensitive(ch, "rrf_k");
          if (cJSON_IsNumber(item) && item->valuedouble > 0)
             cfg->code_hybrid_rrf_k = item->valuedouble;

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1508,6 +1508,92 @@ int pgvec_code_search(const char *project, const float *vec, int dim, int limit,
    return (rc == AIMEE_PG_ERR) ? -1 : n;
 }
 
+/* Like pgvec_code_search, but returns each hit's file_path instead of its
+ * point_id — the hybrid retrieval leg (§5) fuses signals in file-path space, so
+ * it needs paths, not point ids. paths is a flat buffer of `max` slots each
+ * `path_cap` bytes (paths + i*path_cap); rows with an empty file_path are
+ * skipped. Returns the distinct-file count, or -1 on a bad arg / query error
+ * (the caller treats <0 as "no vector signal" and degrades gracefully).
+ *
+ * code_embeddings holds MANY rows per file (one per code unit/symbol), so a
+ * plain LIMIT N over rows would collapse to far fewer than N distinct files. We
+ * over-fetch index-ordered rows (the ORDER BY uses the ANN index) and dedup by
+ * file_path in C, keeping the first occurrence per file — its best (lowest-
+ * distance) row, since rows arrive in ascending distance. */
+int pgvec_code_search_paths(const char *project, const float *vec, int dim, int limit, char *paths,
+                            int path_cap, double *scores, int max)
+{
+   if (!vec || dim <= 0 || !paths || path_cap <= 0 || !scores || max <= 0)
+      return -1;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+
+   char *vec_text = build_vec_text(vec, dim);
+   if (!vec_text)
+      return -1;
+
+   const char *sql;
+   if (project && *project)
+      sql = "SELECT file_path, 1.0 - (embedding <=> :qvec::halfvec) AS score"
+            " FROM code_embeddings"
+            " WHERE project = :project AND file_path <> ''"
+            " ORDER BY embedding <=> :qvec::halfvec LIMIT :lim";
+   else
+      sql = "SELECT file_path, 1.0 - (embedding <=> :qvec::halfvec) AS score"
+            " FROM code_embeddings"
+            " WHERE file_path <> ''"
+            " ORDER BY embedding <=> :qvec::halfvec LIMIT :lim";
+
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+   {
+      free(vec_text);
+      return 0;
+   }
+   /* Over-fetch rows so the C-side dedup can fill `max` DISTINCT files (16x,
+    * capped at 1024 — the ANN ORDER BY still drives the scan). */
+   int want = limit > 0 ? limit : max;
+   int row_lim = want <= 64 ? want * 16 : 1024;
+   if (row_lim > 1024)
+      row_lim = 1024;
+   if (row_lim < want)
+      row_lim = want;
+   aimee_pg_bind_text(stmt, "qvec", vec_text);
+   if (project && *project)
+      aimee_pg_bind_text(stmt, "project", project);
+   aimee_pg_bind_int(stmt, "lim", row_lim);
+
+   int64_t t0 = monotonic_us();
+   int n = 0;
+   aimee_pg_step_t rc;
+   while ((rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf))) == AIMEE_PG_ROW)
+   {
+      if (n >= max)
+         break;
+      const char *fp = aimee_pg_column_text(stmt, 0);
+      if (!fp || !fp[0])
+         continue; /* unfusable in file-path space */
+      int dup = 0; /* keep only the first (best-distance) row per file */
+      for (int k = 0; k < n; k++)
+         if (strcmp(paths + (size_t)k * path_cap, fp) == 0)
+         {
+            dup = 1;
+            break;
+         }
+      if (dup)
+         continue;
+      snprintf(paths + (size_t)n * path_cap, (size_t)path_cap, "%s", fp);
+      scores[n] = aimee_pg_column_double(stmt, 1);
+      n++;
+   }
+   aimee_pg_finalize(stmt);
+   free(vec_text);
+   record_latency(monotonic_us() - t0);
+   return (rc == AIMEE_PG_ERR) ? -1 : n;
+}
+
 int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash,
                               const char *body_hash)
 {

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -182,6 +182,10 @@ int pgvec_code_delete(int64_t point_id);
 int pgvec_code_delete_project(const char *project);
 int pgvec_code_search(const char *project, const float *vec, int dim, int limit, int64_t *ids,
                       double *scores, int max);
+/* Like pgvec_code_search but returns file paths (flat buffer of `max` slots of
+ * `path_cap` bytes) for the §5 hybrid file-path-space fusion. <0 on error. */
+int pgvec_code_search_paths(const char *project, const float *vec, int dim, int limit, char *paths,
+                            int path_cap, double *scores, int max);
 /* Returns 1 if a code_embeddings row with (project, node_key, content_hash,
  * body_hash) exists. body_hash may be blank for legacy callers. */
 int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash,

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1242,6 +1242,7 @@ typedef struct config
     * A weight <= 0 disables that signal's contribution. See kb_rrf.c / §5. */
    double code_hybrid_weight_code;
    double code_hybrid_weight_graph;
+   double code_hybrid_weight_vector;
    double code_hybrid_rrf_k;
    /* embedder-runtime-fetch-autodim §2c: when 0 (default) a recorded-vs-configured
     * embedding-dim mismatch is REFUSED at startup (refuse-and-instruct). When 1, the

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -7,6 +7,7 @@
 #include "db2/lifecycle.h"
 #include "db2/memory_query.h"
 #include "db2/code_projection.h"
+#include "db2/pgvec_transport.h"
 #include "memory.h"
 #include "kb/kb_rrf.h"
 #include "kb/kb_graph_analytics.h"
@@ -567,14 +568,21 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
    memory_t *mems = calloc(HYBRID_PER_SIGNAL, sizeof(*mems));
    kb_rrf_item_t *code_items = calloc(HYBRID_PER_SIGNAL, sizeof(*code_items));
    kb_rrf_item_t *graph_items = calloc(HYBRID_PER_SIGNAL, sizeof(*graph_items));
-   kb_rrf_result_t *fused = calloc(HYBRID_PER_SIGNAL * 2, sizeof(*fused));
-   if (!chits || !ghits || !mems || !code_items || !graph_items || !fused)
+   kb_rrf_item_t *vector_items = calloc(HYBRID_PER_SIGNAL, sizeof(*vector_items));
+   char(*vpaths)[256] = calloc(HYBRID_PER_SIGNAL, sizeof(*vpaths));
+   double *vscores = calloc(HYBRID_PER_SIGNAL, sizeof(*vscores));
+   kb_rrf_result_t *fused = calloc(HYBRID_PER_SIGNAL * 3, sizeof(*fused));
+   if (!chits || !ghits || !mems || !code_items || !graph_items || !vector_items || !vpaths ||
+       !vscores || !fused)
    {
       free(chits);
       free(ghits);
       free(mems);
       free(code_items);
       free(graph_items);
+      free(vector_items);
+      free(vpaths);
+      free(vscores);
       free(fused);
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
       return 500;
@@ -611,19 +619,47 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
 
    /* Per-signal RRF weights + rank constant are config-tunable (§5). */
    config_t hcfg;
-   double w_code = 1.0, w_graph = 1.0, rrf_k = KB_RRF_DEFAULT_K;
+   double w_code = 1.0, w_graph = 1.0, w_vector = 1.0, rrf_k = KB_RRF_DEFAULT_K;
    if (config_load(&hcfg) == 0)
    {
       w_code = hcfg.code_hybrid_weight_code;
       w_graph = hcfg.code_hybrid_weight_graph;
+      w_vector = hcfg.code_hybrid_weight_vector;
       if (hcfg.code_hybrid_rrf_k > 0)
          rrf_k = hcfg.code_hybrid_rrf_k;
    }
-   kb_rrf_signal_t sigs[2] = {
+
+   /* Signal C — vector similarity (key = file_path; §5). Embed the query and
+    * pgvec-search code_embeddings. Gated on a real embedder whose output dim
+    * matches the corpus (db2_embedding_dim): on a dim mismatch (e.g. the 384-dim
+    * builtin vs a 2560-dim corpus) or a down/unconfigured embedder the leg is
+    * simply empty and the route degrades to code+graph. w_vector<=0 disables it. */
+   int nv = 0;
+   if (w_vector > 0.0)
+   {
+      const char *embed_cmd = config_embedding_command(&hcfg, NULL);
+      float qvec[EMBED_MAX_DIM];
+      int qdim = memory_embed_text(query, embed_cmd, qvec, EMBED_MAX_DIM);
+      if (qdim > 0 && qdim == db2_embedding_dim())
+      {
+         nv = pgvec_code_search_paths(proj, qvec, qdim, HYBRID_PER_SIGNAL, (char *)vpaths,
+                                      (int)sizeof(vpaths[0]), vscores, HYBRID_PER_SIGNAL);
+         if (nv < 0)
+            nv = 0;
+         for (int i = 0; i < nv; i++)
+         {
+            snprintf(vector_items[i].id, sizeof(vector_items[i].id), "%s", vpaths[i]);
+            vector_items[i].structural_weight = 0;
+         }
+      }
+   }
+
+   kb_rrf_signal_t sigs[3] = {
        {code_items, nc, w_code, "code"},
        {graph_items, ng, w_graph, "graph"},
+       {vector_items, nv, w_vector, "vector"},
    };
-   int nf = kb_rrf_fuse(sigs, 2, rrf_k, fused, HYBRID_PER_SIGNAL * 2);
+   int nf = kb_rrf_fuse(sigs, 3, rrf_k, fused, HYBRID_PER_SIGNAL * 3);
    if (nf < 0)
       nf = 0;
    if (nf > max_r)
@@ -644,6 +680,9 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       free(mems);
       free(code_items);
       free(graph_items);
+      free(vector_items);
+      free(vpaths);
+      free(vscores);
       free(fused);
       snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
       return 500;
@@ -685,6 +724,14 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
                cJSON_AddItemToArray(which, cJSON_CreateString("graph"));
             cJSON_AddStringToObject(row, "caller", ghits[j].caller);
             cJSON_AddNumberToObject(row, "caller_line", ghits[j].line);
+            break;
+         }
+      for (int j = 0; j < nv; j++)
+         if (strcmp(vpaths[j], fp) == 0)
+         {
+            if (which)
+               cJSON_AddItemToArray(which, cJSON_CreateString("vector"));
+            cJSON_AddNumberToObject(row, "vector_score", vscores[j]);
             break;
          }
       cJSON_AddItemToArray(results, row);
@@ -730,6 +777,9 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
    free(mems);
    free(code_items);
    free(graph_items);
+   free(vector_items);
+   free(vpaths);
+   free(vscores);
    free(fused);
    return status;
 }

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -367,9 +367,10 @@ int db2_reembed_clear_maintenance(int force, int *was_in_progress, int *recorded
    g_test_reembed_in_progress = 0;
    return 0;
 }
+int g_test_embedding_dim = 1024; /* §5 vector-leg tests flip this; default 1024 */
 int db2_embedding_dim(void)
 {
-   return 1024;
+   return g_test_embedding_dim;
 }
 int db2_probe_embedder_dim(int budget_ms, int *out)
 {
@@ -851,6 +852,7 @@ int config_load(config_t *cfg)
     * both signals at equal weight (a 0 weight would disable a signal). */
    cfg->code_hybrid_weight_code = 1.0;
    cfg->code_hybrid_weight_graph = 1.0;
+   cfg->code_hybrid_weight_vector = 1.0;
    cfg->code_hybrid_rrf_k = 60.0;
    return 0;
 }
@@ -1924,6 +1926,8 @@ int main(void)
    test_code_hybrid_ok();
    test_code_hybrid_missing_query();
    test_code_hybrid_no_symbol();
+   test_code_hybrid_vector_ok();
+   test_code_hybrid_vector_dim_mismatch_skips();
    test_code_graph_hubs_ok();
    test_code_graph_hubs_missing_project();
    test_code_project_stats_missing_project();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -71,6 +71,42 @@ int canonical_index_find_callers(const char *project, const char *symbol, void *
    return 1;
 }
 
+/* Vector-leg stubs (§5): the query embedder + pgvec code search. OFF by default
+ * (g_vec_enabled=0 -> memory_embed_text returns 0 -> the leg is skipped), so the
+ * existing hybrid tests are unaffected; test_code_hybrid_vector_ok flips it on. */
+static int g_vec_enabled = 0;
+int memory_embed_text(const char *text, const char *command, float *out, int max_dim)
+{
+   (void)text;
+   (void)command;
+   if (!g_vec_enabled || !out || max_dim <= 0)
+      return 0;
+   int d = 2560; /* the stub embedder's FIXED output dim (independent of the corpus
+                  * dim) so the route's qdim==db2_embedding_dim() gate can mismatch. */
+   if (d > max_dim)
+      return 0;
+   for (int i = 0; i < d; i++)
+      out[i] = 0.01f * (float)(i % 7);
+   return d;
+}
+int pgvec_code_search_paths(const char *project, const float *vec, int dim, int limit, char *paths,
+                            int path_cap, double *scores, int max)
+{
+   (void)project;
+   (void)vec;
+   (void)dim;
+   (void)limit;
+   if (!g_vec_enabled || !paths || path_cap <= 0 || !scores || max < 2)
+      return 0;
+   /* Two hits: src/search.c OVERLAPS the lexical leg (-> 2-signal consensus) and
+    * src/semantic.c is vector-only (a file the lexical+graph legs would miss). */
+   snprintf(paths + 0 * path_cap, (size_t)path_cap, "src/search.c");
+   scores[0] = 0.91;
+   snprintf(paths + 1 * path_cap, (size_t)path_cap, "src/semantic.c");
+   scores[1] = 0.88;
+   return 2;
+}
+
 /* Mirror of code_projection_edge_t (db2/code_projection.h) so the stub writes
  * fields at the offsets the handler reads; cast a void* rather than include the
  * db2 header (same pattern as the canonical_index stubs). */
@@ -208,6 +244,43 @@ static void test_code_hybrid_no_symbol(void)
    assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL);
    assert(strstr(buf, "\"file_path\":\"src/caller.c\"") == NULL); /* no graph leg */
    assert(strstr(buf, "why needle exists") != NULL);
+}
+
+/* §5 vector leg: with a dim-matched embedder it fuses as a 3rd signal — a
+ * vector-only file surfaces (labeled "vector" + score) and a file that BOTH the
+ * lexical and vector legs return fuses to a 2-signal consensus row. */
+static void test_code_hybrid_vector_ok(void)
+{
+   g_test_embedding_dim = 2560; /* matches the embed stub's returned dim */
+   g_vec_enabled = 1;
+   char buf[4096];
+   int s = kb_http_route_ex("GET", "/v1/code/hybrid",
+                            "query=needle&symbol=target_fn&project=proj-alpha&max_results=10", NULL,
+                            NULL, NULL, 0, buf, sizeof(buf));
+   g_vec_enabled = 0;
+   g_test_embedding_dim = 1024;
+   assert(s == 200);
+   /* The vector-only file appears, labeled and carrying its vector score. */
+   assert(strstr(buf, "\"file_path\":\"src/semantic.c\"") != NULL);
+   assert(strstr(buf, "\"vector\"") != NULL);
+   assert(strstr(buf, "\"vector_score\"") != NULL);
+   /* src/search.c was returned by BOTH the lexical and vector legs -> consensus. */
+   assert(strstr(buf, "\"signals\":[\"code\",\"vector\"]") != NULL);
+}
+
+/* The dim gate: a wrong-dim embedder (output != corpus dim) disables the leg, so
+ * the vector-only file never appears and the route degrades to code+graph. */
+static void test_code_hybrid_vector_dim_mismatch_skips(void)
+{
+   g_test_embedding_dim = 1024; /* corpus dim != the stub's 2560 output */
+   g_vec_enabled = 1;
+   char buf[4096];
+   int s = kb_http_route_ex("GET", "/v1/code/hybrid", "query=needle&project=proj-alpha", NULL, NULL,
+                            NULL, 0, buf, sizeof(buf));
+   g_vec_enabled = 0;
+   assert(s == 200);
+   assert(strstr(buf, "\"file_path\":\"src/search.c\"") != NULL);    /* lexical still works */
+   assert(strstr(buf, "\"file_path\":\"src/semantic.c\"") == NULL); /* vector leg skipped */
 }
 
 static void test_code_project_stats_missing_project(void)


### PR DESCRIPTION
## Summary

Completes proposal **code-graph-intelligence §5** — adds the third RRF signal the headline promised: **embedding similarity over `code_embeddings`**, fused with the lexical-code and structural-graph legs in file-path space. This was the last embedder-gated piece; now wired and verified against real systems.

## Implementation

- **`pgvec_code_search_paths`** (`db2/pgvec_transport.c`): like the existing `pgvec_code_search`, but `SELECT`s `file_path` (the hybrid fuses in file-path space, not point-id) in one query, skipping empty paths.
- **`handle_get_code_hybrid`** (`kb/http/kb_http_code.c`): embeds the query via `memory_embed_text` (the same live path `/v1/search` uses), pgvec-searches, and builds a third `kb_rrf_signal_t`. **Gated on a dim-matched embedder** (`qdim == db2_embedding_dim()`): on a dim mismatch (e.g. 384-dim builtin vs a 2560-dim corpus) or a down/unconfigured embedder the leg is simply empty and the route **degrades gracefully** to code+graph (`kb_rrf_fuse` already skips `count<=0` signals). Results carry a `"vector"` signal label + `vector_score`; a file returned by both the lexical and vector legs fuses to a **consensus** row.
- **Config**: `code_hybrid_weight_vector` (default 1.0; `<=0` disables; auto-skips without a dim-matched embedder), completing the `kb.code_hybrid.*` weight trio (6-touch + docs-gen).

## Verification (against real systems, given the live corpus access)

- **The new SQL validated against real pgvector/`halfvec`** (a pg16+pgvector instance): correct cosine ordering (`1.0 - (embedding <=> q::halfvec)`), `project` filter, empty-`file_path` skip, and the `::halfvec` cast all confirmed with known vectors.
- **Real corpus check** (live `.254` KB): code is indexed with **relative** file paths (e.g. `MANUAL.md`), which is exactly what `code_embeddings.file_path` stores — so the vector and lexical legs share an id space and consensus works.
- **`memory_embed_text`** is the prod-proven query-embed path (the live `/v1/search` vector leg already uses it).
- **Shim tests** (`test_kb_http_routes_code.inc`): `test_code_hybrid_vector_ok` (consensus + a vector-only file with label/score) and `test_code_hybrid_vector_dim_mismatch_skips` (the dim gate disables the leg). `make lint`, `docs-gen-check`, `line-check`, `kb-v1-coverage` green.

> The full 2560-dim ingest→query E2E against the prod corpus itself wasn't run from here: the prod Postgres/embedder sit inside smoothnas's container namespace (not reachable from the non-root account), and a standalone local KB couldn't be kept alive under this harness. The components are each verified against real systems above; an integration run belongs on a deploy with embedder access.

Part of the **code-graph-intelligence** proposal (§5 hybrid retrieval — now code+graph+**vector**).