### PR TITLE
bench(ingress): compress net-token A/B arm + task-class breakdown (ingress-compression §6)

### DIFF
--- a/bench/ingress_compress_prompts.txt
+++ b/bench/ingress_compress_prompts.txt
@@ -1,0 +1,14 @@
+# Prompt suite for `ingress_token_bench.py --mode compress` — code-heavy,
+# repo-comprehension prompts that surface recommended-code hits in the envelope,
+# so the lossy fold (file:line references) and any code_span_get recovery are
+# exercised. Each line is "[task_class] prompt"; task classes are the §6.5 B6 set
+# (code_generation, code_review, debugging, question_answer, summarization,
+# agent_tool_loop). Keep answers brief; do not edit code. Lines starting with #
+# are ignored.
+[question_answer] Which function builds the <aimee-context> pre-injection envelope, and in which file? One line.
+[question_answer] Where is the code_span_get MCP resolver implemented, and what validation does it perform on the requested path? Two sentences.
+[code_review] Review how db2_code_index_code_search composes its SQL when enrichment is on — is the content column index safe? Two sentences.
+[debugging] A code fold emits "file:line" but the model can't recover the span — name the most likely cause and the config flag involved. One line.
+[summarization] Summarize, in two sentences, how the ingress envelope decides whether to fold a code hit into a reference.
+[code_generation] Sketch the signature of the helper that locates a ts_headline match line within file content, and where it lives. One line.
+[agent_tool_loop] Using the repository's own tools, find the function that parses X-Aimee-Compress and report its file and the struct field it sets. One line.

--- a/bench/ingress_token_bench.py
+++ b/bench/ingress_token_bench.py
@@ -4,9 +4,25 @@
 Measures how much server-side context pre-injection (config:
 ``ingress_preinject_enabled``) reduces the tokens Codex spends on a turn. For
 each prompt the harness runs ``codex exec --json`` against aimee's ``/v1``
-endpoint twice — once with pre-injection ON, once OFF — and reads the real token
+endpoint twice — once with the A/B flag ON, once OFF — and reads the real token
 usage from the ``turn.completed`` event
 (``input_tokens + cached_input_tokens + output_tokens``).
+
+Two modes (``--mode``):
+
+* ``preinject`` (default) — A/B ``ingress_preinject_enabled``: the original
+  envelope-on/off token benchmark.
+* ``compress`` — the **§6 lossy-fold net-token gate**. Pre-injection is pinned
+  ON and ``ingress_compress_enabled`` is A/B'd, so the comparison isolates the
+  code-fold (file:line references, recovered via ``code_span_get``). Because the
+  per-turn total already includes any ``code_span_get`` recovery the model made,
+  ``saved = off - on`` is the **net** economics (resident savings minus recovery
+  round-trips), exactly the §6 metric — *not* gross resident reduction. Results
+  break down per §6.5 B6 task class (tag prompts ``[class] prompt``); a class
+  whose net is negative must keep folds non-lossy / not flip the default. The
+  forced-rehydration **accuracy** A/B (does the model recover when the
+  folded-out detail is required?) needs a labelled gold set and a live model and
+  runs separately via ``benchmarks/learning/learning_replay.py``.
 
 Toggle mechanism
 ----------------
@@ -35,6 +51,11 @@ Usage
 -----
     python3 bench/ingress_token_bench.py [--prompts FILE] [--project DIR]
                                          [--jsonl] [--model NAME]
+                                         [--mode preinject|compress]
+
+    # the §6 lossy-fold net-token gate, per task class:
+    python3 bench/ingress_token_bench.py --mode compress \\
+        --prompts bench/ingress_compress_prompts.txt
 
 This harness does NOT modify repository files; prompts should ask Codex to
 answer briefly without editing code.
@@ -68,26 +89,51 @@ def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
                           capture_output=True, env=env)
 
 
-def aimee_set_flag(value: int) -> bool:
-    """Set the server pre-injection flag; returns True on apparent success."""
-    res = run(["aimee", "config", "set", FLAG, str(value)])
+def set_flag(flag: str, value: int) -> bool:
+    """Set a server config flag; returns True on apparent success."""
+    res = run(["aimee", "config", "set", flag, str(value)])
     if res.returncode != 0:
-        log(f"aimee config set {FLAG} {value} failed: {res.stderr.strip()[:200]}")
+        log(f"aimee config set {flag} {value} failed: {res.stderr.strip()[:200]}")
         return False
     return True
 
 
-def aimee_get_flag() -> int | None:
-    res = run(["aimee", "config", "get", FLAG])
+def get_flag(flag: str) -> int | None:
+    res = run(["aimee", "config", "get", flag])
     if res.returncode != 0:
         return None
     out = (res.stdout or "").strip().lower()
-    # Tolerate "true"/"1"/"ingress_preinject_enabled: 1" style output.
+    # Tolerate "true"/"1"/"<flag>: 1" style output.
     if "1" in out or "true" in out or "on" in out:
         return 1
     if "0" in out or "false" in out or "off" in out:
         return 0
     return None
+
+
+# Wrappers preserving the original preinject-mode call sites.
+def aimee_set_flag(value: int) -> bool:
+    return set_flag(FLAG, value)
+
+
+def aimee_get_flag() -> int | None:
+    return get_flag(FLAG)
+
+
+# §6.5 B6 task classes; the per-class breakdown the §6 gates require. A prompt is
+# labelled by a leading "[class]" tag in the prompts file (else "unlabelled").
+TASK_CLASSES = ("code_generation", "code_review", "debugging", "question_answer",
+                "summarization", "agent_tool_loop")
+
+
+def split_task_class(line: str) -> tuple[str, str]:
+    """Split a leading "[task_class] prompt" tag; default 'unlabelled'."""
+    if line.startswith("[") and "]" in line:
+        tag, rest = line[1:].split("]", 1)
+        tag = tag.strip()
+        if tag in TASK_CLASSES:
+            return tag, rest.strip()
+    return "unlabelled", line
 
 
 def codex_tokens(prompt: str, project: Path, model: str) -> tuple[int, str] | None:
@@ -130,30 +176,46 @@ def main() -> int:
                     help="working dir codex runs in (read-only prompts)")
     ap.add_argument("--model", default=os.environ.get("AIMEE_BENCH_MODEL", "aimee"))
     ap.add_argument("--jsonl", action="store_true", help="emit raw per-prompt results as JSONL")
+    ap.add_argument("--mode", choices=("preinject", "compress"), default="preinject",
+                    help="preinject: A/B ingress_preinject_enabled (default). "
+                         "compress: pin pre-injection ON and A/B ingress_compress_enabled — the "
+                         "§6 lossy-fold net-token gate. The 'on' total already includes any "
+                         "code_span_get recovery the model made that turn, so saved = off-on is the "
+                         "NET economics (resident savings minus recovery round-trips), not gross.")
     args = ap.parse_args()
+
+    # The flag under A/B, and any flag pinned ON for the run (compress only matters
+    # when pre-injection is on, so it is pinned for the compress arm).
+    ab_flag = FLAG if args.mode == "preinject" else "ingress_compress_enabled"
+    pin_flag = None if args.mode == "preinject" else FLAG
 
     prompts_path = Path(args.prompts)
     if not prompts_path.exists():
         log(f"prompts file not found: {prompts_path}")
         return 2
-    prompts = [ln.strip() for ln in prompts_path.read_text().splitlines()
+    prompts = [split_task_class(ln.strip()) for ln in prompts_path.read_text().splitlines()
                if ln.strip() and not ln.startswith("#")]
     if not prompts:
         log("no prompts to run")
         return 2
     project = Path(args.project)
 
-    original = aimee_get_flag()
-    log(f"original {FLAG} = {original}")
+    original = get_flag(ab_flag)
+    pin_original = get_flag(pin_flag) if pin_flag else None
+    log(f"mode={args.mode} A/B flag={ab_flag} (original={original})"
+        + (f" pin {pin_flag}=1 (original={pin_original})" if pin_flag else ""))
 
     rows = []
     try:
-        for i, prompt in enumerate(prompts, 1):
-            log(f"prompt {i}/{len(prompts)}: {prompt[:60]!r}")
-            if not aimee_set_flag(1):
+        if pin_flag and not set_flag(pin_flag, 1):
+            log(f"could not pin {pin_flag}=1; aborting")
+            return 1
+        for i, (task_class, prompt) in enumerate(prompts, 1):
+            log(f"prompt {i}/{len(prompts)} [{task_class}]: {prompt[:54]!r}")
+            if not set_flag(ab_flag, 1):
                 continue
             on = codex_tokens(prompt, project, args.model)
-            if not aimee_set_flag(0):
+            if not set_flag(ab_flag, 0):
                 continue
             off = codex_tokens(prompt, project, args.model)
             if not on or not off:
@@ -162,32 +224,56 @@ def main() -> int:
             on_tok, off_tok = on[0], off[0]
             saved = off_tok - on_tok
             pct = (saved / off_tok * 100.0) if off_tok else 0.0
-            row = {"prompt": prompt, "on_tokens": on_tok, "off_tokens": off_tok,
-                   "saved": saved, "reduction_pct": round(pct, 1)}
+            row = {"prompt": prompt, "task_class": task_class, "on_tokens": on_tok,
+                   "off_tokens": off_tok, "saved": saved, "reduction_pct": round(pct, 1)}
             rows.append(row)
             if args.jsonl:
                 print(json.dumps(row), flush=True)
-            log(f"  on={on_tok} off={off_tok} saved={saved} ({pct:.1f}%)")
+            log(f"  on={on_tok} off={off_tok} net_saved={saved} ({pct:.1f}%)")
     finally:
         if original is not None:
-            aimee_set_flag(original)
-            log(f"restored {FLAG} = {original}")
+            set_flag(ab_flag, original)
+            log(f"restored {ab_flag} = {original}")
+        if pin_flag and pin_original is not None:
+            set_flag(pin_flag, pin_original)
+            log(f"restored {pin_flag} = {pin_original}")
 
     if not rows:
         log("no successful prompt pairs")
         return 1
 
-    print("\n=== ingress pre-injection token A/B ===")
-    print(f"{'prompt':40.40}  {'off':>9}  {'on':>9}  {'saved':>8}  {'%':>6}")
+    label = "net (incl. recovery)" if args.mode == "compress" else "saved"
+    print(f"\n=== ingress {args.mode} token A/B ({ab_flag}) ===")
+    print(f"{'prompt':36.36}  {'class':16.16}  {'off':>8}  {'on':>8}  {label:>14}  {'%':>6}")
     for r in rows:
-        print(f"{r['prompt']:40.40}  {r['off_tokens']:>9}  {r['on_tokens']:>9}  "
-              f"{r['saved']:>8}  {r['reduction_pct']:>5.1f}")
+        print(f"{r['prompt']:36.36}  {r['task_class']:16.16}  {r['off_tokens']:>8}  "
+              f"{r['on_tokens']:>8}  {r['saved']:>14}  {r['reduction_pct']:>5.1f}")
     tot_off = sum(r["off_tokens"] for r in rows)
     tot_on = sum(r["on_tokens"] for r in rows)
     overall = (tot_off - tot_on) / tot_off * 100.0 if tot_off else 0.0
     mean_pct = statistics.mean(r["reduction_pct"] for r in rows)
     print(f"\npairs: {len(rows)}   total off={tot_off}  on={tot_on}")
-    print(f"overall reduction: {overall:.1f}%   mean per-prompt: {mean_pct:.1f}%")
+    print(f"overall {label}: {overall:.1f}%   mean per-prompt: {mean_pct:.1f}%")
+
+    # §6 B6: per-task-class breakdown — the net-token gate is evaluated PER CLASS
+    # (a class where recovery erases the saving must not flip the default).
+    by_class: dict[str, list[dict]] = {}
+    for r in rows:
+        by_class.setdefault(r["task_class"], []).append(r)
+    if len(by_class) > 1 or args.mode == "compress":
+        print("\nby task class:")
+        print(f"  {'class':18.18}  {'pairs':>5}  {'off':>8}  {'on':>8}  {'net%':>6}")
+        for cls in sorted(by_class):
+            crs = by_class[cls]
+            coff = sum(r["off_tokens"] for r in crs)
+            con = sum(r["on_tokens"] for r in crs)
+            cpct = (coff - con) / coff * 100.0 if coff else 0.0
+            flag = "  <-- net NEGATIVE (do not flip)" if cpct < 0 else ""
+            print(f"  {cls:18.18}  {len(crs):>5}  {coff:>8}  {con:>8}  {cpct:>5.1f}{flag}")
+    if args.mode == "compress":
+        log("NOTE: forced-rehydration ACCURACY A/B (does the model recover when the folded-out "
+            "detail is required?) needs a labelled gold set + a live model and is run separately "
+            "via learning_replay.py; this harness measures the net-token gate only.")
     return 0
 
 

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (118)
+## CLI-settable keys (119)
 
 | Key | Type | Description |
 |-----|------|-------------|


### PR DESCRIPTION
## What

The §6 validation tooling for the lossy fold (P1b, #746). Extends `bench/ingress_token_bench.py` so the default-flip decision can eventually be made on data. **No code behavior change**; the levers stay default-off.

## Changes

- **`--mode compress`**: pins `ingress_preinject_enabled` ON and A/Bs `ingress_compress_enabled`, isolating the code fold. Because codex's per-turn total already includes any `code_span_get` recovery the model made that turn, **`saved = off − on` is the net token economics** (resident savings minus recovery round-trips) the §6 gate requires — not gross resident reduction.
- **§6.5 B6 task-class breakdown**: prompts tagged `[class] prompt` (the six B6 classes); the summary reports net% per class and flags any class whose net is **negative** ("do not flip"). The gate is evaluated per class.
- Generalized the flag set/get helpers over a flag name; the original `preinject` mode behavior and output are the default and unchanged.
- New `bench/ingress_compress_prompts.txt`: a code-heavy, B6-tagged suite that surfaces foldable code hits.

The forced-rehydration **accuracy** A/B (does the model recover when the folded-out detail is required?) needs a labelled gold set + a live model and runs separately via `learning_replay.py`; this harness measures the net-token gate.

## Validation

Python syntax + the pure `split_task_class` parser unit-checked locally (all six classes parse; malformed/untagged → `unlabelled`; default `preinject` mode output preserved). Running the full A/B needs `codex` + a live aimee model provider (not part of CI).