### PR TITLE
feat(kb): §2 tree-sitter — recursive descent for nested class/impl/trait methods

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -131,13 +131,14 @@ pinned commits, gitignored) and compiled only in the opt-in `AIMEE_TREESITTER` b
 without it. Ships grammars for **all 16 hand-rolled supported languages** — C, C++, C#,
 Python, Go, JavaScript, TypeScript, Rust, Java, Ruby, PHP, Lua, Bash, Swift, Kotlin,
 Dart, CSS — each with a per-language `classify_*` mapping its definition node types to
-`function`/`type`; organizational wrappers (namespaces) are descended through so types
-nested under them (C#/C++) are surfaced. `unit-test-code-treesitter` parses real source
-in every language and asserts the extracted defs. Adding a grammar is mechanical — vendor
-its `parser.c`(+`scanner.c`), register its `TSLanguage` + extensions in
-`ts_language_for_ext`, and add a `classify_*`. Remaining increments: recursive
-descent for nested members (class/impl methods), more languages, and call-edge
-extraction (`code_calls`) over the parse tree.
+`function`/`type`. The walk descends through organizational wrappers (namespaces,
+`export`/decorator wrappers) and the member bodies of types, so **nested members
+(class/impl/trait methods) are surfaced** across every OO language — while it never
+descends a function body (so locals stay out). `unit-test-code-treesitter` parses real
+source in every language and asserts the extracted defs (top-level + nested). Adding a
+grammar is mechanical — vendor its `parser.c`(+`scanner.c`), register its `TSLanguage` +
+extensions in `ts_language_for_ext`, and add a `classify_*`. Remaining increments: more
+languages, and call-edge extraction (`code_calls`) over the parse tree.
 
 ## §3 Edge provenance + confidence
 

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -284,17 +284,11 @@ static int classify_cpp(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
-/* Python: function/class definitions, including those wrapped by a decorator. */
+/* Python: function/class definitions. A decorated_definition is descended through (see
+ * is_descendable), so the inner def is classified here directly. */
 static int classify_py(TSNode node, const char **kind, TSNode *name_root)
 {
    const char *t = ts_node_type(node);
-   if (strcmp(t, "decorated_definition") == 0)
-   {
-      TSNode inner = ts_node_child_by_field_name(node, "definition", 10);
-      if (ts_node_is_null(inner))
-         return 0;
-      return classify_py(inner, kind, name_root); /* inner is a function/class def */
-   }
    if (strcmp(t, "function_definition") == 0)
       *kind = "function";
    else if (strcmp(t, "class_definition") == 0)
@@ -338,31 +332,25 @@ static int classify_go(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
-/* JavaScript / TypeScript: function (incl. generator) and class/interface/type/enum
- * declarations, including those behind an `export`/`export default`. */
+/* JavaScript / TypeScript: function (incl. generator), class methods, and
+ * class/interface/type/enum declarations. `export`/`export default` and class bodies are
+ * descended through (see is_descendable), so this fires on the declaration itself. */
 static int classify_jsts(TSNode node, const char **kind, TSNode *name_root)
 {
-   const char *t = ts_node_type(node);
-   if (strcmp(t, "export_statement") == 0)
-   {
-      TSNode inner = ts_node_child_by_field_name(node, "declaration", 11);
-      if (ts_node_is_null(inner))
-         return 0; /* re-export / `export const x = ...` — no named declaration */
-      return classify_jsts(inner, kind, name_root);
-   }
-   static const char *const F[] = {"function_declaration", "generator_function_declaration", NULL};
+   static const char *const F[] = {"function_declaration", "generator_function_declaration",
+                                   "method_definition", NULL};
    static const char *const T[] = {"class_declaration", "interface_declaration",
                                    "type_alias_declaration", "enum_declaration", NULL};
-   if (!kind_lookup(t, F, T, kind))
+   if (!kind_lookup(ts_node_type(node), F, T, kind))
       return 0;
    *name_root = name_node(node);
    return 1;
 }
 
-/* Rust: functions and the named type-like items. */
+/* Rust: functions (incl. trait method signatures) and the named type-like items. */
 static int classify_rust(TSNode node, const char **kind, TSNode *name_root)
 {
-   static const char *const F[] = {"function_item", NULL};
+   static const char *const F[] = {"function_item", "function_signature_item", NULL};
    static const char *const T[] = {"struct_item", "enum_item",  "trait_item",
                                    "type_item",   "union_item", NULL};
    if (!kind_lookup(ts_node_type(node), F, T, kind))
@@ -472,10 +460,12 @@ static int classify_kotlin(TSNode node, const char **kind, TSNode *name_root)
    return 1;
 }
 
-/* Dart: function/method signatures and class-like types. */
+/* Dart: function signatures and class-like types. A class method is a method_signature
+ * wrapping a function_signature; method_signature is descended through (see is_descendable)
+ * so the function_signature inside carries the name. */
 static int classify_dart(TSNode node, const char **kind, TSNode *name_root)
 {
-   static const char *const F[] = {"function_signature", "method_signature", NULL};
+   static const char *const F[] = {"function_signature", NULL};
    static const char *const T[] = {"class_definition", "enum_declaration", "mixin_declaration",
                                    "extension_declaration", NULL};
    if (!kind_lookup(ts_node_type(node), F, T, kind))
@@ -539,18 +529,37 @@ static int classify(ts_lang_t lang, TSNode node, const char **kind, TSNode *name
    return 0;
 }
 
-/* Organizational wrappers we descend THROUGH to reach the definitions inside (namespaces,
- * their declaration lists, C++ templates/extern blocks). We do NOT descend function or
- * class bodies, so nested members (methods) are not surfaced — a follow-up. */
-static int is_container(const char *t)
+/* Node types we descend THROUGH to reach the definitions inside: organizational wrappers
+ * (namespaces, export/decorator wrappers, C++ templates/extern blocks) and the member
+ * bodies of types (class/struct/interface/trait/impl/enum bodies). We do NOT list function
+ * bodies, type aliases, or typedefs — descending a typedef would re-emit its inner struct
+ * tag, and descending a function body would surface locals. Because the walk also stops at
+ * any matched FUNCTION (see visit), method bodies are never descended either. */
+static int is_descendable(const char *t)
 {
-   return strcmp(t, "namespace_declaration") == 0 ||
-          strcmp(t, "file_scoped_namespace_declaration") == 0 ||
-          strcmp(t, "namespace_definition") == 0 || strcmp(t, "declaration_list") == 0 ||
-          strcmp(t, "template_declaration") == 0 || strcmp(t, "linkage_specification") == 0;
+   static const char *const set[] = {
+       /* organizational wrappers */
+       "namespace_declaration", "file_scoped_namespace_declaration", "namespace_definition",
+       "declaration_list", "template_declaration", "linkage_specification", "decorated_definition",
+       "export_statement",
+       /* member bodies */
+       "class_body", "field_declaration_list", "body_statement", "enum_body",
+       "enum_body_declarations", "interface_body", "block", "method_signature",
+       /* member-containing type nodes (descended to reach their bodies; also emitted by
+        * classify where they are named) */
+       "class_declaration", "class_specifier", "struct_specifier", "union_specifier",
+       "class_definition", "class", "interface_declaration", "trait_item", "impl_item", "mod_item",
+       "trait_declaration", "object_declaration", "protocol_declaration", "struct_declaration",
+       "record_declaration", "mixin_declaration", "extension_declaration", "enum_declaration",
+       "enum_specifier", "enum_item", NULL};
+   for (int i = 0; set[i]; i++)
+      if (strcmp(t, set[i]) == 0)
+         return 1;
+   return 0;
 }
 
-/* Emit `node` if it is a definition, then descend into it if it is a container. */
+/* Emit `node` if it is a definition, then descend into it to surface nested definitions
+ * (members of a type, types in a namespace) — but never into a function body. */
 static void visit(ts_lang_t lang, TSNode node, const char *content, definition_t *out, int max,
                   int *count)
 {
@@ -558,7 +567,8 @@ static void visit(ts_lang_t lang, TSNode node, const char *content, definition_t
       return;
    const char *kind = NULL;
    TSNode name_root;
-   if (classify(lang, node, &kind, &name_root) && !ts_node_is_null(name_root))
+   int matched = classify(lang, node, &kind, &name_root);
+   if (matched && !ts_node_is_null(name_root))
    {
       node_text(name_root, content, out[*count].name, (int)sizeof(out[*count].name));
       if (out[*count].name[0])
@@ -567,11 +577,11 @@ static void visit(ts_lang_t lang, TSNode node, const char *content, definition_t
          out[*count].line = (int)ts_node_start_point(node).row + 1;
          out[*count].line_end = (int)ts_node_end_point(node).row + 1;
          (*count)++;
-         if (*count >= max)
-            return;
       }
    }
-   if (is_container(ts_node_type(node)))
+   if (matched && strcmp(kind, "function") == 0)
+      return; /* a function: emit it but never descend into its body */
+   if (is_descendable(ts_node_type(node)))
    {
       uint32_t n = ts_node_named_child_count(node);
       for (uint32_t i = 0; i < n && *count < max; i++)

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -180,6 +180,32 @@ int main(void)
    /* --- CSS (@keyframes name) --- */
    want(".css", "@keyframes spin { from {} to {} }\n.cls { color: red }\n", "spin", "type");
 
+   /* --- nested members: methods inside a type body are surfaced (the walk descends type
+    * bodies but never function bodies), across the OO languages. --- */
+   want(".cpp", "class C { void m(){} };\n", "m", "function");
+   want(".cs", "namespace N { class C { void M(){} } }\n", "M", "function");
+   want(".java", "class C { void m(){} }\n", "m", "function");
+   want(".ts", "class C { greet(){} }\n", "greet", "function");
+   want(".ts", "export class W { go(){} }\n", "go", "function"); /* exported class's method */
+   want(".py", "class C:\n    def m(self):\n        pass\n", "m", "function");
+   want(".rs", "impl C { fn m(&self){} }\n", "m", "function"); /* impl method */
+   want(".rs", "trait T { fn t(&self); }\n", "t", "function"); /* trait method sig */
+   want(".rb", "class C\n  def m; end\nend\n", "m", "function");
+   want(".php", "<?php\nclass C { function m(){} }\n", "m", "function");
+   want(".swift", "class C { func m(){} }\n", "m", "function");
+   want(".dart", "class C { void m(){} }\n", "m", "function");
+
+   /* descending a type body must not double-emit the type or a typedef's struct tag. */
+   {
+      definition_t e[64];
+      int m = code_treesitter_definitions(".c", "typedef struct Point { int x; } Point;\n", e, 64);
+      int seen = 0;
+      for (int i = 0; i < m; i++)
+         if (strcmp(e[i].name, "Point") == 0)
+            seen++;
+      assert(seen == 1); /* not double-emitted via the struct tag */
+   }
+
    /* a vendored-but-unmapped ext -> -1 (caller falls back to the hand-rolled extractor). */
    assert(code_treesitter_definitions(".md", c_src, d, 64) == -1);
 


### PR DESCRIPTION
Polish item #1. The tree-sitter front-end now surfaces **nested members** (methods inside classes/impls/traits), not just top-level definitions.

## How
- `visit` now descends through **type member bodies** (`class_body`, `field_declaration_list`, `declaration_list`, `body_statement`, `block`, …) in addition to namespaces — so a class's methods are emitted across every OO language (C++, C#, Java, TS/JS, Python, Rust impl/trait, Ruby, PHP, Swift, Dart).
- It **never descends a function body** (locals stay out), enforced by returning at any matched `function`.
- `export`/decorator wrappers are now **descended through** (replacing the prior unwrap-in-`classify`). This also fixes a real gap: an **exported class's methods** were previously missed.
- Type aliases / typedefs are NOT descended, so a C `typedef struct Point {…} Point` is **not double-emitted** via its struct tag (asserted in the test).
- New classify cases: TS `method_definition`, Rust `function_signature_item` (trait method sigs); Dart methods come through the descended `method_signature` → `function_signature`.

## Safety
- **Default build byte-identical** (1295896 B). All node types probed empirically from each grammar.
- `unit-test-code-treesitter` now asserts nested members in every OO language **and** the no-double-emit invariant.

Behavior change is opt-in only (`AIMEE_TREESITTER`); the default build/CI is unaffected.