### PR TITLE
feat(fold): P4 fold recall — page folded coordinates back in on re-touch (default-off)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -182,7 +182,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`dedup`** — _Response deduplication._ Keys: `enabled`, `window_seconds`
 - **`dogfood`** — _Session capture for dogfood data._ Keys: `commit_raw`, `enabled`, `inline_tagging`, `log_dir`
 - **`ensemble`** — _Roundtable ensemble panel + aggregator._ Keys: `aggregator`, `max_cost_usd`, `min_successful`, `reference_models`, `reference_personas`
-- **`fold`** — `enabled`, `excerpt_bytes`, `freeze`, `min_fold_msgs`, `register_enabled`, `retained_msgs`
+- **`fold`** — `enabled`, `excerpt_bytes`, `freeze`, `min_fold_msgs`, `recall`, `register_enabled`, `retained_msgs`
 - **`guardrails`** — _Semantic guardrail policy._ Keys: `blast_radius`, `semantic`
 - **`identity`** — _Working-profile identity injection._ Keys: `working_profile_injection`
 - **`ingress`** — _Ingress (proxy frontends) behavior._ Keys: `audit_async`, `trusted_proxy_secret`, `usage_accounting_enabled`

--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c fold_recall.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/config.c
+++ b/src/config.c
@@ -430,6 +430,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_register_enabled = 0; /* fold §6: default-off */
    cfg->fold_freeze_enabled = 0;   /* fold §3: default-off */
    cfg->fold_freeze_tail_cap_msgs = 0;
+   cfg->fold_recall_enabled = 0; /* fold §4: default-off */
+   cfg->fold_recall_ttl_turns = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -963,10 +963,10 @@ int config_save(const config_t *cfg)
       }
    }
 
-   /* Rolling context fold (fold §1/§3/§6, only save if non-default) */
+   /* Rolling context fold (fold §1/§3/§4/§6, only save if non-default) */
    if (cfg->fold_enabled || cfg->fold_retained_msgs || cfg->fold_min_fold_msgs ||
        cfg->fold_excerpt_bytes || cfg->fold_register_enabled || cfg->fold_freeze_enabled ||
-       cfg->fold_freeze_tail_cap_msgs)
+       cfg->fold_freeze_tail_cap_msgs || cfg->fold_recall_enabled || cfg->fold_recall_ttl_turns)
    {
       cJSON *fold = cJSON_AddObjectToObject(root, "fold");
       cJSON_AddBoolToObject(fold, "enabled", cfg->fold_enabled);
@@ -984,6 +984,13 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(freeze, "enabled", cfg->fold_freeze_enabled);
          if (cfg->fold_freeze_tail_cap_msgs)
             cJSON_AddNumberToObject(freeze, "tail_cap_msgs", cfg->fold_freeze_tail_cap_msgs);
+      }
+      if (cfg->fold_recall_enabled || cfg->fold_recall_ttl_turns)
+      {
+         cJSON *recall = cJSON_AddObjectToObject(fold, "recall");
+         cJSON_AddBoolToObject(recall, "enabled", cfg->fold_recall_enabled);
+         if (cfg->fold_recall_ttl_turns)
+            cJSON_AddNumberToObject(recall, "ttl_turns", cfg->fold_recall_ttl_turns);
       }
    }
 

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -721,6 +721,16 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
       if (cJSON_IsNumber(item) && item->valuedouble > 0)
          cfg->fold_freeze_tail_cap_msgs = (int)item->valuedouble;
    }
+   cJSON *recall = cJSON_GetObjectItemCaseSensitive(fold, "recall");
+   if (cJSON_IsObject(recall))
+   {
+      item = cJSON_GetObjectItemCaseSensitive(recall, "enabled");
+      if (cJSON_IsBool(item))
+         cfg->fold_recall_enabled = cJSON_IsTrue(item) ? 1 : 0;
+      item = cJSON_GetObjectItemCaseSensitive(recall, "ttl_turns");
+      if (cJSON_IsNumber(item) && item->valuedouble > 0)
+         cfg->fold_recall_ttl_turns = (int)item->valuedouble;
+   }
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/fold_recall.c
+++ b/src/fold_recall.c
@@ -1,0 +1,121 @@
+/* fold_recall.c: page folded content back in on re-touch (fold §4, P4).
+ * See fold_recall.h. Pure: dstr + libc only. */
+#include "fold_recall.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+void fold_recall_index_init(fold_recall_index_t *ix)
+{
+   if (!ix)
+      return;
+   ix->keys = NULL;
+   ix->last_turn = NULL;
+   ix->count = 0;
+   ix->cap = 0;
+}
+
+void fold_recall_index_free(fold_recall_index_t *ix)
+{
+   if (!ix)
+      return;
+   for (size_t i = 0; i < ix->count; i++)
+      free(ix->keys[i]);
+   free(ix->keys);
+   free(ix->last_turn);
+   fold_recall_index_init(ix);
+}
+
+/* A character that can be part of a coordinate token (path / handle / id). */
+static int is_coord_char(int c)
+{
+   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '/' ||
+          c == '.' || c == '_' || c == '-' || c == ':';
+}
+
+/* Whole-token containment: `key` must appear in `hay` not extended by a coordinate
+ * char on either side, so "/x" does not match "/xyz" and "memory:42" does not match
+ * "memory:420" (avoids spurious recall hints from substring collisions). */
+static int contains_token(const char *hay, const char *key)
+{
+   size_t kl = strlen(key);
+   if (kl == 0)
+      return 0;
+   const char *p = hay;
+   while ((p = strstr(p, key)) != NULL)
+   {
+      int before_ok = (p == hay) || !is_coord_char((unsigned char)p[-1]);
+      int after_ok = !is_coord_char((unsigned char)p[kl]);
+      if (before_ok && after_ok)
+         return 1;
+      p += 1;
+   }
+   return 0;
+}
+
+static int index_has(const fold_recall_index_t *ix, const char *key)
+{
+   for (size_t i = 0; i < ix->count; i++)
+      if (strcmp(ix->keys[i], key) == 0)
+         return 1;
+   return 0;
+}
+
+void fold_recall_index_add(fold_recall_index_t *ix, const char *key)
+{
+   if (!ix || !key || !key[0])
+      return;
+   if (index_has(ix, key))
+      return;
+   if (ix->count == ix->cap)
+   {
+      size_t ncap = ix->cap ? ix->cap * 2 : 8;
+      /* Commit each realloc to ix as it succeeds (realloc frees the old block, so
+       * the old pointer must not be kept). If the second realloc fails, ix->keys
+       * is grown but ix->cap stays at the old (smaller) size — consistent and
+       * OOB-safe, since all writes are bounded by ix->cap. */
+      char **nk = realloc(ix->keys, ncap * sizeof(*nk));
+      if (!nk)
+         return;
+      ix->keys = nk;
+      int *nt = realloc(ix->last_turn, ncap * sizeof(*nt));
+      if (!nt)
+         return;
+      ix->last_turn = nt;
+      ix->cap = ncap;
+   }
+   size_t n = strlen(key);
+   char *copy = malloc(n + 1);
+   if (!copy)
+      return;
+   memcpy(copy, key, n + 1);
+   ix->keys[ix->count] = copy;
+   ix->last_turn[ix->count] = -1;
+   ix->count++;
+}
+
+size_t fold_recall_detect(fold_recall_index_t *ix, const char *turn_text, int turn, int ttl_turns,
+                          dstr_t *out)
+{
+   if (!ix || !turn_text || !turn_text[0])
+      return 0;
+   if (ttl_turns <= 0)
+      ttl_turns = FOLD_RECALL_DEFAULT_TTL_TURNS;
+
+   size_t surfaced = 0;
+   for (size_t i = 0; i < ix->count; i++)
+   {
+      const char *key = ix->keys[i];
+      if (!contains_token(turn_text, key))
+         continue; /* not re-touched this turn (whole-token match) */
+      int last = ix->last_turn[i];
+      if (last >= 0 && (turn - last) < ttl_turns)
+         continue; /* surfaced too recently — anti-thrash */
+      if (out)
+         dstr_appendf(
+             out, "  recall: %s was folded — page it back in via code_span_get/memory_get\n", key);
+      ix->last_turn[i] = turn;
+      surfaced++;
+   }
+   return surfaced;
+}

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -901,6 +901,11 @@ typedef struct config
     * tail exceeds this many messages (0 = module default). */
    int fold_freeze_enabled;
    int fold_freeze_tail_cap_msgs;
+   /* Fold recall (§4): when the agent re-touches a folded-away path/handle, emit a
+    * recall hint so the body can be paged back in on demand. Default-off.
+    * fold_recall_ttl_turns: don't re-surface the same key within this many turns. */
+   int fold_recall_enabled;
+   int fold_recall_ttl_turns;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/headers/fold_recall.h
+++ b/src/headers/fold_recall.h
@@ -1,0 +1,56 @@
+/* fold_recall.h: page folded content back in on re-touch (fold §4, P4).
+ *
+ * When the rolling fold (§1) skeletonizes old turns, the exact bodies leave the
+ * prompt but their "coordinates" (paths, handle:/memory: ids) are conserved in the
+ * Coordinate Closet (§2). If the agent later re-references one of those folded
+ * coordinates, this module detects the re-touch and emits a bounded recall hint so
+ * the agent knows the body can be paged back in on demand (via the existing
+ * code_span_get / memory_get tools). A residency TTL prevents re-surfacing the
+ * same coordinate every turn (anti-thrash). Pure, deterministic; the actual body
+ * fetch is the caller's resolver step.
+ *
+ * Default-off: the caller gates on config (fold_recall_enabled). */
+#ifndef DEC_FOLD_RECALL_H
+#define DEC_FOLD_RECALL_H 1
+
+#include "dstr.h"
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define FOLD_RECALL_DEFAULT_TTL_TURNS 4
+
+   /* Page table: the coordinates that were folded away and could be paged back in,
+    * each with the turn it was last surfaced (residency, -1 = never). */
+   typedef struct
+   {
+      char **keys;
+      int *last_turn;
+      size_t count;
+      size_t cap;
+   } fold_recall_index_t;
+
+   void fold_recall_index_init(fold_recall_index_t *ix);
+   void fold_recall_index_free(fold_recall_index_t *ix);
+
+   /* Add a recall key (path / handle:id / memory:id) if not already present.
+    * Copies the string. Empty/NULL keys are ignored. */
+   void fold_recall_index_add(fold_recall_index_t *ix, const char *key);
+
+   /* Scan `turn_text` for any indexed key whose body is worth paging back in now:
+    * the key appears in the text AND it has not been surfaced within `ttl_turns`
+    * (turn - last_turn >= ttl_turns, or never). For each such key, append a bounded
+    * recall-hint line to `out` (if non-NULL) and stamp last_turn = turn. Keys are
+    * considered in index order (deterministic). ttl_turns <= 0 -> default.
+    * Returns the number of keys surfaced. */
+   size_t fold_recall_detect(fold_recall_index_t *ix, const char *turn_text, int turn,
+                             int ttl_turns, dstr_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_FOLD_RECALL_H */

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -26,6 +26,8 @@
 #include "provider_cli_adapter.h"
 #include "config.h"
 #include "context_fold.h"
+#include "fold_recall.h"
+#include "dstr.h"
 #include "cJSON.h"
 #include <ctype.h>
 #include <fcntl.h>
@@ -212,15 +214,69 @@ static void maybe_compact_before_request(const agent_t *agent, cJSON *messages,
    }
 }
 
-/* Fold §1/§3 (P2b/P2c): build a rolling-fold view of the Anthropic message array
- * if the fold is enabled. Populates *out (zeroed on no-fold). The fold's
+/* Text of the most-recent user message (string or first text block); NULL if none. */
+static const char *newest_user_text(const cJSON *messages)
+{
+   int n = cJSON_GetArraySize((cJSON *)messages);
+   for (int i = n - 1; i >= 0; i--)
+   {
+      cJSON *m = cJSON_GetArrayItem((cJSON *)messages, i);
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(m, "role"));
+      if (!role || strcmp(role, "user") != 0)
+         continue;
+      cJSON *c = cJSON_GetObjectItem(m, "content");
+      if (cJSON_IsString(c))
+         return c->valuestring;
+      if (cJSON_IsArray(c))
+      {
+         cJSON *b;
+         cJSON_ArrayForEach(b, c)
+         {
+            const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+            if (t && strcmp(t, "text") == 0)
+               return cJSON_GetStringValue(cJSON_GetObjectItem(b, "text"));
+         }
+      }
+      return NULL;
+   }
+   return NULL;
+}
+
+/* Add the recall-worthy coordinates (paths, handle:/memory: ids) of the folded
+ * prefix messages[0..split) to the recall index for future re-touch detection. */
+static void recall_index_from_fold(const cJSON *messages, int split, fold_recall_index_t *ix)
+{
+   coord_set_t set;
+   coord_set_init(&set);
+   coord_provenance_t prov = {COORD_LANE_AGENT, -1, -1, -1};
+   for (int i = 0; i < split; i++)
+   {
+      cJSON *it = cJSON_GetArrayItem((cJSON *)messages, i);
+      if (!it)
+         continue;
+      char *s = cJSON_PrintUnformatted(it);
+      if (!s)
+         continue;
+      coord_closet_nominate(s, strlen(s), &prov, &set);
+      free(s);
+   }
+   for (size_t i = 0; i < set.count; i++)
+      if (set.items[i].kind == COORD_KIND_PATH || set.items[i].kind == COORD_KIND_HANDLE)
+         fold_recall_index_add(ix, set.items[i].value);
+   coord_set_free(&set);
+}
+
+/* Fold §1/§3/§4 (P2b/P2c/P4): build a rolling-fold view of the Anthropic message
+ * array if the fold is enabled. Populates *out (zeroed on no-fold). The fold's
  * Coordinate Closet is rendered during this call, so the config's denylist (a
  * pointer into the local config_t) only needs to be valid here — out holds owned
  * cJSON that the caller frees with fold_result_free AFTER the request is
- * serialized. `freeze` (may be NULL) is the per-run fold-freeze state that pins
- * the boundary across turns; it is honored only when fold_freeze_enabled.
- * Returns 1 if a fold view was produced, 0 otherwise. */
-static int build_fold_view(const cJSON *messages, fold_freeze_t *freeze, fold_result_t *out)
+ * serialized. `freeze` (may be NULL) is the per-run fold-freeze state honored only
+ * when fold_freeze_enabled; `recall` (may be NULL) is the per-run recall index for
+ * §4 re-touch hints, honored only when fold_recall_enabled. `turn` is the current
+ * turn index (for recall residency). Returns 1 if a fold view was produced. */
+static int build_fold_view(const cJSON *messages, fold_freeze_t *freeze,
+                           fold_recall_index_t *recall, int turn, fold_result_t *out)
 {
    memset(out, 0, sizeof(*out));
    config_t cfg;
@@ -245,9 +301,40 @@ static int build_fold_view(const cJSON *messages, fold_freeze_t *freeze, fold_re
       fz = freeze;
    }
    context_fold_view(messages, &fc, fz, out);
-   if (out->folded)
-      aimee_log(LOG_DEBUG, "fold", "folded=%d retained=%d reused_boundary=%d epochs=%d",
-                out->folded_msgs, out->retained_msgs, out->reused_boundary, fz ? fz->epochs : 0);
+   if (!out->folded)
+      return 0;
+   aimee_log(LOG_DEBUG, "fold", "folded=%d retained=%d reused_boundary=%d epochs=%d",
+             out->folded_msgs, out->retained_msgs, out->reused_boundary, fz ? fz->epochs : 0);
+
+   /* §4 recall: detect re-touch of a previously-folded coordinate in this turn's
+    * newest user message and surface a hint in the fold preamble; then index this
+    * fold's coordinates for future turns. Detection precedes indexing so a
+    * just-folded key does not trivially match the same turn. */
+   if (cfg.fold_recall_enabled && recall)
+   {
+      const char *uq = newest_user_text(messages);
+      dstr_t hints;
+      dstr_init(&hints);
+      size_t hit = uq ? fold_recall_detect(recall, uq, turn, cfg.fold_recall_ttl_turns, &hints) : 0;
+      if (hit && out->messages)
+      {
+         cJSON *m0 = cJSON_GetArrayItem(out->messages, 0);
+         const char *body = m0 ? cJSON_GetStringValue(cJSON_GetObjectItem(m0, "content")) : NULL;
+         if (m0 && body)
+         {
+            dstr_t merged;
+            dstr_init(&merged);
+            dstr_appendf(&merged, "[fold recall — re-touched coordinates]\n%s\n%s",
+                         dstr_cstr(&hints), body);
+            cJSON *ns = cJSON_CreateString(dstr_cstr(&merged)); /* copies; merged freed below */
+            if (ns) /* on OOM leave the original content intact rather than nulling it */
+               cJSON_ReplaceItemInObjectCaseSensitive(m0, "content", ns);
+            dstr_free(&merged);
+         }
+      }
+      dstr_free(&hints);
+      recall_index_from_fold(messages, out->folded_msgs, recall);
+   }
    return out->folded;
 }
 
@@ -579,6 +666,10 @@ native_provider_http:
     * fold_freeze_enabled; ignored otherwise. */
    fold_freeze_t agent_fold_freeze;
    memset(&agent_fold_freeze, 0, sizeof(agent_fold_freeze));
+   /* §4 fold recall: per-run page table of folded-away coordinates, for re-touch
+    * hints across turns. Honored only when fold_recall_enabled. */
+   fold_recall_index_t agent_fold_recall;
+   fold_recall_index_init(&agent_fold_recall);
    int api_call_count = 0;    /* cumulative provider API calls; published via heartbeat */
    int write_calls_total = 0; /* cumulative write/edit tool calls; used by write_enforce */
    int final_instruction_added = 0;
@@ -744,7 +835,7 @@ native_provider_http:
       {
          /* Fold first so payload-rewrite tracking and the request both observe the
           * actually-sent (possibly folded) message array. */
-         build_fold_view(messages, &agent_fold_freeze, &fold_view);
+         build_fold_view(messages, &agent_fold_freeze, &agent_fold_recall, turn, &fold_view);
          cJSON *anth_msgs = fold_view.folded ? fold_view.messages : messages;
          track_anthropic_payload_rewrite(driver, &fb_agent, anth_msgs, sys);
          req = agent_build_request_anthropic(&fb_agent, anth_msgs, active_tools, sys, tok,
@@ -847,7 +938,7 @@ native_provider_http:
             fb_req = agent_build_request_responses(&fb_agent, messages, active_tools, sys);
          else if (anthropic)
          {
-            build_fold_view(messages, &agent_fold_freeze, &fb_fold_view);
+            build_fold_view(messages, &agent_fold_freeze, NULL, turn, &fb_fold_view);
             cJSON *fb_anth_msgs = fb_fold_view.folded ? fb_fold_view.messages : messages;
             track_anthropic_payload_rewrite(driver, &fb_agent, fb_anth_msgs, sys);
             fb_req = agent_build_request_anthropic(&fb_agent, fb_anth_msgs, active_tools, sys, tok,
@@ -1587,6 +1678,8 @@ native_provider_http:
          db1_agent_job_heartbeat_ext(durable_job_id, "", api_call_count);
       }
    }
+
+   fold_recall_index_free(&agent_fold_recall);
 
    /* If we exhausted turns without a final response, set a clear error */
    if (!out->success && !out->response && turn >= max_t)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -17,7 +17,7 @@ TEST_RUN_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/n
 TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o $(OBJDIR)/config_fields.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
-                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
+                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \
@@ -213,6 +213,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-fold-budget \
                $(TESTPREFIX)/unit-test-context-fold \
                $(TESTPREFIX)/unit-test-fold-register \
+               $(TESTPREFIX)/unit-test-fold-recall \
                $(TESTPREFIX)/unit-test-token-audit \
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
@@ -1987,6 +1988,10 @@ $(TESTPREFIX)/unit-test-context-fold: $(OBJDIR)/tests/test_context_fold.o $(OBJD
 
 $(TESTPREFIX)/unit-test-fold-register: $(OBJDIR)/tests/test_fold_register.o $(OBJDIR)/fold_register.o \
                                   $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-fold-recall: $(OBJDIR)/tests/test_fold_recall.o $(OBJDIR)/fold_recall.o \
+                                  $(OBJDIR)/dstr.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-compact-prune: $(OBJDIR)/tests/test_compact_prune.o \

--- a/src/tests/test_fold_recall.c
+++ b/src/tests/test_fold_recall.c
@@ -1,0 +1,116 @@
+/* test_fold_recall.c: unit tests for fold recall (§4, P4). */
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include "../headers/dstr.h"
+#include "../headers/fold_recall.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static int has(const char *hay, const char *needle)
+{
+   return strstr(hay, needle) != NULL;
+}
+
+static void test_add_dedup(void)
+{
+   fold_recall_index_t ix;
+   fold_recall_index_init(&ix);
+   fold_recall_index_add(&ix, "/src/foo.c");
+   fold_recall_index_add(&ix, "/src/foo.c"); /* dup */
+   fold_recall_index_add(&ix, "memory:abc");
+   fold_recall_index_add(&ix, "");   /* ignored */
+   fold_recall_index_add(&ix, NULL); /* ignored */
+   assert(ix.count == 2);
+   fold_recall_index_free(&ix);
+   PASS("add_dedup");
+}
+
+static void test_detect_and_ttl(void)
+{
+   fold_recall_index_t ix;
+   fold_recall_index_init(&ix);
+   fold_recall_index_add(&ix, "/src/foo.c");
+   fold_recall_index_add(&ix, "handle:xyz");
+
+   /* turn 1: re-touch foo.c -> surfaced */
+   dstr_t o1;
+   dstr_init(&o1);
+   size_t n1 = fold_recall_detect(&ix, "let me look at /src/foo.c again", 1, 4, &o1);
+   assert(n1 == 1);
+   assert(has(dstr_cstr(&o1), "/src/foo.c"));
+   assert(has(dstr_cstr(&o1), "recall:"));
+   dstr_free(&o1);
+
+   /* turn 2: re-touch foo.c again within TTL(4) -> NOT surfaced (anti-thrash) */
+   dstr_t o2;
+   dstr_init(&o2);
+   size_t n2 = fold_recall_detect(&ix, "still in /src/foo.c", 2, 4, &o2);
+   assert(n2 == 0);
+   dstr_free(&o2);
+
+   /* turn 6: past TTL -> surfaced again */
+   dstr_t o3;
+   dstr_init(&o3);
+   size_t n3 = fold_recall_detect(&ix, "back to /src/foo.c", 6, 4, &o3);
+   assert(n3 == 1);
+   dstr_free(&o3);
+
+   /* a turn touching neither key surfaces nothing */
+   dstr_t o4;
+   dstr_init(&o4);
+   size_t n4 = fold_recall_detect(&ix, "unrelated chatter", 7, 4, &o4);
+   assert(n4 == 0);
+   dstr_free(&o4);
+
+   /* handle:xyz first touch surfaces */
+   dstr_t o5;
+   dstr_init(&o5);
+   size_t n5 = fold_recall_detect(&ix, "see handle:xyz for details", 8, 4, &o5);
+   assert(n5 == 1 && has(dstr_cstr(&o5), "handle:xyz"));
+   dstr_free(&o5);
+
+   fold_recall_index_free(&ix);
+   PASS("detect_and_ttl");
+}
+
+static void test_empty_and_null(void)
+{
+   fold_recall_index_t ix;
+   fold_recall_index_init(&ix);
+   fold_recall_index_add(&ix, "/x");
+   assert(fold_recall_detect(&ix, NULL, 1, 4, NULL) == 0);
+   assert(fold_recall_detect(&ix, "", 1, 4, NULL) == 0);
+   /* detect with NULL out still updates residency + counts */
+   assert(fold_recall_detect(&ix, "touch /x here", 1, 4, NULL) == 1);
+   assert(fold_recall_detect(&ix, "touch /x here", 2, 4, NULL) == 0); /* TTL */
+   fold_recall_index_free(&ix);
+   PASS("empty_and_null");
+}
+
+static void test_whole_token_match(void)
+{
+   /* substring collisions must NOT trigger recall: "/x" not in "/xyz",
+    * "memory:42" not in "memory:420" — but exact tokens do match. */
+   fold_recall_index_t ix;
+   fold_recall_index_init(&ix);
+   fold_recall_index_add(&ix, "/x");
+   fold_recall_index_add(&ix, "memory:42");
+   assert(fold_recall_detect(&ix, "editing /xyz now", 1, 4, NULL) == 0);
+   assert(fold_recall_detect(&ix, "see memory:420 later", 1, 4, NULL) == 0);
+   assert(fold_recall_detect(&ix, "open /x please", 1, 4, NULL) == 1); /* space-bounded token */
+   assert(fold_recall_detect(&ix, "recall memory:42 now", 2, 4, NULL) == 1); /* space-bounded */
+   fold_recall_index_free(&ix);
+   PASS("whole_token_match");
+}
+
+int main(void)
+{
+   printf("fold_recall tests:\n");
+   test_add_dedup();
+   test_detect_and_ttl();
+   test_empty_and_null();
+   test_whole_token_match();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

§4 fold recall: when the agent re-references a coordinate that was folded away, surface a hint so the body can be paged back in (via the existing `code_span_get`/`memory_get` tools).

- `src/fold_recall.{c,h}` — a per-run **page table** of folded-away coordinates (paths, `handle:`/`memory:` ids) + a **re-touch detector** with a **residency TTL** (anti-thrash: a key isn't re-surfaced within `ttl_turns`). Pure, deterministic.
- **Live wiring** (`posix/agent_runtime.c`, default-off): a per-run `fold_recall_index_t` threads across the turn loop. On a folding turn, `build_fold_view` detects re-touch of prior-folded coordinates in the newest user message, injects the hints into the fold preamble, then indexes this fold's path/handle coordinates for future turns. Detection precedes indexing (a just-folded key can't trivially match the same turn).
- config `fold.recall.{enabled,ttl_turns}` (default-off); docs regenerated.
- `test_fold_recall`: add/dedup, detect, TTL anti-thrash, NULL/empty.

## Scope
The hint points the agent at the on-demand recovery tools rather than auto-fetching bodies inline (those resolvers need project/kb context and are the agent's existing surface). Recall detection runs on folding turns (the common case in long sessions). Default-off ⇒ no behaviour change.

## Local gates
`make lint` · server+kb build · `make -j unit-tests` (full suite) — all green.