### PR TITLE
docs: formal §9 measurement + approved recall-recovery design

### DIFF
--- a/docs/proposals/done/cross-repo-precision-hardening.md
+++ b/docs/proposals/done/cross-repo-precision-hardening.md
@@ -1,6 +1,18 @@
 # Proposal: Cross-repo dependency graph — precision hardening (structural edges, IDF distinctiveness, FFI-aware)
 
-- **State:** done — implemented, merged to `testing`, and live-validated on `.254` (2026-06-28).
+- **State:** IMPLEMENTED (13 PRs merged) + precision live-validated, but the FORMAL §9 acceptance is
+  **NOT met** (recall). The formal Wilson-CI measurement (2026-06-28; docs/validation/
+  cross-repo-precision-h4-runbook.md §"FORMAL §9 MEASUREMENT") shows the emitted edge set COLLAPSED to
+  **4 HIGH edges corpus-wide**: §4 precision can't be sampled at the gate's N≥100 (observed 3/4 true),
+  and §5 recall is **~18%** vs the gates (HIGH ≥70% / HIGH+MED ≥85%). The hardening eliminated P1's
+  false-positive flood (good) but over-corrected — FetchContent/vendored deps, build/link-only deps
+  (`target_link_libraries` with no source `#include`, not modelled by H0d), and a sparse repo-identity
+  layer (no CMake identities) mean most real intra-corpus deps emit no edge. A **recall-recovery
+  follow-up** is required before §9 passes (exclude `.aimee/worktrees` from indexing; build-link route
+  extraction; CMake-identity population; FetchContent→canonical mapping — see the runbook). The
+  precision MECHANISMS (§1–§6) are done + validated; the proposal's end goal (a precise AND *useful*
+  graph) is not yet achieved at ~18% recall.
+- **Implementation:** merged to `testing`, precision spot-check live-validated on `.254` (2026-06-28).
   Shipped across 13 PRs: H0a–H0d (#824/#825/#827/#828 metadata: def_kind, language, vendored,
   repo-identity, route index), H1 (#830 structural-edge gate + index-time rebuild), H2 (#831 vendor
   canonical-preference), H3a (#832 §5 kind eligibility + §4 vendored ceiling), H3b (#835 §2 header

--- a/docs/proposals/pending/cross-repo-recall-recovery.md
+++ b/docs/proposals/pending/cross-repo-recall-recovery.md
@@ -1,0 +1,158 @@
+# Proposal: Cross-repo dependency graph — recall recovery (build-declared edges)
+
+- **State:** APPROVED — to implement (R1–R4). Roundtable design-reviewed to convergence over 5 rounds
+  (blocking: 6 → 3 → 3 → 3 → 1, each finer; final round = a scope-honesty fix on §6, incorporated):
+  separate evidence-tagged build-edge stream (not in cross_repo_route); canonical host/owner/repo URL
+  mapping; evidence-tiered (URL/submodule MEDIUM-no-symbol, name-mapped annotate-only); enumerated
+  gate applicability; precise `vendored`; explicit §2.6 merge table + §3.5 AMBIGUOUS routing; honest
+  §6 split (build edges reach HIGH+MED ≥85%; HIGH ≥70% needs symbol corroboration, §7-limited).
+  Follow-up to
+  [cross-repo-precision-hardening](../done/cross-repo-precision-hardening.md), whose formal §9
+  measurement (2026-06-28) passed precision (FP flood eliminated) but **collapsed recall to ~18%**
+  (4 HIGH edges corpus-wide vs §5 gates HIGH ≥70% / HIGH+MED ≥85%).
+- **Charter roles:** implementer (this agent) + roundtable reviewers (skeptic/correctness/perf).
+
+## §0 Evidence (measured live, .254, 2026-06-28)
+Full emitted edge set = **4** (gst-wayland-display→smithay, moonlight-qt→moonlight-common-c,
+wolf→inputtino — true; inputtino→wolf — wrong-direction FP from indexed `.aimee/worktrees/` copies).
+Recall ≈ 18%. Diagnosed blockers: (1) the real intra-corpus deps are **build-declared** (CMake
+`FetchContent_Declare(... GIT_REPOSITORY .../<repo>.git)` / git submodules), fetched at build time, so
+no source `#include` matches a definer repo → no `import_header` route → dropped by the H1 gate;
+(2) some deps (C++ class/method APIs, e.g. mdns_cpp) capture no distinctive linking symbol at all, so
+no symbol-model edge is possible; (3) indexing pollution (`.aimee/worktrees/` duplicate copies →
+inputtino→wolf FP); (4) `cross_repo_identity` has no CMake identities (19 crate/npm/pypi only).
+
+## §1 Thesis
+A **declared build dependency on another corpus repo IS a dependency**, evidenced by the build graph
+independent of symbol-level resolution. Build-declared edges are a **distinct evidence class** from
+symbol-resolved edges — they must NOT be laundered through the symbol-graph route table (that would let
+a declaration legitimize unrelated name-collision symbol matches). Carry an explicit `evidence_type`
+so consumers can tell declaration-level adjacency from API-level usage.
+
+## §2 Mechanism (blocking)
+
+### §2.1 A separate build-edge stream (NOT via cross_repo_route)
+Build-declared edges are computed in their own pass and **merged with the symbol-resolved edges only
+at the resolver's output**. They do NOT write `cross_repo_route` and do NOT satisfy H1 for the symbol
+path (so a build declaration can never turn an unrelated symbol/name collision into a HIGH edge —
+roundtable blocker #1/#5). Each emitted edge carries `evidence_type ∈ {symbol_resolved, build_declared,
+both}`, `build_kind ∈ {fetchcontent, submodule, link, manifest}`, `build_scope ∈ {production, test,
+tool, optional}` where derivable, and **`parse_confidence ∈ {high, low}`** (R2 round-2 blocker): a
+declaration whose mapping is fully resolved (literal `GIT_REPOSITORY` URL / `.gitmodules` entry /
+Cargo-go.mod git+path, no unresolved `${VAR}`/generator-expr/conditional) is `high`; one resolved only
+through a guessed `${VAR}` / conditional `if()` / generator expression is `low`.
+
+### §2.2 Extraction (index-time, from file_contents) — top-level only
+Per repo, parse ONLY the caller's **top-level** build/manifest files (its own `CMakeLists.txt` +
+its explicit `include()` closure of tracked `.cmake` files; NOT `_deps/`/build-output trees — roundtable
+transitive-attribution blocker): CMake `FetchContent_Declare`/`ExternalProject_Add` GIT_REPOSITORY,
+`.gitmodules` submodule URLs, and (lower confidence) `target_link_libraries`/`find_package` target/
+package names; Cargo.toml `[dependencies]`/`[dev-dependencies]` git+path, go.mod `require`,
+package.json deps. Parser approach per ecosystem is regex-with-documented-limitations + a per-decl
+parse-confidence; conditional `if()/foreach()`-guarded and `${VAR}`/generator-expression decls that
+can't be resolved are tagged low-confidence (kept for recall but flagged, never promoted to HIGH).
+
+### §2.3 Dep → corpus-repo mapping (canonical, not basename)
+Map a git URL to `(host, owner, repo)` normalized (case-fold; collapse `-`/`_`; strip `.git`; resolve
+relative/`${VAR}` where possible). Match to a corpus repo by its known remote `(host,owner,repo)` (or
+repo-identity) → `parse_confidence=high`. **Basename-only matching is a last-resort fallback** (forks/
+mirrors share basenames — blocker #2) → forces `parse_confidence=low` (so capped at LOW per §2.4); and
+if the basename maps to **>1** corpus repo it is **AMBIGUOUS** (routed to review, not guessed) (round-3
+blocker #1). A target/package NAME maps to a repo only via `cross_repo_identity` and only when it maps
+to exactly one corpus repo (else AMBIGUOUS). Anything not mapping to a corpus repo (fmt/boost/external)
+is dropped — corpus↔corpus only.
+
+### §2.4 Tiering by evidence strength (roundtable blocker #3 + round-2 #1/#3)
+- **URL / submodule / Cargo-go.mod git+path** with `parse_confidence=high` = ground-truth evidence →
+  **MEDIUM** even with no linking symbols; **HIGH** (`evidence_type=both`) when also symbol-corroborated.
+- **Any build decl with `parse_confidence=low`** (unresolved `${VAR}`/conditional/generator-expr) →
+  capped at **LOW** (surfaced for review, excluded from the default MEDIUM+ output) — never MEDIUM/HIGH
+  on a guess.
+- **Name-mapped `target_link_libraries`/`find_package`** → NEVER a standalone edge. It only adds the
+  `build_declared` flag (→ `evidence_type=both`) to an edge that **already exists as a fully
+  symbol-resolved edge** — i.e. one that has already passed H1's route gate, §2 IDF, §5 kind, §3b
+  header-IDF and prefer-local on the symbol path. Name mapping cannot create, re-tier, or weaken those
+  gates; it is pure annotation of an independently-qualified edge.
+
+### §2.6 Merge semantics + final tier table (AUTHORITATIVE — round-3/4 blockers)
+The output is keyed by the **(caller, definer) repo pair**. For each pair the resolver may have a
+symbol-resolved candidate (tier `S` ∈ {HIGH,MEDIUM,LOW}, from the H1–H7 path) and/or a build-declared
+candidate. The single emitted edge per pair is decided by this table (this section is the sole tiering
+authority; §2.4 only classifies the *build candidate's* strength, it does not set the final edge tier):
+
+| symbol candidate | build candidate | → evidence_type | → final tier |
+|---|---|---|---|
+| S (any) | none | symbol_resolved | S |
+| none | high-parse URL/submodule/git+path | build_declared | MEDIUM |
+| none | low-parse | build_declared | LOW |
+| S (any) | high-parse, **same definer** | both | **HIGH** (declared AND used = strongest) |
+| S (any) | low-parse, same definer | both | S (low-parse never promotes; just annotates) |
+
+`evidence_type=both` REQUIRES the symbol edge and build declaration name the **same definer repo**; a
+symbol edge to a *different* repo never upgrades a build edge (they are distinct pairs). Build evidence
+never *lowers* a symbol tier. Dedup is by (caller, definer); within a pair, multiple build declarations
+collapse deterministically: highest `parse_confidence` first, then `build_kind` priority
+(submodule > fetchcontent > manifest > link), then lexicographic by evidence string (round-4 blocker
+#3) — the choice only affects the displayed `build_kind`/example, not the pair or tier.
+
+### §2.5 Which gates apply (roundtable blocker #4 — enumerated)
+Build edges **OBEY**: directionality (caller→definer only), corpus↔corpus pairing, untrusted-definer
+§0 suppression, dedup, and AMBIGUOUS routing if a name maps to >1 repo. Build edges **BYPASS** (these
+guard *name-collision* noise, irrelevant to a URL-declared dep): the H1 symbol-route requirement, §2
+IDF/system-include distinctiveness, §5 kind eligibility, §3b header-IDF, §5 prefer-local. They are
+NEVER written to `cross_repo_route`.
+
+## §3 Precision guards (blocking)
+- Corpus↔corpus only; directional; no reverse edges; URL/submodule evidence is exact-repo.
+- **`vendored` defined precisely** (roundtable blocker #6): a file is vendored iff a path component
+  matches a build-output/dependency-cache pattern (`_deps`, `build`, `cmake-build*`, `.git`,
+  `.aimee/worktrees`, `node_modules`, `Pods`, `.venv`, `venv`, `site-packages`, `vendor`,
+  `third_party`) AND the file is not in the caller's tracked top-level source. `originated_in_caller`
+  ignores vendored definitions. This is correct for BOTH third-party vendored code AND a corpus repo
+  fetched into the caller's `_deps/` (round-2 blocker #2): in either case the `_deps/` file is the
+  DEP's code, not the caller's own definition, so it must not suppress the edge as "originated"; the
+  symbol path then resolves the caller's *use* to the canonical (non-vendored) definer via H2
+  canonical-preference. A vendored copy is never the sole definer of record.
+- Indexing excludes `.aimee/worktrees/`, `.git/`, and build-output dirs (§5 R1) — also fixes
+  inputtino→wolf.
+
+## §3.5 AMBIGUOUS operational semantics (round-4 blocker)
+A build declaration whose mapping is ambiguous (basename → >1 corpus repo; target/package name → >1
+corpus repo) is written to the **existing `cross_repo_review` queue** (the same S4b adjudication path
+symbol-AMBIGUOUS uses) with `evidence_type=build_declared` + the declaration as evidence — it is NOT
+emitted as a default-output edge. For §6 acceptance it is counted in the Wilson **precision
+denominator** (like symbol-AMBIGUOUS) and reported as a recall **coverage gap** (excluded from the
+recall numerator). Unmapped declarations (external deps) are simply dropped, not surfaced.
+
+## §4 Repo-identity completeness (suggestion)
+Investigate why H0c CMake `project()`/`add_library` extraction yielded 0 CMake identities on the
+corpus; populate them so target/package mapping (§2.3) and §5 recall measurement work.
+
+## §5 Slices
+- **R1 — indexing hygiene:** exclude `.aimee/worktrees/`, `.git/`, build-output dirs from the scan;
+  re-scan; confirm inputtino→wolf FP gone. (cheap, self-contained)
+- **R2 — build-declared edge stream (core):** index-time extraction (§2.2) + canonical mapping (§2.3)
+  + the separate build-edge pass merged at output with `evidence_type`/`build_kind` (§2.1, §2.4);
+  URL/submodule + Cargo/go.mod first. Pure pieces shim-tested; live re-measure.
+- **R3 — originated-vendored exclusion (§3) + name-mapped link deps (symbol-corroborated only) + CMake
+  identities (§4).**
+- **R4 — re-measure §9** on .254 against a CURATED gold set (manual production/test/tool + direction
+  classification, separate from the extractor — roundtable circular-validation suggestion), not just
+  the extractor's own re-derivation.
+
+## §6 Acceptance
+§9 gates on the curated gold set, with an HONEST split by what each mechanism can reach (round-5
+blocker): a build-declared-only dep is **MEDIUM** by design (§2.6), so build edges recover the
+**HIGH+MED ≥85%** recall gate — that is the primary, reachable target of this proposal. The **HIGH ≥70%**
+gate additionally requires symbol corroboration (`evidence_type=both`): reachable for deps with
+capturable APIs (C-style functions, e.g. wolf→inputtino) but NOT for symbol-opaque deps (C++ class/
+method APIs like mdns_cpp — §7 out of scope). So HIGH recall is **measured and reported**, expected to
+improve materially (every C-style declared dep that is also used → HIGH) but its residual gap is
+attributed to §7 symbol-extraction limits, not claimed as fully met by build edges alone. Precision:
+Wilson-95% LB ≥90% with AMBIGUOUS in the denominator; the 4 existing true edges retained; no new FP
+class; `evidence_type` exposed so consumers distinguish declared-adjacency from API-usage. Recall
+reported separately for exact-URL/submodule vs name-mapped.
+
+## §7 Out of scope
+C++ class/method-level symbol extraction (mdns_cpp) — build-declared edges cover those deps at the
+repo-pair level without it.

--- a/docs/validation/cross-repo-precision-h4-runbook.md
+++ b/docs/validation/cross-repo-precision-h4-runbook.md
@@ -154,3 +154,76 @@ Residual / known limitations (documented, not regressions):
   modelled (H0d builds routes from file_imports); logged as `low-unresolved (no route)`.
 - generated/SDK header long-tail: the system-header + generated-header lists are
   seed lists (the principled fix is §1.6 marker-based generated-output attribution).
+
+---
+
+## FORMAL §9 MEASUREMENT (2026-06-28, .254 vtesting-b35f1f7, full corpus)
+
+Enumerated the COMPLETE emitted edge set (deps query over all 40 projects) +
+built recall ground truth from intra-corpus `GIT_REPOSITORY` build deps.
+
+### Edge set
+**Total emitted edges: 4 (all HIGH, 0 MEDIUM, 0 AMBIGUOUS surfaced).**
+| edge | adjudication |
+|---|---|
+| gst-wayland-display → smithay (167 syms) | TRUE |
+| moonlight-qt → moonlight-common-c (44 syms) | TRUE |
+| wolf → inputtino (13 syms) | TRUE |
+| inputtino → wolf (2 syms, create_touch_screen) | **FALSE** — wrong direction; create_touch_screen is defined in inputtino + used by wolf. Arises from wolf's vendored/duplicate inputtino copies (incl. indexed `.aimee/worktrees/` pollution) |
+
+### §4 precision — NOT MEASURABLE at the required N
+Gate: N≥100 HIGH edges, Wilson-95% lower bound ≥90%, AMBIGUOUS in denominator.
+Only **4** HIGH edges exist corpus-wide — cannot sample 100. Observed precision
+3/4 = 75% (Wilson-95% LB on 3/4 ≈ 30%, but driven entirely by N=4). The gate is
+UNREACHABLE because edge VOLUME collapsed, not because precision is poor.
+
+### §5 recall — FAILS
+Ground truth (intra-corpus declared deps via GIT_REPOSITORY URLs): 11 pairs;
+emitted: 2 → **recall ≈ 18%** (gate: HIGH ≥70%, HIGH+MED ≥85%). Missed real deps
+include wolf→{mdns_cpp, moonlight-common-c, gst-wayland-display, eventbus},
+smoothnas→{inputtino, smoothfs, eventbus, …}, aimee→smoothgui. (Ground truth is a
+lower bound — git-URL scan; submodule/path deps like moonlight-qt→moonlight-common-c
+are additional and ARE emitted.)
+
+### §6 latency / negatives
+Negatives: of 4 edges, 1 FP (inputtino→wolf). End-to-end deps p50≈812ms /
+p95≈1189ms (CLI+TLS+remote round-trip, NOT the resolver-only metric the gate
+specifies; the index-time-precompute resolver itself is not isolated here). The
+`low-unresolved (no route)` instrumentation is LOG_DEBUG, below the kb's INFO level,
+so the no-route demotion volume was not captured.
+
+### VERDICT: §9 deployment gates (#4/#5) NOT met
+The precision-hardening eliminated the false-positive FLOOD (P1's ~10–20% precision
+on a large edge set) but over-corrected: the edge set collapsed to 4, so precision
+can't be measured at N≥100 and recall is ~18% (vs the 70/85% gates). The earlier
+spot-check (FP classes collapsed, key true deps recovered) PASSED, but the formal
+N≥100/recall bar does NOT.
+
+### Root causes of the recall collapse (for the follow-up)
+1. **FetchContent / vendored deps dominate this corpus.** wolf/Sunshine pull
+   mdns_cpp, moonlight-common-c, inputtino, gst-wayland-display via CMake
+   FetchContent into `_deps/` (vendored); the caller's use resolves to the vendored
+   copy, and H2 canonical-preference only routes to the canonical repo when a
+   structural route to it exists — which it usually doesn't (the include points at
+   the FetchContent path, not a basename that matches the canonical repo).
+2. **Build/link-only deps not modelled.** target_link_libraries + find_package +
+   FetchContent declare deps with NO matching source `#include` route; H0d builds
+   routes from file_imports only (documented gap). These are the bulk of the misses.
+3. **Repo-identity layer lacks CMake identities.** cross_repo_identity has only
+   crate/npm/pypi (19 rows); no `project()`/target identities for the C/C++ repos,
+   so import_module routes can't form for them and §5's package→repo recall mapping
+   can't run for CMake deps.
+4. **Indexing pollution.** wolf indexes its own `.aimee/worktrees/` copies (other
+   sessions' worktrees), duplicating symbols and producing the inputtino→wolf FP.
+
+### Recommended follow-up (recall recovery — a new effort)
+- Exclude `.aimee/worktrees/` (and similar) from indexing (cheap; kills the
+  inputtino→wolf FP class).
+- Build-link route extraction: parse CMake FetchContent_Declare GIT_REPOSITORY +
+  target_link_libraries + find_package, and Cargo/go.mod path/git deps, into
+  cross_repo_route as an `import_build` route kind (the §1 build/link route source,
+  deferred in H0d).
+- Populate CMake project()/target identities (the H0c CMake parser appears not to
+  emit them on this corpus) so module/target routes form.
+- Treat a FetchContent'd dep as a route to the canonical repo (map the _deps/ source
+  to its declaring GIT_REPOSITORY → canonical repo).


### PR DESCRIPTION
## What

Corrects the record after the **formal §9 measurement** and lands the roundtable-converged **recall-recovery design**.

The precision-hardening spot-check passed (FP classes collapsed), but the formal Wilson-CI/recall bar does **not**: the emitted edge set collapsed to **4 HIGH edges** corpus-wide → precision unmeasurable at N≥100 (observed 3/4), recall **~18%** vs §5 gates (70%/85%).

- `cross-repo-precision-hardening.md` — state corrected to **NOT §9-accepted** (recall).
- `cross-repo-precision-h4-runbook.md` — full formal measurement (edge set + adjudication, precision, recall, root causes: FetchContent/vendored deps, build/link-only deps not modelled, sparse repo-identity, `.aimee/worktrees` indexing pollution).
- **NEW `cross-repo-recall-recovery.md`** — design for **build-declared dependency edges** as a separate evidence-tagged stream (the build graph is the evidence; not laundered through `cross_repo_route`). Roundtable design-reviewed to convergence (5 rounds, 6→3→3→3→1 blocking). Slices: **R1** indexing hygiene → **R2** build-declared edges → **R3** originated-vendored + name-mapped + CMake identities → **R4** re-measure §9 vs a curated gold set.

Docs-only; implementation follows in R1–R4.