### PR TITLE
docs(fold): operator guide + proposal close-out for deterministic context folding

### DIFF
--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -1,0 +1,130 @@
+# Deterministic context folding
+
+Sustain long agent sessions inside a fixed context window by **deterministically
+folding old conversation turns** — no LLM summarization call — while conserving the
+exact identifiers an agent needs, and keeping the provider prompt cache warm.
+
+**Status:** shipped on `testing`, **default-off** end to end. Each layer is gated by
+its own config flag; with all flags off, behaviour is byte-identical to pre-fold.
+
+This guide is the operator/developer reference. The design rationale is in
+`docs/proposals/done/deterministic-context-folding.md`; the pipeline-order contract
+is in `docs/dev/fold-pipeline-order.md`.
+
+## What it does
+
+On aimee's **delegate** request path (`posix/agent_runtime.c`, Anthropic shape),
+once a conversation grows past a retained band, a contiguous prefix of older turns
+is replaced by a single synthetic summary:
+
+- **Rolling fold (§1)** — one skeleton line per turn / tool call (`assistant: …`,
+  `  $ tool …`, `    → result (N bytes)`), plus a budgeted reasoning excerpt.
+- **Coordinate Closet (§2)** — the exact identifiers from the folded region (uuids,
+  commit shas, paths, digit-bearing `key=value`, issue/PR refs, `handle:`/`memory:`
+  tokens) are conserved verbatim in a labelled block so truncation can never
+  amputate them. Secrets are redacted; user-pasted content is quarantined.
+- **Fold-freeze (§3)** — the fold boundary is *pinned* across turns, so the folded
+  prefix stays byte-identical turn-to-turn and the provider cache stays warm; the
+  boundary only advances at an "epoch" when the un-folded tail outgrows its cap.
+- **Register grammar (§6)** — folded assistant lines are annotated with their
+  register (verdict / hazard / executing / blocked / in-progress) so the summary
+  preserves which turns were settled conclusions.
+- **Fold recall (§4)** — if a later turn re-references a folded-away coordinate, a
+  recall hint is surfaced so the body can be paged back in on demand via the
+  existing `code_span_get` / `memory_get` tools.
+
+Two more building blocks ship as tested libraries (storage binding is future work,
+see [Limitations](#limitations-and-deferred-work)):
+
+- **Sealed episodes (§5)** — a replayable checkpoint (conclusion + file inventory)
+  with a file-touch auto-recall predicate (`src/episode_seal.{c,h}`).
+- **Task rail (§8)** — a portable plan FSM serialisable outside the prompt
+  (`src/task_rail.{c,h}`).
+
+Everything is **deterministic** (no model, clock, or randomness) — identical input
+yields byte-identical output, which is what makes the freeze and the cache benefit
+possible.
+
+## Enabling it
+
+All knobs live under the `fold` and `compact.coord_closet` config sections
+(`~/.config/aimee/aimee.yaml`). All default to off / zero (module defaults).
+
+```yaml
+fold:
+  enabled: true            # §1 turn out the rolling fold on the delegate path
+  retained_msgs: 8         # trailing messages kept at full fidelity (0 = default 8)
+  min_fold_msgs: 4         # fold only if at least this many messages would fold
+  excerpt_bytes: 160       # per-message reasoning excerpt kept in the skeleton
+  register_enabled: true   # §6 annotate folded assistant lines with their register
+  freeze:
+    enabled: true          # §3 pin the boundary across turns (cache-warm)
+    tail_cap_msgs: 24       # advance the boundary when the un-folded tail exceeds this
+  recall:
+    enabled: true          # §4 emit recall hints on re-touch of a folded coordinate
+    ttl_turns: 4            # don't re-surface the same coordinate within N turns
+
+compact:
+  coord_closet:
+    enabled: true          # §2 conserve verbatim identifiers (also used by the fold)
+    budget_bytes: 2048      # hard cap for the conserved block (0 = default)
+    max_ratio_pct: 100      # closet <= raw_len * pct/100 (0 = default 100)
+    denylist: "corpsecret"  # extra secret substrings (comma/space separated)
+```
+
+Recommended order to turn on (each is independently safe):
+1. `compact.coord_closet.enabled` — conserve identifiers in tool-result compaction
+   (works even without the transcript fold).
+2. `fold.enabled` (+ `register_enabled`) — the transcript fold itself.
+3. `fold.freeze.enabled` — once folding is on, freeze keeps the cache warm.
+4. `fold.recall.enabled` — re-touch hints.
+
+## How it behaves (invariants)
+
+- **No lost coordinates.** A nominated identifier that cannot fit the closet budget
+  is signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)`
+  marker — never silently dropped.
+- **Atomic tool pairs.** The fold boundary is always a *clean user turn*, so a
+  `tool_use` and its `tool_result` are never split, and the retained tail always
+  begins with a user message (valid Anthropic alternation).
+- **Non-destructive.** The raw transcript is never mutated; the fold produces a new
+  view used only to build the outbound request.
+- **Cache stays warm.** With freeze on, the folded prefix is re-emitted byte-for-byte
+  while it is pinned; a mid-run prefix mutation (e.g. compaction) is detected by a
+  digest and forces a clean epoch rather than a false cache claim.
+- **Secrets never echo.** `ghp_`/`sk-`/`AKIA…`/JWT/PEM/etc. token prefixes,
+  credential-bearing paths, and sensitive label names are redacted before render.
+
+## Observability
+
+With `AIMEE_LOG`/debug logging, the fold emits `fold folded=N retained=M
+reused_boundary=B epochs=E` per folding turn. `coord_closet partial (budget)` warns
+on closet eviction. `fold_result_t.reused_boundary` reports cache-warm reuse.
+
+## Limitations and deferred work
+
+The fold is **default-off** and these are the honest gaps (tracked in the proposal
+close-out):
+
+- **Delegate path only.** The fold targets aimee's own agent loop, which already
+  owns the `payload_rewrite` cache machinery. The ingress proxy path
+  (`server/anthropic_http.c`, external clients) is not folded yet.
+- **`payload_rewrite` span registry (§3 substrate).** The cache benefit here comes
+  directly from emitting byte-identical prefixes; integrating the fold span into
+  `payload_rewrite`'s single prefix hash (and the single-owner CI lint) is a
+  follow-up that converges with `ingress-compression-and-cache-alignment`.
+- **Episode/task-rail storage binding.** §5 and §8 ship as tested modules; DB1
+  checkpoint persistence for the rail and DB2 `unit_type` storage + cross-session
+  file-touch recall for sealed episodes are the storage-binding follow-up.
+- **Within-run freeze.** Freeze pins the boundary across turns *within a run*;
+  cross-session (DB-persisted) freeze is future work.
+- **Recall is hint-only.** Re-touch surfaces a hint pointing at the on-demand
+  recovery tools; automatic inline body fetch is deferred.
+
+## Default-on candidacy
+
+Folding is a token/cost optimisation with an agentic-recovery cost (a folded body
+must be re-fetched if needed). Per aimee's off-reasons discipline, default-on is
+gated on the integration-test results (token reduction, cache-read share, and
+0-lost-coordinate fidelity on a captured long session). See the proposal close-out
+for the assessment.

--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -14,15 +14,19 @@ is in `docs/dev/fold-pipeline-order.md`.
 ## What it does
 
 On aimee's **delegate** request path (`posix/agent_runtime.c`, Anthropic shape),
-once a conversation grows past a retained band, a contiguous prefix of older turns
-is replaced by a single synthetic summary:
+once a conversation grows past `retained_msgs` (default 8) trailing messages and at
+least `min_fold_msgs` (default 4) older turns are eligible, a contiguous prefix of
+older turns is replaced by a single synthetic summary:
 
 - **Rolling fold (§1)** — one skeleton line per turn / tool call (`assistant: …`,
   `  $ tool …`, `    → result (N bytes)`), plus a budgeted reasoning excerpt.
 - **Coordinate Closet (§2)** — the exact identifiers from the folded region (uuids,
   commit shas, paths, digit-bearing `key=value`, issue/PR refs, `handle:`/`memory:`
   tokens) are conserved verbatim in a labelled block so truncation can never
-  amputate them. Secrets are redacted; user-pasted content is quarantined.
+  amputate them. Secrets are redacted; user-pasted content is *quarantined* —
+  conserved in a separate lane, rendered with an `(untrusted)` marker under a
+  divider, and never allowed to mint an agent-trusted label (a prompt-injection
+  guard).
 - **Fold-freeze (§3)** — the fold boundary is *pinned* across turns, so the folded
   prefix stays byte-identical turn-to-turn and the provider cache stays warm; the
   boundary only advances at an "epoch" when the un-folded tail outgrows its cap.
@@ -41,14 +45,27 @@ see [Limitations](#limitations-and-deferred-work)):
 - **Task rail (§8)** — a portable plan FSM serialisable outside the prompt
   (`src/task_rail.{c,h}`).
 
-Everything is **deterministic** (no model, clock, or randomness) — identical input
-yields byte-identical output, which is what makes the freeze and the cache benefit
-possible.
+A seventh piece underpins the rest:
+
+- **Per-model budget resolver (§7)** — `src/fold_budget.{c,h}`, a *pure* function
+  that turns a model id into the fold's token budgets. It has **no user-facing
+  config surface** (the operator knobs below are message-count/byte based); it is
+  listed here only so the §1–§8 map is complete and so operators understand fold
+  output may legitimately differ across model identities.
+
+Everything is **deterministic** — no LLM-summarisation call, no wall-clock input,
+no randomness — so identical input yields byte-identical output, which is what makes
+the freeze and the cache benefit possible. (Model *identity* is an input via §7, so
+switching models is treated as a prefix change — see the freeze invariant.)
 
 ## Enabling it
 
 All knobs live under the `fold` and `compact.coord_closet` config sections
-(`~/.config/aimee/aimee.yaml`). All default to off / zero (module defaults).
+(`~/.config/aimee/aimee.yaml`). **Boolean** `*_enabled` flags default **off**.
+**Numeric** keys use **0 as a sentinel** that resolves to a built-in module default:
+`retained_msgs`→8, `min_fold_msgs`→4, `excerpt_bytes`→160, `budget_bytes`→2048,
+`max_ratio_pct`→100, `tail_cap_msgs`→24, `ttl_turns`→4. The snippet below is an
+**all-on reference** — see the staged rollout after it for the recommended order.
 
 ```yaml
 fold:
@@ -81,9 +98,10 @@ Recommended order to turn on (each is independently safe):
 
 ## How it behaves (invariants)
 
-- **No lost coordinates.** A nominated identifier that cannot fit the closet budget
-  is signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)`
-  marker — never silently dropped.
+- **No silent coordinate loss.** Conserved identifiers are rendered verbatim when
+  they fit; a nominated identifier that cannot fit the closet budget is explicitly
+  signalled (`COORD_EVICT_FAIL`) and rendered as a `(partial — … omitted)` marker —
+  never silently dropped.
 - **Atomic tool pairs.** The fold boundary is always a *clean user turn*, so a
   `tool_use` and its `tool_result` are never split, and the retained tail always
   begins with a user message (valid Anthropic alternation).
@@ -91,9 +109,14 @@ Recommended order to turn on (each is independently safe):
   view used only to build the outbound request.
 - **Cache stays warm.** With freeze on, the folded prefix is re-emitted byte-for-byte
   while it is pinned; a mid-run prefix mutation (e.g. compaction) is detected by a
-  digest and forces a clean epoch rather than a false cache claim.
-- **Secrets never echo.** `ghp_`/`sk-`/`AKIA…`/JWT/PEM/etc. token prefixes,
-  credential-bearing paths, and sensitive label names are redacted before render.
+  digest and forces a clean epoch rather than a false cache claim. A model-identity
+  change (different §7 budget) likewise shifts the prefix, so it is handled the same
+  way — a fresh epoch, not a stale cache-warm claim.
+- **Secrets are redacted before render** by the implemented detectors —
+  `ghp_`/`sk-`/`AKIA…`/JWT/PEM token shapes, credential-bearing paths, and sensitive
+  label names — plus any substrings added via `compact.coord_closet.denylist`. The
+  detector set is extensible, not exhaustive: it is a strong filter, not an absolute
+  guarantee against every possible secret shape.
 
 ## Observability
 

--- a/docs/proposals/done/deterministic-context-folding.md
+++ b/docs/proposals/done/deterministic-context-folding.md
@@ -367,6 +367,11 @@ All sections implemented in slices, each roundtable-reviewed before merge to
 | P4   | §4 | #901 | Fold recall — `src/fold_recall.{c,h}`; page table + whole-token re-touch detection + residency TTL; live recall hints. |
 | P5   | §5, §8 | #903 | Sealed episodes (`src/episode_seal.{c,h}`) + task rail (`src/task_rail.{c,h}`) — pure, tested FSM modules. |
 
+The eight rows above are the feature slices; intervening PR numbers in the
+#886–#903 range belong to other concurrent work (infra/CI/docs/structured-PDF), not
+to this feature. (§7, the pure per-model fold-budget resolver, shipped in P1.5/#887
+and has no user-facing config surface.)
+
 Config surface (all default-off): `fold.{enabled,retained_msgs,min_fold_msgs,
 excerpt_bytes,register_enabled}`, `fold.freeze.{enabled,tail_cap_msgs}`,
 `fold.recall.{enabled,ttl_turns}`, `compact.coord_closet.{enabled,budget_bytes,

--- a/docs/proposals/done/deterministic-context-folding.md
+++ b/docs/proposals/done/deterministic-context-folding.md
@@ -1,0 +1,397 @@
+# Proposal: Deterministic context folding — turn skeletons, identifier conservation, and cross-session episodes
+
+- **State:** DONE — §1–§8 shipped to `testing`, default-off (see "Shipped work").
+- **Completed:** 2026-06-29
+- **Author:** JBailes
+- **Date:** 2026-06-29
+- **Charter roles:** Rewrite, Recall, Extract, Calibrate / Evaluate-Optimize
+- **Thesis:** A long agent session should not pay a model round-trip to forget.
+  Aimee can fold old conversation turns into compact, *deterministic* skeletons —
+  no LLM call, byte-identical between turns so the provider prompt cache stays
+  hot — while conserving the exact identifiers (uuids, paths, shas, ports) that
+  truncation and summarization silently drop. Sealed work survives across sessions
+  as replayable episodes.
+
+## Goal
+
+Sustain hundreds of turns inside a fixed context window with three guarantees the
+current envelope work does not yet give us:
+
+1. **Zero-LLM compaction of the transcript itself.** Today Aimee compacts the
+   *injected* `<aimee-context>` envelope and individual oversized tool results. It
+   does not fold the *conversation history* — the accumulating turn-by-turn record
+   that actually exhausts the window on a long session.
+2. **No lost coordinates.** Whatever we fold, the literal identifiers an agent
+   needs to keep working (record ids, absolute paths, commit shas, ports, issue
+   refs) must survive verbatim, not be paraphrased away.
+3. **Cache stays hot.** Re-deriving the folded prefix every turn defeats the prompt
+   cache. The folded prefix must be reproducible byte-for-byte so the provider
+   reads it from cache instead of re-billing it as fresh input.
+
+## §0 What already exists (so we don't rebuild it)
+
+- **Ingress envelope compaction — LIVE/in-progress.** `ingress-compression-and-cache-
+  alignment` (pending) and `recall-economy-progressive-disclosure` (done) bound and
+  fold the `<aimee-context>` envelope, expose id-addressable follow-up reads
+  (`memory_get`, `get_context_block`), and reserve a typed envelope IR
+  (`ingress_entry_t`, `ingress_transform_t` in `src/headers/ingress_preinject.h`).
+  **This proposal targets the transcript, not the envelope** — they compose.
+- **Tool-result compaction — LIVE.** `src/compact.c` does mechanical JSON-structure
+  summary + head/tail truncation per oversized tool result. It is the right
+  primitive but operates per-result, has no identifier-conservation lane, and does
+  not skeletonize whole turns.
+- **Cache-aware prefix rewrite — LIVE.** `src/payload_rewrite.c` tracks a stable
+  prefix (FNV-1a over system + static context) and defers envelope moves to protect
+  the cache (`cache_aware_rewrite_*`, `ingress_cache_placement_enabled`). This is
+  the substrate the fold-freeze in §3 builds on.
+- **Episode cards — LIVE.** `src/memory_episodes.c` LLM-synthesizes episode
+  summaries (`memory_episode_card_generate`, stored as `KIND_EPISODE` memory_units)
+  gated by `memory_episode_summaries_enabled`. They are *narrative summaries*, not
+  *sealed checkpoints with a file inventory*, and they do not auto-recall on file
+  re-touch. §5 adds a **distinct** sealed-checkpoint kind (`KIND_EPISODE_SEAL`) and
+  does not overload `KIND_EPISODE`.
+- **Checkpoints — LIVE.** DB1 `checkpoints` + `file_snapshots` capture per-session
+  snapshots, but there is no portable plan state machine paged back into the turn.
+- **Code-span recovery — LIVE.** `code_span_read()` (`src/headers/code_span.h`)
+  re-fetches a folded code region with drift detection. This is the recovery half
+  of §4 fold-recall; the trigger/index half is missing.
+
+## §1 Rolling fold (deterministic turn skeletonization)
+
+**Principle.** Once a turn is `N` turns behind the head, replace its full body with
+a **skeleton**: one line per tool call, plus a budgeted slice of retained reasoning.
+The newest band of turns stays at full fidelity. No model is invoked — the fold is a
+pure CPU transform over the existing transcript.
+
+- **Skeleton form.** Each historical tool call collapses to a single deterministic
+  line: `read src/foo.c → 412 lines`, `$ make → ok (rc=0)`, `search "ingress_entry"
+  → 7 hits`. Assistant prose collapses to a bounded retained-reasoning excerpt (the
+  conclusion/verdict band, see §6), not the full body.
+- **Non-destructive.** Raw history is append-only and never mutated. The fold
+  produces a *view* — a synthetic assistant/user pair carrying the skeleton with a
+  self-documenting preamble ("the turns below are folded; exact identifiers are
+  conserved in the closet, full bodies are re-openable") — that is what we send to
+  the provider. The raw tail is preserved for re-fold and for replay.
+- **Atomic tool pairs.** A `tool_use` and its matching `tool_result` are a single
+  fold unit — they fold together or not at all. A folded region renders as plain
+  **non-tool** assistant/user text (the skeleton lines), never as an orphaned
+  `tool_use` with no result or vice-versa, which providers reject. Multi-call,
+  parallel-call, and failed-call turns must all collapse to whole skeleton lines.
+  This is a hard provider-validity rule, not a nicety (see §3 golden gate).
+- **Band, not threshold.** Folding is governed by a *retained band* (most-recent
+  turns kept whole) and a *tail cap* (rolling size limit before the fold advances),
+  resolved per model in §7 — not a single global char threshold.
+
+Concretely this is a new transcript-level pass (proposed `src/context_fold.c`)
+sitting between turn assembly and `payload_rewrite`, reusing `compact.c`'s
+truncation primitives for the per-line collapse.
+
+## §2 Coordinate Closet (verbatim identifier conservation)
+
+**Principle.** Skeletonizing a turn must never destroy a value the agent cannot
+reconstruct. Before a turn is folded, extract its **opaque coordinates** and pin
+them verbatim in a conserved block that rides along with the skeleton.
+
+- **Nominate.** A deterministic extractor flags: uuids, long hex hashes / commit
+  shas, absolute and repo-relative paths, digit-bearing key=value pairs
+  (`port=3002`, `pid=8841`), issue/PR refs (`#778`), and `handle:<id>` /
+  `memory:<id>` tokens Aimee already mints. (This is the inverse of the heuristics
+  `compact.c` uses to decide *what to drop* — here we decide *what to keep*.)
+- **Conserve with a label.** Each coordinate gets a stable, deterministic context
+  label derived from its surrounding key, e.g. `7fd5835b ⟦changelog_id⟧`,
+  `3002 ⟦llm_port⟧`. Identical inputs ⇒ identical labels — this is a **hard**
+  requirement for §3 byte-identity, so the derivation is fully specified, not
+  heuristic:
+  - **Normalize.** Coordinate values are Unicode-NFC-normalized; JSON-sourced
+    values are canonicalized (compact form, sorted keys, no insignificant
+    whitespace) before extraction.
+  - **Label.** The label is derived from the nearest key token (snake/camel
+    normalized to snake), falling back to a type tag (`uuid`/`sha`/`path`/`port`/
+    `ref`) when no key is in scope. No model, no clock, no randomness.
+  - **Emission order.** Entries emit in a total order: `(lane, label,
+    first-occurrence byte offset)`, tie-broken by the stable
+    `(turn_id, tool_call_id, result_index)`. Same transcript ⇒ same bytes
+    regardless of internal hash-map iteration order.
+  - Unit tests assert byte-identical closet output for shuffled-input and
+    repeated-run permutations.
+- **Capped lanes with provenance.** Coordinates from agent/tool turns and from
+  **user-pasted text** live in separate capped lanes so a giant paste cannot evict
+  the agent's own working identifiers. User-lane entries are **provenance-tagged**
+  (distinct lane marker) and are *quarantined*: they render as untrusted and never
+  mint an agent-trusted label nor auto-promote into durable memory (§5) without
+  explicit agent action. This blocks a paste like `3002 ⟦llm_port⟧` from
+  impersonating a conserved agent coordinate — a prompt-injection vector. A
+  secret/PII filter runs before any user-lane coordinate is persisted or recalled.
+- **No silent loss (P1 invariant).** The closet is bounded by the §7 budget, but
+  dropping a *nominated* coordinate is treated as a **fold failure**, not silent
+  FIFO eviction: the fold either (a) sizes the cap to fit the conserved set, (b)
+  pages the overflow to a DB-backed spill resolvable via §4, or (c) refuses to
+  advance the fold for that turn. Whichever tier applies is logged. This is what
+  makes the "0 lost coordinates" validation gate achievable rather than
+  self-contradictory.
+
+This is the single highest-leverage piece: it closes a real correctness hole where
+head/tail truncation can amputate the exact id the next tool call needs.
+
+## §3 Fold freeze (byte-identical prefix reuse)
+
+**Principle.** The folded prefix is computed once and **reused byte-for-byte**
+across subsequent turns; only the raw tail grows. The provider then reads the prefix
+from cache instead of re-billing it.
+
+- **Freeze the fold.** After a fold advances, its rendered view (skeleton + closet)
+  is frozen. New turns append only to the raw tail. The frozen bytes are emitted
+  identically next turn — this is what keeps cache-read rates high.
+- **Recompute only at epoch boundaries.** Re-derive the frozen prefix only when:
+  first call; freeze TTL expired; tail exceeded its cap; the retained band's
+  conclusions/claims changed; or a boundary rewrite is forced. Otherwise reuse.
+- **Single prefix-state owner (decision).** `payload_rewrite.c` remains the *sole*
+  owner of the cache-prefix state and the FNV-1a stable-prefix hash. This proposal
+  does **not** introduce a second writer. Instead it adopts a **layered contract**:
+  the transcript fold registers its frozen span with `payload_rewrite` via a new
+  helper (proposed `fold_emit_stable_span`), and the pending
+  `ingress-compression-and-cache-alignment` work registers the envelope span the
+  same way. `payload_rewrite` composes the registered spans into one prefix and
+  hashes once. Two independent writers mutating the prefix — the cache-thrash
+  hazard the review flagged — is thereby ruled out by construction. §0 reflects
+  that the two proposals *converge on one owner* rather than forking it.
+- **Pipeline order (normative).** The stages run in exactly this order so the frozen
+  bytes are never mutated after hashing:
+  1. raw DB1 transcript (append-only) →
+  2. transcript fold view + frozen-prefix assembly (§1/§2) →
+  3. provider-shape normalization (§1 atomic-pair rendering for Anthropic blocks /
+     OpenAI `tool_calls` / Gemini `parts`) →
+  4. `payload_rewrite` stable-span registration + single cache-prefix hash →
+  5. final payload to the provider.
+  The fold pass must sit at stage 2 — it sees the assembled history but runs
+  **before** the stage-4 hash; nothing downstream may rewrite the synthetic
+  assistant/user pair.
+- **Builds on what exists.** This extends `payload_rewrite.c`'s prefix tracking and
+  cache-aware deferral from the *envelope* to the *folded transcript*. Config:
+  reuse the `cache_aware_rewrite_*` family; add `fold_freeze_enabled`,
+  `fold_freeze_ttl_ms`, `fold_tail_cap_tokens`.
+- **Honesty.** Telemetry is measured provider cache-read tokens, not a character-
+  count estimate — consistent with the honest-benchmark framing already adopted for
+  ingress compression.
+
+## §4 Fold recall (ambient page-in)
+
+**Principle.** When the agent re-engages something it had folded away, page the
+relevant folded content back in — as a bounded recall card on the hot tail, not by
+thawing the whole prefix.
+
+- **Page table.** A fold index maps folded content → the path/handle/id that would
+  re-summon it (proposed `context_fold_index`, in-memory per session, optionally
+  persisted).
+- **Trigger.** When a new turn reads/claims a path or cites a `handle:`/`memory:`
+  token present in the index, append a budgeted recall card to the raw tail (cache
+  stays hot) and let it re-fold at the next epoch.
+- **Recovery resolvers already exist.** Code regions resolve via `code_span_read()`
+  (with drift detection); memory via `memory_get`. This proposal adds the *trigger
+  and index*, not new resolvers.
+- **Anti-thrash.** Residency TTL keeps a recalled card resident for a few turns so a
+  fold→recall→fold oscillation cannot churn the cache.
+
+## §5 Episodic recall (sealed work across sessions)
+
+**Principle.** When a unit of work seals, persist it as a **replayable episode** —
+the *set of files touched* plus the agent's conclusions — and auto-recall it when
+any later session touches a member file again.
+
+- **Seal contract.** An episode is a checkpoint, not a paraphrase: file inventory +
+  conclusion band (harvested per §6 trust tags) + the relevant closet coordinates.
+- **Auto-recall by file-touch.** On session entry / first touch of a file, look up
+  episodes whose inventory contains it and surface them as bounded recall cards.
+  This is the gap over today's `memory_episodes.c`, which produces narrative cards
+  with no file-touch trigger.
+- **Distinct kind (avoid collision).** Today's `KIND_EPISODE` memory_units are
+  *narrative cards* from `memory_episodes.c`. A sealed checkpoint is a different
+  thing, so it gets its own memory_unit kind (proposed `KIND_EPISODE_SEAL`) rather
+  than overloading `KIND_EPISODE` — querying and trust semantics stay unambiguous.
+  §0 is updated to state both kinds and their distinction. Reuse the storage
+  plumbing and `memory_episode_cards_query` shape; add the file-inventory index and
+  the touch trigger on top.
+
+## §6 Register grammar (trust tags on assistant turns)
+
+**Principle.** Tag each assistant turn with a one-glyph **register** so the fold and
+the episode harvester know what is settled versus in-flight.
+
+- **Registers.** in-progress / executing / verdict / hazard / blocked (a small fixed
+  set; exact glyphs TBD). The agent opens a turn with its register; a deterministic
+  parser classifies it.
+- **Why it matters here.** (a) The §1 retained-reasoning band keeps *verdict* and
+  *hazard* turns and drops *in-progress* chatter — better fold fidelity per byte.
+  (b) The §5 harvester only seals settled conclusions into durable memory, so
+  transient work self-excludes. This complements `fact_gate_verdict_t`
+  (`src/memory_fact_gate.c`), which gates *facts*, not *turns*.
+- **Soft dependency.** The fold degrades gracefully if turns are untagged (treat as
+  in-progress); the grammar improves fidelity, it is not load-bearing for §1–§3.
+
+## §7 Per-model context budget
+
+**Principle.** Replace scattered global knobs with a single **model → budget**
+resolver that turns a model choice into the fold parameters deterministically.
+
+- **Resolved knobs.** context-window tokens, retained-band tokens, fold-tail-cap
+  tokens, pressure-ceiling (hard-fold trigger), prefix-saturation (freeze recompute
+  trigger), closet cap, eviction policy.
+- **Table-driven.** A pre-seeded table for the models Aimee actually routes to,
+  with an explicit `context_window_tokens` fallback for unknown models. `model_
+  context_window()` (`src/model_registry.c`) already knows window sizes — this
+  layers the fold knobs on top.
+- **Deterministic resolution.** The resolver is a pure function of
+  `(model, transcript, config)` — it is a **prerequisite** for §1/§3 byte-identity,
+  not a later tuning pass. Any per-tool override that still affects a fold
+  (`memory_context_budget_*`, `compact_*`) must be either frozen for the freeze TTL
+  or serialized into the fold-input hash, so the same inputs cannot resolve to two
+  different budgets across turns. The Determinism gate covers this.
+- **Subsumes** the ad-hoc `memory_context_budget_*`, `ingress_compress_min_chars`,
+  and `compact_*` globals over time (those stay as per-tool overrides, under the
+  freeze rule above).
+
+## §8 Task rail (portable plan state, outside the prompt)
+
+**Principle.** Track the multi-step plan as a small serialized **state machine** that
+lives outside the prompt and pages back a compact "where we are" card — so the plan
+survives folds, epoch rebirths, and session boundaries without re-narration.
+
+- **Shape.** A locked rail of steps with status (`pending`/`reserved`/`done` +
+  evidence handle), plus `serialize`/`restore` to JSON. Reuses DB1 `checkpoints`
+  for persistence.
+- **Hard-epoch rebirth.** When the window is force-reset, the wake seed is computed
+  deterministically from the rail + closet + sealed episodes — derived from the
+  trace, not model-summarized.
+
+## Phasing
+
+Each phase is independently shippable behind a default-off flag, validated, then
+considered for default-on per the established off-reasons discipline.
+
+- **P1 — Coordinate Closet (§2) as a `compact.c` lane.** Highest value, smallest
+  blast radius, no transcript surgery. Nominate + conserve (canonical label algo) +
+  render, wired into the existing tool-result and envelope compaction paths.
+  Includes the no-silent-loss invariant and the user-lane provenance guard.
+- **P1.5 — Pipeline-order spike + per-model budget resolver (§7).** Small spike that
+  fixes the fold-pass insertion point (§3 pipeline order) and lands the deterministic
+  `(model, transcript, config)` budget resolver. **Prerequisite for P2** — byte-
+  identity cannot be validated without a deterministic budget, so §7 lands here, not
+  after the fold.
+- **P2 — Rolling fold + freeze (§1, §3).** The transcript-level pass (atomic tool
+  pairs, provider-shape rendering) + byte-identical prefix reuse via the single
+  `payload_rewrite` owner. The core economic win.
+- **P3 — Register grammar (§6).** Fidelity: retained-band selection + episode-seal
+  harvest gating.
+- **P4 — Fold recall (§4).** Page-table + trigger over existing resolvers (also backs
+  the §2 coordinate spill tier).
+- **P5 — Sealed episodes + file-touch recall (§5) + task rail (§8).** Cross-session
+  memory, on the distinct `KIND_EPISODE_SEAL` kind.
+
+## Validation gates
+
+- **Fidelity.** On a captured long session (replayable-verification corpus): fact-
+  retention ≥ target after folding, measured by re-asking the agent for the
+  conserved coordinates and for prior conclusions. **0 lost coordinates** is a hard
+  gate for P1 — made achievable by the §2 no-silent-loss tiering (size / spill /
+  refuse-to-fold), not by hoping the cap never fills.
+- **Cache.** Measured provider cache-read token share before/after P2 on a real
+  multi-hundred-turn run — not a character estimate.
+- **Cost.** End-to-end token cost vs. the current truncation path and vs. an LLM-
+  summarization baseline, on the same corpus.
+- **Determinism.** Same `(transcript, model, config)` ⇒ byte-identical fold view and
+  closet labels, including under shuffled internal iteration order and frozen/
+  serialized per-tool overrides (unit-tested), since §3 depends on it.
+- **Provider validity.** Golden-snapshot tests assert byte-identical *final payloads*
+  across turns and valid tool-call/result pairing for Anthropic blocks, OpenAI
+  `tool_calls`, and Gemini `parts` — including multi-call, parallel-call, and
+  failed-call turns. (Trips `test_mcp_tools_golden`; regenerate per the golden-test
+  procedure.)
+- **No silent loss.** Every closet/tail/recall eviction is logged; a fold that would
+  drop a nominated coordinate fails rather than truncating it.
+
+## Risks / open questions
+
+- **Insertion point.** Folding the transcript interacts with `server-owned-turn-
+  lifecycle` and `payload_rewrite` ordering — the fold pass must run where it sees
+  the assembled history but before cache-prefix hashing. Needs a wiring spike.
+- **Provider shape.** Skeleton + closet must render validly across Anthropic content
+  blocks, OpenAI `tool_calls`, and Gemini `parts` without breaking tool-call/result
+  pairing. Golden-snapshot coverage required (trips `test_mcp_tools_golden`).
+- **Overlap with ingress-compression.** *Resolved (see §3):* a single prefix-state
+  owner (`payload_rewrite`) with both features registering spans via
+  `fold_emit_stable_span`. This proposal layers above that work rather than forking
+  the prefix. The remaining open item is purely sequencing — whether the two land in
+  one PR series or two.
+- **Register grammar is a prompt contract.** It only holds if the agent reliably
+  emits registers; the fold must stay correct when it doesn't (treated as soft).
+
+## Design review (roundtable, 2026-06-29)
+
+A 6-panelist architecture roundtable (`--mode review --rounds 2`, 0 participants
+failed) raised 6 blocking and 3 suggestion items. All were under-specifications
+rather than rejections of the design; each is resolved above:
+
+- **B0 — prefix-state ownership (§3 vs ingress-compression).** Resolved: single
+  owner `payload_rewrite`; both features register spans (`fold_emit_stable_span`).
+- **B1 — fold-pass insertion point.** Resolved: normative 5-stage pipeline in §3;
+  fold runs at stage 2, before the stage-4 cache hash.
+- **B2 — closet label determinism.** Resolved: canonical NFC + JSON-canonical +
+  total emission order in §2, with shuffled-input unit tests.
+- **B3 — FIFO eviction vs "0 lost coordinates".** Resolved: nominated-coordinate
+  drop is a fold failure (size / spill / refuse), not silent FIFO (§2, gates).
+- **B4 — atomic tool_use/tool_result pairing.** Resolved: atomic fold-unit rule in
+  §1; folded regions render as plain non-tool text; golden gate in validation.
+- **B5 — §7 budget scheduled after the fold it gates.** Resolved: §7 moved into
+  P1.5 as a prerequisite for P2 byte-identity.
+- **S7 — `KIND_EPISODE` collision.** Resolved: §5 uses a distinct
+  `KIND_EPISODE_SEAL` kind; §0 disambiguates.
+- **S8 — per-tool overrides break byte-identity.** Resolved: frozen-for-TTL or
+  serialized into the fold-input hash (§7, Determinism gate).
+- **S9 — user-lane label injection (prompt-injection vector).** Resolved: user-lane
+  coordinates are provenance-tagged, quarantined (no agent-trusted label, no auto-
+  promotion), and secret/PII-filtered (§2).
+
+## Shipped work (close-out, 2026-06-29)
+
+All sections implemented in slices, each roundtable-reviewed before merge to
+`testing`, each behind a default-off config flag.
+
+| Slice | Sections | PR | What shipped |
+|-------|----------|----|--------------|
+| P1   | §2 | #886 | Coordinate Closet — `src/coord_closet.{c,h}`; verbatim identifier nomination + deterministic labels + no-silent-loss eviction + user-lane quarantine + secret redaction; wired return-only into `agent_compress_tool_result`. |
+| P1.5 | §7 | #887 | Per-model fold-budget resolver — `src/fold_budget.{c,h}` (pure); + `docs/dev/fold-pipeline-order.md` spike pinning the pipeline order + span-registry plan. |
+| P2a  | §1 | #889 | Rolling-fold module — `src/context_fold.{c,h}`; deterministic turn skeletonization, atomic tool pairs, non-destructive. |
+| P2b  | §1 | #894 | Live wiring of the fold into the Anthropic delegate path (`posix/agent_runtime.c`) + `fold` config section. |
+| P2c  | §3 | #895 | Fold-freeze — boundary pinned across turns (byte-identical prefix, digest-guarded against mid-run mutation) + epoch advance. |
+| P3   | §6 | #898 | Register grammar — `src/fold_register.{c,h}`; glyph/bracket classification; folded assistant lines annotated. |
+| P4   | §4 | #901 | Fold recall — `src/fold_recall.{c,h}`; page table + whole-token re-touch detection + residency TTL; live recall hints. |
+| P5   | §5, §8 | #903 | Sealed episodes (`src/episode_seal.{c,h}`) + task rail (`src/task_rail.{c,h}`) — pure, tested FSM modules. |
+
+Config surface (all default-off): `fold.{enabled,retained_msgs,min_fold_msgs,
+excerpt_bytes,register_enabled}`, `fold.freeze.{enabled,tail_cap_msgs}`,
+`fold.recall.{enabled,ttl_turns}`, `compact.coord_closet.{enabled,budget_bytes,
+max_ratio_pct,denylist}`. Operator guide: `docs/features/context-fold.md`.
+
+### Deferred follow-ups (not blocking close-out; documented honestly)
+
+- **Ingress-proxy path** — the fold targets the delegate path (which owns
+  `payload_rewrite`); folding external-client requests through
+  `server/anthropic_http.c` is a later slice (no prefix-state owner there yet).
+- **`payload_rewrite` span registry + single-owner CI lint (§3 substrate)** — the
+  cache benefit currently comes directly from byte-identical prefixes; integrating
+  the fold span into `payload_rewrite`'s single hash converges with the pending
+  `ingress-compression-and-cache-alignment` work (one shared span-registry PR).
+- **Episode/task-rail storage binding** — DB1 `checkpoints` persistence for the
+  rail; DB2 distinct-`unit_type` store + cross-session file-touch recall for sealed
+  episodes (§5/§8 shipped as tested modules).
+- **Cross-session freeze** — freeze is per-run; DB-persisted cross-session freeze is
+  future work.
+- **Recall body fetch** — recall is hint-only (points at `code_span_get`/
+  `memory_get`); automatic inline page-in is deferred.
+
+### Default-on
+
+Gated on the integration-test results (token reduction, provider cache-read share,
+and 0-lost-coordinate fidelity on a captured long session) per aimee's off-reasons
+discipline. Folding trades tokens for an agentic-recovery cost, so default-on is a
+deliberate operator decision, not an automatic flip.

--- a/docs/proposals/done/deterministic-context-folding.plan.md
+++ b/docs/proposals/done/deterministic-context-folding.plan.md
@@ -1,0 +1,275 @@
+# Implementation plan: Deterministic context folding
+
+Companion to `deterministic-context-folding.md` (PR #881). This plan grounds each
+proposal phase in the actual `testing`-branch code, names the seams, the config
+wiring, the tests, and the per-slice PR/roundtable gate. **Nothing here changes the
+design** — it makes it buildable and flags the one scoping decision the roundtable
+must rule on before P2.
+
+- **State:** DRAFT — awaiting roundtable approval of this plan.
+- **Author:** JBailes
+- **Date:** 2026-06-29
+- **Base:** every slice branches off `origin/testing` (the session checkout is far
+  behind and shared by other sessions — worktrees only, per house rule).
+
+## §A Codebase anchors (verified against `testing`)
+
+- **Tool-result compaction.** `compact_tool_result(raw, raw_len, cfg, tool_name,
+  context_used, context_budget)` (`src/compact.c`, hdr `src/headers/compact.h:46`).
+  Strategies: pass-through, `compact_json_summary` (≈`compact.c:120`), head/tail
+  `compact_plaintext` (≈`compact.c:146`); strategy selection ≈`compact.c:239`.
+  Invoked via `agent_compress_tool_result()` (`src/server/agent_policy.c:1085`) from
+  the bash tool (`src/posix/agent_tools.c:981`) and the generic dispatcher
+  (`src/posix/agent_tools_dispatch.c:1614`).
+- **Cache-prefix machinery.** `payload_rewrite_prefix_hash(system_prompt,
+  static_context, out, len)` — FNV-1a-64 over **system_prompt + static_context only,
+  no messages** (`src/payload_rewrite.c:57`). `payload_rewrite_should_defer` /
+  `payload_rewrite_track_request` (`payload_rewrite.c:77`, `:?`). DB1 state
+  `payload_rewrite_state_t` (`src/db1/payload_rewrite_state.h:7`). Config family
+  `cache_aware_rewrite_*` (master gate, hard-context-threshold 0.85, max-defer-turns
+  20, segment-check-turns 5, min-savings-tokens 500).
+- **Two payload pipelines (the key fact):**
+  - *Delegate path* — `agent_execute_with_tools_internal()`
+    (`src/posix/agent_runtime.c`): `maybe_compact_before_request()` (`:676`) →
+    **[clean fold seam]** → `track_anthropic_payload_rewrite()` (`:698`) → request
+    build (`:693`–`706`). **payload_rewrite runs here.**
+  - *Ingress proxy path* — `src/server/anthropic_http.c`:
+    `messages_run_request_pipeline()` (`:361`) → `translate_request()` (`:369`) →
+    `build_provider_body()` (`:254`). **payload_rewrite does NOT run here.**
+- **Model registry.** `model_context_window(model_id)` prefix-match table
+  (`src/model_registry.c:202`); `model_capability_t` (`src/headers/model_registry.h:41`)
+  with `context_window`, `max_output`, costs, flags. A fold-budget resolver layers on
+  top — no schema change.
+- **Memory kinds.** `KIND_*` string defines + `KIND_COUNT` (`src/headers/aimee.h`);
+  `memory_units` table in **DB2** with `is_episode_card` flag
+  (`src/db2/schema_sqlite.sql:77`, `src/db2/schema.sql`). Episode cards:
+  `memory_episode_card_generate` / `memory_episode_cards_query`
+  (`src/memory_episodes.c:114`,`:239`).
+- **Plan/snapshot storage (DB1).** `checkpoints(snapshot TEXT)`,
+  `file_snapshots`, `file_snapshot_entries`, plus `execution_plans` / `plan_steps`
+  (`src/db1/schema.sql`).
+
+## §B Decision required before P2 — which pipeline does the fold target?
+
+§3 fold-freeze "builds on `payload_rewrite`", but `payload_rewrite` runs **only on
+the delegate path**, not the ingress proxy path that external clients (e.g. a
+Claude-Code-style transcript) flow through. Options:
+
+- **B-1 (recommended): delegate path first.** Land §1/§3 where the cache machinery
+  already exists (`agent_runtime.c` seam). This is exactly aimee's own long
+  autonomous agent loops — the highest-value, lowest-risk target. Ingress-path
+  integration becomes an explicit later slice (needs `payload_rewrite` threaded into
+  `build_provider_body`, signature change).
+- **B-2: ingress path first.** Larger blast radius (touches the stateless proxy +
+  golden envelope), and there is no prefix-state owner there yet — we would build
+  one. Higher value for external clients, higher risk.
+- **B-3: both at once.** Largest single change; rejected — violates the slice
+  discipline.
+
+This plan assumes **B-1** unless the roundtable rules otherwise. The §2 Coordinate
+Closet (P1) is pipeline-independent and proceeds regardless.
+
+## §C Implementation slices
+
+Each slice is one PR off `origin/testing`, **default-off**, with a code roundtable
+before merge (per house rule), the local CI recipe in §D green, and golden/schema
+gates regenerated where touched.
+
+### P1 — Coordinate Closet (§2) — *pipeline-independent, lands first*
+
+- **New:** `src/coord_closet.c` + `src/headers/coord_closet.h`.
+- **API (deterministic, no model/clock/rand):**
+  - `coord_closet_nominate(const char *raw, size_t len, const coord_provenance_t *prov, coord_set_t *out)`
+    — extract uuids, ≥7-hex shas, abs/repo paths, digit-bearing `key=value`,
+    issue/PR refs, `handle:`/`memory:` tokens. **`coord_provenance_t` carries
+    `{lane, turn_id, tool_call_id, result_index}`** and is stamped onto every
+    nominated coordinate (B1) for determinism + auditability.
+  - `coord_closet_render(const coord_set_t *set, size_t budget, dstr *out, coord_evict_t *why)`
+    — emit `Coordinate Closet (conserved from folded turns): …`; canonical NFC +
+    JSON-canonicalization; total order `(lane, label, first-occurrence offset)`,
+    tie-broken by `(turn_id, tool_call_id, result_index)`.
+  - **No-silent-loss + hard cap (B4):** the conserved set is capped at
+    `coord_closet_max_ratio` × raw size (default 1×). If a nominated coordinate
+    would exceed the cap or budget, render returns `COORD_EVICT_FAIL` and the caller
+    must enlarge / defer / spill (P4) / fail the tool — **never** drop silently.
+    `COORD_EVICT_FAIL` propagation is enforced end-to-end.
+- **Provenance / injection guard (B2):** tool results that echo user-pasted content
+  are assigned `COORD_LANE_USER`; user-lane entries render untrusted, never mint an
+  agent-trusted label nor auto-promote. A red-team negative test covers the
+  `3002 ⟦llm_port⟧` impersonation vector.
+- **PII/secret filter BEFORE render (B3):** the filter runs at render time, not just
+  before persist/recall, so secrets never reach the conserved block. Ship a default
+  deny-list (`ghp_`, `sk-`, `AKIA…` token regexes; secret-path patterns) extensible
+  via config. Render-time unit test included.
+- **Wiring (minimal in P1, return-only per F.2):** call `coord_closet_nominate`
+  inside `compact_tool_result` *before* strategy selection (≈`compact.c:239`) so
+  identifiers are captured before truncation; surface the conserved block through the
+  existing compaction return only. No transcript surgery, no cross-turn persistence
+  yet — that arrives in P2 when the fold consumes and re-emits it.
+- **Config:** `coord_closet_enabled` (bool, default off), `coord_closet_budget_tokens`
+  (int), `coord_closet_max_ratio` (int/float, default 1×), `coord_closet_denylist`
+  (string, extends the built-in secret deny-list). Wired across the 5 config files
+  (§D).
+- **Tests:** `src/tests/test_coord_closet.c` — nomination coverage; byte-identical
+  render under shuffled input + repeated runs (determinism gate); overflow→
+  `COORD_EVICT_FAIL` (no silent drop); user-lane quarantine + the `3002 ⟦llm_port⟧`
+  red-team case; render-time PII/secret redaction. Register in `src/tests/Rules.mk`.
+- **Accept:** 0 lost coordinates on a fixture corpus; deterministic bytes; no secret
+  leaks render-side; lint + unit-tests green.
+
+### P1.5 — Pipeline-order spike + per-model budget resolver (§7) — *prereq for P2*
+
+- **New:** `src/fold_budget.c` + `src/headers/fold_budget.h`:
+  `fold_budget_resolve(const char *model_id, const config_t *cfg, fold_budget_t *out)`
+  — pure function of `(model, config)`; fields: `context_window`,
+  `retained_band_tokens`, `tail_cap_tokens`, `pressure_ceiling_tokens`,
+  `prefix_saturation_tokens`, `closet_budget_tokens`, eviction policy. Seeds from
+  `model_capability_get` + a per-model override table; explicit fallback for unknown
+  models.
+- **Determinism rule:** any per-tool override (`memory_context_budget_*`, `compact_*`)
+  that affects a fold is frozen for the freeze TTL or folded into the fold-input hash.
+- **Spike deliverable:** a short design note (committed in the PR) pinning the §3
+  five-stage pipeline order and the exact `agent_runtime.c` seam (per §B-1), plus the
+  `payload_rewrite` span-registry refactor sketch (below) — reviewed before P2 code.
+- **Config:** `fold_budget_*` overrides table (string/int). **Tests:**
+  `test_fold_budget.c` — known + unknown models, override-freeze determinism.
+
+### P2 — Rolling fold (§1) + fold-freeze (§3) — *core economic win*
+
+- **New:** `src/context_fold.c` + `src/headers/context_fold.h`:
+  `context_fold_view(cJSON *messages, const char *sys, const fold_budget_t *b,
+  const config_t *cfg, fold_result_t *out)` — produces the synthetic skeleton
+  assistant/user pair + closet (reusing P1), **non-destructive** (never mutates
+  `messages`).
+- **Atomic tool pairs:** a `tool_use`+`tool_result` fold as one unit or not at all;
+  folded regions render as plain non-tool text. Multi/parallel/failed-call turns
+  collapse whole.
+- **Seam:** insert between `maybe_compact_before_request()` (`agent_runtime.c:677`)
+  and `track_anthropic_payload_rewrite()` (`:698`) — sees assembled history, runs
+  before the cache hash, before request build (per §B-1).
+- **Freeze + single owner (B5/B6/B7/B8):** add an **internal** span registry to
+  `payload_rewrite.c` — `payload_rewrite_register_span(...)` (generic primitive,
+  substrate-owned), declared in `payload_rewrite_internal.h` or enum-keyed from a
+  closed set so it cannot be misused. `fnv1a_update` stays private; the registry
+  collects spans and `payload_rewrite` hashes **once**. The span captures the
+  **post-stage-3 (provider-shape-normalized) serialized bytes**, with an explicit
+  `(ptr, len)` lifetime contract (no use-after-free/double-free). A **CI scan**
+  fails any new caller of `fnv1a_update` / `payload_rewrite_state_t` mutators outside
+  `src/payload_rewrite.c` (single-owner enforcement). Config: `fold_freeze_enabled`,
+  `fold_freeze_ttl_ms`, `fold_tail_cap_tokens`.
+- **Tests + golden:** `test_context_fold.c` — skeletonization; **atomic-pair negative
+  tests** (orphaned `tool_use`, orphaned `tool_result`, partial parallel calls →
+  fail-loud, no orphan emission, B9); byte-identical freeze across turns;
+  cross-renderer determinism for Anthropic/OpenAI/Gemini; span `(ptr,len)` lifetime.
+  Plus an allow-list caller test for the span helper (B8). Regenerate
+  `test_mcp_tools_golden.inc` if the envelope shape shifts (`DUMP_TOOLS=1`, §D).
+- **Accept:** measured provider cache-read share ↑ on a captured long session
+  (validated on the pve testbed, §E); end-to-end token cost ≤ truncation baseline;
+  determinism + provider-validity gates green.
+
+### P3 — Register grammar (§6)
+
+- **New:** `src/fold_register.c` + hdr: `fold_register_parse(turn) -> register_t`
+  (in-progress/executing/verdict/hazard/blocked). Soft: untagged ⇒ in-progress; fold
+  stays correct without it.
+- **Wire:** retained-band selection in `context_fold.c` prefers verdict/hazard;
+  episode-seal harvest (P5) gates on settled registers. Config:
+  `fold_register_enabled`. **Tests:** `test_fold_register.c`.
+
+### P4 — Fold recall (§4)
+
+- **New:** `src/fold_recall.c` + hdr: in-memory page table mapping folded content →
+  path/handle/id; trigger on re-touch/citation appends a bounded recall card to the
+  tail (re-folds next epoch); residency TTL anti-thrash. Reuses existing resolvers
+  `code_span_read()` (`src/headers/code_span.h`) and `memory_get`. Also backs the §2
+  coordinate spill tier. Config: `fold_recall_enabled`, residency TTL.
+  **Tests:** `test_fold_recall.c`.
+
+### P5 — Sealed episodes (§5) + task rail (§8)
+
+- **Episodes:** add `KIND_EPISODE_SEAL "episode_seal"` (`aimee.h`, bump
+  `KIND_COUNT`); store as a **distinct `unit_type` value on the existing
+  `memory_units` row** (F.3 — avoids a new column/migration on the hot table); DB2
+  helper mirroring `db2_memory_unit_episode_card_insert`; file-inventory index;
+  auto-recall on file re-touch. Any schema touch ships an **idempotent migration**
+  under `db2/migrations/` with an apply-twice round-trip test (B10), updates **both**
+  `db2/schema.sql` and `schema_sqlite.sql`, and passes `make schema-sync-check`.
+- **Task rail:** serialize plan FSM to DB1 `checkpoints.snapshot` (or reuse
+  `execution_plans`/`plan_steps`); `serialize`/`restore`; hard-epoch wake seed
+  derived from rail+closet+seals. Config: `fold_episodes_enabled`,
+  `task_rail_enabled`. **Tests:** `test_episode_seal.c`, `test_task_rail.c`.
+
+## §D Cross-cutting recipes
+
+- **Config flag (5 files, lockstep):** declare in `config_t` (`src/headers/config.h`);
+  default + parse in `src/config.c`; allowlist row in `src/config_fields.c`
+  (`{name, offsetof, sizeof, 0, CFG_BOOL|CFG_INT|...}`); schema row in
+  `src/config_schema.inc` (`{name, SCHEMA_BOOL|SCHEMA_INT, 0}`); save in
+  `src/config_save.c` (top-level bool/int auto-handled). `make lint` checks
+  config-field consistency.
+- **Unit test:** add `src/tests/test_<name>.c`; add target to `TEST_TARGETS` and a
+  build rule in `src/tests/Rules.mk` (copy `test_compact` pattern); run
+  `cd src && make -j$(nproc) unit-tests`.
+- **Golden:** regenerate with
+  `DUMP_TOOLS=1 ./build/obj/tests/unit-test-mcp-client-registry` and paste the block
+  into `src/tests/test_mcp_tools_golden.inc`, updating `MCP_TOOLS_GOLDEN_COUNT`.
+- **Local CI gate (run before every PR):**
+  `cd src && make lint && make -j$(nproc) all server && make build-integrity &&
+  make -j$(nproc) unit-tests && make schema-sync-check`.
+- **Commit hygiene:** no `Co-Authored-By` / Claude-attribution trailers (repo gate).
+
+## §E Test environment (pve)
+
+For P2+ behavioral/cache validation we need a live aimee server with an LLM backend.
+Plan: provision a throwaway CT on pve (`root@192.168.1.253`), deploy the
+`testing`+slice build, replay a captured long session through the delegate path, and
+read measured provider cache-read tokens + net token cost. **Tear the CT down when
+the slice is validated.** Unit-level determinism/atomic-pair/closet gates run locally
+and need no server.
+
+## §F Open items for the roundtable
+
+1. **§B pipeline decision** (delegate-first vs ingress-first vs both) — the one
+   blocking ruling needed before P2.
+2. **Closet wiring depth in P1** — surface the conserved block only through
+   `compact_tool_result`'s return now, or also persist it for cross-turn reuse in
+   P1? (Leaning: return-only in P1, persistence in P2 with the fold.)
+3. **Episode-seal storage** — new `is_episode_seal` column vs a distinct `unit_type`
+   value on the existing `memory_units` row (avoids a schema migration).
+4. **Convergence with `ingress-compression-and-cache-alignment`** — one PR series or
+   two; who owns the span registry.
+5. **Default-off → default-on** criteria per phase (off-reasons discipline), and
+   which phases ever flip on by default.
+
+## §G Roundtable ruling (plan approval, 2026-06-29)
+
+6-panelist plan review (`--mode review --rounds 2`, 0 participants failed). **Verdict:
+APPROVED to start P1**, with the refinements below folded in above. The approach was
+not contested; every blocking item tightens it.
+
+**§B pipeline ruling — B-1 ratified:** the transcript fold targets the **delegate
+path** (`posix/agent_runtime.c:677→:698`, which already owns `payload_rewrite`)
+first; ingress-proxy-path integration is an explicit later slice (no second
+prefix-state owner is introduced).
+
+**§F open items — resolved:**
+- **F.1** pipeline → B-1 (above).
+- **F.2** P1 closet wiring → **return-only**; cross-turn persistence deferred to P2
+  where the fold consumes and re-emits it.
+- **F.3** episode-seal storage → **distinct `unit_type`** on `memory_units` (no new
+  column), paired with an idempotent migration.
+- **F.4** convergence with `ingress-compression-and-cache-alignment` → **serialize**:
+  one shared span-registry API PR (P2-owned) lands first, then independent fold /
+  ingress feature PRs — never parallel writers to `payload_rewrite.c`.
+- **F.5** default-off→on → per-phase gate table with a ≥1-release-cycle cooling-off
+  after each green-light (off-reasons discipline).
+
+**Blocking refinements (folded into the phase specs):**
+- P1: provenance `{lane,turn_id,tool_call_id,result_index}` on every coordinate
+  (B1); user-content-echo → `COORD_LANE_USER` + `3002 ⟦llm_port⟧` red-team test
+  (B2); PII/secret filter **before render** + default deny-list (B3); closet hard
+  cap `coord_closet_max_ratio` with `COORD_EVICT_FAIL` (B4).
+- P2: generic internal-only `payload_rewrite_register_span` (B5/B8); post-stage-3
+  byte capture + `(ptr,len)` lifetime (B6); CI single-owner scan on `fnv1a_update` /
+  state mutators (B7); atomic-pair negative tests (B9); serialized convergence (B11).
+- P5: idempotent `db2/migrations/` script + apply-twice round-trip test (B10).


### PR DESCRIPTION
## Summary

Documentation pass for the now-complete (§1–§8, default-off) deterministic context fold.

- **`docs/features/context-fold.md`** — operator/developer guide: what each layer does, the full default-off config surface (`fold.*`, `compact.coord_closet.*`) + recommended enable order, behavioural invariants, observability, and honest limitations/deferred work.
- **`docs/proposals/done/deterministic-context-folding.{md,plan.md}`** — filed to `done/` with a close-out manifest mapping each section to its merged PR (#886, #887, #889, #894, #895, #898, #901, #903), the config surface, deferred follow-ups, and the default-on gating.

Supersedes the design-proposal PR #881 (its content is absorbed here under `done/`).

## Note
Docs-only; `make lint` green. The final step (integration testing + default-on candidacy assessment on a pve testbed) follows separately.