### PR TITLE
feat(vault): route server-principal-write audit to the dedicated 0600 sink (D2/D2c)

### DIFF
--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -404,10 +404,11 @@ int handle_vault_rekey(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_set(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 int handle_vault_set_server(server_ctx_t *ctx, server_conn_t *conn, cJSON *req);
 
-/* Emit the single vault.audit log line for a server-principal credential write
- * (agent, cred type, non-secret fingerprint, attested transport, acting
- * principal). Shared by every server-vault write path so each one is logged
- * identically — never logs the secret itself. */
+/* Emit a VAULT_SERVER_WRITE record to the dedicated append-only 0600 audit sink
+ * (audit_log) for a server-principal credential write (agent, cred type,
+ * non-secret fingerprint, attested transport, acting principal). Shared by every
+ * server-vault write path so each one is logged identically — never logs the
+ * secret itself. */
 void vault_audit_server_write(const server_conn_t *conn, const char *agent, const char *cred,
                               const char *secret);
 

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -6,7 +6,7 @@
 #include "vault_service.h"
 #include "vault_crypto.h"     /* VAULT_ROOT_KEY_LEN */
 #include "vault_capability.h" /* vault:write:server gate (D2c) */
-#include "log.h"              /* aimee_log audit lines (D2c) */
+#include "log.h"              /* audit_log dedicated 0600 audit sink (D2/D2c) */
 #include "cJSON.h"
 #include <openssl/crypto.h>
 #include <openssl/sha.h>
@@ -205,8 +205,11 @@ void vault_audit_server_write(const server_conn_t *conn, const char *agent, cons
       transport = "unknown";
       break;
    }
-   aimee_log(LOG_WARN, "vault.audit",
-             "server-principal write by=%s transport=%s agent=%s cred=%s fp=%s",
+   /* D2/D2c: server-principal writes go to the dedicated append-only 0600 audit
+    * sink (audit_log), NOT the operator-readable general server log — preserving
+    * tamper-evidence + access separation. Never logs the key (fingerprint only). */
+   audit_log("VAULT_SERVER_WRITE",
+             "by=%s transport=%s agent=%s cred=%s fp=%s",
              (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)", transport,
              agent ? agent : "?", cred ? cred : "?", fp);
 }
@@ -303,7 +306,9 @@ int handle_vault_capability(server_ctx_t *ctx, server_conn_t *conn, cJSON *req)
       cJSON_Delete(resp);
       return server_send_error(conn, "vault: capability update failed", NULL);
    }
-   aimee_log(LOG_WARN, "vault.audit", "capability %s principal=%s by=%s", action, jp->valuestring,
+   /* D2/D2c: capability grant/revoke is an authz change to the server-write
+    * allow-list — record it in the dedicated append-only 0600 audit sink. */
+   audit_log("VAULT_CAPABILITY", "action=%s principal=%s by=%s", action, jp->valuestring,
              conn->vault_principal);
    cJSON_AddStringToObject(resp, "status", "ok");
    return server_send_ok(conn, resp);

--- a/src/server/server_vault.c
+++ b/src/server/server_vault.c
@@ -208,8 +208,7 @@ void vault_audit_server_write(const server_conn_t *conn, const char *agent, cons
    /* D2/D2c: server-principal writes go to the dedicated append-only 0600 audit
     * sink (audit_log), NOT the operator-readable general server log — preserving
     * tamper-evidence + access separation. Never logs the key (fingerprint only). */
-   audit_log("VAULT_SERVER_WRITE",
-             "by=%s transport=%s agent=%s cred=%s fp=%s",
+   audit_log("VAULT_SERVER_WRITE", "by=%s transport=%s agent=%s cred=%s fp=%s",
              (conn && conn->vault_principal[0]) ? conn->vault_principal : "(server)", transport,
              agent ? agent : "?", cred ? cred : "?", fp);
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -257,6 +257,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
+               $(TESTPREFIX)/unit-test-vault-audit \
                $(TESTPREFIX)/unit-test-prompts \
                $(TESTPREFIX)/unit-test-cmd-session \
                $(TESTPREFIX)/unit-test-model-registry \
@@ -2599,6 +2600,14 @@ $(TESTPREFIX)/unit-test-aimee-tls-clientcert: $(OBJDIR)/tests/test_aimee_tls_cli
 
 $(TESTPREFIX)/unit-test-vault-capability: $(OBJDIR)/tests/test_vault_capability.o \
                               $(OBJDIR)/server/vault_capability.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-vault-audit: $(OBJDIR)/tests/test_vault_audit.o \
+                              $(OBJDIR)/server/server_vault.o \
+                              $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
+                              $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o $(OBJDIR)/server/vault_capability.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_vault_audit.c
+++ b/src/tests/test_vault_audit.c
@@ -1,0 +1,102 @@
+/* test_vault_audit.c — pin the D2/D2c security control: a server-principal
+ * credential write is recorded in the DEDICATED append-only 0600 audit sink
+ * (audit.log), NOT the operator-readable general server log.
+ *
+ * This test fails if vault_audit_server_write() is ever reverted to
+ * aimee_log(LOG_WARN, "vault.audit", ...): the general log does not write
+ * audit.log, so the file would stay empty. It also asserts the two properties
+ * the dedicated sink exists for — 0600 perms (access separation) — and that the
+ * secret itself is never written (fingerprint only). */
+#include "server.h" /* server_conn_t, vault_audit_server_write */
+#include "log.h"    /* audit_log_open/close */
+#include "config.h" /* config_default_dir */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+/* server_vault.o references these (other handlers in the same TU); the audit
+ * path under test never calls them, so trivial stubs satisfy the linker. */
+int server_send_error(server_conn_t *conn, const char *msg, const char *detail)
+{
+   (void)conn;
+   (void)msg;
+   (void)detail;
+   return 0;
+}
+int server_send_response(server_conn_t *conn, cJSON *resp)
+{
+   (void)conn;
+   (void)resp;
+   return 0;
+}
+
+static char *slurp(const char *path, size_t *len_out)
+{
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   fseek(f, 0, SEEK_END);
+   long n = ftell(f);
+   fseek(f, 0, SEEK_SET);
+   char *buf = malloc((size_t)n + 1);
+   assert(buf);
+   size_t got = fread(buf, 1, (size_t)n, f);
+   buf[got] = '\0';
+   fclose(f);
+   if (len_out)
+      *len_out = got;
+   return buf;
+}
+
+int main(void)
+{
+   char home[256];
+   snprintf(home, sizeof(home), "/tmp/aimee-vaultaudit-test-%d", (int)getpid());
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", home, home);
+   assert(system(cmd) == 0);
+   setenv("AIMEE_HOME", home, 1);
+
+   audit_log_open();
+
+   /* A server-principal write over an attested UDS connection. */
+   server_conn_t conn;
+   memset(&conn, 0, sizeof(conn));
+   conn.attested_transport = ATTEST_UDS_PEERCRED;
+   snprintf(conn.vault_principal, sizeof(conn.vault_principal), "uid:1000");
+
+   const char *secret = "sk-supersecret-must-never-be-logged-9f3a";
+   vault_audit_server_write(&conn, "glm", "api_key", secret);
+
+   audit_log_close();
+
+   char path[320];
+   snprintf(path, sizeof(path), "%s/audit.log", config_default_dir());
+
+   /* (1) The dedicated sink received the record — fails if routed to aimee_log. */
+   size_t len = 0;
+   char *body = slurp(path, &len);
+   assert(body && "audit.log not written — server-principal write was not routed to the dedicated sink");
+   assert(strstr(body, "\"event\":\"VAULT_SERVER_WRITE\"") && "missing VAULT_SERVER_WRITE event");
+   assert(strstr(body, "agent=glm") && "missing agent field");
+   assert(strstr(body, "transport=uds") && "missing/incorrect attested transport");
+   assert(strstr(body, "fp=") && "missing credential fingerprint");
+
+   /* (2) The secret is NEVER written — only the fingerprint. */
+   assert(!strstr(body, secret) && "the raw secret leaked into the audit log");
+
+   /* (3) Access separation: the audit file is 0600. */
+   struct stat st;
+   assert(stat(path, &st) == 0);
+   assert((st.st_mode & 0777) == 0600 && "audit.log must be 0600");
+
+   free(body);
+   snprintf(cmd, sizeof(cmd), "rm -rf %s", home);
+   (void)system(cmd);
+
+   printf("PASS: vault server-principal write routes to the dedicated 0600 audit sink (D2/D2c)\n");
+   return 0;
+}

--- a/src/tests/test_vault_audit.c
+++ b/src/tests/test_vault_audit.c
@@ -79,7 +79,8 @@ int main(void)
    /* (1) The dedicated sink received the record — fails if routed to aimee_log. */
    size_t len = 0;
    char *body = slurp(path, &len);
-   assert(body && "audit.log not written — server-principal write was not routed to the dedicated sink");
+   assert(body &&
+          "audit.log not written — server-principal write was not routed to the dedicated sink");
    assert(strstr(body, "\"event\":\"VAULT_SERVER_WRITE\"") && "missing VAULT_SERVER_WRITE event");
    assert(strstr(body, "agent=glm") && "missing agent field");
    assert(strstr(body, "transport=uds") && "missing/incorrect attested transport");


### PR DESCRIPTION
## What

Route every **server-principal credential write** — and every `vault:write:server` capability grant/revoke — to the dedicated append-only **0600 `audit.log`** sink (`audit_log()`), instead of the operator-readable general server log (`aimee_log(LOG_WARN, "vault.audit", …)`).

## Why

This closes the one open divergence from the `cred-vault-consolidation` proposal (decision **D2/D2c**) that *actively weakened a security control* rather than merely omitting a convenience. The proposal specifies a dedicated audit sink precisely for two properties the general log does not provide:

- **tamper-evidence** — append-only, rotated, not interleaved with operational logging;
- **access separation** — `audit.log` is `0600` and not readable by the delegate-execution principal, whereas the general server log is operator-readable.

Routing audit records through `aimee_log` discarded both. This was surfaced by the closeout roundtable (5-panel) as the highest-value must-fix among the proposal's remaining gaps.

## Change

- `vault_audit_server_write()` → `audit_log("VAULT_SERVER_WRITE", …)`
- capability grant/revoke → `audit_log("VAULT_CAPABILITY", …)`
- Both keep the **key fingerprint** (first 4 bytes of SHA-256) and **never** log the secret. `audit_log` still mirrors to stderr, so operators retain a live breadcrumb; the durable record now lands only in the protected sink.
- `audit_log()` is pre-existing infra (JSON lines, 0600, rotation), opened at server startup via `audit_log_open()`. No behavioural change to the write/gate paths themselves.

## Tests

- New `unit-test-vault-audit` pins the security control: asserts a server-principal write lands a `VAULT_SERVER_WRITE` record in `audit.log`, that the file is `0600`, and that the raw secret never appears (fingerprint only). A revert to `aimee_log` fails this test (the general log never writes `audit.log`) — which the existing dispatch test could not catch because it stubs `audit_log`.
- `unit-test-vault-service`, `unit-test-vault-capability`, `unit-test-server-dispatch` pass; server builds green (`make -j1`).

Part of filing `cred-vault-consolidation` to done (closeout item D2/D2c).
