### PR TITLE
feat(kb): §2 tree-sitter — parse-tree call-edge extraction (caller -> callee)

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -135,10 +135,13 @@ Dart, CSS — each with a per-language `classify_*` mapping its definition node 
 `export`/decorator wrappers) and the member bodies of types, so **nested members
 (class/impl/trait methods) are surfaced** across every OO language — while it never
 descends a function body (so locals stay out). `unit-test-code-treesitter` parses real
-source in every language and asserts the extracted defs (top-level + nested). Adding a
-grammar is mechanical — vendor its `parser.c`(+`scanner.c`), register its `TSLanguage` +
-extensions in `ts_language_for_ext`, and add a `classify_*`. Remaining increments: more
-languages, and call-edge extraction (`code_calls`) over the parse tree.
+source in every language and asserts the extracted defs (top-level + nested). It also
+extracts **call edges** (`code_treesitter_calls` → `call_ref_t` caller→callee, wired into
+`extract_calls`): a caller-tracking walk attributes every call to its enclosing function
+and resolves the callee to the last identifier of the callee expression (`obj.m()` → `m`,
+`a::b()` → `b`); Bash/CSS defer to the hand-rolled path. Adding a grammar is mechanical —
+vendor its `parser.c`(+`scanner.c`), register its `TSLanguage` + extensions in
+`ts_language_for_ext`, and add a `classify_*`. Remaining increment: more languages.
 
 ## §3 Edge provenance + confidence
 

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -645,6 +645,126 @@ int code_treesitter_definitions(const char *ext, const char *content, definition
    return count;
 }
 
+/* ---- call edges (caller -> callee) ------------------------------------------------- */
+
+/* Reverse pre-order DFS for the LAST identifier-like descendant — the called name in a
+ * callee expression (`obj.m` -> m, `a::b::c` -> c, `g` -> g). */
+static int last_identifier(TSNode node, TSNode *out)
+{
+   if (is_identifier_type(ts_node_type(node)))
+   {
+      *out = node;
+      return 1;
+   }
+   uint32_t n = ts_node_named_child_count(node);
+   for (uint32_t i = n; i-- > 0;)
+      if (last_identifier(ts_node_named_child(node, i), out))
+         return 1;
+   return 0;
+}
+
+/* Call/invocation node types across the grammars. */
+static int is_call_node(const char *t)
+{
+   return strcmp(t, "call_expression") == 0 || strcmp(t, "call") == 0 ||
+          strcmp(t, "method_invocation") == 0 || strcmp(t, "invocation_expression") == 0 ||
+          strcmp(t, "function_call") == 0 || strcmp(t, "function_call_expression") == 0 ||
+          strcmp(t, "member_call_expression") == 0 || strcmp(t, "scoped_call_expression") == 0 ||
+          strcmp(t, "nullsafe_member_call_expression") == 0 || strcmp(t, "macro_invocation") == 0 ||
+          strcmp(t, "object_creation_expression") == 0;
+}
+
+/* The called name: the callee expression (the `function`/`name`/`method` field, else the
+ * first child) reduced to its last identifier. Returns 0 if none. */
+static int call_callee_name(TSNode call, const char *content, char *out, int cap)
+{
+   TSNode fn = ts_node_child_by_field_name(call, "function", 8);
+   if (ts_node_is_null(fn))
+      fn = ts_node_child_by_field_name(call, "name", 4);
+   if (ts_node_is_null(fn))
+      fn = ts_node_child_by_field_name(call, "method", 6);
+   if (ts_node_is_null(fn))
+   {
+      if (ts_node_named_child_count(call) == 0)
+         return 0;
+      fn = ts_node_named_child(call, 0); /* Swift/Ruby: callee is the first child */
+   }
+   TSNode id;
+   if (is_identifier_type(ts_node_type(fn)))
+      id = fn;
+   else if (!last_identifier(fn, &id))
+      return 0;
+   node_text(id, content, out, cap);
+   return out[0] != '\0';
+}
+
+/* Walk the whole tree (function bodies included, unlike definitions) tracking the enclosing
+ * function as the caller; emit an edge at every call node. */
+static void walk_calls(ts_lang_t lang, TSNode node, const char *content, const char *caller,
+                       call_ref_t *out, int max, int *count)
+{
+   if (*count >= max)
+      return;
+   const char *kind = NULL;
+   TSNode nm;
+   const char *child_caller = caller;
+   char buf[sizeof(out->caller)];
+   if (classify(lang, node, &kind, &nm) && kind && strcmp(kind, "function") == 0 &&
+       !ts_node_is_null(nm))
+   {
+      node_text(nm, content, buf, (int)sizeof(buf));
+      if (buf[0])
+         child_caller = buf; /* calls in this subtree are attributed to this function */
+   }
+   if (is_call_node(ts_node_type(node)))
+   {
+      char callee[sizeof(out->callee)];
+      if (call_callee_name(node, content, callee, (int)sizeof(callee)) && callee[0])
+      {
+         snprintf(out[*count].caller, sizeof(out[*count].caller), "%s", caller ? caller : "");
+         snprintf(out[*count].callee, sizeof(out[*count].callee), "%s", callee);
+         out[*count].line = (int)ts_node_start_point(node).row + 1;
+         (*count)++;
+         if (*count >= max)
+            return;
+      }
+   }
+   uint32_t n = ts_node_named_child_count(node);
+   for (uint32_t i = 0; i < n && *count < max; i++)
+      walk_calls(lang, ts_node_named_child(node, i), content, child_caller, out, max, count);
+}
+
+int code_treesitter_calls(const char *ext, const char *content, call_ref_t *out, int max)
+{
+   ts_lang_t which;
+   const TSLanguage *lang = ts_language_for_ext(ext, &which);
+   if (!lang || !content || !out || max <= 0)
+      return -1;
+   if (which == TSL_BASH || which == TSL_CSS)
+      return -1; /* no useful call extraction — defer to the hand-rolled path */
+
+   TSParser *parser = ts_parser_new();
+   if (!parser)
+      return -1;
+   if (!ts_parser_set_language(parser, lang))
+   {
+      ts_parser_delete(parser);
+      return -1;
+   }
+   TSTree *tree = ts_parser_parse_string(parser, NULL, content, (uint32_t)strlen(content));
+   if (!tree)
+   {
+      ts_parser_delete(parser);
+      return -1;
+   }
+
+   int count = 0;
+   walk_calls(which, ts_tree_root_node(tree), content, "", out, max, &count);
+   ts_tree_delete(tree);
+   ts_parser_delete(parser);
+   return count;
+}
+
 #else /* !AIMEE_TREESITTER */
 
 int code_treesitter_available(const char *ext)
@@ -654,6 +774,15 @@ int code_treesitter_available(const char *ext)
 }
 
 int code_treesitter_definitions(const char *ext, const char *content, definition_t *out, int max)
+{
+   (void)ext;
+   (void)content;
+   (void)out;
+   (void)max;
+   return -1;
+}
+
+int code_treesitter_calls(const char *ext, const char *content, call_ref_t *out, int max)
 {
    (void)ext;
    (void)content;

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -647,11 +647,25 @@ int code_treesitter_definitions(const char *ext, const char *content, definition
 
 /* ---- call edges (caller -> callee) ------------------------------------------------- */
 
+/* A node carrying the type arguments of a generic/template call (`<IFoo>`, `<T>`, the
+ * Rust turbofish `::<u32>`). The call NAME precedes it, so the callee-name search must
+ * not descend into it — otherwise a generic call records the type argument as the callee
+ * (`GetService<IFoo>()` -> IFoo, `obj.run<T>()` -> T). */
+static int is_type_arguments(const char *t)
+{
+   return strcmp(t, "type_argument_list") == 0 || strcmp(t, "type_arguments") == 0 ||
+          strcmp(t, "template_argument_list") == 0 || strcmp(t, "type_parameters") == 0;
+}
+
 /* Reverse pre-order DFS for the LAST identifier-like descendant — the called name in a
- * callee expression (`obj.m` -> m, `a::b::c` -> c, `g` -> g). */
+ * callee expression (`obj.m` -> m, `a::b::c` -> c, `g` -> g), skipping type-argument
+ * lists so a generic call resolves to the method name, not a type argument. */
 static int last_identifier(TSNode node, TSNode *out)
 {
-   if (is_identifier_type(ts_node_type(node)))
+   const char *t = ts_node_type(node);
+   if (is_type_arguments(t))
+      return 0;
+   if (is_identifier_type(t))
    {
       *out = node;
       return 1;

--- a/src/extractors.c
+++ b/src/extractors.c
@@ -933,6 +933,16 @@ int extract_definitions(const char *ext, const char *content, definition_t *out,
 
 int extract_calls(const char *ext, const char *content, call_ref_t *out, int max)
 {
+   /* Prefer the tree-sitter front-end where it is compiled in and handles this language;
+    * fall back to the hand-rolled per-line extractors otherwise (and in the default
+    * build, where code_treesitter_* is a stub). */
+   if (code_treesitter_available(ext))
+   {
+      int n = code_treesitter_calls(ext, content, out, max);
+      if (n >= 0)
+         return n;
+   }
+
    lang_t lang = detect_lang(ext);
    call_ctx_t ctx;
    memset(&ctx, 0, sizeof(ctx));

--- a/src/headers/code_treesitter.h
+++ b/src/headers/code_treesitter.h
@@ -8,7 +8,7 @@
 #ifndef DEC_CODE_TREESITTER_H
 #define DEC_CODE_TREESITTER_H 1
 
-#include "index.h" /* definition_t */
+#include "index.h" /* definition_t, call_ref_t */
 
 /* 1 if the tree-sitter front-end is compiled in AND has a grammar for `ext`
  * (e.g. ".c"/".h"); 0 otherwise (caller uses extract_definitions instead). */
@@ -19,5 +19,13 @@ int code_treesitter_available(const char *ext);
  * (name/kind/line/line_end). Returns the count, or -1 if tree-sitter is unavailable or
  * has no grammar for `ext` (the caller then falls back to extract_definitions). */
 int code_treesitter_definitions(const char *ext, const char *content, definition_t *out, int max);
+
+/* Extract call edges (caller -> callee, by name) from `content` using the tree-sitter
+ * grammar for `ext`. The caller is the enclosing function/method (empty at file scope);
+ * the callee is the called function/method name (the last identifier of `obj.m()`). Fills
+ * up to `max` call_ref_t. Returns the count, or -1 if tree-sitter is unavailable, has no
+ * grammar for `ext`, or does not extract calls for that language (the caller then falls
+ * back to the hand-rolled extract_calls). */
+int code_treesitter_calls(const char *ext, const char *content, call_ref_t *out, int max);
 
 #endif /* DEC_CODE_TREESITTER_H */

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -255,6 +255,11 @@ int main(void)
    wantcall(".rs", "fn f(){ g(); h::k(); }\n", "f", "k");   /* scoped -> last */
    wantcall(".java", "class C{ void f(){ g(); obj.m(); } }\n", "f", "m");
    wantcall(".cs", "class C{ void F(){ G(); o.M(); } }\n", "F", "M");
+   /* generic/template calls resolve to the method name, not a type argument. */
+   wantcall(".cs", "class C{ void F(){ provider.GetService<IFoo>(); } }\n", "F", "GetService");
+   wantcall(".cs", "class C{ void F(){ var x = new List<Bar>(); } }\n", "F", "List");
+   wantcall(".cpp", "void f(){ obj.run<T>(y); }\n", "f", "run");
+   wantcall(".rs", "fn f(){ parse::<u32>(); }\n", "f", "parse"); /* turbofish */
    wantcall(".php", "<?php\nfunction f(){ g(); $o->m(); }\n", "f", "m");
    wantcall(".rb", "def f\n  g()\n  obj.m\nend\n", "f", "m"); /* g() w/ parens + obj.m */
    wantcall(".swift", "func f(){ g(); obj.m() }\n", "f", "g");

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -30,6 +30,25 @@ static void want(const char *ext, const char *src, const char *name, const char 
    }
 }
 
+/* Parse `src` as `ext` and assert a (caller -> callee) call edge was extracted. */
+static void wantcall(const char *ext, const char *src, const char *caller, const char *callee)
+{
+   call_ref_t c[128];
+   int n = code_treesitter_calls(ext, src, c, 128);
+   int found = 0;
+   for (int i = 0; i < n; i++)
+      if (strcmp(c[i].caller, caller) == 0 && strcmp(c[i].callee, callee) == 0)
+         found = 1;
+   if (n < 0 || !found)
+   {
+      printf("  FAIL %s: want [%s->%s], got %d:", ext, caller, callee, n);
+      for (int i = 0; i < n; i++)
+         printf(" [%s->%s]", c[i].caller, c[i].callee);
+      printf("\n");
+      assert(0);
+   }
+}
+
 int main(void)
 {
    printf("test_code_treesitter:\n");
@@ -222,6 +241,34 @@ int main(void)
 
    /* a vendored-but-unmapped ext -> -1 (caller falls back to the hand-rolled extractor). */
    assert(code_treesitter_definitions(".md", c_src, d, 64) == -1);
+
+   /* === call edges (caller -> callee), tracking the enclosing function. The callee is
+    * the last identifier of the callee expression (`obj.m()` -> m, `a::b()` -> b). === */
+   wantcall(".c", "void f(){ g(); obj->m(); }\n", "f", "g");
+   wantcall(".c", "void f(){ obj->m(); }\n", "f", "m"); /* method call -> last id */
+   wantcall(".py", "def f():\n    g()\n    obj.m()\n", "f", "g");
+   wantcall(".py", "def f():\n    obj.m()\n", "f", "m");
+   wantcall(".js", "function f(){ g(); a.b.c(); }\n", "f", "g");
+   wantcall(".js", "function f(){ a.b.c(); }\n", "f", "c"); /* chained -> last id */
+   wantcall(".ts", "function f(){ svc.run(); }\n", "f", "run");
+   wantcall(".go", "func f(){ g(); pkg.H() }\n", "f", "H"); /* selector -> field */
+   wantcall(".rs", "fn f(){ g(); h::k(); }\n", "f", "k");   /* scoped -> last */
+   wantcall(".java", "class C{ void f(){ g(); obj.m(); } }\n", "f", "m");
+   wantcall(".cs", "class C{ void F(){ G(); o.M(); } }\n", "F", "M");
+   wantcall(".php", "<?php\nfunction f(){ g(); $o->m(); }\n", "f", "m");
+   wantcall(".rb", "def f\n  g()\n  obj.m\nend\n", "f", "m"); /* g() w/ parens + obj.m */
+   wantcall(".swift", "func f(){ g(); obj.m() }\n", "f", "g");
+   wantcall(".lua", "function f() g() end\n", "f", "g");
+   wantcall(".py", "top()\n", "", "top"); /* file-scope: empty caller */
+   /* caller tracking follows the enclosing function. */
+   wantcall(".c", "void outer(){ x(); }\nvoid inner(){ deep(); }\n", "inner", "deep");
+   /* Bash/CSS have no useful call extraction -> -1 (caller falls back). */
+   {
+      call_ref_t cc[8];
+      assert(code_treesitter_calls(".css", "a{color:red}\n", cc, 8) == -1);
+      assert(code_treesitter_calls(".sh", "f(){ g; }\n", cc, 8) == -1);
+      assert(code_treesitter_calls(".md", c_src, cc, 8) == -1); /* unmapped ext */
+   }
 
    printf("  all supported languages extracted (C/C++/C#/Python/Go/JS/TS/Rust/Java/"
           "Ruby/PHP/Lua/Bash/Swift/Kotlin/Dart/CSS)\n");


### PR DESCRIPTION
Polish item #2 — the big one. The tree-sitter front-end now extracts **call edges** (caller → callee), not just definitions.

## How
- New `code_treesitter_calls(ext, content, call_ref_t*, max)`: a caller-tracking walk over the parse tree. It descends function bodies (unlike definition extraction), attributing every call to its **enclosing function** (empty caller at file scope).
- The callee name is the **last identifier of the callee expression**, so `obj.m()` → `m`, `a::b::c()` → `c`, `pkg.H()` → `H` — handling member/selector/scoped/field call forms.
- Call node types covered across C, C++, C#, Python, Go, JS, TS, Rust, Java, Ruby, PHP, Lua, Swift, Kotlin, Dart. **Bash/CSS return -1** (no useful call extraction) so they defer to the hand-rolled scanners.
- Wired into `extractors.c` `extract_calls` (tree-sitter first, hand-rolled fallback), mirroring `extract_definitions`.

## Safety
- **Default build byte-identical** (1295896 B) — the stub returns -1; `extractors.o`'s new `code_treesitter_calls` reference resolves to the stub already linked everywhere.
- `unit-test-code-treesitter` asserts caller→callee edges across the languages, file-scope/empty-caller, nested-function caller tracking, and the Bash/CSS/unmapped → -1 fallback.

Known limitation: Ruby paren-less bare calls (`g` alone) are syntactically ambiguous with variable refs and aren't captured; `obj.m` and `g()` are. All node types probed empirically per grammar.