### PR TITLE
fix(kb): collect repo-root .gitmodules on the git-tracked path (recall §2.2)

### DIFF
--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -435,15 +435,19 @@ int code_default_branch_changed(const char *stored_sha, const char *current_sha)
    return strcmp(stored_sha, current_sha) != 0;
 }
 
-/* Skip a tracked path whose any component is a VCS/build/vendor/hidden dir, so a
- * checked-in node_modules/vendor tree is filtered exactly like the worktree walk
- * filters it (code_dir_skip). */
+/* Skip a tracked path whose any DIRECTORY component is a VCS/build/vendor/hidden
+ * dir, so a checked-in node_modules/vendor tree is filtered exactly like the
+ * worktree walk filters it (code_dir_skip on dirs only). The FINAL component (the
+ * filename) is NOT dir-skipped: its suitability is decided by code_file_wanted.
+ * code_dir_skip rejects any leading-'.' name, so testing it against the filename
+ * would wrongly drop a wanted dotfile manifest (e.g. a repo-root .gitmodules),
+ * diverging from the worktree walk which collects it (recall §2.2). */
 static int code_path_skipped(const char *rel)
 {
    const char *seg = rel;
    for (const char *p = rel;; p++)
    {
-      if (*p == '/' || *p == '\0')
+      if (*p == '/')
       {
          size_t len = (size_t)(p - seg);
          char comp[256];
@@ -454,10 +458,10 @@ static int code_path_skipped(const char *rel)
             if (code_dir_skip(comp))
                return 1;
          }
-         if (*p == '\0')
-            break;
          seg = p + 1;
       }
+      else if (*p == '\0')
+         break; /* trailing segment = filename; gated by code_file_wanted, not dir-skip */
    }
    return 0;
 }

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -265,7 +265,16 @@ static void test_build_manifests_collected_git(void)
    git("config user.name t");
    write_file("CMakeLists.txt", "FetchContent_Declare(dep GIT_REPOSITORY x)");
    write_file("src/a.cpp", "int a(){return 0;}");
+   /* recall §2.2 regression: a repo-root .gitmodules is a wanted manifest whose
+    * filename starts with '.'. The git-tracked path must collect it (the worktree
+    * path already does) — code_path_skipped must not dir-skip the FINAL component. */
+   write_file(".gitmodules", "[submodule \"x\"]\n\turl = https://h/o/dep.git\n");
    write_file("build/CMakeLists.txt", "generated");
+   /* a checked-in vendor/ tree is still dir-skipped on the git path. */
+   write_file("vendor/dep/CMakeLists.txt", "FetchContent_Declare(y GIT_REPOSITORY z)");
+   /* a leading-dot NON-final directory component is still dir-skipped: only the
+    * trailing filename is exempt from code_dir_skip, not interior hidden dirs. */
+   write_file(".config/dep.cmake", "find_package(q)");
    git("add -A -f"); /* -f: build/ may be gitignored in some setups; force-track for the test */
    git("commit -qm c");
 
@@ -273,7 +282,10 @@ static void test_build_manifests_collected_git(void)
    code_collect_files_cb(g_root, rec_cb, NULL);
    assert(has("CMakeLists.txt"));
    assert(has("src/a.cpp"));
-   assert(!has("build/CMakeLists.txt")); /* build-output dir excluded on the git path too */
+   assert(has(".gitmodules"));                /* dotfile manifest collected on the git path */
+   assert(!has("build/CMakeLists.txt"));      /* build-output dir excluded on the git path too */
+   assert(!has("vendor/dep/CMakeLists.txt")); /* vendor dir still dir-skipped */
+   assert(!has(".config/dep.cmake")); /* interior hidden dir still dir-skipped (non-final) */
    printf("  test_build_manifests_collected_git: ok\n");
 }
 


### PR DESCRIPTION
## What

A **live §9 measurement** on the .254 corpus (after deploying R2a/R2b/R2c/R3a + a full `--force` re-scan) showed:
- `cross_repo_identity`: **0 → 77 CMake identities** (the §4 "0 CMake identities" was just pre-R2a non-collection — now resolved).
- `cross_repo_build_dep`: **only 1 row**.
- `gitmodules=0` — **ZERO `.gitmodules` files indexed corpus-wide**, despite moonlight-qt, Sunshine, gow, moonlight-common-c etc. tracking `.gitmodules` declaring corpus↔corpus submodules (moonlight-qt → moonlight-common-c; Sunshine → inputtino + moonlight-common-c).

Git submodules are the **dominant** corpus↔corpus build link, so the build-declared-edge pass (R2) saw almost nothing: the #1 recall regression.

## Root cause

`code_collect.c` has two collection sites. The **worktree walk** collects `.gitmodules` (skips only `.`/`..`, then gates files by `code_file_wanted`, which accepts `.gitmodules` via `code_build_manifest`). The **git-tracked path** ran every `ls-tree` path component — **including the trailing filename** — through `code_path_skipped()` → `code_dir_skip()`, which rejects any leading-`.` name (intended for hidden **directories** like `.git`/`.aimee`). So a repo-root `.gitmodules` was dropped on the git path, diverging from the worktree path.

## Fix

`code_path_skipped()` now applies `code_dir_skip()` only to **directory** components (segments terminated by `/`), never the trailing filename — whose suitability is already decided by `code_file_wanted()`. Interior hidden / `build/` / `vendor/` / `node_modules/` dirs are still skipped.

## Test

`test_build_manifests_collected_git` now seeds a repo-root `.gitmodules` (must be collected), a `vendor/dep/CMakeLists.txt` and an interior `.config/dep.cmake` (both still dir-skipped), alongside the existing `build/` skip.

## Review

Roundtable-reviewed: **converged, 0 blocking** (round 2). Added the suggested interior-hidden-dir test case post-convergence. A pre-existing ≥256-byte-component bypass in `code_path_skipped` was flagged as inherited/out-of-scope.