### PR TITLE
chore(hmem): polish — observability + contract docs for memory interception

### DIFF
--- a/src/harness_memory_watch.h
+++ b/src/harness_memory_watch.h
@@ -18,6 +18,8 @@ extern "C"
 {
 #endif
 
+   /* An hmem_watch_t is single-owner: open/poll/free must all run on one thread
+    * (the watcher loop). It is not safe to poll the same handle concurrently. */
    typedef struct hmem_watch hmem_watch_t;
 
    /* Open an inotify watch over `memreal` (an absolute, realpath'd memory dir)

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -809,14 +809,20 @@ static int server_memory_intercept(const char *tool, const char *tool_input, con
    snprintf(row.name, sizeof(row.name), "%s", name);
    snprintf(row.type, sizeof(row.type), "%s", "fact");
    snprintf(row.last_client, sizeof(row.last_client), "%s", client);
-   row.body = (char *)content; /* borrowed; hmem_upsert binds TRANSIENT */
+   /* content is owned by ti and stays valid until cJSON_Delete(ti) at the end of
+    * this function — after hmem_upsert has copied it (SQLITE_TRANSIENT). */
+   row.body = (char *)content;
    if (hmem_upsert(&row, NULL) != 0)
    {
       cJSON_Delete(ti); /* store failed — fail open rather than block the agent */
       return 0;
    }
-   memory_redirect_rematerialize(path, content, home, scope->projects_root);
-   hmem_audit("redirect", project, name, NULL);
+   /* DB1 is authoritative; the on-disk file is a cache. If the mirror write fails
+    * the row is still stored and the next session-start hydrate re-creates the
+    * file — so note it in the single 'redirect' audit rather than failing the op. */
+   int rmrc = memory_redirect_rematerialize(path, content, home, scope->projects_root);
+   hmem_audit("redirect", project, name,
+              rmrc == 0 ? NULL : "file write failed; stored in DB1, pending hydrate");
    snprintf(msg, msg_len,
             "Saved to aimee's central memory store as memory/%s.md (aimee manages these "
             "files; it has been written for you).",


### PR DESCRIPTION
## What

Non-blocking follow-ups deferred from the v1.2 reviews of central agent-memory interception. **No happy-path behavior change.**

- **`server_memory_intercept`**: when `hmem_upsert` succeeds but the on-disk mirror (`memory_redirect_rematerialize`) fails, the single `redirect` audit now carries a `file write failed; stored in DB1, pending hydrate` detail instead of silently dropping the return value. DB1 is authoritative and the next session-start hydrate re-creates the file, so this stays observability-only (no deny, still fail-safe).
- Sharpened the borrowed-`row.body` lifetime comment (owned by `ti`, valid until `cJSON_Delete(ti)`; `hmem_upsert` copies it `SQLITE_TRANSIENT`).
- **`harness_memory_watch.h`**: documented that `hmem_watch_t` is single-owner (open/poll/free on one thread; not safe to poll concurrently).

## Testing

- `make all server` + `make unit-tests` + `make lint` green.
- Roundtable-reviewed (no blockers); applied the suggestions (single audit event on failure; precise lifetime comment).