### PR TITLE
fix(webchat-git): cross-origin /vscode WS gate + revoke recycles editor/ssh-agent

### DIFF
--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -20,6 +20,7 @@
 #include "git_host_cred.h"    /* per-host git credential store for /v1/git/credentials */
 #include "git_oauth_github.h" /* GitHub device-flow sign-in (/v1/git/oauth/github) */
 #include "git_ops.h"          /* git_ops_run for /v1/workspace/git (WP-E) */
+#include "git_ssh_agent.h"    /* git_ssh_agent_stop — drop live key handles on revoke */
 #include "git_project.h"      /* git_project_clone for /v1/workspace/clone (WP-D) */
 #include "webuser_editor.h"   /* webuser_editor_ensure for /v1/workspace/editor (WP-I) */
 #include "workspace_scope.h"  /* ws_scope_user_root — project workspace root */
@@ -1483,7 +1484,25 @@ static int rh_git_credentials(const route_req_t *rq, char *resp, int cap)
 
    int rc;
    if (strcmp(rq->method, "DELETE") == 0)
+   {
       rc = git_host_cred_delete(host);
+      /* Revocation must leave no live credential handle behind (G5): the user's
+       * running code-server baked the now-removed token into its env at spawn,
+       * and the ssh-agent may hold a key loaded from the vault. Drop both AFTER
+       * the vault entry is gone — order matters: deleting first means a /vscode
+       * request that respawns the editor between these two steps re-reads an
+       * already-empty vault, so it cannot pick the token back up. Both stop
+       * functions are void + idempotent (no-op if nothing is running) so a
+       * concurrent double-revoke is safe; webuser_editor_stop reaps the child
+       * synchronously (bounded ~500ms), git_ssh_agent_stop only signals+unlinks.
+       * Recycling is cheap — the editor respawns lazily on the next /vscode
+       * request with a freshly-built (credential-free) env. */
+      if (rc == 0)
+      {
+         webuser_editor_stop(principal);
+         git_ssh_agent_stop(principal);
+      }
+   }
    else /* POST → set */
    {
       if (!token || !token[0])

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -146,6 +146,13 @@ func (s *server) handleGitCredentials(w http.ResponseWriter, r *http.Request) {
 		}
 		body, _ := json.Marshal(map[string]string{"host": req.Host, "token": req.Token})
 		st, data, err := s.v1RequestWebuser(ctx, user, r.Method, "/v1/git/credentials", body)
+		// On revoke, aimee-server recycles the user's editor (its spawn env held
+		// the now-deleted token). Evict our cached loopback port so the next
+		// /vscode request re-ensures a freshly-spawned, credential-free editor
+		// instead of dialing the dead port and self-healing only after a failure.
+		if r.Method == http.MethodDelete && err == nil && st == http.StatusOK {
+			editorPorts.Delete(user)
+		}
 		s.gitRelay(w, st, data, err)
 	default:
 		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")

--- a/webchat/vscode.go
+++ b/webchat/vscode.go
@@ -21,6 +21,7 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 )
@@ -78,6 +79,18 @@ func (s *server) handleVSCode(w http.ResponseWriter, r *http.Request) {
 	username := currentUser(r)
 	if username == "" {
 		http.Error(w, "authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	// requireAuth gates this route on the session cookie, but a cookie alone is
+	// CSRF-able: a cross-origin page in the victim's browser can open
+	// ws://<webchat>/vscode/... (or POST to code-server's HTTP API) carrying the
+	// victim's cookie and drive the integrated terminal. Cookie SameSite=Strict
+	// helps but is not an explicit gate, so reject any cross-origin request here.
+	// The editor's own assets/XHR/WebSocket all originate from our same-origin
+	// iframe, so legitimate traffic always matches; only foreign origins are cut.
+	if !sameOriginVSCode(r) {
+		http.Error(w, "cross-origin request rejected", http.StatusForbidden)
 		return
 	}
 
@@ -170,9 +183,88 @@ func (s *server) proxyToEditor(w http.ResponseWriter, r *http.Request, username 
 	proxy.ServeHTTP(w, r)
 }
 
+// forwardedProto is the scheme the browser used to reach webchat. webchat
+// usually terminates TLS itself (r.TLS set), but behind an external TLS
+// terminator the hop to us is plaintext and the terminator sets
+// X-Forwarded-Proto — honor it (first value of a possible comma list) so the
+// same-origin gate and code-server's asset URLs use the real external scheme
+// rather than wrongly seeing "http" and 403'ing/ mis-building every request.
 func forwardedProto(r *http.Request) string {
+	if xf := r.Header.Get("X-Forwarded-Proto"); xf != "" {
+		if i := strings.IndexByte(xf, ','); i >= 0 {
+			xf = xf[:i]
+		}
+		if xf = strings.ToLower(strings.TrimSpace(xf)); xf != "" {
+			return xf
+		}
+	}
 	if r.TLS != nil {
 		return "https"
 	}
 	return "http"
+}
+
+// isWebSocketUpgrade reports whether r is a WebSocket upgrade handshake.
+func isWebSocketUpgrade(r *http.Request) bool {
+	if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+		return false
+	}
+	for _, tok := range strings.Split(r.Header.Get("Connection"), ",") {
+		if strings.EqualFold(strings.TrimSpace(tok), "upgrade") {
+			return true
+		}
+	}
+	return false
+}
+
+// hostNoDefaultPort lower-cases host and drops the port when it is the default
+// for scheme, so "host:443"/"https" and a bare "host" compare equal (the common
+// :443/:80 deployment, where the browser omits the default port from Origin but
+// the Host header keeps it).
+func hostNoDefaultPort(host, scheme string) string {
+	host = strings.ToLower(host)
+	h, p, err := net.SplitHostPort(host)
+	if err != nil {
+		return host // no explicit port
+	}
+	if (scheme == "https" && p == "443") || (scheme == "http" && p == "80") {
+		return h
+	}
+	return net.JoinHostPort(h, p)
+}
+
+// sameOriginVSCode is the cross-origin gate for the /vscode proxy. The browser
+// reaches webchat at forwardedProto://r.Host; a request whose Origin resolves to
+// a different scheme+host+port is cross-origin and rejected. Scheme and host are
+// compared normalized (case-insensitive, default port stripped) so a same-origin
+// request on :443/:80 — where the browser omits the default port from Origin —
+// is not wrongly refused.
+//
+// A WebSocket upgrade MUST carry an Origin (browsers always send one on an
+// upgrade), so a missing Origin on an upgrade is cross-origin and refused — this
+// closes the cookie-only CSRF path to the editor terminal. A missing Origin on a
+// non-upgrade request is allowed only for safe methods (top-level iframe
+// navigations, asset GETs) or when the browser explicitly marks it same-origin
+// via Sec-Fetch-Site, so a non-safe cross-origin call that omits Origin cannot
+// slip through.
+func sameOriginVSCode(r *http.Request) bool {
+	origin := strings.TrimSpace(r.Header.Get("Origin"))
+	if origin == "" {
+		if isWebSocketUpgrade(r) {
+			return false
+		}
+		switch r.Method {
+		case http.MethodGet, http.MethodHead, http.MethodOptions:
+			return true
+		}
+		sfs := strings.ToLower(strings.TrimSpace(r.Header.Get("Sec-Fetch-Site")))
+		return sfs == "same-origin" || sfs == "none"
+	}
+	ou, err := url.Parse(origin)
+	if err != nil || ou.Host == "" {
+		return false
+	}
+	exp := forwardedProto(r)
+	return strings.EqualFold(ou.Scheme, exp) &&
+		hostNoDefaultPort(ou.Host, exp) == hostNoDefaultPort(r.Host, exp)
 }

--- a/webchat/vscode_test.go
+++ b/webchat/vscode_test.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// sameOriginVSCode is the cross-origin gate guarding the /vscode reverse proxy.
+// A cookie alone is CSRF-able, so the proxy must reject any cross-origin request
+// and, for WebSocket upgrades (the editor terminal), refuse a missing Origin too
+// (browsers always send one on an upgrade). Same-origin iframe traffic — asset
+// GETs without an Origin, and XHR/WS whose Origin matches our host — must pass.
+func TestSameOriginVSCodeGate(t *testing.T) {
+	mkReq := func(method, host, origin string, tls_ bool, xfproto, secFetch string, ws bool) *http.Request {
+		r := httptest.NewRequest(method, "http://"+host+"/vscode/", nil)
+		r.Host = host
+		if tls_ {
+			r.TLS = &tls.ConnectionState{}
+		}
+		if origin != "" {
+			r.Header.Set("Origin", origin)
+		}
+		if xfproto != "" {
+			r.Header.Set("X-Forwarded-Proto", xfproto)
+		}
+		if secFetch != "" {
+			r.Header.Set("Sec-Fetch-Site", secFetch)
+		}
+		if ws {
+			r.Header.Set("Upgrade", "websocket")
+			r.Header.Set("Connection", "keep-alive, Upgrade")
+		}
+		return r
+	}
+
+	const host = "aimee.example:8443" // explicit non-default port
+	cases := []struct {
+		name                          string
+		method, host, origin, xfproto string
+		secFetch                      string
+		tls_, ws, want                bool
+	}{
+		// Same-origin iframe traffic must pass.
+		{"asset GET no origin", "GET", host, "", "", "", true, false, true},
+		{"XHR same origin", "GET", host, "https://" + host, "", "", true, false, true},
+		{"XHR same origin case-folded scheme", "GET", host, "HTTPS://" + host, "", "", true, false, true},
+		{"WS same origin", "GET", host, "https://" + host, "", "", true, true, true},
+		// Default-port normalization: Host carries :443, Origin omits it.
+		{"XHR same origin default 443 stripped", "GET", "aimee.example:443", "https://aimee.example", "", "", true, false, true},
+		{"WS same origin default 443 stripped", "GET", "aimee.example:443", "https://aimee.example", "", "", true, true, true},
+		{"XHR same origin default 80 stripped", "GET", "aimee.example:80", "http://aimee.example", "", "", false, false, true},
+		// TLS-terminating proxy: r.TLS nil, X-Forwarded-Proto: https.
+		{"behind TLS proxy, XHR https origin", "GET", "aimee.example", "https://aimee.example", "https", "", false, false, true},
+		{"behind TLS proxy, WS https origin", "GET", "aimee.example", "https://aimee.example", "https, http", "", false, true, true},
+		// Cross-origin must be cut.
+		{"XHR cross origin", "GET", host, "https://evil.example", "", "", true, false, false},
+		{"WS cross origin", "GET", host, "https://evil.example", "", "", true, true, false},
+		{"WS missing origin refused", "GET", host, "", "", "", true, true, false},
+		{"WS wrong scheme", "GET", host, "http://" + host, "", "", true, true, false},
+		{"XHR same host wrong port", "GET", "aimee.example:8443", "https://aimee.example:9999", "", "", true, false, false},
+		// Empty-Origin: safe methods pass; non-safe pass only with Sec-Fetch-Site same-origin.
+		{"empty origin POST refused", "POST", host, "", "", "", true, false, false},
+		{"empty origin POST sec-fetch same-origin", "POST", host, "", "", "same-origin", true, false, true},
+		{"empty origin POST sec-fetch cross-site", "POST", host, "", "", "cross-site", true, false, false},
+		{"empty origin OPTIONS allowed", "OPTIONS", host, "", "", "", true, false, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := mkReq(tc.method, tc.host, tc.origin, tc.tls_, tc.xfproto, tc.secFetch, tc.ws)
+			if got := sameOriginVSCode(r); got != tc.want {
+				t.Fatalf("sameOriginVSCode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// isWebSocketUpgrade must detect the upgrade only when both the Upgrade token and
+// a "upgrade" entry in Connection are present (the latter may be one of several
+// comma-separated tokens), and must not be fooled by a bare Connection header.
+func TestIsWebSocketUpgrade(t *testing.T) {
+	cases := []struct {
+		upgrade, conn string
+		want          bool
+	}{
+		{"websocket", "Upgrade", true},
+		{"websocket", "keep-alive, Upgrade", true},
+		{"WebSocket", "upgrade", true},
+		{"websocket", "keep-alive", false},
+		{"", "Upgrade", false},
+		{"h2c", "Upgrade", false},
+	}
+	for _, tc := range cases {
+		r := httptest.NewRequest(http.MethodGet, "/vscode/", nil)
+		if tc.upgrade != "" {
+			r.Header.Set("Upgrade", tc.upgrade)
+		}
+		r.Header.Set("Connection", tc.conn)
+		if got := isWebSocketUpgrade(r); got != tc.want {
+			t.Errorf("isWebSocketUpgrade(Upgrade=%q,Connection=%q)=%v want %v",
+				tc.upgrade, tc.conn, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes two confirmed security gaps in the already-shipped webchat git-projects + in-browser-VSCode feature (proposal `docs/proposals/pending/webchat-git-projects-and-vscode.md`), surfaced by a gap audit + roundtable review of the shipped code.

## 1. Cross-origin WebSocket gate on `/vscode` (CSRF)
The `/vscode` reverse proxy gated on the session cookie (`requireAuth`) and stripped upstream auth, but did **not** validate `Origin`. A cross-origin page in the victim's browser could open a WebSocket to `/vscode/*` carrying the victim's cookie and drive code-server's integrated terminal — cookie `SameSite=Strict` was the only mitigation, not an explicit gate.

`sameOriginVSCode` now rejects cross-origin requests. A WebSocket upgrade with a **missing** `Origin` is refused (browsers always send one on an upgrade); a missing `Origin` on a non-upgrade request is allowed only for safe methods or an explicit `Sec-Fetch-Site: same-origin`. Scheme/host are compared **normalized** (default port stripped, `X-Forwarded-Proto` honored) so same-origin `:443`/`:80` and TLS-terminating-proxy deployments are not wrongly `403`'d. 18-case unit test.

## 2. Revocation leaves no live credential handle (G5)
`DELETE /v1/git/credentials` removed the vault entry but left the user's running code-server (token baked into its spawn env) and ssh-agent holding live handles, so a revoked credential survived in a running editor. On successful delete, aimee-server now stops the editor (respawns lazily with a credential-free env) and the ssh-agent — **deleting the vault entry first** so a racing respawn re-reads an already-empty vault. webchat evicts its cached editor port on revoke so the next `/vscode` request re-ensures cleanly.

## Review
Roundtable code-review run on the diff (6/6 panelists). Both blocking items it raised — the TLS-terminating-proxy scheme mismatch and default-port normalization (each would have `403`'d legitimate same-origin traffic) — are fixed and covered by added test cases. Suggestions addressed: empty-Origin non-safe-method tightening, `editorPorts` eviction on revoke, delete-first ordering rationale documented. The "capture stop() return values" suggestion does not apply (both stop functions are `void` + idempotent by design; documented in-code).

Tests: `go test ./webchat/...` green; `aimee-server` links clean; gofmt + clang-format-19 clean.