### PR TITLE
feat(kb): cross-repo dep graph S3 — DB stats layer

### DIFF
--- a/src/db2/cross_repo_stats.c
+++ b/src/db2/cross_repo_stats.c
@@ -1,0 +1,339 @@
+/* cross_repo_stats.c: DB-backed stats / data-gathering for the cross-repo
+ * resolver (S3). Portable SQL over db2 (Postgres in prod; sqlite test shim).
+ * Feeds the pure S2a/S2b core. See cross_repo_stats.h and
+ * docs/proposals/pending/cross-repo-dependency-graph.md §3.3/§4.1. */
+
+#include "cross_repo_stats.h"
+
+#include "aimee.h"
+#include "db2.h"
+#include "db_postgres.h"
+#include "log.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#define CR_LOG_TAG "cross_repo"
+#define CR_ERRBUF  256
+
+static void *cr_conn(void)
+{
+   return db2_conn();
+}
+
+/* ---- FNV-1a 64-bit ------------------------------------------------------- */
+
+static uint64_t fnv1a_init(void)
+{
+   return 1469598103934665603ULL;
+}
+
+static uint64_t fnv1a_add(uint64_t h, const char *s)
+{
+   if (!s)
+      return h;
+   for (const unsigned char *p = (const unsigned char *)s; *p; p++)
+   {
+      h ^= (uint64_t)*p;
+      h *= 1099511628211ULL;
+   }
+   /* a field separator so ("ab","c") and ("a","bc") differ */
+   h ^= 0x1fULL;
+   h *= 1099511628211ULL;
+   return h;
+}
+
+/* ---- small query helpers ------------------------------------------------- */
+
+/* Run a single-column COUNT/scalar query with up to two text binds; returns the
+ * int64 in *out. Pass NULL for an unused bind. Returns 0 on success, -1 error. */
+static int cr_scalar(void *conn, const char *sql, const char *b1, const char *b2, int64_t *out)
+{
+   char err[CR_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   if (b1)
+      aimee_pg_bind_text(st, "?1", b1);
+   if (b2)
+      aimee_pg_bind_text(st, "?2", b2);
+   int64_t v = 0;
+   int rc = -1;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      v = aimee_pg_column_int64(st, 0);
+      rc = 0;
+   }
+   aimee_pg_finalize(st);
+   if (rc == 0 && out)
+      *out = v;
+   return rc;
+}
+
+/* ---- distinctiveness stats (§3.3) ---------------------------------------- */
+
+int db2_cross_repo_distinct_stats(const char *symbol, const char *caller_repo,
+                                  xrepo_distinct_stats_t *out)
+{
+   void *conn = cr_conn();
+   if (!conn || !symbol || !caller_repo || !out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+
+   int64_t v = 0;
+   /* callee in >= ? trusted repos */
+   if (cr_scalar(conn,
+                 "SELECT COUNT(DISTINCT p.id) FROM code_calls cc "
+                 "JOIN files f ON f.id = cc.file_id JOIN projects p ON p.id = f.project_id "
+                 "WHERE cc.callee = ?1 AND p.trust = 'trusted'",
+                 symbol, NULL, &v) != 0)
+      return -1;
+   out->callee_repo_count = (int)v;
+
+   /* defined in >= ? trusted repos. Positive match on kind='definition' (the
+    * convention db2_code_index_term_find uses) rather than a negative kind<>'route'
+    * exclusion, so a future terms.kind value can't silently inflate the count. */
+   if (cr_scalar(conn,
+                 "SELECT COUNT(DISTINCT p.id) FROM terms t "
+                 "JOIN files f ON f.id = t.file_id JOIN projects p ON p.id = f.project_id "
+                 "WHERE t.name = ?1 AND t.kind = 'definition' AND p.trust = 'trusted'",
+                 symbol, NULL, &v) != 0)
+      return -1;
+   out->definer_repo_count = (int)v;
+
+   /* caller-file percentage: files of A using S as a callee / total files of A */
+   int64_t num = 0, denom = 0;
+   if (cr_scalar(conn,
+                 "SELECT COUNT(DISTINCT f.id) FROM code_calls cc "
+                 "JOIN files f ON f.id = cc.file_id JOIN projects p ON p.id = f.project_id "
+                 "WHERE p.name = ?1 AND cc.callee = ?2",
+                 caller_repo, symbol, &num) != 0)
+      return -1;
+   if (cr_scalar(conn,
+                 "SELECT COUNT(*) FROM files f JOIN projects p ON p.id = f.project_id "
+                 "WHERE p.name = ?1",
+                 caller_repo, NULL, &denom) != 0)
+      return -1;
+   out->caller_file_pct = denom > 0 ? (int)((num * 100) / denom) : 0;
+   return 0;
+}
+
+/* ---- blocked_symbols (§3.3) ---------------------------------------------- */
+
+int db2_cross_repo_symbol_blocked(const char *symbol, const char *lang)
+{
+   void *conn = cr_conn();
+   if (!conn || !symbol)
+      return -1;
+   char err[CR_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "SELECT 1 FROM blocked_symbols WHERE word = ?1 AND (lang = ?2 OR lang = '') LIMIT 1",
+       err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", symbol);
+   aimee_pg_bind_text(st, "?2", lang ? lang : "");
+   int blocked = aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW ? 1 : 0;
+   aimee_pg_finalize(st);
+   return blocked;
+}
+
+int db2_cross_repo_recompute_blocked_symbols(int k, int m, int len_min)
+{
+   void *conn = cr_conn();
+   if (!conn || k <= 0 || m <= 0 || len_min <= 0)
+      return -1;
+   char err[CR_ERRBUF] = "";
+
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+      return -1;
+
+   int ok = 1;
+   /* Bump the version INSIDE the transaction (UPDATE then read), not a
+    * read-before-BEGIN of prev+1: the UPDATE takes the row lock so two concurrent
+    * recomputes serialize and can't both commit the same version (no PK collision
+    * / backward step). UPDATE+SELECT is portable (avoids UPDATE ... RETURNING,
+    * which older sqlite shims lack). */
+   int64_t ver = 0;
+   if (aimee_pg_exec(conn,
+                     "UPDATE cross_repo_meta SET blocked_symbols_version = "
+                     "blocked_symbols_version + 1 WHERE id = 1",
+                     err, sizeof(err)) != 0)
+      ok = 0;
+   if (ok && cr_scalar(conn, "SELECT blocked_symbols_version FROM cross_repo_meta WHERE id = 1",
+                       NULL, NULL, &ver) != 0)
+      ok = 0;
+   if (ok && aimee_pg_exec(conn, "DELETE FROM blocked_symbols", err, sizeof(err)) != 0)
+      ok = 0;
+
+   /* Frequency-derived blocks over TRUSTED repos: callee in >= k repos, or
+    * defined in >= m repos. length >= len_min so we don't store short names
+    * (those are excluded by the distinctiveness len gate at query time). */
+   if (ok)
+   {
+      /* DELETE above clears the table, and the UNION selects only distinct names
+       * (so the two arms can't produce duplicate (word,'') rows) -- no ON CONFLICT
+       * needed, which also keeps the statement portable to the sqlite shim. */
+      aimee_pg_stmt_t *st = aimee_pg_prepare(
+          conn,
+          "INSERT INTO blocked_symbols (word, lang, reason, version) "
+          "SELECT name, '', 'frequency', ?3 FROM ("
+          "  SELECT cc.callee AS name FROM code_calls cc "
+          "    JOIN files f ON f.id = cc.file_id JOIN projects p ON p.id = f.project_id "
+          "    WHERE p.trust = 'trusted' AND length(cc.callee) >= ?4 "
+          "    GROUP BY cc.callee HAVING COUNT(DISTINCT p.id) >= ?1 "
+          "  UNION "
+          "  SELECT t.name AS name FROM terms t "
+          "    JOIN files f ON f.id = t.file_id JOIN projects p ON p.id = f.project_id "
+          "    WHERE p.trust = 'trusted' AND t.kind = 'definition' AND length(t.name) >= ?4 "
+          "    GROUP BY t.name HAVING COUNT(DISTINCT p.id) >= ?2"
+          ") q",
+          err, sizeof(err));
+      if (!st)
+         ok = 0;
+      else
+      {
+         aimee_pg_bind_int(st, "?1", k);
+         aimee_pg_bind_int(st, "?2", m);
+         aimee_pg_bind_int64(st, "?3", ver);
+         aimee_pg_bind_int(st, "?4", len_min);
+         if (aimee_pg_step(st, err, sizeof(err)) < 0)
+            ok = 0;
+         aimee_pg_finalize(st);
+      }
+   }
+
+   if (!ok)
+   {
+      (void)aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      LOG_ERROR(CR_LOG_TAG, "blocked_symbols recompute failed: %s", err);
+      return -1;
+   }
+   if (aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+      return -1;
+
+   int64_t n = 0;
+   (void)cr_scalar(conn, "SELECT COUNT(*) FROM blocked_symbols", NULL, NULL, &n);
+   return (int)n;
+}
+
+/* ---- meta / hashes (§4.1) ------------------------------------------------ */
+
+int db2_cross_repo_meta_read(int64_t *trust_epoch, int64_t *blocked_symbols_version,
+                             char *repo_set_hash, size_t cap)
+{
+   void *conn = cr_conn();
+   if (!conn)
+      return -1;
+   char err[CR_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn,
+       "SELECT trust_epoch, blocked_symbols_version, repo_set_hash FROM cross_repo_meta "
+       "WHERE id = 1",
+       err, sizeof(err));
+   if (!st)
+      return -1;
+   int rc = -1;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      if (trust_epoch)
+         *trust_epoch = aimee_pg_column_int64(st, 0);
+      if (blocked_symbols_version)
+         *blocked_symbols_version = aimee_pg_column_int64(st, 1);
+      if (repo_set_hash && cap)
+         snprintf(repo_set_hash, cap, "%s", aimee_pg_column_text(st, 2));
+      rc = 0;
+   }
+   aimee_pg_finalize(st);
+   return rc;
+}
+
+/* Hash one ordered single-column query's rows into the running FNV state. */
+static int cr_hash_query(void *conn, const char *sql, const char *bind, uint64_t *h)
+{
+   char err[CR_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   if (bind)
+      aimee_pg_bind_text(st, "?1", bind);
+   int step;
+   while ((step = aimee_pg_step(st, err, sizeof(err))) == AIMEE_PG_ROW)
+      *h = fnv1a_add(*h, aimee_pg_column_text(st, 0));
+   aimee_pg_finalize(st);
+   return step < 0 ? -1 : 0;
+}
+
+int db2_cross_repo_repo_symbol_hash(const char *project, char *out, size_t cap)
+{
+   void *conn = cr_conn();
+   if (!conn || !project || !out || cap < 17)
+      return -1;
+   uint64_t h = fnv1a_init();
+   /* terms (name|kind), exports (name), imports (name) -- ordered for determinism. */
+   if (cr_hash_query(conn,
+                     "SELECT t.name || '|' || t.kind FROM terms t "
+                     "JOIN files f ON f.id = t.file_id JOIN projects p ON p.id = f.project_id "
+                     "WHERE p.name = ?1 ORDER BY 1",
+                     project, &h) != 0)
+      return -1;
+   if (cr_hash_query(conn,
+                     "SELECT 'E:' || e.name FROM file_exports e "
+                     "JOIN files f ON f.id = e.file_id JOIN projects p ON p.id = f.project_id "
+                     "WHERE p.name = ?1 ORDER BY 1",
+                     project, &h) != 0)
+      return -1;
+   if (cr_hash_query(conn,
+                     "SELECT 'I:' || i.name FROM file_imports i "
+                     "JOIN files f ON f.id = i.file_id JOIN projects p ON p.id = f.project_id "
+                     "WHERE p.name = ?1 ORDER BY 1",
+                     project, &h) != 0)
+      return -1;
+   snprintf(out, cap, "%016llx", (unsigned long long)h);
+   return 0;
+}
+
+int db2_cross_repo_repo_set_hash(char *out, size_t cap)
+{
+   void *conn = cr_conn();
+   if (!conn || !out || cap < 17)
+      return -1;
+   char err[CR_ERRBUF] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(conn, "SELECT name, trust FROM projects ORDER BY name", err, sizeof(err));
+   if (!st)
+      return -1;
+   uint64_t h = fnv1a_init();
+   int step;
+   int rc = 0;
+   while ((step = aimee_pg_step(st, err, sizeof(err))) == AIMEE_PG_ROW)
+   {
+      const char *name = aimee_pg_column_text(st, 0);
+      const char *trust = aimee_pg_column_text(st, 1);
+      char sym[17] = "";
+      if (db2_cross_repo_repo_symbol_hash(name, sym, sizeof(sym)) != 0)
+      {
+         rc = -1;
+         break;
+      }
+      h = fnv1a_add(h, name);
+      h = fnv1a_add(h, trust);
+      h = fnv1a_add(h, sym);
+   }
+   aimee_pg_finalize(st);
+   if (rc != 0 || step < 0)
+      return -1;
+   snprintf(out, cap, "%016llx", (unsigned long long)h);
+
+   /* persist into cross_repo_meta */
+   aimee_pg_stmt_t *up = aimee_pg_prepare(
+       conn, "UPDATE cross_repo_meta SET repo_set_hash = ?1 WHERE id = 1", err, sizeof(err));
+   if (up)
+   {
+      aimee_pg_bind_text(up, "?1", out);
+      (void)aimee_pg_step(up, err, sizeof(err));
+      aimee_pg_finalize(up);
+   }
+   return 0;
+}

--- a/src/db2/cross_repo_stats.h
+++ b/src/db2/cross_repo_stats.h
@@ -1,0 +1,71 @@
+#ifndef AIMEE_CROSS_REPO_STATS_H
+#define AIMEE_CROSS_REPO_STATS_H
+
+#include "cross_repo_classify.h"
+#include "cross_repo_resolver.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* DB-backed stats / data-gathering for the cross-repo resolver (S3). These run
+ * over db2 (Postgres in production; the sqlite test shim where the SQL is kept
+ * portable -- plain SELECT/GROUP BY/ON CONFLICT, no JSONB/to_char) and feed the
+ * pure S2a/S2b core. S4 composes candidate generation + classification.
+ *
+ * Trust contract (§0): every frequency / candidate query carries the per-repo
+ * trust column; distinctiveness + blocked_symbols are computed over TRUSTED
+ * repos only, while candidate generation still surfaces untrusted edges (the
+ * pure pipeline applies the per-edge trust cap). Functions return -1 on a DB
+ * error / no connection (the caller degrades gracefully, never crashes).
+ *
+ * Cross-slice freshness (§4.1): a projects.trust flip changes which repos feed
+ * the frequency model, so blocked_symbols becomes stale. The trust-write
+ * transaction (S7) is responsible for bumping trust_epoch AND scheduling a
+ * recompute (or invalidating blocked_symbols_version); these stats functions do
+ * not observe trust changes on their own.
+ *
+ * Scale (§4.2): these are per-symbol scans over code_calls/terms. S4a does NOT
+ * call them per-candidate; it builds the cached dominant-definer/exports working
+ * set once per request (the two-step query) and reuses it.
+ *
+ * See docs/proposals/pending/cross-repo-dependency-graph.md §3.3/§3.7/§4.1. */
+
+/* §3.3 distinctiveness stats for symbol S as used by caller repo A, computed over
+ * TRUSTED repos only: callee_repo_count (# trusted repos where S is a callee),
+ * definer_repo_count (# trusted repos defining S), caller_file_pct (% of A's
+ * files where S is a callee). Fills *out. Returns 0 on success, -1 on error. */
+int db2_cross_repo_distinct_stats(const char *symbol, const char *caller_repo,
+                                  xrepo_distinct_stats_t *out);
+
+/* §3.3 recompute the blocked_symbols set over TRUSTED repos: a symbol is blocked
+ * when it is a callee in >= k repos OR defined in >= m repos (length >= len_min
+ * is required to be considered distinctive, so shorter names are implicitly
+ * blocked at query time, not stored). Replaces the table contents and bumps
+ * cross_repo_meta.blocked_symbols_version. Returns rows written, -1 on error. */
+int db2_cross_repo_recompute_blocked_symbols(int k, int m, int len_min);
+
+/* §3.3 membership test against the materialized blocked_symbols set for `lang`
+ * (and the lang='' all-languages rows). Returns 1 = blocked, 0 = not, -1 error. */
+int db2_cross_repo_symbol_blocked(const char *symbol, const char *lang);
+
+/* §4.1 per-repo symbol-table hash: FNV-1a over the repo's canonicalized
+ * (terms,file_exports,file_imports) rows. out buffer must be >= 17 bytes
+ * (16 hex + NUL). Returns 0 on success, -1 on error. */
+int db2_cross_repo_repo_symbol_hash(const char *project, char *out, size_t cap);
+
+/* §4.1 repo_set_hash: FNV-1a over the sorted (name,trust,symbol-table-hash) of
+ * all registered repos; also written into cross_repo_meta.repo_set_hash. out
+ * buffer must be >= 17 bytes. Returns 0 on success, -1 on error. */
+int db2_cross_repo_repo_set_hash(char *out, size_t cap);
+
+/* Read the current global version stamp components (§4.1) from cross_repo_meta:
+ * trust_epoch, blocked_symbols_version, and the stored repo_set_hash. Any out
+ * pointer may be NULL. Returns 0 on success, -1 on error. */
+int db2_cross_repo_meta_read(int64_t *trust_epoch, int64_t *blocked_symbols_version,
+                             char *repo_set_hash, size_t cap);
+
+/* NOTE: repo descriptors (manifest module_id parsing for the §3.7 resolver) and
+ * the §4.2 candidate-generation query are orchestration-coupled and validated
+ * live; they land with S4a (canonical_index_cross_repo_deps), not in this slice. */
+
+#endif /* AIMEE_CROSS_REPO_STATS_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -88,6 +88,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-memory-lanes \
                $(TESTPREFIX)/unit-test-workspace \
                $(TESTPREFIX)/unit-test-cross-repo-deps \
+               $(TESTPREFIX)/unit-test-cross-repo-stats \
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-webchat-claude-sessions \
                $(TESTPREFIX)/unit-test-turn-registry \
@@ -473,6 +474,16 @@ $(TESTPREFIX)/unit-test-schema-subst: $(OBJDIR)/tests/test_schema_subst.o \
 $(TESTPREFIX)/unit-test-code-index-ops: \
                                        $(OBJDIR)/tests/test_code_index_ops.o \
                                        $(OBJDIR)/db2/code_index_ops.o \
+                                       $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
+                                       $(OBJDIR)/db2/db_schema.o \
+                                       $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
+
+# Cross-repo dependency graph S3: DB stats layer over the sqlite shim (portable
+# SQL). Links the db2 init/pool/schema + the shim core like code-index-ops.
+$(TESTPREFIX)/unit-test-cross-repo-stats: \
+                                       $(OBJDIR)/tests/test_cross_repo_stats.o \
+                                       $(OBJDIR)/db2/cross_repo_stats.o \
                                        $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
                                        $(OBJDIR)/db2/db_schema.o \
                                        $(TEST_CORE_OBJS)

--- a/src/tests/test_cross_repo_stats.c
+++ b/src/tests/test_cross_repo_stats.c
@@ -1,0 +1,171 @@
+/* test_cross_repo_stats.c: S3 DB stats layer over the sqlite shim. Seeds a tiny
+ * multi-repo corpus and exercises distinctiveness stats, blocked_symbols
+ * recompute/membership, per-repo + repo-set hashes, and meta read. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "db2_test_shim.h"
+#include "../db2/cross_repo_stats.h"
+#include "../db2/db2.h"
+#include "../db2/db_postgres.h"
+
+static void X(const char *sql)
+{
+   char err[256] = "";
+   int rc = aimee_pg_exec(db2_conn(), sql, err, sizeof(err));
+   if (rc != 0)
+      fprintf(stderr, "seed failed: %s\n  sql: %s\n", err, sql);
+   assert(rc == 0);
+}
+
+/* Seed: trusted repos A (caller), B + C (both define LiStartConnection -> 2
+ * definers), plus a "render" callee/def spread across A,B,C,U and an untrusted
+ * repo U whose defs must NOT count toward trusted frequency. */
+static void seed(void)
+{
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('A','/a','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('B','/b','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('C','/c','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('U','/u','t','untrusted')");
+   /* files: A has 4 files (f1..f4); B,C,U one each. */
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'a1.c','t' FROM projects WHERE "
+     "name='A'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'a2.c','t' FROM projects WHERE "
+     "name='A'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'a3.c','t' FROM projects WHERE "
+     "name='A'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'a4.c','t' FROM projects WHERE "
+     "name='A'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'b.c','t' FROM projects WHERE "
+     "name='B'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'c.c','t' FROM projects WHERE "
+     "name='C'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'u.c','t' FROM projects WHERE "
+     "name='U'");
+   /* definitions: LiStartConnection defined in B and C (2 trusted definers). */
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'LiStartConnection','definition' FROM files "
+     "WHERE path='b.c'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'LiStartConnection','definition' FROM files "
+     "WHERE path='c.c'");
+   /* render defined in A,B,C (3 trusted) + U (untrusted, must not count). */
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'render','definition' FROM files WHERE "
+     "path='a1.c'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'render','definition' FROM files WHERE "
+     "path='b.c'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'render','definition' FROM files WHERE "
+     "path='c.c'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'render','definition' FROM files WHERE "
+     "path='u.c'");
+   /* a route row must be ignored as a definition. */
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'GET /x','route' FROM files WHERE "
+     "path='b.c'");
+   /* calls: A calls LiStartConnection in 1 of its 4 files; render called in A's a1,a2 + B,C. */
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'LiStartConnection' FROM files WHERE "
+     "path='a1.c'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'render' FROM files WHERE path='a1.c'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'render' FROM files WHERE path='a2.c'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'render' FROM files WHERE path='b.c'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'render' FROM files WHERE path='c.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'LiStartConnection' FROM files WHERE "
+     "path='b.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Limelight.h' FROM files WHERE "
+     "path='a1.c'");
+}
+
+static void test_distinct_stats(void)
+{
+   printf("test_distinct_stats... ");
+   xrepo_distinct_stats_t s;
+   /* LiStartConnection: defined in B,C (2 trusted); called in A only (1 repo);
+    * A uses it in 1 of 4 files -> 25%. */
+   assert(db2_cross_repo_distinct_stats("LiStartConnection", "A", &s) == 0);
+   assert(s.definer_repo_count == 2);
+   assert(s.callee_repo_count == 1);
+   assert(s.caller_file_pct == 25);
+
+   /* render: defined in A,B,C trusted (3, NOT U); called in A,B,C (3 repos);
+    * A uses it in a1,a2 -> 2 of 4 files = 50%. */
+   assert(db2_cross_repo_distinct_stats("render", "A", &s) == 0);
+   assert(s.definer_repo_count == 3); /* untrusted U excluded */
+   assert(s.callee_repo_count == 3);
+   assert(s.caller_file_pct == 50);
+   printf("ok\n");
+}
+
+static void test_blocked_symbols(void)
+{
+   printf("test_blocked_symbols... ");
+   /* k=3 (callee in >=3 repos), m=3 (defined in >=3 repos), len_min=4.
+    * render: callee in 3 + defined in 3 -> blocked. LiStartConnection: callee 1,
+    * defined 2 -> not blocked. */
+   int n = db2_cross_repo_recompute_blocked_symbols(3, 3, 4);
+   assert(n >= 1);
+   assert(db2_cross_repo_symbol_blocked("render", "") == 1);
+   assert(db2_cross_repo_symbol_blocked("LiStartConnection", "") == 0);
+   /* version bumped in meta. */
+   int64_t ver = 0;
+   assert(db2_cross_repo_meta_read(NULL, &ver, NULL, 0) == 0);
+   assert(ver >= 1);
+   /* recompute again -> version strictly increases (deterministic bump). */
+   int64_t ver2 = 0;
+   db2_cross_repo_recompute_blocked_symbols(3, 3, 4);
+   db2_cross_repo_meta_read(NULL, &ver2, NULL, 0);
+   assert(ver2 == ver + 1);
+   printf("ok\n");
+}
+
+static void test_hashes(void)
+{
+   printf("test_hashes... ");
+   char ha[17] = "", hb[17] = "", ha2[17] = "";
+   assert(db2_cross_repo_repo_symbol_hash("A", ha, sizeof(ha)) == 0);
+   assert(db2_cross_repo_repo_symbol_hash("B", hb, sizeof(hb)) == 0);
+   assert(strlen(ha) == 16 && strlen(hb) == 16);
+   assert(strcmp(ha, hb) != 0); /* different repos -> different hashes */
+   /* deterministic: same inputs -> same hash. */
+   assert(db2_cross_repo_repo_symbol_hash("A", ha2, sizeof(ha2)) == 0);
+   assert(strcmp(ha, ha2) == 0);
+
+   char rs[17] = "", rs2[17] = "";
+   assert(db2_cross_repo_repo_set_hash(rs, sizeof(rs)) == 0);
+   assert(strlen(rs) == 16);
+   /* persisted into meta. */
+   char stored[64] = "";
+   assert(db2_cross_repo_meta_read(NULL, NULL, stored, sizeof(stored)) == 0);
+   assert(strcmp(stored, rs) == 0);
+   /* a symbol change in A bumps A's hash and the repo-set hash. */
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'NewlyAddedSym','definition' FROM files "
+     "WHERE path='a3.c'");
+   char ha3[17] = "";
+   assert(db2_cross_repo_repo_symbol_hash("A", ha3, sizeof(ha3)) == 0);
+   assert(strcmp(ha, ha3) != 0);
+   assert(db2_cross_repo_repo_set_hash(rs2, sizeof(rs2)) == 0);
+   assert(strcmp(rs, rs2) != 0);
+   printf("ok\n");
+}
+
+static void test_no_conn_graceful(void)
+{
+   printf("test_no_conn_graceful... ");
+   /* NULL inputs degrade, never crash. */
+   xrepo_distinct_stats_t s;
+   assert(db2_cross_repo_distinct_stats(NULL, "A", &s) == -1);
+   assert(db2_cross_repo_recompute_blocked_symbols(0, 3, 4) == -1); /* bad threshold */
+   char buf[17];
+   assert(db2_cross_repo_repo_symbol_hash("A", buf, 4) == -1); /* cap too small */
+   printf("ok\n");
+}
+
+int main(void)
+{
+   db2_test_shim_open();
+   seed();
+   test_distinct_stats();
+   test_blocked_symbols();
+   test_hashes();
+   test_no_conn_graceful();
+   printf("cross_repo_stats: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary
Fourth slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md`), on top of S2b (#803). New `db2/cross_repo_stats.{c,h}` — the DB-backed data-gathering that feeds the pure S2a/S2b core. **Portable SQL** (plain SELECT/GROUP BY/UNION + FNV-1a in C + BEGIN/COMMIT) so it runs on both Postgres and the sqlite test shim, and is genuinely unit-tested rather than only live.

- `db2_cross_repo_distinct_stats` (§3.3) — callee-repo-count, definer-repo-count (`kind='definition'`), caller-file-% for symbol S in caller A, frequency counts over **trusted repos only**.
- `db2_cross_repo_recompute_blocked_symbols` (§3.3) — rebuilds `blocked_symbols` (callee in ≥k OR defined in ≥m trusted repos, `length ≥ len_min`) in one transaction; bumps `blocked_symbols_version` **inside the txn** (UPDATE+SELECT, row-locked — no read-then-write race).
- `db2_cross_repo_symbol_blocked`, per-repo + repo-set FNV hashes (`§4.1`, repo-set persisted to `cross_repo_meta`), and `db2_cross_repo_meta_read` (version-stamp components).

## Tests / gates
`test_cross_repo_stats.c` seeds a trusted/untrusted multi-repo corpus on the shim and asserts: untrusted-excluded frequency, caller-file-%, blocked vs not, version-bump monotonicity, hash determinism + change-on-edit, graceful `-1` errors. All pass; clang-format-19 clean. (The shim caught a real `UNION`/`ON CONFLICT` portability bug, now fixed.)

## Review
Code-review roundtable; 3 blocking resolved: (1) definer predicate switched to positive `kind='definition'` (robust to new kinds; the suggested `terms.kind` CHECK was deliberately **not** added — that table is pre-existing/populated and a CHECK risks breaking schema-apply); (2) version bump moved inside the transaction (race fix); (3) the trust-flip → invalidation cross-slice contract is documented as S7's trust-write responsibility. Also documented the per-request batch contract (no per-candidate N+1 in S4a).

repo descriptors (manifest `module_id` parsing) + the candidate-generation query land with S4a.