### PR TITLE
fix(openai): MiniMax-M3 400s (reasoning_split) + responses string input

### DIFF
--- a/src/server/agent_bridge.c
+++ b/src/server/agent_bridge.c
@@ -165,8 +165,8 @@ cJSON *agent_build_request_openai(const agent_t *agent, cJSON *messages, cJSON *
       cJSON_AddBoolToObject(kwargs, "enable_thinking", 0);
    }
    openrouter_add_routing_hint(agent, req);
-   if (agent && (strcmp(agent->provider, "minimax") == 0 ||
-                 strstr(agent->endpoint, "api.minimax.") || strstr(agent->model, "MiniMax-M2.7")))
+   /* M2.7-only: MiniMax-M3 rejects reasoning_split with HTTP 400, and it is never read back. */
+   if (agent && strstr(agent->model, "MiniMax-M2.7"))
       cJSON_AddBoolToObject(req, "reasoning_split", 1);
 
    return req;

--- a/src/server/openai_shape.c
+++ b/src/server/openai_shape.c
@@ -381,8 +381,21 @@ int openai_parse_responses_to_chat(const char *body, char *model, size_t model_n
    }
 
    const cJSON *input = cJSON_GetObjectItemCaseSensitive(root, "input");
+   /* The Responses API allows `input` to be a bare string (shorthand for a single
+    * user message) OR an array of items. cJSON_ArrayForEach below is a no-op on a
+    * string, so without this branch a string `input` yields an empty messages
+    * array and the provider rejects the turn with HTTP 400. Require a non-empty
+    * string (an empty one carries no turn content — leave messages empty as
+    * before). */
+   if (cJSON_IsString(input) && input->valuestring && input->valuestring[0])
+   {
+      cJSON *m = cJSON_CreateObject();
+      cJSON_AddStringToObject(m, "role", "user");
+      cJSON_AddStringToObject(m, "content", input->valuestring);
+      cJSON_AddItemToArray(messages, m);
+   }
    const cJSON *item;
-   cJSON_ArrayForEach(item, input)
+   cJSON_ArrayForEach(item, input) /* no-op when `input` is the string handled above */
    {
       if (cJSON_IsString(item))
       {

--- a/src/tests/test_agent_http.c
+++ b/src/tests/test_agent_http.c
@@ -422,6 +422,15 @@ static void test_build_request_openai_minimax_options(void)
    assert(cJSON_IsTrue(split));
 
    cJSON_Delete(req);
+
+   /* MiniMax-M3 (and any non-M2.7 MiniMax model) must NOT get reasoning_split —
+    * the current MiniMax API rejects it with HTTP 400. */
+   snprintf(agent.model, sizeof(agent.model), "MiniMax-M3");
+   cJSON *req_m3 = agent_build_request_openai(&agent, messages, NULL, 1024, 0.0);
+   assert(req_m3 != NULL);
+   assert(cJSON_GetObjectItem(req_m3, "reasoning_split") == NULL);
+   cJSON_Delete(req_m3);
+
    cJSON_Delete(messages);
    printf("build_request_openai_minimax_options OK\n");
 }


### PR DESCRIPTION
Two provider-HTTP-400 bugs found while validating Codex against a TLS Aimee. The streaming `/v1/responses` path (`agent_execute_messages` → `agent_build_request_openai`) and minimax delegate requests both failed where the non-streaming path (clean `build_request_openai`) succeeded.

## Bug 1 — `reasoning_split` → MiniMax-M3 HTTP 400

`agent_build_request_openai` added `"reasoning_split":1` for **all** minimax requests (`provider==minimax` OR `api.minimax` endpoint OR `MiniMax-M2.7` model). It is a **MiniMax-M2.7-only** parameter; the current **MiniMax-M3** model rejects it with HTTP 400 (MiniMax strictly rejects unknown fields — noted elsewhere in the same file). The field is never read back out of any response.

**Fix:** gate `reasoning_split` strictly on the M2.7 model.

**Verified live on `.254`:** `model=minimax` non-stream (clean body, no `reasoning_split`) → **HTTP 200 + "PONG"**; with `reasoning_split` → **HTTP 400 every time** (server.log: `HTTP 400 (provider=minimax model=MiniMax-M3)`).

## Bug 2 — string `input` → empty messages → 400

The Responses API allows `input` to be a bare string (shorthand for one user message) or an array. `openai_parse_responses_to_chat` only iterated the array form (`cJSON_ArrayForEach` is a no-op on a string), so a string `input` produced an **empty messages array** → provider 400 (`messages required`).

**Fix:** build a single user message from a string `input`, matching the non-streaming responses parser.

## Tests
`test_agent_http` now asserts MiniMax-M3 gets **no** `reasoning_split` (M2.7 still does).

## Note (not a bug)
The "no content in response" I saw earlier was just MiniMax-M3 (a reasoning model) spending a 20-token budget on reasoning before emitting content — `max_tokens=800` returns "PONG" fine.