### PR TITLE
fix(kb): batch curator drain so synth isn't starved by per-poll catch-up

### DIFF
--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -42,6 +42,12 @@
 #define DRAIN_POLL_SECS 5
 /* Max synthesis ops processed per poll — each is an LLM round-trip. */
 #define SYNTH_DRAIN_BATCH 4
+/* Max curator jobs (extract/synth/…) drained back-to-back per poll. The per-poll
+ * catch-up sweep above (code/doc embed + projection graph, O(projects)) is paid
+ * ONCE per batch instead of before every job, so a large post-ingest backlog can't
+ * starve the synth stages to one job per poll. Bounded so the catch-up + config
+ * reload still get a turn each poll (both progress). */
+#define CURATOR_DRAIN_BATCH 16
 
 static void *drain_thread_main(void *arg)
 {
@@ -218,78 +224,84 @@ static void *drain_thread_main(void *arg)
           cfg.kb_curator_extract_max_tokens > 0 ? cfg.kb_curator_extract_max_tokens : 2048;
       opts.max_attempts = cfg.kb_curator_max_attempts > 0 ? cfg.kb_curator_max_attempts : 3;
 
-      int rc = 0;
-      if (cfg.kb_curator_extract_docs_enabled)
+      /* Drain a batch of curator jobs back-to-back. Each iteration runs ONE job
+       * from the highest-priority non-empty stage (the rc chain below). Draining a
+       * batch per poll — rather than one job then re-running the catch-up sweep +
+       * sleep above — amortizes that sweep across the batch so synth keeps pace
+       * with throughput instead of paying the O(projects) sweep before every job.
+       * The top-of-loop sleep provides the idle/error backoff. */
+      int drained = 0;
+      while (!ctx->stop && drained < CURATOR_DRAIN_BATCH)
       {
-         kb_background_set("curator", "extract docs");
-         rc = kb_curator_extract_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_extract_code_enabled)
-      {
-         kb_background_set("curator", "extract code");
-         rc = kb_curator_extract_code_unit_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_resolve_entities_enabled)
-      {
-         kb_background_set("curator", "resolve entities");
-         rc = kb_curator_resolve_entities_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_index_narrative_enabled)
-      {
-         kb_background_set("curator", "index narrative");
-         rc = kb_curator_index_narrative_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_index_claims_enabled)
-      {
-         kb_background_set("curator", "index claims");
-         rc = kb_curator_index_claims_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_detect_contradictions_enabled)
-      {
-         kb_background_set("curator", "detect contradictions");
-         rc = kb_curator_detect_contradictions_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_index_code_unit_enabled)
-      {
-         kb_background_set("curator", "index code_unit");
-         rc = kb_curator_index_code_unit_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_link_artifacts_enabled)
-      {
-         kb_background_set("curator", "link artifacts");
-         rc = kb_curator_link_artifacts_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_synthesize_enabled)
-      {
-         kb_background_set("curator", "synthesize topic");
-         rc = kb_curator_synthesize_one(&opts);
-      }
-      if (rc == 0 && cfg.kb_curator_promote_entity_enabled)
-      {
-         kb_background_set("curator", "promote entity");
-         rc = kb_curator_promote_entity_one(&opts);
-      }
+         /* Return the thread's pooled connection between jobs so a long batch
+          * doesn't pin one past the stuck-lease ceiling (it's re-acquired lazily
+          * by the next stage); cheap no-op when nothing is held. */
+         db2_lease_release_idle();
+         int rc = 0;
+         if (cfg.kb_curator_extract_docs_enabled)
+         {
+            kb_background_set("curator", "extract docs");
+            rc = kb_curator_extract_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_extract_code_enabled)
+         {
+            kb_background_set("curator", "extract code");
+            rc = kb_curator_extract_code_unit_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_resolve_entities_enabled)
+         {
+            kb_background_set("curator", "resolve entities");
+            rc = kb_curator_resolve_entities_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_index_narrative_enabled)
+         {
+            kb_background_set("curator", "index narrative");
+            rc = kb_curator_index_narrative_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_index_claims_enabled)
+         {
+            kb_background_set("curator", "index claims");
+            rc = kb_curator_index_claims_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_detect_contradictions_enabled)
+         {
+            kb_background_set("curator", "detect contradictions");
+            rc = kb_curator_detect_contradictions_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_index_code_unit_enabled)
+         {
+            kb_background_set("curator", "index code_unit");
+            rc = kb_curator_index_code_unit_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_link_artifacts_enabled)
+         {
+            kb_background_set("curator", "link artifacts");
+            rc = kb_curator_link_artifacts_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_synthesize_enabled)
+         {
+            kb_background_set("curator", "synthesize topic");
+            rc = kb_curator_synthesize_one(&opts);
+         }
+         if (rc == 0 && cfg.kb_curator_promote_entity_enabled)
+         {
+            kb_background_set("curator", "promote entity");
+            rc = kb_curator_promote_entity_one(&opts);
+         }
 
-      if (rc == 1)
-      {
-         /* Job processed — loop straight back to drain the next one (no cap). */
-         aimee_log(LOG_DEBUG, "kb.curator.drain", "job processed");
+         if (rc == 1)
+         {
+            drained++; /* job processed — drain the next one without re-sweeping */
+            continue;
+         }
+         if (rc < 0)
+            /* Stage error: stop the batch; the top-of-loop sleep backs off before
+             * the next poll so a persistently-failing stage can't spin hot. */
+            aimee_log(LOG_WARN, "kb.curator.drain", "extractor returned error; backing off");
+         break; /* rc==0 (all queues empty) or rc<0 (error): end this poll's batch */
       }
-      else if (rc == 0)
-      {
-         /* No jobs pending — wait a full poll interval before next attempt */
-         kb_background_clear("curator");
-         sleep(DRAIN_POLL_SECS);
-      }
-      else
-      {
-         /* Stage error: back off a poll interval before retrying. With the rate
-          * cap gone this is the only thing keeping a persistently-failing stage
-          * (bad provider, schema always rejected) from spinning the loop hot. */
-         aimee_log(LOG_WARN, "kb.curator.drain", "extractor returned error; backing off");
-         kb_background_clear("curator");
-         sleep(DRAIN_POLL_SECS);
-      }
+      if (drained > 0)
+         aimee_log(LOG_DEBUG, "kb.curator.drain", "drained %d job(s) this poll", drained);
       kb_background_clear("curator");
    }
 


### PR DESCRIPTION
## Problem

The curator drain thread (`kb_curator_drain_thread`) does, every 5s poll: a `sleep(5)`, then **O(projects) catch-up sweeps** (code-embed, doc-refresh, projection-graph — iterating *every* indexed project), then the gated curator section which processed **exactly one** job (extract_docs → extract_code/synth → … → promote_entity). After a job it looped back to the top, **re-running the entire catch-up sweep + sleep before the next synth job** — so synth was throttled to ~1 job per poll and paid the full sweep overhead per job.

Observed after ingesting ~40 repos into `.254`: file embeddings completed, but the **36k pending code-unit synth jobs made effectively zero progress** (`done` flat) — the 40-project catch-up sweep dominated every poll and starved the synth stage. (Not GPU/Wolf contention — embeddings flow on the same GPU.)

## Fix

Drain a bounded **batch** (`CURATOR_DRAIN_BATCH=16`) of curator jobs back-to-back per poll instead of one. The expensive catch-up sweep is paid **once per batch** rather than before every job, so synth keeps pace with backend throughput while the catch-up (embeddings / doc chunks) still runs every poll — **both progress** (the interleave). 

- Each batch iteration runs one job via the existing priority rc-chain (unchanged logic/order); `rc==1` → drain next immediately, `rc==0` (empty) / `rc<0` (error) → end the batch.
- The top-of-loop `sleep(5)` is now the single idle/error backoff (removed the per-branch sleeps — exactly one sleep per poll, no hot-spin).
- `ctx->stop` is checked between jobs; `kb_background` status cleared on all exit paths.
- Release the thread's pooled db2 connection between jobs (`db2_lease_release_idle()`) so a long batch can't pin a connection past the 300s stuck-lease ceiling (the `db2.pool: leased > ceiling` warnings seen during the backlog).

This removes the per-job overhead/starvation; synth remains backend-bound (the 12B model is ~10s/job serially), so a large backlog is still gated by raw synth throughput — concurrency / a smaller synth model are separate levers.

## Test / validation

- `make lint` clean (incl. line-check); clang-format-19 clean; compiles under `-Werror`.
- Adversarial review confirmed: single sleep per poll (no busy-spin), bounded batch terminates, stop-responsive between jobs, background status paired, and the per-iteration lease release keeps connection holds under the ceiling.