### PR TITLE
feat(kb): cross-repo dep graph S1 — schema + config foundation

### DIFF
--- a/src/config_kb_curator.c
+++ b/src/config_kb_curator.c
@@ -56,6 +56,17 @@ void config_kb_curator_defaults(config_t *cfg)
    cfg->kb_curator_tier_b_api_key[0] = '\0';
    cfg->kb_evidence_embed_enabled = 1;
    cfg->kb_evidence_embed_batch = 32;
+   /* Cross-repo dependency graph — initial calibration (re-tuned vs S8 fixtures). */
+   cfg->kb_curator_cross_repo_graph_enabled = 1;
+   cfg->kb_curator_cross_repo_distinctiveness_v = 1;
+   cfg->kb_curator_cross_repo_k = 5;
+   cfg->kb_curator_cross_repo_m = 8;
+   cfg->kb_curator_cross_repo_p_pct = 25;
+   cfg->kb_curator_cross_repo_len_min = 4;
+   cfg->kb_curator_cross_repo_caller_collision_c = 5;
+   cfg->kb_curator_cross_repo_max_candidates = 50000;
+   cfg->kb_curator_cross_repo_query_timeout_ms = 5000;
+   cfg->kb_curator_cross_repo_review_queue_max = 5000;
 }
 
 /* Parse a curator provider sub-object {base_url, model, api_key} under `curator`
@@ -215,6 +226,48 @@ int config_parse_kb_curator(config_t *cfg, const cJSON *root)
       const cJSON *enabled = cJSON_GetObjectItemCaseSensitive(projection_graph, "enabled");
       if (enabled && cJSON_IsBool(enabled))
          cfg->kb_curator_projection_graph_enabled = cJSON_IsTrue(enabled) ? 1 : 0;
+   }
+
+   const cJSON *cross_repo = cJSON_GetObjectItemCaseSensitive(curator, "cross_repo_graph");
+   if (cross_repo)
+   {
+      if (!cJSON_IsObject(cross_repo))
+         return config_issue("\"kb.curator.cross_repo_graph\" expected object, got %s",
+                             jo_type_name(cross_repo));
+      const cJSON *enabled = cJSON_GetObjectItemCaseSensitive(cross_repo, "enabled");
+      if (enabled && cJSON_IsBool(enabled))
+         cfg->kb_curator_cross_repo_graph_enabled = cJSON_IsTrue(enabled) ? 1 : 0;
+
+      /* Positive-int knobs, each with an explicit upper bound to reject pathological
+       * inputs (K=10M, timeout=1h, max_candidates=INT_MAX). Automatic (non-static)
+       * so the &cfg->field initializers are valid at runtime. */
+      const struct
+      {
+         const char *key;
+         int *field;
+         int max;
+      } ints[] = {
+          {"distinctiveness_v", &cfg->kb_curator_cross_repo_distinctiveness_v, 1000000},
+          {"k", &cfg->kb_curator_cross_repo_k, 100000},
+          {"m", &cfg->kb_curator_cross_repo_m, 100000},
+          {"p_pct", &cfg->kb_curator_cross_repo_p_pct, 100},
+          {"len_min", &cfg->kb_curator_cross_repo_len_min, 1024},
+          {"caller_collision_c", &cfg->kb_curator_cross_repo_caller_collision_c, 100000},
+          {"max_candidates", &cfg->kb_curator_cross_repo_max_candidates, 100000000},
+          {"query_timeout_ms", &cfg->kb_curator_cross_repo_query_timeout_ms, 600000},
+          {"review_queue_max", &cfg->kb_curator_cross_repo_review_queue_max, 100000000},
+      };
+      for (size_t i = 0; i < sizeof(ints) / sizeof(ints[0]); i++)
+      {
+         const cJSON *v = cJSON_GetObjectItemCaseSensitive(cross_repo, ints[i].key);
+         if (!v)
+            continue;
+         if (!cJSON_IsNumber(v) || v->valueint <= 0 || v->valueint > ints[i].max)
+            config_issue("\"kb.curator.cross_repo_graph.%s\" must be an integer in [1, %d]",
+                         ints[i].key, ints[i].max);
+         else
+            *ints[i].field = v->valueint;
+      }
    }
 
    const cJSON *synthesize = cJSON_GetObjectItemCaseSensitive(curator, "synthesize");
@@ -396,6 +449,16 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
        cfg->kb_curator_provider_base_url[0] || cfg->kb_curator_provider_model[0] ||
        cfg->kb_curator_provider_api_key[0] || cfg->kb_curator_tier_b_base_url[0] ||
        cfg->kb_curator_tier_b_model[0] || cfg->kb_curator_tier_b_api_key[0];
+   int cross_repo_nondefault =
+       !cfg->kb_curator_cross_repo_graph_enabled ||
+       cfg->kb_curator_cross_repo_distinctiveness_v != 1 || cfg->kb_curator_cross_repo_k != 5 ||
+       cfg->kb_curator_cross_repo_m != 8 || cfg->kb_curator_cross_repo_p_pct != 25 ||
+       cfg->kb_curator_cross_repo_len_min != 4 ||
+       cfg->kb_curator_cross_repo_caller_collision_c != 5 ||
+       cfg->kb_curator_cross_repo_max_candidates != 50000 ||
+       cfg->kb_curator_cross_repo_query_timeout_ms != 5000 ||
+       cfg->kb_curator_cross_repo_review_queue_max != 5000;
+   curator_any = curator_any || cross_repo_nondefault;
    int evidence_any = !cfg->kb_evidence_embed_enabled || cfg->kb_evidence_embed_batch != 32;
    if (!curator_any && !evidence_any)
       return;
@@ -440,6 +503,38 @@ void config_save_kb_curator(const config_t *cfg, cJSON *root)
                cJSON_AddBoolToObject(o, "enabled", cfg->kb_curator_promote_entity_enabled ? 1 : 0);
                if (cfg->kb_curator_promote_min_sources != 3)
                   cJSON_AddNumberToObject(o, "min_sources", cfg->kb_curator_promote_min_sources);
+            }
+         }
+         if (cross_repo_nondefault)
+         {
+            cJSON *o = cJSON_AddObjectToObject(cur, "cross_repo_graph");
+            if (o)
+            {
+               cJSON_AddBoolToObject(o, "enabled",
+                                     cfg->kb_curator_cross_repo_graph_enabled ? 1 : 0);
+               if (cfg->kb_curator_cross_repo_distinctiveness_v != 1)
+                  cJSON_AddNumberToObject(o, "distinctiveness_v",
+                                          cfg->kb_curator_cross_repo_distinctiveness_v);
+               if (cfg->kb_curator_cross_repo_k != 5)
+                  cJSON_AddNumberToObject(o, "k", cfg->kb_curator_cross_repo_k);
+               if (cfg->kb_curator_cross_repo_m != 8)
+                  cJSON_AddNumberToObject(o, "m", cfg->kb_curator_cross_repo_m);
+               if (cfg->kb_curator_cross_repo_p_pct != 25)
+                  cJSON_AddNumberToObject(o, "p_pct", cfg->kb_curator_cross_repo_p_pct);
+               if (cfg->kb_curator_cross_repo_len_min != 4)
+                  cJSON_AddNumberToObject(o, "len_min", cfg->kb_curator_cross_repo_len_min);
+               if (cfg->kb_curator_cross_repo_caller_collision_c != 5)
+                  cJSON_AddNumberToObject(o, "caller_collision_c",
+                                          cfg->kb_curator_cross_repo_caller_collision_c);
+               if (cfg->kb_curator_cross_repo_max_candidates != 50000)
+                  cJSON_AddNumberToObject(o, "max_candidates",
+                                          cfg->kb_curator_cross_repo_max_candidates);
+               if (cfg->kb_curator_cross_repo_query_timeout_ms != 5000)
+                  cJSON_AddNumberToObject(o, "query_timeout_ms",
+                                          cfg->kb_curator_cross_repo_query_timeout_ms);
+               if (cfg->kb_curator_cross_repo_review_queue_max != 5000)
+                  cJSON_AddNumberToObject(o, "review_queue_max",
+                                          cfg->kb_curator_cross_repo_review_queue_max);
             }
          }
          if (cfg->kb_curator_extract_command[0])

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -1208,6 +1208,110 @@ CREATE INDEX IF NOT EXISTS idx_ee_target_relation ON entity_edges(target, relati
 CREATE INDEX IF NOT EXISTS idx_ee_origin_source ON entity_edges(edge_origin, source);
 CREATE INDEX IF NOT EXISTS idx_ee_projection_generation ON entity_edges(projection_generation_id, source, relation);
 
+-- Cross-repo dependency graph (proposal docs/proposals/pending/cross-repo-dependency-graph.md).
+-- S1 foundation: per-repo trust, a global version/epoch store, the corpus-derived blocked-symbol
+-- set, the AMBIGUOUS review queue, and the trust-change audit log. Resolver/stats/orchestration
+-- land in later slices. Dialect parity with src/db2/schema_sqlite.sql is at the table-set level
+-- (schema-sync-check); intentional per-dialect deltas: timestamp exprs (to_char vs datetime('now')),
+-- JSONB (Postgres) vs TEXT (sqlite) for `evidence`, identity vs AUTOINCREMENT primary keys.
+--
+-- Per-repo trust (§0): operator-registered repos default 'trusted'; any future non-operator
+-- ingestion path (community ingest, bulk import, fixture/repair scripts) MUST insert 'untrusted'
+-- explicitly -- the 'trusted' default is fail-open and only application discipline guards it today.
+-- The CHECK keeps the column a closed enum (named for stable, idempotent migration); it is part of
+-- the ADD COLUMN so the whole statement is guarded idempotently by IF NOT EXISTS.
+ALTER TABLE projects
+    ADD COLUMN IF NOT EXISTS trust TEXT NOT NULL DEFAULT 'trusted'
+        CONSTRAINT projects_trust_chk CHECK (trust IN ('trusted', 'untrusted'));
+CREATE INDEX IF NOT EXISTS idx_projects_trust ON projects(trust);
+
+-- cross_repo_meta (§4.1): single-row global version/epoch store backing the input-freshness stamp
+-- (canonical_index_generation [from code_projection_generations], repo_set_hash, trust_epoch).
+-- trust_epoch is the monotonic counter S7 atomically reads + bumps (UPDATE ... SET trust_epoch =
+-- trust_epoch + 1 in one txn) on any projects.trust change; blocked_symbols_version is bumped by S3's
+-- blocked_symbols recompute. The counters are NOT NULL DEFAULT 0 with a >= 0 CHECK so a NULL or
+-- negative value can never silently break the monotonic-bump invariant. CHECK (id = 1) pins one row.
+CREATE TABLE IF NOT EXISTS cross_repo_meta (
+    id                      INTEGER PRIMARY KEY CHECK (id = 1),
+    trust_epoch             BIGINT NOT NULL DEFAULT 0 CHECK (trust_epoch >= 0),
+    repo_set_hash           TEXT NOT NULL DEFAULT '',
+    blocked_symbols_version BIGINT NOT NULL DEFAULT 0 CHECK (blocked_symbols_version >= 0),
+    updated_at              TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
+);
+-- DO NOTHING is deliberate: it only guarantees the singleton row exists. On schema re-apply it must
+-- NOT clobber the live runtime-mutated counters (trust_epoch/repo_set_hash/blocked_symbols_version);
+-- a DO UPDATE that reset them to defaults would destroy monotonicity. All columns are runtime-owned
+-- after creation, so there is nothing seed-owned to refresh.
+INSERT INTO cross_repo_meta (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+
+-- blocked_symbols (§3.3): corpus-derived non-distinctive set, recomputed over trusted repos only.
+-- Replaces the static blocklist; `version` lets a tier decision replay against the exact frequency
+-- model (blocked_symbols_version, see cross_repo_meta) that produced it. `lang` '' = all languages
+-- (a per-language entry uses the concrete lang tag). created_at/updated_at support stale cleanup.
+CREATE TABLE IF NOT EXISTS blocked_symbols (
+    word       TEXT NOT NULL,
+    lang       TEXT NOT NULL DEFAULT '',
+    reason     TEXT NOT NULL DEFAULT '',
+    version    BIGINT NOT NULL DEFAULT 0,
+    created_at TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS')),
+    PRIMARY KEY (word, lang)
+);
+CREATE INDEX IF NOT EXISTS idx_blocked_symbols_version ON blocked_symbols(version);
+
+-- cross_repo_review_queue (§3.8): AMBIGUOUS candidates surfaced (not dropped). The fingerprint
+-- (repo_set_hash, symbol, caller_repo, candidate_definer) is UNIQUE so re-resolution upserts the
+-- evidence rather than duplicating -- all four are NOT NULL (Postgres treats NULLs as distinct, so
+-- a nullable fingerprint column would silently defeat the constraint). Eviction on overflow is
+-- deterministic by (evidence_score ASC, arrival_seq ASC) over status='open'. review_class is a
+-- closed enum: 'ambiguous' (default) or 'ffi' (the §3.7 cross-language discriminator); cross_lang
+-- is a 0/1 boolean flag (BIGINT for sqlite-dialect parity). evidence is JSONB on Postgres for
+-- insert-time validation + field-level S3/S4 queries (TEXT in the sqlite shim). No FKs to projects:
+-- caller_repo/candidate_definer are repo *names*, not ids, so queue + audit rows survive a repo
+-- deletion (orphans are tolerated and pruned on the next re-resolution of that repo_set_hash).
+CREATE TABLE IF NOT EXISTS cross_repo_review_queue (
+    id                BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    repo_set_hash     TEXT NOT NULL DEFAULT '',
+    symbol            TEXT NOT NULL,
+    caller_repo       TEXT NOT NULL,
+    candidate_definer TEXT NOT NULL DEFAULT '',
+    evidence          JSONB NOT NULL DEFAULT '{}'::jsonb,
+    evidence_score    DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+    arrival_seq       BIGINT NOT NULL DEFAULT 0,
+    status            TEXT NOT NULL DEFAULT 'open'
+                          CHECK (status IN ('open', 'accepted', 'rejected')),
+    review_class      TEXT NOT NULL DEFAULT 'ambiguous'
+                          CHECK (review_class IN ('ambiguous', 'ffi')),
+    cross_lang        BIGINT NOT NULL DEFAULT 0,
+    created_at        TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS')),
+    updated_at        TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS')),
+    UNIQUE (repo_set_hash, symbol, caller_repo, candidate_definer)
+);
+-- Partial index for the queue-worker / eviction scan (WHERE status='open' ORDER BY evidence_score,
+-- arrival_seq); the low-cardinality standalone status index is intentionally omitted. idx_crrq_caller
+-- covers "open entries for a caller" (the --review-by-project path).
+CREATE INDEX IF NOT EXISTS idx_crrq_evict_open ON cross_repo_review_queue(evidence_score, arrival_seq)
+    WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_crrq_caller ON cross_repo_review_queue(caller_repo, status);
+
+-- cross_repo_trust_audit (§0 authz): durable audit of every projects.trust change (admin-gated,
+-- CAP_INDEX_ADMIN). Records actor, prior->new trust, trust_epoch before/after, repo_set_hash,
+-- request id, timestamp for post-incident attribution of this security-relevant state change.
+-- prior_trust allows '' for the first-set case (no prior value); new_trust mirrors the enum.
+CREATE TABLE IF NOT EXISTS cross_repo_trust_audit (
+    id                 BIGINT PRIMARY KEY GENERATED BY DEFAULT AS IDENTITY,
+    project            TEXT NOT NULL,
+    actor              TEXT NOT NULL DEFAULT '',
+    prior_trust        TEXT NOT NULL DEFAULT '' CHECK (prior_trust IN ('', 'trusted', 'untrusted')),
+    new_trust          TEXT NOT NULL DEFAULT '' CHECK (new_trust IN ('', 'trusted', 'untrusted')),
+    trust_epoch_before BIGINT NOT NULL DEFAULT 0,
+    trust_epoch_after  BIGINT NOT NULL DEFAULT 0,
+    repo_set_hash      TEXT NOT NULL DEFAULT '',
+    request_id         TEXT NOT NULL DEFAULT '',
+    created_at         TEXT NOT NULL DEFAULT (to_char(CURRENT_TIMESTAMP, 'YYYY-MM-DD HH24:MI:SS'))
+);
+CREATE INDEX IF NOT EXISTS idx_crta_project ON cross_repo_trust_audit(project, created_at);
+
 -- CSS migration assistant (WP-B): the style graph. css_rules holds one row per
 -- selector (comma lists already split by the analyzer) with computed
 -- specificity + at-rule context; css_declarations holds each property/value

--- a/src/db2/schema_sqlite.sql
+++ b/src/db2/schema_sqlite.sql
@@ -8,7 +8,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS epistemic_directives_fts USING fts5(  questio
 CREATE VIRTUAL TABLE IF NOT EXISTS memories_code_fts USING fts5(key, content, content='memories', content_rowid='id', tokenize='trigram');
 CREATE VIRTUAL TABLE IF NOT EXISTS code_fts USING fts5(content, content='file_contents', content_rowid='file_id', tokenize='unicode61');
 CREATE TABLE IF NOT EXISTS rules (  id INTEGER PRIMARY KEY AUTOINCREMENT,  polarity TEXT NOT NULL,  title TEXT NOT NULL,  description TEXT NOT NULL DEFAULT '',  weight INTEGER NOT NULL DEFAULT 5,  domain TEXT NOT NULL DEFAULT '',  directive_type TEXT NOT NULL DEFAULT 'soft',  expires_at TEXT DEFAULT NULL,  last_reinforced_at TEXT DEFAULT NULL,  created_at TEXT NOT NULL,  updated_at TEXT NOT NULL);
-CREATE TABLE IF NOT EXISTS projects (  id INTEGER PRIMARY KEY AUTOINCREMENT,  name TEXT NOT NULL UNIQUE,  root TEXT NOT NULL,  workspace TEXT NOT NULL DEFAULT '',  scanned_at TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS projects (  id INTEGER PRIMARY KEY AUTOINCREMENT,  name TEXT NOT NULL UNIQUE,  root TEXT NOT NULL,  workspace TEXT NOT NULL DEFAULT '',  scanned_at TEXT NOT NULL,  trust TEXT NOT NULL DEFAULT 'trusted' CHECK (trust IN ('trusted', 'untrusted')));
 CREATE TABLE IF NOT EXISTS files (  id INTEGER PRIMARY KEY AUTOINCREMENT,  project_id INTEGER NOT NULL REFERENCES projects(id) ON DELETE CASCADE,  path TEXT NOT NULL,  purpose TEXT NOT NULL DEFAULT '',  hash TEXT NOT NULL DEFAULT '',  scanned_at TEXT NOT NULL,  UNIQUE(project_id, path));
 CREATE TABLE IF NOT EXISTS file_exports (  id INTEGER PRIMARY KEY AUTOINCREMENT,  file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,  name TEXT NOT NULL,  kind TEXT NOT NULL DEFAULT '');
 CREATE TABLE IF NOT EXISTS file_imports (  id INTEGER PRIMARY KEY AUTOINCREMENT,  file_id INTEGER NOT NULL REFERENCES files(id) ON DELETE CASCADE,  name TEXT NOT NULL,  kind TEXT NOT NULL DEFAULT '');
@@ -319,6 +319,20 @@ CREATE INDEX IF NOT EXISTS idx_ee_source_relation ON entity_edges(source, relati
 CREATE INDEX IF NOT EXISTS idx_ee_target_relation ON entity_edges(target, relation);
 CREATE INDEX IF NOT EXISTS idx_ee_origin_source ON entity_edges(edge_origin, source);
 CREATE INDEX IF NOT EXISTS idx_ee_projection_generation ON entity_edges(projection_generation_id, source, relation);
+-- Cross-repo dependency graph (sqlite shim mirror of schema.sql; see that file for design notes).
+-- Per-dialect deltas vs schema.sql: evidence is TEXT here (JSONB on Postgres); timestamps use
+-- datetime('now'); ids are AUTOINCREMENT. Table set is kept in parity by schema-sync-check.
+CREATE INDEX IF NOT EXISTS idx_projects_trust ON projects(trust);
+CREATE TABLE IF NOT EXISTS cross_repo_meta (  id INTEGER PRIMARY KEY CHECK (id = 1),  trust_epoch INTEGER NOT NULL DEFAULT 0 CHECK (trust_epoch >= 0),  repo_set_hash TEXT NOT NULL DEFAULT '',  blocked_symbols_version INTEGER NOT NULL DEFAULT 0 CHECK (blocked_symbols_version >= 0),  updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+-- INSERT OR IGNORE only guarantees the singleton row exists; it must not clobber live runtime counters on re-apply (see schema.sql).
+INSERT OR IGNORE INTO cross_repo_meta (id) VALUES (1);
+CREATE TABLE IF NOT EXISTS blocked_symbols (  word TEXT NOT NULL,  lang TEXT NOT NULL DEFAULT '',  reason TEXT NOT NULL DEFAULT '',  version INTEGER NOT NULL DEFAULT 0,  created_at TEXT NOT NULL DEFAULT (datetime('now')),  updated_at TEXT NOT NULL DEFAULT (datetime('now')),  PRIMARY KEY (word, lang));
+CREATE INDEX IF NOT EXISTS idx_blocked_symbols_version ON blocked_symbols(version);
+CREATE TABLE IF NOT EXISTS cross_repo_review_queue (  id INTEGER PRIMARY KEY AUTOINCREMENT,  repo_set_hash TEXT NOT NULL DEFAULT '',  symbol TEXT NOT NULL,  caller_repo TEXT NOT NULL,  candidate_definer TEXT NOT NULL DEFAULT '',  evidence TEXT NOT NULL DEFAULT '{}',  evidence_score REAL NOT NULL DEFAULT 0.0,  arrival_seq INTEGER NOT NULL DEFAULT 0,  status TEXT NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'accepted', 'rejected')),  review_class TEXT NOT NULL DEFAULT 'ambiguous' CHECK (review_class IN ('ambiguous', 'ffi')),  cross_lang INTEGER NOT NULL DEFAULT 0,  created_at TEXT NOT NULL DEFAULT (datetime('now')),  updated_at TEXT NOT NULL DEFAULT (datetime('now')),  UNIQUE (repo_set_hash, symbol, caller_repo, candidate_definer));
+CREATE INDEX IF NOT EXISTS idx_crrq_evict_open ON cross_repo_review_queue(evidence_score, arrival_seq) WHERE status = 'open';
+CREATE INDEX IF NOT EXISTS idx_crrq_caller ON cross_repo_review_queue(caller_repo, status);
+CREATE TABLE IF NOT EXISTS cross_repo_trust_audit (  id INTEGER PRIMARY KEY AUTOINCREMENT,  project TEXT NOT NULL,  actor TEXT NOT NULL DEFAULT '',  prior_trust TEXT NOT NULL DEFAULT '' CHECK (prior_trust IN ('', 'trusted', 'untrusted')),  new_trust TEXT NOT NULL DEFAULT '' CHECK (new_trust IN ('', 'trusted', 'untrusted')),  trust_epoch_before INTEGER NOT NULL DEFAULT 0,  trust_epoch_after INTEGER NOT NULL DEFAULT 0,  repo_set_hash TEXT NOT NULL DEFAULT '',  request_id TEXT NOT NULL DEFAULT '',  created_at TEXT NOT NULL DEFAULT (datetime('now')));
+CREATE INDEX IF NOT EXISTS idx_crta_project ON cross_repo_trust_audit(project, created_at);
 CREATE TABLE IF NOT EXISTS code_embeddings (  point_id INTEGER PRIMARY KEY,  embedding TEXT NOT NULL DEFAULT '[]',  project TEXT NOT NULL DEFAULT '',  node_key TEXT NOT NULL DEFAULT '',  file_path TEXT NOT NULL DEFAULT '',  symbol TEXT NOT NULL DEFAULT '',  record_type TEXT NOT NULL DEFAULT 'code_unit',  content_hash TEXT NOT NULL DEFAULT '',  body_hash TEXT NOT NULL DEFAULT '',  source_hash TEXT NOT NULL DEFAULT '',  payload_json TEXT NOT NULL DEFAULT '',  updated_at TEXT NOT NULL DEFAULT (datetime('now')));
 CREATE INDEX IF NOT EXISTS idx_code_embeddings_project ON code_embeddings(project);
 CREATE INDEX IF NOT EXISTS idx_code_embeddings_node ON code_embeddings(project, node_key);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -1397,6 +1397,27 @@ typedef struct config
    char kb_curator_synthesize_command[512];
    int kb_curator_synthesize_k;
 
+   /* Cross-repo dependency graph (kb.curator.cross_repo_graph), proposal
+    * docs/proposals/pending/cross-repo-dependency-graph.md. The resolver is
+    * query-time (P1); `enabled` gates the cross-repo pass — when 0, the query
+    * API/CLI return empty (no resolution) and no review-queue writes occur; existing
+    * queue/audit rows are preserved, not pruned. The thresholds are the
+    * versioned distinctiveness/tiering knobs (§3.3/§3.4) — bumping any of them must
+    * bump distinctiveness_v so a tier decision replays exactly. Defaults are the
+    * initial calibration (re-tuned against the S8 fixture corpus). caps/timeout
+    * bound the query path (§4.2); review_queue_max bounds the AMBIGUOUS queue (§3.8). */
+   int kb_curator_cross_repo_graph_enabled;
+   int kb_curator_cross_repo_distinctiveness_v; /* blocked_symbols/threshold model version */
+   int kb_curator_cross_repo_k;       /* K: callee in >= K trusted repos -> not distinctive */
+   int kb_curator_cross_repo_m;       /* M: defined in >= M trusted repos -> not distinctive */
+   int kb_curator_cross_repo_p_pct;   /* P: callee in >= P% of caller A's files -> local method */
+   int kb_curator_cross_repo_len_min; /* L: minimum symbol length (code points) */
+   int kb_curator_cross_repo_caller_collision_c; /* C: callee in >= C files of A -> one-tier
+                                                    downgrade */
+   int kb_curator_cross_repo_max_candidates;     /* candidate cap before truncated:true */
+   int kb_curator_cross_repo_query_timeout_ms;   /* statement_timeout for the query path */
+   int kb_curator_cross_repo_review_queue_max;   /* AMBIGUOUS review-queue cap before eviction */
+
    /* Evidence embedding (kb.evidence.embed).
     * kb_evidence_embed_enabled: 1 = drain evidence_index_ops and fill
     *   evidence_vectors via the configured embedding_command (default 1; the

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -88,6 +88,17 @@ int main(void)
       /* css_render_command defaults to the conventional sidecar curl (inert until
        * the sidecar is up), so render-capture works out of the box on-demand. */
       assert(strcmp(cfg.css_render_command, CONFIG_DEFAULT_CSS_RENDER_COMMAND) == 0);
+      /* Cross-repo dependency graph defaults (initial calibration). */
+      assert(cfg.kb_curator_cross_repo_graph_enabled == 1);
+      assert(cfg.kb_curator_cross_repo_distinctiveness_v == 1);
+      assert(cfg.kb_curator_cross_repo_k == 5);
+      assert(cfg.kb_curator_cross_repo_m == 8);
+      assert(cfg.kb_curator_cross_repo_p_pct == 25);
+      assert(cfg.kb_curator_cross_repo_len_min == 4);
+      assert(cfg.kb_curator_cross_repo_caller_collision_c == 5);
+      assert(cfg.kb_curator_cross_repo_max_candidates == 50000);
+      assert(cfg.kb_curator_cross_repo_query_timeout_ms == 5000);
+      assert(cfg.kb_curator_cross_repo_review_queue_max == 5000);
    }
 
    /* --- config_save + config_load round-trip --- */
@@ -197,6 +208,18 @@ int main(void)
       snprintf(cfg.kb_curator_tier_b_model, sizeof(cfg.kb_curator_tier_b_model), "big-32b");
       snprintf(cfg.kb_curator_tier_b_api_key, sizeof(cfg.kb_curator_tier_b_api_key), "sk-secret");
       cfg.kb_evidence_embed_enabled = 0;
+      /* kb.curator.cross_repo_graph.* — non-default values must round-trip; enabled
+       * defaults on so set off to prove the disabled state survives save+reload. */
+      cfg.kb_curator_cross_repo_graph_enabled = 0;
+      cfg.kb_curator_cross_repo_distinctiveness_v = 3;
+      cfg.kb_curator_cross_repo_k = 7;
+      cfg.kb_curator_cross_repo_m = 9;
+      cfg.kb_curator_cross_repo_p_pct = 40;
+      cfg.kb_curator_cross_repo_len_min = 3;
+      cfg.kb_curator_cross_repo_caller_collision_c = 6;
+      cfg.kb_curator_cross_repo_max_candidates = 12345;
+      cfg.kb_curator_cross_repo_query_timeout_ms = 2500;
+      cfg.kb_curator_cross_repo_review_queue_max = 999;
       /* profile_cards now defaults on; set it off to prove the disabled state
        * round-trips (regression class: a default-on bool whose save guard only
        * emitted on a truthy value would silently reset back to on). */
@@ -399,6 +422,16 @@ int main(void)
       assert(strcmp(cfg2.kb_curator_tier_b_model, "big-32b") == 0);
       assert(strcmp(cfg2.kb_curator_tier_b_api_key, "sk-secret") == 0);
       assert(cfg2.kb_evidence_embed_enabled == 0);
+      assert(cfg2.kb_curator_cross_repo_graph_enabled == 0);
+      assert(cfg2.kb_curator_cross_repo_distinctiveness_v == 3);
+      assert(cfg2.kb_curator_cross_repo_k == 7);
+      assert(cfg2.kb_curator_cross_repo_m == 9);
+      assert(cfg2.kb_curator_cross_repo_p_pct == 40);
+      assert(cfg2.kb_curator_cross_repo_len_min == 3);
+      assert(cfg2.kb_curator_cross_repo_caller_collision_c == 6);
+      assert(cfg2.kb_curator_cross_repo_max_candidates == 12345);
+      assert(cfg2.kb_curator_cross_repo_query_timeout_ms == 2500);
+      assert(cfg2.kb_curator_cross_repo_review_queue_max == 999);
       assert(cfg2.memory_profile_cards_enabled == 0);
       assert(cfg2.memory_improve_dedupe_enabled == 0);
       assert(cfg2.memory_improve_summarise_enabled == 1);
@@ -878,6 +911,34 @@ int main(void)
       int rc = config_load(&cfg);
       assert(rc == -1);
       g_config_strict = 0;
+   }
+
+   /* --- kb.curator.cross_repo_graph: strict mode rejects out-of-range knobs --- */
+   {
+      const char *bad[] = {
+          "    p_pct: 101\n", /* > 100 */
+          "    k: 0\n",       /* not positive */
+          "    query_timeout_ms: 0\n",
+          "    max_candidates: -1\n",
+          "    len_min: 99999\n", /* > 1024 ceiling */
+      };
+      for (size_t i = 0; i < sizeof(bad) / sizeof(bad[0]); i++)
+      {
+         char cpath[512];
+         snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+         FILE *f = fopen(cpath, "w");
+         assert(f);
+         fprintf(f, "provider: claude\nkb:\n  curator:\n    cross_repo_graph:\n%s", bad[i]);
+         fclose(f);
+
+         static config_t cfg;
+         memset(&cfg, 0, sizeof(cfg));
+         g_config_strict = 1;
+         platform_setenv("AIMEE_NO_CACHE", "1");
+         int rc = config_load(&cfg);
+         assert(rc == -1); /* each pathological value must be rejected in strict mode */
+         g_config_strict = 0;
+      }
    }
 
    /* --- memory.citations: valid nested values parse --- */


### PR DESCRIPTION
## Summary
First slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md`, merged via #793). **Foundation only** — schema + config; the resolver, DB stats, kb HTTP route, server/CLI surfaces, `aimee repo trust`, fixtures, and live validation land in later slices (S2a…S9). Implementation plan and this slice were roundtable-reviewed.

## Schema (both db2 dialects — `schema.sql` Postgres + `schema_sqlite.sql` shim, kept table-set-parity by `schema-sync-check`)
- `projects.trust` — `'trusted'|'untrusted'`, named CHECK constraint, default `'trusted'` (single-tenant; fail-open default documented — future non-operator INSERT paths MUST set `'untrusted'`) + index (§0).
- `cross_repo_meta` — single-row global version/epoch store (`trust_epoch`, `repo_set_hash`, `blocked_symbols_version`, `>= 0` CHECKs) backing the input-freshness stamp; `trust_epoch` is the monotonic counter S7 reads/bumps (§4.1).
- `blocked_symbols` — corpus-derived non-distinctive set, versioned + timestamped (§3.3).
- `cross_repo_review_queue` — AMBIGUOUS surface; UNIQUE fingerprint `(repo_set_hash,symbol,caller_repo,candidate_definer)` (all NOT NULL), JSONB `evidence` (Postgres) / TEXT (shim), partial eviction index `WHERE status='open'`, `review_class`/`status` enum CHECKs (§3.8).
- `cross_repo_trust_audit` — durable trust-change audit with enum CHECKs (§0 authz).

## Config (`kb.curator.cross_repo_graph.*`)
`enabled` + versioned distinctiveness/tiering knobs (K5/M8/P25/L4/C5, `distinctiveness_v`) + bounded query caps (`max_candidates`, `query_timeout_ms`) + `review_queue_max`; each with explicit type/range validation and save round-trip. `enabled=0` behavior documented.

## Tests / gates
`test_config` asserts defaults, a non-default save+reload round-trip, and strict-mode rejection of out-of-range knobs. `schema-sync-check`, `charter-tables-check`, clang-format-19 clean; the sqlite shim applies the full schema (validated via `unit-test-code-projection`).

## Review
Code-review roundtable across 2 rounds; all blocking items resolved (durable `trust_epoch` store via `cross_repo_meta`; verified NOT NULL fingerprint + full idempotency; `>= 0` CHECKs; deliberate `ON CONFLICT DO NOTHING` documented; JSONB evidence; partial index; bounded config; negative-input tests).