### PR TITLE
docs(readme): lead with a cross-section of abilities; add VS Code ACP path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,39 @@
 # aimee
 
-**One UI. Any model. Memory that travels with you.**
+**One front end for every AI coding tool. Memory, code intelligence, and cheaper
+delegates that travel with you. Any model, any provider.**
 
-aimee is one front end for every AI coding tool and model you use. Drive it from
-Claude Code, Codex, OpenCode, or the built-in browser webchat, and run any turn on
-any model from any provider: Claude, GPT, Gemini, Mistral, MiniMax, or a local
-model. Your memory, preferences, and context follow you between models, so
-switching never starts from zero and never locks you to a vendor. Core services are
-C, sub-10ms, with no cloud dependencies.
+aimee can sit in the path between you and your AI, or beside it. Route every turn
+through aimee — point your tool's OpenAI- or Anthropic-compatible API at it, and it
+runs the turn on any model: Claude, GPT, Gemini, Mistral, MiniMax, a local model,
+or any compatible endpoint. Or attach aimee beside your tool over MCP, ACP, or a
+plugin, where your tool keeps its own model and aimee adds memory, delegates, and
+guardrails as tools and hooks. Both work with Claude Code, Codex, OpenCode, Gemini
+CLI, and the built-in webchat. Your memory and context come with you, so switching
+never starts from zero and never locks you to a vendor.
 
-It starts as persistent memory for your AI coding tool. One install, and every
-session starts knowing what the last one learned. The same substrate scales to a
-company-wide knowledge base that distills what your whole organization knows across
-code, product, sales, support, and ops, then routes work to the cheapest capable
-model. See
-[How aimee learns](docs/KNOWLEDGE.md).
+It does far more than remember:
+
+- **Memory that compounds.** Every session starts already knowing what the last one
+  learned. A curator pipeline distills facts into a typed knowledge base that scales
+  from one developer to a whole company. See [How aimee learns](docs/KNOWLEDGE.md).
+- **Code intelligence.** aimee indexes your codebase into a searchable symbol and
+  call graph, so the AI can find callers, trace an edit's blast radius before it
+  writes, and work from your code instead of re-reading it every session. Cross-repo
+  indexing, one dependency graph spanning every repo you work across, lands shortly;
+  see the
+  [cross-repo dependency graph proposal](docs/proposals/pending/cross-repo-dependency-graph.md).
+- **Delegates that cut your bill.** Route summarization, review, and boilerplate to
+  the cheapest capable model. Local (Ollama) and subscription delegates cost nothing
+  extra, and the primary agent gets back a compact result instead of raw content.
+- **Cross-agent orchestration.** Hand aimee a written proposal and it runs the whole
+  job unattended: design, plan, implement, review, PR. The primary agent manages and
+  the delegates do the work.
+- **Guardrails and isolation.** Sensitive files are blocked before the AI touches
+  them, and every session runs in its own git worktree, so parallel work never
+  collides.
+
+Core services are C, sub-10ms, with no cloud dependencies.
 
 ## The problem
 
@@ -28,8 +47,10 @@ clobbering another session's work.
 
 ## What aimee does
 
-aimee sits between you and your AI tool and intercepts actions through hooks and
-MCP. The CLI is `aimee`; browser chat is `aimee-webchat`.
+aimee runs as a local server your tools connect to. In the path it runs your turns
+over the OpenAI- or Anthropic-compatible ingress; beside your tool it intercepts
+actions through hooks, MCP, ACP, and plugins. The CLI is `aimee`; browser chat is
+`aimee-webchat`.
 
 ```mermaid
 graph TB
@@ -121,7 +142,7 @@ same on every front end, because they live in the server and KB, not the tool.
 | Gemini CLI | Full hook support | Provider CLI | `./install.sh` |
 | Mistral Vibe | Provider-CLI primary and subscription-plan delegates | Provider CLI | `aimee agent add <name> <endpoint> <model> --provider mistral` |
 | GitHub Copilot | MCP server | Via the OpenAI-compatible model | `./install.sh` |
-| VS Code | MCP tools in Copilot Chat, or aimee as an OpenAI-compatible model | Yes, via `/v1/chat/completions` | [VS Code guide](docs/VSCODE.md) |
+| VS Code | MCP tools in Copilot Chat, an ACP agent (`aimee acp-serve`), or aimee as an OpenAI-compatible model | Yes, via `/v1/chat/completions` or ACP | [VS Code guide](docs/VSCODE.md) |
 
 Switch tools any time. Your memory and context stay.
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -114,7 +114,7 @@ hooks call the thin client, which reaches the configured `aimee-server`.
 | Codex CLI | `~/.codex/` directory or `codex` in PATH | `~/.codex/hooks.json` | `~/.codex/mcp-config.json` | Implemented |
 | GitHub Copilot | `~/.copilot/` directory or `copilot` in PATH | `~/.copilot/config.json` | `~/.copilot/mcp-config.json` | Implemented |
 | Claude Desktop | Config directory exists at OS-specific path | N/A (MCP only) | `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `~/.config/Claude/claude_desktop_config.json` (Linux) | Implemented |
-| VS Code | `code` in PATH or user config dir (`~/.config/Code/User/`, macOS `~/Library/Application Support/Code/User/`); Insiders and VSCodium variants detected | N/A (MCP only) | User-level `mcp.json` (uses the `servers` key, not `mcpServers`) | Implemented (MCP), see [VSCODE.md](VSCODE.md) |
+| VS Code | `code` in PATH or user config dir (`~/.config/Code/User/`, macOS `~/Library/Application Support/Code/User/`); Insiders and VSCodium variants detected | N/A (no hooks) | User-level `mcp.json` (uses the `servers` key, not `mcpServers`) | Implemented (MCP); also an ACP agent (`aimee acp-serve`) and an OpenAI-compatible model, see [VSCODE.md](VSCODE.md) |
 
 ### Hook events registered per client
 
@@ -125,7 +125,7 @@ hooks call the thin client, which reaches the configured `aimee-server`.
 | Codex CLI | `SessionStart` | `PreToolUse` | `PostToolUse` | Pre: `Bash`; Post: `Bash` |
 | GitHub Copilot | `SessionStart` | `PreToolUse` | `PostToolUse` | Pre: `Bash\|Edit\|Write`; Post: `Edit\|Write` |
 | Claude Desktop | n/a | n/a | n/a | MCP only; no hook events |
-| VS Code | n/a | n/a | n/a | MCP only; no hook events |
+| VS Code | n/a | n/a | n/a | MCP / ACP / OpenAI-compatible model; no hook events |
 
 ### Installer output
 

--- a/docs/VSCODE.md
+++ b/docs/VSCODE.md
@@ -1,13 +1,14 @@
 # Using aimee with VS Code
 
 aimee integrates with VS Code through surfaces that already ship in the
-binaries, no extra protocol, no plugin build required. There are two ways to
+binaries, no extra protocol, no plugin build required. There are three ways to
 wire it, and they are complementary:
 
 | You want… | Use | What VS Code gets |
 |---|---|---|
 | aimee's **tools** (memory, guardrails, `find_symbol`, `delegate`) inside Copilot Chat | **MCP** (Path A) | aimee tools callable in agent mode |
 | aimee itself **as the chat model** (delegate-routed, memory + guardrails) | **OpenAI `/v1` endpoint** (Path B) | "aimee" as a selectable model |
+| aimee itself **as the chat agent** over stdio, no TCP listener or token | **ACP** (Path C) | "aimee" as an ACP agent |
 
 For the deeper, native-extension experience (aimee in the model picker, an
 `@aimee` chat participant, a docked webchat panel), a dedicated VS Code
@@ -143,11 +144,37 @@ conventions.
 
 ---
 
+## Path C, aimee as an ACP agent (`aimee acp-serve`)
+
+aimee speaks the [Agent Client Protocol](https://agentclientprotocol.com)
+(ACP): newline-delimited JSON-RPC 2.0 over stdio. A VS Code extension that
+speaks ACP launches `aimee acp-serve`, and aimee runs each turn on its primary
+model with memory and guardrails applied, streaming the reply back as
+`session/update` notifications. Like Path B this makes aimee the agent, but over
+stdio instead of the OpenAI endpoint, so it needs no TCP listener and no bearer.
+
+Point your ACP extension at the command:
+
+```jsonc
+{
+  "command": "aimee",
+  "args": ["acp-serve"]
+}
+```
+
+aimee advertises its slash commands (`/help`, `/skill`, `/personality`,
+`/compact`, `/reset`, `/stop`, `/queue`) in the ACP `initialize` handshake.
+ACP turns run the agent against a local `aimee-server`; a network `/v1` remote
+cannot serve them.
+
+---
+
 ## Which path should I use?
 
-- **Both.** Path A gives the model you already use (e.g. Copilot's GPT/Claude)
-  access to aimee's memory and guardrails as tools. Path B makes aimee *itself*
-  the model. They stack: run Path B with aimee as the model **and** Path A so
+- **Stack them.** Path A gives the model you already use (e.g. Copilot's
+  GPT/Claude) access to aimee's memory and guardrails as tools. Path B and
+  Path C both make aimee *itself* the agent (Path B over the OpenAI endpoint,
+  Path C over ACP). Run Path B or C with aimee as the model **and** Path A so
   that model can also reach aimee's tools.
 - For the tightest native experience (aimee in the model picker + `@aimee`
   participant + docked webchat), use the dedicated VS Code extension in


### PR DESCRIPTION
## What

Reworks the README's opening section so new users see the full surface of aimee, not just persistent memory, and documents ACP as a VS Code integration path.

### README hero
- Leads with a scannable cross-section: **memory that compounds, code intelligence, delegates that cut your bill, cross-agent orchestration, guardrails + isolation**.
- Stresses **cross-repo indexing** (coming shortly) with a link to the [cross-repo dependency graph proposal](../docs/proposals/pending/cross-repo-dependency-graph.md).
- Makes the **two ways to connect aimee** explicit: in the path via the OpenAI/Anthropic-compatible ingress, or beside your tool over **MCP / ACP / plugin**.
- Broadens the model claim to "any Anthropic- or OpenAI-compatible endpoint" and the tool list to "anything that speaks those APIs".
- Removed AI-isms (em-dash pile-ups, vague verbs, salesy framing) to match the body's terse voice.

### VS Code ACP
- New **Path C** in `docs/VSCODE.md`: aimee as an ACP agent via `aimee acp-serve` (stdio JSON-RPC, no TCP listener/token).
- VS Code rows in `README.md` and `docs/COMPATIBILITY.md` now mention the ACP agent and OpenAI-compatible model alongside MCP.

## Scope
Docs only. No code changes; `docs/gen/` is unaffected.