### PR TITLE
feat(economizer): freeze cost guardrail (Slice 5) with write-premium economics

### DIFF
--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -144,6 +144,50 @@ close-out):
 - **Recall is hint-only.** Re-touch surfaces a hint pointing at the on-demand
   recovery tools; automatic inline body fetch is deferred.
 
+## Freeze cost guardrail and cross-provider cache placement
+
+The freeze pins the fold boundary so the reduced prefix stays byte-identical
+turn-to-turn, which keeps the provider prompt cache warm. But establishing a cache
+entry costs a one-time **cache-write**, and a boundary that keeps advancing can pay
+that write repeatedly — which, on a provider that bills cache writes at a premium,
+can make freezing cost *more* than it saves.
+
+The **freeze cost guardrail** (`reduce.freeze_guard`, default **on**; only acts when
+the economizer freeze is itself enabled, which is default-off) prices the decision
+before pinning a boundary. It compares the *marginal* cost of caching against the
+savings from reuse, using the same `token_tracker` rates as the rest of the cost
+story:
+
+- **Marginal write cost = the write _premium_**, `cache_write_rate − input_rate` —
+  not the full write rate. You pay the input rate to send the prefix on the first
+  turn regardless; caching only adds the difference. Providers with free cache
+  creation (OpenAI/Responses: `cache_write = 0`) have a premium ≤ 0, so freezing is
+  pure upside and is always kept on.
+- **Per-reuse saving = `input_rate − cache_read_rate`**, accrued over
+  `reduce.freeze_guard_horizon` expected reuses (default **1**, clamped to
+  `FREEZE_GUARD_MAX_HORIZON`).
+- Freeze is pinned when `horizon × per_reuse_saving ≥ write_premium`; otherwise the
+  turn re-derives the boundary without pinning (`reduce_result.freeze_guarded`).
+
+For every model aimee currently prices this keeps freeze **on** even at horizon 1
+(Anthropic has a small positive write premium that a single reuse's read discount
+already covers; OpenAI has no premium). The exact break-even is re-derived from the
+live pricing table by `test_freeze_guard`, so a future price change that would flip
+the verdict fails that test rather than silently drifting from this prose. The
+guardrail therefore changes no current behavior — its job is to encode
+the correct economics as a tested invariant and to disable freeze automatically only
+under *adverse* pricing (a write premium that outweighs the reuse savings), or when
+caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
+**fails open** (freeze stays on, preserving prior behavior).
+
+### Per-provider cache placement
+
+| Provider | Mechanism | Status |
+|----------|-----------|--------|
+| Anthropic | `cache_control:{ephemeral}` on the stable system-prompt prefix | Existing (`cache_shaping_enabled`); a frozen-history breakpoint is possible future work but low value while reduction keeps the frozen prefix small |
+| OpenAI / Responses | Automatic prefix caching — no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
+| Gemini | `cachedContent` resource, created once per run for the system prompt | Existing; extending it to per-epoch message history is deferred (single per-request resource; recreating it per epoch is expensive for the small post-reduction prefix) |
+
 ## Default-on candidacy
 
 Folding is a token/cost optimisation with an agentic-recovery cost (a folded body

--- a/docs/gen/configuration.md
+++ b/docs/gen/configuration.md
@@ -205,7 +205,7 @@ Set in the config JSON as `{"<section>": {"<key>": ...}}`. Keys are derived from
 - **`model_meta`** — _Model metadata + capability routing._ Keys: `capability_routing`, `refresh_minutes`
 - **`otel`** — _OpenTelemetry export._ Keys: `endpoint`, `service_name`
 - **`reasoning_cap`** — _Reasoning-effort cap._ Keys: `enabled`
-- **`reduce`** — `compress`, `delegate_seam`, `gateway_seam`, `history_fold`, `measure`
+- **`reduce`** — `compress`, `delegate_seam`, `freeze_guard`, `freeze_guard_horizon`, `gateway_seam`, `history_fold`, `measure`
 - **`retry`** — _Provider retry / backoff._ Keys: `base_ms`, `max_attempts`, `max_ms`
 - **`rewind`** — _Auto-snapshot / rewind._ Keys: `auto_snapshot`
 - **`roundtable`** — _Roundtable pipeline thresholds, caps, gates, and turns._ Keys: `converge_threshold`, `deadline_ms`, `max_rounds`, `pipeline_done_bar`, `pipeline_gate_ttl_h`, `pipeline_max_attempts_per_pass`, `pipeline_max_cost_usd`, `pipeline_max_passes`, `pipeline_max_total_cost_usd`, `pipeline_parked_releases_slot`, `pipeline_unknown_context_tokens`, `turns`

--- a/src/config.c
+++ b/src/config.c
@@ -437,6 +437,8 @@ static void config_set_defaults(config_t *cfg)
    cfg->reduce_history_fold = 0;
    cfg->reduce_compress = 0;
    cfg->reduce_gateway_seam = 0;
+   cfg->reduce_freeze_guard_enabled = 1; /* safety: on wherever the (default-off) freeze runs */
+   cfg->reduce_freeze_guard_horizon = 1; /* conservative break-even: one reuse pays the write */
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");
    cfg->memory_cognify_async_enabled = 0;

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -282,6 +282,17 @@ static const char *config_save_default_db1_path(void)
    return path;
 }
 
+/* Does the unified context economizer hold any non-default value worth persisting?
+ * Centralized so each new reduce.* key is accounted for in exactly one place (the
+ * save gate + this predicate stay in sync). freeze_guard defaults ON and horizon
+ * defaults 1, so those count as non-default only when changed away from that. */
+static int reduce_has_non_default(const config_t *cfg)
+{
+   return cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
+          cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
+          (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1);
+}
+
 int config_save(const config_t *cfg)
 {
    ensure_config_dir();
@@ -996,9 +1007,9 @@ int config_save(const config_t *cfg)
       }
    }
 
-   /* Unified context economizer (only save if non-default) */
-   if (cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
-       cfg->reduce_compress || cfg->reduce_gateway_seam)
+   /* Unified context economizer (only save if non-default). freeze_guard defaults ON
+    * and horizon defaults 1, so they are emitted only when an operator changed them. */
+   if (reduce_has_non_default(cfg))
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
       if (cfg->reduce_measure_enabled)
@@ -1011,6 +1022,10 @@ int config_save(const config_t *cfg)
          cJSON_AddBoolToObject(reduce, "compress", cfg->reduce_compress);
       if (cfg->reduce_gateway_seam)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
+      if (!cfg->reduce_freeze_guard_enabled) /* default-on -> persist only when disabled */
+         cJSON_AddBoolToObject(reduce, "freeze_guard", 0);
+      if (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1)
+         cJSON_AddNumberToObject(reduce, "freeze_guard_horizon", cfg->reduce_freeze_guard_horizon);
    }
 
    /* Session/worktree cleanup policy (only save if non-default) */

--- a/src/config_sections.c
+++ b/src/config_sections.c
@@ -4,6 +4,7 @@
 #include "json_fluent.h"
 #include "config_internal.h"
 #include "config_sections.h"
+#include "context_reduce.h" /* FREEZE_GUARD_MAX_HORIZON — clamp freeze_guard_horizon at parse */
 #include "sandbox.h"
 #include "toolset.h"
 #include "cJSON.h"
@@ -757,6 +758,17 @@ void config_parse_reduce_section(config_t *cfg, cJSON *root)
    item = cJSON_GetObjectItemCaseSensitive(reduce, "gateway_seam");
    if (cJSON_IsBool(item))
       cfg->reduce_gateway_seam = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard");
+   if (cJSON_IsBool(item))
+      cfg->reduce_freeze_guard_enabled = cJSON_IsTrue(item) ? 1 : 0;
+   item = cJSON_GetObjectItemCaseSensitive(reduce, "freeze_guard_horizon");
+   if (cJSON_IsNumber(item) && item->valuedouble > 0)
+   {
+      int h = (int)item->valuedouble;
+      if (h > FREEZE_GUARD_MAX_HORIZON)
+         h = FREEZE_GUARD_MAX_HORIZON; /* clamp at parse so on-disk == runtime */
+      cfg->reduce_freeze_guard_horizon = h;
+   }
 }
 
 void config_parse_sessions_section(config_t *cfg, cJSON *root)

--- a/src/context_reduce.c
+++ b/src/context_reduce.c
@@ -29,6 +29,64 @@ static int node_token_estimate(cJSON *node)
    return t;
 }
 
+int reduce_freeze_favorable_rates(double input_cost, double write_cost, double read_cost,
+                                  int horizon)
+{
+   if (horizon <= 0)
+      horizon = 1; /* one future reuse is enough to justify one write */
+   if (horizon > FREEZE_GUARD_MAX_HORIZON)
+      horizon = FREEZE_GUARD_MAX_HORIZON;
+
+   /* Per-reuse saving = paying the cache-READ rate instead of the FRESH input rate.
+    * Checked FIRST: with no read discount (read >= input) caching can never pay,
+    * so skip the freeze REGARDLESS of write cost (a free write that yields no read
+    * benefit is still not worth pinning a boundary for). */
+   double per_reuse_saving = input_cost - read_cost;
+   if (per_reuse_saving <= 0)
+      return 0;
+
+   /* The MARGINAL cost of caching is the write PREMIUM over just sending the prefix
+    * fresh once (you pay the input rate on the first turn regardless) — NOT the full
+    * write cost. Providers with free cache creation (OpenAI: cache_write==0) have a
+    * premium <= 0, so freezing is pure upside -> always enable. */
+   double write_premium = write_cost - input_cost;
+   if (write_premium <= 0)
+      return 1;
+
+   return (double)horizon * per_reuse_saving >= write_premium ? 1 : 0;
+}
+
+int reduce_freeze_cost_favorable(const char *model, int prefix_tokens, int horizon)
+{
+   if (prefix_tokens <= 0)
+      return 1; /* nothing to cache -> no churn possible */
+   if (!model || !model[0])
+      return 1; /* fail-open: no model -> keep prior always-on freeze behavior */
+
+   /* Price each cache tier separately. token_estimate_cost_ex SUMS all populated
+    * token_usage_t buckets, so each struct sets EXACTLY ONE bucket to isolate that
+    * tier's cost. The decision is scale-INVARIANT in prefix_tokens (all three costs
+    * scale linearly with it, so it cancels in the rate comparison) — prefix_tokens
+    * therefore only gates the >0 "is there anything to cache" case above; any
+    * positive value yields the same verdict, so the exact cached-prefix size need
+    * not be known here. */
+   int priced = 0;
+   token_usage_t w = {0};
+   w.cache_write_tokens = prefix_tokens;
+   double write_cost = token_estimate_cost_ex(model, &w, &priced);
+   if (!priced)
+      return 1; /* fail-open: unpriced model -> do not regress onto it */
+
+   token_usage_t in = {0};
+   in.input_tokens = prefix_tokens;
+   double input_cost = token_estimate_cost_ex(model, &in, NULL);
+   token_usage_t rd = {0};
+   rd.cache_read_tokens = prefix_tokens;
+   double read_cost = token_estimate_cost_ex(model, &rd, NULL);
+
+   return reduce_freeze_favorable_rates(input_cost, write_cost, read_cost, horizon);
+}
+
 void context_reduce_result_free(reduce_result_t *out)
 {
    if (!out)
@@ -198,9 +256,21 @@ int context_reduce(cJSON *messages, const char *system_prompt, const char *model
          fc.register_enabled = cfg->fold.register_enabled;
          fc.closet = cfg->fold.closet; /* zero -> defaults; denylist borrowed for this call */
 
+         /* Freeze cost guardrail: pin the boundary only when the cache-read savings
+          * cover the cache-write churn (forecast via the prefix-region token estimate);
+          * otherwise pass NULL so this turn re-derives without pinning. Disabled or
+          * cost-favorable -> freeze as before. NULL state -> freeze already off. */
+         fold_freeze_t *freeze_arg = st ? &st->freeze : NULL;
+         if (freeze_arg && cfg->freeze_guard_enabled &&
+             !reduce_freeze_cost_favorable(model, out->foldable_tokens, cfg->freeze_guard_horizon))
+         {
+            freeze_arg = NULL;
+            out->freeze_guarded = 1;
+         }
+
          fold_result_t fr;
          memset(&fr, 0, sizeof(fr));
-         if (context_fold_view(work, &fc, st ? &st->freeze : NULL, &fr) != 0)
+         if (context_fold_view(work, &fc, freeze_arg, &fr) != 0)
          {
             /* hard bypass: an internal fold error -> caller forwards the original. */
             fold_result_free(&fr);

--- a/src/headers/config.h
+++ b/src/headers/config.h
@@ -932,12 +932,21 @@ typedef struct config
     *   Shadow-mode only in this slice (measure_only is forced on at the gateway, so
     *   it NEVER mutates the live client request) — collects baselines on live
     *   ingress traffic with zero behavior change.
+    * reduce_freeze_guard_enabled: freeze cost guardrail (Slice 5). Pin the fold
+    *   boundary (cache-warm reduced prefix) only when the estimated cache-read
+    *   savings over reduce_freeze_guard_horizon reuses cover the one-time cache-write
+    *   churn; otherwise re-derive without pinning. Default-ON, but only acts when the
+    *   (default-off) economizer freeze is live, so no default-path behavior change.
+    * reduce_freeze_guard_horizon: expected reuse turns for the break-even estimate
+    *   (0 -> 1; clamped to FREEZE_GUARD_MAX_HORIZON).
     * (Other per-lever gates and min_gain land in later slices.) */
    int reduce_measure_enabled;
    int reduce_delegate_seam;
    int reduce_history_fold;
    int reduce_compress;
    int reduce_gateway_seam;
+   int reduce_freeze_guard_enabled;
+   int reduce_freeze_guard_horizon;
 
    /* Session/worktree cleanup policy.
     * worktree_stale_secs: inactivity threshold before a session is pruned

--- a/src/headers/context_reduce.h
+++ b/src/headers/context_reduce.h
@@ -29,7 +29,10 @@
  *     inject-compress -> freeze-verify.
  *  5. Net-gain pre-check + freeze cost guardrail. Skip fold when foldable tokens
  *     are below the round-trip recovery threshold (ledger reason="skip_no_gain");
- *     disable freeze when estimated cache-write churn cost > saved cache-read.
+ *     disable freeze when the estimated cache-write PREMIUM is not recovered by the
+ *     cache-read savings over the reuse horizon (Slice 5 —
+ *     reduce_freeze_cost_favorable; freeze_guard config, default-on but inert until
+ *     the default-off freeze is enabled).
  *  6. Live-traffic safety. Per-lever + per-seam gates, a measure-only shadow mode,
  *     and a caller-side hard bypass: on ANY internal error context_reduce returns
  *     non-zero with out->messages == NULL so the caller forwards the ORIGINAL
@@ -77,8 +80,22 @@ extern "C"
        * the existing compact.c/tool-output caps are accounted for. */
       int min_gain_tokens;
 
+      /* Freeze cost guardrail (Slice 5). The freeze pins the fold boundary so the
+       * reduced prefix stays byte-identical (cache-warm) turn-to-turn — but a
+       * boundary that keeps advancing forces provider cache-WRITES (1.25-2x input
+       * rate) that can flip reduction net-negative. When enabled, freeze is pinned
+       * only when the estimated cache-read savings over `horizon` reuses cover the
+       * one-time cache-write cost; otherwise the turn re-derives without pinning.
+       * Default-on, but only acts when the (default-off) economizer freeze is live. */
+      int freeze_guard_enabled;
+      int freeze_guard_horizon; /* expected reuse turns for break-even (0 -> 1) */
+
       fold_config_t fold; /* history-fold sub-config (reused verbatim) */
    } reduce_config_t;
+
+/* Hard cap on the configured freeze-guard horizon, so a misconfigured long horizon
+ * cannot justify an unbounded cache-write bet on a single run. */
+#define FREEZE_GUARD_MAX_HORIZON 5
 
    /* Per-CONVERSATION reducer state, owned by the caller and persisted across
     * turns within one conversation (e.g. a stack local spanning the turn loop).
@@ -133,6 +150,7 @@ extern "C"
       int retained_msgs;
       int reused_boundary; /* 1 = freeze reused (cache-warm) */
       int epochs;
+      int freeze_guarded; /* 1 = the cost guardrail disabled freeze this turn */
    } reduce_result_t;
 
    /* Run the economizer for one request at one seam.
@@ -153,6 +171,32 @@ extern "C"
    int context_reduce(cJSON *messages, const char *system_prompt, const char *model,
                       const char *session_id, reduce_seam_t seam, const reduce_config_t *cfg,
                       reduce_state_t *st, reduce_result_t *out);
+
+   /* Freeze cost guardrail (Slice 5), exposed for unit testing. Returns 1 when
+    * pinning the freeze boundary is cost-favorable — i.e. the estimated cache-read
+    * savings over `horizon` reuses cover the one-time cache-WRITE PREMIUM. The guard
+    * gates the freeze pointer context_reduce hands context_fold_view: when it returns
+    * 0, context_reduce passes NULL, so the fold RE-DERIVES the boundary this turn
+    * WITHOUT persisting it (context_fold_view only reads/commits freeze state when the
+    * pointer is non-NULL). The persisted st->freeze is left as-is; a later non-guarded
+    * turn that reuses it is still protected by the prefix-digest check inside
+    * context_fold_view (a stale boundary fails the digest and re-epochs), so toggling
+    * the guard per-turn can never serve an obsolete cache-warm prefix.
+    *
+    * Conservative + fail-OPEN: returns 1 (freeze on) when prefix_tokens <= 0 (no
+    * churn), when model is NULL/unpriced (preserves prior always-on behavior). Returns
+    * 0 only when pricing is known AND either there is no read discount (cache_read >=
+    * input) OR the read savings provably do not cover the write premium. Pure: prices
+    * via token_estimate_cost_ex, no state. */
+   int reduce_freeze_cost_favorable(const char *model, int prefix_tokens, int horizon);
+
+   /* The scale-invariant arithmetic core of the guardrail, exposed so the disable
+    * branch (unreachable with currently-priced models) can be unit-tested with
+    * synthetic per-tier costs. horizon is clamped to [1, FREEZE_GUARD_MAX_HORIZON].
+    * No read discount (read >= input) -> 0; write premium (write - input) <= 0 -> 1;
+    * else 1 iff horizon * (input - read) >= (write - input). */
+   int reduce_freeze_favorable_rates(double input_cost, double write_cost, double read_cost,
+                                     int horizon);
 
    /* Free a NEW messages array produced by context_reduce. Safe on a zeroed/no-op
     * result (messages==NULL). Must run AFTER the request is serialized (the result

--- a/src/posix/agent_runtime.c
+++ b/src/posix/agent_runtime.c
@@ -862,6 +862,8 @@ native_provider_http:
             rcfg.compress = ecfg.reduce_compress;
             rcfg.measure_only =
                 !(rcfg.history_fold || rcfg.compress); /* a lever on -> mutate; else shadow */
+            rcfg.freeze_guard_enabled = ecfg.reduce_freeze_guard_enabled; /* Slice 5 guardrail */
+            rcfg.freeze_guard_horizon = ecfg.reduce_freeze_guard_horizon;
             rcfg.fold.retained_msgs = ecfg.fold_retained_msgs;
             rcfg.fold.min_fold_msgs = ecfg.fold_min_fold_msgs;
             rcfg.fold.reasoning_excerpt_bytes = ecfg.fold_excerpt_bytes;

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -335,6 +335,11 @@ int main(void)
                "--background-index");
       cfg.lsp_servers[0].extension_count = 1;
       snprintf(cfg.lsp_servers[0].extensions[0], sizeof(cfg.lsp_servers[0].extensions[0]), "c");
+      /* economizer freeze guardrail: default-on bool + default-1 horizon. Flip the
+       * bool OFF and the horizon to a non-default so both must round-trip (regression
+       * class: a default-on save-guard that emits only the non-default state). */
+      cfg.reduce_freeze_guard_enabled = 0;
+      cfg.reduce_freeze_guard_horizon = 3;
       config_save(&cfg);
 
       static config_t cfg2;
@@ -351,6 +356,8 @@ int main(void)
       assert(cfg2.server_api_rate_limit_per_min == 60);
       assert(cfg2.server_api_max_event_streams == 512);
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);
+      assert(cfg2.reduce_freeze_guard_enabled == 0); /* default-on bool persisted off */
+      assert(cfg2.reduce_freeze_guard_horizon == 3); /* non-default horizon persisted */
       /* regression: remote_writes used to be parsed but never written by config_save,
        * so any save silently reset it to off. */
       assert(cfg2.server_api_remote_writes == SERVER_REMOTE_WRITES_FULL);

--- a/src/tests/test_context_reduce.c
+++ b/src/tests/test_context_reduce.c
@@ -2,6 +2,7 @@
  * (Slice 1 — measure-only: baseline + foldable opportunity + cost forecast, no
  * mutation, hard-bypass contract). */
 #include "context_reduce.h"
+#include "token_tracker.h" /* token_usage_t, token_estimate_cost_ex — table-tethered guard test */
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -341,9 +342,76 @@ static void test_compress_measure_only_no_mutation(void)
    PASS("compress measure_only: shadow, no mutation");
 }
 
+/* Slice 5 freeze cost guardrail. The guard prices ONE cache-write PREMIUM (over
+ * sending the prefix fresh once) against `horizon` reuses at the cache-read rate.
+ * Key regression: it must NOT disable freeze for real providers — both OpenAI (free
+ * cache writes) and Anthropic (small write premium, large read discount) pay off,
+ * even at the conservative default horizon of 1. The disable branch fires only under
+ * adverse pricing (write premium > horizon x per-reuse saving) that no model aimee
+ * currently prices satisfies. */
+static void test_freeze_guard(void)
+{
+   /* zero prefix -> no churn possible -> always favorable */
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 0, 1) == 1);
+   /* NULL / empty / unpriced model -> fail-open (preserve prior always-on freeze) */
+   assert(reduce_freeze_cost_favorable(NULL, 100000, 1) == 1);
+   assert(reduce_freeze_cost_favorable("", 100000, 1) == 1);
+   assert(reduce_freeze_cost_favorable("totally-unknown-model-xyz", 100000, 1) == 1);
+   /* OpenAI: cache_write == 0 -> non-positive write premium -> always freeze */
+   assert(reduce_freeze_cost_favorable("gpt-4o", 100000, 1) == 1);
+   /* Anthropic at the default horizon=1: premium 0.75x vs per-reuse saving 2.70x ->
+    * favorable. This is the regression guard against the naive full-write-cost
+    * formula, which would wrongly disable Anthropic freeze here. */
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 100000, 1) == 1);
+   assert(reduce_freeze_cost_favorable("claude-3-opus", 100000, 1) == 1);
+   /* horizon monotonic + clamp: more reuse never makes a favorable case unfavorable,
+    * and an out-of-range horizon is clamped (no crash, still favorable). */
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 100000, 9999) == 1);
+   assert(reduce_freeze_cost_favorable("claude-3-5-sonnet", 100000, -5) == 1);
+
+   /* Table-tethered invariant: recompute the Anthropic premium/saving from the LIVE
+    * pricing table (not prose) so a future price change that flips the verdict fails
+    * HERE, not silently. write premium must be positive and a single reuse must cover
+    * it (this is exactly what the naive full-write-cost formula got wrong). */
+   {
+      const char *m = "claude-3-5-sonnet";
+      int n = 100000;
+      token_usage_t w = {0}, in = {0}, rd = {0};
+      w.cache_write_tokens = n;
+      in.input_tokens = n;
+      rd.cache_read_tokens = n;
+      double write_cost = token_estimate_cost_ex(m, &w, NULL);
+      double input_cost = token_estimate_cost_ex(m, &in, NULL);
+      double read_cost = token_estimate_cost_ex(m, &rd, NULL);
+      assert(write_cost > input_cost); /* a real write premium exists */
+      assert((input_cost - read_cost) >= (write_cost - input_cost)); /* 1 reuse covers it */
+   }
+
+   /* Disable branch — unreachable with currently-priced models, exercised here via
+    * the scale-invariant arithmetic core with SYNTHETIC per-tier costs. */
+   /* favorable (Anthropic-like: input 3, write 3.75, read 0.30) at H=1 */
+   assert(reduce_freeze_favorable_rates(3.0, 3.75, 0.30, 1) == 1);
+   /* free write but NO read discount (read == input) -> skip regardless of write
+    * (pins B1: per-reuse saving is checked BEFORE the write premium) */
+   assert(reduce_freeze_favorable_rates(1.0, 0.0, 1.0, 1) == 0);
+   /* free write WITH a read discount -> always favorable */
+   assert(reduce_freeze_favorable_rates(1.0, 0.0, 0.10, 1) == 1);
+   /* adverse: write premium (9) far exceeds per-reuse saving (0.9) at H=1 -> disable */
+   assert(reduce_freeze_favorable_rates(1.0, 10.0, 0.10, 1) == 0);
+   /* same adverse rates, but the horizon clamp (max 5) still cannot cover it -> disable
+    * (break-even needs H=10) */
+   assert(reduce_freeze_favorable_rates(1.0, 10.0, 0.10, 9999) == 0);
+   /* a milder premium that one reuse misses but several cover: premium 2.0, saving
+    * 0.9 -> H=1 disable, H=3 (2.7 >= 2.0) enable */
+   assert(reduce_freeze_favorable_rates(1.0, 3.0, 0.10, 1) == 0);
+   assert(reduce_freeze_favorable_rates(1.0, 3.0, 0.10, 3) == 1);
+   PASS("freeze cost guardrail: fail-open, real providers freeze, synthetic disable branch");
+}
+
 int main(void)
 {
    printf("context_reduce: unit tests\n");
+   test_freeze_guard();
    test_hard_bypass_null_out();
    test_null_messages();
    test_measure_only_no_mutation();


### PR DESCRIPTION
## What

Slice 5 of the unified context economizer: the **freeze cost guardrail** — the protection `context_reduce.h` has documented but never implemented since the fold landed. Design-roundtable authorized a **guardrail-only re-cut**: the Anthropic frozen-prefix `cache_control` marker is deferred (marginal — reduction keeps the frozen prefix small), OpenAI relies on automatic prefix caching (documented), and Gemini multi-turn history caching is deferred.

## Why / the economics

The freeze pins the fold boundary so the reduced prefix stays cache-warm, but a boundary that keeps advancing pays a provider cache-**write** each time — which on a write-premium provider can make freezing cost *more* than it saves.

The key correctness point (a bug in the original design sketch and my first draft): churn is **not** the full cache-write cost. You pay the input rate to send the prefix fresh on turn 1 *regardless*, so the marginal cost of caching is the **write premium** `cache_write − input`. Freeze pays off when:

```
horizon × (input − cache_read)  ≥  (cache_write − input)
```

- **OpenAI** (`cache_write = 0`): premium ≤ 0 → freeze always on.
- **Anthropic**: small positive premium, covered by a single reuse's read discount → freeze on even at horizon 1.

The decision is **scale-invariant** in `prefix_tokens` (it cancels), so the exact cached-prefix size isn't needed.

## Honest value

With correct economics the guardrail keeps freeze **on for every model aimee prices today** — it changes no current behavior. Its value is (1) encoding the correct economics as a **tested invariant** (a regression test recomputes the Anthropic break-even from the live pricing table, guarding against the naive full-write-cost formula that would wrongly disable Anthropic freeze), (2) auto-disabling freeze only under *adverse/future* pricing or no read discount (`cache_read ≥ input`), and (3) retiring the long-standing `context_reduce.h` TODO. Missing pricing **fails open**.

## Implementation

- `reduce_freeze_cost_favorable(model, prefix_tokens, horizon)` + a scale-invariant arithmetic core `reduce_freeze_favorable_rates(...)` (exposed so the disable branch — unreachable with real pricing — is unit-tested with synthetic adverse rates).
- `context_reduce` gates the `&st->freeze` pointer it hands `context_fold_view` (NULL → re-derive without pinning; `reduce_result.freeze_guarded`). Stale-boundary safety is guaranteed by the existing `prefix_digest` check.
- Config: `reduce.freeze_guard` (default ON; only acts when the default-off freeze is live) + `reduce.freeze_guard_horizon` (default 1, clamped at parse to `FREEZE_GUARD_MAX_HORIZON`).

## Roundtable

Design-gate + code-review roundtables run. Code-review was **conditional**; all five blockers addressed: per-reuse-saving evaluated before the write premium (no-read-discount disables even with free writes); single-bucket `token_estimate_cost_ex` pricing + scale-invariance documented; `context_fold_view` NULL-freeze contract + digest staleness protection documented; doc ratios replaced with a table-tethered test. Plus config round-trip test, `reduce_has_non_default()` helper, parse-time horizon clamp.

## Gates

Full `-Werror` build ✓, unit-tests (whole suite + new `test_freeze_guard` synthetic disable-branch + config round-trip) ✓, clang-format-19 ✓, docs-gen-check ✓, schema-sync-check ✓.