### PR TITLE
feat(codex): explicit REAUTH_REQUIRED state + aimee codex reauth (D6)

### DIFF
--- a/src/cli_agent_setup.c
+++ b/src/cli_agent_setup.c
@@ -412,3 +412,21 @@ int handle_agent_setup_cmd(int argc, char **argv, int json_output)
            provider);
    return 1;
 }
+
+/* `aimee codex reauth` (D6): operator-attended re-authentication for codex when
+ * its stored OAuth refresh token has been rejected (REAUTH_REQUIRED). Runs the
+ * same server-hosted device-code flow as `agent setup codex-oauth` against the
+ * configured remote; a successful exchange re-vaults the token and clears the
+ * REAUTH_REQUIRED marker on the server side. */
+int handle_codex_cmd(int argc, char **argv, int json_output)
+{
+   const char *sub = (argc >= 1) ? argv[0] : NULL;
+   if (sub && strcmp(sub, "reauth") == 0)
+   {
+      fprintf(stderr, "Re-authenticating codex (re-runs the codex-oauth device flow on the "
+                      "configured aimee-server)...\n");
+      return setup_oauth_cli_cmd("codex", json_output);
+   }
+   fprintf(stderr, "usage: aimee codex reauth\n");
+   return 1;
+}

--- a/src/cli_main.c
+++ b/src/cli_main.c
@@ -1846,6 +1846,10 @@ int main(int argc, char **argv)
    if (strcmp(cmd, "agent") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "setup") == 0)
       return handle_agent_setup_cmd(sub_argc - 1, sub_argv + 1, json_output);
 
+   /* `aimee codex reauth` — re-authenticate codex after a rejected refresh (D6). */
+   if (strcmp(cmd, "codex") == 0)
+      return handle_codex_cmd(sub_argc, sub_argv, json_output);
+
    /* workspace serve: a long-running client-side loop (poll -> run -> respond),
     * not a single forwarded /v1 call, so it is driven here rather than via a route. */
    if (strcmp(cmd, "workspace") == 0 && sub_argc >= 1 && strcmp(sub_argv[0], "serve") == 0)

--- a/src/headers/agent_config.h
+++ b/src/headers/agent_config.h
@@ -42,6 +42,10 @@ int agent_has_role(const agent_t *agent, const char *role);
 int agent_is_exec_role(const agent_t *agent, const char *role);
 void agent_expand_env(const char *src, char *dst, size_t dst_len);
 int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len);
+/* An explicit, actionable reason the LAST agent_resolve_auth call failed (e.g.
+ * codex REAUTH_REQUIRED), or NULL. Lets the delegate/chat error path surface a
+ * remedy instead of a generic provider 401 (D6). Thread-local to the turn. */
+const char *agent_request_auth_error(void);
 int agent_has_resolvable_credentials(const agent_t *agent);
 void agent_build_extra_headers(const agent_t *agent, char *buf, size_t buf_len);
 

--- a/src/headers/cli_agent_setup.h
+++ b/src/headers/cli_agent_setup.h
@@ -7,4 +7,8 @@
  * Returns a process exit code (0 = success). */
 int handle_agent_setup_cmd(int argc, char **argv, int json_output);
 
+/* `aimee codex <subcmd>` — currently `reauth`, the operator re-authentication for
+ * a rejected codex OAuth refresh token (D6). Returns a process exit code. */
+int handle_codex_cmd(int argc, char **argv, int json_output);
+
 #endif /* DEC_CLI_AGENT_SETUP_H */

--- a/src/headers/oauth_flow.h
+++ b/src/headers/oauth_flow.h
@@ -51,10 +51,22 @@ int oauth_token_remove(const char *client_name);
 
 /* ---- Token refresh (refresh_token grant) ---- */
 
-/* Refresh expired tokens stored for |client_name| using the given |token_endpoint|.
- * Updates the stored tokens on success.
- * Returns 0 on success, -1 on failure (caller should re-authenticate). */
+/* oauth_token_refresh outcomes (D6): distinguish a transient failure (retryable,
+ * keep using any still-valid access token) from an IdP rejection of the refresh
+ * token (revoked/expired — the server cannot recover, the operator must re-auth). */
+#define OAUTH_REFRESH_TRANSIENT (-1) /* network/5xx/parse — retry later */
+#define OAUTH_REFRESH_REAUTH    (-2) /* 4xx invalid_grant — REAUTH_REQUIRED set */
+
+/* Refresh stored tokens for |client_name| via |token_endpoint|/|client_id|.
+ * Updates the stored tokens on success. Returns 0 on success, or one of the
+ * OAUTH_REFRESH_* codes above. On OAUTH_REFRESH_REAUTH the credential is marked
+ * REAUTH_REQUIRED (see oauth_token_reauth_required). */
 int oauth_token_refresh(const char *client_name, const char *client_id, const char *token_endpoint);
+
+/* True if |client_name|'s credential is marked REAUTH_REQUIRED — a prior refresh
+ * was rejected and the operator must re-authenticate (D6). Cleared automatically
+ * on the next successful token store. */
+int oauth_token_reauth_required(const char *client_name);
 
 /* ---- High-level accessor ---- */
 

--- a/src/server/agent_config.c
+++ b/src/server/agent_config.c
@@ -260,6 +260,17 @@ int agent_has_resolvable_credentials(const agent_t *agent)
 static _Thread_local char g_request_codex_token[MAX_API_KEY_LEN];
 static _Thread_local char g_request_codex_account_id[128];
 
+/* Explicit, actionable reason the current turn's auth resolution failed — set by
+ * agent_resolve_auth on a known failure (e.g. codex REAUTH_REQUIRED) so the
+ * delegate/chat error path can surface it instead of a generic provider 401 (D6).
+ * Thread-local + cleared at the start of each resolve. */
+static _Thread_local char g_request_auth_error[256];
+
+const char *agent_request_auth_error(void)
+{
+   return g_request_auth_error[0] ? g_request_auth_error : NULL;
+}
+
 void agent_set_request_session(const char *session_id)
 {
    if (session_id && session_id[0])
@@ -1773,6 +1784,7 @@ static int agent_read_codex_oauth_token(char *token, size_t token_len)
 int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
 {
    buf[0] = '\0';
+   g_request_auth_error[0] = '\0'; /* reset the per-turn explicit-error channel (D6) */
    const char *auth_type = agent->auth_type;
    if (strcmp(agent->provider, "anthropic") == 0 &&
        (!auth_type[0] || strcmp(auth_type, "bearer") == 0 || strcmp(auth_type, "api_key") == 0))
@@ -1806,7 +1818,16 @@ int agent_resolve_auth(const agent_t *agent, char *buf, size_t buf_len)
          return 0;
       }
       if (agent_read_codex_oauth_token(token, sizeof(token)) != 0)
+      {
+         /* No usable codex token. If a prior refresh was rejected by the IdP, the
+          * refresh token is dead and the server cannot recover on its own — give
+          * the operator the exact remedy instead of a generic provider 401 (D6). */
+         if (oauth_token_reauth_required(CODEX_OAUTH_STORE))
+            snprintf(g_request_auth_error, sizeof(g_request_auth_error),
+                     "codex re-auth required: the stored OAuth refresh token was rejected — run "
+                     "`aimee codex reauth` to re-authenticate");
          return -1;
+      }
       snprintf(buf, buf_len, "Authorization: Bearer %s", token);
       return 0;
    }

--- a/src/server/agent_runtime.c
+++ b/src/server/agent_runtime.c
@@ -998,7 +998,10 @@ int agent_execute(const agent_t *agent, const char *system_prompt, const char *u
    char auth_header[MAX_API_KEY_LEN + 32];
    if (agent_resolve_auth(agent, auth_header, sizeof(auth_header)) != 0)
    {
-      snprintf(out->error, sizeof(out->error), "auth resolution failed");
+      /* Prefer an explicit, actionable reason (e.g. codex REAUTH_REQUIRED) over the
+       * generic message so the operator knows the remedy (D6). */
+      const char *why = agent_request_auth_error();
+      snprintf(out->error, sizeof(out->error), "%s", why ? why : "auth resolution failed");
       return -1;
    }
    char extra_headers[512];

--- a/src/server/oauth_tokens.c
+++ b/src/server/oauth_tokens.c
@@ -314,18 +314,29 @@ int oauth_token_refresh(const char *client_name, const char *client_id, const ch
       return OAUTH_REFRESH_TRANSIENT; /* network/transport — retry later, NOT a re-auth */
    }
 
-   /* A 4xx from the token endpoint means the IdP rejected the refresh — the
-    * refresh token is revoked/expired and the server cannot recover on its own.
-    * Mark REAUTH_REQUIRED so the use-path can surface an explicit, actionable
-    * error and the operator can run `aimee codex reauth` (D6). A 5xx is transient. */
+   /* A 4xx whose body says `invalid_grant` means the IdP rejected the REFRESH
+    * TOKEN itself (revoked/expired) — the server cannot recover, so mark
+    * REAUTH_REQUIRED and surface an actionable error (D6). Latch ONLY on that
+    * precise OAuth error: a bare 4xx (proxy 403, 429 rate-limit, transient 400)
+    * must NOT pin the marker and force a needless re-auth — those are transient. */
    if (http_status >= 400 && http_status < 500)
    {
-      aimee_log(LOG_ERROR, "oauth_flow",
-                "refresh REJECTED for %s (HTTP %d) — re-auth required: run `aimee codex reauth`",
-                client_name, http_status);
-      (void)oauth_secret_store(client_name, OAUTH_VCRED_REAUTH, "1");
+      int is_invalid_grant = (strstr(resp, "invalid_grant") != NULL);
+      if (is_invalid_grant)
+      {
+         aimee_log(LOG_ERROR, "oauth_flow",
+                   "refresh REJECTED for %s (HTTP %d invalid_grant) — re-auth required: run "
+                   "`aimee codex reauth`",
+                   client_name, http_status);
+         (void)oauth_secret_store(client_name, OAUTH_VCRED_REAUTH, "1");
+         free(resp);
+         return OAUTH_REFRESH_REAUTH;
+      }
+      aimee_log(LOG_WARN, "oauth_flow",
+                "token refresh got HTTP %d (no invalid_grant) for %s — treating as transient",
+                http_status, client_name);
       free(resp);
-      return OAUTH_REFRESH_REAUTH;
+      return OAUTH_REFRESH_TRANSIENT;
    }
 
    oauth_token_response_t result;

--- a/src/server/oauth_tokens.c
+++ b/src/server/oauth_tokens.c
@@ -31,6 +31,11 @@
 #define OAUTH_VCRED_ACCESS  "oauth_access_token"
 #define OAUTH_VCRED_REFRESH "oauth_refresh_token"
 #define OAUTH_VCRED_EXPIRES "oauth_expires_at"
+/* Set when a refresh is rejected by the IdP (refresh token revoked/expired): the
+ * server cannot recover autonomously, so the operator must re-auth (D6). Cleared
+ * on the next successful token store (a fresh device-flow re-auth). */
+#define OAUTH_VCRED_REAUTH  "oauth_reauth_required"
+#define OAUTH_DB1FMT_REAUTH "oauth.%s.reauth_required"
 
 static int oauth_secret_store(const char *client_name, const char *vcred, const char *value)
 {
@@ -145,7 +150,25 @@ int oauth_token_store(const char *client_name, const oauth_token_response_t *res
          rc = -1;
    }
 
+   /* A usable token is now stored (fresh exchange or an operator re-auth) — clear
+    * any standing "re-auth required" marker (D6). */
+   if (rc == 0)
+      oauth_secret_remove(client_name, OAUTH_VCRED_REAUTH, OAUTH_DB1FMT_REAUTH);
+
    return rc;
+}
+
+/* True if `client_name`'s OAuth credential is marked REAUTH_REQUIRED — a prior
+ * refresh was rejected by the IdP and the operator must re-authenticate (D6). */
+int oauth_token_reauth_required(const char *client_name)
+{
+   if (!client_name)
+      return 0;
+   char v[8] = "";
+   if (oauth_secret_load(client_name, OAUTH_VCRED_REAUTH, OAUTH_DB1FMT_REAUTH, v, sizeof(v)) == 0 &&
+       v[0] == '1')
+      return 1;
+   return 0;
 }
 
 int oauth_token_load(const char *client_name, char *buf, size_t len)
@@ -191,24 +214,49 @@ int oauth_token_remove(const char *client_name)
  * On success, |*resp_out| is a malloc'd JSON string (caller frees).
  */
 static int curl_post_token(const char *token_endpoint, const char *post_data, char **resp_out,
-                           size_t *resp_len_out)
+                           size_t *resp_len_out, int *http_status_out)
 {
    if (!token_endpoint || !post_data || !resp_out)
       return -1;
+   if (http_status_out)
+      *http_status_out = 0;
 
-   /* Build command: curl -s -X POST -H 'Content-Type: application/x-www-form-urlencoded'
-    *   --data-urlencode not needed here because we pre-encode.
-    *   We use -d with the raw body (caller must percent-encode values). */
+   /* NOTE: NOT `-f`. We deliberately capture the response BODY on HTTP errors so
+    * the caller can tell a rejected refresh (4xx `invalid_grant` → re-auth, D6)
+    * from a transient transport/5xx error. `-w '\n%{http_code}'` appends the
+    * status after the body; we split it off below. We pre-encode the body. */
    char cmd[4096];
    snprintf(cmd, sizeof(cmd),
-            "curl -sf -X POST"
+            "curl -s -X POST"
             " -H 'Content-Type: application/x-www-form-urlencoded'"
             " -H 'Accept: application/json'"
             " --data-binary @-"
+            " -w '\\n%%{http_code}'"
             " '%s'",
             token_endpoint);
 
-   return platform_exec_pipe(cmd, post_data, strlen(post_data), resp_out, resp_len_out);
+   char *raw = NULL;
+   size_t raw_len = 0;
+   int rc = platform_exec_pipe(cmd, post_data, strlen(post_data), &raw, &raw_len);
+   if (rc != 0 || !raw)
+   {
+      free(raw);
+      return -1; /* transport failure: no body, no status */
+   }
+
+   /* Split the trailing "\n<http_code>" appended by -w off the body. */
+   char *nl = strrchr(raw, '\n');
+   if (nl)
+   {
+      if (http_status_out)
+         *http_status_out = atoi(nl + 1);
+      *nl = '\0';
+      raw_len = (size_t)(nl - raw);
+   }
+   *resp_out = raw;
+   if (resp_len_out)
+      *resp_len_out = raw_len;
+   return 0;
 }
 
 /* Minimal percent-encoding for OAuth POST body values.
@@ -258,11 +306,26 @@ int oauth_token_refresh(const char *client_name, const char *client_id, const ch
 
    char *resp = NULL;
    size_t resp_len = 0;
-   if (curl_post_token(token_endpoint, body, &resp, &resp_len) != 0 || !resp)
+   int http_status = 0;
+   if (curl_post_token(token_endpoint, body, &resp, &resp_len, &http_status) != 0 || !resp)
    {
       free(resp);
-      aimee_log(LOG_WARN, "oauth_flow", "token refresh failed for %s", client_name);
-      return -1;
+      aimee_log(LOG_WARN, "oauth_flow", "token refresh failed for %s (transport)", client_name);
+      return OAUTH_REFRESH_TRANSIENT; /* network/transport — retry later, NOT a re-auth */
+   }
+
+   /* A 4xx from the token endpoint means the IdP rejected the refresh — the
+    * refresh token is revoked/expired and the server cannot recover on its own.
+    * Mark REAUTH_REQUIRED so the use-path can surface an explicit, actionable
+    * error and the operator can run `aimee codex reauth` (D6). A 5xx is transient. */
+   if (http_status >= 400 && http_status < 500)
+   {
+      aimee_log(LOG_ERROR, "oauth_flow",
+                "refresh REJECTED for %s (HTTP %d) — re-auth required: run `aimee codex reauth`",
+                client_name, http_status);
+      (void)oauth_secret_store(client_name, OAUTH_VCRED_REAUTH, "1");
+      free(resp);
+      return OAUTH_REFRESH_REAUTH;
    }
 
    oauth_token_response_t result;
@@ -270,11 +333,12 @@ int oauth_token_refresh(const char *client_name, const char *client_id, const ch
    free(resp);
    if (rc != 0)
    {
-      aimee_log(LOG_WARN, "oauth_flow", "token refresh returned invalid JSON for %s", client_name);
-      return -1;
+      aimee_log(LOG_WARN, "oauth_flow", "token refresh returned invalid JSON for %s (HTTP %d)",
+                client_name, http_status);
+      return OAUTH_REFRESH_TRANSIENT;
    }
 
-   return oauth_token_store(client_name, &result);
+   return oauth_token_store(client_name, &result) == 0 ? 0 : OAUTH_REFRESH_TRANSIENT;
 }
 
 int oauth_token_get(const char *client_name, const char *client_id, const char *token_endpoint,

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -309,6 +309,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-clarify \
                $(TESTPREFIX)/unit-test-collab-rules \
                $(TESTPREFIX)/unit-test-oauth-pkce \
+               $(TESTPREFIX)/unit-test-oauth-reauth \
                $(TESTPREFIX)/unit-test-mcp-client \
                $(TESTPREFIX)/unit-test-mcp-client-sse \
                $(TESTPREFIX)/unit-test-mcp-client-integration \
@@ -2925,6 +2926,19 @@ $(TESTPREFIX)/unit-test-otel: $(OBJDIR)/tests/test_otel.o \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-oauth-pkce: $(OBJDIR)/tests/test_oauth_pkce.o \
+                     $(OBJDIR)/server/oauth_pkce.o \
+                     $(OBJDIR)/server/oauth_tokens.o \
+                     $(OBJDIR)/db1/secrets.o \
+                     $(OBJDIR)/server/vault_service.o \
+                     $(OBJDIR)/server/vault_store.o \
+                     $(OBJDIR)/server/vault_crypto.o \
+                     $(OBJDIR)/server/vault_kek_cache.o \
+                     $(OBJDIR)/server/vault_server_key.o \
+                     $(OBJDIR)/platform_random.o \
+                     $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-oauth-reauth: $(OBJDIR)/tests/test_oauth_reauth.o \
                      $(OBJDIR)/server/oauth_pkce.o \
                      $(OBJDIR)/server/oauth_tokens.o \
                      $(OBJDIR)/db1/secrets.o \

--- a/src/tests/support/oauth_tokens_stub.c
+++ b/src/tests/support/oauth_tokens_stub.c
@@ -24,3 +24,9 @@ int oauth_token_store(const char *client_name, const oauth_token_response_t *res
    (void)resp;
    return 0;
 }
+
+int oauth_token_reauth_required(const char *client_name)
+{
+   (void)client_name;
+   return 0; /* tests don't exercise the REAUTH_REQUIRED marker */
+}

--- a/src/tests/test_oauth_reauth.c
+++ b/src/tests/test_oauth_reauth.c
@@ -1,0 +1,56 @@
+/* test_oauth_reauth.c — D6 REAUTH_REQUIRED credential state.
+ *
+ * Proves the marker the codex refresh path sets on an IdP rejection round-trips
+ * through the vault and is cleared by the next successful token store (a fresh
+ * operator re-auth), so a recovered codex credential no longer reports as
+ * needing re-auth. */
+#include "oauth_flow.h"
+#include "vault_service.h"
+#include "vault_server_key.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Mirrors OAUTH_VCRED_REAUTH in oauth_tokens.c (the marker cred slot). */
+#define REAUTH_VCRED "oauth_reauth_required"
+
+int main(void)
+{
+   char home[256];
+   snprintf(home, sizeof(home), "/tmp/aimee-oauthreauth-test-%d", (int)getpid());
+   char cmd[640];
+   snprintf(cmd, sizeof(cmd), "rm -rf %s && mkdir -p %s", home, home);
+   assert(system(cmd) == 0);
+   setenv("AIMEE_HOME", home, 1);
+   vault_server_key_reset_for_test();
+
+   /* Fresh credential: not flagged. */
+   assert(oauth_token_reauth_required("codex") == 0);
+
+   /* Simulate the refresh-rejection path setting the marker. */
+   assert(vault_service_set_server("codex", REAUTH_VCRED, "1") == VAULT_OK);
+   assert(oauth_token_reauth_required("codex") == 1 && "marker should read back set");
+
+   /* A successful token store (operator re-auth) clears the marker. */
+   oauth_token_response_t resp;
+   memset(&resp, 0, sizeof(resp));
+   snprintf(resp.access_token, sizeof(resp.access_token), "tok-after-reauth");
+   snprintf(resp.refresh_token, sizeof(resp.refresh_token), "rt-after-reauth");
+   resp.expires_at = time(NULL) + 3600;
+   assert(oauth_token_store("codex", &resp) == 0);
+   assert(oauth_token_reauth_required("codex") == 0 &&
+          "a successful token store must clear REAUTH_REQUIRED");
+
+   /* And the fresh token is now usable (no refresh needed). */
+   char buf[256] = "";
+   assert(oauth_token_get("codex", NULL, NULL, 0, buf, sizeof(buf)) == 0);
+   assert(strcmp(buf, "tok-after-reauth") == 0 && "stored access token should load");
+
+   snprintf(cmd, sizeof(cmd), "rm -rf %s", home);
+   (void)system(cmd);
+   printf("PASS: codex REAUTH_REQUIRED marker round-trip + clear-on-reauth (D6)\n");
+   return 0;
+}


### PR DESCRIPTION
## What

Ship the **D6** codex re-auth contract from `cred-vault-consolidation`: when codex's stored OAuth refresh token is revoked/expired, raise an explicit `REAUTH_REQUIRED` credential state, surface an actionable delegate error, and give the operator a first-class `aimee codex reauth` command — instead of the generic provider 401 operators previously had to pattern-match.

## Change

- **HTTP status from the token POST** — `curl_post_token` drops `-f` and appends `-w '\n%{http_code}'`, splitting the status off the body, so the refresh path can tell a **4xx IdP rejection** (refresh token dead → re-auth) from a **transient transport/5xx** error.
- **`oauth_token_refresh`** returns `OAUTH_REFRESH_REAUTH` on a 4xx (sets a persistent `REAUTH_REQUIRED` vault marker + logs the remedy) vs `OAUTH_REFRESH_TRANSIENT` otherwise. `oauth_token_store` **clears** the marker on the next successful store (a fresh re-auth). New `oauth_token_reauth_required()` getter.
- **Explicit delegate error** — `agent_resolve_auth` sets a thread-local error channel (`agent_request_auth_error`) when codex has no usable token **and** `REAUTH_REQUIRED` is set; the delegate run reports that exact remedy ("run `aimee codex reauth`") instead of "auth resolution failed".
- **`aimee codex reauth`** (`handle_codex_cmd`) re-runs the codex-oauth device flow on the configured remote; a successful exchange re-vaults the token and clears the marker. **Operator-attended, no autonomous browser flow** — exactly as the proposal requires.

## Tests

`unit-test-oauth-reauth`: the marker round-trips through the vault and is cleared by a successful token store. `oauth-pkce` + `codex-auth` still pass; `oauth_tokens_stub` gains `oauth_token_reauth_required` for the ~36 `agent_config.o` keyless test binaries. Server + client build green (`make -j1`), lint clean (`clang-format-19`).

Part of filing `cred-vault-consolidation` to done (closeout item D6, full scope).
