### PR TITLE
feat(tools): raise tool-output cap to 32KB + make it configurable

### DIFF
--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -22,7 +22,7 @@ aimee config set <key> <value>    # set one value
 
 Structured options (arrays, nested objects — e.g. `ensemble.reference_models`) are not CLI-settable; they are written into the config file under the sections listed at the end.
 
-## CLI-settable keys (134)
+## CLI-settable keys (135)
 
 | Key | Type | Description |
 |-----|------|-------------|
@@ -153,6 +153,7 @@ Structured options (arrays, nested objects — e.g. `ensemble.reference_models`)
 | `provider` | string | Default model provider. |
 | `reasoning_cap_enabled` | bool | Cap the model's reasoning effort. |
 | `require_session_worktree` | bool | Fail closed on mutating ops outside an aimee-managed worktree (session-isolation guard; default off). |
+| `tool_output_max_bytes` | int | Per-result cap (bytes) on the model-visible tool output (read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the prompt + history; the (default-off) context-economizer compresses older results to keep history bounded. |
 | `tsr_command` | string | TSR sidecar endpoint/command for structured-PDF table recognition (resolves like embedding_command; AIMEE_TSR_URL env fallback). |
 | `typed_facts_enabled` | bool | Enable the typed-fact knowledge layer (master gate; default off). |
 | `verify_cross_project` | bool | Let `aimee git verify` span other projects. |

--- a/scripts/gen-reference-docs.py
+++ b/scripts/gen-reference-docs.py
@@ -152,6 +152,11 @@ CFG_KEY_DESC = {
     "ingress_max_raw_scans": "Max raw-content scans per ingress request.",
     "code_span_max_lines": "Max line span the code_span_get recovery resolver returns per call "
     "(default 400).",
+    "tool_output_max_bytes": "Per-result cap (bytes) on the model-visible tool output "
+    "(read_file/bash/grep/glob/git_* results). 0 = built-in default (32768); any positive value is "
+    "clamped to (0, 32768]. Set it lower to bound the bytes a single tool result adds to the "
+    "prompt + history; the (default-off) context-economizer compresses older results to keep "
+    "history bounded.",
     "require_session_worktree": "Fail closed on mutating ops outside an aimee-managed worktree "
     "(session-isolation guard; default off).",
     "ingress_preinject_assembly_budget": "Token budget for ingress context pre-injection.",

--- a/src/config.c
+++ b/src/config.c
@@ -545,6 +545,9 @@ static void config_set_defaults(config_t *cfg)
    cfg->ingress_preinject_assembly_budget = 6144;
    cfg->ingress_max_raw_scans = 0;
    cfg->code_span_max_lines = 400;
+   /* 0 = use the built-in default AGENT_TOOL_OUTPUT_MAX (32768) for the
+    * per-result model-visible tool-output cap (see agent_tool_output_cap()). */
+   cfg->tool_output_max_bytes = 0;
    cfg->ingress_compress_min_chars = 80;
    cfg->require_session_worktree = 0;
    /* Default-on as of the virtual-context rollout: the long-session benchmark
@@ -942,6 +945,10 @@ int config_load(config_t *cfg)
    item = cJSON_GetObjectItemCaseSensitive(root, "code_span_max_lines");
    if (cJSON_IsNumber(item) && item->valuedouble > 0)
       cfg->code_span_max_lines = (int)item->valuedouble;
+
+   item = cJSON_GetObjectItemCaseSensitive(root, "tool_output_max_bytes");
+   if (cJSON_IsNumber(item) && item->valuedouble >= 0)
+      cfg->tool_output_max_bytes = (int)item->valuedouble;
 
    item = cJSON_GetObjectItemCaseSensitive(root, "require_session_worktree");
    if (cJSON_IsBool(item))

--- a/src/config_fields.c
+++ b/src/config_fields.c
@@ -56,6 +56,7 @@ const config_field_t config_fields[] = {
      sizeof(int), 0, CFG_INT},
     {"ingress_max_raw_scans", offsetof(config_t, ingress_max_raw_scans), sizeof(int), 0, CFG_INT},
     {"code_span_max_lines", offsetof(config_t, code_span_max_lines), sizeof(int), 0, CFG_INT},
+    {"tool_output_max_bytes", offsetof(config_t, tool_output_max_bytes), sizeof(int), 0, CFG_INT},
     {"require_session_worktree", offsetof(config_t, require_session_worktree), sizeof(int), 0,
      CFG_BOOL},
     {"typed_facts_enabled", offsetof(config_t, typed_facts_enabled), sizeof(int), 0, CFG_BOOL},

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -801,6 +801,8 @@ int config_save(const config_t *cfg)
                               cfg->ingress_preinject_assembly_budget);
    if (cfg->code_span_max_lines != 400)
       cJSON_AddNumberToObject(root, "code_span_max_lines", cfg->code_span_max_lines);
+   if (cfg->tool_output_max_bytes != 0)
+      cJSON_AddNumberToObject(root, "tool_output_max_bytes", cfg->tool_output_max_bytes);
    if (cfg->ingress_max_raw_scans != 0)
       cJSON_AddNumberToObject(root, "ingress_max_raw_scans", cfg->ingress_max_raw_scans);
    if (cfg->require_session_worktree)

--- a/src/headers/agent_exec.h
+++ b/src/headers/agent_exec.h
@@ -162,6 +162,26 @@ char *agent_load_project_contract(const char *project_root);
  * string bounded by AGENT_TOOL_OUTPUT_MAX; caller must free(). */
 char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *tool_name);
 
+/* Pure clamp half of agent_tool_output_cap(): map a configured
+ * tool_output_max_bytes value to an effective per-result cap. 0/negative ->
+ * AGENT_TOOL_OUTPUT_MAX (built-in default); any positive value is clamped to
+ * (0, AGENT_TOOL_OUTPUT_RAW_MAX]. Header-inline so it is the single source of
+ * truth for both the config-reading resolver and unit tests (zero linkage). */
+static inline size_t agent_tool_output_cap_clamp(int configured)
+{
+   if (configured <= 0)
+      return (size_t)AGENT_TOOL_OUTPUT_MAX;
+   if ((size_t)configured > (size_t)AGENT_TOOL_OUTPUT_RAW_MAX)
+      return (size_t)AGENT_TOOL_OUTPUT_RAW_MAX;
+   return (size_t)configured;
+}
+
+/* Resolve the per-result MODEL-VISIBLE tool-output cap (bytes). Reads
+ * tool_output_max_bytes from config (mtime-cached) and clamps via
+ * agent_tool_output_cap_clamp(). Single source of truth for every
+ * model-visible tool-result truncation site. */
+size_t agent_tool_output_cap(void);
+
 /* Self-correcting delegate loop
  *
  * Wraps agent_run in a quality-checking loop. After each iteration the agent

--- a/src/headers/agent_types.h
+++ b/src/headers/agent_types.h
@@ -45,20 +45,29 @@ struct cJSON;
 #define AGENT_BACKEND_CLI_STDIO    "cli-stdio" /* legacy config alias */
 #define CLI_CMD_MAX                256
 #define AGENT_DEFAULT_MAX_PARALLEL 3
-#define AGENT_TOOL_OUTPUT_MAX      (4 * 1024)
-#define AGENT_TOOL_OUTPUT_RAW_MAX  (32 * 1024)
-#define AGENT_MAX_LIST_FILES       500
-#define AGENT_MAX_TOOL_CALLS       16
-#define AGENT_MAX_NET_HOSTS        64
-#define AGENT_MAX_NETWORKS         8
-#define AGENT_MAX_TUNNELS          8
-#define AGENT_CONTEXT_BUDGET       16000
-#define AGENT_CACHE_TTL_SECONDS    300
-#define AGENT_MAX_PLAN_STEPS       32
-#define AGENT_MAX_PLAN_DEPS        8
-#define AGENT_MAX_CHECKPOINTS      32
-#define AGENT_MAX_EVAL_TASKS       64
-#define AGENT_MAX_COORD_AGENTS     4
+/* Default per-result cap (bytes) on the MODEL-VISIBLE tool output. Raised to
+ * 32 KB (== AGENT_TOOL_OUTPUT_RAW_MAX) so full tool output flows to the model by
+ * default; the (default-off) context-economizer losslessly compresses OLD
+ * results to keep history bounded. Operators can LOWER the per-result cap via
+ * the `tool_output_max_bytes` config key (resolved by agent_tool_output_cap()).
+ * This constant is the resolver's fallback when the key is unset/0. */
+#define AGENT_TOOL_OUTPUT_MAX (32 * 1024)
+/* Raw capture safety buffer (bytes): the hard ceiling on bytes captured from a
+ * child process before any model-visible truncation. NOT operator-configurable
+ * and never exceeded by the resolved per-result cap. */
+#define AGENT_TOOL_OUTPUT_RAW_MAX (32 * 1024)
+#define AGENT_MAX_LIST_FILES      500
+#define AGENT_MAX_TOOL_CALLS      16
+#define AGENT_MAX_NET_HOSTS       64
+#define AGENT_MAX_NETWORKS        8
+#define AGENT_MAX_TUNNELS         8
+#define AGENT_CONTEXT_BUDGET      16000
+#define AGENT_CACHE_TTL_SECONDS   300
+#define AGENT_MAX_PLAN_STEPS      32
+#define AGENT_MAX_PLAN_DEPS       8
+#define AGENT_MAX_CHECKPOINTS     32
+#define AGENT_MAX_EVAL_TASKS      64
+#define AGENT_MAX_COORD_AGENTS    4
 
 /* Per-call HTTP timeout for one turn of the multi-turn tool loop.
  *   agent_timeout_ms  configured per-call timeout (also the per-call cap)

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -353,6 +353,13 @@ typedef struct config
     * resolver will return in one call. Bounds the per-call recovery cost and a
     * model-supplied range. */
    int code_span_max_lines;
+   /* Operator cap (bytes) on the per-result MODEL-VISIBLE tool output (read_file,
+    * bash, grep, glob, git_* results). 0 = use the built-in default
+    * AGENT_TOOL_OUTPUT_MAX (32768). Any positive value is clamped to
+    * (0, AGENT_TOOL_OUTPUT_RAW_MAX=32768]; set it LOWER to bound the bytes a
+    * single tool result contributes to the prompt + history. Resolved by
+    * agent_tool_output_cap(); never exceeds the 32 KB raw capture buffer. */
+   int tool_output_max_bytes;
    /* ingress-compression master gate (§6.5 B8), default off. When on, code-search
     * hits are span-enriched (the matched line is located) and the ingress envelope
     * folds code entries into recoverable references; off keeps the search query,

--- a/src/posix/agent_tools.c
+++ b/src/posix/agent_tools.c
@@ -44,6 +44,19 @@ static int bash_delegate_cancel_requested(void)
    return (job_id > 0 && db1_agent_job_is_cancelled && db1_agent_job_is_cancelled(job_id)) ||
           (agent_delegation_stop_requested && agent_delegation_stop_requested(NULL, 0));
 }
+/* Single source of truth for the per-result MODEL-VISIBLE tool-output cap.
+ * Reads tool_output_max_bytes from config (mtime-cached) and clamps it via the
+ * header-inline agent_tool_output_cap_clamp(): 0/unset -> the built-in
+ * AGENT_TOOL_OUTPUT_MAX default (32768); any positive value clamps to
+ * (0, AGENT_TOOL_OUTPUT_RAW_MAX]. Callers resolve ONCE per call into a local so
+ * the cap can't change mid-loop. */
+size_t agent_tool_output_cap(void)
+{
+   config_t cfg;
+   if (config_load(&cfg) != 0)
+      return (size_t)AGENT_TOOL_OUTPUT_MAX;
+   return agent_tool_output_cap_clamp(cfg.tool_output_max_bytes);
+}
 static void bash_kill_child_tree(pid_t pid)
 {
    if (pid <= 0)
@@ -1105,7 +1118,8 @@ char *tool_read_file(const char *path, int offset, int limit)
       free(file_data);
       return safe_strdup(err_msg);
    }
-   char *buf = malloc(AGENT_TOOL_OUTPUT_MAX + 1);
+   size_t cap = agent_tool_output_cap();
+   char *buf = malloc(cap + 1);
    if (!buf)
    {
       fclose(f);
@@ -1124,12 +1138,12 @@ char *tool_read_file(const char *path, int offset, int limit)
       if (offset > 0 && line_num <= offset)
          continue;
       size_t len = strlen(line);
-      if (total + len >= AGENT_TOOL_OUTPUT_MAX)
+      if (total + len >= cap)
       {
-         size_t avail = AGENT_TOOL_OUTPUT_MAX - total;
+         size_t avail = cap - total;
          if (avail > 0)
             memcpy(buf + total, line, avail);
-         total = AGENT_TOOL_OUTPUT_MAX;
+         total = cap;
          break;
       }
       memcpy(buf + total, line, len);
@@ -1285,7 +1299,7 @@ char *tool_list_files(const char *path, const char *pattern)
          return safe_strdup("error: glob failed");
    }
 
-   size_t buf_size = AGENT_TOOL_OUTPUT_MAX;
+   size_t buf_size = agent_tool_output_cap();
    char *buf = malloc(buf_size + 1);
    if (!buf)
    {
@@ -1580,7 +1594,7 @@ char *tool_verify(const char *check_type, const char *target, const char *expect
                argv[j] = tokens[j];
             argv[tc] = NULL;
             char *output = NULL;
-            int rc = safe_exec_capture(argv, &output, AGENT_TOOL_OUTPUT_MAX);
+            int rc = safe_exec_capture(argv, &output, agent_tool_output_cap());
             int pass = (rc == 0);
             cJSON_AddBoolToObject(result, "pass", pass);
             cJSON_AddNumberToObject(result, "exit_code", rc);
@@ -1629,7 +1643,7 @@ char *tool_grep(const char *path, const char *pattern, int max_results)
    const char *argv[] = {"grep", "--binary-files=without-match", "-rn", "--exclude-dir=.git", "--exclude-dir=.aimee", "--exclude-dir=build", "--exclude-dir=dist", "--exclude-dir=node_modules", "-m", max_str, "--", pattern, actual_path, NULL};
    // clang-format on
    char *output = NULL;
-   int rc = safe_exec_capture(argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = safe_exec_capture(argv, &output, agent_tool_output_cap());
 
    if (rc != 0 && rc != 1 && (!output || !output[0]))
    {
@@ -1663,7 +1677,7 @@ char *tool_git_diff(const char *repo_path, const char *ref)
 
    const workspace_provider_t *ws = workspace_provider_active();
    char *output = NULL;
-   int rc = ws->exec(ws, argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = ws->exec(ws, argv, &output, agent_tool_output_cap());
    if (rc != 0 && (!output || !output[0]))
    {
       free(output);
@@ -1688,7 +1702,7 @@ char *tool_git_status(const char *repo_path)
    const char *argv[] = {"git", "-C", actual_path, "status", "--porcelain", NULL};
    const workspace_provider_t *ws = workspace_provider_active();
    char *output = NULL;
-   int rc = ws->exec(ws, argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = ws->exec(ws, argv, &output, agent_tool_output_cap());
    if (rc != 0 && (!output || !output[0]))
    {
       free(output);
@@ -1797,7 +1811,7 @@ char *tool_git_log(const char *repo_path, int count)
 
    const char *argv[] = {"git", "-C", actual_path, "log", "--oneline", "-n", count_str, NULL};
    char *output = NULL;
-   int rc = safe_exec_capture(argv, &output, AGENT_TOOL_OUTPUT_MAX);
+   int rc = safe_exec_capture(argv, &output, agent_tool_output_cap());
 
    if (rc != 0 && (!output || !output[0]))
    {

--- a/src/server/agent_policy.c
+++ b/src/server/agent_policy.c
@@ -1078,9 +1078,10 @@ static void compact_cfg_from_app_config(const config_t *app, compact_config_t *o
 }
 
 /* Wrapper around compact_tool_result() using application config.
- * Falls back to the AGENT_TOOL_OUTPUT_MAX hard cap so oversized results
- * are always bounded even if compaction produces a larger-than-expected
- * summary (e.g. malformed JSON that fails parsing).
+ * Falls back to the resolved per-result cap (agent_tool_output_cap_clamp;
+ * default AGENT_TOOL_OUTPUT_MAX) so oversized results are always bounded even
+ * if compaction produces a larger-than-expected summary (e.g. malformed JSON
+ * that fails parsing).
  *
  * tool_name may be NULL to skip per-tool overrides. */
 char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *tool_name)
@@ -1097,6 +1098,10 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
    else
       memset(&cfg, 0, sizeof(cfg)); /* use defaults on load failure */
 
+   /* Per-result model-visible cap (operator-configurable, default 32768).
+    * Resolved ONCE here so the closet budget and the hard cap below agree. */
+   size_t cap = agent_tool_output_cap_clamp(loaded ? app_cfg.tool_output_max_bytes : 0);
+
    char *out = compact_tool_result(raw, raw_len, &cfg, tool_name, 0, 0);
    if (!out)
       return strdup("");
@@ -1112,7 +1117,7 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
    /* Fold §2 — Coordinate Closet: when the result was compacted, conserve the
     * verbatim identifiers from the pre-truncation raw so they survive. Render the
     * closet first (it is byte-bounded), then reserve room for it under the hard
-    * cap so the combined result still never exceeds AGENT_TOOL_OUTPUT_MAX.
+    * cap so the combined result still never exceeds the resolved per-result cap.
     * Default-off; return-only wiring (no cross-turn persistence in P1). */
    char *closet = NULL;
    size_t closet_len = 0;
@@ -1129,8 +1134,10 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
       coord_provenance_t prov = {COORD_LANE_AGENT, -1, -1, -1};
       coord_closet_nominate(raw, raw_len, &prov, &set);
       /* Bound the closet budget so body + closet can never exceed the hard cap:
-       * closet <= AGENT_TOOL_OUTPUT_MAX - min-body, leaving room for the body. */
-      int hard_room = AGENT_TOOL_OUTPUT_MAX - 256;
+       * closet <= cap - min-body, leaving room for the body. */
+      int hard_room = (int)cap - 256;
+      if (hard_room < 0)
+         hard_room = 0; /* tiny operator cap: no room for a closet */
       int cb = app_cfg.coord_closet_budget_bytes;
       if (cb > hard_room)
          cb = hard_room;
@@ -1152,11 +1159,12 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
       coord_set_free(&set);
    }
 
-   /* Hard cap: ensure the result never exceeds AGENT_TOOL_OUTPUT_MAX regardless
-    * of what the compaction summary produced. Reserve closet bytes inside the cap. */
-   size_t body_cap = AGENT_TOOL_OUTPUT_MAX;
-   if (closet_len > 0 && closet_len + 1 < AGENT_TOOL_OUTPUT_MAX)
-      body_cap = AGENT_TOOL_OUTPUT_MAX - closet_len - 1;
+   /* Hard cap: ensure the result never exceeds the resolved per-result cap
+    * regardless of what the compaction summary produced. Reserve closet bytes
+    * inside the cap. */
+   size_t body_cap = cap;
+   if (closet_len > 0 && closet_len + 1 < cap)
+      body_cap = cap - closet_len - 1;
    if (out_len > body_cap)
    {
       out[body_cap] = '\0';

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -949,6 +949,11 @@ $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config-surface: $(OBJDIR)/tests/test_config_surface.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+# Configurable tool-output cap: tests the header-inline clamp resolver
+# (agent_tool_output_cap_clamp). No extra objects — the clamp is pure.
+$(TESTPREFIX)/unit-test-tool-output-cap: $(OBJDIR)/tests/test_tool_output_cap.o
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 # Learning detector replay (citation heuristics). Runs the real

--- a/src/tests/test_config_surface.c
+++ b/src/tests/test_config_surface.c
@@ -38,6 +38,7 @@ static const char *FIXTURE_A =
     "true\n"
     "ingress_preinject_assembly_budget: 1\n"
     "code_span_max_lines: 7\n"
+    "tool_output_max_bytes: 4096\n"
     "ingress_max_raw_scans: 3\nembedding_command: ZZA_val\nembedding_model: "
     "ZZA_val\nembedding_endpoint: ZZA_val\nembedding_dim: 1\nmemory_rerank_mode: "
     "ZZA_val\nmemory_rewrite:\n  enabled: true\n  hyde: true\n  decompose: true\n  max_subqueries: "
@@ -93,6 +94,7 @@ static const char *FIXTURE_B =
     "false\n"
     "ingress_preinject_assembly_budget: 4096\n"
     "code_span_max_lines: 4096\n"
+    "tool_output_max_bytes: 8192\n"
     "ingress_max_raw_scans: 4096\nembedding_command: ZZB_val\nembedding_model: "
     "ZZB_val\nembedding_endpoint: ZZB_val\nembedding_dim: 4096\nmemory_rerank_mode: "
     "ZZB_val\nmemory_rewrite:\n  enabled: false\n  hyde: false\n  decompose: false\n  "
@@ -178,6 +180,7 @@ int main(void)
    assert(cfgA.css_style_graph_enabled == 1 && cfgB.css_style_graph_enabled == 0);
    assert(cfgA.ingress_preinject_assembly_budget != cfgB.ingress_preinject_assembly_budget);
    assert(cfgA.code_span_max_lines != cfgB.code_span_max_lines);
+   assert(cfgA.tool_output_max_bytes != cfgB.tool_output_max_bytes);
    assert(cfgA.ingress_max_raw_scans != cfgB.ingress_max_raw_scans);
    assert(strcmp(cfgA.embedding_command, cfgB.embedding_command) != 0);
    assert(strcmp(cfgA.embedding_model, cfgB.embedding_model) != 0);
@@ -328,6 +331,6 @@ int main(void)
    assert(cfgA.ensemble_min_successful != cfgB.ensemble_min_successful);
    assert(cfgA.ensemble_max_cost_usd != cfgB.ensemble_max_cost_usd);
 
-   printf("all tests passed (145 parsed fields)\n");
+   printf("all tests passed (146 parsed fields)\n");
    return 0;
 }

--- a/src/tests/test_tool_output_cap.c
+++ b/src/tests/test_tool_output_cap.c
@@ -1,0 +1,67 @@
+/* test_tool_output_cap.c: unit tests for the configurable tool-output cap.
+ *
+ * Exercises agent_tool_output_cap_clamp() — the pure, header-inline clamp half
+ * of agent_tool_output_cap() that maps a configured tool_output_max_bytes value
+ * to an effective per-result MODEL-VISIBLE cap. This is the single source of
+ * truth for the clamp, so testing it pins the resolver semantics with zero
+ * linkage. */
+#include <assert.h>
+#include <stdio.h>
+#include "aimee.h"
+#include "agent_exec.h"
+
+#define PASS(name) printf("  PASS: %s\n", name)
+
+static void test_constants(void)
+{
+   /* Default raised to 32 KB; never exceeds the raw capture safety buffer. */
+   assert(AGENT_TOOL_OUTPUT_MAX == 32 * 1024);
+   assert(AGENT_TOOL_OUTPUT_RAW_MAX == 32 * 1024);
+   PASS("constants");
+}
+
+static void test_unset_is_default(void)
+{
+   /* 0 == unset -> built-in default (32768). */
+   assert(agent_tool_output_cap_clamp(0) == (size_t)AGENT_TOOL_OUTPUT_MAX);
+   assert(agent_tool_output_cap_clamp(0) == 32768);
+   PASS("unset_is_default");
+}
+
+static void test_negative_is_default(void)
+{
+   /* Defensive: a negative value also falls back to the default. */
+   assert(agent_tool_output_cap_clamp(-1) == 32768);
+   assert(agent_tool_output_cap_clamp(-100000) == 32768);
+   PASS("negative_is_default");
+}
+
+static void test_lower_value_honored(void)
+{
+   /* An operator may set the cap LOWER than the default. */
+   assert(agent_tool_output_cap_clamp(4096) == 4096);
+   assert(agent_tool_output_cap_clamp(16384) == 16384);
+   assert(agent_tool_output_cap_clamp(1) == 1);
+   PASS("lower_value_honored");
+}
+
+static void test_clamp_to_raw_max(void)
+{
+   /* A value above the 32 KB raw safety buffer clamps down to it. */
+   assert(agent_tool_output_cap_clamp(32768) == 32768);
+   assert(agent_tool_output_cap_clamp(32769) == 32768);
+   assert(agent_tool_output_cap_clamp(1000000) == (size_t)AGENT_TOOL_OUTPUT_RAW_MAX);
+   PASS("clamp_to_raw_max");
+}
+
+int main(void)
+{
+   printf("test_tool_output_cap:\n");
+   test_constants();
+   test_unset_is_default();
+   test_negative_is_default();
+   test_lower_value_honored();
+   test_clamp_to_raw_max();
+   printf("All tool-output-cap tests passed.\n");
+   return 0;
+}


### PR DESCRIPTION
Raises the model-visible per-result tool-output cap from **4 KB → 32 KB** (== the existing raw-capture ceiling) and makes it operator-configurable.

**Why:** the hardcoded 4 KB `AGENT_TOOL_OUTPUT_MAX` lossily truncated tool results *at execution time*, before the conversation history existed — so it pre-empted the (lossless, identifier-conserving) context-economizer and starved the model of tool output it often needs *now*. Letting full output (up to the 32 KB raw ceiling) flow, then having the economizer compress OLD results losslessly, is the better architecture: recent results full for the model, old ones bounded.

**What:**
- `AGENT_TOOL_OUTPUT_MAX` 4*1024 → 32*1024 (raw ceiling `AGENT_TOOL_OUTPUT_RAW_MAX` unchanged at 32 KB).
- New flat config key `tool_output_max_bytes` (default 0 = use the 32 KB default; clamped to [1, 32768]) — operators can LOWER it. Resolver `agent_tool_output_cap()` (mtime-cached) + pure `agent_tool_output_cap_clamp()`. Threaded through the model-visible truncation sites in `agent_tools.c` + `agent_policy.c agent_compress_tool_result` (the bash path), resolved once per call.

**⚠️ Behavior change:** tool results now flow up to 32 KB by default (8× larger). For tool-heavy turns this grows context/cost unless the context-economizer (default-off) is enabled to bound history. Pair with `reduce.compress` for lossless history control.

**Safety:** raw-capture buffers unchanged; result strings flow into dynamic cJSON (no fixed-buffer overflow); macro-sized buffers scaled in place. Roundtable: no real blockers (2 flagged were verified false — NULL-check + config-read both present); 8× growth flagged as the deliberate tradeoff. Tests: `unit-test-tool-output-cap` (default 32768 / clamp / lower-honored) + config-surface. Full suite green.

Follow-up (flagged, out of scope): a few delegate/verify/Windows capture sites inherit the new default via the constant but aren't wired to the knob (won't shrink if lowered).