### PR TITLE
feat(ingress): lossy code fold to file:line references (ingress-compression P1b)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (117)
+## CLI-settable keys (118)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -72,6 +72,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `identity_working_profile_injection_enabled` | bool | Inject the working-profile identity into prompts. |
 | `ingress_audit_async` | bool | Audit ingress requests asynchronously. |
 | `ingress_compress_enabled` | bool | Enable ingress envelope compression: span-enrich code hits and fold code entries into recoverable references (default off). |
+| `ingress_compress_min_chars` | int | Minimum code-snippet length (chars) before it is folded to a file:line reference (default 80). |
 | `ingress_max_raw_scans` | int | Max raw-content scans per ingress request. |
 | `ingress_preinject_assembly_budget` | int | Token budget for ingress context pre-injection. |
 | `ingress_preinject_enabled` | bool | Enable `<aimee-context>` pre-injection on ingress. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -154,6 +154,8 @@ CFG_KEY_DESC = {
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress.",
     "ingress_compress_enabled": "Enable ingress envelope compression: span-enrich code hits and "
     "fold code entries into recoverable references (default off).",
+    "ingress_compress_min_chars": "Minimum code-snippet length (chars) before it is folded to a "
+    "file:line reference (default 80).",
     "ingress_trusted_proxy_secret": "Shared secret authenticating a trusted ingress proxy.",
     "ingress_usage_accounting_enabled": "Account token usage on ingress requests.",
     "integrity_dry_run": "Run integrity checks without enforcing.",

--- a/src/config.c
+++ b/src/config.c
@@ -509,6 +509,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->ingress_preinject_assembly_budget = 6144;
    cfg->ingress_max_raw_scans = 0;
    cfg->code_span_max_lines = 400;
+   cfg->ingress_compress_min_chars = 80;
    cfg->require_session_worktree = 0;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
     * gate (make virtual-context-eval-check) passes on synthetic and real
@@ -847,6 +848,10 @@ int config_load(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_compress_enabled");
    if (cJSON_IsBool(item))
       cfg->ingress_compress_enabled = cJSON_IsTrue(item);
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "ingress_compress_min_chars");
+   if (cJSON_IsNumber(item) && item->valuedouble > 0)
+      cfg->ingress_compress_min_chars = (int)item->valuedouble;
 
    item = cJSON_GetObjectItemCaseSensitive(root, "gateway_prevent_subagents");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -43,6 +43,8 @@ const config_field_t config_fields[] = {
      CFG_BOOL},
     {"ingress_compress_enabled", offsetof(config_t, ingress_compress_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"ingress_compress_min_chars", offsetof(config_t, ingress_compress_min_chars), sizeof(int), 0,
+     CFG_INT},
     {"gateway_prevent_subagents", offsetof(config_t, gateway_prevent_subagents), sizeof(int), 0,
      CFG_BOOL},
     {"gateway_pin_model", offsetof(config_t, gateway_pin_model), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -784,6 +784,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
    if (cfg->ingress_compress_enabled)
       cJSON_AddBoolToObject(root, "ingress_compress_enabled", 1);
+   if (cfg->ingress_compress_min_chars != 80)
+      cJSON_AddNumberToObject(root, "ingress_compress_min_chars", cfg->ingress_compress_min_chars);
    if (cfg->gateway_prevent_subagents)
       cJSON_AddBoolToObject(root, "gateway_prevent_subagents", 1);
    if (cfg->gateway_pin_model)

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -9,6 +9,7 @@
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
 {"ingress_compress_enabled", SCHEMA_BOOL, 0},
+{"ingress_compress_min_chars", SCHEMA_INT, 0},
 {"gateway_prevent_subagents", SCHEMA_BOOL, 0},
 {"gateway_pin_model", SCHEMA_BOOL, 0},
 {"css_style_graph_enabled", SCHEMA_BOOL, 0},

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -346,6 +346,10 @@ typedef struct config
     * folds code entries into recoverable references; off keeps the search query,
     * cost, and envelope byte-identical. */
    int ingress_compress_enabled;
+   /* ingress-compression P1b: a code snippet is folded to a `file:line` reference
+    * only when its snippet exceeds this many chars (folding a tiny snippet saves
+    * nothing). Default 80. */
+   int ingress_compress_min_chars;
    /* Session-isolation guard (opt-in): when on, the PreToolUse attention-guard
     * fails closed on a mutating tool whose target is NOT inside an aimee-managed
     * worktree (.aimee/worktrees/...), forcing every mutating session into an

--- a/src/headers/request_context.h
+++ b/src/headers/request_context.h
@@ -43,6 +43,9 @@ typedef struct
    req_transport_t transport;
    unsigned int capabilities; /* route capability/scope bits for this connection */
    int trusted;               /* 1 = principal/source headers may be honoured */
+   int compress_disabled;     /* X-Aimee-Compress: 0 — per-request opt-out of ingress
+                               * envelope compression (ingress-compression P1b §1.4/B1).
+                               * 0 = honor config; never forces compression on. */
 } request_context_t;
 
 /* Set the active request context for the current thread (shallow copy). Pass

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -8,6 +8,8 @@
 #include "config.h"
 #include "kb_client.h"
 #include "dstr.h"
+#include "log.h"
+#include "request_context.h"
 #include "platform_random.h"
 #include <stdbool.h>
 #include <stdint.h>
@@ -286,6 +288,17 @@ static char *format_code_body(const code_search_hit_t *hit)
    return dstr_steal(&d);
 }
 
+/* Folded (lossy) body for a code hit (ingress-compression P1b): the snippet is
+ * dropped in favour of a compact `file:line` reference the model recovers in full
+ * via the code_span_get resolver named in the envelope's explore-with line. */
+static char *format_code_fold(const code_search_hit_t *hit)
+{
+   dstr_t d;
+   dstr_init(&d);
+   dstr_appendf(&d, "  - %s:%d\n", hit->file_path, hit->line);
+   return dstr_steal(&d);
+}
+
 /* Per-record body for a memory preview (no group header). Returns NULL for an
  * empty row (id <= 0) — the old NULL candidate, which produced no output and was
  * not counted. Bumps *headline_missing when the row carries no headline. */
@@ -429,12 +442,29 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    size_t envelope_budget = (size_t)configured_budget;
    if (envelope_budget <= INGRESS_FOOTER_RESERVE_BYTES)
       return NULL;
+   /* P1b lossy code fold (ingress-compression §1.2/§1.3): when enabled, a code
+    * hit's snippet is replaced by a compact `file:line` reference recovered via
+    * code_span_get. Gated by config and a per-request X-Aimee-Compress:0 opt-out
+    * (request context, §1.4/B1 — never a thread-local, never forced on). Folding
+    * a hit additionally requires a known matched line (PR1b enrichment) and a
+    * snippet long enough to be worth folding — so it is fail-closed: no line ->
+    * keep the snippet. */
+   int compress = cfg.ingress_compress_enabled;
+   const request_context_t *rctx = request_context_get();
+   if (rctx && rctx->compress_disabled)
+      compress = 0;
+   int compress_min = cfg.ingress_compress_min_chars > 0 ? cfg.ingress_compress_min_chars : 80;
+   const char *code_header =
+       compress ? "recommended (code — expand via code_span_get):\n" : "recommended (code):\n";
+
    /* P0 Envelope IR: gather each source into a typed entry, then render the block
     * from the list. CAP = 6 code + 5 memory + 1 facts + 1 audit. */
    ingress_entry_t entries[6 + 5 + 1 + 1];
    int k = 0;
    double score = 0.0;
    int headline_missing_count = 0;
+   int folded_count = 0;
+   long folded_saved = 0;
 
    /* Primary signal: code search over the turn query. The code index is the
     * richest source, so recommended code files lead the envelope; the agent
@@ -447,10 +477,18 @@ char *ingress_preinject_build(const char *query, int request_disabled)
                       : 0;
    for (int i = 0; i < n; i++)
    {
+      int fold = compress && hits[i].line > 0 && (int)strlen(hits[i].snippet) > compress_min;
       entries[k].kind = ING_SRC_CODE;
-      entries[k].transform = ING_XF_NONE;
-      entries[k].header = "recommended (code):\n";
-      entries[k].preview = format_code_body(&hits[i]);
+      entries[k].transform = fold ? ING_XF_CODE_SIGNATURE_SPAN : ING_XF_NONE;
+      entries[k].header = code_header;
+      entries[k].preview = fold ? format_code_fold(&hits[i]) : format_code_body(&hits[i]);
+      if (fold)
+      {
+         folded_count++;
+         /* Resident saving estimate: the snippet bytes the fold dropped (the
+          * preview text the unfolded body would have carried), for §6 telemetry. */
+         folded_saved += (long)strlen(hits[i].snippet);
+      }
       k++;
    }
    if (n > 0)
@@ -590,6 +628,13 @@ char *ingress_preinject_build(const char *query, int request_disabled)
    char *blk = ingress_render_block(entries, k, envelope_budget, headline_missing_count, NULL);
    for (int i = 0; i < k; i++)
       free(entries[i].preview);
+
+   /* §6 telemetry: attribute the fold's resident saving per turn (only when the
+    * compression lever is engaged). The bench reads this to compute net token
+    * economics; here it is an observable, non-dead record of what was folded. */
+   if (compress && folded_count > 0)
+      LOG_DEBUG("ingress-compress", "folded %d code %s, dropped ~%ld snippet bytes", folded_count,
+                folded_count == 1 ? "hit" : "hits", folded_saved);
 
    if (!blk || !blk[0])
    {

--- a/src/server/server_http_reqctx.c
+++ b/src/server/server_http_reqctx.c
@@ -84,6 +84,14 @@ void server_http_populate_request_context(int fd, int is_tcp, const char *buf,
 
    http_header(buf, "Idempotency-Key", ctx.idempotency_key, sizeof(ctx.idempotency_key));
 
+   /* X-Aimee-Compress: 0 opts this request out of ingress envelope compression
+    * (ingress-compression P1b §1.4/B1). Not identity, so it needs no trusted
+    * proxy — any caller may disable it for its own turn; it never forces it on. */
+   char compress_hdr[16] = "";
+   if (http_header(buf, "X-Aimee-Compress", compress_hdr, sizeof(compress_hdr)) &&
+       strcmp(compress_hdr, "0") == 0)
+      ctx.compress_disabled = 1;
+
    /* Server-derived principal from the kernel-verified UDS peer uid. */
    if (ctx.peer_uid >= 0)
       snprintf(ctx.principal, sizeof(ctx.principal), "uid:%ld", ctx.peer_uid);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -770,7 +770,8 @@ $(TESTPREFIX)/unit-test-text: $(OBJDIR)/tests/test_text.o $(OBJDIR)/util.o $(OBJ
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-ingress-preinject: $(OBJDIR)/tests/test_ingress_preinject.o \
-                     $(OBJDIR)/server/ingress_preinject.o $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o
+                     $(OBJDIR)/server/ingress_preinject.o $(OBJDIR)/server/request_context.o \
+                     $(OBJDIR)/log.o $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-code-span: $(OBJDIR)/tests/test_code_span.o \
@@ -783,6 +784,7 @@ $(TESTPREFIX)/unit-test-code-match: $(OBJDIR)/tests/test_code_match.o $(OBJDIR)/
 
 $(TESTPREFIX)/unit-test-gw-stage-memory: $(OBJDIR)/tests/test_gw_stage_memory.o \
                      $(OBJDIR)/server/gw_stage_memory.o $(OBJDIR)/server/ingress_preinject.o \
+                     $(OBJDIR)/server/request_context.o $(OBJDIR)/log.o \
                      $(OBJDIR)/cJSON.o $(OBJDIR)/dstr.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -9,6 +9,7 @@
 #include "cJSON.h"
 #include "config.h"
 #include "kb_client.h"
+#include "request_context.h"
 
 /* The kb-backed builder (ingress_preinject_build) is out of scope here; these
  * stubs satisfy the linker so the test links only the pure helpers without
@@ -48,6 +49,9 @@ int kb_client_memory_diagnose(const char *query, int limit, memory_diagnostic_t 
    out[1].parts.total = 0.44;
    return 2;
 }
+/* Drives the compression lever in the build test below (config_load stub). */
+static int g_test_compress = 0;
+
 int kb_client_index_code_search(const char *query, const char *project, code_search_hit_t *out,
                                 int max)
 {
@@ -57,7 +61,20 @@ int kb_client_index_code_search(const char *query, const char *project, code_sea
       return 0;
    memset(out, 0, sizeof(out[0]) * (size_t)max);
    snprintf(out[0].file_path, sizeof(out[0].file_path), "src/server/ingress_preinject.c");
-   snprintf(out[0].snippet, sizeof(out[0].snippet), "builder emits a bounded context envelope");
+   if (g_test_compress)
+   {
+      /* A snippet over the 80-char fold threshold + a known matched line, so the
+       * fold path is exercised. Only when compressing, so the P0 byte-equivalence
+       * golden below (default-off) stays the original short-snippet fixture. */
+      snprintf(out[0].snippet, sizeof(out[0].snippet),
+               "the builder emits a bounded context envelope from a typed entry list and renders "
+               "the recommended code block before exploring");
+      out[0].line = 42;
+   }
+   else
+   {
+      snprintf(out[0].snippet, sizeof(out[0].snippet), "builder emits a bounded context envelope");
+   }
    return 1;
 }
 int config_load(config_t *cfg)
@@ -67,6 +84,7 @@ int config_load(config_t *cfg)
       memset(cfg, 0, sizeof(*cfg));
       cfg->ingress_preinject_enabled = 1;
       cfg->ingress_preinject_assembly_budget = 1200;
+      cfg->ingress_compress_enabled = g_test_compress;
    }
    return 0;
 }
@@ -344,6 +362,50 @@ static void test_turn_id_mint_and_thread_local(void)
    printf("turn_id_mint_and_thread_local OK\n");
 }
 
+/* P1b lossy code fold: default-off keeps the snippet; compress-on replaces it with
+ * a `file:line` reference under a code_span_get-expandable header; X-Aimee-Compress:0
+ * (request context) overrides back to the snippet. */
+static void test_compress_code_fold(void)
+{
+   request_context_clear();
+
+   /* Compression OFF (default): the code entry keeps its snippet preview and the
+    * plain header — byte-for-byte the pre-compression behaviour. */
+   g_test_compress = 0;
+   char *off = ingress_preinject_build("how does the builder work", 0);
+   assert(off != NULL);
+   assert(strstr(off, "recommended (code):\n") != NULL);
+   assert(strstr(off, "    > ") != NULL);                 /* snippet present */
+   assert(strstr(off, "ingress_preinject.c\n") != NULL);  /* file line, no :line */
+   assert(strstr(off, "ingress_preinject.c:42") == NULL); /* not folded */
+   free(off);
+
+   /* Compression ON: the snippet is folded to a `file:line` reference under the
+    * expandable header, and the raw snippet text is gone. */
+   g_test_compress = 1;
+   char *on = ingress_preinject_build("how does the builder work", 0);
+   assert(on != NULL);
+   assert(strstr(on, "recommended (code — expand via code_span_get):\n") != NULL);
+   assert(strstr(on, "ingress_preinject.c:42") != NULL);       /* folded reference */
+   assert(strstr(on, "typed entry list and renders") == NULL); /* snippet body dropped */
+   free(on);
+
+   /* Per-request X-Aimee-Compress:0 overrides the config flag back to no fold. */
+   request_context_t rc;
+   memset(&rc, 0, sizeof(rc));
+   rc.compress_disabled = 1;
+   request_context_set(&rc);
+   char *ovr = ingress_preinject_build("how does the builder work", 0);
+   assert(ovr != NULL);
+   assert(strstr(ovr, "ingress_preinject.c:42") == NULL); /* override -> not folded */
+   assert(strstr(ovr, "    > ") != NULL);                 /* snippet restored */
+   free(ovr);
+   request_context_clear();
+
+   g_test_compress = 0;
+   printf("compress_code_fold OK\n");
+}
+
 int main(void)
 {
    printf("ingress_preinject: ");
@@ -355,6 +417,7 @@ int main(void)
    test_render_block();
    test_budgeted_build_uses_memory_previews();
    test_turn_id_mint_and_thread_local();
+   test_compress_code_fold();
    printf("all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Completes **P1b** (after #743 `code_span_get` resolver and #744 span enrichment). When `ingress_compress_enabled` is on, a code hit's snippet is folded to a compact `  - file:line` reference under a header that points the model at `code_span_get` for full recovery. Default **off** → the envelope is byte-identical to before (the P0 golden is preserved).

## Changes

- **Fold (`ingress_preinject_build`):** a code hit is folded iff `ingress_compress_enabled && hit.line > 0 && strlen(snippet) > ingress_compress_min_chars`. `format_code_fold` emits `  - file:line` (snippet dropped); the code group header becomes `recommended (code — expand via code_span_get):` so the transform is visible. **Fail-closed:** no matched line → keep the snippet (never strand unrecoverable detail). Tagged `ING_XF_CODE_SIGNATURE_SPAN`.
- **`X-Aimee-Compress: 0`** per-request opt-out via a new `request_context_t.compress_disabled` field, parsed in `server_http_reqctx.c` — request-scoped, **not a thread-local** (§1.4/B1); honors config otherwise and never forces compression on.
- **§6 telemetry:** a per-turn `LOG_DEBUG` records folded-hit count and dropped snippet bytes (keeps the lever observable for the bench PR).
- **Config `ingress_compress_min_chars`** (int, default 80) — full surface.

## Tests

`test_ingress_preinject` gains a fold test: off keeps the snippet **and preserves the P0 byte-equivalence golden**; on folds to `file:line` and drops the snippet; `X-Aimee-Compress:0` overrides back to the snippet. `request_context.o`/`log.o` added to the two test link rules that link `ingress_preinject.o`.

## Review

Roundtable + a dedicated 7-point correctness pass: default-off byte-identical (header reverts, fold branch dead, `transform` unread by renderer), NULL `request_context_get()` guarded, fold decision (no sign/overflow), single-group header coherence, `format_code_fold` freed exactly once, telemetry format-string correctness, and reqctx parse ordering — all confirmed clean.

No default flip — the net-token gate (§6) is measured in the bench PR; this ships the lever, off.