### PR TITLE
fix(deploy): set kb LLM_ENDPOINT so curator synth drains

### DIFF
--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -58,6 +58,11 @@ services:
       # Embedding dim — CPU tier default 1024; the GPU override sets 2560.
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-1024}
       AIMEE_KB_HTTP_BIND: "1"
+      # The curator synth sidecar (curator-extract.py) reads LLM_ENDPOINT, NOT
+      # AIMEE_LLM_URL — without it the sidecar exits 256 and code-unit synthesis
+      # never drains. Point it at the same aimee-llm gateway (/v1).
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://aimee-llm:8742/v1}
+      LLM_MODEL: ${LLM_MODEL:-aimee-synth}
     command: ["--http-port=8741"]
     ports:
       - "8741:8741"

--- a/deploy/smoothnas/aimee-kb.plugin.yaml
+++ b/deploy/smoothnas/aimee-kb.plugin.yaml
@@ -92,6 +92,11 @@ services:
       # Bind /v1 on 0.0.0.0 so the published :8741 is reachable from the
       # aimee-server plugin across the bridge.
       AIMEE_KB_HTTP_BIND: "1"
+      # The curator synth sidecar (curator-extract.py) reads LLM_ENDPOINT, NOT
+      # AIMEE_LLM_URL — without it the sidecar exits 256 and code-unit synthesis
+      # never drains. Point it at the same aimee-llm gateway (/v1) on the bridge.
+      LLM_ENDPOINT: http://10.100.0.1:8742/v1
+      LLM_MODEL: aimee-synth
     volumes:
       - name: home
         mode: tier-bound


### PR DESCRIPTION
## Problem

The kb curator **synth sidecar** (`scripts/curator-extract.py`) reads **`LLM_ENDPOINT`** — which is independent of `AIMEE_LLM_URL`. `AIMEE_LLM_URL` configures the kb's in-process embed/rerank/synth tier wiring, but the sidecar is a separate process that does **not** inherit it. With `LLM_ENDPOINT` unset the sidecar falls back to an unresolvable default and **`exits 256`**, so code-unit synthesis never drains even though embeddings flow.

Both deploy configs had `AIMEE_LLM_URL` but not `LLM_ENDPOINT`, so the manifest's "one knob" promise was unmet for the synth sidecar. Hit live during the `.254` tierd-plugin bring-up: embeddings fine, synth queue stuck with repeated `sidecar exited 256`.

## Fix

Set `LLM_ENDPOINT` (+ `LLM_MODEL`) pointing at the same aimee-llm gateway `/v1` in:
- `deploy/compose/aimee.yaml` — `${LLM_ENDPOINT:-http://aimee-llm:8742/v1}` (override-able)
- `deploy/smoothnas/aimee-kb.plugin.yaml` — `http://10.100.0.1:8742/v1` (the bridge gateway)

## Validation

Applied live on `.254` (kb plugin `/update`): the sidecar went from `exited 256` to `wrote artifact` back-to-back, and the code-unit synth queue began draining. YAML parses clean.

Note: a deeper alternative would be to have the kb derive the sidecar's `LLM_ENDPOINT` from `AIMEE_LLM_URL` in-process (true single-knob); this PR takes the minimal deploy-config route.