### PR TITLE
feat(webchat-git): clone token via memfd (#3A.2) + leak-test no-environ invariant (#6)

### DIFF
--- a/src/server/git_project.c
+++ b/src/server/git_project.c
@@ -109,9 +109,11 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
     * already-stored vault token > the principal's own vaulted token > the
     * server's own identity (App token / AIMEE_FORGE_TOKEN); plus the principal's
     * vaulted SSH agent. The token crosses only via GIT_ASKPASS, never argv. */
-   /* TODO(#3A.2): migrate clone to the memfd fd-mode (out_token_fd) so the token
-    * is not in the clone child's environment; env mode (GH_TOKEN) for now. */
-   char **envp = git_cred_inject_build_env_for_repo(principal, url, NULL, token, environ, NULL);
+   /* FD mode (#3A.2): the HTTPS token rides an inherited memfd (token_fd), so the
+    * clone child's /proc/<pid>/environ never carries it (parity with run_git). */
+   int token_fd = -1;
+   char **envp =
+       git_cred_inject_build_env_for_repo(principal, url, NULL, token, environ, &token_fd);
    /* Clone over HTTPS, never SSH: our credential model is per-host HTTPS tokens
     * (+ OAuth), and a non-interactive server has no seeded known_hosts, so an
     * ssh://, git@host:path, or git:// URL would die on "Host key verification
@@ -121,7 +123,11 @@ int git_project_clone(const char *principal, const char *url, const char *name, 
    const char *clone_url = clone_url_norm ? clone_url_norm : url;
    const char *argv[] = {"git", "clone", "--", clone_url, dest, NULL};
    char *out = NULL;
-   int rc = safe_exec_capture_env(argv, envp ? envp : environ, &out, 1 << 16);
+   int rc = safe_exec_capture_cwd_env_fd_timeout(argv, NULL, envp ? envp : environ, &out, 1 << 16,
+                                                 300000, token_fd,
+                                                 token_fd >= 0 ? GIT_CRED_TOKEN_TARGET_FD : -1);
+   if (token_fd >= 0)
+      close(token_fd);
    free(clone_url_norm);
    if (envp)
       git_cred_inject_free_env(envp);

--- a/src/tests/test_webchat_git_leak.c
+++ b/src/tests/test_webchat_git_leak.c
@@ -134,8 +134,24 @@ int main(void)
    for (int i = 0; env[i]; i++)
       if (strncmp(env[i], "GH_TOKEN=", 9) == 0 && strcmp(env[i] + 9, CANARY) == 0)
          has = 1;
-   assert(has); /* the env carries it (in memory only) */
+   assert(has); /* legacy env mode (editor path): the env carries it (in memory only) */
    git_cred_inject_free_env(env);
+
+   /* FD mode (the API git ops + clone): the token must NOT be in the env at all —
+    * it rides an inherited memfd, so the canary appears in NO env string and the
+    * env advertises only the fd number. This is the binding "not in
+    * /proc/<pid>/environ" invariant at the assembly layer (the exec-time proof is
+    * in test_git_cred_inject's safe_exec fd test). */
+   int tfd = -1;
+   char **fenv = git_cred_inject_build_env_for_repo(alice, NULL, NULL, NULL, parent, &tfd);
+   assert(fenv != NULL && tfd >= 0);
+   for (int i = 0; fenv[i]; i++)
+   {
+      assert(strncmp(fenv[i], "GH_TOKEN=", 9) != 0); /* no GH_TOKEN in fd mode */
+      assert(strstr(fenv[i], CANARY) == NULL);       /* canary nowhere in the env */
+   }
+   assert(close(tfd) == 0); /* the memfd is a real, open fd we own + release */
+   git_cred_inject_free_env(fenv);
 
    /* Cross-principal denial: bob has no token and cannot read alice's. */
    char btok[64];


### PR DESCRIPTION
Extends the FD-mode token delivery (#3A) to the **clone** path and strengthens the leak test.

- **`git_project` clone** now uses the memfd FD mode (`safe_exec_capture_cwd_env_fd_timeout` with an inherited token fd) instead of `GH_TOKEN`-in-env — so the clone child's `/proc/<pid>/environ` no longer carries the token, matching `run_git`. (A 300s timeout also replaces the previous unbounded clone exec.)
- **`test_webchat_git_leak`**: in addition to the existing "canary plaintext in no file under `AIMEE_HOME`" + cross-principal denial, now asserts the **FD-mode env carries no `GH_TOKEN`** and the canary appears in **no env string** — the assembly-layer form of "not in `/proc/<pid>/environ`" (the exec-time proof lives in `test_git_cred_inject`'s `safe_exec` fd test).

The mechanism itself was security-reviewed + merged in #3A; this reuses it for clone. The remaining env-mode path is the long-lived **editor** (`webuser_editor`), deferred to the extension-host work (#4) where node's fd-inheritance can be validated on a live code-server. Real-push + SIGKILL-during-push is a deploy-env check (the memfd is anonymous → a SIGKILL leaves no orphan by construction).

Tests: `unit-test-git-project` + `unit-test-webchat-git-leak` green. Roundtable run; summary to follow.