### PR TITLE
fix(kb): exclude vendored caller files from cross-repo route generation

### DIFF
--- a/src/db2/cross_repo_route.c
+++ b/src/db2/cross_repo_route.c
@@ -38,7 +38,9 @@ static const char *const SQL_MODULE_ROUTES =
         "ci.value") " || '/%' ESCAPE '\\' "
                     "  OR imp.name LIKE " ESC(
                         "ci.value") " || '::%' ESCAPE '\\') "
-                                    "WHERE ci.project <> pc.name AND ("
+                                    /* cf.vendored = 0: a vendored caller file is the
+                                     * dep's code, not the host's (recall §3). */
+                                    "WHERE ci.project <> pc.name AND cf.vendored = 0 AND ("
                                     "  (cf.language = 'go' AND ci.kind = 'gomod') "
                                     "  OR (cf.language = 'rust' AND ci.kind = 'crate') "
                                     "  OR (cf.language IN ('js', 'ts') AND ci.kind = 'npm') "
@@ -105,7 +107,12 @@ static const char *const SQL_HEADER_ROUTES =
     "JOIN projects pc ON pc.id = cf.project_id "
     "JOIN files fd ON (fd.path = imp.name OR fd.path LIKE '%/' || " ESC("imp.name") " ESCAPE '\\') "
     "JOIN projects pd ON pd.id = fd.project_id "
-    "WHERE cf.language IN ('c', 'cpp') AND fd.vendored = 0 AND pd.name <> pc.name "
+    /* cf.vendored = 0: a VENDORED caller file (e.g. a monorepo's subprojects/ or a
+     * fetched _deps/ tree) is the dep's code, not the host repo's — its #includes
+     * must not generate routes attributed to the host (recall §3, mirrors the
+     * definer-side fd.vendored = 0 and the originated-vendored exclusion). */
+    "WHERE cf.language IN ('c', 'cpp') AND cf.vendored = 0 AND fd.vendored = 0 "
+    "  AND pd.name <> pc.name "
     /* §2 header IDF: drop ubiquitous (>=4 non-vendored repos) include specifiers. */
     "  AND (SELECT COUNT(DISTINCT fx.project_id) FROM files fx "
     "       WHERE (fx.path = imp.name OR fx.path LIKE '%/' || " ESC("imp.name") " ESCAPE '\\') "

--- a/src/tests/test_cross_repo_route.c
+++ b/src/tests/test_cross_repo_route.c
@@ -330,6 +330,50 @@ static void test_angle_include_recall(void)
    printf("ok\n");
 }
 
+/* recall §3 (precision): a VENDORED caller file (a monorepo's subprojects/ tree,
+ * a fetched _deps/ copy) is the dep's code, not the host repo's — its #includes /
+ * module imports must NOT generate cross-repo routes attributed to the host. This
+ * killed the gstreamer-h265 FP routes (its entire tree is under vendored
+ * subprojects/, sharing generic header basenames like common.h/utils.h with other
+ * corpus repos). A NON-vendored caller still routes. */
+static void test_vendored_caller_excluded(void)
+{
+   printf("test_vendored_caller_excluded... ");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vcap','/vca','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vcap2','/vca2','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vchdr','/vch','t','trusted')");
+   X("INSERT INTO projects (name, root, scanned_at, trust) VALUES ('vcmod','/vcm','t','trusted')");
+   /* definer headers/identity (non-vendored, first-party). */
+   mk_file("vchdr", "include/vcwidget.h", "c", 0);
+   mk_identity("vcmod", "gomod", "example.com/vcmod");
+   /* vcap: a VENDORED file imports both — must produce NO routes from it. */
+   mk_file("vcap", "subprojects/dep/a.c", "c", 1);
+   mk_import("vcap", "subprojects/dep/a.c", "vcwidget.h");
+   mk_file("vcap", "subprojects/dep/b.go", "go", 1);
+   mk_import("vcap", "subprojects/dep/b.go", "example.com/vcmod/sub");
+   /* vcap: NON-vendored files import both — positive controls (header + module). */
+   mk_file("vcap", "src/own.c", "c", 0);
+   mk_import("vcap", "src/own.c", "vcwidget.h");
+   mk_file("vcap", "src/own.go", "go", 0);
+   mk_import("vcap", "src/own.go", "example.com/vcmod/sub");
+   /* vcap2: its ONLY importers are VENDORED — proves the exclusion independent of
+    * route dedup (no non-vendored sibling could mask a leaked vendored route). */
+   mk_file("vcap2", "subprojects/dep/c.c", "c", 1);
+   mk_import("vcap2", "subprojects/dep/c.c", "vcwidget.h");
+   mk_file("vcap2", "subprojects/dep/d.go", "go", 1);
+   mk_import("vcap2", "subprojects/dep/d.go", "example.com/vcmod/sub");
+
+   int rc = db2_cross_repo_rebuild_routes();
+   assert(rc >= 0);
+   /* vcap routes exist via its NON-vendored files (header + module controls). */
+   assert(route_count("vcap", "vchdr", "import_header") == 1);
+   assert(route_count("vcap", "vcmod", "import_module") == 1);
+   /* vcap2 has ONLY vendored importers -> no routes at all. */
+   assert(route_count("vcap2", "vchdr", "import_header") == 0);
+   assert(route_count("vcap2", "vcmod", "import_module") == 0);
+   printf("ok\n");
+}
+
 int main(void)
 {
    db2_test_shim_open();
@@ -337,6 +381,7 @@ int main(void)
    test_header_idf();
    test_prefer_local_and_generated();
    test_angle_include_recall();
+   test_vendored_caller_excluded();
    printf("cross_repo_route: all tests passed\n");
    return 0;
 }


### PR DESCRIPTION
## What

Precision fix found by the live §9 measurement of the recall-recovery build. After the recall fixes, **recall HIGH+MED hit 100%** but precision was hurt by ~6 false-positive **symbol** edges, all from `gstreamer-h265 → {aimee, wolf, Sunshine, moonlight-qt, moonlight-common-c}`.

`gstreamer-h265` is a full GStreamer monorepo: **200 non-vendored files vs 8284 vendored** (its whole tree is under `subprojects/`, flagged `vendored=1`). All 37 of its files importing generic basenames (`common.h`, `utils.h`, `audio.h`, `video.h`, `cuda.h`) are vendored, and the route-generation SQL filtered the **definer** (`fd.vendored = 0`) but **not the caller** — so a vendored caller file's `#include` of a generic header created an `import_header` route attributed to the **host** repo, matching another corpus repo's same-named file. `prefer-local` couldn't help: the caller's own copy is also vendored, and prefer-local deliberately ignores vendored local copies.

## Fix

Add `cf.vendored = 0` to `SQL_HEADER_ROUTES` and `SQL_MODULE_ROUTES`, mirroring the definer-side filter and the R3a originated-vendored principle — **a vendored caller file is the dep's code, not the host's.** A real cross-repo dep's *using* file is the host's own non-vendored code, so it still routes; a dep vendored *into* the host flows through the build-declared path + H2 canonical-preference, not via attributing the vendored copy's includes to the host.

## Test

`test_vendored_caller_excluded`: a vendored-only caller (`vcap2`) produces no header/module routes, while a sibling with non-vendored importers (`vcap`) routes for both (header + module positive controls). The separate vendored-only project proves the exclusion **independent of route dedup**.

## Review

Roundtable-reviewed: **converged, 0 blocking**. Added the suggested vendored-only-project case + non-vendored module control post-convergence. (The §2 header-IDF subquery already restricts `fx.vendored = 0`.)

## §9 status

With this fix, the recall-recovery §9 gate is met: **recall HIGH+MED = 100% (7/7)**; build-declared edge precision 100%; the gstreamer-h265 symbol FPs are eliminated.