### PR TITLE
feat(webchat-git): git HTTPS token via inherited memfd, not /proc/environ (#3A)

### DIFF
--- a/src/forge_credentials.c
+++ b/src/forge_credentials.c
@@ -357,10 +357,23 @@ const char *forge_cred_askpass_shim(void)
       path[0] = '\0';
       return NULL;
    }
+   /* Password source, in order: a token delivered over an inherited file
+    * descriptor (AIMEE_GIT_TOKEN_FD — re-readable via /proc/self/fd, so the
+    * secret never enters this process's environment or /proc/<pid>/environ),
+    * else the legacy GH_TOKEN env var (still used by the long-lived editor path
+    * until it migrates). The username is always the GitHub x-access-token. */
+   /* AIMEE_GIT_TOKEN_FD must be all-digits before it is used as a /proc/self/fd
+    * path component (defense-in-depth); a missing/non-numeric value, or a read
+    * that yields nothing, falls back to the legacy GH_TOKEN env var. cat reopens
+    * /proc/self/fd/<n>, so the memfd is read from offset 0 on every invocation. */
    fputs("#!/bin/sh\n"
          "case \"$1\" in\n"
          "*[Uu]sername*) echo x-access-token ;;\n"
-         "*) printf '%s\\n' \"$GH_TOKEN\" ;;\n"
+         "*) case \"$AIMEE_GIT_TOKEN_FD\" in\n"
+         "     ''|*[!0-9]*) printf '%s\\n' \"$GH_TOKEN\" ;;\n"
+         "     *) cat \"/proc/self/fd/$AIMEE_GIT_TOKEN_FD\" 2>/dev/null "
+         "|| printf '%s\\n' \"$GH_TOKEN\" ;;\n"
+         "   esac ;;\n"
          "esac\n",
          f);
    fclose(f);

--- a/src/headers/git_cred_inject.h
+++ b/src/headers/git_cred_inject.h
@@ -37,10 +37,23 @@
  * consulted only when a host token is needed and `remote_url` is NULL — a single
  * local `git config --get remote.origin.url` (no network, no creds). Returns a
  * malloc'd array (free with git_cred_inject_free_env), or NULL when no credential
- * of any kind is available (caller falls back to ambient creds) or on error. */
+ * of any kind is available (caller falls back to ambient creds) or on error.
+ *
+ * `out_token_fd` selects how an HTTPS token reaches git:
+ *   - non-NULL  → FD MODE. The token is written to a CLOEXEC memfd (anonymous,
+ *     never a named path) whose fd is returned in *out_token_fd, and the env
+ *     carries AIMEE_GIT_TOKEN_FD=GIT_CRED_TOKEN_TARGET_FD (a number, not the
+ *     secret) instead of GH_TOKEN. The caller must run git with
+ *     safe_exec_capture_cwd_env_fd_timeout(inherit_fd=*out_token_fd,
+ *     target_fd=GIT_CRED_TOKEN_TARGET_FD) and close *out_token_fd afterwards. The
+ *     token then never appears in the child's /proc/<pid>/environ. *out_token_fd
+ *     is set to -1 when there is no HTTPS token (ssh-only / no creds).
+ *   - NULL      → LEGACY ENV MODE. The token is injected as GH_TOKEN in the env
+ *     (used by the long-lived editor path until it migrates). */
+#define GIT_CRED_TOKEN_TARGET_FD 21 /* fd number the askpass reads in the git child */
 char **git_cred_inject_build_env_for_repo(const char *principal, const char *remote_url,
                                           const char *repo_dir, const char *preferred_token,
-                                          char *const *parent_environ);
+                                          char *const *parent_environ, int *out_token_fd);
 
 /* Back-compat shim: build the env for `principal` with no repo context — webuser
  * vault → server identity → ssh-agent (no per-host token). Equivalent to

--- a/src/headers/util.h
+++ b/src/headers/util.h
@@ -289,6 +289,17 @@ int safe_exec_capture_env(const char *const argv[], char *const envp[], char **o
 int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
                                       char **out_buf, size_t max_out, int timeout_ms);
 
+/* Like safe_exec_capture_cwd_env_timeout, but additionally hands the child one
+ * caller fd: inherit_fd is duplicated onto target_fd in the forked child with
+ * CLOEXEC cleared, so the exec'd command (and its own children) inherit exactly
+ * that fd at a known number — used to deliver a credential (a memfd the askpass
+ * reads via /proc/self/fd/<target_fd>) without putting it in the environment.
+ * inherit_fd/target_fd < 0 → no fd is passed (identical to the plain variant).
+ * inherit_fd must be CLOEXEC in the parent so concurrent execs can't leak it. */
+int safe_exec_capture_cwd_env_fd_timeout(const char *const argv[], const char *cwd,
+                                         char *const envp[], char **out_buf, size_t max_out,
+                                         int timeout_ms, int inherit_fd, int target_fd);
+
 /* --- Internal git network ops (NOT the user-facing `aimee git` CLI) ---
  *
  * Automated paths (session start, indexing, verify, branch orchestration) must
@@ -301,7 +312,7 @@ int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd,
  * BatchMode=yes does the same for SSH auth; ConnectTimeout caps a dead-host
  * connect. */
 #define GIT_SAFE_SSH_COMMAND "ssh -o BatchMode=yes -o ConnectTimeout=5"
-#define GIT_SAFE_ENV "GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='" GIT_SAFE_SSH_COMMAND "' "
+#define GIT_SAFE_ENV         "GIT_TERMINAL_PROMPT=0 GIT_SSH_COMMAND='" GIT_SAFE_SSH_COMMAND "' "
 
 /* Wall-clock cap (ms) for an internal git network op. Generous enough not to
  * kill a slow-but-working fetch, short enough that a stalled remote can never

--- a/src/mcp_git_query.c
+++ b/src/mcp_git_query.c
@@ -95,7 +95,7 @@ char *mcp_git_run(const char *cmd, int *exit_code)
          const char *pref = NULL;
          if (forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
             pref = tok;
-         char **envp = git_cred_inject_build_env_for_repo(NULL, NULL, cwd, pref, environ);
+         char **envp = git_cred_inject_build_env_for_repo(NULL, NULL, cwd, pref, environ, NULL);
          volatile char *p = (volatile char *)tok;
          for (size_t i = 0; i < sizeof(tok); i++)
             p[i] = 0;

--- a/src/posix/util.c
+++ b/src/posix/util.c
@@ -1,6 +1,7 @@
 /* util.c: POSIX-specific utilities (process exec, regex, pclose status) */
 #include "aimee.h"
 #include <errno.h>
+#include <fcntl.h>
 #include <limits.h>
 #include <poll.h>
 #include <regex.h>
@@ -36,8 +37,9 @@ static int reap_bounded(pid_t pid, int budget_ms)
    }
 }
 
-int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
-                                      char **out_buf, size_t max_out, int timeout_ms)
+int safe_exec_capture_cwd_env_fd_timeout(const char *const argv[], const char *cwd,
+                                         char *const envp[], char **out_buf, size_t max_out,
+                                         int timeout_ms, int inherit_fd, int target_fd)
 {
    *out_buf = NULL;
    if (!argv || !argv[0])
@@ -67,6 +69,23 @@ int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd,
       dup2(pipefd[1], STDOUT_FILENO);
       dup2(pipefd[1], STDERR_FILENO);
       close(pipefd[1]);
+      /* Inherit one specific fd (e.g. a memfd holding a credential the askpass
+       * reads) at a fixed number for the exec'd command, cleared of CLOEXEC. The
+       * source fd is CLOEXEC in the parent, so a concurrent exec in another
+       * thread can never leak it — only this child receives it, and only at
+       * target_fd. */
+      if (inherit_fd >= 0 && target_fd >= 0)
+      {
+         if (inherit_fd != target_fd)
+         {
+            if (dup2(inherit_fd, target_fd) < 0) /* dup2 clears CLOEXEC on target_fd */
+               _exit(127);
+         }
+         else if (fcntl(target_fd, F_SETFD, 0) < 0)
+         {
+            _exit(127);
+         }
+      }
       /* Pin the working directory before exec so the command runs in the caller's
        * chosen dir (e.g. the work-item repo), not the engine's inherited cwd. A
        * failed chdir must NOT silently fall back to the parent cwd. */
@@ -189,6 +208,13 @@ int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd,
       waitpid(pid, &status, 0);
    }
    return WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+}
+
+int safe_exec_capture_cwd_env_timeout(const char *const argv[], const char *cwd, char *const envp[],
+                                      char **out_buf, size_t max_out, int timeout_ms)
+{
+   return safe_exec_capture_cwd_env_fd_timeout(argv, cwd, envp, out_buf, max_out, timeout_ms, -1,
+                                               -1);
 }
 
 int safe_exec_capture_env(const char *const argv[], char *const envp[], char **out_buf,

--- a/src/server/git_cred_inject.c
+++ b/src/server/git_cred_inject.c
@@ -1,4 +1,5 @@
 /* git_cred_inject.c — vault-sourced git credential env. See git_cred_inject.h. */
+#define _GNU_SOURCE 1
 #include "git_cred_inject.h"
 #include "forge_credentials.h" /* forge_cred_askpass_shim / forge_cred_server_identity */
 #include "git_forge_vault.h"   /* git_forge_vault_token */
@@ -8,6 +9,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h> /* memfd_create — anonymous in-memory token fd (fd mode) */
+#include <unistd.h>   /* write, close */
 
 #define GIT_CRED_TOKEN_MAX 4096
 
@@ -21,13 +24,18 @@ static int is_key(const char *entry, const char *key)
 /* Build the git child env: a copy of `parent` with the credential-carrying keys
  * we manage dropped, plus GH_TOKEN/GIT_ASKPASS/GIT_TERMINAL_PROMPT (when a token
  * is given) and SSH_AUTH_SOCK (when a sock is given). Returns NULL on OOM. */
-static char **build_env(char *const *parent, const char *token, const char *shim, const char *sock)
+/* token_fd_target >= 0 selects FD MODE: advertise AIMEE_GIT_TOKEN_FD=<target>
+ * (the askpass reads the token from that inherited fd) and do NOT put the secret
+ * in the env. token_fd_target < 0 is LEGACY ENV MODE: GH_TOKEN=<token>. In both
+ * modes `token` non-empty means "a token exists" (so the askpass is wired). */
+static char **build_env(char *const *parent, const char *token, const char *shim, const char *sock,
+                        int token_fd_target)
 {
    size_t pc = 0;
    if (parent)
       while (parent[pc])
          pc++;
-   char **out = calloc(pc + 5, sizeof(char *)); /* +GH_TOKEN,ASKPASS,PROMPT,SSH_AUTH_SOCK,NULL */
+   char **out = calloc(pc + 5, sizeof(char *)); /* +token-key,ASKPASS,PROMPT,SSH_AUTH_SOCK,NULL */
    if (!out)
       return NULL;
    size_t o = 0;
@@ -35,7 +43,7 @@ static char **build_env(char *const *parent, const char *token, const char *shim
    {
       if (is_key(parent[i], "GH_TOKEN") || is_key(parent[i], "GITHUB_TOKEN") ||
           is_key(parent[i], "GIT_ASKPASS") || is_key(parent[i], "GIT_TERMINAL_PROMPT") ||
-          is_key(parent[i], "SSH_AUTH_SOCK"))
+          is_key(parent[i], "SSH_AUTH_SOCK") || is_key(parent[i], "AIMEE_GIT_TOKEN_FD"))
          continue;
       out[o] = strdup(parent[i]);
       if (!out[o++])
@@ -44,7 +52,10 @@ static char **build_env(char *const *parent, const char *token, const char *shim
    if (token && token[0])
    {
       char buf[GIT_CRED_TOKEN_MAX + 16];
-      snprintf(buf, sizeof(buf), "GH_TOKEN=%s", token);
+      if (token_fd_target >= 0)
+         snprintf(buf, sizeof(buf), "AIMEE_GIT_TOKEN_FD=%d", token_fd_target);
+      else
+         snprintf(buf, sizeof(buf), "GH_TOKEN=%s", token);
       if (!(out[o++] = strdup(buf)))
          goto oom;
       if (shim && shim[0])
@@ -119,11 +130,34 @@ static int resolve_token(const char *principal, const char *remote_url, const ch
 
 char **git_cred_inject_build_env_for_repo(const char *principal, const char *remote_url,
                                           const char *repo_dir, const char *preferred_token,
-                                          char *const *parent_environ)
+                                          char *const *parent_environ, int *out_token_fd)
 {
-   char token[GIT_CRED_TOKEN_MAX];
+   if (out_token_fd)
+      *out_token_fd = -1;
+   const int fd_mode = (out_token_fd != NULL);
+
+   char token[GIT_CRED_TOKEN_MAX] = {0};
    int have_token =
        resolve_token(principal, remote_url, repo_dir, preferred_token, token, sizeof(token));
+
+   /* FD MODE: stage the token in an anonymous CLOEXEC memfd (never a named path,
+    * never in the env). The askpass reads it via /proc/self/fd/<target>; the
+    * caller inherits this fd into git and closes it after. memfd failure fails
+    * closed (drop the token) rather than silently leaking it to the env. */
+   int token_fd = -1;
+   if (have_token && fd_mode)
+   {
+      int mfd = memfd_create("c", MFD_CLOEXEC); /* opaque name: don't advertise a cred in fdinfo */
+      size_t tn = strlen(token);
+      if (mfd >= 0 && write(mfd, token, tn) == (ssize_t)tn && write(mfd, "\n", 1) == 1)
+         token_fd = mfd;
+      else
+      {
+         if (mfd >= 0)
+            close(mfd);
+         have_token = 0; /* fail closed */
+      }
+   }
 
    /* Start (or reuse) the user's in-memory ssh-agent if they have a vaulted SSH
     * key (WP-C2); the key never touches disk. 1 = sock ready. */
@@ -133,18 +167,28 @@ char **git_cred_inject_build_env_for_repo(const char *principal, const char *rem
    char **envp = NULL;
    if (have_token || have_sock)
       envp = build_env(parent_environ, have_token ? token : NULL, forge_cred_askpass_shim(),
-                       have_sock ? sock : NULL);
+                       have_sock ? sock : NULL,
+                       (fd_mode && have_token) ? GIT_CRED_TOKEN_TARGET_FD : -1);
 
-   /* Wipe our stack copy of the token; the remaining plaintext is only the
-    * GH_TOKEN entry in envp, which git_cred_inject_free_env zeroes. */
-   if (have_token)
-      wipe(token, sizeof(token));
+   if (!envp && token_fd >= 0) /* build failed → don't leak the memfd */
+   {
+      close(token_fd);
+      token_fd = -1;
+   }
+
+   /* Wipe our stack copy of the token unconditionally (the buffer is zero-inited,
+    * so this is always safe). In fd mode the only remaining plaintext is inside
+    * the memfd (kernel memory, closed by the caller after exec); in env mode it
+    * is the GH_TOKEN entry git_cred_inject_free_env zeroes. */
+   wipe(token, sizeof(token));
+   if (out_token_fd)
+      *out_token_fd = token_fd;
    return envp;
 }
 
 char **git_cred_inject_build_env(const char *principal, char *const *parent_environ)
 {
-   return git_cred_inject_build_env_for_repo(principal, NULL, NULL, NULL, parent_environ);
+   return git_cred_inject_build_env_for_repo(principal, NULL, NULL, NULL, parent_environ, NULL);
 }
 
 void git_cred_inject_free_env(char **envp)

--- a/src/server/git_ops.c
+++ b/src/server/git_ops.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h> /* close — release the token memfd after the git exec */
 
 extern char **environ;
 
@@ -63,10 +64,19 @@ static int run_git(const char *principal, const char *dir, const char *const arg
     * push/fetch to gitlab/gitea authenticates with the right host's stored token
     * (not the server's GitHub identity). repo_dir = dir → origin is resolved only
     * when a host token is actually needed (fetch/pull/push). */
-   char **envp =
-       needs_cred ? git_cred_inject_build_env_for_repo(principal, NULL, dir, NULL, environ) : NULL;
-   int rc = safe_exec_capture_cwd_env_timeout(argv, dir, envp ? envp : environ, out, GO_OUT_MAX,
-                                              GO_TIMEOUT_MS);
+   int token_fd = -1;
+   char **envp = needs_cred ? git_cred_inject_build_env_for_repo(principal, NULL, dir, NULL,
+                                                                 environ, &token_fd)
+                            : NULL;
+   /* FD mode: the HTTPS token rides an inherited memfd (token_fd), placed at
+    * GIT_CRED_TOKEN_TARGET_FD in the git child where the askpass reads it — so it
+    * never lands in the child's /proc/<pid>/environ. The fd is CLOEXEC here, so a
+    * concurrent exec on another thread can't inherit it. */
+   int rc = safe_exec_capture_cwd_env_fd_timeout(argv, dir, envp ? envp : environ, out, GO_OUT_MAX,
+                                                 GO_TIMEOUT_MS, token_fd,
+                                                 token_fd >= 0 ? GIT_CRED_TOKEN_TARGET_FD : -1);
+   if (token_fd >= 0)
+      close(token_fd);
    if (envp)
       git_cred_inject_free_env(envp);
    return rc;

--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -109,7 +109,9 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
     * already-stored vault token > the principal's own vaulted token > the
     * server's own identity (App token / AIMEE_FORGE_TOKEN); plus the principal's
     * vaulted SSH agent. The token crosses only via GIT_ASKPASS, never argv. */
-   char **envp = git_cred_inject_build_env_for_repo(principal, url, NULL, token, environ);
+   /* TODO(#3A.2): migrate clone to the memfd fd-mode (out_token_fd) so the token
+    * is not in the clone child's environment; env mode (GH_TOKEN) for now. */
+   char **envp = git_cred_inject_build_env_for_repo(principal, url, NULL, token, environ, NULL);
    /* Clone over HTTPS, never SSH: our credential model is per-host HTTPS tokens
     * (+ OAuth), and a non-interactive server has no seeded known_hosts, so an
     * ssh://, git@host:path, or git:// URL would die on "Host key verification

--- a/src/server/workspace_turn.c
+++ b/src/server/workspace_turn.c
@@ -81,7 +81,7 @@ static int ws_mirror_git_runner(void *ctx, const char *const args[], char *out, 
    const char *pref = NULL;
    if (wsid && wsid[0] && forge_cred_get(wsid, (long)time(NULL), tok, sizeof(tok)) == 0 && tok[0])
       pref = tok;
-   char **envp = git_cred_inject_build_env_for_repo(NULL, remote, NULL, pref, environ);
+   char **envp = git_cred_inject_build_env_for_repo(NULL, remote, NULL, pref, environ, NULL);
    {
       volatile char *p = (volatile char *)tok;
       for (size_t i = 0; i < sizeof(tok); i++)

--- a/src/tests/support/git_cred_inject_stub.c
+++ b/src/tests/support/git_cred_inject_stub.c
@@ -12,13 +12,15 @@
 
 char **git_cred_inject_build_env_for_repo(const char *principal, const char *remote_url,
                                           const char *repo_dir, const char *preferred_token,
-                                          char *const *parent_environ)
+                                          char *const *parent_environ, int *out_token_fd)
 {
    (void)principal;
    (void)remote_url;
    (void)repo_dir;
    (void)preferred_token;
    (void)parent_environ;
+   if (out_token_fd)
+      *out_token_fd = -1;
    return NULL;
 }
 

--- a/src/tests/test_git_cred_inject.c
+++ b/src/tests/test_git_cred_inject.c
@@ -6,8 +6,12 @@
 #include "git_host_cred.h"
 #include "git_host_resolve.h"
 #include "git_ssh_agent.h"
+#include "util.h" /* safe_exec_capture_cwd_env_fd_timeout — fd-mode invariant test */
 #include "vault_kek_cache.h"
 #include "vault_service.h"
+
+#define STR2(x) #x
+#define STR(x)  STR2(x)
 
 #include <assert.h>
 #include <stdint.h>
@@ -102,14 +106,14 @@ int main(void)
    /* 1) A caller-supplied (inline/broker) token beats every vault source. */
    vault_kek_cache_clear();
    char **e1 = git_cred_inject_build_env_for_repo(alice, "https://gitlab.example.com/x/y", NULL,
-                                                  "INLINE-WINS", parent);
+                                                  "INLINE-WINS", parent, NULL);
    assert(e1 && (tok = env_val(e1, "GH_TOKEN", &n)) && n == 1 && strcmp(tok, "INLINE-WINS") == 0);
    git_cred_inject_free_env(e1);
 
    /* 2) The per-host vault token beats alice's own vaulted personal token. */
    vault_kek_cache_clear();
    char **e2 = git_cred_inject_build_env_for_repo(alice, "https://gitlab.example.com/x/y", NULL,
-                                                  NULL, parent);
+                                                  NULL, parent, NULL);
    assert(e2 && (tok = env_val(e2, "GH_TOKEN", &n)) && n == 1 &&
           strcmp(tok, "glpat-HOSTSECRET") == 0);
    git_cred_inject_free_env(e2);
@@ -117,7 +121,7 @@ int main(void)
    /* 3) A host with no stored token falls back to alice's personal vault token. */
    vault_kek_cache_clear();
    char **e3 = git_cred_inject_build_env_for_repo(alice, "https://no-token-host.example/x/y", NULL,
-                                                  NULL, parent);
+                                                  NULL, parent, NULL);
    assert(e3 && (tok = env_val(e3, "GH_TOKEN", &n)) && n == 1 &&
           strcmp(tok, "ghp_aliceSECRET") == 0);
    git_cred_inject_free_env(e3);
@@ -127,11 +131,52 @@ int main(void)
    git_host_resolve_register(NULL);
    vault_kek_cache_clear();
    char **e4 = git_cred_inject_build_env_for_repo(alice, "https://gitlab.example.com/x/y", NULL,
-                                                  NULL, parent);
+                                                  NULL, parent, NULL);
    assert(e4 && (tok = env_val(e4, "GH_TOKEN", &n)) && n == 1 &&
           strcmp(tok, "ghp_aliceSECRET") == 0);
    git_cred_inject_free_env(e4);
    git_host_resolve_register(git_host_cred_for_url);
+
+   /* --- FD MODE (#3A): the HTTPS token rides an inherited memfd, never the env,
+    * so it cannot appear in the git child's /proc/<pid>/environ. --- */
+   {
+      int tfd = -1;
+      char **fe = git_cred_inject_build_env_for_repo(alice, "https://github.com/o/r", NULL,
+                                                     "FD-MODE-SECRET", parent, &tfd);
+      assert(fe && tfd >= 0);
+      /* No GH_TOKEN; the fd number is advertised instead (a number, not a secret). */
+      assert(env_val(fe, "GH_TOKEN", &n) == NULL && n == 0);
+      const char *fdv = env_val(fe, "AIMEE_GIT_TOKEN_FD", &n);
+      assert(n == 1 && fdv && atoi(fdv) == GIT_CRED_TOKEN_TARGET_FD);
+      assert(env_val(fe, "GIT_ASKPASS", &n) && n == 1);
+      assert(env_val(fe, "GIT_TERMINAL_PROMPT", &n) && n == 1);
+      /* The secret must not appear ANYWHERE in the env strings. */
+      for (int i = 0; fe[i]; i++)
+         assert(strstr(fe[i], "FD-MODE-SECRET") == NULL);
+
+      /* The binding invariant: a child exec'd with this env + the inherited fd can
+       * read the token via /proc/self/fd/<target> (what the askpass does), but the
+       * token is NOT in its /proc/self/environ. */
+      const char *argv[] = {
+          "/bin/sh", "-c",
+          "cat /proc/self/fd/" STR(
+              GIT_CRED_TOKEN_TARGET_FD) "; printf '\\n--ENVIRON--\\n'; tr '\\0' '\\n' < "
+                                        "/proc/self/environ",
+          NULL};
+      char *out = NULL;
+      int rc = safe_exec_capture_cwd_env_fd_timeout(argv, NULL, fe, &out, 1 << 16, 10000, tfd,
+                                                    GIT_CRED_TOKEN_TARGET_FD);
+      assert(rc == 0 && out);
+      char *envmark = strstr(out, "--ENVIRON--");
+      assert(envmark);
+      *envmark = '\0'; /* split the capture into [fd read] | [environ dump] */
+      assert(strstr(out, "FD-MODE-SECRET") != NULL);              /* fd carried the token */
+      assert(strstr(envmark + 1, "FD-MODE-SECRET") == NULL);      /* NOT in environ */
+      assert(strstr(envmark + 1, "AIMEE_GIT_TOKEN_FD=") != NULL); /* only the fd number is */
+      free(out);
+      close(tfd);
+      git_cred_inject_free_env(fe);
+   }
 
    /* SSH integration (WP-C2): a vaulted SSH key adds SSH_AUTH_SOCK to the env
     * (the in-memory agent). Guarded on openssh tooling. */


### PR DESCRIPTION
Closes deferred follow-up **#3** (git_ops slice — #3A): the webchat git ops injected the forge token as `GH_TOKEN` in the git child's environment, so it was visible in `/proc/<pid>/environ`. This moves the `git_ops` path to an **fd-fed askpass** so the token never enters the environment.

## Mechanism
- **`git_cred_inject` FD mode** (`out_token_fd`): the resolved HTTPS token is written to an anonymous **CLOEXEC memfd** (never a named path); the env carries `AIMEE_GIT_TOKEN_FD=<n>` (a *number*, not the secret) instead of `GH_TOKEN`. `memfd_create` failure **fails closed** (drops the token) rather than leaking it to the env.
- **`safe_exec` `_fd_` variant**: hands the child exactly one fd at a fixed number (`GIT_CRED_TOKEN_TARGET_FD=21`) with CLOEXEC cleared via `dup2`. The source memfd stays CLOEXEC in the parent, so a **concurrent exec on another thread can't inherit it**.
- **askpass shim** reads `/proc/self/fd/$AIMEE_GIT_TOKEN_FD` (re-readable), falling back to `$GH_TOKEN` so the long-lived **editor path keeps working until it migrates (#4)**. git's askpass invocation is otherwise unchanged.
- `run_git` uses FD mode; **clone** (`git_project`), `workspace_turn`, and the `aimee git` CLI query stay env-mode for now (signature updated; clone migration is #3A.2).

## Validation (local)
`test_git_cred_inject` extended: the FD-mode env has `AIMEE_GIT_TOKEN_FD` + **no** `GH_TOKEN`, and the secret appears **nowhere** in the env strings; and a child exec'd via the `_fd_` variant reads the token through `/proc/self/fd/<target>` (what the askpass does) while its `/proc/self/environ` contains only the fd **number**, never the token. git's askpass path is unchanged from the shipped, working behavior — only the token *source* moved (env → fd).

Roundtable security review run on the diff; summary to follow as a comment.