### PR TITLE
feat(kb): §4 precision self-suppress — disable noisy surprising candidates below a floor

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (123)
+## CLI-settable keys (124)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -38,6 +38,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `code_hybrid_weight_memory` | float | RRF weight for the cross-session knowledge-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it; symbol-anchored, empty without an entity graph). |
 | `code_hybrid_weight_vector` | float | RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder). |
 | `code_span_max_lines` | int | Max line span the code_span_get recovery resolver returns per call (default 400). |
+| `code_surprising_precision_floor` | float | §4 self-suppress: when the LLM-judge-sampled precision of surprising-link candidates falls below this floor, an unjudged /v1/code/graph/surprising request returns no candidates (default 0 = disabled). |
 | `cost_reward_enabled` | bool | Factor token cost into the reward signal. |
 | `cost_reward_lambda_pct` | int | Cost-penalty weight (percent) in the reward. |
 | `cost_reward_ref_usd_milli` | int | Reference cost (USD-milli) normalizing the cost reward. |

--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -5,8 +5,8 @@
   delegation, the §4 surprising-links route + its LLM-judge relevance gate, and the §8
   read-only `/v1/code/graph` backend route + the §8 webchat Graph view, and the §6
   live updates (memory-fusion leg + default-branch change-detection gate + post-merge
-  reindex hook); remainder (§2 tree-sitter, the §4 precision self-suppress monitor, and
-  an optional §6 fanotify watch) still open, as build-/telemetry-tier work. See the
+  reindex hook) + the §4 precision self-suppress; remainder is **§2 tree-sitter** (the
+  one build-tier item) and an optional §6 fanotify watch. See the
   "Implementation status" section below.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
@@ -358,7 +358,11 @@ all three are reachable from the frontend over the trusted UDS hop).
   containment hub excluded** (`handle_get_code_graph_surprising`,
   `test_code_graph_surprising_*`), with an opt-in **LLM-judge relevance gate**
   (`judge=true` → shared-symbol cross-check + one batched Tier-B judge,
-  `kb_surprising_judge`, `unit-test-kb-surprising-judge`).
+  `kb_surprising_judge`, `unit-test-kb-surprising-judge`) and a **precision
+  self-suppress**: the judge samples the structural generator's precision
+  (`confirmed`/`judged`, rolling per-project in `kb_runtime_state`), and an unjudged
+  request returns no candidates once that precision falls below the configurable
+  `code_surprising_precision_floor` (`kb_surprising_precision_suppress`).
 - **§5+§6** RRF fusion core (`kb_rrf.c`, `unit-test-kb-rrf`) + the `GET /v1/code/hybrid`
   route fusing `code` + `graph` + **`vector`** (embedding similarity over
   `code_embeddings` via `pgvec_code_search_paths`, gated on a dim-matched embedder,
@@ -389,9 +393,6 @@ all three are reachable from the frontend over the trusted UDS hop).
 **Deferred — needs the embedder / a build-tier dependency / a deployed corpus / a frontend
 (not completable in the agent host):**
 - **§2 tree-sitter** front-end — large build-tier work (vendor ~30 grammars + ABI).
-- **§4 precision self-suppress** — the LLM-judge relevance gate is shipped (opt-in
-  `judge=true`); the precision-sampling monitor that auto-disables the feature below a
-  quality floor needs a deployed corpus + judged-precision telemetry over time.
 - **§6 watch (optional)** — the change-detection gate, the post-merge reindex hook, and
   the memory-fusion leg are all shipped; only an always-on fanotify/inotify watch (for
   non-git trees or freshness without a git event) remains, as an optional follow-up.

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -138,6 +138,7 @@ CFG_KEY_DESC = {
     "code_hybrid_weight_vector": "RRF weight for the embedding-similarity signal in /v1/code/hybrid (default 1.0; <=0 disables it; auto-skips when no dim-matched embedder).",
     "code_hybrid_weight_memory": "RRF weight for the cross-session knowledge-graph signal in /v1/code/hybrid (default 1.0; <=0 disables it; symbol-anchored, empty without an entity graph).",
     "code_hybrid_rrf_k": "Reciprocal Rank Fusion rank constant k for /v1/code/hybrid (default 60).",
+    "code_surprising_precision_floor": "§4 self-suppress: when the LLM-judge-sampled precision of surprising-link candidates falls below this floor, an unjudged /v1/code/graph/surprising request returns no candidates (default 0 = disabled).",
     "guardrails_blast_radius_advisory_enabled": "Surface a structural blast-radius advisory (graph-impacted files) before an edit (advisory, fail-open).",
     "guardrails_semantic_allow_ml_only_block": "Allow blocking on the ML classifier alone.",
     "guardrails_semantic_block_threshold": "Semantic score threshold to block.",

--- a/src/config.c
+++ b/src/config.c
@@ -550,7 +550,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->code_hybrid_weight_graph = 1.0;
    cfg->code_hybrid_weight_vector = 1.0;
    cfg->code_hybrid_weight_memory = 1.0;
-   cfg->code_hybrid_rrf_k = 60.0; /* KB_RRF_DEFAULT_K */
+   cfg->code_hybrid_rrf_k = 60.0;              /* KB_RRF_DEFAULT_K */
+   cfg->code_surprising_precision_floor = 0.0; /* §4 self-suppress off by default */
    cfg->kb_bg_ingest_enabled = 1;
    cfg->kb_bg_ingest_interval_hours = 6;
 #ifdef __linux__

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -132,6 +132,8 @@ const config_field_t config_fields[] = {
     {"code_hybrid_weight_memory", offsetof(config_t, code_hybrid_weight_memory), sizeof(double), 0,
      CFG_FLOAT},
     {"code_hybrid_rrf_k", offsetof(config_t, code_hybrid_rrf_k), sizeof(double), 0, CFG_FLOAT},
+    {"code_surprising_precision_floor", offsetof(config_t, code_surprising_precision_floor),
+     sizeof(double), 0, CFG_FLOAT},
     {"memory_semantic_weight", offsetof(config_t, memory_semantic_weight), sizeof(double), 0,
      CFG_FLOAT},
     {"memory_semantic_floor_scale", offsetof(config_t, memory_semantic_floor_scale), sizeof(double),

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -1360,6 +1360,9 @@ void config_parse_kb_section2(config_t *cfg, cJSON *root)
          item = cJSON_GetObjectItemCaseSensitive(ch, "weight_memory");
          if (cJSON_IsNumber(item))
             cfg->code_hybrid_weight_memory = item->valuedouble;
+         item = cJSON_GetObjectItemCaseSensitive(ch, "surprising_precision_floor");
+         if (cJSON_IsNumber(item))
+            cfg->code_surprising_precision_floor = item->valuedouble;
          item = cJSON_GetObjectItemCaseSensitive(ch, "rrf_k");
          if (cJSON_IsNumber(item) && item->valuedouble > 0)
             cfg->code_hybrid_rrf_k = item->valuedouble;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1263,6 +1263,10 @@ typedef struct config
    double code_hybrid_weight_vector;
    double code_hybrid_weight_memory;
    double code_hybrid_rrf_k;
+   /* §4: when the LLM-judge-sampled precision of surprising-link structural candidates
+    * falls below this floor, an unjudged /v1/code/graph/surprising request suppresses
+    * its candidates (they're mostly false positives). 0 (default) disables it. */
+   double code_surprising_precision_floor;
    /* embedder-runtime-fetch-autodim §2c: when 0 (default) a recorded-vs-configured
     * embedding-dim mismatch is REFUSED at startup (refuse-and-instruct). When 1, the
     * attended `aimee kb reembed --confirm` reset path is AVAILABLE (it still never

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -1130,6 +1130,50 @@ int handle_get_code_graph_route(const char *method, const char *query_string, ch
 #define SURPRISING_MAX_ANCHORS 5000
 /* Cap on links sent to the LLM judge in one batch (bounds the prompt + latency). */
 #define SURPRISING_JUDGE_MAX 12
+/* §4 precision self-suppress: don't act on the judge-sampled precision until this many
+ * candidates have been judged; halve the rolling (judged,confirmed) counters once they
+ * exceed the cap so the metric tracks RECENT precision, not all-time. */
+#define SURPRISING_PRECISION_MIN_SAMPLES 20
+#define SURPRISING_PRECISION_DECAY_CAP   500
+
+/* Read the rolling per-project judge stats (count judged + count confirmed) used to
+ * sample the structural generator's precision. Absent keys -> 0. */
+static void surprising_stats_get(const char *project, int *judged, int *confirmed)
+{
+   char key[320], val[64];
+   *judged = 0;
+   *confirmed = 0;
+   snprintf(key, sizeof(key), "surprising_judged:%s", project);
+   if (db2_kb_runtime_state_get(key, val, sizeof(val)) == 0)
+      *judged = atoi(val);
+   snprintf(key, sizeof(key), "surprising_confirmed:%s", project);
+   if (db2_kb_runtime_state_get(key, val, sizeof(val)) == 0)
+      *confirmed = atoi(val);
+}
+
+/* Accumulate this request's (judged, confirmed) into the rolling stats, decaying when
+ * the sample grows past the cap so older precision fades. Best-effort. */
+static void surprising_stats_add(const char *project, int dj, int dc)
+{
+   if (dj <= 0)
+      return;
+   int judged = 0, confirmed = 0;
+   surprising_stats_get(project, &judged, &confirmed);
+   judged += dj;
+   confirmed += dc;
+   if (judged > SURPRISING_PRECISION_DECAY_CAP)
+   {
+      judged /= 2;
+      confirmed /= 2;
+   }
+   char key[320], val[32];
+   snprintf(key, sizeof(key), "surprising_judged:%s", project);
+   snprintf(val, sizeof(val), "%d", judged);
+   db2_kb_runtime_state_set(key, val);
+   snprintf(key, sizeof(key), "surprising_confirmed:%s", project);
+   snprintf(val, sizeof(val), "%d", confirmed);
+   db2_kb_runtime_state_set(key, val);
+}
 
 int handle_get_code_graph_surprising(const char *query_string, char *out_buf, int out_cap)
 {
@@ -1283,25 +1327,47 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
    gedges = NULL;
    pairs = NULL;
 
+   /* §4 precision self-suppress + rolling judge stats. The LLM judge samples the
+    * structural generator's precision (confirmed/judged); when NOT judging, suppress
+    * the unjudged candidates if that sampled precision has fallen below the configured
+    * floor — they'd be mostly false positives. Floor <= 0 (default) disables it. */
+   config_t scfg;
+   int have_cfg = (config_load(&scfg) == 0);
+   double precision_floor = have_cfg ? scfg.code_surprising_precision_floor : 0.0;
+   int stat_judged = 0, stat_confirmed = 0;
+   surprising_stats_get(project, &stat_judged, &stat_confirmed);
+   int suppressed = 0;
+   if (!judge &&
+       kb_surprising_precision_suppress(stat_judged, stat_confirmed,
+                                        SURPRISING_PRECISION_MIN_SAMPLES, precision_floor))
+   {
+      suppressed = 1;
+      ns = 0; /* historically low-precision structural candidates -> show none */
+      links_truncated = 0;
+   }
+
    /* §4 relevance gate (opt-in): confirm the top links with one batched LLM judge.
     * Bounded to SURPRISING_JUDGE_MAX (prompt/latency). Degrades to unconfirmed if no
-    * Tier-B LLM is configured (judged stays 0). */
+    * Tier-B LLM is configured (judged stays 0). The verdicts also feed the precision
+    * sample above for future requests. */
    kb_surprising_verdict_t *verdicts = NULL;
-   int jn = 0, judged_n = 0;
-   if (judge && ns > 0)
+   int jn = 0, judged_n = 0, confirmed_n = 0;
+   if (judge && ns > 0 && have_cfg)
    {
       jn = ns < SURPRISING_JUDGE_MAX ? ns : SURPRISING_JUDGE_MAX;
       verdicts = calloc((size_t)jn, sizeof(*verdicts));
       if (verdicts)
       {
-         config_t jcfg;
          char jerr[256] = "";
-         if (config_load(&jcfg) == 0)
+         int r = kb_surprising_judge(&scfg, scfg.kb_curator_judge_command, project, out, jn,
+                                     verdicts, jerr, sizeof(jerr));
+         if (r > 0)
          {
-            int r = kb_surprising_judge(&jcfg, jcfg.kb_curator_judge_command, project, out, jn,
-                                        verdicts, jerr, sizeof(jerr));
-            if (r > 0)
-               judged_n = r;
+            judged_n = r;
+            for (int i = 0; i < jn; i++)
+               if (verdicts[i].judged && verdicts[i].confirmed)
+                  confirmed_n++;
+            surprising_stats_add(project, judged_n, confirmed_n);
          }
       }
    }
@@ -1358,6 +1424,15 @@ int handle_get_code_graph_surprising(const char *query_string, char *out_buf, in
     * Tier-B LLM configured -> links are unconfirmed structural candidates). */
    if (judge)
       cJSON_AddNumberToObject(resp, "judged", judged_n);
+   /* §4 self-suppress observability: the judge-sampled structural precision and its
+    * sample size; `suppressed` true when an unjudged request returned nothing because
+    * that precision is below the floor. */
+   if (stat_judged > 0)
+      cJSON_AddNumberToObject(resp, "sampled_precision",
+                              (double)stat_confirmed / (double)stat_judged);
+   cJSON_AddNumberToObject(resp, "judged_samples", stat_judged);
+   if (suppressed)
+      cJSON_AddBoolToObject(resp, "suppressed", 1);
    /* Truncated if the page cap bound the links (precise: the +1 probe overflowed),
     * or either input scan filled its window (edges or candidate pairs) so the
     * candidate set was itself a prefix. */

--- a/src/kb/kb_graph_analytics.c
+++ b/src/kb/kb_graph_analytics.c
@@ -233,3 +233,15 @@ int kb_graph_surprising(const kb_graph_edge_t *edges, int n_edges, const kb_grap
    free(cand);
    return n;
 }
+
+int kb_surprising_precision_suppress(int judged, int confirmed, int min_samples, double floor)
+{
+   if (floor <= 0.0 || min_samples <= 0 || judged < min_samples)
+      return 0;
+   if (confirmed < 0)
+      confirmed = 0;
+   if (confirmed > judged)
+      confirmed = judged;
+   double precision = (double)confirmed / (double)judged;
+   return precision < floor ? 1 : 0;
+}

--- a/src/kb/kb_graph_analytics.h
+++ b/src/kb/kb_graph_analytics.h
@@ -83,4 +83,14 @@ int kb_graph_surprising(const kb_graph_edge_t *edges, int n_edges, const kb_grap
                         int n_pairs, double sim_percentile, int d_min, kb_graph_surprising_t *out,
                         int max);
 
+/* §4 precision self-suppress. The LLM judge samples the structural candidate
+ * generator's precision: `confirmed`/`judged` is the fraction of cosine+distance
+ * candidates the judge deemed genuine. Returns 1 when the surprising feature should
+ * SUPPRESS its (unjudged) structural candidates because that sampled precision has
+ * dropped below `floor` over a meaningful sample — i.e. the structural filter is
+ * mostly surfacing false positives, so showing raw candidates would be noise. Returns
+ * 0 when there isn't enough signal yet (`judged` < `min_samples`), the floor is
+ * disabled (`floor` <= 0), or precision is at/above the floor. Pure. */
+int kb_surprising_precision_suppress(int judged, int confirmed, int min_samples, double floor);
+
 #endif /* KB_GRAPH_ANALYTICS_H */

--- a/src/tests/test_kb_graph_analytics.c
+++ b/src/tests/test_kb_graph_analytics.c
@@ -168,9 +168,30 @@ static void test_surprising_bad_args(void)
    printf("  test_surprising_bad_args: ok\n");
 }
 
+/* §4 precision self-suppress gate: suppress only with enough samples AND a precision
+ * below the (enabled) floor. */
+static void test_precision_suppress(void)
+{
+   /* floor disabled (<=0) -> never suppress. */
+   assert(kb_surprising_precision_suppress(100, 0, 20, 0.0) == 0);
+   assert(kb_surprising_precision_suppress(100, 0, 20, -1.0) == 0);
+   /* too few samples -> not yet. */
+   assert(kb_surprising_precision_suppress(5, 0, 20, 0.1) == 0);
+   /* enough samples + precision below floor -> suppress. */
+   assert(kb_surprising_precision_suppress(100, 5, 20, 0.10) == 1); /* 5% < 10% */
+   /* precision at/above floor -> don't suppress. */
+   assert(kb_surprising_precision_suppress(100, 10, 20, 0.10) == 0); /* exactly 10% */
+   assert(kb_surprising_precision_suppress(100, 50, 20, 0.10) == 0);
+   /* clamps: confirmed>judged or negative don't break it. */
+   assert(kb_surprising_precision_suppress(100, 200, 20, 0.10) == 0); /* clamped to 100% */
+   assert(kb_surprising_precision_suppress(100, -3, 20, 0.10) == 1);  /* clamped to 0% */
+   printf("  test_precision_suppress: ok\n");
+}
+
 int main(void)
 {
    printf("test_kb_graph_analytics:\n");
+   test_precision_suppress();
    test_hub_ranking();
    test_deterministic_tiebreak();
    test_self_loop();

--- a/src/tests/test_kb_http_routes.c
+++ b/src/tests/test_kb_http_routes.c
@@ -281,8 +281,7 @@ int kb_curator_contradictions_json(int limit, char *out, size_t out_cap)
    return 1;
 }
 
-/* §2c: stubs for the /v1/reembed + /v1/search-guard db2 refs in kb_http.o.
- * g_test_reembed_in_progress drives the maintenance marker (the /v1/search 503 guard). */
+/* §2c: /v1/reembed + search-guard db2 stubs (g_test_reembed_in_progress -> 503 guard). */
 static int g_test_reembed_in_progress = 0;
 int db2_reembed_in_progress_get(int *target_dim, long *started_epoch)
 {
@@ -298,9 +297,8 @@ int db2_reembed_in_progress_get(int *target_dim, long *started_epoch)
    (void)started_epoch;
    return 0; /* not in progress -> search path proceeds */
 }
-/* structured-PDF search_chunks db2 stubs — the routes are exercised against real SQL
- * in test_kb_doc_pdf.c; here they only resolve the link (struct args as void* to avoid
- * db2/kb_payload.h, which conflicts with this file's simplified db2 stubs). */
+/* structured-PDF search_chunks db2 stubs — exercised against real SQL in
+ * test_kb_doc_pdf.c; here they only resolve the link (void* args avoid kb_payload.h). */
 int db2_kb_pdf_search_chunks(const char *project, const char *query, int max, void *out)
 {
    return 0;
@@ -828,9 +826,9 @@ void kb_curator_queue_code_units_for_project(const char *project, const char *ro
    g_curator_code_queued++;
 }
 
-/* §2c: lets a test flip kb.reembed_on_dim_change so the /v1/reembed gate
- * (403 when off, proceeds when on) can be exercised both ways. */
+/* §2c: flips kb.reembed_on_dim_change for the /v1/reembed 403/proceed gate test. */
 static int g_test_reembed_enabled = 0;
+static double g_precision_floor = 0.0; /* §4 surprising self-suppress floor (0 = off) */
 int config_load(config_t *cfg)
 {
    memset(cfg, 0, sizeof(*cfg));
@@ -850,6 +848,7 @@ int config_load(config_t *cfg)
    cfg->code_hybrid_weight_vector = 1.0;
    cfg->code_hybrid_weight_memory = 1.0;
    cfg->code_hybrid_rrf_k = 60.0;
+   cfg->code_surprising_precision_floor = g_precision_floor;
    return 0;
 }
 
@@ -1931,6 +1930,7 @@ int main(void)
    test_code_graph_surprising_missing_project();
    test_code_graph_surprising_vecstore_down();
    test_code_graph_surprising_judge();
+   test_code_graph_surprising_self_suppress();
    test_code_graph_node_ok();
    test_code_graph_node_capped_truncates();
    test_code_graph_node_self_loop();

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -3,6 +3,10 @@
  * unit under the 2000-line hard limit. Included (with
  * test_kb_http_routes_endpoints.inc) just before main(); all helpers and
  * fixtures live in test_kb_http_routes.c above the include point. */
+/* §4 surprising self-suppress: rolling judge stats the runtime_state stub serves for
+ * the surprising_judged:/surprising_confirmed: keys (-1 = key absent). */
+static int g_sj_judged = -1;
+static int g_sj_confirmed = -1;
 /* Full memory_t layout (mirrors headers/memory.h) so the stub writes each field
  * at the offset the handler — compiled against the real struct — reads. The main
  * file keeps a truncated local memory_t for other stubs, so we cast a void* here
@@ -613,6 +617,36 @@ static void test_code_graph_surprising_judge(void)
    assert(strstr(buf, "\"judged\":1") != NULL);
 }
 
+/* §4 self-suppress: with the floor enabled and the rolling judge-sampled precision
+ * below it (2/100 = 2% < 10%), an UNJUDGED request returns no links + suppressed:true. */
+static void test_code_graph_surprising_self_suppress(void)
+{
+   char buf[4096];
+   g_precision_floor = 0.10;
+   g_sj_judged = 100;
+   g_sj_confirmed = 2;
+   int s = kb_http_route_ex("GET", "/v1/code/graph/surprising",
+                            "project=proj-alpha&percentile=0&d_min=2&max_results=10", NULL, NULL,
+                            NULL, 0, buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"suppressed\":true") != NULL);
+   assert(strstr(buf, "\"link_count\":0") != NULL);
+   assert(strstr(buf, "\"sampled_precision\":0.02") != NULL);
+
+   /* precision at/above the floor -> NOT suppressed, links shown. */
+   g_sj_confirmed = 50; /* 50% */
+   s = kb_http_route_ex("GET", "/v1/code/graph/surprising",
+                        "project=proj-alpha&percentile=0&d_min=2&max_results=10", NULL, NULL, NULL, 0,
+                        buf, sizeof(buf));
+   assert(s == 200);
+   assert(strstr(buf, "\"suppressed\":true") == NULL);
+   assert(strstr(buf, "\"link_count\":1") != NULL); /* the disconnected pair surfaces */
+
+   g_precision_floor = 0.0; /* reset for other tests */
+   g_sj_judged = -1;
+   g_sj_confirmed = -1;
+}
+
 /* A vector-store failure (pgvec gather returns <0) is surfaced as 503, not a silent
  * empty 200 — an outage must be distinguishable from "no surprising links". */
 static void test_code_graph_surprising_vecstore_down(void)
@@ -713,9 +747,22 @@ int git_resolve_default_sha(const char *root, char *out, size_t outlen)
 }
 int db2_kb_runtime_state_get(const char *key, char *out, size_t out_len)
 {
-   (void)key;
    if (!out || out_len == 0)
       return -1;
+   if (key && strncmp(key, "surprising_judged:", 18) == 0)
+   {
+      if (g_sj_judged < 0)
+         return -1;
+      snprintf(out, out_len, "%d", g_sj_judged);
+      return 0;
+   }
+   if (key && strncmp(key, "surprising_confirmed:", 21) == 0)
+   {
+      if (g_sj_confirmed < 0)
+         return -1;
+      snprintf(out, out_len, "%d", g_sj_confirmed);
+      return 0;
+   }
    snprintf(out, out_len, "%s", g_stored_sha);
    return g_stored_sha[0] ? 0 : -1;
 }


### PR DESCRIPTION
## Summary

Completes **§4**. The key realization: the proposal samples precision "(LLM-judge **or** human spot-check)" — so the **judge itself is the precision sampler**. `confirmed/judged` is the *structural candidate generator's* sampled precision (the fraction of cosine+distance candidates the judge deems genuine). This adds the self-suppress half:

- **`kb_surprising_precision_suppress(judged, confirmed, min_samples, floor)`** — pure gate: suppress once enough samples accumulate **and** sampled precision < floor (floor ≤ 0 or too-few-samples → never). Unit-tested.
- **`/v1/code/graph/surprising`** keeps **rolling per-project `(judged, confirmed)`** counters in `kb_runtime_state` (halved past a cap so the metric tracks *recent* precision); a `judge=true` request accumulates its verdicts. When **not** judging and sampled precision is below the floor, the route returns no links + `suppressed:true` (the unjudged structural candidates are mostly false positives). The response also surfaces `sampled_precision` + `judged_samples` for observability.
- Config-tunable **`code_surprising_precision_floor`** (`kb.code_hybrid.surprising_precision_floor`; default **0 = off**, opt-in; 6-touch + docs).

## Tests
- `test_precision_suppress` (pure: floor-off / too-few-samples / below-floor → suppress / at-floor → not).
- `test_code_graph_surprising_self_suppress` (route: below-floor → `suppressed:true`/`link_count:0`/`sampled_precision`; at/above-floor → links shown). The runtime-state route stub is now key-aware for the surprising stats.
- `aimee-kb` builds clean; build-integrity (tests ≤2000) + line-check + `unit-test-config`/`cmd-config` + docs-gen + proposal gates green.

With this, **only §2 tree-sitter** (the one build-tier item) and an optional §6 fanotify watch remain.