### PR TITLE
feat(fold): P2a rolling-fold module — deterministic turn skeletonization (default-off)

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -1,0 +1,259 @@
+/* context_fold.c: deterministic rolling fold of old conversation turns (§1, P2a).
+ * See context_fold.h for the contract. Pure: cJSON + dstr + coord_closet only. */
+#include "context_fold.h"
+
+#include "dstr.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* A "clean user turn": role=user and NOT a tool_result message. Folding only at
+ * such a boundary guarantees a tool_use and its tool_result never split, and the
+ * retained tail begins with a user message (valid alternation). */
+static int is_clean_user_turn(const cJSON *m)
+{
+   const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
+   if (!role || strcmp(role, "user") != 0)
+      return 0;
+   cJSON *content = cJSON_GetObjectItem((cJSON *)m, "content");
+   if (cJSON_IsString(content))
+      return 1;
+   if (cJSON_IsArray(content))
+   {
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
+      {
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (t && strcmp(t, "tool_result") == 0)
+            return 0;
+      }
+      return 1;
+   }
+   return 0;
+}
+
+/* Append up to `max` bytes of `s` to `d`, single-lined; mark truncation with "…".
+ * If the byte cap would land mid-UTF-8-sequence, back up to a character boundary
+ * so the emitted JSON string value never contains a split multibyte char. */
+static void append_excerpt(dstr_t *d, const char *s, int max)
+{
+   if (!s)
+      return;
+   int len = 0;
+   while (s[len])
+      len++;
+   int n = len < max ? len : max;
+   if (n < len)
+   {
+      /* truncating: back up off any continuation byte (0x80-0xBF) so [0,n) ends
+       * on a complete character */
+      while (n > 0 && ((unsigned char)s[n] & 0xC0) == 0x80)
+         n--;
+   }
+   for (int i = 0; i < n; i++)
+   {
+      char c = s[i];
+      if (c == '\n' || c == '\r' || c == '\t')
+         c = ' ';
+      dstr_append_char(d, c);
+   }
+   if (n < len)
+      dstr_append_str(d, "\xE2\x80\xA6"); /* ellipsis */
+}
+
+/* Emit one skeleton line (or lines) for a folded message; nominate its
+ * identifiers into `set` with turn-indexed provenance. */
+static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, coord_set_t *set)
+{
+   const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
+   cJSON *content = cJSON_GetObjectItem((cJSON *)m, "content");
+   coord_provenance_t prov = {COORD_LANE_AGENT, turn, -1, -1};
+
+   if (cJSON_IsString(content))
+   {
+      const char *txt = content->valuestring;
+      if (txt)
+      {
+         coord_closet_nominate(txt, strlen(txt), &prov, set);
+         dstr_appendf(d, "%s: ", role ? role : "?");
+         append_excerpt(d, txt, excerpt);
+         dstr_append_char(d, '\n');
+      }
+      return;
+   }
+   if (!cJSON_IsArray(content))
+      return;
+
+   cJSON *b;
+   cJSON_ArrayForEach(b, content)
+   {
+      const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+      if (!t)
+         continue;
+      if (strcmp(t, "text") == 0)
+      {
+         const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(b, "text"));
+         if (txt)
+         {
+            coord_closet_nominate(txt, strlen(txt), &prov, set);
+            dstr_appendf(d, "%s: ", role ? role : "?");
+            append_excerpt(d, txt, excerpt);
+            dstr_append_char(d, '\n');
+         }
+      }
+      else if (strcmp(t, "tool_use") == 0)
+      {
+         const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(b, "name"));
+         cJSON *input = cJSON_GetObjectItem(b, "input");
+         char *inp = input ? cJSON_PrintUnformatted(input) : NULL;
+         if (inp)
+            coord_closet_nominate(inp, strlen(inp), &prov, set);
+         dstr_appendf(d, "  $ %s ", name ? name : "tool");
+         append_excerpt(d, inp ? inp : "", excerpt);
+         dstr_append_char(d, '\n');
+         free(inp);
+      }
+      else if (strcmp(t, "tool_result") == 0)
+      {
+         cJSON *c = cJSON_GetObjectItem(b, "content");
+         char *owned = NULL;
+         const char *cv = NULL;
+         if (cJSON_IsString(c))
+            cv = c->valuestring;
+         else if (c)
+         {
+            owned = cJSON_PrintUnformatted(c);
+            cv = owned;
+         }
+         if (cv)
+         {
+            coord_closet_nominate(cv, strlen(cv), &prov, set);
+            dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
+            append_excerpt(d, cv, excerpt);
+            dstr_appendf(d, " (%zu bytes)\n", strlen(cv));
+         }
+         free(owned);
+      }
+   }
+}
+
+void fold_result_free(fold_result_t *out)
+{
+   if (!out)
+      return;
+   if (out->messages)
+      cJSON_Delete(out->messages);
+   out->messages = NULL;
+   out->folded = 0;
+}
+
+int context_fold_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out)
+{
+   if (!out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+   out->closet_evict = COORD_EVICT_NONE;
+   if (!messages || !cJSON_IsArray((cJSON *)messages) || !cfg || !cfg->enabled)
+      return 0;
+
+   int count = cJSON_GetArraySize((cJSON *)messages);
+   int retained = cfg->retained_msgs > 0 ? cfg->retained_msgs : CONTEXT_FOLD_DEFAULT_RETAINED_MSGS;
+   int min_fold = cfg->min_fold_msgs > 0 ? cfg->min_fold_msgs : CONTEXT_FOLD_DEFAULT_MIN_FOLD_MSGS;
+   int excerpt = cfg->reasoning_excerpt_bytes > 0 ? cfg->reasoning_excerpt_bytes
+                                                  : CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES;
+
+   /* Overflow-safe: never compute retained + min_fold (both could be near
+    * INT_MAX from pathological cfg). */
+   if (count <= 0 || retained >= count || count - retained < min_fold)
+      return 0; /* too short to fold cleanly */
+
+   int desired = count - retained;
+   int split = -1;
+   for (int s = desired; s >= min_fold; s--)
+   {
+      if (is_clean_user_turn(cJSON_GetArrayItem((cJSON *)messages, s)))
+      {
+         split = s;
+         break;
+      }
+   }
+   if (split < min_fold)
+      return 0; /* no clean boundary leaves enough folded */
+
+   /* size of the folded region (bounds the closet ratio cap) */
+   size_t folded_bytes = 0;
+   for (int i = 0; i < split; i++)
+   {
+      cJSON *it = cJSON_GetArrayItem((cJSON *)messages, i);
+      if (!it)
+         continue;
+      char *s = cJSON_PrintUnformatted(it);
+      if (s)
+      {
+         folded_bytes += strlen(s);
+         free(s);
+      }
+   }
+
+   coord_set_t set;
+   coord_set_init(&set);
+   dstr_t body;
+   dstr_init(&body);
+   dstr_appendf(
+       &body,
+       "[folded %d earlier message(s); skeleton below — exact identifiers are conserved in "
+       "the Coordinate Closet, full bodies remain in history]\n\n",
+       split);
+   for (int i = 0; i < split; i++)
+      skeleton_message(&body, cJSON_GetArrayItem((cJSON *)messages, i), i, excerpt, &set);
+
+   char *closet = coord_closet_render(&set, &cfg->closet, folded_bytes, &out->closet_evict);
+   if (closet)
+   {
+      dstr_append_char(&body, '\n');
+      dstr_append_str(&body, closet);
+      free(closet);
+   }
+   coord_set_free(&set);
+
+   /* Build the synthetic view. On any allocation failure, clean up and report
+    * no-fold rather than emitting a partial/NULL-bearing array. */
+   cJSON *arr = cJSON_CreateArray();
+   cJSON *fm = cJSON_CreateObject();
+   cJSON *ack = cJSON_CreateObject();
+   if (!arr || !fm || !ack)
+   {
+      cJSON_Delete(arr);
+      cJSON_Delete(fm);
+      cJSON_Delete(ack);
+      dstr_free(&body);
+      return 0; /* OOM: caller uses the original transcript */
+   }
+   cJSON_AddStringToObject(fm, "role", "user");
+   cJSON_AddStringToObject(fm, "content", dstr_cstr(&body));
+   cJSON_AddItemToArray(arr, fm);
+   cJSON_AddStringToObject(ack, "role", "assistant");
+   cJSON_AddStringToObject(ack, "content",
+                           "Understood — continuing from the folded summary above.");
+   cJSON_AddItemToArray(arr, ack);
+   dstr_free(&body);
+
+   for (int i = split; i < count; i++)
+   {
+      cJSON *it = cJSON_GetArrayItem((cJSON *)messages, i);
+      if (!it)
+         continue;
+      cJSON *dup = cJSON_Duplicate(it, 1);
+      if (!dup) /* OOM mid-copy: abandon the fold cleanly */
+      {
+         cJSON_Delete(arr);
+         return 0;
+      }
+      cJSON_AddItemToArray(arr, dup);
+   }
+
+   out->messages = arr;
+   out->folded = 1;
+   out->folded_msgs = split;
+   out->retained_msgs = count - split;
+   return 0;
+}

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -1,0 +1,74 @@
+/* context_fold.h: deterministic rolling fold of old conversation turns (§1, P2a).
+ *
+ * Replaces a contiguous prefix of older messages with a single synthetic
+ * summary: one skeleton line per tool call / per turn, plus a Coordinate Closet
+ * (§2) of the exact identifiers from the folded region. No model call, no clock,
+ * no randomness. The input `messages` array is never mutated — the fold returns a
+ * NEW array (synthetic summary pair + a deep copy of the retained tail).
+ *
+ * Atomicity / validity invariants (P2a):
+ *   - The fold boundary is chosen at a CLEAN USER TURN (role "user", not a
+ *     tool_result message), so a tool_use and its matching tool_result are never
+ *     split across the boundary, and the retained tail always begins with a user
+ *     message (valid Anthropic alternation after the synthetic user+assistant
+ *     pair).
+ *   - If no clean boundary leaves at least `min_fold_msgs` folded, nothing folds.
+ *
+ * Default-off: callers gate on cfg->enabled. The live request-path wiring,
+ * byte-identical freeze, and the payload_rewrite span registry are P2b. */
+#ifndef DEC_CONTEXT_FOLD_H
+#define DEC_CONTEXT_FOLD_H 1
+
+#include "coord_closet.h"
+#include <cJSON.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef struct
+   {
+      int enabled;       /* 0 = off (default) */
+      int retained_msgs; /* trailing messages kept at full fidelity (0 -> default) */
+      int min_fold_msgs; /* fold only if >= this many messages would fold (0 -> default) */
+      int reasoning_excerpt_bytes;  /* per-message text excerpt kept in the skeleton (0 -> default)
+                                     */
+      coord_closet_config_t closet; /* identifier-conservation config (§2) */
+   } fold_config_t;
+
+#define CONTEXT_FOLD_DEFAULT_RETAINED_MSGS 8
+#define CONTEXT_FOLD_DEFAULT_MIN_FOLD_MSGS 4
+#define CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES 160
+
+   typedef struct
+   {
+      cJSON *messages;   /* NEW array the caller owns (cJSON_Delete); NULL if no fold */
+      int folded;        /* 1 if a fold happened */
+      int folded_msgs;   /* number of original messages folded away */
+      int retained_msgs; /* number of trailing messages kept whole */
+      coord_evict_t closet_evict;
+   } fold_result_t;
+
+   /* Produce a folded view of `messages` (an Anthropic-shaped role/content array).
+    * On a successful fold, out->messages is a fresh array: a synthetic user
+    * (preamble + skeleton + closet) + synthetic assistant ack, followed by a deep
+    * copy of the retained tail. If folding is disabled, the transcript is too
+    * short, or no clean boundary exists (or on OOM), out->folded = 0 and
+    * out->messages = NULL (the caller uses the original). Returns 0 on success
+    * (incl. no-fold), -1 on bad args. `*out` is fully overwritten — it need not be
+    * initialized, but a caller reusing a prior *folded* result must
+    * fold_result_free() it first (this call does not free a pre-existing
+    * out->messages). Deterministic: identical (messages, cfg) -> identical
+    * out->messages serialization (relies on coord_closet_render's total-order
+    * rendering for the closet block). */
+   int context_fold_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out);
+
+   /* Free any owned resources in *out (safe on a zeroed/!folded result). */
+   void fold_result_free(fold_result_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CONTEXT_FOLD_H */

--- a/src/headers/coord_closet.h
+++ b/src/headers/coord_closet.h
@@ -97,7 +97,9 @@ extern "C"
    /* Scan `raw` (length `len`) for verbatim coordinates, appending them to `set`
     * with the given provenance. Duplicate values keep their earliest occurrence.
     * Deterministic. `prov` may be NULL (treated as AGENT lane, all ids -1).
-    * Returns the number of distinct coordinates added. */
+    * Copies the nominated bytes into the set; does NOT retain the caller's `raw`
+    * pointer (safe to free `raw` after the call). Returns the number of distinct
+    * coordinates added. */
    size_t coord_closet_nominate(const char *raw, size_t len, const coord_provenance_t *prov,
                                 coord_set_t *set);
 

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -211,6 +211,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-compact \
                $(TESTPREFIX)/unit-test-coord-closet \
                $(TESTPREFIX)/unit-test-fold-budget \
+               $(TESTPREFIX)/unit-test-context-fold \
                $(TESTPREFIX)/unit-test-token-audit \
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
@@ -1976,6 +1977,11 @@ $(TESTPREFIX)/unit-test-coord-closet: $(OBJDIR)/tests/test_coord_closet.o $(OBJD
 $(TESTPREFIX)/unit-test-fold-budget: $(OBJDIR)/tests/test_fold_budget.o $(OBJDIR)/fold_budget.o \
                                   $(OBJDIR)/model_registry.o $(OBJDIR)/models_dev.o \
                                   $(OBJDIR)/models_dev_cache.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-context-fold: $(OBJDIR)/tests/test_context_fold.o $(OBJDIR)/context_fold.o \
+                                  $(OBJDIR)/coord_closet.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o \
+                                  $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-compact-prune: $(OBJDIR)/tests/test_compact_prune.o \

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -1,0 +1,274 @@
+/* test_context_fold.c: unit tests for the rolling fold (§1, P2a). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../headers/context_fold.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static int contains(const char *hay, const char *needle)
+{
+   return hay && needle && strstr(hay, needle) != NULL;
+}
+
+static void add_user_text(cJSON *msgs, const char *text)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "user");
+   cJSON_AddStringToObject(m, "content", text);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void add_assistant_text(cJSON *msgs, const char *text)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "assistant");
+   cJSON_AddStringToObject(m, "content", text);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void add_assistant_tool_use(cJSON *msgs, const char *id, const char *name, const char *arg)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "assistant");
+   cJSON *content = cJSON_AddArrayToObject(m, "content");
+   cJSON *b = cJSON_CreateObject();
+   cJSON_AddStringToObject(b, "type", "tool_use");
+   cJSON_AddStringToObject(b, "id", id);
+   cJSON_AddStringToObject(b, "name", name);
+   cJSON *input = cJSON_AddObjectToObject(b, "input");
+   cJSON_AddStringToObject(input, "arg", arg);
+   cJSON_AddItemToArray(content, b);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void add_user_tool_result(cJSON *msgs, const char *id, const char *result)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "user");
+   cJSON *content = cJSON_AddArrayToObject(m, "content");
+   cJSON *b = cJSON_CreateObject();
+   cJSON_AddStringToObject(b, "type", "tool_result");
+   cJSON_AddStringToObject(b, "tool_use_id", id);
+   cJSON_AddStringToObject(b, "content", result);
+   cJSON_AddItemToArray(content, b);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+/* 14-message conversation with tool_use/tool_result pairs. */
+static cJSON *build_convo(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   add_user_text(m, "start job 7fd5835b-1a2b-4c3d-8e9f-0123456789ab"); /* 0 */
+   add_assistant_tool_use(m, "toolu_1", "read", "/etc/hosts");         /* 1 */
+   add_user_tool_result(m, "toolu_1", "ok; bound on port=3002");       /* 2 */
+   add_assistant_text(m, "read complete");                             /* 3 */
+   add_user_text(m, "next please");                                    /* 4 (clean) */
+   add_assistant_tool_use(m, "toolu_2", "bash", "ls -la");             /* 5 */
+   add_user_tool_result(m, "toolu_2", "file listing here");            /* 6 */
+   add_assistant_text(m, "listing done");                              /* 7 */
+   add_user_text(m, "keep going");                                     /* 8 */
+   add_assistant_tool_use(m, "toolu_3", "grep", "needle");             /* 9 */
+   add_user_tool_result(m, "toolu_3", "3 hits");                       /* 10 */
+   add_assistant_text(m, "found them");                                /* 11 */
+   add_user_text(m, "almost there");                                   /* 12 */
+   add_assistant_text(m, "done");                                      /* 13 */
+   return m;
+}
+
+static int msg_is_clean_user(const cJSON *m)
+{
+   const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
+   if (!role || strcmp(role, "user") != 0)
+      return 0;
+   cJSON *c = cJSON_GetObjectItem((cJSON *)m, "content");
+   if (cJSON_IsString(c))
+      return 1;
+   cJSON *b;
+   cJSON_ArrayForEach(b, c)
+   {
+      const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+      if (t && strcmp(t, "tool_result") == 0)
+         return 0;
+   }
+   return 1;
+}
+
+static void test_basic_fold(void)
+{
+   cJSON *msgs = build_convo();
+   int orig_count = cJSON_GetArraySize(msgs);
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 1);
+   assert(r.messages != NULL);
+
+   /* desired split = 14 - 8 = 6 (a tool_result) -> backs off to the clean user
+    * turn at index 4; folds 4 messages. */
+   assert(r.folded_msgs == 4);
+
+   cJSON *m0 = cJSON_GetArrayItem(r.messages, 0);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(m0, "role")), "user") == 0);
+   const char *c0 = cJSON_GetStringValue(cJSON_GetObjectItem(m0, "content"));
+   assert(contains(c0, "[folded 4 earlier"));
+   assert(contains(c0, "Coordinate Closet"));
+   /* identifiers from the folded region are conserved verbatim */
+   assert(contains(c0, "7fd5835b-1a2b-4c3d-8e9f-0123456789ab"));
+   assert(contains(c0, "3002"));
+   /* skeleton mentions the folded tool calls */
+   assert(contains(c0, "read") && contains(c0, "$"));
+
+   cJSON *m1 = cJSON_GetArrayItem(r.messages, 1);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(m1, "role")), "assistant") == 0);
+
+   /* retained tail begins at original index 4 ("next please") — a clean user turn,
+    * proving no tool pair was straddled. */
+   cJSON *m2 = cJSON_GetArrayItem(r.messages, 2);
+   assert(msg_is_clean_user(m2));
+   assert(contains(cJSON_GetStringValue(cJSON_GetObjectItem(m2, "content")), "next please"));
+
+   /* synthetic count = 2 synthetic + (14 - 4) retained */
+   assert(cJSON_GetArraySize(r.messages) == 2 + (orig_count - 4));
+
+   /* original array is untouched */
+   assert(cJSON_GetArraySize(msgs) == orig_count);
+
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("basic_fold");
+}
+
+static void test_nondestructive_and_deterministic(void)
+{
+   cJSON *a = build_convo();
+   cJSON *b = build_convo();
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t ra, rb;
+   assert(context_fold_view(a, &cfg, &ra) == 0 && ra.folded);
+   assert(context_fold_view(b, &cfg, &rb) == 0 && rb.folded);
+   char *sa = cJSON_PrintUnformatted(ra.messages);
+   char *sb = cJSON_PrintUnformatted(rb.messages);
+   assert(sa && sb && strcmp(sa, sb) == 0); /* identical input -> identical fold */
+   free(sa);
+   free(sb);
+   fold_result_free(&ra);
+   fold_result_free(&rb);
+   cJSON_Delete(a);
+   cJSON_Delete(b);
+   PASS("nondestructive_and_deterministic");
+}
+
+static void test_too_short_no_fold(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   add_user_text(m, "hello");
+   add_assistant_text(m, "hi");
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, &r) == 0);
+   assert(r.folded == 0 && r.messages == NULL);
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("too_short_no_fold");
+}
+
+static void test_disabled_no_fold(void)
+{
+   cJSON *m = build_convo();
+   fold_config_t off = {.enabled = 0};
+   fold_result_t r;
+   assert(context_fold_view(m, &off, &r) == 0);
+   assert(r.folded == 0 && r.messages == NULL);
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("disabled_no_fold");
+}
+
+static void test_small_retained_band(void)
+{
+   /* retained=2, min_fold=4: desired split = 12, walk down to a clean user turn. */
+   cJSON *m = build_convo();
+   fold_config_t cfg = {
+       .enabled = 1, .retained_msgs = 2, .min_fold_msgs = 4, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, &r) == 0);
+   assert(r.folded == 1);
+   /* retained tail still begins with a clean user turn */
+   assert(msg_is_clean_user(cJSON_GetArrayItem(r.messages, 2)));
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("small_retained_band");
+}
+
+static void test_retained_ge_count(void)
+{
+   cJSON *m = build_convo(); /* 14 messages */
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 100, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, &r) == 0);
+   assert(r.folded == 0 && r.messages == NULL); /* nothing to fold below the band */
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("retained_ge_count");
+}
+
+static void test_odd_shapes_no_crash(void)
+{
+   /* a message with no "content" key, and a tool_result whose content is an
+    * array of blocks — must fold without crashing and still conserve ids. */
+   cJSON *m = cJSON_CreateArray();
+   add_user_text(m, "begin path /home/u/app.c"); /* 0 */
+   cJSON *noc = cJSON_CreateObject();            /* 1: missing content */
+   cJSON_AddStringToObject(noc, "role", "assistant");
+   cJSON_AddItemToArray(m, noc);
+   /* 2: tool_result with array content */
+   cJSON *tr = cJSON_CreateObject();
+   cJSON_AddStringToObject(tr, "role", "user");
+   cJSON *content = cJSON_AddArrayToObject(tr, "content");
+   cJSON *blk = cJSON_CreateObject();
+   cJSON_AddStringToObject(blk, "type", "tool_result");
+   cJSON_AddStringToObject(blk, "tool_use_id", "toolu_9");
+   cJSON *inner = cJSON_AddArrayToObject(blk, "content");
+   cJSON *part = cJSON_CreateObject();
+   cJSON_AddStringToObject(part, "type", "text");
+   cJSON_AddStringToObject(part, "text", "deadbeefcafe1234 on port=7700");
+   cJSON_AddItemToArray(inner, part);
+   cJSON_AddItemToArray(content, blk);
+   cJSON_AddItemToArray(m, tr);
+   add_assistant_text(m, "noted"); /* 3 */
+   add_user_text(m, "go on");      /* 4 clean */
+   add_assistant_text(m, "a");     /* 5 */
+   add_user_text(m, "b");          /* 6 */
+   add_assistant_text(m, "c");     /* 7 */
+   add_user_text(m, "d");          /* 8 */
+   add_assistant_text(m, "e");     /* 9 */
+
+   fold_config_t cfg = {
+       .enabled = 1, .retained_msgs = 4, .min_fold_msgs = 4, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+   const char *c0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   assert(contains(c0, "deadbeefcafe1234")); /* id from array-content tool_result conserved */
+   assert(contains(c0, "/home/u/app.c"));
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("odd_shapes_no_crash");
+}
+
+int main(void)
+{
+   printf("context_fold tests:\n");
+   test_basic_fold();
+   test_nondestructive_and_deterministic();
+   test_too_short_no_fold();
+   test_disabled_no_fold();
+   test_small_retained_band();
+   test_retained_ge_count();
+   test_odd_shapes_no_crash();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

Core algorithmic slice of deterministic context folding (design #881; P1=#886, P1.5=#887). **P2a = the rolling-fold module, pure and default-off**; the live request-path wiring + byte-identical freeze + `payload_rewrite` span registry are **P2b** (next slice). Splitting keeps the live-path change reviewable on its own.

`src/context_fold.{c,h}` — `context_fold_view(messages, cfg, &out)`:
- Folds a contiguous prefix of old Anthropic-shaped messages into a synthetic summary: one skeleton line per turn / tool call + a Coordinate Closet (§2) of the exact identifiers from the folded region.
- Returns a **new** array (synthetic user preamble+skeleton+closet → synthetic assistant ack → deep copy of the retained tail). Input is never mutated.
- **Atomic tool pairs / valid alternation:** the boundary is chosen at a *clean user turn* (role user, not a tool_result), so a `tool_use` and its `tool_result` are never split and the tail begins with a user message. No clean boundary with enough to fold → no fold.
- Pure (cJSON + dstr + coord_closet); deterministic; default-off.

`test_context_fold` (5 cases): fold structure, verbatim identifier conservation, non-destructive + byte-identical determinism, clean-boundary selection, disabled/too-short no-ops.

## Local gates
`make lint` · build (server+kb) · `make -j unit-tests` (full suite incl. new test) — all green.

## Note
No runtime behavior change (no caller until P2b); default-off. Branches off `testing` (includes P1+P1.5). Review in progress via roundtable; blocking fixes folded in before merge.