### PR TITLE
feat(combined): bundle + auto-start aimee-llm CPU; close out kb-llm proposal

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -117,8 +117,11 @@ jobs:
       # and (2) point docker's storage at the runner's larger /mnt disk (~65 GB free)
       # BEFORE the buildx builder is created, so buildkit writes its layers there. Both
       # are scoped to the llm legs — the C images build fine without paying this cost.
-      - name: Free disk space (aimee-llm legs)
-        if: startsWith(matrix.image.name, 'aimee-llm')
+      - name: Free disk space (aimee-llm + combined legs)
+        # The combined (aimee-server-kb) image now bundles the aimee-llm CPU
+        # runtime + ~5.5 GB of baked GGUFs (COPYd from aimee-llm-cpu), so it needs
+        # the same disk headroom as the llm legs.
+        if: startsWith(matrix.image.name, 'aimee-llm') || matrix.image.name == 'aimee-server-kb'
         run: |
           echo "before:"; df -h / /mnt
           sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
@@ -128,8 +131,8 @@ jobs:
           sudo apt-get clean || true
           echo "after:"; df -h /
 
-      - name: Move docker storage to /mnt (aimee-llm legs)
-        if: startsWith(matrix.image.name, 'aimee-llm')
+      - name: Move docker storage to /mnt (aimee-llm + combined legs)
+        if: startsWith(matrix.image.name, 'aimee-llm') || matrix.image.name == 'aimee-server-kb'
         run: |
           sudo systemctl stop docker docker.socket || true
           sudo mkdir -p /mnt/docker
@@ -164,12 +167,24 @@ jobs:
           # Images bundle the browser UI (WITH_WEBCHAT=1, the default). webchat's
           # frontend dependency (@rakuensoftware/smoothgui) is vendored in-repo, so
           # the build needs no npm token. The aimee-kb image ignores WITH_WEBCHAT.
+          # Bundled aimee-llm in the combined image is AMD64-ONLY: the llama.cpp
+          # runtime baked into aimee-llm-cpu is the x64 Vulkan binary, so the arm64
+          # combined leg builds lean (WITH_LLM=0) and points at an external llm.
+          # CAVEAT (ordering): the amd64 combined leg COPYs from aimee-llm-cpu:latest
+          # — i.e. the PREVIOUS release's llm image, since this run's llm tags aren't
+          # manifest-merged until after the build matrix. The gateway/model contract
+          # is stable across releases, but for a release that materially changes the
+          # llm image, publish/promote aimee-llm-cpu first (or re-run this leg).
+          # Digest-pinned ordering (combined `needs` the llm digest) is the follow-up.
           build-args: |
             AIMEE_VERSION=${{ needs.prep.outputs.version }}
             WITH_WEBCHAT=1
             ${{ matrix.image.embedder_arg }}
             ${{ matrix.image.reranker_arg }}
             ${{ matrix.image.extra_args }}
+            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && 'WITH_LLM=1' || '' }}
+            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'amd64') && format('AIMEE_LLM_CPU_IMAGE=ghcr.io/{0}/aimee-llm-cpu:latest', env.OWNER) || '' }}
+            ${{ (matrix.image.name == 'aimee-server-kb' && matrix.platform.arch == 'arm64') && 'WITH_LLM=0' || '' }}
           outputs: type=image,name=ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/publish-testing.yml
+++ b/.github/workflows/publish-testing.yml
@@ -66,6 +66,22 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # The combined (aimee-server-kb) image now bundles the aimee-llm CPU runtime
+      # + baked GGUFs (~5.5 GB), COPYd from the prebuilt aimee-llm-cpu:testing
+      # image — so reclaim the preinstalled toolchains we don't use to make room
+      # for the pull + the larger output image. Scoped to the combined leg (the
+      # split server/kb images stay lean and build fine without this).
+      - name: Free disk space (aimee-server-kb leg)
+        if: matrix.image.name == 'aimee-server-kb'
+        run: |
+          echo "before:"; df -h /
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /opt/hostedtoolcache /usr/local/.ghcup /usr/local/share/boost \
+            /usr/share/swift /usr/local/share/powershell /usr/local/lib/node_modules \
+            /opt/microsoft /opt/az "${AGENT_TOOLSDIRECTORY:-/opt/hostedtoolcache}" || true
+          sudo apt-get clean || true
+          echo "after:"; df -h /
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -82,10 +98,16 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
           cache-to: type=gha,mode=max,scope=${{ matrix.image.name }}-amd64
           # WITH_WEBCHAT bundles the browser UI (default for server/combined; the
-          # aimee-kb image ignores it).
+          # aimee-kb image ignores it). WITH_LLM=1 + AIMEE_LLM_CPU_IMAGE make the
+          # combined image bundle the aimee-llm CPU runtime by COPYing from the
+          # prebuilt aimee-llm-cpu:testing (published by publish-llm-testing.yml,
+          # which must have run first). The split server/kb Dockerfiles don't
+          # declare these args (a harmless "not consumed" warning).
           build-args: |
             AIMEE_VERSION=testing-${{ env.SHA7 }}
             WITH_WEBCHAT=1
+            WITH_LLM=1
+            AIMEE_LLM_CPU_IMAGE=ghcr.io/${{ env.OWNER }}/aimee-llm-cpu:testing
           tags: |
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing
             ghcr.io/${{ env.OWNER }}/${{ matrix.image.name }}:testing-${{ env.SHA7 }}

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -20,6 +20,16 @@ ARG WITH_WEBCHAT=1
 # default — the editor is a first-class feature; build with --build-arg
 # WITH_VSCODE=0 to omit it (saves ~100 MB).
 ARG WITH_VSCODE=1
+# WITH_LLM bundles the aimee-llm CPU runtime + baked GGUFs (the unified
+# llama.cpp/Vulkan gateway: embed + rerank + Tier-A synth) INTO this image, so
+# the combined container is self-contained — no external embedder/llm service.
+# ON by default; build with --build-arg WITH_LLM=0 for the lean server+kb image
+# that points at an external AIMEE_LLM_URL (saves ~5.5 GB of baked models). The
+# runtime is COPYd from the prebuilt aimee-llm-cpu image (AIMEE_LLM_CPU_IMAGE),
+# so this build does NOT re-download or re-convert models; that image must exist
+# (CI: aimee-llm-cpu:testing / release: :latest, published by publish-llm-*.yml).
+ARG WITH_LLM=1
+ARG AIMEE_LLM_CPU_IMAGE=ghcr.io/rakuensoftware/aimee-llm-cpu:latest
 FROM debian:bookworm-slim AS build
 
 # Union of the aimee-server and aimee-kb build deps: server links libsqlite3
@@ -99,6 +109,16 @@ FROM debian:bookworm-slim AS code-server-stage-0
 RUN mkdir -p /opt/codeserver/usr
 FROM code-server-stage-${WITH_VSCODE} AS code-server-stage
 
+# Optional bundled aimee-llm (CPU). "1" pulls the prebuilt aimee-llm-cpu image
+# (llama.cpp/Vulkan runtime at /opt/llama, the gateway + supervisor under
+# /opt/aimee, and the baked GGUFs under /models) — BuildKit only materializes the
+# stage the final selector references, so WITH_LLM=0 never pulls this multi-GB
+# image. "0" is an empty stage so the COPYs below are no-ops.
+FROM ${AIMEE_LLM_CPU_IMAGE} AS llm-stage-1
+FROM debian:bookworm-slim AS llm-stage-0
+RUN mkdir -p /opt/llama /opt/aimee /models
+FROM llm-stage-${WITH_LLM} AS llm-stage
+
 FROM debian:bookworm-slim
 
 # Union of both runtime closures: libsqlite3 (server DB1), libpq (kb DB2),
@@ -124,6 +144,23 @@ RUN apt-get update \
         tmux \
         zlib1g \
     && rm -rf /var/lib/apt/lists/*
+
+# Bundled aimee-llm (CPU) runtime deps — only when WITH_LLM=1, so the lean image
+# isn't burdened with the Vulkan driver stack. The llama.cpp release binary is the
+# vendor-agnostic Vulkan build (needs libvulkan1 + an ICD even at NGL=0 on CPU);
+# the gateway is python3 (already present) + numpy for the rerank head; the
+# supervisor is a bash script.
+ARG WITH_LLM=1
+RUN if [ "$WITH_LLM" = "1" ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends \
+            bash \
+            libgomp1 \
+            libvulkan1 \
+            mesa-vulkan-drivers \
+            python3-numpy \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
 
 ENV AIMEE_HOME=/var/lib/aimee
 # On-demand OAuth CLI agents global-install on the persistent home volume so the
@@ -151,8 +188,13 @@ ENV AIMEE_DB1_URL=sqlite:///var/lib/aimee/aimee.db
 # and reach Postgres + the embedder via env (compose supplies the URLs).
 ENV AIMEE_KB_HTTP_BIND=1
 ENV AIMEE_DB2_URL=postgresql://aimee:aimee@postgres:5432/aimee_shared
-ENV AIMEE_EMBEDDER_URL=http://embedder:8080
-ENV LLM_ENDPOINT=http://llm:8080/v1
+# NOTE: AIMEE_EMBEDDER_URL / LLM_ENDPOINT are intentionally NOT baked here. The
+# entrypoint resolves the embed/rerank/synth endpoints at start (see
+# combined-entrypoint.sh): operator-set AIMEE_LLM_URL / AIMEE_EMBEDDER_URL /
+# LLM_ENDPOINT win; else (WITH_LLM=1) the in-container bundled aimee-llm gateway
+# at 127.0.0.1:$AIMEE_LLM_PORT; else the legacy external defaults
+# (embedder:8080 / llm:8080) for a lean WITH_LLM=0 image. Baking them would make
+# every operator look "configured" and suppress the bundled-gateway auto-start.
 # Symmetric with LLM_ENDPOINT: the bundled curator LLM (Gemma E4B) also needs a
 # model name. The curator code-extract stage shells out to curator-extract.py ->
 # llm-chat.py, which hard-requires $LLM_MODEL; a non-configurable plugin instance
@@ -161,6 +203,29 @@ ENV LLM_ENDPOINT=http://llm:8080/v1
 # loaded GGUF regardless of this value; configurable / BYO deploys override it.
 # Kept in sync with compose.combined.yaml's default.
 ENV LLM_MODEL=gemma-3n-e4b
+# Bundled aimee-llm (WITH_LLM=1) gateway port + bring-up policy. AIMEE_BUNDLED_LLM:
+#   auto (default) — start the bundled CPU gateway UNLESS the operator pointed
+#                    AIMEE_LLM_URL at an external/GPU endpoint (opt up only);
+#   on             — always start it (and still honor an explicit AIMEE_LLM_URL);
+#   off            — never start it (use the external embedder/llm env above).
+# No-op in a WITH_LLM=0 image (the supervisor/models aren't present).
+ENV AIMEE_LLM_PORT=8742
+ENV AIMEE_BUNDLED_LLM=auto
+# Bundled aimee-llm gateway wiring — mirrors Dockerfile.aimee-llm's runtime ENV
+# (the COPY only brings the files, not that image's ENV). Without these the
+# gateway 503s on /rerank (no AIMEE_LLM_RERANK_HEAD) and /v1/chat/completions (no
+# AIMEE_LLM_SYNTH_URL); embeds would default-resolve but rerank/synth would fail.
+# The per-role llama-servers the supervisor starts are loopback 8081/8082/8083;
+# the gateway itself binds loopback only (same container/netns as the kb/server).
+# Harmless when WITH_LLM=0 (no gateway runs).
+ENV AIMEE_LLM_EMBED_URL=http://127.0.0.1:8081 \
+    AIMEE_LLM_RERANK_URL=http://127.0.0.1:8082 \
+    AIMEE_LLM_SYNTH_URL=http://127.0.0.1:8083 \
+    AIMEE_LLM_RERANK_HEAD=/models/rerank-head \
+    AIMEE_LLM_EMBED_MODEL=qwen3-embedding \
+    AIMEE_LLM_EMBED_POOLING=last \
+    AIMEE_LLM_NGL=0 \
+    AIMEE_LLM_BIND=127.0.0.1
 # Mirror tier (workspace-resource-plane §3): durable bare mirrors + worktrees on
 # a dedicated volume, matching Dockerfile.server.
 ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces
@@ -171,10 +236,30 @@ ENV AIMEE_WORKSPACES_DIR=/var/lib/aimee-workspaces
 RUN useradd --uid 1000 --user-group --home-dir /var/lib/aimee --create-home --shell /usr/sbin/nologin aimee \
     && mkdir -p /var/lib/aimee-workspaces /var/lib/aimee/.config/aimee \
     && chown -R aimee:aimee /var/lib/aimee-workspaces /var/lib/aimee/.config
+# When the bundled aimee-llm runs on a GPU (AIMEE_LLM_NGL>0 + a mounted /dev/dri),
+# the unprivileged "aimee" user needs the render/video groups to reach the render
+# node. Best-effort + harmless for the default CPU (NGL=0) path, which needs no
+# device. (gid match to the host's render group is a deploy-time --group-add if
+# numbers differ.)
+RUN if [ "$WITH_LLM" = "1" ]; then \
+        groupadd -f render || true; \
+        groupadd -f video || true; \
+        usermod -aG render,video aimee || true; \
+    fi
 VOLUME /var/lib/aimee-workspaces
 
 COPY --from=build /src/aimee-server /usr/local/bin/aimee-server
 COPY --from=build /src/aimee-kb /usr/local/bin/aimee-kb
+
+# Bundled aimee-llm (CPU): the llama.cpp/Vulkan runtime, the unified gateway +
+# rerank head + supervisor, and the baked GGUFs. From the empty llm-stage-0 when
+# WITH_LLM=0 these are no-op copies of empty dirs (the entrypoint then finds no
+# /opt/aimee/supervisor.sh and starts no gateway). The gateway files land in
+# /opt/aimee/ so the supervisor's hardcoded paths (PYTHONPATH=/opt/aimee,
+# /opt/aimee/aimee_llm_gateway.py) resolve unchanged.
+COPY --from=llm-stage /opt/llama/ /opt/llama/
+COPY --from=llm-stage /opt/aimee/ /opt/aimee/
+COPY --from=llm-stage /models/ /models/
 
 # kb sidecar clients (LLM/embedder access code the kb invokes via popen).
 COPY scripts/embed-remote.py scripts/rerank-remote.py scripts/llm-chat.py \
@@ -233,7 +318,13 @@ EXPOSE 8740 8743 8741 8443
 # Every TCP /v1 request is authenticated, so an unauthenticated probe returns
 # 401 — which still proves the listener is up. Treat 200/401 as healthy; only a
 # connection failure ("000") is unhealthy. Mirrors Dockerfile.server.
-HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=5 \
+# start-period is generous: with the bundled aimee-llm (WITH_LLM=1) the entrypoint
+# waits for the gateway's cold multi-GB model load before starting the server, so
+# the server /v1 listener can take minutes to appear. A long start-period prevents
+# the orchestrator marking the container unhealthy during that load (a success
+# during the period still flips it healthy immediately, so the fast WITH_LLM=0
+# path is unaffected). Override AIMEE_LLM_WAIT_SECONDS to bound the entrypoint wait.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=660s --retries=5 \
     CMD curl -s -o /dev/null -w '%{http_code}' \
         http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$'
 

--- a/compose.combined.yaml
+++ b/compose.combined.yaml
@@ -2,9 +2,13 @@
 #
 # One container runs BOTH aimee binaries co-located (server fronts /v1 over TLS on :8743;
 # the kb runs on loopback :8741 inside the same container and the server reaches
-# it via AIMEE_KB_API_URL=http://127.0.0.1:8741). Postgres (DB2 + pgvector) and
-# the embedder remain separate services — the combined image bundles the two
-# aimee binaries, not a database.
+# it via AIMEE_KB_API_URL=http://127.0.0.1:8741). The default combined image also
+# BUNDLES aimee-llm (CPU): the unified llama.cpp/Vulkan gateway (embed + rerank +
+# Tier-A synth) auto-starts inside the container and the kb/curator are pointed at
+# it automatically — so this stack is self-contained and needs only Postgres
+# (DB2 + pgvector) as an external service. The `embedder` + `llm` services below
+# are for the lean WITH_LLM=0 image (or to opt up to a GPU/external endpoint) and
+# are OFF by default behind the `external-llm` profile.
 #
 # Deploy the published images (built + pushed to ghcr on every merge to main):
 #   docker compose -f compose.combined.yaml pull
@@ -36,8 +40,14 @@ services:
       timeout: 5s
       retries: 5
 
+  # External embedder — OFF by default (the combined image bundles aimee-llm,
+  # which serves embeddings in-container). Enable it only with a lean WITH_LLM=0
+  # combined image, by selecting the profile and pointing the kb at it:
+  #   docker compose -f compose.combined.yaml --profile external-llm up -d
+  #   (and set AIMEE_BUNDLED_LLM=off + AIMEE_EMBEDDER_URL=http://embedder:8080).
   embedder:
     restart: unless-stopped
+    profiles: ["external-llm"]
     # Published image (built + pushed to ghcr on every merge to main). `docker
     # compose pull` fetches it; `up --build` rebuilds locally and tags it the same.
     # Override AIMEE_EMBEDDER_IMAGE to pin a version or use a fork/registry.
@@ -93,16 +103,21 @@ services:
       AIMEE_HOME: /var/lib/aimee
       AIMEE_DB1_URL: sqlite:///var/lib/aimee/aimee.db
       AIMEE_DB2_URL: postgresql://aimee:aimee@postgres:5432/aimee_shared
-      AIMEE_EMBEDDER_URL: http://embedder:8080
-      # Must match the embedder model's output dim (empty = config default 2560).
+      # Embed/rerank + curator synth: by default the entrypoint auto-points these
+      # at the in-container bundled aimee-llm gateway (127.0.0.1:8742, dim 1024) —
+      # no need to set AIMEE_EMBEDDER_URL / LLM_ENDPOINT here. Opt UP to a
+      # GPU/external endpoint by setting AIMEE_LLM_URL (then AIMEE_BUNDLED_LLM=auto
+      # leaves the bundled CPU gateway off). For a lean WITH_LLM=0 image, set
+      # AIMEE_BUNDLED_LLM=off and uncomment the external-llm wiring below.
+      AIMEE_LLM_URL: ${AIMEE_LLM_URL:-}
+      AIMEE_BUNDLED_LLM: ${AIMEE_BUNDLED_LLM:-auto}
+      # Override only for a GPU/external tier (the bundled CPU tier is 1024).
       AIMEE_EMBEDDING_DIM: ${AIMEE_EMBEDDING_DIM:-}
-      # Curator LLM (doc/code extraction, entity/claim passes). Defaults to the
-      # bundled `llm` sidecar (Gemma 3n E4B); BYO by setting LLM_ENDPOINT to your
-      # own OpenAI-compatible endpoint (and drop the `llm` service below). The
-      # curator runs in the background drain, so the server never blocks on it.
-      LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
       LLM_MODEL: ${LLM_MODEL:-gemma-3n-e4b}
       LLM_API_KEY: ${LLM_API_KEY:-}
+      # --- external-llm topology (WITH_LLM=0) only; uncomment + use the profile ---
+      # AIMEE_EMBEDDER_URL: http://embedder:8080
+      # LLM_ENDPOINT: ${LLM_ENDPOINT:-http://llm:8080/v1}
       AIMEE_SERVER_HTTP_BIND: "1"
       AIMEE_KB_HTTP_BIND: "1"
       AIMEE_KB_API_URL: http://127.0.0.1:8741
@@ -140,8 +155,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-      embedder:
-        condition: service_healthy
     healthcheck:
       test: ["CMD-SHELL",
              "curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8740/v1/health | grep -qE '^(200|401)$$'"]
@@ -153,17 +166,16 @@ services:
       - aimee-combined-home:/var/lib/aimee
       - aimee-combined-workspaces:/var/lib/aimee-workspaces
 
-  # Bundled local LLM for the curator's extraction passes (and any LLM_ENDPOINT
-  # consumer). On by default — Gemma 3n E4B (GGUF Q4), fetched once at first boot
-  # into the models volume (the multi-GB download is why start_period is long).
-  # The curator only calls it from the background drain, so a warming model never
-  # blocks ingest. BYO: point LLM_ENDPOINT at your own OpenAI-compatible endpoint
-  # and skip this service — `docker compose up --scale llm=0` (or remove it).
-  # Override LLAMA_ARG_HF_REPO to use a different/smaller GGUF.
+  # External curator LLM — OFF by default (the bundled aimee-llm gateway already
+  # serves synthesis at /v1). This standalone llama.cpp is only for the lean
+  # WITH_LLM=0 image or to BYO a different curator GGUF; enable with the
+  # `external-llm` profile and set LLM_ENDPOINT=http://llm:8080/v1. Gemma 3n E4B
+  # (GGUF Q4), fetched once at first boot (the multi-GB download is why
+  # start_period is long). Override LLAMA_ARG_HF_REPO for a different GGUF.
   llm:
     restart: unless-stopped
     image: ghcr.io/ggml-org/llama.cpp:server
-    profiles: ["curator-llm"]
+    profiles: ["external-llm"]
     environment:
       LLAMA_ARG_HF_REPO: ${CURATOR_LLM_HF_REPO:-ggml-org/gemma-4-E4B-it-GGUF:Q4_K_M}
       LLAMA_ARG_HOST: 0.0.0.0

--- a/deploy/container/combined-entrypoint.sh
+++ b/deploy/container/combined-entrypoint.sh
@@ -60,6 +60,7 @@ chown aimee:aimee "$AIMEE_HOME" "${AIMEE_WORKSPACES_DIR:-/var/lib/aimee-workspac
 
 kb_pid=""
 server_pid=""
+llm_pid=""
 
 . /usr/local/bin/webchat-lib.sh
 
@@ -69,9 +70,76 @@ shutdown() {
     # Best-effort teardown of all children; ignore errors during shutdown.
     [ -n "$server_pid" ] && kill "$server_pid" 2>/dev/null || true
     [ -n "$kb_pid" ] && kill "$kb_pid" 2>/dev/null || true
+    [ -n "$llm_pid" ] && kill "$llm_pid" 2>/dev/null || true
     webchat_stop
 }
 trap 'shutdown' TERM INT
+
+# --- bundled aimee-llm (CPU): auto-start + point the kb/server at it ---------
+# When this image was built WITH_LLM=1 it carries the unified llama.cpp/Vulkan
+# gateway (embed + rerank + Tier-A synth) and its baked GGUFs. We start it here
+# and repoint the kb's embed path + the curator synth at the in-container gateway
+# so the combined container is self-contained (no external embedder/llm).
+#
+# Operator endpoints WIN — an existing deploy that set AIMEE_LLM_URL,
+# AIMEE_EMBEDDER_URL or LLM_ENDPOINT (e.g. an external embedder, or opting up to a
+# GPU endpoint) is never silently overridden:
+#   AIMEE_BUNDLED_LLM=auto (default) — start the bundled gateway ONLY if the
+#       operator configured no endpoint; otherwise respect theirs.
+#   AIMEE_BUNDLED_LLM=on            — always start + use the bundled gateway,
+#       overriding any operator endpoint.
+#   AIMEE_BUNDLED_LLM=off           — never start it; use operator/legacy endpoints.
+GW_PORT="${AIMEE_LLM_PORT:-8742}"
+operator_llm=0
+if [ -n "${AIMEE_LLM_URL:-}" ] || [ -n "${AIMEE_EMBEDDER_URL:-}" ] || [ -n "${LLM_ENDPOINT:-}" ]; then
+    operator_llm=1
+fi
+start_bundled_llm=0
+if [ -x /opt/aimee/supervisor.sh ]; then
+    case "${AIMEE_BUNDLED_LLM:-auto}" in
+        on)   start_bundled_llm=1 ;;
+        off)  start_bundled_llm=0 ;;
+        auto) if [ "$operator_llm" = 0 ]; then start_bundled_llm=1; fi ;;
+        *)    log "AIMEE_BUNDLED_LLM='${AIMEE_BUNDLED_LLM:-}' unrecognized; treating as auto"
+              if [ "$operator_llm" = 0 ]; then start_bundled_llm=1; fi ;;
+    esac
+fi
+if [ "$operator_llm" = 1 ] && [ "$start_bundled_llm" = 0 ]; then
+    log "using operator-configured LLM endpoints (bundled aimee-llm not started)"
+fi
+if [ "$start_bundled_llm" = 1 ]; then
+    log "starting bundled aimee-llm (CPU) gateway on :$GW_PORT as user aimee"
+    # Set the runtime's lib + module paths INSIDE the child (after runuser's uid
+    # switch) via sh -c, not as inline vars on runuser: LD_LIBRARY_PATH is
+    # security-sensitive and can be dropped across a privilege change, and we must
+    # NOT put /opt/llama/lib on the aimee-server/kb load path anyway. The gateway's
+    # other settings (AIMEE_LLM_EMBED_URL/RERANK_URL/SYNTH_URL/RERANK_HEAD/...) are
+    # image ENV that runuser preserves like the kb/server's existing env.
+    runuser -u aimee -- sh -c \
+        'LD_LIBRARY_PATH=/opt/llama/lib:/opt/llama PYTHONPATH=/opt/aimee AIMEE_LLM_PORT="$1" exec /opt/aimee/supervisor.sh' \
+        aimee-llm "$GW_PORT" &
+    llm_pid=$!
+    # One-knob: drive the kb embed path (in-process http; the seeded config has no
+    # embedding_command) + reranking via the gateway, and the curator synth
+    # sidecar via its /v1. Default the CPU tier dim (operator-set dim wins). These
+    # exports reach the kb/server children below (runuser preserves the env).
+    export AIMEE_LLM_URL="http://127.0.0.1:${GW_PORT}"
+    export AIMEE_EMBEDDER_URL="http://127.0.0.1:${GW_PORT}"
+    export LLM_ENDPOINT="http://127.0.0.1:${GW_PORT}/v1"
+    : "${AIMEE_EMBEDDING_DIM:=1024}"
+    export AIMEE_EMBEDDING_DIM
+else
+    # Not starting the bundled gateway. Honor operator endpoints, deriving the
+    # ones they left unset from the AIMEE_LLM_URL one-knob; fall back to the legacy
+    # external defaults (embedder:8080 / llm:8080) so a lean WITH_LLM=0 image with
+    # the external-llm compose profile keeps working unchanged.
+    if [ -n "${AIMEE_LLM_URL:-}" ]; then
+        export AIMEE_EMBEDDER_URL="${AIMEE_EMBEDDER_URL:-$AIMEE_LLM_URL}"
+        export LLM_ENDPOINT="${LLM_ENDPOINT:-${AIMEE_LLM_URL}/v1}"
+    fi
+    export AIMEE_EMBEDDER_URL="${AIMEE_EMBEDDER_URL:-http://embedder:8080}"
+    export LLM_ENDPOINT="${LLM_ENDPOINT:-http://llm:8080/v1}"
+fi
 
 log "starting aimee-kb (http-port=$KB_HTTP_PORT) as user aimee"
 runuser -u aimee -- aimee-kb --http-port="$KB_HTTP_PORT" &
@@ -98,6 +166,34 @@ while :; do
     fi
     sleep 1
 done
+
+# If we started the bundled gateway, wait for it to load its models so the first
+# kb embed/search succeeds. Cold CPU load of multi-GB GGUFs is slow, so allow a
+# long window. FAIL-OPEN: if it doesn't come up we still bring up the server (the
+# container's contract) — embeddings/synth degrade until the gateway is healthy,
+# rather than the whole container failing. If the supervisor died, log and move on.
+if [ "$start_bundled_llm" = 1 ]; then
+    LLM_WAIT_SECONDS="${AIMEE_LLM_WAIT_SECONDS:-600}"
+    log "waiting up to ${LLM_WAIT_SECONDS}s for bundled aimee-llm /health on :$GW_PORT"
+    i=0
+    while :; do
+        if curl -fsS --max-time 3 "http://127.0.0.1:${GW_PORT}/health" >/dev/null 2>&1; then
+            log "bundled aimee-llm is healthy"
+            break
+        fi
+        if ! kill -0 "$llm_pid" 2>/dev/null; then
+            log "WARNING: bundled aimee-llm exited during startup; embeddings/synth will be unavailable until it is restarted (continuing fail-open)"
+            llm_pid=""
+            break
+        fi
+        i=$((i + 1))
+        if [ "$i" -ge "$LLM_WAIT_SECONDS" ]; then
+            log "WARNING: bundled aimee-llm not healthy within ${LLM_WAIT_SECONDS}s; continuing fail-open (embeddings/synth degraded)"
+            break
+        fi
+        sleep 1
+    done
+fi
 
 # Delegate-vault auto-provisioning. aimee-server seals operator-supplied delegate
 # API keys into its server-principal vault at startup, so a fresh deploy's

--- a/docs/proposals/done/kb-llm-endpoints-and-default-cpu.md
+++ b/docs/proposals/done/kb-llm-endpoints-and-default-cpu.md
@@ -1,6 +1,12 @@
 # Proposal: aimee-kb LLM endpoint config + zero-config default CPU container
 
-**Status:** IN PROGRESS — P1 (config surface) complete in #694; P2 (zero-config default CPU sibling) is the open deploy-tier residual.
+**Status:** done — P1 (config surface) shipped in #694; P2 (zero-config CPU LLM) delivered
+across all deploy topologies via the unified `aimee-llm` architecture, including the
+**combined image now bundling + auto-starting the aimee-llm CPU variant** (see the
+2026-06-28 reconciliation). P2's original kb-managed-sibling mechanism was **superseded** by
+`aimee-llm` as a first-class deploy unit.
+**Completed:** 2026-06-28
+**Moved from:** `docs/proposals/pending/kb-llm-endpoints-and-default-cpu.md`
 **Owner:** deploy/kb
 
 > **Reconciliation (2026-06-25).** **P1 — config surface — is complete and shipped in
@@ -19,6 +25,44 @@
 > environment that can exercise it (same class as the deployment/CI residual in
 > [autonomous-dev-execution-substrate.md](autonomous-dev-execution-substrate.md) §3). The
 > proposal stays in `pending/` until P2 lands.
+
+> **Reconciliation (2026-06-28) — closing out: P2's goal delivered, its mechanism
+> superseded.** The principle (the kb runs no model and calls a separate `aimee-llm`
+> container over HTTP for embed/rerank/synth) and the zero-config CPU UX are both **realized
+> in the shipped deploy** — but through a *different* mechanism than P2 sketched, so the
+> proposal is closed as done/superseded rather than waiting on the original P2 item:
+>
+> - **`aimee-llm` is now a first-class deploy unit, not a kb-managed sibling.** The unified
+>   Vulkan llama.cpp image (CPU + GPU tiers via `AIMEE_LLM_NGL`) replaced the old
+>   torch-embedder + standalone-llm split. The kb never spawns or manages it.
+> - **Zero-config CPU default — delivered in `deploy/compose/aimee.yaml`.** The base compose
+>   brings up an `aimee-llm` service defaulting to the **CPU** image
+>   (`${AIMEE_LLM_IMAGE:-ghcr.io/rakuensoftware/aimee-llm:cpu}`) and points the kb at it by
+>   default (`AIMEE_LLM_URL: ${AIMEE_LLM_URL:-http://aimee-llm:8742}`, dim 1024). The
+>   operator opts *up* to the GPU tier (2560-dim + `/dev/dri`) by layering
+>   `deploy/compose/aimee.gpu.yaml` — exactly the "opt up only" UX in this proposal.
+> - **SmoothNAS — `aimee-llm` is its own installable plugin** (`deploy/smoothnas/
+>   aimee-llm.plugin.yaml`), and `aimee-kb.plugin.yaml` exposes `AIMEE_LLM_URL` (+ the
+>   per-service overrides + `AIMEE_EMBEDDING_DIM`) as config knobs pointed at it. The
+>   plugin model installs `aimee-llm` as a peer rather than having the kb conditionally
+>   start a CPU sibling — the same outcome, owned by the deploy unit, not the kb.
+> - **Combined all-in-one image — bundles + auto-starts the aimee-llm CPU variant.**
+>   `Dockerfile.combined` (`WITH_LLM=1`, default on) COPYs the llama.cpp/Vulkan runtime +
+>   the unified gateway + baked GGUFs from the prebuilt `aimee-llm-cpu` image;
+>   `combined-entrypoint.sh` auto-starts the gateway and points the kb embed path + the
+>   curator synth at `127.0.0.1:8742` (dim 1024) — so the default combined container is
+>   self-contained (only Postgres external). Operator endpoints win (an external
+>   `AIMEE_LLM_URL`/`AIMEE_EMBEDDER_URL`/`LLM_ENDPOINT` is never overridden;
+>   `AIMEE_BUNDLED_LLM=off` for the lean image). amd64-only (the llama.cpp runtime is the
+>   x64 Vulkan binary); the arm64 combined image stays lean + external.
+> - **Validated live:** the CPU tier end-to-end on pve `.253` (CT 150) and the GPU split on
+>   `.254` (`AIMEE_LLM_URL=http://10.100.0.1:8742`, 2560-dim). The combined-image bundling
+>   ships in the same change as this close-out; its runtime is exercised by the `:testing`
+>   combined image on deploy (the image build runs in `publish-testing.yml`).
+>
+> Net: every part of this proposal's goal is in `testing`; the only "residual" was an
+> implementation mechanism that the unified-`aimee-llm` architecture made unnecessary. No
+> outstanding work — filed to `done/`.
 
 ## Principle
 


### PR DESCRIPTION
## What

Makes the **combined** aimee image (`aimee-server-kb`) **ship and auto-start the aimee-llm CPU variant**, so the container is self-contained for embeddings + reranking + Tier-A synthesis with zero operator config (only Postgres external). This delivers P2 of the **kb-llm-endpoints-and-default-cpu** proposal for the combined topology and files that proposal to `done/`.

### Image / runtime
- **`Dockerfile.combined`** — `WITH_LLM=1` (default on, mirrors `WITH_WEBCHAT`) + `AIMEE_LLM_CPU_IMAGE`; lazy multi-stage `COPY --from` the prebuilt `aimee-llm-cpu` image (llama.cpp/Vulkan runtime + unified gateway + baked GGUFs). `WITH_LLM=0` stays byte-lean (no pull). Conditional Vulkan/numpy/bash deps; `render`/`video` groups for the GPU opt-up; **mirrors the aimee-llm gateway ENV** (`AIMEE_LLM_RERANK_HEAD`/`SYNTH_URL`/… — without them the gateway 503s on /rerank and /v1/chat); long HEALTHCHECK start-period for cold model load.
- **`combined-entrypoint.sh`** — **operator endpoints win** (`AIMEE_LLM_URL`/`AIMEE_EMBEDDER_URL`/`LLM_ENDPOINT`; `AIMEE_BUNDLED_LLM=auto|on|off`); starts the supervisor as user `aimee` with `LD_LIBRARY_PATH`/`PYTHONPATH` set **inside** the child (post-uid-switch, robust to `runuser` env stripping); points the kb embed path + curator synth at `127.0.0.1:8742` (dim 1024); fail-open health wait; teardown on shutdown.
- **`compose.combined.yaml`** — self-contained by default; external embedder/llm behind the `external-llm` profile.

### CI
- `publish-testing.yml` (amd64): combined leg bundles via `aimee-llm-cpu:testing` + disk headroom.
- `publish-images.yml` (release): **amd64 bundles, arm64 stays lean** (the llama.cpp runtime is the x64 Vulkan binary); the `COPY --from=:latest` ordering caveat is documented (digest-pinned ordering is a noted follow-up).

## Review
- **Design roundtable** (6 panelists): blocking items on operator-override safety, build ordering, and Vulkan-as-unprivileged-user — all addressed.
- **Self-review** caught + fixed two real bugs: the missing gateway ENV (rerank/synth would 503) and `LD_LIBRARY_PATH` across `runuser`.
- Focused entrypoint roundtable triaged — remaining flags were snippet-context false positives (verified against the full file).

## Validation gap (important)
There is **no Docker on the dev host**, and the combined image isn't built in pre-merge CI — it's built by **`publish-testing.yml` on push to `testing`**. So the image build + container runtime are validated **post-merge** (a failed build won't overwrite the existing `:testing` image). Static checks pass: `sh -n`, YAML parse, proposal reconcile/links gates.