### PR TITLE
feat(kb): §6 cross-session memory fusion — knowledge-graph leg in /v1/code/hybrid

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (122)
+## CLI-settable keys (123)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -35,6 +35,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `code_hybrid_rrf_k` | float | Reciprocal Rank Fusion rank constant k for /v1/code/hybrid (default 60). |
 | `code_hybrid_weight_code` | float | RRF weight for the lexical-code signal in /v1/code/hybrid (default 1.0; <=0 disables it). |
 | `code_hybrid_weight_graph` | float | RRF weight for the structural call-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it). |
+| `code_hybrid_weight_memory` | float | RRF weight for the cross-session knowledge-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it; symbol-anchored, empty without an entity graph). |
 | `code_hybrid_weight_vector` | float | RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder). |
 | `code_span_max_lines` | int | Max line span the code_span_get recovery resolver returns per call (default 400). |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -136,6 +136,7 @@ CFG_KEY_DESC = {
     "code_hybrid_weight_code": "RRF weight for the lexical-code signal in /v1/code/hybrid (default 1.0; <=0 disables it).",
     "code_hybrid_weight_graph": "RRF weight for the structural call-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it).",
     "code_hybrid_weight_vector": "RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder).",
+    "code_hybrid_weight_memory": "RRF weight for the cross-session knowledge-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it; symbol-anchored, empty without an entity graph).",
     "code_hybrid_rrf_k": "Reciprocal Rank Fusion rank constant k for /v1/code/hybrid (default 60).",
     "guardrails_blast_radius_advisory_enabled": "Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open).",
     "guardrails_semantic_allow_ml_only_block": "Allow blocking on the ML classifier alone.",

--- a/src/config.c
+++ b/src/config.c
@@ -549,6 +549,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->code_hybrid_weight_code = 1.0;
    cfg->code_hybrid_weight_graph = 1.0;
    cfg->code_hybrid_weight_vector = 1.0;
+   cfg->code_hybrid_weight_memory = 1.0;
    cfg->code_hybrid_rrf_k = 60.0; /* KB_RRF_DEFAULT_K */
    cfg->kb_bg_ingest_enabled = 1;
    cfg->kb_bg_ingest_interval_hours = 6;

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -129,6 +129,8 @@ const config_field_t config_fields[] = {
      CFG_FLOAT},
     {"code_hybrid_weight_vector", offsetof(config_t, code_hybrid_weight_vector), sizeof(double), 0,
      CFG_FLOAT},
+    {"code_hybrid_weight_memory", offsetof(config_t, code_hybrid_weight_memory), sizeof(double), 0,
+     CFG_FLOAT},
     {"code_hybrid_rrf_k", offsetof(config_t, code_hybrid_rrf_k), sizeof(double), 0, CFG_FLOAT},
     {"memory_semantic_weight", offsetof(config_t, memory_semantic_weight), sizeof(double), 0,
      CFG_FLOAT},

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1357,6 +1357,9 @@ void config_parse_kb_section2(config_t *cfg, cJSON *root)
          item = cJSON_GetObjectItemCaseSensitive(ch, "weight_vector");
          if (cJSON_IsNumber(item))
             cfg->code_hybrid_weight_vector = item->valuedouble;
+         item = cJSON_GetObjectItemCaseSensitive(ch, "weight_memory");
+         if (cJSON_IsNumber(item))
+            cfg->code_hybrid_weight_memory = item->valuedouble;
          item = cJSON_GetObjectItemCaseSensitive(ch, "rrf_k");
          if (cJSON_IsNumber(item) && item->valuedouble > 0)
             cfg->code_hybrid_rrf_k = item->valuedouble;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1261,6 +1261,7 @@ typedef struct config
    double code_hybrid_weight_code;
    double code_hybrid_weight_graph;
    double code_hybrid_weight_vector;
+   double code_hybrid_weight_memory;
    double code_hybrid_rrf_k;
    /* embedder-runtime-fetch-autodim §2c: when 0 (default) a recorded-vs-configured
     * embedding-dim mismatch is REFUSED at startup (refuse-and-instruct). When 1, the

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -680,6 +680,8 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
             /* the neighbor is whichever endpoint isn't the seed symbol */
             const char *neighbor =
                 strcmp(eedges[i].source, skey) == 0 ? eedges[i].target : eedges[i].source;
+            if (strcmp(neighbor, skey) == 0)
+               continue; /* self-edge: the symbol isn't its own memory neighbor */
             db2_entity_node_t node;
             if (db2_entity_node_get(neighbor, &node) != 0 || !node.file_path[0])
                continue;

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -8,6 +8,8 @@
 #include "db2/memory_query.h"
 #include "db2/code_projection.h"
 #include "db2/pgvec_transport.h"
+#include "db2/entity_edges.h" /* §6 memory-fusion leg: knowledge-graph edges */
+#include "db2/entity_nodes.h" /* db2_entity_node_get -> file_path */
 #include "memory.h"
 #include "kb/kb_rrf.h"
 #include "kb/kb_graph_analytics.h"
@@ -571,11 +573,12 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
    kb_rrf_item_t *code_items = calloc(HYBRID_PER_SIGNAL, sizeof(*code_items));
    kb_rrf_item_t *graph_items = calloc(HYBRID_PER_SIGNAL, sizeof(*graph_items));
    kb_rrf_item_t *vector_items = calloc(HYBRID_PER_SIGNAL, sizeof(*vector_items));
+   kb_rrf_item_t *memory_items = calloc(HYBRID_PER_SIGNAL, sizeof(*memory_items));
    char(*vpaths)[256] = calloc(HYBRID_PER_SIGNAL, sizeof(*vpaths));
    double *vscores = calloc(HYBRID_PER_SIGNAL, sizeof(*vscores));
-   kb_rrf_result_t *fused = calloc(HYBRID_PER_SIGNAL * 3, sizeof(*fused));
-   if (!chits || !ghits || !mems || !code_items || !graph_items || !vector_items || !vpaths ||
-       !vscores || !fused)
+   kb_rrf_result_t *fused = calloc(HYBRID_PER_SIGNAL * 4, sizeof(*fused));
+   if (!chits || !ghits || !mems || !code_items || !graph_items || !vector_items || !memory_items ||
+       !vpaths || !vscores || !fused)
    {
       free(chits);
       free(ghits);
@@ -583,6 +586,7 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       free(code_items);
       free(graph_items);
       free(vector_items);
+      free(memory_items);
       free(vpaths);
       free(vscores);
       free(fused);
@@ -621,12 +625,13 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
 
    /* Per-signal RRF weights + rank constant are config-tunable (§5). */
    config_t hcfg;
-   double w_code = 1.0, w_graph = 1.0, w_vector = 1.0, rrf_k = KB_RRF_DEFAULT_K;
+   double w_code = 1.0, w_graph = 1.0, w_vector = 1.0, w_memory = 1.0, rrf_k = KB_RRF_DEFAULT_K;
    if (config_load(&hcfg) == 0)
    {
       w_code = hcfg.code_hybrid_weight_code;
       w_graph = hcfg.code_hybrid_weight_graph;
       w_vector = hcfg.code_hybrid_weight_vector;
+      w_memory = hcfg.code_hybrid_weight_memory;
       if (hcfg.code_hybrid_rrf_k > 0)
          rrf_k = hcfg.code_hybrid_rrf_k;
    }
@@ -656,12 +661,52 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       }
    }
 
-   kb_rrf_signal_t sigs[3] = {
+   /* Signal D — cross-session memory / knowledge graph (§6 fusion). Symbol-anchored
+    * like the graph leg: seed the symbol's entity node and walk its incident
+    * knowledge-graph edges (built by the curator across sessions), resolving each
+    * neighbor entity to a file_path. Surfaces files the recorded reasoning associates
+    * with the symbol — a signal a regenerated code-only snapshot can never hold.
+    * w_memory<=0 disables it; absent a symbol or an entity graph it is simply empty. */
+   int nmem = 0;
+   if (w_memory > 0.0 && symbol[0])
+   {
+      char skey[GRAPH_ENDPOINT_MAX];
+      db2_entity_edge_explain_t *eedges = calloc(HYBRID_PER_SIGNAL, sizeof(*eedges));
+      if (eedges && db2_entity_node_key_symbol(proj, symbol, skey, sizeof(skey)) == 0)
+      {
+         int ne2 = db2_entity_edge_explain_by_entity(skey, eedges, HYBRID_PER_SIGNAL);
+         for (int i = 0; i < ne2 && nmem < HYBRID_PER_SIGNAL; i++)
+         {
+            /* the neighbor is whichever endpoint isn't the seed symbol */
+            const char *neighbor =
+                strcmp(eedges[i].source, skey) == 0 ? eedges[i].target : eedges[i].source;
+            db2_entity_node_t node;
+            if (db2_entity_node_get(neighbor, &node) != 0 || !node.file_path[0])
+               continue;
+            int dup = 0; /* keep the best-ranked row per file (edges arrive weight-desc) */
+            for (int j = 0; j < nmem; j++)
+               if (strcmp(memory_items[j].id, node.file_path) == 0)
+               {
+                  dup = 1;
+                  break;
+               }
+            if (dup)
+               continue;
+            snprintf(memory_items[nmem].id, sizeof(memory_items[nmem].id), "%s", node.file_path);
+            memory_items[nmem].structural_weight = eedges[i].structural_weight;
+            nmem++;
+         }
+      }
+      free(eedges);
+   }
+
+   kb_rrf_signal_t sigs[4] = {
        {code_items, nc, w_code, "code"},
        {graph_items, ng, w_graph, "graph"},
        {vector_items, nv, w_vector, "vector"},
+       {memory_items, nmem, w_memory, "memory"},
    };
-   int nf = kb_rrf_fuse(sigs, 3, rrf_k, fused, HYBRID_PER_SIGNAL * 3);
+   int nf = kb_rrf_fuse(sigs, 4, rrf_k, fused, HYBRID_PER_SIGNAL * 4);
    if (nf < 0)
       nf = 0;
    if (nf > max_r)
@@ -683,6 +728,7 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
       free(code_items);
       free(graph_items);
       free(vector_items);
+      free(memory_items);
       free(vpaths);
       free(vscores);
       free(fused);
@@ -736,6 +782,13 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
             cJSON_AddNumberToObject(row, "vector_score", vscores[j]);
             break;
          }
+      for (int j = 0; j < nmem; j++)
+         if (strcmp(memory_items[j].id, fp) == 0)
+         {
+            if (which)
+               cJSON_AddItemToArray(which, cJSON_CreateString("memory"));
+            break;
+         }
       cJSON_AddItemToArray(results, row);
    }
 
@@ -780,6 +833,7 @@ int handle_get_code_hybrid(const char *query_string, char *out_buf, int out_cap)
    free(code_items);
    free(graph_items);
    free(vector_items);
+   free(memory_items);
    free(vpaths);
    free(vscores);
    free(fused);

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -850,6 +850,7 @@ int config_load(config_t *cfg)
    cfg->code_hybrid_weight_code = 1.0;
    cfg->code_hybrid_weight_graph = 1.0;
    cfg->code_hybrid_weight_vector = 1.0;
+   cfg->code_hybrid_weight_memory = 1.0;
    cfg->code_hybrid_rrf_k = 60.0;
    return 0;
 }
@@ -1921,6 +1922,7 @@ int main(void)
    test_code_callers_missing_symbol();
    test_code_callers_ok();
    test_code_hybrid_ok();
+   test_code_hybrid_memory_leg();
    test_code_hybrid_missing_query();
    test_code_hybrid_no_symbol();
    test_code_hybrid_vector_ok();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -300,6 +300,20 @@ static void test_code_hybrid_ok(void)
    assert(strstr(buf, "why needle exists") != NULL);
 }
 
+/* §6 cross-session memory fusion: the knowledge graph connects the seed symbol to a
+ * memory-extracted entity that resolves to a file the code/graph/vector legs never
+ * see, fused in as a ranked "memory" signal (not just a why annotation). */
+static void test_code_hybrid_memory_leg(void)
+{
+   char buf[2048];
+   int s = kb_http_route_ex("GET", "/v1/code/hybrid",
+                            "query=needle&symbol=target_fn&project=proj-alpha&max_results=10", NULL,
+                            NULL, NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"file_path\":\"src/design_notes.c\"") != NULL);
+   assert(strstr(buf, "\"signals\":[\"memory\"]") != NULL);
+}
+
 static void test_code_hybrid_missing_query(void)
 {
    char buf[256];
@@ -395,6 +409,72 @@ static void test_code_graph_hubs_missing_project(void)
        kb_http_route_ex("GET", "/v1/code/graph/hubs", "", NULL, NULL, NULL, 0, buf, sizeof(buf));
    assert(s == 400);
    assert(strstr(buf, "missing project") != NULL);
+}
+
+/* §6 memory-fusion leg stubs. The real db2_entity_edge_explain_t / db2_entity_node_t
+ * (db2/entity_*.h) pull in memory.h's edge_t, which conflicts with this file's
+ * simplified memory_t; so mirror the layouts and take void* (same pattern as the
+ * code-projection stub). A symbol seed -> one knowledge-graph edge to a memory-
+ * extracted entity that resolves to a file the code/graph/vector legs never see. */
+typedef struct
+{
+   int64_t id;
+   char source[512];
+   char relation[64];
+   char target[512];
+   int weight;
+   int structural_weight;
+   double utility_score;
+   char edge_origin[32];
+} test_entity_edge_explain_t;
+typedef struct
+{
+   char node_key[512];
+   int node_kind;
+   char project[256];
+   char display_name[256];
+   char full_key[512];
+   char file_path[512];
+   char symbol[256];
+   char node_origin[32];
+   int64_t last_seen_generation_id;
+} test_entity_node_t;
+
+int db2_entity_node_key_symbol(const char *project, const char *name, char *out, size_t cap)
+{
+   (void)project;
+   if (!name || !out || cap == 0)
+      return -1;
+   snprintf(out, cap, "symbol:proj:%s", name);
+   return 0;
+}
+int db2_entity_edge_explain_by_entity(const char *entity, void *out, int max)
+{
+   if (!entity || !out || max < 1)
+      return 0;
+   if (strcmp(entity, "symbol:proj:target_fn") != 0)
+      return 0;
+   test_entity_edge_explain_t *e = (test_entity_edge_explain_t *)out;
+   memset(&e[0], 0, sizeof(e[0]));
+   snprintf(e[0].source, sizeof(e[0].source), "%s", entity);
+   snprintf(e[0].relation, sizeof(e[0].relation), "relates_to");
+   snprintf(e[0].target, sizeof(e[0].target), "mement:proj:design");
+   e[0].weight = 80;
+   e[0].structural_weight = 0;
+   return 1;
+}
+int db2_entity_node_get(const char *node_key, void *out)
+{
+   if (!node_key || !out)
+      return -1;
+   if (strcmp(node_key, "mement:proj:design") != 0)
+      return -1;
+   test_entity_node_t *n = (test_entity_node_t *)out;
+   memset(n, 0, sizeof(*n));
+   snprintf(n->node_key, sizeof(n->node_key), "%s", node_key);
+   snprintf(n->file_path, sizeof(n->file_path), "src/design_notes.c");
+   snprintf(n->node_origin, sizeof(n->node_origin), "memory_extraction");
+   return 0;
 }
 
 /* §4 judge stub: confirm the first link (the disconnected file:x/file:y pair) with a


### PR DESCRIPTION
## Summary

Realizes the **fusion half of §6**: folds the cross-session **knowledge graph** into `/v1/code/hybrid` as a 4th *ranked* signal (`memory`), not just the post-fusion `why` annotation. So a single hybrid query now ranks by **code + call-graph + vector + cross-session memory** — the proposal's thesis.

Symbol-anchored like the graph-callers leg: it seeds the symbol's entity node (`db2_entity_node_key_symbol`), walks its incident curator-built entity edges (`db2_entity_edge_explain_by_entity`), and resolves each neighbor entity to a `file_path` (`db2_entity_node_get`). Those files — which the recorded reasoning associates with the symbol but the code/graph/vector legs never see — fuse in via `kb_rrf_fuse` in file-path space. **This is the substrate a regenerated code-only snapshot can never hold.**

## Design
- 4th `kb_rrf_signal_t` leg (`fused` widened to `HYBRID_PER_SIGNAL*4`); `memory_items` deduped by file_path, ranked by edge order (weight-desc). Files it carries get `"memory"` in their `signals` array.
- Config-tunable **`code_hybrid_weight_memory`** (default 1.0; `<=0` disables — 6-touch: struct / default / parse / flat-field / docs-desc / configuration.md).
- **Gated** on a symbol + `w_memory>0`; **empty without an entity graph**, so zero behavior change on projects the curator hasn't synthesized yet. Memory cleanup added to all three free paths (alloc-oom / resp-null / final).

## Tests
`test_code_hybrid_memory_leg` — a symbol whose entity graph links to a memory-extracted file surfaces that file with `signals:["memory"]`. (Entity structs are mirrored in the test via void* cast, since `db2/entity_*.h` pull `memory.h`'s `edge_t`, which clashes with the route test's simplified `memory_t` — same pattern as the projection-edge stub.) `unit-test-config`/`unit-test-cmd-config` green; `aimee-kb` builds clean; line-check + docs-gen clean.

## Scope
Query-only (no-symbol) memory fusion and the §6 **live-reindex hook** (git post-merge/fetch) remain follow-ups; this lands the symbol-anchored fusion leg.