### PR TITLE
feat(webchat-git): AIMEE_WEBCHAT_GIT opt-out for the git surface

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -216,7 +216,7 @@ Scalar keys read directly from the config root (not via the CLI allowlist above)
 
 ## Environment variables
 
-The binaries read 132 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
+The binaries read 133 `AIMEE_*` environment variables (scanned from `getenv()` in `src/`, excluding tests). They override config-store values and are mostly for deployment/runtime wiring. Secrets/tokens should be supplied via the environment or the credential vault, never committed.
 
 ### Paths & assets
 
@@ -412,7 +412,7 @@ The binaries read 132 `AIMEE_*` environment variables (scanned from `getenv()` i
 
 > These are read by the code but have no description yet — the generator surfaces them so the reference can't silently fall behind.
 
-`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WEBCHAT_EDITOR_IDLE_SECS`, `AIMEE_WORKFLOW_BRANCH`
+`AIMEE_AUTONOMY_BASE`, `AIMEE_AUTONOMY_MAX_ACTIVE_PER_PRINCIPAL`, `AIMEE_AUTONOMY_MAX_USD`, `AIMEE_AUTONOMY_SUBMIT_RATE_PER_MIN`, `AIMEE_AUTONOMY_SUBMIT_WINDOW_SECS`, `AIMEE_AUTONOMY_USD_PER_SEC`, `AIMEE_CODEX_REFRESH_SKEW`, `AIMEE_CODE_INDEX_SOURCE`, `AIMEE_DB2_POOL_SIZE`, `AIMEE_DELEGATE_MAX_INFLIGHT`, `AIMEE_DIM_PROBE_BUDGET_MS`, `AIMEE_PROJECT_ID`, `AIMEE_RUNTIME_DIR`, `AIMEE_TLS_CLIENT_P12_PASS`, `AIMEE_TLS_EXTRA_SAN`, `AIMEE_WEBCHAT_EDITOR_IDLE_SECS`, `AIMEE_WEBCHAT_GIT`, `AIMEE_WORKFLOW_BRANCH`
 
 ## External & provider environment
 

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1152,14 +1152,27 @@ static int rh_workspace_remove(const route_req_t *rq, char *resp, int cap)
    return ws_dispatch_args("workspace.remove", path, NULL, 0, resp, cap);
 }
 
-/* POST /v1/workspaces/{id}/forge-token — install a short-lived brokered forge
- * token for the workspace (workspace-resource-plane §4). Body:
- * {token, scope?, ttl_seconds?}. The token is held in memory only and injected
- * into the server's git/gh exec env; it is never written to disk or logged, and
- * is revoked when the workspace closes. tool:execute (write); reachable over TCP
- * so a filesystem-rich client hands its token to a detached/co-located hub. */
+/* AIMEE_WEBCHAT_GIT=0 disables the whole webchat git surface — forge-token,
+ * clone, ops, per-host credentials, ssh-key, projects, session-dir, OAuth —
+ * without affecting the editor (which has its own AIMEE_WEBCHAT_EDITOR gate;
+ * session-dir is git-panel-only and not on the editor path, so gating it here is
+ * safe). On by default; only the exact value "0" disables it, so a blank/other
+ * value leaves git enabled. Read per call (immediate single-byte compare, like
+ * webuser_editor's AIMEE_WEBCHAT_EDITOR gate) — aimee never setenv()s at request
+ * time, so there is no concurrent-mutation window. Each git route checks this
+ * first and returns 503 when off — ahead of the 403 webuser check, which is
+ * intentional: the disabled state is not a secret, and an operator can ship the
+ * image with the editor but no git intake. */
+static int git_surface_enabled(void)
+{
+   const char *v = getenv("AIMEE_WEBCHAT_GIT");
+   return !(v && v[0] == '0' && v[1] == '\0');
+}
+
 static int rh_workspace_forge_token(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    char path[MAX_PATH_LEN];
    ws_pct_decode(rq->id, path, sizeof(path));
    if (!path[0])
@@ -1197,6 +1210,8 @@ static int rh_workspace_forge_token(const route_req_t *rq, char *resp, int cap)
  * injected from the user's sealed vault (WP-C); never accepted in the body. */
 static int rh_workspace_clone(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git projects require a webchat user");
@@ -1240,6 +1255,8 @@ static int rh_workspace_clone(const route_req_t *rq, char *resp, int cap)
  * allowlisted by git_ops, and remote ops use the user's vaulted creds. */
 static int rh_workspace_git(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git projects require a webchat user");
@@ -1295,6 +1312,8 @@ static int rh_workspace_git(const route_req_t *rq, char *resp, int cap)
 static int rh_workspace_projects(const route_req_t *rq, char *resp, int cap)
 {
    (void)rq;
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git projects require a webchat user");
@@ -1376,6 +1395,8 @@ static int rh_chat_live(const route_req_t *rq, char *resp, int cap)
  * session's agent edits. Identity is the attested webuser principal. */
 static int rh_workspace_session_dir(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git projects require a webchat user");
@@ -1442,6 +1463,8 @@ static int rh_workspace_editor(const route_req_t *rq, char *resp, int cap)
  * tokens. Identity is the attested X-Aimee-Webuser principal. */
 static int rh_git_credentials(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git credentials require a webchat user");
@@ -1531,6 +1554,8 @@ static int rh_git_credentials(const route_req_t *rq, char *resp, int cap)
  * can prompt an unlock. The secret is never logged. */
 static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "ssh keys require a webchat user");
@@ -1610,6 +1635,8 @@ static int rh_git_sshkey(const route_req_t *rq, char *resp, int cap)
 static int rh_git_oauth_github_start(const route_req_t *rq, char *resp, int cap)
 {
    (void)rq;
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git sign-in requires a webchat user");
@@ -1639,6 +1666,8 @@ static int rh_git_oauth_github_start(const route_req_t *rq, char *resp, int cap)
 static int rh_git_oauth_github_poll(const route_req_t *rq, char *resp, int cap)
 {
    (void)rq;
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git sign-in requires a webchat user");
@@ -1661,6 +1690,8 @@ static int rh_git_oauth_github_poll(const route_req_t *rq, char *resp, int cap)
  * button can be configured without touching env vars. */
 static int rh_git_oauth_github_config(const route_req_t *rq, char *resp, int cap)
 {
+   if (!git_surface_enabled())
+      return err_json(resp, cap, 503, "the git surface is disabled on this server");
    const char *principal = server_http_identity_principal();
    if (!principal || strncmp(principal, "webuser:", 8) != 0)
       return err_json(resp, cap, 403, "git sign-in requires a webchat user");

--- a/src/tests/test_server_http.c
+++ b/src/tests/test_server_http.c
@@ -1091,6 +1091,48 @@ int main(void)
       assert(server_http_resolve_bind_addr(1 /*want_ext*/, 1 /*tls*/) == INADDR_ANY);
    }
 
+   /* --- AIMEE_WEBCHAT_GIT=0 disables the whole git surface (503 first) --- */
+   {
+      char resp[2048];
+      /* Every git-surface route; the gate runs before any other work, so a
+       * disabled surface returns 503 for all of them (no server-ctx access). */
+      static const struct
+      {
+         const char *m, *p, *body;
+      } git_routes[] = {
+          {"POST", "/v1/workspaces/ws1/forge-token", "{}"},
+          {"POST", "/v1/workspace/clone", "{}"},
+          {"POST", "/v1/workspace/git", "{}"},
+          {"GET", "/v1/workspace/projects", NULL},
+          {"POST", "/v1/workspace/session-dir", "{}"},
+          {"GET", "/v1/git/credentials", NULL},
+          {"POST", "/v1/git/sshkey", "{}"},
+          {"POST", "/v1/git/oauth/github/start", "{}"},
+          {"POST", "/v1/git/oauth/github/poll", "{}"},
+          {"GET", "/v1/git/oauth/github/config", NULL},
+      };
+      const int gn = (int)(sizeof(git_routes) / sizeof(git_routes[0]));
+      setenv("AIMEE_WEBCHAT_GIT", "0", 1);
+      for (int i = 0; i < gn; i++)
+      {
+         int blen = git_routes[i].body ? (int)strlen(git_routes[i].body) : 0;
+         int st = server_http_route(git_routes[i].m, git_routes[i].p, git_routes[i].body, blen,
+                                    resp, sizeof(resp));
+         assert(st == 503);
+      }
+      /* Enabled (default + any non-"0"): the gate no longer fires. The two
+       * context-free routes fall through to their own 403 webuser check (no
+       * attested webuser in this harness) — crucially NOT 503. */
+      unsetenv("AIMEE_WEBCHAT_GIT");
+      assert(server_http_route("GET", "/v1/workspace/projects", NULL, 0, resp, sizeof(resp)) ==
+             403);
+      assert(server_http_route("GET", "/v1/git/credentials", NULL, 0, resp, sizeof(resp)) == 403);
+      setenv("AIMEE_WEBCHAT_GIT", "1", 1);
+      assert(server_http_route("GET", "/v1/workspace/projects", NULL, 0, resp, sizeof(resp)) ==
+             403);
+      unsetenv("AIMEE_WEBCHAT_GIT");
+   }
+
    platform_test_rmrf(home);
    printf("OK\n");
    return 0;


### PR DESCRIPTION
Closes deferred follow-up **#7** from the webchat-git/VSCode close-out: the git surface shipped **always-on with no operator opt-out**, unlike the editor (`AIMEE_WEBCHAT_EDITOR=0`).

## Change
Adds a `git_surface_enabled()` gate (env `AIMEE_WEBCHAT_GIT`, on by default; only the exact value `0` disables) checked first in each of the 9 git route handlers — `rh_workspace_clone` / `git` / `projects` / `session_dir`, `rh_git_credentials`, `rh_git_sshkey`, `rh_git_oauth_github_start` / `poll` / `config` — returning **503** before any other work. The editor surface is independently controllable and untouched, so an operator can ship the image with the in-browser editor but no git intake.

## Test
`unit-test-server-http` asserts disabled→503 (short-circuits ahead of the 403 webuser check) and enabled→403; `docs/gen/configuration.md` regenerated for the new env var. C build + server-http test green; clang-format clean.

Roundtable code-review run on the diff; summary posted as a comment.