### PR TITLE
feat(kb): cross-repo precision H2 — vendor canonical-preference

### DIFF
--- a/src/db2/cross_repo_classify.h
+++ b/src/db2/cross_repo_classify.h
@@ -42,6 +42,8 @@ typedef struct
    const char *self_type;   /* qualified receiver/self/trait type; "" if free function */
    int arity;               /* parameter count; -1 if unknown */
    const char *param_types; /* normalized parameter type list; "" if unknown */
+   int vendored;            /* §4: 1 if this repo's defs of the symbol are ALL in vendored
+                               files (no canonical copy); 0 if a non-vendored def exists */
 } xrepo_def_t;
 
 typedef enum

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -350,10 +350,63 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
 {
    if (ndef == 0)
       return; /* no external definer */
+
+   /* §4 vendor canonical-preference (precision-hardening §4a + §4b combined): a
+    * symbol may be legitimately vendored (FetchContent subprojects/, header-only
+    * stb/nlohmann in third_party/), so do NOT blanket-drop vendored definers. Drop
+    * a vendored duplicate ONLY when a non-vendored definer of the SAME symbol is
+    * ALSO structurally route-reachable from the caller — that canonical definer is
+    * the real dependency, so the vendored copy is noise that would otherwise
+    * inflate multiplicity into a false AMBIGUOUS / steal the target. If NO
+    * non-vendored candidate is route-reachable, the vendored copy is KEPT: it may
+    * be the copy the caller actually includes (caller vendors lib V's header), and
+    * dropping it would lose the real caller->V edge (the H1 gate would then emit
+    * nothing). A lone vendored definer is likewise kept (header-only-library
+    * exemption); the H1 route gate still requires a real route to it.
+    *
+    * Runs before multiplicity/target so the canonical pass precedes AMBIGUOUS and
+    * the review-queue upsert (pipeline order §7), so review rows are written over
+    * the canonicalized candidate set (no stale vendored-candidate rows). Two-pass
+    * for auditability: free dropped candidates' only heap field (.repo;
+    * self_type/param_types are "" literals, dcount/dexp are parallel int arrays,
+    * no heap), THEN compact survivors with no frees — the tail free loop covers
+    * exactly the surviving [0,ndef). */
+   int has_canonical_route = 0;
+   for (int i = 0; i < ndef; i++)
+      if (!defs[i].vendored && route_seen_has(ctx, defs[i].repo))
+      {
+         has_canonical_route = 1;
+         break;
+      }
+   if (has_canonical_route)
+   {
+      for (int i = 0; i < ndef; i++)
+         if (defs[i].vendored)
+            free((char *)defs[i].repo);
+      int w = 0;
+      for (int i = 0; i < ndef; i++)
+         if (!defs[i].vendored)
+         {
+            if (w != i)
+            {
+               defs[w] = defs[i];
+               dcount[w] = dcount[i];
+               dexp[w] = dexp[i];
+            }
+            w++;
+         }
+      ndef = w;
+   }
+
    xrepo_lang_t lang = defs[0].lang;
 
    /* definer_repo_count over TRUSTED repos (incl. the caller if it is a trusted
-    * definer) — the distinctiveness "defined in >= M repos" signal. */
+    * definer) — the distinctiveness "defined in >= M repos" signal. Computed over
+    * the CANONICALIZED candidate set (§4 may have dropped route-reachable-canonical
+    * duplicates above), so it deliberately measures distinctiveness over canonical
+    * definers, not raw physical copies — a symbol with one canonical definer plus N
+    * vendored copies counts as 1, which is correct (the copies are the same symbol,
+    * not evidence the name is generic). */
    int definer_rc = 0;
    for (int i = 0; i < ndef; i++)
    {
@@ -667,7 +720,8 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
        "          JOIN projects pa ON pa.id = fa.project_id WHERE pa.name = ?1 "
        "          AND cca.callee = c.sym) AS caller_files, "
        "       (SELECT COUNT(*) FROM blocked_symbols b WHERE b.word = c.sym AND b.lang = '') AS "
-       "blk "
+       "blk, "
+       "       MIN(df.vendored) AS dvendored "
        "FROM cand c JOIN terms dt ON dt.name = c.sym AND dt.kind = 'definition' "
        "JOIN files df ON df.id = dt.file_id JOIN projects dp ON dp.id = df.project_id "
        "GROUP BY c.sym, c.sites, c.files, c.exfile, c.exline, dp.name, dp.trust "
@@ -733,6 +787,9 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
          defs[ndef].self_type = "";
          defs[ndef].arity = -1;
          defs[ndef].param_types = "";
+         /* §4: MIN(df.vendored) — last SELECT column (index 12). Adding query columns
+          * must APPEND + bump this index; this is the sole consumer of the cursor. */
+         defs[ndef].vendored = aimee_pg_column_int(cq, 12) > 0 ? 1 : 0;
          dcount[ndef] = aimee_pg_column_int(cq, 6);
          dexp[ndef] = aimee_pg_column_int(cq, 8) > 0 ? 1 : 0;
          ndef++;

--- a/src/tests/test_cross_repo_deps.c
+++ b/src/tests/test_cross_repo_deps.c
@@ -270,15 +270,15 @@ static void test_multiplicity(void)
    xrepo_mult_cfg_t cfg = {.dom_share_pct = 90, .runnerup_share_pct = 5, .runnerup_abs = 2};
 
    /* Single definer repo. */
-   xrepo_def_t one[] = {{"repo-b", XREPO_LANG_C, "", 2, "int,int"}};
+   xrepo_def_t one[] = {{"repo-b", XREPO_LANG_C, "", 2, "int,int", 0}};
    int oc[] = {3};
    int oe[] = {1};
    xrepo_mult_t m = xrepo_classify_multiplicity(one, oc, oe, 1, &cfg);
    assert(m.kind == XREPO_MULT_SINGLE && m.dominant_index == 0);
 
    /* Dominant definer: 95 defs vs 1, runner-up not an exporter -> DOMINANT. */
-   xrepo_def_t dom[] = {{"repo-b", XREPO_LANG_C, "", 1, "int"},
-                        {"repo-c", XREPO_LANG_C, "", 1, "int"}};
+   xrepo_def_t dom[] = {{"repo-b", XREPO_LANG_C, "", 1, "int", 0},
+                        {"repo-c", XREPO_LANG_C, "", 1, "int", 0}};
    int dc[] = {95, 1};
    int de[] = {1, 0};
    m = xrepo_classify_multiplicity(dom, dc, de, 2, &cfg);
@@ -297,8 +297,8 @@ static void test_multiplicity(void)
 
    /* Provably-unrelated signatures (differing arity) -> name-clash even if a
     * count majority exists (polymorphic rescue does not apply). */
-   xrepo_def_t unrel[] = {{"repo-b", XREPO_LANG_CPP, "", 1, ""},
-                          {"repo-c", XREPO_LANG_CPP, "", 3, ""}};
+   xrepo_def_t unrel[] = {{"repo-b", XREPO_LANG_CPP, "", 1, "", 0},
+                          {"repo-c", XREPO_LANG_CPP, "", 3, "", 0}};
    int uc[] = {95, 1};
    int ue[] = {1, 0};
    m = xrepo_classify_multiplicity(unrel, uc, ue, 2, &cfg);
@@ -306,8 +306,8 @@ static void test_multiplicity(void)
 
    /* Unknown/variadic signatures (arity -1, "" params) are NOT provably unrelated,
     * so a clear count majority still resolves to DOMINANT (overloads not punished). */
-   xrepo_def_t vararg[] = {{"repo-b", XREPO_LANG_CPP, "", -1, ""},
-                           {"repo-c", XREPO_LANG_CPP, "", 2, ""}};
+   xrepo_def_t vararg[] = {{"repo-b", XREPO_LANG_CPP, "", -1, "", 0},
+                           {"repo-c", XREPO_LANG_CPP, "", 2, "", 0}};
    m = xrepo_classify_multiplicity(vararg, dc, de, 2, &cfg); /* dc={95,1}, de={1,0} */
    assert(m.kind == XREPO_MULT_DOMINANT);
 

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -295,6 +295,225 @@ static void test_cold_start_rebuild_to_gate(void)
    printf("ok\n");
 }
 
+/* §4 vendor canonical-preference: (a) when a symbol is defined in BOTH a
+ * non-vendored repo and a vendored copy, the vendored candidate is dropped so the
+ * pair resolves to the canonical repo (not a false AMBIGUOUS); (b) a lone vendored
+ * definer with a route is still emitted (header-only-library exemption). */
+static void test_vendor_canonical_preference(void)
+{
+   printf("test_vendor_canonical_preference... ");
+   /* (a) canonical vs vendored duplicate. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vc-app','/va','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES "
+     "('vc-canon','/vc','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vc-vend','/vv','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[256];
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'src/%d.c','t','c',0 FROM projects WHERE name='vc-app'",
+               i);
+      X(sql);
+   }
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'include/Canon.h','t','c',0 FROM projects WHERE name='vc-canon'");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT id,'src/canon.c','t',"
+     "'c',0 FROM projects WHERE name='vc-canon'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'VendorCanonSym','definition' FROM files "
+     "WHERE path='src/canon.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'VendorCanonSym' FROM files WHERE "
+     "path='src/canon.c'");
+   /* vc-vend defines the SAME symbol but only in a vendored file. */
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/dup.c','t','c',1 FROM projects WHERE name='vc-vend'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'VendorCanonSym','definition' FROM files "
+     "WHERE path='third_party/dup.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Canon.h' FROM files WHERE path='src/0.c' "
+     "AND project_id=(SELECT id FROM projects WHERE name='vc-app')");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'VendorCanonSym' FROM files WHERE "
+     "path='src/0.c' AND project_id=(SELECT id FROM projects WHERE name='vc-app')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('vc-app','vc-canon','import_header','medium','Canon.h')");
+
+   xrepo_deps_opts_t opts = {
+       .direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM, .include_review = 1};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+   assert(canonical_index_cross_repo_deps("vc-app", &opts, &edges, &n, &trunc) == 0);
+   int canon = 0, vend = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      if (strcmp(edges[i].definer_repo, "vc-canon") == 0)
+         canon = 1;
+      if (strcmp(edges[i].definer_repo, "vc-vend") == 0)
+         vend = 1;
+   }
+   /* vendored duplicate dropped -> resolves to canonical, NOT AMBIGUOUS, no vend edge. */
+   assert(canon && !vend);
+   free(edges);
+   edges = NULL;
+   /* VendorCanonSym is NOT in the review queue (not ambiguous after canonical pass). */
+   xrepo_review_row_t rows[16];
+   int rn = db2_cross_repo_review_list("vc-app", "open", rows, 16, NULL);
+   for (int i = 0; i < rn; i++)
+      assert(strcmp(rows[i].symbol, "VendorCanonSym") != 0);
+
+   /* (b) lone vendored definer + route -> still emitted (header-only exemption). */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vo-app','/oa','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vo-lib','/ol','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[256];
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'s/%d.c','t','c',0 FROM projects WHERE name='vo-app'",
+               i);
+      X(sql);
+   }
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/Vo.h','t','c',1 FROM projects WHERE name='vo-lib'");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/vo.c','t','c',1 FROM projects WHERE name='vo-lib'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'VendoredOnlySym','definition' FROM files "
+     "WHERE path='third_party/vo.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'VendoredOnlySym' FROM files WHERE "
+     "path='third_party/vo.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Vo.h' FROM files WHERE path='s/0.c' "
+     "AND project_id=(SELECT id FROM projects WHERE name='vo-app')");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'VendoredOnlySym' FROM files WHERE "
+     "path='s/0.c' AND project_id=(SELECT id FROM projects WHERE name='vo-app')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('vo-app','vo-lib','import_header','medium','Vo.h')");
+   assert(canonical_index_cross_repo_deps("vo-app", &opts, &edges, &n, &trunc) == 0);
+   int found = 0;
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(edges[i].definer_repo, "vo-lib") == 0)
+         found = 1;
+   assert(found); /* lone vendored definer kept (exemption) */
+   free(edges);
+   printf("ok\n");
+}
+
+/* §4 canonical-preference edge cases: (c) a single repo with BOTH a vendored and a
+ * non-vendored def of one symbol is treated as CANONICAL (MIN(vendored)=0), so a
+ * competing pure-vendored repo is dropped; (d) no-route-to-canonical — when the
+ * non-vendored definer is NOT route-reachable but a vendored copy IS, the vendored
+ * candidate is KEPT and emits (the recall fix: don't drop the copy the caller
+ * actually uses). */
+static void test_vendor_canonical_edge_cases(void)
+{
+   printf("test_vendor_canonical_edge_cases... ");
+   /* (c) mixed repo (canonical) vs pure-vendored repo. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('mr-app','/ma','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('mr-mix','/mm','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('mr-vend','/mv','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[256];
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'m/%d.c','t','c',0 FROM projects WHERE name='mr-app'",
+               i);
+      X(sql);
+   }
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'include/Mix.h','t','c',0 FROM projects WHERE name='mr-mix'");
+   /* mr-mix defines MixedSym in BOTH a canonical and a vendored file -> MIN=0. */
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'src/m.c','t','c',0 "
+     "FROM projects WHERE name='mr-mix'");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/m2.c','t','c',1 FROM projects WHERE name='mr-mix'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'MixedSym','definition' FROM files WHERE "
+     "path='src/m.c'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'MixedSym','definition' FROM files WHERE "
+     "path='third_party/m2.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'MixedSym' FROM files WHERE "
+     "path='src/m.c'");
+   /* mr-vend is a pure-vendored duplicate. */
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/mv.c','t','c',1 FROM projects WHERE name='mr-vend'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'MixedSym','definition' FROM files WHERE "
+     "path='third_party/mv.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Mix.h' FROM files WHERE path='m/0.c' AND "
+     "project_id=(SELECT id FROM projects WHERE name='mr-app')");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'MixedSym' FROM files WHERE path='m/0.c' "
+     "AND "
+     "project_id=(SELECT id FROM projects WHERE name='mr-app')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('mr-app','mr-mix','import_header','medium','Mix.h')");
+
+   xrepo_deps_opts_t opts = {
+       .direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM, .include_review = 1};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+   assert(canonical_index_cross_repo_deps("mr-app", &opts, &edges, &n, &trunc) == 0);
+   int mix = 0, mvend = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      if (strcmp(edges[i].definer_repo, "mr-mix") == 0)
+         mix = 1;
+      if (strcmp(edges[i].definer_repo, "mr-vend") == 0)
+         mvend = 1;
+   }
+   assert(mix && !mvend); /* mixed repo = canonical (survives); pure-vendored dropped */
+   free(edges);
+   edges = NULL;
+
+   /* (d) no-route-to-canonical: canonical unreachable, vendored copy reachable. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('nr-app','/na','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES "
+     "('nr-canon','/nc','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('nr-vend','/nv','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[256];
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'n/%d.c','t','c',0 FROM projects WHERE name='nr-app'",
+               i);
+      X(sql);
+   }
+   /* nr-canon: non-vendored def, but NO route from nr-app. */
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'src/n.c','t','c',0 "
+     "FROM projects WHERE name='nr-canon'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'NoRouteCanonSym','definition' FROM files "
+     "WHERE path='src/n.c'");
+   /* nr-vend: vendored def + header the app imports + a route. */
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/Nv.h','t','c',1 FROM projects WHERE name='nr-vend'");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'third_party/nv.c','t','c',1 FROM projects WHERE name='nr-vend'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'NoRouteCanonSym','definition' FROM files "
+     "WHERE path='third_party/nv.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'NoRouteCanonSym' FROM files WHERE "
+     "path='third_party/nv.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Nv.h' FROM files WHERE path='n/0.c' AND "
+     "project_id=(SELECT id FROM projects WHERE name='nr-app')");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'NoRouteCanonSym' FROM files WHERE "
+     "path='n/0.c' AND project_id=(SELECT id FROM projects WHERE name='nr-app')");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('nr-app','nr-vend','import_header','medium','Nv.h')");
+   assert(canonical_index_cross_repo_deps("nr-app", &opts, &edges, &n, &trunc) == 0);
+   int canon = 0, vend = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      if (strcmp(edges[i].definer_repo, "nr-canon") == 0)
+         canon = 1;
+      if (strcmp(edges[i].definer_repo, "nr-vend") == 0)
+         vend = 1;
+   }
+   /* vendored copy kept + emitted (canonical was unreachable); canonical not emitted
+    * (no route). Without the route-aware drop this edge would be lost (recall bug). */
+   assert(vend && !canon);
+   free(edges);
+   printf("ok\n");
+}
+
 int main(void)
 {
    test_parse_module_id();
@@ -304,6 +523,8 @@ int main(void)
    test_ambiguous_to_review();
    test_structural_edge_gate();
    test_cold_start_rebuild_to_gate();
+   test_vendor_canonical_preference();
+   test_vendor_canonical_edge_cases();
    printf("cross_repo_deps_orch: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Slice **H2** of the cross-repo precision-hardening — §4 vendor canonical-preference. Builds on H1's structural-edge gate to kill the residual false-positive class that survives it: a symbol legitimately defined in a non-vendored repo and **copied into another repo's vendored tree** (FetchContent `subprojects/`, header-only `stb`/`nlohmann` in `third_party/`). The vendored duplicate would otherwise inflate multiplicity into a false AMBIGUOUS or steal the target.

## Changes

- `cross_repo_classify.h`: `xrepo_def_t.vendored` (per-repo: 1 = all of the repo's defs of the symbol are vendored, 0 = a non-vendored def exists).
- `cross_repo_deps.c`: working-set query adds `MIN(df.vendored)` per `(sym, definer-repo)` group (appended column; existing indices unchanged). `crd_flush` runs a §4 canonical-preference pass **before** multiplicity/target (pipeline order §7): drop a vendored duplicate **only when a non-vendored definer is also structurally route-reachable** (§4a+§4b) — the canonical definer wins when reachable, but a vendored copy the caller actually includes is **kept** when no canonical is reachable (no recall loss). A lone vendored definer is kept (header-only-library exemption; H1 route gate still applies). Two-pass compaction. `definer_rc` is measured over the canonicalized set.
- tests: canonical-vs-vendored-duplicate → resolves to canonical (no AMBIGUOUS, not in review); lone-vendored + route → still emits; mixed-repo (both vendored + non-vendored defs) → treated canonical; no-route-to-canonical → keeps the reachable vendored copy.

## Verification

Full unit-test suite (897) green, `make lint` green, `aimee-kb` links. Reviewed via the aimee roundtable to convergence (three rounds; round-3 supplied the actual diff → 0 blocking).

## Deferred to H3

§5 symbol-kind eligibility and the lone-vendored tier ceiling — both are tiering/kind decisions that belong with §2 IDF + §6 export-booster.