### PR TITLE
ci(kb): §2 tree-sitter — opt-in build+test CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -495,3 +495,29 @@ jobs:
           for f in compose.yaml compose.server.yaml compose.server-standalone.yaml compose.combined.yaml; do
             echo "::group::$f"; docker compose -f "$f" logs --tail=80 2>/dev/null || true; echo "::endgroup::"
           done
+
+  # §2 tree-sitter extraction front-end (opt-in). The default build compiles
+  # code_treesitter.c to a stub, so the other jobs never exercise the grammar
+  # path or unit-test-code-treesitter. This job builds AIMEE_TREESITTER=1 — which
+  # fetches the vendored grammars (scripts/fetch-treesitter.sh) and compiles them
+  # — and runs the opt-in test that parses real source in every supported language
+  # (definitions, nested members, and call edges).
+  treesitter:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Runner diagnostics
+        run: |
+          gcc --version 2>/dev/null | head -1 || true
+          git --version || true
+          df -h / | tail -1
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y -q gcc make git \
+            libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libpq-dev
+      - name: Build + run the opt-in tree-sitter test
+        run: |
+          cd src
+          make AIMEE_TREESITTER=1 build/obj/tests/unit-test-code-treesitter
+          ./build/obj/tests/unit-test-code-treesitter

--- a/src/Makefile
+++ b/src/Makefile
@@ -449,6 +449,10 @@ TS_VENDOR_OBJS = $(OBJDIR)/vendor/ts_runtime.o \
                  $(OBJDIR)/vendor/ts_dart.o $(OBJDIR)/vendor/ts_dart_scan.o \
                  $(OBJDIR)/vendor/ts_css.o $(OBJDIR)/vendor/ts_css_scan.o
 $(OBJDIR)/kb/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
+# code_treesitter.c includes tree_sitter/api.h, which the fetch produces — so on a cold
+# checkout the fetch must run before this object compiles. Order-only: trigger the fetch
+# if the headers are missing, but don't recompile just because lib.c is newer.
+$(OBJDIR)/kb/code_treesitter.o: | vendor/tree-sitter/lib/src/lib.c
 # Any missing vendored source triggers a single fetch of the whole set.
 vendor/tree-sitter/lib/src/lib.c \
 vendor/tree-sitter-c/src/parser.c \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1365,6 +1365,9 @@ $(TESTPREFIX)/unit-test-code-collect: $(OBJDIR)/tests/test_code_collect.o \
 ifdef AIMEE_TREESITTER
 TEST_TARGETS += $(TESTPREFIX)/unit-test-code-treesitter
 $(OBJDIR)/code_treesitter.o: C_FLAGS += -DAIMEE_TREESITTER -Ivendor/tree-sitter/lib/include
+# Order-only dep on a fetch target so a cold checkout fetches tree_sitter/api.h before
+# this object (which includes it) is compiled (see the same note in src/Makefile).
+$(OBJDIR)/code_treesitter.o: | vendor/tree-sitter/lib/src/lib.c
 $(TESTPREFIX)/unit-test-code-treesitter: $(OBJDIR)/tests/test_code_treesitter.o \
                                          $(OBJDIR)/code_treesitter.o \
                                          $(TS_VENDOR_OBJS) \


### PR DESCRIPTION
Polish item #3. Adds a CI job that exercises the §2 tree-sitter front-end, which the default build (a stub) otherwise never covers.

## What
- New `treesitter` job in `.github/workflows/ci.yml`: installs gcc/make/git, builds `make AIMEE_TREESITTER=1 build/obj/tests/unit-test-code-treesitter` (which fetches the vendored grammars via `scripts/fetch-treesitter.sh`), and runs the opt-in test.
- The test parses real source in all 16 supported languages and asserts definitions, **nested members**, and **call edges** — so a regression in any `classify_*` rule, the build wiring, or call extraction now fails CI instead of passing silently.
- Kept as a **separate job** so the grammar fetch (network) doesn't slow the main gates.

## Notes
- Relies on the fetch-rule fixes already merged (`../scripts` path + executable bit), so a fresh checkout fetches the grammars correctly.
- Validated locally: `make AIMEE_TREESITTER=1 build/obj/tests/unit-test-code-treesitter && ./build/obj/tests/unit-test-code-treesitter` → ALL PASS; YAML parses (13 jobs).