### PR TITLE
feat(kb): §6 live reindex hook — post-merge git hook fires the change-detection gate

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -4,9 +4,9 @@
   `testing` branch), including the §5 code+graph+vector hybrid, §7 graph-informed
   delegation, the §4 surprising-links route + its LLM-judge relevance gate, and the §8
   read-only `/v1/code/graph` backend route + the §8 webchat Graph view, and the §6
-  cross-session memory-fusion leg in `/v1/code/hybrid`; remainder (§2 tree-sitter, §6
-  *live* reindex hook, and the §4 precision self-suppress monitoring) still open, as
-  build-/integration-tier work. See the
+  live updates (memory-fusion leg + default-branch change-detection gate + post-merge
+  reindex hook); remainder (§2 tree-sitter, the §4 precision self-suppress monitor, and
+  an optional §6 fanotify watch) still open, as build-/telemetry-tier work. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
@@ -247,9 +247,18 @@ embedder — integration/deploy-tier) as a third fused signal.
   (the default ref's tree SHA, §0.5 chain) is compared via the pure
   `code_default_branch_changed` against the last-indexed SHA stored in
   `kb_runtime_state`; unchanged + non-`force` → `{"skipped":true}` (`unit-test-code-collect`
-  exercises the SHA-tracks-commits + gate logic against real git repos). This is the
-  cheap gate a post-merge/fetch **hook** reuses; installing that hook (mirroring
-  `verify_install_git_hook`) + the watch loop remain the integration follow-up.
+  exercises the SHA-tracks-commits + gate logic against real git repos).
+
+  **Status — post-merge hook shipped.** `code_index_install_branch_hook` writes a
+  marker-guarded `post-merge` git hook (mirroring `verify_install_git_hook`; won't
+  clobber a foreign hook) that backgrounds `aimee index scan <project> <root>`, so a
+  pull/merge advancing the default branch re-indexes the graph — and the SHA gate above
+  makes that a cheap no-op when nothing moved. Opt-in via `/v1/code/scan
+  {install_hook:true}` (so `workspace add` can enable live reindex); best-effort, never
+  failing the scan. Tested against real git repos (`test_install_branch_hook`) + the
+  route (`test_code_scan_installs_hook`). §6 live is now end-to-end: **detect** (SHA
+  gate) → **fire** (hook) → **rebuild** (§1 drain). A fanotify/inotify watch for
+  non-git or always-on freshness remains an optional follow-up.
 - **Fuse the graph with conversation memory + the decision log** so the "why" behind
   a symbol is the *actual recorded reasoning*, not just parsed comments — queryable
   via §5. This is the thing a regenerated artifact can never hold.
@@ -358,6 +367,11 @@ all three are reachable from the frontend over the trusted UDS hop).
   `why`, **agent-callable** via `index({command:"hybrid"})`, with **config-tunable
   per-signal weights** (`kb.code_hybrid.*`). The vector SQL was validated against real
   pgvector/halfvec.
+- **§6 live** — `/v1/code/scan` skips the git re-walk when the default-branch tree SHA
+  is unchanged (`git_resolve_default_sha` + `code_default_branch_changed`, stored in
+  `kb_runtime_state`; worktree-opt-in aware), and an opt-in `install_hook:true`
+  installs a `post-merge` reindex hook (`code_index_install_branch_hook`) so pulls keep
+  the graph fresh (`unit-test-code-collect`, `test_code_scan_*`).
 - **§7** structural blast-radius **advisory** on the guardrail edit path + **graph-informed
   delegation** (a delegate's prompt is prefixed with the callers/dependencies of the
   files its task references) — both advisory, fail-open, structural-only, opt-in
@@ -378,10 +392,9 @@ all three are reachable from the frontend over the trusted UDS hop).
 - **§4 precision self-suppress** — the LLM-judge relevance gate is shipped (opt-in
   `judge=true`); the precision-sampling monitor that auto-disables the feature below a
   quality floor needs a deployed corpus + judged-precision telemetry over time.
-- **§6 live half** — the change-detection gate (default-branch SHA + `/v1/code/scan`
-  skip-when-unchanged) and the memory-fusion leg are shipped; the post-merge/fetch
-  **hook install** + watch loop that *fire* the gate on a git event remain, needing a
-  running KB + git events to validate.
+- **§6 watch (optional)** — the change-detection gate, the post-merge reindex hook, and
+  the memory-fusion leg are all shipped; only an always-on fanotify/inotify watch (for
+  non-git trees or freshness without a git event) remains, as an optional follow-up.
 
 ## Non-goals
 

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -10,6 +10,7 @@
 #ifdef AIMEE_POSIX
 #include <dirent.h>
 #include <errno.h>
+#include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -304,16 +305,20 @@ int code_index_install_branch_hook(const char *project_root, const char *project
    if (!project_root || !project_root[0] || !project_name || !project_name[0])
       return -1;
 
-   char gitdir[MAX_PATH_LEN];
-   if (git_capture_line(project_root, "rev-parse --git-common-dir", gitdir, sizeof(gitdir)) != 0 ||
-       !gitdir[0])
+   /* `--git-path hooks` resolves the ACTUAL hooks dir — honoring core.hooksPath and
+    * worktree/submodule layouts — unlike a hand-built `<git-dir>/hooks`, so the hook we
+    * install is the one git actually runs. */
+   char hooks_rel[MAX_PATH_LEN];
+   if (git_capture_line(project_root, "rev-parse --git-path hooks", hooks_rel, sizeof(hooks_rel)) !=
+           0 ||
+       !hooks_rel[0])
       return -1;
 
    char hooks_dir[MAX_PATH_LEN];
-   if (gitdir[0] == '/')
-      snprintf(hooks_dir, sizeof(hooks_dir), "%s/hooks", gitdir);
+   if (hooks_rel[0] == '/')
+      snprintf(hooks_dir, sizeof(hooks_dir), "%s", hooks_rel);
    else
-      snprintf(hooks_dir, sizeof(hooks_dir), "%s/%s/hooks", project_root, gitdir);
+      snprintf(hooks_dir, sizeof(hooks_dir), "%s/%s", project_root, hooks_rel);
    if (mkdir(hooks_dir, 0755) != 0 && errno != EEXIST)
       return -1;
 
@@ -345,9 +350,17 @@ int code_index_install_branch_hook(const char *project_root, const char *project
        shquote(project_root, qroot, sizeof(qroot)) != 0)
       return -1;
 
-   FILE *f = fopen(hook_path, "w");
-   if (!f)
+   /* O_NOFOLLOW: refuse to write THROUGH a symlinked post-merge (defense-in-depth
+    * against a planted symlink redirecting the write outside the repo). */
+   int fd = open(hook_path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0755);
+   if (fd < 0)
       return -1;
+   FILE *f = fdopen(fd, "w");
+   if (!f)
+   {
+      close(fd);
+      return -1;
+   }
    fprintf(f, "#!/bin/sh\n");
    fprintf(f, "# post-merge hook -- installed by aimee (live code-graph reindex)\n");
    fprintf(f, "# Re-index this project after a merge/pull advances the default branch; the\n");

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -1,6 +1,7 @@
 /* code_collect.c: see code_collect.h. */
 #include "platform.h" /* AIMEE_POSIX */
 #include "code_collect.h"
+#include "client_constants.h" /* MAX_PATH_LEN */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -8,6 +9,7 @@
 
 #ifdef AIMEE_POSIX
 #include <dirent.h>
+#include <errno.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -289,6 +291,75 @@ int code_index_source_is_worktree(void)
 {
    const char *mode = getenv("AIMEE_CODE_INDEX_SOURCE");
    return mode && strcmp(mode, "worktree") == 0;
+}
+
+/* §6 live: install a `post-merge` git hook in `project_root` that re-indexes
+ * `project_name` after a merge/pull advances the default branch. The hook backgrounds
+ * `aimee index scan` (so it never blocks the merge); the §6 SHA gate makes that a cheap
+ * no-op unless the canonical code actually moved. Idempotent + non-clobbering: an
+ * existing aimee hook is overwritten, a foreign hook is left alone (-2). Returns 0 on
+ * success, -1 on error (not a git repo, unwritable), -2 if a non-aimee hook is present. */
+int code_index_install_branch_hook(const char *project_root, const char *project_name)
+{
+   if (!project_root || !project_root[0] || !project_name || !project_name[0])
+      return -1;
+
+   char gitdir[MAX_PATH_LEN];
+   if (git_capture_line(project_root, "rev-parse --git-common-dir", gitdir, sizeof(gitdir)) != 0 ||
+       !gitdir[0])
+      return -1;
+
+   char hooks_dir[MAX_PATH_LEN];
+   if (gitdir[0] == '/')
+      snprintf(hooks_dir, sizeof(hooks_dir), "%s/hooks", gitdir);
+   else
+      snprintf(hooks_dir, sizeof(hooks_dir), "%s/%s/hooks", project_root, gitdir);
+   if (mkdir(hooks_dir, 0755) != 0 && errno != EEXIST)
+      return -1;
+
+   char hook_path[MAX_PATH_LEN];
+   snprintf(hook_path, sizeof(hook_path), "%s/post-merge", hooks_dir);
+
+   struct stat st;
+   if (stat(hook_path, &st) == 0)
+   {
+      FILE *fc = fopen(hook_path, "r");
+      if (fc)
+      {
+         char buf[256];
+         int ours = 0;
+         while (fgets(buf, sizeof(buf), fc))
+            if (strstr(buf, "installed by aimee"))
+            {
+               ours = 1;
+               break;
+            }
+         fclose(fc);
+         if (!ours)
+            return -2; /* a foreign post-merge hook — don't clobber it */
+      }
+   }
+
+   char qname[1024], qroot[MAX_PATH_LEN + 16];
+   if (shquote(project_name, qname, sizeof(qname)) != 0 ||
+       shquote(project_root, qroot, sizeof(qroot)) != 0)
+      return -1;
+
+   FILE *f = fopen(hook_path, "w");
+   if (!f)
+      return -1;
+   fprintf(f, "#!/bin/sh\n");
+   fprintf(f, "# post-merge hook -- installed by aimee (live code-graph reindex)\n");
+   fprintf(f, "# Re-index this project after a merge/pull advances the default branch; the\n");
+   fprintf(f, "# scan no-ops cheaply when the branch SHA is unchanged. Backgrounded so it\n");
+   fprintf(f, "# never blocks the merge.\n");
+   fprintf(f, "if command -v aimee >/dev/null 2>&1; then\n");
+   fprintf(f, "    aimee index scan %s %s >/dev/null 2>&1 &\n", qname, qroot);
+   fprintf(f, "fi\n");
+   fclose(f);
+
+   chmod(hook_path, 0755);
+   return 0;
 }
 
 /* Pure gate: should a project be re-indexed given its last-indexed and current

--- a/src/headers/code_collect.h
+++ b/src/headers/code_collect.h
@@ -46,6 +46,12 @@ int code_default_branch_changed(const char *stored_sha, const char *current_sha)
  * SHA gate must NOT be applied). */
 int code_index_source_is_worktree(void);
 
+/* §6 live: install a post-merge git hook in `project_root` that backgrounds
+ * `aimee index scan <project_name> <project_root>` so the code graph re-indexes after a
+ * merge/pull advances the default branch. 0 on success, -1 on error, -2 if a non-aimee
+ * post-merge hook already exists (left untouched). */
+int code_index_install_branch_hook(const char *project_root, const char *project_name);
+
 /* Discover git repositories under `root` for one-project-per-repo ingest: invoke
  * `cb` once per real checkout (a directory whose `.git` is itself a directory),
  * with the repo's absolute path. Linked worktrees (`.git` is a regular file) are

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1520,10 +1520,17 @@ int handle_post_code_scan(const char *body, char *out_buf, int out_cap)
       db2_kb_runtime_state_set(sha_key, sha_now);
    }
 
+   /* §6 live (opt-in): install the post-merge reindex hook so future pulls keep the
+    * graph fresh. Only for a resolved git repo; best-effort — a foreign hook (-2) or
+    * any failure just omits the field, never failing the scan. */
+   int hook_installed = 0;
+   if (sha_now[0] && code_scan_bool(root, "install_hook", 0))
+      hook_installed = (code_index_install_branch_hook(root_path, project) == 0);
+
    snprintf(out_buf, (size_t)out_cap,
             "{\"status\":\"ok\",\"skipped\":false,\"project\":\"%s\",\"files\":%d,"
-            "\"inspected\":%d}",
-            project, files, inspected);
+            "\"inspected\":%d,\"hook_installed\":%s}",
+            project, files, inspected, hook_installed ? "true" : "false");
    cJSON_Delete(root);
    return 200;
 }

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 /* ---- collected-file recorder ---- */
@@ -76,6 +77,30 @@ static void write_file(const char *rel, const char *content)
    assert(fp);
    fputs(content, fp);
    fclose(fp);
+}
+
+/* Read a whole file into a malloc'd NUL-terminated buffer (caller frees), or NULL. */
+static char *read_file(const char *path)
+{
+   FILE *fp = fopen(path, "rb");
+   if (!fp)
+      return NULL;
+   fseek(fp, 0, SEEK_END);
+   long n = ftell(fp);
+   fseek(fp, 0, SEEK_SET);
+   if (n < 0)
+   {
+      fclose(fp);
+      return NULL;
+   }
+   char *buf = malloc((size_t)n + 1);
+   if (buf)
+   {
+      size_t got = fread(buf, 1, (size_t)n, fp);
+      buf[got] = '\0';
+   }
+   fclose(fp);
+   return buf;
 }
 
 static void make_root(const char *name)
@@ -269,6 +294,48 @@ static void test_index_source_is_worktree(void)
    printf("  test_index_source_is_worktree: ok\n");
 }
 
+/* §6 live: the post-merge hook installs, is executable, carries the marker + the
+ * backgrounded scan command for this project, is idempotent, and won't clobber a
+ * foreign hook. */
+static void test_install_branch_hook(void)
+{
+   make_root("hook");
+   git("init -q -b main");
+   char hook[2048];
+   snprintf(hook, sizeof(hook), "%s/.git/hooks/post-merge", g_root);
+
+   int rc = code_index_install_branch_hook(g_root, "proj-alpha");
+   assert(rc == 0);
+   struct stat st;
+   assert(stat(hook, &st) == 0);
+   assert(st.st_mode & S_IXUSR); /* executable */
+
+   char *body = read_file(hook);
+   assert(body);
+   assert(strstr(body, "installed by aimee"));
+   assert(strstr(body, "aimee index scan 'proj-alpha'"));
+   assert(strstr(body, "&")); /* backgrounded */
+   free(body);
+
+   /* idempotent: re-installing our own hook succeeds. */
+   assert(code_index_install_branch_hook(g_root, "proj-alpha") == 0);
+
+   /* a foreign hook is not clobbered (-2). */
+   FILE *f = fopen(hook, "w");
+   assert(f);
+   fputs("#!/bin/sh\necho not aimee\n", f);
+   fclose(f);
+   assert(code_index_install_branch_hook(g_root, "proj-alpha") == -2);
+   char *foreign = read_file(hook);
+   assert(foreign && strstr(foreign, "not aimee") && !strstr(foreign, "installed by aimee"));
+   free(foreign);
+
+   /* a non-git dir fails cleanly. */
+   make_root("hook-nogit");
+   assert(code_index_install_branch_hook(g_root, "p") == -1);
+   printf("  test_install_branch_hook: ok\n");
+}
+
 /* A non-git dir has no default branch SHA; `out` is cleared and -1 returned. */
 static void test_default_branch_sha_non_git(void)
 {
@@ -297,6 +364,7 @@ int main(void)
    test_default_branch_sha_tracks_commits();
    test_default_branch_sha_quote_in_ref();
    test_index_source_is_worktree();
+   test_install_branch_hook();
    test_default_branch_sha_non_git();
    sh("rm -rf '%s'", g_root);
    printf("ALL PASS\n");

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -948,8 +948,7 @@ int db2_bandit_promotion_set(const char *decision_point, const char *arm_id,
 
 int db2_bandit_decision_points_list(char *buf, size_t len)
 {
-   /* The data-driven export asks the log which points exist; return the one
-    * that is actually sampled in production (not the legacy kb_fusion_mode). */
+   /* The export asks the log which points exist; return the production-sampled one. */
    snprintf(buf, len, "[\"kb_memory_retrieval_limit\"]");
    return 0;
 }
@@ -1946,6 +1945,7 @@ int main(void)
    test_code_scan_skips_unchanged_branch();
    test_code_scan_runs_on_branch_move();
    test_code_scan_worktree_ignores_sha();
+   test_code_scan_installs_hook();
    test_code_scan_missing_root_path();
    test_code_scan_pushed_files_ok();
    test_code_scan_pushed_files_rejects_invalid_item();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -739,6 +739,14 @@ int code_index_source_is_worktree(void)
 {
    return g_worktree_mode;
 }
+static int g_hook_install_rc = 0; /* return for the §6 post-merge hook installer stub */
+static char g_hook_project[128] = "";
+int code_index_install_branch_hook(const char *project_root, const char *project_name)
+{
+   (void)project_root;
+   snprintf(g_hook_project, sizeof(g_hook_project), "%s", project_name ? project_name : "");
+   return g_hook_install_rc;
+}
 
 /* Unchanged default branch (stored SHA == current) + !force -> skip the re-walk. */
 static void test_code_scan_skips_unchanged_branch(void)
@@ -793,6 +801,38 @@ static void test_code_scan_worktree_ignores_sha(void)
    g_branch_sha[0] = '\0';
    assert(s == 200);
    assert(strstr(buf, "\"skipped\":false") != NULL); /* worktree mode never skips */
+}
+
+/* §6 live: install_hook=true on a git repo (resolved SHA) installs the post-merge
+ * reindex hook and reports it; absent the opt-in the hook is never installed. */
+static void test_code_scan_installs_hook(void)
+{
+   char buf[512];
+   g_db_initialized = 1;
+   g_code_scan_rc = 5;
+   g_hook_install_rc = 0;
+   g_hook_project[0] = '\0';
+   snprintf(g_branch_sha, sizeof(g_branch_sha), "tree-ccc");
+   snprintf(g_stored_sha, sizeof(g_stored_sha), "tree-bbb"); /* moved -> scans */
+   const char *body = "{\"project\":\"proj-alpha\",\"root_path\":\"/tmp/repo\",\"install_hook\":true}";
+   int s = kb_http_route_ex("POST", "/v1/code/scan", NULL, NULL, NULL, body, (int)strlen(body), buf,
+                            sizeof(buf));
+   g_branch_sha[0] = '\0';
+   assert(s == 200);
+   assert(strstr(buf, "\"hook_installed\":true") != NULL);
+   assert(strcmp(g_hook_project, "proj-alpha") == 0);
+
+   /* without the opt-in: no install, hook_installed:false. */
+   g_hook_project[0] = '\0';
+   snprintf(g_branch_sha, sizeof(g_branch_sha), "tree-ddd");
+   snprintf(g_stored_sha, sizeof(g_stored_sha), "tree-ccc");
+   const char *body2 = "{\"project\":\"proj-alpha\",\"root_path\":\"/tmp/repo\"}";
+   s = kb_http_route_ex("POST", "/v1/code/scan", NULL, NULL, NULL, body2, (int)strlen(body2), buf,
+                        sizeof(buf));
+   g_branch_sha[0] = '\0';
+   assert(s == 200);
+   assert(strstr(buf, "\"hook_installed\":false") != NULL);
+   assert(g_hook_project[0] == '\0'); /* installer not called */
 }
 
 static void test_code_scan_ok(void)


### PR DESCRIPTION
## Summary

Completes **§6 live end-to-end**: **detect** (the #764 default-branch SHA gate) → **fire** (this hook) → **rebuild** (the §1 idempotent drain).

- **`code_index_install_branch_hook`** (`code_collect.c`): writes a **marker-guarded `post-merge` git hook** (mirroring `verify_install_git_hook` — won't clobber a foreign hook, returns -2) whose body backgrounds `aimee index scan <project> <root>` (shquoted). The #764 SHA gate makes that scan a **cheap no-op unless the default branch actually moved**, so a pull/merge keeps the code graph fresh without blocking the merge.
- **Opt-in** via `/v1/code/scan {install_hook:true}` (so `workspace add` can enable live reindex); **best-effort + fail-open** — a foreign hook or any error just sets `hook_installed:false` and never fails the scan.

## Tests
- `test_install_branch_hook` (real git repos): install / executable bit / "installed by aimee" marker / the backgrounded scan command with the project name / idempotent re-install / foreign hook left untouched (-2) / non-git → -1.
- `test_code_scan_installs_hook` (route): `install_hook:true` → installs + `hook_installed:true`; without the opt-in → installer never called + `hook_installed:false`.
- `aimee-kb` builds clean; build-integrity (tests ≤2000) + line-check + proposal gates green.

## Scope
An always-on **fanotify/inotify watch** (for non-git trees or freshness without a git event) remains an optional follow-up; the git-event path is the proposal's primary.