### PR TITLE
feat(kb): §2 tree-sitter — capture arrow/function-expression bindings (JS/TS)

### DIFF
--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -134,7 +134,8 @@ static int is_identifier_type(const char *t)
 {
    return strcmp(t, "identifier") == 0 || strcmp(t, "type_identifier") == 0 ||
           strcmp(t, "field_identifier") == 0 || strcmp(t, "simple_identifier") == 0 ||
-          strcmp(t, "constant") == 0 || strcmp(t, "name") == 0;
+          strcmp(t, "constant") == 0 || strcmp(t, "name") == 0 ||
+          strcmp(t, "property_identifier") == 0;
 }
 
 /* Pre-order DFS for the first descendant whose type is one of the identifier kinds — used
@@ -332,16 +333,37 @@ static int classify_go(TSNode node, const char **kind, TSNode *name_root)
    return 0;
 }
 
-/* JavaScript / TypeScript: function (incl. generator), class methods, and
- * class/interface/type/enum declarations. `export`/`export default` and class bodies are
- * descended through (see is_descendable), so this fires on the declaration itself. */
+/* JavaScript / TypeScript: function (incl. generator), class methods, arrow/function
+ * expressions bound to a const/let/var or a class field, and class/interface/type/enum
+ * declarations. `export`/`export default`, class bodies, and the const/let/var
+ * declarations are descended through (see is_descendable), so this fires on the
+ * declarator/declaration itself. */
 static int classify_jsts(TSNode node, const char **kind, TSNode *name_root)
 {
+   const char *t = ts_node_type(node);
+   /* `const f = () => {}`, `const g = function(){}`, or a class field `f = () => {}`:
+    * a named binding whose value is a function expression — treat it as a function. */
+   if (strcmp(t, "variable_declarator") == 0 || strcmp(t, "field_definition") == 0 ||
+       strcmp(t, "public_field_definition") == 0)
+   {
+      TSNode val = ts_node_child_by_field_name(node, "value", 5);
+      if (ts_node_is_null(val))
+         return 0;
+      const char *vt = ts_node_type(val);
+      if (strcmp(vt, "arrow_function") != 0 && strcmp(vt, "function_expression") != 0 &&
+          strcmp(vt, "function") != 0 && strcmp(vt, "generator_function") != 0)
+         return 0;
+      *kind = "function";
+      /* variable_declarator exposes a `name` field (an identifier; a destructuring pattern
+       * has none, so it is skipped); a class field's name is a property_identifier child. */
+      *name_root = name_node(node);
+      return 1;
+   }
    static const char *const F[] = {"function_declaration", "generator_function_declaration",
                                    "method_definition", NULL};
    static const char *const T[] = {"class_declaration", "interface_declaration",
                                    "type_alias_declaration", "enum_declaration", NULL};
-   if (!kind_lookup(ts_node_type(node), F, T, kind))
+   if (!kind_lookup(t, F, T, kind))
       return 0;
    *name_root = name_node(node);
    return 1;
@@ -541,7 +563,7 @@ static int is_descendable(const char *t)
        /* organizational wrappers */
        "namespace_declaration", "file_scoped_namespace_declaration", "namespace_definition",
        "declaration_list", "template_declaration", "linkage_specification", "decorated_definition",
-       "export_statement",
+       "export_statement", "lexical_declaration", "variable_declaration",
        /* member bodies */
        "class_body", "field_declaration_list", "body_statement", "enum_body",
        "enum_body_declarations", "interface_body", "block", "method_signature",

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -354,8 +354,9 @@ static int classify_jsts(TSNode node, const char **kind, TSNode *name_root)
           strcmp(vt, "function") != 0 && strcmp(vt, "generator_function") != 0)
          return 0;
       *kind = "function";
-      /* variable_declarator exposes a `name` field (an identifier; a destructuring pattern
-       * has none, so it is skipped); a class field's name is a property_identifier child. */
+      /* variable_declarator's name is an identifier `name` field; a class field's name is a
+       * property_identifier child (no `name` field), which name_node digs out. A destructuring
+       * binding never reaches here — its value is not a function expression. */
       *name_root = name_node(node);
       return 1;
    }

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -112,6 +112,20 @@ int main(void)
    want(".ts", ts, "T", "type");
    want(".ts", ts, "h", "function");
    want(".tsx", "export function App(){ return null }\n", "App", "function");
+   /* arrow / function expressions bound to a const/let or a class field. */
+   want(".js", "const f = () => {}\n", "f", "function");
+   want(".js", "const g = function(){}\n", "g", "function");
+   want(".js", "export const k = () => 2\n", "k", "function");
+   want(".js", "class W { fld = () => {} }\n", "fld", "function"); /* class field arrow */
+   want(".ts", "export const ah = async (): Promise<void> => {}\n", "ah", "function");
+   {
+      /* a plain value binding is not a function; an arrow body's locals don't leak. */
+      definition_t e[32];
+      int m = code_treesitter_definitions(".js", "let x = 1\nconst f = () => { const inner = 1 }\n",
+                                          e, 32);
+      for (int i = 0; i < m; i++)
+         assert(strcmp(e[i].name, "x") != 0 && strcmp(e[i].name, "inner") != 0);
+   }
 
    /* --- Rust --- */
    const char *rs =


### PR DESCRIPTION
Polish item #4 (the JS/TS coverage thin spot). A `const`/`let`/`var` or class field bound to an **arrow function or function expression** is now surfaced as a function — the dominant way functions are declared in modern JS/TS.

## Captures
- `const f = () => {}`, `const g = function(){}`, `export const k = () => 2`
- class-field arrows: `class W { fld = () => {} }`
- multiple declarators: `const a = () => 1, b = () => 2`

## Correctly skips
- plain-value bindings (`let x = 1`), destructuring (`const {a} = o`), call results (`const r = fn()`)
- the arrow **body is never descended**, so locals don't leak

## How
- `lexical_declaration`/`variable_declaration` are descended through; `classify_jsts` emits a `variable_declarator`/`field_definition` **only** when its `value` child is a function expression. Added `property_identifier` to the identifier kinds (a class field's name has no `name` field).

Default build byte-identical (1295896 B). `unit-test-code-treesitter` covers the captured forms and the skip cases. (Swift is already pinned to a reproducible generated-files tag; CSS `@keyframes` is the honest minimal — no symbol-like constructs beyond it.)