### PR TITLE
fix(fullauto): F2 polish — custom blocks in the worktree + orphan-sweep

### DIFF
--- a/docs/proposals/pending/full-autonomous-development.md
+++ b/docs/proposals/pending/full-autonomous-development.md
@@ -43,28 +43,35 @@ per-item USD cap).
   worktree is a path convenience, **not** a sandbox — the real seccomp/namespace
   sandbox stays a GA gate.
 
-**Resolved by design / remaining:**
-- **F5a — single-flight is SATISFIED BY THE SEQUENTIAL SCHEDULER.** `wfe_autonomy_run`
-  runs only on the single `wfe_scheduler` thread (concurrency = 1; `notify` only
-  signals a cond var), so two runs of the same work item can never overlap — a
-  per-item claim primitive would be dead code today. The DB-CAS+TTL claim + per-
-  target merge serialization become load-bearing only when the scheduler is made
-  concurrent (Phase-C scale), and are tracked there.
-- **F4 — the live forge `wfe_forge_t` — FINAL PACKET (design grounded, default-OFF).**
-  A server-side provider behind a new `wfe_live_forge_enabled` config flag
-  (default-OFF), re-checked at every call site and guarded by the F1a merge-target
-  rail, that reuses the existing vaulted handlers — `handle_git_push` (push the
-  work-item branch through `git_cred_inject`) + `handle_git_pr` (create / checks /
-  view / merge via `gh`) — for `open`/`ci_status`/`mergeable`/`is_merged`/`merge`,
-  and is registered in `wfe_autonomy_register` only when the flag is on. This is the
-  highest-blast-radius packet (it opens **and merges real PRs**); per the safety
-  posture it is implemented as a focused, dedicated change with its own roundtable
-  review, and its production enable is an explicit operator deployment gate (branch
-  protection + scoped/rotated creds + break-glass TTL — see GA gates). It closes the
-  criterion-5 gap [autonomous-dev-execution-substrate.md](done/autonomous-dev-execution-substrate.md)
-  deferred here.
-- **intake auth** on `POST /v1/dev/submit` (authn + per-principal rate/concurrency
-  cap + submitter→run audit binding) — required before any live-forge enable.
+- **F5a — single-flight is SATISFIED BY THE SEQUENTIAL SCHEDULER** (resolved by
+  design). `wfe_autonomy_run` runs only on the single `wfe_scheduler` thread
+  (concurrency = 1; `notify` only signals a cond var), so two runs of the same work
+  item can never overlap — a per-item claim primitive would be dead code today. The
+  DB-CAS+TTL claim + per-target merge serialization become load-bearing only when the
+  scheduler is made concurrent (Phase-C scale), and are tracked there.
+- **F4 — live forge `wfe_forge_t` SHIPPED (PR #868, `src/server/wfe_live_forge.c`).**
+  A server-side provider behind the `wfe_live_forge_enabled` config flag
+  (**default-OFF**; `test_config` asserts the default), registered (via
+  `wfe_live_forge_register` in `wfe_autonomy_register`) ONLY when the operator opts in;
+  otherwise the engine keeps its fail-closed stub. Every op re-checks `forge_allowed()`
+  (the flag AND the F1a merge-target rail) — including immediately before each mutating
+  call (TOCTOU-safe) — so a flag flip or protected-base misconfig can never open/merge
+  a real PR. open = `git push` (vaulted via `mcp_git_run`) + `gh pr create --base
+  <autonomous_base>`; ci/mergeable/is_merged/merge map `gh` output to the engine enums,
+  unknown → fail closed. `exec_pr_open` derives the work-item branch `aimee/wi/<id>`.
+  Closes the criterion-5 **code** gap
+  [autonomous-dev-execution-substrate.md](done/autonomous-dev-execution-substrate.md)
+  deferred here. The CODE floor for full-autonomous-development is now complete.
+
+**Remaining = enable-gates only (no further code floor):**
+- **intake-auth hardening** on `POST /v1/dev/submit` (it is already `CAP_DELEGATE`;
+  add per-principal rate/concurrency caps + submitter→run audit binding) — a hardening
+  precondition for the live-forge enable.
+- the **operator deployment gates** to flip `wfe_live_forge_enabled` on: branch
+  protection on RakuenSoftware/aimee, fine-grained scoped + rotated forge creds, the
+  break-glass TTL enable, and a real execution sandbox (see GA gates). A production
+  live-forge roundtrip stays a deployment-tier `validation-pending` check, never a
+  closeout test.
 
 **Ratified deviation — default-OFF, not default-on.** §7 mandates the live forge
 ship *default-on*. The security roundtable ruled that unsafe (it would let any

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -9,6 +9,7 @@
 
 #include "log.h"
 #include "wfe_autonomy.h"
+#include "wfe_blocks.h" /* wfe_worktree_cleanup — orphan-sweep of terminal worktrees */
 #include "wfe_store.h"
 
 #include <pthread.h>
@@ -37,7 +38,18 @@ void wfe_scheduler_run_once(void)
    for (int i = 0; i < n; i++)
    {
       if (strcmp(items[i].state, "active") != 0)
+      {
+         /* Orphan-sweep (F2): a terminal item may still hold a worktree that the
+          * autonomy terminal path didn't clean — e.g. a reject applied via the API
+          * gate, or an override-cap rejection. Tear it down + clear the column. */
+         if (items[i].worktree[0])
+         {
+            const char *rl = getenv("AIMEE_WORKFLOW_REPO");
+            if (wfe_worktree_cleanup(items[i].worktree, (rl && rl[0]) ? rl : ".") == 0)
+               db1_work_item_set_worktree(items[i].work_item_id, "");
+         }
          continue;
+      }
       if (strcmp(items[i].mode, "autonomous") != 0)
          continue; /* interactive items are human-driven in the webchat */
       char err[256] = "";

--- a/src/server/wfe_scheduler.c
+++ b/src/server/wfe_scheduler.c
@@ -37,11 +37,16 @@ void wfe_scheduler_run_once(void)
       return;
    for (int i = 0; i < n; i++)
    {
-      if (strcmp(items[i].state, "active") != 0)
+      const char *st = items[i].state;
+      /* Orphan-sweep (F2): a TERMINAL item may still hold a worktree that the
+       * autonomy terminal path didn't clean — e.g. a reject applied via the API
+       * gate, or an override-cap rejection. Tear it down + clear the column. Match
+       * the terminal set EXPLICITLY (not just !active): a parked item keeps
+       * state=active, and only accepted/rejected/abandoned are immutable-terminal,
+       * so acting on this snapshot can't race an item back to life. */
+      int terminal = !strcmp(st, "accepted") || !strcmp(st, "rejected") || !strcmp(st, "abandoned");
+      if (terminal)
       {
-         /* Orphan-sweep (F2): a terminal item may still hold a worktree that the
-          * autonomy terminal path didn't clean — e.g. a reject applied via the API
-          * gate, or an override-cap rejection. Tear it down + clear the column. */
          if (items[i].worktree[0])
          {
             const char *rl = getenv("AIMEE_WORKFLOW_REPO");
@@ -50,6 +55,8 @@ void wfe_scheduler_run_once(void)
          }
          continue;
       }
+      if (strcmp(st, "active") != 0)
+         continue; /* any other non-terminal state: leave it (don't reap its worktree) */
       if (strcmp(items[i].mode, "autonomous") != 0)
          continue; /* interactive items are human-driven in the webchat */
       char err[256] = "";

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -678,6 +678,8 @@ static wfe_step_result_t exec_custom(wfe_ctx *ctx, const wfe_node_t *node)
    char head[64] = "", base[64] = "", dhash[65] = "", err[128] = "";
    char handle[80];
    snprintf(handle, sizeof handle, "%s.out", node->id);
+   char wd[1024]; /* F2: a custom block acts in the work-item worktree too */
+   resolve_workdir(ctx, wd, sizeof wd);
 
    if (c->executor == WFE_EXEC_COMMAND)
    {
@@ -712,8 +714,8 @@ static wfe_step_result_t exec_custom(wfe_ctx *ctx, const wfe_node_t *node)
        * array (validated at load); run it directly (no shell), pinned to the
        * work-item repo, under a wall-clock timeout (kill -> step failed). */
       char *out = NULL;
-      int rc = safe_exec_capture_cwd_env_timeout((const char *const *)c->argv, repo_dir(), envp,
-                                                 &out, 1 << 20, wfe_custom_command_timeout_ms());
+      int rc = safe_exec_capture_cwd_env_timeout((const char *const *)c->argv, wd, envp, &out,
+                                                 1 << 20, wfe_custom_command_timeout_ms());
       free(out);
       if (rc != 0)
          return wfe_step_failed(); /* non-zero exit or SAFE_EXEC_TIMEOUT */
@@ -722,7 +724,7 @@ static wfe_step_result_t exec_custom(wfe_ctx *ctx, const wfe_node_t *node)
 
    if (c->produces == WFE_ART_BRANCH)
    {
-      if (wfe_git_freeze(repo_dir(), "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
+      if (wfe_git_freeze(wd, "HEAD", base, head, dhash, err, sizeof err) != 0 || !head[0])
          return wfe_step_failed();
       return wfe_step_advanced(handle, head, 0.0);
    }

--- a/src/workflow/wfe_blocks.c
+++ b/src/workflow/wfe_blocks.c
@@ -39,6 +39,8 @@ static void resolve_workdir(wfe_ctx *ctx, char *buf, size_t n)
    if (wfe_worktree_ensure(wfe_ctx_work_item(ctx), wfe_ctx_worktree(ctx), repo_dir(),
                            wfe_autonomous_base(), buf, n) != 0)
       snprintf(buf, n, "%s", repo_dir()); /* fall back to the shared checkout */
+   if (!buf[0])                           /* guarantee a non-empty workdir for every caller */
+      snprintf(buf, n, "%s", repo_dir());
 }
 
 static int git_capture(const char *const argv[], char **out)


### PR DESCRIPTION
Two isolation/cleanup gaps F2 left:
- **exec_custom** (custom command blocks + their freeze) ran in the shared `repo_dir()`, not the per-work-item worktree — so a custom block couldn't see the run's own changes. Now uses `resolve_workdir()` like the other producing executors (same fallback-on-failure).
- a worktree could **leak** when an item went terminal via a non-autonomous path (API gate reject, override-cap reject) — the autonomy terminal cleanup never ran. The scheduler sweep now tears down + clears the worktree of any terminal item still holding one, covering all paths.

Build + wfe suite green.