### PR TITLE
feat(mcp): expose surprising-links judge=true; reconcile §4 LLM-judge in proposal

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -2,10 +2,10 @@
 
 - **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7/§8-backend implemented (on the
   `testing` branch), including the §5 code+graph+vector hybrid, §7 graph-informed
-  delegation, the §4 surprising-links route (`/v1/code/graph/surprising`), and the §8
-  read-only `/v1/code/graph` backend route; remainder (§2 tree-sitter, §4
-  surprising-links LLM-judge confirmation, §6 live fusion, §8 webchat frontend) still
-  open, as build-/integration-/LLM-/frontend-tier work. See the
+  delegation, the §4 surprising-links route + its LLM-judge relevance gate, and the §8
+  read-only `/v1/code/graph` backend route; remainder (§2 tree-sitter, §6 live fusion,
+  §8 webchat frontend, and the §4 precision self-suppress monitoring) still open, as
+  build-/integration-/frontend-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
@@ -173,9 +173,18 @@ Computed over `code_projection_edges` + embeddings, served read-only:
   same-project file pair is 2 hops (file←project→file) and the signal is meaningless.
   A genuine vector-store outage is a 503 (distinct from an empty 200); every link
   carries `hops` (-1 = disconnected) + a `disconnected` bool. The SQL was validated
-  against real pgvector/halfvec. Still open (needs the LLM + a sampled corpus): the
-  §4 **LLM-judge / precision self-suppress** confirmation stage — this route returns
-  the structural candidates.
+  against real pgvector/halfvec.
+
+  **Status — relevance gate shipped.** With `judge=true` the top candidates go through
+  the §4 confirmation: a cheap shared-symbol cross-check plus ONE batched **Tier-B
+  LLM-judge** call (`kb_surprising_judge`, via the curator's `kb_curator_llm_run` —
+  reuses the configured `kb_curator_tier_b_*` provider, no new endpoint) that confirms
+  genuine parallel/duplicated logic vs coincidental similarity. Each judged link gains
+  `shared_symbols` and (when the model returns a verdict) `confirmed` + `reason`;
+  verdicts for pairs not actually sent are rejected so the model can't fabricate a
+  confirmation. Bounded to the top 12 links; opt-in (no LLM configured → unconfirmed
+  structural candidates). The remaining **precision self-suppress** (sample judged
+  precision, auto-disable below a floor) is a monitoring layer left as a follow-up.
 
 ## §5 Hybrid graph+vector+memory retrieval (the headline)
 
@@ -310,7 +319,9 @@ webchat **frontend** consumer remains open.
   (`pgvec_code_similar_pairs`) feeding the pure `kb_graph_surprising`
   (BFS distance + data-driven percentile), over the coupling graph **with the project
   containment hub excluded** (`handle_get_code_graph_surprising`,
-  `test_code_graph_surprising_*`).
+  `test_code_graph_surprising_*`), with an opt-in **LLM-judge relevance gate**
+  (`judge=true` → shared-symbol cross-check + one batched Tier-B judge,
+  `kb_surprising_judge`, `unit-test-kb-surprising-judge`).
 - **§5** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
   route fusing `code` + `graph` + **`vector`** (embedding similarity over
   `code_embeddings` via `pgvec_code_search_paths`, gated on a dim-matched embedder,
@@ -331,10 +342,9 @@ webchat **frontend** consumer remains open.
 **Deferred — needs the embedder / a build-tier dependency / a deployed corpus / a frontend
 (not completable in the agent host):**
 - **§2 tree-sitter** front-end — large build-tier work (vendor ~30 grammars + ABI).
-- **§4 surprising-links LLM-judge** — the route (pgvector pair-gather + node-identity
-  mapping + structural percentile/distance filter) is shipped; the **LLM-judge /
-  precision self-suppress** confirmation stage on the top candidates needs the LLM and
-  a sampled corpus.
+- **§4 precision self-suppress** — the LLM-judge relevance gate is shipped (opt-in
+  `judge=true`); the precision-sampling monitor that auto-disables the feature below a
+  quality floor needs a deployed corpus + judged-precision telemetry over time.
 - **§6 live/memory fusion** — post-merge/fetch incremental hook + watch.
 - **§8 webchat visualization** — the **frontend** consumer; the read-only `/v1/code/graph`
   backend route is shipped (above).

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1102,8 +1102,9 @@ char *kb_client_code_hybrid(const char *query, const char *symbol, const char *p
                             int max_results, int *status_out);
 char *kb_client_code_graph_hubs(const char *project, int max_results, int *status_out);
 /* /v1/code/graph/surprising: file pairs that are semantically close yet
- * structurally far (project required). */
-char *kb_client_code_graph_surprising(const char *project, int max_results, int *status_out);
+ * structurally far (project required). `judge` opts into the LLM confirmation. */
+char *kb_client_code_graph_surprising(const char *project, int max_results, int judge,
+                                      int *status_out);
 
 /* Counts of indexed files / definition-kind terms for one project.
  * Uses /v1 over remote HTTP or local UDS.

--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -127,6 +127,9 @@ void mcp_add_extended_tools(cJSON *tools)
        "with cosine + hop distance.");
    ext_prop(t, "project", "string", "Project to analyze.");
    ext_prop(t, "max_results", "integer", "Max surprising pairs to return (default 20, max 200).");
+   ext_prop(t, "judge", "boolean",
+            "Confirm the top candidates with an LLM (shared-symbol cross-check + a batched "
+            "judge): each gets confirmed + reason. Default false (structural candidates only).");
    ext_require(t, "project");
 
    /* ── Memory grounding: explain a retrieval + provenance/history ───────────── */

--- a/src/server/kb_client_code_graph.c
+++ b/src/server/kb_client_code_graph.c
@@ -91,7 +91,8 @@ char *kb_client_code_graph_hubs(const char *project, int max_results, int *statu
    return json;
 }
 
-char *kb_client_code_graph_surprising(const char *project, int max_results, int *status_out)
+char *kb_client_code_graph_surprising(const char *project, int max_results, int judge,
+                                      int *status_out)
 {
    if (status_out)
       *status_out = -1;
@@ -104,15 +105,16 @@ char *kb_client_code_graph_surprising(const char *project, int max_results, int 
    if (max_results < 1)
       max_results = 1;
 
-   size_t cap = strlen("/v1/code/graph/surprising?project=&max_results=") + strlen(project_q) + 32;
+   size_t cap =
+       strlen("/v1/code/graph/surprising?project=&max_results=&judge=true") + strlen(project_q) + 32;
    char *path = malloc(cap);
    if (!path)
    {
       free(project_q);
       return NULL;
    }
-   snprintf(path, cap, "/v1/code/graph/surprising?project=%s&max_results=%d", project_q,
-            max_results);
+   snprintf(path, cap, "/v1/code/graph/surprising?project=%s&max_results=%d%s", project_q,
+            max_results, judge ? "&judge=true" : "");
    free(project_q);
 
    char *json = kb_client_v1_get_json(path, KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS, status_out);

--- a/src/server/server_mcp_call_table.inc
+++ b/src/server/server_mcp_call_table.inc
@@ -1060,8 +1060,10 @@ static cJSON *mcph_index_graph_surprising(struct mcp_call *c)
       return text_content("error: index_graph_surprising requires 'project'");
    long long mr = 0;
    int max_results = pdf_arg_pos_int(c->jargs, "max_results", 200.0, &mr) ? (int)mr : 20;
+   cJSON *jj = cJSON_GetObjectItemCaseSensitive(c->jargs, "judge");
+   int judge = cJSON_IsTrue(jj) ? 1 : 0;
    int status = -1;
-   char *json = kb_client_code_graph_surprising(jp->valuestring, max_results, &status);
+   char *json = kb_client_code_graph_surprising(jp->valuestring, max_results, judge, &status);
    return code_graph_passthrough(json, status, "index_graph_surprising");
 }
 

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -25,7 +25,7 @@
    "git {action,async,base,body,branch,command,count,depth,diff_stat,files,force,index,job_id,message,mirror,mode,name,number,path,prune,rebase,ref,remote,source,staged,stat_only,state,title,url,wait} req:command\n" \
    "graph {command,entity,episode_key,limit,query} req:command\n" \
    "host {command,name} req:command\n" \
-   "index {command,file_path,line_end,line_start,max_results,paths,project,query,symbol} req:command\n" \
+   "index {command,file_path,judge,line_end,line_start,max_results,paths,project,query,symbol} req:command\n" \
    "job {command,job_id,max_concurrent,plan_id} req:command\n" \
    "learning {command,correction_text,description,evidence_refs,limit,polarity,signal_type,sink,state,target_key,target_memory_id,title,workflow_project,workflow_signal_type} req:command\n" \
    "list_curiosity_items {limit,state} req:\n" \


### PR DESCRIPTION
## Summary

Completes the §4 agent surface + reconciles the proposal.

- **`index({command:"surprising", judge:true})`** now opts into the §4 LLM confirmation (PR #760). `kb_client_code_graph_surprising` gains a `judge` arg (appends `&judge=true`); the MCP handler reads the `judge` bool; the tool advertises a `judge` property. So an agent can ask for **LLM-confirmed** duplicated-logic findings (each pair with `confirmed` + `reason`), not just structural candidates.
- **Golden surface**: count stays **47** — the sub-command folds into the multiplexed `index` family; its merged prop list gains `judge`, so `test_mcp_tools_golden.inc`'s `index` row was regenerated (one line).
- **Proposal doc**: §4 LLM-judge relevance gate marked shipped; only the precision self-suppress monitor remains open.

## Verification
`make all` builds clean, `line-check` clean, registry golden test passes, proposal reconcile + links gates pass, no docs-gen drift. The forwarder mirrors the reviewed `index_graph_hubs`/`surprising` pattern (PR #737/#758) plus one bool param.