### PR TITLE
fix(kb): hidden-path purges spare wanted .gitmodules (recall §2.2)

### DIFF
--- a/src/db2/canonical_index.c
+++ b/src/db2/canonical_index.c
@@ -526,8 +526,11 @@ static int ci_file_list_append(ci_file_list_t *list, const char *path)
 
 static void ci_purge_hidden_paths(int64_t project_id)
 {
-   (void)db2_code_index_purge_files_matching(project_id, ".%");
-   (void)db2_code_index_purge_files_matching(project_id, "%/.%");
+   /* Purge hidden-path files but SPARE a wanted dotfile build manifest
+    * (.gitmodules with all non-hidden ancestors) — recall §2.2. The purge mirrors
+    * the ingest allowlist (ci_path_ingest_excluded), so a re-scan does not delete a
+    * legitimately-ingested submodule declaration back out. */
+   (void)db2_code_index_purge_hidden_except_manifests(project_id);
 }
 
 static void ci_purge_build_exclusions(int64_t project_id, const ci_exclusion_list_t *exclusions)

--- a/src/db2/code_index.c
+++ b/src/db2/code_index.c
@@ -538,6 +538,38 @@ int db2_code_index_purge_files_matching(int64_t project_id, const char *path_glo
    return affected;
 }
 
+/* SQL predicate (on `path`) selecting a project-relative path that HAS a hidden
+ * component yet is NOT a wanted dotfile build manifest, so the hidden-path purges
+ * delete exactly what the ingest layer would have refused (ci_path_ingest_excluded
+ * / ci_is_dotfile_manifest — recall §2.2). A .gitmodules is spared ONLY when every
+ * ANCESTOR component is non-hidden: the repo-root `.gitmodules`, or `dir/.gitmodules`
+ * with no hidden dir before it. A .gitmodules under a hidden ancestor (`.git/.gitmodules`,
+ * `a/.hidden/.gitmodules`) is still purged — ingest never admits it. */
+#define CIDX_HIDDEN_NOT_MANIFEST                                                                   \
+   "(path LIKE '.%' OR path LIKE '%/.%') "                                                         \
+   "AND NOT (path = '.gitmodules' OR (path LIKE '%/.gitmodules' AND path NOT LIKE '.%' "           \
+   "                                  AND path NOT LIKE '%/.%/.gitmodules'))"
+
+int db2_code_index_purge_hidden_except_manifests(int64_t project_id)
+{
+   void *conn = db2_conn();
+   if (!conn)
+      return -1;
+
+   /* Per-project hidden-path purge that spares wanted dotfile manifests. */
+   static const char *sql = "DELETE FROM files WHERE project_id = ?1 AND " CIDX_HIDDEN_NOT_MANIFEST;
+   char err[CIDX_ERRBUF] = "";
+   aimee_pg_stmt_t *st = aimee_pg_prepare(conn, sql, err, sizeof(err));
+   if (!st)
+      return -1;
+   aimee_pg_bind_int64(st, "?1", project_id);
+   int affected = -1;
+   if (aimee_pg_step(st, err, sizeof(err)) == AIMEE_PG_DONE)
+      affected = aimee_pg_stmt_changes(st);
+   aimee_pg_finalize(st);
+   return affected;
+}
+
 int db2_code_index_purge_hidden_pollution(void)
 {
    void *conn = db2_conn();
@@ -547,9 +579,12 @@ int db2_code_index_purge_hidden_pollution(void)
    int total = 0;
    char err[CIDX_ERRBUF] = "";
 
-   /* Cross-project file purge: every file whose project-relative path has
-    * any hidden component. CASCADE drops dependent rows. */
-   static const char *files_sql = "DELETE FROM files WHERE path LIKE '.%' OR path LIKE '%/.%'";
+   /* Cross-project file purge: every file whose project-relative path has a hidden
+    * component, EXCEPT a wanted dotfile build manifest (.gitmodules with all
+    * non-hidden ancestors) — git submodule declarations are legitimately indexed
+    * despite the leading-'.' filename (recall §2.2); the ingest path admits them, so
+    * this startup cleanup must not delete them back out. CASCADE drops dependents. */
+   static const char *files_sql = "DELETE FROM files WHERE " CIDX_HIDDEN_NOT_MANIFEST;
    aimee_pg_stmt_t *st = aimee_pg_prepare(conn, files_sql, err, sizeof(err));
    if (!st)
       return -1;

--- a/src/db2/code_index.h
+++ b/src/db2/code_index.h
@@ -83,6 +83,12 @@ extern "C"
     * error. */
    int db2_code_index_purge_files_matching(int64_t project_id, const char *path_glob);
 
+   /* Purge one project's files whose path has a hidden component, EXCEPT a wanted
+    * dotfile build manifest (.gitmodules with all non-hidden ancestors) — mirrors
+    * the ingest allowlist so a re-scan does not delete legitimately-indexed
+    * submodule declarations (recall §2.2). Returns rows deleted (>=0) or -1. */
+   int db2_code_index_purge_hidden_except_manifests(int64_t project_id);
+
    /* One-shot cleanup of hidden-path pollution across the whole code
     * index. Drops every files row whose project-relative path has any
     * hidden component (dotfile or dot-directory) and every projects row

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -490,6 +490,7 @@ $(TESTPREFIX)/unit-test-schema-subst: $(OBJDIR)/tests/test_schema_subst.o \
 $(TESTPREFIX)/unit-test-code-index-ops: \
                                        $(OBJDIR)/tests/test_code_index_ops.o \
                                        $(OBJDIR)/db2/code_index_ops.o \
+                                       $(OBJDIR)/db2/code_index.o \
                                        $(OBJDIR)/db2/db2_init.o $(OBJDIR)/db2/db2_pool.o \
                                        $(OBJDIR)/db2/db_schema.o \
                                        $(TEST_CORE_OBJS)

--- a/src/tests/test_code_index_ops.c
+++ b/src/tests/test_code_index_ops.c
@@ -4,9 +4,28 @@
 
 #include "aimee.h"
 #include "db2_test_shim.h"
+#include "../db2/code_index.h"
 #include "../db2/code_index_ops.h"
 #include "../db2/db2_internal.h"
 #include "../db2/db_postgres.h"
+
+/* Count files rows for (project, path) over the shim. -1 on DB/step failure. */
+static int file_count_path(const char *project, const char *path)
+{
+   char e[256] = "";
+   aimee_pg_stmt_t *st =
+       aimee_pg_prepare(db2_conn(),
+                        "SELECT count(*) FROM files f JOIN projects p ON p.id=f.project_id "
+                        "WHERE p.name = ?1 AND f.path = ?2",
+                        e, sizeof e);
+   if (!st)
+      return -1;
+   aimee_pg_bind_text(st, "?1", project);
+   aimee_pg_bind_text(st, "?2", path);
+   int n = (aimee_pg_step(st, e, sizeof e) == AIMEE_PG_ROW) ? aimee_pg_column_int(st, 0) : -1;
+   aimee_pg_finalize(st);
+   return n;
+}
 
 int main(void)
 {
@@ -145,6 +164,74 @@ int main(void)
       int q3 = db2_code_index_requeue_drifted();
       assert(q3 == 2); /* dproj2 + dproj3 new; dproj already pending (deduped) */
       printf("  drift requeue enqueues multiple distinct drifted projects (q3=%d) OK\n", q3);
+   }
+
+   /* recall §2.2: the hidden-path purges must SPARE a wanted dotfile manifest
+    * (.gitmodules with all non-hidden ancestors) while still deleting other hidden
+    * files, files under hidden dirs, AND a .gitmodules under a hidden ancestor
+    * (ingest never admits that). Covers the per-project purge used by
+    * ci_purge_hidden_paths and the cross-project startup purge_hidden_pollution. */
+   {
+      void *conn = db2_conn();
+      char e[256] = "";
+      const char *spared[] = {".gitmodules", "sub/.gitmodules", "a/b/.gitmodules"};
+      const char *purged[] = {".bashrc", ".git/config", "sub/.hidden.c", ".git/.gitmodules",
+                              "sub/.hidden/.gitmodules"};
+      const char *keep[] = {"src/a.c"};
+      const char *projs[] = {"hp", "hp2"};
+      const char *seed = "INSERT INTO files (project_id, path, hash, scanned_at) VALUES"
+                         " ((SELECT id FROM projects WHERE name='%s'),'%s','h','t')";
+      for (size_t pj = 0; pj < 2; pj++)
+      {
+         char ins[512];
+         snprintf(ins, sizeof ins,
+                  "INSERT INTO projects (name, root, scanned_at) VALUES ('%s','/x','x')",
+                  projs[pj]);
+         assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         for (size_t i = 0; i < sizeof(spared) / sizeof(spared[0]); i++)
+         {
+            snprintf(ins, sizeof ins, seed, projs[pj], spared[i]);
+            assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         }
+         for (size_t i = 0; i < sizeof(purged) / sizeof(purged[0]); i++)
+         {
+            snprintf(ins, sizeof ins, seed, projs[pj], purged[i]);
+            assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         }
+         for (size_t i = 0; i < sizeof(keep) / sizeof(keep[0]); i++)
+         {
+            snprintf(ins, sizeof ins, seed, projs[pj], keep[i]);
+            assert(aimee_pg_exec(conn, ins, e, sizeof e) == 0);
+         }
+      }
+      int64_t pid = 0;
+      {
+         aimee_pg_stmt_t *st =
+             aimee_pg_prepare(conn, "SELECT id FROM projects WHERE name='hp'", e, sizeof e);
+         assert(st && aimee_pg_step(st, e, sizeof e) == AIMEE_PG_ROW);
+         pid = aimee_pg_column_int64(st, 0);
+         aimee_pg_finalize(st);
+      }
+      /* per-project purge on hp only (hp2 left intact to prove the cross-project purge). */
+      (void)db2_code_index_purge_hidden_except_manifests(pid);
+      for (size_t i = 0; i < sizeof(spared) / sizeof(spared[0]); i++)
+         assert(file_count_path("hp", spared[i]) == 1);
+      assert(file_count_path("hp", "src/a.c") == 1);
+      for (size_t i = 0; i < sizeof(purged) / sizeof(purged[0]); i++)
+         assert(file_count_path("hp", purged[i]) == 0);
+
+      /* cross-project pollution purge: same contract, and hp2 still has hidden rows
+       * to actually delete (proving DELETE, not a no-op). */
+      (void)db2_code_index_purge_hidden_pollution();
+      for (size_t pj = 0; pj < 2; pj++)
+      {
+         for (size_t i = 0; i < sizeof(spared) / sizeof(spared[0]); i++)
+            assert(file_count_path(projs[pj], spared[i]) == 1);
+         assert(file_count_path(projs[pj], "src/a.c") == 1);
+         for (size_t i = 0; i < sizeof(purged) / sizeof(purged[0]); i++)
+            assert(file_count_path(projs[pj], purged[i]) == 0);
+      }
+      printf("  hidden-path purges spare clean .gitmodules, drop the rest (recall §2.2) OK\n");
    }
 
    db2_test_shim_close();


### PR DESCRIPTION
## What

Third and final hidden-path twin of the `.gitmodules` fix (after #852 client collection, #853 kb ingest). A **live re-scan + kb restart still ended with `gitmodules=0`** because two purge passes delete already-ingested `.gitmodules` (filename starts with `.`):

1. `db2_code_index_purge_hidden_pollution()` — runs on **every kb startup** (kb_main.c:639), `DELETE FROM files WHERE path LIKE '.%' OR path LIKE '%/.%'` across **all** projects. A kb restart (which we do to trigger the cold-start cross-repo rebuild) thus wiped every submodule declaration.
2. `ci_purge_hidden_paths()` — per project inside `canonical_index_scan_project` (reached via the kb ingest worker).

This collapsed build-declared recall: with `.gitmodules` present, `build_deps=7` and the resolver emitted moonlight-qt→moonlight-common-c, Sunshine→{inputtino,moonlight-common-c}, wolf→{inputtino HIGH [both], eventbus, mdns_cpp}, gst-wayland-display→smithay; after the purge the submodule-derived deps vanished (`build_deps` dropped to 4).

## Fix

A shared SQL predicate `CIDX_HIDDEN_NOT_MANIFEST` that mirrors the ingest allowlist (`ci_path_ingest_excluded` / `ci_is_dotfile_manifest`): purge a hidden-component path **unless** it is a wanted manifest — `path = '.gitmodules'` **OR** (`path LIKE '%/.gitmodules'` AND not under a hidden ancestor: `NOT LIKE '.%'` AND `NOT LIKE '%/.%/.gitmodules'`). So `.gitmodules` / `sub/.gitmodules` are spared while `.git/.gitmodules` and `a/.hidden/.gitmodules` (hidden ancestor — ingest never admits them) are still purged.

Both purge sites share the one predicate as a single source of truth: new per-project `db2_code_index_purge_hidden_except_manifests()` (used by `ci_purge_hidden_paths`) and the cross-project startup purge.

## Test

Seeds spared/purged/keep paths across two projects; runs the per-project purge on one then the cross-project purge, asserting the spare/purge contract on both (the second project proves the cross-project DELETE actually fires, not a no-op).

## Review

Roundtable-reviewed: round 1 found one blocking issue (exception too broad — spared `.gitmodules` under hidden ancestors), fixed by the precise predicate mirroring ingest; round 2 **converged, 0 blocking**.