### PR TITLE
feat(hmem): full session-start reconcile (disk-import + tombstone removal)

### DIFF
--- a/src/harness_memory_hydrate.c
+++ b/src/harness_memory_hydrate.c
@@ -18,7 +18,7 @@
 
 #ifndef _WIN32
 #include <fcntl.h>
-#include <unistd.h>
+#include <unistd.h> /* unlink, fsync */
 #endif
 
 #ifndef PATH_MAX
@@ -214,6 +214,121 @@ static int consume_spills(const char *project, const char *endpoint, const char 
    return n;
 }
 
+int hmem_md_store_name(const char *fp, const char *memreal, char *out, size_t cap)
+{
+   if (!fp || !memreal || !out || cap == 0)
+      return -1;
+   size_t fl = strlen(fp), ml = strlen(memreal);
+   /* Case-SENSITIVE ".md": on a case-sensitive fs "Foo.MD" is a distinct file
+    * and must not be folded onto the canonical lowercase store name. */
+   if (fl < 3 || memcmp(fp + fl - 3, ".md", 3) != 0)
+      return -1;
+   /* fp must sit strictly under memreal: longer than memreal, shared prefix, and
+    * a '/' boundary. The `fl > ml` guard makes fp[ml] unambiguously in-bounds and
+    * rejects a sibling like "<memreal>X/foo.md" (boundary byte is 'X', not '/'). */
+   if (fl <= ml || strncmp(fp, memreal, ml) != 0 || fp[ml] != '/')
+      return -1;
+   const char *rel = fp + ml + 1;
+   size_t rel_len = fl - (ml + 1) - 3; /* minus ".md" */
+   if (rel_len == 0 || rel_len >= cap)
+      return -1;
+   memcpy(out, rel, rel_len);
+   out[rel_len] = '\0';
+   /* Nested names legitimately keep '/' (e.g. "topics/a") and a literal ".." mid-
+    * token is fine (e.g. "v1..0"), but a ".." that IS a whole path component could
+    * escape the root on write-back, so reject only that. */
+   for (const char *p = strstr(out, ".."); p; p = strstr(p + 2, ".."))
+   {
+      int at_start = (p == out) || (p[-1] == '/');
+      int at_end = (p[2] == '\0') || (p[2] == '/');
+      if (at_start && at_end)
+         return -1;
+   }
+   /* "MEMORY" is the harness index (MEMORY.md), matched EXACT-case — a user file
+    * "memory.md" on a case-sensitive fs is a real memory, not the index. */
+   if (strcmp(out, "MEMORY") == 0)
+      return -1;
+   return 0;
+}
+
+/* True if `name` is one of the `nk` strings in `known`. */
+static int name_known(char *const *known, int nk, const char *name)
+{
+   for (int i = 0; i < nk; i++)
+      if (strcmp(known[i], name) == 0)
+         return 1;
+   return 0;
+}
+
+/* Walk `absdir` recursively (absdir is always under the resolved memreal). Any
+ * regular *.md file whose store name is not in `known` is a disk-only memory
+ * (pre-existing file, external edit, or a fail-open write whose spill was lost):
+ * import it into the store via upsert so DB1 becomes the union of disk + store.
+ * lstat (not stat) means symlinked dirs/files are skipped — a symlink can't make
+ * the scan escape memreal or import something outside it. */
+static void import_orphans(const char *absdir, const char *memreal, char *const *known, int nk,
+                           const char *project, const char *endpoint, const char *bearer,
+                           int *count)
+{
+   DIR *d = opendir(absdir);
+   if (!d)
+      return;
+   struct dirent *e;
+   while ((e = readdir(d)) != NULL)
+   {
+      if (e->d_name[0] == '.') /* skip dotfiles, "." and ".." */
+         continue;
+      char fp[PATH_MAX];
+      if ((size_t)snprintf(fp, sizeof(fp), "%s/%s", absdir, e->d_name) >= sizeof(fp))
+         continue;
+      struct stat st;
+      if (lstat(fp, &st) != 0)
+         continue;
+      if (S_ISDIR(st.st_mode))
+      {
+         import_orphans(fp, memreal, known, nk, project, endpoint, bearer, count);
+         continue;
+      }
+      if (!S_ISREG(st.st_mode))
+         continue;
+      char name[PATH_MAX];
+      if (hmem_md_store_name(fp, memreal, name, sizeof(name)) != 0)
+         continue;
+      if (name_known(known, nk, name))
+         continue;
+      char *content = read_whole(fp);
+      if (!content)
+         continue;
+      cJSON *b = cJSON_CreateObject();
+      if (!b)
+      {
+         free(content);
+         continue;
+      }
+      cJSON_AddStringToObject(b, "project", project);
+      cJSON_AddStringToObject(b, "name", name);
+      cJSON_AddStringToObject(b, "type", "fact");
+      cJSON_AddStringToObject(b, "body", content);
+      char *bs = cJSON_PrintUnformatted(b);
+      cJSON_Delete(b);
+      free(content);
+      if (!bs)
+         continue;
+      int code = 0;
+      cJSON *r =
+          cli_http_request(endpoint, "POST", "/v1/harness_memory/upsert", bs, bearer, 15000, &code);
+      free(bs);
+      if (r && code >= 200 && code < 300)
+      {
+         hmem_audit("import", project, name, NULL);
+         (*count)++;
+      }
+      if (r)
+         cJSON_Delete(r);
+   }
+   closedir(d);
+}
+
 int harness_memory_hydrate(const char *cwd)
 {
    const char *home = getenv("HOME");
@@ -246,8 +361,11 @@ int harness_memory_hydrate(const char *cwd)
     * below reflects them. */
    int consumed = consume_spills(project, endpoint, bearer);
 
+   /* include_deleted so tombstoned rows come back too — we materialize live rows
+    * and *remove* the on-disk file for each tombstone (DB1 is authoritative). */
    cJSON *body = cJSON_CreateObject();
    cJSON_AddStringToObject(body, "project", project);
+   cJSON_AddNumberToObject(body, "include_deleted", 1);
    char *body_s = cJSON_PrintUnformatted(body);
    cJSON_Delete(body);
 
@@ -256,12 +374,12 @@ int harness_memory_hydrate(const char *cwd)
                                            bearer, 15000, &status)
                         : NULL;
    free(body_s);
-   free(endpoint);
-   free(bearer);
    if (!resp || status < 200 || status >= 300)
    {
       if (resp)
          cJSON_Delete(resp);
+      free(endpoint);
+      free(bearer);
       return (consumed > 0) ? consumed : -1;
    }
 
@@ -272,31 +390,90 @@ int harness_memory_hydrate(const char *cwd)
    if (!realpath(memdir, memreal))
    {
       cJSON_Delete(resp);
+      free(endpoint);
+      free(bearer);
       return -1;
    }
 
-   int n = 0;
+   /* Every name DB1 knows about — LIVE *and* TOMBSTONED. The disk scan below
+    * imports any *.md whose name is absent from this set; including tombstoned
+    * names here is what stops a tombstone from being resurrected (a deleted
+    * memory whose file lingers stays "known", so it is never re-imported).
+    * known_ok guards completeness: if any insertion fails (OOM), the set is no
+    * longer authoritative, so we skip the import pass entirely rather than risk
+    * resurrecting a tombstone we failed to record. */
+   char **known = NULL;
+   int nk = 0, kcap = 0, known_ok = 1;
+
+   int n = 0, removed = 0;
    cJSON *mems = cJSON_GetObjectItemCaseSensitive(resp, "memories");
    cJSON *m = NULL;
    cJSON_ArrayForEach(m, mems)
    {
       const char *name = jstr(m, "name");
       const char *btext = jstr(m, "body");
+      const char *del = jstr(m, "deleted_at");
       if (!name || !name[0] || name[0] == '/' || strstr(name, "..")) /* never escape memdir */
          continue;
+      if (nk == kcap)
+      {
+         int nc = kcap ? kcap * 2 : 32;
+         char **t = realloc(known, (size_t)nc * sizeof(*t));
+         if (t)
+         {
+            known = t;
+            kcap = nc;
+         }
+      }
+      if (nk < kcap)
+      {
+         char *dup = strdup(name);
+         if (dup)
+            known[nk++] = dup;
+         else
+            known_ok = 0;
+      }
+      else
+      {
+         known_ok = 0;
+      }
       char target[PATH_MAX];
       if ((size_t)snprintf(target, sizeof(target), "%s/%s.md", memdir, name) >= sizeof(target))
          continue;
+      if (del && del[0]) /* tombstoned: ensure the on-disk file is gone */
+      {
+         if (target_confined(target, memreal) && unlink(target) == 0)
+         {
+            removed++;
+            hmem_audit("tombstone-removed", project, name, NULL);
+         }
+         continue;
+      }
       mkdir_parents(target);
       if (target_confined(target, memreal) && write_file(target, btext ? btext : "") == 0)
          n++;
    }
    cJSON_Delete(resp);
 
-   if (n > 0 || consumed > 0)
+   /* Import disk-only memory files the store has never seen (pre-existing files,
+    * external edits, or fail-open writes whose spill was lost). Skipped when the
+    * known set is incomplete — see known_ok above. */
+   int imported = 0;
+   if (known_ok)
+      import_orphans(memreal, memreal, known, nk, project, endpoint, bearer, &imported);
+
+   for (int i = 0; i < nk; i++)
+      free(known[i]);
+   free(known);
+   free(endpoint);
+   free(bearer);
+
+   if (n > 0 || consumed > 0 || removed > 0 || imported > 0)
    {
-      char detail[96];
-      snprintf(detail, sizeof(detail), "hydrated=%d spills_consumed=%d", n, consumed);
+      char detail[160];
+      snprintf(detail, sizeof(detail),
+               "hydrated=%d spills_consumed=%d tombstones_removed=%d imported=%d", n, consumed,
+               removed, imported);
       hmem_audit("reconcile", project, NULL, detail);
    }
    return n;

--- a/src/harness_memory_hydrate.h
+++ b/src/harness_memory_hydrate.h
@@ -18,6 +18,14 @@ extern "C"
     * terminated slug into out (truncated to cap). PURE — testable. */
    void hmem_slug_from_path(const char *abspath, char *out, size_t cap);
 
+   /* Derive a store name from a memory file path during reconcile: `fp` must be
+    * a "*.md" path strictly under `memreal` (the resolved memory dir). On success
+    * writes the path relative to memreal with ".md" stripped (e.g.
+    * "<memreal>/topics/a.md" -> "topics/a") and returns 0. Returns -1 if fp is
+    * not under memreal, is not a ".md" file, names the "MEMORY" index, or does
+    * not fit in cap. PURE — testable. */
+   int hmem_md_store_name(const char *fp, const char *memreal, char *out, size_t cap);
+
    /* Best-effort hydrate: resolve the project for cwd, fetch its live memory
     * rows from the server, and materialize each under
     * ~/.claude/projects/<slug>/memory/<name>.md. Returns the number written, or

--- a/src/server/harness_memory_routes.c
+++ b/src/server/harness_memory_routes.c
@@ -38,6 +38,7 @@ static cJSON *hmem_row_json(const hmem_row_t *r)
    cJSON_AddStringToObject(o, "meta_json", r->meta_json ? r->meta_json : "{}");
    cJSON_AddStringToObject(o, "content_hash", r->content_hash);
    cJSON_AddStringToObject(o, "last_client", r->last_client);
+   cJSON_AddStringToObject(o, "deleted_at", r->deleted_at); /* "" when live */
    cJSON_AddStringToObject(o, "created_at", r->created_at);
    cJSON_AddStringToObject(o, "updated_at", r->updated_at);
    return o;

--- a/src/tests/test_harness_memory_hydrate.c
+++ b/src/tests/test_harness_memory_hydrate.c
@@ -38,6 +38,64 @@ int main(void)
    hmem_slug_from_path(NULL, s, sizeof(s));
    assert(s[0] == '\0');
 
+   /* hmem_md_store_name: derive a store name from a *.md path under memreal. */
+   const char *mr = "/home/u/.claude/projects/-p/memory";
+   char nm[256];
+
+   /* top-level file: strip dir prefix + ".md" */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/foo.md", mr, nm, sizeof(nm)) == 0);
+   assert(strcmp(nm, "foo") == 0);
+
+   /* nested file keeps the relative subpath */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/topics/a.md", mr, nm,
+                             sizeof(nm)) == 0);
+   assert(strcmp(nm, "topics/a") == 0);
+
+   /* the MEMORY index (exact case) is not a memory entry */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/MEMORY.md", mr, nm, sizeof(nm)) ==
+          -1);
+
+   /* a lowercase "memory.md" is a real memory, NOT the index (case-sensitive) */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/memory.md", mr, nm, sizeof(nm)) ==
+          0);
+   assert(strcmp(nm, "memory") == 0);
+
+   /* ".MD" (wrong case) is not accepted as markdown */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/foo.MD", mr, nm, sizeof(nm)) ==
+          -1);
+
+   /* a name with a parent-dir component is rejected (no escape on write-back) */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/a/../../x.md", mr, nm,
+                             sizeof(nm)) == -1);
+
+   /* but a literal ".." inside a token is fine (not a path component) */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/v1..0.md", mr, nm, sizeof(nm)) ==
+          0);
+   assert(strcmp(nm, "v1..0") == 0);
+
+   /* non-.md is rejected */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/foo.txt", mr, nm, sizeof(nm)) ==
+          -1);
+
+   /* a path not under memreal is rejected (no escape) */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/elsewhere/foo.md", mr, nm, sizeof(nm)) ==
+          -1);
+
+   /* a sibling dir sharing memreal as a prefix (no '/' boundary) is rejected */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memoryX/foo.md", mr, nm, sizeof(nm)) ==
+          -1);
+
+   /* memreal itself + ".md" has empty relative name -> rejected */
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory.md", mr, nm, sizeof(nm)) == -1);
+
+   /* truncation: name does not fit in cap -> rejected, no overrun */
+   char tiny[3];
+   assert(hmem_md_store_name("/home/u/.claude/projects/-p/memory/foo.md", mr, tiny, sizeof(tiny)) ==
+          -1);
+
+   /* NULL args are safe */
+   assert(hmem_md_store_name(NULL, mr, nm, sizeof(nm)) == -1);
+
    printf("test_harness_memory_hydrate: OK\n");
    return 0;
 }


### PR DESCRIPTION
## What

Completes the session-start reconcile for central agent-memory interception (v1.2 item: full reconcile). `harness_memory_hydrate` now performs a true 3-way reconcile between DB1 (authoritative) and the on-disk Claude memory dir, so no disk-only memory is silently lost and tombstones are honored.

## Changes

- **List + route**: hydrate lists with `include_deleted=1`; `hmem_row_json` now emits `deleted_at` ("" when live).
- **Tombstone removal**: for each tombstoned row, the on-disk `<name>.md` is removed (DB1 wins), audited `tombstone-removed`.
- **Disk-only import**: `import_orphans()` recursively walks the resolved `memreal`; any regular `*.md` whose store name is unknown to DB1 (pre-existing file, external edit, or a fail-open write whose spill was lost) is imported via upsert, audited `import`. `lstat` skips symlinked dirs/files so the walk can't escape the root.
- **New pure helper** `hmem_md_store_name(fp, memreal, out, cap)`: derives a store name from a memory path — case-sensitive `.md`, exact-case `MEMORY` index exclusion, component-aware `..` rejection (mid-token `..` allowed), strict under-`memreal` boundary. Unit-tested (12 cases).
- **No tombstone resurrection**: the `known` set spans **live + tombstoned** names, so a lingering tombstoned file is never re-imported; if the set can't be fully built (OOM), the import pass is skipped entirely.
- reconcile audit detail now reports `hydrated/spills_consumed/tombstones_removed/imported`.

## Testing

- `make unit-tests` green (new `hmem_md_store_name` cases included).
- `make all server` + `make lint` (clang-format-19) green.
- Roundtable code-reviewed over 2 revisions; all blocking items resolved, final review returned no remaining blockers.

## Notes

Session-start hydrate remains best-effort and idempotent (upsert/unlink). A global filesystem lock across the reconcile is intentionally out of scope for v1.2; the live+tombstoned `known` set already prevents the one real hazard (tombstone resurrection under a concurrent race).