### PR TITLE
feat(kb): §6 post-checkout reindex hook + 'aimee index watch' command

### DIFF
--- a/docs/proposals/pending/code-graph-intelligence.md
+++ b/docs/proposals/pending/code-graph-intelligence.md
@@ -274,16 +274,21 @@ embedder — integration/deploy-tier) as a third fused signal.
   `kb_runtime_state`; unchanged + non-`force` → `{"skipped":true}` (`unit-test-code-collect`
   exercises the SHA-tracks-commits + gate logic against real git repos).
 
-  **Status — post-merge hook shipped.** `code_index_install_branch_hook` writes a
-  marker-guarded `post-merge` git hook (mirroring `verify_install_git_hook`; won't
-  clobber a foreign hook) that backgrounds `aimee index scan <project> <root>`, so a
-  pull/merge advancing the default branch re-indexes the graph — and the SHA gate above
-  makes that a cheap no-op when nothing moved. Opt-in via `/v1/code/scan
-  {install_hook:true}` (so `workspace add` can enable live reindex); best-effort, never
-  failing the scan. Tested against real git repos (`test_install_branch_hook`) + the
-  route (`test_code_scan_installs_hook`). §6 live is now end-to-end: **detect** (SHA
-  gate) → **fire** (hook) → **rebuild** (§1 drain). A fanotify/inotify watch for
-  non-git or always-on freshness remains an optional follow-up.
+  **Status — post-merge + post-checkout hooks shipped.** `code_index_install_branch_hook`
+  writes marker-guarded `post-merge` **and** `post-checkout` git hooks (mirroring
+  `verify_install_git_hook`; won't clobber a foreign hook, O_NOFOLLOW) that background
+  `aimee index scan <project> <root>`, so a pull/merge **or branch switch** advancing the
+  default branch re-indexes the graph — and the SHA gate above makes that a cheap no-op
+  when nothing moved (the post-checkout hook reindexes only on a branch switch, `$3==1`,
+  not a per-file checkout). Two entry points: the server-side `/v1/code/scan
+  {install_hook:true}` (so `workspace add` can enable live reindex), and the client-side
+  `aimee index watch <name> <root>` — a local command, the correct path when the repo
+  lives on the client (a remote server can't write the client's `.git/hooks`). Best-effort,
+  never failing the scan. Tested against real git repos (`test_install_branch_hook`
+  asserts both hooks + the branch-switch gate) + the route (`test_code_scan_installs_hook`).
+  §6 live is now end-to-end: **detect** (SHA gate) → **fire** (hook) → **rebuild** (§1
+  drain). A fanotify/inotify watch for non-git or always-on freshness remains an optional
+  follow-up.
 - **Fuse the graph with conversation memory + the decision log** so the "why" behind
   a symbol is the *actual recorded reasoning*, not just parsed comments — queryable
   via §5. This is the thing a regenerated artifact can never hold.

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1446,10 +1446,12 @@ static int cli_claude_proxy(int argc, char **argv)
    return 0;
 }
 
+#ifdef AIMEE_POSIX
 /* `aimee index watch <name> <root>`: a client-LOCAL command (no /v1 route) that installs
  * git post-merge + post-checkout hooks so the project re-indexes itself when its default
  * branch advances. The repo + the dev's git live on this host, so the install must happen
- * client-side; the hooks invoke `aimee index scan` (which does route to the server). */
+ * client-side; the hooks invoke `aimee index scan` (which does route to the server).
+ * POSIX-only — code_index_install_branch_hook (git hooks) is not built on Windows. */
 static int cli_index_watch(int argc, char **argv, int json_output)
 {
    if (argc < 2)
@@ -1479,6 +1481,7 @@ static int cli_index_watch(int argc, char **argv, int json_output)
               root);
    return rc == 0 ? 0 : 1;
 }
+#endif /* AIMEE_POSIX */
 
 int main(int argc, char **argv)
 {
@@ -1810,10 +1813,12 @@ int main(int argc, char **argv)
    if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "serve") == 0)
       return cmd_workspace_serve(sub_argc >= 2 ? sub_argv[1] : NULL);
 
+#ifdef AIMEE_POSIX
    /* `index watch` installs git hooks on the LOCAL repo — a filesystem op with no server
-    * round-trip, so it is handled client-side before the /v1 routing. */
+    * round-trip, so it is handled client-side before the /v1 routing (POSIX-only). */
    if (strcmp(cmd, "index") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "watch") == 0)
       return cli_index_watch(sub_argc - 1, sub_argv + 1, json_output);
+#endif
 
    /* Thin-client workspace push: against a remote (tcp) server the workspace
     * root lives on THIS host, which the server cannot read. Resolve + register +

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -14,6 +14,7 @@
 #include "cli_profile.h"
 #include "client_constants.h"
 #include "client_integrations.h"
+#include "code_collect.h" /* code_index_install_branch_hook (index watch) */
 #include "delegate_plan.h"
 #include "cli_tui.h"
 #include "platform.h"
@@ -1445,6 +1446,40 @@ static int cli_claude_proxy(int argc, char **argv)
    return 0;
 }
 
+/* `aimee index watch <name> <root>`: a client-LOCAL command (no /v1 route) that installs
+ * git post-merge + post-checkout hooks so the project re-indexes itself when its default
+ * branch advances. The repo + the dev's git live on this host, so the install must happen
+ * client-side; the hooks invoke `aimee index scan` (which does route to the server). */
+static int cli_index_watch(int argc, char **argv, int json_output)
+{
+   if (argc < 2)
+   {
+      fprintf(stderr, "usage: aimee index watch <name> <root>\n"
+                      "  Install post-merge + post-checkout git hooks that re-index the\n"
+                      "  project whenever a merge/pull or branch switch advances the default\n"
+                      "  branch (the scan no-ops cheaply when the branch SHA is unchanged).\n");
+      return 1;
+   }
+   const char *name = argv[0], *root = argv[1];
+   int rc = code_index_install_branch_hook(root, name);
+   if (json_output)
+   {
+      printf("{\"status\":\"%s\"}\n", rc == 0 ? "ok" : "error");
+      return rc == 0 ? 0 : 1;
+   }
+   if (rc == 0)
+      printf("==> Installed git hooks (post-merge, post-checkout) — '%s' re-indexes when %s's "
+             "default branch advances\n",
+             name, root);
+   else if (rc == -2)
+      fprintf(stderr, "aimee: a non-aimee git hook is already present in %s — left untouched\n",
+              root);
+   else
+      fprintf(stderr, "aimee: could not install git hooks in %s (not a git repo or unwritable)\n",
+              root);
+   return rc == 0 ? 0 : 1;
+}
+
 int main(int argc, char **argv)
 {
    /* Ignore SIGPIPE so write() to a dead aimee-server socket returns EPIPE
@@ -1774,6 +1809,11 @@ int main(int argc, char **argv)
     * not a single forwarded /v1 call, so it is driven here rather than via a route. */
    if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "serve") == 0)
       return cmd_workspace_serve(sub_argc >= 2 ? sub_argv[1] : NULL);
+
+   /* `index watch` installs git hooks on the LOCAL repo — a filesystem op with no server
+    * round-trip, so it is handled client-side before the /v1 routing. */
+   if (strcmp(cmd, "index") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "watch") == 0)
+      return cli_index_watch(sub_argc - 1, sub_argv + 1, json_output);
 
    /* Thin-client workspace push: against a remote (tcp) server the workspace
     * root lives on THIS host, which the server cannot read. Resolve + register +

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -294,12 +294,69 @@ int code_index_source_is_worktree(void)
    return mode && strcmp(mode, "worktree") == 0;
 }
 
-/* §6 live: install a `post-merge` git hook in `project_root` that re-indexes
- * `project_name` after a merge/pull advances the default branch. The hook backgrounds
- * `aimee index scan` (so it never blocks the merge); the §6 SHA gate makes that a cheap
- * no-op unless the canonical code actually moved. Idempotent + non-clobbering: an
- * existing aimee hook is overwritten, a foreign hook is left alone (-2). Returns 0 on
- * success, -1 on error (not a git repo, unwritable), -2 if a non-aimee hook is present. */
+/* Write one reindex git hook (`hook_name`) in `hooks_dir` that backgrounds
+ * `aimee index scan <qname> <qroot>` (already shell-quoted). A post-checkout hook
+ * (`is_checkout`) reindexes only on a branch switch ($3 == 1), not a per-file checkout.
+ * Idempotent + non-clobbering (a foreign hook is left alone), O_NOFOLLOW against a planted
+ * symlink. Returns 0 on success, -1 on error, -2 if a non-aimee hook is present. */
+static int write_reindex_hook(const char *hooks_dir, const char *hook_name, const char *qname,
+                              const char *qroot, int is_checkout)
+{
+   char hook_path[MAX_PATH_LEN];
+   snprintf(hook_path, sizeof(hook_path), "%s/%s", hooks_dir, hook_name);
+
+   struct stat st;
+   if (stat(hook_path, &st) == 0)
+   {
+      FILE *fc = fopen(hook_path, "r");
+      if (fc)
+      {
+         char buf[256];
+         int ours = 0;
+         while (fgets(buf, sizeof(buf), fc))
+            if (strstr(buf, "installed by aimee"))
+            {
+               ours = 1;
+               break;
+            }
+         fclose(fc);
+         if (!ours)
+            return -2; /* a foreign hook — don't clobber it */
+      }
+   }
+
+   /* O_NOFOLLOW: refuse to write THROUGH a symlinked hook (defense-in-depth against a
+    * planted symlink redirecting the write outside the repo). */
+   int fd = open(hook_path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0755);
+   if (fd < 0)
+      return -1;
+   FILE *f = fdopen(fd, "w");
+   if (!f)
+   {
+      close(fd);
+      return -1;
+   }
+   fprintf(f, "#!/bin/sh\n");
+   fprintf(f, "# %s hook -- installed by aimee (live code-graph reindex)\n", hook_name);
+   fprintf(f, "# Re-index this project when the default branch advances; the scan no-ops\n");
+   fprintf(f, "# cheaply when the branch SHA is unchanged. Backgrounded so it never blocks.\n");
+   if (is_checkout)
+      fprintf(f, "[ \"$3\" = \"1\" ] || exit 0\n"); /* post-checkout: branch switch only */
+   fprintf(f, "if command -v aimee >/dev/null 2>&1; then\n");
+   fprintf(f, "    aimee index scan %s %s >/dev/null 2>&1 &\n", qname, qroot);
+   fprintf(f, "fi\n");
+   fclose(f);
+
+   chmod(hook_path, 0755);
+   return 0;
+}
+
+/* §6 live: install `post-merge` + `post-checkout` git hooks in `project_root` that
+ * re-index `project_name` when a merge/pull or branch switch advances the default branch.
+ * Each backgrounds `aimee index scan` (so it never blocks git); the §6 SHA gate makes that
+ * a cheap no-op unless the canonical code actually moved. Idempotent + non-clobbering: an
+ * existing aimee hook is overwritten, a foreign hook is left alone. Returns 0 on success,
+ * -1 on error (not a git repo, unwritable), -2 if a non-aimee hook is present. */
 int code_index_install_branch_hook(const char *project_root, const char *project_name)
 {
    if (!project_root || !project_root[0] || !project_name || !project_name[0])
@@ -322,56 +379,18 @@ int code_index_install_branch_hook(const char *project_root, const char *project
    if (mkdir(hooks_dir, 0755) != 0 && errno != EEXIST)
       return -1;
 
-   char hook_path[MAX_PATH_LEN];
-   snprintf(hook_path, sizeof(hook_path), "%s/post-merge", hooks_dir);
-
-   struct stat st;
-   if (stat(hook_path, &st) == 0)
-   {
-      FILE *fc = fopen(hook_path, "r");
-      if (fc)
-      {
-         char buf[256];
-         int ours = 0;
-         while (fgets(buf, sizeof(buf), fc))
-            if (strstr(buf, "installed by aimee"))
-            {
-               ours = 1;
-               break;
-            }
-         fclose(fc);
-         if (!ours)
-            return -2; /* a foreign post-merge hook — don't clobber it */
-      }
-   }
-
    char qname[1024], qroot[MAX_PATH_LEN + 16];
    if (shquote(project_name, qname, sizeof(qname)) != 0 ||
        shquote(project_root, qroot, sizeof(qroot)) != 0)
       return -1;
 
-   /* O_NOFOLLOW: refuse to write THROUGH a symlinked post-merge (defense-in-depth
-    * against a planted symlink redirecting the write outside the repo). */
-   int fd = open(hook_path, O_WRONLY | O_CREAT | O_TRUNC | O_NOFOLLOW, 0755);
-   if (fd < 0)
+   int rc_merge = write_reindex_hook(hooks_dir, "post-merge", qname, qroot, 0);
+   int rc_checkout = write_reindex_hook(hooks_dir, "post-checkout", qname, qroot, 1);
+   /* Report a foreign hook (the other may still have installed); else any error. */
+   if (rc_merge == -2 || rc_checkout == -2)
+      return -2;
+   if (rc_merge != 0 || rc_checkout != 0)
       return -1;
-   FILE *f = fdopen(fd, "w");
-   if (!f)
-   {
-      close(fd);
-      return -1;
-   }
-   fprintf(f, "#!/bin/sh\n");
-   fprintf(f, "# post-merge hook -- installed by aimee (live code-graph reindex)\n");
-   fprintf(f, "# Re-index this project after a merge/pull advances the default branch; the\n");
-   fprintf(f, "# scan no-ops cheaply when the branch SHA is unchanged. Backgrounded so it\n");
-   fprintf(f, "# never blocks the merge.\n");
-   fprintf(f, "if command -v aimee >/dev/null 2>&1; then\n");
-   fprintf(f, "    aimee index scan %s %s >/dev/null 2>&1 &\n", qname, qroot);
-   fprintf(f, "fi\n");
-   fclose(f);
-
-   chmod(hook_path, 0755);
    return 0;
 }
 

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -317,7 +317,20 @@ static void test_install_branch_hook(void)
    assert(strstr(body, "&")); /* backgrounded */
    free(body);
 
-   /* idempotent: re-installing our own hook succeeds. */
+   /* post-checkout is installed too, gated so only a branch switch ($3 == 1) reindexes. */
+   char co[2048];
+   snprintf(co, sizeof(co), "%s/.git/hooks/post-checkout", g_root);
+   struct stat cst;
+   assert(stat(co, &cst) == 0);
+   assert(cst.st_mode & S_IXUSR);
+   char *cbody = read_file(co);
+   assert(cbody);
+   assert(strstr(cbody, "installed by aimee"));
+   assert(strstr(cbody, "aimee index scan 'proj-alpha'"));
+   assert(strstr(cbody, "\"$3\" = \"1\"")); /* branch-switch gate */
+   free(cbody);
+
+   /* idempotent: re-installing our own hooks succeeds. */
    assert(code_index_install_branch_hook(g_root, "proj-alpha") == 0);
 
    /* a foreign hook is not clobbered (-2). */


### PR DESCRIPTION
Polish item #5 (the §6 always-on watch — the agent-host-completable parts; the fanotify daemon stays deploy-gated).

## Post-checkout hook
The §6 live-reindex installer wrote only a `post-merge` hook, so switching branches — which can move the default branch the graph is built from — didn't trigger a reindex. It now writes **both** `post-merge` and `post-checkout` via a shared `write_reindex_hook` helper (idempotent, non-clobbering, `O_NOFOLLOW`). The post-checkout hook reindexes only on a real **branch switch** (`$3 == 1`), not a per-file checkout.

## `aimee index watch <name> <root>`
An explicit client-side entry point that installs the hooks on the **local** repo. This is the correct path when the repo lives on the client — a remote server can't write the client's `.git/hooks`, so the existing server-side `/v1/code/scan {install_hook:true}` route only covers the local-UDS case. Handled in `cli_main` before /v1 routing (a filesystem op, no server round-trip), mirroring `workspace serve`.

## Tests / validation
- `test_install_branch_hook` now asserts **both** hooks install, are executable, carry the marker + backgrounded scan, and that post-checkout has the branch-switch gate.
- Validated end-to-end: `aimee index watch` installs both hooks, is idempotent, and fails cleanly on a non-git dir.

The fanotify/inotify continuous watch (for non-git or always-on freshness) remains the deploy-gated follow-up.