### PR TITLE
feat(kb): cross-repo precision H3a — symbol-kind eligibility + vendored ceiling

### DIFF
--- a/src/db2/cross_repo_classify.c
+++ b/src/db2/cross_repo_classify.c
@@ -230,9 +230,33 @@ xrepo_classification_t xrepo_classify(const xrepo_candidate_t *c)
       tier = XREPO_TIER_MEDIUM;
       r.trust_cap_applied = 1;
    }
+   /* §5 SDK-style symbol-kind cap: a symbol whose definitions in the target are ALL
+    * macro/typedef is SDK-style (DEFINE_GUID, opaque-handle typedefs) and reaches
+    * HIGH only with export evidence (a project-defined public macro/typedef in
+    * file_exports). Without export membership it caps at MEDIUM — a function/
+    * struct/enum/plain definition is HIGH-capable and unaffected. */
+   if (c->kind_macro_typedef && !c->exported && tier > XREPO_TIER_MEDIUM)
+   {
+      tier = XREPO_TIER_MEDIUM;
+      r.kind_cap_applied = 1;
+   }
+   /* §4 lone-vendored ceiling: when the surviving target is a vendored (third-party)
+    * definer — the header-only-library exemption kept it because no canonical
+    * candidate was reachable — cap at MEDIUM. Vendored code is a real but
+    * lower-trust dependency: a route makes it MEDIUM-eligible, but it should not be
+    * a HIGH first-party dependency without a canonical definer. */
+   if (c->definer_vendored && tier > XREPO_TIER_MEDIUM)
+   {
+      tier = XREPO_TIER_MEDIUM;
+      r.vendored_cap_applied = 1;
+   }
 
-   /* Structural invariant (§3.10): caps only lower, never raise -- the final
-    * ladder tier never exceeds the producer's base tier. */
+   /* Caps run in a fixed order — caller-collision, conditional-modality, trust,
+    * §5 kind, §4 vendored — but the result is order-independent: each only ever
+    * lowers the tier (collision/modality by one step; trust/kind/vendored to
+    * MEDIUM), so the set of applied caps determines the outcome, not their order.
+    * Structural invariant (§3.10): caps only lower, never raise — the final ladder
+    * tier never exceeds the producer's base tier. */
    if (tier > r.base_tier)
       tier = r.base_tier;
 

--- a/src/db2/cross_repo_classify.h
+++ b/src/db2/cross_repo_classify.h
@@ -44,6 +44,9 @@ typedef struct
    const char *param_types; /* normalized parameter type list; "" if unknown */
    int vendored;            /* §4: 1 if this repo's defs of the symbol are ALL in vendored
                                files (no canonical copy); 0 if a non-vendored def exists */
+   int high_capable_kind;   /* §5: 1 if this repo has a HIGH-capable def_kind for the symbol
+                               (function/struct/enum/union/plain definition); 0 if ALL its defs
+                               are macro/typedef (SDK-style, HIGH only with export evidence) */
 } xrepo_def_t;
 
 typedef enum
@@ -105,6 +108,12 @@ typedef struct
    int definer_trusted;          /* definer repo trust (§0): untrusted EXPORT route caps at MEDIUM
                                   * (an untrusted definer can never lend HIGH export) */
    xrepo_import_modality_t modality; /* conditional -> one-tier cap; dynamic -> review */
+   int kind_macro_typedef; /* §5: 1 if the target definer's defs are ALL macro/typedef (SDK-style);
+                            * such a symbol reaches HIGH only with export evidence. Default 0
+                            * (function/struct/…) is HIGH-permissive — no cap. */
+   int exported;           /* §6: target definer has file_exports membership for the symbol */
+   int definer_vendored;   /* §4 ceiling: target is a lone vendored definer (no canonical
+                            * candidate survived) -> third-party code caps at MEDIUM */
 } xrepo_candidate_t;
 
 /* Per-stage trace, for the --dry-run evidence + structural-invariant asserts. */
@@ -116,7 +125,9 @@ typedef struct
    int caller_collision_applied; /* a cap lowered the tier */
    int trust_cap_applied;
    int modality_cap_applied;
-   const char *reason; /* short stage label that determined the outcome */
+   int kind_cap_applied;     /* §5 SDK-style macro/typedef (no export) capped at MEDIUM */
+   int vendored_cap_applied; /* §4 lone-vendored definer capped at MEDIUM */
+   const char *reason;       /* short stage label that determined the outcome */
 } xrepo_classification_t;
 
 /* Run the §3.10 pipeline. Deterministic: a fixed candidate always yields the

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -479,6 +479,11 @@ static void crd_flush(const crd_ctx_t *ctx, edge_acc_t *acc, const char *sym, in
    c.caller_trusted = ctx->caller_trusted;
    c.definer_trusted = definer_trusted;
    c.modality = XREPO_IMPORT_STATIC;
+   /* §5/§6/§4-ceiling inputs for the target definer (defaults are HIGH-permissive
+    * when there is no target, so a no-target candidate is unaffected). */
+   c.kind_macro_typedef = target >= 0 ? !defs[target].high_capable_kind : 0;
+   c.exported = target >= 0 ? dexp[target] : 0;
+   c.definer_vendored = target >= 0 ? defs[target].vendored : 0;
    xrepo_classification_t cl = xrepo_classify(&c);
 
    /* AMBIGUOUS -> review queue (§3.8), surfaced not dropped — but only when a
@@ -721,7 +726,8 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
        "          AND cca.callee = c.sym) AS caller_files, "
        "       (SELECT COUNT(*) FROM blocked_symbols b WHERE b.word = c.sym AND b.lang = '') AS "
        "blk, "
-       "       MIN(df.vendored) AS dvendored "
+       "       MIN(df.vendored) AS dvendored, "
+       "       MAX(CASE WHEN dt.def_kind IN ('macro','typedef') THEN 0 ELSE 1 END) AS high_capable "
        "FROM cand c JOIN terms dt ON dt.name = c.sym AND dt.kind = 'definition' "
        "JOIN files df ON df.id = dt.file_id JOIN projects dp ON dp.id = df.project_id "
        "GROUP BY c.sym, c.sites, c.files, c.exfile, c.exline, dp.name, dp.trust "
@@ -787,9 +793,11 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
          defs[ndef].self_type = "";
          defs[ndef].arity = -1;
          defs[ndef].param_types = "";
-         /* §4: MIN(df.vendored) — last SELECT column (index 12). Adding query columns
-          * must APPEND + bump this index; this is the sole consumer of the cursor. */
+         /* §4 MIN(df.vendored) at column 12, §5 high_capable at column 13 — the last
+          * SELECT columns. Adding query columns must APPEND + bump these indices;
+          * this is the sole consumer of the cursor. */
          defs[ndef].vendored = aimee_pg_column_int(cq, 12) > 0 ? 1 : 0;
+         defs[ndef].high_capable_kind = aimee_pg_column_int(cq, 13) > 0 ? 1 : 0;
          dcount[ndef] = aimee_pg_column_int(cq, 6);
          dexp[ndef] = aimee_pg_column_int(cq, 8) > 0 ? 1 : 0;
          ndef++;

--- a/src/tests/test_cross_repo_deps.c
+++ b/src/tests/test_cross_repo_deps.c
@@ -270,15 +270,15 @@ static void test_multiplicity(void)
    xrepo_mult_cfg_t cfg = {.dom_share_pct = 90, .runnerup_share_pct = 5, .runnerup_abs = 2};
 
    /* Single definer repo. */
-   xrepo_def_t one[] = {{"repo-b", XREPO_LANG_C, "", 2, "int,int", 0}};
+   xrepo_def_t one[] = {{"repo-b", XREPO_LANG_C, "", 2, "int,int", 0, 1}};
    int oc[] = {3};
    int oe[] = {1};
    xrepo_mult_t m = xrepo_classify_multiplicity(one, oc, oe, 1, &cfg);
    assert(m.kind == XREPO_MULT_SINGLE && m.dominant_index == 0);
 
    /* Dominant definer: 95 defs vs 1, runner-up not an exporter -> DOMINANT. */
-   xrepo_def_t dom[] = {{"repo-b", XREPO_LANG_C, "", 1, "int", 0},
-                        {"repo-c", XREPO_LANG_C, "", 1, "int", 0}};
+   xrepo_def_t dom[] = {{"repo-b", XREPO_LANG_C, "", 1, "int", 0, 1},
+                        {"repo-c", XREPO_LANG_C, "", 1, "int", 0, 1}};
    int dc[] = {95, 1};
    int de[] = {1, 0};
    m = xrepo_classify_multiplicity(dom, dc, de, 2, &cfg);
@@ -297,8 +297,8 @@ static void test_multiplicity(void)
 
    /* Provably-unrelated signatures (differing arity) -> name-clash even if a
     * count majority exists (polymorphic rescue does not apply). */
-   xrepo_def_t unrel[] = {{"repo-b", XREPO_LANG_CPP, "", 1, "", 0},
-                          {"repo-c", XREPO_LANG_CPP, "", 3, "", 0}};
+   xrepo_def_t unrel[] = {{"repo-b", XREPO_LANG_CPP, "", 1, "", 0, 1},
+                          {"repo-c", XREPO_LANG_CPP, "", 3, "", 0, 1}};
    int uc[] = {95, 1};
    int ue[] = {1, 0};
    m = xrepo_classify_multiplicity(unrel, uc, ue, 2, &cfg);
@@ -306,8 +306,8 @@ static void test_multiplicity(void)
 
    /* Unknown/variadic signatures (arity -1, "" params) are NOT provably unrelated,
     * so a clear count majority still resolves to DOMINANT (overloads not punished). */
-   xrepo_def_t vararg[] = {{"repo-b", XREPO_LANG_CPP, "", -1, "", 0},
-                           {"repo-c", XREPO_LANG_CPP, "", 2, "", 0}};
+   xrepo_def_t vararg[] = {{"repo-b", XREPO_LANG_CPP, "", -1, "", 0, 1},
+                           {"repo-c", XREPO_LANG_CPP, "", 2, "", 0, 1}};
    m = xrepo_classify_multiplicity(vararg, dc, de, 2, &cfg); /* dc={95,1}, de={1,0} */
    assert(m.kind == XREPO_MULT_DOMINANT);
 

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -514,6 +514,117 @@ static void test_vendor_canonical_edge_cases(void)
    printf("ok\n");
 }
 
+/* Seed one definer repo `lib` exporting/defining `sym` (def_kind) reachable from
+ * ke-app via #include of `hdrbase` (in include/ or third_party/ when vendored) +
+ * a route, with the call placed in ke-app's `appfile`. */
+static void mk_ke_def(const char *lib, const char *hdrbase, const char *sym, const char *def_kind,
+                      int exported, int vendored, const char *appfile)
+{
+   char s[640];
+   const char *dir = vendored ? "third_party" : "include";
+   snprintf(s, sizeof(s),
+            "INSERT INTO projects (name, root, scanned_at, trust) VALUES ('%s','/k','t','trusted')",
+            lib);
+   X(s);
+   snprintf(s, sizeof(s),
+            "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+            "id,'%s/%s','t','c',%d FROM projects WHERE name='%s'",
+            dir, hdrbase, vendored, lib);
+   X(s);
+   snprintf(s, sizeof(s),
+            "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+            "id,'%s/def.c','t','c',%d FROM projects WHERE name='%s'",
+            dir, vendored, lib);
+   X(s);
+   snprintf(s, sizeof(s),
+            "INSERT INTO terms (file_id,name,kind,def_kind) SELECT id,'%s','definition','%s' FROM "
+            "files WHERE path='%s/def.c' AND project_id=(SELECT id FROM projects WHERE name='%s')",
+            sym, def_kind, dir, lib);
+   X(s);
+   if (exported)
+   {
+      snprintf(s, sizeof(s),
+               "INSERT INTO file_exports (file_id,name) SELECT id,'%s' FROM files WHERE "
+               "path='%s/def.c' AND project_id=(SELECT id FROM projects WHERE name='%s')",
+               sym, dir, lib);
+      X(s);
+   }
+   snprintf(s, sizeof(s),
+            "INSERT INTO file_imports (file_id,name) SELECT id,'%s' FROM files WHERE path='%s' AND "
+            "project_id=(SELECT id FROM projects WHERE name='ke-app')",
+            hdrbase, appfile);
+   X(s);
+   snprintf(s, sizeof(s),
+            "INSERT INTO code_calls (file_id,callee) SELECT id,'%s' FROM files WHERE path='%s' AND "
+            "project_id=(SELECT id FROM projects WHERE name='ke-app')",
+            sym, appfile);
+   X(s);
+   snprintf(
+       s, sizeof(s),
+       "INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+       "VALUES ('ke-app','%s','import_header','medium','%s')",
+       lib, hdrbase);
+   X(s);
+}
+
+/* §5 symbol-kind eligibility + §6 export-booster + §4 lone-vendored ceiling: an
+ * import-corroborated edge is HIGH for a function or an EXPORTED macro, but capped
+ * at MEDIUM for a non-exported macro (SDK-style §5) and for a lone vendored definer
+ * (§4 ceiling) even when exported. */
+static void test_kind_eligibility_and_vendored_ceiling(void)
+{
+   printf("test_kind_eligibility_and_vendored_ceiling... ");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('ke-app','/ka','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char s[256];
+      snprintf(s, sizeof(s),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'k/%d.c','t','c',0 FROM projects WHERE name='ke-app'",
+               i);
+      X(s);
+   }
+   mk_ke_def("ke-func", "KeFunc.h", "KeFuncSym", "function", 0, 0, "k/0.c");  /* HIGH */
+   mk_ke_def("ke-macro", "KeMacro.h", "KeMacroSym", "macro", 0, 0, "k/1.c");  /* §5 -> MEDIUM */
+   mk_ke_def("ke-emac", "KeEmac.h", "KeExpMacroSym", "macro", 1, 0, "k/2.c"); /* exported -> HIGH */
+   mk_ke_def("ke-vend", "KeVend.h", "KeVendSym", "function", 1, 1,
+             "k/3.c"); /* §4 ceiling -> MEDIUM */
+
+   xrepo_deps_opts_t opts = {.direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_LOW};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+   assert(canonical_index_cross_repo_deps("ke-app", &opts, &edges, &n, &trunc) == 0);
+   int seen_func = 0, seen_macro = 0, seen_emac = 0, seen_vend = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      const char *d = edges[i].definer_repo;
+      if (strcmp(d, "ke-func") == 0)
+      {
+         seen_func = 1;
+         assert(edges[i].tier == XREPO_TIER_HIGH); /* function + import -> HIGH */
+      }
+      else if (strcmp(d, "ke-macro") == 0)
+      {
+         seen_macro = 1;
+         assert(edges[i].tier == XREPO_TIER_MEDIUM); /* §5: non-exported macro capped */
+      }
+      else if (strcmp(d, "ke-emac") == 0)
+      {
+         seen_emac = 1;
+         assert(edges[i].tier == XREPO_TIER_HIGH); /* §6: exported macro allowed HIGH */
+      }
+      else if (strcmp(d, "ke-vend") == 0)
+      {
+         seen_vend = 1;
+         assert(edges[i].tier == XREPO_TIER_MEDIUM); /* §4 ceiling: lone vendored capped */
+      }
+   }
+   assert(seen_func && seen_macro && seen_emac && seen_vend);
+   free(edges);
+   printf("ok\n");
+}
+
 int main(void)
 {
    test_parse_module_id();
@@ -525,6 +636,7 @@ int main(void)
    test_cold_start_rebuild_to_gate();
    test_vendor_canonical_preference();
    test_vendor_canonical_edge_cases();
+   test_kind_eligibility_and_vendored_ceiling();
    printf("cross_repo_deps_orch: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Slice **H3a** of the cross-repo precision-hardening — §5 symbol-kind eligibility + the §4 lone-vendored tier ceiling (deferred from H2). Caps the `DEFINE_GUID`-class SDK macros below HIGH and stops third-party vendored code from being a HIGH first-party dependency.

## Changes

- **§5 SDK-style kind cap** (`cross_repo_classify.c`): a symbol whose defs in the target are ALL macro/typedef (`def_kind` from H0a) reaches HIGH only with export evidence (`file_exports` = project-defined public macro/typedef); otherwise caps at MEDIUM. Functions/structs/enums/plain definitions are HIGH-capable, unaffected.
- **§4 lone-vendored ceiling**: a surviving vendored target (kept by H2's header-only-library exemption) caps at MEDIUM — a route makes it MEDIUM-eligible, not a HIGH first-party dep.
- **§6 export-booster**: verified already enforced by the producer mapping (HIGH only via import route or TRUSTED_EXPORT, which already requires export) — no code change.
- Plumbing: `xrepo_def_t.high_capable_kind` via `MAX(CASE WHEN def_kind IN ('macro','typedef') THEN 0 ELSE 1 END)`; `xrepo_candidate_t` gains `kind_macro_typedef` (**inverted** so default-zero is HIGH-permissive — a zero-init candidate is never accidentally capped), `exported`, `definer_vendored`, plus `kind_cap_applied`/`vendored_cap_applied` trace flags. Both caps run after the trust cap and only ever lower to MEDIUM (order-independent; `base_tier` invariant holds).

## Verification

Tests (orch): function+import → HIGH; non-exported macro → MEDIUM (§5); exported macro → HIGH (§6); lone-vendored function+export → MEDIUM (§4 ceiling). Full unit-test suite (897) green, `make lint` green, `aimee-kb` links. Reviewed via the aimee roundtable (diff embedded) → 0 blocking.

## Deferred to H3b

§2 IDF distinctiveness (symbol + header-basename corpus IDF + angle-bracket/system-include signal) — needs new include-type extraction.