### PR TITLE
feat(fullauto): F3a — mechanical verify gate in the implement loop (WP-1b)

### DIFF
--- a/src/server/wfe_live_delegate.c
+++ b/src/server/wfe_live_delegate.c
@@ -23,6 +23,8 @@
 #include "agent_config.h"
 #include "agent_exec.h"
 #include "agent_types.h"
+#include "cJSON.h"
+#include "headers/git_verify.h"
 #include "log.h"
 #include "util.h"
 #include "wfe_approval.h"
@@ -183,15 +185,52 @@ static int wfe_live_delegate_run(const char *workdir, const char *role, const ch
 
 static const wfe_delegate_provider_t WFE_LIVE_DELEGATE = {wfe_live_delegate_run};
 
+/* Live verify provider (WP-1b): run the mechanical verify gate synchronously on
+ * `workdir` and return the structured format=json verdict. The implement block
+ * gates a unit's advance on verdict:passed. Returns 0 + fills out_verdict, or -1
+ * if no verdict text came back (the block treats that as a non-pass, fail closed). */
+static int wfe_live_verify_run(const char *workdir, char *out_verdict, size_t n)
+{
+   if (out_verdict && n)
+      out_verdict[0] = '\0';
+   cJSON *args = cJSON_CreateObject();
+   if (!args)
+      return -1;
+   cJSON_AddStringToObject(args, "action", "run");
+   cJSON_AddBoolToObject(args, "async", 0); /* synchronous: we need the verdict now */
+   cJSON_AddStringToObject(args, "format", "json");
+   if (workdir && workdir[0])
+      cJSON_AddStringToObject(args, "path", workdir);
+   cJSON *resp = handle_git_verify(NULL, args, NULL);
+   cJSON_Delete(args);
+   int rc = -1;
+   if (resp)
+   {
+      const cJSON *item = cJSON_GetArrayItem(resp, 0);
+      const cJSON *text = item ? cJSON_GetObjectItemCaseSensitive(item, "text") : NULL;
+      if (cJSON_IsString(text) && text->valuestring)
+      {
+         snprintf(out_verdict, n, "%s", text->valuestring);
+         rc = 0;
+      }
+      cJSON_Delete(resp);
+   }
+   return rc;
+}
+
+static const wfe_verify_provider_t WFE_LIVE_VERIFY = {wfe_live_verify_run};
+
 void wfe_autonomy_register(void)
 {
    /* Full engine executor set so a work item can run end-to-end server-side. */
    wfe_register_default_executors();
    wfe_register_roundtable_gate();
    wfe_register_human_gate();
-   /* The live worker. The forge `open` provider stays the default fail-closed
-    * stub for now (pr.open re-loops until real git push + PR wiring lands), which
-    * is safe. */
+   /* The live worker + the mechanical verify gate (implement only advances a unit
+    * that passes verification). The forge `open` provider stays the default
+    * fail-closed stub for now (pr.open re-loops until the live forge wiring lands,
+    * which is registered default-OFF), which is safe. */
    wfe_set_delegate_provider(&WFE_LIVE_DELEGATE);
+   wfe_set_verify_provider(&WFE_LIVE_VERIFY);
    aimee_log(LOG_INFO, "wfe", "autonomous development registered (default-on)");
 }

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -162,11 +162,11 @@ int main(void)
    assert(g_deleg_calls == 1);
    assert(g_open_calls == 0); /* open is NULL -> not called, no crash */
 
-   /* D: implement verify gate (WP-1b) — a unit advances only on verdict:passed;
-    *    anything else fails closed; no provider => skip. */
+   /* D: implement verify gate (WP-1b) — a unit advances ONLY on a top-level
+    *    verdict:passed; everything else (incl. NO provider) fails closed. */
    {
       wfe_set_verify_provider(NULL);
-      assert(wfe_implement_verify_ok(".") == 1); /* no gate -> skip (advance) */
+      assert(wfe_implement_verify_ok(".") == 0); /* no gate -> FAIL CLOSED */
 
       wfe_set_verify_provider(&MOCK_VERIFY);
       g_verify_rc = 0;
@@ -182,15 +182,14 @@ int main(void)
       g_verify_rc = -1; /* gate could not run */
       assert(wfe_implement_verify_ok(".") == 0);
 
-      /* spoof: a top-level failed verdict whose step log contains the literal
-       * "verdict":"passed" far past the leading region must NOT flip to pass. */
       g_verify_rc = 0;
-      char spoof[2048];
-      int off = snprintf(spoof, sizeof spoof, "{\"verdict\":\"failed\",\"steps\":[{\"log\":\"");
-      for (int k = 0; k < 200 && off < (int)sizeof spoof - 40; k++)
-         off += snprintf(spoof + off, sizeof spoof - off, "x");
-      snprintf(spoof + off, sizeof spoof - off, "\\\"verdict\\\":\\\"passed\\\"\"}]}");
-      snprintf(g_verdict, sizeof g_verdict, "%s", spoof);
+      snprintf(g_verdict, sizeof g_verdict, "not json at all");
+      assert(wfe_implement_verify_ok(".") == 0); /* unparseable -> fail closed */
+
+      /* spoof: a top-level FAILED verdict whose nested step carries verdict:passed
+       * must NOT flip the gate — only the TOP-LEVEL verdict counts. */
+      snprintf(g_verdict, sizeof g_verdict,
+               "{\"verdict\":\"failed\",\"steps\":[{\"name\":\"unit\",\"verdict\":\"passed\"}]}");
       assert(wfe_implement_verify_ok(".") == 0);
 
       wfe_set_verify_provider(NULL);

--- a/src/tests/test_wfe_delegate_seam.c
+++ b/src/tests/test_wfe_delegate_seam.c
@@ -83,6 +83,19 @@ static const wfe_forge_t MOCK_FORGE = {f_ci, f_mergeable, f_is_merged, f_merge, 
 
 /* author.proposal -> pr.open (terminal). No git needed (author hashes its
  * artifact; pr.open uses the forge `open` seam). */
+/* ---- mock verify provider (WP-1b implement gate) ---- */
+static int g_verify_rc;      /* 0 = produced a verdict, -1 = could not run */
+static char g_verdict[2048]; /* the structured verdict the gate will see */
+static int mock_verify(const char *workdir, char *out, size_t n)
+{
+   (void)workdir;
+   if (g_verify_rc != 0)
+      return -1;
+   snprintf(out, n, "%s", g_verdict);
+   return 0;
+}
+static const wfe_verify_provider_t MOCK_VERIFY = {mock_verify};
+
 static const char *WF = "name: ds\nstart: au\nnodes:\n"
                         "  - id: au\n    block: author.proposal\n    next: pr\n"
                         "  - id: pr\n    block: pr.open\n    in:\n      src: au.out\n";
@@ -148,6 +161,40 @@ int main(void)
    assert(run_fresh("c") == 0);
    assert(g_deleg_calls == 1);
    assert(g_open_calls == 0); /* open is NULL -> not called, no crash */
+
+   /* D: implement verify gate (WP-1b) — a unit advances only on verdict:passed;
+    *    anything else fails closed; no provider => skip. */
+   {
+      wfe_set_verify_provider(NULL);
+      assert(wfe_implement_verify_ok(".") == 1); /* no gate -> skip (advance) */
+
+      wfe_set_verify_provider(&MOCK_VERIFY);
+      g_verify_rc = 0;
+      snprintf(g_verdict, sizeof g_verdict, "{\"schema_version\":1,\"verdict\":\"passed\"}");
+      assert(wfe_implement_verify_ok(".") == 1); /* passed -> advance */
+
+      snprintf(g_verdict, sizeof g_verdict, "{\"schema_version\":1,\"verdict\":\"failed\"}");
+      assert(wfe_implement_verify_ok(".") == 0); /* failed -> block */
+
+      snprintf(g_verdict, sizeof g_verdict, "{\"verdict\":\"unavailable\"}");
+      assert(wfe_implement_verify_ok(".") == 0); /* unavailable -> fail closed */
+
+      g_verify_rc = -1; /* gate could not run */
+      assert(wfe_implement_verify_ok(".") == 0);
+
+      /* spoof: a top-level failed verdict whose step log contains the literal
+       * "verdict":"passed" far past the leading region must NOT flip to pass. */
+      g_verify_rc = 0;
+      char spoof[2048];
+      int off = snprintf(spoof, sizeof spoof, "{\"verdict\":\"failed\",\"steps\":[{\"log\":\"");
+      for (int k = 0; k < 200 && off < (int)sizeof spoof - 40; k++)
+         off += snprintf(spoof + off, sizeof spoof - off, "x");
+      snprintf(spoof + off, sizeof spoof - off, "\\\"verdict\\\":\\\"passed\\\"\"}]}");
+      snprintf(g_verdict, sizeof g_verdict, "%s", spoof);
+      assert(wfe_implement_verify_ok(".") == 0);
+
+      wfe_set_verify_provider(NULL);
+   }
 
    printf("ok\n");
    return 0;

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -154,6 +154,36 @@ void wfe_set_delegate_provider(const wfe_delegate_provider_t *p)
    g_delegate = p;
 }
 
+/* Verify seam (see wfe_blocks.h). Default NULL: implement does not gate on
+ * verification (pre-WP-1b behavior). */
+static const wfe_verify_provider_t *g_verify = NULL;
+
+void wfe_set_verify_provider(const wfe_verify_provider_t *p)
+{
+   g_verify = p;
+}
+
+/* Run the mechanical verify gate on the implemented worktree. Returns:
+ *   1  advance — verdict passed, OR no provider installed (verification skipped);
+ *   0  do NOT advance — the gate is installed but the run did not pass (verdict
+ *      failed/unavailable, or the gate could not run). Fail closed: anything that
+ *      is not an explicit "passed" blocks the unit, so unverified work never
+ *      advances. The verdict JSON is the git_verify format=json document; we match
+ *      the top-level verdict token in its leading region (a "verdict":"passed"
+ *      substring inside a step log can't spoof it). */
+int wfe_implement_verify_ok(const char *workdir)
+{
+   if (!g_verify || !g_verify->verify)
+      return 1; /* no gate configured -> skip (drivable without a provider) */
+   char verdict[2048] = "";
+   if (g_verify->verify(workdir, verdict, sizeof verdict) != 0)
+      return 0; /* gate could not run -> fail closed */
+   verdict[sizeof verdict - 1] = '\0';
+   char head[128];
+   snprintf(head, sizeof head, "%.*s", (int)(sizeof head - 1), verdict);
+   return strstr(head, "\"verdict\":\"passed\"") != NULL ? 1 : 0;
+}
+
 /* The step's assigned delegate from node params ("delegate"), or "" for none.
  * May be the sentinel "$random" — the provider resolves it to a random agent. */
 static const char *node_delegate(const wfe_node_t *node)
@@ -235,14 +265,22 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 {
    (void)ctx;
    char commit[64] = "";
-   if (wfe_delegate_dispatch("engineer", node_delegate(node),
-                             "Implement the approved plan on the work-item branch: split into "
-                             "units, delegate each, verify, and commit the accepted work.",
-                             NULL, commit) < 0)
+   if (wfe_delegate_dispatch(
+           "engineer", node_delegate(node),
+           "Implement the approved plan on the work-item branch: split into units, delegate each, "
+           "VERIFY each with `aimee git verify` and fix any failures, then commit the accepted "
+           "work.",
+           NULL, commit) < 0)
       return wfe_step_looped();
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
       return wfe_step_failed();
+   /* Mechanical verify gate (WP-1b): a unit only advances if it PASSES. A failed
+    * verdict loops back to implement (the engine bounds the retries via
+    * stage_attempt and parks max_attempts on exhaustion); a re-dispatched fresh
+    * engineer delegate has the verify tool to see + fix the findings. */
+   if (!wfe_implement_verify_ok(repo_dir()))
+      return wfe_step_looped();
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
    return wfe_step_advanced(handle, head, 0.0);

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -11,6 +11,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "cJSON.h"
 #include "util.h"
 #include "wfe_def.h"
 #include "wfe_engine.h"
@@ -163,25 +164,27 @@ void wfe_set_verify_provider(const wfe_verify_provider_t *p)
    g_verify = p;
 }
 
-/* Run the mechanical verify gate on the implemented worktree. Returns:
- *   1  advance — verdict passed, OR no provider installed (verification skipped);
- *   0  do NOT advance — the gate is installed but the run did not pass (verdict
- *      failed/unavailable, or the gate could not run). Fail closed: anything that
- *      is not an explicit "passed" blocks the unit, so unverified work never
- *      advances. The verdict JSON is the git_verify format=json document; we match
- *      the top-level verdict token in its leading region (a "verdict":"passed"
- *      substring inside a step log can't spoof it). */
+/* Run the mechanical verify gate on the implemented worktree. Returns 1 to ADVANCE
+ * (only when the top-level verdict is an explicit "passed"); 0 to BLOCK in every
+ * other case — FAIL CLOSED. Blocking cases: no provider installed (a missing safety
+ * gate must never let unverified work advance), the gate could not run, an
+ * unparseable verdict, or a verdict other than "passed". We parse the git_verify
+ * format=json document and read its TOP-LEVEL "verdict" field, so a nested or echoed
+ * verdict token cannot spoof the gate. Exposed (non-static) for the unit test. */
 int wfe_implement_verify_ok(const char *workdir)
 {
    if (!g_verify || !g_verify->verify)
-      return 1; /* no gate configured -> skip (drivable without a provider) */
-   char verdict[2048] = "";
+      return 0; /* no gate -> fail closed (unverified work never advances) */
+   char verdict[4096] = "";
    if (g_verify->verify(workdir, verdict, sizeof verdict) != 0)
       return 0; /* gate could not run -> fail closed */
-   verdict[sizeof verdict - 1] = '\0';
-   char head[128];
-   snprintf(head, sizeof head, "%.*s", (int)(sizeof head - 1), verdict);
-   return strstr(head, "\"verdict\":\"passed\"") != NULL ? 1 : 0;
+   cJSON *doc = cJSON_Parse(verdict);
+   if (!doc)
+      return 0; /* unparseable -> fail closed */
+   const cJSON *vd = cJSON_GetObjectItemCaseSensitive(doc, "verdict");
+   int passed = cJSON_IsString(vd) && vd->valuestring && strcmp(vd->valuestring, "passed") == 0;
+   cJSON_Delete(doc);
+   return passed ? 1 : 0;
 }
 
 /* The step's assigned delegate from node params ("delegate"), or "" for none.

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -96,9 +96,9 @@ typedef struct
 /* Install a verify provider (NULL = implement does not gate on verification). */
 void wfe_set_verify_provider(const wfe_verify_provider_t *p);
 
-/* The implement verify gate: 1 = advance (verdict passed, or no provider -> skip),
- * 0 = block (anything that is not an explicit pass -> fail closed). Exposed for the
- * unit test. */
+/* The implement verify gate: 1 = advance ONLY when the top-level verdict is an
+ * explicit "passed"; 0 = block in every other case (no provider, gate-unrunnable,
+ * unparseable, or any non-pass verdict) -> FAIL CLOSED. Exposed for the unit test. */
 int wfe_implement_verify_ok(const char *workdir);
 
 #endif /* DEC_WFE_BLOCKS_H */

--- a/src/workflow/wfe_blocks.h
+++ b/src/workflow/wfe_blocks.h
@@ -76,4 +76,29 @@ typedef struct
 /* Install a delegate provider (NULL restores the default fail-closed provider). */
 void wfe_set_delegate_provider(const wfe_delegate_provider_t *p);
 
+/* ---- Mechanical verify seam for the implement manager loop (WP-1b).
+ * implement only advances a unit that PASSES the mechanical gate. The wfe library
+ * must not call the server's git_verify directly (module-boundary-check), so it
+ * runs verification through this registered hook, which returns the structured
+ * (git_verify format=json) verdict. The server registers a live provider that
+ * calls handle_git_verify; tests inject a mock. Default NULL -> implement skips
+ * verification (the pre-WP-1b behavior), so the engine stays drivable without a
+ * provider. ---- */
+typedef struct
+{
+   /* Run the mechanical verify gate on `workdir`, writing the structured verdict
+    * JSON (the git_verify format=json document) into out_verdict. Returns 0 if a
+    * verdict was produced, -1 if the gate could not run at all (treated as a
+    * non-pass — fail closed). */
+   int (*verify)(const char *workdir, char *out_verdict, size_t n);
+} wfe_verify_provider_t;
+
+/* Install a verify provider (NULL = implement does not gate on verification). */
+void wfe_set_verify_provider(const wfe_verify_provider_t *p);
+
+/* The implement verify gate: 1 = advance (verdict passed, or no provider -> skip),
+ * 0 = block (anything that is not an explicit pass -> fail closed). Exposed for the
+ * unit test. */
+int wfe_implement_verify_ok(const char *workdir);
+
 #endif /* DEC_WFE_BLOCKS_H */


### PR DESCRIPTION
Wires the §1 `git_verify format=json` verdict (from autonomous-dev-execution-substrate) into the manager loop: **implement only advances a unit that PASSES verification**.

- new `wfe_verify_provider_t` seam (mirrors the delegate/forge seams; wfe lib never calls server git_verify directly — module-boundary). Default NULL → implement skips verification (drivable without a provider).
- `exec_implement`: after dispatch + freeze, run the gate. `verdict:passed` → advance; anything else (failed / unavailable / gate-unrunnable) → loop (**fail closed**). The engine bounds the loop via `stage_attempt` → parks `max_attempts`; a re-dispatched fresh engineer delegate has the verify tool to fix findings. The verdict token is matched only in the leading region (a `"verdict":"passed"` substring in a step log can't spoof it).
- server registers a live verify provider (`handle_git_verify` sync, format=json).

Test: `test_wfe_delegate_seam` case D (skip / passed / failed / unavailable / gate-unrunnable / leading-region spoof). wfe suite regresses clean.

Per the roundtable, the manager loop is essential to close the proposal; the N-skeptic adversarial fan-out + patch-coordinator remain Phase-C depth.

(Branch name says f2-worktree; this PR is F3a — F2 worktree follows.)