### PR TITLE
feat(webchat): §8 code-graph Graph view (read-only adjacency explorer)

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -3,10 +3,10 @@
 - **State:** IN PROGRESS — §0.5/§1/§3/§4/§5/§7/§8-backend implemented (on the
   `testing` branch), including the §5 code+graph+vector hybrid, §7 graph-informed
   delegation, the §4 surprising-links route + its LLM-judge relevance gate, and the §8
-  read-only `/v1/code/graph` backend route, and the §6 cross-session memory-fusion
-  leg in `/v1/code/hybrid`; remainder (§2 tree-sitter, §6 *live* reindex hook, §8
-  webchat frontend, and the §4 precision self-suppress monitoring) still open, as
-  build-/integration-/frontend-tier work. See the
+  read-only `/v1/code/graph` backend route + the §8 webchat Graph view, and the §6
+  cross-session memory-fusion leg in `/v1/code/hybrid`; remainder (§2 tree-sitter, §6
+  *live* reindex hook, and the §4 precision self-suppress monitoring) still open, as
+  build-/integration-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
@@ -314,8 +314,17 @@ pre-cap) and a `truncated` flag that fires when **either** the page cap (`max_re
 1–200) **or** the projection scan window (`HUBS_MAX_EDGES`) bounds the result. Reuses
 `db2_code_projection_list_edges` + `kb_graph_edge_provenance` (`handle_get_code_graph`
 in `src/kb/http/kb_http_code.c`); read-only, off the agent hot path. Shim route tests
-(`test_code_graph_node_*`: out/in neighbors, page-cap truncation, self-loop). The
-webchat **frontend** consumer remains open.
+(`test_code_graph_node_*`: out/in neighbors, page-cap truncation, self-loop).
+
+**Status — frontend shipped.** A read-only **Graph** page in the webchat SPA
+(`frontend/src/pages/Graph.tsx`): for the active session's project it ranks the hubs,
+click one to expand its callers/callees/neighbors (direction + relation + §3
+provenance), drill into any neighbor, and surface the surprising links (with optional
+LLM confirm). It is an adjacency explorer (no heavy graph lib). Backed by webchat Go
+proxies `/api/graph/{hubs,surprising,neighbors}` (`webchat/graph.go`,
+`webchat/graph_test.go`) that forward aimee-server's `index_graph_*` MCP tools (the
+per-node route was exposed as `index({command:"neighbors"})` / `index_graph_node` so
+all three are reachable from the frontend over the trusted UDS hop).
 
 ## Phasing (each independently shippable)
 
@@ -358,7 +367,10 @@ webchat **frontend** consumer remains open.
 - **§8** read-only node-projection route — `GET /v1/code/graph?project&node&max_results`
   returns a node's incident edges (relation / direction incl. `self` / structural weight /
   §3 provenance) with `match_count` + a page-or-scan `truncated` flag
-  (`handle_get_code_graph`, `test_code_graph_node_*`). Backs the webchat graph view.
+  (`handle_get_code_graph`, `test_code_graph_node_*`) — **plus the webchat Graph view**
+  (`frontend/src/pages/Graph.tsx`) that ranks hubs, drills neighbors, and shows
+  surprising links, via webchat Go proxies `/api/graph/*` (`webchat/graph.go`,
+  `webchat/graph_test.go`) over the `index_graph_*` MCP tools.
 
 **Deferred — needs the embedder / a build-tier dependency / a deployed corpus / a frontend
 (not completable in the agent host):**
@@ -370,8 +382,6 @@ webchat **frontend** consumer remains open.
   skip-when-unchanged) and the memory-fusion leg are shipped; the post-merge/fetch
   **hook install** + watch loop that *fire* the gate on a git event remain, needing a
   running KB + git events to validate.
-- **§8 webchat visualization** — the **frontend** consumer; the read-only `/v1/code/graph`
-  backend route is shipped (above).
 
 ## Non-goals
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import Chat from './pages/Chat';
 import Dashboard from './pages/Dashboard';
 import Workflows from './pages/Workflows';
 import Projects from './pages/Projects';
+import Graph from './pages/Graph';
 import Editor from './pages/Editor';
 import { SessionProvider, useSessions } from './SessionContext';
 import SettingsPanel from './components/SettingsPanel';
@@ -63,6 +64,7 @@ const NAV_ITEMS: Tab[] = [
   { label: 'Dashboard', icon: '📊', route: '/dashboard' },
   { label: 'Workflows', icon: '🔀', route: '/workflows' },
   { label: 'Projects', icon: '📁', route: '/projects' },
+  { label: 'Graph', icon: '🕸️', route: '/graph' },
   { label: 'Editor', icon: '🖥️', route: '/editor' },
 ];
 
@@ -232,6 +234,7 @@ export default function App() {
                 <Route path="/dashboard" element={<Dashboard />} />
                 <Route path="/workflows" element={<Workflows />} />
                 <Route path="/projects" element={<Projects />} />
+                <Route path="/graph" element={<Graph />} />
                 <Route path="/editor" element={<Editor />} />
                 <Route path="*" element={<Navigate to="/chat" replace />} />
               </Routes>

--- a/frontend/src/pages/Graph.tsx
+++ b/frontend/src/pages/Graph.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from 'react';
+import { Badge, Panel } from '@rakuensoftware/smoothgui';
+import { useSessions } from '../SessionContext';
+
+/* §8 code-graph visualization. A read-only, navigable view of the code projection
+ * graph for the active session's project, backed by /api/graph/* (which forward
+ * aimee-server's index_graph_* MCP tools). It is an adjacency explorer rather than a
+ * force-directed canvas: rank the hubs, click one to expand its callers/callees/
+ * neighbors with provenance, drill into any neighbor, and surface "surprising links"
+ * (semantically close yet structurally far file pairs). Off the agent's hot path. */
+
+async function api(path: string): Promise<Response> {
+  return fetch(path, { headers: { 'X-CSRF-Token': window._csrf || '' } });
+}
+
+interface Hub { node: string; degree: number; in_degree: number; out_degree: number; weighted_degree: number; }
+interface Neighbor { neighbor: string; relation: string; direction: string; structural_weight: number; provenance: string; }
+interface Link { a: string; b: string; cosine: number; hops: number; disconnected: boolean; confirmed?: boolean; reason?: string; shared_symbols?: number; }
+
+const dirVariant = (d: string): 'success' | 'info' | 'neutral' =>
+  d === 'out' ? 'info' : d === 'in' ? 'success' : 'neutral';
+
+export default function Graph() {
+  const { active } = useSessions();
+  const project = active?.projectName || '';
+
+  const [hubs, setHubs] = useState<Hub[]>([]);
+  const [edgeCount, setEdgeCount] = useState<number | null>(null);
+  const [node, setNode] = useState<string>('');
+  const [neighbors, setNeighbors] = useState<Neighbor[]>([]);
+  const [links, setLinks] = useState<Link[]>([]);
+  const [judge, setJudge] = useState(false);
+  const [err, setErr] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+
+  const loadHubs = useCallback(async () => {
+    if (!project) return;
+    setErr(''); setLoading(true); setNode(''); setNeighbors([]);
+    try {
+      const r = await api(`/api/graph/hubs?project=${encodeURIComponent(project)}&max_results=30`);
+      const d = await r.json();
+      if (!r.ok) { setErr(d.error || 'could not load hubs'); setHubs([]); return; }
+      setHubs(d.hubs || []);
+      setEdgeCount(typeof d.edge_count === 'number' ? d.edge_count : null);
+    } catch (e) { setErr(String(e)); } finally { setLoading(false); }
+  }, [project]);
+
+  const loadNeighbors = useCallback(async (n: string) => {
+    if (!project || !n) return;
+    setErr(''); setLoading(true); setNode(n);
+    try {
+      const r = await api(`/api/graph/neighbors?project=${encodeURIComponent(project)}&node=${encodeURIComponent(n)}&max_results=50`);
+      const d = await r.json();
+      if (!r.ok) { setErr(d.error || 'could not load neighbors'); setNeighbors([]); return; }
+      setNeighbors(d.neighbors || []);
+    } catch (e) { setErr(String(e)); } finally { setLoading(false); }
+  }, [project]);
+
+  const loadSurprising = useCallback(async () => {
+    if (!project) return;
+    setErr(''); setLoading(true);
+    try {
+      const r = await api(`/api/graph/surprising?project=${encodeURIComponent(project)}&max_results=20${judge ? '&judge=true' : ''}`);
+      const d = await r.json();
+      if (!r.ok) { setErr(d.error || 'could not load surprising links'); setLinks([]); return; }
+      setLinks(d.links || []);
+    } catch (e) { setErr(String(e)); } finally { setLoading(false); }
+  }, [project, judge]);
+
+  useEffect(() => { loadHubs(); setLinks([]); }, [loadHubs]);
+
+  if (!project) {
+    return <div style={{ padding: 24, color: '#666' }}>Bind this session to a project to explore its code graph.</div>;
+  }
+
+  return (
+    <div style={{ padding: 16, display: 'flex', flexDirection: 'column', gap: 12, overflowY: 'auto' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <strong>Code graph — {project}</strong>
+        {edgeCount != null && <Badge label={`${edgeCount} edges`} variant="neutral" />}
+        {loading && <span style={{ color: '#888', fontSize: 12 }}>loading…</span>}
+        <button onClick={loadHubs} style={{ marginLeft: 'auto', ...btn }}>↻ refresh</button>
+      </div>
+      {err && <div style={{ color: '#b00', fontSize: 13 }}>{err}</div>}
+
+      <div style={{ display: 'flex', gap: 12, flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        <Panel title="Hubs" count={hubs.length}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, maxHeight: 420, overflowY: 'auto' }}>
+            {hubs.length === 0 && <div style={empty}>No projection graph yet — index this project first.</div>}
+            {hubs.map(h => (
+              <button key={h.node} onClick={() => loadNeighbors(h.node)} title={h.node}
+                style={{ ...row, fontWeight: h.node === node ? 600 : 400, background: h.node === node ? '#eef4ff' : '#fff' }}>
+                <span style={ellipsis}>{h.node}</span>
+                <Badge label={String(h.degree)} variant="info" />
+              </button>
+            ))}
+          </div>
+        </Panel>
+
+        <Panel title={node ? `Neighbors of ${shortNode(node)}` : 'Neighbors'} count={neighbors.length}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 2, maxHeight: 420, overflowY: 'auto', minWidth: 280 }}>
+            {!node && <div style={empty}>Click a hub to see its callers / callees / neighbors.</div>}
+            {node && neighbors.length === 0 && <div style={empty}>No incident edges.</div>}
+            {neighbors.map((nb, i) => (
+              <button key={`${nb.neighbor}-${i}`} onClick={() => loadNeighbors(nb.neighbor)} title={nb.neighbor} style={row}>
+                <Badge label={nb.direction} variant={dirVariant(nb.direction)} />
+                <span style={{ color: '#888', fontSize: 11 }}>{nb.relation}</span>
+                <span style={{ ...ellipsis, flex: 1 }}>{nb.neighbor}</span>
+                <Badge label={nb.provenance} variant="neutral" />
+              </button>
+            ))}
+          </div>
+        </Panel>
+      </div>
+
+      <Panel title="Surprising links" count={links.length}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6 }}>
+          <button onClick={loadSurprising} style={btn}>find</button>
+          <label style={{ fontSize: 12, color: '#555' }}>
+            <input type="checkbox" checked={judge} onChange={e => setJudge(e.target.checked)} /> LLM confirm
+          </label>
+          <span style={{ fontSize: 11, color: '#999' }}>semantically close yet structurally far</span>
+        </div>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 3, maxHeight: 300, overflowY: 'auto' }}>
+          {links.map((l, i) => (
+            <div key={i} style={{ ...row, cursor: 'default', alignItems: 'baseline', flexWrap: 'wrap' }}>
+              <span style={ellipsis}>{l.a}</span><span style={{ color: '#bbb' }}>↔</span><span style={ellipsis}>{l.b}</span>
+              <Badge label={`cos ${l.cosine.toFixed(2)}`} variant="info" />
+              <Badge label={l.disconnected ? 'disconnected' : `${l.hops} hops`} variant="neutral" />
+              {l.confirmed != null && <Badge label={l.confirmed ? 'confirmed' : 'rejected'} variant={l.confirmed ? 'success' : 'neutral'} />}
+              {l.reason && <span style={{ fontSize: 11, color: '#888' }}>{l.reason}</span>}
+            </div>
+          ))}
+        </div>
+      </Panel>
+    </div>
+  );
+}
+
+function shortNode(n: string): string {
+  const i = n.lastIndexOf(':');
+  return i >= 0 ? n.slice(i + 1) : n;
+}
+
+const btn: React.CSSProperties = { padding: '3px 10px', borderRadius: 4, border: '1px solid #ccc', background: '#fff', color: '#444', cursor: 'pointer', fontSize: 12 };
+const row: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 6, padding: '4px 6px', borderRadius: 4, border: 'none', background: '#fff', cursor: 'pointer', fontSize: 12, textAlign: 'left', width: '100%' };
+const ellipsis: React.CSSProperties = { whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', maxWidth: 240 };
+const empty: React.CSSProperties = { color: '#999', fontSize: 12, padding: 8 };

--- a/webchat/graph.go
+++ b/webchat/graph.go
@@ -1,0 +1,121 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// graph.go — §8 read-only code-graph visualization. The /v1/code/graph* routes live
+// on aimee-kb, reachable from webchat only via aimee-server's MCP tools
+// (index_graph_hubs / index_graph_surprising / index_graph_node), which forward the
+// KB route's JSON verbatim as a text content node. These handlers expose that JSON to
+// the browser at /api/graph/*; the SPA Graph page renders it.
+
+// mcpText calls an MCP tool and returns its text content — the verbatim JSON the
+// code_graph_* tools forward (or an "error: ..." string the tool emits on failure).
+func (s *server) mcpText(r *http.Request, tool string, args map[string]any) (string, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	resp, err := s.socketCallForRequest(r, map[string]any{
+		"method":    "mcp.call",
+		"tool":      tool,
+		"arguments": args,
+	})
+	if err != nil {
+		return "", err
+	}
+	raw, ok := resp["content"]
+	if !ok {
+		return "", fmt.Errorf("server response missing content")
+	}
+	var content []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &content); err != nil {
+		return "", fmt.Errorf("invalid mcp content: %w", err)
+	}
+	for _, c := range content {
+		if c.Type == "text" {
+			return c.Text, nil
+		}
+	}
+	return "", fmt.Errorf("no text content in response")
+}
+
+// writeGraphResult forwards the tool's JSON verbatim, or maps a transport error / an
+// "error: ..." tool message to a JSON error response.
+func (s *server) writeGraphResult(w http.ResponseWriter, text string, err error) {
+	if err != nil {
+		writeJSONError(w, http.StatusServiceUnavailable, err.Error())
+		return
+	}
+	if strings.HasPrefix(text, "error:") {
+		writeJSONError(w, http.StatusBadGateway, strings.TrimSpace(strings.TrimPrefix(text, "error:")))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(text))
+}
+
+// graphMaxResults reads a bounded max_results from the query (1..200), else `def`.
+func graphMaxResults(r *http.Request, def int) int {
+	if v := r.URL.Query().Get("max_results"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			if n > 200 {
+				n = 200
+			}
+			return n
+		}
+	}
+	return def
+}
+
+// GET /api/graph/hubs?project=&max_results= — a project's most-connected symbols.
+func (s *server) handleGraphHubs(w http.ResponseWriter, r *http.Request) {
+	project := r.URL.Query().Get("project")
+	if project == "" {
+		writeJSONError(w, http.StatusBadRequest, "project required")
+		return
+	}
+	text, err := s.mcpText(r, "index_graph_hubs", map[string]any{
+		"project":     project,
+		"max_results": graphMaxResults(r, 20),
+	})
+	s.writeGraphResult(w, text, err)
+}
+
+// GET /api/graph/surprising?project=&max_results=&judge= — high-similarity, graph-far pairs.
+func (s *server) handleGraphSurprising(w http.ResponseWriter, r *http.Request) {
+	project := r.URL.Query().Get("project")
+	if project == "" {
+		writeJSONError(w, http.StatusBadRequest, "project required")
+		return
+	}
+	args := map[string]any{"project": project, "max_results": graphMaxResults(r, 20)}
+	if r.URL.Query().Get("judge") == "true" {
+		args["judge"] = true
+	}
+	text, err := s.mcpText(r, "index_graph_surprising", args)
+	s.writeGraphResult(w, text, err)
+}
+
+// GET /api/graph/neighbors?project=&node=&max_results= — a node's incident edges.
+func (s *server) handleGraphNeighbors(w http.ResponseWriter, r *http.Request) {
+	project := r.URL.Query().Get("project")
+	node := r.URL.Query().Get("node")
+	if project == "" || node == "" {
+		writeJSONError(w, http.StatusBadRequest, "project and node required")
+		return
+	}
+	text, err := s.mcpText(r, "index_graph_node", map[string]any{
+		"project":     project,
+		"node":        node,
+		"max_results": graphMaxResults(r, 50),
+	})
+	s.writeGraphResult(w, text, err)
+}

--- a/webchat/graph_test.go
+++ b/webchat/graph_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// fakeMCPGraph stands up a fake aimee-server /v1/mcp/call that records the tool +
+// arguments and returns the graph JSON wrapped as a text content node (mirroring the
+// server's code_graph_passthrough -> text_content shape). `text` is the inner JSON
+// (or an "error: ..." string the real tool emits on failure).
+func fakeMCPGraph(t *testing.T, text string, gotTool *string, gotArgs *map[string]any) *config {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/mcp/call", func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Tool      string         `json:"tool"`
+			Arguments map[string]any `json:"arguments"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if gotTool != nil {
+			*gotTool = body.Tool
+		}
+		if gotArgs != nil {
+			*gotArgs = body.Arguments
+		}
+		inner, _ := json.Marshal(text)
+		fmt.Fprintf(w, `{"status":"ok","content":[{"type":"text","text":%s}]}`, string(inner))
+	})
+	return startFakeV1(t, mux)
+}
+
+func TestHandleGraphHubsProxiesMCP(t *testing.T) {
+	var tool string
+	var args map[string]any
+	s := &server{cfg: fakeMCPGraph(t, `{"status":"ok","hubs":[{"node":"hub","degree":3}]}`, &tool, &args)}
+
+	rr := httptest.NewRecorder()
+	s.handleGraphHubs(rr, httptest.NewRequest(http.MethodGet, "/api/graph/hubs?project=proj-alpha&max_results=10", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if tool != "index_graph_hubs" {
+		t.Fatalf("tool=%q want index_graph_hubs", tool)
+	}
+	if args["project"] != "proj-alpha" {
+		t.Fatalf("project arg=%v", args["project"])
+	}
+	if !strings.Contains(rr.Body.String(), `"node":"hub"`) {
+		t.Fatalf("body=%q (expected verbatim hub JSON)", rr.Body.String())
+	}
+}
+
+func TestHandleGraphNeighborsProxiesMCP(t *testing.T) {
+	var tool string
+	var args map[string]any
+	s := &server{cfg: fakeMCPGraph(t, `{"status":"ok","node":"hub","neighbors":[]}`, &tool, &args)}
+
+	rr := httptest.NewRecorder()
+	s.handleGraphNeighbors(rr, httptest.NewRequest(http.MethodGet, "/api/graph/neighbors?project=p&node=hub", nil))
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if tool != "index_graph_node" || args["node"] != "hub" {
+		t.Fatalf("tool=%q node=%v", tool, args["node"])
+	}
+}
+
+func TestHandleGraphNeighborsRequiresNode(t *testing.T) {
+	s := &server{cfg: fakeMCPGraph(t, `{}`, nil, nil)}
+	rr := httptest.NewRecorder()
+	s.handleGraphNeighbors(rr, httptest.NewRequest(http.MethodGet, "/api/graph/neighbors?project=p", nil))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d want 400", rr.Code)
+	}
+}
+
+func TestHandleGraphHubsRequiresProject(t *testing.T) {
+	s := &server{cfg: fakeMCPGraph(t, `{}`, nil, nil)}
+	rr := httptest.NewRecorder()
+	s.handleGraphHubs(rr, httptest.NewRequest(http.MethodGet, "/api/graph/hubs", nil))
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("code=%d want 400", rr.Code)
+	}
+}
+
+func TestHandleGraphSurprisingForwardsJudge(t *testing.T) {
+	var tool string
+	var args map[string]any
+	s := &server{cfg: fakeMCPGraph(t, `{"status":"ok","links":[]}`, &tool, &args)}
+
+	rr := httptest.NewRecorder()
+	s.handleGraphSurprising(rr, httptest.NewRequest(http.MethodGet, "/api/graph/surprising?project=p&judge=true", nil))
+
+	if rr.Code != http.StatusOK || tool != "index_graph_surprising" {
+		t.Fatalf("code=%d tool=%q", rr.Code, tool)
+	}
+	if args["judge"] != true {
+		t.Fatalf("judge arg=%v want true", args["judge"])
+	}
+}
+
+// A tool that returns an "error: ..." text (e.g. KB down) maps to a 5xx JSON error,
+// not a 200 with the error string masquerading as data.
+func TestHandleGraphToolErrorMapsTo5xx(t *testing.T) {
+	s := &server{cfg: fakeMCPGraph(t, `error: index_graph_hubs request failed (status 503)`, nil, nil)}
+	rr := httptest.NewRecorder()
+	s.handleGraphHubs(rr, httptest.NewRequest(http.MethodGet, "/api/graph/hubs?project=p", nil))
+	if rr.Code != http.StatusBadGateway {
+		t.Fatalf("code=%d want 502", rr.Code)
+	}
+	if !strings.Contains(rr.Body.String(), "request failed") {
+		t.Fatalf("body=%q", rr.Body.String())
+	}
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -123,6 +123,9 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/dashboard", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/workflows", s.requireAuth(s.handleSPA))
 	mux.HandleFunc("/projects", s.requireAuth(s.handleSPA))
+	// Code-graph visualization (§8): a read-only SPA page backed by the /api/graph/*
+	// proxies (which forward aimee-server's index_graph_* MCP tools).
+	mux.HandleFunc("/graph", s.requireAuth(s.handleSPA))
 	// The Editor tab is a SPA page that embeds the in-app VSCode in an iframe, so
 	// the nav shell stays visible. The iframe's src is the /vscode proxy below.
 	mux.HandleFunc("/editor", s.requireAuth(s.handleSPA))
@@ -167,6 +170,11 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 
 	// Aggregate dashboard endpoint — all panels in one server round-trip
 	mux.HandleFunc("/api/dashboard", s.requireAuth(s.handleDashboardAll))
+
+	// Code-graph visualization (§8): read-only views via aimee-server's index_graph_* MCP tools.
+	mux.HandleFunc("/api/graph/hubs", s.requireAuth(s.handleGraphHubs))
+	mux.HandleFunc("/api/graph/surprising", s.requireAuth(s.handleGraphSurprising))
+	mux.HandleFunc("/api/graph/neighbors", s.requireAuth(s.handleGraphNeighbors))
 
 	// Workflow visual composer (W7): proxy to aimee-server /v1/workflow/*.
 	mux.HandleFunc("/api/workflow/blocks", s.requireAuth(s.handleWorkflowBlocks))


### PR DESCRIPTION
## Summary

Completes **§8 end-to-end**: the webchat SPA gets a **Graph** page that visualizes the code projection graph for the active session's project. (The backend routes + the `index_graph_node` MCP exposure shipped in #753/#766.)

### Frontend (`frontend/src/pages/Graph.tsx`)
A read-only **adjacency explorer** (no heavy graph lib — clean `smoothgui` Panel/Badge):
- **Hubs** ranked by degree centrality → click one to expand it.
- **Neighbors** — its callers/callees/neighbors with direction (`in`/`out`/`self`), relation, and §3 `provenance`; click any neighbor to drill in.
- **Surprising links** — semantically-close-yet-structurally-far file pairs, with an optional **LLM confirm** toggle (the §4 judge).
- `App.tsx` route + nav entry; empty-state when the session has no project.

### Backend (`webchat/graph.go`)
Read-only Go proxies `/api/graph/{hubs,surprising,neighbors}` that forward aimee-server's `index_graph_*` MCP tools. Those tools return the route JSON as an MCP **text node** (not `structuredContent`), so a small `mcpText` helper extracts `content[0].text` and forwards it **verbatim**; a tool `error: ...` maps to a **5xx** (not a 200 masquerading as data). Registered under `requireAuth`, reachable over the trusted UDS hop.

## Tests
`webchat/graph_test.go` — tool/args forwarding, missing-param → 400, `judge` passthrough, and tool-error → 5xx, via the existing `startFakeV1` harness. Frontend **typechecks (tsc) + bundles (vite)** clean; `go build`/`vet`/`test` green; `aimee-webchat` builds. (`frontend/dist` is gitignored — built at image-publish time, so regular CI builds the Go binary but not the SPA; I validated the TSX locally.)