### PR TITLE
feat(mcp): expose code-graph node neighborhood as index({command:'neighbors'}) (§8 enabler)

### DIFF
--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1105,6 +1105,10 @@ char *kb_client_code_graph_hubs(const char *project, int max_results, int *statu
  * structurally far (project required). `judge` opts into the LLM confirmation. */
 char *kb_client_code_graph_surprising(const char *project, int max_results, int judge,
                                       int *status_out);
+/* /v1/code/graph: a node's incident projection edges (callers/callees/neighbors);
+ * project + node required. Backs the webchat graph view (§8). */
+char *kb_client_code_graph_node(const char *project, const char *node, int max_results,
+                                int *status_out);
 
 /* Counts of indexed files / definition-kind terms for one project.
  * Uses /v1 over remote HTTP or local UDS.

--- a/src/mcp_tools_extended.c
+++ b/src/mcp_tools_extended.c
@@ -132,6 +132,16 @@ void mcp_add_extended_tools(cJSON *tools)
             "judge): each gets confirmed + reason. Default false (structural candidates only).");
    ext_require(t, "project");
 
+   t = ext_tool(tools, "index_graph_node",
+                "A code node's incident projection edges (callers / callees / containers / "
+                "neighbors) with relation, direction (in/out/self), structural weight, and §3 "
+                "provenance. Backs interactive graph exploration.");
+   ext_prop(t, "project", "string", "Project the node belongs to.");
+   ext_prop(t, "node", "string", "Node key/symbol to expand (e.g. a hub from index_graph_hubs).");
+   ext_prop(t, "max_results", "integer", "Max neighbors to return (default 50, max 200).");
+   ext_require(t, "project");
+   ext_require(t, "node");
+
    /* ── Memory grounding: explain a retrieval + provenance/history ───────────── */
    t = ext_tool(tools, "memory_explain_match",
                 "Explain WHY a memory matches a query: the per-signal score breakdown "
@@ -279,6 +289,7 @@ static const struct fam_def MCP_FAMILIES[] = {
       {"hybrid", "index_hybrid"},
       {"hubs", "index_graph_hubs"},
       {"surprising", "index_graph_surprising"},
+      {"neighbors", "index_graph_node"},
       {NULL, NULL}}},
     {"note",
      "command",

--- a/src/server/kb_client_code_graph.c
+++ b/src/server/kb_client_code_graph.c
@@ -121,3 +121,41 @@ char *kb_client_code_graph_surprising(const char *project, int max_results, int 
    free(path);
    return json;
 }
+
+char *kb_client_code_graph_node(const char *project, const char *node, int max_results,
+                                int *status_out)
+{
+   if (status_out)
+      *status_out = -1;
+   if (!project || !project[0] || !node || !node[0])
+      return NULL;
+
+   char *project_q = kb_client_query_escape(project);
+   char *node_q = kb_client_query_escape(node);
+   if (!project_q || !node_q)
+   {
+      free(project_q);
+      free(node_q);
+      return NULL;
+   }
+   if (max_results < 1)
+      max_results = 1;
+
+   size_t cap = strlen("/v1/code/graph?project=&node=&max_results=") + strlen(project_q) +
+                strlen(node_q) + 32;
+   char *path = malloc(cap);
+   if (!path)
+   {
+      free(project_q);
+      free(node_q);
+      return NULL;
+   }
+   snprintf(path, cap, "/v1/code/graph?project=%s&node=%s&max_results=%d", project_q, node_q,
+            max_results);
+   free(project_q);
+   free(node_q);
+
+   char *json = kb_client_v1_get_json(path, KB_CLIENT_CODE_GRAPH_READ_TIMEOUT_MS, status_out);
+   free(path);
+   return json;
+}

--- a/src/server/server_mcp_call_table.inc
+++ b/src/server/server_mcp_call_table.inc
@@ -1053,6 +1053,21 @@ static cJSON *mcph_index_graph_hubs(struct mcp_call *c)
    return code_graph_passthrough(json, status, "index_graph_hubs");
 }
 
+static cJSON *mcph_index_graph_node(struct mcp_call *c)
+{
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
+   cJSON *jn = cJSON_GetObjectItemCaseSensitive(c->jargs, "node");
+   if (!cJSON_IsString(jp) || !jp->valuestring[0])
+      return text_content("error: index_graph_node requires 'project'");
+   if (!cJSON_IsString(jn) || !jn->valuestring[0])
+      return text_content("error: index_graph_node requires 'node'");
+   long long mr = 0;
+   int max_results = pdf_arg_pos_int(c->jargs, "max_results", 200.0, &mr) ? (int)mr : 50;
+   int status = -1;
+   char *json = kb_client_code_graph_node(jp->valuestring, jn->valuestring, max_results, &status);
+   return code_graph_passthrough(json, status, "index_graph_node");
+}
+
 static cJSON *mcph_index_graph_surprising(struct mcp_call *c)
 {
    cJSON *jp = cJSON_GetObjectItemCaseSensitive(c->jargs, "project");
@@ -1251,6 +1266,7 @@ static const struct
     {"index_hybrid", mcph_index_hybrid},
     {"index_graph_hubs", mcph_index_graph_hubs},
     {"index_graph_surprising", mcph_index_graph_surprising},
+    {"index_graph_node", mcph_index_graph_node},
     {"memory_explain_match", mcph_memory_explain_match},
     /* P3b */
     {"index_blast_radius", mcph_index_blast_radius},

--- a/src/tests/test_mcp_tools_golden.inc
+++ b/src/tests/test_mcp_tools_golden.inc
@@ -25,7 +25,7 @@
    "git {action,async,base,body,branch,command,count,depth,diff_stat,files,force,index,job_id,message,mirror,mode,name,number,path,prune,rebase,ref,remote,source,staged,stat_only,state,title,url,wait} req:command\n" \
    "graph {command,entity,episode_key,limit,query} req:command\n" \
    "host {command,name} req:command\n" \
-   "index {command,file_path,judge,line_end,line_start,max_results,paths,project,query,symbol} req:command\n" \
+   "index {command,file_path,judge,line_end,line_start,max_results,node,paths,project,query,symbol} req:command\n" \
    "job {command,job_id,max_concurrent,plan_id} req:command\n" \
    "learning {command,correction_text,description,evidence_refs,limit,polarity,signal_type,sink,state,target_key,target_memory_id,title,workflow_project,workflow_signal_type} req:command\n" \
    "list_curiosity_items {limit,state} req:\n" \


### PR DESCRIPTION
## Summary

First of two PRs for the §8 webchat code-graph visualization. The view needs all three graph routes reachable from the frontend; hubs + surprising are already MCP tools, but the per-node neighborhood route `/v1/code/graph?project&node` had no server-side exposure (it lives on aimee-**kb**; webchat only reaches aimee-**server**). This adds it the same way (exact mirror of `index_graph_surprising`, #758):

- **`kb_client_code_graph_node`** (`server/kb_client_code_graph.c`) — escapes `project` + `node`, forwards the KB route JSON verbatim.
- **`mcph_index_graph_node`** handler + call-table registration; ext_tool schema + index-family command-map `{'neighbors' → index_graph_node}`.
- **Golden**: the `index` family row gains `node` (regenerated; tool count stays **47** — folded into the multiplexed `index` tool).

Dual benefit: completes the **agent-callable** graph surface (typed neighbors with §3 provenance — richer than `find_callers`) *and* is the bridge the webchat `/api/graph` proxy will use via the existing `mcpStructured` path.

## Verification
`make all` builds clean, line-check clean, registry golden test passes, docs-gen no drift. Mirrors the reviewed `index_graph_hubs`/`surprising` pattern (#737/#758/#762) — the forwarder adds a second escaped param (`node`).

**Next (PR B):** webchat Go `/api/graph/*` handlers + `frontend/src/pages/Graph.tsx` (the actual interactive view).