### PR TITLE
feat(kb): cross-repo precision H1 — structural-edge gate + index-time rebuild

### DIFF
--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -307,6 +307,11 @@ typedef struct
 {
    const desc_set_t *descs;
    const char *imp_seen; /* CRD_MAX_REPOS flags: repos A imports (import route) */
+   /* H1 structural-edge gate: CRD_MAX_REPOS flags, repos A has a precomputed
+    * cross_repo_route to (import_module/import_header, H0d). A non-LOW edge
+    * REQUIRES a route — a bare name match with no structural route is
+    * LOW-unresolved and not emitted (precision-hardening §1). */
+   const char *route_seen;
    const char *project;
    int caller_trusted;
    xrepo_distinct_cfg_t dcfg;
@@ -320,6 +325,20 @@ typedef struct
    int include_review; /* write AMBIGUOUS candidates to the review queue (S4b) */
    int queue_max;      /* review-queue overflow cap */
 } crd_ctx_t;
+
+/* Bounds-safe route_seen lookup by repo name (H1 structural-edge gate). desc_index
+ * returns -1 (unknown name) or an index in [0, descs->n); descs->n is capped at
+ * CRD_MAX_REPOS at load (load_descs), so a valid index is always < route_seen's
+ * size. The explicit `< CRD_MAX_REPOS` bound documents that invariant and stays
+ * safe if the load cap ever diverges from the array size. */
+static int route_seen_has(const crd_ctx_t *ctx, const char *repo)
+{
+   int di = desc_index(ctx->descs, repo);
+   /* Out-of-range / unknown name returns 0 = "no route" = FAIL-CLOSED: the gate
+    * rejects (demotes to LOW), never permissively accepts. So a future load_descs
+    * cap regression degrades recall (safe), never precision. */
+   return (di >= 0 && di < CRD_MAX_REPOS) ? ctx->route_seen[di] : 0;
+}
 
 /* Classify one accumulated candidate symbol (its definer rows) and, if it clears
  * the gates/min_tier, fold it into the per-(caller,definer) edge accumulator.
@@ -378,11 +397,24 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
    }
 
    int definer_trusted = 0;
+   int target_has_route = 0;
    if (target >= 0)
    {
       int di = desc_index(ctx->descs, defs[target].repo);
       definer_trusted = di >= 0 ? ctx->descs->d[di].trusted : 0;
+      target_has_route = route_seen_has(ctx, defs[target].repo);
    }
+
+   /* H1 structural-edge gate, applied uniformly: does the caller have a precomputed
+    * route to ANY of this symbol's definers? defs[0..ndef) IS the full external
+    * definer set the resolver accumulated for this symbol (the same array target
+    * selection and the AMBIGUOUS rep use), so this matches the resolver's definer
+    * coverage exactly. If no route to any definer, the symbol is a bare name
+    * collision with no structural backing — neither emit it (below) NOR surface it
+    * to the review queue, so name-only noise can't leak in via the AMBIGUOUS path. */
+   int any_route = 0;
+   for (int i = 0; i < ndef && !any_route; i++)
+      any_route = route_seen_has(ctx, defs[i].repo);
 
    xrepo_candidate_t c = {0};
    c.lang = lang;
@@ -396,8 +428,11 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
    c.modality = XREPO_IMPORT_STATIC;
    xrepo_classification_t cl = xrepo_classify(&c);
 
-   /* AMBIGUOUS -> review queue (§3.8), surfaced not dropped. */
-   if (cl.tier == XREPO_TIER_AMBIGUOUS && ctx->include_review)
+   /* AMBIGUOUS -> review queue (§3.8), surfaced not dropped — but only when a
+    * structural route exists to at least one definer (H1 invariant: no route =>
+    * not a cross-repo relation at all, so not even review-worthy). The genuine
+    * route-backed multi-definer collisions are H2's canonical pass. */
+   if (cl.tier == XREPO_TIER_AMBIGUOUS && ctx->include_review && any_route)
    {
       int routes = (c.corroboration != XREPO_CORROB_NONE) ? 1 : 0;
       double score = xrepo_evidence_score(distinctive ? definer_rc : 0, sites, routes);
@@ -419,8 +454,25 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
                                    "ambiguous", 0, ctx->queue_max);
    }
 
-   if (target >= 0 && cl.tier >= ctx->min_tier && cl.tier != XREPO_TIER_AMBIGUOUS &&
-       cl.tier != XREPO_TIER_NONE && cl.tier != XREPO_TIER_UNIMPLEMENTED)
+   /* H1 structural-edge gate (precision-hardening §1): a non-LOW edge REQUIRES a
+    * precomputed cross_repo_route caller->definer. A bare distinctive-name match
+    * with no real import/module route is LOW-unresolved and not emitted — this is
+    * what collapses the name-collision false positives (DEFINE_GUID, generic
+    * exports) that have no structural route to the named definer. */
+   /* Instrumentation for H4 recall analysis: a candidate that WOULD have emitted a
+    * non-LOW edge but is held back solely for lack of a structural route. Lets H4
+    * distinguish no-route demotions (this) from route-but-untrusted-definer drops,
+    * so link-only recall loss (build/link routes H0d doesn't model yet) is
+    * measurable before deciding on H0e link-directive extraction. */
+   if (target >= 0 && !target_has_route && cl.tier >= ctx->min_tier &&
+       cl.tier != XREPO_TIER_AMBIGUOUS && cl.tier != XREPO_TIER_NONE &&
+       cl.tier != XREPO_TIER_UNIMPLEMENTED)
+      LOG_DEBUG(CRD_LOG_TAG, "low-unresolved (no route): %s -> %s via %s", ctx->project,
+                defs[target].repo, sym);
+
+   if (target >= 0 && target_has_route && cl.tier >= ctx->min_tier &&
+       cl.tier != XREPO_TIER_AMBIGUOUS && cl.tier != XREPO_TIER_NONE &&
+       cl.tier != XREPO_TIER_UNIMPLEMENTED)
    {
       xrepo_dep_edge_t *E = edge_find_or_add(acc, ctx->project, defs[target].repo);
       if (E)
@@ -540,8 +592,42 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
       }
    }
 
+   /* H1 structural-edge gate: repos A has a precomputed cross_repo_route to (H0d).
+    * Read the inter-repo route adjacency once (off the per-candidate path) so the
+    * flush can require a structural route in-memory without an N+1 query.
+    * Concurrency: db2_cross_repo_rebuild_routes rebuilds the table inside a single
+    * BEGIN/DELETE/INSERT/COMMIT txn, so under Postgres MVCC this one SELECT sees a
+    * complete pre- or post-rebuild snapshot — never a half-rebuilt table. A rebuild
+    * committing between this load and the later candidate queries can at worst use
+    * one-call-stale routes (self-healing next call); the rebuild's atomicity rules
+    * out the partial-state precision leak. Keyed by projects.name on BOTH sides
+    * (rebuild_routes writes caller/definer_project from projects.name; desc_index
+    * resolves the same column) so there is no writer/reader name-form drift. */
+   char route_seen[CRD_MAX_REPOS];
+   memset(route_seen, 0, sizeof(route_seen));
+   if (a_idx >= 0)
+   {
+      char rerr[CRD_ERR] = "";
+      aimee_pg_stmt_t *rt = aimee_pg_prepare(
+          conn, "SELECT DISTINCT definer_project FROM cross_repo_route WHERE caller_project = ?1",
+          rerr, sizeof(rerr));
+      if (rt)
+      {
+         aimee_pg_bind_text(rt, "?1", project);
+         while (aimee_pg_step(rt, rerr, sizeof(rerr)) == AIMEE_PG_ROW)
+         {
+            const char *dn = aimee_pg_column_text(rt, 0);
+            int di = dn ? desc_index(&descs, dn) : -1;
+            if (di >= 0 && di < CRD_MAX_REPOS) /* bound: descs.n <= CRD_MAX_REPOS */
+               route_seen[di] = 1;
+         }
+         aimee_pg_finalize(rt);
+      }
+   }
+
    crd_ctx_t ctx = {.descs = &descs,
                     .imp_seen = imp_seen,
+                    .route_seen = route_seen,
                     .project = project,
                     .caller_trusted = (a_idx >= 0) ? descs.d[a_idx].trusted : 1,
                     .dcfg = dcfg,

--- a/src/kb/kb_curator_drain.c
+++ b/src/kb/kb_curator_drain.c
@@ -10,6 +10,9 @@
 #endif
 
 #include "db2/db2.h"
+#include "db2/cross_repo_identity.h" /* db2_cross_repo_rebuild_identities (H0c) */
+#include "db2/cross_repo_route.h"    /* db2_cross_repo_rebuild_routes (H0d) */
+#include "db2/cross_repo_stats.h"    /* db2_cross_repo_recompute_blocked_symbols */
 #include "kb_curator_drain.h"
 #include "kb_curator_extract.h"
 #include "kb_curator_resolve_entities.h"
@@ -49,12 +52,67 @@
  * reload still get a turn each poll (both progress). */
 #define CURATOR_DRAIN_BATCH 16
 
+/* Rebuild the corpus-derived cross-repo precision metadata (precision-hardening
+ * H0/H1): the H0c repo-identity index, the H0d inter-repo structural-route
+ * adjacency, and the distinctiveness blocked-symbols model. In dependency order:
+ * routes are keyed on identities, so a failed identity rebuild must NOT proceed
+ * to routes (it would key them on stale/partial identities). Returns 0 on a
+ * completed rebuild, -1 if the store is not ready / a sub-rebuild failed (caller
+ * retries next poll). Idempotent + set-based DB2; no embedder/LLM.
+ *
+ * Failure semantics — fail-to-last-known-good, NOT fail-open: each sub-rebuild
+ * (rebuild_identities, rebuild_routes) is internally atomic (BEGIN/DELETE/INSERT/
+ * COMMIT, ROLLBACK on error), and cross_repo_route rows store project NAMES (no FK
+ * into the identity table). So on any failure path cross_repo_route remains a
+ * complete, internally-consistent snapshot from the last SUCCESSFUL build — the
+ * resolver's gate keeps using last-known-good routes (bounded staleness, self-
+ * healed by the next successful rebuild), never a torn/partial table and never a
+ * permissive no-route-accepts-all state (no-route demotes to LOW). A persistent
+ * failure is surfaced via WARN so a wedged db2 / schema drift is observable. */
+static int kb_cross_repo_meta_rebuild(const config_t *cfg)
+{
+   int ids = db2_cross_repo_rebuild_identities();
+   if (ids < 0)
+   {
+      aimee_log(
+          LOG_WARN, "kb.cross_repo.meta",
+          "identity rebuild unavailable/failed; gate keeps last-known-good routes this cycle");
+      return -1;
+   }
+   int routes = db2_cross_repo_rebuild_routes();
+   if (routes < 0)
+   {
+      aimee_log(LOG_WARN, "kb.cross_repo.meta",
+                "route rebuild failed; gate keeps last-known-good routes this cycle");
+      return -1;
+   }
+   int bsym = db2_cross_repo_recompute_blocked_symbols(cfg->kb_curator_cross_repo_k,
+                                                       cfg->kb_curator_cross_repo_m,
+                                                       cfg->kb_curator_cross_repo_len_min);
+   aimee_log(LOG_INFO, "kb.cross_repo.meta",
+             "rebuilt cross-repo metadata: identities=%d routes=%d blocked_symbols=%d", ids, routes,
+             bsym);
+   return 0;
+}
+
 static void *drain_thread_main(void *arg)
 {
    kb_curator_drain_ctx_t *ctx = (kb_curator_drain_ctx_t *)arg;
 
    config_t cfg;
    config_load(&cfg);
+
+   /* Cold-start backfill: a quiescent / already-indexed corpus never produces a
+    * built>0 event, so the incremental rebuild below would never fire and
+    * cross_repo_route would stay empty — silently demoting every legitimate
+    * non-LOW cross-repo edge to LOW indefinitely. Run the rebuild once at startup,
+    * independent of corpus change, so routes exist before the resolver is queried.
+    * Retried until it succeeds once (db2 may not be open on the first iteration),
+    * then never again (cleared on the first 0-return); self-heals within one poll
+    * of the store coming up. The retry is naturally rate-limited to one attempt
+    * per DRAIN_POLL_SECS, and each attempt is cheap on a wedged store (db2_conn()
+    * returns NULL fast -> -1). */
+   int cross_repo_cold_start_pending = 1;
 
    /* No artificial rate cap (§5): the curator drains the backlog continuously and
     * then idles. The natural throttle is backend throughput; cost control for a
@@ -79,6 +137,15 @@ static void *drain_thread_main(void *arg)
          config_load(&cfg);
          last_cfg_reload = now;
       }
+
+      /* Cold-start cross-repo metadata backfill (see cross_repo_cold_start_pending
+       * above): once, as soon as the store is ready, so a quiescent corpus's
+       * routes/identities exist before the structural-edge gate queries them.
+       * Cleared only on a successful (0-return) rebuild, so a failed attempt stays
+       * pending and retries — the one-shot guarantee is the flag-clear here. */
+      if (cross_repo_cold_start_pending && cfg.kb_curator_cross_repo_graph_enabled &&
+          kb_cross_repo_meta_rebuild(&cfg) == 0)
+         cross_repo_cold_start_pending = 0;
 
       /* Evidence-vector embed drain — runs every poll, independent of the
        * curator extract gates (it fills evidence_vectors for the neighbourhood
@@ -191,6 +258,18 @@ static void *drain_thread_main(void *arg)
             aimee_log(LOG_INFO, "kb.graph.projection",
                       "published %lld edge(s) across %d changed project(s)", (long long)total,
                       built);
+
+         /* Incremental cross-repo metadata refresh: a project changed this cycle
+          * (the content-addressed `built` signal), so rebuild the H0c identities,
+          * H0d routes, and the distinctiveness model to keep the structural-edge
+          * gate fresh without a manual recompute. Idempotent; on a multi-poll
+          * catch-up the rebuild repeats once per poll-with-changes (set-based, no
+          * LLM — correctness-safe; coalescing to one rebuild at quiescence is a
+          * possible future optimization). The flag here also gates the resolver
+          * (cross_repo_deps.c) and the cold-start backfill above: disabling it
+          * turns off precision gating AND route population together. */
+         if (built > 0 && cfg.kb_curator_cross_repo_graph_enabled)
+            kb_cross_repo_meta_rebuild(&cfg);
       }
 
       /* Candidate-generation synthesis drain — the heavy LLM pass, on the

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -508,6 +508,8 @@ $(TESTPREFIX)/unit-test-cross-repo-deps-orch: \
                                        $(OBJDIR)/db2/cross_repo_resolver.o \
                                        $(OBJDIR)/db2/cross_repo_classify.o \
                                        $(OBJDIR)/db2/cross_repo_review.o \
+                                       $(OBJDIR)/db2/cross_repo_identity.o \
+                                       $(OBJDIR)/db2/cross_repo_route.o \
                                        $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
                                        $(OBJDIR)/db2/db_schema.o \
                                        $(TEST_CORE_OBJS)

--- a/src/tests/test_cross_repo_acceptance.c
+++ b/src/tests/test_cross_repo_acceptance.c
@@ -171,6 +171,17 @@ static void seed_corpus(void)
    mk_export("u.c", "VendoredApiCall");
    mk_import("src/app4.c", "Vendored.h");
    mk_call("src/app4.c", "VendoredApiCall");
+
+   /* H1 structural-edge routes (H0d) for the import-corroborated edges: app->lib-high
+    * and the untrusted-caller ext->lib-high (capped MEDIUM). app->lib-uexp gets a
+    * route too so the test proves the untrusted-DEFINER §0 rule (not the route gate)
+    * is what blocks that edge. lib-med/dup-* have no import, hence no route. */
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('app','lib-high','import_header','medium','Limelight.h')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('ext','lib-high','import_header','medium','Limelight.h')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('app','lib-uexp','import_header','medium','Vendored.h')");
 }
 
 static void run(const char *caller, xrepo_dep_edge_t **edges, size_t *n)
@@ -234,14 +245,17 @@ static void test_multi_definer_ambiguous(void)
    for (size_t i = 0; i < n; i++)
       assert(strcmp(edges[i].example_symbol, "AmbiguousThing") != 0);
    free(edges);
-   /* ... but is surfaced to the review queue. */
+   /* ... and is NOT surfaced to review either: dup-a/dup-b both define it but `app`
+    * has no structural route to either (no import), so under the H1 invariant it is
+    * bare name noise, not a review-worthy cross-repo ambiguity. (The route-backed
+    * ambiguity-IS-surfaced case is covered in test_cross_repo_deps_orch.) */
    xrepo_review_row_t rows[16];
    int rn = db2_cross_repo_review_list("app", "open", rows, 16, NULL);
    int found = 0;
    for (int i = 0; i < rn; i++)
       if (strcmp(rows[i].symbol, "AmbiguousThing") == 0)
          found = 1;
-   assert(found);
+   assert(!found);
    printf("ok\n");
 }
 

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -8,7 +8,9 @@
 #include "aimee.h"
 #include "db2_test_shim.h"
 #include "../db2/cross_repo_deps.h"
+#include "../db2/cross_repo_identity.h"
 #include "../db2/cross_repo_review.h"
+#include "../db2/cross_repo_route.h"
 #include "../db2/db2.h"
 #include "../db2/db_postgres.h"
 
@@ -89,6 +91,11 @@ static void seed_moonlight(void)
      "path='src/main.cpp'");
    X("INSERT INTO code_calls (file_id,callee) SELECT id,'LiStartConnection' FROM files WHERE "
      "path='src/main.cpp'");
+   /* H1 structural-edge gate: the precomputed inter-repo route (H0d) that makes
+    * this a real dependency rather than a bare name match. Without it the gate
+    * holds the edge at LOW-unresolved (not emitted). */
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('moonlight-qt','moonlight-common-c','import_header','medium','Limelight.h')");
 }
 
 static void test_end_to_end(void)
@@ -137,6 +144,13 @@ static void test_ambiguous_to_review(void)
    /* called in 1 of moonlight-qt's 5 files (20% -> distinctive); A imports neither. */
    X("INSERT INTO code_calls (file_id,callee) SELECT id,'AmbiguousThing' FROM files WHERE "
      "path='src/a.cpp'");
+   /* H1: genuine route-backed ambiguity — A has a structural route to BOTH definers,
+    * so the multi-definer collision is real (which one?) and worth review (vs the
+    * no-route name-noise case, asserted not-surfaced in acceptance). */
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('moonlight-qt','lib-x','import_header','medium','ambig.h')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('moonlight-qt','lib-y','import_header','medium','ambig.h')");
 
    xrepo_deps_opts_t opts = {
        .direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM, .include_review = 1};
@@ -149,7 +163,7 @@ static void test_ambiguous_to_review(void)
       assert(strcmp(edges[i].example_symbol, "AmbiguousThing") != 0);
    free(edges);
 
-   /* but it WAS surfaced to the review queue. */
+   /* but it WAS surfaced to the review queue (route-backed ambiguity). */
    xrepo_review_row_t rows[16];
    int rn = db2_cross_repo_review_list("moonlight-qt", "open", rows, 16, NULL);
    int found = 0;
@@ -160,6 +174,127 @@ static void test_ambiguous_to_review(void)
    printf("ok\n");
 }
 
+/* H1 structural-edge gate in isolation: an otherwise-HIGH candidate (distinctive,
+ * single trusted definer, import + call) is NOT emitted while no cross_repo_route
+ * exists; inserting the route flips it to an edge. The route is the ONLY variable. */
+static void test_structural_edge_gate(void)
+{
+   printf("test_structural_edge_gate... ");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES "
+     "('gate-app','/ga','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES "
+     "('gate-lib','/gl','t','trusted')");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'gsrc/0.cpp','t' FROM projects "
+     "WHERE name='gate-app'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'gsrc/1.cpp','t' FROM projects "
+     "WHERE name='gate-app'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'gsrc/2.cpp','t' FROM projects "
+     "WHERE name='gate-app'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'gsrc/3.cpp','t' FROM projects "
+     "WHERE name='gate-app'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'gsrc/4.cpp','t' FROM projects "
+     "WHERE name='gate-app'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'include/Gate.h','t' FROM projects "
+     "WHERE name='gate-lib'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'src/gate.c','t' FROM projects "
+     "WHERE name='gate-lib'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'GateDistinctiveSym','definition' FROM files "
+     "WHERE path='src/gate.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'GateDistinctiveSym' FROM files WHERE "
+     "path='src/gate.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Gate.h' FROM files WHERE "
+     "path='gsrc/0.cpp'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'GateDistinctiveSym' FROM files WHERE "
+     "path='gsrc/0.cpp'");
+
+   xrepo_deps_opts_t opts = {.direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+
+   /* No route yet: the candidate is structurally unbacked -> no gate-lib edge. */
+   assert(canonical_index_cross_repo_deps("gate-app", &opts, &edges, &n, &trunc) == 0);
+   for (size_t i = 0; i < n; i++)
+      assert(strcmp(edges[i].definer_repo, "gate-lib") != 0);
+   free(edges);
+   edges = NULL;
+
+   /* Insert the structural route -> the same candidate now emits an edge. */
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('gate-app','gate-lib','import_header','medium','Gate.h')");
+   assert(canonical_index_cross_repo_deps("gate-app", &opts, &edges, &n, &trunc) == 0);
+   int found = 0;
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(edges[i].definer_repo, "gate-lib") == 0)
+         found = 1;
+   assert(found);
+   free(edges);
+   printf("ok\n");
+}
+
+/* Cold-start end-to-end: the curator drain's rebuild path (db2_cross_repo_rebuild_
+ * identities + rebuild_routes) populates cross_repo_route from raw file_imports/
+ * files with NO hand-seeded route, and the resolver's gate then accepts the edge.
+ * Proves the rebuild produces gate-acceptable routes (the cold-start backfill in
+ * kb_curator_drain.c) and that an empty route table drops the edge (the cliff the
+ * backfill fixes). Header-route variant: C caller #include -> non-vendored
+ * definer file basename. */
+static void test_cold_start_rebuild_to_gate(void)
+{
+   printf("test_cold_start_rebuild_to_gate... ");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('cs-app','/ca','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('cs-lib','/cl','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[256];
+      snprintf(
+          sql, sizeof(sql),
+          "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT id,'src/%d.c',"
+          "'t','c',0 FROM projects WHERE name='cs-app'",
+          i);
+      X(sql);
+   }
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'include/CsWidget.h','t','c',0 FROM projects WHERE name='cs-lib'");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'src/cs.c','t','c',0 "
+     "FROM projects WHERE name='cs-lib'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'CsDistinctiveSym','definition' FROM files "
+     "WHERE path='src/cs.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'CsDistinctiveSym' FROM files WHERE "
+     "path='src/cs.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'CsWidget.h' FROM files WHERE "
+     "path='src/0.c' AND project_id=(SELECT id FROM projects WHERE name='cs-app')");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'CsDistinctiveSym' FROM files WHERE "
+     "path='src/0.c' AND project_id=(SELECT id FROM projects WHERE name='cs-app')");
+
+   xrepo_deps_opts_t opts = {.direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+
+   /* Empty route table (cold start, no backfill): the cliff — edge dropped. */
+   assert(canonical_index_cross_repo_deps("cs-app", &opts, &edges, &n, &trunc) == 0);
+   for (size_t i = 0; i < n; i++)
+      assert(strcmp(edges[i].definer_repo, "cs-lib") != 0);
+   free(edges);
+   edges = NULL;
+
+   /* The drain's rebuild sequence (the cold-start backfill) populates routes. */
+   assert(db2_cross_repo_rebuild_identities() >= 0);
+   assert(db2_cross_repo_rebuild_routes() >= 1);
+
+   /* Same resolver call now emits the edge — the real route satisfies the gate. */
+   assert(canonical_index_cross_repo_deps("cs-app", &opts, &edges, &n, &trunc) == 0);
+   int found = 0;
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(edges[i].definer_repo, "cs-lib") == 0)
+         found = 1;
+   assert(found);
+   free(edges);
+   printf("ok\n");
+}
+
 int main(void)
 {
    test_parse_module_id();
@@ -167,6 +302,8 @@ int main(void)
    test_empty_graceful();
    test_end_to_end();
    test_ambiguous_to_review();
+   test_structural_edge_gate();
+   test_cold_start_rebuild_to_gate();
    printf("cross_repo_deps_orch: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Slice **H1** of the cross-repo precision-hardening — the payoff slice. Live HIGH precision was ~10–20% because a cross-repo edge was emitted on a distinctive **name** match alone (`DEFINE_GUID`→Sunshine, generic exports). H1 makes a precomputed `cross_repo_route` (H0d) a **hard prerequisite** for any non-LOW edge: no real import/module route caller→definer ⇒ LOW-unresolved, not emitted.

## Changes

- **The gate** (`src/db2/cross_repo_deps.c`): the caller's route set is loaded once per resolver call into `route_seen[]` (inlined SQL — no per-candidate N+1, no new link dependency). `route_seen_has()` is bounds-safe and fail-closed. `crd_flush` requires a route to the target for the non-LOW emit gate, and a route to **any** definer for AMBIGUOUS review-queue surfacing, so name-only noise can't leak via either path. A `LOG_DEBUG` instruments no-route demotions for H4 recall analysis.
- **Index-time rebuild** (`src/kb/kb_curator_drain.c`): the previously-missing caller for H0c/H0d. A one-shot **cold-start** rebuild populates identities + routes + blocked-symbols as soon as the store is ready (so a quiescent / already-indexed corpus gets routes without a re-scan); the `built>0` path keeps them fresh on change. Dependency-ordered with error short-circuit; **fail-to-last-known-good** (never fail-open), failures surfaced via WARN.
- **Tests**: gate-in-isolation (toggle only the route → no-edge then edge), cold-start end-to-end (drives the real `rebuild_identities`/`rebuild_routes`, no hand-seeded row), and both sides of the AMBIGUOUS invariant.

## Verification

Full unit-test suite (897) green, `make lint` green, `aimee-kb` links. Reviewed via the aimee roundtable to convergence (two rounds; the round-2 blocker — rebuild-failure behavior — resolved as documented fail-to-last-known-good + WARN observability).

## Deferred (explicit)

Tier-1 FFI bridges (needs cross-lang FFI marker extraction = H0e) and build/link-only routes (CMake `target_link_libraries` — H0d builds routes from `file_imports` only). The no-route demotion log lets H4 quantify the recall impact before deciding to add them.