### PR TITLE
feat(economizer): boundary-free tool-result compress lever (default-off)

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -204,7 +204,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
+- **`reduce`** — `compress`, `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -435,6 +435,7 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
    cfg->reduce_delegate_seam = 0;
    cfg->reduce_history_fold = 0;
+   cfg->reduce_compress = 0;
    cfg->reduce_gateway_seam = 0;
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -996,7 +996,7 @@ int config_save(const config_t *cfg)
 
    /* Unified context economizer (only save if non-default) */
    if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
-       cfg->reduce_gateway_seam)
+       cfg->reduce_compress || cfg->reduce_gateway_seam)
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
@@ -1005,6 +1005,8 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
       if (cfg->reduce_history_fold)
          cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
+      if (cfg->reduce_compress)
+         cJSON_AddBoolToObject(reduce, "compress", cfg->reduce_compress);
       if (cfg->reduce_gateway_seam)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
    }

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -751,6 +751,9 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "history_fold");
    if (cJSON_IsBool(item))
       cfg->reduce_history_fold = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "compress");
+   if (cJSON_IsBool(item))
+      cfg->reduce_compress = cJSON_IsTrue(item) ? 1 : 0;
    item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
    if (cJSON_IsBool(item))
       cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -226,6 +226,199 @@ void fold_result_free(fold_result_t *out)
    out->folded = 0;
 }
 
+/* ---- Boundary-free tool-result body compression (economizer Slice 4) ---- */
+
+/* Compress one tool-result body living at `parent[key]` (a string, or any node we
+ * serialize). `keep` is the head-excerpt size (also the threshold). Returns 1 if
+ * the body was replaced (and accumulates its ORIGINAL byte length into *raw for the
+ * closet ratio cap), 0 if it was below threshold, would not net-shrink, or on OOM.
+ * Identifiers in the FULL body are nominated to `set` ONLY when we commit, so a
+ * body left full never pollutes the closet. Deterministic. */
+static int compress_body_field(cJSON *parent, const char *key, int keep, int turn, coord_set_t *set,
+                               size_t *raw)
+{
+   cJSON *node = cJSON_GetObjectItem(parent, key);
+   char *owned = NULL;
+   const char *body = NULL;
+   if (cJSON_IsString(node))
+      body = node->valuestring;
+   else if (node)
+   {
+      owned = cJSON_PrintUnformatted(node);
+      body = owned;
+   }
+   if (!body)
+   {
+      free(owned);
+      return 0;
+   }
+   size_t blen = strlen(body);
+   if ((int)blen <= keep) /* below threshold -> keep verbatim */
+   {
+      free(owned);
+      return 0;
+   }
+
+   /* Build the candidate (head excerpt + elision marker) and only commit when it
+    * is a genuine net shrink, so an over-threshold-but-tiny body never EXPANDS. */
+   dstr_t d;
+   dstr_init(&d);
+   append_excerpt(&d, body, keep);
+   dstr_appendf(&d, " (%zu bytes elided; identifiers conserved in Coordinate Closet)",
+                blen - (size_t)keep);
+   if (dstr_len(&d) >= blen)
+   {
+      dstr_free(&d);
+      free(owned);
+      return 0;
+   }
+
+   cJSON *repl = cJSON_CreateString(dstr_cstr(&d));
+   dstr_free(&d);
+   if (!repl)
+   {
+      free(owned);
+      return 0;
+   }
+   coord_provenance_t prov = {COORD_LANE_AGENT, turn, -1, -1};
+   coord_closet_nominate(body, blen, &prov, set);
+   if (!cJSON_ReplaceItemInObjectCaseSensitive(parent, key, repl))
+   {
+      cJSON_Delete(repl);
+      free(owned);
+      return 0;
+   }
+   *raw += blen;
+   free(owned);
+   return 1;
+}
+
+/* Compress every oversized tool-result body carried by one message, across all
+ * three provider shapes. Returns the number of bodies compressed in this message.
+ * The shapes are mutually exclusive per message (an OpenAI tool result is a string
+ * `content`; an Anthropic tool_result is a block inside an ARRAY `content`; a
+ * Responses output is a top-level `output`), so no body is double-counted. */
+static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *set, size_t *raw)
+{
+   int n = 0;
+   const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(m, "role"));
+   const char *itype = cJSON_GetStringValue(cJSON_GetObjectItem(m, "type"));
+
+   /* (A) OpenAI / Gemini-as-openai tool result: role=="tool" with string content. */
+   if (role && strcmp(role, "tool") == 0)
+      n += compress_body_field(m, "content", keep, turn, set, raw);
+
+   /* (B) Anthropic tool_result content-block(s) inside a content ARRAY. (A role
+    * "tool" message has a STRING content, so this branch never re-touches it.) */
+   cJSON *content = cJSON_GetObjectItem(m, "content");
+   if (cJSON_IsArray(content))
+   {
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
+      {
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (t && strcmp(t, "tool_result") == 0)
+            n += compress_body_field(b, "content", keep, turn, set, raw);
+      }
+   }
+
+   /* (C) Responses (chatgpt) top-level function_call_output item: an `output` body. */
+   if (itype && strcmp(itype, "function_call_output") == 0)
+      n += compress_body_field(m, "output", keep, turn, set, raw);
+
+   return n;
+}
+
+int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out)
+{
+   if (!out)
+      return -1;
+   memset(out, 0, sizeof(*out));
+   out->closet_evict = COORD_EVICT_NONE;
+   if (!messages || !cJSON_IsArray((cJSON *)messages) || !cfg || !cfg->enabled)
+      return 0;
+
+   int count = cJSON_GetArraySize((cJSON *)messages);
+   int retained = cfg->retained_msgs > 0 ? cfg->retained_msgs : CONTEXT_FOLD_DEFAULT_RETAINED_MSGS;
+   int keep = cfg->reasoning_excerpt_bytes > 0 ? cfg->reasoning_excerpt_bytes
+                                               : CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES;
+   if (count <= 0 || retained >= count)
+      return 0;                  /* nothing ahead of the retained tail */
+   int limit = count - retained; /* messages [0, limit) are compression-eligible */
+
+   /* Deep-copy the whole transcript, then shrink only oversized tool-result BODIES
+    * in the eligible prefix in place. Every message slot, role/type, tool_use_id /
+    * tool_call_id, and the ordering survive untouched, so the call/result pairing
+    * is byte-for-byte intact (zero orphans for message_history_repair). */
+   cJSON *arr = cJSON_Duplicate((cJSON *)messages, 1);
+   if (!arr)
+      return 0; /* OOM: caller uses the original transcript */
+
+   coord_set_t set;
+   coord_set_init(&set);
+   size_t compressed_raw = 0; /* total ORIGINAL bytes of compressed bodies (ratio-cap basis) */
+   int compressed = 0;
+   for (int i = 0; i < limit; i++)
+   {
+      cJSON *m = cJSON_GetArrayItem(arr, i);
+      if (m)
+         compressed += compress_message_bodies(m, keep, i, &set, &compressed_raw);
+   }
+
+   if (compressed == 0)
+   {
+      coord_set_free(&set); /* no body exceeded the threshold -> caller uses original */
+      cJSON_Delete(arr);
+      return 0;
+   }
+
+   /* Conserve any amputated identifiers in a Coordinate Closet, prepended as a
+    * synthetic user+assistant note pair (matching context_fold_view): a plain-text
+    * turn is valid input for every provider builder, and the PAIR keeps Anthropic
+    * role-alternation intact ahead of the (unchanged) original first turn. When the
+    * closet is disabled or empty, render returns NULL and we emit no note — the head
+    * excerpts still carry the leading bytes of each body. */
+   char *closet = coord_closet_render(&set, &cfg->closet, compressed_raw, &out->closet_evict);
+   coord_set_free(&set);
+   if (closet)
+   {
+      cJSON *note = cJSON_CreateObject();
+      cJSON *ack = cJSON_CreateObject();
+      if (note && ack)
+      {
+         dstr_t body;
+         dstr_init(&body);
+         dstr_appendf(&body,
+                      "[compressed %d oversized tool-result body(ies) above; full bodies remain "
+                      "in history — exact identifiers are conserved in the Coordinate Closet]\n\n",
+                      compressed);
+         dstr_append_str(&body, closet);
+         cJSON_AddStringToObject(note, "role", "user");
+         cJSON_AddStringToObject(note, "content", dstr_cstr(&body));
+         cJSON_AddStringToObject(ack, "role", "assistant");
+         cJSON_AddStringToObject(
+             ack, "content",
+             "Understood — identifiers from the compressed tool results are conserved above.");
+         dstr_free(&body);
+         /* insert ack first, then note before it, yielding [note, ack, ...original] */
+         cJSON_InsertItemInArray(arr, 0, ack);
+         cJSON_InsertItemInArray(arr, 0, note);
+      }
+      else
+      {
+         cJSON_Delete(note);
+         cJSON_Delete(ack);
+      }
+      free(closet);
+   }
+
+   out->messages = arr;
+   out->folded = 1; /* flag reused to mean "compressed" */
+   out->folded_msgs = compressed;
+   out->retained_msgs = retained;
+   return 0;
+}
+
 /* FNV-1a over the serialized bytes of messages[0..n); also returns the total
  * serialized size via *bytes. Detects prefix mutation for freeze reuse and bounds
  * the closet ratio cap in one pass. */

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -118,63 +118,136 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
    int foldable_msgs = (n > retained) ? n - retained : 0;
    out->foldable_tokens = prefix_token_estimate(messages, foldable_msgs);
 
-   /* Reduction lever (Slice 2b): when history-fold is enabled and this is neither a
-    * measure-only nor an already-reduced pass, actually fold the prefix via the
-    * provider-agnostic context_fold_view. The fold NEVER mutates `messages` and
-    * NEVER touches `system_prompt` (the immutable prefix zone) — it returns a NEW
-    * array we transfer ownership of into out->messages. */
-   if (cfg->history_fold && !cfg->measure_only)
+   /* `work` is the current working view fed to each lever; it starts as the caller's
+    * (never-mutated) `messages` and becomes a lever-owned NEW array once a lever
+    * mutates. `compressed_owned` is the compress lever's array we own and must free
+    * unless it is published as out->messages or consumed as fold's input copy. */
+   cJSON *work = messages;
+   cJSON *compressed_owned = NULL;
+
+   /* Reduction lever (Slice 4): boundary-free tool-result BODY compression. Runs
+    * FIRST (ahead of fold) so the fold — when also enabled — sees the already-shrunk
+    * bodies. Unlike fold it needs no clean-user-turn boundary, so it engages on
+    * autonomous tool-loops where fold never can. Never mutates `messages`; returns a
+    * NEW array. */
+   if (cfg->compress && !cfg->measure_only)
    {
-      /* Net-gain pre-check: skip when the foldable opportunity is below the
-       * operator's round-trip recovery threshold (no mutation; ledger-auditable). */
-      if (cfg->min_gain_tokens > 0 && out->foldable_tokens < cfg->min_gain_tokens)
-      {
-         out->reason = REDUCE_REASON_SKIP_NO_GAIN;
-         out->mutated = 0;
-         out->messages = NULL;
-         return 0;
-      }
+      fold_config_t cc;
+      memset(&cc, 0, sizeof(cc));
+      cc.enabled = 1;
+      cc.retained_msgs = cfg->fold.retained_msgs;
+      cc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+      cc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
 
-      fold_config_t fc;
-      memset(&fc, 0, sizeof(fc));
-      fc.enabled = 1;
-      fc.retained_msgs = cfg->fold.retained_msgs;
-      fc.min_fold_msgs = cfg->fold.min_fold_msgs;
-      fc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
-      fc.register_enabled = cfg->fold.register_enabled;
-      fc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
-
-      fold_result_t fr;
-      memset(&fr, 0, sizeof(fr));
-      if (context_fold_view(messages, &fc, st ? &st->freeze : NULL, &fr) != 0)
+      fold_result_t cr;
+      memset(&cr, 0, sizeof(cr));
+      if (context_compress_view(work, &cc, &cr) != 0)
       {
-         /* hard bypass: an internal fold error -> caller forwards the original. */
-         fold_result_free(&fr);
+         /* hard bypass: an internal compress error -> caller forwards the original. */
+         fold_result_free(&cr);
          out->messages = NULL;
          out->mutated = 0;
          return 1;
       }
-      if (fr.folded)
+      if (cr.folded)
       {
-         out->messages = fr.messages; /* transfer ownership */
-         fr.messages = NULL;          /* so fold_result_free does not delete it */
+         compressed_owned = cr.messages; /* transfer ownership; we may publish or free it */
+         cr.messages = NULL;             /* so fold_result_free does not delete it */
+         work = compressed_owned;        /* fold (below) compresses-then-folds this view */
          out->mutated = 1;
          out->reason = REDUCE_REASON_REDUCED;
-         out->folded_msgs = fr.folded_msgs;
-         out->retained_msgs = fr.retained_msgs;
-         out->reused_boundary = fr.reused_boundary;
-         out->epochs = st ? st->freeze.epochs : 0;
-
-         int reduced = node_token_estimate(out->messages);
-         if (system_prompt && system_prompt[0])
-            reduced += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
-         out->reduced_tokens = reduced;
-         out->removed_tokens = baseline > reduced ? baseline - reduced : 0;
-
+         out->folded_msgs = cr.folded_msgs; /* bodies compressed (may be overwritten by fold) */
          if (st)
             st->reduced = 1; /* provenance: a later seam re-measures, does not re-reduce */
       }
-      fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
+      fold_result_free(&cr); /* cr.messages is NULL when transferred; no-op otherwise */
+   }
+
+   /* Reduction lever (Slice 2b): when history-fold is enabled and this is neither a
+    * measure-only nor an already-reduced pass, actually fold the prefix via the
+    * provider-agnostic context_fold_view. The fold NEVER mutates its input and
+    * NEVER touches `system_prompt` (the immutable prefix zone) — it returns a NEW
+    * array we transfer ownership of into out->messages. It folds `work` (the
+    * possibly-compressed view), chaining the two levers. */
+   if (cfg->history_fold && !cfg->measure_only)
+   {
+      /* Net-gain pre-check: skip when the foldable opportunity is below the
+       * operator's round-trip recovery threshold (no mutation; ledger-auditable).
+       * When compress already mutated, we fall through to publish that result. */
+      if (cfg->min_gain_tokens > 0 && out->foldable_tokens < cfg->min_gain_tokens)
+      {
+         if (!compressed_owned)
+         {
+            out->reason = REDUCE_REASON_SKIP_NO_GAIN;
+            out->mutated = 0;
+            out->messages = NULL;
+            return 0;
+         }
+         /* compress mutated -> publish below; do not run fold */
+      }
+      else
+      {
+         fold_config_t fc;
+         memset(&fc, 0, sizeof(fc));
+         fc.enabled = 1;
+         fc.retained_msgs = cfg->fold.retained_msgs;
+         fc.min_fold_msgs = cfg->fold.min_fold_msgs;
+         fc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+         fc.register_enabled = cfg->fold.register_enabled;
+         fc.closet = cfg->fold.closet; /* zero -> defaults; denylist borrowed for this call */
+
+         fold_result_t fr;
+         memset(&fr, 0, sizeof(fr));
+         if (context_fold_view(work, &fc, st ? &st->freeze : NULL, &fr) != 0)
+         {
+            /* hard bypass: an internal fold error -> caller forwards the original. */
+            fold_result_free(&fr);
+            if (compressed_owned)
+               cJSON_Delete(compressed_owned);
+            out->messages = NULL;
+            out->mutated = 0;
+            return 1;
+         }
+         if (fr.folded)
+         {
+            out->messages = fr.messages; /* transfer ownership */
+            fr.messages = NULL;          /* so fold_result_free does not delete it */
+            out->mutated = 1;
+            out->reason = REDUCE_REASON_REDUCED;
+            out->folded_msgs = fr.folded_msgs;
+            out->retained_msgs = fr.retained_msgs;
+            out->reused_boundary = fr.reused_boundary;
+            out->epochs = st ? st->freeze.epochs : 0;
+            if (st)
+               st->reduced = 1;   /* provenance: a later seam re-measures, does not re-reduce */
+            if (compressed_owned) /* fold built its own array from the compressed copy */
+            {
+               cJSON_Delete(compressed_owned);
+               compressed_owned = NULL;
+            }
+         }
+         fold_result_free(&fr); /* fr.messages is NULL when transferred; no-op otherwise */
+      }
+   }
+
+   /* Publish the compress-only result when fold was disabled or no-opped (fold sets
+    * out->messages itself and frees compressed_owned when it folds). */
+   if (compressed_owned && !out->messages)
+   {
+      out->messages = compressed_owned;
+      compressed_owned = NULL;
+   }
+
+   /* Recompute the reduced/removed token forecast once, over whatever reduced view
+    * a lever produced (compress and/or fold). The system prompt is the immutable
+    * prefix zone — counted, never reduced (mirrors the baseline). */
+   if (out->mutated && out->messages)
+   {
+      int reduced = node_token_estimate(out->messages);
+      if (system_prompt && system_prompt[0])
+         reduced += (int)(strlen(system_prompt) / CHARS_PER_TOKEN_EST) + 1;
+      out->reduced_tokens = reduced;
+      out->removed_tokens = baseline > reduced ? baseline - reduced : 0;
    }
 
    /* Cost forecast bracket. Basis = the realized saving (removed_tokens) once a

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -916,6 +916,11 @@ typedef struct config
     * reduce_delegate_seam: enable the economizer at the delegate turn loop.
     * reduce_history_fold: actually fold old history (rolling skeleton + Coordinate
     *   Closet) at the delegate seam — the first real reduction lever (default-off).
+    * reduce_compress: boundary-free tool-result BODY compression at the delegate
+    *   seam (Slice 4). Shrinks oversized tool-result bodies in place (identifiers
+    *   conserved in the Coordinate Closet) WITHOUT needing a clean-user-turn
+    *   boundary, so it engages on autonomous tool-loops where history_fold can't.
+    *   Provider-native output (valid for all builders incl. chatgpt). Default-off.
     * reduce_gateway_seam: enable the economizer at the inbound /v1 gateway seam.
     *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
     *   it NEVER mutates the live client request) — collects baselines on live
@@ -924,6 +929,7 @@ typedef struct config
    int reduce_measure_enabled;
    int reduce_delegate_seam;
    int reduce_history_fold;
+   int reduce_compress;
    int reduce_gateway_seam;
 
    /* Session/worktree cleanup policy.

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -89,6 +89,39 @@ extern "C"
    int context_fold_view(const cJSON *messages, const fold_config_t *cfg, fold_freeze_t *freeze,
                          fold_result_t *out);
 
+   /* Boundary-free TOOL-RESULT body compression (§ economizer Slice 4).
+    *
+    * Unlike context_fold_view, this needs NO clean-user-turn boundary: it shrinks
+    * oversized tool-result BODIES IN PLACE while keeping the carrying message, its
+    * role/type, and its tool_use_id / tool_call_id — so a tool_use and its result
+    * are NEVER split and message_history_repair finds zero orphans. This is why it
+    * engages on autonomous tool-loops (one user turn, then assistant tool_calls +
+    * results forever) where the fold's boundary never appears.
+    *
+    * For every message at index < (count - retained_msgs) it walks all three
+    * provider tool-result shapes — Anthropic content-block type=="tool_result"
+    * (.content string|obj), OpenAI role=="tool" (.content string), Responses
+    * type=="function_call_output" (.output) — and, for each body whose serialized
+    * length exceeds cfg->reasoning_excerpt_bytes (0 -> CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES)
+    * AND that would actually shrink, replaces it with a head excerpt + an elision
+    * marker. The exact identifiers in the full body are first nominated into a
+    * Coordinate Closet, which (when cfg->closet.enabled) is prepended as a synthetic
+    * user+assistant note pair (matching context_fold_view's closet emission) so
+    * conserved identifiers ride along. EVERYTHING else — role/type, ids, message
+    * ordering, all non-tool-result content — is byte-for-byte preserved.
+    *
+    * The input `messages` array is NEVER mutated: out->messages is a fresh
+    * deep-copied array the caller owns (fold_result_free). On success with at least
+    * one body compressed, out->folded = 1 (the flag is reused to mean "compressed")
+    * and out->folded_msgs = the count of bodies compressed. If nothing exceeded the
+    * threshold (or on OOM / disabled / too-short), out->folded = 0 and
+    * out->messages = NULL (the caller uses the original). Returns 0 on success
+    * (incl. no-op), -1 on bad args. Deterministic: identical (messages, cfg) ->
+    * byte-identical out->messages serialization (for freeze/cache warmth). Output
+    * is provider-native (only bodies shortened + a plain-text note pair), so it is
+    * valid input for ALL provider builders, including chatgpt/Responses. */
+   int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_result_t *out);
+
    /* Free any owned resources in *out. NULL-safe on a zeroed result and on a
     * no-fold result (out->messages == NULL), so callers may invoke it
     * unconditionally after any build path. */

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -60,6 +60,7 @@ extern "C"
       /* Per-lever gates (all default-off). */
       int inject_compress; /* KB/code envelope + code->file:line compression */
       int history_fold;    /* rolling history skeleton + Coordinate Closet */
+      int compress;        /* boundary-free tool-result BODY compression (Slice 4) */
       int dedup;           /* merge consecutive same-role string turns */
       int freeze;          /* byte-identical reduced prefix across turns */
 

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -844,7 +844,7 @@ native_provider_http:
       {
          config_t ecfg;
          if (config_load(&ecfg) == 0 && ecfg.reduce_delegate_seam &&
-             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold))
+             (ecfg.reduce_measure_enabled || ecfg.reduce_history_fold || ecfg.reduce_compress))
          {
             reduce_config_t rcfg;
             memset(&rcfg, 0, sizeof(rcfg));
@@ -856,7 +856,12 @@ native_provider_http:
              * Keep the Responses path measure-only here; fold it in a later slice
              * once verified live. */
             rcfg.history_fold = ecfg.reduce_history_fold && !chatgpt;
-            rcfg.measure_only = !rcfg.history_fold; /* fold on -> mutate; else shadow */
+            /* Compress only shrinks tool-result BODIES in place — the message
+             * shape (role/type, ids, typed items) is preserved — so its output is
+             * valid for ALL builders INCLUDING chatgpt/Responses. Not gated off. */
+            rcfg.compress = ecfg.reduce_compress;
+            rcfg.measure_only =
+                !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -503,6 +503,216 @@ static void test_responses_shape_fold(void)
    PASS("responses_shape_fold");
 }
 
+/* ---- Boundary-free tool-result body compression (economizer Slice 4) ----
+ * Reuses add_openai_assistant_tool_call / add_openai_tool_result defined above. */
+
+/* Build a deterministic body well past the 160-byte excerpt threshold, with a
+ * unique path placed at the END so it is amputated from the head excerpt and must
+ * be recovered from the Coordinate Closet. Filler carries no identifiers. */
+static void make_big_body(char *buf, size_t bufsz, const char *path_tail)
+{
+   size_t pos = 0;
+   while (pos + 48 < bufsz - 96)
+      pos += (size_t)snprintf(buf + pos, bufsz - pos, "filler padding output text here and more; ");
+   snprintf(buf + pos, bufsz - pos, "trailing details recorded at %s end", path_tail);
+}
+
+/* (a) Single-user-turn OpenAI tool-loop: old tool-result bodies compress, the
+ *     latest `retained` stay full, every tool_call_id survives, and a path buried
+ *     past the excerpt window is conserved (Coordinate Closet). This is the proof
+ *     that compress engages where fold cannot (no user-turn boundary mid-loop). */
+static void test_compress_openai_tool_loop(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "Do the autonomous task."); /* the ONLY user turn */
+   char body[700];
+   char id[32], path[64], args[48];
+   const int pairs = 12;
+   for (int k = 0; k < pairs; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      snprintf(args, sizeof(args), "{\"n\":%d}", k);
+      add_openai_assistant_tool_call(msgs, id, "read_file", args);
+      snprintf(path, sizeof(path), "/work/src/module_%d.c", k);
+      make_big_body(body, sizeof(body), path);
+      add_openai_tool_result(msgs, id, body);
+   }
+   int orig_count = cJSON_GetArraySize(msgs); /* 1 + 24 = 25 */
+
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_compress_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL);
+   assert(r.folded_msgs > 0);
+
+   /* input untouched: the last tool result is still its full big body */
+   cJSON *last_in = cJSON_GetArrayItem(msgs, orig_count - 1);
+   assert(strlen(cJSON_GetStringValue(cJSON_GetObjectItem(last_in, "content"))) > 200);
+
+   /* output: a synthetic closet note pair was prepended, then every original
+    * message survives in order — no message dropped, every tool_call_id kept. */
+   int out_count = cJSON_GetArraySize(r.messages);
+   assert(out_count == orig_count + 2);
+   int in_tool = 0, out_tool = 0;
+   cJSON *it;
+   cJSON_ArrayForEach(it, msgs)
+   {
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(it, "role"));
+      if (role && strcmp(role, "tool") == 0)
+         in_tool++;
+   }
+   /* an early result (in the eligible prefix) is compressed; the latest is full */
+   int compressed_seen = 0, full_seen = 0;
+   cJSON_ArrayForEach(it, r.messages)
+   {
+      const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(it, "role"));
+      if (!role || strcmp(role, "tool") != 0)
+         continue;
+      out_tool++;
+      const char *id_s = cJSON_GetStringValue(cJSON_GetObjectItem(it, "tool_call_id"));
+      const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(it, "content"));
+      assert(id_s && c);
+      if (contains(c, "bytes elided"))
+         compressed_seen++;
+      else if (strlen(c) > 200)
+         full_seen++;
+   }
+   assert(in_tool == pairs && out_tool == pairs); /* none dropped */
+   assert(compressed_seen >= 1);                  /* old bodies shrank */
+   assert(full_seen >= 1);                        /* the retained tail stayed full */
+   assert(compressed_seen == r.folded_msgs);
+
+   /* every original tool_call_id still present in the output */
+   for (int k = 0; k < pairs; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      int found = 0;
+      cJSON_ArrayForEach(it, r.messages)
+      {
+         const char *id_s = cJSON_GetStringValue(cJSON_GetObjectItem(it, "tool_call_id"));
+         if (id_s && strcmp(id_s, id) == 0)
+            found = 1;
+      }
+      assert(found);
+   }
+
+   /* a path buried past the excerpt window in a COMPRESSED body survives via the
+    * Coordinate Closet note (it is NOT in the shrunk body's head excerpt). */
+   char *flat = cJSON_PrintUnformatted(r.messages);
+   assert(contains(flat, "/work/src/module_2.c"));
+   /* and the conserving note rode along */
+   const char *note0 =
+       cJSON_GetStringValue(cJSON_GetObjectItem(cJSON_GetArrayItem(r.messages, 0), "content"));
+   assert(contains(note0, "Coordinate Closet"));
+   free(flat);
+
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("compress_openai_tool_loop");
+}
+
+/* (b) Anthropic tool_result content-block shape compresses in place. */
+static void test_compress_anthropic_shape(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "start");
+   char body[700];
+   char id[32];
+   for (int k = 0; k < 10; k++)
+   {
+      snprintf(id, sizeof(id), "toolu_%02d", k);
+      add_assistant_tool_use(msgs, id, "grep", "pat");
+      char path[64];
+      snprintf(path, sizeof(path), "/repo/pkg/file_%d.go", k);
+      make_big_body(body, sizeof(body), path);
+      add_user_tool_result(msgs, id, body); /* Anthropic block: content string */
+   }
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 6, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_compress_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 1 && r.messages != NULL && r.folded_msgs >= 1);
+
+   /* find a compressed tool_result block in the output */
+   int compressed = 0;
+   cJSON *it;
+   cJSON_ArrayForEach(it, r.messages)
+   {
+      cJSON *content = cJSON_GetObjectItem(it, "content");
+      if (!cJSON_IsArray(content))
+         continue;
+      cJSON *b;
+      cJSON_ArrayForEach(b, content)
+      {
+         const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
+         if (t && strcmp(t, "tool_result") == 0)
+         {
+            const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(b, "content"));
+            /* tool_use_id preserved on the block */
+            assert(cJSON_GetObjectItem(b, "tool_use_id") != NULL);
+            if (c && contains(c, "bytes elided"))
+               compressed++;
+         }
+      }
+   }
+   assert(compressed >= 1);
+   char *flat = cJSON_PrintUnformatted(r.messages);
+   assert(contains(flat, "/repo/pkg/file_1.go")); /* conserved in closet */
+   free(flat);
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("compress_anthropic_shape");
+}
+
+/* (c) Determinism: identical input -> byte-identical output. */
+static void test_compress_deterministic(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "go");
+   char body[700], id[32], path[64];
+   for (int k = 0; k < 12; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      add_openai_assistant_tool_call(msgs, id, "ls", "{}");
+      snprintf(path, sizeof(path), "/srv/data/blob_%d.bin", k);
+      make_big_body(body, sizeof(body), path);
+      add_openai_tool_result(msgs, id, body);
+   }
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+   fold_result_t r1, r2;
+   assert(context_compress_view(msgs, &cfg, &r1) == 0 && r1.folded == 1);
+   assert(context_compress_view(msgs, &cfg, &r2) == 0 && r2.folded == 1);
+   char *s1 = cJSON_PrintUnformatted(r1.messages);
+   char *s2 = cJSON_PrintUnformatted(r2.messages);
+   assert(s1 && s2 && strcmp(s1, s2) == 0);
+   free(s1);
+   free(s2);
+   fold_result_free(&r1);
+   fold_result_free(&r2);
+   cJSON_Delete(msgs);
+   PASS("compress_deterministic");
+}
+
+/* (d) No-op when every tool-result body is below the threshold. */
+static void test_compress_below_threshold_noop(void)
+{
+   cJSON *msgs = cJSON_CreateArray();
+   add_user_text(msgs, "go");
+   char id[32];
+   for (int k = 0; k < 12; k++)
+   {
+      snprintf(id, sizeof(id), "call_%02d", k);
+      add_openai_assistant_tool_call(msgs, id, "ls", "{}");
+      add_openai_tool_result(msgs, id, "ok"); /* tiny body, far below 160 bytes */
+   }
+   fold_config_t cfg = {.enabled = 1, .retained_msgs = 8, .closet = {.enabled = 1}};
+   fold_result_t r;
+   assert(context_compress_view(msgs, &cfg, &r) == 0);
+   assert(r.folded == 0 && r.messages == NULL); /* caller uses the original */
+   fold_result_free(&r);
+   cJSON_Delete(msgs);
+   PASS("compress_below_threshold_noop");
+}
+
 int main(void)
 {
    printf("context_fold tests:\n");
@@ -518,6 +728,10 @@ int main(void)
    test_register_annotation();
    test_openai_shape_fold();
    test_responses_shape_fold();
+   test_compress_openai_tool_loop();
+   test_compress_anthropic_shape();
+   test_compress_deterministic();
+   test_compress_below_threshold_noop();
    printf("ALL PASS\n");
    return 0;
 }

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -231,6 +231,113 @@ static void test_history_fold_skip_no_gain(void)
    PASS("history_fold skip_no_gain: below min_gain, no mutation");
 }
 
+/* Build a single-user-turn OpenAI tool-loop: 1 user msg, then `pairs` of
+ * (assistant tool_calls + role:"tool" result with a big body). There is NO user
+ * turn mid-loop, so context_fold_view can never find a clean boundary — the proof
+ * surface for the boundary-free compress lever. */
+static cJSON *make_tool_loop(int pairs)
+{
+   cJSON *arr = cJSON_CreateArray();
+   cJSON *u = cJSON_CreateObject();
+   cJSON_AddStringToObject(u, "role", "user");
+   cJSON_AddStringToObject(u, "content", "Do the autonomous task.");
+   cJSON_AddItemToArray(arr, u);
+   for (int k = 0; k < pairs; k++)
+   {
+      char id[32];
+      snprintf(id, sizeof(id), "call_%02d", k);
+      cJSON *a = cJSON_CreateObject();
+      cJSON_AddStringToObject(a, "role", "assistant");
+      cJSON *tcs = cJSON_AddArrayToObject(a, "tool_calls");
+      cJSON *tc = cJSON_CreateObject();
+      cJSON_AddStringToObject(tc, "id", id);
+      cJSON_AddStringToObject(tc, "type", "function");
+      cJSON *fn = cJSON_AddObjectToObject(tc, "function");
+      cJSON_AddStringToObject(fn, "name", "read_file");
+      cJSON_AddStringToObject(fn, "arguments", "{}");
+      cJSON_AddItemToArray(tcs, tc);
+      cJSON_AddItemToArray(arr, a);
+
+      cJSON *t = cJSON_CreateObject();
+      cJSON_AddStringToObject(t, "role", "tool");
+      cJSON_AddStringToObject(t, "tool_call_id", id);
+      char body[700];
+      size_t pos = 0;
+      while (pos + 48 < sizeof(body) - 96)
+         pos +=
+             (size_t)snprintf(body + pos, sizeof(body) - pos, "filler output bytes here and on; ");
+      snprintf(body + pos, sizeof(body) - pos, "tail at /work/src/module_%d.c done", k);
+      cJSON_AddStringToObject(t, "content", body);
+      cJSON_AddItemToArray(arr, t);
+   }
+   return arr;
+}
+
+/* Compress engages on a tool-loop where fold cannot: fold-only no-ops (no clean
+ * boundary), but compress mutates and shrinks the old tool-result bodies. */
+static void test_compress_engages_where_fold_cannot(void)
+{
+   /* fold-only: must NOT mutate (no clean user-turn boundary in the loop) */
+   {
+      cJSON *m = make_tool_loop(12);
+      reduce_config_t cfg = {0};
+      cfg.delegate_seam = 1;
+      cfg.history_fold = 1;
+      cfg.fold.closet.enabled = 1;
+      reduce_result_t out;
+      int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+      assert(rc == 0);
+      assert(out.mutated == 0 && out.messages == NULL); /* fold found no boundary */
+      context_reduce_result_free(&out);
+      cJSON_Delete(m);
+   }
+   /* compress-only: mutates, shrinks, preserves every message + tool_call_id */
+   {
+      cJSON *m = make_tool_loop(12);
+      int orig_count = cJSON_GetArraySize(m);
+      reduce_config_t cfg = {0};
+      cfg.delegate_seam = 1;
+      cfg.compress = 1;
+      cfg.fold.closet.enabled = 1;
+      reduce_state_t st = {0};
+      reduce_result_t out;
+      int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out);
+      assert(rc == 0);
+      assert(out.reason == REDUCE_REASON_REDUCED);
+      assert(out.mutated == 1 && out.messages != NULL && out.messages != m);
+      assert(out.folded_msgs > 0);
+      assert(out.reduced_tokens < out.baseline_tokens); /* genuinely smaller */
+      assert(out.removed_tokens == out.baseline_tokens - out.reduced_tokens);
+      assert(st.reduced == 1);
+      assert(cJSON_GetArraySize(m) == orig_count); /* original untouched */
+      /* a buried path is conserved (Coordinate Closet rode along) */
+      char *flat = cJSON_PrintUnformatted(out.messages);
+      assert(flat && strstr(flat, "/work/src/module_2.c"));
+      free(flat);
+      context_reduce_result_free(&out);
+      cJSON_Delete(m);
+   }
+}
+
+/* measure_only must suppress the compress mutation (shadow mode). */
+static void test_compress_measure_only_no_mutation(void)
+{
+   cJSON *m = make_tool_loop(12);
+   reduce_config_t cfg = {0};
+   cfg.delegate_seam = 1;
+   cfg.compress = 1;
+   cfg.measure_only = 1; /* shadow */
+   cfg.fold.closet.enabled = 1;
+   reduce_result_t out;
+   int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, NULL, &out);
+   assert(rc == 0);
+   assert(out.reason == REDUCE_REASON_MEASURED);
+   assert(out.mutated == 0 && out.messages == NULL);
+   context_reduce_result_free(&out);
+   cJSON_Delete(m);
+   PASS("compress measure_only: shadow, no mutation");
+}
+
 int main(void)
 {
    printf("context_reduce: unit tests\n");
@@ -244,6 +351,8 @@ int main(void)
    test_unpriced_model_no_cost();
    test_history_fold_reduces();
    test_history_fold_skip_no_gain();
+   test_compress_engages_where_fold_cannot();
+   test_compress_measure_only_no_mutation();
    printf("All context_reduce tests passed.\n");
    return 0;
 }


### PR DESCRIPTION
Slice 4: adds `reduce.compress` — in-place compression of oversized tool-result bodies, the lever the live .254 measurement showed delegate tool-loops actually need (fold can't engage on single-user-turn loops; compress can, because shrinking a tool_result BODY preserves the message + its tool_use_id/tool_call_id and never splits a pair → no boundary required).

**What:** `context_compress_view` deep-copies the transcript and, for messages before the retained tail, replaces oversized tool-result bodies (OpenAI `role:tool`.content / Anthropic `tool_result` block.content / Responses `function_call_output`.output) with a head-excerpt + `(N bytes elided)` marker, conserving identifiers in a prepended Coordinate Closet note. Net-shrink-guarded (never expands), deterministic (byte-identical — for cache-warmth). Chained in `context_reduce` compress→fold; `reduce.compress` config (default-off); fed to ALL provider builders incl. chatgpt/Responses (shape preserved, unlike fold's synthetic turns).

**Invariants:** only body string values are swapped (`cJSON_ReplaceItemInObjectCaseSensitive`); message slots/role/type/ids untouched → `message_history_repair` sees zero orphans. cJSON ownership tracked across compress-only/fold-only/chained/hard-bypass/no-op.

**Tests:** compress mutates an OpenAI tool-loop while fold no-ops it; Anthropic shape; determinism; below-threshold no-op; ids/messages preserved; a buried path recovered via the closet. Full unit-tests green.

Roundtable: no blockers. Default-off = no behavior change.