### PR TITLE
feat(ingress): opt-in Anthropic-passthrough envelope injection (ingress-compression P5 §2.3)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (120)
+## CLI-settable keys (122)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -77,6 +77,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `ingress_compress_enabled` | bool | Enable ingress envelope compression: span-enrich code hits and fold code entries into recoverable references (default off). |
 | `ingress_compress_min_chars` | int | Minimum code-snippet length (chars) before it is folded to a file:line reference (default 80). |
 | `ingress_max_raw_scans` | int | Max raw-content scans per ingress request. |
+| `ingress_preinject_anthropic_enabled` | bool | Inject the `<aimee-context>` envelope on the Anthropic-native /v1/messages passthrough too (default off). |
 | `ingress_preinject_assembly_budget` | int | Token budget for ingress context pre-injection. |
 | `ingress_preinject_enabled` | bool | Enable `<aimee-context>` pre-injection on ingress. |
 | `ingress_trusted_proxy_secret` | string | Shared secret authenticating a trusted ingress proxy. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -154,6 +154,8 @@ CFG_KEY_DESC = {
     "(session-isolation guard; default off).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",
     "ingress_preinject_enabled": "Enable `<aimee-context>` pre-injection on ingress.",
+    "ingress_preinject_anthropic_enabled": "Inject the `<aimee-context>` envelope on the "
+    "Anthropic-native /v1/messages passthrough too (default off).",
     "ingress_compress_enabled": "Enable ingress envelope compression: span-enrich code hits and "
     "fold code entries into recoverable references (default off).",
     "ingress_compress_min_chars": "Minimum code-snippet length (chars) before it is folded to a "

--- a/src/config.c
+++ b/src/config.c
@@ -851,6 +851,10 @@ int config_load(config_t *cfg)
    if (cJSON_IsBool(item))
       cfg->ingress_preinject_enabled = cJSON_IsTrue(item);
 
+   item = cJSON_GetObjectItemCaseSensitive(root, "ingress_preinject_anthropic_enabled");
+   if (cJSON_IsBool(item))
+      cfg->ingress_preinject_anthropic_enabled = cJSON_IsTrue(item);
+
    item = cJSON_GetObjectItemCaseSensitive(root, "ingress_compress_enabled");
    if (cJSON_IsBool(item))
       cfg->ingress_compress_enabled = cJSON_IsTrue(item);

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -41,6 +41,8 @@ const config_field_t config_fields[] = {
     {"memory_rerank_enabled", offsetof(config_t, memory_rerank_enabled), sizeof(int), 0, CFG_BOOL},
     {"ingress_preinject_enabled", offsetof(config_t, ingress_preinject_enabled), sizeof(int), 0,
      CFG_BOOL},
+    {"ingress_preinject_anthropic_enabled", offsetof(config_t, ingress_preinject_anthropic_enabled),
+     sizeof(int), 0, CFG_BOOL},
     {"ingress_compress_enabled", offsetof(config_t, ingress_compress_enabled), sizeof(int), 0,
      CFG_BOOL},
     {"ingress_cache_placement_enabled", offsetof(config_t, ingress_cache_placement_enabled),

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -784,6 +784,8 @@ int config_save(const config_t *cfg)
       cJSON_AddBoolToObject(root, "delegate_graph_context_enabled", 1);
    if (cfg->ingress_preinject_enabled)
       cJSON_AddBoolToObject(root, "ingress_preinject_enabled", 1);
+   if (cfg->ingress_preinject_anthropic_enabled)
+      cJSON_AddBoolToObject(root, "ingress_preinject_anthropic_enabled", 1);
    if (cfg->ingress_compress_enabled)
       cJSON_AddBoolToObject(root, "ingress_compress_enabled", 1);
    if (cfg->ingress_cache_placement_enabled)

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -8,6 +8,7 @@
 {"kb_client_bearer_token", SCHEMA_STRING, 0},
 {"guardrail_mode", SCHEMA_STRING, 0},
 {"ingress_preinject_enabled", SCHEMA_BOOL, 0},
+{"ingress_preinject_anthropic_enabled", SCHEMA_BOOL, 0},
 {"ingress_compress_enabled", SCHEMA_BOOL, 0},
 {"ingress_cache_placement_enabled", SCHEMA_BOOL, 0},
 {"ingress_compress_min_chars", SCHEMA_INT, 0},

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -335,6 +335,11 @@ typedef struct config
     * system prompt so the external agent stops re-exploring the repo. Default
     * off; a per-request `x-aimee-preinject: 0` header also disables it. */
    int ingress_preinject_enabled;
+   /* ingress-compression P5 (§2.3), default off: inject the <aimee-context>
+    * envelope on the Anthropic-native /v1/messages passthrough (otherwise
+    * parity-skipped to preserve the client's cached prefix). Separate from the
+    * OpenAI/Codex seam's ingress_preinject_enabled. */
+   int ingress_preinject_anthropic_enabled;
    int ingress_preinject_assembly_budget;
    int ingress_max_raw_scans;
    /* ingress-compression P2 (§6.5 B4): max line span the code_span_get recovery

--- a/src/headers/gateway_pipeline.h
+++ b/src/headers/gateway_pipeline.h
@@ -67,6 +67,11 @@ typedef struct
    gw_mem_target_t mem_target; /* how the memory stage renders the envelope */
    int parity;                 /* serving_api == client_api (no translation needed) */
    int stream;                 /* this call is an SSE stream */
+   int allow_anthropic_inject; /* ingress-compression P5 (§2.3): opt-in to inject the
+                                * <aimee-context> envelope on the Anthropic-native
+                                * passthrough (otherwise parity-skipped). Set by the
+                                * caller from ingress_preinject_anthropic_enabled so
+                                * this stage stays config-free. Default 0. */
 } gw_request_t;
 
 /* A request stage: inspect/alter `r->raw` in place. Returns the number of

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -223,6 +223,11 @@ static int gw_stage_model_pin(gw_request_t *r, void *ud)
 static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *driver,
                                          const agent_t *ag, int parity, int stream)
 {
+   /* P5 (§2.3): opt-in to inject the envelope on the Anthropic-native passthrough.
+    * Read config here so gw_stage_memory stays config-free. */
+   config_t pcfg;
+   int allow_anthropic_inject =
+       (config_load(&pcfg) == 0 && pcfg.ingress_preinject_anthropic_enabled) ? 1 : 0;
    gw_request_t r = {
        .raw = req,
        .driver = driver,
@@ -233,6 +238,7 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
        .mem_target = GW_MEM_ANTHROPIC_MESSAGES,
        .parity = parity,
        .stream = stream,
+       .allow_anthropic_inject = allow_anthropic_inject,
    };
    static const gw_stage_t stages[] = {
        {gw_stage_memory, NULL, "memory"},

--- a/src/server/gw_stage_memory.c
+++ b/src/server/gw_stage_memory.c
@@ -75,11 +75,14 @@ int gw_stage_memory(gw_request_t *r, void *ud)
    switch (r->mem_target)
    {
    case GW_MEM_ANTHROPIC_MESSAGES:
-      /* Parity-gated (ONLY here): the Anthropic-native passthrough must not
-       * perturb the client's cached prefix. messages_apply_preinject derives its
-       * own query from r->raw.messages. Accounting-neutral, like the prior inline
-       * stage (injection is not counted as an intervention here). */
-      if (!r->parity)
+      /* Parity-gated: the Anthropic-native passthrough normally must not perturb
+       * the client's cached prefix, so injection is skipped under parity. P5
+       * (§2.3) adds an explicit opt-in (r->allow_anthropic_inject, set by the
+       * caller from config) to inject on that path too. messages_apply_preinject
+       * derives its own query from r->raw.messages and — via
+       * ingress_preinject_apply on the string-system path — honors the cache-prefix
+       * placement lever. Accounting-neutral (not counted as an intervention). */
+      if (!r->parity || r->allow_anthropic_inject)
          messages_apply_preinject(r->raw);
       return 0;
 

--- a/src/tests/test_anthropic_http.c
+++ b/src/tests/test_anthropic_http.c
@@ -225,6 +225,14 @@ char *ingress_preinject_apply(const char *instructions, const char *envelope)
    (void)instructions;
    return envelope ? strdup(envelope) : NULL;
 }
+/* messages_run_request_pipeline reads config for the P5 anthropic-inject opt-in;
+ * these whitebox tests run with it off (zeroed). */
+int config_load(config_t *cfg)
+{
+   if (cfg)
+      memset(cfg, 0, sizeof(*cfg));
+   return 0;
+}
 
 /* HTTP-layer stub: agent_http_last_retry_after has no upstream socket here, so 0
  * (no Retry-After) suffices. */

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -31,7 +31,8 @@ static const char *FIXTURE_A =
     "db1_path: ZZA_val\nguardrail_mode: ZZA_val\nprovider: ZZA_val\nopenai_endpoint: "
     "ZZA_val\nopenai_model: ZZA_val\nopenai_key_cmd: ZZA_val\nclaude_model: ZZA_val\ncodex_model: "
     "ZZA_val\nautonomous: true\nverify_enabled: true\nverify_cross_project: "
-    "true\ningress_preinject_enabled: true\ningress_compress_enabled: "
+    "true\ningress_preinject_enabled: true\ningress_preinject_anthropic_enabled: "
+    "true\ningress_compress_enabled: "
     "true\ningress_cache_placement_enabled: true\ngateway_prevent_subagents: "
     "true\ncss_style_graph_enabled: "
     "true\n"
@@ -85,7 +86,8 @@ static const char *FIXTURE_B =
     "db1_path: ZZB_val\nguardrail_mode: ZZB_val\nprovider: ZZB_val\nopenai_endpoint: "
     "ZZB_val\nopenai_model: ZZB_val\nopenai_key_cmd: ZZB_val\nclaude_model: ZZB_val\ncodex_model: "
     "ZZB_val\nautonomous: false\nverify_enabled: false\nverify_cross_project: "
-    "false\ningress_preinject_enabled: false\ningress_compress_enabled: "
+    "false\ningress_preinject_enabled: false\ningress_preinject_anthropic_enabled: "
+    "false\ningress_compress_enabled: "
     "false\ningress_cache_placement_enabled: false\ngateway_prevent_subagents: "
     "false\ncss_style_graph_enabled: "
     "false\n"
@@ -168,6 +170,8 @@ int main(void)
    assert(cfgA.verify_enabled == 1 && cfgB.verify_enabled == 0);
    assert(cfgA.verify_cross_project == 1 && cfgB.verify_cross_project == 0);
    assert(cfgA.ingress_preinject_enabled == 1 && cfgB.ingress_preinject_enabled == 0);
+   assert(cfgA.ingress_preinject_anthropic_enabled == 1 &&
+          cfgB.ingress_preinject_anthropic_enabled == 0);
    assert(cfgA.ingress_compress_enabled == 1 && cfgB.ingress_compress_enabled == 0);
    assert(cfgA.ingress_cache_placement_enabled == 1 && cfgB.ingress_cache_placement_enabled == 0);
    assert(cfgA.gateway_prevent_subagents == 1 && cfgB.gateway_prevent_subagents == 0);

--- a/src/tests/test_gw_stage_memory.c
+++ b/src/tests/test_gw_stage_memory.c
@@ -224,6 +224,29 @@ static void test_anthropic_parity_gate(void)
    printf("anthropic_parity_gate OK\n");
 }
 
+/* P5 (§2.3): the opt-in — with allow_anthropic_inject set, the envelope IS
+ * injected even under parity (the Anthropic-native passthrough), appended as a
+ * trailing system text block so the cached prefix survives. */
+static void test_anthropic_parity_opt_in_inject(void)
+{
+   cJSON *raw = cJSON_Parse(
+       "{\"messages\":[{\"role\":\"user\",\"content\":\"deploy matrix\"}],\"system\":[]}");
+   gw_request_t r = {.raw = raw,
+                     .serving_api = GW_API_ANTHROPIC,
+                     .mem_target = GW_MEM_ANTHROPIC_MESSAGES,
+                     .parity = 1,
+                     .allow_anthropic_inject = 1};
+   assert(gw_stage_memory(&r, NULL) == 0);
+   cJSON *sys = cJSON_GetObjectItemCaseSensitive(raw, "system");
+   assert(cJSON_GetArraySize(sys) == 1); /* injected despite parity */
+   cJSON *blk = cJSON_GetArrayItem(sys, 0);
+   const cJSON *text = cJSON_GetObjectItemCaseSensitive(blk, "text");
+   assert(text && cJSON_IsString(text) && strstr(text->valuestring, "aimee-context") != NULL);
+
+   cJSON_Delete(raw);
+   printf("anthropic_parity_opt_in_inject OK\n");
+}
+
 /* Pre-injection off / recall empty: every target is a byte-identical no-op. */
 static void test_disabled_noop(void)
 {
@@ -292,6 +315,7 @@ int main(void)
    test_instructions_no_prior();
    test_instructions_placement_appends();
    test_anthropic_parity_gate();
+   test_anthropic_parity_opt_in_inject();
    test_disabled_noop();
    printf("all gw_stage_memory tests passed\n");
    return 0;


### PR DESCRIPTION
## What

**P5** (§2.3) — the final phase. The Anthropic-native `/v1/messages` passthrough is a stateless wire-format proxy, so the shared memory stage **parity-skips** envelope injection there (it must not perturb the client's cached prefix). P5 adds an explicit **opt-in** to inject on that path, behind its own gate separate from the OpenAI/Codex seam. Default **off** → the passthrough is byte-identical to before.

## Scope (reconciled with the live tree)

The injection mechanism **already exists and is cache-safe**: `messages_apply_preinject` appends the `<aimee-context>` envelope as a **trailing `system` text block**, preserving the Anthropic system-block **array** and any per-block `cache_control` (it does *not* flatten through `anthropic_system_to_text`); on a string-system it routes through `ingress_preinject_apply`, which honors the P3 placement lever. So P5 is just the opt-in gate.

## Changes

- **Config `ingress_preinject_anthropic_enabled`** (bool, default off) — full surface, separate from `ingress_preinject_enabled` (§2.3).
- **`gw_request_t.allow_anthropic_inject`**; the `GW_MEM_ANTHROPIC_MESSAGES` gate becomes `!parity || allow_anthropic_inject`. The flag is set by `messages_run_request_pipeline` (`anthropic_http.c`) from config, so **`gw_stage_memory` stays config-free** — no new symbol dependency for its many test consumers (the lesson from the P3 LTO-link break).
- **Tests**: `gw_stage_memory` parity opt-in case (injected despite parity; trailing system text block); config-surface coverage; a `config_load` stub in `test_anthropic_http` (`anthropic_http.o` now reads config for the opt-in).

## Validation note

P5 ships the lever. Proving Claude Code actually calls the advertised Aimee MCP tools (`memory_get` / `code_span_get` / `rehydrate`) when the envelope points at them is the §3.4/§2.3 reachability gate that must pass before any default flip — out of scope here (needs a live Claude Code + registered MCP fixture).

## Review

Default-off byte-identical (the gate adds `|| r->allow_anthropic_inject`, which is 0 unless the caller sets it from the new flag); the config read is isolated to `anthropic_http.c`; full local unit-test suite green.