### PR TITLE
feat(economizer): provider-agnostic history fold (reduction live, default-off)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -204,7 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `delegate_seam`, `measure`
+- **`reduce`** — `delegate_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -434,6 +434,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_recall_ttl_turns = 0;
    cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
    cfg->reduce_delegate_seam = 0;
+   cfg->reduce_history_fold = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -995,13 +995,15 @@ int config_save(const config_t *cfg)
    }
 
    /* Unified context economizer (only save if non-default) */
-   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam)
+   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold)
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
          cJSON_AddBoolToObject(reduce, "measure", cfg->reduce_measure_enabled);
       if (cfg->reduce_delegate_seam)
          cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
+      if (cfg->reduce_history_fold)
+         cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -748,6 +748,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "delegate_seam");
    if (cJSON_IsBool(item))
       cfg->reduce_delegate_seam = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
+   if (cJSON_IsBool(item))
+      cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -9,7 +9,15 @@
 
 /* A "clean user turn": role=user and NOT a tool_result message. Folding only at
  * such a boundary guarantees a tool_use and its tool_result never split, and the
- * retained tail begins with a user message (valid alternation). */
+ * retained tail begins with a user message (valid alternation).
+ *
+ * Cross-provider safe: this only admits a boundary at role=="user" (and rejects an
+ * Anthropic tool_result-carrying user msg). In OpenAI/Gemini a tool result is a
+ * separate role=="tool" message and a role=="user" never interrupts an assistant
+ * tool_calls -> tool result pair; in Responses the function_call/function_call_output
+ * items are not role=="user" either. So folding at a user boundary never splits a
+ * call/result pair in ANY provider shape — the boundary logic needs no per-format
+ * branch. */
 static int is_clean_user_turn(const cJSON *m)
 {
    const char *role = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "role"));
@@ -72,6 +80,11 @@ static void skeleton_prefix(dstr_t *d, const char *role, const char *txt, int re
       dstr_appendf(d, "%s: ", role ? role : "?");
 }
 
+/* Format-aware skeleton emitter. A single message can carry MULTIPLE shapes
+ * depending on provider — e.g. an OpenAI assistant turn has BOTH a string
+ * `content` AND a separate top-level `tool_calls` array — so the extractors run
+ * additively (no early return) and the Coordinate Closet captures identifiers from
+ * EVERY provider's tool calls/results, not just Anthropic's. */
 static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, int register_on,
                              coord_set_t *set)
 {
@@ -79,6 +92,8 @@ static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, i
    cJSON *content = cJSON_GetObjectItem((cJSON *)m, "content");
    coord_provenance_t prov = {COORD_LANE_AGENT, turn, -1, -1};
 
+   /* (1) String content (OpenAI/Gemini text, or any plain turn). Emit it but DO
+    * NOT return: an OpenAI assistant turn also carries a top-level tool_calls. */
    if (cJSON_IsString(content))
    {
       const char *txt = content->valuestring;
@@ -89,61 +104,115 @@ static void skeleton_message(dstr_t *d, const cJSON *m, int turn, int excerpt, i
          append_excerpt(d, txt, excerpt);
          dstr_append_char(d, '\n');
       }
-      return;
    }
-   if (!cJSON_IsArray(content))
-      return;
-
-   cJSON *b;
-   cJSON_ArrayForEach(b, content)
+   /* (2) Anthropic content-block array (text / tool_use / tool_result). */
+   else if (cJSON_IsArray(content))
    {
-      const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
-      if (!t)
-         continue;
-      if (strcmp(t, "text") == 0)
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
       {
-         const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(b, "text"));
-         if (txt)
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (!t)
+            continue;
+         if (strcmp(t, "text") == 0)
          {
-            coord_closet_nominate(txt, strlen(txt), &prov, set);
-            skeleton_prefix(d, role, txt, register_on);
-            append_excerpt(d, txt, excerpt);
+            const char *txt = cJSON_GetStringValue(cJSON_GetObjectItem(b, "text"));
+            if (txt)
+            {
+               coord_closet_nominate(txt, strlen(txt), &prov, set);
+               skeleton_prefix(d, role, txt, register_on);
+               append_excerpt(d, txt, excerpt);
+               dstr_append_char(d, '\n');
+            }
+         }
+         else if (strcmp(t, "tool_use") == 0)
+         {
+            const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(b, "name"));
+            cJSON *input = cJSON_GetObjectItem(b, "input");
+            char *inp = input ? cJSON_PrintUnformatted(input) : NULL;
+            if (inp)
+               coord_closet_nominate(inp, strlen(inp), &prov, set);
+            dstr_appendf(d, "  $ %s ", name ? name : "tool");
+            append_excerpt(d, inp ? inp : "", excerpt);
             dstr_append_char(d, '\n');
+            free(inp);
+         }
+         else if (strcmp(t, "tool_result") == 0)
+         {
+            cJSON *c = cJSON_GetObjectItem(b, "content");
+            char *owned = NULL;
+            const char *cv = NULL;
+            if (cJSON_IsString(c))
+               cv = c->valuestring;
+            else if (c)
+            {
+               owned = cJSON_PrintUnformatted(c);
+               cv = owned;
+            }
+            if (cv)
+            {
+               coord_closet_nominate(cv, strlen(cv), &prov, set);
+               dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
+               append_excerpt(d, cv, excerpt);
+               dstr_appendf(d, " (%zu bytes)\n", strlen(cv));
+            }
+            free(owned);
          }
       }
-      else if (strcmp(t, "tool_use") == 0)
+   }
+
+   /* (3) OpenAI / Gemini-as-openai assistant tool calls: a top-level `tool_calls`
+    * array. Each element's function.arguments is a JSON STRING. */
+   cJSON *tool_calls = cJSON_GetObjectItem((cJSON *)m, "tool_calls");
+   if (cJSON_IsArray(tool_calls))
+   {
+      cJSON *tc;
+      cJSON_ArrayForEach(tc, tool_calls)
       {
-         const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(b, "name"));
-         cJSON *input = cJSON_GetObjectItem(b, "input");
-         char *inp = input ? cJSON_PrintUnformatted(input) : NULL;
-         if (inp)
-            coord_closet_nominate(inp, strlen(inp), &prov, set);
+         cJSON *fn = cJSON_GetObjectItem(tc, "function");
+         const char *name = cJSON_GetStringValue(cJSON_GetObjectItem(fn, "name"));
+         const char *args = cJSON_GetStringValue(cJSON_GetObjectItem(fn, "arguments"));
+         if (args)
+            coord_closet_nominate(args, strlen(args), &prov, set);
          dstr_appendf(d, "  $ %s ", name ? name : "tool");
-         append_excerpt(d, inp ? inp : "", excerpt);
+         append_excerpt(d, args ? args : "", excerpt);
          dstr_append_char(d, '\n');
-         free(inp);
       }
-      else if (strcmp(t, "tool_result") == 0)
+   }
+
+   /* (4) Responses (chatgpt) top-level items: a function_call or its
+    * function_call_output (mirror the tool_use / tool_result branches). */
+   const char *itype = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "type"));
+   if (itype && strcmp(itype, "function_call") == 0)
+   {
+      const char *name = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "name"));
+      const char *args = cJSON_GetStringValue(cJSON_GetObjectItem((cJSON *)m, "arguments"));
+      if (args)
+         coord_closet_nominate(args, strlen(args), &prov, set);
+      dstr_appendf(d, "  $ %s ", name ? name : "tool");
+      append_excerpt(d, args ? args : "", excerpt);
+      dstr_append_char(d, '\n');
+   }
+   else if (itype && strcmp(itype, "function_call_output") == 0)
+   {
+      cJSON *o = cJSON_GetObjectItem((cJSON *)m, "output");
+      char *owned = NULL;
+      const char *ov = NULL;
+      if (cJSON_IsString(o))
+         ov = o->valuestring;
+      else if (o)
       {
-         cJSON *c = cJSON_GetObjectItem(b, "content");
-         char *owned = NULL;
-         const char *cv = NULL;
-         if (cJSON_IsString(c))
-            cv = c->valuestring;
-         else if (c)
-         {
-            owned = cJSON_PrintUnformatted(c);
-            cv = owned;
-         }
-         if (cv)
-         {
-            coord_closet_nominate(cv, strlen(cv), &prov, set);
-            dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
-            append_excerpt(d, cv, excerpt);
-            dstr_appendf(d, " (%zu bytes)\n", strlen(cv));
-         }
-         free(owned);
+         owned = cJSON_PrintUnformatted(o);
+         ov = owned;
       }
+      if (ov)
+      {
+         coord_closet_nominate(ov, strlen(ov), &prov, set);
+         dstr_append_str(d, "    \xE2\x86\x92 "); /* arrow */
+         append_excerpt(d, ov, excerpt);
+         dstr_appendf(d, " (%zu bytes)\n", strlen(ov));
+      }
+      free(owned);
    }
 }
 

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -118,6 +118,65 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
    int foldable_msgs = (n > retained) ? n - retained : 0;
    out->foldable_tokens = prefix_token_estimate(messages, foldable_msgs);
 
+   /* Reduction lever (Slice 2b): when history-fold is enabled and this is neither a
+    * measure-only nor an already-reduced pass, actually fold the prefix via the
+    * provider-agnostic context_fold_view. The fold NEVER mutates `messages` and
+    * NEVER touches `system_prompt` (the immutable prefix zone) — it returns a NEW
+    * array we transfer ownership of into out->messages. */
+   if (cfg->history_fold && !cfg->measure_only)
+   {
+      /* Net-gain pre-check: skip when the foldable opportunity is below the
+       * operator's round-trip recovery threshold (no mutation; ledger-auditable). */
+      if (cfg->min_gain_tokens > 0 && out->foldable_tokens < cfg->min_gain_tokens)
+      {
+         out->reason = REDUCE_REASON_SKIP_NO_GAIN;
+         out->mutated = 0;
+         out->messages = NULL;
+         return 0;
+      }
+
+      fold_config_t fc;
+      memset(&fc, 0, sizeof(fc));
+      fc.enabled = 1;
+      fc.retained_msgs = cfg->fold.retained_msgs;
+      fc.min_fold_msgs = cfg->fold.min_fold_msgs;
+      fc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+      fc.register_enabled = cfg->fold.register_enabled;
+      fc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
+
+      fold_result_t fr;
+      memset(&fr, 0, sizeof(fr));
+      if (context_fold_view(messages, &fc, st ? &st->freeze : NULL, &fr) != 0)
+      {
+         /* hard bypass: an internal fold error -> caller forwards the original. */
+         fold_result_free(&fr);
+         out->messages = NULL;
+         out->mutated = 0;
+         return 1;
+      }
+      if (fr.folded)
+      {
+         out->messages = fr.messages; /* transfer ownership */
+         fr.messages = NULL;          /* so fold_result_free does not delete it */
+         out->mutated = 1;
+         out->reason = REDUCE_REASON_REDUCED;
+         out->folded_msgs = fr.folded_msgs;
+         out->retained_msgs = fr.retained_msgs;
+         out->reused_boundary = fr.reused_boundary;
+         out->epochs = st ? st->freeze.epochs : 0;
+
+         int reduced = node_token_estimate(out->messages);
+         if (system_prompt && system_prompt[0])
+            reduced += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
+         out->reduced_tokens = reduced;
+         out->removed_tokens = baseline > reduced ? baseline - reduced : 0;
+
+         if (st)
+            st->reduced = 1; /* provenance: a later seam re-measures, does not re-reduce */
+      }
+      fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
+   }
+
    /* Cost forecast bracket. Basis = the realized saving (removed_tokens) once a
     * lever runs, or the foldable OPPORTUNITY in measure-only (removed==0 here).
     * floor prices the basis at the provider CACHE-READ rate (cache-warm), ceiling
@@ -139,8 +198,13 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
       }
    }
 
-   out->reason = REDUCE_REASON_MEASURED;
-   out->mutated = 0;
-   out->messages = NULL; /* no new array — caller uses its original */
+   /* Only the measure path falls through with reason still unset; a successful
+    * fold above already stamped REDUCED (and owns out->messages). */
+   if (out->reason == REDUCE_REASON_NONE)
+   {
+      out->reason = REDUCE_REASON_MEASURED;
+      out->mutated = 0;
+      out->messages = NULL; /* no new array — caller uses its original */
+   }
    return 0;
 }

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -914,9 +914,12 @@ typedef struct config
     * reduce_measure_enabled: collect baseline/opportunity ledger rows (no
     *   mutation) — the shadow mode that powers the cost numbers.
     * reduce_delegate_seam: enable the economizer at the delegate turn loop.
-    * (Per-lever gates, the gateway seam, and min_gain land in later slices.) */
+    * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
+    *   Closet) at the delegate seam — the first real reduction lever (default-off).
+    * (Other per-lever gates, the gateway seam, and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
+   int reduce_history_fold;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -667,6 +667,11 @@ native_provider_http:
     * fold_freeze_enabled; ignored otherwise. */
    fold_freeze_t agent_fold_freeze;
    memset(&agent_fold_freeze, 0, sizeof(agent_fold_freeze));
+   /* Context economizer (delegate seam): per-run reducer state persisted across
+    * turns so the §3 fold-freeze boundary stays byte-identical (warm provider
+    * cache). Honored only when reduce.delegate_seam is enabled. */
+   reduce_state_t agent_reduce_state;
+   memset(&agent_reduce_state, 0, sizeof(agent_reduce_state));
    /* §4 fold recall: per-run page table of folded-away coordinates, for re-touch
     * hints across turns. Honored only when fold_recall_enabled. */
    fold_recall_index_t agent_fold_recall;
@@ -826,52 +831,95 @@ native_provider_http:
       }
       cJSON *active_tools = final_text_only_turn ? NULL : tools;
 
-      /* Context economizer (delegate seam, measure-only): record a baseline +
-       * foldable-opportunity ledger row when reduce.measure is enabled. Cheap
-       * (mtime-cached) config load keeps this dark by default. Measures the
-       * canonical pre-reduction `messages` so the baseline is provider-agnostic. */
+      /* Context economizer (delegate seam): record a baseline + foldable-opportunity
+       * ledger row, and — when reduce.history_fold is on — ACTUALLY fold the prefix
+       * (provider-agnostic rolling skeleton + Coordinate Closet). The reduced view,
+       * when produced, replaces `messages` for the request build of every provider
+       * branch below and is freed after the request is serialized. Cheap
+       * (mtime-cached) config load keeps this dark by default; default-off is
+       * byte-identical to the prior behavior. */
+      reduce_result_t agent_reduce_result;
+      memset(&agent_reduce_result, 0, sizeof(agent_reduce_result));
+      int reduce_active = 0; /* 1 once a real reduction replaced the message array */
       {
          config_t ecfg;
-         if (config_load(&ecfg) == 0 && ecfg.reduce_measure_enabled && ecfg.reduce_delegate_seam)
+         if (config_load(&ecfg) == 0 && ecfg.reduce_delegate_seam &&
+             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold))
          {
             reduce_config_t rcfg;
             memset(&rcfg, 0, sizeof(rcfg));
             rcfg.delegate_seam = 1;
-            rcfg.measure_only = 1;
+            /* The synthetic fold turns are {role,content:string} — valid input for
+             * anthropic / openai / gemini builders, but the chatgpt Responses
+             * builder passes the array through unconverted and its API expects
+             * top-level typed items, so feeding it folded turns is unverified.
+             * Keep the Responses path measure-only here; fold it in a later slice
+             * once verified live. */
+            rcfg.history_fold = ecfg.reduce_history_fold && !chatgpt;
+            rcfg.measure_only = !rcfg.history_fold; /* fold on -> mutate; else shadow */
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
-            reduce_result_t rres;
+            rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
+            rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;
+            rcfg.fold.register_enabled = ecfg.fold_register_enabled;
+            rcfg.fold.closet.enabled = ecfg.coord_closet_enabled;
+            rcfg.fold.closet.budget_bytes = ecfg.coord_closet_budget_bytes;
+            rcfg.fold.closet.max_ratio_pct = ecfg.coord_closet_max_ratio_pct;
+            rcfg.fold.closet.denylist =
+                ecfg.coord_closet_denylist[0] ? ecfg.coord_closet_denylist : NULL;
+            /* Per-turn provenance: each loop turn is a distinct request at the single
+             * delegate seam, so clear the cross-seam `reduced` flag while preserving
+             * the across-turn freeze boundary in agent_reduce_state.freeze. */
+            agent_reduce_state.reduced = 0;
+            agent_reduce_state.turn = turn;
             /* session_id param unused by the transform; the ledger writer resolves
              * the session itself (a local `session_id[]` array shadows the fn here). */
             if (context_reduce(messages, sys, fb_agent.model, NULL, REDUCE_SEAM_DELEGATE, &rcfg,
-                               NULL, &rres) == 0)
+                               &agent_reduce_state, &agent_reduce_result) == 0)
             {
-               agent_record_reduce_ledger(&rres, fb_agent.model, agent->name, role);
-               context_reduce_result_free(&rres);
+               agent_record_reduce_ledger(&agent_reduce_result, fb_agent.model, agent->name, role);
+               if (agent_reduce_result.mutated && agent_reduce_result.messages)
+                  reduce_active = 1;
+            }
+            else
+            {
+               /* hard bypass: internal failure -> forward the original transcript */
+               context_reduce_result_free(&agent_reduce_result);
+               memset(&agent_reduce_result, 0, sizeof(agent_reduce_result));
             }
          }
       }
+      /* When the economizer produced a reduced view, every provider branch builds
+       * its request from it (and the Anthropic-only build_fold_view path is skipped
+       * to avoid double-folding). */
+      cJSON *eff_messages = reduce_active ? agent_reduce_result.messages : messages;
 
       /* Build request (use fb_agent which may have fallback model after turn 0) */
       cJSON *req;
       fold_result_t fold_view; /* §1 rolling fold; freed after req is serialized */
       memset(&fold_view, 0, sizeof(fold_view));
       if (chatgpt)
-         req = agent_build_request_responses(&fb_agent, messages, active_tools, sys);
+         req = agent_build_request_responses(&fb_agent, eff_messages, active_tools, sys);
       else if (anthropic)
       {
          /* Fold first so payload-rewrite tracking and the request both observe the
-          * actually-sent (possibly folded) message array. */
-         build_fold_view(messages, &agent_fold_freeze, &agent_fold_recall, turn, &fold_view);
-         cJSON *anth_msgs = fold_view.folded ? fold_view.messages : messages;
+          * actually-sent (possibly folded) message array. The economizer's reduced
+          * view takes precedence; otherwise fall back to the Anthropic build_fold_view. */
+         cJSON *anth_msgs = eff_messages;
+         if (!reduce_active)
+         {
+            build_fold_view(messages, &agent_fold_freeze, &agent_fold_recall, turn, &fold_view);
+            if (fold_view.folded)
+               anth_msgs = fold_view.messages;
+         }
          track_anthropic_payload_rewrite(driver, &fb_agent, anth_msgs, sys);
          req = agent_build_request_anthropic(&fb_agent, anth_msgs, active_tools, sys, tok,
                                              temperature);
       }
       else if (gemini)
-         req = agent_build_request_gemini(&fb_agent, messages, active_tools, sys, tok, temperature,
-                                          gemini_cache_name);
+         req = agent_build_request_gemini(&fb_agent, eff_messages, active_tools, sys, tok,
+                                          temperature, gemini_cache_name);
       else
-         req = agent_build_request_openai(&fb_agent, messages, active_tools, tok, temperature);
+         req = agent_build_request_openai(&fb_agent, eff_messages, active_tools, tok, temperature);
 
       /* Universal-gateway P4: run aimee's own outbound call through the same request
        * pipeline the proxy ingresses use, so a config-enabled tool-policing policy
@@ -885,15 +933,17 @@ native_provider_http:
          snprintf(out->error, sizeof(out->error), "gateway request pipeline failed");
          cJSON_Delete(req);
          fold_result_free(&fold_view);
+         context_reduce_result_free(&agent_reduce_result);
          break;
       }
 
       char *body = cJSON_PrintUnformatted(req);
       /* Order matters: req may hold a non-owning reference into fold_view.messages
-       * (agent_build_request_anthropic's AddItemReference fallback), so req must be
-       * deleted before the fold view is freed. */
+       * OR agent_reduce_result.messages (agent_build_request_anthropic's
+       * AddItemReference fallback), so req must be deleted before either is freed. */
       cJSON_Delete(req);
       fold_result_free(&fold_view);
+      context_reduce_result_free(&agent_reduce_result);
       if (!body)
       {
          snprintf(out->error, sizeof(out->error), "failed to build request");

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -373,6 +373,136 @@ static void test_register_annotation(void)
    PASS("register_annotation");
 }
 
+/* --- Cross-provider skeleton/no-split conformance (Slice 2b) --- */
+
+/* OpenAI assistant turn: a string `content` AND a separate top-level `tool_calls`
+ * array whose function.arguments is a JSON STRING. */
+static void add_openai_assistant_tool_call(cJSON *msgs, const char *call_id, const char *name,
+                                           const char *arguments_json)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "assistant");
+   cJSON_AddStringToObject(m, "content", "calling a tool now");
+   cJSON *tcs = cJSON_AddArrayToObject(m, "tool_calls");
+   cJSON *tc = cJSON_CreateObject();
+   cJSON_AddStringToObject(tc, "id", call_id);
+   cJSON_AddStringToObject(tc, "type", "function");
+   cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+   cJSON_AddStringToObject(fn, "name", name);
+   cJSON_AddStringToObject(fn, "arguments", arguments_json); /* a STRING in OpenAI */
+   cJSON_AddItemToArray(tcs, tc);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+/* OpenAI tool result: a separate role:"tool" message (never a role:"user"). */
+static void add_openai_tool_result(cJSON *msgs, const char *call_id, const char *result)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "role", "tool");
+   cJSON_AddStringToObject(m, "tool_call_id", call_id);
+   cJSON_AddStringToObject(m, "content", result);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void test_openai_shape_fold(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   for (int i = 0; i < 7; i++) /* 7 rounds * 3 msgs = 21 messages */
+   {
+      char u[64], cid[32], args[64], res[64];
+      snprintf(u, sizeof(u), "round %d: please process the next file", i);
+      snprintf(cid, sizeof(cid), "call_%03d", i);
+      snprintf(args, sizeof(args), "{\"path\":\"/work/x/file_%03d.c\"}", i);
+      snprintf(res, sizeof(res), "processed file_%03d ok", i);
+      add_user_text(m, u);
+      add_openai_assistant_tool_call(m, cid, "read", args);
+      add_openai_tool_result(m, cid, res);
+   }
+   /* 21 msgs, retained default 8 -> desired split 13 (an assistant) -> backs down to
+    * the clean user turn at index 12; folds rounds 0..3 (file_000..file_003). */
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, NULL, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+
+   /* No-split invariant: the retained tail's first real item is a role:"user"
+    * message — no dangling role:"tool" was left at the boundary (an assistant
+    * tool_calls and its role:"tool" result were never separated). */
+   cJSON *tail0 = cJSON_GetArrayItem(r.messages, 2);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(tail0, "role")), "user") == 0);
+
+   const char *c0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   /* a path embedded in a folded tool_calls `arguments` is captured by the closet */
+   assert(contains(c0, "/work/x/file_002.c"));
+   /* the openai tool call appears in the skeleton */
+   assert(contains(c0, "$") && contains(c0, "read"));
+
+   /* original array untouched */
+   assert(cJSON_GetArraySize(m) == 21);
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("openai_shape_fold");
+}
+
+/* Responses (chatgpt) top-level function_call item; arguments is a STRING. */
+static void add_responses_function_call(cJSON *msgs, const char *call_id, const char *name,
+                                        const char *arguments_json)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "type", "function_call");
+   cJSON_AddStringToObject(m, "call_id", call_id);
+   cJSON_AddStringToObject(m, "name", name);
+   cJSON_AddStringToObject(m, "arguments", arguments_json);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+/* Responses top-level function_call_output item (mirror of a tool_result). */
+static void add_responses_function_call_output(cJSON *msgs, const char *call_id, const char *output)
+{
+   cJSON *m = cJSON_CreateObject();
+   cJSON_AddStringToObject(m, "type", "function_call_output");
+   cJSON_AddStringToObject(m, "call_id", call_id);
+   cJSON_AddStringToObject(m, "output", output);
+   cJSON_AddItemToArray(msgs, m);
+}
+
+static void test_responses_shape_fold(void)
+{
+   cJSON *m = cJSON_CreateArray();
+   for (int i = 0; i < 7; i++) /* 21 items */
+   {
+      char u[64], cid[32], args[64], out[64];
+      snprintf(u, sizeof(u), "round %d: handle the next item", i);
+      snprintf(cid, sizeof(cid), "fc_%03d", i);
+      snprintf(args, sizeof(args), "{\"path\":\"/resp/file_%03d.c\"}", i);
+      snprintf(out, sizeof(out), "wrote /resp/out/file_%03d.log", i);
+      add_user_text(m, u);
+      add_responses_function_call(m, cid, "read", args);
+      add_responses_function_call_output(m, cid, out);
+   }
+   fold_config_t cfg = {.enabled = 1, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_fold_view(m, &cfg, NULL, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+
+   /* retained tail begins with a clean user turn (function_call /
+    * function_call_output items are not role:"user", so none was straddled). */
+   cJSON *tail0 = cJSON_GetArrayItem(r.messages, 2);
+   assert(strcmp(cJSON_GetStringValue(cJSON_GetObjectItem(tail0, "role")), "user") == 0);
+
+   const char *c0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   assert(contains(c0, "/resp/file_002.c"));       /* from a folded function_call arguments */
+   assert(contains(c0, "/resp/out/file_002.log")); /* from a folded function_call_output output */
+   assert(contains(c0, "$") && contains(c0, "read"));
+
+   assert(cJSON_GetArraySize(m) == 21);
+   fold_result_free(&r);
+   cJSON_Delete(m);
+   PASS("responses_shape_fold");
+}
+
 int main(void)
 {
    printf("context_fold tests:\n");
@@ -386,6 +516,8 @@ int main(void)
    test_freeze_boundary_stable();
    test_freeze_prefix_mutation_breaks_reuse();
    test_register_annotation();
+   test_openai_shape_fold();
+   test_responses_shape_fold();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -121,6 +121,53 @@ static void test_unpriced_model_no_cost(void)
    PASS("unpriced model: token opportunity without a $ forecast");
 }
 
+/* Slice 2b: history_fold on (not measure_only) actually folds the prefix. */
+static void test_history_fold_reduces(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages */
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1; /* measure_only stays 0 -> real reduction */
+   cfg.fold.closet.enabled = 1;
+   reduce_state_t st = {0};
+   reduce_result_t out;
+   int rc = context_reduce(m, "system prompt here", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st,
+                           &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_REDUCED);
+   assert(out.mutated == 1 && out.messages != NULL); /* a NEW folded array */
+   assert(out.messages != m);                        /* not the original */
+   assert(out.folded_msgs > 0 && out.retained_msgs > 0);
+   assert(out.reduced_tokens < out.baseline_tokens); /* genuinely smaller */
+   assert(out.removed_tokens == out.baseline_tokens - out.reduced_tokens);
+   assert(st.reduced == 1); /* provenance stamped */
+   /* cost bracket priced on the realized saving (removed_tokens) */
+   assert(out.est_saved_cost_ceiling >= out.est_saved_cost_floor);
+   /* original array untouched (immutable prefix zone honored) */
+   assert(cJSON_GetArraySize(m) == 40);
+   context_reduce_result_free(&out); /* frees the new array */
+   cJSON_Delete(m);
+   PASS("history_fold reduces: new folded array, original untouched");
+}
+
+/* Net-gain pre-check: foldable below min_gain_tokens -> skip, no mutation. */
+static void test_history_fold_skip_no_gain(void)
+{
+   cJSON *m = make_messages(20);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.history_fold = 1;
+   cfg.min_gain_tokens = 1000000; /* unreachable -> always skip */
+   reduce_result_t out;
+   int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_SKIP_NO_GAIN);
+   assert(out.mutated == 0 && out.messages == NULL); /* original forwarded */
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("history_fold skip_no_gain: below min_gain, no mutation");
+}
+
 int main(void)
 {
    printf("context_reduce: unit tests\n");
@@ -130,6 +177,8 @@ int main(void)
    test_short_history_no_foldable();
    test_provenance_already_reduced();
    test_unpriced_model_no_cost();
+   test_history_fold_reduces();
+   test_history_fold_skip_no_gain();
    printf("All context_reduce tests passed.\n");
    return 0;
 }


### PR DESCRIPTION
Slice 2b: makes history-fold provider-agnostic and turns it on (default-off) in the delegate loop via context_reduce.

**What:**
- `skeleton_message` (context_fold.c) is now format-aware: it reads OpenAI/Gemini top-level `tool_calls` (function.name + arguments-as-string) and Responses `function_call`/`function_call_output` items in addition to Anthropic content-blocks, so the Coordinate Closet captures identifiers from every provider's tool calls/results. The fold BOUNDARY (`is_clean_user_turn`) is unchanged — folding only at `role:user` never splits a tool-call/result pair on any provider.
- `context_reduce` gained a real reduction path behind `history_fold` (+ `min_gain_tokens` net-gain pre-check): calls `context_fold_view` with the per-run freeze, transfers ownership of the folded array, recomputes removed/reduced tokens, reason=REDUCED.
- `reduce.history_fold` config flag (default-off).
- agent_runtime.c: a per-run `reduce_state_t` persists the fold-boundary freeze across turns; the pre-dispatch path folds via context_reduce and feeds the reduced array to anthropic/openai/gemini builders (replacing the Anthropic-only build_fold_view when active), freed after serialize.

**Roundtable blocker fixed:** the chatgpt/Responses builder passes the array through unconverted and expects top-level typed items, so feeding it synthetic `{role,content:string}` fold turns is unverified — the **Responses path stays measure-only** here; its fold is deferred to a later slice pending live verification.

Default-off = byte-identical current behavior. Build + lint + full unit-tests green; new conformance tests assert OpenAI/Responses folds, retained-tail-starts-with-user (no dangling tool result), and closet capture of a path embedded in tool_calls arguments.