### PR TITLE
feat(vault): offline master-key rotation command + runbook (D13)

### DIFF
--- a/docs/runbooks/vault-master-key-rotation.md
+++ b/docs/runbooks/vault-master-key-rotation.md
@@ -31,7 +31,17 @@ decrypts failing for the window between re-wrapping a credential and swapping th
 delegate would 401 mid-rotation. So rotation runs with the **server stopped**, against the
 on-disk vault, and exits.
 
-## 2. Procedure
+## 2. Preconditions
+
+- **Server stopped.** `--rotate-master-key` refuses to run if an `aimee-server` instance is
+  live for the default socket (the server caches the old KEK and could write a credential
+  under it during the re-wrap window — see §1). Stop the server first.
+- **`AIMEE_HOME` permissions.** The pre-rotation backup is written under `AIMEE_HOME` as a
+  `0700` directory of `0600` files, but it inherits the *parent* directory's reachability.
+  Ensure `AIMEE_HOME` is writable only by the server's runtime UID — otherwise the backup
+  (which holds old-key ciphertext) sits in a directory others can traverse.
+
+## 3. Procedure
 
 ```sh
 # 1. Stop the server (so nothing reads/writes the vault during rotation).
@@ -55,7 +65,7 @@ shred -u /var/lib/aimee/.vault.rotate-bak.12345/* 2>/dev/null || true
 rm -rf /var/lib/aimee/.vault.rotate-bak.12345
 ```
 
-## 3. Safety / failure handling
+## 4. Safety / failure handling
 
 - **Atomic + reversible.** The entire `.vault/` is copied to `.vault.rotate-bak.<pid>` (0700)
   **before** any mutation. If any principal's re-wrap fails (wrong key / tamper) **or** the
@@ -72,7 +82,7 @@ rm -rf /var/lib/aimee/.vault.rotate-bak.12345
   `--rotate-master-key` reports "nothing to rotate" and exits 0 (the key is minted lazily on
   the first write).
 
-## 4. Verification checklist
+## 5. Verification checklist
 
 - [ ] command exited 0 and reported a non-zero re-wrap count (matching your agent count);
 - [ ] `aimee delegate <agent> …` authenticates from the vault after restart;

--- a/docs/runbooks/vault-master-key-rotation.md
+++ b/docs/runbooks/vault-master-key-rotation.md
@@ -1,0 +1,80 @@
+# Runbook: rotate the vault `.server-master.key`
+
+Rotate the server-sealed master key that protects the credential vault (D13 of the
+[cred-vault-consolidation](../proposals/done/cred-vault-consolidation.md) proposal).
+**Operator-gated, offline maintenance op** — never automatic.
+
+## 0. What this does (and does not)
+
+The 32-byte `.server-master.key` lives `0600` beside the vault at
+`<AIMEE_HOME>/.vault/.server-master.key`. The **server KEK** is HKDF-derived from it and
+wraps every server-decryptable credential's data-encryption key (DEK):
+
+- the **server principal** (`server`) holds the server KEK as its **primary** wrap
+  (`wrapped_dek`) — these are the shared delegate keys (minimax/mistral/glm/codex…);
+- every **user principal** that has a dual-access entry holds it in `wrapped_dek_server`.
+
+Rotation mints a fresh master key and **re-wraps** those DEKs from the old server KEK to the
+new one. It is a **re-wrap, not a re-encrypt**: no credential plaintext, nonce, ciphertext or
+tag is touched, and the per-user zero-knowledge `wrapped_dek` (under a user/login KEK) is
+left untouched. Rotation defeats a leaked/suspected-compromised *master key file*; it is
+**not** key-per-credential rotation and does not change the provider secrets themselves
+(rotate those at the provider, then `aimee agent key import`).
+
+Trust boundary is unchanged: the new master key is still a `0600` file on the server volume
+(no HSM/KMS), defeating backup/disk theft, not host root.
+
+## 1. Why it is offline
+
+`aimee-server` caches one process-wide server KEK. A *live* rotation would leave autonomous
+decrypts failing for the window between re-wrapping a credential and swapping the key — every
+delegate would 401 mid-rotation. So rotation runs with the **server stopped**, against the
+on-disk vault, and exits.
+
+## 2. Procedure
+
+```sh
+# 1. Stop the server (so nothing reads/writes the vault during rotation).
+systemctl stop aimee-server          # or: docker compose stop aimee-server
+
+# 2. Rotate. Runs as the server's runtime user, with the same AIMEE_HOME.
+#    Backs up the whole .vault/ directory FIRST, then re-wraps, then swaps the key.
+sudo -u aimee AIMEE_HOME=/var/lib/aimee aimee-server --rotate-master-key
+
+#    Example output:
+#    aimee-server: master key rotated — re-wrapped 5 credential(s) across 1 principal(s).
+#      Pre-rotation backup: /var/lib/aimee/.vault.rotate-bak.12345
+#      Verify delegates authenticate, then remove the backup.
+
+# 3. Restart and verify a delegate authenticates from the vault.
+systemctl start aimee-server
+aimee delegate minimax "ping" --persona engineer    # or any vaulted agent
+
+# 4. Once verified, remove the pre-rotation backup (it holds the OLD-key ciphertext).
+shred -u /var/lib/aimee/.vault.rotate-bak.12345/* 2>/dev/null || true
+rm -rf /var/lib/aimee/.vault.rotate-bak.12345
+```
+
+## 3. Safety / failure handling
+
+- **Atomic + reversible.** The entire `.vault/` is copied to `.vault.rotate-bak.<pid>` (0700)
+  **before** any mutation. If any principal's re-wrap fails (wrong key / tamper) **or** the
+  new master key cannot be persisted, the vault is **restored from that backup** and the
+  command aborts non-zero with the vault unchanged — never a new-wrapped vault under an old
+  master, nor the reverse.
+- **Crash mid-run.** The new master key is written **last** (atomic tmp+rename+fsync), only
+  after every re-wrap has succeeded. A crash before that leaves the old master + old wraps
+  intact; a crash after is a fully-rotated, consistent vault. If in doubt, restore the
+  `.vault.rotate-bak.<pid>` directory over `.vault/` and retry.
+- **Fail-closed key reads.** A present-but-unreadable/short master key is **never**
+  overwritten (it aborts), so a transient IO error cannot orphan the vault.
+- **No master key yet?** If the vault has never had a server-principal write,
+  `--rotate-master-key` reports "nothing to rotate" and exits 0 (the key is minted lazily on
+  the first write).
+
+## 4. Verification checklist
+
+- [ ] command exited 0 and reported a non-zero re-wrap count (matching your agent count);
+- [ ] `aimee delegate <agent> …` authenticates from the vault after restart;
+- [ ] `<AIMEE_HOME>/.vault/.server-master.key` mtime is fresh and the file is `0600`;
+- [ ] pre-rotation backup removed once delegates are verified.

--- a/src/headers/server.h
+++ b/src/headers/server.h
@@ -213,6 +213,9 @@ typedef struct
 /* Lifecycle */
 int server_init(server_ctx_t *ctx, const char *socket_path);
 int server_run(server_ctx_t *ctx);
+/* True if an aimee-server instance is already running for `socket_path` (pid-file
+ * + liveness check). Used by the offline --rotate-master-key guard (D13 F2). */
+int server_is_running(const char *socket_path);
 /* Boot-time delegate-vault provisioning: seal operator-supplied delegate API
  * keys ($AIMEE_DELEGATE_SECRETS_FILE / AIMEE_DELEGATE_KEY_<AGENT>) into the
  * server-principal vault so a fresh server's delegates work with no manual

--- a/src/headers/vault_server_key.h
+++ b/src/headers/vault_server_key.h
@@ -44,4 +44,32 @@ int vault_server_kek(uint8_t kek[VAULT_KEK_LEN]);
  * Not for production callers. */
 void vault_server_key_reset_for_test(void);
 
+/* Rotate the `.server-master.key` (D13). Mint a fresh master key, derive the new
+ * server KEK, and RE-WRAP every principal's server wrap from the old KEK to the
+ * new one — a re-wrap, not a re-encrypt: no credential plaintext is touched.
+ *
+ * This is an OFFLINE maintenance operation: the server caches one process-wide
+ * server KEK, so a live rotation would leave autonomous decrypts failing for the
+ * window between re-wrapping a credential and swapping the key. Run it with the
+ * server STOPPED (e.g. `aimee-server --rotate-master-key`).
+ *
+ * Crash/error safety: the whole `.vault/` directory is copied to a 0700 backup
+ * BEFORE any mutation; if ANY principal's re-wrap fails, or the new master cannot
+ * be persisted, the vault is restored from that backup and the rotation aborts
+ * with the vault unchanged (fail-closed — never a new-wrapped vault under an old
+ * master, nor the reverse). On success the backup path is reported so the
+ * operator can verify, then remove it.
+ *
+ * `server_principal` is the principal whose PRIMARY wrap ("wrapped_dek") is the
+ * server KEK (i.e. VAULT_SERVER_PRINCIPAL); every other principal carries the
+ * server KEK only in its dual-access "wrapped_dek_server" field. Passed in so the
+ * key module need not depend on the vault_service naming layer.
+ *
+ * On success returns 0 and (if non-NULL) sets *out_principals / *out_creds to the
+ * number of principals scanned and credentials re-wrapped, and writes the backup
+ * directory path into `backup_path`. On failure returns -1 with a human-readable
+ * reason in `errbuf`. A vault with no master key yet returns 0 (nothing to do). */
+int vault_server_key_rotate(const char *server_principal, int *out_principals, int *out_creds,
+                            char *backup_path, size_t backup_path_len, char *errbuf, size_t errlen);
+
 #endif /* DEC_VAULT_SERVER_KEY_H */

--- a/src/headers/vault_store.h
+++ b/src/headers/vault_store.h
@@ -3,7 +3,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
-#include "vault_crypto.h" /* VAULT_KEK_LEN, VAULT_SALT_LEN */
+#include "vault_crypto.h"    /* VAULT_KEK_LEN, VAULT_SALT_LEN */
+#include "vault_principal.h" /* VAULT_PRINCIPAL_MAX */
 
 /* vault_store: the on-disk substrate for the credential vault (WP-C.1). One
  * 0600 JSON file per attested PRINCIPAL under <aimee_home>/.vault/, holding the
@@ -118,5 +119,26 @@ int vault_store_delete(const char *principal, const char *agent, const char *cre
  * returned (fail-closed). 0 on success (incl. an empty vault). */
 int vault_store_rekey(const char *principal, const uint8_t old_kek[VAULT_KEK_LEN],
                       const uint8_t new_kek[VAULT_KEK_LEN]);
+
+/* Re-wrap the named DEK-wrap `field` of every credential under `principal` from
+ * `old_kek` to `new_kek` — the master-key rotation path (D13). `field` is the
+ * wrap that is held under the SERVER KEK: "wrapped_dek" for the server principal
+ * (whose primary wrap IS the server KEK) or "wrapped_dek_server" for a user
+ * principal's dual-access wrap. The DEKs, nonces, ciphertext and tags are
+ * untouched (a re-wrap, not a re-encrypt). A credential lacking `field` is left
+ * as-is. Atomic per principal: if ANY present `field` fails to unwrap under
+ * `old_kek` (wrong key / tamper) nothing is written and -1 is returned
+ * (fail-closed). On success returns the number of credentials re-wrapped (>=0);
+ * a principal whose vault file is absent returns 0. */
+int vault_store_rekey_field(const char *principal, const char *field,
+                            const uint8_t old_kek[VAULT_KEK_LEN],
+                            const uint8_t new_kek[VAULT_KEK_LEN]);
+
+/* Enumerate the principals that currently have a vault file, decoding each
+ * `<b64url(principal)>.json` name back to its principal string. Writes up to
+ * `max` names into `out` (each up to VAULT_PRINCIPAL_MAX). Returns the count
+ * written (>=0), or -1 on error. Used by master-key rotation to re-wrap every
+ * principal that may hold a server wrap, not just the "server" principal. */
+int vault_store_list_principals(char (*out)[VAULT_PRINCIPAL_MAX], int max);
 
 #endif /* DEC_VAULT_STORE_H */

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1691,6 +1691,14 @@ static int server_pid_alive(const char *socket_path)
 #endif
 }
 
+/* Public liveness check: is an aimee-server instance running for `socket_path`?
+ * Used by the offline `--rotate-master-key` path to refuse to mutate the vault
+ * while the server is up (D13 F2). The caller resolves the default socket path. */
+int server_is_running(const char *socket_path)
+{
+   return socket_path ? server_pid_alive(socket_path) : 0;
+}
+
 static void server_pid_write(const char *socket_path)
 {
    char pid_path[1024];

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -27,6 +27,8 @@
 #include "headers/plugin_loader.h"
 #include "headers/context_engine.h"
 #include "headers/server_cli_oauth.h"
+#include "vault_server_key.h"
+#include "vault_service.h" /* VAULT_SERVER_PRINCIPAL (rotation target) */
 #include <signal.h>
 #include <errno.h>
 #include <stdio.h>
@@ -305,6 +307,34 @@ int main(int argc, char **argv)
       return 0; /* best-effort — never fail the boot that backgrounds this */
    }
 
+   /* Offline master-key rotation (D13). Re-wrap every principal's server wrap
+    * from the old `.server-master.key` to a freshly minted one — a re-wrap, not a
+    * re-encrypt. MUST run with the normal server stopped (the server caches one
+    * process-wide server KEK, so a live rotation would leave autonomous decrypts
+    * failing mid-rotation). Backs up `.vault/` first and restores it on any
+    * failure, then exits without starting the server. */
+   if (argc >= 2 && strcmp(argv[1], "--rotate-master-key") == 0)
+   {
+      int principals = 0, creds = 0;
+      char backup[1280] = "", err[256] = "";
+      if (vault_server_key_rotate(VAULT_SERVER_PRINCIPAL, &principals, &creds, backup,
+                                  sizeof(backup), err, sizeof(err)) != 0)
+      {
+         fprintf(stderr, "aimee-server: master-key rotation FAILED: %s\n",
+                 err[0] ? err : "unknown error");
+         return 1;
+      }
+      if (backup[0])
+         fprintf(stderr,
+                 "aimee-server: master key rotated — re-wrapped %d credential(s) across %d "
+                 "principal(s).\n  Pre-rotation backup: %s\n  Verify delegates authenticate, "
+                 "then remove the backup.\n",
+                 creds, principals, backup);
+      else
+         fprintf(stderr, "aimee-server: no master key present yet — nothing to rotate.\n");
+      return 0;
+   }
+
    const char *socket_path = NULL;
    log_level_t log_level = LOG_INFO;
    int service_mode = 0;
@@ -348,6 +378,8 @@ int main(int argc, char **argv)
              "  --log-level=LEVEL    Log level: error, warn, info, debug (default: info)\n"
              "  --foreground         Run in foreground (default)\n"
              "  --service            Run under the Windows Service Control Manager\n"
+             "  --rotate-master-key  Re-wrap the vault under a fresh .server-master.key and exit\n"
+             "                       (run with the server STOPPED; backs up .vault first)\n"
              "  --version            Print version\n"
              "  --help               Show this help\n");
          return 0;

--- a/src/server/server_main.c
+++ b/src/server/server_main.c
@@ -315,6 +315,17 @@ int main(int argc, char **argv)
     * failure, then exits without starting the server. */
    if (argc >= 2 && strcmp(argv[1], "--rotate-master-key") == 0)
    {
+      /* Refuse to rotate while the server is up (D13 F2): a live server caching
+       * the OLD KEK could write a NEW credential under the old wrap during the
+       * re-wrap→swap window, permanently orphaning it (the backup cannot recover
+       * a credential that was never in it). */
+      const char *sock = cli_default_socket_path();
+      if (server_is_running(sock))
+      {
+         fprintf(stderr, "aimee-server: --rotate-master-key requires the server to be STOPPED "
+                         "(an instance appears to be running). Stop it and retry.\n");
+         return 1;
+      }
       int principals = 0, creds = 0;
       char backup[1280] = "", err[256] = "";
       if (vault_server_key_rotate(VAULT_SERVER_PRINCIPAL, &principals, &creds, backup,

--- a/src/server/vault_server_key.c
+++ b/src/server/vault_server_key.c
@@ -193,7 +193,7 @@ void vault_server_key_reset_for_test(void)
 static int rot_copy_file(const char *src, const char *dst)
 {
    int rc = -1;
-   int in = open(src, O_RDONLY);
+   int in = open(src, O_RDONLY | O_NOFOLLOW); /* never follow a symlink source (F1) */
    if (in < 0)
       return -1;
    int out = open(dst, O_CREAT | O_WRONLY | O_TRUNC, 0600);
@@ -253,9 +253,12 @@ static int rot_copy_dir_flat(const char *src_dir, const char *dst_dir)
          rc = -1;
          break;
       }
+      /* lstat (NOT stat): never follow a symlink planted in .vault/ — a
+       * `<x>.json -> /etc/shadow` would otherwise be read through and copied into
+       * the backup, then written back on restore (F1). Copy only real files. */
       struct stat st;
-      if (stat(sp, &st) != 0 || !S_ISREG(st.st_mode))
-         continue; /* skip non-regular entries (no subdirs expected) */
+      if (lstat(sp, &st) != 0 || !S_ISREG(st.st_mode))
+         continue; /* skip symlinks, dirs, and other non-regular entries */
       if (rot_copy_file(sp, dp) != 0)
       {
          rc = -1;
@@ -330,6 +333,10 @@ int vault_server_key_rotate(const char *server_principal, int *out_principals, i
    if ((size_t)snprintf(bdir, sizeof(bdir), "%s.rotate-bak.%d", vdir, (int)getpid()) >=
        sizeof(bdir))
       ROT_FAIL("backup path too long");
+   struct stat bst;
+   if (lstat(bdir, &bst) == 0)
+      ROT_FAIL("a backup directory from a prior/concurrent rotation already exists — remove it "
+               "first (S3)");
    if (rot_copy_dir_flat(vdir, bdir) != 0)
       ROT_FAIL("could not create the pre-rotation backup");
    restore_on_fail = 1;
@@ -357,15 +364,34 @@ int vault_server_key_rotate(const char *server_principal, int *out_principals, i
       total_creds += c;
    }
 
+   /* F3: prove the new server KEK actually decrypts a server-principal credential
+    * end-to-end BEFORE committing the master. A field-name mismatch (server creds
+    * not in "wrapped_dek") would re-wrap 0 entries and silently orphan every
+    * server cred once the master is swapped — so if the server principal has any
+    * credential, one MUST read back cleanly under the new KEK or we abort. */
+   vault_store_entry_t probe;
+   int sc = vault_store_list(server_principal, &probe, 1);
+   if (sc > 0)
+   {
+      char vbuf[8192];
+      int vrc =
+          vault_store_get(server_principal, new_kek, probe.agent, probe.cred, vbuf, sizeof(vbuf));
+      OPENSSL_cleanse(vbuf, sizeof(vbuf));
+      if (vrc != 0)
+         ROT_FAIL("post-rewrap verify failed: a server-principal credential does not decrypt under "
+                  "the new key (field mismatch?) — refusing to swap master, vault restored");
+   }
+
    /* Commit: swap in the new master key atomically. Only now is the on-disk
     * master consistent with the freshly re-wrapped server wraps. */
    if (master_key_write(path, new_master) != 0)
       ROT_FAIL("re-wrap succeeded but persisting the new master key failed — vault restored");
 
-   /* New master is live; drop the cached KEK so the next use re-derives it. */
+   /* New master is live: mark committed FIRST (so a signal here cannot trigger a
+    * spurious restore), then drop the cached KEK so the next use re-derives it. */
+   restore_on_fail = 0; /* committed — do not restore (F5) */
    OPENSSL_cleanse(g_kek, sizeof(g_kek));
    g_kek_ready = 0;
-   restore_on_fail = 0; /* committed — do not restore */
 
    if (out_principals)
       *out_principals = np;
@@ -378,7 +404,22 @@ int vault_server_key_rotate(const char *server_principal, int *out_principals, i
 
 fail:
    if (restore_on_fail && vdir[0] && bdir[0])
-      (void)rot_copy_dir_flat(bdir, vdir); /* best-effort revert to the pre-rotation state */
+   {
+      /* Revert to the pre-rotation state. The master key was NOT swapped on any
+       * fail path, so the cached g_kek still matches the on-disk (old) master.
+       * If the restore itself fails partway (EIO/ENOSPC), the vault may be left
+       * mixed old/new-wrapped — say so explicitly so the operator restores by
+       * hand from the intact backup rather than trusting a silent revert (F4). */
+      if (rot_copy_dir_flat(bdir, vdir) != 0 && errbuf && errlen)
+      {
+         char base_err[200];
+         snprintf(base_err, sizeof(base_err), "%s", errbuf);
+         snprintf(errbuf, errlen,
+                  "%s; AND automatic restore FAILED — manually copy %s/* back over %s/ before "
+                  "restarting",
+                  base_err, bdir, vdir);
+      }
+   }
 done:
    OPENSSL_cleanse(old_master, sizeof(old_master));
    OPENSSL_cleanse(new_master, sizeof(new_master));

--- a/src/server/vault_server_key.c
+++ b/src/server/vault_server_key.c
@@ -3,15 +3,18 @@
  * manages the 0600 master-key file and caches the derived server KEK. */
 #include "vault_server_key.h"
 #include "vault_crypto.h"
+#include "vault_store.h"   /* vault_store_list_principals, _rekey_field (D13) */
 #include "config.h"        /* config_default_dir */
 #include "platform_path.h" /* platform_mkdir_p */
 #include "log.h"
 #include <openssl/crypto.h> /* OPENSSL_cleanse */
+#include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdatomic.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -182,4 +185,207 @@ void vault_server_key_reset_for_test(void)
    OPENSSL_cleanse(g_kek, sizeof(g_kek));
    g_kek_ready = 0;
    pthread_mutex_unlock(&g_kek_mu);
+}
+
+/* ── Master-key rotation (D13) ────────────────────────────────────────────── */
+
+/* Copy one regular file src→dst, preserving 0600 for sensitive vault content. */
+static int rot_copy_file(const char *src, const char *dst)
+{
+   int rc = -1;
+   int in = open(src, O_RDONLY);
+   if (in < 0)
+      return -1;
+   int out = open(dst, O_CREAT | O_WRONLY | O_TRUNC, 0600);
+   if (out < 0)
+   {
+      close(in);
+      return -1;
+   }
+   char buf[8192];
+   ssize_t n;
+   rc = 0;
+   while ((n = read(in, buf, sizeof(buf))) > 0)
+   {
+      ssize_t off = 0;
+      while (off < n)
+      {
+         ssize_t w = write(out, buf + off, (size_t)(n - off));
+         if (w <= 0)
+         {
+            rc = -1;
+            break;
+         }
+         off += w;
+      }
+      if (rc != 0)
+         break;
+   }
+   if (n < 0)
+      rc = -1;
+   if (rc == 0 && fsync(out) != 0)
+      rc = -1;
+   close(in);
+   close(out);
+   OPENSSL_cleanse(buf, sizeof(buf));
+   return rc;
+}
+
+/* Copy every regular file in src_dir into dst_dir (created 0700). Flat copy — the
+ * .vault directory has no subdirectories. 0 on success, -1 on any error. */
+static int rot_copy_dir_flat(const char *src_dir, const char *dst_dir)
+{
+   if (platform_mkdir_p(dst_dir, 0700) != 0)
+      return -1;
+   DIR *d = opendir(src_dir);
+   if (!d)
+      return -1;
+   int rc = 0;
+   struct dirent *de;
+   while ((de = readdir(d)) != NULL)
+   {
+      if (strcmp(de->d_name, ".") == 0 || strcmp(de->d_name, "..") == 0)
+         continue;
+      char sp[1408], dp[1408];
+      if ((size_t)snprintf(sp, sizeof(sp), "%s/%s", src_dir, de->d_name) >= sizeof(sp) ||
+          (size_t)snprintf(dp, sizeof(dp), "%s/%s", dst_dir, de->d_name) >= sizeof(dp))
+      {
+         rc = -1;
+         break;
+      }
+      struct stat st;
+      if (stat(sp, &st) != 0 || !S_ISREG(st.st_mode))
+         continue; /* skip non-regular entries (no subdirs expected) */
+      if (rot_copy_file(sp, dp) != 0)
+      {
+         rc = -1;
+         break;
+      }
+   }
+   closedir(d);
+   return rc;
+}
+
+int vault_server_key_rotate(const char *server_principal, int *out_principals, int *out_creds,
+                            char *backup_path, size_t backup_path_len, char *errbuf, size_t errlen)
+{
+#define ROT_FAIL(msg)                                                                              \
+   do                                                                                              \
+   {                                                                                               \
+      if (errbuf && errlen)                                                                        \
+         snprintf(errbuf, errlen, "%s", (msg));                                                    \
+      goto fail;                                                                                   \
+   } while (0)
+
+   int ret = -1;
+   uint8_t old_master[VAULT_ROOT_KEY_LEN] = {0}, new_master[VAULT_ROOT_KEY_LEN] = {0};
+   uint8_t old_kek[VAULT_KEK_LEN] = {0}, new_kek[VAULT_KEK_LEN] = {0};
+   char(*principals)[VAULT_PRINCIPAL_MAX] = NULL;
+   int restore_on_fail = 0;
+   char vdir[1024] = "", bdir[1280] = "";
+
+   if (!server_principal || !server_principal[0])
+   {
+      if (errbuf && errlen)
+         snprintf(errbuf, errlen, "internal: server principal not provided");
+      return -1;
+   }
+
+   pthread_mutex_lock(&g_kek_mu);
+
+   char path[1280];
+   if (master_key_path(path, sizeof(path)) != 0)
+      ROT_FAIL("cannot resolve master-key path (AIMEE_HOME unset?)");
+
+   mk_read_t r = master_key_read(path, old_master);
+   if (r == MK_READ_ABSENT)
+   {
+      /* No master key yet — nothing to rotate (it is minted on first write). */
+      if (out_principals)
+         *out_principals = 0;
+      if (out_creds)
+         *out_creds = 0;
+      if (backup_path && backup_path_len)
+         backup_path[0] = '\0';
+      ret = 0;
+      goto done;
+   }
+   if (r != MK_READ_OK)
+      ROT_FAIL("master key present but unreadable/wrong size — fail closed (not overwritten)");
+
+   if (vault_kek_derive(old_master, sizeof(old_master), SERVER_KEK_SALT, sizeof(SERVER_KEK_SALT),
+                        old_kek) != 0)
+      ROT_FAIL("could not derive the current server KEK");
+
+   if (vault_crypto_random(new_master, sizeof(new_master)) != 0)
+      ROT_FAIL("could not generate a new master key (entropy failure)");
+   if (vault_kek_derive(new_master, sizeof(new_master), SERVER_KEK_SALT, sizeof(SERVER_KEK_SALT),
+                        new_kek) != 0)
+      ROT_FAIL("could not derive the new server KEK");
+
+   /* Back up the whole .vault directory BEFORE mutating anything. */
+   const char *base = config_default_dir();
+   if (!base || !base[0] || (size_t)snprintf(vdir, sizeof(vdir), "%s/.vault", base) >= sizeof(vdir))
+      ROT_FAIL("cannot resolve the .vault directory");
+   if ((size_t)snprintf(bdir, sizeof(bdir), "%s.rotate-bak.%d", vdir, (int)getpid()) >=
+       sizeof(bdir))
+      ROT_FAIL("backup path too long");
+   if (rot_copy_dir_flat(vdir, bdir) != 0)
+      ROT_FAIL("could not create the pre-rotation backup");
+   restore_on_fail = 1;
+
+   /* Re-wrap every principal's server wrap old→new. */
+   int max_principals = 256;
+   principals = malloc((size_t)max_principals * sizeof(*principals));
+   if (!principals)
+      ROT_FAIL("out of memory");
+   int np = vault_store_list_principals(principals, max_principals);
+   if (np < 0)
+      ROT_FAIL("could not enumerate vault principals");
+
+   int total_creds = 0;
+   for (int i = 0; i < np; i++)
+   {
+      /* The server principal holds the server KEK as its PRIMARY wrap
+       * ("wrapped_dek"); every other principal holds it only in the dual-access
+       * "wrapped_dek_server" field. Re-wrap exactly the server-KEK-held field. */
+      const char *field =
+          strcmp(principals[i], server_principal) == 0 ? "wrapped_dek" : "wrapped_dek_server";
+      int c = vault_store_rekey_field(principals[i], field, old_kek, new_kek);
+      if (c < 0)
+         ROT_FAIL("a principal's server-wrap re-wrap failed (wrong key / tamper) — vault restored");
+      total_creds += c;
+   }
+
+   /* Commit: swap in the new master key atomically. Only now is the on-disk
+    * master consistent with the freshly re-wrapped server wraps. */
+   if (master_key_write(path, new_master) != 0)
+      ROT_FAIL("re-wrap succeeded but persisting the new master key failed — vault restored");
+
+   /* New master is live; drop the cached KEK so the next use re-derives it. */
+   OPENSSL_cleanse(g_kek, sizeof(g_kek));
+   g_kek_ready = 0;
+   restore_on_fail = 0; /* committed — do not restore */
+
+   if (out_principals)
+      *out_principals = np;
+   if (out_creds)
+      *out_creds = total_creds;
+   if (backup_path && backup_path_len)
+      snprintf(backup_path, backup_path_len, "%s", bdir);
+   ret = 0;
+   goto done;
+
+fail:
+   if (restore_on_fail && vdir[0] && bdir[0])
+      (void)rot_copy_dir_flat(bdir, vdir); /* best-effort revert to the pre-rotation state */
+done:
+   OPENSSL_cleanse(old_master, sizeof(old_master));
+   OPENSSL_cleanse(new_master, sizeof(new_master));
+   OPENSSL_cleanse(old_kek, sizeof(old_kek));
+   OPENSSL_cleanse(new_kek, sizeof(new_kek));
+   free(principals);
+   pthread_mutex_unlock(&g_kek_mu);
+   return ret;
+#undef ROT_FAIL
 }

--- a/src/server/vault_store.c
+++ b/src/server/vault_store.c
@@ -9,6 +9,7 @@
 #include "platform_path.h" /* platform_mkdir_p */
 #include "cJSON.h"
 #include <openssl/crypto.h> /* OPENSSL_cleanse */
+#include <dirent.h>
 #include <fcntl.h>
 #include <pthread.h>
 #include <stdatomic.h>
@@ -643,6 +644,97 @@ int vault_store_add_server_wraps(const char *principal, const uint8_t user_kek[V
    cJSON_Delete(root);
    pthread_mutex_unlock(&g_vault_write_mu);
    return rc;
+}
+
+int vault_store_rekey_field(const char *principal, const char *field,
+                            const uint8_t old_kek[VAULT_KEK_LEN],
+                            const uint8_t new_kek[VAULT_KEK_LEN])
+{
+   if (!principal || !field || !field[0] || !old_kek || !new_kek)
+      return -1;
+   pthread_mutex_lock(&g_vault_write_mu);
+   cJSON *root = load_vault(principal);
+   if (!root)
+   {
+      pthread_mutex_unlock(&g_vault_write_mu);
+      return 0; /* no vault for this principal -> nothing to re-wrap */
+   }
+
+   int rc = 0;
+   int rewrapped_count = 0;
+   cJSON *creds = creds_array(root);
+   cJSON *e = NULL;
+   if (creds)
+   {
+      cJSON_ArrayForEach(e, creds)
+      {
+         cJSON *jw = cJSON_GetObjectItemCaseSensitive(e, field);
+         if (!cJSON_IsString(jw))
+            continue; /* this cred has no such wrap — left untouched */
+         uint8_t wrapped[VAULT_WRAPPED_DEK_LEN], dek[VAULT_DEK_LEN],
+             rewrapped[VAULT_WRAPPED_DEK_LEN];
+         if (b64url_decode(jw->valuestring, wrapped, sizeof(wrapped)) != VAULT_WRAPPED_DEK_LEN ||
+             vault_dek_unwrap(old_kek, wrapped, dek) != 0 ||
+             vault_dek_wrap(new_kek, dek, rewrapped) != 0)
+         {
+            OPENSSL_cleanse(dek, sizeof(dek));
+            rc = -1; /* wrong old KEK / tamper -> abort, write nothing */
+            break;
+         }
+         char *enc = b64url_encode(rewrapped, sizeof(rewrapped));
+         OPENSSL_cleanse(dek, sizeof(dek));
+         if (!enc)
+         {
+            rc = -1;
+            break;
+         }
+         cJSON_SetValuestring(jw, enc); /* overwrite in place */
+         free(enc);
+         rewrapped_count++;
+      }
+   }
+   if (rc == 0 && rewrapped_count > 0)
+      rc = write_vault_file(principal, root);
+   cJSON_Delete(root);
+   pthread_mutex_unlock(&g_vault_write_mu);
+   return rc == 0 ? rewrapped_count : -1;
+}
+
+int vault_store_list_principals(char (*out)[VAULT_PRINCIPAL_MAX], int max)
+{
+   if (!out || max <= 0)
+      return -1;
+   char dir[1024];
+   if (vault_dir(dir, sizeof(dir)) != 0)
+      return -1;
+   DIR *d = opendir(dir);
+   if (!d)
+      return 0; /* no .vault dir yet -> no principals */
+   int count = 0;
+   struct dirent *de;
+   while (count < max && (de = readdir(d)) != NULL)
+   {
+      const char *name = de->d_name;
+      size_t len = strlen(name);
+      /* vault files are "<b64url(principal)>.json"; skip ., .., and the
+       * special master-key / non-JSON entries. */
+      if (len <= 5 || strcmp(name + len - 5, ".json") != 0)
+         continue;
+      char b64[256];
+      if (len - 5 >= sizeof(b64))
+         continue;
+      memcpy(b64, name, len - 5);
+      b64[len - 5] = '\0';
+      uint8_t decoded[VAULT_PRINCIPAL_MAX];
+      int n = b64url_decode(b64, decoded, sizeof(decoded) - 1);
+      if (n <= 0 || (size_t)n >= sizeof(decoded))
+         continue; /* not a principal-named vault file */
+      memcpy(out[count], decoded, (size_t)n);
+      out[count][n] = '\0';
+      count++;
+   }
+   closedir(d);
+   return count;
 }
 
 int vault_store_salt_readonly(const char *principal, uint8_t salt[VAULT_SALT_LEN])

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -244,6 +244,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-vault-kek-cache \
                $(TESTPREFIX)/unit-test-vault-store \
                $(TESTPREFIX)/unit-test-vault-service \
+               $(TESTPREFIX)/unit-test-vault-master-rotate \
                $(TESTPREFIX)/unit-test-git-forge-vault \
                $(TESTPREFIX)/unit-test-git-host-resolve \
                $(TESTPREFIX)/unit-test-git-cred-inject \
@@ -2566,6 +2567,13 @@ $(TESTPREFIX)/unit-test-git-host-resolve: $(OBJDIR)/tests/test_git_host_resolve.
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-vault-service: $(OBJDIR)/tests/test_vault_service.o \
+                              $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
+                              $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
+                              $(OBJDIR)/server/vault_server_key.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-vault-master-rotate: $(OBJDIR)/tests/test_vault_master_rotate.o \
                               $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
                               $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
                               $(OBJDIR)/server/vault_server_key.o \

--- a/src/tests/test_vault_master_rotate.c
+++ b/src/tests/test_vault_master_rotate.c
@@ -1,0 +1,121 @@
+/* test_vault_master_rotate.c — D13 master-key rotation.
+ *
+ * Proves vault_server_key_rotate() re-wraps every server wrap from the old
+ * `.server-master.key` to a freshly minted one (a re-wrap, not a re-encrypt):
+ *   - all server-principal credentials still decrypt under the NEW server KEK;
+ *   - they NO LONGER decrypt under the OLD server KEK (the old key is dead);
+ *   - the on-disk master key actually changed;
+ *   - a recoverable pre-rotation backup of .vault was taken;
+ *   - the reported re-wrap count matches the number of stored credentials. */
+#include "vault_service.h"
+#include "vault_server_key.h"
+#include "vault_store.h"
+#include "vault_crypto.h"
+#include <assert.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static char g_home[256];
+
+static int read_master_key(uint8_t out[VAULT_ROOT_KEY_LEN])
+{
+   char path[400];
+   snprintf(path, sizeof(path), "%s/.vault/.server-master.key", g_home);
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return -1;
+   size_t n = fread(out, 1, VAULT_ROOT_KEY_LEN, f);
+   fclose(f);
+   return n == VAULT_ROOT_KEY_LEN ? 0 : -1;
+}
+
+static int dir_has_regular_file(const char *dir)
+{
+   DIR *d = opendir(dir);
+   if (!d)
+      return 0;
+   int found = 0;
+   struct dirent *de;
+   while ((de = readdir(d)) != NULL)
+   {
+      if (de->d_name[0] == '.')
+         continue;
+      found = 1;
+      break;
+   }
+   closedir(d);
+   return found;
+}
+
+int main(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultrotate-test-%d", (int)getpid());
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", g_home, g_home);
+   assert(system(cmd) == 0);
+   setenv("AIMEE_HOME", g_home, 1);
+   vault_server_key_reset_for_test();
+
+   const char *secretA = "sk-rotateA-3f9c2e";
+   const char *secretB = "sk-rotateB-7a1d8b";
+
+   /* Two server-principal credentials — this mints the master key + server wraps. */
+   assert(vault_service_set_server("agentA", VAULT_API_KEY_CRED, secretA) == VAULT_OK);
+   assert(vault_service_set_server("agentB", VAULT_API_KEY_CRED, secretB) == VAULT_OK);
+
+   /* Capture the OLD server KEK and master key. */
+   uint8_t old_kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(old_kek) == 0);
+   uint8_t mk_before[VAULT_ROOT_KEY_LEN];
+   assert(read_master_key(mk_before) == 0);
+
+   /* Rotate. */
+   int np = -1, nc = -1;
+   char backup[1280] = "", err[256] = "";
+   int rc = vault_server_key_rotate(VAULT_SERVER_PRINCIPAL, &np, &nc, backup, sizeof(backup), err,
+                                    sizeof(err));
+   assert(rc == 0 && "rotation failed");
+   assert(nc == 2 && "expected exactly 2 credentials re-wrapped");
+   assert(np >= 1 && "expected at least the server principal");
+   printf("  rotate: %d principal(s), %d cred(s) re-wrapped, backup=%s\n", np, nc, backup);
+
+   /* The on-disk master key actually changed. */
+   uint8_t mk_after[VAULT_ROOT_KEY_LEN];
+   assert(read_master_key(mk_after) == 0);
+   assert(memcmp(mk_before, mk_after, VAULT_ROOT_KEY_LEN) != 0 && "master key did not change");
+
+   /* A recoverable pre-rotation backup exists and is non-empty. */
+   assert(backup[0] && "no backup path reported");
+   assert(dir_has_regular_file(backup) && "backup directory is empty");
+
+   /* Re-derive the server KEK from the NEW master and confirm both creds decrypt. */
+   vault_server_key_reset_for_test();
+   uint8_t new_kek[VAULT_KEK_LEN];
+   assert(vault_server_kek(new_kek) == 0);
+   assert(memcmp(old_kek, new_kek, VAULT_KEK_LEN) != 0 && "server KEK did not change");
+
+   /* Server-principal creds hold the server KEK as their PRIMARY wrap, so the
+    * read path is vault_store_get (wrapped_dek), not _get_server. */
+   char out[256];
+   assert(vault_store_get(VAULT_SERVER_PRINCIPAL, new_kek, "agentA", VAULT_API_KEY_CRED, out,
+                          sizeof(out)) == 0);
+   assert(strcmp(out, secretA) == 0 && "agentA did not survive rotation under the new KEK");
+   assert(vault_store_get(VAULT_SERVER_PRINCIPAL, new_kek, "agentB", VAULT_API_KEY_CRED, out,
+                          sizeof(out)) == 0);
+   assert(strcmp(out, secretB) == 0 && "agentB did not survive rotation under the new KEK");
+
+   /* The OLD KEK is now dead — it must NOT decrypt the re-wrapped server wrap. */
+   assert(vault_store_get(VAULT_SERVER_PRINCIPAL, old_kek, "agentA", VAULT_API_KEY_CRED, out,
+                          sizeof(out)) != 0 &&
+          "old server KEK still decrypts after rotation");
+
+   snprintf(cmd, sizeof(cmd), "rm -rf %s %s", g_home, backup);
+   (void)system(cmd);
+
+   printf("PASS: vault master-key rotation re-wraps all server wraps (D13)\n");
+   return 0;
+}

--- a/src/tests/test_vault_master_rotate.c
+++ b/src/tests/test_vault_master_rotate.c
@@ -1,12 +1,14 @@
 /* test_vault_master_rotate.c — D13 master-key rotation.
  *
- * Proves vault_server_key_rotate() re-wraps every server wrap from the old
- * `.server-master.key` to a freshly minted one (a re-wrap, not a re-encrypt):
- *   - all server-principal credentials still decrypt under the NEW server KEK;
- *   - they NO LONGER decrypt under the OLD server KEK (the old key is dead);
- *   - the on-disk master key actually changed;
- *   - a recoverable pre-rotation backup of .vault was taken;
- *   - the reported re-wrap count matches the number of stored credentials. */
+ * Proves vault_server_key_rotate() re-wraps every server-KEK-held wrap from the
+ * old `.server-master.key` to a freshly minted one (a re-wrap, not a re-encrypt):
+ *   - server-principal creds (server KEK in the PRIMARY "wrapped_dek") survive;
+ *   - a user dual-access cred's SERVER wrap ("wrapped_dek_server") is re-wrapped
+ *     while its USER wrap ("wrapped_dek") is left untouched;
+ *   - nothing decrypts under the OLD server KEK afterwards;
+ *   - the on-disk master key actually changed; a recoverable backup was taken;
+ *   - a no-master-key vault is a clean no-op (exit 0);
+ *   - a corrupted server wrap makes rotation ABORT fail-closed (master unchanged). */
 #include "vault_service.h"
 #include "vault_server_key.h"
 #include "vault_store.h"
@@ -51,71 +53,173 @@ static int dir_has_regular_file(const char *dir)
    return found;
 }
 
-int main(void)
+static void fresh_home(const char *tag)
 {
-   snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultrotate-test-%d", (int)getpid());
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-vaultrotate-%s-%d", tag, (int)getpid());
    char cmd[640];
    snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", g_home, g_home);
    assert(system(cmd) == 0);
    setenv("AIMEE_HOME", g_home, 1);
    vault_server_key_reset_for_test();
+}
 
+static void cleanup_home(void)
+{
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s %s.rotate-bak.* 2>/dev/null", g_home, g_home);
+   (void)system(cmd);
+}
+
+/* Flip one base64url char of the first `field` value in the server-principal
+ * vault file so it still decodes but fails the AES-KW integrity check. */
+static void corrupt_field(const char *field)
+{
+   char vpath[512];
+   /* b64url("server") = "c2VydmVy" */
+   snprintf(vpath, sizeof(vpath), "%s/.vault/c2VydmVy.json", g_home);
+   FILE *f = fopen(vpath, "rb");
+   assert(f);
+   char buf[8192];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   char needle[64];
+   snprintf(needle, sizeof(needle), "\"%s\":\"", field);
+   char *p = strstr(buf, needle);
+   assert(p && "field not found to corrupt");
+   p += strlen(needle);
+   *p = (*p == 'A') ? 'B' : 'A'; /* still a valid b64url char */
+   f = fopen(vpath, "wb");
+   assert(f);
+   fwrite(buf, 1, n, f);
+   fclose(f);
+}
+
+/* ── Scenario: no master key yet → clean no-op ──────────────────────────────── */
+static void test_no_master(void)
+{
+   fresh_home("nomaster");
+   int np = -1, nc = -1;
+   char backup[1280] = "x", err[256] = "";
+   int rc = vault_server_key_rotate(VAULT_SERVER_PRINCIPAL, &np, &nc, backup, sizeof(backup), err,
+                                    sizeof(err));
+   assert(rc == 0 && "no-master rotation should be a clean no-op");
+   assert(np == 0 && nc == 0 && "nothing to rotate");
+   assert(backup[0] == '\0' && "no backup for an empty vault");
+   cleanup_home();
+   printf("  PASS: no master key -> clean no-op\n");
+}
+
+/* ── Scenario: a corrupted server wrap aborts fail-closed ───────────────────── */
+static void test_corrupt_wrap_aborts(void)
+{
+   fresh_home("corrupt");
+   assert(vault_service_set_server("agentA", VAULT_API_KEY_CRED, "sk-corrupt-test") == VAULT_OK);
+   uint8_t mk_before[VAULT_ROOT_KEY_LEN];
+   assert(read_master_key(mk_before) == 0);
+   corrupt_field("wrapped_dek");
+
+   int np = -1, nc = -1;
+   char backup[1280] = "", err[256] = "";
+   int rc = vault_server_key_rotate(VAULT_SERVER_PRINCIPAL, &np, &nc, backup, sizeof(backup), err,
+                                    sizeof(err));
+   assert(rc != 0 && "rotation must abort on a corrupt/unwrappable server wrap");
+
+   uint8_t mk_after[VAULT_ROOT_KEY_LEN];
+   assert(read_master_key(mk_after) == 0);
+   assert(memcmp(mk_before, mk_after, VAULT_ROOT_KEY_LEN) == 0 &&
+          "master key must be UNCHANGED after an aborted rotation");
+   cleanup_home();
+   printf("  PASS: corrupt server wrap -> abort, master unchanged\n");
+}
+
+/* ── Scenario: server creds + a user dual-access cred all rotate correctly ──── */
+static void test_full_rotation(void)
+{
+   fresh_home("full");
    const char *secretA = "sk-rotateA-3f9c2e";
    const char *secretB = "sk-rotateB-7a1d8b";
+   const char *secretC = "sk-dual-C-1a2b3c";
 
-   /* Two server-principal credentials — this mints the master key + server wraps. */
+   /* Two server-principal creds (server KEK is their PRIMARY wrap). */
    assert(vault_service_set_server("agentA", VAULT_API_KEY_CRED, secretA) == VAULT_OK);
    assert(vault_service_set_server("agentB", VAULT_API_KEY_CRED, secretB) == VAULT_OK);
 
-   /* Capture the OLD server KEK and master key. */
+   /* A user principal with a DUAL-access cred: a user wrap (wrapped_dek under a
+    * user KEK) plus a server wrap (wrapped_dek_server under the server KEK). Only
+    * the server wrap must be re-wrapped; the user wrap must be left untouched. */
    uint8_t old_kek[VAULT_KEK_LEN];
    assert(vault_server_kek(old_kek) == 0);
+   uint8_t user_root[VAULT_ROOT_KEY_LEN];
+   memset(user_root, 0x5a, sizeof(user_root));
+   uint8_t user_salt[VAULT_SALT_LEN];
+   memset(user_salt, 0x11, sizeof(user_salt));
+   uint8_t user_kek[VAULT_KEK_LEN];
+   assert(vault_kek_derive(user_root, sizeof(user_root), user_salt, sizeof(user_salt), user_kek) ==
+          0);
+   /* The principal's vault file must exist before a set; the stored salt is
+    * unused here since we pass the derived KEK directly. */
+   uint8_t throwaway_salt[VAULT_SALT_LEN];
+   assert(vault_store_get_or_create_salt("uid:9999", throwaway_salt) == 0);
+   assert(vault_store_set_dual("uid:9999", user_kek, old_kek, "agentC", VAULT_API_KEY_CRED,
+                               secretC) == 0);
+
    uint8_t mk_before[VAULT_ROOT_KEY_LEN];
    assert(read_master_key(mk_before) == 0);
 
-   /* Rotate. */
    int np = -1, nc = -1;
    char backup[1280] = "", err[256] = "";
    int rc = vault_server_key_rotate(VAULT_SERVER_PRINCIPAL, &np, &nc, backup, sizeof(backup), err,
                                     sizeof(err));
    assert(rc == 0 && "rotation failed");
-   assert(nc == 2 && "expected exactly 2 credentials re-wrapped");
-   assert(np >= 1 && "expected at least the server principal");
-   printf("  rotate: %d principal(s), %d cred(s) re-wrapped, backup=%s\n", np, nc, backup);
+   assert(nc == 3 && "expected 3 server-KEK wraps re-wrapped (agentA, agentB, agentC-server)");
+   assert(np >= 2 && "expected the server principal + uid:9999");
+   printf("  rotate: %d principal(s), %d wrap(s) re-wrapped, backup=%s\n", np, nc, backup);
 
-   /* The on-disk master key actually changed. */
    uint8_t mk_after[VAULT_ROOT_KEY_LEN];
    assert(read_master_key(mk_after) == 0);
    assert(memcmp(mk_before, mk_after, VAULT_ROOT_KEY_LEN) != 0 && "master key did not change");
+   assert(backup[0] && dir_has_regular_file(backup) && "backup missing/empty");
 
-   /* A recoverable pre-rotation backup exists and is non-empty. */
-   assert(backup[0] && "no backup path reported");
-   assert(dir_has_regular_file(backup) && "backup directory is empty");
-
-   /* Re-derive the server KEK from the NEW master and confirm both creds decrypt. */
+   /* New server KEK reads the server-principal creds; old KEK is dead. */
    vault_server_key_reset_for_test();
    uint8_t new_kek[VAULT_KEK_LEN];
    assert(vault_server_kek(new_kek) == 0);
    assert(memcmp(old_kek, new_kek, VAULT_KEK_LEN) != 0 && "server KEK did not change");
 
-   /* Server-principal creds hold the server KEK as their PRIMARY wrap, so the
-    * read path is vault_store_get (wrapped_dek), not _get_server. */
    char out[256];
    assert(vault_store_get(VAULT_SERVER_PRINCIPAL, new_kek, "agentA", VAULT_API_KEY_CRED, out,
-                          sizeof(out)) == 0);
-   assert(strcmp(out, secretA) == 0 && "agentA did not survive rotation under the new KEK");
+                          sizeof(out)) == 0 &&
+          strcmp(out, secretA) == 0);
    assert(vault_store_get(VAULT_SERVER_PRINCIPAL, new_kek, "agentB", VAULT_API_KEY_CRED, out,
-                          sizeof(out)) == 0);
-   assert(strcmp(out, secretB) == 0 && "agentB did not survive rotation under the new KEK");
-
-   /* The OLD KEK is now dead — it must NOT decrypt the re-wrapped server wrap. */
+                          sizeof(out)) == 0 &&
+          strcmp(out, secretB) == 0);
    assert(vault_store_get(VAULT_SERVER_PRINCIPAL, old_kek, "agentA", VAULT_API_KEY_CRED, out,
                           sizeof(out)) != 0 &&
-          "old server KEK still decrypts after rotation");
+          "old server KEK still decrypts a server-principal cred");
 
-   snprintf(cmd, sizeof(cmd), "rm -rf %s %s", g_home, backup);
-   (void)system(cmd);
+   /* The dual cred's SERVER wrap re-wrapped to the new KEK; old KEK dead there too. */
+   assert(vault_store_get_server("uid:9999", new_kek, "agentC", VAULT_API_KEY_CRED, out,
+                                 sizeof(out)) == 0 &&
+          strcmp(out, secretC) == 0 && "dual server wrap did not survive under the new KEK");
+   assert(vault_store_get_server("uid:9999", old_kek, "agentC", VAULT_API_KEY_CRED, out,
+                                 sizeof(out)) != 0 &&
+          "old server KEK still decrypts the dual server wrap");
 
-   printf("PASS: vault master-key rotation re-wraps all server wraps (D13)\n");
+   /* The USER wrap was NOT touched — still decrypts under the unchanged user KEK. */
+   assert(vault_store_get("uid:9999", user_kek, "agentC", VAULT_API_KEY_CRED, out, sizeof(out)) ==
+              0 &&
+          strcmp(out, secretC) == 0 && "user wrap was altered by master-key rotation");
+
+   cleanup_home();
+   printf("  PASS: server + dual-access rotation; user wrap preserved\n");
+}
+
+int main(void)
+{
+   test_no_master();
+   test_corrupt_wrap_aborts();
+   test_full_rotation();
+   printf("PASS: vault master-key rotation (D13)\n");
    return 0;
 }


### PR DESCRIPTION
## What

Ship the `.server-master.key` rotation/re-wrap path that the `cred-vault-consolidation` proposal required (**D13**) but never landed. Until now a leaked or suspected-compromised master key had **no recovery path** short of re-initializing the vault and re-importing every agent key — an incident-response gap flagged as must-build by the proposal closeout roundtable.

## Change

`aimee-server --rotate-master-key` — an **offline maintenance op** (run with the server stopped):

1. Reads the current `.server-master.key`, derives the old server KEK.
2. Mints a fresh master key, derives the new server KEK (not yet persisted).
3. Backs up the whole `.vault/` to `.vault.rotate-bak.<pid>` (0700) **before any mutation**.
4. Re-wraps every server-KEK-held DEK old→new — a **re-wrap, not a re-encrypt** (no credential plaintext / nonce / ciphertext / tag is touched; per-user zero-knowledge wraps are left alone).
5. Writes the new master key **last** (atomic tmp+rename+fsync), then drops the cached KEK.

**Why offline:** the server caches one process-wide server KEK, so a live rotation would leave autonomous decrypts failing for the window between re-wrapping a credential and swapping the key. Offline avoids the window entirely.

**Crash/error safety:** if any principal's re-wrap fails, or the new master can't be persisted, the vault is **restored from the backup** and the op aborts with the vault unchanged — never a new-wrapped vault under an old master, nor the reverse. A crash leaves either the old state or the fully-rotated state.

**Field correctness:** the server principal holds the server KEK as its primary `wrapped_dek`; user principals hold it only in the dual-access `wrapped_dek_server`. Rotation re-wraps exactly the server-KEK-held field per principal (passed in from the caller so the key module stays below the `vault_service` naming layer — module-boundary clean).

## New primitives

- `vault_store_rekey_field(principal, field, old_kek, new_kek)` — re-wrap a named DEK-wrap field; fail-closed (abort, write nothing) if a present field won't unwrap under the old key.
- `vault_store_list_principals()` — enumerate vault principals from `.vault` filenames.
- `vault_server_key_rotate(server_principal, …)` — the orchestrator (backup → re-wrap → atomic swap → cache reset, restore-on-fail).
- `docs/runbooks/vault-master-key-rotation.md` — operator procedure + safety notes + verification checklist.

## Tests

`unit-test-vault-master-rotate`: all server creds still decrypt under the **new** KEK, **no longer** decrypt under the **old** KEK, the on-disk master key actually changed, the server KEK changed, the reported re-wrap count matches, and a recoverable backup was taken. `unit-test-vault-service` / `unit-test-vault-store` still pass; server builds green (`make -j1`), lint clean (`clang-format-19`, module-boundary ok).

Part of filing `cred-vault-consolidation` to done (closeout item D13).
