### PR TITLE
feat(delegate): graph-informed delegation — structural context block (§7)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (119)
+## CLI-settable keys (120)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -46,6 +46,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `db2_url` | string | DB2 connection URL (aimee's vector / knowledge-base store). |
 | `dedup_enabled` | bool | Deduplicate near-identical responses. |
 | `dedup_window_seconds` | int | Window (seconds) for response dedup. |
+| `delegate_graph_context_enabled` | bool | Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off). |
 | `dogfood_autolabel_continuation` | bool | Auto-label continuation turns for dogfood capture. |
 | `dogfood_autolabel_repair` | bool | Auto-label repair turns for dogfood capture. |
 | `dogfood_autolabel_repeat_question` | bool | Auto-label repeated-question turns. |

--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -1,7 +1,8 @@
 # Proposal: Code-graph intelligence — a living, embedded, reasoning graph over code
 
 - **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7 implemented (on the `testing` branch);
-  remainder (§2 tree-sitter, §5 vector leg, §4 surprising-links, §6 live fusion,
+  including the §5 code+graph+vector hybrid and §7 graph-informed delegation;
+  remainder (§2 tree-sitter, §4 surprising-links, §6 live fusion,
   §8 webchat viz) still open, as build-/integration-/frontend-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
@@ -271,22 +272,24 @@ agent's hot path.
   (`kb_graph_analytics.c`, `unit-test-kb-graph-analytics`), **agent-callable** via
   `index({command:"hubs"})`.
 - **§5** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
-  route fusing `code` + `graph` in file-path space with a typed memory `why`,
-  **agent-callable** via `index({command:"hybrid"})`, with **config-tunable per-signal
-  weights** (`kb.code_hybrid.*`).
-- **§7** structural blast-radius **advisory** on the guardrail edit path — advisory,
-  fail-open, structural-only, opt-in (`guardrails_blast_radius.c`,
-  `unit-test-guardrails-blast-radius`); folds in the stale-edge hub note.
+  route fusing `code` + `graph` + **`vector`** (embedding similarity over
+  `code_embeddings` via `pgvec_code_search_paths`, gated on a dim-matched embedder,
+  graceful-degrading) in file-path space with a typed memory `why`, **agent-callable**
+  via `index({command:"hybrid"})`, with **config-tunable per-signal weights**
+  (`kb.code_hybrid.*`). The vector SQL was validated against real pgvector/halfvec.
+- **§7** structural blast-radius **advisory** on the guardrail edit path + **graph-informed
+  delegation** (a delegate's prompt is prefixed with the callers/dependencies of the
+  files its task references) — both advisory, fail-open, structural-only, opt-in
+  (`guardrails_blast_radius.c`, `delegate_inject_graph_context`,
+  `unit-test-guardrails-blast-radius`, `test_delegate_dispatch_reliability`); folds in
+  the stale-edge hub note.
 
 **Deferred — needs the embedder / a build-tier dependency / a deployed corpus / a frontend
 (not completable in the agent host):**
 - **§2 tree-sitter** front-end — large build-tier work (vendor ~30 grammars + ABI).
-- **§5 vector leg** (`pgvec_code_search`) — needs the query embedder (integration/deploy-tier).
 - **§4 surprising-links** — needs embeddings + the percentile/LLM-judge confirmation stage.
 - **§6 live/memory fusion** — post-merge/fetch incremental hook + watch.
 - **§8 webchat visualization** — frontend, read-only `/v1/code/graph` paged projection.
-- **§7 graph-informed delegation** — route a delegate task with the relevant subgraph
-  (follow-up to the shipped blast-radius advisory).
 
 ## Non-goals
 

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -105,6 +105,7 @@ CFG_KEY_DESC = {
     "cache_min_chars": "Minimum prompt size (chars) before cache-shaping applies.",
     "cache_shaping_enabled": "Enable prompt cache-shaping.",
     "claude_cli_delegate_enabled": "Allow delegating to the local Claude CLI agent.",
+    "delegate_graph_context_enabled": "Prepend a structural code-graph context block (callers/dependencies of files a delegate task references) to the delegate prompt (advisory, fail-open, default off).",
     "claude_model": "Default Claude model (empty = CLI default).",
     "gateway_prevent_subagents": "Gateway strips subagent-spawning tools (Task/Agent/etc.) from proxied requests so the served model cannot spawn subagents. Default off.",
     "gateway_pin_model": "Gateway forces the proxied /v1/messages served model to the configured primary's model, overriding the client-requested model. Default off (the passthrough honors the client model); enable for single-model Anthropic-compatible shims.",

--- a/src/config.c
+++ b/src/config.c
@@ -838,6 +838,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->claude_cli_delegate_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "delegate_graph_context_enabled");
+   if (cJSON_IsBool(item))
+      cfg->delegate_graph_context_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "verify_cross_project");
    if (cJSON_IsBool(item))
       cfg->verify_cross_project = cJSON_IsTrue(item);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -219,6 +219,8 @@ const config_field_t config_fields[] = {
     {"verify_enabled", offsetof(config_t, verify_enabled), sizeof(int), 1, CFG_BOOL},
     {"claude_cli_delegate_enabled", offsetof(config_t, claude_cli_delegate_enabled), sizeof(int), 1,
      CFG_BOOL},
+    {"delegate_graph_context_enabled", offsetof(config_t, delegate_graph_context_enabled),
+     sizeof(int), 0, CFG_BOOL},
     {"roundtable.replay_verify_enabled", offsetof(config_t, roundtable_replay_verify_enabled),
      sizeof(int), 1, CFG_BOOL},
     {"verify_cross_project", offsetof(config_t, verify_cross_project), sizeof(int), 1, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -780,6 +780,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "verify_cross_project", 1);
    if (cfg->claude_cli_delegate_enabled)
       cJSON_AddBoolToObject(root, "claude_cli_delegate_enabled", 1);
+   if (cfg->delegate_graph_context_enabled)
+      cJSON_AddBoolToObject(root, "delegate_graph_context_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
    if (cfg->ingress_compress_enabled)

--- a/src/headers/cmd_agent_delegate_impl.h
+++ b/src/headers/cmd_agent_delegate_impl.h
@@ -223,6 +223,12 @@ int delegate_filter_route_capabilities(agent_config_t *cfg, const char *role,
  * or the query yields no results. */
 char *delegate_inject_code_context(const char *prompt);
 
+/* §7 graph-informed delegation: build a "## Structural context (code graph)" block
+ * from the callers/dependencies of the file paths the prompt references (joined
+ * with cwd). Opt-in via delegate_graph_context_enabled; structural-only,
+ * fail-open. Heap string (caller frees) or NULL. */
+char *delegate_inject_graph_context(const char *prompt, const char *cwd);
+
 /* Rewrite every occurrence of `cwd` in `prompt` to `worktree_path` so a delegate
  * running in an isolated sibling worktree sees paths under its own checkout.
  * Returns a newly malloc'd string (caller frees) and sets *occurrences_out to

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -742,6 +742,10 @@ typedef struct config
     * Anthropic's terms and risk account action. Set to 1 to opt in (see
     * DELEGATES.md). Does not affect API-key/HTTP agents or other CLI agents. */
    int claude_cli_delegate_enabled;
+   /* §7 code-graph actuation: prepend a structural-context block (callers /
+    * dependencies of the file paths a delegate task references) to the delegate's
+    * system prompt. Advisory, fail-open, default off (opt-in). */
+   int delegate_graph_context_enabled;
 
    /* Replayable-evidence roundtable verification (Part A). When 1 (default), a
     * review-mode roundtable runs each captured item through an independent replay

--- a/src/server/delegate_prompt.c
+++ b/src/server/delegate_prompt.c
@@ -2,7 +2,9 @@
 #include "cmd_agent_delegate_impl.h"
 #include "agent_config.h"
 #include "agent_coord.h"
+#include "config.h"
 #include "delegate_role.h"
+#include "guardrails_blast_radius.h"
 #include "kb_client.h"
 #include "log.h"
 #include "persona.h"
@@ -1481,6 +1483,127 @@ char *delegate_inject_code_context(const char *prompt)
    if (pos <= 0)
       return NULL;
 
+   buf[pos] = '\0'; /* a truncated final snprintf leaves buf[pos] non-NUL; terminate so
+                     * the malloc(pos+1)/memcpy(pos+1) returns a valid C string. */
+   char *out = malloc((size_t)(pos + 1));
+   if (!out)
+      return NULL;
+   memcpy(out, buf, (size_t)(pos + 1));
+   return out;
+}
+
+/* Append " a, b, c (+N)" — up to `max_names` of `count` entries from names[][]. */
+static void graph_ctx_append_names(char *buf, int *pos, int *rem, char names[][MAX_PATH_LEN],
+                                   int count, int max_names)
+{
+   int cap = count < max_names ? count : max_names;
+   for (int k = 0; k < cap && *rem > 32; k++)
+   {
+      int w = snprintf(buf + *pos, (size_t)*rem, " %s%s", names[k], (k + 1 < cap) ? "," : "");
+      if (w > 0 && w < *rem)
+      {
+         *pos += w;
+         *rem -= w;
+      }
+   }
+   if (count > cap)
+   {
+      int w = snprintf(buf + *pos, (size_t)*rem, " (+%d)", count - cap);
+      if (w > 0 && w < *rem)
+      {
+         *pos += w;
+         *rem -= w;
+      }
+   }
+}
+
+/* §7 graph-informed delegation: prepend a structural-context block — the callers
+ * (dependents) and dependencies of the file paths the delegate task references —
+ * so the delegate starts with the structural neighborhood. Opt-in
+ * (`delegate_graph_context_enabled`, default off) and FAIL-OPEN (NULL on any
+ * miss: flag off, no referenced paths, kb unreachable, or no structural edges).
+ * Uses ONLY the deterministic structural graph (kb_client_index_blast_radius via
+ * the shared resolver), never the LLM entity graph — the same R1 constraint as
+ * the §7 blast-radius advisory. Returns a heap block the caller frees, or NULL. */
+char *delegate_inject_graph_context(const char *prompt, const char *cwd)
+{
+   if (!prompt || !prompt[0])
+      return NULL;
+   config_t cfg;
+   if (config_load(&cfg) != 0 || !cfg.delegate_graph_context_enabled)
+      return NULL;
+
+   char paths[DELEGATE_DRIFT_MAX_PATHS][DELEGATE_DRIFT_PATH_MAX];
+   int np = delegate_extract_named_paths(prompt, paths, DELEGATE_DRIFT_MAX_PATHS);
+   if (np <= 0)
+      return NULL;
+
+   char buf[4096];
+   int pos = 0, rem = (int)sizeof(buf);
+   int w = snprintf(buf + pos, (size_t)rem,
+                    "\n\n## Structural context (code graph)\n"
+                    "Callers/dependencies of the files this task references, from the "
+                    "structural index — review before changing a shared interface:\n");
+   if (w > 0 && w < rem)
+   {
+      pos += w;
+      rem -= w;
+   }
+
+   int files_emitted = 0;
+   for (int i = 0; i < np && files_emitted < 6 && rem > 96; i++)
+   {
+      char abs[MAX_PATH_LEN];
+      if (paths[i][0] == '/' || !cwd || !cwd[0])
+         snprintf(abs, sizeof(abs), "%s", paths[i]);
+      else
+         snprintf(abs, sizeof(abs), "%s/%s", cwd, paths[i]);
+
+      blast_radius_t br;
+      if (guardrails_blast_radius_for_abs_path(abs, &br) != 0)
+         continue; /* fail-open: path not indexed / kb down */
+      if (br.dependent_count <= 0 && br.dependency_count <= 0)
+         continue;
+
+      w = snprintf(buf + pos, (size_t)rem, "- `%s`", paths[i]);
+      if (w <= 0 || w >= rem)
+         break; /* the file header didn't fit; stop rather than attribute callers to nothing */
+      pos += w;
+      rem -= w;
+      if (br.dependent_count > 0)
+      {
+         w = snprintf(buf + pos, (size_t)rem, " — callers:");
+         if (w > 0 && w < rem)
+         {
+            pos += w;
+            rem -= w;
+         }
+         graph_ctx_append_names(buf, &pos, &rem, br.dependents, br.dependent_count, 5);
+      }
+      if (br.dependency_count > 0)
+      {
+         w = snprintf(buf + pos, (size_t)rem,
+                      "%s depends on:", br.dependent_count > 0 ? ";" : " —");
+         if (w > 0 && w < rem)
+         {
+            pos += w;
+            rem -= w;
+         }
+         graph_ctx_append_names(buf, &pos, &rem, br.dependencies, br.dependency_count, 5);
+      }
+      w = snprintf(buf + pos, (size_t)rem, "\n");
+      if (w > 0 && w < rem)
+      {
+         pos += w;
+         rem -= w;
+      }
+      files_emitted++;
+   }
+
+   if (files_emitted == 0)
+      return NULL; /* no structural edges for any referenced file */
+
+   buf[pos] = '\0'; /* defensive: ensure a valid C string even if a write truncated */
    char *out = malloc((size_t)(pos + 1));
    if (!out)
       return NULL;

--- a/src/server/delegate_prompt.c
+++ b/src/server/delegate_prompt.c
@@ -4,7 +4,6 @@
 #include "agent_coord.h"
 #include "config.h"
 #include "delegate_role.h"
-#include "guardrails_blast_radius.h"
 #include "kb_client.h"
 #include "log.h"
 #include "persona.h"
@@ -1517,14 +1516,41 @@ static void graph_ctx_append_names(char *buf, int *pos, int *rem, char names[][M
    }
 }
 
+/* Resolve an abs path to its indexed project + relpath and fetch the structural
+ * blast radius (call graph + projection edges). Returns 0 with *out filled on a
+ * project match + successful fetch, -1 otherwise (FAIL-OPEN). Mirrors the §7
+ * advisory's guardrails_blast_radius_for_abs_path, inlined here so delegate_prompt
+ * stays decoupled from the guardrails object (it already links kb_client_index). */
+static int delegate_blast_radius_for_abs_path(const char *abs_path, blast_radius_t *out)
+{
+   if (!abs_path || !abs_path[0] || !out)
+      return -1;
+   project_info_t projects[32];
+   int pcount = kb_client_index_list(projects, 32);
+   for (int p = 0; p < pcount; p++)
+   {
+      size_t rlen = strlen(projects[p].root);
+      if (strncmp(abs_path, projects[p].root, rlen) == 0 &&
+          (abs_path[rlen] == '/' || abs_path[rlen] == '\0'))
+      {
+         const char *rel = abs_path + rlen;
+         if (*rel == '/')
+            rel++;
+         memset(out, 0, sizeof(*out));
+         return kb_client_index_blast_radius(projects[p].name, rel, out) == 0 ? 0 : -1;
+      }
+   }
+   return -1; /* no indexed project owns this path */
+}
+
 /* §7 graph-informed delegation: prepend a structural-context block — the callers
  * (dependents) and dependencies of the file paths the delegate task references —
  * so the delegate starts with the structural neighborhood. Opt-in
  * (`delegate_graph_context_enabled`, default off) and FAIL-OPEN (NULL on any
  * miss: flag off, no referenced paths, kb unreachable, or no structural edges).
- * Uses ONLY the deterministic structural graph (kb_client_index_blast_radius via
- * the shared resolver), never the LLM entity graph — the same R1 constraint as
- * the §7 blast-radius advisory. Returns a heap block the caller frees, or NULL. */
+ * Uses ONLY the deterministic structural graph (kb_client_index_blast_radius),
+ * never the LLM entity graph — the same R1 constraint as the §7 blast-radius
+ * advisory. Returns a heap block the caller frees, or NULL. */
 char *delegate_inject_graph_context(const char *prompt, const char *cwd)
 {
    if (!prompt || !prompt[0])
@@ -1560,7 +1586,7 @@ char *delegate_inject_graph_context(const char *prompt, const char *cwd)
          snprintf(abs, sizeof(abs), "%s/%s", cwd, paths[i]);
 
       blast_radius_t br;
-      if (guardrails_blast_radius_for_abs_path(abs, &br) != 0)
+      if (delegate_blast_radius_for_abs_path(abs, &br) != 0)
          continue; /* fail-open: path not indexed / kb down */
       if (br.dependent_count <= 0 && br.dependency_count <= 0)
          continue;

--- a/src/server/server_compute.c
+++ b/src/server/server_compute.c
@@ -610,6 +610,25 @@ static cJSON *delegate_build_result_response(
    return resp;
 }
 
+/* Append an owned context `block` to the delegate system prompt, taking ownership
+ * (frees `block` and, on a successful concat, the previous template buffer).
+ * No-op when block is NULL. Shared by the code-context / graph-context / tier
+ * injectors so the ownership dance lives in one place. */
+static void delegate_append_owned_block(const char **system_prompt, char **template_sys_prompt,
+                                        char *block)
+{
+   if (!block)
+      return;
+   char *combined = delegate_prompt_append_block(*system_prompt, block);
+   if (combined)
+   {
+      free(*template_sys_prompt);
+      *template_sys_prompt = combined;
+      *system_prompt = combined;
+   }
+   free(block);
+}
+
 void delegate_worker(void *arg)
 {
    compute_ctx_t *cctx = (compute_ctx_t *)arg;
@@ -1110,38 +1129,20 @@ void delegate_worker(void *arg)
 
    /* Automatic context injection: query the code index for terms in the prompt
     * and append a ## Context block so the delegate starts with relevant snippets
-    * already loaded.  Silently skips if kb is unreachable. */
-   {
-      char *ctx = delegate_inject_code_context(prompt);
-      if (ctx)
-      {
-         char *combined = delegate_prompt_append_block(system_prompt, ctx);
-         if (combined)
-         {
-            free(template_sys_prompt);
-            template_sys_prompt = combined;
-            system_prompt = combined;
-         }
-         free(ctx);
-      }
-   }
+    * already loaded. Silently skips if kb is unreachable. */
+   delegate_append_owned_block(&system_prompt, &template_sys_prompt,
+                               delegate_inject_code_context(prompt));
+
+   /* §7 graph-informed delegation (opt-in, fail-open): prepend the structural
+    * neighborhood (callers/dependencies) of the files the task references so the
+    * delegate sees the blast radius of a shared interface up front. */
+   delegate_append_owned_block(&system_prompt, &template_sys_prompt,
+                               delegate_inject_graph_context(prompt, cwd));
 
    /* Tier orchestration context: for tools-enabled mid-tier delegates, append
     * instructions describing how to fan out sub-tasks to lower-tier agents. */
-   {
-      char *tier_ctx = delegate_build_tier_context(via_name, tier_override, role);
-      if (tier_ctx)
-      {
-         char *combined = delegate_prompt_append_block(system_prompt, tier_ctx);
-         if (combined)
-         {
-            free(template_sys_prompt);
-            template_sys_prompt = combined;
-            system_prompt = combined;
-         }
-         free(tier_ctx);
-      }
-   }
+   delegate_append_owned_block(&system_prompt, &template_sys_prompt,
+                               delegate_build_tier_context(via_name, tier_override, role));
 
    /* Named-file drift guard: extract any repo-relative paths named in the prompt
     * and check pre-flight conditions before running the agent. */

--- a/src/tests/test_delegate_dispatch_reliability.c
+++ b/src/tests/test_delegate_dispatch_reliability.c
@@ -7,6 +7,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #include "cmd_agent_delegate_impl.h"
 #include "index.h"
@@ -39,6 +41,55 @@ static void stub_hits_add(const char *file_path, const char *snippet)
    int i = g_stub_hit_count++;
    snprintf(g_stub_hits[i].file_path, sizeof(g_stub_hits[i].file_path), "%s", file_path);
    snprintf(g_stub_hits[i].snippet, sizeof(g_stub_hits[i].snippet), "%s", snippet);
+}
+
+/* ── stub: guardrails_blast_radius_for_abs_path (the §7 structural resolver) ── */
+
+static int g_br_rc = -1; /* what the resolver returns: 0 = filled, else fail-open */
+static blast_radius_t g_br;
+
+int guardrails_blast_radius_for_abs_path(const char *abs_path, blast_radius_t *out)
+{
+   (void)abs_path;
+   if (g_br_rc != 0 || !out)
+      return -1;
+   *out = g_br;
+   return 0;
+}
+
+static void set_blast_radius(const char *const *deps, int ndeps, const char *const *dependencies,
+                             int ndependencies)
+{
+   memset(&g_br, 0, sizeof(g_br));
+   g_br.dependent_count = ndeps;
+   for (int i = 0; i < ndeps && i < 64; i++)
+      snprintf(g_br.dependents[i], sizeof(g_br.dependents[i]), "%s", deps[i]);
+   g_br.dependency_count = ndependencies;
+   for (int i = 0; i < ndependencies && i < 64; i++)
+      snprintf(g_br.dependencies[i], sizeof(g_br.dependencies[i]), "%s", dependencies[i]);
+   g_br_rc = 0;
+}
+
+/* Drive the real config_load via a temp AIMEE_HOME/aimee.yaml (config.o is linked,
+ * so config_load can't be stubbed). AIMEE_NO_CACHE defeats the config cache. */
+static char g_graph_home[256];
+static void graph_flag_setup(void)
+{
+   snprintf(g_graph_home, sizeof(g_graph_home), "/tmp/aimee-gctx-%d", (int)getpid());
+   mkdir(g_graph_home, 0700);
+   setenv("AIMEE_HOME", g_graph_home, 1);
+   setenv("AIMEE_NO_CACHE", "1", 1);
+}
+static void graph_flag_write(int on)
+{
+   char p[512];
+   snprintf(p, sizeof(p), "%s/aimee.yaml", g_graph_home);
+   FILE *f = fopen(p, "w");
+   if (f)
+   {
+      fprintf(f, "delegate_graph_context_enabled: %s\n", on ? "true" : "false");
+      fclose(f);
+   }
 }
 
 /* ── 1. delegate_extract_named_paths tests ──────────────────────────────── */
@@ -135,6 +186,65 @@ static void test_inject_null_prompt(void)
    printf("  PASS: test_inject_null_prompt\n");
 }
 
+/* ── 2b. delegate_inject_graph_context (§7 graph-informed delegation) ─────── */
+
+/* Flag on + a referenced file with structural edges → a "## Structural context"
+ * block naming the callers and dependencies. */
+static void test_graph_ctx_block_with_edges(void)
+{
+   graph_flag_setup();
+   graph_flag_write(1);
+   const char *deps[] = {"src/caller_a.c", "src/caller_b.c"};
+   const char *dependencies[] = {"src/dep_x.c"};
+   set_blast_radius(deps, 2, dependencies, 1);
+
+   char *ctx = delegate_inject_graph_context("please fix the bug in src/foo.c handler", "/repo");
+   assert(ctx != NULL);
+   assert(strstr(ctx, "## Structural context") != NULL);
+   assert(strstr(ctx, "src/foo.c") != NULL); /* the referenced file */
+   assert(strstr(ctx, "callers:") != NULL);
+   assert(strstr(ctx, "src/caller_a.c") != NULL && strstr(ctx, "src/caller_b.c") != NULL);
+   assert(strstr(ctx, "depends on:") != NULL && strstr(ctx, "src/dep_x.c") != NULL);
+   free(ctx);
+   printf("  PASS: test_graph_ctx_block_with_edges\n");
+}
+
+/* Flag OFF → NULL even with referenced files + edges (opt-in). */
+static void test_graph_ctx_disabled_is_null(void)
+{
+   graph_flag_setup();
+   graph_flag_write(0);
+   const char *deps[] = {"src/caller_a.c"};
+   set_blast_radius(deps, 1, NULL, 0);
+   char *ctx = delegate_inject_graph_context("fix src/foo.c", "/repo");
+   assert(ctx == NULL);
+   printf("  PASS: test_graph_ctx_disabled_is_null\n");
+}
+
+/* Flag on but the prompt references no file path → NULL. */
+static void test_graph_ctx_no_paths_is_null(void)
+{
+   graph_flag_setup();
+   graph_flag_write(1);
+   const char *deps[] = {"src/caller_a.c"};
+   set_blast_radius(deps, 1, NULL, 0);
+   char *ctx = delegate_inject_graph_context("just refactor the thing, no files named", "/repo");
+   assert(ctx == NULL);
+   printf("  PASS: test_graph_ctx_no_paths_is_null\n");
+}
+
+/* Flag on + file referenced but the resolver fails (kb down / unindexed) →
+ * NULL (fail-open). */
+static void test_graph_ctx_resolver_fail_open(void)
+{
+   graph_flag_setup();
+   graph_flag_write(1);
+   g_br_rc = -1; /* resolver returns "no data" for every path */
+   char *ctx = delegate_inject_graph_context("fix src/foo.c", "/repo");
+   assert(ctx == NULL);
+   printf("  PASS: test_graph_ctx_resolver_fail_open\n");
+}
+
 /* ── 3. delegate_worktree_has_changes tests ─────────────────────────────── */
 
 static void test_worktree_has_changes_empty_input(void)
@@ -189,6 +299,10 @@ int main(void)
    test_inject_returns_context_block_with_hits();
    test_inject_handles_multiple_hits();
    test_inject_null_prompt();
+   test_graph_ctx_block_with_edges();
+   test_graph_ctx_disabled_is_null();
+   test_graph_ctx_no_paths_is_null();
+   test_graph_ctx_resolver_fail_open();
 
    test_worktree_has_changes_empty_input();
    test_worktree_has_changes_nonexistent_path();

--- a/src/tests/test_delegate_dispatch_reliability.c
+++ b/src/tests/test_delegate_dispatch_reliability.c
@@ -43,14 +43,25 @@ static void stub_hits_add(const char *file_path, const char *snippet)
    snprintf(g_stub_hits[i].snippet, sizeof(g_stub_hits[i].snippet), "%s", snippet);
 }
 
-/* ── stub: guardrails_blast_radius_for_abs_path (the §7 structural resolver) ── */
+/* ── stubs: the structural blast-radius resolver's kb_client calls ──────────── */
 
-static int g_br_rc = -1; /* what the resolver returns: 0 = filled, else fail-open */
+static int g_br_rc = -1; /* kb_client_index_blast_radius: 0 = filled, else fail-open */
 static blast_radius_t g_br;
 
-int guardrails_blast_radius_for_abs_path(const char *abs_path, blast_radius_t *out)
+int kb_client_index_list(project_info_t *out, int max)
 {
-   (void)abs_path;
+   if (max < 1 || !out)
+      return 0;
+   memset(&out[0], 0, sizeof(out[0]));
+   snprintf(out[0].name, sizeof(out[0].name), "p");
+   snprintf(out[0].root, sizeof(out[0].root), "/repo"); /* abs paths under /repo match */
+   return 1;
+}
+
+int kb_client_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out)
+{
+   (void)project;
+   (void)file_path;
    if (g_br_rc != 0 || !out)
       return -1;
    *out = g_br;

--- a/src/tests/test_server_compute_workspace_stubs.inc
+++ b/src/tests/test_server_compute_workspace_stubs.inc
@@ -54,6 +54,24 @@ int kb_client_index_code_search(const char *query, const char *project, code_sea
    return 0;
 }
 
+/* §7 graph-informed delegation pulls the structural blast radius of referenced
+ * files into the delegate prompt; with no indexed project these no-op (the
+ * injector then fails open and adds no block). */
+int kb_client_index_list(project_info_t *out, int max)
+{
+   (void)out;
+   (void)max;
+   return 0;
+}
+
+int kb_client_index_blast_radius(const char *project, const char *file_path, blast_radius_t *out)
+{
+   (void)project;
+   (void)file_path;
+   (void)out;
+   return -1;
+}
+
 int kb_client_index_find(const char *identifier, term_hit_t *out, int max)
 {
    (void)identifier;


### PR DESCRIPTION
## Summary

Implements proposal **code-graph-intelligence §7** "graph-informed delegation": when dispatching a delegate, prepend a **`## Structural context (code graph)`** block listing the **callers (dependents)** and **dependencies** of the file paths the task references — so the delegate starts with the structural neighborhood / blast radius of any shared interface it's about to touch.

## Implementation

- **`delegate_inject_graph_context(prompt, cwd)`** (`server/delegate_prompt.c`): extracts referenced paths via the existing `delegate_extract_named_paths`, joins with `cwd`, and fetches each file's blast radius through the **shared** structural resolver `guardrails_blast_radius_for_abs_path` (the same one the §7 blast-radius advisory uses). Structural-only (call graph + projection edges, **never** the LLM entity graph — R1), bounded (≤6 files × 5 names each, 4 KB block).
- **Opt-in + fail-open**: gated on the new `delegate_graph_context_enabled` (default off); returns NULL (no block) on flag-off / no referenced paths / kb unreachable / no edges — never breaks dispatch.
- **Hooked** into `server_compute.c`'s delegate prompt assembly beside the existing code-context injector. Extracted the repeated append-ownership dance of the three injectors (code/graph/tier) into `delegate_append_owned_block()` — dedups and keeps `server_compute.c` under the 2000-line cap.
- **Config**: `delegate_graph_context_enabled` (flat key, 5-touch + `make docs-gen`).

## Tests

`test_delegate_dispatch_reliability`: block-with-edges (names callers + dependencies), disabled→NULL, no-referenced-paths→NULL, resolver-fail→NULL (fail-open). Stubs the structural resolver; drives the real `config_load` via a temp `AIMEE_HOME/aimee.yaml`. `make lint` / `line-check` / `docs-gen-check` green; server + binary build.

Part of the **code-graph-intelligence** proposal (§7 actuation — graph-informed delegation, the follow-up to the shipped blast-radius advisory).