### PR TITLE
feat(kb): route failure-mined recurrences through the learning pipeline (ingress-compression P4 §4)

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -567,6 +567,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->kb_maintenance_orphan_days = 90;
    cfg->kb_mining_enabled = 1;
    cfg->kb_mining_min_poll_s = 300;
+   cfg->kb_mining_failure_learning_enabled = 0;
    cfg->review_scheduler_enabled = 0;
    cfg->review_idle_trigger_minutes = 30;
    cfg->review_session_cooldown_hours = 24;

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1339,6 +1339,9 @@ void config_parse_kb_section2(config_t *cfg, cJSON *root)
          item = cJSON_GetObjectItemCaseSensitive(mining, "min_poll_s");
          if (cJSON_IsNumber(item) && item->valuedouble > 0)
             cfg->kb_mining_min_poll_s = (int)item->valuedouble;
+         item = cJSON_GetObjectItemCaseSensitive(mining, "failure_learning_enabled");
+         if (cJSON_IsBool(item))
+            cfg->kb_mining_failure_learning_enabled = cJSON_IsTrue(item) ? 1 : 0;
       }
 
       /* §5 hybrid retrieval per-signal RRF weights + rank constant. */

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1274,6 +1274,11 @@ typedef struct config
     * kb_mining_min_poll_s: minimum seconds between scheduler ticks (default 300). */
    int kb_mining_enabled;
    int kb_mining_min_poll_s;
+   /* kb_mining_failure_learning_enabled (ingress-compression §4, default off):
+    * route the recurrence job's failure clusters through the learning pipeline
+    * (signal -> reviewed proposal -> Gate-Promote -> artifact) instead of writing
+    * a workflow_pattern artifact directly. JSON key kb.mining.failure_learning_enabled. */
+   int kb_mining_failure_learning_enabled;
 
    /* Trigger endpoint (event-triggered-autopilot) */
    char trigger_auth_token[256];

--- a/src/kb/kb_mining.c
+++ b/src/kb/kb_mining.c
@@ -11,6 +11,8 @@
 #include "cJSON.h"
 #include "config.h"
 #include "db2/artifacts.h"
+#include "db2/learning.h"
+#include "learning.h"
 #include "db2/db2_internal.h"
 #include "db2/db_postgres.h"
 #include "db2/feature_rows.h"
@@ -214,6 +216,17 @@ static int run_pattern_cluster(int64_t hwm, int64_t *new_hwm_out)
    return rc;
 }
 
+/* Format a UTC "YYYY-MM-DD HH:MM:SS" timestamp `days` days from now, for a
+ * learning proposal's expires_at (the §4 failure-learning path). */
+static void recurrence_expiry(int days, char *buf, size_t len)
+{
+   time_t now = time(NULL);
+   time_t future = now + (time_t)days * 24 * 60 * 60;
+   struct tm tmv;
+   gmtime_r(&future, &tmv);
+   strftime(buf, len, "%Y-%m-%d %H:%M:%S", &tmv);
+}
+
 static int propose_recurrence(const char *role, const char *failure_mode, int evidence_count,
                               int session_count, int64_t max_event_id)
 {
@@ -261,6 +274,65 @@ static int propose_recurrence(const char *role, const char *failure_mode, int ev
    cJSON_Delete(payload);
    if (!json)
       return -1;
+
+   /* ingress-compression §4: when failure-learning is enabled, route the cluster
+    * through the learning pipeline (signal -> reviewed/Gate-Promoted proposal ->
+    * artifact) instead of writing the workflow_pattern artifact directly. Dedup on
+    * the event_type:role:failure_mode cluster so the same recurrence corroborates
+    * an existing pending proposal rather than spamming new ones (and never produces
+    * both a direct artifact and a proposal for one cluster). */
+   {
+      config_t lcfg;
+      config_load(&lcfg);
+      if (lcfg.kb_mining_failure_learning_enabled)
+      {
+         char target_key[256];
+         snprintf(target_key, sizeof(target_key), "delegate_exit:%s:%s", role ? role : "",
+                  failure_mode ? failure_mode : "");
+         int existing = db2_learning_proposal_find_pending("artifact", target_key, 0);
+         if (existing > 0)
+         {
+            db2_learning_proposal_bump_corroboration(existing);
+            free(json);
+            return 0;
+         }
+         cJSON *action = cJSON_CreateObject();
+         if (action)
+         {
+            cJSON_AddStringToObject(action, "artifact_id", id);
+            cJSON_AddStringToObject(action, "artifact_kind", "workflow_pattern");
+            cJSON_AddStringToObject(action, "scope_kind", "workspace");
+            cJSON_AddNumberToObject(action, "confidence", confidence);
+            cJSON_AddStringToObject(action, "payload_json", json);
+            char *action_json = cJSON_PrintUnformatted(action);
+            cJSON_Delete(action);
+            if (action_json)
+            {
+               learning_signal_input_t sig;
+               memset(&sig, 0, sizeof(sig));
+               snprintf(sig.signal_type, sizeof(sig.signal_type), "recurrence_failure");
+               snprintf(sig.source, sizeof(sig.source), "kb-mining");
+               snprintf(sig.title, sizeof(sig.title), "%s", title);
+               snprintf(sig.description, sizeof(sig.description),
+                        "Recurring %s in role %s: %d events across %d sessions",
+                        failure_mode && failure_mode[0] ? failure_mode : "delegate failure",
+                        role && role[0] ? role : "unknown", evidence_count, session_count);
+               snprintf(sig.target_key, sizeof(sig.target_key), "%s", target_key);
+               int sigid = db2_learning_signal_insert(&sig, "");
+               if (sigid > 0)
+               {
+                  char expires[32];
+                  recurrence_expiry(30, expires, sizeof(expires));
+                  (void)db2_learning_proposal_insert(sigid, "artifact", target_key, 0, action_json,
+                                                     NULL, expires);
+               }
+               free(action_json);
+            }
+         }
+         free(json);
+         return 0;
+      }
+   }
 
    int rc = db2_artifact_write(id, "workflow_pattern", "proposed", "workspace", "", "kb-mining",
                                confidence, json);

--- a/src/learning_router.c
+++ b/src/learning_router.c
@@ -2,6 +2,7 @@
 #include "aimee.h"
 #if !defined(AIMEE_DB2_DISABLED)
 #include "db1.h"
+#include "db2/artifacts.h"
 #include "db2/collab_rules.h"
 #include "db2/learning.h"
 #include "dogfood.h"
@@ -187,6 +188,25 @@ static int learning_apply_sink(const learning_proposal_t *proposal)
                                      session_id()) > 0
                   ? 0
                   : -1;
+   }
+   else if (strcmp(proposal->sink, "artifact") == 0)
+   {
+      /* ingress-compression §4: a failure-mined recurrence proposal commits to the
+       * durable artifact it carried (e.g. workflow_pattern) only after review /
+       * Gate-Promote, instead of kb_mining writing it directly. */
+      cJSON *jid = cJSON_GetObjectItemCaseSensitive(action, "artifact_id");
+      cJSON *jkind = cJSON_GetObjectItemCaseSensitive(action, "artifact_kind");
+      cJSON *jscope = cJSON_GetObjectItemCaseSensitive(action, "scope_kind");
+      cJSON *jpayload = cJSON_GetObjectItemCaseSensitive(action, "payload_json");
+      cJSON *jconf = cJSON_GetObjectItemCaseSensitive(action, "confidence");
+      if (!cJSON_IsString(jid) || !jid->valuestring[0] || !cJSON_IsString(jkind) ||
+          !jkind->valuestring[0] || !cJSON_IsString(jpayload) || !jpayload->valuestring[0])
+         rc = -1;
+      else
+         rc = db2_artifact_write(
+             jid->valuestring, jkind->valuestring, "proposed",
+             cJSON_IsString(jscope) ? jscope->valuestring : "workspace", "", "kb-mining-learning",
+             cJSON_IsNumber(jconf) ? jconf->valuedouble : 0.5, jpayload->valuestring);
    }
 
    cJSON_Delete(action);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1677,6 +1677,7 @@ $(TESTPREFIX)/unit-test-kb-mining: $(OBJDIR)/tests/test_kb_mining.o \
                              $(OBJDIR)/db2/mining.o $(OBJDIR)/db2/artifacts.o \
                              $(OBJDIR)/db2/feature_rows.o \
                              $(OBJDIR)/learning_evidence.o $(OBJDIR)/db2/learning_synth_ops.o \
+                             $(OBJDIR)/db2/learning.o \
                              $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o $(OBJDIR)/db2/db_schema.o \
                              $(OBJDIR)/db2/feedback.o \
                              $(TEST_CORE_OBJS)

--- a/src/tests/test_kb_mining.c
+++ b/src/tests/test_kb_mining.c
@@ -1,6 +1,7 @@
 /* test_kb_mining.c: KB continuous mining scheduler/jobs. */
 
 #include "artifacts.h"
+#include "db2/learning.h"
 #include "db2_test_shim.h"
 #include "db_postgres.h"
 #include "db2_internal.h"
@@ -9,7 +10,9 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 
 static void open_db(void)
 {
@@ -138,6 +141,53 @@ static void test_job_interval_is_respected(void)
    printf("  job_interval_is_respected: ok\n");
 }
 
+/* ingress-compression §4: with kb.mining.failure_learning_enabled on, the
+ * recurrence job emits a *pending learning proposal* (sink=artifact) instead of
+ * writing the workflow_pattern artifact directly — the artifact appears only after
+ * review/Gate-Promote commits the proposal. A repeat cluster corroborates the same
+ * pending proposal rather than producing a second one. */
+static void test_recurrence_routes_to_learning_when_enabled(void)
+{
+   /* Enable the flag via an AIMEE_HOME-scoped config the real config_load reads. */
+   char home[] = "/tmp/kbmining_fl_XXXXXX";
+   assert(mkdtemp(home));
+   char yaml[256];
+   snprintf(yaml, sizeof(yaml), "%s/aimee.yaml", home);
+   FILE *f = fopen(yaml, "w");
+   assert(f);
+   fputs("kb:\n  mining:\n    failure_learning_enabled: true\n", f);
+   fclose(f);
+   setenv("AIMEE_HOME", home, 1);
+
+   open_db();
+   for (int i = 1; i <= 5; i++)
+   {
+      char session[32];
+      snprintf(session, sizeof(session), "sess-%d", (i % 3) + 1);
+      seed_event(i, session, "delegate_exit", "code", "stall/no-writes", "");
+   }
+
+   assert(kb_mining_run_once() >= 1);
+   /* Routed through learning: NO direct artifact, but a pending proposal exists. */
+   assert(db2_artifact_count("workflow_pattern", "proposed") == 0);
+   int pid =
+       db2_learning_proposal_find_pending("artifact", "delegate_exit:code:stall/no-writes", 0);
+   assert(pid > 0);
+
+   /* A second tick on the same cluster corroborates the same proposal (no second
+    * proposal, still no artifact). Re-seed a fresh event past the high-watermark. */
+   seed_event(6, "sess-1", "delegate_exit", "code", "stall/no-writes", "");
+   assert(kb_mining_run_once() >= 0);
+   assert(db2_artifact_count("workflow_pattern", "proposed") == 0);
+   int pid2 =
+       db2_learning_proposal_find_pending("artifact", "delegate_exit:code:stall/no-writes", 0);
+   assert(pid2 == pid); /* same pending proposal, corroborated */
+
+   close_db();
+   unsetenv("AIMEE_HOME");
+   printf("  recurrence_routes_to_learning_when_enabled: ok\n");
+}
+
 int main(void)
 {
    test_seed_defaults();
@@ -145,6 +195,7 @@ int main(void)
    test_pattern_cluster_proposes_interaction_pattern();
    test_disabled_job_is_skipped();
    test_job_interval_is_respected();
+   test_recurrence_routes_to_learning_when_enabled();
    printf("kb_mining: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

P4 (§4) — failure-mined corrections as **learning signals, not direct writes**. The `kb_mining` recurrence job clusters repeated delegate failures (`interaction_event_embeddings`, role + failure_mode) and today writes a `workflow_pattern` artifact **directly**. This routes that finding through the existing learning pipeline — **signal → reviewed/Gate-Promoted proposal → artifact** — so a failure correction is human/Gate-Promote-reviewed before it becomes durable (the §4.3 "signal, not a file" advantage over headroom).

Gated by `kb.mining.failure_learning_enabled` (default **off**); when off the job writes the artifact directly exactly as before (existing behavior grandfathered).

## Changes

- **`propose_recurrence`** (`kb_mining.c`): when the flag is on, dedup on the `event_type:role:failure_mode` cluster via `db2_learning_proposal_find_pending` — bump corroboration on a repeat, else emit `db2_learning_signal_insert` + `db2_learning_proposal_insert` (sink `artifact`, `target_key` `delegate_exit:<role>:<failure_mode>`, `action_json` carrying the `workflow_pattern` payload). **No direct artifact write on this path**, so one cluster never produces both an artifact and a proposal (§4.4 / §8 duplicate-output risk).
- **`learning_apply_sink`** (`learning_router.c`): new `artifact` sink commits the carried `workflow_pattern` via `db2_artifact_write` only when the proposal is accepted / auto-committed (review/Gate-Promote).
- **Config** `kb_mining_failure_learning_enabled` (default off), JSON `kb.mining.failure_learning_enabled` — nested like `kb_mining_enabled` (no CLI/docs surface, matching the sibling).

## Tests

`test_kb_mining` gains a flag-on case (AIMEE_HOME-scoped config the real `config_load` reads): asserts the recurrence emits a **pending proposal and NO direct artifact**, and that a repeat cluster **corroborates the same proposal** (no duplicate). The default-off artifact test is unchanged. `test_feedback` / `test_learning_metrics` (router) still pass.

## Review

Default-off grandfathers the existing direct-artifact behavior; the learning path reuses the pipeline's dedup/corroboration/review/Gate-Promote machinery; the artifact is written only on commit. `db2/learning.o` added to the test link.