### PR TITLE
feat(hmem): resolve harness-memory project key client-side for remote servers

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -14,7 +14,9 @@
 #include "cli_profile.h"
 #include "client_constants.h"
 #include "client_integrations.h"
-#include "code_collect.h" /* code_index_install_branch_hook (index watch) */
+#include "code_collect.h"          /* code_index_install_branch_hook (index watch) */
+#include "harness_memory_audit.h"  /* hmem_audit (diagnostic when project unresolved) */
+#include "harness_memory_common.h" /* hmem_resolve_project (client-side project key) */
 #include "delegate_plan.h"
 #include "cli_tui.h"
 #include "platform.h"
@@ -705,6 +707,23 @@ static int handle_hooks(int argc, char **argv, int json_output)
    cJSON_AddStringToObject(req, "cwd", cwd);
    if (sid && sid[0])
       cJSON_AddStringToObject(req, "session_id", sid);
+
+   /* Resolve the harness-memory project key HERE, on the client, against the real
+    * cwd / git repo / AIMEE_PROJECT_ID, and forward it: a remote server's
+    * filesystem has none of those, so it could not resolve the key itself. Only
+    * the pre phase intercepts memory writes, so skip the git fork on post. */
+   if (strcmp(phase, "pre") == 0 && cwd[0])
+   {
+      char hproject[256], hroot[4096];
+      if (hmem_resolve_project(cwd, hproject, sizeof(hproject), hroot, sizeof(hroot)) == 0 &&
+          hproject[0])
+         cJSON_AddStringToObject(req, "harness_project", hproject);
+      else
+         /* Couldn't resolve client-side: the server falls back to cwd resolution,
+          * which fails on a remote server (memory interception then no-ops). Audit
+          * so this is observable rather than a silent miss. */
+         hmem_audit("project-unresolved", NULL, NULL, "hooks pre");
+   }
 
    cJSON *resp = cli_v1_dispatch_local(req, 5000);
    cJSON_Delete(req);

--- a/src/cmd_hooks.c
+++ b/src/cmd_hooks.c
@@ -236,8 +236,16 @@ void cmd_hooks(app_ctx_t *ctx, int argc, char **argv)
          cJSON *ti = (tool_input && tool_input[0]) ? cJSON_Parse(tool_input) : NULL;
          if (ti)
          {
+            /* The thin client resolves the project against the real cwd/git repo
+             * and forwards it; required when this server is remote. Sourced from
+             * the top-level hook input only — any value nested in tool_input is
+             * intentionally ignored (the agent must not pick its own store key). */
+            const char *hp = NULL;
+            cJSON *hpj = cJSON_GetObjectItemCaseSensitive(json, "harness_project");
+            if (cJSON_IsString(hpj) && hpj->valuestring && hpj->valuestring[0])
+               hp = hpj->valuestring;
             char mr_msg[1024] = "";
-            int mr = memory_redirect_check(tool_name, ti, cwd, mr_msg, sizeof(mr_msg));
+            int mr = memory_redirect_check(tool_name, ti, cwd, hp, mr_msg, sizeof(mr_msg));
             cJSON_Delete(ti);
             if (mr == 2)
             {

--- a/src/harness_memory_common.c
+++ b/src/harness_memory_common.c
@@ -298,6 +298,17 @@ static int git_toplevel(const char *cwd, char *out, size_t cap)
 }
 #endif /* !_WIN32 */
 
+int hmem_project_key_ok(const char *key)
+{
+   if (!key || !key[0])
+      return 0;
+   size_t n = 0;
+   for (const unsigned char *p = (const unsigned char *)key; *p; p++, n++)
+      if (*p < 0x20 || *p == 0x7f) /* control char / newline */
+         return 0;
+   return n < HMEM_PROJECT_KEY_MAX;
+}
+
 int hmem_resolve_project(const char *cwd, char *id_out, size_t id_cap, char *root_out,
                          size_t root_cap)
 {

--- a/src/harness_memory_common.h
+++ b/src/harness_memory_common.h
@@ -50,6 +50,18 @@ extern "C"
    int hmem_resolve_project(const char *cwd, char *id_out, size_t id_cap, char *root_out,
                             size_t root_cap);
 
+/* Size of the project-key buffers throughout the harness-memory paths; the
+ * validator and every consumer size against this so they stay in lockstep. */
+#define HMEM_PROJECT_KEY_MAX 256
+
+   /* Validate a project key received over the wire (e.g. a client-resolved key a
+    * remote server cannot re-derive). A key is an opaque namespace string —
+    * typically a repo path, so '/' is allowed — but must be non-empty, shorter
+    * than HMEM_PROJECT_KEY_MAX (the store buffer), and free of control characters
+    * (which hmem_resolve_project never emits and which would corrupt audit/JSON
+    * lines). Returns 1 if acceptable, 0 otherwise. PURE — testable. */
+   int hmem_project_key_ok(const char *key);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -247,7 +247,8 @@ int memory_redirect_bash_targets_memory(const char *client, const char *command,
    return 0;
 }
 
-int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *msg, size_t msg_len)
+int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, const char *project_hint,
+                          char *msg, size_t msg_len)
 {
    if (!root)
       return 0;
@@ -299,9 +300,19 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *
       snprintf(msg, msg_len, "Memory Write needs a string 'content' field.");
       return 2;
    }
-   char project[256], rootdir[PATH_MAX];
-   if (hmem_resolve_project(cwd, project, sizeof(project), rootdir, sizeof(rootdir)) != 0)
+   /* Prefer the client-resolved project key (correct for a remote server, whose
+    * filesystem lacks the client's cwd/git repo); validate it first since it
+    * arrives over the wire, then fall back to resolving from cwd for a local
+    * server or an older client that doesn't send the hint. */
+   char project[HMEM_PROJECT_KEY_MAX], rootdir[PATH_MAX];
+   if (project_hint && hmem_project_key_ok(project_hint))
+   {
+      snprintf(project, sizeof(project), "%s", project_hint);
+   }
+   else if (hmem_resolve_project(cwd, project, sizeof(project), rootdir, sizeof(rootdir)) != 0)
+   {
       return 0; /* can't identify the project — fail open */
+   }
 
    cJSON *body = cJSON_CreateObject();
    cJSON_AddStringToObject(body, "project", project);

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -48,9 +48,15 @@ extern "C"
     * to /v1/harness_memory/upsert + re-materialize the file) and returns a
     * pre_tool_check verdict: 0 = allow, 2 = deny (msg holds the agent-facing
     * reason). Fail-open: if the store is unreachable it returns 0 (allow) so the
-    * agent is never blocked by our outage. */
-   int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, char *msg,
-                             size_t msg_len);
+    * agent is never blocked by our outage.
+    *
+    * project_hint: when non-empty, the project key to store under, resolved by
+    * the caller (the thin client, where the real cwd / git repo / AIMEE_PROJECT_ID
+    * live). This is REQUIRED for a remote server, whose filesystem has neither the
+    * client's cwd nor its git repo; when NULL/empty the project is resolved from
+    * cwd as a local-server fallback. */
+   int memory_redirect_check(const char *tool, cJSON *root, const char *cwd,
+                             const char *project_hint, char *msg, size_t msg_len);
 
 #ifdef __cplusplus
 }

--- a/src/tests/test_harness_memory.c
+++ b/src/tests/test_harness_memory.c
@@ -79,11 +79,35 @@ static void test_resolve(void)
    assert(strcmp(id2, root2) == 0);
 }
 
+static void test_project_key_ok(void)
+{
+   /* path-shaped keys (the common case) and opaque ids are accepted */
+   assert(hmem_project_key_ok("/home/u/dev/aimee") == 1);
+   assert(hmem_project_key_ok("proj-xyz") == 1);
+   /* empty / NULL rejected */
+   assert(hmem_project_key_ok(NULL) == 0);
+   assert(hmem_project_key_ok("") == 0);
+   /* control chars / newlines rejected (would corrupt audit/JSON lines) */
+   assert(hmem_project_key_ok("a\nb") == 0);
+   assert(hmem_project_key_ok("a\tb") == 0);
+   assert(hmem_project_key_ok("a\x7f"
+                              "b") == 0);
+   /* length: 255 ok, 256 rejected (store buffer is char[256]) */
+   char big[300];
+   memset(big, 'x', sizeof(big));
+   big[255] = '\0'; /* 255 chars */
+   assert(hmem_project_key_ok(big) == 1);
+   big[255] = 'x';
+   big[256] = '\0'; /* 256 chars */
+   assert(hmem_project_key_ok(big) == 0);
+}
+
 int main(void)
 {
    test_sha();
    test_hash();
    test_resolve();
+   test_project_key_ok();
    assert(db1_init(":memory:") == 0);
 
    /* upsert + get (nested name round-trips) */


### PR DESCRIPTION
## What

Fixes central agent-memory interception when the aimee-server is **remote** (v1.2 item: remote-server project-key resolution).

## Problem

The pre-tool hook's memory interception (`memory_redirect_check`) runs in the **aimee-server** process. It resolved the project key via `hmem_resolve_project(cwd)` — which runs `git rev-parse --show-toplevel` / `realpath` on `cwd`. For a remote server, `cwd` is the *client's* path and the server's filesystem has neither that directory nor the git repo, so resolution failed and interception **fail-opened (stored nothing)**. Worse, session-start hydrate already resolves client-side, so for a remote server the two paths used different keys → stored memory was unfindable.

## Fix

Resolve the project key on the **thin client** (real cwd / git toplevel / `AIMEE_PROJECT_ID`) in `aimee hooks pre` and forward it as `harness_project`; the server prefers that hint. Redirect and hydrate now agree on the key for both local and remote servers.

- **cli_main `handle_hooks`**: resolve + send `harness_project` (pre phase only — post doesn't intercept, avoiding an extra git fork); audit `project-unresolved` when resolution fails (observability).
- **cmd_hooks**: extract `harness_project` from the top-level hook input (NULL-safe; nested `tool_input` values ignored), pass to `memory_redirect_check`.
- **memory_redirect_check**: new `project_hint` param, used only when it passes the new validator; else falls back to `cwd` resolution (local server / older client).
- **New pure `hmem_project_key_ok()`**: the key arrives over the wire, so validate server-side — non-empty, < `HMEM_PROJECT_KEY_MAX` (256), no control chars. `/` is allowed (keys are repo paths). Unit-tested.

## Notes

Single-user / auth-off deployment: the key is a namespace within one user's store (not a cross-tenant boundary), and the client already controlled it via `cwd` before this PR — so the validator is canonicalization/hardening, not a new trust boundary. The key is a parameterized SQL value + sha256-hashed for the spill dir; never a server filesystem path.

## Testing

- `make unit-tests` (new `hmem_project_key_ok` cases) + `make all server` + `make lint` green.
- Roundtable-reviewed over two rounds; the round-1 blocker (unvalidated client key) and all actionable findings (NULL-guard, fallback audit, named constant) applied. Remaining review 'blockers' were diff-ingestion truncation artifacts. End-to-end remote validation is covered by the live-deploy task.