### PR TITLE
feat(kb): cross-repo dep graph S2b — pure tier classification pipeline

### DIFF
--- a/src/db2/cross_repo_classify.c
+++ b/src/db2/cross_repo_classify.c
@@ -1,0 +1,254 @@
+/* cross_repo_classify.c: pure tier classification for the cross-repo resolver
+ * (S2b): definition multiplicity (§3.5) + the deterministic gate/cap/producer
+ * pipeline (§3.10). DB-free; see cross_repo_classify.h and
+ * docs/proposals/pending/cross-repo-dependency-graph.md. */
+
+#include "cross_repo_classify.h"
+
+#include <string.h>
+
+const char *xrepo_tier_name(xrepo_tier_t t)
+{
+   switch (t)
+   {
+   case XREPO_TIER_HIGH:
+      return "high";
+   case XREPO_TIER_MEDIUM:
+      return "medium";
+   case XREPO_TIER_LOW:
+      return "low";
+   case XREPO_TIER_AMBIGUOUS:
+      return "ambiguous";
+   case XREPO_TIER_UNIMPLEMENTED:
+      return "unimplemented";
+   default:
+      return "none";
+   }
+}
+
+/* ---- definition multiplicity (§3.5) -------------------------------------- */
+
+static int streq(const char *a, const char *b)
+{
+   return a && b && strcmp(a, b) == 0;
+}
+
+/* Defs are "provably unrelated" only when two definer repos have KNOWN,
+ * INCOMPATIBLE signatures: both arities known (>= 0) and differing, or both
+ * parameter-type lists known (non-empty) and differing. Such a spread is a
+ * genuine cross-repo name-clash and must not be rescued by the dominant-definer
+ * check. Unknown signatures are the caller's signal for "not available": arity
+ * < 0 (incl. variadic) and param_types "" are treated as not-provably-unrelated,
+ * so compatible/variadic overloads are NOT forced to NAMECLASH -- the
+ * dominant-definer hysteresis still decides. The defs[] contract (one row per
+ * distinct definer repo, with arity/param_types or the unknown sentinels) is
+ * the caller's (S3/S4) responsibility; see cross_repo_classify.h. */
+static int provably_unrelated(const xrepo_def_t *defs, int n)
+{
+   for (int i = 0; i < n; i++)
+      for (int j = i + 1; j < n; j++)
+      {
+         if (defs[i].arity >= 0 && defs[j].arity >= 0 && defs[i].arity != defs[j].arity)
+            return 1;
+         if (defs[i].param_types[0] && defs[j].param_types[0] &&
+             !streq(defs[i].param_types, defs[j].param_types))
+            return 1;
+      }
+   return 0;
+}
+
+xrepo_mult_t xrepo_classify_multiplicity(const xrepo_def_t *defs, const int *def_counts,
+                                         const int *exporter, int n, const xrepo_mult_cfg_t *cfg)
+{
+   xrepo_mult_t r = {XREPO_MULT_SINGLE, n < 0 ? 0 : n, n == 1 ? 0 : -1};
+   if (n <= 1)
+      return r;
+
+   /* Total definitions and the top-two definer repos by def count. Non-positive
+    * def_counts are clamped to 0 so a malformed input can't make the share
+    * arithmetic negative/ill-defined; total==0 -> no dominant (falls to NAMECLASH). */
+   long total = 0;
+   int top = 0, second = -1;
+   for (int i = 0; i < n; i++)
+   {
+      int dc = def_counts[i] > 0 ? def_counts[i] : 0;
+      total += dc;
+      if (def_counts[i] > def_counts[top])
+      {
+         second = top;
+         top = i;
+      }
+      else if (second < 0 || def_counts[i] > def_counts[second])
+      {
+         if (i != top)
+            second = i;
+      }
+   }
+
+   /* A genuinely divergent signature spread is always a name-clash. */
+   if (provably_unrelated(defs, n))
+   {
+      r.kind = XREPO_MULT_NAMECLASH;
+      return r;
+   }
+
+   /* Dominant-definer hysteresis (§3.5): top holds >= dom_share_pct% AND the
+    * runner-up holds <= runnerup_share_pct% AND <= runnerup_abs defs AND no
+    * non-dominant definer is itself a distinctive exporter. */
+   int dom_share = cfg ? cfg->dom_share_pct : 90;
+   int ru_share = cfg ? cfg->runnerup_share_pct : 5;
+   int ru_abs = cfg ? cfg->runnerup_abs : 2;
+   int top_pct = total > 0 ? (int)((def_counts[top] * 100L) / total) : 0;
+   int second_pct = (second >= 0 && total > 0) ? (int)((def_counts[second] * 100L) / total) : 0;
+   int second_cnt = second >= 0 ? def_counts[second] : 0;
+
+   int other_exporter = 0;
+   for (int i = 0; i < n; i++)
+      if (i != top && exporter && exporter[i])
+         other_exporter = 1;
+
+   if (top_pct >= dom_share && second_pct <= ru_share && second_cnt <= ru_abs && !other_exporter)
+   {
+      r.kind = XREPO_MULT_DOMINANT;
+      r.dominant_index = top;
+      return r;
+   }
+   r.kind = XREPO_MULT_NAMECLASH;
+   return r;
+}
+
+/* ---- the deterministic tier pipeline (§3.10) ----------------------------- */
+
+/* One-tier downgrade, floored at LOW (caps never drop a passing edge below LOW;
+ * gates handle exclusion/review separately). */
+static xrepo_tier_t downgrade(xrepo_tier_t t)
+{
+   if (t == XREPO_TIER_HIGH)
+      return XREPO_TIER_MEDIUM;
+   if (t == XREPO_TIER_MEDIUM)
+      return XREPO_TIER_LOW;
+   return t;
+}
+
+static xrepo_tier_t producer_tier(xrepo_corrob_t c)
+{
+   switch (c)
+   {
+   case XREPO_CORROB_IMPORT:
+   case XREPO_CORROB_TRUSTED_EXPORT:
+      return XREPO_TIER_HIGH;
+   case XREPO_CORROB_DOMINANT:
+      return XREPO_TIER_MEDIUM;
+   default:
+      return XREPO_TIER_LOW;
+   }
+}
+
+xrepo_classification_t xrepo_classify(const xrepo_candidate_t *c)
+{
+   xrepo_classification_t r;
+   memset(&r, 0, sizeof(r));
+   r.tier = XREPO_TIER_NONE;
+
+   if (!c)
+   {
+      r.reason = "null";
+      return r;
+   }
+   if (c->lang == XREPO_LANG_UNKNOWN)
+   {
+      r.tier = XREPO_TIER_UNIMPLEMENTED;
+      r.reason = "unimplemented-language";
+      return r;
+   }
+
+   int multi_definer = c->mult.kind == XREPO_MULT_NAMECLASH;
+   int corroborated = c->corroboration != XREPO_CORROB_NONE;
+
+   /* Gate 1 -- invariant (§3): S originates in the caller -> no external edge. */
+   if (c->originated_in_caller)
+   {
+      r.reason = "invariant-originated-in-caller";
+      return r;
+   }
+   /* Gate 2 -- distinctiveness (§3.3): fail -> excluded, or AMBIGUOUS if the
+    * symbol is a multi-definer (surfaced for review, not silently dropped). */
+   if (!c->distinctive)
+   {
+      if (multi_definer)
+      {
+         r.tier = XREPO_TIER_AMBIGUOUS;
+         r.routed_to_review = 1;
+         r.reason = "not-distinctive-multi-definer";
+      }
+      else
+         r.reason = "not-distinctive";
+      return r;
+   }
+   /* Gate 3 -- multiplicity (§3.5): a name-clash multi-definer without
+    * corroboration is genuinely ambiguous -> review queue. */
+   if (multi_definer && !corroborated)
+   {
+      r.tier = XREPO_TIER_AMBIGUOUS;
+      r.routed_to_review = 1;
+      r.reason = "nameclash-uncorroborated";
+      return r;
+   }
+   /* Gate 4 -- dynamic imports (§3.7) are out of static tiering -> review. */
+   if (c->modality == XREPO_IMPORT_DYNAMIC)
+   {
+      r.tier = XREPO_TIER_AMBIGUOUS;
+      r.routed_to_review = 1;
+      r.reason = "dynamic-import";
+      return r;
+   }
+
+   /* Producer -- base tier from the corroboration route (§3.1). */
+   r.base_tier = producer_tier(c->corroboration);
+   xrepo_tier_t tier = r.base_tier;
+
+   /* Caps (order-independent MIN; each lowers by at most one tier, §3.10). */
+   if (c->caller_collision)
+   {
+      tier = downgrade(tier);
+      r.caller_collision_applied = 1;
+   }
+   if (c->modality == XREPO_IMPORT_CONDITIONAL)
+   {
+      tier = downgrade(tier);
+      r.modality_cap_applied = 1;
+   }
+   /* Trust cap (§0): an untrusted-rooted corroboration route cannot reach HIGH ->
+    * cap at MEDIUM. The IMPORT route is rooted in the caller (untrusted caller
+    * caps); the TRUSTED_EXPORT route is rooted in the definer (an untrusted
+    * definer can never lend HIGH export). Both are guarded here so untrusted HIGH
+    * cannot leak via either route. */
+   int untrusted_import = !c->caller_trusted && c->corroboration == XREPO_CORROB_IMPORT;
+   int untrusted_export = !c->definer_trusted && c->corroboration == XREPO_CORROB_TRUSTED_EXPORT;
+   if ((untrusted_import || untrusted_export) && tier > XREPO_TIER_MEDIUM)
+   {
+      tier = XREPO_TIER_MEDIUM;
+      r.trust_cap_applied = 1;
+   }
+
+   /* Structural invariant (§3.10): caps only lower, never raise -- the final
+    * ladder tier never exceeds the producer's base tier. */
+   if (tier > r.base_tier)
+      tier = r.base_tier;
+
+   r.tier = tier;
+   r.reason = xrepo_tier_name(tier);
+   return r;
+}
+
+/* ---- eviction score (§3.8) ----------------------------------------------- */
+
+double xrepo_evidence_score(int distinctiveness_rank, int call_site_count, int corroboration_routes)
+{
+   /* Weighted so corroboration dominates, then call sites, then distinctiveness;
+    * purely for deterministic lowest-evidence-first eviction, not a tier. */
+   double d = distinctiveness_rank < 0 ? 0 : distinctiveness_rank;
+   double s = call_site_count < 0 ? 0 : call_site_count;
+   double r = corroboration_routes < 0 ? 0 : corroboration_routes;
+   return 10.0 * r + 1.0 * s + 0.01 * d;
+}

--- a/src/db2/cross_repo_classify.h
+++ b/src/db2/cross_repo_classify.h
@@ -1,0 +1,133 @@
+#ifndef AIMEE_CROSS_REPO_CLASSIFY_H
+#define AIMEE_CROSS_REPO_CLASSIFY_H
+
+#include "cross_repo_resolver.h"
+
+/* Pure, DB-free tier classification for the cross-repo dependency resolver
+ * (S2b): definition multiplicity (§3.5) + the deterministic gate/cap/producer
+ * pipeline (§3.10). Builds on the S2a import-resolution + distinctiveness core.
+ * Deterministic and DB-free, so unit-testable on the sqlite shim; S3 gathers the
+ * inputs and S4 wires this into canonical_index_cross_repo_deps.
+ *
+ * See docs/proposals/pending/cross-repo-dependency-graph.md. */
+
+/* Confidence tiers, ordered so the pipeline's caps are a monotone MIN over the
+ * HIGH..LOW ladder (§3.10). NONE = excluded (no edge); AMBIGUOUS = routed to the
+ * review queue (§3.8), off the ladder; UNIMPLEMENTED = out-of-scope language
+ * (§3.7), surfaced not silently dropped. */
+typedef enum
+{
+   XREPO_TIER_NONE = 0,
+   XREPO_TIER_AMBIGUOUS,
+   XREPO_TIER_LOW,
+   XREPO_TIER_MEDIUM,
+   XREPO_TIER_HIGH,
+   XREPO_TIER_UNIMPLEMENTED
+} xrepo_tier_t;
+
+const char *xrepo_tier_name(xrepo_tier_t t);
+
+/* ---- definition multiplicity (§3.5) -------------------------------------- *
+ * Distinguish a genuine name-clash (same leaf, unrelated defs in >=2 repos ->
+ * AMBIGUOUS) from polymorphic multiplicity (trait impls / method sets / overloads
+ * -> intra-repo, must NOT inflate the definer count). A definition signature is
+ * (qualified receiver/self type, arity, parameter types) where available; the
+ * per-language dispatch matrix decides whether the receiver type is part of the
+ * key. Counting is over unique DEFINER REPOS, not raw rows. */
+
+typedef struct
+{
+   const char *repo;        /* defining repo name */
+   xrepo_lang_t lang;       /* definition language */
+   const char *self_type;   /* qualified receiver/self/trait type; "" if free function */
+   int arity;               /* parameter count; -1 if unknown */
+   const char *param_types; /* normalized parameter type list; "" if unknown */
+} xrepo_def_t;
+
+typedef enum
+{
+   XREPO_MULT_SINGLE = 0, /* one definer repo (or all defs polymorphic in one repo) */
+   XREPO_MULT_DOMINANT,   /* a dominant definer per the hysteresis rule */
+   XREPO_MULT_NAMECLASH   /* unrelated defs across >=2 repos -> AMBIGUOUS w/o corroboration */
+} xrepo_mult_kind_t;
+
+typedef struct
+{
+   xrepo_mult_kind_t kind;
+   int definer_repos;  /* count of distinct defining repos */
+   int dominant_index; /* defs[] index of the dominant definer; -1 if none */
+} xrepo_mult_t;
+
+/* Per-language dispatch config: thresholds for the dominant-definer hysteresis
+ * (§3.5). dominant iff a single definer holds >= dom_share_pct% of defs AND the
+ * runner-up holds <= runnerup_share_pct% AND <= runnerup_abs defs AND no other
+ * definer is itself a distinctive exporter. */
+typedef struct
+{
+   int dom_share_pct;      /* default 90 */
+   int runnerup_share_pct; /* default 5 */
+   int runnerup_abs;       /* default 2 */
+} xrepo_mult_cfg_t;
+
+/* Classify multiplicity over a symbol's definitions. `def_counts[i]` is the
+ * number of definitions of the symbol in defs[i]'s repo (defs[] is one row per
+ * distinct definer repo, already de-duplicated by the caller); `exporter[i]` is
+ * 1 if that repo distinctively exports the symbol. The per-language dispatch
+ * (whether self_type participates) is applied when deciding name-clash vs
+ * polymorphic. */
+xrepo_mult_t xrepo_classify_multiplicity(const xrepo_def_t *defs, const int *def_counts,
+                                         const int *exporter, int n, const xrepo_mult_cfg_t *cfg);
+
+/* ---- the deterministic tier pipeline (§3.10) ----------------------------- */
+
+/* Corroboration route that sets the base tier (the pipeline's only producer). */
+typedef enum
+{
+   XREPO_CORROB_NONE = 0,       /* no corroboration -> LOW */
+   XREPO_CORROB_DOMINANT,       /* dominant single definer -> MEDIUM */
+   XREPO_CORROB_TRUSTED_EXPORT, /* §3.1b export route (trusted definer) -> HIGH */
+   XREPO_CORROB_IMPORT          /* §3.1a import resolution -> HIGH */
+} xrepo_corrob_t;
+
+/* Everything the pipeline needs about one candidate edge. The caller (S4) fills
+ * this from the S2a resolver result + S3 stats; the pipeline itself is pure. */
+typedef struct
+{
+   xrepo_lang_t lang;            /* caller-site language; UNKNOWN -> UNIMPLEMENTED */
+   int originated_in_caller;     /* S has an ORIGINAL (non-re-export) def in A -> no edge */
+   int distinctive;              /* xrepo_name_distinctive result (§3.3) */
+   xrepo_mult_t mult;            /* §3.5 multiplicity result */
+   int caller_collision;         /* S behaves like a local method in A (§3.4) -> one-tier cap */
+   xrepo_corrob_t corroboration; /* base-tier producer (§3.1) */
+   int caller_trusted;           /* caller repo trust (§0): untrusted IMPORT route caps at MEDIUM */
+   int definer_trusted;          /* definer repo trust (§0): untrusted EXPORT route caps at MEDIUM
+                                  * (an untrusted definer can never lend HIGH export) */
+   xrepo_import_modality_t modality; /* conditional -> one-tier cap; dynamic -> review */
+} xrepo_candidate_t;
+
+/* Per-stage trace, for the --dry-run evidence + structural-invariant asserts. */
+typedef struct
+{
+   xrepo_tier_t tier;            /* final tier (or AMBIGUOUS/NONE/UNIMPLEMENTED) */
+   int routed_to_review;         /* 1 = AMBIGUOUS -> review queue */
+   xrepo_tier_t base_tier;       /* producer output before caps */
+   int caller_collision_applied; /* a cap lowered the tier */
+   int trust_cap_applied;
+   int modality_cap_applied;
+   const char *reason; /* short stage label that determined the outcome */
+} xrepo_classification_t;
+
+/* Run the §3.10 pipeline. Deterministic: a fixed candidate always yields the
+ * same classification. Gates (invariant, distinctiveness, multiplicity) may
+ * short-circuit to NONE / AMBIGUOUS; otherwise the producer sets a base tier and
+ * the caps take the MIN (caller-collision, trust, conditional-import each lower
+ * by at most one tier, floored at LOW; dynamic-import routes to review). */
+xrepo_classification_t xrepo_classify(const xrepo_candidate_t *c);
+
+/* Eviction score for the AMBIGUOUS review queue (§3.8): higher = more evidence,
+ * so the queue evicts the lowest first. Independent of the (absent) tier so it is
+ * well-defined for AMBIGUOUS rows. */
+double xrepo_evidence_score(int distinctiveness_rank, int call_site_count,
+                            int corroboration_routes);
+
+#endif /* AIMEE_CROSS_REPO_CLASSIFY_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1386,12 +1386,14 @@ $(TESTPREFIX)/unit-test-code-treesitter: $(OBJDIR)/tests/test_code_treesitter.o 
 	$(TESTLINK) -o $@ $^ $(L_CORE)
 endif
 
-# Cross-repo dependency graph S2a: pure resolver core (import resolution +
-# distinctiveness). DB-free, so it links only the resolver object. The
-# TEST_TARGETS membership is declared in the initial := block above (before the
-# unit-tests rule) so the binary is built, not just run.
+# Cross-repo dependency graph S2a/S2b: pure resolver core (import resolution +
+# distinctiveness) and tier classification (multiplicity + pipeline). DB-free, so
+# it links only the resolver + classify objects. The TEST_TARGETS membership is
+# declared in the initial := block above (before the unit-tests rule) so the
+# binary is built, not just run.
 $(TESTPREFIX)/unit-test-cross-repo-deps: $(OBJDIR)/tests/test_cross_repo_deps.o \
-                                         $(OBJDIR)/db2/cross_repo_resolver.o
+                                         $(OBJDIR)/db2/cross_repo_resolver.o \
+                                         $(OBJDIR)/db2/cross_repo_classify.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-aimee-client: $(OBJDIR)/tests/test_aimee_client.o $(OBJDIR)/aimee_client.o \

--- a/src/tests/test_cross_repo_deps.c
+++ b/src/tests/test_cross_repo_deps.c
@@ -4,6 +4,7 @@
  * S2a portion; S2b adds the tier-pipeline tests. See
  * docs/proposals/pending/cross-repo-dependency-graph.md. */
 
+#include "cross_repo_classify.h"
 #include "cross_repo_resolver.h"
 
 #include <assert.h>
@@ -240,6 +241,205 @@ static void test_resolve_edge_cases(void)
    printf("ok\n");
 }
 
+/* ---- S2b: multiplicity (§3.5) -------------------------------------------- */
+
+static void test_multiplicity(void)
+{
+   printf("test_multiplicity... ");
+   xrepo_mult_cfg_t cfg = {.dom_share_pct = 90, .runnerup_share_pct = 5, .runnerup_abs = 2};
+
+   /* Single definer repo. */
+   xrepo_def_t one[] = {{"repo-b", XREPO_LANG_C, "", 2, "int,int"}};
+   int oc[] = {3};
+   int oe[] = {1};
+   xrepo_mult_t m = xrepo_classify_multiplicity(one, oc, oe, 1, &cfg);
+   assert(m.kind == XREPO_MULT_SINGLE && m.dominant_index == 0);
+
+   /* Dominant definer: 95 defs vs 1, runner-up not an exporter -> DOMINANT. */
+   xrepo_def_t dom[] = {{"repo-b", XREPO_LANG_C, "", 1, "int"},
+                        {"repo-c", XREPO_LANG_C, "", 1, "int"}};
+   int dc[] = {95, 1};
+   int de[] = {1, 0};
+   m = xrepo_classify_multiplicity(dom, dc, de, 2, &cfg);
+   assert(m.kind == XREPO_MULT_DOMINANT && m.dominant_index == 0);
+
+   /* Even split across two repos -> name-clash (AMBIGUOUS). */
+   int sc[] = {5, 5};
+   m = xrepo_classify_multiplicity(dom, sc, de, 2, &cfg);
+   assert(m.kind == XREPO_MULT_NAMECLASH);
+
+   /* Dominant by count but the runner-up is a distinctive exporter -> name-clash. */
+   int dc2[] = {95, 1};
+   int de2[] = {1, 1};
+   m = xrepo_classify_multiplicity(dom, dc2, de2, 2, &cfg);
+   assert(m.kind == XREPO_MULT_NAMECLASH);
+
+   /* Provably-unrelated signatures (differing arity) -> name-clash even if a
+    * count majority exists (polymorphic rescue does not apply). */
+   xrepo_def_t unrel[] = {{"repo-b", XREPO_LANG_CPP, "", 1, ""},
+                          {"repo-c", XREPO_LANG_CPP, "", 3, ""}};
+   int uc[] = {95, 1};
+   int ue[] = {1, 0};
+   m = xrepo_classify_multiplicity(unrel, uc, ue, 2, &cfg);
+   assert(m.kind == XREPO_MULT_NAMECLASH);
+
+   /* Unknown/variadic signatures (arity -1, "" params) are NOT provably unrelated,
+    * so a clear count majority still resolves to DOMINANT (overloads not punished). */
+   xrepo_def_t vararg[] = {{"repo-b", XREPO_LANG_CPP, "", -1, ""},
+                           {"repo-c", XREPO_LANG_CPP, "", 2, ""}};
+   m = xrepo_classify_multiplicity(vararg, dc, de, 2, &cfg); /* dc={95,1}, de={1,0} */
+   assert(m.kind == XREPO_MULT_DOMINANT);
+
+   /* Non-positive def_counts are clamped (no negative shares); total 0 -> name-clash. */
+   int zc[] = {0, 0};
+   m = xrepo_classify_multiplicity(dom, zc, de, 2, &cfg);
+   assert(m.kind == XREPO_MULT_NAMECLASH);
+   printf("ok\n");
+}
+
+/* ---- S2b: the deterministic pipeline (§3.10) ----------------------------- */
+
+static xrepo_candidate_t base_candidate(void)
+{
+   xrepo_candidate_t c;
+   memset(&c, 0, sizeof(c));
+   c.lang = XREPO_LANG_C;
+   c.distinctive = 1;
+   c.caller_trusted = 1;
+   c.definer_trusted = 1;
+   c.mult.kind = XREPO_MULT_SINGLE;
+   c.corroboration = XREPO_CORROB_NONE;
+   c.modality = XREPO_IMPORT_STATIC;
+   return c;
+}
+
+static void test_classify_pipeline(void)
+{
+   printf("test_classify_pipeline... ");
+
+   /* Import-corroborated, distinctive, trusted -> HIGH. */
+   xrepo_candidate_t c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_HIGH);
+
+   /* Trusted-export route -> HIGH. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_TRUSTED_EXPORT;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_HIGH);
+
+   /* Dominant definer only -> MEDIUM. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_DOMINANT;
+   c.mult.kind = XREPO_MULT_DOMINANT;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_MEDIUM);
+
+   /* No corroboration -> LOW. */
+   c = base_candidate();
+   assert(xrepo_classify(&c).tier == XREPO_TIER_LOW);
+
+   /* Invariant: S originates in caller -> NONE. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.originated_in_caller = 1;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_NONE);
+
+   /* Not distinctive + multi-definer -> AMBIGUOUS (review); single -> NONE. */
+   c = base_candidate();
+   c.distinctive = 0;
+   c.mult.kind = XREPO_MULT_NAMECLASH;
+   xrepo_classification_t r = xrepo_classify(&c);
+   assert(r.tier == XREPO_TIER_AMBIGUOUS && r.routed_to_review == 1);
+   c.mult.kind = XREPO_MULT_SINGLE;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_NONE);
+
+   /* Name-clash without corroboration -> AMBIGUOUS; with import -> resolved HIGH. */
+   c = base_candidate();
+   c.mult.kind = XREPO_MULT_NAMECLASH;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_AMBIGUOUS);
+   c.corroboration = XREPO_CORROB_IMPORT;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_HIGH);
+
+   /* Caller-collision caps one tier: HIGH -> MEDIUM. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.caller_collision = 1;
+   r = xrepo_classify(&c);
+   assert(r.tier == XREPO_TIER_MEDIUM && r.caller_collision_applied == 1);
+
+   /* Conditional import caps one tier: HIGH -> MEDIUM. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.modality = XREPO_IMPORT_CONDITIONAL;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_MEDIUM);
+
+   /* Dynamic import -> review (AMBIGUOUS). */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.modality = XREPO_IMPORT_DYNAMIC;
+   r = xrepo_classify(&c);
+   assert(r.tier == XREPO_TIER_AMBIGUOUS && r.routed_to_review == 1);
+
+   /* Untrusted caller caps the import route at MEDIUM (§0). */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.caller_trusted = 0;
+   r = xrepo_classify(&c);
+   assert(r.tier == XREPO_TIER_MEDIUM && r.trust_cap_applied == 1);
+
+   /* Untrusted DEFINER caps the export route at MEDIUM (§0): an untrusted
+    * definer can never lend HIGH export. Caller trust alone does not save it. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_TRUSTED_EXPORT;
+   c.definer_trusted = 0;
+   r = xrepo_classify(&c);
+   assert(r.tier == XREPO_TIER_MEDIUM && r.trust_cap_applied == 1);
+   /* A trusted caller importing from an untrusted definer is unaffected on the
+    * import route (the export-route cap is route-specific). */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.definer_trusted = 0;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_HIGH);
+
+   /* Structural invariant (§3.10): caps only lower -- final tier <= base tier. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.caller_collision = 1;
+   c.modality = XREPO_IMPORT_CONDITIONAL;
+   r = xrepo_classify(&c);
+   assert(r.tier <= r.base_tier);
+
+   /* Combined caps floor at LOW: import + collision + conditional. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_IMPORT;
+   c.caller_collision = 1;
+   c.modality = XREPO_IMPORT_CONDITIONAL;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_LOW);
+
+   /* Unknown language -> UNIMPLEMENTED. */
+   c = base_candidate();
+   c.lang = XREPO_LANG_UNKNOWN;
+   c.corroboration = XREPO_CORROB_IMPORT;
+   assert(xrepo_classify(&c).tier == XREPO_TIER_UNIMPLEMENTED);
+
+   /* Determinism: the same candidate classifies identically. */
+   c = base_candidate();
+   c.corroboration = XREPO_CORROB_DOMINANT;
+   assert(xrepo_classify(&c).tier == xrepo_classify(&c).tier);
+   printf("ok\n");
+}
+
+static void test_evidence_score(void)
+{
+   printf("test_evidence_score... ");
+   /* More corroboration routes outweigh more call sites (eviction keeps the
+    * better-evidenced rows). */
+   assert(xrepo_evidence_score(0, 2, 1) > xrepo_evidence_score(99, 1, 0));
+   /* Ties broken toward more call sites, then distinctiveness. */
+   assert(xrepo_evidence_score(0, 3, 0) > xrepo_evidence_score(0, 2, 0));
+   assert(xrepo_evidence_score(5, 2, 0) > xrepo_evidence_score(1, 2, 0));
+   printf("ok\n");
+}
+
 int main(void)
 {
    test_lang_from_path();
@@ -248,6 +448,9 @@ int main(void)
    test_resolve_c();
    test_resolve_rust_go_py_ts();
    test_resolve_edge_cases();
+   test_multiplicity();
+   test_classify_pipeline();
+   test_evidence_score();
    printf("cross_repo_deps: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## Summary
Third slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md`), on top of S2a (#801). The **DB-free tier classifier** — definition multiplicity (§3.5) and the deterministic gate/cap/producer pipeline (§3.10) — completing the pure resolver core (acceptance #1). New `db2/cross_repo_classify.{c,h}`.

- **`xrepo_classify_multiplicity` (§3.5)**: name-clash vs dominant-definer over distinct definer repos. Dominant hysteresis (≥90% share AND runner-up ≤5% & ≤2 AND no other distinctive exporter). Only **known-incompatible** signatures (differing known arity/param-types) force a name-clash; variadic/unknown (`arity=-1`, `""`) are exempt so compatible overloads aren't punished; non-positive `def_counts` are clamped.
- **`xrepo_classify` (§3.10)**: terminal gates (invariant → NONE; non-distinctive → NONE / AMBIGUOUS-if-multi-definer; name-clash w/o corroboration → AMBIGUOUS; dynamic import → review) then a producer base tier (import/trusted-export → HIGH, dominant → MEDIUM, none → LOW), then order-independent MIN caps (caller-collision −1, conditional-import −1, untrusted **caller** caps the import route, untrusted **definer** caps the export route — both at MEDIUM; floor LOW). A structural invariant (final ≤ base) is enforced and tested. Per-stage trace for `--dry-run`/evidence.
- **`xrepo_evidence_score` (§3.8)**: deterministic lowest-evidence-first eviction key.

## Tests / gates
`test_cross_repo_deps.c` extended (multiplicity incl. variadic-exempt + zero-count guard; full pipeline incl. each gate/cap, route-specific trust caps, caps-only-lower invariant, determinism, UNIMPLEMENTED; evidence-score ordering). All 9 groups pass; clang-format-19 clean; DB-free link.

## Review
Code-review roundtable; 3 blocking resolved: (1) `provably_unrelated` narrowed to known-incompatible + defs[] contract pinned + count guard; (2) gate terminality made explicit + caps-only-lower invariant enforced/tested; (3) trust cap extended to the TRUSTED_EXPORT route via a new `definer_trusted` field (untrusted definer can never lend HIGH export).