### PR TITLE
fix(build): link harness-memory defs into the standalone CLI (CMake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,6 +765,12 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_agent_setup.c
     ${AIMEE_SRC_DIR}/cli_session_start.c
     ${AIMEE_SRC_DIR}/harness_memory_hydrate.c
+    # hydrate calls hmem_resolve_project / hmem_scope_for_client; the standalone
+    # `aimee` CLI does not link aimee-core, so their definers must build into the
+    # CLI directly (the make build links them via L_CLIENT). Without these the
+    # macOS/Windows CMake link fails with undefined hmem_* symbols.
+    ${AIMEE_SRC_DIR}/harness_memory_common.c
+    ${AIMEE_SRC_DIR}/harness_memory_scope.c
     ${AIMEE_SRC_DIR}/cli_attention_guard.c
     ${AIMEE_SRC_DIR}/cli_code_audit.c
     ${AIMEE_SRC_DIR}/cli_css.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -765,12 +765,14 @@ set(CLI_SRCS
     ${AIMEE_SRC_DIR}/cli_agent_setup.c
     ${AIMEE_SRC_DIR}/cli_session_start.c
     ${AIMEE_SRC_DIR}/harness_memory_hydrate.c
-    # hydrate calls hmem_resolve_project / hmem_scope_for_client; the standalone
-    # `aimee` CLI does not link aimee-core, so their definers must build into the
-    # CLI directly (the make build links them via L_CLIENT). Without these the
-    # macOS/Windows CMake link fails with undefined hmem_* symbols.
+    # hydrate calls hmem_resolve_project/_scope_for_client/_spill_dir/_audit; the
+    # standalone `aimee` CLI does not link aimee-core, so their definers must build
+    # into the CLI directly (the make build links them via L_CLIENT). Without these
+    # the macOS/Windows CMake link fails with undefined hmem_* symbols.
     ${AIMEE_SRC_DIR}/harness_memory_common.c
     ${AIMEE_SRC_DIR}/harness_memory_scope.c
+    ${AIMEE_SRC_DIR}/harness_memory_audit.c
+    ${AIMEE_SRC_DIR}/harness_memory_spill.c
     ${AIMEE_SRC_DIR}/cli_attention_guard.c
     ${AIMEE_SRC_DIR}/cli_code_audit.c
     ${AIMEE_SRC_DIR}/cli_css.c

--- a/src/harness_memory_audit.c
+++ b/src/harness_memory_audit.c
@@ -4,6 +4,7 @@
 
 #include "aimee_home.h" /* aimee_home() — honors AIMEE_HOME/AIMEE_PROFILE */
 #include "cJSON.h"
+#include "platform_path.h" /* platform_mkdir_p (portable mkdir -p) */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -39,16 +40,18 @@ void hmem_audit(const char *action, const char *project, const char *name, const
    char logdir[PATH_MAX], logpath[PATH_MAX];
    if ((size_t)snprintf(logdir, sizeof(logdir), "%s/logs", home) >= sizeof(logdir))
       return;
-   mkdir(home, 0700);
-   mkdir(logdir, 0700);
+   platform_mkdir_p(home, 0700);
+   platform_mkdir_p(logdir, 0700);
    if ((size_t)snprintf(logpath, sizeof(logpath), "%s/interception.jsonl", logdir) >=
        sizeof(logpath))
       return;
 
    char ts[32];
    time_t t = time(NULL);
-   struct tm tm_buf;
-   gmtime_r(&t, &tm_buf);
+   struct tm tm_buf = {0};
+   struct tm *gmt = gmtime(&t); /* gmtime_r is POSIX-only; CLI is single-threaded */
+   if (gmt)
+      tm_buf = *gmt;
    strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
 
    cJSON *o = cJSON_CreateObject();

--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -8,6 +8,7 @@
 #include "harness_memory_common.h"
 #include "harness_memory_scope.h"
 #include "harness_memory_spill.h"
+#include "platform_path.h" /* platform_mkdir_p (portable mkdir -p) */
 
 #include <dirent.h>
 #include <stdio.h>
@@ -19,6 +20,16 @@
 #ifndef _WIN32
 #include <fcntl.h>
 #include <unistd.h>
+#endif
+
+/* Portable canonicalization: POSIX realpath resolves symlinks; on Windows
+ * _fullpath returns an absolute path (no AF_UNIX-style symlink resolution, which
+ * matches Windows' privileged-only symlink model). Both return non-NULL on
+ * success and write the absolute path to `out`. */
+#ifdef _WIN32
+#define hm_realpath(p, out) _fullpath((out), (p), PATH_MAX)
+#else
+#define hm_realpath(p, out) realpath((p), (out))
 #endif
 
 #ifndef PATH_MAX
@@ -53,7 +64,7 @@ static void mkdir_parents(const char *file_path)
       if (*p == '/')
       {
          *p = '\0';
-         mkdir(buf, 0700);
+         platform_mkdir_p(buf, 0700);
          *p = '/';
       }
    }
@@ -79,7 +90,7 @@ static int target_confined(const char *target, const char *memreal)
       return 0;
    snprintf(dir, sizeof(dir), "%.*s", (int)(base - target), target);
    char dreal[PATH_MAX];
-   if (!realpath(dir, dreal))
+   if (!hm_realpath(dir, dreal))
       return 0;
    size_t n = strlen(memreal);
    return strncmp(dreal, memreal, n) == 0 && (dreal[n] == '/' || dreal[n] == '\0');
@@ -201,7 +212,7 @@ static int consume_spills(const char *project, const char *endpoint, const char 
          free(bs);
          if (r && st >= 200 && st < 300)
          {
-            unlink(fp);
+            remove(fp); /* ISO C (portable); unistd unlink isn't declared on Windows */
             hmem_audit("spill-consumed", p, nm, NULL);
             n++;
          }
@@ -223,7 +234,7 @@ int harness_memory_hydrate(const char *cwd)
    if (!scope) /* no registered memory surface for this client */
       return -1;
    char real[PATH_MAX];
-   if (!realpath((cwd && cwd[0]) ? cwd : ".", real))
+   if (!hm_realpath((cwd && cwd[0]) ? cwd : ".", real))
       return -1;
    char slug[PATH_MAX * 2];
    hmem_slug_from_path(real, slug, sizeof(slug));
@@ -269,7 +280,7 @@ int harness_memory_hydrate(const char *cwd)
     * under the *real* directory (a symlinked component can't redirect us out). */
    mkdir_p(memdir);
    char memreal[PATH_MAX];
-   if (!realpath(memdir, memreal))
+   if (!hm_realpath(memdir, memreal))
    {
       cJSON_Delete(resp);
       return -1;

--- a/src/harness_memory_spill.c
+++ b/src/harness_memory_spill.c
@@ -5,6 +5,7 @@
 #include "aimee_home.h" /* aimee_home() — honors AIMEE_HOME/AIMEE_PROFILE */
 #include "cJSON.h"
 #include "harness_memory_common.h" /* hmem_sha256_hex */
+#include "platform_path.h"         /* platform_mkdir_p (portable mkdir -p) */
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -41,11 +42,11 @@ int hmem_spill_dir(const char *project, char *out, size_t cap)
    char base[PATH_MAX];
    if ((size_t)snprintf(base, sizeof(base), "%s/harness_spill", home) >= sizeof(base))
       return -1;
-   mkdir(home, 0700);
-   mkdir(base, 0700);
+   platform_mkdir_p(home, 0700);
+   platform_mkdir_p(base, 0700);
    if ((size_t)snprintf(out, cap, "%s/%s", base, ph) >= cap)
       return -1;
-   mkdir(out, 0700);
+   platform_mkdir_p(out, 0700);
    return 0;
 }
 
@@ -59,8 +60,10 @@ int hmem_spill_write(const char *project, const char *name, const char *type, co
 
    char ts[32];
    time_t t = time(NULL);
-   struct tm tm_buf;
-   gmtime_r(&t, &tm_buf);
+   struct tm tm_buf = {0};
+   struct tm *gmt = gmtime(&t); /* gmtime_r is POSIX-only; CLI is single-threaded */
+   if (gmt)
+      tm_buf = *gmt;
    strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%SZ", &tm_buf);
 
    cJSON *o = cJSON_CreateObject();

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -438,10 +438,10 @@ $(TESTPREFIX)/unit-test-db: $(OBJDIR)/tests/test_db.o $(OBJDIR)/db1/db.o $(OBJDI
 $(TESTPREFIX)/unit-test-harness-memory-hydrate: $(OBJDIR)/tests/test_harness_memory_hydrate.o $(OBJDIR)/harness_memory_hydrate.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-harness-memory-spill: $(OBJDIR)/tests/test_harness_memory_spill.o $(OBJDIR)/harness_memory_spill.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o
+$(TESTPREFIX)/unit-test-harness-memory-spill: $(OBJDIR)/tests/test_harness_memory_spill.o $(OBJDIR)/harness_memory_spill.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/aimee_home.o $(OBJDIR)/posix/platform_path.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-harness-memory-audit: $(OBJDIR)/tests/test_harness_memory_audit.o $(OBJDIR)/harness_memory_audit.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o
+$(TESTPREFIX)/unit-test-harness-memory-audit: $(OBJDIR)/tests/test_harness_memory_audit.o $(OBJDIR)/harness_memory_audit.o $(OBJDIR)/aimee_home.o $(OBJDIR)/posix/platform_path.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-harness-memory-scope: $(OBJDIR)/tests/test_harness_memory_scope.o $(OBJDIR)/harness_memory_scope.o


### PR DESCRIPTION
## Problem
The macOS/Windows CMake build of the standalone `aimee` CLI fails to link:
```
Undefined symbols for architecture arm64:
  "_hmem_resolve_project", referenced from: ...
  "_hmem_scope_for_client", referenced from: ...
```
`CLI_SRCS` includes `harness_memory_hydrate.c` (which calls `hmem_resolve_project` / `hmem_scope_for_client`), but the `aimee` target is built from `CLI_SRCS` alone and does **not** link `aimee-core`, where the definers (`harness_memory_common.c`, `harness_memory_scope.c`) otherwise live (`CORE_SRCS`, gated `if(NOT AIMEE_THIN_CLIENT)`). The make build links them via `L_CLIENT`, so only the CMake CLI source list was short — introduced with the harness-memory P3/P4/registry merges.

This is currently red on `testing` and blocks every PR's macOS/Windows checks.

## Fix
Add `harness_memory_common.c` + `harness_memory_scope.c` to `CLI_SRCS`. No duplicate-symbol risk: the `aimee` CLI never links `aimee-core`.

## Validation
Reproduced the failing path and confirmed the fix with a thin-client CMake build of the CLI:
`cmake -B build -DAIMEE_THIN_CLIENT=ON && cmake --build build --target aimee` → links cleanly.