### PR TITLE
fix(client): auto-pin self-signed remote cert (no AIMEE_TLS_INSECURE needed)

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -752,7 +752,9 @@ aimee remote clear    # revert to a local Unix socket
 Precedence is `--server` flag > `AIMEE_SERVER_URL` env > persisted `remote.conf`.
 
 `https://` URLs are supported on Linux/macOS builds (OpenSSL), with certificate
-verification on by default; set `AIMEE_TLS_INSECURE=1` for self-signed/dev servers.
+verification on by default. For a self-signed/private server, `aimee remote set`
+pins its certificate on first use (trust-on-first-use) so verification then passes
+with no further configuration; `aimee remote trust` re-pins after a cert rotation.
 The Windows thin client is built without TLS and refuses `https://`; terminate TLS
 at a reverse proxy and use its `http://` address.
 
@@ -794,7 +796,7 @@ If a dependency is missing, `install.sh` stops and points you back at
 `install-deps.sh`. On **Windows**, aimee runs as the thin client only (server + kb
 run in Docker or on Linux/macOS): run `install.ps1`, point it at your server with
 `aimee remote set https://host:8743 <token>` (the server's `/v1` is TLS-only
-off-loopback with a self-signed cert, so set `AIMEE_TLS_INSECURE=1` or trust it),
+off-loopback with a self-signed cert, which `remote set` pins automatically),
 and run `configure-hooks.ps1`.
 
 The C services (`aimee`, `aimee-server`, `aimee-kb`) need no Go. The browser UI

--- a/src/aimee_client.c
+++ b/src/aimee_client.c
@@ -265,8 +265,8 @@ static char *tcp_request(const char *url, const char *token, const char *method,
    {
       fprintf(stderr,
               "aimee: refusing to send credentials over plaintext http:// to non-loopback host "
-              "'%s'. Use https:// (the server's TLS port); set AIMEE_TLS_INSECURE=1 if the server "
-              "presents a self-signed certificate.\n",
+              "'%s'. Use https:// (the server's TLS port) — `aimee remote set` pins a self-signed "
+              "certificate automatically.\n",
               host);
       return NULL;
    }
@@ -294,9 +294,9 @@ static char *tcp_request(const char *url, const char *token, const char *method,
       {
          if (!g_suppress_conn_errors)
             fprintf(stderr,
-                    "aimee: TLS handshake with %s failed (untrusted/self-signed cert?). "
-                    "Run `aimee remote trust` to pin this server's certificate, or set "
-                    "AIMEE_TLS_INSECURE=1 to skip verification.\n",
+                    "aimee: TLS handshake with %s failed (untrusted/self-signed cert, or the "
+                    "pinned cert was rotated). Run `aimee remote trust` to (re)pin this server's "
+                    "certificate.\n",
                     host);
          platform_net_close(fd);
          return NULL;

--- a/src/cli_remote.c
+++ b/src/cli_remote.c
@@ -14,10 +14,39 @@
 #ifdef _WIN32
 #include <direct.h>
 #define AIMEE_MKDIR(p) _mkdir(p)
+/* _putenv_s(k, "") removes the variable on MSVC. */
+#define AIMEE_UNSETENV(k)  _putenv_s((k), "")
+#define AIMEE_SETENV(k, v) _putenv_s((k), (v))
 #else
 #include <sys/stat.h>
-#define AIMEE_MKDIR(p) mkdir((p), 0700)
+#define AIMEE_MKDIR(p)     mkdir((p), 0700)
+#define AIMEE_UNSETENV(k)  unsetenv(k)
+#define AIMEE_SETENV(k, v) setenv((k), (v), 1)
 #endif
+
+/* Suspend AIMEE_TLS_INSECURE for the duration of trust establishment, returning the
+ * prior value (caller frees via tls_insecure_restore). Trust pinning must verify the
+ * server cert STRICTLY: with the env var set, the trust probe would "succeed"
+ * insecurely and skip pinning, leaving the client dependent on AIMEE_TLS_INSECURE
+ * forever instead of pinning the cert once. Forcing strict verification here makes a
+ * self-signed/private server get pinned (TOFU) regardless of a stray env var, so
+ * normal commands then need no flag. Returns NULL when it was unset/empty. */
+static char *tls_insecure_suspend(void)
+{
+   const char *v = getenv("AIMEE_TLS_INSECURE");
+   char *saved = (v && *v) ? strdup(v) : NULL;
+   AIMEE_UNSETENV("AIMEE_TLS_INSECURE");
+   return saved;
+}
+
+static void tls_insecure_restore(char *saved)
+{
+   if (saved)
+   {
+      AIMEE_SETENV("AIMEE_TLS_INSECURE", saved);
+      free(saved);
+   }
+}
 
 static void remote_conf_path(char *out, size_t out_sz)
 {
@@ -149,11 +178,14 @@ static int remote_set(const char *url, const char *token, int json_output)
 
    /* For an https remote, establish trust now so later commands need no
     * AIMEE_TLS_INSECURE flag. If it already verifies (publicly-trusted CA, or a
-    * previously pinned cert) we leave it alone; otherwise pin its cert (TOFU). */
+    * previously pinned cert) we leave it alone; otherwise pin its cert (TOFU).
+    * Verification is forced strict (env var suspended) so a self-signed/private
+    * server is always pinned even if AIMEE_TLS_INSECURE happens to be set. */
    int is_https = (strncmp(url, "https://", 8) == 0);
    int pinned = 0, verified = 0;
    if (is_https)
    {
+      char *saved_insecure = tls_insecure_suspend();
       aimee_client_set_remote(url, token && *token ? token : NULL);
       /* This first probe is expected to fail for a self-signed server (not pinned
        * yet); silence its diagnostic so a clean set doesn't look like an error. */
@@ -167,6 +199,7 @@ static int remote_set(const char *url, const char *token, int json_output)
          pinned = 1;
          verified = remote_health_ok(); /* re-probe against the pinned cert */
       }
+      tls_insecure_restore(saved_insecure);
    }
 
    if (json_output)
@@ -180,10 +213,10 @@ static int remote_set(const char *url, const char *token, int json_output)
          printf(pinned ? "  TLS: verified against the pinned certificate.\n"
                        : "  TLS: verified against the system trust store.\n");
       else if (is_https)
-         printf("  TLS: could not establish trust (server unreachable, or cert pinning is not "
-                "available on this platform).\n"
-                "       Start the server and re-run, use `aimee remote trust`, or set "
-                "AIMEE_TLS_INSECURE=1 to override.\n");
+         printf(
+             "  TLS: could not establish trust (server unreachable, or cert pinning is not "
+             "available on this platform).\n"
+             "       Start the server and re-run `aimee remote set`, or `aimee remote trust`.\n");
    }
    return 0;
 }
@@ -203,8 +236,10 @@ static int remote_trust(int json_output)
       fprintf(stderr, "aimee: remote %s is not https:// — no certificate to pin\n", url);
       return 1;
    }
+   char *saved_insecure = tls_insecure_suspend(); /* pin + verify strictly, see remote_set */
    if (remote_pin_cert(url, json_output) != 0)
    {
+      tls_insecure_restore(saved_insecure);
       fprintf(stderr,
               "aimee: could not fetch the server certificate (is %s reachable? is pinning "
               "supported on this platform?)\n",
@@ -213,6 +248,7 @@ static int remote_trust(int json_output)
    }
    aimee_client_set_remote(url, token[0] ? token : NULL);
    int verified = remote_health_ok();
+   tls_insecure_restore(saved_insecure);
    if (json_output)
       printf("{\"ok\":true,\"pinned\":true,\"verified\":%s}\n", verified ? "true" : "false");
    else

--- a/src/tests/test_cli_remote.c
+++ b/src/tests/test_cli_remote.c
@@ -86,6 +86,23 @@ static void test_set_creates_missing_home(void)
       setenv("AIMEE_HOME", saved, 1);
 }
 
+static void test_https_set_restores_insecure_env(void)
+{
+   reset_state();
+   /* `remote set` forces strict verification (suspends AIMEE_TLS_INSECURE) so a
+    * self-signed server is always pinned even when the env var is set. It must
+    * RESTORE the caller's env afterward — never permanently clobber it. Use an
+    * unresolvable https host: trust can't be established, but config still
+    * persists and the env var must come back. (Regression for the auto-pin fix.) */
+   setenv("AIMEE_TLS_INSECURE", "1", 1);
+   char *argv[] = {(char *)"set", (char *)"https://made-host.invalid:8799", (char *)"tok"};
+   assert(cli_remote_cmd(3, argv, 1) == 0); /* set always persists config */
+   const char *v = getenv("AIMEE_TLS_INSECURE");
+   assert(v && strcmp(v, "1") == 0); /* restored, not clobbered */
+   PASS("https remote set restores AIMEE_TLS_INSECURE");
+   unsetenv("AIMEE_TLS_INSECURE");
+}
+
 int main(void)
 {
    /* Isolate AIMEE_HOME so we never touch the real config. */
@@ -98,6 +115,7 @@ int main(void)
    test_env_wins_over_file();
    test_clear();
    test_set_creates_missing_home();
+   test_https_set_restores_insecure_env();
    printf("ALL PASS\n");
 
    /* Best-effort cleanup. */


### PR DESCRIPTION
## Problem

Pointing the thin client at a private/self-signed aimee-server was supposed to be invisible: `aimee remote set <url> <token>` pins the server cert to `<home>/remote-ca.pem` (trust-on-first-use), after which TLS verifies **strictly** against that pin with no env var. But the trust probe honored the ambient `AIMEE_TLS_INSECURE`: if that variable happened to be set when `remote set` ran, the probe "succeeded" insecurely → pinning was **skipped** → the client stayed permanently dependent on `AIMEE_TLS_INSECURE` for every later command. A user should never have to deal with that flag.

## Fix

- `remote_set` / `remote_trust` **suspend `AIMEE_TLS_INSECURE`** around the trust-establishment probe (portable macros for POSIX/Windows), forcing strict verification so a self-signed/private cert is **always** pinned regardless of the ambient env, then restore the var. The TOFU cert-fetch path is untouched (it never verifies).
- A real publicly-trusted CA cert is still **not** pinned (verifies on its own → nothing to pin), so rotation isn't broken.
- Drop `AIMEE_TLS_INSECURE` from user-facing messages/README in favor of `aimee remote set` / `aimee remote trust`. The env var remains only as an internal/test escape hatch.

## Result

After `aimee remote set https://host:8743 <token>`, all commands work over fully-verified TLS with **zero** env var — verified live against a self-signed `.254` deployment.

## Test

Adds `test_https_set_restores_insecure_env` (regression: the env var is restored, never clobbered, on the trust-failure path). `make WITH_TLS=1 unit-test-cli-remote` passes; clang-format-19 clean.