### PR TITLE
feat(fold): P5 sealed episodes + task rail — portable plan/episode FSMs

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c fold_recall.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/episode_seal.c
+++ b/src/episode_seal.c
@@ -1,0 +1,165 @@
+/* episode_seal.c: sealed work episode (fold §5, P5). See episode_seal.h. */
+#include "episode_seal.h"
+
+#include "cJSON.h"
+#include <stdlib.h>
+#include <string.h>
+
+static char *dup_str(const char *s)
+{
+   if (!s)
+      return NULL;
+   size_t n = strlen(s);
+   char *c = malloc(n + 1);
+   if (c)
+      memcpy(c, s, n + 1);
+   return c;
+}
+
+void episode_seal_init(episode_seal_t *s)
+{
+   if (!s)
+      return;
+   s->conclusion = NULL;
+   s->files = NULL;
+   s->count = 0;
+   s->cap = 0;
+}
+
+void episode_seal_free(episode_seal_t *s)
+{
+   if (!s)
+      return;
+   free(s->conclusion);
+   for (size_t i = 0; i < s->count; i++)
+      free(s->files[i]);
+   free(s->files);
+   episode_seal_init(s);
+}
+
+int episode_seal_set_conclusion(episode_seal_t *s, const char *text)
+{
+   if (!s)
+      return -1;
+   char *c = dup_str(text ? text : "");
+   if (!c)
+      return -1;
+   free(s->conclusion);
+   s->conclusion = c;
+   return 0;
+}
+
+int episode_seal_add_file(episode_seal_t *s, const char *path)
+{
+   if (!s)
+      return -1;
+   if (!path || !path[0])
+      return 0; /* NULL/empty ignored (not an error) */
+   for (size_t i = 0; i < s->count; i++)
+      if (strcmp(s->files[i], path) == 0)
+         return 0; /* dedup */
+   if (s->count == s->cap)
+   {
+      size_t ncap = s->cap ? s->cap * 2 : 8;
+      char **nf = realloc(s->files, ncap * sizeof(*nf));
+      if (!nf)
+         return -1;
+      s->files = nf;
+      s->cap = ncap;
+   }
+   char *c = dup_str(path);
+   if (!c)
+      return -1;
+   s->files[s->count++] = c;
+   return 0;
+}
+
+int episode_seal_touches(const episode_seal_t *s, const char *path)
+{
+   if (!s || !path)
+      return 0;
+   for (size_t i = 0; i < s->count; i++)
+      if (strcmp(s->files[i], path) == 0)
+         return 1;
+   return 0;
+}
+
+/* All-or-nothing: any cJSON allocation failure deletes root and returns NULL. */
+char *episode_seal_serialize(const episode_seal_t *s)
+{
+   if (!s)
+      return NULL;
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return NULL;
+   if (!cJSON_AddStringToObject(root, "conclusion", s->conclusion ? s->conclusion : ""))
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   cJSON *files = cJSON_AddArrayToObject(root, "files");
+   if (!files)
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   for (size_t i = 0; i < s->count; i++)
+   {
+      cJSON *f = cJSON_CreateString(s->files[i]);
+      if (!f)
+      {
+         cJSON_Delete(root);
+         return NULL;
+      }
+      cJSON_AddItemToArray(files, f);
+   }
+   char *out = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   return out;
+}
+
+/* Validate + build into a temporary; swap into *s only on complete success, so
+ * malformed/partial JSON or OOM never destroys the caller's existing seal. */
+int episode_seal_parse(episode_seal_t *s, const char *json)
+{
+   if (!s || !json)
+      return -1;
+   cJSON *root = cJSON_Parse(json);
+   if (!root || !cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON *files = cJSON_GetObjectItem(root, "files");
+   if (files && !cJSON_IsArray(files))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+
+   episode_seal_t tmp;
+   episode_seal_init(&tmp);
+   if (episode_seal_set_conclusion(
+           &tmp, cJSON_GetStringValue(cJSON_GetObjectItem(root, "conclusion"))) != 0)
+   {
+      episode_seal_free(&tmp);
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON *f;
+   cJSON_ArrayForEach(f, files)
+   {
+      if (!cJSON_IsString(f))
+         continue;
+      if (episode_seal_add_file(&tmp, f->valuestring) != 0)
+      {
+         episode_seal_free(&tmp);
+         cJSON_Delete(root);
+         return -1; /* OOM -> caller's seal untouched */
+      }
+   }
+   cJSON_Delete(root);
+   episode_seal_free(s);
+   *s = tmp; /* swap in only on complete success */
+   return 0;
+}

--- a/src/headers/episode_seal.h
+++ b/src/headers/episode_seal.h
@@ -1,0 +1,60 @@
+/* episode_seal.h: sealed work episode — file inventory + conclusion (fold §5, P5).
+ *
+ * Unlike the existing narrative episode cards (KIND_EPISODE), a *sealed* episode
+ * is a replayable checkpoint: the set of files touched plus the agent's
+ * conclusion, so a later session that re-touches a member file can auto-recall
+ * what was learned. Stored as a distinct unit_type (EPISODE_SEAL_UNIT_TYPE) on the
+ * existing memory_units row — no schema column, no migration. Pure: cJSON only.
+ *
+ * This slice ships the seal record + serialize/parse + the file-touch matcher
+ * (the auto-recall predicate). The DB2 store/query + cross-session recall wiring
+ * is the storage-binding follow-up. */
+#ifndef DEC_EPISODE_SEAL_H
+#define DEC_EPISODE_SEAL_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/* Distinct memory_units.unit_type value for sealed episodes (vs the narrative
+ * "episode_card"); avoids overloading KIND_EPISODE. */
+#define EPISODE_SEAL_UNIT_TYPE "episode_seal"
+
+   typedef struct
+   {
+      char *conclusion; /* what was concluded/settled */
+      char **files;     /* file inventory (paths touched) */
+      size_t count;
+      size_t cap;
+   } episode_seal_t;
+
+   void episode_seal_init(episode_seal_t *s);
+   void episode_seal_free(episode_seal_t *s);
+
+   /* Set/replace the conclusion text. Returns 0, -1 on alloc failure. */
+   int episode_seal_set_conclusion(episode_seal_t *s, const char *text);
+
+   /* Add a file path to the inventory (dedup, exact). NULL/empty is ignored (a
+    * no-op success). Returns 0 on success (incl. ignored/dup), -1 on alloc failure. */
+   int episode_seal_add_file(episode_seal_t *s, const char *path);
+
+   /* Auto-recall predicate: 1 if `path` is in the seal's file inventory (exact
+    * match), i.e. a later turn touching this file should recall this episode. */
+   int episode_seal_touches(const episode_seal_t *s, const char *path);
+
+   /* Serialize to a freshly malloc'd JSON string (caller frees). Deterministic. */
+   char *episode_seal_serialize(const episode_seal_t *s);
+
+   /* Restore from JSON. Validates and builds into a temporary, swapping into *s
+    * only on complete success — so on -1 (malformed JSON, non-object root,
+    * non-array files, or OOM) the caller's existing seal is left UNCHANGED. */
+   int episode_seal_parse(episode_seal_t *s, const char *json);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_EPISODE_SEAL_H */

--- a/src/headers/task_rail.h
+++ b/src/headers/task_rail.h
@@ -1,0 +1,75 @@
+/* task_rail.h: portable plan state machine (fold §8, P5).
+ *
+ * A small, dependency-light execution spine that lives OUTSIDE the prompt: the
+ * agent's plan as a locked list of steps with state + evidence, serializable to
+ * JSON so it survives folds, epoch rebirths, and session boundaries (persist to
+ * DB1 checkpoints.snapshot). Pure: cJSON only, no DB, no clock. Deterministic
+ * serialization (stable key/step order). */
+#ifndef DEC_TASK_RAIL_H
+#define DEC_TASK_RAIL_H 1
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   typedef enum
+   {
+      TASK_STEP_PENDING = 0,
+      TASK_STEP_RESERVED, /* claimed / in flight */
+      TASK_STEP_DONE
+   } task_step_state_t;
+
+   typedef struct
+   {
+      char *title;
+      char *evidence; /* set when DONE (handle/note); may be NULL */
+      task_step_state_t state;
+   } task_step_t;
+
+   typedef struct
+   {
+      char *objective;
+      int locked; /* 1 once started — the step list is fixed */
+      task_step_t *steps;
+      size_t count;
+      size_t cap;
+   } task_rail_t;
+
+   void task_rail_init(task_rail_t *r);
+   void task_rail_free(task_rail_t *r);
+
+   /* Start (and lock) a rail with an objective and `n` step titles. Replaces any
+    * prior state. Returns 0 on success, -1 on bad args. */
+   int task_rail_start(task_rail_t *r, const char *objective, const char *const *titles, size_t n);
+
+   /* Reserve a step (PENDING -> RESERVED). Returns 0, -1 on bad index/state. */
+   int task_rail_reserve(task_rail_t *r, size_t idx);
+
+   /* Acknowledge a step done (PENDING or RESERVED -> DONE) with optional evidence.
+    * Returns 0; -1 on bad index or if duplicating evidence fails (step unchanged). */
+   int task_rail_ack(task_rail_t *r, size_t idx, const char *evidence);
+
+   /* Index of the first not-DONE step — i.e. the next unfinished step, which
+    * INCLUDES a RESERVED (in-flight) step — or -1 if all done. */
+   long task_rail_next(const task_rail_t *r);
+
+   /* Count of DONE steps. */
+   size_t task_rail_done_count(const task_rail_t *r);
+
+   /* Serialize to a freshly malloc'd JSON string (caller frees). Deterministic. */
+   char *task_rail_serialize(const task_rail_t *r);
+
+   /* Restore from JSON. Validates and builds into a temporary, swapping into *r
+    * only on complete success — so on -1 (malformed JSON, non-object root,
+    * non-array steps, or OOM) the caller's existing rail is left UNCHANGED. An
+    * out-of-range step state normalizes to PENDING. Returns 0 / -1. */
+   int task_rail_restore(task_rail_t *r, const char *json);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_TASK_RAIL_H */

--- a/src/task_rail.c
+++ b/src/task_rail.c
@@ -1,0 +1,245 @@
+/* task_rail.c: portable plan state machine (fold §8, P5). See task_rail.h. */
+#include "task_rail.h"
+
+#include "cJSON.h"
+#include <stdlib.h>
+#include <string.h>
+
+static char *dup_str(const char *s)
+{
+   if (!s)
+      return NULL;
+   size_t n = strlen(s);
+   char *c = malloc(n + 1);
+   if (c)
+      memcpy(c, s, n + 1);
+   return c;
+}
+
+void task_rail_init(task_rail_t *r)
+{
+   if (!r)
+      return;
+   r->objective = NULL;
+   r->locked = 0;
+   r->steps = NULL;
+   r->count = 0;
+   r->cap = 0;
+}
+
+void task_rail_free(task_rail_t *r)
+{
+   if (!r)
+      return;
+   free(r->objective);
+   for (size_t i = 0; i < r->count; i++)
+   {
+      free(r->steps[i].title);
+      free(r->steps[i].evidence);
+   }
+   free(r->steps);
+   task_rail_init(r);
+}
+
+static int rail_push(task_rail_t *r, const char *title, task_step_state_t st, const char *ev)
+{
+   /* Allocate into temporaries and publish the slot only after every required
+    * allocation succeeds, so a partial OOM neither leaks nor leaves a NULL-title
+    * slot behind. */
+   char *t = dup_str(title ? title : "");
+   if (!t)
+      return -1;
+   char *e = NULL;
+   if (ev)
+   {
+      e = dup_str(ev);
+      if (!e)
+      {
+         free(t);
+         return -1;
+      }
+   }
+   if (r->count == r->cap)
+   {
+      size_t ncap = r->cap ? r->cap * 2 : 8;
+      task_step_t *ns = realloc(r->steps, ncap * sizeof(*ns));
+      if (!ns)
+      {
+         free(t);
+         free(e);
+         return -1;
+      }
+      r->steps = ns;
+      r->cap = ncap;
+   }
+   task_step_t *s = &r->steps[r->count];
+   s->title = t;
+   s->evidence = e;
+   s->state = st;
+   r->count++;
+   return 0;
+}
+
+int task_rail_start(task_rail_t *r, const char *objective, const char *const *titles, size_t n)
+{
+   if (!r || (n > 0 && !titles))
+      return -1;
+   task_rail_free(r);
+   task_rail_init(r);
+   r->objective = dup_str(objective ? objective : "");
+   if (!r->objective)
+   {
+      task_rail_free(r);
+      return -1; /* -1 leaves the rail empty/initial */
+   }
+   for (size_t i = 0; i < n; i++)
+      if (rail_push(r, titles[i], TASK_STEP_PENDING, NULL) != 0)
+      {
+         task_rail_free(r);
+         return -1;
+      }
+   r->locked = 1;
+   return 0;
+}
+
+int task_rail_reserve(task_rail_t *r, size_t idx)
+{
+   if (!r || idx >= r->count || r->steps[idx].state != TASK_STEP_PENDING)
+      return -1;
+   r->steps[idx].state = TASK_STEP_RESERVED;
+   return 0;
+}
+
+int task_rail_ack(task_rail_t *r, size_t idx, const char *evidence)
+{
+   if (!r || idx >= r->count)
+      return -1;
+   /* Duplicate replacement evidence FIRST; on OOM leave the step unchanged. */
+   if (evidence)
+   {
+      char *e = dup_str(evidence);
+      if (!e)
+         return -1;
+      free(r->steps[idx].evidence);
+      r->steps[idx].evidence = e;
+   }
+   r->steps[idx].state = TASK_STEP_DONE; /* PENDING or RESERVED -> DONE (see header) */
+   return 0;
+}
+
+long task_rail_next(const task_rail_t *r)
+{
+   if (!r)
+      return -1;
+   for (size_t i = 0; i < r->count; i++)
+      if (r->steps[i].state != TASK_STEP_DONE)
+         return (long)i;
+   return -1;
+}
+
+size_t task_rail_done_count(const task_rail_t *r)
+{
+   size_t d = 0;
+   if (r)
+      for (size_t i = 0; i < r->count; i++)
+         if (r->steps[i].state == TASK_STEP_DONE)
+            d++;
+   return d;
+}
+
+/* All-or-nothing: any cJSON allocation failure deletes root and returns NULL, so a
+ * successful return is always a complete serialization (round-trip idempotent). */
+char *task_rail_serialize(const task_rail_t *r)
+{
+   if (!r)
+      return NULL;
+   cJSON *root = cJSON_CreateObject();
+   if (!root)
+      return NULL;
+   if (!cJSON_AddStringToObject(root, "objective", r->objective ? r->objective : "") ||
+       !cJSON_AddBoolToObject(root, "locked", r->locked))
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   cJSON *steps = cJSON_AddArrayToObject(root, "steps");
+   if (!steps)
+   {
+      cJSON_Delete(root);
+      return NULL;
+   }
+   for (size_t i = 0; i < r->count; i++)
+   {
+      cJSON *s = cJSON_CreateObject();
+      if (!s || !cJSON_AddStringToObject(s, "title", r->steps[i].title ? r->steps[i].title : "") ||
+          !cJSON_AddNumberToObject(s, "state", (double)r->steps[i].state) ||
+          (r->steps[i].evidence && !cJSON_AddStringToObject(s, "evidence", r->steps[i].evidence)))
+      {
+         cJSON_Delete(s);
+         cJSON_Delete(root);
+         return NULL;
+      }
+      cJSON_AddItemToArray(steps, s);
+   }
+   char *out = cJSON_PrintUnformatted(root);
+   cJSON_Delete(root);
+   return out;
+}
+
+/* Validate + build into a temporary rail; only swap into *r on complete success,
+ * so malformed/partial JSON or OOM never destroys the caller's existing state. */
+int task_rail_restore(task_rail_t *r, const char *json)
+{
+   if (!r || !json)
+      return -1;
+   cJSON *root = cJSON_Parse(json);
+   if (!root || !cJSON_IsObject(root))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   cJSON *steps = cJSON_GetObjectItem(root, "steps");
+   if (steps && !cJSON_IsArray(steps))
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+
+   task_rail_t tmp;
+   task_rail_init(&tmp);
+   const char *obj = cJSON_GetStringValue(cJSON_GetObjectItem(root, "objective"));
+   tmp.objective = dup_str(obj ? obj : "");
+   if (!tmp.objective)
+   {
+      cJSON_Delete(root);
+      return -1;
+   }
+   tmp.locked = cJSON_IsTrue(cJSON_GetObjectItem(root, "locked")) ? 1 : 0;
+
+   cJSON *s;
+   cJSON_ArrayForEach(s, steps)
+   {
+      if (!cJSON_IsObject(s))
+         continue;
+      const char *title = cJSON_GetStringValue(cJSON_GetObjectItem(s, "title"));
+      const char *ev = cJSON_GetStringValue(cJSON_GetObjectItem(s, "evidence"));
+      cJSON *st = cJSON_GetObjectItem(s, "state");
+      task_step_state_t state = TASK_STEP_PENDING; /* unknown/out-of-range -> pending */
+      if (cJSON_IsNumber(st))
+      {
+         int v = (int)st->valuedouble;
+         if (v == TASK_STEP_RESERVED || v == TASK_STEP_DONE)
+            state = (task_step_state_t)v;
+      }
+      if (rail_push(&tmp, title ? title : "", state, ev) != 0)
+      {
+         task_rail_free(&tmp);
+         cJSON_Delete(root);
+         return -1; /* OOM -> caller's rail untouched */
+      }
+   }
+   cJSON_Delete(root);
+   task_rail_free(r);
+   *r = tmp; /* swap in only on complete success */
+   return 0;
+}

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -214,6 +214,8 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-context-fold \
                $(TESTPREFIX)/unit-test-fold-register \
                $(TESTPREFIX)/unit-test-fold-recall \
+               $(TESTPREFIX)/unit-test-task-rail \
+               $(TESTPREFIX)/unit-test-episode-seal \
                $(TESTPREFIX)/unit-test-token-audit \
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
@@ -1992,6 +1994,14 @@ $(TESTPREFIX)/unit-test-fold-register: $(OBJDIR)/tests/test_fold_register.o $(OB
 
 $(TESTPREFIX)/unit-test-fold-recall: $(OBJDIR)/tests/test_fold_recall.o $(OBJDIR)/fold_recall.o \
                                   $(OBJDIR)/dstr.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-task-rail: $(OBJDIR)/tests/test_task_rail.o $(OBJDIR)/task_rail.o \
+                                  $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-episode-seal: $(OBJDIR)/tests/test_episode_seal.o $(OBJDIR)/episode_seal.o \
+                                  $(OBJDIR)/cJSON.o $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-compact-prune: $(OBJDIR)/tests/test_compact_prune.o \

--- a/src/tests/test_episode_seal.c
+++ b/src/tests/test_episode_seal.c
@@ -1,0 +1,77 @@
+/* test_episode_seal.c: unit tests for sealed episodes (fold §5, P5). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../headers/episode_seal.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static void test_inventory_and_touch(void)
+{
+   episode_seal_t s;
+   episode_seal_init(&s);
+   episode_seal_set_conclusion(&s, "fixed the DNAT reconcile loop");
+   episode_seal_add_file(&s, "src/db2/code_index.c");
+   episode_seal_add_file(&s, "src/db2/code_index.c"); /* dedup */
+   episode_seal_add_file(&s, "src/headers/code_span.h");
+   episode_seal_add_file(&s, ""); /* ignored */
+   assert(s.count == 2);
+
+   /* auto-recall predicate */
+   assert(episode_seal_touches(&s, "src/db2/code_index.c") == 1);
+   assert(episode_seal_touches(&s, "src/headers/code_span.h") == 1);
+   assert(episode_seal_touches(&s, "src/unrelated.c") == 0);
+
+   episode_seal_free(&s);
+   PASS("inventory_and_touch");
+}
+
+static void test_serialize_parse_roundtrip(void)
+{
+   episode_seal_t s;
+   episode_seal_init(&s);
+   episode_seal_set_conclusion(&s, "concluded: cache stays warm with freeze");
+   episode_seal_add_file(&s, "src/context_fold.c");
+   episode_seal_add_file(&s, "src/payload_rewrite.c");
+
+   char *j1 = episode_seal_serialize(&s);
+   assert(j1);
+
+   episode_seal_t s2;
+   episode_seal_init(&s2);
+   assert(episode_seal_parse(&s2, j1) == 0);
+   assert(strcmp(s2.conclusion, "concluded: cache stays warm with freeze") == 0);
+   assert(s2.count == 2);
+   assert(episode_seal_touches(&s2, "src/context_fold.c") == 1);
+
+   char *j2 = episode_seal_serialize(&s2);
+   assert(j2 && strcmp(j1, j2) == 0); /* deterministic round-trip */
+
+   free(j1);
+   free(j2);
+   episode_seal_free(&s);
+   episode_seal_free(&s2);
+   PASS("serialize_parse_roundtrip");
+}
+
+static void test_bad_args(void)
+{
+   episode_seal_t s;
+   episode_seal_init(&s);
+   assert(episode_seal_parse(&s, "{bad") == -1);
+   assert(episode_seal_serialize(NULL) == NULL);
+   assert(episode_seal_touches(NULL, "x") == 0);
+   episode_seal_free(&s);
+   PASS("bad_args");
+}
+
+int main(void)
+{
+   printf("episode_seal tests:\n");
+   test_inventory_and_touch();
+   test_serialize_parse_roundtrip();
+   test_bad_args();
+   printf("ALL PASS\n");
+   return 0;
+}

--- a/src/tests/test_task_rail.c
+++ b/src/tests/test_task_rail.c
@@ -1,0 +1,91 @@
+/* test_task_rail.c: unit tests for the portable plan FSM (fold §8, P5). */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "../headers/task_rail.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static void test_start_and_progress(void)
+{
+   const char *titles[] = {"design", "implement", "test"};
+   task_rail_t r;
+   task_rail_init(&r);
+   assert(task_rail_start(&r, "ship the fold", titles, 3) == 0);
+   assert(r.locked == 1 && r.count == 3);
+   assert(task_rail_next(&r) == 0);
+   assert(task_rail_done_count(&r) == 0);
+
+   assert(task_rail_reserve(&r, 0) == 0);
+   assert(r.steps[0].state == TASK_STEP_RESERVED);
+   assert(task_rail_ack(&r, 0, "commit abc123") == 0);
+   assert(r.steps[0].state == TASK_STEP_DONE);
+   assert(strcmp(r.steps[0].evidence, "commit abc123") == 0);
+   assert(task_rail_next(&r) == 1); /* cursor advanced */
+   assert(task_rail_done_count(&r) == 1);
+
+   task_rail_ack(&r, 1, NULL);
+   task_rail_ack(&r, 2, NULL);
+   assert(task_rail_next(&r) == -1); /* all done */
+   assert(task_rail_done_count(&r) == 3);
+
+   /* bad index/state */
+   assert(task_rail_reserve(&r, 9) == -1);
+   assert(task_rail_ack(&r, 9, NULL) == -1);
+
+   task_rail_free(&r);
+   PASS("start_and_progress");
+}
+
+static void test_serialize_restore_roundtrip(void)
+{
+   const char *titles[] = {"a", "b", "c"};
+   task_rail_t r;
+   task_rail_init(&r);
+   task_rail_start(&r, "obj/with:coords #1", titles, 3);
+   task_rail_ack(&r, 0, "ev0");
+   task_rail_reserve(&r, 1);
+
+   char *s1 = task_rail_serialize(&r);
+   assert(s1);
+
+   task_rail_t r2;
+   task_rail_init(&r2);
+   assert(task_rail_restore(&r2, s1) == 0);
+   assert(r2.count == 3 && r2.locked == 1);
+   assert(strcmp(r2.objective, "obj/with:coords #1") == 0);
+   assert(r2.steps[0].state == TASK_STEP_DONE && strcmp(r2.steps[0].evidence, "ev0") == 0);
+   assert(r2.steps[1].state == TASK_STEP_RESERVED);
+   assert(r2.steps[2].state == TASK_STEP_PENDING);
+
+   char *s2 = task_rail_serialize(&r2);
+   assert(s2 && strcmp(s1, s2) == 0); /* deterministic round-trip */
+
+   free(s1);
+   free(s2);
+   task_rail_free(&r);
+   task_rail_free(&r2);
+   PASS("serialize_restore_roundtrip");
+}
+
+static void test_bad_args(void)
+{
+   task_rail_t r;
+   task_rail_init(&r);
+   assert(task_rail_restore(&r, "{not json") == -1);
+   assert(task_rail_serialize(NULL) == NULL);
+   assert(task_rail_start(NULL, "x", NULL, 0) == -1);
+   task_rail_free(&r);
+   PASS("bad_args");
+}
+
+int main(void)
+{
+   printf("task_rail tests:\n");
+   test_start_and_progress();
+   test_serialize_restore_roundtrip();
+   test_bad_args();
+   printf("ALL PASS\n");
+   return 0;
+}


### PR DESCRIPTION
## Summary

Final implementation slice — two pure, tested building blocks completing the fold surface:

- **`src/task_rail.{c,h}` (§8)** — portable plan FSM: objective + locked step list (PENDING/RESERVED/DONE + evidence), `start`/`reserve`/`ack`/`next`/`done_count`, deterministic JSON `serialize`/`restore` so the plan survives folds, epochs, and session boundaries (persists to the existing DB1 `checkpoints.snapshot`).
- **`src/episode_seal.{c,h}` (§5)** — sealed work episode: conclusion + file inventory + a file-touch auto-recall predicate, JSON `serialize`/`parse`. Stored as a distinct `unit_type` (`EPISODE_SEAL_UNIT_TYPE`) on the existing `memory_units` row — **no schema column, no migration** (per the plan F.3 ruling), and does not overload `KIND_EPISODE`.

Both pure (cJSON only), deterministic, fully unit-tested (round-trip, progress, touch predicate, bad-args).

## Scope
This lands the tested FSM cores. The **storage/live binding** — DB1 checkpoint persistence for the rail; DB2 `unit_type` store + cross-session file-touch recall for seals — is the documented close-out follow-up (it needs DB2 helpers + cross-session retrieval paths). Consistent with the staged, default-off rollout of the whole feature.

## Local gates
`make lint` · server+kb build · `make -j unit-tests` (full suite; task_rail 3 + episode_seal 3 cases) — all green. No config/schema change.