### PR TITLE
fix(hmem): wire central memory interception into the split-server hook path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1399,6 +1399,10 @@ add_executable(aimee-server
     ${SERVER_CORE_SRCS}
     ${DB1_SRCS}
     ${GIT_SRCS}
+    # server.c's hooks.pre handler intercepts agent memory writes via the
+    # transport-free helpers in memory_redirect.c (classify/bash/rematerialize);
+    # it lives in CMD_SRCS, which the server does not otherwise link.
+    ${AIMEE_SRC_DIR}/memory_redirect.c
 )
 add_dependencies(aimee-server agent_help_header tool_prompts_header schema_data_header)
 target_include_directories(aimee-server PRIVATE

--- a/src/Makefile
+++ b/src/Makefile
@@ -393,6 +393,7 @@ SERVER_DATA_OBJS = $(SERVER_DATA_SRCS:%.c=$(OBJDIR)/server/%.o) \
 # pattern rule.
 SERVER_CMD_OBJS = $(OBJDIR)/server/cmd_session_lifecycle.o \
                   $(OBJDIR)/server/cmd_hooks_scope.o \
+                  $(OBJDIR)/memory_redirect.o \
                   $(OBJDIR)/server/server_session_start_stubs.o
 
 # kb_client objects — request-side glue from the daemon to the

--- a/src/memory_redirect.c
+++ b/src/memory_redirect.c
@@ -14,6 +14,7 @@
 #include "harness_memory_common.h"
 #include "harness_memory_scope.h"
 #include "harness_memory_spill.h"
+#include "platform_path.h" /* platform_mkdir_p */
 
 #include <ctype.h>
 #include <stdio.h>
@@ -124,8 +125,8 @@ static const char *json_str(cJSON *o, const char *key)
  * cannot re-enter the PreToolUse hook). The parent dir is realpath-resolved and
  * confined under ~/.claude/projects/, so a symlinked component can't redirect
  * the write outside the memory tree. Atomic (temp + rename) on POSIX. */
-static int rematerialize(const char *path, const char *content, const char *home,
-                         const char *projects_root)
+int memory_redirect_rematerialize(const char *path, const char *content, const char *home,
+                                  const char *projects_root)
 {
    const char *base = strrchr(path, '/');
    if (!base)
@@ -135,6 +136,18 @@ static int rematerialize(const char *path, const char *content, const char *home
    int dn = (int)(base - 1 - path);
    snprintf(dir, sizeof(dir), "%.*s", dn, path);
    size_t len = strlen(content);
+
+   /* Confine BEFORE any on-disk side effect: the parent must be syntactically
+    * under <home>/<projects_root>/ with no ".." segment. This gates the mkdir
+    * itself (so a bad path can't create dirs outside the memory tree) and is the
+    * ONLY confinement on Windows, where the realpath gate below is compiled out.
+    * On POSIX the realpath()+under_projects_root check additionally defeats a
+    * symlinked component. */
+   if (!under_projects_root(dir, home, projects_root) || strstr(dir, ".."))
+      return -1;
+   /* Create the memory dir tree if absent so a first write to a fresh project
+    * materializes. */
+   platform_mkdir_p(dir, 0700);
 
 #ifndef _WIN32
    char rp[PATH_MAX];
@@ -353,7 +366,8 @@ int memory_redirect_check(const char *tool, cJSON *root, const char *cwd, const 
    cJSON_Delete(resp);
 
    const hmem_scope_t *scope = hmem_scope_for_client(client); /* non-NULL: classify redirected */
-   rematerialize(path, content, home, scope ? scope->projects_root : ".claude/projects");
+   memory_redirect_rematerialize(path, content, home,
+                                 scope ? scope->projects_root : ".claude/projects");
    hmem_audit("redirect", project, name, NULL);
    snprintf(msg, msg_len,
             "Saved to aimee memory (id=%ld). The file now reflects your content — do not "

--- a/src/memory_redirect.h
+++ b/src/memory_redirect.h
@@ -58,6 +58,14 @@ extern "C"
    int memory_redirect_check(const char *tool, cJSON *root, const char *cwd,
                              const char *project_hint, char *msg, size_t msg_len);
 
+   /* Re-materialize a memory file with aimee's own I/O (atomic temp+rename on
+    * POSIX), confined under <home>/<projects_root>/ via realpath so a symlinked
+    * component cannot redirect the write out of the memory tree. Used by the
+    * server-side interception (which writes DB1 directly) to mirror the stored
+    * row back to disk. Returns 0 on success, -1 otherwise. */
+   int memory_redirect_rematerialize(const char *path, const char *content, const char *home,
+                                     const char *projects_root);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -3,7 +3,12 @@
 #define _GNU_SOURCE
 #endif
 #include "aimee.h"
-#include "json_fluent.h" /* jo_ok */
+#include "harness_memory.h"        /* hmem_upsert (server owns DB1) */
+#include "harness_memory_audit.h"  /* hmem_audit */
+#include "harness_memory_common.h" /* hmem_resolve_project / hmem_project_key_ok */
+#include "harness_memory_scope.h"  /* hmem_scope_for_client */
+#include "json_fluent.h"           /* jo_ok */
+#include "memory_redirect.h"       /* memory_redirect_classify / _bash_targets / _rematerialize */
 #include "server.h"
 #include "turn_registry.h"
 #include "server_http.h" /* server_http_api_status_report */
@@ -707,6 +712,119 @@ static int handle_hud_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    return server_send_ok(conn, parsed);
 }
 
+/* Server-side central agent-memory interception. The split server owns DB1, so
+ * (unlike the CLI path's HTTP POST) it writes the store directly via hmem_upsert
+ * and mirrors the row back to disk. Returns 2 (deny — msg set) when a memory op
+ * was intercepted/rejected, else 0 (allow). Fail-open: any inability to identify
+ * or store returns 0 so a normal tool call is never blocked by this stage. */
+static int server_memory_intercept(const char *tool, const char *tool_input, const char *cwd,
+                                   cJSON *req, char *msg, size_t msg_len)
+{
+   const char *client = getenv("AIMEE_HOOK_CLIENT");
+   const char *home = getenv("HOME");
+   if (!client || !client[0] || !home || !home[0])
+      return 0;
+   const hmem_scope_t *scope = hmem_scope_for_client(client);
+   if (!scope)
+      return 0;
+   cJSON *ti = tool_input ? cJSON_Parse(tool_input) : NULL;
+   if (!ti)
+      return 0;
+
+   int verdict = 0;
+
+   /* Bash bypass: a shell command that writes a memory file is reject-denied (we
+    * can't capture its output) — steer the agent to the Write tool. */
+   if (strcmp(tool, "Bash") == 0)
+   {
+      cJSON *jc = cJSON_GetObjectItemCaseSensitive(ti, "command");
+      const char *cmd = (jc && cJSON_IsString(jc)) ? jc->valuestring : NULL;
+      if (cmd && memory_redirect_bash_targets_memory(client, cmd, home))
+      {
+         snprintf(msg, msg_len,
+                  "Memory files are managed by aimee — use the Write tool to set "
+                  "memory/<name>.md, not shell redirection.");
+         hmem_audit("reject", NULL, NULL, "bash-write-memory");
+         verdict = 2;
+      }
+      cJSON_Delete(ti);
+      return verdict;
+   }
+
+   cJSON *jp = cJSON_GetObjectItemCaseSensitive(ti, "file_path");
+   if (!jp || !cJSON_IsString(jp))
+      jp = cJSON_GetObjectItemCaseSensitive(ti, "path");
+   const char *path = (jp && cJSON_IsString(jp)) ? jp->valuestring : NULL;
+   if (!path)
+   {
+      cJSON_Delete(ti);
+      return 0;
+   }
+
+   char name[HMEM_NAME_LEN];
+   const char *reason = NULL;
+   mr_verdict_t v = memory_redirect_classify(client, tool, path, home, name, sizeof(name), &reason);
+   if (v == MR_ALLOW)
+   {
+      cJSON_Delete(ti);
+      return 0;
+   }
+   if (v == MR_REJECT)
+   {
+      snprintf(msg, msg_len, "%s", reason ? reason : "memory write rejected");
+      hmem_audit("reject", NULL, NULL, reason);
+      cJSON_Delete(ti);
+      return 2;
+   }
+
+   /* MR_REDIRECT: a Write with no string content is invalid — never store an
+    * empty body over an existing entry. */
+   cJSON *jcont = cJSON_GetObjectItemCaseSensitive(ti, "content");
+   const char *content = (jcont && cJSON_IsString(jcont)) ? jcont->valuestring : NULL;
+   if (!content)
+   {
+      snprintf(msg, msg_len, "Memory Write needs a string 'content' field.");
+      cJSON_Delete(ti);
+      return 2;
+   }
+
+   /* Project key: prefer the client-resolved hint (correct for a remote server),
+    * else resolve from cwd (local server). */
+   char project[HMEM_PROJECT_KEY_MAX], rootdir[1024];
+   const char *hp = NULL;
+   cJSON *hpj = cJSON_GetObjectItemCaseSensitive(req, "harness_project");
+   if (cJSON_IsString(hpj) && hpj->valuestring && hpj->valuestring[0])
+      hp = hpj->valuestring;
+   if (hp && hmem_project_key_ok(hp))
+      snprintf(project, sizeof(project), "%s", hp);
+   else if (hmem_resolve_project(cwd, project, sizeof(project), rootdir, sizeof(rootdir)) != 0)
+   {
+      cJSON_Delete(ti); /* can't identify the project — fail open */
+      return 0;
+   }
+
+   hmem_row_t row;
+   memset(&row, 0, sizeof(row));
+   snprintf(row.project, sizeof(row.project), "%s", project);
+   snprintf(row.name, sizeof(row.name), "%s", name);
+   snprintf(row.type, sizeof(row.type), "%s", "fact");
+   snprintf(row.last_client, sizeof(row.last_client), "%s", client);
+   row.body = (char *)content; /* borrowed; hmem_upsert binds TRANSIENT */
+   if (hmem_upsert(&row, NULL) != 0)
+   {
+      cJSON_Delete(ti); /* store failed — fail open rather than block the agent */
+      return 0;
+   }
+   memory_redirect_rematerialize(path, content, home, scope->projects_root);
+   hmem_audit("redirect", project, name, NULL);
+   snprintf(msg, msg_len,
+            "Saved to aimee's central memory store as memory/%s.md (aimee manages these "
+            "files; it has been written for you).",
+            name);
+   cJSON_Delete(ti);
+   return 2;
+}
+
 static int handle_hooks_pre(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    cJSON *jtn = cJSON_GetObjectItemCaseSensitive(req, "tool_name");
@@ -746,6 +864,29 @@ static int handle_hooks_pre(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
    session_state_t state;
    session_state_load(&state, sid);
    hooks_ensure_cwd_worktree(&state, sid, cwd);
+
+   /* Memory interception: redirect an agent's local memory-file write into the
+    * central store BEFORE the generic guardrails see it (a memory write must not
+    * be tripped by e.g. the worktree guardrail). rc==2 with a message is rendered
+    * by the client as a PreToolUse deny. */
+   {
+      char mr_msg[1024] = "";
+      if (server_memory_intercept(tool_name, tool_input, cwd, req, mr_msg, sizeof(mr_msg)) == 2)
+      {
+         cJSON *mresp = cJSON_CreateObject();
+         cJSON_AddStringToObject(mresp, "status", "blocked");
+         cJSON_AddNumberToObject(mresp, "exit_code", 2);
+         if (mr_msg[0])
+            cJSON_AddStringToObject(mresp, "message", mr_msg);
+         if (request_id)
+            cJSON_AddStringToObject(mresp, "request_id", request_id);
+         int mrc = server_send_response(conn, mresp);
+         cJSON_Delete(mresp);
+         if (ti_heap)
+            free(ti_heap);
+         return mrc;
+      }
+   }
 
    /* Run guardrail check */
    char msg[1024] = "";

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1064,6 +1064,7 @@ $(TESTPREFIX)/unit-test-acp-server: $(OBJDIR)/tests/test_acp_server.o \
 
 $(TESTPREFIX)/unit-test-server-dispatch: $(OBJDIR)/tests/test_server_dispatch.o $(OBJDIR)/server/server.o \
                       $(OBJDIR)/server/harness_memory_routes.o $(OBJDIR)/db1/harness_memory.o $(OBJDIR)/harness_memory_common.o \
+                      $(OBJDIR)/memory_redirect.o $(OBJDIR)/harness_memory_scope.o $(OBJDIR)/harness_memory_audit.o \
                       $(OBJDIR)/tests/support/delegate_child_env_export_stub.o \
 	                                $(OBJDIR)/server/server_config.o $(OBJDIR)/config_fields.o \
 	                                $(OBJDIR)/server/skill_review.o $(OBJDIR)/tests/support/skill_jobs_stub.o \


### PR DESCRIPTION
## What

Makes central agent-memory interception **actually run on the split `aimee-server`** — the real deployment. Found by the live end-to-end validation; the unit suite couldn't catch it because it doesn't exercise the split-server hook RPC path.

## Root cause

The server handles the pre-tool hook via `handle_hooks_pre` (`server/server.c`), which called `pre_tool_check` directly and **never invoked `memory_redirect`** — and `memory_redirect.o` wasn't even linked into the server (it lived only in the combined/CLI binary). So against the split server, agent memory writes were never intercepted; they fell through to the generic guardrails (e.g. the worktree block) and were never stored centrally.

## Fix

- **`handle_hooks_pre`** now runs a new `server_memory_intercept()` **before** the guardrails. Since the server **owns DB1**, it writes the store **directly via `hmem_upsert`** (not the CLI's HTTP-POST-to-self, which would drag in the CLI TLS transport the split server doesn't link) and mirrors the row to disk via the now-exposed `memory_redirect_rematerialize()`. It reuses the pure helpers `memory_redirect_classify` / `_bash_targets_memory`; the project key is the validated client `harness_project` hint (else resolved from cwd). **Fail-open** on any inability to identify/store. `rc==2`+msg is rendered by the client as a PreToolUse deny. Every path frees the parsed input; `row.body` is borrowed and `hmem_upsert` binds it `SQLITE_TRANSIENT` before it's freed.
- **`memory_redirect_rematerialize`**: exposed (was static); now confines `dir` syntactically under `<home>/<projects_root>` (no `..`) **before** any `mkdir -p` (the only confinement on Windows, where the realpath gate is compiled out; POSIX still adds the realpath+containment check). The `mkdir -p` lets a first write to a fresh project materialize.
- The POST-based `memory_redirect_check` is now unreferenced by the server, so `--gc-sections` drops it and its transport deps don't leak into the server link.
- **Makefile + CMakeLists**: link `memory_redirect.o` into `aimee-server`. **unit-test-server-dispatch**: link the newly-referenced objects.

## Testing

- **Validated end-to-end on a deployed split server** (6/6): hook intercept → DB1 store → re-materialize; delete-file + `session-start` hydrate round-trip; real-time watcher backstop; disk-only orphan import; audit trail.
- `make all server` + `make unit-tests` + `make lint` green.
- Roundtable-reviewed; the actionable finding (`mkdir -p` before the confinement gate) was fixed. Other 'blocking' items were diff-ingestion truncation artifacts or verified-safe (cJSON freed on all paths; borrowed `row.body` bound TRANSIENT; header decl present).

Depends on the plugin-loader startup fix (#817, merged) for the server to start in plain environments.