### PR TITLE
fix(hmem): scope server-side memory interception by the per-request client

### DIFF
--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -709,6 +709,13 @@ static int handle_hooks(int argc, char **argv, int json_output)
    if (sid && sid[0])
       cJSON_AddStringToObject(req, "session_id", sid);
 
+   /* Forward THIS client's identity so the (possibly shared) server scopes memory
+    * interception to the right agent — the server must not assume its own
+    * AIMEE_HOOK_CLIENT when many agents hook into one server. */
+   const char *hook_client = getenv("AIMEE_HOOK_CLIENT");
+   if (hook_client && hook_client[0])
+      cJSON_AddStringToObject(req, "harness_client", hook_client);
+
    /* Resolve the harness-memory project key HERE, on the client, against the real
     * cwd / git repo / AIMEE_PROJECT_ID, and forward it: a remote server's
     * filesystem has none of those, so it could not resolve the key itself. Only

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -720,7 +720,24 @@ static int handle_hud_status(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
 static int server_memory_intercept(const char *tool, const char *tool_input, const char *cwd,
                                    cJSON *req, char *msg, size_t msg_len)
 {
-   const char *client = getenv("AIMEE_HOOK_CLIENT");
+   /* The client identity is per-REQUEST: a single shared server fields hooks from
+    * many agents (claude/gemini/codex/...), so it must use the harness_client the
+    * thin client forwarded — NOT the server's own AIMEE_HOOK_CLIENT env (which
+    * would scope every request to one fixed client). Fall back to the env only for
+    * the local/combined-binary path where no field is sent; on a shared split
+    * server AIMEE_HOOK_CLIENT must be UNSET so an older/3rd-party client that omits
+    * the field is treated as unknown (no interception) rather than mis-scoped.
+    * TRUST: harness_client is client-supplied and untrusted, but it is used SOLELY
+    * as a scope-registry lookup key — never an authorization, filesystem, or DB
+    * path input. An unknown key → no interception; a spoofed registered name only
+    * re-scopes the spoofer's OWN writes (no cross-client exposure, no escalation).
+    * Do not derive anything but the scope from it. */
+   const char *client = NULL;
+   cJSON *hc = cJSON_GetObjectItemCaseSensitive(req, "harness_client");
+   if (cJSON_IsString(hc) && hc->valuestring && hc->valuestring[0])
+      client = hc->valuestring;
+   if (!client)
+      client = getenv("AIMEE_HOOK_CLIENT");
    const char *home = getenv("HOME");
    if (!client || !client[0] || !home || !home[0])
       return 0;


### PR DESCRIPTION
## What

Fixes multi-client memory interception on a **shared split `aimee-server`** — found by executing the interception test plan (cases MC1/MC5) against a deployed server.

## Bug

`server_memory_intercept` derived the client identity from the **server's own** `getenv("AIMEE_HOOK_CLIENT")`. But one shared server fields hooks from many agents (claude/gemini/codex/…), so every request was scoped to whatever client the server process was started with:
- a **gemini** write wasn't intercepted under its own surface (fell through to the generic guardrails — the worktree block);
- an **unregistered** client was still intercepted as the server's fixed client.

## Fix (mirrors the PR-F `harness_project` pattern)

- **cli_main `handle_hooks`**: forward this client's `AIMEE_HOOK_CLIENT` as `harness_client` in the `hooks.pre` request.
- **server.c `server_memory_intercept`**: take the client from the request's `harness_client`; fall back to the server env only for the local/combined-binary path that sends no field.
- Inline trust note: `harness_client` is client-supplied but used **solely** as a scope-registry lookup key (never authz/fs/DB path); unknown → no interception; a spoofed name only re-scopes the spoofer's own writes. On a shared split server `AIMEE_HOOK_CLIENT` must be **unset** so a field-omitting client is treated as unknown, not mis-scoped.

## Testing

- **Validated on a deployed split server with the server's `AIMEE_HOOK_CLIENT` UNSET** (3/3): claude intercepted, gemini intercepted under its config-registered scope, unregistered client → no interception.
- `make all server` + `make unit-tests` + `make lint` green.
- Roundtable-reviewed (`converged`, no blockers); the inline trust-boundary documentation suggestion applied.

This was the one real defect surfaced by running the test plan end-to-end; the rest of the plan (functional loop, reconcile, fail-open, concurrency, security, bash heuristic, watcher) passed on the split server.