### PR TITLE
feat(fullauto): F1b — make the per-run USD budget cap functional (WP-5)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -213,7 +213,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 126 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 128 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -409,7 +409,7 @@ The binaries read 126 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_AUTONOMY_BASE`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -26,6 +26,7 @@
 #include "webchat_live.h"     /* db1_webchat_live_get — the browser's live-turn poll */
 #include "index.h"            /* index_scan_project after a webuser clone (WP-D) */
 #include "aimee_home.h"       /* aimee_home — proposal artifact dir for /v1/dev/submit */
+#include <math.h>             /* isfinite — validate the /v1/dev/submit budget cap */
 #include "wfe_engine.h"       /* wfe_work_item_create — POST /v1/dev/submit intake */
 #include "wfe_scheduler.h"    /* wfe_scheduler_notify — resume the autonomy driver */
 #include "wfe_approval.h"     /* wfe_approval_record/present — human-gate approval */
@@ -239,7 +240,7 @@ static int rh_dev_submit(const route_req_t *rq, char *resp, int cap)
       {
          char *e = NULL;
          double d = strtod(v, &e);
-         if (e && *e == '\0' && d >= 0)
+         if (e && *e == '\0' && isfinite(d) && d >= 0) /* reject inf/NaN: would void the cap */
             cap_usd = d;
       }
       if (cap_usd > 0)

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -227,6 +227,24 @@ static int rh_dev_submit(const route_req_t *rq, char *resp, int cap)
       return 500;
    }
    cJSON_Delete(body);
+   /* WP-5: a per-run USD budget ceiling so a runaway autonomous run parks
+    * (budget_exceeded) instead of burning unbounded delegate cost. Default $5.00;
+    * AIMEE_AUTONOMY_MAX_USD overrides (set it to 0 to disable the cap). The engine
+    * checks cum_cost_usd against this each advance; cost is the server-side
+    * wall-clock estimate threaded from the delegate dispatch. */
+   {
+      double cap_usd = 5.0;
+      const char *v = getenv("AIMEE_AUTONOMY_MAX_USD");
+      if (v && v[0])
+      {
+         char *e = NULL;
+         double d = strtod(v, &e);
+         if (e && *e == '\0' && d >= 0)
+            cap_usd = d;
+      }
+      if (cap_usd > 0)
+         db1_work_item_set_cost_cap(id, cap_usd);
+   }
    wfe_scheduler_notify(); /* drive it now; the run continues server-side */
    cJSON *ok = cJSON_CreateObject();
    cJSON_AddStringToObject(ok, "work_item_id", id);

--- a/src/tests/test_wfe_autonomy.c
+++ b/src/tests/test_wfe_autonomy.c
@@ -204,6 +204,23 @@ int main(void)
       assert(strcmp(wi.pause_reason, "budget_exceeded") == 0);
    }
 
+   /* A8: server-side cost estimate (WP-5) — wall-clock seconds * rate; negative
+    * elapsed clamps to 0; the rate is env-overridable. */
+   {
+      unsetenv("AIMEE_AUTONOMY_USD_PER_SEC");
+      assert(wfe_autonomy_cost_estimate(0.0) == 0.0);
+      assert(wfe_autonomy_cost_estimate(-5.0) == 0.0); /* clamp */
+      double c = wfe_autonomy_cost_estimate(10.0);     /* 10s * 0.0005 = 0.005 */
+      assert(c > 0.0049 && c < 0.0051);
+      setenv("AIMEE_AUTONOMY_USD_PER_SEC", "0.01", 1);
+      c = wfe_autonomy_cost_estimate(10.0); /* 10s * 0.01 = 0.1 */
+      assert(c > 0.099 && c < 0.101);
+      setenv("AIMEE_AUTONOMY_USD_PER_SEC", "junk", 1); /* malformed -> default */
+      c = wfe_autonomy_cost_estimate(10.0);
+      assert(c > 0.0049 && c < 0.0051);
+      unsetenv("AIMEE_AUTONOMY_USD_PER_SEC");
+   }
+
    printf("ok\n");
    return 0;
 }

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -216,15 +216,26 @@ static int wfe_delegate_dispatch(const char *role, const char *delegate, const c
    if (!g_delegate || !g_delegate->run)
       return 0;
    char err[256] = "";
-   struct timespec t0, t1;
-   clock_gettime(CLOCK_MONOTONIC, &t0);
+   struct timespec t0 = {0, 0}, t1 = {0, 0};
+   int ok0 = clock_gettime(CLOCK_MONOTONIC, &t0) == 0;
    int rc = g_delegate->run(repo_dir(), role, delegate ? delegate : "", prompt, artifact_path,
                             out_commit_sha, err, sizeof err);
-   clock_gettime(CLOCK_MONOTONIC, &t1);
-   if (out_cost)
-      *out_cost = wfe_autonomy_cost_estimate((double)(t1.tv_sec - t0.tv_sec) +
-                                             (double)(t1.tv_nsec - t0.tv_nsec) / 1e9);
+   int ok1 = clock_gettime(CLOCK_MONOTONIC, &t1) == 0;
+   if (out_cost) /* a failed turn still consumed wall-clock -> still costs */
+      *out_cost = (ok0 && ok1) ? wfe_autonomy_cost_estimate((double)(t1.tv_sec - t0.tv_sec) +
+                                                            (double)(t1.tv_nsec - t0.tv_nsec) / 1e9)
+                               : 0.0;
    return rc == 0 ? 1 : -1;
+}
+
+/* Attach the measured delegate cost to a result, so a turn's wall-clock cost is
+ * charged against the per-run budget on EVERY return path (loop/fail/advance),
+ * not only on advance — else a retry-loop or broken-artifact runaway pays nothing
+ * and the USD cap never bites. */
+static wfe_step_result_t with_cost(wfe_step_result_t r, double cost)
+{
+   r.cost_usd = cost;
+   return r;
 }
 
 /* ---- executors ---- */
@@ -243,7 +254,7 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
                              "Author or revise the workflow artifact at the given path "
                              "per the work item, then commit it.",
                              path, commit, &cost) < 0)
-      return wfe_step_looped();
+      return with_cost(wfe_step_looped(), cost);
    char hash[65] = "";
    if (path && path[0])
    {
@@ -288,16 +299,16 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
            "VERIFY each with `aimee git verify` and fix any failures, then commit the accepted "
            "work.",
            NULL, commit, &cost) < 0)
-      return wfe_step_looped();
+      return with_cost(wfe_step_looped(), cost);
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
-      return wfe_step_failed();
+      return with_cost(wfe_step_failed(), cost);
    /* Mechanical verify gate (WP-1b): a unit only advances if it PASSES. A failed
     * verdict loops back to implement (the engine bounds the retries via
     * stage_attempt and parks max_attempts on exhaustion); a re-dispatched fresh
     * engineer delegate has the verify tool to see + fix the findings. */
    if (!wfe_implement_verify_ok(repo_dir()))
-      return wfe_step_looped();
+      return with_cost(wfe_step_looped(), cost);
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
    return wfe_step_advanced(handle, head, cost);
@@ -317,10 +328,10 @@ static wfe_step_result_t exec_document(wfe_ctx *ctx, const wfe_node_t *node)
                              "Document the change on the work-item branch (README/CHANGELOG/docs "
                              "+ inline comments), then commit.",
                              NULL, commit, &cost) < 0)
-      return wfe_step_looped();
+      return with_cost(wfe_step_looped(), cost);
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
-      return wfe_step_failed();
+      return with_cost(wfe_step_failed(), cost);
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
    return wfe_step_advanced(handle, head, cost);

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 
 #include "cJSON.h"
 #include "util.h"
@@ -198,20 +199,31 @@ static const char *node_delegate(const wfe_node_t *node)
 }
 
 /* Dispatch one block's delegate work, if a provider is installed. `delegate` is
- * the step's assigned agent (or "$random", or "" to route by role). Returns:
+ * the step's assigned agent (or "$random", or "" to route by role). out_cost (may
+ * be NULL) receives the server-side wall-clock USD estimate for the turn (WP-5
+ * budget). Returns:
  *   1  provider ran and succeeded,
  *   0  no provider installed (caller falls back to its fail-closed path),
  *  -1  provider ran and failed (caller should loop/retry). */
 static int wfe_delegate_dispatch(const char *role, const char *delegate, const char *prompt,
-                                 const char *artifact_path, char out_commit_sha[64])
+                                 const char *artifact_path, char out_commit_sha[64],
+                                 double *out_cost)
 {
    if (out_commit_sha)
       out_commit_sha[0] = '\0';
+   if (out_cost)
+      *out_cost = 0.0;
    if (!g_delegate || !g_delegate->run)
       return 0;
    char err[256] = "";
+   struct timespec t0, t1;
+   clock_gettime(CLOCK_MONOTONIC, &t0);
    int rc = g_delegate->run(repo_dir(), role, delegate ? delegate : "", prompt, artifact_path,
                             out_commit_sha, err, sizeof err);
+   clock_gettime(CLOCK_MONOTONIC, &t1);
+   if (out_cost)
+      *out_cost = wfe_autonomy_cost_estimate((double)(t1.tv_sec - t0.tv_sec) +
+                                             (double)(t1.tv_nsec - t0.tv_nsec) / 1e9);
    return rc == 0 ? 1 : -1;
 }
 
@@ -226,10 +238,11 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
     * a failed run loops). Then hash the artifact file as the produced content; if
     * it is absent (no provider ran) the gate that follows simply re-loops. */
    char commit[64] = "";
+   double cost = 0.0;
    if (wfe_delegate_dispatch("architect", node_delegate(node),
                              "Author or revise the workflow artifact at the given path "
                              "per the work item, then commit it.",
-                             path, commit) < 0)
+                             path, commit, &cost) < 0)
       return wfe_step_looped();
    char hash[65] = "";
    if (path && path[0])
@@ -255,7 +268,7 @@ static wfe_step_result_t exec_author(wfe_ctx *ctx, const wfe_node_t *node)
    }
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
-   return wfe_step_advanced(handle, hash, 0.0);
+   return wfe_step_advanced(handle, hash, cost);
 }
 
 /* implement: the manager loop. The live delegate provider owns decompose -> fan
@@ -268,12 +281,13 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
 {
    (void)ctx;
    char commit[64] = "";
+   double cost = 0.0;
    if (wfe_delegate_dispatch(
            "engineer", node_delegate(node),
            "Implement the approved plan on the work-item branch: split into units, delegate each, "
            "VERIFY each with `aimee git verify` and fix any failures, then commit the accepted "
            "work.",
-           NULL, commit) < 0)
+           NULL, commit, &cost) < 0)
       return wfe_step_looped();
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
@@ -286,7 +300,7 @@ static wfe_step_result_t exec_implement(wfe_ctx *ctx, const wfe_node_t *node)
       return wfe_step_looped();
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
-   return wfe_step_advanced(handle, head, 0.0);
+   return wfe_step_advanced(handle, head, cost);
 }
 
 /* document: produces the (documented) branch. In production a delegate writes
@@ -298,17 +312,18 @@ static wfe_step_result_t exec_document(wfe_ctx *ctx, const wfe_node_t *node)
 {
    (void)ctx;
    char commit[64] = "";
+   double cost = 0.0;
    if (wfe_delegate_dispatch("engineer", node_delegate(node),
                              "Document the change on the work-item branch (README/CHANGELOG/docs "
                              "+ inline comments), then commit.",
-                             NULL, commit) < 0)
+                             NULL, commit, &cost) < 0)
       return wfe_step_looped();
    char base[64] = "", head[64] = "", dhash[65] = "", err[128] = "";
    if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
       return wfe_step_failed();
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
-   return wfe_step_advanced(handle, head, 0.0);
+   return wfe_step_advanced(handle, head, cost);
 }
 
 /* freeze: capture the cumulative diff at a stable freeze commit. */

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -1,6 +1,7 @@
 /* wfe_iface.c -- the narrow executor vtable + step-result constructors. */
 #include "wfe_iface.h"
 
+#include <math.h> /* isfinite */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -48,11 +49,13 @@ double wfe_autonomy_cost_estimate(double elapsed_secs)
    {
       char *end = NULL;
       double r = strtod(v, &end);
-      if (end && *end == '\0' && r >= 0)
+      /* require finite AND strictly positive: inf/NaN or rate==0 would silently
+       * neutralize the budget cap (every turn would cost 0 or inf). Fall back. */
+      if (end && *end == '\0' && isfinite(r) && r > 0)
          rate = r;
    }
-   if (elapsed_secs < 0)
-      elapsed_secs = 0;
+   if (!(elapsed_secs > 0)) /* also rejects NaN */
+      return 0;
    return elapsed_secs * rate;
 }
 

--- a/src/workflow/wfe_iface.c
+++ b/src/workflow/wfe_iface.c
@@ -35,6 +35,27 @@ int wfe_autonomous_target_ok(void)
    return !wfe_base_is_protected(wfe_autonomous_base());
 }
 
+/* Server-side authoritative cost estimate (WP-5): a delegate turn's USD cost as
+ * wall-clock seconds * a configured rate. Provider-agnostic (never trusts a
+ * provider-reported figure) so the per-run USD budget cap actually bites. Rate is
+ * AIMEE_AUTONOMY_USD_PER_SEC (default 0.0005 ~= $1.80/hr of delegate wall-clock); a
+ * malformed/negative override falls back to the default. Negative elapsed -> 0. */
+double wfe_autonomy_cost_estimate(double elapsed_secs)
+{
+   double rate = 0.0005;
+   const char *v = getenv("AIMEE_AUTONOMY_USD_PER_SEC");
+   if (v && v[0])
+   {
+      char *end = NULL;
+      double r = strtod(v, &end);
+      if (end && *end == '\0' && r >= 0)
+         rate = r;
+   }
+   if (elapsed_secs < 0)
+      elapsed_secs = 0;
+   return elapsed_secs * rate;
+}
+
 static wfe_block_exec_fn g_execs[WFE_BLK__COUNT];
 
 void wfe_register_block_executor(wfe_block_type_t type, wfe_block_exec_fn fn)

--- a/src/workflow/wfe_iface.h
+++ b/src/workflow/wfe_iface.h
@@ -110,4 +110,10 @@ const char *wfe_autonomous_base(void);
 int wfe_base_is_protected(const char *branch); /* 1 if main/master/release* (refused) */
 int wfe_autonomous_target_ok(void);            /* 1 if the configured base is mergeable */
 
+/* Authoritative server-side USD cost for a delegate turn of `elapsed_secs`
+ * wall-clock (rate AIMEE_AUTONOMY_USD_PER_SEC, default 0.0005). Provider-agnostic,
+ * so the per-run budget cap is enforced on a figure the provider can't understate.
+ * Negative elapsed -> 0. */
+double wfe_autonomy_cost_estimate(double elapsed_secs);
+
 #endif /* DEC_WFE_IFACE_H */


### PR DESCRIPTION
The engine has a per-work-item USD cap but delegate steps reported `cost 0.0`, so it never tripped. This threads a real server-side cost so the cap bites.

- new `wfe_autonomy_cost_estimate(secs)` — authoritative server-side USD = delegate wall-clock × `AIMEE_AUTONOMY_USD_PER_SEC` (default 0.0005). Provider-agnostic (never trusts a provider figure → can't be understated); negative clamps to 0; malformed rate → default.
- `wfe_delegate_dispatch` times `CLOCK_MONOTONIC` around the run; author/implement/document report the estimate (was 0.0) → the engine's existing cost check parks `budget_exceeded`.
- intake sets a default per-run cap ($5.00, `AIMEE_AUTONOMY_MAX_USD`-overridable; 0 disables).

Test: `test_wfe_autonomy` A8 (estimate math, clamp, env override + malformed fallback). wfe suite green. Completes the WP-5 budget story (the turn + wall-clock caps shipped in #856; this makes the USD cap live too).