### PR TITLE
feat(hmem): config-file override of the memory-surface scope registry

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -213,7 +213,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 124 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 125 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -222,6 +222,7 @@ The binaries read 124 `AIMEE_*` environment variables (scanned from `getenv()` i
 | `AIMEE_BUNDLED_SKILLS_DIR` | Override directory for the bundled skills. |
 | `AIMEE_FORENSICS_DIR` | Directory for shutdown-forensics dumps. |
 | `AIMEE_GUARDRAILS_PATH` | Path to the guardrails policy file. |
+| `AIMEE_HARNESS_MEMORY_SCOPES` | Path to the agent memory-surface registry config (default `<AIMEE_HOME>/harness_memory_scopes.conf`). Each `client:projects_root:memory_seg` line adds a new agent or overrides a built-in's paths for memory interception/hydration. |
 | `AIMEE_HOME` | Root of the per-user state/config store (config, DB1, `workflows/`, keys). Overrides the platform default. |
 | `AIMEE_INSTALL_PREFIX` | Install prefix used to locate bundled assets and plugins. |
 | `AIMEE_MODELS_DEV_SNAPSHOT` | Path to an offline models.dev catalog snapshot. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -452,6 +452,7 @@ ENV_DESC = {
     "AIMEE_GUARDRAILS_PATH": ("Paths & assets", "Path to the guardrails policy file."),
     "AIMEE_FORENSICS_DIR": ("Paths & assets", "Directory for shutdown-forensics dumps."),
     "AIMEE_PACK_DIR": ("Paths & assets", "Directory of memory profile packs."),
+    "AIMEE_HARNESS_MEMORY_SCOPES": ("Paths & assets", "Path to the agent memory-surface registry config (default `<AIMEE_HOME>/harness_memory_scopes.conf`). Each `client:projects_root:memory_seg` line adds a new agent or overrides a built-in's paths for memory interception/hydration."),
     "AIMEE_WORKSPACES_DIR": ("Paths & assets", "Root directory for mirrored/registered workspaces."),
     "AIMEE_MODELS_DEV_SNAPSHOT": ("Paths & assets", "Path to an offline models.dev catalog snapshot."),
     # Client & session

--- a/src/harness_memory_scope.c
+++ b/src/harness_memory_scope.c
@@ -1,16 +1,199 @@
 /* harness_memory_scope.c — see harness_memory_scope.h.
  *
- * v1 ships the Claude Code file-memory surface. Adding another agent that has a
- * file-memory directory is one row here — no detection/hydrate code changes.
- * (A config-file override of this table is a documented follow-up.) */
+ * v1 ships the Claude Code file-memory surface as a built-in. Other agents can be
+ * added either by a built-in row below or, at runtime, via a config file
+ * (AIMEE_HARNESS_MEMORY_SCOPES, else <AIMEE_HOME>/harness_memory_scopes.conf) —
+ * each "client:projects_root:memory_seg" line adds a new client or overrides a
+ * built-in's paths, with no detection/hydrate code changes. */
 
 #include "harness_memory_scope.h"
 
+#include "aimee_home.h" /* aimee_home() — honors AIMEE_HOME/AIMEE_PROFILE */
+
+#include <pthread.h> /* pthread_once — winpthreads provides it on Windows too */
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
-static const hmem_scope_t SCOPES[] = {
+#ifndef PATH_MAX
+#define PATH_MAX 4096
+#endif
+
+/* Built-in surfaces. A config line for the same client overrides its paths. */
+static const hmem_scope_t BUILTIN_SCOPES[] = {
     {"claude", ".claude/projects", "memory"},
 };
+
+/* Trim ASCII whitespace in place; returns the (possibly advanced) start. Only
+ * ever called on the writable scratch copy below — never on the const input. */
+static char *trim(char *s)
+{
+   if (!s)
+      return s;
+   while (*s == ' ' || *s == '\t' || *s == '\r' || *s == '\n')
+      s++;
+   size_t n = strlen(s);
+   while (n > 0 && (s[n - 1] == ' ' || s[n - 1] == '\t' || s[n - 1] == '\r' || s[n - 1] == '\n'))
+      s[--n] = '\0';
+   return s;
+}
+
+static int is_sep(char c)
+{
+   return c == '/' || c == '\\'; /* treat '\\' as a separator so Windows is covered */
+}
+
+/* A path field must be relative to $HOME and may not climb out of it. Rejects
+ * absolute ('/...'), UNC/root ('\...'), and drive-rooted/relative ('C:\', 'C:foo')
+ * forms, plus any "." or ".." whole path component (mid-token dots like
+ * "my..backup" are fine). */
+static int path_field_ok(const char *p)
+{
+   if (!p || p[0] == '\0' || is_sep(p[0]))
+      return 0;
+   if (((p[0] >= 'A' && p[0] <= 'Z') || (p[0] >= 'a' && p[0] <= 'z')) && p[1] == ':')
+      return 0;
+   const char *seg = p;
+   for (const char *q = p;; q++)
+   {
+      if (*q == '\0' || is_sep(*q))
+      {
+         size_t len = (size_t)(q - seg);
+         /* reject empty segments ("a//b", "a/") and any "."/".." component so the
+          * stored path is canonical and HOME-confined */
+         if (len == 0 || (len == 1 && seg[0] == '.') ||
+             (len == 2 && seg[0] == '.' && seg[1] == '.'))
+            return 0;
+         if (*q == '\0')
+            break;
+         seg = q + 1;
+      }
+   }
+   return 1;
+}
+
+int hmem_scope_parse_line(const char *line, char *client, size_t client_cap, char *root,
+                          size_t root_cap, char *seg, size_t seg_cap)
+{
+   if (!line || !client || !root || !seg || !client_cap || !root_cap || !seg_cap)
+      return -1;
+   char buf[PATH_MAX * 2];
+   if ((size_t)snprintf(buf, sizeof(buf), "%s", line) >= sizeof(buf))
+      return -1;
+   char *s = trim(buf);
+   if (s[0] == '\0' || s[0] == '#') /* blank or comment */
+      return 1;
+   char *c1 = strchr(s, ':');
+   if (!c1)
+      return -1;
+   *c1 = '\0';
+   char *c2 = strchr(c1 + 1, ':');
+   if (!c2)
+      return -1;
+   *c2 = '\0';
+   char *cl = trim(s);
+   char *rt = trim(c1 + 1);
+   char *sg = trim(c2 + 1);
+   if (cl[0] == '\0' || !path_field_ok(rt) || !path_field_ok(sg))
+      return -1;
+   if (strchr(cl, '/') != NULL || strchr(cl, '\\') != NULL ||
+       strstr(cl, "..") != NULL) /* client id is a bare token */
+      return -1;
+   if ((size_t)snprintf(client, client_cap, "%s", cl) >= client_cap ||
+       (size_t)snprintf(root, root_cap, "%s", rt) >= root_cap ||
+       (size_t)snprintf(seg, seg_cap, "%s", sg) >= seg_cap)
+      return -1;
+   return 0;
+}
+
+static hmem_scope_t *g_scopes;
+static size_t g_count;
+
+/* Add a new client row, or override the paths of an existing one. Strings are
+ * strdup'd; the merged table is built once (below) before any pointer escapes,
+ * so post-init pointers into g_scopes stay stable for the process lifetime. */
+static void scope_add_or_override(const char *client, const char *root, const char *seg)
+{
+   for (size_t i = 0; i < g_count; i++)
+   {
+      if (strcmp(g_scopes[i].client, client) == 0)
+      {
+         char *nr = strdup(root), *ns = strdup(seg);
+         if (!nr || !ns) /* keep the existing row rather than corrupt it */
+         {
+            free(nr);
+            free(ns);
+            return;
+         }
+         free((void *)g_scopes[i].projects_root);
+         free((void *)g_scopes[i].memory_seg);
+         g_scopes[i].projects_root = nr;
+         g_scopes[i].memory_seg = ns;
+         return;
+      }
+   }
+   hmem_scope_t *t = realloc(g_scopes, (g_count + 1) * sizeof(*t));
+   if (!t)
+      return;
+   g_scopes = t;
+   char *dc = strdup(client), *dr = strdup(root), *ds = strdup(seg);
+   if (!dc || !dr || !ds)
+   {
+      free(dc);
+      free(dr);
+      free(ds);
+      return;
+   }
+   g_scopes[g_count].client = dc;
+   g_scopes[g_count].projects_root = dr;
+   g_scopes[g_count].memory_seg = ds;
+   g_count++;
+}
+
+static void scope_load_config(void)
+{
+   char buf[PATH_MAX];
+   const char *path = getenv("AIMEE_HARNESS_MEMORY_SCOPES");
+   if (!path || !path[0])
+   {
+      const char *home = aimee_home();
+      if (!home || !home[0])
+         return;
+      if ((size_t)snprintf(buf, sizeof(buf), "%s/harness_memory_scopes.conf", home) >= sizeof(buf))
+         return;
+      path = buf;
+   }
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return;
+   char line[PATH_MAX * 2];
+   while (fgets(line, sizeof(line), f))
+   {
+      char cl[64], rt[PATH_MAX], sg[128];
+      if (hmem_scope_parse_line(line, cl, sizeof(cl), rt, sizeof(rt), sg, sizeof(sg)) == 0)
+         scope_add_or_override(cl, rt, sg);
+   }
+   fclose(f);
+}
+
+static void scope_init(void)
+{
+   for (size_t i = 0; i < sizeof(BUILTIN_SCOPES) / sizeof(BUILTIN_SCOPES[0]); i++)
+      scope_add_or_override(BUILTIN_SCOPES[i].client, BUILTIN_SCOPES[i].projects_root,
+                            BUILTIN_SCOPES[i].memory_seg);
+   scope_load_config();
+}
+
+/* The registry is built exactly once (pthread_once gives the acquire/release
+ * fences a plain flag would lack). scope_add_or_override — the only code that
+ * realloc()s the table — runs solely inside scope_init, before any pointer can
+ * escape, so the pointers hmem_scope_for_client hands back stay valid for the
+ * process lifetime. There is no reload path that would invalidate them. */
+static pthread_once_t g_once = PTHREAD_ONCE_INIT;
+static void ensure_loaded(void)
+{
+   pthread_once(&g_once, scope_init);
+}
 
 const hmem_scope_t *hmem_scope_for_client(const char *client)
 {
@@ -19,8 +202,9 @@ const hmem_scope_t *hmem_scope_for_client(const char *client)
     * footgun once the table has >1 entry). The cross-client hooks always set it. */
    if (!client || !client[0])
       return NULL;
-   for (size_t i = 0; i < sizeof(SCOPES) / sizeof(SCOPES[0]); i++)
-      if (strcmp(SCOPES[i].client, client) == 0)
-         return &SCOPES[i];
+   ensure_loaded();
+   for (size_t i = 0; i < g_count; i++)
+      if (strcmp(g_scopes[i].client, client) == 0)
+         return &g_scopes[i];
    return NULL;
 }

--- a/src/harness_memory_scope.h
+++ b/src/harness_memory_scope.h
@@ -7,6 +7,8 @@
 #ifndef DEC_HARNESS_MEMORY_SCOPE_H
 #define DEC_HARNESS_MEMORY_SCOPE_H 1
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C"
 {
@@ -23,6 +25,14 @@ extern "C"
     * NULL when the client has no registered memory surface — callers treat that
     * as "not a memory operation / nothing to hydrate". */
    const hmem_scope_t *hmem_scope_for_client(const char *client);
+
+   /* Parse one registry config line "client:projects_root:memory_seg" (each
+    * field whitespace-trimmed). Returns 0 on a valid scope (out buffers filled),
+    * 1 for a blank/comment line (skip), -1 if malformed or a field overflows its
+    * buffer. The path fields must be relative to $HOME (no leading '/' and no
+    * ".."); the client must be a bare token. PURE — testable. */
+   int hmem_scope_parse_line(const char *line, char *client, size_t client_cap, char *root,
+                             size_t root_cap, char *seg, size_t seg_cap);
 
 #ifdef __cplusplus
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -445,10 +445,10 @@ $(TESTPREFIX)/unit-test-harness-memory-spill: $(OBJDIR)/tests/test_harness_memor
 $(TESTPREFIX)/unit-test-harness-memory-audit: $(OBJDIR)/tests/test_harness_memory_audit.o $(OBJDIR)/harness_memory_audit.o $(OBJDIR)/aimee_home.o $(OBJDIR)/posix/platform_path.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-harness-memory-scope: $(OBJDIR)/tests/test_harness_memory_scope.o $(OBJDIR)/harness_memory_scope.o
+$(TESTPREFIX)/unit-test-harness-memory-scope: $(OBJDIR)/tests/test_harness_memory_scope.o $(OBJDIR)/harness_memory_scope.o $(OBJDIR)/aimee_home.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/harness_memory_scope.o $(OBJDIR)/cJSON.o
+$(TESTPREFIX)/unit-test-memory-redirect: $(OBJDIR)/tests/test_memory_redirect.o $(OBJDIR)/memory_redirect.o $(OBJDIR)/harness_memory_scope.o $(OBJDIR)/aimee_home.o $(OBJDIR)/cJSON.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-harness-memory: $(OBJDIR)/tests/test_harness_memory.o $(OBJDIR)/db1/harness_memory.o $(OBJDIR)/harness_memory_common.o $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db2/db_schema.o $(OBJDIR)/db1/db1_init.o $(OBJDIR)/db1/db1_write.o $(OBJDIR)/db1/db1_trigger.o $(OBJDIR)/db1/db1_cron_jobs.o $(OBJDIR)/db1/model_catalog.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/db1/eval.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o \

--- a/src/tests/test_harness_memory_scope.c
+++ b/src/tests/test_harness_memory_scope.c
@@ -1,26 +1,103 @@
-/* Unit tests for the per-client memory-surface registry (PR-A). */
+/* Unit tests for the per-client memory-surface registry (PR-A) and its
+ * config-file override (PR-E). */
 
 #include "harness_memory_scope.h"
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 
 int main(void)
 {
-   const hmem_scope_t *s = hmem_scope_for_client("claude");
-   assert(s && strcmp(s->client, "claude") == 0);
-   assert(strcmp(s->projects_root, ".claude/projects") == 0);
-   assert(strcmp(s->memory_seg, "memory") == 0);
+   char c[64], r[4096], g[128];
 
-   /* a missing/empty client has NO scope — never silently default to claude */
+   /* --- pure line parser --- */
+   assert(hmem_scope_parse_line("gemini:.gemini/projects:memory", c, sizeof(c), r, sizeof(r), g,
+                                sizeof(g)) == 0);
+   assert(!strcmp(c, "gemini") && !strcmp(r, ".gemini/projects") && !strcmp(g, "memory"));
+
+   /* surrounding whitespace on each field is trimmed */
+   assert(hmem_scope_parse_line("  codex : .codex/p : notes ", c, sizeof(c), r, sizeof(r), g,
+                                sizeof(g)) == 0);
+   assert(!strcmp(c, "codex") && !strcmp(r, ".codex/p") && !strcmp(g, "notes"));
+
+   /* blank and comment lines are skipped (1) */
+   assert(hmem_scope_parse_line("", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == 1);
+   assert(hmem_scope_parse_line("   \t ", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == 1);
+   assert(hmem_scope_parse_line("# a comment", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == 1);
+
+   /* malformed: too few fields */
+   assert(hmem_scope_parse_line("only:two", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("noseparators", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+
+   /* empty client or path field rejected */
+   assert(hmem_scope_parse_line(":root:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl::seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:root:", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+
+   /* path safety: a path field may not be absolute or climb out of $HOME */
+   assert(hmem_scope_parse_line("cl:/abs:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:../x:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:root:../s", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:a/../b:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:./x:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+
+   /* a Windows UNC/root path (leading backslash) is rejected. NB: drive paths
+    * like "C:\..." can't even be expressed here — ':' is the field separator. */
+   assert(hmem_scope_parse_line("cl:\\\\server\\share:seg", c, sizeof(c), r, sizeof(r), g,
+                                sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:\\rooted:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+
+   /* empty path segments (consecutive or trailing separators) are rejected */
+   assert(hmem_scope_parse_line("cl:a//b:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("cl:a/:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+
+   /* a mid-token ".." (not a path component) is allowed */
+   assert(hmem_scope_parse_line("cl:my..backup:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) ==
+          0);
+   assert(!strcmp(r, "my..backup"));
+
+   /* the client id must be a bare token (no '/', '\\', or "..") */
+   assert(hmem_scope_parse_line("a/b:root:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+   assert(hmem_scope_parse_line("a\\b:root:seg", c, sizeof(c), r, sizeof(r), g, sizeof(g)) == -1);
+
+   /* a field that overflows its buffer is rejected, never truncated */
+   {
+      char tiny[3];
+      assert(hmem_scope_parse_line("gemini:.g:m", tiny, sizeof(tiny), r, sizeof(r), g, sizeof(g)) ==
+             -1);
+   }
+
+   /* --- live registry merged with a config override file --- */
+   char tmpl[] = "/tmp/hmem_scopes_XXXXXX";
+   int fd = mkstemp(tmpl);
+   assert(fd >= 0);
+   const char *cfg = "# test scopes\n"
+                     "gemini:.gemini/projects:memory\n"
+                     "claude:.claude/projects:memory2\n"; /* overrides the claude built-in seg */
+   assert(write(fd, cfg, strlen(cfg)) == (ssize_t)strlen(cfg));
+   close(fd);
+   setenv("AIMEE_HARNESS_MEMORY_SCOPES", tmpl, 1);
+
+   /* the built-in claude row exists and its seg was overridden by the config */
+   const hmem_scope_t *s = hmem_scope_for_client("claude");
+   assert(s && !strcmp(s->client, "claude"));
+   assert(!strcmp(s->projects_root, ".claude/projects"));
+   assert(!strcmp(s->memory_seg, "memory2"));
+
+   /* a config-only client is registered */
+   const hmem_scope_t *gm = hmem_scope_for_client("gemini");
+   assert(gm && !strcmp(gm->projects_root, ".gemini/projects") &&
+          !strcmp(gm->memory_seg, "memory"));
+
+   /* a missing/empty client never silently defaults; unknown stays unknown */
    assert(hmem_scope_for_client(NULL) == NULL);
    assert(hmem_scope_for_client("") == NULL);
-
-   /* an unregistered client has no memory surface */
-   assert(hmem_scope_for_client("gemini") == NULL);
    assert(hmem_scope_for_client("nope") == NULL);
 
+   unlink(tmpl);
    printf("test_harness_memory_scope: OK\n");
    return 0;
 }


### PR DESCRIPTION
## What

Lets the central agent-memory interception support new agents — or relocate a built-in's paths — at **runtime via a config file**, with no code changes (v1.2 item: config-driven multi-client registry). The per-client registry (`harness_memory_scope`) is the single source of truth, read by both the interception detector (`memory_redirect`) and the session-start hydrator.

## Changes

- **Config source**: `AIMEE_HARNESS_MEMORY_SCOPES` (path), else `<AIMEE_HOME>/harness_memory_scopes.conf`. Each line `client:projects_root:memory_seg`; `#` comments and blank lines skipped.
- **New pure `hmem_scope_parse_line()`** (16+ unit cases): trims each field; field copies use `snprintf` (overflow → reject, never truncate); the client must be a bare token (no `/` `\\` `..`); path fields must be HOME-relative — absolute, UNC/root, and drive (`C:`) forms rejected, and any `.`/`..` **whole path component** rejected (component-aware over both `/` and `\\` separators; empty segments rejected; mid-token dots like `my..backup` allowed).
- **Registry**: lazy-loaded **once** via `pthread_once` (unconditional — winpthreads on Windows, matching the codebase). `scope_init` copies the built-ins then applies config lines via `scope_add_or_override` (override an existing client's paths, else append). New strings are built in temporaries and NULL-checked before any free/swap, so an OOM can't corrupt the table. The merged table is built fully before any pointer escapes and there is no reload path, so the pointers `hmem_scope_for_client` returns stay valid for the process lifetime.
- `claude` remains the built-in default; `NULL`/empty client still returns `NULL` (no silent default). Docs regenerated for the new env var.

## Testing

- `make unit-tests` green (scope parser + live config-override merge, incl. Windows-path and empty-segment cases).
- `make all server` + `make lint` (clang-format-19, docs-gen-check) green.
- Roundtable code-reviewed over two rounds; substantive findings (Windows path validation, component-aware `..`, trim NULL-guard, once-flag → `pthread_once`, OOM-safe override) applied. Remaining review 'blocking' items were diff-ingestion truncation artifacts ("resubmit full diff"), not code defects — the code builds, tests, and lints clean.