### PR TITLE
feat(economizer): default-ON on the delegate seam (fold + compress + closet)

### DIFF
--- a/docs/features/context-fold.md
+++ b/docs/features/context-fold.md
@@ -188,10 +188,55 @@ caching offers no read discount at all (`cache_read ≥ input`). Missing pricing
 | OpenAI / Responses | Automatic prefix caching — no explicit marker exists or is needed; the freeze's byte-identical ordering already satisfies the cache-hit criteria, and cache writes are free | No code; advisory only |
 | Gemini | `cachedContent` resource, created once per run for the system prompt | Existing; extending it to per-epoch message history is deferred (single per-request resource; recreating it per epoch is expensive for the small post-reduction prefix) |
 
-## Default-on candidacy
+## Default state
 
-Folding is a token/cost optimisation with an agentic-recovery cost (a folded body
-must be re-fetched if needed). Per aimee's off-reasons discipline, default-on is
-gated on the integration-test results (token reduction, cache-read share, and
-0-lost-coordinate fidelity on a captured long session). See the proposal close-out
-for the assessment.
+The unified **context economizer** (`reduce.*`) is **default-ON at the delegate
+seam**: `reduce.measure`, `reduce.delegate_seam`, `reduce.history_fold`,
+`reduce.compress`, and `compact.coord_closet` all default true, and the freeze cost
+guardrail (`reduce.freeze_guard`) is on. Concretely, every sub-agent (delegate) turn
+now folds old history and compresses oversized tool-result bodies, with the
+Coordinate Closet conserving the exact identifiers so the lossy reduction stays
+recoverable. `history_fold` auto-excludes the Responses/chatgpt builder at the call
+site (its synthetic-turn shape is unverified there); `compress` runs for every
+provider.
+
+**Recovery model (what "recoverable" means here).** This is a *lossy* reduction with
+**agentic recovery**, not lossless caching — be precise about the guarantee:
+- **Recent context is never touched.** Both levers only reduce messages *before* the
+  retained tail; the most recent `retained_msgs` (default 8) are byte-for-byte intact,
+  so the agent's working set is always full. `retained_msgs` follows the numeric-0 =
+  built-in-default convention (0 → 8), so the working-set floor is always ≥ 1 — it can
+  never be configured to zero; an explicit small value (e.g. 1) just narrows it.
+- **Identifiers are conserved, not bodies.** When an old tool-result body is elided,
+  the Coordinate Closet preserves the exact paths/ids/hashes it contained (plus the
+  body's head+tail excerpt), so references survive. The *omitted middle* of an old
+  body is not retained.
+- **Recovery is the agent re-issuing a tool call** (e.g. re-reading a conserved path)
+  — there is **no automatic inline re-fetch**. If a re-fetch fails, the agent handles
+  it as an ordinary tool error. This refetch is the accepted cost of default-on.
+- Coordinate fidelity (0 lost identifiers) was validated on a captured long session in
+  the deterministic-fold close-out.
+
+Operators who want the prior behavior opt out per lever, e.g.:
+
+```yaml
+reduce:
+  history_fold: false   # keep full history (no rolling skeleton)
+  compress: false       # keep full tool-result bodies
+  # delegate_seam: false  # disable the economizer on the delegate path entirely
+```
+
+**Config persistence convention.** A fresh default config writes **no** `reduce` or
+`compact.coord_closet` block at all — the defaults live in `config_set_defaults`
+(`src/config.c`). On save, *default-on* keys (`measure`, `delegate_seam`,
+`history_fold`, `compress`, `freeze_guard`, `coord_closet.enabled`) persist only their
+non-default **OFF** state; *default-off* keys (`gateway_seam`) persist only their
+non-default **ON** state. So an operator opt-out round-trips, and an unmodified config
+stays empty. Note `coord_closet.budget_bytes: 0` means **"use the built-in default"**,
+not "force a zero-byte closet" — to disable the closet, set `enabled: false`.
+
+**Not yet default-on:** the **gateway seam** (`reduce.gateway_seam`, the inbound /v1
+path that serves the primary agent) remains off — it is shadow-measure-only until its
+request-mutation path and 400-retry-from-pristine circuit breaker are built. The
+legacy standalone `fold.*` path also stays opt-in; the economizer supersedes it (when
+the economizer produces a reduced view, the legacy `build_fold_view` is skipped).

--- a/src/config.c
+++ b/src/config.c
@@ -419,8 +419,10 @@ static void config_set_defaults(config_t *cfg)
    snprintf(cfg->db1_path, sizeof(cfg->db1_path), "%s", config_default_db1_path());
    snprintf(cfg->guardrail_mode, sizeof(cfg->guardrail_mode), "%s", MODE_APPROVE);
    snprintf(cfg->provider, sizeof(cfg->provider), "claude");
-   cfg->compact_enabled = 1;      /* default on; set before no-config early returns */
-   cfg->coord_closet_enabled = 0; /* fold §2: default-off */
+   cfg->compact_enabled = 1; /* default on; set before no-config early returns */
+   cfg->coord_closet_enabled =
+       1; /* fold §2: default-ON — conserves identifiers elided by the
+           * default-on compress/fold so lossy reduction stays recoverable */
    cfg->coord_closet_budget_bytes = 0;
    cfg->coord_closet_max_ratio_pct = 0;
    cfg->fold_enabled = 0; /* fold §1: default-off */
@@ -432,12 +434,23 @@ static void config_set_defaults(config_t *cfg)
    cfg->fold_freeze_tail_cap_msgs = 0;
    cfg->fold_recall_enabled = 0; /* fold §4: default-off */
    cfg->fold_recall_ttl_turns = 0;
-   cfg->reduce_measure_enabled = 0; /* context economizer: all default-off */
-   cfg->reduce_delegate_seam = 0;
-   cfg->reduce_history_fold = 0;
-   cfg->reduce_compress = 0;
+   /* Context economizer: DEFAULT-ON on the delegate seam (the implemented, tested
+    * reduction path). measure + delegate_seam + history_fold + compress all on.
+    * Lossy reduction stays recoverable: both levers only touch messages BEFORE the
+    * retained tail (the most recent retained_msgs stay full), and the Coordinate
+    * Closet (also default-on) conserves the exact identifiers so the agent can
+    * re-issue a tool call to recover an elided body. history_fold is converted to a
+    * live fold ONLY at agent_runtime.c (rcfg.history_fold = reduce_history_fold &&
+    * !chatgpt) — it reaches the Responses builder on ZERO paths; compress is
+    * shape-preserving and runs for all providers. */
+   cfg->reduce_measure_enabled = 1;
+   cfg->reduce_delegate_seam = 1;
+   cfg->reduce_history_fold = 1;
+   cfg->reduce_compress = 1;
+   /* GATEWAY seam (primary-agent /v1 path) stays off: shadow-only until its
+    * request-mutation + 400-retry-from-pristine circuit breaker are built. */
    cfg->reduce_gateway_seam = 0;
-   cfg->reduce_freeze_guard_enabled = 1; /* safety: on wherever the (default-off) freeze runs */
+   cfg->reduce_freeze_guard_enabled = 1; /* safety: on for the default-on economizer freeze */
    cfg->reduce_freeze_guard_horizon = 1; /* conservative break-even: one reuse pays the write */
    snprintf(cfg->memory_citations_mode, sizeof(cfg->memory_citations_mode), "%s", "off");
    snprintf(cfg->memory_coref_mode, sizeof(cfg->memory_coref_mode), "%s", "off");

--- a/src/config_save.c
+++ b/src/config_save.c
@@ -288,8 +288,8 @@ static const char *config_save_default_db1_path(void)
  * defaults 1, so those count as non-default only when changed away from that. */
 static int reduce_has_non_default(const config_t *cfg)
 {
-   return cfg->reduce_measure_enabled || cfg->reduce_delegate_seam || cfg->reduce_history_fold ||
-          cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
+   return !cfg->reduce_measure_enabled || !cfg->reduce_delegate_seam || !cfg->reduce_history_fold ||
+          !cfg->reduce_compress || cfg->reduce_gateway_seam || !cfg->reduce_freeze_guard_enabled ||
           (cfg->reduce_freeze_guard_horizon > 0 && cfg->reduce_freeze_guard_horizon != 1);
 }
 
@@ -937,7 +937,7 @@ int config_save(const config_t *cfg)
 
    /* Tool result compaction (only save non-default values) */
    if (!cfg->compact_enabled || cfg->compact_threshold || cfg->compact_head_bytes ||
-       cfg->compact_tail_bytes || cfg->compact_per_tool_count || cfg->coord_closet_enabled ||
+       cfg->compact_tail_bytes || cfg->compact_per_tool_count || !cfg->coord_closet_enabled ||
        cfg->coord_closet_budget_bytes || cfg->coord_closet_max_ratio_pct ||
        cfg->coord_closet_denylist[0])
    {
@@ -961,8 +961,9 @@ int config_save(const config_t *cfg)
                cJSON_AddNumberToObject(pt, tool, thresh);
          }
       }
-      /* Coordinate Closet (fold §2), nested under "compact". */
-      if (cfg->coord_closet_enabled || cfg->coord_closet_budget_bytes ||
+      /* Coordinate Closet (fold §2), nested under "compact". Default-ON now, so the
+       * block is emitted only to record a non-default (disabled, or tuned budget). */
+      if (!cfg->coord_closet_enabled || cfg->coord_closet_budget_bytes ||
           cfg->coord_closet_max_ratio_pct || cfg->coord_closet_denylist[0])
       {
          cJSON *closet = cJSON_AddObjectToObject(cmpct, "coord_closet");
@@ -1012,14 +1013,17 @@ int config_save(const config_t *cfg)
    if (reduce_has_non_default(cfg))
    {
       cJSON *reduce = cJSON_AddObjectToObject(root, "reduce");
-      if (cfg->reduce_measure_enabled)
-         cJSON_AddBoolToObject(reduce, "measure", cfg->reduce_measure_enabled);
-      if (cfg->reduce_delegate_seam)
-         cJSON_AddBoolToObject(reduce, "delegate_seam", cfg->reduce_delegate_seam);
-      if (cfg->reduce_history_fold)
-         cJSON_AddBoolToObject(reduce, "history_fold", cfg->reduce_history_fold);
-      if (cfg->reduce_compress)
-         cJSON_AddBoolToObject(reduce, "compress", cfg->reduce_compress);
+      /* measure/delegate_seam/history_fold/compress default ON -> persist only the
+       * non-default OFF state so an operator opt-out round-trips. gateway_seam stays
+       * default-OFF -> persist only when enabled. */
+      if (!cfg->reduce_measure_enabled)
+         cJSON_AddBoolToObject(reduce, "measure", 0);
+      if (!cfg->reduce_delegate_seam)
+         cJSON_AddBoolToObject(reduce, "delegate_seam", 0);
+      if (!cfg->reduce_history_fold)
+         cJSON_AddBoolToObject(reduce, "history_fold", 0);
+      if (!cfg->reduce_compress)
+         cJSON_AddBoolToObject(reduce, "compress", 0);
       if (cfg->reduce_gateway_seam)
          cJSON_AddBoolToObject(reduce, "gateway_seam", cfg->reduce_gateway_seam);
       if (!cfg->reduce_freeze_guard_enabled) /* default-on -> persist only when disabled */

--- a/src/tests/Rules.mk
+++ b/src/tests/Rules.mk
@@ -81,7 +81,7 @@ TEST_TARGETS := $(TESTPREFIX)/unit-test-util $(TESTPREFIX)/unit-test-db $(TESTPR
                $(TESTPREFIX)/unit-test-guardrails $(TESTPREFIX)/unit-test-memory $(TESTPREFIX)/unit-test-tasks \
                $(TESTPREFIX)/unit-test-cmd-hooks-scope \
                $(TESTPREFIX)/unit-test-agent $(TESTPREFIX)/unit-test-agent-repair $(TESTPREFIX)/unit-test-agent-apikey $(TESTPREFIX)/unit-test-script-runner $(TESTPREFIX)/unit-test-provider-cli-adapter $(TESTPREFIX)/unit-test-cli-acp $(TESTPREFIX)/unit-test-acp-server $(TESTPREFIX)/unit-test-extractors \
-               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
+               $(TESTPREFIX)/unit-test-text $(TESTPREFIX)/unit-test-config $(TESTPREFIX)/unit-test-config-economizer $(TESTPREFIX)/unit-test-config-surface $(TESTPREFIX)/unit-test-tool-output-cap $(TESTPREFIX)/unit-test-ingress-preinject $(TESTPREFIX)/unit-test-code-span $(TESTPREFIX)/unit-test-code-match $(TESTPREFIX)/unit-test-gw-stage-memory $(TESTPREFIX)/unit-test-attention-guard $(TESTPREFIX)/unit-test-codex-auth $(TESTPREFIX)/unit-test-code-audit $(TESTPREFIX)/unit-test-code-audit-graph $(TESTPREFIX)/unit-test-db2-code-audit $(TESTPREFIX)/unit-test-cron-config $(TESTPREFIX)/unit-test-cron-runtime $(TESTPREFIX)/unit-test-feedback \
                $(TESTPREFIX)/unit-test-render $(TESTPREFIX)/unit-test-index $(TESTPREFIX)/unit-test-manuscript $(TESTPREFIX)/unit-test-persona $(TESTPREFIX)/unit-test-server-http $(TESTPREFIX)/unit-test-openai-shape $(TESTPREFIX)/unit-test-openai-chat-policed $(TESTPREFIX)/unit-test-openai-responses-store \
                $(TESTPREFIX)/unit-test-feedback-shadow $(TESTPREFIX)/unit-test-graph-fusion $(TESTPREFIX)/unit-test-code-vectors $(TESTPREFIX)/unit-test-graph-scoring $(TESTPREFIX)/unit-test-code-projection $(TESTPREFIX)/unit-test-entity-nodes $(TESTPREFIX)/unit-test-memory-advanced $(TESTPREFIX)/unit-test-memory-health \
                $(TESTPREFIX)/unit-test-memory-ranker-boundary \
@@ -946,6 +946,9 @@ $(TESTPREFIX)/unit-test-server-memory-benchmark: \
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS) -lm
 
 $(TESTPREFIX)/unit-test-config: $(OBJDIR)/tests/test_config.o $(TEST_CORE_OBJS)
+	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
+
+$(TESTPREFIX)/unit-test-config-economizer: $(OBJDIR)/tests/test_config_economizer.o $(TEST_CORE_OBJS)
 	$(TESTLINK) -o $@ $^ $(TEST_L_FLAGS)
 
 $(TESTPREFIX)/unit-test-config-surface: $(OBJDIR)/tests/test_config_surface.o $(TEST_CORE_OBJS)

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -57,6 +57,16 @@ int main(void)
        * has to explicitly enable it before any autonomous run can open/merge a PR. */
       assert(cfg.wfe_live_forge_enabled == 0);
       assert(cfg.db1_path[0] != '\0');
+      /* context economizer is DEFAULT-ON on the delegate seam (measure + delegate_seam
+       * + history_fold + compress + closet), with the gateway seam off pending its
+       * mutation build. A regression that silently flips these off is caught here. */
+      assert(cfg.reduce_measure_enabled == 1);
+      assert(cfg.reduce_delegate_seam == 1);
+      assert(cfg.reduce_history_fold == 1);
+      assert(cfg.reduce_compress == 1);
+      assert(cfg.coord_closet_enabled == 1);
+      assert(cfg.reduce_gateway_seam == 0);
+      assert(cfg.reduce_freeze_guard_enabled == 1);
       assert(cfg.guardrails_semantic_advisory_only == 1);
       assert(cfg.skills_review_nudge_interval == 10);
       assert(cfg.skills_curator_interval_hours == 168);
@@ -340,6 +350,13 @@ int main(void)
        * class: a default-on save-guard that emits only the non-default state). */
       cfg.reduce_freeze_guard_enabled = 0;
       cfg.reduce_freeze_guard_horizon = 3;
+      /* the four default-ON economizer levers + the closet must round-trip their
+       * non-default OFF state (config_save persists only the opt-out). */
+      cfg.reduce_measure_enabled = 0;
+      cfg.reduce_delegate_seam = 0;
+      cfg.reduce_history_fold = 0;
+      cfg.reduce_compress = 0;
+      cfg.coord_closet_enabled = 0;
       config_save(&cfg);
 
       static config_t cfg2;
@@ -358,6 +375,11 @@ int main(void)
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);
       assert(cfg2.reduce_freeze_guard_enabled == 0); /* default-on bool persisted off */
       assert(cfg2.reduce_freeze_guard_horizon == 3); /* non-default horizon persisted */
+      assert(cfg2.reduce_measure_enabled == 0);      /* default-on levers persist their */
+      assert(cfg2.reduce_delegate_seam == 0);        /* non-default OFF opt-out */
+      assert(cfg2.reduce_history_fold == 0);
+      assert(cfg2.reduce_compress == 0);
+      assert(cfg2.coord_closet_enabled == 0); /* default-on closet persists OFF */
       /* regression: remote_writes used to be parsed but never written by config_save,
        * so any save silently reset it to off. */
       assert(cfg2.server_api_remote_writes == SERVER_REMOTE_WRITES_FULL);
@@ -516,6 +538,41 @@ int main(void)
              strcmp(cfg2.lsp_servers[0].args[0], "--background-index") == 0);
       assert(cfg2.lsp_servers[0].extension_count == 1 &&
              strcmp(cfg2.lsp_servers[0].extensions[0], "c") == 0);
+   }
+
+   /* --- economizer: PARTIAL opt-out + closet tuning round-trip ---
+    * The bulk round-trip above flips every default-on lever OFF at once. This pins
+    * the trickier per-field cases: (a) a single lever off with siblings at default
+    * ON must persist exactly that one OFF; (b) the closet stays ON (default) while
+    * its numeric tunables round-trip byte-equal under the budget_bytes:0=default
+    * convention. */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      /* config_load reads whatever the prior block persisted, so pin the siblings ON
+       * deterministically. Only fold opts out; the closet stays on but tuned. */
+      cfg.reduce_measure_enabled = 1;
+      cfg.reduce_delegate_seam = 1;
+      cfg.reduce_history_fold = 0; /* opt out of ONLY fold */
+      cfg.reduce_compress = 1;
+      cfg.coord_closet_enabled = 1;
+      cfg.coord_closet_budget_bytes = 4096; /* tune the closet (still enabled) */
+      cfg.coord_closet_max_ratio_pct = 15;
+      snprintf(cfg.coord_closet_denylist, sizeof(cfg.coord_closet_denylist), "secretword");
+      config_save(&cfg);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_history_fold == 0);    /* the single opt-out survived */
+      assert(cfg2.reduce_measure_enabled == 1); /* siblings stayed default-on */
+      assert(cfg2.reduce_delegate_seam == 1);
+      assert(cfg2.reduce_compress == 1);
+      assert(cfg2.coord_closet_enabled == 1); /* closet still on while tuned */
+      assert(cfg2.coord_closet_budget_bytes == 4096);
+      assert(cfg2.coord_closet_max_ratio_pct == 15);
+      assert(strcmp(cfg2.coord_closet_denylist, "secretword") == 0);
    }
 
    /* --- install.sh persists provider/openai/kb_client_* as plain top-level

--- a/src/tests/test_config.c
+++ b/src/tests/test_config.c
@@ -57,16 +57,6 @@ int main(void)
        * has to explicitly enable it before any autonomous run can open/merge a PR. */
       assert(cfg.wfe_live_forge_enabled == 0);
       assert(cfg.db1_path[0] != '\0');
-      /* context economizer is DEFAULT-ON on the delegate seam (measure + delegate_seam
-       * + history_fold + compress + closet), with the gateway seam off pending its
-       * mutation build. A regression that silently flips these off is caught here. */
-      assert(cfg.reduce_measure_enabled == 1);
-      assert(cfg.reduce_delegate_seam == 1);
-      assert(cfg.reduce_history_fold == 1);
-      assert(cfg.reduce_compress == 1);
-      assert(cfg.coord_closet_enabled == 1);
-      assert(cfg.reduce_gateway_seam == 0);
-      assert(cfg.reduce_freeze_guard_enabled == 1);
       assert(cfg.guardrails_semantic_advisory_only == 1);
       assert(cfg.skills_review_nudge_interval == 10);
       assert(cfg.skills_curator_interval_hours == 168);
@@ -350,13 +340,6 @@ int main(void)
        * class: a default-on save-guard that emits only the non-default state). */
       cfg.reduce_freeze_guard_enabled = 0;
       cfg.reduce_freeze_guard_horizon = 3;
-      /* the four default-ON economizer levers + the closet must round-trip their
-       * non-default OFF state (config_save persists only the opt-out). */
-      cfg.reduce_measure_enabled = 0;
-      cfg.reduce_delegate_seam = 0;
-      cfg.reduce_history_fold = 0;
-      cfg.reduce_compress = 0;
-      cfg.coord_closet_enabled = 0;
       config_save(&cfg);
 
       static config_t cfg2;
@@ -375,11 +358,6 @@ int main(void)
       assert(strcmp(cfg2.server_api_client_transport, "http") == 0);
       assert(cfg2.reduce_freeze_guard_enabled == 0); /* default-on bool persisted off */
       assert(cfg2.reduce_freeze_guard_horizon == 3); /* non-default horizon persisted */
-      assert(cfg2.reduce_measure_enabled == 0);      /* default-on levers persist their */
-      assert(cfg2.reduce_delegate_seam == 0);        /* non-default OFF opt-out */
-      assert(cfg2.reduce_history_fold == 0);
-      assert(cfg2.reduce_compress == 0);
-      assert(cfg2.coord_closet_enabled == 0); /* default-on closet persists OFF */
       /* regression: remote_writes used to be parsed but never written by config_save,
        * so any save silently reset it to off. */
       assert(cfg2.server_api_remote_writes == SERVER_REMOTE_WRITES_FULL);
@@ -538,41 +516,6 @@ int main(void)
              strcmp(cfg2.lsp_servers[0].args[0], "--background-index") == 0);
       assert(cfg2.lsp_servers[0].extension_count == 1 &&
              strcmp(cfg2.lsp_servers[0].extensions[0], "c") == 0);
-   }
-
-   /* --- economizer: PARTIAL opt-out + closet tuning round-trip ---
-    * The bulk round-trip above flips every default-on lever OFF at once. This pins
-    * the trickier per-field cases: (a) a single lever off with siblings at default
-    * ON must persist exactly that one OFF; (b) the closet stays ON (default) while
-    * its numeric tunables round-trip byte-equal under the budget_bytes:0=default
-    * convention. */
-   {
-      static config_t cfg;
-      memset(&cfg, 0, sizeof(cfg));
-      config_load(&cfg);
-      /* config_load reads whatever the prior block persisted, so pin the siblings ON
-       * deterministically. Only fold opts out; the closet stays on but tuned. */
-      cfg.reduce_measure_enabled = 1;
-      cfg.reduce_delegate_seam = 1;
-      cfg.reduce_history_fold = 0; /* opt out of ONLY fold */
-      cfg.reduce_compress = 1;
-      cfg.coord_closet_enabled = 1;
-      cfg.coord_closet_budget_bytes = 4096; /* tune the closet (still enabled) */
-      cfg.coord_closet_max_ratio_pct = 15;
-      snprintf(cfg.coord_closet_denylist, sizeof(cfg.coord_closet_denylist), "secretword");
-      config_save(&cfg);
-
-      static config_t cfg2;
-      memset(&cfg2, 0, sizeof(cfg2));
-      config_load(&cfg2);
-      assert(cfg2.reduce_history_fold == 0);    /* the single opt-out survived */
-      assert(cfg2.reduce_measure_enabled == 1); /* siblings stayed default-on */
-      assert(cfg2.reduce_delegate_seam == 1);
-      assert(cfg2.reduce_compress == 1);
-      assert(cfg2.coord_closet_enabled == 1); /* closet still on while tuned */
-      assert(cfg2.coord_closet_budget_bytes == 4096);
-      assert(cfg2.coord_closet_max_ratio_pct == 15);
-      assert(strcmp(cfg2.coord_closet_denylist, "secretword") == 0);
    }
 
    /* --- install.sh persists provider/openai/kb_client_* as plain top-level

--- a/src/tests/test_config_economizer.c
+++ b/src/tests/test_config_economizer.c
@@ -1,0 +1,125 @@
+/* test_config_economizer.c: defaults + save/load round-trip for the context
+ * economizer (reduce.*) and Coordinate Closet config. Kept separate from
+ * test_config.c, which is at the build-integrity line-count limit. */
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "aimee.h"
+#include "config_sections.h"
+#include "aimee_home.h"
+#include "platform_path.h"
+#include "platform_test_util.h"
+
+int main(void)
+{
+   printf("config_economizer: ");
+
+   char tmpdir[512];
+   snprintf(tmpdir, sizeof(tmpdir), "%s/aimee-test-econ-cfg-XXXXXX", platform_tmpdir());
+   assert(platform_mkdtemp(tmpdir) != NULL);
+   char *old_home = getenv("HOME") ? strdup(getenv("HOME")) : NULL;
+   char *old_aimee_home = getenv("AIMEE_HOME") ? strdup(getenv("AIMEE_HOME")) : NULL;
+   char *old_no_cache = getenv("AIMEE_NO_CACHE") ? strdup(getenv("AIMEE_NO_CACHE")) : NULL;
+   platform_setenv("HOME", tmpdir);
+   platform_unsetenv("AIMEE_HOME");
+   platform_setenv("AIMEE_NO_CACHE", "1");
+
+   /* --- defaults: economizer DEFAULT-ON on the delegate seam, gateway OFF --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg); /* missing file -> defaults */
+      assert(cfg.reduce_measure_enabled == 1);
+      assert(cfg.reduce_delegate_seam == 1);
+      assert(cfg.reduce_history_fold == 1);
+      assert(cfg.reduce_compress == 1);
+      assert(cfg.coord_closet_enabled == 1);
+      assert(cfg.reduce_gateway_seam == 0); /* primary path off pending mutation build */
+      assert(cfg.reduce_freeze_guard_enabled == 1);
+      assert(cfg.reduce_freeze_guard_horizon == 1);
+   }
+
+   /* --- bulk opt-out: every default-ON lever + closet flipped OFF must round-trip
+    * (config_save persists only the non-default OFF state) --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      cfg.reduce_measure_enabled = 0;
+      cfg.reduce_delegate_seam = 0;
+      cfg.reduce_history_fold = 0;
+      cfg.reduce_compress = 0;
+      cfg.coord_closet_enabled = 0;
+      cfg.reduce_freeze_guard_enabled = 0;
+      cfg.reduce_freeze_guard_horizon = 3;
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_measure_enabled == 0);
+      assert(cfg2.reduce_delegate_seam == 0);
+      assert(cfg2.reduce_history_fold == 0);
+      assert(cfg2.reduce_compress == 0);
+      assert(cfg2.coord_closet_enabled == 0);
+      assert(cfg2.reduce_freeze_guard_enabled == 0);
+      assert(cfg2.reduce_freeze_guard_horizon == 3);
+   }
+
+   /* --- partial opt-out + closet tuning: one lever OFF with siblings at default ON,
+    * closet ON but tuned (budget/ratio/denylist) must round-trip byte-equal --- */
+   {
+      static config_t cfg;
+      memset(&cfg, 0, sizeof(cfg));
+      config_load(&cfg);
+      /* pin siblings ON deterministically (config_load reads the prior block's file) */
+      cfg.reduce_measure_enabled = 1;
+      cfg.reduce_delegate_seam = 1;
+      cfg.reduce_history_fold = 0; /* the single opt-out */
+      cfg.reduce_compress = 1;
+      cfg.reduce_freeze_guard_enabled = 1;
+      cfg.reduce_freeze_guard_horizon = 1;
+      cfg.coord_closet_enabled = 1;
+      cfg.coord_closet_budget_bytes = 4096;
+      cfg.coord_closet_max_ratio_pct = 15;
+      snprintf(cfg.coord_closet_denylist, sizeof(cfg.coord_closet_denylist), "secretword");
+      assert(config_save(&cfg) == 0);
+
+      static config_t cfg2;
+      memset(&cfg2, 0, sizeof(cfg2));
+      config_load(&cfg2);
+      assert(cfg2.reduce_history_fold == 0);    /* the single opt-out survived */
+      assert(cfg2.reduce_measure_enabled == 1); /* siblings stayed on */
+      assert(cfg2.reduce_delegate_seam == 1);
+      assert(cfg2.reduce_compress == 1);
+      assert(cfg2.coord_closet_enabled == 1); /* closet on while tuned */
+      assert(cfg2.coord_closet_budget_bytes == 4096);
+      assert(cfg2.coord_closet_max_ratio_pct == 15);
+      assert(strcmp(cfg2.coord_closet_denylist, "secretword") == 0);
+   }
+
+   /* restore env */
+   if (old_home)
+   {
+      platform_setenv("HOME", old_home);
+      free(old_home);
+   }
+   if (old_aimee_home)
+   {
+      platform_setenv("AIMEE_HOME", old_aimee_home);
+      free(old_aimee_home);
+   }
+   else
+      platform_unsetenv("AIMEE_HOME");
+   if (old_no_cache)
+   {
+      platform_setenv("AIMEE_NO_CACHE", old_no_cache);
+      free(old_no_cache);
+   }
+   else
+      platform_unsetenv("AIMEE_NO_CACHE");
+
+   printf("ok\n");
+   return 0;
+}


### PR DESCRIPTION
## What

Flips the context economizer's implemented, tested **delegate-path** reduction **on by default** (owner directive: "default on, period"). `config_set_defaults` now enables `coord_closet_enabled`, `reduce_measure_enabled`, `reduce_delegate_seam`, `reduce_history_fold`, `reduce_compress`. Every sub-agent turn now folds old history + compresses oversized tool-result bodies, with the Coordinate Closet conserving identifiers.

## Safety (verified, not assumed)

- **Recovery model — lossy with *agentic* recovery, documented honestly.** Both levers only reduce messages *before* the retained tail (`context_fold.c:349,483`), so the most recent `retained_msgs` (default 8; `0` is the default sentinel — never zero) are byte-identical: the agent's working set is never elided. The closet conserves paths/ids/hashes so the agent can re-issue a tool call to recover an elided body — there is **no automatic inline re-fetch** by design. Coordinate fidelity was validated on a captured long session.
- **chatgpt/Responses exclusion holds.** `reduce_history_fold` becomes a live fold in exactly one place (`agent_runtime.c:858`, `&& !chatgpt`) → reaches the Responses builder on **zero** paths. `compress` is shape-preserving and runs for all providers.
- **Gateway seam stays OFF** (primary `/v1` path) — shadow-only until its request-mutation + 400-retry-from-pristine circuit breaker are built (separate slice).
- Hard-bypass on any internal reducer error forwards the original request.

## Config round-trip

`config_save` inverted: default-ON keys persist only their non-default **OFF** state (so an operator opt-out round-trips); a fresh default config writes no `reduce`/`compact.coord_closet` block. `coord_closet.budget_bytes: 0` = "use built-in default" (disable via `enabled: false`).

## Tests

Defaults test asserts all five levers + closet ON, gateway OFF. Round-trip suite covers the bulk opt-out, a **partial** opt-out (fold off, siblings on), and **closet tuning** (budget/ratio/denylist) round-tripping byte-equal.

## Roundtable

Design + code reviewed. Re-review verdict: **SHIPPABLE — all three prior blockers cleared** (B1 chatgpt exclusion verified single-site; B2 retained-tail recovery model confirmed + honestly documented; B3 budget_bytes:0 semantics documented). Follow-ups tracked (non-blocking): CI grep guard on the `reduce_history_fold` call site; refetch-cost-vs-saving telemetry.

## Gates

Full `-Werror` build ✓, full unit-tests (defaults + round-trip incl. partial opt-out & closet tuning) ✓, clang-format-19 ✓, docs-gen-check ✓, schema-sync-check ✓.