### PR TITLE
feat(webchat-git): wire idle-reaping of per-webuser code-server editors

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -216,7 +216,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 131 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 132 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -412,7 +412,7 @@ The binaries read 131 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WEBCHAT_EDITOR_IDLE_SECS`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/src/headers/webuser_editor.h
+++ b/src/headers/webuser_editor.h
@@ -42,6 +42,18 @@ void webuser_editor_stop(const char *principal);
  * idle_secs <= 0 reaps none. Safe to call frequently. */
 int webuser_editor_reap_idle(long idle_secs);
 
+/* Drive idle-reaping from the server's 1s park-loop tick: call once per tick;
+ * it reaps idle editors on a coarse ~30s cadence (no-op between cadences and
+ * when reaping is disabled). Single-threaded caller. */
+void webuser_editor_reap_tick(void);
+
+/* Configured idle-reap timeout in seconds, from AIMEE_WEBCHAT_EDITOR_IDLE_SECS
+ * (default 1800 = 30 min; 0 disables idle reaping; malformed → default). The
+ * server's park loop calls webuser_editor_reap_idle(webuser_editor_idle_secs())
+ * on a coarse cadence; a live editor's timer is kept warm by webchat's periodic
+ * ensure / WebSocket keepalive, so only genuinely idle editors are reaped. */
+long webuser_editor_idle_secs(void);
+
 /* Stop every running editor (server shutdown). */
 void webuser_editor_shutdown(void);
 

--- a/src/server/server.c
+++ b/src/server/server.c
@@ -1937,11 +1937,13 @@ int server_run(server_ctx_t *ctx)
    /* The /v1 HTTP listener (server_http.c) runs on its own accept thread with
     * per-connection workers, so the main thread has no NDJSON accept loop to
     * drive any more. Park here until a signal flips ctx->running, then return so
-    * run_server() can tear everything down. */
+    * run_server() can tear everything down. The 1s tick also drives idle-reaping
+    * of per-webuser code-server editors (WP-I lifecycle) via reap_tick. */
    while (ctx->running)
    {
       struct timespec ts = {.tv_sec = 1, .tv_nsec = 0};
       nanosleep(&ts, NULL);
+      webuser_editor_reap_tick();
    }
    return 0;
 }

--- a/src/server/webuser_editor.c
+++ b/src/server/webuser_editor.c
@@ -340,38 +340,37 @@ static pid_t spawn_code_server(const char *principal, const char *userroot, int 
    return pid;
 }
 
+/* Kill a code-server's whole session (setsid) and reap it so it can't leak as a
+ * zombie. Bounded (~500ms): SIGTERM then poll, escalate to SIGKILL. Holds no
+ * lock, so it is safe to call after the editor's slot has already been cleared —
+ * bulk reaping clears slots under g_lock and then calls this with the lock
+ * dropped, so a tick that reaps many idle editors never freezes concurrent
+ * webuser_editor_ensure for N×500ms. */
+static void reap_pid(pid_t pid)
+{
+   if (pid <= 0)
+      return;
+   kill(-pid, SIGTERM); /* whole session (setsid) */
+   kill(pid, SIGTERM);
+   for (int i = 0; i < 50; i++) /* up to ~500ms */
+   {
+      if (waitpid(pid, NULL, WNOHANG) == pid)
+         return;
+      struct timespec ts = {0, 10 * 1000 * 1000}; /* 10ms */
+      nanosleep(&ts, NULL);
+   }
+   kill(-pid, SIGKILL);
+   kill(pid, SIGKILL);
+   waitpid(pid, NULL, 0); /* SIGKILL is uncatchable → bounded */
+}
+
 /* Reap one editor entry (kill its process group, clear the slot). Caller holds
- * g_lock. */
+ * g_lock; the bounded kill/wait runs under the lock, so this is only for
+ * single-editor paths (ensure respawn, stop). Bulk idle-reaping uses the
+ * slot-clear-then-reap_pid-outside-lock pattern instead (webuser_editor_reap_idle). */
 static void reap_locked(editor_t *e)
 {
-   pid_t pid = e->pid;
-   if (pid > 0)
-   {
-      kill(-pid, SIGTERM); /* whole session (setsid) */
-      kill(pid, SIGTERM);
-      /* Wait for the child here so it is actually reaped — once we zero the slot
-       * below, sweep_dead_locked can no longer find it, so an un-waited child
-       * would leak as a permanent zombie. code-server exits on SIGTERM quickly;
-       * escalate to SIGKILL if it ignores us. This is a rare path
-       * (stop/idle/shutdown), so the bounded wait under the lock is acceptable. */
-      int reaped = 0;
-      for (int i = 0; i < 50; i++) /* up to ~500ms */
-      {
-         if (waitpid(pid, NULL, WNOHANG) == pid)
-         {
-            reaped = 1;
-            break;
-         }
-         struct timespec ts = {0, 10 * 1000 * 1000}; /* 10ms */
-         nanosleep(&ts, NULL);
-      }
-      if (!reaped)
-      {
-         kill(-pid, SIGKILL);
-         kill(pid, SIGKILL);
-         waitpid(pid, NULL, 0); /* SIGKILL is uncatchable → bounded */
-      }
-   }
+   reap_pid(e->pid);
    e->principal[0] = '\0';
    e->pid = 0;
    e->port = 0;
@@ -537,19 +536,74 @@ int webuser_editor_reap_idle(long idle_secs)
    if (idle_secs <= 0)
       return 0;
    long now = (long)time(NULL);
-   int reaped = 0;
+   /* Two phases so the bounded kill/wait never runs under g_lock: phase 1 (under
+    * the lock) finds idle editors, copies their pids, and clears their slots;
+    * phase 2 (lock dropped) reaps each pid. Holding the lock across N×~500ms
+    * waits would freeze every concurrent webuser_editor_ensure and stall the
+    * park loop. A racing ensure for a just-cleared principal simply spawns a
+    * fresh editor (the user became active again) — its pid differs from the one
+    * we reap, so there is no double-reap. */
+   pid_t dead[WEBUSER_EDITOR_MAX];
+   int n = 0;
    pthread_mutex_lock(&g_lock);
    sweep_dead_locked();
    for (int i = 0; i < WEBUSER_EDITOR_MAX; i++)
    {
-      if (g_editors[i].pid > 0 && now - g_editors[i].last_active > idle_secs)
+      editor_t *e = &g_editors[i];
+      if (e->pid > 0 && now - e->last_active > idle_secs)
       {
-         reap_locked(&g_editors[i]);
-         reaped++;
+         dead[n++] = e->pid;
+         e->principal[0] = '\0';
+         e->pid = 0;
+         e->port = 0;
+         e->last_active = 0;
       }
    }
    pthread_mutex_unlock(&g_lock);
-   return reaped;
+   for (int i = 0; i < n; i++)
+      reap_pid(dead[i]);
+   return n;
+}
+
+void webuser_editor_reap_tick(void)
+{
+   /* Called once per ~1s server park-loop tick; reaps idle editors on a coarse
+    * ~30s cadence (single-threaded caller, so the static counter needs no lock).
+    * The idle bound is read once and cached. A live editor's idle timer is kept
+    * warm by webchat's periodic ensure / WebSocket keepalive, so only genuinely
+    * idle editors are reaped. */
+   static long idle = -1;
+   static int tick = 0;
+   if (idle < 0)
+      idle = webuser_editor_idle_secs();
+   if (idle > 0 && ++tick >= 30)
+   {
+      tick = 0;
+      webuser_editor_reap_idle(idle);
+   }
+}
+
+long webuser_editor_idle_secs(void)
+{
+   /* The editor's idle timer is kept warm by webchat's WebSocket keepalive,
+    * which re-ensures roughly every editorPortTTL (~30s); the idle window must
+    * comfortably exceed that cadence or a live session could be reaped between
+    * keepalives. So clamp any positive value to a 60s floor (2× the keepalive
+    * cadence) and a 7-day ceiling (so a fat-fingered "18000000" can't silently
+    * disable reaping). 0 explicitly disables; empty/malformed/negative/overflow
+    * → the 30-min default. */
+   const long FLOOR = 60, CEIL = 7L * 24 * 3600, DEF = 1800;
+   const char *v = getenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS");
+   if (!v || !v[0])
+      return DEF;
+   errno = 0;
+   char *end = NULL;
+   long n = strtol(v, &end, 10);
+   if (end == v || *end != '\0' || errno == ERANGE || n < 0)
+      return DEF;
+   if (n == 0)
+      return 0; /* explicitly disabled */
+   return n < FLOOR ? FLOOR : (n > CEIL ? CEIL : n);
 }
 
 void webuser_editor_shutdown(void)

--- a/src/tests/test_webuser_editor.c
+++ b/src/tests/test_webuser_editor.c
@@ -137,6 +137,30 @@ int main(void)
    webuser_editor_stop(NULL);
    assert(webuser_editor_reap_idle(0) == 0);  /* idle_secs<=0 reaps nothing */
    assert(webuser_editor_reap_idle(60) == 0); /* empty registry */
+
+   /* Idle-timeout config: AIMEE_WEBCHAT_EDITOR_IDLE_SECS, default 1800; 0
+    * disables; positive values clamped to [60, 7d]; malformed/negative/overflow
+    * → default. */
+   unsetenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS");
+   assert(webuser_editor_idle_secs() == 1800);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "300", 1);
+   assert(webuser_editor_idle_secs() == 300);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "0", 1); /* valid → disables reaping */
+   assert(webuser_editor_idle_secs() == 0);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "10", 1); /* below floor → 60 */
+   assert(webuser_editor_idle_secs() == 60);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "700000", 1); /* above 7d ceiling → 604800 */
+   assert(webuser_editor_idle_secs() == 7L * 24 * 3600);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "-5", 1); /* negative → default */
+   assert(webuser_editor_idle_secs() == 1800);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "abc", 1); /* malformed → default */
+   assert(webuser_editor_idle_secs() == 1800);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "60x", 1); /* trailing junk → default */
+   assert(webuser_editor_idle_secs() == 1800);
+   setenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS", "99999999999999999999", 1); /* overflow → default */
+   assert(webuser_editor_idle_secs() == 1800);
+   unsetenv("AIMEE_WEBCHAT_EDITOR_IDLE_SECS");
+
    webuser_editor_shutdown();
 
    test_editor_env_leak();

--- a/webchat/vscode.go
+++ b/webchat/vscode.go
@@ -180,6 +180,33 @@ func (s *server) proxyToEditor(w http.ResponseWriter, r *http.Request, username 
 			_, _ = rw.Write([]byte("editor connection failed"))
 		},
 	}
+
+	// code-server holds a single long-lived WebSocket open for the editor/terminal
+	// and makes no further /vscode HTTP requests during a session, so the
+	// server-side idle timer (refreshed only by ensureEditorPort) would otherwise
+	// expire and reap an actively-open editor mid-use. While this upgrade is being
+	// proxied, periodically force an ensure to keep that timer warm; the ticker
+	// stops as soon as the connection ends (tab closed), letting a truly idle
+	// editor reap normally.
+	if isWebSocketUpgrade(r) {
+		stop := make(chan struct{})
+		defer close(stop)
+		go func() {
+			t := time.NewTicker(editorPortTTL)
+			defer t.Stop()
+			for {
+				select {
+				case <-stop:
+					return
+				case <-t.C:
+					kctx, cancel := context.WithTimeout(context.Background(), socketCallTimeout)
+					_, _, _ = s.ensureEditorPort(kctx, username, true)
+					cancel()
+				}
+			}
+		}()
+	}
+
 	proxy.ServeHTTP(w, r)
 }
 


### PR DESCRIPTION
Part of finishing off `docs/proposals/pending/webchat-git-projects-and-vscode.md`. The gap audit found that `webuser_editor_reap_idle()` exists but is **never scheduled** — so every per-webuser code-server lives until server shutdown. The proposal's resource-cost mitigation (V2 idle teardown) was effectively unimplemented; N concurrent users meant N editors forever.

## Changes
- **Schedule the reaper.** The server park loop's existing 1s tick now calls `webuser_editor_reap_idle()` every ~30s, bounded by a new `AIMEE_WEBCHAT_EDITOR_IDLE_SECS` (default 1800 = 30 min; `0` disables; malformed/negative → default).
- **Keep active editors alive.** code-server holds a single long-lived WebSocket and makes no further `/vscode` HTTP requests during a session, so the server-side idle timer (refreshed only by `ensureEditorPort`) would otherwise reap an actively-open editor mid-use. The proxy now runs a keepalive ticker for the WebSocket's lifetime that re-ensures the editor (refreshing `last_active`); the ticker stops when the connection ends, so a closed tab's editor reaps normally.

## Tests
`unit-test-webuser-editor` extended to cover `webuser_editor_idle_secs` parsing (default/explicit/zero/negative/malformed/trailing-junk). `docs/gen/configuration.md` regenerated for the new env var. Go + C build clean; gofmt + clang-format-19 clean.

Roundtable code-review run on the diff; summary posted as a comment.