### PR TITLE
fix(llm): recover synth from GPU device-lost (auto-restart the container)

### DIFF
--- a/scripts/aimee_llm_gateway.py
+++ b/scripts/aimee_llm_gateway.py
@@ -303,6 +303,86 @@ def do_rerank(obj):
 
 _synth_breaker = CircuitBreaker()
 
+# A lost Vulkan/GPU device is unrecoverable in-process for a llama-server: after an
+# amdgpu ring-reset / ErrorDeviceLost the child's /health still returns 200 but EVERY
+# decode fails (HTTP 500 carrying one of these markers) forever, so the synth breaker
+# latches open and nothing self-heals (the supervisor only restarts on a child EXIT,
+# and a wedged child stays up). We detect the signature and tear the gateway down so
+# the supervisor restarts the container with a fresh GPU context + a reset breaker.
+# Markers are Vulkan-specific signatures that only appear in a llama-server 5xx body —
+# deliberately NOT loose phrases like "device lost" that could occur in echoed input.
+_DEVICE_LOST_MARKERS = ("ErrorDeviceLost", "ERROR_DEVICE_LOST", "vk::Queue::submit")
+# Rate-limit the auto-restart via a timestamp recorded in a state file so a
+# deterministically-bad GPU (e.g. it re-wedges on the first decode after every restart)
+# does not thrash in a reload loop — after the guard trips we leave it for an operator
+# (loud log). The file persists across a `docker restart` (same container), so the
+# window survives the restart it triggers.
+_DEVICE_LOST_STATE = os.environ.get("AIMEE_LLM_DEVICE_LOST_STATE",
+                                    "/tmp/aimee-llm-device-lost.ts")
+_DEVICE_LOST_MIN_INTERVAL = float(
+    os.environ.get("AIMEE_LLM_DEVICE_LOST_RESTART_MIN_INTERVAL", "180"))
+
+
+def _error_text(exc):
+    """Best-effort text of an upstream failure; an HTTPError carries the JSON body with
+    the llama-server error message (where the device-lost signature appears)."""
+    if isinstance(exc, urllib.error.HTTPError):
+        try:
+            return exc.read().decode("utf-8", "replace")
+        except Exception:  # noqa: BLE001
+            return str(exc)
+    return str(exc)
+
+
+def _is_device_lost(text):
+    return any(m in text for m in _DEVICE_LOST_MARKERS)
+
+
+def _is_synth_device_lost(exc):
+    """A GPU device-lost surfaces ONLY as a 5xx from the synth llama-server. Gate on
+    that so a 4xx body that echoes request content can't spoof a marker and force a
+    spurious container restart."""
+    if isinstance(exc, urllib.error.HTTPError) and exc.code >= 500:
+        return _is_device_lost(_error_text(exc))
+    return False
+
+
+def _device_lost_restart_allowed(now):
+    """True iff we have not auto-restarted within the rate-limit window. Records |now|
+    as the last-restart time when it returns True (so a re-wedge inside the window is
+    held off). Best-effort: a missing/unreadable/unwritable state file means 'allowed'."""
+    try:
+        with open(_DEVICE_LOST_STATE) as fh:
+            last = float(fh.read().strip() or 0)
+    except (OSError, ValueError):
+        last = 0.0
+    if now - last < _DEVICE_LOST_MIN_INTERVAL:
+        return False
+    try:
+        with open(_DEVICE_LOST_STATE, "w") as fh:
+            fh.write(str(now))
+    except OSError:
+        pass
+    return True
+
+
+def _handle_device_lost():
+    """A synth decode failed with a GPU device-lost. Schedule a container restart
+    (deferred ~1s so the in-flight request still returns its error first), unless we
+    restarted too recently — then leave it for an operator with a loud log."""
+    sys.stderr.write("aimee-llm-gateway: synth GPU device lost (Vulkan) — the child cannot "
+                     "recover its context in-process\n")
+    if not _device_lost_restart_allowed(time.time()):
+        sys.stderr.write("aimee-llm-gateway: NOT auto-restarting — another device-lost within "
+                         f"{_DEVICE_LOST_MIN_INTERVAL:.0f}s (suspected hard GPU fault / "
+                         "contention; investigate the host)\n")
+        sys.stderr.flush()
+        return
+    sys.stderr.write("aimee-llm-gateway: restarting the container to recover a fresh GPU "
+                     "context\n")
+    sys.stderr.flush()
+    threading.Timer(1.0, lambda: os._exit(75)).start()  # supervisor reaps -> container restart
+
 
 def do_synth(body):
     """Proxy a /v1/chat/completions request to the configured synth upstream
@@ -328,8 +408,10 @@ def do_synth(body):
         raise GatewayError(503, "provider_unavailable", "synth upstream circuit is open")
     try:
         out = _http_post_json(f"{SYNTH_URL}/v1/chat/completions", body, timeout=300)
-    except Exception:
+    except Exception as exc:
         _synth_breaker.record(False)
+        if _is_synth_device_lost(exc):
+            _handle_device_lost()
         raise
     _synth_breaker.record(True)
     return out

--- a/scripts/tests/test_gateway.py
+++ b/scripts/tests/test_gateway.py
@@ -187,5 +187,75 @@ class RoleHealth(unittest.TestCase):
                 self.assertEqual(self.gw.role_state("http://x"), expected)
 
 
+class SynthDeviceLost(unittest.TestCase):
+    def setUp(self):
+        self.gw = _gw()
+
+    def test_detects_marker(self):
+        self.assertTrue(self.gw._is_device_lost(
+            'decode() failed: vk::Queue::submit: ErrorDeviceLost'))
+        self.assertTrue(self.gw._is_device_lost("VK_ERROR_DEVICE_LOST"))
+        self.assertFalse(self.gw._is_device_lost("context shift not supported"))
+        self.assertFalse(self.gw._is_device_lost("the device lost connection"))  # loose phrase
+
+    def test_synth_device_lost_only_on_5xx(self):
+        import io
+        import urllib.error
+
+        def http_err(code):
+            return urllib.error.HTTPError(
+                "u", code, "e", {}, io.BytesIO(b'{"error":{"message":"ErrorDeviceLost"}}'))
+
+        self.assertTrue(self.gw._is_synth_device_lost(http_err(500)))
+        self.assertFalse(self.gw._is_synth_device_lost(http_err(400)))  # 4xx body can't spoof it
+        self.assertFalse(self.gw._is_synth_device_lost(OSError("ErrorDeviceLost")))
+
+    def test_error_text_reads_httperror_body(self):
+        import io
+        import urllib.error
+        exc = urllib.error.HTTPError(
+            "u", 500, "err", {}, io.BytesIO(b'{"error":{"message":"ErrorDeviceLost"}}'))
+        self.assertIn("ErrorDeviceLost", self.gw._error_text(exc))
+        self.assertEqual(self.gw._error_text(RuntimeError("device lost")), "device lost")
+
+    def test_restart_rate_limited(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as d:
+            self.gw._DEVICE_LOST_STATE = d + "/ts"
+            self.gw._DEVICE_LOST_MIN_INTERVAL = 180.0
+            self.assertTrue(self.gw._device_lost_restart_allowed(1000.0))   # first time: allowed
+            self.assertFalse(self.gw._device_lost_restart_allowed(1100.0))  # within window: held
+            self.assertTrue(self.gw._device_lost_restart_allowed(1200.0))   # past window: allowed
+
+    def test_do_synth_device_lost_triggers_recovery_and_reraises(self):
+        import io
+        import urllib.error
+        self.gw.SYNTH_URL = "http://synth:8083"
+        called = []
+        self.gw._handle_device_lost = lambda: called.append(True)
+
+        def boom(url, payload, timeout=120):
+            raise urllib.error.HTTPError(
+                url, 500, "err", {}, io.BytesIO(b'{"error":{"message":"ErrorDeviceLost"}}'))
+
+        self.gw._http_post_json = boom
+        with self.assertRaises(urllib.error.HTTPError):
+            self.gw.do_synth({"messages": [{"role": "user", "content": "hi"}]})
+        self.assertEqual(called, [True])
+
+    def test_do_synth_other_error_no_recovery(self):
+        self.gw.SYNTH_URL = "http://synth:8083"
+        called = []
+        self.gw._handle_device_lost = lambda: called.append(True)
+
+        def boom(url, payload, timeout=120):
+            raise OSError("connection refused")
+
+        self.gw._http_post_json = boom
+        with self.assertRaises(OSError):
+            self.gw.do_synth({"messages": [{"role": "user", "content": "hi"}]})
+        self.assertEqual(called, [])
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Problem

On AMD/Vulkan the synth `llama-server` can hit `vk::Queue::submit: ErrorDeviceLost` (an `amdgpu` compute-ring timeout) during a decode. After that:

- the synth child's `/health` stays **200** (process up, model loaded), but
- **every** decode returns HTTP 500 with the device-lost signature **forever** — llama.cpp cannot recover a lost Vulkan context in-process.

So the gateway circuit breaker latches open and all `/v1/chat/completions` return `503 provider_unavailable` (curator synthesis dies). The supervisor (`aimee-llm-supervisor.sh`) only restarts the container when a child process **exits** — a wedged-but-alive child never triggers it, so it never self-heals. Found during validation of the v0.2.157 `.254` deploy; recovery there required a manual `docker restart`.

## Fix

In `do_synth`'s error path, detect the Vulkan device-lost signature and tear the gateway down so the supervisor reaps it and the orchestrator restarts the container with a **fresh GPU context + reset breaker**:

- **Gated to 5xx bodies** and **Vulkan-specific markers** (`ErrorDeviceLost` / `ERROR_DEVICE_LOST` / `vk::Queue::submit`) — a 4xx body echoing request content can't spoof a restart.
- **Deferred ~1s** (`threading.Timer` → `os._exit(75)`) so the in-flight request still returns before the process exits.
- **Rate-limited** via a timestamp state file (default 180s window, `AIMEE_LLM_DEVICE_LOST_RESTART_MIN_INTERVAL` / `AIMEE_LLM_DEVICE_LOST_STATE`): the file survives a `docker restart` (same container), so a deterministically-bad GPU can't thrash in a reload loop — past the window it's left for an operator with a loud log.

Embed/rerank are unaffected (separate llama-servers / Vulkan contexts). This stays within the current "any child exit → container restart" design; per-role restart (s6) remains the noted follow-up.

## Test

Adds unit tests for device-lost detection, 5xx-gating (4xx body does not restart), the rate-limit window, and the `do_synth` recovery path (stubs `_handle_device_lost` so `os._exit` is never hit). `python3 scripts/tests/test_gateway.py` → 24 passed.