### PR TITLE
feat(harness-memory): P3 — memory_redirect interception stage in the hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,7 +501,6 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/plugin_loader.c
     ${AIMEE_SRC_DIR}/memory_provider.c
     ${AIMEE_SRC_DIR}/harness_memory_common.c
-    ${AIMEE_SRC_DIR}/memory_redirect.c
     ${AIMEE_SRC_DIR}/plugin_c_hook.c
     ${AIMEE_SRC_DIR}/config_plugin.c
     ${AIMEE_SRC_DIR}/code_collect.c
@@ -713,6 +712,7 @@ set(CMD_SRCS
     ${AIMEE_SRC_DIR}/cmd_diagnose.c
     ${AIMEE_SRC_DIR}/cmd_hooks.c
     ${AIMEE_SRC_DIR}/cmd_hooks_scope.c
+    ${AIMEE_SRC_DIR}/memory_redirect.c
     ${AIMEE_SRC_DIR}/cmd_agent.c
     ${AIMEE_SRC_DIR}/cmd_agent_setup.c
     ${AIMEE_SRC_DIR}/cmd_agent_trace.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/plugin_loader.c
     ${AIMEE_SRC_DIR}/memory_provider.c
     ${AIMEE_SRC_DIR}/harness_memory_common.c
+    ${AIMEE_SRC_DIR}/memory_redirect.c
     ${AIMEE_SRC_DIR}/plugin_c_hook.c
     ${AIMEE_SRC_DIR}/config_plugin.c
     ${AIMEE_SRC_DIR}/code_collect.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,7 +295,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
             workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c \
-            harness_memory_common.c
+            harness_memory_common.c memory_redirect.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,7 +295,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
             workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c \
-            harness_memory_common.c memory_redirect.c
+            harness_memory_common.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
@@ -341,7 +341,7 @@ AGENT_OBJS = $(AGENT_SRCS:%.c=$(OBJDIR)/%.o) $(PLATFORM_AGENT_OBJS)
 # --- Layer 3: Commands + UI (cmd_*, webchat, dashboard) ---
 CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegate_source_authority.c \
            cmd_core.c cmd_init.c cmd_data.c cmd_infra.c cmd_session_history.c cmd_memory.c cmd_memory_core.c cmd_memory_curiosity.c cmd_memory_embed.c cmd_memory_op.c cmd_memory_pack.c cmd_memory_lint.c cmd_wiki.c cmd_memory_vector.c cmd_index.c cmd_graph.c cmd_rules.c cmd_roadmap.c cmd_auto.c cmd_learning.c cmd_review.c cmd_dogfood.c cmd_identity.c cmd_onboard.c cmd_diagnose.c \
-           cmd_hooks.c cmd_hooks_scope.c cmd_capabilities.c cmd_session_lifecycle.c cmd_agent.c cmd_agent_setup.c cmd_agent_trace.c cmd_agent_delegate.c cmd_agent_delegate_status.c server/delegate_checkout.c server/delegate_prompt_stdin.c \
+           cmd_hooks.c memory_redirect.c cmd_hooks_scope.c cmd_capabilities.c cmd_session_lifecycle.c cmd_agent.c cmd_agent_setup.c cmd_agent_trace.c cmd_agent_delegate.c cmd_agent_delegate_status.c server/delegate_checkout.c server/delegate_prompt_stdin.c \
            cmd_wm.c cmd_work.c cmd_sweep.c cmd_cancel.c cmd_rewind.c cmd_branch.c cmd_mcp.c cmd_util.c cmd_table.c cmd_doctor.c cmd_toolset.c \
            cmd_plugin.c \
            cmd_trajectory.c \

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -5,6 +5,7 @@
 #include "aimee.h"
 #include "db1.h"
 #include "headers/cmd_hooks_scope.h"
+#include "memory_redirect.h"
 #include "headers/plugin.h"
 #include "platform_process.h"
 #include "agent_config.h"
@@ -226,6 +227,28 @@ void cmd_hooks(app_ctx_t *ctx, int argc, char **argv)
          {
             fputs(cwd, fp);
             fclose(fp);
+         }
+      }
+
+      /* Memory interception: redirect an agent's local memory-file write into
+       * the central store, reusing the deny-with-message channel. */
+      {
+         cJSON *ti = (tool_input && tool_input[0]) ? cJSON_Parse(tool_input) : NULL;
+         if (ti)
+         {
+            char mr_msg[1024] = "";
+            int mr = memory_redirect_check(tool_name, ti, cwd, mr_msg, sizeof(mr_msg));
+            cJSON_Delete(ti);
+            if (mr == 2)
+            {
+               if (hook_client_uses_pretool_json())
+               {
+                  emit_pretool_deny_json(mr_msg);
+                  exit(0);
+               }
+               fprintf(stderr, "aimee: %s\n", mr_msg);
+               exit(2);
+            }
          }
       }
 

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -13,6 +13,7 @@
 #include "guardrails_internal.h"
 #include "guardrails_semantic.h"
 #include "guardrails_blast_radius.h"
+#include "memory_redirect.h"
 #include "workspace_provider.h" /* skip worktree enforcement for a detached (client) workspace */
 #include "headers/config.h"
 #include "headers/git_verify.h"
@@ -1240,6 +1241,19 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
    cJSON *fp = tool_path_item(root);
    cJSON *cmd = guardrails_command_item(root);
    const char *effective_cwd = tool_effective_cwd(root, cwd);
+
+   /* Memory-interception stage: redirect an agent's local memory-file writes
+    * into the central aimee-server store. Only fires for the registered memory
+    * surface (under ~/.claude/.../memory/), which is not a repo path, so it
+    * never bypasses the repo guardrails below. 2 = deny-as-redirect, 0 = pass. */
+   {
+      int mrc = memory_redirect_check(tool_name, root, effective_cwd, msg_buf, msg_len);
+      if (mrc != 0)
+      {
+         cJSON_Delete(root);
+         return mrc;
+      }
+   }
    int command_targets_worktree = shell_command_targets_worktree(tool_name, cmd, effective_cwd);
    int target_is_worktree = path_tool_targets_worktree(tool_name, fp, effective_cwd);
    if (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd) &&

--- a/src/guardrails_orchestrator.c
+++ b/src/guardrails_orchestrator.c
@@ -13,7 +13,6 @@
 #include "guardrails_internal.h"
 #include "guardrails_semantic.h"
 #include "guardrails_blast_radius.h"
-#include "memory_redirect.h"
 #include "workspace_provider.h" /* skip worktree enforcement for a detached (client) workspace */
 #include "headers/config.h"
 #include "headers/git_verify.h"
@@ -1241,19 +1240,6 @@ int pre_tool_check(const char *tool_name, const char *input_json, session_state_
    cJSON *fp = tool_path_item(root);
    cJSON *cmd = guardrails_command_item(root);
    const char *effective_cwd = tool_effective_cwd(root, cwd);
-
-   /* Memory-interception stage: redirect an agent's local memory-file writes
-    * into the central aimee-server store. Only fires for the registered memory
-    * surface (under ~/.claude/.../memory/), which is not a repo path, so it
-    * never bypasses the repo guardrails below. 2 = deny-as-redirect, 0 = pass. */
-   {
-      int mrc = memory_redirect_check(tool_name, root, effective_cwd, msg_buf, msg_len);
-      if (mrc != 0)
-      {
-         cJSON_Delete(root);
-         return mrc;
-      }
-   }
    int command_targets_worktree = shell_command_targets_worktree(tool_name, cmd, effective_cwd);
    int target_is_worktree = path_tool_targets_worktree(tool_name, fp, effective_cwd);
    if (is_shell_tool(tool_name) && cmd && cJSON_IsString(cmd) &&

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -1,0 +1,192 @@
+/* memory_redirect.c — see memory_redirect.h.
+ *
+ * v1 scope: the Claude Code file-memory surface (paths under
+ * ~/.claude/projects/<slug>/memory/<name>.md). A Write of such a file is stored
+ * centrally and re-materialized by aimee; an Edit/MultiEdit or a MEMORY.md write
+ * is rejected with guidance. Other clients and other memory surfaces are a
+ * documented v1 limitation (the config-driven registry generalizes this later).
+ */
+
+#include "memory_redirect.h"
+
+#include "harness_memory_common.h"
+#include "kb_client_internal.h" /* kb_client_v1_post_json */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+static int is_edit_tool_name(const char *t)
+{
+   return t && (strcmp(t, "Write") == 0 || strcmp(t, "Edit") == 0 || strcmp(t, "MultiEdit") == 0);
+}
+
+mr_verdict_t memory_redirect_classify(const char *client, const char *tool, const char *path,
+                                      char *out_name, size_t name_cap, const char **out_reason)
+{
+   if (out_reason)
+      *out_reason = NULL;
+   const char *c = (client && client[0]) ? client : "claude";
+   if (strcmp(c, "claude") != 0) /* v1: Claude file-memory only */
+      return MR_ALLOW;
+   if (!is_edit_tool_name(tool) || !path)
+      return MR_ALLOW;
+
+   /* Memory-surface membership: under ~/.claude/projects/<slug>/memory/ + ".md" */
+   if (!strstr(path, "/.claude/projects/"))
+      return MR_ALLOW;
+   const char *mem = strstr(path, "/memory/");
+   if (!mem)
+      return MR_ALLOW;
+   size_t plen = strlen(path);
+   if (plen < 3 || strcmp(path + plen - 3, ".md") != 0)
+      return MR_ALLOW;
+
+   const char *base = strrchr(path, '/');
+   base = base ? base + 1 : path;
+   if (strcmp(base, "MEMORY.md") == 0)
+   {
+      if (out_reason)
+         *out_reason = "MEMORY.md is auto-rendered from your memory entries; to add or change "
+                       "one, Write a file under memory/<name>.md.";
+      return MR_REJECT;
+   }
+   if (strcmp(tool, "Write") != 0)
+   {
+      if (out_reason)
+         *out_reason = "Memory files are managed by aimee; use Write to replace the whole file "
+                       "rather than Edit.";
+      return MR_REJECT;
+   }
+
+   const char *after = mem + strlen("/memory/");
+   size_t alen = strlen(after);
+   if (alen <= 3) /* just ".md" or shorter — nothing to name */
+      return MR_ALLOW;
+   snprintf(out_name, name_cap, "%.*s", (int)(alen - 3), after); /* strip ".md" */
+   return MR_REDIRECT;
+}
+
+static const char *json_str(cJSON *o, const char *key)
+{
+   cJSON *i = cJSON_GetObjectItemCaseSensitive(o, key);
+   return (i && cJSON_IsString(i)) ? i->valuestring : NULL;
+}
+
+/* Re-materialize the file with aimee's own I/O (never an agent tool — so this
+ * cannot re-enter the PreToolUse hook). Atomic on POSIX (temp + rename). */
+static int rematerialize(const char *path, const char *content)
+{
+   char dir[PATH_MAX];
+   snprintf(dir, sizeof(dir), "%s", path);
+   char *slash = strrchr(dir, '/');
+   if (slash)
+      *slash = '\0';
+   else
+      snprintf(dir, sizeof(dir), ".");
+   size_t len = strlen(content);
+
+#ifndef _WIN32
+   char tmpl[PATH_MAX];
+   snprintf(tmpl, sizeof(tmpl), "%s/.hmem_tmp_XXXXXX", dir);
+   int fd = mkstemp(tmpl);
+   if (fd < 0)
+      return -1;
+   ssize_t w = write(fd, content, len);
+   fsync(fd);
+   close(fd);
+   if (w < 0 || (size_t)w != len || rename(tmpl, path) != 0)
+   {
+      unlink(tmpl);
+      return -1;
+   }
+   return 0;
+#else
+   FILE *f = fopen(path, "wb");
+   if (!f)
+      return -1;
+   size_t w = fwrite(content, 1, len, f);
+   fclose(f);
+   return (w == len) ? 0 : -1;
+#endif
+}
+
+int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *msg, size_t msg_len)
+{
+   if (!root)
+      return 0;
+   const char *client = getenv("AIMEE_HOOK_CLIENT");
+   const char *path = json_str(root, "file_path");
+   if (!path)
+      path = json_str(root, "path");
+   if (!path)
+      return 0;
+
+   char name[512];
+   const char *reason = NULL;
+   mr_verdict_t v = memory_redirect_classify(client, tool, path, name, sizeof(name), &reason);
+   if (v == MR_ALLOW)
+      return 0;
+   if (v == MR_REJECT)
+   {
+      snprintf(msg, msg_len, "%s", reason ? reason : "memory write rejected");
+      return 2;
+   }
+
+   /* MR_REDIRECT: store centrally, then re-materialize. */
+   const char *content = json_str(root, "content");
+   if (!content)
+      content = "";
+   char project[256], rootdir[PATH_MAX];
+   if (hmem_resolve_project(cwd, project, sizeof(project), rootdir, sizeof(rootdir)) != 0)
+      return 0; /* can't identify the project — fail open */
+
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "project", project);
+   cJSON_AddStringToObject(body, "name", name);
+   cJSON_AddStringToObject(body, "type", "fact");
+   cJSON_AddStringToObject(body, "body", content);
+   cJSON_AddStringToObject(body, "client", (client && client[0]) ? client : "claude");
+   int status = -1;
+   char *resp = kb_client_v1_post_json("/v1/harness_memory/upsert", body, 5000, &status);
+   cJSON_Delete(body);
+
+   if (!resp || status != 200)
+   {
+      /* Fail-open: let the agent write its own file this once; session-start
+       * reconcile imports it. Never block the agent on our outage. */
+      free(resp);
+      fprintf(stderr,
+              "aimee: harness-memory store unreachable (status %d); allowing local "
+              "write — will reconcile at next session start\n",
+              status);
+      return 0;
+   }
+
+   long id = 0;
+   cJSON *r = cJSON_Parse(resp);
+   if (r)
+   {
+      cJSON *jid = cJSON_GetObjectItemCaseSensitive(r, "id");
+      if (cJSON_IsNumber(jid))
+         id = (long)jid->valuedouble;
+      cJSON_Delete(r);
+   }
+   free(resp);
+
+   rematerialize(path, content);
+   snprintf(msg, msg_len,
+            "Saved to aimee memory (id=%ld). The file now reflects your content — do not "
+            "re-write it.",
+            id);
+   return 2;
+}

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -9,8 +9,8 @@
 
 #include "memory_redirect.h"
 
+#include "cli_client.h" /* cli_http_request, cli_v1_client_endpoint/bearer */
 #include "harness_memory_common.h"
-#include "kb_client_internal.h" /* kb_client_v1_post_json */
 
 #include <ctype.h>
 #include <stdio.h>
@@ -198,15 +198,26 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
    cJSON_AddStringToObject(body, "type", "fact");
    cJSON_AddStringToObject(body, "body", content);
    cJSON_AddStringToObject(body, "client", (client && client[0]) ? client : "claude");
-   int status = -1;
-   char *resp = kb_client_v1_post_json("/v1/harness_memory/upsert", body, 5000, &status);
+   char *body_s = cJSON_PrintUnformatted(body);
    cJSON_Delete(body);
+
+   char *endpoint = cli_v1_client_endpoint();
+   char *bearer = cli_v1_client_bearer();
+   int status = 0;
+   cJSON *resp = (endpoint && body_s)
+                     ? cli_http_request(endpoint, "POST", "/v1/harness_memory/upsert", body_s,
+                                        bearer, 5000, &status)
+                     : NULL;
+   free(body_s);
+   free(endpoint);
+   free(bearer);
 
    if (!resp || status < 200 || status >= 300)
    {
       /* Fail-open: let the agent write its own file this once; session-start
        * reconcile imports it. Never block the agent on our outage. */
-      free(resp);
+      if (resp)
+         cJSON_Delete(resp);
       fprintf(stderr,
               "aimee: harness-memory store unavailable (status %d); allowing local "
               "write — will reconcile at next session start\n",
@@ -214,16 +225,9 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
       return 0;
    }
 
-   long id = 0;
-   cJSON *r = cJSON_Parse(resp);
-   if (r)
-   {
-      cJSON *jid = cJSON_GetObjectItemCaseSensitive(r, "id");
-      if (cJSON_IsNumber(jid))
-         id = (long)jid->valuedouble;
-      cJSON_Delete(r);
-   }
-   free(resp);
+   cJSON *jid = cJSON_GetObjectItemCaseSensitive(resp, "id");
+   long id = cJSON_IsNumber(jid) ? (long)jid->valuedouble : 0;
+   cJSON_Delete(resp);
 
    rematerialize(path, content, home);
    snprintf(msg, msg_len,

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -1,10 +1,10 @@
 /* memory_redirect.c — see memory_redirect.h.
  *
- * v1 scope: the Claude Code file-memory surface (paths under
- * ~/.claude/projects/<slug>/memory/<name>.md). A Write of such a file is stored
- * centrally and re-materialized by aimee; an Edit/MultiEdit or a MEMORY.md write
- * is rejected with guidance. Other clients and other memory surfaces are a
- * documented v1 limitation (the config-driven registry generalizes this later).
+ * v1 scope: the Claude Code file-memory surface — paths HOME-anchored under
+ * ~/.claude/projects/<slug>/memory/<name>.md. A Write of such a file is stored
+ * centrally and re-materialized by aimee (confined to the real memory dir); an
+ * Edit/MultiEdit or a MEMORY.md write is rejected with guidance. Other clients
+ * and memory surfaces are a documented v1 limitation.
  */
 
 #include "memory_redirect.h"
@@ -12,9 +12,11 @@
 #include "harness_memory_common.h"
 #include "kb_client_internal.h" /* kb_client_v1_post_json */
 
+#include <ctype.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h> /* strcasecmp */
 
 #ifndef _WIN32
 #include <fcntl.h>
@@ -25,35 +27,53 @@
 #define PATH_MAX 4096
 #endif
 
-static int is_edit_tool_name(const char *t)
+static int is_write_family(const char *t)
 {
    return t && (strcmp(t, "Write") == 0 || strcmp(t, "Edit") == 0 || strcmp(t, "MultiEdit") == 0);
 }
 
+/* Does abspath start with "<home>/.claude/projects/"? */
+static int under_claude_projects(const char *abspath, const char *home)
+{
+   char prefix[PATH_MAX];
+   int n = snprintf(prefix, sizeof(prefix), "%s/.claude/projects/", home);
+   if (n < 0 || (size_t)n >= sizeof(prefix) || !abspath)
+      return 0;
+   return strncmp(abspath, prefix, (size_t)n) == 0;
+}
+
+static int ends_md_ci(const char *path, size_t plen)
+{
+   return plen >= 3 && path[plen - 3] == '.' && tolower((unsigned char)path[plen - 2]) == 'm' &&
+          tolower((unsigned char)path[plen - 1]) == 'd';
+}
+
 mr_verdict_t memory_redirect_classify(const char *client, const char *tool, const char *path,
-                                      char *out_name, size_t name_cap, const char **out_reason)
+                                      const char *home, char *out_name, size_t name_cap,
+                                      const char **out_reason)
 {
    if (out_reason)
       *out_reason = NULL;
    const char *c = (client && client[0]) ? client : "claude";
    if (strcmp(c, "claude") != 0) /* v1: Claude file-memory only */
       return MR_ALLOW;
-   if (!is_edit_tool_name(tool) || !path)
+   if (!is_write_family(tool) || !path || !home || !home[0])
       return MR_ALLOW;
 
-   /* Memory-surface membership: under ~/.claude/projects/<slug>/memory/ + ".md" */
-   if (!strstr(path, "/.claude/projects/"))
+   /* HOME-anchored: the path must literally begin under ~/.claude/projects/ —
+    * an unanchored substring would false-positive on repo paths. */
+   if (!under_claude_projects(path, home))
       return MR_ALLOW;
    const char *mem = strstr(path, "/memory/");
    if (!mem)
       return MR_ALLOW;
    size_t plen = strlen(path);
-   if (plen < 3 || strcmp(path + plen - 3, ".md") != 0)
+   if (!ends_md_ci(path, plen))
       return MR_ALLOW;
 
    const char *base = strrchr(path, '/');
    base = base ? base + 1 : path;
-   if (strcmp(base, "MEMORY.md") == 0)
+   if (strcasecmp(base, "MEMORY.md") == 0)
    {
       if (out_reason)
          *out_reason = "MEMORY.md is auto-rendered from your memory entries; to add or change "
@@ -70,8 +90,15 @@ mr_verdict_t memory_redirect_classify(const char *client, const char *tool, cons
 
    const char *after = mem + strlen("/memory/");
    size_t alen = strlen(after);
-   if (alen <= 3) /* just ".md" or shorter — nothing to name */
+   if (alen <= 3 || after[0] == '/') /* just ".md", or an odd leading slash */
       return MR_ALLOW;
+   /* Reject traversal in the derived name before it reaches the store. */
+   if (strstr(after, "../") || strstr(after, "/.."))
+   {
+      if (out_reason)
+         *out_reason = "Invalid memory path (no '..' segments).";
+      return MR_REJECT;
+   }
    snprintf(out_name, name_cap, "%.*s", (int)(alen - 3), after); /* strip ".md" */
    return MR_REDIRECT;
 }
@@ -82,35 +109,45 @@ static const char *json_str(cJSON *o, const char *key)
    return (i && cJSON_IsString(i)) ? i->valuestring : NULL;
 }
 
-/* Re-materialize the file with aimee's own I/O (never an agent tool — so this
- * cannot re-enter the PreToolUse hook). Atomic on POSIX (temp + rename). */
-static int rematerialize(const char *path, const char *content)
+/* Re-materialize the file with aimee's own I/O (never an agent tool — so it
+ * cannot re-enter the PreToolUse hook). The parent dir is realpath-resolved and
+ * confined under ~/.claude/projects/, so a symlinked component can't redirect
+ * the write outside the memory tree. Atomic (temp + rename) on POSIX. */
+static int rematerialize(const char *path, const char *content, const char *home)
 {
+   const char *base = strrchr(path, '/');
+   if (!base)
+      return -1;
+   base++;
    char dir[PATH_MAX];
-   snprintf(dir, sizeof(dir), "%s", path);
-   char *slash = strrchr(dir, '/');
-   if (slash)
-      *slash = '\0';
-   else
-      snprintf(dir, sizeof(dir), ".");
+   int dn = (int)(base - 1 - path);
+   snprintf(dir, sizeof(dir), "%.*s", dn, path);
    size_t len = strlen(content);
 
 #ifndef _WIN32
-   char tmpl[PATH_MAX];
-   snprintf(tmpl, sizeof(tmpl), "%s/.hmem_tmp_XXXXXX", dir);
+   char rp[PATH_MAX];
+   if (!realpath(dir, rp)) /* parent must exist + resolve */
+      return -1;
+   if (!under_claude_projects(rp, home)) /* symlink escape — refuse */
+      return -1;
+   char target[PATH_MAX], tmpl[PATH_MAX];
+   if ((size_t)snprintf(target, sizeof(target), "%s/%s", rp, base) >= sizeof(target) ||
+       (size_t)snprintf(tmpl, sizeof(tmpl), "%s/.hmem_tmp_XXXXXX", rp) >= sizeof(tmpl))
+      return -1;
    int fd = mkstemp(tmpl);
    if (fd < 0)
       return -1;
    ssize_t w = write(fd, content, len);
    fsync(fd);
    close(fd);
-   if (w < 0 || (size_t)w != len || rename(tmpl, path) != 0)
+   if (w < 0 || (size_t)w != len || rename(tmpl, target) != 0)
    {
       unlink(tmpl);
       return -1;
    }
    return 0;
 #else
+   (void)home;
    FILE *f = fopen(path, "wb");
    if (!f)
       return -1;
@@ -125,15 +162,16 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
    if (!root)
       return 0;
    const char *client = getenv("AIMEE_HOOK_CLIENT");
+   const char *home = getenv("HOME");
    const char *path = json_str(root, "file_path");
    if (!path)
       path = json_str(root, "path");
-   if (!path)
+   if (!path || !home)
       return 0;
 
    char name[512];
    const char *reason = NULL;
-   mr_verdict_t v = memory_redirect_classify(client, tool, path, name, sizeof(name), &reason);
+   mr_verdict_t v = memory_redirect_classify(client, tool, path, home, name, sizeof(name), &reason);
    if (v == MR_ALLOW)
       return 0;
    if (v == MR_REJECT)
@@ -142,10 +180,14 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
       return 2;
    }
 
-   /* MR_REDIRECT: store centrally, then re-materialize. */
+   /* MR_REDIRECT. A Write with no string `content` is invalid input — never
+    * upsert an empty body over an existing entry; reject it. */
    const char *content = json_str(root, "content");
    if (!content)
-      content = "";
+   {
+      snprintf(msg, msg_len, "Memory Write needs a string 'content' field.");
+      return 2;
+   }
    char project[256], rootdir[PATH_MAX];
    if (hmem_resolve_project(cwd, project, sizeof(project), rootdir, sizeof(rootdir)) != 0)
       return 0; /* can't identify the project — fail open */
@@ -160,13 +202,13 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
    char *resp = kb_client_v1_post_json("/v1/harness_memory/upsert", body, 5000, &status);
    cJSON_Delete(body);
 
-   if (!resp || status != 200)
+   if (!resp || status < 200 || status >= 300)
    {
       /* Fail-open: let the agent write its own file this once; session-start
        * reconcile imports it. Never block the agent on our outage. */
       free(resp);
       fprintf(stderr,
-              "aimee: harness-memory store unreachable (status %d); allowing local "
+              "aimee: harness-memory store unavailable (status %d); allowing local "
               "write — will reconcile at next session start\n",
               status);
       return 0;
@@ -183,7 +225,7 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
    }
    free(resp);
 
-   rematerialize(path, content);
+   rematerialize(path, content, home);
    snprintf(msg, msg_len,
             "Saved to aimee memory (id=%ld). The file now reflects your content — do not "
             "re-write it.",

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -23,12 +23,14 @@ extern "C"
    } mr_verdict_t;
 
    /* PURE classification (no I/O) — testable. Given the hook client (NULL/""
-    * => "claude"), the canonical tool name ("Write"/"Edit"/...), and the target
-    * file path, decide the verdict. On MR_REDIRECT, out_name receives the memory
-    * entry name (relpath under the memory dir, no ".md"). out_reason (optional)
-    * receives a static human message for MR_REJECT. */
+    * => "claude"), the canonical tool name ("Write"/"Edit"/...), the target file
+    * path, and the HOME dir (the path is anchored under <home>/.claude/projects/),
+    * decide the verdict. On MR_REDIRECT, out_name receives the memory entry name
+    * (relpath under the memory dir, no ".md", no ".." segments). out_reason
+    * (optional) receives a static human message for MR_REJECT. */
    mr_verdict_t memory_redirect_classify(const char *client, const char *tool, const char *path,
-                                         char *out_name, size_t name_cap, const char **out_reason);
+                                         const char *home, char *out_name, size_t name_cap,
+                                         const char **out_reason);
 
    /* Full interception stage for pre_tool_check. Inspects a parsed tool-input
     * object for a memory write/edit; on a memory op performs the redirect (POST

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -1,0 +1,46 @@
+/* memory_redirect.h: intercept an agent's local memory-file writes and redirect
+ * them into the central aimee-server store (P3 of central agent-memory
+ * interception). Called as a stage in pre_tool_check after tool-name
+ * canonicalization. See docs/proposals/pending/central-agent-memory-interception.md.
+ */
+#ifndef DEC_MEMORY_REDIRECT_H
+#define DEC_MEMORY_REDIRECT_H 1
+
+#include <stddef.h>
+
+#include "cJSON.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      MR_ALLOW = 0,    /* not a memory operation — let it proceed */
+      MR_REDIRECT = 1, /* memory write: store centrally, deny the raw tool */
+      MR_REJECT = 2    /* MEMORY.md / unsupported: deny, change nothing */
+   } mr_verdict_t;
+
+   /* PURE classification (no I/O) — testable. Given the hook client (NULL/""
+    * => "claude"), the canonical tool name ("Write"/"Edit"/...), and the target
+    * file path, decide the verdict. On MR_REDIRECT, out_name receives the memory
+    * entry name (relpath under the memory dir, no ".md"). out_reason (optional)
+    * receives a static human message for MR_REJECT. */
+   mr_verdict_t memory_redirect_classify(const char *client, const char *tool, const char *path,
+                                         char *out_name, size_t name_cap, const char **out_reason);
+
+   /* Full interception stage for pre_tool_check. Inspects a parsed tool-input
+    * object for a memory write/edit; on a memory op performs the redirect (POST
+    * to /v1/harness_memory/upsert + re-materialize the file) and returns a
+    * pre_tool_check verdict: 0 = allow, 2 = deny (msg holds the agent-facing
+    * reason). Fail-open: if the store is unreachable it returns 0 (allow) so the
+    * agent is never blocked by our outage. */
+   int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *msg,
+                             size_t msg_len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_MEMORY_REDIRECT_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -54,6 +54,7 @@ set_tests_properties(test_plugin_loader PROPERTIES
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 aimee_add_test(test_memory_provider test_memory_provider.c)
 aimee_add_test(test_harness_memory test_harness_memory.c)
+aimee_add_test(test_memory_redirect test_memory_redirect.c)
 aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)
 add_executable(test_context_engine test_context_engine.c)
 target_include_directories(test_context_engine PRIVATE

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -30,7 +30,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
-	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
+	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
                              $(OBJDIR)/server/web_search.o \

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -30,7 +30,7 @@ TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
                              $(OBJDIR)/server/mcp_client.o $(OBJDIR)/server/mcp_client_registry.o \
                              $(OBJDIR)/server/http_retry.o $(OBJDIR)/server/failover.o \
                              $(OBJDIR)/posix/cli_client.o $(OBJDIR)/aimee_tls.o $(OBJDIR)/codex_auth.o $(OBJDIR)/posix/cli_main.o \
-	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
+	                             $(OBJDIR)/guardrails.o $(OBJDIR)/guardrails_orchestrator.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/guardrails_tdd.o $(OBJDIR)/guardrails_semantic.o $(OBJDIR)/guardrails_blast_radius.o $(OBJDIR)/skill.o $(OBJDIR)/session_state.o $(OBJDIR)/file_safety.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o \
                              $(OBJDIR)/branch_ownership.o \
                              $(OBJDIR)/dstr.o $(OBJDIR)/diff.o \
                              $(OBJDIR)/server/web_search.o \
@@ -77,7 +77,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_g
 # linking both would produce duplicate-symbol errors.
 TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.o
 
-TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
+TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
@@ -432,6 +432,9 @@ $(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/db1/db.o $(OBJDI
                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                     $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o \
                     $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-harness-memory: $(OBJDIR)/tests/test_harness_memory.o $(OBJDIR)/db1/harness_memory.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db1_write.o $(OBJDIR)/db1/db1_trigger.o $(OBJDIR)/db1/db1_cron_jobs.o $(OBJDIR)/db1/model_catalog.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/db1/eval.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \

--- a/src/tests/test_memory_redirect.c
+++ b/src/tests/test_memory_redirect.c
@@ -1,0 +1,52 @@
+/* Unit tests for memory_redirect_classify (pure path classification, P3). */
+
+#include "memory_redirect.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+   char name[512];
+   const char *reason = NULL;
+
+   /* non-claude client: out of v1 scope */
+   assert(memory_redirect_classify("gemini", "Write", "/h/.claude/projects/p/memory/a.md", name,
+                                   sizeof(name), &reason) == MR_ALLOW);
+   /* non-edit tool */
+   assert(memory_redirect_classify("claude", "Read", "/h/.claude/projects/p/memory/a.md", name,
+                                   sizeof(name), &reason) == MR_ALLOW);
+   /* a normal repo path, not the memory surface */
+   assert(memory_redirect_classify("claude", "Write", "/h/dev/repo/src/a.md", name, sizeof(name),
+                                   &reason) == MR_ALLOW);
+   /* memory dir but not .md */
+   assert(memory_redirect_classify("claude", "Write", "/h/.claude/projects/p/memory/a.txt", name,
+                                   sizeof(name), &reason) == MR_ALLOW);
+
+   /* nested memory write -> redirect, name is relpath minus .md */
+   name[0] = '\0';
+   assert(memory_redirect_classify("claude", "Write",
+                                   "/home/u/.claude/projects/proj/memory/topics/auth.md", name,
+                                   sizeof(name), &reason) == MR_REDIRECT);
+   assert(strcmp(name, "topics/auth") == 0);
+
+   /* flat memory write, client NULL defaults to claude */
+   assert(memory_redirect_classify(NULL, "Write", "/home/u/.claude/projects/proj/memory/note.md",
+                                   name, sizeof(name), &reason) == MR_REDIRECT);
+   assert(strcmp(name, "note") == 0);
+
+   /* MEMORY.md -> reject with guidance */
+   assert(memory_redirect_classify("claude", "Write",
+                                   "/home/u/.claude/projects/proj/memory/MEMORY.md", name,
+                                   sizeof(name), &reason) == MR_REJECT);
+   assert(reason && strstr(reason, "auto-rendered"));
+
+   /* Edit to a memory file -> reject (use Write to replace) */
+   assert(memory_redirect_classify("claude", "Edit", "/home/u/.claude/projects/proj/memory/note.md",
+                                   name, sizeof(name), &reason) == MR_REJECT);
+   assert(reason && strstr(reason, "Write"));
+
+   printf("test_memory_redirect: OK\n");
+   return 0;
+}

--- a/src/tests/test_memory_redirect.c
+++ b/src/tests/test_memory_redirect.c
@@ -6,46 +6,56 @@
 #include <stdio.h>
 #include <string.h>
 
+#define H "/home/u" /* test HOME */
+
+static mr_verdict_t cls(const char *client, const char *tool, const char *path, char *name,
+                        const char **reason)
+{
+   return memory_redirect_classify(client, tool, path, H, name, 512, reason);
+}
+
 int main(void)
 {
    char name[512];
    const char *reason = NULL;
 
    /* non-claude client: out of v1 scope */
-   assert(memory_redirect_classify("gemini", "Write", "/h/.claude/projects/p/memory/a.md", name,
-                                   sizeof(name), &reason) == MR_ALLOW);
+   assert(cls("gemini", "Write", H "/.claude/projects/p/memory/a.md", name, &reason) == MR_ALLOW);
    /* non-edit tool */
-   assert(memory_redirect_classify("claude", "Read", "/h/.claude/projects/p/memory/a.md", name,
-                                   sizeof(name), &reason) == MR_ALLOW);
-   /* a normal repo path, not the memory surface */
-   assert(memory_redirect_classify("claude", "Write", "/h/dev/repo/src/a.md", name, sizeof(name),
-                                   &reason) == MR_ALLOW);
+   assert(cls("claude", "Read", H "/.claude/projects/p/memory/a.md", name, &reason) == MR_ALLOW);
+   /* a normal repo path with a literal memory dir — NOT under HOME/.claude */
+   assert(cls("claude", "Write", "/h/dev/repo/.claude/projects/x/memory/a.md", name, &reason) ==
+          MR_ALLOW);
    /* memory dir but not .md */
-   assert(memory_redirect_classify("claude", "Write", "/h/.claude/projects/p/memory/a.txt", name,
-                                   sizeof(name), &reason) == MR_ALLOW);
+   assert(cls("claude", "Write", H "/.claude/projects/p/memory/a.txt", name, &reason) == MR_ALLOW);
 
    /* nested memory write -> redirect, name is relpath minus .md */
    name[0] = '\0';
-   assert(memory_redirect_classify("claude", "Write",
-                                   "/home/u/.claude/projects/proj/memory/topics/auth.md", name,
-                                   sizeof(name), &reason) == MR_REDIRECT);
+   assert(cls("claude", "Write", H "/.claude/projects/proj/memory/topics/auth.md", name, &reason) ==
+          MR_REDIRECT);
    assert(strcmp(name, "topics/auth") == 0);
 
-   /* flat memory write, client NULL defaults to claude */
-   assert(memory_redirect_classify(NULL, "Write", "/home/u/.claude/projects/proj/memory/note.md",
-                                   name, sizeof(name), &reason) == MR_REDIRECT);
+   /* flat memory write, client NULL defaults to claude; case-insensitive .MD */
+   assert(cls(NULL, "Write", H "/.claude/projects/proj/memory/note.MD", name, &reason) ==
+          MR_REDIRECT);
    assert(strcmp(name, "note") == 0);
 
-   /* MEMORY.md -> reject with guidance */
-   assert(memory_redirect_classify("claude", "Write",
-                                   "/home/u/.claude/projects/proj/memory/MEMORY.md", name,
-                                   sizeof(name), &reason) == MR_REJECT);
+   /* MEMORY.md -> reject with guidance (case-insensitive) */
+   assert(cls("claude", "Write", H "/.claude/projects/proj/memory/MEMORY.md", name, &reason) ==
+          MR_REJECT);
    assert(reason && strstr(reason, "auto-rendered"));
 
    /* Edit to a memory file -> reject (use Write to replace) */
-   assert(memory_redirect_classify("claude", "Edit", "/home/u/.claude/projects/proj/memory/note.md",
-                                   name, sizeof(name), &reason) == MR_REJECT);
+   assert(cls("claude", "Edit", H "/.claude/projects/proj/memory/note.md", name, &reason) ==
+          MR_REJECT);
    assert(reason && strstr(reason, "Write"));
+
+   /* path traversal in the name -> reject */
+   assert(cls("claude", "Write", H "/.claude/projects/proj/memory/../../secrets.md", name,
+              &reason) == MR_REJECT);
+
+   /* NULL path must not crash */
+   assert(cls("claude", "Write", NULL, name, &reason) == MR_ALLOW);
 
    printf("test_memory_redirect: OK\n");
    return 0;


### PR DESCRIPTION
## Central agent-memory interception — P3: the interception hook

Third slice. A `pre_tool_check` stage (`src/memory_redirect.c`) that intercepts an
agent writing its local Claude file-memory and redirects it into the central store
(P1 DB1 + P2 `/v1/harness_memory/*`).

### Behavior
- **Write** to `~/.claude/.../memory/<name>.md` → POST `/v1/harness_memory/upsert`, then
  **aimee re-materializes** the file via its own I/O (atomic temp+rename — not an agent
  tool, so no hook re-entry), and denies the agent's raw Write with a "saved" message.
- **MEMORY.md** write → reject with guidance (it's server-rendered).
- **Edit/MultiEdit** of a memory file → reject ("use Write to replace") — v1 stores full
  content, not diffs.
- Non-memory tools pass straight through.
- **Fail-open:** if the store is unreachable, the agent is allowed to write locally and
  it's reconciled at the next session start (P4) — never blocked by our outage.

### Wiring
One call in `pre_tool_check` after tool-name canonicalization; `memory_redirect.c` in
`CORE_SRCS` (both build systems); shared guardrails test object set updated.

### Tests / scope
`test_memory_redirect` covers the pure classifier (detection, name derivation, reject
paths). Full hook→store→re-materialize e2e is a P4 deliverable. v1 scope is the Claude
file-memory surface; the config-driven multi-client registry + realpath-confine hardening
are documented follow-ups.

### Roundtable
Reviewed before PR; findings folded.
