### PR TITLE
feat(kb): cross-repo precision H7 — shared system-header list (close <process.h> FP)

### DIFF
--- a/src/db2/cross_repo_resolver.c
+++ b/src/db2/cross_repo_resolver.c
@@ -4,6 +4,8 @@
 
 #include "cross_repo_resolver.h"
 
+#include "c_system_headers.h"
+
 #include <stdint.h>
 #include <string.h>
 
@@ -121,42 +123,6 @@ int xrepo_name_distinctive(const char *symbol, const xrepo_distinct_stats_t *sta
 
 /* ---- import resolution (§3.7) -------------------------------------------- */
 
-/* Builtin C/C++ system/framework headers: an include resolving to one of these
- * is rejected (never a cross-repo edge), even if a repo happens to index a file
- * of the same basename. The set is intentionally conservative; the configurable
- * per-workspace blocklist (S3) extends it, and a stale entry degrades to
- * AMBIGUOUS rather than failing open/closed. */
-static const char *const C_SYSTEM_HEADERS[] = {
-    "stdio.h",     "stdlib.h",      "string.h",      "stddef.h", "stdint.h",
-    "stdbool.h",   "stdarg.h",      "ctype.h",       "errno.h",  "math.h",
-    "time.h",      "assert.h",      "limits.h",      "unistd.h", "fcntl.h",
-    "signal.h",    "memory",        "vector",        "string",   "string_view",
-    "cstdio",      "cstdlib",       "cstring",       "cstdint",  "cstddef",
-    "cstdarg",     "cerrno",        "cctype",        "climits",  "map",
-    "set",         "unordered_map", "unordered_set", "list",     "deque",
-    "queue",       "stack",         "algorithm",     "numeric",  "ranges",
-    "utility",     "tuple",         "iostream",      "sstream",  "fstream",
-    "iomanip",     "mutex",         "thread",        "atomic",   "condition_variable",
-    "future",      "chrono",        "filesystem",    "cassert",  "cmath",
-    "stdexcept",   "array",         "functional",    "optional", "variant",
-    "type_traits", "memory.h",      "pthread.h",     "dlfcn.h",
-};
-
-static const char *basename_of(const char *path)
-{
-   const char *slash = strrchr(path, '/');
-   return slash ? slash + 1 : path;
-}
-
-static int is_c_system_header(const char *inc)
-{
-   const char *base = basename_of(inc);
-   for (size_t i = 0; i < sizeof(C_SYSTEM_HEADERS) / sizeof(C_SYSTEM_HEADERS[0]); i++)
-      if (strcmp(base, C_SYSTEM_HEADERS[i]) == 0)
-         return 1;
-   return 0;
-}
-
 /* True if `path` ends with `suffix` on a path-component boundary
  * (path == suffix, or path ends with "/"+suffix). */
 static int path_suffix_match(const char *path, const char *suffix)
@@ -211,7 +177,7 @@ static xrepo_resolve_result_t resolve_c(const char *inc, const char *caller_repo
                                         xrepo_import_modality_t modality,
                                         const xrepo_repo_desc_t *descs, size_t n)
 {
-   if (is_c_system_header(inc))
+   if (aimee_c_system_header_is(inc))
       return result_from_matches(NULL, 0, 1, modality);
 
    int matches[XREPO_MAX_COLLISIONS];

--- a/src/extractors_extra.c
+++ b/src/extractors_extra.c
@@ -1,6 +1,7 @@
 /* extractors_extra.c: language extractors for C#, Shell, CSS, Dart, C/C++, Lua */
 #include "aimee.h"
 #include "extractors_extra.h"
+#include "c_system_headers.h"
 #include <ctype.h>
 
 /* --- C# --- */
@@ -360,42 +361,6 @@ void dart_def_line(const char *line, int lineno, void *ctx)
 
 /* --- C/C++ --- */
 
-/* C/C++ standard-library + common system headers. A BARE ANGLE include `<name>`
- * exactly in this set is a toolchain header, never a cross-repo dependency, so H6
- * drops it at extraction: keeps file_imports lean (no ~10 stdlib rows per C file),
- * prevents the fixed import buffer from being exhausted by system headers (which
- * would drop the real <lib.h> dep H6 recovers), and removes the bare-stdlib
- * angle-collision FP class up front. Matched on the FULL include string (NOT the
- * basename), deliberately: stdlib headers are always included bare, so a
- * PATH-QUALIFIED `<thirdparty/string.h>` or `<sdk/vector>` is a real lib header
- * and must be KEPT — basename matching would wrongly drop it. Mirrors
- * db2/cross_repo_resolver.c's C_SYSTEM_HEADERS (the extractor can't link the db2
- * layer); both are the stable C/C++ stdlib. Quoted includes are never dropped. */
-static int c_is_system_header(const char *name)
-{
-   static const char *const sys[] = {
-       "stdio.h",     "stdlib.h",      "string.h",      "stddef.h", "stdint.h",
-       "stdbool.h",   "stdarg.h",      "ctype.h",       "errno.h",  "math.h",
-       "time.h",      "assert.h",      "limits.h",      "unistd.h", "fcntl.h",
-       "signal.h",    "memory",        "vector",        "string",   "string_view",
-       "cstdio",      "cstdlib",       "cstring",       "cstdint",  "cstddef",
-       "cstdarg",     "cerrno",        "cctype",        "climits",  "map",
-       "set",         "unordered_map", "unordered_set", "list",     "deque",
-       "queue",       "stack",         "algorithm",     "numeric",  "ranges",
-       "utility",     "tuple",         "iostream",      "sstream",  "fstream",
-       "iomanip",     "mutex",         "thread",        "atomic",   "condition_variable",
-       "future",      "chrono",        "filesystem",    "cassert",  "cmath",
-       "stdexcept",   "array",         "functional",    "optional", "variant",
-       "type_traits", "memory.h",      "pthread.h",     "dlfcn.h",
-   };
-   /* Match the FULL include string: a path-qualified angle include (containing '/')
-    * is a real lib header, never bare stdlib, so it can never match here and is kept. */
-   for (size_t i = 0; i < sizeof(sys) / sizeof(sys[0]); i++)
-      if (strcmp(name, sys[i]) == 0)
-         return 1;
-   return 0;
-}
-
 void c_import_line(const char *line, int lineno, void *ctx)
 {
    import_ctx_t *ic = (import_ctx_t *)ctx;
@@ -434,7 +399,7 @@ void c_import_line(const char *line, int lineno, void *ctx)
       buf[len] = '\0';
       is_sys = 1;
       /* Drop C/C++ stdlib/system angle includes up front (never cross-repo). */
-      if (c_is_system_header(buf))
+      if (aimee_c_system_header_is(buf))
          return;
    }
    else

--- a/src/headers/c_system_headers.h
+++ b/src/headers/c_system_headers.h
@@ -1,0 +1,215 @@
+#ifndef AIMEE_C_SYSTEM_HEADERS_H
+#define AIMEE_C_SYSTEM_HEADERS_H 1
+
+#include <stddef.h>
+
+/* Single source of truth for C/C++ standard-library + common system/SDK headers
+ * that are NEVER a cross-repo dependency (precision-hardening H6/H7). Shared,
+ * data-only header (no link dependency) so the two consumers cannot drift:
+ *   - the extractor (extractors_extra.c c_import_line) drops a BARE angle include
+ *     `<name>` matching this set at extraction (keeps file_imports lean, prevents
+ *     the import buffer being exhausted by system headers, removes the bare-system
+ *     angle-collision FP class — e.g. <process.h> vs a repo's own process.h);
+ *   - the resolver (cross_repo_resolver.c) rejects the same on the import-route
+ *     path. Both call aimee_c_system_header_is().
+ *
+ * Matching is on the FULL include string (so a PATH-QUALIFIED `<thirdparty/string.h>`
+ * is a real lib header and is KEPT — only bare stdlib names match) and
+ * CASE-INSENSITIVE (Windows is case-insensitive: `<Windows.h>` == `<windows.h>`).
+ * `static` so each of the (few) including TUs gets its own copy — no ODR/link issue. */
+static const char *const AIMEE_C_SYSTEM_HEADERS[] = {
+    /* C standard library */
+    "stdio.h",
+    "stdlib.h",
+    "string.h",
+    "stddef.h",
+    "stdint.h",
+    "stdbool.h",
+    "stdarg.h",
+    "ctype.h",
+    "errno.h",
+    "math.h",
+    "time.h",
+    "assert.h",
+    "limits.h",
+    "wchar.h",
+    "wctype.h",
+    "locale.h",
+    "setjmp.h",
+    "inttypes.h",
+    "complex.h",
+    "iso646.h",
+    "stdalign.h",
+    "stdnoreturn.h",
+    "uchar.h",
+    "stdatomic.h",
+    "threads.h",
+    "float.h",
+    "fenv.h",
+    "tgmath.h",
+    /* POSIX / unix */
+    "unistd.h",
+    "fcntl.h",
+    "signal.h",
+    "pthread.h",
+    "dlfcn.h",
+    "sched.h",
+    "semaphore.h",
+    "poll.h",
+    "termios.h",
+    "syslog.h",
+    "malloc.h",
+    "alloca.h",
+    "strings.h",
+    "memory.h",
+    /* C++ standard library */
+    "memory",
+    "vector",
+    "string",
+    "string_view",
+    "cstdio",
+    "cstdlib",
+    "cstring",
+    "cstdint",
+    "cstddef",
+    "cstdarg",
+    "cerrno",
+    "cctype",
+    "climits",
+    "map",
+    "set",
+    "unordered_map",
+    "unordered_set",
+    "list",
+    "deque",
+    "queue",
+    "stack",
+    "algorithm",
+    "numeric",
+    "ranges",
+    "utility",
+    "tuple",
+    "iostream",
+    "sstream",
+    "fstream",
+    "iomanip",
+    "mutex",
+    "thread",
+    "atomic",
+    "condition_variable",
+    "future",
+    "chrono",
+    "filesystem",
+    "cassert",
+    "cmath",
+    "stdexcept",
+    "array",
+    "functional",
+    "optional",
+    "variant",
+    "type_traits",
+    "bitset",
+    "span",
+    "bit",
+    "concepts",
+    "coroutine",
+    "format",
+    "iterator",
+    "limits",
+    "new",
+    "typeinfo",
+    "initializer_list",
+    "regex",
+    "random",
+    "ratio",
+    "scoped_allocator",
+    "shared_mutex",
+    "system_error",
+    "csignal",
+    "cstdbool",
+    "cwchar",
+    "cwctype",
+    "clocale",
+    "ctime",
+    "exception",
+    "forward_list",
+    "unordered_multimap",
+    "valarray",
+    "complex",
+    "locale",
+    "ostream",
+    "istream",
+    "streambuf",
+    "iosfwd",
+    "cfloat",
+    "cfenv",
+    /* Windows / Win32 SDK (angle includes on _WIN32 code paths; never cross-repo) */
+    "windows.h",
+    "process.h",
+    "io.h",
+    "direct.h",
+    "conio.h",
+    "tchar.h",
+    "intrin.h",
+    "winsock2.h",
+    "ws2tcpip.h",
+    "winbase.h",
+    "windowsx.h",
+    "shellapi.h",
+    "shlwapi.h",
+    "wincrypt.h",
+    "winuser.h",
+    "objbase.h",
+    "combaseapi.h",
+    "synchapi.h",
+    "processthreadsapi.h",
+    "fileapi.h",
+    "handleapi.h",
+    "errhandlingapi.h",
+    "sysinfoapi.h",
+    "timezoneapi.h",
+    "psapi.h",
+    "winnt.h",
+    "minwindef.h",
+    "minwinbase.h",
+    "basetsd.h",
+    "sal.h",
+    "strsafe.h",
+    "wingdi.h",
+    "commctrl.h",
+    "commdlg.h",
+    "ole2.h",
+    "oleauto.h",
+    "rpc.h",
+    "winreg.h",
+    "winnls.h",
+    "memoryapi.h",
+    "libloaderapi.h",
+};
+
+/* 1 if `name` (a full include specifier) is a C/C++ stdlib or common system header.
+ * Full-string, case-insensitive match (ASCII). */
+static int aimee_c_system_header_is(const char *name)
+{
+   if (!name || !name[0])
+      return 0;
+   for (size_t i = 0; i < sizeof(AIMEE_C_SYSTEM_HEADERS) / sizeof(AIMEE_C_SYSTEM_HEADERS[0]); i++)
+   {
+      const char *a = name;
+      const char *b = AIMEE_C_SYSTEM_HEADERS[i];
+      while (*a && *b)
+      {
+         int ca = (*a >= 'A' && *a <= 'Z') ? *a + 32 : (unsigned char)*a;
+         int cb = (*b >= 'A' && *b <= 'Z') ? *b + 32 : (unsigned char)*b;
+         if (ca != cb)
+            break;
+         a++;
+         b++;
+      }
+      if (!*a && !*b)
+         return 1;
+   }
+   return 0;
+}
+
+#endif /* AIMEE_C_SYSTEM_HEADERS_H */

--- a/src/tests/test_cross_repo_deps.c
+++ b/src/tests/test_cross_repo_deps.c
@@ -161,6 +161,14 @@ static void test_resolve_c(void)
    r = xrepo_resolve_import_to_repo("vector", XREPO_LANG_CPP, "moonlight-qt", XREPO_IMPORT_STATIC,
                                     SEED, SEED_N);
    assert(r.cardinality == XREPO_RESOLVE_NONE && r.system_header == 1);
+   /* H7: Windows system headers rejected too (the resolver's shared system-header
+    * list); case-insensitive (<Windows.h> == <windows.h>). */
+   r = xrepo_resolve_import_to_repo("process.h", XREPO_LANG_C, "moonlight-qt", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE && r.system_header == 1);
+   r = xrepo_resolve_import_to_repo("Windows.h", XREPO_LANG_C, "moonlight-qt", XREPO_IMPORT_STATIC,
+                                    SEED, SEED_N);
+   assert(r.cardinality == XREPO_RESOLVE_NONE && r.system_header == 1);
 
    /* Vendored copy in two repos -> AMBIGUOUS (MANY), never guessed; the colliders
     * are enumerated for the review queue. */

--- a/src/tests/test_extractors.c
+++ b/src/tests/test_extractors.c
@@ -42,6 +42,12 @@ static void test_c_imports(void)
    assert(ic.count == 4);
    c_import_line("#include <vector>", 6, &ic);
    assert(ic.count == 4);
+   /* H7: Windows system headers (angle, _WIN32 paths) are dropped too — closes the
+    * <process.h>-vs-a-repo's-process.h incidental-collision FP found in H4. */
+   c_import_line("#include <process.h>", 7, &ic);
+   assert(ic.count == 4);
+   c_import_line("#include <windows.h>", 8, &ic);
+   assert(ic.count == 4);
 
    /* but a PATH-QUALIFIED angle include with a stdlib-like basename is a real lib
     * header and is KEPT (matched on the full string, not the basename). */


### PR DESCRIPTION
## What

The H4 deeper spot-check found a residual FP: `aimee → Sunshine` (HIGH) via `#include <process.h>` — a Windows system header that H6's angle capture now stores, but which was absent from the skip list, so it matched Sunshine's own `process.h`.

- **NEW `src/headers/c_system_headers.h`**: a single, data-only source of truth (`AIMEE_C_SYSTEM_HEADERS` + `aimee_c_system_header_is`) for C/C++ stdlib + POSIX + Windows/Win32 SDK headers that are never a cross-repo dependency. Matched on the **full** include string (path-qualified `<thirdparty/string.h>` is kept) and **case-insensitive** (`<Windows.h>` == `<windows.h>`). `static` (per-TU copy, no link/ODR issue) — required because the extractor (`src/`) cannot link the `db2/` resolver.
- The extractor and resolver now **both** include it and call `aimee_c_system_header_is`; their previously-duplicated (already-drifted) per-file lists are deleted, so divergence is impossible.
- Adds the Windows/Win32 SDK coverage that closes the observed FP class, plus more bare C/C++ stdlib.

## Verification

Tests: resolver rejects `<process.h>` + (case-insensitive) `<Windows.h>`; extractor drops bare stdlib/Windows angle includes while keeping path-qualified ones. Full unit-test suite (897) green, `make lint` green, `aimee-kb` links. Reviewed via the aimee roundtable to convergence (round-1 = two-list drift + missing test → resolved by the shared list + resolver test; round-2 blocker was the new file being absent from `git diff` → re-reviewed with the file, converged).

## Next

Final re-validation on `.254` — the `aimee→Sunshine` FP should now be gone — then flip the proposal to complete.