### PR TITLE
feat(cost): price OpenAI/o-series prompt-cache reads

### DIFF
--- a/src/server/token_tracker.c
+++ b/src/server/token_tracker.c
@@ -36,15 +36,23 @@ static const model_price_t pricing[] = {
     {"claude-3-sonnet", 3.00, 15.00, 3.75, 0.30},
     {"claude-3-haiku", 0.25, 1.25, 0.30, 0.03},
 
+    /* OpenAI GPT-4o + o-series support automatic prompt caching: cached input
+     * bills at ~0.5x the input rate and cache CREATION is free (no write
+     * premium), so cache_write stays 0 and cache_read = 0.5 x input. 0.5x is the
+     * documented baseline discount; some newer models cache cheaper (0.25x), so
+     * this conservatively UNDER-states the saving. Operator overrides
+     * (models.dev / g_registry_price_fn) refine per-model. gpt-4 classic /
+     * gpt-3.5 do not support prompt caching -> cache tiers stay 0 (they never
+     * report cache_read tokens, so 0 x anything = 0). */
     /* OpenAI GPT-4o family */
-    {"gpt-4o-mini", 0.15, 0.60, 0.0, 0.0},
-    {"gpt-4o", 2.50, 10.00, 0.0, 0.0},
+    {"gpt-4o-mini", 0.15, 0.60, 0.0, 0.075},
+    {"gpt-4o", 2.50, 10.00, 0.0, 1.25},
 
     /* OpenAI o-series */
-    {"o3-mini", 1.10, 4.40, 0.0, 0.0},
-    {"o3", 10.00, 40.00, 0.0, 0.0},
-    {"o1-mini", 1.10, 4.40, 0.0, 0.0},
-    {"o1", 15.00, 60.00, 0.0, 0.0},
+    {"o3-mini", 1.10, 4.40, 0.0, 0.55},
+    {"o3", 10.00, 40.00, 0.0, 5.00},
+    {"o1-mini", 1.10, 4.40, 0.0, 0.55},
+    {"o1", 15.00, 60.00, 0.0, 7.50},
 
     /* OpenAI GPT-4 classic */
     {"gpt-4-turbo", 10.00, 30.00, 0.0, 0.0},

--- a/src/tests/test_token_tracker.c
+++ b/src/tests/test_token_tracker.c
@@ -43,6 +43,31 @@ static void test_cache_tokens_anthropic(void)
    PASS("cost: cache tokens");
 }
 
+static void test_openai_cache_pricing(void)
+{
+   /* gpt-4o + o-series support automatic prompt caching: cached input bills at
+    * ~0.5x the input rate and cache creation is free (no write premium). This is
+    * the cost-story floor for OpenAI in the unified context economizer. */
+   token_usage_t r = {.cache_read_tokens = 1000000};
+   /* all six cache-eligible families = 0.5x their input rate */
+   assert(near_equal(token_estimate_cost("gpt-4o-2024-11-20", &r), 1.25)); /* 0.5 x 2.50 */
+   assert(near_equal(token_estimate_cost("gpt-4o-mini", &r), 0.075));      /* 0.5 x 0.15 */
+   assert(near_equal(token_estimate_cost("o1", &r), 7.50));                /* 0.5 x 15.00 */
+   assert(near_equal(token_estimate_cost("o1-mini", &r), 0.55));           /* 0.5 x 1.10 */
+   assert(near_equal(token_estimate_cost("o3", &r), 5.00));                /* 0.5 x 10.00 */
+   assert(near_equal(token_estimate_cost("o3-mini", &r), 0.55));           /* 0.5 x 1.10 */
+
+   /* OpenAI cache writes are free (automatic) -> cache_write priced at 0. */
+   token_usage_t w = {.cache_write_tokens = 1000000};
+   assert(near_equal(token_estimate_cost("gpt-4o", &w), 0.0));
+
+   /* The model is PRICED (cost authority owns the cached-token $), not unknown. */
+   int priced = -1;
+   double c = token_estimate_cost_ex("gpt-4o", &r, &priced);
+   assert(priced == 1 && c > 0.0);
+   PASS("cost: openai prompt-cache read priced (0.5x input), writes free");
+}
+
 static void test_openai_model(void)
 {
    /* gpt-4o: $2.50 input, $10.00 output per million */
@@ -332,6 +357,7 @@ int main(void)
 
    test_known_anthropic_model();
    test_cache_tokens_anthropic();
+   test_openai_cache_pricing();
    test_openai_model();
    test_unknown_model();
    test_priced_disambiguation();


### PR DESCRIPTION
Slice 0 of the unified context-economizer program (see plan: one provider-agnostic context-reduction system + an honest cost story).

**What:** the static pricing table (`src/server/token_tracker.c`) left OpenAI/o-series `cache_read` at 0.0, so cached OpenAI tokens were costed as free and the cost story for those models was zero. This populates `cache_read = 0.5x input` for gpt-4o, gpt-4o-mini, o1, o1-mini, o3, o3-mini (OpenAI's standard cached-input discount), leaving `cache_write = 0` (OpenAI prompt caching is automatic — no creation premium). 0.5x conservatively under-states families that cache cheaper (0.25x). gpt-4 classic / gpt-3.5 (no prompt caching) keep zero cache tiers.

**Why:** the economizer's cost numbers price removed/cached tokens at the provider cache-read rate; without these, OpenAI savings read as $0. Operator overrides (models.dev / registry / DB1) still take precedence per the existing three-tier authority.

**Tests:** `test_token_tracker` extended to assert the cached rate for all six changed models and that cache writes are free + the model is `priced=1`.

Default-off-safe (pure pricing data; no behavior change). Reviewed via roundtable (no blockers; addressed coverage feedback).