### PR TITLE
feat(webchat-git): SSH private-key web intake (/v1/git/sshkey)

### DIFF
--- a/api/openapi-server-v1.yaml
+++ b/api/openapi-server-v1.yaml
@@ -4037,6 +4037,73 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+  /git/sshkey:
+    post:
+      summary: Store (or replace) the caller's SSH private key for git over SSH
+      description: >
+        Persist an unencrypted OpenSSH/PEM private key in the CALLER's own
+        encrypted vault under (`webuser:<name>`, `git`, `ssh_key`), dual-wrapped so
+        the server can load it into the user's in-memory ssh-agent autonomously
+        (it never touches disk and is never returned to the browser). Storing
+        requires the caller's vault to be unlocked; a locked vault returns 423.
+        Capability: tool:execute.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [ssh_key]
+              properties:
+                ssh_key:
+                  type: string
+                  description: Unencrypted OpenSSH/PEM private key (write-only)
+      responses:
+        "200":
+          description: Stored
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { ok: { type: boolean } }
+        "400":
+          description: Missing or passphrase-encrypted key
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "413":
+          description: Key too large (> 64 KiB)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        "423":
+          description: Vault is locked — unlock it, then retry
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+    delete:
+      summary: Remove the caller's stored SSH private key
+      description: >
+        Delete the SSH key from the caller's vault and drop any live ssh-agent
+        handle holding it. Idempotent. Capability: tool:execute.
+      responses:
+        "200":
+          description: Removed (or absent)
+          content:
+            application/json:
+              schema:
+                type: object
+                properties: { ok: { type: boolean } }
+        "403":
+          description: Not a webchat user
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /git/oauth/github/start:
     post:
       summary: Begin GitHub device-flow sign-in

--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -44,6 +44,7 @@ export default function Projects() {
   const [hosts, setHosts] = useState<string[]>([]);
   const [credHost, setCredHost] = useState('');
   const [credToken, setCredToken] = useState('');
+  const [credSSHKey, setCredSSHKey] = useState('');
   const [ghCode, setGhCode] = useState('');
   const [ghUri, setGhUri] = useState('');
   const [ghConfigured, setGhConfigured] = useState(false);
@@ -131,6 +132,33 @@ export default function Projects() {
       const d = await r.json();
       if (!r.ok) { setErr(d.error || 'could not save credential'); }
       else { setCredHost(''); setCredToken(''); await loadHosts(); }
+    } finally { setBusy(false); }
+  }
+
+  async function addSSHKey() {
+    if (!credSSHKey.trim()) return;
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/sshkey', {
+        method: 'POST',
+        body: JSON.stringify({ ssh_key: credSSHKey }),
+      });
+      const d = await r.json().catch(() => ({}));
+      // Always drop the key from component state once it has left the browser —
+      // never leave private-key material sitting in React state / the textarea.
+      setCredSSHKey('');
+      if (r.status === 423) { setErr('unlock your vault first, then add the SSH key'); }
+      else if (!r.ok) { setErr(d.error || 'could not save SSH key'); }
+      else { setErr('SSH key saved'); }
+    } finally { setBusy(false); }
+  }
+
+  async function removeSSHKey() {
+    setBusy(true); setErr('');
+    try {
+      const r = await api('/api/git/sshkey', { method: 'DELETE' });
+      if (!r.ok) { const d = await r.json().catch(() => ({})); setErr(d.error || 'could not clear SSH key'); }
+      else { setCredSSHKey(''); setErr('SSH key cleared'); }
     } finally { setBusy(false); }
   }
 
@@ -246,6 +274,24 @@ export default function Projects() {
             <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
               disabled={busy || !credHost.trim() || !credToken.trim()} onClick={addCred}>Save</button>
           </div>
+          <details style={{ marginTop: '10px', fontSize: '12px', color: '#aaa' }}>
+            <summary style={{ cursor: 'pointer' }}>SSH private key (for git over SSH)</summary>
+            <div style={{ marginTop: '6px' }}>
+              <div style={{ marginBottom: '6px' }}>
+                Paste an <b>unencrypted</b> OpenSSH/PEM private key (no passphrase). It is stored only in
+                your encrypted vault and never shown again. Requires your vault to be unlocked.
+              </div>
+              <textarea style={{ ...input, width: '100%', minHeight: '110px', fontFamily: 'monospace' }}
+                placeholder={'-----BEGIN OPENSSH PRIVATE KEY-----\n…\n-----END OPENSSH PRIVATE KEY-----'}
+                value={credSSHKey} onChange={e => setCredSSHKey(e.target.value)} />
+              <div style={{ display: 'flex', gap: '8px', marginTop: '6px', flexWrap: 'wrap' }}>
+                <button style={{ ...btn, background: '#234', color: '#8cf', borderColor: '#456' }}
+                  disabled={busy || !credSSHKey.trim()} onClick={addSSHKey}>Save SSH key</button>
+                <button style={{ ...btn, borderColor: '#d99', color: '#c33' }} disabled={busy}
+                  onClick={removeSSHKey}>Clear SSH key</button>
+              </div>
+            </div>
+          </details>
         </div>
       </Panel>
 

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -17,10 +17,12 @@
 
 /* Route-handler deps used below but not needed by server_http.c's own body
  * (kept here, not in server_http.c, to respect its 2000-line limit). */
+#include "git_forge_vault.h"  /* GIT_FORGE_VAULT_AGENT/SSHKEY_CRED — per-webuser ssh-key vault */
 #include "git_host_cred.h"    /* per-host git credential store for /v1/git/credentials */
 #include "git_oauth_github.h" /* GitHub device-flow sign-in (/v1/git/oauth/github) */
 #include "git_ops.h"          /* git_ops_run for /v1/workspace/git (WP-E) */
 #include "git_ssh_agent.h"    /* git_ssh_agent_stop — drop live key handles on revoke */
+#include "vault_service.h"    /* vault_service_set/delete for the per-webuser ssh-key route */
 #include "git_project.h"      /* git_project_clone for /v1/workspace/clone (WP-D) */
 #include "webuser_editor.h"   /* webuser_editor_ensure for /v1/workspace/editor (WP-I) */
 #include "workspace_scope.h"  /* ws_scope_user_root — project workspace root */
@@ -1520,6 +1522,89 @@ static int rh_git_credentials(const route_req_t *rq, char *resp, int cap)
               : err_json(resp, cap, 500, "too large");
 }
 
+/* Per-webuser SSH private key for git over SSH. Stored in the caller's OWN
+ * encrypted vault under (webuser:<name>, "git", "ssh_key") — dual-wrapped so the
+ * server can load it into the user's in-memory ssh-agent autonomously
+ * (git_ssh_agent_ensure → git_forge_vault_sshkey), while the key never reaches
+ * the browser (write-only) and never lands on disk. Storing needs the caller's
+ * vault unlocked (the per-principal KEK); a locked vault returns 423 so the UI
+ * can prompt an unlock. The secret is never logged. */
+static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
+{
+   const char *principal = server_http_identity_principal();
+   if (!principal || strncmp(principal, "webuser:", 8) != 0)
+      return err_json(resp, cap, 403, "ssh keys require a webchat user");
+
+   if (strcmp(rq->method, "DELETE") == 0)
+   {
+      /* Remove the stored key and drop any live agent handle (mirrors revoke). A
+       * missing entry is success — DELETE is idempotent. git_ssh_agent_stop runs
+       * only on a clean delete: on a real vault error the persisted key still
+       * exists, so tearing the agent down would just force a reload — leaving it
+       * is the less-inconsistent state. */
+      vault_status_t st =
+          vault_service_delete(principal, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED);
+      if (st != VAULT_OK && st != VAULT_NO_ENTRY)
+         return err_json(resp, cap, 500, "vault delete failed");
+      git_ssh_agent_stop(principal);
+      return snprintf(resp, (size_t)cap, "{\"ok\":true}") < cap
+                 ? 200
+                 : err_json(resp, cap, 500, "too large");
+   }
+   if (strcmp(rq->method, "POST") != 0)
+      return err_json(resp, cap, 405, "method not allowed");
+
+   /* Bound the body before parsing: a private key is a few KB, so anything past
+    * 64 KiB is abuse — fail fast rather than parse + re-wrap a huge blob. */
+   if (rq->body_len > 65536)
+      return err_json(resp, cap, 413, "ssh key too large");
+
+   cJSON *body = (rq->body && rq->body[0]) ? cJSON_Parse(rq->body) : NULL;
+   if (!body || !cJSON_IsObject(body))
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400, "invalid JSON body");
+   }
+   const cJSON *jkey = cJSON_GetObjectItemCaseSensitive(body, "ssh_key");
+   const char *key = (cJSON_IsString(jkey) && jkey->valuestring) ? jkey->valuestring : NULL;
+   /* Cheap shape check so an obviously-wrong paste fails fast with a clear
+    * message; ssh-add is still the authority at load time. Anchor on the PEM/
+    * OpenSSH armor ("-----BEGIN … PRIVATE KEY-----") rather than a loose
+    * substring so arbitrary text containing the words can't slip through. We do
+    * NOT accept a passphrase-encrypted key — the agent loads non-interactively. */
+   if (!key || strncmp(key, "-----BEGIN", 10) != 0 || !strstr(key, "PRIVATE KEY-----"))
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400, "an unencrypted OpenSSH/PEM private key is required");
+   }
+   if (strstr(key, "ENCRYPTED") || strstr(key, "Proc-Type:"))
+   {
+      cJSON_Delete(body);
+      return err_json(resp, cap, 400,
+                      "passphrase-encrypted keys are not supported; provide an unencrypted key");
+   }
+
+   vault_status_t st = vault_service_set(principal, GIT_FORGE_VAULT_AGENT, GIT_FORGE_SSHKEY_CRED,
+                                         key, (long)time(NULL));
+   /* Zero our parsed copy of the secret before freeing the JSON tree. */
+   if (jkey && jkey->valuestring)
+   {
+      volatile char *p = (volatile char *)jkey->valuestring;
+      for (size_t i = 0; p[i]; i++)
+         p[i] = 0;
+   }
+   cJSON_Delete(body);
+   if (st == VAULT_ERR_LOCKED)
+      return err_json(resp, cap, 423, "vault is locked — unlock it, then add the key");
+   if (st != VAULT_OK)
+      return err_json(resp, cap, 500, "vault store failed");
+   /* A freshly stored key supersedes any agent already running with the old one. */
+   git_ssh_agent_stop(principal);
+   return snprintf(resp, (size_t)cap, "{\"ok\":true}") < cap
+              ? 200
+              : err_json(resp, cap, 500, "too large");
+}
+
 /* POST /v1/git/oauth/github/start — begin GitHub device-flow sign-in. Returns
  * {ok, user_code, verification_uri, interval}; 503 if not configured. */
 static int rh_git_oauth_github_start(const route_req_t *rq, char *resp, int cap)
@@ -2111,6 +2196,8 @@ static const http_route_t g_v1_routes[] = {
     {"GET", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},
     {"POST", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},
     {"DELETE", "/v1/git/credentials", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_credentials},
+    {"POST", "/v1/git/sshkey", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_sshkey},
+    {"DELETE", "/v1/git/sshkey", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE, rh_git_sshkey},
     {"POST", "/v1/git/oauth/github/start", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,
      rh_git_oauth_github_start},
     {"POST", "/v1/git/oauth/github/poll", NULL, RM_EXACT, NULL, CAP_TOOL_EXECUTE,

--- a/src/tests/support/git_route_stub.c
+++ b/src/tests/support/git_route_stub.c
@@ -8,6 +8,7 @@
 #include "git_oauth_github.h"
 #include "git_ops.h"
 #include "git_project.h"
+#include "git_ssh_agent.h"
 #include "index.h"
 #include "webuser_editor.h"
 #include "workspace_scope.h"
@@ -168,4 +169,11 @@ int ws_scope_user_root(const char *principal, int create, char *out, size_t cap)
    if (out && cap)
       out[0] = '\0';
    return -1;
+}
+
+/* The git credential/ssh-key routes drop any live ssh-agent handle on
+ * revoke/replace; a no-op suffices for HTTP-routing tests. */
+void git_ssh_agent_stop(const char *principal)
+{
+   (void)principal;
 }

--- a/src/tests/support/vault_service_stub.c
+++ b/src/tests/support/vault_service_stub.c
@@ -42,3 +42,24 @@ vault_status_t vault_service_get_server_principal(const char *agent, const char 
       out[0] = '\0';
    return VAULT_NO_ENTRY;
 }
+
+/* The git ssh-key route (rh_git_sshkey) stores/removes a per-webuser key; tests
+ * that link server_http.o but not the real vault get a clean success here. */
+vault_status_t vault_service_set(const char *principal, const char *agent, const char *cred,
+                                 const char *secret, long now_epoch)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   (void)secret;
+   (void)now_epoch;
+   return VAULT_OK;
+}
+
+vault_status_t vault_service_delete(const char *principal, const char *agent, const char *cred)
+{
+   (void)principal;
+   (void)agent;
+   (void)cred;
+   return VAULT_OK;
+}

--- a/webchat/git.go
+++ b/webchat/git.go
@@ -159,6 +159,46 @@ func (s *server) handleGitCredentials(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// /api/git/sshkey — store (POST {ssh_key}) or remove (DELETE) the caller's SSH
+// private key for git over SSH. The key is write-only: it goes to the user's
+// encrypted vault server-side and is never read back to the browser. Storing
+// needs the user's vault unlocked; aimee-server returns 423 if it is locked,
+// which the UI surfaces as a prompt to unlock.
+func (s *server) handleGitSSHKey(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), socketCallTimeout)
+	defer cancel()
+	user := currentUser(r)
+	switch r.Method {
+	case http.MethodDelete:
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodDelete, "/v1/git/sshkey", nil)
+		s.gitRelay(w, st, data, err)
+	case http.MethodPost:
+		// A private key is a few KB; cap the body so a huge POST can't force
+		// large allocations + parse + re-marshal here and downstream.
+		r.Body = http.MaxBytesReader(w, r.Body, 64<<10)
+		var req struct {
+			SSHKey string `json:"ssh_key"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.SSHKey == "" {
+			if _, ok := err.(*http.MaxBytesError); ok {
+				writeJSONError(w, http.StatusRequestEntityTooLarge, "ssh key too large")
+				return
+			}
+			writeJSONError(w, http.StatusBadRequest, "ssh_key required")
+			return
+		}
+		body, err := json.Marshal(map[string]string{"ssh_key": req.SSHKey})
+		if err != nil {
+			writeJSONError(w, http.StatusInternalServerError, "could not encode request")
+			return
+		}
+		st, data, err := s.v1RequestWebuser(ctx, user, http.MethodPost, "/v1/git/sshkey", body)
+		s.gitRelay(w, st, data, err)
+	default:
+		writeJSONError(w, http.StatusMethodNotAllowed, "method not allowed")
+	}
+}
+
 // GET /api/git/projects — list the user's cloned projects.
 func (s *server) handleGitProjects(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodGet {

--- a/webchat/git_sshkey_test.go
+++ b/webchat/git_sshkey_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The SSH-key panel POSTs {ssh_key} to /api/git/sshkey; the backend must forward
+// it to aimee-server's /v1/git/sshkey carrying the webuser trust headers, and
+// must never echo the key back to the browser. DELETE clears it (no body).
+func TestGitSSHKeyProxy(t *testing.T) {
+	var gotMethod, gotWebuser, gotAuth, gotBody string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/git/sshkey", func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotWebuser = r.Header.Get("X-Aimee-Webuser")
+		gotAuth = r.Header.Get("Authorization")
+		b := make([]byte, r.ContentLength)
+		r.Body.Read(b)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true}`))
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+		[]byte("sekret-token\n"), 0600); err != nil {
+		t.Fatalf("write server.token: %v", err)
+	}
+	s := &server{cfg: cfg}
+
+	const key = "-----BEGIN OPENSSH PRIVATE KEY-----\nABCDEF\n-----END OPENSSH PRIVATE KEY-----"
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/git/sshkey",
+		strings.NewReader(`{"ssh_key":`+jsonString(key)+`}`)), "alice")
+	rr := httptest.NewRecorder()
+	s.handleGitSSHKey(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("POST sshkey: code=%d body=%q", rr.Code, rr.Body.String())
+	}
+	if gotMethod != http.MethodPost || gotWebuser != "alice" || gotAuth != "Bearer sekret-token" {
+		t.Fatalf("forwarded method=%q webuser=%q auth=%q", gotMethod, gotWebuser, gotAuth)
+	}
+	if !strings.Contains(gotBody, "ABCDEF") {
+		t.Fatalf("forwarded body missing key material: %q", gotBody)
+	}
+	// The key must never be echoed back to the browser.
+	if strings.Contains(rr.Body.String(), "ABCDEF") {
+		t.Fatalf("response leaked key material to the browser: %q", rr.Body.String())
+	}
+
+	// DELETE clears it: no body, forwarded as DELETE.
+	gotMethod, gotBody = "", "x"
+	req = withUser(httptest.NewRequest(http.MethodDelete, "/api/git/sshkey", nil), "alice")
+	rr = httptest.NewRecorder()
+	s.handleGitSSHKey(rr, req)
+	if rr.Code != http.StatusOK || gotMethod != http.MethodDelete {
+		t.Fatalf("DELETE sshkey: code=%d forwardedMethod=%q", rr.Code, gotMethod)
+	}
+}
+
+// A missing/empty key is rejected at the proxy without calling aimee-server.
+func TestGitSSHKeyRejectsEmpty(t *testing.T) {
+	called := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/git/sshkey", func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.Write([]byte(`{"ok":true}`))
+	})
+	cfg := startFakeV1(t, mux)
+	if err := os.WriteFile(filepath.Join(filepath.Dir(cfg.socketPath), "server.token"),
+		[]byte("t\n"), 0600); err != nil {
+		t.Fatalf("write server.token: %v", err)
+	}
+	s := &server{cfg: cfg}
+
+	req := withUser(httptest.NewRequest(http.MethodPost, "/api/git/sshkey",
+		strings.NewReader(`{"ssh_key":""}`)), "alice")
+	rr := httptest.NewRecorder()
+	s.handleGitSSHKey(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("empty key: code=%d, want 400", rr.Code)
+	}
+	if called {
+		t.Fatalf("aimee-server was called for an empty key")
+	}
+}
+
+// jsonString quotes s as a JSON string literal (small helper to avoid importing
+// encoding/json just for the test body).
+func jsonString(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"':
+			b.WriteString(`\"`)
+		case '\\':
+			b.WriteString(`\\`)
+		case '\n':
+			b.WriteString(`\n`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/webchat/server.go
+++ b/webchat/server.go
@@ -200,6 +200,7 @@ func (s *server) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("/api/git/op", s.requireAuth(s.handleGitOp))
 	mux.HandleFunc("/api/git/session-dir", s.requireAuth(s.handleGitSessionDir))
 	mux.HandleFunc("/api/git/credentials", s.requireAuth(s.handleGitCredentials))
+	mux.HandleFunc("/api/git/sshkey", s.requireAuth(s.handleGitSSHKey))
 	mux.HandleFunc("/api/git/oauth/github/start", s.requireAuth(s.handleGitOauthGithubStart))
 	mux.HandleFunc("/api/git/oauth/github/poll", s.requireAuth(s.handleGitOauthGithubPoll))
 	mux.HandleFunc("/api/git/oauth/github/config", s.requireAuth(s.handleGitOauthGithubConfig))


### PR DESCRIPTION
Closes deferred follow-up **#1** from the webchat-git/VSCode close-out: the per-user in-memory ssh-agent path was built + tested but **unreachable from the browser** (only PAT/token + GitHub OAuth had intake), so a webchat user couldn't use git over SSH.

## Change (end-to-end)
- **`POST`/`DELETE /v1/git/sshkey`** (`rh_git_sshkey`). POST stores an unencrypted OpenSSH/PEM private key in the **caller's own vault** under `(webuser:<name>, "git", "ssh_key")` via `vault_service_set` — dual-wrapped, so the already-shipped `git_ssh_agent_ensure → git_forge_vault_sshkey` loads it into the user's in-memory agent **autonomously** (server-wrap read, no user KEK needed at load time). The key is write-only (never returned), shape-checked (rejects empty / non-`PRIVATE KEY` / passphrase-encrypted), zeroed from the parse buffer after store, and never logged. A **locked vault → 423** so the UI can prompt an unlock. DELETE removes the entry + drops any live agent handle; idempotent.
- **webchat `/api/git/sshkey`** proxy forwarding under the webuser trust headers; documented in `api/openapi-server-v1.yaml` (route↔spec conformance gate).
- **`Projects.tsx`**: a collapsible "SSH private key" field in the Git accounts panel.

## Verification
C + Go build clean; frontend `tsc` clean; webchat proxy tests (forward-with-trust-headers, no-echo-to-browser, empty-reject) green; `server-api-conformance` green. The storage↔reader contract is already covered by `test_git_forge_vault.c`. The full **unlock → store → agent-load → git-over-SSH push** round trip needs a deployed server to exercise (no local code-server/forge here) — flagged honestly rather than claimed.

Roundtable code-review run on the diff; summary posted as a comment.