### PR TITLE
feat(kb): R2c — fold build-declared deps into cross-repo resolver output

### DIFF
--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -4940,10 +4940,15 @@ static void print_index_deps(cJSON *resp)
       cJSON *sc = cJSON_GetObjectItemCaseSensitive(d, "symbol_count");
       cJSON *cc = cJSON_GetObjectItemCaseSensitive(d, "call_site_count");
       cJSON *ex = cJSON_GetObjectItemCaseSensitive(d, "example");
-      printf("  %s -> %s  %-7s  (%d symbol(s), %d call site(s))\n", json_str(d, "caller_repo"),
+      const char *etype = json_str(d, "evidence_type");
+      const char *bkind = json_str(d, "build_kind");
+      char evtag[48] = "";
+      if (etype[0] && strcmp(etype, "symbol_resolved") != 0)
+         snprintf(evtag, sizeof(evtag), "  [%s%s%s]", etype, bkind[0] ? ":" : "", bkind);
+      printf("  %s -> %s  %-7s  (%d symbol(s), %d call site(s))%s\n", json_str(d, "caller_repo"),
              json_str(d, "definer_repo"), json_str(d, "tier"),
              cJSON_IsNumber(sc) ? (int)sc->valuedouble : 0,
-             cJSON_IsNumber(cc) ? (int)cc->valuedouble : 0);
+             cJSON_IsNumber(cc) ? (int)cc->valuedouble : 0, evtag);
       if (ex && json_str(ex, "symbol")[0])
       {
          cJSON *line = cJSON_GetObjectItemCaseSensitive(ex, "line");

--- a/src/db2/cross_repo_deps.c
+++ b/src/db2/cross_repo_deps.c
@@ -300,6 +300,15 @@ static xrepo_dep_edge_t *edge_find_or_add(edge_acc_t *a, const char *caller, con
    return E;
 }
 
+/* Find an existing edge without adding (recall R2c merge). NULL if absent. */
+static xrepo_dep_edge_t *edge_find(edge_acc_t *a, const char *caller, const char *definer)
+{
+   for (size_t i = 0; i < a->n; i++)
+      if (strcmp(a->e[i].caller_repo, caller) == 0 && strcmp(a->e[i].definer_repo, definer) == 0)
+         return &a->e[i];
+   return NULL;
+}
+
 /* ---- orchestration ------------------------------------------------------- */
 
 /* Shared, read-only context for the per-symbol flush. */
@@ -808,6 +817,85 @@ int canonical_index_cross_repo_deps(const char *project, const xrepo_deps_opts_t
                 dcount, dexp, ndef, corig);
    aimee_pg_finalize(cq);
    free_descs(&descs);
+
+   /* R2c: merge build-DECLARED deps (recall-recovery §2.6) as a SEPARATE evidence
+    * class — read cross_repo_build_dep for this caller (OUT direction) and fold into
+    * the same (caller, definer) output. NOT via the H1 symbol-route gate (a build
+    * declaration is its own evidence). Merge table: symbol+build(same definer) ->
+    * "both", HIGH if the build dep is high-parse; build-only -> MEDIUM (high-parse) /
+    * LOW (low-parse), subject to min_tier. A pair with multiple build declarations
+    * takes the strongest tier. */
+   {
+      char berr[CRD_ERR] = "";
+      aimee_pg_stmt_t *bd = aimee_pg_prepare(
+          conn,
+          "SELECT definer_project, build_kind, parse_confidence FROM cross_repo_build_dep "
+          "WHERE caller_project = ?1 "
+          "ORDER BY definer_project, (parse_confidence = 'high') DESC, build_kind",
+          berr, sizeof(berr));
+      if (bd)
+      {
+         aimee_pg_bind_text(bd, "?1", project);
+         while (aimee_pg_step(bd, berr, sizeof(berr)) == AIMEE_PG_ROW)
+         {
+            const char *def = aimee_pg_column_text(bd, 0);
+            const char *bkind = aimee_pg_column_text(bd, 1);
+            const char *pconf = aimee_pg_column_text(bd, 2);
+            if (!def || !def[0])
+               continue;
+            int high = pconf && strcmp(pconf, "high") == 0;
+            xrepo_tier_t bt = high ? XREPO_TIER_MEDIUM : XREPO_TIER_LOW;
+            xrepo_dep_edge_t *E = edge_find(&acc, project, def);
+            if (E)
+            {
+               /* An edge already exists for this pair. It carries symbol evidence iff
+                * its evidence_type is still pristine (untouched symbol edge) or already
+                * "both"; "build_declared" means a prior build row created it with no
+                * symbol corroboration. Promotion must be ORDER-INDEPENDENT: a high-parse
+                * build row promotes a symbol-bearing pair to HIGH whether it is seen
+                * before or after a low-parse row for the same pair (§2.6). */
+               int has_symbol = (E->evidence_type[0] == 0) || strcmp(E->evidence_type, "both") == 0;
+               if (has_symbol)
+               {
+                  /* symbol + build -> both; high-parse promotes to HIGH. build_kind takes
+                   * the first row in the ORDER BY (high-parse first, then build_kind), i.e.
+                   * the highest-parse declaration's kind — deterministic provenance for the
+                   * representative build edge. */
+                  snprintf(E->evidence_type, sizeof(E->evidence_type), "both");
+                  if (!E->build_kind[0] && bkind)
+                     snprintf(E->build_kind, sizeof(E->build_kind), "%s", bkind);
+                  if (high && E->tier < XREPO_TIER_HIGH)
+                     E->tier = XREPO_TIER_HIGH;
+               }
+               else
+               {
+                  /* another build declaration for an already-build-only edge -> keep the
+                   * strongest tier. */
+                  if (bt > E->tier && bt >= ctx.min_tier)
+                     E->tier = bt;
+               }
+            }
+            else if (bt >= ctx.min_tier)
+            {
+               xrepo_dep_edge_t *N = edge_find_or_add(&acc, project, def);
+               if (N && N->tier == XREPO_TIER_NONE)
+               {
+                  N->tier = bt;
+                  snprintf(N->evidence_type, sizeof(N->evidence_type), "build_declared");
+                  if (bkind)
+                     snprintf(N->build_kind, sizeof(N->build_kind), "%s", bkind);
+                  snprintf(N->repo_set_hash, sizeof(N->repo_set_hash), "%s", repo_set_hash);
+                  N->resolver_version = XREPO_RESOLVER_VERSION;
+               }
+            }
+         }
+         aimee_pg_finalize(bd);
+      }
+   }
+   /* default evidence_type for pure symbol-resolved edges (untouched by the merge). */
+   for (size_t i = 0; i < acc.n; i++)
+      if (!acc.e[i].evidence_type[0])
+         snprintf(acc.e[i].evidence_type, sizeof(acc.e[i].evidence_type), "symbol_resolved");
 
    *out_edges = acc.e;
    *out_n = acc.n;

--- a/src/db2/cross_repo_deps.h
+++ b/src/db2/cross_repo_deps.h
@@ -43,6 +43,12 @@ typedef struct
    char example_symbol[128];
    char example_file[MAX_PATH_LEN];
    int example_line;
+   /* recall R2c: evidence class — "symbol_resolved" (the H1-H7 symbol path),
+    * "build_declared" (a build dep: FetchContent/submodule/Cargo, no symbol
+    * corroboration), or "both". build_kind is the declaration kind for a build
+    * edge (fetchcontent|submodule|manifest), "" for symbol-only. */
+   char evidence_type[16];
+   char build_kind[16];
    /* version stamp (§4.1): identifies the inputs that produced this edge. */
    char repo_set_hash[24];
    int distinctiveness_v;

--- a/src/kb/http/kb_http_code.c
+++ b/src/kb/http/kb_http_code.c
@@ -677,6 +677,12 @@ int handle_get_code_cross_repo_deps(const char *query_string, char *out_buf, int
       cJSON_AddNumberToObject(e, "call_site_count", edges[i].call_site_count);
       cJSON_AddBoolToObject(e, "import_corroborated", edges[i].import_corroborated ? 1 : 0);
       cJSON_AddBoolToObject(e, "export_corroborated", edges[i].export_corroborated ? 1 : 0);
+      /* recall R2c: evidence class (symbol_resolved|build_declared|both) + build_kind */
+      cJSON_AddStringToObject(e, "evidence_type",
+                              edges[i].evidence_type[0] ? edges[i].evidence_type
+                                                        : "symbol_resolved");
+      if (edges[i].build_kind[0])
+         cJSON_AddStringToObject(e, "build_kind", edges[i].build_kind);
       cJSON *ex = cJSON_AddObjectToObject(e, "example");
       if (ex)
       {

--- a/src/tests/test_cross_repo_deps_orch.c
+++ b/src/tests/test_cross_repo_deps_orch.c
@@ -625,6 +625,142 @@ static void test_kind_eligibility_and_vendored_ceiling(void)
    printf("ok\n");
 }
 
+/* R2c: build-declared deps merge into the deps output as a separate evidence class.
+ * build-only (no symbol) -> MEDIUM build_declared (high-parse) / dropped at MEDIUM
+ * min_tier (low-parse); build + an existing symbol edge -> both, promoted to HIGH. */
+static void test_build_declared_merge(void)
+{
+   printf("test_build_declared_merge... ");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('bdo-app','/bo','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('bdo-lib','/bl','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('bdo-low','/bw','t','trusted')");
+   /* build-only high-parse -> MEDIUM build_declared; low-parse -> LOW (excluded at MEDIUM). */
+   X("INSERT INTO cross_repo_build_dep (caller_project,definer_project,build_kind,parse_confidence,"
+     "evidence) VALUES ('bdo-app','bdo-lib','fetchcontent','high','https://h/o/bdo-lib.git')");
+   X("INSERT INTO cross_repo_build_dep (caller_project,definer_project,build_kind,parse_confidence,"
+     "evidence) VALUES ('bdo-app','bdo-low','submodule','low','${VAR}/bdo-low.git')");
+
+   xrepo_deps_opts_t opts = {.direction = XREPO_DIR_OUT, .min_tier = XREPO_TIER_MEDIUM};
+   xrepo_dep_edge_t *edges = NULL;
+   size_t n = 0;
+   int trunc = 0;
+   assert(canonical_index_cross_repo_deps("bdo-app", &opts, &edges, &n, &trunc) == 0);
+   int lib = 0, low = 0;
+   for (size_t i = 0; i < n; i++)
+   {
+      if (strcmp(edges[i].definer_repo, "bdo-lib") == 0)
+      {
+         lib = 1;
+         assert(edges[i].tier == XREPO_TIER_MEDIUM);
+         assert(strcmp(edges[i].evidence_type, "build_declared") == 0);
+         assert(strcmp(edges[i].build_kind, "fetchcontent") == 0);
+      }
+      if (strcmp(edges[i].definer_repo, "bdo-low") == 0)
+         low = 1;
+   }
+   assert(lib && !low); /* high-parse emitted MEDIUM; low-parse excluded at min_tier MEDIUM */
+   free(edges);
+
+   /* both: seed a self-contained symbol-resolved edge (bdb-app -> bdb-lib via a
+    * distinctive imported symbol, like seed_moonlight) so the merge has a symbol
+    * edge to fold into; adding a high-parse build dep marks it evidence_type=both
+    * and promotes the tier to HIGH. (Self-contained rather than reusing moonlight,
+    * whose seeded edge does not survive intervening tests' shared-shim state.) */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('bdb-app','/ba','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('bdb-lib','/bb','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[160];
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at) SELECT id,'src/f%d.cpp','t' FROM "
+               "projects WHERE name='bdb-app'",
+               i);
+      X(sql);
+   }
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'include/Bdb.h','t' FROM projects "
+     "WHERE name='bdb-lib'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'src/bdb.c','t' FROM projects WHERE "
+     "name='bdb-lib'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'BdbConnectSession','definition' FROM files "
+     "WHERE path='src/bdb.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'BdbConnectSession' FROM files WHERE "
+     "path='src/bdb.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Bdb.h' FROM files WHERE "
+     "path='src/f0.cpp'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'BdbConnectSession' FROM files WHERE "
+     "path='src/f0.cpp'");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('bdb-app','bdb-lib','import_header','medium','Bdb.h')");
+   X("INSERT INTO cross_repo_build_dep (caller_project,definer_project,build_kind,parse_confidence,"
+     "evidence) VALUES ('bdb-app','bdb-lib','submodule','high','https://h/o/bdb-lib.git')");
+   edges = NULL;
+   assert(canonical_index_cross_repo_deps("bdb-app", &opts, &edges, &n, &trunc) == 0);
+   int found = 0;
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(edges[i].definer_repo, "bdb-lib") == 0)
+      {
+         found = 1;
+         assert(edges[i].tier == XREPO_TIER_HIGH);
+         assert(strcmp(edges[i].evidence_type, "both") == 0);
+         assert(strcmp(edges[i].build_kind, "submodule") == 0);
+      }
+   assert(found);
+   free(edges);
+
+   /* order-independence regression: a symbol-bearing pair (bdo2-app -> bdo2-lib)
+    * with a low-parse build row inserted BEFORE a high-parse one must still reach
+    * HIGH (the high-parse row promotes regardless of merge-iteration order). */
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES "
+     "('bdo2-app','/o2a','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES "
+     "('bdo2-lib','/o2b','t','trusted')");
+   for (int i = 0; i < 5; i++)
+   {
+      char sql[160];
+      snprintf(sql, sizeof(sql),
+               "INSERT INTO files (project_id,path,scanned_at) SELECT id,'src/g%d.cpp','t' FROM "
+               "projects WHERE name='bdo2-app'",
+               i);
+      X(sql);
+   }
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'include/Bdo2.h','t' FROM projects "
+     "WHERE name='bdo2-lib'");
+   X("INSERT INTO files (project_id,path,scanned_at) SELECT id,'src/bdo2.c','t' FROM projects "
+     "WHERE "
+     "name='bdo2-lib'");
+   X("INSERT INTO terms (file_id,name,kind) SELECT id,'Bdo2OpenChannel','definition' FROM files "
+     "WHERE path='src/bdo2.c'");
+   X("INSERT INTO file_exports (file_id,name) SELECT id,'Bdo2OpenChannel' FROM files WHERE "
+     "path='src/bdo2.c'");
+   X("INSERT INTO file_imports (file_id,name) SELECT id,'Bdo2.h' FROM files WHERE "
+     "path='src/g0.cpp'");
+   X("INSERT INTO code_calls (file_id,callee) SELECT id,'Bdo2OpenChannel' FROM files WHERE "
+     "path='src/g0.cpp'");
+   X("INSERT INTO cross_repo_route (caller_project,definer_project,kind,confidence,evidence) "
+     "VALUES ('bdo2-app','bdo2-lib','import_header','medium','Bdo2.h')");
+   /* low-parse FIRST, high-parse SECOND (distinct build_kind so both rows persist). */
+   X("INSERT INTO cross_repo_build_dep (caller_project,definer_project,build_kind,parse_confidence,"
+     "evidence) VALUES ('bdo2-app','bdo2-lib','fetchcontent','low','${VAR}/bdo2-lib.git')");
+   X("INSERT INTO cross_repo_build_dep (caller_project,definer_project,build_kind,parse_confidence,"
+     "evidence) VALUES ('bdo2-app','bdo2-lib','submodule','high','https://h/o/bdo2-lib.git')");
+   edges = NULL;
+   assert(canonical_index_cross_repo_deps("bdo2-app", &opts, &edges, &n, &trunc) == 0);
+   found = 0;
+   for (size_t i = 0; i < n; i++)
+      if (strcmp(edges[i].definer_repo, "bdo2-lib") == 0)
+      {
+         found = 1;
+         assert(edges[i].tier == XREPO_TIER_HIGH);
+         assert(strcmp(edges[i].evidence_type, "both") == 0);
+         /* ORDER BY parse_confidence DESC -> the high-parse 'submodule' row wins
+          * build_kind over the earlier-inserted low-parse 'fetchcontent' row. */
+         assert(strcmp(edges[i].build_kind, "submodule") == 0);
+      }
+   assert(found);
+   free(edges);
+   printf("ok\n");
+}
+
 int main(void)
 {
    test_parse_module_id();
@@ -637,6 +773,7 @@ int main(void)
    test_vendor_canonical_preference();
    test_vendor_canonical_edge_cases();
    test_kind_eligibility_and_vendored_ceiling();
+   test_build_declared_merge();
    printf("cross_repo_deps_orch: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Recall-recovery slice **R2c** (the resolver merge that lifts recall). `canonical_index_cross_repo_deps()` now folds `cross_repo_build_dep` rows (populated by R2b in the curator drain) into its OUT-direction edge list as a **separate evidence class** per the design §2.6 (docs/proposals/pending/cross-repo-recall-recovery.md).

## Merge table (§2.6)

- existing **symbol** edge + a **build** dep for the same (caller,definer) → `evidence_type="both"`, promoted to **HIGH** if the build dep is high-parse (order-independent w.r.t. low/high-parse row processing).
- **build-only** (no symbol edge) → **MEDIUM** (high-parse) / **LOW** (low-parse), subject to `min_tier`.
- multiple build declarations on a pair → strongest tier; `build_kind` provenance is deterministic (`ORDER BY` high-parse first).
- pure symbol edges default to `evidence_type="symbol_resolved"`.

A build declaration is its own evidence, so the merge **bypasses the H1 structural-route gate**. The merge is OUT-direction only (the function already returns empty for non-OUT before this point).

## Surfacing

- `evidence_type` + `build_kind` added to the kb `/v1/code/cross-deps` JSON.
- CLI `aimee index deps` human printer shows a `[evidence_type:build_kind]` tag (omitted for plain symbol_resolved edges).

## Tests

New orch tests in `test_cross_repo_deps_orch.c`: build-only MEDIUM/LOW `min_tier` gating, symbol+build "both" HIGH promotion (with build_kind assertion), and an **order-independence regression** (low-parse row inserted before high-parse still reaches HIGH).

## Review

Roundtable-reviewed (review mode): round 1 found one blocking order-dependent-promotion bug (fixed by restructuring the merge so any high-parse row promotes a symbol-bearing pair to HIGH regardless of row order); round 2 returned 0 blocking. The deterministic `build_kind` ORDER BY + assertions address the round-2 provenance suggestion.