### PR TITLE
feat(kb): §4 surprising-links analytical core (BFS distance + percentile filter)

### DIFF
--- a/src/kb/kb_graph_analytics.c
+++ b/src/kb/kb_graph_analytics.c
@@ -92,3 +92,144 @@ int kb_graph_hubs(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out
    free(acc);
    return w;
 }
+
+/* ── §4 surprising links ───────────────────────────────────────────────────── */
+
+int kb_graph_shortest_hops(const kb_graph_edge_t *edges, int n_edges, const char *src,
+                           const char *dst)
+{
+   if (!src || !src[0] || !dst || !dst[0])
+      return -1;
+   if (strcmp(src, dst) == 0)
+      return 0;
+   if (!edges || n_edges <= 0)
+      return -1;
+
+   char(*visited)[KB_GRAPH_NODE_MAX] = malloc((size_t)KB_GRAPH_BFS_MAX_NODES * KB_GRAPH_NODE_MAX);
+   int *depth = malloc((size_t)KB_GRAPH_BFS_MAX_NODES * sizeof(int));
+   if (!visited || !depth)
+   {
+      free(visited);
+      free(depth);
+      return -1;
+   }
+
+   int head = 0, tail = 0, result = -1;
+   snprintf(visited[tail], KB_GRAPH_NODE_MAX, "%s", src);
+   depth[tail] = 0;
+   tail++;
+
+   while (head < tail)
+   {
+      char cur[KB_GRAPH_NODE_MAX];
+      snprintf(cur, sizeof(cur), "%s", visited[head]);
+      int d = depth[head];
+      head++;
+      for (int e = 0; e < n_edges; e++)
+      {
+         const char *nbr = NULL;
+         if (edges[e].source[0] && strcmp(edges[e].source, cur) == 0)
+            nbr = edges[e].target;
+         else if (edges[e].target[0] && strcmp(edges[e].target, cur) == 0)
+            nbr = edges[e].source;
+         if (!nbr || !nbr[0])
+            continue;
+         if (strcmp(nbr, dst) == 0)
+         {
+            result = d + 1;
+            goto done;
+         }
+         int seen = 0;
+         for (int v = 0; v < tail; v++)
+            if (strcmp(visited[v], nbr) == 0)
+            {
+               seen = 1;
+               break;
+            }
+         if (seen)
+            continue;
+         if (tail >= KB_GRAPH_BFS_MAX_NODES)
+            goto done; /* explored the cap — treat as far/disconnected */
+         snprintf(visited[tail], KB_GRAPH_NODE_MAX, "%s", nbr);
+         depth[tail] = d + 1;
+         tail++;
+      }
+   }
+done:
+   free(visited);
+   free(depth);
+   return result;
+}
+
+static int surprising_dbl_cmp_asc(const void *a, const void *b)
+{
+   double x = *(const double *)a, y = *(const double *)b;
+   return (x > y) - (x < y);
+}
+
+static int surprising_cmp(const void *pa, const void *pb)
+{
+   const kb_graph_surprising_t *a = pa, *b = pb;
+   if (a->cosine != b->cosine)
+      return a->cosine < b->cosine ? 1 : -1; /* cosine desc */
+   int ah = a->hops < 0 ? INT_MAX : a->hops; /* disconnected ranks as farthest */
+   int bh = b->hops < 0 ? INT_MAX : b->hops;
+   if (ah != bh)
+      return ah < bh ? 1 : -1; /* hops desc */
+   int c = strcmp(a->a, b->a);
+   if (c)
+      return c;
+   return strcmp(a->b, b->b);
+}
+
+int kb_graph_surprising(const kb_graph_edge_t *edges, int n_edges, const kb_graph_pair_t *pairs,
+                        int n_pairs, double sim_percentile, int d_min, kb_graph_surprising_t *out,
+                        int max)
+{
+   if (!pairs || n_pairs <= 0 || !out || max <= 0 || sim_percentile < 0.0 || sim_percentile > 1.0)
+      return -1;
+   if (d_min < 1)
+      d_min = 1;
+
+   /* Data-driven similarity floor: the sim_percentile-th value of the candidates'
+    * OWN cosine distribution (not a hardcoded constant — R1). */
+   double *cosv = malloc((size_t)n_pairs * sizeof(double));
+   if (!cosv)
+      return -1;
+   for (int i = 0; i < n_pairs; i++)
+      cosv[i] = pairs[i].cosine;
+   qsort(cosv, (size_t)n_pairs, sizeof(double), surprising_dbl_cmp_asc);
+   int idx = (int)(sim_percentile * (double)(n_pairs - 1));
+   if (idx < 0)
+      idx = 0;
+   if (idx >= n_pairs)
+      idx = n_pairs - 1;
+   double threshold = cosv[idx];
+   free(cosv);
+
+   kb_graph_surprising_t *cand = malloc((size_t)n_pairs * sizeof(*cand));
+   if (!cand)
+      return -1;
+   int nc = 0;
+   for (int i = 0; i < n_pairs; i++)
+   {
+      if (!pairs[i].a[0] || !pairs[i].b[0] || strcmp(pairs[i].a, pairs[i].b) == 0)
+         continue;
+      if (pairs[i].cosine < threshold)
+         continue;
+      int h = kb_graph_shortest_hops(edges, n_edges, pairs[i].a, pairs[i].b);
+      if (h >= 0 && h < d_min)
+         continue; /* structurally close — not surprising */
+      snprintf(cand[nc].a, KB_GRAPH_NODE_MAX, "%s", pairs[i].a);
+      snprintf(cand[nc].b, KB_GRAPH_NODE_MAX, "%s", pairs[i].b);
+      cand[nc].cosine = pairs[i].cosine;
+      cand[nc].hops = h;
+      nc++;
+   }
+   qsort(cand, (size_t)nc, sizeof(*cand), surprising_cmp);
+   int n = nc < max ? nc : max;
+   for (int i = 0; i < n; i++)
+      out[i] = cand[i];
+   free(cand);
+   return n;
+}

--- a/src/kb/kb_graph_analytics.h
+++ b/src/kb/kb_graph_analytics.h
@@ -41,4 +41,46 @@ typedef struct
  * allocates caller-visible memory; out[] is caller-owned. */
 int kb_graph_hubs(const kb_graph_edge_t *edges, int n_edges, kb_graph_hub_t *out, int max);
 
+/* ── §4 surprising links (high embedding similarity AND high graph distance) ──── */
+
+/* A candidate node pair + its embedding cosine similarity. `a`/`b` are node ids
+ * in the SAME space as the edges' source/target (so hop distance is meaningful). */
+typedef struct
+{
+   char a[KB_GRAPH_NODE_MAX];
+   char b[KB_GRAPH_NODE_MAX];
+   double cosine;
+} kb_graph_pair_t;
+
+/* A surprising link: semantically close yet structurally far (or disconnected). */
+typedef struct
+{
+   char a[KB_GRAPH_NODE_MAX];
+   char b[KB_GRAPH_NODE_MAX];
+   double cosine;
+   int hops; /* undirected shortest-path hops over the edges; -1 = disconnected */
+} kb_graph_surprising_t;
+
+/* Bound on BFS exploration so a huge graph can't blow time/space (the result is a
+ * conservative "far enough" past this — counted as disconnected). */
+#define KB_GRAPH_BFS_MAX_NODES 4096
+
+/* Undirected shortest-path hop count between `src` and `dst` over `edges` (BFS,
+ * treating each edge as bidirectional). Returns 0 if src==dst, the hop count if
+ * reachable within KB_GRAPH_BFS_MAX_NODES explored nodes, or -1 if disconnected /
+ * either endpoint is absent / a bad argument. Pure (internal scratch only). */
+int kb_graph_shortest_hops(const kb_graph_edge_t *edges, int n_edges, const char *src,
+                           const char *dst);
+
+/* Surprising-links filter (§4, R1-precise). From candidate `pairs`, keep those
+ * whose cosine is at/above the `sim_percentile` (0..1) of the candidates' OWN
+ * cosine distribution (data-driven, not a hardcoded constant) AND whose
+ * structural hop-distance is >= `d_min` OR disconnected. Writes up to `max`,
+ * ordered by cosine desc, tie-broken by larger hops (disconnected ranks highest)
+ * then a asc then b asc (deterministic). Returns the count written, 0 if none
+ * qualify, -1 on a bad argument. Pure; out[] is caller-owned. */
+int kb_graph_surprising(const kb_graph_edge_t *edges, int n_edges, const kb_graph_pair_t *pairs,
+                        int n_pairs, double sim_percentile, int d_min, kb_graph_surprising_t *out,
+                        int max);
+
 #endif /* KB_GRAPH_ANALYTICS_H */

--- a/src/tests/test_kb_graph_analytics.c
+++ b/src/tests/test_kb_graph_analytics.c
@@ -115,6 +115,59 @@ static void test_bad_args(void)
    printf("  test_bad_args: ok\n");
 }
 
+/* ── §4 surprising-links ─────────────────────────────────────────────────── */
+
+static void test_shortest_hops_chain(void)
+{
+   /* a — b — c — d — e (directed edges; hop distance is UNDIRECTED). */
+   kb_graph_edge_t edges[] = {{"a", "b", 1}, {"b", "c", 1}, {"c", "d", 1}, {"d", "e", 1}};
+   assert(kb_graph_shortest_hops(edges, 4, "a", "a") == 0);
+   assert(kb_graph_shortest_hops(edges, 4, "a", "b") == 1);
+   assert(kb_graph_shortest_hops(edges, 4, "a", "e") == 4);
+   assert(kb_graph_shortest_hops(edges, 4, "e", "a") == 4); /* undirected */
+   assert(kb_graph_shortest_hops(edges, 4, "a", "absent") == -1);
+   printf("  test_shortest_hops_chain: ok\n");
+}
+
+static void test_shortest_hops_disconnected(void)
+{
+   kb_graph_edge_t edges[] = {{"a", "b", 1}, {"x", "y", 1}}; /* two components */
+   assert(kb_graph_shortest_hops(edges, 2, "a", "y") == -1);
+   assert(kb_graph_shortest_hops(edges, 2, "a", "b") == 1);
+   printf("  test_shortest_hops_disconnected: ok\n");
+}
+
+static void test_surprising_picks_far_high_sim(void)
+{
+   kb_graph_edge_t edges[] = {{"a", "b", 1}, {"b", "c", 1}, {"c", "d", 1}, {"d", "e", 1}};
+   /* sorted cosines [0.50,0.90,0.92,0.95]; p=0.5 -> idx 1 -> threshold 0.90. */
+   kb_graph_pair_t pairs[] = {
+       {"a", "e", 0.95}, /* hops 4 (far)        -> surprising      */
+       {"a", "b", 0.92}, /* hops 1 (adjacent)   -> NOT surprising  */
+       {"a", "z", 0.90}, /* disconnected        -> surprising      */
+       {"a", "c", 0.50}, /* below sim percentile -> excluded       */
+   };
+   kb_graph_surprising_t out[8];
+   int n = kb_graph_surprising(edges, 4, pairs, 4, 0.5, 4, out, 8);
+   assert(n == 2);
+   assert(strcmp(out[0].a, "a") == 0 && strcmp(out[0].b, "e") == 0 && out[0].hops == 4);
+   assert(strcmp(out[1].b, "z") == 0 && out[1].hops == -1); /* disconnected */
+   /* cosine-desc ordering: 0.95 before 0.90 */
+   assert(out[0].cosine > out[1].cosine);
+   printf("  test_surprising_picks_far_high_sim: ok\n");
+}
+
+static void test_surprising_bad_args(void)
+{
+   kb_graph_edge_t edges[] = {{"a", "b", 1}};
+   kb_graph_pair_t pairs[] = {{"a", "b", 0.9}};
+   kb_graph_surprising_t out[4];
+   assert(kb_graph_surprising(edges, 1, NULL, 1, 0.5, 4, out, 4) == -1);
+   assert(kb_graph_surprising(edges, 1, pairs, 1, 0.5, 4, NULL, 4) == -1);
+   assert(kb_graph_surprising(edges, 1, pairs, 1, 1.5, 4, out, 4) == -1); /* percentile OOR */
+   printf("  test_surprising_bad_args: ok\n");
+}
+
 int main(void)
 {
    printf("test_kb_graph_analytics:\n");
@@ -124,6 +177,10 @@ int main(void)
    test_truncation();
    test_empty_endpoints();
    test_bad_args();
+   test_shortest_hops_chain();
+   test_shortest_hops_disconnected();
+   test_surprising_picks_far_high_sim();
+   test_surprising_bad_args();
    printf("ALL PASS\n");
    return 0;
 }


### PR DESCRIPTION
## Summary

The pure, deterministic analytical core for proposal **code-graph-intelligence §4 "surprising links"** — pairs `(a,b)` with **high embedding similarity AND high structural graph distance** (the "only computable because aimee has vectors" signal). Follows the proven pure-core-first pattern (`kb_rrf` #733 → route #734).

## Implementation (`kb/kb_graph_analytics.{c,h}`)

- **`kb_graph_shortest_hops`** — undirected BFS hop distance between two nodes over the projection edges: `0` if same, the hop count if reachable (bounded by `KB_GRAPH_BFS_MAX_NODES`), `-1` if disconnected / a node is absent.
- **`kb_graph_surprising`** — the R1-precise filter: keeps candidate pairs whose cosine is at/above the **`sim_percentile`-th value of the candidates' OWN cosine distribution** (data-driven, *not* a hardcoded constant) **AND** whose structural hop-distance is `>= d_min` OR disconnected. Deterministic ordering (cosine desc, then hops desc with disconnected farthest, then `a`/`b` asc).

Pure — no DB/network; internal scratch only; reused later by the route.

## Tests (`unit-test-kb-graph-analytics`)

Chain / undirected / disconnected hop distance; the percentile+distance selection (a far high-sim pair and a disconnected high-sim pair qualify; a structurally-adjacent high-sim pair and a low-sim pair are excluded); deterministic ordering; bad-args.

> The route (`/v1/code/graph/surprising`) — gathering high-similarity candidate pairs via a pgvec pairwise self-search, the embedding-node ↔ projection-graph-node identity mapping, and §4's LLM-judge confirmation + sampled-precision self-suppress — is the follow-up. It needs the deployed corpus to verify the node-identity mapping, so the load-bearing, deterministic algorithm ships first (unit-testable without the embedder), exactly as the RRF core did.

Part of the **code-graph-intelligence** proposal (§4 analytics).