### PR TITLE
feat(kb): cross-repo recall R2a — index build manifests

### DIFF
--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -30,6 +30,34 @@ static int code_ext_ok(const char *name)
    return 0;
 }
 
+/* Build manifests (R2): not code by extension, but their CONTENT declares cross-repo
+ * dependencies (CMake FetchContent/target_link_libraries, git submodules, …) that the
+ * build-declared-edge pass reads from file_contents. Indexed (content stored) even
+ * though no language extractor runs on them (detect_lang is extension-based, so these
+ * yield only file_contents, no terms/imports — meson.build is NOT sniffed as Python).
+ * Matched on the trailing component so it works for a bare basename (worktree walk) or
+ * a path (git-tracked list). build/_deps/.git/.aimee subtrees are still excluded by the
+ * dir walk (code_dir_skip) / code_path_skipped, so only the repo's OWN manifests are
+ * collected (top-level + subdirs); R2b's extraction restricts attribution to the
+ * top-level per design §2.2 and STRIPS any URL userinfo (https://user:token@…) so
+ * credentials are never persisted into routes. */
+static int code_build_manifest(const char *name)
+{
+   const char *slash = strrchr(name, '/');
+   const char *base = slash ? slash + 1 : name;
+   if (strcmp(base, "CMakeLists.txt") == 0 || strcmp(base, ".gitmodules") == 0 ||
+       strcmp(base, "meson.build") == 0)
+      return 1;
+   const char *dot = strrchr(base, '.');
+   return dot && strcmp(dot, ".cmake") == 0;
+}
+
+/* A file is wanted if it is code by extension OR a build manifest by name. */
+static int code_file_wanted(const char *name)
+{
+   return code_ext_ok(name) || code_build_manifest(name);
+}
+
 /* .git classification (defined below): 0 = not a repo, 1 = real checkout,
  * 2 = linked worktree. */
 static int code_git_kind(const char *path);
@@ -96,7 +124,7 @@ static int code_collect_walk(const char *root, const char *rel, code_collect_fil
       }
       else if (S_ISREG(st.st_mode))
       {
-         if (!code_ext_ok(ent->d_name))
+         if (!code_file_wanted(ent->d_name))
             continue;
          if (st.st_size <= 0 || st.st_size > CODE_COLLECT_MAX_FILE_BYTES)
             continue;
@@ -544,7 +572,7 @@ static int code_collect_from_git(const char *root, const char *ref, code_collect
       const char *oid = sp2 + 1;
       if (strcmp(type, "blob") != 0)
          continue;
-      if (!code_ext_ok(path) || code_path_skipped(path))
+      if (!code_file_wanted(path) || code_path_skipped(path))
          continue;
       if (n == cap)
       {

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -227,6 +227,56 @@ static void test_non_git_uses_worktree(void)
    printf("  test_non_git_uses_worktree: ok\n");
 }
 
+/* R2: build manifests (CMakeLists.txt, *.cmake, .gitmodules, meson.build) are
+ * collected so the build-declared-edge pass can read their content; a non-manifest
+ * .txt is NOT collected. */
+static void test_build_manifests_collected(void)
+{
+   make_root("buildman");
+   write_file("CMakeLists.txt", "FetchContent_Declare(dep GIT_REPOSITORY x)");
+   write_file("cmake/deps.cmake", "find_package(foo)");
+   write_file(".gitmodules", "[submodule \"x\"]");
+   write_file("meson.build", "project('p')");
+   write_file("src/a.cpp", "int a(){return 0;}");
+   write_file("README.txt", "not a manifest");
+   /* a CMakeLists.txt under a build-output dir must NOT be collected (the walk skips
+    * build/ at directory recursion, so FetchContent'd _deps manifests never enter). */
+   write_file("build/_deps/dep-src/CMakeLists.txt", "FetchContent_Declare(other GIT_REPOSITORY y)");
+
+   reset();
+   code_collect_files_cb(g_root, rec_cb, NULL);
+   assert(has("CMakeLists.txt"));
+   assert(has("cmake/deps.cmake"));
+   assert(has(".gitmodules"));
+   assert(has("meson.build"));
+   assert(has("src/a.cpp"));
+   assert(!has("README.txt"));                         /* plain .txt is not a build manifest */
+   assert(!has("build/_deps/dep-src/CMakeLists.txt")); /* build-output subtree skipped */
+   printf("  test_build_manifests_collected: ok\n");
+}
+
+/* R2: build manifests are collected via the GIT-TRACKED path too (the second
+ * collection site), and a build/ manifest stays excluded there as well. */
+static void test_build_manifests_collected_git(void)
+{
+   make_root("buildman_git");
+   git("init -q -b main");
+   git("config user.email t@t");
+   git("config user.name t");
+   write_file("CMakeLists.txt", "FetchContent_Declare(dep GIT_REPOSITORY x)");
+   write_file("src/a.cpp", "int a(){return 0;}");
+   write_file("build/CMakeLists.txt", "generated");
+   git("add -A -f"); /* -f: build/ may be gitignored in some setups; force-track for the test */
+   git("commit -qm c");
+
+   reset();
+   code_collect_files_cb(g_root, rec_cb, NULL);
+   assert(has("CMakeLists.txt"));
+   assert(has("src/a.cpp"));
+   assert(!has("build/CMakeLists.txt")); /* build-output dir excluded on the git path too */
+   printf("  test_build_manifests_collected_git: ok\n");
+}
+
 /* §6 live: the default-branch tree SHA tracks commits, and the pure change-gate
  * decides when a re-index is warranted. */
 static void test_default_branch_sha_tracks_commits(void)
@@ -374,6 +424,8 @@ int main(void)
    test_clone_resolves_origin_head();
    test_no_default_branch_skips();
    test_non_git_uses_worktree();
+   test_build_manifests_collected();
+   test_build_manifests_collected_git();
    test_default_branch_sha_tracks_commits();
    test_default_branch_sha_quote_in_ref();
    test_index_source_is_worktree();


### PR DESCRIPTION
## What

Recall-recovery prerequisite (per `docs/proposals/pending/cross-repo-recall-recovery.md`). The formal §9 measurement found recall ~18% because the real intra-corpus deps are **build-declared** (CMake `FetchContent`/`target_link_libraries`, git submodules), but the dominant build manifest **isn't even indexed**: `CMakeLists.txt`/`.gitmodules`/`.cmake` have no code extension, so `code_ext_ok` skipped them and their content never reached `file_contents` (where R2b's build-declared-edge extraction will read it).

- `code_collect.c`: `code_build_manifest` (CMakeLists.txt / *.cmake / .gitmodules / meson.build, by trailing component) + `code_file_wanted = code_ext_ok || code_build_manifest`, used at **both** collection sites. `build/`/`_deps/`/`.git/`/`.aimee` stay excluded (only the repo's own manifests collected); no language extractor runs on them (extension-based `detect_lang`) → only `file_contents`, no spurious terms.

## Verification

Tests: manifests collected on worktree + git-tracked paths; plain `.txt` excluded; `build/_deps` CMakeLists excluded on both paths. Full suite (918) green, lint green. Roundtable-converged (round-1 blocker — worktree dir-skip — proven by tests; round-2 0 blocking).

## Next

R2b — the build-declared-edge extraction (`cross_repo_build_dep` table + URL→corpus-repo mapping) reading these now-indexed manifests; then R2c resolver merge; then re-measure §9.