### PR TITLE
feat(harness-memory): intercept Bash writes to memory files

### DIFF
--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -170,14 +170,29 @@ static int rematerialize(const char *path, const char *content, const char *home
 #endif
 }
 
-/* Any write operator in [a,b)? '>' covers >, >>, 2>, &>; plus tool keywords. */
+/* Any write operator in [a,b)? '>' (covers >, >>, 2>, &>) is only counted
+ * OUTSIDE single/double quotes and escapes, so quoted data like grep 'a>b' is
+ * not mistaken for a redirection. Plus a best-effort write-tool keyword list. */
 static int region_has_write_op(const char *a, const char *b)
 {
+   int sq = 0, dq = 0;
    for (const char *p = a; p < b; p++)
-      if (*p == '>')
+   {
+      char c = *p;
+      if (c == '\\' && p + 1 < b)
+      {
+         p++;
+         continue;
+      }
+      if (!dq && c == '\'')
+         sq = !sq;
+      else if (!sq && c == '"')
+         dq = !dq;
+      else if (!sq && !dq && c == '>')
          return 1;
-   static const char *const kw[] = {"tee", "sed -i", "dd of=",  "truncate ",
-                                    "cp ", "mv ",    "install "};
+   }
+   static const char *const kw[] = {"tee", "sed -i",   "dd of=",  "truncate ", "cp ",
+                                    "mv ", "install ", "perl -i", "perl -pi",  "patch "};
    for (size_t i = 0; i < sizeof(kw) / sizeof(kw[0]); i++)
    {
       size_t kl = strlen(kw[i]);

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -170,16 +170,98 @@ static int rematerialize(const char *path, const char *content, const char *home
 #endif
 }
 
+/* Any write operator in [a,b)? '>' covers >, >>, 2>, &>; plus tool keywords. */
+static int region_has_write_op(const char *a, const char *b)
+{
+   for (const char *p = a; p < b; p++)
+      if (*p == '>')
+         return 1;
+   static const char *const kw[] = {"tee", "sed -i", "dd of=",  "truncate ",
+                                    "cp ", "mv ",    "install "};
+   for (size_t i = 0; i < sizeof(kw) / sizeof(kw[0]); i++)
+   {
+      size_t kl = strlen(kw[i]);
+      for (const char *p = a; p + kl <= b; p++)
+         if (strncmp(p, kw[i], kl) == 0)
+            return 1;
+   }
+   return 0;
+}
+
+int memory_redirect_bash_targets_memory(const char *client, const char *command, const char *home)
+{
+   const hmem_scope_t *scope = hmem_scope_for_client(client);
+   if (!scope || !command || !home || !home[0])
+      return 0;
+   char prefix[PATH_MAX], memseg[80];
+   if ((size_t)snprintf(prefix, sizeof(prefix), "%s/%s/", home, scope->projects_root) >=
+       sizeof(prefix))
+      return 0;
+   if ((size_t)snprintf(memseg, sizeof(memseg), "/%s/", scope->memory_seg) >= sizeof(memseg))
+      return 0;
+   size_t mslen = strlen(memseg);
+
+   const char *p = command;
+   while ((p = strstr(p, prefix)))
+   {
+      const char *ts = p; /* path-token start */
+      const char *end = ts;
+      while (*end && !strchr(" \t;|&\n\"'`)<>", *end))
+         end++;
+      size_t tlen = (size_t)(end - ts);
+      int has_mem = 0;
+      for (const char *q = ts; q + mslen <= end; q++)
+         if (strncmp(q, memseg, mslen) == 0)
+         {
+            has_mem = 1;
+            break;
+         }
+      int ends_md = tlen >= 3 && end[-3] == '.' && (end[-2] == 'm' || end[-2] == 'M') &&
+                    (end[-1] == 'd' || end[-1] == 'D');
+      if (has_mem && ends_md)
+      {
+         /* start of this simple command (after the last separator before the path) */
+         const char *cs = ts;
+         while (cs > command && !strchr(";|&\n", cs[-1]))
+            cs--;
+         if (region_has_write_op(cs, ts))
+            return 1;
+      }
+      p = (end > p) ? end : p + 1;
+   }
+   return 0;
+}
+
 int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *msg, size_t msg_len)
 {
    if (!root)
       return 0;
    const char *client = getenv("AIMEE_HOOK_CLIENT");
    const char *home = getenv("HOME");
+   if (!home)
+      return 0;
+
+   /* Bash bypass: a shell command that writes a memory file is reject-denied —
+    * we can't capture the command's output, so steer the agent to the Write
+    * tool (which we intercept + store). Reads of memory files are unaffected. */
+   if (tool && strcmp(tool, "Bash") == 0)
+   {
+      const char *cmd = json_str(root, "command");
+      if (cmd && memory_redirect_bash_targets_memory(client, cmd, home))
+      {
+         snprintf(msg, msg_len,
+                  "Memory files are managed by aimee — use the Write tool to set "
+                  "memory/<name>.md, not shell redirection.");
+         hmem_audit("reject", NULL, NULL, "bash-write-memory");
+         return 2;
+      }
+      return 0;
+   }
+
    const char *path = json_str(root, "file_path");
    if (!path)
       path = json_str(root, "path");
-   if (!path || !home)
+   if (!path)
       return 0;
 
    char name[512];

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -37,7 +37,9 @@ extern "C"
     * <home>/<projects_root>/.../<memory_seg>/...md) that is the target of a write
     * operator (>, >>, tee, sed -i, dd of=, truncate, cp/mv) in the same simple
     * command. A read of a memory file (no preceding write op) returns 0. v1
-    * limit: process substitution / eval / var-indirection can evade. */
+    * limit (best-effort): an interpreter writing the file (python -c, node -e,
+    * ruby -e), process substitution, eval, or var-indirection can evade — the
+    * deferred inotify/fanotify backstop is the complete fix. */
    int memory_redirect_bash_targets_memory(const char *client, const char *command,
                                            const char *home);
 

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -32,6 +32,15 @@ extern "C"
                                          const char *home, char *out_name, size_t name_cap,
                                          const char **out_reason);
 
+   /* PURE (no I/O) — testable. Best-effort: does the Bash `command` WRITE to a
+    * file under the client's memory surface? Looks for a memory path (under
+    * <home>/<projects_root>/.../<memory_seg>/...md) that is the target of a write
+    * operator (>, >>, tee, sed -i, dd of=, truncate, cp/mv) in the same simple
+    * command. A read of a memory file (no preceding write op) returns 0. v1
+    * limit: process substitution / eval / var-indirection can evade. */
+   int memory_redirect_bash_targets_memory(const char *client, const char *command,
+                                           const char *home);
+
    /* Full interception stage for pre_tool_check. Inspects a parsed tool-input
     * object for a memory write/edit; on a memory op performs the redirect (POST
     * to /v1/harness_memory/upsert + re-materialize the file) and returns a

--- a/src/tests/test_memory_redirect.c
+++ b/src/tests/test_memory_redirect.c
@@ -61,6 +61,25 @@ int main(void)
    /* NULL path must not crash */
    assert(cls("claude", "Write", NULL, name, &reason) == MR_ALLOW);
 
+   /* --- Bash-write detection --- */
+#define BT(cmd) memory_redirect_bash_targets_memory("claude", (cmd), H)
+   /* writes to a memory file via redirection / tee / sed -i -> detected */
+   assert(BT("echo hi > " H "/.claude/projects/p/memory/n.md") == 1);
+   assert(BT("printf x >> " H "/.claude/projects/p/memory/n.md") == 1);
+   assert(BT("echo x | tee " H "/.claude/projects/p/memory/n.md") == 1);
+   assert(BT("sed -i 's/a/b/' " H "/.claude/projects/p/memory/n.md") == 1);
+   assert(BT("cat z > " H "/.claude/projects/p/memory/topics/n.md") == 1); /* nested */
+   /* reading a memory file (no preceding write op) -> not detected */
+   assert(BT("cat " H "/.claude/projects/p/memory/n.md") == 0);
+   /* reads memory, writes elsewhere -> the write target isn't memory -> not detected */
+   assert(BT("cat " H "/.claude/projects/p/memory/n.md > /tmp/y") == 0);
+   /* writes a non-memory file -> not detected */
+   assert(BT("echo x > /tmp/y.md") == 0);
+   /* non-claude client -> no surface -> not detected */
+   assert(memory_redirect_bash_targets_memory(
+              "gemini", "echo x > " H "/.claude/projects/p/memory/n.md", H) == 0);
+#undef BT
+
    printf("test_memory_redirect: OK\n");
    return 0;
 }

--- a/src/tests/test_memory_redirect.c
+++ b/src/tests/test_memory_redirect.c
@@ -78,6 +78,17 @@ int main(void)
    /* non-claude client -> no surface -> not detected */
    assert(memory_redirect_bash_targets_memory(
               "gemini", "echo x > " H "/.claude/projects/p/memory/n.md", H) == 0);
+   /* quoted '>' is data, not a redirection -> a read stays allowed */
+   assert(BT("grep 'a>b' " H "/.claude/projects/p/memory/n.md") == 0);
+   /* but a real redirection after quoted data IS detected */
+   assert(BT("echo \"x>y\" > " H "/.claude/projects/p/memory/n.md") == 1);
+   /* no-space redirection */
+   assert(BT("echo x>" H "/.claude/projects/p/memory/n.md") == 1);
+   /* prior simple command's write op does not leak across ; or && to a read */
+   assert(BT("echo x > /tmp/a; cat " H "/.claude/projects/p/memory/n.md") == 0);
+   assert(BT("echo x > /tmp/a && cat " H "/.claude/projects/p/memory/n.md") == 0);
+   /* perl -i in-place edit of a memory file is a write */
+   assert(BT("perl -i -pe 's/x/y/' " H "/.claude/projects/p/memory/n.md") == 1);
 #undef BT
 
    printf("test_memory_redirect: OK\n");


### PR DESCRIPTION
Deferred item #5. A Bash command that writes a memory file is reject-denied (steer to the Write tool — the command's output can't be captured/stored). Reads are unaffected (write op must precede the memory path). Pure detector is unit-tested. v1 limit: process-subst/eval/var-indirection can evade (documented). Roundtable-reviewed.