### PR TITLE
feat(kb): cross-repo precision H5 — prefer-local + generated-header reject

### DIFF
--- a/docs/validation/cross-repo-precision-h4-runbook.md
+++ b/docs/validation/cross-repo-precision-h4-runbook.md
@@ -1,0 +1,122 @@
+# H4 — cross-repo precision live re-validation runbook (.254)
+
+The full precision-hardening build is merged to `testing` (PRs #824, #825, #827,
+#828, #830, #831, #832, #835 — H0a–H0d, H1, H2, H3a, H3b). H4 deploys it to the
+split stack on `.254` (192.168.1.254), repopulates the index-time metadata, and
+spot-checks that the known live false-positive classes collapse while the true
+dependencies survive.
+
+Decision (this session): ground truth = **spot-check the known FP classes only**
+(no formal Wilson-CI N≥100 labeling).
+
+## 0. Access
+- `.254` is a CT on pve; this `code` host (192.168.1.99) has no SSH key for it.
+  Run the deploy steps from pve (`pct exec <ctid> -- ...`) or with `.254` shell.
+- sudo on `.254`: `echo 998Fgh | sudo -S <cmd>`.
+- tierd admin: `plugadm.py` at `http://127.0.0.1:8420` (admin / 998Fgh), from `.254`.
+- Use tierd lifecycle verbs (not `docker restart`) to bounce plugins.
+
+## 1. Deploy latest `:testing`
+`.254` plugins are pinned to the moving `:testing` tag, so they auto-track merges,
+but the running containers must pull + update:
+1. Pull the new images on `.254`: `sudo docker pull <registry>/aimee-kb:testing`
+   and `aimee-server:testing` (the GPU `aimee-llm` image is unchanged — no re-pull).
+2. Update + bounce via tierd (plugadm) so the kb + server plugins run the new image.
+3. Verify versions: the kb/server should report a build at or after `9c6bd56`.
+
+## 2. Repopulate metadata (the re-scan)
+The H0 per-file metadata — `terms.def_kind` (H0a), `files.language` + `files.vendored`
+(H0b) — is written at SCAN time (`canonical_index_scan_project`), so a re-scan of
+the corpus is required:
+1. Re-scan all indexed repos (the `~/dev` + `~/gow` workspaces, ~40 repos) so the
+   files/terms rows carry def_kind/language/vendored.
+2. The repo-identity index (H0c), the inter-repo route index (H0d), and the
+   blocked-symbols distinctiveness model rebuild AUTOMATICALLY: H1 wired a
+   one-shot cold-start rebuild into the curator drain (`kb_curator_drain.c`), so a
+   kb restart (step 1.2) repopulates `cross_repo_identity` + `cross_repo_route` +
+   `blocked_symbols` once the store is ready; the `built>0` incremental keeps them
+   fresh as the re-scan lands changed projects. No manual rebuild call needed.
+3. Wait for the drain to settle (watch the kb log for
+   `kb.cross_repo.meta: rebuilt cross-repo metadata: identities=N routes=M ...`).
+
+## 3. Spot-check (from any host with the enrolled remote, e.g. this one)
+The CLI targets `.254` via `~/.config/aimee/remote.conf`. Run:
+- `aimee index deps moonlight-qt`  → expect **moonlight-common-c** (HIGH, via
+  LiStartConnection / Limelight.h route). The previously-seen FP
+  `moonlight-qt → Sunshine` (DEFINE_GUID) must be GONE (no real route; macro
+  capped below HIGH; §2/extractor drops `<...>`).
+- `aimee index deps wolf`          → expect inputtino / gst-wayland-display /
+  moonlight-common-c; no spurious cross-lang edges.
+- `aimee index deps smoothnas-plugin-aimee` → expect aimee / smoothnas.
+- Reverse: dependents of `moonlight-common-c` include `moonlight-qt`.
+- Confirm the specific live FPs from §0 collapsed: `DEFINE_GUID`→Sunshine,
+  `authenticate` (generic), cross-language `motion` (C++ vs Rust) — none has a real
+  `cross_repo_route`, so each is now LOW-unresolved (not emitted).
+
+## 4. Recall sanity
+On `.254`, grep the kb log for `low-unresolved (no route)` (the H1 instrumentation)
+to see which would-be edges were dropped for lack of a route — distinguishes the
+build/link-only recall loss (CMake `target_link_libraries` with no source include,
+which H0d does not model) from genuine no-dependency. If a known true dep is
+missing AND appears in that log, it is the link-only class (a follow-on, not a
+regression).
+
+## 5. Outcome
+- If the known FP classes collapsed and the true deps survive → flip
+  `docs/proposals/pending/cross-repo-precision-hardening.md` state to COMPLETE and
+  move it to `docs/proposals/accepted/` (or per repo convention).
+- Record the before/after for the spot-checked repos here.
+- Clean up any temporary CTs/scratch created on pve.
+
+---
+
+## H4 RESULTS (2026-06-28, .254 vtesting-9c6bd56, full corpus re-scanned)
+
+Deployed the complete build (H1–H3b) to `.254`, re-scanned 36/37 repos from the
+client (corpus lives on host `code`/192.168.1.99, not in the kb container),
+restarted the kb → cold-start rebuild produced **identities=20, routes=82,
+blocked_symbols=244**. Spot-check of the known FP classes:
+
+| query | result | verdict |
+|---|---|---|
+| `moonlight-qt → Sunshine` | **MEDIUM** via DEFINE_GUID (+ cuda.h/input.h/nvhttp.h/vaapi.h routes) | FP — reduced (was HIGH; §5 macro cap worked) but NOT eliminated |
+| `wolf → Sunshine` | **HIGH** via buffer_descriptor_t (route: config.h) | FP — persists at HIGH |
+| `wolf → inputtino` | HIGH, 13 symbols / 32 sites | TRUE POSITIVE ✓ |
+| `moonlight-qt → moonlight-common-c` | **absent** | TRUE POSITIVE MISSING — recall loss |
+
+### Two diagnosed root causes (both NEW work, beyond H1–H3b)
+
+1. **Residual FPs = incidental header-basename routes.** The Sunshine routes are
+   shared basenames: moonlight-qt's cuda.h/input.h/nvhttp.h/vaapi.h are the
+   caller's OWN headers (verified caller_has_local=t for all 4), and the self-route
+   is excluded so the route fans to Sunshine instead. wolf→Sunshine is via
+   `config.h` (a BUILD-GENERATED header in only 2 non-vendored repos, so the ≥4
+   header-IDF doesn't catch it; wolf's own config.h is generated, not indexed).
+   - Fix A (prefer-local header resolution): no cross-repo import_header route when
+     the CALLER repo has its own file matching the include basename → kills 5/6
+     Sunshine routes (all of moonlight-qt's + wolf's rswrapper.h).
+   - Fix B (generated/build-header reject): a small seed set (config.h, version.h,
+     …) never forms a cross-repo route → kills wolf→Sunshine.
+
+2. **Recall loss = the angle-bracket blanket-drop.** moonlight-qt depends on
+   moonlight-common-c via `#include <Limelight.h>` (angle brackets — an installed
+   lib), and the C extractor (`c_import_line`) records ONLY quoted `#include "..."`,
+   skipping `<...>`. So `<Limelight.h>` never becomes a file_import → 0 routes
+   moonlight-qt→moonlight-common-c → the real edge is dropped. (verified: 0
+   Limelight file_imports; moonlight-qt has no local Limelight.h; moonlight-common-c
+   defines LiStartConnection; moonlight-qt calls it once.)
+   - This revises H3b's "angle-bracket already enforced" conclusion: the blanket
+     `<>`-skip is too aggressive. §2's intent was to distinguish SDK `<>` from
+     external-lib `<>` via IDF / the repo-identity layer, not drop all `<>`.
+   - Fix C (recall, the larger one): capture `<>` includes too (an `is_system`
+     flag), and form a route when a `<Foo.h>` resolves to a repo that PROVIDES
+     Foo.h (repo-identity / non-ubiquitous), keeping the SDK reject via the
+     system-header list + IDF. Needs extractor + file_imports column + re-scan +
+     route logic — the H0e/§2 work previously deferred.
+
+### Status
+Build (H1–H3b) measurably improved precision (DEFINE_GUID HIGH→MEDIUM;
+vendored→canonical; wolf→inputtino clean HIGH) but live validation shows it is NOT
+yet sufficient: Sunshine FPs persist and a key true dep is lost to the `<>`-drop.
+Next: Fix A+B (precision, ~1 slice) and Fix C (recall, larger). Each → roundtable →
+PR → redeploy → re-scan → re-spot-check.

--- a/src/db2/cross_repo_route.c
+++ b/src/db2/cross_repo_route.c
@@ -67,31 +67,63 @@ static const char *const SQL_MODULE_ROUTES =
  * `< 4` in SQL_HEADER_ROUTES below (a candidate for config-ization + tuning after
  * H4's live re-validation). */
 
+/* H5 generated/build-header reject (H4 live finding): a small seed set of headers
+ * that are per-project BUILD-GENERATED (CMake configure_file etc.), never a
+ * cross-repo API header. They collide by basename across repos (each generates its
+ * own) but the generated copy is often not even indexed, so neither prefer-local
+ * nor the §2 IDF catches them — wolf→Sunshine survived H1–H3b via `config.h`.
+ *
+ * NOTGEN(n) rejects ONLY the BARE include `#include "config.h"` (an exact equality,
+ * no LIKE) — deliberately NOT the path-qualified `foo/config.h`, which is a
+ * namespaced header far more likely to be a real API (a project that genuinely
+ * exports a config header almost always namespaces it). Exact-equality also sidesteps
+ * LIKE-metachar escaping. Tradeoff (accepted, precision-over-recall): a project that
+ * exports a literally-bare `config.h`/`version.h` as cross-repo API is suppressed;
+ * that convention is vanishingly rare, and the principled fix is marker-based
+ * generated-output attribution (§1.6, a later slice) rather than a basename list. */
+#define NOTGEN(n) "imp.name <> '" n "'"
+
 /* import_header (MEDIUM): a caller C/C++ #include matched to a definer file whose
  * path equals the include or ends with '/'+include (component boundary). The
  * caller file's language (H0b) restricts this to C/C++ so module specifiers from
  * other languages don't masquerade as headers; the definer file must not be
- * vendored (H0b); and the include must clear the §2 header-IDF threshold above
- * (ubiquity counted on the same path-suffix key, vendored files excluded from the
- * count so a vendored copy never inflates ubiquity). The repo-unique HIGH-vs-MEDIUM
- * is applied by H1's resolver (this is the raw candidate adjacency). */
+ * vendored (H0b); the include must clear the §2 header-IDF threshold; it must not
+ * be a generated/build header (NOTGEN); and — H5 prefer-local (H4 finding) — the
+ * CALLER repo must NOT have its OWN file matching the include (a `#include "x.h"`
+ * where the caller has its own x.h resolves LOCALLY, not cross-repo: this killed
+ * the moonlight-qt→Sunshine FPs via the caller's own cuda.h/input.h/vaapi.h). The
+ * repo-unique HIGH-vs-MEDIUM is applied by H1's resolver (raw candidate adjacency). */
+/* clang-format off — hand-formatted SQL (the ESC()/NOTGEN() macros embedded in the
+ * string concatenation defeat clang-format's literal reflow, mangling it to one
+ * token per line). */
+/* clang-format off */
 static const char *const SQL_HEADER_ROUTES =
     "INSERT INTO cross_repo_route (caller_project, definer_project, kind, confidence, evidence) "
     "SELECT DISTINCT pc.name, pd.name, 'import_header', 'medium', imp.name "
     "FROM file_imports imp "
     "JOIN files cf ON cf.id = imp.file_id "
     "JOIN projects pc ON pc.id = cf.project_id "
-    "JOIN files fd ON (fd.path = imp.name "
-    "  OR fd.path LIKE '%/' || " ESC(
-        "imp.name") " ESCAPE '\\') "
-                    "JOIN projects pd ON pd.id = fd.project_id "
-                    "WHERE cf.language IN ('c', 'cpp') AND fd.vendored = 0 AND pd.name <> pc.name "
-                    "  AND (SELECT COUNT(DISTINCT fx.project_id) FROM files fx "
-                    "       WHERE (fx.path = imp.name OR fx.path LIKE '%/' || " ESC(
-                        "imp.name") " ESCAPE '\\') "
-                                    "         AND fx.vendored = 0) < 4 "
-                                    "ON CONFLICT (caller_project, definer_project, kind, evidence) "
-                                    "DO NOTHING";
+    "JOIN files fd ON (fd.path = imp.name OR fd.path LIKE '%/' || " ESC("imp.name") " ESCAPE '\\') "
+    "JOIN projects pd ON pd.id = fd.project_id "
+    "WHERE cf.language IN ('c', 'cpp') AND fd.vendored = 0 AND pd.name <> pc.name "
+    /* §2 header IDF: drop ubiquitous (>=4 non-vendored repos) include specifiers. */
+    "  AND (SELECT COUNT(DISTINCT fx.project_id) FROM files fx "
+    "       WHERE (fx.path = imp.name OR fx.path LIKE '%/' || " ESC("imp.name") " ESCAPE '\\') "
+    "         AND fx.vendored = 0) < 4 "
+    /* H5 generated/build-header reject. */
+    "  AND " NOTGEN("config.h") " AND " NOTGEN("config.hpp") " "
+    "  AND " NOTGEN("version.h") " AND " NOTGEN("version.hpp") " "
+    /* H5 prefer-local: skip when the caller repo has its OWN non-vendored file for
+     * the include — a quoted #include resolves to the including file's directory
+     * first (C quote-include locality), so a caller-owned copy means local, not
+     * cross-repo, resolution. fl.vendored = 0 is deliberate: a VENDORED caller copy
+     * is NOT treated as local, so a caller that vendors a lib still gets a route to
+     * the canonical definer (H2 canonical-preference then prefers it). */
+    "  AND NOT EXISTS (SELECT 1 FROM files fl "
+    "       WHERE fl.project_id = cf.project_id AND fl.vendored = 0 "
+    "         AND (fl.path = imp.name OR fl.path LIKE '%/' || " ESC("imp.name") " ESCAPE '\\')) "
+    "ON CONFLICT (caller_project, definer_project, kind, evidence) DO NOTHING";
+/* clang-format on */
 
 static int crr_count(void *conn)
 {

--- a/src/tests/test_cross_repo_route.c
+++ b/src/tests/test_cross_repo_route.c
@@ -233,11 +233,67 @@ static void test_header_idf(void)
    printf("ok\n");
 }
 
+/* H5 (H4 live findings): prefer-local header resolution + generated-header reject.
+ * (A) when the CALLER repo has its own file matching the include, no cross-repo
+ * route is formed (the include resolves locally). (B) generated/build headers
+ * (config.h, version.h, ...) never form a cross-repo route even with no local copy. */
+static void test_prefer_local_and_generated(void)
+{
+   printf("test_prefer_local_and_generated... ");
+   /* (A) plapp includes "shared.h" AND has its OWN shared.h; pllib also has shared.h.
+    * Prefer-local => NO route plapp->pllib. plapp2 has NO local shared.h => routes. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('plapp','/pa','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('plapp2','/pb','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('pllib','/pl','t','trusted')");
+   mk_file("pllib", "include/shared.h", "c", 0);
+   mk_file("plapp", "src/a.c", "c", 0);
+   mk_file("plapp", "include/shared.h", "c", 0); /* caller's OWN copy */
+   mk_import("plapp", "src/a.c", "shared.h");
+   mk_file("plapp2", "src/b.c", "c", 0); /* no local shared.h */
+   mk_import("plapp2", "src/b.c", "shared.h");
+
+   /* (B) genapp includes "config.h"; genlib has config.h; genapp has NO local copy.
+    * Generated-header reject => NO route despite the basename being in < 4 repos. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('genapp','/ga','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('genlib','/gl','t','trusted')");
+   mk_file("genlib", "include/config.h", "c", 0);
+   mk_file("genapp", "src/c.c", "c", 0);
+   mk_import("genapp", "src/c.c", "config.h");
+
+   /* (B2) path-qualified "sub/config.h" is NOT a bare generated header => routes. */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('genapp2','/g2','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('genlib2','/l2','t','trusted')");
+   mk_file("genlib2", "inc/sub/config.h", "c", 0);
+   mk_file("genapp2", "src/d.c", "c", 0);
+   mk_import("genapp2", "src/d.c", "sub/config.h");
+
+   /* (A-vendored) vcapp includes "vlib.h" and has its OWN copy but VENDORED; vclib
+    * has it non-vendored. fl.vendored=0 => the vendored caller copy is NOT local =>
+    * route to vclib still forms (a caller that vendors a lib still routes to it). */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vcapp','/vca','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vclib','/vcl','t','trusted')");
+   mk_file("vclib", "include/vlib.h", "c", 0);
+   mk_file("vcapp", "src/e.c", "c", 0);
+   mk_file("vcapp", "third_party/vlib.h", "c", 1); /* caller's copy is VENDORED */
+   mk_import("vcapp", "src/e.c", "vlib.h");
+
+   int rc = db2_cross_repo_rebuild_routes();
+   assert(rc >= 0);
+   assert(route_count("plapp", "pllib", "import_header") == 0);   /* prefer-local: caller owns it */
+   assert(route_count("plapp2", "pllib", "import_header") == 1);  /* no local copy: routes */
+   assert(route_count("genapp", "genlib", "import_header") == 0); /* bare config.h rejected */
+   assert(route_count("genapp2", "genlib2", "import_header") ==
+          1);                                                   /* path-qualified: NOT rejected */
+   assert(route_count("vcapp", "vclib", "import_header") == 1); /* vendored caller copy != local */
+   printf("ok\n");
+}
+
 int main(void)
 {
    db2_test_shim_open();
    test_routes();
    test_header_idf();
+   test_prefer_local_and_generated();
    printf("cross_repo_route: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Precision fixes for two false-positive classes the **H4 live re-validation** found surviving H1–H3b: incidental shared-header-basename routes between sibling streaming projects (`moonlight-qt→Sunshine` MEDIUM via `DEFINE_GUID`, `wolf→Sunshine` HIGH via `buffer_descriptor_t`). Both in `cross_repo_route.c SQL_HEADER_ROUTES` (index-time route build).

- **Prefer-local (Fix A)**: no cross-repo `import_header` route when the caller repo has its OWN **non-vendored** file matching the include — a quoted `#include` resolves to the including file's directory first (C quote-include locality), so a caller-owned copy means local resolution. `fl.vendored = 0` is deliberate: a *vendored* caller copy is not local, so a caller that vendors a lib still routes to the canonical definer (H2 then prefers it). Kills moonlight-qt→Sunshine (its own `cuda.h`/`input.h`/`nvhttp.h`/`vaapi.h`) + wolf's `rswrapper.h`.
- **Generated-header reject (Fix B)**: `NOTGEN` rejects the **bare** include only (`imp.name <> 'config.h'`, exact equality) for `config.h`/`config.hpp`/`version.h`/`version.hpp` — per-project build-generated headers, never a cross-repo API. NOT the path-qualified `foo/config.h` (namespaced, likely real). Kills `wolf→Sunshine` via `config.h`. Accepted precision-over-recall tradeoff; marker-based generated-output detection (§1.6) is the principled later fix.
- SQL wrapped in `clang-format off/on` (the embedded macros otherwise mangle the literal).

## Verification

Tests: caller-owned header → no route; no local copy → routes; bare `config.h` → rejected; path-qualified `sub/config.h` → routes; vendored caller copy → still routes to canonical. Full unit-test suite (897) green, `make lint` green, `aimee-kb` links. Reviewed via the aimee roundtable (diff embedded); the round-2 "blockers" (NOTGEN syntax, missing `vendored=0`) were confirmed already-addressed in the diff — `NOTGEN` is a single comparison (no syntax issue) and `fl.vendored = 0` is present, both proven by passing tests.

## Next

H6 — the recall fix for the `<>`-include drop (`moonlight-qt→moonlight-common-c` via `<Limelight.h>`).