### PR TITLE
feat(mcp): expose /v1/code/graph/surprising as index({command:'surprising'})

### DIFF
--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1101,6 +1101,9 @@ char *kb_client_pdf_inspect_structure(const char *project, const char *document_
 char *kb_client_code_hybrid(const char *query, const char *symbol, const char *project,
                             int max_results, int *status_out);
 char *kb_client_code_graph_hubs(const char *project, int max_results, int *status_out);
+/* /v1/code/graph/surprising: file pairs that are semantically close yet
+ * structurally far (project required). */
+char *kb_client_code_graph_surprising(const char *project, int max_results, int *status_out);
 
 /* Counts of indexed files / definition-kind terms for one project.
  * Uses /v1 over remote HTTP or local UDS.

--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -119,6 +119,16 @@ void mcp_add_extended_tools(cJSON *tools)
    ext_prop(t, "max_results", "integer", "Max hubs to return (default 20, max 200).");
    ext_require(t, "project");
 
+   t = ext_tool(
+       tools, "index_graph_surprising",
+       "Find 'surprising links': file pairs that are semantically close (high embedding "
+       "similarity) yet structurally far apart in the call/dependency graph (or "
+       "disconnected) — a duplicated-logic / parallel-implementation signal. Returns pairs "
+       "with cosine + hop distance.");
+   ext_prop(t, "project", "string", "Project to analyze.");
+   ext_prop(t, "max_results", "integer", "Max surprising pairs to return (default 20, max 200).");
+   ext_require(t, "project");
+
    /* ── Memory grounding: explain a retrieval + provenance/history ───────────── */
    t = ext_tool(tools, "memory_explain_match",
                 "Explain WHY a memory matches a query: the per-signal score breakdown "
@@ -265,6 +275,7 @@ static const struct fam_def MCP_FAMILIES[] = {
       {"preview", "preview_blast_radius"},
       {"hybrid", "index_hybrid"},
       {"hubs", "index_graph_hubs"},
+      {"surprising", "index_graph_surprising"},
       {NULL, NULL}}},
     {"note",
      "command",

--- a/src/server/kb_client_code_graph.c
+++ b/src/server/kb_client_code_graph.c
@@ -90,3 +90,32 @@ char *kb_client_code_graph_hubs(const char *project, int max_results, int *statu
    free(path);
    return json;
 }
+
+char *kb_client_code_graph_surprising(const char *project, int max_results, int *status_out)
+{
+   if (status_out)
+      *status_out = -1;
+   if (!project || !project[0])
+      return NULL;
+
+   char *project_q = kb_client_query_escape(project);
+   if (!project_q)
+      return NULL;
+   if (max_results < 1)
+      max_results = 1;
+
+   size_t cap = strlen("/v1/code/graph/surprising?project=&max_results=") + strlen(project_q) + 32;
+   char *path = malloc(cap);
+   if (!path)
+   {
+      free(project_q);
+      return NULL;
+   }
+   snprintf(path, cap, "/v1/code/graph/surprising?project=%s&max_results=%d", project_q,
+            max_results);
+   free(project_q);
+
+   char *json = kb_client_v1_get_json(path, KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS, status_out);
+   free(path);
+   return json;
+}

--- a/src/server/server_mcp_call_table.inc
+++ b/src/server/server_mcp_call_table.inc
@@ -1053,6 +1053,18 @@ static cJSON *mcph_index_graph_hubs(struct mcp_call *c)
    return code_graph_passthrough(json, status, "index_graph_hubs");
 }
 
+static cJSON *mcph_index_graph_surprising(struct mcp_call *c)
+{
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
+   if (!cJSON_IsString(jp) || !jp->valuestring[0])
+      return text_content("error: index_graph_surprising requires 'project'");
+   long long mr = 0;
+   int max_results = pdf_arg_pos_int(c->jargs, "max_results", 200.0, &mr) ? (int)mr : 20;
+   int status = -1;
+   char *json = kb_client_code_graph_surprising(jp->valuestring, max_results, &status);
+   return code_graph_passthrough(json, status, "index_graph_surprising");
+}
+
 static cJSON *mcph_pdf_search_chunks(struct mcp_call *c)
 {
    cJSON *jq = cJSON_GetObjectItemCaseSensitive(c->jargs, "query");
@@ -1236,6 +1248,7 @@ static const struct
     {"code_span_get", mcph_code_span_get},
     {"index_hybrid", mcph_index_hybrid},
     {"index_graph_hubs", mcph_index_graph_hubs},
+    {"index_graph_surprising", mcph_index_graph_surprising},
     {"memory_explain_match", mcph_memory_explain_match},
     /* P3b */
     {"index_blast_radius", mcph_index_blast_radius},


### PR DESCRIPTION
## Summary

Makes the §4 **surprising-links** route (PR #757) **agent-callable**, completing its actuation surface. Mirrors the `index_graph_hubs` / `index_hybrid` exposure pattern (PR #737):

- **`kb_client_code_graph_surprising`** (`server/kb_client_code_graph.c`) — URL-escapes `project`, builds `/v1/code/graph/surprising?project=&max_results=`, forwards the route JSON **verbatim** via `kb_client_v1_get_json`; frees on every path.
- **`mcph_index_graph_surprising`** (`server_mcp_call_table.inc`) — requires `project`, bounds `max_results` (default 20, max 200), passes through `code_graph_passthrough`.
- **ext_tool schema + command-map** (`mcp_tools_extended.c`) — `{"surprising" → index_graph_surprising}` under the `index` family.

Agents can now ask *"where did we reinvent logic?"* — file pairs that are semantically close (high embedding similarity) yet structurally far apart or disconnected.

## Surface impact
The tool-surface **golden is unchanged** (top-level count stays **47**): the sub-command's props (`project`, `max_results`) are already in the `index` family's merged prop union from `index_graph_hubs`, and the sub-command is folded into the existing multiplexed `index` tool — no new top-level tool. Aligns with the MCP-presentation-program's minimal-surface goal (only the genuinely-new `surprising` capability is exposed; the §8 node-projection route stays frontend-only as it overlaps `find_callers`/`blast_radius`).

## Verification
`make all` builds clean, `line-check` clean, registry golden test passes, no docs drift, `check-kb-v1-coverage` ok. The forwarded route itself is already tested (`test_code_graph_surprising_*`, PR #757); the MCP layer is thin passthrough (same as `index_graph_hubs`, which ships without a dedicated handler test).