### PR TITLE
feat(fold): P2b wire rolling fold into the delegate request path (default-off)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -157,7 +157,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 
 > **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `wfe_live_forge_enabled`
 
-## Config-file sections (49)
+## Config-file sections (50)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
@@ -176,6 +176,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`dedup`** — _Response deduplication._ Keys: `enabled`, `window_seconds`
 - **`dogfood`** — _Session capture for dogfood data._ Keys: `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
 - **`ensemble`** — _Roundtable ensemble panel + aggregator._ Keys: `aggregator`, `max_cost_usd`, `min_successful`, `reference_models`, `reference_personas`
+- **`fold`** — `enabled`, `excerpt_bytes`, `min_fold_msgs`, `retained_msgs`
 - **`guardrails`** — _Semantic guardrail policy._ Keys: `blast_radius`, `semantic`
 - **`identity`** — _Working-profile identity injection._ Keys: `working_profile_injection`
 - **`ingress`** — _Ingress (proxy frontends) behavior._ Keys: `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`

--- a/src/config.c
+++ b/src/config.c
@@ -423,6 +423,10 @@ static void config_set_defaults(config_t *cfg)
    cfg->coord_closet_enabled = 0; /* fold §2: default-off */
    cfg->coord_closet_budget_bytes = 0;
    cfg->coord_closet_max_ratio_pct = 0;
+   cfg->fold_enabled = 0; /* fold §1: default-off */
+   cfg->fold_retained_msgs = 0;
+   cfg->fold_min_fold_msgs = 0;
+   cfg->fold_excerpt_bytes = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;
@@ -1004,6 +1008,7 @@ int config_load(config_t *cfg)
    config_parse_memory_maintenance_section(cfg, root);
 
    config_parse_worktree_gc_section(cfg, root);
+   config_parse_fold_section(cfg, root);
 
    config_parse_memory_section(cfg, root);
    config_apply_learning_settings(cfg, root);

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -950,6 +950,20 @@ int config_save(const config_t *cfg)
       }
    }
 
+   /* Rolling context fold (fold §1, only save if non-default) */
+   if (cfg->fold_enabled || cfg->fold_retained_msgs || cfg->fold_min_fold_msgs ||
+       cfg->fold_excerpt_bytes)
+   {
+      cJSON *fold = cJSON_AddObjectToObject(root, "fold");
+      cJSON_AddBoolToObject(fold, "enabled", cfg->fold_enabled);
+      if (cfg->fold_retained_msgs)
+         cJSON_AddNumberToObject(fold, "retained_msgs", cfg->fold_retained_msgs);
+      if (cfg->fold_min_fold_msgs)
+         cJSON_AddNumberToObject(fold, "min_fold_msgs", cfg->fold_min_fold_msgs);
+      if (cfg->fold_excerpt_bytes)
+         cJSON_AddNumberToObject(fold, "excerpt_bytes", cfg->fold_excerpt_bytes);
+   }
+
    /* Session/worktree cleanup policy (only save if non-default) */
    if (cfg->worktree_stale_secs || cfg->max_sessions || cfg->max_worktrees)
    {

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -690,6 +690,26 @@ void config_parse_compact_section(config_t *cfg, cJSON *root)
       }
    }
 }
+
+void config_parse_fold_section(config_t *cfg, cJSON *root)
+{
+   cJSON *fold = cJSON_GetObjectItemCaseSensitive(root, "fold");
+   if (!cJSON_IsObject(fold))
+      return;
+   cJSON *item = cJSON_GetObjectItemCaseSensitive(fold, "enabled");
+   if (cJSON_IsBool(item))
+      cfg->fold_enabled = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(fold, "retained_msgs");
+   if (cJSON_IsNumber(item) && item->valuedouble > 0)
+      cfg->fold_retained_msgs = (int)item->valuedouble;
+   item = cJSON_GetObjectItemCaseSensitive(fold, "min_fold_msgs");
+   if (cJSON_IsNumber(item) && item->valuedouble > 0)
+      cfg->fold_min_fold_msgs = (int)item->valuedouble;
+   item = cJSON_GetObjectItemCaseSensitive(fold, "excerpt_bytes");
+   if (cJSON_IsNumber(item) && item->valuedouble > 0)
+      cfg->fold_excerpt_bytes = (int)item->valuedouble;
+}
+
 void config_parse_sessions_section(config_t *cfg, cJSON *root)
 {
    cJSON *item = NULL;

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -870,6 +870,17 @@ typedef struct config
    int coord_closet_max_ratio_pct;
    char coord_closet_denylist[256];
 
+   /* Rolling context fold (fold §1, P2b). Folds a prefix of old turns into a
+    * skeleton + Coordinate Closet on the delegate request path. Default-off.
+    * The fold's closet reuses the coord_closet_* settings above (one policy).
+    * fold_enabled: 0 = off (default), 1 = on.
+    * fold_retained_msgs / fold_min_fold_msgs / fold_excerpt_bytes: 0 = module
+    *   defaults (see context_fold.h). */
+   int fold_enabled;
+   int fold_retained_msgs;
+   int fold_min_fold_msgs;
+   int fold_excerpt_bytes;
+
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned
     *   (0 = use default: 14400 = 4 hours).

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -20,6 +20,7 @@ void config_parse_memory_window_section(config_t *cfg, cJSON *root);
 void config_parse_kb_section(config_t *cfg, cJSON *root);
 void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
 void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
+void config_parse_fold_section(config_t *cfg, cJSON *root);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);
 void config_parse_retry_section(config_t *cfg, cJSON *root);

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -61,10 +61,14 @@ extern "C"
     * fold_result_free() it first (this call does not free a pre-existing
     * out->messages). Deterministic: identical (messages, cfg) -> identical
     * out->messages serialization (relies on coord_closet_render's total-order
-    * rendering for the closet block). */
+    * rendering for the closet block). cfg->closet.denylist (if set) is BORROWED
+    * only for the duration of this call (consumed while rendering the closet); it
+    * is never retained in *out, so the caller may free it once this returns. */
    int context_fold_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out);
 
-   /* Free any owned resources in *out (safe on a zeroed/!folded result). */
+   /* Free any owned resources in *out. NULL-safe on a zeroed result and on a
+    * no-fold result (out->messages == NULL), so callers may invoke it
+    * unconditionally after any build path. */
    void fold_result_free(fold_result_t *out);
 
 #ifdef __cplusplus

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -25,6 +25,7 @@
 #include "liveness.h"
 #include "provider_cli_adapter.h"
 #include "config.h"
+#include "context_fold.h"
 #include "cJSON.h"
 #include <ctype.h>
 #include <fcntl.h>
@@ -209,6 +210,32 @@ static void maybe_compact_before_request(const agent_t *agent, cJSON *messages,
       message_history_repair(messages);
       messages_compact_consecutive(messages);
    }
+}
+
+/* Fold §1 (P2b): build a rolling-fold view of the Anthropic message array if the
+ * fold is enabled. Populates *out (zeroed on no-fold). The fold's Coordinate
+ * Closet is rendered during this call, so the config's denylist (a pointer into
+ * the local config_t) only needs to be valid here — out holds owned cJSON that
+ * the caller frees with fold_result_free AFTER the request is serialized.
+ * Returns 1 if a fold view was produced, 0 otherwise. */
+static int build_fold_view(const cJSON *messages, fold_result_t *out)
+{
+   memset(out, 0, sizeof(*out));
+   config_t cfg;
+   if (config_load(&cfg) != 0 || !cfg.fold_enabled)
+      return 0;
+   fold_config_t fc;
+   memset(&fc, 0, sizeof(fc));
+   fc.enabled = 1;
+   fc.retained_msgs = cfg.fold_retained_msgs;
+   fc.min_fold_msgs = cfg.fold_min_fold_msgs;
+   fc.reasoning_excerpt_bytes = cfg.fold_excerpt_bytes;
+   fc.closet.enabled = cfg.coord_closet_enabled;
+   fc.closet.budget_bytes = cfg.coord_closet_budget_bytes;
+   fc.closet.max_ratio_pct = cfg.coord_closet_max_ratio_pct;
+   fc.closet.denylist = cfg.coord_closet_denylist[0] ? cfg.coord_closet_denylist : NULL;
+   context_fold_view(messages, &fc, out);
+   return out->folded;
 }
 
 static void track_anthropic_payload_rewrite(const delegate_driver_t *driver, const agent_t *agent,
@@ -691,12 +718,18 @@ native_provider_http:
 
       /* Build request (use fb_agent which may have fallback model after turn 0) */
       cJSON *req;
+      fold_result_t fold_view; /* §1 rolling fold; freed after req is serialized */
+      memset(&fold_view, 0, sizeof(fold_view));
       if (chatgpt)
          req = agent_build_request_responses(&fb_agent, messages, active_tools, sys);
       else if (anthropic)
       {
-         track_anthropic_payload_rewrite(driver, &fb_agent, messages, sys);
-         req = agent_build_request_anthropic(&fb_agent, messages, active_tools, sys, tok,
+         /* Fold first so payload-rewrite tracking and the request both observe the
+          * actually-sent (possibly folded) message array. */
+         build_fold_view(messages, &fold_view);
+         cJSON *anth_msgs = fold_view.folded ? fold_view.messages : messages;
+         track_anthropic_payload_rewrite(driver, &fb_agent, anth_msgs, sys);
+         req = agent_build_request_anthropic(&fb_agent, anth_msgs, active_tools, sys, tok,
                                              temperature);
       }
       else if (gemini)
@@ -716,11 +749,16 @@ native_provider_http:
       {
          snprintf(out->error, sizeof(out->error), "gateway request pipeline failed");
          cJSON_Delete(req);
+         fold_result_free(&fold_view);
          break;
       }
 
       char *body = cJSON_PrintUnformatted(req);
+      /* Order matters: req may hold a non-owning reference into fold_view.messages
+       * (agent_build_request_anthropic's AddItemReference fallback), so req must be
+       * deleted before the fold view is freed. */
       cJSON_Delete(req);
+      fold_result_free(&fold_view);
       if (!body)
       {
          snprintf(out->error, sizeof(out->error), "failed to build request");
@@ -785,12 +823,16 @@ native_provider_http:
          snprintf(out->served_model, MAX_MODEL_LEN, "%s", fb_agent.model);
 
          cJSON *fb_req;
+         fold_result_t fb_fold_view; /* §1 rolling fold; freed after fb_req serialized */
+         memset(&fb_fold_view, 0, sizeof(fb_fold_view));
          if (chatgpt)
             fb_req = agent_build_request_responses(&fb_agent, messages, active_tools, sys);
          else if (anthropic)
          {
-            track_anthropic_payload_rewrite(driver, &fb_agent, messages, sys);
-            fb_req = agent_build_request_anthropic(&fb_agent, messages, active_tools, sys, tok,
+            build_fold_view(messages, &fb_fold_view);
+            cJSON *fb_anth_msgs = fb_fold_view.folded ? fb_fold_view.messages : messages;
+            track_anthropic_payload_rewrite(driver, &fb_agent, fb_anth_msgs, sys);
+            fb_req = agent_build_request_anthropic(&fb_agent, fb_anth_msgs, active_tools, sys, tok,
                                                    temperature);
          }
          else if (gemini)
@@ -800,7 +842,9 @@ native_provider_http:
             fb_req =
                 agent_build_request_openai(&fb_agent, messages, active_tools, tok, temperature);
          char *fb_body = cJSON_PrintUnformatted(fb_req);
+         /* delete fb_req before freeing the fold view (req may reference it) */
          cJSON_Delete(fb_req);
+         fold_result_free(&fb_fold_view);
          if (fb_body)
          {
             {

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -17,7 +17,7 @@ TEST_RUN_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/n
 TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o $(OBJDIR)/config_fields.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
-                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
+                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \


### PR DESCRIPTION
## Summary

Wires the P2a rolling-fold module into the live Anthropic delegate request path — the value-delivery step (token reduction). Default-off.

- `posix/agent_runtime.c`: at **both** Anthropic build sites (primary + fallback rebuild), build a folded view of the message array and build the request from it when `fold.enabled`. The view is freed **only after the request is serialized** — `agent_build_request_anthropic` can keep a *reference* to the messages (fallback path), so the view must outlive `req`; frees are placed on every post-build path including the gateway-pipeline-failure break. Non-Anthropic providers are untouched (the fold is Anthropic-shaped).
- `build_fold_view()` maps config → `fold_config_t` and renders the closet **within the local config's lifetime** (the `denylist` pointer never escapes).
- New **`fold`** config section (default-off): `fold.{enabled,retained_msgs,min_fold_msgs,excerpt_bytes}`; the fold's Coordinate Closet reuses the existing `compact.coord_closet.*` policy (one closet policy). Docs regenerated.

## Scope / honesty
Delivers token reduction. The byte-identical **fold-freeze + `payload_rewrite` span registry (§3)** — which keeps the folded prefix cache-stable across turns — is **P2c**; without it, folding reduces tokens but can move the cache boundary, so this stays default-off until P2c lands. (Documented in `docs/dev/fold-pipeline-order.md`.)

## Local gates
`make lint` · server+kb build · `make -j unit-tests` (full suite) — all green. When `fold.enabled=0` (default) `build_fold_view` returns immediately → behavior byte-identical to before.

## Note
Live end-to-end token/cache validation (plan §E, pve testbed) is best run once P2c lands; gated default-off until then. Review via roundtable in progress.