### PR TITLE
Promote testing → main: deploy-config fixes (kb LLM_ENDPOINT, server AIMEE_TLS_EXTRA_SAN)

### DIFF
--- a/deploy/compose/aimee.yaml
+++ b/deploy/compose/aimee.yaml
@@ -58,6 +58,11 @@ services:
       # Embedding dim — CPU tier default 1024; the GPU override sets 2560.
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-1024}
       AIMEE_KB_HTTP_BIND: "1"
+      # The curator synth sidecar (curator-extract.py) reads LLM_ENDPOINT, NOT
+      # AIMEE_LLM_URL — without it the sidecar exits 256 and code-unit synthesis
+      # never drains. Point it at the same aimee-llm gateway (/v1).
+      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://aimee-llm:8742/v1}
+      LLM_MODEL: ${LLM_MODEL:-aimee-synth}
     command: ["--http-port=8741"]
     ports:
       - "8741:8741"

--- a/deploy/smoothnas/aimee-kb.plugin.yaml
+++ b/deploy/smoothnas/aimee-kb.plugin.yaml
@@ -92,6 +92,11 @@ services:
       # Bind /v1 on 0.0.0.0 so the published :8741 is reachable from the
       # aimee-server plugin across the bridge.
       AIMEE_KB_HTTP_BIND: "1"
+      # The curator synth sidecar (curator-extract.py) reads LLM_ENDPOINT, NOT
+      # AIMEE_LLM_URL — without it the sidecar exits 256 and code-unit synthesis
+      # never drains. Point it at the same aimee-llm gateway (/v1) on the bridge.
+      LLM_ENDPOINT: http://10.100.0.1:8742/v1
+      LLM_MODEL: aimee-synth
     volumes:
       - name: home
         mode: tier-bound

--- a/deploy/smoothnas/aimee-server.plugin.yaml
+++ b/deploy/smoothnas/aimee-server.plugin.yaml
@@ -62,6 +62,20 @@ services:
         expose: false
         hostExpose: true
     config:
+      # The server's self-signed /v1 TLS cert covers the container hostname +
+      # localhost/loopback only. Behind NAT/DNAT (a tierd plugin reached at the
+      # host's LAN IP/hostname), set the reachable address(es) here so the cert
+      # includes them and thin clients verify (pin) it WITHOUT AIMEE_TLS_INSECURE.
+      # Comma-separated; bare IPs/hosts are auto-typed (e.g. "192.168.1.254" or
+      # "192.168.1.254,nas.lan"). No effect when an operator cert is supplied.
+      - key: AIMEE_TLS_EXTRA_SAN
+        type: string
+        label: Extra TLS cert SAN(s)
+        default: ""
+        description: >-
+          Additional Subject Alternative Names for the self-signed server cert —
+          the deployment's reachable IP(s)/hostname(s) (comma-separated). Lets
+          thin clients pin+verify over the LAN with no AIMEE_TLS_INSECURE.
       # Operator-set at deploy time (kept out of git). The webchat browser UI
       # authenticates via PAM against this user/password; set BOTH to enable
       # sign-in. Leave blank to serve the login page with no account.

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -213,7 +213,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 122 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 123 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -408,7 +408,7 @@ The binaries read 122 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/src/headers/pki.h
+++ b/src/headers/pki.h
@@ -51,6 +51,14 @@ extern "C"
     * is written 0600. Returns 0 if a usable cert is in place, -1 on failure. */
    int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_path);
 
+   /* Build the self-signed server cert SAN string into |out| (cap bytes): always
+    * the hostname |cn| + localhost + IPv4/IPv6 loopback, plus |extra| (the
+    * AIMEE_TLS_EXTRA_SAN value: comma/space-separated additional names, each
+    * pre-typed "IP:"/"DNS:"/… or a bare host/IP auto-classified). Lets a
+    * NAT/DNAT deployment present a cert that verifies for its reachable address
+    * without an operator-supplied cert. Truncation-safe. Exposed for tests. */
+   void pki_build_server_san(const char *cn, const char *extra, char *out, size_t cap);
+
    /* For tests: drop cached CA + snapshot so a fresh AIMEE_HOME is picked up. */
    void pki_reset_for_test(void);
 

--- a/src/server/pki.c
+++ b/src/server/pki.c
@@ -23,7 +23,8 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
-#include <unistd.h> /* gethostname, close */
+#include <unistd.h>    /* gethostname, close */
+#include <arpa/inet.h> /* inet_pton — classify AIMEE_TLS_EXTRA_SAN entries */
 
 #define PKI_CA_AGENT     "__pki_ca__" /* vault agent name under which the CA key is sealed */
 #define PKI_CA_CN        "aimee-client-CA"
@@ -239,6 +240,49 @@ static int set_random_serial(X509 *cert, char *hex_out, size_t hex_len)
  * regardless of trust; clients pin the cert or pass AIMEE_TLS_INSECURE=1. The key
  * is written 0600; the cert (public) is world-readable. Returns 0 if a usable
  * cert exists (already present or freshly written), -1 on failure (logged). */
+void pki_build_server_san(const char *cn, const char *extra, char *out, size_t cap)
+{
+   if (!out || cap == 0)
+      return;
+   int n = snprintf(out, cap, "DNS:%s,DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1",
+                    (cn && *cn) ? cn : "localhost");
+   if (n < 0 || (size_t)n >= cap)
+   {
+      out[cap - 1] = '\0';
+      return;
+   }
+   if (!extra || !*extra)
+      return;
+   /* Append operator-configured extra SANs (comma/space-separated). Each entry is
+    * either pre-typed ("IP:.."/"DNS:.."/"email:.."/"URI:..") or a bare host/IP
+    * that we auto-classify: parses as an IP -> "IP:", else "DNS:". An entry that
+    * would overflow |out| is dropped whole (never half-written). */
+   char buf[512];
+   snprintf(buf, sizeof(buf), "%s", extra);
+   char *save = NULL;
+   for (char *tok = strtok_r(buf, ", ", &save); tok; tok = strtok_r(NULL, ", ", &save))
+   {
+      if (!*tok)
+         continue;
+      const char *prefix = "";
+      if (strncmp(tok, "IP:", 3) != 0 && strncmp(tok, "DNS:", 4) != 0 &&
+          strncmp(tok, "email:", 6) != 0 && strncmp(tok, "URI:", 4) != 0)
+      {
+         unsigned char ipbuf[16];
+         prefix = (inet_pton(AF_INET, tok, ipbuf) == 1 || inet_pton(AF_INET6, tok, ipbuf) == 1)
+                      ? "IP:"
+                      : "DNS:";
+      }
+      size_t cur = strlen(out);
+      int w = snprintf(out + cur, cap - cur, ",%s%s", prefix, tok);
+      if (w < 0 || (size_t)w >= cap - cur)
+      {
+         out[cur] = '\0'; /* drop the entry that didn't fit; keep prior SANs */
+         break;
+      }
+   }
+}
+
 int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_path)
 {
    if (!cert_path || !cert_path[0] || !key_path || !key_path[0])
@@ -262,8 +306,8 @@ int pki_ensure_self_signed_server_cert(const char *cert_path, const char *key_pa
    if (gethostname(cn, sizeof(cn)) != 0 || !cn[0])
       snprintf(cn, sizeof(cn), "aimee-server");
    cn[sizeof(cn) - 1] = '\0';
-   char san[300];
-   snprintf(san, sizeof(san), "DNS:%s,DNS:localhost,IP:127.0.0.1,IP:0:0:0:0:0:0:0:1", cn);
+   char san[1024];
+   pki_build_server_san(cn, getenv("AIMEE_TLS_EXTRA_SAN"), san, sizeof(san));
 
    X509_set_version(cert, 2);
    X509_NAME *name = X509_get_subject_name(cert);

--- a/src/tests/test_pki.c
+++ b/src/tests/test_pki.c
@@ -92,6 +92,24 @@ int main(void)
    assert(pki_ca_ensure() == 0);
    assert(pki_is_revoked(serial2) == 1); /* persisted across reload */
 
+   /* Server-cert SAN builder: base set always present; AIMEE_TLS_EXTRA_SAN entries
+    * appended with auto-typing (IP vs DNS) and pass-through of pre-typed entries. */
+   char san[1024];
+   pki_build_server_san("myhost", NULL, san, sizeof(san));
+   assert(strstr(san, "DNS:myhost") && strstr(san, "DNS:localhost") &&
+          strstr(san, "IP:127.0.0.1") && !strstr(san, "192")); /* no extras when NULL */
+   pki_build_server_san("h", "192.168.1.254", san, sizeof(san));
+   assert(strstr(san, ",IP:192.168.1.254") && !strstr(san, "IP:IP:")); /* bare IPv4 -> IP: */
+   pki_build_server_san("h", "nas.local", san, sizeof(san));
+   assert(strstr(san, ",DNS:nas.local")); /* bare hostname -> DNS: */
+   pki_build_server_san("h", "IP:10.0.0.5", san, sizeof(san));
+   assert(strstr(san, ",IP:10.0.0.5") && !strstr(san, "IP:IP:")); /* pre-typed kept as-is */
+   pki_build_server_san("h", "192.168.1.254, nas.local", san, sizeof(san));
+   assert(strstr(san, ",IP:192.168.1.254") && strstr(san, ",DNS:nas.local")); /* multi */
+   pki_build_server_san("h", "fd00::1", san, sizeof(san));
+   assert(strstr(san, ",IP:fd00::1")); /* IPv6 -> IP: */
+   printf("pki: SAN builder ok\n");
+
    snprintf(cmd, sizeof(cmd), "rm -rf %s", home);
    (void)system(cmd);
    printf("pki: all tests passed\n");


### PR DESCRIPTION
Promotes #790 (kb LLM_ENDPOINT so curator synth drains) and #791 (server AIMEE_TLS_EXTRA_SAN for self-signed cert SAN). Both make a fresh tierd/compose aimee deploy work without hand-patching certs/env. Already applied live on .254.