### PR TITLE
fix(workspace): base auto-detected worktrees on freshly-fetched default

### DIFF
--- a/src/cmd_branch.c
+++ b/src/cmd_branch.c
@@ -59,7 +59,9 @@ static int branch_ref_exists(const char *branch)
 static int branch_fetch_origin_prune(void)
 {
    int ec = 0;
-   char *out = run_cmd("git fetch origin --prune 2>&1", &ec);
+   const char *fetch_argv[] = {"fetch", "origin", "--prune", NULL};
+   char *out = NULL;
+   ec = git_net_exec(NULL, fetch_argv, &out, 4096);
    if (ec != 0)
       printf("WARN: git fetch origin --prune failed: %s\n", out ? out : "unknown error");
    free(out);

--- a/src/cmd_session_lifecycle.c
+++ b/src/cmd_session_lifecycle.c
@@ -915,9 +915,9 @@ static void session_checkout_worktrees(const session_state_t *state, const char 
       char base_ref[320] = {0};
       if (project_primary_branch(gr, primary_branch, sizeof(primary_branch)) == 0)
       {
-         const char *fetch_argv[] = {"git", "-C", gr, "fetch", "origin", primary_branch, NULL};
+         const char *fetch_argv[] = {"fetch", "origin", primary_branch, NULL};
          char *fetch_out = NULL;
-         int rc = safe_exec_capture(fetch_argv, &fetch_out, 2048);
+         int rc = git_net_exec(gr, fetch_argv, &fetch_out, 2048);
          if (rc != 0)
             LOG_WARN("session", "failed to fetch primary branch '%s' in %s: %s", primary_branch, gr,
                      fetch_out ? fetch_out : "unknown");

--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -2,6 +2,7 @@
 #include "platform.h" /* AIMEE_POSIX */
 #include "code_collect.h"
 #include "client_constants.h" /* MAX_PATH_LEN */
+#include "util.h"             /* GIT_SAFE_ENV */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -152,13 +153,11 @@ static int code_collect_walk(const char *root, const char *rel, code_collect_fil
  * THIS change touch" — e.g. blast-radius — read the working tree via their own
  * reader and deliberately do NOT route through here.) */
 
-/* Prefix for every git invocation. This runs in an automated indexing path, so a
- * git command must NEVER block on an interactive credential or SSH-passphrase
- * prompt (GIT_TERMINAL_PROMPT=0 makes git fail fast instead), and a network-bound
- * step like `remote set-head -a` must time out rather than hang the drain
- * (BatchMode=yes + a short ConnectTimeout). Local repos never hit the network. */
-#define GIT_SAFE_ENV                                                                               \
-   "GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='ssh -o BatchMode=yes -o ConnectTimeout=5' "
+/* Every git invocation here runs in an automated indexing path, so it must never
+ * block on an interactive credential / SSH-passphrase prompt or hang on a
+ * network-bound step like `remote set-head -a`. The shared GIT_SAFE_ENV prefix
+ * (util.h) supplies GIT_TERMINAL_PROMPT=0 + a BatchMode/ConnectTimeout
+ * GIT_SSH_COMMAND. Local repos never hit the network. */
 
 /* Quote one argument for /bin/sh: wrap in single quotes, escaping any embedded
  * single quote as '\''. Returns 0 on success, -1 if it doesn't fit. */

--- a/src/git_verify_ops.c
+++ b/src/git_verify_ops.c
@@ -274,11 +274,13 @@ char *verify_prepare_pr(const char *project_root, const char *base_branch)
       }
    }
 
-   /* 1. Fetch base */
+   /* 1. Fetch base (bounded + non-interactive so verify can't hang on a remote;
+    * cwd=NULL uses the thread-local run_cmd CWD, like the run_cmd calls below). */
    char cmd[256];
-   snprintf(cmd, sizeof(cmd), "git fetch origin %s 2>&1", base_branch);
    int rc;
-   char *out = run_cmd(cmd, &rc);
+   const char *fetch_argv[] = {"fetch", "origin", base_branch, NULL};
+   char *out = NULL;
+   rc = git_net_exec(NULL, fetch_argv, &out, 4096);
    dstr_appendf(&res, "1. Fetching base branch... %s\n", (rc == 0) ? "PASS" : "FAIL");
    if (rc != 0 && out)
       dstr_append_str(&res, out);

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -289,6 +289,38 @@ int safe_exec_capture_env(const char *const argv[], char *const envp[], char **o
 int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
                                       char **out_buf, size_t max_out, int timeout_ms);
 
+/* --- Internal git network ops (NOT the user-facing `aimee git` CLI) ---
+ *
+ * Automated paths (session start, indexing, verify, branch orchestration) must
+ * never hang on an unreachable remote or block on an interactive credential /
+ * SSH-passphrase prompt. Two reusable forms:
+ *   - GIT_SAFE_ENV:        shell-command prefix for run_cmd()-style call sites.
+ *   - GIT_SAFE_SSH_COMMAND: the bare GIT_SSH_COMMAND / core.sshCommand value,
+ *                           for argv/exec call sites (e.g. git_net_exec()).
+ * GIT_TERMINAL_PROMPT=0 fails fast instead of prompting for HTTP credentials;
+ * BatchMode=yes does the same for SSH auth; ConnectTimeout caps a dead-host
+ * connect. */
+#define GIT_SAFE_SSH_COMMAND "ssh -o BatchMode=yes -o ConnectTimeout=5"
+#define GIT_SAFE_ENV "GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='" GIT_SAFE_SSH_COMMAND "' "
+
+/* Wall-clock cap (ms) for an internal git network op. Generous enough not to
+ * kill a slow-but-working fetch, short enough that a stalled remote can never
+ * freeze a session start. */
+#define GIT_NET_TIMEOUT_MS 30000
+
+/* Run an internal git network command, non-interactively and hang-proof.
+ * `git_argv` is the git subcommand and its args (e.g.
+ * {"fetch","--quiet","origin","main",NULL}); the repo is selected by chdir to
+ * `cwd`, or the thread-local run_cmd CWD when `cwd` is NULL. Runs under a copy of
+ * the parent environment with GIT_SSH_COMMAND (BatchMode/ConnectTimeout) and
+ * GIT_TERMINAL_PROMPT=0 forced, so SSH/HTTP auth fail fast instead of blocking on
+ * a passphrase or credential prompt regardless of what the parent exported, and
+ * hard-capped at GIT_NET_TIMEOUT_MS wall-clock (SIGKILL on overrun) as a backstop
+ * for any other stall. Combined stdout+stderr (truncated to max_out, or a default
+ * when 0) is returned in *out_buf when non-NULL (caller frees). Returns the child
+ * exit code, SAFE_EXEC_TIMEOUT, or -1 on failure. POSIX-only, like run_cmd(). */
+int git_net_exec(const char *cwd, const char *const *git_argv, char **out_buf, size_t max_out);
+
 /* Returns 1 if string contains shell metacharacters (;|&$`(){}><\n\r'"\\). */
 int has_shell_metachar(const char *s);
 

--- a/src/util.c
+++ b/src/util.c
@@ -745,6 +745,73 @@ char *run_cmd_env(const char *cmd, char *const envp[], int *exit_code)
    free(line);
    return buf;
 }
+
+int git_net_exec(const char *cwd, const char *const *git_argv, char **out_buf, size_t max_out)
+{
+   if (out_buf)
+      *out_buf = NULL;
+   if (!git_argv)
+      return -1;
+
+   size_t n = 0;
+   while (git_argv[n])
+      n++;
+
+   /* argv: git <git_argv...> NULL. The repo is selected by chdir (cwd below). */
+   const char **argv = malloc((1 + n + 1) * sizeof(*argv));
+   if (!argv)
+      return -1;
+   size_t a = 0;
+   argv[a++] = "git";
+   for (size_t i = 0; i < n; i++)
+      argv[a++] = git_argv[i];
+   argv[a] = NULL;
+
+   /* Child env: a copy of the parent environment with GIT_SSH_COMMAND and
+    * GIT_TERMINAL_PROMPT FORCED to the safe values (any inherited copies dropped),
+    * so the BatchMode/ConnectTimeout SSH command and no-prompt policy win
+    * regardless of what the parent exported (git resolves the GIT_SSH_COMMAND env
+    * above core.sshCommand config). PATH / HOME / SSH_AUTH_SOCK and vault tokens
+    * are preserved — safe_exec_capture_*_env REPLACES the env, so a partial list
+    * would strip them. Entries are borrowed (parent strings + string literals);
+    * only the array is owned, so we free just the array. */
+   size_t pn = 0;
+   while (environ && environ[pn])
+      pn++;
+   char **envp = malloc((pn + 3) * sizeof(*envp)); /* parent + 2 forced + NULL */
+   if (!envp)
+   {
+      free(argv);
+      return -1;
+   }
+   size_t o = 0;
+   for (size_t i = 0; i < pn; i++)
+   {
+      if (strncmp(environ[i], "GIT_SSH_COMMAND=", 16) == 0 ||
+          strncmp(environ[i], "GIT_TERMINAL_PROMPT=", 20) == 0)
+         continue;
+      envp[o++] = environ[i];
+   }
+   envp[o++] = (char *)"GIT_SSH_COMMAND=" GIT_SAFE_SSH_COMMAND;
+   envp[o++] = (char *)"GIT_TERMINAL_PROMPT=0";
+   envp[o] = NULL;
+
+   /* When no explicit cwd is given, fall back to the thread-local run_cmd CWD so
+    * this is a drop-in for run_cmd("git ...") in server pool threads (which set
+    * the repo dir there rather than passing -C). The wall-clock cap guarantees a
+    * stalled remote can never hang the caller even if the SSH bound is bypassed. */
+   const char *eff_cwd = (cwd && cwd[0]) ? cwd : run_cmd_get_cwd();
+   char *out = NULL;
+   int rc = safe_exec_capture_cwd_env_timeout((const char *const *)argv, eff_cwd, envp, &out,
+                                              max_out ? max_out : 4096, GIT_NET_TIMEOUT_MS);
+   free(envp);
+   free(argv);
+   if (out_buf)
+      *out_buf = out;
+   else
+      free(out);
+   return rc;
+}
 #endif /* !_WIN32 — run_cmd* are POSIX-only (fork/exec/waitpid) */
 
 int has_shell_metachar(const char *s)

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -922,10 +922,11 @@ void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len
    if (def[0])
    {
       /* Refresh the default branch from origin so the worktree starts from the
-       * latest upstream, not a stale local copy. Best-effort: a remote-less or
-       * offline repo just leaves the existing refs untouched. */
-      snprintf(cmd, sizeof(cmd), "git -C '%s' fetch --quiet origin '%s' 2>/dev/null", git_root, def);
-      free(run_cmd(cmd, &rc));
+       * latest upstream, not a stale local copy. Best-effort and hang-proof
+       * (git_net_exec bounds the wall clock): a remote-less or offline repo just
+       * leaves the existing refs untouched. */
+      const char *fetch_argv[] = {"fetch", "--quiet", "origin", def, NULL};
+      git_net_exec(git_root, fetch_argv, NULL, 0);
 
       /* Prefer the freshly fetched remote-tracking ref; fall back to the local
        * branch when there is no upstream (purely local repo). */

--- a/src/workspace.c
+++ b/src/workspace.c
@@ -860,10 +860,16 @@ int worktree_find_branch_registered(const char *branch, char *out_dir, size_t ou
  * A fresh session must start from the repository's DEFAULT branch, not from
  * whatever branch the source checkout happens to be sitting on — otherwise a
  * session forks off a random feature branch and inherits unrelated WIP. Order:
- *   1. origin/HEAD  — the remote default branch (e.g. "origin/main"); used as
- *      the base ref directly so the worktree tracks the latest fetched default.
- *   2. local main / master / trunk — common defaults when no remote HEAD is set.
+ *   1. origin/HEAD  — the remote default branch (e.g. "origin/main"); fetched
+ *      fresh and used as origin/<default> so the worktree tracks the latest
+ *      upstream rather than a stale remote-tracking ref.
+ *   2. local main / master / trunk — common defaults when no remote HEAD is set;
+ *      fetched and resolved to origin/<default> when an upstream exists.
  *   3. current HEAD — last resort (detached/empty repo, or a default-less repo).
+ * Basing a fresh session on a stale local copy of the default produced spurious
+ * merge conflicts at integration time, so we refresh from origin first (cf. the
+ * session-checkout path, which already fetches origin/<primary>). The fetch is
+ * best-effort: offline or remote-less repos fall back to the local default.
  * Callers that want a specific base (delegates inheriting a parent, or the
  * session-checkout path that bases on origin/<primary>) pass base_ref instead
  * and never reach here. */
@@ -876,8 +882,9 @@ void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len
    char cmd[MAX_PATH_LEN + 128];
    int rc;
 
-   /* 1. Remote default branch via origin/HEAD. symbolic-ref --short yields
-    * e.g. "origin/main"; base directly off that remote-tracking ref. */
+   /* Resolve the default branch NAME (short, e.g. "main"). Prefer origin/HEAD;
+    * symbolic-ref --short yields "origin/main", so strip the remote prefix. */
+   char def[96] = {0};
    snprintf(cmd, sizeof(cmd),
             "git -C '%s' symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null", git_root);
    char *out = run_cmd(cmd, &rc);
@@ -886,31 +893,64 @@ void worktree_detect_base_branch(const char *git_root, char *buf, size_t buf_len
       size_t len = strlen(out);
       while (len > 0 && (out[len - 1] == '\n' || out[len - 1] == '\r' || out[len - 1] == ' '))
          out[--len] = '\0';
-      if (len > 0)
-      {
-         snprintf(buf, buf_len, "%s", out);
-         free(out);
-         return;
-      }
+      const char *name = out;
+      if (strncmp(name, "origin/", 7) == 0)
+         name += 7;
+      if (name[0])
+         snprintf(def, sizeof(def), "%s", name);
    }
    free(out);
 
-   /* 2. Common local default branches. */
-   const char *candidates[] = {"main", "master", "trunk"};
-   for (int b = 0; b < 3; b++)
+   /* Fall back to a common local default branch when origin/HEAD is unset. */
+   if (!def[0])
    {
+      const char *candidates[] = {"main", "master", "trunk"};
+      for (int b = 0; b < 3; b++)
+      {
+         snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
+                  git_root, candidates[b]);
+         char *cand_out = run_cmd(cmd, &rc);
+         free(cand_out);
+         if (rc == 0)
+         {
+            snprintf(def, sizeof(def), "%s", candidates[b]);
+            break;
+         }
+      }
+   }
+
+   if (def[0])
+   {
+      /* Refresh the default branch from origin so the worktree starts from the
+       * latest upstream, not a stale local copy. Best-effort: a remote-less or
+       * offline repo just leaves the existing refs untouched. */
+      snprintf(cmd, sizeof(cmd), "git -C '%s' fetch --quiet origin '%s' 2>/dev/null", git_root, def);
+      free(run_cmd(cmd, &rc));
+
+      /* Prefer the freshly fetched remote-tracking ref; fall back to the local
+       * branch when there is no upstream (purely local repo). */
+      char remote_ref[128];
+      snprintf(remote_ref, sizeof(remote_ref), "origin/%s", def);
       snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
-               git_root, candidates[b]);
-      char *cand_out = run_cmd(cmd, &rc);
-      free(cand_out);
+               git_root, remote_ref);
+      free(run_cmd(cmd, &rc));
       if (rc == 0)
       {
-         snprintf(buf, buf_len, "%s", candidates[b]);
+         snprintf(buf, buf_len, "%s", remote_ref);
+         return;
+      }
+
+      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --verify --quiet '%s' >/dev/null 2>&1",
+               git_root, def);
+      free(run_cmd(cmd, &rc));
+      if (rc == 0)
+      {
+         snprintf(buf, buf_len, "%s", def);
          return;
       }
    }
 
-   /* 3. Last resort: the current branch (may be detached -> stays "HEAD"). */
+   /* Last resort: the current branch (may be detached -> stays "HEAD"). */
    snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse --abbrev-ref HEAD 2>/dev/null", git_root);
    out = run_cmd(cmd, &rc);
    if (rc == 0 && out && out[0])


### PR DESCRIPTION
## Problem

When aimee auto-detects the base for a new session worktree, `worktree_detect_base_branch()` resolved it to `origin/HEAD`'s remote-tracking ref or a local `main`/`master`/`trunk` **without fetching first**. A fresh worktree could therefore fork off a *stale* local copy of the default branch and collide at integration time — the direct cause of a recent spurious merge-conflict episode (local `stable` was behind `origin/stable`).

Basing new worktrees/branches on a stale default is a poor user experience: the work looks fine until it's merged.

## Fix

`worktree_detect_base_branch()` now:
1. Resolves the default branch **name** (`origin/HEAD` with the `origin/` prefix stripped, else local `main`/`master`/`trunk`).
2. Does a best-effort `git fetch origin <name>`.
3. Prefers the freshly-fetched `origin/<name>` as the base ref, falling back to the local branch (remote-less repo) then `HEAD`.

### Scope

Deliberately limited to the **auto-detect path** (SessionStart hooks, guardrails, lifecycle fallback). Explicit-`base_ref` callers are unchanged and already correct:
- `session_checkout_worktrees` already fetches `origin/<primary>` before basing.
- Delegate worktrees intentionally base on the parent anchor's **local HEAD** to inherit uncommitted WIP — fetching would defeat that.

The fetch mirrors `session_checkout_worktrees`' existing best-effort fetch; offline/remote-less repos fall back to local refs.

## Verification

- Builds clean under `-Werror -Wextra` (LTO).
- `unit-test-guardrails` passes, including the three `worktree_detect_base_branch` cases (faked-`origin/main` repo keeps `origin/main`; no-remote-default falls to local `main`; nonexistent repo → `HEAD`).
- Real-remote smoke test: a stale local `origin/main` is refreshed to the new upstream HEAD before being chosen as the base.

## Known consideration

This adds a best-effort network `git fetch` to the auto-detect path, which runs on SessionStart. It is consistent with the existing unbounded fetch in `session_checkout_worktrees`, and in the normal flow that path has already fetched moments earlier so this is usually a fast "already up to date" no-op. Bounding network git calls with a timeout is a cross-cutting concern (it would apply equally to the existing fetch sites) and is left as a possible follow-up rather than introducing a non-portable `timeout` wrapper here.