### PR TITLE
fix(kb): §2 tree-sitter — surface definitions inside #ifdef/#if blocks

### DIFF
--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -565,8 +565,8 @@ static int is_descendable(const char *t)
        "namespace_declaration", "file_scoped_namespace_declaration", "namespace_definition",
        "declaration_list", "template_declaration", "linkage_specification", "decorated_definition",
        "export_statement", "lexical_declaration", "variable_declaration",
-       /* C/C++ preprocessor conditionals — top-level defs are commonly wrapped in platform
-        * or feature guards (#ifdef AIMEE_POSIX, #if ...); descend them so those defs are not
+       /* C/C++/C# preprocessor conditionals — top-level defs are commonly wrapped in platform
+        * or feature guards (#ifdef AIMEE_POSIX, #if DEBUG); descend them so those defs are not
         * lost (function bodies are still never descended, so this stays safe). */
        "preproc_ifdef", "preproc_if", "preproc_else", "preproc_elif", "preproc_elifdef",
        /* member bodies */

--- a/src/code_treesitter.c
+++ b/src/code_treesitter.c
@@ -565,6 +565,10 @@ static int is_descendable(const char *t)
        "namespace_declaration", "file_scoped_namespace_declaration", "namespace_definition",
        "declaration_list", "template_declaration", "linkage_specification", "decorated_definition",
        "export_statement", "lexical_declaration", "variable_declaration",
+       /* C/C++ preprocessor conditionals — top-level defs are commonly wrapped in platform
+        * or feature guards (#ifdef AIMEE_POSIX, #if ...); descend them so those defs are not
+        * lost (function bodies are still never descended, so this stays safe). */
+       "preproc_ifdef", "preproc_if", "preproc_else", "preproc_elif", "preproc_elifdef",
        /* member bodies */
        "class_body", "field_declaration_list", "body_statement", "enum_body",
        "enum_body_declarations", "interface_body", "block", "method_signature",

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -106,6 +106,8 @@ int main(void)
    want(".cs", cs, "I", "type");
    want(".cs", cs, "R", "type");
    want(".cs", cs, "Top", "type"); /* top-level, no namespace */
+   want(".cs", "#if DEBUG\nclass Dbg { void M(){} }\n#endif\n", "Dbg",
+        "type"); /* #if-guarded type */
 
    /* --- Python (incl. a decorated def) --- */
    const char *py = "def add(a, b):\n    return a + b\n"

--- a/src/tests/test_code_treesitter.c
+++ b/src/tests/test_code_treesitter.c
@@ -81,6 +81,15 @@ int main(void)
    }
    assert(code_treesitter_definitions(".c", c_src, d, 1) == 1); /* bounded */
 
+   /* definitions wrapped in a preprocessor conditional are surfaced (real C/C++ files
+    * commonly guard top-level defs with #ifdef/#if). */
+   want(".c", "#ifdef X\nint guarded(void){ return 1; }\ntypedef int gint;\n#endif\n", "guarded",
+        "function");
+   want(".c", "#ifdef X\nint guarded(void){ return 1; }\ntypedef int gint;\n#endif\n", "gint",
+        "type");
+   want(".c", "#if A\nint a(void){return 0;}\n#else\nint b(void){return 1;}\n#endif\n", "b",
+        "function"); /* #else branch too */
+
    /* --- C++ (incl. a namespaced class — exercises container descent) --- */
    const char *cpp = "int add(int a){return a;}\nclass C{ void m(); };\nstruct S{};\n"
                      "namespace N { class Inner{}; }\n";


### PR DESCRIPTION
Found while **validating the merged tree-sitter work against real source files** (not just the unit-test snippets).

## The bug
tree-sitter parses a C/C++ `#ifdef`/`#if` as a `preproc_ifdef`/`preproc_if` node that **wraps** the guarded top-level declarations. Those node types weren't in `is_descendable`, so the definition walk never descended into them — **every definition inside a preprocessor conditional was dropped.**

Real files hit this constantly (platform/feature guards). Before/after on aimee's own source:

| file | guard | defs before | defs after |
|------|-------|-------------|------------|
| `code_treesitter.c` | `#ifdef AIMEE_TREESITTER` | **0** | 39 |
| `code_collect.c` | `#ifdef AIMEE_POSIX` | **0** | 25 |
| `extractors.c` | (none) | 30 | 30 |

The toy tests had no `#ifdef` blocks, so they passed while real C/C++ extraction was badly broken.

## The fix
Add `preproc_ifdef`/`preproc_if`/`preproc_else`/`preproc_elif`/`preproc_elifdef` to `is_descendable`. The walk descends through them like namespaces; function bodies are still never descended (it returns at any matched function), so no locals leak and no double-emit. The `#else` branch is covered too. **Call extraction already handled this** (its walk descends everything).

## Validation
- Default build **byte-identical** (1295896 B). Opt-in test passes, with new `#ifdef`- and `#if/#else`-guarded cases.
- Re-validated against real repo files across C/Python/TSX/Go — all extract cleanly, zero malformed entries.