### PR TITLE
feat(kb): read-only /v1/code/graph node-projection route (P8 §8)

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -1,9 +1,10 @@
 # Proposal: Code-graph intelligence — a living, embedded, reasoning graph over code
 
-- **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7 implemented (on the `testing` branch);
-  including the §5 code+graph+vector hybrid and §7 graph-informed delegation;
-  remainder (§2 tree-sitter, §4 surprising-links, §6 live fusion,
-  §8 webchat viz) still open, as build-/integration-/frontend-tier work. See the
+- **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7 implemented (on the `testing` branch),
+  including the §5 code+graph+vector hybrid, §7 graph-informed delegation, the §4
+  surprising-links distance+selection core, and the §8 read-only `/v1/code/graph`
+  backend route; remainder (§2 tree-sitter, §4 surprising-links route, §6 live fusion,
+  §8 webchat frontend) still open, as build-/integration-/frontend-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
@@ -153,6 +154,17 @@ Computed over `code_projection_edges` + embeddings, served read-only:
     spot-check) and the feature **self-suppresses** if sampled precision drops below a
     floor. Only computable because aimee has vectors.
 
+  **Status — distance + selection core shipped.** Two pure analytics primitives
+  back the precise definition above: `kb_graph_shortest_hops` (undirected BFS over
+  `code_projection_edges`, capped at `KB_GRAPH_BFS_MAX_NODES`, returns hop count /
+  0 / -1-for-disconnected) and `kb_graph_surprising` (a **data-driven** cosine floor
+  at the requested similarity percentile of the supplied pair set, then keeps pairs
+  whose hop distance ≥ `d_min` **or** which are disconnected, in deterministic order)
+  in `src/kb/kb_graph_analytics.c`, unit-tested in `unit-test-kb-graph-analytics`.
+  Still open (needs the embedder + a deployed corpus): the route that gathers
+  candidate pairs from `code_embeddings` via pgvector, maps vector rows back to graph
+  node identity, and runs the LLM-judge/precision-sampling confirmation stage.
+
 ## §5 Hybrid graph+vector+memory retrieval (the headline)
 
 A single ranked query that fuses three signals:
@@ -254,6 +266,17 @@ symbol → callers/callees/neighbors + provenance + the linked "why". Backed by 
 read-only `/v1/code/graph` projection (paged). Human-facing exploration; not on the
 agent's hot path.
 
+**Status — backend route shipped.** `GET /v1/code/graph?project&node&max_results`
+returns a node's incident projection edges — each with `neighbor`, `relation`,
+`direction` (`out` = node→neighbor, `in` = neighbor→node, `self` = recursive edge),
+`structural_weight`, and the §3 `provenance` tag — plus `match_count` (total incident,
+pre-cap) and a `truncated` flag that fires when **either** the page cap (`max_results`,
+1–200) **or** the projection scan window (`HUBS_MAX_EDGES`) bounds the result. Reuses
+`db2_code_projection_list_edges` + `kb_graph_edge_provenance` (`handle_get_code_graph`
+in `src/kb/http/kb_http_code.c`); read-only, off the agent hot path. Shim route tests
+(`test_code_graph_node_*`: out/in neighbors, page-cap truncation, self-loop). The
+webchat **frontend** consumer remains open.
+
 ## Phasing (each independently shippable)
 
 - **P1 (now):** §1 auto-build + §3 provenance. Mostly wiring; makes the graph complete.
@@ -270,7 +293,9 @@ agent's hot path.
 - **§3** edge provenance (`structural`/`inferred`/`ambiguous`) surfaced in `graph.explain`.
 - **§4** hub/degree-centrality analytics — `GET /v1/code/graph/hubs`
   (`kb_graph_analytics.c`, `unit-test-kb-graph-analytics`), **agent-callable** via
-  `index({command:"hubs"})`.
+  `index({command:"hubs"})`; plus the **surprising-links distance + selection core**
+  (`kb_graph_shortest_hops` BFS + data-driven-percentile `kb_graph_surprising`, same
+  unit test).
 - **§5** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
   route fusing `code` + `graph` + **`vector`** (embedding similarity over
   `code_embeddings` via `pgvec_code_search_paths`, gated on a dim-matched embedder,
@@ -283,13 +308,20 @@ agent's hot path.
   (`guardrails_blast_radius.c`, `delegate_inject_graph_context`,
   `unit-test-guardrails-blast-radius`, `test_delegate_dispatch_reliability`); folds in
   the stale-edge hub note.
+- **§8** read-only node-projection route — `GET /v1/code/graph?project&node&max_results`
+  returns a node's incident edges (relation / direction incl. `self` / structural weight /
+  §3 provenance) with `match_count` + a page-or-scan `truncated` flag
+  (`handle_get_code_graph`, `test_code_graph_node_*`). Backs the webchat graph view.
 
 **Deferred — needs the embedder / a build-tier dependency / a deployed corpus / a frontend
 (not completable in the agent host):**
 - **§2 tree-sitter** front-end — large build-tier work (vendor ~30 grammars + ABI).
-- **§4 surprising-links** — needs embeddings + the percentile/LLM-judge confirmation stage.
+- **§4 surprising-links route** — core (BFS distance + percentile selection) shipped;
+  the pgvector pair-gather + node-identity mapping + LLM-judge confirmation stage needs
+  embeddings and a deployed corpus.
 - **§6 live/memory fusion** — post-merge/fetch incremental hook + watch.
-- **§8 webchat visualization** — frontend, read-only `/v1/code/graph` paged projection.
+- **§8 webchat visualization** — the **frontend** consumer; the read-only `/v1/code/graph`
+  backend route is shipped (above).
 
 ## Non-goals
 

--- a/src/headers/kb_http_code.h
+++ b/src/headers/kb_http_code.h
@@ -30,5 +30,8 @@ int handle_get_code_hybrid_route(const char *method, const char *query_string, c
 int handle_get_code_graph_hubs(const char *query_string, char *out_buf, int out_cap);
 int handle_get_code_graph_hubs_route(const char *method, const char *query_string, char *out_buf,
                                      int out_cap);
+int handle_get_code_graph(const char *query_string, char *out_buf, int out_cap);
+int handle_get_code_graph_route(const char *method, const char *query_string, char *out_buf,
+                                int out_cap);
 
 #endif

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1290,6 +1290,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_code_hybrid_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/graph/hubs") == 0)
       return handle_get_code_graph_hubs_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/code/graph") == 0)
+      return handle_get_code_graph_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/search") == 0)
       return handle_get_pdf_search_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/page") == 0)

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -11,6 +11,7 @@
 #include "memory.h"
 #include "kb/kb_rrf.h"
 #include "kb/kb_graph_analytics.h"
+#include "kb/kb_service_graph.h"
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -909,6 +910,129 @@ int handle_get_code_graph_hubs(const char *query_string, char *out_buf, int out_
    free(gedges);
    free(hubs);
    return status;
+}
+
+/* GET /v1/code/graph?project=<proj>&node=<node>&max_results=N
+ * Read-only node-neighborhood projection (proposal §8): the incident projection
+ * edges of `node` — its callers/callees/containers/etc — each with the relation,
+ * direction (out = node→neighbor, in = neighbor→node), structural-trust weight,
+ * and the §3 provenance tag. Backs the webchat graph view; not on the agent hot
+ * path. Reuses db2_code_projection_list_edges (the published generation's edges,
+ * capped at HUBS_MAX_EDGES) and kb_graph_edge_provenance. */
+int handle_get_code_graph(const char *query_string, char *out_buf, int out_cap)
+{
+   char project[256] = "";
+   char node[512] = "";
+   if (!code_qparam(query_string, "project", project, sizeof(project)) || !project[0])
+      return code_scan_write_error(out_buf, out_cap, "missing project");
+   if (!code_qparam(query_string, "node", node, sizeof(node)) || !node[0])
+      return code_scan_write_error(out_buf, out_cap, "missing node");
+
+   int max_r = 50;
+   char mr[16] = "";
+   if (code_qparam(query_string, "max_results", mr, sizeof(mr)))
+      max_r = atoi(mr);
+   if (max_r < 1)
+      max_r = 1;
+   if (max_r > 200)
+      max_r = 200;
+
+   if (!db2_is_initialized())
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"knowledge service not initialized\"}");
+      return 503;
+   }
+
+   code_projection_edge_t *edges = calloc(HUBS_MAX_EDGES, sizeof(*edges));
+   if (!edges)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+
+   int ne = db2_code_projection_list_edges(project, edges, HUBS_MAX_EDGES);
+   if (ne < 0)
+   {
+      free(edges);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"projection graph unavailable (knowledge service not initialized)\"}");
+      return 503;
+   }
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+   {
+      free(edges);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "project", project);
+   cJSON_AddStringToObject(resp, "node", node);
+   cJSON *arr = cJSON_AddArrayToObject(resp, "neighbors");
+   int emitted = 0;
+   for (int i = 0; arr && i < ne && emitted < max_r; i++)
+   {
+      const char *dir = NULL, *neighbor = NULL;
+      if (edges[i].source[0] && strcmp(edges[i].source, node) == 0)
+      {
+         dir = "out"; /* node --relation--> neighbor */
+         neighbor = edges[i].target;
+      }
+      else if (edges[i].target[0] && strcmp(edges[i].target, node) == 0)
+      {
+         dir = "in"; /* neighbor --relation--> node (e.g. callers) */
+         neighbor = edges[i].source;
+      }
+      if (!dir || !neighbor || !neighbor[0])
+         continue;
+      cJSON *n = cJSON_CreateObject();
+      if (!n)
+         continue;
+      cJSON_AddStringToObject(n, "neighbor", neighbor);
+      cJSON_AddStringToObject(n, "relation", edges[i].relation);
+      cJSON_AddStringToObject(n, "direction", dir);
+      cJSON_AddNumberToObject(n, "structural_weight", edges[i].structural_weight);
+      cJSON_AddStringToObject(
+          n, "provenance", kb_graph_edge_provenance("code_projection", edges[i].structural_weight));
+      cJSON_AddItemToArray(arr, n);
+      emitted++;
+   }
+   cJSON_AddNumberToObject(resp, "neighbor_count", emitted);
+   /* A full edge buffer means the scan was over a deterministic prefix of a larger
+    * graph, so a node's neighborhood may be incomplete. */
+   cJSON_AddBoolToObject(resp, "truncated", ne >= HUBS_MAX_EDGES);
+   free(edges);
+
+   char *s = cJSON_PrintUnformatted(resp);
+   int status = 200;
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      status = 500;
+   }
+   else if (strlen(s) >= (size_t)out_cap)
+   {
+      snprintf(
+          out_buf, (size_t)out_cap,
+          "{\"error\":\"result too large; reduce max_results\",\"code\":\"result_too_large\"}");
+      status = 413;
+   }
+   else
+   {
+      snprintf(out_buf, (size_t)out_cap, "%s", s);
+   }
+   free(s);
+   cJSON_Delete(resp);
+   return status;
+}
+
+int handle_get_code_graph_route(const char *method, const char *query_string, char *out_buf,
+                                int out_cap)
+{
+   if (strcmp(method, "GET") != 0)
+      return code_method_not_allowed(out_buf, out_cap);
+   return handle_get_code_graph(query_string, out_buf, out_cap);
 }
 
 int handle_get_code_graph_hubs_route(const char *method, const char *query_string, char *out_buf,

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -915,10 +915,12 @@ int handle_get_code_graph_hubs(const char *query_string, char *out_buf, int out_
 /* GET /v1/code/graph?project=<proj>&node=<node>&max_results=N
  * Read-only node-neighborhood projection (proposal §8): the incident projection
  * edges of `node` — its callers/callees/containers/etc — each with the relation,
- * direction (out = node→neighbor, in = neighbor→node), structural-trust weight,
- * and the §3 provenance tag. Backs the webchat graph view; not on the agent hot
- * path. Reuses db2_code_projection_list_edges (the published generation's edges,
- * capped at HUBS_MAX_EDGES) and kb_graph_edge_provenance. */
+ * direction (out = node→neighbor, in = neighbor→node, self = recursive edge),
+ * structural-trust weight, and the §3 provenance tag. Backs the webchat graph
+ * view; not on the agent hot path. Reuses db2_code_projection_list_edges (the
+ * published generation's edges, capped at HUBS_MAX_EDGES) and
+ * kb_graph_edge_provenance. Emits `neighbor_count` (rows returned), `match_count`
+ * (total incident, pre-cap), and `truncated` (page cap hit OR scan window full). */
 int handle_get_code_graph(const char *query_string, char *out_buf, int out_cap)
 {
    char project[256] = "";
@@ -970,22 +972,36 @@ int handle_get_code_graph(const char *query_string, char *out_buf, int out_cap)
    cJSON_AddStringToObject(resp, "project", project);
    cJSON_AddStringToObject(resp, "node", node);
    cJSON *arr = cJSON_AddArrayToObject(resp, "neighbors");
-   int emitted = 0;
-   for (int i = 0; arr && i < ne && emitted < max_r; i++)
+   int emitted = 0; /* edges actually written to the array (after the max_r cap) */
+   int matched = 0; /* edges incident to `node`, counted before the cap */
+   /* Scan the whole edge window so `matched` reflects the node's true incident
+    * count even once `emitted` has hit max_r; that lets `truncated` distinguish a
+    * page cap from a complete neighborhood. */
+   for (int i = 0; i < ne; i++)
    {
       const char *dir = NULL, *neighbor = NULL;
-      if (edges[i].source[0] && strcmp(edges[i].source, node) == 0)
+      int is_source = edges[i].source[0] && strcmp(edges[i].source, node) == 0;
+      int is_target = edges[i].target[0] && strcmp(edges[i].target, node) == 0;
+      if (is_source && is_target)
+      {
+         dir = "self"; /* recursive / self-referential edge (e.g. a self-call) */
+         neighbor = node;
+      }
+      else if (is_source)
       {
          dir = "out"; /* node --relation--> neighbor */
          neighbor = edges[i].target;
       }
-      else if (edges[i].target[0] && strcmp(edges[i].target, node) == 0)
+      else if (is_target)
       {
          dir = "in"; /* neighbor --relation--> node (e.g. callers) */
          neighbor = edges[i].source;
       }
       if (!dir || !neighbor || !neighbor[0])
          continue;
+      matched++;
+      if (!arr || emitted >= max_r)
+         continue; /* counted toward `matched`/truncation, but past the page cap */
       cJSON *n = cJSON_CreateObject();
       if (!n)
          continue;
@@ -999,9 +1015,11 @@ int handle_get_code_graph(const char *query_string, char *out_buf, int out_cap)
       emitted++;
    }
    cJSON_AddNumberToObject(resp, "neighbor_count", emitted);
-   /* A full edge buffer means the scan was over a deterministic prefix of a larger
-    * graph, so a node's neighborhood may be incomplete. */
-   cJSON_AddBoolToObject(resp, "truncated", ne >= HUBS_MAX_EDGES);
+   cJSON_AddNumberToObject(resp, "match_count", matched);
+   /* Two independent truncation sources: the per-request page cap (matched > emitted)
+    * and the projection scan window — a full edge buffer (ne >= HUBS_MAX_EDGES) means
+    * the scan covered only a deterministic prefix, so even `matched` may undercount. */
+   cJSON_AddBoolToObject(resp, "truncated", matched > emitted || ne >= HUBS_MAX_EDGES);
    free(edges);
 
    char *s = cJSON_PrintUnformatted(resp);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1930,6 +1930,8 @@ int main(void)
    test_code_hybrid_vector_dim_mismatch_skips();
    test_code_graph_hubs_ok();
    test_code_graph_hubs_missing_project();
+   test_code_graph_node_ok();
+   test_code_graph_node_missing_params();
    test_code_project_stats_missing_project();
    test_code_project_stats_ok();
    test_code_project_stats_error_is_json();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1931,6 +1931,8 @@ int main(void)
    test_code_graph_hubs_ok();
    test_code_graph_hubs_missing_project();
    test_code_graph_node_ok();
+   test_code_graph_node_capped_truncates();
+   test_code_graph_node_self_loop();
    test_code_graph_node_missing_params();
    test_code_project_stats_missing_project();
    test_code_project_stats_ok();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -142,6 +142,19 @@ int db2_code_projection_list_edges(const char *project, void *out, int max)
    return n;
 }
 
+/* Hermetic mirror of the §3 provenance helper (kb_service_graph.c). The real
+ * definition lives in a db2-heavy unit; this fake keeps the route test pure
+ * while preserving the only branch the projection route exercises: a
+ * code_projection edge is always "structural". */
+const char *kb_graph_edge_provenance(const char *edge_origin, int structural_weight)
+{
+   if (structural_weight > 0 || (edge_origin && strcmp(edge_origin, "code_projection") == 0))
+      return "structural";
+   if (edge_origin && strcmp(edge_origin, "session") == 0)
+      return "ambiguous";
+   return "inferred";
+}
+
 static void test_code_structure_ok(void)
 {
    char buf[512];
@@ -318,6 +331,38 @@ static void test_code_graph_hubs_missing_project(void)
    char buf[256];
    int s =
        kb_http_route_ex("GET", "/v1/code/graph/hubs", "", NULL, NULL, NULL, 0, buf, sizeof(buf));
+   assert(s == 400);
+   assert(strstr(buf, "missing project") != NULL);
+}
+
+/* §8 read-only node-neighborhood projection. Seed edges: hub->a, hub->b, c->hub. */
+static void test_code_graph_node_ok(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/graph", "project=proj-alpha&node=hub&max_results=10",
+                            NULL, NULL, NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"node\":\"hub\"") != NULL);
+   /* hub --calls--> a, b (out); c --calls--> hub (in). */
+   assert(strstr(buf, "\"neighbor\":\"a\"") != NULL);
+   assert(strstr(buf, "\"neighbor\":\"b\"") != NULL);
+   assert(strstr(buf, "\"neighbor\":\"c\"") != NULL);
+   assert(strstr(buf, "\"direction\":\"out\"") != NULL);
+   assert(strstr(buf, "\"direction\":\"in\"") != NULL);
+   assert(strstr(buf, "\"relation\":\"calls\"") != NULL);
+   /* projection edges are AST-derived -> §3 provenance "structural". */
+   assert(strstr(buf, "\"provenance\":\"structural\"") != NULL);
+   assert(strstr(buf, "\"neighbor_count\":3") != NULL);
+}
+
+static void test_code_graph_node_missing_params(void)
+{
+   char buf[512];
+   int s = kb_http_route_ex("GET", "/v1/code/graph", "project=proj-alpha", NULL, NULL, NULL, 0, buf,
+                            sizeof(buf));
+   assert(s == 400);
+   assert(strstr(buf, "missing node") != NULL);
+   s = kb_http_route_ex("GET", "/v1/code/graph", "node=hub", NULL, NULL, NULL, 0, buf, sizeof(buf));
    assert(s == 400);
    assert(strstr(buf, "missing project") != NULL);
 }

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -118,26 +118,44 @@ typedef struct
    int structural_weight;
 } test_projection_edge_t;
 
+typedef struct
+{
+   const char *s, *r, *t;
+   int w;
+} test_seed_edge_t;
+
 int db2_code_projection_list_edges(const char *project, void *out, int max)
 {
    assert(out);
-   if (!project || strcmp(project, "proj-alpha") != 0 || max < 4)
+   if (max < 4)
       return 0;
    test_projection_edge_t *e = (test_projection_edge_t *)out;
    /* hub: out=2 (->a,->b), in=1 (c->); a,b,c: degree 1 each. */
-   struct
+   static const test_seed_edge_t alpha[] = {
+       {"hub", "calls", "a", 1}, {"hub", "calls", "b", 1}, {"c", "calls", "hub", 1}};
+   /* A single recursive edge: exercises the source==target==node self-loop path. */
+   static const test_seed_edge_t selfloop[] = {{"rec", "calls", "rec", 1}};
+   const test_seed_edge_t *rows = NULL;
+   int n = 0;
+   if (project && strcmp(project, "proj-alpha") == 0)
    {
-      const char *s, *r, *t;
-      int w;
-   } seed[] = {{"hub", "calls", "a", 1}, {"hub", "calls", "b", 1}, {"c", "calls", "hub", 1}};
-   int n = (int)(sizeof(seed) / sizeof(seed[0]));
+      rows = alpha;
+      n = (int)(sizeof(alpha) / sizeof(alpha[0]));
+   }
+   else if (project && strcmp(project, "proj-selfloop") == 0)
+   {
+      rows = selfloop;
+      n = (int)(sizeof(selfloop) / sizeof(selfloop[0]));
+   }
+   else
+      return 0;
    for (int i = 0; i < n && i < max; i++)
    {
       memset(&e[i], 0, sizeof(e[i]));
-      snprintf(e[i].source, sizeof(e[i].source), "%s", seed[i].s);
-      snprintf(e[i].relation, sizeof(e[i].relation), "%s", seed[i].r);
-      snprintf(e[i].target, sizeof(e[i].target), "%s", seed[i].t);
-      e[i].structural_weight = seed[i].w;
+      snprintf(e[i].source, sizeof(e[i].source), "%s", rows[i].s);
+      snprintf(e[i].relation, sizeof(e[i].relation), "%s", rows[i].r);
+      snprintf(e[i].target, sizeof(e[i].target), "%s", rows[i].t);
+      e[i].structural_weight = rows[i].w;
    }
    return n;
 }
@@ -353,6 +371,37 @@ static void test_code_graph_node_ok(void)
    /* projection edges are AST-derived -> §3 provenance "structural". */
    assert(strstr(buf, "\"provenance\":\"structural\"") != NULL);
    assert(strstr(buf, "\"neighbor_count\":3") != NULL);
+   /* all 3 incident edges fit under max_results=10 -> complete neighborhood. */
+   assert(strstr(buf, "\"match_count\":3") != NULL);
+   assert(strstr(buf, "\"truncated\":false") != NULL);
+}
+
+/* The page cap (max_results) must drive `truncated` independently of the DB scan
+ * window: 3 incident edges, max_results=1 -> 1 emitted, truncated=true. */
+static void test_code_graph_node_capped_truncates(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/graph", "project=proj-alpha&node=hub&max_results=1",
+                            NULL, NULL, NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"neighbor_count\":1") != NULL);
+   assert(strstr(buf, "\"match_count\":3") != NULL);
+   assert(strstr(buf, "\"truncated\":true") != NULL);
+}
+
+/* A recursive edge (rec->rec) is emitted once with direction "self". */
+static void test_code_graph_node_self_loop(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/graph", "project=proj-selfloop&node=rec", NULL, NULL,
+                            NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"neighbor\":\"rec\"") != NULL);
+   assert(strstr(buf, "\"direction\":\"self\"") != NULL);
+   assert(strstr(buf, "\"neighbor_count\":1") != NULL);
+   /* exactly one entry: the else-if ladder must not double-emit a self-loop. */
+   assert(strstr(buf, "\"direction\":\"out\"") == NULL);
+   assert(strstr(buf, "\"direction\":\"in\"") == NULL);
 }
 
 static void test_code_graph_node_missing_params(void)


### PR DESCRIPTION
## Summary

Adds the read-only `GET /v1/code/graph?project=&node=&max_results=` route — the backend for the webchat graph view (proposal §8). It returns a node's incident projection edges, each labeled with:

- `relation` (calls / contains / …)
- `direction` — `out` (node→neighbor) or `in` (neighbor→node, e.g. callers)
- `structural_weight`
- `provenance` — the §3 trust tag (`structural` for AST-derived projection edges)

Plus `neighbor_count` and a `truncated` flag when the edge scan hit the cap.

## Design
- Reuses `db2_code_projection_list_edges` (the published generation's edges, capped at `HUBS_MAX_EDGES`) and `kb_graph_edge_provenance` — no new DB query path.
- Read-only and off the agent hot path; sits beside the existing `/v1/code/graph/hubs` (§4) route in the KB sidecar dispatch.
- KB-internal route (like `/v1/code/graph/hubs`), so not part of the public OpenAPI surface.

## Tests
- `test_code_graph_node_ok` — `?project=proj-alpha&node=hub` over the projection stub (hub→a, hub→b, c→hub) asserts both out-neighbors (a, b), the in-neighbor (c), relation `calls`, `provenance:structural`, and `neighbor_count:3`.
- `test_code_graph_node_missing_params` — 400 on missing `node` / missing `project`.
- Full `unit-test-kb-http-routes` green; `aimee-kb` builds clean; clang-format-19 + docs-gen no-op.