### PR TITLE
feat(economizer): reduce config + avoided ledger + delegate measure-wiring

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -163,7 +163,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 
 > **Undocumented** (add to `CFG_KEY_DESC` in gen-reference-docs.py): `wfe_live_forge_enabled`
 
-## Config-file sections (50)
+## Config-file sections (51)
 
 Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from the section parsers in `src/config*.c`; a key shown as a bare name that is itself a nested object is noted in the section description (see *Coverage & limitations*).
 
@@ -204,6 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
+- **`reduce`** — `delegate_seam`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -432,6 +432,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_freeze_tail_cap_msgs = 0;
    cfg->fold_recall_enabled = 0; /* fold §4: default-off */
    cfg->fold_recall_ttl_turns = 0;
+   cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
+   cfg->reduce_delegate_seam = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;
@@ -1039,6 +1041,7 @@ int config_load(config_t *cfg)
 
    config_parse_worktree_gc_section(cfg, root);
    config_parse_fold_section(cfg, root);
+   config_parse_reduce_section(cfg, root);
 
    config_parse_memory_section(cfg, root);
    config_apply_learning_settings(cfg, root);

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -994,6 +994,16 @@ int config_save(const config_t *cfg)
       }
    }
 
+   /* Unified context economizer (only save if non-default) */
+   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam)
+   {
+      cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
+      if (cfg->reduce_measure_enabled)
+         cJSON_AddBoolToObject(reduce, "measure", cfg->reduce_measure_enabled);
+      if (cfg->reduce_delegate_seam)
+         cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
+   }
+
    /* Session/worktree cleanup policy (only save if non-default) */
    if (cfg->worktree_stale_secs || cfg->max_sessions || cfg->max_worktrees)
    {

--- a/src/config_schema.inc
+++ b/src/config_schema.inc
@@ -71,6 +71,7 @@
 {"concurrency", SCHEMA_OBJECT, 0},
 {"search", SCHEMA_OBJECT, 0},
 {"compact", SCHEMA_OBJECT, 0},
+{"reduce", SCHEMA_OBJECT, 0},
 {"sessions", SCHEMA_OBJECT, 0},
 {"sandbox", SCHEMA_OBJECT, 0},
 {"ecomode", SCHEMA_BOOL, 0},

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -733,6 +733,23 @@ void config_parse_fold_section(config_t *cfg, cJSON *root)
    }
 }
 
+/* Unified context economizer (src/context_reduce.c). Orchestration gates for the
+ * single reduction subsystem. Only knobs the current code honors are parsed here;
+ * each lever / the gateway seam / min_gain is added by the slice that implements
+ * it, so an exposed flag is never silently inert. All default-off. */
+void config_parse_reduce_section(config_t *cfg, cJSON *root)
+{
+   cJSON *reduce = cJSON_GetObjectItemCaseSensitive(root, "reduce");
+   if (!cJSON_IsObject(reduce))
+      return;
+   cJSON *item = cJSON_GetObjectItemCaseSensitive(reduce, "measure");
+   if (cJSON_IsBool(item))
+      cfg->reduce_measure_enabled = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "delegate_seam");
+   if (cJSON_IsBool(item))
+      cfg->reduce_delegate_seam = cJSON_IsTrue(item) ? 1 : 0;
+}
+
 void config_parse_sessions_section(config_t *cfg, cJSON *root)
 {
    cJSON *item = NULL;

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -90,6 +90,12 @@ void agent_record_token_audit(const agent_result_t *result, const char *role, co
  * dropping them when the provider stream errors mid-flight. */
 void agent_record_token_audit_kind(const agent_result_t *result, const char *role,
                                    const char *source, const char *usage_kind);
+/* Record a context-economizer ledger row (usage_kind="avoided", FORECAST-only —
+ * see context_reduce.h). Forward-declared struct so this broad header need not
+ * pull in context_reduce.h; the caller includes it for the full type. */
+struct reduce_result_s;
+void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *model,
+                                const char *agent_name, const char *role);
 /* Master gate (proposal §2/§7 rollout knob): returns 1 when
  * ingress_usage_accounting_enabled is set. The stateless ingress handlers call
  * this before writing their cost rows so ingress accounting can be flipped on

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -907,6 +907,17 @@ typedef struct config
    int fold_recall_enabled;
    int fold_recall_ttl_turns;
 
+   /* Unified context economizer (src/context_reduce.c). The single reduction
+    * subsystem invoked at every request-assembly seam. All default-off. Knobs are
+    * added here as each slice implements them, so an exposed flag is always
+    * honored. Currently the measurement engine (delegate seam, measure-only):
+    * reduce_measure_enabled: collect baseline/opportunity ledger rows (no
+    *   mutation) — the shadow mode that powers the cost numbers.
+    * reduce_delegate_seam: enable the economizer at the delegate turn loop.
+    * (Per-lever gates, the gateway seam, and min_gain land in later slices.) */
+   int reduce_measure_enabled;
+   int reduce_delegate_seam;
+
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned
     *   (0 = use default: 14400 = 4 hours).

--- a/src/headers/config_sections.h
+++ b/src/headers/config_sections.h
@@ -21,6 +21,7 @@ void config_parse_kb_section(config_t *cfg, cJSON *root);
 void config_parse_memory_maintenance_section(config_t *cfg, cJSON *root);
 void config_parse_worktree_gc_section(config_t *cfg, cJSON *root);
 void config_parse_fold_section(config_t *cfg, cJSON *root);
+void config_parse_reduce_section(config_t *cfg, cJSON *root);
 void config_parse_memory_section(config_t *cfg, cJSON *root);
 void config_parse_cross_verify_section(config_t *cfg, cJSON *root);
 void config_parse_retry_section(config_t *cfg, cJSON *root);

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -101,7 +101,7 @@ extern "C"
       REDUCE_REASON_ALREADY,      /* provenance: a prior seam already reduced */
    } reduce_reason_t;
 
-   typedef struct
+   typedef struct reduce_result_s
    {
       /* Reduced view. When messages were mutated, `messages` is a NEW array the
        * caller frees via context_reduce_result_free (mutated==1). When nothing

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -26,6 +26,7 @@
 #include "provider_cli_adapter.h"
 #include "config.h"
 #include "context_fold.h"
+#include "context_reduce.h"
 #include "fold_recall.h"
 #include "dstr.h"
 #include "cJSON.h"
@@ -824,6 +825,31 @@ native_provider_http:
          final_instruction_added = 1;
       }
       cJSON *active_tools = final_text_only_turn ? NULL : tools;
+
+      /* Context economizer (delegate seam, measure-only): record a baseline +
+       * foldable-opportunity ledger row when reduce.measure is enabled. Cheap
+       * (mtime-cached) config load keeps this dark by default. Measures the
+       * canonical pre-reduction `messages` so the baseline is provider-agnostic. */
+      {
+         config_t ecfg;
+         if (config_load(&ecfg) == 0 && ecfg.reduce_measure_enabled && ecfg.reduce_delegate_seam)
+         {
+            reduce_config_t rcfg;
+            memset(&rcfg, 0, sizeof(rcfg));
+            rcfg.delegate_seam = 1;
+            rcfg.measure_only = 1;
+            rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
+            reduce_result_t rres;
+            /* session_id param unused by the transform; the ledger writer resolves
+             * the session itself (a local `session_id[]` array shadows the fn here). */
+            if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,
+                               NULL, &rres) == 0)
+            {
+               agent_record_reduce_ledger(&rres, fb_agent.model, agent->name, role);
+               context_reduce_result_free(&rres);
+            }
+         }
+      }
 
       /* Build request (use fb_agent which may have fallback model after turn 0) */
       cJSON *req;

--- a/src/server/agent_logging.c
+++ b/src/server/agent_logging.c
@@ -10,6 +10,7 @@
 #include "db1.h"    /* token_audit + agent_log inserts */
 #include "token_tracker.h"
 #include "request_context.h" /* per-request id / principal / idempotency */
+#include "context_reduce.h"  /* reduce_result_t for the economizer ledger */
 
 #include <pthread.h>
 #include <stdio.h>
@@ -314,6 +315,83 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
     * inline insert when async is off or the ring is full. */
    if (!async || audit_async_enqueue(&row) != 0)
       (void)db1_token_audit_insert(&row);
+}
+
+/* Record a context-economizer ledger row as usage_kind="avoided" (excluded from
+ * realized spend). FORECAST-only: estimated_cost_usd carries the MODELED saving
+ * (cache-read floor) and is non-zero ONLY when a lever actually reduced the
+ * request; measure-only rows record 0 avoided-$ and keep the opportunity in
+ * metadata. The invoice-quality saving is the realized on/off spend delta,
+ * computed separately from the realized rows. Keyless row (empty idempotency_key)
+ * so the partial idem index never dedups per-turn rows. */
+void agent_record_reduce_ledger(const reduce_result_t *r, const char *model, const char *agent_name,
+                                const char *role)
+{
+   if (!r || r->reason == REDUCE_REASON_NONE)
+      return;
+
+   const request_context_t *rctx = request_context_get();
+   const char *eff_session = (rctx && rctx->session_key[0]) ? rctx->session_key : session_id();
+   const char *deleg_id = delegation_active_id();
+
+   const char *reason;
+   switch (r->reason)
+   {
+   case REDUCE_REASON_REDUCED:
+      reason = "reduced";
+      break;
+   case REDUCE_REASON_MEASURED:
+      reason = "measured";
+      break;
+   case REDUCE_REASON_SKIP_NO_GAIN:
+      reason = "skip_no_gain";
+      break;
+   case REDUCE_REASON_ALREADY:
+      reason = "already";
+      break;
+   default:
+      reason = "none";
+      break;
+   }
+
+   char meta[512];
+   snprintf(meta, sizeof(meta),
+            "{\"kind\":\"economizer_forecast\",\"reason\":\"%s\",\"baseline\":%d,\"reduced\":%d,"
+            "\"removed\":%d,\"foldable\":%d,\"floor\":%.6f,\"ceiling\":%.6f,\"folded_msgs\":%d,"
+            "\"reused_boundary\":%d}",
+            reason, r->baseline_tokens, r->reduced_tokens, r->removed_tokens, r->foldable_tokens,
+            r->est_saved_cost_floor, r->est_saved_cost_ceiling, r->folded_msgs, r->reused_boundary);
+
+   /* avoided-$ counts only an actual reduction's modeled saving (REASON_REDUCED);
+    * measure-only / skipped / already-reduced rows contribute 0 avoided-$. */
+   double avoided_cost = (r->reason == REDUCE_REASON_REDUCED) ? r->est_saved_cost_floor : 0.0;
+
+   db1_token_audit_row_t row = {
+       .session_id = eff_session,
+       .delegation_id = deleg_id ? deleg_id : "",
+       .project_name = "",
+       .tool_name = agent_name ? agent_name : "",
+       .role = role ? role : "",
+       .model = model ? model : "",
+       .source = "economizer",
+       .requested_model = "",
+       .stop_reason = "",
+       .usage_kind = "avoided",
+       .agent_log_id = g_agent_log_id,
+       .request_id = rctx ? rctx->request_id : "",
+       .idempotency_key = "",
+       .attempt = 0,
+       .principal = rctx ? rctx->principal : "",
+       .served_model = model ? model : "",
+       .duration_ms = 0,
+       .metadata = meta,
+       .prompt_tokens = r->removed_tokens,
+       .completion_tokens = 0,
+       .cache_write_tokens = 0,
+       .cache_read_tokens = 0,
+       .estimated_cost_usd = avoided_cost,
+   };
+   (void)db1_token_audit_insert(&row);
 }
 
 void agent_log_call(const agent_result_t *result, const char *role)

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -17,7 +17,7 @@ TEST_RUN_JOBS ?= $(shell getconf _NPROCESSORS_ONLN 2>/dev/null || nproc 2>/dev/n
 TEST_CORE_OBJS = $(OBJDIR)/db1/db.o $(OBJDIR)/db1/db_schema.o $(OBJDIR)/db1/maintenance.o $(OBJDIR)/tests/aimee_pg_sqlite_shim.o $(OBJDIR)/db2/db2_test_shim.o $(OBJDIR)/config.o $(OBJDIR)/config_sections.o $(OBJDIR)/config_database.o $(OBJDIR)/config_learning.o $(OBJDIR)/config_memory.o $(OBJDIR)/config_charter.o $(OBJDIR)/config_trigger.o $(OBJDIR)/config_kb_maintenance.o $(OBJDIR)/config_kb_curator.o $(OBJDIR)/config_server_api.o $(OBJDIR)/config_skills.o $(OBJDIR)/config_save.o $(OBJDIR)/config_mode.o $(OBJDIR)/config_fields.o $(OBJDIR)/yaml.o $(OBJDIR)/dstr.o $(OBJDIR)/util.o $(OBJDIR)/text.o \
                  $(OBJDIR)/platform_random.o $(PLATFORM_BASIC_OBJS) \
                  $(OBJDIR)/aimee_home.o $(OBJDIR)/shared/kb_paths.o \
-                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
+                 $(OBJDIR)/log.o $(OBJDIR)/shutdown_forensics.o $(OBJDIR)/cJSON.o $(OBJDIR)/util_url.o $(OBJDIR)/report_enrichment.o $(OBJDIR)/compact.o $(OBJDIR)/coord_closet.o $(OBJDIR)/context_fold.o $(OBJDIR)/context_reduce.o $(OBJDIR)/fold_register.o $(OBJDIR)/fold_recall.o $(OBJDIR)/slop_detect.o $(OBJDIR)/proxy_bootstrap.o \
                  $(OBJDIR)/json_fluent.o $(OBJDIR)/markdown.o
 # Extended set for tests that need workspace/worktree/guardrails functions (pulls in agents).
 TEST_WORKSPACE_OBJS_EXTRA = $(OBJDIR)/workspace.o $(DB1_OBJS) \


### PR DESCRIPTION
Slice 2 of the unified context-economizer program: makes the measurement engine LIVE on the delegate path.

**What:**
- `reduce:` config section (default-off). To keep every exposed knob honored, this slice exposes only `measure` + `delegate_seam` — the gateway seam, per-lever gates, and min_gain are added by the slices that implement them.
- `agent_record_reduce_ledger` (agent_logging.c): writes a `usage_kind='avoided'` FORECAST row via `db1_token_audit_insert`, carrying baseline/reduced/removed/foldable + a cost bracket in metadata. Keyless row (the partial idempotency index `WHERE idempotency_key != ''` never dedups it). avoided-$ is non-zero only for an actual reduction (`REASON_REDUCED`); measure-only rows are 0. The invoice-quality saving remains the realized on/off delta.
- agent_runtime.c: a gated measure-only `context_reduce` call before the provider dispatch (`reduce.measure && reduce.delegate_seam`), measuring the canonical pre-reduction `messages` so the baseline is provider-agnostic.

**Effect:** with both flags on, every delegate turn (all providers) records a baseline + foldable-opportunity ledger row — zero mutation. Default-off → no behavior change.

Reviewed via roundtable: blocker fixed (don't expose unimplemented levers — trimmed to measure+delegate_seam), avoided-cost keyed on the reason enum, metadata buffer widened. Build + lint + tests green.