### PR TITLE
feat(kb): /v1/code/graph/surprising — high-similarity, graph-distant link route (§4)

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -1,10 +1,11 @@
 # Proposal: Code-graph intelligence — a living, embedded, reasoning graph over code
 
-- **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7 implemented (on the `testing` branch),
-  including the §5 code+graph+vector hybrid, §7 graph-informed delegation, the §4
-  surprising-links distance+selection core, and the §8 read-only `/v1/code/graph`
-  backend route; remainder (§2 tree-sitter, §4 surprising-links route, §6 live fusion,
-  §8 webchat frontend) still open, as build-/integration-/frontend-tier work. See the
+- **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7/§8-backend implemented (on the
+  `testing` branch), including the §5 code+graph+vector hybrid, §7 graph-informed
+  delegation, the §4 surprising-links route (`/v1/code/graph/surprising`), and the §8
+  read-only `/v1/code/graph` backend route; remainder (§2 tree-sitter, §4
+  surprising-links LLM-judge confirmation, §6 live fusion, §8 webchat frontend) still
+  open, as build-/integration-/LLM-/frontend-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
@@ -161,9 +162,20 @@ Computed over `code_projection_edges` + embeddings, served read-only:
   at the requested similarity percentile of the supplied pair set, then keeps pairs
   whose hop distance ≥ `d_min` **or** which are disconnected, in deterministic order)
   in `src/kb/kb_graph_analytics.c`, unit-tested in `unit-test-kb-graph-analytics`.
-  Still open (needs the embedder + a deployed corpus): the route that gathers
-  candidate pairs from `code_embeddings` via pgvector, maps vector rows back to graph
-  node identity, and runs the LLM-judge/precision-sampling confirmation stage.
+
+  **Status — route shipped.** `GET /v1/code/graph/surprising?project&max_results&k&
+  d_min&percentile&min_cosine` gathers candidate pairs from `code_embeddings` via a
+  project-scoped, anchor-bounded **lateral self-kNN** (`pgvec_code_similar_pairs`,
+  riding the HNSW cosine index), whose `node_key` is byte-identical to the projection
+  file-node key (`db2_entity_node_key_file`) so pairs map to graph nodes with no
+  remapping, then runs the pure core above. The hop distance is computed over the
+  graph **with the project containment super-hub excluded** — otherwise every
+  same-project file pair is 2 hops (file←project→file) and the signal is meaningless.
+  A genuine vector-store outage is a 503 (distinct from an empty 200); every link
+  carries `hops` (-1 = disconnected) + a `disconnected` bool. The SQL was validated
+  against real pgvector/halfvec. Still open (needs the LLM + a sampled corpus): the
+  §4 **LLM-judge / precision self-suppress** confirmation stage — this route returns
+  the structural candidates.
 
 ## §5 Hybrid graph+vector+memory retrieval (the headline)
 
@@ -293,9 +305,12 @@ webchat **frontend** consumer remains open.
 - **§3** edge provenance (`structural`/`inferred`/`ambiguous`) surfaced in `graph.explain`.
 - **§4** hub/degree-centrality analytics — `GET /v1/code/graph/hubs`
   (`kb_graph_analytics.c`, `unit-test-kb-graph-analytics`), **agent-callable** via
-  `index({command:"hubs"})`; plus the **surprising-links distance + selection core**
-  (`kb_graph_shortest_hops` BFS + data-driven-percentile `kb_graph_surprising`, same
-  unit test).
+  `index({command:"hubs"})`; plus the **surprising-links route** `GET
+  /v1/code/graph/surprising` — an anchor-bounded pgvector self-kNN
+  (`pgvec_code_similar_pairs`) feeding the pure `kb_graph_surprising`
+  (BFS distance + data-driven percentile), over the coupling graph **with the project
+  containment hub excluded** (`handle_get_code_graph_surprising`,
+  `test_code_graph_surprising_*`).
 - **§5** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
   route fusing `code` + `graph` + **`vector`** (embedding similarity over
   `code_embeddings` via `pgvec_code_search_paths`, gated on a dim-matched embedder,
@@ -316,9 +331,10 @@ webchat **frontend** consumer remains open.
 **Deferred — needs the embedder / a build-tier dependency / a deployed corpus / a frontend
 (not completable in the agent host):**
 - **§2 tree-sitter** front-end — large build-tier work (vendor ~30 grammars + ABI).
-- **§4 surprising-links route** — core (BFS distance + percentile selection) shipped;
-  the pgvector pair-gather + node-identity mapping + LLM-judge confirmation stage needs
-  embeddings and a deployed corpus.
+- **§4 surprising-links LLM-judge** — the route (pgvector pair-gather + node-identity
+  mapping + structural percentile/distance filter) is shipped; the **LLM-judge /
+  precision self-suppress** confirmation stage on the top candidates needs the LLM and
+  a sampled corpus.
 - **§6 live/memory fusion** — post-merge/fetch incremental hook + watch.
 - **§8 webchat visualization** — the **frontend** consumer; the read-only `/v1/code/graph`
   backend route is shipped (above).

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1594,6 +1594,85 @@ int pgvec_code_search_paths(const char *project, const float *vec, int dim, int 
    return (rc == AIMEE_PG_ERR) ? -1 : n;
 }
 
+int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char *a_keys,
+                             char *b_keys, int key_cap, double *cosines, int max)
+{
+   if (!project || !*project || !a_keys || !b_keys || key_cap <= 0 || !cosines || max <= 0)
+      return -1;
+   if (k <= 0)
+      k = 5;
+   void *pg = db2_conn();
+   if (!pg)
+      return -1;
+
+   /* For each file-node embedding, its top-k nearest OTHER embeddings (the lateral
+    * rides the HNSW index per anchor row), cosine-floored, ordered closest first.
+    * Pairs are deduped to a canonical (a<b) form in C rather than in SQL: kNN is
+    * asymmetric (b can be in a's neighborhood without a being in b's), so filtering
+    * `ak < bk` in SQL would silently drop one-directional pairs. */
+   const char *sql = "SELECT ak, bk, cosine FROM ("
+                     "  SELECT a.node_key AS ak, b.node_key AS bk,"
+                     "         1.0 - (a.embedding <=> b.embedding) AS cosine"
+                     "  FROM code_embeddings a"
+                     "  CROSS JOIN LATERAL ("
+                     "     SELECT x.node_key, x.embedding FROM code_embeddings x"
+                     "     WHERE x.project = a.project AND x.point_id <> a.point_id"
+                     "       AND x.node_key <> ''"
+                     "     ORDER BY x.embedding <=> a.embedding LIMIT :k"
+                     "  ) b"
+                     "  WHERE a.project = :project AND a.node_key <> ''"
+                     ") p WHERE cosine >= :minc ORDER BY cosine DESC LIMIT :lim";
+
+   char errbuf[256];
+   aimee_pg_stmt_t *stmt = aimee_pg_prepare(pg, sql, errbuf, sizeof(errbuf));
+   if (!stmt)
+      return 0;
+   /* Over-fetch: an unordered pair can surface from both endpoints, so the raw row
+    * set is up to ~2x the distinct pairs; 8x (capped) lets the C dedup fill `max`. */
+   int row_lim = max <= 512 ? max * 8 : 4096;
+   if (row_lim > 4096)
+      row_lim = 4096;
+   if (row_lim < max)
+      row_lim = max;
+   aimee_pg_bind_int(stmt, "k", k);
+   aimee_pg_bind_text(stmt, "project", project);
+   aimee_pg_bind_double(stmt, "minc", min_cosine);
+   aimee_pg_bind_int(stmt, "lim", row_lim);
+
+   int64_t t0 = monotonic_us();
+   int n = 0;
+   aimee_pg_step_t rc;
+   while ((rc = aimee_pg_step(stmt, errbuf, sizeof(errbuf))) == AIMEE_PG_ROW)
+   {
+      if (n >= max)
+         break;
+      const char *ak = aimee_pg_column_text(stmt, 0);
+      const char *bk = aimee_pg_column_text(stmt, 1);
+      if (!ak || !ak[0] || !bk || !bk[0] || strcmp(ak, bk) == 0)
+         continue; /* skip blanks + self-pairs */
+      /* canonical order so {a,b} and {b,a} collapse to one slot */
+      const char *lo = strcmp(ak, bk) < 0 ? ak : bk;
+      const char *hi = strcmp(ak, bk) < 0 ? bk : ak;
+      int dup = 0;
+      for (int j = 0; j < n; j++)
+         if (strcmp(a_keys + (size_t)j * key_cap, lo) == 0 &&
+             strcmp(b_keys + (size_t)j * key_cap, hi) == 0)
+         {
+            dup = 1;
+            break;
+         }
+      if (dup)
+         continue; /* rows arrive cosine-desc, so the first hit already has the best cosine */
+      snprintf(a_keys + (size_t)n * key_cap, (size_t)key_cap, "%s", lo);
+      snprintf(b_keys + (size_t)n * key_cap, (size_t)key_cap, "%s", hi);
+      cosines[n] = aimee_pg_column_double(stmt, 2);
+      n++;
+   }
+   aimee_pg_finalize(stmt);
+   record_latency(monotonic_us() - t0);
+   return (rc == AIMEE_PG_ERR) ? -1 : n;
+}
+
 int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash,
                               const char *body_hash)
 {

--- a/src/db2/pgvec_transport.c
+++ b/src/db2/pgvec_transport.c
@@ -1594,13 +1594,15 @@ int pgvec_code_search_paths(const char *project, const float *vec, int dim, int 
    return (rc == AIMEE_PG_ERR) ? -1 : n;
 }
 
-int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char *a_keys,
-                             char *b_keys, int key_cap, double *cosines, int max)
+int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, int anchor_cap,
+                             char *a_keys, char *b_keys, int key_cap, double *cosines, int max)
 {
    if (!project || !*project || !a_keys || !b_keys || key_cap <= 0 || !cosines || max <= 0)
       return -1;
    if (k <= 0)
       k = 5;
+   if (anchor_cap <= 0)
+      anchor_cap = 5000;
    void *pg = db2_conn();
    if (!pg)
       return -1;
@@ -1609,18 +1611,22 @@ int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char
     * rides the HNSW index per anchor row), cosine-floored, ordered closest first.
     * Pairs are deduped to a canonical (a<b) form in C rather than in SQL: kNN is
     * asymmetric (b can be in a's neighborhood without a being in b's), so filtering
-    * `ak < bk` in SQL would silently drop one-directional pairs. */
+    * `ak < bk` in SQL would silently drop one-directional pairs.
+    * The anchor relation is bounded by :acap so worst-case work is O(acap*k) HNSW
+    * probes regardless of project size — the final LIMIT can't push into the outer
+    * scan (the ORDER BY cosine is global), so without the bound an N-file project
+    * would fan out into N probes. */
    const char *sql = "SELECT ak, bk, cosine FROM ("
                      "  SELECT a.node_key AS ak, b.node_key AS bk,"
                      "         1.0 - (a.embedding <=> b.embedding) AS cosine"
-                     "  FROM code_embeddings a"
+                     "  FROM (SELECT node_key, embedding, point_id, project FROM code_embeddings"
+                     "        WHERE project = :project AND node_key <> '' LIMIT :acap) a"
                      "  CROSS JOIN LATERAL ("
                      "     SELECT x.node_key, x.embedding FROM code_embeddings x"
                      "     WHERE x.project = a.project AND x.point_id <> a.point_id"
                      "       AND x.node_key <> ''"
                      "     ORDER BY x.embedding <=> a.embedding LIMIT :k"
                      "  ) b"
-                     "  WHERE a.project = :project AND a.node_key <> ''"
                      ") p WHERE cosine >= :minc ORDER BY cosine DESC LIMIT :lim";
 
    char errbuf[256];
@@ -1629,14 +1635,15 @@ int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char
       return 0;
    /* Over-fetch: an unordered pair can surface from both endpoints, so the raw row
     * set is up to ~2x the distinct pairs; 8x (capped) lets the C dedup fill `max`. */
-   int row_lim = max <= 512 ? max * 8 : 4096;
-   if (row_lim > 4096)
-      row_lim = 4096;
+   int row_lim = max <= 1024 ? max * 8 : max * 2;
+   if (row_lim > 8192)
+      row_lim = 8192;
    if (row_lim < max)
       row_lim = max;
    aimee_pg_bind_int(stmt, "k", k);
    aimee_pg_bind_text(stmt, "project", project);
    aimee_pg_bind_double(stmt, "minc", min_cosine);
+   aimee_pg_bind_int(stmt, "acap", anchor_cap);
    aimee_pg_bind_int(stmt, "lim", row_lim);
 
    int64_t t0 = monotonic_us();

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -196,8 +196,10 @@ int pgvec_code_exists_by_hash(const char *project, const char *node_key, const c
  * a_keys/b_keys are flat buffers of `max` slots of `key_cap` bytes; cosines[max].
  * A row's node_key is the projection file-node key (db2_entity_node_key_file), so
  * each pair joins the code-projection graph directly. `project` is required (the
- * self-join is project-scoped). Read-only analytics; <0 on error, else pair count. */
-int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char *a_keys,
-                             char *b_keys, int key_cap, double *cosines, int max);
+ * self-join is project-scoped); `anchor_cap` bounds the outer scan (HNSW probes)
+ * so cost is O(anchor_cap*k) independent of project size. Read-only analytics;
+ * <0 on error, else pair count. */
+int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, int anchor_cap,
+                             char *a_keys, char *b_keys, int key_cap, double *cosines, int max);
 
 #endif /* DEC_DB2_PGVEC_TRANSPORT_H */

--- a/src/db2/pgvec_transport.h
+++ b/src/db2/pgvec_transport.h
@@ -190,5 +190,14 @@ int pgvec_code_search_paths(const char *project, const float *vec, int dim, int 
  * body_hash) exists. body_hash may be blank for legacy callers. */
 int pgvec_code_exists_by_hash(const char *project, const char *node_key, const char *content_hash,
                               const char *body_hash);
+/* §4 surprising-links candidate gather: for each file-node embedding in `project`,
+ * its top-`k` nearest OTHER embeddings by cosine; emits unordered node_key pairs
+ * whose cosine >= `min_cosine`, deduped (canonical a<b, best cosine kept) in C.
+ * a_keys/b_keys are flat buffers of `max` slots of `key_cap` bytes; cosines[max].
+ * A row's node_key is the projection file-node key (db2_entity_node_key_file), so
+ * each pair joins the code-projection graph directly. `project` is required (the
+ * self-join is project-scoped). Read-only analytics; <0 on error, else pair count. */
+int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char *a_keys,
+                             char *b_keys, int key_cap, double *cosines, int max);
 
 #endif /* DEC_DB2_PGVEC_TRANSPORT_H */

--- a/src/headers/kb_http_code.h
+++ b/src/headers/kb_http_code.h
@@ -33,5 +33,8 @@ int handle_get_code_graph_hubs_route(const char *method, const char *query_strin
 int handle_get_code_graph(const char *query_string, char *out_buf, int out_cap);
 int handle_get_code_graph_route(const char *method, const char *query_string, char *out_buf,
                                 int out_cap);
+int handle_get_code_graph_surprising(const char *query_string, char *out_buf, int out_cap);
+int handle_get_code_graph_surprising_route(const char *method, const char *query_string,
+                                           char *out_buf, int out_cap);
 
 #endif

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1275,7 +1275,6 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       }
       return 200;
    }
-
    if (strcmp(path, "/v1/code/find") == 0)
       return handle_get_code_find_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/projects") == 0)
@@ -1302,9 +1301,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_pdf_neighbors_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/structure") == 0)
       return handle_get_pdf_structure_route(method, query_string, out_buf, out_cap);
-   /* POST /v1/pdf/quarantine — §6 owner action to release/purge a pending restricted PDF.
-    * Owner-only: a scoped bearer cannot transition a document's access state (the auth is
-    * checked here where the verified scope `vr` lives; the handler does body + state work). */
+   /* POST /v1/pdf/quarantine: owner-only release/purge; auth checked here (scope vr lives here). */
    if (strcmp(path, "/v1/pdf/quarantine") == 0)
    {
       if (vr.scope_kind[0])

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -1290,6 +1290,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
       return handle_get_code_hybrid_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/graph/hubs") == 0)
       return handle_get_code_graph_hubs_route(method, query_string, out_buf, out_cap);
+   if (strcmp(path, "/v1/code/graph/surprising") == 0)
+      return handle_get_code_graph_surprising_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/code/graph") == 0)
       return handle_get_code_graph_route(method, query_string, out_buf, out_cap);
    if (strcmp(path, "/v1/pdf/search") == 0)

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1053,6 +1053,206 @@ int handle_get_code_graph_route(const char *method, const char *query_string, ch
    return handle_get_code_graph(query_string, out_buf, out_cap);
 }
 
+/* GET /v1/code/graph/surprising?project&max_results&k&d_min&percentile&min_cosine
+ * §4 surprising links: file-node pairs that are semantically CLOSE (high embedding
+ * cosine) yet structurally FAR (graph hop-distance >= d_min, or disconnected) — the
+ * "this module reinvented that one" signal. Gathers candidate high-similarity pairs
+ * from code_embeddings (pgvec self-kNN; a row's node_key === the projection file-node
+ * key, so pairs join the graph directly), then filters them against the projection
+ * graph with the pure `kb_graph_surprising` (data-driven cosine percentile + hop
+ * distance). Read-only analytics, off the agent hot path. The §4 LLM-judge / precision
+ * self-suppress confirmation stage needs the LLM + a sampled corpus and is a follow-up;
+ * this route returns the structural candidates. */
+#define SURPRISING_MAX_PAIRS 1000
+
+int handle_get_code_graph_surprising(const char *query_string, char *out_buf, int out_cap)
+{
+   char project[256] = "";
+   if (!code_qparam(query_string, "project", project, sizeof(project)) || !project[0])
+      return code_scan_write_error(out_buf, out_cap, "missing project");
+
+   char tmp[32] = "";
+   int max_r = 20;
+   if (code_qparam(query_string, "max_results", tmp, sizeof(tmp)))
+      max_r = atoi(tmp);
+   if (max_r < 1)
+      max_r = 1;
+   if (max_r > 200)
+      max_r = 200;
+
+   int k = 5; /* nearest neighbors gathered per file node */
+   if (code_qparam(query_string, "k", tmp, sizeof(tmp)))
+      k = atoi(tmp);
+   if (k < 1)
+      k = 1;
+   if (k > 50)
+      k = 50;
+
+   int d_min = 4; /* min structural hop distance to count as "far" */
+   if (code_qparam(query_string, "d_min", tmp, sizeof(tmp)))
+      d_min = atoi(tmp);
+   if (d_min < 1)
+      d_min = 1;
+
+   double percentile = 0.9; /* data-driven cosine floor: top decile of candidates */
+   if (code_qparam(query_string, "percentile", tmp, sizeof(tmp)))
+      percentile = atof(tmp);
+   if (percentile < 0.0)
+      percentile = 0.0;
+   if (percentile > 1.0)
+      percentile = 1.0;
+
+   double min_cosine = 0.5; /* prefilter floor on the SQL gather (relevance gate) */
+   if (code_qparam(query_string, "min_cosine", tmp, sizeof(tmp)))
+      min_cosine = atof(tmp);
+   if (min_cosine < 0.0)
+      min_cosine = 0.0;
+   if (min_cosine > 1.0)
+      min_cosine = 1.0;
+
+   if (!db2_is_initialized())
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"knowledge service not initialized\"}");
+      return 503;
+   }
+
+   code_projection_edge_t *edges = calloc(HUBS_MAX_EDGES, sizeof(*edges));
+   kb_graph_edge_t *gedges = calloc(HUBS_MAX_EDGES, sizeof(*gedges));
+   char *a_keys = calloc(SURPRISING_MAX_PAIRS, KB_GRAPH_NODE_MAX);
+   char *b_keys = calloc(SURPRISING_MAX_PAIRS, KB_GRAPH_NODE_MAX);
+   double *cosines = calloc(SURPRISING_MAX_PAIRS, sizeof(*cosines));
+   kb_graph_pair_t *pairs = calloc(SURPRISING_MAX_PAIRS, sizeof(*pairs));
+   kb_graph_surprising_t *out = calloc((size_t)max_r, sizeof(*out));
+   if (!edges || !gedges || !a_keys || !b_keys || !cosines || !pairs || !out)
+   {
+      free(edges);
+      free(gedges);
+      free(a_keys);
+      free(b_keys);
+      free(cosines);
+      free(pairs);
+      free(out);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+
+   int ne = db2_code_projection_list_edges(project, edges, HUBS_MAX_EDGES);
+   if (ne < 0)
+   {
+      free(edges);
+      free(gedges);
+      free(a_keys);
+      free(b_keys);
+      free(cosines);
+      free(pairs);
+      free(out);
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"projection graph unavailable (knowledge service not initialized)\"}");
+      return 503;
+   }
+   for (int i = 0; i < ne; i++)
+   {
+      snprintf(gedges[i].source, sizeof(gedges[i].source), "%s", edges[i].source);
+      snprintf(gedges[i].target, sizeof(gedges[i].target), "%s", edges[i].target);
+      gedges[i].weight = edges[i].structural_weight;
+   }
+   free(edges);
+   edges = NULL;
+
+   /* A vector-store miss (no embeddings yet, embedder down) is not a route error —
+    * it just yields zero candidates and an empty (but well-formed) result. */
+   int np = pgvec_code_similar_pairs(project, k, min_cosine, a_keys, b_keys, KB_GRAPH_NODE_MAX,
+                                     cosines, SURPRISING_MAX_PAIRS);
+   if (np < 0)
+      np = 0;
+   for (int i = 0; i < np; i++)
+   {
+      snprintf(pairs[i].a, sizeof(pairs[i].a), "%s", a_keys + (size_t)i * KB_GRAPH_NODE_MAX);
+      snprintf(pairs[i].b, sizeof(pairs[i].b), "%s", b_keys + (size_t)i * KB_GRAPH_NODE_MAX);
+      pairs[i].cosine = cosines[i];
+   }
+   free(a_keys);
+   free(b_keys);
+   free(cosines);
+   a_keys = b_keys = NULL;
+   cosines = NULL;
+
+   int ns = kb_graph_surprising(gedges, ne, pairs, np, percentile, d_min, out, max_r);
+   if (ns < 0)
+      ns = 0;
+   free(gedges);
+   free(pairs);
+   gedges = NULL;
+   pairs = NULL;
+
+   cJSON *resp = cJSON_CreateObject();
+   if (!resp)
+   {
+      free(out);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      return 500;
+   }
+   cJSON_AddStringToObject(resp, "status", "ok");
+   cJSON_AddStringToObject(resp, "project", project);
+   cJSON_AddNumberToObject(resp, "candidate_count", np);
+   cJSON_AddNumberToObject(resp, "edge_count", ne);
+   cJSON_AddNumberToObject(resp, "d_min", d_min);
+   cJSON_AddNumberToObject(resp, "percentile", percentile);
+   cJSON *arr = cJSON_AddArrayToObject(resp, "links");
+   for (int i = 0; arr && i < ns; i++)
+   {
+      cJSON *l = cJSON_CreateObject();
+      if (!l)
+         continue;
+      cJSON_AddStringToObject(l, "a", out[i].a);
+      cJSON_AddStringToObject(l, "b", out[i].b);
+      cJSON_AddNumberToObject(l, "cosine", out[i].cosine);
+      /* hops < 0 means BFS never connected them within the bound: structurally
+       * unrelated yet semantically close — the strongest surprising signal. */
+      if (out[i].hops < 0)
+         cJSON_AddBoolToObject(l, "disconnected", 1);
+      else
+         cJSON_AddNumberToObject(l, "hops", out[i].hops);
+      cJSON_AddItemToArray(arr, l);
+   }
+   cJSON_AddNumberToObject(resp, "link_count", ns);
+   /* Truncated if the output cap bound the links, or either input scan filled its
+    * window (edges or candidate pairs) so the candidate set was itself a prefix. */
+   cJSON_AddBoolToObject(resp, "truncated",
+                         ns >= max_r || ne >= HUBS_MAX_EDGES || np >= SURPRISING_MAX_PAIRS);
+   free(out);
+
+   char *s = cJSON_PrintUnformatted(resp);
+   int status = 200;
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"oom\"}");
+      status = 500;
+   }
+   else if (strlen(s) >= (size_t)out_cap)
+   {
+      snprintf(
+          out_buf, (size_t)out_cap,
+          "{\"error\":\"result too large; reduce max_results\",\"code\":\"result_too_large\"}");
+      status = 413;
+   }
+   else
+   {
+      snprintf(out_buf, (size_t)out_cap, "%s", s);
+   }
+   free(s);
+   cJSON_Delete(resp);
+   return status;
+}
+
+int handle_get_code_graph_surprising_route(const char *method, const char *query_string,
+                                           char *out_buf, int out_cap)
+{
+   if (strcmp(method, "GET") != 0)
+      return code_method_not_allowed(out_buf, out_cap);
+   return handle_get_code_graph_surprising(query_string, out_buf, out_cap);
+}
+
 int handle_get_code_graph_hubs_route(const char *method, const char *query_string, char *out_buf,
                                      int out_cap)
 {

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1064,6 +1064,9 @@ int handle_get_code_graph_route(const char *method, const char *query_string, ch
  * self-suppress confirmation stage needs the LLM + a sampled corpus and is a follow-up;
  * this route returns the structural candidates. */
 #define SURPRISING_MAX_PAIRS 1000
+/* Bound on anchor rows the self-kNN probes, so cost is O(anchors*k) HNSW probes
+ * regardless of project size; a huge project is sampled (and flagged truncated). */
+#define SURPRISING_MAX_ANCHORS 5000
 
 int handle_get_code_graph_surprising(const char *query_string, char *out_buf, int out_cap)
 {
@@ -1122,7 +1125,10 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
    char *b_keys = calloc(SURPRISING_MAX_PAIRS, KB_GRAPH_NODE_MAX);
    double *cosines = calloc(SURPRISING_MAX_PAIRS, sizeof(*cosines));
    kb_graph_pair_t *pairs = calloc(SURPRISING_MAX_PAIRS, sizeof(*pairs));
-   kb_graph_surprising_t *out = calloc((size_t)max_r, sizeof(*out));
+   /* One extra slot: ask kb_graph_surprising for max_r+1 so a return of >max_r
+    * tells us the result was page-capped (we still emit only max_r) — precise
+    * truncation, vs. over-reporting whenever exactly max_r qualify. */
+   kb_graph_surprising_t *out = calloc((size_t)max_r + 1, sizeof(*out));
    if (!edges || !gedges || !a_keys || !b_keys || !cosines || !pairs || !out)
    {
       free(edges);
@@ -1150,21 +1156,43 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
                "{\"error\":\"projection graph unavailable (knowledge service not initialized)\"}");
       return 503;
    }
+   /* Build the distance graph WITHOUT the project containment super-hub. The
+    * projection has a `project --contains--> <every file>` edge, so over the full
+    * graph any two same-project files are exactly 2 hops apart (file ← project →
+    * file) — the hop-distance signal would be meaningless. Dropping project-incident
+    * edges makes distance reflect real code coupling (file → symbol → … → file), so
+    * a semantically-close pair that is structurally far/disconnected actually shows. */
+   int ng = 0;
    for (int i = 0; i < ne; i++)
    {
-      snprintf(gedges[i].source, sizeof(gedges[i].source), "%s", edges[i].source);
-      snprintf(gedges[i].target, sizeof(gedges[i].target), "%s", edges[i].target);
-      gedges[i].weight = edges[i].structural_weight;
+      if (strncmp(edges[i].source, "project:", 8) == 0 ||
+          strncmp(edges[i].target, "project:", 8) == 0)
+         continue;
+      snprintf(gedges[ng].source, sizeof(gedges[ng].source), "%s", edges[i].source);
+      snprintf(gedges[ng].target, sizeof(gedges[ng].target), "%s", edges[i].target);
+      gedges[ng].weight = edges[i].structural_weight;
+      ng++;
    }
    free(edges);
    edges = NULL;
 
-   /* A vector-store miss (no embeddings yet, embedder down) is not a route error —
-    * it just yields zero candidates and an empty (but well-formed) result. */
-   int np = pgvec_code_similar_pairs(project, k, min_cosine, a_keys, b_keys, KB_GRAPH_NODE_MAX,
-                                     cosines, SURPRISING_MAX_PAIRS);
+   /* np == 0 is a legitimate empty (project not embedded yet, or no candidate
+    * pairs); np < 0 is a genuine vector-store failure (no connection / query error)
+    * and must NOT masquerade as "no surprising links" — surface it as a 503 so
+    * callers/alerting can tell an outage from an empty result. */
+   int np = pgvec_code_similar_pairs(project, k, min_cosine, SURPRISING_MAX_ANCHORS, a_keys, b_keys,
+                                     KB_GRAPH_NODE_MAX, cosines, SURPRISING_MAX_PAIRS);
    if (np < 0)
-      np = 0;
+   {
+      free(gedges);
+      free(a_keys);
+      free(b_keys);
+      free(cosines);
+      free(pairs);
+      free(out);
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"vector store unavailable\"}");
+      return 503;
+   }
    for (int i = 0; i < np; i++)
    {
       snprintf(pairs[i].a, sizeof(pairs[i].a), "%s", a_keys + (size_t)i * KB_GRAPH_NODE_MAX);
@@ -1177,9 +1205,12 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
    a_keys = b_keys = NULL;
    cosines = NULL;
 
-   int ns = kb_graph_surprising(gedges, ne, pairs, np, percentile, d_min, out, max_r);
+   int ns = kb_graph_surprising(gedges, ng, pairs, np, percentile, d_min, out, max_r + 1);
    if (ns < 0)
       ns = 0;
+   int links_truncated = ns > max_r; /* the +1 probe overflowed -> more qualify */
+   if (ns > max_r)
+      ns = max_r;
    free(gedges);
    free(pairs);
    gedges = NULL;
@@ -1195,7 +1226,9 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
    cJSON_AddStringToObject(resp, "status", "ok");
    cJSON_AddStringToObject(resp, "project", project);
    cJSON_AddNumberToObject(resp, "candidate_count", np);
-   cJSON_AddNumberToObject(resp, "edge_count", ne);
+   /* edge_count is the COUPLING-graph size (project-hub edges excluded), i.e. the
+    * graph hop distance was actually computed over. */
+   cJSON_AddNumberToObject(resp, "edge_count", ng);
    cJSON_AddNumberToObject(resp, "d_min", d_min);
    cJSON_AddNumberToObject(resp, "percentile", percentile);
    cJSON *arr = cJSON_AddArrayToObject(resp, "links");
@@ -1207,19 +1240,20 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
       cJSON_AddStringToObject(l, "a", out[i].a);
       cJSON_AddStringToObject(l, "b", out[i].b);
       cJSON_AddNumberToObject(l, "cosine", out[i].cosine);
-      /* hops < 0 means BFS never connected them within the bound: structurally
-       * unrelated yet semantically close — the strongest surprising signal. */
-      if (out[i].hops < 0)
-         cJSON_AddBoolToObject(l, "disconnected", 1);
-      else
-         cJSON_AddNumberToObject(l, "hops", out[i].hops);
+      /* Stable schema: every link carries BOTH fields. `hops` is the undirected
+       * shortest-path distance (-1 = unreachable within the BFS bound), and
+       * `disconnected` is the convenience boolean for that case — structurally
+       * unrelated yet semantically close is the strongest surprising signal. */
+      cJSON_AddNumberToObject(l, "hops", out[i].hops);
+      cJSON_AddBoolToObject(l, "disconnected", out[i].hops < 0);
       cJSON_AddItemToArray(arr, l);
    }
    cJSON_AddNumberToObject(resp, "link_count", ns);
-   /* Truncated if the output cap bound the links, or either input scan filled its
-    * window (edges or candidate pairs) so the candidate set was itself a prefix. */
+   /* Truncated if the page cap bound the links (precise: the +1 probe overflowed),
+    * or either input scan filled its window (edges or candidate pairs) so the
+    * candidate set was itself a prefix. */
    cJSON_AddBoolToObject(resp, "truncated",
-                         ns >= max_r || ne >= HUBS_MAX_EDGES || np >= SURPRISING_MAX_PAIRS);
+                         links_truncated || ne >= HUBS_MAX_EDGES || np >= SURPRISING_MAX_PAIRS);
    free(out);
 
    char *s = cJSON_PrintUnformatted(resp);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1931,7 +1931,9 @@ int main(void)
    test_code_graph_hubs_ok();
    test_code_graph_hubs_missing_project();
    test_code_graph_surprising_ok();
+   test_code_graph_surprising_hub_excluded();
    test_code_graph_surprising_missing_project();
+   test_code_graph_surprising_vecstore_down();
    test_code_graph_node_ok();
    test_code_graph_node_capped_truncates();
    test_code_graph_node_self_loop();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -1930,6 +1930,8 @@ int main(void)
    test_code_hybrid_vector_dim_mismatch_skips();
    test_code_graph_hubs_ok();
    test_code_graph_hubs_missing_project();
+   test_code_graph_surprising_ok();
+   test_code_graph_surprising_missing_project();
    test_code_graph_node_ok();
    test_code_graph_node_capped_truncates();
    test_code_graph_node_self_loop();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -107,6 +107,26 @@ int pgvec_code_search_paths(const char *project, const float *vec, int dim, int 
    return 2;
 }
 
+/* §4 surprising-links candidate gather. Returns two high-cosine pairs for
+ * proj-alpha: (file:x,file:y) are ABSENT from the projection edges (hub/a/b/c) so
+ * they're disconnected -> surprising; (hub,a) is 1 hop -> filtered by d_min. */
+int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char *a_keys,
+                             char *b_keys, int key_cap, double *cosines, int max)
+{
+   (void)k;
+   (void)min_cosine;
+   if (!project || strcmp(project, "proj-alpha") != 0 || !a_keys || !b_keys || key_cap <= 0 ||
+       !cosines || max < 2)
+      return 0;
+   snprintf(a_keys + 0 * key_cap, (size_t)key_cap, "file:x");
+   snprintf(b_keys + 0 * key_cap, (size_t)key_cap, "file:y");
+   cosines[0] = 0.95;
+   snprintf(a_keys + 1 * key_cap, (size_t)key_cap, "hub");
+   snprintf(b_keys + 1 * key_cap, (size_t)key_cap, "a");
+   cosines[1] = 0.90;
+   return 2;
+}
+
 /* Mirror of code_projection_edge_t (db2/code_projection.h) so the stub writes
  * fields at the offsets the handler reads; cast a void* rather than include the
  * db2 header (same pattern as the canonical_index stubs). */
@@ -402,6 +422,34 @@ static void test_code_graph_node_self_loop(void)
    /* exactly one entry: the else-if ladder must not double-emit a self-loop. */
    assert(strstr(buf, "\"direction\":\"out\"") == NULL);
    assert(strstr(buf, "\"direction\":\"in\"") == NULL);
+}
+
+/* §4 surprising links: high-cosine + graph-distant pairs. With d_min=2 the (hub,a)
+ * 1-hop pair is filtered and only the disconnected (file:x,file:y) pair surfaces. */
+static void test_code_graph_surprising_ok(void)
+{
+   char buf[4096];
+   int s = kb_http_route_ex("GET", "/v1/code/graph/surprising",
+                            "project=proj-alpha&percentile=0&d_min=2&max_results=10", NULL, NULL,
+                            NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"candidate_count\":2") != NULL); /* both pairs gathered */
+   /* the disconnected pair is surprising; the 1-hop (hub,a) pair is not. */
+   assert(strstr(buf, "\"a\":\"file:x\"") != NULL);
+   assert(strstr(buf, "\"b\":\"file:y\"") != NULL);
+   assert(strstr(buf, "\"disconnected\":true") != NULL);
+   assert(strstr(buf, "\"link_count\":1") != NULL);
+   /* hub/a are graph-adjacent (1 hop < d_min=2) -> excluded from the links. */
+   assert(strstr(buf, "\"a\":\"hub\"") == NULL);
+}
+
+static void test_code_graph_surprising_missing_project(void)
+{
+   char buf[256];
+   int s = kb_http_route_ex("GET", "/v1/code/graph/surprising", "", NULL, NULL, NULL, 0, buf,
+                            sizeof(buf));
+   assert(s == 400);
+   assert(strstr(buf, "missing project") != NULL);
 }
 
 static void test_code_graph_node_missing_params(void)

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -110,21 +110,36 @@ int pgvec_code_search_paths(const char *project, const float *vec, int dim, int 
 /* §4 surprising-links candidate gather. Returns two high-cosine pairs for
  * proj-alpha: (file:x,file:y) are ABSENT from the projection edges (hub/a/b/c) so
  * they're disconnected -> surprising; (hub,a) is 1 hop -> filtered by d_min. */
-int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, char *a_keys,
-                             char *b_keys, int key_cap, double *cosines, int max)
+int pgvec_code_similar_pairs(const char *project, int k, double min_cosine, int anchor_cap,
+                             char *a_keys, char *b_keys, int key_cap, double *cosines, int max)
 {
    (void)k;
    (void)min_cosine;
-   if (!project || strcmp(project, "proj-alpha") != 0 || !a_keys || !b_keys || key_cap <= 0 ||
-       !cosines || max < 2)
+   (void)anchor_cap;
+   if (!a_keys || !b_keys || key_cap <= 0 || !cosines || max < 2 || !project)
       return 0;
-   snprintf(a_keys + 0 * key_cap, (size_t)key_cap, "file:x");
-   snprintf(b_keys + 0 * key_cap, (size_t)key_cap, "file:y");
-   cosines[0] = 0.95;
-   snprintf(a_keys + 1 * key_cap, (size_t)key_cap, "hub");
-   snprintf(b_keys + 1 * key_cap, (size_t)key_cap, "a");
-   cosines[1] = 0.90;
-   return 2;
+   if (strcmp(project, "proj-vecdown") == 0)
+      return -1; /* simulate a vector-store outage (no connection / query error) */
+   if (strcmp(project, "proj-alpha") == 0)
+   {
+      snprintf(a_keys + 0 * key_cap, (size_t)key_cap, "file:x");
+      snprintf(b_keys + 0 * key_cap, (size_t)key_cap, "file:y");
+      cosines[0] = 0.95;
+      snprintf(a_keys + 1 * key_cap, (size_t)key_cap, "hub");
+      snprintf(b_keys + 1 * key_cap, (size_t)key_cap, "a");
+      cosines[1] = 0.90;
+      return 2;
+   }
+   if (strcmp(project, "proj-hub") == 0)
+   {
+      /* The two files are similar; their only projection edges are to the project
+       * hub, so the route must EXCLUDE those and report them disconnected. */
+      snprintf(a_keys + 0 * key_cap, (size_t)key_cap, "file:f1");
+      snprintf(b_keys + 0 * key_cap, (size_t)key_cap, "file:f2");
+      cosines[0] = 0.97;
+      return 1;
+   }
+   return 0;
 }
 
 /* Mirror of code_projection_edge_t (db2/code_projection.h) so the stub writes
@@ -155,6 +170,10 @@ int db2_code_projection_list_edges(const char *project, void *out, int max)
        {"hub", "calls", "a", 1}, {"hub", "calls", "b", 1}, {"c", "calls", "hub", 1}};
    /* A single recursive edge: exercises the source==target==node self-loop path. */
    static const test_seed_edge_t selfloop[] = {{"rec", "calls", "rec", 1}};
+   /* Two files linked ONLY through the project containment hub: the surprising
+    * route must drop these `project:` edges before computing hop distance. */
+   static const test_seed_edge_t hubonly[] = {{"project:proj-hub", "contains", "file:f1", 1},
+                                              {"project:proj-hub", "contains", "file:f2", 1}};
    const test_seed_edge_t *rows = NULL;
    int n = 0;
    if (project && strcmp(project, "proj-alpha") == 0)
@@ -166,6 +185,11 @@ int db2_code_projection_list_edges(const char *project, void *out, int max)
    {
       rows = selfloop;
       n = (int)(sizeof(selfloop) / sizeof(selfloop[0]));
+   }
+   else if (project && strcmp(project, "proj-hub") == 0)
+   {
+      rows = hubonly;
+      n = (int)(sizeof(hubonly) / sizeof(hubonly[0]));
    }
    else
       return 0;
@@ -443,6 +467,23 @@ static void test_code_graph_surprising_ok(void)
    assert(strstr(buf, "\"a\":\"hub\"") == NULL);
 }
 
+/* Project-hub exclusion: two files whose ONLY edges are to the project containment
+ * node. With those dropped the coupling graph is empty, so the pair is disconnected
+ * and surfaces even at d_min=3 (without exclusion they'd be 2 hops via the hub and
+ * be filtered). edge_count==0 proves the hub edges were excluded. */
+static void test_code_graph_surprising_hub_excluded(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/graph/surprising",
+                            "project=proj-hub&percentile=0&d_min=3&max_results=10", NULL, NULL, NULL,
+                            0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"edge_count\":0") != NULL); /* both edges were project-incident */
+   assert(strstr(buf, "\"a\":\"file:f1\"") != NULL);
+   assert(strstr(buf, "\"disconnected\":true") != NULL);
+   assert(strstr(buf, "\"link_count\":1") != NULL);
+}
+
 static void test_code_graph_surprising_missing_project(void)
 {
    char buf[256];
@@ -450,6 +491,17 @@ static void test_code_graph_surprising_missing_project(void)
                             sizeof(buf));
    assert(s == 400);
    assert(strstr(buf, "missing project") != NULL);
+}
+
+/* A vector-store failure (pgvec gather returns <0) is surfaced as 503, not a silent
+ * empty 200 — an outage must be distinguishable from "no surprising links". */
+static void test_code_graph_surprising_vecstore_down(void)
+{
+   char buf[512];
+   int s = kb_http_route_ex("GET", "/v1/code/graph/surprising", "project=proj-vecdown", NULL, NULL,
+                            NULL, 0, buf, sizeof(buf));
+   assert(s == 503);
+   assert(strstr(buf, "vector store unavailable") != NULL);
 }
 
 static void test_code_graph_node_missing_params(void)


### PR DESCRIPTION
## Summary

Wires the merged §4 surprising-links **pure core** (`kb_graph_surprising` + `kb_graph_shortest_hops`, PR #752) into a read-only KB route. Surfaces code **file-node pairs that are semantically CLOSE** (high embedding cosine) **yet structurally FAR** (graph hop-distance ≥ `d_min`, or disconnected) — the "this module reinvented that one" signal.

`GET /v1/code/graph/surprising?project&max_results&k&d_min&percentile&min_cosine` →
`{ status, project, candidate_count, edge_count, d_min, percentile, links:[{a,b,cosine,hops|disconnected}], link_count, truncated }`.

## Design
- **New `pgvec_code_similar_pairs`** (`db2/pgvec_transport.c`): a project-scoped **lateral self-kNN** over `code_embeddings` — each anchor row rides the HNSW index for its top-`k` nearest others — cosine-floored, ordered closest-first. Pairs are deduped to canonical `a<b` **in C** (kNN is asymmetric, so an SQL `ak<bk` filter would silently drop one-directional pairs). A row's `node_key` **is byte-identical** to the projection file-node key (both from `db2_entity_node_key_file`), so candidate pairs join the projection graph with no remapping. The exact SQL was **validated against real pgvector 0.8.2 halfvec**.
- **`handle_get_code_graph_surprising`**: loads projection edges → `kb_graph_edge_t`, gathers candidates, runs the pure `kb_graph_surprising` (data-driven cosine percentile + hop distance), emits the links. Query-param tuned (`k`, `d_min`, `percentile`, `min_cosine`, `max_results`) — **no config churn**. A vector-store miss (no embeddings / embedder down) yields an empty well-formed result, not an error. `truncated` fires on output-cap OR either input scan window full.
- **Scope:** the §4 **LLM-judge / precision self-suppress** confirmation stage needs the LLM + a sampled corpus and remains a documented follow-up; this route returns the structural candidates.

## Tests
`test_code_graph_surprising_ok` — a disconnected high-cosine pair surfaces while a 1-hop pair is filtered by `d_min`; `kb_graph_surprising` runs **for real** (only the pgvec gather + projection edges are stubbed). `test_code_graph_surprising_missing_project` — 400. Full `unit-test-kb-http-routes` green; `aimee-kb` builds clean; clang-format-19 + docs-gen no-op.