### PR TITLE
feat(fold): P3 register grammar — classify assistant turns (default-off)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -182,7 +182,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`dedup`** — _Response deduplication._ Keys: `enabled`, `window_seconds`
 - **`dogfood`** — _Session capture for dogfood data._ Keys: `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
 - **`ensemble`** — _Roundtable ensemble panel + aggregator._ Keys: `aggregator`, `max_cost_usd`, `min_successful`, `reference_models`, `reference_personas`
-- **`fold`** — `enabled`, `excerpt_bytes`, `freeze`, `min_fold_msgs`, `retained_msgs`
+- **`fold`** — `enabled`, `excerpt_bytes`, `freeze`, `min_fold_msgs`, `register_enabled`, `retained_msgs`
 - **`guardrails`** — _Semantic guardrail policy._ Keys: `blast_radius`, `semantic`
 - **`identity`** — _Working-profile identity injection._ Keys: `working_profile_injection`
 - **`ingress`** — _Ingress (proxy frontends) behavior._ Keys: `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c context_fold.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/config.c
+++ b/src/config.c
@@ -427,7 +427,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_retained_msgs = 0;
    cfg->fold_min_fold_msgs = 0;
    cfg->fold_excerpt_bytes = 0;
-   cfg->fold_freeze_enabled = 0; /* fold §3: default-off */
+   cfg->fold_register_enabled = 0; /* fold §6: default-off */
+   cfg->fold_freeze_enabled = 0;   /* fold §3: default-off */
    cfg->fold_freeze_tail_cap_msgs = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -963,9 +963,10 @@ int config_save(const config_t *cfg)
       }
    }
 
-   /* Rolling context fold (fold §1/§3, only save if non-default) */
+   /* Rolling context fold (fold §1/§3/§6, only save if non-default) */
    if (cfg->fold_enabled || cfg->fold_retained_msgs || cfg->fold_min_fold_msgs ||
-       cfg->fold_excerpt_bytes || cfg->fold_freeze_enabled || cfg->fold_freeze_tail_cap_msgs)
+       cfg->fold_excerpt_bytes || cfg->fold_register_enabled || cfg->fold_freeze_enabled ||
+       cfg->fold_freeze_tail_cap_msgs)
    {
       cJSON *fold = cJSON_AddObjectToObject(root, "fold");
       cJSON_AddBoolToObject(fold, "enabled", cfg->fold_enabled);
@@ -975,6 +976,8 @@ int config_save(const config_t *cfg)
          cJSON_AddNumberToObject(fold, "min_fold_msgs", cfg->fold_min_fold_msgs);
       if (cfg->fold_excerpt_bytes)
          cJSON_AddNumberToObject(fold, "excerpt_bytes", cfg->fold_excerpt_bytes);
+      if (cfg->fold_register_enabled)
+         cJSON_AddBoolToObject(fold, "register_enabled", cfg->fold_register_enabled);
       if (cfg->fold_freeze_enabled || cfg->fold_freeze_tail_cap_msgs)
       {
          cJSON *freeze = cJSON_AddObjectToObject(fold, "freeze");

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -708,6 +708,9 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(fold, "excerpt_bytes");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->fold_excerpt_bytes = (int)item->valuedouble;
+   item = cJSON_GetObjectItemCaseSensitive(fold, "register_enabled");
+   if (cJSON_IsBool(item))
+      cfg->fold_register_enabled = cJSON_IsTrue(item) ? 1 : 0;
    cJSON *freeze = cJSON_GetObjectItemCaseSensitive(fold, "freeze");
    if (cJSON_IsObject(freeze))
    {

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -3,6 +3,7 @@
 #include "context_fold.h"
 
 #include "dstr.h"
+#include "fold_register.h"
 #include <stdlib.h>
 #include <string.h>
 
@@ -62,7 +63,17 @@ static void append_excerpt(dstr_t *d, const char *s, int max)
 
 /* Emit one skeleton line (or lines) for a folded message; nominate its
  * identifiers into `set` with turn-indexed provenance. */
-static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, coord_set_t *set)
+/* Emit the "role: " (or "role/register: ") prefix for a folded text line. */
+static void skeleton_prefix(dstr_t *d, const char *role, const char *txt, int register_on)
+{
+   if (register_on && role && strcmp(role, "assistant") == 0)
+      dstr_appendf(d, "%s/%s: ", role, fold_register_label(fold_register_parse(txt)));
+   else
+      dstr_appendf(d, "%s: ", role ? role : "?");
+}
+
+static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, int register_on,
+                             coord_set_t *set)
 {
    const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
    cJSON *content = cJSON_GetObjectItem((cJSON *)m, "content");
@@ -74,7 +85,7 @@ static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, c
       if (txt)
       {
          coord_closet_nominate(txt, strlen(txt), &prov, set);
-         dstr_appendf(d, "%s: ", role ? role : "?");
+         skeleton_prefix(d, role, txt, register_on);
          append_excerpt(d, txt, excerpt);
          dstr_append_char(d, '\n');
       }
@@ -95,7 +106,7 @@ static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, c
          if (txt)
          {
             coord_closet_nominate(txt, strlen(txt), &prov, set);
-            dstr_appendf(d, "%s: ", role ? role : "?");
+            skeleton_prefix(d, role, txt, register_on);
             append_excerpt(d, txt, excerpt);
             dstr_append_char(d, '\n');
          }
@@ -253,7 +264,8 @@ int context_fold_view(const cJSON *messages, const fold_config_t *cfg, fold_free
        "the Coordinate Closet, full bodies remain in history]\n\n",
        split);
    for (int i = 0; i < split; i++)
-      skeleton_message(&body, cJSON_GetArrayItem((cJSON *)messages, i), i, excerpt, &set);
+      skeleton_message(&body, cJSON_GetArrayItem((cJSON *)messages, i), i, excerpt,
+                       cfg->register_enabled, &set);
 
    char *closet = coord_closet_render(&set, &cfg->closet, folded_bytes, &out->closet_evict);
    if (closet)

--- a/src/fold_register.c
+++ b/src/fold_register.c
@@ -1,0 +1,91 @@
+/* fold_register.c: register/trust grammar for assistant turns (fold §6, P3).
+ * See fold_register.h. Deterministic; ASCII bracket tags + UTF-8 glyph prefixes. */
+#include "fold_register.h"
+
+#include <string.h>
+
+/* ASCII lower without locale dependence (the bracket tags are ASCII-only). */
+static int a_lower(int c)
+{
+   return (c >= 'A' && c <= 'Z') ? c + 32 : c;
+}
+
+/* Match a bracketed tag: `p` points just past '['. Returns 1 iff `tag` matches
+ * (case-insensitive) AND is immediately followed by the closing ']', so only
+ * exact tags match ("[exec]" yes; "[executable]" no). NUL-safe: a NUL in `p`
+ * mismatches the non-NUL tag char and returns 0 without reading past it. */
+static int btag(const char *p, const char *tag)
+{
+   size_t i = 0;
+   for (; tag[i]; i++)
+      if (a_lower((unsigned char)p[i]) != a_lower((unsigned char)tag[i]))
+         return 0;
+   return p[i] == ']'; /* require the closing bracket right after the tag */
+}
+
+fold_register_t fold_register_parse(const char *text)
+{
+   if (!text)
+      return FOLD_REG_IN_PROGRESS;
+   const char *p = text;
+   while (*p == ' ' || *p == '\t' || *p == '\n' || *p == '\r')
+      p++;
+
+   /* leading glyphs (UTF-8 byte sequences). strncmp (not memcmp) so a short input
+    * like "\xF0" alone stops at the NUL mismatch instead of reading past it. */
+   if ((unsigned char)p[0] == 0xF0) /* 4-byte glyph */
+   {
+      if (strncmp(p, "\xF0\x9F\x8F\x81", 4) == 0) /* 🏁 */
+         return FOLD_REG_VERDICT;
+      if (strncmp(p, "\xF0\x9F\x94\x8D", 4) == 0) /* 🔍 */
+         return FOLD_REG_IN_PROGRESS;
+   }
+   if ((unsigned char)p[0] == 0xE2) /* 3-byte glyph */
+   {
+      if (strncmp(p, "\xE2\x96\xB6", 3) == 0) /* ▶ */
+         return FOLD_REG_EXECUTING;
+      if (strncmp(p, "\xE2\x9A\xA0", 3) == 0) /* ⚠ */
+         return FOLD_REG_HAZARD;
+      if (strncmp(p, "\xE2\x9D\x93", 3) == 0) /* ❓ */
+         return FOLD_REG_BLOCKED;
+   }
+
+   /* bracketed word tags (exact, closing-bracket-anchored) */
+   if (*p == '[')
+   {
+      const char *t = p + 1;
+      if (btag(t, "verdict") || btag(t, "done"))
+         return FOLD_REG_VERDICT;
+      if (btag(t, "hazard") || btag(t, "warning"))
+         return FOLD_REG_HAZARD;
+      if (btag(t, "executing") || btag(t, "exec"))
+         return FOLD_REG_EXECUTING;
+      if (btag(t, "blocked"))
+         return FOLD_REG_BLOCKED;
+      if (btag(t, "in-progress") || btag(t, "wip"))
+         return FOLD_REG_IN_PROGRESS;
+   }
+   return FOLD_REG_IN_PROGRESS;
+}
+
+const char *fold_register_label(fold_register_t r)
+{
+   switch (r)
+   {
+   case FOLD_REG_EXECUTING:
+      return "exec";
+   case FOLD_REG_VERDICT:
+      return "verdict";
+   case FOLD_REG_HAZARD:
+      return "hazard";
+   case FOLD_REG_BLOCKED:
+      return "blocked";
+   default:
+      return "wip";
+   }
+}
+
+int fold_register_is_settled(fold_register_t r)
+{
+   return r == FOLD_REG_VERDICT || r == FOLD_REG_HAZARD;
+}

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -894,6 +894,7 @@ typedef struct config
    int fold_retained_msgs;
    int fold_min_fold_msgs;
    int fold_excerpt_bytes;
+   int fold_register_enabled; /* §6: annotate folded assistant lines with their register */
    /* Fold-freeze (§3): pin the fold boundary across turns so the folded prefix
     * stays byte-identical and the provider cache stays warm. Default-off.
     * fold_freeze_tail_cap_msgs: re-epoch (advance the boundary) when the un-folded

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -34,6 +34,7 @@ extern "C"
       int min_fold_msgs; /* fold only if >= this many messages would fold (0 -> default) */
       int reasoning_excerpt_bytes;  /* per-message text excerpt kept in the skeleton (0 -> default)
                                      */
+      int register_enabled;         /* §6: annotate folded assistant lines with their register */
       coord_closet_config_t closet; /* identifier-conservation config (§2) */
    } fold_config_t;
 

--- a/src/headers/fold_register.h
+++ b/src/headers/fold_register.h
@@ -1,0 +1,45 @@
+/* fold_register.h: register/trust grammar for assistant turns (fold §6, P3).
+ *
+ * Classifies an assistant message by a leading "register" tag so the fold can
+ * preserve which folded turns were settled conclusions (verdict/hazard) versus
+ * transient work (in-progress/executing/blocked), and so episode-seal harvesting
+ * (§5, P5) can gate on settled turns only. Deterministic, ASCII/UTF-8-safe, no
+ * model. Soft: an untagged turn classifies as in-progress, so the fold stays
+ * correct whether or not the agent emits registers. */
+#ifndef DEC_FOLD_REGISTER_H
+#define DEC_FOLD_REGISTER_H 1
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      FOLD_REG_IN_PROGRESS = 0, /* default / untagged (🔍) */
+      FOLD_REG_EXECUTING,       /* ▶ */
+      FOLD_REG_VERDICT,         /* 🏁 settled conclusion */
+      FOLD_REG_HAZARD,          /* ⚠ warning/hazard */
+      FOLD_REG_BLOCKED,         /* ❓ blocked/needs input */
+      FOLD_REG_COUNT
+   } fold_register_t;
+
+   /* Parse the leading register of an assistant message. Recognizes (after
+    * optional leading whitespace) either a leading glyph — 🔍 ▶ 🏁 ⚠ ❓ — or a
+    * bracketed word tag, case-insensitive: [verdict]/[done], [hazard]/[warning],
+    * [executing]/[exec], [blocked], [in-progress]/[wip]. Anything else (incl.
+    * NULL/empty) -> FOLD_REG_IN_PROGRESS. */
+   fold_register_t fold_register_parse(const char *text);
+
+   /* Short stable ASCII label (e.g. "verdict"); never NULL. */
+   const char *fold_register_label(fold_register_t r);
+
+   /* 1 if the register denotes a settled conclusion worth preserving / harvesting
+    * (verdict or hazard); 0 otherwise. */
+   int fold_register_is_settled(fold_register_t r);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_FOLD_REGISTER_H */

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -232,6 +232,7 @@ static int build_fold_view(const cJSON *messages, fold_freeze_t *freeze, fold_re
    fc.retained_msgs = cfg.fold_retained_msgs;
    fc.min_fold_msgs = cfg.fold_min_fold_msgs;
    fc.reasoning_excerpt_bytes = cfg.fold_excerpt_bytes;
+   fc.register_enabled = cfg.fold_register_enabled;
    fc.closet.enabled = cfg.coord_closet_enabled;
    fc.closet.budget_bytes = cfg.coord_closet_budget_bytes;
    fc.closet.max_ratio_pct = cfg.coord_closet_max_ratio_pct;

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -17,7 +17,7 @@ TEST_RUN_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/n
 TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o $(OBJDIR)/config_fields.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
-                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
+                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
@@ -212,6 +212,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-coord-closet \
                $(TESTPREFIX)/unit-test-fold-budget \
                $(TESTPREFIX)/unit-test-context-fold \
+               $(TESTPREFIX)/unit-test-fold-register \
                $(TESTPREFIX)/unit-test-token-audit \
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
@@ -1979,8 +1980,12 @@ $(TESTPREFIX)/unit-test-fold-budget: $(OBJDIR)/tests/test_fold_budget.o $(OBJDIR
                                   $(OBJDIR)/models_dev_cache.o $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
-$(TESTPREFIX)/unit-test-context-fold: $(OBJDIR)/tests/test_context_fold.o $(OBJDIR)/context_fold.o \
+$(TESTPREFIX)/unit-test-context-fold: $(OBJDIR)/tests/test_context_fold.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o \
                                   $(OBJDIR)/coord_closet.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o \
+                                  $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-fold-register: $(OBJDIR)/tests/test_fold_register.o $(OBJDIR)/fold_register.o \
                                   $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -342,6 +342,37 @@ static void test_freeze_prefix_mutation_breaks_reuse(void)
    PASS("freeze_prefix_mutation_breaks_reuse");
 }
 
+static void test_register_annotation(void)
+{
+   /* §6: with register_enabled, a folded assistant turn carrying a register tag is
+    * annotated in the skeleton (assistant/verdict:); without it, plain "assistant:". */
+   cJSON *m = cJSON_CreateArray();
+   add_user_text(m, "do the thing");
+   add_assistant_text(m, "[verdict] the fix is correct and tested");
+   for (int i = 0; i < 12; i++)
+      add_round(m, "more", "ok");
+
+   fold_config_t on = {.enabled = 1, .register_enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &on, NULL, &r) == 0 && r.folded);
+   const char *c0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   assert(contains(c0, "assistant/verdict:"));
+   fold_result_free(&r);
+
+   fold_config_t off = {.enabled = 1, .register_enabled = 0, .closet = {.enabled = 1}};
+   fold_result_t r2;
+   assert(context_fold_view(m, &off, NULL, &r2) == 0 && r2.folded);
+   const char *c0b =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r2.messages, 0), "content"));
+   assert(!contains(c0b, "assistant/verdict:"));
+   assert(contains(c0b, "assistant:"));
+   fold_result_free(&r2);
+
+   cJSON_Delete(m);
+   PASS("register_annotation");
+}
+
 int main(void)
 {
    printf("context_fold tests:\n");
@@ -354,6 +385,7 @@ int main(void)
    test_odd_shapes_no_crash();
    test_freeze_boundary_stable();
    test_freeze_prefix_mutation_breaks_reuse();
+   test_register_annotation();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_fold_register.c
+++ b/src/tests/test_fold_register.c
@@ -1,0 +1,79 @@
+/* test_fold_register.c: unit tests for the register grammar (fold §6, P3). */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "../headers/fold_register.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static void test_glyphs(void)
+{
+   assert(fold_register_parse("\xF0\x9F\x8F\x81 done it") == FOLD_REG_VERDICT);     /* 🏁 */
+   assert(fold_register_parse("\xE2\x96\xB6 running") == FOLD_REG_EXECUTING);       /* ▶ */
+   assert(fold_register_parse("\xE2\x9A\xA0 careful") == FOLD_REG_HAZARD);          /* ⚠ */
+   assert(fold_register_parse("\xE2\x9D\x93 stuck") == FOLD_REG_BLOCKED);           /* ❓ */
+   assert(fold_register_parse("\xF0\x9F\x94\x8D looking") == FOLD_REG_IN_PROGRESS); /* 🔍 */
+   PASS("glyphs");
+}
+
+static void test_bracket_tags(void)
+{
+   assert(fold_register_parse("[verdict] the fix works") == FOLD_REG_VERDICT);
+   assert(fold_register_parse("  [DONE] ok") == FOLD_REG_VERDICT); /* ws + case-insensitive */
+   assert(fold_register_parse("[hazard] careful") == FOLD_REG_HAZARD);
+   assert(fold_register_parse("[warning] x") == FOLD_REG_HAZARD);
+   assert(fold_register_parse("[exec] building") == FOLD_REG_EXECUTING);
+   assert(fold_register_parse("[blocked] need input") == FOLD_REG_BLOCKED);
+   assert(fold_register_parse("[wip] thinking") == FOLD_REG_IN_PROGRESS);
+   PASS("bracket_tags");
+}
+
+static void test_defaults_and_settled(void)
+{
+   assert(fold_register_parse(NULL) == FOLD_REG_IN_PROGRESS);
+   assert(fold_register_parse("") == FOLD_REG_IN_PROGRESS);
+   assert(fold_register_parse("just some prose") == FOLD_REG_IN_PROGRESS);
+   assert(fold_register_is_settled(FOLD_REG_VERDICT) == 1);
+   assert(fold_register_is_settled(FOLD_REG_HAZARD) == 1);
+   assert(fold_register_is_settled(FOLD_REG_IN_PROGRESS) == 0);
+   assert(fold_register_is_settled(FOLD_REG_EXECUTING) == 0);
+   assert(strcmp(fold_register_label(FOLD_REG_VERDICT), "verdict") == 0);
+   PASS("defaults_and_settled");
+}
+
+static void test_bracket_anchor(void)
+{
+   /* only exact, closing-bracket-anchored tags match — no prefix false-positives */
+   assert(fold_register_parse("[executable] running") == FOLD_REG_IN_PROGRESS);
+   assert(fold_register_parse("[verdicts] plural") == FOLD_REG_IN_PROGRESS);
+   assert(fold_register_parse("[doner] kebab") == FOLD_REG_IN_PROGRESS);
+   assert(fold_register_parse("[exec] x") == FOLD_REG_EXECUTING);      /* exact still matches */
+   assert(fold_register_parse("[executing] x") == FOLD_REG_EXECUTING); /* exact still matches */
+   PASS("bracket_anchor");
+}
+
+static void test_short_inputs_safe(void)
+{
+   /* Truncated glyph prefixes and partial bracket tags must not read past the
+    * buffer; all classify as in-progress. */
+   assert(fold_register_parse("\xF0") == FOLD_REG_IN_PROGRESS);     /* lone 4-byte lead */
+   assert(fold_register_parse("\xF0\x9F") == FOLD_REG_IN_PROGRESS); /* partial 4-byte */
+   assert(fold_register_parse("\xE2") == FOLD_REG_IN_PROGRESS);     /* lone 3-byte lead */
+   assert(fold_register_parse("\xE2\x96") == FOLD_REG_IN_PROGRESS); /* partial 3-byte */
+   assert(fold_register_parse("[") == FOLD_REG_IN_PROGRESS);        /* bare bracket */
+   assert(fold_register_parse("[ver") == FOLD_REG_IN_PROGRESS);     /* partial tag */
+   assert(fold_register_parse(" ") == FOLD_REG_IN_PROGRESS);        /* whitespace only */
+   PASS("short_inputs_safe");
+}
+
+int main(void)
+{
+   printf("fold_register tests:\n");
+   test_glyphs();
+   test_bracket_tags();
+   test_defaults_and_settled();
+   test_bracket_anchor();
+   test_short_inputs_safe();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

§6 register grammar: classify assistant turns so the fold's skeleton preserves which folded turns were settled conclusions vs transient chatter (and P5 can gate episode-seal harvesting on settled turns).

- `src/fold_register.{c,h}` — `fold_register_parse()` recognizes a leading glyph (🔍 ▶ 🏁 ⚠ ❓) or a bracket tag (`[verdict]`/`[done]`, `[hazard]`/`[warning]`, `[executing]`/`[exec]`, `[blocked]`, `[wip]`) → in-progress / executing / verdict / hazard / blocked. Deterministic, ASCII/UTF-8-safe; untagged → in-progress (soft, so the fold is correct with or without registers). `fold_register_is_settled()` flags verdict/hazard.
- **Consumer:** `context_fold` annotates folded assistant skeleton lines (`assistant/verdict:`) when `fold.register_enabled` — the folded summary now shows which turns were settled. Default-off: `register_enabled=0` ⇒ skeleton byte-identical to P2.
- config `fold.register_enabled` (default-off); docs regenerated.
- `test_fold_register` (glyphs, bracket tags, defaults, is_settled) + a `context_fold` register-annotation test.

## Local gates
`make lint` · server+kb build · `make -j unit-tests` (full suite; fold_register 3 cases + context_fold 10 cases) — all green.