### PR TITLE
feat(vault): backup-before-scrub + run lock for agent key import (D9)

### DIFF
--- a/src/cli_agent_keys.c
+++ b/src/cli_agent_keys.c
@@ -164,12 +164,33 @@ static int backup_keyring(char *out, size_t out_len)
       free(buf);
       return -1;
    }
+   /* Create the backup 0600 ATOMICALLY (open with the mode, not fopen-then-chmod)
+    * so the plaintext keys are never momentarily world-readable, and with
+    * O_EXCL|O_NOFOLLOW so a pre-planted symlink at the predictable path can't trap
+    * the write. On POSIX; the Windows thin client is not the import target. */
+#ifndef _WIN32
+   int fd = open(dst, O_CREAT | O_EXCL | O_WRONLY | O_NOFOLLOW, 0600);
+   if (fd < 0)
+   {
+      free(buf);
+      return -1;
+   }
+   FILE *f = fdopen(fd, "wb");
+   if (!f)
+   {
+      close(fd);
+      remove(dst);
+      free(buf);
+      return -1;
+   }
+#else
    FILE *f = fopen(dst, "wb");
    if (!f)
    {
       free(buf);
       return -1;
    }
+#endif
    size_t len = strlen(buf);
    int ok = (fwrite(buf, 1, len, f) == len) && (fflush(f) == 0);
    free(buf);
@@ -184,7 +205,9 @@ static int backup_keyring(char *out, size_t out_len)
       remove(dst);
       return -1;
    }
+#ifdef _WIN32
    chmod(dst, 0600);
+#endif
    snprintf(out, out_len, "%s", dst);
    return 0;
 }
@@ -210,10 +233,18 @@ static int acquire_import_lock(char *lockpath, size_t lp_len)
 
 static void release_import_lock(int fd, const char *lockpath)
 {
+   /* Only remove the lock file if it is still OUR lock: if an operator manually
+    * cleared a "stale" lock and another run re-created it, the path now names a
+    * different inode and a blind remove() would delete the live run's lock. */
+   if (fd >= 0 && lockpath && lockpath[0])
+   {
+      struct stat fd_st, path_st;
+      if (fstat(fd, &fd_st) == 0 && stat(lockpath, &path_st) == 0 &&
+          fd_st.st_ino == path_st.st_ino && fd_st.st_dev == path_st.st_dev)
+         remove(lockpath);
+   }
    if (fd >= 0)
       close(fd);
-   if (lockpath && lockpath[0])
-      remove(lockpath);
 }
 #endif
 

--- a/src/cli_agent_keys.c
+++ b/src/cli_agent_keys.c
@@ -13,8 +13,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/stat.h> /* chmod */
+#include <time.h>     /* time() for the backup suffix */
 #ifndef _WIN32
-#include <unistd.h> /* fsync, fileno */
+#include <errno.h>  /* EEXIST (import lock) */
+#include <fcntl.h>  /* open, O_CREAT|O_EXCL (import lock) */
+#include <unistd.h> /* fsync, fileno, write, close */
 #endif
 
 #define AGENT_KEYS_FILE "agent-keys.json"
@@ -136,6 +139,84 @@ int cli_agent_key_set(const char *agent_name, const char *api_key)
    return 0;
 }
 
+/* Copy the keyring file to a 0600 sibling backup before the destructive scrub
+ * (D9 backup-before-scrub). The scrub empties agent-keys.json; if the vault copy
+ * later becomes unreadable (e.g. a lost/corrupt master key — a failure mode the
+ * server's atomic write does NOT cover), this backup is the only recoverable copy
+ * of the plaintext keys. Writes the backup path into `out` (caller reports it so
+ * the operator can verify delegates, then remove it). 0 on success, -1 on error
+ * (incl. no keyring file to back up). */
+static int backup_keyring(char *out, size_t out_len)
+{
+   char src[1024];
+   if (aimee_file_path(AGENT_KEYS_FILE, src, sizeof(src)) != 0)
+      return -1;
+   char *buf = read_text(src);
+   if (!buf)
+      return -1; /* nothing to back up */
+   char dst[1100];
+   /* Unique, portable suffix (the lock already serializes concurrent runs on
+    * POSIX; the timestamp keeps a prior, not-yet-removed backup from being
+    * clobbered). */
+   if ((size_t)snprintf(dst, sizeof(dst), "%s.pre-import.%lld", src, (long long)time(NULL)) >=
+       sizeof(dst))
+   {
+      free(buf);
+      return -1;
+   }
+   FILE *f = fopen(dst, "wb");
+   if (!f)
+   {
+      free(buf);
+      return -1;
+   }
+   size_t len = strlen(buf);
+   int ok = (fwrite(buf, 1, len, f) == len) && (fflush(f) == 0);
+   free(buf);
+#ifndef _WIN32
+   if (ok && fsync(fileno(f)) != 0)
+      ok = 0;
+#endif
+   if (fclose(f) != 0)
+      ok = 0;
+   if (!ok)
+   {
+      remove(dst);
+      return -1;
+   }
+   chmod(dst, 0600);
+   snprintf(out, out_len, "%s", dst);
+   return 0;
+}
+
+#ifndef _WIN32
+/* Advisory exclusive lock so two concurrent `agent key import` runs (or a
+ * concurrent `agent add` write) cannot interleave the read-modify-write of the
+ * keyring (D9 per-run lock). POSIX-only; the import is an operator command run on
+ * the server host. Returns the lock fd (>=0), -1 on a non-contention error, or -2
+ * if the lock is already held. */
+static int acquire_import_lock(char *lockpath, size_t lp_len)
+{
+   if (aimee_file_path(AGENT_KEYS_FILE ".import.lock", lockpath, lp_len) != 0)
+      return -1;
+   int fd = open(lockpath, O_CREAT | O_EXCL | O_WRONLY, 0600);
+   if (fd < 0)
+      return errno == EEXIST ? -2 : -1;
+   char pid[32];
+   int n = snprintf(pid, sizeof(pid), "%d\n", (int)getpid());
+   (void)(write(fd, pid, (size_t)n) >= 0);
+   return fd;
+}
+
+static void release_import_lock(int fd, const char *lockpath)
+{
+   if (fd >= 0)
+      close(fd);
+   if (lockpath && lockpath[0])
+      remove(lockpath);
+}
+#endif
+
 /* `aimee agent key import [--keep] [--dry-run]` (P3): migrate client-held
  * agent-keys.json entries into the server vault under the server principal
  * (vault.set_server). The vault is the single permanent credential store, so the
@@ -159,6 +240,44 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
          scrub = 1; /* accepted no-op (now the default) */
       else if (strcmp(argv[i], "--dry-run") == 0)
          dry = 1;
+   }
+
+   /* Serialize against a concurrent import / `agent add` so two writers cannot
+    * interleave the keyring read-modify-write (D9). A dry-run mutates nothing, so
+    * it needs no lock. POSIX-only; the import is a server-host operator command. */
+#ifndef _WIN32
+   int lock_fd = -1;
+   char lockpath[1100] = "";
+   if (!dry)
+   {
+      lock_fd = acquire_import_lock(lockpath, sizeof(lockpath));
+      if (lock_fd == -2)
+      {
+         printf("agent key import: another import appears to be running (lock %s). Re-run after "
+                "it finishes, or remove a stale lock.\n",
+                lockpath);
+         return 1;
+      }
+      /* lock_fd == -1 (a non-contention error, e.g. read-only home) is non-fatal:
+       * proceed unlocked rather than block a legitimate single-run migration. */
+   }
+#endif
+
+   /* Backup-before-scrub (D9): take ONE recoverable 0600 snapshot of the keyring
+    * before the first destructive scrub. If it can't be written we must not scrub
+    * (keep the plaintext — the safe direction) and say so loudly. */
+   char backup_path[1100] = "";
+   int backup_done = 0;
+   if (scrub && !dry)
+   {
+      if (backup_keyring(backup_path, sizeof(backup_path)) == 0)
+         backup_done = 1;
+      else
+      {
+         scrub = 0;
+         printf("WARNING: could not write a pre-import backup of the keyring — NOT scrubbing "
+                "(plaintext kept). Fix the home directory permissions and re-run to scrub.\n");
+      }
    }
 
    cJSON *keys = cli_agent_keys_load();
@@ -212,10 +331,22 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
 
    if (dry)
    {
+#ifndef _WIN32
+      release_import_lock(lock_fd, lockpath);
+#endif
       printf("agent key import (dry-run): %d entr%s would be sent; nothing changed\n", total,
              total == 1 ? "y" : "ies");
       return 0;
    }
+
+   /* A backup that scrubbed nothing is a redundant extra plaintext copy — drop it.
+    * Otherwise keep it and tell the operator to remove it once delegates verify. */
+   if (backup_done && vaulted == 0)
+   {
+      remove(backup_path);
+      backup_done = 0;
+   }
+
    const char *suffix = "";
    if (vaulted > 0)
       suffix = scrub ? "; vaulted entries scrubbed from the local plaintext keyring"
@@ -223,9 +354,16 @@ int cli_agent_key_import(int argc, char **argv, int json_output)
                        "readable on disk";
    printf("agent key import: %d vaulted, %d refused, %d error (of %d)%s\n", vaulted, refused,
           errors, total, suffix);
+   if (backup_done)
+      printf("pre-import backup written to %s (0600) — verify delegates authenticate from the "
+             "vault, then remove it (it holds the plaintext keys).\n",
+             backup_path);
    if (refused > 0)
       printf("note: server-principal writes need an attested (UDS/webchat) connection holding the "
              "vault:write:server capability — run this on the server host over UDS, or grant the "
              "capability.\n");
+#ifndef _WIN32
+   release_import_lock(lock_fd, lockpath);
+#endif
    return errors > 0 ? 1 : 0;
 }

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -258,6 +258,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-aimee-tls-clientcert \
                $(TESTPREFIX)/unit-test-vault-server-key \
                $(TESTPREFIX)/unit-test-vault-capability \
+               $(TESTPREFIX)/unit-test-agent-key-import \
                $(TESTPREFIX)/unit-test-vault-audit \
                $(TESTPREFIX)/unit-test-prompts \
                $(TESTPREFIX)/unit-test-cmd-session \
@@ -2578,6 +2579,11 @@ $(TESTPREFIX)/unit-test-vault-master-rotate: $(OBJDIR)/tests/test_vault_master_r
                               $(OBJDIR)/server/vault_service.o $(OBJDIR)/server/vault_store.o \
                               $(OBJDIR)/server/vault_crypto.o $(OBJDIR)/server/vault_kek_cache.o \
                               $(OBJDIR)/server/vault_server_key.o \
+                              $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-agent-key-import: $(OBJDIR)/tests/test_agent_key_import.o \
+                              $(OBJDIR)/cli_agent_keys.o \
                               $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_agent_key_import.c
+++ b/src/tests/test_agent_key_import.c
@@ -17,6 +17,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 static char g_home[256];
@@ -108,6 +109,9 @@ int main(void)
 
    char backup[512];
    assert(find_backup(backup, sizeof(backup)) && "no pre-import backup was written");
+   struct stat bst;
+   assert(stat(backup, &bst) == 0 && (bst.st_mode & 0777) == 0600 &&
+          "backup must be 0600 (never momentarily world-readable)");
    FILE *bf = fopen(backup, "rb");
    assert(bf);
    char bbuf[4096];

--- a/src/tests/test_agent_key_import.c
+++ b/src/tests/test_agent_key_import.c
@@ -1,0 +1,158 @@
+/* test_agent_key_import.c — D9 backup-before-scrub + run lock for
+ * `aimee agent key import`.
+ *
+ * Drives the real cli_agent_key_import() with a stubbed server dispatch so the
+ * destructive scrub path runs without a live server. Proves:
+ *   - a successful scrubbing import writes a recoverable 0600 backup of the
+ *     keyring BEFORE scrubbing, and the backup holds the plaintext keys;
+ *   - the keyring is scrubbed only after the backup exists;
+ *   - the run lock is released (no stale lock left behind);
+ *   - a refused import (no capability) scrubs nothing and leaves no backup;
+ *   - --keep imports without scrubbing and writes no backup. */
+#include "cli_agent_keys.h"
+#include "cli_client.h"
+#include "cJSON.h"
+#include <assert.h>
+#include <dirent.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static char g_home[256];
+
+/* Controllable server stub: g_status / g_message drive the response. */
+static const char *g_status = "ok";
+static const char *g_message = NULL;
+cJSON *cli_v1_dispatch(cJSON *req, int timeout_ms)
+{
+   (void)req;
+   (void)timeout_ms;
+   cJSON *r = cJSON_CreateObject();
+   cJSON_AddStringToObject(r, "status", g_status);
+   if (g_message)
+      cJSON_AddStringToObject(r, "message", g_message);
+   return r;
+}
+
+static void write_keyring(const char *json)
+{
+   char path[400];
+   snprintf(path, sizeof(path), "%s/agent-keys.json", g_home);
+   FILE *f = fopen(path, "wb");
+   assert(f);
+   fputs(json, f);
+   fclose(f);
+}
+
+static char *read_keyring(void)
+{
+   char path[400];
+   snprintf(path, sizeof(path), "%s/agent-keys.json", g_home);
+   FILE *f = fopen(path, "rb");
+   if (!f)
+      return NULL;
+   static char buf[4096];
+   size_t n = fread(buf, 1, sizeof(buf) - 1, f);
+   buf[n] = '\0';
+   fclose(f);
+   return buf;
+}
+
+/* Find a backup file agent-keys.json.pre-import.* ; copy its name into `out`. */
+static int find_backup(char *out, size_t out_len)
+{
+   DIR *d = opendir(g_home);
+   if (!d)
+      return 0;
+   int found = 0;
+   struct dirent *de;
+   while ((de = readdir(d)) != NULL)
+   {
+      if (strncmp(de->d_name, "agent-keys.json.pre-import.", 27) == 0)
+      {
+         snprintf(out, out_len, "%s/%s", g_home, de->d_name);
+         found = 1;
+         break;
+      }
+   }
+   closedir(d);
+   return found;
+}
+
+static int lockfile_exists(void)
+{
+   char p[400];
+   snprintf(p, sizeof(p), "%s/agent-keys.json.import.lock", g_home);
+   return access(p, F_OK) == 0;
+}
+
+static void reset_home(void)
+{
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", g_home, g_home);
+   assert(system(cmd) == 0);
+}
+
+int main(void)
+{
+   snprintf(g_home, sizeof(g_home), "/tmp/aimee-keyimport-test-%d", (int)getpid());
+   setenv("AIMEE_HOME", g_home, 1);
+
+   /* 1. Successful scrubbing import: backup written, keyring scrubbed, lock gone. */
+   reset_home();
+   write_keyring("{\"agentA\":\"sk-A-secret\",\"agentB\":\"sk-B-secret\"}");
+   g_status = "ok";
+   g_message = NULL;
+   assert(cli_agent_key_import(0, NULL, 0) == 0);
+
+   char backup[512];
+   assert(find_backup(backup, sizeof(backup)) && "no pre-import backup was written");
+   FILE *bf = fopen(backup, "rb");
+   assert(bf);
+   char bbuf[4096];
+   size_t bn = fread(bbuf, 1, sizeof(bbuf) - 1, bf);
+   bbuf[bn] = '\0';
+   fclose(bf);
+   assert(strstr(bbuf, "sk-A-secret") && strstr(bbuf, "sk-B-secret") &&
+          "backup is missing the plaintext keys");
+
+   char *kr = read_keyring();
+   assert(kr && !strstr(kr, "sk-A-secret") && !strstr(kr, "sk-B-secret") &&
+          "keyring was not scrubbed after a successful import");
+   assert(!lockfile_exists() && "run lock not released");
+   printf("  PASS: scrubbing import backs up then scrubs, lock released\n");
+
+   /* 2. Refused import (no capability): nothing scrubbed, no backup left. */
+   reset_home();
+   write_keyring("{\"agentA\":\"sk-A-secret\"}");
+   g_status = "error";
+   g_message = "vault: caller lacks the vault:write:server capability";
+   /* A capability refusal is counted as "refused", not "error" -> exit 0. */
+   assert(cli_agent_key_import(0, NULL, 0) == 0);
+   kr = read_keyring();
+   assert(kr && strstr(kr, "sk-A-secret") && "a refused import must NOT scrub the key");
+   char ignore[512];
+   assert(!find_backup(ignore, sizeof(ignore)) &&
+          "a refused import (scrubbed nothing) must leave no backup");
+   assert(!lockfile_exists());
+   printf("  PASS: refused import scrubs nothing and leaves no backup\n");
+
+   /* 3. --keep: import without scrubbing, no backup. */
+   reset_home();
+   write_keyring("{\"agentA\":\"sk-A-secret\"}");
+   g_status = "ok";
+   g_message = NULL;
+   char *argv_keep[] = {(char *)"--keep"};
+   assert(cli_agent_key_import(1, argv_keep, 0) == 0);
+   kr = read_keyring();
+   assert(kr && strstr(kr, "sk-A-secret") && "--keep must retain the plaintext key");
+   assert(!find_backup(ignore, sizeof(ignore)) && "--keep takes no backup (nothing is scrubbed)");
+   printf("  PASS: --keep retains plaintext and writes no backup\n");
+
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s", g_home);
+   (void)system(cmd);
+   printf("PASS: agent key import backup-before-scrub + lock (D9)\n");
+   return 0;
+}


### PR DESCRIPTION
## What

Add the two D9 safety items the `cred-vault-consolidation` proposal required for `aimee agent key import` but the shipped flat loop omitted — flagged **must-build** by the closeout roundtable.

`agent key import` migrates client-held `agent-keys.json` keys into the server vault and **scrubs** each plaintext entry once the server reports it vaulted. The server's atomic write proves the vault file is *durable*, but not that it stays *decryptable* (e.g. a later lost/corrupt master key) — and the scrub destroys the only other copy.

## Change

- **Backup-before-scrub:** take ONE recoverable **0600** snapshot of the keyring *before* the first destructive scrub. If it can't be written, **do not scrub** (keep the plaintext — the safe direction) and say so. The path is reported so the operator verifies delegates authenticate from the vault, then removes it. A backup that scrubbed nothing (all refused / nothing vaulted) is dropped rather than left as a redundant extra plaintext copy.
- **Per-run lock:** an advisory `O_CREAT|O_EXCL` lockfile serializes concurrent imports / `agent add` writes against the keyring read-modify-write. POSIX-only (the import is a server-host operator command); a non-contention lock error is non-fatal (proceed unlocked) so a read-only-home edge case can't block a legitimate single run. `--dry-run` takes neither lock nor backup.

## Scope note

The heavier D9 scaffolding (`NOT_STARTED→…→LEGACY_SCRUBBED` state machine, vault-level decrypt-roundtrip verifier, `vault status` surfacing) stays a **tracked follow-up**: the closeout roundtable agreed the decrypt-roundtrip verifier's rationale — defeating a false-VERIFIED via a still-live `/v1/session/credentials` — is moot now that path is deleted; backup-before-scrub covers the independent (durability) failure mode it left open.

## Tests

`unit-test-agent-key-import` drives the real `cli_agent_key_import` with a stubbed dispatch: a scrubbing import backs up (with the plaintext) then scrubs and frees the lock; a refused import scrubs nothing and leaves no backup; `--keep` retains plaintext with no backup. Client builds green (`make -j1`), lint clean (`clang-format-19`).

Part of filing `cred-vault-consolidation` to done (closeout item D9).
