### PR TITLE
feat(economizer): context_reduce module — measure-only core + contract

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -290,7 +290,7 @@ MCP_GIT_OBJS = $(MCP_GIT_SRCS:%.c=$(OBJDIR)/%.o)
 # --- Layer 0: Foundation (db, config, util, text, render, log, platform, cJSON) ---
 CORE_SRCS = db1/db.c db1/db_schema.c config.c config_sections.c config_database.c config_learning.c config_memory.c config_charter.c config_trigger.c config_kb_maintenance.c config_kb_curator.c config_server_api.c config_skills.c config_save.c config_mode.c config_fields.c toolset.c util.c util_url.c forge_credentials.c forge_app_token.c workspace_mirror.c report_enrichment.c delivery_target.c text.c render.c markdown.c json_fluent.c code_audit_graph.c log.c shutdown_forensics.c dstr.c yaml.c diff.c sse_parser.c \
             aimee_home.c shared/kb_paths.c provider_client.c kb_curator_provider.c \
-            compact.c coord_closet.c fold_budget.c context_fold.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
+            compact.c coord_closet.c fold_budget.c context_fold.c context_reduce.c fold_register.c fold_recall.c task_rail.c episode_seal.c platform_random.c slop_detect.c proxy_bootstrap.c reasoning_cap.c \
             client_integrations.c mcp_tools.c mcp_tool_profile.c mcp_tools_extended.c mcp_skill_tools.c mcp_tools_gateway.c events.c \
             model_registry.c models_dev.c models_dev_cache.c lsp_client.c lsp_manager.c plugin.c \
             plugin_ctx.c plugin_loader.c memory_provider.c plugin_c_hook.c config_plugin.c code_collect.c codex_auth.c \

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -1,0 +1,146 @@
+/* context_reduce.c: the unified context economizer orchestrator.
+ *
+ * Slice 1 is MEASURE-ONLY: it computes the caching-independent baseline context
+ * size and the foldable opportunity (the tokens in the fold-eligible prefix
+ * region), prices the opportunity as a forecast bracket, and NEVER mutates the
+ * messages. Later slices add the actual levers behind this same entry point; the
+ * design contracts (idempotence, immutable prefix zone, freeze-first ordering,
+ * per-format boundaries, hard bypass) live in context_reduce.h. */
+#include "context_reduce.h"
+#include "token_tracker.h" /* token_estimate_cost_ex, token_usage_t */
+#include <stdlib.h>
+#include <string.h>
+
+/* Bytes-per-token approximation shared by every estimate here. Matches the
+ * chars_to_tokens convention used elsewhere (session_compact). Forecast-grade. */
+#define CHARS_PER_TOKEN_EST 4
+
+/* chars/4 token estimate of a serialized cJSON node — the same approximation
+ * session_compact_estimate_tokens uses, inlined so context_reduce does not couple
+ * to the whole session_compact subsystem just to count bytes. Forecast-grade only
+ * (the invoice-quality number is realized provider on/off spend). */
+static int node_token_estimate(cJSON *node)
+{
+   if (!node)
+      return 0;
+   char *s = cJSON_PrintUnformatted(node);
+   int t = s ? (int)(strlen(s) / CHARS_PER_TOKEN_EST) : 0;
+   free(s);
+   return t;
+}
+
+void context_reduce_result_free(reduce_result_t *out)
+{
+   if (!out)
+      return;
+   if (out->mutated && out->messages)
+      cJSON_Delete(out->messages);
+   out->messages = NULL;
+   out->mutated = 0;
+}
+
+/* chars/4 token estimate of the first `count` items of an array — the fold-eligible
+ * prefix region. Provider-agnostic (counts serialized bytes), matching
+ * session_compact_estimate_tokens' chars_to_tokens convention. */
+static int prefix_token_estimate(cJSON *messages, int count)
+{
+   if (!messages || count <= 0)
+      return 0;
+   long total = 0;
+   int i = 0;
+   cJSON *it = NULL;
+   cJSON_ArrayForEach(it, messages)
+   {
+      if (i >= count)
+         break;
+      char *s = cJSON_PrintUnformatted(it);
+      if (s)
+      {
+         total += (long)strlen(s);
+         free(s);
+      }
+      i++;
+   }
+   return (int)(total / CHARS_PER_TOKEN_EST);
+}
+
+int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                   const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                   reduce_state_t *st, reduce_result_t *out)
+{
+   (void)session_id; /* used by the ledger writer, not the transform (Slice 1) */
+
+   if (!out)
+      return 1; /* hard bypass: caller forwards the original request */
+   memset(out, 0, sizeof(*out));
+
+   if (!messages || !cJSON_IsArray(messages))
+   {
+      out->reason = REDUCE_REASON_NONE;
+      return 0;
+   }
+
+   /* Per-seam gate: the economizer only engages at a seam the operator enabled.
+    * cfg == NULL or this seam disabled -> a true no-op (no measurement, no cost),
+    * honoring the header contract that gates actually gate. */
+   int seam_on = cfg && ((seam == REDUCE_SEAM_GATEWAY && cfg->gateway_seam) ||
+                         (seam == REDUCE_SEAM_DELEGATE && cfg->delegate_seam));
+   if (!seam_on)
+   {
+      out->reason = REDUCE_REASON_NONE;
+      return 0;
+   }
+
+   /* Baseline = assembled-context tokens (caching-independent). The system prompt
+    * is the immutable prefix zone — counted, never reduced. The +1 mirrors the
+    * existing request_prompt_token_estimate: a one-token allowance so a present
+    * (even tiny) system prompt is never estimated as zero. */
+   int baseline = node_token_estimate(messages);
+   if (system_prompt && system_prompt[0])
+      baseline += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
+   out->baseline_tokens = baseline;
+   out->reduced_tokens = baseline; /* Slice 1: measure-only, nothing removed */
+   out->removed_tokens = 0;
+
+   /* Provenance: a request can cross both seams. If a prior seam already reduced,
+    * this seam re-measures the baseline but does NOT re-account the opportunity —
+    * that saving belongs to the seam that performed it (avoids double-counting). */
+   if (st && st->reduced)
+   {
+      out->reason = REDUCE_REASON_ALREADY;
+      return 0;
+   }
+
+   /* Foldable opportunity: tokens ahead of the retained tail (provider-agnostic). */
+   int retained =
+       (cfg->fold.retained_msgs > 0) ? cfg->fold.retained_msgs : CONTEXT_FOLD_DEFAULT_RETAINED_MSGS;
+   int n = cJSON_GetArraySize(messages);
+   int foldable_msgs = (n > retained) ? n - retained : 0;
+   out->foldable_tokens = prefix_token_estimate(messages, foldable_msgs);
+
+   /* Cost forecast bracket. Basis = the realized saving (removed_tokens) once a
+    * lever runs, or the foldable OPPORTUNITY in measure-only (removed==0 here).
+    * floor prices the basis at the provider CACHE-READ rate (cache-warm), ceiling
+    * at the FRESH input rate (cache-cold). Forecast only — the invoice-quality
+    * number is realized provider on/off spend, recorded separately by the ledger. */
+   int basis = out->removed_tokens > 0 ? out->removed_tokens : out->foldable_tokens;
+   if (model && model[0] && basis > 0)
+   {
+      int priced = 0;
+      token_usage_t floor_u = {0};
+      floor_u.cache_read_tokens = basis;
+      double floor_cost = token_estimate_cost_ex(model, &floor_u, &priced);
+      if (priced) /* same model -> ceiling is priced too; only emit $ when known */
+      {
+         out->est_saved_cost_floor = floor_cost;
+         token_usage_t ceil_u = {0};
+         ceil_u.input_tokens = basis;
+         out->est_saved_cost_ceiling = token_estimate_cost_ex(model, &ceil_u, NULL);
+      }
+   }
+
+   out->reason = REDUCE_REASON_MEASURED;
+   out->mutated = 0;
+   out->messages = NULL; /* no new array — caller uses its original */
+   return 0;
+}

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -1,0 +1,165 @@
+/* context_reduce.h: the unified context economizer — ONE provider-agnostic
+ * reduction subsystem invoked at every request-assembly choke point (the
+ * inbound /v1 gateway AND the delegate turn loop), so it runs for every agent
+ * (primary + delegates) and every provider.
+ *
+ * It is a THIN ORCHESTRATOR over independent, individually-gated levers — it does
+ * not reimplement them:
+ *   - inject-compress  (ingress_preinject_*: KB/code envelope, code -> file:line)
+ *   - history-fold     (context_fold_view: rolling skeleton + Coordinate Closet)
+ *   - dedup/compact    (messages_compact_consecutive)
+ *   - freeze           (byte-identical reduced prefix for provider cache warmth)
+ * plus a measurement ledger that records what each request would save.
+ *
+ * DESIGN CONTRACTS (from the design-gate review — see the plan):
+ *  1. Idempotence / provenance. A single logical request can traverse BOTH seams
+ *     (gateway then delegate loop). `context_reduce` stamps reduce_state_t.reduced
+ *     once a seam mutates; a later seam that sees it set MUST NOT re-reduce (it
+ *     re-measures against what it actually received). The 400-fallback rebuilds
+ *     from the pristine original transcript, never from a prior reduced output.
+ *  2. Per-format structural boundaries. Fold boundary selection parses each
+ *     provider's native tool-call/tool-result structure (NOT detect_format(),
+ *     which is a router heuristic). Invariant: no assistant tool_call/tool_use is
+ *     ever separated from its result across a fold boundary.
+ *  3. Immutable prefix zone. The system prompt and any designated safety turns
+ *     are byte-identical post-reduction; no lossy lever touches them.
+ *  4. Fixed lever order, freeze-first. freeze digests the stable ORIGINAL bytes
+ *     BEFORE inject-compress mutates them, so a turn-varying envelope can never
+ *     silently bust the prompt cache. Order: freeze-capture -> dedup -> fold ->
+ *     inject-compress -> freeze-verify.
+ *  5. Net-gain pre-check + freeze cost guardrail. Skip fold when foldable tokens
+ *     are below the round-trip recovery threshold (ledger reason="skip_no_gain");
+ *     disable freeze when estimated cache-write churn cost > saved cache-read.
+ *  6. Live-traffic safety. Per-lever + per-seam gates, a measure-only shadow mode,
+ *     and a caller-side hard bypass: on ANY internal error context_reduce returns
+ *     non-zero with out->messages == NULL so the caller forwards the ORIGINAL
+ *     request unchanged.
+ *
+ * All levers default OFF. Measurement is itself a gate (measure_only) so baselines
+ * can be collected with zero behavior change. */
+#ifndef DEC_CONTEXT_REDUCE_H
+#define DEC_CONTEXT_REDUCE_H 1
+
+#include "context_fold.h" /* fold_config_t, fold_freeze_t (reused, not duplicated) */
+#include <cJSON.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+   /* Which seam is invoking the reducer (for provenance + per-seam gating). */
+   typedef enum
+   {
+      REDUCE_SEAM_DELEGATE = 0, /* the agent turn loop (provider-native messages) */
+      REDUCE_SEAM_GATEWAY = 1,  /* the inbound /v1 proxy (client wire-format) */
+   } reduce_seam_t;
+
+   typedef struct
+   {
+      /* Per-lever gates (all default-off). */
+      int inject_compress; /* KB/code envelope + code->file:line compression */
+      int history_fold;    /* rolling history skeleton + Coordinate Closet */
+      int dedup;           /* merge consecutive same-role string turns */
+      int freeze;          /* byte-identical reduced prefix across turns */
+
+      /* Per-seam enable (default-off): a lever only runs at a seam that is on. */
+      int gateway_seam;
+      int delegate_seam;
+
+      /* Shadow mode: compute the ledger but DO NOT mutate the messages. Lets the
+       * gateway/delegate path collect baselines on live traffic with zero risk. */
+      int measure_only;
+
+      /* Net-gain pre-check: skip fold when foldable tokens < this (0 -> default).
+       * Guards against routine net-negative folds once recovery round-trips and
+       * the existing compact.c/tool-output caps are accounted for. */
+      int min_gain_tokens;
+
+      fold_config_t fold; /* history-fold sub-config (reused verbatim) */
+   } reduce_config_t;
+
+   /* Per-CONVERSATION reducer state, owned by the caller and persisted across
+    * turns within one conversation (e.g. a stack local spanning the turn loop).
+    * NOT shared across agents/sessions (cross-session sharing would leak context).
+    * Zero-init before first use. */
+   typedef struct
+   {
+      fold_freeze_t freeze; /* §3 freeze boundary + 64-bit prefix digest */
+      int reduced;          /* provenance: set once a seam has reduced this request
+                             * set -> a second seam re-measures but does NOT re-reduce */
+      int turn;             /* current turn index (freeze residency + ledger) */
+   } reduce_state_t;
+
+   /* Why a request did/didn't reduce — recorded in the ledger for auditability. */
+   typedef enum
+   {
+      REDUCE_REASON_NONE = 0,     /* no lever enabled at this seam */
+      REDUCE_REASON_REDUCED,      /* reduction applied */
+      REDUCE_REASON_MEASURED,     /* measure_only: metrics computed, not mutated */
+      REDUCE_REASON_SKIP_NO_GAIN, /* foldable tokens below min_gain_tokens */
+      REDUCE_REASON_ALREADY,      /* provenance: a prior seam already reduced */
+   } reduce_reason_t;
+
+   typedef struct
+   {
+      /* Reduced view. When messages were mutated, `messages` is a NEW array the
+       * caller frees via context_reduce_result_free (mutated==1). When nothing
+       * changed, messages==NULL and the caller uses its original array. */
+      cJSON *messages;
+      int mutated;
+
+      reduce_reason_t reason;
+
+      /* Measurement (token COUNTS are caching-independent; chars/4 estimate, so
+       * forecast only — the invoice-quality number is realized on/off spend). */
+      int baseline_tokens; /* assembled-context tokens before reduction */
+      int reduced_tokens;  /* after reduction (== baseline when measure_only) */
+      int removed_tokens;  /* baseline - reduced (the saving, in tokens) */
+      int foldable_tokens; /* tokens in the fold-eligible prefix region */
+
+      /* Cost forecast bracket, priced via token_estimate_cost_ex on `model`. The
+       * basis is the realized saving (removed_tokens) once a lever runs, or the
+       * foldable OPPORTUNITY (foldable_tokens) in measure-only mode. floor prices
+       * the basis at the provider CACHE-READ rate (cache-warm); ceiling at the
+       * FRESH input rate (cache-cold). NEVER the headline — a forecast bracket;
+       * both 0 when the model is unpriced. */
+      double est_saved_cost_floor;
+      double est_saved_cost_ceiling;
+
+      /* Fold diagnostics (0 in measure-only; populated by the reduction slices). */
+      int folded_msgs;
+      int retained_msgs;
+      int reused_boundary; /* 1 = freeze reused (cache-warm) */
+      int epochs;
+   } reduce_result_t;
+
+   /* Run the economizer for one request at one seam.
+    *
+    *   messages       provider-native (delegate seam) or client-wire (gateway seam)
+    *                  cJSON array; NEVER mutated in place.
+    *   system_prompt  immutable prefix zone (never reduced).
+    *   model          billable model id, for the cost forecast (may be NULL).
+    *   session_id     conversation scope for state/ledger (may be NULL).
+    *   seam           which choke point is calling.
+    *   cfg            lever + seam gates (may be NULL -> all-off, no-op).
+    *   st             per-conversation state (may be NULL -> freeze disabled).
+    *   out            zeroed then populated; free with context_reduce_result_free.
+    *
+    * Returns 0 on success (including the deliberate no-op cases). Returns non-zero
+    * on an internal error with out->messages == NULL, so the caller can FORWARD
+    * THE ORIGINAL request unchanged (hard bypass — never break live traffic). */
+   int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                      const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                      reduce_state_t *st, reduce_result_t *out);
+
+   /* Free a NEW messages array produced by context_reduce. Safe on a zeroed/no-op
+    * result (messages==NULL). Must run AFTER the request is serialized (the result
+    * may hand out non-owning references into the original array). */
+   void context_reduce_result_free(reduce_result_t *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DEC_CONTEXT_REDUCE_H */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -220,6 +220,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-token-audit-load \
                $(TESTPREFIX)/unit-test-windows \
                $(TESTPREFIX)/unit-test-token-tracker \
+               $(TESTPREFIX)/unit-test-context-reduce \
                $(TESTPREFIX)/unit-test-model-pricing \
                $(TESTPREFIX)/unit-test-provider-client \
                $(TESTPREFIX)/unit-test-kb-curator-provider \
@@ -2046,6 +2047,10 @@ $(TESTPREFIX)/unit-test-session-compact: $(OBJDIR)/tests/test_session_compact.o 
 
 $(TESTPREFIX)/unit-test-token-tracker: $(OBJDIR)/tests/test_token_tracker.o \
                                $(OBJDIR)/server/token_tracker.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-context-reduce: $(OBJDIR)/tests/test_context_reduce.o \
+                               $(OBJDIR)/context_reduce.o $(OBJDIR)/server/token_tracker.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-reasoning-cap: $(OBJDIR)/tests/test_reasoning_cap.o \

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -1,0 +1,135 @@
+/* test_context_reduce.c: unit tests for the context economizer orchestrator
+ * (Slice 1 — measure-only: baseline + foldable opportunity + cost forecast, no
+ * mutation, hard-bypass contract). */
+#include "context_reduce.h"
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+#define PASS(name) printf("  %s: ok\n", name)
+
+/* Build a messages array of `rounds` user/assistant pairs with bulky content so
+ * the foldable prefix is non-trivial. */
+static cJSON *make_messages(int rounds)
+{
+   cJSON *arr = cJSON_CreateArray();
+   for (int i = 0; i < rounds; i++)
+   {
+      cJSON *u = cJSON_CreateObject();
+      cJSON_AddStringToObject(u, "role", "user");
+      cJSON_AddStringToObject(u, "content",
+                              "please read the file and summarize the relevant section in detail");
+      cJSON_AddItemToArray(arr, u);
+      cJSON *a = cJSON_CreateObject();
+      cJSON_AddStringToObject(a, "role", "assistant");
+      cJSON_AddStringToObject(
+          a, "content",
+          "here is a fairly long assistant turn that adds bytes to the transcript so the "
+          "fold-eligible prefix carries real token volume across many turns of the session");
+      cJSON_AddItemToArray(arr, a);
+   }
+   return arr;
+}
+
+static void test_hard_bypass_null_out(void)
+{
+   cJSON *m = make_messages(2);
+   int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, NULL, NULL, NULL);
+   assert(rc == 1); /* NULL out -> non-zero so caller forwards original */
+   cJSON_Delete(m);
+   PASS("hard bypass on NULL out");
+}
+
+static void test_null_messages(void)
+{
+   reduce_result_t out;
+   int rc = context_reduce(NULL, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, NULL, NULL, &out);
+   assert(rc == 0 && out.reason == REDUCE_REASON_NONE && out.messages == NULL);
+   context_reduce_result_free(&out); /* safe on no-op result */
+   PASS("null messages -> no-op");
+}
+
+static void test_measure_only_no_mutation(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages */
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.measure_only = 1;
+   reduce_result_t out;
+   int rc = context_reduce(m, "system prompt here", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg,
+                           NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.baseline_tokens > 0);
+   assert(out.reduced_tokens == out.baseline_tokens); /* measure-only: nothing removed */
+   assert(out.removed_tokens == 0);
+   assert(out.mutated == 0 && out.messages == NULL); /* original untouched */
+   /* 40 messages, retained default 8 -> foldable region is the first 32 -> > 0 */
+   assert(out.foldable_tokens > 0);
+   /* gpt-4o is priced -> opportunity bracket populated, ceiling (fresh) >= floor (cache-read) */
+   assert(out.est_saved_cost_ceiling >= out.est_saved_cost_floor);
+   assert(out.est_saved_cost_floor > 0.0);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("measure-only: baseline + foldable opportunity, no mutation");
+}
+
+static void test_short_history_no_foldable(void)
+{
+   cJSON *m = make_messages(2); /* 4 messages, < retained(8) */
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   reduce_result_t out;
+   context_reduce(m, NULL, "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(out.foldable_tokens == 0);        /* nothing ahead of the retained tail */
+   assert(out.est_saved_cost_floor == 0.0); /* no opportunity -> no forecast */
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("short history -> zero foldable opportunity");
+}
+
+static void test_provenance_already_reduced(void)
+{
+   cJSON *m = make_messages(20);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   reduce_state_t st = {0};
+   st.reduced = 1; /* a prior seam already reduced this request */
+   reduce_result_t out;
+   context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out);
+   assert(out.reason == REDUCE_REASON_ALREADY);
+   assert(out.baseline_tokens > 0);  /* still re-measured */
+   assert(out.foldable_tokens == 0); /* but no re-accounting of the opportunity */
+   assert(out.mutated == 0);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("provenance: second seam re-measures, does not re-reduce");
+}
+
+static void test_unpriced_model_no_cost(void)
+{
+   cJSON *m = make_messages(20);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   reduce_result_t out;
+   context_reduce(m, "sys", "some-unknown-model-xyz", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(out.foldable_tokens > 0);         /* opportunity still measured (token-only) */
+   assert(out.est_saved_cost_floor == 0.0); /* but no $ for an unpriced model */
+   assert(out.est_saved_cost_ceiling == 0.0);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("unpriced model: token opportunity without a $ forecast");
+}
+
+int main(void)
+{
+   printf("context_reduce: unit tests\n");
+   test_hard_bypass_null_out();
+   test_null_messages();
+   test_measure_only_no_mutation();
+   test_short_history_no_foldable();
+   test_provenance_already_reduced();
+   test_unpriced_model_no_cost();
+   printf("All context_reduce tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
Slice 1 of the unified context-economizer program (one provider-agnostic reduction system; see the approved plan + design-review amendments).

**What:** new `src/context_reduce.{c,h}` — the single entry point every request-assembly seam will call. This slice is **measure-only**: it computes a caching-independent baseline (chars/4 of the serialized messages + system prompt) and the **foldable opportunity** (prefix-region tokens ahead of the retained tail), prices that as a forecast bracket via `token_estimate_cost_ex` (cache-read floor … fresh-input ceiling; suppressed when unpriced), and **never mutates** the messages. No levers yet — inject-compress / history-fold / dedup / freeze land behind this same entry in later slices.

**Contract (encodes the design-gate amendments):** per-lever + per-seam gates that actually gate (cfg NULL / seam-off → no-op), `measure_only` shadow mode, a provenance marker (`reduce_state_t.reduced`) so a request crossing both seams is reduced once and only re-*measured* at the second, session-scoped state, immutable system-prompt zone, and a hard bypass (NULL out / internal error → non-zero + `out->messages==NULL` so the caller forwards the original request).

**Reuse note:** inlined the chars/4 estimate rather than calling `session_compact_estimate_tokens`, to avoid coupling `context_reduce.o` to the heavy session_compact dependency chain.

**Tests:** 6 conformance cases (hard-bypass, null-messages, measure-only-no-mutation, short-history-zero-opportunity, provenance-already-reduced, unpriced-model). Build + lint green.

Default-off, pure, no behavior change. Reviewed via roundtable — one blocker (gates weren't gating) fixed, plus cost-basis/priced-flag/constant refinements.