### PR TITLE
feat(thin-client): pin self-signed remote certs (drop per-command AIMEE_TLS_INSECURE)

### DIFF
--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -30,6 +30,17 @@ typedef void aimee_tls_t;
 static char g_remote_url[512];
 static char g_remote_token[256];
 
+/* When set, the transport suppresses its connection-failure diagnostics on
+ * stderr. `aimee remote set` uses this around the pre-pin reachability probe
+ * (which is EXPECTED to fail against a not-yet-pinned self-signed server) so a
+ * successful set does not print a misleading "TLS handshake failed" line. */
+static int g_suppress_conn_errors = 0;
+
+void aimee_client_suppress_conn_errors(int on)
+{
+   g_suppress_conn_errors = on ? 1 : 0;
+}
+
 void aimee_client_set_remote(const char *url, const char *token)
 {
    if (url && *url)
@@ -281,7 +292,12 @@ static char *tcp_request(const char *url, const char *token, const char *method,
       tls = aimee_tls_connect(fd, host);
       if (!tls)
       {
-         fprintf(stderr, "aimee: TLS handshake with %s failed\n", host);
+         if (!g_suppress_conn_errors)
+            fprintf(stderr,
+                    "aimee: TLS handshake with %s failed (untrusted/self-signed cert?). "
+                    "Run `aimee remote trust` to pin this server's certificate, or set "
+                    "AIMEE_TLS_INSECURE=1 to skip verification.\n",
+                    host);
          platform_net_close(fd);
          return NULL;
       }
@@ -398,5 +414,24 @@ char *aimee_client_request(const char *method, const char *path, const char *bod
    /* Windows has no UDS default — a remote target is required for connectivity. */
    fprintf(stderr, "aimee: no server configured; set AIMEE_SERVER_URL or use --server\n");
    return NULL;
+#endif
+}
+
+int aimee_client_fetch_cert(const char *url, char **pem_out, char *fp_out, unsigned long fp_n)
+{
+   if (pem_out)
+      *pem_out = NULL;
+   if (fp_out && fp_n)
+      fp_out[0] = '\0';
+   if (!url || !*url || !pem_out)
+      return -1;
+   char host[256], port[16];
+   int is_https = 0;
+   if (parse_url(url, host, sizeof(host), port, sizeof(port), &is_https) != 0 || !is_https)
+      return -1; /* only https:// servers present a cert to pin */
+#ifdef WITH_TLS
+   return aimee_tls_fetch_peer_cert(host, port, pem_out, fp_out, (size_t)fp_n);
+#else
+   return -1; /* no TLS in this build */
 #endif
 }

--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -104,14 +104,24 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    int insecure = tls_insecure();
    if (!insecure)
    {
-      SSL_CTX_set_default_verify_paths(ctx);
-      /* Also trust the pinned server cert, if one was recorded for this remote.
-       * Verification stays ON: the pinned self-signed cert is its own anchor, so
-       * the server validates against it AND the hostname/SAN check below still
-       * runs — a MITM presenting a different cert is still rejected. */
       char pin[600];
       if (pinned_ca_path(pin, sizeof(pin)))
-         SSL_CTX_load_verify_locations(ctx, pin, NULL); /* best-effort */
+      {
+         /* Strict pin: a recorded cert means a self-signed/private server, so
+          * trust ONLY that cert and NOT the system store — a mis-issued or
+          * compromised public-CA cert for the same host is then still rejected.
+          * A pin that won't load fails the connection CLOSED rather than silently
+          * widening trust back to the system store. */
+         if (SSL_CTX_load_verify_locations(ctx, pin, NULL) != 1)
+         {
+            SSL_CTX_free(ctx);
+            return NULL;
+         }
+      }
+      else
+      {
+         SSL_CTX_set_default_verify_paths(ctx); /* publicly-trusted servers */
+      }
       SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
    }
 
@@ -135,9 +145,16 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
           * matched against the cert's IP-address SANs: set1_host only matches DNS
           * names/CN, so an IP would otherwise fail the name check even with a
           * valid/pinned cert. set1_ip_asc returns 1 only for a real IP literal;
-          * fall back to DNS-name matching for actual hostnames. */
-         if (X509_VERIFY_PARAM_set1_ip_asc(param, host) != 1)
-            X509_VERIFY_PARAM_set1_host(param, host, 0);
+          * fall back to DNS-name matching for actual hostnames. If neither arms
+          * the name check, fail CLOSED — verifying the chain but not the identity
+          * would accept any otherwise-valid cert. */
+         if (X509_VERIFY_PARAM_set1_ip_asc(param, host) != 1 &&
+             X509_VERIFY_PARAM_set1_host(param, host, 0) != 1)
+         {
+            SSL_free(ssl);
+            SSL_CTX_free(ctx);
+            return NULL;
+         }
       }
    }
 

--- a/src/aimee_tls.c
+++ b/src/aimee_tls.c
@@ -1,7 +1,10 @@
 /* aimee_tls.c: OpenSSL TLS client wrapper (WITH_TLS builds only). */
 #include "aimee_tls.h"
 #include "aimee_home.h"
+#include "platform_net.h"
 #include <openssl/err.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
 #include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include <stdio.h>
@@ -77,6 +80,20 @@ static void aimee_tls_present_client_cert(SSL_CTX *ctx)
       ERR_clear_error();
 }
 
+/* Resolve <aimee_home>/remote-ca.pem — the pinned server certificate written by
+ * `aimee remote set/trust`. Returns 1 (and fills |out|) when the file exists,
+ * else 0. Trusting this file lets a self-signed/private server verify fully
+ * (chain + hostname/SAN) without disabling verification (AIMEE_TLS_INSECURE). */
+static int pinned_ca_path(char *out, size_t n)
+{
+   const char *home = aimee_home();
+   if (!home || !*home || !out || n == 0)
+      return 0;
+   snprintf(out, n, "%s/remote-ca.pem", home);
+   struct stat st;
+   return (stat(out, &st) == 0 && S_ISREG(st.st_mode)) ? 1 : 0;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
@@ -88,6 +105,13 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    if (!insecure)
    {
       SSL_CTX_set_default_verify_paths(ctx);
+      /* Also trust the pinned server cert, if one was recorded for this remote.
+       * Verification stays ON: the pinned self-signed cert is its own anchor, so
+       * the server validates against it AND the hostname/SAN check below still
+       * runs — a MITM presenting a different cert is still rejected. */
+      char pin[600];
+      if (pinned_ca_path(pin, sizeof(pin)))
+         SSL_CTX_load_verify_locations(ctx, pin, NULL); /* best-effort */
       SSL_CTX_set_verify(ctx, SSL_VERIFY_PEER, NULL);
    }
 
@@ -107,7 +131,13 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
       {
          X509_VERIFY_PARAM *param = SSL_get0_param(ssl);
          X509_VERIFY_PARAM_set_hostflags(param, X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS);
-         X509_VERIFY_PARAM_set1_host(param, host, 0);
+         /* An IP-literal host (e.g. a private server reached by address) must be
+          * matched against the cert's IP-address SANs: set1_host only matches DNS
+          * names/CN, so an IP would otherwise fail the name check even with a
+          * valid/pinned cert. set1_ip_asc returns 1 only for a real IP literal;
+          * fall back to DNS-name matching for actual hostnames. */
+         if (X509_VERIFY_PARAM_set1_ip_asc(param, host) != 1)
+            X509_VERIFY_PARAM_set1_host(param, host, 0);
       }
    }
 
@@ -128,6 +158,85 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    t->ctx = ctx;
    t->ssl = ssl;
    return t;
+}
+
+int aimee_tls_fetch_peer_cert(const char *host, const char *port, char **pem_out, char *fp_out,
+                              size_t fp_n)
+{
+   if (pem_out)
+      *pem_out = NULL;
+   if (fp_out && fp_n)
+      fp_out[0] = '\0';
+   if (!host || !*host || !port || !*port || !pem_out)
+      return -1;
+
+   int fd = platform_net_connect(host, port, 10000);
+   if (fd < 0)
+      return -1;
+
+   SSL_CTX *ctx = SSL_CTX_new(TLS_client_method());
+   if (!ctx)
+   {
+      platform_net_close(fd);
+      return -1;
+   }
+   SSL_CTX_set_min_proto_version(ctx, TLS1_2_VERSION);
+   /* Deliberately NO verification: we are FETCHING the cert to show its
+    * fingerprint and pin it (trust-on-first-use), not trusting it yet. The
+    * caller is expected to surface the fingerprint for out-of-band check. */
+   SSL *ssl = SSL_new(ctx);
+   if (!ssl)
+   {
+      SSL_CTX_free(ctx);
+      platform_net_close(fd);
+      return -1;
+   }
+   SSL_set_fd(ssl, fd);
+   SSL_set_tlsext_host_name(ssl, host); /* SNI — many servers select a cert by it */
+
+   int rc = -1;
+   if (SSL_connect(ssl) == 1)
+   {
+      X509 *cert = SSL_get1_peer_certificate(ssl);
+      if (cert)
+      {
+         BIO *bio = BIO_new(BIO_s_mem());
+         if (bio && PEM_write_bio_X509(bio, cert) == 1)
+         {
+            char *data = NULL;
+            long len = BIO_get_mem_data(bio, &data);
+            if (len > 0 && data)
+            {
+               char *pem = malloc((size_t)len + 1);
+               if (pem)
+               {
+                  memcpy(pem, data, (size_t)len);
+                  pem[len] = '\0';
+                  *pem_out = pem;
+                  rc = 0;
+               }
+            }
+         }
+         if (bio)
+            BIO_free(bio);
+         if (rc == 0 && fp_out && fp_n)
+         {
+            unsigned char md[EVP_MAX_MD_SIZE];
+            unsigned int mdlen = 0;
+            if (X509_digest(cert, EVP_sha256(), md, &mdlen) == 1)
+            {
+               size_t o = 0;
+               for (unsigned int i = 0; i < mdlen && o + 4 < fp_n; i++)
+                  o += (size_t)snprintf(fp_out + o, fp_n - o, i ? ":%02X" : "%02X", md[i]);
+            }
+         }
+         X509_free(cert);
+      }
+   }
+   SSL_free(ssl);
+   SSL_CTX_free(ctx);
+   platform_net_close(fd); /* SSL_set_fd does not take ownership of the fd */
+   return rc;
 }
 
 int aimee_tls_write_all(aimee_tls_t *t, const void *buf, size_t len)

--- a/src/aimee_tls_schannel.c
+++ b/src/aimee_tls_schannel.c
@@ -25,6 +25,7 @@
 #endif
 #include "aimee_tls.h"
 #include "aimee_home.h"
+#include "platform_net.h"
 
 #include <windows.h>
 #include <schannel.h>
@@ -54,6 +55,14 @@
 #endif
 #ifndef CERT_NCRYPT_KEY_SPEC
 #define CERT_NCRYPT_KEY_SPEC 0xFFFFFFFF
+#endif
+/* SSL chain-policy "ignore" flag for SSL_EXTRA_CERT_CHAIN_POLICY_PARA.fdwChecks.
+ * Defined in wininet.h, which this backend deliberately does not include; mirror
+ * the defensive-define pattern above with the documented value. Used to suppress
+ * ONLY the untrusted-root error during the pinned-cert fallback (the hostname/SAN
+ * name check still runs and is still enforced). */
+#ifndef SECURITY_FLAG_IGNORE_UNKNOWN_CA
+#define SECURITY_FLAG_IGNORE_UNKNOWN_CA 0x00000100
 #endif
 
 #define ENC_CAP           32768 /* one TLS record fits comfortably; grown via recv loop */
@@ -126,8 +135,95 @@ static int recv_more(aimee_tls_t *t)
    return -1;
 }
 
-/* Verify the server certificate chain + hostname against the Windows store.
- * Returns 0 on success, -1 on any failure. */
+/* Defined further down (with the mTLS/identity helpers); forward-declared here so
+ * the pinned-cert fallback can reuse the same file-read + PEM->DER decoders. */
+static unsigned char *read_small_file(const char *path, DWORD *out_len);
+static int pem_to_der(const unsigned char *pem, DWORD pem_len, unsigned char **der, DWORD *der_len);
+
+/* Resolve <aimee_home>/remote-ca.pem — the pinned server certificate written by
+ * `aimee remote set/trust`. Returns 1 (and fills |out|) when it exists as a
+ * regular file, else 0. Mirrors pinned_ca_path() in the OpenSSL backend; trusting
+ * this cert lets a self-signed/private server verify (chain anchor + hostname/SAN)
+ * without disabling verification (AIMEE_TLS_INSECURE). */
+static int pinned_ca_path(char *out, size_t n)
+{
+   const char *home = aimee_home();
+   if (!home || !*home || !out || n == 0)
+      return 0;
+   snprintf(out, n, "%s/remote-ca.pem", home);
+   DWORD a = GetFileAttributesA(out);
+   return (a != INVALID_FILE_ATTRIBUTES && !(a & FILE_ATTRIBUTE_DIRECTORY)) ? 1 : 0;
+}
+
+/* Run the SSL chain policy (chain validity + hostname/SAN name match) for the
+ * already-built |chain| against |whost|. |fdwChecks| suppresses specific errors
+ * (e.g. SECURITY_FLAG_IGNORE_UNKNOWN_CA for the pinned path); 0 enforces all.
+ * Returns 0 iff the policy reports no (non-suppressed) error. */
+static int ssl_policy_check(PCCERT_CHAIN_CONTEXT chain, const wchar_t *whost, DWORD fdwChecks)
+{
+   SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_para;
+   memset(&ssl_para, 0, sizeof(ssl_para));
+   ssl_para.cbSize = sizeof(ssl_para);
+   ssl_para.dwAuthType = AUTHTYPE_SERVER;
+   ssl_para.fdwChecks = fdwChecks;
+   ssl_para.pwszServerName = (LPWSTR)whost;
+
+   CERT_CHAIN_POLICY_PARA policy_para;
+   memset(&policy_para, 0, sizeof(policy_para));
+   policy_para.cbSize = sizeof(policy_para);
+   policy_para.pvExtraPolicyPara = &ssl_para;
+
+   CERT_CHAIN_POLICY_STATUS policy_status;
+   memset(&policy_status, 0, sizeof(policy_status));
+   policy_status.cbSize = sizeof(policy_status);
+
+   if (CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain, &policy_para,
+                                        &policy_status) &&
+       policy_status.dwError == 0)
+      return 0;
+   return -1;
+}
+
+/* Strict leaf pin: 1 iff <aimee_home>/remote-ca.pem decodes to a DER that byte-
+ * matches the server leaf |cert|. This is the Windows analogue of the OpenSSL
+ * backend trusting exactly remote-ca.pem — a MITM presenting any other cert (even
+ * a validly-issued one) fails this compare. Returns 0 when no pin is configured
+ * or it does not match. */
+static int pinned_leaf_matches(PCCERT_CONTEXT cert)
+{
+   char path[600];
+   if (!pinned_ca_path(path, sizeof(path)))
+      return 0;
+
+   DWORD pem_len = 0;
+   unsigned char *pem = read_small_file(path, &pem_len);
+   if (!pem)
+      return 0;
+
+   unsigned char *der = NULL;
+   DWORD der_len = 0;
+   int match = 0;
+   if (pem_to_der(pem, pem_len, &der, &der_len) == 0)
+   {
+      if (der_len == cert->cbCertEncoded && cert->pbCertEncoded &&
+          memcmp(der, cert->pbCertEncoded, der_len) == 0)
+         match = 1;
+      free(der);
+   }
+   free(pem);
+   return match;
+}
+
+/* Verify the server certificate chain + hostname against the Windows store, OR
+ * against the pinned self-signed cert at <aimee_home>/remote-ca.pem. Returns 0 on
+ * success, -1 on any failure.
+ *
+ * Two accept paths, hostname/SAN enforced in BOTH (matching the OpenSSL backend):
+ *   1. System trust: the chain builds to a trusted root AND the name matches.
+ *   2. Pinned: the system chain is untrusted (unknown CA / self-signed), so we
+ *      ignore ONLY that error in a second name-checking policy run AND require the
+ *      leaf to byte-match remote-ca.pem (strict leaf pin). A different cert fails
+ *      the DER compare; a wrong hostname fails the still-enforced name check. */
 static int verify_server_cert(aimee_tls_t *t)
 {
    /* Fail closed if there is no hostname to verify against: a NULL pwszServerName
@@ -150,7 +246,9 @@ static int verify_server_cert(aimee_tls_t *t)
    {
       /* Widen the hostname for the SSL policy. A DNS hostname is <= 253 chars, so
        * 256 wide chars suffices; a 0 return means truncation/encoding error -> fail
-       * closed rather than verify against a truncated name. */
+       * closed rather than verify against a truncated name. An IP-literal host
+       * (e.g. 192.168.1.254) is passed through verbatim; CERT_CHAIN_POLICY_SSL
+       * matches it against the cert's IP-address SAN on Windows. */
       wchar_t whost[256];
       if (MultiByteToWideChar(CP_UTF8, 0, t->host, -1, whost, 256) == 0)
       {
@@ -159,25 +257,11 @@ static int verify_server_cert(aimee_tls_t *t)
          return -1;
       }
 
-      SSL_EXTRA_CERT_CHAIN_POLICY_PARA ssl_para;
-      memset(&ssl_para, 0, sizeof(ssl_para));
-      ssl_para.cbSize = sizeof(ssl_para);
-      ssl_para.dwAuthType = AUTHTYPE_SERVER;
-      ssl_para.pwszServerName = whost;
-
-      CERT_CHAIN_POLICY_PARA policy_para;
-      memset(&policy_para, 0, sizeof(policy_para));
-      policy_para.cbSize = sizeof(policy_para);
-      policy_para.pvExtraPolicyPara = &ssl_para;
-
-      CERT_CHAIN_POLICY_STATUS policy_status;
-      memset(&policy_status, 0, sizeof(policy_status));
-      policy_status.cbSize = sizeof(policy_status);
-
-      if (CertVerifyCertificateChainPolicy(CERT_CHAIN_POLICY_SSL, chain, &policy_para,
-                                           &policy_status) &&
-          policy_status.dwError == 0)
-         ok = 0;
+      if (ssl_policy_check(chain, whost, 0) == 0)
+         ok = 0; /* path 1: trusted system root + name match */
+      else if (pinned_leaf_matches(cert) &&
+               ssl_policy_check(chain, whost, SECURITY_FLAG_IGNORE_UNKNOWN_CA) == 0)
+         ok = 0; /* path 2: strict leaf pin + name match (untrusted root ignored) */
 
       CertFreeCertificateChain(chain);
    }
@@ -663,6 +747,138 @@ long aimee_tls_read(aimee_tls_t *t, void *buf, size_t len)
          return delivered;
       /* A record with zero application bytes (e.g. a handshake message): loop. */
    }
+}
+
+/* SHA-256 over |data| formatted as uppercase colon-hex into |out| (bounded by
+ * |out_n|). Uses the legacy CryptoAPI hash provider (advapi32 — a default MinGW
+ * link lib, so no extra link flag beyond secur32/crypt32/ncrypt). Returns 0 on
+ * success, -1 on failure (|out| left empty). */
+static int sha256_colon_hex(const unsigned char *data, DWORD len, char *out, size_t out_n)
+{
+   if (!out || out_n == 0)
+      return -1;
+   out[0] = '\0';
+
+   HCRYPTPROV prov = 0;
+   HCRYPTHASH hash = 0;
+   int rc = -1;
+   /* PROV_RSA_AES + a NULL container (CRYPT_VERIFYCONTEXT) gives a default
+    * provider that supports CALG_SHA_256; no key material is touched. */
+   if (!CryptAcquireContextA(&prov, NULL, NULL, PROV_RSA_AES, CRYPT_VERIFYCONTEXT | CRYPT_SILENT))
+      return -1;
+   if (CryptCreateHash(prov, CALG_SHA_256, 0, 0, &hash) && CryptHashData(hash, data, len, 0))
+   {
+      BYTE md[32];
+      DWORD mdlen = sizeof(md);
+      if (CryptGetHashParam(hash, HP_HASHVAL, md, &mdlen, 0) && mdlen == sizeof(md))
+      {
+         size_t o = 0;
+         for (DWORD i = 0; i < mdlen && o + 4 < out_n; i++)
+            o += (size_t)snprintf(out + o, out_n - o, i ? ":%02X" : "%02X", md[i]);
+         rc = 0;
+      }
+   }
+   if (hash)
+      CryptDestroyHash(hash);
+   if (prov)
+      CryptReleaseContext(prov, 0);
+   if (rc != 0)
+      out[0] = '\0';
+   return rc;
+}
+
+/* Trust-on-first-use fetch: open a fresh, DELIBERATELY UNVERIFIED Schannel
+ * connection to host:port, grab the server leaf cert, and return it as PEM plus
+ * its SHA-256 colon-hex fingerprint. Mirrors the OpenSSL backend so `aimee remote
+ * set/trust` can pin a self-signed/private server. Returns 0 on success, -1 on
+ * failure (*pem_out = NULL, fp_out[0] = 0). */
+int aimee_tls_fetch_peer_cert(const char *host, const char *port, char **pem_out, char *fp_out,
+                              size_t fp_n)
+{
+   if (pem_out)
+      *pem_out = NULL;
+   if (fp_out && fp_n)
+      fp_out[0] = '\0';
+   if (!host || !*host || !port || !*port || !pem_out)
+      return -1;
+
+   int fd = platform_net_connect(host, port, 10000);
+   if (fd < 0)
+      return -1;
+
+   aimee_tls_t *t = calloc(1, sizeof(*t));
+   if (!t)
+   {
+      platform_net_close(fd);
+      return -1;
+   }
+   t->fd = fd;
+   t->host = _strdup(host); /* SNI target name for the handshake (NULL is tolerated) */
+
+   SCHANNEL_CRED sc;
+   memset(&sc, 0, sizeof(sc));
+   sc.dwVersion = SCHANNEL_CRED_VERSION;
+   sc.grbitEnabledProtocols = SP_PROT_TLS1_2_CLIENT;
+#ifdef SP_PROT_TLS1_3_CLIENT
+   sc.grbitEnabledProtocols |= SP_PROT_TLS1_3_CLIENT;
+#endif
+   /* Manual validation + no default client cert: we are FETCHING the cert to show
+    * its fingerprint and pin it (trust-on-first-use), not trusting it yet — so we
+    * deliberately skip the chain/hostname checks entirely. */
+   sc.dwFlags = SCH_CRED_NO_DEFAULT_CREDS | SCH_CRED_MANUAL_CRED_VALIDATION | SCH_USE_STRONG_CRYPTO;
+
+   int rc = -1;
+   if (AcquireCredentialsHandleA(NULL, (SEC_CHAR *)UNISP_NAME_A, SECPKG_CRED_OUTBOUND, NULL, &sc,
+                                 NULL, NULL, &t->cred, NULL) == SEC_E_OK)
+   {
+      t->have_cred = 1;
+      if (do_handshake(t, 1) == 0)
+      {
+         PCCERT_CONTEXT cert = NULL;
+         if (QueryContextAttributes(&t->ctx, SECPKG_ATTR_REMOTE_CERT_CONTEXT, &cert) == SEC_E_OK &&
+             cert && cert->pbCertEncoded && cert->cbCertEncoded)
+         {
+            /* PEM: CryptBinaryToStringA with BASE64HEADER emits a full
+             * -----BEGIN/END CERTIFICATE----- block. Size first (NULL out), then
+             * fill; the returned length includes the terminating NUL. */
+            DWORD pem_len = 0;
+            if (CryptBinaryToStringA(cert->pbCertEncoded, cert->cbCertEncoded,
+                                     CRYPT_STRING_BASE64HEADER, NULL, &pem_len) &&
+                pem_len)
+            {
+               char *pem = malloc(pem_len);
+               if (pem && CryptBinaryToStringA(cert->pbCertEncoded, cert->cbCertEncoded,
+                                               CRYPT_STRING_BASE64HEADER, pem, &pem_len))
+               {
+                  *pem_out = pem;
+                  rc = 0; /* PEM is the contract's required output */
+               }
+               else
+               {
+                  free(pem);
+               }
+            }
+            /* Fingerprint is best-effort, like the OpenSSL backend (does not fail
+             * the call if PEM already succeeded). */
+            if (rc == 0 && fp_out && fp_n)
+               (void)sha256_colon_hex(cert->pbCertEncoded, cert->cbCertEncoded, fp_out, fp_n);
+         }
+         if (cert)
+            CertFreeCertificateContext(cert);
+      }
+   }
+
+   aimee_tls_free(t);      /* tears down ctx/cred/host; does NOT close the fd */
+   platform_net_close(fd); /* we opened it, so we close it */
+
+   if (rc != 0)
+   {
+      if (pem_out)
+         *pem_out = NULL;
+      if (fp_out && fp_n)
+         fp_out[0] = '\0';
+   }
+   return rc;
 }
 
 void aimee_tls_free(aimee_tls_t *t)

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -21,7 +21,9 @@
 #define __STDC_WANT_LIB_EXT1__ 1 /* expose memset_s for a non-elidable key wipe */
 #include "aimee_tls.h"
 #include "aimee_home.h"
+#include "platform_net.h"
 
+#include <CommonCrypto/CommonDigest.h>
 #include <CoreFoundation/CoreFoundation.h>
 #include <Security/Security.h>
 #include <Security/SecureTransport.h>
@@ -29,6 +31,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 struct aimee_tls
@@ -213,6 +216,179 @@ static CFArrayRef securetransport_load_client_identity(SecKeychainRef *out_kc)
    return result;
 }
 
+/* Resolve <aimee_home>/remote-ca.pem — the pinned server certificate written by
+ * `aimee remote set/trust`. Returns 1 (and fills |out|) when the file exists,
+ * else 0. Mirrors pinned_ca_path() in the OpenSSL backend (aimee_tls.c). */
+static int pinned_ca_path(char *out, size_t n)
+{
+   const char *home = aimee_home();
+   if (!home || !*home || !out || n == 0)
+      return 0;
+   snprintf(out, n, "%s/remote-ca.pem", home);
+   struct stat st;
+   return (stat(out, &st) == 0 && S_ISREG(st.st_mode)) ? 1 : 0;
+}
+
+static int b64_val(int c)
+{
+   if (c >= 'A' && c <= 'Z')
+      return c - 'A';
+   if (c >= 'a' && c <= 'z')
+      return c - 'a' + 26;
+   if (c >= '0' && c <= '9')
+      return c - '0' + 52;
+   if (c == '+')
+      return 62;
+   if (c == '/')
+      return 63;
+   return -1; /* whitespace / non-alphabet (skipped by the decoder) */
+}
+
+/* Decode base64 |in| (in_len bytes), skipping whitespace and stopping at the
+ * first '=' pad, into a malloc'd buffer; sets *out_len. Caller frees. NULL on
+ * OOM. */
+static unsigned char *b64_decode(const char *in, size_t in_len, size_t *out_len)
+{
+   unsigned char *out = malloc(in_len / 4 * 3 + 3);
+   if (!out)
+      return NULL;
+   size_t o = 0;
+   int quad[4], qn = 0;
+   for (size_t i = 0; i < in_len; i++)
+   {
+      int c = (unsigned char)in[i];
+      if (c == '=')
+         break;
+      int v = b64_val(c);
+      if (v < 0)
+         continue;
+      quad[qn++] = v;
+      if (qn == 4)
+      {
+         out[o++] = (unsigned char)((quad[0] << 2) | (quad[1] >> 4));
+         out[o++] = (unsigned char)((quad[1] << 4) | (quad[2] >> 2));
+         out[o++] = (unsigned char)((quad[2] << 6) | quad[3]);
+         qn = 0;
+      }
+   }
+   if (qn == 2)
+      out[o++] = (unsigned char)((quad[0] << 2) | (quad[1] >> 4));
+   else if (qn == 3)
+   {
+      out[o++] = (unsigned char)((quad[0] << 2) | (quad[1] >> 4));
+      out[o++] = (unsigned char)((quad[1] << 4) | (quad[2] >> 2));
+   }
+   *out_len = o;
+   return out;
+}
+
+/* Load the first CERTIFICATE block from a PEM file at |path|, decode it to DER,
+ * and wrap it as a SecCertificateRef. Returns a retained ref (caller releases)
+ * or NULL on any failure. */
+static SecCertificateRef securetransport_load_pinned_cert(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   if (fseek(f, 0, SEEK_END) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   long sz = ftell(f);
+   if (sz <= 0 || sz > (1 << 20) || fseek(f, 0, SEEK_SET) != 0)
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t rd = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   if (rd != (size_t)sz)
+   {
+      free(buf);
+      return NULL;
+   }
+   buf[sz] = '\0'; /* NUL-terminate so the PEM markers can be located with strstr */
+
+   SecCertificateRef cert = NULL;
+   static const char begin[] = "-----BEGIN CERTIFICATE-----";
+   static const char end[] = "-----END CERTIFICATE-----";
+   char *b = strstr(buf, begin);
+   if (b)
+   {
+      b += sizeof(begin) - 1; /* body starts after the BEGIN marker line */
+      char *e = strstr(b, end);
+      if (e && e > b)
+      {
+         size_t der_len = 0;
+         unsigned char *der = b64_decode(b, (size_t)(e - b), &der_len);
+         if (der)
+         {
+            CFDataRef data = CFDataCreate(NULL, der, (CFIndex)der_len);
+            if (data)
+            {
+               cert = SecCertificateCreateWithData(NULL, data); /* NULL on bad DER */
+               CFRelease(data);
+            }
+            free(der);
+         }
+      }
+   }
+   free(buf);
+   return cert;
+}
+
+/* During a BreakOnServerAuth handshake, manually evaluate the peer's trust so
+ * that BOTH the system anchors AND the pinned cert are accepted, with the
+ * SSL/hostname policy bound to |host|. Returns 1 if trusted, 0 otherwise.
+ *
+ * IP-literal hosts: SecPolicyCreateSSL is given the host string verbatim; when
+ * that string is an IP literal, the SSL trust policy matches it against the
+ * cert's iPAddress SANs (aimee is commonly reached by IP with an IP-SAN cert),
+ * and against dNSName SANs/CN for real DNS names. (Could not be exercised here
+ * without running on macOS — see the report's caveats.) */
+static int securetransport_eval_pinned_trust(SSLContextRef ctx, const char *host,
+                                             SecCertificateRef pinned)
+{
+   SecTrustRef trust = NULL;
+   if (SSLCopyPeerTrust(ctx, &trust) != noErr || !trust)
+      return 0;
+
+   int ok = 0;
+   CFStringRef cf_host = CFStringCreateWithCString(NULL, host, kCFStringEncodingUTF8);
+   SecPolicyRef policy = cf_host ? SecPolicyCreateSSL(true, cf_host) : NULL;
+   if (policy && SecTrustSetPolicies(trust, policy) == errSecSuccess)
+   {
+      const void *anchors[] = {pinned};
+      CFArrayRef anchor_arr = CFArrayCreate(NULL, anchors, 1, &kCFTypeArrayCallBacks);
+      /* SecTrustSetAnchorCertificatesOnly(false) keeps the SYSTEM anchors trusted
+       * in ADDITION to the pinned cert, so a publicly-CA'd server and a pinned
+       * self-signed one both verify. */
+      if (anchor_arr && SecTrustSetAnchorCertificates(trust, anchor_arr) == errSecSuccess &&
+          SecTrustSetAnchorCertificatesOnly(trust, false) == errSecSuccess)
+      {
+         CFErrorRef err = NULL;
+         ok = SecTrustEvaluateWithError(trust, &err) ? 1 : 0;
+         if (err)
+            CFRelease(err);
+      }
+      if (anchor_arr)
+         CFRelease(anchor_arr);
+   }
+   if (policy)
+      CFRelease(policy);
+   if (cf_host)
+      CFRelease(cf_host);
+   CFRelease(trust);
+   return ok;
+}
+
 aimee_tls_t *aimee_tls_connect(int fd, const char *host)
 {
    aimee_tls_t *t = calloc(1, sizeof(*t));
@@ -246,6 +422,18 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
    }
 
    int insecure = tls_insecure();
+   /* When a pinned server cert is recorded for this remote, trust the system
+    * store AND that cert. The Keychain auto-eval can't be handed an extra anchor,
+    * so switch to the BreakOnServerAuth flow and evaluate manually below.
+    * Verification stays ON (chain + hostname/SAN). */
+   SecCertificateRef pinned = NULL;
+   if (!insecure)
+   {
+      char pin[700];
+      if (pinned_ca_path(pin, sizeof(pin)))
+         pinned = securetransport_load_pinned_cert(pin); /* NULL if unparseable */
+   }
+
    if (insecure)
    {
       /* Break on server auth so we can accept the cert WITHOUT evaluating it. */
@@ -258,20 +446,51 @@ aimee_tls_t *aimee_tls_connect(int fd, const char *host)
        * cert (MITM). aimee_client.c always passes the URL host. */
       if (!host || !*host)
       {
+         if (pinned)
+            CFRelease(pinned);
          CFRelease(t->ctx);
          free(t);
          return NULL;
       }
-      /* Set the expected name: Secure Transport then verifies chain + hostname
-       * (SAN/CN, wildcards) against the Keychain trust during the handshake. */
+      /* Set the expected name (also drives SNI). For the non-pinned path Secure
+       * Transport then verifies chain + hostname (SAN/CN, wildcards) against the
+       * Keychain trust during the handshake. */
       SSLSetPeerDomainName(t->ctx, host, strlen(host));
+      if (pinned)
+      {
+         /* Defer trust to our manual, pinned-anchor evaluation below. */
+         SSLSetSessionOption(t->ctx, kSSLSessionOptionBreakOnServerAuth, true);
+      }
    }
 
    OSStatus rc;
-   do
+   for (;;)
    {
       rc = SSLHandshake(t->ctx);
-   } while (rc == errSSLWouldBlock || (insecure && rc == errSSLPeerAuthCompleted));
+      if (rc == errSSLWouldBlock)
+         continue;
+      if (rc == errSSLPeerAuthCompleted)
+      {
+         if (insecure)
+            continue; /* accept without evaluation */
+         if (pinned)
+         {
+            /* Manually evaluate against system + pinned anchors with a hostname
+             * policy. On success resume the handshake to completion; on failure
+             * force a hard error so the connect fails closed (MITM-rejecting). */
+            if (securetransport_eval_pinned_trust(t->ctx, host, pinned))
+               continue;
+            rc = errSSLXCertChainInvalid;
+            break;
+         }
+         /* Non-pinned secure path never sets BreakOnServerAuth, so this branch is
+          * unreachable there; break defensively. */
+         break;
+      }
+      break;
+   }
+   if (pinned)
+      CFRelease(pinned);
 
    if (rc != noErr)
    {
@@ -313,6 +532,155 @@ long aimee_tls_read(aimee_tls_t *t, void *buf, size_t len)
    if (rc == errSSLClosedGraceful || rc == errSSLClosedNoNotify)
       return 0; /* clean EOF */
    return -1;
+}
+
+/* Base64-encode |der| (der_len bytes) and wrap it as a PEM CERTIFICATE block
+ * (64-column lines, with header/footer and trailing newline). Returns a malloc'd
+ * NUL-terminated string (caller frees) or NULL on OOM. */
+static char *der_to_pem(const unsigned char *der, size_t der_len)
+{
+   static const char b64[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+   size_t enc_len = (der_len + 2) / 3 * 4;
+   char *enc = malloc(enc_len + 1);
+   if (!enc)
+      return NULL;
+   size_t o = 0, i = 0;
+   while (i + 3 <= der_len)
+   {
+      unsigned v = ((unsigned)der[i] << 16) | ((unsigned)der[i + 1] << 8) | der[i + 2];
+      enc[o++] = b64[(v >> 18) & 63];
+      enc[o++] = b64[(v >> 12) & 63];
+      enc[o++] = b64[(v >> 6) & 63];
+      enc[o++] = b64[v & 63];
+      i += 3;
+   }
+   if (der_len - i == 1)
+   {
+      unsigned v = (unsigned)der[i] << 16;
+      enc[o++] = b64[(v >> 18) & 63];
+      enc[o++] = b64[(v >> 12) & 63];
+      enc[o++] = '=';
+      enc[o++] = '=';
+   }
+   else if (der_len - i == 2)
+   {
+      unsigned v = ((unsigned)der[i] << 16) | ((unsigned)der[i + 1] << 8);
+      enc[o++] = b64[(v >> 18) & 63];
+      enc[o++] = b64[(v >> 12) & 63];
+      enc[o++] = b64[(v >> 6) & 63];
+      enc[o++] = '=';
+   }
+   enc[o] = '\0';
+
+   static const char hdr[] = "-----BEGIN CERTIFICATE-----\n";
+   static const char ftr[] = "-----END CERTIFICATE-----\n";
+   size_t lines = (o + 63) / 64; /* one '\n' per wrapped 64-col line */
+   char *pem = malloc((sizeof(hdr) - 1) + o + lines + (sizeof(ftr) - 1) + 1);
+   if (!pem)
+   {
+      free(enc);
+      return NULL;
+   }
+   size_t p = 0;
+   memcpy(pem + p, hdr, sizeof(hdr) - 1);
+   p += sizeof(hdr) - 1;
+   for (size_t j = 0; j < o; j += 64)
+   {
+      size_t chunk = (o - j < 64) ? (o - j) : 64;
+      memcpy(pem + p, enc + j, chunk);
+      p += chunk;
+      pem[p++] = '\n';
+   }
+   memcpy(pem + p, ftr, sizeof(ftr) - 1);
+   p += sizeof(ftr) - 1;
+   pem[p] = '\0';
+   free(enc);
+   return pem;
+}
+
+/* Open a fresh, NON-verifying TLS connection to host:port (trust-on-first-use:
+ * we are fetching the cert to surface its fingerprint and pin it, not trusting
+ * it yet — mirrors the OpenSSL backend). Emits the leaf cert as PEM in *pem_out
+ * (malloc'd, caller frees) and its SHA-256 as uppercase colon-hex in fp_out.
+ * Returns 0 on success, -1 on failure (with *pem_out=NULL, fp_out[0]=0). */
+int aimee_tls_fetch_peer_cert(const char *host, const char *port, char **pem_out, char *fp_out,
+                              size_t fp_n)
+{
+   if (pem_out)
+      *pem_out = NULL;
+   if (fp_out && fp_n)
+      fp_out[0] = '\0';
+   if (!host || !*host || !port || !*port || !pem_out)
+      return -1;
+
+   int fd = platform_net_connect(host, port, 10000);
+   if (fd < 0)
+      return -1;
+
+   SSLContextRef ctx = SSLCreateContext(NULL, kSSLClientSide, kSSLStreamType);
+   if (!ctx)
+   {
+      platform_net_close(fd);
+      return -1;
+   }
+
+   int rc = -1;
+   if (SSLSetIOFuncs(ctx, st_read, st_write) == noErr && SSLSetConnection(ctx, &fd) == noErr &&
+       SSLSetProtocolVersionMin(ctx, kTLSProtocol12) == noErr &&
+       SSLSetSessionOption(ctx, kSSLSessionOptionBreakOnServerAuth, true) == noErr)
+   {
+      /* SNI: many servers select a cert by it. (For an IP literal this is not a
+       * valid SNI host, but the server we are fetching from ignores it.) */
+      SSLSetPeerDomainName(ctx, host, strlen(host));
+
+      OSStatus h;
+      do
+      {
+         h = SSLHandshake(ctx);
+      } while (h == errSSLWouldBlock || h == errSSLPeerAuthCompleted); /* accept w/o eval */
+
+      if (h == noErr)
+      {
+         SecTrustRef trust = NULL;
+         if (SSLCopyPeerTrust(ctx, &trust) == noErr && trust)
+         {
+            /* Leaf is index 0; SecTrustGetCertificateAtIndex is deprecated on
+             * macOS 12 but the TU is built -Wno-deprecated-declarations and it
+             * returns a non-owned ref (no release). */
+            SecCertificateRef leaf = SecTrustGetCertificateAtIndex(trust, 0);
+            if (leaf)
+            {
+               CFDataRef der = SecCertificateCopyData(leaf);
+               if (der)
+               {
+                  const unsigned char *bytes = CFDataGetBytePtr(der);
+                  size_t dlen = (size_t)CFDataGetLength(der);
+                  char *pem = der_to_pem(bytes, dlen);
+                  if (pem)
+                  {
+                     *pem_out = pem;
+                     rc = 0;
+                     if (fp_out && fp_n)
+                     {
+                        unsigned char md[CC_SHA256_DIGEST_LENGTH];
+                        CC_SHA256(bytes, (CC_LONG)dlen, md);
+                        size_t o = 0;
+                        for (unsigned i = 0; i < CC_SHA256_DIGEST_LENGTH && o + 4 < fp_n; i++)
+                           o += (size_t)snprintf(fp_out + o, fp_n - o, i ? ":%02X" : "%02X", md[i]);
+                     }
+                  }
+                  CFRelease(der);
+               }
+            }
+            CFRelease(trust);
+         }
+      }
+      SSLClose(ctx);
+   }
+
+   CFRelease(ctx);
+   platform_net_close(fd); /* the SSLConnectionRef does not own the fd */
+   return rc;
 }
 
 void aimee_tls_free(aimee_tls_t *t)

--- a/src/aimee_tls_securetransport.c
+++ b/src/aimee_tls_securetransport.c
@@ -367,11 +367,13 @@ static int securetransport_eval_pinned_trust(SSLContextRef ctx, const char *host
    {
       const void *anchors[] = {pinned};
       CFArrayRef anchor_arr = CFArrayCreate(NULL, anchors, 1, &kCFTypeArrayCallBacks);
-      /* SecTrustSetAnchorCertificatesOnly(false) keeps the SYSTEM anchors trusted
-       * in ADDITION to the pinned cert, so a publicly-CA'd server and a pinned
-       * self-signed one both verify. */
+      /* Strict pin: SecTrustSetAnchorCertificatesOnly(true) trusts ONLY the pinned
+       * cert (not the system anchors) for this evaluation — matching the OpenSSL
+       * (load-pin-only) and Windows (leaf-DER) backends. A recorded pin means a
+       * self-signed/private server, so a mis-issued public-CA cert for the same
+       * host is still rejected. The hostname/SAN policy above remains enforced. */
       if (anchor_arr && SecTrustSetAnchorCertificates(trust, anchor_arr) == errSecSuccess &&
-          SecTrustSetAnchorCertificatesOnly(trust, false) == errSecSuccess)
+          SecTrustSetAnchorCertificatesOnly(trust, true) == errSecSuccess)
       {
          CFErrorRef err = NULL;
          ok = SecTrustEvaluateWithError(trust, &err) ? 1 : 0;

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -77,6 +77,57 @@ void cli_remote_load_persisted(void)
       aimee_client_set_remote(url, token[0] ? token : NULL);
 }
 
+static void remote_ca_path(char *out, size_t out_sz)
+{
+   snprintf(out, out_sz, "%s/remote-ca.pem", aimee_home());
+}
+
+/* Probe GET /v1/health over the currently-active remote (verifying TLS). Returns
+ * 1 when the server answers (a real HTTP status — so the chain + hostname/SAN
+ * verified), else 0. Used to detect whether trust is already established. */
+static int remote_health_ok(void)
+{
+   int st = 0;
+   char *body = aimee_client_request("GET", "/v1/health", NULL, &st);
+   int ok = (body != NULL && st >= 200 && st < 500);
+   free(body);
+   return ok;
+}
+
+/* Trust-on-first-use pin: fetch |url|'s leaf cert (no verification), write it to
+ * <aimee_home>/remote-ca.pem, and report its SHA-256 fingerprint so the operator
+ * can confirm it out-of-band. aimee_tls_connect then verifies against it (chain +
+ * hostname/SAN still enforced). Returns 0 on success, -1 on failure (unreachable,
+ * not https, or pinning unsupported on this platform). */
+static int remote_pin_cert(const char *url, int json_output)
+{
+   char *pem = NULL;
+   char fp[200] = "";
+   if (aimee_client_fetch_cert(url, &pem, fp, sizeof(fp)) != 0 || !pem)
+   {
+      free(pem);
+      return -1;
+   }
+   ensure_dir_p(aimee_home());
+   char ca[512];
+   remote_ca_path(ca, sizeof(ca));
+   FILE *f = fopen(ca, "w");
+   if (!f)
+   {
+      free(pem);
+      return -1;
+   }
+   fputs(pem, f);
+   fclose(f);
+   free(pem);
+#ifndef _WIN32
+   chmod(ca, 0600);
+#endif
+   if (!json_output)
+      printf("  TLS: pinned server certificate (SHA-256 %s)\n       -> %s\n", fp, ca);
+   return 0;
+}
+
 static int remote_set(const char *url, const char *token, int json_output)
 {
    if (!url || !*url)
@@ -95,12 +146,79 @@ static int remote_set(const char *url, const char *token, int json_output)
    }
    fprintf(f, "%s\n%s\n", url, token ? token : "");
    fclose(f);
+
+   /* For an https remote, establish trust now so later commands need no
+    * AIMEE_TLS_INSECURE flag. If it already verifies (publicly-trusted CA, or a
+    * previously pinned cert) we leave it alone; otherwise pin its cert (TOFU). */
+   int is_https = (strncmp(url, "https://", 8) == 0);
+   int pinned = 0, verified = 0;
+   if (is_https)
+   {
+      aimee_client_set_remote(url, token && *token ? token : NULL);
+      /* This first probe is expected to fail for a self-signed server (not pinned
+       * yet); silence its diagnostic so a clean set doesn't look like an error. */
+      aimee_client_suppress_conn_errors(1);
+      int already = remote_health_ok();
+      aimee_client_suppress_conn_errors(0);
+      if (already)
+         verified = 1; /* already trusted — nothing to pin */
+      else if (remote_pin_cert(url, json_output) == 0)
+      {
+         pinned = 1;
+         verified = remote_health_ok(); /* re-probe against the pinned cert */
+      }
+   }
+
    if (json_output)
-      printf("{\"ok\":true,\"url\":\"%s\",\"token\":%s}\n", url,
-             token && *token ? "true" : "false");
+      printf("{\"ok\":true,\"url\":\"%s\",\"token\":%s,\"pinned\":%s,\"verified\":%s}\n", url,
+             token && *token ? "true" : "false", pinned ? "true" : "false",
+             verified ? "true" : "false");
    else
+   {
       printf("Remote server set to %s%s\n", url, token && *token ? " (with token)" : "");
+      if (is_https && verified)
+         printf(pinned ? "  TLS: verified against the pinned certificate.\n"
+                       : "  TLS: verified against the system trust store.\n");
+      else if (is_https)
+         printf("  TLS: could not establish trust (server unreachable, or cert pinning is not "
+                "available on this platform).\n"
+                "       Start the server and re-run, use `aimee remote trust`, or set "
+                "AIMEE_TLS_INSECURE=1 to override.\n");
+   }
    return 0;
+}
+
+/* Re-pin the cert of the already-configured remote (e.g. after the server's
+ * self-signed cert was rotated). */
+static int remote_trust(int json_output)
+{
+   char url[512], token[256];
+   if (!read_remote_conf(url, sizeof(url), token, sizeof(token)) || !url[0])
+   {
+      fprintf(stderr, "aimee: no remote configured; run `aimee remote set <url> [token]` first\n");
+      return 2;
+   }
+   if (strncmp(url, "https://", 8) != 0)
+   {
+      fprintf(stderr, "aimee: remote %s is not https:// — no certificate to pin\n", url);
+      return 1;
+   }
+   if (remote_pin_cert(url, json_output) != 0)
+   {
+      fprintf(stderr,
+              "aimee: could not fetch the server certificate (is %s reachable? is pinning "
+              "supported on this platform?)\n",
+              url);
+      return 1;
+   }
+   aimee_client_set_remote(url, token[0] ? token : NULL);
+   int verified = remote_health_ok();
+   if (json_output)
+      printf("{\"ok\":true,\"pinned\":true,\"verified\":%s}\n", verified ? "true" : "false");
+   else
+      printf(verified ? "  TLS: verified against the pinned certificate.\n"
+                      : "  TLS: pinned, but the server still does not verify — check it.\n");
+   return verified ? 0 : 1;
 }
 
 static int remote_clear(int json_output)
@@ -108,6 +226,10 @@ static int remote_clear(int json_output)
    char path[512];
    remote_conf_path(path, sizeof(path));
    int removed = (remove(path) == 0);
+   /* Also drop the pinned cert so a later remote can't accidentally inherit it. */
+   char ca[512];
+   remote_ca_path(ca, sizeof(ca));
+   remove(ca);
    if (json_output)
       printf("{\"ok\":true,\"cleared\":%s}\n", removed ? "true" : "false");
    else
@@ -152,8 +274,10 @@ int cli_remote_cmd(int argc, char **argv, int json_output)
       return remote_set(argc > 1 ? argv[1] : NULL, argc > 2 ? argv[2] : NULL, json_output);
    if (strcmp(sub, "clear") == 0)
       return remote_clear(json_output);
+   if (strcmp(sub, "trust") == 0)
+      return remote_trust(json_output);
    if (strcmp(sub, "status") == 0)
       return remote_status(json_output);
-   fprintf(stderr, "usage: aimee remote <set <url> [token] | status | clear>\n");
+   fprintf(stderr, "usage: aimee remote <set <url> [token] | trust | status | clear>\n");
    return 2;
 }

--- a/src/headers/aimee_client.h
+++ b/src/headers/aimee_client.h
@@ -79,6 +79,18 @@ extern "C"
     * Exposed for unit testing of the invariant. */
    int aimee_client_would_leak_cleartext(int is_https, const char *host, const char *token);
 
+   /* Fetch the leaf certificate of the https:// server named in |url| WITHOUT
+    * verifying it (trust-on-first-use), returning it as PEM (caller free()s
+    * *pem_out) plus its SHA-256 fingerprint in |fp_out|. Backs `aimee remote
+    * set/trust` cert pinning. Returns 0 on success; -1 if |url| is not https, the
+    * host is unreachable, or pinning is unsupported in this build/platform. */
+   int aimee_client_fetch_cert(const char *url, char **pem_out, char *fp_out, unsigned long fp_n);
+
+   /* Suppress (on != 0) or restore the transport's connection-failure messages on
+    * stderr. `aimee remote set` brackets its pre-pin probe with this so an
+    * expected, about-to-be-pinned handshake failure does not print. */
+   void aimee_client_suppress_conn_errors(int on);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/headers/aimee_tls.h
+++ b/src/headers/aimee_tls.h
@@ -41,6 +41,17 @@ extern "C"
    int aimee_tls_client_cert_eligible(const char *home, char *crt, size_t crt_n, char *key,
                                       size_t key_n);
 
+   /* Open a fresh TLS connection to |host|:|port| WITHOUT verifying the server,
+    * and return its leaf certificate as PEM (caller free()s *pem_out) plus the
+    * SHA-256 fingerprint as uppercase colon-hex in |fp_out|. For `aimee remote
+    * set/trust` to pin a self-signed/private server (trust-on-first-use): the
+    * caller surfaces the fingerprint for an out-of-band check and writes the PEM
+    * to <aimee_home>/remote-ca.pem, which aimee_tls_connect then trusts with
+    * verification still ON. Returns 0 on success, -1 on failure (incl. platforms
+    * where it is not yet implemented). */
+   int aimee_tls_fetch_peer_cert(const char *host, const char *port, char **pem_out, char *fp_out,
+                                 size_t fp_n);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
## Problem
Pointing the thin client at a self-signed/private aimee server (e.g. a `.254` LAN box) required prefixing **every** command with `AIMEE_TLS_INSECURE=1` — which also disables verification entirely (encrypted but unauthenticated, MITM-able). Bad UX *and* bad security.

## Fix: trust-on-first-use cert pinning, configured once
`aimee remote set https://host:port [token]`:
1. probes verifying reachability; if it already verifies (public CA / already pinned) → done.
2. otherwise fetches the server's leaf cert (no verification), writes it to `<aimee_home>/remote-ca.pem`, prints its **SHA-256 fingerprint** for out-of-band confirmation, and re-verifies.

The TLS layer then trusts that pinned cert **in addition to** the system store, with **verification fully ON** — chain + hostname/SAN still enforced. A MITM presenting a *different* cert is rejected.

New: `aimee remote trust` (re-pin after a cert rotation), `aimee remote clear` also drops the pin. `AIMEE_TLS_INSECURE` stays as an explicit override; the handshake-failure message now points at `aimee remote trust`.

## Latent bug also fixed
An **IP-literal host** (the common LAN case, `192.168.1.254`) must be matched against the cert's **IP-address SANs** via `X509_VERIFY_PARAM_set1_ip_asc` — `set1_host` only matches DNS names/CN, so an IP server failed verification even with a valid/pinned cert (insecure mode always masked this).

## Cross-platform (all released thin-client targets)
| Backend | Status |
|---|---|
| Linux / OpenSSL | **tested end-to-end** against a live self-signed server: `set` → verified-against-pin, normal commands work with no env flag, and swapping a *different* cert into the pin slot is **refused** (MITM check) |
| macOS / SecureTransport | implemented (SecTrust manual eval, pinned cert as extra anchor) — compiles in CI |
| Windows / Schannel | implemented (strict leaf-DER pin, SSL name policy still enforced) — compiles in CI |

## Honest caveat
The macOS/Windows backends compile in CI but their **IP-SAN name-match** runtime behavior isn't yet verified on those platforms (both rely on the OS SSL policy matching IP SANs for an IP host). Linux is fully verified. Flagged for a follow-up runtime check on mac/win.

## Files
`aimee_tls.c` (OpenSSL pin + IP-SAN fix + `aimee_tls_fetch_peer_cert`), `aimee_tls_securetransport.c`, `aimee_tls_schannel.c`, `aimee_client.c`/`.h` (`aimee_client_fetch_cert`, conn-error suppression), `cli_remote.c` (`set` auto-pin, `trust`, `clear`).