### PR TITLE
feat(economizer): inbound /v1 gateway seam (shadow-mode measurement, default-off)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -204,7 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `delegate_seam`, `history_fold`, `measure`
+- **`reduce`** — `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -435,6 +435,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
    cfg->reduce_delegate_seam = 0;
    cfg->reduce_history_fold = 0;
+   cfg->reduce_gateway_seam = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -995,7 +995,8 @@ int config_save(const config_t *cfg)
    }
 
    /* Unified context economizer (only save if non-default) */
-   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold)
+   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
+       cfg->reduce_gateway_seam)
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
@@ -1004,6 +1005,8 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
       if (cfg->reduce_history_fold)
          cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
+      if (cfg->reduce_gateway_seam)
+         cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -751,6 +751,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
    if (cJSON_IsBool(item))
       cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
+   if (cJSON_IsBool(item))
+      cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -916,10 +916,15 @@ typedef struct config
     * reduce_delegate_seam: enable the economizer at the delegate turn loop.
     * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
     *   Closet) at the delegate seam — the first real reduction lever (default-off).
-    * (Other per-lever gates, the gateway seam, and min_gain land in later slices.) */
+    * reduce_gateway_seam: enable the economizer at the inbound /v1 gateway seam.
+    *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
+    *   it NEVER mutates the live client request) — collects baselines on live
+    *   ingress traffic with zero behavior change.
+    * (Other per-lever gates and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
    int reduce_history_fold;
+   int reduce_gateway_seam;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -138,7 +138,7 @@ extern "C"
     *
     *   messages       provider-native (delegate seam) or client-wire (gateway seam)
     *                  cJSON array; NEVER mutated in place.
-    *   system_prompt  immutable prefix zone (never reduced).
+    *   system_prompt  immutable prefix zone (never reduced); may be NULL.
     *   model          billable model id, for the cost forecast (may be NULL).
     *   session_id     conversation scope for state/ledger (may be NULL).
     *   seam           which choke point is calling.

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -16,6 +16,7 @@
 #include "aimee.h" /* size macros for agent_types.h */
 #include "agent_config.h"
 #include "agent_exec.h"
+#include "context_reduce.h"
 #include "agent_protocol.h"
 #include "agent_types.h"
 #include "anthropic_ingress.h"
@@ -226,8 +227,42 @@ static int messages_run_request_pipeline(cJSON *req, const delegate_driver_t *dr
    /* P5 (§2.3): opt-in to inject the envelope on the Anthropic-native passthrough.
     * Read config here so gw_stage_memory stays config-free. */
    config_t pcfg;
-   int allow_anthropic_inject =
-       (config_load(&pcfg) == 0 && pcfg.ingress_preinject_anthropic_enabled) ? 1 : 0;
+   int cfg_ok = (config_load(&pcfg) == 0);
+   int allow_anthropic_inject = (cfg_ok && pcfg.ingress_preinject_anthropic_enabled) ? 1 : 0;
+
+   /* Context economizer (gateway seam, SHADOW-MODE ONLY): when reduce.gateway_seam
+    * is on, measure this inbound /v1/messages request's baseline + foldable
+    * opportunity and record a forecast ledger row. measure_only is forced on here so
+    * the request is NEVER mutated — the client transcript is read for the baseline
+    * and the live `req` is forwarded byte-identical (we ignore res.messages, NULL in
+    * measure-only). Done BEFORE the request pipeline so the baseline reflects the
+    * pristine client request, not the memory-injected one. Fully guarded
+    * (config-load, array, free) and context_reduce hard-bypasses on any internal
+    * error, so this can never perturb the client response. Reuses the loaded pcfg;
+    * cheap mtime-cached load keeps it dark by default. */
+   if (cfg_ok && pcfg.reduce_gateway_seam)
+   {
+      cJSON *cmsgs = cJSON_GetObjectItemCaseSensitive(req, "messages");
+      if (cJSON_IsArray(cmsgs))
+      {
+         char *sys_text = anthropic_system_to_text(req); /* flatten string|array system */
+         const cJSON *cmodel = cJSON_GetObjectItemCaseSensitive(req, "model");
+         const char *model = (cmodel && cJSON_IsString(cmodel)) ? cmodel->valuestring : NULL;
+         reduce_config_t rcfg;
+         memset(&rcfg, 0, sizeof(rcfg));
+         rcfg.gateway_seam = 1;
+         rcfg.measure_only = 1; /* shadow mode: this slice never mutates the request */
+         rcfg.fold.retained_msgs = pcfg.fold_retained_msgs;
+         reduce_result_t gw_res;
+         memset(&gw_res, 0, sizeof(gw_res));
+         if (context_reduce(cmsgs, sys_text, model, NULL, REDUCE_SEAM_GATEWAY, &rcfg, NULL,
+                            &gw_res) == 0)
+            agent_record_reduce_ledger(&gw_res, model, "gateway", NULL);
+         context_reduce_result_free(&gw_res);
+         free(sys_text);
+      }
+   }
+
    gw_request_t r = {
        .raw = req,
        .driver = driver,

--- a/src/server/openai_chat.c
+++ b/src/server/openai_chat.c
@@ -28,6 +28,7 @@
 #include "config.h"                 /* config_t, config_load */
 #include "agent_config.h"
 #include "agent_exec.h"
+#include "context_reduce.h"
 #include "agent_protocol.h"  /* parsed_response_t, message_history_repair */
 #include "delegate_driver.h" /* single provider step for the Codex proxy */
 #include "http_retry.h"
@@ -885,6 +886,33 @@ static int agent_execute_messages(const agent_t *agent, cJSON *messages, cJSON *
    memset(out, 0, sizeof(*out));
    if (!agent || !messages)
       return -1;
+
+   /* Context economizer (gateway seam, SHADOW-MODE ONLY): when reduce.gateway_seam
+    * is on, measure this inbound /v1/responses request's baseline + foldable
+    * opportunity and record a forecast ledger row. measure_only is forced on, so the
+    * client request — the `messages` (input) array + `system_prompt` (instructions)
+    * — is NEVER mutated (we ignore res.messages, NULL in measure-only) and is
+    * forwarded byte-identical. Done at ingress, before the gateway pipeline, so the
+    * baseline reflects the pristine client request. Fully guarded; context_reduce
+    * hard-bypasses on any internal error, so this can never perturb the response.
+    * Cheap mtime-cached config load keeps it dark by default. */
+   {
+      config_t ecfg;
+      if (config_load(&ecfg) == 0 && ecfg.reduce_gateway_seam && cJSON_IsArray(messages))
+      {
+         reduce_config_t rcfg;
+         memset(&rcfg, 0, sizeof(rcfg));
+         rcfg.gateway_seam = 1;
+         rcfg.measure_only = 1; /* shadow mode: this slice never mutates the request */
+         rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
+         reduce_result_t gw_res;
+         memset(&gw_res, 0, sizeof(gw_res));
+         if (context_reduce(messages, system_prompt, agent->model, NULL, REDUCE_SEAM_GATEWAY, &rcfg,
+                            NULL, &gw_res) == 0)
+            agent_record_reduce_ledger(&gw_res, agent->model, "gateway", NULL);
+         context_reduce_result_free(&gw_res);
+      }
+   }
 
    delegate_drivers_init();
    const delegate_driver_t *driver = delegate_driver_get(agent->provider);

--- a/src/tests/test_anthropic_http_p2c.c
+++ b/src/tests/test_anthropic_http_p2c.c
@@ -220,6 +220,38 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
    (void)source;
    (void)usage_kind;
 }
+/* Context economizer (gateway seam) is default-off and not under test here; the
+ * shadow-mode hook in messages_run_request_pipeline references these three, so stub
+ * them as no-ops to keep the minimal P2c link from pulling the economizer + its
+ * db1/token_tracker dependency chain. */
+#include "../headers/context_reduce.h"
+int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                   const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                   reduce_state_t *st, reduce_result_t *out)
+{
+   (void)messages;
+   (void)system_prompt;
+   (void)model;
+   (void)session_id;
+   (void)seam;
+   (void)cfg;
+   (void)st;
+   if (out)
+      memset(out, 0, sizeof(*out));
+   return 0;
+}
+void context_reduce_result_free(reduce_result_t *out)
+{
+   (void)out;
+}
+void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *model,
+                                const char *agent_name, const char *role)
+{
+   (void)r;
+   (void)model;
+   (void)agent_name;
+   (void)role;
+}
 /* Enable accounting in this unit so the tap/record path is exercised. */
 int agent_ingress_accounting_enabled(void)
 {

--- a/src/tests/test_anthropic_http_streaming_p2c.c
+++ b/src/tests/test_anthropic_http_streaming_p2c.c
@@ -218,6 +218,38 @@ void agent_record_token_audit_kind(const agent_result_t *result, const char *rol
    (void)source;
    (void)usage_kind;
 }
+/* Context economizer (gateway seam) is default-off and not under test here; the
+ * shadow-mode hook in messages_run_request_pipeline references these three, so stub
+ * them as no-ops to keep the minimal P2c link from pulling the economizer + its
+ * db1/token_tracker dependency chain. */
+#include "../headers/context_reduce.h"
+int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
+                   const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
+                   reduce_state_t *st, reduce_result_t *out)
+{
+   (void)messages;
+   (void)system_prompt;
+   (void)model;
+   (void)session_id;
+   (void)seam;
+   (void)cfg;
+   (void)st;
+   if (out)
+      memset(out, 0, sizeof(*out));
+   return 0;
+}
+void context_reduce_result_free(reduce_result_t *out)
+{
+   (void)out;
+}
+void agent_record_reduce_ledger(const struct reduce_result_s *r, const char *model,
+                                const char *agent_name, const char *role)
+{
+   (void)r;
+   (void)model;
+   (void)agent_name;
+   (void)role;
+}
 int agent_ingress_accounting_enabled(void)
 {
    return 1;

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -4,6 +4,7 @@
 #include "context_reduce.h"
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #define PASS(name) printf("  %s: ok\n", name)
@@ -72,6 +73,68 @@ static void test_measure_only_no_mutation(void)
    context_reduce_result_free(&out);
    cJSON_Delete(m);
    PASS("measure-only: baseline + foldable opportunity, no mutation");
+}
+
+/* Slice 3: the GATEWAY seam in shadow-mode (gateway_seam=1, measure_only=1, st=NULL)
+ * — the exact config the inbound /v1 gateway wiring uses. Asserts the baseline is
+ * computed, nothing is mutated, and the original array is byte-stable, so the live
+ * client request is safe to forward unchanged. */
+static void test_gateway_seam_measure_only(void)
+{
+   cJSON *m = make_messages(20); /* 40 messages */
+   int n_before = cJSON_GetArraySize(m);
+   char *before = cJSON_PrintUnformatted(m);
+   reduce_config_t cfg = {0};
+   cfg.gateway_seam = 1;
+   cfg.measure_only = 1; /* shadow mode: never mutate the live request */
+   cfg.fold.retained_msgs = 0;
+   reduce_result_t out;
+   int rc = context_reduce(m, "system prompt here", "claude-sonnet-4-5", "s1", REDUCE_SEAM_GATEWAY,
+                           &cfg, NULL /* st */, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.baseline_tokens > 0);
+   assert(out.reduced_tokens == out.baseline_tokens); /* nothing removed */
+   assert(out.removed_tokens == 0);
+   assert(out.mutated == 0 && out.messages == NULL); /* request untouched */
+   assert(out.foldable_tokens > 0);                  /* opportunity still measured */
+   /* original array is byte-identical -> the gateway forwards it unchanged */
+   char *after = cJSON_PrintUnformatted(m);
+   assert(cJSON_GetArraySize(m) == n_before);
+   assert(before && after && strcmp(before, after) == 0);
+   free(before);
+   free(after);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("gateway seam measure-only: baseline computed, request byte-identical");
+}
+
+static void test_gateway_seam_null_system_and_model(void)
+{
+   /* Live-gateway edge (roundtable): anthropic_system_to_text can return NULL and
+    * a request may carry no model — both reach context_reduce as NULL. It must not
+    * crash, must still measure (messages-only baseline, no $ forecast), and must
+    * leave the request byte-identical. */
+   cJSON *m = make_messages(20);
+   char *before = cJSON_PrintUnformatted(m);
+   reduce_config_t cfg = {0};
+   cfg.gateway_seam = 1;
+   cfg.measure_only = 1;
+   reduce_result_t out;
+   int rc = context_reduce(m, NULL /* system */, NULL /* model */, NULL, REDUCE_SEAM_GATEWAY, &cfg,
+                           NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.baseline_tokens > 0);         /* messages-only baseline */
+   assert(out.est_saved_cost_floor == 0.0); /* NULL model -> no $ forecast */
+   assert(out.mutated == 0 && out.messages == NULL);
+   char *after = cJSON_PrintUnformatted(m);
+   assert(before && after && strcmp(before, after) == 0);
+   free(before);
+   free(after);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("gateway seam tolerates NULL system + NULL model, request byte-identical");
 }
 
 static void test_short_history_no_foldable(void)
@@ -174,6 +237,8 @@ int main(void)
    test_hard_bypass_null_out();
    test_null_messages();
    test_measure_only_no_mutation();
+   test_gateway_seam_measure_only();
+   test_gateway_seam_null_system_and_model();
    test_short_history_no_foldable();
    test_provenance_already_reduced();
    test_unpriced_model_no_cost();


### PR DESCRIPTION
Slice 3: extends the measurement engine to the inbound /v1 GATEWAY (the live client-serving proxy path) in SHADOW-MODE ONLY.

**What:** new `reduce.gateway_seam` config (default-off). When on, both inbound paths — Anthropic /v1/messages (`messages_run_request_pipeline`) and OpenAI /v1/responses (`agent_execute_messages`) — call `context_reduce` with `measure_only=1` BEFORE the gateway pipeline, recording a `usage_kind='avoided'` forecast ledger row (baseline + foldable opportunity + cost bracket) for the pristine client request.

**Live-traffic safety (the bar for this path):**
- `measure_only=1` is hardcoded at both seams (never from config) and `history_fold` stays 0 → the request array is never mutated and `out.messages` is NULL/ignored; the client request is forwarded byte-identical (asserted by a test: PrintUnformatted before/after strcmp==0).
- Fully guarded (config-load-ok, `cJSON_IsArray`, model shape) and `context_reduce` hard-bypasses on any internal error → it can never perturb the client response.
- Anthropic `system` flattened via existing `anthropic_system_to_text` (handles string + cache_control'd-array) and freed.

**Roundtable:** the 3 flagged blockers were NULL-handling concerns (NULL system/model reaching context_reduce, free(NULL)) — all verified already-safe (context_reduce guards system_prompt+model; free(NULL) is a no-op). Closed by *proving* it: added a NULL-system + NULL-model gateway test (byte-identical, no crash, no $ forecast) and made the NULL contract explicit in the header.

Gateway *mutation* of live requests is deliberately NOT in this slice — a separate roundtable-gated step. Default-off = byte-identical. Build + lint + full unit-tests green.