### PR TITLE
refactor(economizer): unify tool-result compaction into one shared compact_body core

### DIFF
--- a/src/compact.c
+++ b/src/compact.c
@@ -177,10 +177,15 @@ static char *compact_plaintext(const char *raw, size_t raw_len, int head_bytes, 
    return out;
 }
 
-/* ------------------------------------------------------------------ public API */
+/* ------------------------------------------------------------------ shrink core */
 
-char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_t *cfg,
-                          const char *tool_name, int context_used, int context_budget)
+/* Apply the three-strategy shrink and return a freshly heap-allocated result
+ * (caller frees). This is the byte-for-byte logic the public API used to expose
+ * directly; compact_body() wraps it into a caller-owned buffer. Kept as a static
+ * allocator so the well-tested strategy code (pass-through / JSON summary /
+ * head+tail) is unchanged — only the public ownership model moved. */
+static char *compact_shrink_alloc(const char *raw, size_t raw_len, const char *tool_name,
+                                  const compact_config_t *cfg)
 {
    if (!raw)
       return strdup("");
@@ -220,16 +225,6 @@ char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_
    if (!enabled)
       return strdup(raw);
 
-   /* Dynamic budget adjustment: shrink threshold as context fills */
-   if (context_budget > 0 && context_used > 0)
-   {
-      int used_pct = (int)((long long)context_used * 100 / context_budget);
-      if (used_pct >= 80)
-         threshold = threshold / 2;
-      else if (used_pct >= 60)
-         threshold = threshold * 3 / 4;
-   }
-
    if (threshold < 64)
       threshold = 64; /* floor: never compact below 64 bytes */
 
@@ -246,4 +241,42 @@ char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_
 
    /* Strategy 2: plain-text head + tail */
    return compact_plaintext(raw, raw_len, head_bytes, tail_bytes);
+}
+
+/* ------------------------------------------------------------------ public API */
+
+size_t compact_body(const char *raw, size_t raw_len, const char *tool_name,
+                    const compact_config_t *cfg, char *out, size_t out_cap)
+{
+   if (!out || out_cap == 0)
+      return 0;
+   if (!raw || raw_len == 0)
+   {
+      out[0] = '\0';
+      return 0;
+   }
+
+   char *s = compact_shrink_alloc(raw, raw_len, tool_name, cfg);
+   if (!s)
+   {
+      /* Allocation failure inside the shrink. Degrade to a bounded copy of the raw
+       * body rather than emitting an empty string — a non-empty body must never be
+       * silently dropped to "" (the caller's `compacted = out_len < raw_len` would
+       * otherwise treat OOM as a successful compaction). The caller still bounds the
+       * result (eager hard-cap; lazy net-shrink guard). */
+      size_t n = raw_len;
+      if (n > out_cap - 1)
+         n = out_cap - 1;
+      memcpy(out, raw, n);
+      out[n] = '\0';
+      return n;
+   }
+
+   size_t n = strlen(s);
+   if (n > out_cap - 1)
+      n = out_cap - 1; /* defensive: a correctly-sized buffer never truncates */
+   memcpy(out, s, n);
+   out[n] = '\0';
+   free(s);
+   return n;
 }

--- a/src/context_fold.c
+++ b/src/context_fold.c
@@ -2,6 +2,7 @@
  * See context_fold.h for the contract. Pure: cJSON + dstr + coord_closet only. */
 #include "context_fold.h"
 
+#include "compact.h" /* compact_body — the shared tool-result shrink core */
 #include "dstr.h"
 #include "fold_register.h"
 #include <stdlib.h>
@@ -229,13 +230,14 @@ void fold_result_free(fold_result_t *out)
 /* ---- Boundary-free tool-result body compression (economizer Slice 4) ---- */
 
 /* Compress one tool-result body living at `parent[key]` (a string, or any node we
- * serialize). `keep` is the head-excerpt size (also the threshold). Returns 1 if
- * the body was replaced (and accumulates its ORIGINAL byte length into *raw for the
- * closet ratio cap), 0 if it was below threshold, would not net-shrink, or on OOM.
- * Identifiers in the FULL body are nominated to `set` ONLY when we commit, so a
- * body left full never pollutes the closet. Deterministic. */
-static int compress_body_field(cJSON *parent, const char *key, int keep, int turn, coord_set_t *set,
-                               size_t *raw)
+ * serialize). `cc` carries the resolved shrink policy (threshold/head/tail) for the
+ * shared compact_body() core. Returns 1 if the body was replaced (and accumulates
+ * its ORIGINAL byte length into *raw for the closet ratio cap), 0 if it was below
+ * threshold, would not net-shrink, or on OOM. Identifiers in the FULL body are
+ * nominated to `set` ONLY when we commit, so a body left full never pollutes the
+ * closet. Deterministic. */
+static int compress_body_field(cJSON *parent, const char *key, const compact_config_t *cc, int turn,
+                               coord_set_t *set, size_t *raw)
 {
    cJSON *node = cJSON_GetObjectItem(parent, key);
    char *owned = NULL;
@@ -253,28 +255,32 @@ static int compress_body_field(cJSON *parent, const char *key, int keep, int tur
       return 0;
    }
    size_t blen = strlen(body);
-   if ((int)blen <= keep) /* below threshold -> keep verbatim */
+   if (cc->threshold > 0 && blen <= (size_t)cc->threshold) /* below threshold -> keep verbatim */
    {
       free(owned);
       return 0;
    }
 
-   /* Build the candidate (head excerpt + elision marker) and only commit when it
-    * is a genuine net shrink, so an over-threshold-but-tiny body never EXPANDS. */
-   dstr_t d;
-   dstr_init(&d);
-   append_excerpt(&d, body, keep);
-   dstr_appendf(&d, " (%zu bytes elided; identifiers conserved in Coordinate Closet)",
-                blen - (size_t)keep);
-   if (dstr_len(&d) >= blen)
+   /* Shrink via the shared core (JSON summary or head+tail), then commit only on a
+    * genuine net shrink so an over-threshold-but-tiny body never EXPANDS. The buffer
+    * is sized per the compact_body contract so no strategy is truncated. */
+   size_t cap = blen + COMPACT_JSON_SUMMARY_MAX + 1;
+   char *buf = malloc(cap);
+   if (!buf)
    {
-      dstr_free(&d);
+      free(owned);
+      return 0;
+   }
+   size_t n = compact_body(body, blen, NULL, cc, buf, cap);
+   if (n == 0 || n >= blen)
+   {
+      free(buf);
       free(owned);
       return 0;
    }
 
-   cJSON *repl = cJSON_CreateString(dstr_cstr(&d));
-   dstr_free(&d);
+   cJSON *repl = cJSON_CreateString(buf);
+   free(buf);
    if (!repl)
    {
       free(owned);
@@ -298,7 +304,8 @@ static int compress_body_field(cJSON *parent, const char *key, int keep, int tur
  * The shapes are mutually exclusive per message (an OpenAI tool result is a string
  * `content`; an Anthropic tool_result is a block inside an ARRAY `content`; a
  * Responses output is a top-level `output`), so no body is double-counted. */
-static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *set, size_t *raw)
+static int compress_message_bodies(cJSON *m, const compact_config_t *cc, int turn, coord_set_t *set,
+                                   size_t *raw)
 {
    int n = 0;
    const char *role = cJSON_GetStringValue(cJSON_GetObjectItem(m, "role"));
@@ -306,7 +313,7 @@ static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *se
 
    /* (A) OpenAI / Gemini-as-openai tool result: role=="tool" with string content. */
    if (role && strcmp(role, "tool") == 0)
-      n += compress_body_field(m, "content", keep, turn, set, raw);
+      n += compress_body_field(m, "content", cc, turn, set, raw);
 
    /* (B) Anthropic tool_result content-block(s) inside a content ARRAY. (A role
     * "tool" message has a STRING content, so this branch never re-touches it.) */
@@ -318,13 +325,13 @@ static int compress_message_bodies(cJSON *m, int keep, int turn, coord_set_t *se
       {
          const char *t = cJSON_GetStringValue(cJSON_GetObjectItem(b, "type"));
          if (t && strcmp(t, "tool_result") == 0)
-            n += compress_body_field(b, "content", keep, turn, set, raw);
+            n += compress_body_field(b, "content", cc, turn, set, raw);
       }
    }
 
    /* (C) Responses (chatgpt) top-level function_call_output item: an `output` body. */
    if (itype && strcmp(itype, "function_call_output") == 0)
-      n += compress_body_field(m, "output", keep, turn, set, raw);
+      n += compress_body_field(m, "output", cc, turn, set, raw);
 
    return n;
 }
@@ -346,6 +353,21 @@ int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_
       return 0;                  /* nothing ahead of the retained tail */
    int limit = count - retained; /* messages [0, limit) are compression-eligible */
 
+   /* Resolve the shared shrink policy ONCE. `compact.*` knobs (mirrored into the
+    * fold config) are the single source of truth for head/tail, so this seam and the
+    * eager seam shrink identically. `keep` (the excerpt budget) is the compression
+    * threshold; the tail is capped to keep/2 so a small excerpt budget keeps the
+    * tail proportional instead of inheriting a large compact default (§2.4). */
+   compact_config_t cc;
+   memset(&cc, 0, sizeof(cc));
+   cc.enabled = 1;
+   cc.threshold = keep;
+   cc.head_bytes = cfg->compact_head_bytes; /* 0 -> compact.c default */
+   int tail_default =
+       cfg->compact_tail_bytes > 0 ? cfg->compact_tail_bytes : COMPACT_DEFAULT_TAIL_BYTES;
+   int tail_cap = keep / 2;
+   cc.tail_bytes = tail_cap > 0 && tail_cap < tail_default ? tail_cap : tail_default;
+
    /* Deep-copy the whole transcript, then shrink only oversized tool-result BODIES
     * in the eligible prefix in place. Every message slot, role/type, tool_use_id /
     * tool_call_id, and the ordering survive untouched, so the call/result pairing
@@ -362,7 +384,7 @@ int context_compress_view(const cJSON *messages, const fold_config_t *cfg, fold_
    {
       cJSON *m = cJSON_GetArrayItem(arr, i);
       if (m)
-         compressed += compress_message_bodies(m, keep, i, &set, &compressed_raw);
+         compressed += compress_message_bodies(m, &cc, i, &set, &compressed_raw);
    }
 
    if (compressed == 0)

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -137,6 +137,8 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
       cc.enabled = 1;
       cc.retained_msgs = cfg->fold.retained_msgs;
       cc.reasoning_excerpt_bytes = cfg->fold.reasoning_excerpt_bytes;
+      cc.compact_head_bytes = cfg->fold.compact_head_bytes; /* compact.* governs both seams */
+      cc.compact_tail_bytes = cfg->fold.compact_tail_bytes;
       cc.closet = cfg->fold.closet; /* zero -> module defaults; denylist borrowed for this call */
 
       fold_result_t cr;

--- a/src/headers/compact.h
+++ b/src/headers/compact.h
@@ -10,6 +10,14 @@
 #define COMPACT_DEFAULT_TAIL_BYTES 1024 /* trailing bytes to keep in plain-text results */
 #define COMPACT_MAX_PER_TOOL       8    /* max per-tool threshold overrides */
 
+/* Upper bound on a JSON structural-summary body. A summary can be LARGER than a
+ * tiny raw input (the only way compact_body output exceeds raw_len), so callers
+ * sizing the output buffer must allow raw_len + this much headroom to guarantee
+ * the summary is never itself truncated. ENFORCED: compact_json_summary() builds
+ * into a fixed `char summary[2048]` with bounded snprintf, so its result is always
+ * < this value — keep these in sync, and see test_compact's json_summary_bounded. */
+#define COMPACT_JSON_SUMMARY_MAX 2048
+
 /* Per-tool threshold override.
  * Set threshold to -1 to disable compaction entirely for a specific tool. */
 typedef struct
@@ -28,22 +36,41 @@ typedef struct
    int per_tool_count;
 } compact_config_t;
 
-/* Compact a tool result string.
+/* compact_body: THE single tool-result body-shrink algorithm. Both reduction
+ * seams call it — the eager per-result path (agent_compress_tool_result) and the
+ * economizer's lazy whole-history lever (context_compress_view). It is a pure
+ * transformer over the caller's output buffer:
  *
- * Strategy:
- *   1. If content <= effective threshold, pass through unchanged.
- *   2. If content is valid JSON, emit a structural key/type summary.
- *   3. Otherwise, keep head_bytes + tail_bytes with a truncation notice in between.
+ *   - Never allocates `out`; the caller owns and frees it.
+ *   - Never retains a pointer into `raw` or `cfg` past return.
+ *   - Never writes past `out_cap` (always NUL-terminates when out_cap > 0).
+ *   - Never applies a hard cap and never touches the Coordinate Closet — those
+ *     are per-seam policy the callers own (the eager seam caps to
+ *     agent_tool_output_cap and nominates from the FULL raw; the lazy seam runs a
+ *     net-shrink guard and nominates from the full body). Nomination is gated on
+ *     each seam's own shrink-happened decision, which is why it lives in the
+ *     callers, not here.
+ *   - Output length is <= raw_len EXCEPT the JSON-summary path, which is bounded
+ *     by COMPACT_JSON_SUMMARY_MAX; size `out_cap >= raw_len + COMPACT_JSON_SUMMARY_MAX`
+ *     to guarantee no truncation of any strategy.
  *
- * Dynamic budget: if context_budget > 0 and context_used > 0, the threshold
- * is tightened when context is >60 % or >80 % full.
+ * Strategy, in order:
+ *   1. Pass-through: content <= effective threshold (or compaction disabled).
+ *   2. JSON structural summary: content parses as a JSON object/array.
+ *   3. Head+tail: keep head_bytes + tail_bytes with a truncation notice between.
  *
- * cfg may be NULL to use built-in defaults.
- * tool_name may be NULL to skip per-tool overrides.
- * context_used / context_budget may both be 0 to disable dynamic adjustment.
+ * cfg may be NULL to use built-in defaults. tool_name may be NULL to skip
+ * per-tool overrides (the lazy economizer seam passes NULL — it operates on
+ * deep-copied, mixed-origin history where a single tool identity does not apply;
+ * per-tool thresholds therefore govern the eager seam only). Returns the number of
+ * bytes written to `out` (0 for an empty body, which the caller treats as a
+ * pass-through). On an internal allocation failure the body is copied through
+ * (bounded by out_cap) rather than emptied, so a non-empty body is never dropped.
  *
- * Returns a heap-allocated string that the caller must free(). */
-char *compact_tool_result(const char *raw, size_t raw_len, const compact_config_t *cfg,
-                          const char *tool_name, int context_used, int context_budget);
+ * NOTE: the former context_used/context_budget dynamic-threshold parameters were
+ * removed with the move to this core — they were never passed non-zero by any
+ * production caller (dead capability), so eager output is byte-identical. */
+size_t compact_body(const char *raw, size_t raw_len, const char *tool_name,
+                    const compact_config_t *cfg, char *out, size_t out_cap);
 
 #endif /* COMPACT_H */

--- a/src/headers/context_fold.h
+++ b/src/headers/context_fold.h
@@ -36,6 +36,13 @@ extern "C"
                                      */
       int register_enabled;         /* §6: annotate folded assistant lines with their register */
       coord_closet_config_t closet; /* identifier-conservation config (§2) */
+      /* Tool-result body shrink (context_compress_view) shares the eager seam's
+       * compact_body() core; these mirror the compact.* knobs so ONE shrink policy
+       * governs both seams. 0 -> compact.c built-in defaults. The effective tail is
+       * min(compact_tail_bytes, reasoning_excerpt_bytes/2) so a small excerpt budget
+       * keeps the tail proportional rather than inheriting a large default. */
+      int compact_head_bytes;
+      int compact_tail_bytes;
    } fold_config_t;
 
 #define CONTEXT_FOLD_DEFAULT_RETAINED_MSGS 8
@@ -103,8 +110,10 @@ extern "C"
     * (.content string|obj), OpenAI role=="tool" (.content string), Responses
     * type=="function_call_output" (.output) — and, for each body whose serialized
     * length exceeds cfg->reasoning_excerpt_bytes (0 -> CONTEXT_FOLD_DEFAULT_EXCERPT_BYTES)
-    * AND that would actually shrink, replaces it with a head excerpt + an elision
-    * marker. The exact identifiers in the full body are first nominated into a
+    * AND that would actually shrink, replaces it via the shared compact_body() core
+    * (JSON structural summary for JSON bodies, else head+tail truncation — the same
+    * algorithm the eager seam uses). The exact identifiers in the full body are first
+    * nominated into a
     * Coordinate Closet, which (when cfg->closet.enabled) is prepended as a synthetic
     * user+assistant note pair (matching context_fold_view's closet emission) so
     * conserved identifiers ride along. EVERYTHING else — role/type, ids, message

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -865,6 +865,8 @@ native_provider_http:
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;
+            rcfg.fold.compact_head_bytes = ecfg.compact_head_bytes; /* compact.* drives the */
+            rcfg.fold.compact_tail_bytes = ecfg.compact_tail_bytes; /* shared shrink core    */
             rcfg.fold.register_enabled = ecfg.fold_register_enabled;
             rcfg.fold.closet.enabled = ecfg.coord_closet_enabled;
             rcfg.fold.closet.budget_bytes = ecfg.coord_closet_budget_bytes;

--- a/src/server/agent_policy.c
+++ b/src/server/agent_policy.c
@@ -1077,7 +1077,11 @@ static void compact_cfg_from_app_config(const config_t *app, compact_config_t *o
    }
 }
 
-/* Wrapper around compact_tool_result() using application config.
+/* Eager tool-result seam: shrink via the shared compact_body() core using
+ * application config, conserve identifiers in the Coordinate Closet, and bound
+ * the result to the per-result cap. This is the ONLY writer of compacted bodies
+ * into history; the economizer's lazy lever (context_compress_view) shares the
+ * same compact_body() core but operates on deep copies at request assembly.
  * Falls back to the resolved per-result cap (agent_tool_output_cap_clamp;
  * default AGENT_TOOL_OUTPUT_MAX) so oversized results are always bounded even
  * if compaction produces a larger-than-expected summary (e.g. malformed JSON
@@ -1102,11 +1106,15 @@ char *agent_compress_tool_result(const char *raw, size_t raw_len, const char *to
     * Resolved ONCE here so the closet budget and the hard cap below agree. */
    size_t cap = agent_tool_output_cap_clamp(loaded ? app_cfg.tool_output_max_bytes : 0);
 
-   char *out = compact_tool_result(raw, raw_len, &cfg, tool_name, 0, 0);
+   /* Shrink via the single shared core. Size the buffer for the one strategy that
+    * can exceed raw_len (a JSON structural summary of a tiny body); every other
+    * path is <= raw_len, so this never truncates the shrink. The hard cap below is
+    * applied by THIS caller (per-seam policy), not the core. */
+   size_t out_cap = raw_len + COMPACT_JSON_SUMMARY_MAX + 1;
+   char *out = malloc(out_cap);
    if (!out)
       return strdup("");
-
-   size_t out_len = strlen(out);
+   size_t out_len = compact_body(raw, raw_len, tool_name, &cfg, out, out_cap);
    int compacted = (out_len < raw_len);
 
    /* Log compaction events for diagnostics */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -1990,7 +1990,7 @@ $(TESTPREFIX)/unit-test-fold-budget: $(OBJDIR)/tests/test_fold_budget.o $(OBJDIR
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-context-fold: $(OBJDIR)/tests/test_context_fold.o $(OBJDIR)/context_fold.o $(OBJDIR)/fold_register.o \
-                                  $(OBJDIR)/coord_closet.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o \
+                                  $(OBJDIR)/coord_closet.o $(OBJDIR)/compact.o $(OBJDIR)/dstr.o $(OBJDIR)/cJSON.o \
                                   $(PLATFORM_BASIC_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 

--- a/src/tests/test_compact.c
+++ b/src/tests/test_compact.c
@@ -1,4 +1,4 @@
-/* test_compact.c: unit tests for tool-result compaction */
+/* test_compact.c: unit tests for tool-result compaction (the shared compact_body core) */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,12 +18,25 @@ static char *make_str(char c, size_t len)
    return s;
 }
 
+/* Drive the shared core into a heap string so these golden assertions read the
+ * same way the removed compact_tool_result() did. Sized per the compact_body
+ * contract (raw_len + COMPACT_JSON_SUMMARY_MAX) so no strategy is ever truncated. */
+static char *compact_str(const char *raw, size_t raw_len, const compact_config_t *cfg,
+                         const char *tool)
+{
+   size_t cap = raw_len + COMPACT_JSON_SUMMARY_MAX + 1;
+   char *buf = malloc(cap);
+   assert(buf);
+   compact_body(raw, raw_len, tool, cfg, buf, cap);
+   return buf;
+}
+
 /* ------------------------------------------------------------------ pass-through */
 
 static void test_small_passthrough(void)
 {
    const char *input = "hello world";
-   char *out = compact_tool_result(input, strlen(input), NULL, NULL, 0, 0);
+   char *out = compact_str(input, strlen(input), NULL, NULL);
    assert(out);
    assert(strcmp(out, input) == 0);
    free(out);
@@ -34,7 +47,7 @@ static void test_exactly_threshold_passthrough(void)
 {
    /* A string exactly at the default threshold (4096) should pass through */
    char *input = make_str('x', COMPACT_DEFAULT_THRESHOLD);
-   char *out = compact_tool_result(input, COMPACT_DEFAULT_THRESHOLD, NULL, NULL, 0, 0);
+   char *out = compact_str(input, COMPACT_DEFAULT_THRESHOLD, NULL, NULL);
    assert(out);
    assert(strlen(out) == COMPACT_DEFAULT_THRESHOLD);
    assert(memcmp(out, input, COMPACT_DEFAULT_THRESHOLD) == 0);
@@ -53,7 +66,7 @@ static void test_disabled_passthrough(void)
 
    char *big = make_str('z', COMPACT_DEFAULT_THRESHOLD * 2);
    size_t len = (size_t)(COMPACT_DEFAULT_THRESHOLD * 2);
-   char *out = compact_tool_result(big, len, &cfg, NULL, 0, 0);
+   char *out = compact_str(big, len, &cfg, NULL);
    assert(out);
    assert(strlen(out) == len);
    free(out);
@@ -74,7 +87,7 @@ static void test_per_tool_disabled(void)
 
    char *big = make_str('b', COMPACT_DEFAULT_THRESHOLD * 2);
    size_t len = (size_t)(COMPACT_DEFAULT_THRESHOLD * 2);
-   char *out = compact_tool_result(big, len, &cfg, "bash", 0, 0);
+   char *out = compact_str(big, len, &cfg, "bash");
    assert(out);
    assert(strlen(out) == len); /* not compacted */
    free(out);
@@ -95,7 +108,7 @@ static void test_per_tool_threshold_lower(void)
 
    /* 2 KB input: bigger than the 512-byte per-tool threshold */
    char *big = make_str('r', 2048);
-   char *out = compact_tool_result(big, 2048, &cfg, "read_file", 0, 0);
+   char *out = compact_str(big, 2048, &cfg, "read_file");
    assert(out);
    assert(strlen(out) < 2048); /* should have been compacted */
    free(out);
@@ -117,7 +130,7 @@ static void test_plaintext_contains_head_and_tail(void)
    memset(input + total - COMPACT_DEFAULT_TAIL_BYTES, 'T', COMPACT_DEFAULT_TAIL_BYTES);
    input[total] = '\0';
 
-   char *out = compact_tool_result(input, total, NULL, NULL, 0, 0);
+   char *out = compact_str(input, total, NULL, NULL);
    assert(out);
 
    /* Output should start with 'H' and end with 'T' */
@@ -150,7 +163,7 @@ static void test_custom_head_tail(void)
    memset(input + 180, 'Z', 20);
    input[200] = '\0';
 
-   char *out = compact_tool_result(input, 200, &cfg, NULL, 0, 0);
+   char *out = compact_str(input, 200, &cfg, NULL);
    assert(out);
    assert(out[0] == 'A');
    size_t out_len = strlen(out);
@@ -185,7 +198,7 @@ static void test_json_object_summary(void)
    json[prefix_len + pad + 2] = '\0';
    json_len = prefix_len + pad + 2;
 
-   char *out = compact_tool_result(json, json_len, NULL, NULL, 0, 0);
+   char *out = compact_str(json, json_len, NULL, NULL);
    assert(out);
    /* Should contain the compacted JSON summary marker */
    assert(strstr(out, "compacted JSON summary") != NULL || strstr(out, "status") != NULL ||
@@ -212,7 +225,7 @@ static void test_json_array_summary(void)
    json[prefix_len + pad] = ']';
    json[prefix_len + pad + 1] = '\0';
 
-   char *out = compact_tool_result(json, prefix_len + pad + 1, NULL, NULL, 0, 0);
+   char *out = compact_str(json, prefix_len + pad + 1, NULL, NULL);
    assert(out);
    assert(strlen(out) < prefix_len + pad + 1);
 
@@ -221,68 +234,71 @@ static void test_json_array_summary(void)
    PASS("json_array_summary");
 }
 
-/* ------------------------------------------------------------------ dynamic budget */
-
-static void test_dynamic_budget_tightens_threshold(void)
+/* The JSON structural summary is internally bounded to compact_json_summary's fixed
+ * summary[2048] buffer, so it stays < COMPACT_JSON_SUMMARY_MAX. This pins that
+ * invariant (the buffer-sizing formula out_cap = raw_len + COMPACT_JSON_SUMMARY_MAX
+ * + 1 relies on it) against a future compact.c refactor: a JSON object with thousands
+ * of keys would overflow any naive summary, yet must come back bounded and intact. */
+static void test_json_summary_bounded(void)
 {
-   /* With 80% context used, threshold halves.
-    * Create a string that is between the halved threshold and the full threshold. */
-   int base_threshold = COMPACT_DEFAULT_THRESHOLD; /* 4096 */
-   int halved = base_threshold / 2;                /* 2048 */
+   size_t cap_in = 200000;
+   char *json = malloc(cap_in);
+   assert(json);
+   size_t p = 0;
+   p += (size_t)snprintf(json + p, cap_in - p, "{");
+   for (int i = 0; i < 4000 && p < cap_in - 64; i++)
+      p += (size_t)snprintf(json + p, cap_in - p, "%s\"key_%d\":%d", i ? "," : "", i, i);
+   p += (size_t)snprintf(json + p, cap_in - p, "}");
+   size_t jl = p;
 
-   /* Input between halved and full threshold */
-   size_t input_len = (size_t)(halved + 100);
-   char *input = make_str('d', input_len);
-
-   /* With default threshold, this should pass through (input < 4096) */
-   char *out_no_pressure = compact_tool_result(input, input_len, NULL, NULL, 0, 0);
-   assert(out_no_pressure);
-   assert(strlen(out_no_pressure) == input_len); /* pass-through */
-   free(out_no_pressure);
-
-   /* With 80% context usage, threshold halves to 2048 — should now compact */
-   char *out_high_pressure = compact_tool_result(input, input_len, NULL, NULL, 80, 100);
-   assert(out_high_pressure);
-   assert(strlen(out_high_pressure) < input_len); /* compacted */
-   free(out_high_pressure);
-
-   free(input);
-   PASS("dynamic_budget_tightens_threshold");
+   size_t cap = jl + COMPACT_JSON_SUMMARY_MAX + 1; /* the formula both seams use */
+   char *buf = malloc(cap);
+   assert(buf);
+   size_t n = compact_body(json, jl, NULL, NULL, buf, cap);
+   assert(n > 0);
+   assert(n < COMPACT_JSON_SUMMARY_MAX); /* summary never exceeds the documented bound */
+   assert(buf[n] == '\0');               /* NUL-terminated, not truncated mid-write */
+   assert(strstr(buf, "compacted JSON summary") != NULL); /* JSON-summary path taken */
+   free(buf);
+   free(json);
+   PASS("json_summary_bounded");
 }
 
-static void test_dynamic_budget_moderate(void)
+/* ------------------------------------------------------------------ buffer contract */
+
+/* compact_body writes into a caller buffer and never exceeds out_cap-1. A tight
+ * buffer must still leave a valid NUL-terminated (truncated) result, never a
+ * write past the end. */
+static void test_buffer_cap_respected(void)
 {
-   /* With 60% context, threshold drops to 3/4 of 4096 = 3072 */
-   int base = COMPACT_DEFAULT_THRESHOLD; /* 4096 */
-   int reduced = base * 3 / 4;           /* 3072 */
-
-   /* Input between reduced and full threshold */
-   size_t input_len = (size_t)(reduced + 100); /* 3172 */
-   char *input = make_str('e', input_len);
-
-   char *out_no_pressure = compact_tool_result(input, input_len, NULL, NULL, 0, 0);
-   assert(out_no_pressure);
-   assert(strlen(out_no_pressure) == input_len); /* pass-through below 4096 */
-   free(out_no_pressure);
-
-   char *out_60pct = compact_tool_result(input, input_len, NULL, NULL, 60, 100);
-   assert(out_60pct);
-   assert(strlen(out_60pct) < input_len); /* compacted */
-   free(out_60pct);
-
+   char *input = make_str('q', COMPACT_DEFAULT_THRESHOLD + 1000);
+   size_t len = (size_t)(COMPACT_DEFAULT_THRESHOLD + 1000);
+   char small[64];
+   size_t n = compact_body(input, len, NULL, NULL, small, sizeof(small));
+   assert(n <= sizeof(small) - 1);
+   assert(small[n] == '\0');
    free(input);
-   PASS("dynamic_budget_moderate");
+   PASS("buffer_cap_respected");
 }
 
-/* ------------------------------------------------------------------ null input */
+/* ------------------------------------------------------------------ null / empty input */
 
 static void test_null_input(void)
 {
-   char *out = compact_tool_result(NULL, 0, NULL, NULL, 0, 0);
-   assert(out);
-   assert(strcmp(out, "") == 0);
-   free(out);
+   char buf[8] = {'x', 'x', 'x', 'x', 'x', 'x', 'x', 'x'};
+   size_t n = compact_body(NULL, 0, NULL, NULL, buf, sizeof(buf));
+   assert(n == 0);
+   assert(buf[0] == '\0');
    PASS("null_input");
+}
+
+static void test_empty_body(void)
+{
+   char buf[8] = {'y'};
+   size_t n = compact_body("", 0, NULL, NULL, buf, sizeof(buf));
+   assert(n == 0);
+   assert(buf[0] == '\0');
+   PASS("empty_body");
 }
 
 /* ------------------------------------------------------------------ main */
@@ -292,6 +308,7 @@ int main(void)
    printf("compact:\n");
 
    test_null_input();
+   test_empty_body();
    test_small_passthrough();
    test_exactly_threshold_passthrough();
    test_disabled_passthrough();
@@ -301,8 +318,8 @@ int main(void)
    test_custom_head_tail();
    test_json_object_summary();
    test_json_array_summary();
-   test_dynamic_budget_tightens_threshold();
-   test_dynamic_budget_moderate();
+   test_json_summary_bounded();
+   test_buffer_cap_respected();
 
    printf("all compact tests passed\n");
    return 0;

--- a/src/tests/test_context_fold.c
+++ b/src/tests/test_context_fold.c
@@ -506,15 +506,20 @@ static void test_responses_shape_fold(void)
 /* ---- Boundary-free tool-result body compression (economizer Slice 4) ----
  * Reuses add_openai_assistant_tool_call / add_openai_tool_result defined above. */
 
-/* Build a deterministic body well past the 160-byte excerpt threshold, with a
- * unique path placed at the END so it is amputated from the head excerpt and must
- * be recovered from the Coordinate Closet. Filler carries no identifiers. */
-static void make_big_body(char *buf, size_t bufsz, const char *path_tail)
+/* Build a deterministic body well past the compaction threshold, with a unique
+ * path placed in the MIDDLE so the shared head+tail compaction amputates it from
+ * BOTH ends and it must be recovered from the Coordinate Closet. Filler carries no
+ * identifiers. (The body must be large enough that head+tail genuinely shrinks it,
+ * since the merged seam uses compact.c's default 512-byte head.) */
+static void make_big_body(char *buf, size_t bufsz, const char *path_mid)
 {
+   size_t half = bufsz / 2;
    size_t pos = 0;
-   while (pos + 48 < bufsz - 96)
+   while (pos + 48 < half)
       pos += (size_t)snprintf(buf + pos, bufsz - pos, "filler padding output text here and more; ");
-   snprintf(buf + pos, bufsz - pos, "trailing details recorded at %s end", path_tail);
+   pos += (size_t)snprintf(buf + pos, bufsz - pos, " unique reference at %s here; ", path_mid);
+   while (pos + 48 < bufsz - 1)
+      pos += (size_t)snprintf(buf + pos, bufsz - pos, "more filler padding output text and on; ");
 }
 
 /* (a) Single-user-turn OpenAI tool-loop: old tool-result bodies compress, the
@@ -525,7 +530,7 @@ static void test_compress_openai_tool_loop(void)
 {
    cJSON *msgs = cJSON_CreateArray();
    add_user_text(msgs, "Do the autonomous task."); /* the ONLY user turn */
-   char body[700];
+   char body[4096];
    char id[32], path[64], args[48];
    const int pairs = 12;
    for (int k = 0; k < pairs; k++)
@@ -572,7 +577,7 @@ static void test_compress_openai_tool_loop(void)
       const char *id_s = cJSON_GetStringValue(cJSON_GetObjectItem(it, "tool_call_id"));
       const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(it, "content"));
       assert(id_s && c);
-      if (contains(c, "bytes elided"))
+      if (contains(c, "omitted"))
          compressed_seen++;
       else if (strlen(c) > 200)
          full_seen++;
@@ -616,7 +621,7 @@ static void test_compress_anthropic_shape(void)
 {
    cJSON *msgs = cJSON_CreateArray();
    add_user_text(msgs, "start");
-   char body[700];
+   char body[4096];
    char id[32];
    for (int k = 0; k < 10; k++)
    {
@@ -649,7 +654,7 @@ static void test_compress_anthropic_shape(void)
             const char *c = cJSON_GetStringValue(cJSON_GetObjectItem(b, "content"));
             /* tool_use_id preserved on the block */
             assert(cJSON_GetObjectItem(b, "tool_use_id") != NULL);
-            if (c && contains(c, "bytes elided"))
+            if (c && contains(c, "omitted"))
                compressed++;
          }
       }
@@ -668,7 +673,7 @@ static void test_compress_deterministic(void)
 {
    cJSON *msgs = cJSON_CreateArray();
    add_user_text(msgs, "go");
-   char body[700], id[32], path[64];
+   char body[4096], id[32], path[64];
    for (int k = 0; k < 12; k++)
    {
       snprintf(id, sizeof(id), "call_%02d", k);

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -299,6 +299,9 @@ static void test_compress_engages_where_fold_cannot(void)
       cfg.delegate_seam = 1;
       cfg.compress = 1;
       cfg.fold.closet.enabled = 1;
+      /* small head so the merged head+tail core net-shrinks these modest (~0.6 KB)
+       * tool bodies; also exercises the compact.* knob threading into the lever. */
+      cfg.fold.compact_head_bytes = 40;
       reduce_state_t st = {0};
       reduce_result_t out;
       int rc = context_reduce(m, "sys", "gpt-4o", "s1", REDUCE_SEAM_DELEGATE, &cfg, &st, &out);


### PR DESCRIPTION
## What

Collapses aimee's **two** tool-result compressors into **one shared shrink core**. They independently combined the same two primitives — compact.c's body-shrink (head/tail + JSON structural summary) and Coordinate Closet identifier conservation:

| | eager (`agent_compress_tool_result`) | lazy (economizer `context_compress_view`) |
|---|---|---|
| when | per-result, **stores** shrunk body | request assembly, deep-copy |
| shrink | `compact_tool_result` (head/tail / JSON) | private `append_excerpt` (head-only) |
| default | **on (load-bearing)** | off, per-seam gated |

The eager path runs first and stores its output, so the lazy lever only ever saw pre-shrunk ~1.5 KB bodies — they **stacked** rather than composed. This is the root cause behind the economizer finding "nothing to reduce" in the live `.254` measurements.

## How

- **`compact.c`**: public `compact_tool_result()` → `compact_body(raw, len, tool_name, cfg, out, out_cap)` — a pure transformer into a **caller-owned buffer** (never allocates it, never retains pointers, no hard cap, no closet). Exact shrink logic preserved verbatim as a static `compact_shrink_alloc()` ⇒ **eager output byte-identical**. OOM degrades to a bounded raw copy, never an empty body.
- **eager seam**: sizes a buffer + calls `compact_body`; closet/cap/combine path unchanged.
- **lazy seam**: `compress_body_field` shrinks via `compact_body` (inherits JSON-summary + head+tail). `compact.*` head/tail threaded through two new `fold_config_t` fields from app config, so **`compact.*` governs both seams**; net-shrink guard + nominate-from-full-body unchanged.

## Roundtable

Design-gate **and** code-review roundtables run. Three deliberate deviations from the approved design, all **confirmed sound** on review:
1. **Closet nomination stays in the callers** — both seams gate it on a per-seam shrink-happened decision and must nominate from the *full raw* to preserve **amputated** identifiers (the design's "scan output" would conserve only survivors).
2. **`append_excerpt` retained** — still load-bearing for the fold skeleton's reasoning excerpts.
3. **No `json_summary_enabled` knob** — it didn't exist; JSON-summary stays unconditional, preserving byte-identical eager defaults.

Code-review blockers addressed: JSON-summary upper bound tied to its enforcing `summary[2048]` buffer + pinned by a new `json_summary_bounded` test; param-order realigned between core/wrapper; OOM-vs-empty ambiguity fixed; dropped dynamic-budget params documented (dead capability, never passed non-zero in production ⇒ byte-identical).

## Behavior / compat

- The lazy lever's default head shifts 160 → 512 (`compact.head_bytes`), so sub-~600-byte bodies no longer net-shrink. **Default-off**; operators tune via `compact.head_bytes`. No new config keys.
- Eager (default-on) production output is byte-identical.

## Gates

Full `-Werror` build ✓, unit-tests (compact / context-fold / context-reduce + whole suite) ✓, clang-format-19 ✓, docs-gen-check ✓, schema-sync-check ✓.