### PR TITLE
feat(harness-memory): multi-client scope registry + atomic hydrate

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,7 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/plugin_loader.c
     ${AIMEE_SRC_DIR}/memory_provider.c
     ${AIMEE_SRC_DIR}/harness_memory_common.c
+    ${AIMEE_SRC_DIR}/harness_memory_scope.c
     ${AIMEE_SRC_DIR}/plugin_c_hook.c
     ${AIMEE_SRC_DIR}/config_plugin.c
     ${AIMEE_SRC_DIR}/code_collect.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,7 +295,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
             workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c \
-            harness_memory_common.c
+            harness_memory_common.c harness_memory_scope.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
@@ -351,7 +351,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_main.c cli_agent_setup.c cli_session_start.c harness_memory_hydrate.c harness_memory_common.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
+CLI_SRCS = cli_main.c cli_agent_setup.c cli_session_start.c harness_memory_hydrate.c harness_memory_common.c harness_memory_scope.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -5,12 +5,18 @@
 #include "cJSON.h"
 #include "cli_client.h" /* cli_http_request, cli_v1_client_endpoint/bearer */
 #include "harness_memory_common.h"
+#include "harness_memory_scope.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096
@@ -82,22 +88,51 @@ static const char *jstr(cJSON *o, const char *k)
    return (i && cJSON_IsString(i)) ? i->valuestring : NULL;
 }
 
+/* Atomic write: temp + fsync + rename, so a concurrent reader never sees a
+ * partial hydrated file (parity with P3's re-materialize). */
 static int write_file(const char *path, const char *content)
 {
    mkdir_parents(path);
+   size_t len = content ? strlen(content) : 0;
+#ifndef _WIN32
+   char dir[PATH_MAX];
+   const char *base = strrchr(path, '/');
+   if (base)
+      snprintf(dir, sizeof(dir), "%.*s", (int)(base - path), path);
+   else
+      snprintf(dir, sizeof(dir), ".");
+   char tmpl[PATH_MAX];
+   if ((size_t)snprintf(tmpl, sizeof(tmpl), "%s/.hmem_hyd_XXXXXX", dir) >= sizeof(tmpl))
+      return -1;
+   int fd = mkstemp(tmpl);
+   if (fd < 0)
+      return -1;
+   ssize_t w = (content && len) ? write(fd, content, len) : 0;
+   fsync(fd);
+   close(fd);
+   if (w < 0 || (size_t)w != len || rename(tmpl, path) != 0)
+   {
+      unlink(tmpl);
+      return -1;
+   }
+   return 0;
+#else
    FILE *f = fopen(path, "wb");
    if (!f)
       return -1;
-   size_t len = content ? strlen(content) : 0;
    size_t w = content ? fwrite(content, 1, len, f) : 0;
    fclose(f);
    return (w == len) ? 0 : -1;
+#endif
 }
 
 int harness_memory_hydrate(const char *cwd)
 {
    const char *home = getenv("HOME");
    if (!home || !home[0])
+      return -1;
+   const hmem_scope_t *scope = hmem_scope_for_client(getenv("AIMEE_HOOK_CLIENT"));
+   if (!scope) /* no registered memory surface for this client */
       return -1;
    char real[PATH_MAX];
    if (!realpath((cwd && cwd[0]) ? cwd : ".", real))
@@ -110,8 +145,8 @@ int harness_memory_hydrate(const char *cwd)
       return -1;
 
    char memdir[PATH_MAX];
-   if ((size_t)snprintf(memdir, sizeof(memdir), "%s/.claude/projects/%s/memory", home, slug) >=
-       sizeof(memdir))
+   if ((size_t)snprintf(memdir, sizeof(memdir), "%s/%s/%s/%s", home, scope->projects_root, slug,
+                        scope->memory_seg) >= sizeof(memdir))
       return -1;
 
    char *endpoint = cli_v1_client_endpoint();

--- a/src/harness_memory_scope.c
+++ b/src/harness_memory_scope.c
@@ -14,9 +14,13 @@ static const hmem_scope_t SCOPES[] = {
 
 const hmem_scope_t *hmem_scope_for_client(const char *client)
 {
-   const char *c = (client && client[0]) ? client : "claude";
+   /* Require an explicit client — a missing/empty AIMEE_HOOK_CLIENT must NOT
+    * silently route into another client's tree (cross-client contamination
+    * footgun once the table has >1 entry). The cross-client hooks always set it. */
+   if (!client || !client[0])
+      return NULL;
    for (size_t i = 0; i < sizeof(SCOPES) / sizeof(SCOPES[0]); i++)
-      if (strcmp(SCOPES[i].client, c) == 0)
+      if (strcmp(SCOPES[i].client, client) == 0)
          return &SCOPES[i];
    return NULL;
 }

--- a/src/harness_memory_scope.c
+++ b/src/harness_memory_scope.c
@@ -1,0 +1,22 @@
+/* harness_memory_scope.c — see harness_memory_scope.h.
+ *
+ * v1 ships the Claude Code file-memory surface. Adding another agent that has a
+ * file-memory directory is one row here — no detection/hydrate code changes.
+ * (A config-file override of this table is a documented follow-up.) */
+
+#include "harness_memory_scope.h"
+
+#include <string.h>
+
+static const hmem_scope_t SCOPES[] = {
+    {"claude", ".claude/projects", "memory"},
+};
+
+const hmem_scope_t *hmem_scope_for_client(const char *client)
+{
+   const char *c = (client && client[0]) ? client : "claude";
+   for (size_t i = 0; i < sizeof(SCOPES) / sizeof(SCOPES[0]); i++)
+      if (strcmp(SCOPES[i].client, c) == 0)
+         return &SCOPES[i];
+   return NULL;
+}

--- a/src/harness_memory_scope.h
+++ b/src/harness_memory_scope.h
@@ -1,0 +1,31 @@
+/* harness_memory_scope.h: the per-client memory-surface registry — the single
+ * source of truth for "what is an agent's local memory" — consumed by both the
+ * interception detector (memory_redirect) and the session-start hydrator. Lets
+ * new agents be supported by adding a row rather than editing detection logic.
+ * See docs/proposals/pending/central-agent-memory-interception.md (§6).
+ */
+#ifndef DEC_HARNESS_MEMORY_SCOPE_H
+#define DEC_HARNESS_MEMORY_SCOPE_H 1
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef struct
+   {
+      const char *client;        /* AIMEE_HOOK_CLIENT id, e.g. "claude" */
+      const char *projects_root; /* path under $HOME, e.g. ".claude/projects" */
+      const char *memory_seg;    /* memory subdir segment, e.g. "memory" */
+   } hmem_scope_t;
+
+   /* The memory surface for a client (NULL/"" defaults to "claude"). Returns
+    * NULL when the client has no registered memory surface — callers treat that
+    * as "not a memory operation / nothing to hydrate". */
+   const hmem_scope_t *hmem_scope_for_client(const char *client);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_HARNESS_MEMORY_SCOPE_H */

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -71,7 +71,9 @@ mr_verdict_t memory_redirect_classify(const char *client, const char *tool, cons
    int mn = snprintf(memseg, sizeof(memseg), "/%s/", scope->memory_seg);
    if (mn < 0 || (size_t)mn >= sizeof(memseg))
       return MR_ALLOW;
-   const char *mem = strstr(path, memseg);
+   /* Anchor the memseg search AFTER the confirmed prefix so a "/memory/" inside
+    * HOME/projects_root can't be mistaken for the project's memory dir. */
+   const char *mem = strstr(path + pn, memseg);
    if (!mem)
       return MR_ALLOW;
    size_t plen = strlen(path);

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -11,6 +11,7 @@
 
 #include "cli_client.h" /* cli_http_request, cli_v1_client_endpoint/bearer */
 #include "harness_memory_common.h"
+#include "harness_memory_scope.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -32,11 +33,11 @@ static int is_write_family(const char *t)
    return t && (strcmp(t, "Write") == 0 || strcmp(t, "Edit") == 0 || strcmp(t, "MultiEdit") == 0);
 }
 
-/* Does abspath start with "<home>/.claude/projects/"? */
-static int under_claude_projects(const char *abspath, const char *home)
+/* Does abspath start with "<home>/<projects_root>/"? */
+static int under_projects_root(const char *abspath, const char *home, const char *projects_root)
 {
    char prefix[PATH_MAX];
-   int n = snprintf(prefix, sizeof(prefix), "%s/.claude/projects/", home);
+   int n = snprintf(prefix, sizeof(prefix), "%s/%s/", home, projects_root);
    if (n < 0 || (size_t)n >= sizeof(prefix) || !abspath)
       return 0;
    return strncmp(abspath, prefix, (size_t)n) == 0;
@@ -54,17 +55,23 @@ mr_verdict_t memory_redirect_classify(const char *client, const char *tool, cons
 {
    if (out_reason)
       *out_reason = NULL;
-   const char *c = (client && client[0]) ? client : "claude";
-   if (strcmp(c, "claude") != 0) /* v1: Claude file-memory only */
+   const hmem_scope_t *scope = hmem_scope_for_client(client);
+   if (!scope) /* unregistered client — not a memory surface we manage */
       return MR_ALLOW;
    if (!is_write_family(tool) || !path || !home || !home[0])
       return MR_ALLOW;
 
-   /* HOME-anchored: the path must literally begin under ~/.claude/projects/ —
-    * an unanchored substring would false-positive on repo paths. */
-   if (!under_claude_projects(path, home))
+   /* HOME-anchored to the client's projects root — an unanchored substring would
+    * false-positive on repo paths. */
+   char prefix[PATH_MAX];
+   int pn = snprintf(prefix, sizeof(prefix), "%s/%s/", home, scope->projects_root);
+   if (pn < 0 || (size_t)pn >= sizeof(prefix) || strncmp(path, prefix, (size_t)pn) != 0)
       return MR_ALLOW;
-   const char *mem = strstr(path, "/memory/");
+   char memseg[80];
+   int mn = snprintf(memseg, sizeof(memseg), "/%s/", scope->memory_seg);
+   if (mn < 0 || (size_t)mn >= sizeof(memseg))
+      return MR_ALLOW;
+   const char *mem = strstr(path, memseg);
    if (!mem)
       return MR_ALLOW;
    size_t plen = strlen(path);
@@ -88,7 +95,7 @@ mr_verdict_t memory_redirect_classify(const char *client, const char *tool, cons
       return MR_REJECT;
    }
 
-   const char *after = mem + strlen("/memory/");
+   const char *after = mem + strlen(memseg);
    size_t alen = strlen(after);
    if (alen <= 3 || after[0] == '/') /* just ".md", or an odd leading slash */
       return MR_ALLOW;
@@ -113,7 +120,8 @@ static const char *json_str(cJSON *o, const char *key)
  * cannot re-enter the PreToolUse hook). The parent dir is realpath-resolved and
  * confined under ~/.claude/projects/, so a symlinked component can't redirect
  * the write outside the memory tree. Atomic (temp + rename) on POSIX. */
-static int rematerialize(const char *path, const char *content, const char *home)
+static int rematerialize(const char *path, const char *content, const char *home,
+                         const char *projects_root)
 {
    const char *base = strrchr(path, '/');
    if (!base)
@@ -128,7 +136,7 @@ static int rematerialize(const char *path, const char *content, const char *home
    char rp[PATH_MAX];
    if (!realpath(dir, rp)) /* parent must exist + resolve */
       return -1;
-   if (!under_claude_projects(rp, home)) /* symlink escape — refuse */
+   if (!under_projects_root(rp, home, projects_root)) /* symlink escape — refuse */
       return -1;
    char target[PATH_MAX], tmpl[PATH_MAX];
    if ((size_t)snprintf(target, sizeof(target), "%s/%s", rp, base) >= sizeof(target) ||
@@ -148,6 +156,7 @@ static int rematerialize(const char *path, const char *content, const char *home
    return 0;
 #else
    (void)home;
+   (void)projects_root;
    FILE *f = fopen(path, "wb");
    if (!f)
       return -1;
@@ -229,7 +238,8 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
    long id = cJSON_IsNumber(jid) ? (long)jid->valuedouble : 0;
    cJSON_Delete(resp);
 
-   rematerialize(path, content, home);
+   const hmem_scope_t *scope = hmem_scope_for_client(client); /* non-NULL: classify redirected */
+   rematerialize(path, content, home, scope ? scope->projects_root : ".claude/projects");
    snprintf(msg, msg_len,
             "Saved to aimee memory (id=%ld). The file now reflects your content — do not "
             "re-write it.",

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -56,6 +56,7 @@ aimee_add_test(test_memory_provider test_memory_provider.c)
 aimee_add_test(test_harness_memory test_harness_memory.c)
 aimee_add_test(test_memory_redirect test_memory_redirect.c)
 aimee_add_test(test_harness_memory_hydrate test_harness_memory_hydrate.c)
+aimee_add_test(test_harness_memory_scope test_harness_memory_scope.c)
 aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)
 add_executable(test_context_engine test_context_engine.c)
 target_include_directories(test_context_engine PRIVATE

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -77,7 +77,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_g
 # linking both would produce duplicate-symbol errors.
 TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.o
 
-TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
+TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
@@ -438,7 +438,10 @@ $(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/db1/db.o $(OBJDI
 $(TESTPREFIX)/unit-test-harness-memory-hydrate: $(OBJDIR)/tests/test_harness_memory_hydrate.o $(OBJDIR)/harness_memory_hydrate.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/cJSON.o
+$(TESTPREFIX)/unit-test-harness-memory-scope: $(OBJDIR)/tests/test_harness_memory_scope.o $(OBJDIR)/harness_memory_scope.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/harness_memory_scope.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-harness-memory: $(OBJDIR)/tests/test_harness_memory.o $(OBJDIR)/db1/harness_memory.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db1_write.o $(OBJDIR)/db1/db1_trigger.o $(OBJDIR)/db1/db1_cron_jobs.o $(OBJDIR)/db1/model_catalog.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/db1/eval.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \

--- a/src/tests/test_harness_memory_scope.c
+++ b/src/tests/test_harness_memory_scope.c
@@ -13,9 +13,9 @@ int main(void)
    assert(strcmp(s->projects_root, ".claude/projects") == 0);
    assert(strcmp(s->memory_seg, "memory") == 0);
 
-   /* NULL / empty default to claude */
-   assert(hmem_scope_for_client(NULL) == s);
-   assert(hmem_scope_for_client("") == s);
+   /* a missing/empty client has NO scope — never silently default to claude */
+   assert(hmem_scope_for_client(NULL) == NULL);
+   assert(hmem_scope_for_client("") == NULL);
 
    /* an unregistered client has no memory surface */
    assert(hmem_scope_for_client("gemini") == NULL);

--- a/src/tests/test_harness_memory_scope.c
+++ b/src/tests/test_harness_memory_scope.c
@@ -1,0 +1,26 @@
+/* Unit tests for the per-client memory-surface registry (PR-A). */
+
+#include "harness_memory_scope.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+int main(void)
+{
+   const hmem_scope_t *s = hmem_scope_for_client("claude");
+   assert(s && strcmp(s->client, "claude") == 0);
+   assert(strcmp(s->projects_root, ".claude/projects") == 0);
+   assert(strcmp(s->memory_seg, "memory") == 0);
+
+   /* NULL / empty default to claude */
+   assert(hmem_scope_for_client(NULL) == s);
+   assert(hmem_scope_for_client("") == s);
+
+   /* an unregistered client has no memory surface */
+   assert(hmem_scope_for_client("gemini") == NULL);
+   assert(hmem_scope_for_client("nope") == NULL);
+
+   printf("test_harness_memory_scope: OK\n");
+   return 0;
+}

--- a/src/tests/test_memory_redirect.c
+++ b/src/tests/test_memory_redirect.c
@@ -35,10 +35,14 @@ int main(void)
           MR_REDIRECT);
    assert(strcmp(name, "topics/auth") == 0);
 
-   /* flat memory write, client NULL defaults to claude; case-insensitive .MD */
-   assert(cls(NULL, "Write", H "/.claude/projects/proj/memory/note.MD", name, &reason) ==
+   /* flat memory write; case-insensitive .MD */
+   assert(cls("claude", "Write", H "/.claude/projects/proj/memory/note.MD", name, &reason) ==
           MR_REDIRECT);
    assert(strcmp(name, "note") == 0);
+
+   /* a missing/empty client is never intercepted (no silent claude default) */
+   assert(cls(NULL, "Write", H "/.claude/projects/proj/memory/note.md", name, &reason) == MR_ALLOW);
+   assert(cls("", "Write", H "/.claude/projects/proj/memory/note.md", name, &reason) == MR_ALLOW);
 
    /* MEMORY.md -> reject with guidance (case-insensitive) */
    assert(cls("claude", "Write", H "/.claude/projects/proj/memory/MEMORY.md", name, &reason) ==


### PR DESCRIPTION
Deferred items #1 + #2. Introduces `harness_memory_scope` — the single, extensible source of truth for a client's memory surface — consumed by both the interception detector and the session-start hydrator (removes the hardcoded Claude paths; adding an agent is one table row). Makes hydrate writes atomic (mkstemp+fsync+rename), matching P3. Unit-tested. Config-file override of the table is a documented follow-up. Roundtable-reviewed.