### PR TITLE
test(kb): cross-repo dep graph S8 — end-to-end acceptance harness + live runbook

### DIFF
--- a/docs/validation/cross-repo-deps-acceptance.md
+++ b/docs/validation/cross-repo-deps-acceptance.md
@@ -1,0 +1,86 @@
+# Cross-repo dependency graph — acceptance validation
+
+Live validation procedure for the cross-repo dependency graph proposal
+([cross-repo-dependency-graph](../proposals/pending/cross-repo-dependency-graph.md),
+§9). The **enumerated negative suite + stratified positive strata** are validated
+in CI over the sqlite shim by
+[`tests/test_cross_repo_acceptance.c`](../../src/tests/test_cross_repo_acceptance.c)
+(end-to-end through `canonical_index_cross_repo_deps`) and the pure resolver /
+classifier units in `tests/test_cross_repo_deps.c`. The gates below are the ones
+that **must be measured live** against the real ~40-repo corpus on the `.254`
+split stack — they need Postgres + the actual code index and cannot be screened
+on the shim. This is the S9 runbook.
+
+Prereqs: `aimee-server` + `aimee-kb` + `aimee-llm` running on `.254` with the
+corpus indexed; `aimee index deps` / `aimee repo trust` reachable (the §S6/S7
+CLI). Use `--json` for machine-checkable output.
+
+## Gate #2 — known-true positive (HIGH, import-corroborated)
+
+```
+aimee index deps moonlight-qt --json
+```
+
+PASS iff the result contains an edge to **moonlight-common-c** at tier **≥ MEDIUM**
+whose linking symbols include **`LiStartConnection`**, with evidence carrying:
+call-site count, the resolved import path, `blocked_symbols_version`,
+`distinctiveness_v`, `resolver_version`, and `repo_set_hash`. Spot-check the
+reverse direction once it lands: dependents of `moonlight-common-c` include
+`moonlight-qt`.
+
+## Gate #3 — enumerated negative suite (100%) on the live corpus
+
+Sample real instances of each class and confirm the tier:
+
+| Class | Expectation |
+|---|---|
+| bare-name collisions (`init`, `get`, `run`, …) | **no** cross-repo edge |
+| multi-definer, uncorroborated | **AMBIGUOUS** → review queue, no edge |
+| conditional (`#ifdef`-guarded) import | capped at **MEDIUM** |
+| dynamic import (`dlopen`/`import(...)`) | routed to **review** |
+| untrusted-**caller** import corroboration | capped at **MEDIUM** (never HIGH) |
+| untrusted-**definer** (a trusted caller imports/calls it) | **no edge** — an untrusted repo can't originate one (stricter than the literal §0 export-cap; verified end-to-end in `test_cross_repo_acceptance.c`) |
+
+Vendored-copy: pick a `vendor/`/`third_party/` symbol duplicated across repos and
+confirm it appears in the review queue:
+
+```
+aimee index deps <repo-with-vendored-copy> --review --json
+```
+
+Overflow: confirm the `--review` output carries `overflow.dropped` and the CLI
+prints the overflow **WARNING** when the queue is saturated.
+
+## Gate #4 — `--dry-run` offline inspection
+
+> **Deferred.** `--reverse` and `--dry-run` were intentionally not shipped in S6
+> (the kb canonical query is OUT-only and emits no per-stage pipeline detail yet);
+> they land in the slices that implement reverse traversal and candidate emission.
+> Gate #4 is validated when those ship — it is not a blocker for the P1 query path.
+
+## Gate #5 — precision + recall floors (manual adjudication)
+
+- **Precision:** sample **N = 50** random **HIGH** edges; manually adjudicate.
+  PASS iff **≥ 95%** are true cross-repo dependencies, with **zero**
+  corroboration-audit failures.
+- **Recall:** against a hand-labeled ground-truth set stratified across
+  {import-resolvable, call-site-only, vendored/header-only}, **≥ 50 sites/language**:
+  HIGH recall **≥ 70%**, HIGH+MEDIUM **≥ 85%**.
+- **AMBIGUOUS depth ≤ 10%** of the candidate universe.
+
+Cross-check against direct SQL on `.254` postgres to confirm the emitted edge set
+matches the labeled set and counts are sane.
+
+## Gate #6 — latency + deployment
+
+- `GET /v1/code/cross-repo-deps` + `aimee index deps` live on the `.254` plugin
+  stack over the full corpus.
+- **p50 ≤ 200 ms, p95 ≤ 2000 ms** for the forward query; capture `EXPLAIN
+  (ANALYZE, BUFFERS)` for the working-set query and confirm the
+  `idx_terms_name` / `idx_code_calls_callee` indexes are used (no seq-scan on the
+  hot path).
+- Deploy via the tierd lifecycle verbs (materialise + start / `update`), **not**
+  `docker restart`.
+
+On all gates passing, flip the proposal from `pending` to the completed state and
+note the measured numbers here.

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -90,6 +90,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-cross-repo-deps \
                $(TESTPREFIX)/unit-test-cross-repo-stats \
                $(TESTPREFIX)/unit-test-cross-repo-deps-orch \
+               $(TESTPREFIX)/unit-test-cross-repo-acceptance \
                $(TESTPREFIX)/unit-test-cross-repo-review \
                $(TESTPREFIX)/unit-test-primary-session-adapter \
                $(TESTPREFIX)/unit-test-webchat-claude-sessions \
@@ -497,6 +498,18 @@ $(TESTPREFIX)/unit-test-cross-repo-stats: \
 # S4a orchestration over the sqlite shim (portable candidate-gen + pure core).
 $(TESTPREFIX)/unit-test-cross-repo-deps-orch: \
                                        $(OBJDIR)/tests/test_cross_repo_deps_orch.o \
+                                       $(OBJDIR)/db2/cross_repo_deps.o \
+                                       $(OBJDIR)/db2/cross_repo_stats.o \
+                                       $(OBJDIR)/db2/cross_repo_resolver.o \
+                                       $(OBJDIR)/db2/cross_repo_classify.o \
+                                       $(OBJDIR)/db2/cross_repo_review.o \
+                                       $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
+                                       $(OBJDIR)/db2/db_schema.o \
+                                       $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lzstd
+
+$(TESTPREFIX)/unit-test-cross-repo-acceptance: \
+                                       $(OBJDIR)/tests/test_cross_repo_acceptance.o \
                                        $(OBJDIR)/db2/cross_repo_deps.o \
                                        $(OBJDIR)/db2/cross_repo_stats.o \
                                        $(OBJDIR)/db2/cross_repo_resolver.o \

--- a/src/tests/test_cross_repo_acceptance.c
+++ b/src/tests/test_cross_repo_acceptance.c
@@ -1,0 +1,293 @@
+/* test_cross_repo_acceptance.c: S8 end-to-end acceptance harness for the
+ * cross-repo dependency graph, run over the sqlite shim. The pure resolver /
+ * classifier strata are exhaustively unit-tested in test_cross_repo_deps.c; this
+ * file drives the SAME enumerated cases through the real DB orchestration
+ * (canonical_index_cross_repo_deps + the review queue) so the full pipeline is
+ * validated, and it mirrors the live acceptance procedure S9 runs against the
+ * .254 corpus (docs/proposals/pending/cross-repo-dependency-graph.md §9).
+ *
+ * Stratified positives + enumerated negatives (acceptance #2-#3, shim tier). Each
+ * no-edge case cites the rule it exercises (crd_flush in db2/cross_repo_deps.c /
+ * the pure suite in test_cross_repo_deps.c):
+ *   - import-resolvable, trusted        -> HIGH   (LiStartConnection-style)
+ *   - import-corroborated, UNTRUSTED caller -> capped MEDIUM (§0 caller cap)
+ *   - UNTRUSTED definer (trusted caller imports it) -> NO edge (§0: an untrusted
+ *                                                   repo can't originate an edge)
+ *   - call-site-only, no corroboration  -> NO edge (no import route + lone definer
+ *                                                   -> crd_flush sets no target)
+ *   - bare-name / common collision      -> no edge (distinctiveness gate)
+ *   - multi-definer, no corroboration   -> AMBIGUOUS -> review queue (no edge)
+ *
+ * Live-only gates (precision N=50, recall floors, p50/p95 latency) need the real
+ * Postgres corpus and are measured in S9, not here. */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "aimee.h"
+#include "db2_test_shim.h"
+#include "../db2/cross_repo_deps.h"
+#include "../db2/cross_repo_review.h"
+#include "../db2/db2.h"
+#include "../db2/db_postgres.h"
+
+static void X(const char *sql)
+{
+   char err[256] = "";
+   int rc = aimee_pg_exec(db2_conn(), sql, err, sizeof(err));
+   if (rc != 0)
+      fprintf(stderr, "seed failed: %s\n  sql: %s\n", err, sql);
+   assert(rc == 0);
+}
+
+/* Add a project with explicit trust. */
+static void mk_project(const char *name, const char *trust)
+{
+   char sql[256];
+   snprintf(sql, sizeof(sql),
+            "INSERT INTO projects (name, root, scanned_at, trust) VALUES ('%s','/%s','t','%s')",
+            name, name, trust);
+   X(sql);
+}
+
+/* Add a file to a project. */
+static void mk_file(const char *project, const char *path)
+{
+   char sql[512];
+   snprintf(sql, sizeof(sql),
+            "INSERT INTO files (project_id,path,scanned_at) SELECT id,'%s','t' FROM projects WHERE "
+            "name='%s'",
+            path, project);
+   X(sql);
+}
+
+static void mk_def(const char *file, const char *name)
+{
+   char sql[512];
+   snprintf(sql, sizeof(sql),
+            "INSERT INTO terms (file_id,name,kind) SELECT id,'%s','definition' FROM files WHERE "
+            "path='%s'",
+            name, file);
+   X(sql);
+}
+
+static void mk_export(const char *file, const char *name)
+{
+   char sql[512];
+   snprintf(sql, sizeof(sql),
+            "INSERT INTO file_exports (file_id,name) SELECT id,'%s' FROM files WHERE path='%s'",
+            name, file);
+   X(sql);
+}
+
+static void mk_import(const char *file, const char *header)
+{
+   char sql[512];
+   snprintf(sql, sizeof(sql),
+            "INSERT INTO file_imports (file_id,name) SELECT id,'%s' FROM files WHERE path='%s'",
+            header, file);
+   X(sql);
+}
+
+static void mk_call(const char *file, const char *callee)
+{
+   char sql[512];
+   snprintf(sql, sizeof(sql),
+            "INSERT INTO code_calls (file_id,callee) SELECT id,'%s' FROM files WHERE path='%s'",
+            callee, file);
+   X(sql);
+}
+
+/* Find the emitted edge to `definer` (NULL if none). */
+static const xrepo_dep_edge_t *find_edge(const xrepo_dep_edge_t *edges, size_t n,
+                                         const char *definer, const char *symbol)
+{
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(edges[i].definer_repo, definer) == 0 &&
+          (!symbol || strcmp(edges[i].example_symbol, symbol) == 0))
+         return &edges[i];
+   return NULL;
+}
+
+/* The whole corpus, seeded once. `app` is a trusted 5-file caller; `ext` an
+ * untrusted 5-file caller. Definer repos each export one distinctive symbol. */
+static void seed_corpus(void)
+{
+   mk_project("app", "trusted");
+   mk_project("ext", "untrusted");
+   mk_project("lib-high", "trusted"); /* import-resolvable HIGH target */
+   mk_project("lib-med", "trusted");  /* call-site-only, no corroboration -> no edge */
+   mk_project("dup-a", "trusted");    /* multi-definer (AMBIGUOUS) */
+   mk_project("dup-b", "trusted");
+
+   for (int i = 0; i < 5; i++)
+   {
+      char p[32];
+      snprintf(p, sizeof(p), "src/app%d.c", i);
+      mk_file("app", p);
+      snprintf(p, sizeof(p), "src/ext%d.c", i);
+      mk_file("ext", p);
+   }
+
+   /* lib-high: defines + exports LiStartConnection in include/Limelight.h-style. */
+   mk_file("lib-high", "include/Limelight.h");
+   mk_file("lib-high", "src/connection.c");
+   mk_def("src/connection.c", "LiStartConnection");
+   mk_export("src/connection.c", "LiStartConnection");
+
+   /* lib-med: defines a distinctive symbol, no header app imports. */
+   mk_file("lib-med", "src/widget.c");
+   mk_def("src/widget.c", "WidgetComputeLayout");
+
+   /* dup-a / dup-b: both define AmbiguousThing (multi-definer, no corroboration). */
+   mk_file("dup-a", "a.c");
+   mk_file("dup-b", "b.c");
+   mk_def("a.c", "AmbiguousThing");
+   mk_def("b.c", "AmbiguousThing");
+
+   /* app: imports Limelight.h + calls LiStartConnection (import-resolvable HIGH);
+    * calls WidgetComputeLayout with NO import (call-site-only -> no edge); calls
+    * AmbiguousThing (multi-definer AMBIGUOUS); calls a bare-name "init" that is
+    * defined nowhere distinctive. Each call lands in 1 of 5 files (distinctive). */
+   mk_import("src/app0.c", "Limelight.h");
+   mk_call("src/app0.c", "LiStartConnection");
+   mk_call("src/app1.c", "WidgetComputeLayout");
+   mk_call("src/app2.c", "AmbiguousThing");
+   mk_call("src/app3.c", "init"); /* bare name: short / non-distinctive */
+
+   /* ext (untrusted): imports Limelight.h + calls LiStartConnection. Import
+    * corroboration rooted in an untrusted caller must cap the edge at MEDIUM. */
+   mk_import("src/ext0.c", "Limelight.h");
+   mk_call("src/ext0.c", "LiStartConnection");
+
+   /* lib-uexp (UNTRUSTED): defines + exports VendoredApiCall and ships its header,
+    * and trusted `app` imports + calls it. With an identical TRUSTED definer this
+    * is a HIGH edge (the import route corroborates); because lib-uexp is untrusted
+    * it must originate NO edge at all (§0). */
+   mk_project("lib-uexp", "untrusted");
+   mk_file("lib-uexp", "include/Vendored.h");
+   mk_file("lib-uexp", "u.c");
+   mk_def("u.c", "VendoredApiCall");
+   mk_export("u.c", "VendoredApiCall");
+   mk_import("src/app4.c", "Vendored.h");
+   mk_call("src/app4.c", "VendoredApiCall");
+}
+
+static void run(const char *caller, xrepo_dep_edge_t **edges, size_t *n)
+{
+   xrepo_deps_opts_t opts = {
+       .direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_LOW, .include_review = 1};
+   int trunc = 0;
+   assert(canonical_index_cross_repo_deps(caller, &opts, edges, n, &trunc) == 0);
+}
+
+static void test_import_resolvable_high(void)
+{
+   printf("test_import_resolvable_high... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   run("app", &edges, &n);
+   const xrepo_dep_edge_t *e = find_edge(edges, n, "lib-high", "LiStartConnection");
+   assert(e && e->tier == XREPO_TIER_HIGH && e->import_corroborated == 1);
+   free(edges);
+   printf("ok\n");
+}
+
+static void test_call_site_only_no_edge(void)
+{
+   printf("test_call_site_only_no_edge... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   run("app", &edges, &n);
+   /* WidgetComputeLayout: distinctive, single trusted definer, but `app` does NOT
+    * import lib-med. Grounded in crd_flush (db2/cross_repo_deps.c): an edge gets a
+    * target -- and is emitted -- ONLY via (a) an import route the caller has, or
+    * (b) the dominant definer among MULTIPLE definers. A lone definer with no
+    * caller import has neither route, so no edge of any tier. Core precision rule. */
+   assert(find_edge(edges, n, "lib-med", "WidgetComputeLayout") == NULL);
+   free(edges);
+   printf("ok\n");
+}
+
+static void test_bare_name_no_edge(void)
+{
+   printf("test_bare_name_no_edge... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   run("app", &edges, &n);
+   /* "init" fails the distinctiveness gate (length < len_min and a ubiquitous
+    * identifier), so xrepo_name_distinctive returns false and crd_flush never
+    * emits it; cf. test_cross_repo_deps.c test_distinctiveness. No edge, any tier. */
+   for (size_t i = 0; i < n; i++)
+      assert(strcmp(edges[i].example_symbol, "init") != 0);
+   free(edges);
+   printf("ok\n");
+}
+
+static void test_multi_definer_ambiguous(void)
+{
+   printf("test_multi_definer_ambiguous... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   run("app", &edges, &n);
+   /* AmbiguousThing emits no edge ... */
+   for (size_t i = 0; i < n; i++)
+      assert(strcmp(edges[i].example_symbol, "AmbiguousThing") != 0);
+   free(edges);
+   /* ... but is surfaced to the review queue. */
+   xrepo_review_row_t rows[16];
+   int rn = db2_cross_repo_review_list("app", "open", rows, 16, NULL);
+   int found = 0;
+   for (int i = 0; i < rn; i++)
+      if (strcmp(rows[i].symbol, "AmbiguousThing") == 0)
+         found = 1;
+   assert(found);
+   printf("ok\n");
+}
+
+static void test_untrusted_import_capped_medium(void)
+{
+   printf("test_untrusted_import_capped_medium... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   run("ext", &edges, &n);
+   const xrepo_dep_edge_t *e = find_edge(edges, n, "lib-high", "LiStartConnection");
+   /* §0 untrusted-CALLER cap: same import corroboration as `app`, but the caller is
+    * untrusted -> capped at MEDIUM (HIGH requires a trusted-rooted signal); cf.
+    * test_cross_repo_deps.c "Untrusted caller caps the import route at MEDIUM". */
+   assert(e && e->tier == XREPO_TIER_MEDIUM);
+   free(edges);
+   printf("ok\n");
+}
+
+static void test_untrusted_definer_no_edge(void)
+{
+   printf("test_untrusted_definer_no_edge... ");
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   run("app", &edges, &n);
+   /* §0 untrusted-DEFINER: `app` (trusted) imports lib-uexp's header and calls
+    * VendoredApiCall, defined+exported ONLY by lib-uexp (untrusted). The trusted
+    * caller's import would corroborate a trusted definer to HIGH (see the
+    * lib-uexp=trusted probe), but an untrusted definer cannot originate a
+    * cross-repo edge at all -- realizing "a planted/forged export in an untrusted
+    * repo can neither create nor suppress an edge". Conservative (stricter than the
+    * literal §0 export-cap-to-MEDIUM, applied here to the import route too). */
+   assert(find_edge(edges, n, "lib-uexp", "VendoredApiCall") == NULL);
+   free(edges);
+   printf("ok\n");
+}
+
+int main(void)
+{
+   db2_test_shim_open();
+   seed_corpus();
+   test_import_resolvable_high();
+   test_call_site_only_no_edge();
+   test_bare_name_no_edge();
+   test_multi_definer_ambiguous();
+   test_untrusted_import_capped_medium();
+   test_untrusted_definer_no_edge();
+   printf("cross_repo_acceptance: all tests passed\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary
Tenth slice of the **cross-repo dependency graph** (`docs/proposals/pending/cross-repo-dependency-graph.md` §9), on S7 (#820). The pure resolver/classifier strata are already exhaustively unit-tested (`test_cross_repo_deps.c`); S8 adds an **end-to-end acceptance harness** that drives the enumerated cases through the real DB orchestration (`canonical_index_cross_repo_deps` + the review queue) over the sqlite shim — the same shape S9 runs live — plus a checked-in runbook for the gates that can only be measured against the real Postgres corpus.

- **`tests/test_cross_repo_acceptance.c`** (new `unit-test-cross-repo-acceptance` target): seeds one stratified multi-repo corpus and asserts, end-to-end:
  - import-resolvable, trusted → **HIGH** (LiStartConnection-style)
  - import-corroborated, **untrusted caller** → capped **MEDIUM** (§0 caller cap)
  - **untrusted definer** (trusted caller imports + calls it) → **no edge** (§0: an untrusted repo can't originate one — verified against a trusted-definer probe that *does* go HIGH)
  - call-site-only, no corroboration → **no edge** (lone definer + no import route ⇒ `crd_flush` sets no target)
  - bare-name / common collision → **no edge** (distinctiveness gate)
  - multi-definer, no corroboration → **AMBIGUOUS** → review queue (no edge)
  Each no-edge assertion cites the rule it exercises (`crd_flush` in `db2/cross_repo_deps.c` / the pure suite).
- **`docs/validation/cross-repo-deps-acceptance.md`**: the S9 live runbook — exact `aimee index deps`/SQL commands + thresholds for acceptance #2 / #3 / #5 / #6 (precision N=50 ≥95%, recall HIGH≥70% / H+M≥85%, AMBIGUOUS≤10%, p50≤200/p95≤2000 ms, EXPLAIN index-use, tierd-lifecycle deploy). Notes #4 (`--reverse`/`--dry-run`) deferred to the slices that implement them.

## Review
Roundtable code review; 3 blocking folded:
- **Grounded** the "call-site-only → no edge" assertion in `crd_flush` (an edge gets a target only via an import route or the dominant definer among many) — not a calibration-to-observed hack.
- **Added** the missing **untrusted-definer** end-to-end case (the harness investigation found it produces *no* edge, stronger than the runbook's prior "capped MEDIUM" wording, which is now corrected).
- **Cited** the governing rule on every no-edge assertion.

Conditional→MEDIUM, dynamic→review, dominant-export tiers remain covered at the pure-unit tier (`test_cross_repo_deps.c`) and live (S9); the shim end-to-end harness covers the strata reachable without a large multi-definer-dominant fixture.

## Gates
All green: line-check, proposal-links, docs-gen, clang-format-19; the new target is registered in TEST_TARGETS and passes. No production-code change.