### PR TITLE
[codex] fix Anthropic tools for Responses API

### DIFF
--- a/src/headers/anthropic_ingress.h
+++ b/src/headers/anthropic_ingress.h
@@ -43,6 +43,10 @@ struct cJSON *anthropic_messages_to_openai(const struct cJSON *messages, const c
  * usable tools. */
 struct cJSON *anthropic_tools_to_openai(const struct cJSON *anthropic_tools);
 
+/* Convert Anthropic tools to the OpenAI Responses API's flat function-tool
+ * shape: [{type:"function",name,description,parameters}]. */
+struct cJSON *anthropic_tools_to_responses(const struct cJSON *anthropic_tools);
+
 /* Build a non-streaming Anthropic Messages API response object from a parsed
  * provider reply. resp_id is the "msg_..." id; model echoes the request's
  * model string. Produces:

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -182,7 +182,10 @@ static void translate_request(const cJSON *req, const delegate_driver_t *driver,
    *out_messages =
        anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"),
                                     driver_consumes_system_prompt(driver, ag) ? NULL : *out_system);
-   *out_tools = anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
+   *out_tools = driver && strcmp(driver->name, "chatgpt") == 0
+                    ? anthropic_tools_to_responses(
+                          cJSON_GetObjectItemCaseSensitive(req, "tools"))
+                    : anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 
 /* ---- Gateway request pipeline (universal-gateway P2a) -------------------------

--- a/src/server/anthropic_http.c
+++ b/src/server/anthropic_http.c
@@ -183,8 +183,7 @@ static void translate_request(const cJSON *req, const delegate_driver_t *driver,
        anthropic_messages_to_openai(cJSON_GetObjectItemCaseSensitive(req, "messages"),
                                     driver_consumes_system_prompt(driver, ag) ? NULL : *out_system);
    *out_tools = driver && strcmp(driver->name, "chatgpt") == 0
-                    ? anthropic_tools_to_responses(
-                          cJSON_GetObjectItemCaseSensitive(req, "tools"))
+                    ? anthropic_tools_to_responses(cJSON_GetObjectItemCaseSensitive(req, "tools"))
                     : anthropic_tools_to_openai(cJSON_GetObjectItemCaseSensitive(req, "tools"));
 }
 

--- a/src/server/anthropic_ingress.c
+++ b/src/server/anthropic_ingress.c
@@ -385,6 +385,41 @@ cJSON *anthropic_tools_to_openai(const cJSON *anthropic_tools)
    return out;
 }
 
+cJSON *anthropic_tools_to_responses(const cJSON *anthropic_tools)
+{
+   cJSON *chat_tools = anthropic_tools_to_openai(anthropic_tools);
+   cJSON *out, *tool;
+   if (!chat_tools)
+      return NULL;
+   out = cJSON_CreateArray();
+   cJSON_ArrayForEach(tool, chat_tools)
+   {
+      cJSON *fn = cJSON_GetObjectItemCaseSensitive(tool, "function");
+      cJSON *flat;
+      if (!cJSON_IsObject(fn))
+         continue;
+      flat = cJSON_CreateObject();
+      cJSON_AddStringToObject(flat, "type", "function");
+      cJSON *name = cJSON_GetObjectItemCaseSensitive(fn, "name");
+      cJSON *desc = cJSON_GetObjectItemCaseSensitive(fn, "description");
+      cJSON *params = cJSON_GetObjectItemCaseSensitive(fn, "parameters");
+      if (cJSON_IsString(name))
+         cJSON_AddStringToObject(flat, "name", name->valuestring);
+      if (cJSON_IsString(desc))
+         cJSON_AddStringToObject(flat, "description", desc->valuestring);
+      if (params)
+         cJSON_AddItemToObject(flat, "parameters", cJSON_Duplicate(params, 1));
+      cJSON_AddItemToArray(out, flat);
+   }
+   cJSON_Delete(chat_tools);
+   if (cJSON_GetArraySize(out) == 0)
+   {
+      cJSON_Delete(out);
+      return NULL;
+   }
+   return out;
+}
+
 cJSON *anthropic_response_from_parsed(const char *resp_id, const char *model,
                                       const parsed_response_t *parsed)
 {

--- a/src/tests/test_anthropic_ingress.c
+++ b/src/tests/test_anthropic_ingress.c
@@ -195,9 +195,27 @@ static void test_tools_empty(void)
 {
    cJSON *t = parse("[]");
    assert(anthropic_tools_to_openai(t) == NULL);
+   assert(anthropic_tools_to_responses(t) == NULL);
    cJSON_Delete(t);
    assert(anthropic_tools_to_openai(NULL) == NULL);
+   assert(anthropic_tools_to_responses(NULL) == NULL);
    PASS("tools_empty");
+}
+
+static void test_tools_responses_mapping(void)
+{
+   cJSON *t = parse("[{\"name\":\"Read\",\"description\":\"Read a file\","
+                    "\"input_schema\":{\"type\":\"object\",\"properties\":{}}}]");
+   cJSON *out = anthropic_tools_to_responses(t);
+   cJSON *tool = cJSON_GetArrayItem(out, 0);
+   assert(strcmp(ostr(tool, "type"), "function") == 0);
+   assert(strcmp(ostr(tool, "name"), "Read") == 0);
+   assert(strcmp(ostr(tool, "description"), "Read a file") == 0);
+   assert(cJSON_IsObject(cJSON_GetObjectItemCaseSensitive(tool, "parameters")));
+   assert(cJSON_GetObjectItemCaseSensitive(tool, "function") == NULL);
+   cJSON_Delete(out);
+   cJSON_Delete(t);
+   PASS("tools_responses_mapping");
 }
 
 /* --------------------------------------------------------------- responses */
@@ -704,6 +722,7 @@ int main(void)
    test_messages_image();
    test_tools_mapping();
    test_tools_empty();
+   test_tools_responses_mapping();
    test_response_text();
    test_response_tool_use();
    test_response_empty_gets_text_block();


### PR DESCRIPTION
## What changed

- add an Anthropic tool converter for the OpenAI Responses API flat function-tool schema
- select the Responses converter for the ChatGPT/Codex driver while preserving nested Chat Completions tools for other OpenAI-compatible providers
- cover flat shape, nested-wrapper exclusion, schema preservation, and empty/NULL inputs

## Root cause

The Anthropic ingress always converted tools to Chat Completions shape. Codex uses the Responses API, where function fields must be flat, so upstream rejected Claude Code requests with `Missing required parameter: 'tools[0].name'`.

## Validation

- `make -j2 build/obj/tests/unit-test-anthropic-ingress`
- `build/obj/tests/unit-test-anthropic-ingress`
- aimee review panel: security, architecture, QA, reviewer; no blocking findings
