### PR TITLE
feat(kb): §2 tree-sitter — Python, Go, JavaScript, Rust grammars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,3 +114,7 @@ agent-keys.json
 # compiles against them only in the opt-in AIMEE_TREESITTER build.
 src/vendor/tree-sitter/
 src/vendor/tree-sitter-c/
+src/vendor/tree-sitter-python/
+src/vendor/tree-sitter-go/
+src/vendor/tree-sitter-javascript/
+src/vendor/tree-sitter-rust/

--- a/NOTICE
+++ b/NOTICE
@@ -44,8 +44,10 @@ aimee and is not covered by the AGPL-3.0 grant above:
 
   - The §2 tree-sitter extraction front-end (built only with AIMEE_TREESITTER)
     links tree-sitter and its grammars, fetched at build time by
-    scripts/fetch-treesitter.sh into src/vendor/tree-sitter{,-c}/ (NOT committed;
-    see .gitignore). tree-sitter (https://github.com/tree-sitter/tree-sitter) and
-    tree-sitter-c (https://github.com/tree-sitter/tree-sitter-c) are Copyright (c)
+    scripts/fetch-treesitter.sh into src/vendor/tree-sitter{,-c,-python,-go,
+    -javascript,-rust}/ (NOT committed; see .gitignore). tree-sitter
+    (https://github.com/tree-sitter/tree-sitter) and its grammars tree-sitter-c,
+    tree-sitter-python, tree-sitter-go, tree-sitter-javascript and tree-sitter-rust
+    (https://github.com/tree-sitter/tree-sitter-<lang>) are Copyright (c)
     Max Brunsfeld and contributors, licensed under the MIT License (each clone
     carries its LICENSE file).

--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -5,10 +5,11 @@
   delegation + blast-radius advisory, the §4 surprising-links route with its LLM-judge
   relevance gate + precision self-suppress, the §8 `/v1/code/graph` backend route + the
   webchat Graph view, the §6 live updates (memory-fusion leg + default-branch
-  change-detection gate + post-merge reindex hook), and the **§2 tree-sitter front-end +
-  C grammar** (opt-in `AIMEE_TREESITTER` build, fall-through to the hand-rolled
-  extractors). Only **optional follow-ups** remain — more §2 grammars + parse-tree call
-  edges, and an always-on §6 fanotify watch. See the "Implementation status" section.
+  change-detection gate + post-merge reindex hook), and the **§2 tree-sitter front-end**
+  with **C, Python, Go, JavaScript and Rust** grammars (opt-in `AIMEE_TREESITTER`
+  build, fall-through to the hand-rolled extractors). Only **optional follow-ups**
+  remain — more §2 grammars + nested-member/parse-tree call edges, and an always-on §6
+  fanotify watch. See the "Implementation status" section.
 - **Thesis:** aimee should treat the codebase as a *living* graph that is (a) fully
   built without a manual step, (b) parsed broadly, (c) ranked by **graph structure
   AND vector similarity AND memory** in one query, and (d) able to *change what the
@@ -119,18 +120,21 @@ the *same* `code_calls` / `code_projection_edges` / symbol tables. Target ≥30
 languages. Keep the existing extractor path as fallback for unsupported grammars.
 This is the one true coverage gap and the largest engineering item.
 
-**Status — front-end + first grammar shipped (opt-in).** `code_treesitter.c` parses a
+**Status — front-end + 5 grammars shipped (opt-in).** `code_treesitter.c` parses a
 file with the tree-sitter grammar for its extension and emits the same `definition_t`
-symbols (functions / typedefs / struct·union·enum types) the hand-rolled extractor
-does; `extract_definitions` prefers it where a grammar is compiled in and **falls back**
-otherwise — so the **default build is unchanged**. The runtime + grammars are large
-generated parsers, so they are **fetched at build time** (`scripts/fetch-treesitter.sh`,
-pinned commits, gitignored) and compiled only in the opt-in `AIMEE_TREESITTER` build;
-`code_treesitter.c` is a stub without it. Ships the **C grammar** (aimee dogfoods its
-own source) + the build machinery (`unit-test-code-treesitter` parses real C and asserts
-the extracted defs); adding the remaining ~29 languages is now mechanical — vendor each
-grammar's `parser.c` and register its `TSLanguage` + extensions in `ts_language_for_ext`.
-Call-edge extraction (`code_calls`) over the parse tree is the next increment.
+symbols (functions and types) the hand-rolled extractor does; `extract_definitions`
+prefers it where a grammar is compiled in and **falls back** otherwise — so the
+**default build is unchanged**. The runtime + grammars are large generated parsers, so
+they are **fetched at build time** (`scripts/fetch-treesitter.sh`, pinned commits,
+gitignored) and compiled only in the opt-in `AIMEE_TREESITTER` build (external scanners
+linked where a grammar needs one); `code_treesitter.c` is a stub without it. Ships
+**C, Python, Go, JavaScript and Rust** grammars, each with a per-language `classify_*`
+mapping its definition node types to `function`/`type` (`unit-test-code-treesitter`
+parses real source in all five and asserts the extracted defs). Adding a grammar is
+mechanical — vendor its `parser.c`(+`scanner.c`), register its `TSLanguage` + extensions
+in `ts_language_for_ext`, and add a `classify_*`. Remaining increments: recursive
+descent for nested members (class/impl methods), more languages, and call-edge
+extraction (`code_calls`) over the parse tree.
 
 ## §3 Edge provenance + confidence
 

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -26,7 +26,12 @@ fetch() {
 
 # Runtime (one amalgamated compilation unit via lib/src/lib.c).
 fetch tree-sitter   https://github.com/tree-sitter/tree-sitter   cbee4672665173d1702d836353ef7648dc2b2fac
-# Grammars (one parser.c each). C first — aimee dogfoods its own source.
-fetch tree-sitter-c https://github.com/tree-sitter/tree-sitter-c b780e47fc780ddc8da13afa35a3f4ed5c157823d
+# Grammars (one parser.c each, plus a src/scanner.c for those with an external scanner —
+# Python/JavaScript/Rust have one; C and Go do not). C first — aimee dogfoods its own source.
+fetch tree-sitter-c          https://github.com/tree-sitter/tree-sitter-c          b780e47fc780ddc8da13afa35a3f4ed5c157823d
+fetch tree-sitter-python     https://github.com/tree-sitter/tree-sitter-python     26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64
+fetch tree-sitter-go         https://github.com/tree-sitter/tree-sitter-go         2346a3ab1bb3857b48b29d779a1ef9799a248cd7
+fetch tree-sitter-javascript https://github.com/tree-sitter/tree-sitter-javascript 58404d8cf191d69f2674a8fd507bd5776f46cb11
+fetch tree-sitter-rust       https://github.com/tree-sitter/tree-sitter-rust       77a3747266f4d621d0757825e6b11edcbf991ca5
 
-echo "fetch-treesitter: done -> $VENDOR/tree-sitter{,-c}"
+echo "fetch-treesitter: done -> $VENDOR/tree-sitter{,-c,-python,-go,-javascript,-rust}"

--- a/src/Makefile
+++ b/src/Makefile
@@ -423,9 +423,23 @@ KB_PLATFORM_OBJS = $(PLATFORM_BASIC_OBJS) $(filter %/agent_bridge.o %/cli_client
 # compiled (with -w, since vendored generated code does not pass -Werror), and the KB's
 # code_treesitter.o is built with -DAIMEE_TREESITTER.
 ifdef AIMEE_TREESITTER
-TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o $(OBJDIR)/vendor/ts_c.o
+# Runtime + one object per grammar parser.c, plus a scanner object for grammars with an
+# external scanner (Python/JavaScript/Rust; C and Go have none). Add a language by
+# vendoring it (fetch-treesitter.sh), appending its objs here + a compile rule below, and
+# registering it in code_treesitter.c.
+TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
+                 $(OBJDIR)/vendor/ts_c.o \
+                 $(OBJDIR)/vendor/ts_python.o $(OBJDIR)/vendor/ts_python_scan.o \
+                 $(OBJDIR)/vendor/ts_go.o \
+                 $(OBJDIR)/vendor/ts_javascript.o $(OBJDIR)/vendor/ts_javascript_scan.o \
+                 $(OBJDIR)/vendor/ts_rust.o $(OBJDIR)/vendor/ts_rust_scan.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
-vendor/tree-sitter/lib/src/lib.c vendor/tree-sitter-c/src/parser.c:
+vendor/tree-sitter/lib/src/lib.c \
+vendor/tree-sitter-c/src/parser.c \
+vendor/tree-sitter-python/src/parser.c vendor/tree-sitter-python/src/scanner.c \
+vendor/tree-sitter-go/src/parser.c \
+vendor/tree-sitter-javascript/src/parser.c vendor/tree-sitter-javascript/src/scanner.c \
+vendor/tree-sitter-rust/src/parser.c vendor/tree-sitter-rust/src/scanner.c:
 	./scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
@@ -433,6 +447,27 @@ $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 $(OBJDIR)/vendor/ts_c.o: vendor/tree-sitter-c/src/parser.c
 	@mkdir -p $(OBJDIR)/vendor
 	$(CC) -c -Os -w -Ivendor/tree-sitter-c/src -o $@ $<
+$(OBJDIR)/vendor/ts_python.o: vendor/tree-sitter-python/src/parser.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-python/src -o $@ $<
+$(OBJDIR)/vendor/ts_python_scan.o: vendor/tree-sitter-python/src/scanner.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-python/src -o $@ $<
+$(OBJDIR)/vendor/ts_go.o: vendor/tree-sitter-go/src/parser.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-go/src -o $@ $<
+$(OBJDIR)/vendor/ts_javascript.o: vendor/tree-sitter-javascript/src/parser.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-javascript/src -o $@ $<
+$(OBJDIR)/vendor/ts_javascript_scan.o: vendor/tree-sitter-javascript/src/scanner.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-javascript/src -o $@ $<
+$(OBJDIR)/vendor/ts_rust.o: vendor/tree-sitter-rust/src/parser.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-rust/src -o $@ $<
+$(OBJDIR)/vendor/ts_rust_scan.o: vendor/tree-sitter-rust/src/scanner.c
+	@mkdir -p $(OBJDIR)/vendor
+	$(CC) -c -Os -w -Ivendor/tree-sitter-rust/src -o $@ $<
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -14,21 +14,57 @@
 #include <stdio.h>
 
 /* Grammar entry points (defined in the vendored parser.c files). Add a language by
- * vendoring its grammar + declaring + registering it in ts_language_for_ext below. */
+ * vendoring its grammar (scripts/fetch-treesitter.sh + src/Makefile), declaring its
+ * entry point here, mapping its extension(s) in ts_language_for_ext, and adding a
+ * classify_<lang> for that grammar's definition node types (see classify below). */
 const TSLanguage *tree_sitter_c(void);
+const TSLanguage *tree_sitter_python(void);
+const TSLanguage *tree_sitter_go(void);
+const TSLanguage *tree_sitter_javascript(void);
+const TSLanguage *tree_sitter_rust(void);
 
-static const TSLanguage *ts_language_for_ext(const char *ext)
+typedef enum
+{
+   TSL_C,
+   TSL_PY,
+   TSL_GO,
+   TSL_JS,
+   TSL_RUST
+} ts_lang_t;
+
+static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
 {
    if (!ext)
       return NULL;
-   if (strcmp(ext, ".c") == 0 || strcmp(ext, ".h") == 0)
-      return tree_sitter_c();
+   static const struct
+   {
+      const char *ext;
+      ts_lang_t lang;
+      const TSLanguage *(*fn)(void);
+   } map[] = {
+       {".c", TSL_C, tree_sitter_c},
+       {".h", TSL_C, tree_sitter_c},
+       {".py", TSL_PY, tree_sitter_python},
+       {".go", TSL_GO, tree_sitter_go},
+       {".js", TSL_JS, tree_sitter_javascript},
+       {".mjs", TSL_JS, tree_sitter_javascript},
+       {".cjs", TSL_JS, tree_sitter_javascript},
+       {".jsx", TSL_JS, tree_sitter_javascript},
+       {".rs", TSL_RUST, tree_sitter_rust},
+   };
+   for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
+      if (strcmp(ext, map[i].ext) == 0)
+      {
+         if (which)
+            *which = map[i].lang;
+         return map[i].fn();
+      }
    return NULL;
 }
 
 int code_treesitter_available(const char *ext)
 {
-   return ts_language_for_ext(ext) != NULL;
+   return ts_language_for_ext(ext, NULL) != NULL;
 }
 
 /* Copy a node's source span into out[cap] (NUL-terminated, truncated to fit). */
@@ -62,10 +98,17 @@ static int first_identifier(TSNode node, TSNode *out)
    return 0;
 }
 
-/* Map a top-level node to a (kind, name-bearing subtree). Returns 0 if not a
- * definition we surface. The name is taken from the relevant field's first identifier
- * so it survives pointer/array declarator wrapping. */
-static int classify(TSNode node, const char **kind, TSNode *name_root)
+/* Each classify_<lang> maps a top-level node to a (kind, name-bearing subtree),
+ * returning 0 if it is not a definition we surface. kind is "function" (callables) or
+ * "type" (class/struct/enum/trait/typedef). name_root is the subtree whose first
+ * identifier is the symbol name (see first_identifier) — it may be a possibly-null
+ * field node; the caller re-checks ts_node_is_null. Only the file's TOP-LEVEL named
+ * children are walked, so nested members (methods in a class/impl) are not surfaced;
+ * recursive descent is a follow-up. */
+
+/* C: the name survives pointer/array declarator wrapping, so name_root is the whole
+ * declarator and first_identifier digs out the bare name. */
+static int classify_c(TSNode node, const char **kind, TSNode *name_root)
 {
    const char *t = ts_node_type(node);
    if (strcmp(t, "function_definition") == 0)
@@ -105,9 +148,114 @@ static int classify(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
+/* Python: function/class definitions, including those wrapped by a decorator. */
+static int classify_py(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   if (strcmp(t, "decorated_definition") == 0)
+   {
+      TSNode inner = ts_node_child_by_field_name(node, "definition", 10);
+      if (ts_node_is_null(inner))
+         return 0;
+      return classify_py(inner, kind, name_root); /* inner is a function/class def */
+   }
+   if (strcmp(t, "function_definition") == 0)
+      *kind = "function";
+   else if (strcmp(t, "class_definition") == 0)
+      *kind = "type";
+   else
+      return 0;
+   *name_root = ts_node_child_by_field_name(node, "name", 4);
+   return 1;
+}
+
+/* Go: func/method declarations and named types (type_spec inside a type_declaration,
+ * including the first spec of a grouped `type ( ... )` block). */
+static int classify_go(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   if (strcmp(t, "function_declaration") == 0 || strcmp(t, "method_declaration") == 0)
+   {
+      *kind = "function";
+      *name_root = ts_node_child_by_field_name(node, "name", 4);
+      return 1;
+   }
+   if (strcmp(t, "type_declaration") == 0)
+   {
+      uint32_t n = ts_node_named_child_count(node);
+      for (uint32_t i = 0; i < n; i++)
+      {
+         TSNode spec = ts_node_named_child(node, i);
+         const char *st = ts_node_type(spec);
+         if (strcmp(st, "type_spec") == 0 || strcmp(st, "type_alias") == 0)
+         {
+            TSNode nm = ts_node_child_by_field_name(spec, "name", 4);
+            if (!ts_node_is_null(nm))
+            {
+               *kind = "type";
+               *name_root = nm;
+               return 1;
+            }
+         }
+      }
+      return 0;
+   }
+   return 0;
+}
+
+/* JavaScript: function (incl. generator) and class declarations. Arrow functions
+ * bound to a const/let are not surfaced (no name field) — a follow-up. */
+static int classify_js(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   if (strcmp(t, "function_declaration") == 0 || strcmp(t, "generator_function_declaration") == 0)
+      *kind = "function";
+   else if (strcmp(t, "class_declaration") == 0)
+      *kind = "type";
+   else
+      return 0;
+   *name_root = ts_node_child_by_field_name(node, "name", 4);
+   return 1;
+}
+
+/* Rust: functions and the named type-like items. */
+static int classify_rust(TSNode node, const char **kind, TSNode *name_root)
+{
+   const char *t = ts_node_type(node);
+   if (strcmp(t, "function_item") == 0)
+      *kind = "function";
+   else if (strcmp(t, "struct_item") == 0 || strcmp(t, "enum_item") == 0 ||
+            strcmp(t, "trait_item") == 0 || strcmp(t, "type_item") == 0 ||
+            strcmp(t, "union_item") == 0)
+      *kind = "type";
+   else
+      return 0;
+   *name_root = ts_node_child_by_field_name(node, "name", 4);
+   return 1;
+}
+
+static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name_root)
+{
+   switch (lang)
+   {
+   case TSL_C:
+      return classify_c(node, kind, name_root);
+   case TSL_PY:
+      return classify_py(node, kind, name_root);
+   case TSL_GO:
+      return classify_go(node, kind, name_root);
+   case TSL_JS:
+      return classify_js(node, kind, name_root);
+   case TSL_RUST:
+      return classify_rust(node, kind, name_root);
+   }
+   return 0;
+}
+
 int code_treesitter_definitions(const char *ext, const char *content, definition_t *out, int max)
 {
-   const TSLanguage *lang = ts_language_for_ext(ext);
+   ts_lang_t which;
+   const TSLanguage *lang = ts_language_for_ext(ext, &which);
    if (!lang || !content || !out || max <= 0)
       return -1;
 
@@ -134,7 +282,7 @@ int code_treesitter_definitions(const char *ext, const char *content, definition
       TSNode child = ts_node_named_child(root, i);
       const char *kind = NULL;
       TSNode name_root;
-      if (!classify(child, &kind, &name_root) || ts_node_is_null(name_root))
+      if (!classify(which, child, &kind, &name_root) || ts_node_is_null(name_root))
          continue;
       TSNode id;
       if (!first_identifier(name_root, &id))

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -203,11 +203,19 @@ static int classify_go(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
-/* JavaScript: function (incl. generator) and class declarations. Arrow functions
- * bound to a const/let are not surfaced (no name field) — a follow-up. */
+/* JavaScript: function (incl. generator) and class declarations, including those behind
+ * an `export`/`export default`. Arrow functions bound to a const/let are not surfaced
+ * (no name field) — a follow-up. */
 static int classify_js(TSNode node, const char **kind, TSNode *name_root)
 {
    const char *t = ts_node_type(node);
+   if (strcmp(t, "export_statement") == 0)
+   {
+      TSNode inner = ts_node_child_by_field_name(node, "declaration", 11);
+      if (ts_node_is_null(inner))
+         return 0; /* re-export / `export const x = ...` — no named declaration */
+      return classify_js(inner, kind, name_root);
+   }
    if (strcmp(t, "function_declaration") == 0 || strcmp(t, "generator_function_declaration") == 0)
       *kind = "function";
    else if (strcmp(t, "class_declaration") == 0)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1368,6 +1368,10 @@ $(OBJDIR)/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/
 $(TESTPREFIX)/unit-test-code-treesitter: $(OBJDIR)/tests/test_code_treesitter.o \
                                          $(OBJDIR)/code_treesitter.o \
                                          $(OBJDIR)/vendor/ts_runtime.o $(OBJDIR)/vendor/ts_c.o \
+                                         $(OBJDIR)/vendor/ts_python.o $(OBJDIR)/vendor/ts_python_scan.o \
+                                         $(OBJDIR)/vendor/ts_go.o \
+                                         $(OBJDIR)/vendor/ts_javascript.o $(OBJDIR)/vendor/ts_javascript_scan.o \
+                                         $(OBJDIR)/vendor/ts_rust.o $(OBJDIR)/vendor/ts_rust_scan.o \
                                          $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 endif

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -22,37 +22,83 @@ int main(void)
    /* grammar availability gates the dispatch. */
    assert(code_treesitter_available(".c"));
    assert(code_treesitter_available(".h"));
-   assert(!code_treesitter_available(".py")); /* no python grammar vendored */
+   assert(code_treesitter_available(".py"));
+   assert(code_treesitter_available(".go"));
+   assert(code_treesitter_available(".js"));
+   assert(code_treesitter_available(".jsx"));
+   assert(code_treesitter_available(".rs"));
+   assert(!code_treesitter_available(".ts")); /* typescript grammar not vendored yet */
+   assert(!code_treesitter_available(".txt"));
    assert(!code_treesitter_available(NULL));
 
-   const char *src = "#include <stdio.h>\n"
-                     "typedef struct Point { int x; int y; } Point;\n"
-                     "static int add(int a, int b) { return a + b; }\n"
-                     "void greet(const char *who);\n" /* prototype */
-                     "int main(void) { return add(1, 2); }\n";
    definition_t defs[32];
-   int n = code_treesitter_definitions(".c", src, defs, 32);
-   assert(n >= 4);
 
+   /* --- C --- */
+   const char *c_src = "#include <stdio.h>\n"
+                       "typedef struct Point { int x; int y; } Point;\n"
+                       "static int add(int a, int b) { return a + b; }\n"
+                       "void greet(const char *who);\n" /* prototype */
+                       "int main(void) { return add(1, 2); }\n";
+   int n = code_treesitter_definitions(".c", c_src, defs, 32);
+   assert(n >= 4);
    assert(has(defs, n, "add", "function"));   /* function_definition */
    assert(has(defs, n, "main", "function"));  /* function_definition */
    assert(has(defs, n, "greet", "function")); /* prototype declaration */
    assert(has(defs, n, "Point", "type"));     /* typedef */
-
-   /* line numbers are 1-based and plausible. */
    for (int i = 0; i < n; i++)
    {
       assert(defs[i].line >= 1);
       assert(defs[i].line_end >= defs[i].line);
    }
+   /* bounded output: max=1 yields exactly one. */
+   assert(code_treesitter_definitions(".c", c_src, defs, 1) == 1);
+
+   /* --- Python (incl. a decorated def) --- */
+   const char *py_src = "import os\n"
+                        "def add(a, b):\n    return a + b\n"
+                        "class Point:\n    def m(self):\n        pass\n"
+                        "@deco\ndef wrapped():\n    pass\n";
+   n = code_treesitter_definitions(".py", py_src, defs, 32);
+   assert(has(defs, n, "add", "function"));     /* function_definition */
+   assert(has(defs, n, "Point", "type"));       /* class_definition */
+   assert(has(defs, n, "wrapped", "function")); /* decorated_definition unwrapped */
+
+   /* --- Go (func, method, named type) --- */
+   const char *go_src = "package main\n"
+                        "func Add(a, b int) int { return a + b }\n"
+                        "func (p *Point) M() {}\n"
+                        "type Point struct { X int }\n";
+   n = code_treesitter_definitions(".go", go_src, defs, 32);
+   assert(has(defs, n, "Add", "function")); /* function_declaration */
+   assert(has(defs, n, "M", "function"));   /* method_declaration */
+   assert(has(defs, n, "Point", "type"));   /* type_declaration -> type_spec */
+
+   /* --- JavaScript (function, generator, class) --- */
+   const char *js_src = "import x from 'y'\n"
+                        "function add(a, b) { return a + b }\n"
+                        "class Point { m() {} }\n"
+                        "function* gen() {}\n";
+   n = code_treesitter_definitions(".js", js_src, defs, 32);
+   assert(has(defs, n, "add", "function")); /* function_declaration */
+   assert(has(defs, n, "Point", "type"));   /* class_declaration */
+   assert(has(defs, n, "gen", "function")); /* generator_function_declaration */
+
+   /* --- Rust (fn, struct, enum, trait) --- */
+   const char *rs_src = "use std::io;\n"
+                        "fn add(a: i32, b: i32) -> i32 { a + b }\n"
+                        "struct Point { x: i32 }\n"
+                        "enum E { A, B }\n"
+                        "trait T {}\n";
+   n = code_treesitter_definitions(".rs", rs_src, defs, 32);
+   assert(has(defs, n, "add", "function")); /* function_item */
+   assert(has(defs, n, "Point", "type"));   /* struct_item */
+   assert(has(defs, n, "E", "type"));       /* enum_item */
+   assert(has(defs, n, "T", "type"));       /* trait_item */
 
    /* an ext with no grammar -> -1 (caller falls back to the hand-rolled extractor). */
-   assert(code_treesitter_definitions(".py", src, defs, 32) == -1);
+   assert(code_treesitter_definitions(".ts", c_src, defs, 32) == -1);
 
-   /* bounded output: max=1 yields exactly one. */
-   assert(code_treesitter_definitions(".c", src, defs, 1) == 1);
-
-   printf("  extracted %d defs (add/main/greet/Point)\n", n);
+   printf("  C/Python/Go/JavaScript/Rust definitions extracted\n");
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -77,11 +77,15 @@ int main(void)
    const char *js_src = "import x from 'y'\n"
                         "function add(a, b) { return a + b }\n"
                         "class Point { m() {} }\n"
-                        "function* gen() {}\n";
+                        "function* gen() {}\n"
+                        "export function pub() {}\n" /* export_statement unwrap */
+                        "export class Wid {}\n";     /* export_statement unwrap */
    n = code_treesitter_definitions(".js", js_src, defs, 32);
    assert(has(defs, n, "add", "function")); /* function_declaration */
    assert(has(defs, n, "Point", "type"));   /* class_declaration */
    assert(has(defs, n, "gen", "function")); /* generator_function_declaration */
+   assert(has(defs, n, "pub", "function")); /* export function */
+   assert(has(defs, n, "Wid", "type"));     /* export class */
 
    /* --- Rust (fn, struct, enum, trait) --- */
    const char *rs_src = "use std::io;\n"


### PR DESCRIPTION
Expands the opt-in §2 tree-sitter extraction front-end (PR #771) from C to **five** languages: **C, Python, Go, JavaScript, Rust**.

## What
- `code_treesitter.c` now dispatches `classify` per language. `classify_c` is unchanged; `classify_py/go/js/rust` each map that grammar's definition node types → `function`/`type`. The language is resolved from the file extension via a small table (`.py .go .js/.mjs/.cjs/.jsx .rs`).
- Node types were derived **empirically** by probing each grammar (decorated_definition unwrap for Python; method_declaration + type_spec for Go; generator functions for JS; struct/enum/trait/type items for Rust).
- `fetch-treesitter.sh` pins the four grammar commits; the Makefile compiles each `parser.c` plus a `scanner.c` where the grammar ships an external scanner (Python/JS/Rust; C and Go have none) and links them into `aimee-kb` under `AIMEE_TREESITTER`.

## Safety / scope
- **Default build unchanged** — `code_treesitter.c` is still a stub without `AIMEE_TREESITTER`; default `aimee-kb` verified byte-identical (1295896 B). The opt-in KB links all five grammars cleanly (4.2MB, no symbol conflicts).
- `unit-test-code-treesitter` parses real source in all five languages and asserts the extracted defs (validated locally — the opt-in test isn't in default CI).
- Top-level definitions only; nested class/impl members and call-edge extraction remain follow-ups (noted in proposal §2).

Grammars are fetched at build time and **gitignored** (not committed). NOTICE + .gitignore reconciled.