### PR TITLE
feat(harness-memory): spill durability + audit log + session-start replay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -502,6 +502,8 @@ set(CORE_SRCS
     ${AIMEE_SRC_DIR}/memory_provider.c
     ${AIMEE_SRC_DIR}/harness_memory_common.c
     ${AIMEE_SRC_DIR}/harness_memory_scope.c
+    ${AIMEE_SRC_DIR}/harness_memory_audit.c
+    ${AIMEE_SRC_DIR}/harness_memory_spill.c
     ${AIMEE_SRC_DIR}/plugin_c_hook.c
     ${AIMEE_SRC_DIR}/config_plugin.c
     ${AIMEE_SRC_DIR}/code_collect.c

--- a/src/Makefile
+++ b/src/Makefile
@@ -295,7 +295,7 @@ CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \
             workflow/wfe_iface.c workflow/wfe_def.c workflow/wfe_validate.c workflow/wfe_canonical.c workflow/wfe_custom.c \
-            harness_memory_common.c harness_memory_scope.c
+            harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c
 CORE_OBJS = $(CORE_SRCS:%.c=$(OBJDIR)/%.o) $(OBJDIR)/cJSON.o
 
 # --- Layer 0b: DB1 (user-local tier) ---
@@ -351,7 +351,7 @@ CMD_SRCS = prompts.c persona.c hardware_probe.c curator_profile.c server/delegat
 CMD_OBJS = $(CMD_SRCS:%.c=$(OBJDIR)/%.o)
 
 # --- Pure client (aimee) ---
-CLI_SRCS = cli_main.c cli_agent_setup.c cli_session_start.c harness_memory_hydrate.c harness_memory_common.c harness_memory_scope.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
+CLI_SRCS = cli_main.c cli_agent_setup.c cli_session_start.c harness_memory_hydrate.c harness_memory_common.c harness_memory_scope.c harness_memory_audit.c harness_memory_spill.c cli_attention_guard.c cli_code_audit.c cli_css.c cli_tui.c cli_client.c cli_launch.c cli_mcp_serve.c cli_profile.c client_integrations.c server/delegate_plan.c cmd_profile.c cmd_manuscript.c cmd_optimize.c cli_persona.c cli_roles.c manuscript.c http_uds_client.c aimee_client.c cli_remote.c acp_server.c cli_workspace_serve.c cli_agent_keys.c cmd_workflow.c
 ifeq ($(WITH_TLS),1)
 CLI_SRCS += aimee_tls.c
 TLS_OBJS = $(OBJDIR)/aimee_tls.o

--- a/src/harness_memory_audit.c
+++ b/src/harness_memory_audit.c
@@ -11,6 +11,11 @@
 #include <sys/stat.h>
 #include <time.h>
 
+#ifndef _WIN32
+#include <fcntl.h>
+#include <unistd.h>
+#endif
+
 #ifndef PATH_MAX
 #define PATH_MAX 4096
 #endif
@@ -62,13 +67,34 @@ void hmem_audit(const char *action, const char *project, const char *name, const
    if (!line)
       return;
 
-   FILE *f = fopen(logpath, "a");
-   if (f)
+   /* Create 0600 atomically — no world-readable window on this sensitive log. */
+#ifndef _WIN32
+   int flags = O_CREAT | O_WRONLY | O_APPEND | O_CLOEXEC;
+#ifdef O_NOFOLLOW
+   flags |= O_NOFOLLOW;
+#endif
+   int fd = open(logpath, flags, 0600);
+   if (fd < 0)
    {
-      /* tighten perms best-effort (fopen "a" may have created it) */
-      chmod(logpath, 0600);
-      fprintf(f, "%s\n", line);
-      fclose(f);
+      free(line);
+      return;
    }
+   FILE *f = fdopen(fd, "a");
+   if (!f)
+   {
+      close(fd);
+      free(line);
+      return;
+   }
+#else
+   FILE *f = fopen(logpath, "a");
+   if (!f)
+   {
+      free(line);
+      return;
+   }
+#endif
+   fprintf(f, "%s\n", line);
+   fclose(f);
    free(line);
 }

--- a/src/harness_memory_audit.c
+++ b/src/harness_memory_audit.c
@@ -1,0 +1,74 @@
+/* harness_memory_audit.c — see harness_memory_audit.h. */
+
+#include "harness_memory_audit.h"
+
+#include "aimee_home.h" /* aimee_home() — honors AIMEE_HOME/AIMEE_PROFILE */
+#include "cJSON.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+static int audit_home(char *out, size_t cap)
+{
+   const char *h = aimee_home();
+   if (!h || !h[0])
+      return -1;
+   return ((size_t)snprintf(out, cap, "%s", h) < cap) ? 0 : -1;
+}
+
+void hmem_audit(const char *action, const char *project, const char *name, const char *detail)
+{
+   if (!action)
+      return;
+   char home[PATH_MAX];
+   if (audit_home(home, sizeof(home)) != 0)
+      return;
+
+   char logdir[PATH_MAX], logpath[PATH_MAX];
+   if ((size_t)snprintf(logdir, sizeof(logdir), "%s/logs", home) >= sizeof(logdir))
+      return;
+   mkdir(home, 0700);
+   mkdir(logdir, 0700);
+   if ((size_t)snprintf(logpath, sizeof(logpath), "%s/interception.jsonl", logdir) >=
+       sizeof(logpath))
+      return;
+
+   char ts[32];
+   time_t t = time(NULL);
+   struct tm tm_buf;
+   gmtime_r(&t, &tm_buf);
+   strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
+
+   cJSON *o = cJSON_CreateObject();
+   if (!o)
+      return;
+   cJSON_AddStringToObject(o, "ts", ts);
+   cJSON_AddStringToObject(o, "action", action);
+   if (project)
+      cJSON_AddStringToObject(o, "project", project);
+   if (name)
+      cJSON_AddStringToObject(o, "name", name);
+   if (detail)
+      cJSON_AddStringToObject(o, "detail", detail);
+   char *line = cJSON_PrintUnformatted(o);
+   cJSON_Delete(o);
+   if (!line)
+      return;
+
+   FILE *f = fopen(logpath, "a");
+   if (f)
+   {
+      /* tighten perms best-effort (fopen "a" may have created it) */
+      chmod(logpath, 0600);
+      fprintf(f, "%s\n", line);
+      fclose(f);
+   }
+   free(line);
+}

--- a/src/harness_memory_audit.h
+++ b/src/harness_memory_audit.h
@@ -1,0 +1,25 @@
+/* harness_memory_audit.h: append-only audit trail for the agent-memory
+ * interception layer (a layer that DENYs/redirects tool calls). One JSON line
+ * per decision to <AIMEE_HOME>/logs/interception.jsonl. Self-contained so both
+ * the server-side interceptor and the thin-client reconcile can log.
+ */
+#ifndef DEC_HARNESS_MEMORY_AUDIT_H
+#define DEC_HARNESS_MEMORY_AUDIT_H 1
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Append one audit record. Best-effort (never fails the caller). `action` is
+    * a short verb (e.g. "redirect","reject","spill","spill-failed","import",
+    * "hydrate","tombstone","divergence","reconcile"). project/name/detail may be
+    * NULL/"". The log file is mode 0600 under <AIMEE_HOME>/logs/ (AIMEE_HOME env,
+    * else <HOME>/.config/aimee). */
+   void hmem_audit(const char *action, const char *project, const char *name, const char *detail);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_HARNESS_MEMORY_AUDIT_H */

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -4,9 +4,12 @@
 
 #include "cJSON.h"
 #include "cli_client.h" /* cli_http_request, cli_v1_client_endpoint/bearer */
+#include "harness_memory_audit.h"
 #include "harness_memory_common.h"
 #include "harness_memory_scope.h"
+#include "harness_memory_spill.h"
 
+#include <dirent.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -126,6 +129,88 @@ static int write_file(const char *path, const char *content)
 #endif
 }
 
+static char *read_whole(const char *path)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   fseek(f, 0, SEEK_END);
+   long sz = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   if (sz < 0 || sz > 16 * 1024 * 1024)
+   {
+      fclose(f);
+      return NULL;
+   }
+   char *buf = malloc((size_t)sz + 1);
+   if (!buf)
+   {
+      fclose(f);
+      return NULL;
+   }
+   size_t r = fread(buf, 1, (size_t)sz, f);
+   fclose(f);
+   buf[r] = '\0';
+   return buf;
+}
+
+/* Replay any spilled writes (from a server-down fail-open) into the store, then
+ * delete each consumed spill. Returns count consumed. */
+static int consume_spills(const char *project, const char *endpoint, const char *bearer)
+{
+   char dir[PATH_MAX];
+   if (hmem_spill_dir(project, dir, sizeof(dir)) != 0)
+      return 0;
+   DIR *d = opendir(dir);
+   if (!d)
+      return 0;
+   int n = 0;
+   struct dirent *e;
+   while ((e = readdir(d)))
+   {
+      if (e->d_name[0] == '.') /* skips ., .., and .spill_ in-progress temps */
+         continue;
+      char fp[PATH_MAX];
+      if ((size_t)snprintf(fp, sizeof(fp), "%s/%s", dir, e->d_name) >= sizeof(fp))
+         continue;
+      char *txt = read_whole(fp);
+      if (!txt)
+         continue;
+      cJSON *env = cJSON_Parse(txt);
+      free(txt);
+      if (!env) /* corrupt/partial spill — leave it for inspection, don't replay */
+         continue;
+      const char *p = jstr(env, "project"), *nm = jstr(env, "name"), *ty = jstr(env, "type"),
+                 *bd = jstr(env, "body");
+      if (p && nm)
+      {
+         cJSON *body = cJSON_CreateObject();
+         cJSON_AddStringToObject(body, "project", p);
+         cJSON_AddStringToObject(body, "name", nm);
+         cJSON_AddStringToObject(body, "type", (ty && ty[0]) ? ty : "fact");
+         cJSON_AddStringToObject(body, "body", bd ? bd : "");
+         char *bs = cJSON_PrintUnformatted(body);
+         cJSON_Delete(body);
+         int st = 0;
+         cJSON *r = bs ? cli_http_request(endpoint, "POST", "/v1/harness_memory/upsert", bs, bearer,
+                                          5000, &st)
+                       : NULL;
+         free(bs);
+         if (r && st >= 200 && st < 300)
+         {
+            unlink(fp);
+            hmem_audit("spill-consumed", p, nm, NULL);
+            n++;
+         }
+         if (r)
+            cJSON_Delete(r);
+      }
+      cJSON_Delete(env);
+   }
+   closedir(d);
+   return n;
+}
+
 int harness_memory_hydrate(const char *cwd)
 {
    const char *home = getenv("HOME");
@@ -153,6 +238,11 @@ int harness_memory_hydrate(const char *cwd)
    if (!endpoint)
       return -1;
    char *bearer = cli_v1_client_bearer();
+
+   /* Replay any spilled (server-down) writes into the store first, so the list
+    * below reflects them. */
+   int consumed = consume_spills(project, endpoint, bearer);
+
    cJSON *body = cJSON_CreateObject();
    cJSON_AddStringToObject(body, "project", project);
    char *body_s = cJSON_PrintUnformatted(body);
@@ -169,7 +259,7 @@ int harness_memory_hydrate(const char *cwd)
    {
       if (resp)
          cJSON_Delete(resp);
-      return -1;
+      return (consumed > 0) ? consumed : -1;
    }
 
    /* Ensure the memory dir exists and resolve it, so we can confine every write
@@ -199,5 +289,12 @@ int harness_memory_hydrate(const char *cwd)
          n++;
    }
    cJSON_Delete(resp);
+
+   if (n > 0 || consumed > 0)
+   {
+      char detail[96];
+      snprintf(detail, sizeof(detail), "hydrated=%d spills_consumed=%d", n, consumed);
+      hmem_audit("reconcile", project, NULL, detail);
+   }
    return n;
 }

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -179,7 +179,10 @@ static int consume_spills(const char *project, const char *endpoint, const char 
       cJSON *env = cJSON_Parse(txt);
       free(txt);
       if (!env) /* corrupt/partial spill — leave it for inspection, don't replay */
+      {
+         hmem_audit("spill-corrupt", project, e->d_name, NULL);
          continue;
+      }
       const char *p = jstr(env, "project"), *nm = jstr(env, "name"), *ty = jstr(env, "type"),
                  *bd = jstr(env, "body");
       if (p && nm)

--- a/src/harness_memory_spill.c
+++ b/src/harness_memory_spill.c
@@ -11,7 +11,11 @@
 #include <string.h>
 #include <sys/stat.h>
 #include <time.h>
+
+#ifndef _WIN32
+#include <fcntl.h>
 #include <unistd.h>
+#endif
 
 #ifndef PATH_MAX
 #define PATH_MAX 4096
@@ -53,7 +57,6 @@ int hmem_spill_write(const char *project, const char *name, const char *type, co
    if (hmem_spill_dir(project, dir, sizeof(dir)) != 0)
       return -1;
 
-   static unsigned long counter = 0;
    char ts[32];
    time_t t = time(NULL);
    struct tm tm_buf;
@@ -74,11 +77,11 @@ int hmem_spill_write(const char *project, const char *name, const char *type, co
    cJSON_Delete(o);
    if (!s)
       return -1;
+   size_t len = strlen(s);
 
-   char tmpl[PATH_MAX], target[PATH_MAX];
-   if ((size_t)snprintf(tmpl, sizeof(tmpl), "%s/.spill_XXXXXX", dir) >= sizeof(tmpl) ||
-       (size_t)snprintf(target, sizeof(target), "%s/%d-%lu.json", dir, (int)getpid(), counter++) >=
-           sizeof(target))
+#ifndef _WIN32
+   char tmpl[PATH_MAX];
+   if ((size_t)snprintf(tmpl, sizeof(tmpl), "%s/.spill_XXXXXX", dir) >= sizeof(tmpl))
    {
       free(s);
       return -1;
@@ -89,7 +92,18 @@ int hmem_spill_write(const char *project, const char *name, const char *type, co
       free(s);
       return -1;
    }
-   size_t len = strlen(s);
+   /* Commit under a collision-resistant name reusing mkstemp's unique suffix —
+    * a deterministic pid/counter name could overwrite an unconsumed spill. */
+   const char *rnd = strrchr(tmpl, '_');
+   rnd = rnd ? rnd + 1 : tmpl;
+   char target[PATH_MAX];
+   if ((size_t)snprintf(target, sizeof(target), "%s/spill-%s.json", dir, rnd) >= sizeof(target))
+   {
+      close(fd);
+      unlink(tmpl);
+      free(s);
+      return -1;
+   }
    ssize_t w = write(fd, s, len);
    fsync(fd);
    close(fd);
@@ -99,5 +113,32 @@ int hmem_spill_write(const char *project, const char *name, const char *type, co
       unlink(tmpl);
       return -1;
    }
+   /* fsync the directory so the rename survives power loss (otherwise it can
+    * revert to the dotfile temp name, which the consumer skips → silent loss). */
+   int dfd = open(dir, O_RDONLY | O_DIRECTORY);
+   if (dfd >= 0)
+   {
+      fsync(dfd);
+      close(dfd);
+   }
    return 0;
+#else
+   char target[PATH_MAX];
+   if ((size_t)snprintf(target, sizeof(target), "%s/spill-%lu-%lu.json", dir, (unsigned long)t,
+                        (unsigned long)len) >= sizeof(target))
+   {
+      free(s);
+      return -1;
+   }
+   FILE *f = fopen(target, "wb");
+   if (!f)
+   {
+      free(s);
+      return -1;
+   }
+   size_t wr = fwrite(s, 1, len, f);
+   fclose(f);
+   free(s);
+   return (wr == len) ? 0 : -1;
+#endif
 }

--- a/src/harness_memory_spill.c
+++ b/src/harness_memory_spill.c
@@ -1,0 +1,103 @@
+/* harness_memory_spill.c — see harness_memory_spill.h. */
+
+#include "harness_memory_spill.h"
+
+#include "aimee_home.h" /* aimee_home() — honors AIMEE_HOME/AIMEE_PROFILE */
+#include "cJSON.h"
+#include "harness_memory_common.h" /* hmem_sha256_hex */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+static int spill_home(char *out, size_t cap)
+{
+   const char *h = aimee_home();
+   if (!h || !h[0])
+      return -1;
+   return ((size_t)snprintf(out, cap, "%s", h) < cap) ? 0 : -1;
+}
+
+int hmem_spill_dir(const char *project, char *out, size_t cap)
+{
+   if (!project || !project[0])
+      return -1;
+   char home[PATH_MAX];
+   if (spill_home(home, sizeof(home)) != 0)
+      return -1;
+   char ph[HMEM_HASH_HEX_LEN];
+   hmem_sha256_hex(project, strlen(project), ph);
+   char base[PATH_MAX];
+   if ((size_t)snprintf(base, sizeof(base), "%s/harness_spill", home) >= sizeof(base))
+      return -1;
+   mkdir(home, 0700);
+   mkdir(base, 0700);
+   if ((size_t)snprintf(out, cap, "%s/%s", base, ph) >= cap)
+      return -1;
+   mkdir(out, 0700);
+   return 0;
+}
+
+int hmem_spill_write(const char *project, const char *name, const char *type, const char *body)
+{
+   if (!project || !name)
+      return -1;
+   char dir[PATH_MAX];
+   if (hmem_spill_dir(project, dir, sizeof(dir)) != 0)
+      return -1;
+
+   static unsigned long counter = 0;
+   char ts[32];
+   time_t t = time(NULL);
+   struct tm tm_buf;
+   gmtime_r(&t, &tm_buf);
+   strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
+
+   cJSON *o = cJSON_CreateObject();
+   if (!o)
+      return -1;
+   cJSON_AddStringToObject(o, "op", "upsert");
+   cJSON_AddNumberToObject(o, "schema_version", 1);
+   cJSON_AddStringToObject(o, "project", project);
+   cJSON_AddStringToObject(o, "name", name);
+   cJSON_AddStringToObject(o, "type", (type && type[0]) ? type : "fact");
+   cJSON_AddStringToObject(o, "body", body ? body : "");
+   cJSON_AddStringToObject(o, "ts", ts);
+   char *s = cJSON_PrintUnformatted(o);
+   cJSON_Delete(o);
+   if (!s)
+      return -1;
+
+   char tmpl[PATH_MAX], target[PATH_MAX];
+   if ((size_t)snprintf(tmpl, sizeof(tmpl), "%s/.spill_XXXXXX", dir) >= sizeof(tmpl) ||
+       (size_t)snprintf(target, sizeof(target), "%s/%d-%lu.json", dir, (int)getpid(), counter++) >=
+           sizeof(target))
+   {
+      free(s);
+      return -1;
+   }
+   int fd = mkstemp(tmpl);
+   if (fd < 0)
+   {
+      free(s);
+      return -1;
+   }
+   size_t len = strlen(s);
+   ssize_t w = write(fd, s, len);
+   fsync(fd);
+   close(fd);
+   free(s);
+   if (w < 0 || (size_t)w != len || rename(tmpl, target) != 0)
+   {
+      unlink(tmpl);
+      return -1;
+   }
+   return 0;
+}

--- a/src/harness_memory_spill.h
+++ b/src/harness_memory_spill.h
@@ -1,0 +1,29 @@
+/* harness_memory_spill.h: durability backstop for the interception store. When
+ * a memory write can't reach the server (fail-open), the intended content is
+ * spilled to <AIMEE_HOME>/harness_spill/<project_hash>/ and replayed into the
+ * central store at the next session-start reconcile, so a server outage never
+ * loses a memory. See docs/proposals/pending/central-agent-memory-interception.md.
+ */
+#ifndef DEC_HARNESS_MEMORY_SPILL_H
+#define DEC_HARNESS_MEMORY_SPILL_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Resolve (and mkdir -p) the spill directory for a project:
+    * <AIMEE_HOME>/harness_spill/<sha(project)>. Returns 0 / -1. */
+   int hmem_spill_dir(const char *project, char *out, size_t cap);
+
+   /* Spill an upsert (atomic temp+fsync+rename JSON envelope). Returns 0 / -1.
+    * The envelope carries {op:"upsert",schema_version,project,name,type,body,ts}. */
+   int hmem_spill_write(const char *project, const char *name, const char *type, const char *body);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_HARNESS_MEMORY_SPILL_H */

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -10,8 +10,10 @@
 #include "memory_redirect.h"
 
 #include "cli_client.h" /* cli_http_request, cli_v1_client_endpoint/bearer */
+#include "harness_memory_audit.h"
 #include "harness_memory_common.h"
 #include "harness_memory_scope.h"
+#include "harness_memory_spill.h"
 
 #include <ctype.h>
 #include <stdio.h>
@@ -188,6 +190,7 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
    if (v == MR_REJECT)
    {
       snprintf(msg, msg_len, "%s", reason ? reason : "memory write rejected");
+      hmem_audit("reject", NULL, NULL, reason);
       return 2;
    }
 
@@ -225,14 +228,15 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
 
    if (!resp || status < 200 || status >= 300)
    {
-      /* Fail-open: let the agent write its own file this once; session-start
-       * reconcile imports it. Never block the agent on our outage. */
+      /* Fail-open: spill the intended content so the next session-start reconcile
+       * replays it into the store, and let the agent write its own file this once.
+       * Never block the agent on our outage. */
       if (resp)
          cJSON_Delete(resp);
-      fprintf(stderr,
-              "aimee: harness-memory store unavailable (status %d); allowing local "
-              "write — will reconcile at next session start\n",
-              status);
+      int sp = hmem_spill_write(project, name, "fact", content);
+      hmem_audit(sp == 0 ? "spill" : "spill-failed", project, name, "store unreachable");
+      fprintf(stderr, "aimee: harness-memory store unavailable (status %d); %s\n", status,
+              sp == 0 ? "spilled for reconcile" : "spill FAILED — allowing local write");
       return 0;
    }
 
@@ -242,6 +246,7 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
 
    const hmem_scope_t *scope = hmem_scope_for_client(client); /* non-NULL: classify redirected */
    rematerialize(path, content, home, scope ? scope->projects_root : ".claude/projects");
+   hmem_audit("redirect", project, name, NULL);
    snprintf(msg, msg_len,
             "Saved to aimee memory (id=%ld). The file now reflects your content — do not "
             "re-write it.",

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -57,6 +57,8 @@ aimee_add_test(test_harness_memory test_harness_memory.c)
 aimee_add_test(test_memory_redirect test_memory_redirect.c)
 aimee_add_test(test_harness_memory_hydrate test_harness_memory_hydrate.c)
 aimee_add_test(test_harness_memory_scope test_harness_memory_scope.c)
+aimee_add_test(test_harness_memory_spill test_harness_memory_spill.c)
+aimee_add_test(test_harness_memory_audit test_harness_memory_audit.c)
 aimee_add_test(test_plugin_c_hook test_plugin_c_hook.c)
 add_executable(test_context_engine test_context_engine.c)
 target_include_directories(test_context_engine PRIVATE

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -77,7 +77,7 @@ TEST_DATA_OBJS = $(TEST_CORE_OBJS) $(OBJDIR)/rel_types.o $(OBJDIR)/memory_fact_g
 # linking both would produce duplicate-symbol errors.
 TEST_DATA_OBJS_MOCK = $(TEST_DATA_OBJS) $(OBJDIR)/tests/support/mock_agent_http.o
 
-TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
+TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPREFIX)/unit-test-harness-memory $(TESTPREFIX)/unit-test-memory-redirect $(TESTPREFIX)/unit-test-harness-memory-scope $(TESTPREFIX)/unit-test-harness-memory-spill $(TESTPREFIX)/unit-test-harness-memory-audit $(TESTPREFIX)/unit-test-harness-memory-hydrate $(TESTPREFIX)/unit-test-db2 $(TESTPREFIX)/unit-test-schema-subst $(TESTPREFIX)/unit-test-code-index-ops $(TESTPREFIX)/unit-test-curator-version $(TESTPREFIX)/unit-test-curator-invalidate $(TESTPREFIX)/unit-test-curator-notify $(TESTPREFIX)/unit-test-pgvec $(TESTPREFIX)/unit-test-rules \
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
@@ -436,6 +436,12 @@ $(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/db1/db.o $(OBJDI
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-harness-memory-hydrate: $(OBJDIR)/tests/test_harness_memory_hydrate.o $(OBJDIR)/harness_memory_hydrate.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-harness-memory-spill: $(OBJDIR)/tests/test_harness_memory_spill.o $(OBJDIR)/harness_memory_spill.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-harness-memory-audit: $(OBJDIR)/tests/test_harness_memory_audit.o $(OBJDIR)/harness_memory_audit.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-harness-memory-scope: $(OBJDIR)/tests/test_harness_memory_scope.o $(OBJDIR)/harness_memory_scope.o

--- a/src/tests/test_harness_memory_audit.c
+++ b/src/tests/test_harness_memory_audit.c
@@ -1,0 +1,41 @@
+/* Unit test for the interception audit log (PR-B). */
+
+#include "harness_memory_audit.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+   char tmpl[] = "/tmp/hmem_audit_test_XXXXXX";
+   char *home = mkdtemp(tmpl);
+   assert(home);
+   setenv("AIMEE_HOME", home, 1);
+
+   hmem_audit("redirect", "proj/x", "topics/auth", "saved");
+   hmem_audit("reject", NULL, NULL, "MEMORY.md");
+
+   char path[4096];
+   snprintf(path, sizeof(path), "%s/logs/interception.jsonl", home);
+   FILE *f = fopen(path, "rb");
+   assert(f);
+   char buf[8192];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+
+   assert(strstr(buf, "\"action\":\"redirect\""));
+   assert(strstr(buf, "\"name\":\"topics/auth\""));
+   assert(strstr(buf, "\"action\":\"reject\""));
+   /* two records => two newlines */
+   int lines = 0;
+   for (const char *p = buf; *p; p++)
+      if (*p == '\n')
+         lines++;
+   assert(lines == 2);
+
+   printf("test_harness_memory_audit: OK\n");
+   return 0;
+}

--- a/src/tests/test_harness_memory_spill.c
+++ b/src/tests/test_harness_memory_spill.c
@@ -1,0 +1,61 @@
+/* Unit test for the spill producer (PR-B): write an envelope and read it back. */
+
+#include "cJSON.h"
+#include "harness_memory_spill.h"
+
+#include <assert.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+int main(void)
+{
+   char tmpl[] = "/tmp/hmem_spill_test_XXXXXX";
+   char *home = mkdtemp(tmpl);
+   assert(home);
+   setenv("AIMEE_HOME", home, 1);
+
+   char dir[4096];
+   assert(hmem_spill_dir("proj/x", dir, sizeof(dir)) == 0);
+
+   assert(hmem_spill_write("proj/x", "topics/auth", "fact", "hello body") == 0);
+
+   /* find the .json spill (skip the .spill_ temp + . / ..) */
+   DIR *d = opendir(dir);
+   assert(d);
+   char found[4096] = "";
+   struct dirent *e;
+   while ((e = readdir(d)))
+   {
+      if (e->d_name[0] == '.')
+         continue;
+      size_t l = strlen(e->d_name);
+      if (l > 5 && strcmp(e->d_name + l - 5, ".json") == 0)
+      {
+         snprintf(found, sizeof(found), "%s/%s", dir, e->d_name);
+         break;
+      }
+   }
+   closedir(d);
+   assert(found[0]);
+
+   FILE *f = fopen(found, "rb");
+   assert(f);
+   char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+
+   cJSON *o = cJSON_Parse(buf);
+   assert(o);
+   assert(strcmp(cJSON_GetObjectItem(o, "op")->valuestring, "upsert") == 0);
+   assert(strcmp(cJSON_GetObjectItem(o, "project")->valuestring, "proj/x") == 0);
+   assert(strcmp(cJSON_GetObjectItem(o, "name")->valuestring, "topics/auth") == 0);
+   assert(strcmp(cJSON_GetObjectItem(o, "type")->valuestring, "fact") == 0);
+   assert(strcmp(cJSON_GetObjectItem(o, "body")->valuestring, "hello body") == 0);
+   cJSON_Delete(o);
+
+   printf("test_harness_memory_spill: OK\n");
+   return 0;
+}


### PR DESCRIPTION
Deferred items #4 (spill) + the durable part of #3 (reconcile/audit). A server-down fail-open now spills the intended write (atomic JSON envelope) and session-start replays + deletes it, so an outage never loses a memory. Adds the interception audit log (interception.jsonl). AIMEE_HOME via aimee_home(). Unit-tested. Disk-only import + tombstone removal (the external-edit reconcile) remain a documented follow-up — hydrate already does DB→disk divergence. Roundtable-reviewed.