### PR TITLE
feat(kb): §2 tree-sitter — full supported-language parity (16 languages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,19 @@ agent-keys.json
 # compiles against them only in the opt-in AIMEE_TREESITTER build.
 src/vendor/tree-sitter/
 src/vendor/tree-sitter-c/
+src/vendor/tree-sitter-cpp/
+src/vendor/tree-sitter-c-sharp/
 src/vendor/tree-sitter-python/
 src/vendor/tree-sitter-go/
 src/vendor/tree-sitter-javascript/
+src/vendor/tree-sitter-typescript/
 src/vendor/tree-sitter-rust/
+src/vendor/tree-sitter-java/
+src/vendor/tree-sitter-ruby/
+src/vendor/tree-sitter-php/
+src/vendor/tree-sitter-lua/
+src/vendor/tree-sitter-bash/
+src/vendor/tree-sitter-swift/
+src/vendor/tree-sitter-kotlin/
+src/vendor/tree-sitter-dart/
+src/vendor/tree-sitter-css/

--- a/NOTICE
+++ b/NOTICE
@@ -43,11 +43,13 @@ aimee and is not covered by the AGPL-3.0 grant above:
     headers.
 
   - The §2 tree-sitter extraction front-end (built only with AIMEE_TREESITTER)
-    links tree-sitter and its grammars, fetched at build time by
-    scripts/fetch-treesitter.sh into src/vendor/tree-sitter{,-c,-python,-go,
-    -javascript,-rust}/ (NOT committed; see .gitignore). tree-sitter
-    (https://github.com/tree-sitter/tree-sitter) and its grammars tree-sitter-c,
-    tree-sitter-python, tree-sitter-go, tree-sitter-javascript and tree-sitter-rust
-    (https://github.com/tree-sitter/tree-sitter-<lang>) are Copyright (c)
-    Max Brunsfeld and contributors, licensed under the MIT License (each clone
-    carries its LICENSE file).
+    links tree-sitter and a set of language grammars, fetched at build time by
+    scripts/fetch-treesitter.sh into src/vendor/tree-sitter*/ (NOT committed; see
+    .gitignore). tree-sitter (https://github.com/tree-sitter/tree-sitter) and the
+    grammars under github.com/tree-sitter (c, cpp, c-sharp, python, go, javascript,
+    typescript, rust, java, ruby, php, bash, css) are Copyright (c) Max Brunsfeld and
+    contributors, MIT-licensed. The community-maintained grammars are likewise
+    MIT-licensed: tree-sitter-lua (github.com/tree-sitter-grammars/tree-sitter-lua),
+    tree-sitter-kotlin (github.com/fwcd/tree-sitter-kotlin), tree-sitter-swift
+    (github.com/alex-pinkus/tree-sitter-swift) and tree-sitter-dart
+    (github.com/UserNobody14/tree-sitter-dart). Each clone carries its LICENSE file.

--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -6,7 +6,7 @@
   relevance gate + precision self-suppress, the §8 `/v1/code/graph` backend route + the
   webchat Graph view, the §6 live updates (memory-fusion leg + default-branch
   change-detection gate + post-merge reindex hook), and the **§2 tree-sitter front-end**
-  with **C, Python, Go, JavaScript and Rust** grammars (opt-in `AIMEE_TREESITTER`
+  with grammars for **all 16 supported languages** (opt-in `AIMEE_TREESITTER`
   build, fall-through to the hand-rolled extractors). Only **optional follow-ups**
   remain — more §2 grammars + nested-member/parse-tree call edges, and an always-on §6
   fanotify watch. See the "Implementation status" section.
@@ -120,19 +120,22 @@ the *same* `code_calls` / `code_projection_edges` / symbol tables. Target ≥30
 languages. Keep the existing extractor path as fallback for unsupported grammars.
 This is the one true coverage gap and the largest engineering item.
 
-**Status — front-end + 5 grammars shipped (opt-in).** `code_treesitter.c` parses a
-file with the tree-sitter grammar for its extension and emits the same `definition_t`
-symbols (functions and types) the hand-rolled extractor does; `extract_definitions`
-prefers it where a grammar is compiled in and **falls back** otherwise — so the
-**default build is unchanged**. The runtime + grammars are large generated parsers, so
-they are **fetched at build time** (`scripts/fetch-treesitter.sh`, pinned commits,
-gitignored) and compiled only in the opt-in `AIMEE_TREESITTER` build (external scanners
-linked where a grammar needs one); `code_treesitter.c` is a stub without it. Ships
-**C, Python, Go, JavaScript and Rust** grammars, each with a per-language `classify_*`
-mapping its definition node types to `function`/`type` (`unit-test-code-treesitter`
-parses real source in all five and asserts the extracted defs). Adding a grammar is
-mechanical — vendor its `parser.c`(+`scanner.c`), register its `TSLanguage` + extensions
-in `ts_language_for_ext`, and add a `classify_*`. Remaining increments: recursive
+**Status — front-end + full supported-language set shipped (opt-in).**
+`code_treesitter.c` parses a file with the tree-sitter grammar for its extension and
+emits the same `definition_t` symbols (functions and types) the hand-rolled extractor
+does; `extract_definitions` prefers it where a grammar is compiled in and **falls back**
+otherwise — so the **default build is unchanged**. The runtime + grammars are large
+generated parsers, so they are **fetched at build time** (`scripts/fetch-treesitter.sh`,
+pinned commits, gitignored) and compiled only in the opt-in `AIMEE_TREESITTER` build
+(external scanners linked where a grammar needs one); `code_treesitter.c` is a stub
+without it. Ships grammars for **all 16 hand-rolled supported languages** — C, C++, C#,
+Python, Go, JavaScript, TypeScript, Rust, Java, Ruby, PHP, Lua, Bash, Swift, Kotlin,
+Dart, CSS — each with a per-language `classify_*` mapping its definition node types to
+`function`/`type`; organizational wrappers (namespaces) are descended through so types
+nested under them (C#/C++) are surfaced. `unit-test-code-treesitter` parses real source
+in every language and asserts the extracted defs. Adding a grammar is mechanical — vendor
+its `parser.c`(+`scanner.c`), register its `TSLanguage` + extensions in
+`ts_language_for_ext`, and add a `classify_*`. Remaining increments: recursive
 descent for nested members (class/impl methods), more languages, and call-edge
 extraction (`code_calls`) over the parse tree.
 

--- a/scripts/fetch-treesitter.sh
+++ b/scripts/fetch-treesitter.sh
@@ -26,12 +26,26 @@ fetch() {
 
 # Runtime (one amalgamated compilation unit via lib/src/lib.c).
 fetch tree-sitter   https://github.com/tree-sitter/tree-sitter   cbee4672665173d1702d836353ef7648dc2b2fac
-# Grammars (one parser.c each, plus a src/scanner.c for those with an external scanner —
-# Python/JavaScript/Rust have one; C and Go do not). C first — aimee dogfoods its own source.
+# Grammars — one parser.c each (TypeScript and PHP ship two: a base + a JSX/embedded
+# variant), plus a src/scanner.c for those with an external scanner. The set mirrors the
+# hand-rolled supported languages (src/extractors.c). C first — aimee dogfoods its source.
 fetch tree-sitter-c          https://github.com/tree-sitter/tree-sitter-c          b780e47fc780ddc8da13afa35a3f4ed5c157823d
+fetch tree-sitter-cpp        https://github.com/tree-sitter/tree-sitter-cpp        8b5b49eb196bec7040441bee33b2c9a4838d6967
+fetch tree-sitter-c-sharp    https://github.com/tree-sitter/tree-sitter-c-sharp    af29416d729b7a6603101b513604392d8f675e3b
 fetch tree-sitter-python     https://github.com/tree-sitter/tree-sitter-python     26855eabccb19c6abf499fbc5b8dc7cc9ab8bc64
 fetch tree-sitter-go         https://github.com/tree-sitter/tree-sitter-go         2346a3ab1bb3857b48b29d779a1ef9799a248cd7
 fetch tree-sitter-javascript https://github.com/tree-sitter/tree-sitter-javascript 58404d8cf191d69f2674a8fd507bd5776f46cb11
+fetch tree-sitter-typescript https://github.com/tree-sitter/tree-sitter-typescript 75b3874edb2dc714fb1fd77a32013d0f8699989f
 fetch tree-sitter-rust       https://github.com/tree-sitter/tree-sitter-rust       77a3747266f4d621d0757825e6b11edcbf991ca5
+fetch tree-sitter-java       https://github.com/tree-sitter/tree-sitter-java       e10607b45ff745f5f876bfa3e94fbcc6b44bdc11
+fetch tree-sitter-ruby       https://github.com/tree-sitter/tree-sitter-ruby       ad907a69da0c8a4f7a943a7fe012712208da6dee
+fetch tree-sitter-php        https://github.com/tree-sitter/tree-sitter-php        38216983c07bf9e1b56e16acde53b25adaeab61c
+fetch tree-sitter-lua        https://github.com/tree-sitter-grammars/tree-sitter-lua 10fe0054734eec83049514ea2e718b2a56acd0c9
+fetch tree-sitter-bash       https://github.com/tree-sitter/tree-sitter-bash       a06c2e4415e9bc0346c6b86d401879ffb44058f7
+# Swift's generated parser.c is not on the default branch; use the *-with-generated-files tag.
+fetch tree-sitter-swift      https://github.com/alex-pinkus/tree-sitter-swift      caa99d7d3c14aac03b5f16fc86fedf8755570760
+fetch tree-sitter-kotlin     https://github.com/fwcd/tree-sitter-kotlin           c8ac3d2627240160b999a2c100de3babbdb8f419
+fetch tree-sitter-dart       https://github.com/UserNobody14/tree-sitter-dart      a9bdfa3db2fbc9b9f12c93450d04a671f33a5102
+fetch tree-sitter-css        https://github.com/tree-sitter/tree-sitter-css        dda5cfc5722c429eaba1c910ca32c2c0c5bb1a3f
 
-echo "fetch-treesitter: done -> $VENDOR/tree-sitter{,-c,-python,-go,-javascript,-rust}"
+echo "fetch-treesitter: done -> $VENDOR/tree-sitter*"

--- a/src/Makefile
+++ b/src/Makefile
@@ -423,51 +423,95 @@ KB_PLATFORM_OBJS = $(PLATFORM_BASIC_OBJS) $(filter %/agent_bridge.o %/cli_client
 # compiled (with -w, since vendored generated code does not pass -Werror), and the KB's
 # code_treesitter.o is built with -DAIMEE_TREESITTER.
 ifdef AIMEE_TREESITTER
-# Runtime + one object per grammar parser.c, plus a scanner object for grammars with an
-# external scanner (Python/JavaScript/Rust; C and Go have none). Add a language by
-# vendoring it (fetch-treesitter.sh), appending its objs here + a compile rule below, and
-# registering it in code_treesitter.c.
+# Runtime + one object per grammar parser.c, plus a scanner object for grammars that ship
+# an external scanner. The language set mirrors the hand-rolled extractors (extractors.c).
+# Add a language by vendoring it (fetch-treesitter.sh), registering it in code_treesitter.c,
+# adding its object(s) to TS_VENDOR_OBJS + its source(s) to the fetch prerequisite list, and
+# a $(call ts_obj,...) below. ts_obj compiles one vendored source with -w (vendored generated
+# code does not pass -Werror) and the grammar's own src dir on the include path.
 TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_c.o \
+                 $(OBJDIR)/vendor/ts_cpp.o $(OBJDIR)/vendor/ts_cpp_scan.o \
+                 $(OBJDIR)/vendor/ts_csharp.o $(OBJDIR)/vendor/ts_csharp_scan.o \
                  $(OBJDIR)/vendor/ts_python.o $(OBJDIR)/vendor/ts_python_scan.o \
                  $(OBJDIR)/vendor/ts_go.o \
                  $(OBJDIR)/vendor/ts_javascript.o $(OBJDIR)/vendor/ts_javascript_scan.o \
-                 $(OBJDIR)/vendor/ts_rust.o $(OBJDIR)/vendor/ts_rust_scan.o
+                 $(OBJDIR)/vendor/ts_typescript.o $(OBJDIR)/vendor/ts_typescript_scan.o \
+                 $(OBJDIR)/vendor/ts_tsx.o $(OBJDIR)/vendor/ts_tsx_scan.o \
+                 $(OBJDIR)/vendor/ts_rust.o $(OBJDIR)/vendor/ts_rust_scan.o \
+                 $(OBJDIR)/vendor/ts_java.o \
+                 $(OBJDIR)/vendor/ts_ruby.o $(OBJDIR)/vendor/ts_ruby_scan.o \
+                 $(OBJDIR)/vendor/ts_php.o $(OBJDIR)/vendor/ts_php_scan.o \
+                 $(OBJDIR)/vendor/ts_lua.o $(OBJDIR)/vendor/ts_lua_scan.o \
+                 $(OBJDIR)/vendor/ts_bash.o $(OBJDIR)/vendor/ts_bash_scan.o \
+                 $(OBJDIR)/vendor/ts_swift.o $(OBJDIR)/vendor/ts_swift_scan.o \
+                 $(OBJDIR)/vendor/ts_kotlin.o $(OBJDIR)/vendor/ts_kotlin_scan.o \
+                 $(OBJDIR)/vendor/ts_dart.o $(OBJDIR)/vendor/ts_dart_scan.o \
+                 $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
+# Any missing vendored source triggers a single fetch of the whole set.
 vendor/tree-sitter/lib/src/lib.c \
 vendor/tree-sitter-c/src/parser.c \
+vendor/tree-sitter-cpp/src/parser.c vendor/tree-sitter-cpp/src/scanner.c \
+vendor/tree-sitter-c-sharp/src/parser.c vendor/tree-sitter-c-sharp/src/scanner.c \
 vendor/tree-sitter-python/src/parser.c vendor/tree-sitter-python/src/scanner.c \
 vendor/tree-sitter-go/src/parser.c \
 vendor/tree-sitter-javascript/src/parser.c vendor/tree-sitter-javascript/src/scanner.c \
-vendor/tree-sitter-rust/src/parser.c vendor/tree-sitter-rust/src/scanner.c:
-	./scripts/fetch-treesitter.sh
+vendor/tree-sitter-typescript/typescript/src/parser.c vendor/tree-sitter-typescript/typescript/src/scanner.c \
+vendor/tree-sitter-typescript/tsx/src/parser.c vendor/tree-sitter-typescript/tsx/src/scanner.c \
+vendor/tree-sitter-rust/src/parser.c vendor/tree-sitter-rust/src/scanner.c \
+vendor/tree-sitter-java/src/parser.c \
+vendor/tree-sitter-ruby/src/parser.c vendor/tree-sitter-ruby/src/scanner.c \
+vendor/tree-sitter-php/php/src/parser.c vendor/tree-sitter-php/php/src/scanner.c \
+vendor/tree-sitter-lua/src/parser.c vendor/tree-sitter-lua/src/scanner.c \
+vendor/tree-sitter-bash/src/parser.c vendor/tree-sitter-bash/src/scanner.c \
+vendor/tree-sitter-swift/src/parser.c vendor/tree-sitter-swift/src/scanner.c \
+vendor/tree-sitter-kotlin/src/parser.c vendor/tree-sitter-kotlin/src/scanner.c \
+vendor/tree-sitter-dart/src/parser.c vendor/tree-sitter-dart/src/scanner.c \
+vendor/tree-sitter-css/src/parser.c vendor/tree-sitter-css/src/scanner.c:
+	../scripts/fetch-treesitter.sh
 $(OBJDIR)/vendor/ts_runtime.o: vendor/tree-sitter/lib/src/lib.c
 	@mkdir -p $(OBJDIR)/vendor
 	$(CC) -c -Os -w -Ivendor/tree-sitter/lib/src -Ivendor/tree-sitter/lib/include -o $@ $<
-$(OBJDIR)/vendor/ts_c.o: vendor/tree-sitter-c/src/parser.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-c/src -o $@ $<
-$(OBJDIR)/vendor/ts_python.o: vendor/tree-sitter-python/src/parser.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-python/src -o $@ $<
-$(OBJDIR)/vendor/ts_python_scan.o: vendor/tree-sitter-python/src/scanner.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-python/src -o $@ $<
-$(OBJDIR)/vendor/ts_go.o: vendor/tree-sitter-go/src/parser.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-go/src -o $@ $<
-$(OBJDIR)/vendor/ts_javascript.o: vendor/tree-sitter-javascript/src/parser.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-javascript/src -o $@ $<
-$(OBJDIR)/vendor/ts_javascript_scan.o: vendor/tree-sitter-javascript/src/scanner.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-javascript/src -o $@ $<
-$(OBJDIR)/vendor/ts_rust.o: vendor/tree-sitter-rust/src/parser.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-rust/src -o $@ $<
-$(OBJDIR)/vendor/ts_rust_scan.o: vendor/tree-sitter-rust/src/scanner.c
-	@mkdir -p $(OBJDIR)/vendor
-	$(CC) -c -Os -w -Ivendor/tree-sitter-rust/src -o $@ $<
+# $(call ts_obj,<obj-suffix>,<grammar-src-dir>,<source-file>)
+define ts_obj
+$$(OBJDIR)/vendor/ts_$(1).o: vendor/$(2)/$(3)
+	@mkdir -p $$(OBJDIR)/vendor
+	$$(CC) -c -Os -w -Ivendor/$(2) -o $$@ $$<
+endef
+$(eval $(call ts_obj,c,tree-sitter-c/src,parser.c))
+$(eval $(call ts_obj,cpp,tree-sitter-cpp/src,parser.c))
+$(eval $(call ts_obj,cpp_scan,tree-sitter-cpp/src,scanner.c))
+$(eval $(call ts_obj,csharp,tree-sitter-c-sharp/src,parser.c))
+$(eval $(call ts_obj,csharp_scan,tree-sitter-c-sharp/src,scanner.c))
+$(eval $(call ts_obj,python,tree-sitter-python/src,parser.c))
+$(eval $(call ts_obj,python_scan,tree-sitter-python/src,scanner.c))
+$(eval $(call ts_obj,go,tree-sitter-go/src,parser.c))
+$(eval $(call ts_obj,javascript,tree-sitter-javascript/src,parser.c))
+$(eval $(call ts_obj,javascript_scan,tree-sitter-javascript/src,scanner.c))
+$(eval $(call ts_obj,typescript,tree-sitter-typescript/typescript/src,parser.c))
+$(eval $(call ts_obj,typescript_scan,tree-sitter-typescript/typescript/src,scanner.c))
+$(eval $(call ts_obj,tsx,tree-sitter-typescript/tsx/src,parser.c))
+$(eval $(call ts_obj,tsx_scan,tree-sitter-typescript/tsx/src,scanner.c))
+$(eval $(call ts_obj,rust,tree-sitter-rust/src,parser.c))
+$(eval $(call ts_obj,rust_scan,tree-sitter-rust/src,scanner.c))
+$(eval $(call ts_obj,java,tree-sitter-java/src,parser.c))
+$(eval $(call ts_obj,ruby,tree-sitter-ruby/src,parser.c))
+$(eval $(call ts_obj,ruby_scan,tree-sitter-ruby/src,scanner.c))
+$(eval $(call ts_obj,php,tree-sitter-php/php/src,parser.c))
+$(eval $(call ts_obj,php_scan,tree-sitter-php/php/src,scanner.c))
+$(eval $(call ts_obj,lua,tree-sitter-lua/src,parser.c))
+$(eval $(call ts_obj,lua_scan,tree-sitter-lua/src,scanner.c))
+$(eval $(call ts_obj,bash,tree-sitter-bash/src,parser.c))
+$(eval $(call ts_obj,bash_scan,tree-sitter-bash/src,scanner.c))
+$(eval $(call ts_obj,swift,tree-sitter-swift/src,parser.c))
+$(eval $(call ts_obj,swift_scan,tree-sitter-swift/src,scanner.c))
+$(eval $(call ts_obj,kotlin,tree-sitter-kotlin/src,parser.c))
+$(eval $(call ts_obj,kotlin_scan,tree-sitter-kotlin/src,scanner.c))
+$(eval $(call ts_obj,dart,tree-sitter-dart/src,parser.c))
+$(eval $(call ts_obj,dart_scan,tree-sitter-dart/src,scanner.c))
+$(eval $(call ts_obj,css,tree-sitter-css/src,parser.c))
+$(eval $(call ts_obj,css_scan,tree-sitter-css/src,scanner.c))
 endif
 
 # --- Gateway ---

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -130,15 +130,19 @@ static void node_text(TSNode node, const char *src, char *out, int cap)
    out[n] = '\0';
 }
 
-/* Pre-order DFS for the first descendant whose type is one of the identifier kinds —
- * used to dig a name out of a subtree (e.g. the function name under a declarator, or a
- * Kotlin definition that exposes no `name` field). */
+static int is_identifier_type(const char *t)
+{
+   return strcmp(t, "identifier") == 0 || strcmp(t, "type_identifier") == 0 ||
+          strcmp(t, "field_identifier") == 0 || strcmp(t, "simple_identifier") == 0 ||
+          strcmp(t, "constant") == 0 || strcmp(t, "name") == 0;
+}
+
+/* Pre-order DFS for the first descendant whose type is one of the identifier kinds — used
+ * to dig a name out of a C/C++ declarator (where the name nests under pointer/array/
+ * function declarators). Recurses, so it must only be given the declarator subtree. */
 static int first_identifier(TSNode node, TSNode *out)
 {
-   const char *t = ts_node_type(node);
-   if (strcmp(t, "identifier") == 0 || strcmp(t, "type_identifier") == 0 ||
-       strcmp(t, "field_identifier") == 0 || strcmp(t, "simple_identifier") == 0 ||
-       strcmp(t, "constant") == 0 || strcmp(t, "name") == 0)
+   if (is_identifier_type(ts_node_type(node)))
    {
       *out = node;
       return 1;
@@ -150,15 +154,33 @@ static int first_identifier(TSNode node, TSNode *out)
    return 0;
 }
 
-/* The name node for a definition: its `name` field if it has one, else the first
- * identifier-like descendant. Returns a possibly-null node (caller re-checks). */
+/* The first DIRECT identifier-like child. The name of a definition is always a direct
+ * child (the deeper recursion of first_identifier would wrongly pick up identifiers
+ * inside a preceding modifier/annotation, type-parameter list, or extension receiver). */
+static int direct_identifier(TSNode node, TSNode *out)
+{
+   uint32_t n = ts_node_named_child_count(node);
+   for (uint32_t i = 0; i < n; i++)
+   {
+      TSNode c = ts_node_named_child(node, i);
+      if (is_identifier_type(ts_node_type(c)))
+      {
+         *out = c;
+         return 1;
+      }
+   }
+   return 0;
+}
+
+/* The name node for a definition: its `name` field if it has one, else the first direct
+ * identifier-like child. Returns a possibly-null node (caller re-checks). */
 static TSNode name_node(TSNode node)
 {
    TSNode nm = ts_node_child_by_field_name(node, "name", 4);
    if (!ts_node_is_null(nm))
       return nm;
    TSNode id;
-   if (first_identifier(node, &id))
+   if (direct_identifier(node, &id))
       return id;
    return nm; /* null */
 }

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -2,7 +2,13 @@
  *
  * Real implementation under -DAIMEE_TREESITTER (links the fetched tree-sitter runtime +
  * grammars); otherwise a stub that reports "unavailable" so callers fall back to the
- * hand-rolled extractors and the default build needs no tree-sitter at all. */
+ * hand-rolled extractors and the default build needs no tree-sitter at all.
+ *
+ * Languages mirror the hand-rolled supported set (extractors.c): C, C++, C#, Python, Go,
+ * JavaScript, TypeScript, Rust, Java, Ruby, PHP, Lua, Bash, Swift, Kotlin, Dart, CSS. Add
+ * one by vendoring its grammar (scripts/fetch-treesitter.sh + src/Makefile), declaring its
+ * entry point, mapping its extension(s) in ts_language_for_ext, adding a ts_lang_t, and a
+ * classify_<lang> for its definition node types. */
 
 #include "headers/code_treesitter.h"
 
@@ -13,23 +19,45 @@
 #include "tree_sitter/api.h"
 #include <stdio.h>
 
-/* Grammar entry points (defined in the vendored parser.c files). Add a language by
- * vendoring its grammar (scripts/fetch-treesitter.sh + src/Makefile), declaring its
- * entry point here, mapping its extension(s) in ts_language_for_ext, and adding a
- * classify_<lang> for that grammar's definition node types (see classify below). */
+/* Grammar entry points (defined in the vendored parser.c files). */
 const TSLanguage *tree_sitter_c(void);
+const TSLanguage *tree_sitter_cpp(void);
+const TSLanguage *tree_sitter_c_sharp(void);
 const TSLanguage *tree_sitter_python(void);
 const TSLanguage *tree_sitter_go(void);
 const TSLanguage *tree_sitter_javascript(void);
+const TSLanguage *tree_sitter_typescript(void);
+const TSLanguage *tree_sitter_tsx(void);
 const TSLanguage *tree_sitter_rust(void);
+const TSLanguage *tree_sitter_java(void);
+const TSLanguage *tree_sitter_ruby(void);
+const TSLanguage *tree_sitter_php(void);
+const TSLanguage *tree_sitter_lua(void);
+const TSLanguage *tree_sitter_bash(void);
+const TSLanguage *tree_sitter_swift(void);
+const TSLanguage *tree_sitter_kotlin(void);
+const TSLanguage *tree_sitter_dart(void);
+const TSLanguage *tree_sitter_css(void);
 
 typedef enum
 {
    TSL_C,
+   TSL_CPP,
+   TSL_CSHARP,
    TSL_PY,
    TSL_GO,
    TSL_JS,
-   TSL_RUST
+   TSL_TS,
+   TSL_RUST,
+   TSL_JAVA,
+   TSL_RUBY,
+   TSL_PHP,
+   TSL_LUA,
+   TSL_BASH,
+   TSL_SWIFT,
+   TSL_KOTLIN,
+   TSL_DART,
+   TSL_CSS
 } ts_lang_t;
 
 static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
@@ -44,13 +72,35 @@ static const TSLanguage *ts_language_for_ext(const char *ext, ts_lang_t *which)
    } map[] = {
        {".c", TSL_C, tree_sitter_c},
        {".h", TSL_C, tree_sitter_c},
+       {".cpp", TSL_CPP, tree_sitter_cpp},
+       {".cc", TSL_CPP, tree_sitter_cpp},
+       {".cxx", TSL_CPP, tree_sitter_cpp},
+       {".hpp", TSL_CPP, tree_sitter_cpp},
+       {".hh", TSL_CPP, tree_sitter_cpp},
+       {".cs", TSL_CSHARP, tree_sitter_c_sharp},
        {".py", TSL_PY, tree_sitter_python},
        {".go", TSL_GO, tree_sitter_go},
        {".js", TSL_JS, tree_sitter_javascript},
        {".mjs", TSL_JS, tree_sitter_javascript},
        {".cjs", TSL_JS, tree_sitter_javascript},
        {".jsx", TSL_JS, tree_sitter_javascript},
+       {".ts", TSL_TS, tree_sitter_typescript},
+       {".mts", TSL_TS, tree_sitter_typescript},
+       {".cts", TSL_TS, tree_sitter_typescript},
+       {".tsx", TSL_TS, tree_sitter_tsx},
        {".rs", TSL_RUST, tree_sitter_rust},
+       {".java", TSL_JAVA, tree_sitter_java},
+       {".rb", TSL_RUBY, tree_sitter_ruby},
+       {".php", TSL_PHP, tree_sitter_php},
+       {".lua", TSL_LUA, tree_sitter_lua},
+       {".sh", TSL_BASH, tree_sitter_bash},
+       {".bash", TSL_BASH, tree_sitter_bash},
+       {".zsh", TSL_BASH, tree_sitter_bash},
+       {".swift", TSL_SWIFT, tree_sitter_swift},
+       {".kt", TSL_KOTLIN, tree_sitter_kotlin},
+       {".kts", TSL_KOTLIN, tree_sitter_kotlin},
+       {".dart", TSL_DART, tree_sitter_dart},
+       {".css", TSL_CSS, tree_sitter_css},
    };
    for (size_t i = 0; i < sizeof(map) / sizeof(map[0]); i++)
       if (strcmp(ext, map[i].ext) == 0)
@@ -81,12 +131,14 @@ static void node_text(TSNode node, const char *src, char *out, int cap)
 }
 
 /* Pre-order DFS for the first descendant whose type is one of the identifier kinds —
- * the definition's name (e.g. the function name under a function_declarator). */
+ * used to dig a name out of a subtree (e.g. the function name under a declarator, or a
+ * Kotlin definition that exposes no `name` field). */
 static int first_identifier(TSNode node, TSNode *out)
 {
    const char *t = ts_node_type(node);
    if (strcmp(t, "identifier") == 0 || strcmp(t, "type_identifier") == 0 ||
-       strcmp(t, "field_identifier") == 0)
+       strcmp(t, "field_identifier") == 0 || strcmp(t, "simple_identifier") == 0 ||
+       strcmp(t, "constant") == 0 || strcmp(t, "name") == 0)
    {
       *out = node;
       return 1;
@@ -98,41 +150,86 @@ static int first_identifier(TSNode node, TSNode *out)
    return 0;
 }
 
-/* Each classify_<lang> maps a top-level node to a (kind, name-bearing subtree),
- * returning 0 if it is not a definition we surface. kind is "function" (callables) or
- * "type" (class/struct/enum/trait/typedef). name_root is the subtree whose first
- * identifier is the symbol name (see first_identifier) — it may be a possibly-null
- * field node; the caller re-checks ts_node_is_null. Only the file's TOP-LEVEL named
- * children are walked, so nested members (methods in a class/impl) are not surfaced;
- * recursive descent is a follow-up. */
+/* The name node for a definition: its `name` field if it has one, else the first
+ * identifier-like descendant. Returns a possibly-null node (caller re-checks). */
+static TSNode name_node(TSNode node)
+{
+   TSNode nm = ts_node_child_by_field_name(node, "name", 4);
+   if (!ts_node_is_null(nm))
+      return nm;
+   TSNode id;
+   if (first_identifier(node, &id))
+      return id;
+   return nm; /* null */
+}
 
-/* C: the name survives pointer/array declarator wrapping, so name_root is the whole
- * declarator and first_identifier digs out the bare name. */
+/* Find a direct named child of a given type; returns 1 and sets *out on a match. */
+static int child_of_type(TSNode node, const char *type, TSNode *out)
+{
+   uint32_t n = ts_node_named_child_count(node);
+   for (uint32_t i = 0; i < n; i++)
+   {
+      TSNode c = ts_node_named_child(node, i);
+      if (strcmp(ts_node_type(c), type) == 0)
+      {
+         *out = c;
+         return 1;
+      }
+   }
+   return 0;
+}
+
+/* Map a node type to a kind via two NULL-terminated type lists; sets *kind and returns 1
+ * on a match. Used by the languages whose definition name lives in a `name` field. */
+static int kind_lookup(const char *t, const char *const *fns, const char *const *types,
+                       const char **kind)
+{
+   for (int i = 0; fns[i]; i++)
+      if (strcmp(t, fns[i]) == 0)
+      {
+         *kind = "function";
+         return 1;
+      }
+   for (int i = 0; types[i]; i++)
+      if (strcmp(t, types[i]) == 0)
+      {
+         *kind = "type";
+         return 1;
+      }
+   return 0;
+}
+
+/* C: the function name lives in the declarator (survives pointer/array wrapping), so dig
+ * it out explicitly rather than via name_node (which would grab a named return type). */
 static int classify_c(TSNode node, const char **kind, TSNode *name_root)
 {
    const char *t = ts_node_type(node);
    if (strcmp(t, "function_definition") == 0)
    {
+      TSNode d = ts_node_child_by_field_name(node, "declarator", 10);
+      if (ts_node_is_null(d) || !first_identifier(d, name_root))
+         return 0;
       *kind = "function";
-      *name_root = ts_node_child_by_field_name(node, "declarator", 10);
       return 1;
    }
    if (strcmp(t, "declaration") == 0)
    {
       /* a top-level function prototype: declarator is a function_declarator. */
       TSNode d = ts_node_child_by_field_name(node, "declarator", 10);
-      if (!ts_node_is_null(d) && strstr(ts_node_type(d), "function_declarator"))
+      if (!ts_node_is_null(d) && strstr(ts_node_type(d), "function_declarator") &&
+          first_identifier(d, name_root))
       {
          *kind = "function";
-         *name_root = d;
          return 1;
       }
       return 0;
    }
    if (strcmp(t, "type_definition") == 0)
    {
+      TSNode d = ts_node_child_by_field_name(node, "declarator", 10);
+      if (ts_node_is_null(d) || !first_identifier(d, name_root))
+         return 0;
       *kind = "type"; /* typedef: the new name is the declarator */
-      *name_root = ts_node_child_by_field_name(node, "declarator", 10);
       return 1;
    }
    if (strcmp(t, "struct_specifier") == 0 || strcmp(t, "union_specifier") == 0 ||
@@ -141,6 +238,23 @@ static int classify_c(TSNode node, const char **kind, TSNode *name_root)
       TSNode nm = ts_node_child_by_field_name(node, "name", 4);
       if (ts_node_is_null(nm))
          return 0; /* anonymous */
+      *kind = "type";
+      *name_root = nm;
+      return 1;
+   }
+   return 0;
+}
+
+/* C++: C's rules plus class_specifier; namespaces/templates are containers (see below). */
+static int classify_cpp(TSNode node, const char **kind, TSNode *name_root)
+{
+   if (classify_c(node, kind, name_root))
+      return 1;
+   if (strcmp(ts_node_type(node), "class_specifier") == 0)
+   {
+      TSNode nm = ts_node_child_by_field_name(node, "name", 4);
+      if (ts_node_is_null(nm))
+         return 0;
       *kind = "type";
       *name_root = nm;
       return 1;
@@ -165,19 +279,18 @@ static int classify_py(TSNode node, const char **kind, TSNode *name_root)
       *kind = "type";
    else
       return 0;
-   *name_root = ts_node_child_by_field_name(node, "name", 4);
+   *name_root = name_node(node);
    return 1;
 }
 
-/* Go: func/method declarations and named types (type_spec inside a type_declaration,
- * including the first spec of a grouped `type ( ... )` block). */
+/* Go: func/method declarations and named types (type_spec inside a type_declaration). */
 static int classify_go(TSNode node, const char **kind, TSNode *name_root)
 {
    const char *t = ts_node_type(node);
    if (strcmp(t, "function_declaration") == 0 || strcmp(t, "method_declaration") == 0)
    {
       *kind = "function";
-      *name_root = ts_node_child_by_field_name(node, "name", 4);
+      *name_root = name_node(node);
       return 1;
    }
    if (strcmp(t, "type_declaration") == 0)
@@ -203,10 +316,9 @@ static int classify_go(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
-/* JavaScript: function (incl. generator) and class declarations, including those behind
- * an `export`/`export default`. Arrow functions bound to a const/let are not surfaced
- * (no name field) — a follow-up. */
-static int classify_js(TSNode node, const char **kind, TSNode *name_root)
+/* JavaScript / TypeScript: function (incl. generator) and class/interface/type/enum
+ * declarations, including those behind an `export`/`export default`. */
+static int classify_jsts(TSNode node, const char **kind, TSNode *name_root)
 {
    const char *t = ts_node_type(node);
    if (strcmp(t, "export_statement") == 0)
@@ -214,31 +326,153 @@ static int classify_js(TSNode node, const char **kind, TSNode *name_root)
       TSNode inner = ts_node_child_by_field_name(node, "declaration", 11);
       if (ts_node_is_null(inner))
          return 0; /* re-export / `export const x = ...` — no named declaration */
-      return classify_js(inner, kind, name_root);
+      return classify_jsts(inner, kind, name_root);
    }
-   if (strcmp(t, "function_declaration") == 0 || strcmp(t, "generator_function_declaration") == 0)
-      *kind = "function";
-   else if (strcmp(t, "class_declaration") == 0)
-      *kind = "type";
-   else
+   static const char *const F[] = {"function_declaration", "generator_function_declaration", NULL};
+   static const char *const T[] = {"class_declaration", "interface_declaration",
+                                   "type_alias_declaration", "enum_declaration", NULL};
+   if (!kind_lookup(t, F, T, kind))
       return 0;
-   *name_root = ts_node_child_by_field_name(node, "name", 4);
+   *name_root = name_node(node);
    return 1;
 }
 
 /* Rust: functions and the named type-like items. */
 static int classify_rust(TSNode node, const char **kind, TSNode *name_root)
 {
-   const char *t = ts_node_type(node);
-   if (strcmp(t, "function_item") == 0)
-      *kind = "function";
-   else if (strcmp(t, "struct_item") == 0 || strcmp(t, "enum_item") == 0 ||
-            strcmp(t, "trait_item") == 0 || strcmp(t, "type_item") == 0 ||
-            strcmp(t, "union_item") == 0)
-      *kind = "type";
-   else
+   static const char *const F[] = {"function_item", NULL};
+   static const char *const T[] = {"struct_item", "enum_item",  "trait_item",
+                                   "type_item",   "union_item", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
       return 0;
-   *name_root = ts_node_child_by_field_name(node, "name", 4);
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* C#: types live under namespace_declaration → declaration_list (a container, descended
+ * below), so this fires on the type/method nodes themselves. */
+static int classify_csharp(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"method_declaration", "constructor_declaration",
+                                   "local_function_statement", NULL};
+   static const char *const T[] = {"class_declaration",
+                                   "struct_declaration",
+                                   "interface_declaration",
+                                   "enum_declaration",
+                                   "record_declaration",
+                                   "delegate_declaration",
+                                   NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* Java: top-level types (methods are nested in class bodies — a follow-up). */
+static int classify_java(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"method_declaration", "constructor_declaration", NULL};
+   static const char *const T[] = {
+       "class_declaration",  "interface_declaration",       "enum_declaration",
+       "record_declaration", "annotation_type_declaration", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* Ruby: methods and class/module definitions. */
+static int classify_ruby(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"method", "singleton_method", NULL};
+   static const char *const T[] = {"class", "module", "singleton_class", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* PHP: functions/methods and class-like types. */
+static int classify_php(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"function_definition", "method_declaration", NULL};
+   static const char *const T[] = {"class_declaration", "interface_declaration",
+                                   "trait_declaration", "enum_declaration", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* Lua: function declarations (the name field carries dotted names like `T.m`). */
+static int classify_lua(TSNode node, const char **kind, TSNode *name_root)
+{
+   if (strcmp(ts_node_type(node), "function_declaration") != 0)
+      return 0;
+   TSNode nm = ts_node_child_by_field_name(node, "name", 4);
+   if (ts_node_is_null(nm))
+      return 0;
+   *kind = "function";
+   *name_root = nm;
+   return 1;
+}
+
+/* Bash: function definitions. */
+static int classify_bash(TSNode node, const char **kind, TSNode *name_root)
+{
+   if (strcmp(ts_node_type(node), "function_definition") != 0)
+      return 0;
+   *kind = "function";
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* Swift: functions and class/struct/enum (all class_declaration) + protocols. */
+static int classify_swift(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"function_declaration", "init_declaration", NULL};
+   static const char *const T[] = {"class_declaration", "protocol_declaration", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* Kotlin: definitions expose no `name` field, so name_node digs the simple_identifier /
+ * type_identifier out of the node. */
+static int classify_kotlin(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"function_declaration", NULL};
+   static const char *const T[] = {"class_declaration", "object_declaration", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* Dart: function/method signatures and class-like types. */
+static int classify_dart(TSNode node, const char **kind, TSNode *name_root)
+{
+   static const char *const F[] = {"function_signature", "method_signature", NULL};
+   static const char *const T[] = {"class_definition", "enum_declaration", "mixin_declaration",
+                                   "extension_declaration", NULL};
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
+      return 0;
+   *name_root = name_node(node);
+   return 1;
+}
+
+/* CSS has no functions/types; the one named, referenceable construct is a @keyframes
+ * animation. Surface its name as a "type"; selectors (rule_set) are not symbols. */
+static int classify_css(TSNode node, const char **kind, TSNode *name_root)
+{
+   if (strcmp(ts_node_type(node), "keyframes_statement") != 0)
+      return 0;
+   TSNode nm;
+   if (!child_of_type(node, "keyframes_name", &nm))
+      return 0;
+   *kind = "type";
+   *name_root = nm;
    return 1;
 }
 
@@ -248,16 +482,79 @@ static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name
    {
    case TSL_C:
       return classify_c(node, kind, name_root);
+   case TSL_CPP:
+      return classify_cpp(node, kind, name_root);
+   case TSL_CSHARP:
+      return classify_csharp(node, kind, name_root);
    case TSL_PY:
       return classify_py(node, kind, name_root);
    case TSL_GO:
       return classify_go(node, kind, name_root);
    case TSL_JS:
-      return classify_js(node, kind, name_root);
+   case TSL_TS:
+      return classify_jsts(node, kind, name_root);
    case TSL_RUST:
       return classify_rust(node, kind, name_root);
+   case TSL_JAVA:
+      return classify_java(node, kind, name_root);
+   case TSL_RUBY:
+      return classify_ruby(node, kind, name_root);
+   case TSL_PHP:
+      return classify_php(node, kind, name_root);
+   case TSL_LUA:
+      return classify_lua(node, kind, name_root);
+   case TSL_BASH:
+      return classify_bash(node, kind, name_root);
+   case TSL_SWIFT:
+      return classify_swift(node, kind, name_root);
+   case TSL_KOTLIN:
+      return classify_kotlin(node, kind, name_root);
+   case TSL_DART:
+      return classify_dart(node, kind, name_root);
+   case TSL_CSS:
+      return classify_css(node, kind, name_root);
    }
    return 0;
+}
+
+/* Organizational wrappers we descend THROUGH to reach the definitions inside (namespaces,
+ * their declaration lists, C++ templates/extern blocks). We do NOT descend function or
+ * class bodies, so nested members (methods) are not surfaced — a follow-up. */
+static int is_container(const char *t)
+{
+   return strcmp(t, "namespace_declaration") == 0 ||
+          strcmp(t, "file_scoped_namespace_declaration") == 0 ||
+          strcmp(t, "namespace_definition") == 0 || strcmp(t, "declaration_list") == 0 ||
+          strcmp(t, "template_declaration") == 0 || strcmp(t, "linkage_specification") == 0;
+}
+
+/* Emit `node` if it is a definition, then descend into it if it is a container. */
+static void visit(ts_lang_t lang, TSNode node, const char *content, definition_t *out, int max,
+                  int *count)
+{
+   if (*count >= max)
+      return;
+   const char *kind = NULL;
+   TSNode name_root;
+   if (classify(lang, node, &kind, &name_root) && !ts_node_is_null(name_root))
+   {
+      node_text(name_root, content, out[*count].name, (int)sizeof(out[*count].name));
+      if (out[*count].name[0])
+      {
+         snprintf(out[*count].kind, sizeof(out[*count].kind), "%s", kind);
+         out[*count].line = (int)ts_node_start_point(node).row + 1;
+         out[*count].line_end = (int)ts_node_end_point(node).row + 1;
+         (*count)++;
+         if (*count >= max)
+            return;
+      }
+   }
+   if (is_container(ts_node_type(node)))
+   {
+      uint32_t n = ts_node_named_child_count(node);
+      for (uint32_t i = 0; i < n && *count < max; i++)
+         visit(lang, ts_node_named_child(node, i), content, out, max, count);
+   }
 }
 
 int code_treesitter_definitions(const char *ext, const char *content, definition_t *out, int max)
@@ -286,23 +583,7 @@ int code_treesitter_definitions(const char *ext, const char *content, definition
    int count = 0;
    uint32_t top = ts_node_named_child_count(root);
    for (uint32_t i = 0; i < top && count < max; i++)
-   {
-      TSNode child = ts_node_named_child(root, i);
-      const char *kind = NULL;
-      TSNode name_root;
-      if (!classify(which, child, &kind, &name_root) || ts_node_is_null(name_root))
-         continue;
-      TSNode id;
-      if (!first_identifier(name_root, &id))
-         continue;
-      node_text(id, content, out[count].name, (int)sizeof(out[count].name));
-      if (!out[count].name[0])
-         continue;
-      snprintf(out[count].kind, sizeof(out[count].kind), "%s", kind);
-      out[count].line = (int)ts_node_start_point(child).row + 1;
-      out[count].line_end = (int)ts_node_end_point(child).row + 1;
-      count++;
-   }
+      visit(which, ts_node_named_child(root, i), content, out, max, &count);
 
    ts_tree_delete(tree);
    ts_parser_delete(parser);

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1367,11 +1367,7 @@ TEST_TARGETS += $(TESTPREFIX)/unit-test-code-treesitter
 $(OBJDIR)/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
 $(TESTPREFIX)/unit-test-code-treesitter: $(OBJDIR)/tests/test_code_treesitter.o \
                                          $(OBJDIR)/code_treesitter.o \
-                                         $(OBJDIR)/vendor/ts_runtime.o $(OBJDIR)/vendor/ts_c.o \
-                                         $(OBJDIR)/vendor/ts_python.o $(OBJDIR)/vendor/ts_python_scan.o \
-                                         $(OBJDIR)/vendor/ts_go.o \
-                                         $(OBJDIR)/vendor/ts_javascript.o $(OBJDIR)/vendor/ts_javascript_scan.o \
-                                         $(OBJDIR)/vendor/ts_rust.o $(OBJDIR)/vendor/ts_rust_scan.o \
+                                         $(TS_VENDOR_OBJS) \
                                          $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 endif

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -155,16 +155,27 @@ int main(void)
    want(".swift", swift, "C", "type");
    want(".swift", swift, "P", "type");
 
-   /* --- Kotlin (no name field — exercises identifier digging) --- */
-   const char *kt = "fun f(){}\nclass C{}\nobject O{}\n";
+   /* --- Kotlin (no name field — the name is the first DIRECT identifier child, which
+    * must survive a leading annotation/modifier, a type-parameter list, or an extension
+    * receiver that themselves contain identifiers). --- */
+   const char *kt = "fun f(){}\nclass C{}\nobject O{}\n"
+                    "@Entity class User {}\n"    /* annotation precedes the name */
+                    "@Test fun shouldWork(){}\n" /* annotation precedes the name */
+                    "fun <T> identity(x: T){}\n" /* type params precede the name */
+                    "fun String.shout(){}\n";    /* receiver precedes the name */
    want(".kt", kt, "f", "function");
    want(".kt", kt, "C", "type");
    want(".kt", kt, "O", "type");
+   want(".kt", kt, "User", "type");
+   want(".kt", kt, "shouldWork", "function");
+   want(".kt", kt, "identity", "function");
+   want(".kt", kt, "shout", "function");
 
-   /* --- Dart --- */
-   const char *dart = "void f(){}\nclass C{}\nenum E{a}\n";
+   /* --- Dart (annotated mixin: name survives the leading annotation) --- */
+   const char *dart = "void f(){}\nclass C{}\nenum E{a}\n@sealed mixin Foo {}\n";
    want(".dart", dart, "f", "function");
    want(".dart", dart, "C", "type");
+   want(".dart", dart, "Foo", "type");
 
    /* --- CSS (@keyframes name) --- */
    want(".css", "@keyframes spin { from {} to {} }\n.cls { color: red }\n", "spin", "type");

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -1,6 +1,6 @@
 /* test_code_treesitter.c: §2 tree-sitter front-end. Built + run ONLY in the opt-in
- * AIMEE_TREESITTER build (it links the fetched runtime + grammar). Parses real C and
- * asserts the extracted definition_t set matches the hand-rolled extractor's shape. */
+ * AIMEE_TREESITTER build (it links the fetched runtime + grammars). Parses real source in
+ * every supported language and asserts the extracted definition_t set. */
 #include "headers/code_treesitter.h"
 
 #include <assert.h>
@@ -15,94 +15,165 @@ static int has(const definition_t *d, int n, const char *name, const char *kind)
    return 0;
 }
 
+/* Parse `src` as `ext` and assert (name, kind) is among the extracted definitions. */
+static void want(const char *ext, const char *src, const char *name, const char *kind)
+{
+   definition_t d[64];
+   int n = code_treesitter_definitions(ext, src, d, 64);
+   if (n < 0 || !has(d, n, name, kind))
+   {
+      printf("  FAIL %s: want %s/%s, got %d defs:", ext, name, kind, n);
+      for (int i = 0; i < n; i++)
+         printf(" %s/%s", d[i].name, d[i].kind);
+      printf("\n");
+      assert(0);
+   }
+}
+
 int main(void)
 {
    printf("test_code_treesitter:\n");
 
-   /* grammar availability gates the dispatch. */
-   assert(code_treesitter_available(".c"));
-   assert(code_treesitter_available(".h"));
-   assert(code_treesitter_available(".py"));
-   assert(code_treesitter_available(".go"));
-   assert(code_treesitter_available(".js"));
-   assert(code_treesitter_available(".jsx"));
-   assert(code_treesitter_available(".rs"));
-   assert(!code_treesitter_available(".ts")); /* typescript grammar not vendored yet */
+   /* availability gates the dispatch (a representative extension per language). */
+   const char *avail[] = {".c",   ".h",   ".cpp", ".cc",   ".hpp",   ".cs", ".py",   ".go",
+                          ".js",  ".mjs", ".jsx", ".ts",   ".tsx",   ".rs", ".java", ".rb",
+                          ".php", ".lua", ".sh",  ".bash", ".swift", ".kt", ".dart", ".css"};
+   for (size_t i = 0; i < sizeof(avail) / sizeof(avail[0]); i++)
+      assert(code_treesitter_available(avail[i]));
    assert(!code_treesitter_available(".txt"));
+   assert(!code_treesitter_available(".md"));
    assert(!code_treesitter_available(NULL));
 
-   definition_t defs[32];
-
    /* --- C --- */
-   const char *c_src = "#include <stdio.h>\n"
-                       "typedef struct Point { int x; int y; } Point;\n"
+   const char *c_src = "typedef struct Point { int x; } Point;\n"
                        "static int add(int a, int b) { return a + b; }\n"
-                       "void greet(const char *who);\n" /* prototype */
+                       "void greet(const char *who);\n"
                        "int main(void) { return add(1, 2); }\n";
-   int n = code_treesitter_definitions(".c", c_src, defs, 32);
+   definition_t d[64];
+   int n = code_treesitter_definitions(".c", c_src, d, 64);
    assert(n >= 4);
-   assert(has(defs, n, "add", "function"));   /* function_definition */
-   assert(has(defs, n, "main", "function"));  /* function_definition */
-   assert(has(defs, n, "greet", "function")); /* prototype declaration */
-   assert(has(defs, n, "Point", "type"));     /* typedef */
+   want(".c", c_src, "add", "function");
+   want(".c", c_src, "greet", "function"); /* prototype */
+   want(".c", c_src, "Point", "type");
    for (int i = 0; i < n; i++)
    {
-      assert(defs[i].line >= 1);
-      assert(defs[i].line_end >= defs[i].line);
+      assert(d[i].line >= 1);
+      assert(d[i].line_end >= d[i].line);
    }
-   /* bounded output: max=1 yields exactly one. */
-   assert(code_treesitter_definitions(".c", c_src, defs, 1) == 1);
+   assert(code_treesitter_definitions(".c", c_src, d, 1) == 1); /* bounded */
+
+   /* --- C++ (incl. a namespaced class — exercises container descent) --- */
+   const char *cpp = "int add(int a){return a;}\nclass C{ void m(); };\nstruct S{};\n"
+                     "namespace N { class Inner{}; }\n";
+   want(".cpp", cpp, "add", "function");
+   want(".cpp", cpp, "C", "type");
+   want(".cpp", cpp, "S", "type");
+   want(".cpp", cpp, "Inner", "type"); /* reached through namespace */
+
+   /* --- C# (types live inside a namespace) --- */
+   const char *cs =
+       "namespace N { class C { void M(){} } interface I{} enum E{A} record R(int x); }\n"
+       "class Top {}\n";
+   want(".cs", cs, "C", "type");
+   want(".cs", cs, "I", "type");
+   want(".cs", cs, "R", "type");
+   want(".cs", cs, "Top", "type"); /* top-level, no namespace */
 
    /* --- Python (incl. a decorated def) --- */
-   const char *py_src = "import os\n"
-                        "def add(a, b):\n    return a + b\n"
-                        "class Point:\n    def m(self):\n        pass\n"
-                        "@deco\ndef wrapped():\n    pass\n";
-   n = code_treesitter_definitions(".py", py_src, defs, 32);
-   assert(has(defs, n, "add", "function"));     /* function_definition */
-   assert(has(defs, n, "Point", "type"));       /* class_definition */
-   assert(has(defs, n, "wrapped", "function")); /* decorated_definition unwrapped */
+   const char *py = "def add(a, b):\n    return a + b\n"
+                    "class Point:\n    pass\n"
+                    "@deco\ndef wrapped():\n    pass\n";
+   want(".py", py, "add", "function");
+   want(".py", py, "Point", "type");
+   want(".py", py, "wrapped", "function");
 
-   /* --- Go (func, method, named type) --- */
-   const char *go_src = "package main\n"
-                        "func Add(a, b int) int { return a + b }\n"
-                        "func (p *Point) M() {}\n"
-                        "type Point struct { X int }\n";
-   n = code_treesitter_definitions(".go", go_src, defs, 32);
-   assert(has(defs, n, "Add", "function")); /* function_declaration */
-   assert(has(defs, n, "M", "function"));   /* method_declaration */
-   assert(has(defs, n, "Point", "type"));   /* type_declaration -> type_spec */
+   /* --- Go --- */
+   const char *go = "package main\nfunc Add(a int) int { return a }\n"
+                    "func (p *Point) M() {}\ntype Point struct { X int }\n";
+   want(".go", go, "Add", "function");
+   want(".go", go, "M", "function");
+   want(".go", go, "Point", "type");
 
-   /* --- JavaScript (function, generator, class) --- */
-   const char *js_src = "import x from 'y'\n"
-                        "function add(a, b) { return a + b }\n"
-                        "class Point { m() {} }\n"
-                        "function* gen() {}\n"
-                        "export function pub() {}\n" /* export_statement unwrap */
-                        "export class Wid {}\n";     /* export_statement unwrap */
-   n = code_treesitter_definitions(".js", js_src, defs, 32);
-   assert(has(defs, n, "add", "function")); /* function_declaration */
-   assert(has(defs, n, "Point", "type"));   /* class_declaration */
-   assert(has(defs, n, "gen", "function")); /* generator_function_declaration */
-   assert(has(defs, n, "pub", "function")); /* export function */
-   assert(has(defs, n, "Wid", "type"));     /* export class */
+   /* --- JavaScript (incl. export) --- */
+   const char *js = "function add(a){return a}\nclass Point{}\nfunction* gen(){}\n"
+                    "export function pub(){}\nexport class Wid{}\n";
+   want(".js", js, "add", "function");
+   want(".js", js, "Point", "type");
+   want(".js", js, "gen", "function");
+   want(".js", js, "pub", "function");
+   want(".js", js, "Wid", "type");
 
-   /* --- Rust (fn, struct, enum, trait) --- */
-   const char *rs_src = "use std::io;\n"
-                        "fn add(a: i32, b: i32) -> i32 { a + b }\n"
-                        "struct Point { x: i32 }\n"
-                        "enum E { A, B }\n"
-                        "trait T {}\n";
-   n = code_treesitter_definitions(".rs", rs_src, defs, 32);
-   assert(has(defs, n, "add", "function")); /* function_item */
-   assert(has(defs, n, "Point", "type"));   /* struct_item */
-   assert(has(defs, n, "E", "type"));       /* enum_item */
-   assert(has(defs, n, "T", "type"));       /* trait_item */
+   /* --- TypeScript --- */
+   const char *ts = "function f(){}\nclass C{}\ninterface I{}\ntype T=number\nenum E{A}\n"
+                    "export function h(){}\n";
+   want(".ts", ts, "f", "function");
+   want(".ts", ts, "C", "type");
+   want(".ts", ts, "I", "type");
+   want(".ts", ts, "T", "type");
+   want(".ts", ts, "h", "function");
+   want(".tsx", "export function App(){ return null }\n", "App", "function");
 
-   /* an ext with no grammar -> -1 (caller falls back to the hand-rolled extractor). */
-   assert(code_treesitter_definitions(".ts", c_src, defs, 32) == -1);
+   /* --- Rust --- */
+   const char *rs =
+       "fn add(a: i32) -> i32 { a }\nstruct Point { x: i32 }\nenum E { A }\ntrait T {}\n";
+   want(".rs", rs, "add", "function");
+   want(".rs", rs, "Point", "type");
+   want(".rs", rs, "E", "type");
+   want(".rs", rs, "T", "type");
 
-   printf("  C/Python/Go/JavaScript/Rust definitions extracted\n");
+   /* --- Java (top-level types) --- */
+   const char *java = "class C { void m(){} }\ninterface I{}\nenum E{A}\nrecord R(int x){}\n";
+   want(".java", java, "C", "type");
+   want(".java", java, "I", "type");
+   want(".java", java, "R", "type");
+
+   /* --- Ruby --- */
+   const char *rb = "def foo; end\nclass C\nend\nmodule M\nend\n";
+   want(".rb", rb, "foo", "function");
+   want(".rb", rb, "C", "type");
+   want(".rb", rb, "M", "type");
+
+   /* --- PHP --- */
+   const char *php = "<?php\nfunction f(){}\nclass C{}\ninterface I{}\ntrait Tr{}\n";
+   want(".php", php, "f", "function");
+   want(".php", php, "C", "type");
+   want(".php", php, "Tr", "type");
+
+   /* --- Lua (dotted name preserved) --- */
+   const char *lua = "local function f() end\nfunction g() end\nfunction T.m() end\n";
+   want(".lua", lua, "g", "function");
+   want(".lua", lua, "T.m", "function");
+
+   /* --- Bash --- */
+   const char *sh = "foo() { echo hi; }\nfunction bar { echo yo; }\n";
+   want(".sh", sh, "foo", "function");
+   want(".sh", sh, "bar", "function");
+
+   /* --- Swift --- */
+   const char *swift = "func f(){}\nclass C{}\nstruct S{}\nprotocol P{}\n";
+   want(".swift", swift, "f", "function");
+   want(".swift", swift, "C", "type");
+   want(".swift", swift, "P", "type");
+
+   /* --- Kotlin (no name field — exercises identifier digging) --- */
+   const char *kt = "fun f(){}\nclass C{}\nobject O{}\n";
+   want(".kt", kt, "f", "function");
+   want(".kt", kt, "C", "type");
+   want(".kt", kt, "O", "type");
+
+   /* --- Dart --- */
+   const char *dart = "void f(){}\nclass C{}\nenum E{a}\n";
+   want(".dart", dart, "f", "function");
+   want(".dart", dart, "C", "type");
+
+   /* --- CSS (@keyframes name) --- */
+   want(".css", "@keyframes spin { from {} to {} }\n.cls { color: red }\n", "spin", "type");
+
+   /* a vendored-but-unmapped ext -> -1 (caller falls back to the hand-rolled extractor). */
+   assert(code_treesitter_definitions(".md", c_src, d, 64) == -1);
+
+   printf("  all supported languages extracted (C/C++/C#/Python/Go/JS/TS/Rust/Java/"
+          "Ruby/PHP/Lua/Bash/Swift/Kotlin/Dart/CSS)\n");
    printf("ALL PASS\n");
    return 0;
 }


### PR DESCRIPTION
Brings the opt-in §2 tree-sitter front-end to **parity with aimee's hand-rolled supported languages** (`src/extractors.c`): adds **C++, C#, TypeScript (+TSX), Java, Ruby, PHP, Lua, Bash, Swift, Kotlin, Dart, CSS** on top of the existing C/Python/Go/JS/Rust — **16 language families, 18 grammars**.

## Engine
- Per-language `classify_*` maps each grammar's definition node types → `function`/`type`. Node types were derived **empirically** by probing each grammar.
- `name_node` resolves the symbol name from the `name` field, or the first identifier-like descendant where a grammar exposes none (Kotlin). C/C++ keep the declarator dig so a named return type isn't mistaken for the name.
- A small `is_container` set lets the walk descend **through** organizational wrappers (namespaces) so types nested under them (C#/C++) are surfaced. Class/function bodies are not descended — nested members (methods) remain a documented follow-up.

## Build
- `fetch-treesitter.sh` pins every grammar commit (Swift uses its `*-with-generated-files` tag — the default branch ships no `parser.c`). The Makefile compiles each `parser.c`+`scanner.c` via a `ts_obj` `$(eval)` macro and links them under `AIMEE_TREESITTER`. TypeScript and PHP are dual-grammar.
- Also fixes two **pre-existing** cold-build bugs in the fetch rule: wrong relative path (`./scripts`→`../scripts`) and the script's missing execute bit.

## Safety
- **Default build unchanged** — stub only; default `aimee-kb` verified byte-identical (1295896 B). Opt-in `aimee-kb` links all 18 grammars cleanly (33.7MB, no symbol conflicts).
- `unit-test-code-treesitter` parses real source in **every** language and asserts the extracted defs (validated locally — the opt-in test isn't in default CI).

Grammars are fetched at build time and **gitignored**. NOTICE + .gitignore + proposal §2 reconciled.