### PR TITLE
feat(cli,server,kb,db2): cross-repo dep graph S7 — aimee repo trust vertical

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -1277,6 +1277,47 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /repo/trust:
+    post:
+      summary: Set a registered repo's cross-repo trust (admin)
+      description: >-
+        Proxies the audited kb trust write (CAP_INDEX_ADMIN; local/owner-only over
+        TCP). Sets projects.trust, bumps trust_epoch on a real transition, audits
+        the change, and recomputes the blocked_symbols frequency model. actor is
+        caller-asserted (single-tenant P1).
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [project, trust]
+              properties:
+                project: { type: string }
+                trust: { type: string, enum: [trusted, untrusted] }
+                actor: { type: string }
+                request_id: { type: string }
+      responses:
+        "200":
+          description: Trust applied (status, project, prior_trust, new_trust, changed)
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Missing project or invalid trust value
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "404":
+          description: No such project
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "502":
+          description: Index backend (aimee-kb) unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /index/blast_radius:
     post:
       summary: Dependency blast radius for an indexed file

--- a/api/openapi-v1.yaml
+++ b/api/openapi-v1.yaml
@@ -1713,6 +1713,44 @@ paths:
         "405":
           description: Method not allowed
 
+  /code/repo-trust:
+    post:
+      operationId: postCodeRepoTrust
+      summary: Set a registered repo's cross-repo trust (owner credential only)
+      description: >-
+        Transactionally sets projects.trust, bumps cross_repo_meta.trust_epoch on
+        a real transition, audits the change to cross_repo_trust_audit, and (on a
+        change) recomputes the blocked_symbols frequency model. A scoped token is
+        rejected with 403; the project must already exist.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [project, trust]
+              properties:
+                project: { type: string }
+                trust: { type: string, enum: [trusted, untrusted] }
+                actor: { type: string }
+                request_id: { type: string }
+      responses:
+        "200":
+          description: Trust applied (status, project, prior_trust, new_trust, changed)
+          content:
+            application/json:
+              schema: { type: object }
+        "400":
+          description: Missing project or invalid trust value
+        "403":
+          description: Forbidden (requires the owner credential)
+        "404":
+          description: No such project
+        "405":
+          description: Method not allowed
+        "503":
+          description: Knowledge service store unavailable
+
   /code/build:
     post:
       operationId: postCodeBuild

--- a/docs/gen/api-v1.md
+++ b/docs/gen/api-v1.md
@@ -2,7 +2,7 @@
 
 > Auto-generated from `api/openapi-v1.yaml` by `scripts/gen-api-docs.py`. Do not edit by hand; run `make docs-gen` to regenerate.
 
-Total endpoints: 47
+Total endpoints: 48
 
 ## Endpoints
 
@@ -173,6 +173,23 @@ Responses:
 - `401` — Unauthorized
 - `405` — Method not allowed
 - `503` — Canonical index unavailable
+
+### `POST /v1/code/repo-trust`
+
+Set a registered repo's cross-repo trust (owner credential only)
+
+Transactionally sets projects.trust, bumps cross_repo_meta.trust_epoch on a real transition, audits the change to cross_repo_trust_audit, and (on a change) recomputes the blocked_symbols frequency model. A scoped token is rejected with 403; the project must already exist.
+
+Request body (`application/json`).
+
+Responses:
+
+- `200` — Trust applied (status, project, prior_trust, new_trust, changed)
+- `400` — Missing project or invalid trust value
+- `403` — Forbidden (requires the owner credential)
+- `404` — No such project
+- `405` — Method not allowed
+- `503` — Knowledge service store unavailable
 
 ### `POST /v1/code/scan`
 

--- a/scripts/check-kb-v1-coverage.py
+++ b/scripts/check-kb-v1-coverage.py
@@ -111,6 +111,7 @@ OPENAPI_EXTRA_ENDPOINTS = {
     "GET /v1/code/callers",
     "GET /v1/code/project-stats",
     "GET /v1/code/cross-repo-deps",
+    "POST /v1/code/repo-trust",
     "GET /v1/code/projects",
     "GET /v1/code/search",
     "GET /v1/intelligence/bandit/export",

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -170,6 +170,7 @@ static const struct
     {"index", "structure", "index.structure", NULL, NULL, 0},
     {"index", "callers", "index.find_callers", NULL, NULL, 0},
     {"index", "deps", "index.deps", NULL, NULL, 0},
+    {"repo", "trust", "repo.trust", NULL, NULL, 0},
     {"workspace", "add", "workspace.add", NULL, NULL, 300000},
     {"workspace", "list", "workspace.list", NULL, NULL, 0},
     {"workspace", "get", "workspace.get", NULL, NULL, 0},
@@ -716,6 +717,28 @@ static cJSON *marshal_index_deps(int argc, char **argv)
       cJSON_AddStringToObject(req, "min_tier", tier);
    if (rpc_get(&opts, "review"))
       cJSON_AddStringToObject(req, "status", "ambiguous");
+   return req;
+}
+
+/* Marshal `aimee repo trust <project> <trusted|untrusted> [--actor NAME]` (§0).
+ * actor defaults to $USER so the audit records who ran it (caller-asserted under
+ * the owner credential; single-tenant P1). The server validates the trust enum. */
+static cJSON *marshal_repo_trust(int argc, char **argv)
+{
+   static const char *bools[] = {NULL};
+   rpc_opts_t opts;
+   rpc_parse(argc, argv, bools, &opts);
+
+   cJSON *req = marshal_no_args("repo.trust");
+   if (opts.pos_count > 0)
+      cJSON_AddStringToObject(req, "project", opts.positional[0]);
+   if (opts.pos_count > 1)
+      cJSON_AddStringToObject(req, "trust", opts.positional[1]);
+   const char *actor = rpc_get(&opts, "actor");
+   if (!actor || !actor[0])
+      actor = getenv("USER");
+   if (actor && actor[0])
+      cJSON_AddStringToObject(req, "actor", actor);
    return req;
 }
 
@@ -3260,6 +3283,8 @@ static cJSON *marshal_request(const char *method, int argc, char **argv)
       return marshal_index_find_callers(argc, argv);
    if (strcmp(method, "index.deps") == 0)
       return marshal_index_deps(argc, argv);
+   if (strcmp(method, "repo.trust") == 0)
+      return marshal_repo_trust(argc, argv);
    if (strcmp(method, "graph.sync_code") == 0)
       return marshal_graph_sync_code(argc, argv);
    if (strcmp(method, "graph.explain") == 0)
@@ -5526,6 +5551,18 @@ static void pt_print_index_deps(const char *method, cJSON *resp)
 {
    print_index_deps(resp);
 }
+static void pt_print_repo_trust(const char *method, cJSON *resp)
+{
+   (void)method;
+   cJSON *changed = cJSON_GetObjectItemCaseSensitive(resp, "changed");
+   const char *prior = json_str(resp, "prior_trust");
+   const char *now = json_str(resp, "new_trust");
+   if (cJSON_IsBool(changed) && !cJSON_IsTrue(changed))
+      printf("repo %s: trust already %s (no change)\n", json_str(resp, "project"), now);
+   else
+      printf("repo %s: trust %s -> %s\n", json_str(resp, "project"), prior[0] ? prior : "(unset)",
+             now);
+}
 static void pt_print_graph_sync_code(const char *method, cJSON *resp)
 {
    printf("graph sync-code: project=%s generation=%s edges=%s\n", json_str(resp, "project"),
@@ -6554,6 +6591,7 @@ static const struct
     {"index.structure", pt_print_index_structure},
     {"index.find_callers", pt_print_index_find_callers},
     {"index.deps", pt_print_index_deps},
+    {"repo.trust", pt_print_repo_trust},
     {"graph.sync_code", pt_print_graph_sync_code},
     {"workspace.add", pt_print_workspace_add},
     {"workspace.list", pt_print_workspace_list},

--- a/src/cli_v1_routes_gen.inc
+++ b/src/cli_v1_routes_gen.inc
@@ -147,6 +147,7 @@ static const struct
     {"provider.slot_acquire", "POST", "/v1/provider/slot_acquire"},
     {"provider.slot_release", "POST", "/v1/provider/slot_release"},
     {"provider.test", "POST", "/v1/provider/test"},
+    {"repo.trust", "POST", "/v1/repo/trust"},
     {"rules.delete", "POST", "/v1/rules/delete"},
     {"server.health", "GET", "/v1/server/health"},
     {"server.info", "GET", "/v1/server/info"},

--- a/src/db2/cross_repo_stats.c
+++ b/src/db2/cross_repo_stats.c
@@ -337,3 +337,147 @@ int db2_cross_repo_repo_set_hash(char *out, size_t cap)
    }
    return 0;
 }
+
+/* ---- S7: per-repo trust write + audit ------------------------------------ */
+
+int db2_cross_repo_set_trust(const char *project, const char *new_trust, const char *actor,
+                             const char *request_id, char *prior_out, size_t prior_cap,
+                             int *changed_out)
+{
+   if (prior_out && prior_cap)
+      prior_out[0] = '\0';
+   if (changed_out)
+      *changed_out = 0;
+   void *conn = cr_conn();
+   if (!conn || !project || !project[0] || !new_trust ||
+       (strcmp(new_trust, "trusted") != 0 && strcmp(new_trust, "untrusted") != 0))
+      return -1;
+   char err[CR_ERRBUF] = "";
+
+   if (aimee_pg_exec(conn, "BEGIN", err, sizeof(err)) != 0)
+      return -1;
+
+   int ok = 1, found = 0;
+   char prior[16] = "";
+
+   /* Prior trust + existence check. (Single-tenant admin write: a plain SELECT
+    * then UPDATE is fine; the txn keeps the multi-row write atomic.) */
+   aimee_pg_stmt_t *sel =
+       aimee_pg_prepare(conn, "SELECT trust FROM projects WHERE name = ?1", err, sizeof(err));
+   if (!sel)
+      ok = 0;
+   else
+   {
+      aimee_pg_bind_text(sel, "?1", project);
+      int sr = aimee_pg_step(sel, err, sizeof(err));
+      if (sr == AIMEE_PG_ROW)
+      {
+         const char *t = aimee_pg_column_text(sel, 0);
+         snprintf(prior, sizeof(prior), "%s", t ? t : "");
+         found = 1;
+      }
+      else if (sr < 0)
+         ok = 0;
+      aimee_pg_finalize(sel);
+   }
+
+   if (ok && !found)
+   {
+      (void)aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      return 1; /* no such project */
+   }
+
+   int changed = ok && found && strcmp(prior, new_trust) != 0;
+
+   int64_t epoch_before = 0, epoch_after = 0;
+   if (ok && cr_scalar(conn, "SELECT trust_epoch FROM cross_repo_meta WHERE id = 1", NULL, NULL,
+                       &epoch_before) != 0)
+      ok = 0;
+   epoch_after = epoch_before;
+
+   /* Apply the change + bump trust_epoch only on a real transition, so a no-op
+    * re-assert doesn't needlessly invalidate the frequency model. */
+   if (ok && changed)
+   {
+      aimee_pg_stmt_t *up = aimee_pg_prepare(conn, "UPDATE projects SET trust = ?2 WHERE name = ?1",
+                                             err, sizeof(err));
+      if (!up)
+         ok = 0;
+      else
+      {
+         aimee_pg_bind_text(up, "?1", project);
+         aimee_pg_bind_text(up, "?2", new_trust);
+         if (aimee_pg_step(up, err, sizeof(err)) < 0)
+            ok = 0;
+         aimee_pg_finalize(up);
+      }
+      if (ok && aimee_pg_exec(
+                    conn, "UPDATE cross_repo_meta SET trust_epoch = trust_epoch + 1 WHERE id = 1",
+                    err, sizeof(err)) != 0)
+         ok = 0;
+      if (ok && cr_scalar(conn, "SELECT trust_epoch FROM cross_repo_meta WHERE id = 1", NULL, NULL,
+                          &epoch_after) != 0)
+         ok = 0;
+   }
+
+   /* repo_set_hash stamp at change time (best-effort for the audit row). */
+   char rsh[64] = "";
+   if (ok)
+   {
+      aimee_pg_stmt_t *hs = aimee_pg_prepare(
+          conn, "SELECT repo_set_hash FROM cross_repo_meta WHERE id = 1", err, sizeof(err));
+      if (!hs)
+         ok = 0;
+      else
+      {
+         if (aimee_pg_step(hs, err, sizeof(err)) == AIMEE_PG_ROW)
+         {
+            const char *h = aimee_pg_column_text(hs, 0);
+            snprintf(rsh, sizeof(rsh), "%s", h ? h : "");
+         }
+         aimee_pg_finalize(hs);
+      }
+   }
+
+   /* Audit every call (epoch before==after on a no-op). */
+   if (ok)
+   {
+      aimee_pg_stmt_t *au = aimee_pg_prepare(
+          conn,
+          "INSERT INTO cross_repo_trust_audit (project, actor, prior_trust, new_trust, "
+          "trust_epoch_before, trust_epoch_after, repo_set_hash, request_id) "
+          "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+          err, sizeof(err));
+      if (!au)
+         ok = 0;
+      else
+      {
+         aimee_pg_bind_text(au, "?1", project);
+         aimee_pg_bind_text(au, "?2", actor ? actor : "");
+         aimee_pg_bind_text(au, "?3", prior);
+         aimee_pg_bind_text(au, "?4", new_trust);
+         aimee_pg_bind_int64(au, "?5", epoch_before);
+         aimee_pg_bind_int64(au, "?6", epoch_after);
+         aimee_pg_bind_text(au, "?7", rsh);
+         aimee_pg_bind_text(au, "?8", request_id ? request_id : "");
+         if (aimee_pg_step(au, err, sizeof(err)) < 0)
+            ok = 0;
+         aimee_pg_finalize(au);
+      }
+   }
+
+   if (!ok)
+   {
+      (void)aimee_pg_exec(conn, "ROLLBACK", err, sizeof(err));
+      LOG_ERROR(CR_LOG_TAG, "trust write failed for %s: %s", project, err);
+      return -1;
+   }
+   if (aimee_pg_exec(conn, "COMMIT", err, sizeof(err)) != 0)
+      return -1;
+
+   if (prior_out && prior_cap)
+      snprintf(prior_out, prior_cap, "%s", prior);
+   if (changed_out)
+      *changed_out = changed;
+   return 0;
+}

--- a/src/db2/cross_repo_stats.h
+++ b/src/db2/cross_repo_stats.h
@@ -64,6 +64,20 @@ int db2_cross_repo_repo_set_hash(char *out, size_t cap);
 int db2_cross_repo_meta_read(int64_t *trust_epoch, int64_t *blocked_symbols_version,
                              char *repo_set_hash, size_t cap);
 
+/* §0/S7: apply a per-repo trust change transactionally and audit it. Reads the
+ * prior trust (the project must already exist), UPDATEs projects.trust, and --
+ * only when the value actually changes -- bumps cross_repo_meta.trust_epoch
+ * (which invalidates the cached version stamp; the caller then recomputes
+ * blocked_symbols, since trust changes which repos feed the frequency model).
+ * Every call writes a cross_repo_trust_audit row (epoch before==after on a
+ * no-op). new_trust must be "trusted" or "untrusted". prior_out (optional,
+ * prior_cap bytes) receives the prior trust value; *changed_out (optional) is
+ * set to 1 iff the trust value actually changed. Returns 0 = applied,
+ * 1 = no such project, -1 = DB error / bad argument. */
+int db2_cross_repo_set_trust(const char *project, const char *new_trust, const char *actor,
+                             const char *request_id, char *prior_out, size_t prior_cap,
+                             int *changed_out);
+
 /* NOTE: repo descriptors (manifest module_id parsing for the §3.7 resolver) and
  * the §4.2 candidate-generation query are orchestration-coupled and validated
  * live; they land with S4a (canonical_index_cross_repo_deps), not in this slice. */

--- a/src/headers/kb_client.h
+++ b/src/headers/kb_client.h
@@ -1076,6 +1076,12 @@ int kb_client_index_find_callers(const char *project, const char *symbol, caller
 char *kb_client_index_cross_repo_deps_json(const char *project, const char *direction,
                                            const char *min_tier, int status_ambiguous);
 
+/* S7: POST a per-repo trust change to the kb (project + trust required, actor +
+ * request_id optional). Returns the raw kb JSON body on 2xx (caller frees); NULL
+ * otherwise with *http_status (optional) set to the kb HTTP status. */
+char *kb_client_repo_trust_json(const char *project, const char *trust, const char *actor,
+                                const char *request_id, int *http_status);
+
 /* Full-text code search across indexed file contents.  `project` may be
  * NULL/empty to search all projects.  Returns count, or 0 if kb is
  * unreachable.  Uses /v1 over remote HTTP or local UDS.

--- a/src/headers/kb_http_code.h
+++ b/src/headers/kb_http_code.h
@@ -3,6 +3,9 @@
 
 int handle_post_code_scan(const char *body, char *out_buf, int out_cap);
 int handle_post_code_scan_route(const char *method, const char *body, char *out_buf, int out_cap);
+int handle_post_code_repo_trust(const char *body, char *out_buf, int out_cap, int owner);
+int handle_post_code_repo_trust_route(const char *method, const char *body, char *out_buf,
+                                      int out_cap, int owner);
 int handle_get_code_projects(const char *query_string, char *out_buf, int out_cap);
 int handle_get_code_projects_route(const char *method, const char *query_string, char *out_buf,
                                    int out_cap);

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -297,6 +297,7 @@ int handle_index_blast_radius(server_ctx_t *ctx, server_conn_t *conn, cJSON *req
 int handle_index_structure(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_find_callers(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_index_deps(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
+int handle_repo_trust(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_blast_radius_preview(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_graph_sync_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_graph_explain(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);

--- a/src/kb/http/kb_http.c
+++ b/src/kb/http/kb_http.c
@@ -583,6 +583,12 @@ static void path_seg(const char *path, int n, char *out, size_t out_cap)
    out[i] = '\0';
 }
 
+/* Shared 403 for owner-credential-only mutations (a scoped token must not reach them). */
+static int kb_http_owner_required(char *out, int cap, const char *what)
+{
+   snprintf(out, (size_t)cap, "{\"error\":\"forbidden: %s requires the owner credential\"}", what);
+   return 403;
+}
 /* ── Phase 5 extended routing ────────────────────────────────────────────── */
 
 int kb_http_route_ex(const char *method, const char *path, const char *query_string,
@@ -684,11 +690,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
          return 405;
       }
       if (vr.scope_kind[0])
-      {
-         snprintf(out_buf, (size_t)out_cap,
-                  "{\"error\":\"forbidden: enrollment minting requires the owner credential\"}");
-         return 403;
-      }
+         return kb_http_owner_required(out_buf, out_cap, "enrollment minting");
       cJSON *req = body ? cJSON_Parse(body) : NULL;
       const cJSON *jhost = req ? cJSON_GetObjectItemCaseSensitive(req, "host") : NULL;
       const cJSON *jport = req ? cJSON_GetObjectItemCaseSensitive(req, "port") : NULL;
@@ -1305,11 +1307,7 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
    if (strcmp(path, "/v1/pdf/quarantine") == 0)
    {
       if (vr.scope_kind[0])
-      {
-         snprintf(out_buf, (size_t)out_cap,
-                  "{\"error\":\"forbidden: quarantine actions require the owner credential\"}");
-         return 403;
-      }
+         return kb_http_owner_required(out_buf, out_cap, "quarantine actions");
       return handle_post_pdf_quarantine_route(method, body, body_len, out_buf, out_cap);
    }
    if (strcmp(path, "/v1/code/callers") == 0)
@@ -1442,6 +1440,8 @@ int kb_http_route_ex(const char *method, const char *path, const char *query_str
 
    if (strcmp(path, "/v1/code/scan") == 0)
       return handle_post_code_scan_route(method, body, out_buf, out_cap);
+   if (strcmp(path, "/v1/code/repo-trust") == 0) /* S7: admin; owner gate in handler */
+      return handle_post_code_repo_trust_route(method, body, out_buf, out_cap, !vr.scope_kind[0]);
    /* POST /v1/ingest */
    if (strcmp(path, "/v1/ingest") == 0)
    {

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -7,6 +7,7 @@
 #include "db2/cross_repo_classify.h" /* xrepo_tier_name */
 #include "db2/cross_repo_deps.h"     /* canonical_index_cross_repo_deps */
 #include "db2/cross_repo_review.h"   /* db2_cross_repo_review_list */
+#include "db2/cross_repo_stats.h"    /* db2_cross_repo_set_trust, recompute_blocked_symbols */
 #include "db2/lifecycle.h"
 #include "db2/memory_query.h"
 #include "db2/code_projection.h"
@@ -1795,4 +1796,116 @@ int handle_post_code_scan_route(const char *method, const char *body, char *out_
    if (strcmp(method, "POST") != 0)
       return code_method_not_allowed(out_buf, out_cap);
    return handle_post_code_scan(body, out_buf, out_cap);
+}
+
+/* S7: POST /v1/code/repo-trust {project, trust:"trusted"|"untrusted", actor?,
+ * request_id?}. `owner` (caller holds the unscoped owner credential) is required:
+ * a scoped token must not be able to flip trust. Applies the audited db2 trust
+ * write and, on a real transition, recomputes the blocked_symbols frequency model
+ * (best-effort — the trust write has already committed and bumped trust_epoch,
+ * which invalidates cached results either way). */
+int handle_post_code_repo_trust(const char *body, char *out_buf, int out_cap, int owner)
+{
+   if (!owner)
+   {
+      snprintf(out_buf, (size_t)out_cap,
+               "{\"error\":\"forbidden: repo trust requires the owner credential\"}");
+      return 403;
+   }
+   cJSON *root = cJSON_Parse(body ? body : "{}");
+   if (!root)
+      return code_scan_write_error(out_buf, out_cap, "invalid json");
+
+   char project[256] = "", trust[16] = "", actor[256] = "", request_id[128] = "";
+   cJSON *j;
+   if ((j = cJSON_GetObjectItemCaseSensitive(root, "project")) && cJSON_IsString(j))
+      snprintf(project, sizeof(project), "%s", j->valuestring);
+   if ((j = cJSON_GetObjectItemCaseSensitive(root, "trust")) && cJSON_IsString(j))
+      snprintf(trust, sizeof(trust), "%s", j->valuestring);
+   if ((j = cJSON_GetObjectItemCaseSensitive(root, "actor")) && cJSON_IsString(j))
+      snprintf(actor, sizeof(actor), "%s", j->valuestring);
+   if ((j = cJSON_GetObjectItemCaseSensitive(root, "request_id")) && cJSON_IsString(j))
+      snprintf(request_id, sizeof(request_id), "%s", j->valuestring);
+   cJSON_Delete(root);
+
+   if (!project[0])
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"missing project\"}");
+      return 400;
+   }
+   if (strcmp(trust, "trusted") != 0 && strcmp(trust, "untrusted") != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"trust must be 'trusted' or 'untrusted'\"}");
+      return 400;
+   }
+   if (!db2_is_initialized())
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"failed to open knowledge service store\"}");
+      return 503;
+   }
+
+   char prior[16] = "";
+   int changed = 0;
+   int rc =
+       db2_cross_repo_set_trust(project, trust, actor, request_id, prior, sizeof(prior), &changed);
+   if (rc == 1)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"no such project\"}");
+      return 404;
+   }
+   if (rc != 0)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"trust write failed\"}");
+      return 503;
+   }
+
+   int recomputed = -1; /* -1 = not attempted (no change); >=0 rows; -1 on a recompute error too */
+   if (changed)
+   {
+      config_t cfg;
+      if (config_load(&cfg) == 0)
+         recomputed = db2_cross_repo_recompute_blocked_symbols(cfg.kb_curator_cross_repo_k,
+                                                               cfg.kb_curator_cross_repo_m,
+                                                               cfg.kb_curator_cross_repo_len_min);
+   }
+
+   /* Build via cJSON so the (owner-supplied) project name is JSON-escaped rather
+    * than interpolated raw into a template. */
+   cJSON *out = cJSON_CreateObject();
+   if (!out)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"out of memory\"}");
+      return 500;
+   }
+   cJSON_AddStringToObject(out, "status", "ok");
+   cJSON_AddStringToObject(out, "project", project);
+   cJSON_AddStringToObject(out, "prior_trust", prior);
+   cJSON_AddStringToObject(out, "new_trust", trust);
+   cJSON_AddBoolToObject(out, "changed", changed ? 1 : 0);
+   cJSON_AddNumberToObject(out, "blocked_symbols_recomputed", recomputed);
+   char *s = cJSON_PrintUnformatted(out);
+   cJSON_Delete(out);
+   if (!s)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"out of memory\"}");
+      return 500;
+   }
+   int over = ((int)strlen(s) >= out_cap);
+   if (!over)
+      snprintf(out_buf, (size_t)out_cap, "%s", s);
+   free(s);
+   if (over)
+   {
+      snprintf(out_buf, (size_t)out_cap, "{\"error\":\"response too large\"}");
+      return 500;
+   }
+   return 200;
+}
+
+int handle_post_code_repo_trust_route(const char *method, const char *body, char *out_buf,
+                                      int out_cap, int owner)
+{
+   if (strcmp(method, "POST") != 0)
+      return code_method_not_allowed(out_buf, out_cap);
+   return handle_post_code_repo_trust(body, out_buf, out_cap, owner);
 }

--- a/src/server/kb_client_index.c
+++ b/src/server/kb_client_index.c
@@ -700,3 +700,29 @@ char *kb_client_index_cross_repo_deps_json(const char *project, const char *dire
    free(path);
    return json;
 }
+
+/* S7: POST the cross-repo trust write to the kb. Returns the raw kb JSON body on
+ * 2xx (caller frees); NULL on any non-2xx or transport failure with *http_status
+ * (optional) set to the kb HTTP status (so the proxy can map 404/403/400 to a
+ * precise client error instead of a blanket 502). */
+char *kb_client_repo_trust_json(const char *project, const char *trust, const char *actor,
+                                const char *request_id, int *http_status)
+{
+   if (http_status)
+      *http_status = -1;
+   if (!project || !project[0] || !trust || !trust[0])
+      return NULL;
+   cJSON *body = cJSON_CreateObject();
+   if (!body)
+      return NULL;
+   cJSON_AddStringToObject(body, "project", project);
+   cJSON_AddStringToObject(body, "trust", trust);
+   if (actor && actor[0])
+      cJSON_AddStringToObject(body, "actor", actor);
+   if (request_id && request_id[0])
+      cJSON_AddStringToObject(body, "request_id", request_id);
+   char *json = kb_client_v1_post_json("/v1/code/repo-trust", body, KB_CLIENT_INDEX_READ_TIMEOUT_MS,
+                                       http_status);
+   cJSON_Delete(body);
+   return json;
+}

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1241,6 +1241,7 @@ static const server_method_dispatch_t server_dispatch_table[] = {
     {"index.structure", handle_index_structure},
     {"index.find_callers", handle_index_find_callers},
     {"index.deps", handle_index_deps},
+    {"repo.trust", handle_repo_trust},
     {"graph.sync_code", handle_graph_sync_code},
     {"graph.explain", handle_graph_explain},
     {"blast_radius.preview", handle_blast_radius_preview},

--- a/src/server/server_auth.c
+++ b/src/server/server_auth.c
@@ -162,6 +162,7 @@ const method_policy_t method_registry[] = {
     {"kb.ingest.status", CAP_INDEX_READ, "knowledge-base ingest status (read)"},
     /* Code index/graph rebuilds (mutating) — distinct from the index.* reads. */
     {"index.scan", CAP_INDEX_ADMIN, "scan / re-index the codebase"},
+    {"repo.trust", CAP_INDEX_ADMIN, "set per-repo cross-repo trust"},
     {"graph.sync_code", CAP_INDEX_ADMIN, "sync the code graph"},
     {"graph.*", CAP_INDEX_READ, "code graph query"},
     /* Curator: queries read; synthesize rebuilds artifacts (LLM). */

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1637,6 +1637,7 @@ static const http_route_t g_v1_routes[] = {
     {"POST", "/v1/index/structure", NULL, RM_EXACT, "index.structure", 0, rh_dispatch_op},
     {"POST", "/v1/index/find_callers", NULL, RM_EXACT, "index.find_callers", 0, rh_dispatch_op},
     {"POST", "/v1/index/deps", NULL, RM_EXACT, "index.deps", 0, rh_dispatch_op},
+    {"POST", "/v1/repo/trust", NULL, RM_EXACT, "repo.trust", 0, rh_dispatch_op},
     {"POST", "/v1/index/blast_radius", NULL, RM_EXACT, "index.blast_radius", 0, rh_dispatch_op},
 
     /* Skill + work-queue read families (hub-migration P1), same dispatch-backed

--- a/src/server/server_state_index.c
+++ b/src/server/server_state_index.c
@@ -55,3 +55,39 @@ int handle_index_deps(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       return server_send_error(conn, "knowledge service did not return cross-repo deps", NULL);
    return send_and_free(conn, resp);
 }
+
+/* S7: repo.trust — proxy the cross-repo trust write to the kb. The server op is
+ * gated by CAP_INDEX_ADMIN (method_registry), which over TCP is local/owner-only;
+ * the kb re-checks the owner credential. Inputs are validated here so a bad value
+ * never reaches the kb, and the kb HTTP status is mapped to a precise client error
+ * (404 no-such-project, 403 forbidden) instead of a blanket 502. `actor` is
+ * caller-asserted (single-tenant P1); a server-derived principal is a future
+ * hardening. */
+int handle_repo_trust(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   (void)ctx;
+
+   const char *project;
+   if (jo_need_str(req, "project", &project) < 0 || !project[0])
+      return server_send_error(conn, "missing project", NULL);
+   const char *trust;
+   if (jo_need_str(req, "trust", &trust) < 0 ||
+       (strcmp(trust, "trusted") != 0 && strcmp(trust, "untrusted") != 0))
+      return server_send_error(conn, "trust must be 'trusted' or 'untrusted'", NULL);
+   const char *actor = jo_str(req, "actor", NULL);
+   const char *request_id = jo_str(req, "request_id", NULL);
+
+   int status = -1;
+   char *json = kb_client_repo_trust_json(project, trust, actor, request_id, &status);
+   cJSON *resp = json ? cJSON_Parse(json) : NULL;
+   free(json);
+   if (resp)
+      return send_and_free(conn, resp);
+   if (status == 404)
+      return server_send_error(conn, "no such project", NULL);
+   if (status == 403)
+      return server_send_error(conn, "forbidden: repo trust requires the owner credential", NULL);
+   if (status == 400)
+      return server_send_error(conn, "invalid trust request", NULL);
+   return server_send_error(conn, "knowledge service did not apply the trust change", NULL);
+}

--- a/src/tests/test_cross_repo_stats.c
+++ b/src/tests/test_cross_repo_stats.c
@@ -158,6 +158,61 @@ static void test_no_conn_graceful(void)
    printf("ok\n");
 }
 
+/* count cross_repo_trust_audit rows for a project (direct shim query). */
+static int64_t audit_count(const char *project)
+{
+   char err[256] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(
+       db2_conn(), "SELECT COUNT(*) FROM cross_repo_trust_audit WHERE project = ?1", err,
+       sizeof(err));
+   assert(st);
+   aimee_pg_bind_text(st, "?1", project);
+   int64_t n = 0;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+      n = aimee_pg_column_int64(st, 0);
+   aimee_pg_finalize(st);
+   return n;
+}
+
+/* S7: per-repo trust write + audit. Runs last — it flips A's trust permanently. */
+static void test_set_trust(void)
+{
+   int64_t epoch0 = 0;
+   db2_cross_repo_meta_read(&epoch0, NULL, NULL, 0);
+   assert(audit_count("A") == 0);
+
+   /* trusted -> untrusted: applied, changed, epoch bumps, audited */
+   char prior[16] = "";
+   int changed = -1;
+   assert(db2_cross_repo_set_trust("A", "untrusted", "tester", "r1", prior, sizeof(prior),
+                                   &changed) == 0);
+   assert(strcmp(prior, "trusted") == 0 && changed == 1);
+   int64_t epoch1 = 0;
+   db2_cross_repo_meta_read(&epoch1, NULL, NULL, 0);
+   assert(epoch1 == epoch0 + 1);
+   assert(audit_count("A") == 1);
+
+   /* no-op re-assert: persisted (prior now untrusted), NOT changed, epoch stable,
+    * still audited (every call records the actor's action). */
+   changed = -1;
+   assert(db2_cross_repo_set_trust("A", "untrusted", "tester", "r2", prior, sizeof(prior),
+                                   &changed) == 0);
+   assert(strcmp(prior, "untrusted") == 0 && changed == 0);
+   int64_t epoch2 = 0;
+   db2_cross_repo_meta_read(&epoch2, NULL, NULL, 0);
+   assert(epoch2 == epoch1);
+   assert(audit_count("A") == 2);
+
+   /* no such project / bad trust value -> no audit, no epoch change */
+   assert(db2_cross_repo_set_trust("ZZZ", "trusted", "t", "r3", NULL, 0, NULL) == 1);
+   assert(db2_cross_repo_set_trust("A", "bogus", "t", "r4", NULL, 0, NULL) == -1);
+   int64_t epoch3 = 0;
+   db2_cross_repo_meta_read(&epoch3, NULL, NULL, 0);
+   assert(epoch3 == epoch2);
+   assert(audit_count("A") == 2);
+   assert(audit_count("ZZZ") == 0);
+}
+
 int main(void)
 {
    db2_test_shim_open();
@@ -166,6 +221,7 @@ int main(void)
    test_blocked_symbols();
    test_hashes();
    test_no_conn_graceful();
+   test_set_trust();
    printf("cross_repo_stats: all tests passed\n");
    return 0;
 }

--- a/src/tests/test_kb_http_routes_code.inc
+++ b/src/tests/test_kb_http_routes_code.inc
@@ -115,6 +115,31 @@ const char *xrepo_tier_name(int t)
    return "none";
 }
 
+/* S7: trust-write entry points kb_http_code.o references from the repo-trust
+ * handler (full behavior lives in test_cross_repo_stats). */
+int db2_cross_repo_set_trust(const char *project, const char *new_trust, const char *actor,
+                             const char *request_id, char *prior_out, size_t prior_cap,
+                             int *changed_out)
+{
+   (void)project;
+   (void)new_trust;
+   (void)actor;
+   (void)request_id;
+   if (prior_out && prior_cap)
+      prior_out[0] = '\0';
+   if (changed_out)
+      *changed_out = 0;
+   return 0;
+}
+
+int db2_cross_repo_recompute_blocked_symbols(int k, int m, int len_min)
+{
+   (void)k;
+   (void)m;
+   (void)len_min;
+   return 0;
+}
+
 /* Vector-leg stubs (§5): the query embedder + pgvec code search. OFF by default
  * (g_vec_enabled=0 -> memory_embed_text returns 0 -> the leg is skipped), so the
  * existing hybrid tests are unaffected; test_code_hybrid_vector_ok flips it on. */

--- a/src/tests/test_server_dispatch.c
+++ b/src/tests/test_server_dispatch.c
@@ -535,6 +535,10 @@ int handle_index_deps(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "index.deps");
 }
+int handle_repo_trust(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
+{
+   return stub_handler(conn, "repo.trust");
+}
 int handle_graph_sync_code(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 {
    return stub_handler(conn, "graph.sync_code");


### PR DESCRIPTION
## Summary
Ninth slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md` §0), on S6 (#816). The per-repo **trust** write that S2b's classifier already consumes (untrusted repos are capped at MEDIUM and excluded from the distinctiveness frequency model). Full vertical: **CLI → server op → kb → db2**, authz enforced at *both* the server and kb boundaries.

- **db2** — `db2_cross_repo_set_trust` (`cross_repo_stats.c`): one transaction — read prior trust (project must exist, else `ROLLBACK`+return 1), `UPDATE projects.trust`, bump `cross_repo_meta.trust_epoch` **only on a real transition**, and audit **every** call to `cross_repo_trust_audit` (epoch before==after on a no-op). Returns 0/1/-1 (applied / no-such-project / error) + prior + changed.
- **kb** — `POST /v1/code/repo-trust`: applies the write and, on a change, recomputes the `blocked_symbols` frequency model (trust flips which repos feed it). **Owner-credential-only** (a scoped token must not flip trust) — the gate is passed into the handler so the `kb_http.c` dispatch stays one line; a new `kb_http_owner_required` helper dedups that gate across enroll/quarantine to hold `kb_http.c` at the 2000-line cap.
- **server** — op `repo.trust` (`server_state_index.c`) gated by `CAP_INDEX_ADMIN` (not in `CAPS_AUTHENTICATED` → local/owner-only over TCP). Validates inputs at the boundary; maps the kb HTTP status (404/403/400) to a precise client error instead of a blanket 502.
- **cli** — `aimee repo trust <project> {trusted|untrusted} [--actor NAME]` (actor defaults to `$USER` for the audit).
- Both OpenAPI specs, regenerated `cli_v1_routes_gen.inc`, and a shim unit test for `db2_cross_repo_set_trust` (flip / no-op / no-such-project / bad-value + audit-row count + epoch-bump assertions).

`CAP_INDEX_ADMIN` and the three trust tables already existed (S1).

## Review
Roundtable code review. **Blocking folded:** the success JSON now builds via cJSON (escapes the owner-supplied project name) instead of `snprintf`-interpolation (JSON-injection class). **Verified non-issues:** the handler deep-copies fields into stack buffers *before* `cJSON_Delete` (no use-after-free); the owner gate is the exact same `!vr.scope_kind[0]` semantics as `/v1/enroll` (scoped tokens → 403; unauthenticated → 401 upstream; auth-off ⇒ owner is the established local-trust posture). **Accepted (P1, documented):** SELECT-prior-then-UPDATE is last-writer-wins under concurrent admin flips (single-tenant; rare); `actor` is caller-asserted under the owner credential (server-derived principal is future hardening).

## Gates
All green: dispatch-caps, v1-method-coverage, cli-v1-routes (regen in sync), server + kb api-conformance, kb-v1-coverage, schema-sync, line-check, docs-gen, check-linking, clang-format-19; unit test passes. Live validation lands in S9.