### PR TITLE
feat(kb): cross-repo dep graph S2a — pure import resolution + distinctiveness

### DIFF
--- a/src/db2/cross_repo_resolver.c
+++ b/src/db2/cross_repo_resolver.c
@@ -1,0 +1,339 @@
+/* cross_repo_resolver.c: pure, DB-free core of the cross-repo dependency
+ * resolver (S2a: import resolution + distinctiveness). See cross_repo_resolver.h
+ * and docs/proposals/pending/cross-repo-dependency-graph.md §3.1/§3.3/§3.7. */
+
+#include "cross_repo_resolver.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* ---- language classification --------------------------------------------- */
+
+static int path_has_ext(const char *path, const char *ext)
+{
+   size_t pl = strlen(path), el = strlen(ext);
+   return pl >= el && strcmp(path + pl - el, ext) == 0;
+}
+
+xrepo_lang_t xrepo_lang_from_path(const char *path)
+{
+   if (!path || !path[0])
+      return XREPO_LANG_UNKNOWN;
+   /* C++ first: its extensions are unambiguous; .h is treated as C. */
+   if (path_has_ext(path, ".cpp") || path_has_ext(path, ".cc") || path_has_ext(path, ".cxx") ||
+       path_has_ext(path, ".hpp") || path_has_ext(path, ".hh") || path_has_ext(path, ".hxx"))
+      return XREPO_LANG_CPP;
+   if (path_has_ext(path, ".c") || path_has_ext(path, ".h"))
+      return XREPO_LANG_C;
+   if (path_has_ext(path, ".rs"))
+      return XREPO_LANG_RUST;
+   if (path_has_ext(path, ".go"))
+      return XREPO_LANG_GO;
+   if (path_has_ext(path, ".tsx") || path_has_ext(path, ".ts"))
+      return XREPO_LANG_TS;
+   if (path_has_ext(path, ".jsx") || path_has_ext(path, ".js") || path_has_ext(path, ".mjs") ||
+       path_has_ext(path, ".cjs"))
+      return XREPO_LANG_JS;
+   if (path_has_ext(path, ".py"))
+      return XREPO_LANG_PYTHON;
+   return XREPO_LANG_UNKNOWN;
+}
+
+const char *xrepo_lang_name(xrepo_lang_t lang)
+{
+   switch (lang)
+   {
+   case XREPO_LANG_C:
+      return "c";
+   case XREPO_LANG_CPP:
+      return "cpp";
+   case XREPO_LANG_RUST:
+      return "rust";
+   case XREPO_LANG_GO:
+      return "go";
+   case XREPO_LANG_TS:
+      return "ts";
+   case XREPO_LANG_JS:
+      return "js";
+   case XREPO_LANG_PYTHON:
+      return "python";
+   default:
+      return "unknown";
+   }
+}
+
+/* ---- distinctiveness (§3.3) ---------------------------------------------- */
+
+size_t xrepo_utf8_len(const char *s)
+{
+   size_t n = 0;
+   if (!s)
+      return 0;
+   for (const unsigned char *p = (const unsigned char *)s; *p; p++)
+      if ((*p & 0xC0) != 0x80) /* count lead bytes, skip UTF-8 continuation bytes */
+         n++;
+   return n;
+}
+
+int xrepo_name_distinctive(const char *symbol, const xrepo_distinct_stats_t *stats,
+                           const xrepo_distinct_cfg_t *cfg)
+{
+   if (!symbol || !stats || !cfg)
+      return 0;
+   if ((int)xrepo_utf8_len(symbol) < cfg->len_min)
+      return 0;
+   if (cfg->k > 0 && stats->callee_repo_count >= cfg->k)
+      return 0;
+   if (cfg->m > 0 && stats->definer_repo_count >= cfg->m)
+      return 0;
+   if (cfg->p_pct > 0 && stats->caller_file_pct >= cfg->p_pct)
+      return 0;
+   return 1;
+}
+
+/* ---- import resolution (§3.7) -------------------------------------------- */
+
+/* Builtin C/C++ system/framework headers: an include resolving to one of these
+ * is rejected (never a cross-repo edge), even if a repo happens to index a file
+ * of the same basename. The set is intentionally conservative; the configurable
+ * per-workspace blocklist (S3) extends it, and a stale entry degrades to
+ * AMBIGUOUS rather than failing open/closed. */
+static const char *const C_SYSTEM_HEADERS[] = {
+    "stdio.h",     "stdlib.h",      "string.h",      "stddef.h", "stdint.h",
+    "stdbool.h",   "stdarg.h",      "ctype.h",       "errno.h",  "math.h",
+    "time.h",      "assert.h",      "limits.h",      "unistd.h", "fcntl.h",
+    "signal.h",    "memory",        "vector",        "string",   "string_view",
+    "cstdio",      "cstdlib",       "cstring",       "cstdint",  "cstddef",
+    "cstdarg",     "cerrno",        "cctype",        "climits",  "map",
+    "set",         "unordered_map", "unordered_set", "list",     "deque",
+    "queue",       "stack",         "algorithm",     "numeric",  "ranges",
+    "utility",     "tuple",         "iostream",      "sstream",  "fstream",
+    "iomanip",     "mutex",         "thread",        "atomic",   "condition_variable",
+    "future",      "chrono",        "filesystem",    "cassert",  "cmath",
+    "stdexcept",   "array",         "functional",    "optional", "variant",
+    "type_traits", "memory.h",      "pthread.h",     "dlfcn.h",
+};
+
+static const char *basename_of(const char *path)
+{
+   const char *slash = strrchr(path, '/');
+   return slash ? slash + 1 : path;
+}
+
+static int is_c_system_header(const char *inc)
+{
+   const char *base = basename_of(inc);
+   for (size_t i = 0; i < sizeof(C_SYSTEM_HEADERS) / sizeof(C_SYSTEM_HEADERS[0]); i++)
+      if (strcmp(base, C_SYSTEM_HEADERS[i]) == 0)
+         return 1;
+   return 0;
+}
+
+/* True if `path` ends with `suffix` on a path-component boundary
+ * (path == suffix, or path ends with "/"+suffix). */
+static int path_suffix_match(const char *path, const char *suffix)
+{
+   size_t pl = strlen(path), sl = strlen(suffix);
+   if (sl == 0 || pl < sl)
+      return 0;
+   if (strcmp(path + pl - sl, suffix) != 0)
+      return 0;
+   return pl == sl || path[pl - sl - 1] == '/';
+}
+
+static int is_caller(const xrepo_repo_desc_t *d, const char *caller_repo)
+{
+   return caller_repo && d->name && strcmp(d->name, caller_repo) == 0;
+}
+
+/* Turn a list of matched definer-repo indices into a result. count==0 -> NONE,
+ * 1 -> ONE, >1 -> MANY with the colliders enumerated (capped, total in
+ * collision_count). The caller is assumed already excluded from `idx`. */
+static xrepo_resolve_result_t result_from_matches(const int *idx, int count, int sys,
+                                                  xrepo_import_modality_t modality)
+{
+   xrepo_resolve_result_t r;
+   memset(&r, 0, sizeof(r));
+   r.system_header = sys;
+   r.modality = modality;
+   r.repo_index = -1;
+   if (count <= 0)
+   {
+      r.cardinality = XREPO_RESOLVE_NONE;
+      return r;
+   }
+   if (count == 1)
+   {
+      r.cardinality = XREPO_RESOLVE_ONE;
+      r.repo_index = idx[0];
+      return r;
+   }
+   r.cardinality = XREPO_RESOLVE_MANY;
+   r.collision_count = count;
+   for (int i = 0; i < count && i < XREPO_MAX_COLLISIONS; i++)
+      r.collisions[i] = idx[i];
+   return r;
+}
+
+/* C/C++: path-suffix of the include resolving to indexed headers. A suffix
+ * matching headers in exactly one trusted repo -> ONE; in several -> MANY (the
+ * vendored/header-only collision case). File-level multiplicity within one repo
+ * still resolves to that one repo. The caller repo is excluded (no self-edge). */
+static xrepo_resolve_result_t resolve_c(const char *inc, const char *caller_repo,
+                                        xrepo_import_modality_t modality,
+                                        const xrepo_repo_desc_t *descs, size_t n)
+{
+   if (is_c_system_header(inc))
+      return result_from_matches(NULL, 0, 1, modality);
+
+   int matches[XREPO_MAX_COLLISIONS];
+   int count = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      if (!descs[i].trusted || !descs[i].headers || is_caller(&descs[i], caller_repo))
+         continue;
+      int repo_hit = 0;
+      for (size_t h = 0; h < descs[i].header_count && !repo_hit; h++)
+         if (descs[i].headers[h] && path_suffix_match(descs[i].headers[h], inc))
+            repo_hit = 1;
+      if (repo_hit)
+      {
+         if (count < XREPO_MAX_COLLISIONS)
+            matches[count] = (int)i;
+         count++;
+      }
+   }
+   return result_from_matches(matches, count, 0, modality);
+}
+
+/* Copy the leading component of `s` up to any char in `seps` into out[]. */
+static void leading_component(const char *s, const char *seps, char *out, size_t cap)
+{
+   size_t i = 0;
+   for (; s[i] && i + 1 < cap && !strchr(seps, s[i]); i++)
+      out[i] = s[i];
+   out[i] = '\0';
+}
+
+/* Rust/TS/JS/Python: match the import's leading package/crate token to a repo's
+ * module_id (exact). MANY only on a genuine module_id collision. Caller excluded. */
+static xrepo_resolve_result_t resolve_by_token(const char *token, const char *caller_repo,
+                                               xrepo_import_modality_t modality,
+                                               const xrepo_repo_desc_t *descs, size_t n)
+{
+   if (!token[0])
+      return result_from_matches(NULL, 0, 0, modality);
+   int matches[XREPO_MAX_COLLISIONS];
+   int count = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      if (is_caller(&descs[i], caller_repo))
+         continue;
+      if (descs[i].module_id && descs[i].module_id[0] && strcmp(descs[i].module_id, token) == 0)
+      {
+         if (count < XREPO_MAX_COLLISIONS)
+            matches[count] = (int)i;
+         count++;
+      }
+   }
+   return result_from_matches(matches, count, 0, modality);
+}
+
+/* Go: import path matched to the longest module_id that is a prefix of it (so a
+ * monorepo sub-package resolves to its containing module). Equal-length distinct
+ * module_id prefixes -> MANY. Caller excluded (no self-edge). */
+static xrepo_resolve_result_t resolve_go(const char *imp, const char *caller_repo,
+                                         xrepo_import_modality_t modality,
+                                         const xrepo_repo_desc_t *descs, size_t n)
+{
+   size_t best_len = 0;
+   int matches[XREPO_MAX_COLLISIONS];
+   int count = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      const char *m = descs[i].module_id;
+      if (!m || !m[0] || is_caller(&descs[i], caller_repo))
+         continue;
+      size_t ml = strlen(m);
+      int prefix = strcmp(imp, m) == 0 || (strncmp(imp, m, ml) == 0 && imp[ml] == '/');
+      if (!prefix)
+         continue;
+      if (ml > best_len)
+      {
+         best_len = ml; /* a strictly longer module wins -> reset the match set */
+         count = 0;
+         matches[count++] = (int)i;
+      }
+      else if (ml == best_len)
+      {
+         if (count < XREPO_MAX_COLLISIONS)
+            matches[count] = (int)i;
+         count++;
+      }
+   }
+   return result_from_matches(matches, count, 0, modality);
+}
+
+xrepo_resolve_result_t xrepo_resolve_import_to_repo(const char *raw_import, xrepo_lang_t lang,
+                                                    const char *caller_repo,
+                                                    xrepo_import_modality_t modality,
+                                                    const xrepo_repo_desc_t *descs,
+                                                    size_t desc_count)
+{
+   xrepo_resolve_result_t none = result_from_matches(NULL, 0, 0, modality);
+   if (!raw_import || !raw_import[0] || !descs)
+      return none;
+
+   char tok[256];
+   switch (lang)
+   {
+   case XREPO_LANG_C:
+   case XREPO_LANG_CPP:
+      return resolve_c(raw_import, caller_repo, modality, descs, desc_count);
+
+   case XREPO_LANG_GO:
+      return resolve_go(raw_import, caller_repo, modality, descs, desc_count);
+
+   case XREPO_LANG_RUST:
+   {
+      const char *rs = raw_import;
+      while (*rs == ':') /* Rust 2018+ absolute path "::crate::..." */
+         rs++;
+      leading_component(rs, ":", tok, sizeof(tok)); /* "crate::path" -> "crate" */
+      if (strcmp(tok, "crate") == 0 || strcmp(tok, "super") == 0 || strcmp(tok, "self") == 0)
+         return none; /* intra-repo path */
+      return resolve_by_token(tok, caller_repo, modality, descs, desc_count);
+   }
+
+   case XREPO_LANG_PYTHON:
+      if (raw_import[0] == '.') /* relative import */
+         return none;
+      leading_component(raw_import, ".", tok, sizeof(tok)); /* "pkg.sub" -> "pkg" */
+      return resolve_by_token(tok, caller_repo, modality, descs, desc_count);
+
+   case XREPO_LANG_TS:
+   case XREPO_LANG_JS:
+      if (raw_import[0] == '.' || raw_import[0] == '/') /* relative / absolute path */
+         return none;
+      if (raw_import[0] == '@')
+      {
+         /* scoped package: "@scope/name[/sub]" -> "@scope/name" */
+         const char *slash = strchr(raw_import, '/');
+         const char *slash2 = slash ? strchr(slash + 1, '/') : NULL;
+         size_t len = slash2 ? (size_t)(slash2 - raw_import)
+                             : (slash ? strlen(raw_import) : strlen(raw_import));
+         if (len + 1 > sizeof(tok))
+            len = sizeof(tok) - 1;
+         memcpy(tok, raw_import, len);
+         tok[len] = '\0';
+      }
+      else
+      {
+         leading_component(raw_import, "/", tok, sizeof(tok)); /* "pkg/sub" -> "pkg" */
+      }
+      return resolve_by_token(tok, caller_repo, modality, descs, desc_count);
+
+   default:
+      return none; /* UNKNOWN -> import route unavailable (UNIMPLEMENTED surfaced upstream) */
+   }
+}

--- a/src/db2/cross_repo_resolver.h
+++ b/src/db2/cross_repo_resolver.h
@@ -1,0 +1,139 @@
+#ifndef AIMEE_CROSS_REPO_RESOLVER_H
+#define AIMEE_CROSS_REPO_RESOLVER_H
+
+#include <stddef.h>
+
+/* Pure, DB-free core of the cross-repo dependency resolver.
+ *
+ * S2a covers import resolution (§3.7) + distinctiveness (§3.3); the tier
+ * pipeline + multiplicity (§3.5/§3.10) land in S2b. Every function here is
+ * deterministic and takes precomputed corpus data as input -- it never touches
+ * the database -- so it is fully unit-testable on the sqlite shim (where the
+ * Postgres-only db2 ops return -1). The DB layer (S3) gathers the inputs.
+ *
+ * See docs/proposals/pending/cross-repo-dependency-graph.md. */
+
+/* P1 in-scope languages (§3.7). Anything else -> XREPO_LANG_UNKNOWN, which the
+ * resolver surfaces as the UNIMPLEMENTED tier rather than silently omitting. */
+typedef enum
+{
+   XREPO_LANG_UNKNOWN = 0,
+   XREPO_LANG_C,
+   XREPO_LANG_CPP,
+   XREPO_LANG_RUST,
+   XREPO_LANG_GO,
+   XREPO_LANG_TS,
+   XREPO_LANG_JS,
+   XREPO_LANG_PYTHON
+} xrepo_lang_t;
+
+/* Classify a source path by extension (deterministic; no I/O). */
+xrepo_lang_t xrepo_lang_from_path(const char *path);
+/* Stable lowercase tag ("c","cpp","rust","go","ts","js","python","unknown"). */
+const char *xrepo_lang_name(xrepo_lang_t lang);
+
+/* Import modality (§3.7): static imports can reach HIGH; conditional ones
+ * downgrade HIGH->MEDIUM; dynamic ones are routed to the review queue and never
+ * reach static HIGH. The caller (S3/S4) determines the modality from the
+ * import's guard context and passes it in. */
+typedef enum
+{
+   XREPO_IMPORT_STATIC = 0,
+   XREPO_IMPORT_CONDITIONAL,
+   XREPO_IMPORT_DYNAMIC
+} xrepo_import_modality_t;
+
+/* A registered repo descriptor for import resolution. The DB layer (S3) fills
+ * these and owns the normalization contract for `module_id`:
+ *   - Rust:   the crate name (Cargo.toml [package].name, '-' kept as written;
+ *             the resolver compares the import's first `::` token verbatim).
+ *   - Go:     the module path (go.mod `module`), e.g. "example.com/foo".
+ *   - TS/JS:  the npm package name (package.json "name"), incl. "@scope/name".
+ *   - Python: the top-level import package (dist/top_level), e.g. "requests".
+ *   - "" when the repo exposes no module id (C/C++ repos resolve by `headers`).
+ * `trusted` mirrors projects.trust (§0): only trusted repos can lend HIGH
+ * corroboration. */
+typedef struct
+{
+   const char *name;           /* repo (project) name */
+   int trusted;                /* 1 = trusted, 0 = untrusted */
+   const char *module_id;      /* normalized per the contract above; "" if none */
+   const char *const *headers; /* C/C++ only: indexed header paths to suffix-match;
+                                * NULL/0 for other languages */
+   size_t header_count;
+} xrepo_repo_desc_t;
+
+/* Max colliding definer repos enumerated on a MANY result (for the AMBIGUOUS
+ * review queue evidence). collision_count may exceed this; collisions[] holds
+ * the first XREPO_MAX_COLLISIONS by descriptor order. */
+#define XREPO_MAX_COLLISIONS 8
+
+/* Resolution cardinality (§3.7 cardinality contract): the resolver returns
+ * zero / one / many candidate repos and never silently picks one of several. */
+typedef enum
+{
+   XREPO_RESOLVE_NONE = 0, /* import route unavailable (MEDIUM still reachable) */
+   XREPO_RESOLVE_ONE,      /* exactly one -> import route (HIGH(a)) can fire */
+   XREPO_RESOLVE_MANY      /* many -> routed to AMBIGUOUS, never guessed */
+} xrepo_resolve_card_t;
+
+typedef struct
+{
+   xrepo_resolve_card_t cardinality;
+   int repo_index;                       /* index into descs[] when cardinality==ONE; else -1 */
+   int system_header;                    /* C/C++: include hit a rejected system/framework header */
+   xrepo_import_modality_t modality;     /* echoed through for the pipeline's import-modality cap */
+   int collisions[XREPO_MAX_COLLISIONS]; /* MANY: colliding definer descs[] indices */
+   int collision_count;                  /* MANY: total colliders (may exceed the array) */
+} xrepo_resolve_result_t;
+
+/* Map a raw import/include string in `lang`, used by `caller_repo`, to a definer
+ * repo among descs[]. Pure + deterministic.
+ *   - C/C++: longest path-suffix of the #include that resolves to exactly one
+ *     indexed header in a trusted repo; system/framework headers rejected; a
+ *     suffix that matches >1 indexed file -> MANY (AMBIGUOUS).
+ *   - Rust:  `use crate_or_alias::...` matched to a crate's module_id; crate::/
+ *     super::/self:: paths are intra-repo -> NONE.
+ *   - Go:    import-path prefix matched to a module_id (go.mod).
+ *   - TS/JS: bare specifier matched to a package module_id; relative -> NONE.
+ *   - Python:import's top-level package matched to a module_id; relative -> NONE.
+ *   - Monorepo: a sub-package path resolves to its containing registered repo.
+ * The caller-supplied `modality` is echoed into the result. The caller repo is
+ * excluded from the candidate set before counting, so it never yields a
+ * self-edge nor inflates a MANY result. On MANY, collisions[]/collision_count
+ * enumerate the colliding definer repos (for the review queue). */
+xrepo_resolve_result_t xrepo_resolve_import_to_repo(const char *raw_import, xrepo_lang_t lang,
+                                                    const char *caller_repo,
+                                                    xrepo_import_modality_t modality,
+                                                    const xrepo_repo_desc_t *descs,
+                                                    size_t desc_count);
+
+/* Distinctiveness (§3.3). S is distinctive iff NONE of:
+ *   - S is a callee in >= k trusted repos, or
+ *   - S is defined in >= m trusted repos, or
+ *   - S is a callee in >= p_pct% of the caller repo A's files,
+ * AND xrepo_utf8_len(S) >= len_min. Stats are precomputed over trusted repos
+ * by S3; thresholds come from kb.curator.cross_repo_graph.* (versioned). */
+typedef struct
+{
+   int callee_repo_count;  /* # trusted repos where S appears as a callee */
+   int definer_repo_count; /* # trusted repos defining S */
+   int caller_file_pct;    /* % of caller A's files where S is a callee (0..100) */
+} xrepo_distinct_stats_t;
+
+typedef struct
+{
+   int k;       /* callee-in->=k-repos floor */
+   int m;       /* defined-in->=m-repos floor */
+   int p_pct;   /* caller-file-percentage floor */
+   int len_min; /* minimum UTF-8 code-point length */
+} xrepo_distinct_cfg_t;
+
+/* 1 = distinctive, 0 = not. */
+int xrepo_name_distinctive(const char *symbol, const xrepo_distinct_stats_t *stats,
+                           const xrepo_distinct_cfg_t *cfg);
+
+/* UTF-8 code-point length (count of code points, not bytes) for the len_min gate. */
+size_t xrepo_utf8_len(const char *s);
+
+#endif /* AIMEE_CROSS_REPO_RESOLVER_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -87,6 +87,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
                $(TESTPREFIX)/unit-test-memory-lanes \
                $(TESTPREFIX)/unit-test-workspace \
+               $(TESTPREFIX)/unit-test-cross-repo-deps \
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-webchat-claude-sessions \
                $(TESTPREFIX)/unit-test-turn-registry \
@@ -1381,6 +1382,14 @@ $(TESTPREFIX)/unit-test-code-treesitter: $(OBJDIR)/tests/test_code_treesitter.o 
                                          $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 endif
+
+# Cross-repo dependency graph S2a: pure resolver core (import resolution +
+# distinctiveness). DB-free, so it links only the resolver object. The
+# TEST_TARGETS membership is declared in the initial := block above (before the
+# unit-tests rule) so the binary is built, not just run.
+$(TESTPREFIX)/unit-test-cross-repo-deps: $(OBJDIR)/tests/test_cross_repo_deps.o \
+                                         $(OBJDIR)/db2/cross_repo_resolver.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-aimee-client: $(OBJDIR)/tests/test_aimee_client.o $(OBJDIR)/aimee_client.o \
                                       $(OBJDIR)/posix/platform_net.o $(OBJDIR)/http_uds_client.o \

--- a/src/tests/test_cross_repo_deps.c
+++ b/src/tests/test_cross_repo_deps.c
@@ -1,0 +1,253 @@
+/* test_cross_repo_deps.c: unit tests for the pure cross-repo resolver core
+ * (S2a: import resolution + distinctiveness). DB-free -- exercises
+ * src/db2/cross_repo_resolver.c directly. Acceptance #1 (mechanical) for the
+ * S2a portion; S2b adds the tier-pipeline tests. See
+ * docs/proposals/pending/cross-repo-dependency-graph.md. */
+
+#include "cross_repo_resolver.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+/* ---- language classification + utf8 -------------------------------------- */
+
+static void test_lang_from_path(void)
+{
+   printf("test_lang_from_path... ");
+   assert(xrepo_lang_from_path("src/a.c") == XREPO_LANG_C);
+   assert(xrepo_lang_from_path("inc/a.h") == XREPO_LANG_C);
+   assert(xrepo_lang_from_path("src/a.cpp") == XREPO_LANG_CPP);
+   assert(xrepo_lang_from_path("src/a.hpp") == XREPO_LANG_CPP);
+   assert(xrepo_lang_from_path("src/a.cc") == XREPO_LANG_CPP);
+   assert(xrepo_lang_from_path("m/lib.rs") == XREPO_LANG_RUST);
+   assert(xrepo_lang_from_path("m/main.go") == XREPO_LANG_GO);
+   assert(xrepo_lang_from_path("ui/app.ts") == XREPO_LANG_TS);
+   assert(xrepo_lang_from_path("ui/app.tsx") == XREPO_LANG_TS);
+   assert(xrepo_lang_from_path("ui/app.js") == XREPO_LANG_JS);
+   assert(xrepo_lang_from_path("ui/app.mjs") == XREPO_LANG_JS);
+   assert(xrepo_lang_from_path("svc/app.py") == XREPO_LANG_PYTHON);
+   assert(xrepo_lang_from_path("README.md") == XREPO_LANG_UNKNOWN);
+   assert(xrepo_lang_from_path("Main.java") == XREPO_LANG_UNKNOWN); /* deferred lang */
+   assert(xrepo_lang_from_path(NULL) == XREPO_LANG_UNKNOWN);
+   assert(strcmp(xrepo_lang_name(XREPO_LANG_PYTHON), "python") == 0);
+   assert(strcmp(xrepo_lang_name(XREPO_LANG_UNKNOWN), "unknown") == 0);
+   printf("ok\n");
+}
+
+static void test_utf8_len(void)
+{
+   printf("test_utf8_len... ");
+   assert(xrepo_utf8_len("abcd") == 4);
+   assert(xrepo_utf8_len("") == 0);
+   assert(xrepo_utf8_len(NULL) == 0);
+   assert(xrepo_utf8_len("héllo") == 5); /* é is 2 bytes, 1 code point */
+   assert(xrepo_utf8_len("LiStartConnection") == 17);
+   printf("ok\n");
+}
+
+/* ---- distinctiveness (§3.3) ---------------------------------------------- */
+
+static void test_distinctiveness(void)
+{
+   printf("test_distinctiveness... ");
+   xrepo_distinct_cfg_t cfg = {.k = 5, .m = 8, .p_pct = 25, .len_min = 4};
+
+   /* Distinctive: rare, long, low caller-file ratio. */
+   xrepo_distinct_stats_t good = {
+       .callee_repo_count = 1, .definer_repo_count = 1, .caller_file_pct = 2};
+   assert(xrepo_name_distinctive("LiStartConnection", &good, &cfg) == 1);
+
+   /* Too short (len < 4). */
+   assert(xrepo_name_distinctive("get", &good, &cfg) == 0);
+
+   /* Used as a callee in >= K trusted repos -> not distinctive (common method). */
+   xrepo_distinct_stats_t common = {
+       .callee_repo_count = 9, .definer_repo_count = 1, .caller_file_pct = 2};
+   assert(xrepo_name_distinctive("render", &common, &cfg) == 0);
+
+   /* Defined in >= M repos -> not distinctive (vendored/ubiquitous). */
+   xrepo_distinct_stats_t manydefs = {
+       .callee_repo_count = 1, .definer_repo_count = 8, .caller_file_pct = 2};
+   assert(xrepo_name_distinctive("hashmap_new", &manydefs, &cfg) == 0);
+
+   /* Heavy local use (>= P% of caller's files) -> not distinctive (local method). */
+   xrepo_distinct_stats_t local = {
+       .callee_repo_count = 1, .definer_repo_count = 1, .caller_file_pct = 40};
+   assert(xrepo_name_distinctive("update_state", &local, &cfg) == 0);
+
+   /* Boundary: exactly at the floor is NOT distinctive (>= is the cut). */
+   xrepo_distinct_stats_t at_k = {
+       .callee_repo_count = 5, .definer_repo_count = 1, .caller_file_pct = 0};
+   assert(xrepo_name_distinctive("connect_pipe", &at_k, &cfg) == 0);
+   printf("ok\n");
+}
+
+/* ---- import resolution (§3.7): seed fixture ------------------------------ *
+ * A minimal checked-in corpus exercising the four acceptance shapes:
+ *   - moonlight-common-c : import-resolvable positive (C header + Go/etc module)
+ *   - vendored-copy-a/-b : the same header in two repos -> AMBIGUOUS (MANY)
+ *   - untrusted-lib      : an untrusted definer (resolution still finds it; the
+ *                          trust cap is applied downstream in S2b)
+ * S8 grows this into the full stratified ground-truth corpus. */
+
+static const char *const moonlight_headers[] = {"include/Limelight.h", "src/connection.c"};
+static const char *const vendored_a_headers[] = {"third_party/zlib/zlib.h"};
+static const char *const vendored_b_headers[] = {"vendor/zlib/zlib.h"};
+
+static const xrepo_repo_desc_t SEED[] = {
+    {"moonlight-common-c", 1, "github.com/moonlight-stream/moonlight-common-c", moonlight_headers,
+     2},
+    {"moonlight-qt", 1, "github.com/moonlight-stream/moonlight-qt", NULL, 0},
+    {"vendored-copy-a", 1, "", vendored_a_headers, 1},
+    {"vendored-copy-b", 1, "", vendored_b_headers, 1},
+    {"untrusted-lib", 0, "sketchy-pkg", NULL, 0},
+    {"crate-host", 1, "serde_helpers", NULL, 0},
+    {"go-mono", 1, "example.com/mono", NULL, 0},
+    {"ts-host", 1, "@scope/widgets", NULL, 0},
+    {"py-host", 1, "requests_ext", NULL, 0},
+};
+static const size_t SEED_N = sizeof(SEED) / sizeof(SEED[0]);
+
+static int seed_index(const char *name)
+{
+   for (size_t i = 0; i < SEED_N; i++)
+      if (strcmp(SEED[i].name, name) == 0)
+         return (int)i;
+   return -1;
+}
+
+static void test_resolve_c(void)
+{
+   printf("test_resolve_c... ");
+   /* Positive: a quoted include resolving to exactly one trusted repo's header. */
+   xrepo_resolve_result_t r = xrepo_resolve_import_to_repo(
+       "Limelight.h", XREPO_LANG_C, "moonlight-qt", XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE);
+   assert(r.repo_index == seed_index("moonlight-common-c"));
+   assert(r.system_header == 0);
+
+   /* Path-suffix match on a multi-component include. */
+   r = xrepo_resolve_import_to_repo("include/Limelight.h", XREPO_LANG_C, "moonlight-qt",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE);
+
+   /* System header -> rejected, never an edge. */
+   r = xrepo_resolve_import_to_repo("stdio.h", XREPO_LANG_C, "moonlight-qt", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE && r.system_header == 1);
+   r = xrepo_resolve_import_to_repo("vector", XREPO_LANG_CPP, "moonlight-qt", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE && r.system_header == 1);
+
+   /* Vendored copy in two repos -> AMBIGUOUS (MANY), never guessed; the colliders
+    * are enumerated for the review queue. */
+   r = xrepo_resolve_import_to_repo("zlib.h", XREPO_LANG_C, "moonlight-qt", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_MANY && r.repo_index == -1);
+   assert(r.collision_count == 2);
+   {
+      int a = r.collisions[0], b = r.collisions[1];
+      int va = seed_index("vendored-copy-a"), vb = seed_index("vendored-copy-b");
+      assert((a == va && b == vb) || (a == vb && b == va));
+   }
+
+   /* Unknown include -> NONE. */
+   r = xrepo_resolve_import_to_repo("nope_nowhere.h", XREPO_LANG_C, "moonlight-qt",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+   printf("ok\n");
+}
+
+static void test_resolve_rust_go_py_ts(void)
+{
+   printf("test_resolve_rust_go_py_ts... ");
+   xrepo_resolve_result_t r;
+
+   /* Rust: crate token matches; crate::/super::/self:: are intra-repo. */
+   r = xrepo_resolve_import_to_repo("serde_helpers::ser", XREPO_LANG_RUST, "app",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("crate-host"));
+   r = xrepo_resolve_import_to_repo("crate::util", XREPO_LANG_RUST, "app", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+   /* Rust 2018+ absolute path "::crate_token::..." resolves the crate. */
+   r = xrepo_resolve_import_to_repo("::serde_helpers::de", XREPO_LANG_RUST, "app",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("crate-host"));
+
+   /* Go: exact module + monorepo sub-package both resolve to the module repo. */
+   r = xrepo_resolve_import_to_repo("example.com/mono", XREPO_LANG_GO, "app", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("go-mono"));
+   r = xrepo_resolve_import_to_repo("example.com/mono/internal/util", XREPO_LANG_GO, "app",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("go-mono"));
+
+   /* Python: top-level package; relative imports are intra-package. */
+   r = xrepo_resolve_import_to_repo("requests_ext.session", XREPO_LANG_PYTHON, "app",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("py-host"));
+   r = xrepo_resolve_import_to_repo(".relative", XREPO_LANG_PYTHON, "app", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+
+   /* TS: scoped package "@scope/widgets[/sub]"; relative specifiers are intra-repo. */
+   r = xrepo_resolve_import_to_repo("@scope/widgets/button", XREPO_LANG_TS, "app",
+                                    XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("ts-host"));
+   r = xrepo_resolve_import_to_repo("./local", XREPO_LANG_JS, "app", XREPO_IMPORT_STATIC, SEED,
+                                    SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+   printf("ok\n");
+}
+
+static void test_resolve_edge_cases(void)
+{
+   printf("test_resolve_edge_cases... ");
+   /* Self-match collapses to NONE (no self-dependency edge): a repo importing
+    * its own module id. */
+   xrepo_resolve_result_t r = xrepo_resolve_import_to_repo(
+       "serde_helpers::x", XREPO_LANG_RUST, "crate-host", XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+
+   /* Caller is excluded from candidates: vendored-copy-a importing zlib.h sees
+    * only vendored-copy-b -> ONE (not MANY, and not a self-edge). */
+   r = xrepo_resolve_import_to_repo("zlib.h", XREPO_LANG_C, "vendored-copy-a", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("vendored-copy-b"));
+
+   /* Untrusted definer is still resolved (the trust cap is applied downstream). */
+   r = xrepo_resolve_import_to_repo("sketchy-pkg", XREPO_LANG_PYTHON, "app", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.repo_index == seed_index("untrusted-lib"));
+
+   /* Modality is echoed through for the pipeline's import-modality cap. */
+   r = xrepo_resolve_import_to_repo("requests_ext", XREPO_LANG_PYTHON, "app",
+                                    XREPO_IMPORT_CONDITIONAL, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_ONE && r.modality == XREPO_IMPORT_CONDITIONAL);
+
+   /* Unknown language -> import route unavailable. */
+   r = xrepo_resolve_import_to_repo("anything", XREPO_LANG_UNKNOWN, "app", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+
+   /* Empty / NULL inputs are safe. */
+   r = xrepo_resolve_import_to_repo("", XREPO_LANG_GO, "app", XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+   r = xrepo_resolve_import_to_repo(NULL, XREPO_LANG_GO, "app", XREPO_IMPORT_STATIC, SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE);
+   printf("ok\n");
+}
+
+int main(void)
+{
+   test_lang_from_path();
+   test_utf8_len();
+   test_distinctiveness();
+   test_resolve_c();
+   test_resolve_rust_go_py_ts();
+   test_resolve_edge_cases();
+   printf("cross_repo_deps: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary
Second slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md`), on top of S1 (#797). The **DB-free core** of the resolver — no database dependency, so it is fully unit-testable on the sqlite shim. S3 gathers the inputs; S2b adds the tier pipeline.

## New `db2/cross_repo_resolver.{c,h}`
- `xrepo_lang_from_path` / `_name` — P1 language set (C, C++, Rust, Go, TS, JS, Python); others → `UNKNOWN` (UNIMPLEMENTED surfaced upstream, §3.7).
- `xrepo_utf8_len` — code-point length for the `len_min` gate.
- `xrepo_name_distinctive` (§3.3) — distinctive iff none of `callee ≥ K repos` / `defined ≥ M repos` / `callee ≥ P% of caller files`, and `len ≥ L`.
- `xrepo_resolve_import_to_repo` (§3.7) with the **zero/one/many cardinality contract** (never silently picks one of several → MANY routes to AMBIGUOUS):
  - **C/C++**: path-suffix match over trusted repos' indexed headers; builtin system-header reject; vendored collision → MANY (colliders enumerated for the review queue).
  - **Rust**: crate token (incl. 2018 `::crate::…`); `crate::`/`super::`/`self::` intra-repo.
  - **Go**: longest module-prefix (monorepo sub-package → containing module); equal-length collision → MANY.
  - **TS/JS**: bare vs `@scope/name` specifier; relative intra-repo.
  - **Python**: top-level package; relative intra-repo.
  - The **caller repo is excluded** from candidates (no self-edge, no MANY inflation); `modality` (static/conditional/dynamic) echoed for S2b's cap; the `module_id` normalization contract for S3 is documented in the header.

## Tests / gates
`test_cross_repo_deps.c` (acceptance #1, S2a portion) over a checked-in seed fixture: language detection, UTF-8, distinctiveness (each condition + boundary), per-language resolution, system-header reject, vendored → MANY with collision enumeration, monorepo, caller-excluded-from-MANY, self-match, untrusted-resolved, Rust `::`, NULL/empty safety. Builds, all 6 test groups pass, clang-format-19 clean, DB-free link.

## Review
Code-review roundtable: 0 blocking. Folded the high-value suggestions — caller exclusion + MANY collision enumeration (for S4's review queue), Rust leading `::`, expanded system-header list, and the S3 `module_id` contract.