### PR TITLE
feat(kb): cross-repo dep graph S4b — review queue + adjudication

### DIFF
--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -8,6 +8,7 @@
 
 #include "aimee.h"
 #include "config.h"
+#include "cross_repo_review.h"
 #include "cross_repo_stats.h"
 #include "db2.h"
 #include "db_postgres.h"
@@ -24,6 +25,30 @@
 #define CRD_MAX_REPOS   256
 #define CRD_MAX_HEADERS 20000
 #define CRD_MAX_DEFS    64
+
+/* Minimal JSON string escaper for embedding a symbol into the evidence blob:
+ * escapes " \ and control bytes (< 0x20) as \uXXXX; truncates safely to cap. */
+static void crd_json_escape(const char *in, char *out, size_t cap)
+{
+   size_t o = 0;
+   if (cap == 0)
+      return;
+   for (const unsigned char *p = (const unsigned char *)(in ? in : ""); *p && o + 7 < cap; p++)
+   {
+      if (*p == '"' || *p == '\\')
+      {
+         out[o++] = '\\';
+         out[o++] = (char)*p;
+      }
+      else if (*p < 0x20)
+      {
+         o += (size_t)snprintf(out + o, cap - o, "\\u%04x", *p);
+      }
+      else
+         out[o++] = (char)*p;
+   }
+   out[o] = '\0';
+}
 
 /* ---- manifest module-id parsing (pure) ----------------------------------- */
 
@@ -292,6 +317,8 @@ typedef struct
    int distinctiveness_v;
    int64_t bsv;
    int a_filecount;
+   int include_review; /* write AMBIGUOUS candidates to the review queue (S4b) */
+   int queue_max;      /* review-queue overflow cap */
 } crd_ctx_t;
 
 /* Classify one accumulated candidate symbol (its definer rows) and, if it clears
@@ -368,6 +395,29 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
    c.definer_trusted = definer_trusted;
    c.modality = XREPO_IMPORT_STATIC;
    xrepo_classification_t cl = xrepo_classify(&c);
+
+   /* AMBIGUOUS -> review queue (§3.8), surfaced not dropped. */
+   if (cl.tier == XREPO_TIER_AMBIGUOUS && ctx->include_review)
+   {
+      int routes = (c.corroboration != XREPO_CORROB_NONE) ? 1 : 0;
+      double score = xrepo_evidence_score(distinctive ? definer_rc : 0, sites, routes);
+      /* Representative candidate_definer: deterministic across re-resolutions so
+       * the fingerprint is stable (an adjudicated row is not orphaned by a tie
+       * flip) — highest defcount, tie-broken by repo name. */
+      int rep = 0;
+      for (int i = 1; i < ndef; i++)
+         if (dcount[i] > dcount[rep] ||
+             (dcount[i] == dcount[rep] && strcmp(defs[i].repo, defs[rep].repo) < 0))
+            rep = i;
+      char esym[256];
+      crd_json_escape(sym, esym, sizeof(esym));
+      char ev[512];
+      snprintf(ev, sizeof(ev),
+               "{\"symbol\":\"%s\",\"definers\":%d,\"sites\":%d,\"files\":%d,\"reason\":\"%s\"}",
+               esym, ndef, sites, files, cl.reason ? cl.reason : "ambiguous");
+      db2_cross_repo_review_upsert(ctx->repo_set_hash, sym, ctx->project, defs[rep].repo, ev, score,
+                                   "ambiguous", 0, ctx->queue_max);
+   }
 
    if (target >= 0 && cl.tier >= ctx->min_tier && cl.tier != XREPO_TIER_AMBIGUOUS &&
        cl.tier != XREPO_TIER_NONE && cl.tier != XREPO_TIER_UNIMPLEMENTED)
@@ -501,7 +551,9 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
                     .repo_set_hash = repo_set_hash,
                     .distinctiveness_v = cfg.kb_curator_cross_repo_distinctiveness_v,
                     .bsv = bsv,
-                    .a_filecount = a_filecount};
+                    .a_filecount = a_filecount,
+                    .include_review = opts->include_review,
+                    .queue_max = cfg.kb_curator_cross_repo_review_queue_max};
 
    /* Single working-set query (no per-candidate N+1, per the S3 contract): one row
     * per (candidate symbol, definer repo) with per-symbol stats as correlated

--- a/src/db2/cross_repo_review.c
+++ b/src/db2/cross_repo_review.c
@@ -1,0 +1,203 @@
+/* cross_repo_review.c: S4b — the AMBIGUOUS cross-repo review queue + adjudication
+ * (§3.8). Portable SQL over db2 (Postgres + sqlite shim). See cross_repo_review.h. */
+
+#include "cross_repo_review.h"
+
+#include "aimee.h"
+#include "db2.h"
+#include "db2_internal.h" /* db2_now_utc */
+#include "db_postgres.h"
+#include "log.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <string.h>
+
+#define CRR_TAG "cross_repo"
+#define CRR_ERR 256
+
+static void *crr_conn(void)
+{
+   return db2_conn();
+}
+
+int db2_cross_repo_review_upsert(const char *repo_set_hash, const char *symbol,
+                                 const char *caller_repo, const char *candidate_definer,
+                                 const char *evidence_json, double evidence_score,
+                                 const char *review_class, int cross_lang, int queue_max)
+{
+   void *conn = crr_conn();
+   if (!conn || !symbol || !caller_repo)
+      return -1;
+   if (!isfinite(evidence_score)) /* NaN/Inf would defeat ASC eviction / DESC list ordering */
+      evidence_score = 0.0;
+   char err[CRR_ERR] = "";
+   char ts[32];
+   db2_now_utc(ts, sizeof(ts));
+
+   /* No separate arrival_seq counter (a MAX+1 read-then-write would race): the
+    * row's DB-assigned monotonic `id` is the FIFO tie-break — atomic and preserved
+    * across ON CONFLICT upserts. arrival_seq keeps its column default (unused). */
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn,
+       "INSERT INTO cross_repo_review_queue (repo_set_hash, symbol, caller_repo, "
+       "candidate_definer, evidence, evidence_score, status, review_class, cross_lang, updated_at) "
+       "VALUES (?1, ?2, ?3, ?4, ?5, ?6, 'open', ?7, ?8, ?9) "
+       "ON CONFLICT (repo_set_hash, symbol, caller_repo, candidate_definer) DO UPDATE SET "
+       "evidence = EXCLUDED.evidence, evidence_score = EXCLUDED.evidence_score, "
+       "review_class = EXCLUDED.review_class, cross_lang = EXCLUDED.cross_lang, updated_at = ?9",
+       err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", repo_set_hash ? repo_set_hash : "");
+   aimee_pg_bind_text(st, "?2", symbol);
+   aimee_pg_bind_text(st, "?3", caller_repo);
+   aimee_pg_bind_text(st, "?4", candidate_definer ? candidate_definer : "");
+   aimee_pg_bind_text(st, "?5", evidence_json ? evidence_json : "{}");
+   aimee_pg_bind_double(st, "?6", evidence_score);
+   aimee_pg_bind_text(st, "?7", (review_class && review_class[0]) ? review_class : "ambiguous");
+   aimee_pg_bind_int(st, "?8", cross_lang ? 1 : 0);
+   aimee_pg_bind_text(st, "?9", ts);
+   int rc = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   if (rc < 0)
+   {
+      LOG_ERROR(CRR_TAG, "review upsert failed: %s", err);
+      return -1;
+   }
+
+   /* Overflow eviction: drop the lowest (evidence_score, arrival_seq) 'open' rows
+    * beyond queue_max, accounting the drops (never silent). */
+   if (queue_max > 0)
+   {
+      int64_t cnt = 0;
+      aimee_pg_stmt_t *c = aimee_pg_prepare(
+          conn, "SELECT COUNT(*) FROM cross_repo_review_queue WHERE status = 'open'", err,
+          sizeof(err));
+      if (c)
+      {
+         if (aimee_pg_step(c, err, sizeof(err)) == AIMEE_PG_ROW)
+            cnt = aimee_pg_column_int64(c, 0);
+         aimee_pg_finalize(c);
+      }
+      if (cnt > queue_max)
+      {
+         int excess = (int)(cnt - queue_max);
+         aimee_pg_stmt_t *d =
+             aimee_pg_prepare(conn,
+                              "DELETE FROM cross_repo_review_queue WHERE id IN ("
+                              "  SELECT id FROM cross_repo_review_queue WHERE status = 'open' "
+                              "  ORDER BY evidence_score ASC, id ASC LIMIT ?1)",
+                              err, sizeof(err));
+         if (d)
+         {
+            aimee_pg_bind_int(d, "?1", excess);
+            (void)aimee_pg_step(d, err, sizeof(err));
+            aimee_pg_finalize(d);
+         }
+         aimee_pg_stmt_t *u = aimee_pg_prepare(
+             conn,
+             "UPDATE cross_repo_meta SET review_overflow_dropped = review_overflow_dropped + ?1 "
+             "WHERE id = 1",
+             err, sizeof(err));
+         if (u)
+         {
+            aimee_pg_bind_int(u, "?1", excess);
+            (void)aimee_pg_step(u, err, sizeof(err));
+            aimee_pg_finalize(u);
+         }
+         LOG_WARN(CRR_TAG, "review queue overflow: evicted %d lowest-evidence entries (cap %d)",
+                  excess, queue_max);
+      }
+   }
+   return 0;
+}
+
+int db2_cross_repo_review_list(const char *caller_repo, const char *status, xrepo_review_row_t *out,
+                               int max, int64_t *overflow_dropped)
+{
+   void *conn = crr_conn();
+   if (!conn || !out || max <= 0)
+      return -1;
+   const char *st_filter = (status && status[0]) ? status : "open";
+   int by_caller = caller_repo && caller_repo[0];
+   char err[CRR_ERR] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn,
+       by_caller
+           ? "SELECT id, symbol, caller_repo, candidate_definer, review_class, evidence_score, "
+             "cross_lang, status, evidence FROM cross_repo_review_queue "
+             "WHERE status = ?1 AND caller_repo = ?2 "
+             "ORDER BY evidence_score DESC, id DESC LIMIT ?3"
+           : "SELECT id, symbol, caller_repo, candidate_definer, review_class, evidence_score, "
+             "cross_lang, status, evidence FROM cross_repo_review_queue WHERE status = ?1 "
+             "ORDER BY evidence_score DESC, id DESC LIMIT ?2",
+       err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", st_filter);
+   if (by_caller)
+   {
+      aimee_pg_bind_text(st, "?2", caller_repo);
+      aimee_pg_bind_int(st, "?3", max);
+   }
+   else
+      aimee_pg_bind_int(st, "?2", max);
+
+   int n = 0;
+   while (n < max && aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      xrepo_review_row_t *r = &out[n];
+      memset(r, 0, sizeof(*r));
+      r->id = aimee_pg_column_int64(st, 0);
+      snprintf(r->symbol, sizeof(r->symbol), "%s", aimee_pg_column_text(st, 1));
+      snprintf(r->caller_repo, sizeof(r->caller_repo), "%s", aimee_pg_column_text(st, 2));
+      snprintf(r->candidate_definer, sizeof(r->candidate_definer), "%s",
+               aimee_pg_column_text(st, 3));
+      snprintf(r->review_class, sizeof(r->review_class), "%s", aimee_pg_column_text(st, 4));
+      r->evidence_score = aimee_pg_column_double(st, 5);
+      r->cross_lang = aimee_pg_column_int(st, 6);
+      snprintf(r->status, sizeof(r->status), "%s", aimee_pg_column_text(st, 7));
+      snprintf(r->evidence, sizeof(r->evidence), "%s", aimee_pg_column_text(st, 8));
+      n++;
+   }
+   aimee_pg_finalize(st);
+
+   if (overflow_dropped)
+   {
+      *overflow_dropped = 0;
+      aimee_pg_stmt_t *m =
+          aimee_pg_prepare(conn, "SELECT review_overflow_dropped FROM cross_repo_meta WHERE id = 1",
+                           err, sizeof(err));
+      if (m)
+      {
+         if (aimee_pg_step(m, err, sizeof(err)) == AIMEE_PG_ROW)
+            *overflow_dropped = aimee_pg_column_int64(m, 0);
+         aimee_pg_finalize(m);
+      }
+   }
+   return n;
+}
+
+int db2_cross_repo_review_set_status(int64_t id, const char *status)
+{
+   void *conn = crr_conn();
+   if (!conn || !status)
+      return -1;
+   if (strcmp(status, "accepted") != 0 && strcmp(status, "rejected") != 0)
+      return -1;
+   char err[CRR_ERR] = "";
+   char ts[32];
+   db2_now_utc(ts, sizeof(ts));
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       conn, "UPDATE cross_repo_review_queue SET status = ?1, updated_at = ?2 WHERE id = ?3", err,
+       sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", status);
+   aimee_pg_bind_text(st, "?2", ts);
+   aimee_pg_bind_int64(st, "?3", id);
+   int rc = aimee_pg_step(st, err, sizeof(err));
+   aimee_pg_finalize(st);
+   return rc < 0 ? -1 : 0;
+}

--- a/src/db2/cross_repo_review.h
+++ b/src/db2/cross_repo_review.h
@@ -1,0 +1,48 @@
+#ifndef AIMEE_CROSS_REPO_REVIEW_H
+#define AIMEE_CROSS_REPO_REVIEW_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* S4b: the AMBIGUOUS cross-repo review queue + adjudication (§3.8). Persists
+ * candidates the resolver could not confidently tier (multi-definer without
+ * corroboration, FFI, etc.) so they are surfaced, not dropped. Postgres-backed;
+ * portable SQL so it runs on the sqlite test shim.
+ * See docs/proposals/pending/cross-repo-dependency-graph.md §3.8. */
+
+typedef struct
+{
+   int64_t id;
+   char symbol[128];
+   char caller_repo[128];
+   char candidate_definer[128];
+   char review_class[16]; /* 'ambiguous' | 'ffi' */
+   double evidence_score;
+   int cross_lang;
+   char status[16]; /* 'open' | 'accepted' | 'rejected' */
+   char evidence[1024];
+} xrepo_review_row_t;
+
+/* Upsert an AMBIGUOUS candidate by its fingerprint
+ * (repo_set_hash, symbol, caller_repo, candidate_definer): inserts a new 'open'
+ * row (arrival_seq = max+1) or refreshes the evidence/score of an existing one
+ * (preserving arrival_seq + status). On overflow (> queue_max 'open' rows) evicts
+ * the lowest (evidence_score ASC, arrival_seq ASC) and bumps
+ * cross_repo_meta.review_overflow_dropped (never silent). Returns 0, -1 on error. */
+int db2_cross_repo_review_upsert(const char *repo_set_hash, const char *symbol,
+                                 const char *caller_repo, const char *candidate_definer,
+                                 const char *evidence_json, double evidence_score,
+                                 const char *review_class, int cross_lang, int queue_max);
+
+/* List queued rows, highest-evidence first. `status` filters (NULL/"" -> 'open');
+ * `caller_repo` NULL/"" -> all callers. Fills up to `max` rows, returns the count
+ * (-1 on error). *overflow_dropped receives the cumulative evicted count (the
+ * overflow.dropped indicator); may be NULL. */
+int db2_cross_repo_review_list(const char *caller_repo, const char *status, xrepo_review_row_t *out,
+                               int max, int64_t *overflow_dropped);
+
+/* Adjudicate a queued row: status must be 'accepted' or 'rejected'. Idempotent
+ * (re-setting the same status is a no-op success). Returns 0, -1 on error. */
+int db2_cross_repo_review_set_status(int64_t id, const char *status);
+
+#endif /* AIMEE_CROSS_REPO_REVIEW_H */

--- a/src/db2/schema.sql
+++ b/src/db2/schema.sql
@@ -1243,6 +1243,11 @@ CREATE TABLE IF NOT EXISTS cross_repo_meta (
 -- a DO UPDATE that reset them to defaults would destroy monotonicity. All columns are runtime-owned
 -- after creation, so there is nothing seed-owned to refresh.
 INSERT INTO cross_repo_meta (id) VALUES (1) ON CONFLICT (id) DO NOTHING;
+-- S4b: cumulative count of AMBIGUOUS review-queue rows evicted on overflow (§3.8),
+-- surfaced as overflow.dropped. ALTER (not in the CREATE) so it lands on the
+-- existing single-row table from S1.
+ALTER TABLE cross_repo_meta
+    ADD COLUMN IF NOT EXISTS review_overflow_dropped BIGINT NOT NULL DEFAULT 0;
 
 -- blocked_symbols (§3.3): corpus-derived non-distinctive set, recomputed over trusted repos only.
 -- Replaces the static blocklist; `version` lets a tier decision replay against the exact frequency

--- a/src/db2/schema_sqlite.sql
+++ b/src/db2/schema_sqlite.sql
@@ -323,7 +323,7 @@ CREATE INDEX IF NOT EXISTS idx_ee_projection_generation ON entity_edges(projecti
 -- Per-dialect deltas vs schema.sql: evidence is TEXT here (JSONB on Postgres); timestamps use
 -- datetime('now'); ids are AUTOINCREMENT. Table set is kept in parity by schema-sync-check.
 CREATE INDEX IF NOT EXISTS idx_projects_trust ON projects(trust);
-CREATE TABLE IF NOT EXISTS cross_repo_meta (  id INTEGER PRIMARY KEY CHECK (id = 1),  trust_epoch INTEGER NOT NULL DEFAULT 0 CHECK (trust_epoch >= 0),  repo_set_hash TEXT NOT NULL DEFAULT '',  blocked_symbols_version INTEGER NOT NULL DEFAULT 0 CHECK (blocked_symbols_version >= 0),  updated_at TEXT NOT NULL DEFAULT (datetime('now')));
+CREATE TABLE IF NOT EXISTS cross_repo_meta (  id INTEGER PRIMARY KEY CHECK (id = 1),  trust_epoch INTEGER NOT NULL DEFAULT 0 CHECK (trust_epoch >= 0),  repo_set_hash TEXT NOT NULL DEFAULT '',  blocked_symbols_version INTEGER NOT NULL DEFAULT 0 CHECK (blocked_symbols_version >= 0),  review_overflow_dropped INTEGER NOT NULL DEFAULT 0,  updated_at TEXT NOT NULL DEFAULT (datetime('now')));
 -- INSERT OR IGNORE only guarantees the singleton row exists; it must not clobber live runtime counters on re-apply (see schema.sql).
 INSERT OR IGNORE INTO cross_repo_meta (id) VALUES (1);
 CREATE TABLE IF NOT EXISTS blocked_symbols (  word TEXT NOT NULL,  lang TEXT NOT NULL DEFAULT '',  reason TEXT NOT NULL DEFAULT '',  version INTEGER NOT NULL DEFAULT 0,  created_at TEXT NOT NULL DEFAULT (datetime('now')),  updated_at TEXT NOT NULL DEFAULT (datetime('now')),  PRIMARY KEY (word, lang));

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -90,6 +90,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-cross-repo-deps \
                $(TESTPREFIX)/unit-test-cross-repo-stats \
                $(TESTPREFIX)/unit-test-cross-repo-deps-orch \
+               $(TESTPREFIX)/unit-test-cross-repo-review \
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-webchat-claude-sessions \
                $(TESTPREFIX)/unit-test-turn-registry \
@@ -497,6 +498,16 @@ $(TESTPREFIX)/unit-test-cross-repo-deps-orch: \
                                        $(OBJDIR)/db2/cross_repo_stats.o \
                                        $(OBJDIR)/db2/cross_repo_resolver.o \
                                        $(OBJDIR)/db2/cross_repo_classify.o \
+                                       $(OBJDIR)/db2/cross_repo_review.o \
+                                       $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
+                                       $(OBJDIR)/db2/db_schema.o \
+                                       $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
+
+# S4b review queue + adjudication over the sqlite shim.
+$(TESTPREFIX)/unit-test-cross-repo-review: \
+                                       $(OBJDIR)/tests/test_cross_repo_review.o \
+                                       $(OBJDIR)/db2/cross_repo_review.o \
                                        $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
                                        $(OBJDIR)/db2/db_schema.o \
                                        $(TEST_CORE_OBJS)

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -8,6 +8,7 @@
 #include "aimee.h"
 #include "db2_test_shim.h"
 #include "../db2/cross_repo_deps.h"
+#include "../db2/cross_repo_review.h"
 #include "../db2/db2.h"
 #include "../db2/db_postgres.h"
 
@@ -118,12 +119,54 @@ static void test_end_to_end(void)
    printf("ok\n");
 }
 
+/* A symbol defined in two trusted repos that A imports NEITHER of, called in A:
+ * multi-definer without corroboration -> AMBIGUOUS -> review queue (no edge). */
+static void test_ambiguous_to_review(void)
+{
+   printf("test_ambiguous_to_review... ");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('lib-x','/x','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('lib-y','/y','t','trusted')");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'x.c','t' FROM projects WHERE "
+     "name='lib-x'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'y.c','t' FROM projects WHERE "
+     "name='lib-y'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'AmbiguousThing','definition' FROM files "
+     "WHERE path='x.c'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'AmbiguousThing','definition' FROM files "
+     "WHERE path='y.c'");
+   /* called in 1 of moonlight-qt's 5 files (20% -> distinctive); A imports neither. */
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'AmbiguousThing' FROM files WHERE "
+     "path='src/a.cpp'");
+
+   xrepo_deps_opts_t opts = {
+       .direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM, .include_review = 1};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+   assert(canonical_index_cross_repo_deps("moonlight-qt", &opts, &edges, &n, &trunc) == 0);
+   /* still just the moonlight edge; AmbiguousThing did NOT emit an edge. */
+   for (size_t i = 0; i < n; i++)
+      assert(strcmp(edges[i].example_symbol, "AmbiguousThing") != 0);
+   free(edges);
+
+   /* but it WAS surfaced to the review queue. */
+   xrepo_review_row_t rows[16];
+   int rn = db2_cross_repo_review_list("moonlight-qt", "open", rows, 16, NULL);
+   int found = 0;
+   for (int i = 0; i < rn; i++)
+      if (strcmp(rows[i].symbol, "AmbiguousThing") == 0)
+         found = 1;
+   assert(found);
+   printf("ok\n");
+}
+
 int main(void)
 {
    test_parse_module_id();
    db2_test_shim_open();
    test_empty_graceful();
    test_end_to_end();
+   test_ambiguous_to_review();
    printf("cross_repo_deps_orch: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_cross_repo_review.c
+++ b/src/tests/test_cross_repo_review.c
@@ -1,0 +1,100 @@
+/* test_cross_repo_review.c: S4b review queue + adjudication over the sqlite shim:
+ * upsert/fingerprint-dedup, list ordering, accept/reject, overflow eviction. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "db2_test_shim.h"
+#include "../db2/cross_repo_review.h"
+#include "../db2/db2.h"
+#include "../db2/db_postgres.h"
+
+static int up(const char *sym, const char *caller, const char *definer, double score, int qmax)
+{
+   return db2_cross_repo_review_upsert("rsh1", sym, caller, definer, "{}", score, "ambiguous", 0,
+                                       qmax);
+}
+
+static void clear_queue(void)
+{
+   char e[256] = "";
+   aimee_pg_exec(db2_conn(), "DELETE FROM cross_repo_review_queue", e, sizeof(e));
+   aimee_pg_exec(db2_conn(), "UPDATE cross_repo_meta SET review_overflow_dropped = 0 WHERE id = 1",
+                 e, sizeof(e));
+}
+
+static void test_upsert_list(void)
+{
+   printf("test_upsert_list... ");
+   assert(up("render", "appA", "libX", 3.0, 5000) == 0);
+   assert(up("update", "appA", "libY", 7.0, 5000) == 0);
+   /* same fingerprint -> upsert (no dup); refresh score. */
+   assert(up("render", "appA", "libX", 9.0, 5000) == 0);
+
+   xrepo_review_row_t rows[16];
+   int64_t dropped = -1;
+   int n = db2_cross_repo_review_list(NULL, "open", rows, 16, &dropped);
+   assert(n == 2); /* render upserted, not duplicated */
+   /* ordered by evidence_score DESC: render(9) before update(7). */
+   assert(strcmp(rows[0].symbol, "render") == 0 && rows[0].evidence_score > 8.9);
+   assert(strcmp(rows[1].symbol, "update") == 0);
+   assert(dropped == 0);
+
+   /* filter by caller. */
+   assert(up("foo_sym", "appB", "libZ", 1.0, 5000) == 0);
+   n = db2_cross_repo_review_list("appA", "open", rows, 16, NULL);
+   assert(n == 2);
+   n = db2_cross_repo_review_list("appB", "open", rows, 16, NULL);
+   assert(n == 1 && strcmp(rows[0].symbol, "foo_sym") == 0);
+   printf("ok\n");
+}
+
+static void test_adjudicate(void)
+{
+   printf("test_adjudicate... ");
+   xrepo_review_row_t rows[16];
+   int n = db2_cross_repo_review_list("appA", "open", rows, 16, NULL);
+   assert(n >= 1);
+   int64_t id = rows[0].id;
+   assert(db2_cross_repo_review_set_status(id, "accepted") == 0);
+   assert(db2_cross_repo_review_set_status(id, "bogus") == -1); /* invalid status */
+   /* now one fewer open for appA; the accepted one shows under status=accepted. */
+   int open_after = db2_cross_repo_review_list("appA", "open", rows, 16, NULL);
+   assert(open_after == n - 1);
+   int acc = db2_cross_repo_review_list("appA", "accepted", rows, 16, NULL);
+   assert(acc == 1 && rows[0].id == id);
+   printf("ok\n");
+}
+
+static void test_overflow_eviction(void)
+{
+   printf("test_overflow_eviction... ");
+   /* The overflow cap is global, so isolate: clear the queue, then cap=2 + insert
+    * 4 with increasing score -> the 2 lowest-evidence are evicted, dropped == 2. */
+   clear_queue();
+   for (int i = 0; i < 4; i++)
+   {
+      char sym[32];
+      snprintf(sym, sizeof(sym), "ovf_sym_%d", i);
+      assert(up(sym, "ovfCaller", "libO", (double)(i + 1), 2) == 0);
+   }
+   xrepo_review_row_t rows[16];
+   int64_t dropped = 0;
+   int n = db2_cross_repo_review_list("ovfCaller", "open", rows, 16, &dropped);
+   assert(n == 2); /* capped */
+   /* highest-evidence survive: scores 4 and 3. */
+   assert(rows[0].evidence_score > 3.9 && rows[1].evidence_score > 2.9);
+   assert(dropped >= 2); /* cumulative evictions surfaced */
+   printf("ok\n");
+}
+
+int main(void)
+{
+   db2_test_shim_open();
+   test_upsert_list();
+   test_adjudicate();
+   test_overflow_eviction();
+   printf("cross_repo_review: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary
Sixth slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md`), on S4a (#810). New `db2/cross_repo_review.{c,h}` — the AMBIGUOUS review queue + adjudication (§3.8), so candidates the resolver can't confidently tier (multi-definer without corroboration, FFI, …) are **surfaced, not dropped**.

- **`db2_cross_repo_review_upsert`** — fingerprint upsert `(repo_set_hash, symbol, caller_repo, candidate_definer)`; on overflow (> `queue_max` open rows) evicts the lowest `(evidence_score, id)` and bumps `cross_repo_meta.review_overflow_dropped` (logged, never silent).
- **`db2_cross_repo_review_list`** — highest-evidence-first, status + caller filters, returns the cumulative `overflow.dropped`.
- **`db2_cross_repo_review_set_status`** — accept/reject adjudication.
- **schema** — `cross_repo_meta.review_overflow_dropped` (ALTER on Postgres / inline on the shim).
- **S4a wiring** — `crd_flush` routes AMBIGUOUS candidates to the queue when `include_review`, with escaped evidence JSON + `xrepo_evidence_score`.

## Tests / gates
`test_cross_repo_review.c`: upsert/fingerprint-dedup, list ordering, accept/reject (+ invalid-status reject), overflow eviction with the `dropped` counter. `test_cross_repo_deps_orch.c` extended: a multi-definer-without-corroboration symbol → **no edge, surfaced to the review queue**. All pass; clang-format + schema-sync clean.

## Review
Code-review roundtable; 4 blocking resolved: (1) evidence JSON now escapes the symbol (`crd_json_escape`); (2) the `arrival_seq` `MAX+1` read-then-write race replaced with the DB-assigned monotonic `id` as the FIFO tie-break; (3) `candidate_definer` made deterministic (max defcount, tie-break repo name) so an adjudicated fingerprint isn't orphaned by a tie flip; (4) `isfinite` guard on `evidence_score` (NaN/Inf can't defeat eviction/list ordering).