### PR TITLE
fix(config): register top-level "fold" key in config_schema allowlist

### DIFF
--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -71,6 +71,7 @@
 {"concurrency", SCHEMA_OBJECT, 0},
 {"search", SCHEMA_OBJECT, 0},
 {"compact", SCHEMA_OBJECT, 0},
+{"fold", SCHEMA_OBJECT, 0},
 {"sessions", SCHEMA_OBJECT, 0},
 {"sandbox", SCHEMA_OBJECT, 0},
 {"ecomode", SCHEMA_BOOL, 0},

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -772,6 +772,26 @@ int main(void)
       g_config_strict = 0;
    }
 
+   /* --- schema validation: top-level "fold" object is a recognized key --- */
+   {
+      /* Regression: the top-level `fold:` section must be registered in the
+       * config-key allowlist so it does not emit an "unknown key" warning and
+       * does not hard-fail under strict mode. */
+      char cpath[512];
+      snprintf(cpath, sizeof(cpath), "%s/.config/aimee/aimee.yaml", tmpdir);
+      FILE *f = fopen(cpath, "w");
+      assert(f);
+      fprintf(f, "provider: claude\nfold:\n  enabled: true\n");
+      fclose(f);
+
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      g_config_strict = 1;
+      int rc = config_load(&cfg);
+      assert(rc == 0); /* fold is a known key -> no validation issues even in strict mode */
+      g_config_strict = 0;
+   }
+
    /* --- memory.dispositions: valid nested values parse --- */
    {
       char cpath[512];

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -789,6 +789,9 @@ int main(void)
       g_config_strict = 1;
       int rc = config_load(&cfg);
       assert(rc == 0); /* fold is a known key -> no validation issues even in strict mode */
+      /* Also assert the section actually parsed (not merely allowlisted): a parser
+       * regression that silently dropped fold would still pass rc==0 otherwise. */
+      assert(cfg.fold_enabled == 1);
       g_config_strict = 0;
    }
 


### PR DESCRIPTION
The top-level `fold:` config section is parsed by `config_parse_fold_section` (src/config_sections.c) but `fold` was never registered in the config-key allowlist `src/config_schema.inc`. As a result `config_validate()` flagged it as an unknown key on every startup that enables fold:

```
aimee: config warning: unknown key "fold"
```

This is benign in the default non-strict mode (the section still parses and fold enables), but it is confusing to operators enabling fold and would **hard-fail** under strict mode (`g_config_strict`), where an unknown key aborts startup.

## Fix
Register `fold` as a `SCHEMA_OBJECT`, mirroring the already-registered `compact` entry (which is why `compact:` produces no warning). `config_validate` only iterates the root object's direct children and does not recurse, so the nested `fold.*` keys (`fold.enabled`, `fold.freeze`, `fold.recall`, ...) are not top-level and do not need their own entries.

## Test
Adds a regression case in `src/tests/test_config.c` asserting a config containing a `fold:` object loads with zero validation issues even under strict mode (`config_load` returns 0).

## Gates
- `make` clean (`-Werror`, clang-format-19)
- `make lint` ok (includes `schema-sync-check` + `docs-gen-check`)
- `make docs-gen` produced no diff (the schema allowlist does not feed `docs/gen/configuration.md`)
- `unit-test-config` passes