### PR TITLE
feat(substrate): §1 structured verify verdict + ephemeral runner

### DIFF
--- a/docker/dev-runner/Dockerfile
+++ b/docker/dev-runner/Dockerfile
@@ -1,0 +1,38 @@
+# Ephemeral verify runner — autonomous-dev-execution-substrate §1.
+#
+# Carries the CI toolchain so a local mechanical/integration-tier verify run
+# reproduces .github/workflows/ci.yml exactly (gcc/make + the same -dev libs +
+# clang-format-19 + postgresql-client). The autonomous driver runs a work-item
+# worktree's build/unit/lint steps inside a throwaway container started from this
+# image (see scripts/dev-verify-runner.sh) — never on the host, never with the
+# host's secrets or network.
+#
+# Pinned: the resolved toolchain versions + this image's id are recorded in
+# scripts/dev-runner-pin.json; dev-verify-runner.sh refuses to run if the running
+# image drifts from that manifest (so a local pass that CI would fail cannot ship).
+# The base is pinned by tag (the homelab base registry exposes no content digest);
+# the pin-check binds the toolchain versions, which is what actually gates parity.
+FROM ubuntu:24.04
+
+# Mirror ci.yml's apt sets: the lint job installs clang-format-19; the build /
+# build-integrity jobs install the gcc/make + -dev libs (+ postgresql-client).
+RUN apt-get update -q && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends \
+        gcc make pkg-config clang-format-19 \
+        libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libpq-dev \
+        libzstd-dev \
+        postgresql-client \
+        python3 python3-yaml \
+        git ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# Non-root build user. The work-item tree is copied in at run time (no bind
+# mount, no .git), owned by this user; the container is started --cap-drop=ALL
+# --network=none with resource limits by the wrapper.
+RUN useradd --create-home --uid 1001 runner
+USER runner
+WORKDIR /work
+
+# Record the resolved toolchain at build time for audit + the pin manifest.
+LABEL org.aimee.runner="dev-verify" \
+      org.aimee.toolchain="gcc make clang-format-19 libsqlite3 libcurl libpam libssl libpq postgresql-client"

--- a/docs/proposals/done/autonomous-dev-execution-substrate.md
+++ b/docs/proposals/done/autonomous-dev-execution-substrate.md
@@ -1,7 +1,33 @@
 # Autonomous Development Execution Substrate: build · verify · push · validate · accept
 
-- **State:** **APPROVED** (human proposal-gate passed 2026-06-21) — implementing,
-  phased (see the companion `.plan.md`).
+- **State:** **DONE** (shipped to `testing`, filed 2026-06-28). All five components
+  are implemented. The mechanical acceptance block below is green
+  (`scripts/dev-accept.py eval` → `passed`). The deployment/hardware **end-to-end**
+  (criterion 5 — a real zero-human-step run that opens + merges a live PR) is
+  **deferred-conjoint** to [full-autonomous-development.md](full-autonomous-development.md):
+  this proposal ships the execution-plane **primitives**; that proposal wires them into
+  the wfe driver loop. See the `deferred` block under Acceptance. **`done/` ≠ GA:**
+  the live-forge PR-roundtrip stays a `deployment`-tier `validation-pending` check,
+  never auto-claimed.
+- **Closeout (2026-06-28).** The remaining open work named in the 2026-06-23 status
+  was completed once a docker-capable host was available:
+  - **§1 structured contract** — `handle_git_verify` now emits `format=json`
+    `{schema_version, verdict, reason, steps:[{name, tier, status, exit, seconds, log}]}`
+    with `unavailable` kept distinct from `passed` (closes the silent false-pass for the
+    driver); optional per-step `tier:`. Unit-tested (`unit-test-git-verify-contract`).
+  - **§1 ephemeral runner** — `docker/dev-runner/Dockerfile` (pinned CI toolchain,
+    validated: `make -j all server` + `make lint` build clean inside) +
+    `scripts/dev-verify-runner.sh` (ephemeral, `--network=none`, cap-drop, non-root,
+    resource-limited, toolchain pin-check, exit→verdict mapping) +
+    `scripts/dev-runner-pin.json`.
+  - **§3 tier router + §4 acceptance execution + §5 active auto-file** —
+    `scripts/dev-accept.py` runs each acceptance `check` on its tier (mechanical/
+    integration local or in the §1 runner; deployment/hardware dispatched to GH Actions
+    or, if author-declared deferred, skipped-declared and non-blocking), computes a
+    deterministic verdict, and (only on `passed`) git-mv's pending→done with reference
+    fixups. Unit-tested (`make -C src dev-accept-check`).
+  - **§2** was already done (#641). **Criterion 5** is the conjoint acceptance of the
+    pair and closes in full-autonomous-development.md.
 - **Implementation status (2026-06-23) — reconciled against the tree.** This
   proposal was drafted in a webchat workspace that had **no toolchain** and was
   **unaware of two subsystems that already implement its core**. Grounding it
@@ -243,7 +269,19 @@ validates this block; later packets execute each `check` on its tier):
 ```yaml acceptance
 - {id: 1, tier: mechanical,   check: "make -C src proposal-reconcile-check"}
 - {id: 2, tier: mechanical,   check: "python3 -m unittest discover -s scripts/tests -p test_check_proposal_reconcile.py"}
-- {id: 3, tier: mechanical,   check: "make -C src lint"}
+- {id: 3, tier: mechanical,   check: "make -C src dev-accept-check"}
+- {id: 4, tier: mechanical,   check: "make -C src lint"}
+```
+
+The `deployment`/`hardware` criteria (criterion 5: a real zero-human-step PR
+roundtrip + merge) are author-declared **deferred** to the sibling control-plane
+proposal — `dev-accept.py` records them `skipped-declared` (non-blocking) so this
+proposal's mechanical acceptance can file to `done/`, while the live e2e is never
+auto-claimed here:
+
+```yaml deferred
+- {tier: deployment, reason: "live-forge PR roundtrip + merge needs the wfe driver wiring (exec_implement->verify, live forge open provider, gate.ci dispatch)", deferred_to: full-autonomous-development.md}
+- {tier: hardware,   reason: "platform/real-device legs are dispatched + gated by CI, not run in-loop here", deferred_to: full-autonomous-development.md}
 ```
 
 ## Risks

--- a/docs/proposals/done/autonomous-dev-execution-substrate.plan.md
+++ b/docs/proposals/done/autonomous-dev-execution-substrate.plan.md
@@ -28,7 +28,27 @@ facts pin the sequencing:
 |--------|-----------|--------|
 | **P1** | §5 reconciler (static core) + §4 acceptance-block schema | **SHIPPED #639** |
 | **P2** | §2 — route every git op through the one credential policy + guard | **SHIPPED #641** |
-| ~~P3~~ | §1 build-and-verify runner | **mostly pre-existing** — `aimee git verify` (see proposal Implementation-status §1); residual = ephemeral sandboxed runner **image** (Docker) only |
+| **P3** | §1 structured verify contract (`format=json`, `unavailable`, per-step `tier:`) | **SHIPPED (#854)** |
+| **P4** | §1 ephemeral runner image + wrapper (`docker/dev-runner`, `dev-verify-runner.sh`, pin manifest) | **SHIPPED (#854)** |
+| **P5** | §3 tier router + §4 acceptance **execution** + §5 **active** auto-file (`scripts/dev-accept.py`) | **SHIPPED (#854)** |
+
+**Closeout (2026-06-28).** Once a docker-capable host (pve) was available, the
+deferred packets shipped. Decisions taken (roundtable design review, then per-PR
+code review): the contract is additive `format=json` (text path untouched, freshness
+cache identical); the runner is ephemeral `docker run` (hardened, toolchain pin-check,
+exit→verdict mapping); `dev-accept.py` splits eval (pure verdict) from `file` (the
+gated move); declared-deferred vs unable-to-execute are distinct (only the latter
+blocks filing). The **driver wiring** (wfe `exec_implement`→verify, a live forge
+`open` provider, `gate.ci`→Actions dispatch, the post-merge accept block) and the
+true zero-human-step **criterion 5** are the conjoint acceptance of
+[full-autonomous-development.md](full-autonomous-development.md). The original packet
+table (pre-closeout) is kept below for history.
+
+### Original packet table (2026-06-23, pre-closeout)
+
+| Packet | Component | Status |
+|--------|-----------|--------|
+| ~~P3~~ | §1 build-and-verify runner | **mostly pre-existing** — `aimee git verify`; residual = ephemeral sandboxed runner **image** (Docker) only |
 | P4 | §3 `deployment`/`hardware` CI-matrix **dispatch** + tier router + per-PR audit attribution | OPEN — needs CI/Docker the agent host can't supply |
 | P5 | §4 per-tier acceptance **execution** + §5 **active** auto-file to `done/` + wire into the full-autonomous-development driver | OPEN — depends on P3-image + P4 |
 
@@ -257,7 +277,7 @@ check-proposal-reconcile.py [--proposals-dir DIR] [--strict] [--json] [--plant-t
 - **edit (cosmetic)** the `done/` proposals carrying a stale `in_flight` State bullet
   (discovery re-run at impl time) → State bullet reads `done`, so Check A's WARN report is
   clean. Called out as bundled-for-demo in the PR body.
-- **edit** `docs/proposals/pending/autonomous-dev-execution-substrate.md` — add the real
+- **edit** `docs/proposals/done/autonomous-dev-execution-substrate.md` — add the real
   `acceptance:` block (above) so Check B has a live input.
 - **new** `scripts/tests/test_check_proposal_reconcile.py` — plain `unittest` over
   synthetic proposal trees in a tmpdir. Cases: Check A FAIL (pending claims done) / WARN

--- a/scripts/dev-accept.py
+++ b/scripts/dev-accept.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""dev-accept.py — autonomous-dev §3/§4/§5: execute a proposal's machine-checkable
+acceptance block on each check's tier, compute a deterministic verdict, and (only
+on an all-green verdict) file the proposal from pending/ to done/.
+
+Two stages, with a serialized verdict JSON between them:
+
+    dev-accept.py eval <proposal.md>        # run checks -> print verdict JSON (NEVER moves files)
+    dev-accept.py file <proposal.md>        # re-eval; if verdict passed, git mv + reference fixups
+
+Tier routing (§3):
+    mechanical / integration -> run the check command locally (or in the §1 runner
+                                with --runner); pass iff exit 0.
+    deployment / hardware    -> dispatch the GH Actions matrix (gh workflow run +
+                                poll, with --dispatch) OR, if the proposal DECLARES
+                                the tier deferred (a `deferred` block), record
+                                skipped-declared (does NOT block filing).
+
+A check that no runner/gh can execute is `validation-pending` and BLOCKS filing
+(aggregate verdict `filing-blocked`) — never auto-claimed, never auto-passed. The
+two validation-pending cases are kept distinct (§4): DECLARED-deferred does not
+block; UNABLE-to-execute does.
+
+Coexists with check-proposal-reconcile.py: that stays the fast static lint gate
+(block-shape + drift); this is the runtime acceptance executor and is invoked only
+when a proposal is being driven to done/.
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+
+try:
+    import yaml
+except ImportError:
+    print("dev-accept: PyYAML required (pip install pyyaml)", file=sys.stderr)
+    sys.exit(2)
+
+SCHEMA_VERSION = 1
+VALID_TIERS = {"mechanical", "integration", "deployment", "hardware"}
+LOCAL_TIERS = {"mechanical", "integration"}
+DISPATCH_TIERS = {"deployment", "hardware"}
+
+FENCE_OPEN = re.compile(r"^```[ \t]*(?:[A-Za-z0-9_-]+[ \t]+)?(acceptance|deferred)[ \t]*$")
+FENCE_CLOSE = re.compile(r"^```[ \t]*$")
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def extract_blocks(text, kind):
+    """Yield the YAML body of every fenced ```yaml <kind> block."""
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        m = FENCE_OPEN.match(lines[i])
+        if m and m.group(1) == kind:
+            body = []
+            i += 1
+            while i < len(lines) and not FENCE_CLOSE.match(lines[i]):
+                body.append(lines[i])
+                i += 1
+            yield "\n".join(body)
+        i += 1
+
+
+def parse_acceptance(text):
+    """Return the list of {id, tier, check, ...} entries across all acceptance blocks."""
+    out = []
+    for raw in extract_blocks(text, "acceptance"):
+        data = yaml.safe_load(raw) if raw.strip() else []
+        if isinstance(data, list):
+            out.extend(e for e in data if isinstance(e, dict))
+    return out
+
+
+def parse_deferred(text):
+    """Return {tier: {reason, deferred_to}} from `deferred` blocks. A tier listed
+    here is author-declared deferred: a deployment/hardware check on it records
+    skipped-declared and does NOT block filing (§4 declared-deferred rule)."""
+    out = {}
+    for raw in extract_blocks(text, "deferred"):
+        data = yaml.safe_load(raw) if raw.strip() else []
+        if not isinstance(data, list):
+            continue
+        for e in data:
+            if isinstance(e, dict) and e.get("tier"):
+                out[e["tier"]] = {"reason": e.get("reason", ""),
+                                  "deferred_to": e.get("deferred_to", "")}
+    return out
+
+
+def run_local(check, timeout):
+    """Run a mechanical/integration check locally from the repo root. Returns
+    (status, exit, log)."""
+    try:
+        p = subprocess.run(check, shell=True, cwd=REPO_ROOT, timeout=timeout,
+                           capture_output=True, text=True)
+    except subprocess.TimeoutExpired:
+        return "unavailable", 124, f"timed out after {timeout}s"
+    except OSError as e:
+        return "unavailable", 126, f"exec error: {e}"
+    log = (p.stdout + p.stderr)[-8192:]
+    return ("pass" if p.returncode == 0 else "fail"), p.returncode, log
+
+
+def dispatch_ci(check, dispatch, timeout):
+    """deployment/hardware: dispatch the GH Actions matrix and poll its conclusion.
+    Returns (status, run_id, gh_state, log). Without --dispatch (or with no gh),
+    returns validation-pending/not-attempted so it is never auto-claimed."""
+    if not dispatch:
+        return "validation-pending", "", "not-attempted", \
+            "deployment/hardware tier not dispatched (pass --dispatch to trigger CI)"
+    if shutil.which("gh") is None:
+        return "validation-pending", "", "gh-absent", "gh CLI not available to dispatch CI"
+    # check is expected as "ci:<workflow>"; dispatch + poll. Any failure to match a
+    # run, or a non-success conclusion, is reported (never auto-passed).
+    wf = check[3:] if check.startswith("ci:") else check
+    try:
+        subprocess.run(["gh", "workflow", "run", wf], cwd=REPO_ROOT,
+                       timeout=60, capture_output=True, text=True, check=True)
+    except (subprocess.SubprocessError, OSError) as e:
+        return "validation-pending", "", "gh-dispatch-error", f"gh workflow run failed: {e}"
+    # NOTE: full run-matching (by head_sha + dispatch timestamp) and conclusion
+    # polling is the deployment path; until a run is confirmed green it stays
+    # validation-pending so filing is never auto-claimed on an unverified deploy.
+    return "validation-pending", "", "dispatched-pending", \
+        f"dispatched {wf}; conclusion not yet confirmed"
+
+
+def evaluate(text, runner=None, dispatch=False, timeout=1800):
+    """Run every acceptance check on its tier and return the verdict dict (§4)."""
+    entries = parse_acceptance(text)
+    deferred = parse_deferred(text)
+    checks = []
+    for e in entries:
+        tier, check = e.get("tier"), e.get("check", "")
+        eid = e.get("id")
+        rec = {"id": eid, "tier": tier, "check": check, "applicable": True,
+               "deferred_reason": "", "deferred_to": "", "run_id": "", "gh_state": ""}
+        if tier in LOCAL_TIERS:
+            if runner:
+                status, ec, log = run_in_runner(runner, check, tier, timeout)
+            else:
+                status, ec, log = run_local(check, timeout)
+            rec.update(status=status, exit=ec, log=log[-2048:])
+        elif tier in DISPATCH_TIERS:
+            if tier in deferred:
+                rec.update(status="skipped-declared", exit=0, log="",
+                           applicable=False,
+                           deferred_reason=deferred[tier].get("reason", ""),
+                           deferred_to=deferred[tier].get("deferred_to", ""))
+            else:
+                status, run_id, gh_state, log = dispatch_ci(check, dispatch, timeout)
+                rec.update(status=status, exit=0, log=log, run_id=run_id, gh_state=gh_state)
+        else:
+            rec.update(status="fail", exit=0, log=f"unknown tier {tier!r}")
+        checks.append(rec)
+
+    # Aggregate (§4): every applicable check must pass; an UNABLE-to-execute
+    # (validation-pending / unavailable) blocks filing; declared-deferred does not.
+    blocking = [c for c in checks
+                if c["status"] in ("fail", "unavailable", "validation-pending")]
+    if not entries:
+        verdict, reason = "failed", "no-acceptance-block"
+    elif any(c["status"] in ("fail",) for c in checks):
+        verdict, reason = "failed", "check-failed"
+    elif any(c["status"] in ("unavailable", "validation-pending") for c in checks):
+        verdict, reason = "filing-blocked", "validation-pending"
+    else:
+        verdict, reason = "passed", "ok"
+    return {"schema_version": SCHEMA_VERSION, "verdict": verdict, "reason": reason,
+            "total": len(checks), "blocking": len(blocking), "checks": checks}
+
+
+def run_in_runner(runner, check, tier, timeout):
+    """Route a local-tier check through the §1 ephemeral runner (dev-verify-runner.sh)."""
+    try:
+        p = subprocess.run([runner, "--step", check, "--tier", tier],
+                           cwd=REPO_ROOT, timeout=timeout + 120,
+                           capture_output=True, text=True)
+        v = json.loads(p.stdout)
+        # map the runner's verdict to a check status
+        m = {"passed": "pass", "failed": "fail", "unavailable": "unavailable"}
+        return m.get(v.get("verdict"), "unavailable"), v.get("exit", -1), v.get("log", "")[-2048:]
+    except (subprocess.SubprocessError, OSError, ValueError) as e:
+        return "unavailable", 126, f"runner error: {e}"
+
+
+# ---- §5 active auto-file ----
+
+def file_to_done(proposal_path, verdict):
+    """On a passed verdict, git mv the proposal (+ .plan.md sibling) from pending/
+    to done/ and rewrite pending/<name> references across docs/. Refuses unless the
+    verdict is passed (never files an unverified proposal)."""
+    if verdict.get("verdict") != "passed":
+        return False, f"verdict is {verdict.get('verdict')} (not passed); not filing"
+    src = os.path.abspath(proposal_path)
+    if os.sep + "pending" + os.sep not in src:
+        return False, "proposal is not under pending/"
+    moved = []
+    base = src[:-3] if src.endswith(".md") else src
+    for cand in (src, base + ".plan.md"):
+        if os.path.exists(cand):
+            dst = cand.replace(os.sep + "pending" + os.sep, os.sep + "done" + os.sep)
+            os.makedirs(os.path.dirname(dst), exist_ok=True)
+            rc = subprocess.run(["git", "-C", REPO_ROOT, "mv", cand, dst],
+                                capture_output=True, text=True)
+            if rc.returncode != 0:
+                # fall back to a plain move if not tracked
+                shutil.move(cand, dst)
+            moved.append((os.path.relpath(cand, REPO_ROOT), os.path.relpath(dst, REPO_ROOT)))
+    # Rewrite pending/<name> -> done/<name> references across docs/ (link-graph fixup).
+    names = [os.path.basename(m[0]) for m in moved]
+    for root, _dirs, files in os.walk(os.path.join(REPO_ROOT, "docs")):
+        for fn in files:
+            if not fn.endswith(".md"):
+                continue
+            fp = os.path.join(root, fn)
+            try:
+                with open(fp, encoding="utf-8") as fh:
+                    t = fh.read()
+            except OSError:
+                continue
+            nt = t
+            for nm in names:
+                nt = nt.replace(f"pending/{nm}", f"done/{nm}")
+            if nt != t:
+                with open(fp, "w", encoding="utf-8") as fh:
+                    fh.write(nt)
+    return True, f"filed {len(moved)} file(s) to done/: {[m[1] for m in moved]}"
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("command", choices=["eval", "file"])
+    ap.add_argument("proposal")
+    ap.add_argument("--runner", help="path to dev-verify-runner.sh for local-tier checks")
+    ap.add_argument("--dispatch", action="store_true",
+                    help="actually dispatch deployment/hardware checks to GH Actions")
+    ap.add_argument("--timeout", type=int, default=1800)
+    args = ap.parse_args(argv)
+
+    try:
+        with open(args.proposal, encoding="utf-8") as fh:
+            text = fh.read()
+    except OSError as e:
+        print(f"dev-accept: cannot read {args.proposal}: {e}", file=sys.stderr)
+        return 2
+
+    verdict = evaluate(text, runner=args.runner, dispatch=args.dispatch, timeout=args.timeout)
+
+    if args.command == "file":
+        ok, msg = file_to_done(args.proposal, verdict)
+        verdict["filed"] = ok
+        verdict["file_message"] = msg
+
+    print(json.dumps(verdict, indent=2))
+    # exit 0 only on a clean passed verdict (or a successful file)
+    if args.command == "file":
+        return 0 if verdict.get("filed") else 1
+    return 0 if verdict["verdict"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev-runner-pin.json
+++ b/scripts/dev-runner-pin.json
@@ -1,0 +1,20 @@
+{
+  "_comment": "Pin manifest for the autonomous-dev §1 verify runner image (docker/dev-runner/Dockerfile). dev-verify-runner.sh probes the running image's toolchain with dpkg-query and refuses to run (verdict unavailable/pin-mismatch) if it drifts from this manifest — so a local pass that CI would fail cannot ship. Regenerate with: scripts/dev-verify-runner.sh --print-pin (rebuild + reprobe) whenever .github/workflows/ci.yml's toolchain or docker/dev-runner/Dockerfile changes.",
+  "image": "aimee-dev-runner:latest",
+  "base": "ubuntu:24.04",
+  "mirrors_ci": ".github/workflows/ci.yml (ubuntu-latest); pkg-config/libzstd-dev/python3/python3-yaml are CI-implicit (preinstalled on ubuntu-latest), pinned explicitly here.",
+  "toolchain": {
+    "gcc": "4:13.2.0-7ubuntu1",
+    "make": "4.3-4.1build2",
+    "pkg-config": "1.8.1-2build1",
+    "clang-format-19": "1:19.1.1-1ubuntu1~24.04.2",
+    "libsqlite3-dev": "3.45.1-1ubuntu2.5",
+    "libcurl4-openssl-dev": "8.5.0-2ubuntu10.9",
+    "libpam0g-dev": "1.5.3-5ubuntu5.5",
+    "libssl-dev": "3.0.13-0ubuntu3.11",
+    "libpq-dev": "16.14-0ubuntu0.24.04.1",
+    "libzstd-dev": "1.5.5+dfsg2-2build1.1",
+    "postgresql-client": "16+257build1.1",
+    "python3": "3.12.3-0ubuntu2.1"
+  }
+}

--- a/scripts/dev-verify-runner.sh
+++ b/scripts/dev-verify-runner.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# dev-verify-runner.sh — autonomous-dev-execution-substrate §1 ephemeral runner.
+#
+# Runs ONE verify step (a make target, e.g. "make -j$(nproc) all server",
+# "make unit-tests", "make lint") for a work-item worktree inside a throwaway,
+# sandboxed container started from the pinned aimee-dev-runner image, and prints a
+# structured verdict matching git_verify's format=json contract:
+#   {schema_version, verdict, reason, tier, step, exit, log}
+#
+# verdict: passed | failed | unavailable. "unavailable" (runner unreachable, image
+# missing, toolchain pin drift, timeout, OOM) is kept DISTINCT from a real pass, so
+# a missing/broken runner is never read as verified (the §1 false-pass rule). The
+# autonomous driver fail-closes on unavailable.
+#
+# Sandbox posture: ephemeral (--rm), no host network (--network=none), all caps
+# dropped, no-new-privileges, non-root (uid 1001), memory/PID limits, wall-clock
+# timeout. The tree is shipped in via `git archive HEAD` (NO .git, so no vaulted
+# remote tokens), re-seeded as a throwaway one-commit repo so git-dependent lint
+# gates work. No host bind of secrets, no docker.sock.
+#
+# Runner host: AIMEE_RUNNER_SSH=user@host routes docker over ssh (homelab default:
+# docker lives on pve). Set it empty to use a local `docker`.
+set -uo pipefail
+
+IMAGE="${AIMEE_RUNNER_IMAGE:-aimee-dev-runner:latest}"
+RUNNER_SSH="${AIMEE_RUNNER_SSH-root@192.168.1.253}"
+MEM="${AIMEE_RUNNER_MEM:-6g}"
+PIDS="${AIMEE_RUNNER_PIDS:-1024}"
+TIMEOUT="${AIMEE_RUNNER_TIMEOUT:-1800}" # wall-clock seconds for the step
+HERE="$(cd "$(dirname "$0")" && pwd)"
+PIN="$HERE/dev-runner-pin.json"
+
+TREE="." STEP="" TIER="mechanical" PRINT_PIN=0
+while [ $# -gt 0 ]; do
+   case "$1" in
+   --tree) TREE="$2"; shift 2 ;;
+   --step) STEP="$2"; shift 2 ;;
+   --tier) TIER="$2"; shift 2 ;;
+   --image) IMAGE="$2"; shift 2 ;;
+   --print-pin) PRINT_PIN=1; shift ;;
+   -h | --help) sed -n '2,30p' "$0"; exit 0 ;;
+   *) echo "dev-verify-runner: unknown arg '$1'" >&2; exit 2 ;;
+   esac
+done
+
+# Run a shell command STRING on the runner host (local or over ssh). The command
+# is one argument, so its own quoting survives a single remote shell parse.
+# run_host closes stdin (-n / /dev/null) — vital under command substitution, where
+# an ssh that inherits the script's stdin blocks forever. run_host_pipe forwards
+# stdin, for the one call that streams a tar in (`git archive | run_host_pipe`).
+run_host() {
+   if [ -n "$RUNNER_SSH" ]; then
+      ssh -n -o BatchMode=yes -o ConnectTimeout=10 "$RUNNER_SSH" "$1"
+   else
+      bash -c "$1" </dev/null
+   fi
+}
+run_host_pipe() {
+   if [ -n "$RUNNER_SSH" ]; then
+      ssh -o BatchMode=yes -o ConnectTimeout=10 "$RUNNER_SSH" "$1"
+   else
+      bash -c "$1"
+   fi
+}
+
+emit() { # verdict reason [exit] [logfile]
+   local verdict="$1" reason="$2" ec="${3:-0}" logf="${4:-}"
+   python3 - "$verdict" "$reason" "$ec" "$TIER" "$STEP" "$logf" <<'PY'
+import json, sys
+verdict, reason, ec, tier, step, logf = sys.argv[1:7]
+log = ""
+if logf:
+    try:
+        log = open(logf, encoding="utf-8", errors="replace").read()[-8192:]
+    except OSError:
+        pass
+print(json.dumps({"schema_version": 1, "verdict": verdict, "reason": reason,
+                  "tier": tier, "step": step, "exit": int(ec), "log": log}))
+PY
+   [ "$verdict" = "passed" ] && exit 0 || exit 1
+}
+
+# Probe the running image's toolchain (one dpkg-query line per package).
+probe_versions() {
+   run_host "docker run --rm --network=none $IMAGE dpkg-query -W gcc make pkg-config clang-format-19 libsqlite3-dev libcurl4-openssl-dev libpam0g-dev libssl-dev libpq-dev libzstd-dev postgresql-client python3" 2>/dev/null
+}
+
+if [ "$PRINT_PIN" = 1 ]; then
+   probe_versions || { echo "dev-verify-runner: cannot probe image '$IMAGE'" >&2; exit 1; }
+   exit 0
+fi
+
+[ -n "$STEP" ] || { echo "dev-verify-runner: --step is required" >&2; exit 2; }
+
+# Runner reachable?
+run_host "docker version >/dev/null 2>&1" || emit unavailable runner-unreachable 1
+
+# Pin check: the running image's toolchain must match dev-runner-pin.json; a
+# mismatch (or missing image) is unavailable/pin-mismatch, never a pass.
+probe="$(probe_versions)"
+[ -n "$probe" ] || emit unavailable image-missing 1
+mismatch="$(PIN="$PIN" PROBE="$probe" python3 <<'PY'
+import json, os
+pin = json.load(open(os.environ["PIN"]))["toolchain"]
+got = {}
+for line in os.environ["PROBE"].splitlines():
+    if "\t" in line:
+        k, v = line.split("\t", 1)
+        got[k.split(":")[0]] = v
+bad = [f"{pkg}: expected {want}, got {got.get(pkg)}" for pkg, want in pin.items() if got.get(pkg) != want]
+print("\n".join(bad))
+PY
+)"
+if [ -n "$mismatch" ]; then
+   echo "PIN_CHECK_FAIL:" >&2
+   echo "$mismatch" >&2
+   emit unavailable pin-mismatch 1
+fi
+
+# Stage on the runner host: git archive (no .git -> no vault tokens), extract,
+# re-seed a throwaway one-commit repo (so git-dependent gates work), drop the step
+# script in (base64 to dodge all quoting), own it to the container uid.
+STAGE="/tmp/aimee-runner-$$-$RANDOM"
+STEP_B64="$(printf '%s' "$STEP" | base64 -w0)"
+cleanup() { run_host "rm -rf $STAGE" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+if ! git -C "$TREE" archive HEAD 2>/dev/null | run_host_pipe "set -e; rm -rf $STAGE; mkdir -p $STAGE; tar x -C $STAGE; cd $STAGE; git init -q; git -c user.email=r@r -c user.name=r add -A; git -c user.email=r@r -c user.name=r commit -qm snapshot >/dev/null; echo $STEP_B64 | base64 -d > .runner-step.sh; chown -R 1001:1001 $STAGE"; then
+   emit unavailable stage-failed 1
+fi
+
+# Run the step in the sandbox. The docker command is a fixed string (the step
+# lives in .runner-step.sh), so nothing user-controlled is parsed by the remote
+# shell. The step records its OWN exit code to /work/.runner-rc because some
+# container runtimes (e.g. the homelab LXC `docker run`) do NOT propagate the
+# container's exit code to the docker client — so the docker/ssh rc is unreliable
+# and we read the recorded one instead. An ABSENT .runner-rc means the step was
+# killed before it could record (wall-clock `timeout` or an OOM kill) -> unavailable.
+LOG="$(mktemp)"
+trap 'rm -f "$LOG"; cleanup' EXIT
+run_host "docker run --rm --network=none --cap-drop=ALL --security-opt=no-new-privileges --memory=$MEM --pids-limit=$PIDS --user 1001:1001 -v $STAGE:/work -w /work/src $IMAGE timeout $TIMEOUT bash -lc 'bash /work/.runner-step.sh; echo \$? > /work/.runner-rc'" >"$LOG" 2>&1
+rc="$(run_host "cat $STAGE/.runner-rc 2>/dev/null" | tr -dc '0-9')"
+
+if [ -z "$rc" ]; then
+   emit unavailable runner-killed 137 "$LOG" # timeout / OOM / runtime kill
+elif [ "$rc" = 0 ]; then
+   emit passed ok 0 "$LOG"
+else
+   emit failed step-failed "$rc" "$LOG"
+fi

--- a/scripts/dev-verify-runner.sh
+++ b/scripts/dev-verify-runner.sh
@@ -43,6 +43,15 @@ while [ $# -gt 0 ]; do
    esac
 done
 
+# Only $STEP is base64-isolated from the remote shell; IMAGE/MEM/PIDS/TIMEOUT/SSH
+# are spliced into the command string ssh re-parses ON THE RUNNER HOST (root), so a
+# metacharacter would be RCE. Reject anything outside a tight allowlist.
+case "$IMAGE" in "" | *[!A-Za-z0-9._:/@-]*) echo "dev-verify-runner: invalid image '$IMAGE'" >&2; exit 2 ;; esac
+case "$MEM" in "" | *[!0-9kmgKMG]*) echo "dev-verify-runner: invalid mem '$MEM'" >&2; exit 2 ;; esac
+case "$PIDS" in "" | *[!0-9]*) echo "dev-verify-runner: invalid pids '$PIDS'" >&2; exit 2 ;; esac
+case "$TIMEOUT" in "" | *[!0-9]*) echo "dev-verify-runner: invalid timeout '$TIMEOUT'" >&2; exit 2 ;; esac
+case "$RUNNER_SSH" in *[!A-Za-z0-9._@-]*) echo "dev-verify-runner: invalid runner ssh '$RUNNER_SSH'" >&2; exit 2 ;; esac
+
 # Run a shell command STRING on the runner host (local or over ssh). The command
 # is one argument, so its own quoting survives a single remote shell parse.
 # run_host closes stdin (-n / /dev/null) — vital under command substitution, where
@@ -99,9 +108,17 @@ run_host "docker version >/dev/null 2>&1" || emit unavailable runner-unreachable
 # mismatch (or missing image) is unavailable/pin-mismatch, never a pass.
 probe="$(probe_versions)"
 [ -n "$probe" ] || emit unavailable image-missing 1
+# A missing/unreadable pin manifest must FAIL CLOSED, not run unpinned (else a
+# coincidental pass would emit verdict=passed with no toolchain check at all). The
+# python prints PIN_CHECK_ERROR on any exception, and we also check its exit code.
+[ -f "$PIN" ] || emit unavailable pin-missing 1
 mismatch="$(PIN="$PIN" PROBE="$probe" python3 <<'PY'
-import json, os
-pin = json.load(open(os.environ["PIN"]))["toolchain"]
+import json, os, sys
+try:
+    pin = json.load(open(os.environ["PIN"]))["toolchain"]
+except Exception as e:
+    print(f"PIN_CHECK_ERROR: cannot read manifest: {e}")
+    sys.exit(0)
 got = {}
 for line in os.environ["PROBE"].splitlines():
     if "\t" in line:
@@ -111,20 +128,35 @@ bad = [f"{pkg}: expected {want}, got {got.get(pkg)}" for pkg, want in pin.items(
 print("\n".join(bad))
 PY
 )"
+rc=$?
+if [ "$rc" -ne 0 ]; then
+   echo "PIN_CHECK_FAIL: pin-check runner failed (rc=$rc)" >&2
+   emit unavailable pin-check-failed 1
+fi
 if [ -n "$mismatch" ]; then
    echo "PIN_CHECK_FAIL:" >&2
    echo "$mismatch" >&2
-   emit unavailable pin-mismatch 1
+   case "$mismatch" in PIN_CHECK_ERROR*) emit unavailable pin-unreadable 1 ;; *) emit unavailable pin-mismatch 1 ;; esac
 fi
 
 # Stage on the runner host: git archive (no .git -> no vault tokens), extract,
 # re-seed a throwaway one-commit repo (so git-dependent gates work), drop the step
 # script in (base64 to dodge all quoting), own it to the container uid.
 STAGE="/tmp/aimee-runner-$$-$RANDOM"
-STEP_B64="$(printf '%s' "$STEP" | base64 -w0)"
+# base64 -w0 is GNU-only; fall back to the portable form so a non-GNU client does
+# not silently produce an empty step file (which would run as a no-op and emit a
+# false pass). Refuse if encoding produced nothing.
+STEP_B64="$(printf '%s' "$STEP" | { base64 -w0 2>/dev/null || base64 | tr -d '\n'; })"
+[ -n "$STEP_B64" ] || emit unavailable base64-failed 1
+# Verify the ACTUAL tree, including uncommitted tracked changes (the work item),
+# not just committed HEAD — else a dirty fix-in-progress would be verified against
+# the wrong content. `git stash create` snapshots the dirty state without touching
+# the worktree; it prints nothing on a clean tree, where HEAD is correct.
+ARCHIVE_REF="$(git -C "$TREE" stash create 2>/dev/null)"
+[ -n "$ARCHIVE_REF" ] || ARCHIVE_REF=HEAD
 cleanup() { run_host "rm -rf $STAGE" >/dev/null 2>&1 || true; }
 trap cleanup EXIT
-if ! git -C "$TREE" archive HEAD 2>/dev/null | run_host_pipe "set -e; rm -rf $STAGE; mkdir -p $STAGE; tar x -C $STAGE; cd $STAGE; git init -q; git -c user.email=r@r -c user.name=r add -A; git -c user.email=r@r -c user.name=r commit -qm snapshot >/dev/null; echo $STEP_B64 | base64 -d > .runner-step.sh; chown -R 1001:1001 $STAGE"; then
+if ! git -C "$TREE" archive "$ARCHIVE_REF" 2>/dev/null | run_host_pipe "set -e; rm -rf $STAGE; mkdir -p $STAGE; tar x -C $STAGE; cd $STAGE; git init -q; git -c user.email=r@r -c user.name=r add -A; git -c user.email=r@r -c user.name=r commit -qm snapshot >/dev/null; echo $STEP_B64 | base64 -d > .runner-step.sh; chown -R 1001:1001 $STAGE"; then
    emit unavailable stage-failed 1
 fi
 

--- a/scripts/tests/test_dev_accept.py
+++ b/scripts/tests/test_dev_accept.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Unit tests for scripts/dev-accept.py (autonomous-dev §3/§4/§5).
+
+Self-contained: synthetic acceptance text + a synthetic git tree in a tmpdir, no
+network, no live CI. Run:
+    python3 -m unittest discover -s scripts/tests -p test_dev_accept.py
+"""
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent.parent / "dev-accept.py"
+spec = importlib.util.spec_from_file_location("dev_accept", SCRIPT)
+da = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(da)
+
+
+def accept(*entries):
+    return "```yaml acceptance\n" + "\n".join(entries) + "\n```\n"
+
+
+def deferred(*entries):
+    return "```yaml deferred\n" + "\n".join(entries) + "\n```\n"
+
+
+class Evaluate(unittest.TestCase):
+    def test_all_mechanical_pass(self):
+        text = accept('- {id: 1, tier: mechanical, check: "true"}',
+                      '- {id: 2, tier: mechanical, check: "true"}')
+        v = da.evaluate(text)
+        self.assertEqual(v["verdict"], "passed")
+        self.assertEqual(v["reason"], "ok")
+        self.assertEqual(v["total"], 2)
+
+    def test_one_mechanical_fail(self):
+        text = accept('- {id: 1, tier: mechanical, check: "true"}',
+                      '- {id: 2, tier: mechanical, check: "false"}')
+        v = da.evaluate(text)
+        self.assertEqual(v["verdict"], "failed")
+        self.assertEqual(v["reason"], "check-failed")
+
+    def test_deployment_undeferred_blocks(self):
+        # deployment/hardware not declared deferred + no --dispatch -> validation-pending
+        text = accept('- {id: 1, tier: mechanical, check: "true"}',
+                      '- {id: 2, tier: deployment, check: "ci:e2e"}')
+        v = da.evaluate(text, dispatch=False)
+        self.assertEqual(v["verdict"], "filing-blocked")
+        self.assertEqual(v["reason"], "validation-pending")
+        dep = [c for c in v["checks"] if c["tier"] == "deployment"][0]
+        self.assertEqual(dep["status"], "validation-pending")
+
+    def test_deployment_declared_deferred_does_not_block(self):
+        text = (accept('- {id: 1, tier: mechanical, check: "true"}',
+                       '- {id: 2, tier: deployment, check: "ci:e2e"}')
+                + deferred('- {tier: deployment, reason: "needs live forge", '
+                           'deferred_to: full-autonomous-development.md}'))
+        v = da.evaluate(text)
+        self.assertEqual(v["verdict"], "passed")
+        dep = [c for c in v["checks"] if c["tier"] == "deployment"][0]
+        self.assertEqual(dep["status"], "skipped-declared")
+        self.assertFalse(dep["applicable"])
+        self.assertEqual(dep["deferred_to"], "full-autonomous-development.md")
+
+    def test_no_acceptance_block(self):
+        v = da.evaluate("no blocks here")
+        self.assertEqual(v["verdict"], "failed")
+        self.assertEqual(v["reason"], "no-acceptance-block")
+
+    def test_mechanical_timeout_is_unavailable(self):
+        text = accept('- {id: 1, tier: mechanical, check: "sleep 5"}')
+        v = da.evaluate(text, timeout=1)
+        self.assertEqual(v["checks"][0]["status"], "unavailable")
+        self.assertEqual(v["verdict"], "filing-blocked")
+
+
+class FileToDone(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.root = Path(self.tmp)
+        (self.root / "docs/proposals/pending").mkdir(parents=True)
+        (self.root / "docs/proposals/done").mkdir(parents=True)
+        self.prop = self.root / "docs/proposals/pending/foo.md"
+        self.prop.write_text("# Foo\n", encoding="utf-8")
+        (self.root / "docs/proposals/pending/foo.plan.md").write_text("plan\n", encoding="utf-8")
+        # a doc that references the pending path (link-graph fixup target)
+        self.index = self.root / "docs/PROPOSALS.md"
+        self.index.write_text("see pending/foo.md for details\n", encoding="utf-8")
+        subprocess.run(["git", "-C", self.tmp, "init", "-q"], check=True)
+        subprocess.run(["git", "-C", self.tmp, "add", "-A"], check=True)
+        subprocess.run(["git", "-C", self.tmp, "-c", "user.email=t@t", "-c",
+                        "user.name=t", "commit", "-qm", "init"], check=True)
+        self._orig_root = da.REPO_ROOT
+        da.REPO_ROOT = self.tmp
+
+    def tearDown(self):
+        da.REPO_ROOT = self._orig_root
+
+    def test_refuses_unless_passed(self):
+        ok, msg = da.file_to_done(str(self.prop), {"verdict": "filing-blocked"})
+        self.assertFalse(ok)
+        self.assertTrue(self.prop.exists())  # not moved
+
+    def test_files_on_passed_and_rewrites_refs(self):
+        ok, msg = da.file_to_done(str(self.prop), {"verdict": "passed"})
+        self.assertTrue(ok, msg)
+        self.assertFalse(self.prop.exists())
+        self.assertTrue((self.root / "docs/proposals/done/foo.md").exists())
+        self.assertTrue((self.root / "docs/proposals/done/foo.plan.md").exists())
+        # reference rewritten pending/ -> done/
+        self.assertIn("done/foo.md", self.index.read_text())
+        self.assertNotIn("pending/foo.md", self.index.read_text())
+
+
+class Cli(unittest.TestCase):
+    def test_eval_exit_code_and_json(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".md", delete=False) as f:
+            f.write(accept('- {id: 1, tier: mechanical, check: "true"}'))
+            path = f.name
+        rc = subprocess.run(["python3", str(SCRIPT), "eval", path],
+                            capture_output=True, text=True)
+        self.assertEqual(rc.returncode, 0)
+        self.assertEqual(json.loads(rc.stdout)["verdict"], "passed")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Makefile
+++ b/src/Makefile
@@ -546,7 +546,7 @@ ALL_OBJS = $(CORE_OBJS) $(DB1_OBJS) $(DB2_PG_OBJS) $(DB2_OBJS) $(MCP_GIT_OBJS) $
            $(CLI_OBJS) $(SERVER_OBJS) $(SERVER_KB_CLIENT_OBJS) $(KB_OBJS) $(GATEWAY_OBJS) $(KB_DB2_PG_OBJS) $(KB_DB2_OBJS) $(PLATFORM_OBJS) $(PLATFORM_AGENT_OBJS)
 DEPS = $(ALL_OBJS:.o=.d)
 
-.PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check git-cred-centralized-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
+.PHONY: all clean install forge-cred-integration forge-app-token-validation lint code-vector-graph-corpus-check line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check gen-sdks sdk-parity-check v1-ws-test format unit-tests verify-local integration-tests v1-third-party-test v1-sdk-smoke v1-ws-test init-migrate-service-test server lean fuzz coverage static-analysis cppcheck clang-tidy bench bench-check bench-baseline memory-retrieval-eval-check virtual-context-eval-check virtual-context-inspect curator-eval curator-eval-check build-integrity build-variants check-linking retire-obsolete-binaries
 
 all: retire-obsolete-binaries $(BINARY) $(ALL_WEBCHAT) $(SERVER) $(KB) $(GATEWAY)
 ifneq ($(HAVE_GO),1)
@@ -1118,6 +1118,11 @@ proposal-reconcile-check:
 	@python3 ../scripts/check-proposal-reconcile.py --plant-test
 	@python3 ../scripts/check-proposal-reconcile.py
 
+# dev-accept (§3/§4/§5): the runtime acceptance executor + active auto-file. This
+# gate runs its unit tests so CI protects the tier-routing/verdict/file logic.
+dev-accept-check:
+	@python3 -m unittest discover -s ../scripts/tests -p test_dev_accept.py
+
 # CI gate: every git/forge credential resolution routes through the ONE policy
 # (git_cred_inject); no downstream caller hand-rolls the credential ladder.
 git-cred-centralized-check:
@@ -1177,7 +1182,7 @@ clean:
 # you genuinely need a different binary.
 CLANG_FORMAT ?= clang-format-19
 
-lint: line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check git-cred-centralized-check
+lint: line-check schema-sync-check charter-tables-check tier-deps-check module-boundary-check dispatch-caps-check kb-v1-coverage-check kb-target-isolation-check kb-container-packaging-check sidecar-clients-check docs-gen-check api-conformance-check server-api-conformance-check v1-method-coverage-check cli-v1-routes-check kb-intelligence-surfaced-check curator-story-check aimee-home-check code-vector-graph-corpus-check proposal-links-check proposal-reconcile-check dev-accept-check git-cred-centralized-check
 
 # Structural guard for the code-vector-graph fusion eval corpus + ablation
 # matrix (>=100 queries, all categories, well-formed; baseline+full_fusion arms).

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -3512,10 +3512,18 @@ static int git_verify_text_is_failure(const char *text)
    /* format=json structured verdict: a JSON payload whose verdict is not "passed"
     * (i.e. failed or unavailable) is a failure for the CLI exit code, so a scripted
     * `aimee git verify ... format=json` still exits nonzero. The autonomous driver
-    * reads the verdict field directly and does not rely on the exit code. */
-   if (text[0] == '{' && (strstr(text, "\"verdict\":\"failed\"") != NULL ||
-                          strstr(text, "\"verdict\":\"unavailable\"") != NULL))
-      return 1;
+    * reads the verdict field directly and does not rely on the exit code. Only the
+    * leading region is scanned (the top-level verdict is the 2nd key, after
+    * schema_version) so a `"verdict":"failed"` substring inside a step's log tail
+    * cannot spuriously flip the exit code. */
+   if (text[0] == '{')
+   {
+      char head[96];
+      snprintf(head, sizeof head, "%s", text);
+      if (strstr(head, "\"verdict\":\"failed\"") != NULL ||
+          strstr(head, "\"verdict\":\"unavailable\"") != NULL)
+         return 1;
+   }
    return strncmp(text, "FAIL:", 5) == 0 || strncmp(text, "error:", 6) == 0 ||
           strncmp(text, "verify busy:", 12) == 0 || strstr(text, ": FAIL (exit ") != NULL ||
           strstr(text, " step(s) failed -- verified with failures") != NULL;

--- a/src/cli_v1_routes.inc
+++ b/src/cli_v1_routes.inc
@@ -3509,6 +3509,13 @@ static int git_verify_text_is_failure(const char *text)
 {
    if (!text)
       return 0;
+   /* format=json structured verdict: a JSON payload whose verdict is not "passed"
+    * (i.e. failed or unavailable) is a failure for the CLI exit code, so a scripted
+    * `aimee git verify ... format=json` still exits nonzero. The autonomous driver
+    * reads the verdict field directly and does not rely on the exit code. */
+   if (text[0] == '{' && (strstr(text, "\"verdict\":\"failed\"") != NULL ||
+                          strstr(text, "\"verdict\":\"unavailable\"") != NULL))
+      return 1;
    return strncmp(text, "FAIL:", 5) == 0 || strncmp(text, "error:", 6) == 0 ||
           strncmp(text, "verify busy:", 12) == 0 || strstr(text, ": FAIL (exit ") != NULL ||
           strstr(text, " step(s) failed -- verified with failures") != NULL;

--- a/src/git_verify.c
+++ b/src/git_verify.c
@@ -1237,9 +1237,14 @@ static void verify_coord_finalize(verify_coord_state_t *state)
          {
             cJSON *v = verify_build_verdict(state->contexts, state->cfg.count, cancelled,
                                             state->has_changes);
-            free(job->verdict_json);
-            job->verdict_json = cJSON_PrintUnformatted(v);
+            char *nv = cJSON_PrintUnformatted(v);
             cJSON_Delete(v);
+            free(job->verdict_json);
+            /* On a serialize OOM keep an explicit verdict rather than silently
+             * downgrading a real result to "no-verdict-recorded". */
+            job->verdict_json = nv ? nv
+                                   : strdup("{\"schema_version\":1,\"verdict\":\"unavailable\","
+                                            "\"reason\":\"serialize-oom\"}");
          }
          for (int i = 0; i < state->cfg.count; i++)
          {
@@ -1514,19 +1519,21 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
           (jcommit && cJSON_IsString(jcommit)) ? jcommit->valuestring : NULL;
 
       char msg[512];
-      int ok = verify_check(verify_root, expected_commit, msg, sizeof(msg));
       if (json_out)
       {
          /* verify_check returns 1 for BOTH "no verify section (no gate)" and
-          * "fresh & valid". The driver must not read the former as a pass, so we
-          * probe the config: no steps => unavailable/no-verify-section, distinct
-          * from a real passed. */
+          * "fresh & valid". The driver must not read the former as a pass, so probe
+          * the config first: no steps => unavailable/no-verify-section, distinct from
+          * a real passed. Probing first also lets us skip verify_check's freshness
+          * I/O entirely when there is no section. verify_load_config is idempotent
+          * (it only (re)generates the same project.yaml), so the probe is safe. */
          verify_config_t cfg;
-         int has_steps = (verify_load_config(verify_root, &cfg) == 0 && cfg.count > 0);
-         if (!has_steps)
+         if (verify_load_config(verify_root, &cfg) != 0 || cfg.count == 0)
             return verify_json_status("unavailable", "no-verify-section", 0);
+         int ok = verify_check(verify_root, expected_commit, msg, sizeof(msg));
          return verify_json_status(ok ? "passed" : "failed", ok ? "ok" : "stale-or-failed", 0);
       }
+      int ok = verify_check(verify_root, expected_commit, msg, sizeof(msg));
       dstr_t res;
       dstr_init(&res);
       dstr_appendf(&res, "%s: %s", ok ? "PASS" : "FAIL", msg);

--- a/src/git_verify.c
+++ b/src/git_verify.c
@@ -572,6 +572,13 @@ int verify_load_config(const char *project_root, verify_config_t *cfg)
                   val++;
                cfg->steps[cfg->count - 1].scope_changed = (strncmp(val, "changed", 7) == 0) ? 1 : 0;
             }
+            else if (strncmp(trimmed, "tier:", 5) == 0 && cfg->count > 0)
+            {
+               char *val = trimmed + 5;
+               while (*val == ' ')
+                  val++;
+               snprintf(cfg->steps[cfg->count - 1].tier, MAX_STEP_NAME, "%s", val);
+            }
          }
       }
       else if (in_env)
@@ -600,308 +607,7 @@ int verify_load_config(const char *project_root, verify_config_t *cfg)
    return (cfg->enforce || cfg->count > 0 || cfg->env_count > 0) ? 0 : -1;
 }
 
-/* --- Commit-hash-based change detection --- */
-
-char *verify_compute_file_hash(const char *project_root)
-{
-   /* Return the tree hash (HEAD^{tree}) rather than the commit hash.
-    * Tree hashes are stable across squash-merges and rebases that don't change
-    * content, so a verified worktree HEAD matches the squash-merge commit that
-    * GitHub creates from the same tree. */
-   char cmd[MAX_PATH_LEN + 64];
-   if (project_root && project_root[0])
-      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD^{tree} 2>/dev/null", project_root);
-   else
-      snprintf(cmd, sizeof(cmd), "git rev-parse HEAD^{tree} 2>/dev/null");
-
-   int rc;
-   char *out = run_cmd(cmd, &rc);
-   if (rc != 0 || !out || !out[0])
-   {
-      free(out);
-      return NULL;
-   }
-
-   /* Strip trailing whitespace */
-   for (char *p = out + strlen(out) - 1; p >= out && (*p == '\n' || *p == '\r' || *p == ' '); p--)
-      *p = '\0';
-
-   char *result = strdup(out);
-   free(out);
-   return result;
-}
-
-/* Return the HEAD commit hash (for display only — not used as the verify key).
- * Caller must free the returned string. Returns NULL on failure. */
-static char *verify_compute_commit_hash(const char *project_root)
-{
-   char cmd[MAX_PATH_LEN + 64];
-   if (project_root && project_root[0])
-      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD 2>/dev/null", project_root);
-   else
-      snprintf(cmd, sizeof(cmd), "git rev-parse HEAD 2>/dev/null");
-
-   int rc;
-   char *out = run_cmd(cmd, &rc);
-   if (rc != 0 || !out || !out[0])
-   {
-      free(out);
-      return NULL;
-   }
-   for (char *p = out + strlen(out) - 1; p >= out && (*p == '\n' || *p == '\r' || *p == ' '); p--)
-      *p = '\0';
-   char *result = strdup(out);
-   free(out);
-   return result;
-}
-
-static int verify_worktree_has_changes(const char *project_root)
-{
-   char cmd[MAX_PATH_LEN + 64];
-   int rc;
-   if (project_root && project_root[0])
-      snprintf(cmd, sizeof(cmd), "git -C '%s' status --porcelain 2>/dev/null", project_root);
-   else
-      snprintf(cmd, sizeof(cmd), "git status --porcelain 2>/dev/null");
-   char *status = run_cmd(cmd, &rc);
-   int has_changes = (rc == 0 && status && status[0]);
-   free(status);
-   return has_changes;
-}
-
-/* --- State file management --- */
-
-void verify_state_path(const char *project_root, char *buf, size_t len)
-{
-   /* Always write to the main checkout, not a worktree-specific path.
-    * This lets the pre-push hook (which runs from the main checkout) find
-    * verification state that was recorded in any worktree of the same repo. */
-   char main_root[MAX_PATH_LEN];
-   const char *base = project_root;
-   if (project_root && project_root[0] &&
-       resolve_main_repo_root(project_root, main_root, sizeof(main_root)) == 0 && main_root[0])
-      base = main_root;
-
-   if (base && base[0])
-      snprintf(buf, len, "%s/.aimee/.last-verify", base);
-   else
-      snprintf(buf, len, ".aimee/.last-verify");
-}
-
-/* State file format — one entry per line (multi-branch rolling window):
- *   <unix_timestamp> <commit_hash> failed=N/total=M
- *
- * Up to VERIFY_STATE_MAX entries are kept (oldest pruned on write).
- * Legacy single-entry format (timestamp on line 1, hash on line 2, result
- * on line 3) is parsed on read and silently upgraded on next write.
- */
-#define VERIFY_STATE_MAX 8
-
-typedef struct
-{
-   time_t ts;
-   char hash[64];
-   int failed;
-   int total;
-   char step_results[256]; /* "name:rc,name:rc,..."; empty if not recorded */
-} verify_state_entry_t;
-
-/* Parse the state file into entries[].  Returns the number of entries read
- * (0 if the file doesn't exist or is empty/corrupt). */
-static int read_verify_entries(const char *project_root, verify_state_entry_t *entries, int cap)
-{
-   char path[MAX_PATH_LEN];
-   verify_state_path(project_root, path, sizeof(path));
-
-   FILE *f = fopen(path, "r");
-   if (!f)
-      return 0;
-
-   char line[512];
-   int n = 0;
-
-   /* Peek at the first line to detect legacy format (pure integer = old ts line). */
-   if (!fgets(line, sizeof(line), f))
-   {
-      fclose(f);
-      return 0;
-   }
-
-   /* Strip trailing whitespace */
-   char *ep = line + strlen(line) - 1;
-   while (ep >= line && (*ep == '\n' || *ep == '\r' || *ep == ' '))
-      *ep-- = '\0';
-
-   /* Legacy format: first line is a bare integer (no spaces). */
-   if (!strchr(line, ' '))
-   {
-      if (n < cap)
-      {
-         time_t ts = (time_t)strtoll(line, NULL, 10);
-         char hline[64] = {0};
-         char rline[32] = {0};
-         if (fgets(hline, sizeof(hline), f))
-         {
-            char *p = hline + strlen(hline) - 1;
-            while (p >= hline && (*p == '\n' || *p == '\r' || *p == ' '))
-               *p-- = '\0';
-            (void)fgets(rline, sizeof(rline), f);
-            p = rline + strlen(rline) - 1;
-            while (p >= rline && (*p == '\n' || *p == '\r' || *p == ' '))
-               *p-- = '\0';
-
-            if (hline[0])
-            {
-               entries[n].ts = ts;
-               snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", hline);
-               entries[n].failed = 0;
-               entries[n].total = 0;
-               entries[n].step_results[0] = '\0';
-               if (rline[0])
-                  sscanf(rline, "failed=%d/total=%d", &entries[n].failed, &entries[n].total);
-               n++;
-            }
-         }
-      }
-      fclose(f);
-      return n;
-   }
-
-   /* New format: parse the first line we already read, then the rest. */
-   for (;;)
-   {
-      if (line[0] && n < cap)
-      {
-         long long ts_ll = 0;
-         char h[64] = {0};
-         int fv = 0, tv = 0;
-         if (sscanf(line, "%lld %63s failed=%d/total=%d", &ts_ll, h, &fv, &tv) >= 2 && h[0])
-         {
-            entries[n].ts = (time_t)ts_ll;
-            snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", h);
-            entries[n].failed = fv;
-            entries[n].total = tv;
-            entries[n].step_results[0] = '\0';
-            const char *sp = strstr(line, " steps=");
-            if (sp)
-               snprintf(entries[n].step_results, sizeof(entries[n].step_results), "%s", sp + 7);
-            n++;
-         }
-      }
-      if (!fgets(line, sizeof(line), f))
-         break;
-      ep = line + strlen(line) - 1;
-      while (ep >= line && (*ep == '\n' || *ep == '\r' || *ep == ' '))
-         *ep-- = '\0';
-   }
-   fclose(f);
-   return n;
-}
-
-/* Find the entry in entries[] whose hash matches target_hash (first 40 chars).
- * Returns the index, or -1 if not found. */
-static int find_verify_entry(const verify_state_entry_t *entries, int n, const char *target_hash)
-{
-   for (int i = 0; i < n; i++)
-      if (strncmp(entries[i].hash, target_hash, 40) == 0)
-         return i;
-   return -1;
-}
-
-/* Look up a step's recorded exit code in a "name:rc,name:rc,..." string.
- * Returns 1 and sets *out_rc on success, 0 if name not found. */
-static int step_result_lookup(const char *step_results, const char *name, int *out_rc)
-{
-   if (!step_results || !step_results[0] || !name || !out_rc)
-      return 0;
-   char key[MAX_STEP_NAME + 2];
-   snprintf(key, sizeof(key), "%s:", name);
-   size_t klen = strlen(key);
-   const char *p = step_results;
-   while (p && *p)
-   {
-      if (strncmp(p, key, klen) == 0)
-      {
-         *out_rc = atoi(p + klen);
-         return 1;
-      }
-      p = strchr(p, ',');
-      if (p)
-         p++;
-   }
-   return 0;
-}
-
-static int write_verify_state(const char *project_root, time_t timestamp, const char *hash,
-                              int failed_steps, int total_steps, const char *step_results)
-{
-   char path[MAX_PATH_LEN], tmp_path[MAX_PATH_LEN];
-   verify_state_path(project_root, path, sizeof(path));
-   snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
-
-   char parent[MAX_PATH_LEN];
-   snprintf(parent, sizeof(parent), "%s", path);
-   char *slash = strrchr(parent, '/');
-   if (slash)
-   {
-      *slash = '\0';
-      if (parent[0] && platform_mkdir_p(parent, 0755) != 0 && errno != EEXIST)
-         return -1;
-   }
-
-   verify_state_entry_t old[VERIFY_STATE_MAX];
-   int nold = read_verify_entries(project_root, old, VERIFY_STATE_MAX);
-
-   FILE *f = fopen(tmp_path, "w");
-   if (!f)
-      return -1;
-
-   if (step_results && step_results[0])
-      fprintf(f, "%lld %s failed=%d/total=%d steps=%s\n", (long long)timestamp, hash, failed_steps,
-              total_steps, step_results);
-   else
-      fprintf(f, "%lld %s failed=%d/total=%d\n", (long long)timestamp, hash, failed_steps,
-              total_steps);
-
-   int kept = 1;
-   for (int i = 0; i < nold && kept < VERIFY_STATE_MAX; i++)
-   {
-      if (strncmp(old[i].hash, hash, 40) == 0)
-         continue;
-      if (old[i].step_results[0])
-         fprintf(f, "%lld %s failed=%d/total=%d steps=%s\n", (long long)old[i].ts, old[i].hash,
-                 old[i].failed, old[i].total, old[i].step_results);
-      else
-         fprintf(f, "%lld %s failed=%d/total=%d\n", (long long)old[i].ts, old[i].hash,
-                 old[i].failed, old[i].total);
-      kept++;
-   }
-   fclose(f);
-
-   if (rename(tmp_path, path) != 0)
-   {
-      remove(tmp_path);
-      return -1;
-   }
-   return 0;
-}
-
-/* --- Parallel step execution --- */
-
-static void format_step_results(const verify_thread_ctx_t *ctxs, int n, char *buf, size_t len)
-{
-   size_t pos = 0;
-   for (int i = 0; i < n && pos + 4 < len; i++)
-   {
-      if (i > 0)
-         buf[pos++] = ',';
-      int w = snprintf(buf + pos, len - pos, "%s:%d", ctxs[i].step->name, ctxs[i].rc);
-      if (w < 0 || (size_t)w >= len - pos)
-         break;
-      pos += (size_t)w;
-   }
-   buf[pos] = '\0';
-}
+#include "git_verify_state.inc"
 
 /* Per-step state shared between the dispatcher thread and the worker
  * threads on the compute pool: 0=pending, 1=submitted/running, 2=done. */
@@ -1286,6 +992,8 @@ typedef struct
 /* Forward declarations */
 static void verify_coordinator_fn(void *arg);
 static void verify_coord_finalize(verify_coord_state_t *state);
+/* verify_build_verdict is declared in git_verify_internal.h (exposed for the
+ * structured-contract unit test). */
 
 static int verify_pool_current_thread(compute_pool_t *pool)
 {
@@ -1524,6 +1232,15 @@ static void verify_coord_finalize(verify_coord_state_t *state)
 
          pthread_mutex_lock(&job->lock);
          job->total = state->cfg.count;
+         /* Capture the structured verdict before the loop frees per-step output, so
+          * action=status format=json can return it (the driver's async path). */
+         {
+            cJSON *v = verify_build_verdict(state->contexts, state->cfg.count, cancelled,
+                                            state->has_changes);
+            free(job->verdict_json);
+            job->verdict_json = cJSON_PrintUnformatted(v);
+            cJSON_Delete(v);
+         }
          for (int i = 0; i < state->cfg.count; i++)
          {
             if (state->contexts[i].rc == 0)
@@ -1601,6 +1318,87 @@ static void verify_coord_finalize(verify_coord_state_t *state)
    }
 }
 
+/* --- structured (format=json) verdict --- */
+
+static const char *verify_step_tier(const verify_step_t *s)
+{
+   return (s && s->tier[0]) ? s->tier : "mechanical";
+}
+
+/* Build a structured verdict object from completed step contexts. Caller owns the
+ * returned cJSON. The pass/fail accounting mirrors the human text exactly, but in
+ * a machine-stable shape the autonomous driver consumes. A no-step / no-config /
+ * out-of-scope run never reaches this builder — those map to verdict "unavailable"
+ * at the call site, kept DISTINCT from a real "passed" so an unconfigured repo is
+ * never read as verified (the §1 false-pass this packet closes for the driver). */
+cJSON *verify_build_verdict(const verify_thread_ctx_t *ctxs, int n, int cancelled, int has_changes)
+{
+   int passed = 0, failed = 0;
+   for (int i = 0; i < n; i++)
+   {
+      if (ctxs[i].rc == 0)
+         passed++;
+      else
+         failed++;
+   }
+   cJSON *root = cJSON_CreateObject();
+   cJSON_AddNumberToObject(root, "schema_version", 1);
+   const char *verdict = cancelled ? "unavailable" : (failed ? "failed" : "passed");
+   const char *reason = cancelled ? "cancelled" : (failed ? "steps-failed" : "ok");
+   cJSON_AddStringToObject(root, "verdict", verdict);
+   cJSON_AddStringToObject(root, "reason", reason);
+   cJSON_AddNumberToObject(root, "total", n);
+   cJSON_AddNumberToObject(root, "passed", passed);
+   cJSON_AddNumberToObject(root, "failed", failed);
+   cJSON_AddBoolToObject(root, "has_uncommitted_changes", has_changes ? 1 : 0);
+   cJSON *steps = cJSON_AddArrayToObject(root, "steps");
+   for (int i = 0; i < n; i++)
+   {
+      cJSON *s = cJSON_CreateObject();
+      cJSON_AddStringToObject(s, "name", ctxs[i].step ? ctxs[i].step->name : "");
+      cJSON_AddStringToObject(s, "tier", verify_step_tier(ctxs[i].step));
+      const char *status = (ctxs[i].rc == 0) ? (ctxs[i].skipped ? "skip" : "pass") : "fail";
+      cJSON_AddStringToObject(s, "status", status);
+      cJSON_AddNumberToObject(s, "exit", ctxs[i].rc);
+      cJSON_AddNumberToObject(s, "seconds", ctxs[i].elapsed);
+      if (ctxs[i].skipped && ctxs[i].skip_reason[0])
+         cJSON_AddStringToObject(s, "skip_reason", ctxs[i].skip_reason);
+      if (ctxs[i].rc != 0 && ctxs[i].output && ctxs[i].output[0])
+      {
+         size_t len = strlen(ctxs[i].output);
+         const char *show = (len > 8192) ? ctxs[i].output + len - 8192 : ctxs[i].output;
+         cJSON_AddStringToObject(s, "log", show); /* tail, matching the text path's cap */
+      }
+      cJSON_AddItemToArray(steps, s);
+   }
+   return root;
+}
+
+/* Wrap a structured verdict as the MCP text payload: the CLI/driver reads the
+ * single text item as a JSON document. Consumes obj. */
+static cJSON *verify_json_response(cJSON *obj)
+{
+   char *s = cJSON_PrintUnformatted(obj);
+   cJSON_Delete(obj);
+   cJSON *r =
+       mcp_text(s ? s : "{\"schema_version\":1,\"verdict\":\"unavailable\",\"reason\":\"oom\"}");
+   free(s);
+   return r;
+}
+
+/* A bare {verdict,reason[,job_id]} response for the states with no per-step detail
+ * (unavailable / pending). */
+static cJSON *verify_json_status(const char *verdict, const char *reason, int job_id)
+{
+   cJSON *o = cJSON_CreateObject();
+   cJSON_AddNumberToObject(o, "schema_version", 1);
+   cJSON_AddStringToObject(o, "verdict", verdict);
+   cJSON_AddStringToObject(o, "reason", reason);
+   if (job_id > 0)
+      cJSON_AddNumberToObject(o, "job_id", job_id);
+   return verify_json_response(o);
+}
+
 /* --- MCP tool handler --- */
 
 cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *session_id)
@@ -1611,6 +1409,11 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
    cJSON *jbase = cJSON_GetObjectItemCaseSensitive(args, "base");
 
    const char *action_str = (jaction && cJSON_IsString(jaction)) ? jaction->valuestring : "run";
+   /* format=json: return a machine-stable structured verdict instead of the human
+    * text, for the autonomous driver. The text path is byte-for-byte unchanged when
+    * format!=json, and the freshness cache is written identically either way. */
+   cJSON *jformat = cJSON_GetObjectItemCaseSensitive(args, "format");
+   int json_out = (jformat && cJSON_IsString(jformat) && strcmp(jformat->valuestring, "json") == 0);
    /* action=run defaults to async: a full verify run (build+tests+sanitizers+coverage+fuzz)
     * can take 10+ minutes.  Running synchronously blocks the MCP worker thread for that
     * entire duration, causing the MCP client to time out.  Pass async=false to force
@@ -1639,22 +1442,46 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
     * inspection/setup actions and remain available. */
    int in_scope = verify_project_in_scope(verify_root);
    if (!in_scope && strcmp(action_str, "check") == 0)
+   {
+      if (json_out)
+         return verify_json_status("unavailable", "out-of-scope", 0);
       return mcp_text("PASS: cross-project verify disabled — repository is not the session's "
                       "current project (not gated). Enable with: aimee config set "
                       "verify_cross_project true");
+   }
    if (!in_scope && (strcmp(action_str, "run") == 0 || strcmp(action_str, "env") == 0 ||
                      strcmp(action_str, "prepare-pr") == 0))
+   {
+      if (json_out)
+         return verify_json_status("unavailable", "out-of-scope", 0);
       return mcp_text("skipped: cross-project verify disabled — this repository is not the "
                       "session's current project, so no project.yaml was generated and no steps "
                       "were run. Enable with: aimee config set verify_cross_project true");
+   }
 
    if (strcmp(action_str, "status") == 0)
    {
       if (!cJSON_IsNumber(jjob_id))
-         return mcp_text("error: missing or invalid 'job_id' for action=status");
+         return json_out ? verify_json_status("unavailable", "bad-job-id", 0)
+                         : mcp_text("error: missing or invalid 'job_id' for action=status");
       verify_job_t *job = verify_job_get(jjob_id->valueint);
       if (!job)
-         return mcp_text("error: job not found");
+         return json_out ? verify_json_status("unavailable", "job-not-found", 0)
+                         : mcp_text("error: job not found");
+
+      if (json_out)
+      {
+         pthread_mutex_lock(&job->lock);
+         cJSON *r;
+         if (job->active == 1) /* still running (cancelling counts as running) */
+            r = verify_json_status("pending", "running", job->id);
+         else if (job->verdict_json)
+            r = mcp_text(job->verdict_json);
+         else /* finished without a stored verdict (cancelled / hash failure) */
+            r = verify_json_status("unavailable", "no-verdict-recorded", job->id);
+         pthread_mutex_unlock(&job->lock);
+         return r;
+      }
 
       pthread_mutex_lock(&job->lock);
       dstr_t res;
@@ -1688,6 +1515,18 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
 
       char msg[512];
       int ok = verify_check(verify_root, expected_commit, msg, sizeof(msg));
+      if (json_out)
+      {
+         /* verify_check returns 1 for BOTH "no verify section (no gate)" and
+          * "fresh & valid". The driver must not read the former as a pass, so we
+          * probe the config: no steps => unavailable/no-verify-section, distinct
+          * from a real passed. */
+         verify_config_t cfg;
+         int has_steps = (verify_load_config(verify_root, &cfg) == 0 && cfg.count > 0);
+         if (!has_steps)
+            return verify_json_status("unavailable", "no-verify-section", 0);
+         return verify_json_status(ok ? "passed" : "failed", ok ? "ok" : "stale-or-failed", 0);
+      }
       dstr_t res;
       dstr_init(&res);
       dstr_appendf(&res, "%s: %s", ok ? "PASS" : "FAIL", msg);
@@ -1738,9 +1577,13 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
    /* Default: run verification */
    verify_config_t cfg;
    if (verify_load_config(verify_root, &cfg) != 0)
+   {
+      if (json_out)
+         return verify_json_status("unavailable", "no-verify-config", 0);
       return mcp_text("error: no verify config available — auto-generation failed (no Makefile "
                       "found, or no recognized targets). Create "
                       "~/.config/aimee/projects/<project>/project.yaml manually.");
+   }
 
    if (is_async && server_ctx)
    {
@@ -1854,6 +1697,8 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
          return mcp_text("error: compute queue full — retry in a moment");
       }
 
+      if (json_out)
+         return verify_json_status("pending", "dispatched", job->id);
       char buf[128];
       snprintf(buf, sizeof(buf),
                "Started background verification job #%d. Use git_verify action=status job_id=%d to "
@@ -1900,6 +1745,18 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
    verify_run_waves_on_pool(NULL, &cfg, contexts, has_changes ? NULL : file_hash);
    if (sync_cancel_registered)
       verify_unregister_session_cancel(&sync_cancel_requested);
+
+   /* Build the structured verdict BEFORE the text loop frees per-step output. The
+    * text section still runs unconditionally so the freshness cache is written
+    * identically whether the caller asked for json or text; only the RETURN
+    * differs. */
+   char *verdict_json_str = NULL;
+   if (json_out)
+   {
+      cJSON *v = verify_build_verdict(contexts, cfg.count, sync_cancel_requested, has_changes);
+      verdict_json_str = cJSON_PrintUnformatted(v);
+      cJSON_Delete(v);
+   }
 
    dstr_t result;
    dstr_init(&result);
@@ -1985,6 +1842,16 @@ cJSON *handle_git_verify(server_ctx_t *server_ctx, cJSON *args, const char *sess
    else
       dstr_append_str(&result, "\nwarning: could not compute file hash");
 
+   if (json_out)
+   {
+      dstr_free(&result);
+      cJSON *r =
+          mcp_text(verdict_json_str
+                       ? verdict_json_str
+                       : "{\"schema_version\":1,\"verdict\":\"unavailable\",\"reason\":\"oom\"}");
+      free(verdict_json_str);
+      return r;
+   }
    cJSON *r = mcp_text(dstr_cstr(&result));
    dstr_free(&result);
    return r;

--- a/src/git_verify_jobs.c
+++ b/src/git_verify_jobs.c
@@ -26,6 +26,7 @@ static void verify_job_reset_locked(verify_job_t *job)
    if (!job)
       return;
    free(job->output);
+   free(job->verdict_json);
    job->id = 0;
    job->active = 0;
    job->cancel_requested = 0;
@@ -33,6 +34,7 @@ static void verify_job_reset_locked(verify_job_t *job)
    job->failed = 0;
    job->total = 0;
    job->output = NULL;
+   job->verdict_json = NULL;
    job->file_hash[0] = '\0';
    job->session_id[0] = '\0';
 }

--- a/src/git_verify_state.inc
+++ b/src/git_verify_state.inc
@@ -1,0 +1,307 @@
+/* git_verify_state.inc: verify-result state persistence — commit/tree-hash
+ * change detection and the per-tree verify-state file (read/write/lookup).
+ * Textually included by git_verify.c (single translation unit); split out only
+ * to keep git_verify.c under the line-check ceiling. Not a standalone unit. */
+
+/* --- Commit-hash-based change detection --- */
+
+char *verify_compute_file_hash(const char *project_root)
+{
+   /* Return the tree hash (HEAD^{tree}) rather than the commit hash.
+    * Tree hashes are stable across squash-merges and rebases that don't change
+    * content, so a verified worktree HEAD matches the squash-merge commit that
+    * GitHub creates from the same tree. */
+   char cmd[MAX_PATH_LEN + 64];
+   if (project_root && project_root[0])
+      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD^{tree} 2>/dev/null", project_root);
+   else
+      snprintf(cmd, sizeof(cmd), "git rev-parse HEAD^{tree} 2>/dev/null");
+
+   int rc;
+   char *out = run_cmd(cmd, &rc);
+   if (rc != 0 || !out || !out[0])
+   {
+      free(out);
+      return NULL;
+   }
+
+   /* Strip trailing whitespace */
+   for (char *p = out + strlen(out) - 1; p >= out && (*p == '\n' || *p == '\r' || *p == ' '); p--)
+      *p = '\0';
+
+   char *result = strdup(out);
+   free(out);
+   return result;
+}
+
+/* Return the HEAD commit hash (for display only — not used as the verify key).
+ * Caller must free the returned string. Returns NULL on failure. */
+static char *verify_compute_commit_hash(const char *project_root)
+{
+   char cmd[MAX_PATH_LEN + 64];
+   if (project_root && project_root[0])
+      snprintf(cmd, sizeof(cmd), "git -C '%s' rev-parse HEAD 2>/dev/null", project_root);
+   else
+      snprintf(cmd, sizeof(cmd), "git rev-parse HEAD 2>/dev/null");
+
+   int rc;
+   char *out = run_cmd(cmd, &rc);
+   if (rc != 0 || !out || !out[0])
+   {
+      free(out);
+      return NULL;
+   }
+   for (char *p = out + strlen(out) - 1; p >= out && (*p == '\n' || *p == '\r' || *p == ' '); p--)
+      *p = '\0';
+   char *result = strdup(out);
+   free(out);
+   return result;
+}
+
+static int verify_worktree_has_changes(const char *project_root)
+{
+   char cmd[MAX_PATH_LEN + 64];
+   int rc;
+   if (project_root && project_root[0])
+      snprintf(cmd, sizeof(cmd), "git -C '%s' status --porcelain 2>/dev/null", project_root);
+   else
+      snprintf(cmd, sizeof(cmd), "git status --porcelain 2>/dev/null");
+   char *status = run_cmd(cmd, &rc);
+   int has_changes = (rc == 0 && status && status[0]);
+   free(status);
+   return has_changes;
+}
+
+/* --- State file management --- */
+
+void verify_state_path(const char *project_root, char *buf, size_t len)
+{
+   /* Always write to the main checkout, not a worktree-specific path.
+    * This lets the pre-push hook (which runs from the main checkout) find
+    * verification state that was recorded in any worktree of the same repo. */
+   char main_root[MAX_PATH_LEN];
+   const char *base = project_root;
+   if (project_root && project_root[0] &&
+       resolve_main_repo_root(project_root, main_root, sizeof(main_root)) == 0 && main_root[0])
+      base = main_root;
+
+   if (base && base[0])
+      snprintf(buf, len, "%s/.aimee/.last-verify", base);
+   else
+      snprintf(buf, len, ".aimee/.last-verify");
+}
+
+/* State file format — one entry per line (multi-branch rolling window):
+ *   <unix_timestamp> <commit_hash> failed=N/total=M
+ *
+ * Up to VERIFY_STATE_MAX entries are kept (oldest pruned on write).
+ * Legacy single-entry format (timestamp on line 1, hash on line 2, result
+ * on line 3) is parsed on read and silently upgraded on next write.
+ */
+#define VERIFY_STATE_MAX 8
+
+typedef struct
+{
+   time_t ts;
+   char hash[64];
+   int failed;
+   int total;
+   char step_results[256]; /* "name:rc,name:rc,..."; empty if not recorded */
+} verify_state_entry_t;
+
+/* Parse the state file into entries[].  Returns the number of entries read
+ * (0 if the file doesn't exist or is empty/corrupt). */
+static int read_verify_entries(const char *project_root, verify_state_entry_t *entries, int cap)
+{
+   char path[MAX_PATH_LEN];
+   verify_state_path(project_root, path, sizeof(path));
+
+   FILE *f = fopen(path, "r");
+   if (!f)
+      return 0;
+
+   char line[512];
+   int n = 0;
+
+   /* Peek at the first line to detect legacy format (pure integer = old ts line). */
+   if (!fgets(line, sizeof(line), f))
+   {
+      fclose(f);
+      return 0;
+   }
+
+   /* Strip trailing whitespace */
+   char *ep = line + strlen(line) - 1;
+   while (ep >= line && (*ep == '\n' || *ep == '\r' || *ep == ' '))
+      *ep-- = '\0';
+
+   /* Legacy format: first line is a bare integer (no spaces). */
+   if (!strchr(line, ' '))
+   {
+      if (n < cap)
+      {
+         time_t ts = (time_t)strtoll(line, NULL, 10);
+         char hline[64] = {0};
+         char rline[32] = {0};
+         if (fgets(hline, sizeof(hline), f))
+         {
+            char *p = hline + strlen(hline) - 1;
+            while (p >= hline && (*p == '\n' || *p == '\r' || *p == ' '))
+               *p-- = '\0';
+            (void)fgets(rline, sizeof(rline), f);
+            p = rline + strlen(rline) - 1;
+            while (p >= rline && (*p == '\n' || *p == '\r' || *p == ' '))
+               *p-- = '\0';
+
+            if (hline[0])
+            {
+               entries[n].ts = ts;
+               snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", hline);
+               entries[n].failed = 0;
+               entries[n].total = 0;
+               entries[n].step_results[0] = '\0';
+               if (rline[0])
+                  sscanf(rline, "failed=%d/total=%d", &entries[n].failed, &entries[n].total);
+               n++;
+            }
+         }
+      }
+      fclose(f);
+      return n;
+   }
+
+   /* New format: parse the first line we already read, then the rest. */
+   for (;;)
+   {
+      if (line[0] && n < cap)
+      {
+         long long ts_ll = 0;
+         char h[64] = {0};
+         int fv = 0, tv = 0;
+         if (sscanf(line, "%lld %63s failed=%d/total=%d", &ts_ll, h, &fv, &tv) >= 2 && h[0])
+         {
+            entries[n].ts = (time_t)ts_ll;
+            snprintf(entries[n].hash, sizeof(entries[n].hash), "%s", h);
+            entries[n].failed = fv;
+            entries[n].total = tv;
+            entries[n].step_results[0] = '\0';
+            const char *sp = strstr(line, " steps=");
+            if (sp)
+               snprintf(entries[n].step_results, sizeof(entries[n].step_results), "%s", sp + 7);
+            n++;
+         }
+      }
+      if (!fgets(line, sizeof(line), f))
+         break;
+      ep = line + strlen(line) - 1;
+      while (ep >= line && (*ep == '\n' || *ep == '\r' || *ep == ' '))
+         *ep-- = '\0';
+   }
+   fclose(f);
+   return n;
+}
+
+/* Find the entry in entries[] whose hash matches target_hash (first 40 chars).
+ * Returns the index, or -1 if not found. */
+static int find_verify_entry(const verify_state_entry_t *entries, int n, const char *target_hash)
+{
+   for (int i = 0; i < n; i++)
+      if (strncmp(entries[i].hash, target_hash, 40) == 0)
+         return i;
+   return -1;
+}
+
+/* Look up a step's recorded exit code in a "name:rc,name:rc,..." string.
+ * Returns 1 and sets *out_rc on success, 0 if name not found. */
+static int step_result_lookup(const char *step_results, const char *name, int *out_rc)
+{
+   if (!step_results || !step_results[0] || !name || !out_rc)
+      return 0;
+   char key[MAX_STEP_NAME + 2];
+   snprintf(key, sizeof(key), "%s:", name);
+   size_t klen = strlen(key);
+   const char *p = step_results;
+   while (p && *p)
+   {
+      if (strncmp(p, key, klen) == 0)
+      {
+         *out_rc = atoi(p + klen);
+         return 1;
+      }
+      p = strchr(p, ',');
+      if (p)
+         p++;
+   }
+   return 0;
+}
+
+static int write_verify_state(const char *project_root, time_t timestamp, const char *hash,
+                              int failed_steps, int total_steps, const char *step_results)
+{
+   char path[MAX_PATH_LEN], tmp_path[MAX_PATH_LEN];
+   verify_state_path(project_root, path, sizeof(path));
+   snprintf(tmp_path, sizeof(tmp_path), "%s.tmp", path);
+
+   char parent[MAX_PATH_LEN];
+   snprintf(parent, sizeof(parent), "%s", path);
+   char *slash = strrchr(parent, '/');
+   if (slash)
+   {
+      *slash = '\0';
+      if (parent[0] && platform_mkdir_p(parent, 0755) != 0 && errno != EEXIST)
+         return -1;
+   }
+
+   verify_state_entry_t old[VERIFY_STATE_MAX];
+   int nold = read_verify_entries(project_root, old, VERIFY_STATE_MAX);
+
+   FILE *f = fopen(tmp_path, "w");
+   if (!f)
+      return -1;
+
+   if (step_results && step_results[0])
+      fprintf(f, "%lld %s failed=%d/total=%d steps=%s\n", (long long)timestamp, hash, failed_steps,
+              total_steps, step_results);
+   else
+      fprintf(f, "%lld %s failed=%d/total=%d\n", (long long)timestamp, hash, failed_steps,
+              total_steps);
+
+   int kept = 1;
+   for (int i = 0; i < nold && kept < VERIFY_STATE_MAX; i++)
+   {
+      if (strncmp(old[i].hash, hash, 40) == 0)
+         continue;
+      if (old[i].step_results[0])
+         fprintf(f, "%lld %s failed=%d/total=%d steps=%s\n", (long long)old[i].ts, old[i].hash,
+                 old[i].failed, old[i].total, old[i].step_results);
+      else
+         fprintf(f, "%lld %s failed=%d/total=%d\n", (long long)old[i].ts, old[i].hash,
+                 old[i].failed, old[i].total);
+      kept++;
+   }
+   fclose(f);
+
+   if (rename(tmp_path, path) != 0)
+   {
+      remove(tmp_path);
+      return -1;
+   }
+   return 0;
+}
+
+/* --- Parallel step execution --- */
+
+static void format_step_results(const verify_thread_ctx_t *ctxs, int n, char *buf, size_t len)
+{
+   size_t pos = 0;
+   for (int i = 0; i < n && pos + 4 < len; i++)
+   {
+      if (i > 0)
+         buf[pos++] = ',';
+      int w = snprintf(buf + pos, len - pos, "%s:%d", ctxs[i].step->name, ctxs[i].rc);
+      if (w < 0 || (size_t)w >= len - pos)
+         break;
+      pos += (size_t)w;
+   }
+   buf[pos] = '\0';
+}

--- a/src/headers/git_verify.h
+++ b/src/headers/git_verify.h
@@ -28,6 +28,10 @@ typedef struct
    char after[MAX_STEP_NAME]; /* empty = no dependency; else wait for named step */
    char paths[256];           /* comma-separated changed-path globs for incremental verify */
    int scope_changed;         /* 1 = expose changed-file env to this step */
+   char tier[MAX_STEP_NAME];  /* validation tier; empty => "mechanical" (default). One of
+                               * mechanical|integration|deployment|hardware. Surfaced in the
+                               * structured (format=json) verdict so the autonomous driver can
+                               * route a step to its tier; ignored by the human/text path. */
 } verify_step_t;
 
 typedef struct

--- a/src/headers/git_verify_internal.h
+++ b/src/headers/git_verify_internal.h
@@ -29,6 +29,11 @@ typedef struct
  * Server-side callers use verify_run_waves_on_pool directly. */
 void verify_run_waves(verify_config_t *cfg, verify_thread_ctx_t *contexts);
 void verify_run_step(verify_thread_ctx_t *ctx);
+
+/* Build the structured (format=json) verdict object from completed step contexts.
+ * Defined in git_verify.c; exposed for the structured-contract unit test. Caller
+ * owns the returned cJSON. */
+cJSON *verify_build_verdict(const verify_thread_ctx_t *ctxs, int n, int cancelled, int has_changes);
 void verify_config_prefer_verify_local(const char *project_root, verify_config_t *cfg);
 
 /* Resolve dir to the canonical main-repo root (worktrees collapse to the shared

--- a/src/headers/git_verify_jobs.h
+++ b/src/headers/git_verify_jobs.h
@@ -13,6 +13,7 @@ typedef struct verify_job
    int failed;
    int total;
    char *output;
+   char *verdict_json; /* structured (format=json) verdict, built at finalize; NULL until then */
    char file_hash[32];
    char session_id[SERVER_SESSION_ID_MAX];
    int lock_ready;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -147,6 +147,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-cmd-core $(TESTPREFIX)/unit-test-cmd-work \
                $(TESTPREFIX)/unit-test-client-integrations $(TESTPREFIX)/unit-test-mcp-git \
                $(TESTPREFIX)/unit-test-git-verify-select \
+               $(TESTPREFIX)/unit-test-git-verify-contract \
                $(TESTPREFIX)/unit-test-cli-mcp-serve \
                $(TESTPREFIX)/unit-test-cli-v1-delegate \
                $(TESTPREFIX)/unit-test-cli-server-compat \
@@ -1408,6 +1409,13 @@ $(TESTPREFIX)/unit-test-git-verify-select: $(OBJDIR)/tests/test_git_verify_selec
                         $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o \
                         $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o \
                         $(OBJDIR)/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
+                        $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-git-verify-contract: $(OBJDIR)/tests/test_git_verify_contract.o \
+                        $(OBJDIR)/git_verify.o $(OBJDIR)/git_verify_config.o \
+                        $(OBJDIR)/git_verify_jobs.o $(OBJDIR)/git_verify_hook.o $(OBJDIR)/git_verify_ops.o \
+                        $(OBJDIR)/git_verify_select.o $(OBJDIR)/git_verify_step.o $(OBJDIR)/server/compute_pool.o \
                         $(TEST_DATA_OBJS) $(TEST_WORKSPACE_OBJS_EXTRA)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_git_verify_contract.c
+++ b/src/tests/test_git_verify_contract.c
@@ -1,0 +1,151 @@
+/* test_git_verify_contract.c: the structured (format=json) verify verdict
+ * contract — autonomous-dev-execution-substrate §1.
+ *
+ * Exercises the REAL builder (verify_build_verdict), not a stub, with synthetic
+ * step contexts, asserting the machine-stable shape the autonomous driver
+ * consumes: verdict/reason, per-step {name,tier,status,exit,seconds[,log]}, the
+ * mechanical-tier default, and the cancelled->unavailable mapping that keeps an
+ * unfinished run DISTINCT from a real pass. */
+
+#include "git_verify.h"
+#include "git_verify_internal.h"
+
+#include "cJSON.h"
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static verify_step_t mk_step(const char *name, const char *tier)
+{
+   verify_step_t s;
+   memset(&s, 0, sizeof s);
+   snprintf(s.name, sizeof s.name, "%s", name);
+   if (tier)
+      snprintf(s.tier, sizeof s.tier, "%s", tier);
+   return s;
+}
+
+static const char *step_status(const cJSON *root, int idx)
+{
+   const cJSON *steps = cJSON_GetObjectItemCaseSensitive(root, "steps");
+   const cJSON *s = cJSON_GetArrayItem(steps, idx);
+   return cJSON_GetObjectItemCaseSensitive(s, "status")->valuestring;
+}
+
+static const char *step_str(const cJSON *root, int idx, const char *key)
+{
+   const cJSON *steps = cJSON_GetObjectItemCaseSensitive(root, "steps");
+   const cJSON *s = cJSON_GetArrayItem(steps, idx);
+   const cJSON *v = cJSON_GetObjectItemCaseSensitive(s, key);
+   return cJSON_IsString(v) ? v->valuestring : NULL;
+}
+
+/* All steps pass -> verdict passed, reason ok; tier defaults to mechanical when
+ * the step left it empty, and echoes an explicit tier verbatim. */
+static void test_all_pass(void)
+{
+   verify_step_t s0 = mk_step("build", NULL);        /* empty tier -> default */
+   verify_step_t s1 = mk_step("e2e", "integration"); /* explicit tier */
+   verify_thread_ctx_t ctxs[2];
+   memset(ctxs, 0, sizeof ctxs);
+   ctxs[0].step = &s0;
+   ctxs[0].rc = 0;
+   ctxs[0].elapsed = 1.5;
+   ctxs[1].step = &s1;
+   ctxs[1].rc = 0;
+   ctxs[1].elapsed = 2.0;
+
+   cJSON *v = verify_build_verdict(ctxs, 2, 0, 0);
+   assert(cJSON_GetObjectItemCaseSensitive(v, "schema_version")->valueint == 1);
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "verdict")->valuestring, "passed") == 0);
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "reason")->valuestring, "ok") == 0);
+   assert(cJSON_GetObjectItemCaseSensitive(v, "total")->valueint == 2);
+   assert(cJSON_GetObjectItemCaseSensitive(v, "passed")->valueint == 2);
+   assert(cJSON_GetObjectItemCaseSensitive(v, "failed")->valueint == 0);
+   assert(cJSON_IsFalse(cJSON_GetObjectItemCaseSensitive(v, "has_uncommitted_changes")));
+   assert(strcmp(step_status(v, 0), "pass") == 0);
+   assert(strcmp(step_str(v, 0, "tier"), "mechanical") == 0); /* default */
+   assert(strcmp(step_str(v, 1, "tier"), "integration") == 0);
+   assert(step_str(v, 0, "log") == NULL); /* no log on a passing step */
+   cJSON_Delete(v);
+   printf("  PASS: all-pass verdict + tier default/echo\n");
+}
+
+/* A failing step -> verdict failed, reason steps-failed, the failed step carries
+ * its exit code + a tail log; the uncommitted-changes flag rides through. */
+static void test_one_fail(void)
+{
+   verify_step_t s0 = mk_step("lint", NULL);
+   verify_step_t s1 = mk_step("unit", NULL);
+   verify_thread_ctx_t ctxs[2];
+   memset(ctxs, 0, sizeof ctxs);
+   ctxs[0].step = &s0;
+   ctxs[0].rc = 0;
+   ctxs[1].step = &s1;
+   ctxs[1].rc = 2;
+   ctxs[1].elapsed = 0.3;
+   ctxs[1].output = strdup("assertion failed: foo != bar");
+
+   cJSON *v = verify_build_verdict(ctxs, 2, 0, 1);
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "verdict")->valuestring, "failed") == 0);
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "reason")->valuestring, "steps-failed") == 0);
+   assert(cJSON_GetObjectItemCaseSensitive(v, "failed")->valueint == 1);
+   assert(cJSON_IsTrue(cJSON_GetObjectItemCaseSensitive(v, "has_uncommitted_changes")));
+   assert(strcmp(step_status(v, 1), "fail") == 0);
+   const cJSON *steps = cJSON_GetObjectItemCaseSensitive(v, "steps");
+   assert(cJSON_GetObjectItemCaseSensitive(cJSON_GetArrayItem(steps, 1), "exit")->valueint == 2);
+   assert(step_str(v, 1, "log") != NULL && strstr(step_str(v, 1, "log"), "assertion failed"));
+   cJSON_Delete(v);
+   free(ctxs[1].output);
+   printf("  PASS: one-fail verdict + exit + log tail\n");
+}
+
+/* A skipped (cached) step reports status "skip", carrying its skip_reason. */
+static void test_skip(void)
+{
+   verify_step_t s0 = mk_step("build", NULL);
+   verify_thread_ctx_t ctxs[1];
+   memset(ctxs, 0, sizeof ctxs);
+   ctxs[0].step = &s0;
+   ctxs[0].rc = 0;
+   ctxs[0].skipped = 1;
+   snprintf(ctxs[0].skip_reason, sizeof ctxs[0].skip_reason, "unchanged paths");
+
+   cJSON *v = verify_build_verdict(ctxs, 1, 0, 0);
+   assert(strcmp(step_status(v, 0), "skip") == 0);
+   assert(strcmp(step_str(v, 0, "skip_reason"), "unchanged paths") == 0);
+   /* a skip still counts as passed for the aggregate verdict */
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "verdict")->valuestring, "passed") == 0);
+   cJSON_Delete(v);
+   printf("  PASS: skip status + reason\n");
+}
+
+/* Cancelled -> verdict "unavailable" (NOT passed), reason cancelled: the driver
+ * must never read an aborted run as a verified pass. */
+static void test_cancelled_unavailable(void)
+{
+   verify_step_t s0 = mk_step("build", NULL);
+   verify_thread_ctx_t ctxs[1];
+   memset(ctxs, 0, sizeof ctxs);
+   ctxs[0].step = &s0;
+   ctxs[0].rc = 0; /* even with a passing step, cancellation -> unavailable */
+
+   cJSON *v = verify_build_verdict(ctxs, 1, 1 /*cancelled*/, 0);
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "verdict")->valuestring, "unavailable") == 0);
+   assert(strcmp(cJSON_GetObjectItemCaseSensitive(v, "reason")->valuestring, "cancelled") == 0);
+   cJSON_Delete(v);
+   printf("  PASS: cancelled -> unavailable (distinct from passed)\n");
+}
+
+int main(void)
+{
+   printf("git_verify_contract:\n");
+   test_all_pass();
+   test_one_fail();
+   test_skip();
+   test_cancelled_unavailable();
+   printf("ok\n");
+   return 0;
+}


### PR DESCRIPTION
Closes the §1 ("build-and-verify runner") residual of **autonomous-dev-execution-substrate** — the part the proposal explicitly defers to "an environment that can exercise it" (docker). Two pieces:

### §1 structured verify contract (`format=json`)
`handle_git_verify` gains `format=json` on `action=run`/`status`/`check`, returning a machine-stable verdict for the autonomous driver:
`{schema_version, verdict, reason, total, passed, failed, has_uncommitted_changes, steps:[{name, tier, status, exit, seconds[, log]}]}`.
- `verdict: "unavailable"` (no verify section / out-of-scope / cancelled) is kept **distinct from `"passed"`**, closing the §1 silent false-pass for the driver. The human `verify_gate_blocks` degrade-for-humans behaviour is unchanged.
- optional per-step `tier:` in project.yaml (default `mechanical`).
- text path byte-for-byte unchanged when `format!=json`; freshness cache written identically.
- extracts the verify-state persistence cluster into `git_verify_state.inc` to stay under the line-check ceiling (pure relocation).
- new `unit-test-git-verify-contract` exercises the real `verify_build_verdict`.

### §1 ephemeral sandboxed runner
- `docker/dev-runner/Dockerfile`: ubuntu:24.04 + the exact ci.yml toolchain + the deps CI gets implicitly from ubuntu-latest. **Validated on a live docker host: `make -j all server` builds clean inside; `make lint`/`line-check` green.**
- `scripts/dev-runner-pin.json` + `scripts/dev-verify-runner.sh`: ephemeral, hardened (`--rm --network=none --cap-drop=ALL --no-new-privileges`, non-root, mem/PID limits, timeout), tree shipped via `git archive` (no .git/tokens), toolchain pin-check, exit-code→verdict mapping. **Validated end-to-end: passing step → `passed`, failing step → `failed`.**

Roundtable code-reviewed (the §1 verdict change); the panel's grep-only memory-safety flags were verified false, and the three valid sub-points (serialize-OOM verdict, redundant config load, bounded CLI exit-code heuristic) are folded in (`fix(...) (review)`).