### PR TITLE
feat(fold): P1.5 per-model fold-budget resolver + pipeline-order spike

### DIFF
--- a/docs/dev/fold-pipeline-order.md
+++ b/docs/dev/fold-pipeline-order.md
@@ -1,0 +1,98 @@
+# Fold pipeline-order spike (P1.5)
+
+De-risks the P2 rolling-fold + fold-freeze implementation by pinning **where** the
+transcript fold runs and **how** it contributes to the single cache-prefix owner,
+before any P2 code is written. Companion to `fold_budget.{c,h}` (the §7 resolver
+landed in the same slice). Ruling from the plan roundtable: target the **delegate
+path first** (it already owns `payload_rewrite`); the ingress proxy path is a later
+slice.
+
+## Normative pipeline order (delegate path)
+
+`agent_runtime.c` is the actor throughout: it calls each step and owns the buffers.
+Six steps per turn in `agent_execute_with_tools_internal()`
+(`src/posix/agent_runtime.c`); step 1 is pre-stage input, steps 2–6 are actions:
+
+1. **raw DB1 transcript** — append-only `messages` cJSON array (never mutated).
+2. **session compaction** — `maybe_compact_before_request()` (≈`agent_runtime.c:677`).
+3. **[FOLD PASS — P2]** — runtime calls `context_fold_view(messages, sys, &budget,
+   cfg, &out)`, which **produces and returns** the synthetic skeleton pair +
+   Coordinate Closet (§2) as a view, non-destructively (`messages` untouched), then
+   exits. The fold function does not touch prefix state.
+4. **provider-shape normalization** — runtime renders the step-3 view into the active
+   provider shape (Anthropic content blocks / OpenAI `tool_calls` / Gemini `parts`)
+   into a **runtime-owned byte buffer**, with the **atomic tool-pair** rule (a
+   `tool_use`+`tool_result` fold together or not at all; folded regions are plain
+   non-tool text). This is a deterministic 1:1 render, not a semantic rewrite.
+5. **cache-prefix registration + single hash** — runtime registers the step-4
+   buffer `(ptr,len)` via `payload_rewrite_register_span()`, then the canonical
+   prefix-hash wrapper (`track_anthropic_payload_rewrite()` and its
+   `track_{openai,gemini}_payload_rewrite` siblings, all delegating into
+   `payload_rewrite.c`, ≈`agent_runtime.c:698`) hashes the registered spans **once**.
+6. **request build** — `agent_build_request_*()` (≈`agent_runtime.c:699`).
+
+Invariant: step 3's output is **semantically frozen**; step 4 is a deterministic
+1:1 render; the exact post-step-4 bytes are what step 5 registers and hashes — no
+semantic change *and* no byte change is permitted between steps 4 and 5. "Rewrite"
+means semantic mutation; rendering at step 4 is not a rewrite. The fold pass MUST
+sit at step 3 (after compaction, before the step-5 hash).
+
+## Single prefix-state owner + span registry
+
+`payload_rewrite.c` stays the sole owner of the FNV-1a prefix hash and
+`payload_rewrite_state_t`. The fold does not hash anything itself. New **internal**
+API (declared in a `payload_rewrite_internal.h`, or enum-keyed from a closed set):
+
+```c
+/* Register a stable span that contributes to the cache prefix, in order.
+ * State-scoped to the turn's payload_rewrite_state_t (not process-global) so
+ * nested/concurrent/retried turns cannot leak spans into each other.
+ * ptr must remain valid (runtime-owned, see step 4) until the matching
+ * payload_rewrite_spans_reset(). Returns 0 on success, -1 on a misuse the
+ * registry can detect: bad/duplicate id, NULL ptr, zero len, or out-of-order
+ * registration. A debug build additionally asserts each (ptr,len) is still
+ * resident at hash time. */
+int payload_rewrite_register_span(payload_rewrite_state_t *st, payload_rewrite_span_id_t id,
+                                  const char *ptr, size_t len);
+/* Mandatory + idempotent at the top of each turn. */
+void payload_rewrite_spans_reset(payload_rewrite_state_t *st);
+```
+
+- `fnv1a_update` stays `static` in `payload_rewrite.c`.
+- The registered span is the **post-step-4** (provider-shape-normalized) serialized
+  bytes — exactly what is sent — so the hash matches what the provider caches.
+  `agent_runtime.c` owns that buffer; the fold (step 3) only produces a view and
+  exits. Lifetime: register after step 4, hash at step 5, `spans_reset()` at the top
+  of the next turn — no use-after-free / double-free.
+- The pending `ingress-compression-and-cache-alignment` work registers the envelope
+  span through the same API — **serialized convergence**: the shared span-registry
+  PR lands first, then the fold and ingress features layer on it. Never two writers.
+
+## CI single-owner enforcement
+
+A lint scan fails the build if any new caller of `fnv1a_update` or a
+`payload_rewrite_state_t` mutator appears outside `src/payload_rewrite.c`,
+mechanically preserving the single-owner contract the plan roundtable required (B7).
+
+**Bootstrap gap:** the lint lands in the *same* P2 PR that introduces the registry,
+so that PR is not gated by its own lint at review time. The P2 registry PR must
+therefore be reviewed specifically for any new `fnv1a_update` caller outside
+`payload_rewrite.c`, and ship the `git grep -nE '\bfnv1a_update\b' src/ | grep -v
+payload_rewrite` CI step from day one.
+
+## Budget config surface (deferred to P2)
+
+`fold_budget_resolve()` is a pure function of `(model_id, fold_budget_config_t)`.
+
+**Explicitly NOT in P1.5** (intentionally deferred to P2, so a follow-up author does
+not "helpfully" wire inert config that nothing reads):
+
+- `config_t` fields + a `fold` config section for the five knobs: window fallback,
+  retained-band %, tail-cap %, pressure-ceiling %, prefix-saturation %, and the
+  closet budget;
+- a `fold_budget_config_t`-from-`config_t` populator at the step-3 call site.
+
+These land in P2 in the same change that consumes the resolver. **P2 acceptance
+requires** that wiring plus determinism tests for the B-S8 rule: any per-tool
+override that still affects a fold is frozen for the freeze TTL or serialized into
+the fold-input hash, so identical inputs cannot resolve to two budgets across turns.

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/fold_budget.c
+++ b/src/fold_budget.c
@@ -1,0 +1,63 @@
+/* fold_budget.c: per-model context-fold budget resolver (fold §7, P1.5).
+ * See fold_budget.h for the contract. Pure: model_registry table lookup only. */
+#include "fold_budget.h"
+#include "model_registry.h"
+
+#include <stdint.h>
+#include <string.h>
+
+/* pct of window, clamped to [0, window]. The intermediate product uses a
+ * fixed-width 64-bit type: `long` is 32-bit on LLP64 (Windows) and ILP32, where
+ * window*pct would overflow (signed UB) before any clamp could run. */
+static int pct_of(int window, int pct)
+{
+   if (window <= 0 || pct <= 0)
+      return 0;
+   int64_t v = (int64_t)window * (int64_t)pct / 100;
+   if (v > window)
+      v = window; /* pct > 100 clamps to the whole window (see header contract) */
+   if (v < 0)
+      v = 0; /* defensive: unreachable given the guards above */
+   return (int)v;
+}
+
+int fold_budget_resolve(const char *model_id, const fold_budget_config_t *cfg, fold_budget_t *out)
+{
+   if (!out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+
+   int window = 0;
+   if (model_id && model_id[0])
+      window = model_context_window(model_id); /* 0 if unknown */
+   if (window > 0)
+   {
+      out->is_known = 1;
+   }
+   else
+   {
+      out->is_known = 0;
+      window = (cfg && cfg->context_window_tokens > 0) ? cfg->context_window_tokens
+                                                       : FOLD_BUDGET_DEFAULT_WINDOW;
+   }
+   out->context_window_tokens = window;
+
+   int rb = (cfg && cfg->retained_band_pct > 0) ? cfg->retained_band_pct
+                                                : FOLD_BUDGET_DEFAULT_RETAINED_PCT;
+   int tc = (cfg && cfg->tail_cap_pct > 0) ? cfg->tail_cap_pct : FOLD_BUDGET_DEFAULT_TAIL_CAP_PCT;
+   int pc = (cfg && cfg->pressure_ceiling_pct > 0) ? cfg->pressure_ceiling_pct
+                                                   : FOLD_BUDGET_DEFAULT_PRESSURE_PCT;
+   int ps = (cfg && cfg->prefix_saturation_pct > 0) ? cfg->prefix_saturation_pct
+                                                    : FOLD_BUDGET_DEFAULT_SATURATION_PCT;
+
+   out->retained_band_tokens = pct_of(window, rb);
+   out->tail_cap_tokens = pct_of(window, tc);
+   out->pressure_ceiling_tokens = pct_of(window, pc);
+   out->prefix_saturation_tokens = pct_of(window, ps);
+   out->closet_budget_tokens = (cfg && cfg->closet_budget_tokens > 0)
+                                   ? cfg->closet_budget_tokens
+                                   : FOLD_BUDGET_DEFAULT_CLOSET_TOKENS;
+   if (out->closet_budget_tokens > window) /* §7 single enforcement point */
+      out->closet_budget_tokens = window;
+   return 0;
+}

--- a/src/headers/fold_budget.h
+++ b/src/headers/fold_budget.h
@@ -1,0 +1,69 @@
+/* fold_budget.h: per-model context-fold budget resolver (fold §7, P1.5).
+ *
+ * Turns a model choice into the mechanical fold knobs deterministically — a pure
+ * function of (model_id, config). It is a PREREQUISITE for the P2 rolling fold and
+ * fold-freeze: byte-identical folding cannot be validated without a deterministic
+ * budget. No model call, no clock, no randomness.
+ *
+ * The window comes from model_registry's model_context_window(); unknown models
+ * fall back to a configured (or built-in default) window. The band/tail/pressure/
+ * saturation knobs are fixed percentages of the window (operator-overridable). */
+#ifndef DEC_FOLD_BUDGET_H
+#define DEC_FOLD_BUDGET_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Resolved fold parameters for a model (all token counts). */
+   typedef struct
+   {
+      int context_window_tokens;    /* total model window */
+      int retained_band_tokens;     /* most-recent turns kept at full fidelity */
+      int tail_cap_tokens;          /* rolling-tail size before the fold advances */
+      int pressure_ceiling_tokens;  /* hard-fold (epoch) trigger */
+      int prefix_saturation_tokens; /* freeze recompute trigger */
+      int closet_budget_tokens;     /* Coordinate Closet (§2) budget, <= window */
+      int is_known;                 /* int 0/1: 1 if model_id resolved to a known window */
+   } fold_budget_t;
+
+   /* Operator overrides. Convention: a field <= 0 (including a negative typo)
+    * means "use the built-in default" — there is no presence mask, so a literal
+    * 0% cannot be expressed (none of the knobs has a meaningful 0% today). A
+    * percentage > 100 is clamped to the whole window (not rejected). Percentages
+    * are of the resolved context window. closet_budget_tokens is clamped to the
+    * window. This resolver does mechanical model+pct -> token translation only; it
+    * does NOT enforce cross-field ordering (e.g. retained <= pressure) — the P2
+    * fold consumer validates policy consistency before use. */
+   typedef struct
+   {
+      int context_window_tokens; /* fallback window for unknown models */
+      int retained_band_pct;
+      int tail_cap_pct;
+      int pressure_ceiling_pct;
+      int prefix_saturation_pct;
+      int closet_budget_tokens; /* absolute */
+   } fold_budget_config_t;
+
+#define FOLD_BUDGET_DEFAULT_WINDOW         200000
+#define FOLD_BUDGET_DEFAULT_RETAINED_PCT   25
+#define FOLD_BUDGET_DEFAULT_TAIL_CAP_PCT   15
+#define FOLD_BUDGET_DEFAULT_PRESSURE_PCT   85
+#define FOLD_BUDGET_DEFAULT_SATURATION_PCT 50
+#define FOLD_BUDGET_DEFAULT_CLOSET_TOKENS  512
+
+   /* Resolve the fold budget for model_id. cfg may be NULL (all defaults).
+    * model_id may be NULL/empty (treated as an unknown model -> fallback window).
+    * Returns 0 on success, -1 if out is NULL. Deterministic: identical
+    * (model_id, cfg) always yields identical *out. */
+   int fold_budget_resolve(const char *model_id, const fold_budget_config_t *cfg,
+                           fold_budget_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_FOLD_BUDGET_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -210,6 +210,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-tdd \
                $(TESTPREFIX)/unit-test-compact \
                $(TESTPREFIX)/unit-test-coord-closet \
+               $(TESTPREFIX)/unit-test-fold-budget \
                $(TESTPREFIX)/unit-test-token-audit \
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
@@ -1970,6 +1971,11 @@ $(TESTPREFIX)/unit-test-compact: $(OBJDIR)/tests/test_compact.o $(OBJDIR)/compac
 
 $(TESTPREFIX)/unit-test-coord-closet: $(OBJDIR)/tests/test_coord_closet.o $(OBJDIR)/coord_closet.o \
                                   $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-fold-budget: $(OBJDIR)/tests/test_fold_budget.o $(OBJDIR)/fold_budget.o \
+                                  $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o \
+                                  $(OBJDIR)/models_dev_cache.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-compact-prune: $(OBJDIR)/tests/test_compact_prune.o \

--- a/src/tests/test_fold_budget.c
+++ b/src/tests/test_fold_budget.c
@@ -1,0 +1,118 @@
+/* test_fold_budget.c: unit tests for the per-model fold budget resolver (§7, P1.5). */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "../headers/fold_budget.h"
+#include "../headers/model_registry.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static void test_known_model_defaults(void)
+{
+   /* Derive the expected window from the registry so model-data churn does not
+    * break the resolver test; assert arithmetic-relative values. */
+   int w = model_context_window("claude-opus-4-8");
+   assert(w > 0);
+   fold_budget_t b;
+   assert(fold_budget_resolve("claude-opus-4-8", NULL, &b) == 0);
+   assert(b.is_known == 1);
+   assert(b.context_window_tokens == w);
+   assert(b.retained_band_tokens == w * 25 / 100);
+   assert(b.tail_cap_tokens == w * 15 / 100);
+   assert(b.pressure_ceiling_tokens == w * 85 / 100);
+   assert(b.prefix_saturation_tokens == w * 50 / 100);
+   assert(b.closet_budget_tokens == FOLD_BUDGET_DEFAULT_CLOSET_TOKENS);
+
+   fold_budget_t g;
+   int gw = model_context_window("gpt-4o");
+   assert(gw > 0);
+   assert(fold_budget_resolve("gpt-4o", NULL, &g) == 0);
+   assert(g.is_known == 1 && g.context_window_tokens == gw);
+   PASS("known_model_defaults");
+}
+
+static void test_unknown_model_fallback(void)
+{
+   fold_budget_t b;
+   /* unknown, no config -> built-in default window */
+   assert(fold_budget_resolve("totally-made-up-model-x", NULL, &b) == 0);
+   assert(b.is_known == 0);
+   assert(b.context_window_tokens == FOLD_BUDGET_DEFAULT_WINDOW);
+
+   /* unknown, config fallback window applies */
+   fold_budget_config_t cfg = {0};
+   cfg.context_window_tokens = 64000;
+   fold_budget_t c;
+   assert(fold_budget_resolve("totally-made-up-model-x", &cfg, &c) == 0);
+   assert(c.is_known == 0 && c.context_window_tokens == 64000);
+   assert(c.pressure_ceiling_tokens == 54400); /* 85% of 64000 */
+
+   /* NULL model_id is treated as unknown, still resolves */
+   fold_budget_t n;
+   assert(fold_budget_resolve(NULL, NULL, &n) == 0);
+   assert(n.is_known == 0 && n.context_window_tokens == FOLD_BUDGET_DEFAULT_WINDOW);
+   PASS("unknown_model_fallback");
+}
+
+static void test_overrides(void)
+{
+   fold_budget_config_t cfg = {0};
+   cfg.retained_band_pct = 10;
+   cfg.tail_cap_pct = 5;
+   cfg.closet_budget_tokens = 1000;
+   fold_budget_t b;
+   assert(fold_budget_resolve("claude-opus-4-8", &cfg, &b) == 0);
+   assert(b.retained_band_tokens == 20000); /* 10% of 200000 */
+   assert(b.tail_cap_tokens == 10000);      /* 5% */
+   assert(b.closet_budget_tokens == 1000);
+   /* unset knobs still take defaults */
+   assert(b.pressure_ceiling_tokens == 170000); /* 85% */
+   PASS("overrides");
+}
+
+static void test_determinism(void)
+{
+   fold_budget_config_t cfg = {.retained_band_pct = 30, .closet_budget_tokens = 777};
+   fold_budget_t a, b;
+   assert(fold_budget_resolve("gemini-1.5-pro", &cfg, &a) == 0);
+   assert(fold_budget_resolve("gemini-1.5-pro", &cfg, &b) == 0);
+   assert(memcmp(&a, &b, sizeof(a)) == 0); /* identical inputs -> identical output */
+   assert(a.context_window_tokens == 1000000);
+   PASS("determinism");
+}
+
+static void test_clamping(void)
+{
+   int w = model_context_window("claude-opus-4-8");
+   assert(w > 0);
+   /* pct > 100 clamps to the whole window (documented contract) */
+   fold_budget_config_t over = {.retained_band_pct = 150};
+   fold_budget_t b;
+   assert(fold_budget_resolve("claude-opus-4-8", &over, &b) == 0);
+   assert(b.retained_band_tokens == w);
+   /* closet budget larger than the window clamps to the window */
+   fold_budget_config_t big = {.closet_budget_tokens = w + 1000000};
+   fold_budget_t c;
+   assert(fold_budget_resolve("claude-opus-4-8", &big, &c) == 0);
+   assert(c.closet_budget_tokens == w);
+   PASS("clamping");
+}
+
+static void test_bad_args(void)
+{
+   assert(fold_budget_resolve("claude-opus-4-8", NULL, NULL) == -1);
+   PASS("bad_args");
+}
+
+int main(void)
+{
+   printf("fold_budget tests:\n");
+   test_known_model_defaults();
+   test_unknown_model_fallback();
+   test_overrides();
+   test_determinism();
+   test_clamping();
+   test_bad_args();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

Second slice of deterministic context folding (design PR #881; P1 = #886). Lands the §7 budget resolver and the pipeline-order spike — the prerequisite for P2.

- **`src/fold_budget.{c,h}`** — `fold_budget_resolve(model_id, cfg, out)`: a pure, deterministic function of `(model, config)` that resolves the fold knobs (context window, retained band, tail cap, pressure ceiling, prefix saturation, closet budget). Window from `model_context_window()`; unknown models fall back to a configured/default window (`known_model` flag records which). Percentages are window-relative, clamped.
- **`docs/dev/fold-pipeline-order.md`** — the spike that, before any P2 code, pins: the normative 5-stage delegate-path pipeline order and the exact `agent_runtime.c` seam; the single-owner `payload_rewrite` span registry (internal API, post-stage-4 byte capture, `(ptr,len)` lifetime) + the CI scan that enforces it; and the rationale for deferring the budget config knobs to P2 (consumed there) rather than landing inert config now.
- **`test_fold_budget`** — known/unknown models, overrides, determinism, bad args.

## Local gates
`make lint` · build (server+kb) · `make -j unit-tests` (full suite incl. new test) — all green.

## Review
C code roundtable in progress; I'll post the summary and fold in any blocking fixes before merge.

## Note
No runtime behavior change — the resolver has no caller until P2; default-off feature. Branches off `testing` (includes merged P1).