### PR TITLE
feat(kb): cross-repo precision H3b — header IDF (completes §2)

### DIFF
--- a/src/db2/cross_repo_route.c
+++ b/src/db2/cross_repo_route.c
@@ -46,12 +46,35 @@ static const char *const SQL_MODULE_ROUTES =
                                     "ON CONFLICT (caller_project, definer_project, kind, evidence) "
                                     "DO NOTHING";
 
+/* §2 header IDF (H3b): a quoted #include that resolves to non-vendored files in
+ * >= 4 distinct repos is non-distinctive — a ubiquitous name (config.h, common.h,
+ * log.h) where the include almost always means the caller's OWN copy, not a
+ * cross-repo dependency. Such includes produce no confident header route (they
+ * would otherwise fan a spurious route to every repo that shares the name).
+ *
+ * Ubiquity is measured on the SAME key the route join uses — the include-specifier
+ * path-suffix (`path = imp.name OR path LIKE '%/'||imp.name`) — NOT a bare
+ * basename, deliberately: keying on the route's own match means the count reflects
+ * the route's actual fan-out. For the common bare `#include "config.h"` this is
+ * exactly basename IDF; for a directory-qualified `#include "foo/config.h"` it is
+ * the (more specific, lower-fan-out) component-suffix, which is the correct, more
+ * recall-preserving measure — counting bare-basename ubiquity there would wrongly
+ * exclude a specific path that routes to only one repo.
+ *
+ * Note: angle-bracket / system <...> includes are ALREADY excluded upstream — the
+ * C extractor (c_import_line) records ONLY quoted #include "..." into file_imports
+ * — so §2's system-include signal needs no work here. The threshold is the literal
+ * `< 4` in SQL_HEADER_ROUTES below (a candidate for config-ization + tuning after
+ * H4's live re-validation). */
+
 /* import_header (MEDIUM): a caller C/C++ #include matched to a definer file whose
  * path equals the include or ends with '/'+include (component boundary). The
  * caller file's language (H0b) restricts this to C/C++ so module specifiers from
  * other languages don't masquerade as headers; the definer file must not be
- * vendored (H0b). The repo-unique HIGH-vs-MEDIUM + system-header reject are
- * applied by H1's resolver, not here (this is the raw candidate adjacency). */
+ * vendored (H0b); and the include must clear the §2 header-IDF threshold above
+ * (ubiquity counted on the same path-suffix key, vendored files excluded from the
+ * count so a vendored copy never inflates ubiquity). The repo-unique HIGH-vs-MEDIUM
+ * is applied by H1's resolver (this is the raw candidate adjacency). */
 static const char *const SQL_HEADER_ROUTES =
     "INSERT INTO cross_repo_route (caller_project, definer_project, kind, confidence, evidence) "
     "SELECT DISTINCT pc.name, pd.name, 'import_header', 'medium', imp.name "
@@ -63,7 +86,12 @@ static const char *const SQL_HEADER_ROUTES =
         "imp.name") " ESCAPE '\\') "
                     "JOIN projects pd ON pd.id = fd.project_id "
                     "WHERE cf.language IN ('c', 'cpp') AND fd.vendored = 0 AND pd.name <> pc.name "
-                    "ON CONFLICT (caller_project, definer_project, kind, evidence) DO NOTHING";
+                    "  AND (SELECT COUNT(DISTINCT fx.project_id) FROM files fx "
+                    "       WHERE (fx.path = imp.name OR fx.path LIKE '%/' || " ESC(
+                        "imp.name") " ESCAPE '\\') "
+                                    "         AND fx.vendored = 0) < 4 "
+                                    "ON CONFLICT (caller_project, definer_project, kind, evidence) "
+                                    "DO NOTHING";
 
 static int crr_count(void *conn)
 {

--- a/src/tests/test_cross_repo_route.c
+++ b/src/tests/test_cross_repo_route.c
@@ -133,10 +133,111 @@ static void test_routes(void)
    printf("ok\n");
 }
 
+/* §2 header-basename IDF (H3b): a quoted include whose basename resolves to
+ * non-vendored files in >= 4 distinct repos is too ubiquitous to be a confident
+ * route (produces none); a basename in < 4 repos still routes. */
+static void test_header_idf(void)
+{
+   printf("test_header_idf... ");
+   /* idfapp includes "ubiq.h" and "rare.h". ubiq.h exists in 4 definer repos (>=4
+    * distinct => ubiquitous, no route); rare.h in 1 (routes). */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('idfapp','/ia','t','trusted')");
+   for (int i = 0; i < 4; i++)
+   {
+      char nm[32], sql[400];
+      snprintf(nm, sizeof(nm), "ubiqlib%d", i);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO projects (name, root, scanned_at, trust) VALUES ('%s','/u%d','t',"
+               "'trusted')",
+               nm, i);
+      X(sql);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'inc/ubiq.h','t','c',0 FROM projects WHERE name='%s'",
+               nm);
+      X(sql);
+   }
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('rarelib','/rl','t','trusted')");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT id,'inc/rare.h','t',"
+     "'c',0 FROM projects WHERE name='rarelib'");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'src/m.c','t','c',0 "
+     "FROM projects WHERE name='idfapp'");
+   X("INSERT INTO file_imports (file_id,name) SELECT f.id,'ubiq.h' FROM files f JOIN projects p ON "
+     "p.id=f.project_id WHERE p.name='idfapp' AND f.path='src/m.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT f.id,'rare.h' FROM files f JOIN projects p ON "
+     "p.id=f.project_id WHERE p.name='idfapp' AND f.path='src/m.c'");
+
+   /* boundary: "bnd.h" in exactly 3 repos (< 4) MUST still route. */
+   for (int i = 0; i < 3; i++)
+   {
+      char nm[32], sql[400];
+      snprintf(nm, sizeof(nm), "bndlib%d", i);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO projects (name, root, scanned_at, trust) VALUES ('%s','/b%d','t',"
+               "'trusted')",
+               nm, i);
+      X(sql);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'inc/bnd.h','t','c',0 FROM projects WHERE name='%s'",
+               nm);
+      X(sql);
+   }
+   X("INSERT INTO file_imports (file_id,name) SELECT f.id,'bnd.h' FROM files f JOIN projects p ON "
+     "p.id=f.project_id WHERE p.name='idfapp' AND f.path='src/m.c'");
+   /* vendored copies must NOT count toward ubiquity: "vd.h" in 1 non-vendored repo +
+    * 5 vendored repos -> count is 1 (< 4) -> routes to the non-vendored one. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vdreal','/vr','t','trusted')");
+   X("INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+     "id,'inc/vd.h','t','c',"
+     "0 FROM projects WHERE name='vdreal'");
+   for (int i = 0; i < 5; i++)
+   {
+      char nm[32], sql[400];
+      snprintf(nm, sizeof(nm), "vdvend%d", i);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO projects (name, root, scanned_at, trust) VALUES ('%s','/vv%d','t',"
+               "'trusted')",
+               nm, i);
+      X(sql);
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at,language,vendored) SELECT "
+               "id,'third_party/vd.h','t','c',1 FROM projects WHERE name='%s'",
+               nm);
+      X(sql);
+   }
+   X("INSERT INTO file_imports (file_id,name) SELECT f.id,'vd.h' FROM files f JOIN projects p ON "
+     "p.id=f.project_id WHERE p.name='idfapp' AND f.path='src/m.c'");
+
+   int rc = db2_cross_repo_rebuild_routes();
+   assert(rc >= 0);
+   /* ubiq.h is in 4 repos => no route to any of them. */
+   for (int i = 0; i < 4; i++)
+   {
+      char nm[32];
+      snprintf(nm, sizeof(nm), "ubiqlib%d", i);
+      assert(route_count("idfapp", nm, "import_header") == 0);
+   }
+   /* rare.h is in 1 repo => routes. */
+   assert(route_count("idfapp", "rarelib", "import_header") == 1);
+   /* bnd.h in exactly 3 repos (< 4) => still routes to all three. */
+   for (int i = 0; i < 3; i++)
+   {
+      char nm[32];
+      snprintf(nm, sizeof(nm), "bndlib%d", i);
+      assert(route_count("idfapp", nm, "import_header") == 1);
+   }
+   /* vd.h: 5 vendored copies don't count; the 1 non-vendored repo routes. */
+   assert(route_count("idfapp", "vdreal", "import_header") == 1);
+   printf("ok\n");
+}
+
 int main(void)
 {
    db2_test_shim_open();
    test_routes();
+   test_header_idf();
    printf("cross_repo_route: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Slice **H3b** of the cross-repo precision-hardening — §2 distinctiveness, the final build slice before live re-validation. Of §2's three mechanisms, two are already satisfied and this adds the third:

- **Symbol-level corpus IDF** ("defined in ≥ M repos ⇒ non-distinctive") — already present via `xrepo_name_distinctive`'s `m`/`k` repo-count thresholds. No change.
- **Angle-bracket / system-include signal** — already enforced upstream: the C extractor (`c_import_line`) records ONLY quoted `#include "..."` into `file_imports` and skips `<...>`, so a system include never forms a route (`DEFINE_GUID`-via-`<windows.h>` cannot route). Verified, documented.
- **Header IDF** (this slice): a quoted `#include` resolving to non-vendored files in **≥ 4 distinct repos** is non-distinctive (`config.h`/`common.h`/`log.h` — the include means the caller's own copy, not a cross-repo dep) and produces no header route. `SQL_HEADER_ROUTES` gains a `COUNT(DISTINCT project_id) < 4` subquery measuring ubiquity on the **same include-specifier path-suffix key** the route join uses (route-consistent: bare include ⇒ basename IDF; directory-qualified ⇒ the more-specific, recall-preserving component-suffix), with vendored files excluded from the count.

## Verification

Tests: basename in 4 repos → no route; 1 repo → routes; boundary 3 repos → still routes; 5 vendored copies don't count toward ubiquity. Full unit-test suite (897) green, `make lint` green, `aimee-kb` links. Reviewed via the aimee roundtable (diff embedded) → converged, 0 blocking (round-1 blocker — IDF key semantics — resolved by documenting the route-consistent include-specifier keying + boundary/vendored tests).

## Completes the build

§1 route gate (H1), §3 FFI same-language default, §4 vendor canonical-preference (H2), §5 kind + §4 ceiling (H3a), §6 export-booster (already enforced), §2 IDF (this). Next: **H4** live re-validation on `.254` (spot-check the known FP classes collapse; confirm true deps survive).