### PR TITLE
feat(kb): §6 live change-detection — skip code re-scan when default branch unchanged

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -3,8 +3,9 @@
 - **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7/§8-backend implemented (on the
   `testing` branch), including the §5 code+graph+vector hybrid, §7 graph-informed
   delegation, the §4 surprising-links route + its LLM-judge relevance gate, and the §8
-  read-only `/v1/code/graph` backend route; remainder (§2 tree-sitter, §6 live fusion,
-  §8 webchat frontend, and the §4 precision self-suppress monitoring) still open, as
+  read-only `/v1/code/graph` backend route, and the §6 cross-session memory-fusion
+  leg in `/v1/code/hybrid`; remainder (§2 tree-sitter, §6 *live* reindex hook, §8
+  webchat frontend, and the §4 precision self-suppress monitoring) still open, as
   build-/integration-/frontend-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
@@ -240,9 +241,27 @@ embedder — integration/deploy-tier) as a third fused signal.
 - **Incremental updates** on default-branch movement (post-merge / fetch hook +
   watch) so the graph tracks new commits on the canonical branch (§0.5), not a
   stale snapshot — and not the working tree.
+
+  **Status — change-detection gate shipped.** The `/v1/code/scan` route now no-ops
+  the expensive git re-walk when the default branch hasn't moved: `git_resolve_default_sha`
+  (the default ref's tree SHA, §0.5 chain) is compared via the pure
+  `code_default_branch_changed` against the last-indexed SHA stored in
+  `kb_runtime_state`; unchanged + non-`force` → `{"skipped":true}` (`unit-test-code-collect`
+  exercises the SHA-tracks-commits + gate logic against real git repos). This is the
+  cheap gate a post-merge/fetch **hook** reuses; installing that hook (mirroring
+  `verify_install_git_hook`) + the watch loop remain the integration follow-up.
 - **Fuse the graph with conversation memory + the decision log** so the "why" behind
   a symbol is the *actual recorded reasoning*, not just parsed comments — queryable
   via §5. This is the thing a regenerated artifact can never hold.
+
+  **Status — fusion half shipped.** `/v1/code/hybrid` now fuses a 4th ranked
+  **`memory`** signal: symbol-anchored, it walks the symbol's incident curator-built
+  knowledge-graph edges and resolves each neighbor entity to a `file_path`, so files
+  the recorded reasoning associates with the symbol rank alongside the code/graph/
+  vector legs (not just the post-fusion `why`). Config-tunable `code_hybrid_weight_memory`;
+  empty (no-op) until the curator has synthesized an entity graph
+  (`handle_get_code_hybrid` memory leg, `test_code_hybrid_memory_leg`). The **live
+  half** (incremental reindex on default-branch movement) remains open.
 
 ## §7 Agent actuation (the graph changes behavior)
 
@@ -322,12 +341,14 @@ webchat **frontend** consumer remains open.
   `test_code_graph_surprising_*`), with an opt-in **LLM-judge relevance gate**
   (`judge=true` → shared-symbol cross-check + one batched Tier-B judge,
   `kb_surprising_judge`, `unit-test-kb-surprising-judge`).
-- **§5** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
+- **§5+§6** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
   route fusing `code` + `graph` + **`vector`** (embedding similarity over
   `code_embeddings` via `pgvec_code_search_paths`, gated on a dim-matched embedder,
-  graceful-degrading) in file-path space with a typed memory `why`, **agent-callable**
-  via `index({command:"hybrid"})`, with **config-tunable per-signal weights**
-  (`kb.code_hybrid.*`). The vector SQL was validated against real pgvector/halfvec.
+  graceful-degrading) + **`memory`** (the §6 cross-session knowledge-graph leg,
+  symbol-anchored over curator entity edges) in file-path space with a typed memory
+  `why`, **agent-callable** via `index({command:"hybrid"})`, with **config-tunable
+  per-signal weights** (`kb.code_hybrid.*`). The vector SQL was validated against real
+  pgvector/halfvec.
 - **§7** structural blast-radius **advisory** on the guardrail edit path + **graph-informed
   delegation** (a delegate's prompt is prefixed with the callers/dependencies of the
   files its task references) — both advisory, fail-open, structural-only, opt-in
@@ -345,7 +366,10 @@ webchat **frontend** consumer remains open.
 - **§4 precision self-suppress** — the LLM-judge relevance gate is shipped (opt-in
   `judge=true`); the precision-sampling monitor that auto-disables the feature below a
   quality floor needs a deployed corpus + judged-precision telemetry over time.
-- **§6 live/memory fusion** — post-merge/fetch incremental hook + watch.
+- **§6 live half** — the change-detection gate (default-branch SHA + `/v1/code/scan`
+  skip-when-unchanged) and the memory-fusion leg are shipped; the post-merge/fetch
+  **hook install** + watch loop that *fire* the gate on a git event remain, needing a
+  running KB + git events to validate.
 - **§8 webchat visualization** — the **frontend** consumer; the read-only `/v1/code/graph`
   backend route is shipped (above).
 

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -252,6 +252,42 @@ static int git_resolve_default_ref(const char *root, char *out, size_t outlen)
    return -1;
 }
 
+/* §6 live: the default branch's tree SHA — a content identity for "has the canonical
+ * code moved?". Resolves the default ref (same chain as the collector) then
+ * `git rev-parse <ref>^{tree}`. Returns 0 + the 40-hex SHA in `out`, or -1 if there's
+ * no resolvable default branch (non-git dir, detached, unborn) — the caller then just
+ * scans unconditionally. Cheap (one rev-parse), so it gates the expensive re-walk. */
+int git_resolve_default_sha(const char *root, char *out, size_t outlen)
+{
+   if (!root || !out || outlen == 0)
+      return -1;
+   out[0] = '\0';
+   char ref[256];
+   if (git_resolve_default_ref(root, ref, sizeof(ref)) != 0)
+      return -1;
+   char args[320];
+   snprintf(args, sizeof(args), "rev-parse '%s^{tree}'", ref);
+   if (git_capture_line(root, args, out, outlen) != 0 || !out[0])
+   {
+      out[0] = '\0';
+      return -1;
+   }
+   return 0;
+}
+
+/* Pure gate: should a project be re-indexed given its last-indexed and current
+ * default-branch SHAs? 1 if the current SHA is known AND differs (or there is no
+ * stored SHA = never indexed); 0 if the current SHA is unresolvable (don't thrash on
+ * a transient git failure) or unchanged. */
+int code_default_branch_changed(const char *stored_sha, const char *current_sha)
+{
+   if (!current_sha || !current_sha[0])
+      return 0;
+   if (!stored_sha || !stored_sha[0])
+      return 1;
+   return strcmp(stored_sha, current_sha) != 0;
+}
+
 /* Skip a tracked path whose any component is a VCS/build/vendor/hidden dir, so a
  * checked-in node_modules/vendor tree is filtered exactly like the worktree walk
  * filters it (code_dir_skip). */

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -282,6 +282,15 @@ int git_resolve_default_sha(const char *root, char *out, size_t outlen)
    return 0;
 }
 
+/* 1 when AIMEE_CODE_INDEX_SOURCE opts into indexing the working tree (so the index
+ * reflects WIP, not the default branch). The default-branch SHA gate is invalid in
+ * that mode — the branch SHA can't see a worktree edit — so callers skip the gate. */
+int code_index_source_is_worktree(void)
+{
+   const char *mode = getenv("AIMEE_CODE_INDEX_SOURCE");
+   return mode && strcmp(mode, "worktree") == 0;
+}
+
 /* Pure gate: should a project be re-indexed given its last-indexed and current
  * default-branch SHAs? 1 if the current SHA is known AND differs (or there is no
  * stored SHA = never indexed); 0 if the current SHA is unresolvable (don't thrash on

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -265,8 +265,15 @@ int git_resolve_default_sha(const char *root, char *out, size_t outlen)
    char ref[256];
    if (git_resolve_default_ref(root, ref, sizeof(ref)) != 0)
       return -1;
-   char args[320];
-   snprintf(args, sizeof(args), "rev-parse '%s^{tree}'", ref);
+   /* The ref is the live default-branch name (origin/HEAD target) — attacker-
+    * controllable for an untrusted repo, and git ref names may contain a single
+    * quote — so shquote the whole revision rather than hand-wrapping it in quotes. */
+   char rev[320], qrev[1024];
+   snprintf(rev, sizeof(rev), "%s^{tree}", ref);
+   if (shquote(rev, qrev, sizeof(qrev)) != 0)
+      return -1;
+   char args[1100];
+   snprintf(args, sizeof(args), "rev-parse %s", qrev);
    if (git_capture_line(root, args, out, outlen) != 0 || !out[0])
    {
       out[0] = '\0';

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -42,6 +42,9 @@ int code_collect_files(const char *root, cJSON *files_arr);
  * gate deciding whether a stored vs current SHA warrants a re-index. */
 int git_resolve_default_sha(const char *root, char *out, size_t outlen);
 int code_default_branch_changed(const char *stored_sha, const char *current_sha);
+/* 1 if AIMEE_CODE_INDEX_SOURCE=worktree (the index tracks WIP, so the default-branch
+ * SHA gate must NOT be applied). */
+int code_index_source_is_worktree(void);
 
 /* Discover git repositories under `root` for one-project-per-repo ingest: invoke
  * `cb` once per real checkout (a directory whose `.git` is itself a directory),

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -37,6 +37,12 @@ int code_collect_files_cb(const char *root, code_collect_file_cb cb, void *ctx);
  * and the tree is known-small. Returns the number of files appended. */
 int code_collect_files(const char *root, cJSON *files_arr);
 
+/* §6 live: resolve the default branch's tree SHA for `root` (0 + 40-hex in `out`,
+ * or -1 if no resolvable default branch). `code_default_branch_changed` is the pure
+ * gate deciding whether a stored vs current SHA warrants a re-index. */
+int git_resolve_default_sha(const char *root, char *out, size_t outlen);
+int code_default_branch_changed(const char *stored_sha, const char *current_sha);
+
 /* Discover git repositories under `root` for one-project-per-repo ingest: invoke
  * `cb` once per real checkout (a directory whose `.git` is itself a directory),
  * with the repo's absolute path. Linked worktrees (`.git` is a regular file) are

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -8,8 +8,10 @@
 #include "db2/memory_query.h"
 #include "db2/code_projection.h"
 #include "db2/pgvec_transport.h"
-#include "db2/entity_edges.h" /* §6 memory-fusion leg: knowledge-graph edges */
-#include "db2/entity_nodes.h" /* db2_entity_node_get -> file_path */
+#include "db2/entity_edges.h"     /* §6 memory-fusion leg: knowledge-graph edges */
+#include "db2/entity_nodes.h"     /* db2_entity_node_get -> file_path */
+#include "code_collect.h"         /* §6 live: git_resolve_default_sha + change gate */
+#include "db2/kb_runtime_state.h" /* stored last-indexed default-branch SHA */
 #include "memory.h"
 #include "kb/kb_rrf.h"
 #include "kb/kb_graph_analytics.h"
@@ -1421,6 +1423,8 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
    const char *root_path = cJSON_IsString(root_path_j) ? root_path_j->valuestring : "";
    int force = code_scan_bool(root, "force", 0);
    cJSON *files_j = cJSON_GetObjectItemCaseSensitive(root, "files");
+   char sha_now[128] = ""; /* §6: default-branch SHA, tracked across the local-scan path */
+   char sha_key[320] = "";
 
    if (!db2_is_initialized())
    {
@@ -1469,6 +1473,25 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing root_path\"}");
          return 400;
       }
+      /* §6 live idempotency: skip the expensive git re-walk when the default branch
+       * hasn't moved since the last scan (force overrides). The SHA is cheap; the
+       * scan is not. A future post-merge/fetch hook reuses exactly this gate so it
+       * no-ops unless the canonical code actually changed. */
+      if (!force && git_resolve_default_sha(root_path, sha_now, sizeof(sha_now)) == 0)
+      {
+         char stored[128] = "";
+         snprintf(sha_key, sizeof(sha_key), "code_scan_sha:%s", project);
+         db2_kb_runtime_state_get(sha_key, stored, sizeof(stored));
+         if (!code_default_branch_changed(stored, sha_now))
+         {
+            snprintf(out_buf, (size_t)out_cap,
+                     "{\"status\":\"ok\",\"skipped\":true,\"reason\":\"default branch unchanged\","
+                     "\"project\":\"%s\",\"files\":0,\"inspected\":0}",
+                     project);
+            cJSON_Delete(root);
+            return 200;
+         }
+      }
       files = canonical_index_scan_project(project, root_path, force, &inspected);
    }
    if (files < 0)
@@ -1486,6 +1509,14 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
     * thin client were never queued for curation. The 0.6B embed pass is driven
     * separately by the curator drain. */
    kb_curator_queue_code_units_for_project(project, root_path);
+
+   /* Record the scanned default-branch SHA so the next !force scan can no-op when the
+    * branch hasn't moved (sha_now is set only on the local-scan path that resolved it). */
+   if (sha_now[0])
+   {
+      snprintf(sha_key, sizeof(sha_key), "code_scan_sha:%s", project);
+      db2_kb_runtime_state_set(sha_key, sha_now);
+   }
 
    snprintf(out_buf, (size_t)out_cap,
             "{\"status\":\"ok\",\"skipped\":false,\"project\":\"%s\",\"files\":%d,"

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1473,11 +1473,11 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
          snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing root_path\"}");
          return 400;
       }
-      /* §6 live idempotency: skip the expensive git re-walk when the default branch
-       * hasn't moved since the last scan (force overrides). The SHA is cheap; the
-       * scan is not. A future post-merge/fetch hook reuses exactly this gate so it
-       * no-ops unless the canonical code actually changed. */
-      if (!force && git_resolve_default_sha(root_path, sha_now, sizeof(sha_now)) == 0)
+      /* §6 live idempotency: resolve the default-branch SHA (cheap) so a !force scan
+       * can skip the expensive git re-walk when the branch hasn't moved since the last
+       * index, and so any successful scan (force or not) refreshes the stored SHA. A
+       * future post-merge/fetch hook reuses exactly this gate. */
+      if (git_resolve_default_sha(root_path, sha_now, sizeof(sha_now)) == 0 && !force)
       {
          char stored[128] = "";
          snprintf(sha_key, sizeof(sha_key), "code_scan_sha:%s", project);

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1476,8 +1476,10 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
       /* §6 live idempotency: resolve the default-branch SHA (cheap) so a !force scan
        * can skip the expensive git re-walk when the branch hasn't moved since the last
        * index, and so any successful scan (force or not) refreshes the stored SHA. A
-       * future post-merge/fetch hook reuses exactly this gate. */
-      if (git_resolve_default_sha(root_path, sha_now, sizeof(sha_now)) == 0 && !force)
+       * future post-merge/fetch hook reuses exactly this gate. Disabled under the
+       * worktree opt-in, where the index tracks WIP the branch SHA can't see. */
+      if (!code_index_source_is_worktree() &&
+          git_resolve_default_sha(root_path, sha_now, sizeof(sha_now)) == 0 && !force)
       {
          char stored[128] = "";
          snprintf(sha_key, sizeof(sha_key), "code_scan_sha:%s", project);

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -233,6 +233,28 @@ static void test_default_branch_sha_tracks_commits(void)
    printf("  test_default_branch_sha_tracks_commits: ok\n");
 }
 
+/* Regression: a default branch whose NAME contains a single quote must resolve
+ * correctly (and never break out of the shell) — the ref is shquoted, not hand-
+ * wrapped. Set up via a clone so origin/HEAD points at the quote-named branch. */
+static void test_default_branch_sha_quote_in_ref(void)
+{
+   make_root("qsha");
+   char up[1200];
+   snprintf(up, sizeof(up), "%s-rem", g_root);
+   sh("rm -rf '%s' '%s'", up, g_root); /* clone needs a non-existent / empty target */
+   sh("git init -q -b \"wip'x\" '%s'", up);
+   sh("git -C '%s' config user.email t@t && git -C '%s' config user.name t", up, up);
+   sh("printf 'int q(void){return 0;}' > '%s/q.c'", up);
+   sh("git -C '%s' add -A && git -C '%s' commit -qm c", up, up);
+   sh("git clone -q '%s' '%s'", up, g_root);
+
+   char sha[128] = "";
+   int rc = git_resolve_default_sha(g_root, sha, sizeof(sha));
+   assert(rc == 0 && strlen(sha) >= 7); /* resolved despite the quote in the ref name */
+   sh("rm -rf '%s'", up);
+   printf("  test_default_branch_sha_quote_in_ref: ok\n");
+}
+
 /* A non-git dir has no default branch SHA; `out` is cleared and -1 returned. */
 static void test_default_branch_sha_non_git(void)
 {
@@ -259,6 +281,7 @@ int main(void)
    test_no_default_branch_skips();
    test_non_git_uses_worktree();
    test_default_branch_sha_tracks_commits();
+   test_default_branch_sha_quote_in_ref();
    test_default_branch_sha_non_git();
    sh("rm -rf '%s'", g_root);
    printf("ALL PASS\n");

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -202,6 +202,48 @@ static void test_non_git_uses_worktree(void)
    printf("  test_non_git_uses_worktree: ok\n");
 }
 
+/* §6 live: the default-branch tree SHA tracks commits, and the pure change-gate
+ * decides when a re-index is warranted. */
+static void test_default_branch_sha_tracks_commits(void)
+{
+   make_root("sha");
+   git("init -q -b main");
+   git("config user.email t@t");
+   git("config user.name t");
+   write_file("src/a.c", "int a(void){return 1;}");
+   git("add -A");
+   git("commit -qm c1");
+
+   char sha1[128] = "", sha1b[128] = "";
+   assert(git_resolve_default_sha(g_root, sha1, sizeof(sha1)) == 0 && sha1[0]);
+   assert(git_resolve_default_sha(g_root, sha1b, sizeof(sha1b)) == 0);
+   assert(strcmp(sha1, sha1b) == 0); /* stable when nothing moved */
+
+   write_file("src/b.c", "int b(void){return 2;}");
+   git("add -A");
+   git("commit -qm c2");
+   char sha2[128] = "";
+   assert(git_resolve_default_sha(g_root, sha2, sizeof(sha2)) == 0);
+   assert(strcmp(sha1, sha2) != 0); /* a commit moves the tree SHA */
+
+   assert(code_default_branch_changed(sha1, sha2) == 1); /* moved -> reindex */
+   assert(code_default_branch_changed(sha1, sha1) == 0); /* unchanged -> skip */
+   assert(code_default_branch_changed("", sha1) == 1);   /* never indexed -> reindex */
+   assert(code_default_branch_changed(sha1, "") == 0);   /* unresolved -> don't thrash */
+   printf("  test_default_branch_sha_tracks_commits: ok\n");
+}
+
+/* A non-git dir has no default branch SHA; `out` is cleared and -1 returned. */
+static void test_default_branch_sha_non_git(void)
+{
+   make_root("nogit-sha");
+   write_file("a.c", "x");
+   char sha[128] = "preset";
+   assert(git_resolve_default_sha(g_root, sha, sizeof(sha)) == -1);
+   assert(sha[0] == '\0');
+   printf("  test_default_branch_sha_non_git: ok\n");
+}
+
 int main(void)
 {
    printf("test_code_collect:\n");
@@ -216,6 +258,8 @@ int main(void)
    test_clone_resolves_origin_head();
    test_no_default_branch_skips();
    test_non_git_uses_worktree();
+   test_default_branch_sha_tracks_commits();
+   test_default_branch_sha_non_git();
    sh("rm -rf '%s'", g_root);
    printf("ALL PASS\n");
    return 0;

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -255,6 +255,20 @@ static void test_default_branch_sha_quote_in_ref(void)
    printf("  test_default_branch_sha_quote_in_ref: ok\n");
 }
 
+/* The worktree-source predicate reflects AIMEE_CODE_INDEX_SOURCE (gates off the
+ * default-branch SHA optimization when the index tracks WIP). */
+static void test_index_source_is_worktree(void)
+{
+   unsetenv("AIMEE_CODE_INDEX_SOURCE");
+   assert(code_index_source_is_worktree() == 0);
+   setenv("AIMEE_CODE_INDEX_SOURCE", "default", 1);
+   assert(code_index_source_is_worktree() == 0);
+   setenv("AIMEE_CODE_INDEX_SOURCE", "worktree", 1);
+   assert(code_index_source_is_worktree() == 1);
+   unsetenv("AIMEE_CODE_INDEX_SOURCE");
+   printf("  test_index_source_is_worktree: ok\n");
+}
+
 /* A non-git dir has no default branch SHA; `out` is cleared and -1 returned. */
 static void test_default_branch_sha_non_git(void)
 {
@@ -282,6 +296,7 @@ int main(void)
    test_non_git_uses_worktree();
    test_default_branch_sha_tracks_commits();
    test_default_branch_sha_quote_in_ref();
+   test_index_source_is_worktree();
    test_default_branch_sha_non_git();
    sh("rm -rf '%s'", g_root);
    printf("ALL PASS\n");

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -281,9 +281,8 @@ int kb_curator_contradictions_json(int limit, char *out, size_t out_cap)
    return 1;
 }
 
-/* §2c: stubs for the new /v1/reembed + /v1/search-guard db2 refs in kb_http.o.
- * g_test_reembed_in_progress lets a test drive the maintenance marker so the
- * /v1/search 503 guard can be exercised deterministically. */
+/* §2c: stubs for the /v1/reembed + /v1/search-guard db2 refs in kb_http.o.
+ * g_test_reembed_in_progress drives the maintenance marker (the /v1/search 503 guard). */
 static int g_test_reembed_in_progress = 0;
 int db2_reembed_in_progress_get(int *target_dim, long *started_epoch)
 {
@@ -1945,6 +1944,8 @@ int main(void)
    test_blast_radius_not_found();
    test_blast_radius_ok();
    test_code_scan_ok();
+   test_code_scan_skips_unchanged_branch();
+   test_code_scan_runs_on_branch_move();
    test_code_scan_missing_root_path();
    test_code_scan_pushed_files_ok();
    test_code_scan_pushed_files_rejects_invalid_item();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -523,8 +523,7 @@ int canonical_index_project_lang_breakdown(const char *project, char *buf, size_
    return 0;
 }
 
-/* Must mirror code_search_hit_t (index.h) exactly — the handler casts the out
- * buffer to it; a layout mismatch would corrupt the read. */
+/* Must mirror code_search_hit_t (index.h) exactly (handler casts the out buffer to it). */
 typedef struct
 {
    char project[128];

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -906,8 +906,8 @@ int db2_demotion_profile_read(const char *memory_class, const char *scope_kind,
    return 0;
 }
 
-/* kb_intel_payload's bandit.sample/close builders call these; this test does not
- * link kb_bandit.o. Stub sample as "disabled" and reward as a no-op success. */
+/* kb_intel_payload's bandit.sample/close builders call these (kb_bandit.o unlinked):
+ * stub sample as "disabled", reward as a no-op success. */
 int kb_bandit_sample(const config_t *cfg, const char *decision_point, const char *context_json,
                      const char (*arm_ids)[KB_BANDIT_MAX_ARM_ID], int n_arms, char *decision_id_out)
 {
@@ -1946,6 +1946,7 @@ int main(void)
    test_code_scan_ok();
    test_code_scan_skips_unchanged_branch();
    test_code_scan_runs_on_branch_move();
+   test_code_scan_worktree_ignores_sha();
    test_code_scan_missing_root_path();
    test_code_scan_pushed_files_ok();
    test_code_scan_pushed_files_rejects_invalid_item();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -697,6 +697,80 @@ static void test_blast_radius_ok(void)
    assert(strstr(buf, "\"dependency_count\":1") != NULL);
 }
 
+/* §6 live-idempotency stubs: the scan route gates the git re-walk on the default-
+ * branch SHA. g_branch_sha drives git_resolve_default_sha (empty -> unresolvable, the
+ * gate is skipped); g_stored_sha is the persisted last-indexed SHA. */
+static char g_branch_sha[128] = "";
+static char g_stored_sha[128] = "";
+static char g_runtime_state_set_val[128] = "";
+int git_resolve_default_sha(const char *root, char *out, size_t outlen)
+{
+   (void)root;
+   if (!g_branch_sha[0] || !out || outlen == 0)
+      return -1;
+   snprintf(out, outlen, "%s", g_branch_sha);
+   return 0;
+}
+int db2_kb_runtime_state_get(const char *key, char *out, size_t out_len)
+{
+   (void)key;
+   if (!out || out_len == 0)
+      return -1;
+   snprintf(out, out_len, "%s", g_stored_sha);
+   return g_stored_sha[0] ? 0 : -1;
+}
+int db2_kb_runtime_state_set(const char *key, const char *value)
+{
+   (void)key;
+   snprintf(g_runtime_state_set_val, sizeof(g_runtime_state_set_val), "%s", value ? value : "");
+   return 0;
+}
+/* Faithful mirror of the pure gate (its real logic is unit-tested in test_code_collect). */
+int code_default_branch_changed(const char *stored_sha, const char *current_sha)
+{
+   if (!current_sha || !current_sha[0])
+      return 0;
+   if (!stored_sha || !stored_sha[0])
+      return 1;
+   return strcmp(stored_sha, current_sha) != 0;
+}
+
+/* Unchanged default branch (stored SHA == current) + !force -> skip the re-walk. */
+static void test_code_scan_skips_unchanged_branch(void)
+{
+   char buf[512];
+   g_db_initialized = 1;
+   g_code_scan_rc = 5;
+   snprintf(g_branch_sha, sizeof(g_branch_sha), "tree-aaa");
+   snprintf(g_stored_sha, sizeof(g_stored_sha), "tree-aaa");
+   const char *body = "{\"project\":\"proj-alpha\",\"root_path\":\"/tmp/repo\"}";
+   int s = kb_http_route_ex("POST", "/v1/code/scan", NULL, NULL, NULL, body, (int)strlen(body), buf,
+                            sizeof(buf));
+   g_branch_sha[0] = '\0'; /* reset so later tests see an unresolvable SHA (gate off) */
+   assert(s == 200);
+   assert(strstr(buf, "\"skipped\":true") != NULL);
+   assert(strstr(buf, "default branch unchanged") != NULL);
+}
+
+/* Branch moved (stored != current) -> scan runs and the new SHA is persisted. */
+static void test_code_scan_runs_on_branch_move(void)
+{
+   char buf[512];
+   g_db_initialized = 1;
+   g_code_scan_rc = 5;
+   g_code_scan_inspected = 3;
+   g_runtime_state_set_val[0] = '\0';
+   snprintf(g_branch_sha, sizeof(g_branch_sha), "tree-bbb");
+   snprintf(g_stored_sha, sizeof(g_stored_sha), "tree-aaa");
+   const char *body = "{\"project\":\"proj-alpha\",\"root_path\":\"/tmp/repo\"}";
+   int s = kb_http_route_ex("POST", "/v1/code/scan", NULL, NULL, NULL, body, (int)strlen(body), buf,
+                            sizeof(buf));
+   g_branch_sha[0] = '\0';
+   assert(s == 200);
+   assert(strstr(buf, "\"skipped\":false") != NULL);
+   assert(strcmp(g_runtime_state_set_val, "tree-bbb") == 0); /* persisted for next time */
+}
+
 static void test_code_scan_ok(void)
 {
    char buf[512];

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -734,6 +734,11 @@ int code_default_branch_changed(const char *stored_sha, const char *current_sha)
       return 1;
    return strcmp(stored_sha, current_sha) != 0;
 }
+static int g_worktree_mode = 0; /* drives the SHA-gate bypass under the worktree opt-in */
+int code_index_source_is_worktree(void)
+{
+   return g_worktree_mode;
+}
 
 /* Unchanged default branch (stored SHA == current) + !force -> skip the re-walk. */
 static void test_code_scan_skips_unchanged_branch(void)
@@ -769,6 +774,25 @@ static void test_code_scan_runs_on_branch_move(void)
    assert(s == 200);
    assert(strstr(buf, "\"skipped\":false") != NULL);
    assert(strcmp(g_runtime_state_set_val, "tree-bbb") == 0); /* persisted for next time */
+}
+
+/* Under the worktree opt-in the branch-SHA gate is bypassed: even an unchanged
+ * default-branch SHA must NOT skip, because the index tracks the working tree. */
+static void test_code_scan_worktree_ignores_sha(void)
+{
+   char buf[512];
+   g_db_initialized = 1;
+   g_code_scan_rc = 5;
+   g_worktree_mode = 1;
+   snprintf(g_branch_sha, sizeof(g_branch_sha), "tree-aaa");
+   snprintf(g_stored_sha, sizeof(g_stored_sha), "tree-aaa"); /* would skip in default mode */
+   const char *body = "{\"project\":\"proj-alpha\",\"root_path\":\"/tmp/repo\"}";
+   int s = kb_http_route_ex("POST", "/v1/code/scan", NULL, NULL, NULL, body, (int)strlen(body), buf,
+                            sizeof(buf));
+   g_worktree_mode = 0;
+   g_branch_sha[0] = '\0';
+   assert(s == 200);
+   assert(strstr(buf, "\"skipped\":false") != NULL); /* worktree mode never skips */
 }
 
 static void test_code_scan_ok(void)


### PR DESCRIPTION
## Summary

Lands the **detection half of §6 'live'**: notice that the canonical code moved, so a re-scan only happens when it actually did. (§1's idempotent drain already finishes the rebuild once `files` is refreshed; the gap was git-awareness.)

- **`git_resolve_default_sha`** (`code_collect.c`) — the default ref's **tree SHA** (resolves the §0.5 ref chain, then `git rev-parse <ref>^{tree}`). **`code_default_branch_changed`** — the pure gate (current-known-AND-differs, or never-indexed → reindex; unresolved → don't thrash).
- **`/v1/code/scan`** — on the local-scan path, a non-`force` scan now **no-ops the expensive git re-walk** when the default-branch SHA matches the last-indexed one (stored in `kb_runtime_state` under `code_scan_sha:<project>`) → `{"skipped":true}`. A successful scan persists the new SHA. `force` overrides. This is exactly the cheap gate a future **post-merge/fetch hook** reuses so it fires a rebuild only when the branch moved.

## Tests
- **`unit-test-code-collect`** — `git_resolve_default_sha` + the gate against **real git repos**: the tree SHA tracks commits, is stable when nothing moved, and is cleared on a non-git dir; the pure gate's four cases.
- Route tests — skip-when-unchanged and scan-and-persist-on-move (stubbed SHA + runtime_state).
- `aimee-kb` builds clean; line-check + docs-gen clean.

## Scope
The post-merge/fetch **hook install** (mirroring `verify_install_git_hook`) + the watch loop that *fire* this gate on a git event remain the integration follow-up (need a running KB + git events to validate). Also reconciles the §6 memory-fusion + live status in the proposal doc.