### PR TITLE
feat(webchat-git): open-PR op (gh pr create) for git projects

### DIFF
--- a/frontend/src/pages/Projects.tsx
+++ b/frontend/src/pages/Projects.tsx
@@ -40,6 +40,7 @@ export default function Projects() {
   const [name, setName] = useState('');
   const [token, setToken] = useState('');
   const [commitMsg, setCommitMsg] = useState('');
+  const [prTitle, setPrTitle] = useState('');
   const [branch, setBranch] = useState('');
   const [hosts, setHosts] = useState<string[]>([]);
   const [credHost, setCredHost] = useState('');
@@ -188,8 +189,8 @@ export default function Projects() {
     } finally { setBusy(false); }
   }
 
-  async function runOp(op: string, extra?: Record<string, unknown>) {
-    if (!selected) return;
+  async function runOp(op: string, extra?: Record<string, unknown>): Promise<boolean> {
+    if (!selected) return false;
     setBusy(true); setErr(''); setOutput('');
     try {
       // When operating on the active session's project, act on that session's
@@ -200,9 +201,10 @@ export default function Projects() {
         body: JSON.stringify({ project: selected, op, session_id, ...extra }),
       });
       const d = await r.json();
-      if (!r.ok) { setErr(d.error || `${op} failed`); }
-      else { setOutput(d.output || `(${op}: ok)`); }
-    } finally { setBusy(false); }
+      if (!r.ok) { setErr(d.error || `${op} failed`); return false; }
+      setOutput(d.output || `(${op}: ok)`);
+      return true;
+    } catch { return false; } finally { setBusy(false); }
   }
 
   return (
@@ -330,6 +332,14 @@ export default function Projects() {
                   value={branch} onChange={e => setBranch(e.target.value)} />
                 <button style={btn} disabled={busy || !branch.trim()}
                   onClick={() => runOp('checkout', { branch })}>checkout</button>
+              </div>
+              <div style={{ display: 'flex', gap: '6px', flexWrap: 'wrap', alignItems: 'center' }}>
+                <input style={{ ...input, flex: 1, minWidth: '180px' }}
+                  placeholder="PR title (optional — empty fills from commits)"
+                  value={prTitle} onChange={e => setPrTitle(e.target.value)} />
+                <button style={{ ...btn, borderColor: '#7a7' }} disabled={busy}
+                  title="Open a GitHub pull request for the pushed branch"
+                  onClick={async () => { if (await runOp('pr', { message: prTitle })) setPrTitle(''); }}>open PR</button>
               </div>
             </div>
           )}

--- a/src/headers/git_ops.h
+++ b/src/headers/git_ops.h
@@ -8,7 +8,8 @@
  * exist, no cross-tenant escape), the op is checked against a fixed allowlist,
  * arguments are validated (no shell — argv only), and remote ops get the user's
  * vaulted git credentials injected (WP-C). Read ops: status, log, diff, branch.
- * Write/remote ops: fetch, pull, commit, push, checkout. */
+ * Write/remote ops: fetch, pull, commit, push, checkout. Forge ops: pr (open a
+ * pull request for the current branch via gh; GitHub remotes). */
 
 /* Run `op` on `principal`'s `project`. `text_arg` carries the commit message
  * (op="commit") or target branch (op="checkout"); `num_arg` the log entry count

--- a/src/server/git_ops.c
+++ b/src/server/git_ops.c
@@ -241,6 +241,47 @@ int git_ops_run_session(const char *principal, const char *project, const char *
       argv[1] = "checkout";
       argv[2] = text_arg;
    }
+   else if (strcmp(op, "pr") == 0)
+   {
+      /* Open a PR for the current branch via gh (GitHub remotes). With a title
+       * (text_arg) create it explicitly with an empty body the user edits on the
+       * forge; without one, --fill the title+body from the branch's commits. gh
+       * authenticates with the injected GH_TOKEN; base defaults to the repo's
+       * default branch, head to the current branch. The title is passed as a
+       * single argv token (no shell, no flag injection) but must be one line.
+       * Unlike the agent's handle_git_pr, there is no branch-ownership/verify
+       * gate: this is the webuser acting on their OWN connected repo, already
+       * confined by the principal-scoped project resolution (ws_scope, above),
+       * the route caps, and AIMEE_WEBCHAT_GIT. A non-GitHub origin surfaces gh's
+       * own error (stderr is captured) rather than a pre-flight host check. */
+      argv[0] = "gh";
+      argv[1] = "pr";
+      argv[2] = "create";
+      if (text_arg && text_arg[0])
+      {
+         size_t tn = strlen(text_arg);
+         if (tn > 256)
+         {
+            snprintf(err, errlen, "pr title too long");
+            return -1;
+         }
+         for (size_t i = 0; i < tn; i++)
+            if ((unsigned char)text_arg[i] < 0x20)
+            {
+               snprintf(err, errlen, "invalid pr title");
+               return -1;
+            }
+         argv[3] = "--title";
+         argv[4] = text_arg;
+         argv[5] = "--body";
+         argv[6] = "";
+      }
+      else
+      {
+         argv[3] = "--fill";
+      }
+      needs_cred = 1;
+   }
    else
    {
       snprintf(err, errlen, "unsupported op");

--- a/src/server/server_http_routes.inc
+++ b/src/server/server_http_routes.inc
@@ -1278,9 +1278,10 @@ static int rh_workspace_git(const route_req_t *rq, char *resp, int cap)
    /* Optional: run in the calling session's isolated worktree (same tree its
     * agent edits) rather than the shared project checkout. */
    const char *session_id = (cJSON_IsString(jsid) && jsid->valuestring) ? jsid->valuestring : NULL;
-   /* text_arg is the commit message (commit) or target branch (checkout). */
+   /* text_arg is the commit message (commit), target branch (checkout), or the
+    * PR title (pr; optional — empty → gh --fill from the branch's commits). */
    const char *text = NULL;
-   if (op && strcmp(op, "commit") == 0)
+   if (op && (strcmp(op, "commit") == 0 || strcmp(op, "pr") == 0))
       text = (cJSON_IsString(jmsg) && jmsg->valuestring) ? jmsg->valuestring : NULL;
    else if (op && strcmp(op, "checkout") == 0)
       text = (cJSON_IsString(jbranch) && jbranch->valuestring) ? jbranch->valuestring : NULL;


### PR DESCRIPTION
Closes deferred follow-up **#2**: webchat git projects could clone/commit/push but not **open a PR**.

## Change
- **`git_ops.c`** — new **`pr`** op runs `gh pr create` (argv, no shell) in the user's project checkout with the vaulted forge token injected (`needs_cred=1` → `GH_TOKEN`). With a title it creates explicitly (`--title <t> --body ""`); without one it `--fill`s title+body from the branch's commits. Title is a single argv token (no shell/flag injection) bounded to one line ≤256 chars. GitHub remotes (`gh`).
- **server** — maps the PR title from the op's `message` field to `text_arg`.
- **`Projects.tsx`** — an "open PR" control (optional title) in the per-project action row.

## Validation
The `gh` mechanic was validated **end-to-end against this real GitHub remote**: `gh pr create --fill` with the injected token opened a live PR (#892, then closed + branch deleted) — confirming the exact invocation the op builds. C/Go build clean; frontend `tsc` clean; clang-format clean.

Note: this intentionally bypasses `handle_git_pr`'s agent-oriented guardrails (branch-ownership / verify gate) — those gate the autonomous agent's commits; a webuser opening a PR on their own connected repo is the webchat surface, gated by the per-route caps + `AIMEE_WEBCHAT_GIT`.

Roundtable code-review run on the diff; summary posted as a comment.