### PR TITLE
feat(ingress): cache-prefix placement invariant for the Responses path (ingress-compression P3 §2)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (119)
+## CLI-settable keys (120)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -72,6 +72,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `guardrails_semantic_warn_threshold` | float | Semantic score threshold to warn. |
 | `identity_working_profile_injection_enabled` | bool | Inject the working-profile identity into prompts. |
 | `ingress_audit_async` | bool | Audit ingress requests asynchronously. |
+| `ingress_cache_placement_enabled` | bool | Append the <aimee-context> envelope after the stable instructions prefix (not before) so provider prefix caches survive (default off). |
 | `ingress_compress_enabled` | bool | Enable ingress envelope compression: span-enrich code hits and fold code entries into recoverable references (default off). |
 | `ingress_compress_min_chars` | int | Minimum code-snippet length (chars) before it is folded to a file:line reference (default 80). |
 | `ingress_max_raw_scans` | int | Max raw-content scans per ingress request. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -157,6 +157,8 @@ CFG_KEY_DESC = {
     "fold code entries into recoverable references (default off).",
     "ingress_compress_min_chars": "Minimum code-snippet length (chars) before it is folded to a "
     "file:line reference (default 80).",
+    "ingress_cache_placement_enabled": "Append the <aimee-context> envelope after the stable "
+    "instructions prefix (not before) so provider prefix caches survive (default off).",
     "ingress_trusted_proxy_secret": "Shared secret authenticating a trusted ingress proxy.",
     "ingress_usage_accounting_enabled": "Account token usage on ingress requests.",
     "integrity_dry_run": "Run integrity checks without enforcing.",

--- a/src/config.c
+++ b/src/config.c
@@ -850,6 +850,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_compress_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "ingress_cache_placement_enabled");
+   if (cJSON_IsBool(item))
+      cfg->ingress_cache_placement_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_compress_min_chars");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->ingress_compress_min_chars = (int)item->valuedouble;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -43,6 +43,8 @@ const config_field_t config_fields[] = {
      CFG_BOOL},
     {"ingress_compress_enabled", offsetof(config_t, ingress_compress_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"ingress_cache_placement_enabled", offsetof(config_t, ingress_cache_placement_enabled),
+     sizeof(int), 0, CFG_BOOL},
     {"ingress_compress_min_chars", offsetof(config_t, ingress_compress_min_chars), sizeof(int), 0,
      CFG_INT},
     {"gateway_prevent_subagents", offsetof(config_t, gateway_prevent_subagents), sizeof(int), 0,

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -784,6 +784,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
    if (cfg->ingress_compress_enabled)
       cJSON_AddBoolToObject(root, "ingress_compress_enabled", 1);
+   if (cfg->ingress_cache_placement_enabled)
+      cJSON_AddBoolToObject(root, "ingress_cache_placement_enabled", 1);
    if (cfg->ingress_compress_min_chars != 80)
       cJSON_AddNumberToObject(root, "ingress_compress_min_chars", cfg->ingress_compress_min_chars);
    if (cfg->gateway_prevent_subagents)

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -9,6 +9,7 @@
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
 {"ingress_compress_enabled", SCHEMA_BOOL, 0},
+{"ingress_cache_placement_enabled", SCHEMA_BOOL, 0},
 {"ingress_compress_min_chars", SCHEMA_INT, 0},
 {"gateway_prevent_subagents", SCHEMA_BOOL, 0},
 {"gateway_pin_model", SCHEMA_BOOL, 0},

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -350,6 +350,11 @@ typedef struct config
     * only when its snippet exceeds this many chars (folding a tiny snippet saves
     * nothing). Default 80. */
    int ingress_compress_min_chars;
+   /* ingress-compression P3 (§2 placement invariant), default off. When on, the
+    * volatile <aimee-context> envelope is appended AFTER the stable instructions
+    * prefix (instead of prepended) on the OpenAI/Codex Responses path, so the
+    * provider's automatic prefix cache is not invalidated each turn. */
+   int ingress_cache_placement_enabled;
    /* Session-isolation guard (opt-in): when on, the PreToolUse attention-guard
     * fails closed on a mutating tool whose target is NOT inside an aimee-managed
     * worktree (.aimee/worktrees/...), forcing every mutating session into an

--- a/src/headers/ingress_preinject.h
+++ b/src/headers/ingress_preinject.h
@@ -109,11 +109,22 @@ char *ingress_preinject_query_from_messages(const cJSON *messages);
  * confidence tier, and returns a malloc'd <aimee-context> envelope. */
 char *ingress_preinject_build(const char *query, int request_disabled);
 
-/* Prepend `envelope` to `instructions` (the request system prompt), returning a
- * fresh malloc'd string the caller frees. If envelope is NULL/blank, returns a
+/* Merge `envelope` with `instructions` (the request system prompt), returning a
+ * fresh malloc'd string the caller frees. Default: PREPENDS the envelope. When
+ * the cache-prefix placement lever (ingress_cache_placement_enabled, §2) is on,
+ * APPENDS it instead (delegates to ingress_preinject_append) so the stable
+ * instructions prefix stays cacheable. If envelope is NULL/blank, returns a
  * malloc'd copy of instructions (or NULL when instructions is also NULL). Does
- * not free its arguments. Pure. */
+ * not free its arguments. Reads config (the placement flag); not otherwise
+ * stateful. */
 char *ingress_preinject_apply(const char *instructions, const char *envelope);
+
+/* Cache-prefix placement variant (ingress-compression §2): APPEND `envelope`
+ * after `instructions` (stable prefix first, volatile envelope last) so the
+ * provider's automatic prefix cache is not invalidated by the per-turn envelope.
+ * Same contract as ingress_preinject_apply otherwise (malloc'd result; blank
+ * envelope → copy of instructions; pure). */
+char *ingress_preinject_append(const char *instructions, const char *envelope);
 
 /* Per-request override (thread-local): the HTTP layer sets this from the
  * `x-aimee-preinject: 0` request header before dispatching the turn, so a

--- a/src/server/gw_stage_memory.c
+++ b/src/server/gw_stage_memory.c
@@ -98,6 +98,11 @@ int gw_stage_memory(gw_request_t *r, void *ud)
       if (!env)
          return 0;
       cJSON *cur = cJSON_GetObjectItemCaseSensitive(r->raw, "instructions");
+      /* ingress_preinject_apply internally honors the cache-prefix placement lever
+       * (§2): default prepend, or append after the stable prefix when
+       * ingress_cache_placement_enabled. Keeping the choice inside the applier
+       * leaves this stage config-free (so every gw_stage_memory consumer links
+       * unchanged). */
       char *merged = ingress_preinject_apply(cur ? cur->valuestring : NULL, env);
       free(env);
       if (!merged)

--- a/src/server/ingress_preinject.c
+++ b/src/server/ingress_preinject.c
@@ -648,6 +648,16 @@ char *ingress_preinject_build(const char *query, int request_disabled)
 
 char *ingress_preinject_apply(const char *instructions, const char *envelope)
 {
+   /* Cache-prefix placement (§2): when the lever is on, place the volatile
+    * envelope AFTER the stable instructions prefix (append) instead of before
+    * (prepend), so the provider's automatic prefix cache survives the per-turn
+    * envelope. The choice lives here — not in the caller — so the gateway stage
+    * stays config-free and every consumer links unchanged. Default off => prepend
+    * (byte-identical to before). */
+   config_t cfg;
+   if (config_load(&cfg) == 0 && cfg.ingress_cache_placement_enabled)
+      return ingress_preinject_append(instructions, envelope);
+
    int env_blank = 1;
    if (envelope)
       for (const char *p = envelope; *p; p++)
@@ -666,5 +676,34 @@ char *ingress_preinject_apply(const char *instructions, const char *envelope)
    dstr_append_str(&d, "\n\n");
    if (instructions && instructions[0])
       dstr_append_str(&d, instructions);
+   return dstr_steal(&d);
+}
+
+char *ingress_preinject_append(const char *instructions, const char *envelope)
+{
+   int env_blank = 1;
+   if (envelope)
+      for (const char *p = envelope; *p; p++)
+         if (*p != ' ' && *p != '\t' && *p != '\n' && *p != '\r')
+         {
+            env_blank = 0;
+            break;
+         }
+
+   if (env_blank)
+      return instructions ? strdup(instructions) : NULL;
+
+   /* Cache-prefix placement (§2): the stable instructions prefix stays at the
+    * front and the volatile <aimee-context> envelope lands at the tail, so the
+    * provider's automatic prefix cache (OpenAI/Codex) is not invalidated by the
+    * per-turn envelope. Mirror of ingress_preinject_apply with the order flipped. */
+   dstr_t d;
+   dstr_init(&d);
+   if (instructions && instructions[0])
+   {
+      dstr_append_str(&d, instructions);
+      dstr_append_str(&d, "\n\n");
+   }
+   dstr_append_str(&d, envelope);
    return dstr_steal(&d);
 }

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -32,7 +32,7 @@ static const char *FIXTURE_A =
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
     "true\ningress_preinject_enabled: true\ningress_compress_enabled: "
-    "true\ngateway_prevent_subagents: "
+    "true\ningress_cache_placement_enabled: true\ngateway_prevent_subagents: "
     "true\ncss_style_graph_enabled: "
     "true\n"
     "ingress_preinject_assembly_budget: 1\n"
@@ -86,7 +86,7 @@ static const char *FIXTURE_B =
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
     "false\ningress_preinject_enabled: false\ningress_compress_enabled: "
-    "false\ngateway_prevent_subagents: "
+    "false\ningress_cache_placement_enabled: false\ngateway_prevent_subagents: "
     "false\ncss_style_graph_enabled: "
     "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
@@ -169,6 +169,7 @@ int main(void)
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
    assert(cfgA.ingress_compress_enabled == 1 && cfgB.ingress_compress_enabled == 0);
+   assert(cfgA.ingress_cache_placement_enabled == 1 && cfgB.ingress_cache_placement_enabled == 0);
    assert(cfgA.gateway_prevent_subagents == 1 && cfgB.gateway_prevent_subagents == 0);
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -26,6 +26,7 @@
 /* When set, the recall stubs return nothing so ingress_preinject_build → NULL
  * (the "pre-injection off / recall empty" path). */
 static int g_no_recall = 0;
+static int g_test_placement = 0; /* drives ingress_cache_placement_enabled in config_load stub */
 
 /* --- stubs: make ingress_preinject_build deterministic without the kb graph --- */
 char *kb_client_memory_context_block(const char *query, const char *block_type, int limit)
@@ -74,6 +75,7 @@ int config_load(config_t *cfg)
       memset(cfg, 0, sizeof(*cfg));
       cfg->ingress_preinject_enabled = 1;
       cfg->ingress_preinject_assembly_budget = 1200;
+      cfg->ingress_cache_placement_enabled = g_test_placement;
    }
    return 0;
 }
@@ -90,6 +92,20 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
    (void)query_fingerprint;
    (void)ids;
    (void)n_ids;
+   return 0;
+}
+int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
+                                             const char *query_fingerprint,
+                                             const char *const *types, const char *const *refs,
+                                             const char *const *versions, int n)
+{
+   (void)turn_id;
+   (void)role;
+   (void)query_fingerprint;
+   (void)types;
+   (void)refs;
+   (void)versions;
+   (void)n;
    return 0;
 }
 /* FIXED (not varying): the envelope must render identically across two build()
@@ -231,12 +247,50 @@ static void test_disabled_noop(void)
    printf("disabled_noop OK\n");
 }
 
+/* Cache-prefix placement (§2): with ingress_cache_placement_enabled on, the
+ * OPENAI_INSTRUCTIONS arm APPENDS the envelope after the stable prior prefix
+ * (prior + "\n\n" + env) instead of prepending — so the provider prefix cache is
+ * not invalidated by the per-turn envelope. */
+static void test_instructions_placement_appends(void)
+{
+   cJSON *messages = cJSON_Parse("[{\"role\":\"user\",\"content\":\"deploy matrix\"}]");
+   char *q = ingress_preinject_query_from_messages(messages);
+   char *env = ingress_preinject_build(q, 0);
+   char *prepended = ingress_preinject_apply("PRIOR SYS", env); /* env first (off) */
+   char *appended = ingress_preinject_append("PRIOR SYS", env); /* env last (on)  */
+   assert(env && prepended && appended);
+   assert(strcmp(prepended, appended) != 0); /* order differs */
+
+   g_test_placement = 1;
+   cJSON *raw = cJSON_CreateObject();
+   cJSON_AddStringToObject(raw, "instructions", "PRIOR SYS");
+   gw_request_t r = {.raw = raw,
+                     .serving_api = GW_API_OPENAI,
+                     .mem_target = GW_MEM_OPENAI_INSTRUCTIONS,
+                     .parity = 1};
+   int rc = gw_stage_memory(&r, messages);
+   assert(rc == 1);
+   /* stable prefix stays at the front; envelope is the volatile suffix */
+   assert(strcmp(instr_of(raw), appended) == 0);
+   assert(strncmp(instr_of(raw), "PRIOR SYS", 9) == 0);
+   g_test_placement = 0;
+
+   free(q);
+   free(env);
+   free(prepended);
+   free(appended);
+   cJSON_Delete(raw);
+   cJSON_Delete(messages);
+   printf("instructions_placement_appends OK\n");
+}
+
 int main(void)
 {
    printf("test_gw_stage_memory:\n");
    test_system_prompt_raw_env();
    test_instructions_merge_with_prior();
    test_instructions_no_prior();
+   test_instructions_placement_appends();
    test_anthropic_parity_gate();
    test_disabled_noop();
    printf("all gw_stage_memory tests passed\n");

--- a/src/tests/test_ingress_preinject.c
+++ b/src/tests/test_ingress_preinject.c
@@ -103,6 +103,20 @@ int kb_client_evidence_emit_retrieval_event(const char *turn_id, const char *rol
    (void)n_ids;
    return 0;
 }
+int kb_client_evidence_merge_retrieval_event(const char *turn_id, const char *role,
+                                             const char *query_fingerprint,
+                                             const char *const *types, const char *const *refs,
+                                             const char *const *versions, int n)
+{
+   (void)turn_id;
+   (void)role;
+   (void)query_fingerprint;
+   (void)types;
+   (void)refs;
+   (void)versions;
+   (void)n;
+   return 0;
+}
 /* Stub: deterministic but varying-per-call, so the mint-uniqueness assertion
  * holds without linking the platform layer into this pure unit test. */
 int platform_random_bytes(void *buf, size_t len)
@@ -200,6 +214,30 @@ static void test_apply(void)
    assert(o && strstr(o, "ENV") == o);
    free(o);
    printf("apply OK\n");
+}
+
+/* Cache-prefix placement (§2): append puts the stable instructions first and the
+ * volatile envelope last (mirror of apply). */
+static void test_append(void)
+{
+   /* NULL/blank envelope -> copy of instructions (or NULL). */
+   char *a = ingress_preinject_append("SYS", NULL);
+   assert(a && strcmp(a, "SYS") == 0);
+   free(a);
+   assert(ingress_preinject_append(NULL, NULL) == NULL);
+
+   /* Instructions first, envelope appended, separated by a blank line. */
+   char *m = ingress_preinject_append("SYSTEM PROMPT", "<aimee-context>...</aimee-context>");
+   assert(m != NULL);
+   assert(strstr(m, "SYSTEM PROMPT") == m);                       /* prefix stays at front */
+   assert(strstr(m, "SYSTEM PROMPT\n\n<aimee-context>") != NULL); /* envelope is the suffix */
+   free(m);
+
+   /* NULL instructions -> just the envelope. */
+   char *o = ingress_preinject_append(NULL, "ENV");
+   assert(o && strcmp(o, "ENV") == 0);
+   free(o);
+   printf("append OK\n");
 }
 
 static void test_format_code_block(void)
@@ -414,6 +452,7 @@ int main(void)
    test_format_code_block();
    test_query_from_messages();
    test_apply();
+   test_append();
    test_render_block();
    test_budgeted_build_uses_memory_previews();
    test_turn_id_mint_and_thread_local();


### PR DESCRIPTION
## What

P3 (§2) — the **placement invariant**. When `ingress_cache_placement_enabled` is on, the volatile `<aimee-context>` envelope is **appended after** the stable `instructions` prefix on the OpenAI/Codex Responses path instead of prepended, so the provider's automatic longest-prefix cache is not invalidated by the per-turn envelope. Default **off** → byte-identical to before.

## Scope (reconciled with the live tree)

The proposal's "5 `openai_chat.c` sites" were already consolidated by the universal-gateway refactor into one seam, `gw_stage_memory.c`. Anthropic already implements placement (splits at the `<aimee-context` marker via `cache_shaping_enabled`). OpenAI/Codex caching is automatic longest-prefix, so **placement — not marking — is the only lever** there; this PR owns only the placement invariant and adds **no duplicate cache-marking flag** (marking + ledger belong to the cost-accounting proposal). The realized `cache_read`/`cache_creation` effect is measured by the §6 bench (`ingress_token_bench --mode compress`, #748) which reads `token_tracker` directly.

## Changes

- **`ingress_preinject_append(instructions, envelope)`** — the suffix mirror of `ingress_preinject_apply` (stable prefix first, envelope last; same blank/NULL contract).
- **`gw_stage_memory`** Responses `instructions` arm: chooses append vs prepend on `cfg.ingress_cache_placement_enabled`; fail-safe to prepend if config load fails.
- **Config `ingress_cache_placement_enabled`** (bool, default off) — full surface.
- **Tests**: `gw_stage_memory` placement-on case (envelope is the suffix, prefix stays at front); a direct `ingress_preinject_append` unit test; config-surface coverage.

## Deferred follow-up

`agent_execute_messages()` `payload_rewrite` session-scoped prefix tracking (§2.5) and chat/completions placement — the §6 bench measures realized cache without the tracker, and the Responses `instructions` arm is the primary Codex seam.

## Review

Dedicated correctness pass: default-off byte-identical (same `prior` arg, fail-safe to prepend, existing prepend test unchanged), `append` edge cases (blank/NULL/empty instructions, no dangling separator, no leak), gw_stage_memory ownership (no UAF — `prior` read into `merged` before the Replace) all confirmed clean.