### PR TITLE
feat(fullauto): WP-5 safety rails — merge-target guard + per-run caps

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -213,7 +213,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 125 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 126 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -409,7 +409,7 @@ The binaries read 125 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_AUTONOMY_BASE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -169,10 +169,14 @@ int main(void)
    {
       assert(wfe_base_is_protected("main"));
       assert(wfe_base_is_protected("master"));
+      assert(wfe_base_is_protected("Main"));   /* case-insensitive */
+      assert(wfe_base_is_protected("MASTER")); /* case-insensitive */
       assert(wfe_base_is_protected("release-1.2"));
+      assert(wfe_base_is_protected("release/v2.0"));
       assert(wfe_base_is_protected("")); /* empty -> protected (fail closed) */
       assert(!wfe_base_is_protected("testing"));
       assert(!wfe_base_is_protected("aimee/wi/abc"));
+      assert(!wfe_base_is_protected("release-notes-edit")); /* not the release train */
       unsetenv("AIMEE_AUTONOMY_BASE");
       assert(strcmp(wfe_autonomous_base(), "testing") == 0);
       assert(wfe_autonomous_target_ok());

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -9,6 +9,7 @@
 #include "wfe_store.h"
 #include "wfe_approval.h"
 #include "wfe_autonomy.h"
+#include "wfe_blocks.h"
 #include "wfe_engine.h"
 #include "wfe_iface.h"
 #include "wfe_roundtable.h"
@@ -161,6 +162,42 @@ int main(void)
       db1_work_item_t wi;
       assert(db1_work_item_get(id, &wi) == 1);
       assert(strcmp(wi.state, "rejected") == 0);
+   }
+
+   /* A6: autonomous merge-target rail (WP-5) — protected branches are refused;
+    * the configured base must be non-protected for pr.open/merge to proceed. */
+   {
+      assert(wfe_base_is_protected("main"));
+      assert(wfe_base_is_protected("master"));
+      assert(wfe_base_is_protected("release-1.2"));
+      assert(wfe_base_is_protected("")); /* empty -> protected (fail closed) */
+      assert(!wfe_base_is_protected("testing"));
+      assert(!wfe_base_is_protected("aimee/wi/abc"));
+      unsetenv("AIMEE_AUTONOMY_BASE");
+      assert(strcmp(wfe_autonomous_base(), "testing") == 0);
+      assert(wfe_autonomous_target_ok());
+      setenv("AIMEE_AUTONOMY_BASE", "main", 1); /* misconfig -> guard refuses */
+      assert(!wfe_autonomous_target_ok());
+      setenv("AIMEE_AUTONOMY_BASE", "dev", 1);
+      assert(wfe_autonomous_target_ok());
+      unsetenv("AIMEE_AUTONOMY_BASE");
+   }
+
+   /* A7: per-run turn cap (WP-5) — once the cumulative audit-event count reaches
+    * the cap, an autonomous run parks budget_exceeded BEFORE advancing further
+    * (so a runaway loop can't burn unbounded turns). */
+   {
+      char id[80] = "", err[256] = "";
+      assert(wfe_work_item_create("auto", "cap1", "cap1", "autonomous", id, err, sizeof err) == 0);
+      for (int k = 0; k < 5; k++)
+         db1_lifecycle_event_add(id, "draft", "test", "t", "pad", "", 0);
+      setenv("AIMEE_AUTONOMY_MAX_TURNS", "3", 1);
+      assert(wfe_autonomy_run(id, err, sizeof err) == 0);
+      unsetenv("AIMEE_AUTONOMY_MAX_TURNS");
+      db1_work_item_t wi;
+      assert(db1_work_item_get(id, &wi) == 1);
+      assert(strcmp(wi.state, "active") == 0);
+      assert(strcmp(wi.pause_reason, "budget_exceeded") == 0);
    }
 
    printf("ok\n");

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -2,7 +2,9 @@
 #include "wfe_autonomy.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "cJSON.h"
 #include "wfe_store.h"
@@ -10,6 +12,29 @@
 #include "wfe_def.h"
 #include "wfe_engine.h"
 #include "wfe_iface.h"
+
+/* A positive long from an env var, else the default (a safety rail must never be
+ * silently disabled by a malformed override). */
+static long wfe_env_long(const char *name, long def)
+{
+   const char *v = getenv(name);
+   if (!v || !v[0])
+      return def;
+   char *end = NULL;
+   long n = strtol(v, &end, 10);
+   return (end && *end == '\0' && n > 0) ? n : def;
+}
+
+/* Park an active, not-yet-parked autonomous work item with budget_exceeded and
+ * audit the reason. Safety rail: on breach we park, never silently continue. */
+static void wfe_autonomy_park_budget(const char *work_item_id, const char *why)
+{
+   db1_work_item_t wi;
+   if (db1_work_item_get(work_item_id, &wi) != 1 || wi.pause_reason[0])
+      return;
+   db1_work_item_set_pause(work_item_id, "budget_exceeded", wi.current_stage);
+   db1_lifecycle_event_add(work_item_id, wi.current_stage, "pause", "engine", why, "", 0);
+}
 
 /* Is this paused node a human gate the driver may auto-satisfy in autonomous
  * mode? (policy preauthorized, or optional:true). */
@@ -33,8 +58,29 @@ static int human_gate_auto_ok(const wfe_node_t *node)
 
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
 {
+   /* Per-run safety ceilings (WP-5): a cumulative turn cap (counted from the
+    * persisted audit log, so it bounds the WHOLE run across resumes, not just this
+    * one) and a wall-clock cap for this resume. On breach -> park budget_exceeded.
+    * Env-overridable per deployment; a bad override falls back to the default. */
+   long max_turns = wfe_env_long("AIMEE_AUTONOMY_MAX_TURNS", 300);
+   long max_wall = wfe_env_long("AIMEE_AUTONOMY_MAX_WALL_SECS", 1800);
+   time_t run_start = time(NULL);
    for (int i = 0; i < 10000; i++)
    {
+      db1_lifecycle_event_t *evs = NULL;
+      int nev = db1_lifecycle_event_list(work_item_id, &evs);
+      free(evs);
+      if (nev > 0 && (long)nev >= max_turns)
+      {
+         wfe_autonomy_park_budget(work_item_id, "turn cap reached");
+         return 0;
+      }
+      if ((long)(time(NULL) - run_start) >= max_wall)
+      {
+         wfe_autonomy_park_budget(work_item_id, "wall-clock cap reached");
+         return 0;
+      }
+
       wfe_advance_result_t r;
       if (wfe_engine_advance(work_item_id, &r, err, errlen) != 0)
          return -1;

--- a/src/workflow/wfe_autonomy.c
+++ b/src/workflow/wfe_autonomy.c
@@ -1,6 +1,8 @@
 /* wfe_autonomy.c: the autonomy driver + human-only gate-override. */
 #include "wfe_autonomy.h"
 
+#include <errno.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -14,26 +16,40 @@
 #include "wfe_iface.h"
 
 /* A positive long from an env var, else the default (a safety rail must never be
- * silently disabled by a malformed override). */
+ * silently disabled by a malformed override). Rejects junk, non-positive, AND
+ * strtol overflow (ERANGE -> LONG_MAX would otherwise pass the n>0 test). */
 static long wfe_env_long(const char *name, long def)
 {
    const char *v = getenv(name);
    if (!v || !v[0])
       return def;
+   errno = 0;
    char *end = NULL;
    long n = strtol(v, &end, 10);
-   return (end && *end == '\0' && n > 0) ? n : def;
+   if (errno == ERANGE || !end || *end != '\0' || n <= 0)
+      return def;
+   return n;
 }
 
 /* Park an active, not-yet-parked autonomous work item with budget_exceeded and
- * audit the reason. Safety rail: on breach we park, never silently continue. */
-static void wfe_autonomy_park_budget(const char *work_item_id, const char *why)
+ * audit the reason. Returns 0 on a clean park, 1 if it was already parked (still
+ * audits the breach), -1 if the row could not be read (caller hard-stops — a
+ * safety rail must not silently no-op on a read failure). */
+static int wfe_autonomy_park_budget(const char *work_item_id, const char *why)
 {
    db1_work_item_t wi;
-   if (db1_work_item_get(work_item_id, &wi) != 1 || wi.pause_reason[0])
-      return;
+   if (db1_work_item_get(work_item_id, &wi) != 1)
+      return -1;
+   if (wi.pause_reason[0])
+   {
+      /* already parked (e.g. at a gate): record the breach for audit, don't
+       * overwrite the existing pause reason. */
+      db1_lifecycle_event_add(work_item_id, wi.current_stage, "budget", "engine", why, "", 0);
+      return 1;
+   }
    db1_work_item_set_pause(work_item_id, "budget_exceeded", wi.current_stage);
    db1_lifecycle_event_add(work_item_id, wi.current_stage, "pause", "engine", why, "", 0);
+   return 0;
 }
 
 /* Is this paused node a human gate the driver may auto-satisfy in autonomous
@@ -58,26 +74,41 @@ static int human_gate_auto_ok(const wfe_node_t *node)
 
 int wfe_autonomy_run(const char *work_item_id, char *err, size_t errlen)
 {
-   /* Per-run safety ceilings (WP-5): a cumulative turn cap (counted from the
-    * persisted audit log, so it bounds the WHOLE run across resumes, not just this
-    * one) and a wall-clock cap for this resume. On breach -> park budget_exceeded.
-    * Env-overridable per deployment; a bad override falls back to the default. */
+   /* Per-run safety ceilings (WP-5). max_turns is a CUMULATIVE cap on the persisted
+    * audit-event count: it bounds the WHOLE run across resumes (events persist), and
+    * because one advance emits several events it is a deliberately CONSERVATIVE upper
+    * bound on advances — fine for a runaway backstop. max_wall bounds THIS resume's
+    * wall-clock (a single hung resume); total run time is bounded transitively by the
+    * cumulative turn cap. On breach -> park budget_exceeded (never silently continue).
+    * Env-overridable; a bad override falls back to the default. */
    long max_turns = wfe_env_long("AIMEE_AUTONOMY_MAX_TURNS", 300);
    long max_wall = wfe_env_long("AIMEE_AUTONOMY_MAX_WALL_SECS", 1800);
-   time_t run_start = time(NULL);
+   struct timespec ts0;
+   clock_gettime(CLOCK_MONOTONIC, &ts0); /* monotonic: immune to NTP/clock jumps */
    for (int i = 0; i < 10000; i++)
    {
       db1_lifecycle_event_t *evs = NULL;
       int nev = db1_lifecycle_event_list(work_item_id, &evs);
       free(evs);
-      if (nev > 0 && (long)nev >= max_turns)
+      const char *breach = NULL;
+      if (nev < 0)
+         breach = "turn cap: audit log unreadable"; /* can't evaluate -> fail closed */
+      else if ((long)nev >= max_turns)
+         breach = "turn cap reached";
+      else
       {
-         wfe_autonomy_park_budget(work_item_id, "turn cap reached");
-         return 0;
+         struct timespec ts;
+         clock_gettime(CLOCK_MONOTONIC, &ts);
+         if ((long)(ts.tv_sec - ts0.tv_sec) >= max_wall)
+            breach = "wall-clock cap reached (this resume)";
       }
-      if ((long)(time(NULL) - run_start) >= max_wall)
+      if (breach)
       {
-         wfe_autonomy_park_budget(work_item_id, "wall-clock cap reached");
+         if (wfe_autonomy_park_budget(work_item_id, breach) < 0)
+         {
+            snprintf(err, errlen, "autonomy: budget breach but work item unreadable to park");
+            return -1; /* surface; never leave a breached run un-parked + claim success */
+         }
          return 0;
       }
 

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -307,6 +307,12 @@ static wfe_step_result_t exec_pr_open(wfe_ctx *ctx, const wfe_node_t *node)
 {
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
+   /* Safety rail: an autonomous PR may only target the configured non-protected
+    * base (default testing). Refuse a misconfiguration to main/master/release* —
+    * fail closed so the run stops rather than opening a PR against a protected
+    * branch. */
+   if (!wfe_autonomous_target_ok())
+      return wfe_step_failed();
    if (g_forge->open)
    {
       const char *branch = getenv("AIMEE_WORKFLOW_BRANCH");
@@ -354,6 +360,10 @@ static const char *pr_ref(wfe_ctx *ctx)
  *                      transient error -> park for a human re-drive). */
 static wfe_step_result_t exec_merge(wfe_ctx *ctx, const wfe_node_t *node)
 {
+   /* Safety rail (mirror pr.open): never merge an autonomous run into a protected
+    * branch. Fail closed on a misconfigured base. */
+   if (!wfe_autonomous_target_ok())
+      return wfe_step_failed();
    const char *repo = wfe_ctx_repo(ctx), *pr = pr_ref(ctx);
    int im = g_forge->is_merged(repo, pr);
    if (im == 1)

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <strings.h> /* strcasecmp / strncasecmp */
 
 /* ---- autonomous merge-target rail (WP-5 safety; see wfe_iface.h) ---- */
 
@@ -17,9 +18,14 @@ int wfe_base_is_protected(const char *branch)
 {
    if (!branch || !branch[0])
       return 1; /* empty -> treat as protected (fail closed) */
-   if (strcmp(branch, "main") == 0 || strcmp(branch, "master") == 0)
+   /* Case-insensitive: 'Main'/'MASTER' must not slip past. */
+   if (strcasecmp(branch, "main") == 0 || strcasecmp(branch, "master") == 0)
       return 1;
-   if (strncmp(branch, "release", 7) == 0)
+   /* Protect the release-train namespace ("release/..." or "release-<ver>") without
+    * snagging an unrelated branch that merely starts with the word "release"
+    * (e.g. "release-notes-edit"): require a separator + a version-ish char. */
+   if (strncasecmp(branch, "release", 7) == 0 && (branch[7] == '/' || branch[7] == '-') &&
+       (branch[8] == 'v' || (branch[8] >= '0' && branch[8] <= '9')))
       return 1;
    return 0;
 }

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -2,7 +2,32 @@
 #include "wfe_iface.h"
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
+
+/* ---- autonomous merge-target rail (WP-5 safety; see wfe_iface.h) ---- */
+
+const char *wfe_autonomous_base(void)
+{
+   const char *b = getenv("AIMEE_AUTONOMY_BASE");
+   return (b && b[0]) ? b : "testing";
+}
+
+int wfe_base_is_protected(const char *branch)
+{
+   if (!branch || !branch[0])
+      return 1; /* empty -> treat as protected (fail closed) */
+   if (strcmp(branch, "main") == 0 || strcmp(branch, "master") == 0)
+      return 1;
+   if (strncmp(branch, "release", 7) == 0)
+      return 1;
+   return 0;
+}
+
+int wfe_autonomous_target_ok(void)
+{
+   return !wfe_base_is_protected(wfe_autonomous_base());
+}
 
 static wfe_block_exec_fn g_execs[WFE_BLK__COUNT];
 

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -99,4 +99,15 @@ wfe_step_result_t wfe_step_pending(wfe_pause_reason_t reason);
 wfe_step_result_t wfe_step_failed(void);
 wfe_step_result_t wfe_step_looped(void);
 
+/* ---- Autonomous merge-target rail (WP-5 safety) ----
+ * The single source of truth for the branch an autonomous run may target for a
+ * PR/merge. Autonomous merges only ever go to this branch (default "testing");
+ * promotion to a protected branch (main/master/release*) stays a human action.
+ * Overridable via AIMEE_AUTONOMY_BASE, but NEVER to a protected branch — the guard
+ * refuses and pr.open/merge fail closed, so a misconfiguration can't reach main.
+ * F4's live forge resolves its PR base + merge target through these. */
+const char *wfe_autonomous_base(void);
+int wfe_base_is_protected(const char *branch); /* 1 if main/master/release* (refused) */
+int wfe_autonomous_target_ok(void);            /* 1 if the configured base is mergeable */
+
 #endif /* DEC_WFE_IFACE_H */


### PR DESCRIPTION
First safety-floor packet for **full-autonomous-development** (closeout). Lands the rails BEFORE any live forge, so an autonomous run can never run away or merge to a protected branch.

- **Merge-target rail** (`wfe_iface`): one source of truth `wfe_autonomous_base()` (default `testing`); `wfe_autonomous_target_ok()` checked at the top of `exec_pr_open`/`exec_merge` — a misconfig to main/master/release* fails closed. Promotion to main stays human. F4's live forge resolves its base/target through this.
- **Per-run caps** (`wfe_autonomy_run`): cumulative turn cap (from the persisted audit log → bounds the whole run across resumes) + per-resume wall-clock cap → park `budget_exceeded` on breach. Env-overridable; malformed override falls back to default (rail can't be silently disabled).

Tests: `test_wfe_autonomy` A6 (guard) + A7 (turn cap); existing wfe suite regresses clean.

Per the closeout design roundtable (Q2 resolved **default-OFF** for the live forge): the broader floor (worktree, verify-wiring, single-flight, live forge default-OFF, intake auth) follows; this self-contained rail gates them.