### PR TITLE
feat(harness-memory): P4 — session-start hydration of central memory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -761,6 +761,7 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_main.c
     ${AIMEE_SRC_DIR}/cli_agent_setup.c
     ${AIMEE_SRC_DIR}/cli_session_start.c
+    ${AIMEE_SRC_DIR}/harness_memory_hydrate.c
     ${AIMEE_SRC_DIR}/cli_attention_guard.c
     ${AIMEE_SRC_DIR}/cli_code_audit.c
     ${AIMEE_SRC_DIR}/cli_css.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -351,7 +351,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_main.c cli_agent_setup.c cli_session_start.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
+CLI_SRCS = cli_main.c cli_agent_setup.c cli_session_start.c harness_memory_hydrate.c harness_memory_common.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/cli_session_start.c
+++ b/src/cli_session_start.c
@@ -5,10 +5,12 @@
  * its own TU holds cli_main.c under the source line limit. */
 #include "cli_client.h"
 #include "cli_session_start.h"
+#include "harness_memory_hydrate.h"
 #include "cJSON.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <unistd.h>
 
 struct ss_sbuf
@@ -306,6 +308,14 @@ int handle_session_start(int json_output)
    /* Detect server-invoked context: AIMEE_SESSION_ID is set by chat_stream_worker
     * in the environment of the claude subprocess it forks. */
    int nonblocking = (getenv("AIMEE_SESSION_ID") != NULL);
+
+   /* P4: surface this project's central memory into the local memory dir so a
+    * fresh session/agent sees it (best-effort; never blocks session-start). */
+   {
+      char hcwd[4096];
+      if (getcwd(hcwd, sizeof(hcwd)))
+         harness_memory_hydrate(hcwd);
+   }
 
    const char *sock = cli_ensure_server_for_method("hooks.session_start");
    if (!sock)

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -1,0 +1,131 @@
+/* harness_memory_hydrate.c — see harness_memory_hydrate.h. */
+
+#include "harness_memory_hydrate.h"
+
+#include "cJSON.h"
+#include "cli_client.h" /* cli_http_request, cli_v1_client_endpoint/bearer */
+#include "harness_memory_common.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+void hmem_slug_from_path(const char *abspath, char *out, size_t cap)
+{
+   size_t j = 0;
+   if (!abspath || cap == 0)
+   {
+      if (cap)
+         out[0] = '\0';
+      return;
+   }
+   for (size_t i = 0; abspath[i] && j + 1 < cap; i++)
+   {
+      char c = abspath[i];
+      int alnum = (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9');
+      out[j++] = alnum ? c : '-';
+   }
+   out[j] = '\0';
+}
+
+/* mkdir -p for the parent directories of a file path (best-effort). */
+static void mkdir_parents(const char *file_path)
+{
+   char buf[PATH_MAX];
+   snprintf(buf, sizeof(buf), "%s", file_path);
+   for (char *p = buf + 1; *p; p++)
+   {
+      if (*p == '/')
+      {
+         *p = '\0';
+         mkdir(buf, 0700);
+         *p = '/';
+      }
+   }
+}
+
+static const char *jstr(cJSON *o, const char *k)
+{
+   cJSON *i = cJSON_GetObjectItemCaseSensitive(o, k);
+   return (i && cJSON_IsString(i)) ? i->valuestring : NULL;
+}
+
+static int write_file(const char *path, const char *content)
+{
+   mkdir_parents(path);
+   FILE *f = fopen(path, "wb");
+   if (!f)
+      return -1;
+   size_t len = content ? strlen(content) : 0;
+   size_t w = content ? fwrite(content, 1, len, f) : 0;
+   fclose(f);
+   return (w == len) ? 0 : -1;
+}
+
+int harness_memory_hydrate(const char *cwd)
+{
+   const char *home = getenv("HOME");
+   if (!home || !home[0])
+      return -1;
+   char real[PATH_MAX];
+   if (!realpath((cwd && cwd[0]) ? cwd : ".", real))
+      return -1;
+   char slug[PATH_MAX * 2];
+   hmem_slug_from_path(real, slug, sizeof(slug));
+
+   char project[256], rootdir[PATH_MAX];
+   if (hmem_resolve_project(cwd, project, sizeof(project), rootdir, sizeof(rootdir)) != 0)
+      return -1;
+
+   char memdir[PATH_MAX];
+   if ((size_t)snprintf(memdir, sizeof(memdir), "%s/.claude/projects/%s/memory", home, slug) >=
+       sizeof(memdir))
+      return -1;
+
+   char *endpoint = cli_v1_client_endpoint();
+   if (!endpoint)
+      return -1;
+   char *bearer = cli_v1_client_bearer();
+   cJSON *body = cJSON_CreateObject();
+   cJSON_AddStringToObject(body, "project", project);
+   char *body_s = cJSON_PrintUnformatted(body);
+   cJSON_Delete(body);
+
+   int status = 0;
+   cJSON *resp = body_s ? cli_http_request(endpoint, "POST", "/v1/harness_memory/list", body_s,
+                                           bearer, 15000, &status)
+                        : NULL;
+   free(body_s);
+   free(endpoint);
+   free(bearer);
+   if (!resp || status < 200 || status >= 300)
+   {
+      if (resp)
+         cJSON_Delete(resp);
+      return -1;
+   }
+
+   int n = 0;
+   cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
+   cJSON *m = NULL;
+   cJSON_ArrayForEach(m, mems)
+   {
+      const char *name = jstr(m, "name");
+      const char *btext = jstr(m, "body");
+      if (!name || !name[0] || strstr(name, "..")) /* defensive: never escape memdir */
+         continue;
+      char target[PATH_MAX];
+      if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
+         continue;
+      if (write_file(target, btext ? btext : "") == 0)
+         n++;
+   }
+   cJSON_Delete(resp);
+   return n;
+}

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -50,6 +50,32 @@ static void mkdir_parents(const char *file_path)
    }
 }
 
+/* mkdir -p for a directory path (best-effort). */
+static void mkdir_p(const char *dir)
+{
+   char buf[PATH_MAX];
+   if ((size_t)snprintf(buf, sizeof(buf), "%s/", dir) >= sizeof(buf))
+      return;
+   mkdir_parents(buf);
+}
+
+/* Is the resolved parent dir of `target` confined under realpath(memdir)?
+ * Defends against a symlinked component redirecting the write outside the
+ * memory tree (parity with P3's re-materialize). */
+static int target_confined(const char *target, const char *memreal)
+{
+   char dir[PATH_MAX];
+   const char *base = strrchr(target, '/');
+   if (!base)
+      return 0;
+   snprintf(dir, sizeof(dir), "%.*s", (int)(base - target), target);
+   char dreal[PATH_MAX];
+   if (!realpath(dir, dreal))
+      return 0;
+   size_t n = strlen(memreal);
+   return strncmp(dreal, memreal, n) == 0 && (dreal[n] == '/' || dreal[n] == '\0');
+}
+
 static const char *jstr(cJSON *o, const char *k)
 {
    cJSON *i = cJSON_GetObjectItemCaseSensitive(o, k);
@@ -111,6 +137,16 @@ int harness_memory_hydrate(const char *cwd)
       return -1;
    }
 
+   /* Ensure the memory dir exists and resolve it, so we can confine every write
+    * under the *real* directory (a symlinked component can't redirect us out). */
+   mkdir_p(memdir);
+   char memreal[PATH_MAX];
+   if (!realpath(memdir, memreal))
+   {
+      cJSON_Delete(resp);
+      return -1;
+   }
+
    int n = 0;
    cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
    cJSON *m = NULL;
@@ -118,12 +154,13 @@ int harness_memory_hydrate(const char *cwd)
    {
       const char *name = jstr(m, "name");
       const char *btext = jstr(m, "body");
-      if (!name || !name[0] || strstr(name, "..")) /* defensive: never escape memdir */
+      if (!name || !name[0] || name[0] == '/' || strstr(name, "..")) /* never escape memdir */
          continue;
       char target[PATH_MAX];
       if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
          continue;
-      if (write_file(target, btext ? btext : "") == 0)
+      mkdir_parents(target);
+      if (target_confined(target, memreal) && write_file(target, btext ? btext : "") == 0)
          n++;
    }
    cJSON_Delete(resp);

--- a/src/harness_memory_hydrate.h
+++ b/src/harness_memory_hydrate.h
@@ -1,0 +1,32 @@
+/* harness_memory_hydrate.h: session-start hydration for central agent-memory
+ * interception (P4). Pulls a project's central harness_memory rows and writes
+ * them into the local Claude memory dir so a fresh session/agent sees the
+ * centralized memory. CLI-side (uses the public /v1 client).
+ */
+#ifndef DEC_HARNESS_MEMORY_HYDRATE_H
+#define DEC_HARNESS_MEMORY_HYDRATE_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Claude project-dir slug: every non-alphanumeric byte of the absolute path
+    * becomes '-' (e.g. "/home/u/dev/app" -> "-home-u-dev-app"). Writes a NUL-
+    * terminated slug into out (truncated to cap). PURE — testable. */
+   void hmem_slug_from_path(const char *abspath, char *out, size_t cap);
+
+   /* Best-effort hydrate: resolve the project for cwd, fetch its live memory
+    * rows from the server, and materialize each under
+    * ~/.claude/projects/<slug>/memory/<name>.md. Returns the number written, or
+    * -1 if it could not run (no endpoint / no HOME / request failed). Never
+    * fails the caller — session-start ignores the result. */
+   int harness_memory_hydrate(const char *cwd);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_HARNESS_MEMORY_HYDRATE_H */

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -55,6 +55,7 @@ set_tests_properties(test_plugin_loader PROPERTIES
 aimee_add_test(test_memory_provider test_memory_provider.c)
 aimee_add_test(test_harness_memory test_harness_memory.c)
 aimee_add_test(test_memory_redirect test_memory_redirect.c)
+aimee_add_test(test_harness_memory_hydrate test_harness_memory_hydrate.c)
 aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)
 add_executable(test_context_engine test_context_engine.c)
 target_include_directories(test_context_engine PRIVATE

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -77,7 +77,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_g
 # linking both would produce duplicate-symbol errors.
 TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.o
 
-TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
+TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
@@ -432,6 +432,9 @@ $(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/db1/db.o $(OBJDI
                     $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o \
                     $(OBJDIR)/util.o $(OBJDIR)/text.o $(OBJDIR)/platform_random.o \
                     $(OBJDIR)/log.o $(PLATFORM_BASIC_OBJS) $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-harness-memory-hydrate: $(OBJDIR)/tests/test_harness_memory_hydrate.o $(OBJDIR)/harness_memory_hydrate.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/cJSON.o

--- a/src/tests/test_harness_memory_hydrate.c
+++ b/src/tests/test_harness_memory_hydrate.c
@@ -17,6 +17,18 @@ int main(void)
    hmem_slug_from_path("/home/u/dev/app/.aimee/x", s, sizeof(s));
    assert(strcmp(s, "-home-u-dev-app--aimee-x") == 0);
 
+   /* underscores, spaces, and other non-alnum all map to '-' */
+   hmem_slug_from_path("/a/b_c/d e", s, sizeof(s));
+   assert(strcmp(s, "-a-b-c-d-e") == 0);
+
+   /* consecutive separators are NOT collapsed (matches observed slug dirs) */
+   hmem_slug_from_path("/a//b", s, sizeof(s));
+   assert(strcmp(s, "-a--b") == 0);
+
+   /* digits preserved (e.g. worktree hashes) */
+   hmem_slug_from_path("/p/3ef8b2a0/main", s, sizeof(s));
+   assert(strcmp(s, "-p-3ef8b2a0-main") == 0);
+
    /* truncation safety: never overruns the buffer */
    char t[5];
    hmem_slug_from_path("/abcdefgh", t, sizeof(t));

--- a/src/tests/test_harness_memory_hydrate.c
+++ b/src/tests/test_harness_memory_hydrate.c
@@ -1,0 +1,31 @@
+/* Unit tests for hmem_slug_from_path (Claude project-dir slug, P4). */
+
+#include "harness_memory_hydrate.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+   char s[256];
+
+   hmem_slug_from_path("/home/virant/dev/aimee", s, sizeof(s));
+   assert(strcmp(s, "-home-virant-dev-aimee") == 0);
+
+   /* dotfiles: '/.aimee/' -> '--aimee-' (both '/' and '.' become '-') */
+   hmem_slug_from_path("/home/u/dev/app/.aimee/x", s, sizeof(s));
+   assert(strcmp(s, "-home-u-dev-app--aimee-x") == 0);
+
+   /* truncation safety: never overruns the buffer */
+   char t[5];
+   hmem_slug_from_path("/abcdefgh", t, sizeof(t));
+   assert(strlen(t) == 4);
+
+   /* NULL path is safe */
+   hmem_slug_from_path(NULL, s, sizeof(s));
+   assert(s[0] == '\0');
+
+   printf("test_harness_memory_hydrate: OK\n");
+   return 0;
+}


### PR DESCRIPTION
## Central agent-memory interception — P4: session-start hydration

Final slice. Completes the loop: P3 stores an agent's memory writes centrally; P4
**surfaces them back** to new sessions/agents by hydrating the local Claude memory dir
from the central store at session-start.

- `harness_memory_hydrate(cwd)`: resolve the project, fetch its live rows
  (`/v1/harness_memory/list`), and materialize each under
  `~/.claude/projects/<slug>/memory/<name>.md`. Best-effort — never blocks session-start.
- `hmem_slug_from_path` (pure, unit-tested) derives Claude's project-dir slug (non-alnum → `-`).
- Wired into `handle_session_start`; `harness_memory_common` added to the thin CLI link
  (project resolution is a client-side concern).

### v1 scope / follow-ups
Full reconcile (tombstones, spill consumption, divergence policy, flock), the config-driven
multi-client registry, and remote-server project-key resolution are documented follow-ups.
Core interception (P1–P3) is already merged; this makes the centralized memory flow back.

### Roundtable
Reviewed before PR; findings folded.
