### PR TITLE
fix(kb): ingest repo .gitmodules on the thin-client push path (recall §2.2)

### DIFF
--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -457,6 +457,54 @@ static int ci_path_has_hidden_component(const char *path)
    return 0;
 }
 
+/* Build manifests whose filename legitimately starts with '.' (currently only
+ * .gitmodules — git submodule declarations). A thin-client push sends these (the
+ * client's code_file_wanted accepts them); the kb must not drop them as "hidden"
+ * the way it drops files inside .git/.aimee/etc. dirs (recall §2.2). */
+static int ci_is_dotfile_manifest(const char *component, size_t len)
+{
+   return len == 11 && strncmp(component, ".gitmodules", 11) == 0;
+}
+
+/* Like ci_path_has_hidden_component, but a hidden FINAL (filename) component is
+ * allowed when it is a wanted dotfile build manifest (ci_is_dotfile_manifest).
+ * For thin-client file ingest: the client already gated the file set, and a
+ * .gitmodules must be ingested; interior hidden DIRECTORY components (.git/,
+ * .github/, ...) are still rejected. The exemption is for the FINAL component at
+ * ANY depth (a/b/.gitmodules), not just repo-root — the client gates which paths
+ * it sends, so the kb need not second-guess depth. (Leading slashes are tolerated
+ * for parity with ci_path_has_hidden_component, though the sole caller already
+ * rejects a leading '/'.) */
+static int ci_path_ingest_excluded(const char *path)
+{
+   const char *p = path;
+   while (*p == '/')
+      p++;
+
+   const char *start = p;
+   for (;;)
+   {
+      if (*p == '/' || *p == '\0')
+      {
+         size_t len = (size_t)(p - start);
+         int is_final = (*p == '\0');
+         if (ci_path_component_is_hidden(start, len) &&
+             !(is_final && ci_is_dotfile_manifest(start, len)))
+            return 1;
+         if (is_final)
+            break;
+         p++;
+         start = p;
+      }
+      else
+      {
+         p++;
+      }
+   }
+
+   return 0;
+}
+
 static int ci_file_list_append(ci_file_list_t *list, const char *path)
 {
    if (list->count >= list->max)
@@ -1099,7 +1147,7 @@ int canonical_index_scan_files(const char *name, const char *root_label,
    {
       const char *rel = files[i].rel_path;
       const char *content = files[i].content;
-      if (!rel || !rel[0] || rel[0] == '/' || ci_path_has_hidden_component(rel) || !content)
+      if (!rel || !rel[0] || rel[0] == '/' || ci_path_ingest_excluded(rel) || !content)
          continue;
 
       inspected++;

--- a/src/tests/test_index.c
+++ b/src/tests/test_index.c
@@ -232,6 +232,49 @@ static void seed_stale_hidden_project_row(const char *root)
    assert(aimee_pg_exec(db2_conn(), sql, err, sizeof(err)) == 0);
 }
 
+/* Count of files rows for (project, path). Used to assert ingest of a file
+ * (.gitmodules) that has no extractable symbols, so index_find can't see it.
+ * Returns -1 on a DB/step failure so a schema regression fails loudly rather
+ * than masquerading as "row absent". */
+static int file_row_count(const char *project, const char *path)
+{
+   char err[256] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(db2_conn(),
+                        "SELECT COUNT(*) FROM files f JOIN projects p ON p.id = f.project_id "
+                        "WHERE p.name = ?1 AND f.path = ?2",
+                        err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", path);
+   int n = (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW) ? aimee_pg_column_int(st, 0) : -1;
+   aimee_pg_finalize(st);
+   return n;
+}
+
+/* The stored content body of (project, path) into out (empty if absent/error). */
+static void file_content(const char *project, const char *path, char *out, size_t cap)
+{
+   out[0] = '\0';
+   char err[256] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(db2_conn(),
+                        "SELECT fc.content FROM file_contents fc JOIN files f ON f.id = fc.file_id "
+                        "JOIN projects p ON p.id = f.project_id WHERE p.name = ?1 AND f.path = ?2",
+                        err, sizeof(err));
+   if (!st)
+      return;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", path);
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_ROW)
+   {
+      const char *c = aimee_pg_column_text(st, 0);
+      snprintf(out, cap, "%s", c ? c : "");
+   }
+   aimee_pg_finalize(st);
+}
+
 int main(void)
 {
    printf("index: ");
@@ -446,6 +489,38 @@ int main(void)
       snprintf(cmd, sizeof(cmd), "rm -rf %s", canonical);
       (void)system(cmd);
       free(canonical);
+   }
+
+   /* --- thin-client ingest (scan_files): a repo-root .gitmodules is INGESTED
+    * (recall §2.2), while a hidden non-manifest dotfile and a file inside a hidden
+    * directory are still excluded. --- */
+   {
+      const char *gitmod_body = "[submodule \"dep\"]\n\turl = https://h/o/dep.git\n";
+      canonical_index_file_input_t inputs[] = {
+          {"src/app.c", "void app_entry(void) {}\n"},
+          {".gitmodules", gitmod_body},
+          {".bashrc", "export X=1\n"},                /* hidden non-manifest dotfile */
+          {".github/workflows/ci.yml", "name: ci\n"}, /* file inside a hidden dir */
+          {".gitmodules/payload.txt", "x\n"},         /* .gitmodules as an interior DIR */
+      };
+      int inspected = 0;
+      int scanned = canonical_index_scan_files(
+          "pushproj", "remote", inputs, (int)(sizeof(inputs) / sizeof(inputs[0])), 1, &inspected);
+      /* canonical_index_scan_files upserts the project; of 5 inputs only the 2
+       * non-excluded (src/app.c + .gitmodules) are counted (inspected is post-filter). */
+      assert(inspected == 2);
+      assert(scanned == 2);
+      assert(file_row_count("pushproj", ".gitmodules") == 1); /* dotfile manifest ingested */
+      assert(file_row_count("pushproj", "src/app.c") == 1);
+      assert(file_row_count("pushproj", ".bashrc") == 0); /* hidden non-manifest excluded */
+      assert(file_row_count("pushproj", ".github/workflows/ci.yml") == 0); /* hidden dir excluded */
+      assert(file_row_count("pushproj", ".gitmodules/payload.txt") ==
+             0); /* interior dir excluded */
+      /* the .gitmodules body must survive ingest byte-for-byte (R2b's crb_gitmodules
+       * parses url= lines out of it). */
+      char body[256];
+      file_content("pushproj", ".gitmodules", body, sizeof(body));
+      assert(strcmp(body, gitmod_body) == 0);
    }
 
    /* Cleanup */


### PR DESCRIPTION
## What

KB-side twin of #852. After the client collector was fixed to **send** `.gitmodules`, a re-scan still showed `gitmodules=0` because the **KB drops them on ingest**: the thin client pushes to `/v1/index/ingest` → `canonical_index_scan_files()`, which rejected any path with a hidden component via `ci_path_has_hidden_component()`. A repo-root `.gitmodules`'s filename starts with `.`, so it was discarded — the same class of bug on the kb side. Submodules are the dominant corpus↔corpus build link, so this kept build-declared-edge recall near zero.

## Fix

A new `ci_path_ingest_excluded()` used **only** at the thin-client file-ingest site. It rejects any path with a hidden **directory** component (`.git/`, `.github/`, `.aimee/`, …) but **allows a hidden final (filename) component** when it is a wanted dotfile build manifest (`ci_is_dotfile_manifest` → currently exactly `.gitmodules`). The generic `ci_path_has_hidden_component` is unchanged for the other call sites (exclusion-token parsing, the Makefile-finding `find` which already excludes dotfiles, policy_path, abs_root). The client's `code_file_wanted` already gates the file set, so this kb check is defense-in-depth.

## Test

A `scan_files` block pushes `src/app.c`, `.gitmodules`, `.bashrc`, `.github/workflows/ci.yml` and `.gitmodules/payload.txt`; asserts the first two ingest (`inspected==2`/`scanned==2`, rows present, `.gitmodules` body stored **byte-for-byte** so R2b's `crb_gitmodules` can parse it) and the rest are excluded (hidden non-manifest, file under a hidden dir, and `.gitmodules` used as an interior directory).

## Review

Roundtable-reviewed: **converged, 0 blocking**. Post-convergence added the suggested interior-`.gitmodules`-dir exclusion case, tightened the counts (`==` not `>=`), added a step-failure guard + byte-for-byte content assertion.