### PR TITLE
fix(kb): collect C++ headers (.hpp/.hh/.hxx) — were systematically unindexed

### DIFF
--- a/src/code_collect.c
+++ b/src/code_collect.c
@@ -17,10 +17,18 @@
 
 static int code_ext_ok(const char *name)
 {
-   static const char *const exts[] = {".c",    ".h",   ".cc",    ".cpp",  ".cxx", ".m",    ".py",
-                                      ".go",   ".rs",  ".ts",    ".tsx",  ".js",  ".jsx",  ".md",
-                                      ".yaml", ".yml", ".toml",  ".json", ".sh",  ".bash", ".rb",
-                                      ".java", ".kt",  ".swift", NULL};
+   /* C++ headers (.hpp/.hh/.hxx) were missing — they are the dominant public-API
+    * header extension, so a C++ library's include/ tree (and thus its class/method
+    * symbols and the includes that form cross-repo routes) was never collected. The
+    * kb-side extractor parses them as LANG_C (extractors.c c_exts, which this change
+    * extends in lockstep so the collector never sends an extension the extractor
+    * can't parse). `.inc` is intentionally NOT collected: c_exts lists it, but in
+    * this corpus it is high-volume ambiguous/generated C-include fragments (e.g.
+    * aimee's own *_gen.inc), not a cross-repo API surface. */
+   static const char *const exts[] = {".c",   ".h",    ".cc", ".cpp",  ".cxx", ".hpp",   ".hh",
+                                      ".hxx", ".m",    ".py", ".go",   ".rs",  ".ts",    ".tsx",
+                                      ".js",  ".jsx",  ".md", ".yaml", ".yml", ".toml",  ".json",
+                                      ".sh",  ".bash", ".rb", ".java", ".kt",  ".swift", NULL};
    const char *dot = strrchr(name, '.');
    if (!dot || dot == name)
       return 0;

--- a/src/extractors.c
+++ b/src/extractors.c
@@ -14,7 +14,8 @@ static const char *cs_exts[] = {".cs", NULL};
 static const char *sh_exts[] = {".sh", ".bash", ".zsh", NULL};
 static const char *css_exts[] = {".css", NULL};
 static const char *dart_exts[] = {".dart", NULL};
-static const char *c_exts[] = {".c", ".h", ".cpp", ".cc", ".cxx", ".hpp", ".inc", NULL};
+static const char *c_exts[] = {".c",   ".h",  ".cpp", ".cc",  ".cxx",
+                               ".hpp", ".hh", ".hxx", ".inc", NULL};
 static const char *lua_exts[] = {".lua", NULL};
 static const char *java_exts[] = {".java", NULL};
 static const char *rust_exts[] = {".rs", NULL};

--- a/src/tests/test_code_collect.c
+++ b/src/tests/test_code_collect.c
@@ -422,6 +422,30 @@ static void test_default_branch_sha_non_git(void)
    printf("  test_default_branch_sha_non_git: ok\n");
 }
 
+/* C++ public headers (.hpp/.hh/.hxx) are collected — they are the dominant C++
+ * public-API extension; dropping them left a library's include/ tree (its class/
+ * method symbols + the includes that form cross-repo routes) unindexed. */
+static void test_cpp_headers_collected(void)
+{
+   make_root("cpphdr");
+   write_file("include/lib/api.hpp", "namespace lib { class Api { void run(); }; }");
+   write_file("src/impl.hh", "struct Impl {};");
+   write_file("src/legacy.hxx", "struct Legacy {};");
+   write_file("src/main.cpp", "int main(){return 0;}");
+   write_file("src/c_api.h", "int c_api(void);");
+   write_file("README.txt", "doc");
+
+   reset();
+   code_collect_files_cb(g_root, rec_cb, NULL);
+   assert(has("include/lib/api.hpp")); /* the regression: .hpp under include/ collected */
+   assert(has("src/impl.hh"));
+   assert(has("src/legacy.hxx"));
+   assert(has("src/main.cpp"));
+   assert(has("src/c_api.h"));
+   assert(!has("README.txt"));
+   printf("  test_cpp_headers_collected: ok\n");
+}
+
 int main(void)
 {
    printf("test_code_collect:\n");
@@ -438,6 +462,7 @@ int main(void)
    test_non_git_uses_worktree();
    test_build_manifests_collected();
    test_build_manifests_collected_git();
+   test_cpp_headers_collected();
    test_default_branch_sha_tracks_commits();
    test_default_branch_sha_quote_in_ref();
    test_index_source_is_worktree();


### PR DESCRIPTION
## What

The client collector's extension allowlist (`code_collect.c` `code_ext_ok`) was **missing the C++ header extensions** `.hpp`/`.hh`/`.hxx`. It had `.cpp/.cc/.cxx` (C++ sources) and `.h` (C headers) but not `.hpp`, so the client **never sent any C++ header to the kb**. Every C++ library's public-API headers (in `include/`, overwhelmingly `.hpp`) were therefore systematically unindexed.

Found while scoping the deferred §7 (C++ class/method symbol extraction): `mdns_cpp`'s `include/mdns_cpp/*.hpp` (its `mDNS`/`Logger` classes) were absent → no `#include <mdns_cpp/mdns.hpp>` route could form for wolf → no symbol corroboration possible. This is **prerequisite #1** for C++ cross-repo recall. Corpus impact: unindexed `.hpp` headers in **wolf(56), inputtino(11), mdns_cpp(5), gstreamer-h265(2), eventbus(2)**.

## Fix

Add `.hpp`/`.hh`/`.hxx` to `code_ext_ok` **and** to `extractors.c c_exts` in lockstep (`detect_lang` maps `c_exts`→`LANG_C`, so they're parsed, not inert) — keeping the collector's C/C++ extension set a **subset** of what the extractor parses (the asymmetry that caused this bug). `.inc` is deliberately excluded (c_exts lists it, but in this corpus it is high-volume ambiguous/generated fragments, e.g. aimee's own `*_gen.inc`).

## Test

`test_cpp_headers_collected`: `include/lib/api.hpp` + `.hh` + `.hxx` + `.cpp` + `.h` collected; `README.txt` not.

## Review

Roundtable-reviewed: round 1 found 2 blocking (collector/extractor asymmetry for .hh/.hxx; misleading comment) → fixed by mirroring c_exts + correcting the comment; round 2 **converged, 0 blocking**.

## Post-merge

Will redeploy + re-scan .254 and re-measure §9 (corpus-wide .hpp indexing could add collisions); revert if precision regresses from 100%. Then verify wolf→mdns_cpp / wolf→eventbus routes now form (prerequisite #2).