### PR TITLE
fix(server-tls): advertise http/1.1 over ALPN (unblocks Codex CLI)

### DIFF
--- a/docs/proposals/pending/ingress-compression-and-cache-alignment.md
+++ b/docs/proposals/pending/ingress-compression-and-cache-alignment.md
@@ -712,6 +712,34 @@ this proposal.
   non-lossy there or not flip. Latency from recovery round-trips counts against the
   same gate. The attribution comes from §1.1 per-entry compression/resolver
   telemetry, not only aggregate provider usage.
+
+  > **Empirical status (2026-06-26, measured on .254 with a live model).** The
+  > resident-saving arm is confirmed: on a code-heavy **chat** turn the fold cut
+  > the prompt by ~48% (678 → 355 prompt tokens; the envelope code block shrank
+  > ~78%). For **non-agentic chat ingress** there is no tool loop, so recovery
+  > rate is zero and the fold is a pure win — that ingress is the justified first
+  > flip candidate. For **agentic coding ingress** (Codex/Claude-Code, the
+  > dominant traffic) the agent re-opens the code it was pointed at, so the
+  > recovery rate is expected to be high and a single recovery round-trip
+  > (~80–130 tok) costs more than the fold saved (~40 tok) — the net is likely
+  > **negative**, exactly the risk this gate guards. Making the fold net-positive
+  > for the agentic case (e.g. recovery-rate-aware folding, or folding only spans
+  > the agent is statistically unlikely to re-open) is a **deferred future
+  > improvement**, tracked here and out of scope for the initial non-agentic
+  > flip. Measuring the live agentic recovery rate was unblocked on the client
+  > side by the Codex TLS-ALPN fix below; the remaining dependency is a
+  > recovery-rate capture in `bench/ingress_token_bench.py`.
+  >
+  > **Codex connectivity prerequisite (fixed).** Pointing the Codex CLI at a
+  > TLS Aimee failed at the transport layer: Aimee's server set **no ALPN**, and
+  > Codex's reqwest/hyper model client then attempts HTTP/2 and the request dies
+  > before reaching the server (Aimee is HTTP/1.1-only — `server_http.c`). The
+  > cert was never the cause (`CODEX_CA_CERTIFICATE` loads and verifies the
+  > IP-SAN). Fix: Aimee's TLS context now advertises `http/1.1` over ALPN
+  > (`SSL_CTX_set_alpn_select_cb` in `server_tls.c`), so ALPN-strict clients
+  > settle on HTTP/1.1 instead of a doomed HTTP/2 attempt. Validated: a Codex turn
+  > then connects and starts (`thread.started`/`turn.started`) where it previously
+  > errored instantly.
 - **Realized cache** — provider `cache_read` / `cache_creation` tokens, read from
   the cost-accounting proposal's **ledger fields** (not re-derived), under both
   placements (§2.2).

--- a/src/server/server_tls.c
+++ b/src/server/server_tls.c
@@ -48,6 +48,39 @@ static int mtls_verify_cb(int preverify_ok, X509_STORE_CTX *ctx)
    return 1;
 }
 
+/* ALPN selection: aimee's /v1 server speaks HTTP/1.1 only (hand-rolled HTTP/1.1
+ * server — see server_http.c). Advertise that explicitly so ALPN-strict clients
+ * settle on HTTP/1.1 instead of attempting HTTP/2 on an un-negotiated channel.
+ * The Codex CLI's model client (reqwest/hyper) does exactly this: without a
+ * negotiated ALPN it tries HTTP/2 and the request fails before reaching the
+ * server; offered "http/1.1" it uses HTTP/1.1 and connects. We never advertise
+ * "h2" (we cannot speak it).
+ *
+ * On no overlap we deliberately return NOACK, not a fatal no_application_protocol
+ * alert (RFC 7301 §3.2). NOACK makes OpenSSL omit the ALPN extension from the
+ * ServerHello, which is wire-identical to this server's prior no-ALPN behaviour —
+ * an h2-only or legacy no-ALPN client (e.g. the aimee thin client) keeps the
+ * exact handshake it had before. A fatal alert would instead *regress* those
+ * clients into a hard handshake failure, so backward-compatibility wins here.
+ *
+ * SSL_select_next_proto is the canonical ALPN-selection helper (see the example
+ * in SSL_CTX_set_alpn_select_cb(3)); the (unsigned char **) cast is mandated by
+ * its signature. Requires OpenSSL >= 1.0.2 — far below the 1.1.0+ floor this
+ * file already assumes via SSL_CTX_set_min_proto_version. */
+static int alpn_select_cb(SSL *ssl, const unsigned char **out, unsigned char *outlen,
+                          const unsigned char *in, unsigned int inlen, void *arg)
+{
+   (void)ssl;
+   (void)arg;
+   /* ALPN protocol list = length-prefixed wire form; the leading 8 is the byte
+    * length of "http/1.1" and must track the literal. */
+   static const unsigned char http11[] = {8, 'h', 't', 't', 'p', '/', '1', '.', '1'};
+   if (SSL_select_next_proto((unsigned char **)out, outlen, http11, sizeof(http11), in, inlen) !=
+       OPENSSL_NPN_NEGOTIATED)
+      return SSL_TLSEXT_ERR_NOACK; /* client didn't offer http/1.1 -> leave ALPN unset */
+   return SSL_TLSEXT_ERR_OK;
+}
+
 int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
                     const char *client_ca_path)
 {
@@ -69,6 +102,9 @@ int server_tls_init(const char *cert_path, const char *key_path, int mtls_mode,
    /* Modern floor; no client-cert verification (plain server TLS — the bearer is
     * the caller's authentication, the TLS is the channel). */
    SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+   /* Advertise HTTP/1.1 over ALPN so ALPN-strict clients (e.g. Codex) don't
+    * fall back to HTTP/2 on this HTTP/1.1-only server. */
+   SSL_CTX_set_alpn_select_cb(ctx, alpn_select_cb, NULL);
    /* The private key authenticates the server; warn loudly if it is readable by
     * group/other (defense-in-depth — the operator should 0600 it). */
    struct stat kst;


### PR DESCRIPTION
## Problem

Pointing the **Codex CLI** at a TLS Aimee fails at the **transport layer** with `error sending request` — and it is **not** a cert problem. Aimee's TLS server set **no ALPN** protocol, so Codex 0.141.0's reqwest/hyper model client attempts **HTTP/2** on the un-negotiated channel and the request dies before reaching the server. But Aimee is **HTTP/1.1-only** (hand-rolled server in `server_http.c`).

The cert is a red herring: `CODEX_CA_CERTIFICATE` loads and rustls verifies the IP-SAN — the failure is purely the absent ALPN.

## Diagnosis (how it was isolated)

- Direct to Aimee (`ALPN None`) → instant `error sending request`.
- nginx **h2** sidecar (`ALPN h2`) → Codex **still** failed (request never reached nginx; a client-side h2 quirk — curl `--http2` on the identical path returned 200).
- nginx **http/1.1-only** sidecar (`ALPN http/1.1`) → Codex **connected and started a turn** (`thread.started`/`turn.started`).

So Codex needs ALPN to *explicitly* negotiate `http/1.1`; given that, it works.

## Fix

Add an ALPN select callback (`SSL_CTX_set_alpn_select_cb`) that advertises `http/1.1` — never `h2` (we can't speak it). On no-overlap it returns `NOACK`, leaving ALPN unset exactly as before, so h2-only and no-ALPN (legacy thin-client) handshakes are **unchanged** (no regression). `NOACK` is chosen over a fatal `no_application_protocol` alert deliberately for backward-compat (a fatal alert would regress those clients into a hard failure).

## Validation

Standalone server using the exact callback:
- codex-like `h2,http/1.1` offer → selects **`http/1.1`** ✓
- h2-only client → no ALPN, handshake completes (unchanged) ✓
- no-ALPN legacy client → handshake completes (unchanged) ✓

End-to-end, a Codex turn then connects and starts where it previously errored instantly.

## Also

Records in the ingress-compression proposal (§6) the measured ~48% resident saving on code chat turns, the non-agentic (pure win) vs agentic (likely net-negative) regime split, and that net-positive folding for the **agentic** case is a deferred future improvement.

Reviewed via roundtable (converged, 0 failed); comment expanded to document the NOACK-vs-RFC-7301 rationale and the OpenSSL version floor per panel feedback.